### PR TITLE
feat(gateway): poll for TLS certs on startup instead of failing

### DIFF
--- a/cmd/holomush/cert_poll.go
+++ b/cmd/holomush/cert_poll.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"context"
+	cryptotls "crypto/tls"
+	"errors"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/samber/oops"
+)
+
+// certPollInterval is the interval between cert availability checks.
+const certPollInterval = 500 * time.Millisecond
+
+// defaultCertPollTimeout is the maximum time to wait for TLS certs to become available.
+const defaultCertPollTimeout = 30 * time.Second
+
+// gatewayTLSConfig holds the results of loading all gateway TLS certificates.
+type gatewayTLSConfig struct {
+	gameID     string
+	clientTLS  *cryptotls.Config
+	controlTLS *cryptotls.Config
+}
+
+// isTransientCertError returns true if the error is a transient file-not-found
+// error that may resolve when cert files are created by the core process.
+func isTransientCertError(err error) bool {
+	return err != nil && errors.Is(err, os.ErrNotExist)
+}
+
+// tryLoadCerts attempts to load all gateway TLS certificates in one pass.
+func tryLoadCerts(deps *GatewayDeps, certsDir, component string) (*gatewayTLSConfig, error) {
+	gameID, err := deps.GameIDExtractor(certsDir)
+	if err != nil {
+		return nil, oops.Code("GAME_ID_EXTRACT_FAILED").
+			With("operation", "extract game_id from CA").
+			With("certs_dir", certsDir).
+			Wrap(err)
+	}
+
+	clientTLS, err := deps.ClientTLSLoader(certsDir, component, gameID)
+	if err != nil {
+		return nil, oops.Code("TLS_LOAD_FAILED").
+			With("operation", "load client TLS certificates").
+			With("component", component).
+			With("certs_dir", certsDir).
+			Wrap(err)
+	}
+
+	controlTLS, err := deps.ControlTLSLoader(certsDir, component)
+	if err != nil {
+		return nil, oops.Code("CONTROL_TLS_FAILED").
+			With("operation", "load control TLS config").
+			With("component", component).
+			With("certs_dir", certsDir).
+			Wrap(err)
+	}
+
+	return &gatewayTLSConfig{
+		gameID:     gameID,
+		clientTLS:  clientTLS,
+		controlTLS: controlTLS,
+	}, nil
+}
+
+// waitForTLSCerts polls for TLS certificate availability with the given timeout.
+// It retries on file-not-found errors (transient) but fails immediately on
+// permanent errors like invalid certificate format. This allows the gateway
+// to start before core has generated TLS certificates.
+//
+//nolint:unparam // component is always "gateway" today but the parameter keeps the function general
+func waitForTLSCerts(ctx context.Context, deps *GatewayDeps, certsDir, component string, timeout time.Duration) (*gatewayTLSConfig, error) {
+	// Try immediately — no waiting if certs are already available.
+	result, err := tryLoadCerts(deps, certsDir, component)
+	if err == nil {
+		return result, nil
+	}
+	if !isTransientCertError(err) {
+		return nil, err
+	}
+
+	// Certs not found — poll until available or timeout.
+	slog.Info("waiting for TLS certificates", "certs_dir", certsDir, "timeout", timeout)
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(certPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, oops.
+				Code("CERT_POLL_TIMEOUT").
+				With("timeout", timeout).
+				With("certs_dir", certsDir).
+				Wrapf(err, "timed out waiting for TLS certificates")
+		case <-ticker.C:
+			result, err = tryLoadCerts(deps, certsDir, component)
+			if err == nil {
+				slog.Info("TLS certificates loaded", "certs_dir", certsDir)
+				return result, nil
+			}
+			if !isTransientCertError(err) {
+				return nil, err
+			}
+			slog.Debug("still waiting for TLS certificates", "certs_dir", certsDir, "error", err)
+		}
+	}
+}

