### PR TITLE
feat(grpc): wire unified command dispatcher into CoreServer HandleCommand

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -448,13 +448,15 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		aliasRepo := store.NewPostgresAliasRepository(realStore.Pool())
 		aliasCache := command.NewAliasCache()
 
-		// Pre-populate alias cache from database
+		// Pre-populate alias cache from database — fail startup if aliases
+		// can't be loaded, otherwise the dispatcher silently breaks resolution.
 		sysAliases, sysAliasErr := aliasRepo.GetSystemAliases(ctx)
 		if sysAliasErr != nil {
-			slog.Warn("failed to load system aliases into cache", "error", sysAliasErr)
-		} else {
-			aliasCache.LoadSystemAliases(sysAliases)
+			return oops.Code("COMMAND_ALIAS_LOAD_FAILED").
+				With("operation", "load system aliases").
+				Wrap(sysAliasErr)
 		}
+		aliasCache.LoadSystemAliases(sysAliases)
 
 		cmdServices, cmdSvcErr := command.NewServices(command.ServicesConfig{
 			World:      worldService,

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -30,6 +30,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	authpostgres "github.com/holomush/holomush/internal/auth/postgres"
 	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/config"
 	"github.com/holomush/holomush/internal/control"
 	"github.com/holomush/holomush/internal/core"
@@ -252,7 +253,8 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 
 	// Build ABAC engine stack (requires PostgresEventStore for pool access).
 	// In test mode with mock stores, ABAC wiring is skipped.
-	var worldService *world.Service // hoisted so it's available to CoreServer constructor
+	var worldService *world.Service            // hoisted so it's available to CoreServer constructor
+	var policyEngine types.AccessPolicyEngine // hoisted for command dispatcher wiring
 	// Auth service variables hoisted so they're available in the CoreServer constructor block.
 	var authService *auth.Service
 	var resetService *auth.PasswordResetService
@@ -282,6 +284,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 				slog.Warn("error closing ABAC stack", "error", closeErr)
 			}
 		}()
+		policyEngine = abacStack.Engine
 		slog.Info("ABAC engine stack initialized")
 
 		// Start live policy cache invalidation (dedicated context to avoid race with later ctx reassignment)
@@ -438,6 +441,24 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 
 		// Create and register Core service with guest authentication + cleanup hook
 		sessionStore := store.NewPostgresSessionStore(realStore.Pool())
