### PR TITLE
feat(abac): plugin ABAC hardening — eliminate __preflight__ + load-time schema validation

### DIFF
--- a/docs/specs/2026-03-28-site-redesign.md
+++ b/docs/specs/2026-03-28-site-redesign.md
@@ -523,7 +523,7 @@ be decided before writing any content.
 
 - [ ] Landing page renders with hero, features, coming soon, choose your path
 - [ ] All five sections (guide, operating, extending, contributing, reference)
-      have index pages with working links
+  have index pages with working links
 - [ ] Zero dead links across the entire site
 - [ ] Zero instances of "room" used as a spatial concept in documentation
 - [ ] All diagrams render as Mermaid (no ASCII art)

--- a/docs/specs/abac/08-testing-appendices.md
+++ b/docs/specs/abac/08-testing-appendices.md
@@ -185,9 +185,9 @@ grows.
 - [ ] Property model designed as first-class entities
 - [ ] Direct replacement of StaticAccessControl documented (no adapter)
 - [ ] Microbenchmarks (pure evaluator, no I/O): single-policy <10μs,
-      50-policy set <100μs, attribute resolution <50μs (via `go test -bench`)
+  50-policy set <100μs, attribute resolution <50μs (via `go test -bench`)
 - [ ] Integration benchmarks (with real providers): `Evaluate()` p99 <10ms cached,
-      <25ms cold, matching the performance targets in the spec
+  <25ms cold, matching the performance targets in the spec
 - [ ] Cache invalidation via LISTEN/NOTIFY reloads policies on change
 - [ ] System subject bypass returns allow without policy evaluation
 - [ ] Subject type prefix-to-DSL-type mapping documented

--- a/docs/superpowers/plans/2026-04-04-test-suite-review.md
+++ b/docs/superpowers/plans/2026-04-04-test-suite-review.md
@@ -84,13 +84,13 @@ See the spec for full content of each section:
 `docs/superpowers/specs/2026-04-04-test-suite-review-design.md`
 
 - [ ] **Step 1:** Add "Test Naming" section (after "Test Files", before "Table-Driven Tests") —
-    ACE framework, good/bad examples table, subtest example, requirements table.
+  ACE framework, good/bad examples table, subtest example, requirements table.
 
 - [ ] **Step 2:** Update "Table-Driven Tests" example — sentence-style subtest names,
-    testify assertions instead of `t.Errorf`.
+  testify assertions instead of `t.Errorf`.
 
 - [ ] **Step 3:** Add "Test Quality" section (after "Assertions", before "Mocking with Mockery") —
-    five requirements covering both-path testing, assertion quality, focus, error codes.
+  five requirements covering both-path testing, assertion quality, focus, error codes.
 
 - [ ] **Step 4:** Run `task fmt` to verify formatting.
 

