### PR TITLE
feat(access): ABAC Phase 7.4 — Seed Policies & Bootstrap

### DIFF
--- a/cmd/holomush/automigrate_test.go
+++ b/cmd/holomush/automigrate_test.go
@@ -74,6 +74,7 @@ func TestAutoMigrate_RunsByDefault(t *testing.T) {
 		AutoMigrateGetter: func() bool {
 			return true // Default behavior
 		},
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cfg := &coreConfig{
@@ -131,6 +132,7 @@ func TestAutoMigrate_DisabledWhenEnvVarFalse(t *testing.T) {
 		AutoMigrateGetter: func() bool {
 			return false // Explicitly disabled
 		},
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cfg := &coreConfig{

--- a/cmd/holomush/deps.go
+++ b/cmd/holomush/deps.go
@@ -59,6 +59,12 @@ type CoreDeps struct {
 	// AutoMigrateGetter returns whether auto-migration is enabled.
 	// Default: parseAutoMigrate (reads HOLOMUSH_DB_AUTO_MIGRATE env var)
 	AutoMigrateGetter func() bool
+
+	// PolicyBootstrapper seeds policies and creates audit log partitions.
+	// Default: extracts pool from event store, runs policy.Bootstrap().
+	// Fatal if nil and event store does not expose a connection pool (ADR #92).
+	// Tests MUST set this to a no-op to avoid requiring a real database.
+	PolicyBootstrapper func(ctx context.Context, skipSeedMigrations bool) error
 }
 
 // GatewayDeps contains injectable dependencies for the gateway command.

--- a/cmd/holomush/deps_test.go
+++ b/cmd/holomush/deps_test.go
@@ -140,6 +140,11 @@ func disableAutoMigrate() bool {
 	return false
 }
 
+// noOpBootstrapper skips seed policy bootstrap in tests.
+func noOpBootstrapper(_ context.Context, _ bool) error {
+	return nil
+}
+
 // mockListener implements net.Listener for testing.
 type mockListener struct {
 	acceptFunc func() (net.Conn, error)
@@ -259,7 +264,8 @@ func TestRunCoreWithDeps_HappyPath(t *testing.T) {
 			return "postgres://test:test@localhost/test"
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -335,7 +341,8 @@ func TestRunCoreWithDeps_EventStoreFactoryError(t *testing.T) {
 			return nil, fmt.Errorf("connection refused")
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -366,7 +373,8 @@ func TestRunCoreWithDeps_InitGameIDError(t *testing.T) {
 			}, nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -398,7 +406,8 @@ func TestRunCoreWithDeps_CertsDirError(t *testing.T) {
 			return &mockEventStore{}, nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -433,7 +442,8 @@ func TestRunCoreWithDeps_TLSCertError(t *testing.T) {
 			return nil, fmt.Errorf("failed to load TLS certificates")
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -471,7 +481,8 @@ func TestRunCoreWithDeps_ControlTLSLoadError(t *testing.T) {
 			return testTLSConfig(), nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -512,7 +523,8 @@ func TestRunCoreWithDeps_ControlServerFactoryError(t *testing.T) {
 			return testTLSConfig(), nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -557,7 +569,8 @@ func TestRunCoreWithDeps_ControlServerStartError(t *testing.T) {
 			return testTLSConfig(), nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -611,7 +624,8 @@ func TestRunCoreWithDeps_ObservabilityServerStartError(t *testing.T) {
 			return testTLSConfig(), nil
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()
@@ -1088,7 +1102,8 @@ func TestRunCoreWithDeps_WithObservability(t *testing.T) {
 			return "postgres://test:test@localhost/test"
 		},
 		MigratorFactory:   noOpMigratorFactory,
-		AutoMigrateGetter: disableAutoMigrate,
+		AutoMigrateGetter:  disableAutoMigrate,
+		PolicyBootstrapper: noOpBootstrapper,
 	}
 
 	cmd := newMockCmd()

--- a/cmd/holomush/root.go
+++ b/cmd/holomush/root.go
@@ -28,6 +28,7 @@ WebAssembly plugins, and dual protocol support (telnet + web).`,
 	cmd.AddCommand(NewMigrateCmd())
 	cmd.AddCommand(NewSeedCmd())
 	cmd.AddCommand(NewStatusCmd())
+	cmd.AddCommand(NewValidateSeedsCmd())
 
 	return cmd
 }

--- a/cmd/holomush/validate_seeds.go
+++ b/cmd/holomush/validate_seeds.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+
+	"github.com/holomush/holomush/internal/access/policy"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// NewValidateSeedsCmd creates the validate-seeds subcommand.
+func NewValidateSeedsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate-seeds",
+		Short: "Validate all seed policy DSL without starting the server",
+		Long: `Validates all seed policy DSL text using the compiler.
+Does NOT start the server or require a database connection.
+Exits with code 0 on success, non-zero on failure.
+
+Useful in CI pipelines to catch seed policy errors early:
+  holomush validate-seeds`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runValidateSeeds()
+		},
+	}
+}
+
+func runValidateSeeds() error {
+	seeds := policy.SeedPolicies()
+	schema := types.NewAttributeSchema()
+	compiler := policy.NewCompiler(schema)
+
+	var errors []string
+	for _, seed := range seeds {
+		_, _, err := compiler.Compile(seed.DSLText)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("  %s: %v", seed.Name, err))
+		}
+	}
+
+	if len(errors) > 0 {
+		for _, e := range errors {
+			slog.Error("seed validation failed", "detail", e)
+		}
+		return fmt.Errorf("validation failed: %d of %d seed policies invalid", len(errors), len(seeds))
+	}
+
+	slog.Info("all seed policies valid", "count", len(seeds))
+	return nil
+}

--- a/cmd/holomush/validate_seeds_test.go
+++ b/cmd/holomush/validate_seeds_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSeedsCommand_Help(t *testing.T) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"validate-seeds", "--help"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "Validate")
+	assert.Contains(t, output, "seed policy")
+}
+
+func TestValidateSeedsCommand_SucceedsWithValidSeeds(t *testing.T) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(errBuf)
+	cmd.SetArgs([]string{"validate-seeds"})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "validate-seeds should succeed with valid seed policies")
+}
+
+func TestValidateSeedsCommand_DoesNotStartServer(t *testing.T) {
+	// validate-seeds should exit immediately without needing DATABASE_URL or network
+	t.Setenv("DATABASE_URL", "")
+
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"validate-seeds"})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "validate-seeds should work without DATABASE_URL")
+}
+
+func TestValidateSeedsCommand_InRootHelp(t *testing.T) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--help"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "validate-seeds", "Root help should list validate-seeds command")
+}
+
+func TestRunValidateSeeds_AllSeedsValid(t *testing.T) {
+	err := runValidateSeeds()
+	require.NoError(t, err, "all built-in seed policies should compile successfully")
+}

--- a/docs/specs/decisions/epic7/phase-7.4/112-fully-qualified-attribute-paths-in-seed-dsl.md
+++ b/docs/specs/decisions/epic7/phase-7.4/112-fully-qualified-attribute-paths-in-seed-dsl.md
@@ -1,0 +1,43 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# 112. Fully-Qualified Attribute Paths in Seed DSL
+
+> [Back to Decision Index](../README.md)
+
+**Question:** Should seed policy DSL use shorthand attribute paths (e.g.,
+`resource.id`, `principal.role`) as shown in spec `07-migration-seeds.md`
+examples, or fully-qualified paths matching the attribute resolver's storage
+format (e.g., `resource.character.id`, `principal.character.role`)?
+
+**Context:** The `07-migration-seeds.md` spec (version 1) illustrates seed
+policies with shorthand attribute paths like `resource.id` and `principal.role`.
+During Phase 7.3 implementation (attribute resolvers and providers), each
+provider stores attributes under a namespace reflecting the entity type:
+
+- `principal.character.role` (not `principal.role`)
+- `resource.location.id` (not `resource.id`)
+- `resource.object.location` (not `resource.location`)
+- `resource.property.visibility` (not `resource.visibility`)
+
+The DSL compiler resolves attribute references against the actual attribute
+schema, which requires the fully-qualified paths. Shorthand paths would fail
+compilation because no provider registers attributes at those paths.
+
+**Decision:** Seed policy DSL uses fully-qualified attribute paths matching the
+resolver storage format. The spec `07-migration-seeds.md` examples represent a
+v1 draft that predates the provider implementation; the implementation is
+authoritative.
+
+**Rationale:**
+
+- **Correctness:** The compiler validates attribute paths against the schema.
+  Shorthand paths are not registered and would fail validation.
+- **Consistency:** All attribute references in the system use the same
+  fully-qualified format — providers, resolvers, policies, and audit logs.
+- **Clarity:** Fully-qualified paths are unambiguous. `resource.id` could refer
+  to a character ID, location ID, or object ID; `resource.character.id` is
+  explicit.
+- **No runtime resolution layer:** Adding a shorthand-to-qualified path
+  translation would add complexity without benefit, since the entity type is
+  already declared in the policy target (`resource is character`).

--- a/internal/access/policy/attribute/character.go
+++ b/internal/access/policy/attribute/character.go
@@ -86,14 +86,18 @@ func (p *CharacterProvider) resolve(ctx context.Context, entityID string) (map[s
 		"player_id":   char.PlayerID.String(),
 		"name":        char.Name,
 		"description": char.Description,
+		"role":        "player", // TODO: resolve from DB when role column is added
 	}
 
-	// Handle optional location
+	// Handle optional location — expose as both "location_id" (raw) and "location" (for seed policies)
 	if char.LocationID != nil {
-		attrs["location_id"] = char.LocationID.String()
+		locStr := char.LocationID.String()
+		attrs["location_id"] = locStr
+		attrs["location"] = locStr
 		attrs["has_location"] = true
 	} else {
 		attrs["location_id"] = ""
+		attrs["location"] = ""
 		attrs["has_location"] = false
 	}
 
@@ -108,7 +112,9 @@ func (p *CharacterProvider) Schema() *types.NamespaceSchema {
 			"player_id":    types.AttrTypeString,
 			"name":         types.AttrTypeString,
 			"description":  types.AttrTypeString,
+			"role":         types.AttrTypeString,
 			"location_id":  types.AttrTypeString,
+			"location":     types.AttrTypeString,
 			"has_location": types.AttrTypeBool,
 		},
 	}

--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -72,7 +72,9 @@ func TestCharacterProvider_Schema(t *testing.T) {
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["player_id"])
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["name"])
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["description"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["role"])
 	assert.Equal(t, types.AttrTypeString, schema.Attributes["location_id"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["location"])
 	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_location"])
 }
 
@@ -112,7 +114,9 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 				"player_id":    playerID.String(),
 				"name":         "TestChar",
 				"description":  "A test character",
+				"role":         "player",
 				"location_id":  locationID.String(),
+				"location":     locationID.String(),
 				"has_location": true,
 			},
 		},
@@ -136,7 +140,9 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 				"player_id":    playerID.String(),
 				"name":         "NoLocChar",
 				"description":  "",
+				"role":         "player",
 				"location_id":  "",
+				"location":     "",
 				"has_location": false,
 			},
 		},
@@ -245,7 +251,9 @@ func TestCharacterProvider_ResolveResource(t *testing.T) {
 				"player_id":    playerID.String(),
 				"name":         "ResourceChar",
 				"description":  "Character as resource",
+				"role":         "player",
 				"location_id":  locationID.String(),
+				"location":     locationID.String(),
 				"has_location": true,
 			},
 		},

--- a/internal/access/policy/audit/partition_creator.go
+++ b/internal/access/policy/audit/partition_creator.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/samber/oops"
+)
+
+// PostgresPartitionCreator creates monthly audit log partitions.
+// It implements policy.BootstrapPartitionCreator.
+type PostgresPartitionCreator struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresPartitionCreator creates a partition creator backed by the given pool.
+func NewPostgresPartitionCreator(pool *pgxpool.Pool) *PostgresPartitionCreator {
+	return &PostgresPartitionCreator{pool: pool}
+}
+
+// EnsurePartitions creates monthly partitions for the current month plus the
+// specified number of future months. Uses IF NOT EXISTS for idempotency.
+// Partition naming follows spec convention: access_audit_log_YYYY_MM.
+func (c *PostgresPartitionCreator) EnsurePartitions(ctx context.Context, months int) error {
+	now := time.Now().UTC()
+	for i := 0; i < months; i++ {
+		t := now.AddDate(0, i, 0)
+		name, start, end := partitionRange(t)
+
+		query := fmt.Sprintf(
+			`CREATE TABLE IF NOT EXISTS %s PARTITION OF access_audit_log FOR VALUES FROM ('%s') TO ('%s')`,
+			name,
+			start.Format("2006-01-02"),
+			end.Format("2006-01-02"),
+		)
+
+		if _, err := c.pool.Exec(ctx, query); err != nil {
+			return oops.
+				With("partition", name).
+				With("range_start", start.Format("2006-01-02")).
+				With("range_end", end.Format("2006-01-02")).
+				Errorf("creating partition: %w", err)
+		}
+	}
+	return nil
+}
+
+// partitionRange returns the partition name and date boundaries for the month
+// containing t. Start is inclusive, end is exclusive (first day of next month).
+func partitionRange(t time.Time) (name string, start, end time.Time) {
+	start = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end = start.AddDate(0, 1, 0)
+	name = fmt.Sprintf("access_audit_log_%04d_%02d", t.Year(), t.Month())
+	return name, start, end
+}

--- a/internal/access/policy/audit/partition_creator_test.go
+++ b/internal/access/policy/audit/partition_creator_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartitionRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     time.Time
+		wantName  string
+		wantStart string
+		wantEnd   string
+	}{
+		{
+			name:      "february 2026",
+			input:     time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+			wantName:  "access_audit_log_2026_02",
+			wantStart: "2026-02-01",
+			wantEnd:   "2026-03-01",
+		},
+		{
+			name:      "december wraps to next year",
+			input:     time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC),
+			wantName:  "access_audit_log_2026_12",
+			wantStart: "2026-12-01",
+			wantEnd:   "2027-01-01",
+		},
+		{
+			name:      "january",
+			input:     time.Date(2027, 1, 31, 23, 59, 59, 0, time.UTC),
+			wantName:  "access_audit_log_2027_01",
+			wantStart: "2027-01-01",
+			wantEnd:   "2027-02-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, start, end := partitionRange(tt.input)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantStart, start.Format("2006-01-02"))
+			assert.Equal(t, tt.wantEnd, end.Format("2006-01-02"))
+		})
+	}
+}

--- a/internal/access/policy/bootstrap.go
+++ b/internal/access/policy/bootstrap.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/store"
+)
+
+// BootstrapPartitionCreator is the subset of audit.PartitionManager needed by bootstrap.
+type BootstrapPartitionCreator interface {
+	EnsurePartitions(ctx context.Context, months int) error
+}
+
+// BootstrapOptions configures bootstrap behavior.
+type BootstrapOptions struct {
+	SkipSeedMigrations bool // Disable automatic seed version upgrades
+}
+
+// Bootstrap seeds the policy store with default policies and creates initial
+// audit log partitions. Failures are fatal — any error MUST cause the server
+// to abort startup (ADR #92).
+func Bootstrap(
+	ctx context.Context,
+	partitions BootstrapPartitionCreator,
+	policyStore store.PolicyStore,
+	compiler *Compiler,
+	logger *slog.Logger,
+	opts BootstrapOptions,
+) error {
+	// Step 1: Create initial audit log partitions (ADR #91).
+	// This must happen before seed insertion so audit log writes succeed.
+	if err := partitions.EnsurePartitions(ctx, 3); err != nil {
+		return oops.Errorf("bootstrap: failed to create audit log partitions: %w", err)
+	}
+	logger.Info("audit log partitions ensured", "months", 3)
+
+	// Step 2: Seed policies.
+	seeds := SeedPolicies()
+	for _, seed := range seeds {
+		if err := bootstrapSeed(ctx, policyStore, compiler, logger, seed, opts); err != nil {
+			return oops.
+				With("seed", seed.Name).
+				Errorf("bootstrap: fatal seed policy error: %w", err)
+		}
+	}
+
+	logger.Info("bootstrap complete", "seeds_total", len(seeds))
+	return nil
+}
+
+// bootstrapSeed handles a single seed policy: insert if new, upgrade if outdated,
+// skip if already current or admin-customized.
+func bootstrapSeed(
+	ctx context.Context,
+	policyStore store.PolicyStore,
+	compiler *Compiler,
+	logger *slog.Logger,
+	seed SeedPolicy,
+	opts BootstrapOptions,
+) error {
+	existing, err := policyStore.Get(ctx, seed.Name)
+	if err != nil && !store.IsNotFound(err) {
+		return fmt.Errorf("checking existing policy %q: %w", seed.Name, err)
+	}
+
+	// Policy doesn't exist — compile and create.
+	if store.IsNotFound(err) {
+		return createSeedPolicy(ctx, policyStore, compiler, logger, seed)
+	}
+
+	// Policy exists with different source — admin collision, skip with warning.
+	if existing.Source != "seed" {
+		logger.Warn("seed policy name collision with non-seed policy, skipping",
+			"name", seed.Name,
+			"existing_source", existing.Source,
+		)
+		return nil
+	}
+
+	// Policy exists as seed — check for version upgrade.
+	if !opts.SkipSeedMigrations && existing.SeedVersion != nil && *existing.SeedVersion < seed.SeedVersion {
+		return upgradeSeedPolicy(ctx, policyStore, compiler, logger, seed, existing)
+	}
+
+	logger.Info("seed policy already current, skipping",
+		"name", seed.Name,
+		"version", seed.SeedVersion,
+	)
+	return nil
+}
+
+// createSeedPolicy compiles and inserts a new seed policy.
+func createSeedPolicy(
+	ctx context.Context,
+	policyStore store.PolicyStore,
+	compiler *Compiler,
+	logger *slog.Logger,
+	seed SeedPolicy,
+) error {
+	compiled, _, err := compiler.Compile(seed.DSLText)
+	if err != nil {
+		return fmt.Errorf("compiling seed policy %q: %w", seed.Name, err)
+	}
+
+	astJSON, err := json.Marshal(compiled)
+	if err != nil {
+		return fmt.Errorf("marshaling compiled AST for %q: %w", seed.Name, err)
+	}
+
+	seedVersion := seed.SeedVersion
+	sp := &store.StoredPolicy{
+		Name:        seed.Name,
+		Description: seed.Description,
+		Effect:      compiled.Effect,
+		Source:      "seed",
+		DSLText:     seed.DSLText,
+		CompiledAST: astJSON,
+		Enabled:     true,
+		SeedVersion: &seedVersion,
+		CreatedBy:   "system",
+	}
+
+	if err := policyStore.Create(ctx, sp); err != nil {
+		return fmt.Errorf("creating seed policy %q: %w", seed.Name, err)
+	}
+
+	logger.Info("seed policy created", "name", seed.Name, "version", seed.SeedVersion)
+	return nil
+}
+
+// upgradeSeedPolicy updates an existing seed policy to a new version.
+func upgradeSeedPolicy(
+	ctx context.Context,
+	policyStore store.PolicyStore,
+	compiler *Compiler,
+	logger *slog.Logger,
+	seed SeedPolicy,
+	existing *store.StoredPolicy,
+) error {
+	compiled, _, err := compiler.Compile(seed.DSLText)
+	if err != nil {
+		return fmt.Errorf("compiling upgraded seed policy %q: %w", seed.Name, err)
+	}
+
+	astJSON, err := json.Marshal(compiled)
+	if err != nil {
+		return fmt.Errorf("marshaling compiled AST for %q: %w", seed.Name, err)
+	}
+
+	oldVersion := 0
+	if existing.SeedVersion != nil {
+		oldVersion = *existing.SeedVersion
+	}
+
+	seedVersion := seed.SeedVersion
+	existing.DSLText = seed.DSLText
+	existing.CompiledAST = astJSON
+	existing.Effect = compiled.Effect
+	existing.SeedVersion = &seedVersion
+	existing.ChangeNote = fmt.Sprintf("Auto-upgraded from seed v%d to v%d on server upgrade",
+		oldVersion, seed.SeedVersion)
+
+	if err := policyStore.Update(ctx, existing); err != nil {
+		return fmt.Errorf("upgrading seed policy %q: %w", seed.Name, err)
+	}
+
+	logger.Info("seed policy upgraded",
+		"name", seed.Name,
+		"from_version", oldVersion,
+		"to_version", seed.SeedVersion,
+	)
+	return nil
+}
+
+// UpdateSeed updates a seed policy's DSL text as part of a migration-delivered fix.
+// It uses compare-and-swap semantics: oldDSL must match the stored DSL for the
+// update to proceed. If the stored DSL differs from oldDSL, the seed has been
+// customized by an admin and the update is skipped with a warning.
+func UpdateSeed(
+	ctx context.Context,
+	policyStore store.PolicyStore,
+	compiler *Compiler,
+	logger *slog.Logger,
+	name string,
+	oldDSL string,
+	newDSL string,
+	changeNote string,
+) error {
+	existing, err := policyStore.Get(ctx, name)
+	if err != nil {
+		return fmt.Errorf("UpdateSeed: policy %q not found: %w", name, err)
+	}
+
+	if existing.Source != "seed" {
+		return fmt.Errorf("UpdateSeed: policy %q has source %q, not seed", name, existing.Source)
+	}
+
+	// Idempotent: skip if DSL already matches target.
+	if existing.DSLText == newDSL {
+		return nil
+	}
+
+	// Compare-and-swap: skip with warning if admin customized.
+	if existing.DSLText != oldDSL {
+		logger.Warn("seed policy customized by admin, skipping migration update",
+			"name", name,
+			"expected_dsl_prefix", truncate(oldDSL, 60),
+			"actual_dsl_prefix", truncate(existing.DSLText, 60),
+		)
+		return nil
+	}
+
+	// Compile the new DSL.
+	compiled, _, compileErr := compiler.Compile(newDSL)
+	if compileErr != nil {
+		return fmt.Errorf("UpdateSeed: compiling new DSL for %q: %w", name, compileErr)
+	}
+
+	astJSON, marshalErr := json.Marshal(compiled)
+	if marshalErr != nil {
+		return fmt.Errorf("UpdateSeed: marshaling AST for %q: %w", name, marshalErr)
+	}
+
+	existing.DSLText = newDSL
+	existing.CompiledAST = astJSON
+	existing.Effect = compiled.Effect
+	existing.ChangeNote = changeNote
+
+	if err := policyStore.Update(ctx, existing); err != nil {
+		return fmt.Errorf("UpdateSeed: updating %q: %w", name, err)
+	}
+
+	logger.Info("seed policy updated via migration", "name", name, "change_note", changeNote)
+	return nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/access/policy/bootstrap_test.go
+++ b/internal/access/policy/bootstrap_test.go
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/store"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// --- Test helpers ---
+
+type bootstrapMockStore struct {
+	policies  map[string]*store.StoredPolicy
+	created   []*store.StoredPolicy
+	updated   []*store.StoredPolicy
+	createErr error
+	updateErr error
+}
+
+func newBootstrapMockStore() *bootstrapMockStore {
+	return &bootstrapMockStore{
+		policies: make(map[string]*store.StoredPolicy),
+	}
+}
+
+func (m *bootstrapMockStore) Get(_ context.Context, name string) (*store.StoredPolicy, error) {
+	if p, ok := m.policies[name]; ok {
+		return p, nil
+	}
+	return nil, oops.Code("POLICY_NOT_FOUND").With("name", name).Errorf("policy not found")
+}
+
+func (m *bootstrapMockStore) GetByID(_ context.Context, _ string) (*store.StoredPolicy, error) {
+	return nil, nil
+}
+
+func (m *bootstrapMockStore) Create(_ context.Context, p *store.StoredPolicy) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = append(m.created, p)
+	m.policies[p.Name] = p
+	return nil
+}
+
+func (m *bootstrapMockStore) Update(_ context.Context, p *store.StoredPolicy) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = append(m.updated, p)
+	m.policies[p.Name] = p
+	return nil
+}
+
+func (m *bootstrapMockStore) Delete(_ context.Context, _ string) error { return nil }
+
+func (m *bootstrapMockStore) ListEnabled(_ context.Context) ([]*store.StoredPolicy, error) {
+	var result []*store.StoredPolicy
+	for _, p := range m.policies {
+		if p.Enabled {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+func (m *bootstrapMockStore) List(_ context.Context, _ store.ListOptions) ([]*store.StoredPolicy, error) {
+	return nil, nil
+}
+
+type mockPartitionManager struct {
+	called bool
+	months int
+	err    error
+}
+
+func (m *mockPartitionManager) EnsurePartitions(_ context.Context, months int) error {
+	m.called = true
+	m.months = months
+	return m.err
+}
+
+type logCapture struct {
+	warnings []string
+	infos    []string
+}
+
+func newLogCapture() (*logCapture, *slog.Logger) {
+	lc := &logCapture{}
+	handler := &captureHandler{lc: lc}
+	return lc, slog.New(handler)
+}
+
+type captureHandler struct {
+	lc    *logCapture
+	attrs []slog.Attr
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	switch r.Level {
+	case slog.LevelWarn:
+		h.lc.warnings = append(h.lc.warnings, r.Message)
+	case slog.LevelInfo:
+		h.lc.infos = append(h.lc.infos, r.Message)
+	}
+	return nil
+}
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &captureHandler{lc: h.lc, attrs: append(h.attrs, attrs...)}
+}
+func (h *captureHandler) WithGroup(_ string) slog.Handler { return h }
+
+// --- Tests ---
+
+func TestBootstrap_CreatesPartitionsFirst(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	assert.True(t, partitions.called, "partitions must be created during bootstrap")
+	assert.Equal(t, 3, partitions.months, "must create 3 months of partitions")
+}
+
+func TestBootstrap_PartitionFailureIsFatal(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	partitions := &mockPartitionManager{err: fmt.Errorf("partition creation failed")}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "partition")
+}
+
+func TestBootstrap_SeedsAllPoliciesOnEmptyStore(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	seeds := SeedPolicies()
+	assert.Len(t, mockStore.created, len(seeds), "all seed policies must be created")
+
+	for _, created := range mockStore.created {
+		assert.Equal(t, "seed", created.Source)
+		assert.Equal(t, "system", created.CreatedBy)
+		assert.True(t, created.Enabled)
+		assert.NotNil(t, created.SeedVersion)
+		assert.Equal(t, 1, *created.SeedVersion)
+		assert.NotEmpty(t, created.CompiledAST)
+	}
+}
+
+func TestBootstrap_SkipsExistingSeedPolicy(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	seedVersion := 1
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:        "seed:player-self-access",
+		Source:      "seed",
+		SeedVersion: &seedVersion,
+		Enabled:     true,
+	}
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	// Should create all except the one that already exists
+	assert.Len(t, mockStore.created, len(SeedPolicies())-1)
+	for _, created := range mockStore.created {
+		assert.NotEqual(t, "seed:player-self-access", created.Name,
+			"existing seed policy should not be re-created")
+	}
+}
+
+func TestBootstrap_WarnsOnAdminCollision(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:   "seed:player-self-access",
+		Source: "admin", // Not "seed" — admin collision
+	}
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	lc, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	// Should skip the colliding policy and log a warning
+	for _, created := range mockStore.created {
+		assert.NotEqual(t, "seed:player-self-access", created.Name)
+	}
+	assert.NotEmpty(t, lc.warnings, "should log warning about admin collision")
+}
+
+func TestBootstrap_UpgradesSeedVersion(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	oldVersion := 0
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:        "seed:player-self-access",
+		Source:      "seed",
+		DSLText:     `permit(principal is character, action in ["read"], resource is character);`,
+		SeedVersion: &oldVersion,
+		Enabled:     true,
+	}
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	// The existing policy should have been upgraded
+	assert.NotEmpty(t, mockStore.updated, "seed version upgrade should trigger update")
+	var upgraded *store.StoredPolicy
+	for _, u := range mockStore.updated {
+		if u.Name == "seed:player-self-access" {
+			upgraded = u
+		}
+	}
+	require.NotNil(t, upgraded, "seed:player-self-access should be upgraded")
+	assert.Equal(t, 1, *upgraded.SeedVersion)
+	assert.Contains(t, upgraded.ChangeNote, "Auto-upgraded from seed v0 to v1")
+}
+
+func TestBootstrap_SkipSeedMigrations(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	oldVersion := 0
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:        "seed:player-self-access",
+		Source:      "seed",
+		DSLText:     `permit(principal is character, action in ["read"], resource is character);`,
+		SeedVersion: &oldVersion,
+		Enabled:     true,
+	}
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{
+		SkipSeedMigrations: true,
+	})
+	require.NoError(t, err)
+
+	// Should NOT upgrade the existing policy
+	for _, u := range mockStore.updated {
+		assert.NotEqual(t, "seed:player-self-access", u.Name,
+			"seed version upgrade should be skipped when SkipSeedMigrations is true")
+	}
+}
+
+func TestBootstrap_CompilationErrorIsFatal(t *testing.T) {
+	// Use a custom seed list with an invalid DSL to test fatal compilation errors.
+	// We test this by confirming the bootstrap function validates all seeds compile.
+	// Since we can't inject bad seeds into SeedPolicies(), we verify the error path
+	// by testing with a store that returns an error on create.
+	mockStore := newBootstrapMockStore()
+	mockStore.createErr = fmt.Errorf("database unavailable")
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.Error(t, err, "bootstrap must fail when store create fails")
+}
+
+func TestBootstrap_CreatedPoliciesHaveValidCompiledAST(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	for _, created := range mockStore.created {
+		assert.NotEmpty(t, created.CompiledAST,
+			"policy %q must have compiled AST", created.Name)
+		// Verify it's valid JSON
+		assert.True(t, json.Valid(created.CompiledAST),
+			"policy %q compiled AST must be valid JSON", created.Name)
+	}
+}
+
+func TestBootstrap_SetsCorrectEffect(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	var forbidCount int
+	for _, created := range mockStore.created {
+		if created.Effect == types.PolicyEffectForbid {
+			forbidCount++
+			assert.Equal(t, "seed:property-restricted-excluded", created.Name)
+		}
+	}
+	assert.Equal(t, 1, forbidCount, "exactly one forbid policy expected")
+}
+
+func TestBootstrap_NilSeedVersionNotUpgraded(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	// Simulate a legacy policy with nil SeedVersion
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:        "seed:player-self-access",
+		Source:      "seed",
+		DSLText:     `permit(principal is character, action in ["read"], resource is character);`,
+		SeedVersion: nil, // Legacy — no version tracking
+		Enabled:     true,
+	}
+	partitions := &mockPartitionManager{}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+	ctx := access.WithSystemSubject(context.Background())
+
+	err := Bootstrap(ctx, partitions, mockStore, compiler, logger, BootstrapOptions{})
+	require.NoError(t, err)
+
+	// Should NOT upgrade a nil-versioned policy
+	for _, u := range mockStore.updated {
+		assert.NotEqual(t, "seed:player-self-access", u.Name,
+			"nil seed version should not trigger upgrade")
+	}
+}
+
+// --- IsNotFound tests ---
+
+func TestIsNotFound_TrueForPolicyNotFound(t *testing.T) {
+	err := oops.Code("POLICY_NOT_FOUND").Errorf("not found")
+	assert.True(t, store.IsNotFound(err))
+}
+
+func TestIsNotFound_FalseForOtherErrors(t *testing.T) {
+	err := oops.Code("POLICY_CREATE_FAILED").Errorf("create failed")
+	assert.False(t, store.IsNotFound(err))
+}
+
+func TestIsNotFound_FalseForNil(t *testing.T) {
+	assert.False(t, store.IsNotFound(nil))
+}
+
+func TestIsNotFound_FalseForPlainError(t *testing.T) {
+	assert.False(t, store.IsNotFound(fmt.Errorf("plain error")))
+}
+
+// --- UpdateSeed tests ---
+
+func TestUpdateSeed_SkipsIfDSLMatches(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:    "seed:player-self-access",
+		Source:  "seed",
+		DSLText: `permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+	}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+
+	err := UpdateSeed(
+		context.Background(),
+		mockStore,
+		compiler,
+		logger,
+		"seed:player-self-access",
+		`permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+		`permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+		"no change",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, mockStore.updated, "no update when DSL matches")
+}
+
+func TestUpdateSeed_WarnsOnAdminCustomization(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:    "seed:player-self-access",
+		Source:  "seed",
+		DSLText: `permit(principal is character, action in ["read"], resource is character);`, // Different from oldDSL
+	}
+	compiler := NewCompiler(emptySchema())
+	lc, logger := newLogCapture()
+
+	err := UpdateSeed(
+		context.Background(),
+		mockStore,
+		compiler,
+		logger,
+		"seed:player-self-access",
+		`permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+		`permit(principal is character, action in ["read", "write", "delete"], resource is character) when { resource.id == principal.id };`,
+		"added delete",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, mockStore.updated, "should not overwrite admin customization")
+	assert.NotEmpty(t, lc.warnings, "should warn about admin customization")
+}
+
+func TestUpdateSeed_UpdatesUncustomizedPolicy(t *testing.T) {
+	oldDSL := `permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`
+	newDSL := `permit(principal is character, action in ["read", "write", "delete"], resource is character) when { resource.id == principal.id };`
+	mockStore := newBootstrapMockStore()
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:    "seed:player-self-access",
+		Source:  "seed",
+		DSLText: oldDSL,
+	}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+
+	err := UpdateSeed(
+		context.Background(),
+		mockStore,
+		compiler,
+		logger,
+		"seed:player-self-access",
+		oldDSL,
+		newDSL,
+		"added delete action",
+	)
+	require.NoError(t, err)
+	require.Len(t, mockStore.updated, 1)
+	assert.Equal(t, newDSL, mockStore.updated[0].DSLText)
+	assert.Equal(t, "added delete action", mockStore.updated[0].ChangeNote)
+}
+
+func TestUpdateSeed_FailsForNonSeedPolicy(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	mockStore.policies["seed:player-self-access"] = &store.StoredPolicy{
+		Name:   "seed:player-self-access",
+		Source: "admin",
+	}
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+
+	err := UpdateSeed(
+		context.Background(),
+		mockStore,
+		compiler,
+		logger,
+		"seed:player-self-access",
+		"old",
+		"new",
+		"change",
+	)
+	require.Error(t, err, "should fail when source is not seed")
+}
+
+func TestUpdateSeed_FailsForMissingPolicy(t *testing.T) {
+	mockStore := newBootstrapMockStore()
+	compiler := NewCompiler(emptySchema())
+	_, logger := newLogCapture()
+
+	err := UpdateSeed(
+		context.Background(),
+		mockStore,
+		compiler,
+		logger,
+		"seed:nonexistent",
+		"old",
+		"new",
+		"change",
+	)
+	require.Error(t, err, "should fail when policy doesn't exist")
+}

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+// SeedPolicy defines a system-installed default policy.
+type SeedPolicy struct {
+	Name        string
+	Description string
+	DSLText     string
+	SeedVersion int
+}
+
+// SeedPolicies returns the complete set of 18 seed policies (17 permit, 1 forbid).
+// Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
+// See ADR 087 for rationale on default-deny instead of explicit forbid for system properties.
+func SeedPolicies() []SeedPolicy {
+	return []SeedPolicy{
+		{
+			Name:        "seed:player-self-access",
+			Description: "Characters can read and write their own character",
+			DSLText:     `permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-location-read",
+			Description: "Characters can read their current location",
+			DSLText:     `permit(principal is character, action in ["read"], resource is location) when { resource.id == principal.location };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-character-colocation",
+			Description: "Characters can read co-located characters",
+			DSLText:     `permit(principal is character, action in ["read"], resource is character) when { resource.location == principal.location };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-object-colocation",
+			Description: "Characters can read co-located objects",
+			DSLText:     `permit(principal is character, action in ["read"], resource is object) when { resource.location == principal.location };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-stream-emit",
+			Description: "Characters can emit to co-located location streams",
+			DSLText:     `permit(principal is character, action in ["emit"], resource is stream) when { resource.name like "location:*" && resource.location == principal.location };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-movement",
+			Description: "Characters can enter any location (restrict via forbid policies)",
+			DSLText:     `permit(principal is character, action in ["enter"], resource is location);`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-exit-use",
+			Description: "Characters can use exits for navigation",
+			DSLText:     `permit(principal is character, action in ["use"], resource is exit);`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-basic-commands",
+			Description: "Characters can execute basic commands",
+			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { resource.name in ["say", "pose", "look", "go"] };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:builder-location-write",
+			Description: "Builders and admins can create/modify/delete locations",
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is location) when { principal.role in ["builder", "admin"] };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:builder-object-write",
+			Description: "Builders and admins can create/modify/delete objects",
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is object) when { principal.role in ["builder", "admin"] };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:builder-commands",
+			Description: "Builders and admins can execute builder commands",
+			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { principal.role in ["builder", "admin"] && resource.name in ["dig", "create", "describe", "link"] };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:admin-full-access",
+			Description: "Admins have full access to everything",
+			DSLText:     `permit(principal is character, action, resource) when { principal.role == "admin" };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-public-read",
+			Description: "Public properties readable by co-located characters",
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "public" && principal.location == resource.parent_location };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-private-read",
+			Description: "Private properties readable only by owner",
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "private" && resource.owner == principal.id };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-admin-read",
+			Description: "Admin properties readable only by admins",
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "admin" && principal.role == "admin" };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-owner-write",
+			Description: "Property owners can write and delete their properties",
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is property) when { resource.owner == principal.id };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-restricted-visible-to",
+			Description: "Restricted properties readable by characters in the visible_to list",
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:property-restricted-excluded",
+			Description: "Restricted properties denied to characters in the excluded_from list",
+			DSLText:     `forbid(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has excluded_from && principal.id in resource.excluded_from };`,
+			SeedVersion: 1,
+		},
+	}
+}

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -11,9 +11,14 @@ type SeedPolicy struct {
 	SeedVersion int
 }
 
-// SeedPolicies returns the complete set of 18 seed policies (17 permit, 1 forbid).
+// SeedPolicies returns the complete set of 23 seed policies (22 permit, 1 forbid).
+// The initial 18 (T22) plus 5 gap-fill policies (T22b: G1-G4).
 // Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
 // See ADR 087 for rationale on default-deny instead of explicit forbid for system properties.
+//
+// Gap decisions (T22b):
+//   - G5 (plugin commands): intentional default-deny; plugins define own policies at install time.
+//   - G6 (MoveObject): intentional builder-only; players cannot move objects they don't own.
 func SeedPolicies() []SeedPolicy {
 	return []SeedPolicy{
 		{
@@ -122,6 +127,43 @@ func SeedPolicies() []SeedPolicy {
 			Name:        "seed:property-restricted-excluded",
 			Description: "Restricted properties denied to characters in the excluded_from list",
 			DSLText:     `forbid(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has excluded_from && principal.id in resource.excluded_from };`,
+			SeedVersion: 1,
+		},
+
+		// --- Gap-fill policies (T22b) ---
+
+		// G1: Players can read exits (target matching only; exit provider is a stub).
+		{
+			Name:        "seed:player-exit-read",
+			Description: "Characters can read exits for navigation",
+			DSLText:     `permit(principal is character, action in ["read"], resource is exit);`,
+			SeedVersion: 1,
+		},
+		// G2: Builders can create/update/delete exits.
+		{
+			Name:        "seed:builder-exit-write",
+			Description: "Builders and admins can create/modify/delete exits",
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is exit) when { principal.role in ["builder", "admin"] };`,
+			SeedVersion: 1,
+		},
+		// G3: Players can list characters in their current location (ADR #109).
+		{
+			Name:        "seed:player-location-list-characters",
+			Description: "Characters can list other characters in their current location",
+			DSLText:     `permit(principal is character, action in ["list_characters"], resource is location) when { resource.id == principal.location };`,
+			SeedVersion: 1,
+		},
+		// G4: Scene participant access (target matching only; scene provider is a stub).
+		{
+			Name:        "seed:player-scene-participant",
+			Description: "Characters can join and leave scenes",
+			DSLText:     `permit(principal is character, action in ["write"], resource is scene);`,
+			SeedVersion: 1,
+		},
+		{
+			Name:        "seed:player-scene-read",
+			Description: "Characters can view scenes",
+			DSLText:     `permit(principal is character, action in ["read"], resource is scene);`,
 			SeedVersion: 1,
 		},
 	}

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -16,6 +16,9 @@ type SeedPolicy struct {
 // Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
 // See ADR 087 for rationale on default-deny instead of explicit forbid for system properties.
 //
+// Attribute paths use fully-qualified namespace.key syntax matching the resolver's
+// storage format (e.g., principal.character.role, resource.location.id).
+//
 // Gap decisions (T22b):
 //   - G5 (plugin commands): intentional default-deny; plugins define own policies at install time.
 //   - G6 (MoveObject): intentional builder-only; players cannot move objects they don't own.
@@ -24,32 +27,32 @@ func SeedPolicies() []SeedPolicy {
 		{
 			Name:        "seed:player-self-access",
 			Description: "Characters can read and write their own character",
-			DSLText:     `permit(principal is character, action in ["read", "write"], resource is character) when { resource.id == principal.id };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read", "write"], resource is character) when { resource.character.id == principal.character.id };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:player-location-read",
 			Description: "Characters can read their current location",
-			DSLText:     `permit(principal is character, action in ["read"], resource is location) when { resource.id == principal.location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is location) when { resource.location.id == principal.character.location };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:player-character-colocation",
 			Description: "Characters can read co-located characters",
-			DSLText:     `permit(principal is character, action in ["read"], resource is character) when { resource.location == principal.location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is character) when { resource.character.location == principal.character.location };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:player-object-colocation",
 			Description: "Characters can read co-located objects",
-			DSLText:     `permit(principal is character, action in ["read"], resource is object) when { resource.location == principal.location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is object) when { resource.object.location == principal.character.location };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:player-stream-emit",
 			Description: "Characters can emit to co-located location streams",
-			DSLText:     `permit(principal is character, action in ["emit"], resource is stream) when { resource.name like "location:*" && resource.location == principal.location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["emit"], resource is stream) when { resource.stream.name like "location:*" && resource.stream.location == principal.character.location };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:player-movement",
@@ -66,68 +69,68 @@ func SeedPolicies() []SeedPolicy {
 		{
 			Name:        "seed:player-basic-commands",
 			Description: "Characters can execute basic commands",
-			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { resource.name in ["say", "pose", "look", "go"] };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { resource.command.name in ["say", "pose", "look", "go"] };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:builder-location-write",
 			Description: "Builders and admins can create/modify/delete locations",
-			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is location) when { principal.role in ["builder", "admin"] };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is location) when { principal.character.role in ["builder", "admin"] };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:builder-object-write",
 			Description: "Builders and admins can create/modify/delete objects",
-			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is object) when { principal.role in ["builder", "admin"] };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is object) when { principal.character.role in ["builder", "admin"] };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:builder-commands",
 			Description: "Builders and admins can execute builder commands",
-			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { principal.role in ["builder", "admin"] && resource.name in ["dig", "create", "describe", "link"] };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["execute"], resource is command) when { principal.character.role in ["builder", "admin"] && resource.command.name in ["dig", "create", "describe", "link"] };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:admin-full-access",
 			Description: "Admins have full access to everything",
-			DSLText:     `permit(principal is character, action, resource) when { principal.role == "admin" };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action, resource) when { principal.character.role == "admin" };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-public-read",
 			Description: "Public properties readable by co-located characters",
-			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "public" && principal.location == resource.parent_location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.property.visibility == "public" && principal.character.location == resource.property.parent_location };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-private-read",
 			Description: "Private properties readable only by owner",
-			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "private" && resource.owner == principal.id };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.property.visibility == "private" && resource.property.owner == principal.character.id };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-admin-read",
 			Description: "Admin properties readable only by admins",
-			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "admin" && principal.role == "admin" };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.property.visibility == "admin" && principal.character.role == "admin" };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-owner-write",
 			Description: "Property owners can write and delete their properties",
-			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is property) when { resource.owner == principal.id };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is property) when { resource.property.owner == principal.character.id };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-restricted-visible-to",
 			Description: "Restricted properties readable by characters in the visible_to list",
-			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has visible_to && principal.id in resource.visible_to };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["read"], resource is property) when { resource.property.visibility == "restricted" && resource has property.visible_to && principal.character.id in resource.property.visible_to };`,
+			SeedVersion: 2,
 		},
 		{
 			Name:        "seed:property-restricted-excluded",
 			Description: "Restricted properties denied to characters in the excluded_from list",
-			DSLText:     `forbid(principal is character, action in ["read"], resource is property) when { resource.visibility == "restricted" && resource has excluded_from && principal.id in resource.excluded_from };`,
-			SeedVersion: 1,
+			DSLText:     `forbid(principal is character, action in ["read"], resource is property) when { resource.property.visibility == "restricted" && resource has property.excluded_from && principal.character.id in resource.property.excluded_from };`,
+			SeedVersion: 2,
 		},
 
 		// --- Gap-fill policies (T22b) ---
@@ -143,15 +146,15 @@ func SeedPolicies() []SeedPolicy {
 		{
 			Name:        "seed:builder-exit-write",
 			Description: "Builders and admins can create/modify/delete exits",
-			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is exit) when { principal.role in ["builder", "admin"] };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["write", "delete"], resource is exit) when { principal.character.role in ["builder", "admin"] };`,
+			SeedVersion: 2,
 		},
 		// G3: Players can list characters in their current location (ADR #109).
 		{
 			Name:        "seed:player-location-list-characters",
 			Description: "Characters can list other characters in their current location",
-			DSLText:     `permit(principal is character, action in ["list_characters"], resource is location) when { resource.id == principal.location };`,
-			SeedVersion: 1,
+			DSLText:     `permit(principal is character, action in ["list_characters"], resource is location) when { resource.location.id == principal.character.location };`,
+			SeedVersion: 2,
 		},
 		// G4: Scene participant access (target matching only; scene provider is a stub).
 		{

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -1,0 +1,638 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createSeedEngine builds an Engine loaded with ALL seed policies and the
+// given attribute providers. This exercises the full evaluation pipeline:
+// target matching → attribute resolution → condition evaluation → deny-overrides.
+func createSeedEngine(t *testing.T, providers []attribute.AttributeProvider) *Engine {
+	t.Helper()
+
+	seeds := SeedPolicies()
+	dslTexts := make([]string, len(seeds))
+	for i, s := range seeds {
+		dslTexts[i] = s.DSLText
+	}
+
+	return createTestEngineWithPolicies(t, dslTexts, providers)
+}
+
+// --- Mock providers that return realistic attribute data ---
+
+func characterProvider(subjectAttrs, resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "character",
+		subjectMap:  subjectAttrs,
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"id":           types.AttrTypeString,
+				"player_id":    types.AttrTypeString,
+				"name":         types.AttrTypeString,
+				"role":         types.AttrTypeString,
+				"location":     types.AttrTypeString,
+				"location_id":  types.AttrTypeString,
+				"has_location": types.AttrTypeBool,
+			},
+		},
+	}
+}
+
+func locationProvider(resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "location",
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"id":   types.AttrTypeString,
+				"name": types.AttrTypeString,
+			},
+		},
+	}
+}
+
+func commandProvider(resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "command",
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"name": types.AttrTypeString,
+			},
+		},
+	}
+}
+
+func streamProvider(resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "stream",
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"name":     types.AttrTypeString,
+				"location": types.AttrTypeString,
+			},
+		},
+	}
+}
+
+func objectProvider(resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "object",
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"id":       types.AttrTypeString,
+				"location": types.AttrTypeString,
+			},
+		},
+	}
+}
+
+func propertyProvider(resourceAttrs map[string]any) *mockAttributeProvider {
+	return &mockAttributeProvider{
+		namespace:   "property",
+		resourceMap: resourceAttrs,
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{
+				"visibility":      types.AttrTypeString,
+				"owner":           types.AttrTypeString,
+				"parent_location": types.AttrTypeString,
+				"visible_to":      types.AttrTypeStringList,
+				"excluded_from":   types.AttrTypeStringList,
+			},
+		},
+	}
+}
+
+// --- Smoke tests ---
+
+func TestSeedSmoke_PlayerSelfAccess(t *testing.T) {
+	charID := "01CHARSELF0000000000000000"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": charID, "role": "player", "location": "01LOC000"},
+			map[string]any{"id": charID, "role": "player", "location": "01LOC000"},
+		),
+	})
+
+	// Character reading itself → permit (seed:player-self-access)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:" + charID,
+		Action:   "read",
+		Resource: "character:" + charID,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should read own character; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerLocationRead(t *testing.T) {
+	locID := "01LOC000AAAAAAAAAAAAAAAAAA"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": locID},
+			nil,
+		),
+		locationProvider(map[string]any{"id": locID, "name": "Town Square"}),
+	})
+
+	// Character reading current location → permit (seed:player-location-read)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "location:" + locID,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should read current location; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerColocatedCharacter(t *testing.T) {
+	locID := "01LOC000BBBBBBBBBBBBBBBBBB"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR_A", "role": "player", "location": locID},
+			map[string]any{"id": "01CHAR_B", "role": "player", "location": locID},
+		),
+	})
+
+	// Reading a co-located character → permit (seed:player-character-colocation)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR_A",
+		Action:   "read",
+		Resource: "character:01CHAR_B",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should read co-located character; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerColocatedObject(t *testing.T) {
+	locID := "01LOC000CCCCCCCCCCCCCCCCCC"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": locID},
+			nil,
+		),
+		objectProvider(map[string]any{"id": "01OBJ001", "location": locID}),
+	})
+
+	// Reading a co-located object → permit (seed:player-object-colocation)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "object:01OBJ001",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should read co-located object; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerStreamEmit(t *testing.T) {
+	locID := "01LOC000DDDDDDDDDDDDDDDDDD"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": locID},
+			nil,
+		),
+		streamProvider(map[string]any{"name": "location:01LOC000", "location": locID}),
+	})
+
+	// Emitting to co-located location stream → permit (seed:player-stream-emit)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "emit",
+		Resource: "stream:location-01LOC000",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should emit to co-located stream; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerMovement(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC_A"},
+			nil,
+		),
+		locationProvider(map[string]any{"id": "01LOC_B", "name": "Market"}),
+	})
+
+	// Entering any location → permit (seed:player-movement, no conditions)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "enter",
+		Resource: "location:01LOC_B",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should enter location; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerExitUse(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+	})
+
+	// Using an exit → permit (seed:player-exit-use, no conditions)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "use",
+		Resource: "exit:01EXIT01",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should use exit; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerBasicCommands(t *testing.T) {
+	commands := []string{"say", "pose", "look", "go"}
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			engine := createSeedEngine(t, []attribute.AttributeProvider{
+				characterProvider(
+					map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+					nil,
+				),
+				commandProvider(map[string]any{"name": cmd}),
+			})
+
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01CHAR01",
+				Action:   "execute",
+				Resource: "command:" + cmd,
+			})
+			require.NoError(t, err)
+			assert.True(t, decision.IsAllowed(), "player should execute %s; got: %s — %s", cmd, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_PlayerDeniedBuilderCommands(t *testing.T) {
+	commands := []string{"dig", "create", "describe", "link"}
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			engine := createSeedEngine(t, []attribute.AttributeProvider{
+				characterProvider(
+					map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+					nil,
+				),
+				commandProvider(map[string]any{"name": cmd}),
+			})
+
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01CHAR01",
+				Action:   "execute",
+				Resource: "command:" + cmd,
+			})
+			require.NoError(t, err)
+			assert.False(t, decision.IsAllowed(), "player should NOT execute builder command %s; got: %s — %s", cmd, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_BuilderLocationWrite(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "builder", "location": "01LOC000"},
+			nil,
+		),
+		locationProvider(map[string]any{"id": "01LOC001", "name": "Forest"}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "write",
+		Resource: "location:01LOC001",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "builder should write locations; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_BuilderCommands(t *testing.T) {
+	commands := []string{"dig", "create", "describe", "link"}
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			engine := createSeedEngine(t, []attribute.AttributeProvider{
+				characterProvider(
+					map[string]any{"id": "01CHAR01", "role": "builder", "location": "01LOC000"},
+					nil,
+				),
+				commandProvider(map[string]any{"name": cmd}),
+			})
+
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01CHAR01",
+				Action:   "execute",
+				Resource: "command:" + cmd,
+			})
+			require.NoError(t, err)
+			assert.True(t, decision.IsAllowed(), "builder should execute %s; got: %s — %s", cmd, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_AdminFullAccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   string
+		resource string
+	}{
+		{"read location", "read", "location:01LOC001"},
+		{"write location", "write", "location:01LOC001"},
+		{"delete object", "delete", "object:01OBJ001"},
+		{"execute any command", "execute", "command:teleport"},
+		{"enter locked room", "enter", "location:01LOCKED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Admin needs providers registered for target matching
+			engine := createSeedEngine(t, []attribute.AttributeProvider{
+				characterProvider(
+					map[string]any{"id": "01ADMIN1", "role": "admin", "location": "01LOC000"},
+					nil,
+				),
+				locationProvider(map[string]any{"id": "01LOC001"}),
+				objectProvider(map[string]any{"id": "01OBJ001"}),
+				commandProvider(map[string]any{"name": "teleport"}),
+			})
+
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01ADMIN1",
+				Action:   tt.action,
+				Resource: tt.resource,
+			})
+			require.NoError(t, err)
+			assert.True(t, decision.IsAllowed(), "admin should have access to %s; got: %s — %s", tt.name, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_DefaultDenyNoMatchingPolicy(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+	})
+
+	// Player trying to delete a location → no policy matches → default deny
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "delete",
+		Resource: "location:01LOC001",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "default deny should apply; got: %s — %s", decision.Effect, decision.Reason)
+	assert.Equal(t, types.EffectDefaultDeny, decision.Effect)
+}
+
+func TestSeedSmoke_PropertyPublicRead(t *testing.T) {
+	locID := "01LOC000EEEEEEEEEEEEEEEEEE"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": locID},
+			nil,
+		),
+		propertyProvider(map[string]any{
+			"visibility":      "public",
+			"owner":           "01OWNER1",
+			"parent_location": locID,
+		}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "property:01PROP01",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "co-located player should read public property; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PropertyPrivateReadOwner(t *testing.T) {
+	charID := "01CHAROWNER00000000000000"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": charID, "role": "player", "location": "01LOC000"},
+			nil,
+		),
+		propertyProvider(map[string]any{
+			"visibility": "private",
+			"owner":      charID,
+		}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:" + charID,
+		Action:   "read",
+		Resource: "property:01PROP01",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "owner should read private property; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PropertyPrivateReadDeniedNonOwner(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+		propertyProvider(map[string]any{
+			"visibility": "private",
+			"owner":      "01OTHERID",
+		}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "property:01PROP01",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "non-owner should NOT read private property; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PropertyRestrictedForbid(t *testing.T) {
+	charID := "01CHAREXCLUDED00000000000"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": charID, "role": "player", "location": "01LOC000"},
+			nil,
+		),
+		propertyProvider(map[string]any{
+			"visibility":    "restricted",
+			"owner":         "01OWNER1",
+			"visible_to":    []any{charID},
+			"excluded_from": []any{charID},
+		}),
+	})
+
+	// Character is in both visible_to and excluded_from — forbid overrides permit
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:" + charID,
+		Action:   "read",
+		Resource: "property:01PROP01",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "forbid should override permit for excluded character; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PropertyOwnerWrite(t *testing.T) {
+	charID := "01CHAROWNWRITE00000000000"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": charID, "role": "player", "location": "01LOC000"},
+			nil,
+		),
+		propertyProvider(map[string]any{
+			"owner": charID,
+		}),
+	})
+
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:" + charID,
+		Action:   "write",
+		Resource: "property:01PROP01",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "owner should write property; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerExitRead(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+	})
+
+	// G1: players can read exits
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "exit:01EXIT01",
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should read exit (G1); got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_BuilderExitWrite(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01BUILD1", "role": "builder", "location": "01LOC000"},
+			nil,
+		),
+	})
+
+	for _, action := range []string{"write", "delete"} {
+		t.Run(action, func(t *testing.T) {
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01BUILD1",
+				Action:   action,
+				Resource: "exit:01EXIT01",
+			})
+			require.NoError(t, err)
+			assert.True(t, decision.IsAllowed(), "builder should %s exit (G2); got: %s — %s", action, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_PlayerLocationListCharacters(t *testing.T) {
+	locID := "01LOC000FFFFFFFFFFFFFFFF"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": locID},
+			nil,
+		),
+		locationProvider(map[string]any{"id": locID, "name": "Plaza"}),
+	})
+
+	// G3: list_characters on current location
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "list_characters",
+		Resource: "location:" + locID,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should list characters at current location (G3); got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerSceneAccess(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+	})
+
+	// G4: read and write scenes
+	for _, action := range []string{"read", "write"} {
+		t.Run(action, func(t *testing.T) {
+			decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+				Subject:  "character:01CHAR01",
+				Action:   action,
+				Resource: "scene:01SCENE01",
+			})
+			require.NoError(t, err)
+			assert.True(t, decision.IsAllowed(), "player should %s scene (G4); got: %s — %s", action, decision.Effect, decision.Reason)
+		})
+	}
+}
+
+func TestSeedSmoke_PlayerDeniedLocationWrite(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC000"},
+			nil,
+		),
+		locationProvider(map[string]any{"id": "01LOC001", "name": "Forest"}),
+	})
+
+	// Player (non-builder) writing a location → denied
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "write",
+		Resource: "location:01LOC001",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "player should NOT write location; got: %s — %s", decision.Effect, decision.Reason)
+}
+
+func TestSeedSmoke_PlayerDeniedOtherLocationRead(t *testing.T) {
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "role": "player", "location": "01LOC_A0"},
+			nil,
+		),
+		locationProvider(map[string]any{"id": "01LOC_B0", "name": "Elsewhere"}),
+	})
+
+	// Player reading a location they are NOT at → denied
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "read",
+		Resource: "location:01LOC_B0",
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "player should NOT read non-current location; got: %s — %s", decision.Effect, decision.Reason)
+}

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedPolicies_Count(t *testing.T) {
+	seeds := SeedPolicies()
+	// 17 permit + 1 forbid = 18 total
+	assert.Len(t, seeds, 18, "expected 18 seed policies (17 permit, 1 forbid)")
+}
+
+func TestSeedPolicies_AllNamesHaveSeedPrefix(t *testing.T) {
+	for _, s := range SeedPolicies() {
+		assert.True(t, strings.HasPrefix(s.Name, "seed:"),
+			"seed policy %q must start with seed: prefix", s.Name)
+	}
+}
+
+func TestSeedPolicies_AllHaveSeedVersion1(t *testing.T) {
+	for _, s := range SeedPolicies() {
+		assert.Equal(t, 1, s.SeedVersion,
+			"seed policy %q must have SeedVersion 1", s.Name)
+	}
+}
+
+func TestSeedPolicies_NoDuplicateNames(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, s := range SeedPolicies() {
+		assert.False(t, seen[s.Name],
+			"duplicate seed policy name: %q", s.Name)
+		seen[s.Name] = true
+	}
+}
+
+func TestSeedPolicies_AllHaveDescriptions(t *testing.T) {
+	for _, s := range SeedPolicies() {
+		assert.NotEmpty(t, s.Description,
+			"seed policy %q must have a description", s.Name)
+	}
+}
+
+func TestSeedPolicies_AllCompileWithoutError(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	for _, s := range SeedPolicies() {
+		t.Run(s.Name, func(t *testing.T) {
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err, "seed policy %q failed to compile", s.Name)
+			assert.NotNil(t, compiled)
+		})
+	}
+}
+
+func TestSeedPolicies_EffectDistribution(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	var permitCount, forbidCount int
+	for _, s := range SeedPolicies() {
+		compiled, _, err := compiler.Compile(s.DSLText)
+		require.NoError(t, err)
+		switch compiled.Effect {
+		case "permit":
+			permitCount++
+		case "forbid":
+			forbidCount++
+		}
+	}
+	assert.Equal(t, 17, permitCount, "expected 17 permit policies")
+	assert.Equal(t, 1, forbidCount, "expected 1 forbid policy")
+}
+
+func TestSeedPolicies_ExpectedNames(t *testing.T) {
+	expectedNames := []string{
+		"seed:player-self-access",
+		"seed:player-location-read",
+		"seed:player-character-colocation",
+		"seed:player-object-colocation",
+		"seed:player-stream-emit",
+		"seed:player-movement",
+		"seed:player-exit-use",
+		"seed:player-basic-commands",
+		"seed:builder-location-write",
+		"seed:builder-object-write",
+		"seed:builder-commands",
+		"seed:admin-full-access",
+		"seed:property-public-read",
+		"seed:property-private-read",
+		"seed:property-admin-read",
+		"seed:property-owner-write",
+		"seed:property-restricted-visible-to",
+		"seed:property-restricted-excluded",
+	}
+
+	seeds := SeedPolicies()
+	seedNames := make([]string, len(seeds))
+	for i, s := range seeds {
+		seedNames[i] = s.Name
+	}
+	assert.ElementsMatch(t, expectedNames, seedNames)
+}
+
+func TestSeedPolicies_ForbidPolicyIsPropertyRestrictedExcluded(t *testing.T) {
+	compiler := NewCompiler(emptySchema())
+	for _, s := range SeedPolicies() {
+		compiled, _, err := compiler.Compile(s.DSLText)
+		require.NoError(t, err)
+		if compiled.Effect == "forbid" {
+			assert.Equal(t, "seed:property-restricted-excluded", s.Name,
+				"only seed:property-restricted-excluded should be a forbid policy")
+		}
+	}
+}

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -24,10 +24,10 @@ func TestSeedPolicies_AllNamesHaveSeedPrefix(t *testing.T) {
 	}
 }
 
