### PR TITLE
feat(access): ABAC Phase 7.3 — Policy Engine & Attribute Providers

### DIFF
--- a/.benchmarks/baseline.txt
+++ b/.benchmarks/baseline.txt
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Benchmark baseline values for regression detection.
+# Format: BenchmarkName ns/op
+#
+# These values represent the maximum acceptable performance targets.
+# The check script enforces a 110% threshold on top of these values.
+# Update these when intentional performance changes are made.
+#
+# To regenerate from actual measurements:
+#   go test -bench=. -benchmem -count=3 ./internal/access/policy/ -run=^$ -benchtime=1s
+#
+BenchmarkSinglePolicyEvaluation 10000
+BenchmarkConditionEvaluation 1000000
+BenchmarkFiftyPolicyEvaluation 100000
+BenchmarkAttributeResolution 50000
+BenchmarkWorstCase_NestedIf 25000000
+BenchmarkWorstCase_AllPoliciesMatch 10000000
+BenchmarkEvaluateEndToEnd 1000000

--- a/.github/workflows/benchmark-check.yml
+++ b/.github/workflows/benchmark-check.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+name: Benchmark Regression Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Benchmark Regression Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run benchmark regression check
+        run: bash scripts/check-benchmark-regression.sh

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -103,6 +103,15 @@ tasks:
       FUZZ_TIME: '{{default "30s" .FUZZ_TIME}}'
       FUZZ_PACKAGE: '{{default "./internal/access/policy/dsl/" .FUZZ_PACKAGE}}'
 
+  test:bench:
+    desc: Run benchmarks
+    cmds:
+      - go test -bench=. -benchmem -count={{.BENCH_COUNT}} -benchtime={{.BENCH_TIME}} -run='^$' {{.BENCH_PACKAGE}}
+    vars:
+      BENCH_COUNT: '{{default "3" .BENCH_COUNT}}'
+      BENCH_TIME: '{{default "1s" .BENCH_TIME}}'
+      BENCH_PACKAGE: '{{default "./internal/access/policy/" .BENCH_PACKAGE}}'
+
   mocks:generate:
     desc: Generate mocks with mockery
     cmds:

--- a/internal/access/permissions.go
+++ b/internal/access/permissions.go
@@ -31,10 +31,10 @@ var builderPowers = []string{
 	"delete:object:*",
 
 	// Builder commands
-	"execute:command:@dig",
-	"execute:command:@create",
-	"execute:command:@describe",
-	"execute:command:@link",
+	"execute:command:dig",
+	"execute:command:create",
+	"execute:command:describe",
+	"execute:command:link",
 }
 
 var adminPowers = []string{

--- a/internal/access/permissions_test.go
+++ b/internal/access/permissions_test.go
@@ -24,7 +24,7 @@ func TestDefaultRoles(t *testing.T) {
 
 	// Builder has world modification
 	assert.Contains(t, roles["builder"], "write:location:*")
-	assert.Contains(t, roles["builder"], "execute:command:@dig")
+	assert.Contains(t, roles["builder"], "execute:command:dig")
 
 	// Admin has full access
 	assert.Contains(t, roles["admin"], "read:**")

--- a/internal/access/policy/attribute/cache.go
+++ b/internal/access/policy/attribute/cache.go
@@ -39,17 +39,18 @@ func newAttributeCache(capacity int) *attributeCache {
 	}
 }
 
-// Get retrieves a value from the cache
+// Get retrieves a value from the cache.
+// Uses a full write lock because MoveToFront mutates the LRU list.
 func (c *attributeCache) Get(key string) (map[string]any, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	elem, exists := c.items[key]
 	if !exists {
 		return nil, false
 	}
 
-	// Move to front (most recently used)
+	// Move to front (most recently used) — mutates list, requires write lock
 	c.lru.MoveToFront(elem)
 
 	entry, ok := elem.Value.(*cacheEntry)

--- a/internal/access/policy/attribute/cache.go
+++ b/internal/access/policy/attribute/cache.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type contextKey string
+
+const (
+	cacheContextKey contextKey = "attribute_cache"
+	inResolutionKey contextKey = "in_resolution"
+)
+
+// cacheEntry represents a cached attribute map
+type cacheEntry struct {
+	key   string
+	value map[string]any
+}
+
+// attributeCache is a simple LRU cache for attribute resolution
+type attributeCache struct {
+	mu       sync.RWMutex
+	capacity int
+	items    map[string]*list.Element
+	lru      *list.List
+}
+
+// newAttributeCache creates a new LRU cache with the given capacity
+func newAttributeCache(capacity int) *attributeCache {
+	return &attributeCache{
+		capacity: capacity,
+		items:    make(map[string]*list.Element),
+		lru:      list.New(),
+	}
+}
+
+// Get retrieves a value from the cache
+func (c *attributeCache) Get(key string) (map[string]any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	elem, exists := c.items[key]
+	if !exists {
+		return nil, false
+	}
+
+	// Move to front (most recently used)
+	c.lru.MoveToFront(elem)
+
+	entry, ok := elem.Value.(*cacheEntry)
+	if !ok {
+		return nil, false
+	}
+	return entry.value, true
+}
+
+// Put adds a value to the cache
+func (c *attributeCache) Put(key string, value map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if already exists
+	if elem, exists := c.items[key]; exists {
+		c.lru.MoveToFront(elem)
+		if entry, ok := elem.Value.(*cacheEntry); ok {
+			entry.value = value
+		}
+		return
+	}
+
+	// Add new entry
+	entry := &cacheEntry{key: key, value: value}
+	elem := c.lru.PushFront(entry)
+	c.items[key] = elem
+
+	// Evict oldest if over capacity
+	if c.lru.Len() > c.capacity {
+		oldest := c.lru.Back()
+		if oldest != nil {
+			c.lru.Remove(oldest)
+			if oldEntry, ok := oldest.Value.(*cacheEntry); ok {
+				delete(c.items, oldEntry.key)
+			}
+		}
+	}
+}
+
+// getCacheFromContext retrieves the cache from context, or creates a new one
+func getCacheFromContext(ctx context.Context) *attributeCache {
+	if cache, ok := ctx.Value(cacheContextKey).(*attributeCache); ok {
+		return cache
+	}
+	return newAttributeCache(100)
+}
+
+// withCache returns a new context with a cache attached
+func withCache(ctx context.Context) context.Context {
+	cache := newAttributeCache(100)
+	return context.WithValue(ctx, cacheContextKey, cache)
+}
+
+// isInResolution checks if resolution is already in progress
+func isInResolution(ctx context.Context) bool {
+	if inResolution, ok := ctx.Value(inResolutionKey).(bool); ok {
+		return inResolution
+	}
+	return false
+}
+
+// markInResolution marks the context as being in resolution
+func markInResolution(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inResolutionKey, true)
+}

--- a/internal/access/policy/attribute/character.go
+++ b/internal/access/policy/attribute/character.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"strings"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+)
+
+// CharacterProvider resolves attributes for character entities.
+type CharacterProvider struct {
+	repo world.CharacterRepository
+}
+
+// NewCharacterProvider creates a new character attribute provider.
+func NewCharacterProvider(repo world.CharacterRepository) *CharacterProvider {
+	return &CharacterProvider{repo: repo}
+}
+
+// Namespace returns "character".
+func (p *CharacterProvider) Namespace() string {
+	return "character"
+}
+
+// ResolveSubject resolves character attributes for a subject.
+// Returns nil, nil if the subject is not a character type.
+// Subject ID format: "character:01ABC..."
+func (p *CharacterProvider) ResolveSubject(ctx context.Context, subjectID string) (map[string]any, error) {
+	return p.resolve(ctx, subjectID)
+}
+
+// ResolveResource resolves character attributes for a resource.
+// Characters can be resources (e.g., checking permissions on another character).
+// Returns nil, nil if the resource is not a character type.
+// Resource ID format: "character:01ABC..."
+func (p *CharacterProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
+	return p.resolve(ctx, resourceID)
+}
+
+// resolve is the shared implementation for both subject and resource resolution.
+func (p *CharacterProvider) resolve(ctx context.Context, entityID string) (map[string]any, error) {
+	// Parse entity type and ID
+	parts := strings.SplitN(entityID, ":", 2)
+	if len(parts) != 2 {
+		return nil, oops.
+			Code("INVALID_ENTITY_ID").
+			With("entity_id", entityID).
+			Errorf("invalid subject ID format: expected 'type:id'")
+	}
+
+	entityType, idStr := parts[0], parts[1]
+
+	// Return nil for non-character types
+	if entityType != "character" {
+		return nil, nil
+	}
+
+	// Parse ULID
+	id, err := ulid.Parse(idStr)
+	if err != nil {
+		return nil, oops.
+			Code("INVALID_CHARACTER_ID").
+			With("entity_id", entityID).
+			With("id_part", idStr).
+			Wrapf(err, "invalid character ID")
+	}
+
+	// Fetch character from repository
+	char, err := p.repo.Get(ctx, id)
+	if err != nil {
+		return nil, oops.
+			Code("CHARACTER_FETCH_FAILED").
+			With("character_id", id.String()).
+			Wrapf(err, "failed to fetch character")
+	}
+
+	// Map character fields to attributes
+	attrs := map[string]any{
+		"id":          char.ID.String(),
+		"player_id":   char.PlayerID.String(),
+		"name":        char.Name,
+		"description": char.Description,
+	}
+
+	// Handle optional location
+	if char.LocationID != nil {
+		attrs["location_id"] = char.LocationID.String()
+		attrs["has_location"] = true
+	} else {
+		attrs["location_id"] = ""
+		attrs["has_location"] = false
+	}
+
+	return attrs, nil
+}
+
+// Schema returns the namespace schema for character attributes.
+func (p *CharacterProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id":           types.AttrTypeString,
+			"player_id":    types.AttrTypeString,
+			"name":         types.AttrTypeString,
+			"description":  types.AttrTypeString,
+			"location_id":  types.AttrTypeString,
+			"has_location": types.AttrTypeBool,
+		},
+	}
+}

--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCharacterRepository is a simple mock for testing.
+type mockCharacterRepository struct {
+	getFunc func(ctx context.Context, id ulid.ULID) (*world.Character, error)
+}
+
+func (m *mockCharacterRepository) Get(ctx context.Context, id ulid.ULID) (*world.Character, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, id)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) Create(_ context.Context, _ *world.Character) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) Update(_ context.Context, _ *world.Character) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) Delete(_ context.Context, _ ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) GetByLocation(_ context.Context, _ ulid.ULID, _ world.ListOptions) ([]*world.Character, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) UpdateLocation(_ context.Context, _ ulid.ULID, _ *ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockCharacterRepository) IsOwnedByPlayer(_ context.Context, _, _ ulid.ULID) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func TestCharacterProvider_Namespace(t *testing.T) {
+	repo := &mockCharacterRepository{}
+	provider := NewCharacterProvider(repo)
+
+	assert.Equal(t, "character", provider.Namespace())
+}
+
+func TestCharacterProvider_Schema(t *testing.T) {
+	repo := &mockCharacterRepository{}
+	provider := NewCharacterProvider(repo)
+
+	schema := provider.Schema()
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Attributes)
+
+	// Check expected attributes
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["id"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["player_id"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["name"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["description"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["location_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_location"])
+}
+
+func TestCharacterProvider_ResolveSubject(t *testing.T) {
+	charID := ulid.Make()
+	playerID := ulid.Make()
+	locationID := ulid.Make()
+	createdAt := time.Now().UTC()
+
+	tests := []struct {
+		name           string
+		subjectID      string
+		setupMock      func(*mockCharacterRepository)
+		expectAttrs    map[string]any
+		expectNil      bool
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name:      "valid character ID",
+			subjectID: "character:" + charID.String(),
+			setupMock: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Character, error) {
+					assert.Equal(t, charID, id)
+					return &world.Character{
+						ID:          charID,
+						PlayerID:    playerID,
+						Name:        "TestChar",
+						Description: "A test character",
+						LocationID:  &locationID,
+						CreatedAt:   createdAt,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":           charID.String(),
+				"player_id":    playerID.String(),
+				"name":         "TestChar",
+				"description":  "A test character",
+				"location_id":  locationID.String(),
+				"has_location": true,
+			},
+		},
+		{
+			name:      "character without location",
+			subjectID: "character:" + charID.String(),
+			setupMock: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return &world.Character{
+						ID:          charID,
+						PlayerID:    playerID,
+						Name:        "NoLocChar",
+						Description: "",
+						LocationID:  nil,
+						CreatedAt:   createdAt,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":           charID.String(),
+				"player_id":    playerID.String(),
+				"name":         "NoLocChar",
+				"description":  "",
+				"location_id":  "",
+				"has_location": false,
+			},
+		},
+		{
+			name:        "wrong entity type (location)",
+			subjectID:   "location:" + ulid.Make().String(),
+			setupMock:   func(_ *mockCharacterRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:        "wrong entity type (object)",
+			subjectID:   "object:" + ulid.Make().String(),
+			setupMock:   func(_ *mockCharacterRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:           "invalid ULID format",
+			subjectID:      "character:not-a-ulid",
+			setupMock:      func(_ *mockCharacterRepository) {},
+			expectError:    true,
+			errorSubstring: "invalid character ID",
+		},
+		{
+			name:           "missing colon separator",
+			subjectID:      "character" + charID.String(),
+			setupMock:      func(_ *mockCharacterRepository) {},
+			expectError:    true,
+			errorSubstring: "invalid subject ID format",
+		},
+		{
+			name:      "repository error",
+			subjectID: "character:" + charID.String(),
+			setupMock: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return nil, errors.New("database connection failed")
+				}
+			},
+			expectError:    true,
+			errorSubstring: "database connection failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockCharacterRepository{}
+			tt.setupMock(repo)
+			provider := NewCharacterProvider(repo)
+
+			attrs, err := provider.ResolveSubject(context.Background(), tt.subjectID)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, attrs)
+				return
+			}
+
+			require.NotNil(t, attrs)
+			assert.Equal(t, tt.expectAttrs, attrs)
+		})
+	}
+}
+
+func TestCharacterProvider_ResolveResource(t *testing.T) {
+	charID := ulid.Make()
+	playerID := ulid.Make()
+	locationID := ulid.Make()
+	createdAt := time.Now().UTC()
+
+	tests := []struct {
+		name           string
+		resourceID     string
+		setupMock      func(*mockCharacterRepository)
+		expectAttrs    map[string]any
+		expectNil      bool
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name:       "valid character resource",
+			resourceID: "character:" + charID.String(),
+			setupMock: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return &world.Character{
+						ID:          charID,
+						PlayerID:    playerID,
+						Name:        "ResourceChar",
+						Description: "Character as resource",
+						LocationID:  &locationID,
+						CreatedAt:   createdAt,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":           charID.String(),
+				"player_id":    playerID.String(),
+				"name":         "ResourceChar",
+				"description":  "Character as resource",
+				"location_id":  locationID.String(),
+				"has_location": true,
+			},
+		},
+		{
+			name:        "wrong entity type",
+			resourceID:  "location:" + ulid.Make().String(),
+			setupMock:   func(_ *mockCharacterRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:       "repository error",
+			resourceID: "character:" + charID.String(),
+			setupMock: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return nil, errors.New("repo error")
+				}
+			},
+			expectError:    true,
+			errorSubstring: "repo error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockCharacterRepository{}
+			tt.setupMock(repo)
+			provider := NewCharacterProvider(repo)
+
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, attrs)
+				return
+			}
+
+			require.NotNil(t, attrs)
+			assert.Equal(t, tt.expectAttrs, attrs)
+		})
+	}
+}

--- a/internal/access/policy/attribute/command.go
+++ b/internal/access/policy/attribute/command.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// CommandProvider resolves attributes for command resources.
+// Commands use the format "command:<name>" (e.g., "command:say", "command:@dig").
+type CommandProvider struct{}
+
+// NewCommandProvider creates a new command attribute provider.
+func NewCommandProvider() *CommandProvider {
+	return &CommandProvider{}
+}
+
+// Namespace returns "command".
+func (p *CommandProvider) Namespace() string {
+	return "command"
+}
+
+// ResolveSubject returns nil — commands are not subjects.
+func (p *CommandProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves command attributes for a resource.
+func (p *CommandProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	id, ok := parseEntityID(resourceID, "command")
+	if !ok {
+		return nil, nil
+	}
+
+	return map[string]any{
+		"type": "command",
+		"name": id,
+	}, nil
+}
+
+// Schema returns the namespace schema for command attributes.
+func (p *CommandProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"name": types.AttrTypeString,
+		},
+	}
+}

--- a/internal/access/policy/attribute/command_test.go
+++ b/internal/access/policy/attribute/command_test.go
@@ -41,11 +41,11 @@ func TestCommandProvider_ResolveResource(t *testing.T) {
 			},
 		},
 		{
-			name:       "command with multi-part name",
-			resourceID: "command:@dig",
+			name:       "command with multi-word name",
+			resourceID: "command:dig",
 			expected: map[string]any{
 				"type": "command",
-				"name": "@dig",
+				"name": "dig",
 			},
 		},
 		{

--- a/internal/access/policy/attribute/command_test.go
+++ b/internal/access/policy/attribute/command_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+func TestCommandProvider_Namespace(t *testing.T) {
+	provider := NewCommandProvider()
+	assert.Equal(t, "command", provider.Namespace())
+}
+
+func TestCommandProvider_ResolveSubject(t *testing.T) {
+	provider := NewCommandProvider()
+	attrs, err := provider.ResolveSubject(context.Background(), "command:say")
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+}
+
+func TestCommandProvider_ResolveResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		expected   map[string]any
+		wantNil    bool
+	}{
+		{
+			name:       "command resource type",
+			resourceID: "command:say",
+			expected: map[string]any{
+				"type": "command",
+				"name": "say",
+			},
+		},
+		{
+			name:       "command with multi-part name",
+			resourceID: "command:@dig",
+			expected: map[string]any{
+				"type": "command",
+				"name": "@dig",
+			},
+		},
+		{
+			name:       "non-command resource type",
+			resourceID: "stream:location:01XYZ",
+			wantNil:    true,
+		},
+		{
+			name:       "object resource type",
+			resourceID: "object:01ABC",
+			wantNil:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewCommandProvider()
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, attrs)
+			} else {
+				assert.Equal(t, tt.expected, attrs)
+			}
+		})
+	}
+}
+
+func TestCommandProvider_Schema(t *testing.T) {
+	provider := NewCommandProvider()
+	schema := provider.Schema()
+
+	expected := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"name": types.AttrTypeString,
+		},
+	}
+
+	assert.Equal(t, expected, schema)
+}

--- a/internal/access/policy/attribute/environment.go
+++ b/internal/access/policy/attribute/environment.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// environmentProvider provides environment-level attributes for policy evaluation.
+type environmentProvider struct {
+	clock func() time.Time
+}
+
+// NewEnvironmentProvider creates a new environment attribute provider.
+// If clock is nil, time.Now is used.
+func NewEnvironmentProvider(clock func() time.Time) EnvironmentProvider {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &environmentProvider{clock: clock}
+}
+
+// Namespace returns the namespace for environment attributes.
+func (p *environmentProvider) Namespace() string {
+	return "env"
+}
+
+// Resolve returns environment attributes for the current context.
+func (p *environmentProvider) Resolve(_ context.Context) (map[string]any, error) {
+	now := p.clock()
+
+	return map[string]any{
+		"time":        now.Format(time.RFC3339),
+		"hour":        float64(now.Hour()),
+		"minute":      float64(now.Minute()),
+		"day_of_week": strings.ToLower(now.Weekday().String()),
+		"maintenance": false,
+	}, nil
+}
+
+// Schema returns the schema for environment attributes.
+func (p *environmentProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"time":        types.AttrTypeString,
+			"hour":        types.AttrTypeFloat,
+			"minute":      types.AttrTypeFloat,
+			"day_of_week": types.AttrTypeString,
+			"maintenance": types.AttrTypeBool,
+		},
+	}
+}

--- a/internal/access/policy/attribute/environment_test.go
+++ b/internal/access/policy/attribute/environment_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+func TestEnvironmentProvider_Namespace(t *testing.T) {
+	provider := NewEnvironmentProvider(nil)
+	assert.Equal(t, "env", provider.Namespace())
+}
+
+func TestEnvironmentProvider_Resolve(t *testing.T) {
+	fixedTime := time.Date(2026, 2, 12, 14, 30, 0, 0, time.UTC) // Thursday 14:30
+
+	tests := []struct {
+		name     string
+		clock    func() time.Time
+		expected map[string]any
+	}{
+		{
+			name:  "fixed time returns expected attributes",
+			clock: func() time.Time { return fixedTime },
+			expected: map[string]any{
+				"time":        "2026-02-12T14:30:00Z",
+				"hour":        float64(14),
+				"minute":      float64(30),
+				"day_of_week": "thursday",
+				"maintenance": false,
+			},
+		},
+		{
+			name:  "different time different values",
+			clock: func() time.Time { return time.Date(2026, 1, 5, 9, 15, 0, 0, time.UTC) }, // Monday 9:15
+			expected: map[string]any{
+				"time":        "2026-01-05T09:15:00Z",
+				"hour":        float64(9),
+				"minute":      float64(15),
+				"day_of_week": "monday",
+				"maintenance": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewEnvironmentProvider(tt.clock)
+			attrs, err := provider.Resolve(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, attrs)
+		})
+	}
+}
+
+func TestEnvironmentProvider_Schema(t *testing.T) {
+	provider := NewEnvironmentProvider(nil)
+	schema := provider.Schema()
+
+	expected := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"time":        types.AttrTypeString,
+			"hour":        types.AttrTypeFloat,
+			"minute":      types.AttrTypeFloat,
+			"day_of_week": types.AttrTypeString,
+			"maintenance": types.AttrTypeBool,
+		},
+	}
+
+	assert.Equal(t, expected, schema)
+}
+
+func TestEnvironmentProvider_DefaultClock(t *testing.T) {
+	provider := NewEnvironmentProvider(nil)
+	attrs, err := provider.Resolve(context.Background())
+	require.NoError(t, err)
+
+	// Should have all expected keys
+	assert.Contains(t, attrs, "time")
+	assert.Contains(t, attrs, "hour")
+	assert.Contains(t, attrs, "minute")
+	assert.Contains(t, attrs, "day_of_week")
+	assert.Contains(t, attrs, "maintenance")
+
+	// Validate types
+	assert.IsType(t, "", attrs["time"])
+	assert.IsType(t, float64(0), attrs["hour"])
+	assert.IsType(t, float64(0), attrs["minute"])
+	assert.IsType(t, "", attrs["day_of_week"])
+	assert.IsType(t, false, attrs["maintenance"])
+}

--- a/internal/access/policy/attribute/exit.go
+++ b/internal/access/policy/attribute/exit.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// ExitProvider resolves attributes for exit resources.
+// This is a stub that returns only type and ID.
+type ExitProvider struct{}
+
+// NewExitProvider creates a new exit attribute provider.
+func NewExitProvider() *ExitProvider {
+	return &ExitProvider{}
+}
+
+// Namespace returns "exit".
+func (p *ExitProvider) Namespace() string {
+	return "exit"
+}
+
+// ResolveSubject returns nil — exits are not subjects.
+func (p *ExitProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves exit attributes for a resource.
+func (p *ExitProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	id, ok := parseEntityID(resourceID, "exit")
+	if !ok {
+		return nil, nil
+	}
+
+	return map[string]any{
+		"type": "exit",
+		"id":   id,
+	}, nil
+}
+
+// Schema returns the namespace schema for exit attributes.
+func (p *ExitProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"id":   types.AttrTypeString,
+		},
+	}
+}

--- a/internal/access/policy/attribute/exit_test.go
+++ b/internal/access/policy/attribute/exit_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+func TestExitProvider_Namespace(t *testing.T) {
+	provider := NewExitProvider()
+	assert.Equal(t, "exit", provider.Namespace())
+}
+
+func TestExitProvider_ResolveSubject(t *testing.T) {
+	provider := NewExitProvider()
+	attrs, err := provider.ResolveSubject(context.Background(), "exit:01XYZ")
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+}
+
+func TestExitProvider_ResolveResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		expected   map[string]any
+		wantNil    bool
+	}{
+		{
+			name:       "exit resource type",
+			resourceID: "exit:01XYZ",
+			expected: map[string]any{
+				"type": "exit",
+				"id":   "01XYZ",
+			},
+		},
+		{
+			name:       "exit with different ID",
+			resourceID: "exit:01ABC",
+			expected: map[string]any{
+				"type": "exit",
+				"id":   "01ABC",
+			},
+		},
+		{
+			name:       "non-exit resource type",
+			resourceID: "command:say",
+			wantNil:    true,
+		},
+		{
+			name:       "object resource type",
+			resourceID: "object:01ABC",
+			wantNil:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewExitProvider()
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, attrs)
+			} else {
+				assert.Equal(t, tt.expected, attrs)
+			}
+		})
+	}
+}
+
+func TestExitProvider_Schema(t *testing.T) {
+	provider := NewExitProvider()
+	schema := provider.Schema()
+
+	expected := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"id":   types.AttrTypeString,
+		},
+	}
+
+	assert.Equal(t, expected, schema)
+}

--- a/internal/access/policy/attribute/helpers.go
+++ b/internal/access/policy/attribute/helpers.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import "strings"
+
+// parseEntityID extracts the entity ID from a resource ID with the expected type prefix.
+// Returns the ID and true if the resource ID matches the expected type, otherwise empty string and false.
+func parseEntityID(resourceID, expectedType string) (string, bool) {
+	prefix := expectedType + ":"
+	if !strings.HasPrefix(resourceID, prefix) {
+		return "", false
+	}
+	return resourceID[len(prefix):], true
+}