+
+		// Build unified command dispatcher
+		cmdRegistry := command.NewRegistry()
+		handlers.RegisterAll(cmdRegistry)
+		cmdServices, cmdSvcErr := command.NewServices(command.ServicesConfig{
+			World:   worldService,
+			Session: sessions,
+			Engine:  policyEngine,
+			Events:  realStore,
+		})
+		if cmdSvcErr != nil {
+			return oops.Code("COMMAND_SERVICES_FAILED").Wrap(cmdSvcErr)
+		}
+		cmdDispatcher, cmdDispErr := command.NewDispatcher(cmdRegistry, policyEngine)
+		if cmdDispErr != nil {
+			return oops.Code("COMMAND_DISPATCHER_FAILED").Wrap(cmdDispErr)
+		}
+
 		coreServer := holoGRPC.NewCoreServer(engine, sessions, sessionStore,
 			holoGRPC.WithAuthenticator(guestAuth),
 			holoGRPC.WithEventStore(realStore),
@@ -448,6 +469,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			holoGRPC.WithPlayerTokenRepo(authPlayerTokenRepo),
 			holoGRPC.WithPlayerRepo(authPlayerRepo),
 			holoGRPC.WithCharacterRepo(authCharRepo),
+			holoGRPC.WithDispatcher(cmdDispatcher, cmdServices),
 			holoGRPC.WithSessionDefaults(holoGRPC.SessionDefaults{
 				TTL:        sessionTTL,
 				MaxHistory: cfg.SessionMaxHistory,

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -442,19 +442,35 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		// Create and register Core service with guest authentication + cleanup hook
 		sessionStore := store.NewPostgresSessionStore(realStore.Pool())
 
-		// Build unified command dispatcher
+		// Build unified command dispatcher with alias dependencies
 		cmdRegistry := command.NewRegistry()
 		handlers.RegisterAll(cmdRegistry)
+		aliasRepo := store.NewPostgresAliasRepository(realStore.Pool())
+		aliasCache := command.NewAliasCache()
+
+		// Pre-populate alias cache from database
+		sysAliases, sysAliasErr := aliasRepo.GetSystemAliases(ctx)
+		if sysAliasErr != nil {
+			slog.Warn("failed to load system aliases into cache", "error", sysAliasErr)
+		} else {
+			aliasCache.LoadSystemAliases(sysAliases)
+		}
+
 		cmdServices, cmdSvcErr := command.NewServices(command.ServicesConfig{
-			World:   worldService,
-			Session: sessions,
-			Engine:  policyEngine,
-			Events:  realStore,
+			World:      worldService,
+			Session:    sessions,
+			Engine:     policyEngine,
+			Events:     realStore,
+			AliasCache: aliasCache,
+			AliasRepo:  aliasRepo,
+			Registry:   cmdRegistry,
 		})
 		if cmdSvcErr != nil {
 			return oops.Code("COMMAND_SERVICES_FAILED").Wrap(cmdSvcErr)
 		}
-		cmdDispatcher, cmdDispErr := command.NewDispatcher(cmdRegistry, policyEngine)
+		cmdDispatcher, cmdDispErr := command.NewDispatcher(cmdRegistry, policyEngine,
+			command.WithAliasCache(aliasCache),
+		)
 		if cmdDispErr != nil {
 			return oops.Code("COMMAND_DISPATCHER_FAILED").Wrap(cmdDispErr)
 		}

--- a/internal/command/handlers/pose.go
+++ b/internal/command/handlers/pose.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// PoseHandler broadcasts a pose event to the character's current location stream.
+// The sender sees the event via their location stream subscription — no
+// command_response output is emitted.
+func PoseHandler(ctx context.Context, exec *command.CommandExecution) error {
+	payload, err := json.Marshal(core.PosePayload{
+		CharacterName: exec.CharacterName(),
+		Action:        exec.Args,
+	})
+	if err != nil {
+		return oops.With("operation", "marshal_pose_payload").Wrap(err)
+	}
+
+	event := core.Event{
+		ID:        core.NewULID(),
+		Stream:    world.LocationStream(exec.LocationID()),
+		Type:      core.EventTypePose,
+		Timestamp: time.Now(),
+		Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+		Payload:   payload,
+	}
+
+	if err := exec.Services().Events().Append(ctx, event); err != nil {
+		return oops.With("operation", "append_pose_event").Wrap(err)
+	}
+
+	return nil
+}

--- a/internal/command/handlers/pose_test.go
+++ b/internal/command/handlers/pose_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
+)
+
+func TestPoseHandler(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          string
+		appendErr     error
+		wantErr       bool
+		wantEventType core.EventType
+	}{
+		{
+			name:          "emits pose event",
+			args:          "waves hello",
+			wantEventType: core.EventTypePose,
+		},
+		{
+			name:      "event store failure",
+			args:      "waves",
+			appendErr: errors.New("db error"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			charID := ulid.Make()
+			locationID := ulid.Make()
+
+			var appended core.Event
+			store := &stubEventStoreCapture{
+				appendFunc: func(_ context.Context, e core.Event) error {
+					appended = e
+					return tt.appendErr
+				},
+			}
+
+			svc := command.NewTestServices(command.ServicesConfig{
+				World:   nil,
+				Session: nil,
+				Engine:  policytest.AllowAllEngine(),
+				Events:  store,
+			})
+
+			exec := command.NewTestExecution(command.CommandExecutionConfig{
+				CharacterID:   charID,
+				CharacterName: "TestChar",
+				LocationID:    locationID,
+				Output:        &bytes.Buffer{},
+				Services:      svc,
+			})
+			exec.Args = tt.args
+
+			err := PoseHandler(context.Background(), exec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEventType, appended.Type)
+			assert.Equal(t, "location:"+locationID.String(), appended.Stream)
+			assert.Contains(t, string(appended.Payload), tt.args)
+		})
+	}
+}

--- a/internal/command/handlers/register.go
+++ b/internal/command/handlers/register.go
@@ -21,6 +21,49 @@ func RegisterAll(reg *command.Registry) {
 		}
 	}
 