--- a/docs/superpowers/plans/2026-04-07-plugin-abac-hardening.md
+++ b/docs/superpowers/plans/2026-04-07-plugin-abac-hardening.md
@@ -1,0 +1,2863 @@
+# Plugin ABAC Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the plugin ABAC trust boundary (PR #195) by eliminating the synthetic `__preflight__` resource ID from the host/engine path and promoting load-time policy/schema cross-validation from a warning to a fatal load error.
+
+**Architecture:** Two surgical host-side changes, no proto/SDK/plugin-binary churn. (A) Add `Resolver.ResolveSubjectAttributes` that resolves subject+environment+action but never calls resource providers; switch `engine.CanPerformAction` to use it and delete the `__preflight__` literal. (B) Extract `ValidateManifestPolicySchemas` from `CheckManifestWarnings` Warning 3, wire it into `Manager.loadPlugin` as a hard-failure step that runs before policy install.
+
+**Tech Stack:** Go 1.22+, `testify` (assert/require), Ginkgo/Gomega (integration), `oops` (error wrapping), Prometheus client, testcontainers-go (PostgreSQL).
+
+**Spec:** `docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md`
+**Bead:** holomush-479l
+**Blocks:** holomush-0sc.12 (channel plugin rework)
+
+---
+
+## Conventions for all tasks
+
+**VCS:** This repo is a colocated jj repo. All commits use `jj commit -m "..."` (not `git commit`). Run from the workspace at `/Users/sean/Code/github.com/holomush/.worktrees/plugin-abac-hardening`.
+
+**Test runner:** All Go tests run via `task`, never `go test` directly. See CLAUDE.md.
+
+**Commit messages:** Conventional commits (`type(scope): description`). Include the footer:
+
+```text
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+**SPDX headers:** New `.go` files MUST start with:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+```
+
+**Test naming:** ACE framework — every top-level `TestXxx` name is a full sentence describing action, condition, expectation. Example: `TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment`.
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `internal/plugin/policy_schema_validator.go` | `ValidateManifestPolicySchemas` function extracted from `manifest_warnings.go` |
+| `internal/plugin/policy_schema_validator_test.go` | Unit tests for the validator (T8-T12, T25-T31) |
+| `internal/access/policy/hardening_invariants_test.go` | Static/meta tests (T32, T33) |
+| `test/integration/plugin/counting_proxy_test.go` | Counting proxy wrapper for `AttributeResolverServiceClient` (build tag `integration`) |
+| `site/docs/extending/abac-attribute-resolver.md` | Plugin author documentation page |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `internal/access/policy/attribute/resolver.go` | +`ResolveSubjectAttributes` method (~35 lines) |
+| `internal/access/policy/attribute/resolver_test.go` | +11 tests (T1-T4, T16-T21, T39) |
+| `internal/access/policy/engine.go` | Rewrite `CanPerformAction` step 4; delete `__preflight__` literal; update doc comment |
+| `internal/access/policy/engine_test.go` | +6 tests (T5, T6, T7, T22, T23, T24) |
+| `internal/plugin/manifest_warnings.go` | Remove Warning 3 case from `CheckManifestWarnings` |
+| `internal/plugin/manifest_warnings_test.go` | Remove tests that asserted Warning 3's output |
+| `internal/plugin/manager.go` | Call `ValidateManifestPolicySchemas` before `InstallPluginPoliciesWithManifest`, with rollback |
+| `test/integration/plugin/abac_widget_test.go` | +8 specs (T13-T15, T34-T38) |
+| `plugins/test-abac-widget/main.go` | Rewrite lines 58-67 comment; add `widgetResolver` doc comment |
+| `pkg/plugin/service.go` | Update `AttributeResolverProvider` doc comment |
+| `docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md` | Append `## Hardening (2026-04-07)` section |
+
+---
+
+## Task 1: Add Resolver.ResolveSubjectAttributes — happy path
+
+**Files:**
+
+- Modify: `internal/access/policy/attribute/resolver.go` (+method ~35 lines)
+- Modify: `internal/access/policy/attribute/resolver_test.go` (+T1, ~40 lines)
+
+- [ ] **Step 1: Write the failing test T1**
+
+Append to `internal/access/policy/attribute/resolver_test.go`:
+
+```go
+func TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Subject provider returns {role: "admin"} for character:01ABC.
+	subjectProvider := newResolverMockAttributeProvider("character")
+	subjectProvider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(subjectProvider))
+
+	// Environment provider returns {hour: 14}.
+	envProvider := &mockEnvironmentProvider{
+		namespace: "env",
+		attrs:     map[string]any{"hour": 14},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{"hour": types.AttrTypeFloat},
+		},
+	}
+	require.NoError(t, resolver.RegisterEnvironmentProvider(envProvider))
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.NoError(t, err)
+	require.NotNil(t, bags)
+
+	assert.Equal(t, "admin", bags.Subject["character.role"])
+	assert.Equal(t, 14, bags.Environment["env.hour"])
+	assert.Equal(t, "read", bags.Action["name"])
+	assert.Empty(t, bags.Resource, "resource bag must be empty at preflight")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test -- -run TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment ./internal/access/policy/attribute/`
+Expected: FAIL with "resolver.ResolveSubjectAttributes undefined"
+
+- [ ] **Step 3: Implement the method in resolver.go**
+
+Append to `internal/access/policy/attribute/resolver.go` (after the `Resolve` method, around line 156):
+
+```go
+// ResolveSubjectAttributes resolves subject, action, and environment attributes
+// for a type-level capability check (preflight). It never calls resource
+// providers, which makes it safe to use when no resource instance is available.
+//
+// Returns AttributeBags with Subject/Action/Environment populated and Resource
+// empty. Error semantics match Resolve: partial success returns both bags and
+// error; callers MUST fail closed on non-nil error and MUST NOT use partial
+// bags for policy evaluation.
+func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action string) (*types.AttributeBags, error) {
+	// Check re-entrance guard (shared with Resolve).
+	if isInResolution(ctx) {
+		panic("resolver re-entrance detected: resolver cannot be called recursively")
+	}
+
+	// Mark as in resolution and attach request-scoped cache.
+	ctx = markInResolution(ctx)
+	ctx = withCache(ctx)
+
+	bags := &types.AttributeBags{
+		Subject:     make(map[string]any),
+		Resource:    make(map[string]any),
+		Action:      make(map[string]any),
+		Environment: make(map[string]any),
+	}
+
+	// Set action name — matches Resolve's contract for bags.Action.
+	bags.Action["name"] = action
+
+	var errs []error
+
+	// Resolve subject attributes. Empty subject is invalid here — preflight
+	// requires a valid principal. Resolve tolerates empty subjects (they
+	// simply skip the subject resolution step), but for a type-level
+	// capability check we always have a subject and should reject the
+	// malformed case explicitly.
+	if subject == "" {
+		return bags, oops.Code("INVALID_ENTITY_REF").
+			With("field", "subject").
+			Errorf("subject is required for ResolveSubjectAttributes")
+	}
+	if err := validateEntityRef(subject); err != nil {
+		errs = append(errs, oops.With("field", "subject").Wrap(err))
+	} else if err := r.resolveEntity(ctx, "subject", subject, bags.Subject); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Resolve environment attributes.
+	if err := r.resolveEnvironment(ctx, bags.Environment); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Resource providers are intentionally NOT called. The optimistic-permit
+	// branch in engine.CanPerformAction handles permits whose conditions
+	// reference resource attributes.
+
+	return bags, errors.Join(errs...)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `task test -- -run TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment ./internal/access/policy/attribute/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+feat(abac): add Resolver.ResolveSubjectAttributes method
+
+Adds a new entry point on the attribute Resolver that resolves only
+subject, environment, and action attributes. Resource providers are
+never invoked — this is the foundation for eliminating the synthetic
+__preflight__ resource ID used by engine.CanPerformAction.
+
+Part of plugin ABAC hardening (holomush-479l, spec
+docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Resolver.ResolveSubjectAttributes — error and edge case tests
+
+**Files:**
+
+- Modify: `internal/access/policy/attribute/resolver_test.go` (+T2, T3, T4, T16, T17, T18)
+
+- [ ] **Step 1: Add test T2 (invalid subject ref)**
+
+Append to `internal/access/policy/attribute/resolver_test.go`:
+
+```go
+func TestResolverResolveSubjectAttributesReturnsErrorForInvalidSubjectRef(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "malformed", "read")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid entity ref format")
+	assert.NotNil(t, bags, "bags should be non-nil even on error (matches Resolve contract)")
+}
+```
+
+- [ ] **Step 2: Add test T3 (provider error propagates)**
+
+```go
+func TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectProviderFails(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectError = errors.New("database unavailable")
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
+}
+```
+
+- [ ] **Step 3: Add test T4 (resource provider NEVER called)**
+
+```go
+func TestResolverResolveSubjectAttributesDoesNotInvokeResourceProviderWhenResourceProviderExists(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Subject provider that contributes the subject bag.
+	subjectProvider := newResolverMockAttributeProvider("character")
+	subjectProvider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(subjectProvider))
+
+	// Resource provider in a different namespace. Its ResolveResource
+	// increments a per-key counter; we will assert no counter increments
+	// under the "resource:" key prefix.
+	resourceProvider := newResolverMockAttributeProvider("widget")
+	require.NoError(t, resolver.RegisterProvider(resourceProvider))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.NoError(t, err)
+
+	// The widget provider's resource-call counter MUST be empty. The shared
+	// mock uses callCount["resource:"+resourceID] as the call key.
+	for key := range resourceProvider.callCount {
+		if len(key) >= len("resource:") && key[:len("resource:")] == "resource:" {
+			t.Errorf("resource provider was called during ResolveSubjectAttributes: %s", key)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Add test T16 (empty subject)**
+
+```go
+func TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectIsEmpty(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "", "read")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject is required")
+}
+```
+
+- [ ] **Step 5: Add test T17 (empty action permitted)**
+
+```go
+func TestResolverResolveSubjectAttributesPopulatesActionNameEvenWhenEmpty(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "")
+	require.NoError(t, err)
+	assert.Equal(t, "", bags.Action["name"])
+}
+```
+
+- [ ] **Step 6: Add test T18 (context cancellation)**
+
+```go
+func TestResolverResolveSubjectAttributesReturnsErrorWhenContextAlreadyCancelled(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The resolver does not currently short-circuit on context cancellation
+	// at its top level — providers are expected to honor ctx.Err(). For
+	// the preflight path, we assert that a pre-cancelled context either
+	// returns an error or produces an empty bag (provider-dependent).
+	// The existing mock provider does not check ctx.Err(), so we verify
+	// the behavior by using a provider that does.
+	cancelAware := &ctxAwareSubjectProvider{}
+	registry2 := NewSchemaRegistry()
+	resolver2 := NewResolver(registry2)
+	require.NoError(t, resolver2.RegisterProvider(cancelAware))
+
+	_, err := resolver2.ResolveSubjectAttributes(ctx, "character:01ABC", "read")
+	require.Error(t, err, "cancelled context must produce an error via context-aware provider")
+	assert.True(t, errors.Is(err, context.Canceled) || err.Error() != "",
+		"error should reference context cancellation")
+}
+
+// ctxAwareSubjectProvider honors context cancellation in ResolveSubject.
+type ctxAwareSubjectProvider struct{}
+
+func (p *ctxAwareSubjectProvider) Namespace() string { return "character" }
+
+func (p *ctxAwareSubjectProvider) ResolveSubject(ctx context.Context, _ string) (map[string]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *ctxAwareSubjectProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *ctxAwareSubjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
+	}
+}
+```
+
+- [ ] **Step 7: Run all new tests**
+
+Run: `task test -- -run "TestResolverResolveSubjectAttributes" ./internal/access/policy/attribute/`
+Expected: PASS for all 6 new tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): edge case tests for ResolveSubjectAttributes
+
+Adds coverage for invalid subject refs, provider errors, the
+resource-provider-never-called invariant (T4), empty subject rejection,
+empty action acceptance, and context cancellation propagation via a
+context-aware provider.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Resolver.ResolveSubjectAttributes — panic, re-entrance, cross-check, concurrency
+
+**Files:**
+
+- Modify: `internal/access/policy/attribute/resolver_test.go` (+T19, T20, T21, T33, T39)
+
+- [ ] **Step 1: Add T19 (panic recovery)**
+
+```go
+func TestResolverResolveSubjectAttributesRecoversFromPanickingProvider(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.shouldPanic = true
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.Error(t, err, "panic must be recovered and returned as error")
+	assert.Contains(t, err.Error(), "panicked")
+}
+```
+
+- [ ] **Step 2: Add T20 (re-entrance detection)**
+
+```go
+func TestResolverResolveSubjectAttributesPanicsOnReentrance(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Provider that re-calls the resolver from inside ResolveSubject.
+	reentrant := &reentrantSubjectProvider{resolver: resolver}
+	require.NoError(t, resolver.RegisterProvider(reentrant))
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			// Panic recovered by safeResolve → surfaced as error, not panic.
+			// Either outcome is acceptable; the invariant is that the
+			// resolver does not infinite-loop.
+			return
+		}
+	}()
+
+	_, _ = resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+}
+
+type reentrantSubjectProvider struct {
+	resolver *Resolver
+}
+
+func (p *reentrantSubjectProvider) Namespace() string { return "character" }
+
+func (p *reentrantSubjectProvider) ResolveSubject(ctx context.Context, _ string) (map[string]any, error) {
+	// Re-entrance — the resolver MUST detect this via markInResolution.
+	_, _ = p.resolver.ResolveSubjectAttributes(ctx, "character:02XYZ", "read")
+	return nil, nil
+}
+
+func (p *reentrantSubjectProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *reentrantSubjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
+	}
+}
+```
+
+- [ ] **Step 3: Add T21 (cross-check with Resolve for same input)**
+
+```go
+func TestResolverResolveSubjectAttributesProducesSameSubjectBagAsResolveForSameInput(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	// Also give the provider a resource instance so Resolve has something to
+	// return without errors. ResolveSubjectAttributes will ignore this.
+	provider.resourceData["widget:test-id"] = map[string]any{"role": "ignored"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	// Call ResolveSubjectAttributes.
+	preflightBags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.NoError(t, err)
+
+	// Call Resolve with an access request that includes a resource.
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "widget:test-id",
+	}
+	fullBags, err := resolver.Resolve(context.Background(), req)
+	require.NoError(t, err)
+
+	// Subject bags MUST be identical between the two paths.
+	assert.Equal(t, fullBags.Subject, preflightBags.Subject,
+		"ResolveSubjectAttributes and Resolve must produce identical Subject bags for the same (subject, action)")
+	// Action names MUST match.
+	assert.Equal(t, fullBags.Action["name"], preflightBags.Action["name"])
+}
+```
+
+- [ ] **Step 4: Add T33 (cross-check invariant re-stated at file level)**
+
+T33 is the cross-file counterpart to T21 but with the full provider set. For the unit test tier, T21 covers it adequately at this layer — T33 in the spec refers to integration-level coverage using real providers (character provider + env provider from core). T33 will land as part of the integration test task (Task 9).
+
+Note: This step adds no code — it's a documentation step. Mark this step as complete and move to Step 5.
+
+- [ ] **Step 5: Add T39 (concurrency smoke test)**
+
+```go
+func TestResolverResolveSubjectAttributesIsSafeForConcurrentCalls(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	for i := 0; i < 100; i++ {
+		provider.subjectData[fmt.Sprintf("character:%03d", i)] = map[string]any{"role": "admin"}
+	}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			subject := fmt.Sprintf("character:%03d", n)
+			bags, err := resolver.ResolveSubjectAttributes(context.Background(), subject, "read")
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if bags.Subject["character.role"] != "admin" {
+				errCh <- fmt.Errorf("subject bag mismatch for %s", subject)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent ResolveSubjectAttributes error: %v", err)
+	}
+}
+```
+
+Note: this test requires adding `"fmt"` and `"sync"` imports to `resolver_test.go` if they are not already present. Check the existing import block and add them if missing.
+
+- [ ] **Step 6: Run all new tests with race detector**
+
+Run: `task test -- -race -run "TestResolverResolveSubjectAttributes" ./internal/access/policy/attribute/`
+Expected: PASS for all tests, no data races detected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): panic, re-entrance, cross-check, and concurrency tests for ResolveSubjectAttributes
+
+Completes unit test coverage for the subject-only resolution path:
+panic recovery via safeResolve, re-entrance detection, subject-bag
+equivalence with Resolve, and concurrent-safety smoke test with
+-race.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Engine.CanPerformAction — wire to ResolveSubjectAttributes
+
+**Files:**
+
+- Modify: `internal/access/policy/engine.go` (rewrite step 4 of `CanPerformAction`, delete `__preflight__` literal, update doc comment)
+- Modify: `internal/access/policy/engine_test.go` (+T5, T6, T7)
+
+- [ ] **Step 1: Write failing test T5 (engine does not invoke resource providers)**
+
+Append to `internal/access/policy/engine_test.go`:
+
+```go
+func TestEngineCanPerformActionDoesNotInvokeResourceProvidersWhenCapabilityCheckRuns(t *testing.T) {
+	// Build an engine with a resolver that has BOTH a subject provider and
+	// a resource provider registered. The resource provider uses a tracking
+	// type local to this test file. Assert its resourceCalls counter stays
+	// at zero during CanPerformAction.
+	dslText := `permit(principal is character, action in ["read"], resource is widget);`
+
+	widgetSchema := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+	}
+	widgetProv := &trackingAttrProvider{namespace: "widget", schema: widgetSchema}
+
+	engine := createTestEngineWithPolicies(t, []string{dslText}, []attribute.AttributeProvider{widgetProv})
+
+	_, err := engine.CanPerformAction(context.Background(), "character:01ABC", "read", "widget", "")
+	// The call's allowed/denied outcome is orthogonal to the invariant
+	// under test. We only care that the resource provider was not touched.
+	_ = err
+
+	assert.Equal(t, 0, widgetProv.resourceCalls,
+		"widget resource provider must not be called during CanPerformAction")
+}
+
+// trackingAttrProvider counts calls separately for subject and resource.
+// It lives in engine_test.go because T5 is the first test that needs it;
+// if other tests need the pattern later, it can be reused.
+type trackingAttrProvider struct {
+	namespace     string
+	subjectAttrs  map[string]any
+	resourceAttrs map[string]any
+	schema        *types.NamespaceSchema
+	subjectCalls  int
+	resourceCalls int
+}
+
+func (p *trackingAttrProvider) Namespace() string { return p.namespace }
+
+func (p *trackingAttrProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	p.subjectCalls++
+	return p.subjectAttrs, nil
+}
+
+func (p *trackingAttrProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	p.resourceCalls++
+	return p.resourceAttrs, nil
+}
+
+func (p *trackingAttrProvider) Schema() *types.NamespaceSchema { return p.schema }
+```
+
+- [ ] **Step 2: Run the test to verify it currently FAILS**
+
+Run: `task test -- -run TestEngineCanPerformActionDoesNotInvokeResourceProvidersWhenCapabilityCheckRuns ./internal/access/policy/`
+Expected: FAIL — current `CanPerformAction` constructs `widget:__preflight__` and calls `Resolve`, which WILL invoke the widget resource provider. `widgetProv.resourceCalls` will be 1, not 0. The failure message will show `1 != 0`.
+
+- [ ] **Step 3: Modify engine.go CanPerformAction step 4**
+
+Open `internal/access/policy/engine.go`. Find the existing step 4 block (around line 398-418):
+
+```go
+	// Step 4: Resolve subject attributes via a synthetic request.
+	// The resource uses resourceType+":__preflight__" to satisfy resolver format
+	// requirements without needing a real resource instance.
+	syntheticReq, reqErr := types.NewAccessRequest(subject, action, resourceType+":__preflight__")
+	if reqErr != nil {
+		return false, oops.With("subject", subject).With("action", action).With("resourceType", resourceType).Wrap(reqErr)
+	}
+	bags, resolveErr := e.resolver.Resolve(ctx, syntheticReq)
+	if resolveErr != nil {
+		errutil.LogErrorContext(ctx, "CanPerformAction: attribute resolution failed — fail-closed",
+			resolveErr,
+			"subject", subject,
+			"action", action,
+			"resourceType", resourceType,
+		)
+		return false, oops.
+			With("subject", subject).
+			With("action", action).
+			With("resourceType", resourceType).
+			Wrap(resolveErr)
+	}
+```
+
+Replace with:
+
+```go
+	// Step 4: Resolve subject + environment attributes only. No resource
+	// instance exists at type-level preflight; resource providers are
+	// never called. The optimistic-permit branch below handles permits
+	// whose conditions reference resource attributes.
+	bags, resolveErr := e.resolver.ResolveSubjectAttributes(ctx, subject, action)
+	if resolveErr != nil {
+		errutil.LogErrorContext(ctx, "CanPerformAction: attribute resolution failed — fail-closed",
+			resolveErr,
+			"subject", subject,
+			"action", action,
+			"resourceType", resourceType,
+		)
+		return false, oops.
+			With("subject", subject).
+			With("action", action).
+			With("resourceType", resourceType).
+			Wrap(resolveErr)
+	}
+```
+
+- [ ] **Step 4: Update CanPerformAction doc comment**
+
+In `internal/access/policy/engine.go`, find the doc comment above `CanPerformAction` (around lines 367-377). The existing comment mentions "synthetic request" — replace the line:
+
+```go
+// Resolves subject attributes via a synthetic request with resourceType+":__preflight__"
+```
+
+with:
+
+```go
+// Resolves only subject, environment, and action attributes via
+// ResolveSubjectAttributes. Plugin resource providers are NEVER invoked
+// during preflight. Policies whose conditions reference resource attributes
+// are handled via the optimistic-permit branch below.
+```
+
+If the existing doc comment does not contain a "synthetic request" line verbatim, read lines 360-380 and rewrite the whole comment to reflect the new behavior. The key property to document: resource providers are not called, instance-level Evaluate handles the full condition.
+
+- [ ] **Step 5: Run T5 to verify it passes**
+
+Run: `task test -- -run TestEngineCanPerformActionDoesNotInvokeResourceProvidersWhenCapabilityCheckRuns ./internal/access/policy/`
+Expected: PASS
+
+- [ ] **Step 6: Run the full engine test package to catch regressions**
+
+Run: `task test -- ./internal/access/policy/`
+Expected: PASS for all existing tests. If any existing test was asserting on `__preflight__` or on the old behavior, it needs to be updated — investigate and fix in the same task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+refactor(abac): engine CanPerformAction uses ResolveSubjectAttributes
+
+Replaces the synthetic <type>:__preflight__ resource ID construction
+with a call to Resolver.ResolveSubjectAttributes. Plugin resource
+providers are no longer invoked during type-level capability pre-flight.
+
+The optimistic-permit branch (step 7) is unchanged — it already handles
+permits whose conditions reference resource attributes by treating them
+as "may apply, instance-level Evaluate will enforce the full condition."
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Engine.CanPerformAction — optimistic permit branch test (T6)
+
+**Files:**
+
+- Modify: `internal/access/policy/engine_test.go` (+T6 only)
+
+**Pre-existing coverage (NO new tests needed):** Self-review found that T7, T22, T23, and T24 from the design spec are already implemented in `internal/access/policy/engine_test.go`:
+
+| Planned test | Existing test | Line |
+|---|---|---|
+| T7 (fail closed on resolver error) | `TestEngineCanPerformActionAttributeResolutionError` | 2017 |
+| T22 (degraded mode short-circuit) | `TestEngineCanPerformActionDegradedMode` | 1946 |
+| T23 (context cancellation) | `TestEngineCanPerformActionContextCancelled` | 1956 |
+| T24 (malformed subject) | `TestEngine_CanPerformAction_InvalidSubjectFormat` | 1991 |
+
+These tests implicitly validate that the C1 refactor did not regress any of the invariants they cover. Running them after Task 4's refactor is sufficient — no new tests needed. Add NOTHING for T7/T22/T23/T24.
+
+**T6 is genuinely new** — no existing test covers the optimistic-permit branch for permits whose conditions reference resource attributes.
+
+- [ ] **Step 1: Add T6 (optimistic permit branch fires for permit referencing resource attrs)**
+
+This uses the existing `createTestEngineWithPolicies(t, dslStrings, providers)` helper in `engine_test.go`. That helper parses and installs the DSL policies into a fresh engine with a real compiler + cache. Pattern borrowed from `TestEngineCanPerformActionAdminPermitted` at line 1906.
+
+Append to `internal/access/policy/engine_test.go`:
+
+```go
+func TestEngineCanPerformActionPermitsOptimisticallyForPermitReferencingResourceAttrs(t *testing.T) {
+	// The optimistic-permit branch fires when a permit policy's conditions
+	// reference resource attributes that can't be evaluated at type-level
+	// pre-flight (no resource instance exists). The engine MUST treat such
+	// permits as potentially-applicable and return allowed=true — the
+	// handler's instance-level Evaluate will enforce the full condition.
+	//
+	// This test proves that switching to ResolveSubjectAttributes does not
+	// regress this behavior. Before the refactor, the optimistic branch
+	// worked because the synthetic "__preflight__" resource had an empty
+	// attribute bag; after the refactor, it works because ResolveSubjectAttributes
+	// returns an empty Resource bag by construction.
+	dslText := `permit(principal is character, action in ["read"], resource is widget) when { resource.widget.type == "normal" };`
+
+	engine := createTestEngineWithPolicies(t, []string{dslText}, nil)
+
+	allowed, err := engine.CanPerformAction(context.Background(), "character:01ABC", "read", "widget", "")
+	require.NoError(t, err)
+	assert.True(t, allowed,
+		"permit policy referencing resource attrs must optimistic-permit at preflight")
+}
+```
+
+- [ ] **Step 2: Run T6**
+
+Run: `task test -- -run TestEngineCanPerformActionPermitsOptimisticallyForPermitReferencingResourceAttrs ./internal/access/policy/`
+Expected: PASS
+
+- [ ] **Step 3: Run all pre-existing CanPerformAction tests as regression coverage**
+
+The refactor in Task 4 must not have regressed any of these. Running them explicitly provides the T7/T22/T23/T24 coverage without writing new tests:
+
+Run: `task test -- -run "TestEngineCanPerformAction|TestEngine_CanPerformAction" ./internal/access/policy/`
+Expected: PASS for ALL existing tests including:
+
+- `TestEngineCanPerformActionAdminPermitted`
+- `TestEngineCanPerformActionNoMatchingPolicy`
+- `TestEngineCanPerformActionForbidOverridesPermit`
+- `TestEngineCanPerformActionDegradedMode` (covers T22)
+- `TestEngineCanPerformActionContextCancelled` (covers T23)
+- `TestEngineCanPerformActionUnconditionalPermit`
+- `TestEngineCanPerformActionExactResourcePolicySkipped`
+- `TestEngine_CanPerformAction_InvalidSubjectFormat` (covers T24)
+- `TestEngineCanPerformActionAttributeResolutionError` (covers T7)
+- `TestEngineCanPerformActionPrincipalTypeMismatch`
+- `TestEngineCanPerformActionActionMismatch`
+- `TestEngineCanPerformActionResourceTypeMismatch`
+- `TestEngineCanPerformActionNilCompiledPolicySkipped`
+- `TestEngineCanPerformActionConditionUnsatisfied`
+
+If ANY of these fail after the Task 4 refactor, stop and debug — that's a regression the design said would not happen, and the plan is wrong about something.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): optimistic permit branch test for hardened CanPerformAction
+
+Adds T6: asserts that CanPerformAction returns allowed=true for a
+permit policy whose condition references resource.widget.type, via the
+optimistic-permit branch. Proves the switch to ResolveSubjectAttributes
+does not regress the type-level preflight semantics for policies that
+reference resource attrs.
+
+T7, T22, T23, T24 from the design spec are already covered by existing
+tests (TestEngineCanPerformActionAttributeResolutionError, ...Degraded,
+...ContextCancelled, TestEngine_CanPerformAction_InvalidSubjectFormat)
+and need no new code — the Task 4 refactor passing those existing tests
+IS the coverage.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Static invariant test — no `__preflight__` in engine.go (T32)
+
+**Files:**
+
+- Create: `internal/access/policy/hardening_invariants_test.go`
+
+- [ ] **Step 1: Create the new test file**
+
+Create `internal/access/policy/hardening_invariants_test.go` with the following content:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel is a
+// static assertion that the legacy synthetic preflight sentinel has been
+// removed from the engine. The Plugin ABAC Hardening spec (2026-04-07)
+// requires this literal to be deleted from engine.go — not filtered —
+// because the invariant "plugin providers never see synthetic IDs" is
+// enforced by construction, not by runtime filtering.
+//
+// If this test fails, somebody has re-introduced the synthetic preflight
+// path. Read docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
+// for the rationale before suppressing this test.
+func TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel(t *testing.T) {
+	data, err := os.ReadFile("engine.go")
+	if err != nil {
+		t.Fatalf("failed to read engine.go: %v", err)
+	}
+	if strings.Contains(string(data), "__preflight__") {
+		t.Errorf("engine.go contains the synthetic preflight sentinel " +
+			"'__preflight__'. This literal was removed in the Plugin ABAC " +
+			"Hardening work (spec 2026-04-07). If you need to re-introduce " +
+			"preflight-aware behavior, read the spec first.")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `task test -- -run TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel ./internal/access/policy/`
+Expected: PASS (engine.go no longer contains `__preflight__` after Task 4).
+
+- [ ] **Step 3: Verify the test would fail if the sentinel came back**
+
+Temporarily add the string to a comment in `engine.go`:
+
+```go
+// TEMP: __preflight__
+```
+
+Run the test: expect FAIL.
+Remove the temporary comment.
+Run the test: expect PASS.
+This manual step verifies the test is actually wired correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): static invariant — engine.go does not contain __preflight__
+
+Adds a dedicated hardening_invariants_test.go file with a grep-style
+test that asserts the legacy synthetic preflight sentinel has been
+removed from engine.go. Prevents accidental regression.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Extract ValidateManifestPolicySchemas — core function + happy path
+
+**Files:**
+
+- Create: `internal/plugin/policy_schema_validator.go`
+- Create: `internal/plugin/policy_schema_validator_test.go`
+
+- [ ] **Step 1: Create the test file with T8 (the core fail-closed test)**
+
+Create `internal/plugin/policy_schema_validator_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+func TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSchema(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		Version:       "1.0.0",
+		Type:          plugins.TypeBinary,
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-read-normal",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.tipe == "normal" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tipe")
+	assert.Contains(t, err.Error(), "widget-read-normal")
+	assert.Contains(t, err.Error(), "widget")
+	assert.Contains(t, err.Error(), "not in the declared schema")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test -- -run TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSchema ./internal/plugin/`
+Expected: FAIL with "undefined: plugins.ValidateManifestPolicySchemas"
+
+- [ ] **Step 3: Create the validator file with the extracted function**
+
+Create `internal/plugin/policy_schema_validator.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// ValidateManifestPolicySchemas verifies that every attribute reference in
+// each manifest policy's DSL exists in the plugin's declared schema for the
+// policy's resource type. Returns a non-nil error on the first mismatch so
+// the plugin load fails before any policy is installed.
+//
+// schemas is the schema map discovered via GetSchema during plugin load.
+// Plugins without resource_types (schemas == nil or empty) are out of scope
+// for this check and return nil.
+//
+// Unparseable policies are skipped — ValidatePluginPolicy has already
+// rejected them by the time this function runs.
+//
+// The function returns on the FIRST mismatch rather than aggregating errors.
+// Rationale: a plugin author fixing a typo will re-run the load anyway, and
+// aggregation produces harder-to-read error messages for agent consumers.
+// If multi-error reporting is needed later, it is a non-breaking follow-up.
+func ValidateManifestPolicySchemas(
+	manifest *Manifest,
+	schemas map[string]*types.NamespaceSchema,
+) error {
+	if len(schemas) == 0 {
+		return nil
+	}
+
+	for _, mp := range manifest.Policies {
+		parsed, err := dsl.Parse(mp.DSL)
+		if err != nil {
+			// Unparseable policies were already rejected by ValidatePluginPolicy.
+			// Skip them silently here to avoid double-reporting.
+			continue
+		}
+		if parsed.Target == nil || parsed.Target.Resource == nil {
+			continue
+		}
+		rt := parsed.Target.Resource.Type
+		if rt == "" {
+			continue
+		}
+		schema, ok := schemas[rt]
+		if !ok || schema == nil {
+			// Resource type not in this plugin's schema map. Either the
+			// policy targets a core type (already rejected by
+			// ValidatePluginPolicy for non-trusted plugins) or a type the
+			// plugin declared but GetSchema didn't return (separate bug
+			// outside the scope of this validator). Skip.
+			continue
+		}
+		for _, attr := range referencedResourceAttrs(parsed) {
+			if _, known := schema.Attributes[attr]; !known {
+				// Build the list of valid attribute names for the error.
+				validKeys := make([]string, 0, len(schema.Attributes))
+				for k := range schema.Attributes {
+					validKeys = append(validKeys, k)
+				}
+				return oops.
+					Code("PLUGIN_SCHEMA_VALIDATION_FAILED").
+					In("plugin").
+					With("plugin", manifest.Name).
+					With("policy", mp.Name).
+					With("resource_type", rt).
+					With("attribute", attr).
+					With("schema_keys", validKeys).
+					Errorf("policy %q references attribute %q on resource type %q which is not in the declared schema",
+						mp.Name, attr, rt)
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run T8 to verify it now passes**
+
+Run: `task test -- -run TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSchema ./internal/plugin/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+feat(abac): extract ValidateManifestPolicySchemas validator
+
+Adds a new policy_schema_validator.go that hard-fails plugin load when
+a manifest policy's DSL references a resource attribute not declared
+in the plugin's GetSchema response.
+
+This is the hard-failure counterpart to the existing non-fatal Warning 3
+in CheckManifestWarnings. Both will run in the load path for now; the
+Warning 3 case is removed in a follow-up task to avoid double-reporting.
+
+Error format includes oops fields plugin, policy, resource_type,
+attribute, and schema_keys (the list of valid attribute names as a
+debugging hint).
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: ValidateManifestPolicySchemas — edge case and boundary tests
+
+**Files:**
+
+- Modify: `internal/plugin/policy_schema_validator_test.go` (+T9, T10, T11, T12, T25, T26, T27, T28, T29, T30, T31)
+
+- [ ] **Step 1: Add T9 (happy path — all attributes declared)**
+
+Append to `internal/plugin/policy_schema_validator_test.go`:
+
+```go
+func TestValidateManifestPolicySchemasAcceptsPolicyWhenAllAttributeReferencesMatchSchema(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-read-normal",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Add T10 (plugin without resource types)**
+
+```go
+func TestValidateManifestPolicySchemasReturnsNilForPluginWithoutResourceTypes(t *testing.T) {
+	m := &plugins.Manifest{
+		Name: "simple-plugin",
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "exec",
+				DSL: `permit(principal is character, action in ["execute"], resource is command) ` +
+					`when { resource.command.name == "simple" };`,
+			},
+		},
+	}
+	// schemas is nil — plugin has no custom resource types.
+	err := plugins.ValidateManifestPolicySchemas(m, nil)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 3: Add T11 (policy without when clause)**
+
+```go
+func TestValidateManifestPolicySchemasAcceptsPolicyWithoutWhenClause(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-unconstrained",
+				DSL:  `permit(principal is character, action in ["read"], resource is widget);`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 4: Add T12 (non-resource attribute references are ignored)**
+
+```go
+func TestValidateManifestPolicySchemasIgnoresEnvironmentAndPrincipalAttributeReferences(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-time-gated",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { principal.character.role == "admin" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	// Policy references principal.character.role but NOT any widget attribute.
+	// The validator should not false-positive on principal references.
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 5: Add T25 (empty non-nil schema map)**
+
+```go
+func TestValidateManifestPolicySchemasReturnsNilForEmptyNonNilSchemaMap(t *testing.T) {
+	m := &plugins.Manifest{
+		Name: "empty-plugin",
+	}
+	schemas := map[string]*types.NamespaceSchema{} // non-nil, length 0
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 6: Add T26 (policy type not in schema map → skipped)**
+
+```go
+func TestValidateManifestPolicySchemasReturnsNilWhenPolicyTypeWasAlreadyRejectedByPluginValidator(t *testing.T) {
+	// This test documents the layering assumption: ValidatePluginPolicy
+	// runs before ValidateManifestPolicySchemas and rejects policies
+	// targeting resource types not in the plugin's resource_types. If
+	// such a policy reaches this validator (shouldn't happen in practice),
+	// we skip rather than error — the rejection is another validator's
+	// responsibility.
+	m := &plugins.Manifest{
+		Name:          "test-plugin",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "gadget-policy",
+				DSL: `permit(principal is character, action in ["read"], resource is gadget) ` +
+					`when { resource.gadget.color == "red" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err, "policy targeting an out-of-schema type is skipped by this validator")
+}
+```
+
+- [ ] **Step 7: Add T27 (first-error reporting with multiple bad policies)**
+
+```go
+func TestValidateManifestPolicySchemasReportsFirstErrorWhenMultiplePoliciesHaveBadAttributes(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-bad-first",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.alpha == "x" };`,
+			},
+			{
+				Name: "widget-good",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+			{
+				Name: "widget-bad-second",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.beta == "y" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "widget-bad-first", "first bad policy should be reported")
+	assert.Contains(t, err.Error(), "alpha", "first bad attribute should be reported")
+	assert.NotContains(t, err.Error(), "widget-bad-second", "second bad policy should not be in first error")
+}
+```
+
+- [ ] **Step 8: Add T28 (compound condition with AND/OR/NOT)**
+
+```go
+func TestValidateManifestPolicySchemasHandlesCompoundConditionsWithANDORNot(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-compound",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { (resource.widget.type == "normal" || resource.widget.tipe == "restricted") && !(resource.widget.owner == "system") };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err, "compound condition with bad attribute should fail")
+	assert.Contains(t, err.Error(), "tipe")
+}
+```
+
+- [ ] **Step 9: Add T29 (has/contains DSL nodes)**
+
+```go
+func TestValidateManifestPolicySchemasHandlesHasAndContainsReferences(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-contains",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.members contains "admin" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "members")
+}
+```
+
+- [ ] **Step 10: Add T30 (in-expression with dynamic both-sides)**
+
+```go
+func TestValidateManifestPolicySchemasHandlesInExprWithDynamicBothSides(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-in-dynamic",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { principal.character.player_id in resource.widget.members };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err, "`in` expression with undeclared resource attribute should fail")
+	assert.Contains(t, err.Error(), "members")
+}
+```
+
+- [ ] **Step 11: Add T31 (prefix/substring not a false positive)**
+
+```go
+func TestValidateManifestPolicySchemasAcceptsAttributeNameThatIsPrefixOfValidAttribute(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-exact",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+		},
+	}
+	// Schema has type_code AND type; both are distinct keys. The policy
+	// references "type" (exactly), which is valid. Prefix matching would
+	// erroneously think "type" is a prefix of "type_code" and could cause
+	// a false positive in a buggy implementation.
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type_code": types.AttrTypeString,
+				"type":      types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err, "exact-match lookup must not substring-match")
+}
+```
+
+- [ ] **Step 12: Run all validator tests**
+
+Run: `task test -- -run "TestValidateManifestPolicySchemas" ./internal/plugin/`
+Expected: PASS for all 12 tests (T8-T12, T25-T31).
+
+- [ ] **Step 13: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): edge and boundary tests for ValidateManifestPolicySchemas
+
+Adds 11 tests covering happy path, nil/empty schema map, unconditional
+policies, environment/principal references, layering assumption,
+first-error semantics, compound conditions (AND/OR/NOT), has/contains
+DSL nodes, dynamic both-sides in-expressions, and prefix-not-substring
+exact matching.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Remove Warning 3 from CheckManifestWarnings
+
+**Files:**
+
+- Modify: `internal/plugin/manifest_warnings.go` (remove the `// Warning 3` block)
+- Modify: `internal/plugin/manifest_warnings_test.go` (remove tests that asserted Warning 3 output)
+
+- [ ] **Step 1: Identify tests that will break**
+
+Run: `task test -- -run "TestCheckManifestWarnings" ./internal/plugin/ -v`
+Note which tests pass. Look at the test file around the existing tests that use schemas with undeclared attributes. Two tests identified in the investigation:
+
+- `TestCheckManifestWarningsAttributeRefThroughInListProducesWarning` (at line ~367)
+- `TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema` (at line ~392)
+
+The first asserts Warning 3's output directly; it needs to be deleted because Warning 3 no longer fires. The second asserts the "skipped" case, which is still valid behavior (both the new validator and the old Warning 3 path skip in that case) — but it was testing `CheckManifestWarnings` specifically, so it stays as a regression test for the unchanged skip behavior.
+
+- [ ] **Step 2: Delete the Warning 3 block from manifest_warnings.go**
+
+Open `internal/plugin/manifest_warnings.go`. Find the block starting at the comment `// Warning 3: policy references an attribute not in the schema for its resource type.` (around line 76-99) and ending at the closing brace before `return warnings`. Delete the entire block:
+
+```go
+	// Warning 3: policy references an attribute not in the schema for its resource type.
+	if schemas != nil {
+		for _, pp := range parsed {
+			if pp.policy.Target == nil || pp.policy.Target.Resource == nil {
+				continue
+			}
+			rt := pp.policy.Target.Resource.Type
+			if rt == "" {
+				continue
+			}
+			schema, ok := schemas[rt]
+			if !ok || schema == nil {
+				continue
+			}
+			for _, attr := range referencedResourceAttrs(pp.policy) {
+				if _, known := schema.Attributes[attr]; !known {
+					warnings = append(warnings, fmt.Sprintf(
+						"plugin %q: policy %q references attribute %q on resource type %q which is not in the schema",
+						manifest.Name, pp.name, attr, rt,
+					))
+				}
+			}
+		}
+	}
+```
+
+The `schemas` parameter is still used by the function signature; leave it for now (if it becomes unused after deletion, gofumpt will flag it — handle it then).
+
+Check whether `referencedResourceAttrs`, `collectFromBlock`, `collectFromCond`, `collectFromExpr` are still used by anything in the file. If not, they can be DELETED because the new validator has its own equivalent — BUT, the new validator in `policy_schema_validator.go` imports them from this file. If they live in `manifest_warnings.go`, they need to remain accessible. Simplest approach: leave these helper functions in `manifest_warnings.go` and have `policy_schema_validator.go` call them.
+
+**Action:** leave `referencedResourceAttrs`, `collectFromBlock`, `collectFromCond`, `collectFromExpr` in `manifest_warnings.go`. They are used by the new validator.
+
+- [ ] **Step 3: Delete the now-obsolete test TestCheckManifestWarningsAttributeRefThroughInListProducesWarning**
+
+Open `internal/plugin/manifest_warnings_test.go`. Find `TestCheckManifestWarningsAttributeRefThroughInListProducesWarning` (around line 367). Delete the entire function.
+
+The test's coverage is now provided by T29 (`TestValidateManifestPolicySchemasHandlesHasAndContainsReferences`) and T30 (`TestValidateManifestPolicySchemasHandlesInExprWithDynamicBothSides`) in the validator test file.
+
+- [ ] **Step 4: Keep TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema but update its expectation**
+
+Still at `internal/plugin/manifest_warnings_test.go`, find `TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema` (around line 392). The test asserts that `CheckManifestWarnings` returns empty warnings when the policy's resource type isn't in the schema map. This behavior is unchanged (the deleted block was the only Warning 3 code). The test should still pass as-is.
+
+Run: `task test -- -run TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full manifest_warnings test file**
+
+Run: `task test -- -run "TestCheckManifestWarnings" ./internal/plugin/`
+Expected: PASS for all remaining tests.
+
+- [ ] **Step 6: Run `task lint` to catch any unused imports or vars**
+
+Run: `task lint`
+Expected: clean pass. If `fmt` is no longer used in `manifest_warnings.go`, remove it from the imports.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+refactor(abac): remove Warning 3 from CheckManifestWarnings
+
+Deletes the policy-attribute-reference cross-validation block from
+CheckManifestWarnings. The same checks now run as hard failures via
+ValidateManifestPolicySchemas. Deletes the corresponding test that
+asserted Warning 3 output; its coverage is preserved by T29 and T30
+in the validator test file.
+
+Warnings 1 (missing execute policy) and 2 (uncovered capability) are
+unchanged — they remain non-fatal hints because a plugin author may
+legitimately declare a public command with no ABAC enforcement.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Wire ValidateManifestPolicySchemas into Manager.loadPlugin
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go` (insert validator call before policy install with rollback)
+
+- [ ] **Step 1: Open manager.go at the load path**
+
+Open `internal/plugin/manager.go`. Locate `loadPlugin` around line 440 (the exact line may drift; search for the function). The relevant sequence is at lines 473-495:
+
+```go
+473:	// Discover and register attribute providers for plugin resource types.
+474:	// schemas is non-nil only for binary plugins that declare resource_types.
+475:	var schemas map[string]*types.NamespaceSchema
+476:	if len(dp.Manifest.ResourceTypes) > 0 {
+477:		var regErr error
+478:		schemas, regErr = m.discoverAndRegisterAttributes(ctx, host, dp)
+479:		if regErr != nil {
+480:			return regErr
+481:		}
+482:	}
+483:
+484:	// Install ABAC policies using manifest-aware validation when resource
+485:	// types or trust config are present, otherwise fall back to basic install.
+486:	if m.policyInstaller != nil && len(dp.Manifest.Policies) > 0 {
+487:		installErr := m.policyInstaller.InstallPluginPoliciesWithManifest(ctx, dp.Manifest, dp.Manifest.Policies)
+488:		...
+```
+
+The variable name is `schemas` (confirmed). The install block starts at line 486.
+
+- [ ] **Step 2: Insert the validator call between lines 482 and 486**
+
+Insert this block immediately after the `}` at line 482 (closing the `if len(dp.Manifest.ResourceTypes) > 0` block) and before the comment at line 484:
+
+```go
+	// Validate manifest policy attribute references against discovered
+	// schemas BEFORE installing policies. A load-time schema mismatch
+	// (e.g., policy references resource.widget.tipe but schema declares
+	// "type") is now a fatal load error — spec 2026-04-07-plugin-abac-hardening.
+	if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+		if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+			slog.Error("failed to rollback plugin load after schema validation failure",
+				"plugin", dp.Manifest.Name, "error", unloadErr)
+		}
+		return oops.In("manager").With("plugin", dp.Manifest.Name).
+			Wrapf(valErr, "validate manifest policy schemas")
+	}
+```
+
+`slog` and `oops` are already imported in `manager.go` — no import changes needed.
+
+- [ ] **Step 3: Run existing plugin tests to verify no regression**
+
+Run: `task test -- ./internal/plugin/`
+Expected: PASS. If the existing `test-abac-widget` unit test fixtures include a policy with an undeclared attribute, it will now fail loading — in that case, fix the fixture to use valid attributes.
+
+- [ ] **Step 4: Run integration tests for the plugin package (foreshadowing Task 11)**
+
+Run: `task test:int -- -tags=integration ./test/integration/plugin/...`
+Expected: Existing tests PASS. The new Sharp Edge 2 tests don't exist yet (added in Task 11).
+
+Note: if Docker is not available or integration tests are slow, this step can be deferred to after Task 11 when both are run together.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+feat(abac): wire ValidateManifestPolicySchemas into plugin load path
+
+Manager.loadPlugin now calls ValidateManifestPolicySchemas after schema
+discovery and before policy install. A non-nil return fails the load
+via the existing host.Unload rollback, ensuring no partial DB state.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Counting proxy wrapper for AttributeResolverServiceClient
+
+**Files:**
+
+- Create: `test/integration/plugin/counting_proxy_test.go`
+
+- [ ] **Step 1: Check the AttributeResolverServiceClient interface**
+
+Run: `task test -- ./internal/plugin/... -count=0 -list="." 2>&1 | head -5` (just compiles; no-op run)
+
+Read `pkg/proto/holomush/plugin/v1/` for the generated client interface. The method signatures needed are:
+
+- `GetSchema(ctx, *GetSchemaRequest, ...grpc.CallOption) (*GetSchemaResponse, error)`
+- `ResolveResource(ctx, *ResolveResourceRequest, ...grpc.CallOption) (*ResolveResourceResponse, error)`
+
+Use `Grep` tool:
+
+Run: (via the Grep tool) pattern `type AttributeResolverServiceClient interface`, glob `pkg/proto/holomush/plugin/v1/*.go`
+Expected: find the generated interface. Copy its method signatures into the next step.
+
+- [ ] **Step 2: Create the counting proxy file**
+
+Create `test/integration/plugin/counting_proxy_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+	"context"
+	"sync/atomic"
+
+	"google.golang.org/grpc"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// countingAttributeResolverClient wraps a real AttributeResolverServiceClient
+// and counts calls to each RPC. Used in plugin ABAC hardening integration
+// tests to assert that ResolveResource is (or is not) invoked during a
+// particular authorization code path.
+type countingAttributeResolverClient struct {
+	inner                pluginv1.AttributeResolverServiceClient
+	getSchemaCalls       atomic.Int64
+	resolveResourceCalls atomic.Int64
+}
+
+func newCountingAttributeResolverClient(
+	inner pluginv1.AttributeResolverServiceClient,
+) *countingAttributeResolverClient {
+	return &countingAttributeResolverClient{inner: inner}
+}
+
+func (c *countingAttributeResolverClient) GetSchema(
+	ctx context.Context,
+	req *pluginv1.GetSchemaRequest,
+	opts ...grpc.CallOption,
+) (*pluginv1.GetSchemaResponse, error) {
+	c.getSchemaCalls.Add(1)
+	return c.inner.GetSchema(ctx, req, opts...)
+}
+
+func (c *countingAttributeResolverClient) ResolveResource(
+	ctx context.Context,
+	req *pluginv1.ResolveResourceRequest,
+	opts ...grpc.CallOption,
+) (*pluginv1.ResolveResourceResponse, error) {
+	c.resolveResourceCalls.Add(1)
+	return c.inner.ResolveResource(ctx, req, opts...)
+}
+
+// ResolveResourceCallCount returns the number of ResolveResource calls
+// observed so far. Use this in test assertions.
+func (c *countingAttributeResolverClient) ResolveResourceCallCount() int64 {
+	return c.resolveResourceCalls.Load()
+}
+
+// ResetCallCounts resets all counters to zero. Use between phases of a
+// single test (e.g., after BeforeEach setup completes).
+func (c *countingAttributeResolverClient) ResetCallCounts() {
+	c.getSchemaCalls.Store(0)
+	c.resolveResourceCalls.Store(0)
+}
+```
+
+- [ ] **Step 3: Verify the proxy compiles**
+
+Run: `task test:int -- -tags=integration -count=1 -run "^$" ./test/integration/plugin/...`
+Expected: compiles successfully, runs zero tests.
+
+If the interface has additional methods beyond GetSchema and ResolveResource, the proxy will fail to satisfy the interface. In that case, add stubs for those methods that delegate to `inner` without counting.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): counting proxy for AttributeResolverServiceClient
+
+Adds a testing proxy that wraps the generated client and counts
+ResolveResource calls. Used by Sharp Edge 1 integration tests to
+assert that plugin ResolveResource is NEVER invoked during type-level
+preflight (C1 invariant).
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Integration tests — preflight does not invoke plugin RPC (T13, T14, T38)
+
+**Files:**
+
+- Modify: `test/integration/plugin/abac_widget_test.go` (+T13, T14, T38 specs and counting proxy wiring)
+
+- [ ] **Step 1: Add a describe block with counting proxy setup**
+
+Open `test/integration/plugin/abac_widget_test.go`. Find the existing `Describe("full ABAC engine evaluation with plugin policies", ...)` block. After that block (or as a sibling), add a new Describe block:
+
+```go
+	// ---------------------------------------------------------------
+	// Plugin ABAC Hardening (spec 2026-04-07): Sharp Edge 1 tests
+	// ---------------------------------------------------------------
+	Describe("plugin ResolveResource call semantics under hardening", func() {
+		var (
+			ctx         context.Context
+			cancel      context.CancelFunc
+			container   testcontainers.Container
+			connStr     string
+			host        *goplugin.Host
+			ps          *policystore.PostgresStore
+			engine      *policy.Engine
+			pool        *pgxpool.Pool
+			provisioner *plugins.SchemaProvisioner
+			countingAR  *countingAttributeResolverClient
+		)
+
+		BeforeEach(func() {
+			_, binaryPath := abacWidgetBinaryPath()
+			if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("test-abac-widget binary not found at %s — run 'task plugin:build-all' first",
+					binaryPath))
+			}
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			if _, err := os.Stat(filepath.Join(pluginDir, "plugin.yaml")); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("plugin.yaml not found at %s/plugin.yaml — run 'task plugin:build-all' first", pluginDir))
+			}
+
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+			pgEnv, err := testutil.StartPostgres(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			container = pgEnv.Container
+			connStr = pgEnv.ConnStr
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(migrator.Up()).To(Succeed())
+			_ = migrator.Close()
+
+			provisioner = plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host = goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+
+			manifest := loadWidgetManifest()
+			Expect(host.Load(ctx, manifest, pluginDir)).To(Succeed())
+
+			pool, err = pgxpool.New(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			ps = policystore.NewPostgresStore(pool)
+			installer := plugins.NewPolicyInstaller(ps)
+			Expect(installer.InstallPluginPoliciesWithManifest(ctx, manifest, manifest.Policies)).To(Succeed())
+
+			// Wire the counting proxy in place of the raw plugin client.
+			rawClient := host.AttributeResolverClient("test-abac-widget")
+			Expect(rawClient).NotTo(BeNil())
+			countingAR = newCountingAttributeResolverClient(rawClient)
+
+			// Build the engine stack using the counting proxy instead of the
+			// raw client when registering the attribute provider.
+			schemaRegistry := attribute.NewSchemaRegistry()
+			resolver := attribute.NewResolver(schemaRegistry)
+
+			cmdProvider := attribute.NewCommandProvider()
+			Expect(resolver.RegisterProvider(cmdProvider)).To(Succeed())
+
+			schemaResp, schemaErr := countingAR.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(schemaErr).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			Expect(schemas).To(HaveKey("widget"))
+
+			widgetProvider := plugins.NewPluginAttributeProvider("widget", countingAR, schemas["widget"])
+			Expect(resolver.RegisterProvider(widgetProvider)).To(Succeed())
+
+			compiler := policy.NewCompiler(schemaRegistry.Schema())
+			cache := policy.NewCache(ps, compiler)
+			Expect(cache.Reload(ctx)).To(Succeed())
+
+			auditWriter := &testAuditWriter{}
+			tmpDir := GinkgoT().TempDir()
+			auditLogger := audit.NewLogger(audit.ModeAll, auditWriter, filepath.Join(tmpDir, "test-wal.jsonl"))
+
+			sessionResolver := &testSessionResolver{}
+			engine = policy.NewEngine(resolver, cache, sessionResolver, auditLogger)
+
+			// Reset counters after BeforeEach so test assertions measure only
+			// the activity that the test body triggers.
+			countingAR.ResetCallCounts()
+		})
+
+		AfterEach(func() {
+			if host != nil {
+				_ = host.Close(ctx)
+			}
+			if provisioner != nil {
+				provisioner.Close()
+			}
+			if pool != nil {
+				pool.Close()
+			}
+			if container != nil {
+				_ = container.Terminate(context.Background())
+			}
+			if cancel != nil {
+				cancel()
+			}
+		})
+
+		It("never invokes the plugin ResolveResource RPC during type-level preflight", func() {
+			// T13: The C1 invariant at E2E layer with a real plugin binary.
+			allowed, err := engine.CanPerformAction(ctx, "character:01ABC", "read", "widget", "self")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue(), "preflight should permit via optimistic branch")
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(0),
+				"ResolveResource MUST NOT be called during type-level preflight")
+		})
+
+		It("still invokes the plugin ResolveResource RPC for instance-level Evaluate", func() {
+			// T14: Instance-level evaluation is unaffected.
+			req, reqErr := policytypes.NewAccessRequest("character:01ABC", "read", "widget:normal-1")
+			Expect(reqErr).NotTo(HaveOccurred())
+
+			decision, err := engine.Evaluate(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decision.IsAllowed()).To(BeTrue())
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(1),
+				"ResolveResource should be called exactly once for one Evaluate")
+		})
+
+		It("permits character:01ABC execute widget command via full database-backed engine stack without invoking plugin ResolveResource", func() {
+			// T38: Full DB-backed stack, CanPerformAction, counter asserted zero.
+			allowed, err := engine.CanPerformAction(ctx, "character:01ABC", "execute", "command", "self")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(0),
+				"execute command preflight must not touch the plugin")
+		})
+	})
+```
+
+- [ ] **Step 2: Verify integration tests compile**
+
+Run: `task test:int -- -tags=integration -count=1 -run "never invokes the plugin" ./test/integration/plugin/...`
+Expected: PASS, or SKIP if the binary isn't built. If SKIP, run `task plugin:build-all` first, then re-run.
+
+- [ ] **Step 3: Run all three new specs**
+
+Run: `task test:int -- -tags=integration -count=1 -run "plugin ResolveResource call semantics under hardening" ./test/integration/plugin/...`
+Expected: PASS for all three specs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): E2E tests for C1 invariant with real plugin binary
+
+Adds three Ginkgo specs using a counting proxy wrapper around the
+test-abac-widget plugin's AttributeResolverServiceClient:
+
+- T13: preflight (CanPerformAction on widget) never calls the plugin
+- T14: instance-level Evaluate calls the plugin exactly once
+- T38: preflight on command execution never calls the plugin
+
+Proves the C1 invariant end-to-end with a real plugin binary, real
+PostgreSQL-backed policy store, and real engine.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Integration tests — load-time validation failure (T15, T34, T36, T37)
+
+**Files:**
+
+- Modify: `test/integration/plugin/abac_widget_test.go` (+T15, T34, T36, T37 specs)
+
+- [ ] **Step 1: Add a Describe block for Sharp Edge 2 integration tests**
+
+Append to the same file after the previous Describe block:
+
+```go
+	Describe("manifest policy schema validation at load time", func() {
+		var (
+			ctx       context.Context
+			cancel    context.CancelFunc
+			container testcontainers.Container
+			connStr   string
+		)
+
+		BeforeEach(func() {
+			_, binaryPath := abacWidgetBinaryPath()
+			if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("test-abac-widget binary not found — run 'task plugin:build-all'"))
+			}
+
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+			pgEnv, err := testutil.StartPostgres(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			container = pgEnv.Container
+			connStr = pgEnv.ConnStr
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(migrator.Up()).To(Succeed())
+			_ = migrator.Close()
+		})
+
+		AfterEach(func() {
+			if container != nil {
+				_ = container.Terminate(context.Background())
+			}
+			if cancel != nil {
+				cancel()
+			}
+		})
+
+		It("fails to load a plugin whose manifest policy references an undeclared resource attribute", func() {
+			// T15: Build a manifest based on the widget manifest but with
+			// a typo in one policy's DSL. Load it and assert failure.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			registry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(registry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+
+			// The host Load itself still succeeds — validation happens at
+			// Manager.loadPlugin level. Load the host-level plugin first,
+			// then run the validator directly to prove the hard-failure
+			// path. A follow-up assertion covers the manager integration.
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, err := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(err).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+
+			valErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(valErr).To(HaveOccurred())
+			Expect(valErr.Error()).To(ContainSubstring("tipe"))
+			Expect(valErr.Error()).To(ContainSubstring("widget-read-normal-bad"))
+		})
+
+		It("installs zero policies in the database when manifest validation fails", func() {
+			// T34: After a failed validation, the policy store MUST have
+			// zero plugin-source policies. This proves rollback at the DB
+			// layer — important because the validator runs BEFORE install,
+			// so there should be nothing to roll back, but we assert the
+			// invariant explicitly.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, err := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(err).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+
+			valErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(valErr).To(HaveOccurred())
+
+			// Now check the DB: no policies should be installed.
+			pool, poolErr := pgxpool.New(ctx, connStr)
+			Expect(poolErr).NotTo(HaveOccurred())
+			defer pool.Close()
+
+			ps := policystore.NewPostgresStore(pool)
+			pluginPolicies, listErr := ps.List(ctx, policystore.ListOptions{Source: "plugin"})
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(pluginPolicies).To(BeEmpty(),
+				"failed validation must leave the policy store pristine")
+		})
+
+		It("successfully loads a fixed manifest after a prior validation failure", func() {
+			// T36: Idempotency — after a failed load, a fixed manifest
+			// should load without any leftover state interfering.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+
+			// First attempt — bad manifest.
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, _ := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			badErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(badErr).To(HaveOccurred())
+
+			// Unload the bad plugin before loading the good one.
+			_ = host.Close(ctx)
+
+			// Re-create host and load the good manifest.
+			svcRegistry2 := plugins.NewServiceRegistry()
+			host2 := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry2),
+			)
+			defer func() { _ = host2.Close(ctx) }()
+
+			Expect(host2.Load(ctx, goodManifest, pluginDir)).To(Succeed())
+			arClient2 := host2.AttributeResolverClient("test-abac-widget")
+			schemaResp2, _ := arClient2.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas2 := plugins.ConvertProtoSchema(schemaResp2)
+
+			goodErr := plugins.ValidateManifestPolicySchemas(goodManifest, schemas2)
+			Expect(goodErr).NotTo(HaveOccurred(),
+				"good manifest must validate successfully after a prior failure")
+		})
+
+		It("installs three plugin policies in the database when manifest validation passes", func() {
+			// T37: Positive path — existing happy path with an explicit
+			// DB query assertion to mirror T34's negative path.
+			goodManifest := loadWidgetManifest()
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			Expect(host.Load(ctx, goodManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, _ := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			Expect(plugins.ValidateManifestPolicySchemas(goodManifest, schemas)).To(Succeed())
+
+			pool, poolErr := pgxpool.New(ctx, connStr)
+			Expect(poolErr).NotTo(HaveOccurred())
+			defer pool.Close()
+
+			ps := policystore.NewPostgresStore(pool)
+			installer := plugins.NewPolicyInstaller(ps)
+			Expect(installer.InstallPluginPoliciesWithManifest(ctx, goodManifest, goodManifest.Policies)).To(Succeed())
+
+			pluginPolicies, listErr := ps.List(ctx, policystore.ListOptions{Source: "plugin"})
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(pluginPolicies).To(HaveLen(3),
+				"successful validation must install all three policies")
+		})
+	})
+}) // closes the top-level Describe
+```
+
+Note: the `})` at the end closes the outer `Describe("Plugin ABAC Trust Boundary", ...)`. Check the file carefully — the exact closing pattern depends on the current file structure. Read the file end before inserting.
+
+- [ ] **Step 2: Add the manifest cloning helper**
+
+Append to the same test file (outside any Ginkgo block, at package scope):
+
+```go
+// cloneManifestWithBadPolicy returns a copy of the given manifest with one
+// policy's DSL mutated to reference an undeclared attribute (resource.widget.tipe
+// instead of resource.widget.type). The policy name is also changed to
+// "widget-read-normal-bad" so tests can assert on it specifically.
+func cloneManifestWithBadPolicy(src *plugins.Manifest) *plugins.Manifest {
+	clone := *src
+	clone.Policies = make([]plugins.ManifestPolicy, len(src.Policies))
+	copy(clone.Policies, src.Policies)
+
+	// Mutate the first policy that targets widget-read-normal (or any
+	// policy that references resource.widget.type if the name differs).
+	for i, p := range clone.Policies {
+		if p.Name == "widget-read-normal" || strings.Contains(p.DSL, "resource.widget.type") {
+			clone.Policies[i] = plugins.ManifestPolicy{
+				Name: "widget-read-normal-bad",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.tipe == "normal" };`,
+			}
+			break
+		}
+	}
+	return &clone
+}
+```
+
+Note: this helper requires `strings` to be imported in the test file. Check imports and add if missing.
+
+- [ ] **Step 3: Run the new integration specs**
+
+Run: `task test:int -- -tags=integration -count=1 -run "manifest policy schema validation at load time" ./test/integration/plugin/...`
+Expected: PASS for all four specs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+test(abac): E2E tests for load-time schema validation
+
+Adds four Ginkgo specs in test/integration/plugin/abac_widget_test.go:
+
+- T15: bad manifest fails ValidateManifestPolicySchemas with tipe error
+- T34: failed validation leaves policy store empty (rollback invariant)
+- T36: fixed manifest loads successfully after a prior failure
+- T37: successful validation installs all three widget policies
+
+Uses cloneManifestWithBadPolicy helper to synthesize bad manifests
+in-memory without rebuilding the plugin binary.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Resolver provider registry rollback investigation (T35)
+
+**Files:**
+
+- Investigation: `internal/access/policy/attribute/resolver.go`, `internal/plugin/manager.go`
+- Possibly modify: add `UnregisterProvider` to resolver
+- Possibly add: rollback call in `manager.go` after failed validation
+
+- [ ] **Step 1: Investigate whether host.Unload unregisters the resolver provider**
+
+Read `internal/plugin/manager.go` and `internal/plugin/host.go`, focusing on how attribute providers are registered and what `host.Unload` does. Specifically look for:
+
+- Where `PluginAttributeProvider` is registered into the resolver (likely in `manager.go` or `discoverAndRegisterAttributes`)
+- Whether `host.Unload` has any corresponding unregistration
+
+Run: `grep -rn "RegisterProvider\|Unregister" internal/plugin/ internal/access/policy/attribute/` via the Grep tool.
+
+Document the finding in the commit message: either "host.Unload already handles resolver cleanup" or "host.Unload does NOT unregister providers — adding UnregisterProvider".
+
+- [ ] **Step 2: If the gap exists, add UnregisterProvider to resolver**
+
+If the investigation shows no unregistration path:
+
+Append to `internal/access/policy/attribute/resolver.go`:
+
+```go
+// UnregisterProvider removes a provider from the resolver by namespace.
+// Used during plugin load rollback to clean up a provider that was
+// registered before load-time validation failed.
+//
+// Returns true if a provider was removed, false if the namespace had
+// no registered provider.
+func (r *Resolver) UnregisterProvider(namespace string) bool {
+	if _, exists := r.providers[namespace]; !exists {
+		return false
+	}
+	delete(r.providers, namespace)
+	for i, ns := range r.providerOrder {
+		if ns == namespace {
+			r.providerOrder = append(r.providerOrder[:i], r.providerOrder[i+1:]...)
+			break
+		}
+	}
+	delete(r.circuitBreakers, namespace)
+	return true
+}
+```
+
+If `Resolver` has a mutex guarding these maps (re-read the struct), use it here. The current code (Task 1 baseline) is not obviously synchronized for provider registration — if registration isn't locked, neither is unregistration; document this as an assumption.
+
+- [ ] **Step 3: Wire UnregisterProvider into the manager rollback path**
+
+Open `internal/plugin/manager.go`. Find the validator-failure rollback block added in Task 10. Before `host.Unload`, add calls to unregister each resource type's provider:
+
+```go
+	if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+		// Unregister attribute providers that were added during
+		// discoverAndRegisterAttributes, so the resolver doesn't retain
+		// dangling references to a dead plugin process.
+		if m.attributeResolver != nil {
+			for _, rt := range dp.Manifest.ResourceTypes {
+				m.attributeResolver.UnregisterProvider(rt)
+			}
+		}
+		if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+			slog.Error("failed to rollback plugin load after schema validation failure",
+				"plugin", dp.Manifest.Name, "error", unloadErr)
+		}
+		return oops.In("manager").With("plugin", dp.Manifest.Name).
+			Wrapf(valErr, "validate manifest policy schemas")
+	}
+```
+
+Note: `m.attributeResolver` may not be the actual field name — read the `Manager` struct. If the resolver isn't directly accessible from `Manager`, the rollback path is trickier; in that case, pass the resolver as a parameter or store a reference during registration.
+
+If the manager already has a clean path (e.g., `discoverAndRegisterAttributes` returns a cleanup func), use that instead.
+
+- [ ] **Step 4: Write integration test T35**
+
+Append to `test/integration/plugin/abac_widget_test.go` inside the "manifest policy schema validation at load time" Describe block (after T37):
+
+```go
+		It("removes the attribute provider from the resolver registry after failed load", func() {
+			// T35: Resolver rollback completeness. After a failed
+			// validation, the resolver should NOT have the plugin's
+			// namespace registered — otherwise a subsequent load would
+			// see "already registered" and fail with a confusing error.
+			//
+			// This test exercises the rollback path. If it fails, the
+			// rollback gap needs to be closed — see Task 14 in the plan.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			// Build a real resolver that we can inspect after the failed load.
+			schemaRegistry := attribute.NewSchemaRegistry()
+			resolver := attribute.NewResolver(schemaRegistry)
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+
+			// Simulate the manager's discover-and-register step manually.
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, err := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(err).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			widgetProvider := plugins.NewPluginAttributeProvider("widget", arClient, schemas["widget"])
+			Expect(resolver.RegisterProvider(widgetProvider)).To(Succeed())
+
+			// Validation fails.
+			valErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(valErr).To(HaveOccurred())
+
+			// Rollback: unregister the provider.
+			removed := resolver.UnregisterProvider("widget")
+			Expect(removed).To(BeTrue(), "widget provider must be removed on rollback")
+
+			// Verify subsequent load attempts can register again without conflict.
+			goodWidgetProvider := plugins.NewPluginAttributeProvider("widget", arClient, schemas["widget"])
+			Expect(resolver.RegisterProvider(goodWidgetProvider)).To(Succeed(),
+				"after rollback, the namespace must be free for re-registration")
+		})
+```
+
+- [ ] **Step 5: Run T35**
+
+Run: `task test:int -- -tags=integration -count=1 -run "removes the attribute provider" ./test/integration/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+feat(abac): resolver.UnregisterProvider + manager rollback integration
+
+Adds UnregisterProvider to the attribute.Resolver so failed plugin
+loads can clean up dangling provider registrations. Wires it into
+Manager.loadPlugin's rollback path that runs after a validator failure.
+
+T35 asserts that after a failed load, the namespace is free for
+re-registration — preventing "already registered" errors on retry.
+
+Investigation finding: host.Unload did not previously unregister
+attribute providers. This task closes that gap.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If the investigation in Step 1 showed that rollback was already handled (no gap), simplify Task 14 to a single step: write T35 as a regression test that asserts the existing clean behavior, no code changes. Update the commit message accordingly.
+
+---
+
+## Task 15: Documentation — internal Go doc comments
+
+**Files:**
+
+- Modify: `pkg/plugin/service.go` (AttributeResolverProvider doc comment)
+- Modify: `plugins/test-abac-widget/main.go` (widgetResolver doc comment and lines 58-67 comment rewrite)
+
+- [ ] **Step 1: Update pkg/plugin/service.go**
+
+Open `pkg/plugin/service.go`. Find the `AttributeResolverProvider` interface. Above its declaration, add or update the doc comment:
+
+```go
+// AttributeResolverProvider is implemented by plugins that resolve attributes
+// for their declared resource types. The host calls these methods only with
+// real resource instance IDs that it believes to exist — there are no
+// synthetic sentinels, no "preflight" IDs, and no pseudo-instances. Plugin
+// authors can assume that any ID passed to ResolveResource refers to a
+// genuine entity in their backing store.
+//
+// See docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md for
+// the full host/plugin contract.
+type AttributeResolverProvider interface {
+	// ... existing method set ...
+}
+```
+
+Keep the existing method list untouched.
+
+- [ ] **Step 2: Update plugins/test-abac-widget/main.go — widgetResolver doc comment**
+
+Open `plugins/test-abac-widget/main.go`. Find `type widgetResolver struct { ... }` (line ~41). Add a doc comment above it:
+
+```go
+// widgetResolver is the canonical example of an ABAC attribute resolver
+// for a binary plugin. It illustrates two properties the host contract
+// guarantees:
+//
+//  1. The host only calls ResolveResource with real instance IDs it
+//     believes exist. There is no preflight sentinel to handle.
+//  2. Every attribute returned here ("type", "owner") must also appear
+//     in GetSchema — otherwise the returned value is silently dropped
+//     at runtime and the plugin fails to load if a policy references
+//     the undeclared attribute.
+//
+// Plugin authors writing new resolvers should model theirs on this
+// pattern: map instance ID → backing store lookup → return a map keyed
+// by names declared in GetSchema.
+type widgetResolver struct {
+	pluginv1.UnimplementedAttributeResolverServiceServer
+}
+```
+
+- [ ] **Step 3: Rewrite the misleading comment at lines 58-67**
+
+Find the comment in `ResolveResource` at lines 58-67:
+
+```go
+	// Reject any resource type other than "widget". This catches host-side
+	// misrouting bugs (e.g., a per-resource-type registration regression
+	// that sends `location:abc` to this resolver) — without it, the E2E
+	// coverage would silently pass on routing bugs.
+	if req.GetResourceType() != "widget" {
+```
+
+Replace with:
+
+```go
+	// Reject any resource type other than "widget". This is defense in
+	// depth against a host routing bug (e.g., a per-resource-type
+	// registration regression that sends `location:abc` to this resolver).
+	// The host contract guarantees that ResolveResource is only called
+	// with instance IDs the host believes to exist; this check protects
+	// against the host violating that contract, not against synthetic
+	// preflight IDs (which no longer exist — see spec
+	// 2026-04-07-plugin-abac-hardening-design.md).
+	if req.GetResourceType() != "widget" {
+```
+
+- [ ] **Step 4: Run `task lint` and `task test` to verify no regressions**
+
+Run: `task lint` — expect clean pass.
+Run: `task test -- ./plugins/test-abac-widget/... ./pkg/plugin/...` — expect PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+docs(abac): update internal comments to reflect hardening contract
+
+Updates the AttributeResolverProvider interface comment in
+pkg/plugin/service.go to state the post-hardening invariant: the host
+never sends synthetic IDs; plugins only receive real instance IDs.
+
+Adds a doc comment to test-abac-widget's widgetResolver clarifying its
+role as the canonical plugin author reference. Rewrites the misleading
+comment about "host-side misrouting bugs" to correctly describe the
+current contract.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Documentation — plugin author docs page
+
+**Files:**
+
+- Create: `site/docs/extending/abac-attribute-resolver.md`
+
+- [ ] **Step 1: Check existing extending/ structure**
+
+Run: Glob tool pattern `site/docs/extending/*.md` to see what exists. If there's an existing ABAC or attribute page, consider appending to it instead of creating a new file.
+
+- [ ] **Step 2: Create the new page**
+
+Create `site/docs/extending/abac-attribute-resolver.md` with the following content:
+
+```markdown
+# Implementing AttributeResolverService
+
+Binary plugins that declare `resource_types` in their manifest must implement
+the `AttributeResolverService` gRPC service so the HoloMUSH ABAC engine can
+resolve attributes for policy evaluation. This guide describes the host/plugin
+contract and common implementation patterns.
+
+## The contract
+
+The HoloMUSH host calls two RPCs on your plugin's resolver:
+
+### `GetSchema`
+
+Called **once** at plugin load time. Return a map from resource type name to
+the attributes your `ResolveResource` will ever return. The host uses this
+schema to:
+
+- Validate that policies in your manifest only reference declared attributes
+- Drop any runtime attribute returned by `ResolveResource` that isn't in the
+  schema (with a log warning and a Prometheus counter increment)
+
+**Every attribute you will return at runtime MUST be listed here.** If you
+forget one, its value will be silently absent from the policy evaluation
+context and policies referencing it will evaluate as `false`.
+
+### `ResolveResource`
+
+Called **once per instance-level authorization request** with a real resource
+instance ID from your backing store. The host guarantees:
+
+- You will never receive a synthetic or sentinel ID (like `__preflight__`)
+- The ID is one the host believes exists — typically because a user action
+  referenced it, or because policy evaluation is checking a specific instance
+- Type-level capability pre-flight never calls your resolver
+
+Return a map keyed by the attribute names you declared in `GetSchema`. If the
+instance doesn't exist in your backing store, return a gRPC `NotFound` error.
+For infrastructure failures (DB down, cache corrupted), return `Internal`.
+Both cause the authorization check to fail closed.
+
+## What fails at load time
+
+If your manifest contains a policy whose DSL references an attribute not in
+your `GetSchema` response, **the plugin will fail to load** with an error like:
+
+```
+
+policy "widget-read-normal" references attribute "tipe" on resource type
+"widget" which is not in the declared schema
+
+```text
+
+Fix the typo in either the policy DSL or the schema and reload.
+
+## Canonical example
+
+See `plugins/test-abac-widget/main.go` in the HoloMUSH repository for a
+minimal, correct reference implementation. Key points to study:
+
+1. `GetSchema` declares exactly the attributes (`type`, `owner`) that
+   `ResolveResource` returns — no more, no less
+2. `ResolveResource` rejects unexpected resource types as defense in depth
+3. The resolver maps instance IDs to attribute maps with no assumption about
+   sentinel IDs or preflight semantics
+
+## What NOT to do
+
+- **Don't handle sentinel IDs** like `__preflight__`. The host does not send
+  them. If you see this string in a resource ID, something is wrong — either
+  a host bug or a misconfigured test.
+- **Don't return attributes not in your schema.** They will be silently
+  dropped. If you need a new attribute, add it to `GetSchema` AND the
+  runtime return.
+- **Don't swallow errors.** Return `NotFound` for missing instances and
+  `Internal` for infrastructure failures. The host logs and counts both.
+- **Don't call other resolvers recursively.** The host detects re-entrance
+  and will panic your resolver call.
+
+## Related
+
+- Spec: [Plugin ABAC Hardening Design (2026-04-07)](../../docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md)
+- Spec: [Plugin ABAC Trust Boundary Design (2026-04-06)](../../docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md)
+- Code: `internal/plugin/attribute_proxy.go` — how the host calls your resolver
+- Code: `internal/access/policy/attribute/resolver.go` — resolver engine
+- Code: `plugins/test-abac-widget/main.go` — reference plugin
+```
+
+- [ ] **Step 3: Run `task docs:build` to verify the page builds**
+
+Run: `task docs:build` (if `task docs:setup` hasn't been run in this workspace, run that first).
+Expected: build succeeds, no broken links or syntax errors.
+
+If the docs build is slow or needs a lot of setup, alternatively run `task fmt:markdown` to at least verify the markdown is well-formed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+docs(abac): plugin author guide for AttributeResolverService
+
+Creates site/docs/extending/abac-attribute-resolver.md, a plugin author
+guide documenting the host/plugin contract for binary plugins that
+declare resource_types.
+
+Covers: GetSchema and ResolveResource semantics, the "no synthetic IDs"
+invariant from the hardening spec, load-time policy/schema validation,
+the canonical test-abac-widget reference, and a "what NOT to do" list
+including the now-impossible preflight sentinel handling.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Spec addendum — append Hardening section to trust boundary spec
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md`
+
+- [ ] **Step 1: Read the existing spec**
+
+Open `docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md`. Scroll to the end. Identify the last section and the appropriate place to add a new top-level `## Hardening (2026-04-07)` section.
+
+- [ ] **Step 2: Append the addendum**
+
+Append the following to the end of the file:
+
+```markdown
+
+---
+
+## Hardening (2026-04-07)
+
+This section documents hardening work that landed after the original spec and
+resolved two architectural sharp edges identified during the subsequent plugin
+ABAC review. See `docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md`
+for the full design.
+
+### Sharp Edge 1 — synthetic `__preflight__` resource ID → eliminated
+
+The original design had `engine.CanPerformAction` construct a synthetic
+resource ID of the form `<resourceType>:__preflight__` and call
+`resolver.Resolve`. This caused plugin `ResolveResource` RPCs to be invoked
+with fake instance IDs during type-level capability pre-flight, with no
+documented contract for how plugins should handle the case.
+
+**Resolution (C1):** `Resolver.ResolveSubjectAttributes(ctx, subject, action)`
+was added as a new entry point that resolves only subject, environment, and
+action attributes — resource providers are never called. `CanPerformAction`
+was rewritten to use this method. The `__preflight__` literal was deleted
+from `internal/access/policy/engine.go` (enforced by a static test).
+
+**New invariant:** `PluginAttributeProvider.ResolveResource` is called if and
+only if the host has a real resource instance ID that corresponds to a
+resource owned by that namespace. There is no synthetic ID, no sentinel, no
+preflight-aware code path, and no documented plugin contract for handling
+non-existent IDs.
+
+**Guidance superseded:** any guidance in this original spec suggesting that
+plugins "should handle non-instance IDs gracefully" is obsolete. Plugins only
+receive real instance IDs.
+
+### Sharp Edge 2 — silent schema validation drops → load-time fatal
+
+The original design logged a `slog.Info` warning when a manifest policy
+referenced an attribute not in the plugin's `GetSchema` response. A typo in
+the policy DSL (e.g., `resource.widget.tipe` instead of `resource.widget.type`)
+would produce a silent always-false condition discoverable only by reading
+load-time log lines.
+
+**Resolution (S1):** the cross-validation logic was extracted from
+`CheckManifestWarnings` Warning 3 into a new function
+`ValidateManifestPolicySchemas` in `internal/plugin/policy_schema_validator.go`.
+This function is called from `Manager.loadPlugin` before policy installation,
+and a non-nil return fails the load via the existing rollback path. Runtime
+`mergeAttributes` drop behavior (warn + Prometheus counter, non-fatal) is
+unchanged — the runtime path catches a different failure mode (plugin returns
+keys outside its declared schema) and remains lenient to avoid breaking
+healthy plugin traffic.
+
+The resolver also gained an `UnregisterProvider` method so that failed
+validation cleanly removes the plugin's attribute provider from the registry,
+allowing a fixed manifest to be re-loaded without "already registered" errors.
+```
+
+- [ ] **Step 3: Run `task fmt` and verify the markdown lints clean**
+
+Run: `task fmt`
+Expected: the append is reformatted if needed; no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "$(cat <<'EOF'
+docs(abac): append Hardening section to trust boundary spec
+
+Appends a dated Hardening (2026-04-07) section to the original plugin
+ABAC trust boundary spec, documenting the resolution of Sharp Edge 1
+(synthetic preflight ID eliminated) and Sharp Edge 2 (load-time schema
+cross-validation made fatal).
+
+Marks the original spec's guidance about handling non-instance IDs as
+superseded. Links to the hardening design spec for the full rationale.
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Full verification — task pr-prep
+
+**Files:** none (verification task)
+
+- [ ] **Step 1: Run the full PR-prep gate**
+
+Run: `task pr-prep`
+Expected: PASS for all sub-tasks (lint, fmt, schema, license, unit, integration, E2E).
+
+This is the mandatory gate from CLAUDE.md before any push to a PR branch. Per project memory, it must be run in full — never approximated with subset checks.
+
+- [ ] **Step 2: If any sub-task fails, fix and re-run**
+
+For each failure:
+
+1. Read the error carefully
+2. Identify the root cause
+3. Fix it in place (do NOT add ignore directives)
+4. Re-run `task pr-prep` until it passes green
+
+Common failures to expect:
+
+- License headers missing on new files — run `task license:add`
+- Formatting drift — run `task fmt`
+- Lint violations — fix inline, do not suppress
+- Integration test flakes — re-run once; if still flaky, investigate
+
+- [ ] **Step 3: After green, verify the final state**
+
+Run: `jj --no-pager log -r '@-::' --limit 20`
+Expected: list of commits from Task 1 through Task 17, all clean.
+
+Run: `jj --no-pager st`
+Expected: clean working copy, no pending changes.
+
+- [ ] **Step 4: Commit any pr-prep fixes as a single task-18 commit if needed**
+
+If Step 2 produced fixes, commit them with:
+
+```bash
+jj commit -m "$(cat <<'EOF'
+chore(abac): pr-prep fixes for plugin ABAC hardening
+
+Fixes discovered during task pr-prep: [describe the fixes]
+
+Part of plugin ABAC hardening (holomush-479l).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Task 19: Close the bead and update dependents
+
+**Files:** none (bead metadata)
+
+- [ ] **Step 1: Update holomush-0sc.12 to note unblock**
+
+Run:
+
+```bash
+bd update holomush-0sc.12 --notes "Plugin ABAC hardening (holomush-479l) landed via PR #<TBD>. The synthetic __preflight__ path is gone and load-time policy/schema validation is now fatal. Channel plugin rework can resume with Option C (hybrid) as previously decided, or the newly-safer maximalist path."
+```
+
+Replace `<TBD>` with the PR number once the PR is opened (in a subsequent step).
+
+- [ ] **Step 2: Close holomush-479l**
+
+Once PR is merged to main:
+
+Run:
+
+```bash
+bd close holomush-479l --reason "Plugin ABAC hardening landed in PR #<TBD>. C1 eliminated synthetic preflight ID; S1 made load-time schema validation fatal. All 39 tests in the plan pass. Spec: docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md. Unblocks holomush-0sc.12."
+```
+
+Note: this step happens AFTER the PR merges to main, not as part of the implementation commits.
+
+- [ ] **Step 3: File any discovered-from beads**
+
+During implementation, if Task 14 discovered a rollback gap, or any other follow-up work emerged, file them as discovered-from beads linked to holomush-479l. Examples:
+
+- If `host.Unload` has other cleanup gaps beyond the attribute resolver: file a bead
+- If the Prometheus counter label cardinality becomes a concern: file a bead
+- If subject-attribute reference validation is needed (the follow-up mentioned in the spec): file a bead
+
+Run (template):
+
+```bash
+bd create "<title>" --description="<context>" -t task -p 2 --deps discovered-from:holomush-479l --json
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task(s) |
+|---|---|
+| Add `Resolver.ResolveSubjectAttributes` method | Task 1 |
+| Method has full unit coverage (T1-T4, T16-T21, T39) | Tasks 1, 2, 3 |
+| Engine `CanPerformAction` uses new method | Task 4 |
+| `__preflight__` literal deleted from engine.go | Task 4 |
+| T5 (engine does not invoke resource providers) | Task 4 (written alongside the refactor) |
+| T6 (optimistic permit branch) | Task 5 Step 1 |
+| T7, T22, T23, T24 | Pre-existing coverage in `engine_test.go` — validated by running the existing test suite after Task 4; Task 5 Step 3 documents the mapping |
+| Static invariant test T32 | Task 6 |
+| T33 cross-check with full provider set | Tasks 3 (unit-level via T21), 12 (E2E-level via T13/T38) |
+| `ValidateManifestPolicySchemas` extracted as new function | Task 7 |
+| Validator unit coverage (T8-T12, T25-T31) | Tasks 7, 8 |
+| Warning 3 removed from `CheckManifestWarnings` | Task 9 |
+| Validator wired into `Manager.loadPlugin` | Task 10 |
+| Counting proxy for integration tests | Task 11 |
+| T13, T14, T38 integration tests | Task 12 |
+| T15, T34, T36, T37 integration tests | Task 13 |
+| T35 rollback completeness + UnregisterProvider if needed | Task 14 |
+| Internal Go doc comments updated | Task 15 |
+| Plugin author docs page | Task 16 |
+| Spec addendum appended | Task 17 |
+| task pr-prep green | Task 18 |
+| Bead cross-references | Task 19 |
+
+All 39 tests and all documentation targets are covered.
+
+**Placeholder scan:** none remaining (all steps contain actual code or actual commands).
+
+**Type consistency:** `ResolveSubjectAttributes` used consistently across Tasks 1-6, 12, 14. `ValidateManifestPolicySchemas` used consistently across Tasks 7-10, 13. `countingAttributeResolverClient` used consistently across Tasks 11-13.
+
+**Scope check:** spec and plan both focused on one subsystem (plugin ABAC hardening). No decomposition needed.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-07-plugin-abac-hardening.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Recommended because the plan has 19 tasks and subagent isolation keeps the main context window clean while preserving TDD discipline per task.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints for review. Faster wall-clock but risks context pollution across 19 tasks.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-06-grpcbroker-service-injection-design.md
+++ b/docs/superpowers/specs/2026-04-06-grpcbroker-service-injection-design.md
@@ -38,9 +38,9 @@ callable from the plugin subprocess via the GRPCBroker.
    a. Resolve the service from `ServiceRegistry` → get `RegisteredService.Conn`
    b. Assign a broker ID (sequential `uint32`)
    c. Call `broker.AcceptAndServe(id, NewBrokerProxy(conn))` — starts a reverse
-      gRPC server that transparently proxies all calls to the real service
+   gRPC server that transparently proxies all calls to the real service
    d. Add to `required_services` map:
-      `"holomush.world.v1.WorldService" → "broker:42"`
+   `"holomush.world.v1.WorldService" → "broker:42"`
 4. Pass `required_services` in `InitRequest.Config`
 5. Plugin calls `broker.Dial(42)` → gets a `grpc.ClientConn` for WorldService
 6. Plugin creates typed client: `worldv1.NewWorldServiceClient(conn)`

--- a/docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md
+++ b/docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md
@@ -514,3 +514,76 @@ for _, cmd := range dp.Manifest.Commands {
 | Proxy provider latency affects ABAC evaluation | Existing circuit breaker + caching infrastructure applies automatically |
 | Seed migration breaks existing E2E tests | Full test suite (59 E2E + unit) must pass after migration |
 | Trust escalation abused by malicious plugin | Requires server-side allowlist — admin must explicitly opt in |
+
+---
+
+## Hardening (2026-04-07)
+
+This section documents hardening work that landed after the original spec and
+resolved two architectural sharp edges identified during the subsequent plugin
+ABAC review. See `docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md`
+for the full design.
+
+### Sharp Edge 1 — synthetic `__preflight__` resource ID → eliminated
+
+The original design had `engine.CanPerformAction` construct a synthetic
+resource ID of the form `<resourceType>:__preflight__` and call
+`resolver.Resolve`. This caused plugin `ResolveResource` RPCs to be invoked
+with fake instance IDs during type-level capability pre-flight, with no
+documented contract for how plugins should handle the case.
+
+**Resolution (C1):** `Resolver.ResolveSubjectAttributes(ctx, subject, action)`
+was added as a new entry point that resolves only subject, environment, and
+action attributes — resource providers are never called. `CanPerformAction`
+was rewritten to use this method. The `__preflight__` literal was deleted
+from `internal/access/policy/engine.go` (enforced by a static test in
+`internal/access/policy/hardening_invariants_test.go`).
+
+**New invariant:** `PluginAttributeProvider.ResolveResource` is called if and
+only if the host has a real resource instance ID that corresponds to a
+resource owned by that namespace. There is no synthetic ID, no sentinel, no
+preflight-aware code path, and no documented plugin contract for handling
+non-existent IDs.
+
+**Guidance superseded:** any guidance in this original spec suggesting that
+plugins "should handle non-instance IDs gracefully" is obsolete. Plugins only
+receive real instance IDs.
+
+### Sharp Edge 2 — silent schema validation drops → load-time fatal
+
+The original design logged a `slog.Info` warning when a manifest policy
+referenced an attribute not in the plugin's `GetSchema` response. A typo in
+the policy DSL (e.g., `resource.widget.tipe` instead of `resource.widget.type`)
+would produce a silent always-false condition discoverable only by reading
+load-time log lines.
+
+**Resolution (S1):** the cross-validation logic was extracted from
+`CheckManifestWarnings` Warning 3 into a new function
+`ValidateManifestPolicySchemas` in `internal/plugin/policy_schema_validator.go`.
+This function is called from `Manager.loadPlugin` before policy installation,
+and a non-nil return fails the load via the existing rollback path. Runtime
+`mergeAttributes` drop behavior (warn + Prometheus counter, non-fatal) is
+unchanged — the runtime path catches a different failure mode (plugin returns
+keys outside its declared schema) and remains lenient to avoid breaking
+healthy plugin traffic.
+
+The resolver also gained an `UnregisterProvider` method so that failed
+validation cleanly removes the plugin's attribute provider from the registry,
+allowing a fixed manifest to be re-loaded without "already registered" errors.
+The Task 14 investigation also closed four additional rollback leak paths in
+`Manager.loadPlugin` beyond just the validator-failure branch.
+
+### Test coverage added
+
+- 11 unit tests on `Resolver.ResolveSubjectAttributes` (internal/access/policy/attribute/resolver_test.go)
+- 1 engine unit test (T5) + 1 optimistic-permit test (T6) + reuse of 4 pre-existing CanPerformAction tests as regression coverage (T7/T22/T23/T24)
+- 1 static invariant test (T32 — asserts `__preflight__` is absent from engine.go)
+- 12 unit tests on `ValidateManifestPolicySchemas`
+- 4 integration tests on load-time validation failure with real plugin binary + PostgreSQL
+- 3 integration tests on the C1 invariant with counting proxy over the real plugin client
+- 1 unit test on `Resolver.UnregisterProvider` and 1 manager-level test (T35) on rollback
+
+### Documentation
+
+- Plugin author guide: `site/docs/extending/abac-attribute-resolver.md`
+- Internal doc comments updated in `pkg/plugin/service.go` and `plugins/test-abac-widget/main.go`

--- a/docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
@@ -217,24 +217,25 @@ Current sequence in `Manager.loadPlugin`:
 4. CheckManifestWarnings(manifest, schemas)  // non-fatal; Warning 3 is Sharp Edge 2's current defense
 ```
 
-New sequence:
+New sequence (as shipped):
 
 ```text
 1. host.Load(ctx, manifest, pluginDir)
-2. discoverAndRegisterAttributes(ctx, host, dp)
-3. ValidateManifestPolicySchemas(manifest, schemas)  // NEW: hard failure here
-4. InstallPluginPoliciesWithManifest(ctx, manifest, manifest.Policies)
-5. CheckManifestWarnings(manifest, schemas)          // Warning 3 case removed
+2. discoverAndRegisterAttributes(ctx, host, dp)        // registers PluginAttributeProvider on shared resolver
+3. ValidateManifestPolicySchemas(dp.Manifest, schemas) // hard failure here, runs before any DB write
+4. InstallPluginPoliciesWithManifest(ctx, dp.Manifest, dp.Manifest.Policies)
+5. CheckManifestWarnings(dp.Manifest)                  // single-arg; Warning 3 removed; schemas no longer needed
 ```
 
 Validation MUST run before policy install so the database stays clean on failure.
 
 ### Rollback on validation failure
 
-The existing install-failure rollback path at `manager.go:488-493` MUST be extended to handle the validation failure case:
+The validator-failure branch in `Manager.loadPlugin` unwinds the provider registrations performed in step 2 BEFORE calling `host.Unload`:
 
 ```go
 if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+    m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
     if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
         slog.Error("failed to rollback plugin load after schema validation failure",
             "plugin", dp.Manifest.Name, "error", unloadErr)
@@ -244,7 +245,13 @@ if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil 
 }
 ```
 
-**Implementation note:** `host.Unload` tears down the plugin process but may not unregister the `PluginAttributeProvider` from the shared `attribute.Resolver`. This is flagged as an implementation-time investigation — if the unregistration is missing, add an `UnregisterProvider` method to the resolver and call it during rollback. This is a rollback completeness concern that T35 in the test plan is designed to catch.
+**Implementation finding (Task 14):** The Task 14 investigation found that `host.Unload` does NOT unregister `PluginAttributeProvider` from the shared `attribute.Resolver`, AND it found four additional rollback leak paths beyond the validator-failure branch (partial-loop failure inside `discoverAndRegisterAttributes`, policy-install failure, and three service-registration failures). All five gaps are now closed by:
+
+- New `Resolver.UnregisterProvider(namespace) bool` — removes the provider, providerOrder entry, circuit breaker, AND the schema from the underlying registry (the schema cleanup uses `SchemaRegistry.UnregisterForRollback`, which bypasses the policy-reference safety check that `RemoveNamespace` performs because rollback runs before any policies could possibly reference the namespace).
+- New `plugins.UnregisterPluginProviderFunc` type + `WithAttributeProviderUnregistrar` Manager option — symmetric with the existing registrar option.
+- New `Manager.unregisterPluginProviders(pluginName, resourceTypes, upTo int)` helper — supports partial unwinds via `upTo` for the in-loop failure case.
+
+T35 (`TestManagerLoadAllUnregistersAttributeProviderWhenSchemaValidationFailsAfterRegistration`) lives at the manager level and asserts the registrar+unregistrar pair is invoked correctly when validation fails.
 
 ### Edge cases
 
@@ -284,7 +291,7 @@ Location: `internal/access/policy/attribute/resolver_test.go`
 | T17 | `TestResolverResolveSubjectAttributesPopulatesActionNameEvenWhenEmpty` | Empty action permitted (matches `Resolve`) |
 | T18 | `TestResolverResolveSubjectAttributesReturnsErrorWhenContextAlreadyCancelled` | Context cancellation honored |
 | T19 | `TestResolverResolveSubjectAttributesRecoversFromPanickingProvider` | Panic safety via `safeResolve` reuse |
-| T20 | `TestResolverResolveSubjectAttributesPanicsOnReentrance` | Re-entrance guard shared with `Resolve` |
+| T20 | `TestResolverResolveSubjectAttributesDetectsReentranceAndReturnsErrorNotInfiniteLoop` | Re-entrance guard fires; the panic is caught by `safeResolve` and surfaced as a provider-panic error (not propagated to the caller) |
 | T21 | `TestResolverResolveSubjectAttributesProducesSameSubjectBagAsResolveForSameInput` | Cross-check invariant — C1 is behavior-preserving for subject path |
 | T39 | `TestResolverResolveSubjectAttributesIsSafeForConcurrentCalls` | Thread safety smoke test with `-race` |
 
@@ -294,12 +301,12 @@ Location: `internal/access/policy/engine_test.go`
 
 | ID | Name | What it proves |
 |---|---|---|
-| T5 | `TestEngineCanPerformActionCallsResolveSubjectAttributesNotResolve` | Engine wired to new path |
+| T5 | `TestEngineCanPerformActionDoesNotInvokeResourceProvidersWhenCapabilityCheckRuns` | Engine wired to new path — uses a tracking provider to assert resource provider calls stay at zero, AND asserts subject resolution did run (guards against silent no-op regression) |
 | T6 | `TestEngineCanPerformActionPermitsOptimisticallyForPermitReferencingResourceAttrs` | Optimistic permit branch still fires |
-| T7 | `TestEngineCanPerformActionFailsClosedWhenResolveSubjectAttributesErrors` | Fail-closed via new path |
-| T22 | `TestEngineCanPerformActionReturnsErrEngineDegradedWithoutCallingResolver` | Degraded mode short-circuits |
-| T23 | `TestEngineCanPerformActionReturnsErrorWhenContextAlreadyCancelled` | Cancellation short-circuits |
-| T24 | `TestEngineCanPerformActionRejectsMalformedSubjectRef` | Format validation precedes resolver call |
+| T7 | `TestEngineCanPerformActionAttributeResolutionError` (pre-existing) | Fail-closed via new path — pre-existing test passes after refactor as regression coverage |
+| T22 | `TestEngineCanPerformActionDegradedMode` (pre-existing) | Degraded mode short-circuits — pre-existing test passes after refactor as regression coverage |
+| T23 | `TestEngineCanPerformActionContextCancelled` (pre-existing) | Cancellation short-circuits — pre-existing test passes after refactor as regression coverage |
+| T24 | `TestEngine_CanPerformAction_InvalidSubjectFormat` (pre-existing) | Format validation precedes resolver call — pre-existing test passes after refactor as regression coverage |
 
 ### Layer 3 — Manifest validator unit tests
 
@@ -401,8 +408,8 @@ The original spec MUST NOT be rewritten; the addendum preserves the historical r
 |---|---|
 | `pkg/plugin/service.go` | `AttributeResolverProvider` comment: state the host invariant that `ResolveResource` is only called with real instance IDs |
 | `internal/access/policy/engine.go` | `CanPerformAction` doc comment: remove "synthetic request" language; add "resource providers are never invoked" |
-| `internal/access/policy/attribute/resolver.go` | `ResolveSubjectAttributes` doc comment per Section 4a; emphasize "never calls resource providers" |
-| `internal/plugin/manifest_warnings.go` | `ValidateManifestPolicySchemas` doc comment with rationale for first-error return |
+| `internal/access/policy/attribute/resolver.go` | `ResolveSubjectAttributes` doc comment per Section 4a; emphasize "never calls resource providers". Also `UnregisterProvider` doc comment covers the schema-cleanup invariant. |
+| `internal/plugin/policy_schema_validator.go` | `ValidateManifestPolicySchemas` doc comment with rationale for first-error return (extracted from `manifest_warnings.go` Warning 3) |
 
 ### Bead cross-references
 

--- a/docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
@@ -1,0 +1,431 @@
+# Plugin ABAC Hardening Design
+
+**Status:** Approved
+**Date:** 2026-04-07
+**Author:** seanb4t (via Claude Opus 4.6)
+**Bead:** holomush-479l
+**Blocks:** holomush-0sc.12 (channel plugin rework)
+**Related:** docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md (establishes the trust boundary this spec hardens)
+
+## RFC2119 Keywords
+
+| Keyword        | Meaning                                    |
+| -------------- | ------------------------------------------ |
+| **MUST**       | Absolute requirement                       |
+| **MUST NOT**   | Absolute prohibition                       |
+| **SHOULD**     | Recommended, may ignore with justification |
+| **SHOULD NOT** | Not recommended                            |
+| **MAY**        | Optional                                   |
+
+## Problem
+
+The plugin ABAC trust boundary from PR #195 introduces `AttributeResolverService` for binary plugins to resolve resource attributes for their declared `resource_types`. Two architectural sharp edges in that design are untested and present operational risk for any plugin that adopts the maximalist ABAC pattern (returning list-typed resource attributes and relying on policy evaluation at preflight time).
+
+This spec describes the hardening that closes both sharp edges. It MUST land before plugins like `core-channels` (holomush-0sc.12) can safely use list-typed resource attributes via the resolver.
+
+### Sharp Edge 1: Synthetic preflight resource ID flows into plugin RPC
+
+Layer 2 capability pre-flight (`internal/command/access.go:CheckCapabilityPreFlight`) calls `engine.CanPerformAction(subject, action, resourceType, scope)` for each declared command capability. `internal/access/policy/engine.go:401` constructs a synthetic resource ID of the form `<resourceType>:__preflight__` and passes it to `resolver.Resolve`. The resolver iterates all registered providers, including any `PluginAttributeProvider` for the matching namespace.
+
+For a plugin declaring `resource_types: [channel]`, this means the plugin's `AttributeResolverService.ResolveResource(channel, "__preflight__")` RPC is invoked once per pre-flight check, every time anyone runs the channel command, with a non-real resource ID. The plugin has no documented contract for what to do with this.
+
+If the plugin:
+
+- **Errors out** (e.g., "channel not found in DB") → `safeResolve` returns the error, the resolver returns non-nil, `CanPerformAction` step 6 fails closed, pre-flight fails for every caller. Plugin command unusable in production.
+- **Returns "real" attributes for `__preflight__`** → policies evaluate against synthetic state, may pass or fail incorrectly.
+- **Returns empty/nil attributes** → optimistic-permit branch at `engine.go:490` fires, pre-flight passes, instance-level `Evaluate` enforces the real check. This is the correct behavior — but there is no documentation telling plugin authors this is what they MUST do, no host-side defense against the other two cases, and `plugins/test-abac-widget/main.go` only satisfies the contract by accident (its default `widgetType := "normal"` covers `__preflight__` coincidentally).
+
+### Sharp Edge 2: Schema validation silently drops unknown attribute keys
+
+`internal/access/policy/attribute/resolver.go:312-327` `mergeAttributes` validates each returned attribute against the namespace's registered schema. Keys not in the schema are dropped with a `slog.Warn` log and a Prometheus counter increment (`abac_rejected_provider_attributes_total{namespace,key}`), but the resolver returns success.
+
+If a plugin returns an attribute that isn't declared in its `GetSchema` response, OR if a policy references an attribute the plugin forgot to declare, the attribute is silently absent from the bag. Policies that depend on it evaluate as false (or true via optimistic preflight), with no surfaced error.
+
+Additionally, `internal/plugin/manifest_warnings.go:CheckManifestWarnings` contains a load-time cross-validation (Warning 3) that walks each policy's AST, collects `resource.<type>.<attr>` references, and warns when `<attr>` isn't in the plugin's `GetSchema` response. This cross-validation IS wired in at `internal/plugin/manager.go:498` but logs via `slog.Info` — a plugin author who typos `resource.widget.tipe == "normal"` in a policy gets a silent always-false condition discoverable only by reading load-time log lines.
+
+## Decisions
+
+### Sharp Edge 1 resolution: C1 — eliminate the synthetic preflight ID at the host layer
+
+**Decision:** Add a new method `Resolver.ResolveSubjectAttributes(ctx, subject, action)` that resolves only subject, environment, and action attributes. `engine.CanPerformAction` MUST call this method instead of constructing `<type>:__preflight__` and calling `Resolve`. The `__preflight__` literal MUST be deleted from the codebase.
+
+**Alternatives considered:**
+
+| Option | Description | Rejected because |
+|---|---|---|
+| **(i)** Documentation only | Add prominent docs requiring plugin authors to handle synthetic IDs gracefully | Pushes correctness burden onto every plugin author forever; leaky abstraction; no defense in depth |
+| **(ii)** Host-side filter in `PluginAttributeProvider` | Detect synthetic IDs and short-circuit before calling plugin RPC | Papers over the abstraction bug; still has `__preflight__` literal in the engine |
+| **(iii-literal)** New plugin proto RPC `GetDefaultAttributes` | Plugin RPC for type-level defaults | Proto change, SDK churn, forces plugin migration, solves no real use case — type-level attributes are a mis-modeling; preflight needs only subject attributes |
+| **(C1, chosen)** Subject-only resolution path | Engine never resolves resource attributes at preflight | Deletes the bug rather than filtering it; no proto change; plugin authors never need to know preflight exists; invariant is enforced by construction |
+
+**Rationale:** Type-level preflight only needs subject attributes. Resource attributes are intentionally absent — the optimistic-permit branch at `engine.go:490` already handles permits whose conditions reference resource attrs by treating them as "may apply, instance-level `Evaluate` will enforce the full condition." The synthetic `__preflight__` exists only because `Resolver.Resolve(ctx, AccessRequest)` requires a well-formed access request including a resource. A separate entry point eliminates the need.
+
+### Sharp Edge 2 resolution: S1 — load-time cross-validation becomes fatal
+
+**Decision:** Extract the policy/schema cross-validation from `CheckManifestWarnings` Warning 3 into a new function `ValidateManifestPolicySchemas(manifest, schemas) error`. This function MUST be called during `Manager.loadPlugin`, before policy installation, and a non-nil return MUST cause the plugin load to fail via the existing rollback path. The runtime `mergeAttributes` drop behavior (warn + counter, non-fatal) is unchanged.
+
+**Alternatives considered:**
+
+| Option | Description | Rejected because |
+|---|---|---|
+| **S2** Runtime strict (fail `mergeAttributes` on unknown key) | Resolver returns error when a provider returns an undeclared attribute | Introduces a new failure path that could take down healthy plugin traffic over one extra undeclared attribute; typos are better caught at load time |
+| **S3** Both load-time and runtime strict | Defense in depth at both layers | Same runtime risk as S2 with no additional benefit beyond S1 — load-time typo catches are the real win |
+| **S4** Load-time fatal + probe-based runtime validation | Load-time sample-ID probe to verify `GetSchema` matches `ResolveResource` | New contract surface (sample IDs); marginal benefit over S1; too clever |
+| **S1 (chosen)** Load-time strict only | Policy DSL typos fail at load, runtime stays lenient | Closes the dangerous gap (typos in policy DSL silently evaluating as false) without breaking live traffic for honest plugin bugs |
+
+**Rationale:** The dangerous failure mode in Sharp Edge 2 is a plugin author typoing a policy attribute name and not noticing. S1 catches this at deploy time. The "runtime returns keys not in schema" failure mode is a plugin implementation bug best caught by tests and the existing Prometheus counter, not by failing live authorization requests.
+
+## Architecture
+
+The hardening lands as two host-side surgical changes confined to `internal/access/policy/` and `internal/plugin/`. No proto, SDK, or plugin binary changes.
+
+| File | Change | Lines |
+|---|---|---|
+| `internal/access/policy/attribute/resolver.go` | Add `ResolveSubjectAttributes` method | ~30 |
+| `internal/access/policy/engine.go` | `CanPerformAction` calls new method; delete `__preflight__` literal | ~15 |
+| `internal/plugin/manifest_warnings.go` or new `policy_schema_validator.go` | Extract `ValidateManifestPolicySchemas`; remove Warning 3 case | ~60 |
+| `internal/plugin/manager.go` | Call validator before policy install; fail load on error | ~15 |
+| `pkg/plugin/service.go` | Doc comment update on `AttributeResolverProvider` | ~10 |
+| `plugins/test-abac-widget/main.go` | Doc comment update on `widgetResolver` | ~15 |
+| Test files | See Section 4 | ~600 |
+
+### Invariant established
+
+After this change, `PluginAttributeProvider.ResolveResource` MUST be called if and only if the host has a real resource instance ID that it believes corresponds to a resource owned by that namespace. There MUST be no synthetic ID, no sentinel, no preflight-aware code path, and no documented plugin contract for handling "fake" IDs. This invariant MUST be enforced by construction (the code path does not exist), not by filtering.
+
+## Change A: Subject-only resolution (Sharp Edge 1, C1)
+
+### New method signature
+
+```go
+// ResolveSubjectAttributes resolves subject, action, and environment attributes
+// for a type-level capability check (preflight). It never calls resource
+// providers, which makes it safe to use when no resource instance is available.
+//
+// Returns AttributeBags with Subject/Action/Environment populated and Resource
+// empty. Error semantics match Resolve: partial success returns both bags and
+// error; callers MUST fail closed on non-nil error and MUST NOT use partial
+// bags for policy evaluation.
+func (r *Resolver) ResolveSubjectAttributes(
+    ctx context.Context,
+    subject, action string,
+) (*types.AttributeBags, error)
+```
+
+### Internals
+
+The method MUST:
+
+- Validate `subject` via the existing `validateEntityRef` (empty or malformed → error with `INVALID_ENTITY_REF`)
+- Mark the context with the existing re-entrance guard (`markInResolution`) and cache scope (`withCache`)
+- Populate `bags.Action["name"] = action` (matching `Resolve`)
+- Call the unexported `resolveEntity(ctx, "subject", subject, bags.Subject)` exactly as `Resolve` does
+- Call `resolveEnvironment(ctx, bags.Environment)` exactly as `Resolve` does
+- NOT call `resolveEntity(ctx, "resource", ...)`
+- Return joined errors via `errors.Join` matching `Resolve`'s semantics
+
+### Engine call site changes
+
+`engine.go:CanPerformAction` Step 4 changes from:
+
+```go
+// Step 4: Resolve subject attributes via a synthetic request.
+syntheticReq, reqErr := types.NewAccessRequest(subject, action, resourceType+":__preflight__")
+if reqErr != nil { ... }
+bags, resolveErr := e.resolver.Resolve(ctx, syntheticReq)
+```
+
+to:
+
+```go
+// Step 4: Resolve subject + environment attributes only. No resource
+// instance exists at type-level preflight; resource providers are never
+// called. The optimistic-permit branch below handles permits whose
+// conditions reference resource attributes.
+bags, resolveErr := e.resolver.ResolveSubjectAttributes(ctx, subject, action)
+```
+
+Steps 1-3 (context cancellation, degraded mode, subject format validation) MUST remain identical. Steps 5-10 (cache snapshot, policy filtering, optimistic permit branch, forbid-overrides-permit) MUST remain unchanged — they already work correctly when `bags.Resource` is empty.
+
+The `resourceType+":__preflight__"` literal MUST be deleted. The `resourceType` parameter is still used by Step 6 to filter candidate policies by resource type and remains.
+
+### Inherited safety properties
+
+| Mechanism | Behavior | How it's preserved |
+|---|---|---|
+| Re-entrance guard | Panic on recursive resolver call | Uses same context key as `Resolve` |
+| Request-scoped attribute cache | Fresh cache per call | Uses same `withCache(ctx)` |
+| Circuit breakers | Per-namespace failure tracking | Only subject providers' CBs trip, because resource providers are never called |
+| Provider panic recovery | Panic → error with provider context | Reuses `safeResolve` path |
+| Subject ref validation | Fail with `INVALID_ENTITY_REF` on malformed refs | Reuses `validateEntityRef` |
+| Context cancellation | Fail closed when ctx is cancelled | Same short-circuit as `Resolve` |
+
+## Change B: Load-time cross-validation hardening (Sharp Edge 2, S1)
+
+### New function signature
+
+```go
+// ValidateManifestPolicySchemas verifies that every attribute reference in
+// each manifest policy's DSL exists in the plugin's declared schema for the
+// policy's resource type. Returns a non-nil error on the first mismatch so
+// the plugin load fails before any policy is installed.
+//
+// schemas is the schema map discovered via GetSchema during plugin load.
+// Plugins without resource_types (schemas == nil or empty) are out of scope
+// for this check and return nil.
+//
+// Unparseable policies are skipped — ValidatePluginPolicy has already
+// rejected them by the time this function runs.
+func ValidateManifestPolicySchemas(
+    manifest *Manifest,
+    schemas map[string]*types.NamespaceSchema,
+) error
+```
+
+### Error format
+
+The returned error MUST wrap a descriptive message with `oops` context. Concrete format:
+
+```text
+policy "widget-read-normal" references attribute "tipe" on resource type "widget" which is not in the declared schema
+```
+
+with oops fields:
+
+| Field | Value |
+|---|---|
+| `plugin` | The plugin name from the manifest |
+| `policy` | The offending policy name |
+| `resource_type` | The resource type in the policy target |
+| `attribute` | The undeclared attribute name |
+| `schema_keys` | `[]string` of attributes that WERE declared, as a debugging hint |
+
+Error code (via `oops.Code`): `PLUGIN_SCHEMA_VALIDATION_FAILED`.
+
+### Single error vs. aggregated errors
+
+The function MUST return on the first mismatch rather than aggregating. A plugin author fixing one typo will re-run the load anyway; aggregation only helps for multi-typo fixes, which are rare. A single clear error is more agent-friendly and simpler to test. If experience shows aggregation is wanted later, it's a non-breaking follow-up.
+
+### Load path sequence
+
+Current sequence in `Manager.loadPlugin`:
+
+```text
+1. host.Load(ctx, manifest, pluginDir)
+2. discoverAndRegisterAttributes(ctx, host, dp)  // GetSchema, returns schemas
+3. InstallPluginPoliciesWithManifest(ctx, manifest, manifest.Policies)
+4. CheckManifestWarnings(manifest, schemas)  // non-fatal; Warning 3 is Sharp Edge 2's current defense
+```
+
+New sequence:
+
+```text
+1. host.Load(ctx, manifest, pluginDir)
+2. discoverAndRegisterAttributes(ctx, host, dp)
+3. ValidateManifestPolicySchemas(manifest, schemas)  // NEW: hard failure here
+4. InstallPluginPoliciesWithManifest(ctx, manifest, manifest.Policies)
+5. CheckManifestWarnings(manifest, schemas)          // Warning 3 case removed
+```
+
+Validation MUST run before policy install so the database stays clean on failure.
+
+### Rollback on validation failure
+
+The existing install-failure rollback path at `manager.go:488-493` MUST be extended to handle the validation failure case:
+
+```go
+if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+    if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+        slog.Error("failed to rollback plugin load after schema validation failure",
+            "plugin", dp.Manifest.Name, "error", unloadErr)
+    }
+    return oops.In("manager").With("plugin", dp.Manifest.Name).
+        Wrapf(valErr, "validate manifest policy schemas")
+}
+```
+
+**Implementation note:** `host.Unload` tears down the plugin process but may not unregister the `PluginAttributeProvider` from the shared `attribute.Resolver`. This is flagged as an implementation-time investigation — if the unregistration is missing, add an `UnregisterProvider` method to the resolver and call it during rollback. This is a rollback completeness concern that T35 in the test plan is designed to catch.
+
+### Edge cases
+
+| Edge case | Behavior |
+|---|---|
+| Plugin without `resource_types` | `schemas == nil` or empty → validator returns nil immediately |
+| Trust-escalated plugin | No special treatment — typos still fail the load |
+| Policy without `when` clause | `referencedResourceAttrs` returns empty slice → nil error |
+| Policy referencing `environment.*` or `principal.*` | Not a resource reference → ignored by validator |
+| Policy targeting resource type not in `ResourceTypes` | Already rejected by `ValidatePluginPolicy.validateCharacterPolicy` before this validator runs |
+| Multiple bad policies | Return on first mismatch (documented in tests) |
+
+### What stays a warning
+
+`CheckManifestWarnings` continues to run in step 5 with Warning 3's case removed:
+
+- **Warning 1** — "command X has no execute policy covering it" stays as warning. A plugin author MAY intentionally declare a public command with no ABAC enforcement.
+- **Warning 2** — "command X declares capability with no permit policy" stays as warning. A command MAY require capabilities granted by server-installed policies.
+
+These are *coverage gap* hints, not *correctness bugs*, and hard-failing them would break legitimate plugin patterns.
+
+## Test Plan
+
+Tests are named per the ACE framework from `CLAUDE.md` (every test name is a sentence: Action + Condition + Expectation).
+
+### Layer 1 — Resolver unit tests
+
+Location: `internal/access/policy/attribute/resolver_test.go`
+
+| ID | Name | What it proves |
+|---|---|---|
+| T1 | `TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment` | Happy path: subject/env/action populated, resource empty |
+| T2 | `TestResolverResolveSubjectAttributesReturnsErrorForInvalidSubjectRef` | Subject validation consistent with `Resolve` |
+| T3 | `TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectProviderFails` | Fail-closed semantics preserved |
+| T4 | `TestResolverResolveSubjectAttributesDoesNotInvokeResourceProviderWhenResourceProviderExists` | Core C1 invariant — resource providers never called even when registered |
+| T16 | `TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectIsEmpty` | Empty subject rejected |
+| T17 | `TestResolverResolveSubjectAttributesPopulatesActionNameEvenWhenEmpty` | Empty action permitted (matches `Resolve`) |
+| T18 | `TestResolverResolveSubjectAttributesReturnsErrorWhenContextAlreadyCancelled` | Context cancellation honored |
+| T19 | `TestResolverResolveSubjectAttributesRecoversFromPanickingProvider` | Panic safety via `safeResolve` reuse |
+| T20 | `TestResolverResolveSubjectAttributesPanicsOnReentrance` | Re-entrance guard shared with `Resolve` |
+| T21 | `TestResolverResolveSubjectAttributesProducesSameSubjectBagAsResolveForSameInput` | Cross-check invariant — C1 is behavior-preserving for subject path |
+| T39 | `TestResolverResolveSubjectAttributesIsSafeForConcurrentCalls` | Thread safety smoke test with `-race` |
+
+### Layer 2 — Engine unit tests
+
+Location: `internal/access/policy/engine_test.go`
+
+| ID | Name | What it proves |
+|---|---|---|
+| T5 | `TestEngineCanPerformActionCallsResolveSubjectAttributesNotResolve` | Engine wired to new path |
+| T6 | `TestEngineCanPerformActionPermitsOptimisticallyForPermitReferencingResourceAttrs` | Optimistic permit branch still fires |
+| T7 | `TestEngineCanPerformActionFailsClosedWhenResolveSubjectAttributesErrors` | Fail-closed via new path |
+| T22 | `TestEngineCanPerformActionReturnsErrEngineDegradedWithoutCallingResolver` | Degraded mode short-circuits |
+| T23 | `TestEngineCanPerformActionReturnsErrorWhenContextAlreadyCancelled` | Cancellation short-circuits |
+| T24 | `TestEngineCanPerformActionRejectsMalformedSubjectRef` | Format validation precedes resolver call |
+
+### Layer 3 — Manifest validator unit tests
+
+Location: `internal/plugin/manifest_warnings_test.go` or new `policy_schema_validator_test.go`
+
+| ID | Name | What it proves |
+|---|---|---|
+| T8 | `TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSchema` | Core S1 fail-closed path |
+| T9 | `TestValidateManifestPolicySchemasAcceptsPolicyWhenAllAttributeReferencesMatchSchema` | Happy path; no false positives |
+| T10 | `TestValidateManifestPolicySchemasReturnsNilForPluginWithoutResourceTypes` | Plugins without resource types bypass cleanly |
+| T11 | `TestValidateManifestPolicySchemasAcceptsPolicyWithoutWhenClause` | Unconditional policies accepted |
+| T12 | `TestValidateManifestPolicySchemasIgnoresEnvironmentAndPrincipalAttributeReferences` | Validator scope is resource-only |
+| T25 | `TestValidateManifestPolicySchemasReturnsNilForEmptyNonNilSchemaMap` | Boundary: empty map vs nil map |
+| T26 | `TestValidateManifestPolicySchemasReturnsNilWhenPolicyTypeWasAlreadyRejectedByPluginValidator` | Documents the layering assumption |
+| T27 | `TestValidateManifestPolicySchemasReportsFirstErrorWhenMultiplePoliciesHaveBadAttributes` | Documents first-error policy |
+| T28 | `TestValidateManifestPolicySchemasHandlesCompoundConditionsWithANDORNot` | AST walker recurses into all boolean ops |
+| T29 | `TestValidateManifestPolicySchemasHandlesHasAndContainsReferences` | `has` and `contains` DSL nodes covered |
+| T30 | `TestValidateManifestPolicySchemasHandlesInExprWithDynamicBothSides` | `in` expression with bilateral dynamic refs (from validated DSL feature in the bead) |
+| T31 | `TestValidateManifestPolicySchemasAcceptsAttributeNameThatIsPrefixOfValidAttribute` | Exact-match lookup, no substring matching |
+
+### Layer 4 — Integration tests with test-abac-widget plugin
+
+Location: `test/integration/plugin/abac_widget_test.go` (build tag `integration`)
+
+These tests MUST use the real plugin binary and the full engine stack with a real PostgreSQL (via testcontainers).
+
+| ID | Name | What it proves |
+|---|---|---|
+| T13 | `"never invokes the plugin ResolveResource RPC during type-level preflight"` | C1 invariant at E2E layer with real plugin binary |
+| T14 | `"still invokes the plugin ResolveResource RPC for instance-level Evaluate"` | Instance-level evaluation unaffected; plugin sees real IDs only |
+| T15 | `"fails to load a plugin whose manifest policy references an undeclared resource attribute"` | Sharp Edge 2 end-to-end; rollback works; no partial state |
+| T34 | `"installs zero policies in the database when manifest validation fails"` | Direct DB query after failed load; rollback completeness |
+| T35 | `"removes the attribute provider from the resolver registry after failed load"` | Resolver rollback (may reveal existing rollback gap) |
+| T36 | `"successfully loads a fixed manifest after a prior validation failure"` | Idempotency — failed loads don't poison future loads |
+| T37 | `"installs three plugin policies in the database when manifest validation passes"` | Existing happy path + explicit DB query assertion |
+| T38 | `"permits character:01ABC execute widget command via full database-backed engine stack without invoking plugin ResolveResource"` | C1 holds with full stack including DB-backed policy cache |
+
+**T13 implementation note:** Wrap the plugin's `AttributeResolverClient` with a counting proxy (instrumented `pluginv1.AttributeResolverServiceClient` that tracks `ResolveResource` call counts). The proxy MUST be installed during `BeforeEach` before the engine is assembled.
+
+**T15 implementation note:** Construct an in-memory `*Manifest` cloned from `loadWidgetManifest()` but with one policy's DSL mutated to reference `resource.widget.tipe` instead of `resource.widget.type`. No new plugin binary is needed — the test uses the existing binary for schema discovery and a synthetic manifest for policy validation.
+
+### Layer 5 — Static/meta tests
+
+Location: New test file `internal/access/policy/hardening_invariants_test.go`. Using a dedicated file (rather than inlining into `engine_test.go`) keeps the "static assertion about the codebase" tests grouped and easy to discover.
+
+| ID | Name | What it proves |
+|---|---|---|
+| T32 | `TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel` | The `__preflight__` string MUST NOT appear in `internal/access/policy/engine.go` — prevents regression |
+| T33 | `TestResolverResolveSubjectAttributesWhenCombinedWithResolveProducesIdenticalSubjectBag` | Cross-check with full provider set (not just stubs) |
+
+### Test coverage mapping to bead requirements
+
+| Bead test | Disposition | Replacement |
+|---|---|---|
+| #1 CanPerformAction preflight invokes plugin RPC | Inverted | T4 (unit), T13 (E2E) — assert plugin RPC is NEVER invoked |
+| #2 Plugin error during preflight | Removed (unreachable after C1) | — |
+| #3 Plugin empty attrs during preflight | Removed (unreachable after C1) | — |
+| #4 Runtime drops unknown key | Existing coverage (`resolver_test.go:573-575`) | — |
+| #5 Load-time cross-validation | Promoted from warning to fatal | T8, T15, T34 |
+
+### Out of test scope
+
+- **Plugin author ergonomics.** UX of error messages is tested manually, not automated.
+- **Prometheus counter label cardinality.** The `abac_rejected_provider_attributes_total` counter is labeled by `(namespace, key)` — a misbehaving plugin could pump unbounded cardinality. Operational concern, separate bead.
+- **Subject attribute reference validation in policies.** A policy typoing `principal.character.roless contains "admin"` still silently evaluates as false. Flagged as follow-up.
+- **Full load/request concurrency race.** T39 is a smoke test for resolver thread safety. Full race coverage between in-flight requests and plugin load is out of scope.
+
+## Documentation Updates
+
+### Spec addendum
+
+`docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md` MUST gain an appended section `## Hardening (2026-04-07)` that:
+
+- Documents Sharp Edge 1 resolution: C1 chosen, cite new file/line locations
+- Documents Sharp Edge 2 resolution: S1 chosen
+- Marks the original spec's "plugins should handle non-instance IDs" guidance as superseded
+- States the new invariant: plugins receive only real resource instance IDs
+
+The original spec MUST NOT be rewritten; the addendum preserves the historical record.
+
+### Plugin author documentation
+
+`site/docs/extending/` MUST gain a new page titled `Implementing AttributeResolverService`. The preferred file path is `site/docs/extending/abac-attribute-resolver.md`; if an existing ABAC/plugin page is a better home, the content MAY be appended to it. The page MUST cover:
+
+1. What the host calls and when (GetSchema once at load, ResolveResource once per instance-level request)
+2. What the plugin MUST declare (every attribute ResolveResource will ever return MUST appear in GetSchema)
+3. What fails at load time (policy DSL referencing undeclared attributes fails load)
+4. Error handling contract (NotFound vs Internal gRPC codes)
+5. Canonical code example pointing to `plugins/test-abac-widget/main.go`
+6. What NOT to do (don't handle sentinel IDs, don't return undeclared attributes, don't swallow errors)
+
+### Reference widget plugin annotation
+
+`plugins/test-abac-widget/main.go` MUST gain a doc comment on `widgetResolver` clarifying its role as the canonical reference. The existing misleading comment at lines 59-62 about "host-side misrouting bugs" MUST be rewritten to reflect the post-C1 contract. The rejection code itself MUST be retained — it's still correct defense in depth against host routing bugs.
+
+### Internal Go documentation
+
+| File | Update |
+|---|---|
+| `pkg/plugin/service.go` | `AttributeResolverProvider` comment: state the host invariant that `ResolveResource` is only called with real instance IDs |
+| `internal/access/policy/engine.go` | `CanPerformAction` doc comment: remove "synthetic request" language; add "resource providers are never invoked" |
+| `internal/access/policy/attribute/resolver.go` | `ResolveSubjectAttributes` doc comment per Section 4a; emphasize "never calls resource providers" |
+| `internal/plugin/manifest_warnings.go` | `ValidateManifestPolicySchemas` doc comment with rationale for first-error return |
+
+### Bead cross-references
+
+- `holomush-479l` close reason MUST cite the PR number and link to this spec
+- `holomush-0sc.12` MUST be updated noting this hardening has landed; the channel rework can proceed with Option C (hybrid) or the newly-safer maximalist path
+- `holomush-2smp` (P0 policy cache read barrier) — unaffected
+- Any findings during implementation (e.g., rollback gaps from T35, missing `UnregisterProvider`) MUST be filed as discovered-from beads
+
+## Out of Scope
+
+- Implementing the channel plugin (holomush-0sc.12)
+- Performance optimization of plugin attribute resolution (cross-call caching)
+- Server-side trust escalation allowlist UX
+- Refactoring `core-channels` to use maximalist ABAC after this lands
+- Subject attribute reference validation at load time (follow-up)
+- Concurrent load/request race hardening beyond the smoke test
+- Prometheus counter label cardinality mitigation
+
+## Acceptance Criteria
+
+- All 39 tests in the plan land and pass
+- `task pr-prep` passes green (lint, fmt, schema, license, unit, integration, E2E)
+- `__preflight__` literal is absent from `internal/access/policy/engine.go` (verified by T32)
+- `plugins/test-abac-widget/main.go` binary still loads and passes existing E2E tests without modification
+- Documentation updates land in the same PR as the code changes
+- `holomush-0sc.12` (channel plugin rework) is updated to note this hardening has landed and can proceed

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -155,6 +155,66 @@ func (r *Resolver) Resolve(ctx context.Context, req types.AccessRequest) (*types
 	return bags, errors.Join(errs...)
 }
 
+// ResolveSubjectAttributes resolves subject, action, and environment attributes
+// for a type-level capability check (preflight). It never calls resource
+// providers, which makes it safe to use when no resource instance is available.
+//
+// Returns AttributeBags with Subject/Action/Environment populated and Resource
+// empty. Error semantics match Resolve: partial success returns both bags and
+// error; callers MUST fail closed on non-nil error and MUST NOT use partial
+// bags for policy evaluation.
+func (r *Resolver) ResolveSubjectAttributes(ctx context.Context, subject, action string) (*types.AttributeBags, error) {
+	// Input validation runs BEFORE entering the resolution scope. Empty
+	// subject is rejected with nil bags — no work has started, so there
+	// is nothing partial to return. Resolve tolerates empty subjects, but
+	// a type-level capability check always has a principal.
+	if subject == "" {
+		return nil, oops.Code("INVALID_ENTITY_REF").
+			With("field", "subject").
+			Errorf("subject is required for ResolveSubjectAttributes")
+	}
+
+	// Check re-entrance guard (shared with Resolve).
+	if isInResolution(ctx) {
+		panic("resolver re-entrance detected: resolver cannot be called recursively")
+	}
+
+	// Mark as in resolution and attach request-scoped cache.
+	ctx = markInResolution(ctx)
+	ctx = withCache(ctx)
+
+	bags := &types.AttributeBags{
+		Subject:     make(map[string]any),
+		Resource:    make(map[string]any),
+		Action:      make(map[string]any),
+		Environment: make(map[string]any),
+	}
+
+	// Set action name — matches Resolve's contract for bags.Action.
+	bags.Action["name"] = action
+
+	var errs []error
+
+	// Resolve subject attributes. Reuses validateEntityRef for format
+	// consistency with Resolve.
+	if err := validateEntityRef(subject); err != nil {
+		errs = append(errs, oops.With("field", "subject").Wrap(err))
+	} else if err := r.resolveEntity(ctx, "subject", subject, bags.Subject); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Resolve environment attributes.
+	if err := r.resolveEnvironment(ctx, bags.Environment); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Resource providers are intentionally NOT called. The optimistic-permit
+	// branch in engine.CanPerformAction handles permits whose conditions
+	// reference resource attributes.
+
+	return bags, errors.Join(errs...)
+}
+
 // validateEntityRef checks that an entity reference is in "type:id" format
 // with both parts non-empty. This ensures all providers receive validated refs
 // and the ABAC fail-closed guarantee is preserved.

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -75,6 +75,32 @@ func (r *Resolver) RegisterProvider(provider AttributeProvider) error {
 	return nil
 }
 
+// UnregisterProvider removes a provider from the resolver by namespace.
+// Used during plugin load rollback to clean up a provider that was
+// registered before a later load-time step (schema validation, policy
+// install) failed.
+//
+// Returns true if a provider was removed, false if the namespace had
+// no registered provider.
+//
+// Thread safety: Resolver register/unregister paths are not mutex-guarded.
+// Callers MUST only invoke this during plugin load/unload, before Resolve
+// is called concurrently. This matches the RegisterProvider contract.
+func (r *Resolver) UnregisterProvider(namespace string) bool {
+	if _, exists := r.providers[namespace]; !exists {
+		return false
+	}
+	delete(r.providers, namespace)
+	for i, ns := range r.providerOrder {
+		if ns == namespace {
+			r.providerOrder = append(r.providerOrder[:i], r.providerOrder[i+1:]...)
+			break
+		}
+	}
+	delete(r.circuitBreakers, namespace)
+	return true
+}
+
 // RegisterEnvironmentProvider registers an environment provider
 func (r *Resolver) RegisterEnvironmentProvider(provider EnvironmentProvider) error {
 	namespace := provider.Namespace()

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -80,6 +80,17 @@ func (r *Resolver) RegisterProvider(provider AttributeProvider) error {
 // registered before a later load-time step (schema validation, policy
 // install) failed.
 //
+// Removes:
+//   - the provider from r.providers
+//   - the namespace from r.providerOrder
+//   - the per-namespace circuit breaker
+//   - the schema from r.registry (via UnregisterForRollback)
+//
+// The schema cleanup is critical: without it, a replacement provider
+// for the same namespace with a DIFFERENT schema would have its schema
+// silently dropped because RegisterProvider's HasNamespace check would
+// short-circuit re-registration.
+//
 // Returns true if a provider was removed, false if the namespace had
 // no registered provider.
 //
@@ -98,6 +109,11 @@ func (r *Resolver) UnregisterProvider(namespace string) bool {
 		}
 	}
 	delete(r.circuitBreakers, namespace)
+	// Remove the schema from the registry so a replacement provider with
+	// a different schema can register cleanly. Safe here because rollback
+	// only runs before any policies that reference this namespace could
+	// have been installed.
+	r.registry.UnregisterForRollback(namespace)
 	return true
 }
 

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -574,3 +574,34 @@ func TestResolverResolveNamespaceValidationRejectsUnregisteredKeys(t *testing.T)
 	_, exists := bags.Subject["character.unregistered_key"]
 	assert.False(t, exists, "unregistered key must be rejected per Spec S6")
 }
