### PR TITLE
feat(auth): implement argon2id hasher and rate limiter

### DIFF
--- a/internal/auth/hasher.go
+++ b/internal/auth/hasher.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package auth provides authentication primitives for HoloMUSH.
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/samber/oops"
+	"golang.org/x/crypto/argon2"
+)
+
+// OWASP-recommended argon2id parameters.
+const (
+	argon2Time    = 1         // iterations
+	argon2Memory  = 64 * 1024 // 64 MB
+	argon2Threads = 4         // parallelism
+	argon2SaltLen = 16        // salt length in bytes
+	argon2KeyLen  = 32        // output length in bytes
+)
+
+// ErrEmptyPassword is returned when attempting to hash an empty password.
+var ErrEmptyPassword = oops.Code("AUTH_EMPTY_PASSWORD").Errorf("password cannot be empty")
+
+// PasswordHasher provides password hashing and verification.
+type PasswordHasher interface {
+	// Hash produces an argon2id hash of the password.
+	Hash(password string) (string, error)
+
+	// Verify checks if the password matches the hash.
+	// Returns (true, nil) on match, (false, nil) on mismatch, or error on invalid hash.
+	Verify(password, hash string) (bool, error)
+
+	// NeedsUpgrade returns true if the hash should be upgraded to argon2id.
+	NeedsUpgrade(hash string) bool
+}
+
+// Argon2idHasher implements PasswordHasher using argon2id.
+type Argon2idHasher struct{}
+
+// NewArgon2idHasher creates a new Argon2idHasher.
+func NewArgon2idHasher() *Argon2idHasher {
+	return &Argon2idHasher{}
+}
+
+// Hash produces an argon2id hash of the password.
+func (h *Argon2idHasher) Hash(password string) (string, error) {
+	if password == "" {
+		return "", ErrEmptyPassword
+	}
+
+	// Generate random salt
+	salt := make([]byte, argon2SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", oops.Code("AUTH_SALT_FAILED").Wrap(err)
+	}
+
+	// Compute hash
+	hash := argon2.IDKey([]byte(password), salt, argon2Time, argon2Memory, argon2Threads, argon2KeyLen)
+
+	// Encode as PHC string format
+	// $argon2id$v=19$m=65536,t=1,p=4$<salt>$<hash>
+	encoded := fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		argon2Memory,
+		argon2Time,
+		argon2Threads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	)
+
+	return encoded, nil
+}
+
+// Verify checks if the password matches the hash.
+func (h *Argon2idHasher) Verify(password, encodedHash string) (bool, error) {
+	// Parse the hash
+	parts := strings.Split(encodedHash, "$")
+	if len(parts) != 6 {
+		return false, oops.Code("AUTH_INVALID_HASH").Errorf("invalid hash format")
+	}
+
+	if parts[1] != "argon2id" {
+		return false, oops.Code("AUTH_INVALID_HASH").Errorf("unsupported hash algorithm: %s", parts[1])
+	}
+
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return false, oops.Code("AUTH_INVALID_HASH").Wrap(err)
+	}
+
+	var memory, time, threads uint32
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
+		return false, oops.Code("AUTH_INVALID_HASH").Wrap(err)
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, oops.Code("AUTH_INVALID_HASH").Wrap(err)
+	}
+
+	expectedHash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, oops.Code("AUTH_INVALID_HASH").Wrap(err)
+	}
+
+	// Validate threads fits in uint8 to prevent silent truncation
+	if threads > 255 {
+		return false, oops.Code("AUTH_INVALID_HASH").Errorf("threads value %d exceeds uint8 max", threads)
+	}
+
+	// Validate key length to prevent integer overflow in uint32 conversion
+	keyLen := len(expectedHash)
+	if keyLen <= 0 || keyLen > 1<<30 {
+		return false, oops.Code("AUTH_INVALID_HASH").Errorf("invalid hash key length: %d", keyLen)
+	}
+
+	// Compute hash with same parameters
+	computedHash := argon2.IDKey([]byte(password), salt, time, memory, uint8(threads), uint32(keyLen))
+
+	// Constant-time comparison
+	if subtle.ConstantTimeCompare(computedHash, expectedHash) == 1 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// NeedsUpgrade returns true if the hash is not argon2id (e.g., bcrypt).
+func (h *Argon2idHasher) NeedsUpgrade(hash string) bool {
+	return !strings.HasPrefix(hash, "$argon2id$")
+}

