### PR TITLE
fix(toolchain): bump Go 1.25→1.26.2, migrate grpc.NewClient, add task gowork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,6 +519,24 @@ This mirrors all CI jobs (lint, format, schema, license, unit, integration,
 E2E) and MUST pass with zero failures. Do NOT push to a PR branch without
 a green `task pr-prep`. Docker is always available — never skip E2E tests.
 
+### jj Workspace Commands
+
+Workspaces live in a `.worktrees/` directory that is a sibling of the main repo root
+(e.g., `<parent>/.worktrees/<name>`). The exact path is machine-specific.
+
+```bash
+jj workspace add <parent>/.worktrees/<name> --name <name> -r main
+jj workspace forget <name>  # then: rm -rf <parent>/.worktrees/<name>
+task gowork                 # MUST run after add or forget — regenerates go.work
+```
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** run `task gowork` | After every `jj workspace add` or `jj workspace forget` |
+
+`task gowork` regenerates `go.work` in the main repo root so gopls covers all active
+workspaces without "not in workspace" LSP diagnostics. Works from any workspace.
+
 ### Beads Commands
 
 ```bash

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -484,6 +484,44 @@ tasks:
       - go mod download
       - go mod tidy
 
+  gowork:
+    desc: Regenerate go.work to cover the main repo and all active jj workspaces (run after jj workspace add/forget)
+    cmds:
+      - |
+        set -euo pipefail
+
+        # In a jj workspace, .jj/repo is a FILE pointing (relatively) to the
+        # shared repo directory inside the main checkout. In the main checkout
+        # itself, .jj/repo is a DIRECTORY. Use that to find the main repo root
+        # regardless of which workspace this task is invoked from.
+        if [ -f ".jj/repo" ]; then
+          POINTER=$(cat ".jj/repo")
+          MAIN_REPO=$(cd ".jj/${POINTER}/../.." && pwd -P)
+        else
+          MAIN_REPO=$(pwd -P)
+        fi
+
+        # Read Go version from go.mod so go.work stays aligned with CI regardless
+        # of which patch version a developer has installed locally.
+        GO_VER=$(awk '/^go[[:space:]]+/ {print $2; exit}' "$MAIN_REPO/go.mod")
+        [ -n "$GO_VER" ] || { echo "ERROR: failed to parse go version from $MAIN_REPO/go.mod"; exit 1; }
+
+        WORKTREES="$(dirname "$MAIN_REPO")/.worktrees"
+
+        {
+          echo "go $GO_VER"
+          echo ""
+          echo "use ."
+          if [ -d "$WORKTREES" ]; then
+            for dir in "$WORKTREES"/*/; do
+              [ -f "${dir}go.mod" ] && echo "use ${dir%/}"
+            done
+          fi
+        } > "$MAIN_REPO/go.work"
+
+        COUNT=$(grep -c '^use' "$MAIN_REPO/go.work")
+        echo "✓ go.work written to $MAIN_REPO with $COUNT module(s)"
+
   # ──────────────────────────────────────────
   # Database migrations
   # ──────────────────────────────────────────

--- a/cmd/holomush/status.go
+++ b/cmd/holomush/status.go
@@ -154,31 +154,7 @@ func queryProcessStatusGRPC(component, addr string) ProcessStatus {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// TODO: Migrate to grpc.NewClient when ready.
-	//
-	// grpc.DialContext is deprecated in favor of grpc.NewClient. Key differences:
-	//
-	// 1. Connection behavior: grpc.NewClient creates a "virtual" connection without
-	//    immediately establishing a physical connection (lazy connect). grpc.DialContext
-	//    can block with WithBlock option. For our use case, we want eager connection
-	//    to detect unavailable services quickly.
-	//
-	// 2. Name resolver: grpc.NewClient uses "dns" as default resolver, while DialContext
-	//    uses "passthrough". For direct IP:port addresses like ours, this shouldn't matter,
-	//    but we should verify behavior with mTLS ServerName verification.
-	//
-	// 3. Migration steps:
-	//    a. Replace grpc.DialContext with grpc.NewClient
-	//    b. Remove context parameter (NewClient doesn't take context)
-	//    c. If blocking behavior is needed, call conn.Connect() and use
-	//       conn.WaitForStateChange() to wait for Ready state
-	//    d. Test mTLS with ServerName verification still works correctly
-	//    e. Update timeout handling (move to RPC context instead of dial context)
-	//
-	// See: https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
-	//
-	//nolint:staticcheck // grpc.NewClient requires different setup; DialContext works for 1.x
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return NewProcessStatusError(component, oops.Code("GRPC_CONNECT_FAILED").With("operation", "connect").With("addr", addr).Wrap(err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/holomush/holomush
 
-go 1.25.0
+go 1.26.2
 
 require (
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
 	buf.build/go/protovalidate v1.1.3
 	connectrpc.com/connect v1.19.1
 	github.com/Masterminds/semver/v3 v3.4.0
@@ -23,6 +24,7 @@ require (
 	github.com/pashagolub/pgxmock/v4 v4.9.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/oops v1.21.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sethvargo/go-retry v0.3.0
@@ -49,7 +51,6 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -120,7 +121,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/quasilyte/go-ruleguard/dsl v0.3.23 // indirect
 	github.com/samber/lo v1.52.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect


### PR DESCRIPTION
## Summary

- **go.mod** bumped from `go 1.25.0` to `go 1.26.2` to match the installed toolchain. The old version caused gopls and staticcheck to report false positives for stdlib files gated with `//go:build go1.26` constraints (e.g., `chacha20poly1305/fips140only_go1.26.go`). CI uses `go-version-file: go.mod`, so this also aligns the CI toolchain.
- **`cmd/holomush/status.go`**: Migrated `grpc.DialContext` (deprecated) to `grpc.NewClient`. The 2-second timeout is enforced at the RPC call level, so behavior is unchanged.
- **`Taskfile.yaml`**: Added `task gowork` which regenerates `go.work` in the main repo root to cover all active jj workspaces. Reads Go version from `go.mod` (not `go env GOVERSION`) for deterministic output across contributor environments. Uses `.jj/repo` pointer to locate the main repo regardless of which workspace invokes it.
- **`CLAUDE.md`**: Documents the jj workspace workflow including the `task gowork` requirement after `jj workspace add`/`forget`.

## Test plan

- [ ] All 5290 unit tests pass (`task test`)
- [ ] `staticcheck ./...` reports zero issues
- [ ] `task lint` reports zero issues
- [ ] `task gowork` generates correct `go.work` from both main repo and worktree context
- [ ] CI Go version matches local (`go 1.26.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)