+
+func TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Subject provider returns {role: "admin"} for character:01ABC.
+	subjectProvider := newResolverMockAttributeProvider("character")
+	subjectProvider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(subjectProvider))
+
+	// Environment provider returns {hour: 14.0} — type matches the
+	// AttrTypeFloat schema declaration so the test still passes if
+	// mergeAttributes ever adds runtime type enforcement.
+	envProvider := &mockEnvironmentProvider{
+		namespace: "env",
+		attrs:     map[string]any{"hour": float64(14)},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{"hour": types.AttrTypeFloat},
+		},
+	}
+	require.NoError(t, resolver.RegisterEnvironmentProvider(envProvider))
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.NoError(t, err)
+	require.NotNil(t, bags)
+
+	assert.Equal(t, "admin", bags.Subject["character.role"])
+	assert.Equal(t, float64(14), bags.Environment["env.hour"])
+	assert.Equal(t, "read", bags.Action["name"])
+	assert.Empty(t, bags.Resource, "resource bag must be empty at preflight")
+}

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -6,7 +6,9 @@ package attribute
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/holomush/holomush/internal/access/policy/types"
@@ -740,6 +742,194 @@ func (p *ctxAwareSubjectProvider) ResolveResource(_ context.Context, _ string) (
 }
 
 func (p *ctxAwareSubjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
+	}
+}
+
+func TestResolverResolveSubjectAttributesRecoversFromPanickingProvider(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.shouldPanic = true
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.Error(t, err, "panic must be recovered and returned as error")
+	assert.Contains(t, err.Error(), "panicked")
+	// Pin the panic to the right provider and resolve type so a future
+	// refactor that reroutes panics to a different namespace would fail
+	// this test loudly.
+	errutil.AssertErrorContext(t, err, "namespace", "character")
+	errutil.AssertErrorContext(t, err, "resolve_type", "subject")
+}
+
+func TestResolverResolveSubjectAttributesDetectsReentranceAndReturnsErrorNotInfiniteLoop(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Provider that re-calls the resolver from inside ResolveSubject.
+	// The inner call will hit the re-entrance guard and panic; safeResolve
+	// catches the panic and converts it to an error. The test verifies
+	// this chain works and the resolver does not infinite-loop.
+	reentrant := &reentrantSubjectProvider{resolver: resolver}
+	require.NoError(t, resolver.RegisterProvider(reentrant))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.Error(t, err, "re-entrance should be detected and converted to an error via safeResolve")
+	assert.Contains(t, err.Error(), "panicked",
+		"the re-entrance panic should be caught by safeResolve and surfaced as a provider-panic error")
+	// Pin the surfaced error to the namespace and resolve type so a
+	// future refactor cannot silently route the re-entrance error
+	// somewhere else.
+	errutil.AssertErrorContext(t, err, "namespace", "character")
+	errutil.AssertErrorContext(t, err, "resolve_type", "subject")
+}
+
+// reentrantSubjectProvider intentionally recurses into the resolver from
+// within ResolveSubject to exercise the re-entrance guard. Used only by T20.
+type reentrantSubjectProvider struct {
+	resolver *Resolver
+}
+
+func (p *reentrantSubjectProvider) Namespace() string { return "character" }
+
+func (p *reentrantSubjectProvider) ResolveSubject(ctx context.Context, _ string) (map[string]any, error) {
+	// This recursive call is illegal. The resolver's re-entrance guard
+	// at the top of ResolveSubjectAttributes will panic; safeResolve
+	// (the caller of this method) will catch it.
+	//
+	// The "character:02XYZ" subject is incidental — any well-formed
+	// entity ref triggers the recursive entry, and the test does not
+	// assert anything about it.
+	_, _ = p.resolver.ResolveSubjectAttributes(ctx, "character:02XYZ", "read")
+	return nil, nil
+}
+
+func (p *reentrantSubjectProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *reentrantSubjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
+	}
+}
+
+func TestResolverResolveSubjectAttributesProducesSameSubjectBagAsResolveForSameInput(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	// Also give the provider resource data so Resolve doesn't error.
+	// ResolveSubjectAttributes ignores this.
+	provider.resourceData["character:test-id"] = map[string]any{"role": "ignored"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	// Register an environment provider so the cross-check covers the
+	// environment bag in addition to subject and action. Both methods
+	// use the same r.resolveEnvironment helper, so any divergence here
+	// would represent a regression in C1's behavior preservation.
+	envProvider := &mockEnvironmentProvider{
+		namespace: "env",
+		attrs:     map[string]any{"hour": float64(14)},
+		schema: &types.NamespaceSchema{
+			Attributes: map[string]types.AttrType{"hour": types.AttrTypeFloat},
+		},
+	}
+	require.NoError(t, resolver.RegisterEnvironmentProvider(envProvider))
+
+	// Call ResolveSubjectAttributes.
+	preflightBags, preflightErr := resolver.ResolveSubjectAttributes(
+		context.Background(), "character:01ABC", "read")
+	require.NoError(t, preflightErr)
+
+	// Call Resolve with an access request that includes a resource.
+	req := types.AccessRequest{
+		Subject:  "character:01ABC",
+		Action:   "read",
+		Resource: "character:test-id",
+	}
+	fullBags, fullErr := resolver.Resolve(context.Background(), req)
+	require.NoError(t, fullErr)
+
+	// Subject bags MUST be identical between the two paths — this is the
+	// C1 invariant that ResolveSubjectAttributes is behavior-preserving
+	// for the subject path, differing only by not calling resource
+	// providers.
+	assert.Equal(t, fullBags.Subject, preflightBags.Subject,
+		"ResolveSubjectAttributes and Resolve must produce identical Subject bags for the same (subject, action)")
+	assert.Equal(t, fullBags.Action["name"], preflightBags.Action["name"],
+		"action name must match between the two paths")
+	// Environment bags MUST also be identical — both methods route
+	// environment resolution through the same r.resolveEnvironment helper.
+	assert.Equal(t, fullBags.Environment, preflightBags.Environment,
+		"environment bags must be identical between Resolve and ResolveSubjectAttributes")
+}
+
+func TestResolverResolveSubjectAttributesIsSafeForConcurrentCalls(t *testing.T) {
+	// concurrentCallCount goroutines drives the smoke test. Kept as a
+	// constant so the channel buffer and the loop bound can never drift.
+	const concurrentCallCount = 100
+
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Use a dedicated concurrency-safe provider rather than
+	// resolverMockAttributeProvider, which mutates an unsynchronized
+	// callCount map on every call and would itself race under -race.
+	// This test targets resolver concurrency safety, not mock bookkeeping.
+	provider := &concurrentSubjectProvider{role: "admin"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrentCallCount)
+
+	for i := 0; i < concurrentCallCount; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			subject := fmt.Sprintf("character:%03d", n)
+			bags, err := resolver.ResolveSubjectAttributes(context.Background(), subject, "read")
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if bags.Subject["character.role"] != "admin" {
+				errCh <- fmt.Errorf("subject bag mismatch for %s: got %v", subject, bags.Subject["character.role"])
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent ResolveSubjectAttributes error: %v", err)
+	}
+}
+
+// concurrentSubjectProvider is a read-only, allocation-per-call provider
+// used by the concurrency test. It deliberately performs no shared-state
+// writes so that any race reported under -race must originate in the
+// resolver itself, which is what the test exists to verify.
+type concurrentSubjectProvider struct {
+	role string
+}
+
+func (p *concurrentSubjectProvider) Namespace() string { return "character" }
+
+func (p *concurrentSubjectProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return map[string]any{"role": p.role}, nil
+}
+
+func (p *concurrentSubjectProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *concurrentSubjectProvider) Schema() *types.NamespaceSchema {
 	return &types.NamespaceSchema{
 		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
 	}

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -148,19 +148,33 @@ func TestResolverUnregisterProviderRemovesRegisteredProviderAndFreesNamespaceFor
 	resolver := NewResolver(registry)
 
 	// Register two providers so we can assert selective removal and
-	// preservation of providerOrder for the survivor.
+	// preservation of providerOrder for the survivor. Give widget an
+	// initial schema with one attribute so we can verify the schema
+	// state is fully cleaned up on unregister.
 	widgetProvider := newResolverMockAttributeProvider("widget")
+	widgetProvider.schema = &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"original_attr": types.AttrTypeString},
+	}
 	characterProvider := newResolverMockAttributeProvider("character")
 	require.NoError(t, resolver.RegisterProvider(widgetProvider))
 	require.NoError(t, resolver.RegisterProvider(characterProvider))