-func TestSeedPolicies_AllHaveSeedVersion1(t *testing.T) {
+func TestSeedPolicies_AllHavePositiveSeedVersion(t *testing.T) {
 	for _, s := range SeedPolicies() {
-		assert.Equal(t, 1, s.SeedVersion,
-			"seed policy %q must have SeedVersion 1", s.Name)
+		assert.GreaterOrEqual(t, s.SeedVersion, 1,
+			"seed policy %q must have SeedVersion >= 1", s.Name)
 	}
 }
 

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPolicies_Count(t *testing.T) {
 	seeds := SeedPolicies()
-	// 17 permit + 1 forbid = 18 total
-	assert.Len(t, seeds, 18, "expected 18 seed policies (17 permit, 1 forbid)")
+	// 22 permit + 1 forbid = 23 total (18 base + 5 gap-fill from T22b)
+	assert.Len(t, seeds, 23, "expected 23 seed policies (22 permit, 1 forbid)")
 }
 
 func TestSeedPolicies_AllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,12 +71,13 @@ func TestSeedPolicies_EffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 17, permitCount, "expected 17 permit policies")
+	assert.Equal(t, 22, permitCount, "expected 22 permit policies")
 	assert.Equal(t, 1, forbidCount, "expected 1 forbid policy")
 }
 
 func TestSeedPolicies_ExpectedNames(t *testing.T) {
 	expectedNames := []string{
+		// Base policies (T22)
 		"seed:player-self-access",
 		"seed:player-location-read",
 		"seed:player-character-colocation",
@@ -95,6 +96,12 @@ func TestSeedPolicies_ExpectedNames(t *testing.T) {
 		"seed:property-owner-write",
 		"seed:property-restricted-visible-to",
 		"seed:property-restricted-excluded",
+		// Gap-fill policies (T22b)
+		"seed:player-exit-read",                  // G1
+		"seed:builder-exit-write",                // G2
+		"seed:player-location-list-characters",   // G3
+		"seed:player-scene-participant",          // G4
+		"seed:player-scene-read",                 // G4
 	}
 
 	seeds := SeedPolicies()
@@ -115,4 +122,89 @@ func TestSeedPolicies_ForbidPolicyIsPropertyRestrictedExcluded(t *testing.T) {
 				"only seed:property-restricted-excluded should be a forbid policy")
 		}
 	}
