### PR TITLE
chore(beads): remove metadata.json from version control

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,9 +1,0 @@
-{
-  "database": "dolt",
-  "jsonl_export": "issues.jsonl",
-  "backend": "dolt",
-  "dolt_mode": "server",
-  "dolt_server_host": "127.0.0.1",
-  "dolt_server_port": 3306,
-  "dolt_database": "beads_holomush"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ dist/
 # MCP server state
 .serena/
 
+# Beads local state
+.beads/metadata.json
+
 # Documentation site
 site/build/
 site/.venv/


### PR DESCRIPTION
## Summary

- Removes `.beads/metadata.json` from git tracking (contains local agent state)
- Adds it to `.gitignore` so it stays local going forward

A backup is at `/tmp/beads-metadata.json.bak` to restore after merge.

## Test plan

- [x] Local file preserved after `git rm --cached`
- [x] `.gitignore` entry added
- [x] No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)