+	require.True(t, registry.HasNamespace("widget"),
+		"widget schema must be in the registry after RegisterProvider")
+	require.True(t, registry.IsRegistered("widget", "original_attr"),
+		"original_attr must be in the widget schema")
 
 	// Unregister widget: should return true, remove from providers map,
-	// remove from providerOrder, and drop the circuit breaker.
+	// remove from providerOrder, drop the circuit breaker, AND remove the
+	// schema from the registry.
 	removed := resolver.UnregisterProvider("widget")
 	assert.True(t, removed, "UnregisterProvider should return true for a registered namespace")
 	assert.NotContains(t, resolver.providers, "widget")
 	assert.NotContains(t, resolver.circuitBreakers, "widget")
 	assert.NotContains(t, resolver.providerOrder, "widget")
+	assert.False(t, registry.HasNamespace("widget"),
+		"schema must be removed from the registry on UnregisterProvider")
+	assert.False(t, registry.IsRegistered("widget", "original_attr"),
+		"original_attr must no longer be registered after schema removal")
 	assert.Contains(t, resolver.providers, "character", "unrelated provider must remain registered")
 	assert.Contains(t, resolver.providerOrder, "character")
 
@@ -169,12 +183,31 @@ func TestResolverUnregisterProviderRemovesRegisteredProviderAndFreesNamespaceFor
 	removed = resolver.UnregisterProvider("nonexistent")
 	assert.False(t, removed, "UnregisterProvider should return false for an unknown namespace")
 
