### PR TITLE
feat: describe, page & whisper commands for v0.1

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -262,6 +262,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	var authPlayerRepo *authpostgres.PlayerRepository
 	var authPlayerTokenRepo *store.PostgresPlayerTokenStore
 	var authCharRepo *authCharRepoAdapter
+	var sessionStore *store.PostgresSessionStore // hoisted for hostfunc + gRPC wiring
 	realStoreForABAC, hasPool := eventStore.(*store.PostgresEventStore)
 	if !hasPool {
 		// In production, PostgresEventStore always has a pool. This branch
@@ -343,6 +344,9 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			return oops.Code("AUTH_SETUP_FAILED").Wrap(charErr)
 		}
 
+		// Create session store early so plugins can access session functions
+		sessionStore = store.NewPostgresSessionStore(abacPool)
+
 		// Build plugin stack
 		var pluginsBaseDir string
 		if cfg.DataDir != "" {
@@ -359,6 +363,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		hostFuncs := hostfunc.New(nil, // KV store not yet available
 			hostfunc.WithEngine(abacStack.Engine),
 			hostfunc.WithWorldService(worldService),
+			hostfunc.WithSessionAccess(sessionStore),
 		)
 		luaHost := pluginlua.NewHostWithFunctions(hostFuncs)
 		pluginManager := plugins.NewManager(pluginsDir,
@@ -438,8 +443,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 
 		guestAuth := telnet.NewGuestAuthenticator(telnet.NewGemstoneElementTheme(), startLocationID)
 
-		// Create and register Core service with guest authentication + cleanup hook
-		sessionStore := store.NewPostgresSessionStore(realStore.Pool())
+		// Session store was created earlier (in the ABAC stack block) — reuse it here.
 
 		// Build unified command dispatcher with alias dependencies
 		cmdRegistry := command.NewRegistry()

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -480,7 +480,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			return oops.Code("COMMAND_DISPATCHER_FAILED").Wrap(cmdDispErr)
 		}
 
-		coreServer := holoGRPC.NewCoreServer(engine, sessionStore,
+		coreServer := holoGRPC.NewCoreServer(engine, sessionStore, cmdDispatcher, cmdServices,
 			holoGRPC.WithAuthenticator(guestAuth),
 			holoGRPC.WithEventStore(realStore),
 			holoGRPC.WithWorldQuerier(worldService),
@@ -490,7 +490,6 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			holoGRPC.WithPlayerTokenRepo(authPlayerTokenRepo),
 			holoGRPC.WithPlayerRepo(authPlayerRepo),
 			holoGRPC.WithCharacterRepo(authCharRepo),
-			holoGRPC.WithDispatcher(cmdDispatcher, cmdServices),
 			holoGRPC.WithSessionDefaults(holoGRPC.SessionDefaults{
 				TTL:        sessionTTL,
 				MaxHistory: cfg.SessionMaxHistory,

--- a/docs/superpowers/plans/2026-03-27-describe-page-whisper.md
+++ b/docs/superpowers/plans/2026-03-27-describe-page-whisper.md
@@ -733,9 +733,8 @@ Add to the session table in `registerSession`:
 
 ```go
 sessionTable.RawSetString("set_last_whispered", ls.NewFunction(func(ls *lua.LState) int {
-	name := ls.CheckString(1)
-	// Need session ID from command context — stored in Lua registry
-	sessionID := getSessionIDFromContext(ls)
+	sessionID := ls.CheckString(1)
+	name := ls.CheckString(2)
 	ctx := context.Background()
 	_ = sessAccess.UpdateLastWhispered(ctx, sessionID, name)
 	return 0
@@ -908,7 +907,7 @@ function handle_whisper(ctx)
     end
 
     -- Update last-whispered
-    holo.session.set_last_whispered(target.character_name)
+    holo.session.set_last_whispered(ctx.session_id, target.character_name)
 
     return holo.emit.flush()
 end

--- a/docs/superpowers/plans/2026-03-27-describe-page-whisper.md
+++ b/docs/superpowers/plans/2026-03-27-describe-page-whisper.md
@@ -1,0 +1,1051 @@
+# Describe, Page & Whisper Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `describe`, `page`, and `whisper` commands for v0.1 release.
+
+**Architecture:** `describe` and `page` are core Go handlers; `whisper` is a Lua plugin in `plugins/communication/`. Shared infrastructure includes new session fields (`last_paged`, `last_whispered`), a `FindByCharacterName` session method, and `WorldService.UpdateCharacterDescription`. Page emits to character streams only; whisper emits to both character and location streams.
+
+**Tech Stack:** Go, gopher-lua, PostgreSQL migrations, oops error handling
+
+**Spec:** `docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md`
+
+---
+
+## Chunk 1: Shared Infrastructure
+
+### Task 1: Database migration — session columns
+
+**Files:**
+
+- Create: `internal/store/migrations/000019_session_messaging.up.sql`
+- Create: `internal/store/migrations/000019_session_messaging.down.sql`
+
+- [ ] **Step 1: Write up migration**
+
+```sql
+-- 000019_session_messaging.up.sql
+ALTER TABLE sessions
+  ADD COLUMN last_paged TEXT NOT NULL DEFAULT '',
+  ADD COLUMN last_whispered TEXT NOT NULL DEFAULT '';
+```
+
+```sql
+-- 000019_session_messaging.down.sql
+ALTER TABLE sessions
+  DROP COLUMN IF EXISTS last_paged,
+  DROP COLUMN IF EXISTS last_whispered;
+```
+
+- [ ] **Step 2: Verify migration number is next in sequence**
+
+Run: `ls internal/store/migrations/ | tail -4`
+Expected: 000018 is the latest; 000019 is correct.
+
+- [ ] **Step 3: Commit**
+
+```text
+feat(store): add session messaging columns migration
+```
+
+---
+
+### Task 2: session.Info fields + scan updates
+
+**Files:**
+
+- Modify: `internal/session/session.go` (Info struct, ~line 41)
+- Modify: `internal/store/session_store.go` (sessionSelectColumns, scanSession)
+- Modify: `internal/session/memstore.go` (if needed for field propagation)
+
+- [ ] **Step 1: Add fields to session.Info**
+
+In `internal/session/session.go`, add to the `Info` struct after `UpdatedAt`:
+
+```go
+LastPaged     string
+LastWhispered string
+```
+
+- [ ] **Step 2: Update sessionSelectColumns in PostgresSessionStore**
+
+In `internal/store/session_store.go`, find the `sessionSelectColumns` const
+and add `last_paged, last_whispered` to the SELECT list.
+
+- [ ] **Step 3: Update scanSession to read the new columns**
+
+In `internal/store/session_store.go`, find the `scanSession` function and add
+`&info.LastPaged, &info.LastWhispered` to the scan destination list. Order
+MUST match the SELECT column order.
+
+- [ ] **Step 4: Update Set to persist the new fields**
+
+In `internal/store/session_store.go`, find the `Set` method and add
+`last_paged` and `last_whispered` to the INSERT/UPDATE columns and values.
+
+- [ ] **Step 5: Run tests**
+
+Run: `task test`
+Expected: All pass (new fields default to zero values).
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(session): add LastPaged and LastWhispered fields to Info
+```
+
+---
+
+### Task 3: New session.Access methods
+
+**Files:**
+
+- Modify: `internal/session/session.go` (Access interface, ~line 96)
+- Modify: `internal/store/session_store.go` (PostgresSessionStore implementations)
+- Modify: `internal/session/memstore.go` (MemStore implementations)
+- Modify: `internal/command/handlers/testutil/mock_session.go`
+- Modify: `internal/command/handlers/testutil/services.go` (defaultAccess)
+- Modify: `internal/command/dispatcher_test.go` (stubAccess)
+- Modify: `internal/command/types_test.go` (mockAccess)
+- Modify: `test/integration/command/ratelimit_integration_test.go` (stubSessionService)
+- Modify: `internal/web/handler_test.go` (mockSessionStore)
+
+- [ ] **Step 1: Add three methods to session.Access interface**
+
+In `internal/session/session.go`, add to the `Access` interface:
+
+```go
+// FindByCharacterName returns the active session for a character by name.
+// Case-insensitive match. Returns SESSION_NOT_FOUND code if no match.
+FindByCharacterName(ctx context.Context, name string) (*Info, error)
+
+// UpdateLastPaged sets the last-paged character name for a session.
+UpdateLastPaged(ctx context.Context, sessionID string, name string) error
+
+// UpdateLastWhispered sets the last-whispered character name for a session.
+UpdateLastWhispered(ctx context.Context, sessionID string, name string) error
+```
+
+Also add these to the `Store` interface if it doesn't embed `Access`
+(it does — check first).
+
+- [ ] **Step 2: Implement FindByCharacterName on PostgresSessionStore**
+
+In `internal/store/session_store.go`:
+
+```go
+func (s *PostgresSessionStore) FindByCharacterName(ctx context.Context, name string) (*Info, error) {
+	query := `SELECT ` + sessionSelectColumns + ` FROM sessions
+		WHERE LOWER(character_name) = LOWER($1) AND status = 'active'`
+	row := s.pool.QueryRow(ctx, query, name)
+	info, err := scanSession(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.Code("SESSION_NOT_FOUND").
+				With("character_name", name).
+				Errorf("no active session for character %q", name)
+		}
+		return nil, oops.With("operation", "find_by_character_name").Wrap(err)
+	}
+	return info, nil
+}
+```
+
+- [ ] **Step 3: Implement UpdateLastPaged on PostgresSessionStore**
+
+```go
+func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID string, name string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE sessions SET last_paged = $1 WHERE id = $2`, name, sessionID)
+	if err != nil {
+		return oops.With("operation", "update_last_paged").With("session_id", sessionID).Wrap(err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Implement UpdateLastWhispered on PostgresSessionStore**
+
+Same pattern as UpdateLastPaged with `last_whispered`.
+
+- [ ] **Step 5: Implement all three on MemStore**
+
+In `internal/session/memstore.go`:
+
+`FindByCharacterName`: iterate `m.sessions`, case-insensitive compare
+on `CharacterName`, return first active match or `SESSION_NOT_FOUND`.
+
+`UpdateLastPaged`: find session by ID, set `LastPaged` field.
+
+`UpdateLastWhispered`: find session by ID, set `LastWhispered` field.
+
+- [ ] **Step 6: Add stub implementations to all test mocks**
+
+Add to each mock/stub that implements `session.Access`:
+
+- `internal/command/handlers/testutil/mock_session.go` — MockSessionAccess
+- `internal/command/handlers/testutil/services.go` — defaultAccess
+- `internal/command/dispatcher_test.go` — stubAccess
+- `internal/command/types_test.go` — mockAccess
+- `test/integration/command/ratelimit_integration_test.go` — stubSessionService
+- `internal/web/handler_test.go` — mockSessionStore
+Each stub returns nil/empty values (no-op for updates, SESSION_NOT_FOUND for find).
+
+Note: `internal/grpc/server_test.go` uses `session.MemStore` directly
+(not a custom stub), so it does not need manual updates — MemStore
+implementations from Step 5 cover it.
+
+- [ ] **Step 7: Write tests for FindByCharacterName**
+
+In `internal/session/memstore_test.go` (or a new file if it doesn't exist):
+
+- Test case-insensitive match
+- Test no match returns SESSION_NOT_FOUND
+- Test only returns active sessions (not detached/expired)
+
+- [ ] **Step 8: Run tests**
+
+Run: `task test`
+Expected: All pass.
+
+- [ ] **Step 9: Commit**
+
+```text
+feat(session): add FindByCharacterName, UpdateLastPaged, UpdateLastWhispered
+```
+
+---
+
+### Task 4: New event types
+
+**Files:**
+
+- Modify: `internal/core/event.go` (EventType constants)
+- Modify: `internal/core/event_test.go` (TestDocumentedEventTypes validTypes map)
+
+- [ ] **Step 1: Add event type constants**
+
+In `internal/core/event.go`, add to the event type constants:
+
+```go
+// Messaging event types.
+EventTypePage    EventType = "page"
+EventTypeWhisper EventType = "whisper"
+```
+
+- [ ] **Step 2: Add payload structs**
+
+In `internal/core/event.go`:
+
+```go
+// PagePayload is the event payload for page messages.
+type PagePayload struct {
+	SenderID   string `json:"sender_id"`
+	SenderName string `json:"sender_name"`
+	Message    string `json:"message"`
+	IsPose     bool   `json:"is_pose"`
+}
+
+// WhisperPayload is the event payload for whisper messages on a character stream.
+type WhisperPayload struct {
+	SenderID   string `json:"sender_id"`
+	SenderName string `json:"sender_name"`
+	Message    string `json:"message"`
+	IsPose     bool   `json:"is_pose"`
+}
+
+// WhisperNoticePayload is the event payload for whisper notices on a location stream.
+type WhisperNoticePayload struct {
+	SenderName string `json:"sender_name"`
+	TargetName string `json:"target_name"`
+	Notice     string `json:"notice"`
+}
+```
+
+- [ ] **Step 3: Update TestDocumentedEventTypes**
+
+In `internal/core/event_test.go`, add to the `validTypes` map:
+
+```go
+string(EventTypePage):    true,
+string(EventTypeWhisper): true,
+```
+
+- [ ] **Step 4: Update plugin authoring docs if referenced by test**
+
+Check `site/docs/developers/plugin-authoring.md` for event type listings.
+Add `page` and `whisper` to any documented lists.
+
+- [ ] **Step 5: Run tests**
+
+Run: `task test`
+Expected: All pass including TestDocumentedEventTypes.
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(core): add page and whisper event types with payload structs
+```
+
+---
+
+### Task 5: WorldService.UpdateCharacterDescription
+
+**Files:**
+
+- Modify: `internal/command/types.go` (WorldService interface, ~line 24)
+- Modify: `internal/world/service.go` (implementation)
+- Create: `internal/world/service_describe_test.go` (or add to existing test file)
+- Modify: Test mocks for WorldService (find with `grep -rn "WorldService" --include="*_test.go"`)
+
+- [ ] **Step 1: Add method to WorldService interface**
+
+In `internal/command/types.go`, add to the `WorldService` interface:
+
+```go
+// UpdateCharacterDescription sets a character's description after checking authorization.
+UpdateCharacterDescription(ctx context.Context, subjectID string, characterID ulid.ULID, description string) error
+```
+
+- [ ] **Step 2: Implement on world.Service**
+
+In `internal/world/service.go`:
+
+```go
+func (s *Service) UpdateCharacterDescription(ctx context.Context, subjectID string, characterID ulid.ULID, description string) error {
+	if err := s.checkAccess(ctx, subjectID, "write", access.CharacterResource(characterID.String()), prefixCharacter); err != nil {
+		return err
+	}
+
+	char, err := s.charRepo.Get(ctx, characterID)
+	if err != nil {
+		return oops.Code("CHARACTER_GET_FAILED").
+			With("character_id", characterID.String()).Wrap(err)
+	}
+
+	char.Description = description
+	if err := s.charRepo.Update(ctx, char); err != nil {
+		return oops.Code("CHARACTER_UPDATE_FAILED").
+			With("character_id", characterID.String()).Wrap(err)
+	}
+	return nil
+}
+```
+
+`checkAccess` takes `(ctx, subject, action, resource string, prefix entityPrefix)`.
+Follow the pattern of `GetCharacter` which uses `"read"` action + `access.CharacterResource()`
+
+- `prefixCharacter`. For mutation, use `"write"` action.
+
+- [ ] **Step 3: Write test for UpdateCharacterDescription**
+
+Test: successful update, access denied, character not found.
+
+- [ ] **Step 4: Add stub to WorldService mocks in test files**
+
+Find all mock/stub implementations of `WorldService` and add a no-op
+`UpdateCharacterDescription` method.
+
+- [ ] **Step 5: Run tests**
+
+Run: `task test`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(world): add UpdateCharacterDescription to WorldService
+```
+
+---
+
+## Chunk 2: Describe Command
+
+### Task 6: describe handler + tests
+
+**Files:**
+
+- Create: `internal/command/handlers/describe.go`
+- Create: `internal/command/handlers/describe_test.go`
+- Modify: `internal/command/handlers/register.go` (RegisterAll)
+
+- [ ] **Step 1: Write failing tests for describe handler**
+
+Create `internal/command/handlers/describe_test.go`:
+
+```go
+func TestDescribeHandler_Me(t *testing.T) {
+	// describe me A tall figure with dark hair
+	// → calls WorldService.UpdateCharacterDescription with the text
+}
+
+func TestDescribeHandler_Here(t *testing.T) {
+	// describe here A dusty chamber
+	// → calls applyProperty for "location" entity type with "description"
+}
+
+func TestDescribeHandler_TargetEquals(t *testing.T) {
+	// describe sword=A gleaming blade
+	// → resolves target, calls applyProperty for "object"
+}
+
+func TestDescribeHandler_NoText(t *testing.T) {
+	// describe me
+	// → returns ErrInvalidArgs
+}
+
+func TestDescribeHandler_EmptyArgs(t *testing.T) {
+	// describe (no args)
+	// → returns ErrInvalidArgs
+}
+
+func TestDescribeHandler_HerePermissionDenied(t *testing.T) {
+	// describe here A dusty chamber (without objects.set capability)
+	// → returns access denied error
+}
+```
+
+Use `testutil.ServicesBuilder` to wire up mock WorldService. Follow the
+pattern in `say_test.go` and `objects_test.go` for CommandExecution setup.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test -- -run TestDescribeHandler -count=1 ./internal/command/handlers/`
+Expected: FAIL — DescribeHandler not defined.
+
+- [ ] **Step 3: Implement DescribeHandler**
+
+Create `internal/command/handlers/describe.go`:
+
+```go
+// DescribeHandler sets the description of a character, object, or location.
+// Syntax:
+//   describe me <text>       — set own character description
+//   describe here <text>     — set current location description
+//   describe <target>=<text> — set named target description
+func DescribeHandler(ctx context.Context, exec *command.CommandExecution) error {
+	args := strings.TrimSpace(exec.Args)
+	if args == "" {
+		return command.ErrInvalidArgs("describe", "describe me <text>")
+	}
+
+	// Parse: "me <text>", "here <text>", or "<target>=<text>"
+	target, text, err := parseDescribeArgs(args)
+	if err != nil {
+		return err
+	}
+	if text == "" {
+		return command.ErrInvalidArgs("describe", "describe me <text>")
+	}
+
+	if target == "me" {
+		return describeSelf(ctx, exec, text)
+	}
+
+	return describeTarget(ctx, exec, target, text)
+}
+```
+
+`parseDescribeArgs`: check for `me` prefix, `here` prefix, otherwise
+split on `=`. Return (target, text, error).
+
+`describeSelf`: check `player.describe` capability via ABAC engine,
+then call `exec.Services().World().UpdateCharacterDescription(ctx, subjectID, charID, text)`.
+
+`describeTarget`: resolve target via `resolveTarget`, look up `description`
+property, call `applyProperty`. Same flow as `set` command but hardcoded
+to `description` property.
+
+- [ ] **Step 4: Run tests**
+
+Run: `task test -- -run TestDescribeHandler -count=1 ./internal/command/handlers/`
+Expected: All pass.
+
+- [ ] **Step 5: Register in RegisterAll**
+
+In `internal/command/handlers/register.go`, add:
+
+```go
+mustRegister(command.CommandEntryConfig{
+	Name:    "describe",
+	Handler: DescribeHandler,
+	Help:    "Set a description",
+	Usage:   "describe me <text>",
+	HelpText: `## Describe
+
+Set the description of your character, the current location, or an object.
+
+### Usage
+
+- ` + "`describe me <text>`" + ` - Set your character's description
+- ` + "`describe here <text>`" + ` - Set the location's description
+- ` + "`describe <target>=<text>`" + ` - Set a named target's description
+
+### Examples
+
+- ` + "`describe me A tall figure with dark hair and bright eyes.`" + `
+- ` + "`describe here A dusty chamber lit by flickering torches.`" + `
+- ` + "`describe sword=A gleaming blade etched with runes.`" + ``,
+	Source: "core",
+})
+```
+
+No capabilities at registration level — checked inside handler.
+
+- [ ] **Step 6: Run full tests + lint**
+
+Run: `task test && task lint:go`
+Expected: All pass, 0 lint issues.
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(command): add describe handler for character/location/object descriptions
+```
+
+---
+
+## Chunk 3: Page Command
+
+### Task 7: page handler + tests
+
+**Files:**
+
+- Create: `internal/command/handlers/page.go`
+- Create: `internal/command/handlers/page_test.go`
+- Modify: `internal/command/handlers/register.go` (RegisterAll)
+
+- [ ] **Step 1: Write failing tests for page handler**
+
+Create `internal/command/handlers/page_test.go`:
+
+```go
+func TestPageHandler_Basic(t *testing.T) {
+	// page alex=Hey there
+	// → emits page event to Alex's character stream
+	// → emits command_response to sender's character stream
+	// → updates session.LastPaged to "Alex"
+}
+
+func TestPageHandler_LastPaged(t *testing.T) {
+	// Set session.LastPaged = "Alex"
+	// page How's it going?
+	// → pages Alex with "How's it going?"
+}
+
+func TestPageHandler_NoLastPaged(t *testing.T) {
+	// page How's it going? (no last-paged set)
+	// → returns error "Page who?"
+}
+
+func TestPageHandler_Pose(t *testing.T) {
+	// page alex=:waves
+	// → page event has is_pose=true
+	// → sender sees "Long distance to Alex: Sean waves."
+	// → target sees "From afar, Sean waves."
+}
+
+func TestPageHandler_PoseSemicolon(t *testing.T) {
+	// page alex=;'s jaw drops
+	// → sender sees "Long distance to Alex: Sean's jaw drops."
+}
+
+func TestPageHandler_TargetNotFound(t *testing.T) {
+	// page nobody=Hey
+	// → error "No one named "nobody" is connected."
+}
+
+func TestPageHandler_EmptyMessage(t *testing.T) {
+	// page alex=
+	// → returns ErrInvalidArgs
+}
+
+func TestPageHandler_NoArgs(t *testing.T) {
+	// page (no args)
+	// → returns ErrInvalidArgs
+}
+```
+
+Tests need:
+
+- MockSessionAccess with `FindByCharacterName` returning a target session
+- MockEventStore to capture appended events
+- Verify page event payload on target character stream
+- Verify command_response output on sender's io.Writer
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test -- -run TestPageHandler -count=1 ./internal/command/handlers/`
+Expected: FAIL — PageHandler not defined.
+
+- [ ] **Step 3: Implement PageHandler**
+
+Create `internal/command/handlers/page.go`:
+
+```go
+func PageHandler(ctx context.Context, exec *command.CommandExecution) error {
+	args := strings.TrimSpace(exec.Args)
+	if args == "" {
+		return command.ErrInvalidArgs("page", "page <name>=<message>")
+	}
+
+	target, message := parsePageArgs(args, exec)
+	if target == "" {
+		// No = and no last-paged
+		return command.ErrInvalidArgs("page", "Page who? Use: page <name>=<message>")
+	}
+	if message == "" {
+		return command.ErrInvalidArgs("page", "page <name>=<message>")
+	}
+
+	// Find target session
+	targetSession, err := exec.Services().Session().FindByCharacterName(ctx, target)
+	if err != nil {
+		writeOutputf(ctx, exec, "page", "No one named %q is connected.\n", target)
+		return nil // User-facing error, not infrastructure failure
+	}
+
+	// Detect pose mode
+	isPose, displayMessage := formatPageMessage(exec.CharacterName(), message)
+
+	// Emit page event to target's character stream
+	// ... (marshal PagePayload, append to character:targetCharID stream)
+
+	// Emit command_response to sender
+	// ... (format sender confirmation)
+
+	// Update last-paged
+	_ = exec.Services().Session().UpdateLastPaged(ctx, exec.SessionID().String(), targetSession.CharacterName)
+
+	return nil
+}
+```
+
+`parsePageArgs`: if `=` present, split. Otherwise use `exec` session's
+`LastPaged` as target, entire args as message. Need to read session info
+from the session store to get `LastPaged` — the handler needs the session
+ID. `exec.SessionID()` provides it; fetch the session to read `LastPaged`.
+
+`formatPageMessage`: check `:` or `;` prefix → pose mode. Return
+(isPose bool, formattedMessage string).
+
+- [ ] **Step 4: Run tests**
+
+Run: `task test -- -run TestPageHandler -count=1 ./internal/command/handlers/`
+Expected: All pass.
+
+- [ ] **Step 5: Register in RegisterAll**
+
+```go
+mustRegister(command.CommandEntryConfig{
+	Name:         "page",
+	Handler:      PageHandler,
+	Capabilities: []string{"comms.page"},
+	Help:         "Send a private message",
+	Usage:        "page <name>=<message>",
+	HelpText: `## Page
+
+Send a private out-of-character message to another player.
+
+### Usage
+
+- ` + "`page <name>=<message>`" + ` - Page a player
+- ` + "`page <message>`" + ` - Page the last person you paged
+- ` + "`page <name>=:<action>`" + ` - Pose-page
+
+### Examples
+
+- ` + "`page Alex=Hey, want to join the scene?`" + `
+- ` + "`page How about now?`" + ` - Pages Alex again
+- ` + "`page Alex=:waves hello.`" + ` - Alex sees: From afar, Sean waves hello.`,
+	Source: "core",
+})
+```
+
+- [ ] **Step 6: Run full tests + lint**
+
+Run: `task test && task lint:go`
+Expected: All pass, 0 lint issues.
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(command): add page handler for OOC private messaging
+```
+
+---
+
+## Chunk 4: Whisper Command (Lua Plugin)
+
+### Task 8: Extend RegisterStdlib for session dependency
+
+**Files:**
+
+- Modify: `internal/plugin/hostfunc/stdlib.go` (RegisterStdlib signature, add session namespace)
+- Modify: All callers of RegisterStdlib (search: `RegisterStdlib(`)
+- Create: `internal/plugin/hostfunc/stdlib_session_test.go`
+
+- [ ] **Step 1: Find all callers of RegisterStdlib**
+
+Run: `rg 'RegisterStdlib\(' --type go -n`
+
+Update the function signature and all call sites.
+
+- [ ] **Step 2: Add session.Access parameter to RegisterStdlib**
+
+```go
+func RegisterStdlib(ls *lua.LState, sessAccess session.Access) {
+```
+
+If `sessAccess` is non-nil, register the `holo.session` namespace.
+
+- [ ] **Step 3: Implement holo.session.find_by_name**
+
+In `internal/plugin/hostfunc/stdlib.go`, add a `registerSession` function:
+
+```go
+func registerSession(ls *lua.LState, holoTable *lua.LTable, sessAccess session.Access) {
+	sessionTable := ls.NewTable()
+
+	sessionTable.RawSetString("find_by_name", ls.NewFunction(func(ls *lua.LState) int {
+		name := ls.CheckString(1)
+		ctx := context.Background() // or extract from Lua state
+		info, err := sessAccess.FindByCharacterName(ctx, name)
+		if err != nil {
+			ls.Push(lua.LNil)
+			return 1
+		}
+		result := ls.NewTable()
+		result.RawSetString("character_id", lua.LString(info.CharacterID.String()))
+		result.RawSetString("character_name", lua.LString(info.CharacterName))
+		result.RawSetString("location_id", lua.LString(info.LocationID.String()))
+		ls.Push(result)
+		return 1
+	}))
+
+	holoTable.RawSetString("session", sessionTable)
+}
+```
+
+- [ ] **Step 4: Implement holo.session.set_last_whispered**
+
+Add to the session table in `registerSession`:
+
+```go
+sessionTable.RawSetString("set_last_whispered", ls.NewFunction(func(ls *lua.LState) int {
+	name := ls.CheckString(1)
+	// Need session ID from command context — stored in Lua registry
+	sessionID := getSessionIDFromContext(ls)
+	ctx := context.Background()
+	_ = sessAccess.UpdateLastWhispered(ctx, sessionID, name)
+	return 0
+}))
+```
+
+Note: The session ID must be available in the Lua command context. Check
+how the command context (`ctx.session_id`) is set in the Lua host. The
+`on_command(ctx)` function receives a context table — ensure `session_id`
+is populated there.
+
+- [ ] **Step 5: Write tests**
+
+Test `find_by_name` returns correct table for existing session, nil for missing.
+Test `set_last_whispered` calls UpdateLastWhispered on the mock.
+
+- [ ] **Step 6: Run tests + lint**
+
+Run: `task test && task lint:go`
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(plugin): add holo.session namespace with find_by_name and set_last_whispered
+```
+
+---
+
+### Task 9: Whisper Lua handler + plugin registration
+
+**Files:**
+
+- Modify: `plugins/communication/plugin.yaml` (add whisper command)
+- Modify: `plugins/communication/main.lua` (add whisper handler)
+
+- [ ] **Step 1: Add whisper command to plugin.yaml**
+
+In `plugins/communication/plugin.yaml`, add to the `commands` list:
+
+```yaml
+  - name: whisper
+    capabilities:
+      - comms.whisper
+    help: "Whisper to someone in the room"
+    usage: "whisper <character>=<message>"
+    helpText: |
+      ## Whisper
+
+      Whisper a private in-character message to someone in your location.
+      Others see that you whispered, but not what you said.
+
+      ### Usage
+
+      - `whisper <name>=<message>` - Whisper to someone
+      - `whisper <message>` - Whisper to the last person you whispered to
+      - `whisper <name>=:<action>` - Pose-whisper
+
+      ### Examples
+
+      - `whisper Alex=Meet me at the tavern`
+      - `whisper Alex=:nods knowingly.`
+```
+
+Also add `session.query` to the policies section so the plugin can call
+`holo.session.find_by_name`.
+
+- [ ] **Step 2: Implement whisper handler in main.lua**
+
+Add to `plugins/communication/main.lua`:
+
+```lua
+function on_command(ctx)
+    if ctx.name == "say" then
+        return handle_say(ctx)
+    elseif ctx.name == "pose" then
+        return handle_pose(ctx)
+    elseif ctx.name == "emit" then
+        return handle_emit(ctx)
+    elseif ctx.name == "whisper" then
+        return handle_whisper(ctx)
+    end
+    return nil
+end
+
+function handle_whisper(ctx)
+    local target_name, message = parse_whisper_args(ctx.args, ctx)
+    if target_name == nil then
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = "Whisper to whom? Use: whisper <name>=<message>",
+            is_error = true
+        })
+        return holo.emit.flush()
+    end
+    if message == "" or message == nil then
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = "Whisper what?",
+            is_error = true
+        })
+        return holo.emit.flush()
+    end
+
+    -- Find target session
+    local target = holo.session.find_by_name(target_name)
+    if target == nil then
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = 'No one named "' .. target_name .. '" is connected.',
+            is_error = true
+        })
+        return holo.emit.flush()
+    end
+
+    -- Same-location check
+    if target.location_id ~= ctx.location_id then
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = 'You don\'t see anyone named "' .. target_name .. '" here.',
+            is_error = true
+        })
+        return holo.emit.flush()
+    end
+
+    -- Detect pose mode
+    local is_pose = false
+    local display_message = message
+    local sender_display = message
+    if message:sub(1, 1) == ":" then
+        is_pose = true
+        display_message = "From nearby, " .. ctx.character_name .. " " .. message:sub(2)
+        sender_display = message:sub(2)
+    elseif message:sub(1, 1) == ";" then
+        is_pose = true
+        display_message = "From nearby, " .. ctx.character_name .. message:sub(2)
+        sender_display = message:sub(2)
+    end
+
+    -- Emit to location stream (notice only)
+    holo.emit.location(ctx.location_id, "whisper", {
+        sender_name = ctx.character_name,
+        target_name = target.character_name,
+        notice = ctx.character_name .. " whispers to " .. target.character_name .. "."
+    })
+
+    -- Emit to target's character stream (full content)
+    if is_pose then
+        holo.emit.character(target.character_id, "whisper", {
+            sender_id = ctx.character_id,
+            sender_name = ctx.character_name,
+            message = display_message,
+            is_pose = true
+        })
+    else
+        holo.emit.character(target.character_id, "whisper", {
+            sender_id = ctx.character_id,
+            sender_name = ctx.character_name,
+            message = ctx.character_name .. ' whispers, "' .. message .. '"',
+            is_pose = false
+        })
+    end
+
+    -- Emit confirmation to sender
+    if is_pose then
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = "You whisper-pose to " .. target.character_name .. ": " .. sender_display,
+            is_error = false
+        })
+    else
+        holo.emit.character(ctx.character_id, "command_response", {
+            text = "You whisper to " .. target.character_name .. ": " .. message,
+            is_error = false
+        })
+    end
+
+    -- Update last-whispered
+    holo.session.set_last_whispered(target.character_name)
+
+    return holo.emit.flush()
+end
+
+function parse_whisper_args(args, ctx)
+    if args == nil or args == "" then
+        return nil, nil
+    end
+    local eq_pos = args:find("=")
+    if eq_pos then
+        local name = args:sub(1, eq_pos - 1)
+        local msg = args:sub(eq_pos + 1)
+        return name, msg
+    end
+    -- No = sign: use last-whispered target
+    -- Need to get last_whispered from context
+    -- This requires ctx.last_whispered to be populated
+    if ctx.last_whispered and ctx.last_whispered ~= "" then
+        return ctx.last_whispered, args
+    end
+    return nil, nil
+end
+```
+
+- [ ] **Step 3: Inject last_whispered into Lua command context**
+
+In `internal/plugin/hostfunc/commands.go`, find where the command context
+table is built (the table passed to `on_command(ctx)`). Add a
+`last_whispered` field from the session info. This requires the command
+context builder to have access to session info — check how `session_id`
+and other session fields are currently populated, and add `last_whispered`
+following the same pattern. If session info is not currently available
+in the context builder, extend the builder to accept it.
+
+- [ ] **Step 4: Run communication plugin integration test**
+
+Run: `task test -- -run TestCommunication -count=1 ./internal/plugin/`
+Expected: Existing tests still pass, whisper command appears in manifest.
+
+- [ ] **Step 4: Commit**
+
+```text
+feat(plugin): add whisper command to communication plugin
+```
+
+---
+
+## Chunk 5: System Aliases + E2E
+
+### Task 10: Register aliases
+
+**Files:**
+
+- Modify: `internal/command/handlers/register.go`
+
+- [ ] **Step 1: Add alias registrations**
+
+In `RegisterAll`, add `desc` as a second registration for `DescribeHandler`,
+and `p` as a second registration for `PageHandler`:
+
+```go
+mustRegister(command.CommandEntryConfig{
+	Name:    "desc",
+	Handler: DescribeHandler,
+	Help:    "Set a description (alias for describe)",
+	Usage:   "desc me <text>",
+	Source:  "core",
+})
+
+mustRegister(command.CommandEntryConfig{
+	Name:         "p",
+	Handler:      PageHandler,
+	Capabilities: []string{"comms.page"},
+	Help:         "Send a private message (alias for page)",
+	Usage:        "p <name>=<message>",
+	Source:       "core",
+})
+```
+
+`w` for whisper: add a second command entry in
+`plugins/communication/plugin.yaml` with `name: w` pointing to the same
+handler as `whisper`. This is the same pattern used for `:` → pose.
+
+- [ ] **Step 2: Run tests + lint**
+
+Run: `task test && task lint:go`
+
+- [ ] **Step 3: Commit**
+
+```text
+feat(command): register desc and p as core command aliases
+```
+
+---
+
+### Task 11: E2E tests
+
+**Files:**
+
+- Create: `test/integration/telnet/messaging_test.go` (Ginkgo suite, follows existing pattern in `test/integration/telnet/`)
+
+- [ ] **Step 1: Add describe E2E test**
+
+Test that `describe me A tall figure` sets the description, and `look me`
+(or `look` for location) shows it.
+
+- [ ] **Step 2: Add page E2E test**
+
+Two concurrent telnet sessions. Session A pages Session B. Verify Session B
+receives the page event.
+
+- [ ] **Step 3: Add whisper E2E test**
+
+Two concurrent telnet sessions in the same location. Session A whispers to
+Session B. Verify:
+
+- Session B receives the whisper content
+- Both sessions see the location whisper notice
+
+- [ ] **Step 4: Run E2E tests**
+
+Run: `task test:e2e`
+Expected: All pass including new tests.
+
+- [ ] **Step 5: Commit**
+
+```text
+test(e2e): add describe, page, and whisper end-to-end tests
+```
+
+---
+
+## Post-Implementation Checklist
+
+- [ ] `task test` — all unit tests pass
+- [ ] `task lint` — clean
+- [ ] `task test:int` — integration tests pass
+- [ ] `task test:e2e` — E2E tests pass
+- [ ] Close beads: `bd close holomush-a3a7.1 holomush-a3a7.2`
+- [ ] Create PR

--- a/docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md
+++ b/docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md
@@ -1,0 +1,384 @@
+# Describe, Page & Whisper Commands — Design
+
+Three new commands for HoloMUSH v0.1: `describe` (set descriptions),
+`page` (OOC private messaging), and `whisper` (IC private messaging).
+
+## RFC 2119
+
+Keywords MUST, SHOULD, MAY per RFC 2119.
+
+---
+
+## 1. `describe` — Core Go Handler
+
+### Purpose
+
+Set the description of a character, object, or location. Viewed via `look`.
+
+### Syntax
+
+| Form                         | Target                        | Capability       |
+| ---------------------------- | ----------------------------- | ---------------- |
+| `describe me <text>`         | Caller's character            | `player.describe` |
+| `describe here <text>`       | Current location              | `objects.set`    |
+| `describe <target>=<text>`   | Named object/location         | `objects.set`    |
+
+`desc` MUST be registered as a system alias for `describe`.
+
+### Parsing Rules
+
+1. If args start with `me`, target is caller's character, remainder is text.
+2. If args start with `here`, target is current location, remainder is text.
+3. Otherwise, split on first `=`. Left side is target name, right side is text.
+4. Empty text MUST return an invalid-args error with usage hint.
+
+### Implementation
+
+- New file: `internal/command/handlers/describe.go`
+- **`me` path:** Fetch character via `WorldService.GetCharacter`, set
+  `Description` field, persist via `CharacterRepository.Update`. Check
+  `player.describe` capability via ABAC engine before mutating.
+  `applyProperty()` does not support characters — this path bypasses
+  the property system entirely.
+- **`here` / named target path:** Resolve via existing `resolveTarget()`,
+  look up `description` in the property registry, apply via `applyProperty()`.
+  ABAC enforces `objects.set` inside the property system.
+- Output on success: `Description set.`
+
+### WorldService Dependency
+
+The `me` path requires access to `CharacterRepository`. Today
+`WorldService` exposes `GetCharacter` but not a direct update-description
+method. The handler MUST call `WorldService.GetCharacter` + mutate the
+struct + `CharacterRepository.Update`. This requires `CharacterRepository`
+to be accessible from the handler — either exposed on `Services` or via a
+new `WorldService.UpdateCharacterDescription(ctx, subjectID, charID, desc)` method.
+
+The `WorldService` method is preferred — it keeps repository access behind
+the service and can enforce ABAC uniformly. This method MUST be added to
+the `WorldService` interface in `internal/command/types.go`.
+
+### Registration
+
+Register in `handlers.RegisterAll` with:
+
+- Name: `describe`
+- Capability: none (checked inside handler based on target)
+- Source: `core`
+
+---
+
+## 2. `page` — Core Go Handler
+
+### Purpose
+
+OOC private messaging between characters. Works across locations.
+No one else sees the message.
+
+### Syntax
+
+| Form | Behavior |
+|------|----------|
+| `page <character>=<message>` | Page character, set as last-paged |
+| `page <message>` | Page last-paged character |
+| `page <character>=:<action>` | Pose-page to character |
+
+`p` MUST be registered as a system alias for `page`.
+
+### Parsing Rules
+
+1. If args contain `=`, split on first `=`. Left is target name, right is message.
+2. If no `=`, entire args is the message; target is last-paged from session.
+3. If no `=` and no last-paged target, return error: `Page who? Use: page <name>=<message>`
+4. If message starts with `:`, treat as pose. Strip `:`, prepend sender name + space.
+5. If message starts with `;`, treat as pose. Strip `;`, prepend sender name (no space).
+6. Empty message MUST return an invalid-args error.
+
+### Events
+
+**Target's character stream** — `page` event:
+
+```json
+{
+  "sender_id": "<ulid>",
+  "sender_name": "Sean",
+  "message": "Hey there",
+  "is_pose": false
+}
+```
+
+**Sender's character stream** — `command_response`:
+
+| Mode | Sender sees                          | Target sees                |
+| ---- | ------------------------------------ | -------------------------- |
+| Say  | `You paged Alex: Hey there`          | `Sean pages: Hey there`    |
+| Pose | `Long distance to Alex: Sean waves.` | `From afar, Sean waves.`   |
+
+No location stream event. Page is entirely private.
+
+### New Event Type
+
+```go
+EventTypePage EventType = "page"
+```
+
+### Target Resolution
+
+New method on `session.Access`:
+
+```go
+FindByCharacterName(ctx context.Context, name string) (*Info, error)
+```
+
+Case-insensitive match against active sessions. Returns
+`SESSION_NOT_FOUND` code if no match.
+
+MUST also be added to:
+
+- `session.Store` interface
+- `PostgresSessionStore` (SQL: `WHERE LOWER(character_name) = LOWER($1) AND status = 'active'`)
+- `session.MemStore` (iterate + case-insensitive compare)
+- All test mocks/stubs that implement `session.Access`
+
+### Last-Paged State
+
+New field on `session.Info`:
+
+```go
+LastPaged string // character name of last page target
+```
+
+Persisted to Postgres via a new `last_paged` column on the `sessions` table.
+Updated on every successful page with a target.
+
+Migration: `ALTER TABLE sessions ADD COLUMN last_paged TEXT NOT NULL DEFAULT ''`
+
+The handler reads `LastPaged` from the session info already fetched by the
+gRPC `HandleCommand` path. Updates via a new method on `session.Access`:
+
+```go
+UpdateLastPaged(ctx context.Context, sessionID string, name string) error
+```
+
+This is a dedicated method rather than extending `UpdateActivity`, to
+avoid changing the existing interface contract and all its callers/mocks.
+
+### Capability
+
+`comms.page` — granted to all players by default.
+
+---
+
+## 3. `whisper` — Lua Plugin
+
+### Purpose
+
+IC private messaging. Target MUST be in the same location.
+Others in the location see that a whisper occurred (but not the content).
+Game-customizable via Lua (overhearing, stealth, etc.).
+
+### Syntax
+
+| Form | Behavior |
+|------|----------|
+| `whisper <character>=<message>` | Whisper to co-located character |
+| `whisper <message>` | Whisper to last-whispered character |
+| `whisper <character>=:<action>` | Pose-whisper |
+
+`w` MUST be registered as a system alias for `whisper`. This is a
+shorthand for the full `whisper` command, not a pose-specific variant.
+Note: some test fixtures use `w` → `west` as example alias data. The
+production alias `w` → `whisper` takes precedence. Players use `west`
+or `move west` directly for navigation — `w` is not needed for movement.
+
+### Parsing Rules
+
+Same as `page` — split on `=`, fall back to last-whispered.
+
+### Events
+
+**Location stream** — `whisper` event (visible to all in location):
+
+```json
+{
+  "sender_name": "Sean",
+  "target_name": "Alex",
+  "notice": "Sean whispers to Alex."
+}
+```
+
+Content is NOT included in the location event.
+
+**Target's character stream** — `whisper` event:
+
+| Mode | Text |
+|------|------|
+| Say | `Sean whispers, "Hey there"` |
+| Pose | `From nearby, Sean waves.` |
+
+**Sender's character stream** — via `holo.emit.character`:
+
+| Mode | Text |
+|------|------|
+| Say  | `You whisper to Alex: Hey there`         |
+| Pose | `You whisper-pose to Alex: waves.`       |
+
+### New Event Type
+
+```go
+EventTypeWhisper EventType = "whisper"
+```
+
+### Same-Location Check
+
+The Lua handler calls `holo.session.find_by_name(name)` to get the
+target's session info including `location_id`. If the target's location
+does not match the sender's location, return:
+`You don't see anyone named "Alex" here.`
+
+If the target is not online at all:
+`No one named "Alex" is connected.`
+
+### New Host Function
+
+```text
+holo.session.find_by_name(name) -> table | nil
+```
+
+Returns `{character_id, character_name, location_id}` for the named
+character's active session. Case-insensitive. Returns nil if not found.
+
+Implemented in `internal/plugin/hostfunc/stdlib.go`. Calls
+`session.Access.FindByCharacterName` (same method added for `page`).
+
+The Lua host function pipeline receives dependencies via `RegisterStdlib`.
+`session.Access` (or `session.Store`, which embeds `Access`) MUST be
+passed to `RegisterStdlib` so the `holo.session` namespace can call
+session methods. If `RegisterStdlib` does not currently accept a session
+dependency, it MUST be extended.
+
+Requires new capability: `session.query` — granted to plugins that
+declare it in their `plugin.yaml`.
+
+### Last-Whispered State
+
+New field on `session.Info`:
+
+```go
+LastWhispered string // character name of last whisper target
+```
+
+Persisted to Postgres via `last_whispered` column.
+
+Migration: same migration as `last_paged` — add both columns together.
+
+The Lua handler updates this via a new host function:
+
+```text
+holo.session.set_last_whispered(name)
+```
+
+Scoped to the caller's session (session ID from command context).
+Implemented in `internal/plugin/hostfunc/stdlib.go`, calls a new
+`UpdateLastWhispered(ctx, sessionID, name)` method on `session.Access`.
+
+### Plugin Registration
+
+Add to `plugins/communication/plugin.yaml`:
+
+- Command `whisper` with capability `comms.whisper`
+- Policy for `session.query` capability
+
+### Customization
+
+Operators MAY modify the whisper Lua to add:
+
+- Overhearing chance based on attributes
+- Stealth/perception checks
+- Distance-based whisper range
+- Logging for moderation
+
+---
+
+## 4. Shared Infrastructure
+
+### Migration
+
+One migration adding two columns to `sessions`:
+
+```sql
+ALTER TABLE sessions
+  ADD COLUMN last_paged TEXT NOT NULL DEFAULT '',
+  ADD COLUMN last_whispered TEXT NOT NULL DEFAULT '';
+```
+
+### New `session.Access` Methods
+
+Three new methods MUST be added to `session.Access` (and `session.Store`,
+which embeds it):
+
+```go
+FindByCharacterName(ctx context.Context, name string) (*Info, error)
+UpdateLastPaged(ctx context.Context, sessionID string, name string) error
+UpdateLastWhispered(ctx context.Context, sessionID string, name string) error
+```
+
+Implementations in `PostgresSessionStore` and `MemStore`. All test
+mocks/stubs that implement `session.Access` MUST add these methods.
+
+### System Aliases
+
+Seeded on first boot (or added to existing alias seeding if `.3` is done):
+
+- `desc` → `describe`
+- `p` → `page`
+- `w` → `whisper`
+
+If alias seeding (holomush-a3a7.3) is not yet implemented, these three
+aliases SHOULD be added to the `RegisterAll` function as additional
+command registrations (same handler, different name) rather than waiting
+for the alias system.
+
+---
+
+## 5. Testing
+
+### `describe`
+
+- `describe me <text>` sets caller's character description
+- `describe here <text>` sets location description (with `objects.set` capability)
+- `describe <target>=<text>` sets named target description
+- `describe me` with no text returns usage error
+- ABAC: player without `objects.set` cannot describe objects/locations
+
+### `page`
+
+- `page alex=Hey` delivers page event to Alex's character stream
+- Sender receives `You paged Alex: Hey` command_response
+- `page alex=:waves` delivers pose: `From afar, Sean waves.`
+- `page Hey` uses last-paged target
+- `page Hey` with no last-paged returns error
+- Target not online returns `No one named "Alex" is connected.`
+- Last-paged persists across commands in same session
+
+### `whisper`
+
+- `whisper alex=Hey` delivers whisper to Alex + location notice
+- Location notice is `Sean whispers to Alex.` (no content)
+- Target not in same location returns error
+- Target not online returns error
+- `whisper alex=:waves` delivers pose-whisper
+- `whisper Hey` uses last-whispered target
+- Last-whispered persists across commands in same session
+
+### Event Type Registration
+
+Adding `EventTypePage` and `EventTypeWhisper` to `core/event.go` MUST
+also update `TestDocumentedEventTypes` in `core/event_test.go` and the
+plugin authoring docs, or the test will fail.
+
+### Integration
+
+- Page and whisper E2E tests use the existing telnet E2E infrastructure
+  (two concurrent telnet connections to the Docker stack)
+- Describe output visible via `look` after setting

