### PR TITLE
fix(lint): resolve markdown lint errors and update linter excludes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,7 +489,6 @@ Default deny - explicit permission required for all operations.
 - Events are immutable and ordered
 - State is derived from event replay
 
-
 <!-- BEGIN BEADS INTEGRATION -->
 ## Issue Tracking with bd (beads)
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -178,7 +178,7 @@ tasks:
   lint:markdown:
     desc: Lint Markdown files
     cmds:
-      - rumdl check --exclude site .
+      - rumdl check --exclude 'site,.git,.beads,.serena' .
       - rumdl check --config site/.rumdl.toml site/
 
   lint:yaml:
@@ -203,7 +203,7 @@ tasks:
   fmt:markdown:
     desc: Format Markdown files
     cmds:
-      - rumdl fmt --exclude site .
+      - rumdl fmt --exclude 'site,.git,.beads,.serena' .
       - rumdl fmt --config site/.rumdl.toml site/
 
   fmt:go:
@@ -225,7 +225,7 @@ tasks:
     desc: Check formatting without modifying
     cmds:
       - dprint check
-      - rumdl fmt --check --exclude site .
+      - rumdl fmt --check --exclude 'site,.git,.beads,.serena' .
       - rumdl fmt --check --config site/.rumdl.toml site/
 
   # Dependencies

