### PR TITLE
feat(plugin): make ABAC actions extensible for plugin-contributed action types

### DIFF
--- a/docs/superpowers/plans/2026-04-11-extensible-actions.md
+++ b/docs/superpowers/plans/2026-04-11-extensible-actions.md
@@ -12,15 +12,15 @@
 
 ## File Map
 
-| File | Change |
-|---|---|
-| `internal/command/types.go` | Remove `!validActions` check from `Validate()`; add `CoreActions()`, `ValidateAction()` |
-| `internal/command/types_test.go` | Update "unknown action" test cases; add `CoreActions` and `ValidateAction` tests |
-| `internal/plugin/manifest.go` | Add `Actions []string` field; validate in `Manifest.Validate()` |
-| `internal/plugin/manifest_test.go` | Add table-driven cases to `TestParseManifestResourceTypesAndTrust` for `actions` |
-| `internal/plugin/manager.go` | Add `CollectActions()`; update `loadPlugin` signature and body; update `LoadAll` Phase 2 |
-| `internal/plugin/manager_test.go` | Add `CollectActions` unit tests; add `LoadAll` action validation integration tests |
-| `test/integration/plugin/extensible_actions_test.go` | New Ginkgo integration test: custom actions end-to-end through LoadAll |
+| File                                                     | Change                                                                                    |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `internal/command/types.go`                              | Remove `!validActions` check from `Validate()`; add `CoreActions()`, `ValidateAction()`  |
+| `internal/command/types_test.go`                         | Update "unknown action" test cases; add `CoreActions` and `ValidateAction` tests          |
+| `internal/plugin/manifest.go`                            | Add `Actions []string` field; validate in `Manifest.Validate()`                          |
+| `internal/plugin/manifest_test.go`                       | Add table-driven cases to `TestParseManifestResourceTypesAndTrust` for `actions`         |
+| `internal/plugin/manager.go`                             | Add `CollectActions()`; update `loadPlugin` signature and body; update `LoadAll` Phase 2 |
+| `internal/plugin/manager_test.go`                        | Add `CollectActions` unit tests; add `LoadAll` action validation integration tests        |
+| `test/integration/plugin/extensible_actions_test.go`     | New Ginkgo integration test: custom actions end-to-end through `LoadAll`                 |
 
 ---
 

