### PR TITLE
chore(claude): add automation recommendations

### DIFF
--- a/.claude/agents/abac-reviewer.md
+++ b/.claude/agents/abac-reviewer.md
@@ -18,29 +18,34 @@ Review changes in `internal/access/` and any code that touches access control po
 ## Review Checklist
 
 ### Default-Deny Integrity
+
 - [ ] New code paths MUST NOT grant access without an explicit policy match
 - [ ] Missing attributes MUST result in deny, not allow
 - [ ] Error conditions in the engine MUST result in deny, not allow
 - [ ] The adapter MUST map engine errors to `false` (deny), never `true`
 
 ### Policy Bypass Risks
+
 - [ ] No hardcoded permission grants that skip the policy engine
 - [ ] No `context.Background()` usage that loses authorization context
 - [ ] No `TODO` or `FIXME` comments deferring security checks
 - [ ] No wildcard or overly broad attribute matching patterns
 
 ### DSL Safety
+
 - [ ] Policy expressions cannot cause unbounded computation (no recursion, bounded iteration)
 - [ ] String interpolation in policies is properly escaped/sanitized
 - [ ] Attribute names are validated against an allowlist, not arbitrary strings
 - [ ] Type mismatches in comparisons produce deny, not panics
 
 ### Audit Trail
+
 - [ ] All access decisions (allow AND deny) are logged with sufficient context
 - [ ] Policy evaluation errors include the policy ID and request details
 - [ ] Audit log entries cannot be tampered with by the evaluated subject
 
 ### Seed Policies
+
 - [ ] Bootstrap/seed policies follow least-privilege principle
 - [ ] No seed policy grants broader access than documented in the spec
 - [ ] Seed policies reference `docs/specs/2026-02-05-full-abac-design.md` for expected permissions
@@ -48,6 +53,7 @@ Review changes in `internal/access/` and any code that touches access control po
 ## Output Format
 
 For each finding, report:
+
 1. **Severity**: Critical / High / Medium / Low
 2. **Location**: File and line/function
 3. **Issue**: What the problem is

--- a/.claude/agents/abac-reviewer.md
+++ b/.claude/agents/abac-reviewer.md
@@ -1,0 +1,57 @@
+# ABAC Security Reviewer
+
+You are a security-focused code reviewer specializing in the HoloMUSH Attribute-Based Access Control (ABAC) system.
+
+## Scope
+
+Review changes in `internal/access/` and any code that touches access control policies, attribute providers, or authorization decisions.
+
+## Architecture Context
+
+- **Policy DSL**: Custom expression language parsed by `participle/v2` in `internal/access/dsl/`
+- **Policy Engine**: `AccessPolicyEngine` evaluates policies via `Evaluate(ctx, AccessRequest) (Decision, error)`
+- **Decision type**: Contains `Effect` (allow/deny), `Reason`, and `PolicyID` — errors are distinct from denials
+- **Attribute Providers**: Supply subject/resource/environment attributes to the evaluator
+- **Legacy adapter**: `AccessControl.Check()` wraps the new engine for backward compatibility (~28 call sites)
+- **Default posture**: Default-deny — no policy match means access denied
+
+## Review Checklist
+
+### Default-Deny Integrity
+- [ ] New code paths MUST NOT grant access without an explicit policy match
+- [ ] Missing attributes MUST result in deny, not allow
+- [ ] Error conditions in the engine MUST result in deny, not allow
+- [ ] The adapter MUST map engine errors to `false` (deny), never `true`
+
+### Policy Bypass Risks
+- [ ] No hardcoded permission grants that skip the policy engine
+- [ ] No `context.Background()` usage that loses authorization context
+- [ ] No `TODO` or `FIXME` comments deferring security checks
+- [ ] No wildcard or overly broad attribute matching patterns
+
+### DSL Safety
+- [ ] Policy expressions cannot cause unbounded computation (no recursion, bounded iteration)
+- [ ] String interpolation in policies is properly escaped/sanitized
+- [ ] Attribute names are validated against an allowlist, not arbitrary strings
+- [ ] Type mismatches in comparisons produce deny, not panics
+
+### Audit Trail
+- [ ] All access decisions (allow AND deny) are logged with sufficient context
+- [ ] Policy evaluation errors include the policy ID and request details
+- [ ] Audit log entries cannot be tampered with by the evaluated subject
+
+### Seed Policies
+- [ ] Bootstrap/seed policies follow least-privilege principle
+- [ ] No seed policy grants broader access than documented in the spec
+- [ ] Seed policies reference `docs/specs/2026-02-05-full-abac-design.md` for expected permissions
+
+## Output Format
+
+For each finding, report:
+1. **Severity**: Critical / High / Medium / Low
+2. **Location**: File and line/function
+3. **Issue**: What the problem is
+4. **Risk**: What could go wrong
+5. **Fix**: Specific recommendation
+
+Summarize with counts by severity at the end.