--- a/internal/auth/hasher_test.go
+++ b/internal/auth/hasher_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+func TestHashPassword(t *testing.T) {
+	hasher := auth.NewArgon2idHasher()
+
+	t.Run("produces valid hash", func(t *testing.T) {
+		hash, err := hasher.Hash("password123")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(hash, "$argon2id$"))
+	})
+
+	t.Run("different passwords produce different hashes", func(t *testing.T) {
+		hash1, err := hasher.Hash("password1")
+		require.NoError(t, err)
+		hash2, err := hasher.Hash("password2")
+		require.NoError(t, err)
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("same password produces different hashes (salt)", func(t *testing.T) {
+		hash1, err := hasher.Hash("samepassword")
+		require.NoError(t, err)
+		hash2, err := hasher.Hash("samepassword")
+		require.NoError(t, err)
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("rejects empty password", func(t *testing.T) {
+		_, err := hasher.Hash("")
+		assert.Error(t, err)
+	})
+}
+
+func TestVerifyPassword(t *testing.T) {
+	hasher := auth.NewArgon2idHasher()
+
+	t.Run("correct password verifies", func(t *testing.T) {
+		hash, err := hasher.Hash("correctpassword")
+		require.NoError(t, err)
+
+		ok, err := hasher.Verify("correctpassword", hash)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("incorrect password fails", func(t *testing.T) {
+		hash, err := hasher.Hash("correctpassword")
+		require.NoError(t, err)
+
+		ok, err := hasher.Verify("wrongpassword", hash)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid hash format returns error", func(t *testing.T) {
+		_, err := hasher.Verify("password", "not-a-valid-hash")
+		assert.Error(t, err)
+	})
+}
+
+func TestVerifyBcryptUpgrade(t *testing.T) {
+	hasher := auth.NewArgon2idHasher()
+
+	// This is a valid bcrypt hash for testing upgrade detection
+	bcryptHash := "$2a$10$N9qo8uLOickgx2ZMRZoMyeIvNq.Uf3hE9tQALNP1Qn9sNp5x5x5x5"
+
+	t.Run("detects bcrypt hash needing upgrade", func(t *testing.T) {
+		needsUpgrade := hasher.NeedsUpgrade(bcryptHash)
+		assert.True(t, needsUpgrade)
+	})
+
+	t.Run("argon2id hash does not need upgrade", func(t *testing.T) {
+		hash, err := hasher.Hash("password")
+		require.NoError(t, err)
+		assert.False(t, hasher.NeedsUpgrade(hash))
+	})
+}

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth
+
+import (
+	"time"
+)
+
+// Rate limiting configuration.
+const (
+	// LockoutDuration is the time a user is locked out after too many failures.
+	LockoutDuration = 15 * time.Minute
+
+	// LockoutThreshold is the number of failures that triggers a lockout.
+	LockoutThreshold = 7
+
+	// CaptchaThreshold is the number of failures that triggers CAPTCHA requirement (web only).
+	CaptchaThreshold = 4
+)
+
+// RateLimitResult contains the result of a rate limit check.
+type RateLimitResult struct {
+	// Delay is the time to wait before allowing another attempt.
+	Delay time.Duration
+
+	// RequiresCaptcha indicates the web client should require CAPTCHA.
+	RequiresCaptcha bool
+
+	// IsLockedOut indicates the account is temporarily locked.
+	IsLockedOut bool
+
+	// LockoutRemaining is the time until the lockout expires.
+	LockoutRemaining time.Duration
+}
+
+// CheckFailures evaluates the rate limit state based on failure count.
+// lockedUntil is the current lockout timestamp (nil if not locked).
+func CheckFailures(failures int, lockedUntil *time.Time) RateLimitResult {
+	result := RateLimitResult{}
+
+	// Check existing lockout first
+	if IsLockedOut(lockedUntil) {
+		result.IsLockedOut = true
+		result.LockoutRemaining = time.Until(*lockedUntil)
+		return result
+	}
+
+	// Progressive delay: 2^(failures-1) seconds, max 32s before lockout
+	if failures > 0 && failures < LockoutThreshold {
+		result.Delay = time.Duration(1<<(failures-1)) * time.Second
+		if result.Delay > 32*time.Second {
+			result.Delay = 32 * time.Second
+		}
+	}
+
+	// CAPTCHA required at 4+ failures (for web clients)
+	if failures >= CaptchaThreshold && failures < LockoutThreshold {
+		result.RequiresCaptcha = true
+	}
+
+	// Lockout at 7+ failures
+	if failures >= LockoutThreshold {
+		result.IsLockedOut = true
+		result.LockoutRemaining = LockoutDuration
+	}
+
+	return result
+}
+
+// IsLockedOut returns true if the lockout time is in the future.
+func IsLockedOut(lockedUntil *time.Time) bool {
+	return lockedUntil != nil && lockedUntil.After(time.Now())
+}
+
+// ComputeLockoutTime returns the lockout timestamp for the given failure count.
+// Returns nil if failures < LockoutThreshold.
+func ComputeLockoutTime(failures int) *time.Time {
+	if failures < LockoutThreshold {
+		return nil
+	}
+	lockout := time.Now().Add(LockoutDuration)
+	return &lockout
+}
+
+// ResetOnSuccess returns the values to set after a successful login.
+// Returns 0 for failed_attempts and nil for locked_until.
+func ResetOnSuccess() (int, *time.Time) {
+	return 0, nil
+}

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -20,6 +20,13 @@ func TestRateLimiter_CheckFailures(t *testing.T) {
 		assert.False(t, result.IsLockedOut)
 	})
 
+	t.Run("negative failures treated as zero", func(t *testing.T) {
+		result := auth.CheckFailures(-1, nil)
+		assert.Zero(t, result.Delay)
+		assert.False(t, result.RequiresCaptcha)
+		assert.False(t, result.IsLockedOut)
+	})
+
 	t.Run("1-3 failures returns progressive delay", func(t *testing.T) {
 		result1 := auth.CheckFailures(1, nil)
 		assert.Equal(t, time.Second, result1.Delay)

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+func TestRateLimiter_CheckFailures(t *testing.T) {
+	t.Run("no failures returns no delay", func(t *testing.T) {
+		result := auth.CheckFailures(0, nil)
+		assert.Zero(t, result.Delay)
+		assert.False(t, result.RequiresCaptcha)
+		assert.False(t, result.IsLockedOut)
+	})
+
+	t.Run("1-3 failures returns progressive delay", func(t *testing.T) {
+		result1 := auth.CheckFailures(1, nil)
+		assert.Equal(t, time.Second, result1.Delay)
+		assert.False(t, result1.RequiresCaptcha)
+
+		result2 := auth.CheckFailures(2, nil)
+		assert.Equal(t, 2*time.Second, result2.Delay)
+
+		result3 := auth.CheckFailures(3, nil)
+		assert.Equal(t, 4*time.Second, result3.Delay)
+	})
+
+	t.Run("4-6 failures requires captcha (web)", func(t *testing.T) {
+		result4 := auth.CheckFailures(4, nil)
+		assert.True(t, result4.RequiresCaptcha)
+		assert.Equal(t, 8*time.Second, result4.Delay)
+
+		result6 := auth.CheckFailures(6, nil)
+		assert.True(t, result6.RequiresCaptcha)
+		assert.Equal(t, 32*time.Second, result6.Delay)
+	})
+
+	t.Run("7+ failures causes lockout", func(t *testing.T) {
+		result := auth.CheckFailures(7, nil)
+		assert.True(t, result.IsLockedOut)
+		assert.Equal(t, auth.LockoutDuration, result.LockoutRemaining)
+	})
+
+	t.Run("existing lockout is detected", func(t *testing.T) {
+		future := time.Now().Add(10 * time.Minute)
+		result := auth.CheckFailures(0, &future)
+		assert.True(t, result.IsLockedOut)
+		assert.True(t, result.LockoutRemaining > 0)
+		assert.True(t, result.LockoutRemaining <= 10*time.Minute)
+	})
+}
+
+func TestRateLimiter_IsLockedOut(t *testing.T) {
+	now := time.Now()
+
+	t.Run("nil locked_until means not locked", func(t *testing.T) {
+		assert.False(t, auth.IsLockedOut(nil))
+	})
+
+	t.Run("past locked_until means not locked", func(t *testing.T) {
+		past := now.Add(-time.Hour)
+		assert.False(t, auth.IsLockedOut(&past))
+	})
+
+	t.Run("future locked_until means locked", func(t *testing.T) {
+		future := now.Add(time.Hour)
+		assert.True(t, auth.IsLockedOut(&future))
+	})
+}
+
+func TestRateLimiter_ComputeLockoutTime(t *testing.T) {
+	t.Run("7 failures returns lockout time", func(t *testing.T) {
+		lockout := auth.ComputeLockoutTime(7)
+		assert.NotNil(t, lockout)
+		assert.True(t, lockout.After(time.Now()))
+	})
+
+	t.Run("less than 7 failures returns nil", func(t *testing.T) {
+		assert.Nil(t, auth.ComputeLockoutTime(6))
+	})
+
+	t.Run("more than 7 failures still returns lockout", func(t *testing.T) {
+		lockout := auth.ComputeLockoutTime(10)
+		assert.NotNil(t, lockout)
+	})
+}
+
+func TestRateLimiter_ResetOnSuccess(t *testing.T) {
+	t.Run("returns zero failures and nil lockout", func(t *testing.T) {
+		failures, lockout := auth.ResetOnSuccess()
+		assert.Equal(t, 0, failures)
+		assert.Nil(t, lockout)
+	})
+}


### PR DESCRIPTION
## Summary

Implements Epic 5 Phase 2 authentication primitives:

- **Argon2id Password Hasher** (`internal/auth/hasher.go`)
  - OWASP-recommended parameters (t=1, m=64MB, p=4)
  - PHC string format encoding
  - Bcrypt upgrade detection for hash migration
  - Constant-time comparison for security

- **Rate Limiter** (`internal/auth/ratelimit.go`)
  - Progressive delays: 1s → 2s → 4s → 8s → 16s → 32s
  - CAPTCHA requirement at 4+ failures (web clients)
  - Account lockout at 7+ failures (15 minute duration)
  - Helper functions for lockout time computation

## Test plan

- [x] `go test ./internal/auth/...` - all tests pass
- [ ] CI passes

## Tasks

Closes holomush-dwk.11, holomush-dwk.12

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>