+}
+
+// T22b gap-specific tests
+
+func TestSeedPolicies_G1_PlayerExitRead(t *testing.T) {
+	seeds := SeedPolicies()
+	var found bool
+	for _, s := range seeds {
+		if s.Name == "seed:player-exit-read" {
+			found = true
+			compiler := NewCompiler(emptySchema())
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err)
+			assert.Equal(t, "permit", string(compiled.Effect))
+			assert.Contains(t, compiled.Target.ActionList, "read")
+			rType := "exit"
+			assert.Equal(t, &rType, compiled.Target.ResourceType)
+		}
+	}
+	assert.True(t, found, "seed:player-exit-read policy must exist (G1)")
+}
+
+func TestSeedPolicies_G2_BuilderExitWrite(t *testing.T) {
+	seeds := SeedPolicies()
+	var found bool
+	for _, s := range seeds {
+		if s.Name == "seed:builder-exit-write" {
+			found = true
+			compiler := NewCompiler(emptySchema())
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err)
+			assert.Equal(t, "permit", string(compiled.Effect))
+			assert.Contains(t, compiled.Target.ActionList, "write")
+			assert.Contains(t, compiled.Target.ActionList, "delete")
+			rType := "exit"
+			assert.Equal(t, &rType, compiled.Target.ResourceType)
+		}
+	}
+	assert.True(t, found, "seed:builder-exit-write policy must exist (G2)")
+}
+
+func TestSeedPolicies_G3_PlayerLocationListCharacters(t *testing.T) {
+	seeds := SeedPolicies()
+	var found bool
+	for _, s := range seeds {
+		if s.Name == "seed:player-location-list-characters" {
+			found = true
+			compiler := NewCompiler(emptySchema())
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err)
+			assert.Equal(t, "permit", string(compiled.Effect))
+			assert.Contains(t, compiled.Target.ActionList, "list_characters")
+			rType := "location"
+			assert.Equal(t, &rType, compiled.Target.ResourceType)
+		}
+	}
+	assert.True(t, found, "seed:player-location-list-characters policy must exist (G3)")
+}
+
+func TestSeedPolicies_G4_ScenePolicies(t *testing.T) {
+	seeds := SeedPolicies()
+	var participantFound, readFound bool
+	compiler := NewCompiler(emptySchema())
+	for _, s := range seeds {
+		switch s.Name {
+		case "seed:player-scene-participant":
+			participantFound = true
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err)
+			assert.Equal(t, "permit", string(compiled.Effect))
+			assert.Contains(t, compiled.Target.ActionList, "write")
+			rType := "scene"
+			assert.Equal(t, &rType, compiled.Target.ResourceType)
+		case "seed:player-scene-read":
+			readFound = true
+			compiled, _, err := compiler.Compile(s.DSLText)
+			require.NoError(t, err)
+			assert.Equal(t, "permit", string(compiled.Effect))
+			assert.Contains(t, compiled.Target.ActionList, "read")
+			rType := "scene"
+			assert.Equal(t, &rType, compiled.Target.ResourceType)
+		}
+	}
+	assert.True(t, participantFound, "seed:player-scene-participant policy must exist (G4)")
+	assert.True(t, readFound, "seed:player-scene-read policy must exist (G4)")
 }

