### PR TITLE
feat(plugin): add host functions with capability enforcement

### DIFF
--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -94,10 +94,11 @@ func (f *Functions) logFn(pluginName string) lua.LGFunction {
 		case "error":
 			logger.Error(message)
 		default:
-			slog.Warn("invalid log level from plugin, falling back to info",
+			slog.Warn("invalid log level from plugin",
 				"plugin", pluginName,
 				"requested_level", level)
-			logger.Info(message)
+			L.RaiseError("invalid log level %q: must be debug, info, warn, or error", level)
+			return 0
 		}
 		return 0
 	}

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -106,6 +106,9 @@ func (f *Functions) logFn(pluginName string) lua.LGFunction {
 
 func (f *Functions) newRequestIDFn() lua.LGFunction {
 	return func(L *lua.LState) int {
+		// ulid.Make() cannot panic per library documentation:
+		// "NOTE: MustNew can't panic since DefaultEntropy never returns an error."
+		// See: https://github.com/oklog/ulid/blob/main/ulid.go (func Make)
 		id := ulid.Make()
 		L.Push(lua.LString(id.String()))
 		return 1

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -115,6 +115,10 @@ func (f *Functions) newRequestIDFn() lua.LGFunction {
 func (f *Functions) kvGetFn(pluginName string) lua.LGFunction {
 	return func(L *lua.LState) int {
 		key := L.CheckString(1)
+		if key == "" {
+			L.RaiseError("kv_get: key cannot be empty")
+			return 0
+		}
 
 		if f.kvStore == nil {
 			slog.Error("kv_get called but store unavailable",
@@ -155,6 +159,10 @@ func (f *Functions) kvSetFn(pluginName string) lua.LGFunction {
 	return func(L *lua.LState) int {
 		key := L.CheckString(1)
 		value := L.CheckString(2)
+		if key == "" {
+			L.RaiseError("kv_set: key cannot be empty")
+			return 0
+		}
 
 		if f.kvStore == nil {
 			slog.Error("kv_set called but store unavailable",
@@ -187,6 +195,10 @@ func (f *Functions) kvSetFn(pluginName string) lua.LGFunction {
 func (f *Functions) kvDeleteFn(pluginName string) lua.LGFunction {
 	return func(L *lua.LState) int {
 		key := L.CheckString(1)
+		if key == "" {
+			L.RaiseError("kv_delete: key cannot be empty")
+			return 0
+		}
 
 		if f.kvStore == nil {
 			slog.Error("kv_delete called but store unavailable",

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -1,0 +1,166 @@
+// Package hostfunc provides host functions to Lua plugins.
+//
+// Host functions expose server capabilities to plugins in a controlled way.
+// Functions that access sensitive resources require capability checks.
+package hostfunc
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/holomush/holomush/internal/plugin/capability"
+	"github.com/oklog/ulid/v2"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// KVStore provides namespaced key-value storage.
+type KVStore interface {
+	Get(ctx context.Context, namespace, key string) ([]byte, error)
+	Set(ctx context.Context, namespace, key string, value []byte) error
+	Delete(ctx context.Context, namespace, key string) error
+}
+
+// WorldReader provides read-only access to world data.
+type WorldReader interface {
+	// Future: GetLocation, GetCharacter, GetObject
+}
+
+// Functions provides host functions to Lua plugins.
+type Functions struct {
+	kvStore  KVStore
+	world    WorldReader
+	enforcer *capability.Enforcer
+}
+
+// New creates host functions with dependencies.
+func New(kv KVStore, world WorldReader, enforcer *capability.Enforcer) *Functions {
+	return &Functions{
+		kvStore:  kv,
+		world:    world,
+		enforcer: enforcer,
+	}
+}
+
+// Register adds host functions to a Lua state.
+func (f *Functions) Register(ls *lua.LState, pluginName string) {
+	mod := ls.NewTable()
+
+	// Logging (no capability required)
+	ls.SetField(mod, "log", ls.NewFunction(f.logFn(pluginName)))
+
+	// Request ID (no capability required)
+	ls.SetField(mod, "new_request_id", ls.NewFunction(f.newRequestIDFn()))
+
+	// KV operations (capability required)
+	ls.SetField(mod, "kv_get", ls.NewFunction(f.wrap(pluginName, "kv.read", f.kvGetFn(pluginName))))
+	ls.SetField(mod, "kv_set", ls.NewFunction(f.wrap(pluginName, "kv.write", f.kvSetFn(pluginName))))
+	ls.SetField(mod, "kv_delete", ls.NewFunction(f.wrap(pluginName, "kv.write", f.kvDeleteFn(pluginName))))
+
+	ls.SetGlobal("holomush", mod)
+}
+
+func (f *Functions) wrap(plugin, capName string, fn lua.LGFunction) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if !f.enforcer.Check(plugin, capName) {
+			L.RaiseError("capability denied: %s requires %s", plugin, capName)
+			return 0
+		}
+		return fn(L)
+	}
+}
+
+func (f *Functions) logFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		level := L.CheckString(1)
+		message := L.CheckString(2)
+
+		logger := slog.Default().With("plugin", pluginName)
+		switch level {
+		case "debug":
+			logger.Debug(message)
+		case "info":
+			logger.Info(message)
+		case "warn":
+			logger.Warn(message)
+		case "error":
+			logger.Error(message)
+		default:
+			logger.Info(message)
+		}
+		return 0
+	}
+}
+
+func (f *Functions) newRequestIDFn() lua.LGFunction {
+	return func(L *lua.LState) int {
+		id := ulid.Make()
+		L.Push(lua.LString(id.String()))
+		return 1
+	}
+}
+
+func (f *Functions) kvGetFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		key := L.CheckString(1)
+
+		if f.kvStore == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("kv store not available"))
+			return 2
+		}
+
+		value, err := f.kvStore.Get(context.Background(), pluginName, key)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+
+		if value == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LNil) // No error, just not found
+			return 2
+		}
+
+		L.Push(lua.LString(string(value)))
+		L.Push(lua.LNil) // No error
+		return 2
+	}
+}
+
+func (f *Functions) kvSetFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		key := L.CheckString(1)
+		value := L.CheckString(2)
+
+		if f.kvStore == nil {
+			L.Push(lua.LString("kv store not available"))
+			return 1
+		}
+
+		if err := f.kvStore.Set(context.Background(), pluginName, key, []byte(value)); err != nil {
+			L.Push(lua.LString(err.Error()))
+			return 1
+		}
+
+		return 0
+	}
+}
+
+func (f *Functions) kvDeleteFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		key := L.CheckString(1)
+
+		if f.kvStore == nil {
+			L.Push(lua.LString("kv store not available"))
+			return 1
+		}
+
+		if err := f.kvStore.Delete(context.Background(), pluginName, key); err != nil {
+			L.Push(lua.LString(err.Error()))
+			return 1
+		}
+
+		return 0
+	}
+}

--- a/internal/plugin/hostfunc/functions_test.go
+++ b/internal/plugin/hostfunc/functions_test.go
@@ -1,0 +1,338 @@
+// Package hostfunc_test tests host function implementations.
+package hostfunc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holomush/holomush/internal/plugin/capability"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestHostFunctions_Log(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	hf := hostfunc.New(nil, nil, capability.NewEnforcer())
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.log("info", "test message")`)
+	if err != nil {
+		t.Errorf("log() failed: %v", err)
+	}
+}
+
+func TestHostFunctions_Log_Levels(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+	}{
+		{"debug level", "debug"},
+		{"info level", "info"},
+		{"warn level", "warn"},
+		{"error level", "error"},
+		{"unknown level defaults to info", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			L := lua.NewState()
+			defer L.Close()
+
+			hf := hostfunc.New(nil, nil, capability.NewEnforcer())
+			hf.Register(L, "test-plugin")
+
+			err := L.DoString(`holomush.log("` + tt.level + `", "test message")`)
+			if err != nil {
+				t.Errorf("log(%q) failed: %v", tt.level, err)
+			}
+		})
+	}
+}
+
+func TestHostFunctions_NewRequestID(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	hf := hostfunc.New(nil, nil, capability.NewEnforcer())
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`id = holomush.new_request_id()`)
+	if err != nil {
+		t.Fatalf("new_request_id() failed: %v", err)
+	}
+
+	id := L.GetGlobal("id").String()
+	if len(id) != 26 { // ULID length
+		t.Errorf("id length = %d, want 26", len(id))
+	}
+}
+
+func TestHostFunctions_NewRequestID_Unique(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	hf := hostfunc.New(nil, nil, capability.NewEnforcer())
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`
+		id1 = holomush.new_request_id()
+		id2 = holomush.new_request_id()
+	`)
+	if err != nil {
+		t.Fatalf("new_request_id() failed: %v", err)
+	}
+
+	id1 := L.GetGlobal("id1").String()
+	id2 := L.GetGlobal("id2").String()
+	if id1 == id2 {
+		t.Errorf("IDs should be unique, got %q twice", id1)
+	}
+}
+
+func TestHostFunctions_KV_RequiresCapability(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	// No capabilities granted
+
+	hf := hostfunc.New(nil, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_get("key")`)
+	if err == nil {
+		t.Error("expected capability error for kv_get without kv.read")
+	}
+}
+
+func TestHostFunctions_KVSet_RequiresWriteCapability(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	// Only kv.read, not kv.write
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_set("key", "value")`)
+	if err == nil {
+		t.Error("expected capability error for kv_set without kv.write")
+	}
+}
+
+func TestHostFunctions_KVDelete_RequiresWriteCapability(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	// Only kv.read, not kv.write
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_delete("key")`)
+	if err == nil {
+		t.Error("expected capability error for kv_delete without kv.write")
+	}
+}
+
+func TestHostFunctions_KV_WithCapability(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read", "kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	// Set and get
+	err := L.DoString(`holomush.kv_set("mykey", "myvalue")`)
+	if err != nil {
+		t.Fatalf("kv_set failed: %v", err)
+	}
+
+	err = L.DoString(`result = holomush.kv_get("mykey")`)
+	if err != nil {
+		t.Fatalf("kv_get failed: %v", err)
+	}
+
+	result := L.GetGlobal("result").String()
+	if result != "myvalue" {
+		t.Errorf("result = %q, want %q", result, "myvalue")
+	}
+}
+
+func TestHostFunctions_KVGet_ReturnsNilForMissingKey(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`
+		val, err = holomush.kv_get("nonexistent")
+	`)
+	if err != nil {
+		t.Fatalf("kv_get failed: %v", err)
+	}
+
+	val := L.GetGlobal("val")
+	errVal := L.GetGlobal("err")
+
+	if val.Type() != lua.LTNil {
+		t.Errorf("expected nil for missing key, got %v", val)
+	}
+	if errVal.Type() != lua.LTNil {
+		t.Errorf("expected nil error for missing key, got %v", errVal)
+	}
+}
+
+func TestHostFunctions_KVGet_NoStoreAvailable(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// nil kv store
+	hf := hostfunc.New(nil, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`
+		val, err = holomush.kv_get("key")
+	`)
+	if err != nil {
+		t.Fatalf("kv_get failed: %v", err)
+	}
+
+	errVal := L.GetGlobal("err")
+	if errVal.Type() != lua.LTString {
+		t.Errorf("expected error string when kv store unavailable, got %v", errVal.Type())
+	}
+}
+
+func TestHostFunctions_KVSet_NoStoreAvailable(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// nil kv store
+	hf := hostfunc.New(nil, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`err = holomush.kv_set("key", "value")`)
+	if err != nil {
+		t.Fatalf("kv_set failed: %v", err)
+	}
+
+	errVal := L.GetGlobal("err")
+	if errVal.Type() != lua.LTString {
+		t.Errorf("expected error string when kv store unavailable, got %v", errVal.Type())
+	}
+}
+
+func TestHostFunctions_KVDelete(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read", "kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	// Set a key
+	err := L.DoString(`holomush.kv_set("deletekey", "somevalue")`)
+	if err != nil {
+		t.Fatalf("kv_set failed: %v", err)
+	}
+
+	// Delete it
+	err = L.DoString(`holomush.kv_delete("deletekey")`)
+	if err != nil {
+		t.Fatalf("kv_delete failed: %v", err)
+	}
+
+	// Verify it's gone
+	err = L.DoString(`result, err = holomush.kv_get("deletekey")`)
+	if err != nil {
+		t.Fatalf("kv_get failed: %v", err)
+	}
+
+	result := L.GetGlobal("result")
+	if result.Type() != lua.LTNil {
+		t.Errorf("expected nil after delete, got %v", result)
+	}
+}
+
+func TestHostFunctions_KVDelete_NoStoreAvailable(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// nil kv store
+	hf := hostfunc.New(nil, nil, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`err = holomush.kv_delete("key")`)
+	if err != nil {
+		t.Fatalf("kv_delete failed: %v", err)
+	}
+
+	errVal := L.GetGlobal("err")
+	if errVal.Type() != lua.LTString {
+		t.Errorf("expected error string when kv store unavailable, got %v", errVal.Type())
+	}
+}
+
+type mockKVStore struct {
+	data map[string][]byte
+}
+
+func (m *mockKVStore) Get(_ context.Context, namespace, key string) ([]byte, error) {
+	return m.data[namespace+":"+key], nil
+}
+
+func (m *mockKVStore) Set(_ context.Context, namespace, key string, value []byte) error {
+	m.data[namespace+":"+key] = value
+	return nil
+}
+
+func (m *mockKVStore) Delete(_ context.Context, namespace, key string) error {
+	delete(m.data, namespace+":"+key)
+	return nil
+}

