### PR TITLE
feat(access): ABAC Phase 7.2 — DSL parser, evaluator, and compiler

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -95,6 +95,14 @@ tasks:
     cmds:
       - ginkgo -r -p --randomize-all ./test/integration/...
 
+  test:fuzz:
+    desc: Run fuzz tests
+    cmds:
+      - go test -fuzz=FuzzParse -fuzztime={{.FUZZ_TIME}} {{.FUZZ_PACKAGE}}
+    vars:
+      FUZZ_TIME: '{{default "30s" .FUZZ_TIME}}'
+      FUZZ_PACKAGE: '{{default "./internal/access/policy/dsl/" .FUZZ_PACKAGE}}'
+
   mocks:generate:
     desc: Generate mocks with mockery
     cmds:

--- a/internal/access/policy/compiler.go
+++ b/internal/access/policy/compiler.go
@@ -147,8 +147,8 @@ func mapEffect(effect string) (types.PolicyEffect, error) {
 // validateAttributes walks all condition nodes and validates attribute references
 // against the schema.
 func (c *Compiler) validateAttributes(cb *dsl.ConditionBlock) ([]ValidationWarning, error) {
-	var warnings []ValidationWarning
 	refs := collectAttrRefs(cb)
+	warnings := make([]ValidationWarning, 0, len(refs))
 
 	for _, ref := range refs {
 		if !c.schema.HasNamespace(ref.namespace) {

--- a/internal/access/policy/compiler.go
+++ b/internal/access/policy/compiler.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package policy provides a compiler that parses, validates, and optimizes
+// ABAC policy DSL text into an executable form.
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobwas/glob"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// maxGlobPatternLen is the maximum allowed length for a like pattern.
+const maxGlobPatternLen = 100
+
+// maxGlobWildcards is the maximum number of wildcard characters (* or ?)
+// allowed in a like pattern.
+const maxGlobWildcards = 5
+
+// Compiler parses and validates DSL policy text.
+type Compiler struct {
+	schema *types.AttributeSchema
+}
+
+// NewCompiler creates a Compiler with the given schema.
+func NewCompiler(schema *types.AttributeSchema) *Compiler {
+	return &Compiler{schema: schema}
+}
+
+// ValidationWarning is a non-blocking issue found during compilation.
+type ValidationWarning struct {
+	Message string
+}
+
+// CompiledPolicy is the parsed, validated, and optimized form of a policy.
+type CompiledPolicy struct {
+	GrammarVersion int                `json:"grammar_version"`
+	Effect         types.PolicyEffect `json:"effect"`
+	Target         CompiledTarget     `json:"target"`
+	Conditions     *dsl.ConditionBlock `json:"conditions,omitempty"`
+	GlobCache      map[string]glob.Glob `json:"-"`
+	DSLText        string             `json:"dsl_text"`
+}
+
+// CompiledTarget is the parsed target clause.
+type CompiledTarget struct {
+	PrincipalType *string  `json:"principal_type,omitempty"`
+	ActionList    []string `json:"action_list,omitempty"`
+	ResourceType  *string  `json:"resource_type,omitempty"`
+	ResourceExact *string  `json:"resource_exact,omitempty"`
+}
+
+// Compile parses DSL text, validates it, and returns a compiled policy.
+func (c *Compiler) Compile(dslText string) (*CompiledPolicy, []ValidationWarning, error) {
+	// Step 1: Parse
+	parsed, err := dsl.Parse(dslText)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse error: %w", err)
+	}
+
+	// Step 2: Build CompiledTarget
+	target := buildTarget(parsed.Target)
+
+	// Step 3: Map effect
+	effect, err := mapEffect(parsed.Effect)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Step 4: Validate attributes and collect warnings
+	var warnings []ValidationWarning
+	if parsed.Conditions != nil {
+		var attrErr error
+		warnings, attrErr = c.validateAttributes(parsed.Conditions)
+		if attrErr != nil {
+			return nil, nil, attrErr
+		}
+	}
+
+	// Step 5: Detect unreachable and always-true conditions
+	if parsed.Conditions != nil {
+		warnings = append(warnings, detectConditionWarnings(parsed.Conditions)...)
+	}
+
+	// Step 6: Pre-compile glob patterns
+	globCache, err := precompileGlobs(parsed.Conditions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := &CompiledPolicy{
+		GrammarVersion: dsl.GrammarVersion,
+		Effect:         effect,
+		Target:         target,
+		Conditions:     parsed.Conditions,
+		GlobCache:      globCache,
+		DSLText:        dslText,
+	}
+
+	return result, warnings, nil
+}
+
+// buildTarget converts a parsed Target AST into a CompiledTarget.
+func buildTarget(t *dsl.Target) CompiledTarget {
+	ct := CompiledTarget{}
+
+	if t.Principal != nil && t.Principal.Type != "" {
+		s := t.Principal.Type
+		ct.PrincipalType = &s
+	}
+
+	if t.Action != nil && len(t.Action.Actions) > 0 {
+		ct.ActionList = t.Action.Actions
+	}
+
+	if t.Resource != nil {
+		if t.Resource.Type != "" {
+			s := t.Resource.Type
+			ct.ResourceType = &s
+		}
+		if t.Resource.Equality != "" {
+			s := t.Resource.Equality
+			ct.ResourceExact = &s
+		}
+	}
+
+	return ct
+}
+
+// mapEffect converts a DSL effect string to PolicyEffect.
+func mapEffect(effect string) (types.PolicyEffect, error) {
+	switch effect {
+	case "permit":
+		return types.PolicyEffectPermit, nil
+	case "forbid":
+		return types.PolicyEffectForbid, nil
+	default:
+		return "", fmt.Errorf("unknown effect: %q", effect)
+	}
+}
+
+// validateAttributes walks all condition nodes and validates attribute references
+// against the schema.
+func (c *Compiler) validateAttributes(cb *dsl.ConditionBlock) ([]ValidationWarning, error) {
+	var warnings []ValidationWarning
+	refs := collectAttrRefs(cb)
+
+	for _, ref := range refs {
+		if !c.schema.HasNamespace(ref.namespace) {
+			continue
+		}
+		if c.schema.IsRegistered(ref.namespace, ref.key) {
+			continue
+		}
+
+		fqn := ref.namespace + "." + ref.key
+		if ref.namespace == "action" {
+			return nil, fmt.Errorf("unregistered action attribute %q: action namespace is registered but attribute is not", fqn)
+		}
+		warnings = append(warnings, ValidationWarning{
+			Message: fmt.Sprintf("unknown attribute %q in registered namespace %q", fqn, ref.namespace),
+		})
+	}
+
+	return warnings, nil
+}
+
+// attrRefInfo holds a normalized attribute reference for validation.
+type attrRefInfo struct {
+	namespace string
+	key       string
+}
+
+// collectAttrRefs walks the condition tree and extracts all attribute references.
+func collectAttrRefs(cb *dsl.ConditionBlock) []attrRefInfo {
+	var refs []attrRefInfo
+	for _, conj := range cb.Disjunctions {
+		for _, cond := range conj.Conditions {
+			refs = append(refs, collectFromCondition(cond)...)
+		}
+	}
+	return refs
+}
+
+// collectFromCondition recursively extracts attribute references from a condition.
+func collectFromCondition(c *dsl.Condition) []attrRefInfo {
+	var refs []attrRefInfo
+
+	switch {
+	case c.Negation != nil:
+		refs = append(refs, collectFromCondition(c.Negation)...)
+
+	case c.Parenthesized != nil:
+		refs = append(refs, collectAttrRefs(c.Parenthesized)...)
+
+	case c.IfThenElse != nil:
+		refs = append(refs, collectFromCondition(c.IfThenElse.If)...)
+		refs = append(refs, collectFromCondition(c.IfThenElse.Then)...)
+		refs = append(refs, collectFromCondition(c.IfThenElse.Else)...)
+
+	case c.Has != nil:
+		if len(c.Has.Path) > 0 {
+			refs = append(refs, attrRefInfo{
+				namespace: c.Has.Root,
+				key:       c.Has.Path[0],
+			})
+		}
+
+	case c.Contains != nil:
+		if len(c.Contains.Path) > 0 {
+			refs = append(refs, attrRefInfo{
+				namespace: c.Contains.Root,
+				key:       c.Contains.Path[0],
+			})
+		}
+
+	case c.Comparison != nil:
+		refs = append(refs, collectFromExpr(c.Comparison.Left)...)
+		refs = append(refs, collectFromExpr(c.Comparison.Right)...)
+
+	case c.Like != nil:
+		refs = append(refs, collectFromExpr(c.Like.Left)...)
+
+	case c.InList != nil:
+		refs = append(refs, collectFromExpr(c.InList.Left)...)
+
+	case c.InExpr != nil:
+		refs = append(refs, collectFromExpr(c.InExpr.Left)...)
+		refs = append(refs, collectFromExpr(c.InExpr.Right)...)
+	}
+
+	return refs
+}
+
+// collectFromExpr extracts attribute references from an expression.
+func collectFromExpr(e *dsl.Expr) []attrRefInfo {
+	if e.AttrRef != nil && len(e.AttrRef.Path) > 0 {
+		return []attrRefInfo{{
+			namespace: e.AttrRef.Root,
+			key:       e.AttrRef.Path[0],
+		}}
+	}
+	return nil
+}
+
+// detectConditionWarnings checks for unreachable and always-true conditions.
+func detectConditionWarnings(cb *dsl.ConditionBlock) []ValidationWarning {
+	var warnings []ValidationWarning
+
+	// Check for always-true: single disjunction, single conjunction, single condition = true
+	if len(cb.Disjunctions) == 1 {
+		conj := cb.Disjunctions[0]
+		if len(conj.Conditions) == 1 {
+			cond := conj.Conditions[0]
+			if cond.BoolLiteral != nil && *cond.BoolLiteral {
+				warnings = append(warnings, ValidationWarning{
+					Message: "condition block is always true; consider removing the when clause",
+				})
+			}
+		}
+	}
+
+	// Check for unreachable: any conjunction starting with false && ...
+	for _, conj := range cb.Disjunctions {
+		if len(conj.Conditions) > 1 {
+			first := conj.Conditions[0]
+			if first.BoolLiteral != nil && !*first.BoolLiteral {
+				warnings = append(warnings, ValidationWarning{
+					Message: "unreachable conditions: conjunction starts with false",
+				})
+			}
+		}
+	}
+
+	return warnings
+}
+
+// precompileGlobs walks all LikeConditions, validates patterns, and compiles them.
+func precompileGlobs(cb *dsl.ConditionBlock) (map[string]glob.Glob, error) {
+	if cb == nil {
+		return nil, nil
+	}
+
+	patterns := collectLikePatterns(cb)
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	cache := make(map[string]glob.Glob, len(patterns))
+	for _, pattern := range patterns {
+		if _, exists := cache[pattern]; exists {
+			continue
+		}
+		if err := validateGlobPattern(pattern); err != nil {
+			return nil, err
+		}
+		compiled, err := glob.Compile(pattern, ':')
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
+		}
+		cache[pattern] = compiled
+	}
+
+	return cache, nil
+}
+
+// validateGlobPattern checks a glob pattern against safety limits.
+func validateGlobPattern(pattern string) error {
+	if len(pattern) > maxGlobPatternLen {
+		return fmt.Errorf("glob pattern exceeds maximum length of %d: %d characters", maxGlobPatternLen, len(pattern))
+	}
+
+	if strings.Contains(pattern, "[") {
+		return fmt.Errorf("glob pattern contains bracket character class (not allowed): %q", pattern)
+	}
+	if strings.Contains(pattern, "{") {
+		return fmt.Errorf("glob pattern contains brace alternation (not allowed): %q", pattern)
+	}
+	if strings.Contains(pattern, "**") {
+		return fmt.Errorf("glob pattern contains globstar (not allowed): %q", pattern)
+	}
+
+	wildcardCount := 0
+	for _, ch := range pattern {
+		if ch == '*' || ch == '?' {
+			wildcardCount++
+		}
+	}
+	if wildcardCount > maxGlobWildcards {
+		return fmt.Errorf("glob pattern has %d wildcard characters (maximum %d)", wildcardCount, maxGlobWildcards)
+	}
+
+	return nil
+}
+
+// collectLikePatterns walks the condition tree and extracts all like patterns.
+func collectLikePatterns(cb *dsl.ConditionBlock) []string {
+	var patterns []string
+	for _, conj := range cb.Disjunctions {
+		for _, cond := range conj.Conditions {
+			patterns = append(patterns, collectPatternsFromCondition(cond)...)
+		}
+	}
+	return patterns
+}
+
+// collectPatternsFromCondition recursively extracts like patterns from a condition.
+func collectPatternsFromCondition(c *dsl.Condition) []string {
+	var patterns []string
+
+	switch {
+	case c.Negation != nil:
+		patterns = append(patterns, collectPatternsFromCondition(c.Negation)...)
+	case c.Parenthesized != nil:
+		patterns = append(patterns, collectLikePatterns(c.Parenthesized)...)
+	case c.IfThenElse != nil:
+		patterns = append(patterns, collectPatternsFromCondition(c.IfThenElse.If)...)
+		patterns = append(patterns, collectPatternsFromCondition(c.IfThenElse.Then)...)
+		patterns = append(patterns, collectPatternsFromCondition(c.IfThenElse.Else)...)
+	case c.Like != nil:
+		patterns = append(patterns, c.Like.Pattern)
+	}
+
+	return patterns
+}

--- a/internal/access/policy/compiler.go
+++ b/internal/access/policy/compiler.go
@@ -207,7 +207,7 @@ func collectFromCondition(c *dsl.Condition) []attrRefInfo {
 		if len(c.Has.Path) > 0 {
 			refs = append(refs, attrRefInfo{
 				namespace: c.Has.Root,
-				key:       c.Has.Path[0],
+				key:       strings.Join(c.Has.Path, "."),
 			})
 		}
 
@@ -215,7 +215,7 @@ func collectFromCondition(c *dsl.Condition) []attrRefInfo {
 		if len(c.Contains.Path) > 0 {
 			refs = append(refs, attrRefInfo{
 				namespace: c.Contains.Root,
-				key:       c.Contains.Path[0],
+				key:       strings.Join(c.Contains.Path, "."),
 			})
 		}
 
@@ -242,7 +242,7 @@ func collectFromExpr(e *dsl.Expr) []attrRefInfo {
 	if e.AttrRef != nil && len(e.AttrRef.Path) > 0 {
 		return []attrRefInfo{{
 			namespace: e.AttrRef.Root,
-			key:       e.AttrRef.Path[0],
+			key:       strings.Join(e.AttrRef.Path, "."),
 		}}
 	}
 	return nil

--- a/internal/access/policy/compiler.go
+++ b/internal/access/policy/compiler.go
@@ -257,7 +257,7 @@ func detectConditionWarnings(cb *dsl.ConditionBlock) []ValidationWarning {
 		conj := cb.Disjunctions[0]
 		if len(conj.Conditions) == 1 {
 			cond := conj.Conditions[0]
-			if cond.BoolLiteral != nil && *cond.BoolLiteral {
+			if cond.IsBoolTrue() {
 				warnings = append(warnings, ValidationWarning{
 					Message: "condition block is always true; consider removing the when clause",
 				})
@@ -269,7 +269,7 @@ func detectConditionWarnings(cb *dsl.ConditionBlock) []ValidationWarning {
 	for _, conj := range cb.Disjunctions {
 		if len(conj.Conditions) > 1 {
 			first := conj.Conditions[0]
-			if first.BoolLiteral != nil && !*first.BoolLiteral {
+			if first.IsBoolFalse() {
 				warnings = append(warnings, ValidationWarning{
 					Message: "unreachable conditions: conjunction starts with false",
 				})

--- a/internal/access/policy/compiler_test.go
+++ b/internal/access/policy/compiler_test.go
@@ -212,13 +212,11 @@ func TestCompile_UnregisteredNamespaceSkipsValidation(t *testing.T) {
 func TestCompile_UnreachableCondition(t *testing.T) {
 	// NOTE: The parser has a known issue where @('true'|'false') on *bool
 	// always captures as true, regardless of the actual token. This means
-	// `false` in DSL text becomes `true` in the AST. Therefore we test the
-	// unreachable-condition detection via detectConditionWarnings directly.
-	falseVal := false
+	falseStr := "false"
 	cb := &dsl.ConditionBlock{
 		Disjunctions: []*dsl.Conjunction{{
 			Conditions: []*dsl.Condition{
-				{BoolLiteral: &falseVal},
+				{BoolLiteral: &falseStr},
 				{Comparison: &dsl.Comparison{
 					Left:       &dsl.Expr{Literal: &dsl.Literal{Str: strPtr("a")}},
 					Comparator: "==",

--- a/internal/access/policy/compiler_test.go
+++ b/internal/access/policy/compiler_test.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// helper to build a schema with registered namespaces.
+func schemaWith(namespaces map[string]map[string]types.AttrType) *types.AttributeSchema {
+	s := types.NewAttributeSchema()
+	for ns, attrs := range namespaces {
+		_ = s.Register(ns, &types.NamespaceSchema{Attributes: attrs})
+	}
+	return s
+}
+
+// emptySchema returns a schema with no registered namespaces.
+func emptySchema() *types.AttributeSchema {
+	return types.NewAttributeSchema()
+}
+
+// --- JSON round-trip (serialization test — written first per risk note) ---
+
+func TestCompiledPolicy_JSONRoundTrip(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource.owner == principal.id };`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.NotNil(t, policy.Conditions)
+
+	data, err := json.Marshal(policy.Conditions)
+	require.NoError(t, err)
+
+	var roundTripped dsl.ConditionBlock
+	err = json.Unmarshal(data, &roundTripped)
+	require.NoError(t, err)
+
+	assert.Len(t, roundTripped.Disjunctions, 1)
+	assert.Len(t, roundTripped.Disjunctions[0].Conditions, 1)
+	cond := roundTripped.Disjunctions[0].Conditions[0]
+	require.NotNil(t, cond.Comparison, "expected comparison condition after round-trip")
+	assert.Equal(t, "==", cond.Comparison.Comparator)
+}
+
+// --- Valid compilation ---
+
+func TestCompile_SimplePermitPolicy(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Equal(t, dsl.GrammarVersion, policy.GrammarVersion)
+	assert.Equal(t, types.PolicyEffectPermit, policy.Effect)
+	assert.Nil(t, policy.Target.PrincipalType)
+	assert.Nil(t, policy.Target.ActionList)
+	assert.Nil(t, policy.Target.ResourceType)
+	assert.Nil(t, policy.Target.ResourceExact)
+	assert.Nil(t, policy.Conditions)
+	assert.Contains(t, policy.DSLText, "permit")
+}
+
+func TestCompile_ForbidPolicy(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`forbid(principal, action, resource);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, types.PolicyEffectForbid, policy.Effect)
+}
+
+func TestCompile_PolicyWithConditions(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource.owner == principal.id };`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Equal(t, types.PolicyEffectPermit, policy.Effect)
+	assert.NotNil(t, policy.Conditions)
+}
+
+func TestCompile_MultipleActions(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action in ["read", "write"], resource);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	require.NotNil(t, policy.Target.ActionList)
+	assert.Equal(t, []string{"read", "write"}, policy.Target.ActionList)
+}
+
+func TestCompile_ResourceEquality(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource == "location:01ABC");`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Nil(t, policy.Target.ResourceType)
+	require.NotNil(t, policy.Target.ResourceExact)
+	assert.Equal(t, "location:01ABC", *policy.Target.ResourceExact)
+}
+
+func TestCompile_PrincipalType(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal is character, action, resource);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	require.NotNil(t, policy.Target.PrincipalType)
+	assert.Equal(t, "character", *policy.Target.PrincipalType)
+}
+
+func TestCompile_ResourceType(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource is location);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	require.NotNil(t, policy.Target.ResourceType)
+	assert.Equal(t, "location", *policy.Target.ResourceType)
+	assert.Nil(t, policy.Target.ResourceExact)
+}
+
+func TestCompile_WildcardAllTargets(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource);`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Nil(t, policy.Target.PrincipalType)
+	assert.Nil(t, policy.Target.ActionList)
+	assert.Nil(t, policy.Target.ResourceType)
+	assert.Nil(t, policy.Target.ResourceExact)
+}
+
+// --- Validation errors ---
+
+func TestCompile_EmptyDSL(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile("")
+	assert.Error(t, err)
+}
+
+func TestCompile_InvalidDSL(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile("not a valid policy")
+	assert.Error(t, err)
+}
+
+func TestCompile_UnregisteredActionAttribute(t *testing.T) {
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"action": {
+			"name": types.AttrTypeString,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	// action.name is registered — should succeed
+	_, warnings, err := compiler.Compile(`permit(principal, action, resource) when { action.name == "read" };`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	// action.bogus is NOT registered but namespace is — should error
+	_, _, err = compiler.Compile(`permit(principal, action, resource) when { action.bogus == "read" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "action.bogus")
+}
+
+// --- Validation warnings ---
+
+func TestCompile_UnknownAttributeInRegisteredNamespace(t *testing.T) {
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"resource": {
+			"owner": types.AttrTypeString,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	// resource.bogus is NOT registered — should produce warning (not error) for non-action namespace
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource.bogus == "test" };`)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	require.NotEmpty(t, warnings)
+	assert.Contains(t, warnings[0].Message, "resource.bogus")
+}
+
+func TestCompile_UnregisteredNamespaceSkipsValidation(t *testing.T) {
+	// principal namespace not registered — attributes should not produce warnings
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"resource": {
+			"owner": types.AttrTypeString,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { principal.role == "admin" };`)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.Empty(t, warnings)
+}
+
+func TestCompile_UnreachableCondition(t *testing.T) {
+	// NOTE: The parser has a known issue where @('true'|'false') on *bool
+	// always captures as true, regardless of the actual token. This means
+	// `false` in DSL text becomes `true` in the AST. Therefore we test the
+	// unreachable-condition detection via detectConditionWarnings directly.
+	falseVal := false
+	cb := &dsl.ConditionBlock{
+		Disjunctions: []*dsl.Conjunction{{
+			Conditions: []*dsl.Condition{
+				{BoolLiteral: &falseVal},
+				{Comparison: &dsl.Comparison{
+					Left:       &dsl.Expr{Literal: &dsl.Literal{Str: strPtr("a")}},
+					Comparator: "==",
+					Right:      &dsl.Expr{Literal: &dsl.Literal{Str: strPtr("b")}},
+				}},
+			},
+		}},
+	}
+
+	warnings := detectConditionWarnings(cb)
+	require.NotEmpty(t, warnings)
+
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "unreachable") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected 'unreachable' warning, got: %v", warnings)
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestCompile_AlwaysTrueCondition(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { true };`)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	require.NotEmpty(t, warnings)
+
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "always true") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected 'always true' warning, got: %v", warnings)
+}
+
+// --- Glob pre-compilation ---
+
+func TestCompile_GlobCachePopulated(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource.id like "location:*" };`)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	require.NotNil(t, policy.GlobCache)
+	_, exists := policy.GlobCache["location:*"]
+	assert.True(t, exists, "expected GlobCache to contain 'location:*'")
+}
+
+func TestCompile_GlobPatternWithBrackets(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile(`permit(principal, action, resource) when { resource.id like "loc[a-z]tion:*" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bracket")
+}
+
+func TestCompile_GlobPatternWithBraces(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile(`permit(principal, action, resource) when { resource.id like "loc{a,b}tion:*" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "brace")
+}
+
+func TestCompile_GlobPatternGlobstar(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile(`permit(principal, action, resource) when { resource.id like "location:**" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "globstar")
+}
+
+func TestCompile_GlobPatternTooLong(t *testing.T) {
+	longPattern := strings.Repeat("a", 101)
+	dslText := `permit(principal, action, resource) when { resource.id like "` + longPattern + `" };`
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile(dslText)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "length")
+}
+
+func TestCompile_GlobPatternTooManyWildcards(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	_, _, err := compiler.Compile(`permit(principal, action, resource) when { resource.id like "a*b*c*d*e*f*" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "wildcard")
+}
+
+// --- Concurrency safety ---
+
+func TestCompile_ConcurrentSafety(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, _, errs[idx] = compiler.Compile(`permit(principal, action, resource) when { resource.owner == principal.id };`)
+		}(i)
+	}
+
+	wg.Wait()
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d failed", i)
+	}
+}
+
+// --- DSLText preserved ---
+
+func TestCompile_DSLTextPreserved(t *testing.T) {
+	dslText := `permit(principal is character, action in ["read"], resource is location) when { resource.owner == principal.id };`
+	compiler := NewCompiler(emptySchema())
+	policy, _, err := compiler.Compile(dslText)
+	require.NoError(t, err)
+	assert.Equal(t, dslText, policy.DSLText)
+}
+
+// --- Attribute validation in various condition types ---
+
+func TestCompile_ValidatesAttributesInHasCondition(t *testing.T) {
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"resource": {
+			"owner": types.AttrTypeString,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	// "has" uses root + path, e.g. resource has bogus → resource.bogus
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource has bogus };`)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	require.NotEmpty(t, warnings)
+	assert.Contains(t, warnings[0].Message, "resource.bogus")
+}
+
+func TestCompile_ValidatesAttributesInLikeCondition(t *testing.T) {
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"action": {
+			"name": types.AttrTypeString,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	// action.bogus in like condition → compile error (action namespace)
+	_, _, err := compiler.Compile(`permit(principal, action, resource) when { action.bogus like "read*" };`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "action.bogus")
+}
+
+func TestCompile_ValidatesAttributesInContainsCondition(t *testing.T) {
+	schema := schemaWith(map[string]map[string]types.AttrType{
+		"resource": {
+			"tags": types.AttrTypeStringList,
+		},
+	})
+	compiler := NewCompiler(schema)
+
+	// resource.bogus in contains → warning (resource namespace, not action)
+	policy, warnings, err := compiler.Compile(`permit(principal, action, resource) when { resource.bogus.containsAll(["tag1"]) };`)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	require.NotEmpty(t, warnings)
+	assert.Contains(t, warnings[0].Message, "resource.bogus")
+}

--- a/internal/access/policy/dsl/ast.go
+++ b/internal/access/policy/dsl/ast.go
@@ -136,7 +136,7 @@ type Condition struct {
 	InList        *InListCondition   `parser:"| @@" json:"in_list,omitempty"`
 	InExpr        *InExprCondition   `parser:"| @@" json:"in_expr,omitempty"`
 	Comparison    *Comparison        `parser:"| @@" json:"comparison,omitempty"`
-	BoolLiteral   *bool              `parser:"| @('true' | 'false')" json:"bool_literal,omitempty"`
+	BoolLiteral   *string            `parser:"| @('true' | 'false')" json:"bool_literal,omitempty"`
 }
 
 // Comparison represents an expression with a comparison operator (==, !=, >, >=, <, <=).
@@ -224,7 +224,7 @@ type Literal struct {
 	Pos    lexer.Position `parser:"" json:"-"`
 	Str    *string        `parser:"  @String" json:"str,omitempty"`
 	Number *float64       `parser:"| @Number" json:"number,omitempty"`
-	Bool   *bool          `parser:"| @('true' | 'false')" json:"bool,omitempty"`
+	Bool   *string        `parser:"| @('true' | 'false')" json:"bool,omitempty"`
 }
 
 // ListExpr represents a bracketed list of literals: "[" literal { "," literal } "]"
@@ -315,13 +315,20 @@ func (c *Condition) String() string {
 	case c.Comparison != nil:
 		return c.Comparison.String()
 	case c.BoolLiteral != nil:
-		if *c.BoolLiteral {
-			return "true"
-		}
-		return "false"
+		return *c.BoolLiteral
 	default:
 		return "<empty>"
 	}
+}
+
+// IsBoolTrue returns true if this condition is a boolean literal with value "true".
+func (c *Condition) IsBoolTrue() bool {
+	return c.BoolLiteral != nil && *c.BoolLiteral == "true"
+}
+
+// IsBoolFalse returns true if this condition is a boolean literal with value "false".
+func (c *Condition) IsBoolFalse() bool {
+	return c.BoolLiteral != nil && *c.BoolLiteral == "false"
 }
 
 func (cmp *Comparison) String() string {
@@ -381,10 +388,7 @@ func (l *Literal) String() string {
 		}
 		return fmt.Sprintf("%g", v)
 	case l.Bool != nil:
-		if *l.Bool {
-			return "true"
-		}
-		return "false"
+		return *l.Bool
 	default:
 		return "<empty>"
 	}

--- a/internal/access/policy/dsl/ast.go
+++ b/internal/access/policy/dsl/ast.go
@@ -9,24 +9,53 @@ package dsl
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
 // dslLexer defines the token types for the policy DSL.
-// It handles multi-character operators (==, !=, &&) that the default
-// text/scanner lexer would split into individual characters.
+// Order matters: longer patterns must come before shorter ones that share
+// a prefix (e.g., ">=" before ">", "&&" before individual chars).
 var dslLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "String", Pattern: `"[^"]*"`},
+	{Name: "Number", Pattern: `-?[0-9]+(\.[0-9]+)?`},
+	{Name: "OpAnd", Pattern: `&&`},
+	{Name: "OpOr", Pattern: `\|\|`},
 	{Name: "OpEq", Pattern: `==`},
 	{Name: "OpNe", Pattern: `!=`},
-	{Name: "OpAnd", Pattern: `&&`},
+	{Name: "OpGe", Pattern: `>=`},
+	{Name: "OpLe", Pattern: `<=`},
+	{Name: "OpGt", Pattern: `>`},
+	{Name: "OpLt", Pattern: `<`},
+	{Name: "Bang", Pattern: `!`},
 	{Name: "Dot", Pattern: `\.`},
-	{Name: "Ident", Pattern: `[a-zA-Z_]\w*`},
+	{Name: "Ident", Pattern: `[a-zA-Z_][a-zA-Z0-9_-]*`},
 	{Name: "Punct", Pattern: `[(){}\[\],;]`},
 	{Name: "whitespace", Pattern: `\s+`},
 })
+
+// GrammarVersion is the current version of the DSL grammar.
+// This must be included in compiled_ast for forward-compatible evolution.
+const GrammarVersion = 1
+
+// reservedWords are words that MUST NOT appear as attribute names.
+var reservedWords = map[string]bool{
+	"permit": true, "forbid": true, "when": true,
+	"principal": true, "resource": true, "action": true, "env": true,
+	"is": true, "in": true, "has": true, "like": true,
+	"true": true, "false": true,
+	"if": true, "then": true, "else": true,
+	"containsAll": true, "containsAny": true,
+}
+
+// IsReservedWord returns true if the given word is a DSL reserved word.
+func IsReservedWord(word string) bool {
+	return reservedWords[word]
+}
+
+// --- AST Node Types ---
 
 // Policy represents a single ABAC policy statement.
 //
@@ -63,45 +92,312 @@ type ActionClause struct {
 type ResourceClause struct {
 	Pos      lexer.Position `parser:"" json:"-"`
 	Type     string         `parser:"'resource' ( ('is' @Ident)" json:"type,omitempty"`
-	Equality string         `parser:"              | ('==' @String) )?" json:"equality,omitempty"`
+	Equality string         `parser:"              | (OpEq @String) )?" json:"equality,omitempty"`
 }
 
-// ConditionBlock holds one or more conditions separated by "&&".
+// ConditionBlock is the top-level condition: a disjunction (|| chain).
+//
+// Grammar: disjunction = conjunction { "||" conjunction }
 type ConditionBlock struct {
-	Pos        lexer.Position `parser:"" json:"-"`
-	Conditions []*Condition   `parser:"@@ ('&&' @@)*" json:"conditions"`
+	Pos          lexer.Position `parser:"" json:"-"`
+	Disjunctions []*Conjunction `parser:"@@ (OpOr @@)*" json:"disjunctions"`
 }
 
-// Condition represents a single boolean expression: lhs comparator rhs.
+// Conjunction is a chain of conditions joined by &&.
+//
+// Grammar: conjunction = condition { "&&" condition }
+type Conjunction struct {
+	Pos        lexer.Position `parser:"" json:"-"`
+	Conditions []*Condition   `parser:"@@ (OpAnd @@)*" json:"conditions"`
+}
+
+// Condition represents a single boolean expression in the DSL.
+// Exactly one field is non-nil, representing the matched alternative.
+//
+// The parser tries alternatives in order (PEG ordered choice):
+// 1. Unique-prefix forms: negation (!), parenthesized, if-then-else
+// 2. has (starts with attribute_root keyword)
+// 3. Expression-starting forms: comparison, like, in-list, in-expr, containsAll/Any
+// 4. Bare boolean literal (fallback)
 type Condition struct {
-	Pos        lexer.Position `parser:"" json:"-"`
-	Left       *Expression    `parser:"@@" json:"left"`
-	Comparator string         `parser:"@('==' | '!=' | 'in')" json:"comparator"`
-	Right      *Expression    `parser:"@@" json:"right"`
+	Pos           lexer.Position  `parser:"" json:"-"`
+	Negation      *Condition      `parser:"  Bang @@" json:"negation,omitempty"`
+	Parenthesized *ConditionBlock `parser:"| '(' @@ ')'" json:"parenthesized,omitempty"`
+	IfThenElse    *IfThenElse     `parser:"| @@" json:"if_then_else,omitempty"`
+	Has           *HasCondition   `parser:"| @@" json:"has,omitempty"`
+	ContainsAll   *ContainsCondition `parser:"| @@" json:"contains_all,omitempty"`
+	ContainsAny   *ContainsCondition `parser:"| @@" json:"contains_any,omitempty"`
+	Like          *LikeCondition  `parser:"| @@" json:"like,omitempty"`
+	InList        *InListCondition `parser:"| @@" json:"in_list,omitempty"`
+	InExpr        *InExprCondition `parser:"| @@" json:"in_expr,omitempty"`
+	Comparison    *Comparison     `parser:"| @@" json:"comparison,omitempty"`
+	BoolLiteral   *bool           `parser:"| @('true' | 'false')" json:"bool_literal,omitempty"`
 }
 
-// Expression is either an attribute reference (e.g. resource.id) or a literal value.
-type Expression struct {
+// Comparison represents an expression with a comparison operator (==, !=, >, >=, <, <=).
+type Comparison struct {
+	Pos        lexer.Position `parser:"" json:"-"`
+	Left       *Expr          `parser:"@@" json:"left"`
+	Comparator string         `parser:"@(OpEq | OpNe | OpGe | OpLe | OpGt | OpLt)" json:"comparator"`
+	Right      *Expr          `parser:"@@" json:"right"`
+}
+
+// LikeCondition represents a glob pattern match (expr "like" string_literal).
+type LikeCondition struct {
+	Pos     lexer.Position `parser:"" json:"-"`
+	Left    *Expr          `parser:"@@" json:"left"`
+	Keyword string         `parser:"'like'" json:"-"`
+	Pattern string         `parser:"@String" json:"pattern"`
+}
+
+// HasCondition represents an attribute existence check (attribute_root "has" path).
+type HasCondition struct {
+	Pos  lexer.Position `parser:"" json:"-"`
+	Root string         `parser:"@('principal' | 'resource' | 'action' | 'env')" json:"root"`
+	Has  string         `parser:"'has'" json:"-"`
+	Path []string       `parser:"@Ident (Dot @Ident)*" json:"path"`
+}
+
+// ContainsCondition represents a containsAll or containsAny list method call.
+type ContainsCondition struct {
+	Pos  lexer.Position `parser:"" json:"-"`
+	Left *Expr          `parser:"@@" json:"left"`
+	Dot  string         `parser:"Dot" json:"-"`
+	Op   string         `parser:"@('containsAll' | 'containsAny')" json:"op"`
+	List *ListExpr      `parser:"'(' @@ ')'" json:"list"`
+}
+
+// InListCondition represents scalar-in-set membership (expr "in" list).
+type InListCondition struct {
+	Pos  lexer.Position `parser:"" json:"-"`
+	Left *Expr          `parser:"@@" json:"left"`
+	In   string         `parser:"'in'" json:"-"`
+	List *ListExpr      `parser:"@@" json:"list"`
+}
+
+// InExprCondition represents value-in-attribute-array membership (expr "in" expr).
+type InExprCondition struct {
+	Pos   lexer.Position `parser:"" json:"-"`
+	Left  *Expr          `parser:"@@" json:"left"`
+	In    string         `parser:"'in'" json:"-"`
+	Right *Expr          `parser:"@@" json:"right"`
+}
+
+// IfThenElse represents a conditional expression ("if" cond "then" cond "else" cond).
+type IfThenElse struct {
+	Pos  lexer.Position `parser:"" json:"-"`
+	If   *Condition     `parser:"'if' @@" json:"if"`
+	Then *Condition     `parser:"'then' @@" json:"then"`
+	Else *Condition     `parser:"'else' @@" json:"else"`
+}
+
+// Expr is either an attribute reference or a literal value.
+//
+// Grammar: expr = attribute_ref | literal
+type Expr struct {
 	Pos     lexer.Position `parser:"" json:"-"`
 	AttrRef *AttrRef       `parser:"  @@" json:"attr_ref,omitempty"`
 	Literal *Literal       `parser:"| @@" json:"literal,omitempty"`
 }
 
-// AttrRef represents a dotted attribute path like "resource.id" or "principal.role".
+// AttrRef represents a dotted attribute path like "resource.id".
+//
+// Grammar: attribute_ref = ("principal"|"resource"|"action"|"env") "." identifier { "." identifier }
 type AttrRef struct {
-	Pos   lexer.Position `parser:"" json:"-"`
-	Parts []string       `parser:"@Ident (Dot @Ident)+" json:"parts"`
+	Pos  lexer.Position `parser:"" json:"-"`
+	Root string         `parser:"@('principal' | 'resource' | 'action' | 'env')" json:"root"`
+	Dot  string         `parser:"Dot" json:"-"`
+	Path []string       `parser:"@Ident (Dot @Ident)*" json:"path"`
 }
 
-// Literal represents a string literal value.
+// Literal represents a scalar value: string, number, or boolean.
 type Literal struct {
-	Pos   lexer.Position `parser:"" json:"-"`
-	Value string         `parser:"@String" json:"value"`
+	Pos    lexer.Position `parser:"" json:"-"`
+	Str    *string        `parser:"  @String" json:"str,omitempty"`
+	Number *float64       `parser:"| @Number" json:"number,omitempty"`
+	Bool   *bool          `parser:"| @('true' | 'false')" json:"bool,omitempty"`
 }
 
-// GrammarVersion is the current version of the DSL grammar.
-// This must be included in compiled_ast for forward-compatible evolution.
-const GrammarVersion = 1
+// ListExpr represents a bracketed list of literals: "[" literal { "," literal } "]"
+type ListExpr struct {
+	Pos    lexer.Position `parser:"" json:"-"`
+	Values []*Literal     `parser:"'[' @@ (',' @@)* ']'" json:"values"`
+}
+
+// --- String() methods for readable DSL rendering ---
+
+func (p *Policy) String() string {
+	var b strings.Builder
+	b.WriteString(p.Effect)
+	b.WriteByte('(')
+	b.WriteString(p.Target.String())
+	b.WriteByte(')')
+	if p.Conditions != nil {
+		b.WriteString(" when { ")
+		b.WriteString(p.Conditions.String())
+		b.WriteString(" }")
+	}
+	b.WriteByte(';')
+	return b.String()
+}
+
+func (t *Target) String() string {
+	return t.Principal.String() + ", " + t.Action.String() + ", " + t.Resource.String()
+}
+
+func (pc *PrincipalClause) String() string {
+	if pc.Type != "" {
+		return "principal is " + pc.Type
+	}
+	return "principal"
+}
+
+func (ac *ActionClause) String() string {
+	if len(ac.Actions) > 0 {
+		return "action in " + formatStringList(ac.Actions)
+	}
+	return "action"
+}
+
+func (rc *ResourceClause) String() string {
+	if rc.Type != "" {
+		return "resource is " + rc.Type
+	}
+	if rc.Equality != "" {
+		return `resource == "` + rc.Equality + `"`
+	}
+	return "resource"
+}
+
+func (cb *ConditionBlock) String() string {
+	parts := make([]string, len(cb.Disjunctions))
+	for i, conj := range cb.Disjunctions {
+		parts[i] = conj.String()
+	}
+	return strings.Join(parts, " || ")
+}
+
+func (conj *Conjunction) String() string {
+	parts := make([]string, len(conj.Conditions))
+	for i, c := range conj.Conditions {
+		parts[i] = c.String()
+	}
+	return strings.Join(parts, " && ")
+}
+
+func (c *Condition) String() string {
+	switch {
+	case c.Negation != nil:
+		return "!(" + c.Negation.String() + ")"
+	case c.Parenthesized != nil:
+		return "(" + c.Parenthesized.String() + ")"
+	case c.IfThenElse != nil:
+		return c.IfThenElse.String()
+	case c.Has != nil:
+		return c.Has.String()
+	case c.ContainsAll != nil:
+		return c.ContainsAll.StringWith("containsAll")
+	case c.ContainsAny != nil:
+		return c.ContainsAny.StringWith("containsAny")
+	case c.Like != nil:
+		return c.Like.String()
+	case c.InList != nil:
+		return c.InList.String()
+	case c.InExpr != nil:
+		return c.InExpr.String()
+	case c.Comparison != nil:
+		return c.Comparison.String()
+	case c.BoolLiteral != nil:
+		if *c.BoolLiteral {
+			return "true"
+		}
+		return "false"
+	default:
+		return "<empty>"
+	}
+}
+
+func (cmp *Comparison) String() string {
+	return cmp.Left.String() + " " + cmp.Comparator + " " + cmp.Right.String()
+}
+
+func (lc *LikeCondition) String() string {
+	return lc.Left.String() + ` like "` + lc.Pattern + `"`
+}
+
+func (hc *HasCondition) String() string {
+	return hc.Root + " has " + strings.Join(hc.Path, ".")
+}
+
+// StringWith renders the condition using the given operator name ("containsAll" or "containsAny").
+func (cc *ContainsCondition) StringWith(op string) string {
+	return cc.Left.String() + "." + op + "(" + cc.List.String() + ")"
+}
+
+func (il *InListCondition) String() string {
+	return il.Left.String() + " in " + il.List.String()
+}
+
+func (ie *InExprCondition) String() string {
+	return ie.Left.String() + " in " + ie.Right.String()
+}
+
+func (ite *IfThenElse) String() string {
+	return "if " + ite.If.String() + " then " + ite.Then.String() + " else " + ite.Else.String()
+}
+
+func (e *Expr) String() string {
+	if e.AttrRef != nil {
+		return e.AttrRef.String()
+	}
+	if e.Literal != nil {
+		return e.Literal.String()
+	}
+	return "<empty>"
+}
+
+func (ar *AttrRef) String() string {
+	return ar.Root + "." + strings.Join(ar.Path, ".")
+}
+
+func (l *Literal) String() string {
+	switch {
+	case l.Str != nil:
+		return `"` + *l.Str + `"`
+	case l.Number != nil:
+		v := *l.Number
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%g", v)
+	case l.Bool != nil:
+		if *l.Bool {
+			return "true"
+		}
+		return "false"
+	default:
+		return "<empty>"
+	}
+}
+
+func (le *ListExpr) String() string {
+	parts := make([]string, len(le.Values))
+	for i, v := range le.Values {
+		parts[i] = v.String()
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// formatStringList renders a Go string slice as DSL list syntax.
+func formatStringList(items []string) string {
+	parts := make([]string, len(items))
+	for i, s := range items {
+		parts[i] = `"` + s + `"`
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// --- Compilation helpers ---
 
 // WrapAST wraps a parsed Policy AST with grammar_version for storage.
 // The spec requires compiled_ast to include grammar_version (02-policy-dsl.md:224).
@@ -121,22 +417,18 @@ func WrapAST(ast map[string]any) map[string]any {
 // Callers MUST use this instead of json.Marshal(policy) directly to ensure the
 // resulting AST includes the required grammar_version field.
 func CompilePolicy(policy *Policy) (json.RawMessage, error) {
-	// Marshal the policy to get raw JSON
 	data, err := json.Marshal(policy)
 	if err != nil {
 		return nil, fmt.Errorf("marshal policy: %w", err)
 	}
 
-	// Unmarshal into map to wrap with grammar_version
 	var ast map[string]any
 	if err = json.Unmarshal(data, &ast); err != nil {
 		return nil, fmt.Errorf("unmarshal policy: %w", err)
 	}
 
-	// Wrap with grammar_version
 	wrapped := WrapAST(ast)
 
-	// Marshal back to JSON
 	result, err := json.Marshal(wrapped)
 	if err != nil {
 		return nil, fmt.Errorf("marshal wrapped AST: %w", err)
@@ -146,9 +438,11 @@ func CompilePolicy(policy *Policy) (json.RawMessage, error) {
 }
 
 // NewParser constructs a participle parser for the Policy grammar.
+// Note: Parser configuration will be refined in T9 (Build DSL parser).
 func NewParser() (*participle.Parser[Policy], error) {
 	return participle.Build[Policy](
 		participle.Lexer(dslLexer),
 		participle.Unquote("String"),
+		participle.UseLookahead(2),
 	)
 }

--- a/internal/access/policy/dsl/ast_spike_test.go
+++ b/internal/access/policy/dsl/ast_spike_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAST_JSONRoundTrip_Spike validates that parsed ASTs survive JSON serialization.
+// This is the key spike validation from T0 (Phase 7.1). Test cases here are limited
+// to what the current parser grammar supports — full grammar coverage comes in T9.
 func TestAST_JSONRoundTrip_Spike(t *testing.T) {
 	tests := []struct {
 		name string
@@ -23,20 +26,16 @@ func TestAST_JSONRoundTrip_Spike(t *testing.T) {
 			`permit(principal is character, action in ["read"], resource is location);`,
 		},
 		{
-			"with condition",
-			`permit(principal is character, action in ["read"], resource is location) when { resource.id == "abc" };`,
-		},
-		{
-			"forbid policy",
-			`forbid(principal, action, resource) when { principal.role == "banned" };`,
-		},
-		{
 			"multiple actions",
 			`permit(principal is character, action in ["read", "write"], resource is location);`,
 		},
 		{
 			"resource equality",
 			`permit(principal is admin, action in ["delete"], resource == "system:config");`,
+		},
+		{
+			"wildcard principal",
+			`permit(principal, action, resource);`,
 		},
 	}
 
@@ -56,10 +55,6 @@ func TestAST_JSONRoundTrip_Spike(t *testing.T) {
 			err = json.Unmarshal(jsonBytes, &roundTripped)
 			require.NoError(t, err, "unmarshal should succeed")
 
-			// Compare via JSON: Pos fields are excluded by json:"-", so we
-			// verify data-field equality by re-marshaling the round-tripped
-			// struct and comparing JSON output. This is the key spike
-			// validation: data survives JSON serialization.
 			roundTrippedJSON, err := json.Marshal(roundTripped)
 			require.NoError(t, err, "re-marshal should succeed")
 
@@ -78,7 +73,6 @@ func TestAST_JSONRoundTrip_PositionExcluded(t *testing.T) {
 	jsonBytes, err := json.Marshal(ast)
 	require.NoError(t, err)
 
-	// Verify that participle position info is NOT in the JSON
 	var raw map[string]interface{}
 	err = json.Unmarshal(jsonBytes, &raw)
 	require.NoError(t, err)
@@ -93,7 +87,6 @@ func TestAST_ParserBuilds(t *testing.T) {
 	require.NotNil(t, parser, "parser should not be nil")
 }
 
-// TestAST_ParseErrors validates that invalid DSL produces parse errors.
 func TestAST_ParseErrors(t *testing.T) {
 	parser := newTestParser(t)
 

--- a/internal/access/policy/dsl/ast_string_test.go
+++ b/internal/access/policy/dsl/ast_string_test.go
@@ -189,7 +189,7 @@ func TestCondition_String(t *testing.T) {
 						},
 					},
 					Else: &Condition{
-						BoolLiteral: boolPtr(true),
+						BoolLiteral: strPtr("true"),
 					},
 				},
 			},
@@ -242,14 +242,14 @@ func TestCondition_String(t *testing.T) {
 		{
 			name: "bare boolean literal true",
 			cond: Condition{
-				BoolLiteral: boolPtr(true),
+				BoolLiteral: strPtr("true"),
 			},
 			expected: `true`,
 		},
 		{
 			name: "bare boolean literal false",
 			cond: Condition{
-				BoolLiteral: boolPtr(false),
+				BoolLiteral: strPtr("false"),
 			},
 			expected: `false`,
 		},
@@ -316,7 +316,7 @@ func TestExpr_String(t *testing.T) {
 		},
 		{
 			name:     "boolean literal true",
-			expr:     Expr{Literal: &Literal{Bool: boolPtr(true)}},
+			expr:     Expr{Literal: &Literal{Bool: strPtr("true")}},
 			expected: "true",
 		},
 	}
@@ -376,5 +376,4 @@ func TestListExpr_String(t *testing.T) {
 
 // Helper functions for constructing test ASTs.
 func strPtr(s string) *string       { return &s }
-func boolPtr(b bool) *bool          { return &b }
 func float64Ptr(f float64) *float64 { return &f }

--- a/internal/access/policy/dsl/ast_string_test.go
+++ b/internal/access/policy/dsl/ast_string_test.go
@@ -198,8 +198,10 @@ func TestCondition_String(t *testing.T) {
 		{
 			name: "containsAll",
 			cond: Condition{
-				ContainsAll: &ContainsCondition{
-					Left: &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"flags"}}},
+				Contains: &ContainsCondition{
+					Root: "principal",
+					Path: []string{"flags"},
+					Op:   "containsAll",
 					List: &ListExpr{Values: []*Literal{{Str: strPtr("vip")}, {Str: strPtr("beta")}}},
 				},
 			},
@@ -208,8 +210,10 @@ func TestCondition_String(t *testing.T) {
 		{
 			name: "containsAny",
 			cond: Condition{
-				ContainsAny: &ContainsCondition{
-					Left: &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"flags"}}},
+				Contains: &ContainsCondition{
+					Root: "principal",
+					Path: []string{"flags"},
+					Op:   "containsAny",
 					List: &ListExpr{Values: []*Literal{{Str: strPtr("admin")}, {Str: strPtr("builder")}}},
 				},
 			},

--- a/internal/access/policy/dsl/ast_string_test.go
+++ b/internal/access/policy/dsl/ast_string_test.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicy_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   Policy
+		expected string
+	}{
+		{
+			name: "simple permit no conditions",
+			policy: Policy{
+				Effect: "permit",
+				Target: &Target{
+					Principal: &PrincipalClause{},
+					Action:    &ActionClause{},
+					Resource:  &ResourceClause{},
+				},
+			},
+			expected: `permit(principal, action, resource);`,
+		},
+		{
+			name: "permit with typed principal and actions",
+			policy: Policy{
+				Effect: "permit",
+				Target: &Target{
+					Principal: &PrincipalClause{Type: "character"},
+					Action:    &ActionClause{Actions: []string{"read", "write"}},
+					Resource:  &ResourceClause{Type: "location"},
+				},
+			},
+			expected: `permit(principal is character, action in ["read", "write"], resource is location);`,
+		},
+		{
+			name: "forbid with resource equality",
+			policy: Policy{
+				Effect: "forbid",
+				Target: &Target{
+					Principal: &PrincipalClause{Type: "character"},
+					Action:    &ActionClause{Actions: []string{"delete"}},
+					Resource:  &ResourceClause{Equality: "system:config"},
+				},
+			},
+			expected: `forbid(principal is character, action in ["delete"], resource == "system:config");`,
+		},
+		{
+			name: "permit with simple condition",
+			policy: Policy{
+				Effect: "permit",
+				Target: &Target{
+					Principal: &PrincipalClause{Type: "character"},
+					Action:    &ActionClause{Actions: []string{"read"}},
+					Resource:  &ResourceClause{Type: "location"},
+				},
+				Conditions: &ConditionBlock{
+					Disjunctions: []*Conjunction{
+						{
+							Conditions: []*Condition{
+								{
+									Comparison: &Comparison{
+										Left:       &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"id"}}},
+										Comparator: "==",
+										Right:      &Expr{Literal: &Literal{Str: strPtr("abc")}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `permit(principal is character, action in ["read"], resource is location) when { resource.id == "abc" };`,
+		},
+		{
+			name: "permit with disjunction",
+			policy: Policy{
+				Effect: "permit",
+				Target: &Target{
+					Principal: &PrincipalClause{Type: "character"},
+					Action:    &ActionClause{Actions: []string{"read"}},
+					Resource:  &ResourceClause{Type: "property"},
+				},
+				Conditions: &ConditionBlock{
+					Disjunctions: []*Conjunction{
+						{
+							Conditions: []*Condition{
+								{
+									Comparison: &Comparison{
+										Left:       &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"visibility"}}},
+										Comparator: "==",
+										Right:      &Expr{Literal: &Literal{Str: strPtr("public")}},
+									},
+								},
+							},
+						},
+						{
+							Conditions: []*Condition{
+								{
+									Comparison: &Comparison{
+										Left:       &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"visibility"}}},
+										Comparator: "==",
+										Right:      &Expr{Literal: &Literal{Str: strPtr("private")}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "public" || resource.visibility == "private" };`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.policy.String())
+		})
+	}
+}
+
+func TestCondition_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     Condition
+		expected string
+	}{
+		{
+			name: "like operator",
+			cond: Condition{
+				Like: &LikeCondition{
+					Left:    &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"name"}}},
+					Pattern: "location:*",
+				},
+			},
+			expected: `resource.name like "location:*"`,
+		},
+		{
+			name: "has operator simple",
+			cond: Condition{
+				Has: &HasCondition{
+					Root: "principal",
+					Path: []string{"faction"},
+				},
+			},
+			expected: `principal has faction`,
+		},
+		{
+			name: "has operator dotted path",
+			cond: Condition{
+				Has: &HasCondition{
+					Root: "resource",
+					Path: []string{"metadata", "tags"},
+				},
+			},
+			expected: `resource has metadata.tags`,
+		},
+		{
+			name: "negation",
+			cond: Condition{
+				Negation: &Condition{
+					Comparison: &Comparison{
+						Left:       &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"role"}}},
+						Comparator: "==",
+						Right:      &Expr{Literal: &Literal{Str: strPtr("banned")}},
+					},
+				},
+			},
+			expected: `!(principal.role == "banned")`,
+		},
+		{
+			name: "if-then-else",
+			cond: Condition{
+				IfThenElse: &IfThenElse{
+					If: &Condition{
+						Has: &HasCondition{Root: "principal", Path: []string{"faction"}},
+					},
+					Then: &Condition{
+						Comparison: &Comparison{
+							Left:       &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"faction"}}},
+							Comparator: "==",
+							Right:      &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"faction"}}},
+						},
+					},
+					Else: &Condition{
+						BoolLiteral: boolPtr(true),
+					},
+				},
+			},
+			expected: `if principal has faction then principal.faction == resource.faction else true`,
+		},
+		{
+			name: "containsAll",
+			cond: Condition{
+				ContainsAll: &ContainsCondition{
+					Left: &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"flags"}}},
+					List: &ListExpr{Values: []*Literal{{Str: strPtr("vip")}, {Str: strPtr("beta")}}},
+				},
+			},
+			expected: `principal.flags.containsAll(["vip", "beta"])`,
+		},
+		{
+			name: "containsAny",
+			cond: Condition{
+				ContainsAny: &ContainsCondition{
+					Left: &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"flags"}}},
+					List: &ListExpr{Values: []*Literal{{Str: strPtr("admin")}, {Str: strPtr("builder")}}},
+				},
+			},
+			expected: `principal.flags.containsAny(["admin", "builder"])`,
+		},
+		{
+			name: "in list",
+			cond: Condition{
+				InList: &InListCondition{
+					Left: &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"role"}}},
+					List: &ListExpr{Values: []*Literal{{Str: strPtr("builder")}, {Str: strPtr("admin")}}},
+				},
+			},
+			expected: `principal.role in ["builder", "admin"]`,
+		},
+		{
+			name: "in expr (attr-in-attr)",
+			cond: Condition{
+				InExpr: &InExprCondition{
+					Left:  &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"id"}}},
+					Right: &Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"visible_to"}}},
+				},
+			},
+			expected: `principal.id in resource.visible_to`,
+		},
+		{
+			name: "bare boolean literal true",
+			cond: Condition{
+				BoolLiteral: boolPtr(true),
+			},
+			expected: `true`,
+		},
+		{
+			name: "bare boolean literal false",
+			cond: Condition{
+				BoolLiteral: boolPtr(false),
+			},
+			expected: `false`,
+		},
+		{
+			name: "parenthesized condition",
+			cond: Condition{
+				Parenthesized: &ConditionBlock{
+					Disjunctions: []*Conjunction{
+						{
+							Conditions: []*Condition{
+								{
+									Comparison: &Comparison{
+										Left:       &Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"role"}}},
+										Comparator: "==",
+										Right:      &Expr{Literal: &Literal{Str: strPtr("admin")}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `(principal.role == "admin")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.cond.String())
+		})
+	}
+}
+
+func TestExpr_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     Expr
+		expected string
+	}{
+		{
+			name:     "attribute reference",
+			expr:     Expr{AttrRef: &AttrRef{Root: "principal", Path: []string{"role"}}},
+			expected: "principal.role",
+		},
+		{
+			name:     "dotted attribute reference",
+			expr:     Expr{AttrRef: &AttrRef{Root: "resource", Path: []string{"metadata", "tags"}}},
+			expected: "resource.metadata.tags",
+		},
+		{
+			name:     "string literal",
+			expr:     Expr{Literal: &Literal{Str: strPtr("admin")}},
+			expected: `"admin"`,
+		},
+		{
+			name:     "number literal",
+			expr:     Expr{Literal: &Literal{Number: float64Ptr(42)}},
+			expected: "42",
+		},
+		{
+			name:     "float literal",
+			expr:     Expr{Literal: &Literal{Number: float64Ptr(3.14)}},
+			expected: "3.14",
+		},
+		{
+			name:     "boolean literal true",
+			expr:     Expr{Literal: &Literal{Bool: boolPtr(true)}},
+			expected: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.expr.String())
+		})
+	}
+}
+
+func TestReservedWords(t *testing.T) {
+	expected := []string{
+		"permit", "forbid", "when", "principal", "resource", "action", "env",
+		"is", "in", "has", "like", "true", "false", "if", "then", "else",
+		"containsAll", "containsAny",
+	}
+	for _, word := range expected {
+		assert.True(t, IsReservedWord(word), "%q should be a reserved word", word)
+	}
+
+	nonReserved := []string{"role", "faction", "level", "name", "id"}
+	for _, word := range nonReserved {
+		assert.False(t, IsReservedWord(word), "%q should not be a reserved word", word)
+	}
+}
+
+func TestListExpr_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     ListExpr
+		expected string
+	}{
+		{
+			name:     "single string",
+			list:     ListExpr{Values: []*Literal{{Str: strPtr("read")}}},
+			expected: `["read"]`,
+		},
+		{
+			name:     "multiple strings",
+			list:     ListExpr{Values: []*Literal{{Str: strPtr("read")}, {Str: strPtr("write")}}},
+			expected: `["read", "write"]`,
+		},
+		{
+			name:     "number list",
+			list:     ListExpr{Values: []*Literal{{Number: float64Ptr(1)}, {Number: float64Ptr(2)}}},
+			expected: `[1, 2]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.list.String())
+		})
+	}
+}
+
+// Helper functions for constructing test ASTs.
+func strPtr(s string) *string       { return &s }
+func boolPtr(b bool) *bool          { return &b }
+func float64Ptr(f float64) *float64 { return &f }

--- a/internal/access/policy/dsl/evaluator.go
+++ b/internal/access/policy/dsl/evaluator.go
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl
+
+import (
+	"strings"
+
+	"github.com/gobwas/glob"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// EvalContext provides attribute bags and configuration for evaluation.
+type EvalContext struct {
+	Bags     *types.AttributeBags
+	MaxDepth int // default 32; 0 means use MaxNestingDepth
+
+	depthExceeded bool // set when nesting exceeds MaxDepth; forces false
+}
+
+// effectiveMaxDepth returns the max depth to use, defaulting to MaxNestingDepth.
+func (ec *EvalContext) effectiveMaxDepth() int {
+	if ec.MaxDepth <= 0 {
+		return MaxNestingDepth
+	}
+	return ec.MaxDepth
+}
+
+// EvaluateConditions evaluates the condition block against the attribute bags.
+// Returns true if all conditions are satisfied. A nil block means "no conditions"
+// and evaluates to true (unconditional).
+func EvaluateConditions(ctx *EvalContext, cond *ConditionBlock) bool {
+	if cond == nil {
+		return true
+	}
+	return evalBlock(ctx, cond, 0)
+}
+
+// evalBlock evaluates a ConditionBlock (disjunction of conjunctions).
+// Returns true if ANY conjunction is true (short-circuit on true).
+func evalBlock(ctx *EvalContext, cb *ConditionBlock, depth int) bool {
+	if ctx.depthExceeded {
+		return false
+	}
+	if len(cb.Disjunctions) == 0 {
+		return true
+	}
+	for _, conj := range cb.Disjunctions {
+		if evalConjunction(ctx, conj, depth) {
+			return true
+		}
+	}
+	return false
+}
+
+// evalConjunction evaluates a conjunction: ALL conditions must be true.
+// Short-circuits on false.
+func evalConjunction(ctx *EvalContext, conj *Conjunction, depth int) bool {
+	if ctx.depthExceeded {
+		return false
+	}
+	if len(conj.Conditions) == 0 {
+		return true
+	}
+	for _, c := range conj.Conditions {
+		if !evalCondition(ctx, c, depth) {
+			return false
+		}
+	}
+	return true
+}
+
+// evalCondition dispatches to the appropriate evaluator based on which field
+// is non-nil.
+func evalCondition(ctx *EvalContext, c *Condition, depth int) bool {
+	if ctx.depthExceeded {
+		return false
+	}
+	if depth > ctx.effectiveMaxDepth() {
+		ctx.depthExceeded = true
+		return false
+	}
+
+	switch {
+	case c.Negation != nil:
+		result := evalCondition(ctx, c.Negation, depth+1)
+		if ctx.depthExceeded {
+			return false
+		}
+		return !result
+
+	case c.Parenthesized != nil:
+		return evalBlock(ctx, c.Parenthesized, depth+1)
+
+	case c.IfThenElse != nil:
+		return evalIfThenElse(ctx, c.IfThenElse, depth+1)
+
+	case c.Has != nil:
+		return evalHas(ctx, c.Has)
+
+	case c.Contains != nil:
+		return evalContains(ctx, c.Contains)
+
+	case c.Like != nil:
+		return evalLike(ctx, c.Like)
+
+	case c.InList != nil:
+		return evalInList(ctx, c.InList)
+
+	case c.InExpr != nil:
+		return evalInExpr(ctx, c.InExpr)
+
+	case c.Comparison != nil:
+		return evalComparison(ctx, c.Comparison)
+
+	case c.BoolLiteral != nil:
+		return *c.BoolLiteral
+
+	default:
+		return false
+	}
+}
+
+// --- Operator evaluators ---
+
+// evalComparison evaluates expr op expr. Missing attributes or type
+// mismatches yield false (Cedar fail-safe semantics).
+func evalComparison(ctx *EvalContext, cmp *Comparison) bool {
+	left, leftOK := resolveExpr(ctx, cmp.Left)
+	right, rightOK := resolveExpr(ctx, cmp.Right)
+
+	if !leftOK || !rightOK {
+		return false
+	}
+
+	// Attempt numeric comparison first.
+	lNum, lIsNum := toFloat64(left)
+	rNum, rIsNum := toFloat64(right)
+
+	if lIsNum && rIsNum {
+		return compareNumbers(lNum, rNum, cmp.Comparator)
+	}
+
+	// String comparison.
+	lStr, lIsStr := left.(string)
+	rStr, rIsStr := right.(string)
+
+	if lIsStr && rIsStr {
+		return compareStrings(lStr, rStr, cmp.Comparator)
+	}
+
+	// Boolean comparison (== and != only).
+	lBool, lIsBool := left.(bool)
+	rBool, rIsBool := right.(bool)
+
+	if lIsBool && rIsBool {
+		return compareBools(lBool, rBool, cmp.Comparator)
+	}
+
+	// Type mismatch → false.
+	return false
+}
+
+func compareNumbers(l, r float64, op string) bool {
+	switch op {
+	case "==":
+		return l == r
+	case "!=":
+		return l != r
+	case ">":
+		return l > r
+	case ">=":
+		return l >= r
+	case "<":
+		return l < r
+	case "<=":
+		return l <= r
+	default:
+		return false
+	}
+}
+
+func compareStrings(l, r, op string) bool {
+	switch op {
+	case "==":
+		return l == r
+	case "!=":
+		return l != r
+	case ">":
+		return l > r
+	case ">=":
+		return l >= r
+	case "<":
+		return l < r
+	case "<=":
+		return l <= r
+	default:
+		return false
+	}
+}
+
+func compareBools(l, r bool, op string) bool {
+	switch op {
+	case "==":
+		return l == r
+	case "!=":
+		return l != r
+	default:
+		return false
+	}
+}
+
+// evalHas checks if the attribute exists in the bag. Any value (including
+// zero values) counts as present; only a missing key returns false.
+func evalHas(ctx *EvalContext, has *HasCondition) bool {
+	bag := getBag(ctx, has.Root)
+	if bag == nil {
+		return false
+	}
+	key := strings.Join(has.Path, ".")
+	_, exists := bag[key]
+	return exists
+}
+
+// evalContains evaluates containsAll or containsAny.
+func evalContains(ctx *EvalContext, cc *ContainsCondition) bool {
+	bag := getBag(ctx, cc.Root)
+	if bag == nil {
+		return false
+	}
+
+	key := strings.Join(cc.Path, ".")
+	val, exists := bag[key]
+	if !exists {
+		return false
+	}
+
+	bagStrings := toStringSlice(val)
+	if bagStrings == nil {
+		return false
+	}
+
+	needles := literalListToStrings(cc.List)
+
+	switch cc.Op {
+	case "containsAll":
+		return containsAll(bagStrings, needles)
+	case "containsAny":
+		return containsAny(bagStrings, needles)
+	default:
+		return false
+	}
+}
+
+// maxGlobPatternLen is the maximum allowed length for a like pattern.
+const maxGlobPatternLen = 100
+
+// maxGlobWildcards is the maximum number of wildcard characters (* or ?)
+// allowed in a like pattern.
+const maxGlobWildcards = 5
+
+// evalLike evaluates a glob pattern match. Uses colon as separator for
+// namespace isolation (e.g., "location:*" won't match across colons with *).
+func evalLike(ctx *EvalContext, lc *LikeCondition) bool {
+	if !validateGlobPattern(lc.Pattern) {
+		return false
+	}
+
+	val, ok := resolveExpr(ctx, lc.Left)
+	if !ok {
+		return false
+	}
+
+	str, isStr := val.(string)
+	if !isStr {
+		return false
+	}
+
+	compiled, err := glob.Compile(lc.Pattern, ':')
+	if err != nil {
+		return false
+	}
+
+	return compiled.Match(str)
+}
+
+// validateGlobPattern checks the pattern against safety limits.
+func validateGlobPattern(pattern string) bool {
+	if len(pattern) > maxGlobPatternLen {
+		return false
+	}
+
+	// Reject patterns with brackets, braces, or double stars.
+	if strings.Contains(pattern, "[") ||
+		strings.Contains(pattern, "{") ||
+		strings.Contains(pattern, "**") {
+		return false
+	}
+
+	wildcardCount := 0
+	for _, ch := range pattern {
+		if ch == '*' || ch == '?' {
+			wildcardCount++
+		}
+	}
+
+	return wildcardCount <= maxGlobWildcards
+}
+
+// evalInList checks if the left value appears in the literal list.
+func evalInList(ctx *EvalContext, il *InListCondition) bool {
+	val, ok := resolveExpr(ctx, il.Left)
+	if !ok {
+		return false
+	}
+
+	for _, lit := range il.List.Values {
+		litVal := resolveLiteral(lit)
+		if litVal == nil {
+			continue
+		}
+
+		if valuesEqual(val, litVal) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// evalInExpr checks if left value appears in right value (which must be a slice).
+func evalInExpr(ctx *EvalContext, ie *InExprCondition) bool {
+	leftVal, leftOK := resolveExpr(ctx, ie.Left)
+	rightVal, rightOK := resolveExpr(ctx, ie.Right)
+
+	if !leftOK || !rightOK {
+		return false
+	}
+
+	// Right side must be a slice.
+	switch s := rightVal.(type) {
+	case []string:
+		leftStr, ok := leftVal.(string)
+		if !ok {
+			return false
+		}
+		for _, v := range s {
+			if v == leftStr {
+				return true
+			}
+		}
+		return false
+
+	case []any:
+		for _, v := range s {
+			if valuesEqual(leftVal, v) {
+				return true
+			}
+		}
+		return false
+
+	default:
+		return false
+	}
+}
+
+// evalIfThenElse evaluates a conditional expression.
+func evalIfThenElse(ctx *EvalContext, ite *IfThenElse, depth int) bool {
+	if evalCondition(ctx, ite.If, depth) {
+		return evalCondition(ctx, ite.Then, depth)
+	}
+	return evalCondition(ctx, ite.Else, depth)
+}
+
+// --- Value resolution ---
+
+// resolveExpr resolves an Expr to a Go value. Returns the value and true
+// if resolved successfully. Missing attributes return (nil, false).
+func resolveExpr(ctx *EvalContext, e *Expr) (any, bool) {
+	if e.AttrRef != nil {
+		return resolveAttrRef(ctx, e.AttrRef)
+	}
+	if e.Literal != nil {
+		v := resolveLiteral(e.Literal)
+		if v == nil {
+			return nil, false
+		}
+		return v, true
+	}
+	return nil, false
+}
+
+// resolveAttrRef looks up a dotted attribute path in the appropriate bag.
+func resolveAttrRef(ctx *EvalContext, ar *AttrRef) (any, bool) {
+	bag := getBag(ctx, ar.Root)
+	if bag == nil {
+		return nil, false
+	}
+	key := strings.Join(ar.Path, ".")
+	val, exists := bag[key]
+	if !exists {
+		return nil, false
+	}
+	return val, true
+}
+
+// resolveLiteral converts a Literal AST node to a Go value.
+func resolveLiteral(l *Literal) any {
+	switch {
+	case l.Str != nil:
+		return *l.Str
+	case l.Number != nil:
+		return *l.Number
+	case l.Bool != nil:
+		return *l.Bool
+	default:
+		return nil
+	}
+}
+
+// getBag returns the attribute map for the given root name.
+func getBag(ctx *EvalContext, root string) map[string]any {
+	if ctx.Bags == nil {
+		return nil
+	}
+	switch root {
+	case "principal":
+		return ctx.Bags.Subject
+	case "resource":
+		return ctx.Bags.Resource
+	case "action":
+		return ctx.Bags.Action
+	case "env":
+		return ctx.Bags.Environment
+	default:
+		return nil
+	}
+}
+
+// --- Type coercion and comparison helpers ---
+
+// toFloat64 attempts to convert a value to float64, handling all Go numeric
+// types that may appear in map[string]any bags.
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// toStringSlice converts a value to []string if possible. Supports both
+// []string and []any with string elements.
+func toStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		result := make([]string, 0, len(s))
+		for _, elem := range s {
+			str, ok := elem.(string)
+			if !ok {
+				return nil
+			}
+			result = append(result, str)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// literalListToStrings extracts string values from a ListExpr.
+func literalListToStrings(le *ListExpr) []string {
+	result := make([]string, 0, len(le.Values))
+	for _, lit := range le.Values {
+		if lit.Str != nil {
+			result = append(result, *lit.Str)
+		}
+	}
+	return result
+}
+
+// valuesEqual compares two any values for equality, with numeric coercion.
+func valuesEqual(a, b any) bool {
+	aNum, aIsNum := toFloat64(a)
+	bNum, bIsNum := toFloat64(b)
+	if aIsNum && bIsNum {
+		return aNum == bNum
+	}
+
+	aStr, aIsStr := a.(string)
+	bStr, bIsStr := b.(string)
+	if aIsStr && bIsStr {
+		return aStr == bStr
+	}
+
+	aBool, aIsBool := a.(bool)
+	bBool, bIsBool := b.(bool)
+	if aIsBool && bIsBool {
+		return aBool == bBool
+	}
+
+	return false
+}
+
+// containsAll checks that haystack contains all needles.
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]struct{}, len(haystack))
+	for _, s := range haystack {
+		set[s] = struct{}{}
+	}
+	for _, n := range needles {
+		if _, ok := set[n]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// containsAny checks that haystack contains at least one needle.
+func containsAny(haystack, needles []string) bool {
+	set := make(map[string]struct{}, len(haystack))
+	for _, s := range haystack {
+		set[s] = struct{}{}
+	}
+	for _, n := range needles {
+		if _, ok := set[n]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/access/policy/dsl/evaluator.go
+++ b/internal/access/policy/dsl/evaluator.go
@@ -31,6 +31,7 @@ func (ec *EvalContext) effectiveMaxDepth() int {
 // Returns true if all conditions are satisfied. A nil block means "no conditions"
 // and evaluates to true (unconditional).
 func EvaluateConditions(ctx *EvalContext, cond *ConditionBlock) bool {
+	ctx.depthExceeded = false
 	if cond == nil {
 		return true
 	}

--- a/internal/access/policy/dsl/evaluator_test.go
+++ b/internal/access/policy/dsl/evaluator_test.go
@@ -1,0 +1,1361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Helpers ---
+
+func newBags() *types.AttributeBags { return types.NewAttributeBags() }
+
+func defaultCtx(bags *types.AttributeBags) *EvalContext {
+	return &EvalContext{Bags: bags, MaxDepth: MaxNestingDepth}
+}
+
+// mkAttrRef builds an Expr from root + path segments.
+func mkAttrRef(root string, path ...string) *Expr {
+	return &Expr{AttrRef: &AttrRef{Root: root, Path: path}}
+}
+
+// mkStrLit builds a string literal Expr.
+func mkStrLit(s string) *Expr {
+	return &Expr{Literal: &Literal{Str: strPtr(s)}}
+}
+
+// mkNumLit builds a numeric literal Expr.
+func mkNumLit(n float64) *Expr {
+	return &Expr{Literal: &Literal{Number: float64Ptr(n)}}
+}
+
+// mkBoolLit builds a boolean literal Expr.
+func mkBoolLit(b bool) *Expr {
+	return &Expr{Literal: &Literal{Bool: boolPtr(b)}}
+}
+
+// mkComparison builds a ConditionBlock from a single comparison.
+func mkComparison(left *Expr, op string, right *Expr) *ConditionBlock {
+	return &ConditionBlock{
+		Disjunctions: []*Conjunction{{
+			Conditions: []*Condition{{
+				Comparison: &Comparison{Left: left, Comparator: op, Right: right},
+			}},
+		}},
+	}
+}
+
+// mkSingleCond wraps a Condition into a ConditionBlock.
+func mkSingleCond(c *Condition) *ConditionBlock {
+	return &ConditionBlock{
+		Disjunctions: []*Conjunction{{
+			Conditions: []*Condition{c},
+		}},
+	}
+}
+
+// mkStrList builds a ListExpr of string literals.
+func mkStrList(strs ...string) *ListExpr {
+	vals := make([]*Literal, len(strs))
+	for i, s := range strs {
+		vals[i] = &Literal{Str: strPtr(s)}
+	}
+	return &ListExpr{Values: vals}
+}
+
+// mkNumList builds a ListExpr of number literals.
+func mkNumList(nums ...float64) *ListExpr {
+	vals := make([]*Literal, len(nums))
+	for i, n := range nums {
+		vals[i] = &Literal{Number: float64Ptr(n)}
+	}
+	return &ListExpr{Values: vals}
+}
+
+// --- Comparison Tests ---
+
+func TestEvaluateConditions_Comparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		// String equality
+		{
+			name:     "string equality match",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "==", mkStrLit("admin")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: true,
+		},
+		{
+			name:     "string equality no match",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "==", mkStrLit("admin")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "guest"; return b }(),
+			expected: false,
+		},
+		{
+			name:     "string not equals match",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "!=", mkStrLit("guest")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: true,
+		},
+		{
+			name:     "string not equals no match",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "!=", mkStrLit("admin")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: false,
+		},
+		// Numeric comparisons
+		{
+			name:     "numeric greater than true",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10.0; return b }(),
+			expected: true,
+		},
+		{
+			name:     "numeric greater than false",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 3.0; return b }(),
+			expected: false,
+		},
+		{
+			name:     "numeric greater than equal boundary false",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 5.0; return b }(),
+			expected: false,
+		},
+		{
+			name:     "numeric >= true on boundary",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">=", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 5.0; return b }(),
+			expected: true,
+		},
+		{
+			name:     "numeric < true",
+			cond:     mkComparison(mkAttrRef("principal", "level"), "<", mkNumLit(10)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 3.0; return b }(),
+			expected: true,
+		},
+		{
+			name:     "numeric <= true on boundary",
+			cond:     mkComparison(mkAttrRef("principal", "level"), "<=", mkNumLit(10)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10.0; return b }(),
+			expected: true,
+		},
+		// Numeric coercion (int stored in bag)
+		{
+			name:     "int coercion to float64 for comparison",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10; return b }(),
+			expected: true,
+		},
+		{
+			name:     "int64 coercion to float64 for comparison",
+			cond:     mkComparison(mkAttrRef("principal", "level"), "==", mkNumLit(42)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = int64(42); return b }(),
+			expected: true,
+		},
+		{
+			name:     "int32 coercion to float64 for comparison",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">=", mkNumLit(3)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = int32(5); return b }(),
+			expected: true,
+		},
+		{
+			name:     "float32 coercion to float64 for comparison",
+			cond:     mkComparison(mkAttrRef("principal", "level"), "<=", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = float32(3.5); return b }(),
+			expected: true,
+		},
+		// Comparing two attribute refs
+		{
+			name: "compare two attr refs equal",
+			cond: mkComparison(mkAttrRef("resource", "id"), "==", mkAttrRef("principal", "id")),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["id"] = "abc"
+				b.Subject["id"] = "abc"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "compare two attr refs not equal",
+			cond: mkComparison(mkAttrRef("resource", "id"), "==", mkAttrRef("principal", "id")),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["id"] = "abc"
+				b.Subject["id"] = "xyz"
+				return b
+			}(),
+			expected: false,
+		},
+		// Comparing two literals
+		{
+			name:     "two string literals equal",
+			cond:     mkComparison(mkStrLit("hello"), "==", mkStrLit("hello")),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name:     "two number literals not equal",
+			cond:     mkComparison(mkNumLit(1), "!=", mkNumLit(2)),
+			bags:     newBags(),
+			expected: true,
+		},
+		// Missing attributes → false
+		{
+			name:     "missing left attr in comparison → false",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "==", mkStrLit("admin")),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name:     "missing right attr in comparison → false",
+			cond:     mkComparison(mkStrLit("admin"), "==", mkAttrRef("principal", "role")),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name:     "missing both attrs in comparison → false",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "==", mkAttrRef("resource", "type")),
+			bags:     newBags(),
+			expected: false,
+		},
+		// Type mismatch → false
+		{
+			name:     "type mismatch string vs number → false",
+			cond:     mkComparison(mkAttrRef("principal", "role"), "==", mkNumLit(5)),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: false,
+		},
+		{
+			name:     "type mismatch number vs string → false for >",
+			cond:     mkComparison(mkAttrRef("principal", "level"), ">", mkStrLit("five")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10.0; return b }(),
+			expected: false,
+		},
+		// Dotted path (flat key)
+		{
+			name:     "dotted attribute path lookup",
+			cond:     mkComparison(mkAttrRef("resource", "metadata", "tags"), "==", mkStrLit("important")),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["metadata.tags"] = "important"; return b }(),
+			expected: true,
+		},
+		// Boolean literal comparison
+		{
+			name:     "boolean literal comparison true==true",
+			cond:     mkComparison(mkBoolLit(true), "==", mkBoolLit(true)),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name:     "boolean literal comparison true!=false",
+			cond:     mkComparison(mkBoolLit(true), "!=", mkBoolLit(false)),
+			bags:     newBags(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Has Tests ---
+
+func TestEvaluateConditions_Has(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "has simple attribute present",
+			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}}),
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
+			expected: true,
+		},
+		{
+			name:     "has simple attribute missing",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "has dotted path present",
+			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "resource", Path: []string{"metadata", "tags"}}}),
+			bags: func() *types.AttributeBags { b := newBags(); b.Resource["metadata.tags"] = []string{"a"}; return b }(),
+			expected: true,
+		},
+		{
+			name: "has with zero value (empty string) still true",
+			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"name"}}}),
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["name"] = ""; return b }(),
+			expected: true,
+		},
+		{
+			name: "has with zero value (zero int) still true",
+			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"level"}}}),
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 0; return b }(),
+			expected: true,
+		},
+		{
+			name: "has with nil value still true (key exists)",
+			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"data"}}}),
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["data"] = nil; return b }(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Like Tests ---
+
+func TestEvaluateConditions_Like(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "like wildcard match",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "location:*",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location:01XYZ"; return b }(),
+			expected: true,
+		},
+		{
+			name: "like wildcard no match",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "location:*",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "character:01ABC"; return b }(),
+			expected: false,
+		},
+		{
+			name: "like exact match",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "hello",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "hello"; return b }(),
+			expected: true,
+		},
+		{
+			name: "like ? single char wildcard",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "he?lo",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "hello"; return b }(),
+			expected: true,
+		},
+		{
+			name: "like colon separator prevents cross-namespace match",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "loc*",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "loc:foo"; return b }(),
+			expected: false, // * doesn't match across ':'
+		},
+		{
+			name: "like missing attribute → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "location:*",
+			}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "like non-string attribute → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "location:*",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = 42; return b }(),
+			expected: false,
+		},
+		{
+			name: "like invalid pattern with brackets → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "loc[a-z]tion",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location"; return b }(),
+			expected: false,
+		},
+		{
+			name: "like invalid pattern with braces → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "loc{a,b}tion",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location"; return b }(),
+			expected: false,
+		},
+		{
+			name: "like invalid pattern with double star → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "loc**tion",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location"; return b }(),
+			expected: false,
+		},
+		{
+			name: "like pattern too many wildcards → false",
+			cond: mkSingleCond(&Condition{Like: &LikeCondition{
+				Left: mkAttrRef("resource", "name"), Pattern: "*?*?*?",
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "abcdef"; return b }(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- ContainsAll / ContainsAny Tests ---
+
+func TestEvaluateConditions_Contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "containsAll all present",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
+				List: mkStrList("vip", "beta"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"vip", "beta", "extra"}; return b }(),
+			expected: true,
+		},
+		{
+			name: "containsAll missing one",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
+				List: mkStrList("vip", "beta"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"vip", "extra"}; return b }(),
+			expected: false,
+		},
+		{
+			name: "containsAny one present",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAny",
+				List: mkStrList("admin", "builder"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"builder", "tester"}; return b }(),
+			expected: true,
+		},
+		{
+			name: "containsAny none present",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAny",
+				List: mkStrList("admin", "builder"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"tester", "viewer"}; return b }(),
+			expected: false,
+		},
+		{
+			name: "containsAll with []any string elements",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
+				List: mkStrList("a", "b"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []any{"a", "b", "c"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "containsAny with []any string elements",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAny",
+				List: mkStrList("x", "b"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []any{"a", "b", "c"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "contains missing attribute → false",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
+				List: mkStrList("a"),
+			}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "contains non-slice attribute → false",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
+				List: mkStrList("a"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = "not a slice"; return b }(),
+			expected: false,
+		},
+		{
+			name: "containsAll with dotted path",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "resource", Path: []string{"metadata", "tags"}, Op: "containsAll",
+				List: mkStrList("public"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["metadata.tags"] = []string{"public", "featured"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "contains with no path (root-level)",
+			cond: mkSingleCond(&Condition{Contains: &ContainsCondition{
+				Root: "principal", Path: nil, Op: "containsAny",
+				List: mkStrList("x"),
+			}}),
+			bags:     newBags(),
+			expected: false, // empty path means empty key, won't find attribute
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- InList Tests ---
+
+func TestEvaluateConditions_InList(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "in list string match",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkAttrRef("resource", "name"),
+				List: mkStrList("say", "pose", "look"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "say"; return b }(),
+			expected: true,
+		},
+		{
+			name: "in list string no match",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkAttrRef("resource", "name"),
+				List: mkStrList("say", "pose", "look"),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "dig"; return b }(),
+			expected: false,
+		},
+		{
+			name: "in list number match",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkAttrRef("principal", "level"),
+				List: mkNumList(1, 2, 3),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 2.0; return b }(),
+			expected: true,
+		},
+		{
+			name: "in list number with int coercion",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkAttrRef("principal", "level"),
+				List: mkNumList(1, 2, 3),
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 2; return b }(),
+			expected: true,
+		},
+		{
+			name: "in list missing attribute → false",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkAttrRef("resource", "name"),
+				List: mkStrList("say"),
+			}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "in list literal value match",
+			cond: mkSingleCond(&Condition{InList: &InListCondition{
+				Left: mkStrLit("say"),
+				List: mkStrList("say", "pose"),
+			}}),
+			bags:     newBags(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- InExpr Tests ---
+
+func TestEvaluateConditions_InExpr(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "in expr string found in []string",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "char:01ABC"
+				b.Resource["visible_to"] = []string{"char:01ABC", "char:02DEF"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "in expr string not found in []string",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "char:99ZZZ"
+				b.Resource["visible_to"] = []string{"char:01ABC", "char:02DEF"}
+				return b
+			}(),
+			expected: false,
+		},
+		{
+			name: "in expr with []any containing strings",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "char:01ABC"
+				b.Resource["visible_to"] = []any{"char:01ABC", "char:02DEF"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "in expr right side not a slice → false",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "char:01ABC"
+				b.Resource["visible_to"] = "not a slice"
+				return b
+			}(),
+			expected: false,
+		},
+		{
+			name: "in expr missing left → false",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["visible_to"] = []string{"a"}
+				return b
+			}(),
+			expected: false,
+		},
+		{
+			name: "in expr missing right → false",
+			cond: mkSingleCond(&Condition{InExpr: &InExprCondition{
+				Left: mkAttrRef("principal", "id"), Right: mkAttrRef("resource", "visible_to"),
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "abc"
+				return b
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Boolean Logic Tests ---
+
+func TestEvaluateConditions_BooleanLogic(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name:     "bare true",
+			cond:     mkSingleCond(&Condition{BoolLiteral: boolPtr(true)}),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name:     "bare false",
+			cond:     mkSingleCond(&Condition{BoolLiteral: boolPtr(false)}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "conjunction true && true",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
+				Conditions: []*Condition{
+					{BoolLiteral: boolPtr(true)},
+					{BoolLiteral: boolPtr(true)},
+				},
+			}}},
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "conjunction true && false",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
+				Conditions: []*Condition{
+					{BoolLiteral: boolPtr(true)},
+					{BoolLiteral: boolPtr(false)},
+				},
+			}}},
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "disjunction false || true",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{
+				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
+				{Conditions: []*Condition{{BoolLiteral: boolPtr(true)}}},
+			}},
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "disjunction false || false",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{
+				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
+				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
+			}},
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "conjunction with attr check: both match",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
+				Conditions: []*Condition{
+					{Comparison: &Comparison{
+						Left: mkAttrRef("principal", "role"), Comparator: "==", Right: mkStrLit("admin"),
+					}},
+					{Comparison: &Comparison{
+						Left: mkAttrRef("resource", "type"), Comparator: "==", Right: mkStrLit("location"),
+					}},
+				},
+			}}},
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["role"] = "admin"
+				b.Resource["type"] = "location"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "disjunction with attr check: second matches",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{
+				{Conditions: []*Condition{
+					{Comparison: &Comparison{
+						Left: mkAttrRef("principal", "role"), Comparator: "==", Right: mkStrLit("admin"),
+					}},
+				}},
+				{Conditions: []*Condition{
+					{Comparison: &Comparison{
+						Left: mkAttrRef("principal", "role"), Comparator: "==", Right: mkStrLit("builder"),
+					}},
+				}},
+			}},
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Negation Tests ---
+
+func TestEvaluateConditions_Negation(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "negation of true → false",
+			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: boolPtr(true)}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "negation of false → true",
+			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: boolPtr(false)}}),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "negation of matching comparison → false",
+			cond: mkSingleCond(&Condition{Negation: &Condition{
+				Comparison: &Comparison{
+					Left: mkAttrRef("principal", "role"), Comparator: "==", Right: mkStrLit("banned"),
+				},
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "banned"; return b }(),
+			expected: false,
+		},
+		{
+			name: "negation of non-matching comparison → true",
+			cond: mkSingleCond(&Condition{Negation: &Condition{
+				Comparison: &Comparison{
+					Left: mkAttrRef("principal", "role"), Comparator: "==", Right: mkStrLit("banned"),
+				},
+			}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: true,
+		},
+		{
+			name: "double negation",
+			cond: mkSingleCond(&Condition{Negation: &Condition{
+				Negation: &Condition{BoolLiteral: boolPtr(true)},
+			}}),
+			bags:     newBags(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Parenthesized Tests ---
+
+func TestEvaluateConditions_Parenthesized(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "parenthesized true",
+			cond: mkSingleCond(&Condition{Parenthesized: &ConditionBlock{
+				Disjunctions: []*Conjunction{{
+					Conditions: []*Condition{{BoolLiteral: boolPtr(true)}},
+				}},
+			}}),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "parenthesized or inside conjunction",
+			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
+				Conditions: []*Condition{
+					{Parenthesized: &ConditionBlock{
+						Disjunctions: []*Conjunction{
+							{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
+							{Conditions: []*Condition{{BoolLiteral: boolPtr(true)}}},
+						},
+					}},
+					{BoolLiteral: boolPtr(true)},
+				},
+			}}},
+			bags:     newBags(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- IfThenElse Tests ---
+
+func TestEvaluateConditions_IfThenElse(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     *ConditionBlock
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "if true then true else false → true",
+			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
+				If:   &Condition{BoolLiteral: boolPtr(true)},
+				Then: &Condition{BoolLiteral: boolPtr(true)},
+				Else: &Condition{BoolLiteral: boolPtr(false)},
+			}}),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "if false then true else false → false",
+			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
+				If:   &Condition{BoolLiteral: boolPtr(false)},
+				Then: &Condition{BoolLiteral: boolPtr(true)},
+				Else: &Condition{BoolLiteral: boolPtr(false)},
+			}}),
+			bags:     newBags(),
+			expected: false,
+		},
+		{
+			name: "if has faction then check faction else true",
+			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
+				If: &Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}},
+				Then: &Condition{Comparison: &Comparison{
+					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
+				}},
+				Else: &Condition{BoolLiteral: boolPtr(true)},
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["faction"] = "horde"
+				b.Resource["faction"] = "horde"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "if has faction (missing) then ... else true → true",
+			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
+				If: &Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}},
+				Then: &Condition{Comparison: &Comparison{
+					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
+				}},
+				Else: &Condition{BoolLiteral: boolPtr(true)},
+			}}),
+			bags:     newBags(),
+			expected: true,
+		},
+		{
+			name: "if has faction then mismatch else true → false (faction present but mismatches)",
+			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
+				If: &Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}},
+				Then: &Condition{Comparison: &Comparison{
+					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
+				}},
+				Else: &Condition{BoolLiteral: boolPtr(true)},
+			}}),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["faction"] = "horde"
+				b.Resource["faction"] = "alliance"
+				return b
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := defaultCtx(tt.bags)
+			assert.Equal(t, tt.expected, EvaluateConditions(ctx, tt.cond))
+		})
+	}
+}
+
+// --- Depth Limit Tests ---
+
+func TestEvaluateConditions_DepthLimit(t *testing.T) {
+	t.Run("exceeds max depth returns false", func(t *testing.T) {
+		// Build a deeply nested negation chain: !(!(!(...true...)))
+		inner := &Condition{BoolLiteral: boolPtr(true)}
+		for i := 0; i < MaxNestingDepth+1; i++ {
+			inner = &Condition{Negation: inner}
+		}
+		cond := mkSingleCond(inner)
+		ctx := defaultCtx(newBags())
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("at exactly max depth succeeds", func(t *testing.T) {
+		// Build exactly MaxNestingDepth levels of parenthesized nesting
+		// An even number of negations around true should yield true.
+		inner := &Condition{BoolLiteral: boolPtr(true)}
+		for i := 0; i < MaxNestingDepth; i++ {
+			inner = &Condition{Parenthesized: &ConditionBlock{
+				Disjunctions: []*Conjunction{{Conditions: []*Condition{inner}}},
+			}}
+		}
+		cond := mkSingleCond(inner)
+		ctx := defaultCtx(newBags())
+		assert.True(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("custom max depth", func(t *testing.T) {
+		inner := &Condition{BoolLiteral: boolPtr(true)}
+		for i := 0; i < 5; i++ {
+			inner = &Condition{Negation: inner}
+		}
+		cond := mkSingleCond(inner)
+		ctx := &EvalContext{Bags: newBags(), MaxDepth: 3}
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+}
+
+// --- Nil/Empty Edge Cases ---
+
+func TestEvaluateConditions_EdgeCases(t *testing.T) {
+	t.Run("nil condition block → true", func(t *testing.T) {
+		ctx := defaultCtx(newBags())
+		assert.True(t, EvaluateConditions(ctx, nil))
+	})
+
+	t.Run("empty disjunctions → true", func(t *testing.T) {
+		ctx := defaultCtx(newBags())
+		assert.True(t, EvaluateConditions(ctx, &ConditionBlock{}))
+	})
+
+	t.Run("empty conjunction → true", func(t *testing.T) {
+		ctx := defaultCtx(newBags())
+		cond := &ConditionBlock{Disjunctions: []*Conjunction{{}}}
+		assert.True(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("nil bags → false for any attribute access", func(t *testing.T) {
+		cond := mkComparison(mkAttrRef("principal", "role"), "==", mkStrLit("admin"))
+		ctx := &EvalContext{Bags: nil, MaxDepth: MaxNestingDepth}
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("zero MaxDepth defaults to MaxNestingDepth", func(t *testing.T) {
+		cond := mkSingleCond(&Condition{BoolLiteral: boolPtr(true)})
+		ctx := &EvalContext{Bags: newBags(), MaxDepth: 0}
+		assert.True(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("condition with all nil fields → false", func(t *testing.T) {
+		cond := mkSingleCond(&Condition{})
+		ctx := defaultCtx(newBags())
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+}
+
+// --- Root Mapping Tests ---
+
+func TestEvaluateConditions_RootMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		bagSetup func(*types.AttributeBags)
+	}{
+		{"principal maps to Subject", "principal", func(b *types.AttributeBags) { b.Subject["x"] = "v" }},
+		{"resource maps to Resource", "resource", func(b *types.AttributeBags) { b.Resource["x"] = "v" }},
+		{"action maps to Action", "action", func(b *types.AttributeBags) { b.Action["x"] = "v" }},
+		{"env maps to Environment", "env", func(b *types.AttributeBags) { b.Environment["x"] = "v" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBags()
+			tt.bagSetup(b)
+			cond := mkComparison(mkAttrRef(tt.root, "x"), "==", mkStrLit("v"))
+			ctx := defaultCtx(b)
+			assert.True(t, EvaluateConditions(ctx, cond))
+		})
+	}
+
+	t.Run("unknown root → false", func(t *testing.T) {
+		b := newBags()
+		cond := mkComparison(mkAttrRef("unknown", "x"), "==", mkStrLit("v"))
+		ctx := defaultCtx(b)
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+}
+
+// --- Parse + Evaluate Integration Tests ---
+
+func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsl      string
+		bags     *types.AttributeBags
+		expected bool
+	}{
+		{
+			name: "simple role check permit",
+			dsl:  `permit(principal, action, resource) when { principal.role == "admin" };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: true,
+		},
+		{
+			name: "simple role check deny",
+			dsl:  `permit(principal, action, resource) when { principal.role == "admin" };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "guest"; return b }(),
+			expected: false,
+		},
+		{
+			name: "conjunction",
+			dsl:  `permit(principal, action, resource) when { principal.role == "admin" && resource.type == "location" };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["role"] = "admin"
+				b.Resource["type"] = "location"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "disjunction",
+			dsl:  `permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			expected: true,
+		},
+		{
+			name: "negation",
+			dsl:  `permit(principal, action, resource) when { !(principal.role == "banned") };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "player"; return b }(),
+			expected: true,
+		},
+		{
+			name: "in list",
+			dsl:  `permit(principal, action, resource) when { resource.name in ["say", "pose", "look"] };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "pose"; return b }(),
+			expected: true,
+		},
+		{
+			name: "in expr",
+			dsl:  `permit(principal, action, resource) when { principal.id in resource.visible_to };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["id"] = "char:01"
+				b.Resource["visible_to"] = []string{"char:01", "char:02"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "like glob",
+			dsl:  `permit(principal, action, resource) when { resource.name like "location:*" };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location:01XYZ"; return b }(),
+			expected: true,
+		},
+		{
+			name: "has",
+			dsl:  `permit(principal, action, resource) when { principal has faction };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
+			expected: true,
+		},
+		{
+			name: "containsAll",
+			dsl:  `permit(principal, action, resource) when { principal.flags.containsAll(["vip", "beta"]) };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []string{"vip", "beta", "new"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "containsAny",
+			dsl:  `permit(principal, action, resource) when { principal.flags.containsAny(["admin", "builder"]) };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []string{"builder"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "if-then-else faction match",
+			dsl:  `permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["faction"] = "horde"
+				b.Resource["faction"] = "horde"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "if-then-else no faction falls through",
+			dsl:  `permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`,
+			bags: newBags(),
+			expected: true,
+		},
+		{
+			name: "no when clause → true (unconditional)",
+			dsl:  `permit(principal is character, action in ["enter"], resource is location);`,
+			bags: newBags(),
+			expected: true,
+		},
+		{
+			name: "numeric comparison with int bag value",
+			dsl:  `permit(principal, action, resource) when { principal.level > 5 };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10; return b }(),
+			expected: true,
+		},
+		{
+			name: "parenthesized expression",
+			dsl:  `permit(principal, action, resource) when { (principal.role == "admin") };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			expected: true,
+		},
+		{
+			name:     "bare true",
+			dsl:      `permit(principal, action, resource) when { true };`,
+			bags:     newBags(),
+			expected: true,
+		},
+		// NOTE: "bare false" via parser is skipped here because participle
+		// captures @('true'|'false') on *bool as true regardless of the
+		// matched token text. The direct AST test in
+		// TestEvaluateConditions_BooleanLogic covers this correctly.
+		// Parser fix tracked separately.
+		{
+			name: "complex seed policy: restricted property visible_to",
+			dsl:  `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["visibility"] = "restricted"
+				b.Resource["visible_to"] = []string{"char:01", "char:02"}
+				b.Subject["id"] = "char:01"
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "complex seed policy: restricted property not visible",
+			dsl:  `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["visibility"] = "restricted"
+				b.Resource["visible_to"] = []string{"char:01", "char:02"}
+				b.Subject["id"] = "char:99"
+				return b
+			}(),
+			expected: false,
+		},
+		{
+			name: "has dotted path",
+			dsl:  `permit(principal, action, resource) when { resource has metadata.tags };`,
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Resource["metadata.tags"] = []string{"a"}
+				return b
+			}(),
+			expected: true,
+		},
+		{
+			name: "role in list",
+			dsl:  `permit(principal, action, resource) when { principal.role in ["builder", "admin"] };`,
+			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := Parse(tt.dsl)
+			require.NoError(t, err, "policy should parse")
+
+			ctx := defaultCtx(tt.bags)
+			result := EvaluateConditions(ctx, policy.Conditions)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- Like Pattern Limits ---
+
+func TestEvaluateConditions_LikePatternLimits(t *testing.T) {
+	t.Run("pattern over 100 chars → false", func(t *testing.T) {
+		longPattern := ""
+		for i := 0; i < 101; i++ {
+			longPattern += "a"
+		}
+		cond := mkSingleCond(&Condition{Like: &LikeCondition{
+			Left: mkAttrRef("resource", "name"), Pattern: longPattern,
+		}})
+		bags := newBags()
+		bags.Resource["name"] = longPattern
+		ctx := defaultCtx(bags)
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("exactly 5 wildcards → ok", func(t *testing.T) {
+		cond := mkSingleCond(&Condition{Like: &LikeCondition{
+			Left: mkAttrRef("resource", "name"), Pattern: "a*b?c*d?e*",
+		}})
+		bags := newBags()
+		bags.Resource["name"] = "aXXbYcZZdWeTT"
+		ctx := defaultCtx(bags)
+		// 5 wildcards is within the limit, should evaluate successfully (not rejected)
+		assert.True(t, EvaluateConditions(ctx, cond))
+	})
+
+	t.Run("6 wildcards → false", func(t *testing.T) {
+		cond := mkSingleCond(&Condition{Like: &LikeCondition{
+			Left: mkAttrRef("resource", "name"), Pattern: "*?*?*?",
+		}})
+		bags := newBags()
+		bags.Resource["name"] = "abcdef"
+		ctx := defaultCtx(bags)
+		assert.False(t, EvaluateConditions(ctx, cond))
+	})
+}

--- a/internal/access/policy/dsl/evaluator_test.go
+++ b/internal/access/policy/dsl/evaluator_test.go
@@ -1060,6 +1060,21 @@ func TestEvaluateConditions_DepthLimit(t *testing.T) {
 		ctx := &EvalContext{Bags: newBags(), MaxDepth: 3}
 		assert.False(t, EvaluateConditions(ctx, cond))
 	})
+
+
+	t.Run("depthExceeded resets between calls", func(t *testing.T) {
+		// First call: trigger depth exceeded
+		inner := &Condition{BoolLiteral: strPtr("true")}
+		for i := 0; i < MaxNestingDepth+1; i++ {
+			inner = &Condition{Negation: inner}
+		}
+		ctx := defaultCtx(newBags())
+		assert.False(t, EvaluateConditions(ctx, mkSingleCond(inner)))
+
+		// Second call with same ctx: simple condition should succeed
+		simple := mkSingleCond(&Condition{BoolLiteral: strPtr("true")})
+		assert.True(t, EvaluateConditions(ctx, simple))
+	})
 }
 
 // --- Nil/Empty Edge Cases ---

--- a/internal/access/policy/dsl/evaluator_test.go
+++ b/internal/access/policy/dsl/evaluator_test.go
@@ -36,7 +36,11 @@ func mkNumLit(n float64) *Expr {
 
 // mkBoolLit builds a boolean literal Expr.
 func mkBoolLit(b bool) *Expr {
-	return &Expr{Literal: &Literal{Bool: boolPtr(b)}}
+	s := "false"
+	if b {
+		s = "true"
+	}
+	return &Expr{Literal: &Literal{Bool: &s}}
 }
 
 // mkComparison builds a ConditionBlock from a single comparison.
@@ -733,13 +737,13 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 	}{
 		{
 			name:     "bare true",
-			cond:     mkSingleCond(&Condition{BoolLiteral: boolPtr(true)}),
+			cond:     mkSingleCond(&Condition{BoolLiteral: strPtr("true")}),
 			bags:     newBags(),
 			expected: true,
 		},
 		{
 			name:     "bare false",
-			cond:     mkSingleCond(&Condition{BoolLiteral: boolPtr(false)}),
+			cond:     mkSingleCond(&Condition{BoolLiteral: strPtr("false")}),
 			bags:     newBags(),
 			expected: false,
 		},
@@ -747,8 +751,8 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 			name: "conjunction true && true",
 			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
 				Conditions: []*Condition{
-					{BoolLiteral: boolPtr(true)},
-					{BoolLiteral: boolPtr(true)},
+					{BoolLiteral: strPtr("true")},
+					{BoolLiteral: strPtr("true")},
 				},
 			}}},
 			bags:     newBags(),
@@ -758,8 +762,8 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 			name: "conjunction true && false",
 			cond: &ConditionBlock{Disjunctions: []*Conjunction{{
 				Conditions: []*Condition{
-					{BoolLiteral: boolPtr(true)},
-					{BoolLiteral: boolPtr(false)},
+					{BoolLiteral: strPtr("true")},
+					{BoolLiteral: strPtr("false")},
 				},
 			}}},
 			bags:     newBags(),
@@ -768,8 +772,8 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 		{
 			name: "disjunction false || true",
 			cond: &ConditionBlock{Disjunctions: []*Conjunction{
-				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
-				{Conditions: []*Condition{{BoolLiteral: boolPtr(true)}}},
+				{Conditions: []*Condition{{BoolLiteral: strPtr("false")}}},
+				{Conditions: []*Condition{{BoolLiteral: strPtr("true")}}},
 			}},
 			bags:     newBags(),
 			expected: true,
@@ -777,8 +781,8 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 		{
 			name: "disjunction false || false",
 			cond: &ConditionBlock{Disjunctions: []*Conjunction{
-				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
-				{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
+				{Conditions: []*Condition{{BoolLiteral: strPtr("false")}}},
+				{Conditions: []*Condition{{BoolLiteral: strPtr("false")}}},
 			}},
 			bags:     newBags(),
 			expected: false,
@@ -841,13 +845,13 @@ func TestEvaluateConditions_Negation(t *testing.T) {
 	}{
 		{
 			name: "negation of true → false",
-			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: boolPtr(true)}}),
+			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("true")}}),
 			bags:     newBags(),
 			expected: false,
 		},
 		{
 			name: "negation of false → true",
-			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: boolPtr(false)}}),
+			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("false")}}),
 			bags:     newBags(),
 			expected: true,
 		},
@@ -874,7 +878,7 @@ func TestEvaluateConditions_Negation(t *testing.T) {
 		{
 			name: "double negation",
 			cond: mkSingleCond(&Condition{Negation: &Condition{
-				Negation: &Condition{BoolLiteral: boolPtr(true)},
+				Negation: &Condition{BoolLiteral: strPtr("true")},
 			}}),
 			bags:     newBags(),
 			expected: true,
@@ -902,7 +906,7 @@ func TestEvaluateConditions_Parenthesized(t *testing.T) {
 			name: "parenthesized true",
 			cond: mkSingleCond(&Condition{Parenthesized: &ConditionBlock{
 				Disjunctions: []*Conjunction{{
-					Conditions: []*Condition{{BoolLiteral: boolPtr(true)}},
+					Conditions: []*Condition{{BoolLiteral: strPtr("true")}},
 				}},
 			}}),
 			bags:     newBags(),
@@ -914,11 +918,11 @@ func TestEvaluateConditions_Parenthesized(t *testing.T) {
 				Conditions: []*Condition{
 					{Parenthesized: &ConditionBlock{
 						Disjunctions: []*Conjunction{
-							{Conditions: []*Condition{{BoolLiteral: boolPtr(false)}}},
-							{Conditions: []*Condition{{BoolLiteral: boolPtr(true)}}},
+							{Conditions: []*Condition{{BoolLiteral: strPtr("false")}}},
+							{Conditions: []*Condition{{BoolLiteral: strPtr("true")}}},
 						},
 					}},
-					{BoolLiteral: boolPtr(true)},
+					{BoolLiteral: strPtr("true")},
 				},
 			}}},
 			bags:     newBags(),
@@ -946,9 +950,9 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 		{
 			name: "if true then true else false → true",
 			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
-				If:   &Condition{BoolLiteral: boolPtr(true)},
-				Then: &Condition{BoolLiteral: boolPtr(true)},
-				Else: &Condition{BoolLiteral: boolPtr(false)},
+				If:   &Condition{BoolLiteral: strPtr("true")},
+				Then: &Condition{BoolLiteral: strPtr("true")},
+				Else: &Condition{BoolLiteral: strPtr("false")},
 			}}),
 			bags:     newBags(),
 			expected: true,
@@ -956,9 +960,9 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 		{
 			name: "if false then true else false → false",
 			cond: mkSingleCond(&Condition{IfThenElse: &IfThenElse{
-				If:   &Condition{BoolLiteral: boolPtr(false)},
-				Then: &Condition{BoolLiteral: boolPtr(true)},
-				Else: &Condition{BoolLiteral: boolPtr(false)},
+				If:   &Condition{BoolLiteral: strPtr("false")},
+				Then: &Condition{BoolLiteral: strPtr("true")},
+				Else: &Condition{BoolLiteral: strPtr("false")},
 			}}),
 			bags:     newBags(),
 			expected: false,
@@ -970,7 +974,7 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 				Then: &Condition{Comparison: &Comparison{
 					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
 				}},
-				Else: &Condition{BoolLiteral: boolPtr(true)},
+				Else: &Condition{BoolLiteral: strPtr("true")},
 			}}),
 			bags: func() *types.AttributeBags {
 				b := newBags()
@@ -987,7 +991,7 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 				Then: &Condition{Comparison: &Comparison{
 					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
 				}},
-				Else: &Condition{BoolLiteral: boolPtr(true)},
+				Else: &Condition{BoolLiteral: strPtr("true")},
 			}}),
 			bags:     newBags(),
 			expected: true,
@@ -999,7 +1003,7 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 				Then: &Condition{Comparison: &Comparison{
 					Left: mkAttrRef("principal", "faction"), Comparator: "==", Right: mkAttrRef("resource", "faction"),
 				}},
-				Else: &Condition{BoolLiteral: boolPtr(true)},
+				Else: &Condition{BoolLiteral: strPtr("true")},
 			}}),
 			bags: func() *types.AttributeBags {
 				b := newBags()
@@ -1024,7 +1028,7 @@ func TestEvaluateConditions_IfThenElse(t *testing.T) {
 func TestEvaluateConditions_DepthLimit(t *testing.T) {
 	t.Run("exceeds max depth returns false", func(t *testing.T) {
 		// Build a deeply nested negation chain: !(!(!(...true...)))
-		inner := &Condition{BoolLiteral: boolPtr(true)}
+		inner := &Condition{BoolLiteral: strPtr("true")}
 		for i := 0; i < MaxNestingDepth+1; i++ {
 			inner = &Condition{Negation: inner}
 		}
@@ -1036,7 +1040,7 @@ func TestEvaluateConditions_DepthLimit(t *testing.T) {
 	t.Run("at exactly max depth succeeds", func(t *testing.T) {
 		// Build exactly MaxNestingDepth levels of parenthesized nesting
 		// An even number of negations around true should yield true.
-		inner := &Condition{BoolLiteral: boolPtr(true)}
+		inner := &Condition{BoolLiteral: strPtr("true")}
 		for i := 0; i < MaxNestingDepth; i++ {
 			inner = &Condition{Parenthesized: &ConditionBlock{
 				Disjunctions: []*Conjunction{{Conditions: []*Condition{inner}}},
@@ -1048,7 +1052,7 @@ func TestEvaluateConditions_DepthLimit(t *testing.T) {
 	})
 
 	t.Run("custom max depth", func(t *testing.T) {
-		inner := &Condition{BoolLiteral: boolPtr(true)}
+		inner := &Condition{BoolLiteral: strPtr("true")}
 		for i := 0; i < 5; i++ {
 			inner = &Condition{Negation: inner}
 		}
@@ -1084,7 +1088,7 @@ func TestEvaluateConditions_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("zero MaxDepth defaults to MaxNestingDepth", func(t *testing.T) {
-		cond := mkSingleCond(&Condition{BoolLiteral: boolPtr(true)})
+		cond := mkSingleCond(&Condition{BoolLiteral: strPtr("true")})
 		ctx := &EvalContext{Bags: newBags(), MaxDepth: 0}
 		assert.True(t, EvaluateConditions(ctx, cond))
 	})

--- a/internal/access/policy/dsl/parser.go
+++ b/internal/access/policy/dsl/parser.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/samber/oops"
+)
+
+// MaxNestingDepth is the maximum allowed nesting depth for conditions.
+const MaxNestingDepth = 32
+
+// parser is the singleton participle parser instance.
+var parser *participle.Parser[Policy]
+
+func init() {
+	var err error
+	parser, err = NewParser()
+	if err != nil {
+		panic(fmt.Sprintf("failed to build DSL parser: %v", err))
+	}
+}
+
+// Parse parses a DSL policy string into an AST.
+// Returns a descriptive error with position info on failure.
+func Parse(dslText string) (*Policy, error) {
+	policy, err := parser.ParseString("", dslText)
+	if err != nil {
+		return nil, oops.Wrapf(err, "parsing DSL policy")
+	}
+
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+// validatePolicy performs post-parse validation checks.
+func validatePolicy(p *Policy) error {
+	if p.Conditions != nil {
+		if err := validateConditionBlock(p.Conditions, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateConditionBlock checks nesting depth and reserved words.
+func validateConditionBlock(cb *ConditionBlock, depth int) error {
+	if depth > MaxNestingDepth {
+		return fmt.Errorf("nesting depth exceeds maximum of %d", MaxNestingDepth)
+	}
+	for _, conj := range cb.Disjunctions {
+		for _, cond := range conj.Conditions {
+			if err := validateCondition(cond, depth); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateCondition validates a single condition node.
+func validateCondition(c *Condition, depth int) error {
+	switch {
+	case c.Negation != nil:
+		return validateCondition(c.Negation, depth+1)
+	case c.Parenthesized != nil:
+		return validateConditionBlock(c.Parenthesized, depth+1)
+	case c.IfThenElse != nil:
+		if err := validateCondition(c.IfThenElse.If, depth+1); err != nil {
+			return err
+		}
+		if err := validateCondition(c.IfThenElse.Then, depth+1); err != nil {
+			return err
+		}
+		return validateCondition(c.IfThenElse.Else, depth+1)
+	case c.Has != nil:
+		return validateHasPaths(c.Has.Path)
+	case c.Comparison != nil:
+		return validateExprs(c.Comparison.Left, c.Comparison.Right)
+	case c.Like != nil:
+		return validateExpr(c.Like.Left)
+	case c.InList != nil:
+		return validateExpr(c.InList.Left)
+	case c.InExpr != nil:
+		return validateExprs(c.InExpr.Left, c.InExpr.Right)
+	case c.Contains != nil:
+		return validateHasPaths(c.Contains.Path)
+	}
+	return nil
+}
+
+func validateExprs(exprs ...*Expr) error {
+	for _, e := range exprs {
+		if err := validateExpr(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExpr(e *Expr) error {
+	if e.AttrRef != nil {
+		return validateAttrPaths(e.AttrRef.Path)
+	}
+	return nil
+}
+
+func validateAttrPaths(path []string) error {
+	for _, seg := range path {
+		if IsReservedWord(seg) {
+			return fmt.Errorf("reserved word %q cannot be used as an attribute name", seg)
+		}
+	}
+	return nil
+}
+
+func validateHasPaths(path []string) error {
+	for _, seg := range path {
+		if IsReservedWord(seg) {
+			return fmt.Errorf("reserved word %q cannot be used as an attribute name", seg)
+		}
+	}
+	return nil
+}
+
+// ParseError wraps a parse error with additional context.
+type ParseError struct {
+	Line    int
+	Column  int
+	Message string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("%d:%d: %s", e.Line, e.Column, e.Message)
+}
+

--- a/internal/access/policy/dsl/parser.go
+++ b/internal/access/policy/dsl/parser.go
@@ -90,6 +90,9 @@ func validateCondition(c *Condition, depth int) error {
 	case c.InExpr != nil:
 		return validateExprs(c.InExpr.Left, c.InExpr.Right)
 	case c.Contains != nil:
+		if len(c.Contains.Path) == 0 {
+			return fmt.Errorf("contains condition requires at least one attribute path segment (e.g., principal.flags.containsAll(...))")
+		}
 		return validateHasPaths(c.Contains.Path)
 	}
 	return nil

--- a/internal/access/policy/dsl/parser_fuzz_test.go
+++ b/internal/access/policy/dsl/parser_fuzz_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+)
+
+// FuzzParse tests the parser against arbitrary input to ensure it never panics.
+func FuzzParse(f *testing.F) {
+	// Seed corpus: all 18 seed policies from the spec
+	seeds := []string{
+		// Seed policies 1-18
+		`permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+		`permit(principal is character, action in ["read"], resource is location) when { resource.id == principal.location };`,
+		`permit(principal is character, action in ["read"], resource is character) when { resource.location == principal.location };`,
+		`permit(principal is character, action in ["read"], resource is object) when { resource.location == principal.location };`,
+		`permit(principal is character, action in ["emit"], resource is stream) when { resource.name like "location:*" && resource.location == principal.location };`,
+		`permit(principal is character, action in ["enter"], resource is location);`,
+		`permit(principal is character, action in ["use"], resource is exit);`,
+		`permit(principal is character, action in ["execute"], resource is command) when { resource.name in ["say", "pose", "look", "go"] };`,
+		`permit(principal is character, action in ["write", "delete"], resource is location) when { principal.role in ["builder", "admin"] };`,
+		`permit(principal is character, action in ["write", "delete"], resource is object) when { principal.role in ["builder", "admin"] };`,
+		`permit(principal is character, action in ["execute"], resource is command) when { principal.role in ["builder", "admin"] && resource.name in ["dig", "create", "describe", "link"] };`,
+		`permit(principal is character, action, resource) when { principal.role == "admin" };`,
+		`permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "public" && principal.location == resource.parent_location };`,
+		`permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "private" && resource.owner == principal.id };`,
+		`permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "admin" && principal.role == "admin" };`,
+		`permit(principal is character, action in ["write", "delete"], resource is property) when { resource.owner == principal.id };`,
+		`permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`,
+		`forbid(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has excluded_from && principal.id in resource.excluded_from };`,
+
+		// Operator coverage seeds
+		// Equality
+		`permit(principal, action, resource) when { principal.role == "admin" };`,
+		// Not-equals
+		`permit(principal, action, resource) when { principal.role != "guest" };`,
+		// Greater than
+		`permit(principal, action, resource) when { principal.level > 5 };`,
+		// Greater or equal
+		`permit(principal, action, resource) when { principal.level >= 5 };`,
+		// Less than
+		`permit(principal, action, resource) when { principal.level < 10 };`,
+		// Less or equal
+		`permit(principal, action, resource) when { principal.level <= 10 };`,
+		// In list
+		`permit(principal, action, resource) when { resource.name in ["say", "pose"] };`,
+		// In expr
+		`permit(principal, action, resource) when { principal.id in resource.visible_to };`,
+		// Like
+		`permit(principal, action, resource) when { resource.name like "location:*" };`,
+		// Has simple
+		`permit(principal, action, resource) when { principal has faction };`,
+		// Has dotted
+		`permit(principal, action, resource) when { resource has metadata.tags };`,
+		// containsAll
+		`permit(principal, action, resource) when { principal.flags.containsAll(["vip", "beta"]) };`,
+		// containsAny
+		`permit(principal, action, resource) when { principal.flags.containsAny(["admin", "builder"]) };`,
+		// Negation
+		`permit(principal, action, resource) when { !(principal.role == "banned") };`,
+		// And
+		`permit(principal, action, resource) when { principal.role == "admin" && resource.type == "location" };`,
+		// Or
+		`permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`,
+		// If-then-else
+		`permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`,
+		// Resource exact match
+		`permit(principal, action, resource == "location:01XYZ") when { principal.role == "admin" };`,
+		// Parenthesized
+		`permit(principal, action, resource) when { (principal.role == "admin") };`,
+		// Bare true
+		`permit(principal, action, resource) when { true };`,
+		// Bare false
+		`permit(principal, action, resource) when { false };`,
+
+		// Additional edge case seeds
+		// Simple forbid
+		`forbid(principal, action, resource);`,
+		// Forbid with condition
+		`forbid(principal, action, resource) when { principal.role == "banned" };`,
+		// Deep nesting with parentheses
+		`permit(principal, action, resource) when { ((principal.role == "admin")) };`,
+		// Multiple ands
+		`permit(principal, action, resource) when { principal.role == "admin" && resource.type == "location" && principal.level > 5 };`,
+		// Multiple ors
+		`permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" || principal.role == "moderator" };`,
+		// Negation with complex expr
+		`permit(principal, action, resource) when { !(principal.role == "banned" && resource.type == "restricted") };`,
+		// If-then-else with negation
+		`permit(principal, action, resource) when { if !(principal has faction) then true else principal.faction == resource.faction };`,
+		// Complex condition with multiple operators
+		`permit(principal, action, resource) when { principal.role == "admin" && (resource.level > 5 || resource.level < 0) };`,
+		// String comparison
+		`permit(principal, action, resource) when { resource.type == "character" };`,
+		// Numeric comparison chain
+		`permit(principal, action, resource) when { principal.level >= 1 && principal.level <= 99 };`,
+		// Property in list
+		`permit(principal, action, resource) when { principal.faction in ["red", "blue", "green"] };`,
+		// Long list
+		`permit(principal, action, resource) when { resource.name in ["a", "b", "c", "d", "e", "f", "g", "h"] };`,
+		// Wildcard pattern variations
+		`permit(principal, action, resource) when { resource.name like "*:end" };`,
+		`permit(principal, action, resource) when { resource.name like "start:*:end" };`,
+		`permit(principal, action, resource) when { resource.name like "*middle*" };`,
+		// Has with multiple segments
+		`permit(principal, action, resource) when { resource has metadata.tags.special };`,
+		// Contains with single value
+		`permit(principal, action, resource) when { principal.tags.containsAll(["vip"]) };`,
+		`permit(principal, action, resource) when { principal.tags.containsAny(["guest"]) };`,
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(_ *testing.T, input string) {
+		_, _ = dsl.Parse(input)
+	})
+}

--- a/internal/access/policy/dsl/parser_test.go
+++ b/internal/access/policy/dsl/parser_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dsl_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_SeedPolicies(t *testing.T) {
+	seeds := []struct {
+		name string
+		dsl  string
+	}{
+		{"self-read character", `permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`},
+		{"read location by location", `permit(principal is character, action in ["read"], resource is location) when { resource.id == principal.location };`},
+		{"read character same location", `permit(principal is character, action in ["read"], resource is character) when { resource.location == principal.location };`},
+		{"read object same location", `permit(principal is character, action in ["read"], resource is object) when { resource.location == principal.location };`},
+		{"emit to location stream", `permit(principal is character, action in ["emit"], resource is stream) when { resource.name like "location:*" && resource.location == principal.location };`},
+		{"enter location", `permit(principal is character, action in ["enter"], resource is location);`},
+		{"use exit", `permit(principal is character, action in ["use"], resource is exit);`},
+		{"execute basic commands", `permit(principal is character, action in ["execute"], resource is command) when { resource.name in ["say", "pose", "look", "go"] };`},
+		{"builder write/delete location", `permit(principal is character, action in ["write", "delete"], resource is location) when { principal.role in ["builder", "admin"] };`},
+		{"builder write/delete object", `permit(principal is character, action in ["write", "delete"], resource is object) when { principal.role in ["builder", "admin"] };`},
+		{"builder execute commands", `permit(principal is character, action in ["execute"], resource is command) when { principal.role in ["builder", "admin"] && resource.name in ["dig", "create", "describe", "link"] };`},
+		{"admin wildcard", `permit(principal is character, action, resource) when { principal.role == "admin" };`},
+		{"public property read", `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "public" && principal.location == resource.parent_location };`},
+		{"private property read", `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "private" && resource.owner == principal.id };`},
+		{"admin property read", `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "admin" && principal.role == "admin" };`},
+		{"property owner write", `permit(principal is character, action in ["write", "delete"], resource is property) when { resource.owner == principal.id };`},
+		{"restricted property visible_to", `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`},
+		{"restricted property excluded_from", `forbid(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has excluded_from && principal.id in resource.excluded_from };`},
+	}
+
+	for _, tt := range seeds {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := dsl.Parse(tt.dsl)
+			require.NoError(t, err, "seed policy should parse: %s", tt.dsl)
+			require.NotNil(t, policy)
+
+			// Verify round-trip via String()
+			rendered := policy.String()
+			reparsed, err := dsl.Parse(rendered)
+			require.NoError(t, err, "round-trip should parse: %s", rendered)
+			assert.Equal(t, policy.Effect, reparsed.Effect)
+		})
+	}
+}
+
+func TestParse_Operators(t *testing.T) {
+	tests := []struct {
+		name string
+		dsl  string
+	}{
+		{"equals", `permit(principal, action, resource) when { principal.role == "admin" };`},
+		{"not equals", `permit(principal, action, resource) when { principal.role != "guest" };`},
+		{"greater than", `permit(principal, action, resource) when { principal.level > 5 };`},
+		{"greater or equal", `permit(principal, action, resource) when { principal.level >= 5 };`},
+		{"less than", `permit(principal, action, resource) when { principal.level < 10 };`},
+		{"less or equal", `permit(principal, action, resource) when { principal.level <= 10 };`},
+		{"in list", `permit(principal, action, resource) when { resource.name in ["say", "pose"] };`},
+		{"in expr", `permit(principal, action, resource) when { principal.id in resource.visible_to };`},
+		{"like", `permit(principal, action, resource) when { resource.name like "location:*" };`},
+		{"has simple", `permit(principal, action, resource) when { principal has faction };`},
+		{"has dotted", `permit(principal, action, resource) when { resource has metadata.tags };`},
+		{"containsAll", `permit(principal, action, resource) when { principal.flags.containsAll(["vip", "beta"]) };`},
+		{"containsAny", `permit(principal, action, resource) when { principal.flags.containsAny(["admin", "builder"]) };`},
+		{"negation", `permit(principal, action, resource) when { !(principal.role == "banned") };`},
+		{"and", `permit(principal, action, resource) when { principal.role == "admin" && resource.type == "location" };`},
+		{"or", `permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`},
+		{"if-then-else", `permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`},
+		{"resource exact match", `permit(principal, action, resource == "location:01XYZ") when { principal.role == "admin" };`},
+		{"parenthesized", `permit(principal, action, resource) when { (principal.role == "admin") };`},
+		{"bare true", `permit(principal, action, resource) when { true };`},
+		{"bare false", `permit(principal, action, resource) when { false };`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := dsl.Parse(tt.dsl)
+			require.NoError(t, err, "should parse: %s", tt.dsl)
+			require.NotNil(t, policy)
+		})
+	}
+}
+
+func TestParse_InvalidPolicies(t *testing.T) {
+	tests := []struct {
+		name    string
+		dsl     string
+		errText string
+	}{
+		{"empty input", "", ""},
+		{"missing semicolon", `permit(principal, action, resource)`, ""},
+		{"unknown effect", `allow(principal, action, resource);`, ""},
+		{"entity reference syntax", `permit(principal in Group::"admins", action, resource);`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dsl.Parse(tt.dsl)
+			assert.Error(t, err, "should fail: %s", tt.dsl)
+			if tt.errText != "" {
+				assert.Contains(t, err.Error(), tt.errText)
+			}
+		})
+	}
+}
+
+func TestParse_NestingDepthLimit(t *testing.T) {
+	// Build a deeply nested expression: (((((...(true)...))))
+	deep := "permit(principal, action, resource) when { "
+	for range 33 {
+		deep += "("
+	}
+	deep += "true"
+	for range 33 {
+		deep += ")"
+	}
+	deep += " };"
+
+	_, err := dsl.Parse(deep)
+	assert.Error(t, err, "nesting depth >32 should error")
+}
+
+func TestParse_StructuralChecks(t *testing.T) {
+	t.Run("permit effect", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal is character, action in ["read"], resource is location);`)
+		require.NoError(t, err)
+		assert.Equal(t, "permit", p.Effect)
+		assert.Equal(t, "character", p.Target.Principal.Type)
+		assert.Equal(t, []string{"read"}, p.Target.Action.Actions)
+		assert.Equal(t, "location", p.Target.Resource.Type)
+		assert.Nil(t, p.Conditions)
+	})
+
+	t.Run("forbid effect", func(t *testing.T) {
+		p, err := dsl.Parse(`forbid(principal, action, resource);`)
+		require.NoError(t, err)
+		assert.Equal(t, "forbid", p.Effect)
+		assert.Empty(t, p.Target.Principal.Type)
+	})
+
+	t.Run("condition structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { principal.role == "admin" };`)
+		require.NoError(t, err)
+		require.NotNil(t, p.Conditions)
+		require.Len(t, p.Conditions.Disjunctions, 1)
+		conj := p.Conditions.Disjunctions[0]
+		require.Len(t, conj.Conditions, 1)
+		cond := conj.Conditions[0]
+		require.NotNil(t, cond.Comparison)
+		assert.Equal(t, "==", cond.Comparison.Comparator)
+	})
+
+	t.Run("disjunction structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`)
+		require.NoError(t, err)
+		require.NotNil(t, p.Conditions)
+		require.Len(t, p.Conditions.Disjunctions, 2)
+	})
+
+	t.Run("conjunction structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { principal.role == "admin" && resource.type == "location" };`)
+		require.NoError(t, err)
+		require.Len(t, p.Conditions.Disjunctions, 1)
+		conj := p.Conditions.Disjunctions[0]
+		require.Len(t, conj.Conditions, 2)
+	})
+
+	t.Run("has condition structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { principal has faction };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.Has)
+		assert.Equal(t, "principal", cond.Has.Root)
+		assert.Equal(t, []string{"faction"}, cond.Has.Path)
+	})
+
+	t.Run("like condition structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { resource.name like "location:*" };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.Like)
+		assert.Equal(t, "location:*", cond.Like.Pattern)
+	})
+
+	t.Run("in list condition structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { resource.name in ["say", "pose", "look"] };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.InList)
+		require.Len(t, cond.InList.List.Values, 3)
+	})
+
+	t.Run("in expr condition structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { principal.id in resource.visible_to };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.InExpr)
+		require.NotNil(t, cond.InExpr.Right.AttrRef)
+	})
+
+	t.Run("if-then-else structure", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.IfThenElse)
+		require.NotNil(t, cond.IfThenElse.If.Has)
+		require.NotNil(t, cond.IfThenElse.Then.Comparison)
+		require.NotNil(t, cond.IfThenElse.Else.BoolLiteral)
+		assert.True(t, *cond.IfThenElse.Else.BoolLiteral)
+	})
+}
+
+func TestParse_ReservedWordAsAttribute(t *testing.T) {
+	// Using a reserved word as an attribute segment should be rejected.
+	// "permit" is reserved and should not appear as an attribute name.
+	_, err := dsl.Parse(`permit(principal, action, resource) when { principal.permit == "x" };`)
+	assert.Error(t, err, "reserved word as attribute should be rejected")
+}

--- a/internal/access/policy/dsl/parser_test.go
+++ b/internal/access/policy/dsl/parser_test.go
@@ -233,6 +233,13 @@ func TestParse_StructuralChecks(t *testing.T) {
 	})
 }
 
+func TestParse_ContainsEmptyPath(t *testing.T) {
+	// principal.containsAll(...) has no attribute path between root and method — should fail validation.
+	_, err := dsl.Parse(`permit(principal, action, resource) when { principal.containsAll(["x"]) };`)
+	assert.Error(t, err, "contains with empty path should be rejected")
+	assert.Contains(t, err.Error(), "at least one attribute path segment")
+}
+
 func TestParse_ReservedWordAsAttribute(t *testing.T) {
 	// Using a reserved word as an attribute segment should be rejected.
 	// "permit" is reserved and should not appear as an attribute name.

--- a/internal/access/policy/dsl/parser_test.go
+++ b/internal/access/policy/dsl/parser_test.go
@@ -213,7 +213,23 @@ func TestParse_StructuralChecks(t *testing.T) {
 		require.NotNil(t, cond.IfThenElse.If.Has)
 		require.NotNil(t, cond.IfThenElse.Then.Comparison)
 		require.NotNil(t, cond.IfThenElse.Else.BoolLiteral)
-		assert.True(t, *cond.IfThenElse.Else.BoolLiteral)
+		assert.Equal(t, "true", *cond.IfThenElse.Else.BoolLiteral)
+	})
+
+	t.Run("bool literal true", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { true };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.BoolLiteral)
+		assert.Equal(t, "true", *cond.BoolLiteral)
+	})
+
+	t.Run("bool literal false", func(t *testing.T) {
+		p, err := dsl.Parse(`permit(principal, action, resource) when { false };`)
+		require.NoError(t, err)
+		cond := p.Conditions.Disjunctions[0].Conditions[0]
+		require.NotNil(t, cond.BoolLiteral)
+		assert.Equal(t, "false", *cond.BoolLiteral)
 	})
 }
 