--- a/docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md
+++ b/docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md
@@ -275,12 +275,12 @@ Migration: same migration as `last_paged` — add both columns together.
 The Lua handler updates this via a new host function:
 
 ```text
-holo.session.set_last_whispered(name)
+holo.session.set_last_whispered(session_id, name)
 ```
 
-Scoped to the caller's session (session ID from command context).
-Implemented in `internal/plugin/hostfunc/stdlib.go`, calls a new
-`UpdateLastWhispered(ctx, sessionID, name)` method on `session.Access`.
+Takes an explicit session ID and target character name.
+Implemented in `internal/plugin/hostfunc/stdlib_session.go`, calls
+`UpdateLastWhispered(ctx, sessionID, name)` on `session.Access`.
 
 ### Plugin Registration
 

--- a/internal/command/dispatcher_test.go
+++ b/internal/command/dispatcher_test.go
@@ -60,6 +60,18 @@ func (s *stubAccess) UpdateActivity(_ context.Context, _ string) error {
 	return nil
 }
 
+func (s *stubAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, nil
+}
+
+func (s *stubAccess) UpdateLastPaged(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (s *stubAccess) UpdateLastWhispered(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 type stubEventStore struct{}
 
 func (s *stubEventStore) Append(_ context.Context, _ core.Event) error { return nil }

--- a/internal/command/handlers/describe.go
+++ b/internal/command/handlers/describe.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// DescribeHandler handles the describe command.
+// Syntax:
+//   - describe me <text>        — set own character description
+//   - describe here <text>      — set current location description
+//   - describe <target>=<text>  — set named target description
+func DescribeHandler(ctx context.Context, exec *command.CommandExecution) error {
+	args := strings.TrimSpace(exec.Args)
+	if args == "" {
+		//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+		return command.ErrInvalidArgs("describe", "describe me <text> | describe here <text> | describe <target>=<text>")
+	}
+
+	target, text, err := parseDescribeArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if target == "me" {
+		return describeSelf(ctx, exec, text)
+	}
+	return describeTarget(ctx, exec, target, text)
+}
+
+// parseDescribeArgs parses describe command arguments into target and text.
+// Returns ErrInvalidArgs if text is missing.
+func parseDescribeArgs(args string) (target, text string, err error) {
+	// "me <text>"
+	if strings.HasPrefix(args, "me ") {
+		text = strings.TrimSpace(args[3:])
+		if text == "" {
+			//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+			return "", "", command.ErrInvalidArgs("describe", "describe me <text>")
+		}
+		return "me", text, nil
+	}
+	// "here <text>"
+	if strings.HasPrefix(args, "here ") {
+		text = strings.TrimSpace(args[5:])
+		if text == "" {
+			//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+			return "", "", command.ErrInvalidArgs("describe", "describe here <text>")
+		}
+		return "here", text, nil
+	}
+	// "<target>=<text>"
+	idx := strings.IndexByte(args, '=')
+	if idx > 0 {
+		tgt := strings.TrimSpace(args[:idx])
+		txt := strings.TrimSpace(args[idx+1:])
+		if tgt == "" || txt == "" {
+			//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+			return "", "", command.ErrInvalidArgs("describe", "describe <target>=<text>")
+		}
+		return tgt, txt, nil
+	}
+
+	// args present but no recognisable form (e.g. "describe me" with no text)
+	//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+	return "", "", command.ErrInvalidArgs("describe", "describe me <text> | describe here <text> | describe <target>=<text>")
+}
+
+// describeSelf updates the calling character's own description.
+func describeSelf(ctx context.Context, exec *command.CommandExecution, text string) error {
+	subjectID := access.CharacterSubject(exec.CharacterID().String())
+	charID := exec.CharacterID()
+
+	if err := exec.Services().World().UpdateCharacterDescription(ctx, subjectID, charID, text); err != nil {
+		if errors.Is(err, world.ErrAccessEvaluationFailed) {
+			return err //nolint:wrapcheck // preserve oops error code from world service
+		}
+		if errors.Is(err, world.ErrPermissionDenied) {
+			return err //nolint:wrapcheck // preserve oops error code from world service
+		}
+		slog.ErrorContext(ctx, "describe: UpdateCharacterDescription failed",
+			"character_id", charID,
+			"error", err)
+		return writeOutputWithWorldError(ctx, exec, "describe", "Failed to set description. Please try again.", err)
+	}
+
+	writeOutput(ctx, exec, "describe", "Description set.\n")
+	return nil
+}
+
+// describeTarget updates the description of a named target (here, #id, or named object).
+// It uses the property registry to locate the "description" property and applies it.
+func describeTarget(ctx context.Context, exec *command.CommandExecution, target, text string) error {
+	registry := exec.Services().PropertyRegistry()
+	if registry == nil {
+		return writeOutputWithWorldError(ctx, exec, "describe", "Property registry not configured.", nil)
+	}
+
+	entry, err := registry.Resolve("description")
+	if err != nil {
+		slog.DebugContext(ctx, "describe: property resolution failed",
+			"character_id", exec.CharacterID(),
+			"error", err)
+		return writeOutputfWithWorldError(ctx, exec, "describe", "Unknown property: description\n", err)
+	}
+
+	entityType, entityID, err := resolveTarget(ctx, exec, target)
+	if err != nil {
+		slog.DebugContext(ctx, "describe: target resolution failed",
+			"character_id", exec.CharacterID(),
+			"target", target,
+			"error", err)
+		writeOutputf(ctx, exec, "describe", "Could not find target: %s\n", target)
+		return err
+	}
+
+	if err := applyProperty(ctx, exec, entityType, entityID, entry.Name, entry.Definition, text); err != nil {
+		if errors.Is(err, world.ErrAccessEvaluationFailed) {
+			return err
+		}
+		if errors.Is(err, world.ErrPermissionDenied) {
+			return err
+		}
+		slog.ErrorContext(ctx, "describe: applyProperty failed",
+			"character_id", exec.CharacterID(),
+			"entity_type", entityType,
+			"entity_id", entityID,
+			"error", err)
+		return writeOutputWithWorldError(ctx, exec, "describe", "Failed to set description. Please try again.", err)
+	}
+
+	writeOutput(ctx, exec, "describe", "Description set.\n")
+	return nil
+}

--- a/internal/command/handlers/describe_test.go
+++ b/internal/command/handlers/describe_test.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/holomush/holomush/internal/world/worldtest"
+)
+
+func TestDescribeHandler_Me(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+
+	charRepo := worldtest.NewMockCharacterRepository(t)
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+
+	// UpdateCharacterDescription checks "write" on the character resource.
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "write",
+			Resource: access.CharacterResource(charID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+
+	charRepo.EXPECT().
+		Get(mock.Anything, charID).
+		Return(&world.Character{ID: charID, Name: "TestChar"}, nil)
+	charRepo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(c *world.Character) bool {
+			return c.Description == "A tall figure"
+		})).
+		Return(nil)
+
+	worldService := world.NewService(world.ServiceConfig{
+		CharacterRepo: charRepo,
+		Engine:        accessControl,
+	})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "me A tall figure",
+		Output:      &buf,
+		Services:    command.NewTestServices(command.ServicesConfig{World: worldService}),
+	})
+
+	err := DescribeHandler(context.Background(), exec)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Description set.")
+}
+
+func TestDescribeHandler_Here(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+
+	locationRepo := worldtest.NewMockLocationRepository(t)
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+
+	// applyProperty calls GetLocation (read) then UpdateLocation (write).
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "read",
+			Resource: access.LocationResource(locationID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+	locationRepo.EXPECT().
+		Get(mock.Anything, locationID).
+		Return(&world.Location{ID: locationID, Name: "Test Room", Type: world.LocationTypePersistent}, nil)
+
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "write",
+			Resource: access.LocationResource(locationID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+	locationRepo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(loc *world.Location) bool {
+			return loc.Description == "A dusty chamber"
+		})).
+		Return(nil)
+
+	worldService := world.NewService(world.ServiceConfig{
+		LocationRepo: locationRepo,
+		Engine:       accessControl,
+	})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "here A dusty chamber",
+		Output:      &buf,
+		Services:    command.NewTestServices(command.ServicesConfig{World: worldService}),
+	})
+
+	err := DescribeHandler(context.Background(), exec)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Description set.")
+}
+
+func TestDescribeHandler_TargetEquals(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+	objectID := ulid.Make()
+
+	objectRepo := worldtest.NewMockObjectRepository(t)
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+
+	// applyProperty calls GetObject (read) then UpdateObject (write).
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "read",
+			Resource: access.ObjectResource(objectID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+	sword, err := world.NewObjectWithID(objectID, "Sword", world.InLocation(locationID))
+	require.NoError(t, err)
+	objectRepo.EXPECT().
+		Get(mock.Anything, objectID).
+		Return(sword, nil)
+
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "write",
+			Resource: access.ObjectResource(objectID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+	objectRepo.EXPECT().
+		Update(mock.Anything, mock.MatchedBy(func(obj *world.Object) bool {
+			return obj.Description == "A gleaming blade"
+		})).
+		Return(nil)
+
+	worldService := world.NewService(world.ServiceConfig{
+		ObjectRepo: objectRepo,
+		Engine:     accessControl,
+	})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "#" + objectID.String() + "=A gleaming blade",
+		Output:      &buf,
+		Services:    command.NewTestServices(command.ServicesConfig{World: worldService}),
+	})
+
+	descErr := DescribeHandler(context.Background(), exec)
+	require.NoError(t, descErr)
+	assert.Contains(t, buf.String(), "Description set.")
+}
+
+func TestDescribeHandler_NoText(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+	worldService := world.NewService(world.ServiceConfig{Engine: accessControl})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "me",
+		Output:      &buf,
+		Services:    command.NewTestServices(command.ServicesConfig{World: worldService}),
+	})
+
+	err := DescribeHandler(context.Background(), exec)
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "expected oops error")
+	assert.Equal(t, command.CodeInvalidArgs, oopsErr.Code())
+}
+
+func TestDescribeHandler_EmptyArgs(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+	worldService := world.NewService(world.ServiceConfig{Engine: accessControl})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "",
+		Output:      &buf,
+		Services:    command.NewTestServices(command.ServicesConfig{World: worldService}),
+	})
+
+	err := DescribeHandler(context.Background(), exec)
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "expected oops error")
+	assert.Equal(t, command.CodeInvalidArgs, oopsErr.Code())
+}
+
+func TestDescribeHandler_HerePermissionDenied(t *testing.T) {
+	charID := ulid.Make()
+	locationID := ulid.Make()
+
+	locationRepo := worldtest.NewMockLocationRepository(t)
+	accessControl := worldtest.NewMockAccessPolicyEngine(t)
+
+	// GetLocation (read) succeeds.
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "read",
+			Resource: access.LocationResource(locationID.String()),
+		}).
+		Return(types.NewDecision(types.EffectAllow, "", ""), nil)
+	locationRepo.EXPECT().
+		Get(mock.Anything, locationID).
+		Return(&world.Location{ID: locationID, Name: "Test Room", Type: world.LocationTypePersistent}, nil)
+
+	// UpdateLocation (write) is denied.
+	accessControl.EXPECT().
+		Evaluate(mock.Anything, types.AccessRequest{
+			Subject:  access.CharacterSubject(charID.String()),
+			Action:   "write",
+			Resource: access.LocationResource(locationID.String()),
+		}).
+		Return(types.NewDecision(types.EffectDeny, "", ""), nil)
+
+	worldService := world.NewService(world.ServiceConfig{
+		LocationRepo: locationRepo,
+		Engine:       accessControl,
+	})
+
+	var buf bytes.Buffer
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID: charID,
+		LocationID:  locationID,
+		Args:        "here A dusty chamber",
+		Output:      &buf,
+		Services: command.NewTestServices(command.ServicesConfig{
+			World:  worldService,
+			Engine: policytest.AllowAllEngine(),
+		}),
+	})
+
+	err := DescribeHandler(context.Background(), exec)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, world.ErrPermissionDenied), "expected permission denied error, got: %v", err)
+}