--- a/docs/adr/0009-custom-go-native-abac-engine.md
+++ b/docs/adr/0009-custom-go-native-abac-engine.md
@@ -127,6 +127,6 @@ resolve full attribute bags for any entity.
 ## References
 
 - [Full ABAC Architecture Design](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #1: Policy Engine Approach](../specs/2026-02-05-full-abac-design-decisions.md#1-policy-engine-approach)
-- [Design Decision #2: Policy Definition Format](../specs/2026-02-05-full-abac-design-decisions.md#2-policy-definition-format)
+- [Design Decision #1: Policy Engine Approach](../specs/decisions/epic7/general/001-policy-engine-approach.md)
+- [Design Decision #2: Policy Definition Format](../specs/decisions/epic7/general/002-policy-definition-format.md)
 - [Cedar Language Specification](https://docs.cedarpolicy.com/)

--- a/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
+++ b/docs/adr/0010-cedar-aligned-fail-safe-type-semantics.md
@@ -157,5 +157,5 @@ is the primary security guarantee of the type system.
 ## References
 
 - [Full ABAC Architecture Design — Type System](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #28: Cedar-Aligned Missing Attribute Semantics](../specs/2026-02-05-full-abac-design-decisions.md#28-cedar-aligned-missing-attribute-semantics)
+- [Design Decision #28: Cedar-Aligned Missing Attribute Semantics](../specs/decisions/epic7/phase-7.3/028-cedar-aligned-missing-attribute-semantics.md)
 - [Cedar Language Specification — Type System](https://docs.cedarpolicy.com/)

--- a/docs/adr/0011-deny-overrides-without-priority.md
+++ b/docs/adr/0011-deny-overrides-without-priority.md
@@ -142,5 +142,5 @@ think "narrow the deny condition itself so the unwanted cases no longer match."
 ## References
 
 - [Full ABAC Architecture Design — Evaluation Algorithm](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #4: Conflict Resolution](../specs/2026-02-05-full-abac-design-decisions.md#4-conflict-resolution)
+- [Design Decision #4: Conflict Resolution](../specs/decisions/epic7/general/004-conflict-resolution.md)
 - [Cedar Language Specification — Policy Evaluation](https://docs.cedarpolicy.com/)

--- a/docs/adr/0012-eager-attribute-resolution.md
+++ b/docs/adr/0012-eager-attribute-resolution.md
@@ -136,5 +136,5 @@ request cycle is an edge case that resolves on the next request.
 ## References
 
 - [Full ABAC Architecture Design — Attribute Resolution](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #3: Attribute Resolution Strategy](../specs/2026-02-05-full-abac-design-decisions.md#3-attribute-resolution-strategy)
-- [Design Decision #26: Per-Request Attribute Caching](../specs/2026-02-05-full-abac-design-decisions.md#26-per-request-attribute-caching)
+- [Design Decision #3: Attribute Resolution Strategy](../specs/decisions/epic7/general/003-attribute-resolution-strategy.md)
+- [Design Decision #26: Per-Request Attribute Caching](../specs/decisions/epic7/phase-7.3/026-per-request-attribute-caching.md)

--- a/docs/adr/0013-properties-as-first-class-entities.md
+++ b/docs/adr/0013-properties-as-first-class-entities.md
@@ -187,6 +187,6 @@ without adding anyone to the list.
 ## References
 
 - [Full ABAC Architecture Design — Property Model](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #9: Property Model](../specs/2026-02-05-full-abac-design-decisions.md#9-property-model)
-- [Design Decision #18: Property Package Ownership](../specs/2026-02-05-full-abac-design-decisions.md#18-property-package-ownership)
-- [Design Decision #32: PropertyProvider Uses SQL JOIN](../specs/2026-02-05-full-abac-design-decisions.md#32-propertyprovider-uses-sql-join-for-parent-location)
+- [Design Decision #9: Property Model](../specs/decisions/epic7/phase-7.1/009-property-model.md)
+- [Design Decision #18: Property Package Ownership](../specs/decisions/epic7/phase-7.1/018-property-package-ownership.md)
+- [Design Decision #32: PropertyProvider Uses SQL JOIN](../specs/decisions/epic7/phase-7.3/032-property-provider-sql-join.md)

--- a/docs/adr/0014-direct-static-access-control-replacement.md
+++ b/docs/adr/0014-direct-static-access-control-replacement.md
@@ -154,6 +154,6 @@ code with no long-term value.
 ## References
 
 - [Full ABAC Architecture Design — Replacing Static Roles](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #36: Direct Replacement](../specs/2026-02-05-full-abac-design-decisions.md#36-direct-replacement-no-adapter)
-- [Design Decision #37: No Shadow Mode](../specs/2026-02-05-full-abac-design-decisions.md#37-no-shadow-mode)
+- [Design Decision #36: Direct Replacement](../specs/decisions/epic7/phase-7.6/036-direct-replacement-no-adapter.md)
+- [Design Decision #37: No Shadow Mode](../specs/decisions/epic7/phase-7.6/037-no-shadow-mode.md)
 - [ADR 0007: Command Security Model](0007-command-security-model.md) (superseded)

--- a/docs/adr/0015-three-layer-player-access-control.md
+++ b/docs/adr/0015-three-layer-player-access-control.md
@@ -194,9 +194,8 @@ plugin tokens require a dot prefix).
 
 ## References
 
-- [Full ABAC Architecture Design — Access Control Layers](../specs/2026-02-05-full-abac-design.md#access-control-layers)
-- [Full ABAC Architecture Design — Lock Token Registry](../specs/2026-02-05-full-abac-design.md#layer-2-object-locks-owners)
-- [Design Decision #12: Player Access Control Layers](../specs/2026-02-05-full-abac-design-decisions.md#12-player-access-control-layers)
-- [Design Decision #19: Lock Policies Are Not Versioned](../specs/2026-02-05-full-abac-design-decisions.md#19-lock-policies-are-not-versioned)
-- [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/2026-02-05-full-abac-design-decisions.md#33-plugin-lock-tokens-must-be-namespaced)
+- [Full ABAC Architecture Design — Layers & Commands](../specs/abac/06-layers-commands.md)
+- [Design Decision #12: Player Access Control Layers](../specs/decisions/epic7/phase-7.1/012-player-access-control-layers.md)
+- [Design Decision #19: Lock Policies Are Not Versioned](../specs/decisions/epic7/phase-7.5/019-lock-policies-are-not-versioned.md)
+- [Design Decision #33: Plugin Lock Tokens MUST Be Namespaced](../specs/decisions/epic7/phase-7.5/033-plugin-lock-tokens-must-be-namespaced.md)
 - [ADR 0011: Deny-Overrides Without Priority](0011-deny-overrides-without-priority.md)

--- a/docs/adr/0016-listen-notify-policy-cache-invalidation.md
+++ b/docs/adr/0016-listen-notify-policy-cache-invalidation.md
@@ -185,5 +185,5 @@ for the current single-server architecture.
 ## References
 
 - [Full ABAC Architecture Design — Cache Invalidation](../specs/2026-02-05-full-abac-design.md)
-- [Design Decision #11: Cache Invalidation](../specs/2026-02-05-full-abac-design-decisions.md#11-cache-invalidation)
+- [Design Decision #11: Cache Invalidation](../specs/decisions/epic7/phase-7.3/011-cache-invalidation.md)
 - [PostgreSQL LISTEN/NOTIFY Documentation](https://www.postgresql.org/docs/current/sql-notify.html)

--- a/docs/specs/abac/01-core-types.md
+++ b/docs/specs/abac/01-core-types.md
@@ -1,9 +1,9 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Core Interfaces
+# Core Interfaces
 
-### AccessPolicyEngine
+## AccessPolicyEngine
 
 ```go
 // AccessPolicyEngine is the main entry point for policy-based authorization.

--- a/docs/specs/abac/02-policy-dsl.md
+++ b/docs/specs/abac/02-policy-dsl.md
@@ -1,12 +1,12 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Policy DSL
+# Policy DSL
 
 The DSL is Cedar-inspired with a full expression language. Policies have a
 **target** (what they apply to) and optional **conditions** (when they apply).
 
-### Grammar
+## Grammar
 
 ````text
 policy     = effect "(" target ")" [ "when" "{" conditions "}" ] ";"

--- a/docs/specs/abac/03-property-model.md
+++ b/docs/specs/abac/03-property-model.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Property Model
+# Property Model
 
 Properties are first-class entities with their own identity, ownership, and
 access control attributes. This provides conceptual uniformity — characters,
@@ -38,7 +38,7 @@ This prevents a circular dependency:
 `Engine → PropertyProvider → PropertyRepository` (no callback to Engine).
 `PropertyProvider` MUST NOT depend on `WorldService` or `AccessPolicyEngine`.
 
-### Property Attributes
+## Property Attributes
 
 | Attribute         | Type     | Description                                                                   |
 | ----------------- | -------- | ----------------------------------------------------------------------------- |

--- a/docs/specs/abac/04-resolution-evaluation.md
+++ b/docs/specs/abac/04-resolution-evaluation.md
@@ -1,13 +1,13 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Attribute Resolution
+# Attribute Resolution
 
 The engine uses eager resolution: all attributes are collected before any policy
 is evaluated. This provides a complete attribute snapshot for every decision,
 which powers audit logging and the `policy test` debugging command.
 
-### Resolution Flow
+## Resolution Flow
 
 ```text
 Evaluate(ctx, AccessRequest{Subject: "character:01ABC", Action: "enter", Resource: "location:01XYZ"})

--- a/docs/specs/abac/07-migration-seeds.md
+++ b/docs/specs/abac/07-migration-seeds.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Replacing Static Roles
+# Replacing Static Roles
 
 **Design decision:** HoloMUSH has no production releases. The static
 `AccessControl` system from Epic 3 is replaced entirely by `AccessPolicyEngine`.
@@ -13,7 +13,7 @@ migration adapters, shadow mode metrics, cutover criteria). See
 and [decision #37](../decisions/epic7/phase-7.6/037-no-shadow-mode.md)
 in the decisions log.
 
-### Seed Policies
+## Seed Policies
 
 The seed policies define the default permission model. They use the ABAC
 engine's full capabilities (attribute-based conditions, `enter` action for

--- a/docs/specs/abac/08-testing-appendices.md
+++ b/docs/specs/abac/08-testing-appendices.md
@@ -1,9 +1,9 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- Copyright 2026 HoloMUSH Contributors -->
 
-## Testing Strategy
+# Testing Strategy
 
-### Unit Tests
+## Unit Tests
 
 ```text
 internal/access/policy/dsl/


### PR DESCRIPTION
## Summary

- Add `.git`, `.beads`, `.serena` to rumdl excludes in Taskfile.yaml
- Add H1 headings to 6 ABAC spec files in `docs/specs/abac/`
- Update 8 ADRs to link to reorganized decision files under `docs/specs/decisions/epic7/`
- Remove extra blank lines in CLAUDE.md

All lint checks now pass cleanly.