### PR TITLE
feat(e2e): structured test reports for AI-friendly output

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -84,9 +84,13 @@ tasks:
     desc: Run Playwright E2E tests in Docker
     deps: ['docker:build']
     cmds:
-      - docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml run --rm playwright npx playwright test --reporter=line
-        {{.CLI_ARGS}}
       - defer: docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml down
+      - cmd: |
+          set +e
+          docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml run --rm playwright npx playwright test {{.CLI_ARGS}}
+          E2E_EXIT=$?
+          ./scripts/e2e-summary.sh
+          exit $E2E_EXIT
 
   test:e2e:cover:
     desc: Run E2E tests with binary coverage instrumentation
@@ -94,11 +98,17 @@ tasks:
     cmds:
       - mkdir -p .coverdata/core .coverdata/gateway
       - defer: {docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml down -v; rm -rf .coverdata;: ''}
-      - >-
-        E2E_EXIT=0; docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml run --rm
-        playwright npx playwright test --reporter=line {{.CLI_ARGS}} || E2E_EXIT=$?; docker compose -p holomush-e2e -f compose.yaml
-        -f compose.e2e.yaml -f compose.e2e.cover.yaml stop core gateway; go tool covdata textfmt -i=.coverdata/core,.coverdata/gateway
-        -o coverage-e2e.out; echo "E2E coverage written to coverage-e2e.out"; exit $E2E_EXIT #magic___^_^___line
+      - cmd: |
+          set +e
+          E2E_EXIT=0
+          docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml run --rm \
+            playwright npx playwright test {{.CLI_ARGS}} || E2E_EXIT=$?
+          docker compose -p holomush-e2e -f compose.yaml -f compose.e2e.yaml -f compose.e2e.cover.yaml stop core gateway
+          go tool covdata textfmt -i=.coverdata/core,.coverdata/gateway -o coverage-e2e.out
+          echo "E2E coverage written to coverage-e2e.out"
+          ./scripts/e2e-summary.sh
+          exit $E2E_EXIT
+
   test:bench:
     desc: Run benchmarks
     cmds:

--- a/scripts/e2e-summary.sh
+++ b/scripts/e2e-summary.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Print a compact E2E test summary. Called by test:e2e and test:e2e:cover tasks.
+
+set -euo pipefail
+
+SUMMARY="web/test-results/summary.md"
+
+echo ""
+if [ -f "$SUMMARY" ]; then
+  echo "─── E2E Summary ───────────────────────────────"
+  head -14 "$SUMMARY"
+  echo "────────────────────────────────────────────────"
+  echo "Full report: $SUMMARY"
+  echo "JSON report: web/test-results/report.json"
+else
+  echo "No E2E summary found at $SUMMARY"
+fi

--- a/web/e2e/helpers/fixtures.ts
+++ b/web/e2e/helpers/fixtures.ts
@@ -33,10 +33,33 @@ export async function getClientCharacterName(page: Page): Promise<string | null>
 }
 
 /**
- * Extended test fixture that tears down the DB pool after all tests.
- * Import `test` and `expect` from this module instead of @playwright/test.
+ * Extended test fixture that captures browser console logs and tears down the
+ * DB pool after all tests. Import `test` and `expect` from this module instead
+ * of @playwright/test.
  */