--- a/internal/command/handlers/page.go
+++ b/internal/command/handlers/page.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// PageHandler handles the page command for OOC private messaging.
+//
+// Syntax:
+//   - page <character>=<message>   — page someone, set as last-paged
+//   - page <message>               — page last-paged character (no = means message to last target)
+//   - page <character>=:<action>   — pose-page (colon prefix)
+//   - page <character>=;<action>   — no-space pose (semicolon prefix)
+func PageHandler(ctx context.Context, exec *command.CommandExecution) error {
+	args := strings.TrimSpace(exec.Args)
+	if args == "" {
+		//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+		return command.ErrInvalidArgs("page", "page <name>=<message>")
+	}
+
+	var targetName, rawMessage string
+	var useLastPaged bool
+
+	idx := strings.IndexByte(args, '=')
+	if idx > 0 {
+		targetName = strings.TrimSpace(args[:idx])
+		rawMessage = args[idx+1:] // do NOT trim — leading : or ; is meaningful
+	} else {
+		// No '=' — page last-paged character with args as message
+		rawMessage = args
+		useLastPaged = true
+	}
+
+	if rawMessage == "" {
+		//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+		return command.ErrInvalidArgs("page", "page <name>=<message>")
+	}
+
+	// Resolve target name from last-paged if needed.
+	if useLastPaged {
+		senderSession, err := exec.Services().Session().FindByCharacter(ctx, exec.CharacterID())
+		if err != nil {
+			return oops.With("operation", "find_sender_session").Wrap(err)
+		}
+		if senderSession == nil || senderSession.LastPaged == "" {
+			writeOutput(ctx, exec, "page", "You have no last-paged character. Use: page <name>=<message>")
+			return nil
+		}
+		targetName = senderSession.LastPaged
+	}
+
+	// Look up target session.
+	targetSession, err := exec.Services().Session().FindByCharacterName(ctx, targetName)
+	if err != nil {
+		return oops.With("operation", "find_target_session").Wrap(err)
+	}
+	if targetSession == nil {
+		writeOutputf(ctx, exec, "page", "No one named %q is connected.\n", targetName)
+		return nil
+	}
+
+	// Determine pose vs. normal message.
+	isPose := false
+	var formattedForTarget, formattedForSender string
+
+	switch {
+	case strings.HasPrefix(rawMessage, ":"):
+		// Colon pose: "page alex=:waves" → "From afar, Sean waves."
+		action := rawMessage[1:]
+		if action == "" {
+			//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+			return command.ErrInvalidArgs("page", "page <name>=:<action>")
+		}
+		isPose = true
+		formattedForTarget = fmt.Sprintf("From afar, %s %s", exec.CharacterName(), action)
+		formattedForSender = fmt.Sprintf("Long distance to %s: %s %s", targetSession.CharacterName, exec.CharacterName(), action)
+
+	case strings.HasPrefix(rawMessage, ";"):
+		// Semicolon pose (no space): "page alex=;'s jaw drops" → "From afar, Sean's jaw drops."
+		action := rawMessage[1:]
+		if action == "" {
+			//nolint:wrapcheck // ErrInvalidArgs creates a structured oops error
+			return command.ErrInvalidArgs("page", "page <name>=;<action>")
+		}
+		isPose = true
+		formattedForTarget = fmt.Sprintf("From afar, %s%s", exec.CharacterName(), action)
+		formattedForSender = fmt.Sprintf("Long distance to %s: %s%s", targetSession.CharacterName, exec.CharacterName(), action)
+
+	default:
+		// Normal message.
+		formattedForTarget = fmt.Sprintf("%s pages: %s", exec.CharacterName(), rawMessage)
+		formattedForSender = fmt.Sprintf("You paged %s: %s", targetSession.CharacterName, rawMessage)
+	}
+
+	// Emit page event to target's character stream.
+	pagePayload, err := json.Marshal(core.PagePayload{
+		SenderID:   exec.CharacterID().String(),
+		SenderName: exec.CharacterName(),
+		Message:    formattedForTarget,
+		IsPose:     isPose,
+	})
+	if err != nil {
+		return oops.With("operation", "marshal_page_payload").Wrap(err)
+	}
+
+	targetCharID := targetSession.CharacterID
+	pageEvent := core.Event{
+		ID:        core.NewULID(),
+		Stream:    world.CharacterStream(targetCharID),
+		Type:      core.EventTypePage,
+		Timestamp: time.Now(),
+		Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+		Payload:   pagePayload,
+	}
+	if err := exec.Services().Events().Append(ctx, pageEvent); err != nil {
+		return oops.With("operation", "append_page_event").Wrap(err)
+	}
+
+	// Update last-paged on the sender's session.
+	if sid := exec.SessionID(); !sid.IsZero() {
+		if err := exec.Services().Session().UpdateLastPaged(ctx, sid.String(), targetSession.CharacterName); err != nil {
+			// Log but do not fail the command — the page was already delivered.
+			writeOutput(ctx, exec, "page", "(Warning: could not update last-paged state.)")
+		}
+	}
+
+	// Send confirmation to sender.
+	writeOutput(ctx, exec, "page", formattedForSender)
+	return nil
+}

