### PR TITLE
fix(telnet): address PR #116 review findings

### DIFF
--- a/internal/telnet/guest_auth.go
+++ b/internal/telnet/guest_auth.go
@@ -45,7 +45,7 @@ func NewGemstoneElementTheme() *GemstoneElementTheme {
 
 // Name returns the theme identifier.
 func (t *GemstoneElementTheme) Name() string {
-	return "GemstoneElement"
+	return "gemstone_element"
 }
 
 // Generate returns a random (gemstone, element) pair.

--- a/internal/telnet/guest_auth_test.go
+++ b/internal/telnet/guest_auth_test.go
@@ -18,7 +18,7 @@ import (
 // TestGemstoneElementTheme_Name verifies the theme name.
 func TestGemstoneElementTheme_Name(t *testing.T) {
 	theme := NewGemstoneElementTheme()
-	assert.Equal(t, "GemstoneElement", theme.Name())
+	assert.Equal(t, "gemstone_element", theme.Name())
 }
 
 // TestGemstoneElementTheme_Generate verifies generated names are non-empty and distinct.

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -118,8 +118,9 @@ func connectAsGuest(c *testTelnetClient) string {
 // full command→event subscription pipeline is ready. This replaces fixed
 // time.Sleep calls that are flaky under CI load.
 func waitForPipeline(c *testTelnetClient) {
-	c.SendLine(`say __ready__`)
-	c.ReadUntil("__ready__", 5*time.Second)
+	probe := "__ready__:" + ulid.Make().String()
+	c.SendLine("say " + probe)
+	c.ReadUntil(fmt.Sprintf(`You say, "%s"`, probe), 5*time.Second)
 }
 
 var _ = Describe("Telnet Vertical Slice E2E", func() {
@@ -454,7 +455,7 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			line := client.ReadLine()
 			Expect(line).To(ContainSubstring(`You say, "Persistence test"`))
 
-			// Poll for event persistence instead of fixed sleep
+			// Poll for the specific "Persistence test" event (not readiness probes)
 			stream := "location:" + startLocation.String()
 			Eventually(func() bool {
 				events, err := eventStore.Replay(testCtx, stream, ulid.ULID{}, 100)
@@ -462,12 +463,12 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 					return false
 				}
 				for _, ev := range events {
-					if ev.Type == core.EventTypeSay {
+					if ev.Type == core.EventTypeSay && strings.Contains(string(ev.Payload), "Persistence test") {
 						return true
 					}
 				}
 				return false
-			}, 5*time.Second, 50*time.Millisecond).Should(BeTrue(), "expected a say event persisted")
+			}, 5*time.Second, 50*time.Millisecond).Should(BeTrue(), "expected 'Persistence test' say event persisted")
 		})
 	})
 

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -114,6 +114,14 @@ func connectAsGuest(c *testTelnetClient) string {
 	return match[1]
 }
 
