### PR TITLE
chore: unexport TxFromContext, update README for current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,24 @@ A modern MUSH platform combining classic text-based multiplayer gameplay with co
 
 ## Status
 
-**Phase 1 Complete** - Telnet server with event-sourced architecture, session persistence, and event replay.
+**Core systems implemented** — Telnet server, event-sourced architecture, Lua plugin system, world model, and ABAC access control.
 
 ### What Works Now
 
-- Connect via telnet and authenticate
-- Chat using `say` and `pose` commands
-- Disconnect and reconnect with missed event replay
-- Events persisted to PostgreSQL or in-memory store
-- WASM plugin host proof-of-concept
+- Telnet server with session persistence and event replay
+- Lua plugin system (gopher-lua) with manifest-defined ABAC policies
+- World model: locations, exits, objects, scenes, characters
+- ABAC (Attribute-Based Access Control) with Cedar-inspired policy DSL
+- Seed policies for player, builder, and admin roles
+- Plugin policy lifecycle: install on load, remove on unload, atomic replace
+- `say`, `pose`, `look`, `go`, building commands (`dig`, `link`)
 
 ### Planned Features
 
 - Web client (SvelteKit PWA)
-- Multiple locations and movement
 - Character creation and player accounts
-- Full WASM plugin API
-- ABAC access control
+- Go binary plugins (go-plugin) for complex extensions
+- Operator admin tools and control plane
 
 ## Quick Start
 