--- a/internal/command/handlers/page_test.go
+++ b/internal/command/handlers/page_test.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers/testutil"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// captureStore wraps stubEventStoreCapture to capture all appended events.
+type captureStore struct {
+	events []core.Event
+}
+
+func (c *captureStore) Append(_ context.Context, e core.Event) error {
+	c.events = append(c.events, e)
+	return nil
+}
+
+func (c *captureStore) Replay(_ context.Context, _ string, _ ulid.ULID, _ int) ([]core.Event, error) {
+	return nil, nil
+}
+
+func (c *captureStore) LastEventID(_ context.Context, _ string) (ulid.ULID, error) {
+	return ulid.ULID{}, nil
+}
+
+func (c *captureStore) Subscribe(_ context.Context, _ string) (<-chan ulid.ULID, <-chan error, error) {
+	return nil, nil, nil
+}
+
+// makePageExec builds a CommandExecution for page handler tests.
+const testSenderName = "Sean"
+
+func makePageExec(
+	t *testing.T,
+	senderID ulid.ULID,
+	sessionID ulid.ULID,
+	args string,
+	store core.EventStore,
+	sessionAccess *testutil.MockSessionAccess,
+) (*command.CommandExecution, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	svc := testutil.NewServicesBuilder().
+		WithSession(sessionAccess).
+		WithEvents(store).
+		Build()
+	exec := command.NewTestExecution(command.CommandExecutionConfig{
+		CharacterID:   senderID,
+		CharacterName: testSenderName,
+		LocationID:    ulid.Make(),
+		SessionID:     sessionID,
+		Output:        &buf,
+		Services:      svc,
+	})
+	exec.Args = args
+	return exec, &buf
+}
+
+func TestPageHandler_Basic(t *testing.T) {
+	senderID := ulid.Make()
+	targetID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+	mock.AddSession(senderID, "Sean")
+	mock.AddSession(targetID, "Alex")
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "alex=Hey there", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	// Should emit exactly one event (to target's stream).
+	require.Len(t, store.events, 1)
+	ev := store.events[0]
+	assert.Equal(t, core.EventTypePage, ev.Type)
+	assert.Equal(t, world.CharacterStream(targetID), ev.Stream)
+	assert.Contains(t, string(ev.Payload), "Sean pages: Hey there")
+	assert.Contains(t, string(ev.Payload), `"is_pose":false`)
+
+	// Sender sees confirmation.
+	assert.Contains(t, buf.String(), "You paged Alex: Hey there")
+}
+
+func TestPageHandler_LastPaged(t *testing.T) {
+	senderID := ulid.Make()
+	targetID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess(
+		&session.Info{
+			ID:            sessionID.String(),
+			CharacterID:   senderID,
+			CharacterName: "Sean",
+			Status:        session.StatusActive,
+			LastPaged:     "Alex",
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		},
+		&session.Info{
+			ID:            ulid.Make().String(),
+			CharacterID:   targetID,
+			CharacterName: "Alex",
+			Status:        session.StatusActive,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		},
+	)
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "How's it going?", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	require.Len(t, store.events, 1)
+	assert.Equal(t, world.CharacterStream(targetID), store.events[0].Stream)
+	assert.Contains(t, buf.String(), "You paged Alex: How's it going?")
+}
+
+func TestPageHandler_NoLastPaged(t *testing.T) {
+	senderID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess(
+		&session.Info{
+			ID:            sessionID.String(),
+			CharacterID:   senderID,
+			CharacterName: "Sean",
+			Status:        session.StatusActive,
+			LastPaged:     "", // no last-paged
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		},
+	)
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "Hey", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	// No events emitted.
+	assert.Empty(t, store.events)
+	assert.Contains(t, buf.String(), "no last-paged character")
+}
+
+func TestPageHandler_Pose(t *testing.T) {
+	senderID := ulid.Make()
+	targetID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+	mock.AddSession(senderID, "Sean")
+	mock.AddSession(targetID, "Alex")
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "alex=:waves.", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	require.Len(t, store.events, 1)
+	ev := store.events[0]
+	assert.Equal(t, core.EventTypePage, ev.Type)
+	assert.Contains(t, string(ev.Payload), "From afar, Sean waves.")
+	assert.Contains(t, string(ev.Payload), `"is_pose":true`)
+
+	// Sender sees long-distance format.
+	assert.Contains(t, buf.String(), "Long distance to Alex: Sean waves.")
+}
+
+func TestPageHandler_PoseSemicolon(t *testing.T) {
+	senderID := ulid.Make()
+	targetID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+	mock.AddSession(senderID, "Sean")
+	mock.AddSession(targetID, "Alex")
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "alex=;'s jaw drops.", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	require.Len(t, store.events, 1)
+	// No space between name and action.
+	assert.Contains(t, string(store.events[0].Payload), "From afar, Sean's jaw drops.")
+	assert.Contains(t, buf.String(), "Long distance to Alex: Sean's jaw drops.")
+}
+
+func TestPageHandler_TargetNotFound(t *testing.T) {
+	senderID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+	mock.AddSession(senderID, "Sean")
+	// "nobody" is not in the mock.
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "nobody=Hey", store, mock)
+
+	err := PageHandler(context.Background(), exec)
+	require.NoError(t, err)
+
+	// No events emitted.
+	assert.Empty(t, store.events)
+	assert.Contains(t, buf.String(), `"nobody"`)
+	assert.Contains(t, buf.String(), "connected")
+}
+
+func TestPageHandler_EmptyMessage(t *testing.T) {
+	senderID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+	mock.AddSession(senderID, "Sean")
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "alex=", store, mock)
+	_ = buf
+
+	err := PageHandler(context.Background(), exec)
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, command.CodeInvalidArgs, oopsErr.Code())
+}
+
+func TestPageHandler_NoArgs(t *testing.T) {
+	senderID := ulid.Make()
+	sessionID := ulid.Make()
+
+	mock := testutil.NewMockSessionAccess()
+
+	store := &captureStore{}
+	exec, buf := makePageExec(t, senderID, sessionID, "", store, mock)
+	_ = buf
+
+	err := PageHandler(context.Background(), exec)
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, command.CodeInvalidArgs, oopsErr.Code())
+}

--- a/internal/command/handlers/register.go
+++ b/internal/command/handlers/register.go
@@ -48,6 +48,15 @@ Send an OOC private message to another connected character.
 	})
 
 	mustRegister(command.CommandEntryConfig{
+		Name:         "p",
+		Handler:      PageHandler,
+		Capabilities: []string{"comms.page"},
+		Help:         "Send a private message (alias for page)",
+		Usage:        "p <name>=<message>",
+		Source:       "core",
+	})
+
+	mustRegister(command.CommandEntryConfig{
 		Name:    "say",
 		Handler: SayHandler,
 		Help:    "Say something to the room",
@@ -276,6 +285,14 @@ Set the description of yourself, your current location, or a named object.
 - ` + "`describe here A dusty chamber lit by a single torch.`" + `
 - ` + "`describe #01ABCDEF=A gleaming blade.`" + ``,
 		Source: "core",
+	})
+
+	mustRegister(command.CommandEntryConfig{
+		Name:    "desc",
+		Handler: DescribeHandler,
+		Help:    "Set a description (alias for describe)",
+		Usage:   "desc me <text>",
+		Source:  "core",
 	})
 
 	// Object commands

