### PR TITLE
feat(plugin): add event subscriber with filtering

### DIFF
--- a/internal/plugin/subscriber.go
+++ b/internal/plugin/subscriber.go
@@ -1,0 +1,125 @@
+// Package plugin provides plugin management and lifecycle control.
+package plugin
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	pluginpkg "github.com/holomush/holomush/pkg/plugin"
+)
+
+// EventEmitter publishes events from plugins.
+type EventEmitter interface {
+	EmitPluginEvent(ctx context.Context, pluginName string, event pluginpkg.EmitEvent) error
+}
+
+// subscription tracks which events a plugin wants.
+type subscription struct {
+	pluginName string
+	stream     string
+	eventTypes map[string]bool // empty = all events
+}
+
+// Subscriber dispatches events to plugins.
+type Subscriber struct {
+	host          Host
+	emitter       EventEmitter
+	subscriptions []subscription
+	mu            sync.RWMutex
+	wg            sync.WaitGroup
+}
+
+// NewSubscriber creates an event subscriber.
+func NewSubscriber(host Host, emitter EventEmitter) *Subscriber {
+	return &Subscriber{
+		host:    host,
+		emitter: emitter,
+	}
+}
+
+// Subscribe registers a plugin to receive events.
+func (s *Subscriber) Subscribe(pluginName, stream string, eventTypes []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	typeSet := make(map[string]bool)
+	for _, t := range eventTypes {
+		typeSet[t] = true
+	}
+
+	s.subscriptions = append(s.subscriptions, subscription{
+		pluginName: pluginName,
+		stream:     stream,
+		eventTypes: typeSet,
+	})
+}
+
+// Start begins processing events from the channel.
+func (s *Subscriber) Start(ctx context.Context, events <-chan pluginpkg.Event) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				s.dispatch(ctx, event)
+			}
+		}
+	}()
+}
+
+// Stop waits for the subscriber to finish.
+func (s *Subscriber) Stop() {
+	s.wg.Wait()
+}
+
+func (s *Subscriber) dispatch(ctx context.Context, event pluginpkg.Event) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, sub := range s.subscriptions {
+		if sub.stream != event.Stream {
+			continue
+		}
+		if len(sub.eventTypes) > 0 && !sub.eventTypes[string(event.Type)] {
+			continue
+		}
+
+		s.deliverAsync(ctx, sub.pluginName, event)
+	}
+}
+
+func (s *Subscriber) deliverAsync(ctx context.Context, pluginName string, event pluginpkg.Event) {
+	// Use timeout for plugin execution
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+	go func() {
+		defer cancel()
+
+		emits, err := s.host.DeliverEvent(ctx, pluginName, event)
+		if err != nil {
+			slog.Error("failed to deliver event to plugin",
+				"plugin", pluginName,
+				"event_id", event.ID,
+				"error", err)
+			return
+		}
+
+		// Emit response events
+		for _, emit := range emits {
+			if err := s.emitter.EmitPluginEvent(ctx, pluginName, emit); err != nil {
+				slog.Error("failed to emit plugin event",
+					"plugin", pluginName,
+					"stream", emit.Stream,
+					"error", err)
+			}
+		}
+	}()
+}

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -293,3 +293,142 @@ func TestSubscriber_ChannelClose(t *testing.T) {
 		t.Fatal("Stop() did not complete within timeout after channel close")
 	}
 }
