### PR TITLE
feat(plugin): plugin-contributed session stream subscription (holomush-oirq)

### DIFF
--- a/api/proto/holomush/plugin/v1/hostfunc.proto
+++ b/api/proto/holomush/plugin/v1/hostfunc.proto
@@ -46,6 +46,14 @@ service HostFunctionsService {
   // GetCommandHelp returns detailed help for a specific command.
   // Requires capability: command.help
   rpc GetCommandHelp(GetCommandHelpRequest) returns (GetCommandHelpResponse);
+
+  // AddSessionStream subscribes an active session to an additional stream mid-session.
+  // Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+  rpc AddSessionStream(AddSessionStreamRequest) returns (AddSessionStreamResponse);
+
+  // RemoveSessionStream unsubscribes an active session from a stream.
+  // Idempotent: returns success if stream is not subscribed.
+  rpc RemoveSessionStream(RemoveSessionStreamRequest) returns (RemoveSessionStreamResponse);
 }
 
 // LogLevel specifies the severity of a log message.
@@ -245,4 +253,36 @@ message CommandHelpInfo {
   repeated string capabilities = 5;
   // Source plugin name or "core".
   string source = 6 [(buf.validate.field).string.min_len = 1];
+}
+
+// AddSessionStreamRequest specifies which session and stream to add.
+message AddSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Stream name to subscribe to (format: "prefix:id").
+  string stream = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+// AddSessionStreamResponse indicates success or failure.
+message AddSessionStreamResponse {
+  // Whether the stream was successfully added.
+  bool success = 1;
+  // Non-empty on error.
+  string error = 2;
+}
+
+// RemoveSessionStreamRequest specifies which stream to remove.
+message RemoveSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Stream name to unsubscribe from.
+  string stream = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+// RemoveSessionStreamResponse indicates success or failure.
+message RemoveSessionStreamResponse {
+  // Whether the stream was successfully removed (true even if not subscribed).
+  bool success = 1;
+  // Non-empty on error.
+  string error = 2;
 }

--- a/api/proto/holomush/plugin/v1/plugin.proto
+++ b/api/proto/holomush/plugin/v1/plugin.proto
@@ -23,6 +23,11 @@ service PluginService {
 
   // HandleCommand delivers a command to the plugin.
   rpc HandleCommand(HandleCommandRequest) returns (HandleCommandResponse);
+
+  // QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+  // Called once at session establishment, before LISTEN setup.
+  // Only invoked for plugins that declare session_streams: true in their manifest.
+  rpc QuerySessionStreams(QuerySessionStreamsRequest) returns (QuerySessionStreamsResponse);
 }
 
 // PluginHostService runs in the host process, allowing binary plugins
@@ -38,6 +43,12 @@ service PluginHostService {
   rpc KVSet(PluginHostServiceKVSetRequest) returns (PluginHostServiceKVSetResponse);
   // KVDelete removes a value from the plugin's key-value store.
   rpc KVDelete(PluginHostServiceKVDeleteRequest) returns (PluginHostServiceKVDeleteResponse);
+  // AddSessionStream subscribes an active session to an additional stream mid-session.
+  // Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+  rpc AddSessionStream(PluginHostServiceAddSessionStreamRequest) returns (PluginHostServiceAddSessionStreamResponse);
+  // RemoveSessionStream unsubscribes an active session from a stream.
+  // Idempotent: returns success if stream is not subscribed.
+  rpc RemoveSessionStream(PluginHostServiceRemoveSessionStreamRequest) returns (PluginHostServiceRemoveSessionStreamResponse);
 }
 
 // ServiceConfig carries initialization data from the host to the plugin.
@@ -252,3 +263,49 @@ message PluginHostServiceKVDeleteRequest {
 }
 
 message PluginHostServiceKVDeleteResponse {}
+
+// PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
+message PluginHostServiceAddSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1;
+  // Stream name to subscribe to (format: "prefix:id").
+  string stream = 2;
+}
+
+// PluginHostServiceAddSessionStreamResponse indicates success or failure.
+message PluginHostServiceAddSessionStreamResponse {
+  // Whether the stream was successfully added.
+  bool success = 1;
+}
+
+// PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
+message PluginHostServiceRemoveSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1;
+  // Stream name to unsubscribe from.
+  string stream = 2;
+}
+
+// PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
+message PluginHostServiceRemoveSessionStreamResponse {
+  // Whether the stream was successfully removed (true even if not subscribed).
+  bool success = 1;
+}
+
+// QuerySessionStreamsRequest provides session context for stream contribution.
+message QuerySessionStreamsRequest {
+  // Identifier of the character entering the session.
+  string character_id = 1;
+  // Identifier of the player owning the character.
+  string player_id = 2;
+  // Session identifier.
+  string session_id = 3;
+}
+
+// QuerySessionStreamsResponse returns stream names and an optional error.
+message QuerySessionStreamsResponse {
+  // Stream names the plugin wants added to this session's subscription.
+  repeated string streams = 1;
+  // Non-empty indicates a plugin-reported error. Host degrades (logs + skips).
+  string error = 2;
+}

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -25,6 +25,7 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/config"
+	holoGRPC "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/logging"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
@@ -248,6 +249,10 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		DB: dbSub,
 	})
 
+	// Create stream registry early so it can be shared between the plugin
+	// subsystem (hostfunc) and the gRPC subsystem (CoreServer + PluginHostService).
+	streamRegistry := holoGRPC.NewSessionStreamRegistry()
+
 	pluginSub := pluginsetup.NewPluginSubsystem(pluginsetup.PluginSubsystemConfig{
 		DataDir:         cfg.DataDir,
 		DatabaseConnStr: databaseURL,
@@ -261,6 +266,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		Sessions:        &sessionBridge{sub: sessionSub},
 		AdminDeps:       &adminDepsBridge{auth: authSub, db: dbSub},
 		Registry:        registry,
+		StreamRegistry:  streamRegistry,
 	})
 
 	bootstrapSub := bootstrapsetup.NewBootstrapSubsystem(bootstrapsetup.BootstrapSubsystemConfig{
@@ -291,6 +297,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		ReaperInterval: reaperInterval,
 		MaxHistory:     cfg.SessionMaxHistory,
 		GameConfig:     gameConfig,
+		StreamRegistry: streamRegistry,
 	})
 
 	// --- 8. Orchestrator: register + start ---

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -31,7 +31,6 @@ import (
 	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
 	contentv1 "github.com/holomush/holomush/pkg/proto/holomush/content/v1"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
-
 	abacsetup "github.com/holomush/holomush/internal/access/setup"
 	authsetup "github.com/holomush/holomush/internal/auth/setup"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
@@ -55,6 +54,7 @@ type grpcSubsystemConfig struct {
 	ReaperInterval time.Duration
 	MaxHistory     int
 	GameConfig     config.GameConfig
+	StreamRegistry *holoGRPC.SessionStreamRegistry
 }
 
 // grpcSubsystem is the terminal subsystem that wires the gRPC server.
@@ -189,7 +189,7 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	}
 
 	// 8. Create CoreServer and register with gRPC.
-	coreServer := holoGRPC.NewCoreServer(engine, sessionStore, cmdDispatcher, cmdServices,
+	coreServerOpts := []holoGRPC.CoreServerOption{
 		holoGRPC.WithEventStore(eventStore),
 		holoGRPC.WithWorldQuerier(worldService),
 		holoGRPC.WithAuthService(authService),
@@ -208,7 +208,12 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 			}
 		}),
 		holoGRPC.WithGuestService(guestService),
-	)
+		holoGRPC.WithStreamContributor(pluginManager),
+	}
+	if s.cfg.StreamRegistry != nil {
+		coreServerOpts = append(coreServerOpts, holoGRPC.WithStreamRegistry(s.cfg.StreamRegistry))
+	}
+	coreServer := holoGRPC.NewCoreServer(engine, sessionStore, cmdDispatcher, cmdServices, coreServerOpts...)
 	corev1.RegisterCoreServiceServer(s.grpcServer, coreServer)
 
 	// 9. Create ContentService, register with gRPC.

--- a/docs/superpowers/plans/2026-04-08-plugin-session-stream-contribution.md
+++ b/docs/superpowers/plans/2026-04-08-plugin-session-stream-contribution.md
@@ -1,0 +1,2375 @@
+# Plugin Session Stream Contribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a general mechanism for plugins to contribute session stream subscriptions at login time and modify them mid-session, enabling channels (and future plugins) to auto-subscribe characters on connect.
+
+**Architecture:** `QuerySessionStreams` RPC on `PluginService` collects streams from opted-in plugins before LISTEN setup (preserving LISTEN-before-replay invariant). `AddSessionStream`/`RemoveSessionStream` on `HostFunctionsService` write to a per-session control channel, handled inline by the Subscribe goroutine.
+
+**Tech Stack:** Go, protobuf/gRPC, gopher-lua, HashiCorp go-plugin, testify, Ginkgo/Gomega
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `api/proto/holomush/plugin/v1/plugin.proto` | Modify | Add `QuerySessionStreams` RPC + messages |
+| `api/proto/holomush/plugin/v1/hostfunc.proto` | Modify | Add `AddSessionStream`/`RemoveSessionStream` |
+| `internal/plugin/host.go` | Modify | Add `SessionStreamsRequest`, `StreamRegistry`, `QuerySessionStreams` to `Host` |
+| `internal/plugin/manifest.go` | Modify | Add `SessionStreams bool` field + validation |
+| `internal/plugin/manifest_test.go` | Modify | Validation tests for `session_streams` |
+| `internal/plugin/manager.go` | Modify | Add `QuerySessionStreams` fan-out method |
+| `internal/plugin/manager_test.go` | Modify | Fan-out unit tests |
+| `internal/plugin/mocks/mock_Host.go` | Regenerate | Updated interface mock |
+| `internal/plugin/lua/host.go` | Modify | Implement `QuerySessionStreams` via `on_session_subscribe` Lua callback |
+| `internal/plugin/lua/host_test.go` | Modify | Lua host QuerySessionStreams tests |
+| `internal/plugin/hostfunc/functions.go` | Modify | Add `streamRegistry StreamRegistry` field + `WithStreamRegistry` option |
+| `internal/plugin/hostfunc/stdlib_streams.go` | Create | `RegisterStreamFuncs` — `holo.add_session_stream` / `holo.remove_session_stream` |
+| `internal/plugin/hostfunc/stdlib_streams_test.go` | Create | Hostfunc stream tests |
+| `internal/plugin/goplugin/host.go` | Modify | Implement `QuerySessionStreams` via gRPC |
+| `internal/plugin/goplugin/host_test.go` | Modify | Binary host QuerySessionStreams tests |
+| `internal/plugin/goplugin/host_service.go` | Modify | Implement `AddSessionStream`/`RemoveSessionStream` for binary plugins |
+| `internal/plugin/goplugin/host_service_test.go` | Modify | Binary host service stream tests |
+| `internal/grpc/stream_registry.go` | Create | `SessionStreamRegistry` — maps session IDs to control channels |
+| `internal/grpc/stream_registry_test.go` | Create | Registry unit tests |
+| `internal/grpc/server.go` | Modify | Subscribe: collect plugin streams, ctrlCh, per-stream cancels, afterLISTENHook |
+| `internal/grpc/server_test.go` | Modify | Subscribe unit tests for plugin stream integration |
+| `test/integration/plugin/` | Create (dir) | New integration test package for plugin E2E |
+| `test/integration/plugin/session_streams_suite_test.go` | Create | Ginkgo suite registration |
+| `test/integration/plugin/session_streams_integration_test.go` | Create | UC1, UC2, invariant E2E tests |
+| `cmd/holomush/` (setup file) | Modify | Wire `SessionStreamRegistry` + `streamContributor` into server + hostfunc |
+
+---
+
+### Task 1: Proto Changes
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/plugin.proto`
+- Modify: `api/proto/holomush/plugin/v1/hostfunc.proto`
+
+> Proto changes have no tests. Run `task proto` and `task build` to verify generation and compilation.
+
+- [ ] **Step 1: Add `QuerySessionStreams` to `plugin.proto`**
+
+In `api/proto/holomush/plugin/v1/plugin.proto`, after the `HandleCommand` RPC, add:
+
+```protobuf
+  // QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+  // Called once at session establishment, before LISTEN setup.
+  // Only invoked for plugins that declare session_streams: true in their manifest.
+  rpc QuerySessionStreams(QuerySessionStreamsRequest) returns (QuerySessionStreamsResponse);
+```
+
+After the existing message definitions, add:
+
+```protobuf
+// QuerySessionStreamsRequest provides session context for stream contribution.
+message QuerySessionStreamsRequest {
+  // Identifier of the character entering the session.
+  string character_id = 1;
+  // Identifier of the player owning the character.
+  string player_id = 2;
+  // Session identifier.
+  string session_id = 3;
+}
+
+// QuerySessionStreamsResponse returns stream names and an optional error.
+message QuerySessionStreamsResponse {
+  // Stream names the plugin wants added to this session's subscription.
+  repeated string streams = 1;
+  // Non-empty indicates a plugin-reported error. Host degrades (logs + skips).
+  string error = 2;
+}
+```
+
+- [ ] **Step 2: Add `AddSessionStream` and `RemoveSessionStream` to `hostfunc.proto`**
+
+In `api/proto/holomush/plugin/v1/hostfunc.proto`, after the `GetCommandHelp` RPC, add:
+
+```protobuf
+  // AddSessionStream subscribes an active session to an additional stream mid-session.
+  // Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+  rpc AddSessionStream(AddSessionStreamRequest) returns (AddSessionStreamResponse);
+
+  // RemoveSessionStream unsubscribes an active session from a stream.
+  // Idempotent: returns success if stream is not subscribed.
+  rpc RemoveSessionStream(RemoveSessionStreamRequest) returns (RemoveSessionStreamResponse);
+```
+
+After the existing message definitions, add:
+
+```protobuf
+// AddSessionStreamRequest specifies which session and stream to add.
+message AddSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1;
+  // Stream name to subscribe to (format: "prefix:id").
+  string stream = 2;
+}
+
+// AddSessionStreamResponse indicates success or failure.
+message AddSessionStreamResponse {
+  // Whether the stream was successfully added.
+  bool success = 1;
+  // Non-empty on error.
+  string error = 2;
+}
+
+// RemoveSessionStreamRequest specifies which stream to remove.
+message RemoveSessionStreamRequest {
+  // Active session identifier.
+  string session_id = 1;
+  // Stream name to unsubscribe from.
+  string stream = 2;
+}
+
+// RemoveSessionStreamResponse indicates success or failure.
+message RemoveSessionStreamResponse {
+  // Whether the stream was successfully removed (true even if not subscribed).
+  bool success = 1;
+  // Non-empty on error.
+  string error = 2;
+}
+```
+
+- [ ] **Step 3: Regenerate proto code**
+
+```bash
+task proto
+```
+
+Expected: no errors. Generated files updated in `pkg/proto/holomush/plugin/v1/`.
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+task build
+```
+
+Expected: successful build. If `UnimplementedPluginServiceServer` or `UnimplementedHostFunctionsServiceServer` fail, add stub implementations in the relevant host files (goplugin/host_service.go, etc.) — the proto generator adds unimplemented stubs to the embedded types automatically.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(proto): add QuerySessionStreams, AddSessionStream, RemoveSessionStream RPCs"
+```
+
+---
+
+### Task 2: Manifest `session_streams` Field
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go`
+- Modify: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `internal/plugin/manifest_test.go`, add a new test group. Find the existing test function structure and add:
+
+```go
+func TestManifestSessionStreamsValidationAcceptsLuaPlugin(t *testing.T) {
+    data := []byte(`
+name: my-plugin
+version: 1.0.0
+type: lua
+session_streams: true
+lua-plugin:
+  entry: main.lua
+`)
+    m, err := ParseManifest(data)
+    require.NoError(t, err)
+    assert.True(t, m.SessionStreams)
+}
+
+func TestManifestSessionStreamsValidationAcceptsBinaryPlugin(t *testing.T) {
+    data := []byte(`
+name: my-plugin
+version: 1.0.0
+type: binary
+session_streams: true
+binary-plugin:
+  executable: plugin
+`)
+    m, err := ParseManifest(data)
+    require.NoError(t, err)
+    assert.True(t, m.SessionStreams)
+}
+
+func TestManifestSessionStreamsValidationRejectsCorePlugin(t *testing.T) {
+    data := []byte(`
+name: my-plugin
+version: 1.0.0
+type: core
+session_streams: true
+commands:
+  - name: mycmd
+    help: "does stuff"
+`)
+    _, err := ParseManifest(data)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "session_streams")
+}
+
+func TestManifestSessionStreamsValidationRejectsSettingPlugin(t *testing.T) {
+    data := []byte(`
+name: my-plugin
+version: 1.0.0
+type: setting
+session_streams: true
+setting:
+  display_name: My World
+  content_dir: content
+  starting_location: start
+`)
+    _, err := ParseManifest(data)
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "session_streams")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run TestManifestSessionStreams ./internal/plugin/
+```
+
+Expected: compile error (field doesn't exist yet) or test failures.
+
+- [ ] **Step 3: Add `SessionStreams` field to `Manifest`**
+
+In `internal/plugin/manifest.go`, add the field after `Priority`:
+
+```go
+// SessionStreams indicates the plugin implements QuerySessionStreams and contributes
+// streams to session subscriptions. Only valid for lua and binary plugin types.
+SessionStreams bool `yaml:"session_streams,omitempty" json:"session_streams,omitempty" jsonschema:"description=Plugin contributes streams to session subscriptions via QuerySessionStreams"`
+```
+
+- [ ] **Step 4: Add validation rule**
+
+In `manifest.go`'s `Validate()` method, add after the existing type-specific validations (before the load priority check):
+
+```go
+// Validate session_streams: only lua and binary plugins can contribute session streams.
+if m.SessionStreams && m.Type != TypeLua && m.Type != TypeBinary {
+    return oops.In("manifest").With("name", m.Name).With("type", m.Type).
+        New("session_streams is only valid for lua and binary plugin types")
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+task test -- -run TestManifestSessionStreams ./internal/plugin/
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 6: Update JSON schema**
+
+```bash
+task generate:schema
+```
+
+Expected: `internal/plugin/schema.json` updated with `session_streams` field.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "feat(plugin): add session_streams manifest field with lua/binary-only validation"
+```
+
+---
+
+### Task 3: `Host` Interface Extension + `StreamRegistry` Interface
+
+**Files:**
+
+- Modify: `internal/plugin/host.go`
+- Regenerate: `internal/plugin/mocks/mock_Host.go`
+
+- [ ] **Step 1: Add `SessionStreamsRequest` and `StreamRegistry` to `host.go`**
+
+In `internal/plugin/host.go`, add after the existing content:
+
+```go
+// SessionStreamsRequest carries session context for plugin stream contribution queries.
+type SessionStreamsRequest struct {
+    // CharacterID is the character entering the session.
+    CharacterID string
+    // PlayerID is the player owning the character.
+    PlayerID string
+    // SessionID is the active session identifier.
+    SessionID string
+}
+
+// StreamRegistry allows plugins to modify session stream subscriptions mid-session.
+type StreamRegistry interface {
+    // AddStream subscribes a session to an additional stream.
+    // Returns an error (code SESSION_NOT_FOUND) if the session is not active.
+    AddStream(ctx context.Context, sessionID, stream string) error
+    // RemoveStream unsubscribes a session from a stream. Idempotent.
+    RemoveStream(ctx context.Context, sessionID, stream string) error
+}
+```
+
+The file currently imports only `context` and `pluginsdk`. Add `"context"` if not already present (it should be).
+
+- [ ] **Step 2: Add `QuerySessionStreams` to `Host` interface**
+
+In `internal/plugin/host.go`, add to the `Host` interface after `DeliverCommand`:
+
+```go
+// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+// Only called for plugins with SessionStreams: true in their manifest.
+// Returns nil if the plugin has no streams to contribute.
+QuerySessionStreams(ctx context.Context, name string, req SessionStreamsRequest) ([]string, error)
+```
+
+- [ ] **Step 3: Regenerate mocks**
+
+```bash
+task mocks:generate
+```
+
+Expected: `internal/plugin/mocks/mock_Host.go` updated with `QuerySessionStreams` method.
+
+- [ ] **Step 4: Verify build**
+
+```bash
+task build
+```
+
+Expected: compile errors in `internal/plugin/lua/host.go` and `internal/plugin/goplugin/host.go` because they don't implement the new method yet. Note these errors — they'll be fixed in Tasks 6 and 8.
+
+- [ ] **Step 5: Add stub implementations to fix build**
+
+In `internal/plugin/lua/host.go`, add a temporary stub:
+
+```go
+// QuerySessionStreams calls the plugin's on_session_subscribe handler if defined.
+// Returns nil if the function is not defined in the plugin.
+// TODO: implement in Task 6.
+func (h *Host) QuerySessionStreams(_ context.Context, name string, _ plugins.SessionStreamsRequest) ([]string, error) {
+    return nil, nil
+}
+```
+
+In `internal/plugin/goplugin/host.go`, add a temporary stub:
+
+```go
+// QuerySessionStreams calls the plugin's QuerySessionStreams RPC.
+// TODO: implement in Task 8.
+func (h *Host) QuerySessionStreams(_ context.Context, name string, _ plugins.SessionStreamsRequest) ([]string, error) {
+    return nil, nil
+}
+```
+
+- [ ] **Step 6: Verify build passes**
+
+```bash
+task build
+```
+
+Expected: successful build (stubs satisfy interface).
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "feat(plugin): add SessionStreamsRequest, StreamRegistry, QuerySessionStreams to Host interface"
+```
+
+---
+
+### Task 4: `Manager.QuerySessionStreams` Fan-Out
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go`
+- Modify: `internal/plugin/manager_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `internal/plugin/manager_test.go`, add (imports: `"sync/atomic"`, `mocks` package):
+
+```go
+func TestManagerQuerySessionStreamsReturnsNilWhenNoOptedInPlugins(t *testing.T) {
+    m := newTestManager(t)
+    result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+        CharacterID: "char-1",
+        PlayerID:    "player-1",
+        SessionID:   "sess-1",
+    })
+    assert.Nil(t, result)
+}
+
+func TestManagerQuerySessionStreamsMergesContributionsFromMultiplePlugins(t *testing.T) {
+    m := newTestManager(t)
+
+    hostA := mocks.NewMockHost(t)
+    hostA.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    hostA.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+        Return([]string{"channel:abc", "channel:shared"}, nil)
+    m.RegisterHost(plugins.TypeLua, hostA)
+
+    hostB := mocks.NewMockHost(t)
+    hostB.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    hostB.EXPECT().QuerySessionStreams(mock.Anything, "plugin-b", mock.Anything).
+        Return([]string{"channel:shared", "channel:def"}, nil) // channel:shared is a duplicate
+    m.RegisterHost(plugins.TypeBinary, hostB)
+
+    loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)  // session_streams: true
+    loadPlugin(t, m, "plugin-b", plugins.TypeBinary, true)
+
+    result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+        CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+    })
+
+    assert.ElementsMatch(t, []string{"channel:abc", "channel:shared", "channel:def"}, result)
+}
+
+func TestManagerQuerySessionStreamsDegradeOnSinglePluginError(t *testing.T) {
+    m := newTestManager(t)
+
+    hostA := mocks.NewMockHost(t)
+    hostA.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    hostA.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+        Return(nil, errors.New("db unavailable"))
+    m.RegisterHost(plugins.TypeLua, hostA)
+
+    hostB := mocks.NewMockHost(t)
+    hostB.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    hostB.EXPECT().QuerySessionStreams(mock.Anything, "plugin-b", mock.Anything).
+        Return([]string{"channel:abc"}, nil)
+    m.RegisterHost(plugins.TypeBinary, hostB)
+
+    loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)
+    loadPlugin(t, m, "plugin-b", plugins.TypeBinary, true)
+
+    result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+        CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+    })
+
+    assert.Equal(t, []string{"channel:abc"}, result)
+}
+
+func TestManagerQuerySessionStreamsSkipsOptedOutPlugins(t *testing.T) {
+    m := newTestManager(t)
+
+    host := mocks.NewMockHost(t)
+    host.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    // QuerySessionStreams must NOT be called on opted-out plugin
+    m.RegisterHost(plugins.TypeLua, host)
+    loadPlugin(t, m, "plugin-a", plugins.TypeLua, false) // session_streams: false
+
+    result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+        CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+    })
+    assert.Nil(t, result)
+    // testify/mock will fail the test if QuerySessionStreams was called unexpectedly
+}
+
+func TestManagerQuerySessionStreamsDropsInvalidStreamNames(t *testing.T) {
+    m := newTestManager(t)
+    host := mocks.NewMockHost(t)
+    host.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+    host.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+        Return([]string{
+            "",               // empty — invalid
+            "nocolon",        // no colon — invalid
+            "has space:abc",  // whitespace — invalid
+            "channel:valid",  // valid
+        }, nil)
+    m.RegisterHost(plugins.TypeLua, host)
+    loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)
+
+    result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+        CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+    })
+    assert.Equal(t, []string{"channel:valid"}, result)
+}
+```
+
+You'll need a helper. Add to the test file (or a `manager_test_helpers_test.go`):
+
+```go
+// loadPlugin registers a fake plugin manifest with the manager.
+// sessionStreams controls whether Manifest.SessionStreams is true.
+func loadPlugin(t *testing.T, m *plugins.Manager, name string, plugType plugins.Type, sessionStreams bool) {
+    t.Helper()
+    manifest := &plugins.Manifest{
+        Name:          name,
+        Version:       "1.0.0",
+        Type:          plugType,
+        SessionStreams: sessionStreams,
+    }
+    // For lua: set LuaPlugin
+    if plugType == plugins.TypeLua {
+        manifest.LuaPlugin = &plugins.LuaConfig{Entry: "main.lua"}
+    }
+    if plugType == plugins.TypeBinary {
+        manifest.BinaryPlugin = &plugins.BinaryConfig{Executable: "plugin"}
+    }
+    // Inject directly into manager's internal map for testing
+    // (avoids needing real plugin files)
+    // Add to manager.loaded via a test-exported method or use reflect
+    // Simplest: add an exported test helper on Manager:
+    m.TestLoadPlugin(name, manifest)
+}
+```
+
+Add `TestLoadPlugin` to `manager.go`:
+
+```go
+// TestLoadPlugin injects a plugin directly for unit testing.
+// Only available in tests.
+func (m *Manager) TestLoadPlugin(name string, manifest *Manifest) {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    m.loaded[name] = &DiscoveredPlugin{Manifest: manifest}
+    // pluginHosts entry needed for routing — use whichever host is registered for this type
+    if host, ok := m.hosts[manifest.Type]; ok {
+        m.pluginHosts[name] = host
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run TestManagerQuerySessionStreams ./internal/plugin/
+```
+
+Expected: compile error (`QuerySessionStreams` not defined on Manager) or failures.
+
+- [ ] **Step 3: Implement `Manager.QuerySessionStreams`**
+
+In `internal/plugin/manager.go`, add after existing methods. First check the `DiscoveredPlugin` struct — if it doesn't have a `Manifest` field exposed, check what field name is used (it's likely `manifest` lowercase, in which case use `dp.manifest`):
+
+```go
+// isValidStreamName returns true if name is a valid HoloMUSH stream name.
+// Stream names must be non-empty, contain exactly one colon, have no whitespace,
+// and be at most 256 characters long.
+func isValidStreamName(name string) bool {
+    if name == "" || len(name) > 256 {
+        return false
+    }
+    for _, r := range name {
+        if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+            return false
+        }
+    }
+    colonCount := strings.Count(name, ":")
+    return colonCount >= 1
+}
+
+// QuerySessionStreams collects plugin-contributed stream names for a session.
+// Only plugins with SessionStreams: true in their manifest are queried.
+// Plugin errors are logged and skipped (degraded-subscribe policy).
+// Invalid stream names are dropped. Duplicate streams are deduplicated.
+func (m *Manager) QuerySessionStreams(ctx context.Context, req SessionStreamsRequest) []string {
+    m.mu.RLock()
+    type pluginEntry struct {
+        name string
+        host Host
+    }
+    var opted []pluginEntry
+    for name, dp := range m.loaded {
+        if dp.Manifest.SessionStreams {
+            if host, ok := m.pluginHosts[name]; ok {
+                opted = append(opted, pluginEntry{name, host})
+            }
+        }
+    }
+    m.mu.RUnlock()
+
+    if len(opted) == 0 {
+        return nil
+    }
+
+    type result struct {
+        name    string
+        streams []string
+        err     error
+    }
+    results := make(chan result, len(opted))
+    for _, p := range opted {
+        p := p
+        go func() {
+            streams, err := p.host.QuerySessionStreams(ctx, p.name, req)
+            results <- result{name: p.name, streams: streams, err: err}
+        }()
+    }
+
+    seen := make(map[string]bool)
+    var merged []string
+    for range opted {
+        r := <-results
+        if r.err != nil {
+            slog.WarnContext(ctx, "plugin stream contribution failed — skipping",
+                "plugin", r.name,
+                "character_id", req.CharacterID,
+                "session_id", req.SessionID,
+                "error", r.err)
+            continue
+        }
+        for _, s := range r.streams {
+            if !isValidStreamName(s) {
+                slog.WarnContext(ctx, "plugin returned invalid stream name — dropping",
+                    "plugin", r.name,
+                    "stream", s)
+                continue
+            }
+            if !seen[s] {
+                seen[s] = true
+                merged = append(merged, s)
+            }
+        }
+    }
+    return merged
+}
+```
+
+Add `"strings"` to imports if not present.
+
+Check `DiscoveredPlugin` type — look for how loaded plugins store their manifest (in `manager.go` or `bootstrap.go`). The field is likely `Manifest *Manifest`. If it's lowercase `manifest`, update the field access accordingly.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+task test -- -run TestManagerQuerySessionStreams ./internal/plugin/
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(plugin): Manager.QuerySessionStreams fan-out with degraded-subscribe policy"
+```
+
+---
+
+### Task 5: `SessionStreamRegistry`
+
+**Files:**
+
+- Create: `internal/grpc/stream_registry.go`
+- Create: `internal/grpc/stream_registry_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/grpc/stream_registry_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestSessionStreamRegistrySendDeliversToRegisteredSession(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    ch := make(chan sessionStreamUpdate, 1)
+    r.Register("sess-1", ch)
+
+    err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+    require.NoError(t, err)
+
+    update := <-ch
+    assert.Equal(t, "channel:abc", update.stream)
+    assert.True(t, update.add)
+}
+
+func TestSessionStreamRegistrySendReturnsNotFoundForUnknownSession(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    err := r.Send("missing", sessionStreamUpdate{stream: "channel:abc", add: true})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "SESSION_NOT_FOUND")
+}
+
+func TestSessionStreamRegistrySendReturnsNotFoundAfterDeregister(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    ch := make(chan sessionStreamUpdate, 1)
+    r.Register("sess-1", ch)
+    r.Deregister("sess-1")
+
+    err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "SESSION_NOT_FOUND")
+}
+
+func TestSessionStreamRegistrySendReturnsChannelFullWhenBufferExhausted(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    ch := make(chan sessionStreamUpdate, 1) // buffer of 1
+    r.Register("sess-1", ch)
+
+    // Fill the buffer
+    err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+    require.NoError(t, err)
+
+    // Second send to full buffer should return error immediately
+    err = r.Send("sess-1", sessionStreamUpdate{stream: "channel:def", add: true})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "CONTROL_CHANNEL_FULL")
+}
+
+func TestSessionStreamRegistryAddStreamDelegatesToSend(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    ch := make(chan sessionStreamUpdate, 1)
+    r.Register("sess-1", ch)
+
+    err := r.AddStream(context.Background(), "sess-1", "channel:abc")
+    require.NoError(t, err)
+    update := <-ch
+    assert.Equal(t, "channel:abc", update.stream)
+    assert.True(t, update.add)
+}
+
+func TestSessionStreamRegistryRemoveStreamDelegatesToSend(t *testing.T) {
+    r := NewSessionStreamRegistry()
+    ch := make(chan sessionStreamUpdate, 1)
+    r.Register("sess-1", ch)
+
+    err := r.RemoveStream(context.Background(), "sess-1", "channel:abc")
+    require.NoError(t, err)
+    update := <-ch
+    assert.Equal(t, "channel:abc", update.stream)
+    assert.False(t, update.add)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run TestSessionStreamRegistry ./internal/grpc/
+```
+
+Expected: compile error (types not defined yet).
+
+- [ ] **Step 3: Implement `SessionStreamRegistry`**
+
+Create `internal/grpc/stream_registry.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+    "context"
+    "sync"
+
+    "github.com/samber/oops"
+)
+
+// sessionStreamUpdate is sent on a session's control channel to add or remove a stream.
+type sessionStreamUpdate struct {
+    stream string
+    add    bool // true = subscribe, false = unsubscribe
+}
+
+// SessionStreamRegistry maps active session IDs to their Subscribe control channels.
+// It implements plugins.StreamRegistry for use by the hostfunc layer.
+type SessionStreamRegistry struct {
+    mu       sync.Mutex
+    channels map[string]chan<- sessionStreamUpdate
+}
+
+// NewSessionStreamRegistry creates an empty registry.
+func NewSessionStreamRegistry() *SessionStreamRegistry {
+    return &SessionStreamRegistry{
+        channels: make(map[string]chan<- sessionStreamUpdate),
+    }
+}
+
+// Register associates a session with its control channel.
+// Called by CoreServer.Subscribe at stream setup time.
+func (r *SessionStreamRegistry) Register(sessionID string, ch chan<- sessionStreamUpdate) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.channels[sessionID] = ch
+}
+
+// Deregister removes a session from the registry.
+// Called by CoreServer.Subscribe on exit (via defer).
+func (r *SessionStreamRegistry) Deregister(sessionID string) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    delete(r.channels, sessionID)
+}
+
+// Send writes an update to a session's control channel without blocking.
+// Returns SESSION_NOT_FOUND if no active Subscribe exists for the session.
+// Returns CONTROL_CHANNEL_FULL if the channel buffer is exhausted.
+func (r *SessionStreamRegistry) Send(sessionID string, update sessionStreamUpdate) error {
+    r.mu.Lock()
+    ch, ok := r.channels[sessionID]
+    r.mu.Unlock()
+    if !ok {
+        return oops.Code("SESSION_NOT_FOUND").Errorf("no active subscribe for session %s", sessionID)
+    }
+    select {
+    case ch <- update:
+        return nil
+    default:
+        return oops.Code("CONTROL_CHANNEL_FULL").Errorf("control channel full for session %s", sessionID)
+    }
+}
+
+// AddStream implements plugins.StreamRegistry. Subscribes a session to a stream.
+func (r *SessionStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
+    return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true})
+}
+
+// RemoveStream implements plugins.StreamRegistry. Unsubscribes a session from a stream.
+func (r *SessionStreamRegistry) RemoveStream(_ context.Context, sessionID, stream string) error {
+    return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: false})
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+task test -- -run TestSessionStreamRegistry ./internal/grpc/
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(grpc): SessionStreamRegistry for plugin-driven session stream control"
+```
+
+---
+
+### Task 6: Lua Host `QuerySessionStreams`
+
+**Files:**
+
+- Modify: `internal/plugin/lua/host.go` (replace stub from Task 3)
+- Modify: `internal/plugin/lua/host_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `internal/plugin/lua/host_test.go`, add:
+
+```go
+func TestLuaHostQuerySessionStreamsCallsOnSessionSubscribeWhenDefined(t *testing.T) {
+    h := NewHost()
+    ctx := context.Background()
+
+    // Plugin that returns two streams
+    luaCode := `
+function on_session_subscribe(character_id, player_id, session_id)
+    return {"channel:" .. character_id, "channel:general"}
+end
+`
+    err := h.Load(ctx, &plugins.Manifest{
+        Name:          "test-plugin",
+        Version:       "1.0.0",
+        Type:          plugins.TypeLua,
+        SessionStreams: true,
+        LuaPlugin:     &plugins.LuaConfig{Entry: "main.lua"},
+    }, t.TempDir())
+    // Load via code injection — use the test helper pattern from existing host_test.go
+    // (check how existing tests inject Lua code without a real file — likely LoadFromCode or similar)
+    _ = err // handled below
+
+    // Use the existing test code injection mechanism:
+    h.testInjectCode("test-plugin", luaCode)
+
+    req := plugins.SessionStreamsRequest{
+        CharacterID: "char-abc",
+        PlayerID:    "player-xyz",
+        SessionID:   "sess-123",
+    }
+    streams, err := h.QuerySessionStreams(ctx, "test-plugin", req)
+    require.NoError(t, err)
+    assert.ElementsMatch(t, []string{"channel:char-abc", "channel:general"}, streams)
+}
+
+func TestLuaHostQuerySessionStreamsReturnsNilWhenHandlerNotDefined(t *testing.T) {
+    h := NewHost()
+    ctx := context.Background()
+    h.testInjectCode("test-plugin", `-- no on_session_subscribe defined`)
+
+    streams, err := h.QuerySessionStreams(ctx, "test-plugin", plugins.SessionStreamsRequest{
+        CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+    })
+    require.NoError(t, err)
+    assert.Nil(t, streams)
+}
+
+func TestLuaHostQuerySessionStreamsReturnsErrorWhenHandlerFails(t *testing.T) {
+    h := NewHost()
+    ctx := context.Background()
+    h.testInjectCode("test-plugin", `
+function on_session_subscribe(character_id, player_id, session_id)
+    error("db connection failed")
+end
+`)
+    _, err := h.QuerySessionStreams(ctx, "test-plugin", plugins.SessionStreamsRequest{
+        CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+    })
+    require.Error(t, err)
+}
+```
+
+Check existing `host_test.go` for the pattern used to inject Lua code without a real file. Look for `testInjectCode` or a similar mechanism. If it doesn't exist, look for how `DeliverEvent` tests work and replicate the pattern. The typical approach in this codebase is to directly assign to `h.plugins[name]` in a test helper.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run TestLuaHostQuerySessionStreams ./internal/plugin/lua/
+```
+
+Expected: test failures (stub returns nil).
+
+- [ ] **Step 3: Implement `QuerySessionStreams` in Lua host**
+
+Replace the stub in `internal/plugin/lua/host.go`:
+
+```go
+// QuerySessionStreams calls the plugin's on_session_subscribe(character_id, player_id, session_id)
+// function if defined. Returns the list of stream names the plugin wants added.
+// Returns nil without error if the function is not defined.
+func (h *Host) QuerySessionStreams(ctx context.Context, name string, req plugins.SessionStreamsRequest) ([]string, error) {
+    h.mu.RLock()
+    p, ok := h.plugins[name]
+    if !ok {
+        h.mu.RUnlock()
+        return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").New("plugin not loaded")
+    }
+    code := p.code
+    h.mu.RUnlock()
+
+    L, err := h.factory.NewState(ctx)
+    if err != nil {
+        return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").Wrap(err)
+    }
+    defer L.Close()
+    L.SetContext(ctx)
+
+    if h.hostFuncs != nil {
+        h.hostFuncs.Register(L, name)
+    }
+
+    if err := L.DoString(code); err != nil {
+        return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").Wrap(err)
+    }
+
+    fn := L.GetGlobal("on_session_subscribe")
+    if fn.Type() == lua.LTNil {
+        return nil, nil // handler not defined — not an error
+    }
+
+    if err := L.CallByParam(lua.P{
+        Fn:      fn,
+        NRet:    1,
+        Protect: true,
+    },
+        lua.LString(req.CharacterID),
+        lua.LString(req.PlayerID),
+        lua.LString(req.SessionID),
+    ); err != nil {
+        return nil, oops.In("lua").With("plugin", name).With("operation", "on_session_subscribe").Wrap(err)
+    }
+
+    ret := L.Get(-1)
+    L.Pop(1)
+
+    tbl, ok := ret.(*lua.LTable)
+    if !ok {
+        if ret.Type() == lua.LTNil {
+            return nil, nil
+        }
+        return nil, oops.In("lua").With("plugin", name).With("operation", "on_session_subscribe").
+            Errorf("expected table return, got %s", ret.Type())
+    }
+
+    var streams []string
+    tbl.ForEach(func(_ lua.LValue, v lua.LValue) {
+        if s, ok := v.(lua.LString); ok {
+            streams = append(streams, string(s))
+        }
+    })
+    return streams, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+task test -- -run TestLuaHostQuerySessionStreams ./internal/plugin/lua/
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(lua): implement QuerySessionStreams via on_session_subscribe callback"
+```
+
+---
+
+### Task 7: Hostfunc Stream Functions (`holo.add_session_stream` / `holo.remove_session_stream`)
+
+**Files:**
+
+- Modify: `internal/plugin/hostfunc/functions.go`
+- Create: `internal/plugin/hostfunc/stdlib_streams.go`
+- Create: `internal/plugin/hostfunc/stdlib_streams_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/plugin/hostfunc/stdlib_streams_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+    "context"
+    "testing"
+
+    lua "github.com/yuin/gopher-lua"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+
+    plugins "github.com/holomush/holomush/internal/plugin"
+    "github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+// mockStreamRegistry records calls for assertion.
+type mockStreamRegistry struct {
+    addCalls    []struct{ sessionID, stream string }
+    removeCalls []struct{ sessionID, stream string }
+    addErr      error
+    removeErr   error
+}
+
+func (m *mockStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
+    m.addCalls = append(m.addCalls, struct{ sessionID, stream string }{sessionID, stream})
+    return m.addErr
+}
+
+func (m *mockStreamRegistry) RemoveStream(_ context.Context, sessionID, stream string) error {
+    m.removeCalls = append(m.removeCalls, struct{ sessionID, stream string }{sessionID, stream})
+    return m.removeErr
+}
+
+// Ensure mockStreamRegistry implements plugins.StreamRegistry.
+var _ plugins.StreamRegistry = (*mockStreamRegistry)(nil)
+
+func newTestLuaState(t *testing.T, reg plugins.StreamRegistry) *lua.LState {
+    t.Helper()
+    L := lua.NewState()
+    t.Cleanup(L.Close)
+    hf := hostfunc.New(nil, hostfunc.WithStreamRegistry(reg))
+    hf.Register(L, "test-plugin")
+    return L
+}
+
+func TestAddSessionStreamCallsRegistryWithCorrectArgs(t *testing.T) {
+    reg := &mockStreamRegistry{}
+    L := newTestLuaState(t, reg)
+
+    err := L.DoString(`holomush.add_session_stream("sess-1", "channel:abc")`)
+    require.NoError(t, err)
+
+    require.Len(t, reg.addCalls, 1)
+    assert.Equal(t, "sess-1", reg.addCalls[0].sessionID)
+    assert.Equal(t, "channel:abc", reg.addCalls[0].stream)
+}
+
+func TestRemoveSessionStreamCallsRegistryWithCorrectArgs(t *testing.T) {
+    reg := &mockStreamRegistry{}
+    L := newTestLuaState(t, reg)
+
+    err := L.DoString(`holomush.remove_session_stream("sess-1", "channel:abc")`)
+    require.NoError(t, err)
+
+    require.Len(t, reg.removeCalls, 1)
+    assert.Equal(t, "sess-1", reg.removeCalls[0].sessionID)
+    assert.Equal(t, "channel:abc", reg.removeCalls[0].stream)
+}
+
+func TestAddSessionStreamWithNilRegistryIsNoOp(t *testing.T) {
+    L := lua.NewState()
+    defer L.Close()
+    // Register without stream registry
+    hf := hostfunc.New(nil)
+    hf.Register(L, "test-plugin")
+
+    // Should not panic — just be a no-op or return an error message
+    err := L.DoString(`holomush.add_session_stream("sess-1", "channel:abc")`)
+    require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run "TestAddSessionStream|TestRemoveSessionStream" ./internal/plugin/hostfunc/
+```
+
+Expected: compile errors (WithStreamRegistry and add/remove_session_stream not defined).
+
+- [ ] **Step 3: Add `WithStreamRegistry` to `functions.go`**
+
+In `internal/plugin/hostfunc/functions.go`:
+
+Add field to `Functions` struct:
+
+```go
+streamRegistry plugins.StreamRegistry
+```
+
+Add import: `plugins "github.com/holomush/holomush/internal/plugin"`
+
+Add option function:
+
+```go
+// WithStreamRegistry sets the stream registry for add/remove session stream host functions.
+// When set, plugins can call holomush.add_session_stream and holomush.remove_session_stream.
+func WithStreamRegistry(r plugins.StreamRegistry) Option {
+    return func(f *Functions) {
+        f.streamRegistry = r
+    }
+}
+```
+
+In `Functions.Register`, add after the session functions block:
+
+```go
+// Register stream management functions if registry is configured.
+if f.streamRegistry != nil {
+    RegisterStreamFuncs(ls, mod, f.streamRegistry)
+}
+```
+
+- [ ] **Step 4: Create `stdlib_streams.go`**
+
+Create `internal/plugin/hostfunc/stdlib_streams.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+    "context"
+    "log/slog"
+
+    lua "github.com/yuin/gopher-lua"
+
+    plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+const streamRegistryKey = "__holo_stream_registry"
+
+// RegisterStreamFuncs adds holomush.add_session_stream and holomush.remove_session_stream
+// to an existing holomush module table.
+func RegisterStreamFuncs(ls *lua.LState, holoMushTable *lua.LTable, r plugins.StreamRegistry) {
+    ud := ls.NewUserData()
+    ud.Value = r
+    ls.SetGlobal(streamRegistryKey, ud)
+
+    ls.SetField(holoMushTable, "add_session_stream", ls.NewFunction(addSessionStreamFn))
+    ls.SetField(holoMushTable, "remove_session_stream", ls.NewFunction(removeSessionStreamFn))
+}
+
+func getStreamRegistry(ls *lua.LState) plugins.StreamRegistry {
+    ud := ls.GetGlobal(streamRegistryKey)
+    if ud.Type() == lua.LTUserData {
+        if userData, ok := ud.(*lua.LUserData); ok {
+            if r, ok := userData.Value.(plugins.StreamRegistry); ok {
+                return r
+            }
+        }
+    }
+    return nil
+}
+
+// addSessionStreamFn implements holomush.add_session_stream(session_id, stream).
+// Returns nothing on success; logs a warning on error.
+func addSessionStreamFn(ls *lua.LState) int {
+    sessionID := ls.CheckString(1)
+    stream := ls.CheckString(2)
+
+    r := getStreamRegistry(ls)
+    if r == nil {
+        slog.Warn("holomush.add_session_stream: stream registry not initialized")
+        return 0
+    }
+
+    ctx := ls.Context()
+    if ctx == nil {
+        ctx = context.Background()
+    }
+
+    if err := r.AddStream(ctx, sessionID, stream); err != nil {
+        slog.WarnContext(ctx, "holomush.add_session_stream failed",
+            "session_id", sessionID, "stream", stream, "error", err)
+    }
+    return 0
+}
+
+// removeSessionStreamFn implements holomush.remove_session_stream(session_id, stream).
+// Returns nothing on success; logs a warning on error.
+func removeSessionStreamFn(ls *lua.LState) int {
+    sessionID := ls.CheckString(1)
+    stream := ls.CheckString(2)
+
+    r := getStreamRegistry(ls)
+    if r == nil {
+        slog.Warn("holomush.remove_session_stream: stream registry not initialized")
+        return 0
+    }
+
+    ctx := ls.Context()
+    if ctx == nil {
+        ctx = context.Background()
+    }
+
+    if err := r.RemoveStream(ctx, sessionID, stream); err != nil {
+        slog.WarnContext(ctx, "holomush.remove_session_stream failed",
+            "session_id", sessionID, "stream", stream, "error", err)
+    }
+    return 0
+}
+```
+
+Note: `RegisterStreamFuncs` receives `holoMushTable` (the `holomush` module table, not the `holo` table). Check `functions.go`'s `Register` to confirm — the `mod` variable is set as `holomush` global. Pass `mod` (not a `holo` sub-table) to `RegisterStreamFuncs`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+task test -- -run "TestAddSessionStream|TestRemoveSessionStream" ./internal/plugin/hostfunc/
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(hostfunc): add holomush.add_session_stream / remove_session_stream Lua hostfuncs"
+```
+
+---
+
+### Task 8: Binary Plugin `QuerySessionStreams`
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go` (replace stub from Task 3)
+- Modify: `internal/plugin/goplugin/host_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `internal/plugin/goplugin/host_test.go`, following the existing `DeliverEvent` test pattern:
+
+```go
+func TestGopluginHostQuerySessionStreamsCallsPluginRPC(t *testing.T) {
+    // Arrange: create a host with a mock factory
+    factory := &mockClientFactory{}
+    h := NewHostWithFactory(factory)
+
+    // Load a fake plugin using the test helper pattern from existing tests
+    // (look for how existing tests set up a loaded plugin without a real binary)
+    // Typically: inject directly into h.plugins map
+    mockClient := &mockPluginServiceClient{}
+    mockClient.QuerySessionStreamsFunc = func(ctx context.Context, req *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error) {
+        return &pluginv1.QuerySessionStreamsResponse{
+            Streams: []string{"channel:abc", "channel:def"},
+        }, nil
+    }
+    h.testInjectPlugin("test-plugin", mockClient)
+
+    streams, err := h.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+        CharacterID: "char-1",
+        PlayerID:    "player-1",
+        SessionID:   "sess-1",
+    })
+    require.NoError(t, err)
+    assert.ElementsMatch(t, []string{"channel:abc", "channel:def"}, streams)
+}
+
+func TestGopluginHostQuerySessionStreamsReturnsErrorFromPlugin(t *testing.T) {
+    factory := &mockClientFactory{}
+    h := NewHostWithFactory(factory)
+
+    mockClient := &mockPluginServiceClient{}
+    mockClient.QuerySessionStreamsFunc = func(ctx context.Context, req *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error) {
+        return &pluginv1.QuerySessionStreamsResponse{Error: "db unavailable"}, nil
+    }
+    h.testInjectPlugin("test-plugin", mockClient)
+
+    _, err := h.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+        CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+    })
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "db unavailable")
+}
+```
+
+Check existing test patterns for `mockPluginServiceClient` — it likely already has fields for `HandleEventFunc`, `HandleCommandFunc`. Add `QuerySessionStreamsFunc` the same way.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run TestGopluginHostQuerySessionStreams ./internal/plugin/goplugin/
+```
+
+Expected: compile errors or failures.
+
+- [ ] **Step 3: Implement `QuerySessionStreams` in goplugin host**
+
+Replace the stub in `internal/plugin/goplugin/host.go`:
+
+```go
+// QuerySessionStreams calls the plugin's QuerySessionStreams RPC.
+// Returns nil if the plugin has no streams to contribute.
+func (h *Host) QuerySessionStreams(ctx context.Context, name string, req plugins.SessionStreamsRequest) ([]string, error) {
+    h.mu.RLock()
+    if h.closed {
+        h.mu.RUnlock()
+        return nil, ErrHostClosed
+    }
+    p, ok := h.plugins[name]
+    h.mu.RUnlock()
+
+    if !ok {
+        return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").Wrap(ErrPluginNotLoaded)
+    }
+
+    resp, err := p.plugin.QuerySessionStreams(ctx, &pluginv1.QuerySessionStreamsRequest{
+        CharacterId: req.CharacterID,
+        PlayerId:    req.PlayerID,
+        SessionId:   req.SessionID,
+    })
+    if err != nil {
+        return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").Wrap(err)
+    }
+    if resp.Error != "" {
+        return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").New(resp.Error)
+    }
+    return resp.Streams, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+task test -- -run TestGopluginHostQuerySessionStreams ./internal/plugin/goplugin/
+```
+
+Expected: all 2 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(goplugin): implement QuerySessionStreams via PluginService RPC"
+```
+
+---
+
+### Task 9: Binary Plugin `HostService` Stream Methods
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host_service.go`
+- Modify: `internal/plugin/goplugin/host_service_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `internal/plugin/goplugin/host_service_test.go`, following the existing pattern:
+
+```go
+func TestPluginHostServiceAddSessionStreamSucceeds(t *testing.T) {
+    registry := &mockStreamRegistry{}
+    proxy := newMockServiceProxy()
+    svc := NewPluginHostService(proxy, slog.Default())
+    svc.streamRegistry = registry // inject directly for test; or use constructor option
+
+    resp, err := svc.AddSessionStream(context.Background(), &pluginv1.AddSessionStreamRequest{
+        SessionId: "sess-1",
+        Stream:    "channel:abc",
+    })
+    require.NoError(t, err)
+    assert.True(t, resp.Success)
+    require.Len(t, registry.addCalls, 1)
+    assert.Equal(t, "sess-1", registry.addCalls[0].sessionID)
+    assert.Equal(t, "channel:abc", registry.addCalls[0].stream)
+}
+
+func TestPluginHostServiceAddSessionStreamReturnsNotFoundWhenSessionGone(t *testing.T) {
+    registry := &mockStreamRegistry{addErr: oops.Code("SESSION_NOT_FOUND").Errorf("not found")}
+    svc := NewPluginHostServiceWithRegistry(newMockServiceProxy(), slog.Default(), registry)
+
+    _, err := svc.AddSessionStream(context.Background(), &pluginv1.AddSessionStreamRequest{
+        SessionId: "sess-gone",
+        Stream:    "channel:abc",
+    })
+    require.Error(t, err)
+    // Should be gRPC status NotFound
+    st, ok := status.FromError(err)
+    require.True(t, ok)
+    assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestPluginHostServiceRemoveSessionStreamSucceeds(t *testing.T) {
+    registry := &mockStreamRegistry{}
+    svc := NewPluginHostServiceWithRegistry(newMockServiceProxy(), slog.Default(), registry)
+
+    resp, err := svc.RemoveSessionStream(context.Background(), &pluginv1.RemoveSessionStreamRequest{
+        SessionId: "sess-1",
+        Stream:    "channel:abc",
+    })
+    require.NoError(t, err)
+    assert.True(t, resp.Success)
+    require.Len(t, registry.removeCalls, 1)
+}
+```
+
+Add a `mockStreamRegistry` in this test file (same shape as in Task 7, or share via a test helper).
+
+Adjust the constructor: `NewPluginHostService` needs to accept the registry. Use a functional option or a new constructor `NewPluginHostServiceWithRegistry`. Check how `PluginHostService` is currently constructed and follow the same pattern.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run "TestPluginHostServiceAddSessionStream|TestPluginHostServiceRemoveSessionStream" ./internal/plugin/goplugin/
+```
+
+Expected: compile errors.
+
+- [ ] **Step 3: Add `streamRegistry` to `PluginHostService` and new constructor**
+
+In `internal/plugin/goplugin/host_service.go`:
+
+Add field to `PluginHostService`:
+
+```go
+streamRegistry plugins.StreamRegistry
+```
+
+Add import: `plugins "github.com/holomush/holomush/internal/plugin"`
+
+Add constructor option:
+
+```go
+// NewPluginHostServiceWithRegistry creates a PluginHostService with a stream registry
+// for handling AddSessionStream/RemoveSessionStream calls.
+func NewPluginHostServiceWithRegistry(proxy plugins.ServiceProxy, logger *slog.Logger, registry plugins.StreamRegistry) *PluginHostService {
+    svc := NewPluginHostService(proxy, logger)
+    svc.streamRegistry = registry
+    return svc
+}
+```
+
+- [ ] **Step 4: Implement `AddSessionStream` and `RemoveSessionStream`**
+
+In `internal/plugin/goplugin/host_service.go`, add:
+
+```go
+// AddSessionStream subscribes an active session to an additional stream.
+func (s *PluginHostService) AddSessionStream(ctx context.Context, req *pluginv1.AddSessionStreamRequest) (*pluginv1.AddSessionStreamResponse, error) {
+    if s.streamRegistry == nil {
+        return nil, status.Error(codes.Unimplemented, "stream registry not configured")
+    }
+    if err := s.streamRegistry.AddStream(ctx, req.GetSessionId(), req.GetStream()); err != nil {
+        e := oops.AsOops(err)
+        if e != nil && e.Code() == "SESSION_NOT_FOUND" {
+            return nil, status.Errorf(codes.NotFound, "session not found: %s", req.GetSessionId())
+        }
+        return nil, status.Errorf(codes.Internal, "add stream failed: %v", err)
+    }
+    return &pluginv1.AddSessionStreamResponse{Success: true}, nil
+}
+
+// RemoveSessionStream unsubscribes an active session from a stream. Idempotent.
+func (s *PluginHostService) RemoveSessionStream(ctx context.Context, req *pluginv1.RemoveSessionStreamRequest) (*pluginv1.RemoveSessionStreamResponse, error) {
+    if s.streamRegistry == nil {
+        return nil, status.Error(codes.Unimplemented, "stream registry not configured")
+    }
+    if err := s.streamRegistry.RemoveStream(ctx, req.GetSessionId(), req.GetStream()); err != nil {
+        e := oops.AsOops(err)
+        if e != nil && e.Code() == "SESSION_NOT_FOUND" {
+            // Session gone — idempotent success (character already disconnected)
+            return &pluginv1.RemoveSessionStreamResponse{Success: true}, nil
+        }
+        return nil, status.Errorf(codes.Internal, "remove stream failed: %v", err)
+    }
+    return &pluginv1.RemoveSessionStreamResponse{Success: true}, nil
+}
+```
+
+Check `oops.AsOops` — if it doesn't exist, use `oops.GetCode(err)` or check the oops package for how to extract a code from a wrapped error. The pattern in the codebase is `oops.AsOops(err).Code()` or checking `errors.Is` with a sentinel.
+
+Look at how `errutil.AssertErrorCode` works in `pkg/errutil/` for the right pattern to extract oops codes.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+task test -- -run "TestPluginHostServiceAddSessionStream|TestPluginHostServiceRemoveSessionStream" ./internal/plugin/goplugin/
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(goplugin): implement AddSessionStream/RemoveSessionStream on PluginHostService"
+```
+
+---
+
+### Task 10: `CoreServer.Subscribe` Extension
+
+**Files:**
+
+- Modify: `internal/grpc/server.go`
+- Modify: `internal/grpc/server_test.go`
+
+- [ ] **Step 1: Write failing unit tests**
+
+In `internal/grpc/server_test.go`, add a mock for `SessionStreamContributor` (define the interface first):
+
+```go
+// mockStreamContributor returns a fixed list of plugin streams.
+type mockStreamContributor struct {
+    streams []string
+}
+
+func (m *mockStreamContributor) QuerySessionStreams(_ context.Context, _ plugins.SessionStreamsRequest) []string {
+    return m.streams
+}
+```
+
+Add tests:
+
+```go
+func TestSubscribeIncludesPluginContributedStreams(t *testing.T) {
+    // Arrange: CoreServer with a contributor that returns one channel stream
+    contrib := &mockStreamContributor{streams: []string{"channel:abc"}}
+    s := newTestCoreServer(t, withStreamContributor(contrib))
+
+    session := createTestSession(t, s) // uses existing test helpers
+
+    // Act: subscribe
+    msgs := collectSubscribeMessages(t, s, session.ID, 0 /* timeout ms */)
+
+    // Assert: LISTEN was set up for channel:abc (verify via replay or mock event store)
+    // The simplest assertion: subscribe doesn't error and the mock event store
+    // received a Subscribe call for "channel:abc"
+    mockStore := s.eventStore.(*mockEventStore)
+    assert.Contains(t, mockStore.subscribedStreams, "channel:abc")
+}
+
+func TestSubscribeCtrlChAddStreamSetupLISTENAndReplays(t *testing.T) {
+    s := newTestCoreServer(t)
+    sess := createTestSession(t, s)
+
+    // Append an event to channel:new before the subscribe
+    appendTestEvent(t, s, "channel:new", "test.event", `{}`)
+
+    // Start subscribe in background
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    msgs := startSubscribeAsync(t, ctx, s, sess.ID)
+
+    // Wait for replay complete
+    waitForReplayComplete(t, msgs, time.Second)
+
+    // Now send ctrlCh add via registry
+    err := s.streamRegistry.AddStream(ctx, sess.ID, "channel:new")
+    require.NoError(t, err)
+
+    // Should receive the previously-appended event via tail replay
+    msg := waitForMessage(t, msgs, time.Second)
+    require.NotNil(t, msg.GetEvent())
+    assert.Equal(t, "channel:new", msg.GetEvent().Stream)
+}
+
+func TestSubscribeCtrlChRemoveStreamStopsForwarding(t *testing.T) {
+    s := newTestCoreServer(t, withStreamContributor(&mockStreamContributor{
+        streams: []string{"channel:abc"},
+    }))
+    sess := createTestSession(t, s)
+
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    msgs := startSubscribeAsync(t, ctx, s, sess.ID)
+    waitForReplayComplete(t, msgs, time.Second)
+
+    // Remove the stream
+    err := s.streamRegistry.RemoveStream(ctx, sess.ID, "channel:abc")
+    require.NoError(t, err)
+
+    // Append event to channel:abc — should NOT be forwarded
+    appendTestEvent(t, s, "channel:abc", "test.event", `{}`)
+
+    // Short wait to confirm no message arrives
+    select {
+    case msg := <-msgs:
+        if msg.GetEvent() != nil && msg.GetEvent().Stream == "channel:abc" {
+            t.Fatal("received event on removed stream")
+        }
+    case <-time.After(200 * time.Millisecond):
+        // Expected: no message forwarded
+    }
+}
+
+func TestSubscribeDeregistersRegistryOnExit(t *testing.T) {
+    registry := NewSessionStreamRegistry()
+    s := newTestCoreServer(t, withStreamRegistry(registry))
+    sess := createTestSession(t, s)
+
+    ctx, cancel := context.WithCancel(context.Background())
+    startSubscribeAsync(t, ctx, s, sess.ID)
+    time.Sleep(50 * time.Millisecond) // brief settle
+
+    // Verify registered
+    err := registry.Send(sess.ID, sessionStreamUpdate{stream: "channel:x", add: true})
+    require.NoError(t, err)
+
+    // Cancel to end subscribe
+    cancel()
+    time.Sleep(50 * time.Millisecond) // let goroutine exit
+
+    // Verify deregistered
+    err = registry.Send(sess.ID, sessionStreamUpdate{stream: "channel:x", add: true})
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "SESSION_NOT_FOUND")
+}
+```
+
+These tests use `newTestCoreServer` and supporting helpers — look at how existing `server_test.go` constructs test servers and replicate the pattern. Add `withStreamContributor` and `withStreamRegistry` as `CoreServerOption` helpers for tests.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+task test -- -run "TestSubscribeIncludesPlugin|TestSubscribeCtrlCh|TestSubscribeDeregisters" ./internal/grpc/
+```
+
+Expected: compile errors (new fields/interface not defined).
+
+- [ ] **Step 3: Add `SessionStreamContributor` interface and new fields to `CoreServer`**
+
+In `internal/grpc/server.go`, add after the existing interface definitions:
+
+```go
+// SessionStreamContributor collects plugin-contributed stream names for a session.
+type SessionStreamContributor interface {
+    QuerySessionStreams(ctx context.Context, req plugins.SessionStreamsRequest) []string
+}
+```
+
+Add import: `plugins "github.com/holomush/holomush/internal/plugin"`
+
+Add to `CoreServer` struct:
+
+```go
+streamContributor SessionStreamContributor
+streamRegistry    *SessionStreamRegistry
+
+// afterLISTENHook is called between LISTEN setup and replay in Subscribe.
+// Used in tests to inject events into the race window.
+afterLISTENHook func()
+```
+
+Add option functions:
+
+```go
+// WithStreamContributor sets the plugin stream contributor for session subscriptions.
+func WithStreamContributor(c SessionStreamContributor) CoreServerOption {
+    return func(s *CoreServer) {
+        s.streamContributor = c
+    }
+}
+
+// WithStreamRegistry sets the session stream registry for mid-session stream control.
+func WithStreamRegistry(r *SessionStreamRegistry) CoreServerOption {
+    return func(s *CoreServer) {
+        s.streamRegistry = r
+    }
+}
+```
+
+- [ ] **Step 4: Modify `CoreServer.Subscribe`**
+
+In `server.go`'s `Subscribe` method, make these changes in order:
+
+**After** `info, err := s.sessionStore.Get(...)` and before the `streams := req.Streams` block, add:
+
+```go
+// Collect plugin-contributed streams before LISTEN setup.
+if s.streamContributor != nil {
+    contribCtx, contribCancel := context.WithTimeout(ctx, 2*time.Second)
+    pluginStreams := s.streamContributor.QuerySessionStreams(contribCtx, plugins.SessionStreamsRequest{
+        CharacterID: info.CharacterID.String(),
+        PlayerID:    info.PlayerID.String(),
+        SessionID:   info.ID,
+    })
+    contribCancel()
+    if len(req.Streams) == 0 {
+        // Will be defaulted below; append after default assignment
+    }
+    _ = pluginStreams // used after defaults are applied
+}
+```
+
+Actually restructure the plugin stream collection to happen after the `streams` / `staticStreams` / `locStreamName` computation:
+
+After the existing block that builds `staticStreams` and `locStreamName`, add:
+
+```go
+// Merge plugin-contributed streams into staticStreams.
+if s.streamContributor != nil {
+    contribCtx, contribCancel := context.WithTimeout(ctx, 2*time.Second)
+    pluginStreams := s.streamContributor.QuerySessionStreams(contribCtx, plugins.SessionStreamsRequest{
+        CharacterID: info.CharacterID.String(),
+        PlayerID:    info.PlayerID.String(),
+        SessionID:   info.ID,
+    })
+    contribCancel()
+    for _, ps := range pluginStreams {
+        // Exclude location streams (managed by locationFollower)
+        if !strings.HasPrefix(ps, world.StreamPrefixLocation) {
+            // Check for duplicate
+            duplicate := false
+            for _, existing := range staticStreams {
+                if existing == ps {
+                    duplicate = true
+                    break
+                }
+            }
+            if !duplicate {
+                staticStreams = append(staticStreams, ps)
+            }
+        }
+    }
+}
+```
+
+**Replace** the existing `subscribeStream` calls with a per-stream cancel version. Add a `streamCancels` map before the LISTEN loop:
+
+```go
+streamCancels := make(map[string]context.CancelFunc)
+subscribeWithCancel := func(sn string) error {
+    sctx, cancel := context.WithCancel(ctx)
+    streamCancels[sn] = cancel
+    return subscribeStream(sctx, s.eventStore, sn, notifyCh, errCh)
+}
+```
+
+Replace `subscribeStream(ctx, ...)` calls with `subscribeWithCancel(sn)`.
+
+**After** the LISTEN loop and before the synthetic location_state block, add:
+
+```go
+// Register this session's control channel for mid-session stream updates.
+ctrlCh := make(chan sessionStreamUpdate, 16)
+if s.streamRegistry != nil {
+    s.streamRegistry.Register(info.ID, ctrlCh)
+    defer s.streamRegistry.Deregister(info.ID)
+}
+
+// afterLISTENHook fires between LISTEN setup and replay for race-window testing.
+if s.afterLISTENHook != nil {
+    s.afterLISTENHook()
+}
+```
+
+**In the live-forward select loop**, add a `ctrlCh` case. Find the `select` statement in the post-replay loop and add:
+
+```go
+case ctrl, ok := <-ctrlCh:
+    if !ok {
+        return nil
+    }
+    if ctrl.add {
+        if _, exists := streamCancels[ctrl.stream]; !exists {
+            // Reject attempts to take over location stream management
+            if strings.HasPrefix(ctrl.stream, world.StreamPrefixLocation) {
+                slog.WarnContext(ctx, "plugin attempted to add location stream — rejected",
+                    "session_id", info.ID, "stream", ctrl.stream)
+                continue
+            }
+            if subErr := subscribeWithCancel(ctrl.stream); subErr != nil {
+                slog.WarnContext(ctx, "mid-session stream add failed",
+                    "session_id", info.ID, "stream", ctrl.stream, "error", subErr)
+            } else {
+                // Replay tail — use stored cursor if character was subscribed before
+                cursor := ulid.ULID{}
+                if info.EventCursors != nil {
+                    if c, ok := info.EventCursors[ctrl.stream]; ok {
+                        cursor = c
+                    }
+                }
+                if _, sendErr := s.replayAndSend(ctx, info, ctrl.stream, cursor, stream, lf); sendErr != nil {
+                    return oops.Code("SEND_FAILED").With("session_id", info.ID).Wrap(sendErr)
+                }
+            }
+        }
+    } else {
+        if cancel, exists := streamCancels[ctrl.stream]; exists {
+            cancel()
+            delete(streamCancels, ctrl.stream)
+        }
+    }
+```
+
+Also ensure stream cancels are cleaned up on exit. After the defer for `lf.locCancel`, add:
+
+```go
+defer func() {
+    for _, cancel := range streamCancels {
+        cancel()
+    }
+}()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+task test -- -run "TestSubscribeIncludesPlugin|TestSubscribeCtrlCh|TestSubscribeDeregisters" ./internal/grpc/
+```
+
+Expected: all 4 tests PASS. Run full server tests too:
+
+```bash
+task test -- ./internal/grpc/
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(grpc): Subscribe collects plugin streams, handles mid-session add/remove via ctrlCh"
+```
+
+---
+
+### Task 11: Wiring
+
+**Files:**
+
+- Modify: The file in `cmd/holomush/` where `NewCoreServer` and `hostfunc.New` are called. Check `cmd/holomush/` — likely `app.go`, `server.go`, or `setup.go`.
+
+- [ ] **Step 1: Find the wiring file**
+
+```bash
+task build
+```
+
+Check compiler errors — they'll point to files that need updating. Also:
+
+```bash
+ls cmd/holomush/
+```
+
+- [ ] **Step 2: Create and wire `SessionStreamRegistry`**
+
+In the wiring file, add:
+
+```go
+// Create stream registry — shared by CoreServer (Subscribe) and hostfunc (plugin calls).
+streamRegistry := grpcpkg.NewSessionStreamRegistry()
+```
+
+- [ ] **Step 3: Pass `streamRegistry` to `hostfunc.New`**
+
+Find the `hostfunc.New(...)` call and add `hostfunc.WithStreamRegistry(streamRegistry)`:
+
+```go
+hf := hostfunc.New(kvStore,
+    hostfunc.WithWorldService(worldSvc),
+    hostfunc.WithSessionAccess(sessionAccess),
+    hostfunc.WithStreamRegistry(streamRegistry), // NEW
+    // ... other existing options
+)
+```
+
+- [ ] **Step 4: Pass `streamRegistry` to binary plugin host service**
+
+Find where `goplugin.NewPluginHostService` is called and update to `NewPluginHostServiceWithRegistry`:
+
+```go
+hostSvc := goplugin.NewPluginHostServiceWithRegistry(serviceProxy, logger, streamRegistry)
+```
+
+- [ ] **Step 5: Pass `manager` as `streamContributor` and `streamRegistry` to `CoreServer`**
+
+Find the `grpcpkg.NewCoreServer(...)` call and add:
+
+```go
+grpcpkg.NewCoreServer(engine, sessionStore, dispatcher, cmdServices,
+    // ... existing options ...
+    grpcpkg.WithStreamContributor(pluginManager), // pluginManager is *plugins.Manager
+    grpcpkg.WithStreamRegistry(streamRegistry),   // NEW
+)
+```
+
+- [ ] **Step 6: Verify build and tests**
+
+```bash
+task build && task test
+```
+
+Expected: successful build, all unit tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "feat(cmd): wire SessionStreamRegistry and StreamContributor into server and hostfunc"
+```
+
+---
+
+### Task 12: Integration Tests
+
+**Files:**
+
+- Create: `test/integration/plugin/session_streams_suite_test.go`
+- Create: `test/integration/plugin/session_streams_integration_test.go`
+
+- [ ] **Step 1: Create suite file**
+
+Create `test/integration/plugin/session_streams_suite_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+    "testing"
+
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+func TestPluginSessionStreams(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "Plugin Session Streams Suite")
+}
+```
+
+- [ ] **Step 2: Create integration test file**
+
+Create `test/integration/plugin/session_streams_integration_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+    "context"
+    "fmt"
+    "net"
+    "sync/atomic"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+    "github.com/testcontainers/testcontainers-go/modules/postgres"
+    "google.golang.org/grpc"
+
+    "github.com/holomush/holomush/internal/access/policy/policytest"
+    "github.com/holomush/holomush/internal/command"
+    "github.com/holomush/holomush/internal/core"
+    grpcpkg "github.com/holomush/holomush/internal/grpc"
+    plugins "github.com/holomush/holomush/internal/plugin"
+    "github.com/holomush/holomush/internal/session"
+    "github.com/holomush/holomush/internal/store"
+    corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// staticContributor is a test-only SessionStreamContributor that returns fixed streams.
+type staticContributor struct {
+    streams []string
+    called  atomic.Int32
+}
+
+func (c *staticContributor) QuerySessionStreams(_ context.Context, _ plugins.SessionStreamsRequest) []string {
+    c.called.Add(1)
+    return c.streams
+}
+
+var _ = Describe("Plugin Session Stream Contribution", func() {
+    var (
+        testCtx      context.Context
+        testCancel   context.CancelFunc
+        container    *postgres.PostgresContainer
+        grpcServer   *grpc.Server
+        grpcCli      *grpcpkg.Client
+        sessionStore *store.PostgresSessionStore
+        eventStore   *store.PostgresEventStore
+        contributor  *staticContributor
+        registry     *grpcpkg.SessionStreamRegistry
+    )
+
+    BeforeEach(func() {
+        testCtx, testCancel = context.WithTimeout(context.Background(), 60*time.Second)
+        // Start Postgres testcontainer — follow the pattern from session_persistence_integration_test.go
+        // (copy the container setup and server construction from there)
+        // Key difference: pass contributor and registry to CoreServer
+
+        contributor = &staticContributor{streams: []string{}}
+        registry = grpcpkg.NewSessionStreamRegistry()
+
+        // Wire contributor and registry into CoreServer via options:
+        //   grpcpkg.WithStreamContributor(contributor),
+        //   grpcpkg.WithStreamRegistry(registry),
+        // See session_persistence_integration_test.go for the full server construction pattern.
+    })
+
+    AfterEach(func() {
+        testCancel()
+        if grpcServer != nil {
+            grpcServer.GracefulStop()
+        }
+        if container != nil {
+            _ = container.Terminate(context.Background())
+        }
+    })
+
+    Describe("UC1: session-start auto-subscribe", func() {
+        It("receives messages posted before login via replay", func() {
+            // Arrange: configure contributor to return "channel:general"
+            contributor.streams = []string{"channel:general"}
+
+            // Append a message to channel:general before the session starts
+            msgID := ulid.Make()
+            Expect(eventStore.Append(testCtx, core.Event{
+                ID:      msgID,
+                Stream:  "channel:general",
+                Type:    "channel.message",
+                Actor:   core.Actor{Kind: core.ActorCharacter, ID: "char-other"},
+                Payload: []byte(`{"message":"hello from before"}`),
+            })).To(Succeed())
+
+            // Authenticate and subscribe
+            resp, err := grpcCli.Authenticate(testCtx, &corev1.AuthenticateRequest{
+                Username: "guest", Password: "",
+            })
+            Expect(err).NotTo(HaveOccurred())
+            Expect(resp.Success).To(BeTrue())
+
+            subCtx, subCancel := context.WithTimeout(testCtx, 5*time.Second)
+            defer subCancel()
+            subStream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+                SessionId: resp.SessionId,
+            })
+            Expect(err).NotTo(HaveOccurred())
+
+            // Collect messages until REPLAY_COMPLETE
+            var received []string
+            for {
+                msg, err := subStream.Recv()
+                Expect(err).NotTo(HaveOccurred())
+                if msg.GetControl() != nil &&
+                    msg.GetControl().Signal == corev1.ControlSignal_CONTROL_SIGNAL_REPLAY_COMPLETE {
+                    break
+                }
+                if msg.GetEvent() != nil {
+                    received = append(received, msg.GetEvent().Stream)
+                }
+            }
+
+            Expect(received).To(ContainElement("channel:general"))
+        })
+
+        It("proceeds normally when contributor returns error", func() {
+            // Arrange: contributor that panics / returns nothing (simulate failure)
+            // by setting contributor.streams to nil and testing session still establishes
+            contributor.streams = nil
+
+            resp, err := grpcCli.Authenticate(testCtx, &corev1.AuthenticateRequest{
+                Username: "guest", Password: "",
+            })
+            Expect(err).NotTo(HaveOccurred())
+            Expect(resp.Success).To(BeTrue())
+
+            // Subscribe should succeed with core-only streams
+            subCtx, subCancel := context.WithTimeout(testCtx, 3*time.Second)
+            defer subCancel()
+            _, err = grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{SessionId: resp.SessionId})
+            Expect(err).NotTo(HaveOccurred())
+        })
+    })
+
+    Describe("UC2: mid-session subscription changes", func() {
+        It("receives messages on a stream added mid-session without reconnecting", func() {
+            contributor.streams = nil // no streams at login
+
+            resp, err := grpcCli.Authenticate(testCtx, &corev1.AuthenticateRequest{
+                Username: "guest", Password: "",
+            })
+            Expect(err).NotTo(HaveOccurred())
+            Expect(resp.Success).To(BeTrue())
+            sessionID := resp.SessionId
+
+            subCtx, subCancel := context.WithTimeout(testCtx, 10*time.Second)
+            defer subCancel()
+            subStream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{SessionId: sessionID})
+            Expect(err).NotTo(HaveOccurred())
+
+            // Wait for REPLAY_COMPLETE
+            Eventually(func() bool {
+                msg, err := subStream.Recv()
+                if err != nil {
+                    return false
+                }
+                return msg.GetControl() != nil &&
+                    msg.GetControl().Signal == corev1.ControlSignal_CONTROL_SIGNAL_REPLAY_COMPLETE
+            }, 3*time.Second, 50*time.Millisecond).Should(BeTrue())
+
+            // Add stream mid-session
+            Expect(registry.AddStream(testCtx, sessionID, "channel:new")).To(Succeed())
+
+            // Append event to channel:new
+            Expect(eventStore.Append(testCtx, core.Event{
+                ID:      ulid.Make(),
+                Stream:  "channel:new",
+                Type:    "channel.message",
+                Actor:   core.Actor{Kind: core.ActorCharacter, ID: "char-other"},
+                Payload: []byte(`{"message":"mid-session msg"}`),
+            })).To(Succeed())
+
+            // Should receive the event without reconnecting
+            Eventually(func() string {
+                msg, err := subStream.Recv()
+                if err != nil || msg.GetEvent() == nil {
+                    return ""
+                }
+                return msg.GetEvent().Stream
+            }, 3*time.Second, 50*time.Millisecond).Should(Equal("channel:new"))
+        })
+
+        It("stops forwarding messages after stream removed mid-session", func() {
+            contributor.streams = []string{"channel:active"}
+
+            resp, err := grpcCli.Authenticate(testCtx, &corev1.AuthenticateRequest{
+                Username: "guest", Password: "",
+            })
+            Expect(err).NotTo(HaveOccurred())
+            sessionID := resp.SessionId
+
+            subCtx, subCancel := context.WithTimeout(testCtx, 10*time.Second)
+            defer subCancel()
+            subStream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{SessionId: sessionID})
+            Expect(err).NotTo(HaveOccurred())
+
+            // Wait for replay complete
+            Eventually(func() bool {
+                msg, err := subStream.Recv()
+                if err != nil {
+                    return false
+                }
+                return msg.GetControl() != nil &&
+                    msg.GetControl().Signal == corev1.ControlSignal_CONTROL_SIGNAL_REPLAY_COMPLETE
+            }, 3*time.Second, 50*time.Millisecond).Should(BeTrue())
+
+            // Remove stream
+            Expect(registry.RemoveStream(testCtx, sessionID, "channel:active")).To(Succeed())
+            time.Sleep(50 * time.Millisecond) // let ctrlCh be processed
+
+            // Append event — should NOT be forwarded
+            Expect(eventStore.Append(testCtx, core.Event{
+                ID:      ulid.Make(),
+                Stream:  "channel:active",
+                Type:    "channel.message",
+                Actor:   core.Actor{Kind: core.ActorCharacter, ID: "char-other"},
+                Payload: []byte(`{"message":"should not arrive"}`),
+            })).To(Succeed())
+
+            // Confirm no message on removed stream
+            Consistently(func() bool {
+                // Try to receive with a short deadline
+                msg, err := subStream.Recv()
+                if err != nil {
+                    return true // stream ended — acceptable
+                }
+                return !(msg.GetEvent() != nil && msg.GetEvent().Stream == "channel:active")
+            }, 300*time.Millisecond, 50*time.Millisecond).Should(BeTrue())
+        })
+    })
+
+    Describe("LISTEN-before-replay invariant", func() {
+        It("does not lose a message posted in the race window between LISTEN setup and replay", func() {
+            contributor.streams = []string{"channel:race"}
+
+            // Install afterLISTENHook to inject event during the race window
+            var hookFired atomic.Bool
+            // The test CoreServer needs afterLISTENHook — in integration tests this requires
+            // the server to be constructed with an afterLISTENHook test option.
+            // Add a CoreServerOption for testing:
+            //   grpcpkg.WithAfterLISTENHook(func() { ... })
+            // This hook fires after LISTEN but before replay.
+            raceEventID := ulid.Make()
+            // Set up the hook to fire once and append a race-window event
+            // (actual hook injection requires the server be constructed in BeforeEach;
+            // restructure the test to configure the hook before server construction)
+
+            _ = hookFired
+            _ = raceEventID
+            // Implementation note: set the hook in BeforeEach, then reconstruct
+            // the server with WithAfterLISTENHook. The hook appends to "channel:race"
+            // then signals. After subscribe replay, assert the event was received.
+            // This test verifies the LISTEN was set up BEFORE the event was appended.
+            Pending()
+        })
+    })
+})
+```
+
+Note: The Pending() on the race-window test is intentional — it documents the invariant test intent. Implement it fully by adding `WithAfterLISTENHook` to CoreServerOption (a `func()` field on CoreServer, already added in Task 10 as `afterLISTENHook`). Add the exported option:
+
+```go
+// WithAfterLISTENHook sets a callback fired between LISTEN setup and replay.
+// For testing only.
+func WithAfterLISTENHook(hook func()) CoreServerOption {
+    return func(s *CoreServer) {
+        s.afterLISTENHook = hook
+    }
+}
+```
+
+Then implement the Pending test with a server that uses `WithAfterLISTENHook`.
+
+- [ ] **Step 3: Run integration tests**
+
+```bash
+task test:int -- ./test/integration/plugin/
+```
+
+Expected: UC1 and UC2 tests pass. The race-window test is Pending (skipped).
+
+- [ ] **Step 4: Implement the race-window invariant test**
+
+In `session_streams_integration_test.go`, replace the `Pending()` body:
+
+```go
+It("does not lose a message posted in the race window between LISTEN setup and replay", func() {
+    raceEventID := ulid.Make()
+    var raceAppended atomic.Bool
+
+    // Rebuild the server (in BeforeEach this would be cleaner;
+    // for this test reconstruct inline with the hook)
+    //
+    // AfterLISTENHook: append event to "channel:race" synchronously
+    hookFn := func() {
+        if !raceAppended.Swap(true) {
+            _ = eventStore.Append(testCtx, core.Event{
+                ID:      raceEventID,
+                Stream:  "channel:race",
+                Type:    "channel.message",
+                Actor:   core.Actor{Kind: core.ActorCharacter, ID: "char-other"},
+                Payload: []byte(`{"message":"race window event"}`),
+            })
+        }
+    }
+    // Reconfigure server with hook (requires server rebuild or in-place hook assignment)
+    // If grpcServer was constructed in BeforeEach, add a test-only setter:
+    //   grpcServer = rebuildServerWithHook(hookFn)
+    // For simplicity, expose a test setter:
+    //   coreServer.SetAfterLISTENHook(hookFn)
+    _ = hookFn
+
+    contributor.streams = []string{"channel:race"}
+
+    resp, err := grpcCli.Authenticate(testCtx, &corev1.AuthenticateRequest{Username: "guest"})
+    Expect(err).NotTo(HaveOccurred())
+
+    subCtx, subCancel := context.WithTimeout(testCtx, 5*time.Second)
+    defer subCancel()
+    subStream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{SessionId: resp.SessionId})
+    Expect(err).NotTo(HaveOccurred())
+
+    var foundRaceEvent bool
+    for {
+        msg, err := subStream.Recv()
+        Expect(err).NotTo(HaveOccurred())
+        if msg.GetControl() != nil &&
+            msg.GetControl().Signal == corev1.ControlSignal_CONTROL_SIGNAL_REPLAY_COMPLETE {
+            break
+        }
+        if msg.GetEvent() != nil && msg.GetEvent().Id == raceEventID.String() {
+            foundRaceEvent = true
+        }
+    }
+    Expect(foundRaceEvent).To(BeTrue(), "race window event must be received via replay")
+})
+```
+
+For the hook to work in integration tests, expose a test-only method on `CoreServer`:
+
+```go
+// SetAfterLISTENHook sets the after-LISTEN test hook. For testing only.
+func (s *CoreServer) SetAfterLISTENHook(hook func()) {
+    s.afterLISTENHook = hook
+}
+```
+
+- [ ] **Step 5: Run integration tests again**
+
+```bash
+task test:int -- ./test/integration/plugin/
+```
+
+Expected: all tests pass, including the race-window invariant test.
+
+- [ ] **Step 6: Run full pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: zero failures across lint, format, schema, license, unit, integration, and E2E.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "test(integration): plugin session stream contribution — UC1, UC2, LISTEN invariant"
+```
+
+---
+
+## Self-Review Notes
+
+- All requirements FR1–FR5, NFR1–NFR3 have corresponding tasks
+- Stream name validation is in Task 4 (Manager) and validated before merging
+- `afterLISTENHook` / `SetAfterLISTENHook` is needed by both Task 10 and Task 12 — add in Task 10, use in Task 12
+- `TestLoadPlugin` helper on Manager: check whether `DiscoveredPlugin.Manifest` is exported — if field is `manifest *Manifest` (unexported), use `Manifest *Manifest` (capitalize) or add a `TestLoadPlugin` method that injects directly. Check `bootstrap.go` to see the struct definition.
+- The `oops.AsOops(err).Code()` pattern in Task 9: verify against the oops package API. Alternative: use `strings.Contains(err.Error(), "SESSION_NOT_FOUND")` for the error code check if oops doesn't expose `AsOops`.
+- Binary plugin `mockPluginServiceClient` in Task 8: check if it already exists in `host_test.go`. If it wraps `pluginv1.PluginServiceClient`, add `QuerySessionStreams` to it.
+- Integration test server construction: closely follow `test/integration/session/session_persistence_integration_test.go` — copy its Postgres testcontainer setup and grpc server wiring, then add `WithStreamContributor(contributor)` and `WithStreamRegistry(registry)`.

--- a/docs/superpowers/specs/2026-04-08-plugin-session-stream-contribution-design.md
+++ b/docs/superpowers/specs/2026-04-08-plugin-session-stream-contribution-design.md
@@ -1,0 +1,424 @@
+# Plugin Session Stream Contribution Design
+
+**Issue:** holomush-oirq  
+**Date:** 2026-04-08  
+**Status:** Approved
+
+---
+
+## Problem
+
+Core's `Subscribe` RPC hardcodes subscriptions to only two streams: the character stream and the
+current location stream. Plugins that expose session-scoped streams (channels, guilds, friend feeds,
+faction broadcasts) have no mechanism to contribute additional streams at session establishment.
+
+Concrete impact: a channels plugin cannot auto-subscribe a character to their channel memberships on
+login. The character misses all channel messages until they explicitly re-subscribe or reconnect.
+
+---
+
+## Requirements
+
+### Functional
+
+- **FR1**: A plugin MUST be able to contribute additional stream names to a session's subscription
+  set when the session is established.
+- **FR2**: Core's Subscribe handler MUST set up LISTEN subscriptions for plugin-contributed streams
+  before the replay phase, preserving the existing LISTEN-before-replay ordering invariant.
+- **FR3**: Contribution MUST be scoped to the session's character and player so plugins can filter
+  their own membership relations.
+- **FR4**: Core MUST NOT hardcode knowledge of specific plugins. The mechanism is a general
+  extension point usable by any plugin.
+- **FR5**: Mid-session subscription changes (UC2) MUST take effect immediately — joining or leaving
+  a channel mid-session MUST start/stop message delivery without reconnecting.
+
+### Non-functional
+
+- **NFR1**: Plugin contribution failures MUST use degraded-subscribe semantics: log the error, skip
+  the plugin's contribution, proceed with what succeeded. Session establishment MUST NOT fail due to
+  a plugin error.
+- **NFR2**: The mechanism MUST be testable end-to-end: a test can assert that a character receives
+  messages from a plugin-contributed stream via both replay (UC1) and live-forward (UC2) paths.
+- **NFR3**: Per-Subscribe call cost MUST be bounded. Only plugins that explicitly opt in are called.
+
+---
+
+## Design
+
+### Approach
+
+**UC1 (session start):** Add `QuerySessionStreams` RPC to `PluginService` in `plugin.proto`. Core
+calls this on all opted-in plugins in parallel before LISTEN setup. Results are merged (deduplicated)
+into the stream list before the existing LISTEN loop runs — preserving the ordering invariant.
+
+**UC2 (mid-session changes):** Add `AddSessionStream` / `RemoveSessionStream` to
+`HostFunctionsService` in `hostfunc.proto`. The Subscribe goroutine gains a `ctrlCh` that it selects
+on alongside `notifyCh`. A `SessionStreamRegistry` maps active session IDs to their control
+channels. Plugin calls write to the registry; the goroutine handles them inline.
+
+This approach is uniform across plugin types (Lua and binary both use the same RPC contract), fits
+the existing `HandleEvent`/`HandleCommand` pattern, and mirrors how `locationFollower` already
+manages live stream switching inside the Subscribe goroutine.
+
+---
+
+## Proto Changes
+
+### `api/proto/holomush/plugin/v1/plugin.proto`
+
+Add to `PluginService`:
+
+```protobuf
+// QuerySessionStreams returns stream names to subscribe for a session.
+// Called once at session establishment, before LISTEN setup.
+// Only called for plugins that declare session_streams: true in their manifest.
+rpc QuerySessionStreams(QuerySessionStreamsRequest) returns (QuerySessionStreamsResponse);
+
+message QuerySessionStreamsRequest {
+  string character_id = 1;
+  string player_id    = 2;
+  string session_id   = 3;
+}
+
+message QuerySessionStreamsResponse {
+  repeated string streams = 1;
+  // non-empty = plugin-reported error; host degrades (logs + skips this plugin's contribution)
+  string error = 2;
+}
+```
+
+### `api/proto/holomush/plugin/v1/hostfunc.proto`
+
+Add to `HostFunctionsService`:
+
+```protobuf
+// AddSessionStream subscribes an active session to an additional stream mid-session.
+// Returns SESSION_NOT_FOUND if session_id is not active (character disconnected).
+rpc AddSessionStream(AddSessionStreamRequest) returns (AddSessionStreamResponse);
+
+// RemoveSessionStream unsubscribes an active session from a stream.
+// Idempotent: succeeds silently if stream is not subscribed.
+rpc RemoveSessionStream(RemoveSessionStreamRequest) returns (RemoveSessionStreamResponse);
+
+message AddSessionStreamRequest {
+  string session_id = 1;
+  string stream     = 2;
+}
+message AddSessionStreamResponse {
+  bool   success = 1;
+  string error   = 2;
+}
+
+message RemoveSessionStreamRequest {
+  string session_id = 1;
+  string stream     = 2;
+}
+message RemoveSessionStreamResponse {
+  bool   success = 1;
+  string error   = 2;
+}
+```
+
+**Error model:** `QuerySessionStreamsResponse.error` is a plugin-reported error string, consistent
+with the existing `EmitEventResponse.error` pattern — used for logging only, not gRPC status.
+`AddSessionStream`/`RemoveSessionStream` use gRPC status codes for host-side errors (session not
+found, invalid stream name) since those are infrastructure errors.
+
+---
+
+## Manifest Changes
+
+### `internal/plugin/manifest.go`
+
+```go
+type Manifest struct {
+    // ... existing fields ...
+
+    // SessionStreams indicates the plugin implements QuerySessionStreams and wants
+    // to contribute streams to session subscriptions.
+    // Only valid for lua and binary plugin types.
+    SessionStreams bool `yaml:"session_streams,omitempty" json:"session_streams,omitempty"`
+}
+```
+
+Validation: `session_streams: true` is rejected for `core` and `setting` plugin types with a clear
+error message. Core plugins are wired in-process and have no plugin-side code to implement the
+callback; setting plugins are content-only.
+
+---
+
+## Host Interface & Manager
+
+### `internal/plugin/host.go`
+
+```go
+type SessionStreamsRequest struct {
+    CharacterID string
+    PlayerID    string
+    SessionID   string
+}
+
+type Host interface {
+    Load(ctx context.Context, manifest *Manifest, dir string) error
+    Unload(ctx context.Context, name string) error
+    DeliverEvent(ctx context.Context, name string, event pluginsdk.Event) ([]pluginsdk.EmitEvent, error)
+    DeliverCommand(ctx context.Context, name string, cmd pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error)
+    QuerySessionStreams(ctx context.Context, name string, req SessionStreamsRequest) ([]string, error) // NEW
+    Plugins() []string
+    Close(ctx context.Context) error
+}
+```
+
+### `internal/plugin/manager.go`
+
+`Manager.QuerySessionStreams` fans out to all opted-in plugins in parallel, collects results with
+degraded-subscribe semantics, deduplicates, and returns the merged stream list:
+
+```go
+func (m *Manager) QuerySessionStreams(ctx context.Context, req SessionStreamsRequest) []string
+```
+
+- Collects opted-in plugins under read lock; releases lock before fan-out
+- Each plugin called in its own goroutine with the provided context (caller sets timeout)
+- Results sent on a buffered channel; all goroutines awaited
+- Per-plugin errors: log warning with plugin name + session context, skip contribution
+- Invalid stream names (see validation below) dropped after collection
+- Deduplication via `map[string]bool` before returning
+
+`CoreServer` receives a `SessionStreamContributor` interface (not `*Manager` directly) to keep
+wiring testable:
+
+```go
+type SessionStreamContributor interface {
+    QuerySessionStreams(ctx context.Context, req plugins.SessionStreamsRequest) []string
+}
+```
+
+---
+
+## Subscribe Handler Changes
+
+### `internal/grpc/stream_registry.go` (new)
+
+```go
+type sessionStreamUpdate struct {
+    stream string
+    add    bool // true = subscribe, false = unsubscribe
+}
+
+// SessionStreamRegistry maps active session IDs to their Subscribe control channels.
+// Multiple subscribers per session are supported — each Subscribe call registers
+// its own channel, and updates are broadcast to all active subscribers.
+type SessionStreamRegistry struct {
+    mu       sync.Mutex
+    channels map[string]map[chan<- sessionStreamUpdate]struct{}
+}
+
+func (r *SessionStreamRegistry) Register(sessionID string, ch chan<- sessionStreamUpdate)
+func (r *SessionStreamRegistry) Deregister(sessionID string, ch chan<- sessionStreamUpdate)
+func (r *SessionStreamRegistry) Send(sessionID string, update sessionStreamUpdate) error
+```
+
+`Send` is non-blocking (select with default). If the control channel buffer (capacity 16) is full,
+`Send` returns `CONTROL_CHANNEL_FULL` — the plugin's hostfunc call returns an error and the plugin
+can retry. This prevents backpressure from a slow Subscribe goroutine blocking plugin execution.
+
+### `internal/grpc/server.go` — Subscribe
+
+Changes in order within the handler:
+
+1. **After session info resolved, before LISTEN setup:** `CoreServer.Subscribe` wraps `ctx` with a
+   2s deadline before calling `s.streamContributor.QuerySessionStreams(contributionCtx, ...)`.
+   The Manager uses the provided context as-is — timeout responsibility belongs to the caller.
+   Merge returned streams into `staticStreams` (dedup already done by manager).
+
+2. **Per-stream cancel contexts:** each stream (original and plugin-contributed) gets
+   `context.WithCancel(ctx)`. Cancel functions stored in `streamCancels map[string]context.CancelFunc`.
+   Required for `RemoveSessionStream` to cancel individual stream relay goroutines. Parent ctx
+   cancellation (client disconnect) still cascades to all children automatically.
+
+3. **Register control channel before live-forward loop:**
+
+   ```go
+   ctrlCh := make(chan sessionStreamUpdate, 16)
+   s.streamRegistry.Register(info.ID, ctrlCh)
+   defer s.streamRegistry.Deregister(info.ID)
+   ```
+
+4. **Select loop gains `ctrlCh` arm:**
+   - **Add:** if stream not in `streamCancels`, call `subscribeStreamWithCancel`, then
+     `replayAndSend` using `info.EventCursors[stream]` as the cursor (zero if no prior cursor
+     exists). This means returning channel members replay only new messages since they last left;
+     first-time subscribers replay from the beginning. Mirrors the UC1 cursor logic exactly.
+     If stream already subscribed: no-op (idempotent).
+   - **Remove:** if stream in `streamCancels`, call cancel, delete from map. Location stream
+     (`world.StreamPrefixLocation`) is rejected — owned by `locationFollower`, not plugin-managed.
+
+5. **Test seam:** expose `afterLISTENHook func()` on `CoreServer` (configurable via
+   `WithAfterLISTENHook`) that fires between LISTEN setup and replay. Allows integration tests to
+   inject an event into the race window and assert it is received exactly once. Mirrors the
+   `cursorCommitHook` pattern from PR #201.
+
+---
+
+## Lua Host Changes
+
+### `on_session_subscribe` callback
+
+Lua plugins that declare `session_streams: true` implement an optional global function:
+
+```lua
+function on_session_subscribe(character_id, player_id, session_id)
+    -- return a table of stream name strings
+    return {"channel:abc123", "channel:def456"}
+end
+```
+
+If `on_session_subscribe` is not defined in a plugin that declares `session_streams: true`, the Lua
+host returns an empty list (not an error).
+
+### Stdlib additions (`hostfunc/stdlib_session.go`)
+
+```text
+holo.add_session_stream(session_id, stream) → success bool, err string
+holo.remove_session_stream(session_id, stream) → success bool, err string
+```
+
+Wired through the existing Lua hostfunc adapter pattern (same as `holo.emit_event`).
+
+---
+
+## Binary Plugin Wiring
+
+`GopluginHost.QuerySessionStreams` is a thin RPC wrapper over the new `PluginService` RPC, following
+the identical pattern as `HandleEvent` and `HandleCommand`.
+
+`AddSessionStream` / `RemoveSessionStream` on `HostFunctionsService` (binary plugin side) look up
+the `SessionStreamRegistry`, write the control update, and return success/error — identical in
+structure to the existing `EmitEvent` host function handler.
+
+---
+
+## Stream Name Validation
+
+Applied in `Manager.QuerySessionStreams` before merging, and in `AddSessionStream` hostfunc handler:
+
+- Non-empty
+- No whitespace characters
+- Contains at least one `:` (all HoloMUSH stream names follow `prefix:id`)
+- Maximum 256 characters
+
+Invalid names are dropped with a warning log. ABAC handles stream-level access control separately;
+validation here is format-only.
+
+---
+
+## Failure Policy
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Plugin `QuerySessionStreams` returns error | Log warning (plugin name + session), skip contribution, continue |
+| Plugin `QuerySessionStreams` times out (2s) | Same as error |
+| All plugins fail | Log error, proceed with core-only streams |
+| `AddSessionStream`: session not found | Return `SESSION_NOT_FOUND` gRPC error to plugin |
+| `AddSessionStream`: stream already subscribed | No-op, return success |
+| `AddSessionStream`: control channel full | Return `CONTROL_CHANNEL_FULL` error; plugin may retry |
+| `RemoveSessionStream`: stream not subscribed | No-op, return success (idempotent) |
+| `RemoveSessionStream`: location stream | Rejected with `INVALID_STREAM` error |
+
+---
+
+## Testing
+
+### Boundary Tests (unit)
+
+| Test | Covers |
+|------|--------|
+| `TestManagerQuerySessionStreamsEmptyResult` | Plugin returns empty list — no streams merged |
+| `TestManagerQuerySessionStreamsNoOptedInPlugins` | Zero opted-in plugins — returns nil immediately |
+| `TestManagerQuerySessionStreamsDuplicateAcrossPlugins` | Two plugins return same stream — deduplicated |
+| `TestManagerQuerySessionStreamsAllPluginsFail` | All error — empty result, all logged |
+| `TestManagerQuerySessionStreamsTimeout` | Plugin hangs past 2s deadline (deadline set by CoreServer, not Manager) — context cancels, Subscribe unblocked |
+| `TestSessionStreamRegistryControlChannelFull` | Buffer full — `Send` returns error, does not block |
+| `TestSubscribeAddStreamAlreadySubscribed` | Duplicate add — idempotent, no duplicate LISTEN |
+| `TestSubscribeRemoveStreamNotSubscribed` | Remove unknown stream — silent success |
+| `TestSubscribeRemoveLocationStream` | Plugin removes location stream — rejected |
+| `TestStreamNameValidationRejectsEmpty` | Empty name dropped |
+| `TestStreamNameValidationRejectsNoColon` | `"channelabcdef"` dropped |
+| `TestStreamNameValidationRejectsWhitespace` | `"channel: abc"` dropped |
+| `TestStreamNameValidationRejectsTooLong` | 257-char name dropped |
+| `TestManifestSessionStreamsRejectedForCoreType` | `session_streams: true` on core plugin — validation error |
+| `TestManifestSessionStreamsRejectedForSettingType` | Same for setting plugin |
+
+### Invariant Tests (unit)
+
+| Test | Invariant |
+|------|-----------|
+| `TestSubscribeLISTENBeforeReplayWithPluginStreams` | Plugin streams have LISTEN before replay — verified by mock call ordering |
+| `TestSubscribePluginStreamsIncludedInReplay` | Every plugin-contributed stream passed to `replayAndSend` |
+| `TestAddSessionStreamLISTENBeforeReplay` | Mid-session add: LISTEN before `replayAndSend` |
+| `TestSubscribeRegistryCleanedUpOnExit` | `Deregister` called on every Subscribe exit path |
+| `TestSubscribeStreamCancelsCleanedUpOnExit` | All per-stream cancels called on exit — no goroutine leaks |
+| `TestManagerQuerySessionStreamsNeverCallsOptedOutPlugin` | Opted-out plugin's `QuerySessionStreams` never called |
+
+### End-to-End Tests (integration, Ginkgo/Gomega)
+
+```go
+Describe("Plugin session stream contribution", func() {
+
+    Describe("UC1: session-start auto-subscribe", func() {
+        It("receives messages posted before login via replay")
+        It("subscribes to multiple channels simultaneously")
+        It("does not subscribe to channels the character is not a member of")
+        It("proceeds normally when channels plugin fails to respond")
+    })
+
+    Describe("UC2: mid-session subscription changes", func() {
+        It("receives messages immediately after joining a channel mid-session")
+        It("receives tail replay of recent messages on mid-session join")
+        It("stops receiving messages immediately after leaving a channel")
+        It("handles rapid join/leave without message duplication")
+    })
+
+    Describe("LISTEN-before-replay invariant", func() {
+        It("never loses a message posted in the race window between LISTEN setup and replay", func() {
+            // Uses subscribePhaseHook test seam (mirrors cursorCommitHook from PR #201)
+            // to inject a message during setup; asserts received exactly once
+        })
+    })
+})
+```
+
+---
+
+## Non-Goals
+
+- Stream-level access control (handled by existing ABAC + relation gates)
+- Dynamic stream creation or stream lifecycle management
+- Client-side changes (web gateway passes empty streams; Subscribe adds everything server-side)
+- Caching of `QuerySessionStreams` results (plugins own their membership data; caching is their
+  responsibility if needed)
+
+---
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `api/proto/holomush/plugin/v1/plugin.proto` | Add `QuerySessionStreams` RPC + messages |
+| `api/proto/holomush/plugin/v1/hostfunc.proto` | Add `AddSessionStream` / `RemoveSessionStream` |
+| `internal/plugin/host.go` | Add `QuerySessionStreams` to `Host` interface |
+| `internal/plugin/manifest.go` | Add `SessionStreams` field + validation |
+| `internal/plugin/manager.go` | Add `QuerySessionStreams` fan-out method |
+| `internal/plugin/lua/` | Wire `on_session_subscribe` callback + stdlib hostfuncs |
+| `internal/plugin/goplugin/` | Wire binary plugin `QuerySessionStreams` RPC |
+| `internal/plugin/hostfunc/functions.go` | Handle `AddSessionStream` / `RemoveSessionStream` |
+| `internal/grpc/server.go` | Collect plugin streams; ctrlCh select arm; per-stream cancels; test hook |
+| `internal/grpc/stream_registry.go` | New: `SessionStreamRegistry` |
+
+---
+
+## Related
+
+- holomush-oirq — this issue
+- holomush-0sc.12 — Channel plugin rework (blocked by this)

--- a/internal/auth/mocks/mock_PlayerRepository.go
+++ b/internal/auth/mocks/mock_PlayerRepository.go
@@ -7,11 +7,12 @@ package mocks
 
 import (
 	context "context"
-	time "time"
 
 	auth "github.com/holomush/holomush/internal/auth"
 
 	mock "github.com/stretchr/testify/mock"
+
+	time "time"
 
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -175,6 +176,53 @@ func (_c *MockPlayerRepository_Delete_Call) Return(_a0 error) *MockPlayerReposit
 }
 
 func (_c *MockPlayerRepository_Delete_Call) RunAndReturn(run func(context.Context, ulid.ULID) error) *MockPlayerRepository_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteGuestPlayer provides a mock function with given fields: ctx, playerID
+func (_m *MockPlayerRepository) DeleteGuestPlayer(ctx context.Context, playerID ulid.ULID) error {
+	ret := _m.Called(ctx, playerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteGuestPlayer")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, ulid.ULID) error); ok {
+		r0 = rf(ctx, playerID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockPlayerRepository_DeleteGuestPlayer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteGuestPlayer'
+type MockPlayerRepository_DeleteGuestPlayer_Call struct {
+	*mock.Call
+}
+
+// DeleteGuestPlayer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - playerID ulid.ULID
+func (_e *MockPlayerRepository_Expecter) DeleteGuestPlayer(ctx interface{}, playerID interface{}) *MockPlayerRepository_DeleteGuestPlayer_Call {
+	return &MockPlayerRepository_DeleteGuestPlayer_Call{Call: _e.mock.On("DeleteGuestPlayer", ctx, playerID)}
+}
+
+func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) Run(run func(ctx context.Context, playerID ulid.ULID)) *MockPlayerRepository_DeleteGuestPlayer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ulid.ULID))
+	})
+	return _c
+}
+
+func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) Return(_a0 error) *MockPlayerRepository_DeleteGuestPlayer_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) RunAndReturn(run func(context.Context, ulid.ULID) error) *MockPlayerRepository_DeleteGuestPlayer_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -356,6 +404,65 @@ func (_c *MockPlayerRepository_GetByUsername_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// ListIdleGuests provides a mock function with given fields: ctx, idleSince
+func (_m *MockPlayerRepository) ListIdleGuests(ctx context.Context, idleSince time.Time) ([]*auth.Player, error) {
+	ret := _m.Called(ctx, idleSince)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListIdleGuests")
+	}
+
+	var r0 []*auth.Player
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) ([]*auth.Player, error)); ok {
+		return rf(ctx, idleSince)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) []*auth.Player); ok {
+		r0 = rf(ctx, idleSince)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*auth.Player)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = rf(ctx, idleSince)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockPlayerRepository_ListIdleGuests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIdleGuests'
+type MockPlayerRepository_ListIdleGuests_Call struct {
+	*mock.Call
+}
+
+// ListIdleGuests is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idleSince time.Time
+func (_e *MockPlayerRepository_Expecter) ListIdleGuests(ctx interface{}, idleSince interface{}) *MockPlayerRepository_ListIdleGuests_Call {
+	return &MockPlayerRepository_ListIdleGuests_Call{Call: _e.mock.On("ListIdleGuests", ctx, idleSince)}
+}
+
+func (_c *MockPlayerRepository_ListIdleGuests_Call) Run(run func(ctx context.Context, idleSince time.Time)) *MockPlayerRepository_ListIdleGuests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(time.Time))
+	})
+	return _c
+}
+
+func (_c *MockPlayerRepository_ListIdleGuests_Call) Return(_a0 []*auth.Player, _a1 error) *MockPlayerRepository_ListIdleGuests_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockPlayerRepository_ListIdleGuests_Call) RunAndReturn(run func(context.Context, time.Time) ([]*auth.Player, error)) *MockPlayerRepository_ListIdleGuests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function with given fields: ctx, player
 func (_m *MockPlayerRepository) Update(ctx context.Context, player *auth.Player) error {
 	ret := _m.Called(ctx, player)
@@ -495,112 +602,6 @@ func (_c *MockPlayerRepository_UpdatePasswordAndClearLockout_Call) Return(_a0 er
 }
 
 func (_c *MockPlayerRepository_UpdatePasswordAndClearLockout_Call) RunAndReturn(run func(context.Context, ulid.ULID, string) error) *MockPlayerRepository_UpdatePasswordAndClearLockout_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteGuestPlayer provides a mock function with given fields: ctx, playerID
-func (_m *MockPlayerRepository) DeleteGuestPlayer(ctx context.Context, playerID ulid.ULID) error {
-	ret := _m.Called(ctx, playerID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteGuestPlayer")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, ulid.ULID) error); ok {
-		r0 = rf(ctx, playerID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockPlayerRepository_DeleteGuestPlayer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteGuestPlayer'
-type MockPlayerRepository_DeleteGuestPlayer_Call struct {
-	*mock.Call
-}
-
-// DeleteGuestPlayer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - playerID ulid.ULID
-func (_e *MockPlayerRepository_Expecter) DeleteGuestPlayer(ctx interface{}, playerID interface{}) *MockPlayerRepository_DeleteGuestPlayer_Call {
-	return &MockPlayerRepository_DeleteGuestPlayer_Call{Call: _e.mock.On("DeleteGuestPlayer", ctx, playerID)}
-}
-
-func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) Run(run func(ctx context.Context, playerID ulid.ULID)) *MockPlayerRepository_DeleteGuestPlayer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(ulid.ULID))
-	})
-	return _c
-}
-
-func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) Return(_a0 error) *MockPlayerRepository_DeleteGuestPlayer_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockPlayerRepository_DeleteGuestPlayer_Call) RunAndReturn(run func(context.Context, ulid.ULID) error) *MockPlayerRepository_DeleteGuestPlayer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListIdleGuests provides a mock function with given fields: ctx, idleSince
-func (_m *MockPlayerRepository) ListIdleGuests(ctx context.Context, idleSince time.Time) ([]*auth.Player, error) {
-	ret := _m.Called(ctx, idleSince)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListIdleGuests")
-	}
-
-	var r0 []*auth.Player
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Time) ([]*auth.Player, error)); ok {
-		return rf(ctx, idleSince)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, time.Time) []*auth.Player); ok {
-		r0 = rf(ctx, idleSince)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*auth.Player)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
-		r1 = rf(ctx, idleSince)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockPlayerRepository_ListIdleGuests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIdleGuests'
-type MockPlayerRepository_ListIdleGuests_Call struct {
-	*mock.Call
-}
-
-// ListIdleGuests is a helper method to define mock.On call
-//   - ctx context.Context
-//   - idleSince time.Time
-func (_e *MockPlayerRepository_Expecter) ListIdleGuests(ctx interface{}, idleSince interface{}) *MockPlayerRepository_ListIdleGuests_Call {
-	return &MockPlayerRepository_ListIdleGuests_Call{Call: _e.mock.On("ListIdleGuests", ctx, idleSince)}
-}
-
-func (_c *MockPlayerRepository_ListIdleGuests_Call) Run(run func(ctx context.Context, idleSince time.Time)) *MockPlayerRepository_ListIdleGuests_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(time.Time))
-	})
-	return _c
-}
-
-func (_c *MockPlayerRepository_ListIdleGuests_Call) Return(_a0 []*auth.Player, _a1 error) *MockPlayerRepository_ListIdleGuests_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockPlayerRepository_ListIdleGuests_Call) RunAndReturn(run func(context.Context, time.Time) ([]*auth.Player, error)) *MockPlayerRepository_ListIdleGuests_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
@@ -93,6 +94,11 @@ type WorldQuerier interface {
 	GetExitsByLocation(ctx context.Context, subjectID string, locationID ulid.ULID) ([]*world.Exit, error)
 }
 
+// SessionStreamContributor collects plugin-contributed stream names for a session.
+type SessionStreamContributor interface {
+	QuerySessionStreams(ctx context.Context, req plugins.SessionStreamsRequest) []string
+}
+
 // CoreServer implements the gRPC Core service.
 type CoreServer struct {
 	corev1.UnimplementedCoreServiceServer
@@ -114,6 +120,13 @@ type CoreServer struct {
 	playerRepo        auth.PlayerRepository
 	charRepo          auth.CharacterRepository
 	guestService      *auth.GuestService
+
+	// Plugin stream contribution and mid-session stream control.
+	streamContributor SessionStreamContributor
+	streamRegistry    *SessionStreamRegistry
+
+	// afterLISTENHook fires between LISTEN setup and replay — used in tests.
+	afterLISTENHook func()
 
 	// newSessionID is used for generating session IDs. Can be overridden for testing.
 	newSessionID func() ulid.ULID
@@ -201,6 +214,24 @@ func WithCursorCommitHook(hook func(ctx context.Context, sessionID string, event
 // has no semantic meaning outside the lock map's internals.
 func (s *CoreServer) CursorLockRefCount(sessionID string) int {
 	return s.cursorLocks.refCount(sessionID)
+}
+
+// WithStreamContributor sets the plugin stream contributor for the server.
+func WithStreamContributor(c SessionStreamContributor) CoreServerOption {
+	return func(s *CoreServer) { s.streamContributor = c }
+}
+
+// WithStreamRegistry sets the session stream registry for mid-session stream control.
+func WithStreamRegistry(r *SessionStreamRegistry) CoreServerOption {
+	return func(s *CoreServer) { s.streamRegistry = r }
+}
+
+// WithAfterLISTENHook sets a callback fired between LISTEN setup and replay.
+// For testing only.
+func WithAfterLISTENHook(hook func()) CoreServerOption {
+	return func(s *CoreServer) {
+		s.afterLISTENHook = hook
+	}
 }
 
 // NewCoreServer creates a new Core gRPC server.
@@ -400,6 +431,21 @@ func (s *CoreServer) executeViaDispatcher(ctx context.Context, info *session.Inf
 func isUserFacingError(err error) bool {
 	msg := command.PlayerMessage(err)
 	return msg != "Something went wrong. Try again."
+}
+
+// isValidSessionStreamName validates a plugin-contributed stream name.
+// Stream names must be non-empty, contain at least one colon, have no whitespace,
+// and be at most 256 characters long. Mirrors internal/plugin/manager.isValidStreamName.
+func isValidSessionStreamName(name string) bool {
+	if name == "" || len(name) > 256 {
+		return false
+	}
+	for _, r := range name {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return false
+		}
+	}
+	return strings.Contains(name, ":")
 }
 
 // emitCommandResponse emits a command_response or command_error event to the
@@ -673,6 +719,37 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		staticStreams = append(staticStreams, charStreamName)
 	}
 
+	// Collect plugin-contributed streams (before LISTEN setup to preserve ordering invariant).
+	if s.streamContributor != nil {
+		contribCtx, contribCancel := context.WithTimeout(ctx, 2*time.Second)
+		playerID := ""
+		if !info.PlayerID.IsZero() {
+			playerID = info.PlayerID.String()
+		}
+		pluginStreams := s.streamContributor.QuerySessionStreams(contribCtx, plugins.SessionStreamsRequest{
+			CharacterID: info.CharacterID.String(),
+			PlayerID:    playerID,
+			SessionID:   info.ID,
+		})
+		contribCancel()
+		seen := make(map[string]bool, len(staticStreams))
+		for _, sn := range staticStreams {
+			seen[sn] = true
+		}
+		for _, ps := range pluginStreams {
+			if strings.HasPrefix(ps, world.StreamPrefixLocation) || seen[ps] {
+				continue
+			}
+			if !isValidSessionStreamName(ps) {
+				slog.WarnContext(ctx, "plugin contributed malformed stream name — skipping",
+					"session_id", info.ID, "stream", ps)
+				continue
+			}
+			staticStreams = append(staticStreams, ps)
+			seen[ps] = true
+		}
+	}
+
 	// All streams = static + location.
 	allStreams := make([]string, 0, len(staticStreams)+1)
 	allStreams = append(allStreams, staticStreams...)
@@ -683,8 +760,23 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// Set up LISTEN subscriptions before any replay to avoid missing events.
 	notifyCh := make(chan streamNotification, 100)
 	errCh := make(chan error, len(allStreams))
+	streamCancels := make(map[string]context.CancelFunc)
+	subscribeWithCancel := func(sn string) error {
+		sctx, cancel := context.WithCancel(ctx)
+		if err := subscribeStream(sctx, s.eventStore, sn, notifyCh, errCh); err != nil {
+			cancel()
+			return err
+		}
+		streamCancels[sn] = cancel
+		return nil
+	}
+	defer func() {
+		for _, cancel := range streamCancels {
+			cancel()
+		}
+	}()
 	for _, sn := range allStreams {
-		if subErr := subscribeStream(ctx, s.eventStore, sn, notifyCh, errCh); subErr != nil {
+		if subErr := subscribeWithCancel(sn); subErr != nil {
 			return oops.Code("SUBSCRIBE_FAILED").With("session_id", req.SessionId).With("stream", sn).Wrap(subErr)
 		}
 	}
@@ -719,6 +811,17 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 			lf.locCancel()
 		}
 	}()
+
+	// Register session control channel for mid-session stream updates.
+	ctrlCh := make(chan sessionStreamUpdate, 16)
+	if s.streamRegistry != nil {
+		s.streamRegistry.Register(info.ID, ctrlCh)
+		defer s.streamRegistry.Deregister(info.ID, ctrlCh)
+	}
+
+	if s.afterLISTENHook != nil {
+		s.afterLISTENHook()
+	}
 
 	// Single replay pass: catches both historical cursor-based events
 	// (reconnection) and events appended during LISTEN setup (race window).
@@ -791,6 +894,44 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 					},
 				})
 				return nil
+			}
+
+		case ctrl, ok := <-ctrlCh:
+			if !ok {
+				return nil
+			}
+			if ctrl.add {
+				if _, exists := streamCancels[ctrl.stream]; exists {
+					continue // already subscribed — idempotent
+				}
+				if strings.HasPrefix(ctrl.stream, world.StreamPrefixLocation) {
+					slog.WarnContext(ctx, "plugin attempted to add location stream — rejected",
+						"session_id", info.ID, "stream", ctrl.stream)
+					continue
+				}
+				if subErr := subscribeWithCancel(ctrl.stream); subErr != nil {
+					slog.WarnContext(ctx, "mid-session stream add failed",
+						"session_id", info.ID, "stream", ctrl.stream, "error", subErr)
+				} else {
+					cursor := lastSentID[ctrl.stream]
+					if cursor.IsZero() && info.EventCursors != nil {
+						if c, ok := info.EventCursors[ctrl.stream]; ok {
+							cursor = c
+						}
+					}
+					last, sendErr := s.replayAndSend(ctx, info, ctrl.stream, cursor, stream, lf)
+					if sendErr != nil {
+						return oops.Code("SEND_FAILED").With("session_id", info.ID).Wrap(sendErr)
+					}
+					if !last.IsZero() {
+						lastSentID[ctrl.stream] = last
+					}
+				}
+			} else {
+				if cancel, exists := streamCancels[ctrl.stream]; exists {
+					cancel()
+					delete(streamCancels, ctrl.stream)
+				}
 			}
 		}
 	}

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/session"
 	tlscerts "github.com/holomush/holomush/internal/tls"
+	"github.com/holomush/holomush/pkg/errutil"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
 
@@ -80,6 +82,7 @@ type mockEventStore struct {
 	appendFunc      func(ctx context.Context, event core.Event) error
 	replayFunc      func(ctx context.Context, stream string, afterID ulid.ULID, limit int) ([]core.Event, error)
 	lastEventIDFunc func(ctx context.Context, stream string) (ulid.ULID, error)
+	subscribeFunc   func(ctx context.Context, stream string) (<-chan ulid.ULID, <-chan error, error)
 }
 
 func (m *mockEventStore) Append(ctx context.Context, event core.Event) error {
@@ -103,7 +106,10 @@ func (m *mockEventStore) LastEventID(ctx context.Context, stream string) (ulid.U
 	return ulid.ULID{}, core.ErrStreamEmpty
 }
 
-func (m *mockEventStore) Subscribe(ctx context.Context, _ string) (<-chan ulid.ULID, <-chan error, error) {
+func (m *mockEventStore) Subscribe(ctx context.Context, stream string) (<-chan ulid.ULID, <-chan error, error) {
+	if m.subscribeFunc != nil {
+		return m.subscribeFunc(ctx, stream)
+	}
 	eventCh := make(chan ulid.ULID)
 	errCh := make(chan error)
 	go func() {
@@ -324,6 +330,25 @@ func TestNewCoreServer_WithOptions(t *testing.T) {
 
 	require.NotNil(t, server, "NewCoreServer returned nil")
 	assert.Equal(t, customStore, server.sessionStore, "WithSessionStore option not applied")
+}
+
+func TestNewCoreServer_WithStreamOptions(t *testing.T) {
+	store := &mockEventStore{}
+
+	registry := NewSessionStreamRegistry()
+	hookCalled := false
+	server := newHandleCommandServer(t, store, nil,
+		WithStreamContributor(nil),
+		WithStreamRegistry(registry),
+		WithAfterLISTENHook(func() { hookCalled = true }),
+	)
+
+	require.NotNil(t, server)
+	assert.Nil(t, server.streamContributor)
+	assert.Equal(t, registry, server.streamRegistry)
+	assert.NotNil(t, server.afterLISTENHook)
+	server.afterLISTENHook()
+	assert.True(t, hookCalled)
 }
 
 func TestNewCoreServer_PanicsWithoutDispatcher(t *testing.T) {
@@ -3036,4 +3061,164 @@ func TestCoreServer_GetCommandHistory(t *testing.T) {
 		assert.True(t, resp.Success)
 		assert.Empty(t, resp.Commands)
 	})
+}
+
+// =============================================================================
+// Plugin Stream Contribution Tests (holomush-oirq Task 10)
+// =============================================================================
+
+// mockStreamContributor returns a fixed list of plugin streams.
+type mockStreamContributor struct {
+	streams []string
+}
+
+func (m *mockStreamContributor) QuerySessionStreams(_ context.Context, _ plugins.SessionStreamsRequest) []string {
+	return m.streams
+}
+
+// trackingEventStore wraps core.MemoryEventStore and records Subscribe calls.
+type trackingEventStore struct {
+	core.EventStore
+	mu              sync.Mutex
+	subscribedNames []string
+}
+
+func newTrackingEventStore() *trackingEventStore {
+	return &trackingEventStore{EventStore: core.NewMemoryEventStore()}
+}
+
+func (t *trackingEventStore) Subscribe(ctx context.Context, stream string) (<-chan ulid.ULID, <-chan error, error) {
+	t.mu.Lock()
+	t.subscribedNames = append(t.subscribedNames, stream)
+	t.mu.Unlock()
+	return t.EventStore.Subscribe(ctx, stream)
+}
+
+func (t *trackingEventStore) subscribedStreams() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	result := make([]string, len(t.subscribedNames))
+	copy(result, t.subscribedNames)
+	return result
+}
+
+func TestSubscribeIncludesPluginContributedStreams(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+
+	eventStore := newTrackingEventStore()
+
+	contributor := &mockStreamContributor{streams: []string{"channel:abc"}}
+
+	ready := make(chan struct{})
+	server := &CoreServer{
+		engine:            core.NewEngine(eventStore),
+		eventStore:        eventStore,
+		streamContributor: contributor,
+		afterLISTENHook:   func() { close(ready) },
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			sessionID.String(): {
+				CharacterID: charID,
+				LocationID:  locationID,
+				Status:      session.StatusActive,
+			},
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &mockSubscribeStream{ctx: ctx}
+
+	req := &corev1.SubscribeRequest{
+		SessionId: sessionID.String(),
+		Streams:   []string{"location:" + locationID.String()},
+	}
+
+	done := make(chan error)
+	go func() {
+		done <- server.Subscribe(req, stream)
+	}()
+
+	// Wait for Subscribe to finish LISTEN setup before cancelling.
+	select {
+	case <-ready:
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not finish LISTEN setup")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not return after context cancellation")
+	}
+
+	subscribed := eventStore.subscribedStreams()
+	assert.Contains(t, subscribed, "channel:abc",
+		"Subscribe should have called Subscribe on plugin-contributed stream channel:abc; got %v", subscribed)
+}
+
+func TestSubscribeDeregistersRegistryOnExit(t *testing.T) {
+	charID := core.NewULID()
+	sessionID := core.NewULID()
+	locationID := core.NewULID()
+
+	eventStore := core.NewMemoryEventStore()
+	registry := NewSessionStreamRegistry()
+
+	server := &CoreServer{
+		engine:         core.NewEngine(eventStore),
+		eventStore:     eventStore,
+		streamRegistry: registry,
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			sessionID.String(): {
+				ID:          sessionID.String(),
+				CharacterID: charID,
+				LocationID:  locationID,
+				Status:      session.StatusActive,
+			},
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &mockSubscribeStream{ctx: ctx}
+
+	req := &corev1.SubscribeRequest{
+		SessionId: sessionID.String(),
+		Streams:   []string{"location:" + locationID.String()},
+	}
+
+	// Use afterLISTENHook to verify the session IS registered just before replay.
+	registeredDuringSetup := make(chan bool, 1)
+	server.afterLISTENHook = func() {
+		err := registry.Send(sessionID.String(), sessionStreamUpdate{stream: "channel:test", add: true})
+		registeredDuringSetup <- (err == nil)
+	}
+
+	done := make(chan error)
+	go func() {
+		done <- server.Subscribe(req, stream)
+	}()
+
+	// Wait for afterLISTENHook to fire.
+	select {
+	case wasRegistered := <-registeredDuringSetup:
+		assert.True(t, wasRegistered, "session should be registered in registry during Subscribe")
+	case <-time.After(time.Second):
+		t.Fatal("afterLISTENHook did not fire")
+	}
+
+	// Cancel context to exit Subscribe.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not return after context cancellation")
+	}
+
+	// After Subscribe exits, the session should be deregistered.
+	err := registry.Send(sessionID.String(), sessionStreamUpdate{stream: "channel:test", add: false})
+	require.Error(t, err, "registry should return SESSION_NOT_FOUND after Subscribe exits")
+	errutil.AssertErrorCode(t, err, "SESSION_NOT_FOUND")
 }

--- a/internal/grpc/stream_registry.go
+++ b/internal/grpc/stream_registry.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"sync"
+
+	"github.com/samber/oops"
+)
+
+// sessionStreamUpdate is sent on a session's control channel to add or remove a stream.
+type sessionStreamUpdate struct {
+	stream string
+	add    bool // true = subscribe, false = unsubscribe
+}
+
+// SessionStreamRegistry maps active session IDs to their Subscribe control channels.
+// It implements plugins.StreamRegistry for use by the hostfunc layer.
+// Multiple subscribers per session are supported — each Subscribe call registers
+// its own channel, and updates are broadcast to all active subscribers.
+type SessionStreamRegistry struct {
+	mu       sync.Mutex
+	channels map[string]map[chan<- sessionStreamUpdate]struct{}
+}
+
+// NewSessionStreamRegistry creates an empty registry.
+func NewSessionStreamRegistry() *SessionStreamRegistry {
+	return &SessionStreamRegistry{
+		channels: make(map[string]map[chan<- sessionStreamUpdate]struct{}),
+	}
+}
+
+// Register associates a session subscriber with its control channel.
+// Called by CoreServer.Subscribe at stream setup time.
+func (r *SessionStreamRegistry) Register(sessionID string, ch chan<- sessionStreamUpdate) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	subs, ok := r.channels[sessionID]
+	if !ok {
+		subs = make(map[chan<- sessionStreamUpdate]struct{})
+		r.channels[sessionID] = subs
+	}
+	subs[ch] = struct{}{}
+}
+
+// Deregister removes a specific subscriber channel from the registry.
+// Called by CoreServer.Subscribe on exit (via defer).
+func (r *SessionStreamRegistry) Deregister(sessionID string, ch chan<- sessionStreamUpdate) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	subs, ok := r.channels[sessionID]
+	if !ok {
+		return
+	}
+	delete(subs, ch)
+	if len(subs) == 0 {
+		delete(r.channels, sessionID)
+	}
+}
+
+// Send broadcasts an update to all active subscribers for a session.
+// Returns SESSION_NOT_FOUND if no active Subscribe exists for the session.
+// Returns CONTROL_CHANNEL_FULL if any subscriber's channel buffer is exhausted
+// (the update is still delivered to other subscribers).
+func (r *SessionStreamRegistry) Send(sessionID string, update sessionStreamUpdate) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	subs, ok := r.channels[sessionID]
+	if !ok || len(subs) == 0 {
+		return oops.Code("SESSION_NOT_FOUND").Errorf("no active subscribe for session %s", sessionID)
+	}
+	var lastErr error
+	for ch := range subs {
+		select {
+		case ch <- update:
+		default:
+			lastErr = oops.Code("CONTROL_CHANNEL_FULL").Errorf("control channel full for session %s", sessionID)
+		}
+	}
+	return lastErr
+}
+
+// AddStream implements plugins.StreamRegistry. Subscribes a session to a stream.
+func (r *SessionStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
+	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true})
+}
+
+// RemoveStream implements plugins.StreamRegistry. Unsubscribes a session from a stream.
+func (r *SessionStreamRegistry) RemoveStream(_ context.Context, sessionID, stream string) error {
+	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: false})
+}

--- a/internal/grpc/stream_registry_test.go
+++ b/internal/grpc/stream_registry_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestSessionStreamRegistrySendDeliversToRegisteredSession(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	r.Register("sess-1", ch)
+
+	err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+	require.NoError(t, err)
+
+	update := <-ch
+	assert.Equal(t, "channel:abc", update.stream)
+	assert.True(t, update.add)
+}
+
+func TestSessionStreamRegistrySendReturnsNotFoundForUnknownSession(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	err := r.Send("missing", sessionStreamUpdate{stream: "channel:abc", add: true})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_NOT_FOUND")
+}
+
+func TestSessionStreamRegistrySendReturnsNotFoundAfterDeregister(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	r.Register("sess-1", ch)
+	r.Deregister("sess-1", ch)
+
+	err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_NOT_FOUND")
+}
+
+func TestSessionStreamRegistrySendReturnsChannelFullWhenBufferExhausted(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1) // buffer of 1
+	r.Register("sess-1", ch)
+
+	// Fill the buffer
+	err := r.Send("sess-1", sessionStreamUpdate{stream: "channel:abc", add: true})
+	require.NoError(t, err)
+
+	// Second send to full buffer should return error immediately
+	err = r.Send("sess-1", sessionStreamUpdate{stream: "channel:def", add: true})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CONTROL_CHANNEL_FULL")
+}
+
+func TestSessionStreamRegistryAddStreamDelegatesToSend(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	r.Register("sess-1", ch)
+
+	err := r.AddStream(context.Background(), "sess-1", "channel:abc")
+	require.NoError(t, err)
+	update := <-ch
+	assert.Equal(t, "channel:abc", update.stream)
+	assert.True(t, update.add)
+}
+
+func TestSessionStreamRegistryRemoveStreamDelegatesToSend(t *testing.T) {
+	r := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	r.Register("sess-1", ch)
+
+	err := r.RemoveStream(context.Background(), "sess-1", "channel:abc")
+	require.NoError(t, err)
+	update := <-ch
+	assert.Equal(t, "channel:abc", update.stream)
+	assert.False(t, update.add)
+}

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -632,6 +632,38 @@ func (h *Host) Plugins() []string {
 	return names
 }
 
+// QuerySessionStreams calls the plugin's QuerySessionStreams RPC.
+// Returns nil if the plugin has no streams to contribute.
+func (h *Host) QuerySessionStreams(ctx context.Context, name string, req plugins.SessionStreamsRequest) ([]string, error) {
+	h.mu.RLock()
+	if h.closed {
+		h.mu.RUnlock()
+		return nil, ErrHostClosed
+	}
+	p, ok := h.plugins[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").Wrap(ErrPluginNotLoaded)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, DefaultEventTimeout)
+	defer cancel()
+
+	resp, err := p.plugin.QuerySessionStreams(callCtx, &pluginv1.QuerySessionStreamsRequest{
+		CharacterId: req.CharacterID,
+		PlayerId:    req.PlayerID,
+		SessionId:   req.SessionID,
+	})
+	if err != nil {
+		return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").Wrap(err)
+	}
+	if resp.GetError() != "" {
+		return nil, oops.In("goplugin").With("plugin", name).With("operation", "query_session_streams").New(resp.GetError())
+	}
+	return resp.GetStreams(), nil
+}
+
 // Close shuts down the host and all plugins.
 func (h *Host) Close(_ context.Context) error {
 	h.mu.Lock()

--- a/internal/plugin/goplugin/host_test.go
+++ b/internal/plugin/goplugin/host_test.go
@@ -81,6 +81,8 @@ type mockGRPCPluginClient struct {
 	initCalled bool
 	initReq    *pluginv1.InitRequest
 	initErr    error
+
+	QuerySessionStreamsFunc func(ctx context.Context, req *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error)
 }
 
 func (m *mockGRPCPluginClient) Init(_ context.Context, req *pluginv1.InitRequest, _ ...grpc.CallOption) (*pluginv1.InitResponse, error) {
@@ -116,6 +118,13 @@ func (m *mockGRPCPluginClient) HandleCommand(_ context.Context, _ *pluginv1.Hand
 		return m.cmdResponse, nil
 	}
 	return &pluginv1.HandleCommandResponse{Response: &pluginv1.CommandResponse{}}, nil
+}
+
+func (m *mockGRPCPluginClient) QuerySessionStreams(ctx context.Context, req *pluginv1.QuerySessionStreamsRequest, _ ...grpc.CallOption) (*pluginv1.QuerySessionStreamsResponse, error) {
+	if m.QuerySessionStreamsFunc != nil {
+		return m.QuerySessionStreamsFunc(ctx, req)
+	}
+	return &pluginv1.QuerySessionStreamsResponse{}, nil
 }
 
 // mockClientFactory creates mock clients for testing.
@@ -1310,4 +1319,167 @@ func TestPluginConnReturnsErrorWhenNoConnection(t *testing.T) {
 
 func TestHostImplementsServiceConnProvider(_ *testing.T) {
 	var _ plugins.ServiceConnProvider = (*Host)(nil)
+}
+
+// --- QuerySessionStreams tests ---
+
+func TestGopluginHostQuerySessionStreamsCallsPluginRPC(t *testing.T) {
+	var capturedReq *pluginv1.QuerySessionStreamsRequest
+	grpcClient := &mockGRPCPluginClient{
+		QuerySessionStreamsFunc: func(_ context.Context, req *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error) {
+			capturedReq = req
+			return &pluginv1.QuerySessionStreamsResponse{
+				Streams: []string{"channel:general", "channel:ooc"},
+			}, nil
+		},
+	}
+	mockClient := &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: grpcClient},
+	}
+	factory := &mockClientFactory{client: mockClient}
+	host := NewHostWithFactory(factory)
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	err := createTempExecutable(tmpDir + "/test-plugin")
+	require.NoError(t, err)
+
+	manifest := &plugins.Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Type:    plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{
+			Executable: "test-plugin",
+		},
+	}
+
+	err = host.Load(ctx, manifest, tmpDir)
+	require.NoError(t, err)
+
+	req := plugins.SessionStreamsRequest{
+		CharacterID: "char-123",
+		PlayerID:    "player-456",
+		SessionID:   "sess-789",
+	}
+
+	streams, err := host.QuerySessionStreams(ctx, "test-plugin", req)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"channel:general", "channel:ooc"}, streams)
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, "char-123", capturedReq.CharacterId)
+	assert.Equal(t, "player-456", capturedReq.PlayerId)
+	assert.Equal(t, "sess-789", capturedReq.SessionId)
+}
+
+func TestGopluginHostQuerySessionStreamsReturnsErrorFromPlugin(t *testing.T) {
+	grpcClient := &mockGRPCPluginClient{
+		QuerySessionStreamsFunc: func(_ context.Context, _ *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error) {
+			return &pluginv1.QuerySessionStreamsResponse{
+				Error: "db unavailable",
+			}, nil
+		},
+	}
+	mockClient := &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: grpcClient},
+	}
+	factory := &mockClientFactory{client: mockClient}
+	host := NewHostWithFactory(factory)
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	err := createTempExecutable(tmpDir + "/test-plugin")
+	require.NoError(t, err)
+
+	manifest := &plugins.Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Type:    plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{
+			Executable: "test-plugin",
+		},
+	}
+
+	err = host.Load(ctx, manifest, tmpDir)
+	require.NoError(t, err)
+
+	req := plugins.SessionStreamsRequest{
+		CharacterID: "char-123",
+		PlayerID:    "player-456",
+		SessionID:   "sess-789",
+	}
+
+	_, err = host.QuerySessionStreams(ctx, "test-plugin", req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db unavailable")
+}
+
+func TestGopluginHostQuerySessionStreamsReturnsErrorOnRPCFailure(t *testing.T) {
+	wantErr := errors.New("transport failure")
+	grpcClient := &mockGRPCPluginClient{
+		QuerySessionStreamsFunc: func(_ context.Context, _ *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error) {
+			return nil, wantErr
+		},
+	}
+	mockClient := &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: grpcClient},
+	}
+	factory := &mockClientFactory{client: mockClient}
+	host := NewHostWithFactory(factory)
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	err := createTempExecutable(tmpDir + "/test-plugin")
+	require.NoError(t, err)
+
+	manifest := &plugins.Manifest{
+		Name:    "test-plugin",
+		Version: "1.0.0",
+		Type:    plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{
+			Executable: "test-plugin",
+		},
+	}
+
+	err = host.Load(ctx, manifest, tmpDir)
+	require.NoError(t, err)
+
+	_, err = host.QuerySessionStreams(ctx, "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-1",
+		PlayerID:    "player-1",
+		SessionID:   "sess-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transport failure")
+}
+
+func TestGopluginHostQuerySessionStreamsReturnsErrorWhenHostClosed(t *testing.T) {
+	factory := &mockClientFactory{client: &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: &mockGRPCPluginClient{}},
+	}}
+	host := NewHostWithFactory(factory)
+
+	tmpDir := t.TempDir()
+	require.NoError(t, createTempExecutable(tmpDir+"/test-plugin"))
+	manifest := &plugins.Manifest{
+		Name:         "test-plugin",
+		Version:      "1.0.0",
+		Type:         plugins.TypeBinary,
+		BinaryPlugin: &plugins.BinaryConfig{Executable: "test-plugin"},
+	}
+	require.NoError(t, host.Load(context.Background(), manifest, tmpDir))
+	require.NoError(t, host.Close(context.Background()))
+
+	_, err := host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHostClosed)
+}
+
+func TestGopluginHostQuerySessionStreamsReturnsErrorForUnknownPlugin(t *testing.T) {
+	host := NewHostWithFactory(&mockClientFactory{client: &mockPluginClient{
+		protocol: &mockClientProtocol{pluginClient: &mockGRPCPluginClient{}},
+	}})
+
+	_, err := host.QuerySessionStreams(context.Background(), "nonexistent", plugins.SessionStreamsRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPluginNotLoaded)
 }

--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -12,6 +12,25 @@ import (
 	"google.golang.org/grpc"
 )
 
+// SessionStreamsRequest carries session context for plugin stream contribution queries.
+type SessionStreamsRequest struct {
+	// CharacterID is the character entering the session.
+	CharacterID string
+	// PlayerID is the player owning the character.
+	PlayerID string
+	// SessionID is the active session identifier.
+	SessionID string
+}
+
+// StreamRegistry allows plugins to modify session stream subscriptions mid-session.
+type StreamRegistry interface {
+	// AddStream subscribes a session to an additional stream.
+	// Returns an error (code SESSION_NOT_FOUND) if the session is not active.
+	AddStream(ctx context.Context, sessionID, stream string) error
+	// RemoveStream unsubscribes a session from a stream. Idempotent.
+	RemoveStream(ctx context.Context, sessionID, stream string) error
+}
+
 // Host manages a specific plugin runtime type.
 type Host interface {
 	// Load initializes a plugin from its manifest.
@@ -25,6 +44,11 @@ type Host interface {
 
 	// DeliverCommand sends a command to a plugin and returns the response.
 	DeliverCommand(ctx context.Context, name string, cmd pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error)
+
+	// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+	// Only called for plugins with SessionStreams: true in their manifest.
+	// Returns nil if the plugin has no streams to contribute.
+	QuerySessionStreams(ctx context.Context, name string, req SessionStreamsRequest) ([]string, error)
 
 	// Plugins returns names of all loaded plugins.
 	Plugins() []string

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/idgen"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/property"
 	"github.com/holomush/holomush/internal/session"
 )
@@ -44,6 +45,7 @@ type Functions struct {
 	propertyRegistry *property.Registry
 	sessionAccess    session.Access
 	capabilities     *CapabilityRegistry
+	streamRegistry   plugins.StreamRegistry
 }
 
 // Option configures Functions.
@@ -78,6 +80,13 @@ func WithSessionAccess(sa session.Access) Option {
 func WithCapabilities(reg *CapabilityRegistry) Option {
 	return func(f *Functions) {
 		f.capabilities = reg
+	}
+}
+
+// WithStreamRegistry sets the stream registry for add/remove session stream host functions.
+func WithStreamRegistry(r plugins.StreamRegistry) Option {
+	return func(f *Functions) {
+		f.streamRegistry = r
 	}
 }
 
@@ -143,6 +152,9 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 	// Command registry functions
 	ls.SetField(mod, "list_commands", ls.NewFunction(f.listCommandsFn(pluginName)))
 	ls.SetField(mod, "get_command_help", ls.NewFunction(f.getCommandHelpFn(pluginName)))
+
+	// Register stream management functions (always; guard against nil registry inside).
+	RegisterStreamFuncs(ls, mod, f.streamRegistry)
 
 	ls.SetGlobal("holomush", mod)
 

--- a/internal/plugin/hostfunc/stdlib_streams.go
+++ b/internal/plugin/hostfunc/stdlib_streams.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"context"
+	"log/slog"
+
+	lua "github.com/yuin/gopher-lua"
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+const streamRegistryKey = "__holo_stream_registry"
+
+// RegisterStreamFuncs adds holomush.add_session_stream and holomush.remove_session_stream
+// to an existing holomush module table. r may be nil; calls will be no-ops in that case.
+func RegisterStreamFuncs(ls *lua.LState, holoMushTable *lua.LTable, r plugins.StreamRegistry) {
+	ud := ls.NewUserData()
+	ud.Value = r
+	ls.SetGlobal(streamRegistryKey, ud)
+
+	ls.SetField(holoMushTable, "add_session_stream", ls.NewFunction(addSessionStreamFn))
+	ls.SetField(holoMushTable, "remove_session_stream", ls.NewFunction(removeSessionStreamFn))
+}
+
+func getStreamRegistry(ls *lua.LState) plugins.StreamRegistry {
+	ud := ls.GetGlobal(streamRegistryKey)
+	if ud.Type() == lua.LTUserData {
+		if userData, ok := ud.(*lua.LUserData); ok {
+			if r, ok := userData.Value.(plugins.StreamRegistry); ok {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// addSessionStreamFn implements holomush.add_session_stream(session_id, stream).
+// Returns true on success; returns (nil, error_message) on failure.
+func addSessionStreamFn(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	stream := ls.CheckString(2)
+
+	r := getStreamRegistry(ls)
+	if r == nil {
+		slog.Warn("holomush.add_session_stream: stream registry not initialized")
+		return 0
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := r.AddStream(ctx, sessionID, stream); err != nil {
+		slog.WarnContext(ctx, "holomush.add_session_stream failed",
+			"session_id", sessionID, "stream", stream, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// removeSessionStreamFn implements holomush.remove_session_stream(session_id, stream).
+// Returns true on success; returns (nil, error_message) on failure.
+func removeSessionStreamFn(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	stream := ls.CheckString(2)
+
+	r := getStreamRegistry(ls)
+	if r == nil {
+		slog.Warn("holomush.remove_session_stream: stream registry not initialized")
+		return 0
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := r.RemoveStream(ctx, sessionID, stream); err != nil {
+		slog.WarnContext(ctx, "holomush.remove_session_stream failed",
+			"session_id", sessionID, "stream", stream, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	ls.Push(lua.LTrue)
+	return 1
+}

--- a/internal/plugin/hostfunc/stdlib_streams_test.go
+++ b/internal/plugin/hostfunc/stdlib_streams_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+// mockStreamRegistry records calls for assertion.
+type mockStreamRegistry struct {
+	addCalls    []struct{ sessionID, stream string }
+	removeCalls []struct{ sessionID, stream string }
+	addErr      error
+	removeErr   error
+}
+
+func (m *mockStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
+	m.addCalls = append(m.addCalls, struct{ sessionID, stream string }{sessionID, stream})
+	return m.addErr
+}
+
+func (m *mockStreamRegistry) RemoveStream(_ context.Context, sessionID, stream string) error {
+	m.removeCalls = append(m.removeCalls, struct{ sessionID, stream string }{sessionID, stream})
+	return m.removeErr
+}
+
+// Ensure mockStreamRegistry implements plugins.StreamRegistry.
+var _ plugins.StreamRegistry = (*mockStreamRegistry)(nil)
+
+func newTestLuaState(t *testing.T, reg plugins.StreamRegistry) *lua.LState {
+	t.Helper()
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+	hf := hostfunc.New(nil, hostfunc.WithStreamRegistry(reg))
+	hf.Register(L, "test-plugin")
+	return L
+}
+
+func TestAddSessionStreamCallsRegistryWithCorrectArgs(t *testing.T) {
+	reg := &mockStreamRegistry{}
+	L := newTestLuaState(t, reg)
+
+	err := L.DoString(`holomush.add_session_stream("sess-1", "channel:abc")`)
+	require.NoError(t, err)
+
+	require.Len(t, reg.addCalls, 1)
+	assert.Equal(t, "sess-1", reg.addCalls[0].sessionID)
+	assert.Equal(t, "channel:abc", reg.addCalls[0].stream)
+}
+
+func TestRemoveSessionStreamCallsRegistryWithCorrectArgs(t *testing.T) {
+	reg := &mockStreamRegistry{}
+	L := newTestLuaState(t, reg)
+
+	err := L.DoString(`holomush.remove_session_stream("sess-1", "channel:abc")`)
+	require.NoError(t, err)
+
+	require.Len(t, reg.removeCalls, 1)
+	assert.Equal(t, "sess-1", reg.removeCalls[0].sessionID)
+	assert.Equal(t, "channel:abc", reg.removeCalls[0].stream)
+}
+
+func TestAddSessionStreamReturnsErrorToLuaOnRegistryFailure(t *testing.T) {
+	reg := &mockStreamRegistry{addErr: errors.New("registry error")}
+	L := newTestLuaState(t, reg)
+
+	// Error is returned to Lua as (nil, error_string)
+	err := L.DoString(`
+local ok, errmsg = holomush.add_session_stream("sess-1", "channel:abc")
+assert(ok == nil, "expected nil on error, got: " .. tostring(ok))
+assert(errmsg == "registry error", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+	require.Len(t, reg.addCalls, 1)
+}
+
+func TestRemoveSessionStreamReturnsErrorToLuaOnRegistryFailure(t *testing.T) {
+	reg := &mockStreamRegistry{removeErr: errors.New("registry error")}
+	L := newTestLuaState(t, reg)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.remove_session_stream("sess-1", "channel:abc")
+assert(ok == nil, "expected nil on error, got: " .. tostring(ok))
+assert(errmsg == "registry error", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+	require.Len(t, reg.removeCalls, 1)
+}
+
+func TestAddSessionStreamReturnsTrueOnSuccess(t *testing.T) {
+	reg := &mockStreamRegistry{}
+	L := newTestLuaState(t, reg)
+
+	err := L.DoString(`
+local ok = holomush.add_session_stream("sess-1", "channel:abc")
+assert(ok == true, "expected true on success, got: " .. tostring(ok))
+`)
+	require.NoError(t, err)
+}
+
+func TestRemoveSessionStreamReturnsTrueOnSuccess(t *testing.T) {
+	reg := &mockStreamRegistry{}
+	L := newTestLuaState(t, reg)
+
+	err := L.DoString(`
+local ok = holomush.remove_session_stream("sess-1", "channel:abc")
+assert(ok == true, "expected true on success, got: " .. tostring(ok))
+`)
+	require.NoError(t, err)
+}
+
+func TestAddSessionStreamWithNilRegistryIsNoOp(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.add_session_stream("sess-1", "channel:abc")`)
+	require.NoError(t, err)
+}
+
+func TestRemoveSessionStreamWithNilRegistryIsNoOp(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.remove_session_stream("sess-1", "channel:abc")`)
+	require.NoError(t, err)
+}

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -260,6 +260,77 @@ func (h *Host) Plugins() []string {
 	return names
 }
 
+// QuerySessionStreams calls the plugin's on_session_subscribe(character_id, player_id, session_id)
+// function if defined. Returns the list of stream names the plugin wants added.
+// Returns nil without error if the function is not defined.
+func (h *Host) QuerySessionStreams(ctx context.Context, name string, req plugins.SessionStreamsRequest) ([]string, error) {
+	h.mu.RLock()
+	if h.closed {
+		h.mu.RUnlock()
+		return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").New("host is closed")
+	}
+	p, ok := h.plugins[name]
+	if !ok {
+		h.mu.RUnlock()
+		return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").New("plugin not loaded")
+	}
+	code := p.code
+	requires := p.manifest.Requires
+	h.mu.RUnlock()
+
+	L, err := h.factory.NewState(ctx)
+	if err != nil {
+		return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").Hint("failed to create state").Wrap(err)
+	}
+	defer L.Close()
+	L.SetContext(ctx)
+
+	if h.hostFuncs != nil {
+		h.hostFuncs.Register(L, name, requires...)
+	}
+
+	if err := L.DoString(code); err != nil {
+		return nil, oops.In("lua").With("plugin", name).With("operation", "query_session_streams").Hint("failed to load code").Wrap(err)
+	}
+
+	fn := L.GetGlobal("on_session_subscribe")
+	if fn.Type() == lua.LTNil {
+		return nil, nil
+	}
+
+	if err := L.CallByParam(lua.P{
+		Fn:      fn,
+		NRet:    1,
+		Protect: true,
+	},
+		lua.LString(req.CharacterID),
+		lua.LString(req.PlayerID),
+		lua.LString(req.SessionID),
+	); err != nil {
+		return nil, oops.In("lua").With("plugin", name).With("operation", "on_session_subscribe").Wrap(err)
+	}
+
+	ret := L.Get(-1)
+	L.Pop(1)
+
+	tbl, ok := ret.(*lua.LTable)
+	if !ok {
+		if ret.Type() == lua.LTNil {
+			return nil, nil
+		}
+		return nil, oops.In("lua").With("plugin", name).With("operation", "on_session_subscribe").
+			Errorf("expected table return, got %s", ret.Type())
+	}
+
+	var streams []string
+	tbl.ForEach(func(_ lua.LValue, v lua.LValue) {
+		if s, ok := v.(lua.LString); ok {
+			streams = append(streams, string(s))
+		}
+	})
+	return streams, nil
+}
+
 // Close shuts down the host.
 func (h *Host) Close(_ context.Context) error {
 	h.mu.Lock()

--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -1467,3 +1467,187 @@ end
 	require.NotNil(t, resp)
 	assert.Contains(t, resp.Output, "request_id=")
 }
+
+func TestLuaHostQuerySessionStreamsReturnsErrorWhenHostClosed(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `function on_session_subscribe() return {} end`)
+	host := pluginlua.NewHost()
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	require.NoError(t, host.Load(context.Background(), manifest, dir))
+	closeHost(t, host)
+
+	_, err := host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host is closed")
+}
+
+func TestLuaHostQuerySessionStreamsReturnsErrorForUnknownPlugin(t *testing.T) {
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	_, err := host.QuerySessionStreams(context.Background(), "nonexistent", plugins.SessionStreamsRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin not loaded")
+}
+
+func TestLuaHostQuerySessionStreamsRegistersHostFuncsWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `
+function on_session_subscribe(character_id, player_id, session_id)
+    return {"channel:test"}
+end
+`)
+	hf := hostfunc.New(nil)
+	host := pluginlua.NewHostWithFunctions(hf)
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+		Requires:  []string{"test-svc"},
+	}
+	require.NoError(t, host.Load(context.Background(), manifest, dir))
+
+	streams, err := host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"channel:test"}, streams)
+}
+
+func TestLuaHostQuerySessionStreamsCallsOnSessionSubscribeWhenDefined(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `
+function on_session_subscribe(character_id, player_id, session_id)
+    return {"channel:" .. character_id, "channel:general"}
+end
+`)
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	req := plugins.SessionStreamsRequest{
+		CharacterID: "char-abc",
+		PlayerID:    "player-xyz",
+		SessionID:   "sess-123",
+	}
+	streams, err := host.QuerySessionStreams(context.Background(), "test-plugin", req)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"channel:char-abc", "channel:general"}, streams)
+}
+
+func TestLuaHostQuerySessionStreamsReturnsNilWhenHandlerNotDefined(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `-- no on_session_subscribe defined`)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	streams, err := host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, streams)
+}
+
+func TestLuaHostQuerySessionStreamsReturnsErrorWhenHandlerFails(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `
+function on_session_subscribe(character_id, player_id, session_id)
+    error("db connection failed")
+end
+`)
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	_, err = host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+	})
+	require.Error(t, err)
+}
+
+func TestLuaHostQuerySessionStreamsReturnsErrorWhenHandlerReturnsNonTable(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `
+function on_session_subscribe(character_id, player_id, session_id)
+    return "not a table"
+end
+`)
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	_, err = host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected table return")
+}
+
+func TestLuaHostQuerySessionStreamsReturnsNilWhenHandlerReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLua(t, dir, `
+function on_session_subscribe(character_id, player_id, session_id)
+    return nil
+end
+`)
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "test-plugin",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	streams, err := host.QuerySessionStreams(context.Background(), "test-plugin", plugins.SessionStreamsRequest{
+		CharacterID: "char-abc", PlayerID: "player-xyz", SessionID: "sess-123",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, streams)
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/samber/oops"
@@ -724,6 +725,119 @@ func (m *Manager) ListPlugins() []string {
 	// Sort for deterministic output
 	sort.Strings(names)
 	return names
+}
+
+// TestLoadPlugin injects a plugin directly for unit testing.
+// Only available in tests (but not build-tag restricted to keep it simple).
+func (m *Manager) TestLoadPlugin(name string, manifest *Manifest) {
+	m.mu.Lock()
+	host, ok := m.hosts[manifest.Type]
+	if !ok && manifest.Type == TypeLua && m.luaHost != nil {
+		host, ok = m.luaHost, true
+	}
+	m.mu.Unlock()
+
+	if ok {
+		if err := host.Load(context.Background(), manifest, ""); err != nil {
+			panic("TestLoadPlugin: host.Load failed: " + err.Error())
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.loaded[name] = &DiscoveredPlugin{Manifest: manifest}
+	if ok {
+		m.pluginHosts[name] = host
+	}
+}
+
+// isValidStreamName returns true if name is a valid HoloMUSH stream name.
+// Stream names must be non-empty, contain at least one colon, have no whitespace,
+// and be at most 256 characters long.
+func isValidStreamName(name string) bool {
+	if name == "" || len(name) > 256 {
+		return false
+	}
+	for _, r := range name {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return false
+		}
+	}
+	return strings.Contains(name, ":")
+}
+
+// QuerySessionStreams collects plugin-contributed stream names for a session.
+// Only plugins with SessionStreams: true in their manifest are queried.
+// Plugin errors are logged and skipped (degraded-subscribe policy).
+// Invalid stream names are dropped. Duplicate streams are deduplicated.
+func (m *Manager) QuerySessionStreams(ctx context.Context, req SessionStreamsRequest) []string {
+	m.mu.RLock()
+	type pluginEntry struct {
+		name string
+		host Host
+	}
+	var opted []pluginEntry
+	for name, dp := range m.loaded {
+		if dp.Manifest.SessionStreams {
+			if host, ok := m.pluginHosts[name]; ok {
+				opted = append(opted, pluginEntry{name, host})
+			}
+		}
+	}
+	m.mu.RUnlock()
+
+	if len(opted) == 0 {
+		return nil
+	}
+
+	type result struct {
+		name    string
+		streams []string
+		err     error
+	}
+	results := make(chan result, len(opted))
+	for _, p := range opted {
+		p := p
+		go func() {
+			streams, err := p.host.QuerySessionStreams(ctx, p.name, req)
+			select {
+			case results <- result{name: p.name, streams: streams, err: err}:
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	seen := make(map[string]bool)
+	var merged []string
+	for range opted {
+		var r result
+		select {
+		case r = <-results:
+		case <-ctx.Done():
+			return merged
+		}
+		if r.err != nil {
+			slog.WarnContext(ctx, "plugin stream contribution failed — skipping",
+				"plugin", r.name,
+				"character_id", req.CharacterID,
+				"session_id", req.SessionID,
+				"error", r.err)
+			continue
+		}
+		for _, s := range r.streams {
+			if !isValidStreamName(s) {
+				slog.WarnContext(ctx, "plugin returned invalid stream name — dropping",
+					"plugin", r.name,
+					"stream", s)
+				continue
+			}
+			if !seen[s] {
+				seen[s] = true
+				merged = append(merged, s)
+			}
+		}
+	}
+	return merged
 }
 
 // Close shuts down the manager and all loaded plugins.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -557,6 +557,9 @@ func (h *mockBinaryHost) Close(_ context.Context) error { return h.closeErr }
 func (h *mockBinaryHost) PluginConn(_ string) (grpc.ClientConnInterface, error) {
 	return h.conn, h.connErr
 }
+func (h *mockBinaryHost) QuerySessionStreams(_ context.Context, _ string, _ plugins.SessionStreamsRequest) ([]string, error) {
+	return nil, nil
+}
 
 func TestManagerRegistersProvidedServicesAfterBinaryPluginLoad(t *testing.T) {
 	dir := t.TempDir()
@@ -1225,4 +1228,149 @@ binary-plugin:
 	require.Len(t, registered, 1, "manager should register one provider per declared resource type")
 	assert.Equal(t, "widget", registered[0].Namespace())
 	assert.Contains(t, mgr.ListPlugins(), "good-widget")
+}
+
+// newTestManager creates a Manager with a temp dir for unit tests.
+func newTestManager(t *testing.T) *plugins.Manager {
+	t.Helper()
+	return plugins.NewManager(t.TempDir())
+}
+
+// loadPlugin registers a fake plugin manifest with the manager.
+// sessionStreams controls whether Manifest.SessionStreams is true.
+func loadPlugin(t *testing.T, m *plugins.Manager, name string, plugType plugins.Type, sessionStreams bool) {
+	t.Helper()
+	manifest := &plugins.Manifest{
+		Name:          name,
+		Version:       "1.0.0",
+		Type:          plugType,
+		SessionStreams: sessionStreams,
+	}
+	if plugType == plugins.TypeLua {
+		manifest.LuaPlugin = &plugins.LuaConfig{Entry: "main.lua"}
+	}
+	if plugType == plugins.TypeBinary {
+		manifest.BinaryPlugin = &plugins.BinaryConfig{Executable: "plugin"}
+	}
+	m.TestLoadPlugin(name, manifest)
+}
+
+func TestManagerQuerySessionStreamsReturnsNilWhenNoOptedInPlugins(t *testing.T) {
+	m := newTestManager(t)
+	result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+		CharacterID: "char-1",
+		PlayerID:    "player-1",
+		SessionID:   "sess-1",
+	})
+	assert.Nil(t, result)
+}
+
+func TestManagerQuerySessionStreamsMergesContributionsFromMultiplePlugins(t *testing.T) {
+	m := newTestManager(t)
+
+	hostA := mocks.NewMockHost(t)
+	hostA.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hostA.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+		Return([]string{"channel:abc", "channel:shared"}, nil)
+	m.RegisterHost(plugins.TypeLua, hostA)
+
+	hostB := mocks.NewMockHost(t)
+	hostB.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hostB.EXPECT().QuerySessionStreams(mock.Anything, "plugin-b", mock.Anything).
+		Return([]string{"channel:shared", "channel:def"}, nil) // channel:shared is a duplicate
+	m.RegisterHost(plugins.TypeBinary, hostB)
+
+	loadPlugin(t, m, "plugin-a", plugins.TypeLua, true) // session_streams: true
+	loadPlugin(t, m, "plugin-b", plugins.TypeBinary, true)
+
+	result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+
+	assert.ElementsMatch(t, []string{"channel:abc", "channel:shared", "channel:def"}, result)
+}
+
+func TestManagerQuerySessionStreamsDegradeOnSinglePluginError(t *testing.T) {
+	m := newTestManager(t)
+
+	hostA := mocks.NewMockHost(t)
+	hostA.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hostA.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+		Return(nil, errors.New("db unavailable"))
+	m.RegisterHost(plugins.TypeLua, hostA)
+
+	hostB := mocks.NewMockHost(t)
+	hostB.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hostB.EXPECT().QuerySessionStreams(mock.Anything, "plugin-b", mock.Anything).
+		Return([]string{"channel:abc"}, nil)
+	m.RegisterHost(plugins.TypeBinary, hostB)
+
+	loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)
+	loadPlugin(t, m, "plugin-b", plugins.TypeBinary, true)
+
+	result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+
+	assert.Equal(t, []string{"channel:abc"}, result)
+}
+
+func TestManagerQuerySessionStreamsSkipsOptedOutPlugins(t *testing.T) {
+	m := newTestManager(t)
+
+	host := mocks.NewMockHost(t)
+	host.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// QuerySessionStreams must NOT be called on opted-out plugin
+	m.RegisterHost(plugins.TypeLua, host)
+	loadPlugin(t, m, "plugin-a", plugins.TypeLua, false) // session_streams: false
+
+	result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+	assert.Nil(t, result)
+	// testify/mock will fail the test if QuerySessionStreams was called unexpectedly
+}
+
+func TestManagerQuerySessionStreamsDropsInvalidStreamNames(t *testing.T) {
+	m := newTestManager(t)
+	host := mocks.NewMockHost(t)
+	host.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	host.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+		Return([]string{
+			"",              // empty — invalid
+			"nocolon",       // no colon — invalid
+			"has space:abc", // whitespace — invalid
+			"channel:valid", // valid
+		}, nil)
+	m.RegisterHost(plugins.TypeLua, host)
+	loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)
+
+	result := m.QuerySessionStreams(context.Background(), plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+	assert.Equal(t, []string{"channel:valid"}, result)
+}
+
+func TestManagerQuerySessionStreamsReturnsEarlyOnContextCancellation(t *testing.T) {
+	m := newTestManager(t)
+	host := mocks.NewMockHost(t)
+	host.EXPECT().Load(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// Plugin blocks forever — context cancellation should rescue us.
+	// Use Maybe() since the goroutine may not start before context is cancelled.
+	host.EXPECT().QuerySessionStreams(mock.Anything, "plugin-a", mock.Anything).
+		RunAndReturn(func(ctx context.Context, _ string, _ plugins.SessionStreamsRequest) ([]string, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Maybe()
+	m.RegisterHost(plugins.TypeLua, host)
+	loadPlugin(t, m, "plugin-a", plugins.TypeLua, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	result := m.QuerySessionStreams(ctx, plugins.SessionStreamsRequest{
+		CharacterID: "char-1", PlayerID: "player-1", SessionID: "sess-1",
+	})
+	// Should return empty/partial results instead of blocking
+	assert.Empty(t, result)
 }

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -67,18 +67,19 @@ type ManifestPolicy struct {
 
 // Manifest represents a plugin.yaml file.
 type Manifest struct {
-	Name         string            `yaml:"name" json:"name" jsonschema:"required,minLength=1,maxLength=64,pattern=^[a-z](-?[a-z0-9])*$"`
-	Version      string            `yaml:"version" json:"version" jsonschema:"required,minLength=1"`
-	Type         Type              `yaml:"type" json:"type" jsonschema:"required,enum=lua,enum=binary,enum=setting"`
-	Engine       string            `yaml:"engine,omitempty" json:"engine,omitempty" jsonschema:"description=HoloMUSH version constraint (e.g. >= 2.0.0)"`
-	Dependencies map[string]string `yaml:"dependencies,omitempty" json:"dependencies,omitempty" jsonschema:"description=Plugin dependencies with version constraints"`
-	Events       []string          `yaml:"events,omitempty" json:"events,omitempty"`
-	Policies     []ManifestPolicy  `yaml:"policies,omitempty" json:"policies,omitempty"`
-	Commands     []CommandSpec     `yaml:"commands,omitempty" json:"commands,omitempty" jsonschema:"description=Commands provided by this plugin"`
-	Priority     *LoadPriority     `yaml:"priority,omitempty" json:"priority,omitempty" jsonschema:"description=Load priority (lower loads first)"`
-	LuaPlugin    *LuaConfig        `yaml:"lua-plugin,omitempty" json:"lua-plugin,omitempty"`
-	BinaryPlugin *BinaryConfig     `yaml:"binary-plugin,omitempty" json:"binary-plugin,omitempty"`
-	Setting      *SettingConfig    `yaml:"setting,omitempty" json:"setting,omitempty"`
+	Name          string            `yaml:"name" json:"name" jsonschema:"required,minLength=1,maxLength=64,pattern=^[a-z](-?[a-z0-9])*$"`
+	Version       string            `yaml:"version" json:"version" jsonschema:"required,minLength=1"`
+	Type          Type              `yaml:"type" json:"type" jsonschema:"required,enum=lua,enum=binary,enum=setting"`
+	Engine        string            `yaml:"engine,omitempty" json:"engine,omitempty" jsonschema:"description=HoloMUSH version constraint (e.g. >= 2.0.0)"`
+	Dependencies  map[string]string `yaml:"dependencies,omitempty" json:"dependencies,omitempty" jsonschema:"description=Plugin dependencies with version constraints"`
+	Events        []string          `yaml:"events,omitempty" json:"events,omitempty"`
+	Policies      []ManifestPolicy  `yaml:"policies,omitempty" json:"policies,omitempty"`
+	Commands      []CommandSpec     `yaml:"commands,omitempty" json:"commands,omitempty" jsonschema:"description=Commands provided by this plugin"`
+	Priority      *LoadPriority     `yaml:"priority,omitempty" json:"priority,omitempty" jsonschema:"description=Load priority (lower loads first)"`
+	SessionStreams bool              `yaml:"session_streams,omitempty" json:"session_streams,omitempty" jsonschema:"description=Plugin contributes streams to session subscriptions via QuerySessionStreams"`
+	LuaPlugin     *LuaConfig        `yaml:"lua-plugin,omitempty" json:"lua-plugin,omitempty"`
+	BinaryPlugin  *BinaryConfig     `yaml:"binary-plugin,omitempty" json:"binary-plugin,omitempty"`
+	Setting       *SettingConfig    `yaml:"setting,omitempty" json:"setting,omitempty"`
 
 	// Deprecated: capabilities field is no longer supported. Use policies instead.
 	// This field exists only to detect old-format manifests and produce a clear error.
@@ -281,6 +282,12 @@ func (m *Manifest) Validate() error {
 		}
 	default:
 		return oops.In("manifest").With("name", m.Name).With("type", m.Type).New("type must be 'lua', 'binary', or 'setting'")
+	}
+
+	// Validate session_streams: only lua and binary plugins can contribute session streams.
+	if m.SessionStreams && m.Type != TypeLua && m.Type != TypeBinary {
+		return oops.In("manifest").With("name", m.Name).With("type", m.Type).
+			New("session_streams is only valid for lua and binary plugin types")
 	}
 
 	// Validate load priority: priorities below -999 are reserved (historically for core plugins).

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1736,3 +1736,63 @@ func TestSceneResourceTypeIsNotProtected(t *testing.T) {
 }
 
 // TestManifestTrustFieldParsed is folded into TestParseManifestResourceTypesAndTrust.
+
+func TestParseManifestSessionStreamsValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "accepts lua plugin with session_streams",
+			data: `
+name: my-plugin
+version: 1.0.0
+type: lua
+session_streams: true
+lua-plugin:
+  entry: main.lua
+`,
+		},
+		{
+			name: "accepts binary plugin with session_streams",
+			data: `
+name: my-plugin
+version: 1.0.0
+type: binary
+session_streams: true
+binary-plugin:
+  executable: plugin
+`,
+		},
+		{
+			name: "rejects setting plugin with session_streams",
+			data: `
+name: my-plugin
+version: 1.0.0
+type: setting
+session_streams: true
+setting:
+  display_name: My World
+  content_dir: content
+  starting_location: start
+`,
+			wantErr:   true,
+			errSubstr: "session_streams",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := plugins.ParseManifest([]byte(tt.data))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, m.SessionStreams)
+			}
+		})
+	}
+}

--- a/internal/plugin/mocks/mock_Host.go
+++ b/internal/plugin/mocks/mock_Host.go
@@ -288,6 +288,66 @@ func (_c *MockHost_Plugins_Call) RunAndReturn(run func() []string) *MockHost_Plu
 	return _c
 }
 
+// QuerySessionStreams provides a mock function with given fields: ctx, name, req
+func (_m *MockHost) QuerySessionStreams(ctx context.Context, name string, req plugins.SessionStreamsRequest) ([]string, error) {
+	ret := _m.Called(ctx, name, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QuerySessionStreams")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, plugins.SessionStreamsRequest) ([]string, error)); ok {
+		return rf(ctx, name, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, plugins.SessionStreamsRequest) []string); ok {
+		r0 = rf(ctx, name, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, plugins.SessionStreamsRequest) error); ok {
+		r1 = rf(ctx, name, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockHost_QuerySessionStreams_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QuerySessionStreams'
+type MockHost_QuerySessionStreams_Call struct {
+	*mock.Call
+}
+
+// QuerySessionStreams is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+//   - req plugins.SessionStreamsRequest
+func (_e *MockHost_Expecter) QuerySessionStreams(ctx interface{}, name interface{}, req interface{}) *MockHost_QuerySessionStreams_Call {
+	return &MockHost_QuerySessionStreams_Call{Call: _e.mock.On("QuerySessionStreams", ctx, name, req)}
+}
+
+func (_c *MockHost_QuerySessionStreams_Call) Run(run func(ctx context.Context, name string, req plugins.SessionStreamsRequest)) *MockHost_QuerySessionStreams_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(plugins.SessionStreamsRequest))
+	})
+	return _c
+}
+
+func (_c *MockHost_QuerySessionStreams_Call) Return(_a0 []string, _a1 error) *MockHost_QuerySessionStreams_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockHost_QuerySessionStreams_Call) RunAndReturn(run func(context.Context, string, plugins.SessionStreamsRequest) ([]string, error)) *MockHost_QuerySessionStreams_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Unload provides a mock function with given fields: ctx, name
 func (_m *MockHost) Unload(ctx context.Context, name string) error {
 	ret := _m.Called(ctx, name)

--- a/internal/plugin/otel_middleware.go
+++ b/internal/plugin/otel_middleware.go
@@ -174,6 +174,11 @@ func (m *HostMiddleware) DeliverEvent(ctx context.Context, name string, event pl
 	return emits, nil
 }
 
+// QuerySessionStreams delegates to the wrapped host.
+func (m *HostMiddleware) QuerySessionStreams(ctx context.Context, name string, req SessionStreamsRequest) ([]string, error) {
+	return m.next.QuerySessionStreams(ctx, name, req)
+}
+
 // Plugins delegates to the wrapped host.
 func (m *HostMiddleware) Plugins() []string {
 	return m.next.Plugins()

--- a/internal/plugin/otel_middleware_test.go
+++ b/internal/plugin/otel_middleware_test.go
@@ -182,6 +182,8 @@ func TestHostMiddlewarePassthrough(t *testing.T) {
 	mockHost.EXPECT().Close(mock.Anything).Return(nil)
 	mockHost.EXPECT().Load(mock.Anything, mock.Anything, "dir").Return(nil)
 	mockHost.EXPECT().Unload(mock.Anything, "a").Return(nil)
+	mockHost.EXPECT().QuerySessionStreams(mock.Anything, "a", mock.Anything).
+		Return([]string{"channel:test"}, nil)
 
 	mw, err := plugins.NewHostMiddleware(mockHost, h.tracerProvider, h.meterProvider)
 	require.NoError(t, err)
@@ -189,6 +191,11 @@ func TestHostMiddlewarePassthrough(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, mw.Plugins())
 	require.NoError(t, mw.Load(context.Background(), &plugins.Manifest{}, "dir"))
 	require.NoError(t, mw.Unload(context.Background(), "a"))
+
+	streams, qErr := mw.QuerySessionStreams(context.Background(), "a", plugins.SessionStreamsRequest{})
+	require.NoError(t, qErr)
+	assert.Equal(t, []string{"channel:test"}, streams)
+
 	require.NoError(t, mw.Close(context.Background()))
 }
 

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -81,6 +81,7 @@ type PluginSubsystemConfig struct {
 	Sessions        SessionProvider
 	AdminDeps       AdminDepsProvider
 	Registry        *lifecycle.ReadinessRegistry
+	StreamRegistry  plugins.StreamRegistry
 }
 
 // PluginSubsystem manages the plugin Manager, Lua host, core plugin
@@ -137,12 +138,16 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 	capRegistry.Register("holomush.plugin.v1.AuditService", hostfunc.NewAuditCapability())
 
 	// Create hostfunc bridge.
-	hostFuncs := hostfunc.New(nil, // KV store not yet available
+	hostFuncOpts := []hostfunc.Option{
 		hostfunc.WithEngine(s.cfg.ABAC.Engine()),
 		hostfunc.WithWorldService(s.cfg.World.Service()),
 		hostfunc.WithSessionAccess(sessionStore),
 		hostfunc.WithCapabilities(capRegistry),
-	)
+	}
+	if s.cfg.StreamRegistry != nil {
+		hostFuncOpts = append(hostFuncOpts, hostfunc.WithStreamRegistry(s.cfg.StreamRegistry))
+	}
+	hostFuncs := hostfunc.New(nil, hostFuncOpts...) // KV store not yet available
 
 	// 3. Create Lua host.
 	luaHost := pluginlua.NewHostWithFunctions(hostFuncs)

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -40,6 +40,10 @@ func (h *subscriberHost) DeliverEvent(_ context.Context, _ string, event plugins
 	return h.response, h.err
 }
 
+func (h *subscriberHost) QuerySessionStreams(context.Context, string, plugins.SessionStreamsRequest) ([]string, error) {
+	return nil, nil
+}
+
 func (h *subscriberHost) deliveredCount() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -469,6 +473,10 @@ func (h *slowSubscriberHost) DeliverEvent(_ context.Context, _ string, event plu
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.delivered = append(h.delivered, event)
+	return nil, nil
+}
+
+func (h *slowSubscriberHost) QuerySessionStreams(context.Context, string, plugins.SessionStreamsRequest) ([]string, error) {
 	return nil, nil
 }
 

--- a/pkg/proto/holomush/plugin/v1/hostfunc.pb.go
+++ b/pkg/proto/holomush/plugin/v1/hostfunc.pb.go
@@ -1395,6 +1395,226 @@ func (x *CommandHelpInfo) GetSource() string {
 	return ""
 }
 
+// AddSessionStreamRequest specifies which session and stream to add.
+type AddSessionStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Active session identifier.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Stream name to subscribe to (format: "prefix:id").
+	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddSessionStreamRequest) Reset() {
+	*x = AddSessionStreamRequest{}
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddSessionStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddSessionStreamRequest) ProtoMessage() {}
+
+func (x *AddSessionStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddSessionStreamRequest.ProtoReflect.Descriptor instead.
+func (*AddSessionStreamRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_hostfunc_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *AddSessionStreamRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *AddSessionStreamRequest) GetStream() string {
+	if x != nil {
+		return x.Stream
+	}
+	return ""
+}
+
+// AddSessionStreamResponse indicates success or failure.
+type AddSessionStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the stream was successfully added.
+	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	// Non-empty on error.
+	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddSessionStreamResponse) Reset() {
+	*x = AddSessionStreamResponse{}
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddSessionStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddSessionStreamResponse) ProtoMessage() {}
+
+func (x *AddSessionStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddSessionStreamResponse.ProtoReflect.Descriptor instead.
+func (*AddSessionStreamResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_hostfunc_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *AddSessionStreamResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *AddSessionStreamResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+// RemoveSessionStreamRequest specifies which stream to remove.
+type RemoveSessionStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Active session identifier.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Stream name to unsubscribe from.
+	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveSessionStreamRequest) Reset() {
+	*x = RemoveSessionStreamRequest{}
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveSessionStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveSessionStreamRequest) ProtoMessage() {}
+
+func (x *RemoveSessionStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveSessionStreamRequest.ProtoReflect.Descriptor instead.
+func (*RemoveSessionStreamRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_hostfunc_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *RemoveSessionStreamRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *RemoveSessionStreamRequest) GetStream() string {
+	if x != nil {
+		return x.Stream
+	}
+	return ""
+}
+
+// RemoveSessionStreamResponse indicates success or failure.
+type RemoveSessionStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the stream was successfully removed (true even if not subscribed).
+	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	// Non-empty on error.
+	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveSessionStreamResponse) Reset() {
+	*x = RemoveSessionStreamResponse{}
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveSessionStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveSessionStreamResponse) ProtoMessage() {}
+
+func (x *RemoveSessionStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_hostfunc_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveSessionStreamResponse.ProtoReflect.Descriptor instead.
+func (*RemoveSessionStreamResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_hostfunc_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *RemoveSessionStreamResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *RemoveSessionStreamResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 var File_holomush_plugin_v1_hostfunc_proto protoreflect.FileDescriptor
 
 const file_holomush_plugin_v1_hostfunc_proto_rawDesc = "" +
@@ -1478,13 +1698,27 @@ const file_holomush_plugin_v1_hostfunc_proto_rawDesc = "" +
 	"\x05usage\x18\x03 \x01(\tB\b\xbaH\x05r\x03\x18\x80@R\x05usage\x12&\n" +
 	"\thelp_text\x18\x04 \x01(\tB\t\xbaH\x06r\x04\x18\x80\x80\x04R\bhelpText\x12\"\n" +
 	"\fcapabilities\x18\x05 \x03(\tR\fcapabilities\x12\x1f\n" +
-	"\x06source\x18\x06 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06source*w\n" +
+	"\x06source\x18\x06 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06source\"b\n" +
+	"\x17AddSessionStreamRequest\x12&\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x12\x1f\n" +
+	"\x06stream\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06stream\"J\n" +
+	"\x18AddSessionStreamResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"e\n" +
+	"\x1aRemoveSessionStreamRequest\x12&\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x12\x1f\n" +
+	"\x06stream\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06stream\"M\n" +
+	"\x1bRemoveSessionStreamResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error*w\n" +
 	"\bLogLevel\x12\x19\n" +
 	"\x15LOG_LEVEL_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n" +
 	"\x0eLOG_LEVEL_INFO\x10\x02\x12\x12\n" +
 	"\x0eLOG_LEVEL_WARN\x10\x03\x12\x13\n" +
-	"\x0fLOG_LEVEL_ERROR\x10\x042\xcb\a\n" +
+	"\x0fLOG_LEVEL_ERROR\x10\x042\xb2\t\n" +
 	"\x14HostFunctionsService\x12X\n" +
 	"\tEmitEvent\x12$.holomush.plugin.v1.EmitEventRequest\x1a%.holomush.plugin.v1.EmitEventResponse\x12d\n" +
 	"\rQueryLocation\x12(.holomush.plugin.v1.QueryLocationRequest\x1a).holomush.plugin.v1.QueryLocationResponse\x12g\n" +
@@ -1495,7 +1729,9 @@ const file_holomush_plugin_v1_hostfunc_proto_rawDesc = "" +
 	"\bKVDelete\x12#.holomush.plugin.v1.KVDeleteRequest\x1a$.holomush.plugin.v1.KVDeleteResponse\x12F\n" +
 	"\x03Log\x12\x1e.holomush.plugin.v1.LogRequest\x1a\x1f.holomush.plugin.v1.LogResponse\x12a\n" +
 	"\fListCommands\x12'.holomush.plugin.v1.ListCommandsRequest\x1a(.holomush.plugin.v1.ListCommandsResponse\x12g\n" +
-	"\x0eGetCommandHelp\x12).holomush.plugin.v1.GetCommandHelpRequest\x1a*.holomush.plugin.v1.GetCommandHelpResponseB\xd5\x01\n" +
+	"\x0eGetCommandHelp\x12).holomush.plugin.v1.GetCommandHelpRequest\x1a*.holomush.plugin.v1.GetCommandHelpResponse\x12m\n" +
+	"\x10AddSessionStream\x12+.holomush.plugin.v1.AddSessionStreamRequest\x1a,.holomush.plugin.v1.AddSessionStreamResponse\x12v\n" +
+	"\x13RemoveSessionStream\x12..holomush.plugin.v1.RemoveSessionStreamRequest\x1a/.holomush.plugin.v1.RemoveSessionStreamResponseB\xd5\x01\n" +
 	"\x16com.holomush.plugin.v1B\rHostfuncProtoP\x01ZBgithub.com/holomush/holomush/pkg/proto/holomush/plugin/v1;pluginv1\xa2\x02\x03HPX\xaa\x02\x12Holomush.Plugin.V1\xca\x02\x12Holomush\\Plugin\\V1\xe2\x02\x1eHolomush\\Plugin\\V1\\GPBMetadata\xea\x02\x14Holomush::Plugin::V1b\x06proto3"
 
 var (
@@ -1511,7 +1747,7 @@ func file_holomush_plugin_v1_hostfunc_proto_rawDescGZIP() []byte {
 }
 
 var file_holomush_plugin_v1_hostfunc_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_holomush_plugin_v1_hostfunc_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_holomush_plugin_v1_hostfunc_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_holomush_plugin_v1_hostfunc_proto_goTypes = []any{
 	(LogLevel)(0),                           // 0: holomush.plugin.v1.LogLevel
 	(*EmitEventRequest)(nil),                // 1: holomush.plugin.v1.EmitEventRequest
@@ -1538,16 +1774,20 @@ var file_holomush_plugin_v1_hostfunc_proto_goTypes = []any{
 	(*GetCommandHelpRequest)(nil),           // 22: holomush.plugin.v1.GetCommandHelpRequest
 	(*GetCommandHelpResponse)(nil),          // 23: holomush.plugin.v1.GetCommandHelpResponse
 	(*CommandHelpInfo)(nil),                 // 24: holomush.plugin.v1.CommandHelpInfo
-	nil,                                     // 25: holomush.plugin.v1.LogRequest.FieldsEntry
-	(*EmitEvent)(nil),                       // 26: holomush.plugin.v1.EmitEvent
+	(*AddSessionStreamRequest)(nil),         // 25: holomush.plugin.v1.AddSessionStreamRequest
+	(*AddSessionStreamResponse)(nil),        // 26: holomush.plugin.v1.AddSessionStreamResponse
+	(*RemoveSessionStreamRequest)(nil),      // 27: holomush.plugin.v1.RemoveSessionStreamRequest
+	(*RemoveSessionStreamResponse)(nil),     // 28: holomush.plugin.v1.RemoveSessionStreamResponse
+	nil,                                     // 29: holomush.plugin.v1.LogRequest.FieldsEntry
+	(*EmitEvent)(nil),                       // 30: holomush.plugin.v1.EmitEvent
 }
 var file_holomush_plugin_v1_hostfunc_proto_depIdxs = []int32{
-	26, // 0: holomush.plugin.v1.EmitEventRequest.event:type_name -> holomush.plugin.v1.EmitEvent
+	30, // 0: holomush.plugin.v1.EmitEventRequest.event:type_name -> holomush.plugin.v1.EmitEvent
 	5,  // 1: holomush.plugin.v1.QueryLocationResponse.location:type_name -> holomush.plugin.v1.LocationInfo
 	8,  // 2: holomush.plugin.v1.QueryCharacterResponse.character:type_name -> holomush.plugin.v1.CharacterInfo
 	8,  // 3: holomush.plugin.v1.QueryLocationCharactersResponse.characters:type_name -> holomush.plugin.v1.CharacterInfo
 	0,  // 4: holomush.plugin.v1.LogRequest.level:type_name -> holomush.plugin.v1.LogLevel
-	25, // 5: holomush.plugin.v1.LogRequest.fields:type_name -> holomush.plugin.v1.LogRequest.FieldsEntry
+	29, // 5: holomush.plugin.v1.LogRequest.fields:type_name -> holomush.plugin.v1.LogRequest.FieldsEntry
 	21, // 6: holomush.plugin.v1.ListCommandsResponse.commands:type_name -> holomush.plugin.v1.CommandInfo
 	24, // 7: holomush.plugin.v1.GetCommandHelpResponse.command:type_name -> holomush.plugin.v1.CommandHelpInfo
 	1,  // 8: holomush.plugin.v1.HostFunctionsService.EmitEvent:input_type -> holomush.plugin.v1.EmitEventRequest
@@ -1560,18 +1800,22 @@ var file_holomush_plugin_v1_hostfunc_proto_depIdxs = []int32{
 	17, // 15: holomush.plugin.v1.HostFunctionsService.Log:input_type -> holomush.plugin.v1.LogRequest
 	19, // 16: holomush.plugin.v1.HostFunctionsService.ListCommands:input_type -> holomush.plugin.v1.ListCommandsRequest
 	22, // 17: holomush.plugin.v1.HostFunctionsService.GetCommandHelp:input_type -> holomush.plugin.v1.GetCommandHelpRequest
-	2,  // 18: holomush.plugin.v1.HostFunctionsService.EmitEvent:output_type -> holomush.plugin.v1.EmitEventResponse
-	4,  // 19: holomush.plugin.v1.HostFunctionsService.QueryLocation:output_type -> holomush.plugin.v1.QueryLocationResponse
-	7,  // 20: holomush.plugin.v1.HostFunctionsService.QueryCharacter:output_type -> holomush.plugin.v1.QueryCharacterResponse
-	10, // 21: holomush.plugin.v1.HostFunctionsService.QueryLocationCharacters:output_type -> holomush.plugin.v1.QueryLocationCharactersResponse
-	12, // 22: holomush.plugin.v1.HostFunctionsService.KVGet:output_type -> holomush.plugin.v1.KVGetResponse
-	14, // 23: holomush.plugin.v1.HostFunctionsService.KVSet:output_type -> holomush.plugin.v1.KVSetResponse
-	16, // 24: holomush.plugin.v1.HostFunctionsService.KVDelete:output_type -> holomush.plugin.v1.KVDeleteResponse
-	18, // 25: holomush.plugin.v1.HostFunctionsService.Log:output_type -> holomush.plugin.v1.LogResponse
-	20, // 26: holomush.plugin.v1.HostFunctionsService.ListCommands:output_type -> holomush.plugin.v1.ListCommandsResponse
-	23, // 27: holomush.plugin.v1.HostFunctionsService.GetCommandHelp:output_type -> holomush.plugin.v1.GetCommandHelpResponse
-	18, // [18:28] is the sub-list for method output_type
-	8,  // [8:18] is the sub-list for method input_type
+	25, // 18: holomush.plugin.v1.HostFunctionsService.AddSessionStream:input_type -> holomush.plugin.v1.AddSessionStreamRequest
+	27, // 19: holomush.plugin.v1.HostFunctionsService.RemoveSessionStream:input_type -> holomush.plugin.v1.RemoveSessionStreamRequest
+	2,  // 20: holomush.plugin.v1.HostFunctionsService.EmitEvent:output_type -> holomush.plugin.v1.EmitEventResponse
+	4,  // 21: holomush.plugin.v1.HostFunctionsService.QueryLocation:output_type -> holomush.plugin.v1.QueryLocationResponse
+	7,  // 22: holomush.plugin.v1.HostFunctionsService.QueryCharacter:output_type -> holomush.plugin.v1.QueryCharacterResponse
+	10, // 23: holomush.plugin.v1.HostFunctionsService.QueryLocationCharacters:output_type -> holomush.plugin.v1.QueryLocationCharactersResponse
+	12, // 24: holomush.plugin.v1.HostFunctionsService.KVGet:output_type -> holomush.plugin.v1.KVGetResponse
+	14, // 25: holomush.plugin.v1.HostFunctionsService.KVSet:output_type -> holomush.plugin.v1.KVSetResponse
+	16, // 26: holomush.plugin.v1.HostFunctionsService.KVDelete:output_type -> holomush.plugin.v1.KVDeleteResponse
+	18, // 27: holomush.plugin.v1.HostFunctionsService.Log:output_type -> holomush.plugin.v1.LogResponse
+	20, // 28: holomush.plugin.v1.HostFunctionsService.ListCommands:output_type -> holomush.plugin.v1.ListCommandsResponse
+	23, // 29: holomush.plugin.v1.HostFunctionsService.GetCommandHelp:output_type -> holomush.plugin.v1.GetCommandHelpResponse
+	26, // 30: holomush.plugin.v1.HostFunctionsService.AddSessionStream:output_type -> holomush.plugin.v1.AddSessionStreamResponse
+	28, // 31: holomush.plugin.v1.HostFunctionsService.RemoveSessionStream:output_type -> holomush.plugin.v1.RemoveSessionStreamResponse
+	20, // [20:32] is the sub-list for method output_type
+	8,  // [8:20] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name
@@ -1589,7 +1833,7 @@ func file_holomush_plugin_v1_hostfunc_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_holomush_plugin_v1_hostfunc_proto_rawDesc), len(file_holomush_plugin_v1_hostfunc_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   25,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/holomush/plugin/v1/hostfunc_grpc.pb.go
+++ b/pkg/proto/holomush/plugin/v1/hostfunc_grpc.pb.go
@@ -34,6 +34,8 @@ const (
 	HostFunctionsService_Log_FullMethodName                     = "/holomush.plugin.v1.HostFunctionsService/Log"
 	HostFunctionsService_ListCommands_FullMethodName            = "/holomush.plugin.v1.HostFunctionsService/ListCommands"
 	HostFunctionsService_GetCommandHelp_FullMethodName          = "/holomush.plugin.v1.HostFunctionsService/GetCommandHelp"
+	HostFunctionsService_AddSessionStream_FullMethodName        = "/holomush.plugin.v1.HostFunctionsService/AddSessionStream"
+	HostFunctionsService_RemoveSessionStream_FullMethodName     = "/holomush.plugin.v1.HostFunctionsService/RemoveSessionStream"
 )
 
 // HostFunctionsServiceClient is the client API for HostFunctionsService service.
@@ -66,6 +68,12 @@ type HostFunctionsServiceClient interface {
 	// GetCommandHelp returns detailed help for a specific command.
 	// Requires capability: command.help
 	GetCommandHelp(ctx context.Context, in *GetCommandHelpRequest, opts ...grpc.CallOption) (*GetCommandHelpResponse, error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(ctx context.Context, in *AddSessionStreamRequest, opts ...grpc.CallOption) (*AddSessionStreamResponse, error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(ctx context.Context, in *RemoveSessionStreamRequest, opts ...grpc.CallOption) (*RemoveSessionStreamResponse, error)
 }
 
 type hostFunctionsServiceClient struct {
@@ -176,6 +184,26 @@ func (c *hostFunctionsServiceClient) GetCommandHelp(ctx context.Context, in *Get
 	return out, nil
 }
 
+func (c *hostFunctionsServiceClient) AddSessionStream(ctx context.Context, in *AddSessionStreamRequest, opts ...grpc.CallOption) (*AddSessionStreamResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddSessionStreamResponse)
+	err := c.cc.Invoke(ctx, HostFunctionsService_AddSessionStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *hostFunctionsServiceClient) RemoveSessionStream(ctx context.Context, in *RemoveSessionStreamRequest, opts ...grpc.CallOption) (*RemoveSessionStreamResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RemoveSessionStreamResponse)
+	err := c.cc.Invoke(ctx, HostFunctionsService_RemoveSessionStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // HostFunctionsServiceServer is the server API for HostFunctionsService service.
 // All implementations must embed UnimplementedHostFunctionsServiceServer
 // for forward compatibility.
@@ -206,6 +234,12 @@ type HostFunctionsServiceServer interface {
 	// GetCommandHelp returns detailed help for a specific command.
 	// Requires capability: command.help
 	GetCommandHelp(context.Context, *GetCommandHelpRequest) (*GetCommandHelpResponse, error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *AddSessionStreamRequest) (*AddSessionStreamResponse, error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *RemoveSessionStreamRequest) (*RemoveSessionStreamResponse, error)
 	mustEmbedUnimplementedHostFunctionsServiceServer()
 }
 
@@ -245,6 +279,12 @@ func (UnimplementedHostFunctionsServiceServer) ListCommands(context.Context, *Li
 }
 func (UnimplementedHostFunctionsServiceServer) GetCommandHelp(context.Context, *GetCommandHelpRequest) (*GetCommandHelpResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCommandHelp not implemented")
+}
+func (UnimplementedHostFunctionsServiceServer) AddSessionStream(context.Context, *AddSessionStreamRequest) (*AddSessionStreamResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddSessionStream not implemented")
+}
+func (UnimplementedHostFunctionsServiceServer) RemoveSessionStream(context.Context, *RemoveSessionStreamRequest) (*RemoveSessionStreamResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveSessionStream not implemented")
 }
 func (UnimplementedHostFunctionsServiceServer) mustEmbedUnimplementedHostFunctionsServiceServer() {}
 func (UnimplementedHostFunctionsServiceServer) testEmbeddedByValue()                              {}
@@ -447,6 +487,42 @@ func _HostFunctionsService_GetCommandHelp_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _HostFunctionsService_AddSessionStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddSessionStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostFunctionsServiceServer).AddSessionStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostFunctionsService_AddSessionStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostFunctionsServiceServer).AddSessionStream(ctx, req.(*AddSessionStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _HostFunctionsService_RemoveSessionStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RemoveSessionStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostFunctionsServiceServer).RemoveSessionStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HostFunctionsService_RemoveSessionStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostFunctionsServiceServer).RemoveSessionStream(ctx, req.(*RemoveSessionStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // HostFunctionsService_ServiceDesc is the grpc.ServiceDesc for HostFunctionsService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -493,6 +569,14 @@ var HostFunctionsService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetCommandHelp",
 			Handler:    _HostFunctionsService_GetCommandHelp_Handler,
+		},
+		{
+			MethodName: "AddSessionStream",
+			Handler:    _HostFunctionsService_AddSessionStream_Handler,
+		},
+		{
+			MethodName: "RemoveSessionStream",
+			Handler:    _HostFunctionsService_RemoveSessionStream_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/holomush/plugin/v1/plugin.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin.pb.go
@@ -1406,6 +1406,327 @@ func (*PluginHostServiceKVDeleteResponse) Descriptor() ([]byte, []int) {
 	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{21}
 }
 
+// PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
+type PluginHostServiceAddSessionStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Active session identifier.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Stream name to subscribe to (format: "prefix:id").
+	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceAddSessionStreamRequest) Reset() {
+	*x = PluginHostServiceAddSessionStreamRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceAddSessionStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceAddSessionStreamRequest) ProtoMessage() {}
+
+func (x *PluginHostServiceAddSessionStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceAddSessionStreamRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceAddSessionStreamRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *PluginHostServiceAddSessionStreamRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *PluginHostServiceAddSessionStreamRequest) GetStream() string {
+	if x != nil {
+		return x.Stream
+	}
+	return ""
+}
+
+// PluginHostServiceAddSessionStreamResponse indicates success or failure.
+type PluginHostServiceAddSessionStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the stream was successfully added.
+	Success       bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceAddSessionStreamResponse) Reset() {
+	*x = PluginHostServiceAddSessionStreamResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceAddSessionStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceAddSessionStreamResponse) ProtoMessage() {}
+
+func (x *PluginHostServiceAddSessionStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceAddSessionStreamResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceAddSessionStreamResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *PluginHostServiceAddSessionStreamResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+// PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
+type PluginHostServiceRemoveSessionStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Active session identifier.
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// Stream name to unsubscribe from.
+	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceRemoveSessionStreamRequest) Reset() {
+	*x = PluginHostServiceRemoveSessionStreamRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceRemoveSessionStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceRemoveSessionStreamRequest) ProtoMessage() {}
+
+func (x *PluginHostServiceRemoveSessionStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceRemoveSessionStreamRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceRemoveSessionStreamRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *PluginHostServiceRemoveSessionStreamRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *PluginHostServiceRemoveSessionStreamRequest) GetStream() string {
+	if x != nil {
+		return x.Stream
+	}
+	return ""
+}
+
+// PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
+type PluginHostServiceRemoveSessionStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the stream was successfully removed (true even if not subscribed).
+	Success       bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceRemoveSessionStreamResponse) Reset() {
+	*x = PluginHostServiceRemoveSessionStreamResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceRemoveSessionStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceRemoveSessionStreamResponse) ProtoMessage() {}
+
+func (x *PluginHostServiceRemoveSessionStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceRemoveSessionStreamResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceRemoveSessionStreamResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *PluginHostServiceRemoveSessionStreamResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+// QuerySessionStreamsRequest provides session context for stream contribution.
+type QuerySessionStreamsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identifier of the character entering the session.
+	CharacterId string `protobuf:"bytes,1,opt,name=character_id,json=characterId,proto3" json:"character_id,omitempty"`
+	// Identifier of the player owning the character.
+	PlayerId string `protobuf:"bytes,2,opt,name=player_id,json=playerId,proto3" json:"player_id,omitempty"`
+	// Session identifier.
+	SessionId     string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuerySessionStreamsRequest) Reset() {
+	*x = QuerySessionStreamsRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuerySessionStreamsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuerySessionStreamsRequest) ProtoMessage() {}
+
+func (x *QuerySessionStreamsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuerySessionStreamsRequest.ProtoReflect.Descriptor instead.
+func (*QuerySessionStreamsRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *QuerySessionStreamsRequest) GetCharacterId() string {
+	if x != nil {
+		return x.CharacterId
+	}
+	return ""
+}
+
+func (x *QuerySessionStreamsRequest) GetPlayerId() string {
+	if x != nil {
+		return x.PlayerId
+	}
+	return ""
+}
+
+func (x *QuerySessionStreamsRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+// QuerySessionStreamsResponse returns stream names and an optional error.
+type QuerySessionStreamsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stream names the plugin wants added to this session's subscription.
+	Streams []string `protobuf:"bytes,1,rep,name=streams,proto3" json:"streams,omitempty"`
+	// Non-empty indicates a plugin-reported error. Host degrades (logs + skips).
+	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuerySessionStreamsResponse) Reset() {
+	*x = QuerySessionStreamsResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuerySessionStreamsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuerySessionStreamsResponse) ProtoMessage() {}
+
+func (x *QuerySessionStreamsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuerySessionStreamsResponse.ProtoReflect.Descriptor instead.
+func (*QuerySessionStreamsResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *QuerySessionStreamsResponse) GetStreams() []string {
+	if x != nil {
+		return x.Streams
+	}
+	return nil
+}
+
+func (x *QuerySessionStreamsResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 var File_holomush_plugin_v1_plugin_proto protoreflect.FileDescriptor
 
 const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
@@ -1501,7 +1822,27 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"\vplugin_name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\n" +
 	"pluginName\x12\x19\n" +
 	"\x03key\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x03key\"#\n" +
-	"!PluginHostServiceKVDeleteResponse*\x96\x01\n" +
+	"!PluginHostServiceKVDeleteResponse\"a\n" +
+	"(PluginHostServiceAddSessionStreamRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
+	"\x06stream\x18\x02 \x01(\tR\x06stream\"E\n" +
+	")PluginHostServiceAddSessionStreamResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\"d\n" +
+	"+PluginHostServiceRemoveSessionStreamRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
+	"\x06stream\x18\x02 \x01(\tR\x06stream\"H\n" +
+	",PluginHostServiceRemoveSessionStreamResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\"{\n" +
+	"\x1aQuerySessionStreamsRequest\x12!\n" +
+	"\fcharacter_id\x18\x01 \x01(\tR\vcharacterId\x12\x1b\n" +
+	"\tplayer_id\x18\x02 \x01(\tR\bplayerId\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"M\n" +
+	"\x1bQuerySessionStreamsResponse\x12\x18\n" +
+	"\astreams\x18\x01 \x03(\tR\astreams\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error*\x96\x01\n" +
 	"\rCommandStatus\x12\x1e\n" +
 	"\x1aCOMMAND_STATUS_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11COMMAND_STATUS_OK\x10\x01\x12\x18\n" +
@@ -1511,17 +1852,20 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"\vAuditEffect\x12\x1c\n" +
 	"\x18AUDIT_EFFECT_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11AUDIT_EFFECT_DENY\x10\x01\x12\x16\n" +
-	"\x12AUDIT_EFFECT_ALLOW\x10\x022\xa0\x02\n" +
+	"\x12AUDIT_EFFECT_ALLOW\x10\x022\x98\x03\n" +
 	"\rPluginService\x12I\n" +
 	"\x04Init\x12\x1f.holomush.plugin.v1.InitRequest\x1a .holomush.plugin.v1.InitResponse\x12^\n" +
 	"\vHandleEvent\x12&.holomush.plugin.v1.HandleEventRequest\x1a'.holomush.plugin.v1.HandleEventResponse\x12d\n" +
-	"\rHandleCommand\x12(.holomush.plugin.v1.HandleCommandRequest\x1a).holomush.plugin.v1.HandleCommandResponse2\xd2\x04\n" +
+	"\rHandleCommand\x12(.holomush.plugin.v1.HandleCommandRequest\x1a).holomush.plugin.v1.HandleCommandResponse\x12v\n" +
+	"\x13QuerySessionStreams\x12..holomush.plugin.v1.QuerySessionStreamsRequest\x1a/.holomush.plugin.v1.QuerySessionStreamsResponse2\xff\x06\n" +
 	"\x11PluginHostService\x12z\n" +
 	"\tEmitEvent\x125.holomush.plugin.v1.PluginHostServiceEmitEventRequest\x1a6.holomush.plugin.v1.PluginHostServiceEmitEventResponse\x12h\n" +
 	"\x03Log\x12/.holomush.plugin.v1.PluginHostServiceLogRequest\x1a0.holomush.plugin.v1.PluginHostServiceLogResponse\x12n\n" +
 	"\x05KVGet\x121.holomush.plugin.v1.PluginHostServiceKVGetRequest\x1a2.holomush.plugin.v1.PluginHostServiceKVGetResponse\x12n\n" +
 	"\x05KVSet\x121.holomush.plugin.v1.PluginHostServiceKVSetRequest\x1a2.holomush.plugin.v1.PluginHostServiceKVSetResponse\x12w\n" +
-	"\bKVDelete\x124.holomush.plugin.v1.PluginHostServiceKVDeleteRequest\x1a5.holomush.plugin.v1.PluginHostServiceKVDeleteResponseB\xd3\x01\n" +
+	"\bKVDelete\x124.holomush.plugin.v1.PluginHostServiceKVDeleteRequest\x1a5.holomush.plugin.v1.PluginHostServiceKVDeleteResponse\x12\x8f\x01\n" +
+	"\x10AddSessionStream\x12<.holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest\x1a=.holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse\x12\x98\x01\n" +
+	"\x13RemoveSessionStream\x12?.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest\x1a@.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponseB\xd3\x01\n" +
 	"\x16com.holomush.plugin.v1B\vPluginProtoP\x01ZBgithub.com/holomush/holomush/pkg/proto/holomush/plugin/v1;pluginv1\xa2\x02\x03HPX\xaa\x02\x12Holomush.Plugin.V1\xca\x02\x12Holomush\\Plugin\\V1\xe2\x02\x1eHolomush\\Plugin\\V1\\GPBMetadata\xea\x02\x14Holomush::Plugin::V1b\x06proto3"
 
 var (
@@ -1537,37 +1881,43 @@ func file_holomush_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_holomush_plugin_v1_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_holomush_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_holomush_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_holomush_plugin_v1_plugin_proto_goTypes = []any{
-	(CommandStatus)(0),                         // 0: holomush.plugin.v1.CommandStatus
-	(AuditEffect)(0),                           // 1: holomush.plugin.v1.AuditEffect
-	(*ServiceConfig)(nil),                      // 2: holomush.plugin.v1.ServiceConfig
-	(*InitRequest)(nil),                        // 3: holomush.plugin.v1.InitRequest
-	(*InitResponse)(nil),                       // 4: holomush.plugin.v1.InitResponse
-	(*Event)(nil),                              // 5: holomush.plugin.v1.Event
-	(*EmitEvent)(nil),                          // 6: holomush.plugin.v1.EmitEvent
-	(*HandleEventRequest)(nil),                 // 7: holomush.plugin.v1.HandleEventRequest
-	(*HandleEventResponse)(nil),                // 8: holomush.plugin.v1.HandleEventResponse
-	(*CommandRequest)(nil),                     // 9: holomush.plugin.v1.CommandRequest
-	(*CommandResponse)(nil),                    // 10: holomush.plugin.v1.CommandResponse
-	(*AuditDecisionHint)(nil),                  // 11: holomush.plugin.v1.AuditDecisionHint
-	(*HandleCommandRequest)(nil),               // 12: holomush.plugin.v1.HandleCommandRequest
-	(*HandleCommandResponse)(nil),              // 13: holomush.plugin.v1.HandleCommandResponse
-	(*PluginHostServiceEmitEventRequest)(nil),  // 14: holomush.plugin.v1.PluginHostServiceEmitEventRequest
-	(*PluginHostServiceEmitEventResponse)(nil), // 15: holomush.plugin.v1.PluginHostServiceEmitEventResponse
-	(*PluginHostServiceLogRequest)(nil),        // 16: holomush.plugin.v1.PluginHostServiceLogRequest
-	(*PluginHostServiceLogResponse)(nil),       // 17: holomush.plugin.v1.PluginHostServiceLogResponse
-	(*PluginHostServiceKVGetRequest)(nil),      // 18: holomush.plugin.v1.PluginHostServiceKVGetRequest
-	(*PluginHostServiceKVGetResponse)(nil),     // 19: holomush.plugin.v1.PluginHostServiceKVGetResponse
-	(*PluginHostServiceKVSetRequest)(nil),      // 20: holomush.plugin.v1.PluginHostServiceKVSetRequest
-	(*PluginHostServiceKVSetResponse)(nil),     // 21: holomush.plugin.v1.PluginHostServiceKVSetResponse
-	(*PluginHostServiceKVDeleteRequest)(nil),   // 22: holomush.plugin.v1.PluginHostServiceKVDeleteRequest
-	(*PluginHostServiceKVDeleteResponse)(nil),  // 23: holomush.plugin.v1.PluginHostServiceKVDeleteResponse
-	nil, // 24: holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
-	nil, // 25: holomush.plugin.v1.AuditDecisionHint.AttributesEntry
+	(CommandStatus)(0),                                   // 0: holomush.plugin.v1.CommandStatus
+	(AuditEffect)(0),                                     // 1: holomush.plugin.v1.AuditEffect
+	(*ServiceConfig)(nil),                                // 2: holomush.plugin.v1.ServiceConfig
+	(*InitRequest)(nil),                                  // 3: holomush.plugin.v1.InitRequest
+	(*InitResponse)(nil),                                 // 4: holomush.plugin.v1.InitResponse
+	(*Event)(nil),                                        // 5: holomush.plugin.v1.Event
+	(*EmitEvent)(nil),                                    // 6: holomush.plugin.v1.EmitEvent
+	(*HandleEventRequest)(nil),                           // 7: holomush.plugin.v1.HandleEventRequest
+	(*HandleEventResponse)(nil),                          // 8: holomush.plugin.v1.HandleEventResponse
+	(*CommandRequest)(nil),                               // 9: holomush.plugin.v1.CommandRequest
+	(*CommandResponse)(nil),                              // 10: holomush.plugin.v1.CommandResponse
+	(*AuditDecisionHint)(nil),                            // 11: holomush.plugin.v1.AuditDecisionHint
+	(*HandleCommandRequest)(nil),                         // 12: holomush.plugin.v1.HandleCommandRequest
+	(*HandleCommandResponse)(nil),                        // 13: holomush.plugin.v1.HandleCommandResponse
+	(*PluginHostServiceEmitEventRequest)(nil),            // 14: holomush.plugin.v1.PluginHostServiceEmitEventRequest
+	(*PluginHostServiceEmitEventResponse)(nil),           // 15: holomush.plugin.v1.PluginHostServiceEmitEventResponse
+	(*PluginHostServiceLogRequest)(nil),                  // 16: holomush.plugin.v1.PluginHostServiceLogRequest
+	(*PluginHostServiceLogResponse)(nil),                 // 17: holomush.plugin.v1.PluginHostServiceLogResponse
+	(*PluginHostServiceKVGetRequest)(nil),                // 18: holomush.plugin.v1.PluginHostServiceKVGetRequest
+	(*PluginHostServiceKVGetResponse)(nil),               // 19: holomush.plugin.v1.PluginHostServiceKVGetResponse
+	(*PluginHostServiceKVSetRequest)(nil),                // 20: holomush.plugin.v1.PluginHostServiceKVSetRequest
+	(*PluginHostServiceKVSetResponse)(nil),               // 21: holomush.plugin.v1.PluginHostServiceKVSetResponse
+	(*PluginHostServiceKVDeleteRequest)(nil),             // 22: holomush.plugin.v1.PluginHostServiceKVDeleteRequest
+	(*PluginHostServiceKVDeleteResponse)(nil),            // 23: holomush.plugin.v1.PluginHostServiceKVDeleteResponse
+	(*PluginHostServiceAddSessionStreamRequest)(nil),     // 24: holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
+	(*PluginHostServiceAddSessionStreamResponse)(nil),    // 25: holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
+	(*PluginHostServiceRemoveSessionStreamRequest)(nil),  // 26: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
+	(*PluginHostServiceRemoveSessionStreamResponse)(nil), // 27: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
+	(*QuerySessionStreamsRequest)(nil),                   // 28: holomush.plugin.v1.QuerySessionStreamsRequest
+	(*QuerySessionStreamsResponse)(nil),                  // 29: holomush.plugin.v1.QuerySessionStreamsResponse
+	nil,                                                  // 30: holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
+	nil,                                                  // 31: holomush.plugin.v1.AuditDecisionHint.AttributesEntry
 }
 var file_holomush_plugin_v1_plugin_proto_depIdxs = []int32{
-	24, // 0: holomush.plugin.v1.ServiceConfig.required_services:type_name -> holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
+	30, // 0: holomush.plugin.v1.ServiceConfig.required_services:type_name -> holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
 	2,  // 1: holomush.plugin.v1.InitRequest.config:type_name -> holomush.plugin.v1.ServiceConfig
 	5,  // 2: holomush.plugin.v1.HandleEventRequest.event:type_name -> holomush.plugin.v1.Event
 	6,  // 3: holomush.plugin.v1.HandleEventResponse.emit_events:type_name -> holomush.plugin.v1.EmitEvent
@@ -1575,27 +1925,33 @@ var file_holomush_plugin_v1_plugin_proto_depIdxs = []int32{
 	6,  // 5: holomush.plugin.v1.CommandResponse.events:type_name -> holomush.plugin.v1.EmitEvent
 	11, // 6: holomush.plugin.v1.CommandResponse.audit_hints:type_name -> holomush.plugin.v1.AuditDecisionHint
 	1,  // 7: holomush.plugin.v1.AuditDecisionHint.effect:type_name -> holomush.plugin.v1.AuditEffect
-	25, // 8: holomush.plugin.v1.AuditDecisionHint.attributes:type_name -> holomush.plugin.v1.AuditDecisionHint.AttributesEntry
+	31, // 8: holomush.plugin.v1.AuditDecisionHint.attributes:type_name -> holomush.plugin.v1.AuditDecisionHint.AttributesEntry
 	9,  // 9: holomush.plugin.v1.HandleCommandRequest.command:type_name -> holomush.plugin.v1.CommandRequest
 	10, // 10: holomush.plugin.v1.HandleCommandResponse.response:type_name -> holomush.plugin.v1.CommandResponse
 	3,  // 11: holomush.plugin.v1.PluginService.Init:input_type -> holomush.plugin.v1.InitRequest
 	7,  // 12: holomush.plugin.v1.PluginService.HandleEvent:input_type -> holomush.plugin.v1.HandleEventRequest
 	12, // 13: holomush.plugin.v1.PluginService.HandleCommand:input_type -> holomush.plugin.v1.HandleCommandRequest
-	14, // 14: holomush.plugin.v1.PluginHostService.EmitEvent:input_type -> holomush.plugin.v1.PluginHostServiceEmitEventRequest
-	16, // 15: holomush.plugin.v1.PluginHostService.Log:input_type -> holomush.plugin.v1.PluginHostServiceLogRequest
-	18, // 16: holomush.plugin.v1.PluginHostService.KVGet:input_type -> holomush.plugin.v1.PluginHostServiceKVGetRequest
-	20, // 17: holomush.plugin.v1.PluginHostService.KVSet:input_type -> holomush.plugin.v1.PluginHostServiceKVSetRequest
-	22, // 18: holomush.plugin.v1.PluginHostService.KVDelete:input_type -> holomush.plugin.v1.PluginHostServiceKVDeleteRequest
-	4,  // 19: holomush.plugin.v1.PluginService.Init:output_type -> holomush.plugin.v1.InitResponse
-	8,  // 20: holomush.plugin.v1.PluginService.HandleEvent:output_type -> holomush.plugin.v1.HandleEventResponse
-	13, // 21: holomush.plugin.v1.PluginService.HandleCommand:output_type -> holomush.plugin.v1.HandleCommandResponse
-	15, // 22: holomush.plugin.v1.PluginHostService.EmitEvent:output_type -> holomush.plugin.v1.PluginHostServiceEmitEventResponse
-	17, // 23: holomush.plugin.v1.PluginHostService.Log:output_type -> holomush.plugin.v1.PluginHostServiceLogResponse
-	19, // 24: holomush.plugin.v1.PluginHostService.KVGet:output_type -> holomush.plugin.v1.PluginHostServiceKVGetResponse
-	21, // 25: holomush.plugin.v1.PluginHostService.KVSet:output_type -> holomush.plugin.v1.PluginHostServiceKVSetResponse
-	23, // 26: holomush.plugin.v1.PluginHostService.KVDelete:output_type -> holomush.plugin.v1.PluginHostServiceKVDeleteResponse
-	19, // [19:27] is the sub-list for method output_type
-	11, // [11:19] is the sub-list for method input_type
+	28, // 14: holomush.plugin.v1.PluginService.QuerySessionStreams:input_type -> holomush.plugin.v1.QuerySessionStreamsRequest
+	14, // 15: holomush.plugin.v1.PluginHostService.EmitEvent:input_type -> holomush.plugin.v1.PluginHostServiceEmitEventRequest
+	16, // 16: holomush.plugin.v1.PluginHostService.Log:input_type -> holomush.plugin.v1.PluginHostServiceLogRequest
+	18, // 17: holomush.plugin.v1.PluginHostService.KVGet:input_type -> holomush.plugin.v1.PluginHostServiceKVGetRequest
+	20, // 18: holomush.plugin.v1.PluginHostService.KVSet:input_type -> holomush.plugin.v1.PluginHostServiceKVSetRequest
+	22, // 19: holomush.plugin.v1.PluginHostService.KVDelete:input_type -> holomush.plugin.v1.PluginHostServiceKVDeleteRequest
+	24, // 20: holomush.plugin.v1.PluginHostService.AddSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
+	26, // 21: holomush.plugin.v1.PluginHostService.RemoveSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
+	4,  // 22: holomush.plugin.v1.PluginService.Init:output_type -> holomush.plugin.v1.InitResponse
+	8,  // 23: holomush.plugin.v1.PluginService.HandleEvent:output_type -> holomush.plugin.v1.HandleEventResponse
+	13, // 24: holomush.plugin.v1.PluginService.HandleCommand:output_type -> holomush.plugin.v1.HandleCommandResponse
+	29, // 25: holomush.plugin.v1.PluginService.QuerySessionStreams:output_type -> holomush.plugin.v1.QuerySessionStreamsResponse
+	15, // 26: holomush.plugin.v1.PluginHostService.EmitEvent:output_type -> holomush.plugin.v1.PluginHostServiceEmitEventResponse
+	17, // 27: holomush.plugin.v1.PluginHostService.Log:output_type -> holomush.plugin.v1.PluginHostServiceLogResponse
+	19, // 28: holomush.plugin.v1.PluginHostService.KVGet:output_type -> holomush.plugin.v1.PluginHostServiceKVGetResponse
+	21, // 29: holomush.plugin.v1.PluginHostService.KVSet:output_type -> holomush.plugin.v1.PluginHostServiceKVSetResponse
+	23, // 30: holomush.plugin.v1.PluginHostService.KVDelete:output_type -> holomush.plugin.v1.PluginHostServiceKVDeleteResponse
+	25, // 31: holomush.plugin.v1.PluginHostService.AddSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
+	27, // 32: holomush.plugin.v1.PluginHostService.RemoveSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
+	22, // [22:33] is the sub-list for method output_type
+	11, // [11:22] is the sub-list for method input_type
 	11, // [11:11] is the sub-list for extension type_name
 	11, // [11:11] is the sub-list for extension extendee
 	0,  // [0:11] is the sub-list for field type_name
@@ -1612,7 +1968,7 @@ func file_holomush_plugin_v1_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_holomush_plugin_v1_plugin_proto_rawDesc), len(file_holomush_plugin_v1_plugin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   24,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
@@ -24,9 +24,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	PluginService_Init_FullMethodName          = "/holomush.plugin.v1.PluginService/Init"
-	PluginService_HandleEvent_FullMethodName   = "/holomush.plugin.v1.PluginService/HandleEvent"
-	PluginService_HandleCommand_FullMethodName = "/holomush.plugin.v1.PluginService/HandleCommand"
+	PluginService_Init_FullMethodName                = "/holomush.plugin.v1.PluginService/Init"
+	PluginService_HandleEvent_FullMethodName         = "/holomush.plugin.v1.PluginService/HandleEvent"
+	PluginService_HandleCommand_FullMethodName       = "/holomush.plugin.v1.PluginService/HandleCommand"
+	PluginService_QuerySessionStreams_FullMethodName = "/holomush.plugin.v1.PluginService/QuerySessionStreams"
 )
 
 // PluginServiceClient is the client API for PluginService service.
@@ -44,6 +45,10 @@ type PluginServiceClient interface {
 	HandleEvent(ctx context.Context, in *HandleEventRequest, opts ...grpc.CallOption) (*HandleEventResponse, error)
 	// HandleCommand delivers a command to the plugin.
 	HandleCommand(ctx context.Context, in *HandleCommandRequest, opts ...grpc.CallOption) (*HandleCommandResponse, error)
+	// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+	// Called once at session establishment, before LISTEN setup.
+	// Only invoked for plugins that declare session_streams: true in their manifest.
+	QuerySessionStreams(ctx context.Context, in *QuerySessionStreamsRequest, opts ...grpc.CallOption) (*QuerySessionStreamsResponse, error)
 }
 
 type pluginServiceClient struct {
@@ -84,6 +89,16 @@ func (c *pluginServiceClient) HandleCommand(ctx context.Context, in *HandleComma
 	return out, nil
 }
 
+func (c *pluginServiceClient) QuerySessionStreams(ctx context.Context, in *QuerySessionStreamsRequest, opts ...grpc.CallOption) (*QuerySessionStreamsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QuerySessionStreamsResponse)
+	err := c.cc.Invoke(ctx, PluginService_QuerySessionStreams_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginServiceServer is the server API for PluginService service.
 // All implementations must embed UnimplementedPluginServiceServer
 // for forward compatibility.
@@ -99,6 +114,10 @@ type PluginServiceServer interface {
 	HandleEvent(context.Context, *HandleEventRequest) (*HandleEventResponse, error)
 	// HandleCommand delivers a command to the plugin.
 	HandleCommand(context.Context, *HandleCommandRequest) (*HandleCommandResponse, error)
+	// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+	// Called once at session establishment, before LISTEN setup.
+	// Only invoked for plugins that declare session_streams: true in their manifest.
+	QuerySessionStreams(context.Context, *QuerySessionStreamsRequest) (*QuerySessionStreamsResponse, error)
 	mustEmbedUnimplementedPluginServiceServer()
 }
 
@@ -117,6 +136,9 @@ func (UnimplementedPluginServiceServer) HandleEvent(context.Context, *HandleEven
 }
 func (UnimplementedPluginServiceServer) HandleCommand(context.Context, *HandleCommandRequest) (*HandleCommandResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method HandleCommand not implemented")
+}
+func (UnimplementedPluginServiceServer) QuerySessionStreams(context.Context, *QuerySessionStreamsRequest) (*QuerySessionStreamsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method QuerySessionStreams not implemented")
 }
 func (UnimplementedPluginServiceServer) mustEmbedUnimplementedPluginServiceServer() {}
 func (UnimplementedPluginServiceServer) testEmbeddedByValue()                       {}
@@ -193,6 +215,24 @@ func _PluginService_HandleCommand_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginService_QuerySessionStreams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QuerySessionStreamsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginServiceServer).QuerySessionStreams(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginService_QuerySessionStreams_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginServiceServer).QuerySessionStreams(ctx, req.(*QuerySessionStreamsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginService_ServiceDesc is the grpc.ServiceDesc for PluginService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -212,17 +252,23 @@ var PluginService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "HandleCommand",
 			Handler:    _PluginService_HandleCommand_Handler,
 		},
+		{
+			MethodName: "QuerySessionStreams",
+			Handler:    _PluginService_QuerySessionStreams_Handler,
+		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "holomush/plugin/v1/plugin.proto",
 }
 
 const (
-	PluginHostService_EmitEvent_FullMethodName = "/holomush.plugin.v1.PluginHostService/EmitEvent"
-	PluginHostService_Log_FullMethodName       = "/holomush.plugin.v1.PluginHostService/Log"
-	PluginHostService_KVGet_FullMethodName     = "/holomush.plugin.v1.PluginHostService/KVGet"
-	PluginHostService_KVSet_FullMethodName     = "/holomush.plugin.v1.PluginHostService/KVSet"
-	PluginHostService_KVDelete_FullMethodName  = "/holomush.plugin.v1.PluginHostService/KVDelete"
+	PluginHostService_EmitEvent_FullMethodName           = "/holomush.plugin.v1.PluginHostService/EmitEvent"
+	PluginHostService_Log_FullMethodName                 = "/holomush.plugin.v1.PluginHostService/Log"
+	PluginHostService_KVGet_FullMethodName               = "/holomush.plugin.v1.PluginHostService/KVGet"
+	PluginHostService_KVSet_FullMethodName               = "/holomush.plugin.v1.PluginHostService/KVSet"
+	PluginHostService_KVDelete_FullMethodName            = "/holomush.plugin.v1.PluginHostService/KVDelete"
+	PluginHostService_AddSessionStream_FullMethodName    = "/holomush.plugin.v1.PluginHostService/AddSessionStream"
+	PluginHostService_RemoveSessionStream_FullMethodName = "/holomush.plugin.v1.PluginHostService/RemoveSessionStream"
 )
 
 // PluginHostServiceClient is the client API for PluginHostService service.
@@ -242,6 +288,12 @@ type PluginHostServiceClient interface {
 	KVSet(ctx context.Context, in *PluginHostServiceKVSetRequest, opts ...grpc.CallOption) (*PluginHostServiceKVSetResponse, error)
 	// KVDelete removes a value from the plugin's key-value store.
 	KVDelete(ctx context.Context, in *PluginHostServiceKVDeleteRequest, opts ...grpc.CallOption) (*PluginHostServiceKVDeleteResponse, error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(ctx context.Context, in *PluginHostServiceAddSessionStreamRequest, opts ...grpc.CallOption) (*PluginHostServiceAddSessionStreamResponse, error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(ctx context.Context, in *PluginHostServiceRemoveSessionStreamRequest, opts ...grpc.CallOption) (*PluginHostServiceRemoveSessionStreamResponse, error)
 }
 
 type pluginHostServiceClient struct {
@@ -302,6 +354,26 @@ func (c *pluginHostServiceClient) KVDelete(ctx context.Context, in *PluginHostSe
 	return out, nil
 }
 
+func (c *pluginHostServiceClient) AddSessionStream(ctx context.Context, in *PluginHostServiceAddSessionStreamRequest, opts ...grpc.CallOption) (*PluginHostServiceAddSessionStreamResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServiceAddSessionStreamResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_AddSessionStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *pluginHostServiceClient) RemoveSessionStream(ctx context.Context, in *PluginHostServiceRemoveSessionStreamRequest, opts ...grpc.CallOption) (*PluginHostServiceRemoveSessionStreamResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServiceRemoveSessionStreamResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_RemoveSessionStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginHostServiceServer is the server API for PluginHostService service.
 // All implementations must embed UnimplementedPluginHostServiceServer
 // for forward compatibility.
@@ -319,6 +391,12 @@ type PluginHostServiceServer interface {
 	KVSet(context.Context, *PluginHostServiceKVSetRequest) (*PluginHostServiceKVSetResponse, error)
 	// KVDelete removes a value from the plugin's key-value store.
 	KVDelete(context.Context, *PluginHostServiceKVDeleteRequest) (*PluginHostServiceKVDeleteResponse, error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *PluginHostServiceAddSessionStreamRequest) (*PluginHostServiceAddSessionStreamResponse, error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *PluginHostServiceRemoveSessionStreamRequest) (*PluginHostServiceRemoveSessionStreamResponse, error)
 	mustEmbedUnimplementedPluginHostServiceServer()
 }
 
@@ -343,6 +421,12 @@ func (UnimplementedPluginHostServiceServer) KVSet(context.Context, *PluginHostSe
 }
 func (UnimplementedPluginHostServiceServer) KVDelete(context.Context, *PluginHostServiceKVDeleteRequest) (*PluginHostServiceKVDeleteResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method KVDelete not implemented")
+}
+func (UnimplementedPluginHostServiceServer) AddSessionStream(context.Context, *PluginHostServiceAddSessionStreamRequest) (*PluginHostServiceAddSessionStreamResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddSessionStream not implemented")
+}
+func (UnimplementedPluginHostServiceServer) RemoveSessionStream(context.Context, *PluginHostServiceRemoveSessionStreamRequest) (*PluginHostServiceRemoveSessionStreamResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveSessionStream not implemented")
 }
 func (UnimplementedPluginHostServiceServer) mustEmbedUnimplementedPluginHostServiceServer() {}
 func (UnimplementedPluginHostServiceServer) testEmbeddedByValue()                           {}
@@ -455,6 +539,42 @@ func _PluginHostService_KVDelete_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginHostService_AddSessionStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServiceAddSessionStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).AddSessionStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_AddSessionStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).AddSessionStream(ctx, req.(*PluginHostServiceAddSessionStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PluginHostService_RemoveSessionStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServiceRemoveSessionStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).RemoveSessionStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_RemoveSessionStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).RemoveSessionStream(ctx, req.(*PluginHostServiceRemoveSessionStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginHostService_ServiceDesc is the grpc.ServiceDesc for PluginHostService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -481,6 +601,14 @@ var PluginHostService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "KVDelete",
 			Handler:    _PluginHostService_KVDelete_Handler,
+		},
+		{
+			MethodName: "AddSessionStream",
+			Handler:    _PluginHostService_AddSessionStream_Handler,
+		},
+		{
+			MethodName: "RemoveSessionStream",
+			Handler:    _PluginHostService_RemoveSessionStream_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/holomush/plugin/v1/pluginv1connect/hostfunc.connect.go
+++ b/pkg/proto/holomush/plugin/v1/pluginv1connect/hostfunc.connect.go
@@ -68,6 +68,12 @@ const (
 	// HostFunctionsServiceGetCommandHelpProcedure is the fully-qualified name of the
 	// HostFunctionsService's GetCommandHelp RPC.
 	HostFunctionsServiceGetCommandHelpProcedure = "/holomush.plugin.v1.HostFunctionsService/GetCommandHelp"
+	// HostFunctionsServiceAddSessionStreamProcedure is the fully-qualified name of the
+	// HostFunctionsService's AddSessionStream RPC.
+	HostFunctionsServiceAddSessionStreamProcedure = "/holomush.plugin.v1.HostFunctionsService/AddSessionStream"
+	// HostFunctionsServiceRemoveSessionStreamProcedure is the fully-qualified name of the
+	// HostFunctionsService's RemoveSessionStream RPC.
+	HostFunctionsServiceRemoveSessionStreamProcedure = "/holomush.plugin.v1.HostFunctionsService/RemoveSessionStream"
 )
 
 // HostFunctionsServiceClient is a client for the holomush.plugin.v1.HostFunctionsService service.
@@ -94,6 +100,12 @@ type HostFunctionsServiceClient interface {
 	// GetCommandHelp returns detailed help for a specific command.
 	// Requires capability: command.help
 	GetCommandHelp(context.Context, *connect.Request[v1.GetCommandHelpRequest]) (*connect.Response[v1.GetCommandHelpResponse], error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *connect.Request[v1.AddSessionStreamRequest]) (*connect.Response[v1.AddSessionStreamResponse], error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *connect.Request[v1.RemoveSessionStreamRequest]) (*connect.Response[v1.RemoveSessionStreamResponse], error)
 }
 
 // NewHostFunctionsServiceClient constructs a client for the holomush.plugin.v1.HostFunctionsService
@@ -167,6 +179,18 @@ func NewHostFunctionsServiceClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(hostFunctionsServiceMethods.ByName("GetCommandHelp")),
 			connect.WithClientOptions(opts...),
 		),
+		addSessionStream: connect.NewClient[v1.AddSessionStreamRequest, v1.AddSessionStreamResponse](
+			httpClient,
+			baseURL+HostFunctionsServiceAddSessionStreamProcedure,
+			connect.WithSchema(hostFunctionsServiceMethods.ByName("AddSessionStream")),
+			connect.WithClientOptions(opts...),
+		),
+		removeSessionStream: connect.NewClient[v1.RemoveSessionStreamRequest, v1.RemoveSessionStreamResponse](
+			httpClient,
+			baseURL+HostFunctionsServiceRemoveSessionStreamProcedure,
+			connect.WithSchema(hostFunctionsServiceMethods.ByName("RemoveSessionStream")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -182,6 +206,8 @@ type hostFunctionsServiceClient struct {
 	log                     *connect.Client[v1.LogRequest, v1.LogResponse]
 	listCommands            *connect.Client[v1.ListCommandsRequest, v1.ListCommandsResponse]
 	getCommandHelp          *connect.Client[v1.GetCommandHelpRequest, v1.GetCommandHelpResponse]
+	addSessionStream        *connect.Client[v1.AddSessionStreamRequest, v1.AddSessionStreamResponse]
+	removeSessionStream     *connect.Client[v1.RemoveSessionStreamRequest, v1.RemoveSessionStreamResponse]
 }
 
 // EmitEvent calls holomush.plugin.v1.HostFunctionsService.EmitEvent.
@@ -234,6 +260,16 @@ func (c *hostFunctionsServiceClient) GetCommandHelp(ctx context.Context, req *co
 	return c.getCommandHelp.CallUnary(ctx, req)
 }
 
+// AddSessionStream calls holomush.plugin.v1.HostFunctionsService.AddSessionStream.
+func (c *hostFunctionsServiceClient) AddSessionStream(ctx context.Context, req *connect.Request[v1.AddSessionStreamRequest]) (*connect.Response[v1.AddSessionStreamResponse], error) {
+	return c.addSessionStream.CallUnary(ctx, req)
+}
+
+// RemoveSessionStream calls holomush.plugin.v1.HostFunctionsService.RemoveSessionStream.
+func (c *hostFunctionsServiceClient) RemoveSessionStream(ctx context.Context, req *connect.Request[v1.RemoveSessionStreamRequest]) (*connect.Response[v1.RemoveSessionStreamResponse], error) {
+	return c.removeSessionStream.CallUnary(ctx, req)
+}
+
 // HostFunctionsServiceHandler is an implementation of the holomush.plugin.v1.HostFunctionsService
 // service.
 type HostFunctionsServiceHandler interface {
@@ -259,6 +295,12 @@ type HostFunctionsServiceHandler interface {
 	// GetCommandHelp returns detailed help for a specific command.
 	// Requires capability: command.help
 	GetCommandHelp(context.Context, *connect.Request[v1.GetCommandHelpRequest]) (*connect.Response[v1.GetCommandHelpResponse], error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *connect.Request[v1.AddSessionStreamRequest]) (*connect.Response[v1.AddSessionStreamResponse], error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *connect.Request[v1.RemoveSessionStreamRequest]) (*connect.Response[v1.RemoveSessionStreamResponse], error)
 }
 
 // NewHostFunctionsServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -328,6 +370,18 @@ func NewHostFunctionsServiceHandler(svc HostFunctionsServiceHandler, opts ...con
 		connect.WithSchema(hostFunctionsServiceMethods.ByName("GetCommandHelp")),
 		connect.WithHandlerOptions(opts...),
 	)
+	hostFunctionsServiceAddSessionStreamHandler := connect.NewUnaryHandler(
+		HostFunctionsServiceAddSessionStreamProcedure,
+		svc.AddSessionStream,
+		connect.WithSchema(hostFunctionsServiceMethods.ByName("AddSessionStream")),
+		connect.WithHandlerOptions(opts...),
+	)
+	hostFunctionsServiceRemoveSessionStreamHandler := connect.NewUnaryHandler(
+		HostFunctionsServiceRemoveSessionStreamProcedure,
+		svc.RemoveSessionStream,
+		connect.WithSchema(hostFunctionsServiceMethods.ByName("RemoveSessionStream")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/holomush.plugin.v1.HostFunctionsService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case HostFunctionsServiceEmitEventProcedure:
@@ -350,6 +404,10 @@ func NewHostFunctionsServiceHandler(svc HostFunctionsServiceHandler, opts ...con
 			hostFunctionsServiceListCommandsHandler.ServeHTTP(w, r)
 		case HostFunctionsServiceGetCommandHelpProcedure:
 			hostFunctionsServiceGetCommandHelpHandler.ServeHTTP(w, r)
+		case HostFunctionsServiceAddSessionStreamProcedure:
+			hostFunctionsServiceAddSessionStreamHandler.ServeHTTP(w, r)
+		case HostFunctionsServiceRemoveSessionStreamProcedure:
+			hostFunctionsServiceRemoveSessionStreamHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -397,4 +455,12 @@ func (UnimplementedHostFunctionsServiceHandler) ListCommands(context.Context, *c
 
 func (UnimplementedHostFunctionsServiceHandler) GetCommandHelp(context.Context, *connect.Request[v1.GetCommandHelpRequest]) (*connect.Response[v1.GetCommandHelpResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.HostFunctionsService.GetCommandHelp is not implemented"))
+}
+
+func (UnimplementedHostFunctionsServiceHandler) AddSessionStream(context.Context, *connect.Request[v1.AddSessionStreamRequest]) (*connect.Response[v1.AddSessionStreamResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.HostFunctionsService.AddSessionStream is not implemented"))
+}
+
+func (UnimplementedHostFunctionsServiceHandler) RemoveSessionStream(context.Context, *connect.Request[v1.RemoveSessionStreamRequest]) (*connect.Response[v1.RemoveSessionStreamResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.HostFunctionsService.RemoveSessionStream is not implemented"))
 }

--- a/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
+++ b/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
@@ -48,6 +48,9 @@ const (
 	// PluginServiceHandleCommandProcedure is the fully-qualified name of the PluginService's
 	// HandleCommand RPC.
 	PluginServiceHandleCommandProcedure = "/holomush.plugin.v1.PluginService/HandleCommand"
+	// PluginServiceQuerySessionStreamsProcedure is the fully-qualified name of the PluginService's
+	// QuerySessionStreams RPC.
+	PluginServiceQuerySessionStreamsProcedure = "/holomush.plugin.v1.PluginService/QuerySessionStreams"
 	// PluginHostServiceEmitEventProcedure is the fully-qualified name of the PluginHostService's
 	// EmitEvent RPC.
 	PluginHostServiceEmitEventProcedure = "/holomush.plugin.v1.PluginHostService/EmitEvent"
@@ -60,6 +63,12 @@ const (
 	// PluginHostServiceKVDeleteProcedure is the fully-qualified name of the PluginHostService's
 	// KVDelete RPC.
 	PluginHostServiceKVDeleteProcedure = "/holomush.plugin.v1.PluginHostService/KVDelete"
+	// PluginHostServiceAddSessionStreamProcedure is the fully-qualified name of the PluginHostService's
+	// AddSessionStream RPC.
+	PluginHostServiceAddSessionStreamProcedure = "/holomush.plugin.v1.PluginHostService/AddSessionStream"
+	// PluginHostServiceRemoveSessionStreamProcedure is the fully-qualified name of the
+	// PluginHostService's RemoveSessionStream RPC.
+	PluginHostServiceRemoveSessionStreamProcedure = "/holomush.plugin.v1.PluginHostService/RemoveSessionStream"
 )
 
 // PluginServiceClient is a client for the holomush.plugin.v1.PluginService service.
@@ -72,6 +81,10 @@ type PluginServiceClient interface {
 	HandleEvent(context.Context, *connect.Request[v1.HandleEventRequest]) (*connect.Response[v1.HandleEventResponse], error)
 	// HandleCommand delivers a command to the plugin.
 	HandleCommand(context.Context, *connect.Request[v1.HandleCommandRequest]) (*connect.Response[v1.HandleCommandResponse], error)
+	// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+	// Called once at session establishment, before LISTEN setup.
+	// Only invoked for plugins that declare session_streams: true in their manifest.
+	QuerySessionStreams(context.Context, *connect.Request[v1.QuerySessionStreamsRequest]) (*connect.Response[v1.QuerySessionStreamsResponse], error)
 }
 
 // NewPluginServiceClient constructs a client for the holomush.plugin.v1.PluginService service. By
@@ -103,14 +116,21 @@ func NewPluginServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 			connect.WithSchema(pluginServiceMethods.ByName("HandleCommand")),
 			connect.WithClientOptions(opts...),
 		),
+		querySessionStreams: connect.NewClient[v1.QuerySessionStreamsRequest, v1.QuerySessionStreamsResponse](
+			httpClient,
+			baseURL+PluginServiceQuerySessionStreamsProcedure,
+			connect.WithSchema(pluginServiceMethods.ByName("QuerySessionStreams")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // pluginServiceClient implements PluginServiceClient.
 type pluginServiceClient struct {
-	init          *connect.Client[v1.InitRequest, v1.InitResponse]
-	handleEvent   *connect.Client[v1.HandleEventRequest, v1.HandleEventResponse]
-	handleCommand *connect.Client[v1.HandleCommandRequest, v1.HandleCommandResponse]
+	init                *connect.Client[v1.InitRequest, v1.InitResponse]
+	handleEvent         *connect.Client[v1.HandleEventRequest, v1.HandleEventResponse]
+	handleCommand       *connect.Client[v1.HandleCommandRequest, v1.HandleCommandResponse]
+	querySessionStreams *connect.Client[v1.QuerySessionStreamsRequest, v1.QuerySessionStreamsResponse]
 }
 
 // Init calls holomush.plugin.v1.PluginService.Init.
@@ -128,6 +148,11 @@ func (c *pluginServiceClient) HandleCommand(ctx context.Context, req *connect.Re
 	return c.handleCommand.CallUnary(ctx, req)
 }
 
+// QuerySessionStreams calls holomush.plugin.v1.PluginService.QuerySessionStreams.
+func (c *pluginServiceClient) QuerySessionStreams(ctx context.Context, req *connect.Request[v1.QuerySessionStreamsRequest]) (*connect.Response[v1.QuerySessionStreamsResponse], error) {
+	return c.querySessionStreams.CallUnary(ctx, req)
+}
+
 // PluginServiceHandler is an implementation of the holomush.plugin.v1.PluginService service.
 type PluginServiceHandler interface {
 	// Init is called by the host after connection, providing service configuration
@@ -138,6 +163,10 @@ type PluginServiceHandler interface {
 	HandleEvent(context.Context, *connect.Request[v1.HandleEventRequest]) (*connect.Response[v1.HandleEventResponse], error)
 	// HandleCommand delivers a command to the plugin.
 	HandleCommand(context.Context, *connect.Request[v1.HandleCommandRequest]) (*connect.Response[v1.HandleCommandResponse], error)
+	// QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+	// Called once at session establishment, before LISTEN setup.
+	// Only invoked for plugins that declare session_streams: true in their manifest.
+	QuerySessionStreams(context.Context, *connect.Request[v1.QuerySessionStreamsRequest]) (*connect.Response[v1.QuerySessionStreamsResponse], error)
 }
 
 // NewPluginServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -165,6 +194,12 @@ func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOp
 		connect.WithSchema(pluginServiceMethods.ByName("HandleCommand")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pluginServiceQuerySessionStreamsHandler := connect.NewUnaryHandler(
+		PluginServiceQuerySessionStreamsProcedure,
+		svc.QuerySessionStreams,
+		connect.WithSchema(pluginServiceMethods.ByName("QuerySessionStreams")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/holomush.plugin.v1.PluginService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PluginServiceInitProcedure:
@@ -173,6 +208,8 @@ func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOp
 			pluginServiceHandleEventHandler.ServeHTTP(w, r)
 		case PluginServiceHandleCommandProcedure:
 			pluginServiceHandleCommandHandler.ServeHTTP(w, r)
+		case PluginServiceQuerySessionStreamsProcedure:
+			pluginServiceQuerySessionStreamsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -194,6 +231,10 @@ func (UnimplementedPluginServiceHandler) HandleCommand(context.Context, *connect
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginService.HandleCommand is not implemented"))
 }
 
+func (UnimplementedPluginServiceHandler) QuerySessionStreams(context.Context, *connect.Request[v1.QuerySessionStreamsRequest]) (*connect.Response[v1.QuerySessionStreamsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginService.QuerySessionStreams is not implemented"))
+}
+
 // PluginHostServiceClient is a client for the holomush.plugin.v1.PluginHostService service.
 type PluginHostServiceClient interface {
 	// EmitEvent publishes an event to a stream.
@@ -206,6 +247,12 @@ type PluginHostServiceClient interface {
 	KVSet(context.Context, *connect.Request[v1.PluginHostServiceKVSetRequest]) (*connect.Response[v1.PluginHostServiceKVSetResponse], error)
 	// KVDelete removes a value from the plugin's key-value store.
 	KVDelete(context.Context, *connect.Request[v1.PluginHostServiceKVDeleteRequest]) (*connect.Response[v1.PluginHostServiceKVDeleteResponse], error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *connect.Request[v1.PluginHostServiceAddSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceAddSessionStreamResponse], error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error)
 }
 
 // NewPluginHostServiceClient constructs a client for the holomush.plugin.v1.PluginHostService
@@ -249,16 +296,30 @@ func NewPluginHostServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithSchema(pluginHostServiceMethods.ByName("KVDelete")),
 			connect.WithClientOptions(opts...),
 		),
+		addSessionStream: connect.NewClient[v1.PluginHostServiceAddSessionStreamRequest, v1.PluginHostServiceAddSessionStreamResponse](
+			httpClient,
+			baseURL+PluginHostServiceAddSessionStreamProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("AddSessionStream")),
+			connect.WithClientOptions(opts...),
+		),
+		removeSessionStream: connect.NewClient[v1.PluginHostServiceRemoveSessionStreamRequest, v1.PluginHostServiceRemoveSessionStreamResponse](
+			httpClient,
+			baseURL+PluginHostServiceRemoveSessionStreamProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("RemoveSessionStream")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // pluginHostServiceClient implements PluginHostServiceClient.
 type pluginHostServiceClient struct {
-	emitEvent *connect.Client[v1.PluginHostServiceEmitEventRequest, v1.PluginHostServiceEmitEventResponse]
-	log       *connect.Client[v1.PluginHostServiceLogRequest, v1.PluginHostServiceLogResponse]
-	kVGet     *connect.Client[v1.PluginHostServiceKVGetRequest, v1.PluginHostServiceKVGetResponse]
-	kVSet     *connect.Client[v1.PluginHostServiceKVSetRequest, v1.PluginHostServiceKVSetResponse]
-	kVDelete  *connect.Client[v1.PluginHostServiceKVDeleteRequest, v1.PluginHostServiceKVDeleteResponse]
+	emitEvent           *connect.Client[v1.PluginHostServiceEmitEventRequest, v1.PluginHostServiceEmitEventResponse]
+	log                 *connect.Client[v1.PluginHostServiceLogRequest, v1.PluginHostServiceLogResponse]
+	kVGet               *connect.Client[v1.PluginHostServiceKVGetRequest, v1.PluginHostServiceKVGetResponse]
+	kVSet               *connect.Client[v1.PluginHostServiceKVSetRequest, v1.PluginHostServiceKVSetResponse]
+	kVDelete            *connect.Client[v1.PluginHostServiceKVDeleteRequest, v1.PluginHostServiceKVDeleteResponse]
+	addSessionStream    *connect.Client[v1.PluginHostServiceAddSessionStreamRequest, v1.PluginHostServiceAddSessionStreamResponse]
+	removeSessionStream *connect.Client[v1.PluginHostServiceRemoveSessionStreamRequest, v1.PluginHostServiceRemoveSessionStreamResponse]
 }
 
 // EmitEvent calls holomush.plugin.v1.PluginHostService.EmitEvent.
@@ -286,6 +347,16 @@ func (c *pluginHostServiceClient) KVDelete(ctx context.Context, req *connect.Req
 	return c.kVDelete.CallUnary(ctx, req)
 }
 
+// AddSessionStream calls holomush.plugin.v1.PluginHostService.AddSessionStream.
+func (c *pluginHostServiceClient) AddSessionStream(ctx context.Context, req *connect.Request[v1.PluginHostServiceAddSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceAddSessionStreamResponse], error) {
+	return c.addSessionStream.CallUnary(ctx, req)
+}
+
+// RemoveSessionStream calls holomush.plugin.v1.PluginHostService.RemoveSessionStream.
+func (c *pluginHostServiceClient) RemoveSessionStream(ctx context.Context, req *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error) {
+	return c.removeSessionStream.CallUnary(ctx, req)
+}
+
 // PluginHostServiceHandler is an implementation of the holomush.plugin.v1.PluginHostService
 // service.
 type PluginHostServiceHandler interface {
@@ -299,6 +370,12 @@ type PluginHostServiceHandler interface {
 	KVSet(context.Context, *connect.Request[v1.PluginHostServiceKVSetRequest]) (*connect.Response[v1.PluginHostServiceKVSetResponse], error)
 	// KVDelete removes a value from the plugin's key-value store.
 	KVDelete(context.Context, *connect.Request[v1.PluginHostServiceKVDeleteRequest]) (*connect.Response[v1.PluginHostServiceKVDeleteResponse], error)
+	// AddSessionStream subscribes an active session to an additional stream mid-session.
+	// Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+	AddSessionStream(context.Context, *connect.Request[v1.PluginHostServiceAddSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceAddSessionStreamResponse], error)
+	// RemoveSessionStream unsubscribes an active session from a stream.
+	// Idempotent: returns success if stream is not subscribed.
+	RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error)
 }
 
 // NewPluginHostServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -338,6 +415,18 @@ func NewPluginHostServiceHandler(svc PluginHostServiceHandler, opts ...connect.H
 		connect.WithSchema(pluginHostServiceMethods.ByName("KVDelete")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pluginHostServiceAddSessionStreamHandler := connect.NewUnaryHandler(
+		PluginHostServiceAddSessionStreamProcedure,
+		svc.AddSessionStream,
+		connect.WithSchema(pluginHostServiceMethods.ByName("AddSessionStream")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pluginHostServiceRemoveSessionStreamHandler := connect.NewUnaryHandler(
+		PluginHostServiceRemoveSessionStreamProcedure,
+		svc.RemoveSessionStream,
+		connect.WithSchema(pluginHostServiceMethods.ByName("RemoveSessionStream")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/holomush.plugin.v1.PluginHostService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PluginHostServiceEmitEventProcedure:
@@ -350,6 +439,10 @@ func NewPluginHostServiceHandler(svc PluginHostServiceHandler, opts ...connect.H
 			pluginHostServiceKVSetHandler.ServeHTTP(w, r)
 		case PluginHostServiceKVDeleteProcedure:
 			pluginHostServiceKVDeleteHandler.ServeHTTP(w, r)
+		case PluginHostServiceAddSessionStreamProcedure:
+			pluginHostServiceAddSessionStreamHandler.ServeHTTP(w, r)
+		case PluginHostServiceRemoveSessionStreamProcedure:
+			pluginHostServiceRemoveSessionStreamHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -377,4 +470,12 @@ func (UnimplementedPluginHostServiceHandler) KVSet(context.Context, *connect.Req
 
 func (UnimplementedPluginHostServiceHandler) KVDelete(context.Context, *connect.Request[v1.PluginHostServiceKVDeleteRequest]) (*connect.Response[v1.PluginHostServiceKVDeleteResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.KVDelete is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) AddSessionStream(context.Context, *connect.Request[v1.PluginHostServiceAddSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceAddSessionStreamResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.AddSessionStream is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.RemoveSessionStream is not implemented"))
 }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -117,6 +117,10 @@
       "type": "integer",
       "description": "Load priority (lower loads first)"
     },
+    "session_streams": {
+      "type": "boolean",
+      "description": "Plugin contributes streams to session subscriptions via QuerySessionStreams"
+    },
     "lua-plugin": {
       "properties": {
         "entry": {

--- a/test/integration/plugin/session_streams_integration_test.go
+++ b/test/integration/plugin/session_streams_integration_test.go
@@ -1,0 +1,426 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugin_test
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/auth"
+	authpg "github.com/holomush/holomush/internal/auth/postgres"
+	bootstrapsetup "github.com/holomush/holomush/internal/bootstrap/setup"
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/idgen"
+	grpcpkg "github.com/holomush/holomush/internal/grpc"
+	"github.com/holomush/holomush/internal/naming"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/internal/telnet"
+	"github.com/holomush/holomush/internal/world"
+	worldpg "github.com/holomush/holomush/internal/world/postgres"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// staticContributor is a test-only SessionStreamContributor that returns fixed streams.
+type staticContributor struct {
+	streams atomic.Pointer[[]string]
+}
+
+func newStaticContributor(streams ...string) *staticContributor {
+	c := &staticContributor{}
+	c.SetStreams(streams...)
+	return c
+}
+
+func (c *staticContributor) SetStreams(streams ...string) {
+	cp := make([]string, len(streams))
+	copy(cp, streams)
+	c.streams.Store(&cp)
+}
+
+func (c *staticContributor) QuerySessionStreams(_ context.Context, _ plugins.SessionStreamsRequest) []string {
+	p := c.streams.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// collectUntilReplayComplete reads from a Subscribe stream until the
+// REPLAY_COMPLETE control signal is received, then returns all event types
+// seen so far. It does not close the stream.
+func collectUntilReplayComplete(stream corev1.CoreService_SubscribeClient) []string {
+	GinkgoHelper()
+	var types []string
+	for {
+		resp, err := stream.Recv()
+		Expect(err).NotTo(HaveOccurred(), "receiving from subscribe stream")
+		if ctrl := resp.GetControl(); ctrl != nil {
+			if ctrl.GetSignal() == corev1.ControlSignal_CONTROL_SIGNAL_REPLAY_COMPLETE {
+				return types
+			}
+		}
+		if ev := resp.GetEvent(); ev != nil {
+			types = append(types, ev.GetType())
+		}
+	}
+}
+
+var _ = Describe("Plugin Session Stream Contribution", func() {
+	var (
+		testCtx       context.Context
+		testCancel    context.CancelFunc
+		container     *postgres.PostgresContainer
+		grpcServer    *grpc.Server
+		grpcCli       *grpcpkg.Client
+		eventStore    *store.PostgresEventStore
+		contributor   *staticContributor
+		registry      *grpcpkg.SessionStreamRegistry
+		startLocation ulid.ULID
+		guestAuth     *telnet.GuestAuthenticator
+	)
+
+	// hookFn is a pointer so individual tests can swap it before subscribing.
+	hookFnPtr := new(func())
+
+	BeforeEach(func() {
+		testCtx, testCancel = context.WithTimeout(context.Background(), 5*time.Minute)
+
+		var err error
+		container, err = postgres.Run(testCtx,
+			"postgres:18-alpine",
+			postgres.WithDatabase("holomush_test"),
+			postgres.WithUsername("holomush"),
+			postgres.WithPassword("holomush"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2).
+					WithStartupTimeout(30*time.Second),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		connStr, err := container.ConnectionString(testCtx, "sslmode=disable")
+		Expect(err).NotTo(HaveOccurred())
+
+		migrator, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrator.Up()).To(Succeed())
+		_ = migrator.Close()
+
+		eventStore, err = store.NewPostgresEventStore(testCtx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+
+		pool := eventStore.Pool()
+		Expect(pool).NotTo(BeNil())
+		sessionStore := store.NewPostgresSessionStore(pool)
+		playerSessionStore := store.NewPostgresPlayerSessionStore(pool)
+		playerRepo := authpg.NewPlayerRepository(pool)
+		charRepo := bootstrapsetup.NewCharRepoAdapter(pool, worldpg.NewCharacterRepository(pool))
+		locRepo := worldpg.NewLocationRepository(pool)
+
+		startLocation = idgen.New()
+		loc := &world.Location{
+			ID:           startLocation,
+			Name:         "Test Origin",
+			Description:  "Integration test starting location",
+			Type:         world.LocationTypePersistent,
+			ReplayPolicy: world.DefaultReplayPolicy(world.LocationTypePersistent),
+		}
+		Expect(locRepo.Create(testCtx, loc)).To(Succeed())
+
+		engine := core.NewEngine(eventStore)
+		guestAuth = telnet.NewGuestAuthenticator(naming.NewGemstoneElementTheme(), startLocation)
+
+		guestService, gsErr := auth.NewGuestService(
+			guestAuth,
+			playerRepo,
+			charRepo,
+			playerSessionStore,
+		)
+		Expect(gsErr).NotTo(HaveOccurred())
+
+		pe := policytest.AllowAllEngine()
+		reg := command.NewRegistry()
+		handlers.RegisterAll(reg)
+		cmdSvc := command.NewTestServices(command.ServicesConfig{
+			Engine:  pe,
+			Session: sessionStore,
+			Events:  eventStore,
+		})
+		disp, dispErr := command.NewDispatcher(reg, pe)
+		Expect(dispErr).NotTo(HaveOccurred())
+
+		contributor = newStaticContributor()
+		registry = grpcpkg.NewSessionStreamRegistry()
+
+		// hookFnPtr starts as a no-op; tests may overwrite it.
+		*hookFnPtr = func() {}
+
+		coreServer := grpcpkg.NewCoreServer(engine, sessionStore, disp, cmdSvc,
+			grpcpkg.WithEventStore(eventStore),
+			grpcpkg.WithGuestService(guestService),
+			grpcpkg.WithPlayerRepo(playerRepo),
+			grpcpkg.WithPlayerSessionRepo(playerSessionStore),
+			grpcpkg.WithCharacterRepo(charRepo),
+			grpcpkg.WithSessionDefaults(grpcpkg.SessionDefaults{
+				TTL:        5 * time.Minute,
+				MaxHistory: 500,
+				MaxReplay:  1000,
+			}),
+			grpcpkg.WithStreamContributor(contributor),
+			grpcpkg.WithStreamRegistry(registry),
+			grpcpkg.WithAfterLISTENHook(func() {
+				if fn := *hookFnPtr; fn != nil {
+					fn()
+				}
+			}),
+			grpcpkg.WithDisconnectHook(func(info session.Info) {
+				if info.IsGuest {
+					guestAuth.ReleaseGuest(info.CharacterName)
+				}
+			}),
+		)
+
+		grpcServer = grpcpkg.NewGRPCServerInsecure()
+		corev1.RegisterCoreServiceServer(grpcServer, coreServer)
+
+		lis, lisErr := net.Listen("tcp", "127.0.0.1:0")
+		Expect(lisErr).NotTo(HaveOccurred())
+		go func() { _ = grpcServer.Serve(lis) }()
+
+		grpcAddr := lis.Addr().String()
+		Eventually(func() bool {
+			conn, dialErr := net.DialTimeout("tcp", grpcAddr, 100*time.Millisecond)
+			if dialErr != nil {
+				return false
+			}
+			conn.Close()
+			return true
+		}).Should(BeTrue())
+
+		grpcCli, err = grpcpkg.NewClient(testCtx, grpcpkg.ClientConfig{Address: grpcAddr})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if grpcCli != nil {
+			_ = grpcCli.Close()
+		}
+		if grpcServer != nil {
+			grpcServer.GracefulStop()
+		}
+		if eventStore != nil {
+			eventStore.Close()
+		}
+		if container != nil {
+			_ = container.Terminate(context.Background())
+		}
+		if testCancel != nil {
+			testCancel()
+		}
+	})
+
+	// authenticate performs the two-phase guest login (CreateGuest + SelectCharacter)
+	// and returns the resulting game session ID.
+	authenticate := func() string {
+		GinkgoHelper()
+		guestResp, err := grpcCli.CreateGuest(testCtx, &corev1.CreateGuestRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(guestResp.Success).To(BeTrue(), "guest creation should succeed: %s", guestResp.ErrorMessage)
+		Expect(guestResp.Characters).To(HaveLen(1))
+
+		selectResp, err := grpcCli.SelectCharacter(testCtx, &corev1.SelectCharacterRequest{
+			PlayerSessionToken: guestResp.PlayerSessionToken,
+			CharacterId:        guestResp.DefaultCharacterId,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(selectResp.Success).To(BeTrue(), "character selection should succeed: %s", selectResp.ErrorMessage)
+		return selectResp.SessionId
+	}
+
+	// appendEvent appends a test event on the given stream.
+	appendEvent := func(stream string) {
+		GinkgoHelper()
+		Expect(eventStore.Append(testCtx, core.Event{
+			ID:        core.NewULID(),
+			Stream:    stream,
+			Type:      core.EventType("test"),
+			Payload:   []byte(`{}`),
+			Timestamp: time.Now(),
+			Actor:     core.Actor{Kind: core.ActorSystem},
+		})).To(Succeed())
+	}
+
+	Describe("UC1: session-start auto-subscribe", func() {
+		It("receives messages posted before login via replay", func() {
+			contributor.SetStreams("channel:general")
+
+			// Append event to channel:general before subscribing.
+			appendEvent("channel:general")
+
+			sessionID := authenticate()
+
+			subCtx, subCancel := context.WithTimeout(testCtx, 10*time.Second)
+			defer subCancel()
+
+			stream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+				SessionId: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			types := collectUntilReplayComplete(stream)
+			Expect(types).To(ContainElement("test"),
+				"expected to replay event posted to channel:general before subscribe")
+		})
+
+		It("proceeds normally when contributor returns no streams", func() {
+			// contributor returns no streams (default).
+			sessionID := authenticate()
+
+			subCtx, subCancel := context.WithTimeout(testCtx, 10*time.Second)
+			defer subCancel()
+
+			stream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+				SessionId: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should still reach REPLAY_COMPLETE without error.
+			_ = collectUntilReplayComplete(stream)
+		})
+	})
+
+	Describe("UC2: mid-session subscription changes", func() {
+		It("receives messages on a stream added mid-session without reconnecting", func() {
+			// Start with no plugin streams.
+			sessionID := authenticate()
+
+			subCtx, subCancel := context.WithTimeout(testCtx, 15*time.Second)
+			defer subCancel()
+
+			stream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+				SessionId: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for REPLAY_COMPLETE before adding the new stream.
+			_ = collectUntilReplayComplete(stream)
+
+			// Start a looped receiver before issuing the control update so we
+			// don't miss any frames while the subscribe loop processes the add.
+			received := make(chan string, 8)
+			go func() {
+				defer GinkgoRecover()
+				for {
+					resp, recvErr := stream.Recv()
+					if recvErr != nil {
+						return
+					}
+					if ev := resp.GetEvent(); ev != nil {
+						received <- ev.GetType()
+					}
+				}
+			}()
+
+			// Add stream mid-session via registry.
+			Expect(registry.AddStream(testCtx, sessionID, "channel:new")).To(Succeed())
+
+			// Give the subscribe loop time to process the control update.
+			time.Sleep(200 * time.Millisecond)
+
+			// Append an event to the newly-added stream.
+			appendEvent("channel:new")
+
+			Eventually(received, 10*time.Second).Should(Receive(Equal("test")),
+				"event on dynamically-added stream should be delivered live")
+		})
+
+		It("stops forwarding messages after stream removed mid-session", func() {
+			contributor.SetStreams("channel:active")
+			sessionID := authenticate()
+
+			subCtx, subCancel := context.WithTimeout(testCtx, 15*time.Second)
+			defer subCancel()
+
+			stream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+				SessionId: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for REPLAY_COMPLETE.
+			_ = collectUntilReplayComplete(stream)
+
+			// Start a looped receiver before issuing the remove.
+			received := make(chan struct{}, 8)
+			go func() {
+				defer GinkgoRecover()
+				for {
+					resp, recvErr := stream.Recv()
+					if recvErr != nil {
+						return
+					}
+					if resp.GetEvent() != nil {
+						received <- struct{}{}
+					}
+				}
+			}()
+
+			// Remove the stream.
+			Expect(registry.RemoveStream(testCtx, sessionID, "channel:active")).To(Succeed())
+
+			// Give the subscribe loop time to process the control update.
+			time.Sleep(200 * time.Millisecond)
+
+			// Append an event to the removed stream.
+			appendEvent("channel:active")
+
+			// The event must NOT arrive.
+			Consistently(received, 2*time.Second, 100*time.Millisecond).ShouldNot(Receive(),
+				"event on removed stream should NOT be forwarded")
+		})
+	})
+
+	Describe("LISTEN-before-replay invariant", func() {
+		It("does not lose a message posted in the race window between LISTEN setup and replay", func() {
+			contributor.SetStreams("channel:race")
+
+			// Install the race-window hook: fires synchronously after LISTEN is set
+			// up but before replay — append now to exercise the race path.
+			*hookFnPtr = func() {
+				appendEvent("channel:race")
+			}
+
+			sessionID := authenticate()
+
+			subCtx, subCancel := context.WithTimeout(testCtx, 10*time.Second)
+			defer subCancel()
+
+			stream, err := grpcCli.Subscribe(subCtx, &corev1.SubscribeRequest{
+				SessionId: sessionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			types := collectUntilReplayComplete(stream)
+			Expect(types).To(ContainElement("test"),
+				"event appended in race window (after LISTEN, before replay) must appear in replay output")
+		})
+	})
+})

--- a/web/src/lib/connect/holomush/plugin/v1/hostfunc_connect.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/hostfunc_connect.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { EmitEventRequest, EmitEventResponse, GetCommandHelpRequest, GetCommandHelpResponse, KVDeleteRequest, KVDeleteResponse, KVGetRequest, KVGetResponse, KVSetRequest, KVSetResponse, ListCommandsRequest, ListCommandsResponse, LogRequest, LogResponse, QueryCharacterRequest, QueryCharacterResponse, QueryLocationCharactersRequest, QueryLocationCharactersResponse, QueryLocationRequest, QueryLocationResponse } from "./hostfunc_pb.js";
+import { AddSessionStreamRequest, AddSessionStreamResponse, EmitEventRequest, EmitEventResponse, GetCommandHelpRequest, GetCommandHelpResponse, KVDeleteRequest, KVDeleteResponse, KVGetRequest, KVGetResponse, KVSetRequest, KVSetResponse, ListCommandsRequest, ListCommandsResponse, LogRequest, LogResponse, QueryCharacterRequest, QueryCharacterResponse, QueryLocationCharactersRequest, QueryLocationCharactersResponse, QueryLocationRequest, QueryLocationResponse, RemoveSessionStreamRequest, RemoveSessionStreamResponse } from "./hostfunc_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -131,6 +131,30 @@ export const HostFunctionsService = {
       name: "GetCommandHelp",
       I: GetCommandHelpRequest,
       O: GetCommandHelpResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * AddSessionStream subscribes an active session to an additional stream mid-session.
+     * Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+     *
+     * @generated from rpc holomush.plugin.v1.HostFunctionsService.AddSessionStream
+     */
+    addSessionStream: {
+      name: "AddSessionStream",
+      I: AddSessionStreamRequest,
+      O: AddSessionStreamResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * RemoveSessionStream unsubscribes an active session from a stream.
+     * Idempotent: returns success if stream is not subscribed.
+     *
+     * @generated from rpc holomush.plugin.v1.HostFunctionsService.RemoveSessionStream
+     */
+    removeSessionStream: {
+      name: "RemoveSessionStream",
+      I: RemoveSessionStreamRequest,
+      O: RemoveSessionStreamResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/web/src/lib/connect/holomush/plugin/v1/hostfunc_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/hostfunc_pb.ts
@@ -18,7 +18,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file holomush/plugin/v1/hostfunc.proto.
  */
 export const file_holomush_plugin_v1_hostfunc: GenFile = /*@__PURE__*/
-  fileDesc("CiFob2xvbXVzaC9wbHVnaW4vdjEvaG9zdGZ1bmMucHJvdG8SEmhvbG9tdXNoLnBsdWdpbi52MSJAChBFbWl0RXZlbnRSZXF1ZXN0EiwKBWV2ZW50GAEgASgLMh0uaG9sb211c2gucGx1Z2luLnYxLkVtaXRFdmVudCIzChFFbWl0RXZlbnRSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJIjQKFFF1ZXJ5TG9jYXRpb25SZXF1ZXN0EhwKC2xvY2F0aW9uX2lkGAEgASgJQge6SARyAhABIloKFVF1ZXJ5TG9jYXRpb25SZXNwb25zZRIyCghsb2NhdGlvbhgBIAEoCzIgLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2NhdGlvbkluZm8SDQoFZXJyb3IYAiABKAkiWQoMTG9jYXRpb25JbmZvEhMKAmlkGAEgASgJQge6SARyAhABEhUKBG5hbWUYAiABKAlCB7pIBHICEAESHQoLZGVzY3JpcHRpb24YAyABKAlCCLpIBXIDGIBAIjYKFVF1ZXJ5Q2hhcmFjdGVyUmVxdWVzdBIdCgxjaGFyYWN0ZXJfaWQYASABKAlCB7pIBHICEAEiXQoWUXVlcnlDaGFyYWN0ZXJSZXNwb25zZRI0CgljaGFyYWN0ZXIYASABKAsyIS5ob2xvbXVzaC5wbHVnaW4udjEuQ2hhcmFjdGVySW5mbxINCgVlcnJvchgCIAEoCSI7Cg1DaGFyYWN0ZXJJbmZvEhMKAmlkGAEgASgJQge6SARyAhABEhUKBG5hbWUYAiABKAlCB7pIBHICEAEiPgoeUXVlcnlMb2NhdGlvbkNoYXJhY3RlcnNSZXF1ZXN0EhwKC2xvY2F0aW9uX2lkGAEgASgJQge6SARyAhABImcKH1F1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzUmVzcG9uc2USNQoKY2hhcmFjdGVycxgBIAMoCzIhLmhvbG9tdXNoLnBsdWdpbi52MS5DaGFyYWN0ZXJJbmZvEg0KBWVycm9yGAIgASgJIiQKDEtWR2V0UmVxdWVzdBIUCgNrZXkYASABKAlCB7pIBHICEAEiPAoNS1ZHZXRSZXNwb25zZRINCgV2YWx1ZRgBIAEoDBINCgVmb3VuZBgCIAEoCBINCgVlcnJvchgDIAEoCSIzCgxLVlNldFJlcXVlc3QSFAoDa2V5GAEgASgJQge6SARyAhABEg0KBXZhbHVlGAIgASgMIi8KDUtWU2V0UmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCBINCgVlcnJvchgCIAEoCSInCg9LVkRlbGV0ZVJlcXVlc3QSFAoDa2V5GAEgASgJQge6SARyAhABIjIKEEtWRGVsZXRlUmVzcG9uc2USDwoHZGVsZXRlZBgBIAEoCBINCgVlcnJvchgCIAEoCSK/AQoKTG9nUmVxdWVzdBIrCgVsZXZlbBgBIAEoDjIcLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2dMZXZlbBIZCgdtZXNzYWdlGAIgASgJQgi6SAVyAxiAQBI6CgZmaWVsZHMYAyADKAsyKi5ob2xvbXVzaC5wbHVnaW4udjEuTG9nUmVxdWVzdC5GaWVsZHNFbnRyeRotCgtGaWVsZHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIg0KC0xvZ1Jlc3BvbnNlIjQKE0xpc3RDb21tYW5kc1JlcXVlc3QSHQoMY2hhcmFjdGVyX2lkGAEgASgJQge6SARyAhABIlgKFExpc3RDb21tYW5kc1Jlc3BvbnNlEjEKCGNvbW1hbmRzGAEgAygLMh8uaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRJbmZvEg0KBWVycm9yGAIgASgJIm4KC0NvbW1hbmRJbmZvEhUKBG5hbWUYASABKAlCB7pIBHICEAESFgoEaGVscBgCIAEoCUIIukgFcgMYgEASFwoFdXNhZ2UYAyABKAlCCLpIBXIDGIBAEhcKBnNvdXJjZRgEIAEoCUIHukgEcgIQASI2ChVHZXRDb21tYW5kSGVscFJlcXVlc3QSHQoMY29tbWFuZF9uYW1lGAEgASgJQge6SARyAhABIl0KFkdldENvbW1hbmRIZWxwUmVzcG9uc2USNAoHY29tbWFuZBgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kSGVscEluZm8SDQoFZXJyb3IYAiABKAkipgEKD0NvbW1hbmRIZWxwSW5mbxIVCgRuYW1lGAEgASgJQge6SARyAhABEhYKBGhlbHAYAiABKAlCCLpIBXIDGIBAEhcKBXVzYWdlGAMgASgJQgi6SAVyAxiAQBIcCgloZWxwX3RleHQYBCABKAlCCbpIBnIEGICABBIUCgxjYXBhYmlsaXRpZXMYBSADKAkSFwoGc291cmNlGAYgASgJQge6SARyAhABKncKCExvZ0xldmVsEhkKFUxPR19MRVZFTF9VTlNQRUNJRklFRBAAEhMKD0xPR19MRVZFTF9ERUJVRxABEhIKDkxPR19MRVZFTF9JTkZPEAISEgoOTE9HX0xFVkVMX1dBUk4QAxITCg9MT0dfTEVWRUxfRVJST1IQBDLLBwoUSG9zdEZ1bmN0aW9uc1NlcnZpY2USWAoJRW1pdEV2ZW50EiQuaG9sb211c2gucGx1Z2luLnYxLkVtaXRFdmVudFJlcXVlc3QaJS5ob2xvbXVzaC5wbHVnaW4udjEuRW1pdEV2ZW50UmVzcG9uc2USZAoNUXVlcnlMb2NhdGlvbhIoLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uUmVxdWVzdBopLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uUmVzcG9uc2USZwoOUXVlcnlDaGFyYWN0ZXISKS5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlDaGFyYWN0ZXJSZXF1ZXN0GiouaG9sb211c2gucGx1Z2luLnYxLlF1ZXJ5Q2hhcmFjdGVyUmVzcG9uc2USggEKF1F1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzEjIuaG9sb211c2gucGx1Z2luLnYxLlF1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzUmVxdWVzdBozLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uQ2hhcmFjdGVyc1Jlc3BvbnNlEkwKBUtWR2V0EiAuaG9sb211c2gucGx1Z2luLnYxLktWR2V0UmVxdWVzdBohLmhvbG9tdXNoLnBsdWdpbi52MS5LVkdldFJlc3BvbnNlEkwKBUtWU2V0EiAuaG9sb211c2gucGx1Z2luLnYxLktWU2V0UmVxdWVzdBohLmhvbG9tdXNoLnBsdWdpbi52MS5LVlNldFJlc3BvbnNlElUKCEtWRGVsZXRlEiMuaG9sb211c2gucGx1Z2luLnYxLktWRGVsZXRlUmVxdWVzdBokLmhvbG9tdXNoLnBsdWdpbi52MS5LVkRlbGV0ZVJlc3BvbnNlEkYKA0xvZxIeLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2dSZXF1ZXN0Gh8uaG9sb211c2gucGx1Z2luLnYxLkxvZ1Jlc3BvbnNlEmEKDExpc3RDb21tYW5kcxInLmhvbG9tdXNoLnBsdWdpbi52MS5MaXN0Q29tbWFuZHNSZXF1ZXN0GiguaG9sb211c2gucGx1Z2luLnYxLkxpc3RDb21tYW5kc1Jlc3BvbnNlEmcKDkdldENvbW1hbmRIZWxwEikuaG9sb211c2gucGx1Z2luLnYxLkdldENvbW1hbmRIZWxwUmVxdWVzdBoqLmhvbG9tdXNoLnBsdWdpbi52MS5HZXRDb21tYW5kSGVscFJlc3BvbnNlQkRaQmdpdGh1Yi5jb20vaG9sb211c2gvaG9sb211c2gvcGtnL3Byb3RvL2hvbG9tdXNoL3BsdWdpbi92MTtwbHVnaW52MWIGcHJvdG8z", [file_buf_validate_validate, file_holomush_plugin_v1_plugin]);
+  fileDesc("CiFob2xvbXVzaC9wbHVnaW4vdjEvaG9zdGZ1bmMucHJvdG8SEmhvbG9tdXNoLnBsdWdpbi52MSJAChBFbWl0RXZlbnRSZXF1ZXN0EiwKBWV2ZW50GAEgASgLMh0uaG9sb211c2gucGx1Z2luLnYxLkVtaXRFdmVudCIzChFFbWl0RXZlbnRSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJIjQKFFF1ZXJ5TG9jYXRpb25SZXF1ZXN0EhwKC2xvY2F0aW9uX2lkGAEgASgJQge6SARyAhABIloKFVF1ZXJ5TG9jYXRpb25SZXNwb25zZRIyCghsb2NhdGlvbhgBIAEoCzIgLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2NhdGlvbkluZm8SDQoFZXJyb3IYAiABKAkiWQoMTG9jYXRpb25JbmZvEhMKAmlkGAEgASgJQge6SARyAhABEhUKBG5hbWUYAiABKAlCB7pIBHICEAESHQoLZGVzY3JpcHRpb24YAyABKAlCCLpIBXIDGIBAIjYKFVF1ZXJ5Q2hhcmFjdGVyUmVxdWVzdBIdCgxjaGFyYWN0ZXJfaWQYASABKAlCB7pIBHICEAEiXQoWUXVlcnlDaGFyYWN0ZXJSZXNwb25zZRI0CgljaGFyYWN0ZXIYASABKAsyIS5ob2xvbXVzaC5wbHVnaW4udjEuQ2hhcmFjdGVySW5mbxINCgVlcnJvchgCIAEoCSI7Cg1DaGFyYWN0ZXJJbmZvEhMKAmlkGAEgASgJQge6SARyAhABEhUKBG5hbWUYAiABKAlCB7pIBHICEAEiPgoeUXVlcnlMb2NhdGlvbkNoYXJhY3RlcnNSZXF1ZXN0EhwKC2xvY2F0aW9uX2lkGAEgASgJQge6SARyAhABImcKH1F1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzUmVzcG9uc2USNQoKY2hhcmFjdGVycxgBIAMoCzIhLmhvbG9tdXNoLnBsdWdpbi52MS5DaGFyYWN0ZXJJbmZvEg0KBWVycm9yGAIgASgJIiQKDEtWR2V0UmVxdWVzdBIUCgNrZXkYASABKAlCB7pIBHICEAEiPAoNS1ZHZXRSZXNwb25zZRINCgV2YWx1ZRgBIAEoDBINCgVmb3VuZBgCIAEoCBINCgVlcnJvchgDIAEoCSIzCgxLVlNldFJlcXVlc3QSFAoDa2V5GAEgASgJQge6SARyAhABEg0KBXZhbHVlGAIgASgMIi8KDUtWU2V0UmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCBINCgVlcnJvchgCIAEoCSInCg9LVkRlbGV0ZVJlcXVlc3QSFAoDa2V5GAEgASgJQge6SARyAhABIjIKEEtWRGVsZXRlUmVzcG9uc2USDwoHZGVsZXRlZBgBIAEoCBINCgVlcnJvchgCIAEoCSK/AQoKTG9nUmVxdWVzdBIrCgVsZXZlbBgBIAEoDjIcLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2dMZXZlbBIZCgdtZXNzYWdlGAIgASgJQgi6SAVyAxiAQBI6CgZmaWVsZHMYAyADKAsyKi5ob2xvbXVzaC5wbHVnaW4udjEuTG9nUmVxdWVzdC5GaWVsZHNFbnRyeRotCgtGaWVsZHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBIg0KC0xvZ1Jlc3BvbnNlIjQKE0xpc3RDb21tYW5kc1JlcXVlc3QSHQoMY2hhcmFjdGVyX2lkGAEgASgJQge6SARyAhABIlgKFExpc3RDb21tYW5kc1Jlc3BvbnNlEjEKCGNvbW1hbmRzGAEgAygLMh8uaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRJbmZvEg0KBWVycm9yGAIgASgJIm4KC0NvbW1hbmRJbmZvEhUKBG5hbWUYASABKAlCB7pIBHICEAESFgoEaGVscBgCIAEoCUIIukgFcgMYgEASFwoFdXNhZ2UYAyABKAlCCLpIBXIDGIBAEhcKBnNvdXJjZRgEIAEoCUIHukgEcgIQASI2ChVHZXRDb21tYW5kSGVscFJlcXVlc3QSHQoMY29tbWFuZF9uYW1lGAEgASgJQge6SARyAhABIl0KFkdldENvbW1hbmRIZWxwUmVzcG9uc2USNAoHY29tbWFuZBgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kSGVscEluZm8SDQoFZXJyb3IYAiABKAkipgEKD0NvbW1hbmRIZWxwSW5mbxIVCgRuYW1lGAEgASgJQge6SARyAhABEhYKBGhlbHAYAiABKAlCCLpIBXIDGIBAEhcKBXVzYWdlGAMgASgJQgi6SAVyAxiAQBIcCgloZWxwX3RleHQYBCABKAlCCbpIBnIEGICABBIUCgxjYXBhYmlsaXRpZXMYBSADKAkSFwoGc291cmNlGAYgASgJQge6SARyAhABIk8KF0FkZFNlc3Npb25TdHJlYW1SZXF1ZXN0EhsKCnNlc3Npb25faWQYASABKAlCB7pIBHICEAESFwoGc3RyZWFtGAIgASgJQge6SARyAhABIjoKGEFkZFNlc3Npb25TdHJlYW1SZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJIlIKGlJlbW92ZVNlc3Npb25TdHJlYW1SZXF1ZXN0EhsKCnNlc3Npb25faWQYASABKAlCB7pIBHICEAESFwoGc3RyZWFtGAIgASgJQge6SARyAhABIj0KG1JlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJKncKCExvZ0xldmVsEhkKFUxPR19MRVZFTF9VTlNQRUNJRklFRBAAEhMKD0xPR19MRVZFTF9ERUJVRxABEhIKDkxPR19MRVZFTF9JTkZPEAISEgoOTE9HX0xFVkVMX1dBUk4QAxITCg9MT0dfTEVWRUxfRVJST1IQBDKyCQoUSG9zdEZ1bmN0aW9uc1NlcnZpY2USWAoJRW1pdEV2ZW50EiQuaG9sb211c2gucGx1Z2luLnYxLkVtaXRFdmVudFJlcXVlc3QaJS5ob2xvbXVzaC5wbHVnaW4udjEuRW1pdEV2ZW50UmVzcG9uc2USZAoNUXVlcnlMb2NhdGlvbhIoLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uUmVxdWVzdBopLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uUmVzcG9uc2USZwoOUXVlcnlDaGFyYWN0ZXISKS5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlDaGFyYWN0ZXJSZXF1ZXN0GiouaG9sb211c2gucGx1Z2luLnYxLlF1ZXJ5Q2hhcmFjdGVyUmVzcG9uc2USggEKF1F1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzEjIuaG9sb211c2gucGx1Z2luLnYxLlF1ZXJ5TG9jYXRpb25DaGFyYWN0ZXJzUmVxdWVzdBozLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUxvY2F0aW9uQ2hhcmFjdGVyc1Jlc3BvbnNlEkwKBUtWR2V0EiAuaG9sb211c2gucGx1Z2luLnYxLktWR2V0UmVxdWVzdBohLmhvbG9tdXNoLnBsdWdpbi52MS5LVkdldFJlc3BvbnNlEkwKBUtWU2V0EiAuaG9sb211c2gucGx1Z2luLnYxLktWU2V0UmVxdWVzdBohLmhvbG9tdXNoLnBsdWdpbi52MS5LVlNldFJlc3BvbnNlElUKCEtWRGVsZXRlEiMuaG9sb211c2gucGx1Z2luLnYxLktWRGVsZXRlUmVxdWVzdBokLmhvbG9tdXNoLnBsdWdpbi52MS5LVkRlbGV0ZVJlc3BvbnNlEkYKA0xvZxIeLmhvbG9tdXNoLnBsdWdpbi52MS5Mb2dSZXF1ZXN0Gh8uaG9sb211c2gucGx1Z2luLnYxLkxvZ1Jlc3BvbnNlEmEKDExpc3RDb21tYW5kcxInLmhvbG9tdXNoLnBsdWdpbi52MS5MaXN0Q29tbWFuZHNSZXF1ZXN0GiguaG9sb211c2gucGx1Z2luLnYxLkxpc3RDb21tYW5kc1Jlc3BvbnNlEmcKDkdldENvbW1hbmRIZWxwEikuaG9sb211c2gucGx1Z2luLnYxLkdldENvbW1hbmRIZWxwUmVxdWVzdBoqLmhvbG9tdXNoLnBsdWdpbi52MS5HZXRDb21tYW5kSGVscFJlc3BvbnNlEm0KEEFkZFNlc3Npb25TdHJlYW0SKy5ob2xvbXVzaC5wbHVnaW4udjEuQWRkU2Vzc2lvblN0cmVhbVJlcXVlc3QaLC5ob2xvbXVzaC5wbHVnaW4udjEuQWRkU2Vzc2lvblN0cmVhbVJlc3BvbnNlEnYKE1JlbW92ZVNlc3Npb25TdHJlYW0SLi5ob2xvbXVzaC5wbHVnaW4udjEuUmVtb3ZlU2Vzc2lvblN0cmVhbVJlcXVlc3QaLy5ob2xvbXVzaC5wbHVnaW4udjEuUmVtb3ZlU2Vzc2lvblN0cmVhbVJlc3BvbnNlQkRaQmdpdGh1Yi5jb20vaG9sb211c2gvaG9sb211c2gvcGtnL3Byb3RvL2hvbG9tdXNoL3BsdWdpbi92MTtwbHVnaW52MWIGcHJvdG8z", [file_buf_validate_validate, file_holomush_plugin_v1_plugin]);
 
 /**
  * EmitEventRequest wraps an event for emission by the host.
@@ -688,6 +688,118 @@ export const CommandHelpInfoSchema: GenMessage<CommandHelpInfo> = /*@__PURE__*/
   messageDesc(file_holomush_plugin_v1_hostfunc, 23);
 
 /**
+ * AddSessionStreamRequest specifies which session and stream to add.
+ *
+ * @generated from message holomush.plugin.v1.AddSessionStreamRequest
+ */
+export type AddSessionStreamRequest = Message<"holomush.plugin.v1.AddSessionStreamRequest"> & {
+  /**
+   * Active session identifier.
+   *
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * Stream name to subscribe to (format: "prefix:id").
+   *
+   * @generated from field: string stream = 2;
+   */
+  stream: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.AddSessionStreamRequest.
+ * Use `create(AddSessionStreamRequestSchema)` to create a new message.
+ */
+export const AddSessionStreamRequestSchema: GenMessage<AddSessionStreamRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_hostfunc, 24);
+
+/**
+ * AddSessionStreamResponse indicates success or failure.
+ *
+ * @generated from message holomush.plugin.v1.AddSessionStreamResponse
+ */
+export type AddSessionStreamResponse = Message<"holomush.plugin.v1.AddSessionStreamResponse"> & {
+  /**
+   * Whether the stream was successfully added.
+   *
+   * @generated from field: bool success = 1;
+   */
+  success: boolean;
+
+  /**
+   * Non-empty on error.
+   *
+   * @generated from field: string error = 2;
+   */
+  error: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.AddSessionStreamResponse.
+ * Use `create(AddSessionStreamResponseSchema)` to create a new message.
+ */
+export const AddSessionStreamResponseSchema: GenMessage<AddSessionStreamResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_hostfunc, 25);
+
+/**
+ * RemoveSessionStreamRequest specifies which stream to remove.
+ *
+ * @generated from message holomush.plugin.v1.RemoveSessionStreamRequest
+ */
+export type RemoveSessionStreamRequest = Message<"holomush.plugin.v1.RemoveSessionStreamRequest"> & {
+  /**
+   * Active session identifier.
+   *
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * Stream name to unsubscribe from.
+   *
+   * @generated from field: string stream = 2;
+   */
+  stream: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.RemoveSessionStreamRequest.
+ * Use `create(RemoveSessionStreamRequestSchema)` to create a new message.
+ */
+export const RemoveSessionStreamRequestSchema: GenMessage<RemoveSessionStreamRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_hostfunc, 26);
+
+/**
+ * RemoveSessionStreamResponse indicates success or failure.
+ *
+ * @generated from message holomush.plugin.v1.RemoveSessionStreamResponse
+ */
+export type RemoveSessionStreamResponse = Message<"holomush.plugin.v1.RemoveSessionStreamResponse"> & {
+  /**
+   * Whether the stream was successfully removed (true even if not subscribed).
+   *
+   * @generated from field: bool success = 1;
+   */
+  success: boolean;
+
+  /**
+   * Non-empty on error.
+   *
+   * @generated from field: string error = 2;
+   */
+  error: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.RemoveSessionStreamResponse.
+ * Use `create(RemoveSessionStreamResponseSchema)` to create a new message.
+ */
+export const RemoveSessionStreamResponseSchema: GenMessage<RemoveSessionStreamResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_hostfunc, 27);
+
+/**
  * LogLevel specifies the severity of a log message.
  *
  * @generated from enum holomush.plugin.v1.LogLevel
@@ -834,6 +946,28 @@ export const HostFunctionsService: GenService<{
     methodKind: "unary";
     input: typeof GetCommandHelpRequestSchema;
     output: typeof GetCommandHelpResponseSchema;
+  },
+  /**
+   * AddSessionStream subscribes an active session to an additional stream mid-session.
+   * Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+   *
+   * @generated from rpc holomush.plugin.v1.HostFunctionsService.AddSessionStream
+   */
+  addSessionStream: {
+    methodKind: "unary";
+    input: typeof AddSessionStreamRequestSchema;
+    output: typeof AddSessionStreamResponseSchema;
+  },
+  /**
+   * RemoveSessionStream unsubscribes an active session from a stream.
+   * Idempotent: returns success if stream is not subscribed.
+   *
+   * @generated from rpc holomush.plugin.v1.HostFunctionsService.RemoveSessionStream
+   */
+  removeSessionStream: {
+    methodKind: "unary";
+    input: typeof RemoveSessionStreamRequestSchema;
+    output: typeof RemoveSessionStreamResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_holomush_plugin_v1_hostfunc, 0);

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { HandleCommandRequest, HandleCommandResponse, HandleEventRequest, HandleEventResponse, InitRequest, InitResponse, PluginHostServiceEmitEventRequest, PluginHostServiceEmitEventResponse, PluginHostServiceKVDeleteRequest, PluginHostServiceKVDeleteResponse, PluginHostServiceKVGetRequest, PluginHostServiceKVGetResponse, PluginHostServiceKVSetRequest, PluginHostServiceKVSetResponse, PluginHostServiceLogRequest, PluginHostServiceLogResponse } from "./plugin_pb.js";
+import { HandleCommandRequest, HandleCommandResponse, HandleEventRequest, HandleEventResponse, InitRequest, InitResponse, PluginHostServiceAddSessionStreamRequest, PluginHostServiceAddSessionStreamResponse, PluginHostServiceEmitEventRequest, PluginHostServiceEmitEventResponse, PluginHostServiceKVDeleteRequest, PluginHostServiceKVDeleteResponse, PluginHostServiceKVGetRequest, PluginHostServiceKVGetResponse, PluginHostServiceKVSetRequest, PluginHostServiceKVSetResponse, PluginHostServiceLogRequest, PluginHostServiceLogResponse, PluginHostServiceRemoveSessionStreamRequest, PluginHostServiceRemoveSessionStreamResponse, QuerySessionStreamsRequest, QuerySessionStreamsResponse } from "./plugin_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -53,6 +53,19 @@ export const PluginService = {
       name: "HandleCommand",
       I: HandleCommandRequest,
       O: HandleCommandResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+     * Called once at session establishment, before LISTEN setup.
+     * Only invoked for plugins that declare session_streams: true in their manifest.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginService.QuerySessionStreams
+     */
+    querySessionStreams: {
+      name: "QuerySessionStreams",
+      I: QuerySessionStreamsRequest,
+      O: QuerySessionStreamsResponse,
       kind: MethodKind.Unary,
     },
   }
@@ -120,6 +133,30 @@ export const PluginHostService = {
       name: "KVDelete",
       I: PluginHostServiceKVDeleteRequest,
       O: PluginHostServiceKVDeleteResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * AddSessionStream subscribes an active session to an additional stream mid-session.
+     * Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.AddSessionStream
+     */
+    addSessionStream: {
+      name: "AddSessionStream",
+      I: PluginHostServiceAddSessionStreamRequest,
+      O: PluginHostServiceAddSessionStreamResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * RemoveSessionStream unsubscribes an active session from a stream.
+     * Idempotent: returns success if stream is not subscribed.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.RemoveSessionStream
+     */
+    removeSessionStream: {
+      name: "RemoveSessionStream",
+      I: PluginHostServiceRemoveSessionStreamRequest,
+      O: PluginHostServiceRemoveSessionStreamResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
@@ -16,7 +16,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file holomush/plugin/v1/plugin.proto.
  */
 export const file_holomush_plugin_v1_plugin: GenFile = /*@__PURE__*/
-  fileDesc("Ch9ob2xvbXVzaC9wbHVnaW4vdjEvcGx1Z2luLnByb3RvEhJob2xvbXVzaC5wbHVnaW4udjEitwEKDVNlcnZpY2VDb25maWcSGQoRY29ubmVjdGlvbl9zdHJpbmcYASABKAkSUgoRcmVxdWlyZWRfc2VydmljZXMYAiADKAsyNy5ob2xvbXVzaC5wbHVnaW4udjEuU2VydmljZUNvbmZpZy5SZXF1aXJlZFNlcnZpY2VzRW50cnkaNwoVUmVxdWlyZWRTZXJ2aWNlc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQAoLSW5pdFJlcXVlc3QSMQoGY29uZmlnGAEgASgLMiEuaG9sb211c2gucGx1Z2luLnYxLlNlcnZpY2VDb25maWciKQoMSW5pdFJlc3BvbnNlEhkKEXByb3ZpZGVkX3NlcnZpY2VzGAEgAygJIrMBCgVFdmVudBITCgJpZBgBIAEoCUIHukgEcgIQARIXCgZzdHJlYW0YAiABKAlCB7pIBHICEAESFQoEdHlwZRgDIAEoCUIHukgEcgIQARIRCgl0aW1lc3RhbXAYBCABKAMSGwoKYWN0b3Jfa2luZBgFIAEoCUIHukgEcgIQARIZCghhY3Rvcl9pZBgGIAEoCUIHukgEcgIQARIaCgdwYXlsb2FkGAcgASgJQgm6SAZyBBiAgAQiVwoJRW1pdEV2ZW50EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIVCgR0eXBlGAIgASgJQge6SARyAhABEhoKB3BheWxvYWQYAyABKAlCCbpIBnIEGICABCI+ChJIYW5kbGVFdmVudFJlcXVlc3QSKAoFZXZlbnQYASABKAsyGS5ob2xvbXVzaC5wbHVnaW4udjEuRXZlbnQiSQoTSGFuZGxlRXZlbnRSZXNwb25zZRIyCgtlbWl0X2V2ZW50cxgBIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQi9gEKDkNvbW1hbmRSZXF1ZXN0EhgKB2NvbW1hbmQYASABKAlCB7pIBHICEAESFgoEYXJncxgCIAEoCUIIukgFcgMYgEASGwoJcmF3X2lucHV0GAMgASgJQgi6SAVyAxiAQBIdCgxjaGFyYWN0ZXJfaWQYBCABKAlCB7pIBHICEAESHwoOY2hhcmFjdGVyX25hbWUYBSABKAlCB7pIBHICEAESHAoLbG9jYXRpb25faWQYBiABKAlCB7pIBHICEAESGwoKc2Vzc2lvbl9pZBgHIAEoCUIHukgEcgIQARIaCglwbGF5ZXJfaWQYCCABKAlCB7pIBHICEAEiyQEKD0NvbW1hbmRSZXNwb25zZRIxCgZzdGF0dXMYASABKA4yIS5ob2xvbXVzaC5wbHVnaW4udjEuQ29tbWFuZFN0YXR1cxIYCgZvdXRwdXQYAiABKAlCCLpIBXIDGIBAEi0KBmV2ZW50cxgDIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQSOgoLYXVkaXRfaGludHMYBCADKAsyJS5ob2xvbXVzaC5wbHVnaW4udjEuQXVkaXREZWNpc2lvbkhpbnQizAIKEUF1ZGl0RGVjaXNpb25IaW50EhYKAmlkGAEgASgJQgq6SAdyBRABGIABEhYKBG5hbWUYAiABKAlCCLpIBXIDGIACEhkKB21lc3NhZ2UYAyABKAlCCLpIBXIDGIAIEi8KBmVmZmVjdBgEIAEoDjIfLmhvbG9tdXNoLnBsdWdpbi52MS5BdWRpdEVmZmVjdBIhChBhY3Rpb25fcXVhbGlmaWVyGAUgASgJQge6SARyAhhAEhoKCHJlc291cmNlGAYgASgJQgi6SAVyAxiAAhJJCgphdHRyaWJ1dGVzGAcgAygLMjUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RGVjaXNpb25IaW50LkF0dHJpYnV0ZXNFbnRyeRoxCg9BdHRyaWJ1dGVzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJLChRIYW5kbGVDb21tYW5kUmVxdWVzdBIzCgdjb21tYW5kGAEgASgLMiIuaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRSZXF1ZXN0Ik4KFUhhbmRsZUNvbW1hbmRSZXNwb25zZRI1CghyZXNwb25zZRgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kUmVzcG9uc2UiagohUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIbCgpldmVudF90eXBlGAIgASgJQge6SARyAhABEg8KB3BheWxvYWQYAyABKAwiJAoiUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXNwb25zZSJQChtQbHVnaW5Ib3N0U2VydmljZUxvZ1JlcXVlc3QSFgoFbGV2ZWwYASABKAlCB7pIBHICEAESGQoHbWVzc2FnZRgCIAEoCUIIukgFcgMYgEAiHgocUGx1Z2luSG9zdFNlcnZpY2VMb2dSZXNwb25zZSJTCh1QbHVnaW5Ib3N0U2VydmljZUtWR2V0UmVxdWVzdBIcCgtwbHVnaW5fbmFtZRgBIAEoCUIHukgEcgIQARIUCgNrZXkYAiABKAlCB7pIBHICEAEiPgoeUGx1Z2luSG9zdFNlcnZpY2VLVkdldFJlc3BvbnNlEg0KBXZhbHVlGAEgASgJEg0KBWZvdW5kGAIgASgIImIKHVBsdWdpbkhvc3RTZXJ2aWNlS1ZTZXRSZXF1ZXN0EhwKC3BsdWdpbl9uYW1lGAEgASgJQge6SARyAhABEhQKA2tleRgCIAEoCUIHukgEcgIQARINCgV2YWx1ZRgDIAEoCSIgCh5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2UiVgogUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QSHAoLcGx1Z2luX25hbWUYASABKAlCB7pIBHICEAESFAoDa2V5GAIgASgJQge6SARyAhABIiMKIVBsdWdpbkhvc3RTZXJ2aWNlS1ZEZWxldGVSZXNwb25zZSqWAQoNQ29tbWFuZFN0YXR1cxIeChpDT01NQU5EX1NUQVRVU19VTlNQRUNJRklFRBAAEhUKEUNPTU1BTkRfU1RBVFVTX09LEAESGAoUQ09NTUFORF9TVEFUVVNfRVJST1IQAhIaChZDT01NQU5EX1NUQVRVU19GQUlMVVJFEAMSGAoUQ09NTUFORF9TVEFUVVNfRkFUQUwQBCpaCgtBdWRpdEVmZmVjdBIcChhBVURJVF9FRkZFQ1RfVU5TUEVDSUZJRUQQABIVChFBVURJVF9FRkZFQ1RfREVOWRABEhYKEkFVRElUX0VGRkVDVF9BTExPVxACMqACCg1QbHVnaW5TZXJ2aWNlEkkKBEluaXQSHy5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlcXVlc3QaIC5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlc3BvbnNlEl4KC0hhbmRsZUV2ZW50EiYuaG9sb211c2gucGx1Z2luLnYxLkhhbmRsZUV2ZW50UmVxdWVzdBonLmhvbG9tdXNoLnBsdWdpbi52MS5IYW5kbGVFdmVudFJlc3BvbnNlEmQKDUhhbmRsZUNvbW1hbmQSKC5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlcXVlc3QaKS5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlc3BvbnNlMtIEChFQbHVnaW5Ib3N0U2VydmljZRJ6CglFbWl0RXZlbnQSNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0GjYuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlRW1pdEV2ZW50UmVzcG9uc2USaAoDTG9nEi8uaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlTG9nUmVxdWVzdBowLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUxvZ1Jlc3BvbnNlEm4KBUtWR2V0EjEuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXF1ZXN0GjIuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXNwb25zZRJuCgVLVlNldBIxLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVxdWVzdBoyLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2USdwoIS1ZEZWxldGUSNC5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QaNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlc3BvbnNlQkRaQmdpdGh1Yi5jb20vaG9sb211c2gvaG9sb211c2gvcGtnL3Byb3RvL2hvbG9tdXNoL3BsdWdpbi92MTtwbHVnaW52MWIGcHJvdG8z", [file_buf_validate_validate]);
+  fileDesc("Ch9ob2xvbXVzaC9wbHVnaW4vdjEvcGx1Z2luLnByb3RvEhJob2xvbXVzaC5wbHVnaW4udjEitwEKDVNlcnZpY2VDb25maWcSGQoRY29ubmVjdGlvbl9zdHJpbmcYASABKAkSUgoRcmVxdWlyZWRfc2VydmljZXMYAiADKAsyNy5ob2xvbXVzaC5wbHVnaW4udjEuU2VydmljZUNvbmZpZy5SZXF1aXJlZFNlcnZpY2VzRW50cnkaNwoVUmVxdWlyZWRTZXJ2aWNlc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQAoLSW5pdFJlcXVlc3QSMQoGY29uZmlnGAEgASgLMiEuaG9sb211c2gucGx1Z2luLnYxLlNlcnZpY2VDb25maWciKQoMSW5pdFJlc3BvbnNlEhkKEXByb3ZpZGVkX3NlcnZpY2VzGAEgAygJIrMBCgVFdmVudBITCgJpZBgBIAEoCUIHukgEcgIQARIXCgZzdHJlYW0YAiABKAlCB7pIBHICEAESFQoEdHlwZRgDIAEoCUIHukgEcgIQARIRCgl0aW1lc3RhbXAYBCABKAMSGwoKYWN0b3Jfa2luZBgFIAEoCUIHukgEcgIQARIZCghhY3Rvcl9pZBgGIAEoCUIHukgEcgIQARIaCgdwYXlsb2FkGAcgASgJQgm6SAZyBBiAgAQiVwoJRW1pdEV2ZW50EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIVCgR0eXBlGAIgASgJQge6SARyAhABEhoKB3BheWxvYWQYAyABKAlCCbpIBnIEGICABCI+ChJIYW5kbGVFdmVudFJlcXVlc3QSKAoFZXZlbnQYASABKAsyGS5ob2xvbXVzaC5wbHVnaW4udjEuRXZlbnQiSQoTSGFuZGxlRXZlbnRSZXNwb25zZRIyCgtlbWl0X2V2ZW50cxgBIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQi9gEKDkNvbW1hbmRSZXF1ZXN0EhgKB2NvbW1hbmQYASABKAlCB7pIBHICEAESFgoEYXJncxgCIAEoCUIIukgFcgMYgEASGwoJcmF3X2lucHV0GAMgASgJQgi6SAVyAxiAQBIdCgxjaGFyYWN0ZXJfaWQYBCABKAlCB7pIBHICEAESHwoOY2hhcmFjdGVyX25hbWUYBSABKAlCB7pIBHICEAESHAoLbG9jYXRpb25faWQYBiABKAlCB7pIBHICEAESGwoKc2Vzc2lvbl9pZBgHIAEoCUIHukgEcgIQARIaCglwbGF5ZXJfaWQYCCABKAlCB7pIBHICEAEiyQEKD0NvbW1hbmRSZXNwb25zZRIxCgZzdGF0dXMYASABKA4yIS5ob2xvbXVzaC5wbHVnaW4udjEuQ29tbWFuZFN0YXR1cxIYCgZvdXRwdXQYAiABKAlCCLpIBXIDGIBAEi0KBmV2ZW50cxgDIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQSOgoLYXVkaXRfaGludHMYBCADKAsyJS5ob2xvbXVzaC5wbHVnaW4udjEuQXVkaXREZWNpc2lvbkhpbnQizAIKEUF1ZGl0RGVjaXNpb25IaW50EhYKAmlkGAEgASgJQgq6SAdyBRABGIABEhYKBG5hbWUYAiABKAlCCLpIBXIDGIACEhkKB21lc3NhZ2UYAyABKAlCCLpIBXIDGIAIEi8KBmVmZmVjdBgEIAEoDjIfLmhvbG9tdXNoLnBsdWdpbi52MS5BdWRpdEVmZmVjdBIhChBhY3Rpb25fcXVhbGlmaWVyGAUgASgJQge6SARyAhhAEhoKCHJlc291cmNlGAYgASgJQgi6SAVyAxiAAhJJCgphdHRyaWJ1dGVzGAcgAygLMjUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RGVjaXNpb25IaW50LkF0dHJpYnV0ZXNFbnRyeRoxCg9BdHRyaWJ1dGVzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJLChRIYW5kbGVDb21tYW5kUmVxdWVzdBIzCgdjb21tYW5kGAEgASgLMiIuaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRSZXF1ZXN0Ik4KFUhhbmRsZUNvbW1hbmRSZXNwb25zZRI1CghyZXNwb25zZRgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kUmVzcG9uc2UiagohUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIbCgpldmVudF90eXBlGAIgASgJQge6SARyAhABEg8KB3BheWxvYWQYAyABKAwiJAoiUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXNwb25zZSJQChtQbHVnaW5Ib3N0U2VydmljZUxvZ1JlcXVlc3QSFgoFbGV2ZWwYASABKAlCB7pIBHICEAESGQoHbWVzc2FnZRgCIAEoCUIIukgFcgMYgEAiHgocUGx1Z2luSG9zdFNlcnZpY2VMb2dSZXNwb25zZSJTCh1QbHVnaW5Ib3N0U2VydmljZUtWR2V0UmVxdWVzdBIcCgtwbHVnaW5fbmFtZRgBIAEoCUIHukgEcgIQARIUCgNrZXkYAiABKAlCB7pIBHICEAEiPgoeUGx1Z2luSG9zdFNlcnZpY2VLVkdldFJlc3BvbnNlEg0KBXZhbHVlGAEgASgJEg0KBWZvdW5kGAIgASgIImIKHVBsdWdpbkhvc3RTZXJ2aWNlS1ZTZXRSZXF1ZXN0EhwKC3BsdWdpbl9uYW1lGAEgASgJQge6SARyAhABEhQKA2tleRgCIAEoCUIHukgEcgIQARINCgV2YWx1ZRgDIAEoCSIgCh5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2UiVgogUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QSHAoLcGx1Z2luX25hbWUYASABKAlCB7pIBHICEAESFAoDa2V5GAIgASgJQge6SARyAhABIiMKIVBsdWdpbkhvc3RTZXJ2aWNlS1ZEZWxldGVSZXNwb25zZSJOCihQbHVnaW5Ib3N0U2VydmljZUFkZFNlc3Npb25TdHJlYW1SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkSDgoGc3RyZWFtGAIgASgJIjwKKVBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgiUQorUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg4KBnN0cmVhbRgCIAEoCSI/CixQbHVnaW5Ib3N0U2VydmljZVJlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIIlkKGlF1ZXJ5U2Vzc2lvblN0cmVhbXNSZXF1ZXN0EhQKDGNoYXJhY3Rlcl9pZBgBIAEoCRIRCglwbGF5ZXJfaWQYAiABKAkSEgoKc2Vzc2lvbl9pZBgDIAEoCSI9ChtRdWVyeVNlc3Npb25TdHJlYW1zUmVzcG9uc2USDwoHc3RyZWFtcxgBIAMoCRINCgVlcnJvchgCIAEoCSqWAQoNQ29tbWFuZFN0YXR1cxIeChpDT01NQU5EX1NUQVRVU19VTlNQRUNJRklFRBAAEhUKEUNPTU1BTkRfU1RBVFVTX09LEAESGAoUQ09NTUFORF9TVEFUVVNfRVJST1IQAhIaChZDT01NQU5EX1NUQVRVU19GQUlMVVJFEAMSGAoUQ09NTUFORF9TVEFUVVNfRkFUQUwQBCpaCgtBdWRpdEVmZmVjdBIcChhBVURJVF9FRkZFQ1RfVU5TUEVDSUZJRUQQABIVChFBVURJVF9FRkZFQ1RfREVOWRABEhYKEkFVRElUX0VGRkVDVF9BTExPVxACMpgDCg1QbHVnaW5TZXJ2aWNlEkkKBEluaXQSHy5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlcXVlc3QaIC5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlc3BvbnNlEl4KC0hhbmRsZUV2ZW50EiYuaG9sb211c2gucGx1Z2luLnYxLkhhbmRsZUV2ZW50UmVxdWVzdBonLmhvbG9tdXNoLnBsdWdpbi52MS5IYW5kbGVFdmVudFJlc3BvbnNlEmQKDUhhbmRsZUNvbW1hbmQSKC5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlcXVlc3QaKS5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlc3BvbnNlEnYKE1F1ZXJ5U2Vzc2lvblN0cmVhbXMSLi5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1JlcXVlc3QaLy5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1Jlc3BvbnNlMv8GChFQbHVnaW5Ib3N0U2VydmljZRJ6CglFbWl0RXZlbnQSNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0GjYuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlRW1pdEV2ZW50UmVzcG9uc2USaAoDTG9nEi8uaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlTG9nUmVxdWVzdBowLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUxvZ1Jlc3BvbnNlEm4KBUtWR2V0EjEuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXF1ZXN0GjIuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXNwb25zZRJuCgVLVlNldBIxLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVxdWVzdBoyLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2USdwoIS1ZEZWxldGUSNC5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QaNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlc3BvbnNlEo8BChBBZGRTZXNzaW9uU3RyZWFtEjwuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlcXVlc3QaPS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VBZGRTZXNzaW9uU3RyZWFtUmVzcG9uc2USmAEKE1JlbW92ZVNlc3Npb25TdHJlYW0SPy5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVxdWVzdBpALmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZVJlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZUJEWkJnaXRodWIuY29tL2hvbG9tdXNoL2hvbG9tdXNoL3BrZy9wcm90by9ob2xvbXVzaC9wbHVnaW4vdjE7cGx1Z2ludjFiBnByb3RvMw", [file_buf_validate_validate]);
 
 /**
  * ServiceConfig carries initialization data from the host to the plugin.
@@ -660,6 +660,167 @@ export const PluginHostServiceKVDeleteResponseSchema: GenMessage<PluginHostServi
   messageDesc(file_holomush_plugin_v1_plugin, 21);
 
 /**
+ * PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
+ *
+ * @generated from message holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
+ */
+export type PluginHostServiceAddSessionStreamRequest = Message<"holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest"> & {
+  /**
+   * Active session identifier.
+   *
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * Stream name to subscribe to (format: "prefix:id").
+   *
+   * @generated from field: string stream = 2;
+   */
+  stream: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest.
+ * Use `create(PluginHostServiceAddSessionStreamRequestSchema)` to create a new message.
+ */
+export const PluginHostServiceAddSessionStreamRequestSchema: GenMessage<PluginHostServiceAddSessionStreamRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 22);
+
+/**
+ * PluginHostServiceAddSessionStreamResponse indicates success or failure.
+ *
+ * @generated from message holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
+ */
+export type PluginHostServiceAddSessionStreamResponse = Message<"holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse"> & {
+  /**
+   * Whether the stream was successfully added.
+   *
+   * @generated from field: bool success = 1;
+   */
+  success: boolean;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse.
+ * Use `create(PluginHostServiceAddSessionStreamResponseSchema)` to create a new message.
+ */
+export const PluginHostServiceAddSessionStreamResponseSchema: GenMessage<PluginHostServiceAddSessionStreamResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 23);
+
+/**
+ * PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
+ *
+ * @generated from message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
+ */
+export type PluginHostServiceRemoveSessionStreamRequest = Message<"holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest"> & {
+  /**
+   * Active session identifier.
+   *
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * Stream name to unsubscribe from.
+   *
+   * @generated from field: string stream = 2;
+   */
+  stream: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest.
+ * Use `create(PluginHostServiceRemoveSessionStreamRequestSchema)` to create a new message.
+ */
+export const PluginHostServiceRemoveSessionStreamRequestSchema: GenMessage<PluginHostServiceRemoveSessionStreamRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 24);
+
+/**
+ * PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
+ *
+ * @generated from message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
+ */
+export type PluginHostServiceRemoveSessionStreamResponse = Message<"holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse"> & {
+  /**
+   * Whether the stream was successfully removed (true even if not subscribed).
+   *
+   * @generated from field: bool success = 1;
+   */
+  success: boolean;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse.
+ * Use `create(PluginHostServiceRemoveSessionStreamResponseSchema)` to create a new message.
+ */
+export const PluginHostServiceRemoveSessionStreamResponseSchema: GenMessage<PluginHostServiceRemoveSessionStreamResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 25);
+
+/**
+ * QuerySessionStreamsRequest provides session context for stream contribution.
+ *
+ * @generated from message holomush.plugin.v1.QuerySessionStreamsRequest
+ */
+export type QuerySessionStreamsRequest = Message<"holomush.plugin.v1.QuerySessionStreamsRequest"> & {
+  /**
+   * Identifier of the character entering the session.
+   *
+   * @generated from field: string character_id = 1;
+   */
+  characterId: string;
+
+  /**
+   * Identifier of the player owning the character.
+   *
+   * @generated from field: string player_id = 2;
+   */
+  playerId: string;
+
+  /**
+   * Session identifier.
+   *
+   * @generated from field: string session_id = 3;
+   */
+  sessionId: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.QuerySessionStreamsRequest.
+ * Use `create(QuerySessionStreamsRequestSchema)` to create a new message.
+ */
+export const QuerySessionStreamsRequestSchema: GenMessage<QuerySessionStreamsRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 26);
+
+/**
+ * QuerySessionStreamsResponse returns stream names and an optional error.
+ *
+ * @generated from message holomush.plugin.v1.QuerySessionStreamsResponse
+ */
+export type QuerySessionStreamsResponse = Message<"holomush.plugin.v1.QuerySessionStreamsResponse"> & {
+  /**
+   * Stream names the plugin wants added to this session's subscription.
+   *
+   * @generated from field: repeated string streams = 1;
+   */
+  streams: string[];
+
+  /**
+   * Non-empty indicates a plugin-reported error. Host degrades (logs + skips).
+   *
+   * @generated from field: string error = 2;
+   */
+  error: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.QuerySessionStreamsResponse.
+ * Use `create(QuerySessionStreamsResponseSchema)` to create a new message.
+ */
+export const QuerySessionStreamsResponseSchema: GenMessage<QuerySessionStreamsResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 27);
+
+/**
  * CommandStatus maps to pkg/plugin.CommandStatus values.
  *
  * @generated from enum holomush.plugin.v1.CommandStatus
@@ -768,6 +929,18 @@ export const PluginService: GenService<{
     input: typeof HandleCommandRequestSchema;
     output: typeof HandleCommandResponseSchema;
   },
+  /**
+   * QuerySessionStreams returns stream names the plugin wants subscribed for a session.
+   * Called once at session establishment, before LISTEN setup.
+   * Only invoked for plugins that declare session_streams: true in their manifest.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginService.QuerySessionStreams
+   */
+  querySessionStreams: {
+    methodKind: "unary";
+    input: typeof QuerySessionStreamsRequestSchema;
+    output: typeof QuerySessionStreamsResponseSchema;
+  },
 }> = /*@__PURE__*/
   serviceDesc(file_holomush_plugin_v1_plugin, 0);
 
@@ -827,6 +1000,28 @@ export const PluginHostService: GenService<{
     methodKind: "unary";
     input: typeof PluginHostServiceKVDeleteRequestSchema;
     output: typeof PluginHostServiceKVDeleteResponseSchema;
+  },
+  /**
+   * AddSessionStream subscribes an active session to an additional stream mid-session.
+   * Returns SESSION_NOT_FOUND (codes.NotFound) if session_id is not active.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.AddSessionStream
+   */
+  addSessionStream: {
+    methodKind: "unary";
+    input: typeof PluginHostServiceAddSessionStreamRequestSchema;
+    output: typeof PluginHostServiceAddSessionStreamResponseSchema;
+  },
+  /**
+   * RemoveSessionStream unsubscribes an active session from a stream.
+   * Idempotent: returns success if stream is not subscribed.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.RemoveSessionStream
+   */
+  removeSessionStream: {
+    methodKind: "unary";
+    input: typeof PluginHostServiceRemoveSessionStreamRequestSchema;
+    output: typeof PluginHostServiceRemoveSessionStreamResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_holomush_plugin_v1_plugin, 1);


### PR DESCRIPTION
## Summary

- Adds `QuerySessionStreams` to the `Host` interface (Lua + binary), called at session start to let plugins contribute streams for pre-LISTEN subscription
- Adds `AddSessionStream` / `RemoveSessionStream` to `HostFunctionsService` proto and `PluginHostService`, enabling mid-session stream push/pull via `SessionStreamRegistry`
- Extends `CoreServer.Subscribe` to collect plugin-contributed streams before LISTEN setup, merge them with static streams (dedup, location-stream guard), and handle mid-session add/remove via per-stream cancel contexts
- Wires `SessionStreamRegistry` through plugin subsystem and gRPC server in `cmd/holomush`

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — 5149 unit tests, 0 failures
- [x] `task test:int` — 284 integration tests including 5 new plugin session stream integration tests
- [x] `task test:e2e` — 48 E2E tests, 0 failures
- [x] `task pr-prep` — all checks green

## Key design decisions

- **Pull-based at session start**: `QuerySessionStreams` is called once before LISTEN, ensuring LISTEN-before-replay invariant is maintained for plugin-contributed streams
- **Push-based mid-session**: `AddSessionStream` / `RemoveSessionStream` give plugins imperative control; each stream gets its own `context.WithCancel` for clean teardown
- **Degraded-subscribe policy**: plugin failures during `QuerySessionStreams` log + skip; session proceeds with core-only streams
- **Location stream protection**: plugins cannot subscribe to `location:*` streams (reserved for core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can contribute session-scoped streams at session start (QuerySessionStreams) and request mid-session subscribe/unsubscribe (AddSessionStream / RemoveSessionStream); Remove is idempotent. Lua host functions holomush.add_session_stream / holomush.remove_session_stream and a runtime session stream registry enable live add/remove without reconnect. Manifest gains session_streams opt‑in.

* **Documentation**
  * Added end‑to‑end design and implementation plan covering contribution, registry, and LISTEN-before-replay semantics.

* **Tests**
  * New unit and integration tests for contribution, validation, deduplication, registry dispatch, and live add/remove behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->