### PR TITLE
feat(auth): implement Player domain type

### DIFF
--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+)
+
+// DefaultMaxCharacters is the default character limit per player.
+const DefaultMaxCharacters = 5
+
+// Username validation constraints.
+const (
+	MinUsernameLength = 3
+	MaxUsernameLength = 30
+)
+
+// usernameRegex matches usernames that:
+// - Start with a letter (a-z, A-Z)
+// - Contain only letters, numbers, and underscores
+var usernameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
+
+// Player represents a player account.
+type Player struct {
+	ID                 ulid.ULID
+	Username           string
+	PasswordHash       string
+	Email              *string
+	EmailVerified      bool
+	FailedAttempts     int
+	LockedUntil        *time.Time
+	DefaultCharacterID *ulid.ULID
+	Preferences        PlayerPreferences
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// PlayerPreferences contains player-specific settings.
+type PlayerPreferences struct {
+	AutoLogin     bool   `json:"auto_login,omitempty"`
+	MaxCharacters int    `json:"max_characters,omitempty"`
+	Theme         string `json:"theme,omitempty"`
+}
+
+// EffectiveMaxCharacters returns the character limit, using default if not set.
+func (p PlayerPreferences) EffectiveMaxCharacters() int {
+	if p.MaxCharacters <= 0 {
+		return DefaultMaxCharacters
+	}
+	return p.MaxCharacters
+}
+
+// IsLocked returns true if the player is currently locked out.
+func (p *Player) IsLocked() bool {
+	return IsLockedOut(p.LockedUntil)
+}
+
+// RecordFailure increments the failure counter and sets lockout if threshold reached.
+func (p *Player) RecordFailure() {
+	p.FailedAttempts++
+	p.LockedUntil = ComputeLockoutTime(p.FailedAttempts)
+	p.UpdatedAt = time.Now()
+}
+
+// RecordSuccess resets failure counter and lockout.
+func (p *Player) RecordSuccess() {
+	p.FailedAttempts = 0
+	p.LockedUntil = nil
+	p.UpdatedAt = time.Now()
+}
+
+// ValidateUsername validates a username against rules.
+// Username requirements:
+// - Length: MinUsernameLength to MaxUsernameLength characters
+// - Must start with a letter
+// - Can contain only letters (a-z, A-Z), numbers (0-9), and underscores (_)
+func ValidateUsername(username string) error {
+	if username == "" {
+		return oops.Code("AUTH_INVALID_USERNAME").Errorf("username cannot be empty")
+	}
+	if len(username) < MinUsernameLength {
+		return oops.Code("AUTH_INVALID_USERNAME").
+			With("min", MinUsernameLength).
+			Errorf("username must be at least %d characters", MinUsernameLength)
+	}
+	if len(username) > MaxUsernameLength {
+		return oops.Code("AUTH_INVALID_USERNAME").
+			With("max", MaxUsernameLength).
+			Errorf("username must be at most %d characters", MaxUsernameLength)
+	}
+	if !usernameRegex.MatchString(username) {
+		return oops.Code("AUTH_INVALID_USERNAME").
+			Errorf("username must start with a letter and contain only letters, numbers, and underscores")
+	}
+	return nil
+}

--- a/internal/auth/player_test.go
+++ b/internal/auth/player_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+func TestPlayer_IsLocked(t *testing.T) {
+	t.Run("no lockout", func(t *testing.T) {
+		p := &auth.Player{}
+		assert.False(t, p.IsLocked())
+	})
+
+	t.Run("future lockout", func(t *testing.T) {
+		future := time.Now().Add(time.Hour)
+		p := &auth.Player{LockedUntil: &future}
+		assert.True(t, p.IsLocked())
+	})
+
+	t.Run("past lockout", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour)
+		p := &auth.Player{LockedUntil: &past}
+		assert.False(t, p.IsLocked())
+	})
+}
+
+func TestPlayer_RecordFailure(t *testing.T) {
+	t.Run("increments counter", func(t *testing.T) {
+		p := &auth.Player{FailedAttempts: 0}
+		p.RecordFailure()
+		assert.Equal(t, 1, p.FailedAttempts)
+	})
+
+	t.Run("sets lockout at threshold", func(t *testing.T) {
+		p := &auth.Player{FailedAttempts: 6}
+		p.RecordFailure()
+		assert.Equal(t, 7, p.FailedAttempts)
+		assert.NotNil(t, p.LockedUntil)
+		assert.True(t, p.LockedUntil.After(time.Now()))
+	})
+
+	t.Run("updates UpdatedAt", func(t *testing.T) {
+		p := &auth.Player{FailedAttempts: 0}
+		before := time.Now().Add(-time.Millisecond)
+		p.RecordFailure()
+		assert.True(t, p.UpdatedAt.After(before))
+	})
+}
+
+func TestPlayer_RecordSuccess(t *testing.T) {
+	t.Run("resets failures and lockout", func(t *testing.T) {
+		future := time.Now().Add(time.Hour)
+		p := &auth.Player{
+			FailedAttempts: 5,
+			LockedUntil:    &future,
+		}
+		p.RecordSuccess()
+		assert.Equal(t, 0, p.FailedAttempts)
+		assert.Nil(t, p.LockedUntil)
+	})
+
+	t.Run("updates UpdatedAt", func(t *testing.T) {
+		p := &auth.Player{FailedAttempts: 3}
+		before := time.Now().Add(-time.Millisecond)
+		p.RecordSuccess()
+		assert.True(t, p.UpdatedAt.After(before))
+	})
+}
+
+func TestPlayerPreferences(t *testing.T) {
+	t.Run("default values", func(t *testing.T) {
+		prefs := auth.PlayerPreferences{}
+		assert.False(t, prefs.AutoLogin)
+		assert.Equal(t, 0, prefs.MaxCharacters) // 0 means use default
+	})
+
+	t.Run("effective max characters uses default when zero", func(t *testing.T) {
+		prefs := auth.PlayerPreferences{}
+		assert.Equal(t, auth.DefaultMaxCharacters, prefs.EffectiveMaxCharacters())
+	})
+
+	t.Run("effective max characters uses custom when set", func(t *testing.T) {
+		prefs := auth.PlayerPreferences{MaxCharacters: 10}
+		assert.Equal(t, 10, prefs.EffectiveMaxCharacters())
+	})
+
+	t.Run("effective max characters uses default when negative", func(t *testing.T) {
+		prefs := auth.PlayerPreferences{MaxCharacters: -1}
+		assert.Equal(t, auth.DefaultMaxCharacters, prefs.EffectiveMaxCharacters())
+	})
+}
+
+func TestPlayer_Fields(t *testing.T) {
+	t.Run("all fields are settable", func(t *testing.T) {
+		now := time.Now()
+		playerID := ulid.Make()
+		charID := ulid.Make()
+		email := "test@example.com"
+
+		p := &auth.Player{
+			ID:                 playerID,
+			Username:           "testuser",
+			PasswordHash:       "$argon2id$v=19$...",
+			Email:              &email,
+			EmailVerified:      true,
+			FailedAttempts:     2,
+			LockedUntil:        nil,
+			DefaultCharacterID: &charID,
+			Preferences: auth.PlayerPreferences{
+				AutoLogin:     true,
+				MaxCharacters: 3,
+				Theme:         "dark",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+
+		assert.Equal(t, playerID, p.ID)
+		assert.Equal(t, "testuser", p.Username)
+		assert.Equal(t, "$argon2id$v=19$...", p.PasswordHash)
+		assert.Equal(t, &email, p.Email)
+		assert.True(t, p.EmailVerified)
+		assert.Equal(t, 2, p.FailedAttempts)
+		assert.Nil(t, p.LockedUntil)
+		assert.Equal(t, &charID, p.DefaultCharacterID)
+		assert.True(t, p.Preferences.AutoLogin)
+		assert.Equal(t, 3, p.Preferences.MaxCharacters)
+		assert.Equal(t, "dark", p.Preferences.Theme)
+		assert.Equal(t, now, p.CreatedAt)
+		assert.Equal(t, now, p.UpdatedAt)
+	})
+}
+
+func TestValidateUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		wantErr  bool
+	}{
+		{"valid", "testuser", false},
+		{"valid with numbers", "user123", false},
+		{"valid with underscore", "test_user", false},
+		{"valid min length", "abc", false},
+		{"valid max length", "abcdefghijklmnopqrstuvwxyz1234", false}, // 30 chars
+		{"too short", "ab", true},
+		{"too long", "abcdefghijklmnopqrstuvwxyz12345", true}, // 31 chars
+		{"empty", "", true},
+		{"spaces", "test user", true},
+		{"special chars at", "test@user", true},
+		{"special chars bang", "test!user", true},
+		{"special chars hyphen", "test-user", true},
+		{"starts with number", "123user", true},
+		{"starts with underscore", "_user", true},
+		{"uppercase valid", "TestUser", false},
+		{"mixed case valid", "Test_User_123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := auth.ValidateUsername(tt.username)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateUsername_ErrorCodes(t *testing.T) {
+	t.Run("empty username has correct error code", func(t *testing.T) {
+		err := auth.ValidateUsername("")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("too short has correct error message", func(t *testing.T) {
+		err := auth.ValidateUsername("ab")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "at least")
+	})
+
+	t.Run("too long has correct error message", func(t *testing.T) {
+		err := auth.ValidateUsername("abcdefghijklmnopqrstuvwxyz12345")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "at most")
+	})
+
+	t.Run("invalid chars has correct error message", func(t *testing.T) {
+		err := auth.ValidateUsername("test@user")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "letter")
+	})
+}


### PR DESCRIPTION
## Summary

- Implements Epic 5 Task 5.2.3: Player Domain Type
- Player struct with all required fields (ID, Username, PasswordHash, Email, EmailVerified, FailedAttempts, LockedUntil, DefaultCharacterID, Preferences, CreatedAt, UpdatedAt)
- PlayerPreferences struct (AutoLogin, MaxCharacters, Theme) with EffectiveMaxCharacters() method
- IsLocked() method delegating to existing rate limiter
- RecordFailure() and RecordSuccess() methods for login attempt tracking
- ValidateUsername() function (3-30 chars, letter start, alphanumeric + underscore)

## Test Plan

- [x] All Player method tests pass
- [x] ValidateUsername table-driven tests cover edge cases
- [x] Linting passes
- [x] Code review completed with no issues

Closes beads-dwk.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)