### PR TITLE
feat(plugin): manifest-declared verb registration

### DIFF
--- a/docs/superpowers/plans/2026-04-12-plugin-verb-registration.md
+++ b/docs/superpowers/plans/2026-04-12-plugin-verb-registration.md
@@ -1,0 +1,1124 @@
+# Plugin Verb Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable plugins to declare verb registrations in their manifest, removing the boundary violation where plugin-owned event types are hardcoded in `internal/core/builtins.go`.
+
+**Architecture:** Add `verbs:` section to plugin manifests, parsed at load time. The loader calls `VerbRegistry.Register()` for each entry — same path builtins use. Add `Source` field for ownership tracking and `Unregister`/`UnregisterBySource` methods for load-failure cleanup and future unload. Move channel verb types from builtins to the channel plugin manifest.
+
+**Tech Stack:** Go, YAML manifest parsing, testify assertions, Ginkgo/Gomega for integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-plugin-verb-registration-design.md`
+
+---
+
+## Task 1: Add Source field and Unregister methods to VerbRegistry
+
+**Files:**
+
+- Modify: `internal/core/registry.go`
+- Modify: `internal/core/builtins.go`
+- Modify: `internal/core/registry_test.go`
+
+- [ ] **Step 1: Write failing tests for Source field and Unregister**
+
+Add to `internal/core/registry_test.go`:
+
+```go
+func TestVerbRegistrySourceFieldPreservedThroughRegisterLookup(t *testing.T) {
+	r := NewVerbRegistry()
+	err := r.Register(VerbRegistration{
+		Type: "custom", Category: "communication", Format: "action", Source: "my-plugin",
+	})
+	require.NoError(t, err)
+
+	reg, ok := r.Lookup("custom")
+	require.True(t, ok)
+	assert.Equal(t, "my-plugin", reg.Source)
+}
+
+func TestVerbRegistryUnregisterRemovesEntry(t *testing.T) {
+	r := NewVerbRegistry()
+	err := r.Register(VerbRegistration{
+		Type: "temp", Category: "system", Format: "notification", Source: "test",
+	})
+	require.NoError(t, err)
+
+	removed := r.Unregister("temp")
+	assert.True(t, removed)
+
+	_, ok := r.Lookup("temp")
+	assert.False(t, ok)
+}
+
+func TestVerbRegistryUnregisterNonexistentReturnsFalse(t *testing.T) {
+	r := NewVerbRegistry()
+	removed := r.Unregister("nonexistent")
+	assert.False(t, removed)
+}
+
+func TestVerbRegistryUnregisterBySourceRemovesAllFromSource(t *testing.T) {
+	r := NewVerbRegistry()
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "a", Category: "communication", Format: "action", Source: "plugin-x",
+	}))
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "b", Category: "system", Format: "notification", Source: "plugin-x",
+	}))
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "c", Category: "command", Format: "narrative", Source: "builtin",
+	}))
+
+	count := r.UnregisterBySource("plugin-x")
+	assert.Equal(t, 2, count)
+
+	_, ok := r.Lookup("a")
+	assert.False(t, ok)
+	_, ok = r.Lookup("b")
+	assert.False(t, ok)
+	_, ok = r.Lookup("c")
+	assert.True(t, ok)
+}
+
+func TestVerbRegistryUnregisterBySourceUnknownReturnsZero(t *testing.T) {
+	r := NewVerbRegistry()
+	count := r.UnregisterBySource("nonexistent")
+	assert.Equal(t, 0, count)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test -- -run TestVerbRegistry ./internal/core/`
+Expected: FAIL — `Source` field does not exist, `Unregister`/`UnregisterBySource` methods do not exist.
+
+- [ ] **Step 3: Add Source field and implement Unregister methods**
+
+In `internal/core/registry.go`, add `Source` field to `VerbRegistration`:
+
+```go
+// VerbRegistration holds rendering metadata for an event type.
+type VerbRegistration struct {
+	Type          string
+	Category      string // "communication", "movement", "state", "system", "command"
+	Format        string // "speech", "action", "narrative", "notification", "error", "snapshot", "delta"
+	Label         string // "says", "telepathically sends" -- required when Format is "speech"
+	DisplayTarget webv1.EventChannel
+	MetadataKeys  []MetadataKey
+	Source        string // "builtin" or plugin name -- tracks ownership for unload
+}
+```
+
+Add `Unregister` and `UnregisterBySource` methods after the existing `All()` method:
+
+```go
+// Unregister removes a single verb by event type. Returns true if found.
+func (r *VerbRegistry) Unregister(eventType string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.types[eventType]; !exists {
+		return false
+	}
+	delete(r.types, eventType)
+	return true
+}
+
+// UnregisterBySource removes all verbs registered by a given source.
+// Returns the count of removed entries.
+func (r *VerbRegistry) UnregisterBySource(source string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for key, reg := range r.types {
+		if reg.Source == source {
+			delete(r.types, key)
+			count++
+		}
+	}
+	return count
+}
+```
+
+- [ ] **Step 4: Update builtins to set Source field**
+
+In `internal/core/builtins.go`, update `RegisterBuiltinTypes` — add `Source: "builtin"` to every registration. The function signature and loop stay the same; each struct literal gains one field.
+
+For each entry in the `builtins` slice, add `Source: "builtin"`. Example for the first entry:
+
+```go
+{Type: "say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+```
+
+Apply this to all entries in the slice (lines 13-74 of the current file).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- -run TestVerbRegistry ./internal/core/`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Run full test suite to check for regressions**
+
+Run: `task test`
+Expected: ALL PASS. The `Source` field is a new addition — existing code that reads `VerbRegistration` won't break because Go zero-values uninitialized string fields to `""`.
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(core): add Source field and Unregister methods to VerbRegistry
+
+Source tracks ownership (builtin vs plugin name) for load-failure
+cleanup and future unload. UnregisterBySource removes all verbs
+from a given plugin in one call.
+
+Part of holomush-6l7l.
+```
+
+---
+
+### Task 2: Add VerbSpec to manifest parsing and validation
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go`
+- Modify: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write failing tests for manifest verb parsing**
+
+Add to `internal/plugin/manifest_test.go`:
+
+```go
+func TestManifestAcceptsLuaPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: verb-plugin
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom_say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+  - type: custom_action
+    category: communication
+    format: action
+    display_target: both
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, m.Verbs, 2)
+	assert.Equal(t, "custom_say", m.Verbs[0].Type)
+	assert.Equal(t, "communication", m.Verbs[0].Category)
+	assert.Equal(t, "speech", m.Verbs[0].Format)
+	assert.Equal(t, "says", m.Verbs[0].Label)
+	assert.Equal(t, "terminal", m.Verbs[0].DisplayTarget)
+	assert.Equal(t, "custom_action", m.Verbs[1].Type)
+	assert.Equal(t, "both", m.Verbs[1].DisplayTarget)
+}
+
+func TestManifestAcceptsBinaryPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: verb-binary
+version: 1.0.0
+type: binary
+binary-plugin:
+  executable: verb-binary
+verbs:
+  - type: custom_event
+    category: state
+    format: delta
+    display_target: state
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, m.Verbs, 1)
+	assert.Equal(t, "state", m.Verbs[0].DisplayTarget)
+}
+
+func TestManifestRejectsSettingPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: verb-setting
+version: 1.0.0
+type: setting
+setting:
+  display_name: Test
+  content_dir: content/
+  starting_location: "#1"
+verbs:
+  - type: custom
+    category: system
+    format: notification
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting plugins must not declare verbs")
+}
+
+func TestManifestRejectsVerbWithEmptyType(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: ""
+    category: communication
+    format: action
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "type must not be empty")
+}
+
+func TestManifestRejectsVerbWithUnknownCategory(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: unknown
+    format: action
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb category")
+}
+
+func TestManifestRejectsVerbWithUnknownFormat(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: communication
+    format: unknown
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb format")
+}
+
+func TestManifestRejectsVerbWithUnknownDisplayTarget(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: communication
+    format: action
+    display_target: sidebar
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb display_target")
+}
+
+func TestManifestRejectsSpeechVerbWithoutLabel(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: communication
+    format: speech
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "label is required")
+}
+
+func TestManifestRejectsDuplicateVerbType(t *testing.T) {
+	data := []byte(`
+name: bad-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: communication
+    format: action
+    display_target: terminal
+  - type: custom
+    category: system
+    format: notification
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate verb type")
+}
+
+func TestManifestDisplayTargetCaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"lowercase", "terminal"},
+		{"uppercase", "TERMINAL"},
+		{"mixed case", "Terminal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(fmt.Sprintf(`
+name: case-test
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom
+    category: communication
+    format: action
+    display_target: %s
+`, tt.input))
+			m, err := plugins.ParseManifest(data)
+			require.NoError(t, err)
+			require.Len(t, m.Verbs, 1)
+		})
+	}
+}
+
+func TestManifestAcceptsPluginWithNoVerbs(t *testing.T) {
+	data := []byte(`
+name: no-verbs
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	assert.Empty(t, m.Verbs)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test -- -run TestManifest ./internal/plugin/`
+Expected: FAIL — `Verbs` field and `VerbSpec` type do not exist.
+
+- [ ] **Step 3: Add VerbSpec and manifest validation**
+
+In `internal/plugin/manifest.go`, add the `VerbSpec` struct after `CommandSpec`:
+
+```go
+// VerbSpec declares a verb registration contributed by a plugin.
+type VerbSpec struct {
+	Type          string `yaml:"type" json:"type" jsonschema:"required"`
+	Category      string `yaml:"category" json:"category" jsonschema:"required"`
+	Format        string `yaml:"format" json:"format" jsonschema:"required"`
+	Label         string `yaml:"label,omitempty" json:"label,omitempty"`
+	DisplayTarget string `yaml:"display_target" json:"display_target" jsonschema:"required"`
+}
+
+// validVerbCategories lists the known verb categories.
+var validVerbCategories = map[string]bool{
+	"communication": true, "movement": true, "state": true, "system": true, "command": true,
+}
+
+// validVerbFormats lists the known verb formats.
+var validVerbFormats = map[string]bool{
+	"speech": true, "action": true, "narrative": true, "notification": true,
+	"error": true, "snapshot": true, "delta": true,
+}
+
+// validDisplayTargets lists the known display target values (case-insensitive).
+var validDisplayTargets = map[string]bool{
+	"terminal": true, "state": true, "both": true,
+}
+```
+
+Add `Verbs` field to the `Manifest` struct (after the `Commands` field, around line 79):
+
+```go
+Verbs    []VerbSpec    `yaml:"verbs,omitempty" json:"verbs,omitempty" jsonschema:"description=Verb registrations contributed by this plugin"`
+```
+
+Add verb validation inside `Manifest.Validate()`. Place it after the setting-type block (after line 321 in the current file, inside the `TypeSetting` case, alongside the existing "setting plugins must not declare commands" check):
+
+In the `TypeSetting` case, add:
+
+```go
+if len(m.Verbs) > 0 {
+	return oops.In("manifest").With("name", m.Name).New("setting plugins must not declare verbs")
+}
+```
+
+Then add verb validation after the commands validation block (after the `seenCommands` loop, around line 372):
+
+```go
+// Validate verbs and check for duplicates.
+seenVerbs := make(map[string]bool)
+for i, v := range m.Verbs {
+	if v.Type == "" {
+		return oops.In("manifest").With("plugin", m.Name).With("verb_index", i).
+			New("verb type must not be empty")
+	}
+	if !validVerbCategories[v.Category] {
+		return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+			With("category", v.Category).New("unknown verb category")
+	}
+	if !validVerbFormats[v.Format] {
+		return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+			With("format", v.Format).New("unknown verb format")
+	}
+	if !validDisplayTargets[strings.ToLower(v.DisplayTarget)] {
+		return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+			With("display_target", v.DisplayTarget).New("unknown verb display_target")
+	}
+	if v.Format == "speech" && v.Label == "" {
+		return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+			New("label is required when verb format is speech")
+	}
+	if seenVerbs[v.Type] {
+		return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+			New("duplicate verb type")
+	}
+	seenVerbs[v.Type] = true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- -run TestManifest ./internal/plugin/`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Regenerate JSON schema**
+
+Run: `go generate ./internal/plugin/...`
+
+The `//go:generate` directive at the top of `manifest.go` regenerates the manifest JSON schema. The new `Verbs` and `VerbSpec` fields need to appear in the schema.
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(plugin): add VerbSpec to manifest parsing and validation
+
+Plugins can now declare verbs in manifest.yaml with type, category,
+format, label, and display_target. Validation enforces known enum
+values, speech-requires-label, duplicate detection, and setting
+plugins excluded.
+
+Part of holomush-6l7l.
+```
+
+---
+
+### Task 3: Wire VerbRegistry into Manager and loadPlugin
+
+**Files:**
+
+- Modify: `internal/plugin/manager.go`
+- Modify: `internal/plugin/manager_test.go`
+
+- [ ] **Step 1: Write failing tests for verb registration in loadPlugin**
+
+Add to `internal/plugin/manager_test.go`:
+
+```go
+func TestManagerLoadAllRegistersVerbsFromManifest(t *testing.T) {
+	verbReg := core.NewVerbRegistry()
+	dir := writePluginDir(t, "verb-plugin", `
+name: verb-plugin
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: custom_say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+  - type: custom_action
+    category: communication
+    format: action
+    display_target: both
+`)
+	host := &mockHost{}
+	mgr := plugins.NewManager(dir,
+		plugins.WithLuaHost(host),
+		plugins.WithVerbRegistry(verbReg),
+	)
+
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err)
+
+	reg, ok := verbReg.Lookup("custom_say")
+	require.True(t, ok, "custom_say should be registered")
+	assert.Equal(t, "communication", reg.Category)
+	assert.Equal(t, "speech", reg.Format)
+	assert.Equal(t, "says", reg.Label)
+	assert.Equal(t, "verb-plugin", reg.Source)
+
+	reg, ok = verbReg.Lookup("custom_action")
+	require.True(t, ok, "custom_action should be registered")
+	assert.Equal(t, "verb-plugin", reg.Source)
+}
+
+func TestManagerLoadAllRejectsPluginWithDuplicateVerbType(t *testing.T) {
+	verbReg := core.NewVerbRegistry()
+	// Pre-register a builtin verb
+	require.NoError(t, verbReg.Register(core.VerbRegistration{
+		Type: "say", Category: "communication", Format: "speech",
+		Label: "says", Source: "builtin",
+	}))
+
+	dir := writePluginDir(t, "dup-verb", `
+name: dup-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+`)
+	host := &mockHost{}
+	mgr := plugins.NewManager(dir,
+		plugins.WithLuaHost(host),
+		plugins.WithVerbRegistry(verbReg),
+	)
+
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already registered")
+}
+
+func TestManagerLoadAllCleansUpVerbsOnPartialFailure(t *testing.T) {
+	verbReg := core.NewVerbRegistry()
+	// Pre-register "conflict" so the second verb in the manifest fails
+	require.NoError(t, verbReg.Register(core.VerbRegistration{
+		Type: "conflict", Category: "system", Format: "notification", Source: "builtin",
+	}))
+
+	dir := writePluginDir(t, "partial-verb", `
+name: partial-verb
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: good_verb
+    category: communication
+    format: action
+    display_target: terminal
+  - type: conflict
+    category: system
+    format: notification
+    display_target: terminal
+`)
+	host := &mockHost{}
+	mgr := plugins.NewManager(dir,
+		plugins.WithLuaHost(host),
+		plugins.WithVerbRegistry(verbReg),
+	)
+
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err)
+
+	// good_verb should have been cleaned up by UnregisterBySource
+	_, ok := verbReg.Lookup("good_verb")
+	assert.False(t, ok, "good_verb should have been cleaned up after partial failure")
+}
+
+func TestManagerLoadAllWithoutVerbRegistrySkipsVerbRegistration(t *testing.T) {
+	dir := writePluginDir(t, "no-reg", `
+name: no-reg
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: orphan
+    category: system
+    format: notification
+    display_target: terminal
+`)
+	host := &mockHost{}
+	mgr := plugins.NewManager(dir, plugins.WithLuaHost(host))
+
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err)
+}
+```
+
+Note: The `writePluginDir` helper and `mockHost` type should already exist in `manager_test.go` from other tests. If the exact helper name differs, match the existing pattern.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test -- -run TestManagerLoadAll.*Verb ./internal/plugin/`
+Expected: FAIL — `WithVerbRegistry` option does not exist.
+
+- [ ] **Step 3: Implement VerbRegistry wiring in Manager**
+
+In `internal/plugin/manager.go`, add `verbRegistry` field to `Manager` struct:
+
+```go
+verbRegistry        *core.VerbRegistry
+```
+
+Add the `WithVerbRegistry` option function (after the existing `With*` functions):
+
+```go
+// WithVerbRegistry sets the VerbRegistry for plugin verb registration.
+func WithVerbRegistry(reg *core.VerbRegistry) ManagerOption {
+	return func(m *Manager) {
+		m.verbRegistry = reg
+	}
+}
+```
+
+Add a `displayTargetFromString` helper (private function, place near the top of the file or near other helper functions):
+
+```go
+// displayTargetFromString converts a manifest display_target string to the
+// proto enum. Returns EVENT_CHANNEL_UNSPECIFIED for unknown values (validation
+// should catch these before this is called).
+func displayTargetFromString(s string) webv1.EventChannel {
+	switch strings.ToLower(s) {
+	case "terminal":
+		return webv1.EventChannel_EVENT_CHANNEL_TERMINAL
+	case "state":
+		return webv1.EventChannel_EVENT_CHANNEL_STATE
+	case "both":
+		return webv1.EventChannel_EVENT_CHANNEL_BOTH
+	default:
+		return webv1.EventChannel_EVENT_CHANNEL_UNSPECIFIED
+	}
+}
+```
+
+This requires adding the `webv1` import:
+
+```go
+webv1 "github.com/holomush/holomush/pkg/proto/holomush/web/v1"
+```
+
+In `loadPlugin()`, add verb registration after the manifest warnings check (after line 668 in the current file, after `CheckManifestWarnings`) and before service registration:
+
+```go
+// Register plugin-declared verbs in the VerbRegistry.
+if m.verbRegistry != nil && len(dp.Manifest.Verbs) > 0 {
+	for _, vs := range dp.Manifest.Verbs {
+		regErr := m.verbRegistry.Register(core.VerbRegistration{
+			Type:          vs.Type,
+			Category:      vs.Category,
+			Format:        vs.Format,
+			Label:         vs.Label,
+			DisplayTarget: displayTargetFromString(vs.DisplayTarget),
+			Source:        dp.Manifest.Name,
+		})
+		if regErr != nil {
+			// Clean up any verbs already registered from this plugin.
+			m.verbRegistry.UnregisterBySource(dp.Manifest.Name)
+			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
+			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+				slog.Error("failed to rollback plugin load after verb registration failure",
+					"plugin", dp.Manifest.Name, "error", unloadErr)
+			}
+			return oops.In("manager").With("plugin", dp.Manifest.Name).
+				With("verb", vs.Type).Wrapf(regErr, "register plugin verb")
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- -run TestManagerLoadAll.*Verb ./internal/plugin/`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(plugin): wire VerbRegistry into Manager and loadPlugin
+
+Plugin-declared verbs are registered in the VerbRegistry at load time.
+Registration failures are fatal (same as bad policies or invalid
+capabilities). Partial registrations are cleaned up via
+UnregisterBySource on failure.
+
+Part of holomush-6l7l.
+```
+
+---
+
+### Task 4: Move channel verb types from builtins to channel plugin manifest
+
+**Files:**
+
+- Modify: `internal/core/builtins.go`
+- Modify: `plugins/core-channels/plugin.yaml`
+- Modify: `internal/core/registry_test.go`
+
+- [ ] **Step 1: Write a test verifying builtins no longer include channel types**
+
+Add to `internal/core/registry_test.go`:
+
+```go
+func TestRegisterBuiltinTypesDoesNotIncludeChannelTypes(t *testing.T) {
+	r := NewVerbRegistry()
+	err := RegisterBuiltinTypes(r)
+	require.NoError(t, err)
+
+	channelTypes := []string{"channel_say", "channel_pose", "channel_system"}
+	for _, ct := range channelTypes {
+		_, ok := r.Lookup(ct)
+		assert.False(t, ok, "builtin registry should not include %s", ct)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestRegisterBuiltinTypesDoesNotIncludeChannelTypes ./internal/core/`
+Expected: FAIL — channel types are currently in builtins.
+
+- [ ] **Step 3: Remove channel verb types from builtins.go**
+
+In `internal/core/builtins.go`, remove lines 62-74 (the entire "Channel types" block):
+
+```go
+		// Channel types (future use, registered now)
+		{
+			Type: "channel_say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
+		},
+		{
+			Type: "channel_pose", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
+		},
+		{
+			Type: "channel_system", Category: "system", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
+		},
+```
+
+- [ ] **Step 4: Add verbs to channel plugin manifest**
+
+In `plugins/core-channels/plugin.yaml`, add a `verbs:` section:
+
+```yaml
+verbs:
+  - type: channel_say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+  - type: channel_pose
+    category: communication
+    format: action
+    display_target: terminal
+  - type: channel_system
+    category: system
+    format: notification
+    display_target: terminal
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- -run TestRegisterBuiltinTypes ./internal/core/`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS. If any test depended on channel types being in builtins, it will need updating. Search for `channel_say` or `channel_pose` in test files.
+
+- [ ] **Step 7: Commit**
+
+```text
+refactor(core): move channel verb types from builtins to plugin manifest
+
+Removes channel_say, channel_pose, channel_system from
+RegisterBuiltinTypes and declares them in the core-channels plugin
+manifest. This eliminates the boundary violation where plugin-owned
+event types leaked into internal/core/builtins.go.
+
+Closes holomush-6l7l.
+```
+
+---
+
+### Task 5: Add verbs to plugin info command output
+
+**Files:**
+
+- Modify: `internal/command/handlers/plugin_admin.go`
+- Create: `internal/command/handlers/plugin_admin_test.go` (if it does not exist, otherwise modify)
+
+- [ ] **Step 1: Write failing test for plugin info verb display**
+
+Check if `internal/command/handlers/plugin_admin_test.go` exists. If not, create it. Add:
+
+```go
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/command/handlers"
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+type stubPluginLister struct {
+	plugins map[string]*plugins.DiscoveredPlugin
+}
+
+func (s *stubPluginLister) ListPlugins() []string {
+	names := make([]string, 0, len(s.plugins))
+	for n := range s.plugins {
+		names = append(names, n)
+	}
+	return names
+}
+
+func (s *stubPluginLister) GetLoadedPlugin(name string) (*plugins.DiscoveredPlugin, bool) {
+	dp, ok := s.plugins[name]
+	return dp, ok
+}
+
+func TestPluginInfoShowsVerbs(t *testing.T) {
+	lister := &stubPluginLister{
+		plugins: map[string]*plugins.DiscoveredPlugin{
+			"test-plugin": {
+				Manifest: &plugins.Manifest{
+					Name:    "test-plugin",
+					Version: "1.0.0",
+					Type:    plugins.TypeLua,
+					Storage: plugins.StorageKV,
+					Verbs: []plugins.VerbSpec{
+						{Type: "custom_say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: "terminal"},
+						{Type: "custom_action", Category: "communication", Format: "action", DisplayTarget: "both"},
+					},
+				},
+			},
+		},
+	}
+
+	handler := handlers.NewPluginHandler(lister)
+	var output string
+	ctx := command.WithOutputWriter(context.Background(), func(_ context.Context, _ *command.CommandExecution, _ string, text string) {
+		output = text
+	})
+	exec := &command.CommandExecution{Args: "info test-plugin"}
+
+	err := handler(ctx, exec)
+	require.NoError(t, err)
+	assert.Contains(t, output, "custom_say (communication/speech)")
+	assert.Contains(t, output, "custom_action (communication/action)")
+}
+```
+
+Note: The `command.WithOutputWriter` pattern and `writeOutput` helper may work differently. Match the existing test patterns in the codebase. The key assertion is that verb type and category/format appear in the output.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestPluginInfoShowsVerbs ./internal/command/handlers/`
+Expected: FAIL — verb display not implemented.
+
+- [ ] **Step 3: Add verb display to plugin info**
+
+In `internal/command/handlers/plugin_admin.go`, in the `handlePluginInfo` function, after the commands block (after line 98), add:
+
+```go
+if len(m.Verbs) > 0 {
+	verbDescs := make([]string, len(m.Verbs))
+	for i, v := range m.Verbs {
+		verbDescs[i] = fmt.Sprintf("%s (%s/%s)", v.Type, v.Category, v.Format)
+	}
+	fmt.Fprintf(&sb, "\nVerbs: %s", strings.Join(verbDescs, ", "))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestPluginInfoShowsVerbs ./internal/command/handlers/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```text
+feat(plugin): show verb registrations in plugin info output
+
+plugin info <name> now displays declared verbs as
+"type (category/format)" alongside existing commands and services.
+
+Part of holomush-6l7l.
+```
+
+---
+
+### Task 6: Integration tests
+
+**Files:**
+
+- Create: `test/integration/plugin/verb_registration_test.go`
+
+- [ ] **Step 1: Check existing integration test structure**
+
+Read `test/integration/plugin/` to understand the Ginkgo suite setup, test container helpers, and the pattern used for existing plugin integration tests. The new tests should follow the same setup.
+
+- [ ] **Step 2: Write integration test file**
+
+Create `test/integration/plugin/verb_registration_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugin_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+var _ = Describe("Plugin verb registration", func() {
+	Describe("loading a plugin with manifest-declared verbs", func() {
+		It("registers all declared verbs in the VerbRegistry", func() {
+			// Setup: create a VerbRegistry with builtins, then load a plugin
+			// with verbs declared in its manifest.
+			verbReg := core.NewVerbRegistry()
+			Expect(core.RegisterBuiltinTypes(verbReg)).To(Succeed())
+
+			// The core-channels plugin declares verbs in its manifest.
+			// After loading, those verbs should appear in the registry.
+			// Use the test harness from the existing integration suite to
+			// load the plugin manager with the verb registry wired in.
+			//
+			// Adapt this to match the existing integration test setup pattern
+			// in this directory — use the same helpers and fixtures.
+
+			// Verify channel verbs are registered with correct source
+			reg, ok := verbReg.Lookup("channel_say")
+			Expect(ok).To(BeTrue(), "channel_say should be registered after plugin load")
+			Expect(reg.Source).To(Equal("core-channels"))
+			Expect(reg.Category).To(Equal("communication"))
+			Expect(reg.Format).To(Equal("speech"))
+
+			reg, ok = verbReg.Lookup("channel_pose")
+			Expect(ok).To(BeTrue(), "channel_pose should be registered after plugin load")
+			Expect(reg.Source).To(Equal("core-channels"))
+		})
+
+		It("rejects a plugin whose verb type conflicts with a builtin", func() {
+			verbReg := core.NewVerbRegistry()
+			Expect(core.RegisterBuiltinTypes(verbReg)).To(Succeed())
+
+			// Attempt to load a test plugin that declares a verb with type "say"
+			// (which is a builtin). Should fail.
+			// Create a temp plugin dir with a conflicting verb manifest.
+			// Use the same fixture pattern as existing integration tests.
+		})
+
+		It("cleans up verbs when plugin load fails partway", func() {
+			verbReg := core.NewVerbRegistry()
+			Expect(core.RegisterBuiltinTypes(verbReg)).To(Succeed())
+
+			// Load a plugin with two verbs where the second conflicts.
+			// Verify the first verb is cleaned up.
+		})
+	})
+})
+```
+
+Note: The integration test bodies above are scaffolds. The implementer MUST adapt them to match the existing integration test infrastructure in `test/integration/plugin/`. Read the existing `*_test.go` files in that directory to understand the setup pattern (test containers, manager construction, fixture plugins).
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `task test:int -- -run "Plugin verb" ./test/integration/plugin/`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```text
+test(integration): add verb registration integration tests
+
+Verifies full plugin load cycle with manifest-declared verbs,
+conflict detection against builtins, and cleanup on partial failure.
+
+Part of holomush-6l7l.
+```
+
+---
+
+### Task 7: Final verification and cleanup
+
+- [ ] **Step 1: Run full unit test suite**
+
+Run: `task test`
+Expected: ALL PASS.
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `task test:int`
+Expected: ALL PASS.
+
+- [ ] **Step 3: Run linter**
+
+Run: `task lint`
+Expected: ALL PASS. Fix any issues.
+
+- [ ] **Step 4: Run formatter**
+
+Run: `task fmt`
+
+- [ ] **Step 5: Run pr-prep**
+
+Run: `task pr-prep`
+Expected: ALL PASS. This mirrors all CI jobs.
+
+- [ ] **Step 6: Update beads issue**
+
+```bash
+bd close holomush-6l7l --reason "Implemented: manifest-declared verbs with Source tracking, Unregister methods, display_target string→enum mapping, channel verbs moved from builtins to plugin manifest, plugin info display, integration tests."
+```
+
+- [ ] **Step 7: Final commit if any cleanup was needed**
+
+Commit any formatting or lint fixes from steps 3-4.

--- a/docs/superpowers/specs/2026-04-12-plugin-verb-registration-design.md
+++ b/docs/superpowers/specs/2026-04-12-plugin-verb-registration-design.md
@@ -1,0 +1,359 @@
+# Plugin Verb Registration Design
+
+**Issue:** holomush-6l7l
+**Date:** 2026-04-12
+**Status:** Draft
+**Author:** Sean Brandt, Claude Opus 4.6
+
+## Problem
+
+`VerbRegistry` in `internal/core/registry.go` is a runtime registry with
+`Register()`/`Lookup()` methods. `builtins.go` seeds it with core entries at
+startup. Plugins have no way to register their own verb entries.
+
+When a plugin emits an event with an unknown type (e.g., `channel_say`), the
+registry falls back to default rendering (system/narrative/TERMINAL). Plugin
+events like channel messages render as generic text instead of
+domain-appropriate formats.
+
+The only way to add verb entries for plugin event types is to edit
+`builtins.go` — a boundary violation.
+
+## Approach
+
+Manifest-declared verbs following the established pattern for commands,
+policies, resource_types, and actions. Plugins declare a `verbs:` section in
+their `manifest.yaml`. The loader calls `VerbRegistry.Register()` for each
+entry at load time.
+
+### Why manifest-declared
+
+- Consistent with every other manifest-declared resource in the system
+- Inspectable without loading the plugin — tooling, `plugin info`, docs
+- Validation happens at load time — bad entries caught early
+- VerbRegistry already has `Register()` with duplicate detection and format
+  validation
+
+### Alternatives considered
+
+**Runtime host function** — Plugin calls `RegisterVerb` during initialization.
+Rejected: breaks manifest-as-contract pattern, requires new host function for
+Lua AND new gRPC service for binary, creates ordering questions.
+
+**Hybrid (manifest + runtime)** — Rejected: YAGNI. No known use case for
+runtime registration today. Can be added later without disturbing
+manifest-declared verbs.
+
+## Design
+
+### Manifest Schema
+
+Add optional `verbs` section to `manifest.yaml`:
+
+```yaml
+verbs:
+  - type: channel_say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+  - type: channel_pose
+    category: communication
+    format: action
+    display_target: terminal
+  - type: channel_join
+    category: state
+    format: notification
+    display_target: both
+  - type: channel_leave
+    category: state
+    format: notification
+    display_target: both
+```
+
+#### Fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `type` | MUST | Event type string (e.g., `channel_say`) |
+| `category` | MUST | One of: `communication`, `movement`, `state`, `system`, `command` |
+| `format` | MUST | One of: `speech`, `action`, `narrative`, `notification`, `error`, `snapshot`, `delta` |
+| `label` | Conditional | MUST be present when `format` is `speech` (e.g., "says", "whispers") |
+| `display_target` | MUST | One of: `terminal`, `state`, `both` |
+
+#### display_target
+
+`display_target` is the event's routing intent — it controls which client
+display surface receives the event. It decouples routing from category
+semantics, allowing flexibility (e.g., a `state` event that also appears in
+the terminal, or a `communication` event that updates a sidebar panel).
+
+| Value | Meaning |
+| --- | --- |
+| `terminal` | Main scrolling text output only |
+| `state` | Sidebar/status panel only |
+| `both` | Both terminal and sidebar |
+
+The server uses `display_target` for telnet filtering (skip state-only events)
+and stamps it onto the `GameEvent` proto for web clients. The web client's
+`eventRouter.ts` uses it as the primary routing signal.
+
+#### Metadata keys
+
+Metadata keys (e.g., `no_space: bool` for `pose`) are omitted from the
+manifest schema. They are currently purely descriptive — nothing validates them
+at runtime. Adding them later is a backwards-compatible change.
+
+### VerbRegistration Changes
+
+Add `Source` field to track ownership:
+
+```go
+type VerbRegistration struct {
+    Type          string
+    Category      string
+    Format        string
+    Label         string
+    DisplayTarget webv1.EventChannel
+    MetadataKeys  []MetadataKey
+    Source        string // "builtin" or plugin name
+}
+```
+
+Builtins set `Source: "builtin"`. Plugin-registered verbs set `Source` to the
+plugin's manifest name.
+
+### VerbRegistry Changes
+
+Add removal methods to support unload:
+
+```go
+// Unregister removes a single verb by event type. Returns true if found.
+func (r *VerbRegistry) Unregister(eventType string) bool
+
+// UnregisterBySource removes all verbs registered by a given source.
+// Returns the count of removed entries.
+func (r *VerbRegistry) UnregisterBySource(source string) int
+```
+
+These methods are needed for:
+
+- Load-failure unwind (clean up partial verb registration)
+- Future plugin unload orchestration
+
+Full plugin unload/reload orchestration is out of scope for this issue. The
+registry API is designed to support it when needed.
+
+### Manifest Parsing
+
+Add `VerbSpec` struct to manifest types:
+
+```go
+type VerbSpec struct {
+    Type          string `yaml:"type"`
+    Category      string `yaml:"category"`
+    Format        string `yaml:"format"`
+    Label         string `yaml:"label,omitempty"`
+    DisplayTarget string `yaml:"display_target"`
+}
+```
+
+`display_target` is parsed as a string in YAML and converted to
+`webv1.EventChannel` via an explicit case-insensitive mapping during
+validation:
+
+```go
+var displayTargetValues = map[string]webv1.EventChannel{
+    "terminal": webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
+    "state":    webv1.EventChannel_EVENT_CHANNEL_STATE,
+    "both":     webv1.EventChannel_EVENT_CHANNEL_BOTH,
+}
+```
+
+#### Validation Rules
+
+Performed at manifest parse time (`ParseManifest`):
+
+| Rule | Error |
+| --- | --- |
+| `type` MUST NOT be empty | `INVALID_MANIFEST` |
+| `category` MUST be a known value | `INVALID_MANIFEST` |
+| `format` MUST be a known value | `INVALID_MANIFEST` |
+| `label` MUST be present when `format` is `speech` | `INVALID_MANIFEST` |
+| `display_target` MUST be a known value | `INVALID_MANIFEST` |
+| Duplicate `type` within same manifest | `INVALID_MANIFEST` |
+| `setting` type plugins MUST NOT declare verbs | `INVALID_MANIFEST` |
+
+### Loader Wiring
+
+In `Manager.loadPlugin()`, after policy installation and before alias seeding:
+
+1. Iterate `manifest.Verbs`
+2. Convert each `VerbSpec` to `core.VerbRegistration` (with `Source` set to
+   plugin name, `DisplayTarget` converted from string to enum)
+3. Call `VerbRegistry.Register()` for each
+4. If registration fails → call `VerbRegistry.UnregisterBySource(pluginName)`
+   to clean up any verbs already registered in this batch, then return error
+   (plugin fails to load)
+
+Registration failure is fatal — same as a bad policy or invalid capability.
+
+### Namespace Enforcement
+
+Convention-based (B). Plugin verb types SHOULD be prefixed with the plugin's
+domain (e.g., `channel_*` for `core-channels`). This is documented but not
+enforced at load time. `Register()` duplicate detection serves as the safety
+net — if two plugins try to register the same event type, the second fails.
+
+### plugin info Integration
+
+Add verbs to the `plugin info <name>` admin command output:
+
+```text
+Verbs: channel_say (communication/speech), channel_pose (communication/action),
+       channel_join (state/notification), channel_leave (state/notification)
+```
+
+Format: `type (category/format)` — compact, scannable.
+
+## Invariants
+
+1. **No duplicate event types.** `Register()` rejects duplicates across
+   builtins and all loaded plugins. A plugin MUST NOT register a verb type
+   that conflicts with a builtin or another plugin.
+
+2. **Speech requires label.** Any verb with `format: speech` MUST declare a
+   `label`. Enforced at both manifest parse time and `Register()` time.
+
+3. **Source tracking.** Every `VerbRegistration` MUST have a non-empty
+   `Source` field. Builtins use `"builtin"`, plugins use their manifest name.
+
+4. **Load-failure cleanup.** If verb registration fails partway through a
+   plugin's verb list, all verbs from that plugin MUST be removed before the
+   error propagates. No orphaned registrations.
+
+5. **Fallback rendering.** Unknown event types (not registered in
+   VerbRegistry) MUST continue to fall back to system/narrative/TERMINAL.
+   This design does not change fallback behavior.
+
+6. **Setting plugins excluded.** Plugins with `type: setting` MUST NOT
+   declare verbs. Enforced at parse time.
+
+## Consumer Impact
+
+### Telnet handler (`internal/telnet/gateway_handler.go`)
+
+No changes needed. The handler already:
+
+- Looks up VerbRegistration via `Lookup()`
+- Filters by `DisplayTarget` (skips state-only)
+- Switches on `Category` with fallback to `formatFallback()`
+
+Plugin verbs with known categories work through existing formatting. Unknown
+categories hit the fallback path safely.
+
+### Web translator (`internal/web/translate.go`)
+
+No changes needed. The translator already:
+
+- Looks up VerbRegistration via `Lookup()`
+- Passes category, format, label, display_target through to `GameEvent` proto
+- Falls back to system/narrative/TERMINAL for unknown types
+
+Plugin verbs flow through to web clients with correct metadata.
+
+### Web client (`web/src/lib/stores/eventRouter.ts`)
+
+No changes needed. The client already:
+
+- Routes by `displayTarget` as primary signal
+- Sub-routes sidebar by `category`
+
+Plugin events with correct `displayTarget` will route correctly.
+
+## Out of Scope
+
+| Item | Reason |
+| --- | --- |
+| Metadata keys in manifest | YAGNI. Additive later. |
+| Emit-time validation | Separate concern. Unregistered types get fallback rendering today. |
+| `emits`/verbs cross-validation | Orthogonal axes (stream namespaces vs event type rendering). |
+| Full plugin unload/reload orchestration | Own epic. VerbRegistry API designed to support it. |
+| Runtime verb registration (host function/gRPC) | No known use case. Additive later if needed. |
+
+## Test Plan
+
+### Unit Tests — VerbRegistry (`internal/core`)
+
+| Test | Type |
+| --- | --- |
+| Register valid verb with all fields | Positive |
+| Register speech verb with label | Positive |
+| Reject empty type | Negative |
+| Reject empty category | Negative |
+| Reject empty format | Negative |
+| Reject speech format without label | Negative |
+| Reject duplicate type | Negative |
+| Lookup returns registered verb | Positive |
+| Lookup returns false for unknown type | Negative |
+| Unregister removes entry, Lookup returns false | Positive |
+| Unregister nonexistent type returns false | Boundary |
+| UnregisterBySource removes all verbs from source | Positive |
+| UnregisterBySource with unknown source returns 0 | Boundary |
+| All() includes verbs from multiple sources | Positive |
+| Source field preserved through Register/Lookup | Invariant |
+
+### Unit Tests — Manifest Parsing (`internal/plugin`)
+
+| Test | Type |
+| --- | --- |
+| Parse manifest with valid verbs section | Positive |
+| Parse manifest with no verbs section | Positive |
+| Reject unknown display_target value | Negative |
+| Reject unknown category value | Negative |
+| Reject unknown format value | Negative |
+| Reject speech verb without label | Negative |
+| Reject duplicate type within same manifest | Negative |
+| Reject verbs on setting-type plugin | Negative |
+| display_target string→enum conversion (terminal, state, both) | Boundary |
+| display_target case insensitivity (TERMINAL, Terminal, terminal) | Boundary |
+
+### Unit Tests — Loader Wiring (`internal/plugin`)
+
+| Test | Type |
+| --- | --- |
+| loadPlugin registers verbs in VerbRegistry | Positive |
+| loadPlugin sets Source to plugin name | Invariant |
+| Invalid verb → loadPlugin returns error | Negative |
+| Duplicate verb (cross-plugin) → second plugin fails | Negative |
+| Duplicate verb (plugin vs builtin) → plugin fails | Boundary |
+| Load failure after partial verb registration → verbs cleaned up | Invariant |
+| Plugin with verbs appears in plugin info output | Positive |
+
+### Integration Tests (`test/integration`)
+
+| Test | Type |
+| --- | --- |
+| Full plugin load cycle: plugin with verbs → verbs in registry | Positive |
+| Event with registered verb → web translator produces correct GameEvent fields | Positive |
+| Event with registered verb → telnet formats according to registration | Positive |
+| Plugin verb with display_target: state → telnet skips, web routes to sidebar | Boundary |
+| Plugin verb with unknown category → telnet/web use fallback formatting | Boundary |
+
+### E2E Tests
+
+| Test | Type |
+| --- | --- |
+| Load plugin with verbs → `plugin info` shows verbs | Positive |
+| Emit event with plugin-registered verb → correct rendering reaches client | Positive |
+
+## References
+
+- `internal/core/registry.go` — VerbRegistry implementation
+- `internal/core/builtins.go` — builtin verb registrations
+- `internal/plugin/manifest.go` — manifest parsing
+- `internal/plugin/manager.go` — plugin loader
+- `internal/web/translate.go` — web event translation
+- `internal/telnet/gateway_handler.go` — telnet event formatting
+- `web/src/lib/stores/eventRouter.ts` — web client event routing
+- holomush-275o (closed) — extensible actions, pattern precedent

--- a/internal/command/handlers/plugin_admin.go
+++ b/internal/command/handlers/plugin_admin.go
@@ -96,6 +96,13 @@ func handlePluginInfo(ctx context.Context, exec *command.CommandExecution, liste
 		}
 		fmt.Fprintf(&sb, "\nCommands: %s", strings.Join(cmdNames, ", "))
 	}
+	if len(m.Verbs) > 0 {
+		verbDescs := make([]string, len(m.Verbs))
+		for i, v := range m.Verbs {
+			verbDescs[i] = fmt.Sprintf("%s (%s/%s)", v.Type, v.Category, v.Format)
+		}
+		fmt.Fprintf(&sb, "\nVerbs: %s", strings.Join(verbDescs, ", "))
+	}
 
 	writeOutput(ctx, exec, pluginCommandName, sb.String())
 	return nil

--- a/internal/command/handlers/plugin_admin_test.go
+++ b/internal/command/handlers/plugin_admin_test.go
@@ -187,6 +187,40 @@ func TestPluginInfoOmitsEmptyOptionalFields(t *testing.T) {
 	assert.NotContains(t, output, "Provides:")
 }
 
+func TestPluginInfoShowsVerbRegistrations(t *testing.T) {
+	ts := newPluginTestSetup()
+	m := luaPlugin()
+	m.Verbs = []plugins.VerbSpec{
+		{Type: "custom_say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: "terminal"},
+		{Type: "custom_action", Category: "communication", Format: "action", DisplayTarget: "both"},
+	}
+	lister := newPluginListerWithPlugins(
+		&plugins.DiscoveredPlugin{Manifest: m},
+	)
+
+	handler := NewPluginHandler(lister)
+	err := handler(context.Background(), ts.makeExec(t, "info core-communication"))
+
+	require.NoError(t, err)
+	output := ts.buf.String()
+	assert.Contains(t, output, "Verbs:")
+	assert.Contains(t, output, "custom_say (communication/speech)")
+	assert.Contains(t, output, "custom_action (communication/action)")
+}
+
+func TestPluginInfoOmitsVerbsWhenEmpty(t *testing.T) {
+	ts := newPluginTestSetup()
+	lister := newPluginListerWithPlugins(
+		&plugins.DiscoveredPlugin{Manifest: luaPlugin()},
+	)
+
+	handler := NewPluginHandler(lister)
+	err := handler(context.Background(), ts.makeExec(t, "info core-communication"))
+
+	require.NoError(t, err)
+	assert.NotContains(t, ts.buf.String(), "Verbs:")
+}
+
 func TestPluginShowsUsageForInvalidSubcommands(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/core/builtins.go
+++ b/internal/core/builtins.go
@@ -10,22 +10,22 @@ import webv1 "github.com/holomush/holomush/pkg/proto/holomush/web/v1"
 func RegisterBuiltinTypes(r *VerbRegistry) error {
 	builtins := []VerbRegistration{
 		// Communication
-		{Type: "say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
+		{Type: "say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
 		{
-			Type: "pose", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			Type: "pose", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin",
 			MetadataKeys: []MetadataKey{{Key: "no_space", ValueType: "bool", Description: "Suppress space between actor and text"}},
 		},
-		{Type: "page", Category: "communication", Format: "speech", Label: "pages", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "whisper", Category: "communication", Format: "speech", Label: "whispers", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "whisper_notice", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "ooc", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "pemit", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
+		{Type: "page", Category: "communication", Format: "speech", Label: "pages", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "whisper", Category: "communication", Format: "speech", Label: "whispers", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "whisper_notice", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "ooc", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "pemit", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
 
 		// Movement
-		{Type: "arrive", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH},
-		{Type: "leave", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH},
+		{Type: "arrive", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH, Source: "builtin"},
+		{Type: "leave", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH, Source: "builtin"},
 		{
-			Type: "move", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH,
+			Type: "move", Category: "movement", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_BOTH, Source: "builtin",
 			MetadataKeys: []MetadataKey{
 				{Key: "from_id", ValueType: "string"},
 				{Key: "to_id", ValueType: "string"},
@@ -35,7 +35,7 @@ func RegisterBuiltinTypes(r *VerbRegistry) error {
 
 		// State
 		{
-			Type: "location_state", Category: "state", Format: "snapshot", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE,
+			Type: "location_state", Category: "state", Format: "snapshot", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE, Source: "builtin",
 			MetadataKeys: []MetadataKey{
 				{Key: "location", ValueType: "object"},
 				{Key: "exits", ValueType: "array"},
@@ -43,35 +43,21 @@ func RegisterBuiltinTypes(r *VerbRegistry) error {
 			},
 		},
 		{
-			Type: "exit_update", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE,
+			Type: "exit_update", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE, Source: "builtin",
 			MetadataKeys: []MetadataKey{{Key: "exits", ValueType: "array"}},
 		},
-		{Type: "object_create", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE},
-		{Type: "object_destroy", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE},
+		{Type: "object_create", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE, Source: "builtin"},
+		{Type: "object_destroy", Category: "state", Format: "delta", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_STATE, Source: "builtin"},
 
 		// Command
-		{Type: "command_response", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "command_error", Category: "command", Format: "error", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "object_use", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "object_examine", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-		{Type: "object_give", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
+		{Type: "command_response", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "command_error", Category: "command", Format: "error", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "object_use", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "object_examine", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
+		{Type: "object_give", Category: "command", Format: "narrative", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
 
 		// System
-		{Type: "system", Category: "system", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL},
-
-		// Channel types (future use, registered now)
-		{
-			Type: "channel_say", Category: "communication", Format: "speech", Label: "says", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
-			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
-		},
-		{
-			Type: "channel_pose", Category: "communication", Format: "action", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
-			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
-		},
-		{
-			Type: "channel_system", Category: "system", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL,
-			MetadataKeys: []MetadataKey{{Key: "channel", ValueType: "string", Description: "Channel name"}},
-		},
+		{Type: "system", Category: "system", Format: "notification", DisplayTarget: webv1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "builtin"},
 	}
 
 	for _, b := range builtins {

--- a/internal/core/registry.go
+++ b/internal/core/registry.go
@@ -19,6 +19,7 @@ type VerbRegistration struct {
 	Label         string // "says", "telepathically sends" -- required when Format is "speech"
 	DisplayTarget webv1.EventChannel
 	MetadataKeys  []MetadataKey
+	Source        string // "builtin" or plugin name -- tracks ownership for unload
 }
 
 // MetadataKey declares a well-known metadata field for an event type.
@@ -85,4 +86,30 @@ func (r *VerbRegistry) All() []VerbRegistration {
 		result = append(result, reg)
 	}
 	return result
+}
+
+// Unregister removes a single verb by event type. Returns true if found.
+func (r *VerbRegistry) Unregister(eventType string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.types[eventType]; !exists {
+		return false
+	}
+	delete(r.types, eventType)
+	return true
+}
+
+// UnregisterBySource removes all verbs registered by a given source.
+// Returns the count of removed entries.
+func (r *VerbRegistry) UnregisterBySource(source string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for key, reg := range r.types {
+		if reg.Source == source {
+			delete(r.types, key)
+			count++
+		}
+	}
+	return count
 }

--- a/internal/core/registry_test.go
+++ b/internal/core/registry_test.go
@@ -109,6 +109,67 @@ func TestVerbRegistryConcurrentAccessIsSafe(t *testing.T) {
 	}
 }
 
+func TestVerbRegistrySourceFieldPreservedThroughRegisterLookup(t *testing.T) {
+	r := NewVerbRegistry()
+	err := r.Register(VerbRegistration{
+		Type: "custom", Category: "communication", Format: "action", Source: "my-plugin",
+	})
+	require.NoError(t, err)
+
+	reg, ok := r.Lookup("custom")
+	require.True(t, ok)
+	assert.Equal(t, "my-plugin", reg.Source)
+}
+
+func TestVerbRegistryUnregisterRemovesEntry(t *testing.T) {
+	r := NewVerbRegistry()
+	err := r.Register(VerbRegistration{
+		Type: "temp", Category: "system", Format: "notification", Source: "test",
+	})
+	require.NoError(t, err)
+
+	removed := r.Unregister("temp")
+	assert.True(t, removed)
+
+	_, ok := r.Lookup("temp")
+	assert.False(t, ok)
+}
+
+func TestVerbRegistryUnregisterNonexistentReturnsFalse(t *testing.T) {
+	r := NewVerbRegistry()
+	removed := r.Unregister("nonexistent")
+	assert.False(t, removed)
+}
+
+func TestVerbRegistryUnregisterBySourceRemovesAllFromSource(t *testing.T) {
+	r := NewVerbRegistry()
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "a", Category: "communication", Format: "action", Source: "plugin-x",
+	}))
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "b", Category: "system", Format: "notification", Source: "plugin-x",
+	}))
+	require.NoError(t, r.Register(VerbRegistration{
+		Type: "c", Category: "command", Format: "narrative", Source: "builtin",
+	}))
+
+	count := r.UnregisterBySource("plugin-x")
+	assert.Equal(t, 2, count)
+
+	_, ok := r.Lookup("a")
+	assert.False(t, ok)
+	_, ok = r.Lookup("b")
+	assert.False(t, ok)
+	_, ok = r.Lookup("c")
+	assert.True(t, ok)
+}
+
+func TestVerbRegistryUnregisterBySourceUnknownReturnsZero(t *testing.T) {
+	r := NewVerbRegistry()
+	count := r.UnregisterBySource("nonexistent")
+	assert.Equal(t, 0, count)
+}
+
 func TestRegisterBuiltinTypesRegistersAllKnownEventTypes(t *testing.T) {
 	r := NewVerbRegistry()
 	err := RegisterBuiltinTypes(r)
@@ -132,4 +193,16 @@ func TestRegisterBuiltinTypesRegistersAllKnownEventTypes(t *testing.T) {
 
 	_, ok = r.Lookup("location_state")
 	assert.True(t, ok)
+}
+
+func TestRegisterBuiltinTypesDoesNotIncludeChannelTypes(t *testing.T) {
+	r := NewVerbRegistry()
+	err := RegisterBuiltinTypes(r)
+	require.NoError(t, err)
+
+	channelTypes := []string{"channel_say", "channel_pose", "channel_system"}
+	for _, ct := range channelTypes {
+		_, ok := r.Lookup(ct)
+		assert.False(t, ok, "builtin registry should not include %s", ct)
+	}
 }

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+	webv1 "github.com/holomush/holomush/pkg/proto/holomush/web/v1"
 )
 
 // RegisterPluginProviderFunc is a callback that registers a PluginAttributeProvider
@@ -62,6 +63,7 @@ type Manager struct {
 	gracefulDegradation bool                         // if true, LoadAll continues despite plugin failures
 	aliasSeeder         AliasSeeder
 	aliasCache          *command.AliasCache
+	verbRegistry        *core.VerbRegistry
 	eventEmitter        *PluginEventEmitter
 	loaded              map[string]*DiscoveredPlugin
 	inflight            map[string]*DiscoveredPlugin
@@ -143,6 +145,13 @@ func WithTrustAllowlist(names []string) ManagerOption {
 func WithGracefulDegradation() ManagerOption {
 	return func(m *Manager) {
 		m.gracefulDegradation = true
+	}
+}
+
+// WithVerbRegistry sets the VerbRegistry for plugin verb registration.
+func WithVerbRegistry(reg *core.VerbRegistry) ManagerOption {
+	return func(m *Manager) {
+		m.verbRegistry = reg
 	}
 }
 
@@ -667,6 +676,31 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 		}
 	}
 
+	// Register plugin-declared verbs in the VerbRegistry.
+	if m.verbRegistry != nil && len(dp.Manifest.Verbs) > 0 {
+		for _, vs := range dp.Manifest.Verbs {
+			regErr := m.verbRegistry.Register(core.VerbRegistration{
+				Type:          vs.Type,
+				Category:      vs.Category,
+				Format:        vs.Format,
+				Label:         vs.Label,
+				DisplayTarget: displayTargetFromString(vs.DisplayTarget),
+				Source:        dp.Manifest.Name,
+			})
+			if regErr != nil {
+				// Clean up any verbs already registered from this plugin.
+				m.verbRegistry.UnregisterBySource(dp.Manifest.Name)
+				m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
+				if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
+					slog.Error("failed to rollback plugin load after verb registration failure",
+						"plugin", dp.Manifest.Name, "error", unloadErr)
+				}
+				return oops.In("manager").With("plugin", dp.Manifest.Name).
+					With("verb", vs.Type).Wrapf(regErr, "register plugin verb")
+			}
+		}
+	}
+
 	// Register plugin-provided services in the service registry.
 	// Registration failures are treated as hard errors — dependents resolved
 	// by ResolveDependencyOrder rely on the Provides contract being satisfied.
@@ -1036,5 +1070,21 @@ func (m *Manager) RegisterPluginCommands(registry *command.Registry) {
 					"error", regErr)
 			}
 		}
+	}
+}
+
+// displayTargetFromString converts a manifest display_target string to the
+// proto enum. Returns EVENT_CHANNEL_UNSPECIFIED for unknown values (validation
+// should catch these before this is called).
+func displayTargetFromString(s string) webv1.EventChannel {
+	switch strings.ToLower(s) {
+	case "terminal":
+		return webv1.EventChannel_EVENT_CHANNEL_TERMINAL
+	case "state":
+		return webv1.EventChannel_EVENT_CHANNEL_STATE
+	case "both":
+		return webv1.EventChannel_EVENT_CHANNEL_BOTH
+	default:
+		return webv1.EventChannel_EVENT_CHANNEL_UNSPECIFIED
 	}
 }

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/holomush/holomush/internal/access/policy/attribute"
 	"github.com/holomush/holomush/internal/command"
+	"github.com/holomush/holomush/internal/core"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
 	"github.com/holomush/holomush/internal/plugin/mocks"
@@ -1559,4 +1560,175 @@ func TestManagerQuerySessionStreamsReturnsEarlyOnContextCancellation(t *testing.
 	})
 	// Should return empty/partial results instead of blocking
 	assert.Empty(t, result)
+}
+
+func TestManagerLoadAllRegistersVerbsFromManifest(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	echoDir := filepath.Join(pluginsDir, "chat-plugin")
+	mkdirAll(t, echoDir)
+	manifest := `name: chat-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: whisper
+    category: communication
+    format: speech
+    label: whispers to
+    display_target: terminal
+  - type: shout
+    category: communication
+    format: speech
+    label: shouts
+    display_target: both
+lua-plugin:
+  entry: main.lua`
+	writeFile(t, filepath.Join(echoDir, "plugin.yaml"), []byte(manifest))
+	writeFile(t, filepath.Join(echoDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	reg := core.NewVerbRegistry()
+	mgr := plugins.NewManager(pluginsDir,
+		plugins.WithLuaHost(luaHost),
+		plugins.WithVerbRegistry(reg),
+	)
+	require.NoError(t, mgr.LoadAll(context.Background()))
+
+	whisper, ok := reg.Lookup("whisper")
+	require.True(t, ok, "whisper verb should be registered")
+	assert.Equal(t, "communication", whisper.Category)
+	assert.Equal(t, "speech", whisper.Format)
+	assert.Equal(t, "whispers to", whisper.Label)
+	assert.Equal(t, "chat-plugin", whisper.Source)
+
+	shout, ok := reg.Lookup("shout")
+	require.True(t, ok, "shout verb should be registered")
+	assert.Equal(t, "chat-plugin", shout.Source)
+}
+
+func TestManagerLoadAllRejectsPluginWithDuplicateVerbType(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	plugDir := filepath.Join(pluginsDir, "dup-plugin")
+	mkdirAll(t, plugDir)
+	manifest := `name: dup-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: existing_verb
+    category: communication
+    format: action
+    display_target: terminal
+lua-plugin:
+  entry: main.lua`
+	writeFile(t, filepath.Join(plugDir, "plugin.yaml"), []byte(manifest))
+	writeFile(t, filepath.Join(plugDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	reg := core.NewVerbRegistry()
+	// Pre-register a verb that the plugin also declares.
+	require.NoError(t, reg.Register(core.VerbRegistration{
+		Type:     "existing_verb",
+		Category: "state",
+		Format:   "snapshot",
+		Source:   "builtin",
+	}))
+
+	mgr := plugins.NewManager(pluginsDir,
+		plugins.WithLuaHost(luaHost),
+		plugins.WithVerbRegistry(reg),
+	)
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "register plugin verb")
+	errutil.AssertErrorCode(t, err, "DUPLICATE_REGISTRATION")
+}
+
+func TestManagerLoadAllCleansUpVerbsOnPartialFailure(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	plugDir := filepath.Join(pluginsDir, "partial-plugin")
+	mkdirAll(t, plugDir)
+	manifest := `name: partial-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: good_verb
+    category: communication
+    format: action
+    display_target: terminal
+  - type: conflict
+    category: state
+    format: snapshot
+    display_target: state
+lua-plugin:
+  entry: main.lua`
+	writeFile(t, filepath.Join(plugDir, "plugin.yaml"), []byte(manifest))
+	writeFile(t, filepath.Join(plugDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	reg := core.NewVerbRegistry()
+	// Pre-register the conflict verb so the second registration fails.
+	require.NoError(t, reg.Register(core.VerbRegistration{
+		Type:     "conflict",
+		Category: "state",
+		Format:   "snapshot",
+		Source:   "builtin",
+	}))
+
+	mgr := plugins.NewManager(pluginsDir,
+		plugins.WithLuaHost(luaHost),
+		plugins.WithVerbRegistry(reg),
+	)
+	err := mgr.LoadAll(context.Background())
+	require.Error(t, err)
+
+	// good_verb should have been cleaned up via UnregisterBySource.
+	_, ok := reg.Lookup("good_verb")
+	assert.False(t, ok, "good_verb should have been cleaned up after partial failure")
+
+	// The pre-existing conflict verb should remain (owned by builtin, not the plugin).
+	conflict, ok := reg.Lookup("conflict")
+	require.True(t, ok, "builtin conflict verb should still exist")
+	assert.Equal(t, "builtin", conflict.Source)
+}
+
+func TestManagerLoadAllWithoutVerbRegistrySkipsVerbRegistration(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+
+	plugDir := filepath.Join(pluginsDir, "verby-plugin")
+	mkdirAll(t, plugDir)
+	manifest := `name: verby-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: some_verb
+    category: communication
+    format: action
+    display_target: terminal
+lua-plugin:
+  entry: main.lua`
+	writeFile(t, filepath.Join(plugDir, "plugin.yaml"), []byte(manifest))
+	writeFile(t, filepath.Join(plugDir, "main.lua"), []byte("function on_event(e) end"))
+
+	luaHost := pluginlua.NewHost()
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	// No WithVerbRegistry — verb registration should be silently skipped.
+	mgr := plugins.NewManager(pluginsDir, plugins.WithLuaHost(luaHost))
+	err := mgr.LoadAll(context.Background())
+	require.NoError(t, err)
+
+	loaded := mgr.ListPlugins()
+	assert.Contains(t, loaded, "verby-plugin")
 }

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -77,6 +77,7 @@ type Manifest struct {
 	Emits          []string          `yaml:"emits,omitempty" json:"emits,omitempty"`
 	Policies       []ManifestPolicy  `yaml:"policies,omitempty" json:"policies,omitempty"`
 	Commands       []CommandSpec     `yaml:"commands,omitempty" json:"commands,omitempty" jsonschema:"description=Commands provided by this plugin"`
+	Verbs          []VerbSpec        `yaml:"verbs,omitempty" json:"verbs,omitempty" jsonschema:"description=Verb registrations contributed by this plugin"`
 	Priority       *LoadPriority     `yaml:"priority,omitempty" json:"priority,omitempty" jsonschema:"description=Load priority (lower loads first)"`
 	SessionStreams bool              `yaml:"session_streams,omitempty" json:"session_streams,omitempty" jsonschema:"description=Plugin contributes streams to session subscriptions via QuerySessionStreams"`
 	LuaPlugin      *LuaConfig        `yaml:"lua-plugin,omitempty" json:"lua-plugin,omitempty"`
@@ -127,6 +128,28 @@ type SettingConfig struct {
 	WorldDir         string `yaml:"world_dir" json:"world_dir"`
 	Theme            string `yaml:"theme" json:"theme"`
 	StartingLocation string `yaml:"starting_location" json:"starting_location"`
+}
+
+// VerbSpec declares a verb registration contributed by a plugin.
+type VerbSpec struct {
+	Type          string `yaml:"type" json:"type" jsonschema:"required"`
+	Category      string `yaml:"category" json:"category" jsonschema:"required"`
+	Format        string `yaml:"format" json:"format" jsonschema:"required"`
+	Label         string `yaml:"label,omitempty" json:"label,omitempty"`
+	DisplayTarget string `yaml:"display_target" json:"display_target" jsonschema:"required"`
+}
+
+var validVerbCategories = map[string]bool{
+	"communication": true, "movement": true, "state": true, "system": true, "command": true,
+}
+
+var validVerbFormats = map[string]bool{
+	"speech": true, "action": true, "narrative": true, "notification": true,
+	"error": true, "snapshot": true, "delta": true,
+}
+
+var validDisplayTargets = map[string]bool{
+	"terminal": true, "state": true, "both": true,
 }
 
 // CommandSpec declares a command provided by a plugin.
@@ -314,6 +337,9 @@ func (m *Manifest) Validate() error {
 		if len(m.Commands) > 0 {
 			return oops.In("manifest").With("name", m.Name).New("setting plugins must not declare commands")
 		}
+		if len(m.Verbs) > 0 {
+			return oops.In("manifest").With("name", m.Name).New("setting plugins must not declare verbs")
+		}
 		if m.LuaPlugin != nil {
 			return oops.In("manifest").With("name", m.Name).New("setting plugins must not specify lua-plugin")
 		}
@@ -370,6 +396,36 @@ func (m *Manifest) Validate() error {
 			return oops.In("manifest").With("plugin", m.Name).With("command", m.Commands[i].Name).New("duplicate command name")
 		}
 		seenCommands[m.Commands[i].Name] = true
+	}
+
+	// Validate verbs and check for duplicates.
+	seenVerbs := make(map[string]bool)
+	for i, v := range m.Verbs {
+		if v.Type == "" {
+			return oops.In("manifest").With("plugin", m.Name).With("verb_index", i).
+				New("verb type must not be empty")
+		}
+		if !validVerbCategories[v.Category] {
+			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				With("category", v.Category).New("unknown verb category")
+		}
+		if !validVerbFormats[v.Format] {
+			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				With("format", v.Format).New("unknown verb format")
+		}
+		if !validDisplayTargets[strings.ToLower(v.DisplayTarget)] {
+			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				With("display_target", v.DisplayTarget).New("unknown verb display_target")
+		}
+		if v.Format == "speech" && v.Label == "" {
+			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				New("label is required when verb format is speech")
+		}
+		if seenVerbs[v.Type] {
+			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				New("duplicate verb type")
+		}
+		seenVerbs[v.Type] = true
 	}
 
 	// Validate provides — only binary plugins can provide services.

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -4,6 +4,7 @@
 package plugins_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -2014,4 +2015,225 @@ setting:
 			}
 		})
 	}
+}
+
+func TestManifestAcceptsLuaPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: speech
+    label: says
+    display_target: terminal
+  - type: channel.pose
+    category: communication
+    format: action
+    display_target: both
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, m.Verbs, 2)
+
+	assert.Equal(t, "channel.say", m.Verbs[0].Type)
+	assert.Equal(t, "communication", m.Verbs[0].Category)
+	assert.Equal(t, "speech", m.Verbs[0].Format)
+	assert.Equal(t, "says", m.Verbs[0].Label)
+	assert.Equal(t, "terminal", m.Verbs[0].DisplayTarget)
+
+	assert.Equal(t, "channel.pose", m.Verbs[1].Type)
+	assert.Equal(t, "action", m.Verbs[1].Format)
+	assert.Equal(t, "both", m.Verbs[1].DisplayTarget)
+}
+
+func TestManifestAcceptsBinaryPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: scenes
+version: 1.0.0
+type: binary
+binary-plugin:
+  executable: scenes
+verbs:
+  - type: scene.narrate
+    category: state
+    format: narrative
+    display_target: terminal
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, m.Verbs, 1)
+	assert.Equal(t, "scene.narrate", m.Verbs[0].Type)
+}
+
+func TestManifestRejectsSettingPluginWithVerbs(t *testing.T) {
+	data := []byte(`
+name: my-setting
+version: 1.0.0
+type: setting
+setting:
+  display_name: My Setting
+  content_dir: content
+  starting_location: start
+verbs:
+  - type: custom.say
+    category: communication
+    format: speech
+    label: says
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting plugins must not declare verbs")
+}
+
+func TestManifestRejectsVerbWithEmptyType(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: ""
+    category: communication
+    format: action
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verb type must not be empty")
+}
+
+func TestManifestRejectsVerbWithUnknownCategory(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: unknown-category
+    format: speech
+    label: says
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb category")
+}
+
+func TestManifestRejectsVerbWithUnknownFormat(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: unknown-format
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb format")
+}
+
+func TestManifestRejectsVerbWithUnknownDisplayTarget(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: action
+    display_target: unknown-target
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown verb display_target")
+}
+
+func TestManifestRejectsSpeechVerbWithoutLabel(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: speech
+    display_target: terminal
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "label is required when verb format is speech")
+}
+
+func TestManifestRejectsDuplicateVerbType(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: action
+    display_target: terminal
+  - type: channel.say
+    category: communication
+    format: narrative
+    display_target: both
+`)
+	_, err := plugins.ParseManifest(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate verb type")
+}
+
+func TestManifestDisplayTargetCaseInsensitive(t *testing.T) {
+	targets := []string{"terminal", "TERMINAL", "Terminal", "state", "STATE", "State", "both", "BOTH", "Both"}
+	for _, target := range targets {
+		t.Run(fmt.Sprintf("accepts display_target %s", target), func(t *testing.T) {
+			data := []byte(fmt.Sprintf(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+verbs:
+  - type: channel.say
+    category: communication
+    format: action
+    display_target: %s
+`, target))
+			_, err := plugins.ParseManifest(data)
+			require.NoError(t, err, "display_target %q should be accepted", target)
+		})
+	}
+}
+
+func TestManifestAcceptsPluginWithNoVerbs(t *testing.T) {
+	data := []byte(`
+name: channels
+version: 1.0.0
+type: lua
+lua-plugin:
+  entry: main.lua
+`)
+	m, err := plugins.ParseManifest(data)
+	require.NoError(t, err)
+	assert.Empty(t, m.Verbs)
 }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -143,6 +143,37 @@
       "type": "array",
       "description": "Commands provided by this plugin"
     },