--- a/docs/superpowers/plans/2026-04-11-extensible-actions.md
+++ b/docs/superpowers/plans/2026-04-11-extensible-actions.md
@@ -1,0 +1,896 @@
+# Extensible Plugin Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow plugins to declare custom ABAC action strings (e.g., `join`, `leave`) in their manifests, unblocking the core-channels plugin and any future plugin with domain-specific ABAC actions.
+
+**Architecture:** Three-layer change: (1) relax `Capability.Validate()` to defer action validation to load time, (2) add `actions` field to manifests with `CollectActions` merge pass in the plugin manager, (3) call `ValidateAction` during `loadPlugin` and warn when a plugin borrows an action it doesn't own.
+
+**Tech Stack:** Go 1.26, `internal/command`, `internal/plugin`, `github.com/samber/oops`, `log/slog`, Ginkgo/Gomega for integration tests.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `internal/command/types.go` | Remove `!validActions` check from `Validate()`; add `CoreActions()`, `ValidateAction()` |
+| `internal/command/types_test.go` | Update "unknown action" test cases; add `CoreActions` and `ValidateAction` tests |
+| `internal/plugin/manifest.go` | Add `Actions []string` field; validate in `Manifest.Validate()` |
+| `internal/plugin/manifest_test.go` | Add table-driven cases to `TestParseManifestResourceTypesAndTrust` for `actions` |
+| `internal/plugin/manager.go` | Add `CollectActions()`; update `loadPlugin` signature and body; update `LoadAll` Phase 2 |
+| `internal/plugin/manager_test.go` | Add `CollectActions` unit tests; add `LoadAll` action validation integration tests |
+| `test/integration/plugin/extensible_actions_test.go` | New Ginkgo integration test: custom actions end-to-end through LoadAll |
+
+---
+
+## Task 1: Relax `Capability.Validate()` to accept unknown action strings
+
+The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that must be removed. `TestNewCommandEntry_InvalidCapabilityReturnsError` has the same. A new positive test asserts that unknown actions pass `Validate()`. Only then do we remove the `!validActions` check.
+
+**Files:**
+- Modify: `internal/command/types_test.go`
+- Modify: `internal/command/types.go:150-157`
+
+- [ ] **Step 1: Update `TestCapability_ValidateInvalid` — remove the "unknown action" case**
+
+  Open `internal/command/types_test.go` at line 590. The table currently contains:
+
+  ```go
+  {"unknown action", Capability{Action: "destroy", Resource: "location"}, "action"},
+  ```
+
+  Remove that row. The table should become:
+
+  ```go
+  func TestCapability_ValidateInvalid(t *testing.T) {
+  	tests := []struct {
+  		name string
+  		cap  Capability
+  		want string
+  	}{
+  		{"empty action", Capability{Action: "", Resource: "location"}, "action"},
+  		{"empty resource", Capability{Action: "read", Resource: ""}, "resource"},
+  		// Note: unknown resource type is NOT checked by Validate() — it's checked
+  		// by ValidateResourceType() at load time with cross-plugin context.
+  		{"invalid scope", Capability{Action: "read", Resource: "location", Scope: "everywhere"}, "scope"},
+  	}
+  	for _, tt := range tests {
+  		t.Run(tt.name, func(t *testing.T) {
+  			err := tt.cap.Validate()
+  			require.Error(t, err)
+  			assert.Contains(t, err.Error(), tt.want)
+  		})
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Update `TestNewCommandEntry_InvalidCapabilityReturnsError` — remove "unknown action" case**
+
+  Find `TestNewCommandEntry_InvalidCapabilityReturnsError` (around line 648). Remove the case:
+
+  ```go
+  {
+  	name: "unknown action",
+  	caps: []Capability{{Action: "destroy", Resource: "location"}},
+  	want: "action",
+  },
+  ```
+
+- [ ] **Step 3: Add a positive test confirming unknown actions pass `Validate()`**
+
+  Add directly after `TestCapability_ValidateAcceptsUnknownResourceType` (around line 617):
+
+  ```go
+  func TestCapability_ValidateAcceptsUnknownAction(t *testing.T) {
+  	// Validate() is structural only — unknown actions pass here.
+  	// ValidateAction() checks membership at load time with cross-plugin context.
+  	c := Capability{Action: "destroy", Resource: "location"}
+  	assert.NoError(t, c.Validate())
+  }
+  ```
+
+- [ ] **Step 4: Run the tests — they should fail because `Validate()` still rejects "destroy"**
+
+  ```bash
+  task test -- -run TestCapability_ValidateAcceptsUnknownAction ./internal/command/
+  ```
+
+  Expected: FAIL — `"unknown action \"destroy\""` error.
+
+- [ ] **Step 5: Remove the `!validActions` check from `Capability.Validate()`**
+
+  In `internal/command/types.go`, `Capability.Validate()` (around line 150), delete lines:
+
+  ```go
+  if !validActions[c.Action] {
+  	return oops.Code("INVALID_CAPABILITY").
+  		With("action", c.Action).
+  		Errorf("unknown action %q", c.Action)
+  }
+  ```
+
+  The method should now read:
+
+  ```go
+  func (c Capability) Validate() error {
+  	if c.Action == "" {
+  		return oops.Code("INVALID_CAPABILITY").Errorf("action is required")
+  	}
+  	if c.Resource == "" {
+  		return oops.Code("INVALID_CAPABILITY").Errorf("resource is required")
+  	}
+  	if !validScopes[c.Scope] {
+  		return oops.Code("INVALID_CAPABILITY").
+  			With("scope", c.Scope).
+  			Errorf("unknown scope %q", c.Scope)
+  	}
+  	return nil
+  }
+  ```
+
+- [ ] **Step 6: Run all command package tests**
+
+  ```bash
+  task test -- ./internal/command/
+  ```
+
+  Expected: PASS.
+
+---
+
+## Task 2: Add `CoreActions()` and `ValidateAction()`
+
+**Files:**
+- Modify: `internal/command/types_test.go`
+- Modify: `internal/command/types.go`
+
+- [ ] **Step 1: Write failing tests for `CoreActions()` and `ValidateAction()`**
+
+  Add after `TestCoreResourceTypesReturnsCopy` (around line 632) in `internal/command/types_test.go`:
+
+  ```go
+  func TestCoreActionsContainsExpectedDefaults(t *testing.T) {
+  	actions := CoreActions()
+  	for _, expected := range []string{"read", "write", "emit", "enter", "use", "delete", "execute", "admin"} {
+  		assert.True(t, actions[expected], "core action %q must be present", expected)
+  	}
+  }
+
+  func TestCoreActionsReturnsCopy(t *testing.T) {
+  	actions := CoreActions()
+  	assert.True(t, actions["read"])
+  	// Mutating the copy must not affect a second call.
+  	actions["invent"] = true
+  	actions2 := CoreActions()
+  	assert.False(t, actions2["invent"], "subsequent calls must not see prior mutations")
+  }
+
+  func TestCapability_ValidateActionWithKnownAction(t *testing.T) {
+  	known := map[string]bool{"join": true, "read": true}
+  	assert.NoError(t, Capability{Action: "join", Resource: "channel"}.ValidateAction(known))
+  	assert.NoError(t, Capability{Action: "read", Resource: "location"}.ValidateAction(known))
+  }
+
+  func TestCapability_ValidateActionWithUnknownAction(t *testing.T) {
+  	known := map[string]bool{"read": true}
+  	err := Capability{Action: "join", Resource: "channel"}.ValidateAction(known)
+  	require.Error(t, err)
+  	assert.Contains(t, err.Error(), "join")
+  	errutil.AssertErrorCode(t, err, "INVALID_CAPABILITY")
+  }
+
+  func TestCapability_ValidateActionBoundaryEmptyKnownMap(t *testing.T) {
+  	err := Capability{Action: "read", Resource: "location"}.ValidateAction(map[string]bool{})
+  	require.Error(t, err, "empty known map must reject any action")
+  }
+  ```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+  ```bash
+  task test -- -run "TestCoreActions|TestCapability_ValidateAction" ./internal/command/
+  ```
+
+  Expected: FAIL — `CoreActions` and `ValidateAction` undefined.
+
+- [ ] **Step 3: Add `CoreActions()` and `ValidateAction()` to `internal/command/types.go`**
+
+  Add after `CoreResourceTypes()` (around line 190):
+
+  ```go
+  // CoreActions returns a defensive copy of the built-in action set.
+  // Used by the plugin manager to build the full known-actions map.
+  func CoreActions() map[string]bool {
+  	result := make(map[string]bool, len(validActions))
+  	for k, v := range validActions {
+  		result[k] = v
+  	}
+  	return result
+  }
+
+  // ValidateAction checks that the capability's action is in the provided set.
+  // Called during plugin load with a set that includes both core actions and
+  // plugin-declared actions.
+  func (c Capability) ValidateAction(known map[string]bool) error {
+  	if !known[c.Action] {
+  		return oops.Code("INVALID_CAPABILITY").
+  			With("action", c.Action).
+  			Errorf("unknown action %q", c.Action)
+  	}
+  	return nil
+  }
+  ```
+
+- [ ] **Step 4: Run tests**
+
+  ```bash
+  task test -- ./internal/command/
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(command): relax Capability.Validate(), add CoreActions/ValidateAction"
+  ```
+
+---
+
+## Task 3: Add `actions` field to Manifest
+
+**Files:**
+- Modify: `internal/plugin/manifest.go`
+- Modify: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write failing tests — add cases to `TestParseManifestResourceTypesAndTrust`**
+
+  In `internal/plugin/manifest_test.go`, find `TestParseManifestResourceTypesAndTrust` (around line 1766). Add four new cases to the `tests` slice before the closing `}`:
+
+  ```go
+  {
+  	name: "parses actions when declared on a binary plugin",
+  	yaml: `
+  name: test-plugin
+  version: 1.0.0
+  type: binary
+  binary-plugin:
+    executable: test-plugin
+  actions: [join, leave]
+  `,
+  	check: func(t *testing.T, m *plugins.Manifest) {
+  		assert.Equal(t, []string{"join", "leave"}, m.Actions)
+  	},
+  },
+  {
+  	name: "parses actions when declared on a Lua plugin",
+  	yaml: `
+  name: test-plugin
+  version: 1.0.0
+  type: lua
+  lua-plugin:
+    entry: main.lua
+  actions: [craft]
+  `,
+  	check: func(t *testing.T, m *plugins.Manifest) {
+  		assert.Equal(t, []string{"craft"}, m.Actions)
+  	},
+  },
+  {
+  	name:    "rejects actions with an empty entry",
+  	wantErr: "action",
+  	yaml: `
+  name: test-plugin
+  version: 1.0.0
+  type: lua
+  lua-plugin:
+    entry: main.lua
+  actions: [""]
+  `,
+  },
+  {
+  	name:    "rejects actions with duplicate entries",
+  	wantErr: "duplicate",
+  	yaml: `
+  name: test-plugin
+  version: 1.0.0
+  type: binary
+  binary-plugin:
+    executable: test-plugin
+  actions: [join, join]
+  `,
+  },
+  {
+  	name: "accepts actions that re-declare a core action",
+  	yaml: `
+  name: test-plugin
+  version: 1.0.0
+  type: binary
+  binary-plugin:
+    executable: test-plugin
+  actions: [read]
+  `,
+  	check: func(t *testing.T, m *plugins.Manifest) {
+  		assert.Equal(t, []string{"read"}, m.Actions)
+  	},
+  },
+  ```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+  ```bash
+  task test -- -run TestParseManifestResourceTypesAndTrust ./internal/plugin/
+  ```
+
+  Expected: FAIL — `actions` field unknown / not parsed.
+
+- [ ] **Step 3: Add `Actions` field to `Manifest` struct**
+
+  In `internal/plugin/manifest.go`, find the `Manifest` struct (around line 96). Add `Actions` after `ResourceTypes`:
+
+  ```go
+  // ABAC trust boundary fields
+  ResourceTypes []string     `yaml:"resource_types,omitempty" json:"resource_types,omitempty"`
+  Actions       []string     `yaml:"actions,omitempty" json:"actions,omitempty"`
+  Trust         *TrustConfig `yaml:"trust,omitempty" json:"trust,omitempty"`
+  ```
+
+- [ ] **Step 4: Add `actions` validation to `Manifest.Validate()`**
+
+  In `internal/plugin/manifest.go`, find the `resource_types` validation block (around line 393). Add an `actions` validation block immediately after it (before `return nil`):
+
+  ```go
+  // Validate actions: no empty strings, no duplicates.
+  // All plugin types may declare actions (unlike resource_types, actions
+  // have no structural coupling to AttributeResolverService).
+  if len(m.Actions) > 0 {
+  	seen := make(map[string]bool, len(m.Actions))
+  	for _, a := range m.Actions {
+  		if a == "" {
+  			return oops.In("manifest").With("name", m.Name).
+  				New("action entry must not be empty")
+  		}
+  		if seen[a] {
+  			return oops.In("manifest").With("name", m.Name).With("action", a).
+  				New("duplicate action")
+  		}
+  		seen[a] = true
+  	}
+  }
+  ```
+
+- [ ] **Step 5: Run tests**
+
+  ```bash
+  task test -- ./internal/plugin/
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(plugin): add actions field to Manifest with validation"
+  ```
+
+---
+
+## Task 4: Add `CollectActions()` to the plugin manager
+
+**Files:**
+- Modify: `internal/plugin/manager.go`
+- Modify: `internal/plugin/manager_test.go`
+
+- [ ] **Step 1: Write failing tests for `CollectActions()`**
+
+  In `internal/plugin/manager_test.go`, add after `TestCollectResourceTypesReturnsNewMapPerCall` (around line 883):
+
+  ```go
+  // CollectActions is the exported test seam that backs the
+  // cross-plugin action collection used during LoadAll.
+
+  func TestCollectActionsIncludesCoreActions(t *testing.T) {
+  	known := plugins.CollectActions(nil)
+  	for _, action := range []string{"read", "write", "emit", "enter", "use", "delete", "execute", "admin"} {
+  		assert.True(t, known[action], "core action %q must be included", action)
+  	}
+  }
+
+  func TestCollectActionsMergesExplicitManifestActions(t *testing.T) {
+  	discovered := []*plugins.DiscoveredPlugin{
+  		{Manifest: &plugins.Manifest{Name: "p1", Actions: []string{"join"}}},
+  		{Manifest: &plugins.Manifest{Name: "p2", Actions: []string{"leave", "vote"}}},
+  	}
+  	known := plugins.CollectActions(discovered)
+  	assert.True(t, known["join"], "declared 'join' should be present")
+  	assert.True(t, known["leave"], "declared 'leave' should be present")
+  	assert.True(t, known["vote"], "declared 'vote' should be present")
+  	assert.True(t, known["read"], "core actions should still be present after merge")
+  }
+
+  func TestCollectActionsDeduplicatesAcrossPlugins(t *testing.T) {
+  	discovered := []*plugins.DiscoveredPlugin{
+  		{Manifest: &plugins.Manifest{Name: "p1", Actions: []string{"join"}}},
+  		{Manifest: &plugins.Manifest{Name: "p2", Actions: []string{"join"}}},
+  	}
+  	known := plugins.CollectActions(discovered)
+  	assert.True(t, known["join"], "'join' declared by two plugins should be present once")
+  }
+
+  func TestCollectActionsReturnsNewMapPerCall(t *testing.T) {
+  	first := plugins.CollectActions(nil)
+  	first["mutated"] = true
+  	second := plugins.CollectActions(nil)
+  	assert.False(t, second["mutated"], "subsequent calls must not see prior mutations")
+  }
+
+  func TestCollectActionsIgnoresCapabilityActionsNotInActionsField(t *testing.T) {
+  	// Only the explicit Actions manifest field feeds CollectActions.
+  	// Action strings in command capabilities are NOT auto-promoted.
+  	discovered := []*plugins.DiscoveredPlugin{
+  		{Manifest: &plugins.Manifest{
+  			Name: "p1",
+  			Commands: []plugins.CommandSpec{
+  				{Name: "channel", Capabilities: []command.Capability{
+  					{Action: "join", Resource: "channel"},
+  				}},
+  			},
+  			// No Actions field declared.
+  		}},
+  	}
+  	known := plugins.CollectActions(discovered)
+  	assert.False(t, known["join"], "'join' in capabilities but not in actions field must not appear")
+  }
+  ```
+
+  Note: this test file imports `command "github.com/holomush/holomush/internal/command"` — check the existing imports and add it if missing.
+
+- [ ] **Step 2: Run to confirm they fail**
+
+  ```bash
+  task test -- -run "TestCollectActions" ./internal/plugin/
+  ```
+
+  Expected: FAIL — `plugins.CollectActions` undefined.
+
+- [ ] **Step 3: Add `CollectActions()` to `internal/plugin/manager.go`**
+
+  Add directly after `CollectResourceTypes()` (around line 453):
+
+  ```go
+  // CollectActions builds the full set of known ABAC actions: core actions plus
+  // all actions explicitly declared across discovered plugins. This cross-plugin
+  // context is needed for semantic validation during loadPlugin. Exported as a
+  // test seam so callers can verify the merge logic without driving LoadAll.
+  func CollectActions(discovered []*DiscoveredPlugin) map[string]bool {
+  	known := command.CoreActions()
+  	for _, dp := range discovered {
+  		for _, a := range dp.Manifest.Actions {
+  			known[a] = true
+  		}
+  	}
+  	return known
+  }
+  ```
+
+- [ ] **Step 4: Run tests**
+
+  ```bash
+  task test -- ./internal/plugin/
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(plugin): add CollectActions for cross-plugin action validation"
+  ```
+
+---
+
+## Task 5: Wire `CollectActions` and `ValidateAction` into `LoadAll` / `loadPlugin`
+
+This is the integration point. `loadPlugin` gains a `knownActions` parameter. `LoadAll` Phase 2 collects actions alongside resource types. `loadPlugin` validates each capability action and warns when borrowing from another plugin.
+
+**Files:**
+- Modify: `internal/plugin/manager.go`
+- Modify: `internal/plugin/manager_test.go`
+
+- [ ] **Step 1: Write failing load integration tests**
+
+  Add after `TestManagerLoadAllAcceptsCapabilityOnAnotherPluginsResourceType` (around line 956) in `internal/plugin/manager_test.go`:
+
+  ```go
+  func TestManagerLoadAllRejectsCommandCapabilityOnUnknownAction(t *testing.T) {
+  	dir := t.TempDir()
+  	pluginsDir := filepath.Join(dir, "plugins")
+
+  	pluginDir := filepath.Join(pluginsDir, "channel-plugin")
+  	mkdirAll(t, pluginDir)
+  	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: channel-plugin
+  version: 1.0.0
+  type: lua
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: channel
+  lua-plugin:
+    entry: main.lua`))
+  	writeFile(t, filepath.Join(pluginDir, "main.lua"), []byte("function on_event(e) end"))
+
+  	luaHost := pluginlua.NewHost()
+  	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+  	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  	err := mgr.LoadAll(context.Background())
+  	require.Error(t, err, "load should fail when capability uses an undeclared action")
+  	assert.Contains(t, err.Error(), "join")
+  }
+
+  func TestManagerLoadAllAcceptsCapabilityWithDeclaredAction(t *testing.T) {
+  	dir := t.TempDir()
+  	pluginsDir := filepath.Join(dir, "plugins")
+
+  	pluginDir := filepath.Join(pluginsDir, "channel-plugin")
+  	mkdirAll(t, pluginDir)
+  	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: channel-plugin
+  version: 1.0.0
+  type: lua
+  actions: [join, leave]
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: channel
+        - action: leave
+          resource: channel
+  lua-plugin:
+    entry: main.lua`))
+  	writeFile(t, filepath.Join(pluginDir, "main.lua"), []byte("function on_event(e) end"))
+
+  	luaHost := pluginlua.NewHost()
+  	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+  	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  	err := mgr.LoadAll(context.Background())
+  	require.NoError(t, err, "load should succeed when action is declared in the plugin manifest")
+  	assert.Contains(t, mgr.ListPlugins(), "channel-plugin")
+  }
+
+  func TestManagerLoadAllAcceptsCapabilityOnAnotherPluginsAction(t *testing.T) {
+  	dir := t.TempDir()
+  	pluginsDir := filepath.Join(dir, "plugins")
+
+  	// Plugin A declares the "join" action so Plugin B's capability is valid.
+  	declarerDir := filepath.Join(pluginsDir, "action-declarer")
+  	mkdirAll(t, declarerDir)
+  	writeFile(t, filepath.Join(declarerDir, "plugin.yaml"), []byte(`name: action-declarer
+  version: 1.0.0
+  type: binary
+  actions: [join]
+  binary-plugin:
+    executable: action-declarer`))
+
+  	// Plugin B uses "join" declared by Plugin A.
+  	consumerDir := filepath.Join(pluginsDir, "action-consumer")
+  	mkdirAll(t, consumerDir)
+  	writeFile(t, filepath.Join(consumerDir, "plugin.yaml"), []byte(`name: action-consumer
+  version: 1.0.0
+  type: lua
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: channel
+  lua-plugin:
+    entry: main.lua`))
+  	writeFile(t, filepath.Join(consumerDir, "main.lua"), []byte("function on_event(e) end"))
+
+  	luaHost := pluginlua.NewHost()
+  	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+  	// No binary host — declarer is silently skipped, but its actions still
+  	// feed CollectActions during Phase 2.
+  	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  	err := mgr.LoadAll(context.Background())
+  	require.NoError(t, err, "consumer should validate against declarer's action")
+  	assert.Contains(t, mgr.ListPlugins(), "action-consumer")
+  }
+  ```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+  ```bash
+  task test -- -run "TestManagerLoadAllRejectsCommandCapabilityOnUnknownAction|TestManagerLoadAllAcceptsCapabilityWithDeclaredAction|TestManagerLoadAllAcceptsCapabilityOnAnotherPluginsAction" ./internal/plugin/
+  ```
+
+  Expected: FAIL — `loadPlugin` does not yet validate actions, so the rejection test fails (no error) and the acceptance tests may or may not pass.
+
+- [ ] **Step 3: Update `loadPlugin` signature in `internal/plugin/manager.go`**
+
+  Find `func (m *Manager) loadPlugin` (around line 520). Update signature from:
+
+  ```go
+  func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes map[string]bool) error {
+  ```
+
+  to:
+
+  ```go
+  func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes map[string]bool, knownActions map[string]bool) error {
+  ```
+
+- [ ] **Step 4: Add action validation loop to `loadPlugin`**
+
+  In `loadPlugin`, find the existing resource type validation block (around line 522):
+
+  ```go
+  for i := range dp.Manifest.Commands {
+  	cmd := &dp.Manifest.Commands[i]
+  	for _, cap := range cmd.Capabilities {
+  		if err := cap.ValidateResourceType(knownResourceTypes); err != nil {
+  			return oops.In("manager").With("plugin", dp.Manifest.Name).
+  				With("command", cmd.Name).Wrap(err)
+  		}
+  	}
+  }
+  ```
+
+  Replace with (adds action validation and cross-plugin borrow warning):
+
+  ```go
+  coreActions := command.CoreActions()
+  ownActions := make(map[string]bool, len(dp.Manifest.Actions))
+  for _, a := range dp.Manifest.Actions {
+  	ownActions[a] = true
+  }
+  for i := range dp.Manifest.Commands {
+  	cmd := &dp.Manifest.Commands[i]
+  	for _, cap := range cmd.Capabilities {
+  		if err := cap.ValidateResourceType(knownResourceTypes); err != nil {
+  			return oops.In("manager").With("plugin", dp.Manifest.Name).
+  				With("command", cmd.Name).Wrap(err)
+  		}
+  		if err := cap.ValidateAction(knownActions); err != nil {
+  			return oops.In("manager").With("plugin", dp.Manifest.Name).
+  				With("command", cmd.Name).Wrap(err)
+  		}
+  		if !coreActions[cap.Action] && !ownActions[cap.Action] {
+  			slog.Warn("capability uses action not declared by this plugin",
+  				"plugin", dp.Manifest.Name,
+  				"command", cmd.Name,
+  				"action", cap.Action)
+  		}
+  	}
+  }
+  ```
+
+- [ ] **Step 5: Update `LoadAll` Phase 2 to collect actions**
+
+  Find Phase 2 in `LoadAll` (around line 344):
+
+  ```go
+  // Phase 2: Collect cross-plugin context.
+  knownResourceTypes := CollectResourceTypes(discovered)
+  ```
+
+  Add `CollectActions` call:
+
+  ```go
+  // Phase 2: Collect cross-plugin context.
+  knownResourceTypes := CollectResourceTypes(discovered)
+  knownActions := CollectActions(discovered)
+  ```
+
+- [ ] **Step 6: Update `loadPlugin` call site in `LoadAll`**
+
+  Find the `loadPlugin` call (around line 353):
+
+  ```go
+  if err := m.loadPlugin(ctx, dp, knownResourceTypes); err != nil {
+  ```
+
+  Update to:
+
+  ```go
+  if err := m.loadPlugin(ctx, dp, knownResourceTypes, knownActions); err != nil {
+  ```
+
+- [ ] **Step 7: Run all plugin tests**
+
+  ```bash
+  task test -- ./internal/plugin/
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 8: Run full unit test suite**
+
+  ```bash
+  task test
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(plugin): wire CollectActions and ValidateAction into LoadAll/loadPlugin"
+  ```
+
+---
+
+## Task 6: Integration test — custom actions end-to-end
+
+A new Ginkgo test file in `test/integration/plugin/` exercises the full LoadAll pipeline with real plugin manifests on disk.
+
+**Files:**
+- Create: `test/integration/plugin/extensible_actions_test.go`
+
+- [ ] **Step 1: Create `test/integration/plugin/extensible_actions_test.go`**
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+  // Copyright 2026 HoloMUSH Contributors
+
+  //go:build integration
+
+  package plugin_test
+
+  import (
+  	"context"
+  	"os"
+  	"path/filepath"
+
+  	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+  	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+  	plugins "github.com/holomush/holomush/internal/plugin"
+  	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+  )
+
+  var _ = Describe("Plugin loading with custom actions", func() {
+  	var (
+  		pluginsDir string
+  		luaHost    *pluginlua.Host //nolint:typecheck // pluginlua.Host is *lua.Host
+  	)
+
+  	BeforeEach(func() {
+  		pluginsDir = GinkgoT().TempDir()
+  		luaHost = pluginlua.NewHost()
+  		DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+  	})
+
+  	writePlugin := func(name, yamlContent, luaContent string) {
+  		dir := filepath.Join(pluginsDir, name)
+  		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+  		Expect(os.WriteFile(filepath.Join(dir, "plugin.yaml"), []byte(yamlContent), 0o644)).To(Succeed())
+  		if luaContent != "" {
+  			Expect(os.WriteFile(filepath.Join(dir, "main.lua"), []byte(luaContent), 0o644)).To(Succeed())
+  		}
+  	}
+
+  	It("loads a plugin that declares non-core actions in the actions field", func() {
+  		writePlugin("channels", `
+  name: channels
+  version: 1.0.0
+  type: lua
+  actions: [join, leave]
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: location
+        - action: leave
+          resource: location
+  lua-plugin:
+    entry: main.lua
+  `, "function on_event(e) end")
+
+  		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+  		Expect(mgr.ListPlugins()).To(ContainElement("channels"))
+  	})
+
+  	It("rejects a plugin whose capability uses an undeclared action", func() {
+  		writePlugin("bad-plugin", `
+  name: bad-plugin
+  version: 1.0.0
+  type: lua
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: location
+  lua-plugin:
+    entry: main.lua
+  `, "function on_event(e) end")
+
+  		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  		err := mgr.LoadAll(context.Background())
+  		Expect(err).To(HaveOccurred())
+  		Expect(err.Error()).To(ContainSubstring("join"))
+  	})
+
+  	It("loads two plugins where one borrows an action declared by the other", func() {
+  		// Plugin A declares "join"; Plugin B uses it without declaring it.
+  		writePlugin("action-declarer", `
+  name: action-declarer
+  version: 1.0.0
+  type: binary
+  actions: [join]
+  binary-plugin:
+    executable: action-declarer
+  `, "")
+
+  		writePlugin("action-borrower", `
+  name: action-borrower
+  version: 1.0.0
+  type: lua
+  commands:
+    - name: channel
+      capabilities:
+        - action: join
+          resource: location
+  lua-plugin:
+    entry: main.lua
+  `, "function on_event(e) end")
+
+  		// No binary host — declarer is silently skipped; its declared actions
+  		// still feed CollectActions during Phase 2.
+  		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+  		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+  		Expect(mgr.ListPlugins()).To(ContainElement("action-borrower"))
+  	})
+  })
+  ```
+
+- [ ] **Step 2: Run integration tests**
+
+  ```bash
+  task test:int
+  ```
+
+  Expected: PASS (all three `It` blocks green).
+
+- [ ] **Step 3: Run lint**
+
+  ```bash
+  task lint
+  ```
+
+  Expected: PASS with no new warnings.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "test(integration): extensible plugin actions end-to-end"
+  ```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run full pr-prep**
+
+  ```bash
+  task pr-prep
+  ```
+
+  Expected: all checks green (lint, format, schema, license, unit, integration, E2E).
+
+- [ ] **Step 2: Update beads issue**
+
+  ```bash
+  bd close holomush-275o --reason "Implemented: actions field in manifest, CollectActions, ValidateAction, cross-plugin borrow warning. Channels plugin unblocked."
+  ```
+
+---
+
+## Out of Scope
+
+- Updating `plugins/core-channels/plugin.yaml` to add `actions: [join, leave]` — this is in scope for holomush-0sc.12.
+- Removing the redundant `scene` entry from `validResourceTypes` — noted in holomush-275o but deferred.

--- a/docs/superpowers/plans/2026-04-11-extensible-actions.md
+++ b/docs/superpowers/plans/2026-04-11-extensible-actions.md
@@ -29,6 +29,7 @@
 The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that must be removed. `TestNewCommandEntry_InvalidCapabilityReturnsError` has the same. A new positive test asserts that unknown actions pass `Validate()`. Only then do we remove the `!validActions` check.
 
 **Files:**
+
 - Modify: `internal/command/types_test.go`
 - Modify: `internal/command/types.go:150-157`
 
@@ -142,6 +143,7 @@ The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that mu
 ## Task 2: Add `CoreActions()` and `ValidateAction()`
 
 **Files:**
+
 - Modify: `internal/command/types_test.go`
 - Modify: `internal/command/types.go`
 
@@ -241,6 +243,7 @@ The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that mu
 ## Task 3: Add `actions` field to Manifest
 
 **Files:**
+
 - Modify: `internal/plugin/manifest.go`
 - Modify: `internal/plugin/manifest_test.go`
 
@@ -379,6 +382,7 @@ The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that mu
 ## Task 4: Add `CollectActions()` to the plugin manager
 
 **Files:**
+
 - Modify: `internal/plugin/manager.go`
 - Modify: `internal/plugin/manager_test.go`
 
@@ -495,6 +499,7 @@ The test `TestCapability_ValidateInvalid` has an `"unknown action"` case that mu
 This is the integration point. `loadPlugin` gains a `knownActions` parameter. `LoadAll` Phase 2 collects actions alongside resource types. `loadPlugin` validates each capability action and warns when borrowing from another plugin.
 
 **Files:**
+
 - Modify: `internal/plugin/manager.go`
 - Modify: `internal/plugin/manager_test.go`
 
@@ -728,6 +733,7 @@ This is the integration point. `loadPlugin` gains a `knownActions` parameter. `L
 A new Ginkgo test file in `test/integration/plugin/` exercises the full LoadAll pipeline with real plugin manifests on disk.
 
 **Files:**
+
 - Create: `test/integration/plugin/extensible_actions_test.go`
 
 - [ ] **Step 1: Create `test/integration/plugin/extensible_actions_test.go`**

--- a/docs/superpowers/specs/2026-04-11-extensible-actions-design.md
+++ b/docs/superpowers/specs/2026-04-11-extensible-actions-design.md
@@ -1,0 +1,186 @@
+# Extensible Plugin Actions
+
+**Status:** Approved  
+**Date:** 2026-04-11  
+**Issue:** holomush-275o  
+**Blocks:** holomush-0sc.12 (channel plugin rework)
+
+---
+
+## Problem
+
+`validActions` in `internal/command/types.go` is a hardcoded map. `Capability.Validate()` rejects any action string not in that map, which blocks plugins that introduce domain-specific ABAC actions. The core-channels plugin needs `join` and `leave`; both fail validation today.
+
+`validResourceTypes` had the same problem and was already solved with explicit manifest declarations (`resource_types`), a `CollectResourceTypes` merge pass, and a deferred `ValidateResourceType` check. Actions need the same treatment.
+
+---
+
+## Decision
+
+Use a **hybrid approach**: an explicit `actions` field in the manifest as the authoritative source, plus a load-time warning when a plugin borrows an action declared by another plugin.
+
+This mirrors the `resource_types` pattern for auditability and enables future tooling (policy editors, permission introspection) to enumerate all ABAC action primitives from manifests alone, without loading plugins.
+
+---
+
+## Design
+
+### 1. `internal/command/types.go`
+
+**Remove** the `!validActions[c.Action]` check from `Capability.Validate()`. The action field still MUST be non-empty; unknown values are no longer rejected here. Validation of the action vocabulary is deferred to load time, consistent with how resource types already work.
+
+Add two new exports:
+
+```go
+// CoreActions returns a defensive copy of the built-in action set.
+// Used by the plugin manager to build the full known-actions map.
+func CoreActions() map[string]bool
+
+// ValidateAction checks that the capability's action is in the provided set.
+// Called during plugin load with a set that includes both core actions and
+// plugin-declared actions.
+func (c Capability) ValidateAction(known map[string]bool) error
+```
+
+The built-in set remains: `read`, `write`, `emit`, `enter`, `use`, `delete`, `execute`, `admin`.
+
+### 2. `internal/plugin/manifest.go`
+
+Add an `Actions` field to `Manifest`:
+
+```go
+Actions []string `yaml:"actions,omitempty" json:"actions,omitempty"`
+```
+
+Unlike `resource_types`, this field is available to all plugin types (Lua, binary, setting). There is no structural coupling between actions and the `AttributeResolverService` gRPC contract, so the binary-only restriction does not apply.
+
+Validation rules (enforced in `Manifest.Validate()`):
+
+- Each entry MUST be non-empty.
+- Entries MUST be unique within the manifest.
+- Re-declaring a core action (e.g., `actions: [read]`) is silently allowed. It is redundant but not harmful.
+
+### 3. `internal/plugin/manager.go`
+
+**`CollectActions`** — new exported function, parallel to `CollectResourceTypes`:
+
+```go
+// CollectActions builds the full set of known ABAC actions: core actions plus
+// all actions explicitly declared across discovered plugins. Exported as a test
+// seam so callers can verify the merge logic without driving LoadAll.
+func CollectActions(discovered []*DiscoveredPlugin) map[string]bool
+```
+
+Returns `CoreActions()` merged with the union of each manifest's `Actions` field. Does not scan capability action strings — only explicit declarations feed the authoritative set.
+
+**`loadPlugin` signature change:**
+
+```go
+func (m *Manager) loadPlugin(
+    ctx context.Context,
+    dp *DiscoveredPlugin,
+    knownResourceTypes map[string]bool,
+    knownActions map[string]bool,
+) error
+```
+
+In `loadPlugin`, after the existing `ValidateResourceType` loop, add a second loop:
+
+```go
+for i := range dp.Manifest.Commands {
+    cmd := &dp.Manifest.Commands[i]
+    for _, cap := range cmd.Capabilities {
+        if err := cap.ValidateAction(knownActions); err != nil {
+            return oops.In("manager").With("plugin", dp.Manifest.Name).
+                With("command", cmd.Name).Wrap(err)
+        }
+        // Warn when a plugin borrows an action declared by another plugin.
+        if !CoreActions()[cap.Action] && !slices.Contains(dp.Manifest.Actions, cap.Action) {
+            slog.Warn("capability uses action not declared by this plugin",
+                "plugin", dp.Manifest.Name,
+                "command", cmd.Name,
+                "action", cap.Action)
+        }
+    }
+}
+```
+
+**`LoadAll` Phase 2** — call `CollectActions` alongside `CollectResourceTypes`:
+
+```go
+knownResourceTypes := CollectResourceTypes(discovered)
+knownActions := CollectActions(discovered)
+```
+
+Pass `knownActions` into each `loadPlugin` call.
+
+---
+
+## Validation Summary
+
+| Scenario | Result |
+|---|---|
+| Core action (e.g., `read`) in capability | Pass, no warning |
+| Non-core action declared in own `actions` field | Pass, no warning |
+| Non-core action declared by another plugin's `actions` field | Pass, warning logged |
+| Non-core action not declared in any plugin's `actions` field | Hard fail (INVALID_CAPABILITY) |
+| Empty action string | Hard fail (INVALID_CAPABILITY, from `Capability.Validate()`) |
+| Duplicate entry in `actions` field | Hard fail at manifest parse time |
+
+---
+
+## Testing
+
+### `internal/command/types_test.go`
+
+**Updates:**
+- Remove or invert tests that assert `Capability.Validate()` rejects unknown action strings. A non-empty unknown action now passes `Validate()`.
+
+**Additions:**
+- `TestCoreActionsContainsExpectedDefaults` — invariant: returned map always contains `read`, `write`, `emit`, `enter`, `use`, `delete`, `execute`, `admin`.
+- `TestCoreActionsReturnsCopy` — mutating the returned map does not affect a second call.
+- `TestCapability_ValidateActionWithKnownAction` — action present in provided map returns nil.
+- `TestCapability_ValidateActionWithUnknownAction` — action absent from provided map returns INVALID_CAPABILITY error.
+- `TestCapability_ValidateActionBoundaryEmptyKnownMap` — empty known map rejects any action.
+
+### `internal/plugin/manifest_test.go`
+
+- `TestManifestValidateRejectsEmptyActionEntry` — empty string in `actions` fails validation.
+- `TestManifestValidateRejectsDuplicateActions` — duplicate strings in `actions` fails validation.
+- `TestManifestValidateAcceptsActionsOnLuaPlugin` — Lua plugin with `actions` parses and validates.
+- `TestManifestValidateAcceptsActionsOnBinaryPlugin` — Binary plugin with `actions` parses and validates.
+- `TestManifestValidateAcceptsRedeclaredCoreAction` — `actions: [read]` parses and validates without error.
+
+### `internal/plugin/manager_test.go`
+
+**`CollectActions` unit tests:**
+- `TestCollectActionsIncludesCoreActions` — `CollectActions(nil)` returns all core actions.
+- `TestCollectActionsMergesExplicitManifestActions` — plugin declaring `actions: [join]` causes `join` in result.
+- `TestCollectActionsDeduplicatesAcrossPlugins` — two plugins declaring the same action produce one entry.
+- `TestCollectActionsReturnsNewMapPerCall` — invariant: mutations to the returned map do not affect a second call.
+- `TestCollectActionsIgnoresCapabilityActionsNotInActionsField` — action appearing only in capabilities (not in `actions` field) does not appear in result.
+
+**Load integration tests:**
+- Plugin with `actions: [join]` and `action: join` in a capability loads successfully.
+- Plugin with `action: join` in a capability but no `actions: [join]` in any discovered plugin fails with INVALID_CAPABILITY.
+- Plugin using an action declared by a different plugin loads with a warning logged.
+- Plugin re-declaring a core action in `actions` field loads without error.
+
+### `test/integration/` (Ginkgo/Gomega)
+
+- `Describe("Plugin loading with custom actions")`:
+  - `It("loads a plugin that declares non-core actions in the actions field")`
+  - `It("rejects a plugin whose capability uses an undeclared action")`
+  - `It("loads two plugins where one borrows an action declared by the other")`
+
+### E2E scope
+
+E2E for this issue is integration-level: the core-channels plugin manifest (`actions: [join, leave]`) loads cleanly through the full `LoadAll` pipeline. Gameplay E2E for channel commands (join/leave behavior, ABAC authorization) is in scope for holomush-0sc.12.
+
+---
+
+## Out of Scope
+
+- Removing the redundant `scene` entry from `validResourceTypes` (pre-existing tech debt, noted in holomush-275o but not addressed here).
+- Any changes to Cedar policy DSL or the ABAC evaluation engine.
+- Restricting which plugins may borrow actions from other plugins (the warning is informational; cross-plugin action reuse is permitted).

--- a/docs/superpowers/specs/2026-04-11-extensible-actions-design.md
+++ b/docs/superpowers/specs/2026-04-11-extensible-actions-design.md
@@ -134,9 +134,11 @@ Pass `knownActions` into each `loadPlugin` call.
 ### `internal/command/types_test.go`
 
 **Updates:**
+
 - Remove or invert tests that assert `Capability.Validate()` rejects unknown action strings. A non-empty unknown action now passes `Validate()`.
 
 **Additions:**
+
 - `TestCoreActionsContainsExpectedDefaults` — invariant: returned map always contains `read`, `write`, `emit`, `enter`, `use`, `delete`, `execute`, `admin`.
 - `TestCoreActionsReturnsCopy` — mutating the returned map does not affect a second call.
 - `TestCapability_ValidateActionWithKnownAction` — action present in provided map returns nil.
@@ -154,6 +156,7 @@ Pass `knownActions` into each `loadPlugin` call.
 ### `internal/plugin/manager_test.go`
 
 **`CollectActions` unit tests:**
+
 - `TestCollectActionsIncludesCoreActions` — `CollectActions(nil)` returns all core actions.
 - `TestCollectActionsMergesExplicitManifestActions` — plugin declaring `actions: [join]` causes `join` in result.
 - `TestCollectActionsDeduplicatesAcrossPlugins` — two plugins declaring the same action produce one entry.
@@ -161,6 +164,7 @@ Pass `knownActions` into each `loadPlugin` call.
 - `TestCollectActionsIgnoresCapabilityActionsNotInActionsField` — action appearing only in capabilities (not in `actions` field) does not appear in result.
 
 **Load integration tests:**
+
 - Plugin with `actions: [join]` and `action: join` in a capability loads successfully.
 - Plugin with `action: join` in a capability but no `actions: [join]` in any discovered plugin fails with INVALID_CAPABILITY.
 - Plugin using an action declared by a different plugin loads with a warning logged.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -144,17 +144,12 @@ type Capability struct {
 	Scope    string `yaml:"scope,omitempty" json:"scope,omitempty"`
 }
 
-// Validate checks structural validity: action is known, resource is non-empty,
-// scope is valid. Does NOT check resource type membership — that requires
-// cross-plugin context and is deferred to ValidateResourceType at load time.
+// Validate checks structural validity: action is non-empty, resource is non-empty,
+// scope is valid. Does NOT check action or resource type membership — that requires
+// cross-plugin context and is deferred to ValidateAction/ValidateResourceType at load time.
 func (c Capability) Validate() error {
 	if c.Action == "" {
 		return oops.Code("INVALID_CAPABILITY").Errorf("action is required")
-	}
-	if !validActions[c.Action] {
-		return oops.Code("INVALID_CAPABILITY").
-			With("action", c.Action).
-			Errorf("unknown action %q", c.Action)
 	}
 	if c.Resource == "" {
 		return oops.Code("INVALID_CAPABILITY").Errorf("resource is required")
@@ -187,6 +182,28 @@ func CoreResourceTypes() map[string]bool {
 		result[k] = v
 	}
 	return result
+}
+
+// CoreActions returns a defensive copy of the built-in action set.
+// Used by the plugin manager to build the full known-actions map.
+func CoreActions() map[string]bool {
+	result := make(map[string]bool, len(validActions))
+	for k, v := range validActions {
+		result[k] = v
+	}
+	return result
+}
+
+// ValidateAction checks that the capability's action is in the provided set.
+// Called during plugin load with a set that includes both core actions and
+// plugin-declared actions.
+func (c Capability) ValidateAction(known map[string]bool) error {
+	if !known[c.Action] {
+		return oops.Code("INVALID_CAPABILITY").
+			With("action", c.Action).
+			Errorf("unknown action %q", c.Action)
+	}
+	return nil
 }
 
 // EffectiveScope returns the scope, defaulting to ScopeSelf if empty.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -110,6 +110,9 @@ const (
 //
 // Thread safety: this map is initialized at package load time and never
 // modified afterward. Concurrent reads without writes are safe in Go.
+// CoreActions() returns a defensive copy for external mutation.
+// ValidateAction() accepts a separate "known" map parameter rather
+// than reading this global, keeping plugin-contributed types isolated.
 var validActions = map[string]bool{
 	"read": true, "write": true, "emit": true, "enter": true,
 	"use": true, "delete": true, "execute": true, "admin": true,
@@ -174,7 +177,7 @@ func (c Capability) ValidateResourceType(known map[string]bool) error {
 	return nil
 }
 
-// CoreResourceTypes returns a copy of the core resource type set.
+// CoreResourceTypes returns a defensive copy of the core resource type set.
 // Used by the plugin manager to build the full known-types map.
 func CoreResourceTypes() map[string]bool {
 	result := make(map[string]bool, len(validResourceTypes))

--- a/internal/command/types_test.go
+++ b/internal/command/types_test.go
@@ -634,6 +634,7 @@ func TestCapability_ValidateResourceTypeUnknown(t *testing.T) {
 	err := Capability{Action: "read", Resource: "spaceship"}.ValidateResourceType(known)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "spaceship")
+	errutil.AssertErrorCode(t, err, "INVALID_CAPABILITY")
 }
 
 func TestCoreResourceTypesReturnsCopy(t *testing.T) {

--- a/internal/command/types_test.go
+++ b/internal/command/types_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
+	"github.com/holomush/holomush/pkg/errutil"
 )
 
 func TestCommandEntryHasRequiredFields(t *testing.T) {
@@ -595,7 +596,6 @@ func TestCapability_ValidateInvalid(t *testing.T) {
 	}{
 		{"empty action", Capability{Action: "", Resource: "location"}, "action"},
 		{"empty resource", Capability{Action: "read", Resource: ""}, "resource"},
-		{"unknown action", Capability{Action: "destroy", Resource: "location"}, "action"},
 		// Note: unknown resource type is NOT checked by Validate() — it's checked
 		// by ValidateResourceType() at load time with cross-plugin context.
 		{"invalid scope", Capability{Action: "read", Resource: "location", Scope: "everywhere"}, "scope"},
@@ -613,6 +613,13 @@ func TestCapability_ValidateAcceptsUnknownResourceType(t *testing.T) {
 	// Validate() is structural only — unknown resource types pass.
 	// ValidateResourceType() checks membership at load time.
 	c := Capability{Action: "read", Resource: "widget", Scope: ScopeLocal}
+	assert.NoError(t, c.Validate())
+}
+
+func TestCapability_ValidateAcceptsUnknownAction(t *testing.T) {
+	// Validate() is structural only — unknown actions pass here.
+	// ValidateAction() checks membership at load time with cross-plugin context.
+	c := Capability{Action: "destroy", Resource: "location"}
 	assert.NoError(t, c.Validate())
 }
 
@@ -639,6 +646,41 @@ func TestCoreResourceTypesReturnsCopy(t *testing.T) {
 	assert.False(t, types2["spaceship"])
 }
 
+func TestCoreActionsContainsExpectedDefaults(t *testing.T) {
+	actions := CoreActions()
+	for _, expected := range []string{"read", "write", "emit", "enter", "use", "delete", "execute", "admin"} {
+		assert.True(t, actions[expected], "core action %q must be present", expected)
+	}
+}
+
+func TestCoreActionsReturnsCopy(t *testing.T) {
+	actions := CoreActions()
+	assert.True(t, actions["read"])
+	// Mutating the copy must not affect a second call.
+	actions["invent"] = true
+	actions2 := CoreActions()
+	assert.False(t, actions2["invent"], "subsequent calls must not see prior mutations")
+}
+
+func TestCapability_ValidateActionWithKnownAction(t *testing.T) {
+	known := map[string]bool{"join": true, "read": true}
+	assert.NoError(t, Capability{Action: "join", Resource: "channel"}.ValidateAction(known))
+	assert.NoError(t, Capability{Action: "read", Resource: "location"}.ValidateAction(known))
+}
+
+func TestCapability_ValidateActionWithUnknownAction(t *testing.T) {
+	known := map[string]bool{"read": true}
+	err := Capability{Action: "join", Resource: "channel"}.ValidateAction(known)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "join")
+	errutil.AssertErrorCode(t, err, "INVALID_CAPABILITY")
+}
+
+func TestCapability_ValidateActionBoundaryEmptyKnownMap(t *testing.T) {
+	err := Capability{Action: "read", Resource: "location"}.ValidateAction(map[string]bool{})
+	require.Error(t, err, "empty known map must reject any action")
+}
+
 func TestCapabilityEffectiveScope(t *testing.T) {
 	assert.Equal(t, ScopeSelf, Capability{Action: "read", Resource: "character"}.EffectiveScope())
 	assert.Equal(t, ScopeLocal, Capability{Action: "read", Resource: "location", Scope: ScopeLocal}.EffectiveScope())
@@ -653,11 +695,6 @@ func TestNewCommandEntry_InvalidCapabilityReturnsError(t *testing.T) {
 		caps []Capability
 		want string
 	}{
-		{
-			name: "unknown action",
-			caps: []Capability{{Action: "destroy", Resource: "location"}},
-			want: "action",
-		},
 		// Note: unknown resource type is NOT checked by Validate() at construction
 		// time — resource type validation happens at load time via ValidateResourceType().
 		{

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -533,33 +533,9 @@ func (m *Manager) unregisterPluginProviders(pluginName string, resourceTypes []s
 // graceful degradation. This allows running without Lua support or before
 // binary plugin support is implemented. The warning logs provide visibility.
 func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes, knownActions map[string]bool) error {
-	// Semantic validation: check capability resource types and actions against the full known sets.
-	coreActions := command.CoreActions()
-	ownActions := make(map[string]bool, len(dp.Manifest.Actions))
-	for _, a := range dp.Manifest.Actions {
-		ownActions[a] = true
-	}
-	for i := range dp.Manifest.Commands {
-		cmd := &dp.Manifest.Commands[i]
-		for _, cap := range cmd.Capabilities {
-			if err := cap.ValidateResourceType(knownResourceTypes); err != nil {
-				return oops.In("manager").With("plugin", dp.Manifest.Name).
-					With("command", cmd.Name).Wrap(err)
-			}
-			if err := cap.ValidateAction(knownActions); err != nil {
-				return oops.In("manager").With("plugin", dp.Manifest.Name).
-					With("command", cmd.Name).Wrap(err)
-			}
-			if !coreActions[cap.Action] && !ownActions[cap.Action] {
-				slog.Warn("capability uses action not declared by this plugin",
-					"plugin", dp.Manifest.Name,
-					"command", cmd.Name,
-					"action", cap.Action)
-			}
-		}
-	}
-
-	// Resolve the host for this plugin type.
+	// Resolve the host for this plugin type first — unsupported configurations
+	// are skipped here before any semantic validation so that graceful degradation
+	// (e.g., no binary host configured) is not blocked by capability checks.
 	// For backward compatibility, TypeLua falls back to the dedicated luaHost field.
 	var host Host
 	switch dp.Manifest.Type {
@@ -585,6 +561,32 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			"plugin", dp.Manifest.Name,
 			"type", dp.Manifest.Type)
 		return nil
+	}
+
+	// Semantic validation: check capability resource types and actions against the full known sets.
+	coreActions := command.CoreActions()
+	ownActions := make(map[string]bool, len(dp.Manifest.Actions))
+	for _, a := range dp.Manifest.Actions {
+		ownActions[a] = true
+	}
+	for i := range dp.Manifest.Commands {
+		cmd := &dp.Manifest.Commands[i]
+		for _, cap := range cmd.Capabilities {
+			if err := cap.ValidateResourceType(knownResourceTypes); err != nil {
+				return oops.In("manager").With("plugin", dp.Manifest.Name).
+					With("command", cmd.Name).Wrap(err)
+			}
+			if err := cap.ValidateAction(knownActions); err != nil {
+				return oops.In("manager").With("plugin", dp.Manifest.Name).
+					With("command", cmd.Name).Wrap(err)
+			}
+			if !coreActions[cap.Action] && !ownActions[cap.Action] {
+				slog.Warn("capability uses action not declared by this plugin",
+					"plugin", dp.Manifest.Name,
+					"command", cmd.Name,
+					"action", cap.Action)
+			}
+		}
 	}
 
 	// Reject duplicate plugin names before loading to prevent the second plugin

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -532,7 +532,7 @@ func (m *Manager) unregisterPluginProviders(pluginName string, resourceTypes []s
 // Design: Returns nil (not error) for unsupported configurations to support
 // graceful degradation. This allows running without Lua support or before
 // binary plugin support is implemented. The warning logs provide visibility.
-func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes map[string]bool, knownActions map[string]bool) error {
+func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes, knownActions map[string]bool) error {
 	// Semantic validation: check capability resource types and actions against the full known sets.
 	coreActions := command.CoreActions()
 	ownActions := make(map[string]bool, len(dp.Manifest.Actions))

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -343,6 +343,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 
 	// Phase 2: Collect cross-plugin context.
 	knownResourceTypes := CollectResourceTypes(discovered)
+	knownActions := CollectActions(discovered)
 
 	// Phase 3: Resolve load order.
 	ordered := m.resolveLoadOrder(discovered)
@@ -350,7 +351,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 	// Phase 4: Load each plugin with full context.
 	var loadErrors []error
 	for _, dp := range ordered {
-		if err := m.loadPlugin(ctx, dp, knownResourceTypes); err != nil {
+		if err := m.loadPlugin(ctx, dp, knownResourceTypes, knownActions); err != nil {
 			slog.Error("failed to load plugin",
 				"plugin", dp.Manifest.Name,
 				"priority", dp.Manifest.EffectivePriority(),
@@ -531,14 +532,29 @@ func (m *Manager) unregisterPluginProviders(pluginName string, resourceTypes []s
 // Design: Returns nil (not error) for unsupported configurations to support
 // graceful degradation. This allows running without Lua support or before
 // binary plugin support is implemented. The warning logs provide visibility.
-func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes map[string]bool) error {
-	// Semantic validation: check capability resource types against the full known set.
+func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownResourceTypes map[string]bool, knownActions map[string]bool) error {
+	// Semantic validation: check capability resource types and actions against the full known sets.
+	coreActions := command.CoreActions()
+	ownActions := make(map[string]bool, len(dp.Manifest.Actions))
+	for _, a := range dp.Manifest.Actions {
+		ownActions[a] = true
+	}
 	for i := range dp.Manifest.Commands {
 		cmd := &dp.Manifest.Commands[i]
 		for _, cap := range cmd.Capabilities {
 			if err := cap.ValidateResourceType(knownResourceTypes); err != nil {
 				return oops.In("manager").With("plugin", dp.Manifest.Name).
 					With("command", cmd.Name).Wrap(err)
+			}
+			if err := cap.ValidateAction(knownActions); err != nil {
+				return oops.In("manager").With("plugin", dp.Manifest.Name).
+					With("command", cmd.Name).Wrap(err)
+			}
+			if !coreActions[cap.Action] && !ownActions[cap.Action] {
+				slog.Warn("capability uses action not declared by this plugin",
+					"plugin", dp.Manifest.Name,
+					"command", cmd.Name,
+					"action", cap.Action)
 			}
 		}
 	}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -452,6 +452,20 @@ func CollectResourceTypes(discovered []*DiscoveredPlugin) map[string]bool {
 	return known
 }
 
+// CollectActions builds the full set of known ABAC actions: core actions plus
+// all actions explicitly declared across discovered plugins. This cross-plugin
+// context is needed for semantic validation during loadPlugin. Exported as a
+// test seam so callers can verify the merge logic without driving LoadAll.
+func CollectActions(discovered []*DiscoveredPlugin) map[string]bool {
+	known := command.CoreActions()
+	for _, dp := range discovered {
+		for _, a := range dp.Manifest.Actions {
+			known[a] = true
+		}
+	}
+	return known
+}
+
 // resolveLoadOrder returns plugins in the order they should be loaded.
 // When a registry is configured, it uses DAG-based dependency resolution.
 // Falls back to priority sort if DAG resolution fails or no registry is set.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1111,6 +1111,34 @@ lua-plugin:
 	assert.Contains(t, mgr.ListPlugins(), "action-consumer")
 }
 
+func TestManagerLoadAllAcceptsPluginRedeclaringCoreAction(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	pluginDir := filepath.Join(pluginsDir, "reader-plugin")
+	mkdirAll(t, pluginDir)
+	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: reader-plugin
+version: 1.0.0
+type: lua
+actions: [read]
+commands:
+  - name: look
+    capabilities:
+      - action: read
+        resource: location
+lua-plugin:
+  entry: main.lua`))
+	writeFile(t, filepath.Join(pluginDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err, "re-declaring a core action in the actions field should not prevent loading")
+	assert.Contains(t, mgr.ListPlugins(), "reader-plugin")
+}
+
 // WithTrustAllowlist is plumbed through but only takes effect when policies
 // install. The option itself is verified by ensuring no panic / no behavior
 // change for plugins that don't request escalation.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1039,6 +1039,7 @@ lua-plugin:
 	err := mgr.LoadAll(context.Background())
 	require.Error(t, err, "load should fail when capability uses an undeclared action")
 	assert.Contains(t, err.Error(), "join")
+	assert.Empty(t, mgr.ListPlugins(), "no plugins should be registered after a load failure")
 }
 
 func TestManagerLoadAllAcceptsCapabilityWithDeclaredAction(t *testing.T) {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -882,6 +882,62 @@ func TestCollectResourceTypesReturnsNewMapPerCall(t *testing.T) {
 	assert.False(t, second["mutated"], "subsequent calls must not see prior mutations")
 }
 
+// CollectActions is the exported test seam that backs the
+// cross-plugin action collection used during LoadAll.
+
+func TestCollectActionsIncludesCoreActions(t *testing.T) {
+	known := plugins.CollectActions(nil)
+	for _, action := range []string{"read", "write", "emit", "enter", "use", "delete", "execute", "admin"} {
+		assert.True(t, known[action], "core action %q must be included", action)
+	}
+}
+
+func TestCollectActionsMergesExplicitManifestActions(t *testing.T) {
+	discovered := []*plugins.DiscoveredPlugin{
+		{Manifest: &plugins.Manifest{Name: "p1", Actions: []string{"join"}}},
+		{Manifest: &plugins.Manifest{Name: "p2", Actions: []string{"leave", "vote"}}},
+	}
+	known := plugins.CollectActions(discovered)
+	assert.True(t, known["join"], "declared 'join' should be present")
+	assert.True(t, known["leave"], "declared 'leave' should be present")
+	assert.True(t, known["vote"], "declared 'vote' should be present")
+	assert.True(t, known["read"], "core actions should still be present after merge")
+}
+
+func TestCollectActionsDeduplicatesAcrossPlugins(t *testing.T) {
+	discovered := []*plugins.DiscoveredPlugin{
+		{Manifest: &plugins.Manifest{Name: "p1", Actions: []string{"join"}}},
+		{Manifest: &plugins.Manifest{Name: "p2", Actions: []string{"join"}}},
+	}
+	known := plugins.CollectActions(discovered)
+	assert.True(t, known["join"], "'join' declared by two plugins should be present once")
+}
+
+func TestCollectActionsReturnsNewMapPerCall(t *testing.T) {
+	first := plugins.CollectActions(nil)
+	first["mutated"] = true
+	second := plugins.CollectActions(nil)
+	assert.False(t, second["mutated"], "subsequent calls must not see prior mutations")
+}
+
+func TestCollectActionsIgnoresCapabilityActionsNotInActionsField(t *testing.T) {
+	// Only the explicit Actions manifest field feeds CollectActions.
+	// Action strings in command capabilities are NOT auto-promoted.
+	discovered := []*plugins.DiscoveredPlugin{
+		{Manifest: &plugins.Manifest{
+			Name: "p1",
+			Commands: []plugins.CommandSpec{
+				{Name: "channel", Capabilities: []command.Capability{
+					{Action: "join", Resource: "channel"},
+				}},
+			},
+			// No Actions field declared.
+		}},
+	}
+	known := plugins.CollectActions(discovered)
+	assert.False(t, known["join"], "'join' in capabilities but not in actions field must not appear")
+}
+
 // Semantic capability validation: loadPlugin must reject manifests whose
 // commands declare capabilities on resource types that aren't in the
 // cross-plugin known set.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1011,6 +1011,106 @@ lua-plugin:
 	assert.Contains(t, mgr.ListPlugins(), "widget-consumer")
 }
 
