### PR TITLE
feat(core): add NewEvent constructor + event ID monotonicity hardening (I-16)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -84,7 +84,11 @@ tasks:
       # tested, which hides cross-package exercise (e.g., integration tests
       # that drive multiple packages via an end-to-end flow).
       - gotestsum --format pkgname -- -race -coverprofile=coverage.out -covermode=atomic -coverpkg=./... ./...
-      - go tool cover -html=coverage.out -o coverage.html
+      # HTML generation can fail with "inconsistent NumStmt" when packages
+      # use build tags (e.g., store_memory.go with //go:build !integration)
+      # that change statement structure across compilation contexts. The
+      # coverage profile itself is correct for Codecov; HTML is convenience.
+      - go tool cover -html=coverage.out -o coverage.html || true
 
   test:int:
     desc: Run integration tests (needs Docker for testcontainers)

--- a/gorules/rules.go
+++ b/gorules/rules.go
@@ -14,14 +14,22 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// EventIDMustBeMonotonic ensures core.Event{} literals use core.NewULID()
-// (monotonic-within-millisecond entropy), not idgen.New() (fresh random
-// per call). Non-monotonic event IDs silently break PostgresEventStore.Replay
-// (WHERE id > afterID ORDER BY id) and PostgresSessionStore cursor
-// monotonicity. See internal/core/ulid.go for the invariant documentation.
+// EventIDMustBeMonotonic ensures events are constructed via core.NewEvent(),
+// not via raw core.Event{} struct literals. core.NewEvent() assigns the ID
+// from core.NewULID() (monotonic-within-millisecond), enforcing invariant
+// I-16 from the focus-substrate design spec. Raw struct literals risk using
+// idgen.New() or ulid.Make() which produce non-monotonic IDs that silently
+// break PostgresEventStore.Replay and cursor CAS advances.
+//
+// The rule catches ANY core.Event{} literal. The only legitimate construction
+// site is core.NewEvent() itself (in internal/core/event.go), which is
+// excluded via the Where clause filtering on the file path.
+//
+// See docs/superpowers/specs/2026-04-11-focus-substrate-design.md section 3.1 I-16.
 func EventIDMustBeMonotonic(m dsl.Matcher) {
-	m.Match(`core.Event{$*_, ID: idgen.New(), $*_}`).
-		Report(`event IDs must use core.NewULID() (monotonic), not idgen.New() (random) — see internal/core/ulid.go`)
+	m.Match(`core.Event{$*_}`).
+		Where(!m.File().Name.Matches(`event\.go$`)).
+		Report(`use core.NewEvent() instead of raw core.Event{} literal -- see I-16 in focus-substrate spec`)
 }
 
 // ULIDMakeForbidden forbids ulid.Make() in production code. ulid.Make()

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
@@ -597,20 +596,10 @@ func (s *Services) BroadcastSystemMessage(ctx context.Context, stream, message s
 		"message": message,
 	})
 
-	event := core.Event{
-		// Event IDs MUST be monotonic for PostgresEventStore.Replay
-		// (WHERE id > afterID ORDER BY id) and the PostgresSessionStore
-		// cursor CAS. idgen.New() is non-monotonic. See internal/core/ulid.go.
-		ID:        core.NewULID(),
-		Stream:    stream,
-		Type:      core.EventTypeSystem,
-		Timestamp: time.Now(),
-		Actor: core.Actor{
-			Kind: core.ActorSystem,
-			ID:   "system",
-		},
-		Payload: payload,
-	}
+	event := core.NewEvent(stream, core.EventTypeSystem, core.Actor{
+		Kind: core.ActorSystem,
+		ID:   "system",
+	}, payload)
 
 	if err := s.events.Append(ctx, event); err != nil {
 		slog.WarnContext(ctx, "BroadcastSystemMessage: failed to append event",

--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -158,3 +158,26 @@ type Event struct {
 	Actor     Actor
 	Payload   []byte // JSON
 }
+
+// NewEvent constructs an Event with a monotonic ULID (from NewULID) and
+// the current timestamp. This is the ONLY blessed construction path for
+// events that will be appended to an EventStore.
+//
+// Invariant I-16 (Event ID Monotonicity): every event appended to
+// EventStore MUST be constructed via NewEvent, which assigns the ID from
+// NewULID() -- a monotonic-within-millisecond generator. idgen.New() and
+// ulid.Make() are forbidden for event IDs because they produce
+// non-monotonic IDs that silently break PostgresEventStore.Replay
+// (WHERE id > afterID ORDER BY id) and cursor CAS advances.
+//
+// See docs/superpowers/specs/2026-04-11-focus-substrate-design.md section 3.1.
+func NewEvent(stream string, eventType EventType, actor Actor, payload []byte) Event {
+	return Event{
+		ID:        NewULID(),
+		Stream:    stream,
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Actor:     actor,
+		Payload:   payload,
+	}
+}

--- a/internal/core/event_constructor_test.go
+++ b/internal/core/event_constructor_test.go
@@ -4,6 +4,8 @@
 package core_test
 
 import (
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,5 +58,63 @@ func TestNewEventIDsAreMonotonicWithinGoroutine(t *testing.T) {
 				"IDs must be strictly monotonic: prev=%s cur=%s", prev, ev.ID)
 		}
 		prev = ev.ID
+	}
+}
+
+func TestEventIDMonotonicityUnderLoad(t *testing.T) {
+	// I-16 stress test: 10 goroutines x 10,000 NewEvent calls.
+	// Each goroutine collects its IDs; within each goroutine the IDs
+	// must be strictly monotonically increasing (the monotonic entropy
+	// source is protected by entropyLock in ulid.go).
+	const goroutines = 10
+	const eventsPerGoroutine = 10_000
+
+	type idSlice []ulid.ULID
+
+	results := make([]idSlice, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			ids := make(idSlice, 0, eventsPerGoroutine)
+			for range eventsPerGoroutine {
+				ev := core.NewEvent("stress:test", core.EventTypeSay, core.Actor{
+					Kind: core.ActorSystem,
+					ID:   "stress",
+				}, []byte(`{}`))
+				ids = append(ids, ev.ID)
+			}
+			results[idx] = ids
+		}(g)
+	}
+	wg.Wait()
+
+	// Merge all IDs into a single slice preserving per-goroutine order.
+	all := make([]ulid.ULID, 0, goroutines*eventsPerGoroutine)
+	for _, ids := range results {
+		all = append(all, ids...)
+	}
+
+	// Sort the merged slice. Since NewULID is monotonic (mutex-protected),
+	// the global sequence must also be strictly monotonic -- no two IDs
+	// should be equal.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Compare(all[j]) < 0
+	})
+
+	for i := 1; i < len(all); i++ {
+		require.NotEqual(t, all[i], all[i-1],
+			"duplicate ID at sorted position %d: %s", i, all[i])
+	}
+
+	// Within each goroutine, IDs must be strictly ascending (monotonic).
+	for g, ids := range results {
+		for i := 1; i < len(ids); i++ {
+			require.True(t, ids[i].Compare(ids[i-1]) > 0,
+				"goroutine %d: non-monotonic at position %d: prev=%s cur=%s",
+				g, i, ids[i-1], ids[i])
+		}
 	}
 }