--- a/internal/command/handlers/register.go
+++ b/internal/command/handlers/register.go
@@ -23,6 +23,31 @@ func RegisterAll(reg *command.Registry) {
 
 	// Communication commands
 	mustRegister(command.CommandEntryConfig{
+		Name:         "page",
+		Handler:      PageHandler,
+		Capabilities: []string{"comms.page"},
+		Help:         "Send a private message",
+		Usage:        "page <name>=<message>",
+		HelpText: `## Page
+
+Send an OOC private message to another connected character.
+
+### Usage
+
+- ` + "`page <name>=<message>`" + ` - Send a private message
+- ` + "`page <message>`" + ` - Page your last-paged character
+- ` + "`page <name>=:<action>`" + ` - Pose-page (shows "From afar, ...")
+- ` + "`page <name>=;<action>`" + ` - No-space pose-page
+
+### Examples
+
+- ` + "`page Alex=Hey, are you around?`" + `
+- ` + "`page How's it going?`" + ` - Pages last-paged character
+- ` + "`page Alex=:waves hello.`" + ` - Pose-page`,
+		Source: "core",
+	})
+
+	mustRegister(command.CommandEntryConfig{
 		Name:    "say",
 		Handler: SayHandler,
 		Help:    "Say something to the room",
@@ -226,6 +251,30 @@ Send a broadcast message to all connected players.
 ### Permissions
 
 Requires the ` + "`admin.wall`" + ` capability.`,
+		Source: "core",
+	})
+
+	// Description commands
+	mustRegister(command.CommandEntryConfig{
+		Name:    "describe",
+		Handler: DescribeHandler,
+		Help:    "Set a description",
+		Usage:   "describe me <text>",
+		HelpText: `## Describe
+
+Set the description of yourself, your current location, or a named object.
+
+### Usage
+
+- ` + "`describe me <text>`" + ` - Set your character's description
+- ` + "`describe here <text>`" + ` - Set the current location's description
+- ` + "`describe <target>=<text>`" + ` - Set a named target's description
+
+### Examples
+
+- ` + "`describe me A tall figure in a dark cloak.`" + `
+- ` + "`describe here A dusty chamber lit by a single torch.`" + `
+- ` + "`describe #01ABCDEF=A gleaming blade.`" + ``,
 		Source: "core",
 	})
 

--- a/internal/command/handlers/testutil/mock_session.go
+++ b/internal/command/handlers/testutil/mock_session.go
@@ -5,19 +5,20 @@ package testutil
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/session"
 )
 
 // MockSessionAccess implements session.Access for handler tests.
 type MockSessionAccess struct {
-	mu       sync.Mutex
-	sessions []*session.Info
+	mu                      sync.Mutex
+	sessions                []*session.Info
+	findByCharacterNameFunc func(ctx context.Context, name string) (*session.Info, error)
 }
 
 // NewMockSessionAccess creates a MockSessionAccess with the given sessions.
@@ -68,9 +69,32 @@ func (m *MockSessionAccess) UpdateActivity(_ context.Context, _ string) error {
 	return nil
 }
 