+// Semantic action validation: loadPlugin must reject manifests whose commands
+// declare capabilities on actions that aren't in the cross-plugin known set.
+
+func TestManagerLoadAllRejectsCommandCapabilityOnUnknownAction(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	pluginDir := filepath.Join(pluginsDir, "channel-plugin")
+	mkdirAll(t, pluginDir)
+	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: channel-plugin
+version: 1.0.0
+type: lua
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+lua-plugin:
+  entry: main.lua`))
+	writeFile(t, filepath.Join(pluginDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err, "load should fail when capability uses an undeclared action")
+	assert.Contains(t, err.Error(), "join")
+}
+
+func TestManagerLoadAllAcceptsCapabilityWithDeclaredAction(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	pluginDir := filepath.Join(pluginsDir, "channel-plugin")
+	mkdirAll(t, pluginDir)
+	writeFile(t, filepath.Join(pluginDir, "plugin.yaml"), []byte(`name: channel-plugin
+version: 1.0.0
+type: lua
+actions: [join, leave]
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+      - action: leave
+        resource: location
+lua-plugin:
+  entry: main.lua`))
+	writeFile(t, filepath.Join(pluginDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err, "load should succeed when action is declared in the plugin manifest")
+	assert.Contains(t, mgr.ListPlugins(), "channel-plugin")
+}
+
+func TestManagerLoadAllAcceptsCapabilityOnAnotherPluginsAction(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	// Plugin A declares the "join" action so Plugin B's capability is valid.
+	declarerDir := filepath.Join(pluginsDir, "action-declarer")
+	mkdirAll(t, declarerDir)
+	writeFile(t, filepath.Join(declarerDir, "plugin.yaml"), []byte(`name: action-declarer
+version: 1.0.0
+type: binary
+actions: [join]
+binary-plugin:
+  executable: action-declarer`))
+
+	// Plugin B uses "join" declared by Plugin A.
+	consumerDir := filepath.Join(pluginsDir, "action-consumer")
+	mkdirAll(t, consumerDir)
+	writeFile(t, filepath.Join(consumerDir, "plugin.yaml"), []byte(`name: action-consumer
+version: 1.0.0
+type: lua
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+lua-plugin:
+  entry: main.lua`))
+	writeFile(t, filepath.Join(consumerDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	// No binary host — declarer is silently skipped, but its actions still
+	// feed CollectActions during Phase 2.
+	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err, "consumer should validate against declarer's action")
+	assert.Contains(t, mgr.ListPlugins(), "action-consumer")
+}
+
 // WithTrustAllowlist is plumbed through but only takes effect when policies
 // install. The option itself is verified by ensuring no panic / no behavior
 // change for plugins that don't request escalation.

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -424,7 +424,7 @@ func (m *Manifest) Validate() error {
 	if len(m.Actions) > 0 {
 		seen := make(map[string]bool, len(m.Actions))
 		for _, a := range m.Actions {
-			if a == "" {
+			if strings.TrimSpace(a) == "" {
 				return oops.In("manifest").With("name", m.Name).
 					New("action entry must not be empty")
 			}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -94,6 +94,7 @@ type Manifest struct {
 
 	// ABAC trust boundary fields
 	ResourceTypes []string     `yaml:"resource_types,omitempty" json:"resource_types,omitempty"`
+	Actions       []string     `yaml:"actions,omitempty" json:"actions,omitempty"`
 	Trust         *TrustConfig `yaml:"trust,omitempty" json:"trust,omitempty"`
 
 	emitsDeclared bool `yaml:"-" json:"-" jsonschema:"-"`
@@ -411,6 +412,24 @@ func (m *Manifest) Validate() error {
 					New("duplicate resource type")
 			}
 			seen[rt] = true
+		}
+	}
+
+	// Validate actions: no empty strings, no duplicates.
+	// All plugin types may declare actions (unlike resource_types, actions
+	// have no structural coupling to AttributeResolverService).
+	if len(m.Actions) > 0 {
+		seen := make(map[string]bool, len(m.Actions))
+		for _, a := range m.Actions {
+			if a == "" {
+				return oops.In("manifest").With("name", m.Name).
+					New("action entry must not be empty")
+			}
+			if seen[a] {
+				return oops.In("manifest").With("name", m.Name).With("action", a).
+					New("duplicate action")
+			}
+			seen[a] = true
 		}
 	}
 

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -418,6 +418,9 @@ func (m *Manifest) Validate() error {
 	// Validate actions: no empty strings, no duplicates.
 	// All plugin types may declare actions (unlike resource_types, actions
 	// have no structural coupling to AttributeResolverService).
+	// Note: no format constraint on action names — actions are free-form identifiers
+	// and may re-declare core actions (unlike resource_types which checks namePattern
+	// and ProtectedResourceTypes).
 	if len(m.Actions) > 0 {
 		seen := make(map[string]bool, len(m.Actions))
 		for _, a := range m.Actions {

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1519,16 +1519,9 @@ func TestCommandSpec_Validate_InvalidCapability(t *testing.T) {
 		cmd    plugins.CommandSpec
 		errMsg string
 	}{
-		{
-			name: "invalid action in capability",
-			cmd: plugins.CommandSpec{
-				Name:         "teleport",
-				Capabilities: []command.Capability{{Action: "destroy", Resource: "location"}},
-			},
-			errMsg: "action",
-		},
-		// Note: unknown resource type is NOT checked by Validate() — resource type
-		// validation happens during loadPlugin with cross-plugin context.
+		// Note: unknown action strings are now allowed — Capability.Validate() only
+		// requires non-empty action. Cross-plugin validation of action membership
+		// happens during loadPlugin with context from plugin manifests.
 		{
 			name: "invalid scope in capability",
 			cmd: plugins.CommandSpec{
@@ -1545,6 +1538,8 @@ func TestCommandSpec_Validate_InvalidCapability(t *testing.T) {
 			},
 			errMsg: "action",
 		},
+		// Note: unknown resource type is NOT checked by Validate() — resource type
+		// validation happens during loadPlugin with cross-plugin context.
 		// "second capability invalid resource" removed — resource type validation
 		// is deferred to loadPlugin with cross-plugin context.
 	}
@@ -1566,7 +1561,7 @@ type: lua
 commands:
   - name: teleport
     capabilities:
-      - action: destroy
+      - action: ""
         resource: location
 lua-plugin:
   entry: main.lua
@@ -1822,6 +1817,72 @@ trust:
 			check: func(t *testing.T, m *plugins.Manifest) {
 				require.NotNil(t, m.Trust)
 				assert.True(t, m.Trust.AllPrincipals)
+			},
+		},
+		{
+			name: "parses actions when declared on a binary plugin",
+			yaml: `
+name: test-plugin
+version: 1.0.0
+type: binary
+binary-plugin:
+  executable: test-plugin
+actions: [join, leave]
+`,
+			check: func(t *testing.T, m *plugins.Manifest) {
+				assert.Equal(t, []string{"join", "leave"}, m.Actions)
+			},
+		},
+		{
+			name: "parses actions when declared on a Lua plugin",
+			yaml: `
+name: test-plugin
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+actions: [craft]
+`,
+			check: func(t *testing.T, m *plugins.Manifest) {
+				assert.Equal(t, []string{"craft"}, m.Actions)
+			},
+		},
+		{
+			name:    "rejects actions with an empty entry",
+			wantErr: "action",
+			yaml: `
+name: test-plugin
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+actions: [""]
+`,
+		},
+		{
+			name:    "rejects actions with duplicate entries",
+			wantErr: "duplicate",
+			yaml: `
+name: test-plugin
+version: 1.0.0
+type: binary
+binary-plugin:
+  executable: test-plugin
+actions: [join, join]
+`,
+		},
+		{
+			name: "accepts actions that re-declare a core action",
+			yaml: `
+name: test-plugin
+version: 1.0.0
+type: binary
+binary-plugin:
+  executable: test-plugin
+actions: [read]
+`,
+			check: func(t *testing.T, m *plugins.Manifest) {
+				assert.Equal(t, []string{"read"}, m.Actions)
 			},
 		},
 	}

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -230,6 +230,12 @@
       },
       "type": "array"
     },
+    "actions": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "trust": {
       "properties": {
         "all_principals": {

--- a/test/integration/plugin/extensible_actions_test.go
+++ b/test/integration/plugin/extensible_actions_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+)
+
+var _ = Describe("Plugin loading with custom actions", func() {
+	var (
+		pluginsDir string
+		luaHost    *pluginlua.Host
+	)
+
+	BeforeEach(func() {
+		pluginsDir = GinkgoT().TempDir()
+		luaHost = pluginlua.NewHost()
+		DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+	})
+
+	writePlugin := func(name, yamlContent, luaContent string) {
+		dir := filepath.Join(pluginsDir, name)
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, "plugin.yaml"), []byte(yamlContent), 0o644)).To(Succeed())
+		if luaContent != "" {
+			Expect(os.WriteFile(filepath.Join(dir, "main.lua"), []byte(luaContent), 0o644)).To(Succeed())
+		}
+	}
+
+	It("loads a plugin that declares non-core actions in the actions field", func() {
+		writePlugin("channels", `
+name: channels
+version: 1.0.0
+type: lua
+actions: [join, leave]
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+      - action: leave
+        resource: location
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+		Expect(mgr.ListPlugins()).To(ContainElement("channels"))
+	})
+
+	It("rejects a plugin whose capability uses an undeclared action", func() {
+		writePlugin("bad-plugin", `
+name: bad-plugin
+version: 1.0.0
+type: lua
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+		err := mgr.LoadAll(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("join"))
+	})
+
+	It("loads two plugins where one borrows an action declared by the other", func() {
+		// Plugin A declares "join"; Plugin B uses it without declaring it.
+		writePlugin("action-declarer", `
+name: action-declarer
+version: 1.0.0
+type: binary
+actions: [join]
+binary-plugin:
+  executable: action-declarer
+`, "")
+
+		writePlugin("action-borrower", `
+name: action-borrower
+version: 1.0.0
+type: lua
+commands:
+  - name: channel
+    capabilities:
+      - action: join
+        resource: location
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		// No binary host — declarer is silently skipped; its declared actions
+		// still feed CollectActions during Phase 2.
+		mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+		Expect(mgr.ListPlugins()).To(ContainElement("action-borrower"))
+	})
+})