+	// Communication commands
+	mustRegister(command.CommandEntryConfig{
+		Name:    "say",
+		Handler: SayHandler,
+		Help:    "Say something to the room",
+		Usage:   "say <message>",
+		HelpText: `## Say
+
+Say something aloud to everyone in your current location.
+
+### Usage
+
+- ` + "`say <message>`" + ` - Speak the message aloud
+
+### Examples
+
+- ` + "`say Hello, everyone!`" + `
+- ` + "`say How are you?`" + ``,
+		Source: "core",
+	})
+
+	mustRegister(command.CommandEntryConfig{
+		Name:    "pose",
+		Handler: PoseHandler,
+		Help:    "Perform an action",
+		Usage:   "pose <action>",
+		HelpText: `## Pose
+
+Describe an action your character performs, visible to everyone in your
+current location.
+
+### Usage
+
+- ` + "`pose <action>`" + ` - Perform the action
+- ` + "`:` + `<action>`" + ` - Shorthand for pose
+
+### Examples
+
+- ` + "`pose waves hello`" + ` - Shows "CharName waves hello"
+- ` + "`:waves hello`" + ` - Same as above`,
+		Source: "core",
+	})
+
 	// Navigation commands
 	mustRegister(command.CommandEntryConfig{
 		Name:    "look",

--- a/internal/command/handlers/register.go
+++ b/internal/command/handlers/register.go
@@ -55,7 +55,7 @@ current location.
 ### Usage
 
 - ` + "`pose <action>`" + ` - Perform the action
-- ` + "`:` + `<action>`" + ` - Shorthand for pose
+- ` + "`:<action>`" + ` - Shorthand for pose
 
 ### Examples
 

--- a/internal/command/handlers/register_test.go
+++ b/internal/command/handlers/register_test.go
@@ -19,6 +19,7 @@ func TestRegisterAll_RegistersCoreCommands(t *testing.T) {
 
 	// Verify all core commands are registered
 	expectedCommands := []string{
+		"say", "pose",
 		"look", "move", "quit", "who",
 		"boot", "shutdown", "wall",
 		"create", "set",

--- a/internal/command/handlers/say.go
+++ b/internal/command/handlers/say.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// SayHandler broadcasts a say event to the character's current location stream.
+// The sender sees the event via their location stream subscription — no
+// command_response output is emitted.
+func SayHandler(ctx context.Context, exec *command.CommandExecution) error {
+	payload, err := json.Marshal(core.SayPayload{
+		CharacterName: exec.CharacterName(),
+		Message:       exec.Args,
+	})
+	if err != nil {
+		return oops.With("operation", "marshal_say_payload").Wrap(err)
+	}
+
+	event := core.Event{
+		ID:        core.NewULID(),
+		Stream:    world.LocationStream(exec.LocationID()),
+		Type:      core.EventTypeSay,
+		Timestamp: time.Now(),
+		Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+		Payload:   payload,
+	}
+
+	if err := exec.Services().Events().Append(ctx, event); err != nil {
+		return oops.With("operation", "append_say_event").Wrap(err)
+	}
+
+	return nil
+}

--- a/internal/command/handlers/say_test.go
+++ b/internal/command/handlers/say_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
+)
+
+func TestSayHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         string
+		appendErr    error
+		wantErr      bool
+		wantEventType core.EventType
+	}{
+		{
+			name:          "emits say event",
+			args:          "Hello, world!",
+			wantEventType: core.EventTypeSay,
+		},
+		{
+			name:      "event store failure",
+			args:      "Hello",
+			appendErr: errors.New("db error"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			charID := ulid.Make()
+			locationID := ulid.Make()
+
+			var appended core.Event
+			store := &stubEventStoreCapture{
+				appendFunc: func(_ context.Context, e core.Event) error {
+					appended = e
+					return tt.appendErr
+				},
+			}
+
+			svc := command.NewTestServices(command.ServicesConfig{
+				World:   nil,
+				Session: nil,
+				Engine:  policytest.AllowAllEngine(),
+				Events:  store,
+			})
+
+			exec := command.NewTestExecution(command.CommandExecutionConfig{
+				CharacterID:   charID,
+				CharacterName: "TestChar",
+				LocationID:    locationID,
+				Output:        &bytes.Buffer{},
+				Services:      svc,
+			})
+			exec.Args = tt.args
+
+			err := SayHandler(context.Background(), exec)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEventType, appended.Type)
+			assert.Equal(t, "location:"+locationID.String(), appended.Stream)
+			assert.Contains(t, string(appended.Payload), tt.args)
+		})
+	}
+}
+
+// stubEventStoreCapture captures appended events.
+type stubEventStoreCapture struct {
+	appendFunc func(ctx context.Context, e core.Event) error
+}
+
+func (s *stubEventStoreCapture) Append(ctx context.Context, e core.Event) error {
+	if s.appendFunc != nil {
+		return s.appendFunc(ctx, e)
+	}
+	return nil
+}
+
+func (s *stubEventStoreCapture) Replay(_ context.Context, _ string, _ ulid.ULID, _ int) ([]core.Event, error) {
+	return nil, nil
+}
+
+func (s *stubEventStoreCapture) LastEventID(_ context.Context, _ string) (ulid.ULID, error) {
+	return ulid.ULID{}, nil
+}
+
+func (s *stubEventStoreCapture) Subscribe(_ context.Context, _ string) (<-chan ulid.ULID, <-chan error, error) {
+	return nil, nil, nil
+}

