### PR TITLE
ci: add CODECOV_TOKEN to coverage upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary

- Add `token` parameter to `codecov/codecov-action@v5` in CI workflow

The upload was failing with `"Token required because branch is protected"`. The secret is now configured in repo settings.

## Test plan
- [x] CI runs coverage upload step
- [ ] Codecov receives the upload successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)