### PR TITLE
fix(bootstrap): use NULL created_by for system-seeded aliases

### DIFF
--- a/internal/bootstrap/aliases.go
+++ b/internal/bootstrap/aliases.go
@@ -43,7 +43,7 @@ func SeedSystemAliases(ctx context.Context, repo AliasSeeder, cache *command.Ali
 		if _, exists := existing[a.alias]; exists {
 			continue
 		}
-		if err := repo.SetSystemAlias(ctx, a.alias, a.command, "system:bootstrap"); err != nil {
+		if err := repo.SetSystemAlias(ctx, a.alias, a.command, ""); err != nil {
 			return oops.With("operation", "set system alias").With("alias", a.alias).Wrap(err)
 		}
 		seeded = append(seeded, a.alias)


### PR DESCRIPTION
## Summary

- SeedSystemAliases passed `"system:bootstrap"` as `created_by`, violating the FK constraint to `players(id)`. Pass empty string instead, which `SetSystemAlias` converts to NULL.

**Root cause:** The `system_aliases.created_by` column has a FK to `players(id)`. Bootstrap seeding used a non-existent player ID `"system:bootstrap"`.

Closes holomush-dbl4.

## Test plan
- [x] Unit tests pass (`task test`)
- [x] E2E core container starts successfully (was crashing)
- [x] 20/25 E2E Playwright tests pass (4 terminal failures are pre-existing/separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal system alias initialization process with a minor adjustment to configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->