### PR TITLE
feat(store): add Epic 5 auth migrations (000009-000011)

### DIFF
--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -263,16 +263,16 @@ func TestMigrator_Close_Idempotent(t *testing.T) {
 }
 
 func TestMigrator_PendingMigrations_Success(t *testing.T) {
-	// At version 3, migrations 4-8 should be pending
+	// At version 3, migrations 4-11 should be pending
 	m := &Migrator{m: &mockMigrate{versionVal: 3}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{4, 5, 6, 7, 8}, pending)
+	assert.Equal(t, []uint{4, 5, 6, 7, 8, 9, 10, 11}, pending)
 }
 
 func TestMigrator_PendingMigrations_AtLatest(t *testing.T) {
-	// At version 8 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 8}}
+	// At version 11 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 11}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)
@@ -283,7 +283,7 @@ func TestMigrator_PendingMigrations_AtZero(t *testing.T) {
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, pending)
 }
 
 func TestMigrator_PendingMigrations_VersionError(t *testing.T) {
@@ -311,11 +311,11 @@ func TestMigrator_AppliedMigrations_AtZero(t *testing.T) {
 }
 
 func TestMigrator_AppliedMigrations_AtLatest(t *testing.T) {
-	// At version 8, all migrations applied
-	m := &Migrator{m: &mockMigrate{versionVal: 8}}
+	// At version 11, all migrations applied
+	m := &Migrator{m: &mockMigrate{versionVal: 11}}
 	applied, err := m.AppliedMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8}, applied)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, applied)
 }
 
 func TestMigrator_AppliedMigrations_VersionError(t *testing.T) {

--- a/internal/store/migrations/000009_auth_player_fields.down.sql
+++ b/internal/store/migrations/000009_auth_player_fields.down.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Reverse 000009_auth_player_fields.up.sql
+
+-- Remove FK constraint first
+ALTER TABLE players DROP CONSTRAINT IF EXISTS fk_players_default_character;
+
+-- Restore NOT NULL on characters.player_id
+-- WARNING: This will fail if any rostered characters exist (NULL player_id).
+-- Before running this down migration, either:
+--   1. Assign all rostered characters to a player, or
+--   2. Delete rostered characters
+-- This is intentional: reversing Epic 5 requires addressing rostered characters.
+ALTER TABLE characters ALTER COLUMN player_id SET NOT NULL;
+
+-- Remove index
+DROP INDEX IF EXISTS idx_players_email;
+
+-- Remove columns
+ALTER TABLE players DROP COLUMN IF EXISTS updated_at;
+ALTER TABLE players DROP COLUMN IF EXISTS preferences;
+ALTER TABLE players DROP COLUMN IF EXISTS default_character_id;
+ALTER TABLE players DROP COLUMN IF EXISTS locked_until;
+ALTER TABLE players DROP COLUMN IF EXISTS failed_attempts;
+ALTER TABLE players DROP COLUMN IF EXISTS email_verified;
+ALTER TABLE players DROP COLUMN IF EXISTS email;

--- a/internal/store/migrations/000009_auth_player_fields.up.sql
+++ b/internal/store/migrations/000009_auth_player_fields.up.sql
@@ -18,7 +18,7 @@ ALTER TABLE players ADD COLUMN IF NOT EXISTS default_character_id TEXT;
 -- Extensible preferences
 ALTER TABLE players ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}';
 
--- Timestamps
+-- Timestamps (updated_at managed at application layer, not via database trigger)
 ALTER TABLE players ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- Unique index on email (partial - only when email is set)

--- a/internal/store/migrations/000009_auth_player_fields.up.sql
+++ b/internal/store/migrations/000009_auth_player_fields.up.sql
@@ -1,0 +1,32 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Auth player fields for Epic 5
+-- Adds email, rate limiting, preferences, and rostering support
+
+-- Email and verification
+ALTER TABLE players ADD COLUMN IF NOT EXISTS email TEXT;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Rate limiting fields
+ALTER TABLE players ADD COLUMN IF NOT EXISTS failed_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS locked_until TIMESTAMPTZ;
+
+-- Default character preference (FK added after characters nullable player_id)
+ALTER TABLE players ADD COLUMN IF NOT EXISTS default_character_id TEXT;
+
+-- Extensible preferences
+ALTER TABLE players ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}';
+
+-- Timestamps
+ALTER TABLE players ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Unique index on email (partial - only when email is set)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_players_email ON players(email) WHERE email IS NOT NULL;
+
+-- Allow rostered characters (player_id nullable for future holomush-gloh epic)
+ALTER TABLE characters ALTER COLUMN player_id DROP NOT NULL;
+
+-- Now add the FK constraint for default_character_id
+ALTER TABLE players ADD CONSTRAINT fk_players_default_character
+    FOREIGN KEY (default_character_id) REFERENCES characters(id) ON DELETE SET NULL;

