### PR TITLE
fix(web): cancel event stream on disconnect, detect stream loss

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -12,6 +12,11 @@
   let events: Array<{ type: string; characterName: string; text: string }> = $state([]);
   let error = $state("");
 
+  // AbortController cancels the active StreamEvents when disconnecting.
+  // Without this, old streams keep running after reconnect (causing dupes)
+  // and the UI stays "connected" after server restarts.
+  let streamAbort: AbortController | null = null;
+
   async function login() {
     error = "";
     try {
@@ -30,8 +35,15 @@
   }
 
   async function startEventStream() {
+    streamAbort?.abort();
+    const abort = new AbortController();
+    streamAbort = abort;
+
     try {
-      for await (const resp of client.streamEvents({ sessionId })) {
+      for await (const resp of client.streamEvents(
+        { sessionId },
+        { signal: abort.signal },
+      )) {
         const ev = resp.event;
         if (!ev) continue;
         events = [
@@ -43,8 +55,17 @@
           },
         ];
       }
+      // Stream ended cleanly (server closed it)
+      if (connected && !abort.signal.aborted) {
+        error = "Connection to server lost.";
+        connected = false;
+      }
     } catch {
-      // Stream ended
+      // Stream cancelled (disconnect) or network error
+      if (connected && !abort.signal.aborted) {
+        error = "Connection to server lost.";
+        connected = false;
+      }
     }
   }
 
@@ -60,6 +81,8 @@
   }
 
   async function disconnect() {
+    streamAbort?.abort();
+    streamAbort = null;
     try {
       await client.disconnect({ sessionId });
     } catch {


### PR DESCRIPTION
## Summary

- Uses `AbortController` to cancel the active `StreamEvents` connection when disconnecting
- Prevents duplicate events from stale streams accumulating across reconnect cycles
- Detects server-side stream closure and resets UI to disconnected state

**Root cause:** `startEventStream()` ran fire-and-forget — old streams kept running after disconnect/reconnect, producing duplicate events. The `disconnect()` function cleared UI state but didn't cancel the HTTP stream.

**Fixes:** holomush-qve.11, holomush-qve.12, holomush-qve.13

## Test Plan

- [x] Go tests pass (`task test`)
- [x] SvelteKit builds (`pnpm build`)
- [x] Manual: connect → say → event appears (1 copy)
- [x] Manual: disconnect → reconnect → no stale events
- [x] Manual: say after reconnect → 1 event, no duplicates
- [x] Manual: 3 rapid disconnect/reconnect cycles → clean state, no dupes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event stream cancellation to prevent stale connections during client disconnects and reconnects
  * Enhanced stream lifecycle management for more reliable connection state updates
  * Fixed connection state handling to properly reflect network failures and server-initiated disconnections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->