--- a/internal/grpc/dispatcher_integration_test.go
+++ b/internal/grpc/dispatcher_integration_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// newDispatcherTestServer creates a CoreServer wired with the unified
+// command dispatcher, using in-memory stores for testing.
+func newDispatcherTestServer(t *testing.T, store core.EventStore, opts ...CoreServerOption) (*CoreServer, *core.SessionManager) {
+	t.Helper()
+	sessions := core.NewSessionManager()
+	engine := core.NewEngine(store, sessions)
+
+	reg := command.NewRegistry()
+	handlers.RegisterAll(reg)
+
+	policyEngine := policytest.AllowAllEngine()
+	svc := command.NewTestServices(command.ServicesConfig{
+		World:   nil,
+		Session: sessions,
+		Engine:  policyEngine,
+		Events:  store,
+	})
+
+	dispatcher, err := command.NewDispatcher(reg, policyEngine)
+	require.NoError(t, err)
+
+	allOpts := make([]CoreServerOption, 0, 2+len(opts))
+	allOpts = append(allOpts,
+		WithEventStore(store),
+		WithDispatcher(dispatcher, svc),
+	)
+	allOpts = append(allOpts, opts...)
+
+	server := NewCoreServer(engine, sessions, session.NewMemStore(), allOpts...)
+	return server, sessions
+}
+
+func TestDispatcher_HandleCommand_Say(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+
+	var appended []core.Event
+	store := &mockEventStore{
+		appendFunc: func(_ context.Context, event core.Event) error {
+			appended = append(appended, event)
+			return nil
+		},
+	}
+
+	server, sessions := newDispatcherTestServer(t, store)
+	sessions.Connect(charID, core.NewULID())
+
+	ctx := context.Background()
+	require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
+		ID:            sessionID.String(),
+		CharacterID:   charID,
+		CharacterName: "Tester",
+		LocationID:    locationID,
+		Status:        session.StatusActive,
+	}))
+
+	resp, err := server.HandleCommand(ctx, &corev1.HandleCommandRequest{
+		Meta:      &corev1.RequestMeta{RequestId: "say-test", Timestamp: timestamppb.Now()},
+		SessionId: sessionID.String(),
+		Command:   "say Hello, world!",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success, "say should succeed: %s", resp.Error)
+
+	// Should emit a say event on the location stream
+	require.NotEmpty(t, appended)
+	assert.Equal(t, core.EventTypeSay, appended[0].Type)
+	assert.Equal(t, "location:"+locationID.String(), appended[0].Stream)
+}
+
+func TestDispatcher_HandleCommand_Pose(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+
+	var appended []core.Event
+	store := &mockEventStore{
+		appendFunc: func(_ context.Context, event core.Event) error {
+			appended = append(appended, event)
+			return nil
+		},
+	}
+
+	server, sessions := newDispatcherTestServer(t, store)
+	sessions.Connect(charID, core.NewULID())
+
+	ctx := context.Background()
+	require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
+		ID:            sessionID.String(),
+		CharacterID:   charID,
+		CharacterName: "Tester",
+		LocationID:    locationID,
+		Status:        session.StatusActive,
+	}))
+
+	resp, err := server.HandleCommand(ctx, &corev1.HandleCommandRequest{
+		Meta:      &corev1.RequestMeta{RequestId: "pose-test", Timestamp: timestamppb.Now()},
+		SessionId: sessionID.String(),
+		Command:   "pose waves hello",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success, "pose should succeed: %s", resp.Error)
+
+	require.NotEmpty(t, appended)
+	assert.Equal(t, core.EventTypePose, appended[0].Type)
+}
+
+func TestDispatcher_HandleCommand_ColonPrefix(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+
+	var appended []core.Event
+	store := &mockEventStore{
+		appendFunc: func(_ context.Context, event core.Event) error {
+			appended = append(appended, event)
+			return nil
+		},
+	}
+
+	server, sessions := newDispatcherTestServer(t, store)
+	sessions.Connect(charID, core.NewULID())
+
+	ctx := context.Background()
+	require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
+		ID:            sessionID.String(),
+		CharacterID:   charID,
+		CharacterName: "Tester",
+		LocationID:    locationID,
+		Status:        session.StatusActive,
+	}))
+
+	resp, err := server.HandleCommand(ctx, &corev1.HandleCommandRequest{
+		Meta:      &corev1.RequestMeta{RequestId: "colon-test", Timestamp: timestamppb.Now()},
+		SessionId: sessionID.String(),
+		Command:   ": nods",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success, ": should expand to pose: %s", resp.Error)
+
+	require.NotEmpty(t, appended)
+	assert.Equal(t, core.EventTypePose, appended[0].Type)
+}
+
+func TestDispatcher_HandleCommand_UnknownCommand(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+	store := core.NewMemoryEventStore()
+
+	server, sessions := newDispatcherTestServer(t, store)
+	sessions.Connect(charID, core.NewULID())
+
+	ctx := context.Background()
+	require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
+		ID:            sessionID.String(),
+		CharacterID:   charID,
+		CharacterName: "Tester",
+		LocationID:    locationID,
+		Status:        session.StatusActive,
+	}))
+
+	resp, err := server.HandleCommand(ctx, &corev1.HandleCommandRequest{
+		Meta:      &corev1.RequestMeta{RequestId: "unknown-test", Timestamp: timestamppb.Now()},
+		SessionId: sessionID.String(),
+		Command:   "unknowncommand args",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success, "unknown command should succeed at RPC level")
+
+	// Should emit error command_response on character stream
+	charEvents, err := store.Replay(ctx, "character:"+charID.String(), ulid.ULID{}, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, charEvents, "expected command_response event")
+	assert.Equal(t, core.EventTypeCommandResponse, charEvents[0].Type)
+
+	var crp core.CommandResponsePayload
+	require.NoError(t, json.Unmarshal(charEvents[0].Payload, &crp))
+	assert.True(t, crp.IsError)
+}
+
+func TestDispatcher_HandleCommand_Quit(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+	store := core.NewMemoryEventStore()
+
+	var hookCalled bool
+	server, sessions := newDispatcherTestServer(t, store,
+		WithDisconnectHook(func(_ session.Info) {
+			hookCalled = true
+		}),
+	)
+	sessions.Connect(charID, core.NewULID())
+
+	ctx := context.Background()
+	sessStore := server.sessionStore
+	require.NoError(t, sessStore.Set(ctx, sessionID.String(), &session.Info{
+		ID:            sessionID.String(),
+		CharacterID:   charID,
+		CharacterName: "QuitChar",
+		LocationID:    locationID,
+		Status:        session.StatusActive,
+		TTLSeconds:    1800,
+	}))
+
+	resp, err := server.HandleCommand(ctx, &corev1.HandleCommandRequest{
+		Meta:      &corev1.RequestMeta{RequestId: "quit-test", Timestamp: timestamppb.Now()},
+		SessionId: sessionID.String(),
+		Command:   "quit",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+
+	// Session should be deleted
+	_, err = sessStore.Get(ctx, sessionID.String())
+	assert.Error(t, err, "session should be deleted after quit")
+
+	// Leave event should be emitted on location stream
+	locEvents, err := store.Replay(ctx, "location:"+locationID.String(), ulid.ULID{}, 100)
+	require.NoError(t, err)
+	require.Len(t, locEvents, 1, "expected exactly one leave event")
+	assert.Equal(t, core.EventTypeLeave, locEvents[0].Type)
+
+	// Goodbye command_response event on character stream
+	charEvents, err := store.Replay(ctx, "character:"+charID.String(), ulid.ULID{}, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, charEvents)
+	assert.Equal(t, core.EventTypeCommandResponse, charEvents[0].Type)
+
+	var crp core.CommandResponsePayload
+	require.NoError(t, json.Unmarshal(charEvents[0].Payload, &crp))
+	assert.False(t, crp.IsError)
+	assert.Contains(t, crp.Text, "Goodbye")
+
+	// Disconnect hook should fire
+	assert.True(t, hookCalled)
+}
+
+func TestExpandMUSHPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{": waves", "pose  waves"},
+		{":waves", "pose waves"},
+		{"say hello", "say hello"},
+		{"look", "look"},
+		{"", ""},
+		{"  ", "  "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, expandMUSHPrefix(tt.input))
+		})
+	}
+}