-// FindByCharacterName is a stub that always returns SESSION_NOT_FOUND.
-func (m *MockSessionAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
-	return nil, oops.Code("SESSION_NOT_FOUND").Errorf("session not found")
+// FindByCharacterName returns the session for a character by name (case-insensitive).
+// If a custom func is set via WithFindByCharacterName, it delegates to that.
+// Otherwise it searches the in-memory sessions slice (case-insensitive).
+// Returns nil, nil if not found.
+func (m *MockSessionAccess) FindByCharacterName(ctx context.Context, name string) (*session.Info, error) {
+	m.mu.Lock()
+	fn := m.findByCharacterNameFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, name)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.sessions {
+		if strings.EqualFold(s.CharacterName, name) {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+// WithFindByCharacterName sets a custom func for FindByCharacterName.
+func (m *MockSessionAccess) WithFindByCharacterName(fn func(ctx context.Context, name string) (*session.Info, error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.findByCharacterNameFunc = fn
 }
 
 // UpdateLastPaged is a no-op for the mock.

--- a/internal/command/handlers/testutil/mock_session.go
+++ b/internal/command/handlers/testutil/mock_session.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/session"
 )
@@ -64,6 +65,21 @@ func (m *MockSessionAccess) DeleteByCharacter(_ context.Context, charID ulid.ULI
 
 // UpdateActivity is a no-op for the mock.
 func (m *MockSessionAccess) UpdateActivity(_ context.Context, _ string) error {
+	return nil
+}
+
+// FindByCharacterName is a stub that always returns SESSION_NOT_FOUND.
+func (m *MockSessionAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, oops.Code("SESSION_NOT_FOUND").Errorf("session not found")
+}
+
+// UpdateLastPaged is a no-op for the mock.
+func (m *MockSessionAccess) UpdateLastPaged(_ context.Context, _, _ string) error {
+	return nil
+}
+
+// UpdateLastWhispered is a no-op for the mock.
+func (m *MockSessionAccess) UpdateLastWhispered(_ context.Context, _, _ string) error {
 	return nil
 }
 

--- a/internal/command/handlers/testutil/services.go
+++ b/internal/command/handlers/testutil/services.go
@@ -36,6 +36,18 @@ func (d *defaultAccess) UpdateActivity(_ context.Context, _ string) error {
 	return nil
 }
 
+func (d *defaultAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, nil
+}
+
+func (d *defaultAccess) UpdateLastPaged(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (d *defaultAccess) UpdateLastWhispered(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // ServicesBuilder builds command.Services with reasonable defaults for tests.
 type ServicesBuilder struct {
 	config command.ServicesConfig

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -54,6 +54,9 @@ type WorldService interface {
 
 	// UpdateObject updates an existing object after checking write authorization.
 	UpdateObject(ctx context.Context, subjectID string, obj *world.Object) error
+
+	// UpdateCharacterDescription sets a character's description after checking authorization.
+	UpdateCharacterDescription(ctx context.Context, subjectID string, characterID ulid.ULID, description string) error
 }
 
 // AliasWriter defines write-only persistence operations for alias management.

--- a/internal/command/types_test.go
+++ b/internal/command/types_test.go
@@ -165,6 +165,18 @@ func (m *mockAccess) UpdateActivity(_ context.Context, _ string) error {
 	return nil
 }
 
+func (m *mockAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, nil
+}
+
+func (m *mockAccess) UpdateLastPaged(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (m *mockAccess) UpdateLastWhispered(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 type mockEngine struct{}
 
 func (m *mockEngine) Evaluate(_ context.Context, _ types.AccessRequest) (types.Decision, error) {

--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -29,6 +29,10 @@ const (
 	EventTypeObjectExamine EventType = "object_examine"
 	EventTypeObjectGive    EventType = "object_give"
 
+	// Private communication event types
+	EventTypePage    EventType = "page"
+	EventTypeWhisper EventType = "whisper"
+
 	// Command response event type
 	EventTypeCommandResponse EventType = "command_response"
 
@@ -69,6 +73,30 @@ type LocationStateChar struct {
 // delta update to the exits in the current location.
 type ExitUpdatePayload struct {
 	Exits []LocationStateExit `json:"exits"`
+}
+
+// PagePayload is the JSON payload for page events (private messages between characters).
+type PagePayload struct {
+	SenderID   string `json:"sender_id"`
+	SenderName string `json:"sender_name"`
+	Message    string `json:"message"`
+	IsPose     bool   `json:"is_pose"`
+}
+
+// WhisperPayload is the JSON payload for whisper events (location-scoped private messages).
+type WhisperPayload struct {
+	SenderID   string `json:"sender_id"`
+	SenderName string `json:"sender_name"`
+	Message    string `json:"message"`
+	IsPose     bool   `json:"is_pose"`
+}
+
+// WhisperNoticePayload is the JSON payload for whisper notice events, informing
+// bystanders that a whisper occurred without revealing its content.
+type WhisperNoticePayload struct {
+	SenderName string `json:"sender_name"`
+	TargetName string `json:"target_name"`
+	Notice     string `json:"notice"`
 }
 
 // ActorKind identifies what type of entity caused an event.

--- a/internal/core/event_test.go
+++ b/internal/core/event_test.go
@@ -67,6 +67,8 @@ func TestDocumentedEventTypes(t *testing.T) {
 		string(EventTypeObjectGive):    true,
 		string(EventTypeLocationState): true,
 		string(EventTypeExitUpdate):    true,
+		string(EventTypePage):          true,
+		string(EventTypeWhisper):       true,
 	}
 
 	for _, docType := range documentedTypes {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -189,6 +189,10 @@ func NewCoreServer(engine *core.Engine, sessionStore session.Store, opts ...Core
 		opt(s)
 	}
 
+	if s.dispatcher == nil || s.cmdServices == nil {
+		panic("grpc.NewCoreServer: WithDispatcher is required")
+	}
+
 	return s
 }
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -169,19 +169,13 @@ func WithDisconnectHook(hook func(session.Info)) CoreServerOption {
 	}
 }
 
-// WithDispatcher sets the unified command dispatcher for command execution.
-func WithDispatcher(d *command.Dispatcher, svc *command.Services) CoreServerOption {
-	return func(s *CoreServer) {
-		s.dispatcher = d
-		s.cmdServices = svc
-	}
-}
-
 // NewCoreServer creates a new Core gRPC server.
-func NewCoreServer(engine *core.Engine, sessionStore session.Store, opts ...CoreServerOption) *CoreServer {
+func NewCoreServer(engine *core.Engine, sessionStore session.Store, dispatcher *command.Dispatcher, cmdServices *command.Services, opts ...CoreServerOption) *CoreServer {
 	s := &CoreServer{
 		engine:       engine,
 		sessionStore: sessionStore,
+		dispatcher:   dispatcher,
+		cmdServices:  cmdServices,
 		newSessionID: core.NewULID,
 	}
 
@@ -189,8 +183,8 @@ func NewCoreServer(engine *core.Engine, sessionStore session.Store, opts ...Core
 		opt(s)
 	}
 
-	if s.dispatcher == nil || s.cmdServices == nil {
-		panic("grpc.NewCoreServer: WithDispatcher is required")
+	if dispatcher == nil || cmdServices == nil {
+		panic("grpc.NewCoreServer: dispatcher and cmdServices must not be nil")
 	}
 
 	return s

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -399,12 +399,7 @@ func TestCoreServer_Disconnect(t *testing.T) {
 
 func TestNewCoreServer(t *testing.T) {
 	store := &mockEventStore{}
-	sessStore := session.NewMemStore()
-
-	server := NewCoreServer(
-		core.NewEngine(store),
-		sessStore,
-	)
+	server := newHandleCommandServer(t, store, nil)
 
 	require.NotNil(t, server, "NewCoreServer returned nil")
 	assert.NotNil(t, server.sessionStore, "sessionStore should be initialized")
@@ -416,9 +411,7 @@ func TestNewCoreServer_WithOptions(t *testing.T) {
 	customAuth := &mockAuthenticator{}
 	customStore := session.NewMemStore()
 
-	server := NewCoreServer(
-		core.NewEngine(store),
-		session.NewMemStore(),
+	server := newHandleCommandServer(t, store, nil,
 		WithAuthenticator(customAuth),
 		WithSessionStore(customStore),
 	)
@@ -426,6 +419,16 @@ func TestNewCoreServer_WithOptions(t *testing.T) {
 	require.NotNil(t, server, "NewCoreServer returned nil")
 	assert.Equal(t, customAuth, server.authenticator, "WithAuthenticator option not applied")
 	assert.Equal(t, customStore, server.sessionStore, "WithSessionStore option not applied")
+}
+
+func TestCoreServer_HandleCommand_NoDispatcher(t *testing.T) {
+	server := &CoreServer{
+		engine:       core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore: session.NewMemStore(),
+	}
+	err := server.executeCommand(context.Background(), &session.Info{}, "say hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command dispatcher not configured")
 }
 
 func TestCoreServer_Authenticate_NoAuthenticator(t *testing.T) {
@@ -2176,12 +2179,11 @@ func TestCoreServer_DisconnectHook(t *testing.T) {
 	sessionID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
 	var hookCalled bool
 	var hookInfo session.Info
 	sessStore := session.NewMemStore()
-	server := NewCoreServer(engine, sessStore,
+	server := newHandleCommandServer(t, store, sessStore,
 		WithDisconnectHook(func(info session.Info) {
 			hookCalled = true
 			hookInfo = info
@@ -2269,10 +2271,9 @@ func TestCoreServer_Disconnect_NonGuest_NoEndSession(t *testing.T) {
 	sessionID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
 	sessStore := session.NewMemStore()
-	server := NewCoreServer(engine, sessStore)
+	server := newHandleCommandServer(t, store, sessStore)
 	ctx := context.Background()
 	require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
 		CharacterID:   charID,
@@ -2422,7 +2423,6 @@ func TestCoreServer_Authenticate_EmitsArriveEvent(t *testing.T) {
 	sessionID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
 	auth := &mockAuthenticator{
 		authenticateFunc: func(_ context.Context, _, _ string) (*AuthResult, error) {
@@ -2434,7 +2434,7 @@ func TestCoreServer_Authenticate_EmitsArriveEvent(t *testing.T) {
 		},
 	}
 
-	server := NewCoreServer(engine, session.NewMemStore(),
+	server := newHandleCommandServer(t, store, nil,
 		WithAuthenticator(auth),
 	)
 	server.newSessionID = func() ulid.ULID { return sessionID }
@@ -2463,9 +2463,8 @@ func TestCoreServer_Disconnect_EmitsLeaveEvent(t *testing.T) {
 		sessionID := core.NewULID()
 
 		store := core.NewMemoryEventStore()
-		engine := core.NewEngine(store)
 
-		server := NewCoreServer(engine, session.NewMemStore())
+		server := newHandleCommandServer(t, store, nil)
 		ctx := context.Background()
 		require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
 			CharacterID:   charID,
@@ -2496,9 +2495,8 @@ func TestCoreServer_Disconnect_EmitsLeaveEvent(t *testing.T) {
 		sessionID := core.NewULID()
 
 		store := core.NewMemoryEventStore()
-		engine := core.NewEngine(store)
 
-		server := NewCoreServer(engine, session.NewMemStore())
+		server := newHandleCommandServer(t, store, nil)
 		ctx := context.Background()
 		require.NoError(t, server.sessionStore.Set(ctx, sessionID.String(), &session.Info{
 			CharacterID:   charID,
@@ -3128,7 +3126,6 @@ func TestCoreServer_Authenticate_RegistersConnection(t *testing.T) {
 	sessionID := core.NewULID()
 
 	store := core.NewMemoryEventStore()
-	engine := core.NewEngine(store)
 
 	auth := &mockAuthenticator{
 		authenticateFunc: func(_ context.Context, _, _ string) (*AuthResult, error) {
@@ -3141,7 +3138,7 @@ func TestCoreServer_Authenticate_RegistersConnection(t *testing.T) {
 	}
 
 	sessStore := session.NewMemStore()
-	server := NewCoreServer(engine, sessStore,
+	server := newHandleCommandServer(t, store, sessStore,
 		WithAuthenticator(auth),
 	)
 	server.newSessionID = func() ulid.ULID { return sessionID }
@@ -3194,10 +3191,9 @@ func TestCoreServer_Disconnect_GridPresencePhaseOut(t *testing.T) {
 		sessionID := core.NewULID()
 
 		eventStore := core.NewMemoryEventStore()
-		engine := core.NewEngine(eventStore)
 
 		sessStore := session.NewMemStore()
-		server := NewCoreServer(engine, sessStore)
+		server := newHandleCommandServer(t, eventStore, sessStore)
 		ctx := context.Background()
 
 		// Create session
@@ -3250,10 +3246,9 @@ func TestCoreServer_Disconnect_GridPresencePhaseOut(t *testing.T) {
 		sessionID := core.NewULID()
 
 		eventStore := core.NewMemoryEventStore()
-		engine := core.NewEngine(eventStore)
 
 		sessStore := session.NewMemStore()
-		server := NewCoreServer(engine, sessStore)
+		server := newHandleCommandServer(t, eventStore, sessStore)
 		ctx := context.Background()
 
 		require.NoError(t, sessStore.Set(ctx, sessionID.String(), &session.Info{
@@ -3301,10 +3296,9 @@ func TestCoreServer_Disconnect_GridPresencePhaseOut(t *testing.T) {
 		sessionID := core.NewULID()
 
 		eventStore := core.NewMemoryEventStore()
-		engine := core.NewEngine(eventStore)
 
 		sessStore := session.NewMemStore()
-		server := NewCoreServer(engine, sessStore)
+		server := newHandleCommandServer(t, eventStore, sessStore)
 		ctx := context.Background()
 
 		require.NoError(t, sessStore.Set(ctx, sessionID.String(), &session.Info{

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -421,14 +421,10 @@ func TestNewCoreServer_WithOptions(t *testing.T) {
 	assert.Equal(t, customStore, server.sessionStore, "WithSessionStore option not applied")
 }
 
-func TestCoreServer_HandleCommand_NoDispatcher(t *testing.T) {
-	server := &CoreServer{
-		engine:       core.NewEngine(core.NewMemoryEventStore()),
-		sessionStore: session.NewMemStore(),
-	}
-	err := server.executeCommand(context.Background(), &session.Info{}, "say hello")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "command dispatcher not configured")
+func TestNewCoreServer_PanicsWithoutDispatcher(t *testing.T) {
+	assert.Panics(t, func() {
+		NewCoreServer(core.NewEngine(&mockEventStore{}), session.NewMemStore())
+	}, "NewCoreServer should panic without WithDispatcher")
 }
 
 func TestCoreServer_Authenticate_NoAuthenticator(t *testing.T) {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -69,14 +69,11 @@ func newHandleCommandServer(t *testing.T, store core.EventStore, sessStore sessi
 	dispatcher, err := command.NewDispatcher(reg, policyEngine)
 	require.NoError(t, err)
 
-	allOpts := make([]CoreServerOption, 0, 2+len(opts))
-	allOpts = append(allOpts,
-		WithEventStore(store),
-		WithDispatcher(dispatcher, svc),
-	)
+	allOpts := make([]CoreServerOption, 0, 1+len(opts))
+	allOpts = append(allOpts, WithEventStore(store))
 	allOpts = append(allOpts, opts...)
 
-	return NewCoreServer(engine, sessStore, allOpts...)
+	return NewCoreServer(engine, sessStore, dispatcher, svc, allOpts...)
 }
 
 // mockEventStore implements core.EventStore for testing.
@@ -423,8 +420,8 @@ func TestNewCoreServer_WithOptions(t *testing.T) {
 
 func TestNewCoreServer_PanicsWithoutDispatcher(t *testing.T) {
 	assert.Panics(t, func() {
-		NewCoreServer(core.NewEngine(&mockEventStore{}), session.NewMemStore())
-	}, "NewCoreServer should panic without WithDispatcher")
+		NewCoreServer(core.NewEngine(&mockEventStore{}), session.NewMemStore(), nil, nil)
+	}, "NewCoreServer should panic without dispatcher")
 }
 
 func TestCoreServer_Authenticate_NoAuthenticator(t *testing.T) {

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -22,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/property"
+	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
 )
 
@@ -44,6 +45,7 @@ type Functions struct {
 	commandRegistry  CommandRegistry
 	engine           types.AccessPolicyEngine
 	propertyRegistry *property.Registry
+	sessionAccess    session.Access
 }
 
 // Option configures Functions.
@@ -62,6 +64,14 @@ func WithWorldService(svc WorldMutator) Option {
 func WithPropertyRegistry(registry *property.Registry) Option {
 	return func(f *Functions) {
 		f.propertyRegistry = registry
+	}
+}
+
+// WithSessionAccess sets the session access dependency for holo.session.* host functions.
+// When set, plugins can call holo.session.find_by_name and holo.session.set_last_whispered.
+func WithSessionAccess(sa session.Access) Option {
+	return func(f *Functions) {
+		f.sessionAccess = sa
 	}
 }
 
@@ -104,6 +114,14 @@ func New(kv KVStore, opts ...Option) *Functions {
 func (f *Functions) Register(ls *lua.LState, pluginName string) {
 	// Register the holo.* stdlib (fmt, emit namespaces)
 	RegisterStdlib(ls)
+
+	// Register holo.session namespace if session access is configured.
+	if f.sessionAccess != nil {
+		holoTable, ok := ls.GetGlobal("holo").(*lua.LTable)
+		if ok {
+			RegisterSessionFuncs(ls, holoTable, f.sessionAccess)
+		}
+	}
 
 	mod := ls.NewTable()
 

--- a/internal/plugin/hostfunc/stdlib_session.go
+++ b/internal/plugin/hostfunc/stdlib_session.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"context"
+	"log/slog"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// sessionAccessRegistryKey is used to store the session.Access in Lua's registry.
+const sessionAccessRegistryKey = "__holo_session_access"
+
+// RegisterSessionFuncs adds the holo.session.* namespace to an existing holoTable.
+// It stores the session.Access in the Lua state registry so individual host
+// functions can retrieve it without needing a Go closure over the interface.
+func RegisterSessionFuncs(ls *lua.LState, holoTable *lua.LTable, sa session.Access) {
+	// Store session.Access in the Lua state registry.
+	ud := ls.NewUserData()
+	ud.Value = sa
+	ls.SetGlobal(sessionAccessRegistryKey, ud)
+
+	sessionMod := ls.NewTable()
+	ls.SetField(sessionMod, "find_by_name", ls.NewFunction(sessionFindByName))
+	ls.SetField(sessionMod, "set_last_whispered", ls.NewFunction(sessionSetLastWhispered))
+	ls.SetField(holoTable, "session", sessionMod)
+}
+
+// getSessionAccess retrieves the session.Access from the Lua state registry.
+// Returns nil if not found, which indicates RegisterSessionFuncs was not called.
+func getSessionAccess(ls *lua.LState) session.Access {
+	ud := ls.GetGlobal(sessionAccessRegistryKey)
+	if ud.Type() == lua.LTUserData {
+		userData, ok := ud.(*lua.LUserData)
+		if ok {
+			if sa, saOK := userData.Value.(session.Access); saOK {
+				return sa
+			}
+		}
+	}
+	slog.Error("session access not found in Lua state registry",
+		"registry_key", sessionAccessRegistryKey,
+		"hint", "RegisterSessionFuncs must be called before holo.session functions")
+	return nil
+}
+
+// sessionFindByName implements holo.session.find_by_name(name).
+// Returns a table {character_id, character_name, location_id} or nil if not found.
+//
+// Lua signature: result = holo.session.find_by_name(name)
+func sessionFindByName(ls *lua.LState) int {
+	name := ls.CheckString(1)
+
+	sa := getSessionAccess(ls)
+	if sa == nil {
+		ls.RaiseError("holo.session: session access not initialized (RegisterSessionFuncs not called)")
+		return 0
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	info, err := sa.FindByCharacterName(ctx, name)
+	if err != nil || info == nil {
+		ls.Push(lua.LNil)
+		return 1
+	}
+
+	t := ls.NewTable()
+	ls.SetField(t, "character_id", lua.LString(info.CharacterID.String()))
+	ls.SetField(t, "character_name", lua.LString(info.CharacterName))
+	ls.SetField(t, "location_id", lua.LString(info.LocationID.String()))
+	ls.Push(t)
+	return 1
+}
+
+// sessionSetLastWhispered implements holo.session.set_last_whispered(session_id, name).
+// Updates the caller's session to record the last character whispered to.
+//
+// Lua signature: holo.session.set_last_whispered(session_id, name)
+func sessionSetLastWhispered(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	name := ls.CheckString(2)
+
+	sa := getSessionAccess(ls)
+	if sa == nil {
+		ls.RaiseError("holo.session: session access not initialized (RegisterSessionFuncs not called)")
+		return 0
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := sa.UpdateLastWhispered(ctx, sessionID, name); err != nil {
+		slog.WarnContext(ctx, "holo.session.set_last_whispered: update failed",
+			"session_id", sessionID,
+			"name", name,
+			"error", err)
+	}
+
+	return 0
+}

--- a/internal/plugin/hostfunc/stdlib_session.go
+++ b/internal/plugin/hostfunc/stdlib_session.go
@@ -67,7 +67,12 @@ func sessionFindByName(ls *lua.LState) int {
 	}
 
 	info, err := sa.FindByCharacterName(ctx, name)
-	if err != nil || info == nil {
+	if err != nil {
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	if info == nil {
 		ls.Push(lua.LNil)
 		return 1
 	}

--- a/internal/plugin/hostfunc/stdlib_session_test.go
+++ b/internal/plugin/hostfunc/stdlib_session_test.go
@@ -208,12 +208,16 @@ func TestSessionFindByName_StoreError(t *testing.T) {
 	L := newLuaStateWithSession(t, errSA)
 	defer L.Close()
 
-	// Should return nil on error (no panic), not raise an error.
-	err := L.DoString(`result = holo.session.find_by_name("Alex")`)
+	// Should return nil + error string on error (no panic).
+	err := L.DoString(`result, find_err = holo.session.find_by_name("Alex")`)
 	require.NoError(t, err)
 
 	result := L.GetGlobal("result")
 	assert.Equal(t, lua.LTNil, result.Type(), "find_by_name should return nil on store error")
+
+	findErr := L.GetGlobal("find_err")
+	require.Equal(t, lua.LTString, findErr.Type(), "find_by_name should return error string as second value")
+	assert.Contains(t, findErr.String(), "db unavailable")
 }
 
 // =============================================================================

--- a/internal/plugin/hostfunc/stdlib_session_test.go
+++ b/internal/plugin/hostfunc/stdlib_session_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/session"
+)
+
+// mockSessionAccess is a minimal session.Access implementation for hostfunc tests.
+type mockSessionAccess struct {
+	mu                    sync.Mutex
+	sessions              []*session.Info
+	updateLastWhisperedFn func(ctx context.Context, sessionID, name string) error
+	lastWhisperedCalls    []whisperCall
+}
+
+type whisperCall struct {
+	SessionID string
+	Name      string
+}
+
+func newMockSessionAccess(infos ...*session.Info) *mockSessionAccess {
+	return &mockSessionAccess{sessions: infos}
+}
+
+func (m *mockSessionAccess) ListActive(_ context.Context) ([]*session.Info, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*session.Info
+	for _, s := range m.sessions {
+		if s.Status == session.StatusActive {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSessionAccess) FindByCharacter(_ context.Context, charID ulid.ULID) (*session.Info, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.sessions {
+		if s.CharacterID == charID {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockSessionAccess) FindByCharacterName(_ context.Context, name string) (*session.Info, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.sessions {
+		if strings.EqualFold(s.CharacterName, name) {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockSessionAccess) DeleteByCharacter(_ context.Context, charID ulid.ULID, _ string) (*session.Info, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, s := range m.sessions {
+		if s.CharacterID == charID {
+			m.sessions = append(m.sessions[:i], m.sessions[i+1:]...)
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockSessionAccess) UpdateActivity(_ context.Context, _ string) error { return nil }
+
+func (m *mockSessionAccess) UpdateLastPaged(_ context.Context, _, _ string) error { return nil }
+
+func (m *mockSessionAccess) UpdateLastWhispered(ctx context.Context, sessionID, name string) error {
+	m.mu.Lock()
+	m.lastWhisperedCalls = append(m.lastWhisperedCalls, whisperCall{SessionID: sessionID, Name: name})
+	fn := m.updateLastWhisperedFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, sessionID, name)
+	}
+	return nil
+}
+
+func (m *mockSessionAccess) whisperCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.lastWhisperedCalls)
+}
+
+func (m *mockSessionAccess) lastWhisperCall() (whisperCall, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.lastWhisperedCalls) == 0 {
+		return whisperCall{}, false
+	}
+	return m.lastWhisperedCalls[len(m.lastWhisperedCalls)-1], true
+}
+
+// newLuaStateWithSession creates a Lua state with stdlib registered and holo.session configured.
+func newLuaStateWithSession(t *testing.T, sa session.Access) *lua.LState {
+	t.Helper()
+	L := lua.NewState()
+	hostfunc.RegisterStdlib(L)
+	holoTable, ok := L.GetGlobal("holo").(*lua.LTable)
+	require.True(t, ok, "holo table must be set after RegisterStdlib")
+	hostfunc.RegisterSessionFuncs(L, holoTable, sa)
+	return L
+}
+
+// makeSessionInfo builds a minimal session.Info for test scenarios.
+func makeSessionInfo(charID, charName, locID string) *session.Info {
+	cid := ulid.MustParse(charID)
+	lid := ulid.MustParse(locID)
+	return &session.Info{
+		ID:            ulid.Make().String(),
+		CharacterID:   cid,
+		CharacterName: charName,
+		LocationID:    lid,
+		Status:        session.StatusActive,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+}
+
+// Valid Crockford base32 ULIDs for use in tests.
+// ULID alphabet: 0123456789ABCDEFGHJKMNPQRSTVWXYZ (no I, L, O, U)
+const (
+	testCharID1 = "01BX5ZZKBKACTAV9WEVGEMMVRY" // valid ULID
+	testCharID2 = "01BX5ZZKBKACTAV9WEVGEMMVRZ" // valid ULID
+	testLocID1  = "01BX5ZZKBKACTAV9WEVGEMMVS0" // valid ULID
+	testSessID1 = "01BX5ZZKBKACTAV9WEVGEMMVS1" // valid ULID
+)
+
+// =============================================================================
+// holo.session.find_by_name()
+// =============================================================================
+
+func TestSessionFindByName_Found(t *testing.T) {
+	info := makeSessionInfo(testCharID1, "Alice", testLocID1)
+	sa := newMockSessionAccess(info)
+	L := newLuaStateWithSession(t, sa)
+	defer L.Close()
+
+	err := L.DoString(`result = holo.session.find_by_name("Alice")`)
+	require.NoError(t, err)
+
+	result := L.GetGlobal("result")
+	require.Equal(t, lua.LTTable, result.Type(), "find_by_name should return a table for existing session")
+
+	tbl := result.(*lua.LTable)
+	assert.Equal(t, testCharID1, tbl.RawGetString("character_id").String())
+	assert.Equal(t, "Alice", tbl.RawGetString("character_name").String())
+	assert.Equal(t, testLocID1, tbl.RawGetString("location_id").String())
+}
+
+func TestSessionFindByName_CaseInsensitive(t *testing.T) {
+	info := makeSessionInfo(testCharID2, "Bob", testLocID1)
+	sa := newMockSessionAccess(info)
+	L := newLuaStateWithSession(t, sa)
+	defer L.Close()
+
+	err := L.DoString(`result = holo.session.find_by_name("bob")`)
+	require.NoError(t, err)
+
+	result := L.GetGlobal("result")
+	require.Equal(t, lua.LTTable, result.Type(), "case-insensitive lookup should find session")
+
+	tbl := result.(*lua.LTable)
+	assert.Equal(t, "Bob", tbl.RawGetString("character_name").String())
+}
+
+
+func TestSessionFindByName_NotFound(t *testing.T) {
+	sa := newMockSessionAccess()
+	L := newLuaStateWithSession(t, sa)
+	defer L.Close()
+
+	err := L.DoString(`result = holo.session.find_by_name("Nonexistent")`)
+	require.NoError(t, err)
+
+	result := L.GetGlobal("result")
+	assert.Equal(t, lua.LTNil, result.Type(), "find_by_name should return nil for missing session")
+}
+
+func TestSessionFindByName_StoreError(t *testing.T) {
+	sa := newMockSessionAccess()
+	sa.updateLastWhisperedFn = nil // doesn't apply here, test find returning error
+	// Override FindByCharacterName to return an error via a session that panics — instead, build a
+	// custom access that returns an error for find.
+	errSA := &errorSessionAccess{findErr: errors.New("db unavailable")}
+	L := newLuaStateWithSession(t, errSA)
+	defer L.Close()
+
+	// Should return nil on error (no panic), not raise an error.
+	err := L.DoString(`result = holo.session.find_by_name("Alex")`)
+	require.NoError(t, err)
+
+	result := L.GetGlobal("result")
+	assert.Equal(t, lua.LTNil, result.Type(), "find_by_name should return nil on store error")
+}
+
+// =============================================================================
+// holo.session.set_last_whispered()
+// =============================================================================
+
+func TestSessionSetLastWhispered_CallsUpdate(t *testing.T) {
+	sa := newMockSessionAccess()
+	L := newLuaStateWithSession(t, sa)
+	defer L.Close()
+
+	err := L.DoString(`holo.session.set_last_whispered("` + testSessID1 + `", "Alice")`)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sa.whisperCallCount(), "UpdateLastWhispered should be called once")
+	call, ok := sa.lastWhisperCall()
+	require.True(t, ok)
+	assert.Equal(t, testSessID1, call.SessionID)
+	assert.Equal(t, "Alice", call.Name)
+}
+
+func TestSessionSetLastWhispered_StoreError_NoLuaError(t *testing.T) {
+	// Even if UpdateLastWhispered returns an error, the Lua call should not raise an error.
+	sa := newMockSessionAccess()
+	sa.updateLastWhisperedFn = func(_ context.Context, _, _ string) error {
+		return errors.New("db write failed")
+	}
+	L := newLuaStateWithSession(t, sa)
+	defer L.Close()
+
+	// Should complete without error — errors are logged, not propagated.
+	err := L.DoString(`holo.session.set_last_whispered("` + testSessID1 + `", "Alice")`)
+	require.NoError(t, err, "set_last_whispered should not raise a Lua error on store failure")
+}
+
+// =============================================================================
+// errorSessionAccess — test helper for error path coverage
+// =============================================================================
+
+type errorSessionAccess struct {
+	findErr error
+}
+
+func (e *errorSessionAccess) ListActive(_ context.Context) ([]*session.Info, error) {
+	return nil, nil
+}
+
+func (e *errorSessionAccess) FindByCharacter(_ context.Context, _ ulid.ULID) (*session.Info, error) {
+	return nil, e.findErr
+}
+
+func (e *errorSessionAccess) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, e.findErr
+}
+
+func (e *errorSessionAccess) DeleteByCharacter(_ context.Context, _ ulid.ULID, _ string) (*session.Info, error) {
+	return nil, nil
+}
+
+func (e *errorSessionAccess) UpdateActivity(_ context.Context, _ string) error  { return nil }
+func (e *errorSessionAccess) UpdateLastPaged(_ context.Context, _, _ string) error { return nil }
+func (e *errorSessionAccess) UpdateLastWhispered(_ context.Context, _, _ string) error {
+	return nil
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -251,6 +251,8 @@ func (h *Host) buildContextTable(state *lua.LState, ctx holo.CommandContext) *lu
 	state.SetField(t, "character_id", lua.LString(ctx.CharacterID))
 	state.SetField(t, "location_id", lua.LString(ctx.LocationID))
 	state.SetField(t, "player_id", lua.LString(ctx.PlayerID))
+	state.SetField(t, "session_id", lua.LString(ctx.SessionID))
+	state.SetField(t, "last_whispered", lua.LString(ctx.LastWhispered))
 	return t
 }
 

--- a/internal/session/memstore.go
+++ b/internal/session/memstore.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -373,6 +374,54 @@ func (m *MemStore) UpdateActivity(_ context.Context, id string) error {
 			With("session_id", id).
 			Errorf("session not found")
 	}
+	info.UpdatedAt = time.Now()
+	return nil
+}
+
+// FindByCharacterName returns the active session for a character by name.
+// The lookup is case-insensitive.
+func (m *MemStore) FindByCharacterName(_ context.Context, name string) (*Info, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, info := range m.sessions {
+		if info.Status == StatusActive && strings.EqualFold(info.CharacterName, name) {
+			return copyInfo(info), nil
+		}
+	}
+	return nil, oops.Code("SESSION_NOT_FOUND").
+		With("character_name", name).
+		Errorf("no active session for character name")
+}
+
+// UpdateLastPaged records the name of the character most recently paged.
+func (m *MemStore) UpdateLastPaged(_ context.Context, id, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info, ok := m.sessions[id]
+	if !ok {
+		return oops.Code("SESSION_NOT_FOUND").
+			With("session_id", id).
+			Errorf("session not found")
+	}
+	info.LastPaged = name
+	info.UpdatedAt = time.Now()
+	return nil
+}
+
+// UpdateLastWhispered records the name of the character most recently whispered to.
+func (m *MemStore) UpdateLastWhispered(_ context.Context, id, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info, ok := m.sessions[id]
+	if !ok {
+		return oops.Code("SESSION_NOT_FOUND").
+			With("session_id", id).
+			Errorf("session not found")
+	}
+	info.LastWhispered = name
 	info.UpdatedAt = time.Now()
 	return nil
 }

--- a/internal/session/memstore_test.go
+++ b/internal/session/memstore_test.go
@@ -298,3 +298,112 @@ func TestMemStore_ConcurrentAccess(t *testing.T) {
 	// No assertion needed — the test passes if the race detector finds no issues.
 	assert.True(t, true)
 }
+
+func TestMemStore_FindByCharacterName(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		lookup    string
+		wantName  string
+		wantFound bool
+	}{
+		{
+			name:      "exact match succeeds",
+			lookup:    "Artanis",
+			wantName:  "Artanis",
+			wantFound: true,
+		},
+		{
+			name:      "case-insensitive match succeeds",
+			lookup:    "artanis",
+			wantName:  "Artanis",
+			wantFound: true,
+		},
+		{
+			name:      "upper-case lookup succeeds",
+			lookup:    "ARTANIS",
+			wantName:  "Artanis",
+			wantFound: true,
+		},
+		{
+			name:      "no match returns SESSION_NOT_FOUND",
+			lookup:    "Zeratul",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMemStore()
+			charID := ulid.Make()
+			err := store.Set(ctx, "session-1", &Info{
+				ID:            "session-1",
+				CharacterID:   charID,
+				CharacterName: "Artanis",
+				Status:        StatusActive,
+			})
+			require.NoError(t, err)
+
+			got, err := store.FindByCharacterName(ctx, tt.lookup)
+			if tt.wantFound {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantName, got.CharacterName)
+			} else {
+				require.Error(t, err)
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestMemStore_FindByCharacterName_OnlyActiveSession(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+
+	err := store.Set(ctx, "session-detached", &Info{
+		ID:            "session-detached",
+		CharacterID:   ulid.Make(),
+		CharacterName: "Zeratul",
+		Status:        StatusDetached,
+	})
+	require.NoError(t, err)
+
+	got, err := store.FindByCharacterName(ctx, "Zeratul")
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestMemStore_UpdateLastPaged(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+
+	err := store.Set(ctx, "session-1", &Info{
+		ID:     "session-1",
+		Status: StatusActive,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateLastPaged(ctx, "session-1", "Zeratul"))
+
+	got, err := store.Get(ctx, "session-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Zeratul", got.LastPaged)
+}
+
+func TestMemStore_UpdateLastWhispered(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+
+	err := store.Set(ctx, "session-1", &Info{
+		ID:     "session-1",
+		Status: StatusActive,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateLastWhispered(ctx, "session-1", "Artanis"))
+
+	got, err := store.Get(ctx, "session-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Artanis", got.LastWhispered)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -51,10 +51,12 @@ type Info struct {
 	CommandHistory []string
 	TTLSeconds     int
 	MaxHistory     int
-	DetachedAt     *time.Time
-	ExpiresAt      *time.Time
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	DetachedAt      *time.Time
+	ExpiresAt       *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	LastPaged       string
+	LastWhispered   string
 }
 
 // IsActive returns true if the session is in active status.
@@ -102,6 +104,10 @@ type Access interface {
 	// FindByCharacter returns the active or detached session for a character.
 	FindByCharacter(ctx context.Context, characterID ulid.ULID) (*Info, error)
 
+	// FindByCharacterName returns the active session for a character by name.
+	// The lookup is case-insensitive.
+	FindByCharacterName(ctx context.Context, name string) (*Info, error)
+
 	// DeleteByCharacter finds and deletes a character's session.
 	// Returns the deleted Info for caller use (disconnect hooks, leave events).
 	// Returns nil, nil if no session exists.
@@ -109,6 +115,12 @@ type Access interface {
 
 	// UpdateActivity bumps the updated_at timestamp for a session.
 	UpdateActivity(ctx context.Context, id string) error
+
+	// UpdateLastPaged records the name of the character most recently paged.
+	UpdateLastPaged(ctx context.Context, sessionID string, name string) error
+
+	// UpdateLastWhispered records the name of the character most recently whispered to.
+	UpdateLastWhispered(ctx context.Context, sessionID string, name string) error
 }
 
 // Store manages persistent session state. Implementations MUST be
@@ -185,4 +197,14 @@ type Store interface {
 
 	// UpdateActivity bumps the updated_at timestamp for a session.
 	UpdateActivity(ctx context.Context, id string) error
+
+	// FindByCharacterName returns the active session for a character by name.
+	// The lookup is case-insensitive.
+	FindByCharacterName(ctx context.Context, name string) (*Info, error)
+
+	// UpdateLastPaged records the name of the character most recently paged.
+	UpdateLastPaged(ctx context.Context, sessionID string, name string) error
+
+	// UpdateLastWhispered records the name of the character most recently whispered to.
+	UpdateLastWhispered(ctx context.Context, sessionID string, name string) error
 }

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -263,16 +263,16 @@ func TestMigrator_Close_Idempotent(t *testing.T) {
 }
 
 func TestMigrator_PendingMigrations_Success(t *testing.T) {
-	// At version 3, migrations 4-18 should be pending
+	// At version 3, migrations 4-19 should be pending
 	m := &Migrator{m: &mockMigrate{versionVal: 3}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}, pending)
+	assert.Equal(t, []uint{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, pending)
 }
 
 func TestMigrator_PendingMigrations_AtLatest(t *testing.T) {
-	// At version 18 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 18}}
+	// At version 19 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 19}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)
@@ -283,7 +283,7 @@ func TestMigrator_PendingMigrations_AtZero(t *testing.T) {
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, pending)
 }
 
 func TestMigrator_PendingMigrations_VersionError(t *testing.T) {

--- a/internal/store/migrations/000019_session_messaging.down.sql
+++ b/internal/store/migrations/000019_session_messaging.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sessions
+  DROP COLUMN IF EXISTS last_paged,
+  DROP COLUMN IF EXISTS last_whispered;

--- a/internal/store/migrations/000019_session_messaging.down.sql
+++ b/internal/store/migrations/000019_session_messaging.down.sql
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
 ALTER TABLE sessions
   DROP COLUMN IF EXISTS last_paged,
   DROP COLUMN IF EXISTS last_whispered;

--- a/internal/store/migrations/000019_session_messaging.up.sql
+++ b/internal/store/migrations/000019_session_messaging.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
 ALTER TABLE sessions
   ADD COLUMN last_paged TEXT NOT NULL DEFAULT '',
   ADD COLUMN last_whispered TEXT NOT NULL DEFAULT '';

--- a/internal/store/migrations/000019_session_messaging.up.sql
+++ b/internal/store/migrations/000019_session_messaging.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sessions
+  ADD COLUMN last_paged TEXT NOT NULL DEFAULT '',
+  ADD COLUMN last_whispered TEXT NOT NULL DEFAULT '';

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -517,7 +517,7 @@ func (s *PostgresSessionStore) FindByCharacterName(ctx context.Context, name str
 	row := s.pool.QueryRow(ctx, query, name)
 	info, err := scanSession(row)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, oops.Code("SESSION_NOT_FOUND").With("character_name", name).Wrap(err)
+		return nil, nil
 	}
 	if err != nil {
 		return nil, oops.With("operation", "find session by character name").With("character_name", name).Wrap(err)

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -41,7 +41,8 @@ var (
 const sessionSelectColumns = `id, character_id, character_name, location_id,
 	is_guest, status, grid_present, event_cursors,
 	command_history, ttl_seconds, max_history,
-	detached_at, expires_at, created_at, updated_at`
+	detached_at, expires_at, created_at, updated_at,
+	last_paged, last_whispered`
 
 // parseSessionRow parses the scalar fields scanned from a session row into a
 // session.Info. Both scanSession and scanSessions call Scan with the same
@@ -99,6 +100,8 @@ func scanSession(row pgx.Row) (*session.Info, error) {
 		&info.ExpiresAt,
 		&info.CreatedAt,
 		&info.UpdatedAt,
+		&info.LastPaged,
+		&info.LastWhispered,
 	)
 	if err != nil {
 		return nil, oops.With("operation", "scan session row").Wrap(err)
@@ -136,6 +139,8 @@ func scanSessions(rows pgx.Rows) ([]*session.Info, error) {
 			&info.ExpiresAt,
 			&info.CreatedAt,
 			&info.UpdatedAt,
+			&info.LastPaged,
+			&info.LastWhispered,
 		)
 		if err != nil {
 			return nil, oops.With("operation", "scan session row").Wrap(err)
@@ -186,8 +191,9 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 		`INSERT INTO sessions (id, character_id, character_name, location_id,
 			is_guest, status, grid_present, event_cursors,
 			command_history, ttl_seconds, max_history,
-			detached_at, expires_at, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14)
+			detached_at, expires_at, created_at,
+			last_paged, last_whispered)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15, $16)
 		 ON CONFLICT (id) DO UPDATE SET
 			character_id = EXCLUDED.character_id,
 			character_name = EXCLUDED.character_name,
@@ -201,6 +207,8 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 			max_history = EXCLUDED.max_history,
 			detached_at = EXCLUDED.detached_at,
 			expires_at = EXCLUDED.expires_at,
+			last_paged = EXCLUDED.last_paged,
+			last_whispered = EXCLUDED.last_whispered,
 			updated_at = now()`,
 		id,
 		info.CharacterID.String(),
@@ -216,6 +224,8 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 		info.DetachedAt,
 		info.ExpiresAt,
 		info.CreatedAt,
+		info.LastPaged,
+		info.LastWhispered,
 	)
 	if err != nil {
 		return oops.With("operation", "set session").With("session_id", id).Wrap(err)
@@ -496,6 +506,41 @@ func (s *PostgresSessionStore) UpdateActivity(ctx context.Context, id string) er
 		`UPDATE sessions SET updated_at = now() WHERE id = $1`, id)
 	if err != nil {
 		return oops.With("operation", "update activity").With("session_id", id).Wrap(err)
+	}
+	return nil
+}
+
+// FindByCharacterName returns the active session for a character by name.
+// The lookup is case-insensitive.
+func (s *PostgresSessionStore) FindByCharacterName(ctx context.Context, name string) (*session.Info, error) {
+	query := `SELECT ` + sessionSelectColumns + ` FROM sessions WHERE LOWER(character_name) = LOWER($1) AND status = 'active'`
+	row := s.pool.QueryRow(ctx, query, name)
+	info, err := scanSession(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, oops.Code("SESSION_NOT_FOUND").With("character_name", name).Wrap(err)
+	}
+	if err != nil {
+		return nil, oops.With("operation", "find session by character name").With("character_name", name).Wrap(err)
+	}
+	return info, nil
+}
+
+// UpdateLastPaged records the name of the character most recently paged.
+func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID string, name string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE sessions SET last_paged = $1, updated_at = now() WHERE id = $2`, name, sessionID)
+	if err != nil {
+		return oops.With("operation", "update last paged").With("session_id", sessionID).Wrap(err)
+	}
+	return nil
+}
+
+// UpdateLastWhispered records the name of the character most recently whispered to.
+func (s *PostgresSessionStore) UpdateLastWhispered(ctx context.Context, sessionID string, name string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE sessions SET last_whispered = $1, updated_at = now() WHERE id = $2`, name, sessionID)
+	if err != nil {
+		return oops.With("operation", "update last whispered").With("session_id", sessionID).Wrap(err)
 	}
 	return nil
 }

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -526,7 +526,7 @@ func (s *PostgresSessionStore) FindByCharacterName(ctx context.Context, name str
 }
 
 // UpdateLastPaged records the name of the character most recently paged.
-func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID string, name string) error {
+func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID, name string) error {
 	_, err := s.pool.Exec(ctx,
 		`UPDATE sessions SET last_paged = $1, updated_at = now() WHERE id = $2`, name, sessionID)
 	if err != nil {
@@ -536,7 +536,7 @@ func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID st
 }
 
 // UpdateLastWhispered records the name of the character most recently whispered to.
-func (s *PostgresSessionStore) UpdateLastWhispered(ctx context.Context, sessionID string, name string) error {
+func (s *PostgresSessionStore) UpdateLastWhispered(ctx context.Context, sessionID, name string) error {
 	_, err := s.pool.Exec(ctx,
 		`UPDATE sessions SET last_whispered = $1, updated_at = now() WHERE id = $2`, name, sessionID)
 	if err != nil {

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -527,20 +527,26 @@ func (s *PostgresSessionStore) FindByCharacterName(ctx context.Context, name str
 
 // UpdateLastPaged records the name of the character most recently paged.
 func (s *PostgresSessionStore) UpdateLastPaged(ctx context.Context, sessionID, name string) error {
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`UPDATE sessions SET last_paged = $1, updated_at = now() WHERE id = $2`, name, sessionID)
 	if err != nil {
 		return oops.With("operation", "update last paged").With("session_id", sessionID).Wrap(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
 	}
 	return nil
 }
 
 // UpdateLastWhispered records the name of the character most recently whispered to.
 func (s *PostgresSessionStore) UpdateLastWhispered(ctx context.Context, sessionID, name string) error {
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`UPDATE sessions SET last_whispered = $1, updated_at = now() WHERE id = $2`, name, sessionID)
 	if err != nil {
 		return oops.With("operation", "update last whispered").With("session_id", sessionID).Wrap(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
 	}
 	return nil
 }

--- a/internal/store/session_store_test.go
+++ b/internal/store/session_store_test.go
@@ -49,6 +49,7 @@ func sessionColumns() []string {
 		"is_guest", "status", "grid_present", "event_cursors",
 		"command_history", "ttl_seconds", "max_history",
 		"detached_at", "expires_at", "created_at", "updated_at",
+		"last_paged", "last_whispered",
 	}
 }
 
@@ -71,6 +72,8 @@ func sessionRow(info *session.Info) []any {
 		info.ExpiresAt,
 		info.CreatedAt,
 		info.UpdatedAt,
+		info.LastPaged,
+		info.LastWhispered,
 	}
 }
 
@@ -193,6 +196,8 @@ func TestPostgresSessionStore_Set(t *testing.T) {
 						pgxmock.AnyArg(), // detached_at
 						pgxmock.AnyArg(), // expires_at
 						pgxmock.AnyArg(), // created_at
+						pgxmock.AnyArg(), // last_paged
+						pgxmock.AnyArg(), // last_whispered
 					).
 					WillReturnResult(pgxmock.NewResult("INSERT", 1))
 			},
@@ -208,7 +213,8 @@ func TestPostgresSessionStore_Set(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(),
 					).
 					WillReturnError(errors.New("disk full"))
 			},
@@ -276,6 +282,8 @@ func TestPostgresSessionStore_Set_NilCommandHistory(t *testing.T) {
 			pgxmock.AnyArg(),     // detached_at
 			pgxmock.AnyArg(),     // expires_at
 			pgxmock.AnyArg(),     // created_at
+			pgxmock.AnyArg(),     // last_paged
+			pgxmock.AnyArg(),     // last_whispered
 		).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 

--- a/internal/telnet/gateway_handler.go
+++ b/internal/telnet/gateway_handler.go
@@ -642,6 +642,37 @@ func (h *GatewayHandler) sendProtoEvent(ev *corev1.EventFrame) {
 		// Leave notifications are persisted but not yet displayed to clients.
 		slog.Debug("gateway: leave event received", "session_id", h.sessionID)
 
+	case string(core.EventTypePage):
+		var p core.PagePayload
+		if err := json.Unmarshal(ev.GetPayload(), &p); err != nil {
+			slog.Error("gateway: failed to unmarshal page event payload", "error", err)
+			return
+		}
+		h.send(p.Message)
+
+	case string(core.EventTypeWhisper):
+		// Whisper events have two payload shapes:
+		// - Character stream: WhisperPayload with Message field
+		// - Location stream: WhisperNoticePayload with Notice field
+		// JSON unmarshal succeeds for both; distinguish by checking which field is populated.
+		var wp core.WhisperPayload
+		if err := json.Unmarshal(ev.GetPayload(), &wp); err != nil {
+			slog.Error("gateway: failed to unmarshal whisper event payload", "error", err)
+			return
+		}
+		if wp.Message != "" {
+			h.send(wp.Message)
+			return
+		}
+		var notice core.WhisperNoticePayload
+		if err := json.Unmarshal(ev.GetPayload(), &notice); err != nil {
+			slog.Error("gateway: failed to unmarshal whisper notice payload", "error", err)
+			return
+		}
+		if notice.Notice != "" {
+			h.send(notice.Notice)
+		}
+
 	default:
 		slog.Warn("gateway: unknown event type", "type", ev.GetType())
 		h.send(fmt.Sprintf("<event: %s>", ev.GetType()))

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -475,3 +475,15 @@ func (m *mockSessionStore) DeleteByCharacter(_ context.Context, id ulid.ULID, _ 
 func (m *mockSessionStore) UpdateActivity(_ context.Context, id string) error {
 	return fmt.Errorf("mockSessionStore.UpdateActivity(%q): not implemented", id)
 }
+
+func (m *mockSessionStore) FindByCharacterName(_ context.Context, name string) (*session.Info, error) {
+	return nil, fmt.Errorf("mockSessionStore.FindByCharacterName(%q): not implemented", name)
+}
+
+func (m *mockSessionStore) UpdateLastPaged(_ context.Context, id string, _ string) error {
+	return fmt.Errorf("mockSessionStore.UpdateLastPaged(%q): not implemented", id)
+}
+
+func (m *mockSessionStore) UpdateLastWhispered(_ context.Context, id string, _ string) error {
+	return fmt.Errorf("mockSessionStore.UpdateLastWhispered(%q): not implemented", id)
+}

--- a/internal/world/service.go
+++ b/internal/world/service.go
@@ -635,6 +635,32 @@ func (s *Service) GetCharacter(ctx context.Context, subjectID string, id ulid.UL
 	return char, nil
 }
 
+// UpdateCharacterDescription sets a character's description after checking write authorization.
+func (s *Service) UpdateCharacterDescription(ctx context.Context, subjectID string, characterID ulid.ULID, description string) error {
+	if s.characterRepo == nil {
+		return oops.Code("CHARACTER_UPDATE_FAILED").Errorf("character repository not configured")
+	}
+	resource := access.CharacterResource(characterID.String())
+	if err := s.checkAccess(ctx, subjectID, "write", resource, prefixCharacter); err != nil {
+		return err
+	}
+	char, err := s.characterRepo.Get(ctx, characterID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return oops.Code("CHARACTER_NOT_FOUND").Wrapf(err, "get character %s", characterID)
+		}
+		return oops.Code("CHARACTER_GET_FAILED").Wrapf(err, "get character %s", characterID)
+	}
+	char.Description = description
+	if err := s.characterRepo.Update(ctx, char); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return oops.Code("CHARACTER_NOT_FOUND").Wrapf(err, "update character %s", characterID)
+		}
+		return oops.Code("CHARACTER_UPDATE_FAILED").Wrapf(err, "update character %s", characterID)
+	}
+	return nil
+}
+
 // GetCharactersByLocation retrieves characters at a location with pagination after checking list_characters authorization.
 // Note: This decomposes the legacy compound resource "location:<id>:characters" into
 // resource="location:<id>" with action="list_characters" per ADR #76 (Compound Resource Decomposition,

--- a/pkg/holo/context.go
+++ b/pkg/holo/context.go
@@ -15,13 +15,15 @@ import (
 //
 // Lua plugins receive this as a table with fields:
 //
-//	ctx.name           -- "say"
-//	ctx.args           -- "Hello everyone!"
-//	ctx.invoked_as     -- ";" or original command
-//	ctx.character_name -- "Alice"
-//	ctx.character_id   -- "01ABC..."
-//	ctx.location_id    -- "01DEF..."
-//	ctx.player_id      -- "01GHI..."
+//	ctx.name            -- "say"
+//	ctx.args            -- "Hello everyone!"
+//	ctx.invoked_as      -- ";" or original command
+//	ctx.character_name  -- "Alice"
+//	ctx.character_id    -- "01ABC..."
+//	ctx.location_id     -- "01DEF..."
+//	ctx.player_id       -- "01GHI..."
+//	ctx.session_id      -- "01JKL..." (session executing the command)
+//	ctx.last_whispered  -- "Bob" (last character whispered to, may be empty)
 type CommandContext struct {
 	// Name is the canonical command name (e.g., "say", "pose", "emit").
 	Name string
@@ -46,6 +48,13 @@ type CommandContext struct {
 
 	// PlayerID is the ULID of the player who owns the character.
 	PlayerID string
+
+	// SessionID is the ULID of the session executing the command.
+	SessionID string
+
+	// LastWhispered is the name of the character most recently whispered to
+	// by this session. May be empty if no whisper has been sent.
+	LastWhispered string
 }
 
 // commandPayload mirrors the JSON structure of command event payloads.
@@ -58,6 +67,8 @@ type commandPayload struct {
 	CharacterID   string `json:"character_id"`
 	LocationID    string `json:"location_id"`
 	PlayerID      string `json:"player_id"`
+	SessionID     string `json:"session_id"`
+	LastWhispered string `json:"last_whispered"`
 }
 
 // ValidateULIDs checks that CharacterID, LocationID, and PlayerID are valid ULID strings.

--- a/plugins/communication/main.lua
+++ b/plugins/communication/main.lua
@@ -90,8 +90,8 @@ function handle_whisper(ctx)
     if eq_pos then
         target_name = ctx.args:sub(1, eq_pos - 1)
         message = ctx.args:sub(eq_pos + 1)
-    else
-        -- No =: use last whispered target.
+    elseif ctx.invoked_as == "w" then
+        -- Short form: use last whispered target.
         if not ctx.last_whispered or ctx.last_whispered == "" then
             holo.emit.character(ctx.character_id, "error", {
                 message = "Whisper to whom? Use: whisper <name>=<message>"
@@ -100,6 +100,11 @@ function handle_whisper(ctx)
         end
         target_name = ctx.last_whispered
         message = ctx.args
+    else
+        holo.emit.character(ctx.character_id, "error", {
+            message = "Usage: whisper <name>=<message> or w <message>"
+        })
+        return holo.emit.flush()
     end
 
     if target_name == "" then
@@ -117,7 +122,13 @@ function handle_whisper(ctx)
     end
 
     -- Find target session.
-    local target = holo.session.find_by_name(target_name)
+    local target, find_err = holo.session.find_by_name(target_name)
+    if find_err then
+        holo.emit.character(ctx.character_id, "error", {
+            message = "An internal error occurred. Please try again."
+        })
+        return holo.emit.flush()
+    end
     if target == nil then
         holo.emit.character(ctx.character_id, "error", {
             message = 'No one named "' .. target_name .. '" is connected.'
@@ -183,7 +194,7 @@ function handle_whisper(ctx)
         sender_msg = "You whisper to " .. target.character_name .. ": " .. message
     end
     holo.emit.character(ctx.character_id, "command_response", {
-        message = sender_msg
+        text = sender_msg
     })
 
     -- Record last whispered target.

--- a/plugins/communication/main.lua
+++ b/plugins/communication/main.lua
@@ -1,7 +1,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 -- Copyright 2026 HoloMUSH Contributors
 
--- Communication plugin: handles say, pose, emit commands
+-- Communication plugin: handles say, pose, emit, whisper commands
 -- Uses the holo stdlib for typed context and event emission.
 
 function on_command(ctx)
@@ -11,6 +11,8 @@ function on_command(ctx)
         return handle_pose(ctx)
     elseif ctx.name == "emit" then
         return handle_emit(ctx)
+    elseif ctx.name == "whisper" or ctx.name == "w" then
+        return handle_whisper(ctx)
     end
     return nil
 end
@@ -77,5 +79,111 @@ function handle_emit(ctx)
     holo.emit.location(ctx.location_id, "emit", {
         message = ctx.args
     })
+    return holo.emit.flush()
+end
+
+function handle_whisper(ctx)
+    -- Parse target and message from args.
+    local target_name
+    local message
+    local eq_pos = ctx.args:find("=", 1, true)
+    if eq_pos then
+        target_name = ctx.args:sub(1, eq_pos - 1)
+        message = ctx.args:sub(eq_pos + 1)
+    else
+        -- No =: use last whispered target.
+        if not ctx.last_whispered or ctx.last_whispered == "" then
+            holo.emit.character(ctx.character_id, "error", {
+                message = "Whisper to whom? Use: whisper <name>=<message>"
+            })
+            return holo.emit.flush()
+        end
+        target_name = ctx.last_whispered
+        message = ctx.args
+    end
+
+    if target_name == "" then
+        holo.emit.character(ctx.character_id, "error", {
+            message = "Whisper to whom? Use: whisper <name>=<message>"
+        })
+        return holo.emit.flush()
+    end
+
+    if message == "" then
+        holo.emit.character(ctx.character_id, "error", {
+            message = "What do you want to whisper?"
+        })
+        return holo.emit.flush()
+    end
+
+    -- Find target session.
+    local target = holo.session.find_by_name(target_name)
+    if target == nil then
+        holo.emit.character(ctx.character_id, "error", {
+            message = 'No one named "' .. target_name .. '" is connected.'
+        })
+        return holo.emit.flush()
+    end
+
+    -- Same-location check.
+    if target.location_id ~= ctx.location_id then
+        holo.emit.character(ctx.character_id, "error", {
+            message = 'You don\'t see anyone named "' .. target_name .. '" here.'
+        })
+        return holo.emit.flush()
+    end
+
+    -- Detect pose mode.
+    local is_pose = false
+    local pose_space = " "
+    local first_char = message:sub(1, 1)
+    if first_char == ":" then
+        is_pose = true
+        pose_space = " "
+        message = message:sub(2)
+    elseif first_char == ";" then
+        is_pose = true
+        pose_space = ""
+        message = message:sub(2)
+    end
+
+    if message == "" then
+        holo.emit.character(ctx.character_id, "error", {
+            message = "What do you want to whisper?"
+        })
+        return holo.emit.flush()
+    end
+
+    -- Emit location notice (no content revealed).
+    holo.emit.location(ctx.location_id, "whisper", {
+        notice = ctx.character_name .. " whispers to " .. target.character_name .. "."
+    })
+
+    -- Emit to target.
+    local target_msg
+    if is_pose then
+        target_msg = "From nearby, " .. ctx.character_name .. pose_space .. message
+    else
+        target_msg = ctx.character_name .. ' whispers, "' .. message .. '"'
+    end
+    holo.emit.character(target.character_id, "whisper", {
+        message = target_msg,
+        speaker = ctx.character_name
+    })
+
+    -- Emit confirmation to sender.
+    local sender_msg
+    if is_pose then
+        sender_msg = "You whisper-pose to " .. target.character_name .. ": " .. message
+    else
+        sender_msg = "You whisper to " .. target.character_name .. ": " .. message
+    end
+    holo.emit.character(ctx.character_id, "command_response", {
+        message = sender_msg
+    })
+
+    -- Record last whispered target.
+    holo.session.set_last_whispered(ctx.session_id, target.character_name)
+
     return holo.emit.flush()
 end

--- a/plugins/communication/main.lua
+++ b/plugins/communication/main.lua
@@ -156,6 +156,8 @@ function handle_whisper(ctx)
 
     -- Emit location notice (no content revealed).
     holo.emit.location(ctx.location_id, "whisper", {
+        sender_name = ctx.character_name,
+        target_name = target.character_name,
         notice = ctx.character_name .. " whispers to " .. target.character_name .. "."
     })
 
@@ -167,8 +169,10 @@ function handle_whisper(ctx)
         target_msg = ctx.character_name .. ' whispers, "' .. message .. '"'
     end
     holo.emit.character(target.character_id, "whisper", {
+        sender_id = ctx.character_id,
+        sender_name = ctx.character_name,
         message = target_msg,
-        speaker = ctx.character_name
+        is_pose = is_pose
     })
 
     -- Emit confirmation to sender.

--- a/plugins/communication/plugin.yaml
+++ b/plugins/communication/plugin.yaml
@@ -75,5 +75,33 @@ commands:
       - `emit The room shakes violently!` - Shows "The room shakes violently!"
       - `emit A cold wind blows through.` - Shows "A cold wind blows through."
 
+  - name: whisper
+    capabilities:
+      - comms.whisper
+    help: "Whisper to someone in the room"
+    usage: "whisper <character>=<message>"
+    helpText: |
+      ## Whisper
+
+      Whisper a private in-character message to someone in your location.
+      Others see that you whispered, but not what you said.
+
+      ### Usage
+
+      - `whisper <name>=<message>` - Whisper to someone
+      - `whisper <message>` - Whisper to the last person you whispered to
+      - `whisper <name>=:<action>` - Pose-whisper
+
+      ### Examples
+
+      - `whisper Alex=Meet me at the tavern`
+      - `whisper Alex=:nods knowingly.`
+
+  - name: w
+    capabilities:
+      - comms.whisper
+    help: "Whisper (alias)"
+    usage: "w <character>=<message>"
+
 lua-plugin:
   entry: main.lua

--- a/test/integration/command/ratelimit_integration_test.go
+++ b/test/integration/command/ratelimit_integration_test.go
@@ -54,6 +54,18 @@ func (s *stubSessionService) UpdateActivity(_ context.Context, _ string) error {
 	return nil
 }
 
+func (s *stubSessionService) FindByCharacterName(_ context.Context, _ string) (*session.Info, error) {
+	return nil, nil
+}
+
+func (s *stubSessionService) UpdateLastPaged(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (s *stubSessionService) UpdateLastWhispered(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 type stubEventStore struct{}
 
 func (s *stubEventStore) Append(_ context.Context, _ core.Event) error { return nil }

--- a/test/integration/phase1_5_test.go
+++ b/test/integration/phase1_5_test.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/control"
 	"github.com/holomush/holomush/internal/core"
 	grpcpkg "github.com/holomush/holomush/internal/grpc"
@@ -55,6 +57,18 @@ func (n *noopEventStore) Subscribe(ctx context.Context, _ string) (<-chan ulid.U
 		close(errs)
 	}()
 	return events, errs, nil
+}
+
+// newMinimalDispatcher creates a dispatcher with no registered commands for tests
+// that don't exercise command functionality.
+func newMinimalDispatcher() (*command.Dispatcher, *command.Services) {
+	pe := policytest.AllowAllEngine()
+	svc := command.NewTestServices(command.ServicesConfig{Engine: pe})
+	d, err := command.NewDispatcher(command.NewRegistry(), pe)
+	if err != nil {
+		panic("newMinimalDispatcher: " + err.Error())
+	}
+	return d, svc
 }
 
 // testEnv holds all the resources needed for integration tests.
@@ -302,7 +316,8 @@ var _ = Describe("Phase 1.5 Integration", func() {
 			engine := core.NewEngine(eventStore)
 
 			// Create gRPC server with mTLS
-			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(),
+			disp, cmdSvc := newMinimalDispatcher()
+			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(), disp, cmdSvc,
 				grpcpkg.WithEventStore(eventStore))
 			env.grpcServer = grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
 			corev1.RegisterCoreServiceServer(env.grpcServer, coreServer)
@@ -372,7 +387,8 @@ var _ = Describe("Phase 1.5 Integration", func() {
 			engine := core.NewEngine(eventStore)
 
 			// Create gRPC server with mTLS
-			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(),
+			disp, cmdSvc := newMinimalDispatcher()
+			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(), disp, cmdSvc,
 				grpcpkg.WithEventStore(eventStore))
 			env.grpcServer = grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
 			corev1.RegisterCoreServiceServer(env.grpcServer, coreServer)
@@ -534,7 +550,8 @@ var _ = Describe("Phase 1.5 Integration", func() {
 			eventStore := &noopEventStore{}
 			engine := core.NewEngine(eventStore)
 
-			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(),
+			disp, cmdSvc := newMinimalDispatcher()
+			coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(), disp, cmdSvc,
 				grpcpkg.WithEventStore(eventStore))
 			env.grpcServer = grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
 			corev1.RegisterCoreServiceServer(env.grpcServer, coreServer)

--- a/test/integration/session/session_persistence_integration_test.go
+++ b/test/integration/session/session_persistence_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	grpcpkg "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/session"
@@ -103,8 +104,14 @@ var _ = Describe("Session Persistence", func() {
 
 		// 7. Create CoreServer with PostgresSessionStore and session defaults
 		pe := policytest.AllowAllEngine()
-		cmdSvc := command.NewTestServices(command.ServicesConfig{Engine: pe})
-		disp, dispErr := command.NewDispatcher(command.NewRegistry(), pe)
+		reg := command.NewRegistry()
+		handlers.RegisterAll(reg)
+		cmdSvc := command.NewTestServices(command.ServicesConfig{
+			Engine:  pe,
+			Session: sessionStore,
+			Events:  eventStore,
+		})
+		disp, dispErr := command.NewDispatcher(reg, pe)
 		Expect(dispErr).NotTo(HaveOccurred())
 		coreServer := grpcpkg.NewCoreServer(engine, sessionStore, disp, cmdSvc,
 			grpcpkg.WithAuthenticator(guestAuth),

--- a/test/integration/session/session_persistence_integration_test.go
+++ b/test/integration/session/session_persistence_integration_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
 
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
 	grpcpkg "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/session"
@@ -100,7 +102,11 @@ var _ = Describe("Session Persistence", func() {
 		guestAuth = telnet.NewGuestAuthenticator(telnet.NewGemstoneElementTheme(), startLocation)
 
 		// 7. Create CoreServer with PostgresSessionStore and session defaults
-		coreServer := grpcpkg.NewCoreServer(engine, sessionStore,
+		pe := policytest.AllowAllEngine()
+		cmdSvc := command.NewTestServices(command.ServicesConfig{Engine: pe})
+		disp, dispErr := command.NewDispatcher(command.NewRegistry(), pe)
+		Expect(dispErr).NotTo(HaveOccurred())
+		coreServer := grpcpkg.NewCoreServer(engine, sessionStore, disp, cmdSvc,
 			grpcpkg.WithAuthenticator(guestAuth),
 			grpcpkg.WithEventStore(eventStore),
 			grpcpkg.WithSessionDefaults(grpcpkg.SessionDefaults{

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -25,6 +25,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	grpcpkg "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/session"
@@ -206,10 +209,23 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 		startLocation = ulid.Make()
 		guestAuth = telnet.NewGuestAuthenticator(telnet.NewGemstoneElementTheme(), startLocation)
 
-		// 9. Create gRPC server
-		coreServer := grpcpkg.NewCoreServer(engine, session.NewMemStore(),
+		// 9. Create gRPC server with command dispatcher
+		sessStore := session.NewMemStore()
+		reg := command.NewRegistry()
+		handlers.RegisterAll(reg)
+		pe := policytest.AllowAllEngine()
+		cmdSvc := command.NewTestServices(command.ServicesConfig{
+			Session: sessStore,
+			Engine:  pe,
+			Events:  eventStore,
+		})
+		dispatcher, dispErr := command.NewDispatcher(reg, pe)
+		Expect(dispErr).NotTo(HaveOccurred())
+
+		coreServer := grpcpkg.NewCoreServer(engine, sessStore,
 			grpcpkg.WithAuthenticator(guestAuth),
 			grpcpkg.WithEventStore(eventStore),
+			grpcpkg.WithDispatcher(dispatcher, cmdSvc),
 			grpcpkg.WithDisconnectHook(func(info session.Info) {
 				if info.IsGuest {
 					guestAuth.ReleaseGuest(info.CharacterName)

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -222,10 +222,9 @@ var _ = Describe("Telnet Vertical Slice E2E", func() {
 		dispatcher, dispErr := command.NewDispatcher(reg, pe)
 		Expect(dispErr).NotTo(HaveOccurred())
 
-		coreServer := grpcpkg.NewCoreServer(engine, sessStore,
+		coreServer := grpcpkg.NewCoreServer(engine, sessStore, dispatcher, cmdSvc,
 			grpcpkg.WithAuthenticator(guestAuth),
 			grpcpkg.WithEventStore(eventStore),
-			grpcpkg.WithDispatcher(dispatcher, cmdSvc),
 			grpcpkg.WithDisconnectHook(func(info session.Info) {
 				if info.IsGuest {
 					guestAuth.ReleaseGuest(info.CharacterName)


### PR DESCRIPTION
## Summary

- **describe** — core Go handler to set character/location/object descriptions (`describe me <text>`, `describe here <text>`, `describe <target>=<text>`)
- **page** — core Go handler for OOC private messaging with last-paged memory and pose support (`page <name>=<msg>`, `p <msg>`)
- **whisper** — Lua plugin for IC same-location messaging with location notices (`whisper <name>=<msg>`, `w <msg>`)

## Changes

| Area | What |
|------|------|
| `internal/store/migrations/000019_*` | Add `last_paged`, `last_whispered` columns to sessions |
| `internal/session/` | `LastPaged`, `LastWhispered` on Info; `FindByCharacterName`, `UpdateLastPaged`, `UpdateLastWhispered` on Access |
| `internal/core/event.go` | `EventTypePage`, `EventTypeWhisper` + payload structs |
| `internal/world/service.go` | `UpdateCharacterDescription` method |
| `internal/command/handlers/describe.go` | Describe handler wrapping property system (me path uses WorldService) |
| `internal/command/handlers/page.go` | Page handler with event emission, last-paged, pose mode |
| `internal/command/handlers/register.go` | Register describe/desc/page/p |
| `internal/plugin/hostfunc/stdlib_session.go` | `holo.session.find_by_name` + `set_last_whispered` host functions |
| `pkg/holo/context.go` | `SessionID`, `LastWhispered` in Lua command context |
| `plugins/communication/` | Whisper + w commands in plugin.yaml + main.lua |

## Design

Spec: `docs/superpowers/specs/2026-03-27-describe-page-whisper-design.md`
Plan: `docs/superpowers/plans/2026-03-27-describe-page-whisper.md`

Key decisions:
- **describe** wraps property system for here/target, calls `WorldService.UpdateCharacterDescription` for me
- **page** is OOC (no location event), **whisper** is IC (location notice without content)
- **whisper in Lua** for game customization (overhearing, stealth checks)
- **Last-paged/whispered** stored on session — survives reconnect, gone when session ends

## Test plan

- [x] `task test` — all unit tests pass (14 new tests for describe + page)
- [x] `task lint` — clean (0 Go lint issues)
- [ ] `task test:int` — running
- [ ] `task test:e2e` — running

## Follow-up

- E2E tests for describe/page/whisper (multi-session telnet test)
- Wire `session.Access` into plugin host for production whisper path

Closes holomush-a3a7.1, holomush-a3a7.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * describe (desc): set character/location/object descriptions via "me", "here", or "target=text" with confirmation.
  * page (p): OOC private messaging with pose styling, sender confirmation, and fallback to your last-paged recipient.
  * whisper (w): IC in-room private messages with pose styling, location-aware delivery, bystander notice, sender confirmation, and fallback to your last-whispered recipient.

* **Behavior**
  * Last-paged and last-whispered recipients are now persisted for convenient repeat messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->