--- a/internal/access/policy/attribute/location.go
+++ b/internal/access/policy/attribute/location.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+)
+
+// LocationProvider resolves attributes for location entities.
+type LocationProvider struct {
+	repo world.LocationRepository
+}
+
+// NewLocationProvider creates a new location attribute provider.
+func NewLocationProvider(repo world.LocationRepository) *LocationProvider {
+	return &LocationProvider{repo: repo}
+}
+
+// Namespace returns "location".
+func (p *LocationProvider) Namespace() string {
+	return "location"
+}
+
+// ResolveSubject returns nil — locations are not subjects.
+func (p *LocationProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves location attributes for a resource.
+func (p *LocationProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
+	parts := strings.SplitN(resourceID, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid resource ID format: expected 'type:id'")
+	}
+
+	entityType, idStr := parts[0], parts[1]
+	if entityType != "location" {
+		return nil, nil
+	}
+
+	id, err := ulid.Parse(idStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid location ID: %w", err)
+	}
+
+	loc, err := p.repo.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("fetch location %s: %w", id, err)
+	}
+
+	attrs := map[string]any{
+		"id":            loc.ID.String(),
+		"type":          loc.Type.String(),
+		"name":          loc.Name,
+		"description":   loc.Description,
+		"replay_policy": loc.ReplayPolicy,
+		"archived":      loc.ArchivedAt != nil,
+	}
+
+	if loc.OwnerID != nil {
+		attrs["owner_id"] = loc.OwnerID.String()
+		attrs["has_owner"] = true
+	} else {
+		attrs["owner_id"] = ""
+		attrs["has_owner"] = false
+	}
+
+	if loc.ShadowsID != nil {
+		attrs["shadows_id"] = loc.ShadowsID.String()
+		attrs["is_shadow"] = true
+	} else {
+		attrs["shadows_id"] = ""
+		attrs["is_shadow"] = false
+	}
+
+	return attrs, nil
+}
+
+// Schema returns the namespace schema for location attributes.
+func (p *LocationProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id":            types.AttrTypeString,
+			"type":          types.AttrTypeString,
+			"name":          types.AttrTypeString,
+			"description":   types.AttrTypeString,
+			"owner_id":      types.AttrTypeString,
+			"has_owner":     types.AttrTypeBool,
+			"shadows_id":    types.AttrTypeString,
+			"is_shadow":     types.AttrTypeBool,
+			"replay_policy": types.AttrTypeString,
+			"archived":      types.AttrTypeBool,
+		},
+	}
+}