--- a/internal/core/event_constructor_test.go
+++ b/internal/core/event_constructor_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package core_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEventAssignsMonotonicID(t *testing.T) {
+	before := time.Now()
+	ev := core.NewEvent("location:test", core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter,
+		ID:   "char-1",
+	}, []byte(`{"message":"hello"}`))
+	after := time.Now()
+
+	require.NotEqual(t, ulid.ULID{}, ev.ID, "ID must be non-zero")
+	assert.Equal(t, "location:test", ev.Stream)
+	assert.Equal(t, core.EventTypeSay, ev.Type)
+	assert.Equal(t, core.ActorCharacter, ev.Actor.Kind)
+	assert.Equal(t, "char-1", ev.Actor.ID)
+	assert.Equal(t, []byte(`{"message":"hello"}`), ev.Payload)
+	assert.False(t, ev.Timestamp.Before(before), "Timestamp must be >= before")
+	assert.False(t, ev.Timestamp.After(after), "Timestamp must be <= after")
+}
+
+func TestNewEventProducesUniqueIDs(t *testing.T) {
+	seen := make(map[ulid.ULID]struct{}, 100)
+	for range 100 {
+		ev := core.NewEvent("location:test", core.EventTypeSay, core.Actor{
+			Kind: core.ActorSystem,
+			ID:   "system",
+		}, []byte(`{}`))
+		_, dup := seen[ev.ID]
+		require.False(t, dup, "NewEvent must produce unique IDs")
+		seen[ev.ID] = struct{}{}
+	}
+}
+
+func TestNewEventIDsAreMonotonicWithinGoroutine(t *testing.T) {
+	var prev ulid.ULID
+	for range 1000 {
+		ev := core.NewEvent("location:test", core.EventTypeSay, core.Actor{
+			Kind: core.ActorSystem,
+			ID:   "system",
+		}, []byte(`{}`))
+		if prev != (ulid.ULID{}) {
+			assert.True(t, ev.ID.Compare(prev) > 0,
+				"IDs must be strictly monotonic: prev=%s cur=%s", prev, ev.ID)
+		}
+		prev = ev.ID
+	}
+}