+
+func TestSubscriber_HandlesEmitterError(t *testing.T) {
+	host := &subscriberHost{
+		response: []pluginpkg.EmitEvent{
+			{Stream: "location:123", Type: pluginpkg.EventTypeSay, Payload: `{"text":"hello"}`},
+		},
+	}
+	emitter := &subscriberEmitter{err: errors.New("emit failed")}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	// Should not panic on emitter error
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Host was called and delivered
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1", got)
+	}
+	// Emitter was called (even though it errors)
+	if got := emitter.emittedCount(); got != 1 {
+		t.Errorf("emitted = %d, want 1 (emitter should still be called)", got)
+	}
+}
+
+func TestSubscriber_EmptyEventTypesSliceReceivesAll(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{}) // empty slice = all event types
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 3)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+	events <- pluginpkg.Event{ID: "2", Stream: "location:123", Type: pluginpkg.EventTypePose}
+	events <- pluginpkg.Event{ID: "3", Stream: "location:123", Type: pluginpkg.EventTypeArrive}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := host.deliveredCount(); got != 3 {
+		t.Errorf("delivered = %d, want 3 (empty slice should deliver all)", got)
+	}
+}
+
+func TestSubscriber_StopWaitsForInFlightDeliveries(t *testing.T) {
+	// Use a slow host to simulate in-flight delivery
+	deliveryCh := make(chan struct{})
+	host := &slowSubscriberHost{
+		blockCh: deliveryCh,
+	}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	// Send event that will block in delivery
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	// Give time for the async delivery to start
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel context to stop the event loop
+	cancel()
+
+	// Start Stop() in background - it should wait for in-flight delivery
+	stopDone := make(chan struct{})
+	go func() {
+		sub.Stop()
+		close(stopDone)
+	}()
+
+	// Stop should NOT complete yet because delivery is blocked
+	select {
+	case <-stopDone:
+		t.Fatal("Stop() should not complete while delivery is in-flight")
+	case <-time.After(50 * time.Millisecond):
+		// Expected - Stop() is still waiting
+	}
+
+	// Unblock the delivery
+	close(deliveryCh)
+
+	// Now Stop should complete
+	select {
+	case <-stopDone:
+		// Success - Stop() completed after delivery finished
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() did not complete after unblocking delivery")
+	}
+
+	// Verify delivery happened
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1", got)
+	}
+}
+
+// slowSubscriberHost blocks DeliverEvent until blockCh is closed.
+type slowSubscriberHost struct {
+	delivered []pluginpkg.Event
+	blockCh   chan struct{}
+	mu        sync.Mutex
+}
+
+func (h *slowSubscriberHost) Load(context.Context, *plugin.Manifest, string) error { return nil }
+func (h *slowSubscriberHost) Unload(context.Context, string) error                 { return nil }
+func (h *slowSubscriberHost) Plugins() []string                                    { return []string{"test"} }
+func (h *slowSubscriberHost) Close(context.Context) error                          { return nil }
+
+func (h *slowSubscriberHost) DeliverEvent(_ context.Context, _ string, event pluginpkg.Event) ([]pluginpkg.EmitEvent, error) {
+	<-h.blockCh // Block until closed
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.delivered = append(h.delivered, event)
+	return nil, nil
+}
+
+func (h *slowSubscriberHost) deliveredCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.delivered)
+}

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -1,0 +1,295 @@
+package plugin_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/plugin"
+	pluginpkg "github.com/holomush/holomush/pkg/plugin"
+)
+
+// subscriberHost is a mock Host for subscriber tests.
+type subscriberHost struct {
+	delivered []pluginpkg.Event
+	response  []pluginpkg.EmitEvent
+	err       error
+	mu        sync.Mutex
+}
+
+func (h *subscriberHost) Load(context.Context, *plugin.Manifest, string) error { return nil }
+func (h *subscriberHost) Unload(context.Context, string) error                 { return nil }
+func (h *subscriberHost) Plugins() []string                                    { return []string{"test"} }
+func (h *subscriberHost) Close(context.Context) error                          { return nil }
+
+func (h *subscriberHost) DeliverEvent(_ context.Context, _ string, event pluginpkg.Event) ([]pluginpkg.EmitEvent, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.delivered = append(h.delivered, event)
+	return h.response, h.err
+}
+
+func (h *subscriberHost) deliveredCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.delivered)
+}
+
+// subscriberEmitter is a mock EventEmitter for subscriber tests.
+type subscriberEmitter struct {
+	emitted []pluginpkg.EmitEvent
+	err     error
+	mu      sync.Mutex
+}
+
+func (e *subscriberEmitter) EmitPluginEvent(_ context.Context, _ string, event pluginpkg.EmitEvent) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.emitted = append(e.emitted, event)
+	return e.err
+}
+
+func (e *subscriberEmitter) emittedCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.emitted)
+}
+
+func TestSubscriber_DeliversEvents(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{
+		ID:     "01ABC",
+		Stream: "location:123",
+		Type:   pluginpkg.EventTypeSay,
+	}
+
+	// Wait for delivery
+	time.Sleep(50 * time.Millisecond)
+
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1", got)
+	}
+}
+
+func TestSubscriber_FiltersEventTypes(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"}) // Only say events
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 2)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+	events <- pluginpkg.Event{ID: "2", Stream: "location:123", Type: pluginpkg.EventTypePose} // Should be filtered
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1 (pose should be filtered)", got)
+	}
+}
+
+func TestSubscriber_FiltersStreams(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 2)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+	events <- pluginpkg.Event{ID: "2", Stream: "location:456", Type: pluginpkg.EventTypeSay} // Different stream
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1 (different stream should be filtered)", got)
+	}
+}
+
+func TestSubscriber_SubscribeAllEventTypes(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", nil) // nil = all event types
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 3)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+	events <- pluginpkg.Event{ID: "2", Stream: "location:123", Type: pluginpkg.EventTypePose}
+	events <- pluginpkg.Event{ID: "3", Stream: "location:123", Type: pluginpkg.EventTypeArrive}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := host.deliveredCount(); got != 3 {
+		t.Errorf("delivered = %d, want 3 (all types should be delivered)", got)
+	}
+}
+
+func TestSubscriber_EmitsResponseEvents(t *testing.T) {
+	host := &subscriberHost{
+		response: []pluginpkg.EmitEvent{
+			{Stream: "location:123", Type: pluginpkg.EventTypeSay, Payload: `{"text":"hello"}`},
+		},
+	}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := emitter.emittedCount(); got != 1 {
+		t.Errorf("emitted = %d, want 1", got)
+	}
+}
+
+func TestSubscriber_HandlesHostError(t *testing.T) {
+	host := &subscriberHost{
+		err: errors.New("plugin error"),
+	}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	// Should not panic on error
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Host was called
+	if got := host.deliveredCount(); got != 1 {
+		t.Errorf("delivered = %d, want 1", got)
+	}
+	// But no events emitted due to error
+	if got := emitter.emittedCount(); got != 0 {
+		t.Errorf("emitted = %d, want 0 (error should prevent emit)", got)
+	}
+}
+
+func TestSubscriber_MultiplePlugins(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("plugin-a", "location:123", []string{"say"})
+	sub.Subscribe("plugin-b", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Both plugins should receive the event
+	if got := host.deliveredCount(); got != 2 {
+		t.Errorf("delivered = %d, want 2 (both plugins should receive)", got)
+	}
+}
+
+func TestSubscriber_StopWaitsForCompletion(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+	sub.Subscribe("test-plugin", "location:123", []string{"say"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	events <- pluginpkg.Event{ID: "1", Stream: "location:123", Type: pluginpkg.EventTypeSay}
+
+	// Cancel context and stop
+	cancel()
+
+	// Use a channel to detect if Stop() completes
+	done := make(chan struct{})
+	go func() {
+		sub.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - Stop() completed
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() did not complete within timeout")
+	}
+}
+
+func TestSubscriber_ChannelClose(t *testing.T) {
+	host := &subscriberHost{}
+	emitter := &subscriberEmitter{}
+
+	sub := plugin.NewSubscriber(host, emitter)
+
+	ctx := context.Background()
+	events := make(chan pluginpkg.Event, 1)
+	sub.Start(ctx, events)
+
+	// Close channel should cause graceful exit
+	close(events)
+
+	// Use a channel to detect if Stop() completes
+	done := make(chan struct{})
+	go func() {
+		sub.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - Stop() completed
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() did not complete within timeout after channel close")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Subscriber` to dispatch events to plugins based on stream and event type filters
- Delivers events asynchronously with 5-second timeout to prevent slow plugins from blocking
- Forwards plugin response events to `EventEmitter` for re-emission
- Handles host errors gracefully (logs and continues)

## Test plan
- [x] 9 unit tests covering delivery, filtering, response events, error handling
- [x] `task test` passes (excluding pre-existing WASM testdata issue)

## Related
- Part of Epic 2: Plugin System (`holomush-1hq`)
- Closes Task 7: Plugin Subscriber (`holomush-1hq.16`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>