--- a/internal/access/policy/attribute/location_test.go
+++ b/internal/access/policy/attribute/location_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLocationRepository is a simple mock for testing.
+type mockLocationRepository struct {
+	getFunc func(ctx context.Context, id ulid.ULID) (*world.Location, error)
+}
+
+func (m *mockLocationRepository) Get(ctx context.Context, id ulid.ULID) (*world.Location, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, id)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) Create(_ context.Context, _ *world.Location) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) Update(_ context.Context, _ *world.Location) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) Delete(_ context.Context, _ ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) ListByType(_ context.Context, _ world.LocationType) ([]*world.Location, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) GetShadowedBy(_ context.Context, _ ulid.ULID) ([]*world.Location, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockLocationRepository) FindByName(_ context.Context, _ string) (*world.Location, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestLocationProvider_Namespace(t *testing.T) {
+	repo := &mockLocationRepository{}
+	provider := NewLocationProvider(repo)
+
+	assert.Equal(t, "location", provider.Namespace())
+}
+
+func TestLocationProvider_Schema(t *testing.T) {
+	repo := &mockLocationRepository{}
+	provider := NewLocationProvider(repo)
+
+	schema := provider.Schema()
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Attributes)
+
+	// Check expected attributes
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["id"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["type"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["name"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["description"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["owner_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_owner"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["shadows_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["is_shadow"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["replay_policy"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["archived"])
+}
+
+func TestLocationProvider_ResolveSubject(t *testing.T) {
+	// Locations are not subjects, should always return nil, nil
+	repo := &mockLocationRepository{}
+	provider := NewLocationProvider(repo)
+
+	attrs, err := provider.ResolveSubject(context.Background(), "location:"+ulid.Make().String())
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+
+	attrs, err = provider.ResolveSubject(context.Background(), "character:"+ulid.Make().String())
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+}
+
+func TestLocationProvider_ResolveResource(t *testing.T) {
+	locID := ulid.Make()
+	ownerID := ulid.Make()
+	shadowsID := ulid.Make()
+	createdAt := time.Now().UTC()
+	archivedAt := time.Now().UTC()
+
+	tests := []struct {
+		name           string
+		resourceID     string
+		setupMock      func(*mockLocationRepository)
+		expectAttrs    map[string]any
+		expectNil      bool
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name:       "persistent location with owner",
+			resourceID: "location:" + locID.String(),
+			setupMock: func(m *mockLocationRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Location, error) {
+					assert.Equal(t, locID, id)
+					return &world.Location{
+						ID:           locID,
+						Type:         world.LocationTypePersistent,
+						Name:         "Test Room",
+						Description:  "A test location",
+						OwnerID:      &ownerID,
+						ReplayPolicy: "last:0",
+						CreatedAt:    createdAt,
+						ShadowsID:    nil,
+						ArchivedAt:   nil,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":            locID.String(),
+				"type":          "persistent",
+				"name":          "Test Room",
+				"description":   "A test location",
+				"owner_id":      ownerID.String(),
+				"has_owner":     true,
+				"shadows_id":    "",
+				"is_shadow":     false,
+				"replay_policy": "last:0",
+				"archived":      false,
+			},
+		},
+		{
+			name:       "scene without owner",
+			resourceID: "location:" + locID.String(),
+			setupMock: func(m *mockLocationRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Location, error) {
+					return &world.Location{
+						ID:           locID,
+						Type:         world.LocationTypeScene,
+						Name:         "RP Scene",
+						Description:  "",
+						OwnerID:      nil,
+						ReplayPolicy: "last:-1",
+						CreatedAt:    createdAt,
+						ShadowsID:    nil,
+						ArchivedAt:   nil,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":            locID.String(),
+				"type":          "scene",
+				"name":          "RP Scene",
+				"description":   "",
+				"owner_id":      "",
+				"has_owner":     false,
+				"shadows_id":    "",
+				"is_shadow":     false,
+				"replay_policy": "last:-1",
+				"archived":      false,
+			},
+		},
+		{
+			name:       "shadow location (archived)",
+			resourceID: "location:" + locID.String(),
+			setupMock: func(m *mockLocationRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Location, error) {
+					return &world.Location{
+						ID:           locID,
+						Type:         world.LocationTypeScene,
+						Name:         "Shadow",
+						Description:  "Shadow desc",
+						OwnerID:      &ownerID,
+						ShadowsID:    &shadowsID,
+						ReplayPolicy: "last:100",
+						CreatedAt:    createdAt,
+						ArchivedAt:   &archivedAt,
+					}, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":            locID.String(),
+				"type":          "scene",
+				"name":          "Shadow",
+				"description":   "Shadow desc",
+				"owner_id":      ownerID.String(),
+				"has_owner":     true,
+				"shadows_id":    shadowsID.String(),
+				"is_shadow":     true,
+				"replay_policy": "last:100",
+				"archived":      true,
+			},
+		},
+		{
+			name:        "wrong entity type (character)",
+			resourceID:  "character:" + ulid.Make().String(),
+			setupMock:   func(_ *mockLocationRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:        "wrong entity type (object)",
+			resourceID:  "object:" + ulid.Make().String(),
+			setupMock:   func(_ *mockLocationRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:           "invalid ULID format",
+			resourceID:     "location:not-a-ulid",
+			setupMock:      func(_ *mockLocationRepository) {},
+			expectError:    true,
+			errorSubstring: "invalid location ID",
+		},
+		{
+			name:           "missing colon separator",
+			resourceID:     "location" + locID.String(),
+			setupMock:      func(_ *mockLocationRepository) {},
+			expectError:    true,
+			errorSubstring: "invalid resource ID format",
+		},
+		{
+			name:       "repository error",
+			resourceID: "location:" + locID.String(),
+			setupMock: func(m *mockLocationRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Location, error) {
+					return nil, errors.New("database error")
+				}
+			},
+			expectError:    true,
+			errorSubstring: "database error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockLocationRepository{}
+			tt.setupMock(repo)
+			provider := NewLocationProvider(repo)
+
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				assert.Nil(t, attrs)
+				return
+			}
+
+			require.NotNil(t, attrs)
+			assert.Equal(t, tt.expectAttrs, attrs)
+		})
+	}
+}

--- a/internal/access/policy/attribute/property.go
+++ b/internal/access/policy/attribute/property.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+)
+
+// ParentLocationResolver resolves the parent location for an entity.
+// For objects, this walks the containment chain via recursive CTE.
+type ParentLocationResolver interface {
+	ResolveParentLocation(ctx context.Context, parentType string, parentID ulid.ULID) (*ulid.ULID, error)
+}
+
+// PropertyProvider resolves attributes for property entities.
+type PropertyProvider struct {
+	repo     world.PropertyRepository
+	resolver ParentLocationResolver
+}
+
+// NewPropertyProvider creates a new property attribute provider.
+func NewPropertyProvider(repo world.PropertyRepository, resolver ParentLocationResolver) *PropertyProvider {
+	return &PropertyProvider{
+		repo:     repo,
+		resolver: resolver,
+	}
+}
+
+// Namespace returns "property".
+func (p *PropertyProvider) Namespace() string {
+	return "property"
+}
+
+// ResolveSubject returns nil, nil — properties are not subjects.
+func (p *PropertyProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves property attributes for a resource.
+// Returns nil, nil if the resource is not a property type.
+// Resource ID format: "property:01ABC..."
+func (p *PropertyProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
+	// Parse entity ID using helper from helpers.go
+	idStr, ok := parseEntityID(resourceID, "property")
+	if !ok {
+		// Not a property resource
+		return nil, nil
+	}
+
+	// Parse ULID
+	id, err := ulid.Parse(idStr)
+	if err != nil {
+		return nil, oops.
+			Code("INVALID_PROPERTY_ID").
+			With("entity_id", resourceID).
+			With("id_part", idStr).
+			Wrapf(err, "invalid property ID")
+	}
+
+	// Fetch property from repository
+	prop, err := p.repo.Get(ctx, id)
+	if err != nil {
+		return nil, oops.
+			Code("PROPERTY_FETCH_FAILED").
+			With("property_id", id.String()).
+			Wrapf(err, "failed to fetch property")
+	}
+
+	// Build base attributes
+	attrs := map[string]any{
+		"id":          prop.ID.String(),
+		"parent_type": prop.ParentType,
+		"parent_id":   prop.ParentID.String(),
+		"name":        prop.Name,
+		"visibility":  prop.Visibility,
+	}
+
+	// Handle optional Value
+	if prop.Value != nil {
+		attrs["value"] = *prop.Value
+		attrs["has_value"] = true
+	} else {
+		attrs["value"] = ""
+		attrs["has_value"] = false
+	}
+
+	// Handle optional Owner
+	if prop.Owner != nil {
+		attrs["owner"] = *prop.Owner
+		attrs["has_owner"] = true
+	} else {
+		attrs["owner"] = ""
+		attrs["has_owner"] = false
+	}
+
+	// Resolve parent_location
+	p.resolveParentLocation(ctx, prop, attrs)
+
+	return attrs, nil
+}
+
+// resolveParentLocation resolves the parent_location attribute.
+// For location parents, parent_location = parent_id.
+// For character/object parents, uses the ParentLocationResolver.
+// Sets parent_location="" and has_parent_location=false on timeout or error.
+func (p *PropertyProvider) resolveParentLocation(ctx context.Context, prop *world.EntityProperty, attrs map[string]any) {
+	// If parent is a location, parent_location = parent_id
+	if prop.ParentType == "location" {
+		attrs["parent_location"] = prop.ParentID.String()
+		attrs["has_parent_location"] = true
+		return
+	}
+
+	// For character/object parents, use resolver with timeout
+	resolveCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	locationID, err := p.resolver.ResolveParentLocation(resolveCtx, prop.ParentType, prop.ParentID)
+	if err != nil {
+		// Log warning and set parent_location as unresolvable
+		slog.WarnContext(ctx, "failed to resolve parent location",
+			"property_id", prop.ID.String(),
+			"parent_type", prop.ParentType,
+			"parent_id", prop.ParentID.String(),
+			"error", err)
+		attrs["parent_location"] = ""
+		attrs["has_parent_location"] = false
+		return
+	}
+
+	if locationID == nil {
+		// Unresolvable (e.g., character not in a location)
+		attrs["parent_location"] = ""
+		attrs["has_parent_location"] = false
+		return
+	}
+
+	// Successfully resolved
+	attrs["parent_location"] = locationID.String()
+	attrs["has_parent_location"] = true
+}
+
+// Schema returns the namespace schema for property attributes.
+func (p *PropertyProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id":                  types.AttrTypeString,
+			"parent_type":         types.AttrTypeString,
+			"parent_id":           types.AttrTypeString,
+			"name":                types.AttrTypeString,
+			"value":               types.AttrTypeString,
+			"has_value":           types.AttrTypeBool,
+			"owner":               types.AttrTypeString,
+			"has_owner":           types.AttrTypeBool,
+			"visibility":          types.AttrTypeString,
+			"parent_location":     types.AttrTypeString,
+			"has_parent_location": types.AttrTypeBool,
+		},
+	}
+}

--- a/internal/access/policy/attribute/property_test.go
+++ b/internal/access/policy/attribute/property_test.go
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/holomush/holomush/pkg/errutil"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPropertyRepository is a test double for PropertyRepository.
+type mockPropertyRepository struct {
+	getFunc func(ctx context.Context, id ulid.ULID) (*world.EntityProperty, error)
+}
+
+func (m *mockPropertyRepository) Create(_ context.Context, _ *world.EntityProperty) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockPropertyRepository) Get(ctx context.Context, id ulid.ULID) (*world.EntityProperty, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, id)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPropertyRepository) ListByParent(_ context.Context, _ string, _ ulid.ULID) ([]*world.EntityProperty, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPropertyRepository) Update(_ context.Context, _ *world.EntityProperty) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockPropertyRepository) Delete(_ context.Context, _ ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockPropertyRepository) DeleteByParent(_ context.Context, _ string, _ ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+// mockParentLocationResolver is a test double for ParentLocationResolver.
+type mockParentLocationResolver struct {
+	resolveFunc func(ctx context.Context, parentType string, parentID ulid.ULID) (*ulid.ULID, error)
+}
+
+func (m *mockParentLocationResolver) ResolveParentLocation(ctx context.Context, parentType string, parentID ulid.ULID) (*ulid.ULID, error) {
+	if m.resolveFunc != nil {
+		return m.resolveFunc(ctx, parentType, parentID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func TestPropertyProvider_Namespace(t *testing.T) {
+	provider := NewPropertyProvider(nil, nil)
+	assert.Equal(t, "property", provider.Namespace())
+}
+
+func TestPropertyProvider_ResolveSubject(t *testing.T) {
+	provider := NewPropertyProvider(nil, nil)
+	attrs, err := provider.ResolveSubject(context.Background(), "property:01ABC")
+	require.NoError(t, err)
+	assert.Nil(t, attrs, "properties are not subjects")
+}
+
+func TestPropertyProvider_ResolveResource(t *testing.T) {
+	propID := ulid.MustNew(ulid.Now(), nil)
+	parentID := ulid.MustNew(ulid.Now(), nil)
+	locationID := ulid.MustNew(ulid.Now(), nil)
+	value := "test-value"
+	owner := "owner:01ABC"
+
+	tests := []struct {
+		name               string
+		resourceID         string
+		property           *world.EntityProperty
+		repoErr            error
+		resolverResult     *ulid.ULID
+		resolverErr        error
+		expectedAttrs      map[string]any
+		expectedErr        string
+		expectResolverCall bool
+	}{
+		{
+			name:       "full property with location parent",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "location",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "location",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     parentID.String(),
+				"has_parent_location": true,
+			},
+			expectResolverCall: false, // location parent doesn't need resolver
+		},
+		{
+			name:       "property on character parent",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "character",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			resolverResult: &locationID,
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "character",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     locationID.String(),
+				"has_parent_location": true,
+			},
+			expectResolverCall: true,
+		},
+		{
+			name:       "property on object parent",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "object",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			resolverResult: &locationID,
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "object",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     locationID.String(),
+				"has_parent_location": true,
+			},
+			expectResolverCall: true,
+		},
+		{
+			name:       "property without value",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "location",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      nil,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "location",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "",
+				"has_value":           false,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     parentID.String(),
+				"has_parent_location": true,
+			},
+			expectResolverCall: false,
+		},
+		{
+			name:       "property without owner",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "location",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      nil,
+				Visibility: "public",
+			},
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "location",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "",
+				"has_owner":           false,
+				"visibility":          "public",
+				"parent_location":     parentID.String(),
+				"has_parent_location": true,
+			},
+			expectResolverCall: false,
+		},
+		{
+			name:       "resolver returns nil (unresolvable)",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "character",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			resolverResult: nil,
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "character",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     "",
+				"has_parent_location": false,
+			},
+			expectResolverCall: true,
+		},
+		{
+			name:       "resolver returns error",
+			resourceID: "property:" + propID.String(),
+			property: &world.EntityProperty{
+				ID:         propID,
+				ParentType: "character",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			},
+			resolverErr: errors.New("resolver error"),
+			expectedAttrs: map[string]any{
+				"id":                  propID.String(),
+				"parent_type":         "character",
+				"parent_id":           parentID.String(),
+				"name":                "test-prop",
+				"value":               "test-value",
+				"has_value":           true,
+				"owner":               "owner:01ABC",
+				"has_owner":           true,
+				"visibility":          "public",
+				"parent_location":     "",
+				"has_parent_location": false,
+			},
+			expectResolverCall: true,
+		},
+		{
+			name:          "wrong entity type - character",
+			resourceID:    "character:" + propID.String(),
+			expectedAttrs: nil,
+		},
+		{
+			name:          "wrong entity type - location",
+			resourceID:    "location:" + propID.String(),
+			expectedAttrs: nil,
+		},
+		{
+			name:        "invalid ULID",
+			resourceID:  "property:invalid",
+			expectedErr: "INVALID_PROPERTY_ID",
+		},
+		{
+			name:          "missing colon separator",
+			resourceID:    "propertyinvalid",
+			expectedAttrs: nil, // parseEntityID returns nil, nil for non-matching types
+		},
+		{
+			name:        "repository error",
+			resourceID:  "property:" + propID.String(),
+			repoErr:     errors.New("db error"),
+			expectedErr: "PROPERTY_FETCH_FAILED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockPropertyRepository{
+				getFunc: func(_ context.Context, _ ulid.ULID) (*world.EntityProperty, error) {
+					if tt.repoErr != nil {
+						return nil, tt.repoErr
+					}
+					return tt.property, nil
+				},
+			}
+
+			var resolverCalled bool
+			resolver := &mockParentLocationResolver{
+				resolveFunc: func(_ context.Context, _ string, _ ulid.ULID) (*ulid.ULID, error) {
+					resolverCalled = true
+					if tt.resolverErr != nil {
+						return nil, tt.resolverErr
+					}
+					return tt.resolverResult, nil
+				},
+			}
+
+			provider := NewPropertyProvider(repo, resolver)
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				errutil.AssertErrorCode(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expectedAttrs == nil {
+				assert.Nil(t, attrs)
+			} else {
+				assert.Equal(t, tt.expectedAttrs, attrs)
+			}
+
+			assert.Equal(t, tt.expectResolverCall, resolverCalled, "resolver call mismatch")
+		})
+	}
+}
+
+func TestPropertyProvider_ResolveResource_Timeout(t *testing.T) {
+	propID := ulid.MustNew(ulid.Now(), nil)
+	parentID := ulid.MustNew(ulid.Now(), nil)
+	value := "test-value"
+	owner := "owner:01ABC"
+
+	repo := &mockPropertyRepository{
+		getFunc: func(_ context.Context, _ ulid.ULID) (*world.EntityProperty, error) {
+			return &world.EntityProperty{
+				ID:         propID,
+				ParentType: "character",
+				ParentID:   parentID,
+				Name:       "test-prop",
+				Value:      &value,
+				Owner:      &owner,
+				Visibility: "public",
+			}, nil
+		},
+	}
+
+	resolver := &mockParentLocationResolver{
+		resolveFunc: func(ctx context.Context, _ string, _ ulid.ULID) (*ulid.ULID, error) {
+			// Simulate slow resolution
+			select {
+			case <-time.After(200 * time.Millisecond):
+				locationID := ulid.MustNew(ulid.Now(), nil)
+				return &locationID, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	provider := NewPropertyProvider(repo, resolver)
+	attrs, err := provider.ResolveResource(context.Background(), "property:"+propID.String())
+
+	require.NoError(t, err)
+	assert.Equal(t, "", attrs["parent_location"], "parent_location should be empty on timeout")
+	assert.Equal(t, false, attrs["has_parent_location"], "has_parent_location should be false on timeout")
+}
+
+func TestPropertyProvider_Schema(t *testing.T) {
+	provider := NewPropertyProvider(nil, nil)
+	schema := provider.Schema()
+
+	require.NotNil(t, schema)
+	assert.Equal(t, map[string]types.AttrType{
+		"id":                  types.AttrTypeString,
+		"parent_type":         types.AttrTypeString,
+		"parent_id":           types.AttrTypeString,
+		"name":                types.AttrTypeString,
+		"value":               types.AttrTypeString,
+		"has_value":           types.AttrTypeBool,
+		"owner":               types.AttrTypeString,
+		"has_owner":           types.AttrTypeBool,
+		"visibility":          types.AttrTypeString,
+		"parent_location":     types.AttrTypeString,
+		"has_parent_location": types.AttrTypeBool,
+	}, schema.Attributes)
+}

--- a/internal/access/policy/attribute/provider.go
+++ b/internal/access/policy/attribute/provider.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// AttributeProvider resolves attributes for a specific namespace.
+// Providers return attributes for subjects and resources.
+//
+// IMPORTANT: Providers MUST return all numeric attributes as float64.
+// This ensures consistent type handling in policy evaluation.
+//
+// Example:
+//
+//	type CharacterProvider struct {}
+//
+//	func (p *CharacterProvider) Namespace() string {
+//		return "character"
+//	}
+//
+//	func (p *CharacterProvider) ResolveSubject(ctx context.Context, subjectID string) (map[string]any, error) {
+//		// Query database for character attributes
+//		char, err := p.repo.GetCharacter(ctx, subjectID)
+//		if err != nil {
+//			return nil, err
+//		}
+//		return map[string]any{
+//			"name":  char.Name,
+//			"level": float64(char.Level),  // MUST be float64, not int
+//			"role":  char.Role,
+//		}, nil
+//	}
+//
+//	func (p *CharacterProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
+//		// Character provider doesn't resolve resources
+//		return nil, nil
+//	}
+//
+//	func (p *CharacterProvider) Schema() *types.NamespaceSchema {
+//		return &types.NamespaceSchema{
+//			Attributes: map[string]types.AttrType{
+//				"name":  types.AttrTypeString,
+//				"level": types.AttrTypeFloat,
+//				"role":  types.AttrTypeString,
+//			},
+//		}
+//	}
+//
+//nolint:revive // AttributeProvider is the canonical name from the ABAC spec
+type AttributeProvider interface {
+	// Namespace returns the attribute namespace this provider handles.
+	// Example: "character", "location", "reputation"
+	Namespace() string
+
+	// ResolveSubject resolves attributes for a subject (principal).
+	// Returns nil, nil if this provider doesn't handle the given subject type.
+	// MUST return all numeric attributes as float64.
+	ResolveSubject(ctx context.Context, subjectID string) (map[string]any, error)
+
+	// ResolveResource resolves attributes for a resource.
+	// Returns nil, nil if this provider doesn't handle the given resource type.
+	// MUST return all numeric attributes as float64.
+	ResolveResource(ctx context.Context, resourceID string) (map[string]any, error)
+
+	// Schema returns the namespace schema defining the attributes
+	// this provider contributes.
+	Schema() *types.NamespaceSchema
+}
+
+// EnvironmentProvider resolves environment-level attributes (no entity context).
+// Environment attributes are global state that doesn't depend on specific
+// subjects or resources.
+//
+// Example:
+//
+//	type EnvProvider struct {}
+//
+//	func (p *EnvProvider) Namespace() string {
+//		return "env"
+//	}
+//
+//	func (p *EnvProvider) Resolve(ctx context.Context) (map[string]any, error) {
+//		now := time.Now().UTC()
+//		return map[string]any{
+//			"time":        now.Format(time.RFC3339),
+//			"hour":        float64(now.Hour()),  // MUST be float64
+//			"minute":      float64(now.Minute()),
+//			"day_of_week": strings.ToLower(now.Weekday().String()),
+//			"maintenance": false,
+//		}, nil
+//	}
+//
+//	func (p *EnvProvider) Schema() *types.NamespaceSchema {
+//		return &types.NamespaceSchema{
+//			Attributes: map[string]types.AttrType{
+//				"time":        types.AttrTypeString,
+//				"hour":        types.AttrTypeFloat,
+//				"minute":      types.AttrTypeFloat,
+//				"day_of_week": types.AttrTypeString,
+//				"maintenance": types.AttrTypeBool,
+//			},
+//		}
+//	}
+type EnvironmentProvider interface {
+	// Namespace returns the attribute namespace this provider handles.
+	// Example: "env", "weather"
+	Namespace() string
+
+	// Resolve resolves environment attributes.
+	// MUST return all numeric attributes as float64.
+	Resolve(ctx context.Context) (map[string]any, error)
+
+	// Schema returns the namespace schema defining the attributes
+	// this provider contributes.
+	Schema() *types.NamespaceSchema
+}

--- a/internal/access/policy/attribute/provider_test.go
+++ b/internal/access/policy/attribute/provider_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock implementation of AttributeProvider for testing
+type mockAttributeProvider struct {
+	namespace     string
+	subjectAttrs  map[string]any
+	resourceAttrs map[string]any
+	subjectErr    error
+	resourceErr   error
+	schema        *types.NamespaceSchema
+}
+
+func (m *mockAttributeProvider) Namespace() string {
+	return m.namespace
+}
+
+func (m *mockAttributeProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	if m.subjectErr != nil {
+		return nil, m.subjectErr
+	}
+	return m.subjectAttrs, nil
+}
+
+func (m *mockAttributeProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	if m.resourceErr != nil {
+		return nil, m.resourceErr
+	}
+	return m.resourceAttrs, nil
+}
+
+func (m *mockAttributeProvider) Schema() *types.NamespaceSchema {
+	return m.schema
+}
+
+// Mock implementation of EnvironmentProvider for testing
+type mockEnvironmentProvider struct {
+	namespace string
+	attrs     map[string]any
+	err       error
+	schema    *types.NamespaceSchema
+}
+
+func (m *mockEnvironmentProvider) Namespace() string {
+	return m.namespace
+}
+
+func (m *mockEnvironmentProvider) Resolve(_ context.Context) (map[string]any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.attrs, nil
+}
+
+func (m *mockEnvironmentProvider) Schema() *types.NamespaceSchema {
+	return m.schema
+}
+
+func TestAttributeProvider_Interface(t *testing.T) {
+	provider := &mockAttributeProvider{
+		namespace: "character",
+		subjectAttrs: map[string]any{
+			"name":  "Alice",
+			"level": float64(5),
+		},
+		resourceAttrs: map[string]any{
+			"type": "location",
+		},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"name":  types.AttrTypeString,
+				"level": types.AttrTypeFloat,
+			},
+		},
+	}
+
+	// Test Namespace method
+	assert.Equal(t, "character", provider.Namespace())
+
+	// Test ResolveSubject method
+	ctx := context.Background()
+	subjectAttrs, err := provider.ResolveSubject(ctx, "01ABC")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", subjectAttrs["name"])
+	assert.Equal(t, float64(5), subjectAttrs["level"])
+
+	// Test ResolveResource method
+	resourceAttrs, err := provider.ResolveResource(ctx, "01XYZ")
+	require.NoError(t, err)
+	assert.Equal(t, "location", resourceAttrs["type"])
+
+	// Test Schema method
+	schema := provider.Schema()
+	require.NotNil(t, schema)
+	assert.Len(t, schema.Attributes, 2)
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["name"])
+	assert.Equal(t, types.AttrTypeFloat, schema.Attributes["level"])
+}
+
+func TestEnvironmentProvider_Interface(t *testing.T) {
+	provider := &mockEnvironmentProvider{
+		namespace: "env",
+		attrs: map[string]any{
+			"time":        "2026-02-05T14:30:00Z",
+			"maintenance": false,
+		},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"time":        types.AttrTypeString,
+				"maintenance": types.AttrTypeBool,
+			},
+		},
+	}
+
+	// Test Namespace method
+	assert.Equal(t, "env", provider.Namespace())
+
+	// Test Resolve method
+	ctx := context.Background()
+	attrs, err := provider.Resolve(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-02-05T14:30:00Z", attrs["time"])
+	assert.Equal(t, false, attrs["maintenance"])
+
+	// Test Schema method
+	schema := provider.Schema()
+	require.NotNil(t, schema)
+	assert.Len(t, schema.Attributes, 2)
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["time"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["maintenance"])
+}
+
+func TestAttributeProvider_NumericTypesAsFloat64(t *testing.T) {
+	// This test verifies that providers return numeric attributes as float64
+	// as per the spec requirement
+	provider := &mockAttributeProvider{
+		namespace: "character",
+		subjectAttrs: map[string]any{
+			"level": float64(10),   // MUST be float64, not int
+			"score": float64(85.5), // already float64
+		},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"level": types.AttrTypeFloat,
+				"score": types.AttrTypeFloat,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	attrs, err := provider.ResolveSubject(ctx, "01ABC")
+	require.NoError(t, err)
+
+	// Verify that numeric values are float64
+	level, ok := attrs["level"].(float64)
+	require.True(t, ok, "level should be float64")
+	assert.Equal(t, float64(10), level)
+
+	score, ok := attrs["score"].(float64)
+	require.True(t, ok, "score should be float64")
+	assert.Equal(t, float64(85.5), score)
+}

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/samber/oops"
+)
+
+// Resolver resolves attributes for access requests
+type Resolver struct {
+	registry           *SchemaRegistry
+	providers          map[string]AttributeProvider
+	envProviders       map[string]EnvironmentProvider
+	providerOrder      []string // Track registration order
+	envProviderOrder   []string
+	logger             *slog.Logger
+}
+
+// NewResolver creates a new attribute resolver
+func NewResolver(registry *SchemaRegistry) *Resolver {
+	return &Resolver{
+		registry:         registry,
+		providers:        make(map[string]AttributeProvider),
+		envProviders:     make(map[string]EnvironmentProvider),
+		providerOrder:    make([]string, 0),
+		envProviderOrder: make([]string, 0),
+		logger:           slog.Default(),
+	}
+}
+
+// RegisterProvider registers an attribute provider
+func (r *Resolver) RegisterProvider(provider AttributeProvider) error {
+	namespace := provider.Namespace()
+	if namespace == "" {
+		return oops.Errorf("provider namespace cannot be empty")
+	}
+
+	if _, exists := r.providers[namespace]; exists {
+		return oops.Errorf("provider for namespace %q already registered", namespace)
+	}
+
+	r.providers[namespace] = provider
+	r.providerOrder = append(r.providerOrder, namespace)
+
+	// Register schema
+	schema := provider.Schema()
+	if schema != nil {
+		if err := r.registry.Register(namespace, schema); err != nil {
+			// If already registered, that's OK
+			if !strings.Contains(err.Error(), "already registered") {
+				return oops.Wrapf(err, "failed to register schema for namespace %q", namespace)
+			}
+		}
+	}
+
+	return nil
+}
+
+// RegisterEnvironmentProvider registers an environment provider
+func (r *Resolver) RegisterEnvironmentProvider(provider EnvironmentProvider) error {
+	namespace := provider.Namespace()
+	if namespace == "" {
+		return oops.Errorf("environment provider namespace cannot be empty")
+	}
+
+	if _, exists := r.envProviders[namespace]; exists {
+		return oops.Errorf("environment provider for namespace %q already registered", namespace)
+	}
+
+	r.envProviders[namespace] = provider
+	r.envProviderOrder = append(r.envProviderOrder, namespace)
+
+	// Register schema
+	schema := provider.Schema()
+	if schema != nil {
+		if err := r.registry.Register(namespace, schema); err != nil {
+			// If already registered, that's OK
+			if !strings.Contains(err.Error(), "already registered") {
+				return oops.Wrapf(err, "failed to register schema for namespace %q", namespace)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Resolve resolves all attributes for an access request
+func (r *Resolver) Resolve(ctx context.Context, req types.AccessRequest) (*types.AttributeBags, error) {
+	// Check re-entrance guard
+	if isInResolution(ctx) {
+		panic("resolver re-entrance detected: resolver cannot be called recursively")
+	}
+
+	// Mark as in resolution and attach cache
+	ctx = markInResolution(ctx)
+	ctx = withCache(ctx)
+
+	bags := &types.AttributeBags{
+		Subject:     make(map[string]any),
+		Resource:    make(map[string]any),
+		Action:      make(map[string]any),
+		Environment: make(map[string]any),
+	}
+
+	// Parse subject and resource IDs
+	subjectType, subjectID := splitEntityID(req.Subject)
+	resourceType, resourceID := splitEntityID(req.Resource)
+
+	// Set action name
+	bags.Action["name"] = req.Action
+
+	// Resolve subject attributes
+	if subjectID != "" {
+		r.resolveEntity(ctx, "subject", subjectType, subjectID, bags.Subject)
+	}
+
+	// Resolve resource attributes
+	if resourceID != "" {
+		r.resolveEntity(ctx, "resource", resourceType, resourceID, bags.Resource)
+	}
+
+	// Resolve environment attributes
+	r.resolveEnvironment(ctx, bags.Environment)
+
+	return bags, nil
+}
+
+// splitEntityID splits an entity ID in the format "type:id" into its components.
+func splitEntityID(entityID string) (entityType, id string) {
+	parts := strings.SplitN(entityID, ":", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// resolveEntity resolves attributes for a single entity (subject or resource)
+func (r *Resolver) resolveEntity(ctx context.Context, resolveType, _, entityID string, bag map[string]any) {
+	cache := getCacheFromContext(ctx)
+
+	// Try each provider in registration order
+	for _, namespace := range r.providerOrder {
+		provider := r.providers[namespace]
+
+		// Build cache key
+		cacheKey := fmt.Sprintf("%s:%s:%s", resolveType, namespace, entityID)
+
+		// Check cache first
+		if cached, found := cache.Get(cacheKey); found {
+			r.mergeAttributes(namespace, cached, bag)
+			continue
+		}
+
+		// Resolve from provider with panic recovery
+		attrs := r.safeResolve(ctx, provider, resolveType, entityID)
+		if attrs != nil {
+			// Cache the result
+			cache.Put(cacheKey, attrs)
+
+			// Merge into bag
+			r.mergeAttributes(namespace, attrs, bag)
+		}
+	}
+}
+
+// resolveEnvironment resolves environment attributes
+func (r *Resolver) resolveEnvironment(ctx context.Context, bag map[string]any) {
+	for _, namespace := range r.envProviderOrder {
+		provider := r.envProviders[namespace]
+
+		// Resolve with panic recovery
+		attrs := r.safeResolveEnvironment(ctx, provider)
+		if attrs != nil {
+			r.mergeAttributes(namespace, attrs, bag)
+		}
+	}
+}
+
+// safeResolve calls a provider with error and panic recovery
+func (r *Resolver) safeResolve(ctx context.Context, provider AttributeProvider, resolveType, entityID string) map[string]any {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			r.logger.Error("provider panicked during resolution",
+				"namespace", provider.Namespace(),
+				"resolve_type", resolveType,
+				"entity_id", entityID,
+				"panic", recovered,
+			)
+		}
+	}()
+
+	var attrs map[string]any
+	var err error
+
+	switch resolveType {
+	case "subject":
+		attrs, err = provider.ResolveSubject(ctx, entityID)
+	case "resource":
+		attrs, err = provider.ResolveResource(ctx, entityID)
+	default:
+		return nil
+	}
+
+	if err != nil {
+		r.logger.Error("provider error during resolution",
+			"namespace", provider.Namespace(),
+			"resolve_type", resolveType,
+			"entity_id", entityID,
+			"error", err,
+		)
+		return nil
+	}
+
+	return attrs
+}
+
+// safeResolveEnvironment calls an environment provider with error and panic recovery
+func (r *Resolver) safeResolveEnvironment(ctx context.Context, provider EnvironmentProvider) map[string]any {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			r.logger.Error("environment provider panicked during resolution",
+				"namespace", provider.Namespace(),
+				"panic", recovered,
+			)
+		}
+	}()
+
+	attrs, err := provider.Resolve(ctx)
+	if err != nil {
+		r.logger.Error("environment provider error during resolution",
+			"namespace", provider.Namespace(),
+			"error", err,
+		)
+		return nil
+	}
+
+	return attrs
+}
+
+// mergeAttributes merges attributes from a provider into a bag with namespace prefix
+func (r *Resolver) mergeAttributes(namespace string, attrs, bag map[string]any) {
+	for key, value := range attrs {
+		// Use namespace.key format
+		bagKey := fmt.Sprintf("%s.%s", namespace, key)
+		bag[bagKey] = value
+	}
+}

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -15,12 +15,12 @@ import (
 
 // Resolver resolves attributes for access requests
 type Resolver struct {
-	registry           *SchemaRegistry
-	providers          map[string]AttributeProvider
-	envProviders       map[string]EnvironmentProvider
-	providerOrder      []string // Track registration order
-	envProviderOrder   []string
-	logger             *slog.Logger
+	registry         *SchemaRegistry
+	providers        map[string]AttributeProvider
+	envProviders     map[string]EnvironmentProvider
+	providerOrder    []string // Track registration order
+	envProviderOrder []string
+	logger           *slog.Logger
 }
 
 // NewResolver creates a new attribute resolver

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Extended mock providers for resolver testing
+// These extend the basic mocks from provider_test.go with additional capabilities
+
+type resolverMockAttributeProvider struct {
+	namespace       string
+	subjectData     map[string]map[string]any
+	resourceData    map[string]map[string]any
+	subjectError    error
+	resourceError   error
+	shouldPanic     bool
+	callCount       map[string]int
+}
+
+func newResolverMockAttributeProvider(namespace string) *resolverMockAttributeProvider {
+	return &resolverMockAttributeProvider{
+		namespace:    namespace,
+		subjectData:  make(map[string]map[string]any),
+		resourceData: make(map[string]map[string]any),
+		callCount:    make(map[string]int),
+	}
+}
+
+func (m *resolverMockAttributeProvider) Namespace() string {
+	return m.namespace
+}
+
+func (m *resolverMockAttributeProvider) ResolveSubject(_ context.Context, subjectID string) (map[string]any, error) {
+	m.callCount["subject:"+subjectID]++
+	if m.shouldPanic {
+		panic("mock provider panic")
+	}
+	if m.subjectError != nil {
+		return nil, m.subjectError
+	}
+	if data, ok := m.subjectData[subjectID]; ok {
+		return data, nil
+	}
+	return nil, nil
+}
+
+func (m *resolverMockAttributeProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	m.callCount["resource:"+resourceID]++
+	if m.shouldPanic {
+		panic("mock provider panic")
+	}
+	if m.resourceError != nil {
+		return nil, m.resourceError
+	}
+	if data, ok := m.resourceData[resourceID]; ok {
+		return data, nil
+	}
+	return nil, nil
+}
+
+func (m *resolverMockAttributeProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"role": types.AttrTypeString,
+		},
+	}
+}
+
+func TestNewResolver(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+	require.NotNil(t, resolver)
+}
+
+func TestResolver_RegisterProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*Resolver)
+		provider    AttributeProvider
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "register single provider",
+			provider: newResolverMockAttributeProvider("character"),
+			wantErr:  false,
+		},
+		{
+			name: "register duplicate namespace",
+			setup: func(r *Resolver) {
+				_ = r.RegisterProvider(newResolverMockAttributeProvider("character"))
+			},
+			provider:    newResolverMockAttributeProvider("character"),
+			wantErr:     true,
+			errContains: "already registered",
+		},
+		{
+			name:        "register empty namespace",
+			provider:    newResolverMockAttributeProvider(""),
+			wantErr:     true,
+			errContains: "namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewSchemaRegistry()
+			resolver := NewResolver(registry)
+
+			if tt.setup != nil {
+				tt.setup(resolver)
+			}
+
+			err := resolver.RegisterProvider(tt.provider)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolver_RegisterEnvironmentProvider(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := &mockEnvironmentProvider{
+		namespace: "environment",
+		attrs: map[string]any{
+			"time": "2026-02-12T12:00:00Z",
+		},
+	}
+
+	err := resolver.RegisterEnvironmentProvider(provider)
+	require.NoError(t, err)
+
+	// Duplicate should error
+	err = resolver.RegisterEnvironmentProvider(provider)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already registered")
+}
+
+func TestResolver_Resolve_SingleProvider(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["01ABC"] = map[string]any{
+		"role":  "admin",
+		"level": 5,
+	}
+	provider.resourceData["01XYZ"] = map[string]any{
+		"owner": "01ABC",
+		"type":  "room",
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, bags)
+
+	// Check subject attributes with namespace prefix
+	assert.Equal(t, "admin", bags.Subject["character.role"])
+	assert.Equal(t, 5, bags.Subject["character.level"])
+
+	// Check resource attributes with namespace prefix
+	assert.Equal(t, "01ABC", bags.Resource["character.owner"])
+	assert.Equal(t, "room", bags.Resource["character.type"])
+
+	// Check action
+	assert.Equal(t, "read", bags.Action["name"])
+}
+
+func TestResolver_Resolve_MultipleProviders(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// First provider (character namespace)
+	provider1 := newResolverMockAttributeProvider("character")
+	provider1.subjectData["01ABC"] = map[string]any{
+		"role":  "admin",
+		"level": 5,
+	}
+
+	// Second provider (permissions namespace)
+	provider2 := newResolverMockAttributeProvider("permissions")
+	provider2.subjectData["01ABC"] = map[string]any{
+		"role":        "superuser", // Duplicate key - should override
+		"permissions": []string{"read", "write"},
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider1))
+	require.NoError(t, resolver.RegisterProvider(provider2))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// First provider's role
+	assert.Equal(t, "admin", bags.Subject["character.role"])
+	assert.Equal(t, 5, bags.Subject["character.level"])
+
+	// Second provider's role (last-registered wins for scalars)
+	assert.Equal(t, "superuser", bags.Subject["permissions.role"])
+	assert.Equal(t, []string{"read", "write"}, bags.Subject["permissions.permissions"])
+}
+
+func TestResolver_Resolve_ListMerging(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider1 := newResolverMockAttributeProvider("provider1")
+	provider1.subjectData["01ABC"] = map[string]any{
+		"tags": []string{"admin", "moderator"},
+	}
+
+	provider2 := newResolverMockAttributeProvider("provider2")
+	provider2.subjectData["01ABC"] = map[string]any{
+		"tags": []string{"verified", "premium"},
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider1))
+	require.NoError(t, resolver.RegisterProvider(provider2))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Both providers' tags should be in separate namespace keys
+	assert.Equal(t, []string{"admin", "moderator"}, bags.Subject["provider1.tags"])
+	assert.Equal(t, []string{"verified", "premium"}, bags.Subject["provider2.tags"])
+}
+
+func TestResolver_Resolve_ProviderError(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Provider that errors
+	provider1 := newResolverMockAttributeProvider("failing")
+	provider1.subjectError = errors.New("database error")
+
+	// Provider that works
+	provider2 := newResolverMockAttributeProvider("working")
+	provider2.subjectData["01ABC"] = map[string]any{
+		"role": "user",
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider1))
+	require.NoError(t, resolver.RegisterProvider(provider2))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err) // Should not error, just skip failing provider
+
+	// Working provider's data should be present
+	assert.Equal(t, "user", bags.Subject["working.role"])
+
+	// Failing provider's data should not be present
+	_, exists := bags.Subject["failing.role"]
+	assert.False(t, exists)
+}
+
+func TestResolver_Resolve_ProviderPanic(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Provider that panics
+	provider1 := newResolverMockAttributeProvider("panicking")
+	provider1.shouldPanic = true
+
+	// Provider that works
+	provider2 := newResolverMockAttributeProvider("working")
+	provider2.subjectData["01ABC"] = map[string]any{
+		"role": "user",
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider1))
+	require.NoError(t, resolver.RegisterProvider(provider2))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	// Should not panic, just skip the panicking provider
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Working provider's data should be present
+	assert.Equal(t, "user", bags.Subject["working.role"])
+}
+
+func TestResolver_Resolve_PerRequestCache(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["01ABC"] = map[string]any{
+		"role": "admin",
+	}
+	provider.resourceData["01ABC"] = map[string]any{
+		"role": "admin",
+	}
+
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "character:01ABC", // Same entity as subject
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should be called once each for subject and resource
+	// (different resolve types, separate cache keys)
+	subjectCalls := provider.callCount["subject:01ABC"]
+	resourceCalls := provider.callCount["resource:01ABC"]
+	assert.Equal(t, 1, subjectCalls)
+	assert.Equal(t, 1, resourceCalls)
+
+	// Both should have the data
+	assert.Equal(t, "admin", bags.Subject["character.role"])
+	assert.Equal(t, "admin", bags.Resource["character.role"])
+}
+
+func TestResolver_Resolve_ReEntranceGuard(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Create a provider that tries to call resolver again
+	reentrantProvider := &reentrantMockProvider{
+		namespace: "reentrant",
+		resolver:  resolver,
+	}
+
+	require.NoError(t, resolver.RegisterProvider(reentrantProvider))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	// Re-entrance panic is caught by safeResolve's recovery — outer call succeeds
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Reentrant provider's attributes should be empty (its call was recovered)
+	_, exists := bags.Subject["reentrant.test"]
+	assert.False(t, exists)
+}
+
+// Mock provider that attempts re-entrance
+type reentrantMockProvider struct {
+	namespace string
+	resolver  *Resolver
+}
+
+func (r *reentrantMockProvider) Namespace() string {
+	return r.namespace
+}
+
+func (r *reentrantMockProvider) ResolveSubject(ctx context.Context, _ string) (map[string]any, error) {
+	// Try to call resolver again (re-entrance)
+	req := types.AccessRequest{
+		Subject:  "character:01XYZ",
+		Action:     "read",
+		Resource: "room:01ABC",
+	}
+	_, _ = r.resolver.Resolve(ctx, req)
+	return nil, nil
+}
+
+func (r *reentrantMockProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (r *reentrantMockProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"test": types.AttrTypeString,
+		},
+	}
+}
+
+func TestResolver_Resolve_UnknownEntityType(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	req := types.AccessRequest{
+		Subject:  "unknown:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should have empty subject bag (no provider for "unknown" type)
+	assert.Empty(t, bags.Subject)
+	// Should still have action
+	assert.Equal(t, "read", bags.Action["name"])
+}
+
+func TestResolver_Resolve_EnvironmentProvider(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	envProvider := &mockEnvironmentProvider{
+		namespace: "environment",
+		attrs: map[string]any{
+			"time":       "2026-02-12T12:00:00Z",
+			"ip_address": "192.168.1.1",
+		},
+	}
+
+	require.NoError(t, resolver.RegisterEnvironmentProvider(envProvider))
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Check environment attributes with namespace prefix
+	assert.Equal(t, "2026-02-12T12:00:00Z", bags.Environment["environment.time"])
+	assert.Equal(t, "192.168.1.1", bags.Environment["environment.ip_address"])
+}
+
+func TestResolver_Resolve_InvalidEntityIDFormat(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	req := types.AccessRequest{
+		Subject:  "invalid_no_colon",
+		Action:     "read",
+		Resource: "room:01XYZ",
+	}
+
+	bags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should have empty subject bag (invalid format)
+	assert.Empty(t, bags.Subject)
+}

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -17,13 +17,13 @@ import (
 // These extend the basic mocks from provider_test.go with additional capabilities
 
 type resolverMockAttributeProvider struct {
-	namespace       string
-	subjectData     map[string]map[string]any
-	resourceData    map[string]map[string]any
-	subjectError    error
-	resourceError   error
-	shouldPanic     bool
-	callCount       map[string]int
+	namespace     string
+	subjectData   map[string]map[string]any
+	resourceData  map[string]map[string]any
+	subjectError  error
+	resourceError error
+	shouldPanic   bool
+	callCount     map[string]int
 }
 
 func newResolverMockAttributeProvider(namespace string) *resolverMockAttributeProvider {
@@ -171,7 +171,7 @@ func TestResolver_Resolve_SingleProvider(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -214,7 +214,7 @@ func TestResolver_Resolve_MultipleProviders(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -249,7 +249,7 @@ func TestResolver_Resolve_ListMerging(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -280,7 +280,7 @@ func TestResolver_Resolve_ProviderError(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -314,7 +314,7 @@ func TestResolver_Resolve_ProviderPanic(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -375,7 +375,7 @@ func TestResolver_Resolve_ReEntranceGuard(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -402,7 +402,7 @@ func (r *reentrantMockProvider) ResolveSubject(ctx context.Context, _ string) (m
 	// Try to call resolver again (re-entrance)
 	req := types.AccessRequest{
 		Subject:  "character:01XYZ",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01ABC",
 	}
 	_, _ = r.resolver.Resolve(ctx, req)
@@ -430,7 +430,7 @@ func TestResolver_Resolve_UnknownEntityType(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "unknown:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -459,7 +459,7 @@ func TestResolver_Resolve_EnvironmentProvider(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "character:01ABC",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 
@@ -480,7 +480,7 @@ func TestResolver_Resolve_InvalidEntityIDFormat(t *testing.T) {
 
 	req := types.AccessRequest{
 		Subject:  "invalid_no_colon",
-		Action:     "read",
+		Action:   "read",
 		Resource: "room:01XYZ",
 	}
 

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -172,7 +172,7 @@ func TestResolver_Resolve_SingleProvider(t *testing.T) {
 	provider.schema = &types.NamespaceSchema{
 		Attributes: map[string]types.AttrType{
 			"role":  types.AttrTypeString,
-			"level": types.AttrTypeInt,
+			"level": types.AttrTypeFloat,
 			"owner": types.AttrTypeString,
 			"type":  types.AttrTypeString,
 		},
@@ -219,7 +219,7 @@ func TestResolver_Resolve_MultipleProviders(t *testing.T) {
 	provider1.schema = &types.NamespaceSchema{
 		Attributes: map[string]types.AttrType{
 			"role":  types.AttrTypeString,
-			"level": types.AttrTypeInt,
+			"level": types.AttrTypeFloat,
 		},
 	}
 	provider1.subjectData["01ABC"] = map[string]any{

--- a/internal/access/policy/attribute/scene.go
+++ b/internal/access/policy/attribute/scene.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// SceneProvider resolves attributes for scene resources.
+// This is a stub that returns only type and ID.
+type SceneProvider struct{}
+
+// NewSceneProvider creates a new scene attribute provider.
+func NewSceneProvider() *SceneProvider {
+	return &SceneProvider{}
+}
+
+// Namespace returns "scene".
+func (p *SceneProvider) Namespace() string {
+	return "scene"
+}
+
+// ResolveSubject returns nil — scenes are not subjects.
+func (p *SceneProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves scene attributes for a resource.
+func (p *SceneProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	id, ok := parseEntityID(resourceID, "scene")
+	if !ok {
+		return nil, nil
+	}
+
+	return map[string]any{
+		"type": "scene",
+		"id":   id,
+	}, nil
+}
+
+// Schema returns the namespace schema for scene attributes.
+func (p *SceneProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"id":   types.AttrTypeString,
+		},
+	}
+}

--- a/internal/access/policy/attribute/scene_test.go
+++ b/internal/access/policy/attribute/scene_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+func TestSceneProvider_Namespace(t *testing.T) {
+	provider := NewSceneProvider()
+	assert.Equal(t, "scene", provider.Namespace())
+}
+
+func TestSceneProvider_ResolveSubject(t *testing.T) {
+	provider := NewSceneProvider()
+	attrs, err := provider.ResolveSubject(context.Background(), "scene:01XYZ")
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+}
+
+func TestSceneProvider_ResolveResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		expected   map[string]any
+		wantNil    bool
+	}{
+		{
+			name:       "scene resource type",
+			resourceID: "scene:01XYZ",
+			expected: map[string]any{
+				"type": "scene",
+				"id":   "01XYZ",
+			},
+		},
+		{
+			name:       "scene with different ID",
+			resourceID: "scene:01ABC",
+			expected: map[string]any{
+				"type": "scene",
+				"id":   "01ABC",
+			},
+		},
+		{
+			name:       "non-scene resource type",
+			resourceID: "command:say",
+			wantNil:    true,
+		},
+		{
+			name:       "object resource type",
+			resourceID: "object:01ABC",
+			wantNil:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewSceneProvider()
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, attrs)
+			} else {
+				assert.Equal(t, tt.expected, attrs)
+			}
+		})
+	}
+}
+
+func TestSceneProvider_Schema(t *testing.T) {
+	provider := NewSceneProvider()
+	schema := provider.Schema()
+
+	expected := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type": types.AttrTypeString,
+			"id":   types.AttrTypeString,
+		},
+	}
+
+	assert.Equal(t, expected, schema)
+}

--- a/internal/access/policy/attribute/schema.go
+++ b/internal/access/policy/attribute/schema.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package attribute provides attribute provider interfaces and schema registry.
+package attribute
+
+import (
+	"fmt"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/samber/oops"
+)
+
+// SchemaRegistry manages attribute schema registration and validation.
+// It wraps types.AttributeSchema with full validation logic.
+type SchemaRegistry struct {
+	schema *types.AttributeSchema
+}
+
+// NewSchemaRegistry creates a new SchemaRegistry with an empty schema.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		schema: types.NewAttributeSchema(),
+	}
+}
+
+// Register adds a namespace schema with full validation.
+// Returns error if:
+// - namespace is empty
+// - namespace is already registered
+// - schema is nil
+// - schema has no attributes
+func Register(r *SchemaRegistry, namespace string, schema *types.NamespaceSchema) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace cannot be empty")
+	}
+
+	if r.schema.HasNamespace(namespace) {
+		return fmt.Errorf("namespace already registered: %s", namespace)
+	}
+
+	if schema == nil {
+		return fmt.Errorf("schema cannot be nil")
+	}
+
+	if len(schema.Attributes) == 0 {
+		return fmt.Errorf("schema must have at least one attribute")
+	}
+
+	// Validate that all attribute types are valid
+	for key, attrType := range schema.Attributes {
+		// AttrType uses iota (0-4), so any value outside that range is invalid
+		if attrType < 0 || attrType > types.AttrTypeStringList {
+			return fmt.Errorf("invalid attribute type for %s.%s: %d", namespace, key, attrType)
+		}
+	}
+
+	if err := r.schema.Register(namespace, schema); err != nil {
+		return oops.Wrapf(err, "failed to register namespace %s", namespace)
+	}
+	return nil
+}
+
+// Register is the receiver method that delegates to the package-level function.
+func (r *SchemaRegistry) Register(namespace string, schema *types.NamespaceSchema) error {
+	return Register(r, namespace, schema)
+}
+
+// IsRegistered checks if a namespace+key pair exists in the registry.
+func (r *SchemaRegistry) IsRegistered(namespace, key string) bool {
+	return r.schema.IsRegistered(namespace, key)
+}
+
+// HasNamespace returns true if the given namespace has been registered.
+func (r *SchemaRegistry) HasNamespace(namespace string) bool {
+	return r.schema.HasNamespace(namespace)
+}
+
+// Schema returns the underlying AttributeSchema for use by the compiler.
+func (r *SchemaRegistry) Schema() *types.AttributeSchema {
+	return r.schema
+}

--- a/internal/access/policy/attribute/schema_test.go
+++ b/internal/access/policy/attribute/schema_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaRegistry_Register(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		schema    *types.NamespaceSchema
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "valid namespace registration",
+			namespace: "character",
+			schema: &types.NamespaceSchema{
+				Attributes: map[string]types.AttrType{
+					"name":  types.AttrTypeString,
+					"level": types.AttrTypeFloat,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			schema: &types.NamespaceSchema{
+				Attributes: map[string]types.AttrType{
+					"name": types.AttrTypeString,
+				},
+			},
+			wantErr: true,
+			errMsg:  "namespace cannot be empty",
+		},
+		{
+			name:      "duplicate namespace",
+			namespace: "character",
+			schema: &types.NamespaceSchema{
+				Attributes: map[string]types.AttrType{
+					"name": types.AttrTypeString,
+				},
+			},
+			wantErr: true,
+			errMsg:  "namespace already registered",
+		},
+		{
+			name:      "nil schema",
+			namespace: "location",
+			schema:    nil,
+			wantErr:   true,
+			errMsg:    "schema cannot be nil",
+		},
+		{
+			name:      "empty attributes",
+			namespace: "object",
+			schema: &types.NamespaceSchema{
+				Attributes: map[string]types.AttrType{},
+			},
+			wantErr: true,
+			errMsg:  "schema must have at least one attribute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewSchemaRegistry()
+
+			// Pre-register "character" namespace for duplicate test
+			if tt.name == "duplicate namespace" {
+				err := registry.Register("character", &types.NamespaceSchema{
+					Attributes: map[string]types.AttrType{
+						"id": types.AttrTypeString,
+					},
+				})
+				require.NoError(t, err)
+			}
+
+			err := registry.Register(tt.namespace, tt.schema)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSchemaRegistry_IsRegistered(t *testing.T) {
+	registry := NewSchemaRegistry()
+
+	// Register a namespace with some attributes
+	err := registry.Register("character", &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"name":  types.AttrTypeString,
+			"level": types.AttrTypeFloat,
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register("location", &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id": types.AttrTypeString,
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		namespace string
+		key       string
+		expected  bool
+	}{
+		{
+			name:      "registered namespace and key",
+			namespace: "character",
+			key:       "name",
+			expected:  true,
+		},
+		{
+			name:      "registered namespace, different key",
+			namespace: "character",
+			key:       "level",
+			expected:  true,
+		},
+		{
+			name:      "registered namespace, unregistered key",
+			namespace: "character",
+			key:       "faction",
+			expected:  false,
+		},
+		{
+			name:      "unregistered namespace",
+			namespace: "plugin",
+			key:       "score",
+			expected:  false,
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			key:       "name",
+			expected:  false,
+		},
+		{
+			name:      "empty key",
+			namespace: "character",
+			key:       "",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := registry.IsRegistered(tt.namespace, tt.key)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSchemaRegistry_HasNamespace(t *testing.T) {
+	registry := NewSchemaRegistry()
+
+	// Register some namespaces
+	err := registry.Register("character", &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"name": types.AttrTypeString,
+		},
+	})
+	require.NoError(t, err)
+
+	err = registry.Register("location", &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id": types.AttrTypeString,
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		namespace string
+		expected  bool
+	}{
+		{
+			name:      "registered namespace",
+			namespace: "character",
+			expected:  true,
+		},
+		{
+			name:      "different registered namespace",
+			namespace: "location",
+			expected:  true,
+		},
+		{
+			name:      "unregistered namespace",
+			namespace: "plugin",
+			expected:  false,
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := registry.HasNamespace(tt.namespace)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSchemaRegistry_Schema(t *testing.T) {
+	registry := NewSchemaRegistry()
+
+	// Register a namespace
+	err := registry.Register("character", &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"name": types.AttrTypeString,
+		},
+	})
+	require.NoError(t, err)
+
+	// Get the underlying schema
+	schema := registry.Schema()
+	require.NotNil(t, schema)
+
+	// Verify it has the registered namespace
+	assert.True(t, schema.HasNamespace("character"))
+	assert.True(t, schema.IsRegistered("character", "name"))
+}

--- a/internal/access/policy/attribute/stream.go
+++ b/internal/access/policy/attribute/stream.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"strings"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// StreamProvider resolves attributes for stream resources.
+// Streams use the format "stream:<name>" where name may contain colons
+// (e.g., "stream:global", "stream:location:01XYZ").
+type StreamProvider struct{}
+
+// NewStreamProvider creates a new stream attribute provider.
+func NewStreamProvider() *StreamProvider {
+	return &StreamProvider{}
+}
+
+// Namespace returns "stream".
+func (p *StreamProvider) Namespace() string {
+	return "stream"
+}
+
+// ResolveSubject returns nil — streams are not subjects.
+func (p *StreamProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves stream attributes for a resource.
+func (p *StreamProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	id, ok := parseEntityID(resourceID, "stream")
+	if !ok {
+		return nil, nil
+	}
+
+	attrs := map[string]any{
+		"type": "stream",
+		"name": id,
+	}
+
+	// Extract location ID from "location:ULID" pattern
+	if strings.HasPrefix(id, "location:") {
+		attrs["location"] = id[len("location:"):]
+	}
+
+	return attrs, nil
+}
+
+// Schema returns the namespace schema for stream attributes.
+func (p *StreamProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type":     types.AttrTypeString,
+			"name":     types.AttrTypeString,
+			"location": types.AttrTypeString,
+		},
+	}
+}

--- a/internal/access/policy/attribute/stream_test.go
+++ b/internal/access/policy/attribute/stream_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+func TestStreamProvider_Namespace(t *testing.T) {
+	provider := NewStreamProvider()
+	assert.Equal(t, "stream", provider.Namespace())
+}
+
+func TestStreamProvider_ResolveSubject(t *testing.T) {
+	provider := NewStreamProvider()
+	attrs, err := provider.ResolveSubject(context.Background(), "stream:location:01XYZ")
+	require.NoError(t, err)
+	assert.Nil(t, attrs)
+}
+
+func TestStreamProvider_ResolveResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		expected   map[string]any
+		wantNil    bool
+	}{
+		{
+			name:       "location stream with location ID",
+			resourceID: "stream:location:01XYZ",
+			expected: map[string]any{
+				"type":     "stream",
+				"name":     "location:01XYZ",
+				"location": "01XYZ",
+			},
+		},
+		{
+			name:       "simple stream name",
+			resourceID: "stream:global",
+			expected: map[string]any{
+				"type": "stream",
+				"name": "global",
+			},
+		},
+		{
+			name:       "stream with colon but not location prefix",
+			resourceID: "stream:scene:01ABC",
+			expected: map[string]any{
+				"type": "stream",
+				"name": "scene:01ABC",
+			},
+		},
+		{
+			name:       "non-stream resource type",
+			resourceID: "command:say",
+			wantNil:    true,
+		},
+		{
+			name:       "object resource type",
+			resourceID: "object:01ABC",
+			wantNil:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewStreamProvider()
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, attrs)
+			} else {
+				assert.Equal(t, tt.expected, attrs)
+			}
+		})
+	}
+}
+
+func TestStreamProvider_Schema(t *testing.T) {
+	provider := NewStreamProvider()
+	schema := provider.Schema()
+
+	expected := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"type":     types.AttrTypeString,
+			"name":     types.AttrTypeString,
+			"location": types.AttrTypeString,
+		},
+	}
+
+	assert.Equal(t, expected, schema)
+}

--- a/internal/access/policy/audit/doc.go
+++ b/internal/access/policy/audit/doc.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package audit provides audit logging for ABAC access control decisions.
+//
+// # Overview
+//
+// The audit package implements configurable audit logging for access control
+// decisions with sync/async writes and WAL (Write-Ahead Log) fallback for
+// resilience. It supports three logging modes and provides PostgreSQL storage.
+//
+// # Audit Modes
+//
+//   - ModeMinimal: Logs denials, default denials, and system bypasses (sync)
+//   - ModeDenialsOnly: Logs all denials and system bypasses (sync)
+//   - ModeAll: Logs everything - denials sync, allows async
+//
+// # Architecture
+//
+// The Logger routes entries based on effect and mode:
+//
+//	deny, default_deny, system_bypass → sync write → WAL fallback on failure
+//	allow (in ModeAll only) → async write via buffered channel
+//
+// PostgresWriter implements batched async writes with periodic flushing.
+//
+// # Resilience
+//
+// When sync writes fail, entries are written to a WAL file at
+// $XDG_STATE_HOME/holomush/audit-wal.jsonl. The ReplayWAL method can be
+// used to recover entries after outages.
+//
+// # Metrics
+//
+//   - abac_audit_channel_full_total: Channel overflow counter
+//   - abac_audit_failures_total{reason}: Failure counter by reason
+//   - abac_audit_wal_entries: Current WAL entry count
+//
+// # Example Usage
+//
+//	db, _ := sql.Open("postgres", connString)
+//	writer := audit.NewPostgresWriter(db)
+//	logger := audit.NewLogger(audit.ModeAll, writer, "")
+//	defer logger.Close()
+//
+//	// Log a decision
+//	entry := audit.Entry{
+//	    Subject:    "character:01ABC",
+//	    Action:     "read",
+//	    Resource:   "location:01XYZ",
+//	    Effect:     types.EffectAllow,
+//	    PolicyID:   "policy-123",
+//	    PolicyName: "allow-read",
+//	    Attributes: map[string]any{"role": "player"},
+//	    DurationUS: 150,
+//	    Timestamp:  time.Now(),
+//	}
+//	logger.Log(ctx, entry)
+//
+//	// Replay WAL after recovery
+//	logger.ReplayWAL(ctx)
+package audit

--- a/internal/access/policy/audit/logger.go
+++ b/internal/access/policy/audit/logger.go
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package audit provides audit logging for ABAC access control decisions.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/xdg"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/samber/oops"
+)
+
+// Mode controls which decisions are logged.
+type Mode string
+
+// Audit logging modes.
+const (
+	ModeMinimal     Mode = "minimal"      // system bypasses + denials
+	ModeDenialsOnly Mode = "denials_only" // denials + default_deny + system_bypass
+	ModeAll         Mode = "all"          // everything
+)
+
+// Entry represents a single access control decision to be logged.
+type Entry struct {
+	Subject    string         `json:"subject"`
+	Action     string         `json:"action"`
+	Resource   string         `json:"resource"`
+	Effect     types.Effect   `json:"effect"`
+	PolicyID   string         `json:"policy_id"`
+	PolicyName string         `json:"policy_name"`
+	Attributes map[string]any `json:"attributes"`
+	DurationUS int64          `json:"duration_us"`
+	Timestamp  time.Time      `json:"timestamp"`
+}
+
+// Writer is the interface for writing audit entries to a backend.
+type Writer interface {
+	WriteSync(ctx context.Context, entry Entry) error
+	WriteAsync(entry Entry) error
+	Close() error
+}
+
+var (
+	channelFullCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "abac_audit_channel_full_total",
+		Help: "Total number of times async audit channel was full",
+	})
+
+	failuresCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "abac_audit_failures_total",
+		Help: "Total number of audit logging failures",
+	}, []string{"reason"})
+
+	walEntriesGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "abac_audit_wal_entries",
+		Help: "Current number of entries in the WAL",
+	})
+)
+
+// Logger routes audit entries based on mode and effect.
+type Logger struct {
+	mode      Mode
+	writer    Writer
+	walPath   string
+	walFile   *os.File
+	walMu     sync.Mutex
+	asyncChan chan Entry
+	stopChan  chan struct{}
+	wg        sync.WaitGroup
+}
+
+// NewLogger creates a Logger with the given mode, writer, and WAL path.
+// If walPath is empty, a default path in the XDG state directory will be used.
+func NewLogger(mode Mode, writer Writer, walPath string) *Logger {
+	if walPath == "" {
+		stateDir, err := xdg.StateDir()
+		if err != nil {
+			slog.Error("failed to get state directory for WAL", "error", err)
+			walPath = "/tmp/holomush-audit-wal.jsonl"
+		} else {
+			if err := xdg.EnsureDir(stateDir); err != nil {
+				slog.Error("failed to ensure state directory", "error", err)
+			}
+			walPath = filepath.Join(stateDir, "audit-wal.jsonl")
+		}
+	}
+
+	logger := &Logger{
+		mode:      mode,
+		writer:    writer,
+		walPath:   walPath,
+		asyncChan: make(chan Entry, 1000), // buffered channel
+		stopChan:  make(chan struct{}),
+	}
+
+	// Start async consumer goroutine
+	logger.wg.Add(1)
+	go logger.asyncConsumer()
+
+	return logger
+}
+
+// Log routes an audit entry based on the configured mode and effect.
+func (l *Logger) Log(ctx context.Context, entry Entry) error {
+	// Determine if entry should be logged based on mode and effect
+	shouldLog, useSync := l.shouldLog(entry.Effect)
+	if !shouldLog {
+		return nil
+	}
+
+	if useSync {
+		// Synchronous write for denials, default_deny, system_bypass
+		if err := l.writer.WriteSync(ctx, entry); err != nil {
+			// Fallback to WAL
+			if walErr := l.writeToWAL(entry); walErr != nil {
+				// Both failed - log error and drop entry
+				slog.Error("audit write failed: both DB and WAL failed",
+					"db_error", err,
+					"wal_error", walErr,
+					"subject", entry.Subject,
+					"action", entry.Action,
+					"resource", entry.Resource,
+					"effect", entry.Effect,
+				)
+				failuresCounter.WithLabelValues("wal_failed").Inc()
+			}
+		}
+		return nil
+	}
+
+	// Async write for allows in all mode
+	select {
+	case l.asyncChan <- entry:
+		return nil
+	default:
+		// Channel full - drop entry and increment metric
+		channelFullCounter.Inc()
+		return nil
+	}
+}
+
+// shouldLog determines if an entry should be logged based on mode and effect.
+// Returns (shouldLog bool, useSync bool).
+func (l *Logger) shouldLog(effect types.Effect) (shouldLog, useSync bool) {
+	switch l.mode {
+	case ModeMinimal:
+		// Log: deny, default_deny, system_bypass (all sync)
+		switch effect {
+		case types.EffectDeny, types.EffectDefaultDeny, types.EffectSystemBypass:
+			shouldLog, useSync = true, true
+		default:
+			shouldLog, useSync = false, false
+		}
+
+	case ModeDenialsOnly:
+		// Log: deny, default_deny, system_bypass (all sync)
+		switch effect {
+		case types.EffectDeny, types.EffectDefaultDeny, types.EffectSystemBypass:
+			shouldLog, useSync = true, true
+		default:
+			shouldLog, useSync = false, false
+		}
+
+	case ModeAll:
+		// Log everything: denials sync, allows async
+		switch effect {
+		case types.EffectDeny, types.EffectDefaultDeny, types.EffectSystemBypass:
+			shouldLog, useSync = true, true
+		case types.EffectAllow:
+			shouldLog, useSync = true, false
+		default:
+			shouldLog, useSync = false, false
+		}
+
+	default:
+		shouldLog, useSync = false, false
+	}
+
+	return shouldLog, useSync
+}
+
+// asyncConsumer processes async writes from the channel.
+func (l *Logger) asyncConsumer() {
+	defer l.wg.Done()
+
+	for {
+		select {
+		case entry := <-l.asyncChan:
+			if err := l.writer.WriteAsync(entry); err != nil {
+				slog.Error("async audit write failed",
+					"error", err,
+					"subject", entry.Subject,
+					"action", entry.Action,
+				)
+				failuresCounter.WithLabelValues("async_write_failed").Inc()
+			}
+		case <-l.stopChan:
+			// Drain remaining entries
+			l.drainAsync()
+			return
+		}
+	}
+}
+
+// drainAsync processes all remaining entries in the channel.
+func (l *Logger) drainAsync() {
+	for {
+		select {
+		case entry := <-l.asyncChan:
+			if err := l.writer.WriteAsync(entry); err != nil {
+				slog.Error("async audit write failed during drain",
+					"error", err,
+					"subject", entry.Subject,
+				)
+				failuresCounter.WithLabelValues("async_write_failed").Inc()
+			}
+		default:
+			return
+		}
+	}
+}
+
+// writeToWAL writes an entry to the write-ahead log.
+func (l *Logger) writeToWAL(entry Entry) error {
+	l.walMu.Lock()
+	defer l.walMu.Unlock()
+
+	// Open WAL file if not already open
+	if l.walFile == nil {
+		file, err := os.OpenFile(l.walPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY|os.O_SYNC, 0o600)
+		if err != nil {
+			return oops.With("path", l.walPath).Wrap(err)
+		}
+		l.walFile = file
+	}
+
+	// Write JSON entry
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return oops.Wrap(err)
+	}
+
+	if _, err := fmt.Fprintf(l.walFile, "%s\n", data); err != nil {
+		return oops.Wrap(err)
+	}
+
+	walEntriesGauge.Inc()
+	return nil
+}
+
+// ReplayWAL reads all entries from the WAL and writes them to the writer.
+// On success, truncates the WAL file.
+func (l *Logger) ReplayWAL(ctx context.Context) error {
+	l.walMu.Lock()
+	defer l.walMu.Unlock()
+
+	// Check if WAL exists
+	if _, err := os.Stat(l.walPath); os.IsNotExist(err) {
+		return nil // No WAL to replay
+	}
+
+	// Read WAL file
+	data, err := os.ReadFile(l.walPath)
+	if err != nil {
+		return oops.With("path", l.walPath).Wrap(err)
+	}
+
+	if len(data) == 0 {
+		return nil // Empty WAL
+	}
+
+	// Parse and replay entries
+	lines := 0
+	for _, line := range splitLines(string(data)) {
+		if line == "" {
+			continue
+		}
+
+		var entry Entry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			slog.Error("failed to unmarshal WAL entry", "error", err, "line", line)
+			failuresCounter.WithLabelValues("wal_unmarshal_failed").Inc()
+			continue
+		}
+
+		if err := l.writer.WriteSync(ctx, entry); err != nil {
+			slog.Error("failed to replay WAL entry", "error", err, "entry", entry)
+			failuresCounter.WithLabelValues("wal_replay_failed").Inc()
+			// Continue with other entries
+		}
+		lines++
+	}
+
+	// Truncate WAL on success
+	if err := os.Truncate(l.walPath, 0); err != nil {
+		return oops.With("path", l.walPath).Wrap(err)
+	}
+
+	walEntriesGauge.Set(0)
+	slog.Info("replayed WAL entries", "count", lines)
+	return nil
+}
+
+// Close gracefully shuts down the logger.
+func (l *Logger) Close() error {
+	// Signal stop
+	close(l.stopChan)
+
+	// Wait for async consumer to drain
+	l.wg.Wait()
+
+	// Close writer
+	if err := l.writer.Close(); err != nil {
+		return oops.Wrap(err)
+	}
+
+	// Close WAL file
+	l.walMu.Lock()
+	defer l.walMu.Unlock()
+	if l.walFile != nil {
+		if err := l.walFile.Close(); err != nil {
+			return oops.Wrap(err)
+		}
+		l.walFile = nil
+	}
+
+	return nil
+}
+
+// splitLines splits a string by newlines.
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}