--- a/internal/store/migrations/000010_web_sessions.down.sql
+++ b/internal/store/migrations/000010_web_sessions.down.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Reverse 000010_web_sessions.up.sql
+
+DROP INDEX IF EXISTS idx_web_sessions_expires;
+DROP INDEX IF EXISTS idx_web_sessions_token;
+DROP INDEX IF EXISTS idx_web_sessions_player;
+DROP TABLE IF EXISTS web_sessions;

--- a/internal/store/migrations/000010_web_sessions.up.sql
+++ b/internal/store/migrations/000010_web_sessions.up.sql
@@ -15,5 +15,5 @@ CREATE TABLE IF NOT EXISTS web_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_web_sessions_player ON web_sessions(player_id);
-CREATE INDEX IF NOT EXISTS idx_web_sessions_token ON web_sessions(token_signature);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_web_sessions_token ON web_sessions(token_signature);
 CREATE INDEX IF NOT EXISTS idx_web_sessions_expires ON web_sessions(expires_at);

--- a/internal/store/migrations/000010_web_sessions.up.sql
+++ b/internal/store/migrations/000010_web_sessions.up.sql
@@ -1,0 +1,19 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Web sessions for Epic 5
+-- Database-backed sessions for web clients with signed tokens
+
+CREATE TABLE IF NOT EXISTS web_sessions (
+    id TEXT PRIMARY KEY,
+    player_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+    character_id TEXT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    token_signature TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    last_active_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_web_sessions_player ON web_sessions(player_id);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_token ON web_sessions(token_signature);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_expires ON web_sessions(expires_at);

--- a/internal/store/migrations/000011_password_resets.down.sql
+++ b/internal/store/migrations/000011_password_resets.down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Reverse 000011_password_resets.up.sql
+
+DROP INDEX IF EXISTS idx_password_resets_expires;
+DROP INDEX IF EXISTS idx_password_resets_player;
+DROP TABLE IF EXISTS password_resets;

--- a/internal/store/migrations/000011_password_resets.up.sql
+++ b/internal/store/migrations/000011_password_resets.up.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Password reset tokens for Epic 5
+-- Stores hashed tokens with expiry for secure password recovery
+
+CREATE TABLE IF NOT EXISTS password_resets (
+    id TEXT PRIMARY KEY,
+    player_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_resets_player ON password_resets(player_id);
+CREATE INDEX IF NOT EXISTS idx_password_resets_expires ON password_resets(expires_at);

--- a/internal/store/migrations/000011_password_resets.up.sql
+++ b/internal/store/migrations/000011_password_resets.up.sql
@@ -9,8 +9,10 @@ CREATE TABLE IF NOT EXISTS password_resets (
     player_id TEXT NOT NULL REFERENCES players(id) ON DELETE CASCADE,
     token_hash TEXT NOT NULL,
     expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,  -- NULL means unused, set when token is consumed
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_password_resets_player ON password_resets(player_id);
 CREATE INDEX IF NOT EXISTS idx_password_resets_expires ON password_resets(expires_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_password_resets_token_hash ON password_resets(token_hash);


### PR DESCRIPTION
## Summary

Add three database migrations for Epic 5 Auth & Identity:

- **000009_auth_player_fields**: Adds authentication fields to `players` table (email, email_verified, failed_attempts, locked_until, default_character_id, preferences, updated_at). Makes `characters.player_id` nullable for rostering support. Adds unique partial index on email and FK constraint for default_character_id.

- **000010_web_sessions**: Creates `web_sessions` table for database-backed web client sessions with player_id, character_id, token_signature, expires_at, and last_active_at. Includes indexes for efficient lookups.

- **000011_password_resets**: Creates `password_resets` table for secure password recovery with player_id, token_hash, and expires_at.

All migrations include proper up/down files with SPDX license headers following golang-migrate naming conventions.

## Test plan

- [x] Verified migration test passes: `go test -run TestMigrationsFS_EmbeddedFiles ./internal/store/...`
- [x] Ran `task fmt` and `task lint` - all checks pass
- [ ] CI will run full test suite including migration tests

## Related

- Implements Tasks 5.1.1, 5.1.2, 5.1.3 from Epic 5
- Design spec: docs/specs/2026-01-25-auth-identity-design.md
- Implementation plan: docs/plans/2026-01-25-epic-5-auth-identity-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)