### PR TITLE
feat(plugin): implement LuaHost with event delivery

### DIFF
--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -1,0 +1,26 @@
+// Package plugin provides plugin management and lifecycle control.
+package plugin
+
+import (
+	"context"
+
+	pluginpkg "github.com/holomush/holomush/pkg/plugin"
+)
+
+// Host manages a specific plugin runtime type.
+type Host interface {
+	// Load initializes a plugin from its manifest.
+	Load(ctx context.Context, manifest *Manifest, dir string) error
+
+	// Unload tears down a plugin.
+	Unload(ctx context.Context, name string) error
+
+	// DeliverEvent sends an event to a plugin and returns response events.
+	DeliverEvent(ctx context.Context, name string, event pluginpkg.Event) ([]pluginpkg.EmitEvent, error)
+
+	// Plugins returns names of all loaded plugins.
+	Plugins() []string
+
+	// Close shuts down the host and all plugins.
+	Close(ctx context.Context) error
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -1,0 +1,203 @@
+package lua
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/holomush/holomush/internal/plugin"
+	pluginpkg "github.com/holomush/holomush/pkg/plugin"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// Compile-time interface check.
+var _ plugin.Host = (*Host)(nil)
+
+// luaPlugin holds compiled Lua code for a plugin.
+type luaPlugin struct {
+	manifest *plugin.Manifest
+	code     string // Lua source (compiled at load time in future)
+}
+
+// Host manages Lua plugins.
+type Host struct {
+	factory *StateFactory
+	plugins map[string]*luaPlugin
+	mu      sync.RWMutex
+	closed  bool
+}
+
+// NewHost creates a new Lua plugin host.
+func NewHost() *Host {
+	return &Host{
+		factory: NewStateFactory(),
+		plugins: make(map[string]*luaPlugin),
+	}
+}
+
+// Load reads and validates a Lua plugin.
+func (h *Host) Load(ctx context.Context, manifest *plugin.Manifest, dir string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return fmt.Errorf("host is closed")
+	}
+
+	entryPath := filepath.Join(dir, manifest.LuaPlugin.Entry)
+	code, err := os.ReadFile(entryPath) //nolint:gosec // entryPath is from trusted manifest
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", entryPath, err)
+	}
+
+	// Validate syntax by compiling in a throwaway state
+	L, err := h.factory.NewState(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create validation state: %w", err)
+	}
+	defer L.Close()
+
+	if err := L.DoString(string(code)); err != nil {
+		return fmt.Errorf("syntax error in %s: %w", manifest.LuaPlugin.Entry, err)
+	}
+
+	h.plugins[manifest.Name] = &luaPlugin{
+		manifest: manifest,
+		code:     string(code),
+	}
+
+	return nil
+}
+
+// Unload removes a plugin.
+func (h *Host) Unload(_ context.Context, name string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.plugins[name]; !ok {
+		return fmt.Errorf("plugin %s not loaded", name)
+	}
+	delete(h.plugins, name)
+	return nil
+}
+
+// DeliverEvent executes the plugin's on_event function.
+func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginpkg.Event) ([]pluginpkg.EmitEvent, error) {
+	h.mu.RLock()
+	p, ok := h.plugins[name]
+	if !ok {
+		h.mu.RUnlock()
+		return nil, fmt.Errorf("plugin %s not loaded", name)
+	}
+	code := p.code
+	h.mu.RUnlock()
+
+	// Create fresh state for this event
+	L, err := h.factory.NewState(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state: %w", err)
+	}
+	defer L.Close()
+
+	// Load plugin code
+	if err := L.DoString(code); err != nil {
+		return nil, fmt.Errorf("failed to load plugin code: %w", err)
+	}
+
+	// Check if on_event exists
+	onEvent := L.GetGlobal("on_event")
+	if onEvent.Type() == lua.LTNil {
+		return nil, nil // No handler
+	}
+
+	// Build event table
+	eventTable := h.buildEventTable(L, event)
+
+	// Call on_event(event)
+	if err := L.CallByParam(lua.P{
+		Fn:      onEvent,
+		NRet:    1,
+		Protect: true,
+	}, eventTable); err != nil {
+		return nil, fmt.Errorf("on_event failed: %w", err)
+	}
+
+	// Get return value
+	ret := L.Get(-1)
+	L.Pop(1)
+
+	return h.parseEmitEvents(ret), nil
+}
+
+// Plugins returns names of loaded plugins.
+func (h *Host) Plugins() []string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	names := make([]string, 0, len(h.plugins))
+	for name := range h.plugins {
+		names = append(names, name)
+	}
+	return names
+}
+
+// Close shuts down the host.
+func (h *Host) Close(_ context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.closed = true
+	h.plugins = nil
+	return nil
+}
+
+func (h *Host) buildEventTable(state *lua.LState, event pluginpkg.Event) *lua.LTable {
+	t := state.NewTable()
+	state.SetField(t, "id", lua.LString(event.ID))
+	state.SetField(t, "stream", lua.LString(event.Stream))
+	state.SetField(t, "type", lua.LString(string(event.Type)))
+	state.SetField(t, "timestamp", lua.LNumber(event.Timestamp))
+	state.SetField(t, "actor_kind", lua.LString(actorKindToString(event.ActorKind)))
+	state.SetField(t, "actor_id", lua.LString(event.ActorID))
+	state.SetField(t, "payload", lua.LString(event.Payload))
+	return t
+}
+
+func actorKindToString(kind pluginpkg.ActorKind) string {
+	switch kind {
+	case pluginpkg.ActorCharacter:
+		return "character"
+	case pluginpkg.ActorSystem:
+		return "system"
+	case pluginpkg.ActorPlugin:
+		return "plugin"
+	default:
+		return "unknown"
+	}
+}
+
+func (h *Host) parseEmitEvents(ret lua.LValue) []pluginpkg.EmitEvent {
+	if ret.Type() == lua.LTNil {
+		return nil
+	}
+
+	table, ok := ret.(*lua.LTable)
+	if !ok {
+		return nil // Non-table return is ignored
+	}
+
+	var emits []pluginpkg.EmitEvent
+	table.ForEach(func(_, v lua.LValue) {
+		if eventTable, ok := v.(*lua.LTable); ok {
+			emit := pluginpkg.EmitEvent{
+				Stream:  eventTable.RawGetString("stream").String(),
+				Type:    pluginpkg.EventType(eventTable.RawGetString("type").String()),
+				Payload: eventTable.RawGetString("payload").String(),
+			}
+			emits = append(emits, emit)
+		}
+	})
+
+	return emits
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -97,13 +97,13 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginpkg.Ev
 	// Create fresh state for this event
 	L, err := h.factory.NewState(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create state: %w", err)
+		return nil, fmt.Errorf("plugin %s: failed to create state: %w", name, err)
 	}
 	defer L.Close()
 
 	// Load plugin code
 	if err := L.DoString(code); err != nil {
-		return nil, fmt.Errorf("failed to load plugin code: %w", err)
+		return nil, fmt.Errorf("plugin %s: failed to load code: %w", name, err)
 	}
 
 	// Check if on_event exists
@@ -121,7 +121,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginpkg.Ev
 		NRet:    1,
 		Protect: true,
 	}, eventTable); err != nil {
-		return nil, fmt.Errorf("on_event failed: %w", err)
+		return nil, fmt.Errorf("plugin %s: on_event failed: %w", name, err)
 	}
 
 	// Get return value