--- a/internal/access/policy/audit/logger_test.go
+++ b/internal/access/policy/audit/logger_test.go
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWriter records all writes for verification
+type mockWriter struct {
+	mu          sync.Mutex
+	syncWrites  []Entry
+	asyncWrites []Entry
+	failSync    bool
+	failAsync   bool
+	closed      bool
+}
+
+func (m *mockWriter) WriteSync(_ context.Context, entry Entry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failSync {
+		return assert.AnError
+	}
+	m.syncWrites = append(m.syncWrites, entry)
+	return nil
+}
+
+func (m *mockWriter) WriteAsync(entry Entry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failAsync {
+		return assert.AnError
+	}
+	m.asyncWrites = append(m.asyncWrites, entry)
+	return nil
+}
+
+func (m *mockWriter) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *mockWriter) getSyncWrites() []Entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]Entry{}, m.syncWrites...)
+}
+
+func (m *mockWriter) getAsyncWrites() []Entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]Entry{}, m.asyncWrites...)
+}
+
+func (m *mockWriter) isClosed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
+func TestAuditLogger_MinimalMode_Allow_NotLogged(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeMinimal, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "read",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectAllow,
+		PolicyID:   "policy-123",
+		PolicyName: "allow-read",
+		Attributes: map[string]any{"role": "player"},
+		DurationUS: 100,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond) // allow async processing
+	assert.Empty(t, writer.getSyncWrites())
+	assert.Empty(t, writer.getAsyncWrites())
+}
+
+func TestAuditLogger_MinimalMode_Deny_LoggedSync(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeMinimal, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-456",
+		PolicyName: "deny-delete",
+		Attributes: map[string]any{"role": "player"},
+		DurationUS: 200,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	syncWrites := writer.getSyncWrites()
+	require.Len(t, syncWrites, 1)
+	assert.Equal(t, entry.Subject, syncWrites[0].Subject)
+	assert.Equal(t, entry.Effect, syncWrites[0].Effect)
+	assert.Empty(t, writer.getAsyncWrites())
+}
+
+func TestAuditLogger_MinimalMode_SystemBypass_LoggedSync(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeMinimal, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "system",
+		Action:     "write",
+		Resource:   "property:01DEF",
+		Effect:     types.EffectSystemBypass,
+		PolicyID:   "system-bypass",
+		PolicyName: "system-bypass",
+		Attributes: map[string]any{},
+		DurationUS: 50,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	syncWrites := writer.getSyncWrites()
+	require.Len(t, syncWrites, 1)
+	assert.Equal(t, entry.Effect, syncWrites[0].Effect)
+}
+
+func TestAuditLogger_DenialsOnlyMode_Allow_NotLogged(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeDenialsOnly, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "read",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectAllow,
+		PolicyID:   "policy-123",
+		PolicyName: "allow-read",
+		Attributes: map[string]any{},
+		DurationUS: 100,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, writer.getSyncWrites())
+	assert.Empty(t, writer.getAsyncWrites())
+}
+
+func TestAuditLogger_DenialsOnlyMode_Deny_LoggedSync(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeDenialsOnly, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-456",
+		PolicyName: "deny-delete",
+		Attributes: map[string]any{},
+		DurationUS: 200,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	syncWrites := writer.getSyncWrites()
+	require.Len(t, syncWrites, 1)
+	assert.Equal(t, entry.Effect, syncWrites[0].Effect)
+}
+
+func TestAuditLogger_AllMode_Allow_LoggedAsync(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeAll, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "read",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectAllow,
+		PolicyID:   "policy-123",
+		PolicyName: "allow-read",
+		Attributes: map[string]any{},
+		DurationUS: 100,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond) // allow async processing
+	asyncWrites := writer.getAsyncWrites()
+	require.Len(t, asyncWrites, 1)
+	assert.Equal(t, entry.Effect, asyncWrites[0].Effect)
+	assert.Empty(t, writer.getSyncWrites())
+}
+
+func TestAuditLogger_AllMode_Deny_LoggedSync(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeAll, writer, "")
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-456",
+		PolicyName: "deny-delete",
+		Attributes: map[string]any{},
+		DurationUS: 200,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	syncWrites := writer.getSyncWrites()
+	require.Len(t, syncWrites, 1)
+	assert.Equal(t, entry.Effect, syncWrites[0].Effect)
+	assert.Empty(t, writer.getAsyncWrites())
+}
+
+func TestAuditLogger_SyncWriteFailure_WALFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	walPath := filepath.Join(tmpDir, "audit-wal.jsonl")
+
+	writer := &mockWriter{failSync: true}
+	logger := NewLogger(ModeMinimal, writer, walPath)
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-456",
+		PolicyName: "deny-delete",
+		Attributes: map[string]any{"role": "player"},
+		DurationUS: 200,
+		Timestamp:  time.Now(),
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err) // WAL fallback should succeed
+
+	// Verify WAL file exists and contains entry
+	data, err := os.ReadFile(walPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "character:01ABC")
+	assert.Contains(t, string(data), "deny-delete")
+}
+
+func TestAuditLogger_ReplayWAL(t *testing.T) {
+	tmpDir := t.TempDir()
+	walPath := filepath.Join(tmpDir, "audit-wal.jsonl")
+
+	// Create initial logger and write entries to WAL
+	writer1 := &mockWriter{failSync: true}
+	logger1 := NewLogger(ModeMinimal, writer1, walPath)
+
+	entry1 := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-1",
+		PolicyName: "deny-1",
+		Attributes: map[string]any{},
+		DurationUS: 100,
+		Timestamp:  time.Now(),
+	}
+
+	entry2 := Entry{
+		Subject:    "character:01DEF",
+		Action:     "write",
+		Resource:   "property:01GHI",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-2",
+		PolicyName: "deny-2",
+		Attributes: map[string]any{},
+		DurationUS: 150,
+		Timestamp:  time.Now(),
+	}
+
+	logger1.Log(context.Background(), entry1)
+	logger1.Log(context.Background(), entry2)
+	logger1.Close()
+
+	// Create new logger with working writer and replay
+	writer2 := &mockWriter{}
+	logger2 := NewLogger(ModeMinimal, writer2, walPath)
+	defer logger2.Close()
+
+	err := logger2.ReplayWAL(context.Background())
+	require.NoError(t, err)
+
+	syncWrites := writer2.getSyncWrites()
+	require.Len(t, syncWrites, 2)
+	assert.Equal(t, "policy-1", syncWrites[0].PolicyID)
+	assert.Equal(t, "policy-2", syncWrites[1].PolicyID)
+
+	// WAL should be empty after replay
+	data, err := os.ReadFile(walPath)
+	require.NoError(t, err)
+	assert.Empty(t, data)
+}
+
+func TestAuditLogger_BothDBAndWALFail_EntryDropped(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create invalid WAL path (directory instead of file)
+	walPath := filepath.Join(tmpDir, "invalid-dir")
+	err := os.Mkdir(walPath, 0o700)
+	require.NoError(t, err)
+
+	writer := &mockWriter{failSync: true}
+	logger := NewLogger(ModeMinimal, writer, walPath)
+	defer logger.Close()
+
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "delete",
+		Resource:   "location:01XYZ",
+		Effect:     types.EffectDeny,
+		PolicyID:   "policy-456",
+		PolicyName: "deny-delete",
+		Attributes: map[string]any{},
+		DurationUS: 200,
+		Timestamp:  time.Now(),
+	}
+
+	err = logger.Log(context.Background(), entry)
+	// Should not error, but entry is dropped and metric incremented
+	require.NoError(t, err)
+}
+
+func TestAuditLogger_GracefulShutdown_FlushesBuffered(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeAll, writer, "")
+
+	// Queue multiple async entries
+	for i := 0; i < 5; i++ {
+		entry := Entry{
+			Subject:    "character:01ABC",
+			Action:     "read",
+			Resource:   "location:01XYZ",
+			Effect:     types.EffectAllow,
+			PolicyID:   "policy-123",
+			PolicyName: "allow-read",
+			Attributes: map[string]any{},
+			DurationUS: int64(100 + i),
+			Timestamp:  time.Now(),
+		}
+		logger.Log(context.Background(), entry)
+	}
+
+	// Close should flush all buffered entries
+	err := logger.Close()
+	require.NoError(t, err)
+
+	asyncWrites := writer.getAsyncWrites()
+	assert.Len(t, asyncWrites, 5)
+	assert.True(t, writer.isClosed())
+}
+
+func TestAuditLogger_EntryContainsAllFields(t *testing.T) {
+	writer := &mockWriter{}
+	logger := NewLogger(ModeAll, writer, "")
+	defer logger.Close()
+
+	now := time.Now()
+	entry := Entry{
+		Subject:    "character:01ABC",
+		Action:     "write",
+		Resource:   "property:01DEF",
+		Effect:     types.EffectAllow,
+		PolicyID:   "policy-789",
+		PolicyName: "allow-write-property",
+		Attributes: map[string]any{
+			"role":        "builder",
+			"permissions": []string{"write", "read"},
+		},
+		DurationUS: 250,
+		Timestamp:  now,
+	}
+
+	err := logger.Log(context.Background(), entry)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	asyncWrites := writer.getAsyncWrites()
+	require.Len(t, asyncWrites, 1)
+
+	logged := asyncWrites[0]
+	assert.Equal(t, "character:01ABC", logged.Subject)
+	assert.Equal(t, "write", logged.Action)
+	assert.Equal(t, "property:01DEF", logged.Resource)
+	assert.Equal(t, types.EffectAllow, logged.Effect)
+	assert.Equal(t, "policy-789", logged.PolicyID)
+	assert.Equal(t, "allow-write-property", logged.PolicyName)
+	assert.Equal(t, int64(250), logged.DurationUS)
+	assert.Equal(t, now, logged.Timestamp)
+	assert.NotNil(t, logged.Attributes)
+	assert.Equal(t, "builder", logged.Attributes["role"])
+}

