### PR TITLE
feat(auth): implement Password Reset PostgreSQL Repository

### DIFF
--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package auth
+
+import "errors"
+
+// ErrNotFound is returned when a requested entity does not exist.
+var ErrNotFound = errors.New("not found")

--- a/internal/auth/postgres/postgres_test.go
+++ b/internal/auth/postgres/postgres_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/holomush/holomush/internal/store"
+)
+
+// testPool is the shared database pool for integration tests.
+var testPool *pgxpool.Pool
+
+// testCleanup is called to terminate the container after tests.
+var testCleanup func()
+
+// TestMain sets up a PostgreSQL testcontainer for integration tests.
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	container, err := postgres.Run(ctx,
+		"postgres:18-alpine",
+		postgres.WithDatabase("holomush_test"),
+		postgres.WithUsername("holomush"),
+		postgres.WithPassword("holomush"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	if err != nil {
+		panic("failed to start postgres container: " + err.Error())
+	}
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		panic("failed to get connection string: " + err.Error())
+	}
+
+	// Run all migrations using the new Migrator
+	migrator, err := store.NewMigrator(connStr)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		panic("failed to create migrator: " + err.Error())
+	}
+	if err := migrator.Up(); err != nil {
+		_ = migrator.Close()
+		_ = container.Terminate(ctx)
+		panic("failed to run migrations: " + err.Error())
+	}
+	_ = migrator.Close()
+
+	// Create a new pool for tests
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		panic("failed to create pool: " + err.Error())
+	}
+
+	testPool = pool
+	testCleanup = func() {
+		pool.Close()
+		_ = container.Terminate(ctx)
+	}
+
+	// Run tests
+	code := m.Run()
+
+	// Cleanup
+	testCleanup()
+
+	os.Exit(code)
+}

--- a/internal/auth/postgres/reset_repo.go
+++ b/internal/auth/postgres/reset_repo.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package postgres provides PostgreSQL implementations of auth repositories.
+package postgres
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+// PasswordResetRepository implements auth.PasswordResetRepository using PostgreSQL.
+type PasswordResetRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPasswordResetRepository creates a new PasswordResetRepository.
+func NewPasswordResetRepository(pool *pgxpool.Pool) *PasswordResetRepository {
+	return &PasswordResetRepository{pool: pool}
+}
+
+// Create stores a new password reset request.
+func (r *PasswordResetRepository) Create(ctx context.Context, reset *auth.PasswordReset) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO password_resets (id, player_id, token_hash, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, reset.ID.String(), reset.PlayerID.String(), reset.TokenHash, reset.ExpiresAt, reset.CreatedAt)
+	if err != nil {
+		return oops.Code("RESET_CREATE_FAILED").
+			With("operation", "insert password_reset").
+			With("player_id", reset.PlayerID.String()).
+			Wrap(err)
+	}
+	return nil
+}
+
+// GetByPlayer retrieves the most recent reset request for a player.
+func (r *PasswordResetRepository) GetByPlayer(ctx context.Context, playerID ulid.ULID) (*auth.PasswordReset, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, player_id, token_hash, expires_at, created_at
+		FROM password_resets
+		WHERE player_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, playerID.String())
+
+	return r.scanReset(row)
+}
+
+// GetByTokenHash retrieves a reset request by its token hash.
+func (r *PasswordResetRepository) GetByTokenHash(ctx context.Context, tokenHash string) (*auth.PasswordReset, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, player_id, token_hash, expires_at, created_at
+		FROM password_resets
+		WHERE token_hash = $1
+	`, tokenHash)
+
+	return r.scanReset(row)
+}
+
+// Delete removes a password reset request.
+func (r *PasswordResetRepository) Delete(ctx context.Context, id ulid.ULID) error {
+	result, err := r.pool.Exec(ctx, `
+		DELETE FROM password_resets WHERE id = $1
+	`, id.String())
+	if err != nil {
+		return oops.Code("RESET_DELETE_FAILED").
+			With("operation", "delete password_reset").
+			With("id", id.String()).
+			Wrap(err)
+	}
+	if result.RowsAffected() == 0 {
+		return oops.Code("RESET_NOT_FOUND").
+			With("id", id.String()).
+			Wrap(auth.ErrNotFound)
+	}
+	return nil
+}
+
+// DeleteByPlayer removes all reset requests for a player.
+func (r *PasswordResetRepository) DeleteByPlayer(ctx context.Context, playerID ulid.ULID) error {
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM password_resets WHERE player_id = $1
+	`, playerID.String())
+	if err != nil {
+		return oops.Code("RESET_DELETE_BY_PLAYER_FAILED").
+			With("operation", "delete password_resets by player").
+			With("player_id", playerID.String()).
+			Wrap(err)
+	}
+	// Note: No ErrNotFound if no rows deleted - that's a valid state
+	return nil
+}
+
+// DeleteExpired removes all expired reset requests and returns the count.
+func (r *PasswordResetRepository) DeleteExpired(ctx context.Context) (int64, error) {
+	result, err := r.pool.Exec(ctx, `
+		DELETE FROM password_resets WHERE expires_at < $1
+	`, time.Now())
+	if err != nil {
+		return 0, oops.Code("RESET_DELETE_EXPIRED_FAILED").
+			With("operation", "delete expired password_resets").
+			Wrap(err)
+	}
+	return result.RowsAffected(), nil
+}
+
+// scanReset scans a single row into a PasswordReset.
+func (r *PasswordResetRepository) scanReset(row pgx.Row) (*auth.PasswordReset, error) {
+	var (
+		idStr       string
+		playerIDStr string
+		tokenHash   string
+		expiresAt   time.Time
+		createdAt   time.Time
+	)
+
+	err := row.Scan(&idStr, &playerIDStr, &tokenHash, &expiresAt, &createdAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, auth.ErrNotFound
+		}
+		return nil, oops.Code("RESET_SCAN_FAILED").
+			With("operation", "scan password_reset").
+			Wrap(err)
+	}
+
+	id, err := ulid.Parse(idStr)
+	if err != nil {
+		return nil, oops.Code("RESET_INVALID_ID").
+			With("operation", "parse reset id").
+			With("id", idStr).
+			Wrap(err)
+	}
+
+	playerID, err := ulid.Parse(playerIDStr)
+	if err != nil {
+		return nil, oops.Code("RESET_INVALID_PLAYER_ID").
+			With("operation", "parse player id").
+			With("player_id", playerIDStr).
+			Wrap(err)
+	}
+
+	return &auth.PasswordReset{
+		ID:        id,
+		PlayerID:  playerID,
+		TokenHash: tokenHash,
+		ExpiresAt: expiresAt,
+		CreatedAt: createdAt,
+	}, nil
+}
+
+// Compile-time interface check.
+var _ auth.PasswordResetRepository = (*PasswordResetRepository)(nil)

