### PR TITLE
fix(e2e): isolate E2E compose project to avoid port conflicts

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -84,20 +84,21 @@ tasks:
     desc: Run Playwright E2E tests in Docker
     deps: ['docker:build']
     cmds:
-      - docker compose -f compose.yaml -f compose.e2e.yaml run --rm playwright npx playwright test --reporter=line {{.CLI_ARGS}}
-      - defer: docker compose -f compose.yaml -f compose.e2e.yaml down
+      - docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml run --rm playwright npx playwright test --reporter=line
+        {{.CLI_ARGS}}
+      - defer: docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml down
 
   test:e2e:cover:
     desc: Run E2E tests with binary coverage instrumentation
     deps: ['docker:build:cover']
     cmds:
       - mkdir -p .coverdata/core .coverdata/gateway
-      - defer: {docker compose -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml down -v; rm -rf .coverdata;: ''}
+      - defer: {docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml down -v; rm -rf .coverdata;: ''}
       - >-
-        E2E_EXIT=0; docker compose -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml run --rm playwright npx playwright
-        test --reporter=line {{.CLI_ARGS}} || E2E_EXIT=$?; docker compose -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml
-        stop core gateway; go tool covdata textfmt -i=.coverdata/core,.coverdata/gateway -o coverage-e2e.out; echo "E2E coverage
-        written to coverage-e2e.out"; exit $E2E_EXIT #magic___^_^___line
+        E2E_EXIT=0; docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml run --rm
+        playwright npx playwright test --reporter=line {{.CLI_ARGS}} || E2E_EXIT=$?; docker compose -p holomush-e2e -f compose.yaml
+        -f compose.e2e.yaml -f compose.e2e.cover.yaml stop core gateway; go tool covdata textfmt -i=.coverdata/core,.coverdata/gateway
+        -o coverage-e2e.out; echo "E2E coverage written to coverage-e2e.out"; exit $E2E_EXIT #magic___^_^___line
   test:bench:
     desc: Run benchmarks
     cmds:


### PR DESCRIPTION
## Summary
- Add `-p holomush-e2e` to all `docker compose` invocations in `test:e2e` and `test:e2e:cover` tasks
- Prevents container/network/volume collisions when dev stack is running simultaneously
- Integration tests (testcontainers) already use ephemeral ports — no changes needed

## Context
Without a distinct project name, `task test:e2e` and `task dev` both default to the same Docker Compose project (`holomush`), causing conflicts when both are running. The E2E overlay already strips gateway host port bindings (`ports: !reset []`) and postgres never had host port mappings — the missing piece was project-level isolation.

Closes holomush-9sgn

## Test plan
- [ ] Run `task test:e2e` while dev stack is up — should not conflict
- [ ] Run `task test:e2e:cover` — should use isolated project
- [ ] Verify `docker compose -p holomush-e2e ps` shows separate containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test execution with explicit Docker Compose project isolation and enhanced command-line argument handling for better test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->