### PR TITLE
feat(tooling): add Claude Code session hooks

### DIFF
--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
 
 [[ -z "$FILE_PATH" ]] && exit 0
 [[ -f "$FILE_PATH" ]] || exit 0
@@ -17,7 +17,7 @@ REPO_ROOT=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/nu
 
 EXT="${FILE_PATH##*.}"
 case "$EXT" in
-  go|md|json|toml|yaml|yml)
+  go|md|json|toml)
     ;;
   *)
     exit 0
@@ -26,11 +26,12 @@ esac
 
 FORMATTED=true
 
-# dprint handles markdown, json, toml (no Go or YAML plugins configured)
+# dprint handles markdown, json, toml
 if [[ -f "$REPO_ROOT/dprint.json" ]] || [[ -f "$REPO_ROOT/.dprint.json" ]]; then
   if command -v dprint >/dev/null 2>&1; then
-    if ! dprint fmt "$FILE_PATH" 2>&1; then
+    if ! OUTPUT=$(dprint fmt "$FILE_PATH" 2>&1); then
       FORMATTED=false
+      echo "dprint error: $OUTPUT" >&2
     fi
   fi
 fi
@@ -38,8 +39,9 @@ fi
 # goimports handles Go import organization and formatting
 if [[ "$EXT" == "go" ]]; then
   if command -v goimports >/dev/null 2>&1; then
-    if ! goimports -w "$FILE_PATH" 2>&1; then
+    if ! OUTPUT=$(goimports -w "$FILE_PATH" 2>&1); then
       FORMATTED=false
+      echo "goimports error: $OUTPUT" >&2
     fi
   fi
 fi

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -5,10 +5,14 @@
 # PostToolUse hook: auto-format files after Edit/Write
 # Uses dprint for markdown/json/toml and goimports for Go files.
 # Error strategy: convenience hook — fails open (errors don't block edits).
-set -euo pipefail
+set -uo pipefail
+trap 'exit 0' ERR
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || {
+  echo "auto-format: failed to parse hook input" >&2
+  exit 0
+}
 
 [[ -z "$FILE_PATH" ]] && exit 0
 [[ -f "$FILE_PATH" ]] || exit 0
@@ -16,34 +20,41 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) 
 REPO_ROOT=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 EXT="${FILE_PATH##*.}"
+FORMATTED=true
+RAN_FORMATTER=false
+
 case "$EXT" in
-  go|md|json|toml)
+  md|json|toml)
+    # dprint handles markdown, json, toml
+    if [[ -f "$REPO_ROOT/dprint.json" ]] || [[ -f "$REPO_ROOT/.dprint.json" ]]; then
+      if command -v dprint >/dev/null 2>&1; then
+        RAN_FORMATTER=true
+        if ! OUTPUT=$(dprint fmt "$FILE_PATH" 2>&1); then
+          FORMATTED=false
+          echo "dprint error: $OUTPUT" >&2
+        fi
+      fi
+    fi
+    ;;
+  go)
+    # goimports handles Go import organization and formatting
+    if command -v goimports >/dev/null 2>&1; then
+      RAN_FORMATTER=true
+      if ! OUTPUT=$(goimports -w "$FILE_PATH" 2>&1); then
+        FORMATTED=false
+        echo "goimports error: $OUTPUT" >&2
+      fi
+    fi
     ;;
   *)
     exit 0
     ;;
 esac
 
-FORMATTED=true
-
-# dprint handles markdown, json, toml
-if [[ -f "$REPO_ROOT/dprint.json" ]] || [[ -f "$REPO_ROOT/.dprint.json" ]]; then
-  if command -v dprint >/dev/null 2>&1; then
-    if ! OUTPUT=$(dprint fmt "$FILE_PATH" 2>&1); then
-      FORMATTED=false
-      echo "dprint error: $OUTPUT" >&2
-    fi
-  fi
-fi
-
-# goimports handles Go import organization and formatting
-if [[ "$EXT" == "go" ]]; then
-  if command -v goimports >/dev/null 2>&1; then
-    if ! OUTPUT=$(goimports -w "$FILE_PATH" 2>&1); then
-      FORMATTED=false
-      echo "goimports error: $OUTPUT" >&2
-    fi
-  fi
+# Only report if a formatter actually ran — don't claim formatting
+# happened when no tool was available.
+if [[ "$RAN_FORMATTER" == "false" ]]; then
+  exit 0
 fi
 
 RELATIVE_PATH="${FILE_PATH#"$REPO_ROOT"/}"

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PostToolUse hook: auto-format files after Edit/Write
+# Runs dprint fmt on formattable files to keep formatting consistent.
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Nothing to do without a file path
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only format files that exist (Write might target a new path that failed)
+[[ -f "$FILE_PATH" ]] || exit 0
+
+# Determine the repo root for this file
+REPO_ROOT=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Check file extension
+EXT="${FILE_PATH##*.}"
+case "$EXT" in
+  go|md|json|toml|yaml|yml)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Run dprint if config exists in the repo
+if [[ -f "$REPO_ROOT/dprint.json" ]] || [[ -f "$REPO_ROOT/.dprint.json" ]]; then
+  if command -v dprint >/dev/null 2>&1; then
+    dprint fmt "$FILE_PATH" 2>/dev/null || true
+  fi
+fi
+
+# For Go files, also run goimports for import organization
+if [[ "$EXT" == "go" ]]; then
+  if command -v goimports >/dev/null 2>&1; then
+    goimports -w "$FILE_PATH" 2>/dev/null || true
+  fi
+fi
+
+# Report what we did
+RELATIVE_PATH="${FILE_PATH#"$REPO_ROOT"/}"
+echo "Auto-formatted: $RELATIVE_PATH"