--- a/internal/auth/postgres/reset_repo.go
+++ b/internal/auth/postgres/reset_repo.go
@@ -52,7 +52,17 @@ func (r *PasswordResetRepository) GetByPlayer(ctx context.Context, playerID ulid
 		LIMIT 1
 	`, playerID.String())
 
-	return r.scanReset(row)
+	reset, err := r.scanReset(row)
+	if err != nil {
+		if errors.Is(err, auth.ErrNotFound) {
+			return nil, oops.Code("RESET_NOT_FOUND").
+				With("operation", "get by player").
+				With("player_id", playerID.String()).
+				Wrap(err)
+		}
+		return nil, err
+	}
+	return reset, nil
 }
 
 // GetByTokenHash retrieves a reset request by its token hash.
@@ -63,7 +73,16 @@ func (r *PasswordResetRepository) GetByTokenHash(ctx context.Context, tokenHash 
 		WHERE token_hash = $1
 	`, tokenHash)
 
-	return r.scanReset(row)
+	reset, err := r.scanReset(row)
+	if err != nil {
+		if errors.Is(err, auth.ErrNotFound) {
+			return nil, oops.Code("RESET_NOT_FOUND").
+				With("operation", "get by token hash").
+				Wrap(err)
+		}
+		return nil, err
+	}
+	return reset, nil
 }
 
 // Delete removes a password reset request.

--- a/internal/auth/postgres/reset_repo.go
+++ b/internal/auth/postgres/reset_repo.go
@@ -59,7 +59,9 @@ func (r *PasswordResetRepository) GetByPlayer(ctx context.Context, playerID ulid
 			Wrap(auth.ErrNotFound)
 	}
 	if err != nil {
-		return nil, err
+		return nil, oops.With("operation", "get reset by player").
+			With("player_id", playerID.String()).
+			Wrap(err)
 	}
 	return reset, nil
 }
@@ -77,7 +79,7 @@ func (r *PasswordResetRepository) GetByTokenHash(ctx context.Context, tokenHash 
 		return nil, oops.Code("RESET_NOT_FOUND").Wrap(auth.ErrNotFound)
 	}
 	if err != nil {
-		return nil, err
+		return nil, oops.With("operation", "get reset by token hash").Wrap(err)
 	}
 	return reset, nil
 }
