### PR TITLE
feat(plugin): integrate host functions with LuaHost

### DIFF
--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -667,3 +667,19 @@ end
 		t.Errorf("expected capability denied error, got: %v", err)
 	}
 }
+
+func TestLuaHost_NewHostWithFunctions_NilPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected panic when hostFuncs is nil")
+		}
+		// Verify panic message is descriptive
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "hostFuncs cannot be nil") {
+			t.Errorf("panic message should mention 'hostFuncs cannot be nil', got: %v", r)
+		}
+	}()
+
+	_ = pluginlua.NewHostWithFunctions(nil)
+}


### PR DESCRIPTION
## Summary

- Add `NewHostWithFunctions()` constructor to `lua.Host` that accepts `hostfunc.Functions`
- Register host functions in `DeliverEvent` before loading plugin code
- Lua plugins can now call `holomush.log()`, `holomush.new_request_id()`, and `holomush.kv_*()` functions
- Add nil check with panic for consistency with `hostfunc.New()`

## Test plan

- [x] `TestLuaHost_WithHostFunctions` - verifies log and new_request_id work
- [x] `TestLuaHost_WithHostFunctions_CapabilityEnforcement` - verifies capability denial
- [x] All existing plugin tests pass
- [x] Code reviewed by review agent

## Related

Part of Epic 2: Plugin System (`holomush-1hq.17`)

🤖 Generated with [Claude Code](https://claude.ai/code)