--- a/.claude/hooks/enforce-task-runner.sh
+++ b/.claude/hooks/enforce-task-runner.sh
@@ -6,8 +6,11 @@
 # Blocks direct go/lint commands and shell search utilities, suggesting
 # the proper task commands or native Claude Code tools.
 # Error strategy: enforcement hook — fails open on jq/parse errors
-# but deterministically blocks known bad commands.
+# (command proceeds unchecked), but reliably blocks known bad patterns
+# when parsing succeeds.
 set -uo pipefail
+
+# --- Parse phase: fail open on malformed input ---
 trap 'exit 0' ERR
 
 INPUT=$(cat)
@@ -18,32 +21,45 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || {
 
 [[ -z "$COMMAND" ]] && exit 0
 
+# --- Enforcement phase: errors here are bugs, not parse failures ---
+trap - ERR
+
+strip_leading_ws() {
+  local s="$1"
+  echo "${s#"${s%%[![:space:]]*}"}"
+}
+
+# Strip leading KEY=value assignments (unquoted, double-quoted, single-quoted).
+strip_env_vars() {
+  local s="$1"
+  while [[ "$s" =~ ^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  done
+  echo "$s"
+}
+
 # Strips leading whitespace, all KEY=value env var assignments (including
 # quoted values like FOO="bar baz"), shell wrapper prefixes (env, sudo,
 # command, exec, nice, nohup) and their flags, then returns the first
 # real command word.
+#
+# Known limitations:
+# - KEY=value at end of string without trailing whitespace is not stripped.
 first_cmd_word() {
   local segment="$1"
-  # Strip leading whitespace
-  segment="${segment#"${segment%%[![:space:]]*}"}"
-  # Strip leading KEY=value assignments (unquoted, double-quoted, single-quoted)
-  while [[ "$segment" =~ ^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
-    segment="${segment#"${BASH_REMATCH[0]}"}"
-    segment="${segment#"${segment%%[![:space:]]*}"}"
-  done
+  segment=$(strip_leading_ws "$segment")
+  segment=$(strip_env_vars "$segment")
   local word="${segment%% *}"
   # Skip shell wrapper commands, their flags, and subsequent KEY=value pairs
   while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup)$ ]]; do
     segment="${segment#"$word"}"
-    segment="${segment#"${segment%%[![:space:]]*}"}"
+    segment=$(strip_leading_ws "$segment")
     while [[ "${segment%% *}" == -* ]]; do
       segment="${segment#"${segment%% *}"}"
-      segment="${segment#"${segment%%[![:space:]]*}"}"
+      segment=$(strip_leading_ws "$segment")
     done
-    while [[ "$segment" =~ ^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
-      segment="${segment#"${BASH_REMATCH[0]}"}"
-      segment="${segment#"${segment%%[![:space:]]*}"}"
-    done
+    segment=$(strip_env_vars "$segment")
     word="${segment%% *}"
   done
   echo "$word"
@@ -51,20 +67,23 @@ first_cmd_word() {
 
 # Split command on chain operators (&& ; ||) and check each segment's
 # first word before any pipe. This catches:
-#   "go test ./..."           → blocked (go)
-#   "cd foo && go test"       → blocked (go in second segment)
-#   "env go test ./..."       → blocked (env prefix stripped)
-#   "env -i go test ./..."    → blocked (env flag stripped)
-#   "FOO=a BAR=b go test"    → blocked (multiple env vars stripped)
-#   "git log | grep fix"      → allowed (grep is after pipe)
-#   "task test"               → allowed (task)
+#   "go test ./..."           -> blocked (go)
+#   "cd foo && go test"       -> blocked (go in second segment)
+#   "env go test ./..."       -> blocked (env prefix stripped)
+#   "env -i go test ./..."    -> blocked (env flag stripped)
+#   "FOO=a BAR=b go test"    -> blocked (multiple env vars stripped)
+#   "git log | grep fix"      -> allowed (grep is after pipe)
+#   "task test"               -> allowed (task)
 #
 # Known limitations:
 # - Commands inside $(...) or backticks are not inspected.
 # - Quoted strings containing && ; || are incorrectly split.
+# - || fallback clauses are checked as independent commands, which may
+#   produce false positives (e.g., "cmd || cat /dev/null").
 
 # Split on && ; || using awk for portability (BSD sed does not support \n
-# in replacement strings).
+# in replacement strings). Note: || is consumed by the awk split, so the
+# pipe split below never misidentifies || as two separate pipe characters.
 SEGMENTS=$(echo "$COMMAND" | awk '{gsub(/ *&& */, "\n"); gsub(/ *; */, "\n"); gsub(/ *\|\| */, "\n"); print}')
 
 while IFS= read -r segment; do
@@ -76,7 +95,7 @@ while IFS= read -r segment; do
 
   # Also get the second word for "go test" / "go build" distinction
   rest="${before_pipe#*"$word"}"
-  rest="${rest#"${rest%%[![:space:]]*}"}"
+  rest=$(strip_leading_ws "$rest")
   second_word="${rest%% *}"
 
   case "$word" in
@@ -100,14 +119,14 @@ while IFS= read -r segment; do
       echo "Use 'task fmt' instead of '$word'" >&2
       exit 2
       ;;
-    grep|egrep|fgrep|rg)
+    grep|egrep|fgrep)
       echo "Use the Grep tool instead of $word" >&2
       exit 2
       ;;
     cat)
-      # Allow heredocs: cat <<EOF, cat <<'EOF'
-      # Allow /dev/null: cat /dev/null
-      if ! echo "$before_pipe" | command grep -qE "cat[[:space:]]+(<<|/dev/)"; then
+      # Allow heredocs (with or without space/flags): cat <<EOF, cat<<EOF, cat -s <<EOF
+      # Allow /dev paths: cat /dev/null
+      if ! echo "$before_pipe" | command grep -qE "(<<|/dev/)"; then
         echo "Use the Read tool instead of cat" >&2
         exit 2
       fi

--- a/.claude/hooks/enforce-task-runner.sh
+++ b/.claude/hooks/enforce-task-runner.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PreToolUse hook: enforce task runner and dedicated tools
+# Blocks direct go/lint commands and shell search utilities, suggesting
+# the proper task commands or native Claude Code tools.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Nothing to check
+[[ -z "$COMMAND" ]] && exit 0
+
+# Extract the first command word from each chained segment.
+# Splits on && ; || and pipes, then gets the first non-whitespace word.
+# We only care about the FIRST segment (before any pipe) since piped-into
+# usage like "git log | grep" is fine.
+first_cmd_word() {
+  local segment="$1"
+  # Strip leading whitespace and env var assignments (FOO=bar cmd)
+  segment=$(echo "$segment" | sed 's/^[[:space:]]*//' | sed 's/^[A-Za-z_][A-Za-z_0-9]*=[^[:space:]]* *//')
+  # Get first word
+  echo "${segment%% *}"
+}
+
+# Split command on chain operators (&& ; ||) and check each segment's
+# first word before any pipe. This catches:
+#   "go test ./..."           → blocked (go)
+#   "cd foo && go test"       → blocked (go in second segment)
+#   "git log | grep fix"      → allowed (grep is after pipe)
+#   "task test"               → allowed (task)
+
+# Split on && ; || (preserving pipe chains as single segments)
+# Use newline as segment delimiter
+SEGMENTS=$(echo "$COMMAND" | sed 's/ *&& */\n/g; s/ *; */\n/g; s/ *|| */\n/g')
+
+while IFS= read -r segment; do
+  [[ -z "$segment" ]] && continue
+
+  # Get the part before any pipe (first command in a pipeline)
+  before_pipe="${segment%%|*}"
+  word=$(first_cmd_word "$before_pipe")
+
+  # Also get the second word for "go test" / "go build" distinction
+  rest="${before_pipe#*"$word"}"
+  rest="${rest#"${rest%%[![:space:]]*}"}"
+  second_word="${rest%% *}"
+
+  case "$word" in
+    go)
+      case "$second_word" in
+        test)
+          echo "Use 'task test' instead of 'go test'" >&2
+          exit 2
+          ;;
+        build)
+          echo "Use 'task build' instead of 'go build'" >&2
+          exit 2
+          ;;
+      esac
+      ;;
+    golangci-lint)
+      echo "Use 'task lint' instead of 'golangci-lint'" >&2
+      exit 2
+      ;;
+    gofmt)
+      echo "Use 'task fmt' instead of 'gofmt'" >&2
+      exit 2
+      ;;
+    goimports)
+      echo "Use 'task fmt' instead of 'goimports'" >&2
+      exit 2
+      ;;
+    grep|egrep|fgrep)
+      echo "Use the Grep tool instead of $word" >&2
+      exit 2
+      ;;
+    rg)
+      echo "Use the Grep tool instead of rg" >&2
+      exit 2
+      ;;
+    cat)
+      # Allow heredocs: cat <<EOF, cat <<'EOF'
+      # Allow /dev/null: cat /dev/null
+      if ! echo "$before_pipe" | grep -qE "cat[[:space:]]+(<<|/dev/)"; then
+        echo "Use the Read tool instead of cat" >&2
+        exit 2
+      fi
+      ;;
+    head)
+      echo "Use the Read tool with offset/limit instead of head" >&2
+      exit 2
+      ;;
+    tail)
+      echo "Use the Read tool with offset/limit instead of tail" >&2
+      exit 2
+      ;;
+    find)
+      echo "Use the Glob tool instead of find" >&2
+      exit 2
+      ;;
+  esac
+done <<< "$SEGMENTS"
+
+exit 0