--- a/cmd/holomush/cert_poll_test.go
+++ b/cmd/holomush/cert_poll_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"context"
+	cryptotls "crypto/tls"
+	"errors"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// notFoundErr wraps os.ErrNotExist to simulate file-not-found through oops wrapping.
+func notFoundErr(msg string) error {
+	return fmt.Errorf("%s: %w", msg, os.ErrNotExist)
+}
+
+func TestWaitForTLSCerts_ImmediateSuccess(t *testing.T) {
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "test-game", nil
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	result, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "test-game", result.gameID)
+	assert.NotNil(t, result.clientTLS)
+	assert.NotNil(t, result.controlTLS)
+}
+
+func TestWaitForTLSCerts_PollsUntilAvailable(t *testing.T) {
+	var calls atomic.Int32
+
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		n := calls.Add(1)
+		if n <= 2 {
+			return "", notFoundErr("root-ca.crt not found")
+		}
+		return "test-game", nil
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	start := time.Now()
+	result, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", 5*time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-game", result.gameID)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3), "should have polled at least 3 times")
+	assert.GreaterOrEqual(t, elapsed, 800*time.Millisecond, "should have waited for at least 2 poll intervals")
+}
+
+func TestWaitForTLSCerts_PermanentErrorFailsImmediately(t *testing.T) {
+	permanentErr := fmt.Errorf("invalid certificate format")
+
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "", permanentErr
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	start := time.Now()
+	_, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", 5*time.Second)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid certificate format")
+	assert.Less(t, elapsed, 500*time.Millisecond, "permanent errors should fail immediately without polling")
+}
+
+func TestWaitForTLSCerts_ClientTLSTransientRetries(t *testing.T) {
+	var clientCalls atomic.Int32
+
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "test-game", nil
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		n := clientCalls.Add(1)
+		if n <= 2 {
+			return nil, notFoundErr("gateway.crt not found")
+		}
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	result, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "test-game", result.gameID)
+	assert.GreaterOrEqual(t, clientCalls.Load(), int32(3))
+}
+
+func TestWaitForTLSCerts_ControlTLSTransientRetries(t *testing.T) {
+	var controlCalls atomic.Int32
+
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "test-game", nil
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		n := controlCalls.Add(1)
+		if n <= 2 {
+			return nil, notFoundErr("gateway.crt not found")
+		}
+		return &cryptotls.Config{}, nil
+	}
+
+	result, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "test-game", result.gameID)
+	assert.GreaterOrEqual(t, controlCalls.Load(), int32(3))
+}
+
+func TestWaitForTLSCerts_Timeout(t *testing.T) {
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "", notFoundErr("root-ca.crt not found")
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	start := time.Now()
+	_, err := waitForTLSCerts(context.Background(), deps, "/fake/certs", "gateway", time.Second)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.True(t, elapsed >= 900*time.Millisecond, "should wait close to the timeout")
+	assert.True(t, elapsed < 2*time.Second, "should not wait much longer than timeout")
+}
+
+func TestWaitForTLSCerts_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	deps := &GatewayDeps{}
+	deps.GameIDExtractor = func(_ string) (string, error) {
+		return "", notFoundErr("root-ca.crt not found")
+	}
+	deps.ClientTLSLoader = func(_, _, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+	deps.ControlTLSLoader = func(_, _ string) (*cryptotls.Config, error) {
+		return &cryptotls.Config{}, nil
+	}
+
+	// Cancel after a short delay
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := waitForTLSCerts(ctx, deps, "/fake/certs", "gateway", 30*time.Second)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestIsTransientCertError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{"nil error", nil, false},
+		{"file not found", os.ErrNotExist, true},
+		{"wrapped file not found", fmt.Errorf("reading cert: %w", os.ErrNotExist), true},
+		{"deeply wrapped file not found", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", os.ErrNotExist)), true},
+		{"permission denied", os.ErrPermission, false},
+		{"generic error", fmt.Errorf("invalid certificate"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.transient, isTransientCertError(tt.err))
+		})
+	}
+}