--- a/internal/access/policy/audit/postgres.go
+++ b/internal/access/policy/audit/postgres.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/samber/oops"
+)
+
+// PostgresWriter implements Writer for PostgreSQL.
+type PostgresWriter struct {
+	db          *sql.DB
+	asyncChan   chan Entry
+	stopChan    chan struct{}
+	wg          sync.WaitGroup
+	batchSize   int
+	flushPeriod time.Duration
+}
+
+// NewPostgresWriter creates a PostgresWriter with the given database connection.
+func NewPostgresWriter(db *sql.DB) *PostgresWriter {
+	writer := &PostgresWriter{
+		db:          db,
+		asyncChan:   make(chan Entry, 1000),
+		stopChan:    make(chan struct{}),
+		batchSize:   100,
+		flushPeriod: 1 * time.Second,
+	}
+
+	// Start batch consumer goroutine
+	writer.wg.Add(1)
+	go writer.batchConsumer()
+
+	return writer
+}
+
+// WriteSync performs a synchronous write to the database.
+func (w *PostgresWriter) WriteSync(ctx context.Context, entry Entry) error {
+	query := `
+		INSERT INTO access_audit_log (
+			subject, action, resource, effect, policy_id, policy_name,
+			attributes, duration_us, timestamp
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
+
+	attributesJSON, err := json.Marshal(entry.Attributes)
+	if err != nil {
+		return oops.Wrap(err)
+	}
+
+	_, err = w.db.ExecContext(ctx, query,
+		entry.Subject,
+		entry.Action,
+		entry.Resource,
+		entry.Effect.String(),
+		entry.PolicyID,
+		entry.PolicyName,
+		attributesJSON,
+		entry.DurationUS,
+		entry.Timestamp,
+	)
+	if err != nil {
+		return oops.With("subject", entry.Subject).
+			With("action", entry.Action).
+			With("resource", entry.Resource).
+			Wrap(err)
+	}
+
+	return nil
+}
+
+// WriteAsync queues an entry for asynchronous batch writing.
+func (w *PostgresWriter) WriteAsync(entry Entry) error {
+	select {
+	case w.asyncChan <- entry:
+		return nil
+	default:
+		// Channel full - caller should handle
+		channelFullCounter.Inc()
+		return fmt.Errorf("async channel full")
+	}
+}
+
+// batchConsumer processes async writes in batches.
+func (w *PostgresWriter) batchConsumer() {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.flushPeriod)
+	defer ticker.Stop()
+
+	var batch []Entry
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := w.writeBatch(ctx, batch); err != nil {
+			slog.Error("failed to write audit batch", "error", err, "count", len(batch))
+			failuresCounter.WithLabelValues("batch_write_failed").Inc()
+		}
+
+		batch = batch[:0] // reset batch
+	}
+
+	for {
+		select {
+		case entry := <-w.asyncChan:
+			batch = append(batch, entry)
+			if len(batch) >= w.batchSize {
+				flush()
+			}
+
+		case <-ticker.C:
+			flush()
+
+		case <-w.stopChan:
+			// Drain remaining entries
+			for {
+				select {
+				case entry := <-w.asyncChan:
+					batch = append(batch, entry)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+// writeBatch writes multiple entries in a single transaction.
+func (w *PostgresWriter) writeBatch(ctx context.Context, entries []Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	tx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		return oops.Wrap(err)
+	}
+	defer func() {
+		//nolint:errcheck // Rollback error is expected when transaction commits successfully
+		_ = tx.Rollback()
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO access_audit_log (
+			subject, action, resource, effect, policy_id, policy_name,
+			attributes, duration_us, timestamp
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`)
+	if err != nil {
+		return oops.Wrap(err)
+	}
+	defer func() {
+		//nolint:errcheck // Close error is not critical - statement will be closed when transaction ends
+		_ = stmt.Close()
+	}()
+
+	for i := range entries {
+		entry := &entries[i]
+		attributesJSON, err := json.Marshal(entry.Attributes)
+		if err != nil {
+			slog.Error("failed to marshal attributes", "error", err, "entry", entry)
+			continue
+		}
+
+		_, err = stmt.ExecContext(ctx,
+			entry.Subject,
+			entry.Action,
+			entry.Resource,
+			entry.Effect.String(),
+			entry.PolicyID,
+			entry.PolicyName,
+			attributesJSON,
+			entry.DurationUS,
+			entry.Timestamp,
+		)
+		if err != nil {
+			slog.Error("failed to insert audit entry", "error", err, "entry", entry)
+			// Continue with other entries
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return oops.Wrap(err)
+	}
+
+	return nil
+}
+
+// Close gracefully shuts down the writer.
+func (w *PostgresWriter) Close() error {
+	// Signal stop
+	close(w.stopChan)
+
+	// Wait for batch consumer to drain
+	w.wg.Wait()
+
+	return nil
+}

--- a/internal/access/policy/audit/retention.go
+++ b/internal/access/policy/audit/retention.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// RetentionConfig defines the retention policy for audit logs.
+type RetentionConfig struct {
+	RetainDenials time.Duration // How long to keep denial records
+	RetainAllows  time.Duration // How long to keep allow records
+	PurgeInterval time.Duration // How often to run the purge cycle
+}
+
+// DefaultRetentionConfig returns the default retention configuration.
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{
+		RetainDenials: 90 * 24 * time.Hour,
+		RetainAllows:  7 * 24 * time.Hour,
+		PurgeInterval: 24 * time.Hour,
+	}
+}
+
+// PartitionManager manages audit log partitions and purging.
+type PartitionManager interface {
+	EnsurePartitions(ctx context.Context, months int) error
+	PurgeExpiredAllows(ctx context.Context, olderThan time.Time) (int64, error)
+	DetachExpiredPartitions(ctx context.Context, olderThan time.Time) ([]string, error)
+	DropDetachedPartitions(ctx context.Context, gracePeriod time.Duration) ([]string, error)
+	HealthCheck(ctx context.Context) error
+}
+
+// RetentionWorker runs periodic retention maintenance on audit logs.
+type RetentionWorker struct {
+	cfg     RetentionConfig
+	manager PartitionManager
+	logger  *slog.Logger
+	clock   func() time.Time
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewRetentionWorker creates a new retention worker.
+func NewRetentionWorker(cfg RetentionConfig, manager PartitionManager) *RetentionWorker {
+	return &RetentionWorker{
+		cfg:     cfg,
+		manager: manager,
+		logger:  slog.Default(),
+		clock:   time.Now,
+	}
+}
+
+// RunOnce executes a single retention cycle. All operations are attempted
+// even if earlier ones fail; errors are combined.
+func (w *RetentionWorker) RunOnce(ctx context.Context) error {
+	now := w.clock()
+	var errs []error
+
+	// Ensure partitions exist for the next 3 months
+	if err := w.manager.EnsurePartitions(ctx, 3); err != nil {
+		w.logger.Error("ensure partitions failed", "error", err)
+		errs = append(errs, err)
+	}
+
+	// Purge expired allow records
+	purged, err := w.manager.PurgeExpiredAllows(ctx, now.Add(-w.cfg.RetainAllows))
+	if err != nil {
+		w.logger.Error("purge expired allows failed", "error", err)
+		errs = append(errs, err)
+	} else if purged > 0 {
+		w.logger.Info("purged expired allow records", "count", purged)
+	}
+
+	// Detach expired partitions
+	detached, err := w.manager.DetachExpiredPartitions(ctx, now.Add(-w.cfg.RetainDenials))
+	if err != nil {
+		w.logger.Error("detach expired partitions failed", "error", err)
+		errs = append(errs, err)
+	} else if len(detached) > 0 {
+		w.logger.Info("detached expired partitions", "partitions", detached)
+	}
+
+	// Drop detached partitions after grace period
+	dropped, err := w.manager.DropDetachedPartitions(ctx, 7*24*time.Hour)
+	if err != nil {
+		w.logger.Error("drop detached partitions failed", "error", err)
+		errs = append(errs, err)
+	} else if len(dropped) > 0 {
+		w.logger.Info("dropped detached partitions", "partitions", dropped)
+	}
+
+	return errors.Join(errs...)
+}
+
+// Start begins periodic retention maintenance.
+func (w *RetentionWorker) Start(ctx context.Context) error {
+	ctx, w.cancel = context.WithCancel(ctx)
+	w.wg.Add(1)
+	go w.run(ctx)
+	return nil
+}
+
+// Stop stops the retention worker and waits for completion.
+func (w *RetentionWorker) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wg.Wait()
+}
+
+// HealthCheck delegates to the partition manager.
+func (w *RetentionWorker) HealthCheck(ctx context.Context) error {
+	if err := w.manager.HealthCheck(ctx); err != nil {
+		return fmt.Errorf("partition health check: %w", err)
+	}
+	return nil
+}
+
+func (w *RetentionWorker) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.cfg.PurgeInterval)
+	defer ticker.Stop()
+
+	// Run once immediately
+	if err := w.RunOnce(ctx); err != nil {
+		w.logger.Error("retention cycle failed", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := w.RunOnce(ctx); err != nil {
+				w.logger.Error("retention cycle failed", "error", err)
+			}
+		}
+	}
+}

--- a/internal/access/policy/audit/retention_test.go
+++ b/internal/access/policy/audit/retention_test.go
@@ -16,24 +16,24 @@ import (
 
 // mockPartitionManager is a mock implementation of PartitionManager for testing.
 type mockPartitionManager struct {
-	mu                    sync.Mutex
-	ensureCalls           int
-	purgeCalls            int
-	detachCalls           int
-	dropCalls             int
-	healthCalls           int
-	ensureErr             error
-	purgeErr              error
-	detachErr             error
-	dropErr               error
-	healthErr             error
-	lastPurgeTime         time.Time
-	lastDetachTime        time.Time
-	lastDropGracePeriod   time.Duration
-	lastEnsureMonths      int
-	purgedRows            int64
-	detachedPartitions    []string
-	droppedPartitions     []string
+	mu                  sync.Mutex
+	ensureCalls         int
+	purgeCalls          int
+	detachCalls         int
+	dropCalls           int
+	healthCalls         int
+	ensureErr           error
+	purgeErr            error
+	detachErr           error
+	dropErr             error
+	healthErr           error
+	lastPurgeTime       time.Time
+	lastDetachTime      time.Time
+	lastDropGracePeriod time.Duration
+	lastEnsureMonths    int
+	purgedRows          int64
+	detachedPartitions  []string
+	droppedPartitions   []string
 }
 
 func (m *mockPartitionManager) EnsurePartitions(_ context.Context, months int) error {

--- a/internal/access/policy/audit/retention_test.go
+++ b/internal/access/policy/audit/retention_test.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPartitionManager is a mock implementation of PartitionManager for testing.
+type mockPartitionManager struct {
+	mu                    sync.Mutex
+	ensureCalls           int
+	purgeCalls            int
+	detachCalls           int
+	dropCalls             int
+	healthCalls           int
+	ensureErr             error
+	purgeErr              error
+	detachErr             error
+	dropErr               error
+	healthErr             error
+	lastPurgeTime         time.Time
+	lastDetachTime        time.Time
+	lastDropGracePeriod   time.Duration
+	lastEnsureMonths      int
+	purgedRows            int64
+	detachedPartitions    []string
+	droppedPartitions     []string
+}
+
+func (m *mockPartitionManager) EnsurePartitions(_ context.Context, months int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ensureCalls++
+	m.lastEnsureMonths = months
+	return m.ensureErr
+}
+
+func (m *mockPartitionManager) PurgeExpiredAllows(_ context.Context, olderThan time.Time) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.purgeCalls++
+	m.lastPurgeTime = olderThan
+	if m.purgeErr != nil {
+		return 0, m.purgeErr
+	}
+	return m.purgedRows, nil
+}
+
+func (m *mockPartitionManager) DetachExpiredPartitions(_ context.Context, olderThan time.Time) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detachCalls++
+	m.lastDetachTime = olderThan
+	if m.detachErr != nil {
+		return nil, m.detachErr
+	}
+	return m.detachedPartitions, nil
+}
+
+func (m *mockPartitionManager) DropDetachedPartitions(_ context.Context, gracePeriod time.Duration) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dropCalls++
+	m.lastDropGracePeriod = gracePeriod
+	if m.dropErr != nil {
+		return nil, m.dropErr
+	}
+	return m.droppedPartitions, nil
+}
+
+func (m *mockPartitionManager) HealthCheck(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.healthCalls++
+	return m.healthErr
+}
+
+func (m *mockPartitionManager) getCalls() (ensure, purge, detach, drop, health int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ensureCalls, m.purgeCalls, m.detachCalls, m.dropCalls, m.healthCalls
+}
+
+func TestDefaultRetentionConfig(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+
+	assert.Equal(t, 90*24*time.Hour, cfg.RetainDenials, "default denial retention should be 90 days")
+	assert.Equal(t, 7*24*time.Hour, cfg.RetainAllows, "default allow retention should be 7 days")
+	assert.Equal(t, 24*time.Hour, cfg.PurgeInterval, "default purge interval should be 24 hours")
+}
+
+func TestRetentionWorker_RunOnce_HappyPath(t *testing.T) {
+	cfg := RetentionConfig{
+		RetainDenials: 90 * 24 * time.Hour,
+		RetainAllows:  7 * 24 * time.Hour,
+		PurgeInterval: 24 * time.Hour,
+	}
+
+	mock := &mockPartitionManager{
+		purgedRows:         42,
+		detachedPartitions: []string{"access_audit_log_2025_01", "access_audit_log_2025_02"},
+		droppedPartitions:  []string{"access_audit_log_2024_12"},
+	}
+
+	now := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	worker := NewRetentionWorker(cfg, mock)
+	worker.clock = func() time.Time { return now }
+
+	err := worker.RunOnce(context.Background())
+	require.NoError(t, err)
+
+	// Verify all operations were called
+	ensure, purge, detach, drop, _ := mock.getCalls()
+	assert.Equal(t, 1, ensure, "EnsurePartitions should be called once")
+	assert.Equal(t, 1, purge, "PurgeExpiredAllows should be called once")
+	assert.Equal(t, 1, detach, "DetachExpiredPartitions should be called once")
+	assert.Equal(t, 1, drop, "DropDetachedPartitions should be called once")
+
+	// Verify correct parameters
+	assert.Equal(t, 3, mock.lastEnsureMonths, "should ensure partitions for 3 months")
+
+	expectedPurgeTime := now.Add(-7 * 24 * time.Hour)
+	assert.Equal(t, expectedPurgeTime, mock.lastPurgeTime, "purge cutoff should be now - RetainAllows")
+
+	expectedDetachTime := now.Add(-90 * 24 * time.Hour)
+	assert.Equal(t, expectedDetachTime, mock.lastDetachTime, "detach cutoff should be now - RetainDenials")
+
+	assert.Equal(t, 7*24*time.Hour, mock.lastDropGracePeriod, "drop grace period should be 7 days")
+}
+
+func TestRetentionWorker_RunOnce_EnsurePartitionsError(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+	mock := &mockPartitionManager{
+		ensureErr:          fmt.Errorf("database error"),
+		purgedRows:         10,
+		detachedPartitions: []string{"partition_1"},
+		droppedPartitions:  []string{"partition_2"},
+	}
+
+	worker := NewRetentionWorker(cfg, mock)
+	err := worker.RunOnce(context.Background())
+
+	// Should return error from EnsurePartitions
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database error")
+
+	// But other operations should still be attempted
+	ensure, purge, detach, drop, _ := mock.getCalls()
+	assert.Equal(t, 1, ensure)
+	assert.Equal(t, 1, purge, "purge should still be attempted after ensure fails")
+	assert.Equal(t, 1, detach, "detach should still be attempted after ensure fails")
+	assert.Equal(t, 1, drop, "drop should still be attempted after ensure fails")
+}
+
+func TestRetentionWorker_RunOnce_PurgeExpiredAllows(t *testing.T) {
+	cfg := RetentionConfig{
+		RetainDenials: 90 * 24 * time.Hour,
+		RetainAllows:  14 * 24 * time.Hour, // 2 weeks
+		PurgeInterval: 24 * time.Hour,
+	}
+
+	mock := &mockPartitionManager{
+		purgedRows: 100,
+	}
+
+	now := time.Date(2026, 2, 12, 15, 30, 0, 0, time.UTC)
+	worker := NewRetentionWorker(cfg, mock)
+	worker.clock = func() time.Time { return now }
+
+	err := worker.RunOnce(context.Background())
+	require.NoError(t, err)
+
+	// Verify correct cutoff time passed to PurgeExpiredAllows
+	expectedCutoff := now.Add(-14 * 24 * time.Hour)
+	assert.Equal(t, expectedCutoff, mock.lastPurgeTime)
+}
+
+func TestRetentionWorker_RunOnce_DetachExpiredPartitions(t *testing.T) {
+	cfg := RetentionConfig{
+		RetainDenials: 60 * 24 * time.Hour, // 60 days
+		RetainAllows:  7 * 24 * time.Hour,
+		PurgeInterval: 24 * time.Hour,
+	}
+
+	mock := &mockPartitionManager{
+		detachedPartitions: []string{"access_audit_log_2025_12", "access_audit_log_2025_11"},
+	}
+
+	now := time.Date(2026, 2, 12, 8, 0, 0, 0, time.UTC)
+	worker := NewRetentionWorker(cfg, mock)
+	worker.clock = func() time.Time { return now }
+
+	err := worker.RunOnce(context.Background())
+	require.NoError(t, err)
+
+	// Verify correct cutoff time passed to DetachExpiredPartitions
+	expectedCutoff := now.Add(-60 * 24 * time.Hour)
+	assert.Equal(t, expectedCutoff, mock.lastDetachTime)
+}
+
+func TestRetentionWorker_StartStop_Lifecycle(t *testing.T) {
+	cfg := RetentionConfig{
+		RetainDenials: 90 * 24 * time.Hour,
+		RetainAllows:  7 * 24 * time.Hour,
+		PurgeInterval: 100 * time.Millisecond, // Short interval for testing
+	}
+
+	mock := &mockPartitionManager{
+		purgedRows: 1,
+	}
+
+	worker := NewRetentionWorker(cfg, mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := worker.Start(ctx)
+	require.NoError(t, err)
+
+	// Wait for at least 2 cycles
+	time.Sleep(250 * time.Millisecond)
+
+	// Stop the worker
+	worker.Stop()
+
+	// Verify worker ran multiple times
+	ensure, purge, detach, drop, _ := mock.getCalls()
+	assert.GreaterOrEqual(t, ensure, 2, "should run at least 2 cycles")
+	assert.GreaterOrEqual(t, purge, 2, "should run at least 2 cycles")
+	assert.GreaterOrEqual(t, detach, 2, "should run at least 2 cycles")
+	assert.GreaterOrEqual(t, drop, 2, "should run at least 2 cycles")
+}
+
+func TestRetentionWorker_HealthCheck_Delegation(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+	mock := &mockPartitionManager{
+		healthErr: fmt.Errorf("partition missing"),
+	}
+
+	worker := NewRetentionWorker(cfg, mock)
+	err := worker.HealthCheck(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "partition missing")
+
+	_, _, _, _, health := mock.getCalls()
+	assert.Equal(t, 1, health, "HealthCheck should delegate to manager")
+}
+
+func TestRetentionWorker_RunOnce_AllErrorsCombined(t *testing.T) {
+	cfg := DefaultRetentionConfig()
+	mock := &mockPartitionManager{
+		ensureErr: fmt.Errorf("ensure failed"),
+		purgeErr:  fmt.Errorf("purge failed"),
+		detachErr: fmt.Errorf("detach failed"),
+		dropErr:   fmt.Errorf("drop failed"),
+	}
+
+	worker := NewRetentionWorker(cfg, mock)
+	err := worker.RunOnce(context.Background())
+
+	require.Error(t, err)
+	// Should contain all error messages
+	assert.Contains(t, err.Error(), "ensure failed")
+	assert.Contains(t, err.Error(), "purge failed")
+	assert.Contains(t, err.Error(), "detach failed")
+	assert.Contains(t, err.Error(), "drop failed")
+
+	// All operations should still be attempted
+	ensure, purge, detach, drop, _ := mock.getCalls()
+	assert.Equal(t, 1, ensure)
+	assert.Equal(t, 1, purge)
+	assert.Equal(t, 1, detach)
+	assert.Equal(t, 1, drop)
+}
+
+func TestRetentionWorker_StartStop_GracefulShutdown(t *testing.T) {
+	cfg := RetentionConfig{
+		RetainDenials: 90 * 24 * time.Hour,
+		RetainAllows:  7 * 24 * time.Hour,
+		PurgeInterval: 1 * time.Second, // Longer interval
+	}
+
+	mock := &mockPartitionManager{
+		purgedRows: 1,
+	}
+
+	worker := NewRetentionWorker(cfg, mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := worker.Start(ctx)
+	require.NoError(t, err)
+
+	// Stop immediately
+	worker.Stop()
+
+	// Should complete without hanging
+	// (test will timeout if Stop doesn't work properly)
+}

--- a/internal/access/policy/cache.go
+++ b/internal/access/policy/cache.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/holomush/holomush/internal/access/policy/store"
+)
+
+// Default cache configuration values.
+const (
+	defaultStalenessThreshold = 30 * time.Second
+	defaultReconnectInitial   = 100 * time.Millisecond
+	defaultReconnectMax       = 30 * time.Second
+	defaultReconnectFactor    = 2.0
+)
+
+// Listener abstracts the PostgreSQL LISTEN/NOTIFY mechanism for testability.
+// Implementations return a channel that emits notification payloads.
+// The channel should close when the context is cancelled.
+type Listener interface {
+	Listen(ctx context.Context) (<-chan string, error)
+}
+
+// CachedPolicy pairs a stored policy with its compiled form.
+type CachedPolicy struct {
+	ID       string
+	Name     string
+	Compiled *CompiledPolicy
+}
+
+// Snapshot is an immutable, read-only view of compiled policies.
+// It is safe for concurrent reads without locking.
+type Snapshot struct {
+	Policies  []CachedPolicy
+	CreatedAt time.Time
+}
+
+// CacheOption configures Cache behavior.
+type CacheOption func(*cacheConfig)
+
+type cacheConfig struct {
+	stalenessThreshold time.Duration
+	reconnectInitial   time.Duration
+	reconnectMax       time.Duration
+	reconnectFactor    float64
+	lastUpdateGauge    prometheus.Gauge
+}
+
+// WithStalenessThreshold sets the duration after which the cache is considered stale.
+func WithStalenessThreshold(d time.Duration) CacheOption {
+	return func(c *cacheConfig) {
+		c.stalenessThreshold = d
+	}
+}
+
+// WithReconnectConfig sets the exponential backoff parameters for LISTEN/NOTIFY reconnection.
+func WithReconnectConfig(initial, maxInterval time.Duration, factor float64) CacheOption {
+	return func(c *cacheConfig) {
+		c.reconnectInitial = initial
+		c.reconnectMax = maxInterval
+		c.reconnectFactor = factor
+	}
+}
+
+// WithLastUpdateGauge sets the Prometheus gauge to record the last successful reload timestamp.
+func WithLastUpdateGauge(g prometheus.Gauge) CacheOption {
+	return func(c *cacheConfig) {
+		c.lastUpdateGauge = g
+	}
+}
+
+// Cache provides concurrent access to compiled ABAC policies with
+// LISTEN/NOTIFY-based invalidation and staleness detection.
+type Cache struct {
+	store    store.PolicyStore
+	compiler *Compiler
+	cfg      cacheConfig
+
+	mu       sync.RWMutex
+	snapshot *Snapshot
+
+	// lastUpdate stores the Unix timestamp in nanoseconds of the last successful reload.
+	// Zero means no reload has occurred.
+	lastUpdate atomic.Int64
+
+	// wg tracks background goroutines for graceful shutdown.
+	wg sync.WaitGroup
+}
+
+// NewCache creates a Cache with the given store, compiler, and options.
+// Call Reload to populate the cache before first use.
+func NewCache(s store.PolicyStore, compiler *Compiler, opts ...CacheOption) *Cache {
+	cfg := cacheConfig{
+		stalenessThreshold: defaultStalenessThreshold,
+		reconnectInitial:   defaultReconnectInitial,
+		reconnectMax:       defaultReconnectMax,
+		reconnectFactor:    defaultReconnectFactor,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	pc := &Cache{
+		store:    s,
+		compiler: compiler,
+		cfg:      cfg,
+		snapshot: &Snapshot{}, // empty, non-nil snapshot
+	}
+	return pc
+}
+
+// Snapshot returns the current read-only policy snapshot.
+// The returned snapshot is safe for concurrent use.
+// Returns a copy of the slice to prevent callers from mutating the snapshot.
+func (pc *Cache) Snapshot() *Snapshot {
+	pc.mu.RLock()
+	snap := pc.snapshot
+	pc.mu.RUnlock()
+
+	// Return a copy with its own slice to prevent mutation.
+	copied := &Snapshot{
+		Policies:  make([]CachedPolicy, len(snap.Policies)),
+		CreatedAt: snap.CreatedAt,
+	}
+	copy(copied.Policies, snap.Policies)
+	return copied
+}
+
+// Reload fetches enabled policies from the store, compiles them, and atomically
+// swaps the snapshot. The write lock is held only during the pointer swap (~50us),
+// not during the DB fetch + compilation (~50ms).
+func (pc *Cache) Reload(ctx context.Context) error {
+	// Fetch and compile without holding the lock.
+	stored, err := pc.store.ListEnabled(ctx)
+	if err != nil {
+		return fmt.Errorf("policy cache reload: list enabled: %w", err)
+	}
+
+	policies := make([]CachedPolicy, 0, len(stored))
+	for _, sp := range stored {
+		compiled, _, compileErr := pc.compiler.Compile(sp.DSLText)
+		if compileErr != nil {
+			return fmt.Errorf("policy cache reload: compile %q (id=%s): %w", sp.Name, sp.ID, compileErr)
+		}
+		policies = append(policies, CachedPolicy{
+			ID:       sp.ID,
+			Name:     sp.Name,
+			Compiled: compiled,
+		})
+	}
+
+	snap := &Snapshot{
+		Policies:  policies,
+		CreatedAt: time.Now(),
+	}
+
+	// Atomic swap — write lock held only for pointer assignment.
+	pc.mu.Lock()
+	pc.snapshot = snap
+	pc.mu.Unlock()
+
+	// Record the reload timestamp (nanoseconds for sub-second staleness detection).
+	now := time.Now()
+	pc.lastUpdate.Store(now.UnixNano())
+
+	if pc.cfg.lastUpdateGauge != nil {
+		pc.cfg.lastUpdateGauge.Set(float64(now.Unix()))
+	}
+
+	return nil
+}
+
+// IsStale returns true if no successful reload has occurred within the staleness threshold.
+// Callers should return EffectDefaultDeny (fail-closed) when the cache is stale.
+func (pc *Cache) IsStale() bool {
+	last := pc.lastUpdate.Load()
+	if last == 0 {
+		return true // never reloaded
+	}
+	return time.Since(time.Unix(0, last)) > pc.cfg.stalenessThreshold
+}
+
+// Start spawns a background goroutine that listens for PostgreSQL NOTIFY events
+// on the "policy_changed" channel using a dedicated connection. On each notification,
+// it triggers a reload. Uses exponential backoff for reconnection.
+//
+// The connStr should be a PostgreSQL connection string for a dedicated (non-pooled)
+// connection. The goroutine exits when the context is cancelled.
+func (pc *Cache) Start(_ context.Context, connStr string) error {
+	// This method would create a real PgListener. For now, it's a placeholder
+	// that production code will wire up. Tests use StartWithListener instead.
+	_ = connStr
+	slog.Warn("Cache.Start called without real PG listener implementation")
+	return nil
+}
+
+// StartWithListener spawns the background LISTEN/NOTIFY goroutine using the
+// provided Listener interface. This is the primary method for both production
+// (with a real PG listener) and testing (with a mock).
+func (pc *Cache) StartWithListener(ctx context.Context, listener Listener) error {
+	ch, err := listener.Listen(ctx)
+	if err != nil {
+		return fmt.Errorf("policy cache start listener: %w", err)
+	}
+
+	pc.wg.Add(1)
+	go pc.listenLoop(ctx, ch)
+	return nil
+}
+
+// Wait blocks until all background goroutines have exited.
+func (pc *Cache) Wait() {
+	pc.wg.Wait()
+}
+
+// Stop is a convenience alias for cancelling the context externally and waiting.
+// In practice, callers cancel the context passed to Start/StartWithListener.
+func (pc *Cache) Stop() {
+	pc.wg.Wait()
+}
+
+// listenLoop runs in a goroutine, processing notifications and triggering reloads.
+func (pc *Cache) listenLoop(ctx context.Context, ch <-chan string) {
+	defer pc.wg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return // channel closed
+			}
+			if err := pc.Reload(ctx); err != nil {
+				slog.Error("policy cache reload on notification failed",
+					slog.String("error", err.Error()))
+			}
+		}
+	}
+}
+
+// CacheLastUpdate is the default Prometheus gauge for tracking the last
+// successful policy cache reload. Register with your Prometheus registry at startup.
+var CacheLastUpdate = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "abac_policy_cache_last_update",
+	Help: "Unix timestamp of the last successful policy cache reload",
+})
+
+// RegisterCacheMetrics registers policy cache metrics with the given Prometheus registry.
+func RegisterCacheMetrics(reg prometheus.Registerer) {
+	reg.MustRegister(CacheLastUpdate)
+}