--- a/.claude/hooks/protect-main.sh
+++ b/.claude/hooks/protect-main.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PreToolUse hook: prevent edits on main branch
+# Blocks Edit/Write tool calls when the target file is in a repo on main.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path means nothing to guard
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Get the directory — if the file doesn't exist yet (Write), use parent dir
+if [[ -d "$(dirname "$FILE_PATH")" ]]; then
+  DIR="$(dirname "$FILE_PATH")"
+else
+  exit 0
+fi
+
+# Determine if we're in a git repo
+REPO_ROOT=$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Get current branch
+BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null) || exit 0
+
+if [[ "$BRANCH" == "main" ]]; then
+  echo "Cannot edit files on the main branch." >&2
+  echo "Create a feature branch or worktree first:" >&2
+  echo "  git worktree add ../.worktrees/<name> -b feat/<name>" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/session-reminder.sh
+++ b/.claude/hooks/session-reminder.sh
@@ -3,13 +3,13 @@
 # Copyright 2026 HoloMUSH Contributors
 #
 # Stop hook: remind about unsynced beads and uncommitted changes
-# Fires at the end of each agent turn. Only outputs when there's
-# actually unsynced work to avoid noise.
+# Fires when the agent finishes responding (Stop event). Only outputs
+# when there's actually unsynced work to avoid noise.
 # Error strategy: convenience hook — fails open (errors don't block).
 set -euo pipefail
 
 INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || true
 
 WORKDIR="${CWD:-.}"
 
