### PR TITLE
feat(world): add character name validation with Initial Caps normalization

### DIFF
--- a/internal/world/character.go
+++ b/internal/world/character.go
@@ -55,14 +55,14 @@ func (c *Character) SetLocationID(id *ulid.ULID) error {
 }
 
 // SetName updates the character's name with validation.
-// The name must be non-empty, valid UTF-8, within MaxNameLength, and contain
-// no control characters.
+// Character names must contain letters and spaces only, be 2-32 characters,
+// with no leading/trailing/consecutive spaces.
 //
 // Note: Direct field access to Name is acceptable for repository hydration
 // from the database. This setter should be used by application code to ensure
 // validation.
 func (c *Character) SetName(name string) error {
-	if err := ValidateName(name); err != nil {
+	if err := ValidateCharacterName(name); err != nil {
 		return err
 	}
 	c.Name = name
@@ -92,7 +92,7 @@ func (c *Character) Validate() error {
 	if c.PlayerID.IsZero() {
 		return &ValidationError{Field: "player_id", Message: "cannot be zero"}
 	}
-	if err := ValidateName(c.Name); err != nil {
+	if err := ValidateCharacterName(c.Name); err != nil {
 		return err
 	}
 	return ValidateDescription(c.Description)

--- a/internal/world/character.go
+++ b/internal/world/character.go
@@ -55,8 +55,8 @@ func (c *Character) SetLocationID(id *ulid.ULID) error {
 }
 
 // SetName updates the character's name with validation.
-// Character names must contain letters and spaces only, be 2-32 characters,
-// with no leading/trailing/consecutive spaces.
+// Character names must contain letters and spaces only, be MinCharacterNameLength
+// to MaxCharacterNameLength characters, with no leading/trailing/consecutive spaces.
 //
 // Note: Direct field access to Name is acceptable for repository hydration
 // from the database. This setter should be used by application code to ensure

--- a/internal/world/character_test.go
+++ b/internal/world/character_test.go
@@ -512,6 +512,13 @@ func TestValidateCharacterName(t *testing.T) {
 		{name: "contains null", input: "Alar\x00ic", wantErr: true, errMsg: "letters and spaces only"},
 		{name: "contains tab", input: "John\tSmith", wantErr: true, errMsg: "letters and spaces only"},
 		{name: "contains newline", input: "John\nSmith", wantErr: true, errMsg: "letters and spaces only"},
+
+		// Invalid: UTF-8 validation
+		{name: "invalid UTF-8 bytes", input: "\xff\xfe", wantErr: true, errMsg: "must be valid UTF-8"},
+
+		// Unicode length counting (runes, not bytes)
+		{name: "32 char cyrillic valid", input: "Александрийскийгородзеленоград", wantErr: false}, // 30 Cyrillic chars
+		{name: "unicode accented at max", input: "Éléonoreélisabethéléonore", wantErr: false},     // 25 chars with accents
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `ValidateCharacterName` and `NormalizeCharacterName` functions for stricter character name rules
- Character names must be letters and spaces only (no numbers, no special characters)
- Character names must be 2-32 characters with no leading/trailing/consecutive spaces
- Initial Caps normalization converts "alaric" to "Alaric", "jOhN sMiTh" to "John Smith"
- Update `Character.Validate()` and `Character.SetName()` to use the new validation

## Test plan

- [x] Run `task test -- -run TestCharacter ./internal/world/...` - all tests pass
- [x] Run `task test -- -run TestValidateCharacterName ./internal/world/...` - all tests pass
- [x] Run `task test -- -run TestNormalizeCharacterName ./internal/world/...` - all tests pass
- [x] Run `task fmt` and `task lint` - no issues

## Related

Task 5.3.1 (holomush-dwk.15) from Epic 5: Auth & Identity implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)