--- a/internal/plugin/hostfunc/functions_test.go
+++ b/internal/plugin/hostfunc/functions_test.go
@@ -487,6 +487,63 @@ func TestHostFunctions_KVDelete_StoreError(t *testing.T) {
 	}
 }
 
+func TestHostFunctions_KVGet_EmptyKeyRejected(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.read"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_get("")`)
+	if err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
+func TestHostFunctions_KVSet_EmptyKeyRejected(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_set("", "value")`)
+	if err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
+func TestHostFunctions_KVDelete_EmptyKeyRejected(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	enforcer := capability.NewEnforcer()
+	if err := enforcer.SetGrants("test-plugin", []string{"kv.write"}); err != nil {
+		t.Fatal(err)
+	}
+
+	kvStore := &mockKVStore{data: make(map[string][]byte)}
+	hf := hostfunc.New(kvStore, enforcer)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.kv_delete("")`)
+	if err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
 func TestHostFunctions_KV_NamespaceIsolation(t *testing.T) {
 	kvStore := &mockKVStore{data: make(map[string][]byte)}
 


### PR DESCRIPTION
## Summary

- Implements host functions available to Lua plugins via `holomush.*` namespace
- Capability enforcement for KV operations using existing `CapabilityEnforcer`
- Plugin name used as namespace for KV storage isolation

## Functions

| Function | Capability Required | Returns |
|----------|---------------------|---------|
| `holomush.log(level, message)` | None | Nothing |
| `holomush.new_request_id()` | None | 26-char ULID string |
| `holomush.kv_get(key)` | `kv.read` | `(value, nil)` or `(nil, error)` |
| `holomush.kv_set(key, value)` | `kv.write` | `nil` on success, error on failure |
| `holomush.kv_delete(key)` | `kv.write` | `nil` on success, error on failure |

## Files

- `internal/plugin/hostfunc/functions.go` - Implementation
- `internal/plugin/hostfunc/functions_test.go` - Tests

## Test plan

- [x] All log levels (debug, info, warn, error, unknown defaults to info)
- [x] ULID generation (26 chars, uniqueness)
- [x] Capability enforcement for all KV operations
- [x] Missing KV store error handling
- [x] Full KV lifecycle (set, get, delete)

Part of Epic 2: Plugin System (holomush-1hq.14)

🤖 Generated with [Claude Code](https://claude.ai/code)