@@ -18,7 +18,7 @@ REPO_ROOT=$(git -C "$WORKDIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
 REMINDERS=()
 
 # Check for uncommitted changes
-GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>&1) || {
+GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || {
   REMINDERS+=("git status failed — check repo health")
   GIT_STATUS=""
 }

--- a/.claude/hooks/session-reminder.sh
+++ b/.claude/hooks/session-reminder.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Stop hook: remind about unsynced beads and uncommitted changes
+# Fires every time Claude finishes a response. Only outputs when there's
+# actually unsynced work to avoid noise.
+set -euo pipefail
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Use CWD from the event, fall back to pwd
+WORKDIR="${CWD:-.}"
+
+# Check if we're in a git repo
+REPO_ROOT=$(git -C "$WORKDIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+REMINDERS=()
+
+# Check for uncommitted changes
+GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || true
+if [[ -n "$GIT_STATUS" ]]; then
+  CHANGED_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
+  REMINDERS+=("$CHANGED_COUNT uncommitted file(s) in working tree")
+fi
+
+# Check for beads sync status
+if command -v bd >/dev/null 2>&1; then
+  BEADS_STATUS=$(bd sync --status 2>/dev/null) || true
+  if echo "$BEADS_STATUS" | grep -qi "ahead\|dirty\|unsync"; then
+    REMINDERS+=("beads issues need syncing (run 'bd sync')")
+  fi
+fi
+
+# Check for unpushed commits
+UNPUSHED=$(git -C "$REPO_ROOT" log --oneline '@{upstream}..HEAD' 2>/dev/null) || true
+if [[ -n "$UNPUSHED" ]]; then
+  COMMIT_COUNT=$(echo "$UNPUSHED" | wc -l | tr -d ' ')
+  REMINDERS+=("$COMMIT_COUNT unpushed commit(s)")
+fi
+
+# Only output if there's something to remind about
+if [[ ${#REMINDERS[@]} -gt 0 ]]; then
+  echo "Session reminder:"
+  for r in "${REMINDERS[@]}"; do
+    echo "  - $r"
+  done
+fi
+
+exit 0

--- a/.claude/hooks/session-reminder.sh
+++ b/.claude/hooks/session-reminder.sh
@@ -3,29 +3,31 @@
 # Copyright 2026 HoloMUSH Contributors
 #
 # Stop hook: remind about unsynced beads and uncommitted changes
-# Fires every time Claude finishes a response. Only outputs when there's
+# Fires at the end of each agent turn. Only outputs when there's
 # actually unsynced work to avoid noise.
+# Error strategy: convenience hook — fails open (errors don't block).
 set -euo pipefail
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
-# Use CWD from the event, fall back to pwd
 WORKDIR="${CWD:-.}"
 
-# Check if we're in a git repo
 REPO_ROOT=$(git -C "$WORKDIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 REMINDERS=()
 
 # Check for uncommitted changes
-GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || true
+GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>&1) || {
+  REMINDERS+=("git status failed — check repo health")
+  GIT_STATUS=""
+}
 if [[ -n "$GIT_STATUS" ]]; then
   CHANGED_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
   REMINDERS+=("$CHANGED_COUNT uncommitted file(s) in working tree")
 fi
 
-# Check for beads sync status
+# bd sync --status outputs "ahead", "dirty", or "unsync" when out of sync
 if command -v bd >/dev/null 2>&1; then
   BEADS_STATUS=$(bd sync --status 2>/dev/null) || true
   if echo "$BEADS_STATUS" | grep -qi "ahead\|dirty\|unsync"; then
@@ -33,14 +35,13 @@ if command -v bd >/dev/null 2>&1; then
   fi
 fi
 
-# Check for unpushed commits
+# Check for unpushed commits (may fail if no upstream tracking)
 UNPUSHED=$(git -C "$REPO_ROOT" log --oneline '@{upstream}..HEAD' 2>/dev/null) || true
 if [[ -n "$UNPUSHED" ]]; then
   COMMIT_COUNT=$(echo "$UNPUSHED" | wc -l | tr -d ' ')
   REMINDERS+=("$COMMIT_COUNT unpushed commit(s)")
 fi
 
-# Only output if there's something to remind about
 if [[ ${#REMINDERS[@]} -gt 0 ]]; then
   echo "Session reminder:"
   for r in "${REMINDERS[@]}"; do

--- a/.claude/hooks/session-reminder.sh
+++ b/.claude/hooks/session-reminder.sh
@@ -5,7 +5,7 @@
 # Stop hook: remind about unsynced beads and uncommitted changes
 # Fires when the agent finishes responding (Stop event). Only outputs
 # when there's actually unsynced work to avoid noise.
-# Does not fire on user interrupts (Ctrl+C) — only on natural completion.
+# Does not fire on user interrupts (Ctrl+C) — only when Claude finishes responding.
 # Error strategy: convenience hook — fails open (errors don't block).
 set -uo pipefail
 trap 'exit 0' ERR
@@ -25,17 +25,18 @@ GIT_STATUS=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || {
   GIT_STATUS=""
 }
 if [[ -n "$GIT_STATUS" ]]; then
-  CHANGED_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
+  CHANGED_COUNT=$(echo "$GIT_STATUS" | grep -c .)
   REMINDERS+=("$CHANGED_COUNT uncommitted file(s) in working tree")
 fi
 
-# bd sync --status outputs "ahead", "dirty", or "unsync" when out of sync
+# bd sync --status shows "Pending changes: none" when fully synced.
+# Trigger reminder if pending changes or conflicts exist.
 if command -v bd >/dev/null 2>&1; then
   BEADS_STATUS=$(bd sync --status 2>/dev/null) || {
     REMINDERS+=("beads sync check failed — run 'bd sync --status' manually")
     BEADS_STATUS=""
   }
-  if [[ -n "$BEADS_STATUS" ]] && echo "$BEADS_STATUS" | command grep -qi "ahead\|dirty\|unsync"; then
+  if [[ -n "$BEADS_STATUS" ]] && ! echo "$BEADS_STATUS" | command grep -q "Pending changes: none"; then
     REMINDERS+=("beads issues need syncing (run 'bd sync')")
   fi
 fi
@@ -43,7 +44,7 @@ fi
 # Check for unpushed commits (may fail if no upstream tracking)
 UNPUSHED=$(git -C "$REPO_ROOT" log --oneline '@{upstream}..HEAD' 2>/dev/null) || true
 if [[ -n "$UNPUSHED" ]]; then
-  COMMIT_COUNT=$(echo "$UNPUSHED" | wc -l | tr -d ' ')
+  COMMIT_COUNT=$(echo "$UNPUSHED" | grep -c .)
   REMINDERS+=("$COMMIT_COUNT unpushed commit(s)")
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,50 @@
       "Edit(/.worktrees/**)"
     ]
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-main.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-task-runner.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-format.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-reminder.sh"
+          }
+        ]
+      }
+    ]
+  },
   "sandbox": {
     "allowUnsandboxedCommands": true,
     "autoAllowBashIfSandboxed": true,

--- a/docs/plans/2026-02-05-claude-code-hooks-design.md
+++ b/docs/plans/2026-02-05-claude-code-hooks-design.md
@@ -23,9 +23,10 @@ them during the session provides faster feedback and prevents wasted effort.
 Four Claude Code hooks configured in `.claude/settings.json`, implemented as
 shell scripts in `.claude/hooks/`. All scripts use `jq` to parse stdin JSON.
 
-Security hooks (protect-main, enforce-task-runner) fail closed — unknown
-state blocks the action. Convenience hooks (auto-format, session-reminder)
-fail open — errors do not block the user.
+protect-main fails closed — unknown state blocks the action.
+enforce-task-runner fails open on parse errors but deterministically blocks
+known bad patterns. Convenience hooks (auto-format, session-reminder) fail
+open — errors do not block the user.
 
 ### Hook 1: Auto-format after Edit/Write
 
@@ -33,9 +34,9 @@ fail open — errors do not block the user.
 - **Matcher:** `Edit|Write`
 - **Script:** `.claude/hooks/auto-format.sh`
 - **Behavior:** After any successful Edit or Write to a formattable file
-  (`.go`, `.md`, `.yaml`, `.yml`, `.json`, `.toml`), runs `dprint fmt <file>`
-  for markdown/json/toml and `goimports` for Go files. Reports what it
-  formatted as `additionalContext`. Reports errors visibly if formatting fails.
+  (`.go`, `.md`, `.json`, `.toml`), runs `dprint fmt <file>` for
+  markdown/json/toml and `goimports` for Go files. Reports what it formatted
+  as `additionalContext`. Captures tool output and only surfaces errors.
 - **Cannot block:** PostToolUse hooks run after the tool succeeds.
 
 ### Hook 2: Prevent edits on main
@@ -48,7 +49,8 @@ fail open — errors do not block the user.
   message: *"Cannot edit files on main. Create a feature branch first."*
   Skips files outside a git repo (e.g., temp files in `/tmp/`, user-global
   files in `~/.claude/`). Within a repo, fails closed — if the current branch
-  cannot be determined, blocks as a precaution.
+  cannot be determined, blocks as a precaution. Known limitation: detached
+  HEAD at main's tip is not detected.
 
 ### Hook 3: Enforce task runner and dedicated tools
 
@@ -57,28 +59,31 @@ fail open — errors do not block the user.
 - **Script:** `.claude/hooks/enforce-task-runner.sh`
 - **Behavior:** Before any Bash command, checks for blocked patterns:
 
-| Pattern                                    | Suggestion             |
-| ------------------------------------------ | ---------------------- |
-| `go test`                                  | Use `task test`        |
-| `go build`                                 | Use `task build`       |
-| `golangci-lint`                            | Use `task lint`        |
-| `gofmt` / `goimports`                      | Use `task fmt`         |
-| `grep ` / `rg ` (standalone)              | Use the Grep tool      |
-| `cat ` / `head ` / `tail ` (standalone)   | Use the Read tool      |
-| `find ` (standalone)                       | Use the Glob tool      |
+| Pattern                                         | Suggestion        |
+| ----------------------------------------------- | ----------------- |
+| `go test`                                       | Use `task test`   |
+| `go build`                                      | Use `task build`  |
+| `golangci-lint`                                 | Use `task lint`   |
+| `gofmt` / `goimports`                           | Use `task fmt`    |
+| `grep` / `rg` (first in pipeline)               | Use the Grep tool |
+| `cat` / `head` / `tail` (first in pipeline)     | Use the Read tool |
+| `find` (first in pipeline)                      | Use the Glob tool |
 
   Allows these patterns when they appear after pipes (e.g.,
   `git log \| grep`). Strips shell wrapper prefixes (`env`, `sudo`,
-  `command`, `exec`) before matching. Known limitation: commands inside
-  `$(...)` subshells are not inspected.
+  `command`, `exec`, `nice`, `nohup`), their flags, and inline env var
+  assignments before matching. Known limitations: commands inside `$(...)`
+  subshells are not inspected; quoted strings containing `&&`/`;`/`||` are
+  incorrectly split.
 
 ### Hook 4: Beads sync reminder
 
 - **Event:** `Stop`
 - **Matcher:** *(none — fires on every Stop)*
 - **Script:** `.claude/hooks/session-reminder.sh`
-- **Behavior:** Checks `bd sync --status` and `git status --porcelain`. If
-  either shows unsynced/uncommitted changes, outputs a reminder as
+- **Behavior:** Checks `bd sync --status`, `git status --porcelain`, and
+  `git log '@{upstream}..HEAD'` for unpushed commits. If any show
+  unsynced/uncommitted/unpushed changes, outputs a reminder as
   `additionalContext`. Silent when everything is clean.
 
 ## File Layout

--- a/docs/plans/2026-02-05-claude-code-hooks-design.md
+++ b/docs/plans/2026-02-05-claude-code-hooks-design.md
@@ -1,0 +1,92 @@
+# Claude Code Hooks Design
+
+**Date:** 2026-02-05
+**Status:** Draft
+**Scope:** Developer tooling — Claude Code session-time guardrails
+
+## Problem
+
+Several recurring issues arise during AI-assisted development sessions that
+aren't caught until commit time (or not at all):
+
+1. Forgetting to run `task fmt` after edits, causing noisy formatting diffs
+2. Accidentally editing files on `main` instead of a feature branch
+3. Using raw `go test`/`go build` instead of `task test`/`task build`
+4. Using shell commands (`grep`, `cat`, `find`) instead of dedicated tools
+5. Forgetting to `bd sync` at end of session, losing beads state
+
+Lefthook pre-commit hooks catch some of these at commit time, but catching
+them during the session provides faster feedback and prevents wasted effort.
+
+## Solution
+
+Five Claude Code hooks configured in `.claude/settings.json`, implemented as
+shell scripts in `.claude/hooks/`. All scripts use `jq` to parse stdin JSON.
+
+### Hook 1: Auto-format after Edit/Write
+
+- **Event:** `PostToolUse`
+- **Matcher:** `Edit|Write`
+- **Script:** `.claude/hooks/auto-format.sh`
+- **Behavior:** After any successful Edit or Write to a formattable file
+  (`.go`, `.md`, `.yaml`, `.yml`, `.json`, `.toml`), runs `dprint fmt <file>`.
+  For `.go` files, also runs `goimports` if available. Reports what it
+  formatted as `additionalContext`.
+- **Cannot block:** PostToolUse hooks run after the tool succeeds.
+
+### Hook 2: Prevent edits on main
+
+- **Event:** `PreToolUse`
+- **Matcher:** `Edit|Write`
+- **Script:** `.claude/hooks/protect-main.sh`
+- **Behavior:** Before any Edit or Write, checks `git branch --show-current`
+  for the file's repository. If on `main`, blocks with exit code 2 and
+  message: *"Cannot edit files on main. Create a feature branch first."*
+  Skips files outside a git repo (e.g., `~/.claude/`).
+
+### Hook 3+5: Enforce task runner and dedicated tools
+
+- **Event:** `PreToolUse`
+- **Matcher:** `Bash`
+- **Script:** `.claude/hooks/enforce-task-runner.sh`
+- **Behavior:** Before any Bash command, checks for blocked patterns:
+
+| Pattern | Suggestion |
+|---------|------------|
+| `go test` | Use `task test` |
+| `go build` | Use `task build` |
+| `golangci-lint` | Use `task lint` |
+| `gofmt` / `goimports` | Use `task fmt` |
+| `grep ` / `rg ` (standalone) | Use the Grep tool |
+| `cat ` / `head ` / `tail ` (standalone) | Use the Read tool |
+| `find ` (standalone) | Use the Glob tool |
+
+  Allows these patterns when they appear inside pipes or as subcommands
+  (e.g., `git log \| grep`, `git grep`, `cat <<EOF`).
+
+### Hook 6: Beads sync reminder
+
+- **Event:** `Stop`
+- **Matcher:** *(none — fires on every Stop)*
+- **Script:** `.claude/hooks/session-reminder.sh`
+- **Behavior:** Checks `bd sync --status` and `git status --porcelain`. If
+  either shows unsynced/uncommitted changes, outputs a reminder as
+  `additionalContext`. Silent when everything is clean.
+
+## File Layout
+
+```
+.claude/
+  hooks/
+    auto-format.sh
+    protect-main.sh
+    enforce-task-runner.sh
+    session-reminder.sh
+  settings.json          # Hook configuration added here
+```
+
+## Testing
+
+Each hook SHOULD be testable by piping sample JSON to stdin and checking
+exit codes and stdout/stderr output. Manual testing in a Claude Code session
+validates end-to-end behavior.

--- a/docs/plans/2026-02-05-claude-code-hooks-design.md
+++ b/docs/plans/2026-02-05-claude-code-hooks-design.md
@@ -26,11 +26,15 @@ Problems 1 and 2 each have a dedicated hook; problem 3 is handled by a
 single hook covering both task runner and tool enforcement.
 
 protect-main fails open outside repos (allows non-repo files) and fails
-closed within repos (unknown branch = block). enforce-task-runner fails open
-on parse errors but deterministically blocks known bad patterns. Convenience
-hooks (auto-format, session-reminder) fail open — errors do not block the
-user. All fail-open hooks use `trap 'exit 0' ERR` to ensure unexpected
-errors produce exit 0 rather than a non-zero-non-2 exit code.
+closed within repos (unknown branch = block). It uses `trap 'exit 2' ERR`
+so unexpected errors block the edit rather than allowing it through.
+enforce-task-runner fails open on parse errors (command proceeds unchecked)
+but reliably blocks known bad patterns when parsing succeeds; the ERR trap
+is scoped to the parse phase only, so enforcement logic errors surface
+rather than silently allowing commands. Convenience hooks (auto-format,
+session-reminder) fail open — errors do not block the user. Fail-open hooks
+use `trap 'exit 0' ERR` to ensure unexpected errors produce exit 0 rather
+than a non-zero-non-2 exit code.
 
 ### Hook 1: Auto-format after Edit/Write
 
@@ -42,7 +46,8 @@ errors produce exit 0 rather than a non-zero-non-2 exit code.
   files. Reports what it formatted in verbose mode output (plain text
   stdout). Only reports if a formatter actually ran — does not claim
   formatting occurred when tools are missing.
-- **Cannot block:** PostToolUse hooks run after the tool succeeds.
+- **Cannot prevent execution:** PostToolUse hooks run after the tool succeeds.
+  The hook can provide feedback to Claude but cannot undo the operation.
 
 ### Hook 2: Prevent edits on main
 
@@ -70,31 +75,34 @@ errors produce exit 0 rather than a non-zero-non-2 exit code.
 | `go build`                                  | Use `task build`  |
 | `golangci-lint`                             | Use `task lint`   |
 | `gofmt` / `goimports`                       | Use `task fmt`    |
-| `grep` / `rg` (first in pipeline)           | Use the Grep tool |
+| `grep` (first in pipeline)                  | Use the Grep tool |
 | `cat` / `head` / `tail` (first in pipeline) | Use the Read tool |
 | `find` (first in pipeline)                  | Use the Glob tool |
 
-`sed`/`awk`/`echo` are intentionally not blocked — they are frequently
+`sed`/`awk`/`echo`/`rg` are intentionally not blocked — they are frequently
 needed for shell operations where native Claude Code tools are insufficient.
+`rg` (ripgrep) in particular is used in pipelines and scripted searches
+where the Grep tool cannot substitute.
 
 Allows blocked patterns when they appear after pipes (e.g.,
 `git log \| grep`). Strips shell wrapper prefixes (`env`, `sudo`,
 `command`, `exec`, `nice`, `nohup`), their flags, and inline env var
 assignments (including quoted values) before matching. Known limitations:
 commands inside `$(...)` subshells are not inspected; quoted strings
-containing `&&`/`;`/`||` are incorrectly split.
+containing `&&`/`;`/`||` are incorrectly split; `||` fallback clauses are
+checked as independent commands, which may produce false positives.
 
 ### Hook 4: Beads sync reminder
 
 - **Event:** `Stop`
-- **Matcher:** _(none — fires on every Stop)_
+- **Matcher:** _(Stop hooks ignore matchers — fires on every Stop)_
 - **Script:** `.claude/hooks/session-reminder.sh`
 - **Behavior:** Checks `bd sync --status`, `git status --porcelain`, and
   `git log '@{upstream}..HEAD'` for unpushed commits. If any show
   unsynced/uncommitted/unpushed changes, outputs a reminder in verbose mode
   output (plain text stdout). Silent when everything is clean.
-- **Caveat:** Does not fire on user interrupts (Ctrl+C) — only on natural
-  response completion.
+- **Caveat:** Does not fire on user interrupts (Ctrl+C) — only when Claude
+  finishes responding.
 
 ## File Layout
 

--- a/docs/plans/2026-02-05-claude-code-hooks-design.md
+++ b/docs/plans/2026-02-05-claude-code-hooks-design.md
@@ -11,9 +11,9 @@ aren't caught until commit time (or not at all):
 
 1. Forgetting to run `task fmt` after edits, causing noisy formatting diffs
 2. Accidentally editing files on `main` instead of a feature branch
-3. Using raw `go test`/`go build` instead of `task test`/`task build`
-4. Using shell commands (`grep`, `cat`, `find`) instead of dedicated tools
-5. Forgetting to `bd sync` at end of session, losing beads state
+3. Using raw `go test`/`go build` instead of `task test`/`task build`, or
+   shell commands (`grep`, `cat`, `find`) instead of dedicated tools
+4. Forgetting to `bd sync` at end of session, losing beads state
 
 Lefthook pre-commit hooks catch some of these at commit time, but catching
 them during the session provides faster feedback and prevents wasted effort.
@@ -22,21 +22,26 @@ them during the session provides faster feedback and prevents wasted effort.
 
 Four Claude Code hooks configured in `.claude/settings.json`, implemented as
 shell scripts in `.claude/hooks/`. All scripts use `jq` to parse stdin JSON.
+Problems 1 and 2 each have a dedicated hook; problem 3 is handled by a
+single hook covering both task runner and tool enforcement.
 
-protect-main fails closed — unknown state blocks the action.
-enforce-task-runner fails open on parse errors but deterministically blocks
-known bad patterns. Convenience hooks (auto-format, session-reminder) fail
-open — errors do not block the user.
+protect-main fails open outside repos (allows non-repo files) and fails
+closed within repos (unknown branch = block). enforce-task-runner fails open
+on parse errors but deterministically blocks known bad patterns. Convenience
+hooks (auto-format, session-reminder) fail open — errors do not block the
+user. All fail-open hooks use `trap 'exit 0' ERR` to ensure unexpected
+errors produce exit 0 rather than a non-zero-non-2 exit code.
 
 ### Hook 1: Auto-format after Edit/Write
 
 - **Event:** `PostToolUse`
 - **Matcher:** `Edit|Write`
 - **Script:** `.claude/hooks/auto-format.sh`
-- **Behavior:** After any successful Edit or Write to a formattable file
-  (`.go`, `.md`, `.json`, `.toml`), runs `dprint fmt <file>` for
-  markdown/json/toml and `goimports` for Go files. Reports what it formatted
-  as `additionalContext`. Captures tool output and only surfaces errors.
+- **Behavior:** After any successful Edit or Write to a formattable file,
+  runs `dprint fmt <file>` for markdown/json/toml and `goimports` for Go
+  files. Reports what it formatted in verbose mode output (plain text
+  stdout). Only reports if a formatter actually ran — does not claim
+  formatting occurred when tools are missing.
 - **Cannot block:** PostToolUse hooks run after the tool succeeds.
 
 ### Hook 2: Prevent edits on main
@@ -46,11 +51,11 @@ open — errors do not block the user.
 - **Script:** `.claude/hooks/protect-main.sh`
 - **Behavior:** Before any Edit or Write, checks `git branch --show-current`
   for the file's repository. If on `main`, blocks with exit code 2 and
-  message: *"Cannot edit files on main. Create a feature branch first."*
+  message: _"Cannot edit files on main. Create a feature branch first."_
   Skips files outside a git repo (e.g., temp files in `/tmp/`, user-global
   files in `~/.claude/`). Within a repo, fails closed — if the current branch
-  cannot be determined, blocks as a precaution. Known limitation: detached
-  HEAD at main's tip is not detected.
+  cannot be determined or HEAD is detached, blocks as a precaution. Walks up
+  the directory tree for new deep paths where parent dirs don't exist yet.
 
 ### Hook 3: Enforce task runner and dedicated tools
 
@@ -59,32 +64,37 @@ open — errors do not block the user.
 - **Script:** `.claude/hooks/enforce-task-runner.sh`
 - **Behavior:** Before any Bash command, checks for blocked patterns:
 
-| Pattern                                         | Suggestion        |
-| ----------------------------------------------- | ----------------- |
-| `go test`                                       | Use `task test`   |
-| `go build`                                      | Use `task build`  |
-| `golangci-lint`                                 | Use `task lint`   |
-| `gofmt` / `goimports`                           | Use `task fmt`    |
-| `grep` / `rg` (first in pipeline)               | Use the Grep tool |
-| `cat` / `head` / `tail` (first in pipeline)     | Use the Read tool |
-| `find` (first in pipeline)                      | Use the Glob tool |
+| Pattern                                     | Suggestion        |
+| ------------------------------------------- | ----------------- |
+| `go test`                                   | Use `task test`   |
+| `go build`                                  | Use `task build`  |
+| `golangci-lint`                             | Use `task lint`   |
+| `gofmt` / `goimports`                       | Use `task fmt`    |
+| `grep` / `rg` (first in pipeline)           | Use the Grep tool |
+| `cat` / `head` / `tail` (first in pipeline) | Use the Read tool |
+| `find` (first in pipeline)                  | Use the Glob tool |
 
-  Allows these patterns when they appear after pipes (e.g.,
-  `git log \| grep`). Strips shell wrapper prefixes (`env`, `sudo`,
-  `command`, `exec`, `nice`, `nohup`), their flags, and inline env var
-  assignments before matching. Known limitations: commands inside `$(...)`
-  subshells are not inspected; quoted strings containing `&&`/`;`/`||` are
-  incorrectly split.
+`sed`/`awk`/`echo` are intentionally not blocked — they are frequently
+needed for shell operations where native Claude Code tools are insufficient.
+
+Allows blocked patterns when they appear after pipes (e.g.,
+`git log \| grep`). Strips shell wrapper prefixes (`env`, `sudo`,
+`command`, `exec`, `nice`, `nohup`), their flags, and inline env var
+assignments (including quoted values) before matching. Known limitations:
+commands inside `$(...)` subshells are not inspected; quoted strings
+containing `&&`/`;`/`||` are incorrectly split.
 
 ### Hook 4: Beads sync reminder
 
 - **Event:** `Stop`
-- **Matcher:** *(none — fires on every Stop)*
+- **Matcher:** _(none — fires on every Stop)_
 - **Script:** `.claude/hooks/session-reminder.sh`
 - **Behavior:** Checks `bd sync --status`, `git status --porcelain`, and
   `git log '@{upstream}..HEAD'` for unpushed commits. If any show
-  unsynced/uncommitted/unpushed changes, outputs a reminder as
-  `additionalContext`. Silent when everything is clean.
+  unsynced/uncommitted/unpushed changes, outputs a reminder in verbose mode
+  output (plain text stdout). Silent when everything is clean.
+- **Caveat:** Does not fire on user interrupts (Ctrl+C) — only on natural
+  response completion.
 
 ## File Layout
 


### PR DESCRIPTION
## Summary

- Add four Claude Code hooks that enforce project conventions during AI-assisted development sessions
- Auto-format files after Edit/Write using dprint + goimports
- Block edits on `main` branch (must use feature branch/worktree)
- Block raw `go test`/`go build`/`golangci-lint`/`grep`/`cat`/`find` — suggests `task` commands and native tools
- Remind about uncommitted/unsynced work when Claude finishes responding

## Files

| File | Purpose |
|------|---------|
| `.claude/hooks/auto-format.sh` | PostToolUse: runs `dprint fmt` + `goimports` after edits |
| `.claude/hooks/protect-main.sh` | PreToolUse: blocks Edit/Write on main branch |
| `.claude/hooks/enforce-task-runner.sh` | PreToolUse: blocks raw go/lint/search commands |
| `.claude/hooks/session-reminder.sh` | Stop: warns about uncommitted/unsynced work |
| `.claude/settings.json` | Hook wiring configuration |
| `docs/plans/2026-02-05-claude-code-hooks-design.md` | Design document |

## Test plan

- [x] `protect-main.sh`: blocks on main, allows on feature branch, allows non-repo files
- [x] `enforce-task-runner.sh`: 22/22 test cases pass (12 blocked, 10 allowed)
- [x] `session-reminder.sh`: detects uncommitted files and unpushed commits
- [ ] End-to-end: start a new Claude Code session with hooks active and verify they fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)