--- a/internal/access/policy/cache_test.go
+++ b/internal/access/policy/cache_test.go
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/store"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// --- Mock PolicyStore ---
+
+type mockPolicyStore struct {
+	policies []*store.StoredPolicy
+	err      error
+	calls    atomic.Int64
+}
+
+func (m *mockPolicyStore) ListEnabled(_ context.Context) ([]*store.StoredPolicy, error) {
+	m.calls.Add(1)
+	return m.policies, m.err
+}
+
+func (m *mockPolicyStore) Create(_ context.Context, _ *store.StoredPolicy) error { return nil }
+func (m *mockPolicyStore) Get(_ context.Context, _ string) (*store.StoredPolicy, error) {
+	return nil, nil
+}
+
+func (m *mockPolicyStore) GetByID(_ context.Context, _ string) (*store.StoredPolicy, error) {
+	return nil, nil
+}
+func (m *mockPolicyStore) Update(_ context.Context, _ *store.StoredPolicy) error { return nil }
+func (m *mockPolicyStore) Delete(_ context.Context, _ string) error              { return nil }
+func (m *mockPolicyStore) List(_ context.Context, _ store.ListOptions) ([]*store.StoredPolicy, error) {
+	return nil, nil
+}
+
+// --- Mock Listener ---
+
+type mockListener struct {
+	ch  chan string
+	err error
+}
+
+func (m *mockListener) Listen(_ context.Context) (<-chan string, error) {
+	return m.ch, m.err
+}
+
+// --- Test helpers ---
+
+func testCompiler() *Compiler {
+	return NewCompiler(emptySchema())
+}
+
+func testPolicies() []*store.StoredPolicy {
+	return []*store.StoredPolicy{
+		{
+			ID:      "pol-1",
+			Name:    "allow-read",
+			Enabled: true,
+			Effect:  types.PolicyEffectPermit,
+			DSLText: `permit(principal, action, resource);`,
+		},
+		{
+			ID:      "pol-2",
+			Name:    "deny-delete",
+			Enabled: true,
+			Effect:  types.PolicyEffectForbid,
+			DSLText: `forbid(principal, action in ["delete"], resource);`,
+		},
+	}
+}
+
+// newTestGauge returns a fresh gauge for test isolation.
+func newTestGauge() prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_abac_policy_cache_last_update",
+		Help: "Test gauge",
+	})
+}
+
+// --- Tests ---
+
+func TestCache_Reload(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	// Before reload, snapshot should be nil or empty.
+	snap := cache.Snapshot()
+	require.NotNil(t, snap, "snapshot should never be nil (zero value)")
+	assert.Empty(t, snap.Policies, "snapshot should have no policies before reload")
+
+	// Reload.
+	err := cache.Reload(context.Background())
+	require.NoError(t, err)
+
+	// Snapshot should now contain compiled policies.
+	snap = cache.Snapshot()
+	require.NotNil(t, snap)
+	assert.Len(t, snap.Policies, 2, "snapshot should contain 2 compiled policies")
+	assert.Equal(t, "pol-1", snap.Policies[0].ID)
+	assert.Equal(t, "pol-2", snap.Policies[1].ID)
+	assert.NotNil(t, snap.Policies[0].Compiled)
+	assert.NotNil(t, snap.Policies[1].Compiled)
+
+	// Store should have been called once.
+	assert.Equal(t, int64(1), ms.calls.Load())
+}
+
+func TestCache_Reload_CompilationError(t *testing.T) {
+	ms := &mockPolicyStore{
+		policies: []*store.StoredPolicy{
+			{
+				ID:      "pol-bad",
+				Name:    "bad-policy",
+				Enabled: true,
+				Effect:  types.PolicyEffectPermit,
+				DSLText: `this is not valid DSL`,
+			},
+		},
+	}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	err := cache.Reload(context.Background())
+	assert.Error(t, err, "reload should fail when a policy cannot compile")
+
+	// Snapshot should still be empty (no partial update).
+	snap := cache.Snapshot()
+	assert.Empty(t, snap.Policies)
+}
+
+func TestCache_Reload_StoreError(t *testing.T) {
+	ms := &mockPolicyStore{
+		err: assert.AnError,
+	}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	err := cache.Reload(context.Background())
+	assert.Error(t, err, "reload should propagate store errors")
+}
+
+func TestCache_Snapshot_Concurrent(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	// Initial load.
+	require.NoError(t, cache.Reload(context.Background()))
+
+	const goroutines = 50
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines + 1) // readers + 1 reloader
+
+	// Concurrent readers.
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				snap := cache.Snapshot()
+				require.NotNil(t, snap)
+				// Snapshot should be consistent: either 0 or 2 policies.
+				n := len(snap.Policies)
+				assert.True(t, n == 0 || n == 2,
+					"snapshot should be atomic, got %d policies", n)
+			}
+		}()
+	}
+
+	// Concurrent reloader.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = cache.Reload(context.Background())
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestCache_Staleness(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	threshold := 50 * time.Millisecond
+	cache := NewCache(ms, compiler, WithStalenessThreshold(threshold))
+
+	// Before any reload, cache is stale.
+	assert.True(t, cache.IsStale(), "cache should be stale before first reload")
+
+	// After reload, cache is fresh.
+	require.NoError(t, cache.Reload(context.Background()))
+	assert.False(t, cache.IsStale(), "cache should be fresh immediately after reload")
+
+	// Wait for staleness threshold to pass.
+	time.Sleep(threshold + 10*time.Millisecond)
+	assert.True(t, cache.IsStale(), "cache should be stale after threshold")
+}
+
+func TestCache_Staleness_FailClosed(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	threshold := 50 * time.Millisecond
+	cache := NewCache(ms, compiler, WithStalenessThreshold(threshold))
+
+	// Load policies.
+	require.NoError(t, cache.Reload(context.Background()))
+
+	// Wait for staleness.
+	time.Sleep(threshold + 10*time.Millisecond)
+	require.True(t, cache.IsStale())
+
+	// When stale, callers should treat the cache as unreliable and default deny.
+	// The cache itself returns a snapshot, but IsStale() signals fail-closed.
+	snap := cache.Snapshot()
+	assert.NotNil(t, snap, "snapshot should still be returned even when stale")
+	assert.True(t, cache.IsStale(), "IsStale should remain true until next reload")
+
+	// After a fresh reload, staleness clears.
+	require.NoError(t, cache.Reload(context.Background()))
+	assert.False(t, cache.IsStale())
+}
+
+func TestCache_GracefulShutdown(t *testing.T) {
+	ch := make(chan string, 1)
+	listener := &mockListener{ch: ch}
+
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the background listener.
+	err := cache.StartWithListener(ctx, listener)
+	require.NoError(t, err)
+
+	// Give the goroutine a moment to start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel the context — goroutine should exit cleanly.
+	cancel()
+
+	// Wait for the goroutine to finish (with timeout).
+	done := make(chan struct{})
+	go func() {
+		cache.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Goroutine exited cleanly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit within timeout after context cancellation")
+	}
+}
+
+func TestCache_ListenNotify_TriggersReload(t *testing.T) {
+	ch := make(chan string, 1)
+	listener := &mockListener{ch: ch}
+
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Initial reload so we have a baseline.
+	require.NoError(t, cache.Reload(context.Background()))
+	assert.Equal(t, int64(1), ms.calls.Load())
+
+	// Start listener.
+	err := cache.StartWithListener(ctx, listener)
+	require.NoError(t, err)
+
+	// Send a notification.
+	ch <- "policy_changed"
+
+	// Wait for the reload to happen.
+	require.Eventually(t, func() bool {
+		return ms.calls.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"store should be called again after NOTIFY")
+
+	cancel()
+	cache.Wait()
+}
+
+func TestCache_ReloadMetric(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	gauge := newTestGauge()
+	cache := NewCache(ms, compiler, WithLastUpdateGauge(gauge))
+
+	// Before reload, gauge should be 0.
+	assert.Equal(t, float64(0), testutil.ToFloat64(gauge))
+
+	// After reload, gauge should be set to a recent Unix timestamp.
+	before := time.Now().Unix()
+	require.NoError(t, cache.Reload(context.Background()))
+	after := time.Now().Unix()
+
+	val := testutil.ToFloat64(gauge)
+	assert.GreaterOrEqual(t, val, float64(before), "gauge should be >= reload start time")
+	assert.LessOrEqual(t, val, float64(after), "gauge should be <= reload end time")
+}
+
+func TestSnapshot_Immutable(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+	cache := NewCache(ms, compiler)
+
+	require.NoError(t, cache.Reload(context.Background()))
+
+	snap1 := cache.Snapshot()
+	snap2 := cache.Snapshot()
+
+	// Both snapshots should reference the same underlying data.
+	assert.Equal(t, len(snap1.Policies), len(snap2.Policies))
+
+	// Modifying the returned slice should not affect the snapshot.
+	if len(snap1.Policies) > 0 {
+		snap1.Policies[0] = CachedPolicy{}
+		assert.NotEqual(t, snap1.Policies[0].ID, snap2.Policies[0].ID,
+			"snapshots should be independent copies")
+	}
+}
+
+func TestCacheOption_WithStalenessThreshold(t *testing.T) {
+	ms := &mockPolicyStore{policies: testPolicies()}
+	compiler := testCompiler()
+
+	// Very long threshold — should not be stale after reload.
+	cache := NewCache(ms, compiler, WithStalenessThreshold(1*time.Hour))
+	require.NoError(t, cache.Reload(context.Background()))
+	assert.False(t, cache.IsStale())
+}

--- a/internal/access/policy/compiler.go
+++ b/internal/access/policy/compiler.go
@@ -39,12 +39,12 @@ type ValidationWarning struct {
 
 // CompiledPolicy is the parsed, validated, and optimized form of a policy.
 type CompiledPolicy struct {
-	GrammarVersion int                `json:"grammar_version"`
-	Effect         types.PolicyEffect `json:"effect"`
-	Target         CompiledTarget     `json:"target"`
-	Conditions     *dsl.ConditionBlock `json:"conditions,omitempty"`
+	GrammarVersion int                  `json:"grammar_version"`
+	Effect         types.PolicyEffect   `json:"effect"`
+	Target         CompiledTarget       `json:"target"`
+	Conditions     *dsl.ConditionBlock  `json:"conditions,omitempty"`
 	GlobCache      map[string]glob.Glob `json:"-"`
-	DSLText        string             `json:"dsl_text"`
+	DSLText        string               `json:"dsl_text"`
 }
 
 // CompiledTarget is the parsed target clause.

--- a/internal/access/policy/dsl/ast.go
+++ b/internal/access/policy/dsl/ast.go
@@ -120,11 +120,11 @@ type Conjunction struct {
 //
 // The parser tries alternatives in order (PEG ordered choice) with
 // MaxLookahead for full backtracking:
-// 1. Unique-prefix forms: negation (!), parenthesized, if-then-else
-// 2. has (starts with attribute_root keyword + "has")
-// 3. Expression-starting forms ordered most-specific first:
-//    contains > like > in-list > in-expr > comparison
-// 4. Bare boolean literal (fallback)
+//  1. Unique-prefix forms: negation (!), parenthesized, if-then-else
+//  2. has (starts with attribute_root keyword + "has")
+//  3. Expression-starting forms ordered most-specific first:
+//     contains > like > in-list > in-expr > comparison
+//  4. Bare boolean literal (fallback)
 type Condition struct {
 	Pos           lexer.Position     `parser:"" json:"-"`
 	Negation      *Condition         `parser:"  Bang @@" json:"negation,omitempty"`

--- a/internal/access/policy/dsl/evaluator_test.go
+++ b/internal/access/policy/dsl/evaluator_test.go
@@ -285,9 +285,9 @@ func TestEvaluateConditions_Has(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "has simple attribute present",
-			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}}),
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
+			name:     "has simple attribute present",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"faction"}}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
 			expected: true,
 		},
 		{
@@ -297,27 +297,27 @@ func TestEvaluateConditions_Has(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "has dotted path present",
-			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "resource", Path: []string{"metadata", "tags"}}}),
-			bags: func() *types.AttributeBags { b := newBags(); b.Resource["metadata.tags"] = []string{"a"}; return b }(),
+			name:     "has dotted path present",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "resource", Path: []string{"metadata", "tags"}}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["metadata.tags"] = []string{"a"}; return b }(),
 			expected: true,
 		},
 		{
-			name: "has with zero value (empty string) still true",
-			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"name"}}}),
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["name"] = ""; return b }(),
+			name:     "has with zero value (empty string) still true",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"name"}}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["name"] = ""; return b }(),
 			expected: true,
 		},
 		{
-			name: "has with zero value (zero int) still true",
-			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"level"}}}),
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 0; return b }(),
+			name:     "has with zero value (zero int) still true",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"level"}}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 0; return b }(),
 			expected: true,
 		},
 		{
-			name: "has with nil value still true (key exists)",
-			cond: mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"data"}}}),
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["data"] = nil; return b }(),
+			name:     "has with nil value still true (key exists)",
+			cond:     mkSingleCond(&Condition{Has: &HasCondition{Root: "principal", Path: []string{"data"}}}),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["data"] = nil; return b }(),
 			expected: true,
 		},
 	}
@@ -452,7 +452,11 @@ func TestEvaluateConditions_Contains(t *testing.T) {
 				Root: "principal", Path: []string{"flags"}, Op: "containsAll",
 				List: mkStrList("vip", "beta"),
 			}}),
-			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"vip", "beta", "extra"}; return b }(),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []string{"vip", "beta", "extra"}
+				return b
+			}(),
 			expected: true,
 		},
 		{
@@ -470,7 +474,11 @@ func TestEvaluateConditions_Contains(t *testing.T) {
 				Root: "principal", Path: []string{"flags"}, Op: "containsAny",
 				List: mkStrList("admin", "builder"),
 			}}),
-			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"builder", "tester"}; return b }(),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []string{"builder", "tester"}
+				return b
+			}(),
 			expected: true,
 		},
 		{
@@ -479,7 +487,11 @@ func TestEvaluateConditions_Contains(t *testing.T) {
 				Root: "principal", Path: []string{"flags"}, Op: "containsAny",
 				List: mkStrList("admin", "builder"),
 			}}),
-			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["flags"] = []string{"tester", "viewer"}; return b }(),
+			bags: func() *types.AttributeBags {
+				b := newBags()
+				b.Subject["flags"] = []string{"tester", "viewer"}
+				return b
+			}(),
 			expected: false,
 		},
 		{
@@ -821,7 +833,7 @@ func TestEvaluateConditions_BooleanLogic(t *testing.T) {
 					}},
 				}},
 			}},
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
 			expected: true,
 		},
 	}
@@ -844,14 +856,14 @@ func TestEvaluateConditions_Negation(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "negation of true → false",
-			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("true")}}),
+			name:     "negation of true → false",
+			cond:     mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("true")}}),
 			bags:     newBags(),
 			expected: false,
 		},
 		{
-			name: "negation of false → true",
-			cond: mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("false")}}),
+			name:     "negation of false → true",
+			cond:     mkSingleCond(&Condition{Negation: &Condition{BoolLiteral: strPtr("false")}}),
 			bags:     newBags(),
 			expected: true,
 		},
@@ -1061,7 +1073,6 @@ func TestEvaluateConditions_DepthLimit(t *testing.T) {
 		assert.False(t, EvaluateConditions(ctx, cond))
 	})
 
-
 	t.Run("depthExceeded resets between calls", func(t *testing.T) {
 		// First call: trigger depth exceeded
 		inner := &Condition{BoolLiteral: strPtr("true")}
@@ -1157,15 +1168,15 @@ func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "simple role check permit",
-			dsl:  `permit(principal, action, resource) when { principal.role == "admin" };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			name:     "simple role check permit",
+			dsl:      `permit(principal, action, resource) when { principal.role == "admin" };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
 			expected: true,
 		},
 		{
-			name: "simple role check deny",
-			dsl:  `permit(principal, action, resource) when { principal.role == "admin" };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "guest"; return b }(),
+			name:     "simple role check deny",
+			dsl:      `permit(principal, action, resource) when { principal.role == "admin" };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "guest"; return b }(),
 			expected: false,
 		},
 		{
@@ -1180,21 +1191,21 @@ func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "disjunction",
-			dsl:  `permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			name:     "disjunction",
+			dsl:      `permit(principal, action, resource) when { principal.role == "admin" || principal.role == "builder" };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
 			expected: true,
 		},
 		{
-			name: "negation",
-			dsl:  `permit(principal, action, resource) when { !(principal.role == "banned") };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "player"; return b }(),
+			name:     "negation",
+			dsl:      `permit(principal, action, resource) when { !(principal.role == "banned") };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "player"; return b }(),
 			expected: true,
 		},
 		{
-			name: "in list",
-			dsl:  `permit(principal, action, resource) when { resource.name in ["say", "pose", "look"] };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "pose"; return b }(),
+			name:     "in list",
+			dsl:      `permit(principal, action, resource) when { resource.name in ["say", "pose", "look"] };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "pose"; return b }(),
 			expected: true,
 		},
 		{
@@ -1209,15 +1220,15 @@ func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "like glob",
-			dsl:  `permit(principal, action, resource) when { resource.name like "location:*" };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location:01XYZ"; return b }(),
+			name:     "like glob",
+			dsl:      `permit(principal, action, resource) when { resource.name like "location:*" };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Resource["name"] = "location:01XYZ"; return b }(),
 			expected: true,
 		},
 		{
-			name: "has",
-			dsl:  `permit(principal, action, resource) when { principal has faction };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
+			name:     "has",
+			dsl:      `permit(principal, action, resource) when { principal has faction };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["faction"] = "horde"; return b }(),
 			expected: true,
 		},
 		{
@@ -1252,27 +1263,27 @@ func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "if-then-else no faction falls through",
-			dsl:  `permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`,
-			bags: newBags(),
+			name:     "if-then-else no faction falls through",
+			dsl:      `permit(principal, action, resource) when { if principal has faction then principal.faction == resource.faction else true };`,
+			bags:     newBags(),
 			expected: true,
 		},
 		{
-			name: "no when clause → true (unconditional)",
-			dsl:  `permit(principal is character, action in ["enter"], resource is location);`,
-			bags: newBags(),
+			name:     "no when clause → true (unconditional)",
+			dsl:      `permit(principal is character, action in ["enter"], resource is location);`,
+			bags:     newBags(),
 			expected: true,
 		},
 		{
-			name: "numeric comparison with int bag value",
-			dsl:  `permit(principal, action, resource) when { principal.level > 5 };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10; return b }(),
+			name:     "numeric comparison with int bag value",
+			dsl:      `permit(principal, action, resource) when { principal.level > 5 };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["level"] = 10; return b }(),
 			expected: true,
 		},
 		{
-			name: "parenthesized expression",
-			dsl:  `permit(principal, action, resource) when { (principal.role == "admin") };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
+			name:     "parenthesized expression",
+			dsl:      `permit(principal, action, resource) when { (principal.role == "admin") };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "admin"; return b }(),
 			expected: true,
 		},
 		{
@@ -1321,9 +1332,9 @@ func TestEvaluateConditions_ParsedPolicies(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "role in list",
-			dsl:  `permit(principal, action, resource) when { principal.role in ["builder", "admin"] };`,
-			bags: func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
+			name:     "role in list",
+			dsl:      `permit(principal, action, resource) when { principal.role in ["builder", "admin"] };`,
+			bags:     func() *types.AttributeBags { b := newBags(); b.Subject["role"] = "builder"; return b }(),
 			expected: true,
 		},
 	}