### PR DESCRIPTION
## Summary

- Removes the hardcoded `validActions` check from `Capability.Validate()` — action validation is now deferred to load time with full cross-plugin context
- Adds `actions []string` manifest field so plugins can declare custom ABAC action strings (e.g., `join`, `leave`); all plugin types (Lua, binary, setting) may declare actions
- Wires `CollectActions` + `ValidateAction` into `LoadAll`/`loadPlugin`: undeclared actions fail with `INVALID_CAPABILITY`; borrowing another plugin's declared action loads with a warning

Unblocks `holomush-0sc.12` (core-channels plugin rework): channels plugin can now add `actions: [join, leave]` to its manifest.

Closes holomush-275o.

## Test Plan

- [x] `task pr-prep` green (lint, format, schema, license, unit, integration, E2E)
- [x] Unit: `internal/command` — `TestCoreActions*`, `TestCapability_ValidateAction*`
- [x] Unit: `internal/plugin` — `TestManifest*`, `TestCollectActions*`, `TestManagerLoadAll*`
- [x] Integration: `test/integration/plugin/extensible_actions_test.go` — 3 Ginkgo specs (declare-and-use, undeclared-fails, cross-plugin-borrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now declare custom ABAC actions via the `actions` field in their manifest.
  * Cross-plugin action borrowing is now supported—plugins can use actions declared by other plugins.
  * Action validation deferred to plugin load time for improved extensibility.

* **Documentation**
  * Added implementation plan and design specification for extensible plugin actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->