@@ -143,7 +145,6 @@ func (r *PasswordResetRepository) scanReset(row pgx.Row) (*auth.PasswordReset, e
 	err := row.Scan(&idStr, &playerIDStr, &tokenHash, &expiresAt, &createdAt)
 	if err != nil {
 		// Propagate pgx.ErrNoRows unchanged for callers to handle with context.
-		// This matches the established pattern in internal/world/postgres/*_repo.go.
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, err //nolint:wrapcheck // Callers wrap with context-specific info
 		}

--- a/internal/auth/postgres/reset_repo_test.go
+++ b/internal/auth/postgres/reset_repo_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/auth"
+	"github.com/holomush/holomush/internal/auth/postgres"
+)
+
+// createTestPlayer creates a player in the database for testing password resets.
+func createTestPlayer(ctx context.Context, t *testing.T, username string) ulid.ULID {
+	t.Helper()
+	playerID := ulid.Make()
+	_, err := testPool.Exec(ctx, `
+		INSERT INTO players (id, username, password_hash, created_at)
+		VALUES ($1, $2, 'testhash', NOW())
+	`, playerID.String(), username)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM players WHERE id = $1`, playerID.String())
+	})
+
+	return playerID
+}
+
+func TestPasswordResetRepository_Create(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_create_test")
+
+	t.Run("creates new reset", func(t *testing.T) {
+		reset := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "testhash123",
+			ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond),
+			CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+		}
+
+		err := repo.Create(ctx, reset)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE id = $1`, reset.ID.String())
+		})
+
+		// Verify it was stored
+		stored, err := repo.GetByTokenHash(ctx, reset.TokenHash)
+		require.NoError(t, err)
+		assert.Equal(t, reset.ID, stored.ID)
+		assert.Equal(t, reset.PlayerID, stored.PlayerID)
+		assert.Equal(t, reset.TokenHash, stored.TokenHash)
+	})
+
+	t.Run("fails on duplicate token_hash", func(t *testing.T) {
+		reset1 := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "duplicate_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, reset1)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE token_hash = $1`, "duplicate_hash")
+		})
+
+		reset2 := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "duplicate_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CreatedAt: time.Now().UTC(),
+		}
+		err = repo.Create(ctx, reset2)
+		assert.Error(t, err)
+	})
+}
+
+func TestPasswordResetRepository_GetByPlayer(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_getbyplayer_test")
+
+	t.Run("returns most recent reset", func(t *testing.T) {
+		// Create two resets with different timestamps
+		older := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "older_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond),
+			CreatedAt: time.Now().Add(-time.Hour).UTC().Truncate(time.Microsecond),
+		}
+		err := repo.Create(ctx, older)
+		require.NoError(t, err)
+
+		newer := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "newer_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond),
+			CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+		}
+		err = repo.Create(ctx, newer)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE player_id = $1`, playerID.String())
+		})
+
+		// Should return the newer one
+		result, err := repo.GetByPlayer(ctx, playerID)
+		require.NoError(t, err)
+		assert.Equal(t, newer.ID, result.ID)
+		assert.Equal(t, "newer_hash", result.TokenHash)
+	})
+
+	t.Run("returns ErrNotFound for non-existent player", func(t *testing.T) {
+		nonExistentID := ulid.Make()
+		result, err := repo.GetByPlayer(ctx, nonExistentID)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+	})
+}
+
+func TestPasswordResetRepository_GetByTokenHash(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_getbyhash_test")
+
+	t.Run("returns reset by hash", func(t *testing.T) {
+		reset := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "unique_test_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond),
+			CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+		}
+		err := repo.Create(ctx, reset)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE id = $1`, reset.ID.String())
+		})
+
+		result, err := repo.GetByTokenHash(ctx, "unique_test_hash")
+		require.NoError(t, err)
+		assert.Equal(t, reset.ID, result.ID)
+		assert.Equal(t, reset.PlayerID, result.PlayerID)
+	})
+
+	t.Run("returns ErrNotFound for non-existent hash", func(t *testing.T) {
+		result, err := repo.GetByTokenHash(ctx, "nonexistent_hash")
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+	})
+}
+
+func TestPasswordResetRepository_Delete(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_delete_test")
+
+	t.Run("deletes existing reset", func(t *testing.T) {
+		reset := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "delete_test_hash",
+			ExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CreatedAt: time.Now().UTC(),
+		}
+		err := repo.Create(ctx, reset)
+		require.NoError(t, err)
+
+		err = repo.Delete(ctx, reset.ID)
+		require.NoError(t, err)
+
+		// Verify it's gone
+		result, err := repo.GetByTokenHash(ctx, "delete_test_hash")
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+	})
+
+	t.Run("returns ErrNotFound for non-existent ID", func(t *testing.T) {
+		nonExistentID := ulid.Make()
+		err := repo.Delete(ctx, nonExistentID)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+	})
+}
+
+func TestPasswordResetRepository_DeleteByPlayer(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_deletebyplayer_test")
+
+	t.Run("deletes all resets for player", func(t *testing.T) {
+		// Create multiple resets
+		for i := 0; i < 3; i++ {
+			reset := &auth.PasswordReset{
+				ID:        ulid.Make(),
+				PlayerID:  playerID,
+				TokenHash: "deletebyplayer_hash_" + ulid.Make().String(),
+				ExpiresAt: time.Now().Add(time.Hour).UTC(),
+				CreatedAt: time.Now().UTC(),
+			}
+			err := repo.Create(ctx, reset)
+			require.NoError(t, err)
+		}
+
+		err := repo.DeleteByPlayer(ctx, playerID)
+		require.NoError(t, err)
+
+		// Verify all are gone
+		result, err := repo.GetByPlayer(ctx, playerID)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+	})
+
+	t.Run("succeeds even when no resets exist", func(t *testing.T) {
+		nonExistentPlayerID := ulid.Make()
+		err := repo.DeleteByPlayer(ctx, nonExistentPlayerID)
+		// Should not error - valid state to have no resets
+		assert.NoError(t, err)
+	})
+}
+
+func TestPasswordResetRepository_DeleteExpired(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPasswordResetRepository(testPool)
+	playerID := createTestPlayer(ctx, t, "reset_deleteexpired_test")
+
+	t.Run("deletes expired resets and returns count", func(t *testing.T) {
+		// Create an expired reset
+		expired := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "expired_hash_" + ulid.Make().String(),
+			ExpiresAt: time.Now().Add(-time.Hour).UTC(), // Already expired
+			CreatedAt: time.Now().Add(-2 * time.Hour).UTC(),
+		}
+		err := repo.Create(ctx, expired)
+		require.NoError(t, err)
+
+		// Create a valid (non-expired) reset
+		valid := &auth.PasswordReset{
+			ID:        ulid.Make(),
+			PlayerID:  playerID,
+			TokenHash: "valid_hash_" + ulid.Make().String(),
+			ExpiresAt: time.Now().Add(time.Hour).UTC(), // Not expired
+			CreatedAt: time.Now().UTC(),
+		}
+		err = repo.Create(ctx, valid)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE player_id = $1`, playerID.String())
+		})
+
+		// Delete expired
+		count, err := repo.DeleteExpired(ctx)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, count, int64(1))
+
+		// Verify expired is gone
+		result, err := repo.GetByTokenHash(ctx, expired.TokenHash)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, auth.ErrNotFound)
+
+		// Verify valid still exists
+		result, err = repo.GetByTokenHash(ctx, valid.TokenHash)
+		require.NoError(t, err)
+		assert.Equal(t, valid.ID, result.ID)
+	})
+
+	t.Run("returns zero when no expired resets", func(t *testing.T) {
+		// Clean up any existing expired resets first
+		_, _ = testPool.Exec(ctx, `DELETE FROM password_resets WHERE expires_at < NOW()`)
+
+		count, err := repo.DeleteExpired(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+}
+
+// Compile-time interface check (test ensures the repository implements the interface).
+var _ auth.PasswordResetRepository = (*postgres.PasswordResetRepository)(nil)


### PR DESCRIPTION
## Summary

- Add PostgreSQL implementation of `auth.PasswordResetRepository` for password reset token persistence
- Implements all CRUD operations: Create, GetByPlayer, GetByTokenHash, Delete, DeleteByPlayer, DeleteExpired
- Add `auth.ErrNotFound` sentinel error for consistent error handling
- Integration tests using testcontainers with PostgreSQL 18

## Test plan

- [x] All integration tests pass (`go test -tags=integration ./internal/auth/postgres/...`)
- [x] Linter passes (`golangci-lint run ./internal/auth/...`)
- [x] Compile-time interface check ensures contract compliance

Closes holomush-dwk.22

🤖 Generated with [Claude Code](https://claude.ai/code)