@@ -32,6 +33,7 @@ A modern MUSH platform combining classic text-based multiplayer gameplay with co
 
 - Go 1.23+
 - [Task](https://taskfile.dev/) (task runner)
+- PostgreSQL (for data storage)
 - Docker (for integration tests)
 
 ### Build and Run
@@ -63,7 +65,22 @@ telnet localhost 4000
 | `look`                  | Describe current location            |
 | `say <message>`         | Speak to others in the room          |
 | `pose <action>`         | Emote an action (e.g., `pose waves`) |
+| `go <exit>`             | Move through an exit                 |
+| `dig <exit> to "<loc>"` | Create a new location with exit      |
+| `link <exit> to <target>`| Link current location to another     |
+| `help`                  | List available commands               |
 | `quit`                  | Disconnect (session persists)        |
+
+## Architecture
+
+- **Go core** with event-oriented architecture
+- **Dual protocol**: telnet + web (planned)
+- **Lua plugins** (gopher-lua) with go-plugin for complex extensions (planned)
+- **PostgreSQL** for production data (in-memory store available for development)
+- **ABAC engine** with Cedar-inspired DSL, in-memory policy cache, pg_notify invalidation
+- **SvelteKit PWA** for web client (planned)
+
+See [Architecture](site/docs/contributors/architecture.md) for details.
 
 ## Development
 
@@ -81,6 +98,12 @@ task lint
 
 # Format code
 task fmt
+
+# Generate EBNF grammar + railroad diagram
+task generate:ebnf
+
+# Generate plugin JSON schema
+task generate:schema
 ```
 
 See [CLAUDE.md](CLAUDE.md) for AI assistant guidelines.
@@ -116,10 +139,8 @@ See [Verifying Releases](docs/reference/verifying-releases.md) for complete inst
 
 ## Documentation
 
-- [Getting Started](docs/reference/getting-started.md) - Setup and usage guide
-- [Architecture Overview](docs/reference/architecture-overview.md) - System design summary
-- [Full Architecture Design](docs/plans/2026-01-17-holomush-architecture-design.md) - Detailed specifications
-- [Verifying Releases](docs/reference/verifying-releases.md) - How to verify signed releases
+- [Architecture](site/docs/contributors/architecture.md) - System design overview
+- [Plugin Guide](site/docs/developers/plugin-guide.md) - Writing plugins with ABAC policies
 - [Contributing](CONTRIBUTING.md) - Contribution guidelines
 
 ## License

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -229,83 +229,83 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, cmd *cobra.Command, d
 		// if this ever happens unexpectedly in production.
 		slog.Error("ABAC stack not initialized: event store does not expose a connection pool")
 	} else {
-	abacPool := realStoreForABAC.Pool()
+		abacPool := realStoreForABAC.Pool()
 
-	abacStack, abacErr := abacsetup.BuildABACStack(ctx, abacsetup.ABACConfig{
-		Pool:          abacPool,
-		CharacterRepo: worldpostgres.NewCharacterRepository(abacPool),
-		AuditMode:     audit.ModeDenialsOnly,
-	})
-	if abacErr != nil {
-		return oops.Code("ABAC_SETUP_FAILED").Wrap(abacErr)
-	}
-	defer func() {
-		if closeErr := abacStack.Close(); closeErr != nil {
-			slog.Warn("error closing ABAC stack", "error", closeErr)
+		abacStack, abacErr := abacsetup.BuildABACStack(ctx, abacsetup.ABACConfig{
+			Pool:          abacPool,
+			CharacterRepo: worldpostgres.NewCharacterRepository(abacPool),
+			AuditMode:     audit.ModeDenialsOnly,
+		})
+		if abacErr != nil {
+			return oops.Code("ABAC_SETUP_FAILED").Wrap(abacErr)
 		}
-	}()
-	slog.Info("ABAC engine stack initialized")
+		defer func() {
+			if closeErr := abacStack.Close(); closeErr != nil {
+				slog.Warn("error closing ABAC stack", "error", closeErr)
+			}
+		}()
+		slog.Info("ABAC engine stack initialized")
 
-	// Start live policy cache invalidation (dedicated context to avoid race with later ctx reassignment)
-	listenerCtx, listenerCancel := context.WithCancel(ctx)
-	defer listenerCancel()
-	pgListener := policy.NewPgListener(databaseURL)
-	go func() {
-		if listenErr := abacStack.Cache.StartWithListener(listenerCtx, pgListener); listenErr != nil {
-			slog.Error("policy cache listener failed", "error", listenErr)
+		// Start live policy cache invalidation (dedicated context to avoid race with later ctx reassignment)
+		listenerCtx, listenerCancel := context.WithCancel(ctx)
+		defer listenerCancel()
+		pgListener := policy.NewPgListener(databaseURL)
+		go func() {
+			if listenErr := abacStack.Cache.StartWithListener(listenerCtx, pgListener); listenErr != nil {
+				slog.Error("policy cache listener failed", "error", listenErr)
+			}
+		}()
+
+		// Build world.Service with ABAC engine
+		worldService := world.NewService(world.ServiceConfig{
+			LocationRepo:  worldpostgres.NewLocationRepository(abacPool),
+			ExitRepo:      worldpostgres.NewExitRepository(abacPool),
+			ObjectRepo:    worldpostgres.NewObjectRepository(abacPool),
+			SceneRepo:     worldpostgres.NewSceneRepository(abacPool),
+			CharacterRepo: worldpostgres.NewCharacterRepository(abacPool),
+			PropertyRepo:  worldpostgres.NewPropertyRepository(abacPool),
+			Engine:        abacStack.Engine,
+			Transactor:    worldpostgres.NewTransactor(abacPool),
+		})
+
+		// Build plugin stack
+		var pluginsBaseDir string
+		if cfg.dataDir != "" {
+			pluginsBaseDir = cfg.dataDir
+		} else {
+			var pluginsDirErr error
+			pluginsBaseDir, pluginsDirErr = xdg.DataDir()
+			if pluginsDirErr != nil {
+				return oops.Code("PLUGINS_DIR_FAILED").With("operation", "get plugins directory").Wrap(pluginsDirErr)
+			}
 		}
-	}()
+		pluginsDir := filepath.Join(pluginsBaseDir, "plugins")
 
-	// Build world.Service with ABAC engine
-	worldService := world.NewService(world.ServiceConfig{
-		LocationRepo:  worldpostgres.NewLocationRepository(abacPool),
-		ExitRepo:      worldpostgres.NewExitRepository(abacPool),
-		ObjectRepo:    worldpostgres.NewObjectRepository(abacPool),
-		SceneRepo:     worldpostgres.NewSceneRepository(abacPool),
-		CharacterRepo: worldpostgres.NewCharacterRepository(abacPool),
-		PropertyRepo:  worldpostgres.NewPropertyRepository(abacPool),
-		Engine:        abacStack.Engine,
-		Transactor:    worldpostgres.NewTransactor(abacPool),
-	})
+		hostFuncs := hostfunc.New(nil, // KV store not yet available
+			hostfunc.WithEngine(abacStack.Engine),
+			hostfunc.WithWorldService(worldService),
+		)
+		luaHost := pluginlua.NewHostWithFunctions(hostFuncs)
+		pluginManager := plugins.NewManager(pluginsDir,
+			plugins.WithLuaHost(luaHost),
+			plugins.WithPolicyInstaller(abacStack.PolicyInstaller),
+		)
 
-	// Build plugin stack
-	var pluginsBaseDir string
-	if cfg.dataDir != "" {
-		pluginsBaseDir = cfg.dataDir
-	} else {
-		var pluginsDirErr error
-		pluginsBaseDir, pluginsDirErr = xdg.DataDir()
-		if pluginsDirErr != nil {
-			return oops.Code("PLUGINS_DIR_FAILED").With("operation", "get plugins directory").Wrap(pluginsDirErr)
+		// Complete circular dependency: set plugin registry
+		abacStack.PluginProvider.SetRegistry(pluginManager)
+
+		// Load all discovered plugins
+		if loadErr := pluginManager.LoadAll(ctx); loadErr != nil {
+			slog.Error("failed to load plugins", "error", loadErr)
 		}
-	}
-	pluginsDir := filepath.Join(pluginsBaseDir, "plugins")
-
-	hostFuncs := hostfunc.New(nil, // KV store not yet available
-		hostfunc.WithEngine(abacStack.Engine),
-		hostfunc.WithWorldService(worldService),
-	)
-	luaHost := pluginlua.NewHostWithFunctions(hostFuncs)
-	pluginManager := plugins.NewManager(pluginsDir,
-		plugins.WithLuaHost(luaHost),
-		plugins.WithPolicyInstaller(abacStack.PolicyInstaller),
-	)
-
-	// Complete circular dependency: set plugin registry
-	abacStack.PluginProvider.SetRegistry(pluginManager)
-
-	// Load all discovered plugins
-	if loadErr := pluginManager.LoadAll(ctx); loadErr != nil {
-		slog.Error("failed to load plugins", "error", loadErr)
-	}
-	defer func() {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer shutdownCancel()
-		if closeErr := pluginManager.Close(shutdownCtx); closeErr != nil {
-			slog.Warn("error closing plugin manager", "error", closeErr)
-		}
-	}()
-	slog.Info("plugin stack initialized", "plugins_dir", pluginsDir)
+		defer func() {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer shutdownCancel()
+			if closeErr := pluginManager.Close(shutdownCtx); closeErr != nil {
+				slog.Warn("error closing plugin manager", "error", closeErr)
+			}
+		}()
+		slog.Info("plugin stack initialized", "plugins_dir", pluginsDir)
 	} // end ABAC stack wiring (hasPool)
 
 	certsDir, err := deps.CertsDirGetter()

--- a/internal/plugin/hostfunc/commands_test.go
+++ b/internal/plugin/hostfunc/commands_test.go
@@ -1234,7 +1234,6 @@ func TestGetCommandHelp_NoCapabilities_NoCheck(t *testing.T) {
 	assert.Equal(t, lua.LNil, errVal)
 }
 
-
 func TestGetCommandHelp_NilEngine_FailsClosed(t *testing.T) {
 	registry := &mockCommandRegistry{
 		commands: []command.CommandEntry{

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -220,7 +220,6 @@ func (m *Manager) Close(ctx context.Context) error {
 	return nil
 }
 
-
 // IsPluginLoaded returns true if the named plugin is currently loaded.
 // Implements attribute.PluginRegistry for ABAC attribute resolution.
 func (m *Manager) IsPluginLoaded(name string) bool {

--- a/internal/world/postgres/export_test.go
+++ b/internal/world/postgres/export_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TxFromContext exports txFromContext for testing in the external test package.
+func TxFromContext(ctx context.Context) pgx.Tx {
+	return txFromContext(ctx)
+}

--- a/internal/world/postgres/helpers.go
+++ b/internal/world/postgres/helpers.go
@@ -28,9 +28,9 @@ type execer interface {
 // txKey is the context key for an active pgx.Tx.
 type txKey struct{}
 
-// TxFromContext returns the active pgx.Tx stored in context by InTransaction,
+// txFromContext returns the active pgx.Tx stored in context by InTransaction,
 // or nil if no transaction is active.
-func TxFromContext(ctx context.Context) pgx.Tx {
+func txFromContext(ctx context.Context) pgx.Tx {
 	tx, ok := ctx.Value(txKey{}).(pgx.Tx)
 	if !ok {
 		return nil
@@ -40,7 +40,7 @@ func TxFromContext(ctx context.Context) pgx.Tx {
 
 // execerFromCtx returns the active transaction from context, or falls back to the pool.
 func execerFromCtx(ctx context.Context, pool execer) execer {
-	if tx := TxFromContext(ctx); tx != nil {
+	if tx := txFromContext(ctx); tx != nil {
 		return tx
 	}
 	return pool


### PR DESCRIPTION
## Summary

- **Unexport `TxFromContext`** — renamed to `txFromContext` with `export_test.go` for external test access (closes holomush-i0s6)
- **Update README.md** — reflects current architecture: Lua plugin system, world model, ABAC, building commands. Removes stale WASM/Extism references (closes holomush-nzu)
- **Fix CLAUDE.md** — remove WASM comparison in plugin test section

## Test plan

- [x] `task build` — clean
- [x] `task lint` — 0 issues
- [x] `internal/world/postgres` tests pass (TxFromContext via export_test.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized docs: updated status, expanded feature list, added PostgreSQL prerequisite, new Architecture and Plugin Guide, and refreshed Getting Started/Development pages.

* **New Features**
  * Added new commands (go, dig, link, help) and expanded core system capabilities and policy support.

* **Refactor**
  * Startup sequencing improved so access-control and core services initialize before plugins; lifecycle and error logging tightened.

* **Tests**
  * Added a test helper to expose transaction-context behavior for external tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->