### PR TITLE
ci: add repo-token to arduino/setup-task to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install golangci-lint v2
         run: |
@@ -83,6 +84,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: task test:coverage
@@ -111,6 +113,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: task build


### PR DESCRIPTION
## Summary

- Adds `repo-token: ${{ secrets.GITHUB_TOKEN }}` to all `arduino/setup-task@v2` usages
- Uses authenticated GitHub API requests instead of anonymous ones
- Prevents transient CI failures due to GitHub API rate limits on shared runners

## Context

PR #52 failed with:
```
##[error]API rate limit exceeded for 20.169.77.229
```

The `arduino/setup-task` action downloads Task from GitHub releases. Without authentication, it uses the low anonymous rate limit which gets exhausted on shared runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)