### PR TITLE
fix(build): make clean build work when node_modules is missing

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -209,6 +209,11 @@ tasks:
     sources:
       - web/package.json
       - web/pnpm-lock.yaml
+    preconditions:
+      - sh: command -v pnpm
+        msg: "pnpm not found. Install with: npm install -g pnpm"
+    status:
+      - test -d node_modules/.pnpm
 
   web:generate:
     desc: Generate TypeScript ConnectRPC clients from proto
@@ -530,3 +535,5 @@ tasks:
       - rm -rf dist/
       - rm -f {{.BINARY_NAME}}
       - rm -f coverage.out coverage.html
+      - rm -rf web/build
+      - rm -rf internal/web/dist


### PR DESCRIPTION
## Summary

- Add `status` check to `web:install` task so it re-runs `pnpm install` when `node_modules/.pnpm` is missing (e.g., after `task clean` or manual deletion)
- Extend `task clean` to remove `web/build/` and `internal/web/dist/` so the full web build chain reruns from scratch
- Add `preconditions` check for `pnpm` binary availability

Previously, Task's fingerprint-based caching on `sources` considered `web:install` up-to-date based solely on `package.json`/`pnpm-lock.yaml`, even when `node_modules/` was gone. This caused `task clean build` and `task dev` to fail with `Cannot find package '@tailwindcss/vite'`.

## Test plan

- [ ] `task clean build` succeeds from scratch
- [ ] `task build` (repeat) skips `web:install` ("up to date")
- [ ] `rm -rf web/node_modules && task build` re-runs `pnpm install` automatically
- [ ] `task dev` works after `task dev:clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>