--- a/internal/grpc/dispatcher_test.go
+++ b/internal/grpc/dispatcher_test.go
@@ -266,10 +266,11 @@ func TestExpandMUSHPrefix(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{": waves", "pose  waves"},
+		{": waves", "pose waves"},
 		{":waves", "pose waves"},
 		{"say hello", "say hello"},
 		{"look", "look"},
+		{":", "pose"},
 		{"", ""},
 		{"  ", "  "},
 	}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -411,13 +411,21 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 	input = expandMUSHPrefix(input)
 
 	char := core.CharacterRef{ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID}
+	hadSessionBefore := s.sessions.GetSession(info.CharacterID) != nil
+
+	sessionID, parseErr := ulid.Parse(info.ID)
+	if parseErr != nil {
+		return oops.Code("INVALID_SESSION_ID").
+			With("session_id", info.ID).
+			Wrap(parseErr)
+	}
 
 	var buf bytes.Buffer
 	exec, err := command.NewCommandExecution(command.CommandExecutionConfig{
 		CharacterID:   info.CharacterID,
 		LocationID:    info.LocationID,
 		CharacterName: info.CharacterName,
-		SessionID:     ulid.MustParse(info.ID),
+		SessionID:     sessionID,
 		Output:        &buf,
 		Services:      s.cmdServices,
 	})
@@ -447,10 +455,13 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 		return oops.Wrap(dispatchErr)
 	}
 
-	// Post-quit cleanup: if the quit handler ended the session via
+	// Post-quit cleanup: if the quit handler ended the in-memory session via
 	// SessionService.EndSession, perform server-side teardown that the
 	// handler doesn't own (leave event, persistent store, hooks).