--- a/internal/access/policy/dsl/parser.go
+++ b/internal/access/policy/dsl/parser.go
@@ -142,4 +142,3 @@ type ParseError struct {
 func (e *ParseError) Error() string {
 	return fmt.Sprintf("%d:%d: %s", e.Line, e.Column, e.Message)
 }
-

--- a/internal/access/policy/engine.go
+++ b/internal/access/policy/engine.go
@@ -167,6 +167,9 @@ func (e *Engine) Evaluate(ctx context.Context, req types.AccessRequest) (types.D
 		_ = auditErr
 	}
 
+	// Record metrics
+	RecordEvaluationMetrics(time.Since(start), decision.Effect)
+
 	return decision, nil
 }
 

--- a/internal/access/policy/engine.go
+++ b/internal/access/policy/engine.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/access/policy/audit"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// AccessPolicyEngine is the main entry point for policy-based authorization.
+type AccessPolicyEngine interface {
+	Evaluate(ctx context.Context, request types.AccessRequest) (types.Decision, error)
+}
+
+// Engine implements AccessPolicyEngine.
+type Engine struct {
+	resolver *attribute.Resolver
+	cache    *Cache
+	sessions SessionResolver
+	audit    *audit.Logger
+}
+
+// NewEngine creates a new policy engine with the given dependencies.
+func NewEngine(resolver *attribute.Resolver, cache *Cache, sessions SessionResolver, auditLogger *audit.Logger) *Engine {
+	return &Engine{
+		resolver: resolver,
+		cache:    cache,
+		sessions: sessions,
+		audit:    auditLogger,
+	}
+}
+
+// Evaluate evaluates an access request against the policy engine.
+// This implementation covers Steps 1-2 (system bypass + session resolution).
+func (e *Engine) Evaluate(ctx context.Context, req types.AccessRequest) (types.Decision, error) {
+	start := time.Now()
+
+	// Step 1: System bypass
+	if req.Subject == "system" {
+		decision := types.NewDecision(types.EffectSystemBypass, "system bypass", "")
+		if err := decision.Validate(); err != nil {
+			return decision, oops.Wrapf(err, "decision validation failed")
+		}
+
+		// Audit system bypass
+		entry := audit.Entry{
+			Subject:    req.Subject,
+			Action:     req.Action,
+			Resource:   req.Resource,
+			Effect:     types.EffectSystemBypass,
+			PolicyID:   "",
+			PolicyName: "",
+			DurationUS: time.Since(start).Microseconds(),
+			Timestamp:  time.Now(),
+		}
+		if err := e.audit.Log(ctx, entry); err != nil {
+			// Log error but don't fail the decision
+			_ = err
+		}
+
+		return decision, nil
+	}
+
+	// Step 2: Session resolution
+	if strings.HasPrefix(req.Subject, "session:") {
+		sessionID := strings.TrimPrefix(req.Subject, "session:")
+		characterID, err := e.sessions.ResolveSession(ctx, sessionID)
+		if err != nil {
+			// Check if this is a SESSION_INVALID error
+			oopsErr, ok := oops.AsOops(err)
+			var decision types.Decision
+			if ok && oopsErr.Code() == "SESSION_INVALID" {
+				decision = types.NewDecision(types.EffectDefaultDeny, "session invalid", "infra:session-invalid")
+			} else {
+				decision = types.NewDecision(types.EffectDefaultDeny, "session store error", "infra:session-store-error")
+			}
+
+			if valErr := decision.Validate(); valErr != nil {
+				return decision, oops.Wrapf(valErr, "decision validation failed")
+			}
+			return decision, nil
+		}
+
+		// Rewrite subject to character: format
+		req.Subject = "character:" + characterID
+
+		// Continue to placeholder (steps 3-6 not implemented)
+	}
+
+	// Placeholder for steps 3-6
+	decision := types.NewDecision(types.EffectDefaultDeny, "evaluation pending", "")
+	if err := decision.Validate(); err != nil {
+		return decision, oops.Wrapf(err, "decision validation failed")
+	}
+
+	return decision, nil
+}

--- a/internal/access/policy/engine.go
+++ b/internal/access/policy/engine.go
@@ -168,7 +168,7 @@ func (e *Engine) Evaluate(ctx context.Context, req types.AccessRequest) (types.D
 	}
 
 	// Step 5: Evaluate conditions for each candidate policy
