### PR TITLE
fix(grpc): resolve location name in character picker instead of showing ULID

### DIFF
--- a/internal/grpc/auth_handlers.go
+++ b/internal/grpc/auth_handlers.go
@@ -474,8 +474,11 @@ func (s *CoreServer) buildCharacterSummaries(ctx context.Context, playerID ulid.
 			CharacterName: c.Name,
 		}
 
-		if c.LocationID != nil {
-			summary.LastLocation = c.LocationID.String()
+		if c.LocationID != nil && s.worldQuerier != nil {
+			subj := "character:" + c.ID.String()
+			if loc, locErr := s.worldQuerier.GetLocation(ctx, subj, *c.LocationID); locErr == nil && loc != nil {
+				summary.LastLocation = loc.Name
+			}
 		}
 
 		if sess, ok := sessionByChar[c.ID]; ok {

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -5,6 +5,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -516,6 +517,85 @@ func TestListCharacters_Success(t *testing.T) {
 	require.Len(t, resp.Characters, 1)
 	assert.Equal(t, charID.String(), resp.Characters[0].CharacterId)
 	assert.Equal(t, "Alice", resp.Characters[0].CharacterName)
+	assert.Empty(t, resp.Characters[0].LastLocation, "no worldQuerier = no location name, never expose raw IDs")
+}
+
+func TestListCharacters_ResolvesLocationName(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	charID := ulid.Make()
+	locID := ulid.Make()
+
+	tokenRepo := authmocks.NewMockPlayerTokenRepository(t)
+	tokenRepo.EXPECT().GetByToken(mock.Anything, "valid-token").
+		Return(&auth.PlayerToken{
+			Token:     "valid-token",
+			PlayerID:  playerID,
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+		}, nil)
+
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{
+			{ID: charID, PlayerID: playerID, Name: "Bob", LocationID: &locID},
+		}, nil)
+
+	server := &CoreServer{
+		engine:          core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:    session.NewMemStore(),
+		playerTokenRepo: tokenRepo,
+		charRepo:        charRepo,
+		worldQuerier: &mockWorldQuerier{
+			location: &world.Location{ID: locID, Name: "The Nexus"},
+		},
+	}
+
+	resp, err := server.ListCharacters(ctx, &corev1.ListCharactersRequest{
+		PlayerToken: "valid-token",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Characters, 1)
+	assert.Equal(t, "The Nexus", resp.Characters[0].LastLocation, "should resolve location ID to name")
+}
+
+func TestListCharacters_LocationLookupFailure_OmitsLocation(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	charID := ulid.Make()
+	locID := ulid.Make()
+
+	tokenRepo := authmocks.NewMockPlayerTokenRepository(t)
+	tokenRepo.EXPECT().GetByToken(mock.Anything, "valid-token").
+		Return(&auth.PlayerToken{
+			Token:     "valid-token",
+			PlayerID:  playerID,
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+		}, nil)
+
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{
+			{ID: charID, PlayerID: playerID, Name: "Carol", LocationID: &locID},
+		}, nil)
+
+	server := &CoreServer{
+		engine:          core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:    session.NewMemStore(),
+		playerTokenRepo: tokenRepo,
+		charRepo:        charRepo,
+		worldQuerier: &mockWorldQuerier{
+			locErr: errors.New("db connection failed"),
+		},
+	}
+
+	resp, err := server.ListCharacters(ctx, &corev1.ListCharactersRequest{
+		PlayerToken: "valid-token",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Characters, 1)
+	assert.Empty(t, resp.Characters[0].LastLocation, "should not expose ULID when lookup fails")
 }
 
 // --- RequestPasswordReset ---

--- a/web/src/routes/(authed)/characters/+page.svelte
+++ b/web/src/routes/(authed)/characters/+page.svelte
@@ -127,7 +127,7 @@
             <div class="char-info">
               <span class="char-name">{char.characterName}</span>
               <span class="char-meta">Last played: {formatDate(char.lastPlayedAt)}</span>
-              {#if char.lastLocation}
+              {#if char.lastLocation && !/^[0-9A-Z]{26}$/.test(char.lastLocation)}
                 <span class="char-meta">At: {char.lastLocation}</span>
               {/if}
               {#if char.hasActiveSession}


### PR DESCRIPTION
## Summary

The character picker screen showed raw ULIDs (e.g., `01HZN3XS000000000000000000`) instead of location names like "The Nexus".

## Root Cause

`buildCharacterSummaries` set `LastLocation` to `c.LocationID.String()` — the raw ULID — without resolving it to a name. The `worldQuerier` was available on the `CoreServer` but wasn't being used.

## Fix

Look up the location name via `worldQuerier.GetLocation` using the character's own ABAC subject. If the lookup fails (DB error, missing location), `LastLocation` stays empty — the client's `{#if char.lastLocation}` guard hides it. No internal ID ever reaches the client.

## Tests

| Test | What it proves |
|---|---|
| `TestListCharacters_Success` | Updated: asserts `LastLocation` is empty when no `worldQuerier` |
| `TestListCharacters_ResolvesLocationName` | New: asserts "The Nexus" is returned when location exists |
| `TestListCharacters_LocationLookupFailure_OmitsLocation` | New: asserts empty string when DB lookup fails (no ULID leak) |

## Test plan

- [x] `task test` — all pass
- [x] `task lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character locations now display human-readable location names when available, replacing raw identifiers for improved clarity.

* **Bug Fixes**
  * Fixed display logic to prevent raw location IDs from appearing when location name resolution is unavailable or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->