### PR TITLE
feat(abac): Epic 7 cleanup — action constants, Effect.Valid(), Lua API doc

### DIFF
--- a/docs/plans/2026-02-06-full-abac-phase-7.6.md
+++ b/docs/plans/2026-02-06-full-abac-phase-7.6.md
@@ -58,6 +58,10 @@ This task uses **5 atomic commits** (T28-pkg1 through T28-pkg5), each covering s
 - [ ] Rollback strategy documented ([Decision #65](../specs/decisions/epic7/phase-7.6/065-git-revert-migration-rollback.md)): `git revert` of Task 28 commit(s) restores `AccessControl.Check()` call sites
 - [ ] Database rollback procedure documented ([Decision #65](../specs/decisions/epic7/phase-7.6/065-git-revert-migration-rollback.md#database-migration-rollback-procedure)) covering all 3 migration files (000015, 000016, 000017) with down-migration order, backup requirements, and data recovery steps
 
+**Breaking Changes:**
+
+- **Lua API:** `list_commands` host function return format changed from flat string list to structured table with `name` and `incomplete` fields per command entry. Plugins using the old format will need updating.
+
 **Files:**
 
 - Modify: `cmd/holomush/main.go` (or server bootstrap file) — DI wiring

--- a/internal/access/policy/types/types.go
+++ b/internal/access/policy/types/types.go
@@ -37,6 +37,11 @@ func (e Effect) String() string {
 	return fmt.Sprintf("unknown(%d)", int(e))
 }
 
+// Valid returns true if e is a known Effect value.
+func (e Effect) Valid() bool {
+	return e >= 0 && int(e) < len(effectStrings)
+}
+
 // PolicyEffect is a string type used in policy declarations to specify
 // the intended effect when a policy matches.
 type PolicyEffect string
@@ -81,6 +86,17 @@ func (pe PolicyEffect) ToEffect() Effect {
 		return EffectDefaultDeny
 	}
 }
+
+// Action constants for well-known ABAC actions.
+const (
+	ActionRead    = "read"
+	ActionWrite   = "write"
+	ActionDelete  = "delete"
+	ActionEnter   = "enter"
+	ActionExecute = "execute"
+	ActionEmit    = "emit"
+	ActionUse     = "use"
+)
 
 // AccessRequest represents a subject attempting an action on a resource.
 //


### PR DESCRIPTION
## Summary

- Add well-known action constants (`ActionRead`, `ActionWrite`, `ActionDelete`, `ActionEnter`, `ActionExecute`, `ActionEmit`, `ActionUse`) to the `types` package for consistent use across call sites
- Add `Effect.Valid()` method for enum validation
- Document breaking Lua API `list_commands` return format change in Phase 7.6 plan

Part of closing Epic 7 (Full ABAC).

## Test plan

- [x] `task test` — all tests pass
- [x] `task lint` — no Go lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated Lua plugin API: `list_commands` now returns structured table with per-command fields (name, incomplete) instead of flat string list. Existing plugins relying on the old format require updates.

* **Improvements**
  * Enhanced authorization and access control system for improved security and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->