### PR TITLE
ci: bump golangci-lint from v2.1.6 to v2.11.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Install golangci-lint v2
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.1.6/install.sh \
-            | sh -s -- -b "$(go env GOPATH)/bin" v2.1.6
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.3/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.11.3
 
       - name: Cache rumdl
         id: cache-rumdl


### PR DESCRIPTION
v2.1.6 was built with Go 1.24, causing `can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)` on all dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling used in continuous integration pipeline for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->