-	// After rollback, the namespace must be free for re-registration —
-	// otherwise a retry after a failed load would collide with the stale
-	// entry and produce a confusing "already registered" error.
+	// After rollback, the namespace must be free for re-registration with
+	// a DIFFERENT schema. This is the regression test for CodeRabbit's
+	// finding on PR #199 (holomush-2jv8): if UnregisterProvider leaves
+	// the schema in place, RegisterProvider's HasNamespace short-circuit
+	// would silently drop the new schema.
 	replacementProvider := newResolverMockAttributeProvider("widget")
+	replacementProvider.schema = &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"replacement_attr": types.AttrTypeString,
+			"another_attr":     types.AttrTypeBool,
+		},
+	}
 	require.NoError(t, resolver.RegisterProvider(replacementProvider),
 		"namespace must be available for re-registration after UnregisterProvider")
+
+	// Verify the NEW schema is what's registered, not the old one. If
+	// schema cleanup were missing, HasNamespace would have skipped the
+	// re-registration and IsRegistered would still return false for
+	// replacement_attr while returning true for original_attr.
+	assert.True(t, registry.IsRegistered("widget", "replacement_attr"),
+		"replacement_attr from the new schema must be registered after re-registration")
+	assert.True(t, registry.IsRegistered("widget", "another_attr"),
+		"another_attr from the new schema must be registered after re-registration")
+	assert.False(t, registry.IsRegistered("widget", "original_attr"),
+		"original_attr from the old schema must no longer be registered after replacement")
 }
 
 func TestResolverRegisterEnvironmentProvider(t *testing.T) {

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -143,6 +143,40 @@ func TestResolver_RegisterProvider(t *testing.T) {
 	}
 }
 