--- a/internal/grpc/cursor_lock_test.go
+++ b/internal/grpc/cursor_lock_test.go
@@ -343,12 +343,7 @@ func TestSendAndCommitEventFiresHookBetweenSendAndCommit(t *testing.T) {
 	// Send and BEFORE UpdateCursors, under the per-session lock.
 	sessionID := core.NewULID().String()
 	streamName := "location:test"
-	ev := core.Event{
-		ID:      core.NewULID(),
-		Stream:  streamName,
-		Type:    core.EventTypeSay,
-		Payload: []byte(`{"message":"hi"}`),
-	}
+	ev := core.NewEvent(streamName, core.EventTypeSay, core.Actor{}, []byte(`{"message":"hi"}`))
 
 	// The MemStore requires a pre-existing session for UpdateCursors
 	// to take effect. Populate one with an empty cursor map.
@@ -419,12 +414,7 @@ func TestSendAndCommitEventPropagatesSendErrorAndReleasesLock(t *testing.T) {
 	//   (3) release the per-session lock (no leaked refcount)
 	sessionID := core.NewULID().String()
 	streamName := "location:test"
-	ev := core.Event{
-		ID:      core.NewULID(),
-		Stream:  streamName,
-		Type:    core.EventTypeSay,
-		Payload: []byte(`{"message":"hi"}`),
-	}
+	ev := core.NewEvent(streamName, core.EventTypeSay, core.Actor{}, []byte(`{"message":"hi"}`))
 
 	store := newTestSessionStore(t, map[string]*session.Info{
 		sessionID: {
@@ -471,12 +461,7 @@ func TestSendAndCommitEventPropagatesSendErrorAndReleasesLock(t *testing.T) {
 func TestSendAndCommitEventSkipsHookWhenNil(t *testing.T) {
 	sessionID := core.NewULID().String()
 	streamName := "location:test"
-	ev := core.Event{
-		ID:      core.NewULID(),
-		Stream:  streamName,
-		Type:    core.EventTypeSay,
-		Payload: []byte(`{"message":"hi"}`),
-	}
+	ev := core.NewEvent(streamName, core.EventTypeSay, core.Actor{}, []byte(`{"message":"hi"}`))
 
 	store := newTestSessionStore(t, map[string]*session.Info{
 		sessionID: {

--- a/internal/grpc/dispatcher_test.go
+++ b/internal/grpc/dispatcher_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -43,14 +42,12 @@ func registerTestCommands(t *testing.T, reg *command.Registry) {
 				"character_name": exec.CharacterName(),
 				"message":        exec.Args,
 			})
-			event := core.Event{
-				ID:        core.NewULID(),
-				Type:      core.EventTypeSay,
-				Stream:    "location:" + exec.LocationID().String(),
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload:   payload,
-			}
+			event := core.NewEvent(
+				"location:"+exec.LocationID().String(),
+				core.EventTypeSay,
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				payload,
+			)
 			return exec.Services().Events().Append(ctx, event)
 		},
 	})
@@ -62,14 +59,12 @@ func registerTestCommands(t *testing.T, reg *command.Registry) {
 				"character_name": exec.CharacterName(),
 				"action":         exec.Args,
 			})
-			event := core.Event{
-				ID:        core.NewULID(),
-				Type:      core.EventTypePose,
-				Stream:    "location:" + exec.LocationID().String(),
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload:   payload,
-			}
+			event := core.NewEvent(
+				"location:"+exec.LocationID().String(),
+				core.EventTypePose,
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				payload,
+			)
 			return exec.Services().Events().Append(ctx, event)
 		},
 	})
@@ -82,14 +77,12 @@ func registerTestCommands(t *testing.T, reg *command.Registry) {
 				Message:       exec.Args,
 				Style:         "say",
 			})
-			event := core.Event{
-				ID:        core.NewULID(),
-				Type:      core.EventTypeOOC,
-				Stream:    "location:" + exec.LocationID().String(),
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload:   payload,
-			}
+			event := core.NewEvent(
+				"location:"+exec.LocationID().String(),
+				core.EventTypeOOC,
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				payload,
+			)
 			return exec.Services().Events().Append(ctx, event)
 		},
 	})

