### PR TITLE
fix(web): preserve whitespace in terminal event renderers

### DIFF
--- a/web/src/lib/components/terminal/AnsiRenderer.svelte
+++ b/web/src/lib/components/terminal/AnsiRenderer.svelte
@@ -18,3 +18,7 @@
 </script>
 
 <span class="ansi-output">{@html html}</span>
+
+<style>
+  .ansi-output { white-space: pre-wrap; }
+</style>

--- a/web/src/lib/components/terminal/CommandRenderer.svelte
+++ b/web/src/lib/components/terminal/CommandRenderer.svelte
@@ -35,6 +35,6 @@
 
 <style>
   .event { line-height: 1.7; }
-  .command-output { color: var(--color-command-output); }
-  .command-error { color: var(--color-command-error); }
+  .command-output { color: var(--color-command-output); white-space: pre-wrap; }
+  .command-error { color: var(--color-command-error); white-space: pre-wrap; }
 </style>

--- a/web/src/lib/components/terminal/FallbackRenderer.svelte
+++ b/web/src/lib/components/terminal/FallbackRenderer.svelte
@@ -36,6 +36,6 @@
 <style>
   .event { line-height: 1.7; }
   .actor { color: var(--color-pose-actor); }
-  .generic { color: var(--color-command-output); }
+  .generic { color: var(--color-command-output); white-space: pre-wrap; }
   .raw-metadata { color: var(--color-system); opacity: 0.6; font-size: 0.9em; }
 </style>

--- a/web/src/lib/components/terminal/SystemRenderer.svelte
+++ b/web/src/lib/components/terminal/SystemRenderer.svelte
@@ -29,6 +29,6 @@
 
 <style>
   .event { line-height: 1.7; }
-  .system-text { color: var(--color-system); }
-  .system-error { color: var(--color-command-error); }
+  .system-text { color: var(--color-system); white-space: pre-wrap; }
+  .system-error { color: var(--color-command-error); white-space: pre-wrap; }
 </style>


### PR DESCRIPTION
## Summary

- Add `white-space: pre-wrap` to all terminal event renderer components
- Fixes help command output rendering as a wall of text with no line breaks or table alignment

## Problem

The `holo.Fmt.Table()` formatter outputs newline-separated rows (correct for telnet). But the web client renders event text as HTML via `{@html ...}`, where `\n` is collapsed to whitespace. Help output, command results, and system messages all lost their formatting.

## Fix

Added `white-space: pre-wrap` to text spans in 4 renderer components:

| Component | Classes fixed |
|---|---|
| `CommandRenderer.svelte` | `.command-output`, `.command-error` |
| `AnsiRenderer.svelte` | `.ansi-output` |
| `FallbackRenderer.svelte` | `.generic` |
| `SystemRenderer.svelte` | `.system-text`, `.system-error` |

`pre-wrap` preserves newlines and spaces while allowing text to wrap at container boundaries — correct for a terminal-like web UI.

## Test plan

- [x] `task test:e2e` — 43/43 pass
- [x] Visual verification: help command renders with proper table alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal output display to consistently preserve whitespace and line breaks across all rendering types including system messages, command output, error messages, and ANSI-formatted content, improving text formatting and ensuring proper visual presentation of terminal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->