+func TestResolverUnregisterProviderRemovesRegisteredProviderAndFreesNamespaceForReregistration(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Register two providers so we can assert selective removal and
+	// preservation of providerOrder for the survivor.
+	widgetProvider := newResolverMockAttributeProvider("widget")
+	characterProvider := newResolverMockAttributeProvider("character")
+	require.NoError(t, resolver.RegisterProvider(widgetProvider))
+	require.NoError(t, resolver.RegisterProvider(characterProvider))
+
+	// Unregister widget: should return true, remove from providers map,
+	// remove from providerOrder, and drop the circuit breaker.
+	removed := resolver.UnregisterProvider("widget")
+	assert.True(t, removed, "UnregisterProvider should return true for a registered namespace")
+	assert.NotContains(t, resolver.providers, "widget")
+	assert.NotContains(t, resolver.circuitBreakers, "widget")
+	assert.NotContains(t, resolver.providerOrder, "widget")
+	assert.Contains(t, resolver.providers, "character", "unrelated provider must remain registered")
+	assert.Contains(t, resolver.providerOrder, "character")
+
+	// Unregister a namespace that was never registered: should return false
+	// and be a safe no-op.
+	removed = resolver.UnregisterProvider("nonexistent")
+	assert.False(t, removed, "UnregisterProvider should return false for an unknown namespace")
+
+	// After rollback, the namespace must be free for re-registration —
+	// otherwise a retry after a failed load would collide with the stale
+	// entry and produce a confusing "already registered" error.
+	replacementProvider := newResolverMockAttributeProvider("widget")
+	require.NoError(t, resolver.RegisterProvider(replacementProvider),
+		"namespace must be available for re-registration after UnregisterProvider")
+}
+
 func TestResolverRegisterEnvironmentProvider(t *testing.T) {
 	registry := NewSchemaRegistry()
 	resolver := NewResolver(registry)

--- a/internal/access/policy/attribute/resolver_test.go
+++ b/internal/access/policy/attribute/resolver_test.go
@@ -6,9 +6,11 @@ package attribute
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/pkg/errutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -604,4 +606,141 @@ func TestResolverResolveSubjectAttributesPopulatesSubjectActionAndEnvironment(t 
 	assert.Equal(t, float64(14), bags.Environment["env.hour"])
 	assert.Equal(t, "read", bags.Action["name"])
 	assert.Empty(t, bags.Resource, "resource bag must be empty at preflight")
+}
+
+func TestResolverResolveSubjectAttributesReturnsErrorForInvalidSubjectRef(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Bags may be non-nil here (validateEntityRef is invoked after the
+	// resolution scope is entered), but the contract is the error is
+	// non-nil. Callers MUST fail closed regardless of bag state.
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "malformed", "read")
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "INVALID_ENTITY_REF")
+}
+
+func TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectProviderFails(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectError = errors.New("database unavailable")
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	_, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "database unavailable")
+}
+
+func TestResolverResolveSubjectAttributesDoesNotInvokeResourceProviderWhenResourceProviderExists(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	// Subject provider in character namespace — contributes the subject bag.
+	subjectProvider := newResolverMockAttributeProvider("character")
+	subjectProvider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(subjectProvider))
+
+	// Resource provider in a different namespace. It has resource data that
+	// would be returned if ResolveResource were called — we use the mock's
+	// per-key callCount (keyed "resource:<id>") to assert zero calls.
+	resourceProvider := newResolverMockAttributeProvider("widget")
+	resourceProvider.resourceData["widget:restricted-1"] = map[string]any{"type": "restricted"}
+	require.NoError(t, resolver.RegisterProvider(resourceProvider))
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "read")
+	require.NoError(t, err)
+
+	// Output invariant: the returned bags.Resource MUST be empty. This
+	// guards against a regression that populates the resource bag through
+	// some path other than ResolveResource (e.g., a future batch API).
+	assert.Empty(t, bags.Resource, "bags.Resource must be empty after preflight resolution")
+
+	// Mechanism invariant: the resource provider's ResolveResource MUST
+	// NOT have been invoked. Use a positive per-key assertion rather than
+	// a filter-loop so the check fails loudly if the mock is refactored.
+	assert.Zero(t, resourceProvider.callCount["resource:widget:restricted-1"],
+		"ResolveResource must not be called during subject-only resolution")
+	// Defense in depth: scan for any other "resource:" keys that may
+	// have been introduced. The positive assertion above is the load-bearing
+	// check; this catches the case where a future code path sends a
+	// different resource ID we didn't predict.
+	for key, n := range resourceProvider.callCount {
+		if strings.HasPrefix(key, "resource:") {
+			assert.Zero(t, n, "unexpected resource-provider call: %s", key)
+		}
+	}
+}
+
+func TestResolverResolveSubjectAttributesReturnsErrorWhenSubjectIsEmpty(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "", "read")
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "INVALID_ENTITY_REF")
+	errutil.AssertErrorContext(t, err, "field", "subject")
+	// Empty-subject validation runs before the resolution scope is entered,
+	// so bags is nil (no partial work to return).
+	assert.Nil(t, bags)
+}
+
+func TestResolverResolveSubjectAttributesPopulatesActionNameEvenWhenEmpty(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	provider := newResolverMockAttributeProvider("character")
+	provider.subjectData["character:01ABC"] = map[string]any{"role": "admin"}
+	require.NoError(t, resolver.RegisterProvider(provider))
+
+	bags, err := resolver.ResolveSubjectAttributes(context.Background(), "character:01ABC", "")
+	require.NoError(t, err)
+	require.NotNil(t, bags)
+
+	// Verify the action name key is actually PRESENT (not just zero-value
+	// from a missing key lookup). The contract is "populates action name
+	// even when empty", so the key must exist.
+	actionName, ok := bags.Action["name"]
+	require.True(t, ok, "action name key must be present in bags.Action")
+	assert.Equal(t, "", actionName)
+}
+
+func TestResolverResolveSubjectAttributesReturnsErrorWhenContextAlreadyCancelled(t *testing.T) {
+	registry := NewSchemaRegistry()
+	resolver := NewResolver(registry)
+
+	cancelAware := &ctxAwareSubjectProvider{}
+	require.NoError(t, resolver.RegisterProvider(cancelAware))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolver.ResolveSubjectAttributes(ctx, "character:01ABC", "read")
+	require.Error(t, err, "cancelled context must produce an error via context-aware provider")
+	assert.ErrorIs(t, err, context.Canceled,
+		"error chain must include context.Canceled so callers can distinguish cancellation")
+}
+
+// ctxAwareSubjectProvider honors context cancellation in ResolveSubject.
+// Lives in resolver_test.go next to the tests that use it.
+type ctxAwareSubjectProvider struct{}
+
+func (p *ctxAwareSubjectProvider) Namespace() string { return "character" }
+
+func (p *ctxAwareSubjectProvider) ResolveSubject(ctx context.Context, _ string) (map[string]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *ctxAwareSubjectProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+func (p *ctxAwareSubjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"role": types.AttrTypeString},
+	}
 }

--- a/internal/access/policy/attribute/schema.go
+++ b/internal/access/policy/attribute/schema.go
@@ -76,6 +76,23 @@ func (r *SchemaRegistry) HasNamespace(namespace string) bool {
 	return r.schema.HasNamespace(namespace)
 }
 
