### PR TITLE
fix(plans): resolve 21 review findings from PR #69 (batch 3)

### DIFF
--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -3526,6 +3526,7 @@ git commit -m "feat(command): add policy validate/reload/attributes/audit/seed/r
 - [ ] Committed per package (dispatcher, world, plugin)
 - [ ] `task test` passes after all migrations
 - [ ] No commits with intentional build breakage
+- [ ] Rollback strategy documented (Decision #65): `git revert` of Task 28 commit(s) restores `AccessControl.Check()` call sites
 
 **Files:**
 
@@ -3622,6 +3623,15 @@ if !decision.Allowed {
 ```
 
 Ensure all subject strings use `character:` prefix (not legacy `char:`).
+
+**Rollback Strategy:**
+
+If serious issues are discovered after Task 28 migration, rollback is performed via `git revert` (documented in Decision #65 of the design decisions document):
+
+1. **Revert Task 28 commit(s)** — This restores all 28 `AccessControl.Check()` call sites and removes `AccessPolicyEngine.Evaluate()` wiring. Each package migration commit (Package 1-4) can be reverted independently or together.
+2. **Do NOT revert Task 29** — Task 29 removes code that still exists at Task 28. If Task 28 is reverted, Task 29's commit should not exist yet (it depends on Task 28 completion). If Task 29 has already been committed, it MUST be reverted first before reverting Task 28.
+
+**Rationale:** No feature flag or adapter layer exists (per Decision #36 and Decision #37 — no adapter, no shadow mode). The migration is a direct replacement with comprehensive test coverage as the safety net. Git revert provides the rollback path (per Decision #65).
 
 ---
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -547,7 +547,7 @@ git commit -m "feat(world): add EntityProperty type and PostgreSQL repository"
 
 > **Note:** This task integrates the PropertyRepository (from Task 4a) with WorldService to ensure properties are cleaned up when parent entities are deleted.
 
-> **Implementation Note:** `WorldService.DeleteCharacter()`, `DeleteObject()`, and `DeleteLocation()` do not currently exist in `internal/world/service.go`. They MUST be created as part of this task's scope before property cascade deletion can be wired in.
+> **Implementation Note:** `WorldService.DeleteCharacter()` does not currently exist in `internal/world/service.go` and MUST be created as part of this task's scope. `DeleteObject()` and `DeleteLocation()` already exist and MUST be modified to add property cascade deletion calls.
 
 > **Scope:** This task modifies WorldService deletion methods to cascade delete properties, adds an orphan cleanup goroutine, and implements startup integrity checks.
 
@@ -565,7 +565,8 @@ git commit -m "feat(world): add EntityProperty type and PostgreSQL repository"
 
 **Files:**
 
-- Modify: `internal/world/service.go` (cascade deletion in DeleteCharacter, DeleteObject, DeleteLocation)
+- Create: `internal/world/service.go` (DeleteCharacter method)
+- Modify: `internal/world/service.go` (cascade deletion in DeleteObject, DeleteLocation)
 - Create: `internal/world/property_lifecycle.go` (orphan cleanup goroutine, startup integrity check)
 - Test: `internal/world/service_test.go` (cascade deletion tests)
 - Test: `internal/world/property_lifecycle_test.go` (orphan cleanup tests)
@@ -596,7 +597,7 @@ func (s *WorldService) DeleteCharacter(ctx context.Context, id string) error {
 }
 ```
 
-Repeat for `DeleteObject()` and `DeleteLocation()`.
+Add similar property cascade deletion logic to existing `DeleteObject()` and `DeleteLocation()` methods.
 
 **Step 3: Implement orphan cleanup**
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -555,8 +555,12 @@ git commit -m "feat(world): add EntityProperty type and PostgreSQL repository"
 - [ ] `WorldService.DeleteCharacter()` → `PropertyRepository.DeleteByParent("character", charID)` in same transaction
 - [ ] `WorldService.DeleteObject()` → `PropertyRepository.DeleteByParent("object", objID)` in same transaction
 - [ ] `WorldService.DeleteLocation()` → `PropertyRepository.DeleteByParent("location", locID)` in same transaction
-- [ ] Orphan cleanup goroutine: periodic check for orphaned properties (parent entity no longer exists) and delete them
-- [ ] Startup integrity check: scan for orphaned properties, log count at WARN level, schedule cleanup
+- [ ] Orphan cleanup goroutine: runs on configurable timer (default: daily) to detect orphaned properties (parent entity no longer exists)
+- [ ] Orphan cleanup: detected orphans logged at WARN level on first discovery
+- [ ] Orphan cleanup: configurable grace period (default: 24h, configured via `world.orphan_grace_period` in server YAML)
+- [ ] Orphan cleanup: orphans persisting across two consecutive runs are actively deleted with batch `DELETE` and logged at INFO level with count
+- [ ] Startup integrity check: count orphaned properties on server startup
+- [ ] Startup integrity check: if orphan count exceeds configurable threshold (default: 100), log at ERROR level but continue starting (not fail-fast)
 - [ ] All tests pass via `task test`
 
 **Files:**

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -194,6 +194,9 @@ graph TD
     style T4c fill:#ffcccc
     style T7 fill:#ffcccc
     style T12 fill:#ffcccc
+    style T13 fill:#ffcccc
+    style T14 fill:#ffcccc
+    style T15 fill:#ffcccc
     style T17 fill:#ffcccc
     style T18 fill:#ffcccc
     style T23 fill:#ffcccc
@@ -201,11 +204,15 @@ graph TD
     style T29 fill:#ffcccc
 ```
 
-**Critical Path (highlighted in red):** Task 3 → Task 4a → Task 4b → Task 4c → Task 7 → Task 12 → Task 17 → Task 18 → Task 23 → Task 28 → Task 29
+**Critical Path (highlighted in red):** Task 3 → Task 4a → Task 4b → Task 4c → Task 7 → (DSL chain: Task 12) + (Provider chain: Task 13 → Task 14 → Task 15) → Task 17 → Task 18 → Task 23 → Task 28 → Task 29
+
+**Note:** Task 17 depends on BOTH Task 12 (DSL compiler) and Task 15 (core attribute providers). These chains can run in parallel after Task 7 completes, but both must finish before Task 17 can start.
 
 **Parallel Work Opportunities:**
 
-- Phase 7.2 (Tasks 8-11) can start independently; only Task 12 (PolicyCompiler) requires Task 7
+- After Task 7 completes, two critical chains can run in parallel:
+  - DSL chain: Tasks 8-11 can start independently; only Task 12 (PolicyCompiler) requires Task 7
+  - Provider chain: Tasks 13-15 (attribute providers) can run in parallel with the DSL chain
 - Task 16a (simple providers) can proceed independently of Task 16b (PropertyProvider)
 - Task 19b (audit retention) can proceed in parallel with Task 20 (metrics)
 - Phase 7.5 (Locks & Admin) can proceed independently after Task 23

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -3977,12 +3977,13 @@ git commit -m "test(access): add ABAC integration tests with seed policies and p
 
 Intentional deviations from the design spec, tracked here for discoverability and review.
 
-| Deviation                                                        | Spec Reference  | Task    | Rationale                                                                         |
-| ---------------------------------------------------------------- | --------------- | ------- | --------------------------------------------------------------------------------- |
-| Primary key uses composite PK instead of spec's serial PK        | Spec line ~2015 | Task 2  | Better partition compatibility                                                    |
-| Metric labels use `{source, effect}` instead of `{name, effect}` | Spec line 1877  | Task 20 | Prevents unbounded cardinality from admin-created policy names                    |
-| Denial audit sync writes elevated from SHOULD to MUST            | Spec line 2238  | Task 19 | Denial audit integrity critical for security forensics; ~1-2ms latency acceptable |
-| Lock naming uses `lock:<type>:<id>:<action>` format              | Spec line 2656  | Task 26 | Explicit resource type prefix improves discoverability and query filtering        |
+| Deviation                                                        | Spec Reference    | Task    | Rationale                                                                                                                                |
+| ---------------------------------------------------------------- | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary key uses composite PK instead of spec's serial PK        | Spec line ~2015   | Task 2  | Better partition compatibility                                                                                                           |
+| Metric labels use `{source, effect}` instead of `{name, effect}` | Spec line 1877    | Task 20 | Prevents unbounded cardinality from admin-created policy names                                                                           |
+| Denial audit sync writes elevated from SHOULD to MUST            | Spec line 2238    | Task 19 | Denial audit integrity critical for security forensics; ~1-2ms latency acceptable                                                        |
+| Lock naming uses `lock:<type>:<id>:<action>` format              | Spec line 2656    | Task 26 | Explicit resource type prefix improves discoverability and query filtering                                                               |
+| Policy compilation moved from PolicyStore to caller              | Spec lines 278-281 | Task 7  | Keeps store as pure data access layer; PolicyService wrapper considered but deferred for simplicity; caller validates before persisting |
 
 ## Deferred Features
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -2925,7 +2925,7 @@ git commit -m "feat(access): define seed policies"
 
 ### Task 23: Bootstrap sequence
 
-**Spec References:** Bootstrap Sequence (lines 2916-2992), Seed Policy Migrations (lines 3123-3173)
+**Spec References:** Bootstrap Sequence (lines 3007-3122), Seed Policy Migrations (lines 3123-3173)
 
 **Acceptance Criteria:**
 

--- a/docs/plans/2026-02-06-full-abac-implementation.md
+++ b/docs/plans/2026-02-06-full-abac-implementation.md
@@ -3870,6 +3870,7 @@ Intentional deviations from the design spec, tracked here for discoverability an
 | Primary key uses composite PK instead of spec's serial PK        | Spec line ~2015 | Task 2  | Better partition compatibility                                                    |
 | Metric labels use `{source, effect}` instead of `{name, effect}` | Spec line 1877  | Task 20 | Prevents unbounded cardinality from admin-created policy names                    |
 | Denial audit sync writes elevated from SHOULD to MUST            | Spec line 2238  | Task 19 | Denial audit integrity critical for security forensics; ~1-2ms latency acceptable |
+| Lock naming uses `lock:<type>:<id>:<action>` format              | Spec line 2656  | Task 26 | Explicit resource type prefix improves discoverability and query filtering        |
 
 ## Deferred Features
 

--- a/docs/specs/2026-02-05-full-abac-design-decisions.md
+++ b/docs/specs/2026-02-05-full-abac-design-decisions.md
@@ -1553,8 +1553,8 @@ decision #19 (Lock Policies Are Not Versioned); bead `holomush-5k1.193`.
 decision `Effect` enum (`EffectDefaultDeny`, `EffectAllow`, `EffectDeny`,
 `EffectSystemBypass`) for `StoredPolicy.Effect`. But the database stores policy
 effect as `TEXT CHECK ('permit', 'forbid')` — a fundamentally different concept.
-Policy effect declares what a policy *intends* (permit or forbid); decision
-effect records what the engine *decided* (allow, deny, default_deny, or
+Policy effect declares what a policy _intends_ (permit or forbid); decision
+effect records what the engine _decided_ (allow, deny, default_deny, or
 system_bypass). Conflating them creates type confusion and invalid states
 (e.g., a stored policy with `EffectSystemBypass`).
 
@@ -1568,8 +1568,15 @@ runtime outcome. Separating them makes invalid states unrepresentable at the
 type level. A stored policy can only be `permit` or `forbid`; the
 `system_bypass` and `default_deny` variants only exist in evaluation results.
 
+**Implementation note (PR #69, C2):** The bootstrap code in Task 21 no longer
+needs to convert between types. `PolicyCompiler` returns `CompiledPolicy.Effect`
+as `PolicyEffect` directly, which is stored in `StoredPolicy.Effect` without
+conversion. The awkward switch statement comparing `compiled.Effect` against
+`policy.EffectAllow`/`policy.EffectDeny` (which are decision-level values) was
+eliminated by making the type correction at the compiler level.
+
 **Cross-reference:** Main spec, Policy Data Model section; bead
-`holomush-5k1.53`.
+`holomush-5k1.53`, `holomush-5k1.202`.
 
 ---
 

--- a/docs/specs/2026-02-05-full-abac-design.md
+++ b/docs/specs/2026-02-05-full-abac-design.md
@@ -2410,15 +2410,15 @@ Two forms are supported:
 1. **Action-specific unlock:** `unlock <resource>/<action>` removes the lock
    policy for the specified action on the resource. Example:
    `unlock my-chest/read` deletes the policy named
-   `lock:<resource_ulid>:read`.
+   `lock:object:<resource_ulid>:read`.
 
 2. **Resource-wide unlock:** `unlock <resource>` removes **all** lock policies
    for the resource across all actions. Example: `unlock my-chest` deletes all
-   policies matching the pattern `lock:<resource_ulid>:*`. The implementation
-   **MUST** query `PolicyStore` with
-   `WHERE name LIKE 'lock:<resource_ulid>:%'` and delete all matching
-   policies. This ensures bulk unlock for resources with multiple action
-   locks.
+   policies matching the pattern `lock:object:<resource_ulid>:*`. The
+   implementation **MUST** query `PolicyStore` with
+   `WHERE name LIKE 'lock:object:<resource_ulid>:%'` (or equivalent pattern for
+   the resolved resource type) and delete all matching policies. This ensures
+   bulk unlock for resources with multiple action locks.
 
 **Resource target resolution:** The lock command resolves the resource target
 (the part before `/`) using the same name resolution as other world commands:


### PR DESCRIPTION
## Summary

Resolves all remaining open bugs from Epic 7 (holomush-5k1) PR #69 code review findings:

- **4 P1 (Critical):** Task 4b deletion claims, ADR #60 Task 16c removal, ADR #62 Effect type, ADR #61 lock naming
- **10 P2 (Important):** Orphan cleanup criteria, Task 4b split, functions.go migration, rollback strategy, CTE cycle detection, audit sync/async, spec references, compilation deviation, critical path, AST spike
- **7 P3 (Suggestion):** XDG path, Task 21a scope, ParentID type, provider starvation, degraded mode triggers, deferred features, Task 21a independence

Also closed 6 duplicate bugs that overlapped with more detailed findings.

## Changes

| Commit | Finding |
|--------|---------|
| correct Task 4b — only DeleteCharacter needs creation | C: Task 4b false claims |
| apply ADR #60 — remove Task 16c, add visibility seed policies | C1: ADR #60 not applied |
| apply ADR #62 — CompiledPolicy.Effect uses PolicyEffect type | C2: Effect type mismatch |
| add lock naming deviation to table, fix spec inconsistency | C3: ADR #61 missing |
| strengthen Task 4b orphan cleanup acceptance criteria per spec | I6: Orphan cleanup underspecified |
| split Task 4b — separate deletion methods from property cascade | I2: Task 4b scope creep |
| account for functions.go in migration tasks | I8: functions.go excluded |
| add rollback strategy to Task 28 migration | I3: No rollback path |
| add cycle detection to Task 16b recursive CTE | I4: CTE missing cycle detection |
| system bypasses use sync audit path like denials | I5: Audit async/sync contradiction |
| correct Task 23 bootstrap sequence spec reference | I7: Wrong spec reference |
| document compilation spec deviation in Task 7 | I: Compilation deviation |
| include attribute provider chain in critical path | I: Critical path gap |
| add Task 0 AST serialization spike | I1: AST serialization risk |
| resolve 7 P3 review findings (suggestions batch) | S1-S5: Various suggestions |

## Test plan

- [ ] All markdown lints pass (`task lint`)
- [ ] Mermaid diagrams render correctly
- [ ] Spec Deviations table has all documented deviations
- [ ] Seed policy count is consistent (16) throughout plan
- [ ] No remaining references to removed Task 16c

🤖 Generated with [Claude Code](https://claude.com/claude-code)