--- a/.claude/hooks/go-vet.sh
+++ b/.claude/hooks/go-vet.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PostToolUse hook: run go vet on edited Go files
+# Catches semantic issues (bad printf verbs, unreachable code, struct tags)
+# that goimports/gofmt don't detect.
+# Error strategy: convenience hook — fails open (errors don't block edits).
+set -uo pipefail
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || {
+  echo "go-vet: failed to parse hook input" >&2
+  exit 0
+}
+
+[[ -z "$FILE_PATH" ]] && exit 0
+[[ -f "$FILE_PATH" ]] || exit 0
+
+# Only vet Go source files (skip test helpers, generated code checked separately)
+EXT="${FILE_PATH##*.}"
+[[ "$EXT" != "go" ]] && exit 0
+
+REPO_ROOT=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Derive the package path from the file's directory
+PKG_DIR=$(dirname "$FILE_PATH")
+RELATIVE_PKG="./${PKG_DIR#"$REPO_ROOT"/}"
+
+# Run go vet on the package (not the single file — vet needs full package context)
+if ! OUTPUT=$(cd "$REPO_ROOT" && go vet "$RELATIVE_PKG/..." 2>&1); then
+  RELATIVE_PATH="${FILE_PATH#"$REPO_ROOT"/}"
+  echo "go vet found issues in $RELATIVE_PATH:"
+  echo "$OUTPUT"
+else
+  # Silent on success — only report problems
+  :
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/auto-format.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/go-vet.sh"
           }
         ]
       }

--- a/.claude/skills/new-integration-test/SKILL.md
+++ b/.claude/skills/new-integration-test/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: new-integration-test
+description: Scaffold a Ginkgo/Gomega BDD integration test suite with testcontainers
+disable-model-invocation: true
+---
+
+# New Integration Test
+
+Scaffold a Ginkgo/Gomega BDD integration test for a new domain area.
+
+## Usage
+
+```
+/new-integration-test <domain>
+```
+
+Where `<domain>` is the test domain (e.g., `auth`, `plugin`, `access`).
+
+## Steps
+
+1. **Create the test directory** if it doesn't exist:
+   ```
+   test/integration/<domain>/
+   ```
+
+2. **Create the suite file** `test/integration/<domain>/<domain>_suite_test.go`:
+   ```go
+   //go:build integration
+
+   // SPDX-License-Identifier: Apache-2.0
+   // Copyright 2026 HoloMUSH Contributors
+
+   package <domain>_test
+
+   import (
+       "testing"
+
+       . "github.com/onsi/ginkgo/v2"
+       . "github.com/onsi/gomega"
+   )
+
+   func TestIntegration(t *testing.T) {
+       RegisterFailHandler(Fail)
+       RunSpecs(t, "<Domain> Integration Suite")
+   }
+   ```
+
+3. **Create the first spec file** `test/integration/<domain>/<feature>_test.go`:
+   ```go
+   //go:build integration
+
+   // SPDX-License-Identifier: Apache-2.0
+   // Copyright 2026 HoloMUSH Contributors
+
+   package <domain>_test
+
+   import (
+       . "github.com/onsi/ginkgo/v2"
+       . "github.com/onsi/gomega"
+   )
+
+   var _ = Describe("<Feature>", func() {
+       Describe("<capability or user story>", func() {
+           It("<expected behavior in plain English>", func() {
+               // Given/When/Then
+               Expect(true).To(BeTrue()) // TODO: implement
+           })
+       })
+   })
+   ```
+
+4. **Add testcontainers setup** if the domain needs PostgreSQL. Use the shared helper pattern from `test/integration/world/world_suite_test.go` as reference:
+   - `BeforeSuite`: start PostgreSQL container, run migrations
+   - `AfterSuite`: terminate container
+   - Pass the `*pgxpool.Pool` to specs via a package-level variable
+
+5. **Verify** the suite bootstraps:
+   ```bash
+   task test:integration
+   ```
+
+## Conventions
+
+- Build tag: `//go:build integration` (MUST be first line)
+- SPDX header follows the build tag
+- Package name: `<domain>_test` (external test package)
+- Use dot-imports for Ginkgo/Gomega only
+- Describe blocks: capability/user story level
+- It blocks: specific behavior in plain English
+- Async assertions: use `Eventually` with timeout for async operations
+- Reference existing suites in `test/integration/world/` for patterns

--- a/.claude/skills/new-integration-test/SKILL.md
+++ b/.claude/skills/new-integration-test/SKILL.md
@@ -10,7 +10,7 @@ Scaffold a Ginkgo/Gomega BDD integration test for a new domain area.
 
 ## Usage
 
-```
+```text
 /new-integration-test <domain>
 ```
 
@@ -19,11 +19,13 @@ Where `<domain>` is the test domain (e.g., `auth`, `plugin`, `access`).
 ## Steps
 
 1. **Create the test directory** if it doesn't exist:
-   ```
+
+   ```text
    test/integration/<domain>/
    ```
 
 2. **Create the suite file** `test/integration/<domain>/<domain>_suite_test.go`:
+
    ```go
    //go:build integration
 
@@ -46,6 +48,7 @@ Where `<domain>` is the test domain (e.g., `auth`, `plugin`, `access`).
    ```
 
 3. **Create the first spec file** `test/integration/<domain>/<feature>_test.go`:
+
    ```go
    //go:build integration
 
@@ -75,6 +78,7 @@ Where `<domain>` is the test domain (e.g., `auth`, `plugin`, `access`).
    - Pass the `*pgxpool.Pool` to specs via a package-level variable
 
 5. **Verify** the suite bootstraps:
+
    ```bash
    task test:integration
    ```

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: new-migration
+description: Create a new database migration with up/down SQL files following project conventions
+disable-model-invocation: true
+---
+
+# New Migration
+
+Create a PostgreSQL migration pair using golang-migrate conventions.
+
+## Usage
+
+```
+/new-migration <name>
+```
+
+Where `<name>` is a snake_case description (e.g., `add_player_inventory`).
+
+## Steps
+
+1. **Create migration files** using the task runner:
+   ```bash
+   task migrate:create -- <name>
+   ```
+   This creates sequentially numbered `NNNNNN_<name>.up.sql` and `NNNNNN_<name>.down.sql` in `internal/store/migrations/`.
+
+2. **Add SPDX headers** to both files:
+   ```sql
+   -- SPDX-License-Identifier: Apache-2.0
+   -- Copyright 2026 HoloMUSH Contributors
+   ```
+
+3. **Populate the up migration** with the requested schema changes. Follow these conventions:
+   - Use `IF NOT EXISTS` for `CREATE TABLE`, `CREATE INDEX`
+   - Use `NOT NULL` with sensible defaults
+   - Use `ULID` (CHAR(26)) for entity IDs, matching the Go `ulid.ULID` type
+   - Use `TIMESTAMPTZ` for all timestamps with `DEFAULT NOW()`
+   - Add appropriate indexes for foreign keys and query patterns
+   - Add `COMMENT ON TABLE/COLUMN` for non-obvious fields
+   - Wrap multi-statement migrations in `BEGIN; ... COMMIT;`
+
+4. **Populate the down migration** with the exact reverse:
+   - `DROP TABLE IF EXISTS` in reverse order of creation
+   - `DROP INDEX IF EXISTS` for any standalone indexes
+   - The down migration MUST cleanly reverse the up migration
+
+5. **Verify** the migration compiles into the embed:
+   ```bash
+   task build
+   ```
+
+6. **Show the user** the migration number and both file paths for review.
+
+## Conventions
+
+- Migration names: `snake_case`, descriptive (e.g., `add_scene_tags`, `alter_objects_add_properties`)
+- Foreign keys: always name them explicitly (`CONSTRAINT fk_<table>_<column>`)
+- Indexes: `idx_<table>_<column(s)>`
+- Existing migrations are in `internal/store/migrations/` — check them for patterns

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -10,7 +10,7 @@ Create a PostgreSQL migration pair using golang-migrate conventions.
 
 ## Usage
 
-```
+```text
 /new-migration <name>
 ```
 
@@ -19,12 +19,15 @@ Where `<name>` is a snake_case description (e.g., `add_player_inventory`).
 ## Steps
 
 1. **Create migration files** using the task runner:
+
    ```bash
    task migrate:create -- <name>
    ```
+
    This creates sequentially numbered `NNNNNN_<name>.up.sql` and `NNNNNN_<name>.down.sql` in `internal/store/migrations/`.
 
 2. **Add SPDX headers** to both files:
+
    ```sql
    -- SPDX-License-Identifier: Apache-2.0
    -- Copyright 2026 HoloMUSH Contributors
@@ -45,6 +48,7 @@ Where `<name>` is a snake_case description (e.g., `add_player_inventory`).
    - The down migration MUST cleanly reverse the up migration
 
 5. **Verify** the migration compiles into the embed:
+
    ```bash
    task build
    ```

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.mcp.json` with **context7** MCP server for live library documentation lookup (pgx, testcontainers, gopher-lua, etc.)
- Add **new-migration** skill (`/new-migration <name>`) — scaffolds golang-migrate SQL pairs with SPDX headers and project conventions
- Add **new-integration-test** skill (`/new-integration-test <domain>`) — scaffolds Ginkgo/Gomega BDD suites with testcontainers setup
- Add **go-vet** PostToolUse hook — runs `go vet` on edited Go files to catch semantic issues after auto-format
- Add **abac-reviewer** subagent — security-focused reviewer for the ABAC system (default-deny integrity, policy bypass, DSL safety)
- Wire go-vet hook into `.claude/settings.json` PostToolUse chain

## Test plan

- [ ] Verify `context7` MCP server connects: `claude mcp list` shows context7
- [ ] Test `/new-migration add_test_table` creates numbered up/down SQL files
- [ ] Test `/new-integration-test auth` creates suite and spec files
- [ ] Edit a `.go` file and confirm go-vet hook runs silently on success
- [ ] Introduce a `fmt.Printf("%d", "string")` and confirm go-vet reports the issue
- [ ] Verify `abac-reviewer` agent appears in agent list

🤖 Generated with [Claude Code](https://claude.com/claude-code)