+// waitForPipeline sends a probe command and waits for the echo, proving the
+// full command→event subscription pipeline is ready. This replaces fixed
+// time.Sleep calls that are flaky under CI load.
+func waitForPipeline(c *testTelnetClient) {
+	c.SendLine(`say __ready__`)
+	c.ReadUntil("__ready__", 5*time.Second)
+}
+
 var _ = Describe("Telnet Vertical Slice E2E", func() {
 	var (
 		testCtx      context.Context
@@ -312,8 +320,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
 
-			// Small delay to let subscriptions establish
-			time.Sleep(200 * time.Millisecond)
+			waitForPipeline(clientA)
+			waitForPipeline(clientB)
 		})
 
 		AfterEach(func() {
@@ -359,7 +367,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
 
-			time.Sleep(200 * time.Millisecond)
+			waitForPipeline(clientA)
+			waitForPipeline(clientB)
 		})
 
 		AfterEach(func() {
@@ -403,7 +412,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
-			time.Sleep(200 * time.Millisecond)
+			waitForPipeline(clientA)
+			waitForPipeline(clientB)
 
 			// A says something, B receives
 			clientA.SendLine(`say Before quit`)
@@ -415,7 +425,6 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			clientA.SendLine("quit")
 			_ = clientA.ReadLine() // Goodbye!
 			clientA.Close()
-			time.Sleep(200 * time.Millisecond)
 
 			// C connects and says something — B should receive
 			clientC, err := newTestTelnetClient(telnetAddr)
@@ -423,7 +432,7 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			defer clientC.Close()
 
 			connectAsGuest(clientC)
-			time.Sleep(200 * time.Millisecond)
+			waitForPipeline(clientC)
 
 			clientC.SendLine(`say After A left`)
 			_ = clientC.ReadLine()
@@ -439,30 +448,26 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			defer client.Close()
 
 			connectAsGuest(client)
-			time.Sleep(200 * time.Millisecond)
+			waitForPipeline(client)
 
 			client.SendLine(`say Persistence test`)
 			line := client.ReadLine()
 			Expect(line).To(ContainSubstring(`You say, "Persistence test"`))
 
-			// Wait for event to be persisted
-			time.Sleep(500 * time.Millisecond)
-
-			// Replay events from the location stream
+			// Poll for event persistence instead of fixed sleep
 			stream := "location:" + startLocation.String()
-			events, err := eventStore.Replay(testCtx, stream, ulid.ULID{}, 100)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(events)).To(BeNumerically(">", 0), "expected at least one event persisted")
-
-			// Verify at least one say event
-			var foundSay bool
-			for _, ev := range events {
-				if ev.Type == core.EventTypeSay {
-					foundSay = true
-					break
+			Eventually(func() bool {
+				events, err := eventStore.Replay(testCtx, stream, ulid.ULID{}, 100)
+				if err != nil {
+					return false
 				}
-			}
-			Expect(foundSay).To(BeTrue(), "expected a say event in persisted events")
+				for _, ev := range events {
+					if ev.Type == core.EventTypeSay {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Second, 50*time.Millisecond).Should(BeTrue(), "expected a say event persisted")
 		})
 	})
 
@@ -474,20 +479,20 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 
 			connectAsGuest(client)
 
-			time.Sleep(200 * time.Millisecond)
-
-			events, err := eventStore.Replay(testCtx,
-				"location:"+startLocation.String(), ulid.ULID{}, 100)
-			Expect(err).NotTo(HaveOccurred())
-
-			found := false
-			for _, e := range events {
-				if string(e.Type) == "arrive" {
-					found = true
-					break
+			// Poll for arrive event persistence
+			Eventually(func() bool {
+				events, err := eventStore.Replay(testCtx,
+					"location:"+startLocation.String(), ulid.ULID{}, 100)
+				if err != nil {
+					return false
 				}
-			}
-			Expect(found).To(BeTrue(), "expected arrive event in store")
+				for _, e := range events {
+					if string(e.Type) == "arrive" {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Second, 50*time.Millisecond).Should(BeTrue(), "expected arrive event in store")
 		})
 
 		It("emits leave event on guest disconnect", func() {

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -115,12 +115,15 @@ func connectAsGuest(c *testTelnetClient) string {
 }
 
 // waitForPipeline sends a probe command and waits for the echo, proving the
-// full command→event subscription pipeline is ready. This replaces fixed
-// time.Sleep calls that are flaky under CI load.
-func waitForPipeline(c *testTelnetClient) {
+// full command→event subscription pipeline is ready. Peers drain the broadcast
+// so probe messages don't leak into subsequent assertions.
+func waitForPipeline(c *testTelnetClient, peers ...*testTelnetClient) {
 	probe := "__ready__:" + ulid.Make().String()
 	c.SendLine("say " + probe)
 	c.ReadUntil(fmt.Sprintf(`You say, "%s"`, probe), 5*time.Second)
+	for _, p := range peers {
+		p.ReadUntil(probe, 5*time.Second)
+	}
 }
 
 var _ = Describe("Telnet Vertical Slice E2E", func() {
@@ -321,8 +324,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
 
-			waitForPipeline(clientA)
-			waitForPipeline(clientB)
+			waitForPipeline(clientA, clientB)
+			waitForPipeline(clientB, clientA)
 		})
 
 		AfterEach(func() {
@@ -368,8 +371,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
 
-			waitForPipeline(clientA)
-			waitForPipeline(clientB)
+			waitForPipeline(clientA, clientB)
+			waitForPipeline(clientB, clientA)
 		})
 
 		AfterEach(func() {
@@ -413,8 +416,8 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 
 			connectAsGuest(clientA)
 			connectAsGuest(clientB)
-			waitForPipeline(clientA)
-			waitForPipeline(clientB)
+			waitForPipeline(clientA, clientB)
+			waitForPipeline(clientB, clientA)
 
 			// A says something, B receives
 			clientA.SendLine(`say Before quit`)
@@ -433,7 +436,7 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 			defer clientC.Close()
 
 			connectAsGuest(clientC)
-			waitForPipeline(clientC)
+			waitForPipeline(clientC, clientB)
 
 			clientC.SendLine(`say After A left`)
 			_ = clientC.ReadLine()


### PR DESCRIPTION
## Summary

- Fix theme name to return `gemstone_element` (snake_case) per spec instead of `GemstoneElement` (PascalCase)

## Findings Addressed

| Finding | Status | Resolution |
|---------|--------|------------|
| .5 | Fixed | Theme name snake_case |
| .22 | Already fixed | Error leak resolved in PR #117 |
| .18 | Already fixed | Helper removed in PR #117 |
| .23 | Closed | No redundancy — active map is the only data structure |
| .6 | Already fixed | Config system in PR #118 |
| .15 | Closed | Known limitation, future work |
| .10 | Deferred | Rate limiting needs design |
| .4 | Deferred | Connection ULID needs design |
| .20 | Deferred | Sleep→Eventually needs subscription readiness signal |

## Test plan

- [x] `task test` — all pass
- [x] `task lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized a public theme identifier to a lowercase format for consistency (may affect integrations that compare theme names).

* **Tests**
  * Improved end-to-end tests by replacing fixed delays with readiness probes and polling-based checks, reducing flakiness and improving CI stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->