--- a/cmd/holomush/deps.go
+++ b/cmd/holomush/deps.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	cryptotls "crypto/tls"
 	"net"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -72,6 +73,12 @@ type CoreDeps struct {
 // All fields with nil values will use their default implementations.
 type GatewayDeps struct {
 	CommonDeps
+
+	// CertPollTimeout is the maximum time to wait for TLS certificates to
+	// become available. The gateway polls for certs on startup, allowing it
+	// to start before the core process has generated them.
+	// Default: 30s (defaultCertPollTimeout)
+	CertPollTimeout time.Duration
 
 	// GameIDExtractor extracts game ID from CA certificate.
 	// Default: control.ExtractGameIDFromCA

--- a/cmd/holomush/deps_test.go
+++ b/cmd/holomush/deps_test.go
@@ -833,6 +833,9 @@ func TestRunGatewayWithDeps_GRPCClientFactoryError(t *testing.T) {
 			CertsDirGetter: func() (string, error) {
 				return "/tmp/certs", nil
 			},
+			ControlTLSLoader: func(_, _ string) (*cryptotls.Config, error) {
+				return testTLSConfig(), nil
+			},
 		},
 		GameIDExtractor: func(_ string) (string, error) {
 			return "test-game-id", nil

--- a/cmd/holomush/gateway.go
+++ b/cmd/holomush/gateway.go
@@ -152,16 +152,14 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, cmd *cobra.Comm
 		return oops.Code("CERTS_DIR_FAILED").With("operation", "get certs directory").Wrap(err)
 	}
 
-	// Extract game_id from CA certificate for proper ServerName verification
-	gameID, err := deps.GameIDExtractor(certsDir)
-	if err != nil {
-		return oops.Code("GAME_ID_EXTRACT_FAILED").With("operation", "extract game_id from CA").With("certs_dir", certsDir).Wrap(err)
+	// Poll for TLS certificates — allows gateway to start before core generates certs.
+	certPollTimeout := deps.CertPollTimeout
+	if certPollTimeout <= 0 {
+		certPollTimeout = defaultCertPollTimeout
 	}
-
-	// Load TLS client certificates for mTLS connection to core
-	tlsConfig, err := deps.ClientTLSLoader(certsDir, "gateway", gameID)
+	tlsCfg, err := waitForTLSCerts(ctx, deps, certsDir, "gateway", certPollTimeout)
 	if err != nil {
-		return oops.Code("TLS_LOAD_FAILED").With("operation", "load TLS certificates").With("component", "gateway").Wrap(err)
+		return err
 	}
 
 	slog.Info("TLS certificates loaded", "certs_dir", certsDir)
@@ -169,7 +167,7 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, cmd *cobra.Comm
 	// Create gRPC client with mTLS
 	grpcClient, err := deps.GRPCClientFactory(ctx, holoGRPC.ClientConfig{
 		Address:   cfg.CoreAddr,
-		TLSConfig: tlsConfig,
+		TLSConfig: tlsCfg.clientTLS,
 	})
 	if err != nil {
 		return oops.Code("GRPC_CLIENT_CREATE_FAILED").With("operation", "create gRPC client").With("core_addr", cfg.CoreAddr).Wrap(err)
@@ -185,17 +183,11 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, cmd *cobra.Comm
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Start control gRPC server (always enabled)
-	controlTLSConfig, tlsErr := deps.ControlTLSLoader(certsDir, "gateway")
-	if tlsErr != nil {
-		return oops.Code("CONTROL_TLS_FAILED").With("operation", "load control TLS config").With("component", "gateway").Wrap(tlsErr)
-	}
-
 	controlGRPCServer, err := deps.ControlServerFactory("gateway", func() { cancel() })
 	if err != nil {
 		return oops.Code("CONTROL_SERVER_CREATE_FAILED").With("operation", "create control gRPC server").Wrap(err)
 	}
-	controlErrChan, err := controlGRPCServer.Start(cfg.ControlAddr, controlTLSConfig)
+	controlErrChan, err := controlGRPCServer.Start(cfg.ControlAddr, tlsCfg.controlTLS)
 	if err != nil {
 		return oops.Code("CONTROL_SERVER_START_FAILED").With("operation", "start control gRPC server").With("addr", cfg.ControlAddr).Wrap(err)
 	}

--- a/cmd/holomush/gateway_test.go
+++ b/cmd/holomush/gateway_test.go
@@ -181,17 +181,25 @@ func TestGatewayCommand_Help(t *testing.T) {
 }
 
 func TestGatewayCommand_MissingCertificates(t *testing.T) {
-	// Set certs directory to a non-existent path
-	t.Setenv("XDG_CONFIG_HOME", "/nonexistent/path/that/does/not/exist")
+	// Gateway should poll for certs and eventually time out when they never appear.
+	cfg := &gatewayConfig{
+		TelnetAddr:  ":4201",
+		CoreAddr:    "localhost:9000",
+		ControlAddr: "127.0.0.1:9002",
+		LogFormat:   "json",
+	}
 
-	cmd := NewRootCmd()
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	cmd.SetOut(buf)
-	cmd.SetErr(errBuf)
-	cmd.SetArgs([]string{"gateway"})
+	deps := &GatewayDeps{
+		CertPollTimeout: time.Millisecond, // Fail fast in tests
+		CommonDeps: CommonDeps{
+			CertsDirGetter: func() (string, error) {
+				return "/nonexistent/path/certs", nil
+			},
+		},
+	}
 
-	err := cmd.Execute()
+	cmd := newMockCmd()
+	err := runGatewayWithDeps(context.Background(), cfg, cmd, deps)
 	require.Error(t, err, "Expected error when certificates are missing")
 
 	// Error should mention TLS or certificates
@@ -256,9 +264,9 @@ func TestGatewayCommand_CAExtractionFails(t *testing.T) {
 }
 
 func TestGatewayCommand_TLSLoadFails(t *testing.T) {
-	// Create a certs directory with a valid CA but invalid gateway certificate
+	// CA exists but gateway cert is missing — transient error that polls and times out.
 	tmpDir := t.TempDir()
-	certsDir := tmpDir + "/holomush/certs"
+	certsDir := filepath.Join(tmpDir, "holomush", "certs")
 
 	// Generate a valid CA
 	gameID := "test-gateway-tls-fail"
@@ -268,16 +276,24 @@ func TestGatewayCommand_TLSLoadFails(t *testing.T) {
 	// Save CA only (no gateway certificate)
 	require.NoError(t, tlscerts.SaveCertificates(certsDir, ca, nil), "failed to save CA")
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	cfg := &gatewayConfig{
+		TelnetAddr:  ":4201",
+		CoreAddr:    "localhost:9000",
+		ControlAddr: "127.0.0.1:9002",
+		LogFormat:   "json",
+	}
 
-	cmd := NewRootCmd()
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	cmd.SetOut(buf)
-	cmd.SetErr(errBuf)
-	cmd.SetArgs([]string{"gateway"})
+	deps := &GatewayDeps{
+		CertPollTimeout: time.Millisecond, // Fail fast in tests
+		CommonDeps: CommonDeps{
+			CertsDirGetter: func() (string, error) {
+				return certsDir, nil
+			},
+		},
+	}
 
-	err = cmd.Execute()
+	cmd := newMockCmd()
+	err = runGatewayWithDeps(context.Background(), cfg, cmd, deps)
 	require.Error(t, err, "Expected error when TLS certificates are incomplete")
 
 	// Error should mention TLS or certificate


### PR DESCRIPTION
## Summary

- Gateway now polls for TLS certificates with 500ms intervals and 30s timeout instead of crashing when certs aren't available yet
- Distinguishes transient errors (file not found → retry) from permanent errors (invalid cert → fail immediately)
- Removes Docker/init ordering dependency between core and gateway processes

## Changes

- **`cert_poll.go`** — New `waitForTLSCerts` function with `tryLoadCerts` helper and `isTransientCertError` classifier
- **`deps.go`** — Added `CertPollTimeout` to `GatewayDeps` for test injection
- **`gateway.go`** — Replaced eager cert loading with `waitForTLSCerts` polling
- **`cert_poll_test.go`** — 8 tests: immediate success, polling, permanent error, transient retries (client/control TLS), timeout, context cancellation, `isTransientCertError` table test
- **`gateway_test.go`** — Updated `MissingCertificates` and `TLSLoadFails` tests to use deps injection with short timeout
- **`deps_test.go`** — Added missing `ControlTLSLoader` to `GRPCClientFactoryError` test

## Test plan

- [x] All new tests pass (\`task test\`)
- [x] All existing tests pass — no regressions
- [x] Go lint clean (\`task lint:go\`)
- [ ] E2E: Start gateway before core in Docker Compose, verify gateway waits and connects when core starts

Closes: holomush-6pa6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway now waits for TLS certificates at startup with automatic retries, logging while waiting, and immediate failure on permanent errors.
  * Added a configurable certificate-poll timeout to control startup wait duration.

* **Tests**
  * Added comprehensive tests for success, retry, timeout, cancellation, and transient-vs-permanent error classification.
  * Updated gateway tests to exercise the new polling startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->