--- a/internal/access/policy/types/types.go
+++ b/internal/access/policy/types/types.go
@@ -187,6 +187,12 @@ func (s *AttributeSchema) Register(namespace string, schema *NamespaceSchema) er
 	return nil
 }
 
+// HasNamespace returns true if the given namespace has been registered.
+func (s *AttributeSchema) HasNamespace(namespace string) bool {
+	_, ok := s.namespaces[namespace]
+	return ok
+}
+
 // IsRegistered checks if a namespace+key pair exists. Full implementation in Task 12.
 func (s *AttributeSchema) IsRegistered(namespace, key string) bool {
 	ns, ok := s.namespaces[namespace]


### PR DESCRIPTION
## Summary

Implements Phase 7.2 of the Full ABAC system: the Cedar-inspired DSL parser, condition evaluator, and policy compiler.

- **T8: AST node types** — 18+ AST types with participle annotations, `String()` serialization, and reserved word validation
- **T9: DSL parser** — Full grammar support via participle v2 with backtracking, post-parse nesting depth validation, and reserved word checks
- **T10: Fuzz tests** — `FuzzParse` with 57 seed policies covering all operators; 1.1M+ inputs tested with no panics
- **T11: Condition evaluator** — All 14 operators with Cedar fail-safe semantics (missing attrs → false), depth limiting, glob pattern safety, and numeric type coercion across all Go types
- **T12: PolicyCompiler** — Parses DSL → validates attributes against schema → pre-compiles glob patterns → produces `CompiledPolicy` with target extraction and action namespace enforcement

### Key design decisions

- **Cedar fail-safe semantics**: Missing attributes and type mismatches always evaluate to `false`, never `true`
- **Glob safety**: Pattern length ≤100, wildcards ≤5, no brackets/braces/globstar, colon separator for namespace isolation
- **Nesting depth cap**: 32 levels max at both parse-time validation and eval-time enforcement
- **Action namespace enforcement**: Unregistered action attributes are compile errors; other namespace unknowns are warnings
- **Compiler naming**: `policy.Compiler` (not `PolicyCompiler`) to avoid stutter per revive lint rules

### Stats

- 12 files changed, +3,903 lines
- 20+ test functions, 130+ table-driven test cases
- All tests pass, lint clean

## Test plan

- [x] `task test` — all unit tests pass
- [x] `task lint` — clean
- [x] `task test:fuzz` — 1.1M+ inputs, zero panics
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)