### PR TITLE
feat(settings): generalized scoped settings with game/player/character chain

### DIFF
--- a/internal/settings/chain.go
+++ b/internal/settings/chain.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings
+
+import (
+	"context"
+	"time"
+)
+
+// Chain composes scoped Settings instances with first-match-wins
+// resolution. Typical construction for a session context:
+//
+//	chain := settings.NewChain(
+//	    characterStore.For(ctx, info.CharacterID),
+//	    playerStore.For(ctx, info.PlayerID),
+//	    gameSettings,
+//	)
+//	tail, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+//
+// Chain itself implements Settings, so the resolution chain is a Settings
+// instance that can be passed to consumers unaware of the scope layering.
+type Chain struct {
+	scopes []Settings
+}
+
+// NewChain constructs a Chain from scopes in resolution priority order
+// (most-specific first). Nil scopes are accepted and skipped (null-object
+// pattern), making it safe to pass a nil CharacterSettingsStore result.
+func NewChain(scopes ...Settings) *Chain {
+	filtered := make([]Settings, 0, len(scopes))
+	for _, s := range scopes {
+		if s != nil {
+			filtered = append(filtered, s)
+		}
+	}
+	return &Chain{scopes: filtered}
+}
+
+// StringN returns the first non-absent string value across scopes.
+func (c *Chain) StringN(ctx context.Context, key string) (string, bool) {
+	for _, s := range c.scopes {
+		if v, ok := s.StringN(ctx, key); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// IntN returns the first non-absent int value across scopes.
+func (c *Chain) IntN(ctx context.Context, key string) (int, bool) {
+	for _, s := range c.scopes {
+		if v, ok := s.IntN(ctx, key); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+// BoolN returns the first non-absent bool value across scopes.
+func (c *Chain) BoolN(ctx context.Context, key string) (bool, bool) {
+	for _, s := range c.scopes {
+		if v, ok := s.BoolN(ctx, key); ok {
+			return v, true
+		}
+	}
+	return false, false
+}
+
+// DurationN returns the first non-absent duration value across scopes.
+func (c *Chain) DurationN(ctx context.Context, key string) (time.Duration, bool) {
+	for _, s := range c.scopes {
+		if v, ok := s.DurationN(ctx, key); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}

--- a/internal/settings/chain.go
+++ b/internal/settings/chain.go
@@ -58,7 +58,7 @@ func (c *Chain) IntN(ctx context.Context, key string) (int, bool) {
 }
 
 // BoolN returns the first non-absent bool value across scopes.
-func (c *Chain) BoolN(ctx context.Context, key string) (bool, bool) {
+func (c *Chain) BoolN(ctx context.Context, key string) (value, ok bool) {
 	for _, s := range c.scopes {
 		if v, ok := s.BoolN(ctx, key); ok {
 			return v, true

--- a/internal/settings/chain_test.go
+++ b/internal/settings/chain_test.go
@@ -156,7 +156,7 @@ func TestChainEmptyScopesReturnsFalse(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestChainImplementsSettingsInterface(t *testing.T) {
+func TestChainImplementsSettingsInterface(_ *testing.T) {
 	// Compile-time check that Chain satisfies Settings.
 	var _ settings.Settings = settings.NewChain()
 }

--- a/internal/settings/chain_test.go
+++ b/internal/settings/chain_test.go
@@ -229,6 +229,44 @@ func TestChainWithNilCharacterScopeFallsToPlayer(t *testing.T) {
 	assert.Equal(t, 7, v)
 }
 
+func TestChainBoolNReturnsFalseWhenNoScopeHasKey(t *testing.T) {
+	ctx := context.Background()
+	chain := settings.NewChain(newStub(), newStub())
+	_, ok := chain.BoolN(ctx, "auth.auto_login")
+	assert.False(t, ok)
+}
+
+func TestChainDurationNReturnsFalseWhenNoScopeHasKey(t *testing.T) {
+	ctx := context.Background()
+	chain := settings.NewChain(newStub(), newStub())
+	_, ok := chain.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
+}
+
+func TestChainDurationNFallsToLaterScope(t *testing.T) {
+	ctx := context.Background()
+	player := newStub() // no duration set
+	game := newStub()
+	game.durations["core.session_timeout"] = 60 * time.Second
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.DurationN(ctx, "core.session_timeout")
+	assert.True(t, ok)
+	assert.Equal(t, 60*time.Second, v)
+}
+
+func TestChainBoolNFallsToLaterScope(t *testing.T) {
+	ctx := context.Background()
+	player := newStub() // no bool set
+	game := newStub()
+	game.bools["auth.auto_login"] = true
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.BoolN(ctx, "auth.auto_login")
+	assert.True(t, ok)
+	assert.True(t, v)
+}
+
 func TestChainTypeMixStringFromCharIntFromGame(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/settings/chain_test.go
+++ b/internal/settings/chain_test.go
@@ -160,3 +160,90 @@ func TestChainImplementsSettingsInterface(t *testing.T) {
 	// Compile-time check that Chain satisfies Settings.
 	var _ settings.Settings = settings.NewChain()
 }
+
+func TestChainResolutionOrderMatchesSpecCharacterPlayerGame(t *testing.T) {
+	ctx := context.Background()
+
+	char := newStub()
+	char.ints["scenes.focus.replay_tail_default"] = 2
+	player := newStub()
+	player.ints["scenes.focus.replay_tail_default"] = 5
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(char, player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 2, v, "character scope (first) must win")
+}
+
+func TestChainResolutionSkipsCharacterFallsToPlayer(t *testing.T) {
+	ctx := context.Background()
+
+	char := newStub() // no value
+	player := newStub()
+	player.ints["scenes.focus.replay_tail_default"] = 5
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(char, player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 5, v, "player scope must win when character unset")
+}
+
+func TestChainResolutionSkipsCharacterAndPlayerFallsToGame(t *testing.T) {
+	ctx := context.Background()
+
+	char := newStub()   // no value
+	player := newStub() // no value
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(char, player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 3, v, "game scope must win when character and player unset")
+}
+
+func TestChainResolutionAllUnsetReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	chain := settings.NewChain(newStub(), newStub(), newStub())
+	_, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.False(t, ok, "all-unset chain must return false")
+}
+
+func TestChainWithNilCharacterScopeFallsToPlayer(t *testing.T) {
+	ctx := context.Background()
+
+	player := newStub()
+	player.ints["scenes.focus.replay_tail_default"] = 7
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	// nil simulates CharacterSettingsStore.For returning nil
+	chain := settings.NewChain(nil, player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 7, v)
+}
+
+func TestChainTypeMixStringFromCharIntFromGame(t *testing.T) {
+	ctx := context.Background()
+
+	char := newStub()
+	char.strings["scenes.focus.mode"] = "bounded"
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(char, game)
+
+	mode, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.True(t, ok)
+	assert.Equal(t, "bounded", mode)
+
+	tail, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 3, tail)
+}

--- a/internal/settings/chain_test.go
+++ b/internal/settings/chain_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/settings"
+)
+
+// stubSettings implements Settings for testing. Stores values as strings
+// keyed by setting name. Returns false for missing keys.
+type stubSettings struct {
+	strings   map[string]string
+	ints      map[string]int
+	bools     map[string]bool
+	durations map[string]time.Duration
+}
+
+func newStub() *stubSettings {
+	return &stubSettings{
+		strings:   make(map[string]string),
+		ints:      make(map[string]int),
+		bools:     make(map[string]bool),
+		durations: make(map[string]time.Duration),
+	}
+}
+
+func (s *stubSettings) StringN(_ context.Context, key string) (string, bool) {
+	v, ok := s.strings[key]
+	return v, ok
+}
+
+func (s *stubSettings) IntN(_ context.Context, key string) (int, bool) {
+	v, ok := s.ints[key]
+	return v, ok
+}
+
+func (s *stubSettings) BoolN(_ context.Context, key string) (bool, bool) {
+	v, ok := s.bools[key]
+	return v, ok
+}
+
+func (s *stubSettings) DurationN(_ context.Context, key string) (time.Duration, bool) {
+	v, ok := s.durations[key]
+	return v, ok
+}
+
+func TestChainStringNReturnsFirstMatchInScopeOrder(t *testing.T) {
+	ctx := context.Background()
+	player := newStub()
+	player.strings["scenes.focus.mode"] = "player-value"
+	game := newStub()
+	game.strings["scenes.focus.mode"] = "game-value"
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.True(t, ok)
+	assert.Equal(t, "player-value", v)
+}
+
+func TestChainStringNFallsToLaterScope(t *testing.T) {
+	ctx := context.Background()
+	player := newStub() // no value set
+	game := newStub()
+	game.strings["scenes.focus.mode"] = "game-value"
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.True(t, ok)
+	assert.Equal(t, "game-value", v)
+}
+
+func TestChainStringNReturnsFalseWhenNoScopeHasKey(t *testing.T) {
+	ctx := context.Background()
+	chain := settings.NewChain(newStub(), newStub())
+	_, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestChainIntNReturnsFirstMatch(t *testing.T) {
+	ctx := context.Background()
+	char := newStub()
+	char.ints["scenes.focus.replay_tail_default"] = 5
+	player := newStub()
+	player.ints["scenes.focus.replay_tail_default"] = 7
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(char, player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 5, v)
+}
+
+func TestChainIntNDistinguishesZeroFromUnset(t *testing.T) {
+	ctx := context.Background()
+	player := newStub()
+	player.ints["scenes.focus.replay_tail_default"] = 0
+	game := newStub()
+	game.ints["scenes.focus.replay_tail_default"] = 3
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 0, v, "explicit 0 must win over game default 3")
+}
+
+func TestChainBoolNReturnsFirstMatch(t *testing.T) {
+	ctx := context.Background()
+	player := newStub()
+	player.bools["auth.auto_login"] = true
+	game := newStub()
+	game.bools["auth.auto_login"] = false
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.BoolN(ctx, "auth.auto_login")
+	assert.True(t, ok)
+	assert.True(t, v)
+}
+
+func TestChainDurationNReturnsFirstMatch(t *testing.T) {
+	ctx := context.Background()
+	player := newStub()
+	player.durations["core.session_timeout"] = 30 * time.Second
+	game := newStub()
+	game.durations["core.session_timeout"] = 60 * time.Second
+
+	chain := settings.NewChain(player, game)
+	v, ok := chain.DurationN(ctx, "core.session_timeout")
+	assert.True(t, ok)
+	assert.Equal(t, 30*time.Second, v)
+}
+
+func TestChainSkipsNilScopes(t *testing.T) {
+	ctx := context.Background()
+	game := newStub()
+	game.strings["scenes.focus.mode"] = "game-value"
+
+	// nil represents CharacterSettingsStore.For returning nil
+	chain := settings.NewChain(nil, nil, game)
+	v, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.True(t, ok)
+	assert.Equal(t, "game-value", v)
+}
+
+func TestChainEmptyScopesReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	chain := settings.NewChain()
+	_, ok := chain.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestChainImplementsSettingsInterface(t *testing.T) {
+	// Compile-time check that Chain satisfies Settings.
+	var _ settings.Settings = settings.NewChain()
+}

--- a/internal/settings/character.go
+++ b/internal/settings/character.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// nullCharacterSettingsStore is the Phase 4 null implementation of
+// CharacterSettingsStore. All reads return (zero, false). Writes return
+// an error. When character-scope preferences become a real need, this
+// is replaced with a Postgres-backed implementation.
+type nullCharacterSettingsStore struct{}
+
+// NewNullCharacterSettingsStore returns a CharacterSettingsStore that
+// always reports all keys as unset.
+func NewNullCharacterSettingsStore() CharacterSettingsStore {
+	return &nullCharacterSettingsStore{}
+}
+
+func (n *nullCharacterSettingsStore) For(_ context.Context, _ ulid.ULID) Settings {
+	return &emptySettings{}
+}
+
+func (n *nullCharacterSettingsStore) SetString(
+	_ context.Context, _ ulid.ULID, _, _ string,
+) error {
+	return errors.New("character settings not implemented in Phase 4")
+}
+
+// Compile-time interface check.
+var _ CharacterSettingsStore = (*nullCharacterSettingsStore)(nil)

--- a/internal/settings/character_test.go
+++ b/internal/settings/character_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/settings"
+)
+
+func TestNullCharacterSettingsForReturnsAlwaysUnset(t *testing.T) {
+	ctx := context.Background()
+	store := settings.NewNullCharacterSettingsStore()
+	cid := ulid.Make()
+
+	s := store.For(ctx, cid)
+
+	_, ok := s.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+
+	_, ok = s.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.False(t, ok)
+
+	_, ok = s.BoolN(ctx, "auth.auto_login")
+	assert.False(t, ok)
+
+	_, ok = s.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
+}
+
+func TestNullCharacterSettingsForReturnsNonNilSettings(t *testing.T) {
+	ctx := context.Background()
+	store := settings.NewNullCharacterSettingsStore()
+	cid := ulid.Make()
+
+	s := store.For(ctx, cid)
+	assert.NotNil(t, s)
+}
+
+func TestNullCharacterSettingsSetStringReturnsError(t *testing.T) {
+	ctx := context.Background()
+	store := settings.NewNullCharacterSettingsStore()
+	cid := ulid.Make()
+
+	err := store.SetString(ctx, cid, "scenes.focus.mode", "bounded")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
+}
+
+func TestNullCharacterSettingsStoreImplementsInterface(t *testing.T) {
+	var _ settings.CharacterSettingsStore = settings.NewNullCharacterSettingsStore()
+}

--- a/internal/settings/character_test.go
+++ b/internal/settings/character_test.go
@@ -52,6 +52,6 @@ func TestNullCharacterSettingsSetStringReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "not implemented")
 }
 
-func TestNullCharacterSettingsStoreImplementsInterface(t *testing.T) {
-	var _ settings.CharacterSettingsStore = settings.NewNullCharacterSettingsStore()
+func TestNullCharacterSettingsStoreImplementsInterface(_ *testing.T) {
+	var _ settings.CharacterSettingsStore = settings.NewNullCharacterSettingsStore() //nolint:staticcheck // intentional interface check
 }

--- a/internal/settings/game.go
+++ b/internal/settings/game.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/samber/oops"
+)
+
+// ErrNotFound is returned by SystemInfoStore when a key does not exist.
+var ErrNotFound = errors.New("setting not found")
+
+// SystemInfoStore is the narrow interface for reading and writing
+// key/value pairs from holomush_system_info. Satisfied by
+// *store.PostgresEventStore.
+type SystemInfoStore interface {
+	GetSystemInfo(ctx context.Context, key string) (string, error)
+	SetSystemInfo(ctx context.Context, key, value string) error
+}
+
+// SystemInfoAdapter wraps a store that uses its own not-found sentinel,
+// mapping it to settings.ErrNotFound for consistent handling.
+type SystemInfoAdapter struct {
+	Store       SystemInfoStore
+	NotFoundErr error // the store's not-found sentinel (e.g., store.ErrSystemInfoNotFound)
+}
+
+// GetSystemInfo delegates to the underlying store, mapping the store's
+// not-found error to settings.ErrNotFound.
+func (a *SystemInfoAdapter) GetSystemInfo(ctx context.Context, key string) (string, error) {
+	v, err := a.Store.GetSystemInfo(ctx, key)
+	if err != nil && a.NotFoundErr != nil && errors.Is(err, a.NotFoundErr) {
+		return "", ErrNotFound
+	}
+	return v, err
+}
+
+// SetSystemInfo delegates to the underlying store.
+func (a *SystemInfoAdapter) SetSystemInfo(ctx context.Context, key, value string) error {
+	return a.Store.SetSystemInfo(ctx, key, value)
+}
+
+// postgresGameSettings implements GameSettings backed by holomush_system_info.
+type postgresGameSettings struct {
+	store SystemInfoStore
+}
+
+// NewGameSettings creates a GameSettings backed by the given SystemInfoStore.
+func NewGameSettings(store SystemInfoStore) GameSettings {
+	return &postgresGameSettings{store: store}
+}
+
+func (g *postgresGameSettings) StringN(ctx context.Context, key string) (string, bool) {
+	v, err := g.store.GetSystemInfo(ctx, key)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			slog.DebugContext(ctx, "game settings read failed",
+				"key", key, "error", err)
+		}
+		return "", false
+	}
+	return v, true
+}
+
+func (g *postgresGameSettings) IntN(ctx context.Context, key string) (int, bool) {
+	s, ok := g.StringN(ctx, key)
+	if !ok {
+		return 0, false
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		slog.DebugContext(ctx, "game settings int parse failed",
+			"key", key, "raw", s, "error", err)
+		return 0, false
+	}
+	return v, true
+}
+
+func (g *postgresGameSettings) BoolN(ctx context.Context, key string) (bool, bool) {
+	s, ok := g.StringN(ctx, key)
+	if !ok {
+		return false, false
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		slog.DebugContext(ctx, "game settings bool parse failed",
+			"key", key, "raw", s, "error", err)
+		return false, false
+	}
+	return v, true
+}
+
+func (g *postgresGameSettings) DurationN(ctx context.Context, key string) (time.Duration, bool) {
+	s, ok := g.StringN(ctx, key)
+	if !ok {
+		return 0, false
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		slog.DebugContext(ctx, "game settings duration parse failed",
+			"key", key, "raw", s, "error", err)
+		return 0, false
+	}
+	return v, true
+}
+
+func (g *postgresGameSettings) SetString(ctx context.Context, key, value string) error {
+	if err := ValidateNamespace(key); err != nil {
+		return oops.With("key", key).Wrap(err)
+	}
+	return g.store.SetSystemInfo(ctx, key, value)
+}

--- a/internal/settings/game.go
+++ b/internal/settings/game.go
@@ -38,12 +38,18 @@ func (a *SystemInfoAdapter) GetSystemInfo(ctx context.Context, key string) (stri
 	if err != nil && a.NotFoundErr != nil && errors.Is(err, a.NotFoundErr) {
 		return "", ErrNotFound
 	}
-	return v, err
+	if err != nil {
+		return "", oops.With("key", key).Wrap(err)
+	}
+	return v, nil
 }
 
 // SetSystemInfo delegates to the underlying store.
 func (a *SystemInfoAdapter) SetSystemInfo(ctx context.Context, key, value string) error {
-	return a.Store.SetSystemInfo(ctx, key, value)
+	if err := a.Store.SetSystemInfo(ctx, key, value); err != nil {
+		return oops.With("key", key).Wrap(err)
+	}
+	return nil
 }
 
 // postgresGameSettings implements GameSettings backed by holomush_system_info.
@@ -82,7 +88,7 @@ func (g *postgresGameSettings) IntN(ctx context.Context, key string) (int, bool)
 	return v, true
 }
 
-func (g *postgresGameSettings) BoolN(ctx context.Context, key string) (bool, bool) {
+func (g *postgresGameSettings) BoolN(ctx context.Context, key string) (value, ok bool) {
 	s, ok := g.StringN(ctx, key)
 	if !ok {
 		return false, false
@@ -114,5 +120,8 @@ func (g *postgresGameSettings) SetString(ctx context.Context, key, value string)
 	if err := ValidateNamespace(key); err != nil {
 		return oops.With("key", key).Wrap(err)
 	}
-	return g.store.SetSystemInfo(ctx, key, value)
+	if err := g.store.SetSystemInfo(ctx, key, value); err != nil {
+		return oops.With("key", key).Wrap(err)
+	}
+	return nil
 }

--- a/internal/settings/game_test.go
+++ b/internal/settings/game_test.go
@@ -184,6 +184,105 @@ func TestGameSettingsSetStringReturnsStoreError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGameSettingsBoolNReturnsFalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	gs := settings.NewGameSettings(newMockSystemInfoStore())
+
+	_, ok := gs.BoolN(ctx, "core.maintenance_mode")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsDurationNReturnsFalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	gs := settings.NewGameSettings(newMockSystemInfoStore())
+
+	_, ok := gs.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
+}
+
+// --- SystemInfoAdapter tests ---
+
+func TestSystemInfoAdapterMapsNotFoundToSettingsErrNotFound(t *testing.T) {
+	ctx := context.Background()
+	storeErr := errors.New("store: not found")
+	adapter := &settings.SystemInfoAdapter{
+		Store:       &foreignNotFoundStore{sentinel: storeErr},
+		NotFoundErr: storeErr,
+	}
+
+	_, err := adapter.GetSystemInfo(ctx, "anything")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, settings.ErrNotFound)
+}
+
+func TestSystemInfoAdapterPassesThroughNonNotFoundErrors(t *testing.T) {
+	ctx := context.Background()
+	storeErr := errors.New("store: not found")
+	otherErr := errors.New("connection refused")
+	adapter := &settings.SystemInfoAdapter{
+		Store:       &foreignNotFoundStore{sentinel: otherErr},
+		NotFoundErr: storeErr,
+	}
+
+	_, err := adapter.GetSystemInfo(ctx, "anything")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, settings.ErrNotFound)
+}
+
+func TestSystemInfoAdapterReturnsValueOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	inner := newMockSystemInfoStore()
+	inner.data["core.name"] = "TestMUSH"
+	adapter := &settings.SystemInfoAdapter{
+		Store:       inner,
+		NotFoundErr: settings.ErrNotFound,
+	}
+
+	v, err := adapter.GetSystemInfo(ctx, "core.name")
+	require.NoError(t, err)
+	assert.Equal(t, "TestMUSH", v)
+}
+
+func TestSystemInfoAdapterSetSystemInfoDelegatesToStore(t *testing.T) {
+	ctx := context.Background()
+	inner := newMockSystemInfoStore()
+	adapter := &settings.SystemInfoAdapter{
+		Store:       inner,
+		NotFoundErr: settings.ErrNotFound,
+	}
+
+	err := adapter.SetSystemInfo(ctx, "core.name", "TestMUSH")
+	require.NoError(t, err)
+	assert.Equal(t, "TestMUSH", inner.data["core.name"])
+}
+
+func TestSystemInfoAdapterSetSystemInfoReturnsStoreError(t *testing.T) {
+	ctx := context.Background()
+	inner := newMockSystemInfoStore()
+	inner.err = errors.New("write failed")
+	adapter := &settings.SystemInfoAdapter{
+		Store:       inner,
+		NotFoundErr: settings.ErrNotFound,
+	}
+
+	err := adapter.SetSystemInfo(ctx, "core.name", "TestMUSH")
+	assert.Error(t, err)
+}
+
+// foreignNotFoundStore is a SystemInfoStore that returns its sentinel error
+// for all reads, simulating a store with its own not-found error type.
+type foreignNotFoundStore struct {
+	sentinel error
+}
+
+func (f *foreignNotFoundStore) GetSystemInfo(context.Context, string) (string, error) {
+	return "", f.sentinel
+}
+
+func (f *foreignNotFoundStore) SetSystemInfo(context.Context, string, string) error {
+	return nil
+}
+
 func TestGameSettingsImplementsGameSettingsInterface(_ *testing.T) {
 	var _ settings.GameSettings = settings.NewGameSettings(newMockSystemInfoStore()) //nolint:staticcheck // intentional interface check
 }

--- a/internal/settings/game_test.go
+++ b/internal/settings/game_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/settings"
+)
+
+// mockSystemInfoStore implements settings.SystemInfoStore for testing.
+type mockSystemInfoStore struct {
+	data map[string]string
+	err  error
+}
+
+func newMockSystemInfoStore() *mockSystemInfoStore {
+	return &mockSystemInfoStore{data: make(map[string]string)}
+}
+
+func (m *mockSystemInfoStore) GetSystemInfo(_ context.Context, key string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	v, ok := m.data[key]
+	if !ok {
+		return "", settings.ErrNotFound
+	}
+	return v, nil
+}
+
+func (m *mockSystemInfoStore) SetSystemInfo(_ context.Context, key, value string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.data[key] = value
+	return nil
+}
+
+func TestGameSettingsStringNReturnsStoredValue(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["scenes.focus.mode"] = "bounded"
+	gs := settings.NewGameSettings(store)
+
+	v, ok := gs.StringN(ctx, "scenes.focus.mode")
+	assert.True(t, ok)
+	assert.Equal(t, "bounded", v)
+}
+
+func TestGameSettingsStringNReturnsFalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	gs := settings.NewGameSettings(newMockSystemInfoStore())
+
+	_, ok := gs.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsStringNReturnsFalseOnError(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.err = errors.New("connection failed")
+	gs := settings.NewGameSettings(store)
+
+	_, ok := gs.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsIntNParsesStoredValue(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["scenes.focus.replay_tail_default"] = "3"
+	gs := settings.NewGameSettings(store)
+
+	v, ok := gs.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 3, v)
+}
+
+func TestGameSettingsIntNReturnsFalseForNonNumeric(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["scenes.focus.replay_tail_default"] = "not-a-number"
+	gs := settings.NewGameSettings(store)
+
+	_, ok := gs.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsIntNReturnsFalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	gs := settings.NewGameSettings(newMockSystemInfoStore())
+
+	_, ok := gs.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsBoolNParsesTrue(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["core.maintenance_mode"] = "true"
+	gs := settings.NewGameSettings(store)
+
+	v, ok := gs.BoolN(ctx, "core.maintenance_mode")
+	assert.True(t, ok)
+	assert.True(t, v)
+}
+
+func TestGameSettingsBoolNParsesFalse(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["core.maintenance_mode"] = "false"
+	gs := settings.NewGameSettings(store)
+
+	v, ok := gs.BoolN(ctx, "core.maintenance_mode")
+	assert.True(t, ok)
+	assert.False(t, v)
+}
+
+func TestGameSettingsBoolNReturnsFalseForNonBool(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["core.maintenance_mode"] = "maybe"
+	gs := settings.NewGameSettings(store)
+
+	_, ok := gs.BoolN(ctx, "core.maintenance_mode")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsDurationNParsesStoredValue(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["core.session_timeout"] = "30s"
+	gs := settings.NewGameSettings(store)
+
+	v, ok := gs.DurationN(ctx, "core.session_timeout")
+	assert.True(t, ok)
+	assert.Equal(t, 30*time.Second, v)
+}
+
+func TestGameSettingsDurationNReturnsFalseForInvalidDuration(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.data["core.session_timeout"] = "not-a-duration"
+	gs := settings.NewGameSettings(store)
+
+	_, ok := gs.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
+}
+
+func TestGameSettingsSetStringStoresValue(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	gs := settings.NewGameSettings(store)
+
+	err := gs.SetString(ctx, "scenes.focus.replay_tail_default", "5")
+	require.NoError(t, err)
+	assert.Equal(t, "5", store.data["scenes.focus.replay_tail_default"])
+}
+
+func TestGameSettingsSetStringRejectsInvalidNamespace(t *testing.T) {
+	ctx := context.Background()
+	gs := settings.NewGameSettings(newMockSystemInfoStore())
+
+	err := gs.SetString(ctx, "bogus.key", "val")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown namespace")
+}
+
+func TestGameSettingsSetStringReturnsStoreError(t *testing.T) {
+	ctx := context.Background()
+	store := newMockSystemInfoStore()
+	store.err = errors.New("write failed")
+	gs := settings.NewGameSettings(store)
+
+	err := gs.SetString(ctx, "scenes.focus.replay_tail_default", "5")
+	assert.Error(t, err)
+}
+
+func TestGameSettingsImplementsGameSettingsInterface(t *testing.T) {
+	var _ settings.GameSettings = settings.NewGameSettings(newMockSystemInfoStore())
+}

--- a/internal/settings/game_test.go
+++ b/internal/settings/game_test.go
@@ -184,6 +184,6 @@ func TestGameSettingsSetStringReturnsStoreError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestGameSettingsImplementsGameSettingsInterface(t *testing.T) {
-	var _ settings.GameSettings = settings.NewGameSettings(newMockSystemInfoStore())
+func TestGameSettingsImplementsGameSettingsInterface(_ *testing.T) {
+	var _ settings.GameSettings = settings.NewGameSettings(newMockSystemInfoStore()) //nolint:staticcheck // intentional interface check
 }

--- a/internal/settings/namespaces.go
+++ b/internal/settings/namespaces.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RegisteredNamespaces lists the known top-level namespaces. Keys not
+// beginning with one of these (followed by '.') are rejected by
+// SetString. This list grows additively; removing a namespace is a
+// breaking change and requires migration of any stored keys.
+var RegisteredNamespaces = []string{
+	"core",
+	"scenes",
+	"channels",
+	"auth",
+}
+
+// ValidateNamespace checks that key is dot-namespaced and begins with a
+// registered top-level namespace.
+func ValidateNamespace(key string) error {
+	if key == "" {
+		return fmt.Errorf("settings key must not be empty")
+	}
+	dot := strings.IndexByte(key, '.')
+	if dot < 0 {
+		return fmt.Errorf("settings key %q must be dot-namespaced (e.g. 'scenes.focus.replay_tail_default')", key)
+	}
+	ns := key[:dot]
+	for _, registered := range RegisteredNamespaces {
+		if ns == registered {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown namespace %q in key %q; registered: %v", ns, key, RegisteredNamespaces)
+}

--- a/internal/settings/namespaces_test.go
+++ b/internal/settings/namespaces_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/settings"
+)
+
+func TestValidateNamespaceAcceptsRegisteredNamespace(t *testing.T) {
+	assert.NoError(t, settings.ValidateNamespace("scenes.focus.replay_tail_default"))
+}
+
+func TestValidateNamespaceAcceptsCoreNamespace(t *testing.T) {
+	assert.NoError(t, settings.ValidateNamespace("core.server_name"))
+}
+
+func TestValidateNamespaceAcceptsChannelsNamespace(t *testing.T) {
+	assert.NoError(t, settings.ValidateNamespace("channels.max_per_player"))
+}
+
+func TestValidateNamespaceAcceptsAuthNamespace(t *testing.T) {
+	assert.NoError(t, settings.ValidateNamespace("auth.session_timeout"))
+}
+
+func TestValidateNamespaceRejectsUnknownNamespace(t *testing.T) {
+	err := settings.ValidateNamespace("unknown.some_key")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown namespace")
+}
+
+func TestValidateNamespaceRejectsKeyWithoutDot(t *testing.T) {
+	err := settings.ValidateNamespace("nodot")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be dot-namespaced")
+}
+
+func TestValidateNamespaceRejectsEmptyKey(t *testing.T) {
+	err := settings.ValidateNamespace("")
+	assert.Error(t, err)
+}
+
+func TestRegisteredNamespacesContainsExpectedEntries(t *testing.T) {
+	expected := []string{"core", "scenes", "channels", "auth"}
+	assert.Equal(t, expected, settings.RegisteredNamespaces)
+}

--- a/internal/settings/namespaces_test.go
+++ b/internal/settings/namespaces_test.go
@@ -46,5 +46,7 @@ func TestValidateNamespaceRejectsEmptyKey(t *testing.T) {
 
 func TestRegisteredNamespacesContainsExpectedEntries(t *testing.T) {
 	expected := []string{"core", "scenes", "channels", "auth"}
-	assert.Equal(t, expected, settings.RegisteredNamespaces)
+	for _, ns := range expected {
+		assert.Contains(t, settings.RegisteredNamespaces, ns, "missing expected namespace %q", ns)
+	}
 }

--- a/internal/settings/player.go
+++ b/internal/settings/player.go
@@ -63,7 +63,10 @@ func (s *playerSettingsStore) SetString(
 	if err := ValidateNamespace(key); err != nil {
 		return oops.With("key", key).Wrap(err)
 	}
-	return s.reader.SetPlayerPreferenceKey(ctx, playerID, key, value)
+	if err := s.reader.SetPlayerPreferenceKey(ctx, playerID, key, value); err != nil {
+		return oops.With("key", key).With("player_id", playerID.String()).Wrap(err)
+	}
+	return nil
 }
 
 // jsonMapSettings implements Settings backed by a flat JSON map. Values may
@@ -110,7 +113,7 @@ func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
 	return v, true
 }
 
-func (j *jsonMapSettings) BoolN(ctx context.Context, key string) (bool, bool) {
+func (j *jsonMapSettings) BoolN(ctx context.Context, key string) (value, ok bool) {
 	raw, ok := j.data[key]
 	if !ok {
 		return false, false
@@ -149,7 +152,7 @@ type emptySettings struct{}
 
 func (e *emptySettings) StringN(context.Context, string) (string, bool)           { return "", false }
 func (e *emptySettings) IntN(context.Context, string) (int, bool)                 { return 0, false }
-func (e *emptySettings) BoolN(context.Context, string) (bool, bool)               { return false, false }
+func (e *emptySettings) BoolN(context.Context, string) (value, ok bool)           { return false, false }
 func (e *emptySettings) DurationN(context.Context, string) (time.Duration, bool)  { return 0, false }
 
 // Compile-time interface checks.

--- a/internal/settings/player.go
+++ b/internal/settings/player.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+)
+
+// PlayerPrefsReader is the narrow interface for reading and writing player
+// preferences as raw JSON. Satisfied by a thin adapter around
+// auth.PlayerRepository.
+type PlayerPrefsReader interface {
+	GetPlayerPreferencesJSON(ctx context.Context, playerID ulid.ULID) (json.RawMessage, error)
+	SetPlayerPreferenceKey(ctx context.Context, playerID ulid.ULID, key, value string) error
+}
+
+// playerSettingsStore implements PlayerSettingsStore.
+type playerSettingsStore struct {
+	reader PlayerPrefsReader
+}
+
+// NewPlayerSettingsStore creates a PlayerSettingsStore backed by a
+// PlayerPrefsReader.
+func NewPlayerSettingsStore(reader PlayerPrefsReader) PlayerSettingsStore {
+	return &playerSettingsStore{reader: reader}
+}
+
+// For returns a read-only Settings view for a specific player. The
+// returned Settings reads the player's preferences JSONB as a flat
+// dot-keyed map (keys like "scenes.focus.replay_tail_default").
+func (s *playerSettingsStore) For(ctx context.Context, playerID ulid.ULID) Settings {
+	raw, err := s.reader.GetPlayerPreferencesJSON(ctx, playerID)
+	if err != nil {
+		slog.DebugContext(ctx, "player settings read failed",
+			"player_id", playerID.String(), "error", err)
+		return &emptySettings{}
+	}
+	if raw == nil {
+		return &emptySettings{}
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &data); err != nil {
+		slog.DebugContext(ctx, "player settings JSON unmarshal failed",
+			"player_id", playerID.String(), "error", err)
+		return &emptySettings{}
+	}
+	return &jsonMapSettings{data: data}
+}
+
+// SetString writes a single preference key for a player.
+func (s *playerSettingsStore) SetString(
+	ctx context.Context, playerID ulid.ULID, key, value string,
+) error {
+	if err := ValidateNamespace(key); err != nil {
+		return oops.With("key", key).Wrap(err)
+	}
+	return s.reader.SetPlayerPreferenceKey(ctx, playerID, key, value)
+}
+
+// jsonMapSettings implements Settings backed by a flat JSON map. Values may
+// be JSON strings, numbers, or bools. String accessor returns the raw
+// JSON-decoded string; int/bool/duration parse from the string
+// representation.
+type jsonMapSettings struct {
+	data map[string]json.RawMessage
+}
+
+func (j *jsonMapSettings) StringN(_ context.Context, key string) (string, bool) {
+	raw, ok := j.data[key]
+	if !ok {
+		return "", false
+	}
+	// Try to unmarshal as a JSON string first.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	// Fall back to raw string (for numeric/bool JSON values).
+	return string(raw), true
+}
+
+func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
+	raw, ok := j.data[key]
+	if !ok {
+		return 0, false
+	}
+	// Try native JSON number first.
+	var n float64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return int(n), true
+	}
+	// Fall back to string parse.
+	s, ok := j.StringN(ctx, key)
+	if !ok {
+		return 0, false
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func (j *jsonMapSettings) BoolN(ctx context.Context, key string) (bool, bool) {
+	raw, ok := j.data[key]
+	if !ok {
+		return false, false
+	}
+	// Try native JSON bool first.
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b, true
+	}
+	// Fall back to string parse.
+	s, ok := j.StringN(ctx, key)
+	if !ok {
+		return false, false
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, false
+	}
+	return v, true
+}
+
+func (j *jsonMapSettings) DurationN(ctx context.Context, key string) (time.Duration, bool) {
+	s, ok := j.StringN(ctx, key)
+	if !ok {
+		return 0, false
+	}
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// emptySettings always returns (zero, false) for all reads.
+type emptySettings struct{}
+
+func (e *emptySettings) StringN(context.Context, string) (string, bool)           { return "", false }
+func (e *emptySettings) IntN(context.Context, string) (int, bool)                 { return 0, false }
+func (e *emptySettings) BoolN(context.Context, string) (bool, bool)               { return false, false }
+func (e *emptySettings) DurationN(context.Context, string) (time.Duration, bool)  { return 0, false }
+
+// Compile-time interface checks.
+var (
+	_ Settings = (*jsonMapSettings)(nil)
+	_ Settings = (*emptySettings)(nil)
+)

--- a/internal/settings/player.go
+++ b/internal/settings/player.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"strconv"
 	"time"
 
@@ -22,21 +23,21 @@ type PlayerPrefsReader interface {
 	SetPlayerPreferenceKey(ctx context.Context, playerID ulid.ULID, key, value string) error
 }
 
-// playerSettingsStore implements PlayerSettingsStore.
-type playerSettingsStore struct {
+// PlayerSettings implements PlayerSettingsStore.
+type PlayerSettings struct {
 	reader PlayerPrefsReader
 }
 
 // NewPlayerSettingsStore creates a PlayerSettingsStore backed by a
 // PlayerPrefsReader.
-func NewPlayerSettingsStore(reader PlayerPrefsReader) PlayerSettingsStore {
-	return &playerSettingsStore{reader: reader}
+func NewPlayerSettingsStore(reader PlayerPrefsReader) *PlayerSettings {
+	return &PlayerSettings{reader: reader}
 }
 
 // For returns a read-only Settings view for a specific player. The
 // returned Settings reads the player's preferences JSONB as a flat
 // dot-keyed map (keys like "scenes.focus.replay_tail_default").
-func (s *playerSettingsStore) For(ctx context.Context, playerID ulid.ULID) Settings {
+func (s *PlayerSettings) For(ctx context.Context, playerID ulid.ULID) Settings {
 	raw, err := s.reader.GetPlayerPreferencesJSON(ctx, playerID)
 	if err != nil {
 		slog.DebugContext(ctx, "player settings read failed",
@@ -57,7 +58,7 @@ func (s *playerSettingsStore) For(ctx context.Context, playerID ulid.ULID) Setti
 }
 
 // SetString writes a single preference key for a player.
-func (s *playerSettingsStore) SetString(
+func (s *PlayerSettings) SetString(
 	ctx context.Context, playerID ulid.ULID, key, value string,
 ) error {
 	if err := ValidateNamespace(key); err != nil {
@@ -77,7 +78,11 @@ type jsonMapSettings struct {
 	data map[string]json.RawMessage
 }
 
-func (j *jsonMapSettings) StringN(_ context.Context, key string) (string, bool) {
+func (j *jsonMapSettings) StringN(ctx context.Context, key string) (string, bool) {
+	if err := ValidateNamespace(key); err != nil {
+		slog.DebugContext(ctx, "settings read: invalid namespace", "key", key, "error", err)
+		return "", false
+	}
 	raw, ok := j.data[key]
 	if !ok {
 		return "", false
@@ -92,6 +97,10 @@ func (j *jsonMapSettings) StringN(_ context.Context, key string) (string, bool) 
 }
 
 func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
+	if err := ValidateNamespace(key); err != nil {
+		slog.DebugContext(ctx, "settings read: invalid namespace", "key", key, "error", err)
+		return 0, false
+	}
 	raw, ok := j.data[key]
 	if !ok {
 		return 0, false
@@ -99,6 +108,9 @@ func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
 	// Try native JSON number first.
 	var n float64
 	if err := json.Unmarshal(raw, &n); err == nil {
+		if math.Floor(n) != n {
+			return 0, false
+		}
 		return int(n), true
 	}
 	// Fall back to string parse.
@@ -114,6 +126,10 @@ func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
 }
 
 func (j *jsonMapSettings) BoolN(ctx context.Context, key string) (value, ok bool) {
+	if err := ValidateNamespace(key); err != nil {
+		slog.DebugContext(ctx, "settings read: invalid namespace", "key", key, "error", err)
+		return false, false
+	}
 	raw, ok := j.data[key]
 	if !ok {
 		return false, false
@@ -136,6 +152,7 @@ func (j *jsonMapSettings) BoolN(ctx context.Context, key string) (value, ok bool
 }
 
 func (j *jsonMapSettings) DurationN(ctx context.Context, key string) (time.Duration, bool) {
+	// Namespace validation happens inside StringN; no need to duplicate here.
 	s, ok := j.StringN(ctx, key)
 	if !ok {
 		return 0, false

--- a/internal/settings/player.go
+++ b/internal/settings/player.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"math"
+
 	"strconv"
 	"time"
 
@@ -106,9 +106,10 @@ func (j *jsonMapSettings) IntN(ctx context.Context, key string) (int, bool) {
 		return 0, false
 	}
 	// Try native JSON number first.
-	var n float64
-	if err := json.Unmarshal(raw, &n); err == nil {
-		if math.Floor(n) != n {
+	var num json.Number
+	if err := json.Unmarshal(raw, &num); err == nil {
+		n, err := num.Int64()
+		if err != nil {
 			return 0, false
 		}
 		return int(n), true

--- a/internal/settings/player_test.go
+++ b/internal/settings/player_test.go
@@ -157,6 +157,12 @@ func TestPlayerSettingsSetStringPersistsValidKey(t *testing.T) {
 
 	err := store.SetString(ctx, pid, "scenes.focus.replay_tail_default", "8")
 	assert.NoError(t, err)
+
+	// Read the value back and assert it was persisted.
+	s := store.For(ctx, pid)
+	val, ok := s.StringN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok, "value should be readable after SetString")
+	assert.Equal(t, "8", val)
 }
 
 func TestPlayerSettingsSetStringRejectsInvalidNamespace(t *testing.T) {

--- a/internal/settings/player_test.go
+++ b/internal/settings/player_test.go
@@ -169,6 +169,6 @@ func TestPlayerSettingsSetStringRejectsInvalidNamespace(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown namespace")
 }
 
-func TestPlayerSettingsStoreImplementsInterface(t *testing.T) {
-	var _ settings.PlayerSettingsStore = settings.NewPlayerSettingsStore(newMockPlayerPrefsReader())
+func TestPlayerSettingsStoreImplementsInterface(_ *testing.T) {
+	var _ settings.PlayerSettingsStore = settings.NewPlayerSettingsStore(newMockPlayerPrefsReader()) //nolint:staticcheck // intentional interface check
 }

--- a/internal/settings/player_test.go
+++ b/internal/settings/player_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -167,6 +168,134 @@ func TestPlayerSettingsSetStringRejectsInvalidNamespace(t *testing.T) {
 	err := store.SetString(ctx, pid, "bogus.key", "val")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown namespace")
+}
+
+func TestPlayerSettingsForReturnsEmptyOnJSONUnmarshalFailure(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`not valid json`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsSetStringReturnsStoreWriteError(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	store := settings.NewPlayerSettingsStore(reader)
+	pid := ulid.Make()
+
+	// First set succeeds (no error configured).
+	err := store.SetString(ctx, pid, "scenes.focus.mode", "bounded")
+	assert.NoError(t, err)
+
+	// Now configure a write error.
+	reader.err = errors.New("disk full")
+	err = store.SetString(ctx, pid, "scenes.focus.mode", "bounded")
+	assert.Error(t, err)
+}
+
+func TestPlayerSettingsStringNFallsBackToRawForNonStringJSON(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	// Store a raw numeric value — json.Unmarshal into string will fail,
+	// triggering the fallback to string(raw).
+	reader.prefs[pid] = json.RawMessage(`{"count":42}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.StringN(ctx, "count")
+	assert.True(t, ok)
+	assert.Equal(t, "42", v)
+}
+
+func TestPlayerSettingsIntNReturnsFalseForMissingKey(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"other.key":"hello"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.IntN(ctx, "scenes.focus.count")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsIntNReturnsFalseForUnparseableString(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"scenes.focus.count":"not-a-number"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.IntN(ctx, "scenes.focus.count")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsBoolNReturnsFalseForMissingKey(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"other.key":"hello"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.BoolN(ctx, "auth.auto_login")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsBoolNReturnsFalseForUnparseableString(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"auth.auto_login":"maybe"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.BoolN(ctx, "auth.auto_login")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsDurationNParsesStoredValue(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"core.session_timeout":"30s"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.DurationN(ctx, "core.session_timeout")
+	assert.True(t, ok)
+	assert.Equal(t, 30*time.Second, v)
+}
+
+func TestPlayerSettingsDurationNReturnsFalseForMissingKey(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"other.key":"hello"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsDurationNReturnsFalseForInvalidDuration(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"core.session_timeout":"not-a-duration"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.DurationN(ctx, "core.session_timeout")
+	assert.False(t, ok)
 }
 
 func TestPlayerSettingsStoreImplementsInterface(_ *testing.T) {

--- a/internal/settings/player_test.go
+++ b/internal/settings/player_test.go
@@ -60,7 +60,7 @@ func (m *mockPlayerPrefsReader) SetPlayerPreferenceKey(
 	return nil
 }
 
-func TestPlayerSettingsForReturnsNilWhenNoPreferences(t *testing.T) {
+func TestPlayerSettingsStringNReturnsFalseWhenNoPreferencesExist(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	store := settings.NewPlayerSettingsStore(reader)
@@ -71,7 +71,7 @@ func TestPlayerSettingsForReturnsNilWhenNoPreferences(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPlayerSettingsForReadsNestedDotKey(t *testing.T) {
+func TestPlayerSettingsStringNReturnsDotKeyedValue(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -85,7 +85,7 @@ func TestPlayerSettingsForReadsNestedDotKey(t *testing.T) {
 	assert.Equal(t, "7", v)
 }
 
-func TestPlayerSettingsIntNParsesStoredString(t *testing.T) {
+func TestPlayerSettingsIntNParsesStringValueAsInteger(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -98,7 +98,7 @@ func TestPlayerSettingsIntNParsesStoredString(t *testing.T) {
 	assert.Equal(t, 5, v)
 }
 
-func TestPlayerSettingsIntNHandlesNumericJSON(t *testing.T) {
+func TestPlayerSettingsIntNReturnsNativeJSONNumber(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -111,7 +111,7 @@ func TestPlayerSettingsIntNHandlesNumericJSON(t *testing.T) {
 	assert.Equal(t, 5, v)
 }
 
-func TestPlayerSettingsBoolNParsesStoredValue(t *testing.T) {
+func TestPlayerSettingsBoolNParsesStringTrueValue(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -124,7 +124,7 @@ func TestPlayerSettingsBoolNParsesStoredValue(t *testing.T) {
 	assert.True(t, v)
 }
 
-func TestPlayerSettingsBoolNHandsNativeBoolJSON(t *testing.T) {
+func TestPlayerSettingsBoolNReturnsNativeJSONBool(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -137,7 +137,7 @@ func TestPlayerSettingsBoolNHandsNativeBoolJSON(t *testing.T) {
 	assert.True(t, v)
 }
 
-func TestPlayerSettingsForReturnsFalseOnReadError(t *testing.T) {
+func TestPlayerSettingsStringNReturnsFalseOnDatabaseReadError(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	reader.err = errors.New("db down")
@@ -149,7 +149,7 @@ func TestPlayerSettingsForReturnsFalseOnReadError(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPlayerSettingsSetStringWritesKey(t *testing.T) {
+func TestPlayerSettingsSetStringPersistsValidKey(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	store := settings.NewPlayerSettingsStore(reader)
@@ -170,7 +170,7 @@ func TestPlayerSettingsSetStringRejectsInvalidNamespace(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown namespace")
 }
 
-func TestPlayerSettingsForReturnsEmptyOnJSONUnmarshalFailure(t *testing.T) {
+func TestPlayerSettingsStringNReturnsFalseOnInvalidJSON(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -182,7 +182,7 @@ func TestPlayerSettingsForReturnsEmptyOnJSONUnmarshalFailure(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPlayerSettingsSetStringReturnsStoreWriteError(t *testing.T) {
+func TestPlayerSettingsSetStringReturnsErrorOnWriteFailure(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	store := settings.NewPlayerSettingsStore(reader)
@@ -198,17 +198,17 @@ func TestPlayerSettingsSetStringReturnsStoreWriteError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestPlayerSettingsStringNFallsBackToRawForNonStringJSON(t *testing.T) {
+func TestPlayerSettingsStringNReturnsRawJSONWhenValueIsNotString(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
 	// Store a raw numeric value — json.Unmarshal into string will fail,
 	// triggering the fallback to string(raw).
-	reader.prefs[pid] = json.RawMessage(`{"count":42}`)
+	reader.prefs[pid] = json.RawMessage(`{"core.count":42}`)
 	store := settings.NewPlayerSettingsStore(reader)
 
 	s := store.For(ctx, pid)
-	v, ok := s.StringN(ctx, "count")
+	v, ok := s.StringN(ctx, "core.count")
 	assert.True(t, ok)
 	assert.Equal(t, "42", v)
 }
@@ -261,7 +261,7 @@ func TestPlayerSettingsBoolNReturnsFalseForUnparseableString(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPlayerSettingsDurationNParsesStoredValue(t *testing.T) {
+func TestPlayerSettingsDurationNParsesValidDurationString(t *testing.T) {
 	ctx := context.Background()
 	reader := newMockPlayerPrefsReader()
 	pid := ulid.Make()
@@ -298,6 +298,30 @@ func TestPlayerSettingsDurationNReturnsFalseForInvalidDuration(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPlayerSettingsStoreImplementsInterface(_ *testing.T) {
-	var _ settings.PlayerSettingsStore = settings.NewPlayerSettingsStore(newMockPlayerPrefsReader()) //nolint:staticcheck // intentional interface check
+func TestPlayerSettingsStringNReturnsFalseForUnknownNamespace(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"bogus.key":"value"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.StringN(ctx, "bogus.key")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsIntNReturnsFalseForFractionalJSONNumber(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"scenes.focus.count":3.7}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	_, ok := s.IntN(ctx, "scenes.focus.count")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsStoreConcreteTypeSatisfiesInterface(_ *testing.T) {
+	var _ settings.PlayerSettingsStore = settings.NewPlayerSettingsStore(newMockPlayerPrefsReader())
 }

--- a/internal/settings/player_test.go
+++ b/internal/settings/player_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/settings"
+)
+
+// mockPlayerPrefsReader implements settings.PlayerPrefsReader for testing.
+type mockPlayerPrefsReader struct {
+	prefs map[ulid.ULID]json.RawMessage
+	err   error
+}
+
+func newMockPlayerPrefsReader() *mockPlayerPrefsReader {
+	return &mockPlayerPrefsReader{prefs: make(map[ulid.ULID]json.RawMessage)}
+}
+
+func (m *mockPlayerPrefsReader) GetPlayerPreferencesJSON(
+	_ context.Context, playerID ulid.ULID,
+) (json.RawMessage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	v, ok := m.prefs[playerID]
+	if !ok {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (m *mockPlayerPrefsReader) SetPlayerPreferenceKey(
+	_ context.Context, playerID ulid.ULID, key, value string,
+) error {
+	if m.err != nil {
+		return m.err
+	}
+	// Read existing prefs, update key, write back.
+	raw := m.prefs[playerID]
+	var data map[string]any
+	if raw != nil {
+		_ = json.Unmarshal(raw, &data)
+	}
+	if data == nil {
+		data = make(map[string]any)
+	}
+	data[key] = value
+	b, _ := json.Marshal(data)
+	m.prefs[playerID] = b
+	return nil
+}
+
+func TestPlayerSettingsForReturnsNilWhenNoPreferences(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	store := settings.NewPlayerSettingsStore(reader)
+	pid := ulid.Make()
+
+	s := store.For(ctx, pid)
+	_, ok := s.StringN(ctx, "scenes.focus.replay_tail_default")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsForReadsNestedDotKey(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	// Store nested JSON matching dot-path "scenes.focus_replay_tail"
+	reader.prefs[pid] = json.RawMessage(`{"scenes.focus.replay_tail_default":"7"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.StringN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, "7", v)
+}
+
+func TestPlayerSettingsIntNParsesStoredString(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"scenes.focus.replay_tail_default":"5"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 5, v)
+}
+
+func TestPlayerSettingsIntNHandlesNumericJSON(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"scenes.focus.replay_tail_default":5}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.IntN(ctx, "scenes.focus.replay_tail_default")
+	assert.True(t, ok)
+	assert.Equal(t, 5, v)
+}
+
+func TestPlayerSettingsBoolNParsesStoredValue(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"auth.auto_login":"true"}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.BoolN(ctx, "auth.auto_login")
+	assert.True(t, ok)
+	assert.True(t, v)
+}
+
+func TestPlayerSettingsBoolNHandsNativeBoolJSON(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	pid := ulid.Make()
+	reader.prefs[pid] = json.RawMessage(`{"auth.auto_login":true}`)
+	store := settings.NewPlayerSettingsStore(reader)
+
+	s := store.For(ctx, pid)
+	v, ok := s.BoolN(ctx, "auth.auto_login")
+	assert.True(t, ok)
+	assert.True(t, v)
+}
+
+func TestPlayerSettingsForReturnsFalseOnReadError(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	reader.err = errors.New("db down")
+	store := settings.NewPlayerSettingsStore(reader)
+	pid := ulid.Make()
+
+	s := store.For(ctx, pid)
+	_, ok := s.StringN(ctx, "scenes.focus.mode")
+	assert.False(t, ok)
+}
+
+func TestPlayerSettingsSetStringWritesKey(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	store := settings.NewPlayerSettingsStore(reader)
+	pid := ulid.Make()
+
+	err := store.SetString(ctx, pid, "scenes.focus.replay_tail_default", "8")
+	assert.NoError(t, err)
+}
+
+func TestPlayerSettingsSetStringRejectsInvalidNamespace(t *testing.T) {
+	ctx := context.Background()
+	reader := newMockPlayerPrefsReader()
+	store := settings.NewPlayerSettingsStore(reader)
+	pid := ulid.Make()
+
+	err := store.SetString(ctx, pid, "bogus.key", "val")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown namespace")
+}
+
+func TestPlayerSettingsStoreImplementsInterface(t *testing.T) {
+	var _ settings.PlayerSettingsStore = settings.NewPlayerSettingsStore(newMockPlayerPrefsReader())
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package settings provides typed namespaced configuration reads with
+// scope chaining. The same key may be set at game (server-wide), player,
+// or character scope; resolution order is most-specific to least-specific,
+// with first-match-wins and a substrate fallback.
+//
+// Scope storage backing:
+//   - Game:      holomush_system_info table (key/value)
+//   - Player:    players.preferences JSONB column
+//   - Character: characters.preferences JSONB column (future; null impl in Phase 4)
+package settings
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Settings is the read-only typed namespaced accessor shared by every
+// scope. Each scope-specific store produces a Settings instance for a
+// specific principal (a player ID, a character ID, or the singleton game
+// instance) and that instance is used identically by callers.
+//
+// All read methods return (zero, false) for unset keys and never return
+// errors. Infrastructure failures are logged and surfaced as "unset."
+// Callers using the resolution Chain rely on this contract to avoid
+// double error-handling at every scope level.
+//
+// Keys MUST be dot-namespaced and MUST begin with a registered top-level
+// namespace (see RegisteredNamespaces). Unknown namespaces on reads return
+// (zero, false) with a debug-level warning; writes return an error.
+type Settings interface {
+	StringN(ctx context.Context, key string) (string, bool)
+	IntN(ctx context.Context, key string) (int, bool)
+	BoolN(ctx context.Context, key string) (bool, bool)
+	DurationN(ctx context.Context, key string) (time.Duration, bool)
+}
+
+// GameSettings is the server-wide scope backed by holomush_system_info.
+// Exactly one GameSettings instance per server. Writes are supported for
+// operator tooling.
+type GameSettings interface {
+	Settings
+	SetString(ctx context.Context, key, value string) error
+}
+
+// PlayerSettingsStore is the factory for per-player Settings instances.
+// Call For(playerID) to obtain the read view for a specific player,
+// backed by their row in players.preferences.
+type PlayerSettingsStore interface {
+	For(ctx context.Context, playerID ulid.ULID) Settings
+	SetString(ctx context.Context, playerID ulid.ULID, key, value string) error
+}
+
+// CharacterSettingsStore is the factory for per-character Settings. Phase 4
+// ships this interface with a null implementation (always-unset) because
+// no character.preferences schema exists yet.
+type CharacterSettingsStore interface {
+	For(ctx context.Context, characterID ulid.ULID) Settings
+	SetString(ctx context.Context, characterID ulid.ULID, key, value string) error
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -43,6 +43,7 @@ type migrateIface interface {
 	Up() error
 	Down() error
 	Steps(n int) error
+	Migrate(version uint) error
 	Version() (version uint, dirty bool, err error)
 	Force(version int) error
 	Close() (source error, database error)
@@ -106,6 +107,17 @@ func (m *Migrator) Down() error {
 func (m *Migrator) Steps(n int) error {
 	if err := m.m.Steps(n); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return oops.Code("MIGRATION_STEPS_FAILED").With("steps", n).Wrap(err)
+	}
+	return nil
+}
+
+// Migrate migrates to the specified version. If the current version is
+// higher, it runs down migrations; if lower, up migrations. This is more
+// stable than Steps(-N) for targeting a specific schema state because it
+// does not depend on knowing how many migrations exist above the target.
+func (m *Migrator) Migrate(version uint) error {
+	if err := m.m.Migrate(version); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return oops.Code("MIGRATION_MIGRATE_FAILED").With("target_version", version).Wrap(err)
 	}
 	return nil
 }

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -140,7 +140,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(6), version)
+	assert.Equal(t, uint(7), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -165,7 +165,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(6), version)
+	assert.Equal(t, uint(7), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -263,17 +263,12 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-7 should be pending (baseline + is_guest +
-	// alias_source + session_player_id + audit_source_component + session_focus + seed_scene_defaults)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 7 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)
@@ -304,11 +299,8 @@ func TestMigratorAppliedMigrationsReturnsEmptyAtVersionZero(t *testing.T) {
 }
 
 func TestMigratorAppliedMigrationsReturnsAllAtLatestVersion(t *testing.T) {
-	// At version 7 (latest), all migrations applied
-	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	applied, err := m.AppliedMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, applied)
 }
 
 func TestMigratorAppliedMigrationsReturnsErrorWhenVersionFails(t *testing.T) {

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -59,6 +59,7 @@ type mockMigrate struct {
 	upErr          error
 	downErr        error
 	stepsErr       error
+	migrateErr     error
 	versionVal     uint
 	versionErr     error
 	dirty          bool
@@ -70,7 +71,7 @@ type mockMigrate struct {
 func (m *mockMigrate) Up() error                    { return m.upErr }
 func (m *mockMigrate) Down() error                  { return m.downErr }
 func (m *mockMigrate) Steps(_ int) error            { return m.stepsErr }
-func (m *mockMigrate) Migrate(_ uint) error         { return nil }
+func (m *mockMigrate) Migrate(_ uint) error         { return m.migrateErr }
 func (m *mockMigrate) Version() (uint, bool, error) { return m.versionVal, m.dirty, m.versionErr }
 func (m *mockMigrate) Force(_ int) error            { return m.forceErr }
 func (m *mockMigrate) Close() (error, error)        { return m.closeSourceErr, m.closeDbErr }
@@ -111,6 +112,19 @@ func TestMigratorDownReturnsWrappedErrorOnFailure(t *testing.T) {
 	err := m.Down()
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "MIGRATION_DOWN_FAILED")
+}
+
+func TestMigratorMigrateSucceedsWhenUnderlyingReturnsNil(t *testing.T) {
+	m := &Migrator{m: &mockMigrate{}}
+	err := m.Migrate(5)
+	require.NoError(t, err)
+}
+
+func TestMigratorMigrateReturnsErrorWhenUnderlyingFails(t *testing.T) {
+	m := &Migrator{m: &mockMigrate{migrateErr: errors.New("target version not found")}}
+	err := m.Migrate(99)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "MIGRATION_MIGRATE_FAILED")
 }
 
 func TestMigratorStepsAppliesNMigrations(t *testing.T) {

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -70,6 +70,7 @@ type mockMigrate struct {
 func (m *mockMigrate) Up() error                    { return m.upErr }
 func (m *mockMigrate) Down() error                  { return m.downErr }
 func (m *mockMigrate) Steps(_ int) error            { return m.stepsErr }
+func (m *mockMigrate) Migrate(_ uint) error         { return nil }
 func (m *mockMigrate) Version() (uint, bool, error) { return m.versionVal, m.dirty, m.versionErr }
 func (m *mockMigrate) Force(_ int) error            { return m.forceErr }
 func (m *mockMigrate) Close() (error, error)        { return m.closeSourceErr, m.closeDbErr }
@@ -355,6 +356,12 @@ func (m *closedMock) Version() (uint, bool, error) {
 	return 1, false, nil
 }
 
+func (m *closedMock) Migrate(_ uint) error {
+	if m.closed {
+		return errMigratorClosed
+	}
+	return nil
+}
 func (m *closedMock) Force(_ int) error {
 	if m.closed {
 		return errMigratorClosed

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -263,17 +263,17 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-6 should be pending (baseline + is_guest +
-	// alias_source + session_player_id + audit_source_component + session_focus)
+	// At version 0, migrations 1-7 should be pending (baseline + is_guest +
+	// alias_source + session_player_id + audit_source_component + session_focus + seed_scene_defaults)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 6 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 6}}
+	// At version 7 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)
@@ -304,11 +304,11 @@ func TestMigratorAppliedMigrationsReturnsEmptyAtVersionZero(t *testing.T) {
 }
 
 func TestMigratorAppliedMigrationsReturnsAllAtLatestVersion(t *testing.T) {
-	// At version 6 (latest), all migrations applied
-	m := &Migrator{m: &mockMigrate{versionVal: 6}}
+	// At version 7 (latest), all migrations applied
+	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	applied, err := m.AppliedMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6}, applied)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, applied)
 }
 
 func TestMigratorAppliedMigrationsReturnsErrorWhenVersionFails(t *testing.T) {
@@ -449,7 +449,7 @@ func TestMigrationName(t *testing.T) {
 		{3, "000003_alias_source", false},
 		{4, "000004_session_player_id", false},
 		{5, "000005_audit_source_component", false},
-		{7, "", false},   // No migration 7 after collapse
+		{7, "000007_seed_scene_defaults", false},
 		{999, "", false}, // Unknown version returns empty string and nil error (not found is expected)
 	}
 

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -263,12 +263,17 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
+	// At version 0, migrations 1-7 should be pending (baseline + is_guest +
+	// alias_source + session_player_id + audit_source_component + session_focus + seed_scene_defaults)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
+	// At version 7 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)
@@ -299,8 +304,11 @@ func TestMigratorAppliedMigrationsReturnsEmptyAtVersionZero(t *testing.T) {
 }
 
 func TestMigratorAppliedMigrationsReturnsAllAtLatestVersion(t *testing.T) {
+	// At version 7 (latest), all migrations applied
+	m := &Migrator{m: &mockMigrate{versionVal: 7}}
 	applied, err := m.AppliedMigrations()
 	require.NoError(t, err)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7}, applied)
 }
 
 func TestMigratorAppliedMigrationsReturnsErrorWhenVersionFails(t *testing.T) {

--- a/internal/store/migrations/000007_seed_scene_defaults.down.sql
+++ b/internal/store/migrations/000007_seed_scene_defaults.down.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Remove the seeded scene default. Only deletes the row if the value is
+-- still the default '3'; operator-customized values are preserved.
+
+DELETE FROM holomush_system_info
+WHERE key = 'scenes.focus.replay_tail_default'
+  AND value = '3';

--- a/internal/store/migrations/000007_seed_scene_defaults.up.sql
+++ b/internal/store/migrations/000007_seed_scene_defaults.up.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Seed the default scene focus replay tail count in holomush_system_info.
+-- ON CONFLICT DO NOTHING preserves operator overrides on re-application.
+
+INSERT INTO holomush_system_info (key, value)
+VALUES ('scenes.focus.replay_tail_default', '3')
+ON CONFLICT (key) DO NOTHING;

--- a/internal/store/migrations_audit_shape_integration_test.go
+++ b/internal/store/migrations_audit_shape_integration_test.go
@@ -86,7 +86,14 @@ func TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	// Sanity: after Up, the new shape is present.
+	// Sanity: after Up, 000005 is applied and the new shape is present.
+	migratorCheck, err := store.NewMigrator(pgEnv.ConnStr)
+	require.NoError(t, err)
+	version, dirty, err := migratorCheck.Version()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, version, uint(5), "000005 must be applied before testing rollback")
+	assert.False(t, dirty)
+	require.NoError(t, migratorCheck.Close())
 	assertColumnExists(t, db, "access_audit_log", "event_id")
 	assertColumnExists(t, db, "access_audit_log", "source")
 

--- a/internal/store/migrations_audit_shape_integration_test.go
+++ b/internal/store/migrations_audit_shape_integration_test.go
@@ -90,11 +90,11 @@ func TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape
 	assertColumnExists(t, db, "access_audit_log", "event_id")
 	assertColumnExists(t, db, "access_audit_log", "source")
 
-	// Roll back 000006 (session focus) then 000005 (audit source component)
-	// to restore the pre-000005 audit schema shape.
+	// Roll back 000007 (seed scene defaults), 000006 (session focus), then
+	// 000005 (audit source component) to restore the pre-000005 audit schema shape.
 	migratorDown, err := store.NewMigrator(pgEnv.ConnStr)
 	require.NoError(t, err)
-	require.NoError(t, migratorDown.Steps(-2))
+	require.NoError(t, migratorDown.Steps(-3))
 	require.NoError(t, migratorDown.Close())
 
 	// After down, the original shape is restored.

--- a/internal/store/migrations_audit_shape_integration_test.go
+++ b/internal/store/migrations_audit_shape_integration_test.go
@@ -90,11 +90,12 @@ func TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape
 	assertColumnExists(t, db, "access_audit_log", "event_id")
 	assertColumnExists(t, db, "access_audit_log", "source")
 
-	// Roll back 000007 (seed scene defaults), 000006 (session focus), then
-	// 000005 (audit source component) to restore the pre-000005 audit schema shape.
+	// Migrate down to version 4 (just before 000005_audit_source_component)
+	// to restore the pre-000005 audit schema shape. Using Migrate(4) instead
+	// of Steps(-N) so the test doesn't break when new migrations are added.
 	migratorDown, err := store.NewMigrator(pgEnv.ConnStr)
 	require.NoError(t, err)
-	require.NoError(t, migratorDown.Steps(-3))
+	require.NoError(t, migratorDown.Migrate(4))
 	require.NoError(t, migratorDown.Close())
 
 	// After down, the original shape is restored.

--- a/test/integration/settings/game_settings_integration_test.go
+++ b/test/integration/settings/game_settings_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/holomush/holomush/internal/settings"
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var _ = Describe("GameSettings with real Postgres", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		eventStore *store.PostgresEventStore
+		gs         settings.GameSettings
+		container  testcontainers.Container
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+
+		pgEnv, err := testutil.StartPostgres(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		container = pgEnv.Container
+
+		migrator, err := store.NewMigrator(pgEnv.ConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrator.Up()).To(Succeed())
+		_ = migrator.Close()
+
+		eventStore, err = store.NewPostgresEventStore(ctx, pgEnv.ConnStr)
+		Expect(err).NotTo(HaveOccurred())
+
+		gs = settings.NewGameSettings(&settings.SystemInfoAdapter{
+			Store:       eventStore,
+			NotFoundErr: store.ErrSystemInfoNotFound,
+		})
+	})
+
+	AfterEach(func() {
+		if eventStore != nil {
+			eventStore.Close()
+		}
+		cancel()
+		if container != nil {
+			_ = container.Terminate(context.Background())
+		}
+	})
+
+	Describe("Seeded defaults", func() {
+		It("reads the seeded scenes.focus.replay_tail_default value", func() {
+			v, ok := gs.IntN(ctx, "scenes.focus.replay_tail_default")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal(3))
+		})
+	})
+
+	Describe("Round-trip write and read", func() {
+		It("persists a string value and reads it back", func() {
+			err := gs.SetString(ctx, "scenes.focus.mode", "bounded")
+			Expect(err).NotTo(HaveOccurred())
+
+			v, ok := gs.StringN(ctx, "scenes.focus.mode")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("bounded"))
+		})
+
+		It("persists an int value as string and reads as int", func() {
+			err := gs.SetString(ctx, "scenes.focus.replay_tail_default", "7")
+			Expect(err).NotTo(HaveOccurred())
+
+			v, ok := gs.IntN(ctx, "scenes.focus.replay_tail_default")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal(7))
+		})
+
+		It("persists a bool value as string and reads as bool", func() {
+			err := gs.SetString(ctx, "core.maintenance_mode", "true")
+			Expect(err).NotTo(HaveOccurred())
+
+			v, ok := gs.BoolN(ctx, "core.maintenance_mode")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(BeTrue())
+		})
+
+		It("persists a duration value as string and reads as duration", func() {
+			err := gs.SetString(ctx, "core.session_timeout", "5m")
+			Expect(err).NotTo(HaveOccurred())
+
+			v, ok := gs.DurationN(ctx, "core.session_timeout")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal(5 * time.Minute))
+		})
+	})
+
+	Describe("Namespace validation", func() {
+		It("rejects writes with unknown namespace", func() {
+			err := gs.SetString(ctx, "bogus.key", "value")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown namespace"))
+		})
+	})
+
+	Describe("Missing keys", func() {
+		It("returns false for a key that does not exist", func() {
+			_, ok := gs.StringN(ctx, "core.nonexistent")
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/test/integration/settings/settings_suite_test.go
+++ b/test/integration/settings/settings_suite_test.go
@@ -1,0 +1,18 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package settings_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+func TestSettingsIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Settings Integration Suite")
+}


### PR DESCRIPTION
## Summary
- New `internal/settings` package: `Settings` interface, `Chain` (first-match-wins), namespace validation
- `GameSettings` backed by `holomush_system_info` via narrow `SystemInfoStore` interface
- `PlayerSettingsStore` backed by `players.preferences` JSONB via narrow `PlayerPrefsReader`
- Null `CharacterSettingsStore` for Phase 4 (future backing store)
- `RegisteredNamespaces`: core, scenes, channels, auth
- Migration `000007_seed_scene_defaults`: seeds `scenes.focus.replay_tail_default = 3`
- 53 unit tests + Ginkgo integration test against real Postgres

## Context
Part of epic `holomush-oy6e` (Server-Owned Focus Substrate).
Spec: `docs/superpowers/specs/2026-04-11-focus-substrate-design.md` § 6
Bead: `holomush-oy6e.5`

## Test plan
- [x] `task pr-prep` passes
- [x] Chain resolution: character → player → game → substrate default verified
- [x] Namespace validation: unknown namespaces rejected on write
- [x] Integration test: seeded defaults readable, round-trip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game-wide configuration system with namespaced settings (core, scenes, channels, auth).
  * Player preference storage and retrieval across sessions.
  * Server-seeded default for scene focus replay restored.

* **Chores**
  * Database migrations updated to add persistent settings and seed default values.
  * Migration tooling extended to support migrating to a specific version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->