+    "verbs": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "display_target": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type",
+          "category",
+          "format",
+          "display_target"
+        ]
+      },
+      "type": "array",
+      "description": "Verb registrations contributed by this plugin"
+    },
     "priority": {
       "type": "integer",
       "description": "Load priority (lower loads first)"

--- a/test/integration/plugin/verb_registration_test.go
+++ b/test/integration/plugin/verb_registration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package plugin_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/core"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+)
+
+var _ = Describe("Plugin verb registration", func() {
+	var (
+		pluginsDir string
+		luaHost    *pluginlua.Host
+		verbReg    *core.VerbRegistry
+	)
+
+	BeforeEach(func() {
+		pluginsDir = GinkgoT().TempDir()
+		luaHost = pluginlua.NewHost()
+		verbReg = core.NewVerbRegistry()
+		Expect(core.RegisterBuiltinTypes(verbReg)).To(Succeed())
+		DeferCleanup(func() { _ = luaHost.Close(context.Background()) })
+	})
+
+	writePlugin := func(name, yamlContent, luaContent string) {
+		dir := filepath.Join(pluginsDir, name)
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, "plugin.yaml"), []byte(yamlContent), 0o644)).To(Succeed())
+		if luaContent != "" {
+			Expect(os.WriteFile(filepath.Join(dir, "main.lua"), []byte(luaContent), 0o644)).To(Succeed())
+		}
+	}
+
+	It("registers plugin-declared verbs in the VerbRegistry", func() {
+		writePlugin("verb-plugin", `
+name: verb-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: custom_say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+  - type: custom_action
+    category: communication
+    format: action
+    display_target: both
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		mgr := plugins.NewManager(pluginsDir,
+			plugins.WithLuaHost(luaHost),
+			plugins.WithVerbRegistry(verbReg),
+		)
+		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+
+		reg, ok := verbReg.Lookup("custom_say")
+		Expect(ok).To(BeTrue(), "custom_say should be registered")
+		Expect(reg.Category).To(Equal("communication"))
+		Expect(reg.Format).To(Equal("speech"))
+		Expect(reg.Label).To(Equal("says"))
+		Expect(reg.Source).To(Equal("verb-plugin"))
+
+		reg, ok = verbReg.Lookup("custom_action")
+		Expect(ok).To(BeTrue(), "custom_action should be registered")
+		Expect(reg.Source).To(Equal("verb-plugin"))
+	})
+
+	It("rejects a plugin whose verb type conflicts with a builtin", func() {
+		writePlugin("conflict-plugin", `
+name: conflict-plugin
+version: 1.0.0
+type: lua
+verbs:
+  - type: say
+    category: communication
+    format: speech
+    label: "says"
+    display_target: terminal
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		mgr := plugins.NewManager(pluginsDir,
+			plugins.WithLuaHost(luaHost),
+			plugins.WithVerbRegistry(verbReg),
+		)
+		err := mgr.LoadAll(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("already registered"))
+	})
+
+	It("cleans up verbs when plugin load fails partway through verb list", func() {
+		// Pre-register "conflict" so the second verb in the manifest fails
+		Expect(verbReg.Register(core.VerbRegistration{
+			Type: "conflict", Category: "system", Format: "notification", Source: "pre-existing",
+		})).To(Succeed())
+
+		writePlugin("partial-fail", `
+name: partial-fail
+version: 1.0.0
+type: lua
+verbs:
+  - type: good_verb
+    category: communication
+    format: action
+    display_target: terminal
+  - type: conflict
+    category: system
+    format: notification
+    display_target: terminal
+lua-plugin:
+  entry: main.lua
+`, "function on_event(e) end")
+
+		mgr := plugins.NewManager(pluginsDir,
+			plugins.WithLuaHost(luaHost),
+			plugins.WithVerbRegistry(verbReg),
+		)
+		err := mgr.LoadAll(context.Background())
+		Expect(err).To(HaveOccurred())
+
+		// good_verb should have been cleaned up by UnregisterBySource
+		_, ok := verbReg.Lookup("good_verb")
+		Expect(ok).To(BeFalse(), "good_verb should have been cleaned up after partial failure")
+	})
+})


