### PR TITLE
fix(web): add onboarding hints to registration and character pages

### DIFF
--- a/web/src/routes/(authed)/characters/+page.svelte
+++ b/web/src/routes/(authed)/characters/+page.svelte
@@ -105,6 +105,14 @@
   <div class="container">
     <h1 class="title">Choose Your Character</h1>
 
+    {#if !loading && characters.length === 0}
+      <p class="hint">
+        Now pick a name and step into the world. This is your in-character
+        identity — who people will see and interact with. You can always
+        come back and create more characters later.
+      </p>
+    {/if}
+
     {#if error}
       <p class="error">{error}</p>
     {/if}
@@ -194,6 +202,14 @@
     color: var(--color-say-speaker);
     margin: 0 0 24px;
     font-weight: 600;
+  }
+
+  .hint {
+    font-size: 12px;
+    color: var(--color-status-text);
+    line-height: 1.5;
+    margin: -16px 0 16px;
+    text-align: center;
   }
 
   .error {

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -56,6 +56,12 @@
   <form class="card" onsubmit={(e) => { e.preventDefault(); handleRegister(); }}>
     <h1 class="title">Create Account</h1>
 
+    <p class="hint">
+      This creates your player account — think of it as your login.
+      Once you're in, you'll pick a character name to enter the world.
+      You can have multiple characters on one account.
+    </p>
+
     {#if error}
       <p class="error">{error}</p>
     {/if}
@@ -129,6 +135,14 @@
     color: var(--color-say-speaker);
     margin: 0;
     font-weight: 600;
+    text-align: center;
+  }
+
+  .hint {
+    font-size: 12px;
+    color: var(--color-status-text);
+    line-height: 1.5;
+    margin: 0;
     text-align: center;
   }
 


### PR DESCRIPTION
## Summary

- Add explanatory text to the registration page clarifying account vs character
- Add first-time hint on the character selection page when the player has no characters yet

## Problem

HoloMUSH separates player accounts from characters (one account, many characters). This differs from traditional MU\*s where `connect <name> <password>` creates both at once. New players don't understand what "Create Account" means in this context, or why character creation is a separate step.

## Changes

**Registration page** (`/register`): Added hint below the title:
> *This creates your player account — think of it as your login. Once you're in, you'll pick a character name to enter the world. You can have multiple characters on one account.*

**Character selection page** (`/characters`): Added context-sensitive hint shown only when the player has zero characters:
> *Now pick a name and step into the world. This is your in-character identity — who people will see and interact with. You can always come back and create more characters later.*

## Test plan

- [x] `task test:e2e` — 44/44 pass
- [x] Visual verification on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)