### PR TITLE
refactor: remove legacy executeViaSwitch fallback

### DIFF
--- a/internal/grpc/dispatcher_test.go
+++ b/internal/grpc/dispatcher_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/holomush/holomush/internal/access/policy/policytest"
-	"github.com/holomush/holomush/internal/command"
-	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
@@ -25,32 +22,7 @@ import (
 // command dispatcher, using in-memory stores for testing.
 func newDispatcherTestServer(t *testing.T, store core.EventStore, opts ...CoreServerOption) *CoreServer {
 	t.Helper()
-	engine := core.NewEngine(store)
-	sessionStore := session.NewMemStore()
-
-	reg := command.NewRegistry()
-	handlers.RegisterAll(reg)
-
-	policyEngine := policytest.AllowAllEngine()
-	svc := command.NewTestServices(command.ServicesConfig{
-		World:   nil,
-		Session: sessionStore,
-		Engine:  policyEngine,
-		Events:  store,
-	})
-
-	dispatcher, err := command.NewDispatcher(reg, policyEngine)
-	require.NoError(t, err)
-
-	allOpts := make([]CoreServerOption, 0, 2+len(opts))
-	allOpts = append(allOpts,
-		WithEventStore(store),
-		WithDispatcher(dispatcher, svc),
-	)
-	allOpts = append(allOpts, opts...)
-
-	server := NewCoreServer(engine, sessionStore, allOpts...)
-	return server
+	return newHandleCommandServer(t, store, nil, opts...)
 }
 
 func TestDispatcher_HandleCommand_Say(t *testing.T) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -170,8 +170,6 @@ func WithDisconnectHook(hook func(session.Info)) CoreServerOption {
 }
 
 // WithDispatcher sets the unified command dispatcher for command execution.
-// When set, executeCommand delegates to the dispatcher instead of the
-// hardcoded switch statement.
 func WithDispatcher(d *command.Dispatcher, svc *command.Services) CoreServerOption {
 	return func(s *CoreServer) {
 		s.dispatcher = d
@@ -389,13 +387,11 @@ func (s *CoreServer) HandleCommand(ctx context.Context, req *corev1.HandleComman
 	}, nil
 }
 
-// executeCommand parses and executes a command. Output is delivered via
-// command_response events emitted to the character's personal stream.
+// executeCommand parses and executes a command via the unified dispatcher.
+// Output is delivered via command_response events emitted to the character's
+// personal stream.
 func (s *CoreServer) executeCommand(ctx context.Context, info *session.Info, input string) error {
-	if s.dispatcher != nil {
-		return s.executeViaDispatcher(ctx, info, input)
-	}
-	return s.executeViaSwitch(ctx, info, input)
+	return s.executeViaDispatcher(ctx, info, input)
 }
 
 // executeViaDispatcher uses the unified command.Dispatcher for command
@@ -490,53 +486,6 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 func isUserFacingError(err error) bool {
 	msg := command.PlayerMessage(err)
 	return msg != "Something went wrong. Try again."
-}
-
-// executeViaSwitch is the legacy hardcoded switch for servers constructed
-// without a dispatcher (primarily tests). Remove once all callers provide
-// a dispatcher.
-func (s *CoreServer) executeViaSwitch(ctx context.Context, info *session.Info, input string) error {
-	parts := strings.SplitN(input, " ", 2)
-	cmd := strings.ToLower(parts[0])
-	if cmd == "" {
-		return oops.Code("EMPTY_COMMAND").Errorf("empty command")
-	}
-	var arg string
-	if len(parts) > 1 {
-		arg = parts[1]
-	}
-
-	char := core.CharacterRef{ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID}
-	switch cmd {
-	case "say":
-		if err := s.engine.HandleSay(ctx, char, arg); err != nil {
-			return oops.Code("COMMAND_FAILED").With("command", "say").Wrap(err)
-		}
-		return nil
-
-	case "pose", ":":
-		if err := s.engine.HandlePose(ctx, char, arg); err != nil {
-			return oops.Code("COMMAND_FAILED").With("command", "pose").Wrap(err)
-		}
-		return nil
-
-	case "quit":
-		//nolint:errcheck // legacy path — removed in holomush-a3a7.8
-		s.emitCommandResponse(ctx, char, "Goodbye!", false)
-		if err := s.engine.HandleDisconnect(ctx, char, "quit"); err != nil {
-			slog.WarnContext(ctx, "leave event failed", "error", err)
-		}
-		if err := s.sessionStore.Delete(ctx, info.ID, "Goodbye!"); err != nil {
-			slog.WarnContext(ctx, "session delete failed", "error", err)
-		}
-		s.runDisconnectHooks(ctx, *info)
-		return nil
-
-	default:
-		//nolint:errcheck // legacy path — removed in holomush-a3a7.8
-		s.emitCommandResponse(ctx, char, "Unknown command: "+cmd, true)
-		return nil
-	}
 }
 
 // expandMUSHPrefix rewrites MUSH single-character command prefixes to their

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -19,6 +19,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
 	tlscerts "github.com/holomush/holomush/internal/tls"
@@ -31,9 +34,49 @@ func newTestSessionStore(t *testing.T, sessions map[string]*session.Info) sessio
 	store := session.NewMemStore()
 	ctx := context.Background()
 	for id, info := range sessions {
+		if info.ID == "" {
+			info.ID = id
+		}
 		require.NoError(t, store.Set(ctx, id, info))
 	}
 	return store
+}
+
+// newHandleCommandServer creates a CoreServer wired with the unified command
+// dispatcher. Tests that call HandleCommand MUST use this helper (or
+// newDispatcherTestServer) because executeViaSwitch has been removed.
+//
+// The store is used for both Engine and dispatcher Services.Events.
+// Pass a custom sessStore to pre-populate sessions; nil uses a fresh MemStore.
+func newHandleCommandServer(t *testing.T, store core.EventStore, sessStore session.Store, opts ...CoreServerOption) *CoreServer {
+	t.Helper()
+	engine := core.NewEngine(store)
+	if sessStore == nil {
+		sessStore = session.NewMemStore()
+	}
+
+	reg := command.NewRegistry()
+	handlers.RegisterAll(reg)
+
+	policyEngine := policytest.AllowAllEngine()
+	svc := command.NewTestServices(command.ServicesConfig{
+		World:   nil,
+		Session: sessStore,
+		Engine:  policyEngine,
+		Events:  store,
+	})
+
+	dispatcher, err := command.NewDispatcher(reg, policyEngine)
+	require.NoError(t, err)
+
+	allOpts := make([]CoreServerOption, 0, 2+len(opts))
+	allOpts = append(allOpts,
+		WithEventStore(store),
+		WithDispatcher(dispatcher, svc),
+	)
+	allOpts = append(allOpts, opts...)
+
+	return NewCoreServer(engine, sessStore, allOpts...)
 }
 
 // mockEventStore implements core.EventStore for testing.
@@ -195,19 +238,13 @@ func TestCoreServer_HandleCommand_Say(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -227,11 +264,7 @@ func TestCoreServer_HandleCommand_Say(t *testing.T) {
 }
 
 func TestCoreServer_HandleCommand_InvalidSession(t *testing.T) {
-	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
-
-		sessionStore: session.NewMemStore(),
-	}
+	server := newHandleCommandServer(t, core.NewMemoryEventStore(), nil)
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -465,19 +498,13 @@ func TestCoreServer_HandleCommand_NilMeta(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -505,19 +532,13 @@ func TestCoreServer_HandleCommand_Pose(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -559,21 +580,15 @@ func TestCoreServer_HandleCommand_UnknownCommand(t *testing.T) {
 	locationID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
-	server := &CoreServer{
-		engine: engine,
-
-		eventStore: store,
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID:   charID,
-				CharacterName: "Tester",
-				LocationID:    locationID,
-				Status:        session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID:   charID,
+			CharacterName: "Tester",
+			LocationID:    locationID,
+			Status:        session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -615,19 +630,13 @@ func TestCoreServer_HandleCommand_SayFails(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -657,19 +666,13 @@ func TestCoreServer_HandleCommand_PoseFails(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 	req := &corev1.HandleCommandRequest{
@@ -694,7 +697,6 @@ func TestCoreServer_HandleCommand_Quit(t *testing.T) {
 	locationID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
 	sessStore := session.NewMemStore()
 	ctx := context.Background()
@@ -709,8 +711,7 @@ func TestCoreServer_HandleCommand_Quit(t *testing.T) {
 	}))
 
 	var hookCalled bool
-	server := NewCoreServer(engine, sessStore,
-		WithEventStore(store),
+	server := newHandleCommandServer(t, store, sessStore,
 		WithDisconnectHook(func(_ session.Info) {
 			hookCalled = true
 		}),
@@ -1172,8 +1173,6 @@ func TestCoreServer_SessionRefreshOnActivity(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
 	sessionStore := newTestSessionStore(t, map[string]*session.Info{
 		sessionID.String(): {
 			CharacterID: charID,
@@ -1182,11 +1181,7 @@ func TestCoreServer_SessionRefreshOnActivity(t *testing.T) {
 		},
 	})
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: sessionStore,
-	}
+	server := newHandleCommandServer(t, store, sessionStore)
 
 	ctx := context.Background()
 
@@ -1290,19 +1285,13 @@ func TestCoreServer_HandleCommand_ContextTimeout(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	// Create a context with a short timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -1342,19 +1331,13 @@ func TestCoreServer_HandleCommand_ContextCancellation(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1499,19 +1482,13 @@ func TestCoreServer_HandleCommand_TimeoutErrorMessage(t *testing.T) {
 				},
 			}
 
-			engine := core.NewEngine(store)
-
-			server := &CoreServer{
-				engine: engine,
-
-				sessionStore: newTestSessionStore(t, map[string]*session.Info{
-					sessionID.String(): {
-						CharacterID: charID,
-						LocationID:  locationID,
-						Status:      session.StatusActive,
-					},
-				}),
-			}
+			server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+				sessionID.String(): {
+					CharacterID: charID,
+					LocationID:  locationID,
+					Status:      session.StatusActive,
+				},
+			}))
 
 			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
 			defer cancel()
@@ -1628,19 +1605,14 @@ func TestCoreServer_HandleCommand_EmptyCommandWithTimeout(t *testing.T) {
 	locationID := core.NewULID()
 
 	store := &mockEventStore{}
-	engine := core.NewEngine(store)
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	// Even with a short timeout, an empty command should fail fast
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -1728,11 +1700,7 @@ func TestCoreServer_MalformedRequest_EmptyUsername(t *testing.T) {
 }
 
 func TestCoreServer_MalformedRequest_InvalidSessionID(t *testing.T) {
-	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
-
-		sessionStore: session.NewMemStore(),
-	}
+	server := newHandleCommandServer(t, core.NewMemoryEventStore(), nil)
 
 	ctx := context.Background()
 
@@ -1783,19 +1751,14 @@ func TestCoreServer_MalformedRequest_InvalidCommand(t *testing.T) {
 	locationID := core.NewULID()
 
 	store := &mockEventStore{}
-	engine := core.NewEngine(store)
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -1925,19 +1888,13 @@ func TestCoreServer_MalformedRequest_NilMeta(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -2032,19 +1989,13 @@ func TestCoreServer_MalformedRequest_ConcurrentMalformedRequests(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -2115,19 +2066,13 @@ func TestCoreServer_MalformedRequest_VeryLargePayload(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -2166,19 +2111,13 @@ func TestCoreServer_MalformedRequest_SpecialCharacters(t *testing.T) {
 		},
 	}
 
-	engine := core.NewEngine(store)
-
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: newTestSessionStore(t, map[string]*session.Info{
-			sessionID.String(): {
-				CharacterID: charID,
-				LocationID:  locationID,
-				Status:      session.StatusActive,
-			},
-		}),
-	}
+	server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
+		sessionID.String(): {
+			CharacterID: charID,
+			LocationID:  locationID,
+			Status:      session.StatusActive,
+		},
+	}))
 
 	ctx := context.Background()
 
@@ -2373,7 +2312,6 @@ func TestCoreServer_HandleCommand_RecordsHistory(t *testing.T) {
 	store := &mockEventStore{
 		appendFunc: func(_ context.Context, _ core.Event) error { return nil },
 	}
-	engine := core.NewEngine(store)
 
 	sessStore := session.NewMemStore()
 	ctx := context.Background()
@@ -2385,11 +2323,7 @@ func TestCoreServer_HandleCommand_RecordsHistory(t *testing.T) {
 		MaxHistory:  100,
 	}))
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: sessStore,
-	}
+	server := newHandleCommandServer(t, store, sessStore)
 
 	commands := []string{"say hello", "pose waves", "say goodbye"}
 	for _, cmd := range commands {
@@ -2416,7 +2350,6 @@ func TestCoreServer_HandleCommand_HistoryEnforcedCap(t *testing.T) {
 	store := &mockEventStore{
 		appendFunc: func(_ context.Context, _ core.Event) error { return nil },
 	}
-	engine := core.NewEngine(store)
 
 	const maxHistory = 3
 	sessStore := session.NewMemStore()
@@ -2429,11 +2362,7 @@ func TestCoreServer_HandleCommand_HistoryEnforcedCap(t *testing.T) {
 		MaxHistory:  maxHistory,
 	}))
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: sessStore,
-	}
+	server := newHandleCommandServer(t, store, sessStore)
 
 	// Send more commands than maxHistory
 	for i := 0; i < 5; i++ {
@@ -2463,7 +2392,6 @@ func TestCoreServer_HandleCommand_HistoryBestEffort(t *testing.T) {
 	store := &mockEventStore{
 		appendFunc: func(_ context.Context, _ core.Event) error { return nil },
 	}
-	engine := core.NewEngine(store)
 
 	ctx := context.Background()
 	realStore := session.NewMemStore()
@@ -2475,11 +2403,7 @@ func TestCoreServer_HandleCommand_HistoryBestEffort(t *testing.T) {
 		MaxHistory:  100,
 	}))
 
-	server := &CoreServer{
-		engine: engine,
-
-		sessionStore: realStore,
-	}
+	server := newHandleCommandServer(t, store, realStore)
 
 	req := &corev1.HandleCommandRequest{
 		Meta:      &corev1.RequestMeta{RequestId: "best-effort-test", Timestamp: timestamppb.Now()},


### PR DESCRIPTION
## Summary

- Delete the hardcoded 3-command switch statement (`executeViaSwitch`) that served as a fallback for tests constructing CoreServer without a dispatcher
- All 22 HandleCommand tests now use the unified command dispatcher via a shared `newHandleCommandServer` helper
- Net deletion: 155 lines

## Changes

| File | What |
|------|------|
| `internal/grpc/server.go` | Delete `executeViaSwitch` (45 lines), remove nil-dispatcher branch in `executeCommand` |
| `internal/grpc/server_test.go` | Add `newHandleCommandServer` helper, migrate 22 tests, fix `newTestSessionStore` to auto-populate `Info.ID` |
| `internal/grpc/dispatcher_test.go` | Consolidate `newDispatcherTestServer` to delegate to shared helper |

## Test plan

- [x] `task test` — all unit tests pass
- [x] `task lint` — clean (0 issues)
- [x] `task test:int` — all integration suites pass
- [x] `task test:e2e` — 24/24 E2E tests pass

Closes holomush-a3a7.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated command execution to use unified dispatcher handling exclusively, removing legacy routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->