-	var satisfied []types.PolicyMatch
+	satisfied := make([]types.PolicyMatch, 0, len(candidates))
 	for _, candidate := range candidates {
 		met := e.evaluatePolicy(candidate, bags)
 		satisfied = append(satisfied, types.PolicyMatch{
@@ -220,8 +220,7 @@ func (e *Engine) evaluatePolicy(policy CachedPolicy, bags *types.AttributeBags) 
 // findApplicablePolicies filters policies by target matching.
 // Returns only policies whose target constraints match the access request.
 func (e *Engine) findApplicablePolicies(req types.AccessRequest, policies []CachedPolicy) []CachedPolicy {
-	var result []CachedPolicy
-
+	result := make([]CachedPolicy, 0, len(policies))
 	for _, policy := range policies {
 		if policy.Compiled == nil {
 			continue

--- a/internal/access/policy/engine_bench_test.go
+++ b/internal/access/policy/engine_bench_test.go
@@ -69,10 +69,15 @@ func (p *benchAttributeProvider) Schema() *types.NamespaceSchema {
 	return &types.NamespaceSchema{
 		Attributes: map[string]types.AttrType{
 			"role":    types.AttrTypeString,
-			"level":   types.AttrTypeInt,
+			"level":   types.AttrTypeFloat,
 			"banned":  types.AttrTypeBool,
 			"faction": types.AttrTypeString,
 			"muted":   types.AttrTypeBool,
+			"score":   types.AttrTypeFloat,
+			"rank":    types.AttrTypeString,
+			"credits": types.AttrTypeFloat,
+			"karma":   types.AttrTypeFloat,
+			"xp":      types.AttrTypeFloat,
 		},
 	}
 }
@@ -167,7 +172,7 @@ func generateNestedIfPolicy(depth int) string {
 // Target: <10μs
 func BenchmarkSinglePolicyEvaluation(b *testing.B) {
 	dslText := `permit(principal is character, action in ["say"], resource is location) when { principal.character.role == "admin" };`
-	attrs := map[string]any{"role": "admin", "level": 10}
+	attrs := map[string]any{"role": "admin", "level": float64(10)}
 
 	engine := createBenchEngine(b, []string{dslText}, attrs)
 
@@ -199,7 +204,7 @@ func BenchmarkConditionEvaluation(b *testing.B) {
 	};`
 	attrs := map[string]any{
 		"role":   "admin",
-		"level":  10,
+		"level":  float64(10),
 		"banned": false,
 	}
 
@@ -227,7 +232,7 @@ func BenchmarkConditionEvaluation(b *testing.B) {
 // Target: <100μs
 func BenchmarkFiftyPolicyEvaluation(b *testing.B) {
 	policies := generateBenchPolicies(50)
-	attrs := map[string]any{"role": "admin", "level": 25}
+	attrs := map[string]any{"role": "admin", "level": float64(25)}
 
 	engine := createBenchEngine(b, policies, attrs)
 
@@ -254,15 +259,15 @@ func BenchmarkFiftyPolicyEvaluation(b *testing.B) {
 func BenchmarkAttributeResolution(b *testing.B) {
 	attrs := map[string]any{
 		"role":    "admin",
-		"level":   10,
+		"level":   float64(10),
 		"banned":  false,
 		"faction": "rebels",
 		"muted":   false,
-		"score":   1000,
+		"score":   float64(1000),
 		"rank":    "general",
-		"credits": 5000,
-		"karma":   50,
-		"xp":      10000,
+		"credits": float64(5000),
+		"karma":   float64(50),
+		"xp":      float64(10000),
 	}
 
 	registry := attribute.NewSchemaRegistry()
@@ -298,7 +303,7 @@ func BenchmarkAttributeResolution(b *testing.B) {
 // Target: <25ms
 func BenchmarkWorstCase_NestedIf(b *testing.B) {
 	dslText := generateNestedIfPolicy(10)
-	attrs := map[string]any{"level": 15}
+	attrs := map[string]any{"level": float64(15)}
 
 	engine := createBenchEngine(b, []string{dslText}, attrs)
 
@@ -325,7 +330,7 @@ func BenchmarkWorstCase_NestedIf(b *testing.B) {
 func BenchmarkWorstCase_AllPoliciesMatch(b *testing.B) {
 	// All policies use level > 0, so with level=50 they all match
 	policies := generateBenchPolicies(50)
-	attrs := map[string]any{"level": 50}
+	attrs := map[string]any{"level": float64(50)}
 
 	engine := createBenchEngine(b, policies, attrs)
 
@@ -356,7 +361,7 @@ func BenchmarkEvaluateEndToEnd(b *testing.B) {
 	}
 	attrs := map[string]any{
 		"role":   "admin",
-		"level":  10,
+		"level":  float64(10),
 		"banned": false,
 	}
 

--- a/internal/access/policy/engine_bench_test.go
+++ b/internal/access/policy/engine_bench_test.go
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package policy provides benchmarks for the ABAC policy engine.
+//
+// Run benchmarks from the repository root:
+//
+//	go test -bench=. -benchmem -count=3 ./internal/access/policy/ -run=^$
+//
+// Run specific benchmark:
+//
+//	go test -bench=BenchmarkSinglePolicyEvaluation -benchmem ./internal/access/policy/ -run=^$
+//
+// Performance targets:
+//   - BenchmarkSinglePolicyEvaluation: <10μs per operation
+//   - BenchmarkConditionEvaluation: <1ms per operation
+//   - BenchmarkFiftyPolicyEvaluation: <100μs per operation
+//   - BenchmarkAttributeResolution: <50μs per operation
+//   - BenchmarkWorstCase_NestedIf: <25ms per operation
+//   - BenchmarkWorstCase_AllPoliciesMatch: <10ms per operation
+package policy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/access/policy/audit"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// noopAuditWriter discards all audit entries for benchmarking.
+type noopAuditWriter struct{}
+
+func (n *noopAuditWriter) WriteSync(_ context.Context, _ audit.Entry) error { return nil }
+func (n *noopAuditWriter) WriteAsync(_ audit.Entry) error                   { return nil }
+func (n *noopAuditWriter) Close() error                                     { return nil }
+
+// noopSessionResolver always returns empty for benchmarking.
+type noopSessionResolver struct{}
+
+func (n *noopSessionResolver) ResolveSession(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+// benchAttributeProvider provides in-memory attributes for benchmarking.
+type benchAttributeProvider struct {
+	namespace string
+	attrs     map[string]any
+}
+
+func (p *benchAttributeProvider) Namespace() string {
+	return p.namespace
+}
+
+func (p *benchAttributeProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return p.attrs, nil
+}
+
+func (p *benchAttributeProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *benchAttributeProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"role":    types.AttrTypeString,
+			"level":   types.AttrTypeInt,
+			"banned":  types.AttrTypeBool,
+			"faction": types.AttrTypeString,
+			"muted":   types.AttrTypeBool,
+		},
+	}
+}
+
+// createBenchEngine creates an engine with in-memory dependencies for benchmarking.
+func createBenchEngine(b *testing.B, dslTexts []string, attrs map[string]any) *Engine {
+	b.Helper()
+
+	registry := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(registry)
+
+	provider := &benchAttributeProvider{
+		namespace: "character",
+		attrs:     attrs,
+	}
+	if err := resolver.RegisterProvider(provider); err != nil {
+		b.Fatal(err)
+	}
+
+	tmpDir := b.TempDir()
+	walPath := filepath.Join(tmpDir, "bench-wal.jsonl")
+	auditLogger := audit.NewLogger(audit.ModeAll, &noopAuditWriter{}, walPath)
+	b.Cleanup(func() {
+		_ = auditLogger.Close()
+		_ = os.Remove(walPath)
+	})
+
+	schema := types.NewAttributeSchema()
+	compiler := NewCompiler(schema)
+
+	policies := make([]CachedPolicy, 0, len(dslTexts))
+	for i, text := range dslTexts {
+		compiled, _, err := compiler.Compile(text)
+		if err != nil {
+			b.Fatalf("compile policy %d: %v", i, err)
+		}
+		policies = append(policies, CachedPolicy{
+			ID:       fmt.Sprintf("policy-%d", i+1),
+			Name:     fmt.Sprintf("bench-policy-%d", i+1),
+			Compiled: compiled,
+		})
+	}
+
+	cache := NewCache(nil, nil)
+	cache.mu.Lock()
+	cache.snapshot = &Snapshot{
+		Policies:  policies,
+		CreatedAt: time.Now(),
+	}
+	cache.mu.Unlock()
+	cache.lastUpdate.Store(time.Now().UnixNano())
+
+	engine := NewEngine(resolver, cache, &noopSessionResolver{}, auditLogger)
+	return engine
+}
+
+// generateBenchPolicies creates N policies alternating between permit and forbid.
+func generateBenchPolicies(count int) []string {
+	var policies []string
+	for i := 0; i < count; i++ {
+		effect := "permit"
+		if i%2 == 0 {
+			effect = "forbid"
+		}
+		policies = append(policies, fmt.Sprintf(
+			`%s(principal is character, action in ["say"], resource is location) when { principal.character.level > %d };`,
+			effect, i,
+		))
+	}
+	return policies
+}
+
+// generateNestedIfPolicy creates a policy with deeply nested if-then-else.
+func generateNestedIfPolicy(depth int) string {
+	dsl := `permit(principal is character, action in ["say"], resource is location) when { `
+
+	for i := 0; i < depth; i++ {
+		dsl += fmt.Sprintf("if principal.character.level > %d then ", i)
+	}
+
+	dsl += "true"
+
+	for i := 0; i < depth; i++ {
+		dsl += " else false"
+	}
+
+	dsl += " };"
+	return dsl
+}
+
+// BenchmarkSinglePolicyEvaluation benchmarks a single policy evaluation.
+// Target: <10μs
+func BenchmarkSinglePolicyEvaluation(b *testing.B) {
+	dslText := `permit(principal is character, action in ["say"], resource is location) when { principal.character.role == "admin" };`
+	attrs := map[string]any{"role": "admin", "level": 10}
+
+	engine := createBenchEngine(b, []string{dslText}, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkConditionEvaluation benchmarks a single policy with 3 conditions.
+// Target: <1ms per policy
+func BenchmarkConditionEvaluation(b *testing.B) {
+	dslText := `permit(principal is character, action in ["say"], resource is location) when {
+		principal.character.role == "admin" &&
+		principal.character.level > 5 &&
+		principal.character.banned == false
+	};`
+	attrs := map[string]any{
+		"role":   "admin",
+		"level":  10,
+		"banned": false,
+	}
+
+	engine := createBenchEngine(b, []string{dslText}, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFiftyPolicyEvaluation benchmarks 50 policies.
+// Target: <100μs
+func BenchmarkFiftyPolicyEvaluation(b *testing.B) {
+	policies := generateBenchPolicies(50)
+	attrs := map[string]any{"role": "admin", "level": 25}
+
+	engine := createBenchEngine(b, policies, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAttributeResolution benchmarks in-memory attribute resolution.
+// Target: <50μs
+func BenchmarkAttributeResolution(b *testing.B) {
+	attrs := map[string]any{
+		"role":    "admin",
+		"level":   10,
+		"banned":  false,
+		"faction": "rebels",
+		"muted":   false,
+		"score":   1000,
+		"rank":    "general",
+		"credits": 5000,
+		"karma":   50,
+		"xp":      10000,
+	}
+
+	registry := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(registry)
+
+	provider := &benchAttributeProvider{
+		namespace: "character",
+		attrs:     attrs,
+	}
+	if err := resolver.RegisterProvider(provider); err != nil {
+		b.Fatal(err)
+	}
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := resolver.Resolve(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWorstCase_NestedIf benchmarks deeply nested if-then-else (10 levels).
+// Target: <25ms
+func BenchmarkWorstCase_NestedIf(b *testing.B) {
+	dslText := generateNestedIfPolicy(10)
+	attrs := map[string]any{"level": 15}
+
+	engine := createBenchEngine(b, []string{dslText}, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWorstCase_AllPoliciesMatch benchmarks 50 policies all matching.
+// Target: <10ms
+func BenchmarkWorstCase_AllPoliciesMatch(b *testing.B) {
+	// All policies use level > 0, so with level=50 they all match
+	policies := generateBenchPolicies(50)
+	attrs := map[string]any{"level": 50}
+
+	engine := createBenchEngine(b, policies, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEvaluateEndToEnd benchmarks full Evaluate() with in-memory deps.
+func BenchmarkEvaluateEndToEnd(b *testing.B) {
+	policies := []string{
+		`permit(principal is character, action in ["say"], resource is location) when { principal.character.role == "admin" };`,
+		`permit(principal is character, action in ["say"], resource is location) when { principal.character.level > 5 };`,
+		`forbid(principal is character, action in ["say"], resource is location) when { principal.character.banned == true };`,
+	}
+	attrs := map[string]any{
+		"role":   "admin",
+		"level":  10,
+		"banned": false,
+	}
+
+	engine := createBenchEngine(b, policies, attrs)
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "say",
+		Resource: "location:01XYZ",
+	}
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		decision, err := engine.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !decision.IsAllowed() {
+			b.Fatal("expected allowed decision")
+		}
+	}
+}

--- a/internal/access/policy/engine_contract_test.go
+++ b/internal/access/policy/engine_contract_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// TestContract_MalformedSubjectPrefix verifies that subjects without the
+// expected "type:id" format are rejected with INVALID_ENTITY_REF error.
+func TestContract_MalformedSubjectPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"no colon separator", "invalid-no-colon"},
+		{"bare word", "character"},
+		{"trailing colon empty id", "character:"},
+		{"leading colon empty type", ":01ABC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+			req := types.AccessRequest{
+				Subject:  tt.subject,
+				Action:   "read",
+				Resource: "location:01XYZ",
+			}
+
+			_, err := engine.Evaluate(context.Background(), req)
+			require.Error(t, err, "malformed subject %q should return error", tt.subject)
+			errutil.AssertErrorCode(t, err, "INVALID_ENTITY_REF")
+		})
+	}
+}
+
+// TestContract_EmptyFields verifies that requests with empty strings in
+// subject, action, or resource fields are rejected with clear error codes.
+func TestContract_EmptyFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      types.AccessRequest
+		wantCode string
+	}{
+		{
+			name:     "empty subject",
+			req:      types.AccessRequest{Subject: "", Action: "read", Resource: "location:01XYZ"},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "empty action",
+			req:      types.AccessRequest{Subject: "character:01ABC", Action: "", Resource: "location:01XYZ"},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "empty resource",
+			req:      types.AccessRequest{Subject: "character:01ABC", Action: "read", Resource: ""},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "empty subject and action",
+			req:      types.AccessRequest{Subject: "", Action: "", Resource: "location:01XYZ"},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "all empty strings",
+			req:      types.AccessRequest{Subject: "", Action: "", Resource: ""},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "whitespace-only subject",
+			req:      types.AccessRequest{Subject: "   ", Action: "read", Resource: "location:01XYZ"},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "whitespace-only action",
+			req:      types.AccessRequest{Subject: "character:01ABC", Action: "  ", Resource: "location:01XYZ"},
+			wantCode: "INVALID_REQUEST",
+		},
+		{
+			name:     "whitespace-only resource",
+			req:      types.AccessRequest{Subject: "character:01ABC", Action: "read", Resource: "  "},
+			wantCode: "INVALID_REQUEST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+			_, err := engine.Evaluate(context.Background(), tt.req)
+			require.Error(t, err, "empty field should return error")
+			errutil.AssertErrorCode(t, err, tt.wantCode)
+		})
+	}
+}
+
+// TestContract_ZeroValueAccessRequest verifies that a zero-value
+// AccessRequest{} is rejected with INVALID_REQUEST error code.
+func TestContract_ZeroValueAccessRequest(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{} // all zero values
+
+	_, err := engine.Evaluate(context.Background(), req)
+	require.Error(t, err, "zero-value AccessRequest should return error")
+	errutil.AssertErrorCode(t, err, "INVALID_REQUEST")
+}
+
+// TestContract_ContextCancellation verifies that a cancelled context
+// returns context.Canceled error.
+func TestContract_ContextCancellation(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	_, err := engine.Evaluate(ctx, req)
+	require.Error(t, err, "cancelled context should return error")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestContract_EmptyPolicyCache verifies that when no policies are loaded,
+// evaluation returns EffectDefaultDeny without error.
+func TestContract_EmptyPolicyCache(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+	assert.False(t, decision.IsAllowed())
+	assert.Equal(t, "no applicable policies", decision.Reason)
+	assert.Empty(t, decision.PolicyID)
+}
+
+// TestContract_EmptyPolicyCache_AllSubjectTypes verifies default deny for
+// all valid subject type prefixes when no policies exist.
+func TestContract_EmptyPolicyCache_AllSubjectTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"character subject", "character:01ABC"},
+		{"plugin subject", "plugin:echo-bot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+			req := types.AccessRequest{
+				Subject:  tt.subject,
+				Action:   "read",
+				Resource: "location:01XYZ",
+			}
+
+			decision, err := engine.Evaluate(context.Background(), req)
+			require.NoError(t, err)
+
+			assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+			assert.False(t, decision.IsAllowed())
+		})
+	}
+}
+
+// TestContract_ErrorCodePreservation verifies that session resolution errors
+// with oops codes are preserved through the engine's error handling.
+func TestContract_ErrorCodePreservation(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionErr   error
+		wantReason   string
+		wantPolicyID string
+	}{
+		{
+			name:         "SESSION_INVALID code preserved",
+			sessionErr:   oops.Code("SESSION_INVALID").Errorf("session expired"),
+			wantReason:   "session invalid",
+			wantPolicyID: "infra:session-invalid",
+		},
+		{
+			name:         "SESSION_NOT_FOUND code preserved",
+			sessionErr:   oops.Code("SESSION_NOT_FOUND").Errorf("unknown session"),
+			wantReason:   "session store error",
+			wantPolicyID: "infra:session-store-error",
+		},
+		{
+			name:         "generic error without code",
+			sessionErr:   oops.Errorf("database timeout"),
+			wantReason:   "session store error",
+			wantPolicyID: "infra:session-store-error",
+		},
+		{
+			name:         "wrapped oops error preserves code",
+			sessionErr:   oops.Code("SESSION_INVALID").Wrapf(oops.Errorf("inner"), "outer"),
+			wantReason:   "session invalid",
+			wantPolicyID: "infra:session-invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &mockSessionResolver{
+				resolveFunc: func(_ context.Context, _ string) (string, error) {
+					return "", tt.sessionErr
+				},
+			}
+			engine, _ := createTestEngine(t, resolver)
+
+			req := types.AccessRequest{
+				Subject:  "session:test-session",
+				Action:   "read",
+				Resource: "location:01XYZ",
+			}
+
+			decision, err := engine.Evaluate(context.Background(), req)
+			require.NoError(t, err, "session errors should not propagate as engine errors")
+
+			assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+			assert.False(t, decision.IsAllowed())
+			assert.Equal(t, tt.wantReason, decision.Reason)
+			assert.Equal(t, tt.wantPolicyID, decision.PolicyID)
+		})
+	}
+}
+
+// TestContract_SystemBypass_SkipsValidation verifies that "system" subject
+// bypasses input validation and returns SystemBypass regardless of other fields.
+func TestContract_SystemBypass_SkipsValidation(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "system",
+		Action:   "", // would normally fail validation
+		Resource: "", // would normally fail validation
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectSystemBypass, decision.Effect)
+	assert.True(t, decision.IsAllowed())
+}
+
+// TestContract_ValidSubjectFormats verifies that well-formed subjects do
+// NOT return INVALID_ENTITY_REF errors.
+func TestContract_ValidSubjectFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"character ref", "character:01ABC"},
+		{"plugin ref", "plugin:echo-bot"},
+		{"system literal", "system"},
+		{"session ref", "session:web-123"},
+		{"multiple colons in id", "character:01ABC:extra"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &mockSessionResolver{
+				resolveFunc: func(_ context.Context, _ string) (string, error) {
+					return "01ABC", nil
+				},
+			}
+			engine, _ := createTestEngine(t, resolver)
+
+			req := types.AccessRequest{
+				Subject:  tt.subject,
+				Action:   "read",
+				Resource: "location:01XYZ",
+			}
+
+			_, err := engine.Evaluate(context.Background(), req)
+			require.NoError(t, err, "valid subject %q should not error", tt.subject)
+		})
+	}
+}

--- a/internal/access/policy/engine_test.go
+++ b/internal/access/policy/engine_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/access/policy/audit"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// mockSessionResolver is a test double for SessionResolver.
+type mockSessionResolver struct {
+	resolveFunc func(ctx context.Context, sessionID string) (string, error)
+}
+
+func (m *mockSessionResolver) ResolveSession(ctx context.Context, sessionID string) (string, error) {
+	if m.resolveFunc != nil {
+		return m.resolveFunc(ctx, sessionID)
+	}
+	return "", oops.Errorf("mock not configured")
+}
+
+// mockAuditWriter captures audit entries for testing.
+type mockAuditWriter struct {
+	entries []audit.Entry
+	mu      sync.Mutex
+}
+
+func (m *mockAuditWriter) WriteSync(_ context.Context, entry audit.Entry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *mockAuditWriter) WriteAsync(entry audit.Entry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *mockAuditWriter) Close() error {
+	return nil
+}
+
+func (m *mockAuditWriter) getEntries() []audit.Entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]audit.Entry, len(m.entries))
+	copy(result, m.entries)
+	return result
+}
+
+// createTestEngine creates an Engine with test doubles.
+func createTestEngine(t *testing.T, sessionResolver SessionResolver) (*Engine, *mockAuditWriter) {
+	t.Helper()
+
+	registry := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(registry)
+
+	mockWriter := &mockAuditWriter{}
+	walPath := filepath.Join(t.TempDir(), "test-wal.jsonl")
+	auditLogger := audit.NewLogger(audit.ModeAll, mockWriter, walPath)
+	t.Cleanup(func() {
+		_ = auditLogger.Close()
+	})
+
+	cache := NewCache(nil, nil) // Not used in steps 1-2
+
+	engine := NewEngine(resolver, cache, sessionResolver, auditLogger)
+	return engine, mockWriter
+}
+
+func TestEngine_SystemBypass(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "system",
+		Action:   "write",
+		Resource: "location:01ABC",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectSystemBypass, decision.Effect)
+	assert.True(t, decision.IsAllowed())
+	assert.Equal(t, "system bypass", decision.Reason)
+}
+
+func TestEngine_SystemBypass_ValidatesDecision(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "system",
+		Action:   "write",
+		Resource: "location:01ABC",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.NoError(t, decision.Validate())
+}
+
+func TestEngine_SystemBypass_Audited(t *testing.T) {
+	engine, mockWriter := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "system",
+		Action:   "write",
+		Resource: "location:01ABC",
+	}
+
+	_, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	entries := mockWriter.getEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "system", entries[0].Subject)
+	assert.Equal(t, "write", entries[0].Action)
+	assert.Equal(t, "location:01ABC", entries[0].Resource)
+	assert.Equal(t, types.EffectSystemBypass, entries[0].Effect)
+}
+
+func TestEngine_SessionResolved(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, sessionID string) (string, error) {
+			assert.Equal(t, "web-123", sessionID)
+			return "01ABC", nil
+		},
+	}
+	engine, _ := createTestEngine(t, resolver)
+
+	req := types.AccessRequest{
+		Subject:  "session:web-123",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	// Steps 3-6 not implemented yet, so we get placeholder
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+	assert.False(t, decision.IsAllowed())
+	assert.Equal(t, "evaluation pending", decision.Reason)
+}
+
+func TestEngine_SessionResolved_RewritesSubject(t *testing.T) {
+	var capturedRequest types.AccessRequest
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "01ABC", nil
+		},
+	}
+	engine, _ := createTestEngine(t, resolver)
+
+	// We need to capture the rewritten request. For now, we verify by checking
+	// that the session resolver was called with the correct session ID.
+	req := types.AccessRequest{
+		Subject:  "session:web-123",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	capturedRequest = req
+
+	_, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	// Original request unchanged (pass by value)
+	assert.Equal(t, "session:web-123", capturedRequest.Subject)
+}
+
+func TestEngine_SessionInvalid(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "", oops.Code("SESSION_INVALID").Errorf("session not found")
+		},
+	}
+	engine, _ := createTestEngine(t, resolver)
+
+	req := types.AccessRequest{
+		Subject:  "session:invalid-999",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+	assert.False(t, decision.IsAllowed())
+	assert.Equal(t, "session invalid", decision.Reason)
+	assert.Equal(t, "infra:session-invalid", decision.PolicyID)
+}
+
+func TestEngine_SessionStoreError(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "", oops.Errorf("database connection failed")
+		},
+	}
+	engine, _ := createTestEngine(t, resolver)
+
+	req := types.AccessRequest{
+		Subject:  "session:web-123",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+	assert.False(t, decision.IsAllowed())
+	assert.Equal(t, "session store error", decision.Reason)
+	assert.Equal(t, "infra:session-store-error", decision.PolicyID)
+}
+
+func TestEngine_NonSystemNonSession(t *testing.T) {
+	engine, _ := createTestEngine(t, &mockSessionResolver{})
+
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "location:01XYZ",
+	}
+
+	decision, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+	assert.False(t, decision.IsAllowed())
+	assert.Equal(t, "evaluation pending", decision.Reason)
+	assert.Equal(t, "", decision.PolicyID)
+}
+
+func TestEngine_AllDecisionsValidate(t *testing.T) {
+	tests := []struct {
+		name            string
+		subject         string
+		sessionResolver SessionResolver
+	}{
+		{
+			name:            "system bypass",
+			subject:         "system",
+			sessionResolver: &mockSessionResolver{},
+		},
+		{
+			name:    "session resolved",
+			subject: "session:web-123",
+			sessionResolver: &mockSessionResolver{
+				resolveFunc: func(_ context.Context, _ string) (string, error) {
+					return "01ABC", nil
+				},
+			},
+		},
+		{
+			name:    "session invalid",
+			subject: "session:invalid",
+			sessionResolver: &mockSessionResolver{
+				resolveFunc: func(_ context.Context, _ string) (string, error) {
+					return "", oops.Code("SESSION_INVALID").Errorf("not found")
+				},
+			},
+		},
+		{
+			name:    "session store error",
+			subject: "session:error",
+			sessionResolver: &mockSessionResolver{
+				resolveFunc: func(_ context.Context, _ string) (string, error) {
+					return "", oops.Errorf("store error")
+				},
+			},
+		},
+		{
+			name:            "non-system non-session",
+			subject:         "character:01ABC",
+			sessionResolver: &mockSessionResolver{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, _ := createTestEngine(t, tt.sessionResolver)
+
+			req := types.AccessRequest{
+				Subject:  tt.subject,
+				Action:   "read",
+				Resource: "location:01XYZ",
+			}
+
+			decision, err := engine.Evaluate(context.Background(), req)
+			require.NoError(t, err)
+
+			assert.NoError(t, decision.Validate(),
+				"decision with effect=%s should validate", decision.Effect)
+		})
+	}
+}
+
+func TestMockAuditWriter_ThreadSafety(t *testing.T) {
+	writer := &mockAuditWriter{}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			entry := audit.Entry{
+				Subject:  "test",
+				Action:   "read",
+				Resource: "test",
+				Effect:   types.EffectAllow,
+			}
+			if idx%2 == 0 {
+				_ = writer.WriteSync(ctx, entry)
+			} else {
+				_ = writer.WriteAsync(entry)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	entries := writer.getEntries()
+	assert.Len(t, entries, 100)
+}
+
+func TestEngine_AuditLoggerCleanup(t *testing.T) {
+	// Verify that audit logger is properly closed in cleanup
+	registry := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(registry)
+
+	mockWriter := &mockAuditWriter{}
+	tmpDir := t.TempDir()
+	walPath := filepath.Join(tmpDir, "test-wal.jsonl")
+	auditLogger := audit.NewLogger(audit.ModeAll, mockWriter, walPath)
+
+	cache := NewCache(nil, nil)
+	_ = NewEngine(resolver, cache, &mockSessionResolver{}, auditLogger)
+
+	// Trigger a write to create the WAL file
+	ctx := context.Background()
+	req := types.AccessRequest{
+		Subject:  "system",
+		Action:   "write",
+		Resource: "location:01ABC",
+	}
+	engine := NewEngine(resolver, cache, &mockSessionResolver{}, auditLogger)
+	_, _ = engine.Evaluate(ctx, req)
+
+	// Close the logger
+	err := auditLogger.Close()
+	require.NoError(t, err)
+
+	// Verify WAL directory exists (file may or may not exist depending on whether WAL was written)
+	_, err = os.Stat(tmpDir)
+	assert.NoError(t, err, "temp directory should exist")
+}

--- a/internal/access/policy/metrics.go
+++ b/internal/access/policy/metrics.go
@@ -41,10 +41,11 @@ var (
 	}, []string{"namespace", "error_type"})
 
 	// unregisteredAttributesCounter counts accesses to unregistered attributes.
-	// Not yet used - will be wired when attribute validation tracking is added.
+	// Superseded by abac_rejected_provider_attributes_total in the attribute package (S6).
+	// Kept for backward compatibility with existing dashboards.
 	unregisteredAttributesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "abac_unregistered_attributes_total",
-		Help: "Total number of accesses to unregistered attributes",
+		Help: "Total number of accesses to unregistered attributes (legacy, see abac_rejected_provider_attributes_total)",
 	}, []string{"namespace", "key"})
 
 	// circuitBreakerTripsCounter counts circuit breaker trips per provider.

--- a/internal/access/policy/metrics.go
+++ b/internal/access/policy/metrics.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics for ABAC policy evaluation.
+var (
+	// evaluateDuration tracks the latency of Evaluate() calls.
+	evaluateDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "abac_evaluate_duration_seconds",
+		Help:    "Histogram of ABAC policy evaluation latency in seconds",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	// policyEvaluations counts evaluations by source and effect.
+	policyEvaluations = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "abac_policy_evaluations_total",
+		Help: "Total number of ABAC policy evaluations",
+	}, []string{"source", "effect"})
+
+	// degradedModeGauge indicates if the engine is in degraded mode.
+	// Not yet used - will be wired in future tasks when degraded mode is implemented.
+	degradedModeGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "abac_degraded_mode",
+		Help: "ABAC degraded mode status (0=normal, 1=degraded)",
+	})
+
+	// providerErrorsCounter counts errors from attribute providers.
+	// Not yet used - will be wired when attribute provider error tracking is added.
+	providerErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "abac_provider_errors_total",
+		Help: "Total number of attribute provider errors",
+	}, []string{"namespace", "error_type"})
+
+	// unregisteredAttributesCounter counts accesses to unregistered attributes.
+	// Not yet used - will be wired when attribute validation tracking is added.
+	unregisteredAttributesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "abac_unregistered_attributes_total",
+		Help: "Total number of accesses to unregistered attributes",
+	}, []string{"namespace", "key"})
+
+	// circuitBreakerTripsCounter counts circuit breaker trips per provider.
+	// Not yet used - will be wired when circuit breaker is implemented.
+	circuitBreakerTripsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "abac_provider_circuit_breaker_trips_total",
+		Help: "Total number of circuit breaker trips for attribute providers",
+	}, []string{"provider"})
+)
+
+// RecordEvaluationMetrics records metrics for a completed evaluation.
+// This should be called after each Evaluate() call with the duration and effect.
+func RecordEvaluationMetrics(duration time.Duration, effect types.Effect) {
+	// Record histogram
+	evaluateDuration.Observe(duration.Seconds())
+
+	// Record counter with source=unknown until adapter layer adds policy source tracking
+	policyEvaluations.WithLabelValues("unknown", effect.String()).Inc()
+}
+
+func init() {
+	// Force evaluation of unused metrics to ensure they are registered with Prometheus.
+	// These metrics are defined for future use but not yet wired into the code.
+	_ = degradedModeGauge
+	_ = providerErrorsCounter
+	_ = unregisteredAttributesCounter
+	_ = circuitBreakerTripsCounter
+}

--- a/internal/access/policy/metrics_test.go
+++ b/internal/access/policy/metrics_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// TestMetrics_MetricsRegistered verifies all metric descriptors are registered.
+func TestMetrics_MetricsRegistered(t *testing.T) {
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	registered := make(map[string]bool)
+	for _, family := range families {
+		registered[family.GetName()] = true
+	}
+
+	expectedMetrics := []string{
+		"abac_evaluate_duration_seconds",
+		"abac_policy_evaluations_total",
+	}
+
+	for _, name := range expectedMetrics {
+		assert.True(t, registered[name], "metric %q should be registered", name)
+	}
+}
+
+// TestMetrics_RecordEvaluationMetrics verifies the helper function increments counters.
+func TestMetrics_RecordEvaluationMetrics(t *testing.T) {
+	initialCount := testutil.ToFloat64(policyEvaluations.WithLabelValues("unknown", "allow"))
+
+	RecordEvaluationMetrics(50*time.Millisecond, types.EffectAllow)
+
+	newCount := testutil.ToFloat64(policyEvaluations.WithLabelValues("unknown", "allow"))
+	assert.Equal(t, initialCount+1, newCount)
+}
+
+// TestMetrics_EvaluateDuration_Recorded verifies that engine.Evaluate() records metrics.
+func TestMetrics_EvaluateDuration_Recorded(t *testing.T) {
+	dslText := `permit(principal is character, action in ["read"], resource is location);`
+
+	engine := createTestEngineWithPolicies(t, []string{dslText}, []attribute.AttributeProvider{})
+
+	req := types.AccessRequest{
+		Subject:  "character:char-123",
+		Action:   "read",
+		Resource: "location:loc-456",
+	}
+	_, err := engine.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+
+	count := testutil.CollectAndCount(evaluateDuration)
+	assert.GreaterOrEqual(t, count, 1, "histogram should have at least one observation")
+}
+
+// TestMetrics_EffectLabels verifies different effects produce different counter labels.
+func TestMetrics_EffectLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		effect types.Effect
+		label  string
+	}{
+		{"allow", types.EffectAllow, "allow"},
+		{"deny", types.EffectDeny, "deny"},
+		{"default_deny", types.EffectDefaultDeny, "default_deny"},
+		{"system_bypass", types.EffectSystemBypass, "system_bypass"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := testutil.ToFloat64(policyEvaluations.WithLabelValues("unknown", tt.label))
+
+			RecordEvaluationMetrics(10*time.Millisecond, tt.effect)
+
+			updated := testutil.ToFloat64(policyEvaluations.WithLabelValues("unknown", tt.label))
+			assert.Equal(t, initial+1, updated)
+		})
+	}
+}

--- a/internal/access/policy/session_resolver.go
+++ b/internal/access/policy/session_resolver.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import "context"
+
+// SessionResolver resolves session: subjects to character: subjects.
+// Implementations query the session store to map session IDs to character IDs.
+type SessionResolver interface {
+	// ResolveSession returns the character ID associated with a session ID.
+	// Returns an error with code "SESSION_INVALID" if the session does not exist or is expired.
+	// Returns other errors for store/infrastructure failures.
+	ResolveSession(ctx context.Context, sessionID string) (characterID string, err error)
+}

--- a/internal/access/policy/session_resolver_test.go
+++ b/internal/access/policy/session_resolver_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestMockSessionResolver_Success(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "01ABC", nil
+		},
+	}
+
+	characterID, err := resolver.ResolveSession(context.Background(), "web-123")
+	require.NoError(t, err)
+	assert.Equal(t, "01ABC", characterID)
+}
+
+func TestMockSessionResolver_SessionInvalid(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "", oops.Code("SESSION_INVALID").Errorf("session not found")
+		},
+	}
+
+	characterID, err := resolver.ResolveSession(context.Background(), "invalid-999")
+	require.Error(t, err)
+	assert.Empty(t, characterID)
+
+	errutil.AssertErrorCode(t, err, "SESSION_INVALID")
+}
+
+func TestMockSessionResolver_GenericError(t *testing.T) {
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, _ string) (string, error) {
+			return "", oops.Errorf("database connection failed")
+		},
+	}
+
+	characterID, err := resolver.ResolveSession(context.Background(), "web-123")
+	require.Error(t, err)
+	assert.Empty(t, characterID)
+
+	// Should not have SESSION_INVALID code
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.NotEqual(t, "SESSION_INVALID", oopsErr.Code())
+}
+
+func TestMockSessionResolver_NotConfigured(t *testing.T) {
+	resolver := &mockSessionResolver{}
+
+	characterID, err := resolver.ResolveSession(context.Background(), "web-123")
+	require.Error(t, err)
+	assert.Empty(t, characterID)
+	assert.Contains(t, err.Error(), "mock not configured")
+}
+
+func TestMockSessionResolver_PassesThroughSessionID(t *testing.T) {
+	var capturedSessionID string
+	resolver := &mockSessionResolver{
+		resolveFunc: func(_ context.Context, sessionID string) (string, error) {
+			capturedSessionID = sessionID
+			return "01ABC", nil
+		},
+	}
+
+	_, err := resolver.ResolveSession(context.Background(), "web-999")
+	require.NoError(t, err)
+	assert.Equal(t, "web-999", capturedSessionID)
+}
+
+func TestMockSessionResolver_PassesThroughContext(t *testing.T) {
+	type ctxKey string
+	const testKey ctxKey = "test"
+
+	var capturedCtx context.Context
+	resolver := &mockSessionResolver{
+		resolveFunc: func(ctx context.Context, _ string) (string, error) {
+			capturedCtx = ctx
+			return "01ABC", nil
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), testKey, "test-value")
+	_, err := resolver.ResolveSession(ctx, "web-123")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-value", capturedCtx.Value(testKey))
+}

--- a/internal/access/static_test.go
+++ b/internal/access/static_test.go
@@ -81,15 +81,15 @@ func TestStaticAccessControl_RoleBasedAccess(t *testing.T) {
 	assert.True(t, ac.Check(ctx, "char:player1", "execute", "command:look"))
 
 	// Player cannot use builder commands
-	assert.False(t, ac.Check(ctx, "char:player1", "execute", "command:@dig"))
+	assert.False(t, ac.Check(ctx, "char:player1", "execute", "command:dig"))
 	assert.False(t, ac.Check(ctx, "char:player1", "write", "location:01ABC"))
 
 	// Builder can use builder commands
-	assert.True(t, ac.Check(ctx, "char:builder1", "execute", "command:@dig"))
+	assert.True(t, ac.Check(ctx, "char:builder1", "execute", "command:dig"))
 	assert.True(t, ac.Check(ctx, "char:builder1", "write", "location:01ABC"))
 
 	// Admin can do everything
-	assert.True(t, ac.Check(ctx, "char:admin1", "execute", "command:@dig"))
+	assert.True(t, ac.Check(ctx, "char:admin1", "execute", "command:dig"))
 	assert.True(t, ac.Check(ctx, "char:admin1", "grant", "anything"))
 	assert.True(t, ac.Check(ctx, "char:admin1", "delete", "world:everything"))
 }
@@ -149,7 +149,7 @@ func TestStaticAccessControl_SessionSubjects(t *testing.T) {
 	// Session subjects work like char subjects
 	require.NoError(t, ac.AssignRole("session:web-123", "player"))
 	assert.True(t, ac.Check(ctx, "session:web-123", "execute", "command:say"))
-	assert.False(t, ac.Check(ctx, "session:web-123", "execute", "command:@dig"))
+	assert.False(t, ac.Check(ctx, "session:web-123", "execute", "command:dig"))
 }
 
 func TestStaticAccessControl_ConcurrentAccess(t *testing.T) {

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -25,9 +25,9 @@ type subscriberHost struct {
 }
 
 func (h *subscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
-func (h *subscriberHost) Unload(context.Context, string) error                 { return nil }
-func (h *subscriberHost) Plugins() []string                                    { return []string{"test"} }
-func (h *subscriberHost) Close(context.Context) error                          { return nil }
+func (h *subscriberHost) Unload(context.Context, string) error                  { return nil }
+func (h *subscriberHost) Plugins() []string                                     { return []string{"test"} }
+func (h *subscriberHost) Close(context.Context) error                           { return nil }
 
 func (h *subscriberHost) DeliverEvent(_ context.Context, _ string, event pluginsdk.Event) ([]pluginsdk.EmitEvent, error) {
 	h.mu.Lock()
@@ -396,9 +396,9 @@ type slowSubscriberHost struct {
 }
 
 func (h *slowSubscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
-func (h *slowSubscriberHost) Unload(context.Context, string) error                 { return nil }
-func (h *slowSubscriberHost) Plugins() []string                                    { return []string{"test"} }
-func (h *slowSubscriberHost) Close(context.Context) error                          { return nil }
+func (h *slowSubscriberHost) Unload(context.Context, string) error                  { return nil }
+func (h *slowSubscriberHost) Plugins() []string                                     { return []string{"test"} }
+func (h *slowSubscriberHost) Close(context.Context) error                           { return nil }
 
 func (h *slowSubscriberHost) DeliverEvent(_ context.Context, _ string, event pluginsdk.Event) ([]pluginsdk.EmitEvent, error) {
 	<-h.blockCh // Block until closed

--- a/scripts/check-benchmark-regression.sh
+++ b/scripts/check-benchmark-regression.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Benchmark regression check script.
+# Runs Go benchmarks and compares results against baseline values.
+# Exits 1 if any benchmark exceeds 110% of its baseline.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/.benchmarks/baseline.txt"
+BENCH_PACKAGE="./internal/access/policy/"
+
+if [ ! -f "${BASELINE_FILE}" ]; then
+    echo "ERROR: Baseline file not found: ${BASELINE_FILE}"
+    exit 1
+fi
+
+# Parse baseline values into associative array.
+declare -A baselines
+while IFS= read -r line; do
+    # Skip comments and blank lines.
+    case "${line}" in
+        "#"*|"") continue ;;
+    esac
+    name=$(echo "${line}" | awk '{print $1}')
+    value=$(echo "${line}" | awk '{print $2}')
+    if [ -n "${name}" ] && [ -n "${value}" ]; then
+        baselines["${name}"]="${value}"
+    fi
+done < "${BASELINE_FILE}"
+
+if [ ${#baselines[@]} -eq 0 ]; then
+    echo "ERROR: No baselines loaded from ${BASELINE_FILE}"
+    exit 1
+fi
+
+echo "Loaded ${#baselines[@]} baseline(s) from ${BASELINE_FILE}"
+echo ""
+
+# Run benchmarks.
+echo "Running benchmarks (count=3, benchtime=1s)..."
+echo ""
+
+BENCH_OUTPUT=$(cd "${REPO_ROOT}" && go test \
+    -bench=. \
+    -benchmem \
+    -count=3 \
+    -benchtime=1s \
+    -run='^$' \
+    "${BENCH_PACKAGE}" 2>&1)
+
+echo "${BENCH_OUTPUT}"
+echo ""
+
+# Parse benchmark output and compute averages across runs.
+# Go bench output format: BenchmarkName-N    iterations    value ns/op
+declare -A totals
+declare -A counts
+
+while IFS= read -r line; do
+    # Match lines like: BenchmarkSinglePolicyEvaluation-10    123456    80.50 ns/op
+    if echo "${line}" | grep -qE '^Benchmark.*ns/op'; then
+        # Extract the benchmark base name (strip -N suffix).
+        bench_name=$(echo "${line}" | awk '{print $1}' | sed 's/-[0-9]*$//')
+        # Extract ns/op value (field before "ns/op").
+        ns_op=$(echo "${line}" | grep -oE '[0-9]+\.?[0-9]*[[:space:]]+ns/op' | awk '{print $1}')
+
+        if [ -n "${bench_name}" ] && [ -n "${ns_op}" ]; then
+            # Accumulate for averaging. Use awk for floating-point addition.
+            prev="${totals[${bench_name}]:-0}"
+            totals["${bench_name}"]=$(awk "BEGIN {printf \"%.2f\", ${prev} + ${ns_op}}")
+            prev_count="${counts[${bench_name}]:-0}"
+            counts["${bench_name}"]=$((prev_count + 1))
+        fi
+    fi
+done <<< "${BENCH_OUTPUT}"
+
+if [ ${#totals[@]} -eq 0 ]; then
+    echo "ERROR: No benchmark results parsed from output"
+    exit 1
+fi
+
+# Compare against baselines.
+failures=0
+passed=0
+
+# Print summary header.
+printf "\n%-45s %12s %12s %12s %8s\n" "BENCHMARK" "BASELINE" "ACTUAL" "THRESHOLD" "STATUS"
+printf "%-45s %12s %12s %12s %8s\n" "$(printf '%0.s-' {1..45})" "$(printf '%0.s-' {1..12})" "$(printf '%0.s-' {1..12})" "$(printf '%0.s-' {1..12})" "$(printf '%0.s-' {1..8})"
+
+for bench_name in "${!baselines[@]}"; do
+    baseline_ns="${baselines[${bench_name}]}"
+    threshold=$(awk "BEGIN {printf \"%.0f\", ${baseline_ns} * 1.1}")
+
+    if [ -z "${totals[${bench_name}]:-}" ]; then
+        printf "%-45s %12s %12s %12s %8s\n" "${bench_name}" "${baseline_ns}" "MISSING" "${threshold}" "SKIP"
+        echo "  WARNING: Benchmark ${bench_name} not found in results"
+        continue
+    fi
+
+    total="${totals[${bench_name}]}"
+    count="${counts[${bench_name}]}"
+    avg=$(awk "BEGIN {printf \"%.0f\", ${total} / ${count}}")
+
+    # Check if average exceeds 110% of baseline.
+    exceeded=$(awk "BEGIN {print (${avg} > ${threshold}) ? 1 : 0}")
+
+    if [ "${exceeded}" -eq 1 ]; then
+        status="FAIL"
+        failures=$((failures + 1))
+    else
+        status="PASS"
+        passed=$((passed + 1))
+    fi
+
+    printf "%-45s %10s ns %10s ns %10s ns %8s\n" "${bench_name}" "${baseline_ns}" "${avg}" "${threshold}" "${status}"
+done
+
+echo ""
+echo "Results: ${passed} passed, ${failures} failed"
+
+if [ ${failures} -gt 0 ]; then
+    echo ""
+    echo "FAILED: ${failures} benchmark(s) exceeded 110% of baseline"
+    exit 1
+fi
+
+echo ""
+echo "All benchmarks within acceptable thresholds."
+exit 0

--- a/scripts/check-benchmark-regression.sh
+++ b/scripts/check-benchmark-regression.sh
@@ -43,13 +43,10 @@ echo ""
 echo "Running benchmarks (count=3, benchtime=1s)..."
 echo ""
 
-BENCH_OUTPUT=$(cd "${REPO_ROOT}" && go test \
-    -bench=. \
-    -benchmem \
-    -count=3 \
-    -benchtime=1s \
-    -run='^$' \
-    "${BENCH_PACKAGE}" 2>&1)
+BENCH_OUTPUT=$(cd "${REPO_ROOT}" && task test:bench \
+    BENCH_COUNT=3 \
+    BENCH_TIME=1s \
+    BENCH_PACKAGE="${BENCH_PACKAGE}" 2>&1)
 
 echo "${BENCH_OUTPUT}"
 echo ""


### PR DESCRIPTION
## Summary

Phase 7.3 implements the core ABAC policy engine and attribute provider infrastructure:

- **Attribute providers** — schema registry, resolver with per-request caching, 8 providers (character, location, object, environment, command, stream, exit, scene)
- **Property provider** — recursive CTE-based property resolution
- **Policy engine** — full 7-step evaluation: system bypass, session resolution, attribute resolution, target matching, DSL condition evaluation, deny-overrides combination, audit logging
- **Policy cache** — snapshot-based with LISTEN/NOTIFY invalidation support
- **Audit logger** — WAL-based with sync/async modes, PostgreSQL writer, retention management
- **Prometheus metrics** — evaluation latency histograms, effect counters
- **Performance benchmarks** — 7 benchmarks with documented targets
- **CI benchmark enforcement** — regression detection at 110% threshold via GitHub Actions
- **Contract tests** — API-boundary edge case validation (input validation, error codes, context cancellation)

Implements tasks T13–T21b from the [Phase 7.3 plan](docs/plans/2026-02-06-full-abac-phase-7.3.md), plus T7b (deferred contract tests from Phase 7.1).

## Commits (9 total, will be squash-merged)

1. Wave 1: Providers, cache, audit, command cleanup (T13, T16a, T18, T19, T21a)
2. Wave 2: Attribute resolver, providers, retention (T14, T15, T19b)
3. Wave 3: Property provider, engine scaffold, session resolver (T16b, T17.1)
4. Wave 4: Target matching and policy filtering (T17.2)
5. Wave 5: DSL condition evaluation (T17.3)
6. Wave 6: Deny-overrides combination and audit logging (T17.4)
7. Wave 7: Prometheus metrics and performance benchmarks (T20, T21)
8. T7b: AccessPolicyEngine contract tests + input validation
9. T21b: CI benchmark regression enforcement

## Test plan

- [x] All 32 packages pass (`task test`)
- [x] All linters pass (`task lint`)
- [x] Benchmarks pass with wide margin under documented targets
- [x] CI benchmark regression script verified locally
- [ ] CI pipeline passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)