### PR TITLE
fix: use errors.New for sentinel errors instead of oops.Errorf

### DIFF
--- a/internal/auth/hasher.go
+++ b/internal/auth/hasher.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -36,7 +37,7 @@ const (
 )
 
 // ErrEmptyPassword is returned when attempting to hash an empty password.
-var ErrEmptyPassword = oops.Code("AUTH_EMPTY_PASSWORD").Errorf("password cannot be empty")
+var ErrEmptyPassword = errors.New("password cannot be empty")
 
 // PasswordHasher provides password hashing and verification.
 type PasswordHasher interface {

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"errors"
 	"log/slog"
 
 	"github.com/samber/oops"
@@ -27,22 +28,26 @@ const (
 )
 
 // Sentinel errors for special conditions.
+// These use errors.New so they work reliably with errors.Is/errors.As.
+// When structured context is needed, wrap the sentinel with oops at the call site:
+//
+//	oops.Code(CodeShutdownRequested).Wrap(ErrShutdownRequested)
 var (
 	// ErrShutdownRequested signals that a graceful shutdown has been requested.
 	// Command dispatchers should check for this error and initiate shutdown.
-	ErrShutdownRequested = oops.Code(CodeShutdownRequested).Errorf("shutdown requested")
+	ErrShutdownRequested = errors.New("shutdown requested")
 
 	// ErrEmptyCommandName is returned when registering a command with an empty name.
-	ErrEmptyCommandName = oops.Errorf("command name cannot be empty")
+	ErrEmptyCommandName = errors.New("command name cannot be empty")
 
 	// ErrNilHandler is returned when registering a command with a nil handler.
-	ErrNilHandler = oops.Errorf("command handler cannot be nil")
+	ErrNilHandler = errors.New("command handler cannot be nil")
 
 	// ErrNilRegistry is returned when creating a dispatcher with a nil registry.
-	ErrNilRegistry = oops.Errorf("registry cannot be nil")
+	ErrNilRegistry = errors.New("registry cannot be nil")
 
 	// ErrNilAccessControl is returned when creating a dispatcher with nil access control.
-	ErrNilAccessControl = oops.Errorf("access control cannot be nil")
+	ErrNilAccessControl = errors.New("access control cannot be nil")
 )
 
 // ErrUnknownCommand creates an error for an unknown command.


### PR DESCRIPTION
## Summary

- Convert 6 sentinel error vars from `oops.Errorf()`/`oops.Code().Errorf()` to `errors.New()` so `errors.Is()` comparisons work by design rather than by accident
- `internal/command/errors.go`: `ErrShutdownRequested`, `ErrEmptyCommandName`, `ErrNilHandler`, `ErrNilRegistry`, `ErrNilAccessControl`
- `internal/auth/hasher.go`: `ErrEmptyPassword`
- oops remains in use for operational errors at call sites where structured context (`.Code()`, `.With()`) is needed

## Why

Sentinel errors declared as `var ErrFoo = oops.Errorf("...")` have fragile identity semantics. `errors.Is()` only works because the var is initialized once at package load (pointer stability), not because oops guarantees it. Standard `errors.New()` provides this guarantee by design.

## Test plan

- [x] All 32 packages pass (`task test`)
- [x] No new lint issues (`task lint` — 16 pre-existing issues unchanged)
- [x] `errors.Is(err, command.ErrShutdownRequested)` assertions in shutdown_test.go continue to pass
- [x] `assert.ErrorIs(t, err, ErrEmptyCommandName)` and `ErrNilHandler` assertions in registry_test.go continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>