--- a/internal/grpc/location_follow_test.go
+++ b/internal/grpc/location_follow_test.go
@@ -92,12 +92,7 @@ func TestLocationFollower_HandleEvent_DetectsCharacterMove(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	event := core.Event{
-		ID:      ulid.Make(),
-		Stream:  world.CharacterStream(charID),
-		Type:    core.EventTypeMove,
-		Payload: movePayload,
-	}
+	event := core.NewEvent(world.CharacterStream(charID), core.EventTypeMove, core.Actor{}, movePayload)
 
 	stream := &capturingStream{ctx: context.Background()}
 	handled := lf.handleEvent(context.Background(), event, stream)
@@ -120,10 +115,7 @@ func TestLocationFollower_HandleEvent_IgnoresNonMoveEvents(t *testing.T) {
 		worldQuerier: &mockWorldQuerier{},
 	}
 
-	event := core.Event{
-		ID:   ulid.Make(),
-		Type: core.EventTypeSay,
-	}
+	event := core.NewEvent("", core.EventTypeSay, core.Actor{}, nil)
 
 	stream := &capturingStream{ctx: context.Background()}
 	handled := lf.handleEvent(context.Background(), event, stream)
@@ -154,11 +146,7 @@ func TestLocationFollower_HandleEvent_IgnoresOtherCharacterMoves(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	event := core.Event{
-		ID:      ulid.Make(),
-		Type:    core.EventTypeMove,
-		Payload: movePayload,
-	}
+	event := core.NewEvent("", core.EventTypeMove, core.Actor{}, movePayload)
 
 	stream := &capturingStream{ctx: context.Background()}
 	handled := lf.handleEvent(context.Background(), event, stream)
@@ -190,11 +178,7 @@ func TestLocationFollower_HandleEvent_IgnoresObjectMoves(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	event := core.Event{
-		ID:      ulid.Make(),
-		Type:    core.EventTypeMove,
-		Payload: movePayload,
-	}
+	event := core.NewEvent("", core.EventTypeMove, core.Actor{}, movePayload)
 
 	stream := &capturingStream{ctx: context.Background()}
 	handled := lf.handleEvent(context.Background(), event, stream)
@@ -210,10 +194,7 @@ func TestLocationFollower_HandleEvent_NilWorldQuerier(t *testing.T) {
 		worldQuerier: nil,
 	}
 
-	event := core.Event{
-		ID:   ulid.Make(),
-		Type: core.EventTypeMove,
-	}
+	event := core.NewEvent("", core.EventTypeMove, core.Actor{}, nil)
 
 	stream := &capturingStream{ctx: context.Background()}
 	handled := lf.handleEvent(context.Background(), event, stream)

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -466,14 +466,10 @@ func (s *CoreServer) emitCommandResponse(ctx context.Context, char core.Characte
 	if isError {
 		eventType = core.EventTypeCommandError
 	}
-	event := core.Event{
-		ID:        core.NewULID(),
-		Stream:    world.CharacterStream(char.ID),
-		Type:      eventType,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorSystem, ID: "system"},
-		Payload:   payload,
-	}
+	event := core.NewEvent(world.CharacterStream(char.ID), eventType, core.Actor{
+		Kind: core.ActorSystem,
+		ID:   "system",
+	}, payload)
 
 	if s.eventStore == nil {
 		slog.DebugContext(ctx, "emitCommandResponse: eventStore not configured, event not emitted")

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -240,14 +240,12 @@ func TestCoreServer_Subscribe_SendsEvents(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Send an event through the event store (triggers Subscribe notification)
-	testEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    "location:" + locationID.String(),
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
-		Payload:   []byte(`{"message":"test"}`),
-	}
+	testEvent := core.NewEvent(
+		"location:"+locationID.String(),
+		core.EventTypeSay,
+		core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
+		[]byte(`{"message":"test"}`),
+	)
 	require.NoError(t, eventStore.Append(ctx, testEvent))
 
 	// Give time for event to be sent
@@ -788,14 +786,12 @@ func TestCoreServer_Subscribe_SendError(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Send an event that will cause send error
-	testEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    "location:" + locationID.String(),
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
-		Payload:   []byte(`{"message":"test"}`),
-	}
+	testEvent := core.NewEvent(
+		"location:"+locationID.String(),
+		core.EventTypeSay,
+		core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
+		[]byte(`{"message":"test"}`),
+	)
 	require.NoError(t, eventStore.Append(ctx, testEvent))
 
 	select {
@@ -1281,14 +1277,12 @@ func TestCoreServer_Subscribe_ContextCancellationCleanup(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify subscription is active by sending an event
-	testEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    streamName,
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
-		Payload:   []byte(`{"message":"test"}`),
-	}
+	testEvent := core.NewEvent(
+		streamName,
+		core.EventTypeSay,
+		core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
+		[]byte(`{"message":"test"}`),
+	)
 	require.NoError(t, eventStore.Append(ctx, testEvent))
 
 	// Give time for event to be received
@@ -1440,14 +1434,12 @@ func TestCoreServer_Subscribe_TimeoutDuringEventSend(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// Send an event that will block
-	testEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    streamName,
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
-		Payload:   []byte(`{"message":"test"}`),
-	}
+	testEvent := core.NewEvent(
+		streamName,
+		core.EventTypeSay,
+		core.Actor{Kind: core.ActorCharacter, ID: charID.String()},
+		[]byte(`{"message":"test"}`),
+	)
 	require.NoError(t, eventStore.Append(ctx, testEvent))
 
 	// Wait for send to be called
@@ -2290,33 +2282,20 @@ func TestCoreServer_Subscribe_ReplayFromCursor(t *testing.T) {
 	ctx := context.Background()
 
 	// Prepopulate store: cursor event + 2 historical events
-	cursorEvent := core.Event{
-		ID:     core.NewULID(),
-		Stream: streamName, Type: core.EventTypeSay,
-		Timestamp: time.Now().Add(-3 * time.Second),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor0"},
-		Payload:   []byte(`{"message":"cursor"}`),
-	}
+	cursorEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor0",
+	}, []byte(`{"message":"cursor"}`))
 	require.NoError(t, eventStore.Append(ctx, cursorEvent))
 
-	historicalID1 := core.NewULID()
-	historicalID2 := core.NewULID()
-	for _, ev := range []core.Event{
-		{
-			ID: historicalID1, Stream: streamName, Type: core.EventTypeSay,
-			Timestamp: time.Now().Add(-2 * time.Second),
-			Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor1"},
-			Payload:   []byte(`{"message":"missed-1"}`),
-		},
-		{
-			ID: historicalID2, Stream: streamName, Type: core.EventTypeSay,
-			Timestamp: time.Now().Add(-1 * time.Second),
-			Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor2"},
-			Payload:   []byte(`{"message":"missed-2"}`),
-		},
-	} {
-		require.NoError(t, eventStore.Append(ctx, ev))
-	}
+	historical1 := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor1",
+	}, []byte(`{"message":"missed-1"}`))
+	require.NoError(t, eventStore.Append(ctx, historical1))
+
+	historical2 := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor2",
+	}, []byte(`{"message":"missed-2"}`))
+	require.NoError(t, eventStore.Append(ctx, historical2))
 
 	server := &CoreServer{
 		engine: core.NewEngine(eventStore),
@@ -2355,15 +2334,9 @@ func TestCoreServer_Subscribe_ReplayFromCursor(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Send a live event after replay
-	liveID := core.NewULID()
-	liveEvent := core.Event{
-		ID:        liveID,
-		Stream:    streamName,
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now(),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor3"},
-		Payload:   []byte(`{"message":"live"}`),
-	}
+	liveEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor3",
+	}, []byte(`{"message":"live"}`))
 	require.NoError(t, eventStore.Append(subCtx, liveEvent))
 
 	// Give time for live event delivery