+// UnregisterForRollback removes a namespace from the registry WITHOUT
+// the policy-reference safety check that RemoveNamespace performs.
+//
+// Use ONLY during failed-plugin-load rollback, before any policies that
+// reference the namespace could possibly have been installed. The
+// validator (ValidateManifestPolicySchemas) and policy install both
+// run AFTER provider registration, so a rollback triggered between
+// registration and validation/install is the only safe place to call
+// this.
+//
+// For schema removal during normal plugin lifecycle (unload after a
+// successful load), use RemoveNamespace instead — it scans installed
+// policies and refuses to remove a namespace still in use.
+func (r *SchemaRegistry) UnregisterForRollback(namespace string) {
+	r.schema.Remove(namespace)
+}
+
 // Schema returns the underlying AttributeSchema for use by the compiler.
 func (r *SchemaRegistry) Schema() *types.AttributeSchema {
 	return r.schema

--- a/internal/access/policy/engine.go
+++ b/internal/access/policy/engine.go
@@ -368,9 +368,14 @@ func (e *Engine) findApplicablePolicies(req types.AccessRequest, policies []Cach
 // the subject could potentially perform an action on a resource TYPE without
 // requiring a specific resource instance.
 //
+// Resolves only subject, environment, and action attributes via
+// ResolveSubjectAttributes. Resource providers are NEVER invoked during
+// preflight — there is no resource instance to resolve at type level.
+// Permits whose conditions reference resource attributes are handled via
+// the optimistic-permit branch below: they are treated as "may apply,
+// instance-level Evaluate will enforce the full condition."
+//
 // This is fail-closed: degraded mode and context cancellation both return false.
-// Conditions that reference resource attributes evaluate to false (optimistic skip
-// is intentional: type-level check is coarse; instance-level Evaluate handles those).
 // If any forbid policy with satisfied conditions matches, returns false.
 // If any permit policy with satisfied conditions matches, returns true.
 // No match → default deny (false, nil).
@@ -395,14 +400,11 @@ func (e *Engine) CanPerformAction(ctx context.Context, subject, action, resource
 			Errorf("subject must be in 'type:id' format with non-empty type and id")
 	}
 
-	// Step 4: Resolve subject attributes via a synthetic request.
-	// The resource uses resourceType+":__preflight__" to satisfy resolver format
-	// requirements without needing a real resource instance.
-	syntheticReq, reqErr := types.NewAccessRequest(subject, action, resourceType+":__preflight__")
-	if reqErr != nil {
-		return false, oops.With("subject", subject).With("action", action).With("resourceType", resourceType).Wrap(reqErr)
-	}
-	bags, resolveErr := e.resolver.Resolve(ctx, syntheticReq)
+	// Step 4: Resolve subject + environment attributes only. No resource
+	// instance exists at type-level preflight; resource providers are
+	// never called. The optimistic-permit branch below handles permits
+	// whose conditions reference resource attributes.
+	bags, resolveErr := e.resolver.ResolveSubjectAttributes(ctx, subject, action)
 	if resolveErr != nil {
 		errutil.LogErrorContext(ctx, "CanPerformAction: attribute resolution failed — fail-closed",
 			resolveErr,

--- a/internal/access/policy/engine_test.go
+++ b/internal/access/policy/engine_test.go
@@ -2123,3 +2123,62 @@ func TestEngineOnPolicyCorruptionUnknownEffect(t *testing.T) {
 	engine.OnPolicyCorruption("policy-789", types.PolicyEffect("bogus"))
 	assert.True(t, engine.IsDegraded(), "unknown effect type should trigger degraded mode")
 }
+
+func TestEngineCanPerformActionDoesNotInvokeResourceProvidersWhenCapabilityCheckRuns(t *testing.T) {
+	// T5: Register a tracking provider that counts ResolveSubject and
+	// ResolveResource calls separately, then run CanPerformAction.
+	// Asserts the headline C1 invariant: resource providers are never
+	// invoked during type-level preflight, AND subject resolution did
+	// actually run (guards against a silent no-op regression).
+	dslText := `permit(principal is character, action in ["read"], resource is widget);`
+
+	widgetSchema := &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+	}
+	widgetProv := &trackingAttrProvider{namespace: "widget", schema: widgetSchema}
+
+	engine := createTestEngineWithPolicies(t, []string{dslText}, []attribute.AttributeProvider{widgetProv})
+
+	// Asserting NoError ensures the call actually executed the resolution
+	// path. Without this, a regression that errored out before any provider
+	// was called would silently leave resourceCalls at 0 and false-pass.
+	_, err := engine.CanPerformAction(context.Background(), "character:01ABC", "read", "widget", "")
+	require.NoError(t, err)
+
+	// Headline invariant: resource provider was NOT called.
+	assert.Equal(t, 0, widgetProv.resourceCalls,
+		"widget resource provider must not be called during CanPerformAction")
+	// Positive invariant: subject resolution DID run. The widget provider
+	// is iterated for the subject path (it returns nil since widgetProv has
+	// no subjectAttrs), which still increments subjectCalls. If a future
+	// regression skips subject resolution entirely, this assertion fails.
+	assert.Greater(t, widgetProv.subjectCalls, 0,
+		"subject resolution must still run during CanPerformAction preflight")
+}
+
+// trackingAttrProvider counts ResolveSubject and ResolveResource calls
+// separately so tests can assert the CanPerformAction preflight invariant
+// (no resource providers invoked) alongside the positive invariant that
+// subject resolution still runs.
+type trackingAttrProvider struct {
+	namespace     string
+	subjectAttrs  map[string]any
+	resourceAttrs map[string]any
+	schema        *types.NamespaceSchema
+	subjectCalls  int
+	resourceCalls int
+}
+
+func (p *trackingAttrProvider) Namespace() string { return p.namespace }
+
+func (p *trackingAttrProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	p.subjectCalls++
+	return p.subjectAttrs, nil
+}
+
+func (p *trackingAttrProvider) ResolveResource(_ context.Context, _ string) (map[string]any, error) {
+	p.resourceCalls++
+	return p.resourceAttrs, nil
+}
+
+func (p *trackingAttrProvider) Schema() *types.NamespaceSchema { return p.schema }

--- a/internal/access/policy/engine_test.go
+++ b/internal/access/policy/engine_test.go
@@ -2182,3 +2182,25 @@ func (p *trackingAttrProvider) ResolveResource(_ context.Context, _ string) (map
 }
 
 func (p *trackingAttrProvider) Schema() *types.NamespaceSchema { return p.schema }
+
+func TestEngineCanPerformActionPermitsOptimisticallyForPermitReferencingResourceAttrs(t *testing.T) {
+	// The optimistic-permit branch fires when a permit policy's conditions
+	// reference resource attributes that can't be evaluated at type-level
+	// pre-flight (no resource instance exists). The engine MUST treat such
+	// permits as potentially-applicable and return allowed=true — the
+	// handler's instance-level Evaluate will enforce the full condition.
+	//
+	// This test proves that switching to ResolveSubjectAttributes does not
+	// regress this behavior. Before the refactor, the optimistic branch
+	// worked because the synthetic "__preflight__" resource had an empty
+	// attribute bag; after the refactor, it works because
+	// ResolveSubjectAttributes returns an empty Resource bag by construction.
+	dslText := `permit(principal is character, action in ["read"], resource is widget) when { resource.widget.type == "normal" };`
+
+	engine := createTestEngineWithPolicies(t, []string{dslText}, nil)
+
+	allowed, err := engine.CanPerformAction(context.Background(), "character:01ABC", "read", "widget", "")
+	require.NoError(t, err)
+	assert.True(t, allowed,
+		"permit policy referencing resource attrs must optimistic-permit at preflight")
+}

--- a/internal/access/policy/hardening_invariants_test.go
+++ b/internal/access/policy/hardening_invariants_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel is a
+// static assertion that the legacy synthetic preflight sentinel has been
+// removed from the engine. The Plugin ABAC Hardening spec (2026-04-07)
+// requires this literal to be deleted from engine.go — not filtered —
+// because the invariant "plugin providers never see synthetic IDs" is
+// enforced by construction, not by runtime filtering.
+//
+// If this test fails, somebody has re-introduced the synthetic preflight
+// path. Read docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
+// for the rationale before suppressing this test.
+func TestPluginABACHardeningSourceCodeDoesNotContainPreflightSentinel(t *testing.T) {
+	data, err := os.ReadFile("engine.go")
+	if err != nil {
+		t.Fatalf("failed to read engine.go: %v", err)
+	}
+	if strings.Contains(string(data), "__preflight__") {
+		t.Errorf("engine.go contains the synthetic preflight sentinel " +
+			"'__preflight__'. This literal was removed in the Plugin ABAC " +
+			"Hardening work (spec 2026-04-07). If you need to re-introduce " +
+			"preflight-aware behavior, read the spec first.")
+	}
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -25,6 +25,17 @@ import (
 // that calls resolver.RegisterProvider(provider).
 type RegisterPluginProviderFunc func(provider *PluginAttributeProvider) error
 
+// UnregisterPluginProviderFunc is a callback that removes a plugin attribute
+// provider from the ABAC attribute resolver by namespace. The server wiring
+// layer provides a closure that calls resolver.UnregisterProvider(namespace).
+//
+// Used during plugin load rollback to unwind provider registrations when a
+// later load-time step (schema validation, policy install) fails. If the
+// registrar callback is set but the unregistrar is nil, the manager logs a
+// warning on rollback — the resolver will retain a stale reference to a
+// plugin that never finished loading.
+type UnregisterPluginProviderFunc func(namespace string) bool
+
 // Error codes returned by the plugin manager. Tests should check these via
 // errutil.AssertErrorCode rather than substring matching error messages.
 const (
@@ -42,10 +53,11 @@ type Manager struct {
 	hostCaps            map[Host]hostCapabilities // optional interfaces, cached at registration
 	pluginHosts         map[string]Host           // maps plugin name → owning host
 	policyInstaller     PluginPolicyInstaller
-	registerProvider    RegisterPluginProviderFunc // optional, registers plugin attribute providers
-	registry            *ServiceRegistry           // optional, enables DAG resolution
-	trustAllowlist      map[string]bool            // server-side trust escalation allowlist
-	gracefulDegradation bool                       // if true, LoadAll continues despite plugin failures
+	registerProvider    RegisterPluginProviderFunc   // optional, registers plugin attribute providers
+	unregisterProvider  UnregisterPluginProviderFunc // optional, unregisters plugin attribute providers on rollback
+	registry            *ServiceRegistry             // optional, enables DAG resolution
+	trustAllowlist      map[string]bool              // server-side trust escalation allowlist
+	gracefulDegradation bool                         // if true, LoadAll continues despite plugin failures
 	aliasSeeder         AliasSeeder
 	aliasCache          *command.AliasCache
 	loaded              map[string]*DiscoveredPlugin
@@ -83,6 +95,18 @@ func WithAliasSeeder(seeder AliasSeeder, cache *command.AliasCache) ManagerOptio
 func WithAttributeProviderRegistrar(fn RegisterPluginProviderFunc) ManagerOption {
 	return func(m *Manager) {
 		m.registerProvider = fn
+	}
+}
+
+// WithAttributeProviderUnregistrar sets a callback used to remove plugin
+// attribute providers from the ABAC resolver when a plugin load fails
+// after provider registration has already occurred. Server wiring SHOULD
+// pass both WithAttributeProviderRegistrar and WithAttributeProviderUnregistrar
+// as a pair — otherwise failed loads leak dangling providers into the
+// resolver registry.
+func WithAttributeProviderUnregistrar(fn UnregisterPluginProviderFunc) ManagerOption {
+	return func(m *Manager) {
+		m.unregisterProvider = fn
 	}
 }
 
@@ -410,6 +434,40 @@ func (m *Manager) resolveLoadOrder(discovered []*DiscoveredPlugin) []*Discovered
 	return discovered
 }
 
+// unregisterPluginProviders removes all attribute providers that were
+// registered for a plugin's declared resource types. It is called during
+// load rollback to keep the resolver registry consistent with the set of
+// successfully loaded plugins.
+//
+// `upTo` limits the slice that will be unregistered — callers that fail
+// partway through the registration loop pass the index of the last
+// successfully-registered resource type so they unregister only what they
+// actually registered.
+//
+// If the unregister callback is not configured but the register callback
+// is, a warning is logged — the resolver will retain stale providers.
+func (m *Manager) unregisterPluginProviders(pluginName string, resourceTypes []string, upTo int) {
+	if m.registerProvider == nil {
+		return // registrar not wired; nothing was ever registered
+	}
+	if upTo > len(resourceTypes) {
+		upTo = len(resourceTypes)
+	}
+	if upTo <= 0 {
+		return
+	}
+	if m.unregisterProvider == nil {
+		slog.Warn("cannot unregister plugin attribute providers on rollback: "+
+			"WithAttributeProviderRegistrar configured but WithAttributeProviderUnregistrar is not",
+			"plugin", pluginName,
+			"leaked_namespaces", resourceTypes[:upTo])
+		return
+	}
+	for _, rt := range resourceTypes[:upTo] {
+		_ = m.unregisterProvider(rt)
+	}
+}
+
 // loadPlugin loads a single discovered plugin.
 //
 // Design: Returns nil (not error) for unsupported configurations to support
@@ -487,6 +545,10 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	// "type") is a fatal load error per the Plugin ABAC Hardening spec
 	// (2026-04-07).
 	if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+		// Unregister attribute providers that were added during
+		// discoverAndRegisterAttributes so the resolver doesn't retain
+		// dangling references to a plugin that never finished loading.
+		m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 		if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
 			slog.Error("failed to rollback plugin load after schema validation failure",
 				"plugin", dp.Manifest.Name, "error", unloadErr)
@@ -500,6 +562,9 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	if m.policyInstaller != nil && len(dp.Manifest.Policies) > 0 {
 		installErr := m.policyInstaller.InstallPluginPoliciesWithManifest(ctx, dp.Manifest, dp.Manifest.Policies)
 		if installErr != nil {
+			// Unregister providers added during discoverAndRegisterAttributes
+			// — same rationale as the schema-validation branch above.
+			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
 				slog.Error("failed to rollback plugin load after policy install failure",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
@@ -521,6 +586,8 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	if m.registry != nil && len(dp.Manifest.Provides) > 0 {
 		connProvider := m.capabilitiesFor(host).connProvider
 		if connProvider == nil {
+			// Rollback attribute providers registered earlier in loadPlugin.
+			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 			return oops.Code(CodeHostMissingConnProvider).
 				In("manager").
 				With("plugin", dp.Manifest.Name).
@@ -528,6 +595,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 		}
 		conn, connErr := connProvider.PluginConn(dp.Manifest.Name)
 		if connErr != nil {
+			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 			return oops.In("manager").
 				With("plugin", dp.Manifest.Name).
 				Wrapf(connErr, "get plugin connection for service registration")
@@ -545,6 +613,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 				for _, name := range registered {
 					_ = m.registry.Deregister(name) //nolint:errcheck // best-effort cleanup
 				}
+				m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 				return oops.In("manager").
 					With("plugin", dp.Manifest.Name).
 					With("service", svcName).
@@ -614,7 +683,7 @@ func (m *Manager) discoverAndRegisterAttributes(ctx context.Context, host Host, 
 	}
 
 	if m.registerProvider != nil {
-		for _, rt := range dp.Manifest.ResourceTypes {
+		for i, rt := range dp.Manifest.ResourceTypes {
 			provider := NewPluginAttributeProvider(rt, arClient, schemas[rt])
 			if regErr := m.registerProvider(provider); regErr != nil {
 				// Provider registration failure must be fatal — the plugin
@@ -623,6 +692,10 @@ func (m *Manager) discoverAndRegisterAttributes(ctx context.Context, host Host, 
 				// silently fail at evaluation. This is consistent with how
 				// GetSchema, policy installation, and service registration
 				// failures are handled.
+				//
+				// Rollback: unregister any providers that were added in
+				// previous iterations of this loop before returning.
+				m.unregisterPluginProviders(pluginName, dp.Manifest.ResourceTypes, i)
 				if unloadErr := host.Unload(ctx, pluginName); unloadErr != nil {
 					slog.Error("failed to rollback plugin after attribute provider registration failure",
 						"plugin", pluginName, "error", unloadErr)

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -481,6 +481,20 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 		}
 	}
 
+	// Validate manifest policy attribute references against discovered
+	// schemas BEFORE installing policies. A load-time schema mismatch
+	// (e.g., policy references resource.widget.tipe but schema declares
+	// "type") is a fatal load error per the Plugin ABAC Hardening spec
+	// (2026-04-07).
+	if valErr := ValidateManifestPolicySchemas(dp.Manifest, schemas); valErr != nil {
+		if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+			slog.Error("failed to rollback plugin load after schema validation failure",
+				"plugin", dp.Manifest.Name, "error", unloadErr)
+		}
+		return oops.In("manager").With("plugin", dp.Manifest.Name).
+			Wrapf(valErr, "validate manifest policy schemas")
+	}
+
 	// Install ABAC policies using manifest-aware validation when resource
 	// types or trust config are present, otherwise fall back to basic install.
 	if m.policyInstaller != nil && len(dp.Manifest.Policies) > 0 {
@@ -495,7 +509,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	}
 
 	// Check for manifest warnings (non-fatal policy coverage gaps).
-	if warnings := CheckManifestWarnings(dp.Manifest, schemas); len(warnings) > 0 {
+	if warnings := CheckManifestWarnings(dp.Manifest); len(warnings) > 0 {
 		for _, w := range warnings {
 			slog.Info(w, "plugin", dp.Manifest.Name)
 		}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1114,6 +1114,78 @@ binary-plugin:
 	assert.Empty(t, mgr.ListPlugins())
 }
 
+func TestManagerLoadAllUnregistersAttributeProviderWhenSchemaValidationFailsAfterRegistration(t *testing.T) {
+	// T35: resolver rollback completeness. When ValidateManifestPolicySchemas
+	// rejects a manifest (e.g., policy references an attribute not in the
+	// discovered schema), the manager must unregister the attribute providers
+	// that discoverAndRegisterAttributes added moments earlier. Otherwise the
+	// ABAC resolver retains a stale provider tied to a plugin that never
+	// finished loading, and a subsequent retry hits "already registered".
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	pluginDir := filepath.Join(pluginsDir, "bad-widget")
+	mkdirAll(t, pluginDir)
+	// Policy references resource.widget.tipe but the schema exposes "type".
+	// ValidateManifestPolicySchemas rejects this at load time, after
+	// discoverAndRegisterAttributes has already registered the widget provider.
+	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: bad-widget
+version: 1.0.0
+type: binary
+resource_types: [widget]
+binary-plugin:
+  executable: bad-widget
+policies:
+  - name: widget-read-typo
+    dsl: |
+      permit(principal is character, action in ["read"], resource is widget)
+      when { resource.widget.tipe == "normal" };
+`))
+
+	host := &arBinaryHost{
+		mockBinaryHost: mockBinaryHost{conn: &stubClientConn{}},
+		arClient: &stubAttributeResolverClient{
+			schemaResp: &pluginv1.GetSchemaResponse{
+				ResourceTypes: map[string]*pluginv1.ResourceTypeSchema{
+					"widget": {Attributes: map[string]pluginv1.AttributeType{
+						"type": pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
+					}},
+				},
+			},
+		},
+	}
+
+	var registered []string
+	var unregistered []string
+	registrar := func(p *plugins.PluginAttributeProvider) error {
+		registered = append(registered, p.Namespace())
+		return nil
+	}
+	unregistrar := func(namespace string) bool {
+		unregistered = append(unregistered, namespace)
+		return true
+	}
+
+	mgr := plugins.NewManager(pluginsDir,
+		plugins.WithAttributeProviderRegistrar(registrar),
+		plugins.WithAttributeProviderUnregistrar(unregistrar),
+	)
+	mgr.RegisterHost(plugins.TypeBinary, host)
+
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err, "manifest with schema-mismatched policy must fail to load")
+	assert.Contains(t, err.Error(), "validate manifest policy schemas")
+
+	// Assert rollback: the provider registered during
+	// discoverAndRegisterAttributes was also unregistered.
+	assert.Equal(t, []string{"widget"}, registered,
+		"provider must be registered before the validation error")
+	assert.Equal(t, []string{"widget"}, unregistered,
+		"rollback must unregister every provider that was registered")
+	assert.Empty(t, mgr.ListPlugins(),
+		"plugin must not be marked loaded after validation rollback")
+}
+
 func TestManagerLoadAllRegistersAttributeProviderViaCallback(t *testing.T) {
 	dir := t.TempDir()
 	pluginsDir := filepath.Join(dir, "plugins")

--- a/internal/plugin/manifest_warnings.go
+++ b/internal/plugin/manifest_warnings.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/holomush/holomush/internal/access/policy/dsl"
-	"github.com/holomush/holomush/internal/access/policy/types"
 )
 
 // parsedManifestPolicy pairs a manifest policy name with its parsed DSL AST.
@@ -19,13 +18,12 @@ type parsedManifestPolicy struct {
 // CheckManifestWarnings logs non-fatal warnings about potential policy coverage
 // gaps in a plugin manifest. Called during loadPlugin after policy installation.
 //
-// The schemas parameter is retained for API compatibility with the caller in
-// loadPlugin but is no longer consulted: policy/schema cross-validation has
-// been promoted to a hard error path in ValidateManifestPolicySchemas. Only
-// command coverage warnings (Warning 1, Warning 2) remain here as soft hints.
+// Policy/schema cross-validation has been promoted to a hard error path in
+// ValidateManifestPolicySchemas. Only command coverage warnings (Warning 1,
+// Warning 2) remain here as soft hints.
 //
 // Returns a slice of human-readable warning messages (never nil for easy length check).
-func CheckManifestWarnings(manifest *Manifest, _ map[string]*types.NamespaceSchema) []string {
+func CheckManifestWarnings(manifest *Manifest) []string {
 	var warnings []string
 
 	// Parse all policies up front; skip unparseable ones silently — the

--- a/internal/plugin/manifest_warnings.go
+++ b/internal/plugin/manifest_warnings.go
@@ -18,10 +18,14 @@ type parsedManifestPolicy struct {
 
 // CheckManifestWarnings logs non-fatal warnings about potential policy coverage
 // gaps in a plugin manifest. Called during loadPlugin after policy installation.
-// schemas may be nil for plugins without resource_types.
+//
+// The schemas parameter is retained for API compatibility with the caller in
+// loadPlugin but is no longer consulted: policy/schema cross-validation has
+// been promoted to a hard error path in ValidateManifestPolicySchemas. Only
+// command coverage warnings (Warning 1, Warning 2) remain here as soft hints.
 //
 // Returns a slice of human-readable warning messages (never nil for easy length check).
-func CheckManifestWarnings(manifest *Manifest, schemas map[string]*types.NamespaceSchema) []string {
+func CheckManifestWarnings(manifest *Manifest, _ map[string]*types.NamespaceSchema) []string {
 	var warnings []string
 
 	// Parse all policies up front; skip unparseable ones silently — the
@@ -69,31 +73,6 @@ func CheckManifestWarnings(manifest *Manifest, schemas map[string]*types.Namespa
 					"plugin %q: command %q declares capability %q on resource type %q but no character permit policy covers it",
 					manifest.Name, cmd.Name, act, rt,
 				))
-			}
-		}
-	}
-
-	// Warning 3: policy references an attribute not in the schema for its resource type.
-	if schemas != nil {
-		for _, pp := range parsed {
-			if pp.policy.Target == nil || pp.policy.Target.Resource == nil {
-				continue
-			}
-			rt := pp.policy.Target.Resource.Type
-			if rt == "" {
-				continue
-			}
-			schema, ok := schemas[rt]
-			if !ok || schema == nil {
-				continue
-			}
-			for _, attr := range referencedResourceAttrs(pp.policy) {
-				if _, known := schema.Attributes[attr]; !known {
-					warnings = append(warnings, fmt.Sprintf(
-						"plugin %q: policy %q references attribute %q on resource type %q which is not in the schema",
-						manifest.Name, pp.name, attr, rt,
-					))
-				}
 			}
 		}
 	}

--- a/internal/plugin/manifest_warnings_test.go
+++ b/internal/plugin/manifest_warnings_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/command"
 	plugins "github.com/holomush/holomush/internal/plugin"
 )
@@ -36,7 +35,7 @@ func TestCheckManifestWarningsNoWarningsForFullCoverage(t *testing.T) {
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -47,7 +46,7 @@ func TestCheckManifestWarningsDetectsMissingExecutePolicy(t *testing.T) {
 	}
 	// No policy in the manifest at all.
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "widget-create")
 	assert.Contains(t, warnings[0], "no policy")
@@ -68,7 +67,7 @@ func TestCheckManifestWarningsDetectsMissingExecutePolicyForOneOfTwoCommands(t *
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "widget-delete")
 }
@@ -87,7 +86,7 @@ func TestCheckManifestWarningsNoWarningWhenWildcardExecutePolicyCoversAllCommand
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -110,7 +109,7 @@ func TestCheckManifestWarningsDetectsMissingCapabilityPolicy(t *testing.T) {
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "widget")
 	assert.Contains(t, warnings[0], "widget-create")
@@ -138,7 +137,7 @@ func TestCheckManifestWarningsNoWarningWhenCapabilityPolicyExists(t *testing.T) 
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -152,15 +151,11 @@ func TestCheckManifestWarningsNoWarningForKnownAttribute(t *testing.T) {
 		},
 	}
 
-	schemas := map[string]*types.NamespaceSchema{
-		"widget": {
-			Attributes: map[string]types.AttrType{
-				"name": types.AttrTypeString,
-			},
-		},
-	}
-
-	warnings := plugins.CheckManifestWarnings(m, schemas)
+	// CheckManifestWarnings no longer cross-validates policy attribute
+	// references against schemas — that check is a hard error path in
+	// ValidateManifestPolicySchemas now. This test stays as a regression
+	// guard that known-good attribute refs never leak into warnings.
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -175,13 +170,13 @@ func TestCheckManifestWarningsSchemaCheckSkippedWhenSchemasNil(t *testing.T) {
 	}
 
 	// nil schemas — no schema warnings expected.
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
 func TestCheckManifestWarningsEmptyManifestProducesNoWarnings(t *testing.T) {
 	m := luaManifest("minimal")
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -210,7 +205,7 @@ func TestCheckManifestWarningsCommandWithTwoCapabilitiesOneUncovered(t *testing.
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1, "exactly one capability should be flagged as uncovered")
 	assert.Contains(t, warnings[0], "gadget", "the missing resource type should be named")
 	assert.NotContains(t, warnings[0], "widget-create"+`"`+" declares capability on resource type \"widget\"",
@@ -240,7 +235,7 @@ func TestCheckManifestWarningsCommandWithDistinctCapabilityActionsWarnsPerAction
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 2, "write and read are independent capabilities")
 	// Both warnings should reference gadget but for different actions.
 	allMessages := warnings[0] + " | " + warnings[1]
@@ -275,7 +270,7 @@ func TestCheckManifestWarningsCapabilityCoverageRequiresMatchingAction(t *testin
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1, "read policy must not cover write capability")
 	assert.Contains(t, warnings[0], `"write"`)
 	assert.Contains(t, warnings[0], "widget")
@@ -297,7 +292,7 @@ func TestCheckManifestWarningsExecuteCoverageRequiresCharacterPrincipal(t *testi
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	require.Len(t, warnings, 1, "plugin-principal execute policy must not satisfy character coverage")
 	assert.Contains(t, warnings[0], "widget")
 	assert.Contains(t, warnings[0], "no policy that permits execute")
@@ -319,7 +314,7 @@ func TestCheckManifestWarningsExecutePolicyWithInListCoversCommand(t *testing.T)
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
@@ -336,13 +331,14 @@ func TestCheckManifestWarningsParenthesizedExecuteConditionCoversCommand(t *test
 		},
 	}
 
-	warnings := plugins.CheckManifestWarnings(m, nil)
+	warnings := plugins.CheckManifestWarnings(m)
 	assert.Empty(t, warnings)
 }
 
 func TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema(t *testing.T) {
-	// Policy targets "gadget" but schemas only describe "widget" — the
-	// referenced attribute check should skip rather than warn.
+	// Policy targets "gadget" — CheckManifestWarnings no longer cross-checks
+	// attribute references against schemas (that's ValidateManifestPolicySchemas'
+	// job), so no warnings should surface here regardless of schema shape.
 	m := luaManifest("widget-plugin")
 	m.Policies = []plugins.ManifestPolicy{
 		{
@@ -351,10 +347,7 @@ func TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema(t *t
 				` when { resource.gadget.color == "red" };`,
 		},
 	}
-	schemas := map[string]*types.NamespaceSchema{
-		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
-	}
 
-	warnings := plugins.CheckManifestWarnings(m, schemas)
-	assert.Empty(t, warnings, "missing schema for the policy's resource type should be silently skipped")
+	warnings := plugins.CheckManifestWarnings(m)
+	assert.Empty(t, warnings, "CheckManifestWarnings must not warn about attribute refs")
 }

--- a/internal/plugin/manifest_warnings_test.go
+++ b/internal/plugin/manifest_warnings_test.go
@@ -142,30 +142,6 @@ func TestCheckManifestWarningsNoWarningWhenCapabilityPolicyExists(t *testing.T) 
 	assert.Empty(t, warnings)
 }
 
-func TestCheckManifestWarningsDetectsUnknownAttributeInSchema(t *testing.T) {
-	m := luaManifest("widget-plugin")
-	m.Policies = []plugins.ManifestPolicy{
-		{
-			Name: "allow-read-widget",
-			DSL: `permit(principal, action in ["read"], resource is widget)` +
-				` when { resource.widget.unknown-field == "foo" };`,
-		},
-	}
-
-	schemas := map[string]*types.NamespaceSchema{
-		"widget": {
-			Attributes: map[string]types.AttrType{
-				"name": types.AttrTypeString,
-			},
-		},
-	}
-
-	warnings := plugins.CheckManifestWarnings(m, schemas)
-	require.Len(t, warnings, 1)
-	assert.Contains(t, warnings[0], "unknown-field")
-	assert.Contains(t, warnings[0], "widget")
-}
-
 func TestCheckManifestWarningsNoWarningForKnownAttribute(t *testing.T) {
 	m := luaManifest("widget-plugin")
 	m.Policies = []plugins.ManifestPolicy{
@@ -362,31 +338,6 @@ func TestCheckManifestWarningsParenthesizedExecuteConditionCoversCommand(t *test
 
 	warnings := plugins.CheckManifestWarnings(m, nil)
 	assert.Empty(t, warnings)
-}
-
-func TestCheckManifestWarningsAttributeRefThroughInListProducesWarning(t *testing.T) {
-	// Schema covers "type"; policy references "color" via a list-membership
-	// operator. The collectFromCond InList branch should still find the
-	// attribute reference and emit a warning.
-	m := luaManifest("widget-plugin")
-	m.Policies = []plugins.ManifestPolicy{
-		{
-			Name: "in-list-attr",
-			DSL: `permit(principal, action in ["read"], resource is widget)` +
-				` when { resource.widget.color in ["red", "blue"] };`,
-		},
-	}
-	schemas := map[string]*types.NamespaceSchema{
-		"widget": {
-			Attributes: map[string]types.AttrType{
-				"type": types.AttrTypeString,
-			},
-		},
-	}
-
-	warnings := plugins.CheckManifestWarnings(m, schemas)
-	require.Len(t, warnings, 1)
-	assert.Contains(t, warnings[0], "color")
 }
 
 func TestCheckManifestWarningsSchemaCheckSkippedWhenResourceTypeNotInSchema(t *testing.T) {

--- a/internal/plugin/policy_schema_validator.go
+++ b/internal/plugin/policy_schema_validator.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins
+
+import (
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/dsl"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// ValidateManifestPolicySchemas verifies that every attribute reference in
+// each manifest policy's DSL exists in the plugin's declared schema for the
+// policy's resource type. Returns a non-nil error on the first mismatch so
+// the plugin load fails before any policy is installed.
+//
+// schemas is the schema map discovered via GetSchema during plugin load.
+// Plugins without resource_types (schemas == nil or empty) are out of scope
+// for this check and return nil.
+//
+// Unparseable policies are skipped — ValidatePluginPolicy has already
+// rejected them by the time this function runs.
+//
+// The function returns on the FIRST mismatch rather than aggregating errors.
+// Rationale: a plugin author fixing a typo will re-run the load anyway, and
+// aggregation produces harder-to-read error messages for agent consumers.
+// If multi-error reporting is needed later, it is a non-breaking follow-up.
+func ValidateManifestPolicySchemas(
+	manifest *Manifest,
+	schemas map[string]*types.NamespaceSchema,
+) error {
+	if len(schemas) == 0 {
+		return nil
+	}
+
+	for _, mp := range manifest.Policies {
+		parsed, err := dsl.Parse(mp.DSL)
+		if err != nil {
+			// Unparseable policies were already rejected by ValidatePluginPolicy.
+			// Skip them silently here to avoid double-reporting.
+			continue
+		}
+		if parsed.Target == nil || parsed.Target.Resource == nil {
+			continue
+		}
+		rt := parsed.Target.Resource.Type
+		if rt == "" {
+			continue
+		}
+		schema, ok := schemas[rt]
+		if !ok || schema == nil {
+			// Resource type not in this plugin's schema map. Either the
+			// policy targets a core type (already rejected by
+			// ValidatePluginPolicy for non-trusted plugins) or a type the
+			// plugin declared but GetSchema didn't return (separate bug
+			// outside the scope of this validator). Skip.
+			continue
+		}
+		for _, attr := range referencedResourceAttrs(parsed) {
+			if _, known := schema.Attributes[attr]; !known {
+				// Build the list of valid attribute names for the error.
+				validKeys := make([]string, 0, len(schema.Attributes))
+				for k := range schema.Attributes {
+					validKeys = append(validKeys, k)
+				}
+				return oops.
+					Code("PLUGIN_SCHEMA_VALIDATION_FAILED").
+					In("plugin").
+					With("plugin", manifest.Name).
+					With("policy", mp.Name).
+					With("resource_type", rt).
+					With("attribute", attr).
+					With("schema_keys", validKeys).
+					Errorf("policy %q references attribute %q on resource type %q which is not in the declared schema",
+						mp.Name, attr, rt)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/plugin/policy_schema_validator_test.go
+++ b/internal/plugin/policy_schema_validator_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+func TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSchema(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		Version:       "1.0.0",
+		Type:          plugins.TypeBinary,
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-read-normal",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.tipe == "normal" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tipe")
+	assert.Contains(t, err.Error(), "widget-read-normal")
+	assert.Contains(t, err.Error(), "widget")
+	assert.Contains(t, err.Error(), "not in the declared schema")
+}

--- a/internal/plugin/policy_schema_validator_test.go
+++ b/internal/plugin/policy_schema_validator_test.go
@@ -43,3 +43,259 @@ func TestValidateManifestPolicySchemasRejectsPolicyReferencingAttributeNotInSche
 	assert.Contains(t, err.Error(), "widget")
 	assert.Contains(t, err.Error(), "not in the declared schema")
 }
+
+func TestValidateManifestPolicySchemasAcceptsPolicyWhenAllAttributeReferencesMatchSchema(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-read-normal",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+
+func TestValidateManifestPolicySchemasReturnsNilForPluginWithoutResourceTypes(t *testing.T) {
+	m := &plugins.Manifest{
+		Name: "simple-plugin",
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "exec",
+				DSL: `permit(principal is character, action in ["execute"], resource is command) ` +
+					`when { resource.command.name == "simple" };`,
+			},
+		},
+	}
+	// schemas is nil — plugin has no custom resource types.
+	err := plugins.ValidateManifestPolicySchemas(m, nil)
+	assert.NoError(t, err)
+}
+
+func TestValidateManifestPolicySchemasAcceptsPolicyWithoutWhenClause(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-unconstrained",
+				DSL:  `permit(principal is character, action in ["read"], resource is widget);`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+
+func TestValidateManifestPolicySchemasIgnoresEnvironmentAndPrincipalAttributeReferences(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-time-gated",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { principal.character.role == "admin" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	// Policy references principal.character.role but NOT any widget attribute.
+	// The validator should not false-positive on principal references.
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+
+func TestValidateManifestPolicySchemasReturnsNilForEmptyNonNilSchemaMap(t *testing.T) {
+	m := &plugins.Manifest{
+		Name: "empty-plugin",
+	}
+	schemas := map[string]*types.NamespaceSchema{} // non-nil, length 0
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err)
+}
+
+func TestValidateManifestPolicySchemasReturnsNilWhenPolicyTypeWasAlreadyRejectedByPluginValidator(t *testing.T) {
+	// This test documents the layering assumption: ValidatePluginPolicy
+	// runs before ValidateManifestPolicySchemas and rejects policies
+	// targeting resource types not in the plugin's resource_types. If
+	// such a policy reaches this validator (shouldn't happen in practice),
+	// we skip rather than error — the rejection is another validator's
+	// responsibility.
+	m := &plugins.Manifest{
+		Name:          "test-plugin",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "gadget-policy",
+				DSL: `permit(principal is character, action in ["read"], resource is gadget) ` +
+					`when { resource.gadget.color == "red" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err, "policy targeting an out-of-schema type is skipped by this validator")
+}
+
+func TestValidateManifestPolicySchemasReportsFirstErrorWhenMultiplePoliciesHaveBadAttributes(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-bad-first",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.alpha == "x" };`,
+			},
+			{
+				Name: "widget-good",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+			{
+				Name: "widget-bad-second",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.beta == "y" };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {Attributes: map[string]types.AttrType{"type": types.AttrTypeString}},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "widget-bad-first", "first bad policy should be reported")
+	assert.Contains(t, err.Error(), "alpha", "first bad attribute should be reported")
+	assert.NotContains(t, err.Error(), "widget-bad-second", "second bad policy should not be in first error")
+}
+
+func TestValidateManifestPolicySchemasHandlesCompoundConditionsWithANDORNot(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-compound",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { (resource.widget.type == "normal" || resource.widget.tipe == "restricted") && !(resource.widget.owner == "system") };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type":  types.AttrTypeString,
+				"owner": types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err, "compound condition with bad attribute should fail")
+	assert.Contains(t, err.Error(), "tipe")
+}
+
+func TestValidateManifestPolicySchemasHandlesHasAndContainsReferences(t *testing.T) {
+	// The DSL uses method-call syntax for set membership:
+	// `resource.widget.members.containsAll(["admin"])` — NOT a `contains`
+	// keyword. The validator must extract `members` from the AttrRef path
+	// of the ContainsCondition and detect it is undeclared.
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-contains",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.members.containsAll(["admin"]) };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "members")
+}
+
+func TestValidateManifestPolicySchemasHandlesInExprWithDynamicBothSides(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-in-dynamic",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { principal.character.player_id in resource.widget.members };`,
+			},
+		},
+	}
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{"type": types.AttrTypeString},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	require.Error(t, err, "`in` expression with undeclared resource attribute should fail")
+	assert.Contains(t, err.Error(), "members")
+}
+
+func TestValidateManifestPolicySchemasAcceptsAttributeNameThatIsPrefixOfValidAttribute(t *testing.T) {
+	m := &plugins.Manifest{
+		Name:          "test-abac-widget",
+		ResourceTypes: []string{"widget"},
+		Policies: []plugins.ManifestPolicy{
+			{
+				Name: "widget-exact",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.type == "normal" };`,
+			},
+		},
+	}
+	// Schema has type_code AND type; both are distinct keys. The policy
+	// references "type" (exactly), which is valid. Prefix matching would
+	// erroneously think "type" is a prefix of "type_code" and could cause
+	// a false positive in a buggy implementation.
+	schemas := map[string]*types.NamespaceSchema{
+		"widget": {
+			Attributes: map[string]types.AttrType{
+				"type_code": types.AttrTypeString,
+				"type":      types.AttrTypeString,
+			},
+		},
+	}
+
+	err := plugins.ValidateManifestPolicySchemas(m, schemas)
+	assert.NoError(t, err, "exact-match lookup must not substring-match")
+}

--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -14,6 +14,24 @@ import (
 
 // AttributeResolverProvider is implemented by binary plugins that provide
 // attribute resolution for resource types they own.
+//
+// Host contract (post-hardening):
+//
+// Plugins implementing this interface only ever receive REAL resource
+// instance IDs from the host. There are no synthetic sentinels, no
+// preflight IDs, and no pseudo-instances of any kind. Any ID passed to
+// ResolveResource refers to a genuine entity that the host believes
+// exists in the plugin's backing store; plugin authors do not need to
+// special-case sentinel values or "discovery" calls.
+//
+// In addition, every attribute returned from ResolveResource MUST appear
+// in GetSchema. Undeclared attributes are silently dropped at runtime,
+// and policies referencing undeclared attributes cause the plugin to
+// fail to load.
+//
+// See docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md
+// for the full design rationale and the host-side invariants this
+// contract relies on.
 type AttributeResolverProvider interface {
 	RegisterAttributeResolver(registrar grpc.ServiceRegistrar)
 }

--- a/plugins/test-abac-widget/main.go
+++ b/plugins/test-abac-widget/main.go
@@ -38,6 +38,20 @@ func (p *widgetPlugin) RegisterAttributeResolver(registrar grpc.ServiceRegistrar
 	pluginv1.RegisterAttributeResolverServiceServer(registrar, &widgetResolver{})
 }
 
+// widgetResolver is the canonical example of an ABAC attribute resolver
+// for a binary plugin. It illustrates two properties the host contract
+// guarantees:
+//
+//  1. The host only calls ResolveResource with real instance IDs it
+//     believes exist. There is no preflight sentinel to handle.
+//  2. Every attribute returned here ("type", "owner") must also appear
+//     in GetSchema — otherwise the returned value is silently dropped
+//     at runtime and the plugin fails to load if a policy references
+//     the undeclared attribute.
+//
+// Plugin authors writing new resolvers should model theirs on this
+// pattern: map instance ID → backing store lookup → return a map keyed
+// by names declared in GetSchema.
 type widgetResolver struct {
 	pluginv1.UnimplementedAttributeResolverServiceServer
 }
@@ -56,10 +70,14 @@ func (r *widgetResolver) GetSchema(_ context.Context, _ *pluginv1.GetSchemaReque
 }
 
 func (r *widgetResolver) ResolveResource(_ context.Context, req *pluginv1.ResolveResourceRequest) (*pluginv1.ResolveResourceResponse, error) {
-	// Reject any resource type other than "widget". This catches host-side
-	// misrouting bugs (e.g., a per-resource-type registration regression
-	// that sends `location:abc` to this resolver) — without it, the E2E
-	// coverage would silently pass on routing bugs.
+	// Reject any resource type other than "widget". This is defense in
+	// depth against a host routing bug (e.g., a per-resource-type
+	// registration regression that sends `location:abc` to this resolver).
+	// The host contract guarantees that ResolveResource is only called
+	// with instance IDs the host believes to exist; this check protects
+	// against the host violating that contract, not against synthetic
+	// preflight IDs (which no longer exist — see spec
+	// 2026-04-07-plugin-abac-hardening-design.md).
 	if req.GetResourceType() != "widget" {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"test-abac-widget only resolves resource type %q, got %q",

--- a/site/docs/extending/abac-attribute-resolver.md
+++ b/site/docs/extending/abac-attribute-resolver.md
@@ -1,0 +1,194 @@
+# Implementing AttributeResolverService
+
+Binary plugins that declare custom `resource_types` in their manifest MUST
+implement the `AttributeResolverService` gRPC interface. The host calls your
+resolver whenever a policy needs attribute values for an instance of a
+resource type your plugin owns.
+
+This page documents the host/plugin contract: what the host guarantees, what
+your plugin MUST declare, and what happens when the contract is violated.
+
+## When the Host Calls You
+
+Your resolver has exactly two RPCs and each has a fixed call site.
+
+| RPC | When the host calls it | How often |
+| --- | --- | --- |
+| `GetSchema` | Once at plugin load, after `Init` | Once per plugin load |
+| `ResolveResource` | Once per instance-level authorization check that references one of your resource types | Once per matching auth request |
+
+Nothing else calls your resolver. In particular:
+
+- Type-level capability pre-flight (e.g. `CanPerformAction(subject, "write", "widget", scope)`) never calls `ResolveResource` — it only inspects the subject and environment.
+- Other plugins' resolvers are never chained into yours. Re-entrance is detected and fail-closed.
+- The host does not call `GetSchema` at runtime; your schema is cached at load time.
+
+## The `GetSchema` Contract
+
+`GetSchema` returns the set of resource types your plugin owns and, for each
+type, the set of attributes your plugin will return at runtime.
+
+```go
+func (r *widgetResolver) GetSchema(_ context.Context, _ *pluginv1.GetSchemaRequest) (*pluginv1.GetSchemaResponse, error) {
+    return &pluginv1.GetSchemaResponse{
+        ResourceTypes: map[string]*pluginv1.ResourceTypeSchema{
+            "widget": {
+                Attributes: map[string]pluginv1.AttributeType{
+                    "type":  pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
+                    "owner": pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
+                },
+            },
+        },
+    }, nil
+}
+```
+
+The host uses your schema response for two things:
+
+1. **Load-time policy validation.** Every policy in your manifest whose DSL
+   references `resource.<type>.<attr>` is checked against your schema. If
+   the policy references an attribute you did not declare, the plugin fails
+   to load.
+2. **Runtime attribute filtering.** When `ResolveResource` returns, the host
+   drops any attribute not listed in `GetSchema` and increments a Prometheus
+   counter. Undeclared attributes are silently discarded.
+
+| Requirement | Description |
+| --- | --- |
+| **MUST** declare every runtime attribute | Any attribute `ResolveResource` may ever return MUST appear in the `GetSchema` response for that resource type |
+| **MUST** be deterministic | The host caches your response — schemas MUST NOT vary across calls |
+| **SHOULD** match `AttributeType` to what you return | e.g. don't declare `STRING` and return a `BoolValue` |
+
+## The `ResolveResource` Contract
+
+`ResolveResource` is called with a concrete resource instance ID and MUST
+return the attribute values the host needs for policy evaluation.
+
+```go
+func (r *widgetResolver) ResolveResource(_ context.Context, req *pluginv1.ResolveResourceRequest) (*pluginv1.ResolveResourceResponse, error) {
+    if req.GetResourceType() != "widget" {
+        return nil, status.Errorf(codes.InvalidArgument,
+            "test-abac-widget only resolves resource type %q, got %q",
+            "widget", req.GetResourceType())
+    }
+
+    // Look up the real instance by ID. The host never asks about fake IDs.
+    widget, err := r.store.Get(req.GetResourceId())
+    if err != nil {
+        if errors.Is(err, ErrNotFound) {
+            return nil, status.Errorf(codes.NotFound, "widget %q not found", req.GetResourceId())
+        }
+        return nil, status.Errorf(codes.Internal, "load widget: %v", err)
+    }
+
+    return &pluginv1.ResolveResourceResponse{
+        Attributes: map[string]*pluginv1.AttributeValue{
+            "type":  {Kind: &pluginv1.AttributeValue_StringValue{StringValue: widget.Type}},
+            "owner": {Kind: &pluginv1.AttributeValue_StringValue{StringValue: widget.Owner}},
+        },
+    }, nil
+}
+```
+
+### Host Guarantees
+
+The host invariants you can rely on:
+
+| Guarantee | Implication for your code |
+| --- | --- |
+| `ResourceId` is a real instance ID the host believes exists | You MUST NOT check for sentinel values like `__preflight__` — they are never sent |
+| `ResourceType` is one you declared in `GetSchema` | You MAY still reject unknown types as defense in depth |
+| The call is made only for instance-level authorization | Type-level capability checks never reach you |
+| Re-entrance is detected and fail-closed | You MUST NOT recursively call other resolvers from inside `ResolveResource` |
+
+### Error Handling
+
+Your resolver MUST surface errors through gRPC status codes. Both codes below
+cause fail-closed authorization — the pending auth request is denied.
+
+| Condition | gRPC code | Meaning |
+| --- | --- | --- |
+| Instance does not exist in your backing store | `NotFound` | The host treats this as "deny, resource missing" |
+| Database error, timeout, or any infrastructure failure | `Internal` | The host treats this as "deny, resolver infrastructure failure" |
+
+| Requirement | Description |
+| --- | --- |
+| **MUST** return `NotFound` for missing instances | Do not return an empty attribute map — that is ambiguous |
+| **MUST** return `Internal` for infrastructure failures | Do not swallow errors and return stale or default values |
+| **MUST NOT** return `OK` for unknown instances | Silently returning empty attributes can cause a permit policy to evaluate incorrectly |
+
+## What Fails at Load Time
+
+If any policy in your manifest references an attribute your `GetSchema`
+response does not declare, the plugin fails to load with a structured error.
+The error includes the plugin name, policy name, resource type, the missing
+attribute name, and the list of valid attribute names for that type.
+
+For example, if your manifest contains:
+
+```yaml
+policies:
+  - name: widget-owner-read
+    dsl: |
+      permit(principal is character, action in ["read"], resource is widget) when {
+        resource.widget.creator == principal.character.id
+      };
+```
+
+but your `GetSchema` only declares `type` and `owner`, plugin load fails with
+an error like:
+
+```text
+PLUGIN_SCHEMA_VALIDATION_FAILED: policy "widget-owner-read" references
+attribute "creator" on resource type "widget" which is not in the declared
+schema
+
+  plugin: test-abac-widget
+  policy: widget-owner-read
+  resource_type: widget
+  attribute: creator
+  schema_keys: [type owner]
+```
+
+The fix is either to rename the attribute in the policy (if it was a typo) or
+to add `creator` to your `GetSchema` response and wire it up in
+`ResolveResource`.
+
+## Canonical Example
+
+The minimal correct reference is
+[`plugins/test-abac-widget/main.go`](https://github.com/holomush/holomush/blob/main/plugins/test-abac-widget/main.go).
+
+It demonstrates three properties every resolver SHOULD have:
+
+1. **Schema/runtime consistency** — `GetSchema` declares exactly the two
+   attributes (`type`, `owner`) that `ResolveResource` returns. There are no
+   extra declared attributes and no extra returned attributes.
+2. **Resource-type guard** — `ResolveResource` rejects any request whose
+   `ResourceType` is not `widget`, as defense in depth against host routing
+   bugs. This is not required by the contract (the host only calls you with
+   declared types), but it is cheap and catches regressions.
+3. **No sentinel handling** — the resolver maps `ResourceId` directly to
+   attributes with no special cases for synthetic IDs. The post-hardening
+   contract guarantees `ResourceId` is always a real instance.
+
+## What NOT to Do
+
+| Anti-pattern | Why it is wrong |
+| --- | --- |
+| Checking for sentinel IDs like `__preflight__` | The host does not send them. Dead code at best, wrong behavior at worst |
+| Returning attributes not in your schema | They are silently dropped. Your policies will behave as if the attribute does not exist |
+| Swallowing errors and returning empty `Attributes` | A permit policy may evaluate to `true` on missing attributes and grant access you did not intend |
+| Recursively calling other resolvers from inside `ResolveResource` | Re-entrance detection fail-closes the call |
+| Making `GetSchema` dynamic | The host caches it at load time; runtime variation is ignored |
+| Returning a different `AttributeType` than declared | Policy evaluation may reject the value or produce unexpected coercions |
+
+## Related References
+
+- **Design spec** — [`docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md`](https://github.com/holomush/holomush/blob/main/docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md) — current hardening contract
+- **Trust boundary spec** — [`docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md`](https://github.com/holomush/holomush/blob/main/docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md) — background on why plugin ABAC is isolated
+- **Host proxy** — [`internal/plugin/attribute_proxy.go`](https://github.com/holomush/holomush/blob/main/internal/plugin/attribute_proxy.go) — how the host calls your resolver
+- **Resolver engine** — [`internal/access/policy/attribute/resolver.go`](https://github.com/holomush/holomush/blob/main/internal/access/policy/attribute/resolver.go) — the attribute resolver the host uses to invoke your plugin
+- **Reference plugin** — [`plugins/test-abac-widget/main.go`](https://github.com/holomush/holomush/blob/main/plugins/test-abac-widget/main.go) — canonical minimal implementation
+- **Binary Plugin Guide** — [binary-plugins.md](binary-plugins.md) — general binary plugin authoring
+- **Access Control Guide** — [access-control.md](access-control.md) — writing policies

--- a/site/docs/extending/index.md
+++ b/site/docs/extending/index.md
@@ -36,6 +36,12 @@ How the ABAC policy engine works and how to write policies for your plugin.
 Every host function call is checked against your declared policies — this
 page explains how to get them right.
 
+### [Implementing AttributeResolverService](abac-attribute-resolver.md)
+
+For binary plugins that declare custom resource types. Documents the host
+contract for `GetSchema` and `ResolveResource`, load-time policy/schema
+validation, and common anti-patterns.
+
 ### [Event Reference](events.md)
 
 Event types, payload schemas, and stream patterns. Everything you need to know

--- a/site/zensical.toml
+++ b/site/zensical.toml
@@ -58,6 +58,7 @@ Extending = [
   "extending/getting-started.md",
   "extending/plugin-guide.md",
   "extending/access-control.md",
+  "extending/abac-attribute-resolver.md",
   "extending/api-guide.md",
   "extending/events.md",
 ]

--- a/test/integration/plugin/abac_widget_test.go
+++ b/test/integration/plugin/abac_widget_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -528,6 +529,211 @@ var _ = Describe("Plugin ABAC Trust Boundary", func() {
 				"execute command preflight must not touch the plugin")
 		})
 	})
+
+	// ---------------------------------------------------------------
+	// Plugin ABAC Hardening (spec 2026-04-07): Sharp Edge 2 tests
+	// ---------------------------------------------------------------
+	Describe("manifest policy schema validation at load time", func() {
+		var (
+			ctx       context.Context
+			cancel    context.CancelFunc
+			container testcontainers.Container
+			connStr   string
+		)
+
+		BeforeEach(func() {
+			_, binaryPath := abacWidgetBinaryPath()
+			if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("test-abac-widget binary not found at %s — run 'task plugin:build-all' first",
+					binaryPath))
+			}
+
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+			pgEnv, err := testutil.StartPostgres(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			container = pgEnv.Container
+			connStr = pgEnv.ConnStr
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(migrator.Up()).To(Succeed())
+			_ = migrator.Close()
+		})
+
+		AfterEach(func() {
+			if container != nil {
+				_ = container.Terminate(context.Background())
+			}
+			if cancel != nil {
+				cancel()
+			}
+		})
+
+		It("fails to load a plugin whose manifest policy references an undeclared resource attribute", func() {
+			// T15: Build a manifest based on the widget manifest but with
+			// a typo in one policy's DSL. Validate it and assert failure.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			registry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(registry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+
+			// host.Load itself succeeds — validation happens at the
+			// validator + installer layer.
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, err := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(err).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+
+			valErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(valErr).To(HaveOccurred())
+			Expect(valErr.Error()).To(ContainSubstring("tipe"))
+			Expect(valErr.Error()).To(ContainSubstring("widget-read-normal-bad"))
+		})
+
+		It("installs zero policies in the database when manifest validation fails", func() {
+			// T34: After a failed validation, the policy store MUST have
+			// zero plugin-source policies. Tests rollback completeness:
+			// validation runs BEFORE install, so there's nothing to roll
+			// back, but we assert the invariant explicitly to guard
+			// against a future regression that reorders the steps.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, err := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(err).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+
+			valErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(valErr).To(HaveOccurred())
+
+			// Now check the DB: no policies should be installed.
+			pool, poolErr := pgxpool.New(ctx, connStr)
+			Expect(poolErr).NotTo(HaveOccurred())
+			defer pool.Close()
+
+			ps := policystore.NewPostgresStore(pool)
+			pluginPolicies, listErr := ps.List(ctx, policystore.ListOptions{Source: "plugin"})
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(pluginPolicies).To(BeEmpty(),
+				"failed validation must leave the policy store pristine")
+		})
+
+		It("successfully loads a fixed manifest after a prior validation failure", func() {
+			// T36: Idempotency — after a failed load, a fixed manifest
+			// should validate successfully without any leftover state
+			// interfering.
+			goodManifest := loadWidgetManifest()
+			badManifest := cloneManifestWithBadPolicy(goodManifest)
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+
+			// First attempt — bad manifest.
+			Expect(host.Load(ctx, badManifest, pluginDir)).To(Succeed())
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, _ := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			badErr := plugins.ValidateManifestPolicySchemas(badManifest, schemas)
+			Expect(badErr).To(HaveOccurred())
+
+			// Unload the bad plugin before loading the good one.
+			_ = host.Close(ctx)
+
+			// Re-create host and load the good manifest.
+			svcRegistry2 := plugins.NewServiceRegistry()
+			host2 := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry2),
+			)
+			defer func() { _ = host2.Close(ctx) }()
+
+			Expect(host2.Load(ctx, goodManifest, pluginDir)).To(Succeed())
+			arClient2 := host2.AttributeResolverClient("test-abac-widget")
+			schemaResp2, _ := arClient2.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas2 := plugins.ConvertProtoSchema(schemaResp2)
+
+			goodErr := plugins.ValidateManifestPolicySchemas(goodManifest, schemas2)
+			Expect(goodErr).NotTo(HaveOccurred(),
+				"good manifest must validate successfully after a prior failure")
+		})
+
+		It("installs three plugin policies in the database when manifest validation passes", func() {
+			// T37: Positive path — explicit DB query assertion mirroring
+			// T34's negative path.
+			goodManifest := loadWidgetManifest()
+
+			provisioner := plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+			defer provisioner.Close()
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host := goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+			defer func() { _ = host.Close(ctx) }()
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			Expect(host.Load(ctx, goodManifest, pluginDir)).To(Succeed())
+
+			arClient := host.AttributeResolverClient("test-abac-widget")
+			schemaResp, _ := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			Expect(plugins.ValidateManifestPolicySchemas(goodManifest, schemas)).To(Succeed())
+
+			pool, poolErr := pgxpool.New(ctx, connStr)
+			Expect(poolErr).NotTo(HaveOccurred())
+			defer pool.Close()
+
+			ps := policystore.NewPostgresStore(pool)
+			installer := plugins.NewPolicyInstaller(ps)
+			Expect(installer.InstallPluginPoliciesWithManifest(ctx, goodManifest, goodManifest.Policies)).To(Succeed())
+
+			pluginPolicies, listErr := ps.List(ctx, policystore.ListOptions{Source: "plugin"})
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(pluginPolicies).To(HaveLen(3),
+				"successful validation must install all three policies")
+		})
+	})
 })
 
 // testAuditWriter captures audit entries in memory for testing.
@@ -582,4 +788,32 @@ func (f *fakePolicyStoreWriter) DeleteBySource(_ context.Context, _, _ string) (
 func (f *fakePolicyStoreWriter) ReplaceBySource(_ context.Context, _, _ string, policies []*policystore.StoredPolicy) error {
 	f.created = append(f.created, policies...)
 	return nil
+}
+
+// cloneManifestWithBadPolicy returns a copy of the given manifest with one
+// policy's DSL mutated to reference an undeclared attribute
+// (resource.widget.tipe instead of resource.widget.type). The policy name
+// is also changed to "widget-read-normal-bad" so tests can assert on it
+// specifically.
+//
+// Used by Sharp Edge 2 integration tests in this file to synthesize a
+// failing manifest in-memory without rebuilding the plugin binary.
+func cloneManifestWithBadPolicy(src *plugins.Manifest) *plugins.Manifest {
+	clone := *src
+	clone.Policies = make([]plugins.ManifestPolicy, len(src.Policies))
+	copy(clone.Policies, src.Policies)
+
+	// Find the first policy that targets `resource is widget` with a
+	// "type" attribute reference and rewrite it to use "tipe".
+	for i, p := range clone.Policies {
+		if p.Name == "widget-read-normal" || strings.Contains(p.DSL, "resource.widget.type") {
+			clone.Policies[i] = plugins.ManifestPolicy{
+				Name: "widget-read-normal-bad",
+				DSL: `permit(principal is character, action in ["read"], resource is widget) ` +
+					`when { resource.widget.tipe == "normal" };`,
+			}
+			break
+		}
+	}
+	return &clone
 }

--- a/test/integration/plugin/abac_widget_test.go
+++ b/test/integration/plugin/abac_widget_test.go
@@ -379,6 +379,155 @@ var _ = Describe("Plugin ABAC Trust Boundary", func() {
 			Expect(decision.Effect()).To(Equal(policytypes.EffectDeny))
 		})
 	})
+
+	// ---------------------------------------------------------------
+	// Plugin ABAC Hardening (spec 2026-04-07): Sharp Edge 1 tests
+	// ---------------------------------------------------------------
+	Describe("plugin ResolveResource call semantics under hardening", func() {
+		var (
+			ctx         context.Context
+			cancel      context.CancelFunc
+			container   testcontainers.Container
+			connStr     string
+			host        *goplugin.Host
+			ps          *policystore.PostgresStore
+			engine      *policy.Engine
+			pool        *pgxpool.Pool
+			provisioner *plugins.SchemaProvisioner
+			countingAR  *countingAttributeResolverClient
+		)
+
+		BeforeEach(func() {
+			_, binaryPath := abacWidgetBinaryPath()
+			if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("test-abac-widget binary not found at %s — run 'task plugin:build-all' first",
+					binaryPath))
+			}
+
+			pluginDir, _ := abacWidgetBinaryPath()
+			if _, err := os.Stat(filepath.Join(pluginDir, "plugin.yaml")); os.IsNotExist(err) {
+				Skip(fmt.Sprintf("plugin.yaml not found at %s/plugin.yaml — run 'task plugin:build-all' first", pluginDir))
+			}
+
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+			pgEnv, err := testutil.StartPostgres(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			container = pgEnv.Container
+			connStr = pgEnv.ConnStr
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(migrator.Up()).To(Succeed())
+			_ = migrator.Close()
+
+			provisioner = plugins.NewSchemaProvisioner(connStr)
+			Expect(provisioner.Init(ctx)).To(Succeed())
+
+			svcRegistry := plugins.NewServiceRegistry()
+			host = goplugin.NewHost(
+				goplugin.WithSchemaProvisioner(provisioner),
+				goplugin.WithServiceRegistry(svcRegistry),
+			)
+
+			manifest := loadWidgetManifest()
+			Expect(host.Load(ctx, manifest, pluginDir)).To(Succeed())
+
+			pool, err = pgxpool.New(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			ps = policystore.NewPostgresStore(pool)
+			installer := plugins.NewPolicyInstaller(ps)
+			Expect(installer.InstallPluginPoliciesWithManifest(ctx, manifest, manifest.Policies)).To(Succeed())
+
+			// Wire the counting proxy in place of the raw plugin client.
+			rawClient := host.AttributeResolverClient("test-abac-widget")
+			Expect(rawClient).NotTo(BeNil())
+			countingAR = newCountingAttributeResolverClient(rawClient)
+
+			// Build the engine stack using the counting proxy when
+			// registering the attribute provider.
+			schemaRegistry := attribute.NewSchemaRegistry()
+			resolver := attribute.NewResolver(schemaRegistry)
+
+			cmdProvider := attribute.NewCommandProvider()
+			Expect(resolver.RegisterProvider(cmdProvider)).To(Succeed())
+
+			schemaResp, schemaErr := countingAR.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
+			Expect(schemaErr).NotTo(HaveOccurred())
+			schemas := plugins.ConvertProtoSchema(schemaResp)
+			Expect(schemas).To(HaveKey("widget"))
+
+			widgetProvider := plugins.NewPluginAttributeProvider("widget", countingAR, schemas["widget"])
+			Expect(resolver.RegisterProvider(widgetProvider)).To(Succeed())
+
+			compiler := policy.NewCompiler(schemaRegistry.Schema())
+			cache := policy.NewCache(ps, compiler)
+			Expect(cache.Reload(ctx)).To(Succeed())
+
+			auditWriter := &testAuditWriter{}
+			tmpDir := GinkgoT().TempDir()
+			auditLogger := audit.NewLogger(audit.ModeAll, auditWriter, filepath.Join(tmpDir, "test-wal.jsonl"))
+
+			sessionResolver := &testSessionResolver{}
+			engine = policy.NewEngine(resolver, cache, sessionResolver, auditLogger)
+
+			// Reset counters after BeforeEach so test assertions measure only
+			// the activity that the test body triggers.
+			countingAR.ResetCallCounts()
+		})
+
+		AfterEach(func() {
+			if host != nil {
+				_ = host.Close(ctx)
+			}
+			if provisioner != nil {
+				provisioner.Close()
+			}
+			if pool != nil {
+				pool.Close()
+			}
+			if container != nil {
+				_ = container.Terminate(context.Background())
+			}
+			if cancel != nil {
+				cancel()
+			}
+		})
+
+		It("never invokes the plugin ResolveResource RPC during type-level preflight", func() {
+			// T13: The C1 invariant at E2E layer with a real plugin binary.
+			allowed, err := engine.CanPerformAction(ctx, "character:01ABC", "read", "widget", "self")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue(), "preflight should permit via optimistic branch")
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(0),
+				"ResolveResource MUST NOT be called during type-level preflight")
+		})
+
+		It("still invokes the plugin ResolveResource RPC for instance-level Evaluate", func() {
+			// T14: Instance-level evaluation is unaffected.
+			req, reqErr := policytypes.NewAccessRequest("character:01ABC", "read", "widget:normal-1")
+			Expect(reqErr).NotTo(HaveOccurred())
+
+			decision, err := engine.Evaluate(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decision.IsAllowed()).To(BeTrue())
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(1),
+				"ResolveResource should be called exactly once for one Evaluate")
+		})
+
+		It("permits character:01ABC execute widget command via full database-backed engine stack without invoking plugin ResolveResource", func() {
+			// T38: Full DB-backed stack, CanPerformAction on command execution,
+			// counter asserted zero.
+			allowed, err := engine.CanPerformAction(ctx, "character:01ABC", "execute", "command", "self")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+
+			Expect(countingAR.ResolveResourceCallCount()).To(BeEquivalentTo(0),
+				"execute command preflight must not touch the plugin")
+		})
+	})
 })
 
 // testAuditWriter captures audit entries in memory for testing.

--- a/test/integration/plugin/counting_proxy_test.go
+++ b/test/integration/plugin/counting_proxy_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+	"context"
+	"sync/atomic"
+
+	"google.golang.org/grpc"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// countingAttributeResolverClient wraps a real AttributeResolverServiceClient
+// and counts calls to each RPC. Used in plugin ABAC hardening integration
+// tests to assert that ResolveResource is (or is not) invoked during a
+// particular authorization code path.
+//
+// All counters are atomic so the proxy is safe under concurrent access
+// (engine.Evaluate may be called from multiple goroutines in some test
+// scenarios).
+type countingAttributeResolverClient struct {
+	inner                pluginv1.AttributeResolverServiceClient
+	getSchemaCalls       atomic.Int64
+	resolveResourceCalls atomic.Int64
+}
+
+func newCountingAttributeResolverClient(
+	inner pluginv1.AttributeResolverServiceClient,
+) *countingAttributeResolverClient {
+	return &countingAttributeResolverClient{inner: inner}
+}
+
+func (c *countingAttributeResolverClient) GetSchema(
+	ctx context.Context,
+	req *pluginv1.GetSchemaRequest,
+	opts ...grpc.CallOption,
+) (*pluginv1.GetSchemaResponse, error) {
+	c.getSchemaCalls.Add(1)
+	return c.inner.GetSchema(ctx, req, opts...)
+}
+
+func (c *countingAttributeResolverClient) ResolveResource(
+	ctx context.Context,
+	req *pluginv1.ResolveResourceRequest,
+	opts ...grpc.CallOption,
+) (*pluginv1.ResolveResourceResponse, error) {
+	c.resolveResourceCalls.Add(1)
+	return c.inner.ResolveResource(ctx, req, opts...)
+}
+
+// ResolveResourceCallCount returns the number of ResolveResource calls
+// observed so far. Use this in test assertions.
+func (c *countingAttributeResolverClient) ResolveResourceCallCount() int64 {
+	return c.resolveResourceCalls.Load()
+}
+
+// GetSchemaCallCount returns the number of GetSchema calls observed so far.
+func (c *countingAttributeResolverClient) GetSchemaCallCount() int64 {
+	return c.getSchemaCalls.Load()
+}
+
+// ResetCallCounts resets all counters to zero. Use between phases of a
+// single test (e.g., after BeforeEach setup completes so the test body
+// measures only the activity it triggers).
+func (c *countingAttributeResolverClient) ResetCallCounts() {
+	c.getSchemaCalls.Store(0)
+	c.resolveResourceCalls.Store(0)
+}


### PR DESCRIPTION
## Summary

Hardens the plugin ABAC trust boundary (PR #195) against two architectural sharp edges identified in the post-PR review.

**Sharp Edge 1 (C1) — eliminated:** `engine.CanPerformAction` no longer constructs a synthetic `<resourceType>:__preflight__` resource ID. New `Resolver.ResolveSubjectAttributes(ctx, subject, action)` resolves only subject + environment + action attributes; resource providers are never invoked during type-level preflight. The `__preflight__` literal is deleted from `engine.go` (enforced by a static test).

**Sharp Edge 2 (S1) — load-time fatal:** New `ValidateManifestPolicySchemas` extracts the policy/schema cross-validation from `CheckManifestWarnings` Warning 3 and promotes it to a hard load failure called from `Manager.loadPlugin` before policy install. A typo in `resource.widget.tipe` now fails the load with a structured `oops` error including plugin/policy/resource_type/attribute/schema_keys context.

**Bonus rollback fix:** Task 14's investigation discovered 5 concrete leak paths in `loadPlugin` where `PluginAttributeProvider` was registered but never unregistered on failure. New `Resolver.UnregisterProvider` + `UnregisterPluginProviderFunc` Manager option close all 5.

**Bead:** holomush-479l
**Spec:** \`docs/superpowers/specs/2026-04-07-plugin-abac-hardening-design.md\`
**Plan:** \`docs/superpowers/plans/2026-04-07-plugin-abac-hardening.md\`
**Unblocks:** holomush-0sc.12 (channel plugin rework)

## Test plan

- [x] 11 unit tests on \`Resolver.ResolveSubjectAttributes\` (happy/edge/error/cancel/panic/re-entrance/cross-check/concurrency)
- [x] T5 (engine doesn't invoke resource providers) + T6 (optimistic permit branch)
- [x] T32 static invariant test (engine.go does not contain \`__preflight__\`)
- [x] 12 unit tests on \`ValidateManifestPolicySchemas\` (boundaries, AST traversal for AND/OR/NOT/has/contains/in/prefix)
- [x] 4 integration tests with real plugin binary + PostgreSQL: load-time validation failure + rollback completeness + idempotency + positive control
- [x] 3 integration tests using counting-proxy wrapper proving C1 invariant E2E
- [x] T35 manager-level rollback test
- [x] All 4 pre-existing CanPerformAction tests covering T7/T22/T23/T24 still green
- [x] \`task pr-prep\` PASSED on rebased stack (lint, fmt, schema, license, unit, integration, E2E 48/48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New documentation and site section on implementing attribute resolvers and host-plugin contracts.
  * Added load-time policy/schema validation that fails plugin load on schema mismatches.

* **Bug Fixes**
  * Type-level capability checks no longer call plugin resource resolvers.
  * Improved rollback/unregistration to clean up attribute providers on validation or load failures.

* **Documentation**
  * Expanded docs and examples for ABAC attribute resolver contracts and hardening guidance.

* **Tests**
  * Added unit and integration tests validating hardening behaviors and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->