--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -1,0 +1,272 @@
+package lua_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/holomush/holomush/internal/plugin"
+	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+	pluginpkg "github.com/holomush/holomush/pkg/plugin"
+)
+
+// writeMainLua creates a main.lua plugin file in the given directory.
+func writeMainLua(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "main.lua"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// closeHost closes the host and fails the test if an error occurs.
+func closeHost(t *testing.T, host *pluginlua.Host) {
+	t.Helper()
+	if err := host.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestLuaHost_Load(t *testing.T) {
+	dir := t.TempDir()
+
+	mainLua := `
+function on_event(event)
+    return nil
+end
+`
+	writeMainLua(t, dir, mainLua)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Type:    plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{
+			Entry: "main.lua",
+		},
+	}
+
+	err := host.Load(context.Background(), manifest, dir)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	plugins := host.Plugins()
+	if len(plugins) != 1 || plugins[0] != "test-plugin" {
+		t.Errorf("Plugins() = %v, want [test-plugin]", plugins)
+	}
+}
+
+func TestLuaHost_DeliverEvent_ReturnsEmitEvents(t *testing.T) {
+	dir := t.TempDir()
+
+	mainLua := `
+function on_event(event)
+    if event.type == "say" then
+        return {
+            {
+                stream = event.stream,
+                type = "say",
+                payload = '{"message":"Echo: ' .. event.payload .. '"}'
+            }
+        }
+    end
+    return nil
+end
+`
+	writeMainLua(t, dir, mainLua)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:      "echo",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "main.lua"},
+	}
+
+	if err := host.Load(context.Background(), manifest, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	event := pluginpkg.Event{
+		ID:        "01ABC",
+		Stream:    "location:123",
+		Type:      "say",
+		Timestamp: 1705591234000,
+		ActorKind: pluginpkg.ActorCharacter,
+		ActorID:   "char_1",
+		Payload:   "Hello",
+	}
+
+	emits, err := host.DeliverEvent(context.Background(), "echo", event)
+	if err != nil {
+		t.Fatalf("DeliverEvent() error = %v", err)
+	}
+
+	if len(emits) != 1 {
+		t.Fatalf("len(emits) = %d, want 1", len(emits))
+	}
+
+	if emits[0].Stream != "location:123" {
+		t.Errorf("emit.Stream = %q, want %q", emits[0].Stream, "location:123")
+	}
+}
+
+func TestLuaHost_DeliverEvent_NoHandler(t *testing.T) {
+	dir := t.TempDir()
+
+	// Plugin without on_event function
+	writeMainLua(t, dir, `x = 1`)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:      "no-handler",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "main.lua"},
+	}
+
+	if err := host.Load(context.Background(), manifest, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	event := pluginpkg.Event{ID: "01ABC", Type: "say"}
+	emits, err := host.DeliverEvent(context.Background(), "no-handler", event)
+	if err != nil {
+		t.Fatalf("DeliverEvent() error = %v", err)
+	}
+
+	if len(emits) != 0 {
+		t.Errorf("expected no emits for plugin without handler")
+	}
+}
+
+func TestLuaHost_Unload(t *testing.T) {
+	dir := t.TempDir()
+
+	writeMainLua(t, dir, `function on_event(event) return nil end`)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "main.lua"},
+	}
+
+	if err := host.Load(context.Background(), manifest, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(host.Plugins()) != 1 {
+		t.Fatalf("expected 1 plugin after load")
+	}
+
+	if err := host.Unload(context.Background(), "test-plugin"); err != nil {
+		t.Fatalf("Unload() error = %v", err)
+	}
+
+	if len(host.Plugins()) != 0 {
+		t.Errorf("expected 0 plugins after unload, got %d", len(host.Plugins()))
+	}
+}
+
+func TestLuaHost_Unload_NotFound(t *testing.T) {
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	err := host.Unload(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error when unloading nonexistent plugin")
+	}
+}
+
+func TestLuaHost_DeliverEvent_NotLoaded(t *testing.T) {
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	event := pluginpkg.Event{ID: "01ABC", Type: "say"}
+	_, err := host.DeliverEvent(context.Background(), "nonexistent", event)
+	if err == nil {
+		t.Error("expected error when delivering to nonexistent plugin")
+	}
+}
+
+func TestLuaHost_Load_SyntaxError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Invalid Lua syntax
+	writeMainLua(t, dir, `function on_event(event return nil end`)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:      "bad-syntax",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "main.lua"},
+	}
+
+	err := host.Load(context.Background(), manifest, dir)
+	if err == nil {
+		t.Error("expected error when loading plugin with syntax error")
+	}
+}
+
+func TestLuaHost_Load_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugin.Manifest{
+		Name:      "missing-file",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "nonexistent.lua"},
+	}
+
+	err := host.Load(context.Background(), manifest, dir)
+	if err == nil {
+		t.Error("expected error when loading plugin with missing file")
+	}
+}
+
+func TestLuaHost_Close(t *testing.T) {
+	dir := t.TempDir()
+
+	writeMainLua(t, dir, `function on_event(event) return nil end`)
+
+	host := pluginlua.NewHost()
+
+	manifest := &plugin.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugin.TypeLua,
+		LuaPlugin: &plugin.LuaConfig{Entry: "main.lua"},
+	}
+
+	if err := host.Load(context.Background(), manifest, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := host.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Should error when loading after close
+	err := host.Load(context.Background(), manifest, dir)
+	if err == nil {
+		t.Error("expected error when loading after close")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `plugin.Host` interface for plugin runtime management
- `LuaHost` loads Lua plugins, creates fresh sandboxed states per event, and executes `on_event` handlers
- Plugins can return emit events for the event bus
- Gracefully handles plugins without `on_event` (no error)

## Files

- `internal/plugin/host.go` - Host interface definition
- `internal/plugin/lua/host.go` - LuaHost implementation  
- `internal/plugin/lua/host_test.go` - 9 comprehensive tests

## Test plan

- [x] `TestLuaHost_Load` - Basic loading
- [x] `TestLuaHost_DeliverEvent_ReturnsEmitEvents` - Event delivery with response
- [x] `TestLuaHost_DeliverEvent_NoHandler` - Plugin without on_event
- [x] `TestLuaHost_Unload` - Plugin removal
- [x] `TestLuaHost_Unload_NotFound` - Error handling
- [x] `TestLuaHost_DeliverEvent_NotLoaded` - Error handling
- [x] `TestLuaHost_Load_SyntaxError` - Syntax validation
- [x] `TestLuaHost_Load_MissingFile` - File not found
- [x] `TestLuaHost_Close` - Host shutdown

Part of Epic 2: Plugin System (holomush-1hq.13)

🤖 Generated with [Claude Code](https://claude.ai/code)