### PR TITLE
docs(specs): add Full ABAC architecture design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ dist/
 .worktrees/
 .task/
 
+# MCP server state
+.serena/
+
 # Documentation site
 site/build/
 site/.venv/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,6 +9,7 @@ ignores:
   - ".worktrees"
   - ".beads"
   - ".claude"
+  - ".serena"
   - "dist"
   - "node_modules"
   - "vendor"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -40,3 +40,6 @@ MD046:
 # Code fence style
 MD048:
   style: backtick
+
+# Table column alignment - disabled (too strict for complex tables)
+MD060: false

--- a/docs/adr/0007-command-security-model.md
+++ b/docs/adr/0007-command-security-model.md
@@ -1,7 +1,7 @@
 # ADR 0007: Command Security Model
 
 **Date:** 2026-02-02
-**Status:** Accepted
+**Status:** Superseded by [ADR 0014](0014-direct-static-access-control-replacement.md)
 **Deciders:** HoloMUSH Contributors
 
 ## Context

--- a/docs/adr/0009-custom-go-native-abac-engine.md
+++ b/docs/adr/0009-custom-go-native-abac-engine.md
@@ -1,0 +1,129 @@
+# ADR 0009: Custom Go-Native ABAC Engine
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH needs to evolve from static role-based access control (Epic 3) to a full
+Attribute-Based Access Control (ABAC) system. The domain is heavily attribute-driven:
+faction gates, level requirements, property visibility, time-of-day restrictions, and
+plugin-contributed attributes. At the expected scale of ~200 concurrent users, the system
+must be expressive enough for game administrators while remaining maintainable by a small
+contributor team.
+
+Several existing authorization frameworks were evaluated:
+
+### Options Considered
+
+**Option A: Embed OpenFGA (Zanzibar-style ReBAC)**
+
+OpenFGA is a mature Go-native authorization engine with a PostgreSQL backend, designed for
+relationship-based access control (ReBAC). It excels at graph traversal queries like
+"is user X a member of group Y?"
+
+| Aspect     | Assessment                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strengths  | Mature engine, Go-native, PostgreSQL backend, good for org charts                                                                                            |
+| Weaknesses | ReBAC-first model is awkward for attribute comparisons (`level >= 5`, `faction == resource.faction`); limited condition language; heavyweight for ~200 users |
+
+**Option B: OPA with Rego**
+
+The Open Policy Agent uses the Rego language, a Turing-complete policy language based on
+Datalog. It can express any authorization model.
+
+| Aspect     | Assessment                                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Extremely flexible, large ecosystem, well-tested                                                                                                  |
+| Weaknesses | Rego is hard for non-engineer game admins to read and write; overkill for MUSH domain; sidecar or embedded Go library adds operational complexity |
+
+**Option C: Cedar (AWS Verified Permissions)**
+
+Cedar is a purpose-built policy language with formal verification. Its model directly
+inspired the HoloMUSH DSL design.
+
+| Aspect     | Assessment                                                                                                                   |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Clean, readable syntax; formal model; well-documented semantics                                                              |
+| Weaknesses | Rust-only implementation; Go integration requires CGO bridge or gRPC sidecar; cannot tightly integrate with Go plugin system |
+
+**Option D: Custom Go-native ABAC engine with Cedar-inspired DSL**
+
+Build a custom authorization engine in Go with a policy language inspired by Cedar's syntax
+and semantics, tailored to the MUSH domain.
+
+| Aspect     | Assessment                                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Full control over DSL; tight plugin integration via `AttributeProvider`; no impedance mismatch; readable by game admins; no external dependencies |
+| Weaknesses | Parser and evaluator must be built and maintained; no formal verification; smaller community than established frameworks                          |
+
+## Decision
+
+**Option D: Custom Go-native ABAC engine with Cedar-inspired DSL.**
+
+The engine implements `AccessPolicyEngine.Evaluate(ctx, AccessRequest) (Decision, error)` as
+the single authorization entry point. Policies are authored in a Cedar-inspired DSL stored in
+PostgreSQL, compiled to an AST at creation time, and evaluated against dynamically resolved
+attribute bags.
+
+## Rationale
+
+**Domain fit:** HoloMUSH authorization is attribute-driven, not relationship-driven. The
+primary patterns are attribute comparisons (`principal.faction == resource.faction`,
+`principal.level >= 5`, `resource.visibility == "private"`), set membership
+(`principal.flags.containsAny(["healer"])`), and conditional logic
+(`if resource.restricted then principal.level >= 5 else true`). OpenFGA's graph traversal
+model would require modeling every attribute comparison as a synthetic relationship, creating
+impedance mismatch.
+
+**Plugin integration:** Attribute providers register directly with the engine and contribute
+attributes synchronously during eager resolution. With an external framework, plugin
+attributes would need to cross a serialization boundary (gRPC, JSON) on every evaluation,
+adding latency and complexity.
+
+**Admin readability:** The Cedar-inspired DSL reads close to English:
+`permit(principal is character, action in ["enter"], resource is location) when { ... }`.
+Game administrators (non-engineers) can read and author policies. Rego's Datalog-based syntax
+would require training that is disproportionate for a MUSH community.
+
+**Scale appropriateness:** At ~200 concurrent users with ~50 active policies, a custom engine
+with in-memory policy caching achieves <5ms p99 evaluation latency. The operational overhead
+of OpenFGA or OPA (separate processes, health monitoring, version management) is not justified
+at this scale.
+
+**Key insight:** Relationships that frameworks like OpenFGA model as graph edges can be
+modeled as attributes resolved at evaluation time. The existing `LocationResolver` already
+performs this pattern — resolving `$here` to a location ID dynamically. The ABAC engine's
+`AttributeProvider` generalizes this: instead of replacing tokens in strings, providers
+resolve full attribute bags for any entity.
+
+## Consequences
+
+**Positive:**
+
+- Full control over DSL syntax and semantics — can evolve the language as MUSH needs emerge
+- Zero serialization overhead between authorization and the rest of the Go codebase
+- Plugin attribute providers use the same Go interface as core providers
+- No external process to deploy, monitor, or version-manage
+- Policy language tailored to MUSH domain (factions, levels, flags, properties)
+
+**Negative:**
+
+- Parser and evaluator must be built from scratch (~2,000 lines estimated)
+- No formal verification of policy correctness (Cedar has this; we rely on testing)
+- Smaller community — bugs and edge cases must be found by HoloMUSH contributors
+- Future contributors must learn a custom DSL rather than an industry-standard language
+
+**Neutral:**
+
+- The Cedar-inspired syntax is documented publicly and follows Cedar's formal model closely
+- Migration to Cedar proper remains possible if a Go-native Cedar implementation emerges
+- The `policy test` command provides runtime policy debugging in lieu of formal verification
+
+## References
+
+- [Full ABAC Architecture Design](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #1: Policy Engine Approach](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #2: Policy Definition Format](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Cedar Language Specification](https://docs.cedarpolicy.com/)

--- a/docs/adr/0009-custom-go-native-abac-engine.md
+++ b/docs/adr/0009-custom-go-native-abac-engine.md
@@ -124,6 +124,6 @@ resolve full attribute bags for any entity.
 ## References
 
 - [Full ABAC Architecture Design](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #1: Policy Engine Approach](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #2: Policy Definition Format](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #1: Policy Engine Approach](../specs/2026-02-05-full-abac-design-decisions.md#1-policy-engine-approach)
+- [Design Decision #2: Policy Definition Format](../specs/2026-02-05-full-abac-design-decisions.md#2-policy-definition-format)
 - [Cedar Language Specification](https://docs.cedarpolicy.com/)

--- a/docs/adr/0009-custom-go-native-abac-engine.md
+++ b/docs/adr/0009-custom-go-native-abac-engine.md
@@ -110,7 +110,10 @@ resolve full attribute bags for any entity.
 
 **Negative:**
 
-- Parser and evaluator must be built from scratch (~2,000 lines estimated)
+- Parser and evaluator must be built from scratch:
+  - ~2,000 lines for core engine (parser + evaluator)
+  - ~1,000 additional for lock compilation, token registry, and audit infrastructure
+  - Total estimate: 3,000-3,500 lines
 - No formal verification of policy correctness (Cedar has this; we rely on testing)
 - Smaller community — bugs and edge cases must be found by HoloMUSH contributors
 - Future contributors must learn a custom DSL rather than an industry-standard language

--- a/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
+++ b/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
@@ -1,0 +1,155 @@
+# ADR 0010: Cedar-Aligned Fail-Safe Type Semantics
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The ABAC policy DSL uses dynamic typing — attribute values can be strings, numbers, booleans,
+or arrays, and attributes may be absent entirely (e.g., a character has no faction, or a
+plugin is not loaded). The DSL evaluator must define what happens when a condition references
+a missing attribute or compares values of different types.
+
+This decision is security-critical because it determines whether missing data can
+accidentally grant access.
+
+### The Hazard
+
+Consider a policy intended to block enemies:
+
+```text
+forbid(principal is character, action in ["enter"], resource is location)
+when { principal.faction == "enemy" };
+```
+
+An admin might write the inverse — "allow anyone who is NOT an enemy":
+
+```text
+permit(principal is character, action in ["enter"], resource is location)
+when { principal.faction != "enemy" };
+```
+
+If a character has no `faction` attribute at all (e.g., a new character, or faction data
+failed to load), the behavior of `principal.faction != "enemy"` determines whether they
+gain access.
+
+### Options Considered
+
+**Option A: SQL-style NULL semantics**
+
+Missing attributes produce NULL. Comparisons with NULL return NULL (unknown), which is
+treated as `false` for `==` but `true` for `!=`.
+
+| Aspect     | Assessment                                                                                                            |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Familiar to SQL developers                                                                                            |
+| Weaknesses | `!= "enemy"` returns `true` when attribute is missing — accidentally grants access to characters without faction data |
+
+**Option B: JavaScript-style coercion**
+
+Missing attributes become `undefined`, which coerces to `false` for equality but can produce
+surprising results with other operators.
+
+| Aspect     | Assessment                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| Strengths  | Familiar to web developers                                                                         |
+| Weaknesses | Inconsistent behavior across operators; `undefined != "enemy"` is `true` — same hazard as Option A |
+
+**Option C: Cedar-aligned fail-safe semantics**
+
+Missing attributes cause ALL comparisons to evaluate to `false`, regardless of operator.
+This matches Cedar's behavior where a missing attribute produces an error value that makes
+the entire condition unsatisfied.
+
+| Aspect     | Assessment                                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Missing attributes can never grant access; proven safe by Cedar's formal model; consistent across all operators                                |
+| Weaknesses | Counterintuitive — `principal.faction != "enemy"` is `false` when faction is missing; requires explicit existence checks for negation patterns |
+
+## Decision
+
+**Option C: Cedar-aligned fail-safe semantics.**
+
+ALL comparisons involving a missing attribute evaluate to `false`, including `!=`. ALL
+comparisons involving a type mismatch evaluate to `false`. The `has` operator is the only
+way to check attribute existence.
+
+### Complete Type Behavior
+
+| Scenario                                 | Result  |
+| ---------------------------------------- | ------- |
+| Attribute missing (any operator)         | `false` |
+| Type mismatch (e.g., string > int)       | `false` |
+| `!=` with missing attribute              | `false` |
+| `==` with missing attribute              | `false` |
+| `>`, `>=`, `<`, `<=` on non-number       | `false` |
+| `containsAll`/`containsAny` on non-array | `false` |
+| `has` on non-existent attribute          | `false` |
+| `in` (list) with missing left operand    | `false` |
+| `in` (expr) with missing right array     | `false` |
+
+### Defensive Patterns for Negation
+
+```text
+// CORRECT: explicitly check existence first
+when { principal has faction && principal.faction != "enemy" };
+
+// ALSO CORRECT: use if-then-else with safe default
+when { if principal has faction then principal.faction != "enemy" else false };
+
+// WRONG: missing faction silently evaluates to false, denying non-faction characters
+// This may be intentional (deny unknowns) but must be a conscious choice
+when { principal.faction != "enemy" };
+```
+
+## Rationale
+
+**Security over convenience:** The naive `!=` behavior (Option A/B) creates a class of
+policies that silently grant access when attributes are absent. A plugin being unloaded, a
+database query failing, or a character missing optional data should never widen access. The
+fail-safe behavior ensures that missing data always results in denial, which aligns with the
+default-deny posture.
+
+**Cedar's formal model validates this:** Cedar's type system was formally verified to
+prevent this exact class of vulnerability. By aligning with Cedar's semantics, we inherit
+the safety guarantees of their formal model without needing our own verification.
+
+**Plugin safety:** When a plugin providing `reputation.score` is unloaded, any policy
+referencing `principal.reputation.score >= 50` silently evaluates to `false`. No access is
+granted. No error is thrown. The system degrades safely.
+
+## Consequences
+
+**Positive:**
+
+- Missing attributes can never accidentally grant access
+- Plugin unloading or provider failures are automatically fail-safe
+- Behavior is consistent and predictable across all operators
+- Aligns with Cedar's formally verified semantics
+
+**Negative:**
+
+- `!=` with missing attributes is counterintuitive — admins may expect `!= "enemy"` to be
+  `true` when faction is absent
+- Negation patterns require explicit `has` checks, adding verbosity
+- The `policy test` command becomes essential for admins to verify policy behavior
+
+**Neutral:**
+
+- The `has` operator provides a clear, explicit mechanism for existence checks
+- Documentation and the `policy test` command mitigate the learning curve
+- This behavior is identical to Cedar, so Cedar documentation serves as supplementary
+  reference
+
+## Testing Requirements
+
+Every DSL evaluator test case for every operator MUST include a "missing attribute" variant
+that asserts `false`. This is a non-negotiable testing requirement — the fail-safe behavior
+is the primary security guarantee of the type system.
+
+## References
+
+- [Full ABAC Architecture Design — Type System](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #28: Cedar-Aligned Missing Attribute Semantics](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Cedar Language Specification — Type System](https://docs.cedarpolicy.com/)

--- a/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
+++ b/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
@@ -34,6 +34,12 @@ If a character has no `faction` attribute at all (e.g., a new character, or fact
 failed to load), the behavior of `principal.faction != "enemy"` determines whether they
 gain access.
 
+**Why this is safe:** With fail-safe semantics, when the `faction` attribute is missing,
+ALL comparisons (including `!=`) evaluate to `false`. So `principal.faction != "enemy"`
+evaluates to `false` → the permit never matches → access is denied by default (safe).
+However, this may not be what the admin intended. For the correct pattern that explicitly
+checks for attribute existence, see the **Defensive Patterns for Negation** section below.
+
 ### Options Considered
 
 **Option A: SQL-style NULL semantics**

--- a/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
+++ b/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
@@ -151,5 +151,5 @@ is the primary security guarantee of the type system.
 ## References
 
 - [Full ABAC Architecture Design — Type System](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #28: Cedar-Aligned Missing Attribute Semantics](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #28: Cedar-Aligned Missing Attribute Semantics](../specs/2026-02-05-full-abac-design-decisions.md#28-cedar-aligned-missing-attribute-semantics)
 - [Cedar Language Specification — Type System](https://docs.cedarpolicy.com/)

--- a/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
+++ b/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
@@ -148,7 +148,7 @@ granted. No error is thrown. The system degrades safely.
 - This behavior is identical to Cedar, so Cedar documentation serves as supplementary
   reference
 
-## Testing Requirements
+**Testing requirements:**
 
 Every DSL evaluator test case for every operator MUST include a "missing attribute" variant
 that asserts `false`. This is a non-negotiable testing requirement — the fail-safe behavior

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -94,10 +94,10 @@ narrow the `forbid`'s conditions, not to escalate priority.
 
 **Comparison table for admins from priority-based systems:**
 
-| Approach                 | Policy Example                                                                                                                                                            | Outcome                                                                    |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`           | **Not supported** — deny-overrides means the forbid always wins           |
-| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it | VIPs under level 5 are no longer blocked; default permit grants access    |
+| Approach                  | Policy Example                                                                                                                                                            | Outcome                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`           | **Not supported** — deny-overrides means the forbid always wins        |
+| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it | VIPs under level 5 are no longer blocked; default permit grants access |
 
 **Before (blocks all characters under level 5):**
 

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -1,0 +1,132 @@
+# ADR 0011: Deny-Overrides Without Priority Ordering
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+When multiple policies apply to the same access request, their effects may conflict — one
+policy may `permit` while another may `forbid`. The engine needs a deterministic strategy
+for combining these conflicting decisions into a single outcome.
+
+Additionally, game administrators may want fine-grained control over which policies "win."
+In complex systems, this is often handled by assigning numeric priorities to policies, where
+higher-priority policies override lower-priority ones. The question is whether HoloMUSH
+should support priority-based ordering.
+
+### Options Considered
+
+**Option A: Deny-overrides without priority**
+
+Any `forbid` policy that matches and whose conditions are satisfied produces a deny. Any
+`permit` policy that matches produces an allow. If both exist, deny wins. If neither
+matches, the default is deny.
+
+| Aspect     | Assessment                                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Simple mental model; Cedar-proven approach; policy creation order irrelevant; no "why was my priority wrong?" debugging |
+| Weaknesses | Cannot express "this allow should override that deny" without rewriting conditions                                      |
+
+**Option B: Priority-based ordering**
+
+Each policy has a numeric priority. Higher-priority policies override lower-priority ones.
+
+| Aspect     | Assessment                                                                                                                                                 |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | More flexible; can express VIP overrides; familiar from firewall rules                                                                                     |
+| Weaknesses | "Why was I denied?" requires understanding priority across all policies; priority conflicts between independently authored policies; escalation arms races |
+
+**Option C: Specificity-based resolution (CSS-like)**
+
+More specific policies override less specific ones, determined by the specificity of
+target and condition clauses.
+
+| Aspect     | Assessment                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strengths  | Intuitive — more specific rules win                                                                                                              |
+| Weaknesses | "Specificity" is hard to define for arbitrary conditions; CSS specificity is notoriously confusing; adds significant complexity to the evaluator |
+
+## Decision
+
+**Option A: Deny-overrides without priority.**
+
+The evaluation algorithm is:
+
+1. Evaluate all candidate policies (no short-circuit — all matches recorded)
+2. If any satisfied `forbid` policy exists → **deny** (report which forbid)
+3. Else if any satisfied `permit` policy exists → **allow** (report which permit)
+4. Else → **default deny** (no policy matched)
+
+The `system` subject bypasses this entirely (always allowed, step 0).
+
+Policy creation order, storage order, and evaluation order are all irrelevant to the
+outcome. The same set of policies always produces the same decision regardless of when
+they were created or in what order they are evaluated.
+
+## Rationale
+
+**Cedar validates this model:** Cedar chose deny-overrides without priority and it scales
+to production systems at AWS. The model works because administrators control specificity
+through conditions, not through priority escalation. If a deny is too broad, the admin
+narrows its conditions rather than creating a higher-priority allow.
+
+**Debugging simplicity:** With priority-based ordering, answering "why was I denied?"
+requires examining all policies, their priorities, and the resolution order. With
+deny-overrides, the answer is always: "because this `forbid` policy matched." The admin
+can then inspect the forbid's conditions to understand why.
+
+**Safe concurrent authoring:** Multiple admins can create policies independently without
+worrying about priority collisions. In priority-based systems, two admins creating
+policies at priority 100 creates an ambiguous conflict. With deny-overrides, there is
+no such conflict.
+
+**Player lock safety:** The three-layer access model (metadata → locks → full policies)
+relies on admin `forbid` policies always trumping player `permit` locks. Priority-based
+ordering would require players to understand that their locks have lower priority — an
+unnecessary cognitive burden. With deny-overrides, the rule is simple: if an admin says
+no, the answer is no.
+
+### How to Handle "Override" Scenarios
+
+When an admin needs to allow access that a `forbid` blocks, the correct approach is to
+narrow the `forbid`'s conditions, not to escalate priority:
+
+```text
+// Original: blocks ALL characters under level 5
+forbid(principal is character, action in ["enter"], resource is location)
+when { resource.restricted && principal.level < 5 };
+
+// To exempt VIPs, narrow the forbid — don't add a higher-priority permit
+forbid(principal is character, action in ["enter"], resource is location)
+when { resource.restricted && principal.level < 5
+    && !principal.flags.containsAny(["vip"]) };
+```
+
+## Consequences
+
+**Positive:**
+
+- Simple mental model: deny always wins, no exceptions
+- Policy creation order is irrelevant — safer for concurrent authoring
+- No priority escalation arms races between administrators
+- `policy test` output is straightforward — shows which forbid blocked access
+- Player locks are automatically subordinate to admin forbids (by design)
+
+**Negative:**
+
+- Cannot express "this allow overrides that deny" without modifying the deny
+- Overly broad `forbid` policies must be narrowed rather than overridden
+- Admins accustomed to firewall-style priority ordering face a learning curve
+
+**Neutral:**
+
+- The `policy test --verbose` command helps admins understand which policies matched
+- Documentation should include the "narrowing forbids" pattern prominently
+- This matches Cedar's behavior exactly, so Cedar documentation applies
+
+## References
+
+- [Full ABAC Architecture Design — Evaluation Algorithm](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #4: Conflict Resolution](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Cedar Language Specification — Policy Evaluation](https://docs.cedarpolicy.com/)

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -94,10 +94,10 @@ narrow the `forbid`'s conditions, not to escalate priority.
 
 **Comparison table for admins from priority-based systems:**
 
-| Approach                  | Policy Example                                                                                                                                                                   | Outcome                                                                |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`                  | **Not supported** — deny-overrides means the forbid always wins        |
-| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it        | VIPs under level 5 are no longer blocked; default permit grants access |
+| Approach                  | Policy Example                                                                                                                                                           | Outcome                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`            | **Not supported** — deny-overrides means the forbid always wins        |
+| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it | VIPs under level 5 are no longer blocked; default permit grants access |
 
 **Before (blocks all characters under level 5):**
 

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -128,5 +128,5 @@ when { resource.restricted && principal.level < 5
 ## References
 
 - [Full ABAC Architecture Design — Evaluation Algorithm](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #4: Conflict Resolution](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #4: Conflict Resolution](../specs/2026-02-05-full-abac-design-decisions.md#4-conflict-resolution)
 - [Cedar Language Specification — Policy Evaluation](https://docs.cedarpolicy.com/)

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -94,10 +94,10 @@ narrow the `forbid`'s conditions, not to escalate priority.
 
 **Comparison table for admins from priority-based systems:**
 
-| Approach                  | Policy Example                                                                                                                                                            | Outcome                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`           | **Not supported** — deny-overrides means the forbid always wins        |
-| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it | VIPs under level 5 are no longer blocked; default permit grants access |
+| Approach                  | Policy Example                                                                                                                                                                   | Outcome                                                                |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Wrong: priority-based** | Keep broad forbid: `forbid when { principal.level < 5 }` <br>Add higher-priority permit: `permit(priority=100) when { principal.flags.containsAny(["vip"]) }`                  | **Not supported** — deny-overrides means the forbid always wins        |
+| **Correct: narrowing**    | Narrow the forbid to exclude VIPs: `forbid when { principal.level < 5 && !principal.flags.containsAny(["vip"]) }` <br>No separate permit needed — base permit handles it        | VIPs under level 5 are no longer blocked; default permit grants access |
 
 **Before (blocks all characters under level 5):**
 

--- a/docs/adr/0012-eager-attribute-resolution.md
+++ b/docs/adr/0012-eager-attribute-resolution.md
@@ -1,0 +1,135 @@
+# ADR 0012: Eager Attribute Resolution with Per-Request Caching
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The ABAC engine evaluates policy conditions against attribute bags containing subject,
+resource, action, and environment attributes. These attributes come from multiple providers
+(character data, location data, plugin data, environment state). The engine must decide
+WHEN to resolve attributes: all up front before any policy is evaluated, or on demand as
+individual policies reference them.
+
+A single user action (e.g., typing a command) may trigger multiple `Evaluate()` calls:
+check command permission, check location entry, check property read. Without caching,
+the same subject attributes are re-resolved for each call.
+
+### Options Considered
+
+**Option A: Eager resolution (collect-then-evaluate)**
+
+Call all registered attribute providers before evaluating any policy. Assemble complete
+`AttributeBags` with every known attribute for the subject, resource, and environment.
+Then evaluate all candidate policies against these bags.
+
+| Aspect     | Assessment                                                                                                                                                        |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Simple, predictable; complete attribute snapshot for every decision; powers audit logging and `policy test` debugging; no ordering dependencies between providers |
+| Weaknesses | May fetch attributes that no policy references; all providers called even if no policy needs their data                                                           |
+
+**Option B: Lazy resolution (resolve-on-reference)**
+
+Resolve attributes only when a policy condition references them. Cache resolved values
+for subsequent references within the same evaluation.
+
+| Aspect     | Assessment                                                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | More efficient when few attributes are actually needed; avoids unused provider calls                                                                                               |
+| Weaknesses | Harder to audit (snapshot is incomplete); provider call ordering depends on policy conditions; cache invalidation is complex; `policy test` cannot show "all available attributes" |
+
+## Decision
+
+**Option A: Eager resolution** with **per-request caching** across multiple `Evaluate()`
+calls within the same request context.
+
+### Resolution Flow
+
+1. Parse subject and resource type/ID from `AccessRequest` strings
+2. Call all registered `AttributeProvider` implementations for subject resolution
+3. Call all registered `AttributeProvider` implementations for resource resolution
+4. Call all `EnvironmentProvider` implementations
+5. Construct `AttributeBags.Action` from `AccessRequest.Action`
+6. Assemble complete `AttributeBags`
+7. Evaluate all candidate policies against the bags
+
+### Per-Request Caching
+
+An `AttributeCache` is attached to the request context at the command handler entry point.
+Multiple `Evaluate()` calls within the same context share cached provider results.
+
+```go
+type AttributeCache struct {
+    mu    sync.RWMutex
+    items map[string]map[string]any // "character:01ABC" → attributes
+}
+```
+
+- **Scope:** Per `context.Context` — garbage-collected when the context is cancelled
+- **Key:** `{entityType, entityID}` tuple
+- **Invalidation:** None within a request. The cache assumes read-only world state during
+  request processing
+- **Provider isolation:** Each provider's results are cached independently. A plugin
+  provider failure does not invalidate cached core provider results
+
+## Rationale
+
+**Audit completeness:** Every `Decision` includes a complete `AttributeBags` snapshot. The
+audit log records exactly what the engine knew when it made the decision. With lazy
+resolution, the snapshot only contains attributes that happened to be referenced — missing
+context that makes "why was I denied?" investigations incomplete.
+
+**`policy test` debugging:** The `policy test` command shows all resolved attributes before
+evaluating policies. Admins see every attribute available for the subject and resource, not
+just the ones current policies reference. This is essential for authoring new policies —
+admins need to know what attributes exist.
+
+**Scale appropriateness:** At ~200 concurrent users with ~10 core attributes per entity and
+~20 providers total, eager resolution adds <2ms per evaluation. The per-request cache
+eliminates redundant resolution when a single user action triggers multiple authorization
+checks (common: 3-5 checks per command).
+
+**Simplicity:** Eager resolution has no ordering dependencies between providers. Provider A
+does not need to run before Provider B. All providers are called, results are merged, and
+evaluation proceeds. Lazy resolution introduces implicit ordering based on which policy
+conditions are evaluated first.
+
+### Stale Data Assumption
+
+The cache assumes world state does not change during request processing. If a command
+modifies a character's location, subsequent authorization checks in the same request use
+the pre-modification location. This is consistent with the eager resolution model —
+attributes are a point-in-time snapshot.
+
+For MUSH workloads, this stale window (~10ms per request) is acceptable. A character
+moving between rooms and immediately checking access at the new location within the same
+request cycle is an edge case that resolves on the next request.
+
+## Consequences
+
+**Positive:**
+
+- Complete attribute snapshot for every decision — full audit trail
+- `policy test` shows all available attributes, not just referenced ones
+- No provider ordering dependencies — simpler to reason about and test
+- Per-request cache eliminates redundant provider calls within a user action
+- Provider errors are detected up front, not mid-evaluation
+
+**Negative:**
+
+- Unused attributes are resolved (wasted work for providers nobody references)
+- Per-request cache assumes read-only world state during request processing
+- All providers are called even if the policy set only uses core attributes
+
+**Neutral:**
+
+- Performance impact is negligible at MUSH scale (<2ms cold, <100μs warm)
+- Future optimization: if profiling shows waste, introduce provider-to-policy affinity
+  (only call providers whose namespace appears in active policies). Deferred until needed
+
+## References
+
+- [Full ABAC Architecture Design — Attribute Resolution](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #3: Attribute Resolution Strategy](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #26: Per-Request Attribute Caching](../specs/2026-02-05-full-abac-design-decisions.md)

--- a/docs/adr/0012-eager-attribute-resolution.md
+++ b/docs/adr/0012-eager-attribute-resolution.md
@@ -62,7 +62,12 @@ Multiple `Evaluate()` calls within the same context share cached provider result
 ```go
 type AttributeCache struct {
     mu    sync.RWMutex
-    items map[string]map[string]any // "character:01ABC" → attributes
+    items map[cacheKey]map[string]any
+}
+
+type cacheKey struct {
+    entityType string
+    entityID   string
 }
 ```
 
@@ -131,5 +136,5 @@ request cycle is an edge case that resolves on the next request.
 ## References
 
 - [Full ABAC Architecture Design — Attribute Resolution](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #3: Attribute Resolution Strategy](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #26: Per-Request Attribute Caching](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #3: Attribute Resolution Strategy](../specs/2026-02-05-full-abac-design-decisions.md#3-attribute-resolution-strategy)
+- [Design Decision #26: Per-Request Attribute Caching](../specs/2026-02-05-full-abac-design-decisions.md#26-per-request-attribute-caching)

--- a/docs/adr/0013-properties-as-first-class-entities.md
+++ b/docs/adr/0013-properties-as-first-class-entities.md
@@ -170,6 +170,6 @@ without adding anyone to the list.
 ## References
 
 - [Full ABAC Architecture Design — Property Model](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #9: Property Model](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #18: Property Package Ownership](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #32: PropertyProvider Uses SQL JOIN](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #9: Property Model](../specs/2026-02-05-full-abac-design-decisions.md#9-property-model)
+- [Design Decision #18: Property Package Ownership](../specs/2026-02-05-full-abac-design-decisions.md#18-property-package-ownership)
+- [Design Decision #32: PropertyProvider Uses SQL JOIN](../specs/2026-02-05-full-abac-design-decisions.md#32-propertyprovider-uses-sql-join-for-parent-location)

--- a/docs/adr/0013-properties-as-first-class-entities.md
+++ b/docs/adr/0013-properties-as-first-class-entities.md
@@ -107,7 +107,7 @@ attribute resolution); authorization happens AFTER attributes are resolved.
 
 - `character` → join `characters` table for current location
 - `location` → use `parent_id` directly (the location IS the parent)
-- `object` → join `objects` table for containing location
+- `object` → resolution by placement type: direct `location_id`, character holder's location via `characters` JOIN, or recursive CTE traversal of `contained_in_object_id` chain (see full spec for details)
 
 ## Rationale
 

--- a/docs/adr/0013-properties-as-first-class-entities.md
+++ b/docs/adr/0013-properties-as-first-class-entities.md
@@ -1,0 +1,175 @@
+# ADR 0013: Properties as First-Class World Model Entities
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH needs per-property access control for gameplay scenarios like:
+
+- A healer can see another character's `wounds` property, but the character themselves cannot
+- A character's `backstory` is visible to a select group of trusted players
+- A location's `secret_passage` property is only visible to characters with the `explorer` flag
+
+Properties currently exist as simple key-value pairs on entities. To support fine-grained
+access control, properties need access control metadata: who owns them, who can see them,
+and under what conditions.
+
+The question is whether properties should be modeled as sub-resources of their parent
+entity (e.g., `character:01ABC/wounds`) or as independent entities with their own identity
+in the world model.
+
+### Options Considered
+
+**Option A: Properties as sub-resources (path-based addressing)**
+
+Properties are addressed by path from their parent: `character:01ABC/wounds`. The parent
+entity's repository manages property CRUD. Access control policies reference properties
+by path pattern.
+
+| Aspect     | Assessment                                                                                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strengths  | Minimal world model change; path-based addressing is familiar                                                                                                                                                                  |
+| Weaknesses | Introduces a second resource model (entities vs sub-resources); admins must learn two addressing schemes; property attributes are implicitly derived from parent type; policies on sub-resources require different DSL grammar |
+
+**Option B: Properties as first-class entities**
+
+Properties have their own ULID identity, their own database table (`entity_properties`),
+and their own repository (`PropertyRepository`). They are entities in the same sense as
+characters, locations, and objects. The policy engine evaluates access to properties using
+`resource is property` with the same syntax as any other resource type.
+
+| Aspect     | Assessment                                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strengths  | Conceptual uniformity — everything is an entity; admins learn one model; `PropertyProvider` resolves attributes the same way as `CharacterProvider`; parent relationship is an attribute, not a structural concern |
+| Weaknesses | More database rows; properties need their own table and repository; introduces access control metadata directly into the world model                                                                               |
+
+**Option C: Property flags only (no ABAC integration)**
+
+Properties store simple visibility flags (`public`, `private`, `admin`) without ABAC
+integration. Access is checked by flag value in application code.
+
+| Aspect     | Assessment                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Simplest to implement                                                                                                                   |
+| Weaknesses | Cannot write rich policies on properties; no `visible_to` lists; no conditional visibility; parallel access control system outside ABAC |
+
+## Decision
+
+**Option B: Properties as first-class entities.**
+
+Properties are world model entities managed by `internal/world/PropertyRepository`,
+alongside `LocationRepository` and `ObjectRepository`. The `entity_properties` table is
+part of the world schema. The `PropertyProvider` in `internal/access/policy/attribute/`
+wraps `PropertyRepository` to resolve property attributes for policy evaluation.
+
+### Property Schema
+
+| Attribute       | Type       | Description                                     |
+| --------------- | ---------- | ----------------------------------------------- |
+| `id`            | ULID       | Unique property identifier                      |
+| `parent_type`   | string     | Parent entity type: character, location, object |
+| `parent_id`     | ULID       | Parent entity ID                                |
+| `name`          | string     | Property name (unique per parent)               |
+| `value`         | string     | Property value (NULL for flag-style properties) |
+| `owner`         | string     | Subject who created/set this property           |
+| `visibility`    | string     | public, private, restricted, system, admin      |
+| `flags`         | \[\]string | Arbitrary flags                                 |
+| `visible_to`    | \[\]string | Character IDs (restricted visibility only)      |
+| `excluded_from` | \[\]string | Character IDs (restricted visibility only)      |
+
+### Intentional Coupling
+
+Properties embed access control metadata (`owner`, `visibility`, `visible_to`,
+`excluded_from`) directly in the world model struct. This is an **intentional architectural
+tradeoff**:
+
+- Properties are the **ONLY** world entity with first-class access control fields
+- Other entities (locations, objects) rely on external policies alone
+- The coupling exists because property visibility is a **core gameplay feature** that
+  players configure directly, not just an admin concern
+
+### Dependency Layering
+
+To prevent circular dependencies during attribute resolution:
+
+```text
+Engine → PropertyProvider → PropertyRepository → PostgreSQL
+```
+
+`PropertyProvider` MUST call `PropertyRepository` directly, bypassing `WorldService`.
+The engine resolves property attributes unconditionally (no authorization check during
+attribute resolution); authorization happens AFTER attributes are resolved.
+
+`PropertyRepository.GetByID()` uses a SQL JOIN against the parent entity's table to fetch
+`parent_location` in the same query. The join target depends on `parent_type`:
+
+- `character` → join `characters` table for current location
+- `location` → use `parent_id` directly (the location IS the parent)
+- `object` → join `objects` table for containing location
+
+## Rationale
+
+**Conceptual uniformity:** Admins learn one model: "everything is an entity with attributes,
+policies control access to entities." Characters, locations, objects, and properties all
+work the same way in the DSL:
+
+```text
+// Same pattern for any entity type
+permit(principal is character, action in ["read"], resource is property)
+when { resource.name == "wounds" && principal.flags.containsAny(["healer"]) };
+```
+
+Option A would require admins to learn two addressing schemes and two sets of DSL patterns.
+
+**Gameplay validation:** The healer-wound scenario was tested during design review:
+
+```text
+// Healers can see wounds (but not the character themselves)
+permit(principal is character, action in ["read"], resource is property)
+when { resource.name == "wounds" && principal.flags.containsAny(["healer"]) };
+
+forbid(principal is character, action in ["read"], resource is property)
+when { resource.name == "wounds" && resource.parent_id == principal.id };
+```
+
+This works cleanly with first-class properties because the property has its own `parent_id`
+attribute. With sub-resources, the parent relationship would need special-case handling in
+the DSL evaluator.
+
+**Visibility defaults prevent footguns:** When visibility is set to `restricted`, the Go
+property store auto-populates `visible_to = [parent_id]` and `excluded_from = []`. This
+prevents the "nobody can see it" scenario where a character sets restricted visibility
+without adding anyone to the list.
+
+## Consequences
+
+**Positive:**
+
+- Single entity model for admins — characters, locations, objects, and properties all work
+  the same way in policies
+- `PropertyProvider` follows the same `AttributeProvider` pattern as all other providers
+- `visible_to` and `excluded_from` enable fine-grained access lists without separate ACL
+  infrastructure
+- SQL JOIN for `parent_location` keeps a single code path for all location data
+
+**Negative:**
+
+- Properties have their own database table, adding schema complexity
+- Access control metadata is coupled into the world model struct (intentional but unusual)
+- `PropertyRepository` must handle parent-type-dependent JOINs
+
+**Neutral:**
+
+- Property count scales with game content (thousands of properties for an active MUSH is
+  expected and manageable)
+- The `entity_properties` table has a compound unique constraint on
+  `(parent_type, parent_id, name)` preventing duplicate property names per entity
+
+## References
+
+- [Full ABAC Architecture Design — Property Model](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #9: Property Model](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #18: Property Package Ownership](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #32: PropertyProvider Uses SQL JOIN](../specs/2026-02-05-full-abac-design-decisions.md)

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -1,0 +1,156 @@
+# ADR 0014: Direct StaticAccessControl Replacement
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+**Supersedes:** [ADR 0007: Command Security Model](0007-command-security-model.md)
+
+## Context
+
+HoloMUSH's current authorization system consists of two components:
+
+1. **`StaticAccessControl`** (Epic 3): Role-based permission checking with glob patterns,
+   `$self`/`$here` token resolution, and three static roles (player, builder, admin)
+2. **`capability.Enforcer`**: Plugin permission checking using manifest-declared capabilities
+
+These are used at ~29 call sites across the codebase (primarily `internal/world/service.go`
+and `internal/command/dispatcher.go`). All call sites use the `AccessControl.Check(ctx,
+subject, action, resource) bool` interface.
+
+The ABAC system introduces `AccessPolicyEngine.Evaluate(ctx, AccessRequest) (Decision,
+error)` with a richer return type (allowed/denied, effect, reason, matched policies,
+attribute snapshot). The question is how to migrate existing call sites.
+
+[ADR 0007](0007-command-security-model.md) established a capability-based command security
+model with dot-notation namespaces (`build.dig`, `comms.say`), wildcard matching
+(`world.*`), and a planned `character_capabilities` table. The ABAC system replaces this
+model entirely — commands become `resource is command` with DSL policy conditions.
+
+### Options Considered
+
+**Option A: Backward-compatibility adapter**
+
+Introduce an adapter that wraps `AccessPolicyEngine` behind the existing `AccessControl`
+interface. Existing call sites continue using `Check()` unchanged. The adapter normalizes
+subjects and resources, translates the `Decision` to a boolean, and logs discrepancies.
+
+| Aspect     | Assessment                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Zero call site changes initially; incremental migration possible                                                                                                                            |
+| Weaknesses | Adapter must normalize `char:` ↔ `character:` prefixes, translate resources, handle `Decision` → `bool` lossy conversion; adds an indirection layer; temporary code with no long-term value |
+
+**Option B: Adapter + shadow mode**
+
+Same as Option A, plus run both the old and new systems in parallel, comparing results
+to validate equivalence before cutover.
+
+| Aspect     | Assessment                                                                                                                                                                                                                                                                               |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | High confidence in behavioral equivalence before migration                                                                                                                                                                                                                               |
+| Weaknesses | All Option A weaknesses, plus: the static system has known gaps (`$here` patterns that never match, missing `delete:location` for builders, legacy `@`-prefixed command names); exclusion filtering for known differences is itself bug-prone; ~1,000+ lines of temporary infrastructure |
+
+**Option C: Direct replacement**
+
+Replace `AccessControl` with `AccessPolicyEngine` directly. All call sites switch to
+`Evaluate()` in a single phase. The `AccessControl` interface, `StaticAccessControl`,
+and `capability.Enforcer` are deleted.
+
+| Aspect     | Assessment                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Clean cutover; no temporary adapter code; callers get rich `Decision` type; no subject/resource normalization layer |
+| Weaknesses | All ~29 call sites must add error handling for `(Decision, error)` return; large single-phase change                |
+
+## Decision
+
+**Option C: Direct replacement.** No backward-compatibility adapter. No shadow mode.
+
+All ~29 call sites update from `AccessControl.Check()` to `AccessPolicyEngine.Evaluate()`
+in phase 7.3 of the implementation. The `AccessControl` interface, `StaticAccessControl`,
+and `capability.Enforcer` are deleted in phase 7.6.
+
+### What This Supersedes
+
+**ADR 0007 (Command Security Model)** established the following patterns, all of which are
+replaced by the ABAC policy system:
+
+| ADR 0007 Pattern                              | ABAC Replacement                                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Capability namespaces (`build.dig`)           | `resource is command` with `resource.name == "dig"`                                  |
+| Wildcard matching (`world.*`)                 | Policy conditions with `resource.name like "..."` or role-based permits              |
+| `character_capabilities` table                | `access_policies` table with seed policies                                           |
+| Default grants (all characters get `world.*`) | Seed policies: `permit(...) when { resource.name in ["say", "pose", "look", "go"] }` |
+| `@grant`/`@revoke` commands                   | `policy create`/`policy delete` commands                                             |
+| `capability.Enforcer` for plugins             | Plugin subjects evaluated by same policy engine                                      |
+
+### Subject Prefix Normalization
+
+The static system uses `char:` as the subject prefix for characters. The ABAC system
+normalizes to `character:` everywhere. All call sites MUST use `character:` (the access
+package defines prefix constants). The `char:` prefix is not supported by the new engine.
+
+### Implementation Phases
+
+1. **Phase 7.3:** Replace `AccessControl` with `AccessPolicyEngine` in dependency injection.
+   Update all call sites to use `Evaluate()` directly
+2. **Phase 7.6:** Delete `StaticAccessControl`, `AccessControl` interface,
+   `capability.Enforcer`, and all related code. Remove legacy `char:` prefix handling
+
+### Call Site Inventory
+
+| Package                                     | Call Sites | Change Required                         |
+| ------------------------------------------- | ---------- | --------------------------------------- |
+| `internal/world/service.go`                 | 18         | `Check()` → `Evaluate()` + error handle |
+| `internal/command/dispatcher.go`            | 1          | Capability loop → single `Evaluate()`   |
+| `internal/command/rate_limit_middleware.go` | 1          | `Check()` → `Evaluate()` + error handle |
+| `internal/command/handlers/boot.go`         | 1          | `Check()` → `Evaluate()` + error handle |
+| `internal/plugin/hostfunc/commands.go`      | 1          | `Check()` → `Evaluate()` + error handle |
+| `internal/core/broadcaster` (test)          | ~7         | Update mock injection                   |
+
+## Rationale
+
+**No production releases:** HoloMUSH has no deployed users. The static access control
+system has never served real traffic. Building adapter and shadow mode infrastructure for
+a system with zero consumers is wasted effort.
+
+**Static system has known gaps:** The static system has dead permissions (`$here` patterns
+that never match actual call site resource strings), missing capabilities (no
+`delete:location` for builders), and legacy `@`-prefixed command names. Seed policies
+intentionally fix these gaps — they define the correct permission model, not a replica.
+Shadow mode would flag these intentional improvements as disagreements.
+
+**Rich return type:** The `Decision` type provides `Effect`, `Reason`, `PolicyID`, matched
+policy list, and attribute snapshot. Collapsing this to a boolean via an adapter discards
+information that callers can use for error messages, audit trails, and debugging.
+
+**Adapter complexity:** Normalization between `char:` and `character:` prefixes, resource
+format translation, and `Decision` → `bool` conversion would add ~500 lines of temporary
+code with no long-term value.
+
+## Consequences
+
+**Positive:**
+
+- Clean, permanent codebase — no adapter layer to eventually remove
+- Callers get rich `Decision` type with matched policies and attribute snapshots
+- No subject/resource normalization layer
+- Known static system gaps are fixed by seed policies, not replicated
+- Eliminates the entire `capability.Enforcer` subsystem for plugin permissions
+
+**Negative:**
+
+- All ~29 call sites must be updated in a single phase (large but mechanical change)
+- Call sites must handle `(Decision, error)` return instead of simple `bool`
+- No gradual rollout — all authorization switches at once
+
+**Neutral:**
+
+- Error handling at call sites follows the existing `oops.Code()` pattern
+- Test helpers (`AllowAll`, `DenyAll`, `MockAccessControl`) need ABAC equivalents
+- Integration tests validate seed policies provide equivalent or expanded access
+
+## References
+
+- [Full ABAC Architecture Design — Replacing Static Roles](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #36: Direct Replacement](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #37: No Shadow Mode](../specs/2026-02-05-full-abac-design-decisions.md)
+- [ADR 0007: Command Security Model](0007-command-security-model.md) (superseded)

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -13,7 +13,7 @@ HoloMUSH's current authorization system consists of two components:
    `$self`/`$here` token resolution, and three static roles (player, builder, admin)
 2. **`capability.Enforcer`**: Plugin permission checking using manifest-declared capabilities
 
-These are used at ~24 production call sites across the codebase (plus 6 test mocks),
+These are used at ~29 production call sites across the codebase (plus 6 test mocks),
 primarily in `internal/world/service.go` and `internal/command/dispatcher.go`. All
 call sites use the `AccessControl.Check(ctx, subject, action, resource) bool` interface.
 
@@ -58,13 +58,13 @@ and `capability.Enforcer` are deleted.
 | Aspect     | Assessment                                                                                                          |
 | ---------- | ------------------------------------------------------------------------------------------------------------------- |
 | Strengths  | Clean cutover; no temporary adapter code; callers get rich `Decision` type; no subject/resource normalization layer |
-| Weaknesses | All ~24 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
+| Weaknesses | All ~29 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
 
 ## Decision
 
 **Option C: Direct replacement.** No backward-compatibility adapter. No shadow mode.
 
-All ~24 production call sites (plus test mocks) update from `AccessControl.Check()` to
+All ~29 production call sites (plus test mocks) update from `AccessControl.Check()` to
 `AccessPolicyEngine.Evaluate()` in phase 7.3 of the implementation. The `AccessControl`
 interface, `StaticAccessControl`, and `capability.Enforcer` are deleted in phase 7.6.
 
@@ -139,7 +139,7 @@ code with no long-term value.
 
 **Negative:**
 
-- All ~24 production call sites must be updated in a single phase (large but mechanical change)
+- All ~29 production call sites must be updated in a single phase (large but mechanical change)
 - Call sites must handle `(Decision, error)` return instead of simple `bool`
 - No gradual rollout — all authorization switches at once
 

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -13,7 +13,7 @@ HoloMUSH's current authorization system consists of two components:
    `$self`/`$here` token resolution, and three static roles (player, builder, admin)
 2. **`capability.Enforcer`**: Plugin permission checking using manifest-declared capabilities
 
-These are used at ~29 production call sites across the codebase (plus 6 test mocks),
+These are used at ~24 production call sites across the codebase (plus 6 test mocks),
 primarily in `internal/world/service.go` and `internal/command/dispatcher.go`. All
 call sites use the `AccessControl.Check(ctx, subject, action, resource) bool` interface.
 
@@ -58,15 +58,15 @@ and `capability.Enforcer` are deleted.
 | Aspect     | Assessment                                                                                                          |
 | ---------- | ------------------------------------------------------------------------------------------------------------------- |
 | Strengths  | Clean cutover; no temporary adapter code; callers get rich `Decision` type; no subject/resource normalization layer |
-| Weaknesses | All ~29 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
+| Weaknesses | All ~24 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
 
 ## Decision
 
 **Option C: Direct replacement.** No backward-compatibility adapter. No shadow mode.
 
-All ~29 production call sites update from `AccessControl.Check()` to `AccessPolicyEngine.Evaluate()`
-in phase 7.3 of the implementation. The `AccessControl` interface, `StaticAccessControl`,
-and `capability.Enforcer` are deleted in phase 7.6.
+All ~24 production call sites (plus test mocks) update from `AccessControl.Check()` to
+`AccessPolicyEngine.Evaluate()` in phase 7.3 of the implementation. The `AccessControl`
+interface, `StaticAccessControl`, and `capability.Enforcer` are deleted in phase 7.6.
 
 ### What This Supersedes
 
@@ -139,7 +139,7 @@ code with no long-term value.
 
 **Negative:**
 
-- All ~29 production call sites must be updated in a single phase (large but mechanical change)
+- All ~24 production call sites must be updated in a single phase (large but mechanical change)
 - Call sites must handle `(Decision, error)` return instead of simple `bool`
 - No gradual rollout — all authorization switches at once
 

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -13,7 +13,7 @@ HoloMUSH's current authorization system consists of two components:
    `$self`/`$here` token resolution, and three static roles (player, builder, admin)
 2. **`capability.Enforcer`**: Plugin permission checking using manifest-declared capabilities
 
-These are used at ~29 production call sites across the codebase (plus 6 test mocks),
+These are used at ~30 production call sites across the codebase (plus 6 test mocks),
 primarily in `internal/world/service.go` and `internal/command/dispatcher.go`. All
 call sites use the `AccessControl.Check(ctx, subject, action, resource) bool` interface.
 
@@ -58,13 +58,13 @@ and `capability.Enforcer` are deleted.
 | Aspect     | Assessment                                                                                                          |
 | ---------- | ------------------------------------------------------------------------------------------------------------------- |
 | Strengths  | Clean cutover; no temporary adapter code; callers get rich `Decision` type; no subject/resource normalization layer |
-| Weaknesses | All ~29 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
+| Weaknesses | All ~30 production call sites must add error handling for `(Decision, error)` return; large single-phase change     |
 
 ## Decision
 
 **Option C: Direct replacement.** No backward-compatibility adapter. No shadow mode.
 
-All ~29 production call sites (plus test mocks) update from `AccessControl.Check()` to
+All ~30 production call sites (plus test mocks) update from `AccessControl.Check()` to
 `AccessPolicyEngine.Evaluate()` in phase 7.3 of the implementation. The `AccessControl`
 interface, `StaticAccessControl`, and `capability.Enforcer` are deleted in phase 7.6.
 
@@ -105,6 +105,7 @@ package defines prefix constants). The `char:` prefix is not supported by the ne
 | `internal/command/handlers/boot.go`         | 1          | `Check()` → `Evaluate()` + error handle |
 | `internal/plugin/hostfunc/commands.go`      | 1          | `Check()` → `Evaluate()` + error handle |
 | `internal/plugin/hostfunc/functions.go`     | 1          | `Check()` → `Evaluate()` + error handle |
+| `internal/access/static.go`                 | 1          | `Check()` → `Evaluate()` + error handle |
 | `internal/core/broadcaster` (test only)     | 6          | Update mock injection (no migration)    |
 
 ## Rationale
@@ -139,7 +140,7 @@ code with no long-term value.
 
 **Negative:**
 
-- All ~29 production call sites must be updated in a single phase (large but mechanical change)
+- All ~30 production call sites must be updated in a single phase (large but mechanical change)
 - Call sites must handle `(Decision, error)` return instead of simple `bool`
 - No gradual rollout — all authorization switches at once
 

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -13,9 +13,9 @@ HoloMUSH's current authorization system consists of two components:
    `$self`/`$here` token resolution, and three static roles (player, builder, admin)
 2. **`capability.Enforcer`**: Plugin permission checking using manifest-declared capabilities
 
-These are used at ~35 call sites across the codebase (primarily `internal/world/service.go`
-and `internal/command/dispatcher.go`). All call sites use the `AccessControl.Check(ctx,
-subject, action, resource) bool` interface.
+These are used at ~29 production call sites across the codebase (plus 6 test mocks),
+primarily in `internal/world/service.go` and `internal/command/dispatcher.go`. All
+call sites use the `AccessControl.Check(ctx, subject, action, resource) bool` interface.
 
 The ABAC system introduces `AccessPolicyEngine.Evaluate(ctx, AccessRequest) (Decision,
 error)` with a richer return type (allowed/denied, effect, reason, matched policies,

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -148,6 +148,7 @@ code with no long-term value.
 - Error handling at call sites follows the existing `oops.Code()` pattern
 - Test helpers (`AllowAll`, `DenyAll`, `MockAccessControl`) need ABAC equivalents
 - Integration tests validate seed policies provide equivalent or expanded access
+- Each seed policy requires integration tests: allowed, denied, edge case (100% coverage before Phase 7.3 cutover)
 
 ## References
 

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -152,6 +152,6 @@ code with no long-term value.
 ## References
 
 - [Full ABAC Architecture Design — Replacing Static Roles](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #36: Direct Replacement](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #37: No Shadow Mode](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #36: Direct Replacement](../specs/2026-02-05-full-abac-design-decisions.md#36-direct-replacement-no-adapter)
+- [Design Decision #37: No Shadow Mode](../specs/2026-02-05-full-abac-design-decisions.md#37-no-shadow-mode)
 - [ADR 0007: Command Security Model](0007-command-security-model.md) (superseded)

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -156,12 +156,16 @@ ID string. The engine validates this at registration and rejects non-namespaced 
 incorrectly-prefixed plugin tokens. Core tokens (`faction`, `flag`, `level`) are
 un-namespaced because they ship with the engine.
 
-Duplicate token registrations between plugins MUST cause a startup error. The error
-message identifies both plugins and the conflicting token name, directing the operator to
-disable one plugin. Non-deterministic last-registered-wins behavior is operationally
-dangerous — server restarts could silently change lock semantics if plugin load order
-varies. Core-to-plugin collisions are structurally prevented by the namespacing
-requirement (core tokens are un-namespaced; plugin tokens require a dot prefix).
+Duplicate token registrations between plugins MUST cause a startup error. The collision
+check occurs during plugin initialization (phase 7.4 of the ABAC implementation). When
+`PluginManager.LoadPlugin()` calls `LockTokenRegistry.RegisterTokens()`, the registry
+checks for existing tokens. Plugin load FAILS with a clear error identifying both plugins
+and the conflicting token. Server startup ABORTS if a configured plugin cannot load, since
+its declared lock tokens are required for policy evaluation. Non-deterministic
+last-registered-wins behavior is operationally dangerous — server restarts could silently
+change lock semantics if plugin load order varies. Core-to-plugin collisions are
+structurally prevented by the namespacing requirement (core tokens are un-namespaced;
+plugin tokens require a dot prefix).
 
 ## Consequences
 

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -89,9 +89,9 @@ The lock syntax uses registered token predicates — not hard-coded vocabulary. 
 
 **Plugin tokens** (registered at plugin load, namespaced by plugin ID):
 
-| Token              | Type     | Example                  | Compiles To                               |
-| ------------------ | -------- | ------------------------ | ----------------------------------------- |
-| `reputation.score` | numeric  | `reputation.score:>=50`  | `principal.reputation.score >= 50`        |
+| Token              | Type     | Example                    | Compiles To                               |
+| ------------------ | -------- | -------------------------- | ----------------------------------------- |
+| `reputation.score` | numeric  | `reputation.score:>=50`    | `principal.reputation.score >= 50`        |
 | `guilds.primary`   | equality | `guilds.primary:merchants` | `principal.guilds.primary == "merchants"` |
 
 Lock compilation generates a `permit` policy scoped to the specific resource and action:
@@ -156,8 +156,10 @@ ID string. The engine validates this at registration and rejects non-namespaced 
 incorrectly-prefixed plugin tokens. Core tokens (`faction`, `flag`, `level`) are
 un-namespaced because they ship with the engine.
 
-Duplicate token names are a **fatal startup error**. The server MUST NOT start if any
-token name collides. This fail-fast behavior catches naming conflicts at deploy time.
+Duplicate token names are logged as a **WARN** and resolved by last-registered-wins.
+The server logs the collision (including both the existing and new provider) so operators
+can investigate, but continues startup. This avoids a single misbehaving plugin from
+preventing the entire server from starting.
 
 ## Consequences
 
@@ -179,7 +181,8 @@ token name collides. This fail-fast behavior catches naming conflicts at deploy 
 
 - Lock-generated policies use the naming convention `lock:{type}:{id}:{action}` for
   identification and cleanup
-- Token conflicts are caught at server startup, not at lock authoring time
+- Token conflicts are logged as WARN at startup (last-registered-wins), not at lock
+  authoring time
 - The `lock tokens` command reads from the registry at runtime — output changes as
   plugins load and unload
 

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -194,8 +194,8 @@ plugin tokens require a dot prefix).
 
 ## References
 
-- [Full ABAC Architecture Design — Access Control Layers](../specs/2026-02-05-full-abac-design.md)
-- [Full ABAC Architecture Design — Lock Token Registry](../specs/2026-02-05-full-abac-design.md)
+- [Full ABAC Architecture Design — Access Control Layers](../specs/2026-02-05-full-abac-design.md#access-control-layers)
+- [Full ABAC Architecture Design — Lock Token Registry](../specs/2026-02-05-full-abac-design.md#layer-2-object-locks-owners)
 - [Design Decision #12: Player Access Control Layers](../specs/2026-02-05-full-abac-design-decisions.md#12-player-access-control-layers)
 - [Design Decision #19: Lock Policies Are Not Versioned](../specs/2026-02-05-full-abac-design-decisions.md#19-lock-policies-are-not-versioned)
 - [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/2026-02-05-full-abac-design-decisions.md#33-plugin-lock-tokens-must-be-namespaced)

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -100,7 +100,7 @@ Lock compilation generates a `permit` policy scoped to the specific resource and
 Input:  lock my-chest/read = (faction:rebels | flag:ally) & level:>=3
 Output:
   permit(
-    principal,
+    principal is character,
     action in ["read"],
     resource == "object:01ABC..."
   ) when {
@@ -183,8 +183,8 @@ requirement (core tokens are un-namespaced; plugin tokens require a dot prefix).
 
 - Lock-generated policies use the naming convention `lock:{type}:{id}:{action}` for
   identification and cleanup
-- Token conflicts are logged as WARN at startup (last-registered-wins), not at lock
-  authoring time
+- Duplicate token registrations between plugins cause a startup error identifying both
+  plugins and the conflicting token name
 - The `lock tokens` command reads from the registry at runtime — output changes as
   plugins load and unload
 
@@ -192,7 +192,7 @@ requirement (core tokens are un-namespaced; plugin tokens require a dot prefix).
 
 - [Full ABAC Architecture Design — Access Control Layers](../specs/2026-02-05-full-abac-design.md)
 - [Full ABAC Architecture Design — Lock Token Registry](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #12: Player Access Control Layers](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #19: Lock Policies Are Not Versioned](../specs/2026-02-05-full-abac-design-decisions.md)
-- [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #12: Player Access Control Layers](../specs/2026-02-05-full-abac-design-decisions.md#12-player-access-control-layers)
+- [Design Decision #19: Lock Policies Are Not Versioned](../specs/2026-02-05-full-abac-design-decisions.md#19-lock-policies-are-not-versioned)
+- [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/2026-02-05-full-abac-design-decisions.md#33-plugin-lock-tokens-must-be-namespaced)
 - [ADR 0011: Deny-Overrides Without Priority](0011-deny-overrides-without-priority.md)

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -89,10 +89,10 @@ The lock syntax uses registered token predicates — not hard-coded vocabulary. 
 
 **Plugin tokens** (registered at plugin load, namespaced by plugin ID):
 
-| Token       | Type     | Example           | Compiles To                               |
-| ----------- | -------- | ----------------- | ----------------------------------------- |
-| `rep.score` | numeric  | `rep.score:>=50`  | `principal.reputation.score >= 50`        |
-| `guild`     | equality | `guild:merchants` | `principal.guilds.primary == "merchants"` |
+| Token              | Type     | Example                  | Compiles To                               |
+| ------------------ | -------- | ------------------------ | ----------------------------------------- |
+| `reputation.score` | numeric  | `reputation.score:>=50`  | `principal.reputation.score >= 50`        |
+| `guilds.primary`   | equality | `guilds.primary:merchants` | `principal.guilds.primary == "merchants"` |
 
 Lock compilation generates a `permit` policy scoped to the specific resource and action:
 
@@ -136,8 +136,8 @@ Builders and engaged players use Layer 2 (lock a room to faction members). Only 
 use Layer 3. Each layer adds complexity only for users who need it.
 
 **Lock tokens are extensible:** The token registry means the lock vocabulary grows with
-the plugin ecosystem. A reputation plugin adds `rep.score:>=50` to locks automatically.
-Players discover available tokens via `lock tokens`.
+the plugin ecosystem. A reputation plugin adds `reputation.score:>=50` to locks
+automatically. Players discover available tokens via `lock tokens`.
 
 **Locks compile to policies:** Lock-generated policies are evaluated by the same engine
 as admin policies. No separate access control path exists. This ensures deny-overrides
@@ -149,10 +149,12 @@ context — locking a chest is a quick action, not a governance event.
 
 ### Token Namespace Enforcement
 
-Plugin lock tokens MUST use a dot-separated prefix matching their plugin ID (e.g.,
-`rep.score`, not `score`). The engine validates this at registration and rejects
-non-namespaced plugin tokens. Core tokens (`faction`, `flag`, `level`) are un-namespaced
-because they ship with the engine.
+Plugin lock tokens MUST use a dot-separated prefix that **exactly matches** their
+plugin ID (e.g., plugin `reputation` registers `reputation.score`, not `rep.score`).
+Abbreviations are not allowed — the prefix before the first `.` MUST equal the plugin
+ID string. The engine validates this at registration and rejects non-namespaced or
+incorrectly-prefixed plugin tokens. Core tokens (`faction`, `flag`, `level`) are
+un-namespaced because they ship with the engine.
 
 Duplicate token names are a **fatal startup error**. The server MUST NOT start if any
 token name collides. This fail-fast behavior catches naming conflicts at deploy time.

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -156,10 +156,12 @@ ID string. The engine validates this at registration and rejects non-namespaced 
 incorrectly-prefixed plugin tokens. Core tokens (`faction`, `flag`, `level`) are
 un-namespaced because they ship with the engine.
 
-Duplicate token names are logged as a **WARN** and resolved by last-registered-wins.
-The server logs the collision (including both the existing and new provider) so operators
-can investigate, but continues startup. This avoids a single misbehaving plugin from
-preventing the entire server from starting.
+Duplicate token registrations between plugins MUST cause a startup error. The error
+message identifies both plugins and the conflicting token name, directing the operator to
+disable one plugin. Non-deterministic last-registered-wins behavior is operationally
+dangerous — server restarts could silently change lock semantics if plugin load order
+varies. Core-to-plugin collisions are structurally prevented by the namespacing
+requirement (core tokens are un-namespaced; plugin tokens require a dot prefix).
 
 ## Consequences
 

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -1,0 +1,191 @@
+# ADR 0015: Three-Layer Player Access Control
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The ABAC policy engine provides powerful, admin-authored policies using a Cedar-inspired
+DSL. However, regular players also need to control access to resources they own — locking
+a chest, hiding a property from specific characters, or restricting entry to a personal
+room.
+
+Exposing the full DSL to all players would be overwhelming and error-prone. Conversely,
+limiting players to only setting visibility flags would be too restrictive for the rich
+social dynamics of a MUSH environment. The system needs to balance expressiveness with
+usability across different user roles.
+
+### Options Considered
+
+**Option A: Full DSL for everyone**
+
+All characters can author policies using the full Cedar-inspired DSL.
+
+| Aspect     | Assessment                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Maximum expressiveness for all users                                                                                                                                                        |
+| Weaknesses | Overwhelming for non-technical players; policies could interact in unexpected ways; difficult to provide good error messages for syntax errors; security risk from poorly authored policies |
+
+**Option B: Metadata-only (flags and lists)**
+
+Players configure visibility and access lists on their properties. No policy authoring.
+All logic lives in system-level policies that evaluate these metadata attributes.
+
+| Aspect     | Assessment                                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Simple for players; all policy logic centralized in system policies                                                  |
+| Weaknesses | Cannot express conditional access (e.g., "faction rebels AND level >= 5"); limited to the predefined metadata fields |
+
+**Option C: Three-layer progressive model**
+
+Three layers of increasing complexity: metadata configuration, simplified lock syntax,
+and full DSL. Each layer targets a different user role.
+
+| Aspect     | Assessment                                                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Progressive disclosure — players use what they need; locks provide conditional access without full DSL; admins retain full power |
+| Weaknesses | Lock syntax is a third "language" to learn (alongside metadata and DSL); lock compilation adds a translation layer               |
+
+## Decision
+
+**Option C: Three-layer progressive model.**
+
+### Layer 1: Property Metadata (All Characters)
+
+Characters set visibility and access lists on properties they own. No policy authoring
+required. The character configures data; existing system-level seed policies evaluate it.
+
+```text
+> set me/secret_background.visibility = private
+> set me/wounds.visibility = restricted
+> set me/wounds.visible_to += character:01AAA
+```
+
+This layer requires no understanding of policies or conditions. Players interact with
+structured fields that seed policies already know how to evaluate.
+
+### Layer 2: Object Locks (Resource Owners)
+
+Owners set conditions on their resources using a simplified lock syntax. Locks compile
+to scoped `permit` policies behind the scenes.
+
+```text
+> lock my-chest/read = faction:rebels & level:>=5
+> lock me/backstory/read = me | flag:storyteller
+> unlock my-chest/read
+```
+
+The lock syntax uses registered token predicates — not hard-coded vocabulary. Each
+`AttributeProvider` registers lock tokens that expose its attributes to the lock parser.
+
+**Core tokens** (shipped with `CharacterProvider`):
+
+| Token     | Type       | Example            | Compiles To                        |
+| --------- | ---------- | ------------------ | ---------------------------------- |
+| `faction` | equality   | `faction:rebels`   | `principal.faction == "rebels"`    |
+| `flag`    | membership | `flag:storyteller` | `"storyteller" in principal.flags` |
+| `level`   | numeric    | `level:>=5`        | `principal.level >= 5`             |
+
+**Plugin tokens** (registered at plugin load, namespaced by plugin ID):
+
+| Token       | Type     | Example           | Compiles To                               |
+| ----------- | -------- | ----------------- | ----------------------------------------- |
+| `rep.score` | numeric  | `rep.score:>=50`  | `principal.reputation.score >= 50`        |
+| `guild`     | equality | `guild:merchants` | `principal.guilds.primary == "merchants"` |
+
+Lock compilation generates a `permit` policy scoped to the specific resource and action:
+
+```text
+Input:  lock my-chest/read = (faction:rebels | flag:ally) & level:>=3
+Output:
+  permit(
+    principal,
+    action in ["read"],
+    resource == "object:01ABC..."
+  ) when {
+    (principal.faction == "rebels" || "ally" in principal.flags)
+    && principal.level >= 3
+  };
+```
+
+**Access constraint:** The `lock` command verifies write permission via `Evaluate()` before
+creating the policy. Characters can only lock resources they have write access to.
+
+### Layer 3: Full Policies (Admin Only)
+
+The complete Cedar-inspired DSL with unrestricted scope, managed via the `policy` command
+set. Only characters with the `admin` role can create, edit, and delete full policies.
+
+### Layer Interaction
+
+Admin `forbid` policies always trump player locks via the deny-overrides conflict
+resolution model ([ADR 0011](0011-deny-overrides-without-priority.md)). Players operate
+within the boundaries admins set.
+
+| Layer             | Who             | Scope          | Deny-overrides? |
+| ----------------- | --------------- | -------------- | --------------- |
+| Property metadata | All characters  | Own properties | Yes             |
+| Object locks      | Resource owners | Own resources  | Yes             |
+| Full policies     | Admins          | Everything     | Top authority   |
+
+## Rationale
+
+**Progressive disclosure:** Most players only need Layer 1 (set a property to private).
+Builders and engaged players use Layer 2 (lock a room to faction members). Only admins
+use Layer 3. Each layer adds complexity only for users who need it.
+
+**Lock tokens are extensible:** The token registry means the lock vocabulary grows with
+the plugin ecosystem. A reputation plugin adds `rep.score:>=50` to locks automatically.
+Players discover available tokens via `lock tokens`.
+
+**Locks compile to policies:** Lock-generated policies are evaluated by the same engine
+as admin policies. No separate access control path exists. This ensures deny-overrides
+work uniformly — an admin `forbid` blocks a player lock `permit` without special-casing.
+
+**Lock policies are ephemeral:** Lock-generated policies are NOT versioned. Each
+`lock`/`unlock` creates or deletes a policy directly. This matches the casual gameplay
+context — locking a chest is a quick action, not a governance event.
+
+### Token Namespace Enforcement
+
+Plugin lock tokens MUST use a dot-separated prefix matching their plugin ID (e.g.,
+`rep.score`, not `score`). The engine validates this at registration and rejects
+non-namespaced plugin tokens. Core tokens (`faction`, `flag`, `level`) are un-namespaced
+because they ship with the engine.
+
+Duplicate token names are a **fatal startup error**. The server MUST NOT start if any
+token name collides. This fail-fast behavior catches naming conflicts at deploy time.
+
+## Consequences
+
+**Positive:**
+
+- Players get access control without learning a policy language
+- Lock syntax is concise and readable (`faction:rebels & level:>=5`)
+- Extensible via token registry — plugins add lock vocabulary automatically
+- All layers evaluated by the same engine — uniform deny-overrides behavior
+- `lock tokens` command provides discoverability
+
+**Negative:**
+
+- Lock syntax is a third "language" alongside property metadata and the full DSL
+- Lock compilation adds a translation layer (parser → AST → DSL text → compiled policy)
+- Plugin token namespace enforcement adds a constraint on plugin authors
+
+**Neutral:**
+
+- Lock-generated policies use the naming convention `lock:{type}:{id}:{action}` for
+  identification and cleanup
+- Token conflicts are caught at server startup, not at lock authoring time
+- The `lock tokens` command reads from the registry at runtime — output changes as
+  plugins load and unload
+
+## References
+
+- [Full ABAC Architecture Design — Access Control Layers](../specs/2026-02-05-full-abac-design.md)
+- [Full ABAC Architecture Design — Lock Token Registry](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #12: Player Access Control Layers](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #19: Lock Policies Are Not Versioned](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/2026-02-05-full-abac-design-decisions.md)
+- [ADR 0011: Deny-Overrides Without Priority](0011-deny-overrides-without-priority.md)

--- a/docs/adr/0016-listen-notify-policy-cache-invalidation.md
+++ b/docs/adr/0016-listen-notify-policy-cache-invalidation.md
@@ -50,6 +50,12 @@ a dedicated PostgreSQL connection and reloads its cache on notification.
 
 **Option C: PostgreSQL LISTEN/NOTIFY in Go application code.**
 
+**Critical limitation:** PostgreSQL LISTEN/NOTIFY is **fire-and-forget with zero
+buffering**. Notifications are not queued — if the listener is disconnected when a
+notification is sent, that notification is permanently lost. There is no replay
+mechanism, no delivery guarantee, and no way to recover missed notifications. The
+reconnection protocol below handles this by performing a full reload on reconnect.
+
 The Go policy store sends `pg_notify('policy_changed', policyID)` within the same
 transaction as any Create, Update, or Delete operation on the `access_policies` table.
 The engine subscribes to the `policy_changed` channel and reloads all enabled policies

--- a/docs/adr/0016-listen-notify-policy-cache-invalidation.md
+++ b/docs/adr/0016-listen-notify-policy-cache-invalidation.md
@@ -1,0 +1,179 @@
+# ADR 0016: PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation
+
+**Date:** 2026-02-05
+**Status:** Accepted
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The ABAC policy engine maintains an in-memory cache of compiled policies for fast
+evaluation (<5ms p99 target). When an administrator creates, edits, enables, disables,
+or deletes a policy, the in-memory cache must be updated to reflect the change. The
+question is how the engine learns that a policy has changed.
+
+HoloMUSH has a hard constraint: no database triggers or stored procedures. All logic
+must live in Go application code. PostgreSQL is storage only.
+
+### Options Considered
+
+**Option A: Polling**
+
+The engine periodically queries the policy table for changes (e.g., checking `updated_at`
+timestamps every N seconds).
+
+| Aspect     | Assessment                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strengths  | Simple to implement; works with any PostgreSQL connection pool                                                                                                |
+| Weaknesses | Latency proportional to poll interval; wasted queries when no changes occur; at 1s interval, up to 1s stale window; at 100ms interval, significant query load |
+
+**Option B: Application-level pub/sub (Redis, NATS)**
+
+Use an external message broker to notify the engine of policy changes.
+
+| Aspect     | Assessment                                                                                               |
+| ---------- | -------------------------------------------------------------------------------------------------------- |
+| Strengths  | Low latency; scalable to multiple server instances                                                       |
+| Weaknesses | Additional infrastructure dependency; operational complexity; overkill for single-server MUSH deployment |
+
+**Option C: PostgreSQL LISTEN/NOTIFY (in Go application code)**
+
+The Go policy store calls `pg_notify('policy_changed', policyID)` in the same transaction
+as any policy CRUD operation. The engine subscribes to the `policy_changed` channel using
+a dedicated PostgreSQL connection and reloads its cache on notification.
+
+| Aspect     | Assessment                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Strengths  | Push-based (no polling overhead); built into PostgreSQL; no external dependencies; notification is transactional (sent only on commit); low latency (<100ms) |
+| Weaknesses | Requires a dedicated persistent connection outside the pool; notification is fire-and-forget (no delivery guarantee on disconnect); single-server only       |
+
+## Decision
+
+**Option C: PostgreSQL LISTEN/NOTIFY in Go application code.**
+
+The Go policy store sends `pg_notify('policy_changed', policyID)` within the same
+transaction as any Create, Update, or Delete operation on the `access_policies` table.
+The engine subscribes to the `policy_changed` channel and reloads all enabled policies
+into its in-memory cache on notification.
+
+### Notification Flow
+
+```text
+Admin runs: policy edit faction-hq-access
+    │
+    ▼
+PolicyStore.Update() — within transaction:
+    1. UPDATE access_policies SET dsl_text=..., version=version+1
+    2. INSERT INTO access_policy_versions (...)
+    3. SELECT pg_notify('policy_changed', 'policy-ulid-here')
+    4. COMMIT
+    │
+    ▼
+Engine's LISTEN goroutine receives notification
+    │
+    ▼
+Engine reloads all enabled policies from DB
+    │
+    ▼
+Next Evaluate() uses updated policy cache
+```
+
+### Dedicated Connection
+
+The engine uses `pgx.Conn.Listen()` which requires a dedicated persistent connection
+**outside the connection pool**. This connection is used only for LISTEN — it cannot be
+shared with query traffic. This is a PostgreSQL requirement: LISTEN subscriptions are
+per-connection state that is lost if the connection is returned to a pool.
+
+### Reconnection Protocol
+
+On connection loss, the engine MUST:
+
+1. Log a warning: `slog.Warn("policy cache may be stale, LISTEN/NOTIFY reconnecting")`
+2. Reconnect with exponential backoff:
+   - Initial delay: 100ms
+   - Multiplier: 2x
+   - Maximum delay: 30s
+   - Retries: indefinite (the engine cannot function without cache updates)
+3. Re-subscribe to the `policy_changed` channel
+4. Perform a **full policy reload** before serving the next `Evaluate()` call
+
+The full reload on reconnect is essential: notifications received during the disconnect
+are lost (LISTEN/NOTIFY is fire-and-forget). The engine cannot know which policies changed
+during the outage.
+
+### Staleness During Reconnection
+
+During reconnection, `Evaluate()` continues using the stale in-memory cache. The engine
+does NOT block authorization on reconnection — a stale allow or deny for <30 seconds is
+acceptable for MUSH workloads where the primary risk is a player seeing a slightly outdated
+policy, not a financial transaction.
+
+## Rationale
+
+**No external dependencies:** PostgreSQL LISTEN/NOTIFY is built into the database
+HoloMUSH already depends on. Adding Redis or NATS for a single-server deployment with
+~200 users would be operational overhead without proportional benefit.
+
+**Transactional consistency:** Because `pg_notify()` is called within the same transaction
+as the policy CRUD operation, the notification is sent if and only if the change commits.
+If the transaction rolls back, no notification is sent. This eliminates a class of
+inconsistency where the cache is invalidated but the change didn't persist.
+
+**Push-based efficiency:** At steady state, the LISTEN connection is idle — no queries,
+no CPU, no network traffic. Notifications arrive only when policies change, which is
+infrequent in a running MUSH (minutes to hours between policy edits). Polling at any
+interval would waste resources for the vast majority of the time.
+
+**No database triggers:** The `pg_notify()` call is explicit Go code in the policy store,
+not a database trigger. This satisfies the project constraint that all logic lives in Go.
+
+### Why Full Reload (Not Incremental)
+
+The notification payload includes the policy ID, which could support incremental cache
+updates (reload only the changed policy). However, full reload is simpler and sufficient:
+
+- At <500 active policies and <50ms reload time, full reload is fast enough
+- Incremental updates require handling create/delete/enable/disable state transitions
+- Full reload is idempotent and self-healing — any cache corruption is fixed on next
+  notification
+- The complexity of incremental updates is not justified until policy counts grow
+  significantly
+
+### Future: Multi-Server
+
+If HoloMUSH scales to multiple server instances, LISTEN/NOTIFY works across connections
+to the same PostgreSQL instance. Each server's engine subscribes independently. No
+changes to the notification mechanism are needed. Cross-instance PostgreSQL (read replicas)
+would require a different approach (application-level pub/sub), but this is not in scope
+for the current single-server architecture.
+
+## Consequences
+
+**Positive:**
+
+- Push-based invalidation with <100ms latency (no polling delay)
+- Transactional consistency — notification sent only on successful commit
+- No external infrastructure dependencies beyond PostgreSQL
+- All notification logic in Go application code (no database triggers)
+- Works across multiple connections to the same PostgreSQL instance
+
+**Negative:**
+
+- Requires a dedicated persistent PostgreSQL connection outside the pool
+- Notifications are fire-and-forget — lost during connection outages
+- Full policy reload required on reconnection (cannot recover missed notifications)
+- Stale cache during reconnection (<30s) — acceptable for MUSH, not for financial systems
+
+**Neutral:**
+
+- The dedicated LISTEN connection adds one persistent connection to the PostgreSQL
+  connection count
+- Exponential backoff on reconnection prevents thundering herd on database recovery
+- The `policy_changed` channel name is a convention, not a PostgreSQL object — no schema
+  migration needed to set it up
+
+## References
+
+- [Full ABAC Architecture Design — Cache Invalidation](../specs/2026-02-05-full-abac-design.md)
+- [Design Decision #11: Cache Invalidation](../specs/2026-02-05-full-abac-design-decisions.md)
+- [PostgreSQL LISTEN/NOTIFY Documentation](https://www.postgresql.org/docs/current/sql-notify.html)

--- a/docs/adr/0016-listen-notify-policy-cache-invalidation.md
+++ b/docs/adr/0016-listen-notify-policy-cache-invalidation.md
@@ -181,5 +181,5 @@ for the current single-server architecture.
 ## References
 
 - [Full ABAC Architecture Design — Cache Invalidation](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #11: Cache Invalidation](../specs/2026-02-05-full-abac-design-decisions.md)
+- [Design Decision #11: Cache Invalidation](../specs/2026-02-05-full-abac-design-decisions.md#11-cache-invalidation)
 - [PostgreSQL LISTEN/NOTIFY Documentation](https://www.postgresql.org/docs/current/sql-notify.html)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,151 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records (ADRs) documenting significant design
+decisions made during HoloMUSH development. Each ADR captures the context, options
+considered, decision made, and consequences of architectural choices.
+
+## Purpose
+
+ADRs provide:
+
+- **Historical context** — Why was this choice made?
+- **Trade-off analysis** — What alternatives were considered and why were they rejected?
+- **Consequences** — What are the implications of this decision?
+- **Rationale** — What reasoning led to this conclusion?
+
+ADRs are immutable once accepted. If a decision is reversed, a new ADR supersedes the old
+one rather than modifying the original.
+
+## Index
+
+| ADR                                                                              | Title                                                  | Date       |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------- |
+| [0001](0001-opaque-session-tokens.md)                                            | Use Opaque Session Tokens Instead of Signed JWTs      | 2026-02-02 |
+| [0002](0002-argon2id-password-hashing.md)                                        | Argon2id Password Hashing                              | 2026-02-02 |
+| [0003](0003-player-character-auth-model.md)                                      | Player-Character Authentication Model                  | 2026-02-02 |
+| [0004](0004-timing-attack-resistant-auth.md)                                     | Timing-Attack Resistant Authentication                 | 2026-02-02 |
+| [0005](0005-command-state-management.md)                                         | Command State Management for Multi-Turn Interactions   | 2026-02-04 |
+| [0006](0006-unified-command-registry.md)                                         | Unified Command Registry                               | 2026-02-04 |
+| [0007](0007-command-security-model.md)                                           | Command Security Model                                 | 2026-02-04 |
+| [0008](0008-command-conflict-resolution.md)                                      | Command Conflict Resolution                            | 2026-02-04 |
+| [0009](0009-custom-go-native-abac-engine.md)                                     | Custom Go-Native ABAC Engine                           | 2026-02-05 |
+| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)                           | Cedar-Aligned Fail-Safe Type Semantics                 | 2026-02-05 |
+| [0011](0011-deny-overrides-without-priority.md)                                  | Deny-Overrides Without Priority Ordering               | 2026-02-05 |
+| [0012](0012-eager-attribute-resolution.md)                                       | Eager Attribute Resolution with Per-Request Caching    | 2026-02-05 |
+| [0013](0013-properties-as-first-class-entities.md)                               | Properties as First-Class World Model Entities         | 2026-02-05 |
+| [0014](0014-direct-static-access-control-replacement.md)                         | Direct StaticAccessControl Replacement                 | 2026-02-05 |
+| [0015](0015-three-layer-player-access-control.md)                                | Three-Layer Player Access Control                      | 2026-02-05 |
+| [0016](0016-listen-notify-policy-cache-invalidation.md)                          | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation | 2026-02-05 |
+
+## Format Evolution
+
+ADRs in this repository use two valid formats:
+
+### Original Format (ADRs 0001-0008)
+
+- **Context** — Problem statement and background
+- **Decision** — The choice made
+- **Rationale** — Why this decision was made
+- **Consequences** — Positive, negative, and neutral outcomes
+- **Alternatives Considered** — Separate section for rejected options
+- **References** — Related documents and implementations
+
+### Current Format (ADRs 0009+)
+
+- **Context** — Problem statement with embedded **Options Considered** subsection
+- **Decision** — The choice made
+- **Rationale** — Why this decision was made
+- **Consequences** — Positive, negative, and neutral outcomes (may include testing requirements)
+- **References** — Related documents and implementations
+
+Both formats are valid. The evolution reflects a preference for more compact ADRs with
+options embedded in context rather than separated. New ADRs SHOULD use the current format.
+
+## Template for New ADRs
+
+```markdown
+# ADR NNNN: Title
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+[Describe the problem, background, and relevant constraints]
+
+### Options Considered
+
+**Option A: [Name]**
+
+[Description]
+
+| Aspect     | Assessment                    |
+| ---------- | ----------------------------- |
+| Strengths  | [What this option does well]  |
+| Weaknesses | [What this option lacks]      |
+
+**Option B: [Name]**
+
+[Description]
+
+| Aspect     | Assessment                    |
+| ---------- | ----------------------------- |
+| Strengths  | [What this option does well]  |
+| Weaknesses | [What this option lacks]      |
+
+## Decision
+
+**Option [X]: [Chosen option name].**
+
+[Brief statement of the decision and key details]
+
+## Rationale
+
+[Detailed explanation of WHY this decision was made]
+
+- **Key factor 1:** [Explanation]
+- **Key factor 2:** [Explanation]
+
+## Consequences
+
+**Positive:**
+
+- [Benefit 1]
+- [Benefit 2]
+
+**Negative:**
+
+- [Trade-off 1]
+- [Trade-off 2]
+
+**Neutral:**
+
+- [Neither good nor bad implication]
+
+## References
+
+- [Related spec](../specs/filename.md)
+- [Related design decision](../specs/design-decisions.md#anchor)
+- [External reference](https://example.com)
+```
+
+## Writing Guidelines
+
+| Guideline                 | Description                                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| **Immutability**          | ADRs are permanent records — do not edit accepted ADRs to change decisions                   |
+| **Supersession**          | To reverse a decision, create a new ADR and mark the old one as "Superseded by ADR-XXXX"     |
+| **RFC2119 keywords**      | Use MUST/SHOULD/MAY in consequences when describing implementation requirements              |
+| **Comprehensive options** | Document ALL options considered, not just the chosen one                                     |
+| **Trade-off clarity**     | Consequences should honestly capture both benefits and costs                                 |
+| **Future-proof**          | Assume readers in 5 years won't have context — explain everything                            |
+
+## References
+
+- [Michael Nygard's ADR template](https://github.com/joelparkerhenderson/architecture-decision-record)
+- [ADR Tools GitHub](https://github.com/npryce/adr-tools)
+- [RFC 2119: Key words for RFCs](https://www.ietf.org/rfc/rfc2119.txt)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,24 +21,24 @@ one rather than modifying the original.
 
 ## Index
 
-| ADR                                                                              | Title                                                  | Date       |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------- |
-| [0001](0001-opaque-session-tokens.md)                                            | Use Opaque Session Tokens Instead of Signed JWTs      | 2026-02-02 |
-| [0002](0002-argon2id-password-hashing.md)                                        | Argon2id Password Hashing                              | 2026-02-02 |
-| [0003](0003-player-character-auth-model.md)                                      | Player-Character Authentication Model                  | 2026-02-02 |
-| [0004](0004-timing-attack-resistant-auth.md)                                     | Timing-Attack Resistant Authentication                 | 2026-02-02 |
-| [0005](0005-command-state-management.md)                                         | Command State Management for Multi-Turn Interactions   | 2026-02-04 |
-| [0006](0006-unified-command-registry.md)                                         | Unified Command Registry                               | 2026-02-04 |
-| [0007](0007-command-security-model.md)                                           | Command Security Model                                 | 2026-02-04 |
-| [0008](0008-command-conflict-resolution.md)                                      | Command Conflict Resolution                            | 2026-02-04 |
-| [0009](0009-custom-go-native-abac-engine.md)                                     | Custom Go-Native ABAC Engine                           | 2026-02-05 |
-| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)                           | Cedar-Aligned Fail-Safe Type Semantics                 | 2026-02-05 |
-| [0011](0011-deny-overrides-without-priority.md)                                  | Deny-Overrides Without Priority Ordering               | 2026-02-05 |
-| [0012](0012-eager-attribute-resolution.md)                                       | Eager Attribute Resolution with Per-Request Caching    | 2026-02-05 |
-| [0013](0013-properties-as-first-class-entities.md)                               | Properties as First-Class World Model Entities         | 2026-02-05 |
-| [0014](0014-direct-static-access-control-replacement.md)                         | Direct StaticAccessControl Replacement                 | 2026-02-05 |
-| [0015](0015-three-layer-player-access-control.md)                                | Three-Layer Player Access Control                      | 2026-02-05 |
-| [0016](0016-listen-notify-policy-cache-invalidation.md)                          | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation | 2026-02-05 |
+| ADR                                                                              | Title                                                  | Date       | Status            |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------- | ----------------- |
+| [0001](0001-opaque-session-tokens.md)                                            | Use Opaque Session Tokens Instead of Signed JWTs      | 2026-02-02 | Accepted          |
+| [0002](0002-argon2id-password-hashing.md)                                        | Argon2id Password Hashing                              | 2026-02-02 | Accepted          |
+| [0003](0003-player-character-auth-model.md)                                      | Player-Character Authentication Model                  | 2026-02-02 | Accepted          |
+| [0004](0004-timing-attack-resistant-auth.md)                                     | Timing-Attack Resistant Authentication                 | 2026-02-02 | Accepted          |
+| [0005](0005-command-state-management.md)                                         | Command State Management for Multi-Turn Interactions   | 2026-02-04 | Accepted          |
+| [0006](0006-unified-command-registry.md)                                         | Unified Command Registry                               | 2026-02-04 | Accepted          |
+| [0007](0007-command-security-model.md)                                           | Command Security Model                                 | 2026-02-04 | Superseded by 0014|
+| [0008](0008-command-conflict-resolution.md)                                      | Command Conflict Resolution                            | 2026-02-04 | Accepted          |
+| [0009](0009-custom-go-native-abac-engine.md)                                     | Custom Go-Native ABAC Engine                           | 2026-02-05 | Accepted          |
+| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)                           | Cedar-Aligned Fail-Safe Type Semantics                 | 2026-02-05 | Accepted          |
+| [0011](0011-deny-overrides-without-priority.md)                                  | Deny-Overrides Without Priority Ordering               | 2026-02-05 | Accepted          |
+| [0012](0012-eager-attribute-resolution.md)                                       | Eager Attribute Resolution with Per-Request Caching    | 2026-02-05 | Accepted          |
+| [0013](0013-properties-as-first-class-entities.md)                               | Properties as First-Class World Model Entities         | 2026-02-05 | Accepted          |
+| [0014](0014-direct-static-access-control-replacement.md)                         | Direct StaticAccessControl Replacement                 | 2026-02-05 | Accepted          |
+| [0015](0015-three-layer-player-access-control.md)                                | Three-Layer Player Access Control                      | 2026-02-05 | Accepted          |
+| [0016](0016-listen-notify-policy-cache-invalidation.md)                          | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation | 2026-02-05 | Accepted          |
 
 ## Format Evolution
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,24 +21,24 @@ one rather than modifying the original.
 
 ## Index
 
-| ADR                                                      | Title                                                    | Date       | Status              |
-| -------------------------------------------------------- | -------------------------------------------------------- | ---------- | ------------------- |
-| [0001](0001-opaque-session-tokens.md)                    | Use Opaque Session Tokens Instead of Signed JWTs        | 2026-02-02 | Accepted            |
-| [0002](0002-argon2id-password-hashing.md)                | Argon2id Password Hashing                                | 2026-02-02 | Accepted            |
-| [0003](0003-player-character-auth-model.md)              | Player-Character Authentication Model                    | 2026-02-02 | Accepted            |
-| [0004](0004-timing-attack-resistant-auth.md)             | Timing-Attack Resistant Authentication                   | 2026-02-02 | Accepted            |
-| [0005](0005-command-state-management.md)                 | Command State Management for Multi-Turn Interactions     | 2026-02-04 | Accepted            |
-| [0006](0006-unified-command-registry.md)                 | Unified Command Registry                                 | 2026-02-04 | Accepted            |
-| [0007](0007-command-security-model.md)                   | Command Security Model                                   | 2026-02-04 | Superseded by 0014  |
-| [0008](0008-command-conflict-resolution.md)              | Command Conflict Resolution                              | 2026-02-04 | Accepted            |
-| [0009](0009-custom-go-native-abac-engine.md)             | Custom Go-Native ABAC Engine                             | 2026-02-05 | Accepted            |
-| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)   | Cedar-Aligned Fail-Safe Type Semantics                   | 2026-02-05 | Accepted            |
-| [0011](0011-deny-overrides-without-priority.md)          | Deny-Overrides Without Priority Ordering                 | 2026-02-05 | Accepted            |
-| [0012](0012-eager-attribute-resolution.md)               | Eager Attribute Resolution with Per-Request Caching      | 2026-02-05 | Accepted            |
-| [0013](0013-properties-as-first-class-entities.md)       | Properties as First-Class World Model Entities           | 2026-02-05 | Accepted            |
-| [0014](0014-direct-static-access-control-replacement.md) | Direct StaticAccessControl Replacement                   | 2026-02-05 | Accepted            |
-| [0015](0015-three-layer-player-access-control.md)        | Three-Layer Player Access Control                        | 2026-02-05 | Accepted            |
-| [0016](0016-listen-notify-policy-cache-invalidation.md)  | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation   | 2026-02-05 | Accepted            |
+| ADR                                                      | Title                                                  | Date       | Status             |
+| -------------------------------------------------------- | ------------------------------------------------------ | ---------- | ------------------ |
+| [0001](0001-opaque-session-tokens.md)                    | Use Opaque Session Tokens Instead of Signed JWTs       | 2026-02-02 | Accepted           |
+| [0002](0002-argon2id-password-hashing.md)                | Argon2id Password Hashing                              | 2026-02-02 | Accepted           |
+| [0003](0003-player-character-auth-model.md)              | Player-Character Authentication Model                  | 2026-02-02 | Accepted           |
+| [0004](0004-timing-attack-resistant-auth.md)             | Timing-Attack Resistant Authentication                 | 2026-02-02 | Accepted           |
+| [0005](0005-command-state-management.md)                 | Command State Management for Multi-Turn Interactions   | 2026-02-04 | Accepted           |
+| [0006](0006-unified-command-registry.md)                 | Unified Command Registry                               | 2026-02-04 | Accepted           |
+| [0007](0007-command-security-model.md)                   | Command Security Model                                 | 2026-02-04 | Superseded by 0014 |
+| [0008](0008-command-conflict-resolution.md)              | Command Conflict Resolution                            | 2026-02-04 | Accepted           |
+| [0009](0009-custom-go-native-abac-engine.md)             | Custom Go-Native ABAC Engine                           | 2026-02-05 | Accepted           |
+| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)   | Cedar-Aligned Fail-Safe Type Semantics                 | 2026-02-05 | Accepted           |
+| [0011](0011-deny-overrides-without-priority.md)          | Deny-Overrides Without Priority Ordering               | 2026-02-05 | Accepted           |
+| [0012](0012-eager-attribute-resolution.md)               | Eager Attribute Resolution with Per-Request Caching    | 2026-02-05 | Accepted           |
+| [0013](0013-properties-as-first-class-entities.md)       | Properties as First-Class World Model Entities         | 2026-02-05 | Accepted           |
+| [0014](0014-direct-static-access-control-replacement.md) | Direct StaticAccessControl Replacement                 | 2026-02-05 | Accepted           |
+| [0015](0015-three-layer-player-access-control.md)        | Three-Layer Player Access Control                      | 2026-02-05 | Accepted           |
+| [0016](0016-listen-notify-policy-cache-invalidation.md)  | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation | 2026-02-05 | Accepted           |
 
 ## Format Evolution
 
@@ -83,19 +83,19 @@ options embedded in context rather than separated. New ADRs SHOULD use the curre
 
 [Description]
 
-| Aspect     | Assessment                    |
-| ---------- | ----------------------------- |
-| Strengths  | [What this option does well]  |
-| Weaknesses | [What this option lacks]      |
+| Aspect     | Assessment                   |
+| ---------- | ---------------------------- |
+| Strengths  | [What this option does well] |
+| Weaknesses | [What this option lacks]     |
 
 **Option B: [Name]**
 
 [Description]
 
-| Aspect     | Assessment                    |
-| ---------- | ----------------------------- |
-| Strengths  | [What this option does well]  |
-| Weaknesses | [What this option lacks]      |
+| Aspect     | Assessment                   |
+| ---------- | ---------------------------- |
+| Strengths  | [What this option does well] |
+| Weaknesses | [What this option lacks]     |
 
 ## Decision
 
@@ -135,14 +135,14 @@ options embedded in context rather than separated. New ADRs SHOULD use the curre
 
 ## Writing Guidelines
 
-| Guideline                 | Description                                                                                  |
-| ------------------------- | -------------------------------------------------------------------------------------------- |
-| **Immutability**          | ADRs are permanent records — do not edit accepted ADRs to change decisions                   |
-| **Supersession**          | To reverse a decision, create a new ADR and mark the old one as "Superseded by ADR-XXXX"     |
-| **RFC2119 keywords**      | Use MUST/SHOULD/MAY in consequences when describing implementation requirements              |
-| **Comprehensive options** | Document ALL options considered, not just the chosen one                                     |
-| **Trade-off clarity**     | Consequences should honestly capture both benefits and costs                                 |
-| **Future-proof**          | Assume readers in 5 years won't have context — explain everything                            |
+| Guideline                 | Description                                                                              |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| **Immutability**          | ADRs are permanent records — do not edit accepted ADRs to change decisions               |
+| **Supersession**          | To reverse a decision, create a new ADR and mark the old one as "Superseded by ADR-XXXX" |
+| **RFC2119 keywords**      | Use MUST/SHOULD/MAY in consequences when describing implementation requirements          |
+| **Comprehensive options** | Document ALL options considered, not just the chosen one                                 |
+| **Trade-off clarity**     | Consequences should honestly capture both benefits and costs                             |
+| **Future-proof**          | Assume readers in 5 years won't have context — explain everything                        |
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,24 +21,24 @@ one rather than modifying the original.
 
 ## Index
 
-| ADR                                                                              | Title                                                  | Date       | Status            |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------- | ----------------- |
-| [0001](0001-opaque-session-tokens.md)                                            | Use Opaque Session Tokens Instead of Signed JWTs      | 2026-02-02 | Accepted          |
-| [0002](0002-argon2id-password-hashing.md)                                        | Argon2id Password Hashing                              | 2026-02-02 | Accepted          |
-| [0003](0003-player-character-auth-model.md)                                      | Player-Character Authentication Model                  | 2026-02-02 | Accepted          |
-| [0004](0004-timing-attack-resistant-auth.md)                                     | Timing-Attack Resistant Authentication                 | 2026-02-02 | Accepted          |
-| [0005](0005-command-state-management.md)                                         | Command State Management for Multi-Turn Interactions   | 2026-02-04 | Accepted          |
-| [0006](0006-unified-command-registry.md)                                         | Unified Command Registry                               | 2026-02-04 | Accepted          |
-| [0007](0007-command-security-model.md)                                           | Command Security Model                                 | 2026-02-04 | Superseded by 0014|
-| [0008](0008-command-conflict-resolution.md)                                      | Command Conflict Resolution                            | 2026-02-04 | Accepted          |
-| [0009](0009-custom-go-native-abac-engine.md)                                     | Custom Go-Native ABAC Engine                           | 2026-02-05 | Accepted          |
-| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)                           | Cedar-Aligned Fail-Safe Type Semantics                 | 2026-02-05 | Accepted          |
-| [0011](0011-deny-overrides-without-priority.md)                                  | Deny-Overrides Without Priority Ordering               | 2026-02-05 | Accepted          |
-| [0012](0012-eager-attribute-resolution.md)                                       | Eager Attribute Resolution with Per-Request Caching    | 2026-02-05 | Accepted          |
-| [0013](0013-properties-as-first-class-entities.md)                               | Properties as First-Class World Model Entities         | 2026-02-05 | Accepted          |
-| [0014](0014-direct-static-access-control-replacement.md)                         | Direct StaticAccessControl Replacement                 | 2026-02-05 | Accepted          |
-| [0015](0015-three-layer-player-access-control.md)                                | Three-Layer Player Access Control                      | 2026-02-05 | Accepted          |
-| [0016](0016-listen-notify-policy-cache-invalidation.md)                          | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation | 2026-02-05 | Accepted          |
+| ADR                                                      | Title                                                    | Date       | Status              |
+| -------------------------------------------------------- | -------------------------------------------------------- | ---------- | ------------------- |
+| [0001](0001-opaque-session-tokens.md)                    | Use Opaque Session Tokens Instead of Signed JWTs        | 2026-02-02 | Accepted            |
+| [0002](0002-argon2id-password-hashing.md)                | Argon2id Password Hashing                                | 2026-02-02 | Accepted            |
+| [0003](0003-player-character-auth-model.md)              | Player-Character Authentication Model                    | 2026-02-02 | Accepted            |
+| [0004](0004-timing-attack-resistant-auth.md)             | Timing-Attack Resistant Authentication                   | 2026-02-02 | Accepted            |
+| [0005](0005-command-state-management.md)                 | Command State Management for Multi-Turn Interactions     | 2026-02-04 | Accepted            |
+| [0006](0006-unified-command-registry.md)                 | Unified Command Registry                                 | 2026-02-04 | Accepted            |
+| [0007](0007-command-security-model.md)                   | Command Security Model                                   | 2026-02-04 | Superseded by 0014  |
+| [0008](0008-command-conflict-resolution.md)              | Command Conflict Resolution                              | 2026-02-04 | Accepted            |
+| [0009](0009-custom-go-native-abac-engine.md)             | Custom Go-Native ABAC Engine                             | 2026-02-05 | Accepted            |
+| [0010](0010-cedar-aligned-fail-safe-type-semantics.md)   | Cedar-Aligned Fail-Safe Type Semantics                   | 2026-02-05 | Accepted            |
+| [0011](0011-deny-overrides-without-priority.md)          | Deny-Overrides Without Priority Ordering                 | 2026-02-05 | Accepted            |
+| [0012](0012-eager-attribute-resolution.md)               | Eager Attribute Resolution with Per-Request Caching      | 2026-02-05 | Accepted            |
+| [0013](0013-properties-as-first-class-entities.md)       | Properties as First-Class World Model Entities           | 2026-02-05 | Accepted            |
+| [0014](0014-direct-static-access-control-replacement.md) | Direct StaticAccessControl Replacement                   | 2026-02-05 | Accepted            |
+| [0015](0015-three-layer-player-access-control.md)        | Three-Layer Player Access Control                        | 2026-02-05 | Accepted            |
+| [0016](0016-listen-notify-policy-cache-invalidation.md)  | PostgreSQL LISTEN/NOTIFY for Policy Cache Invalidation   | 2026-02-05 | Accepted            |
 
 ## Format Evolution
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -350,7 +350,7 @@ resources) create confusion in policies and audit logs. Normalizing to
 `character:` aligns subjects with resources and with Cedar conventions where
 the principal type name matches the DSL type name.
 
-_Note: Decision #36 removed the adapter. All call sites switch directly to
+_Note: [decision #36](#36-direct-replacement-no-adapter) removed the adapter. All call sites switch directly to
 `character:` — the engine **MUST** reject the `char:` prefix with a clear
 error rather than normalizing it. The prefix constants (`SubjectCharacter`,
 `SubjectPlugin`, etc.) remain the recommended approach._
@@ -408,7 +408,7 @@ errors. Better to reject at parse time with a helpful message than to accept
 syntax that fails silently at evaluation time.
 
 **Updates [decision #8](#8-dsl-expression-language-scope):** The full expression language still includes all
-operators from decision #8. Only `entity_ref` is deferred — `in` works with
+operators from [decision #8](#8-dsl-expression-language-scope). Only `entity_ref` is deferred — `in` works with
 lists and attribute expressions.
 
 ---
@@ -450,7 +450,7 @@ world package maintains the separation of concerns: world model stores data,
 access control evaluates policies against it.
 
 **Updates [decision #9](#9-property-model):** Clarifies the implementation location of the property
-model from decision #9.
+model from [decision #9](#9-property-model).
 
 ---
 
@@ -654,7 +654,7 @@ the defensive pattern is `principal has faction && principal.faction !=
 "enemy"`.
 
 **Updates [decision #8](#8-dsl-expression-language-scope):** Changes the type
-system table from decision #8's implied semantics.
+system table from [decision #8](#8-dsl-expression-language-scope)'s implied semantics.
 
 ---
 
@@ -830,8 +830,8 @@ for cleanup.
 
 ## 36. Direct Replacement (No Adapter)
 
-**Review finding:** The adapter pattern (decision #5) and shadow mode
-(decision #21) add significant complexity: normalization helpers, migration
+**Review finding:** The adapter pattern ([decision #5](#5-migration-strategy)) and shadow mode
+([decision #21](#21-shadow-mode-cutover-criteria)) add significant complexity: normalization helpers, migration
 adapters, shadow mode metrics, cutover criteria, exclusion filtering. This
 complexity exists solely to support incremental migration from
 `StaticAccessControl`.
@@ -856,7 +856,7 @@ been released wastes effort and makes the design harder to understand.
 - The `AccessControl` interface and `StaticAccessControl` struct are deleted
   in phase 7.6
 
-**Supersedes:** [Decision #5](#5-migration-strategy) (adapter pattern),
+**Supersedes:** [decision #5](#5-migration-strategy) (adapter pattern),
 [decision #21](#21-shadow-mode-cutover-criteria) (shadow mode)
 
 ---

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -10,6 +10,60 @@ rationale for the chosen approach.
 
 ---
 
+## Table of Contents
+
+1. [Policy Engine Approach](#1-policy-engine-approach)
+2. [Policy Definition Format](#2-policy-definition-format)
+3. [Attribute Resolution Strategy](#3-attribute-resolution-strategy)
+4. [Conflict Resolution](#4-conflict-resolution)
+5. ~~[Migration Strategy](#5-migration-strategy)~~ (superseded by #36)
+6. [Plugin Attribute Contributions](#6-plugin-attribute-contributions)
+7. [Audit Logging Destination](#7-audit-logging-destination)
+8. [DSL Expression Language Scope](#8-dsl-expression-language-scope)
+9. [Property Model](#9-property-model)
+10. [Property Visibility Defaults](#10-property-visibility-defaults)
+11. [Cache Invalidation](#11-cache-invalidation)
+12. [Player Access Control Layers](#12-player-access-control-layers)
+13. [Subject Prefix Normalization](#13-subject-prefix-normalization)
+14. [No Database Triggers](#14-no-database-triggers)
+15. [Grammar: `in` Operator Extended to Attribute Expressions](#15-grammar-in-operator-extended-to-attribute-expressions)
+16. [Entity References Explicitly Deferred](#16-entity-references-explicitly-deferred)
+17. [Session Resolution at Engine Entry Point](#17-session-resolution-at-engine-entry-point)
+18. [Property Package Ownership](#18-property-package-ownership)
+19. [Lock Policies Are Not Versioned](#19-lock-policies-are-not-versioned)
+20. ~~[`enter` Action as New ABAC-Only Path](#20-enter-action-as-new-abac-only-path)~~ (superseded by #37)
+21. ~~[Shadow Mode Cutover Criteria](#21-shadow-mode-cutover-criteria)~~ (superseded by #37)
+22. [Flat Prefixed Strings Over Typed Structs](#22-flat-prefixed-strings-over-typed-structs)
+23. [Performance Targets](#23-performance-targets)
+24. [Bootstrap Sequence](#24-bootstrap-sequence)
+25. [Intentional Builder Permission Expansion](#25-intentional-builder-permission-expansion)
+26. [Per-Request Attribute Caching](#26-per-request-attribute-caching)
+27. [Unified `AttributeProvider` Interface](#27-unified-attributeprovider-interface)
+28. [Cedar-Aligned Missing Attribute Semantics](#28-cedar-aligned-missing-attribute-semantics)
+29. [DSL `like` Pattern Validation at Parser Layer](#29-dsl-like-pattern-validation-at-parser-layer)
+30. [PolicyCompiler Component](#30-policycompiler-component)
+31. [Provider Re-Entrance Prohibition](#31-provider-re-entrance-prohibition)
+32. [PropertyProvider Uses SQL JOIN for Parent Location](#32-propertyprovider-uses-sql-join-for-parent-location)
+33. [Plugin Lock Tokens MUST Be Namespaced](#33-plugin-lock-tokens-must-be-namespaced)
+34. [Time-of-Day Attributes for Environment Provider](#34-time-of-day-attributes-for-environment-provider)
+35. [Audit Log Source Column and No Decision Column](#35-audit-log-source-column-and-no-decision-column)
+36. [Direct Replacement (No Adapter)](#36-direct-replacement-no-adapter)
+37. [No Shadow Mode](#37-no-shadow-mode)
+38. [Audit Log Configuration Modes](#38-audit-log-configuration-modes)
+39. [`EffectSystemBypass` as Fourth Effect Variant](#39-effectsystembypass-as-fourth-effect-variant)
+40. [`has` Operator Supports Dotted Attribute Paths](#40-has-operator-supports-dotted-attribute-paths)
+41. [LL(1) Parser Disambiguation for Condition Grammar](#41-ll1-parser-disambiguation-for-condition-grammar)
+42. [Sequential Provider Resolution](#42-sequential-provider-resolution)
+43. [Property Lifecycle: Go-Level CASCADE Cleanup](#43-property-lifecycle-go-level-cascade-cleanup)
+44. [Nested Container Resolution via Recursive CTE](#44-nested-container-resolution-via-recursive-cte)
+45. [Bounded List Sizes for `visible_to` / `excluded_from`](#45-bounded-list-sizes-for-visible_to--excluded_from)
+46. [`policy validate` and `policy reload` Commands](#46-policy-validate-and-policy-reload-commands)
+47. [Fuzz Testing for DSL Parser](#47-fuzz-testing-for-dsl-parser)
+48. [Deterministic Seed Policy Names](#48-deterministic-seed-policy-names)
+49. [Revised Audit Volume Estimate](#49-revised-audit-volume-estimate)
+
+---
+
 ## 1. Policy Engine Approach
 
 **Question:** Should HoloMUSH adopt an existing authorization framework or build
@@ -295,6 +349,11 @@ internally. The `access` package SHOULD define prefix constants
 resources) create confusion in policies and audit logs. Normalizing to
 `character:` aligns subjects with resources and with Cedar conventions where
 the principal type name matches the DSL type name.
+
+_Note: Decision #36 removed the adapter. All call sites switch directly to
+`character:` — the engine **MUST** reject the `char:` prefix with a clear
+error rather than normalizing it. The prefix constants (`SubjectCharacter`,
+`SubjectPlugin`, etc.) remain the recommended approach._
 
 ---
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -70,6 +70,7 @@ rationale for the chosen approach.
 56. [Audit Off Mode Includes System Bypasses](#56-audit-off-mode-includes-system-bypasses)
 57. [ADR Format Evolution](#57-adr-format-evolution)
 58. [Provider Re-Entrance Goroutine Prohibition](#58-provider-re-entrance-goroutine-prohibition)
+59. [Fair-Share Provider Timeout Scheduling](#59-fair-share-provider-timeout-scheduling)
 
 ---
 
@@ -1406,3 +1407,60 @@ than production.
 
 **Cross-reference:** Main spec, Attribute Providers section; decision #31
 (Provider Re-Entrance Prohibition); bead `holomush-npmk`.
+
+---
+
+## 59. Fair-Share Provider Timeout Scheduling
+
+**Question:** What scheduling approach should be used for distributing the 100ms
+evaluation timeout budget across attribute providers during policy evaluation?
+
+**Decision:** Fair-share dynamic allocation is the definitive approach for
+provider timeout scheduling. Each provider receives `max(remaining_budget /
+remaining_providers, 5ms)` at call time, with unused time automatically
+redistributed to subsequent providers. The 100ms total budget serves as a hard
+backstop. This is a go-forward commitment—we have evaluated the alternatives and
+accept the tradeoffs.
+
+**Rationale:** Fair-share maximizes total budget utilization while maintaining
+simplicity. Fast providers (e.g., in-memory lookups returning in <1ms) donate
+their unused time to slower providers (e.g., database queries), naturally
+balancing the system without operator configuration. The formula is trivial to
+implement and reason about, with no tuning parameters beyond the hard 100ms
+limit.
+
+**Acknowledged concerns and why they're acceptable:**
+
+1. **Registration order dependency** — A slow early provider can consume budget
+   before fast later providers run. This is acceptable because: (a) providers
+   register at startup in deterministic order, making behavior predictable; (b)
+   the 5ms minimum ensures even late providers get meaningful time; (c) truly
+   pathological cases (e.g., a provider consistently timing out) surface quickly
+   in monitoring and can be fixed at the provider level.
+
+2. **Dynamic per-provider budgets complicate alerting** — Operators cannot set
+   static "provider X should complete in Y ms" alerts because budgets vary based
+   on what ran before. This is acceptable because: (a) the total 100ms budget
+   provides a clear hard limit for alerting; (b) per-provider P99 latency
+   metrics still reveal slow providers; (c) the alternative (fixed equal slices)
+   wastes budget when fast providers finish early, making total evaluation
+   slower on average.
+
+3. **Alternatives considered but not chosen:**
+   - **Fixed equal slices** (e.g., 20ms each for 5 providers) — Simple but
+     wastes unused time, making evaluations slower when some providers are fast.
+   - **Priority-based allocation** — Adds configuration burden (operators must
+     rank provider importance) and complexity (priority queues, starvation
+     prevention) with unclear benefit given most providers are ~1-5ms.
+   - **Parallel execution** — Would give each provider the full 100ms budget but
+     requires thread-safe providers (breaking current single-goroutine contract)
+     and adds synchronization complexity. Deferred as future optimization if
+     profiling shows evaluation latency is a bottleneck.
+
+Fair-share is the optimal balance of simplicity, utilization, and
+predictability. The 100ms hard backstop prevents runaway evaluations, and the
+self-balancing property eliminates the need for operator tuning. We move forward
+with this approach.
+
+**Cross-reference:** Main spec, Attribute Providers section (lines 1768-1807);
+decision #58 (Provider Re-Entrance Goroutine Prohibition).

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -116,14 +116,14 @@ simple: deny always wins, period.
 
 ## 5. Migration Strategy
 
-**Question:** How do we migrate ~28 production call sites from the old
+**Question:** How do we migrate ~29 production call sites from the old
 `AccessControl` interface to the new `AccessPolicyEngine`?
 
 **Options considered:**
 
 | Option | Description                                 | Pros                                                  | Cons                                                                  |
 | ------ | ------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
-| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all ~28 callers need error handling added at once |
+| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all ~29 callers need error handling added at once |
 | B      | New interface + adapter for backward compat | Incremental migration, preserves fail-closed behavior | Two interfaces exist temporarily                                      |
 
 **Decision:** ~~**Option B — New `AccessPolicyEngine` interface with adapter.**~~
@@ -423,9 +423,13 @@ entry control, but the static system handles movement through
 `write:character:$self` (changing character location). This semantic gap affects
 shadow mode validation.
 
-**Decision:** The `enter` action is a new capability introduced by the ABAC
+**Decision:** ~~The `enter` action is a new capability introduced by the ABAC
 system with no static-system equivalent. Shadow mode validation MUST exclude
-`enter` actions when comparing engine results against `StaticAccessControl`.
+`enter` actions when comparing engine results against `StaticAccessControl`.~~
+
+**Superseded by [decision #37](#37-no-shadow-mode).** Shadow mode was removed.
+The `enter` action remains a new ABAC capability with no static-system
+equivalent, but no shadow mode validation is performed.
 
 **Rationale:** The static system conflates "move yourself" with "enter a
 location" under the `write:character` permission. ABAC separates these concerns
@@ -518,8 +522,11 @@ omission was a gap, not a deliberate restriction.
 
 **Rationale:** Builder workflow requires the ability to clean up test locations.
 Without `delete`, builders must ask an admin to remove locations, which is an
-unnecessary bottleneck. Shadow mode validation excludes `delete:location`
-comparisons alongside `enter` actions.
+unnecessary bottleneck.
+
+*Note: Shadow mode was removed by [decision #37](#37-no-shadow-mode). The
+original rationale about shadow mode exclusions no longer applies, but the
+permission expansion itself is intentional.*
 
 ---
 
@@ -746,7 +753,7 @@ been released wastes effort and makes the design harder to understand.
   `normalizeResource()`, `shadowModeMetrics`
 - Removes shadow mode cutover criteria, exclusion filtering, disagreement
   tracking
-- All ~28 call sites update to `AccessPolicyEngine.Evaluate()` in a single
+- All ~29 production call sites update to `AccessPolicyEngine.Evaluate()` in a single
   phase (phase 7.3)
 - The `AccessControl` interface and `StaticAccessControl` struct are deleted
   in phase 7.6

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -686,12 +686,19 @@ not just detectable. Requiring namespacing makes collisions structurally
 impossible between plugins (each has a unique ID) while core tokens remain
 un-namespaced.
 
+**Clarification (inter-plugin collisions):** Namespace enforcement prevents
+cross-plugin token collisions (plugin A cannot register `pluginB.score`).
+If two plugins with the same ID are loaded (a deployment error), duplicate
+token registrations MUST cause a startup error — see the main spec's token
+conflict resolution section for the updated policy.
+
 ---
 
 ## 34. Time-of-Day Attributes for Environment Provider
 
-**Review finding:** The original spec included only `env.maintenance_mode` and
-`env.game_state` as environment attributes. Time-based policy gating (e.g.,
+**Review finding:** The original spec included only `env.maintenance_mode`
+(since renamed to `env.maintenance` in the final spec) and `env.game_state`
+as environment attributes. Time-based policy gating (e.g.,
 restrict certain areas during night hours) was not possible.
 
 **Decision:** Add `env.hour` (float64, 0-23), `env.minute` (float64, 0-59),

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -179,14 +179,14 @@ simple: deny always wins, period.
 
 ## 5. Migration Strategy
 
-**Question:** How do we migrate ~29 production call sites from the old
+**Question:** How do we migrate ~30 production call sites from the old
 `AccessControl` interface to the new `AccessPolicyEngine`?
 
 **Options considered:**
 
 | Option | Description                                 | Pros                                                  | Cons                                                                  |
 | ------ | ------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
-| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all ~29 callers need error handling added at once |
+| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all ~30 callers need error handling added at once |
 | B      | New interface + adapter for backward compat | Incremental migration, preserves fail-closed behavior | Two interfaces exist temporarily                                      |
 
 **Decision:** ~~**Option B — New `AccessPolicyEngine` interface with adapter.**~~
@@ -860,7 +860,7 @@ been released wastes effort and makes the design harder to understand.
   `normalizeResource()`, `shadowModeMetrics`
 - Removes shadow mode cutover criteria, exclusion filtering, disagreement
   tracking
-- All ~29 production call sites update to `AccessPolicyEngine.Evaluate()` in a single
+- All ~30 production call sites update to `AccessPolicyEngine.Evaluate()` in a single
   phase (phase 7.3)
 - The `AccessControl` interface and `StaticAccessControl` struct are deleted
   in phase 7.6

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -667,10 +667,12 @@ Without enforcement, a plugin registering `score` would collide with any future
 core token or another plugin's `score`, causing server startup failures that are
 hard to diagnose.
 
-**Decision:** Plugin lock tokens MUST use a dot-separated prefix matching their
-plugin ID (e.g., `rep.score`, `craft.type`). The engine validates this at
-registration time — plugin tokens without the correct namespace prefix are
-rejected.
+**Decision:** Plugin lock tokens MUST use a dot-separated prefix that **exactly
+matches** their plugin ID (e.g., plugin `reputation` registers
+`reputation.score`, plugin `crafting` registers `crafting.type`). Abbreviations
+are not allowed — the prefix before the first `.` MUST equal the plugin ID
+string. The engine validates this at registration time — plugin tokens without
+the correct namespace prefix are rejected.
 
 **Rationale:** Fatal startup errors from token collisions should be preventable,
 not just detectable. Requiring namespacing makes collisions structurally
@@ -1019,13 +1021,14 @@ where the purpose is a kebab-case description of the policy's intent:
 - `seed:player-self-access`
 - `seed:player-location-read`
 - `seed:player-character-colocation`
-- `seed:player-default-commands`
+- `seed:player-object-colocation`
+- `seed:player-stream-emit`
 - `seed:player-movement`
-- `seed:builder-world-management`
-- `seed:builder-advanced-commands`
+- `seed:player-basic-commands`
+- `seed:builder-location-write`
+- `seed:builder-object-write`
+- `seed:builder-commands`
 - `seed:admin-full-access`
-- `seed:admin-command-access`
-- `seed:builder-policy-test`
 
 **Rationale:** Deterministic names enable idempotent seeding (upsert by name)
 and allow admins to identify seed policies via `policy list`. The `seed:`

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -1157,6 +1157,9 @@ where the purpose is a kebab-case description of the policy's intent:
 - `seed:builder-object-write`
 - `seed:builder-commands`
 - `seed:admin-full-access`
+- `seed:property-public-read`
+- `seed:property-private-read`
+- `seed:property-admin-read`
 
 **Rationale:** Deterministic names enable idempotent seeding (upsert by name)
 and allow admins to identify seed policies via `policy list`. The `seed:`

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -285,7 +285,25 @@ Admin `forbid` policies always trump player locks via deny-overrides.
 
 ---
 
-## 13. No Database Triggers
+## 13. Subject Prefix Normalization
+
+**Question:** The static system uses `char:` as the subject prefix for
+characters, but resources already use `character:` (e.g., `character:01ABC`).
+Should the ABAC system normalize?
+
+**Decision:** Normalize to `character:` everywhere. The adapter MUST accept
+both `char:` and `character:` during migration, normalizing to `character:`
+internally. The `access` package SHOULD define prefix constants
+(`SubjectCharacter`, `SubjectPlugin`, etc.) to prevent typos.
+
+**Rationale:** Asymmetric prefixes (`char:` for subjects, `character:` for
+resources) create confusion in policies and audit logs. Normalizing to
+`character:` aligns subjects with resources and with Cedar conventions where
+the principal type name matches the DSL type name.
+
+---
+
+## 14. No Database Triggers
 
 **Sean's hard constraint:** No database triggers or stored procedures. All logic
 must live in Go application code. PostgreSQL is storage only.

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -277,7 +277,7 @@ call is explicit Go code.
 1. **Property metadata** (all characters) — Set visibility, visible_to,
    excluded_from on owned properties. No policy authoring needed.
 2. **Object locks** (resource owners) — Simplified lock syntax (`faction:X`,
-   `flag:X`, `level>=N`, `me`, `&`, `|`, `!`) that compiles to scoped policies.
+   `flag:X`, `level:>=N`, `me`, `&`, `|`, `!`) that compiles to scoped policies.
    Ownership verified before creation.
 3. **Full policies** (admin only) — Full DSL with unrestricted scope.
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -992,7 +992,7 @@ cannot appear as an attribute name or operator. This keeps the parser simple
 
 **Implementation note:** Phase 7.2 recommends participle (PEG-based parser)
 which uses ordered-choice semantics rather than explicit lookahead. The LL(1)
-specification describes the *logical grammar design* (what ambiguities exist,
+specification describes the _logical grammar design_ (what ambiguities exist,
 how to resolve them). Participle's PEG ordered-choice achieves the same
 disambiguation effect — when multiple alternatives match, the first one in
 source order is selected. Implementers MUST verify disambiguation behavior with

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -36,8 +36,10 @@ integration with the plugin system, and a policy language readable by non-engine
 game admins.
 
 **Key insight:** Relationships can be modeled as attributes that get resolved at
-evaluation time. The existing `LocationResolver` already resolves `$here`
-dynamically — full ABAC generalizes this pattern to any entity property.
+evaluation time. The existing `LocationResolver` performs token replacement for
+`$here` in glob patterns — a form of dynamic context resolution. The ABAC
+engine's `AttributeProvider` generalizes this concept: instead of replacing
+tokens in strings, providers resolve full attribute bags for any entity.
 
 ---
 
@@ -114,15 +116,15 @@ simple: deny always wins, period.
 
 ## 5. Migration Strategy
 
-**Question:** How do we migrate ~35 callers from the old `AccessControl`
-interface to the new `AccessPolicyEngine`?
+**Question:** How do we migrate ~28 production call sites from the old
+`AccessControl` interface to the new `AccessPolicyEngine`?
 
 **Options considered:**
 
-| Option | Description                                 | Pros                                                  | Cons                                                                 |
-| ------ | ------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all 35 callers need error handling added at once |
-| B      | New interface + adapter for backward compat | Incremental migration, preserves fail-closed behavior | Two interfaces exist temporarily                                     |
+| Option | Description                                 | Pros                                                  | Cons                                                                  |
+| ------ | ------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all ~28 callers need error handling added at once |
+| B      | New interface + adapter for backward compat | Incremental migration, preserves fail-closed behavior | Two interfaces exist temporarily                                      |
 
 **Decision:** **Option B — New `AccessPolicyEngine` interface with adapter.**
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -524,9 +524,9 @@ omission was a gap, not a deliberate restriction.
 Without `delete`, builders must ask an admin to remove locations, which is an
 unnecessary bottleneck.
 
-*Note: Shadow mode was removed by [decision #37](#37-no-shadow-mode). The
+_Note: Shadow mode was removed by [decision #37](#37-no-shadow-mode). The
 original rationale about shadow mode exclusions no longer applies, but the
-permission expansion itself is intentional.*
+permission expansion itself is intentional._
 
 ---
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -340,9 +340,9 @@ Admin `forbid` policies always trump player locks via deny-overrides.
 characters, but resources already use `character:` (e.g., `character:01ABC`).
 Should the ABAC system normalize?
 
-**Decision:** Normalize to `character:` everywhere. The adapter MUST accept
+**Decision:** Normalize to `character:` everywhere. ~~The adapter MUST accept
 both `char:` and `character:` during migration, normalizing to `character:`
-internally. The `access` package SHOULD define prefix constants
+internally.~~ The `access` package SHOULD define prefix constants
 (`SubjectCharacter`, `SubjectPlugin`, etc.) to prevent typos.
 
 **Rationale:** Asymmetric prefixes (`char:` for subjects, `character:` for

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -1,0 +1,292 @@
+# Full ABAC Design Decisions
+
+**Date:** 2026-02-05
+**Participants:** Sean (lead), Claude (design assistant)
+**Related:** [Full ABAC Architecture Design](2026-02-05-full-abac-design.md)
+
+This document records the design interview that produced the Full ABAC
+architecture. Each section captures the question, options considered, and
+rationale for the chosen approach.
+
+---
+
+## 1. Policy Engine Approach
+
+**Question:** Should HoloMUSH adopt an existing authorization framework or build
+a custom engine?
+
+**Options considered:**
+
+| Option | Description                            | Pros                                                                                   | Cons                                                                                                           |
+| ------ | -------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| A      | Embed OpenFGA + custom attribute layer | Mature engine, Go-native, PostgreSQL backend, good for relationship graphs             | ReBAC-first model is awkward for attribute comparisons; limited condition language; heavyweight for ~200 users |
+| B      | Custom ABAC engine, Cedar-inspired DSL | Full control, tight plugin integration, no impedance mismatch, readable by game admins | More upfront work to build and maintain                                                                        |
+
+**Also evaluated:** Cedar (Rust-only, would need CGO/sidecar), OPA/Rego
+(Turing-complete but hard for game admins to read/write).
+
+**Decision:** **Option B — Custom ABAC engine.**
+
+**Rationale:** HoloMUSH's domain is heavily attribute-driven (faction checks,
+level gates, property visibility), not relationship-driven. OpenFGA's strength
+is graph traversal (org hierarchies, document sharing), which isn't the primary
+pattern here. At ~200 concurrent users, we don't need Zanzibar-scale
+infrastructure. A custom engine gives full control over the DSL, tight
+integration with the plugin system, and a policy language readable by non-engineer
+game admins.
+
+**Key insight:** Relationships can be modeled as attributes that get resolved at
+evaluation time. The existing `LocationResolver` already resolves `$here`
+dynamically — full ABAC generalizes this pattern to any entity property.
+
+---
+
+## 2. Policy Definition Format
+
+**Question:** How should policies be defined and stored?
+
+**Options considered:**
+
+| Option | Description                                | Pros                                                         | Cons                                       |
+| ------ | ------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------ |
+| 1      | Declarative YAML/JSON with template syntax | Familiar format, easy to store                               | Template syntax (`{{...}}`) gets confusing |
+| 2      | Cedar-style policy DSL                     | Reads like English, expressive, well-documented formal model | Requires a parser                          |
+| 3      | Structured conditions (pure JSON data)     | Easiest to validate, easy for admin commands to construct    | Verbose, hard to read at a glance          |
+
+**Decision:** **Option 2 — Cedar-style policy DSL.**
+
+**Rationale:** Readable by game admins, expressive enough for complex conditions,
+and we can store the text in PostgreSQL while keeping a parsed/validated form.
+The parser is straightforward since we're building conditions with attribute
+references, not a full programming language. Cedar's formal model is
+well-documented to draw from without importing the Rust dependency.
+
+---
+
+## 3. Attribute Resolution Strategy
+
+**Question:** When should attributes be resolved — all up front, or on demand?
+
+**Options considered:**
+
+| Option | Description                   | Pros                                                      | Cons                                         |
+| ------ | ----------------------------- | --------------------------------------------------------- | -------------------------------------------- |
+| A      | Eager (collect-then-evaluate) | Simple, predictable, complete audit snapshot per decision | May fetch unused attributes                  |
+| B      | Lazy (resolve-on-reference)   | More efficient, only fetches what policies need           | Harder to audit, ordering/caching complexity |
+
+**Decision:** **Option A — Eager resolution.**
+
+**Rationale:** At ~200 users and modest policy counts, the performance difference
+is negligible. Eager resolution provides a complete attribute snapshot for every
+decision, which powers both audit logging and the `policy test` debugging
+command. The implementation is simpler and the mental model is clearer: every
+check starts with "here's everything we know about the subject and resource."
+
+---
+
+## 4. Conflict Resolution
+
+**Question:** How should conflicting policies be resolved? Should policies have
+priority ordering?
+
+**Roadmap predefined:** Deny-overrides (any deny wins, then any allow, then
+default deny).
+
+**Additional question:** Should policies have numeric priority for override
+scenarios?
+
+**Options considered:**
+
+| Option | Description                     | Pros                                  | Cons                                       |
+| ------ | ------------------------------- | ------------------------------------- | ------------------------------------------ |
+| A      | Deny-overrides without priority | Simple mental model, Cedar-proven     | Can't say "this allow overrides that deny" |
+| B      | Priority-based ordering         | More flexible, supports VIP overrides | "Why was I denied?" debugging nightmares   |
+
+**Decision:** **Deny-overrides without priority, with system subject bypass.**
+
+**Rationale:** Cedar chose no priority and it works well. If an admin needs an
+override, they write a more specific `allow` that avoids triggering the `deny`
+condition, rather than using priority escalation. The `system` subject bypass
+(already existing) handles the "ultimate override" case. Keeps the mental model
+simple: deny always wins, period.
+
+---
+
+## 5. Migration Strategy
+
+**Question:** How do we migrate ~35 callers from the old `AccessControl`
+interface to the new `AccessPolicyEngine`?
+
+**Options considered:**
+
+| Option | Description                                 | Pros                                                  | Cons                                                                 |
+| ------ | ------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| A      | Big-bang interface change                   | Clean, one-time effort                                | Large blast radius, all 35 callers need error handling added at once |
+| B      | New interface + adapter for backward compat | Incremental migration, preserves fail-closed behavior | Two interfaces exist temporarily                                     |
+
+**Decision:** **Option B — New `AccessPolicyEngine` interface with adapter.**
+
+**Rationale:** The adapter wraps the new engine to satisfy the old
+`AccessControl` interface (logging errors internally, returning `false`). Callers
+migrate incrementally — those needing richer error info (like the command
+dispatcher) move to `AccessPolicyEngine.Evaluate()` directly, while others stay
+on the adapter. The new interface also accepts structured `AccessRequest` and
+returns structured `Decision` with reason, matched policy, and attributes.
+
+**Tracking:** Migration tracked as `holomush-c6qch` (P3, depends on phase 7.3).
+
+**Naming:** The new interface is called `AccessPolicyEngine` (per Sean's
+preference).
+
+---
+
+## 6. Plugin Attribute Contributions
+
+**Question:** How do plugins contribute attributes to the evaluation context?
+
+**Options considered:**
+
+| Option | Description                      | Pros                                                            | Cons                                  |
+| ------ | -------------------------------- | --------------------------------------------------------------- | ------------------------------------- |
+| A      | Registration-based providers     | Simple interface, synchronous, consistent with eager resolution | Every check calls every provider      |
+| B      | Attribute hooks via event system | Lower latency per check, async                                  | Attributes can be stale, more complex |
+
+**Decision:** **Option A — Registration-based providers.**
+
+**Rationale:** Consistent with the eager resolution choice. Plugins implement a
+simple `AttributeProvider` interface with `Namespace()` to prevent collisions.
+At ~200 users the synchronous resolution cost is trivial. Caching can be added
+later if profiling shows it's needed.
+
+---
+
+## 7. Audit Logging Destination
+
+**Question:** Where should access decisions be logged?
+
+**Options considered:**
+
+| Option | Description                    | Pros                                                                | Cons                                                        |
+| ------ | ------------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------- |
+| A      | Event store                    | Queryable, replayable, consistent with architecture                 | Enormous volume, mixes auth noise into game streams         |
+| B      | Separate PostgreSQL table      | Clean separation, independent retention policy, easy to query/purge | Additional table to manage                                  |
+| C      | Structured logging only (slog) | Cheapest, no DB overhead                                            | Harder to query historically, depends on log infrastructure |
+
+**Decision:** **Option B — Separate audit table.**
+
+**Rationale:** Keeps the game event store clean while giving admins a queryable
+audit trail. Configurable verbosity: log all denials by default, allow-decisions
+only when audit mode is enabled. Denials are always interesting; allows are only
+interesting when troubleshooting.
+
+---
+
+## 8. DSL Expression Language Scope
+
+**Initial proposal:** Stripped-down operators (comparisons, AND/OR/NOT, `in`
+lists). Excluded hierarchy traversal, `has`, set operations, and if-then-else.
+
+**Sean's feedback:** Include the full set — hierarchy, `has`, set operations, and
+if-then-else.
+
+**Decision:** **Full Cedar-compatible expression language.**
+
+**Rationale:** The healer-wound-visibility scenario demonstrated why the full
+language is needed. Without `has`, every property would need every possible
+attribute defined. Without `containsAny`/`in`, you'd need a separate policy per
+healer character. The full expression language pays for itself in real MUSH
+scenarios. Operators: `==`, `!=`, `>`, `>=`, `<`, `<=`, `in` (list and
+hierarchy), `has`, `containsAll`, `containsAny`, `if-then-else`, `like`, `&&`,
+`||`, `!`.
+
+---
+
+## 9. Property Model
+
+**Question:** How should per-property access control work?
+
+**Options considered:**
+
+| Option | Description                        | Pros                                              | Cons                                                               |
+| ------ | ---------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
+| A      | Properties as sub-resources        | Minimal world model change, path-based addressing | Two concepts (entities vs sub-resources), implicit type derivation |
+| B      | Properties as first-class entities | Conceptual uniformity, one mental model           | More DB rows, properties need own table                            |
+| C      | Property flags only (no ABAC)      | Simplest                                          | Loses ability to write rich policies on properties                 |
+
+**Discussion:** Sean initially leaned toward B but questioned whether it was
+over-engineering. Analysis of the admin experience showed that option A
+introduces a second-class citizen (sub-resources) requiring admins to understand
+two different resource models. Option B keeps everything uniform: characters,
+locations, objects, and properties are all entities evaluated by the same engine.
+
+**Decision:** **Option B — Properties as first-class entities.**
+
+**Rationale:** Properties already need storage (name, value, parent entity).
+Adding `owner`, `visibility`, and `flags` columns is minimal overhead. Admins
+learn one model: "everything is an entity with attributes, policies control
+access to entities." The healer-wound example and faction-backstory scenarios
+both validated this approach.
+
+**Key scenario tested:** A property of a character visible only to a group of
+other characters (healers) but NOT to the character it belongs to. This works
+cleanly with first-class properties:
+
+```text
+permit(principal is character, action in ["read"], resource is property)
+when { resource.name == "wounds" && principal.flags.containsAny(["healer"]) };
+
+forbid(principal is character, action in ["read"], resource is property)
+when { resource.name == "wounds" && resource.parent_id == principal.id };
+```
+
+---
+
+## 10. Property Visibility Defaults
+
+**Question:** Should `visible_to`/`excluded_from` always have defaults?
+
+**Sean's input:** Default to always visible to self and empty excluded list when
+set to restricted. Prevents footguns.
+
+**Decision:** When visibility is set to `restricted`, auto-populate
+`visible_to = [parent_id]` (self) and `excluded_from = []`. For other visibility
+levels, both fields are NULL (not applicable). Logic lives in Go property store,
+not database triggers.
+
+---
+
+## 11. Cache Invalidation
+
+**Sean's input:** Use PostgreSQL LISTEN/NOTIFY from the start, not polling.
+
+**Decision:** The Go policy store sends `pg_notify('policy_changed', policyID)`
+in the same transaction as any CRUD operation. The engine subscribes and reloads
+its in-memory cache on notification. No database triggers — the notification
+call is explicit Go code.
+
+---
+
+## 12. Player Access Control Layers
+
+**Question:** Can characters manage policies for things they own?
+
+**Decision:** Three-layer model:
+
+1. **Property metadata** (all characters) — Set visibility, visible_to,
+   excluded_from on owned properties. No policy authoring needed.
+2. **Object locks** (resource owners) — Simplified lock syntax (`faction:X`,
+   `flag:X`, `level>=N`, `me`, `&`, `|`, `!`) that compiles to scoped policies.
+   Ownership verified before creation.
+3. **Full policies** (admin only) — Full DSL with unrestricted scope.
+
+Admin `forbid` policies always trump player locks via deny-overrides.
+
+---
+
+## 13. No Database Triggers
+
+**Sean's hard constraint:** No database triggers or stored procedures. All logic
+must live in Go application code. PostgreSQL is storage only.
+
+**Impact:** Visibility defaults, LISTEN/NOTIFY notifications, and version
+history management are all handled in Go store implementations.

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -949,7 +949,7 @@ the existence of plugin-contributed attributes.
 **Decision:** Extend the grammar to allow dotted paths after `has`:
 
 ```text
-| expr "has" identifier { "." identifier }
+| attribute_root "has" identifier { "." identifier }
 ```
 
 The parser joins segments with `.` and checks the resulting flat key against

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -989,6 +989,15 @@ the primary expression.
 cannot appear as an attribute name or operator. This keeps the parser simple
 (no backtracking, no GLR) while handling the full grammar.
 
+**Implementation note:** Phase 7.2 recommends participle (PEG-based parser)
+which uses ordered-choice semantics rather than explicit lookahead. The LL(1)
+specification describes the *logical grammar design* (what ambiguities exist,
+how to resolve them). Participle's PEG ordered-choice achieves the same
+disambiguation effect — when multiple alternatives match, the first one in
+source order is selected. Implementers MUST verify disambiguation behavior with
+test cases covering ambiguous inputs (e.g., `principal.faction` alone vs
+`principal.faction == "red"`) regardless of parser implementation choice.
+
 ---
 
 ## 42. Sequential Provider Resolution

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -40,8 +40,8 @@ Players control access to their own properties through a simplified lock system.
 
 ### Glossary
 
-| Term            | Definition                                                                                                                                                                                   |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Term            | Definition                                                                                                                                                                                  |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Subject**     | The entity in `AccessRequest.Subject` — the Go-side identity string (e.g., `"character:01ABC"`)                                                                                             |
 | **Principal**   | The DSL keyword referring to the subject — `principal is character` matches subjects with `character:` prefix                                                                               |
 | **Resource**    | The target of the access request — entity string in `AccessRequest.Resource`                                                                                                                |
@@ -77,20 +77,20 @@ full set.
 
 All string identifiers in the ABAC system use reserved prefixes for validation and routing:
 
-| Category        | Prefix       | Purpose                                | Example                       |
-| --------------- | ------------ | -------------------------------------- | ----------------------------- |
-| Subject Strings | `character:` | Character entity reference             | `character:01ABC`             |
-|                 | `plugin:`    | Plugin identifier                      | `plugin:echo-bot`             |
-|                 | `system`     | System bypass (no ID, immediate allow) | `system`                      |
-|                 | `session:`   | Session ID (resolved to `character:`)  | `session:01XYZ`               |
-| Resource Strings| `location:`  | Location/room reference                | `location:01XYZ`              |
-|                 | `object:`    | Object entity reference                | `object:01DEF`                |
-|                 | `command:`   | Command name                           | `command:say`                 |
-|                 | `property:`  | Property entity reference              | `property:01GHI`              |
-|                 | `stream:`    | Event stream reference                 | `stream:location:01XYZ`       |
-| Policy Names    | `seed:`      | System seed policies                   | `seed:player-self-access`     |
-|                 | `lock:`      | Lock-generated policies                | `lock:object:01ABC:read`      |
-| Policy IDs      | `infra:`     | Infrastructure error disambiguation    | `infra:attr-resolution-error` |
+| Category         | Prefix       | Purpose                                | Example                       |
+| ---------------- | ------------ | -------------------------------------- | ----------------------------- |
+| Subject Strings  | `character:` | Character entity reference             | `character:01ABC`             |
+|                  | `plugin:`    | Plugin identifier                      | `plugin:echo-bot`             |
+|                  | `system`     | System bypass (no ID, immediate allow) | `system`                      |
+|                  | `session:`   | Session ID (resolved to `character:`)  | `session:01XYZ`               |
+| Resource Strings | `location:`  | Location/room reference                | `location:01XYZ`              |
+|                  | `object:`    | Object entity reference                | `object:01DEF`                |
+|                  | `command:`   | Command name                           | `command:say`                 |
+|                  | `property:`  | Property entity reference              | `property:01GHI`              |
+|                  | `stream:`    | Event stream reference                 | `stream:location:01XYZ`       |
+| Policy Names     | `seed:`      | System seed policies                   | `seed:player-self-access`     |
+|                  | `lock:`      | Lock-generated policies                | `lock:object:01ABC:read`      |
+| Policy IDs       | `infra:`     | Infrastructure error disambiguation    | `infra:attr-resolution-error` |
 
 See [AccessRequest](#accessrequest) for subject/resource format details and [Seed Policies](#seed-policies) for policy name conventions.
 
@@ -143,8 +143,7 @@ See [AccessRequest](#accessrequest) for subject/resource format details and [See
 
 ### Request Flow
 
-This section provides a high-level overview. See [Evaluation
-Algorithm](#evaluation-algorithm) for the authoritative step-by-step specification.
+This section provides a high-level overview. See [Evaluation Algorithm](#evaluation-algorithm) for the authoritative step-by-step specification.
 
 1. Caller invokes `Evaluate(ctx, AccessRequest)`
 2. System bypass: if subject is `"system"`, immediately allow with
@@ -251,7 +250,7 @@ type CompiledPolicy struct {
     "principal_type": "character",
     "action_list": ["read", "write"],
     "resource_type": "property",
-    "resource_exact": null  // Target-level pinning: if non-null, policy applies only to this exact resource string
+    "resource_exact": null // Target-level pinning: if non-null, policy applies only to this exact resource string
   },
   "conditions": [
     {
@@ -737,7 +736,7 @@ The DSL is Cedar-inspired with a full expression language. Policies have a
 
 ### Grammar
 
-```text
+````text
 policy     = effect "(" target ")" [ "when" "{" conditions "}" ] ";"
 effect     = "permit" | "forbid"
 target     = principal_clause "," action_clause "," resource_clause
@@ -843,7 +842,7 @@ permit(principal, action in ["read"], resource)
 // VALID - bare literals allowed
 permit(principal, action in ["debug"], resource)
   when { false };  // Policy disabled
-```
+````
 
 **Migration:** Existing policies with bare boolean attributes can be automatically
 fixed using `policy lint --fix`, which rewrites bare attributes as
@@ -1134,7 +1133,7 @@ This prevents a circular dependency:
 
 ### Property Attributes
 
-| Attribute       | Type     | Description                                                                   |
+| Attribute         | Type     | Description                                                                   |
 | ----------------- | -------- | ----------------------------------------------------------------------------- |
 | `id`              | ULID     | Unique property identifier                                                    |
 | `parent_type`     | string   | Parent entity type: character, location, object                               |
@@ -1388,14 +1387,14 @@ attributes in the `reputation` namespace.
 Attribute providers MUST register schemas during plugin initialization. The
 schema registry enforces the following validation rules at registration time:
 
-| Validation Rule                | Behavior                                              |
-| ------------------------------ | ----------------------------------------------------- |
-| Missing namespace              | Reject registration, return error to plugin loader    |
-| Empty namespace                | Reject registration, return error to plugin loader    |
-| Duplicate namespace            | Reject registration, return error to plugin loader    |
-| Empty attribute definition     | Reject registration, return error to plugin loader    |
-| Invalid type (not in enum)     | Reject registration, return error to plugin loader    |
-| Duplicate attribute keys       | Reject registration, return error to plugin loader    |
+| Validation Rule            | Behavior                                           |
+| -------------------------- | -------------------------------------------------- |
+| Missing namespace          | Reject registration, return error to plugin loader |
+| Empty namespace            | Reject registration, return error to plugin loader |
+| Duplicate namespace        | Reject registration, return error to plugin loader |
+| Empty attribute definition | Reject registration, return error to plugin loader |
+| Invalid type (not in enum) | Reject registration, return error to plugin loader |
+| Duplicate attribute keys   | Reject registration, return error to plugin loader |
 
 **Registration failure behavior:** If a plugin fails to register a valid schema,
 the plugin loader MUST fail plugin initialization and log the error. The plugin
@@ -1446,12 +1445,12 @@ if !schema.IsRegistered(namespace, key) {
 When a plugin is reloaded, the engine MUST compare the new schema against the
 previous schema version and log warnings for breaking changes:
 
-| Schema Change          | Behavior                                                                         |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| Attribute added        | Info log, no action required                                                     |
-| Attribute type changed | Warn log, existing policies may break                                            |
-| Attribute removed      | Warn log, scan policies for references                                           |
-| Namespace removed      | Error log, scan policies for references, reject reload if policies reference it  |
+| Schema Change          | Behavior                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| Attribute added        | Info log, no action required                                                    |
+| Attribute type changed | Warn log, existing policies may break                                           |
+| Attribute removed      | Warn log, scan policies for references                                          |
+| Namespace removed      | Error log, scan policies for references, reject reload if policies reference it |
 
 **Schema evolution example:**
 
@@ -1826,10 +1825,10 @@ expire regardless of what the current provider is doing.
 The ABAC engine uses three distinct circuit breaker designs, each tuned for
 different failure modes:
 
-| Component        | Trigger                                                  | Window | Behavior              | Metric                                                       | Rationale                                                                                                 |
-| ---------------- | -------------------------------------------------------- | ------ | --------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| General provider | >80% budget utilization in >50% of calls (min 10 calls) | 60s    | Skip provider for 60s | `abac_provider_circuit_breaker_trips_total`                  | Higher threshold because some transient slowness is expected; detects systematic performance degradation  |
-| PropertyProvider | 3 timeout errors                                         | 60s    | Skip queries for 60s  | `abac_property_provider_circuit_breaker_trips_total`         | Lower threshold because timeouts indicate systematic issues with recursive CTE or data model corruption  |
+| Component        | Trigger                                                 | Window | Behavior              | Metric                                               | Rationale                                                                                                |
+| ---------------- | ------------------------------------------------------- | ------ | --------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| General provider | >80% budget utilization in >50% of calls (min 10 calls) | 60s    | Skip provider for 60s | `abac_provider_circuit_breaker_trips_total`          | Higher threshold because some transient slowness is expected; detects systematic performance degradation |
+| PropertyProvider | 3 timeout errors                                        | 60s    | Skip queries for 60s  | `abac_property_provider_circuit_breaker_trips_total` | Lower threshold because timeouts indicate systematic issues with recursive CTE or data model corruption  |
 
 **General provider circuit breaker:** Providers that stay just
 under the timeout but consistently consume >80% of their allocated budget

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1,0 +1,853 @@
+# Full ABAC Architecture Design
+
+**Status:** Draft
+**Date:** 2026-02-05
+**Epic:** holomush-5k1 (Epic 7: Full ABAC)
+**Task:** holomush-5k1.1
+
+## Overview
+
+This document defines the full Attribute-Based Access Control (ABAC) architecture
+for HoloMUSH, replacing the static role-based system from Epic 3 with a
+policy-driven engine. Game administrators define policies using a Cedar-inspired
+DSL that references dynamic attributes of subjects, resources, and the environment.
+Players control access to their own properties through a simplified lock system.
+
+### Goals
+
+- Dynamic, admin-editable authorization policies stored in PostgreSQL
+- Cedar-inspired DSL with rich expression language (comparisons, set operations,
+  hierarchy traversal, if-then-else)
+- Extensible attribute system with plugin contributions via registration-based
+  providers
+- Properties as first-class entities with per-property access control
+- Player-authored locks for owned resources (simplified policy syntax)
+- In-game admin commands for policy CRUD and debugging (`policy` command set)
+- Full audit trail of access decisions in a dedicated PostgreSQL table
+- Backward-compatible migration from `AccessControl` to `AccessPolicyEngine`
+- Default-deny posture with deny-overrides conflict resolution
+
+### Non-Goals
+
+- Graph-based relationship traversal (OpenFGA/Zanzibar-style) — relationships
+  are modeled as attributes
+- Priority-based policy ordering — deny always wins, no escalation
+- Real-time policy synchronization across multiple server instances
+  (single-server for now)
+- Web-based policy editor (admin commands cover MVP, web UI deferred)
+- Database triggers or stored procedures — all logic lives in Go
+
+### Key Design Decisions
+
+| Decision              | Choice                                  | Rationale                                                         |
+| --------------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| Engine                | Custom Go-native ABAC                   | Full control, no impedance mismatch, tight plugin integration     |
+| Policy language       | Cedar-inspired DSL                      | Readable by game admins, expressive, well-documented formal model |
+| Attribute resolution  | Eager (collect-then-evaluate)           | Simple, predictable, better audit story                           |
+| Conflict resolution   | Deny-overrides, no priority             | Simple mental model, Cedar-proven approach                        |
+| Property model        | First-class entities                    | Conceptual uniformity — everything is an entity                   |
+| Plugin attributes     | Registration-based providers            | Synchronous, consistent with eager resolution                     |
+| Audit logging         | Separate PostgreSQL table               | Clean separation from game events, independent retention          |
+| Migration             | New interface + adapter                 | Incremental caller migration, no big-bang change                  |
+| Cache invalidation    | PostgreSQL LISTEN/NOTIFY (in Go code)   | Push-based, no polling overhead                                   |
+| Player access control | Layered: metadata + locks + full policy | Progressive complexity for different user roles                   |
+
+## Architecture
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│                        AccessPolicyEngine                            │
+│                                                                      │
+│   Evaluate(ctx, AccessRequest) (Decision, error)                    │
+│                                                                      │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│   ┌─────────────────┐  ┌──────────────────┐  ┌─────────────────┐   │
+│   │ Policy Store     │  │ Attribute        │  │ Audit Logger    │   │
+│   │ (PostgreSQL)     │  │ Resolver         │  │ (PostgreSQL)    │   │
+│   │                  │  │                  │  │                 │   │
+│   │ - CRUD policies  │  │ - Core providers │  │ - Log denials   │   │
+│   │ - Version history│  │ - Plugin provs   │  │ - Optional      │   │
+│   │ - DSL text +     │  │ - Environment    │  │   allow logging │   │
+│   │   parsed form    │  │                  │  │ - Attr snapshot  │   │
+│   └─────────────────┘  └──────┬───────────┘  └─────────────────┘   │
+│                               │                                      │
+│                    ┌──────────┴───────────┐                          │
+│                    │  Attribute Providers  │                          │
+│                    ├──────────────────────┤                          │
+│                    │ CharacterProvider     │ ← World model            │
+│                    │ LocationProvider      │ ← World model            │
+│                    │ PropertyProvider      │ ← Property store         │
+│                    │ SessionProvider       │ ← Session store          │
+│                    │ EnvironmentProvider   │ ← Clock, game state      │
+│                    │ PluginProvider(s)     │ ← Registered by plugins  │
+│                    └──────────────────────┘                          │
+│                                                                      │
+├──────────────────────────────────────────────────────────────────────┤
+│   ┌──────────────────────────────────────┐                           │
+│   │ accessControlAdapter                  │                           │
+│   │ Wraps AccessPolicyEngine → old        │                           │
+│   │ AccessControl interface               │                           │
+│   │ (for incremental migration)           │                           │
+│   └──────────────────────────────────────┘                           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Request Flow
+
+1. Caller invokes `Evaluate(ctx, AccessRequest)` (or `Check()` via adapter)
+2. Engine resolves all attributes eagerly — calls core providers + registered
+   plugin providers
+3. Engine loads matching policies from the in-memory cache
+4. Engine evaluates each policy's conditions against the attribute bags
+5. Deny-overrides: any deny → deny, any allow → allow, default → deny
+6. Audit logger records the decision, matched policies, and attribute snapshot
+7. Returns `Decision` with allowed/denied, reason, and matched policy ID
+
+### Package Structure
+
+```text
+internal/access/               # Existing — keeps AccessControl interface + adapter
+internal/access/policy/        # NEW — AccessPolicyEngine, evaluation
+  engine.go                    # AccessPolicyEngine implementation
+  policy.go                    # Policy type, parsing, validation
+  dsl/                         # DSL parser and AST
+    parser.go
+    ast.go
+    evaluator.go
+  attribute/                   # Attribute resolution
+    resolver.go                # AttributeResolver orchestrates providers
+    provider.go                # AttributeProvider interface
+    character.go               # Core: character attributes
+    location.go                # Core: location attributes
+    property.go                # Core: property attributes
+    environment.go             # Core: env attributes (time, game state)
+  store/                       # Policy persistence
+    postgres.go                # Policy CRUD + versioning + LISTEN/NOTIFY
+  audit/                       # Audit logging
+    logger.go                  # Audit decision logger
+    postgres.go                # Audit table writes
+```
+
+## Core Interfaces
+
+### AccessPolicyEngine
+
+```go
+// AccessPolicyEngine is the main entry point for policy-based authorization.
+type AccessPolicyEngine interface {
+    Evaluate(ctx context.Context, request AccessRequest) (Decision, error)
+}
+```
+
+### AccessRequest
+
+```go
+// AccessRequest contains all information needed for an access decision.
+type AccessRequest struct {
+    Subject  string // "char:01ABC", "plugin:echo-bot", "system"
+    Action   string // "read", "write", "enter", "execute"
+    Resource string // "location:01XYZ", "command:dig", "property:01DEF"
+}
+```
+
+### Decision
+
+```go
+// Decision represents the outcome of a policy evaluation.
+type Decision struct {
+    Allowed    bool
+    Effect     Effect          // Allow, Deny, or DefaultDeny (no policy matched)
+    Reason     string          // Human-readable explanation
+    PolicyID   string          // ID of the determining policy ("" if default deny)
+    Policies   []PolicyMatch   // All policies that matched (for debugging)
+    Attributes *AttributeBags  // Snapshot of all resolved attributes
+}
+
+// Effect represents the type of decision.
+type Effect int
+
+const (
+    EffectDefaultDeny Effect = iota // No policy matched
+    EffectAllow
+    EffectDeny
+)
+
+// PolicyMatch records a single policy's evaluation result.
+type PolicyMatch struct {
+    PolicyID       string
+    PolicyName     string
+    Effect         Effect
+    ConditionsMet  bool
+}
+```
+
+### AttributeBags
+
+```go
+// AttributeBags holds the resolved attributes for a request.
+type AttributeBags struct {
+    Subject     map[string]any // e.g., {"type": "character", "faction": "rebels", "level": 7}
+    Resource    map[string]any // e.g., {"type": "location", "faction": "rebels", "restricted": true}
+    Action      map[string]any // e.g., {"name": "enter"}
+    Environment map[string]any // e.g., {"time": "2026-02-05T14:30:00Z"}
+}
+```
+
+### Attribute Providers
+
+```go
+// AttributeProvider resolves attributes for a specific namespace.
+type AttributeProvider interface {
+    Namespace() string
+    ResolveSubject(ctx context.Context, subjectType, subjectID string) (map[string]any, error)
+    ResolveResource(ctx context.Context, resourceType, resourceID string) (map[string]any, error)
+}
+
+// EnvironmentProvider resolves environment-level attributes (no entity context).
+type EnvironmentProvider interface {
+    Namespace() string
+    Resolve(ctx context.Context) (map[string]any, error)
+}
+```
+
+### Backward-Compatible Adapter
+
+```go
+// accessControlAdapter bridges AccessPolicyEngine to the legacy AccessControl interface.
+// Callers that need richer error handling SHOULD migrate to AccessPolicyEngine directly.
+type accessControlAdapter struct {
+    engine AccessPolicyEngine
+    logger *slog.Logger
+}
+
+func (a *accessControlAdapter) Check(ctx context.Context, subject, action, resource string) bool {
+    decision, err := a.engine.Evaluate(ctx, AccessRequest{
+        Subject: subject, Action: action, Resource: resource,
+    })
+    if err != nil {
+        a.logger.Error("access policy engine error", "error", err,
+            "subject", subject, "action", action, "resource", resource)
+        return false // fail-closed
+    }
+    return decision.Allowed
+}
+```
+
+## Policy DSL
+
+The DSL is Cedar-inspired with a full expression language. Policies have a
+**target** (what they apply to) and optional **conditions** (when they apply).
+
+### Grammar
+
+```text
+policy     = effect "(" target ")" [ "when" "{" conditions "}" ] ";"
+effect     = "permit" | "forbid"
+target     = principal_clause "," action_clause "," resource_clause
+principal_clause = "principal" [ "is" type_name ]
+action_clause    = "action" [ "in" list ]
+resource_clause  = "resource" [ "is" type_name ]
+
+conditions = condition { "&&" condition }
+           | conditions "||" conditions
+condition  = expr comparator expr
+           | expr "in" list
+           | expr "in" entity_ref
+           | expr "." "containsAll" "(" list ")"
+           | expr "." "containsAny" "(" list ")"
+           | expr "has" identifier
+           | "!" condition
+           | "(" conditions ")"
+           | "if" condition "then" condition "else" condition
+
+expr       = attribute_ref | literal | entity_ref
+attribute_ref = ("principal" | "resource" | "env") "." identifier { "." identifier }
+entity_ref = type_name "::" string_literal
+literal    = string | number | boolean
+list       = "[" literal { "," literal } "]"
+comparator = "==" | "!=" | ">" | ">=" | "<" | "<="
+type_name  = identifier
+```
+
+### Supported Operators
+
+| Operator       | Types            | Example                                                      |
+| -------------- | ---------------- | ------------------------------------------------------------ |
+| `==`, `!=`     | Any              | `principal.faction == resource.faction`                      |
+| `>`, `>=`      | Numbers          | `principal.level >= 5`                                       |
+| `<`, `<=`      | Numbers          | `principal.level < 10`                                       |
+| `in` (list)    | Value in list    | `action in ["read", "write"]`                                |
+| `in` (entity)  | Entity group     | `principal in Group::"admins"`                               |
+| `has`          | Attribute exists | `principal has faction`                                      |
+| `containsAll`  | Set: all present | `principal.flags.containsAll(["approved", "active"])`        |
+| `containsAny`  | Set: any present | `principal.flags.containsAny(["admin", "builder"])`          |
+| `if-then-else` | Conditional      | `if resource.restricted then principal.level >= 5 else true` |
+| `like`         | Glob match       | `resource.name like "faction-hq-*"`                          |
+| `&&`           | Boolean AND      | Conditions joined with AND                                   |
+| `\|\|`         | Boolean OR       | Grouped with parentheses                                     |
+| `!`            | Boolean NOT      | `!(principal.banned == true)`                                |
+
+### Example Policies
+
+```text
+// Players can read their own character
+permit(principal is character, action in ["read"], resource is character)
+when { principal.id == resource.id };
+
+// Characters can enter locations matching their faction
+permit(principal is character, action in ["enter"], resource is location)
+when { principal.faction == resource.faction };
+
+// Block entry to restricted locations for characters under level 5
+forbid(principal is character, action in ["enter"], resource is location)
+when { resource.restricted == true && principal.level < 5 };
+
+// Admins can do anything
+permit(principal is character, action, resource)
+when { principal.role == "admin" };
+
+// Block all access during maintenance
+forbid(principal, action, resource)
+when { env.maintenance == true };
+
+// Healers can view wound properties on any character
+permit(principal is character, action in ["read"], resource is property)
+when {
+    resource.name == "wounds"
+    && principal.flags.containsAny(["healer"])
+};
+
+// Characters can read their own properties except system/admin ones
+permit(principal is character, action in ["read"], resource is property)
+when { resource.parent_type == "character" && resource.parent_id == principal.id };
+
+forbid(principal is character, action in ["read"], resource is property)
+when { resource.visibility in ["system", "admin"] && principal.role != "admin" };
+
+// Properties with visible_to lists: only listed characters can read
+permit(principal is character, action in ["read"], resource is property)
+when {
+    resource has visible_to
+    && principal.id in resource.visible_to
+};
+
+// Exclude specific characters from seeing a property
+forbid(principal is character, action in ["read"], resource is property)
+when {
+    resource has excluded_from
+    && principal.id in resource.excluded_from
+};
+
+// Plugin: echo-bot can emit to location streams
+permit(principal is plugin, action in ["emit"], resource is stream)
+when { principal.name == "echo-bot" && resource.name like "location:*" };
+```
+
+## Property Model
+
+Properties are first-class entities with their own identity, ownership, and
+access control attributes. This provides conceptual uniformity — characters,
+locations, objects, and properties are all entities that the policy engine
+evaluates against using the same interface.
+
+### Property Attributes
+
+| Attribute       | Type     | Description                                              |
+| --------------- | -------- | -------------------------------------------------------- |
+| `id`            | ULID     | Unique property identifier                               |
+| `parent_type`   | string   | Parent entity type: character, location, object          |
+| `parent_id`     | ULID     | Parent entity ID                                         |
+| `name`          | string   | Property name (unique per parent)                        |
+| `value`         | string   | Property value                                           |
+| `owner`         | string   | Subject who created/set this property                    |
+| `visibility`    | string   | Access level: public, private, restricted, system, admin |
+| `flags`         | []string | Arbitrary flags (JSON array)                             |
+| `visible_to`    | []string | Character IDs allowed to read (restricted visibility)    |
+| `excluded_from` | []string | Character IDs denied from reading                        |
+
+### Visibility Levels
+
+| Visibility   | Who can see?        | visible_to/excluded_from |
+| ------------ | ------------------- | ------------------------ |
+| `public`     | Anyone in same room | Not applicable (NULL)    |
+| `private`    | Owner only          | Not applicable (NULL)    |
+| `restricted` | Explicit list       | Defaults: [self], []     |
+| `system`     | System only         | Not applicable (NULL)    |
+| `admin`      | Admins only         | Not applicable (NULL)    |
+
+When visibility is set to `restricted`, the Go property store MUST auto-populate
+`visible_to` with `[parent_id]` and `excluded_from` with `[]` if they are nil.
+This prevents the "nobody can see it" footgun.
+
+## Attribute Resolution
+
+The engine uses eager resolution: all attributes are collected before any policy
+is evaluated. This provides a complete attribute snapshot for every decision,
+which powers audit logging and the `policy test` debugging command.
+
+### Resolution Flow
+
+```text
+Evaluate(ctx, AccessRequest{Subject: "char:01ABC", Action: "enter", Resource: "location:01XYZ"})
+
+1. Parse subject → type="character", id="01ABC"
+2. Parse resource → type="location", id="01XYZ"
+3. Resolve subject attributes:
+   CharacterProvider.ResolveSubject("character", "01ABC")
+     → {type: "character", id: "01ABC", faction: "rebels", level: 7, role: "player"}
+   PluginProvider("reputation").ResolveSubject("character", "01ABC")
+     → {reputation.score: 85}
+4. Resolve resource attributes:
+   LocationProvider.ResolveResource("location", "01XYZ")
+     → {type: "location", id: "01XYZ", faction: "rebels", restricted: true}
+5. Resolve environment attributes:
+   EnvironmentProvider.Resolve()
+     → {time: "2026-02-05T14:30:00Z", maintenance: false}
+6. Assemble AttributeBags and proceed to policy evaluation
+```
+
+### Provider Registration
+
+Plugins register attribute providers at startup. The engine calls all registered
+providers during eager resolution. Provider namespaces MUST be unique to prevent
+collisions.
+
+```go
+engine.RegisterAttributeProvider(reputationProvider)
+engine.RegisterEnvironmentProvider(weatherProvider)
+```
+
+### Error Handling
+
+- If a core provider returns an error, the engine returns `Decision{error}`
+  rather than silently denying. The adapter translates this to `false` with a
+  log, but direct callers can distinguish "denied" from "broken."
+- If a plugin provider returns an error, the engine logs a warning and continues
+  with the remaining providers. Plugin failures SHOULD NOT block access
+  decisions.
+
+## Evaluation Algorithm
+
+```text
+Evaluate(ctx, AccessRequest{Subject, Action, Resource})
+│
+├─ 1. System bypass
+│    subject == "system" → return Decision{Allowed: true, Effect: Allow}
+│
+├─ 2. Resolve attributes (eager)
+│    ├─ Parse subject type/ID from subject string
+│    ├─ Parse resource type/ID from resource string
+│    ├─ Call all registered AttributeProviders
+│    └─ Assemble AttributeBags{Subject, Resource, Action, Environment}
+│
+├─ 3. Find applicable policies
+│    ├─ Load from in-memory cache
+│    └─ Filter: policy target matches request
+│         ├─ principal type matches subject type (or unscoped)
+│         ├─ action matches (or unscoped)
+│         └─ resource type matches resource type (or unscoped)
+│
+├─ 4. Evaluate conditions
+│    For each candidate policy:
+│    ├─ Evaluate DSL conditions against AttributeBags
+│    ├─ If all conditions true → policy is "satisfied"
+│    └─ If any condition false or attribute missing → policy does not apply
+│
+├─ 5. Combine decisions (deny-overrides)
+│    ├─ Any satisfied forbid → Decision{Allowed: false, Effect: Deny}
+│    ├─ Any satisfied permit → Decision{Allowed: true, Effect: Allow}
+│    └─ No policies satisfied → Decision{Allowed: false, Effect: DefaultDeny}
+│
+└─ 6. Audit
+     ├─ Always log denials (forbid + default deny)
+     ├─ Log allows when audit mode is enabled
+     └─ Include: decision, matched policies, attribute snapshot
+```
+
+### Key Behaviors
+
+- **Missing attributes:** If a condition references an attribute that does not
+  exist, the condition evaluates to `false`. A missing attribute can never grant
+  access (fail-safe).
+- **No short-circuit:** The engine evaluates all candidate policies so the
+  `Decision` records all matches. This powers `policy test` debugging.
+- **Cache invalidation:** The engine subscribes to PostgreSQL LISTEN/NOTIFY on
+  the `policy_changed` channel. The Go policy store calls `pg_notify` after any
+  Create/Update/Delete operation. On notification, the engine reloads all enabled
+  policies before the next evaluation.
+
+## Policy Storage
+
+### Schema
+
+```sql
+CREATE TABLE access_policies (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    description TEXT,
+    effect      TEXT NOT NULL,
+    dsl_text    TEXT NOT NULL,
+    enabled     BOOLEAN NOT NULL DEFAULT true,
+    created_by  TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version     INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE access_policy_versions (
+    id          TEXT PRIMARY KEY,
+    policy_id   TEXT NOT NULL REFERENCES access_policies(id) ON DELETE CASCADE,
+    version     INTEGER NOT NULL,
+    dsl_text    TEXT NOT NULL,
+    changed_by  TEXT NOT NULL,
+    changed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    change_note TEXT,
+    UNIQUE(policy_id, version)
+);
+
+CREATE TABLE access_audit_log (
+    id            TEXT PRIMARY KEY,
+    timestamp     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    subject       TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    resource      TEXT NOT NULL,
+    decision      TEXT NOT NULL,
+    effect        TEXT NOT NULL,
+    policy_id     TEXT,
+    policy_name   TEXT,
+    attributes    JSONB,
+    error_message TEXT
+);
+
+CREATE INDEX idx_audit_log_timestamp ON access_audit_log(timestamp DESC);
+CREATE INDEX idx_audit_log_subject ON access_audit_log(subject, timestamp DESC);
+CREATE INDEX idx_audit_log_decision ON access_audit_log(decision, timestamp DESC);
+
+CREATE TABLE entity_properties (
+    id            TEXT PRIMARY KEY,
+    parent_type   TEXT NOT NULL,
+    parent_id     TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    value         TEXT,
+    owner         TEXT,
+    visibility    TEXT NOT NULL DEFAULT 'public',
+    flags         JSONB DEFAULT '[]',
+    visible_to    JSONB DEFAULT NULL,
+    excluded_from JSONB DEFAULT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(parent_type, parent_id, name)
+);
+
+CREATE INDEX idx_properties_parent ON entity_properties(parent_type, parent_id);
+```
+
+### Cache Invalidation
+
+The Go policy store sends `pg_notify('policy_changed', policyID)` in the same
+transaction as any policy CRUD operation. The engine subscribes to this channel
+and reloads its in-memory policy cache on notification. No database triggers are
+used — all notification logic lives in Go application code.
+
+### Visibility Defaults
+
+When the Go property store sets visibility to `restricted`, it MUST populate
+`visible_to` with `[parent_id]` and `excluded_from` with `[]` if they are nil.
+When visibility is changed away from `restricted`, it MUST set both fields to
+NULL. This logic lives in the Go store layer, not in database triggers.
+
+## Access Control Layers
+
+HoloMUSH provides three layers of access control, offering progressive
+complexity for different user roles.
+
+### Layer 1: Property Metadata (All Characters)
+
+Characters set visibility and access lists on properties they own. No policy
+authoring required — the character configures data that existing system-level
+policies evaluate.
+
+```text
+> set me/secret_background.visibility = private
+> set me/wounds.visibility = restricted
+> set me/wounds.visible_to += char:01AAA
+> set me/wounds.excluded_from += me
+```
+
+### Layer 2: Object Locks (Owners)
+
+Owners can set conditions on their owned objects and properties using a
+simplified lock syntax. Locks compile to scoped policies behind the scenes.
+
+```text
+> lock my-chest/read = faction:rebels
+> lock me/backstory/read = me | flag:storyteller
+> lock here/enter = level>=5 & !flag:banned
+> unlock my-chest/read
+```
+
+**Lock syntax:**
+
+| Token        | Meaning                       |
+| ------------ | ----------------------------- |
+| `faction:X`  | Character faction equals X    |
+| `flag:X`     | Character has flag X          |
+| `level>=N`   | Character level is at least N |
+| `me`         | The owning character (self)   |
+| `&`          | AND                           |
+| `\|`         | OR                            |
+| `!`          | NOT                           |
+| Char name/ID | Specific character reference  |
+
+**Ownership constraint:** Lock-generated policies can ONLY target resources the
+character owns. The lock command MUST verify ownership before creating the
+policy. A character can never write a lock that affects another player's
+resources.
+
+### Layer 3: Full Policies (Admin Only)
+
+The full DSL with unrestricted scope, managed via the `policy` command set.
+
+### Layer Interaction
+
+| Layer             | Who             | Scope          | Deny-overrides? |
+| ----------------- | --------------- | -------------- | --------------- |
+| Property metadata | All characters  | Own properties | Yes             |
+| Object locks      | Resource owners | Own resources  | Yes             |
+| Full policies     | Admins          | Everything     | Top authority   |
+
+Admin `forbid` policies always trump player locks. Players operate within the
+boundaries admins set.
+
+## Admin Commands
+
+### Policy Management
+
+```text
+policy list [--enabled|--disabled] [--effect=permit|forbid]
+policy show <name>
+policy create <name>
+policy edit <name>
+policy delete <name>
+policy enable <name>
+policy disable <name>
+policy test <subject> <action> <resource> [--verbose]
+policy history <name> [--limit=N]
+policy audit [--subject=X] [--action=Y] [--decision=denied] [--last=1h]
+```
+
+### policy create
+
+Accepts multiline DSL input terminated by `.` on a line by itself. Validates DSL
+syntax before saving — rejects errors with line/column information.
+
+```text
+> policy create faction-hq-access
+Enter policy (end with '.' on a line by itself):
+permit(principal is character, action in ["enter", "look"], resource is location)
+when { principal.faction == resource.faction && resource.restricted == true };
+.
+Policy 'faction-hq-access' created (version 1).
+```
+
+### policy test
+
+Dry-run evaluation showing resolved attributes, matching policies, and the
+final decision. Available to admins and builders (for debugging builds).
+
+```text
+> policy test char:01ABC enter location:01XYZ --verbose
+Subject attributes:
+  type=character, id=01ABC, faction=rebels, level=7, role=player
+Resource attributes:
+  type=location, id=01XYZ, faction=empire, restricted=true
+Environment:
+  time=2026-02-05T14:30:00Z, maintenance=false
+
+Evaluating 3 matching policies:
+  faction-hq-access    permit  CONDITIONS FAILED (rebels != empire)
+  maintenance-lockout  forbid  CONDITIONS FAILED (maintenance=false)
+  level-gate           forbid  CONDITIONS FAILED (level 7 >= 5)
+
+Decision: DENIED (default deny — no policies matched)
+```
+
+### Command Permissions
+
+```text
+permit(principal is character, action in ["execute"], resource is command)
+when { principal.role == "admin" && resource.name like "policy*" };
+
+permit(principal is character, action in ["execute"], resource is command)
+when { principal.role == "builder" && resource.name == "policy test" };
+```
+
+## Migration from Static Roles
+
+### Seed Policies
+
+The current static role permissions translate to seed policies:
+
+```text
+// player-powers: self access
+permit(principal is character, action in ["read", "write"], resource is character)
+when { resource.id == principal.id };
+
+// player-powers: current location access
+permit(principal is character, action in ["read"], resource is location)
+when { resource.id == principal.location };
+
+permit(principal is character, action in ["read"], resource is character)
+when { resource.location == principal.location };
+
+permit(principal is character, action in ["read"], resource is object)
+when { resource.location == principal.location };
+
+permit(principal is character, action in ["emit"], resource is stream)
+when { resource.name like "location:*" && resource.location == principal.location };
+
+// player-powers: basic commands
+permit(principal is character, action in ["execute"], resource is command)
+when { resource.name in ["say", "pose", "look", "go"] };
+
+// builder-powers
+permit(principal is character, action in ["write", "delete"], resource is location)
+when { principal.role in ["builder", "admin"] };
+
+permit(principal is character, action in ["write", "delete"], resource is object)
+when { principal.role in ["builder", "admin"] };
+
+permit(principal is character, action in ["execute"], resource is command)
+when { principal.role in ["builder", "admin"]
+    && resource.name in ["dig", "create", "describe", "link"] };
+
+// admin-powers: full access
+permit(principal is character, action, resource)
+when { principal.role == "admin" };
+```
+
+### Migration Strategy
+
+1. **Phase 7.1 (Policy Schema):** Create DB tables and policy store. Seed with
+   the translated policies above. `StaticAccessControl` continues to serve all
+   checks.
+
+2. **Phase 7.3 (Policy Engine):** Build `AccessPolicyEngine` and wrap with
+   adapter. Swap the adapter into dependency injection where
+   `StaticAccessControl` was. Both implementations exist — the adapter now serves
+   checks backed by seed policies.
+
+3. **Shadow mode validation:** Run both engines in parallel during testing.
+   Evaluate with both, log disagreements, fix policy gaps. Remove
+   `StaticAccessControl` once 100% agreement is confirmed.
+
+4. **Caller migration (holomush-c6qch):** Callers incrementally migrate from
+   `AccessControl.Check()` to `AccessPolicyEngine.Evaluate()` for richer error
+   handling.
+
+### Plugin Capability Migration
+
+The current `capability.Enforcer` handles plugin permissions separately. Under
+ABAC, plugin manifests become seed policies. The Enforcer becomes unnecessary
+once all plugin capabilities are expressed as policies and can be removed
+alongside `StaticAccessControl`.
+
+## Testing Strategy
+
+### Unit Tests
+
+```text
+internal/access/policy/dsl/
+  parser_test.go        — Parse valid/invalid DSL, verify AST
+  evaluator_test.go     — Evaluate conditions against attribute bags
+                          Table-driven: each operator, edge cases,
+                          missing attributes, type mismatches
+
+internal/access/policy/
+  engine_test.go        — Full evaluation flow with mock providers
+                          System bypass, deny-overrides, default deny,
+                          provider errors, cache invalidation
+
+internal/access/policy/attribute/
+  resolver_test.go      — Orchestrates multiple providers
+  character_test.go     — Resolves character attrs from mock world service
+  location_test.go      — Resolves location attrs from mock world service
+  property_test.go      — Resolves property attrs including visibility/lists
+  environment_test.go   — Time, maintenance mode, game state
+
+internal/access/policy/store/
+  postgres_test.go      — CRUD, versioning, LISTEN/NOTIFY dispatch
+
+internal/access/policy/audit/
+  logger_test.go        — Logs denials, optional allows, attribute snapshots
+
+internal/access/
+  adapter_test.go       — Adapter wraps engine, fail-closed on error
+```
+
+### DSL Evaluator Coverage
+
+Table-driven tests MUST cover every operator with valid inputs, invalid inputs,
+missing attributes, and type mismatches.
+
+### Integration Tests (Ginkgo/Gomega)
+
+```go
+Describe("AccessPolicyEngine", func() {
+    Describe("Policy evaluation with real PostgreSQL", func() {
+        It("denies by default when no policies exist", func() { ... })
+        It("allows when a permit policy matches", func() { ... })
+        It("deny overrides permit", func() { ... })
+        It("resolves character attributes from world model", func() { ... })
+        It("handles property visibility with visible_to lists", func() { ... })
+        It("plugin attribute providers contribute to evaluation", func() { ... })
+    })
+
+    Describe("Lock-generated policies", func() {
+        It("creates a scoped policy from lock syntax", func() { ... })
+        It("rejects locks on unowned resources", func() { ... })
+        It("admin forbid overrides player lock permit", func() { ... })
+    })
+
+    Describe("Shadow mode migration", func() {
+        It("StaticAccessControl and AccessPolicyEngine agree on seed policies", func() { ... })
+    })
+
+    Describe("Cache invalidation via LISTEN/NOTIFY", func() {
+        It("reloads policies when notification received", func() { ... })
+    })
+})
+```
+
+### Shadow Mode Validation
+
+During migration, a test harness runs both `StaticAccessControl` and
+`AccessPolicyEngine` against the same requests and asserts identical results.
+This confirms the seed policies faithfully reproduce the static role behavior.
+
+## Acceptance Criteria
+
+- [ ] ABAC policy data model documented (subjects, resources, actions, conditions)
+- [ ] Attribute schema defined for subjects (players, plugins, connections)
+- [ ] Attribute schema defined for resources (objects, rooms, commands, properties)
+- [ ] Environment attributes defined (time, location, game state)
+- [ ] Policy DSL grammar specified with full expression language
+- [ ] Policy storage format designed (PostgreSQL schema with versioning)
+- [ ] Policy evaluation algorithm documented (deny-overrides, no priority)
+- [ ] Audit event schema defined for access decisions
+- [ ] Plugin attribute contribution interface designed (registration-based)
+- [ ] Admin commands documented for policy management
+- [ ] Player lock system designed for owned resource access control
+- [ ] Property model designed as first-class entities
+- [ ] Migration path documented from static permissions to full ABAC
+
+## References
+
+- [Core Access Control Design](2026-01-21-access-control-design.md) — Current
+  static role implementation (Epic 3)
+- [HoloMUSH Roadmap](../plans/2026-01-18-holomush-roadmap-design.md) — Epic 7
+  definition
+- [Cedar Language Specification](https://docs.cedarpolicy.com/) — DSL inspiration
+- [Commands & Behaviors Design](2026-02-02-commands-behaviors-design.md) —
+  Command system integration

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1215,9 +1215,12 @@ The audit log records the `error_message` field for these cases.
 **Plugin provider errors:** The engine logs an error via slog and continues
 evaluation with the remaining providers. Missing plugin attributes cause
 conditions referencing them to evaluate to `false` (fail-safe). The audit log
-records plugin provider errors in a `provider_errors` JSONB field (structured
-as `[{"provider": "reputation", "error": "connection refused"}]`) to aid
-debugging "why was I denied?" investigations. Logging is rate-limited to 1
+records plugin provider errors in a `provider_errors` JSONB field to aid
+debugging "why was I denied?" investigations. The field is an array of error
+objects with schema: `[{"namespace": "string", "error": "string", "timestamp":
+"RFC3339", "duration_us": "int"}]`. For example:
+`[{"namespace": "reputation", "error": "connection refused", "timestamp":
+"2026-02-06T12:00:00Z", "duration_us": 1500}]`. Logging is rate-limited to 1
 error per minute per `(namespace, error_hash)` tuple to control spam while
 preserving visibility of distinct failure modes. If a provider has two
 different error types (e.g., DB timeout and network error), both are logged
@@ -1456,7 +1459,7 @@ expire regardless of what the current provider is doing.
 - Export a Prometheus histogram metric for `Evaluate()` latency
   (e.g., `abac_evaluate_duration_seconds`)
 - Add `BenchmarkEvaluate_*` tests with targets as failure thresholds (CI
-  fails if benchmarks regress >20% from baseline)
+  fails if benchmarks regress >10% from baseline)
 - Staging monitoring alerts on p99 > 10ms (2x target)
 - Implementation SHOULD add `slog.Debug()` timers in `engine.Evaluate()` for
   attribute resolution, policy filtering, condition evaluation, and audit

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1204,13 +1204,13 @@ The repository determines the resolution strategy based on `parent_type`:
     corruption), `parent_location` is nil and location-based visibility
     policies fail-safe (deny).
 
-  The recursive CTE **MUST** include both a depth limit of **10 iterations**
+  The recursive CTE **MUST** include both a depth limit of **20 iterations**
   and cycle detection (tracking visited IDs via an array path column,
   rejecting IDs already in the path) as defense-in-depth against data
   corruption. PostgreSQL `WITH RECURSIVE` does not automatically prevent
   cycles. If cycles are detected or the depth limit is exceeded,
   `parent_location` is nil and location-based visibility policies fail-safe
-  (deny). A 10-level nesting limit is sufficient for typical object
+  (deny). A 20-level nesting limit is sufficient for typical object
   containment hierarchies (e.g., gem → lockbox → drawer → chest → room)
   while preventing excessive query complexity.
 

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2960,6 +2960,10 @@ the policy was customized and the update is skipped with a warning.
 
 ```go
 // 2026-02-10-fix-player-self-access.go
+// NOTE: This is a hypothetical version 1→2 migration example.
+// The current seed policy already includes both "read" and "write" actions.
+// This example shows how a migration would add "write" if upgrading from
+// a hypothetical v1 that only had "read".
 func up(ctx context.Context, store PolicyStore) error {
     oldDSL := `permit(principal is character, action in ["read"], resource is character)
 when { resource.id == principal.id };`

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1526,8 +1526,8 @@ objects with schema: `[{"namespace": "string", "error": "string", "timestamp":
 error per minute per `(namespace, error_hash)` tuple to control spam while
 preserving visibility of distinct failure modes. If a provider has two
 different error types (e.g., DB timeout and network error), both are logged
-independently. The rate limiter uses a bounded LRU cache keyed by namespace
-and error message hash.
+independently. The rate limiter uses a bounded LRU cache (capacity: 256 entries,
+per-engine-instance, in-memory) keyed by namespace and error message hash.
 
 ```text
 slog.Error("plugin attribute provider failed",

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -481,10 +481,14 @@ AttributeBags.Action = map[string]any{
 }
 ```
 
-**Note:** The action bag currently contains only `name`. Conditions
-referencing any other `action.*` attribute will evaluate to `false` (missing
-attribute, fail-safe). Future attributes (e.g., `action.type`,
-`action.scope`) MAY be added when use cases emerge.
+**Note:** The action bag currently contains only `name`. The
+`PolicyCompiler` MUST reject policies referencing unregistered `action.*`
+attributes (e.g., `action.type`, `action.scope`) at compile time — the
+attribute schema registry defines the complete set of valid attributes. The
+runtime fail-safe behavior (conditions on missing attributes evaluate to
+`false`) serves as defense-in-depth but is not expected to trigger for
+`action.*` attributes in production. Future attributes MAY be added by
+registering them in the action schema when use cases emerge.
 
 ### Attribute Providers
 

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2747,6 +2747,20 @@ Error at line 2, column 27: expected expression after '>='
 
 ### policy test
 
+**Usage:**
+
+```text
+policy test <subject> <action> <resource> [--verbose] [--json]
+```
+
+**Parameters:**
+
+- `<subject>` — Subject entity reference (e.g., `character:01ABC`)
+- `<action>` — Action to test (e.g., `enter`, `read`, `write`)
+- `<resource>` — Resource entity reference (e.g., `location:01XYZ`)
+- `--verbose` — Show detailed condition evaluation for all policies
+- `--json` — Output structured JSON instead of human-readable text
+
 Dry-run evaluation showing resolved attributes, matching policies, and the
 final decision. Available to admins and builders (for debugging builds).
 

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -3384,6 +3384,21 @@ location resolution, not strict snapshot consistency. Authorization decisions
 reflect a consistent view within each provider's transaction, but not
 necessarily across all providers involved in a single `Evaluate()` call.
 
+### Attribute Schema Versioning
+
+Plugins that change attribute types (e.g., `reputation.score` from number to
+string) could silently break existing policies. Full schema versioning—where
+policies declare minimum schema versions and the engine enforces
+compatibility—would prevent this.
+
+**Deferred to future iteration.** The existing schema evolution infrastructure
+(registration-time validation, reload-time schema comparison, runtime warnings
+for unregistered attributes) is sufficient for MVP. With few plugins and active
+development, type changes trigger immediate warnings visible to operators.
+Manual policy updates are acceptable at this scale. Policy-level schema version
+pinning adds complexity without proportional benefit until the plugin ecosystem
+grows.
+
 ## Acceptance Criteria
 
 - [ ] ABAC policy data model documented (subjects, resources, actions, conditions)

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2778,6 +2778,16 @@ customizations to seed policies (via `policy edit`) but prevents automatic
 security patching. Operators using this flag **MUST** manually track seed
 policy updates and apply fixes via `policy edit` or explicit migrations.
 
+**Rollback mechanism:** If a buggy seed policy locks out admins (e.g., by
+removing `execute` permission on `command:policy*` required to edit policies),
+operators **MAY** use the `--force-seed-version=N` startup flag to force
+downgrade to a specific seed version. The bootstrap process treats this flag
+as the "current" shipped version and downgrades stored policies if their
+`seed_version > N`. Emergency recovery SQL: `UPDATE access_policies SET enabled = false WHERE source = 'seed' AND seed_version > N;` disables all seed
+policies newer than version N, allowing manual fix via `policy edit`. Operators
+**SHOULD** test seed policy changes in staging environments before deploying to
+production to avoid lockout scenarios.
+
 **Version mismatch detection:** The `policy seed status` admin command
 compares installed seed policies against shipped seed definitions and
 reports version discrepancies. Example output:

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -195,11 +195,12 @@ type PolicyCompiler struct {
 // Returns a descriptive error with line/column information on parse failure.
 // Validation warnings are returned for:
 // - Unknown attributes (schema evolves over time)
-// - Bare boolean expressions (recommend explicit `== true`)
 // - Unreachable conditions (e.g., `false && ...`)
 // - Always-true conditions (e.g., `principal.level >= 0`)
 // - Redundant sub-conditions
 // Warnings do not block creation.
+// Compile errors are returned for:
+// - Bare boolean attribute references (use explicit `== true` instead)
 func (c *PolicyCompiler) Compile(dslText string) (*CompiledPolicy, []ValidationWarning, error)
 
 // CompiledPolicy is the parsed, validated, and optimized form of a policy.
@@ -890,12 +891,11 @@ fixed using `policy lint --fix`, which rewrites bare attributes as
   participate in evaluation. Alternatively, use an impossible condition (e.g.,
   `when { false }`) to keep a policy visible but inactive.
 - **Bare boolean expressions:** The `| expr` alternative in `condition` allows
-  bare `true`, `false`, or boolean attribute references as conditions. This is
-  required for the `else true` pattern in `if-then-else` expressions. Bare
-  boolean attributes (e.g., `resource.restricted`) are equivalent to
-  `resource.restricted == true` — both forms are valid. If a bare expression
-  resolves to a non-boolean value, the condition evaluates to `false`
-  (fail-safe).
+  bare boolean literals (`true`, `false`) as conditions. This is required for
+  the `else true` pattern in `if-then-else` expressions and for disabled
+  policies (e.g., `when { false }`). Bare boolean attribute references are NOT
+  permitted — see **Bare boolean restriction** in the grammar section for
+  rationale and enforcement.
 - **Future: target-level parent type matching.** Property policies frequently
   filter by `resource.parent_type` in conditions (e.g.,
   `when { resource.parent_type == "character" }`). A future grammar extension

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -24,7 +24,7 @@ Players control access to their own properties through a simplified lock system.
 - Player-authored locks for owned resources (simplified policy syntax)
 - In-game admin commands for policy CRUD and debugging (`policy` command set)
 - Configurable audit logging with mode control (off, denials-only, all)
-- Direct replacement of `AccessControl` with `AccessPolicyEngine` across all
+- Direct replacement of `AccessControl` with `AccessPolicyEngine` across ~30
   call sites (greenfield deployment — no backward-compatibility adapter)
 - Default-deny posture with deny-overrides conflict resolution
 
@@ -2940,7 +2940,7 @@ before/after diffs and a human-readable change note.
 **Migration testing requirements:** Each seed policy **MUST** have an
 integration test suite with at least three scenarios: allowed operation,
 denied operation, and edge case (e.g., missing attribute, boundary condition).
-Direct replacement of ~29 call sites without shadow mode creates migration
+Direct replacement of ~30 call sites without shadow mode creates migration
 risk — a single seed policy bug can cause platform-wide authorization
 failures. No call site migration **MAY** proceed without passing integration
 tests for all affected seed policies. Coverage target: 100% of seed policies
@@ -3042,6 +3042,7 @@ skips customized seeds and logs the appropriate warning.
 | `internal/world/service`                 | World model operation authorization |
 | `internal/plugin/hostfunc/commands`      | Plugin command execution auth       |
 | `internal/plugin/hostfunc/functions`     | Plugin host function auth           |
+| `internal/access/static.go`              | Static evaluator checks             |
 | `internal/core/broadcaster` (test)       | Test mock injection                 |
 
 This list is derived from the current codebase. Run `grep -r "AccessControl"

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2049,9 +2049,10 @@ fraction of this (most checks result in allows). The 7-day allow retention
 and 24-hour purge interval are important to enforce in `all` mode to prevent
 unbounded growth.
 
-**System bypass auditing:** When audit mode is `all`, system subject bypasses
-SHOULD also be logged with `effect = "system_bypass"` to provide a complete
-audit trail. In `denials_only` mode, system bypasses are not logged.
+**System bypass auditing:** System subject bypasses **MUST** be logged with
+`effect = "system_bypass"` in **all** audit modes (`all`, `denials_only`, and
+`off`). This ensures bugs or compromised system contexts are never invisible in
+the audit trail, regardless of the configured audit mode.
 
 **Synchronous denial audits:** Denial events (`deny` and `default_deny`) **MUST**
 be written synchronously to PostgreSQL before `Evaluate()` returns. This prevents

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -792,7 +792,9 @@ from the grammar alone whether this is a bare boolean expression or the start of
 after parsing an `expr`, if the next token is a comparator (`==`, `!=`, `>`,
 `>=`, `<`, `<=`), `in`, `like`, `has`, or `.` followed by `containsAll`/
 `containsAny`, treat it as the corresponding compound condition; otherwise treat
-it as a bare boolean. This makes the grammar LL(1) at the implementation level.
+it as a bare boolean. This makes the grammar LL(1) at the logical design level.
+**Implementation note:** See Decision #41 for how participle's PEG ordered-choice
+semantics achieve the same disambiguation effect.
 
 **Bare boolean restriction:** The compiler MUST reject bare boolean attribute
 references in `when` clauses, requiring explicit comparison operators. Bare
@@ -3019,8 +3021,13 @@ skips customized seeds and logs the appropriate warning.
    `goyacc` (requires separate `.y` grammar file and manual AST mapping) and
    hand-rolled recursive descent (more code, harder to maintain) because its
    struct-tag approach generates Go AST structs directly from grammar
-   annotations, eliminating the mapping layer. Mandate fuzz testing for all
-   parser entry points. Unit test with table-driven tests.
+   annotations, eliminating the mapping layer. **Note:** Decision #41 specifies
+   LL(1) disambiguation as the grammar design intent (one-token lookahead to
+   resolve ambiguities). Participle uses PEG-style ordered-choice semantics
+   which achieve the same disambiguation effect — the first matching alternative
+   is selected. Implementers MUST verify disambiguation behavior with test cases
+   regardless of parser choice. Mandate fuzz testing for all parser entry
+   points. Unit test with table-driven tests.
 
 3. **Phase 7.3 (Policy Engine):** Build `AccessPolicyEngine`, attribute
    providers, and audit logger. Replace `AccessControl` with

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -781,9 +781,9 @@ unambiguous.
   - `"*:01ABC"` matches `"location:01ABC"` — prefix wildcard
   - `"*:01ABC"` does NOT match `"character:01ABC"` if the resource string
     has additional segments (it does match here because there is no second `:`)
-  The DSL evaluator tests **MUST** verify this separator behavior explicitly,
-  including edge cases with current single-segment and potential future
-  multi-segment resource formats.
+    The DSL evaluator tests **MUST** verify this separator behavior explicitly,
+    including edge cases with current single-segment and potential future
+    multi-segment resource formats.
 - `action` is a valid attribute root in conditions, providing access to the
   `AttributeBags.Action` map (e.g., `action.name`). Action matching in the
   target clause covers most use cases, but conditions MAY reference action
@@ -1219,11 +1219,11 @@ This provides aggregate visibility into chronic provider failures that
 individual log entries cannot. Implementation **SHOULD** include a circuit
 breaker per provider with the following parameters:
 
-| Parameter          | Default | Description                             |
-| ------------------ | ------- | --------------------------------------- |
-| Failure threshold  | 10      | Consecutive errors to open the circuit  |
-| Open duration      | 30s     | Time to skip provider while circuit open|
-| Half-open attempts | 1       | Single probe request to test recovery   |
+| Parameter          | Default | Description                              |
+| ------------------ | ------- | ---------------------------------------- |
+| Failure threshold  | 10      | Consecutive errors to open the circuit   |
+| Open duration      | 30s     | Time to skip provider while circuit open |
+| Half-open attempts | 1       | Single probe request to test recovery    |
 
 When the circuit opens, the engine logs at WARN level with the provider
 namespace and failure count. During the open period, the provider is

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1457,6 +1457,8 @@ persists until administratively cleared. In degraded mode:
   evaluating any policies (fail-closed for all subjects)
 - The CRITICAL log entry **MUST** include the policy name, effect, and
   degraded mode activation message
+- All deny decisions during degraded mode **MUST** be audited with the reason
+  `degraded_mode` to ensure forensic visibility
 - A Prometheus gauge `abac_degraded_mode` (0=normal, 1=degraded) **MUST**
   be exposed for alerting
 - Administrators **MUST** use CLI access or direct database access to
@@ -1469,6 +1471,11 @@ degraded mode flag and allows normal evaluation to resume. Operators
 `abac_degraded_mode` gauge. Policies with effect `permit` do **not**
 trigger degraded mode when corrupted, as skipping a permit policy defaults
 to deny, which is fail-safe.
+
+**Future work:** The current seed policy `seed:admin-full-access` grants
+unrestricted access. A future iteration **SHOULD** split admin privileges
+into scoped roles (e.g., `admin:policy`, `admin:world`, `admin:player`)
+rather than a blanket admin role, reducing risk from compromised credentials.
 
 Callers of `AccessPolicyEngine.Evaluate()` can distinguish "denied by
 policy" (`err == nil, Decision.Effect == EffectDeny`) from "system failure"

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -778,7 +778,7 @@ when { principal.role in ["builder", "admin"] };
 
 permit(principal is character, action in ["execute"], resource is command)
 when { principal.role in ["builder", "admin"]
-    && resource.name in ["@dig", "@create", "@describe", "@link"] };
+    && resource.name in ["dig", "create", "describe", "link"] };
 
 // admin-powers: full access
 permit(principal is character, action, resource)

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2909,6 +2909,15 @@ mechanisms:
 Seed policy fixes **SHOULD** be shipped as explicit migration files with
 before/after diffs and a human-readable change note.
 
+**Migration testing requirements:** Each seed policy **MUST** have an
+integration test suite with at least three scenarios: allowed operation,
+denied operation, and edge case (e.g., missing attribute, boundary condition).
+Direct replacement of ~29 call sites without shadow mode creates migration
+risk — a single seed policy bug can cause platform-wide authorization
+failures. No call site migration **MAY** proceed without passing integration
+tests for all affected seed policies. Coverage target: 100% of seed policies
+tested before Phase 7.3 cutover.
+
 #### Seed Policy Migrations
 
 When a server version needs to fix a seed policy bug or update seed policy

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1225,6 +1225,13 @@ The repository determines the resolution strategy based on `parent_type`:
   alerting on this metric and investigate data model integrity issues (deep
   nesting, circular containment) when circuit breaker trips occur.
 
+  **N+1 Query Pattern:** Resolving multiple properties with `parent_location`
+  triggers separate recursive CTE executions per property (e.g., a `look`
+  command checking 10 properties executes 10 CTEs). The per-request attribute
+  cache mitigates within-request duplication. Implementations **SHOULD**
+  prefer batch resolution: collect all needed properties upfront and resolve
+  `parent_location` once per unique object.
+
 ## Attribute Resolution
 
 The engine uses eager resolution: all attributes are collected before any policy

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1731,6 +1731,7 @@ CREATE TABLE access_policies (
     dsl_text     TEXT NOT NULL,
     compiled_ast JSONB NOT NULL,             -- Pre-parsed AST from PolicyCompiler
     enabled      BOOLEAN NOT NULL DEFAULT true,
+    seed_version INTEGER DEFAULT NULL,       -- NULL for operator-created policies, integer for seed policies (tracks upgrade lineage)
     created_by   TEXT NOT NULL,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2061,28 +2061,28 @@ ORDER BY denials DESC
 LIMIT 10;
 
 -- Most frequently matched forbid policies (security hotspots)
-SELECT matched_policies[1] as policy_id, COUNT(*) as matches
+SELECT policy_id, policy_name, COUNT(*) as matches
 FROM access_audit_log
 WHERE timestamp > NOW() - INTERVAL '7 days'
   AND effect = 'deny'
-  AND array_length(matched_policies, 1) > 0
-GROUP BY policy_id
+  AND policy_id IS NOT NULL
+GROUP BY policy_id, policy_name
 ORDER BY matches DESC
 LIMIT 10;
 
--- Evaluation latency outliers (p99 > 10ms)
-SELECT subject, resource, action, latency_ms
+-- Evaluation latency outliers (p99 > 10ms = 10000 microseconds)
+SELECT subject, resource, action, duration_us
 FROM access_audit_log
 WHERE timestamp > NOW() - INTERVAL '1 hour'
-  AND latency_ms > 10
-ORDER BY latency_ms DESC
+  AND duration_us > 10000
+ORDER BY duration_us DESC
 LIMIT 20;
 
 -- Provider timeout rate (attribute resolution failures)
 SELECT subject, resource, COUNT(*) as timeout_count
 FROM access_audit_log
 WHERE timestamp > NOW() - INTERVAL '1 hour'
-  AND reason LIKE '%timeout%'
+  AND error_message LIKE '%timeout%'
 GROUP BY subject, resource
 ORDER BY timeout_count DESC
 LIMIT 10;

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1758,7 +1758,7 @@ CREATE TABLE access_audit_log (
     policy_name   TEXT,
     attributes      JSONB,
     error_message   TEXT,
-    provider_errors JSONB,                   -- e.g., [{"provider": "reputation", "error": "connection refused"}]
+    provider_errors JSONB,                   -- e.g., [{"namespace": "reputation", "error": "connection refused", "timestamp": "2026-02-06T12:00:00Z", "duration_us": 1500}]
     duration_us     INTEGER                  -- evaluation duration in microseconds (for performance debugging)
 );
 

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -73,6 +73,27 @@ They define baseline access (movement, self-access, builder/admin privileges)
 using the ABAC policy language. See [Seed Policies](#seed-policies) for the
 full set.
 
+### Reserved Prefixes
+
+All string identifiers in the ABAC system use reserved prefixes for validation and routing:
+
+| Category        | Prefix       | Purpose                                | Example                       |
+| --------------- | ------------ | -------------------------------------- | ----------------------------- |
+| Subject Strings | `character:` | Character entity reference             | `character:01ABC`             |
+|                 | `plugin:`    | Plugin identifier                      | `plugin:echo-bot`             |
+|                 | `system`     | System bypass (no ID, immediate allow) | `system`                      |
+|                 | `session:`   | Session ID (resolved to `character:`)  | `session:01XYZ`               |
+| Resource Strings| `location:`  | Location/room reference                | `location:01XYZ`              |
+|                 | `object:`    | Object entity reference                | `object:01DEF`                |
+|                 | `command:`   | Command name                           | `command:say`                 |
+|                 | `property:`  | Property entity reference              | `property:01GHI`              |
+|                 | `stream:`    | Event stream reference                 | `stream:location:01XYZ`       |
+| Policy Names    | `seed:`      | System seed policies                   | `seed:player-self-access`     |
+|                 | `lock:`      | Lock-generated policies                | `lock:object:01ABC:read`      |
+| Policy IDs      | `infra:`     | Infrastructure error disambiguation    | `infra:attr-resolution-error` |
+
+See [AccessRequest](#accessrequest-interface) for subject/resource format details and [Seed Policies](#seed-policies) for policy name conventions.
+
 ## Architecture
 
 ```text

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -350,6 +350,8 @@ as constants in the `internal/access` package. The following error code
 constants **MUST** be exported:
 
 - `ErrCodeSessionNotFound` — `"infra:session-not-found"`
+- `ErrCodeSessionStoreError` — `"infra:session-store-error"`
+- `ErrCodeSessionNoCharacter` — `"infra:session-no-character"`
 - `ErrCodeSessionCharacterIntegrity` — `"infra:session-character-integrity"`
 
 These constants ensure consistent error handling and filterable audit queries

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -1524,7 +1524,8 @@ Evaluate(ctx, AccessRequest{Subject, Action, Resource})
 │    ├─ Any satisfied permit → Decision{Allowed: true, Effect: Allow}
 │    └─ No policies satisfied → Decision{Allowed: false, Effect: DefaultDeny}
 │
-└─ 6. Audit (when mode != off)
+└─ 6. Audit
+     ├─ Log system bypasses in ALL modes (off, denials_only, all)
      ├─ Log denials (forbid + default deny) in denials_only and all modes
      ├─ Log allows only in all mode
      └─ Include: decision, matched policies, attribute snapshot
@@ -2018,7 +2019,7 @@ The audit logger supports three modes, configurable via server settings:
 type AuditMode string
 
 const (
-    AuditOff        AuditMode = "off"          // No audit logging
+    AuditOff        AuditMode = "off"          // System bypasses only
     AuditDenialsOnly AuditMode = "denials_only" // Log deny + default_deny only
     AuditAll        AuditMode = "all"           // Log all decisions
 )
@@ -2033,7 +2034,7 @@ type AuditConfig struct {
 
 | Mode           | What is logged            | Typical use case            |
 | -------------- | ------------------------- | --------------------------- |
-| `off`          | Nothing                   | Development, performance    |
+| `off`          | System bypasses only      | Development, performance    |
 | `denials_only` | Deny + default_deny       | Production default          |
 | `all`          | All decisions incl. allow | Debugging, compliance audit |
 
@@ -3134,7 +3135,7 @@ Describe("AccessPolicyEngine", func() {
     Describe("Audit logging", func() {
         It("logs denials in denials_only mode", func() { ... })
         It("logs all decisions in all mode", func() { ... })
-        It("logs nothing in off mode", func() { ... })
+        It("logs system bypasses only in off mode", func() { ... })
     })
 
     Describe("Cache invalidation via LISTEN/NOTIFY", func() {

--- a/docs/specs/CLAUDE.md
+++ b/docs/specs/CLAUDE.md
@@ -1,3 +1,0 @@
-<claude-mem-context>
-
-</claude-mem-context>

--- a/docs/specs/CLAUDE.md
+++ b/docs/specs/CLAUDE.md
@@ -1,0 +1,3 @@
+<claude-mem-context>
+
+</claude-mem-context>


### PR DESCRIPTION
## Summary

- Design spec for Epic 7 (holomush-5k1): Full ABAC architecture replacing static role-based access control
- Custom Go-native policy engine with Cedar-inspired DSL supporting rich expressions (comparisons, set operations, hierarchy traversal, if-then-else)
- Properties as first-class entities with per-property access control and three-layer permission model (property metadata, player locks, admin policies)
- 8 Architecture Decision Records (ADR 0009–0016) documenting key design choices: custom engine rationale, fail-safe type semantics, deny-overrides conflict resolution, eager attribute resolution, property model, direct replacement strategy, three-layer access control, and LISTEN/NOTIFY cache invalidation
- Companion decision log (40+ numbered decisions with rationale) capturing review-driven refinements
- Covers policy storage, attribute resolution, evaluation algorithm, audit logging, admin commands, migration path, and phased testing strategy

### Files

| File | Description |
|------|-------------|
| `docs/specs/2026-02-05-full-abac-design.md` | Main design specification (~2200 lines) |
| `docs/specs/2026-02-05-full-abac-design-decisions.md` | Decision log with rationale for 40+ choices |
| `docs/adr/0009-custom-go-native-abac-engine.md` | ADR: Custom Go engine over Cedar-Go/OPA |
| `docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md` | ADR: Missing attributes → false (not error) |
| `docs/adr/0011-deny-overrides-without-priority.md` | ADR: Any forbid beats any permit |
| `docs/adr/0012-eager-attribute-resolution.md` | ADR: Collect all attributes before evaluation |
| `docs/adr/0013-properties-as-first-class-entities.md` | ADR: Properties get ULIDs and own DB table |
| `docs/adr/0014-direct-static-access-control-replacement.md` | ADR: No adapter/shadow mode for migration |
| `docs/adr/0015-three-layer-player-access-control.md` | ADR: Metadata → locks → policies layering |
| `docs/adr/0016-listen-notify-policy-cache-invalidation.md` | ADR: Push-based cache invalidation |
| `docs/adr/0007-command-security-model.md` | Updated status to Superseded by ADR 0014 |

## Test plan

- [x] Review spec for completeness against holomush-5k1.1 acceptance criteria
- [x] Validate DSL grammar covers all required MUSH use cases
- [x] Confirm migration path from static roles is feasible
- [x] Verify property model design integrates with existing world model
- [x] Architecture review (principal engineer focus on design coherence)
- [x] Address all review findings (5 important issues, 6 suggestions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)