### PR TITLE
fix(docs): add deployment page to site navigation

### DIFF
--- a/site/zensical.toml
+++ b/site/zensical.toml
@@ -42,6 +42,7 @@ Guide = [
 [[project.nav]]
 Operating = [
   "operating/index.md",
+  "operating/deployment.md",
   "operating/installation.md",
   "operating/configuration.md",
   "operating/database.md",


### PR DESCRIPTION
## Summary

Add `operating/deployment.md` to the site navigation in `zensical.toml`. The deployment guide (PR #170) was merged but the page wasn't listed in the sidebar nav.

## Test plan

- [x] Visual verification: deployment page appears in Operating sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new deployment documentation page to the Operating section, providing users with access to deployment guidance and procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->