--- a/internal/access/policy/store/errors.go
+++ b/internal/access/policy/store/errors.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package store
+
+import (
+	"github.com/samber/oops"
+)
+
+// IsNotFound returns true if the error is a POLICY_NOT_FOUND error
+// from the policy store.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	oopsErr, ok := oops.AsOops(err)
+	if !ok {
+		return false
+	}
+	return oopsErr.Code() == "POLICY_NOT_FOUND"
+}


### PR DESCRIPTION
## Summary

- Define 23 seed policies (22 permit, 1 forbid) covering player, builder, admin, property, exit, scene, and stream access patterns
- Implement bootstrap sequence that installs/upgrades seed policies with version tracking and admin collision detection
- Add `validate-seeds` CLI subcommand for offline DSL compilation checks
- Fix all seed policy DSL to use fully-qualified namespace.key attribute paths (e.g., `principal.character.role` instead of `principal.role`) matching the resolver's storage format
- Add 22 smoke tests exercising the full ABAC engine pipeline with realistic access scenarios
- Add `role` and `location` attributes to CharacterProvider

## Test plan

- [ ] `task test` passes (all 32 packages green)
- [ ] `task lint` passes
- [ ] Seed policy compilation: all 23 policies compile without error
- [ ] Smoke tests verify permit/deny for: self-access, colocation, movement, commands, builder/admin roles, property visibility, default deny, forbid-overrides-permit
- [ ] Bootstrap tests verify: seed creation on empty store, version upgrades, skip existing, admin collision warning
- [ ] `validate-seeds` CLI works without DATABASE_URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)