@@ -2386,11 +2359,11 @@ func TestCoreServer_Subscribe_ReplayFromCursor(t *testing.T) {
 		}
 	}
 	require.GreaterOrEqual(t, len(sayEvents), 2, "expected at least 2 replayed say events")
-	assert.Equal(t, historicalID1.String(), sayEvents[0].GetEvent().GetId(), "first say event should be historical")
-	assert.Equal(t, historicalID2.String(), sayEvents[1].GetEvent().GetId(), "second say event should be historical")
+	assert.Equal(t, historical1.ID.String(), sayEvents[0].GetEvent().GetId(), "first say event should be historical")
+	assert.Equal(t, historical2.ID.String(), sayEvents[1].GetEvent().GetId(), "second say event should be historical")
 
 	if len(sayEvents) >= 3 {
-		assert.Equal(t, liveID.String(), sayEvents[2].GetEvent().GetId(), "third say event should be the live one")
+		assert.Equal(t, liveEvent.ID.String(), sayEvents[2].GetEvent().GetId(), "third say event should be the live one")
 	}
 }
 
@@ -2407,21 +2380,14 @@ func TestCoreServer_Subscribe_ReplayDeduplicatesLiveEvents(t *testing.T) {
 	ctx := context.Background()
 
 	// Prepopulate: cursor + one historical event
-	cursorEvent := core.Event{
-		ID: core.NewULID(), Stream: streamName, Type: core.EventTypeSay,
-		Timestamp: time.Now().Add(-2 * time.Second),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor0"},
-		Payload:   []byte(`{"message":"cursor"}`),
-	}
+	cursorEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor0",
+	}, []byte(`{"message":"cursor"}`))
 	require.NoError(t, eventStore.Append(ctx, cursorEvent))
 
-	historicalID := core.NewULID()
-	historicalEvent := core.Event{
-		ID: historicalID, Stream: streamName, Type: core.EventTypeSay,
-		Timestamp: time.Now().Add(-1 * time.Second),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor1"},
-		Payload:   []byte(`{"message":"historical"}`),
-	}
+	historicalEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor1",
+	}, []byte(`{"message":"historical"}`))
 	require.NoError(t, eventStore.Append(ctx, historicalEvent))
 
 	server := &CoreServer{
@@ -2470,7 +2436,7 @@ func TestCoreServer_Subscribe_ReplayDeduplicatesLiveEvents(t *testing.T) {
 	// Count how many times the historical event appears (should be exactly once)
 	count := 0
 	for _, ev := range stream.events {
-		if ef := ev.GetEvent(); ef != nil && ef.GetId() == historicalID.String() {
+		if ef := ev.GetEvent(); ef != nil && ef.GetId() == historicalEvent.ID.String() {
 			count++
 		}
 	}
@@ -2610,24 +2576,14 @@ func TestCoreServer_Subscribe_EmitsReplayCompleteControlFrame(t *testing.T) {
 	ctx := context.Background()
 
 	// Prepopulate store: cursor event + 1 historical event after it
-	cursorEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    streamName,
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now().Add(-2 * time.Second),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor0"},
-		Payload:   []byte(`{"message":"before-cursor"}`),
-	}
+	cursorEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor0",
+	}, []byte(`{"message":"before-cursor"}`))
 	require.NoError(t, eventStore.Append(ctx, cursorEvent))
 
-	historicalEvent := core.Event{
-		ID:        core.NewULID(),
-		Stream:    streamName,
-		Type:      core.EventTypeSay,
-		Timestamp: time.Now().Add(-1 * time.Second),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "actor1"},
-		Payload:   []byte(`{"message":"missed"}`),
-	}
+	historicalEvent := core.NewEvent(streamName, core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "actor1",
+	}, []byte(`{"message":"missed"}`))
 	require.NoError(t, eventStore.Append(ctx, historicalEvent))
 
 	server := &CoreServer{
@@ -2801,28 +2757,21 @@ replayComplete:
 }
 
 func TestEventToProto(t *testing.T) {
-	id := core.NewULID()
-	ts := time.Now()
-	ev := core.Event{
-		ID:        id,
-		Stream:    "location:test",
-		Type:      core.EventTypeSay,
-		Timestamp: ts,
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-1"},
-		Payload:   []byte(`{"msg":"hello"}`),
-	}
+	ev := core.NewEvent("location:test", core.EventTypeSay, core.Actor{
+		Kind: core.ActorCharacter, ID: "char-1",
+	}, []byte(`{"msg":"hello"}`))
 
 	proto := eventToProto(ev)
 	ef := proto.GetEvent()
 	require.NotNil(t, ef)
 
-	assert.Equal(t, id.String(), ef.GetId())
+	assert.Equal(t, ev.ID.String(), ef.GetId())
 	assert.Equal(t, "location:test", ef.GetStream())
 	assert.Equal(t, "say", ef.GetType())
 	assert.Equal(t, "character", ef.GetActorType())
 	assert.Equal(t, "char-1", ef.GetActorId())
 	assert.Equal(t, []byte(`{"msg":"hello"}`), ef.GetPayload())
-	assert.Equal(t, ts.UnixNano()/1e9, ef.GetTimestamp().AsTime().UnixNano()/1e9)
+	assert.Equal(t, ev.Timestamp.UnixNano()/1e9, ef.GetTimestamp().AsTime().UnixNano()/1e9)
 }
 
 // =============================================================================