-export const test = base.extend({});
+export const test = base.extend<{ _consoleCapture: void }>({
+  _consoleCapture: [
+    async ({ page }, use, testInfo) => {
+      const logs: string[] = [];
+      page.on('console', (msg) => {
+        logs.push(`[${msg.type()}] ${msg.text()}`);
+      });
+      page.on('pageerror', (err) => {
+        logs.push(`[error] ${err.message}`);
+      });
+
+      await use();
+
+      if (logs.length > 0) {
+        await testInfo.attach('browser-console-logs', {
+          body: logs.join('\n'),
+          contentType: 'text/plain',
+        });
+      }
+    },
+    { auto: true },
+  ],
+});
 
 // Close the shared pool after all workers finish.
 base.afterAll(async () => {

--- a/web/e2e/helpers/summary-reporter.ts
+++ b/web/e2e/helpers/summary-reporter.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+} from '@playwright/test/reporter';
+
+/** Strip ANSI escape sequences so error messages are plain text. */
+function stripAnsi(s: string): string {
+  // Matches CSI sequences (colors, cursor movement) and OSC sequences
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(?:\x07|\x1b\\)/g, '');
+}
+
+interface FailureInfo {
+  title: string;
+  file: string;
+  line: number;
+  duration: number;
+  error: string;
+  attachments: string[];
+  consoleLogs: string | null;
+}
+
+/**
+ * Writes a concise Markdown summary to test-results/summary.md after each run.
+ *
+ * Designed for AI assistants (Claude Code) that need to quickly understand what
+ * passed, what failed, and where to look for details — without grepping stdout.
+ */
+class SummaryReporter implements Reporter {
+  private totalTests = 0;
+  private passed = 0;
+  private failed = 0;
+  private skipped = 0;
+  private timedOut = 0;
+  private failures: FailureInfo[] = [];
+  private startTime = 0;
+  private outputDir = '';
+
+  onBegin(config: FullConfig, suite: Suite) {
+    this.totalTests = suite.allTests().length;
+    this.startTime = Date.now();
+    this.outputDir = config.projects[0]?.outputDir ?? 'test-results';
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    switch (result.status) {
+      case 'passed':
+        this.passed++;
+        break;
+      case 'skipped':
+        this.skipped++;
+        break;
+      case 'timedOut':
+        this.timedOut++;
+        this.recordFailure(test, result, 'timed out');
+        break;
+      case 'failed':
+      case 'interrupted':
+        this.failed++;
+        this.recordFailure(test, result, result.status);
+        break;
+    }
+  }
+
+  private recordFailure(test: TestCase, result: TestResult, reason: string) {
+    const rawError =
+      result.error?.message ?? result.errors?.map((e) => e.message).join('\n') ?? reason;
+    const errorMsg = stripAnsi(rawError);
+
+    const attachments = result.attachments
+      .filter((a) => a.path)
+      .map((a) => {
+        const relPath = path.relative(process.cwd(), a.path!);
+        return `${a.name} (${a.contentType}): ${relPath}`;
+      });
+
+    const consoleLogs =
+      result.attachments.find((a) => a.name === 'browser-console-logs')?.body?.toString() ?? null;
+
+    this.failures.push({
+      title: test.titlePath().slice(1).join(' > '),
+      file: test.location.file.replace(process.cwd() + '/', ''),
+      line: test.location.line,
+      duration: result.duration,
+      error: errorMsg,
+      attachments,
+      consoleLogs,
+    });
+  }
+
+  onEnd(result: FullResult) {
+    const elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1);
+    const allPassed = this.failed === 0 && this.timedOut === 0;
+
+    const lines: string[] = [];
+
+    lines.push(`# E2E Test Summary`);
+    lines.push('');
+    lines.push(`**Result: ${allPassed ? 'PASSED' : 'FAILED'}**`);
+    lines.push('');
+    lines.push(`| Metric | Count |`);
+    lines.push(`|--------|-------|`);
+    lines.push(`| Passed | ${this.passed} |`);
+    lines.push(`| Failed | ${this.failed} |`);
+    lines.push(`| Timed out | ${this.timedOut} |`);
+    lines.push(`| Skipped | ${this.skipped} |`);
+    lines.push(`| Total | ${this.totalTests} |`);
+    lines.push(`| Duration | ${elapsed}s |`);
+
+    if (this.failures.length > 0) {
+      lines.push('');
+      lines.push(`## Failures`);
+
+      for (const f of this.failures) {
+        lines.push('');
+        lines.push(`### ${f.title}`);
+        lines.push('');
+        lines.push(`**Location:** ${f.file}:${f.line}`);
+        lines.push(`**Duration:** ${f.duration}ms`);
+        lines.push('');
+        lines.push('```');
+        lines.push(f.error);
+        lines.push('```');
+
+        if (f.consoleLogs) {
+          lines.push('');
+          lines.push('<details><summary>Browser console logs</summary>');
+          lines.push('');
+          lines.push('```');
+          lines.push(f.consoleLogs);
+          lines.push('```');
+          lines.push('');
+          lines.push('</details>');
+        }
+
+        if (f.attachments.length > 0) {
+          lines.push('');
+          lines.push('**Attachments:**');
+          for (const a of f.attachments) {
+            lines.push(`- ${a}`);
+          }
+        }
+      }
+    }
+
+    if (allPassed) {
+      lines.push('');
+      lines.push(`All ${this.passed} tests passed in ${elapsed}s.`);
+    } else {
+      lines.push('');
+      lines.push(`## Quick reference`);
+      lines.push('');
+      lines.push('Traces (time-travel debug): `npx playwright show-trace <trace.zip>`');
+      lines.push('HTML report: `npx playwright show-report test-results/html`');
+    }
+
+    lines.push('');
+
+    fs.mkdirSync(this.outputDir, { recursive: true });
+    fs.writeFileSync(path.join(this.outputDir, 'summary.md'), lines.join('\n'));
+  }
+}
+
+export default SummaryReporter;

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -6,7 +6,14 @@ export default defineConfig({
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8080",
     headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
   },
+  reporter: [
+    ["line"],
+    ["json", { outputFile: "test-results/report.json" }],
+    ["./e2e/helpers/summary-reporter.ts"],
+  ],
   projects: [
     {
       name: "chromium",


### PR DESCRIPTION
## Summary

- Add custom Playwright summary reporter that writes `web/test-results/summary.md` with pass/fail table, per-failure error messages (ANSI-stripped), screenshot/trace paths, and browser console logs
- Configure `screenshot: 'only-on-failure'` and `trace: 'retain-on-failure'` in Playwright config for automatic failure context capture
- Add `_consoleCapture` auto-fixture to capture browser `console.*` and `pageerror` events as test attachments
- Add JSON reporter output to `web/test-results/report.json` for structured programmatic access
- Centralize E2E summary printing via `scripts/e2e-summary.sh` shared by both `test:e2e` and `test:e2e:cover`
- Fix exit code handling so summary prints even when tests fail

### Before
```
Bash(task test:e2e 2>&1 | grep -E "passed|failed|DONE|FAIL|error" | head -10)
Bash(task test:e2e 2>&1 | grep -E "^\s+\d+ (passed|failed)" | head -5)
```
Multiple lossy grep rounds to understand what happened.

### After
```
Bash(task test:e2e)                   → check exit code
Read(web/test-results/summary.md)     → structured failure details
```
One call to run, one to understand.

## Test plan

- [x] `task test:e2e` runs successfully, summary prints to stdout on both pass and failure
- [x] `web/test-results/summary.md` contains clean (ANSI-stripped) error messages with file:line locations
- [x] `web/test-results/report.json` contains full structured test data
- [x] Screenshots and traces saved to `web/test-results/<test-name>/` on failure
- [ ] `task test:e2e:cover` also prints summary (same shared script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)