### PR DESCRIPTION
## Summary

- Enable plugins to declare `verbs:` in their `manifest.yaml` with type, category, format, label, and display_target
- Add `Source` field to `VerbRegistration` for ownership tracking and `Unregister`/`UnregisterBySource` methods for load-failure cleanup and future unload
- Wire `VerbRegistry` into `Manager.loadPlugin()` with full rollback on partial registration failure
- Remove `channel_say`/`channel_pose`/`channel_system` from `builtins.go` — the channel plugin will declare them when created
- Show verb registrations in `plugin info` output
- Integration tests for load cycle, builtin conflict detection, and partial failure cleanup

Closes holomush-6l7l.

## Spec

`docs/superpowers/specs/2026-04-12-plugin-verb-registration-design.md`

## Test plan

- [x] Unit: `VerbRegistry` — Source field, Unregister, UnregisterBySource, concurrent access
- [x] Unit: Manifest parsing — valid verbs, invalid category/format/display_target, speech-without-label, duplicates, settings excluded, case-insensitive display_target
- [x] Unit: Manager — verb registration on load, duplicate rejection, partial failure cleanup, nil registry skip
- [x] Unit: plugin info — shows verbs, omits when empty
- [x] Integration: full load cycle, builtin conflict, cleanup on partial failure
- [x] `task pr-prep` green (lint, format, schema, license, unit, integration, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)