-	if s.sessions.GetSession(info.CharacterID) == nil {
+	// TODO(holomush-a3a7): replace in-memory session check with an explicit
+	// quit signal (e.g. sentinel error or CommandExecution flag) so this
+	// doesn't depend on SessionManager state.
+	if hadSessionBefore && s.sessions.GetSession(info.CharacterID) == nil {
 		if dcErr := s.engine.HandleDisconnect(ctx, char, "quit"); dcErr != nil {
 			slog.WarnContext(ctx, "leave event failed", "error", dcErr)
 		}
@@ -465,29 +476,12 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 
 // isUserFacingError returns true for errors that should be delivered to the
 // player via a command_response event rather than as an RPC-level failure.
+// Delegates to command.PlayerMessage to stay in sync with the command package's
+// error classification — if PlayerMessage returns a specific message (not the
+// generic fallback), the error is user-facing.
 func isUserFacingError(err error) bool {
-	oopsErr, ok := oops.AsOops(err)
-	if !ok {
-		return false
-	}
-	code, ok := oopsErr.Code().(string)
-	if !ok {
-		return false
-	}
-	switch code {
-	case command.CodeUnknownCommand,
-		command.CodePermissionDenied,
-		command.CodeInvalidArgs,
-		command.CodeWorldError,
-		command.CodeRateLimited,
-		command.CodeCircularAlias,
-		command.CodeAliasConflict,
-		command.CodeTargetNotFound,
-		command.CodeNoAliasCache,
-		command.CodeInvalidName:
-		return true
-	}
-	return false
+	msg := command.PlayerMessage(err)
+	return msg != "Something went wrong. Try again."
 }
 
 // executeViaSwitch is the legacy hardcoded switch for servers constructed
@@ -546,7 +540,11 @@ func expandMUSHPrefix(input string) string {
 	}
 	switch trimmed[0] {
 	case ':':
-		return "pose " + trimmed[1:]
+		remainder := strings.TrimSpace(trimmed[1:])
+		if remainder == "" {
+			return "pose"
+		}
+		return "pose " + remainder
 	default:
 		return input
 	}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -5,6 +5,7 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -21,6 +22,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/auth"
+	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
@@ -106,6 +108,8 @@ type CoreServer struct {
 	worldQuerier    WorldQuerier
 	sessionDefaults SessionDefaults
 	disconnectHooks []func(session.Info)
+	dispatcher      *command.Dispatcher
+	cmdServices     *command.Services
 
 	// Auth services for two-phase login and account management.
 	authService      AuthServiceProvider
@@ -162,6 +166,16 @@ func WithWorldQuerier(wq WorldQuerier) CoreServerOption {
 func WithDisconnectHook(hook func(session.Info)) CoreServerOption {
 	return func(s *CoreServer) {
 		s.disconnectHooks = append(s.disconnectHooks, hook)
+	}
+}
+
+// WithDispatcher sets the unified command dispatcher for command execution.
+// When set, executeCommand delegates to the dispatcher instead of the
+// hardcoded switch statement.
+func WithDispatcher(d *command.Dispatcher, svc *command.Services) CoreServerOption {
+	return func(s *CoreServer) {
+		s.dispatcher = d
+		s.cmdServices = svc
 	}
 }
 
@@ -381,8 +395,106 @@ func (s *CoreServer) HandleCommand(ctx context.Context, req *corev1.HandleComman
 
 // executeCommand parses and executes a command. Output is delivered via
 // command_response events emitted to the character's personal stream.
-func (s *CoreServer) executeCommand(ctx context.Context, info *session.Info, command string) error {
-	parts := strings.SplitN(command, " ", 2)
+func (s *CoreServer) executeCommand(ctx context.Context, info *session.Info, input string) error {
+	if s.dispatcher != nil {
+		return s.executeViaDispatcher(ctx, info, input)
+	}
+	return s.executeViaSwitch(ctx, info, input)
+}
+
+// executeViaDispatcher uses the unified command.Dispatcher for command
+// execution. Handler output written to the CommandExecution's io.Writer is
+// captured in a buffer and emitted as a command_response event afterward.
+func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Info, input string) error {
+	// Expand MUSH single-character prefixes before dispatch.
+	// These will become proper system aliases when the alias cache is wired.
+	input = expandMUSHPrefix(input)
+
+	char := core.CharacterRef{ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID}
+
+	var buf bytes.Buffer
+	exec, err := command.NewCommandExecution(command.CommandExecutionConfig{
+		CharacterID:   info.CharacterID,
+		LocationID:    info.LocationID,
+		CharacterName: info.CharacterName,
+		SessionID:     ulid.MustParse(info.ID),
+		Output:        &buf,
+		Services:      s.cmdServices,
+	})
+	if err != nil {
+		return oops.Code("EXECUTION_SETUP_FAILED").Wrap(err)
+	}
+
+	dispatchErr := s.dispatcher.Dispatch(ctx, input, exec)
+
+	// Emit any buffered output as a command_response event.
+	if buf.Len() > 0 {
+		isError := dispatchErr != nil
+		s.emitCommandResponse(ctx, char, strings.TrimRight(buf.String(), "\n"), isError)
+	}
+
+	if dispatchErr != nil {
+		// User-facing errors are delivered as command_response events, not
+		// RPC-level failures. Emit the player message and return nil so
+		// HandleCommand returns Success=true.
+		if isUserFacingError(dispatchErr) {
+			if buf.Len() == 0 {
+				s.emitCommandResponse(ctx, char, command.PlayerMessage(dispatchErr), true)
+			}
+			return nil
+		}
+		// Infrastructure errors propagate as RPC failures (Success=false).
+		return oops.Wrap(dispatchErr)
+	}
+
+	// Post-quit cleanup: if the quit handler ended the session via
+	// SessionService.EndSession, perform server-side teardown that the
+	// handler doesn't own (leave event, persistent store, hooks).
+	if s.sessions.GetSession(info.CharacterID) == nil {
+		if dcErr := s.engine.HandleDisconnect(ctx, char, "quit"); dcErr != nil {
+			slog.WarnContext(ctx, "leave event failed", "error", dcErr)
+		}
+		if delErr := s.sessionStore.Delete(ctx, info.ID, "Goodbye!"); delErr != nil {
+			slog.WarnContext(ctx, "session delete failed", "error", delErr)
+		}
+		s.runDisconnectHooks(ctx, *info)
+	}
+
+	return nil
+}
+
+// isUserFacingError returns true for errors that should be delivered to the
+// player via a command_response event rather than as an RPC-level failure.
+func isUserFacingError(err error) bool {
+	oopsErr, ok := oops.AsOops(err)
+	if !ok {
+		return false
+	}
+	code, ok := oopsErr.Code().(string)
+	if !ok {
+		return false
+	}
+	switch code {
+	case command.CodeUnknownCommand,
+		command.CodePermissionDenied,
+		command.CodeInvalidArgs,
+		command.CodeWorldError,
+		command.CodeRateLimited,
+		command.CodeCircularAlias,
+		command.CodeAliasConflict,
+		command.CodeTargetNotFound,
+		command.CodeNoAliasCache,
+		command.CodeInvalidName:
+		return true
+	}
+	return false
+}
+
+// executeViaSwitch is the legacy hardcoded switch for servers constructed
+// without a dispatcher (primarily tests). Remove once all callers provide
+// a dispatcher.
+func (s *CoreServer) executeViaSwitch(ctx context.Context, info *session.Info, input string) error {
+	parts := strings.SplitN(input, " ", 2)
 	cmd := strings.ToLower(parts[0])
 	if cmd == "" {
 		return oops.Code("EMPTY_COMMAND").Errorf("empty command")
@@ -395,26 +507,19 @@ func (s *CoreServer) executeCommand(ctx context.Context, info *session.Info, com
 	char := core.CharacterRef{ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID}
 	switch cmd {
 	case "say":
-		// Sender sees the broadcast say event from the location stream — no
-		// command_response needed.
 		if err := s.engine.HandleSay(ctx, char, arg); err != nil {
 			return oops.Code("COMMAND_FAILED").With("command", "say").Wrap(err)
 		}
 		return nil
 
 	case "pose", ":":
-		// Sender sees the broadcast pose event from the location stream — no
-		// command_response needed.
 		if err := s.engine.HandlePose(ctx, char, arg); err != nil {
 			return oops.Code("COMMAND_FAILED").With("command", "pose").Wrap(err)
 		}
 		return nil
 
 	case "quit":
-		// Emit a command_response with "Goodbye!" before disconnect.
 		s.emitCommandResponse(ctx, char, "Goodbye!", false)
-
-		// Explicit quit — terminate session immediately
 		if err := s.engine.HandleDisconnect(ctx, char, "quit"); err != nil {
 			slog.WarnContext(ctx, "leave event failed", "error", err)
 		}
@@ -426,9 +531,24 @@ func (s *CoreServer) executeCommand(ctx context.Context, info *session.Info, com
 		return nil
 
 	default:
-		// Emit an error command_response for unknown commands.
 		s.emitCommandResponse(ctx, char, "Unknown command: "+cmd, true)
 		return nil
+	}
+}
+
+// expandMUSHPrefix rewrites MUSH single-character command prefixes to their
+// full command names. E.g., ": waves" → "pose waves". These will become
+// proper system aliases once the alias cache is wired.
+func expandMUSHPrefix(input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return input
+	}
+	switch trimmed[0] {
+	case ':':
+		return "pose " + trimmed[1:]
+	default:
+		return input
 	}
 }
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -438,7 +438,9 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 	// Emit any buffered output as a command_response event.
 	if buf.Len() > 0 {
 		isError := dispatchErr != nil
-		s.emitCommandResponse(ctx, char, strings.TrimRight(buf.String(), "\n"), isError)
+		if emitErr := s.emitCommandResponse(ctx, char, strings.TrimRight(buf.String(), "\n"), isError); emitErr != nil {
+			return oops.Wrap(emitErr)
+		}
 	}
 
 	if dispatchErr != nil {
@@ -447,7 +449,9 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 		// HandleCommand returns Success=true.
 		if isUserFacingError(dispatchErr) {
 			if buf.Len() == 0 {
-				s.emitCommandResponse(ctx, char, command.PlayerMessage(dispatchErr), true)
+				if emitErr := s.emitCommandResponse(ctx, char, command.PlayerMessage(dispatchErr), true); emitErr != nil {
+					return oops.Wrap(emitErr)
+				}
 			}
 			return nil
 		}
@@ -513,6 +517,7 @@ func (s *CoreServer) executeViaSwitch(ctx context.Context, info *session.Info, i
 		return nil
 
 	case "quit":
+		//nolint:errcheck // legacy path — removed in holomush-a3a7.8
 		s.emitCommandResponse(ctx, char, "Goodbye!", false)
 		if err := s.engine.HandleDisconnect(ctx, char, "quit"); err != nil {
 			slog.WarnContext(ctx, "leave event failed", "error", err)
@@ -525,6 +530,7 @@ func (s *CoreServer) executeViaSwitch(ctx context.Context, info *session.Info, i
 		return nil
 
 	default:
+		//nolint:errcheck // legacy path — removed in holomush-a3a7.8
 		s.emitCommandResponse(ctx, char, "Unknown command: "+cmd, true)
 		return nil
 	}
@@ -551,8 +557,8 @@ func expandMUSHPrefix(input string) string {
 }
 
 // emitCommandResponse emits a command_response event to the character's
-// personal stream. Best-effort: errors are logged but not propagated.
-func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.CharacterRef, text string, isError bool) {
+// personal stream. Returns an error if the event could not be emitted.
+func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.CharacterRef, text string, isError bool) error {
 	payload, err := json.Marshal(core.CommandResponsePayload{
 		Text:    text,
 		IsError: isError,
@@ -562,7 +568,7 @@ func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.Characte
 			"character_id", char.ID.String(),
 			"error", err,
 		)
-		return
+		return oops.Code("COMMAND_RESPONSE_MARSHAL_FAILED").Wrap(err)
 	}
 
 	event := core.Event{
@@ -576,7 +582,7 @@ func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.Characte
 
 	if s.eventStore == nil {
 		slog.Debug("emitCommandResponse: eventStore not configured, event not emitted")
-		return
+		return nil
 	}
 
 	if err := s.eventStore.Append(ctx, event); err != nil {
@@ -584,7 +590,9 @@ func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.Characte
 			"character_id", char.ID.String(),
 			"error", err,
 		)
+		return oops.Code("COMMAND_RESPONSE_EMIT_FAILED").Wrap(err)
 	}
+	return nil
 }
 
 // runDisconnectHooks runs all registered disconnect hooks with panic recovery.


### PR DESCRIPTION
## Summary

- Wire the unified `command.Dispatcher` (18 registered commands, ABAC checks, alias resolution, OTel tracing, metrics) into `CoreServer.HandleCommand`, replacing the hardcoded 3-command switch that only handled say/pose/quit
- Create `SayHandler` and `PoseHandler` in `internal/command/handlers` so say/pose events are emitted through the standard handler pattern
- Add post-dispatch quit cleanup (leave event, session store delete, disconnect hooks) and MUSH prefix expansion (`:` → `pose`)

## Key Design Decisions

- **Dual path**: `executeViaDispatcher` (new) and `executeViaSwitch` (legacy) — tests that construct `CoreServer` without a dispatcher still work via the fallback switch
- **Error routing**: User-facing errors (unknown command, permission denied, rate limited) emit `command_response` events and return `Success=true`; infrastructure errors propagate as RPC failures
- **Output bridge**: Handler `io.Writer` output is captured in a `bytes.Buffer` and emitted as `command_response` events after dispatch
- **Quit detection**: Post-dispatch session check — if `EndSession` removed the session, server-side cleanup runs (leave event, persistent store delete, hooks)

## Test plan

- [x] `TestDispatcher_HandleCommand_Say` — say via dispatcher emits say event
- [x] `TestDispatcher_HandleCommand_Pose` — pose via dispatcher emits pose event
- [x] `TestDispatcher_HandleCommand_ColonPrefix` — `:` expands to pose
- [x] `TestDispatcher_HandleCommand_UnknownCommand` — emits error command_response, returns Success=true
- [x] `TestDispatcher_HandleCommand_Quit` — session deleted, leave event, Goodbye response, hooks fire
- [x] `TestExpandMUSHPrefix` — prefix expansion cases
- [x] `TestSayHandler` / `TestPoseHandler` — handler unit tests
- [x] All existing tests pass (36 packages, 0 failures)
- [x] `task lint:go` — 0 issues
- [x] `task build` — exit 0

Closes holomush-a3a7.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "say" and "pose" commands and support for MUSH-style ":" prefix to trigger poses.

* **Bug Fixes**
  * Unified command dispatch path with improved routing, command-response event handling, and session cleanup on quit/disconnect.

* **Tests**
  * Added end-to-end and unit tests covering command handlers, dispatcher integration, prefix expansion, and session/disconnect behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->