### PR TITLE
fix(auth): make reset token swap test deterministic

### DIFF
--- a/internal/auth/reset_test.go
+++ b/internal/auth/reset_test.go
@@ -85,9 +85,14 @@ func TestVerifyResetToken(t *testing.T) {
 		token, hash, err := auth.GenerateResetToken()
 		require.NoError(t, err)
 
-		// Swap two characters in the token
+		// Swap two different characters in the token to guarantee mutation.
 		tokenBytes := []byte(token)
-		tokenBytes[0], tokenBytes[1] = tokenBytes[1], tokenBytes[0]
+		for i := 0; i < len(tokenBytes)-1; i++ {
+			if tokenBytes[i] != tokenBytes[i+1] {
+				tokenBytes[i], tokenBytes[i+1] = tokenBytes[i+1], tokenBytes[i]
+				break
+			}
+		}
 		tamperedToken := string(tokenBytes)
 
 		valid, err := auth.VerifyResetToken(tamperedToken, hash)

--- a/internal/auth/reset_test.go
+++ b/internal/auth/reset_test.go
@@ -94,6 +94,7 @@ func TestVerifyResetToken(t *testing.T) {
 			}
 		}
 		tamperedToken := string(tokenBytes)
+		require.NotEqual(t, token, tamperedToken, "swap must produce a different token")
 
 		valid, err := auth.VerifyResetToken(tamperedToken, hash)
 		require.NoError(t, err)


### PR DESCRIPTION
The flaky test `TestVerifyResetToken/rejects_token_with_swapped_characters` swapped `tokenBytes[0]` and `tokenBytes[1]` to create a tampered token. When those two hex characters happened to be identical, the \"tampered\" token was unchanged and verification correctly passed — causing a spurious failure.

The fix scans for the first pair of different adjacent characters before swapping, guaranteeing an actual mutation.

- Stress tested with `-count=50`: 50/50 pass
- Full test suite: all green