--- a/internal/plugin/event_emitter.go
+++ b/internal/plugin/event_emitter.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
-	"time"
 
 	"github.com/holomush/holomush/internal/core"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
@@ -74,14 +73,7 @@ func (e *PluginEventEmitter) Emit(ctx context.Context, pluginName string, intent
 			New("event payload must be valid JSON")
 	}
 
-	event := core.Event{
-		ID:        core.NewULID(),
-		Stream:    intent.Stream,
-		Type:      core.EventType(intent.Type),
-		Timestamp: time.Now().UTC(),
-		Actor:     actor,
-		Payload:   []byte(intent.Payload),
-	}
+	event := core.NewEvent(intent.Stream, core.EventType(intent.Type), actor, []byte(intent.Payload))
 
 	if err := e.store.Append(ctx, event); err != nil {
 		return oops.With("plugin", pluginName).With("stream", intent.Stream).Wrap(err)

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -71,14 +71,9 @@ var _ = Describe("PostgresEventStore", func() {
 	Describe("Append", func() {
 		It("stores events correctly", func() {
 			ctx := context.Background()
-			event := core.Event{
-				ID:        core.NewULID(),
-				Stream:    "location:test-room",
-				Type:      core.EventTypeSay,
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-				Payload:   []byte(`{"message":"Hello, world!"}`),
-			}
+			event := core.NewEvent("location:test-room", core.EventTypeSay, core.Actor{
+				Kind: core.ActorCharacter, ID: "char-123",
+			}, []byte(`{"message":"Hello, world!"}`))
 
 			err := eventStore.Append(ctx, event)
 			Expect(err).NotTo(HaveOccurred())
@@ -99,15 +94,10 @@ var _ = Describe("PostgresEventStore", func() {
 			ctx := context.Background()
 			ids = make([]ulid.ULID, 5)
 			for i := range 5 {
-				ids[i] = core.NewULID()
-				event := core.Event{
-					ID:        ids[i],
-					Stream:    stream,
-					Type:      core.EventTypeSay,
-					Timestamp: time.Now(),
-					Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-					Payload:   []byte(`{"message":"test"}`),
-				}
+				event := core.NewEvent(stream, core.EventTypeSay, core.Actor{
+					Kind: core.ActorCharacter, ID: "char-123",
+				}, []byte(`{"message":"test"}`))
+				ids[i] = event.ID
 				err := eventStore.Append(ctx, event)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(time.Millisecond) // Ensure ULID ordering
@@ -158,15 +148,10 @@ var _ = Describe("PostgresEventStore", func() {
 			BeforeEach(func() {
 				ctx := context.Background()
 				for i := range 3 {
-					lastID = core.NewULID()
-					event := core.Event{
-						ID:        lastID,
-						Stream:    stream,
-						Type:      core.EventTypeSay,
-						Timestamp: time.Now(),
-						Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-						Payload:   []byte(`{}`),
-					}
+					event := core.NewEvent(stream, core.EventTypeSay, core.Actor{
+						Kind: core.ActorCharacter, ID: "char-123",
+					}, []byte(`{}`))
+					lastID = event.ID
 					err := eventStore.Append(ctx, event)
 					Expect(err).NotTo(HaveOccurred(), "Append %d failed", i)
 					time.Sleep(time.Millisecond)
@@ -196,14 +181,9 @@ var _ = Describe("PostgresEventStore", func() {
 			}
 
 			for _, et := range eventTypes {
-				event := core.Event{
-					ID:        core.NewULID(),
-					Stream:    stream,
-					Type:      et,
-					Timestamp: time.Now(),
-					Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-					Payload:   []byte(`{}`),
-				}
+				event := core.NewEvent(stream, et, core.Actor{
+					Kind: core.ActorCharacter, ID: "char-123",
+				}, []byte(`{}`))
 				err := eventStore.Append(ctx, event)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -230,14 +210,9 @@ var _ = Describe("PostgresEventStore", func() {
 			}
 
 			for _, ak := range actorKinds {
-				event := core.Event{
-					ID:        core.NewULID(),
-					Stream:    stream,
-					Type:      core.EventTypeSay,
-					Timestamp: time.Now(),
-					Actor:     core.Actor{Kind: ak, ID: "test-actor"},
-					Payload:   []byte(`{}`),
-				}
+				event := core.NewEvent(stream, core.EventTypeSay, core.Actor{
+					Kind: ak, ID: "test-actor",
+				}, []byte(`{}`))
 				err := eventStore.Append(ctx, event)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -327,14 +302,9 @@ var _ = Describe("PostgresEventStore", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Append an event
-			event := core.Event{
-				ID:        core.NewULID(),
-				Stream:    stream,
-				Type:      core.EventTypeSay,
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-				Payload:   []byte(`{"message":"Hello via NOTIFY!"}`),
-			}
+			event := core.NewEvent(stream, core.EventTypeSay, core.Actor{
+				Kind: core.ActorCharacter, ID: "char-123",
+			}, []byte(`{"message":"Hello via NOTIFY!"}`))
 			err = eventStore.Append(ctx, event)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -355,15 +325,10 @@ var _ = Describe("PostgresEventStore", func() {
 			// Append multiple events
 			ids := make([]ulid.ULID, 3)
 			for i := range 3 {
-				ids[i] = core.NewULID()
-				event := core.Event{
-					ID:        ids[i],
-					Stream:    stream,
-					Type:      core.EventTypeSay,
-					Timestamp: time.Now(),
-					Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-					Payload:   []byte(`{}`),
-				}
+				event := core.NewEvent(stream, core.EventTypeSay, core.Actor{
+					Kind: core.ActorCharacter, ID: "char-123",
+				}, []byte(`{}`))
+				ids[i] = event.ID
 				err := eventStore.Append(ctx, event)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(10 * time.Millisecond) // Ensure ordering
@@ -399,14 +364,9 @@ var _ = Describe("PostgresEventStore", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Append to a different stream
-			event := core.Event{
-				ID:        core.NewULID(),
-				Stream:    "location:stream-b",
-				Type:      core.EventTypeSay,
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-				Payload:   []byte(`{}`),
-			}
+			event := core.NewEvent("location:stream-b", core.EventTypeSay, core.Actor{
+				Kind: core.ActorCharacter, ID: "char-123",
+			}, []byte(`{}`))
 			err = eventStore.Append(ctx, event)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -21,14 +21,10 @@ import (
 
 // testEvent creates a test event with the given parameters.
 func testEvent(stream string, eventType core.EventType) core.Event {
-	return core.Event{
-		ID:        core.NewULID(),
-		Stream:    stream,
-		Type:      eventType,
-		Timestamp: time.Now().UTC().Truncate(time.Microsecond),
-		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-123"},
-		Payload:   []byte(`{"message":"test"}`),
-	}
+	return core.NewEvent(stream, eventType, core.Actor{
+		Kind: core.ActorCharacter,
+		ID:   "char-123",
+	}, []byte(`{"message":"test"}`))
 }
 
 func TestPostgresEventStore_Append(t *testing.T) {

--- a/internal/world/event_store_adapter.go
+++ b/internal/world/event_store_adapter.go
@@ -5,7 +5,6 @@ package world
 
 import (
 	"context"
-	"time"
 
 	"github.com/samber/oops"
 
@@ -32,17 +31,10 @@ func NewEventStoreAdapter(store EventAppender) *EventStoreAdapter {
 // Emit publishes an event to the given stream.
 // Implements world.EventEmitter interface.
 func (a *EventStoreAdapter) Emit(ctx context.Context, stream, eventType string, payload []byte) error {
-	event := core.Event{
-		ID:        core.NewULID(),
-		Stream:    stream,
-		Type:      core.EventType(eventType),
-		Timestamp: time.Now(),
-		Actor: core.Actor{
-			Kind: core.ActorSystem,
-			ID:   "world-service",
-		},
-		Payload: payload,
-	}
+	event := core.NewEvent(stream, core.EventType(eventType), core.Actor{
+		Kind: core.ActorSystem,
+		ID:   "world-service",
+	}, payload)
 
 	if err := a.store.Append(ctx, event); err != nil {
 		return oops.Code("EVENT_STORE_APPEND_FAILED").

--- a/test/integration/plugin/session_streams_integration_test.go
+++ b/test/integration/plugin/session_streams_integration_test.go
@@ -259,14 +259,12 @@ var _ = Describe("Plugin Session Stream Contribution", func() {
 	// appendEvent appends a test event on the given stream.
 	appendEvent := func(stream string) {
 		GinkgoHelper()
-		Expect(eventStore.Append(testCtx, core.Event{
-			ID:        core.NewULID(),
-			Stream:    stream,
-			Type:      core.EventType("test"),
-			Payload:   []byte(`{}`),
-			Timestamp: time.Now(),
-			Actor:     core.Actor{Kind: core.ActorSystem},
-		})).To(Succeed())
+		Expect(eventStore.Append(testCtx, core.NewEvent(
+			stream,
+			core.EventType("test"),
+			core.Actor{Kind: core.ActorSystem},
+			[]byte(`{}`),
+		))).To(Succeed())
 	}
 
 	Describe("UC1: session-start auto-subscribe", func() {

--- a/test/integration/session/session_persistence_integration_test.go
+++ b/test/integration/session/session_persistence_integration_test.go
@@ -81,14 +81,12 @@ func registerTestSayCommand(reg *command.Registry) {
 		Name: "say",
 		Handler: func(ctx context.Context, exec *command.CommandExecution) error {
 			payload := []byte(`{"character_name":"` + exec.CharacterName() + `","message":"` + exec.Args + `"}`)
-			return exec.Services().Events().Append(ctx, core.Event{
-				ID:        ulid.Make(),
-				Stream:    world.LocationStream(exec.LocationID()),
-				Type:      core.EventType(pluginsdk.EventTypeSay),
-				Timestamp: time.Now(),
-				Actor:     core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload:   payload,
-			})
+			return exec.Services().Events().Append(ctx, core.NewEvent(
+				world.LocationStream(exec.LocationID()),
+				core.EventType(pluginsdk.EventTypeSay),
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				payload,
+			))
 		},
 		Help:   "Say something",
 		Usage:  "say <message>",
@@ -325,14 +323,9 @@ var _ = Describe("Session Persistence", func() {
 			// activity from other characters while we are disconnected.
 			missedPayloads := []string{"missed-A", "missed-B", "missed-C"}
 			for _, msg := range missedPayloads {
-				missed := core.Event{
-					ID:        core.NewULID(),
-					Stream:    locationStream,
-					Type:      core.EventTypeSay,
-					Payload:   []byte(`{"character_name":"Other","message":"` + msg + `"}`),
-					Timestamp: time.Now(),
-					Actor:     core.Actor{Kind: core.ActorCharacter, ID: "other"},
-				}
+				missed := core.NewEvent(locationStream, core.EventTypeSay, core.Actor{
+					Kind: core.ActorCharacter, ID: "other",
+				}, []byte(`{"character_name":"Other","message":"`+msg+`"}`))
 				Expect(env.eventStore.Append(testCtx, missed)).To(Succeed())
 			}
 

--- a/test/integration/telnet/e2e_test.go
+++ b/test/integration/telnet/e2e_test.go
@@ -142,13 +142,12 @@ func registerTestCommands(reg *command.Registry) {
 	mustRegister(command.CommandEntryConfig{
 		Name: "say",
 		Handler: func(ctx context.Context, exec *command.CommandExecution) error {
-			return exec.Services().Events().Append(ctx, core.Event{
-				ID:      ulid.Make(),
-				Stream:  "location:" + exec.LocationID().String(),
-				Type:    core.EventType(pluginsdk.EventTypeSay),
-				Actor:   core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload: []byte(fmt.Sprintf(`{"character_name":"%s","message":"%s"}`, exec.CharacterName(), exec.Args)),
-			})
+			return exec.Services().Events().Append(ctx, core.NewEvent(
+				"location:"+exec.LocationID().String(),
+				core.EventType(pluginsdk.EventTypeSay),
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				[]byte(fmt.Sprintf(`{"character_name":"%s","message":"%s"}`, exec.CharacterName(), exec.Args)),
+			))
 		},
 		Help:   "Say something",
 		Usage:  "say <message>",
@@ -158,13 +157,12 @@ func registerTestCommands(reg *command.Registry) {
 	mustRegister(command.CommandEntryConfig{
 		Name: "pose",
 		Handler: func(ctx context.Context, exec *command.CommandExecution) error {
-			return exec.Services().Events().Append(ctx, core.Event{
-				ID:      ulid.Make(),
-				Stream:  "location:" + exec.LocationID().String(),
-				Type:    core.EventType(pluginsdk.EventTypePose),
-				Actor:   core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
-				Payload: []byte(fmt.Sprintf(`{"character_name":"%s","message":"%s"}`, exec.CharacterName(), exec.Args)),
-			})
+			return exec.Services().Events().Append(ctx, core.NewEvent(
+				"location:"+exec.LocationID().String(),
+				core.EventType(pluginsdk.EventTypePose),
+				core.Actor{Kind: core.ActorCharacter, ID: exec.CharacterID().String()},
+				[]byte(fmt.Sprintf(`{"character_name":"%s","message":"%s"}`, exec.CharacterName(), exec.Args)),
+			))
 		},
 		Help:   "Pose an action",
 		Usage:  "pose <action>",


### PR DESCRIPTION
## Summary
- Introduces `core.NewEvent` as the sole blessed constructor for events, enforcing invariant I-16
- Migrated all 44 `core.Event{}` call sites (4 production, 40 test)
- Fixed 8 `ulid.Make()` hazards using `math/rand` instead of `crypto/rand`
- Extended gorules `EventIDMustBeMonotonic` to flag ALL raw `Event{}` literals
- 10-goroutine concurrent monotonicity stress test under `-race`

## Context
Part of epic `holomush-oy6e` (Server-Owned Focus Substrate).
Spec: `docs/superpowers/specs/2026-04-11-focus-substrate-design.md` § 3.1 I-16
Bead: `holomush-oy6e.1`

## Test plan
- [x] `task pr-prep` passes
- [x] Concurrent monotonicity stress test: 10 goroutines x 10k events, strict ascending
- [x] No remaining `core.Event{` struct literals outside `event.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new event constructor that automatically generates monotonic IDs and timestamps for consistency across the application.

* **Improvements**
  * Updated code to leverage the new event constructor, simplifying event creation and ensuring uniform ID generation behavior system-wide.

* **Tests**
  * Added comprehensive test coverage for the new event constructor, validating ID uniqueness, monotonicity, and thread-safe behavior under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->