### PR TITLE
fix(plans): resolve 20 review findings in ABAC implementation plan

### DIFF
--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -33,6 +33,8 @@ Each task MUST denote which spec sections and ADRs it implements. This is tracke
 
 **Design spec:** `docs/specs/2026-02-05-full-abac-design.md`
 
+> **Note:** Spec line numbers in task references are approximate and based on the spec at time of writing. Verify against the current spec before implementing.
+
 Applicable ADRs (from spec §18):
 
 | ADR      | Title                              | Applies To      |

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the static role-based `AccessControl` system with a full policy-driven `AccessPolicyEngine` supporting a Cedar-inspired DSL, extensible attribute providers, audit logging, and admin commands.
 
-**Architecture:** Custom Go-native ABAC engine with eager attribute resolution, in-memory policy cache invalidated via PostgreSQL LISTEN/NOTIFY, deny-overrides conflict resolution, and per-request attribute caching. No adapter layer — direct replacement of all ~28 call sites.
+**Architecture:** Custom Go-native ABAC engine with eager attribute resolution, in-memory policy cache invalidated via PostgreSQL LISTEN/NOTIFY, deny-overrides conflict resolution, and per-request attribute caching. No adapter layer — direct replacement of all ~28 production call sites (plus test files and generated mocks).
 
 **Tech Stack:** Go 1.23+, [participle](https://github.com/alecthomas/participle) (struct-tag parser generator), pgx/pgxpool, oops (structured errors), prometheus/client_golang, testify + Ginkgo/Gomega, mockery
 
@@ -2492,7 +2492,7 @@ git commit -m "refactor(access): wire AccessPolicyEngine in dependency injection
 
 **Acceptance Criteria:**
 
-- [ ] ALL ~28 call sites migrated from `AccessControl.Check()` to `engine.Evaluate()`
+- [ ] ALL ~28 production call sites (plus test files and generated mocks) migrated from `AccessControl.Check()` to `engine.Evaluate()`
 - [ ] Each call site uses `policy.AccessRequest{Subject, Action, Resource}` struct
 - [ ] Error handling: `Evaluate()` error → fail-closed (deny), logged via slog
 - [ ] All subject strings use `character:` prefix (not legacy `char:`)
@@ -2501,7 +2501,7 @@ git commit -m "refactor(access): wire AccessPolicyEngine in dependency injection
 - [ ] Committed per package (dispatcher, world, plugin)
 - [ ] `task test` passes after all migrations
 
-**Files to modify** (run `grep -r "AccessControl" internal/ --include="*.go" -l` for current list):
+**Key files include (non-exhaustive)** — run `grep -r "AccessControl" internal/ --include="*.go" -l` for the authoritative list:
 
 - `internal/command/dispatcher.go` — Command execution authorization
 - `internal/command/rate_limit_middleware.go` — Rate limit bypass for admins

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -2307,12 +2307,13 @@ git commit -m "feat(access): add lock expression parser and DSL compiler"
 **Acceptance Criteria:**
 
 - [ ] `EntityProperty` struct: ID, ParentType, ParentID, Name, Value, Owner, Visibility, Flags, VisibleTo, ExcludedFrom, timestamps
-- [ ] `PropertyRepository` interface: `Create`, `Get`, `ListByParent`, `Update`, `Delete`
+- [ ] `PropertyRepository` interface: `Create`, `Get`, `ListByParent`, `Update`, `Delete`, `DeleteByParent`
 - [ ] CRUD operations round-trip all fields correctly
 - [ ] Visibility defaults: `restricted` → auto-set `visible_to=[owner]`, `excluded_from=[]`
 - [ ] `visible_to` max 100 entries; `excluded_from` max 100 entries → error if exceeded
 - [ ] No overlap between `visible_to` and `excluded_from` → error
 - [ ] Parent name uniqueness → error on duplicate `(parent_type, parent_id, name)`
+- [ ] `DeleteByParent(ctx, parentType, parentID)` deletes all properties for the given parent entity (for cascade deletion when parent entities are deleted)
 - [ ] Follows existing repository pattern from `internal/world/postgres/location_repo.go`
 - [ ] All tests pass via `task test`
 
@@ -2329,6 +2330,7 @@ git commit -m "feat(access): add lock expression parser and DSL compiler"
 - List by parent (type + ID)
 - Update property (value, visibility, flags)
 - Delete property
+- Delete by parent (type + ID) → deletes all properties for that parent
 - Visibility defaults: `restricted` → auto-set `visible_to=[owner]`, `excluded_from=[]`
 - Constraints: `visible_to` max 100 entries, `excluded_from` max 100 entries
 - No overlap between `visible_to` and `excluded_from` → error
@@ -2363,6 +2365,7 @@ type PropertyRepository interface {
     ListByParent(ctx context.Context, parentType, parentID string) ([]*EntityProperty, error)
     Update(ctx context.Context, p *EntityProperty) error
     Delete(ctx context.Context, id ulid.ULID) error
+    DeleteByParent(ctx context.Context, parentType, parentID string) error
 }
 ```
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -2574,10 +2574,13 @@ git commit -m "refactor(plugin): migrate host functions to AccessPolicyEngine"
 - Delete: `internal/access/static_test.go`
 - Delete: `internal/access/permissions.go` (if only used by static evaluator)
 - Delete: `internal/access/permissions_test.go`
+- Delete: `internal/world/worldtest/mock_AccessControl.go` (generated mock)
+- Delete: `internal/access/accesstest/mock.go` (generated mock)
 - Modify: `internal/access/access.go` — remove `AccessControl` interface
 - Delete or modify: `internal/plugin/capability/` — remove `Enforcer` (capabilities now seed policies)
 - Search and remove: all `char:` prefix usage (replace with `character:`)
 - Search and remove: all `@`-prefixed command name handling
+- Run: `mockery` to regenerate mocks for new `AccessPolicyEngine` interface
 
 **Step 1: Delete static access control files**
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -63,6 +63,8 @@ A task is complete ONLY when: tests pass, acceptance criteria met, AND review pa
 
 ## Phase 7.1: Policy Schema (Database Tables + Policy Store)
 
+> **Note:** Migration numbers in this phase (000015, 000016, 000017) are relative to the current latest migration `000014_aliases`. If other migrations merge before this work, these numbers MUST be updated to avoid collisions.
+
 ### Task 1: Create access\_policies migration
 
 **Spec References:** §8.1 (Policy Storage Schema, lines 1971-2050)

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -1153,6 +1153,7 @@ git commit -m "feat(access): add PolicyCompiler with validation and glob pre-com
 - [ ] Duplicate attribute key within namespace → error
 - [ ] Invalid attribute type → error
 - [ ] `AttrType` enum: `String`, `Int`, `Float`, `Bool`, `StringList`
+- [ ] Providers MUST return all numeric attributes as `float64` (per spec §3.4.1)
 - [ ] All tests pass via `task test`
 
 **Files:**
@@ -1200,12 +1201,17 @@ type LockTokenDef struct {
 package attribute
 
 // AttrType identifies the type of an attribute value.
+//
+// NOTE: Per spec §3.4.1, all numeric attributes MUST be returned as float64
+// by providers at runtime, regardless of whether they are declared as Int or Float.
+// The Int/Float distinction exists only for schema validation and documentation.
+// All numeric comparisons in the policy engine operate on float64 values.
 type AttrType int
 
 const (
     AttrTypeString     AttrType = iota
-    AttrTypeInt
-    AttrTypeFloat
+    AttrTypeInt        // Providers MUST return as float64
+    AttrTypeFloat      // Providers MUST return as float64
     AttrTypeBool
     AttrTypeStringList
 )

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -41,7 +41,7 @@ Applicable ADRs (from spec §18):
 | ADR 0012 | Eager attribute resolution         | Tasks 13, 16    |
 | ADR 0013 | Properties as first-class entities | Tasks 3, 15, 25 |
 | ADR 0014 | Direct replacement (no adapter)    | Tasks 28-30     |
-| ADR 0015 | Fuzz testing for DSL parser        | Task 9          |
+| ADR 0015 | Three-Layer Player Access Control  | Tasks 15, 25    |
 | ADR 0016 | LISTEN/NOTIFY cache invalidation   | Task 17         |
 
 ### Acceptance Criteria
@@ -868,7 +868,7 @@ git commit -m "feat(access): add participle-based DSL parser"
 
 ### Task 9: Add DSL fuzz tests
 
-**Spec References:** ADR 0015 (Fuzz testing for DSL parser), §4 (DSL Grammar)
+**Spec References:** §16 (Testing Strategy — Fuzz Testing, lines 3272-3314), Policy DSL Grammar (lines 737-825)
 
 **Acceptance Criteria:**
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -946,6 +946,8 @@ func FuzzParse(f *testing.F) {
 Run: `go test -fuzz=FuzzParse -fuzztime=30s ./internal/access/policy/dsl/`
 Expected: No panics
 
+**Note:** Direct `go test` is intentional here — fuzz testing is not covered by `task test` runner.
+
 **Step 3: Commit**
 
 ```bash
@@ -1892,6 +1894,8 @@ Setup: 50 active policies (25 permit, 25 forbid), 3 operators per condition aver
 Run: `go test -bench=. -benchmem ./internal/access/policy/`
 Expected: All within spec targets
 
+**Note:** Direct `go test` is intentional here — benchmark testing is not covered by `task test` runner.
+
 **Step 3: Commit**
 
 ```bash
@@ -2637,7 +2641,7 @@ Expected: PASS
 **Step 6: Commit**
 
 ```bash
-git add -A
+git add internal/access/ internal/world/worldtest/ internal/plugin/capability/
 git commit -m "refactor(access): remove StaticAccessControl, AccessControl interface, and capability.Enforcer"
 ```
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -2050,7 +2050,7 @@ git commit -m "feat(access): add seed policy bootstrap sequence"
 
 **Acceptance Criteria:**
 
-- [ ] Core lock tokens registered: `locked`, `faction`, `level`
+- [ ] Core lock tokens registered: `faction`, `flag`, `level`
 - [ ] Plugin lock tokens require namespace prefix (e.g., `myplugin:custom_token`)
 - [ ] Duplicate token → error
 - [ ] `Lookup()` returns definition with DSL expansion info
@@ -2064,7 +2064,7 @@ git commit -m "feat(access): add seed policy bootstrap sequence"
 
 **Step 1: Write failing tests**
 
-- Register core lock tokens (locked, faction, level)
+- Register core lock tokens (faction, flag, level)
 - Register plugin lock tokens (must be namespace-prefixed)
 - Duplicate token → error
 - Lookup token → returns definition with DSL expansion info
@@ -2109,11 +2109,11 @@ git commit -m "feat(access): add lock token registry"
 
 **Acceptance Criteria:**
 
-- [ ] `locked` → generates `forbid` policy with owner exception
 - [ ] `faction:rebels` → generates `forbid` with faction check
+- [ ] `flag:storyteller` → generates `forbid` with flag membership check
 - [ ] `level>5` → generates `forbid` with level comparison (inverted)
-- [ ] `locked+faction:rebels` → compound (multiple forbids)
-- [ ] `!locked` → removes the lock-generated forbid policy
+- [ ] `faction:rebels & flag:storyteller` → compound (multiple forbids)
+- [ ] `!faction:rebels` → negates faction check
 - [ ] Compiler output → valid DSL that `PolicyCompiler` accepts
 - [ ] Invalid lock expression → descriptive error
 - [ ] All tests pass via `task test`
@@ -2129,11 +2129,11 @@ git commit -m "feat(access): add lock token registry"
 
 Lock syntax from spec:
 
-- `locked` → `forbid(principal, action, resource == "<target>") when { principal.id != resource.owner };`
 - `faction:rebels` → `forbid(principal is character, action, resource == "<target>") when { principal.faction != "rebels" };`
+- `flag:storyteller` → `forbid(principal is character, action, resource == "<target>") when { !("storyteller" in principal.flags) };`
 - `level>5` → `forbid(principal is character, action, resource == "<target>") when { principal.level <= 5 };`
-- `locked+faction:rebels` → compound (both conditions as separate forbids or combined)
-- `!locked` → remove the lock-generated forbid policy
+- `faction:rebels & flag:storyteller` → compound (both conditions as separate forbids or combined)
+- `!faction:rebels` → negates faction check
 
 Compiler takes parsed lock expression + target resource string → DSL policy text. Then PolicyCompiler validates the generated DSL.
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -466,6 +466,7 @@ git commit -m "feat(access): add core ABAC types (AccessRequest, Decision, Effec
 - [ ] `stream:location:01XYZ` parses to type `"stream"`, ID `"location:01XYZ"`
 - [ ] Unknown prefix returns `INVALID_ENTITY_REF` error code (oops)
 - [ ] Empty string returns `INVALID_ENTITY_REF` error code
+- [ ] Legacy `char:01ABC` prefix returns `INVALID_ENTITY_REF` error code
 - [ ] Session error code constants defined: `infra:session-invalid`, `infra:session-store-error`
 - [ ] All tests pass via `task test`
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -780,7 +780,7 @@ git commit -m "feat(access): add DSL AST node types with participle annotations"
 
 Table-driven tests MUST cover:
 
-**Valid policies (all 15 seed policies):**
+**Valid policies (14 seed policies plus catch-all forbid test case):**
 
 ```text
 permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };
@@ -1847,7 +1847,7 @@ git commit -m "test(access): add ABAC engine benchmarks for performance targets"
 
 **Step 1: Write failing tests**
 
-- All 15 seed policies compile without error via `PolicyCompiler`
+- All 14 seed policies compile without error via `PolicyCompiler`
 - Each seed policy name starts with `seed:`
 - Each seed policy source is `"seed"`
 - No duplicate seed names
@@ -1866,7 +1866,7 @@ type SeedPolicy struct {
     DSLText     string
 }
 
-// SeedPolicies returns the complete set of 15 seed policies.
+// SeedPolicies returns the complete set of 14 seed policies.
 func SeedPolicies() []SeedPolicy {
     return []SeedPolicy{
         {


### PR DESCRIPTION
## Summary

Fixes all 20 bugs identified during spec-accuracy review of the Full ABAC implementation plan (`docs/plans/2026-02-06-full-abac-implementation.md`).

### P1 Fixes (4 bugs)
- **holomush-5k1.28**: Corrected fabricated ADR 0015 title to "Three-Layer Player Access Control"
- **holomush-5k1.29**: Standardized seed policy count to 14 per spec
- **holomush-5k1.30**: Added missing CHECK constraints and partial index to entity_properties migration
- **holomush-5k1.31**: Replaced `locked` token with `flag` per spec, fixed compound operators

### P2 Fixes (8 bugs)
- **holomush-5k1.32**: Documented composite PK rationale, fixed partition naming and count
- **holomush-5k1.33**: Added ~12 missing spec requirements as new/expanded tasks (Tasks 32-36)
- **holomush-5k1.34**: Added sync denial auditing with WAL fallback to Task 18
- **holomush-5k1.35**: Rewrote Task 22 bootstrap with per-seed checks and version upgrades
- **holomush-5k1.36**: Qualified call site count, marked file list non-exhaustive
- **holomush-5k1.37**: Added mock file deletions to Task 30
- **holomush-5k1.39**: Added audit step (Step 8) to Task 16 acceptance criteria
- **holomush-5k1.45**: Aligned Task 16 step numbering with spec evaluation algorithm

### P3 Fixes (8 bugs)
- **holomush-5k1.38**: Added migration number relativity note to Phase 7.1
- **holomush-5k1.40**: Added char: prefix rejection criterion to Task 5
- **holomush-5k1.41**: Added degraded_mode gauge and audit_failures counter to Task 19
- **holomush-5k1.42**: Added DeleteByParent to PropertyRepository in Task 25
- **holomush-5k1.43**: Already fixed by .31 (lock operators)
- **holomush-5k1.44**: Added note about fragile spec line numbers
- **holomush-5k1.46**: Documented float64 requirement for AttrType in Task 12
- **holomush-5k1.47**: Added fuzz/bench exception notes, fixed git add -A in Task 30

## Test plan

- [ ] Verify plan markdown renders correctly
- [ ] Verify spec line number references are reasonable
- [ ] Verify no remaining fabricated section numbers
- [ ] Verify all 20 beads are closed
- [ ] Run task fmt on plan file

🤖 Generated with [Claude Code](https://claude.com/claude-code)