### PR TITLE
feat(focus): FocusCoordinator + ScenePolicy + preference wiring (B4+B6)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -231,7 +231,7 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 		coreServerOpts = append(coreServerOpts, holoGRPC.WithStreamRegistry(s.cfg.StreamRegistry))
 	}
 
-	// 8a. Create FocusCoordinator.
+	// 8a. Create focus.Coordinator.
 	focusCoordOpts := []holoFocus.CoordinatorOption{
 		holoFocus.WithSessionStore(sessionStore),
 		holoFocus.WithEventStore(eventStore),

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -25,6 +25,8 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
 	holoFocus "github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/grpc/focus/scenepolicy"
+	"github.com/holomush/holomush/internal/settings"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/naming"
 	plugins "github.com/holomush/holomush/internal/plugin"
@@ -232,9 +234,16 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	}
 
 	// 8a. Create focus.Coordinator.
+	gameSettings := settings.NewGameSettings(&settings.SystemInfoAdapter{
+		Store:       rawEventStore,
+		NotFoundErr: store.ErrSystemInfoNotFound,
+	})
 	focusCoordOpts := []holoFocus.CoordinatorOption{
 		holoFocus.WithSessionStore(sessionStore),
 		holoFocus.WithEventStore(eventStore),
+		holoFocus.WithKindPolicy(scenepolicy.New()),
+		holoFocus.WithGameSettings(gameSettings),
+		holoFocus.WithPlayerPreferences(holoFocus.NewPlayerPrefsAdapter(authPlayerRepo)),
 	}
 	if s.cfg.StreamRegistry != nil {
 		focusCoordOpts = append(focusCoordOpts,

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/holomush/holomush/internal/content"
 	"github.com/holomush/holomush/internal/core"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
+	holoFocus "github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/naming"
 	plugins "github.com/holomush/holomush/internal/plugin"
@@ -229,6 +230,23 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	if s.cfg.StreamRegistry != nil {
 		coreServerOpts = append(coreServerOpts, holoGRPC.WithStreamRegistry(s.cfg.StreamRegistry))
 	}
+
+	// 8a. Create FocusCoordinator.
+	focusCoordOpts := []holoFocus.CoordinatorOption{
+		holoFocus.WithSessionStore(sessionStore),
+		holoFocus.WithEventStore(eventStore),
+	}
+	if s.cfg.StreamRegistry != nil {
+		focusCoordOpts = append(focusCoordOpts,
+			holoFocus.WithStreamSender(holoGRPC.NewStreamSenderAdapter(s.cfg.StreamRegistry)),
+		)
+	}
+	focusCoord, focusErr := holoFocus.NewCoordinator(focusCoordOpts...)
+	if focusErr != nil {
+		return oops.Code("FOCUS_COORDINATOR_FAILED").Wrap(focusErr)
+	}
+	coreServerOpts = append(coreServerOpts, holoGRPC.WithFocusCoordinator(focusCoord))
+
 	coreServer := holoGRPC.NewCoreServer(engine, sessionStore, cmdDispatcher, cmdServices, coreServerOpts...)
 	corev1.RegisterCoreServiceServer(s.grpcServer, coreServer)
 

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -86,9 +86,19 @@ func NewGuestPlayer(username string) (*Player, error) {
 
 // PlayerPreferences contains player-specific settings.
 type PlayerPreferences struct {
-	AutoLogin     bool   `json:"auto_login,omitempty"`
-	MaxCharacters int    `json:"max_characters,omitempty"`
-	Theme         string `json:"theme,omitempty"`
+	AutoLogin     bool                   `json:"auto_login,omitempty"`
+	MaxCharacters int                    `json:"max_characters,omitempty"`
+	Theme         string                 `json:"theme,omitempty"`
+	Scenes        ScenePlayerPreferences `json:"scenes,omitempty"`
+}
+
+// ScenePlayerPreferences holds scene-related per-player configuration.
+type ScenePlayerPreferences struct {
+	// FocusReplayTail is the number of most recent IC contributions
+	// replayed to the session when it focus-switches into a scene.
+	// Pointer type distinguishes "unset" (nil) from "explicitly 0
+	// (disable catch-up)."
+	FocusReplayTail *int `json:"focus_replay_tail,omitempty"`
 }
 
 // EffectiveMaxCharacters returns the character limit, using default if not set.

--- a/internal/auth/player_test.go
+++ b/internal/auth/player_test.go
@@ -4,6 +4,7 @@
 package auth_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -157,6 +158,41 @@ func TestPlayerPreferences(t *testing.T) {
 		prefs := auth.PlayerPreferences{MaxCharacters: -1}
 		assert.Equal(t, auth.DefaultMaxCharacters, prefs.EffectiveMaxCharacters())
 	})
+}
+
+func TestScenePlayerPreferencesRoundTripsJSON(t *testing.T) {
+	tail := 5
+	prefs := auth.PlayerPreferences{
+		Scenes: auth.ScenePlayerPreferences{FocusReplayTail: &tail},
+	}
+	data, err := json.Marshal(prefs)
+	require.NoError(t, err)
+
+	var decoded auth.PlayerPreferences
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Scenes.FocusReplayTail)
+	assert.Equal(t, 5, *decoded.Scenes.FocusReplayTail)
+}
+
+func TestScenePlayerPreferencesOmitsNilTail(t *testing.T) {
+	prefs := auth.PlayerPreferences{}
+	data, err := json.Marshal(prefs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "focus_replay_tail")
+}
+
+func TestScenePlayerPreferencesExplicitZeroIsPreserved(t *testing.T) {
+	zero := 0
+	prefs := auth.PlayerPreferences{
+		Scenes: auth.ScenePlayerPreferences{FocusReplayTail: &zero},
+	}
+	data, err := json.Marshal(prefs)
+	require.NoError(t, err)
+
+	var decoded auth.PlayerPreferences
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Scenes.FocusReplayTail)
+	assert.Equal(t, 0, *decoded.Scenes.FocusReplayTail)
 }
 
 func TestPlayer_Fields(t *testing.T) {

--- a/internal/grpc/cursor_lock.go
+++ b/internal/grpc/cursor_lock.go
@@ -3,7 +3,11 @@
 
 package grpc
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/holomush/holomush/internal/grpc/focus"
+)
 
 // sessionCursorLock is a per-session mutex with a reference count.
 //
@@ -127,3 +131,21 @@ func (m *cursorLockMap) refCount(sessionID string) int {
 	}
 	return 0
 }
+
+// CursorLockerAdapter wraps cursorLockMap to satisfy focus.CursorLocker.
+type CursorLockerAdapter struct {
+	locks *cursorLockMap
+}
+
+// NewCursorLockerAdapter creates a CursorLockerAdapter.
+func NewCursorLockerAdapter(m *cursorLockMap) *CursorLockerAdapter {
+	return &CursorLockerAdapter{locks: m}
+}
+
+// Lock implements focus.CursorLocker.
+func (a *CursorLockerAdapter) Lock(sessionID string) func() {
+	return a.locks.lock(sessionID)
+}
+
+// Ensure CursorLockerAdapter satisfies the focus.CursorLocker interface at compile time.
+var _ focus.CursorLocker = (*CursorLockerAdapter)(nil)

--- a/internal/grpc/cursor_lock_test.go
+++ b/internal/grpc/cursor_lock_test.go
@@ -486,3 +486,14 @@ func TestSendAndCommitEventSkipsHookWhenNil(t *testing.T) {
 		context.Background(), info, streamName, ev, stream, nil))
 	assert.Equal(t, 0, s.CursorLockRefCount(sessionID))
 }
+
+func TestCursorLockerAdapterLocksAndUnlocks(t *testing.T) {
+	m := newCursorLockMap()
+	adapter := NewCursorLockerAdapter(m)
+
+	unlock := adapter.Lock("sess-1")
+	assert.Equal(t, 1, m.refCount("sess-1"))
+
+	unlock()
+	assert.Equal(t, 0, m.refCount("sess-1"))
+}

--- a/internal/grpc/focus/coordinator.go
+++ b/internal/grpc/focus/coordinator.go
@@ -26,9 +26,9 @@ type CursorLocker interface {
 	Lock(sessionID string) (unlock func())
 }
 
-// FocusCoordinator is the sole authoritative mutator of a session's
+// Coordinator is the sole authoritative mutator of a session's
 // focused-context state.
-type FocusCoordinator interface {
+type Coordinator interface {
 	JoinFocus(ctx context.Context, sessionID string, target session.FocusKey) error
 	LeaveFocus(ctx context.Context, sessionID string, target session.FocusKey) error
 	PresentFocus(ctx context.Context, sessionID string, target session.FocusKey) error
@@ -42,13 +42,13 @@ type RestorePlan struct {
 	PresentingStream string // empty if no presenting focus
 }
 
-// defaultCoordinator is the production FocusCoordinator implementation.
+// defaultCoordinator is the production Coordinator implementation.
 type defaultCoordinator struct {
 	sessionStore session.Store
 	eventStore   core.EventStore
 	streamSender StreamSender
 	cursorLocker CursorLocker
-	policies     map[session.FocusKind]FocusKindPolicy
+	policies     map[session.FocusKind]KindPolicy
 
 	// Settings stores for preference resolution.
 	gameSettings      settings.Settings
@@ -79,8 +79,8 @@ func WithCursorLocker(locker CursorLocker) CoordinatorOption {
 	return func(c *defaultCoordinator) { c.cursorLocker = locker }
 }
 
-// WithKindPolicy registers a FocusKindPolicy for its kind.
-func WithKindPolicy(policy FocusKindPolicy) CoordinatorOption {
+// WithKindPolicy registers a KindPolicy for its kind.
+func WithKindPolicy(policy KindPolicy) CoordinatorOption {
 	return func(c *defaultCoordinator) {
 		c.policies[policy.Kind()] = policy
 	}
@@ -102,9 +102,9 @@ func WithCharacterSettings(cs settings.CharacterSettingsStore) CoordinatorOption
 }
 
 // NewCoordinator constructs a defaultCoordinator. sessionStore is required.
-func NewCoordinator(opts ...CoordinatorOption) (FocusCoordinator, error) {
+func NewCoordinator(opts ...CoordinatorOption) (Coordinator, error) {
 	c := &defaultCoordinator{
-		policies: make(map[session.FocusKind]FocusKindPolicy),
+		policies: make(map[session.FocusKind]KindPolicy),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -115,13 +115,13 @@ func NewCoordinator(opts ...CoordinatorOption) (FocusCoordinator, error) {
 	return c, nil
 }
 
-// policyFor looks up the registered FocusKindPolicy for the given kind.
-func (c *defaultCoordinator) policyFor(kind session.FocusKind) (FocusKindPolicy, error) {
+// policyFor looks up the registered KindPolicy for the given kind.
+func (c *defaultCoordinator) policyFor(kind session.FocusKind) (KindPolicy, error) {
 	p, ok := c.policies[kind]
 	if !ok {
 		return nil, oops.Code("FOCUS_KIND_UNREGISTERED").
 			With("kind", string(kind)).
-			Errorf("no FocusKindPolicy registered for kind %q", kind)
+			Errorf("no KindPolicy registered for kind %q", kind)
 	}
 	return p, nil
 }
@@ -147,8 +147,8 @@ func (c *defaultCoordinator) buildPolicyContext(
 	ctx context.Context,
 	info *session.Info,
 	target session.FocusKey,
-) FocusPolicyContext {
-	pctx := FocusPolicyContext{
+) PolicyContext {
+	pctx := PolicyContext{
 		SessionID:            info.ID,
 		Target:               target,
 		SceneFocusReplayTail: 3, // substrate default

--- a/internal/grpc/focus/coordinator.go
+++ b/internal/grpc/focus/coordinator.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/settings"
+)
+
+// StreamSender delivers stream subscription updates to the live loop.
+// Decouples the coordinator from the concrete SessionStreamRegistry
+// type in internal/grpc (avoiding an import cycle).
+type StreamSender interface {
+	Send(sessionID string, stream string, add bool, mode ReplayMode) error
+}
+
+// CursorLocker provides per-session mutex access for serializing focus
+// transitions against live-loop cursor commits.
+type CursorLocker interface {
+	Lock(sessionID string) (unlock func())
+}
+
+// FocusCoordinator is the sole authoritative mutator of a session's
+// focused-context state.
+type FocusCoordinator interface {
+	JoinFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+	LeaveFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+	PresentFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+	RestoreFocus(ctx context.Context, sessionID string) (RestorePlan, error)
+}
+
+// RestorePlan is the ordered list of streams and their replay modes to
+// apply when a Subscribe handler starts.
+type RestorePlan struct {
+	Streams          []StreamWithMode
+	PresentingStream string // empty if no presenting focus
+}
+
+// defaultCoordinator is the production FocusCoordinator implementation.
+type defaultCoordinator struct {
+	sessionStore session.Store
+	eventStore   core.EventStore
+	streamSender StreamSender
+	cursorLocker CursorLocker
+	policies     map[session.FocusKind]FocusKindPolicy
+
+	// Settings stores for preference resolution.
+	gameSettings      settings.Settings
+	playerSettings    settings.PlayerSettingsStore
+	characterSettings settings.CharacterSettingsStore
+}
+
+// CoordinatorOption configures a defaultCoordinator.
+type CoordinatorOption func(*defaultCoordinator)
+
+// WithSessionStore sets the session store.
+func WithSessionStore(store session.Store) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.sessionStore = store }
+}
+
+// WithEventStore sets the event store.
+func WithEventStore(store core.EventStore) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.eventStore = store }
+}
+
+// WithStreamSender sets the stream sender.
+func WithStreamSender(sender StreamSender) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.streamSender = sender }
+}
+
+// WithCursorLocker sets the cursor locker.
+func WithCursorLocker(locker CursorLocker) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.cursorLocker = locker }
+}
+
+// WithKindPolicy registers a FocusKindPolicy for its kind.
+func WithKindPolicy(policy FocusKindPolicy) CoordinatorOption {
+	return func(c *defaultCoordinator) {
+		c.policies[policy.Kind()] = policy
+	}
+}
+
+// WithGameSettings sets the game-wide settings store.
+func WithGameSettings(gs settings.Settings) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.gameSettings = gs }
+}
+
+// WithPlayerSettings sets the player settings store.
+func WithPlayerSettings(ps settings.PlayerSettingsStore) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.playerSettings = ps }
+}
+
+// WithCharacterSettings sets the character settings store.
+func WithCharacterSettings(cs settings.CharacterSettingsStore) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.characterSettings = cs }
+}
+
+// NewCoordinator constructs a defaultCoordinator. sessionStore is required.
+func NewCoordinator(opts ...CoordinatorOption) (FocusCoordinator, error) {
+	c := &defaultCoordinator{
+		policies: make(map[session.FocusKind]FocusKindPolicy),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	if c.sessionStore == nil {
+		return nil, oops.Errorf("session store is required")
+	}
+	return c, nil
+}
+
+// policyFor looks up the registered FocusKindPolicy for the given kind.
+func (c *defaultCoordinator) policyFor(kind session.FocusKind) (FocusKindPolicy, error) {
+	p, ok := c.policies[kind]
+	if !ok {
+		return nil, oops.Code("FOCUS_KIND_UNREGISTERED").
+			With("kind", string(kind)).
+			Errorf("no FocusKindPolicy registered for kind %q", kind)
+	}
+	return p, nil
+}
+
+// sessionOrError retrieves the session and validates it's not expired.
+func (c *defaultCoordinator) sessionOrError(ctx context.Context, sessionID string) (*session.Info, error) {
+	info, err := c.sessionStore.Get(ctx, sessionID)
+	if err != nil {
+		return nil, oops.Code("SESSION_NOT_FOUND").
+			With("session_id", sessionID).
+			Wrap(err)
+	}
+	if info.Status == session.StatusExpired {
+		return nil, oops.Code("SESSION_EXPIRED").
+			With("session_id", sessionID).
+			Errorf("session %s is expired", sessionID)
+	}
+	return info, nil
+}
+
+// buildPolicyContext resolves preference inputs for the kind policy.
+func (c *defaultCoordinator) buildPolicyContext(
+	ctx context.Context,
+	info *session.Info,
+	target session.FocusKey,
+) FocusPolicyContext {
+	pctx := FocusPolicyContext{
+		SessionID:            info.ID,
+		Target:               target,
+		SceneFocusReplayTail: 3, // substrate default
+	}
+
+	var scopes []settings.Settings
+	if c.characterSettings != nil {
+		scopes = append(scopes, c.characterSettings.For(ctx, info.CharacterID))
+	}
+	if c.playerSettings != nil {
+		scopes = append(scopes, c.playerSettings.For(ctx, info.PlayerID))
+	}
+	if c.gameSettings != nil {
+		scopes = append(scopes, c.gameSettings)
+	}
+	if len(scopes) > 0 {
+		chain := settings.NewChain(scopes...)
+		if tail, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default"); ok {
+			pctx.SceneFocusReplayTail = clamp(tail, 0, 10)
+		}
+	}
+
+	return pctx
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/internal/grpc/focus/coordinator.go
+++ b/internal/grpc/focus/coordinator.go
@@ -6,12 +6,19 @@ package focus
 import (
 	"context"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/settings"
 )
+
+// PlayerPreferencesReader provides read access to player preferences.
+// Narrow interface to decouple from the full auth.PlayerRepository.
+type PlayerPreferencesReader interface {
+	SceneFocusReplayTail(ctx context.Context, playerID ulid.ULID) *int
+}
 
 // StreamSender delivers stream subscription updates to the live loop.
 // Decouples the coordinator from the concrete SessionStreamRegistry
@@ -54,6 +61,9 @@ type defaultCoordinator struct {
 	gameSettings      settings.Settings
 	playerSettings    settings.PlayerSettingsStore
 	characterSettings settings.CharacterSettingsStore
+
+	// Typed player preference reader (highest precedence in resolution).
+	playerPrefs PlayerPreferencesReader
 }
 
 // CoordinatorOption configures a defaultCoordinator.
@@ -99,6 +109,11 @@ func WithPlayerSettings(ps settings.PlayerSettingsStore) CoordinatorOption {
 // WithCharacterSettings sets the character settings store.
 func WithCharacterSettings(cs settings.CharacterSettingsStore) CoordinatorOption {
 	return func(c *defaultCoordinator) { c.characterSettings = cs }
+}
+
+// WithPlayerPreferences sets the player preference reader.
+func WithPlayerPreferences(pr PlayerPreferencesReader) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.playerPrefs = pr }
 }
 
 // NewCoordinator constructs a defaultCoordinator. sessionStore is required.
@@ -168,6 +183,13 @@ func (c *defaultCoordinator) buildPolicyContext(
 		chain := settings.NewChain(scopes...)
 		if tail, ok := chain.IntN(ctx, "scenes.focus.replay_tail_default"); ok {
 			pctx.SceneFocusReplayTail = clamp(tail, 0, 10)
+		}
+	}
+
+	// Layer 2: typed player preference override (highest precedence).
+	if c.playerPrefs != nil {
+		if tail := c.playerPrefs.SceneFocusReplayTail(ctx, info.PlayerID); tail != nil {
+			pctx.SceneFocusReplayTail = clamp(*tail, 0, 10)
 		}
 	}
 

--- a/internal/grpc/focus/coordinator_test.go
+++ b/internal/grpc/focus/coordinator_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/holomush/holomush/internal/session"
 )
 
-// stubPolicy is a test FocusKindPolicy that returns configurable streams.
+// stubPolicy is a test KindPolicy that returns configurable streams.
 type stubPolicy struct {
 	kind      session.FocusKind
 	streams   []string
@@ -24,8 +24,8 @@ type stubPolicy struct {
 
 func (p *stubPolicy) Kind() session.FocusKind                               { return p.kind }
 func (p *stubPolicy) StreamsFor(_ session.FocusKey) []string                { return p.streams }
-func (p *stubPolicy) OnJoin(_ FocusPolicyContext) ([]StreamWithMode, error) { return p.onJoin, p.onJoinErr }
-func (p *stubPolicy) OnRestore(_ FocusPolicyContext) ([]StreamWithMode, error) {
+func (p *stubPolicy) OnJoin(_ PolicyContext) ([]StreamWithMode, error) { return p.onJoin, p.onJoinErr }
+func (p *stubPolicy) OnRestore(_ PolicyContext) ([]StreamWithMode, error) {
 	return p.onRestore, nil
 }
 
@@ -46,7 +46,7 @@ func (s *capturingSender) Send(sessionID, stream string, add bool, mode ReplayMo
 	return nil
 }
 
-func newTestCoordinator(t *testing.T, sessions map[string]*session.Info, policies ...FocusKindPolicy) (*defaultCoordinator, *capturingSender) {
+func newTestCoordinator(t *testing.T, sessions map[string]*session.Info, policies ...KindPolicy) (*defaultCoordinator, *capturingSender) {
 	t.Helper()
 	store := session.NewMemStore()
 	ctx := context.Background()
@@ -57,10 +57,8 @@ func newTestCoordinator(t *testing.T, sessions map[string]*session.Info, policie
 		require.NoError(t, store.Set(ctx, id, info))
 	}
 	sender := &capturingSender{}
-	opts := []CoordinatorOption{
-		WithSessionStore(store),
-		WithStreamSender(sender),
-	}
+	opts := make([]CoordinatorOption, 0, 2+len(policies))
+	opts = append(opts, WithSessionStore(store), WithStreamSender(sender))
 	for _, p := range policies {
 		opts = append(opts, WithKindPolicy(p))
 	}

--- a/internal/grpc/focus/coordinator_test.go
+++ b/internal/grpc/focus/coordinator_test.go
@@ -80,6 +80,23 @@ func TestNewCoordinatorFailsWithoutSessionStore(t *testing.T) {
 	assert.Contains(t, err.Error(), "session store")
 }
 
+func TestNewCoordinatorAcceptsAllOptions(t *testing.T) {
+	store := session.NewMemStore()
+	sender := &capturingSender{}
+	coord, err := NewCoordinator(
+		WithSessionStore(store),
+		WithStreamSender(sender),
+		WithCursorLocker(nil),
+		WithGameSettings(nil),
+		WithPlayerSettings(nil),
+		WithCharacterSettings(nil),
+		WithPlayerPreferences(nil),
+		WithKindPolicy(NewNullPolicy(session.FocusKindScene)),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, coord)
+}
+
 func TestNewCoordinatorRegistersKindPolicy(t *testing.T) {
 	store := session.NewMemStore()
 	null := NewNullPolicy(session.FocusKindScene)

--- a/internal/grpc/focus/coordinator_test.go
+++ b/internal/grpc/focus/coordinator_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// stubPolicy is a test FocusKindPolicy that returns configurable streams.
+type stubPolicy struct {
+	kind      session.FocusKind
+	streams   []string
+	onJoin    []StreamWithMode
+	onJoinErr error
+	onRestore []StreamWithMode
+}
+
+func (p *stubPolicy) Kind() session.FocusKind                               { return p.kind }
+func (p *stubPolicy) StreamsFor(_ session.FocusKey) []string                { return p.streams }
+func (p *stubPolicy) OnJoin(_ FocusPolicyContext) ([]StreamWithMode, error) { return p.onJoin, p.onJoinErr }
+func (p *stubPolicy) OnRestore(_ FocusPolicyContext) ([]StreamWithMode, error) {
+	return p.onRestore, nil
+}
+
+// capturingSender records all Send calls for assertion.
+type capturingSender struct {
+	calls []sendCall
+}
+
+type sendCall struct {
+	sessionID string
+	stream    string
+	add       bool
+	mode      ReplayMode
+}
+
+func (s *capturingSender) Send(sessionID, stream string, add bool, mode ReplayMode) error {
+	s.calls = append(s.calls, sendCall{sessionID, stream, add, mode})
+	return nil
+}
+
+func newTestCoordinator(t *testing.T, sessions map[string]*session.Info, policies ...FocusKindPolicy) (*defaultCoordinator, *capturingSender) {
+	t.Helper()
+	store := session.NewMemStore()
+	ctx := context.Background()
+	for id, info := range sessions {
+		if info.ID == "" {
+			info.ID = id
+		}
+		require.NoError(t, store.Set(ctx, id, info))
+	}
+	sender := &capturingSender{}
+	opts := []CoordinatorOption{
+		WithSessionStore(store),
+		WithStreamSender(sender),
+	}
+	for _, p := range policies {
+		opts = append(opts, WithKindPolicy(p))
+	}
+	coord, err := NewCoordinator(opts...)
+	require.NoError(t, err)
+	return coord.(*defaultCoordinator), sender
+}
+
+func TestNewCoordinatorSucceedsWithRequiredDeps(t *testing.T) {
+	store := session.NewMemStore()
+	coord, err := NewCoordinator(WithSessionStore(store))
+	require.NoError(t, err)
+	assert.NotNil(t, coord)
+}
+
+func TestNewCoordinatorFailsWithoutSessionStore(t *testing.T) {
+	_, err := NewCoordinator()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session store")
+}
+
+func TestNewCoordinatorRegistersKindPolicy(t *testing.T) {
+	store := session.NewMemStore()
+	null := NewNullPolicy(session.FocusKindScene)
+	coord, err := NewCoordinator(WithSessionStore(store), WithKindPolicy(null))
+	require.NoError(t, err)
+	dc := coord.(*defaultCoordinator)
+	policy, ok := dc.policies[session.FocusKindScene]
+	assert.True(t, ok)
+	assert.Equal(t, session.FocusKindScene, policy.Kind())
+}

--- a/internal/grpc/focus/join.go
+++ b/internal/grpc/focus/join.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// JoinFocus adds a new focus membership to the session and applies the
+// kind-specific join policy.
+func (c *defaultCoordinator) JoinFocus(ctx context.Context, sessionID string, target session.FocusKey) error {
+	info, err := c.sessionOrError(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+
+	policy, err := c.policyFor(target.Kind)
+	if err != nil {
+		return err
+	}
+
+	pctx := c.buildPolicyContext(ctx, info, target)
+
+	joinStreams, err := policy.OnJoin(pctx)
+	if err != nil {
+		return oops.Code("FOCUS_POLICY_FAILED").With("kind", string(target.Kind)).Wrap(err)
+	}
+
+	now := time.Now().UTC()
+	mutErr := c.sessionStore.UpdateFocusMemberships(ctx, sessionID, session.NewFocusMutator(
+		func(current []session.FocusMembership, presenting *session.FocusKey) ([]session.FocusMembership, *session.FocusKey, error) {
+			for _, m := range current {
+				if m.Kind == target.Kind && m.TargetID == target.TargetID {
+					return nil, nil, oops.Code("FOCUS_ALREADY_MEMBER").
+						Errorf("session %s already has membership for %s:%s", sessionID, target.Kind, target.TargetID)
+				}
+			}
+			next := append(current, session.FocusMembership{Kind: target.Kind, TargetID: target.TargetID, JoinedAt: now})
+			return next, presenting, nil
+		},
+	))
+	if mutErr != nil {
+		return mutErr
+	}
+
+	if c.streamSender != nil {
+		for _, sw := range joinStreams {
+			_ = c.streamSender.Send(sessionID, sw.Stream, true, sw.Mode)
+		}
+	}
+
+	return nil
+}

--- a/internal/grpc/focus/join.go
+++ b/internal/grpc/focus/join.go
@@ -41,17 +41,17 @@ func (c *defaultCoordinator) JoinFocus(ctx context.Context, sessionID string, ta
 						Errorf("session %s already has membership for %s:%s", sessionID, target.Kind, target.TargetID)
 				}
 			}
-			next := append(current, session.FocusMembership{Kind: target.Kind, TargetID: target.TargetID, JoinedAt: now})
-			return next, presenting, nil
+			current = append(current, session.FocusMembership{Kind: target.Kind, TargetID: target.TargetID, JoinedAt: now})
+			return current, presenting, nil
 		},
 	))
 	if mutErr != nil {
-		return mutErr
+		return oops.With("session_id", sessionID).Wrap(mutErr)
 	}
 
 	if c.streamSender != nil {
 		for _, sw := range joinStreams {
-			_ = c.streamSender.Send(sessionID, sw.Stream, true, sw.Mode)
+			_ = c.streamSender.Send(sessionID, sw.Stream, true, sw.Mode) //nolint:errcheck // best-effort: SESSION_NOT_FOUND means no live subscriber
 		}
 	}
 

--- a/internal/grpc/focus/join_test.go
+++ b/internal/grpc/focus/join_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestJoinFocusAddsMembershipAndSendsStreams(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+	policy := &stubPolicy{
+		kind:    session.FocusKindScene,
+		streams: []string{"scene:" + targetID.String() + ":ic"},
+		onJoin: []StreamWithMode{
+			{Stream: "scene:" + targetID.String() + ":ic", Mode: ReplayModeFromCursor},
+			{Stream: "scene:" + targetID.String() + ":ooc", Mode: ReplayModeLiveOnly},
+		},
+	}
+
+	coord, sender := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {Status: session.StatusActive},
+		},
+		policy,
+	)
+
+	err := coord.JoinFocus(context.Background(), "sess-1", target)
+	require.NoError(t, err)
+
+	// Verify membership was persisted.
+	info, getErr := coord.sessionStore.Get(context.Background(), "sess-1")
+	require.NoError(t, getErr)
+	require.Len(t, info.FocusMemberships, 1)
+	assert.Equal(t, session.FocusKindScene, info.FocusMemberships[0].Kind)
+	assert.Equal(t, targetID, info.FocusMemberships[0].TargetID)
+
+	// Verify streams were sent.
+	require.Len(t, sender.calls, 2)
+	assert.Equal(t, "sess-1", sender.calls[0].sessionID)
+	assert.True(t, sender.calls[0].add)
+	assert.Equal(t, ReplayModeFromCursor, sender.calls[0].mode)
+	assert.Equal(t, "sess-1", sender.calls[1].sessionID)
+	assert.True(t, sender.calls[1].add)
+	assert.Equal(t, ReplayModeLiveOnly, sender.calls[1].mode)
+}
+
+func TestJoinFocusRejectsDuplicateMembership(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {
+				Status: session.StatusActive,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+			},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.JoinFocus(context.Background(), "sess-1", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "FOCUS_ALREADY_MEMBER")
+}
+
+func TestJoinFocusRejectsExpiredSession(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-expired": {Status: session.StatusExpired},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.JoinFocus(context.Background(), "sess-expired", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_EXPIRED")
+}
+
+func TestJoinFocusRejectsUnregisteredKind(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	// No policies registered.
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {Status: session.StatusActive},
+		},
+	)
+
+	err := coord.JoinFocus(context.Background(), "sess-1", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "FOCUS_KIND_UNREGISTERED")
+}
+
+func TestJoinFocusRejectsNotFoundSession(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t, map[string]*session.Info{},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.JoinFocus(context.Background(), "nonexistent", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_NOT_FOUND")
+}

--- a/internal/grpc/focus/kind_policy.go
+++ b/internal/grpc/focus/kind_policy.go
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-// Package focus implements the FocusCoordinator — the sole authoritative
+// Package focus implements the Coordinator — the sole authoritative
 // mutator of a session's focused-context state. It encapsulates transition
 // semantics (join, leave, present, restore) and dispatches per-kind replay
-// policy to FocusKindPolicy implementations.
+// policy to KindPolicy implementations.
 //
 // ReplayMode is defined here (not in the parent internal/grpc package)
 // because the dependency graph is grpc → focus. Defining the type in the
@@ -62,10 +62,10 @@ type StreamWithMode struct {
 	NotBefore time.Time // for ReplayModeBoundedTail
 }
 
-// FocusPolicyContext carries the preference-resolved inputs a kind policy
+// PolicyContext carries the preference-resolved inputs a kind policy
 // needs. Constructed by the coordinator before dispatching to the policy,
 // so the policy remains stateless and test-pure.
-type FocusPolicyContext struct {
+type PolicyContext struct {
 	SessionID string
 	Target    session.FocusKey
 
@@ -75,14 +75,14 @@ type FocusPolicyContext struct {
 	SceneFocusReplayTail int
 }
 
-// FocusKindPolicy encapsulates the per-kind replay policy for a focused
+// KindPolicy encapsulates the per-kind replay policy for a focused
 // context. Implementations MUST be stateless (invariant I-9). Instances
 // are registered in the coordinator constructor keyed by FocusKind.
 //
-// Implementations are pure functions: they take inputs from FocusPolicyContext
+// Implementations are pure functions: they take inputs from PolicyContext
 // and return decisions as StreamWithMode values. No side effects, no store
 // access, no registry access.
-type FocusKindPolicy interface {
+type KindPolicy interface {
 	// Kind returns the FocusKind this policy handles.
 	Kind() session.FocusKind
 
@@ -93,14 +93,14 @@ type FocusKindPolicy interface {
 
 	// OnJoin returns the per-stream replay policy to apply when the
 	// membership is first created.
-	OnJoin(pctx FocusPolicyContext) ([]StreamWithMode, error)
+	OnJoin(pctx PolicyContext) ([]StreamWithMode, error)
 
 	// OnRestore returns the per-stream replay policy to apply when the
 	// membership is restored on reconnect.
-	OnRestore(pctx FocusPolicyContext) ([]StreamWithMode, error)
+	OnRestore(pctx PolicyContext) ([]StreamWithMode, error)
 }
 
-// NullPolicy is a bootstrapping FocusKindPolicy that returns empty streams
+// NullPolicy is a bootstrapping KindPolicy that returns empty streams
 // for all operations. It allows the coordinator to construct and pass tests
 // before real kind policies (ScenePolicy) are registered.
 type NullPolicy struct {
@@ -119,7 +119,7 @@ func (p *NullPolicy) Kind() session.FocusKind { return p.kind }
 func (p *NullPolicy) StreamsFor(_ session.FocusKey) []string { return nil }
 
 // OnJoin returns nil — no replay for null policy.
-func (p *NullPolicy) OnJoin(_ FocusPolicyContext) ([]StreamWithMode, error) { return nil, nil }
+func (p *NullPolicy) OnJoin(_ PolicyContext) ([]StreamWithMode, error) { return nil, nil }
 
 // OnRestore returns nil — no replay for null policy.
-func (p *NullPolicy) OnRestore(_ FocusPolicyContext) ([]StreamWithMode, error) { return nil, nil }
+func (p *NullPolicy) OnRestore(_ PolicyContext) ([]StreamWithMode, error) { return nil, nil }

--- a/internal/grpc/focus/kind_policy.go
+++ b/internal/grpc/focus/kind_policy.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package focus implements the FocusCoordinator — the sole authoritative
+// mutator of a session's focused-context state. It encapsulates transition
+// semantics (join, leave, present, restore) and dispatches per-kind replay
+// policy to FocusKindPolicy implementations.
+//
+// ReplayMode is defined here (not in the parent internal/grpc package)
+// because the dependency graph is grpc → focus. Defining the type in the
+// lower-level package that produces replay decisions avoids duplication
+// and lets grpc use focus.ReplayMode directly.
+package focus
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// ReplayMode controls how the live loop replays events when processing a
+// stream addition. The coordinator and kind policies produce ReplayMode
+// values; the live loop in internal/grpc consumes them.
+type ReplayMode int
+
+const (
+	// ReplayModeFromCursor replays from the stored per-stream cursor in
+	// session.Info.EventCursors, or from ULID zero if no cursor is set.
+	ReplayModeFromCursor ReplayMode = iota
+
+	// ReplayModeBoundedTail replays the most recent TailCount events on
+	// the stream (optionally bounded by NotBefore), then advances the
+	// cursor to the tail. Used by scene focus-switch IC catch-up.
+	ReplayModeBoundedTail
+
+	// ReplayModeLiveOnly advances the cursor to the current stream tail
+	// without replaying anything. Used by channels for mid-session joins.
+	ReplayModeLiveOnly
+)
+
+// String returns a human-readable name for the replay mode.
+func (m ReplayMode) String() string {
+	switch m {
+	case ReplayModeFromCursor:
+		return "from_cursor"
+	case ReplayModeBoundedTail:
+		return "bounded_tail"
+	case ReplayModeLiveOnly:
+		return "live_only"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}
+
+// StreamWithMode pairs a stream name with its replay mode and optional
+// mode-specific parameters.
+type StreamWithMode struct {
+	Stream    string
+	Mode      ReplayMode
+	TailCount int       // for ReplayModeBoundedTail
+	NotBefore time.Time // for ReplayModeBoundedTail
+}
+
+// FocusPolicyContext carries the preference-resolved inputs a kind policy
+// needs. Constructed by the coordinator before dispatching to the policy,
+// so the policy remains stateless and test-pure.
+type FocusPolicyContext struct {
+	SessionID string
+	Target    session.FocusKey
+
+	// SceneFocusReplayTail is the number of most recent IC contributions
+	// replayed on focus-switch into a scene. Resolved by the coordinator
+	// from the settings.Chain before calling the policy.
+	SceneFocusReplayTail int
+}
+
+// FocusKindPolicy encapsulates the per-kind replay policy for a focused
+// context. Implementations MUST be stateless (invariant I-9). Instances
+// are registered in the coordinator constructor keyed by FocusKind.
+//
+// Implementations are pure functions: they take inputs from FocusPolicyContext
+// and return decisions as StreamWithMode values. No side effects, no store
+// access, no registry access.
+type FocusKindPolicy interface {
+	// Kind returns the FocusKind this policy handles.
+	Kind() session.FocusKind
+
+	// StreamsFor derives the stream names a membership of this kind implies
+	// for a given target. Return order matters — the first stream is the
+	// "primary" used for PresentingFocus default resolution.
+	StreamsFor(target session.FocusKey) []string
+
+	// OnJoin returns the per-stream replay policy to apply when the
+	// membership is first created.
+	OnJoin(pctx FocusPolicyContext) ([]StreamWithMode, error)
+
+	// OnRestore returns the per-stream replay policy to apply when the
+	// membership is restored on reconnect.
+	OnRestore(pctx FocusPolicyContext) ([]StreamWithMode, error)
+}
+
+// NullPolicy is a bootstrapping FocusKindPolicy that returns empty streams
+// for all operations. It allows the coordinator to construct and pass tests
+// before real kind policies (ScenePolicy) are registered.
+type NullPolicy struct {
+	kind session.FocusKind
+}
+
+// NewNullPolicy creates a NullPolicy for the given kind.
+func NewNullPolicy(kind session.FocusKind) *NullPolicy {
+	return &NullPolicy{kind: kind}
+}
+
+// Kind returns the FocusKind this null policy handles.
+func (p *NullPolicy) Kind() session.FocusKind { return p.kind }
+
+// StreamsFor returns nil — no streams for null policy.
+func (p *NullPolicy) StreamsFor(_ session.FocusKey) []string { return nil }
+
+// OnJoin returns nil — no replay for null policy.
+func (p *NullPolicy) OnJoin(_ FocusPolicyContext) ([]StreamWithMode, error) { return nil, nil }
+
+// OnRestore returns nil — no replay for null policy.
+func (p *NullPolicy) OnRestore(_ FocusPolicyContext) ([]StreamWithMode, error) { return nil, nil }

--- a/internal/grpc/focus/kind_policy_test.go
+++ b/internal/grpc/focus/kind_policy_test.go
@@ -47,7 +47,7 @@ func TestNullPolicyStreamsForReturnsEmpty(t *testing.T) {
 
 func TestNullPolicyOnJoinReturnsEmpty(t *testing.T) {
 	p := NewNullPolicy(session.FocusKindScene)
-	result, err := p.OnJoin(FocusPolicyContext{
+	result, err := p.OnJoin(PolicyContext{
 		SessionID: "sess-1",
 		Target:    session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()},
 	})
@@ -57,7 +57,7 @@ func TestNullPolicyOnJoinReturnsEmpty(t *testing.T) {
 
 func TestNullPolicyOnRestoreReturnsEmpty(t *testing.T) {
 	p := NewNullPolicy(session.FocusKindScene)
-	result, err := p.OnRestore(FocusPolicyContext{
+	result, err := p.OnRestore(PolicyContext{
 		SessionID: "sess-1",
 		Target:    session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()},
 	})

--- a/internal/grpc/focus/kind_policy_test.go
+++ b/internal/grpc/focus/kind_policy_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+func TestReplayModeStringReturnsHumanReadableName(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     ReplayMode
+		expected string
+	}{
+		{"from cursor", ReplayModeFromCursor, "from_cursor"},
+		{"bounded tail", ReplayModeBoundedTail, "bounded_tail"},
+		{"live only", ReplayModeLiveOnly, "live_only"},
+		{"unknown value", ReplayMode(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.mode.String())
+		})
+	}
+}
+
+func TestNullPolicyKindReturnsRegisteredKind(t *testing.T) {
+	p := NewNullPolicy(session.FocusKindScene)
+	assert.Equal(t, session.FocusKindScene, p.Kind())
+}
+
+func TestNullPolicyStreamsForReturnsEmpty(t *testing.T) {
+	p := NewNullPolicy(session.FocusKindScene)
+	streams := p.StreamsFor(session.FocusKey{
+		Kind:     session.FocusKindScene,
+		TargetID: ulid.Make(),
+	})
+	assert.Empty(t, streams)
+}
+
+func TestNullPolicyOnJoinReturnsEmpty(t *testing.T) {
+	p := NewNullPolicy(session.FocusKindScene)
+	result, err := p.OnJoin(FocusPolicyContext{
+		SessionID: "sess-1",
+		Target:    session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestNullPolicyOnRestoreReturnsEmpty(t *testing.T) {
+	p := NewNullPolicy(session.FocusKindScene)
+	result, err := p.OnRestore(FocusPolicyContext{
+		SessionID: "sess-1",
+		Target:    session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/internal/grpc/focus/leave.go
+++ b/internal/grpc/focus/leave.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// LeaveFocus removes a focus membership. Clears PresentingFocus if it
+// pointed at the removed membership (I-10). Idempotent on not-a-member.
+func (c *defaultCoordinator) LeaveFocus(ctx context.Context, sessionID string, target session.FocusKey) error {
+	if _, err := c.sessionOrError(ctx, sessionID); err != nil {
+		return err
+	}
+
+	var streamsToRemove []string
+	if policy, err := c.policyFor(target.Kind); err == nil {
+		streamsToRemove = policy.StreamsFor(target)
+	}
+
+	var wasMember bool
+	mutErr := c.sessionStore.UpdateFocusMemberships(ctx, sessionID, session.NewFocusMutator(
+		func(current []session.FocusMembership, presenting *session.FocusKey) ([]session.FocusMembership, *session.FocusKey, error) {
+			next := make([]session.FocusMembership, 0, len(current))
+			for _, m := range current {
+				if m.Kind == target.Kind && m.TargetID == target.TargetID {
+					wasMember = true
+					continue
+				}
+				next = append(next, m)
+			}
+			nextPresenting := presenting
+			if presenting != nil && presenting.Kind == target.Kind && presenting.TargetID == target.TargetID {
+				nextPresenting = nil
+			}
+			return next, nextPresenting, nil
+		},
+	))
+	if mutErr != nil {
+		return mutErr
+	}
+
+	if wasMember && c.streamSender != nil {
+		for _, stream := range streamsToRemove {
+			_ = c.streamSender.Send(sessionID, stream, false, ReplayModeFromCursor)
+		}
+	}
+
+	return nil
+}

--- a/internal/grpc/focus/leave.go
+++ b/internal/grpc/focus/leave.go
@@ -6,6 +6,8 @@ package focus
 import (
 	"context"
 
+	"github.com/samber/oops"
+
 	"github.com/holomush/holomush/internal/session"
 )
 
@@ -40,12 +42,12 @@ func (c *defaultCoordinator) LeaveFocus(ctx context.Context, sessionID string, t
 		},
 	))
 	if mutErr != nil {
-		return mutErr
+		return oops.With("session_id", sessionID).Wrap(mutErr)
 	}
 
 	if wasMember && c.streamSender != nil {
 		for _, stream := range streamsToRemove {
-			_ = c.streamSender.Send(sessionID, stream, false, ReplayModeFromCursor)
+			_ = c.streamSender.Send(sessionID, stream, false, ReplayModeFromCursor) //nolint:errcheck // best-effort: SESSION_NOT_FOUND means no live subscriber
 		}
 	}
 

--- a/internal/grpc/focus/leave_test.go
+++ b/internal/grpc/focus/leave_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestLeaveFocusRemovesMembershipAndUnsubscribes(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+	streamName := "scene:" + targetID.String() + ":ic"
+
+	policy := &stubPolicy{
+		kind:    session.FocusKindScene,
+		streams: []string{streamName},
+	}
+
+	coord, sender := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {
+				Status: session.StatusActive,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+			},
+		},
+		policy,
+	)
+
+	err := coord.LeaveFocus(context.Background(), "sess-1", target)
+	require.NoError(t, err)
+
+	// Membership removed.
+	info, getErr := coord.sessionStore.Get(context.Background(), "sess-1")
+	require.NoError(t, getErr)
+	assert.Empty(t, info.FocusMemberships)
+
+	// Unsubscribe sent.
+	require.Len(t, sender.calls, 1)
+	assert.Equal(t, "sess-1", sender.calls[0].sessionID)
+	assert.Equal(t, streamName, sender.calls[0].stream)
+	assert.False(t, sender.calls[0].add)
+}
+
+func TestLeaveFocusClearsPresentingWhenPointingAtRemoved(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {
+				Status: session.StatusActive,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+				PresentingFocus: &session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID},
+			},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.LeaveFocus(context.Background(), "sess-1", target)
+	require.NoError(t, err)
+
+	info, getErr := coord.sessionStore.Get(context.Background(), "sess-1")
+	require.NoError(t, getErr)
+	assert.Empty(t, info.FocusMemberships)
+	assert.Nil(t, info.PresentingFocus)
+}
+
+func TestLeaveFocusIsIdempotentForNonMember(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, sender := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {Status: session.StatusActive},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.LeaveFocus(context.Background(), "sess-1", target)
+	require.NoError(t, err)
+	// No unsubscribe sent since not a member.
+	assert.Empty(t, sender.calls)
+}
+
+func TestLeaveFocusRejectsExpiredSession(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-expired": {Status: session.StatusExpired},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.LeaveFocus(context.Background(), "sess-expired", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_EXPIRED")
+}

--- a/internal/grpc/focus/player_prefs_adapter.go
+++ b/internal/grpc/focus/player_prefs_adapter.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+// PlayerRepoReader is the subset of auth.PlayerRepository needed by
+// PlayerPrefsAdapter.
+type PlayerRepoReader interface {
+	GetByID(ctx context.Context, id ulid.ULID) (*auth.Player, error)
+}
+
+// PlayerPrefsAdapter bridges auth.PlayerRepository to PlayerPreferencesReader.
+type PlayerPrefsAdapter struct {
+	repo PlayerRepoReader
+}
+
+// NewPlayerPrefsAdapter creates a PlayerPrefsAdapter.
+func NewPlayerPrefsAdapter(repo PlayerRepoReader) *PlayerPrefsAdapter {
+	return &PlayerPrefsAdapter{repo: repo}
+}
+
+// SceneFocusReplayTail returns the player's configured value, or nil if
+// unset or on lookup error (degrades to "unset").
+func (a *PlayerPrefsAdapter) SceneFocusReplayTail(ctx context.Context, playerID ulid.ULID) *int {
+	player, err := a.repo.GetByID(ctx, playerID)
+	if err != nil {
+		return nil
+	}
+	return player.Preferences.Scenes.FocusReplayTail
+}

--- a/internal/grpc/focus/player_prefs_adapter_test.go
+++ b/internal/grpc/focus/player_prefs_adapter_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/auth"
+)
+
+type mockPlayerRepo struct {
+	player *auth.Player
+	err    error
+}
+
+func (m *mockPlayerRepo) GetByID(_ context.Context, _ ulid.ULID) (*auth.Player, error) {
+	return m.player, m.err
+}
+
+func TestPlayerPrefsAdapterReturnsNilWhenNotSet(t *testing.T) {
+	adapter := NewPlayerPrefsAdapter(&mockPlayerRepo{
+		player: &auth.Player{Preferences: auth.PlayerPreferences{}},
+	})
+	result := adapter.SceneFocusReplayTail(context.Background(), ulid.Make())
+	assert.Nil(t, result)
+}
+
+func TestPlayerPrefsAdapterReturnsValueWhenSet(t *testing.T) {
+	tail := 7
+	adapter := NewPlayerPrefsAdapter(&mockPlayerRepo{
+		player: &auth.Player{
+			Preferences: auth.PlayerPreferences{
+				Scenes: auth.ScenePlayerPreferences{FocusReplayTail: &tail},
+			},
+		},
+	})
+	result := adapter.SceneFocusReplayTail(context.Background(), ulid.Make())
+	assert.NotNil(t, result)
+	assert.Equal(t, 7, *result)
+}
+
+func TestPlayerPrefsAdapterReturnsNilOnError(t *testing.T) {
+	adapter := NewPlayerPrefsAdapter(&mockPlayerRepo{err: assert.AnError})
+	result := adapter.SceneFocusReplayTail(context.Background(), ulid.Make())
+	assert.Nil(t, result)
+}

--- a/internal/grpc/focus/prefs_test.go
+++ b/internal/grpc/focus/prefs_test.go
@@ -27,7 +27,8 @@ func TestBuildPolicyContextUsesSubstrateDefaultWhenNoSettings(t *testing.T) {
 	coord, _ := newTestCoordinator(t, map[string]*session.Info{
 		"sess-1": {CharacterID: ulid.Make(), PlayerID: ulid.Make(), Status: session.StatusActive},
 	})
-	info, _ := coord.sessionStore.Get(context.Background(), "sess-1")
+	info, err := coord.sessionStore.Get(context.Background(), "sess-1")
+	require.NoError(t, err)
 	pctx := coord.buildPolicyContext(context.Background(), info, session.FocusKey{
 		Kind: session.FocusKindScene, TargetID: ulid.Make(),
 	})
@@ -48,7 +49,8 @@ func TestBuildPolicyContextUsesPlayerPreferenceWhenSet(t *testing.T) {
 	)
 	require.NoError(t, err)
 	dc := coord.(*defaultCoordinator)
-	info, _ := dc.sessionStore.Get(ctx, "sess-1")
+	info, infoErr := dc.sessionStore.Get(ctx, "sess-1")
+	require.NoError(t, infoErr)
 	pctx := dc.buildPolicyContext(ctx, info, session.FocusKey{
 		Kind: session.FocusKindScene, TargetID: ulid.Make(),
 	})
@@ -68,7 +70,8 @@ func TestBuildPolicyContextClampsPlayerPreference(t *testing.T) {
 	)
 	require.NoError(t, err)
 	dc := coord.(*defaultCoordinator)
-	info, _ := dc.sessionStore.Get(ctx, "sess-1")
+	info, infoErr := dc.sessionStore.Get(ctx, "sess-1")
+	require.NoError(t, infoErr)
 	pctx := dc.buildPolicyContext(ctx, info, session.FocusKey{
 		Kind: session.FocusKindScene, TargetID: ulid.Make(),
 	})

--- a/internal/grpc/focus/prefs_test.go
+++ b/internal/grpc/focus/prefs_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// stubPlayerPrefs is a test PlayerPreferencesReader.
+type stubPlayerPrefs struct {
+	tail *int
+}
+
+func (s *stubPlayerPrefs) SceneFocusReplayTail(_ context.Context, _ ulid.ULID) *int {
+	return s.tail
+}
+
+func TestBuildPolicyContextUsesSubstrateDefaultWhenNoSettings(t *testing.T) {
+	coord, _ := newTestCoordinator(t, map[string]*session.Info{
+		"sess-1": {CharacterID: ulid.Make(), PlayerID: ulid.Make(), Status: session.StatusActive},
+	})
+	info, _ := coord.sessionStore.Get(context.Background(), "sess-1")
+	pctx := coord.buildPolicyContext(context.Background(), info, session.FocusKey{
+		Kind: session.FocusKindScene, TargetID: ulid.Make(),
+	})
+	assert.Equal(t, 3, pctx.SceneFocusReplayTail)
+}
+
+func TestBuildPolicyContextUsesPlayerPreferenceWhenSet(t *testing.T) {
+	tail := 7
+	store := session.NewMemStore()
+	ctx := context.Background()
+	playerID := ulid.Make()
+	require.NoError(t, store.Set(ctx, "sess-1", &session.Info{
+		ID: "sess-1", CharacterID: ulid.Make(), PlayerID: playerID, Status: session.StatusActive,
+	}))
+	coord, err := NewCoordinator(
+		WithSessionStore(store),
+		WithPlayerPreferences(&stubPlayerPrefs{tail: &tail}),
+	)
+	require.NoError(t, err)
+	dc := coord.(*defaultCoordinator)
+	info, _ := dc.sessionStore.Get(ctx, "sess-1")
+	pctx := dc.buildPolicyContext(ctx, info, session.FocusKey{
+		Kind: session.FocusKindScene, TargetID: ulid.Make(),
+	})
+	assert.Equal(t, 7, pctx.SceneFocusReplayTail)
+}
+
+func TestBuildPolicyContextClampsPlayerPreference(t *testing.T) {
+	tail := 50
+	store := session.NewMemStore()
+	ctx := context.Background()
+	require.NoError(t, store.Set(ctx, "sess-1", &session.Info{
+		ID: "sess-1", CharacterID: ulid.Make(), PlayerID: ulid.Make(), Status: session.StatusActive,
+	}))
+	coord, err := NewCoordinator(
+		WithSessionStore(store),
+		WithPlayerPreferences(&stubPlayerPrefs{tail: &tail}),
+	)
+	require.NoError(t, err)
+	dc := coord.(*defaultCoordinator)
+	info, _ := dc.sessionStore.Get(ctx, "sess-1")
+	pctx := dc.buildPolicyContext(ctx, info, session.FocusKey{
+		Kind: session.FocusKindScene, TargetID: ulid.Make(),
+	})
+	assert.Equal(t, 10, pctx.SceneFocusReplayTail) // clamped
+}

--- a/internal/grpc/focus/present.go
+++ b/internal/grpc/focus/present.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// PresentFocus updates PresentingFocus to the specified target. The target
+// MUST already exist in FocusMemberships. No replay, no subscription change.
+func (c *defaultCoordinator) PresentFocus(ctx context.Context, sessionID string, target session.FocusKey) error {
+	if _, err := c.sessionOrError(ctx, sessionID); err != nil {
+		return err
+	}
+
+	return c.sessionStore.UpdateFocusMemberships(ctx, sessionID, session.NewFocusMutator(
+		func(current []session.FocusMembership, _ *session.FocusKey) ([]session.FocusMembership, *session.FocusKey, error) {
+			found := false
+			for _, m := range current {
+				if m.Kind == target.Kind && m.TargetID == target.TargetID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, nil, oops.Code("FOCUS_NOT_MEMBER").
+					Errorf("target %s:%s is not in FocusMemberships", target.Kind, target.TargetID)
+			}
+			return current, &target, nil
+		},
+	))
+}

--- a/internal/grpc/focus/present.go
+++ b/internal/grpc/focus/present.go
@@ -18,7 +18,7 @@ func (c *defaultCoordinator) PresentFocus(ctx context.Context, sessionID string,
 		return err
 	}
 
-	return c.sessionStore.UpdateFocusMemberships(ctx, sessionID, session.NewFocusMutator(
+	mutErr := c.sessionStore.UpdateFocusMemberships(ctx, sessionID, session.NewFocusMutator(
 		func(current []session.FocusMembership, _ *session.FocusKey) ([]session.FocusMembership, *session.FocusKey, error) {
 			found := false
 			for _, m := range current {
@@ -34,4 +34,8 @@ func (c *defaultCoordinator) PresentFocus(ctx context.Context, sessionID string,
 			return current, &target, nil
 		},
 	))
+	if mutErr != nil {
+		return oops.With("session_id", sessionID).Wrap(mutErr)
+	}
+	return nil
 }

--- a/internal/grpc/focus/present_test.go
+++ b/internal/grpc/focus/present_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestPresentFocusUpdatesPresentingPointer(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {
+				Status: session.StatusActive,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+			},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.PresentFocus(context.Background(), "sess-1", target)
+	require.NoError(t, err)
+
+	info, getErr := coord.sessionStore.Get(context.Background(), "sess-1")
+	require.NoError(t, getErr)
+	require.NotNil(t, info.PresentingFocus)
+	assert.Equal(t, session.FocusKindScene, info.PresentingFocus.Kind)
+	assert.Equal(t, targetID, info.PresentingFocus.TargetID)
+}
+
+func TestPresentFocusRejectsNonMember(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	// Session has no memberships.
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {Status: session.StatusActive},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.PresentFocus(context.Background(), "sess-1", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "FOCUS_NOT_MEMBER")
+}
+
+func TestPresentFocusRejectsExpiredSession(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	target := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-expired": {Status: session.StatusExpired},
+		},
+		NewNullPolicy(session.FocusKindScene),
+	)
+
+	err := coord.PresentFocus(context.Background(), "sess-expired", target)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_EXPIRED")
+}

--- a/internal/grpc/focus/restore.go
+++ b/internal/grpc/focus/restore.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// RestoreFocus derives the ordered stream-plus-mode list for the initial
+// replay pass. Pure derivation from session.Info (invariant I-8).
+func (c *defaultCoordinator) RestoreFocus(ctx context.Context, sessionID string) (RestorePlan, error) {
+	info, err := c.sessionOrError(ctx, sessionID)
+	if err != nil {
+		return RestorePlan{}, err
+	}
+
+	plan := RestorePlan{}
+
+	for _, m := range info.FocusMemberships {
+		policy, pErr := c.policyFor(m.Kind)
+		if pErr != nil {
+			continue
+		}
+		pctx := c.buildPolicyContext(ctx, info, session.FocusKey{Kind: m.Kind, TargetID: m.TargetID})
+		streams, rErr := policy.OnRestore(pctx)
+		if rErr != nil {
+			continue
+		}
+		plan.Streams = append(plan.Streams, streams...)
+	}
+
+	if info.PresentingFocus != nil {
+		if policy, pErr := c.policyFor(info.PresentingFocus.Kind); pErr == nil {
+			streams := policy.StreamsFor(*info.PresentingFocus)
+			if len(streams) > 0 {
+				plan.PresentingStream = streams[0]
+			}
+		}
+	}
+
+	return plan, nil
+}

--- a/internal/grpc/focus/restore_test.go
+++ b/internal/grpc/focus/restore_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+func TestRestoreFocusReturnsEmptyPlanForNewSession(t *testing.T) {
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {Status: session.StatusActive},
+		},
+	)
+
+	plan, err := coord.RestoreFocus(context.Background(), "sess-1")
+	require.NoError(t, err)
+	assert.Empty(t, plan.Streams)
+	assert.Empty(t, plan.PresentingStream)
+}
+
+func TestRestoreFocusDispatchesToKindPolicyOnRestore(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	streamName := "scene:" + targetID.String() + ":ic"
+
+	policy := &stubPolicy{
+		kind:    session.FocusKindScene,
+		streams: []string{streamName},
+		onRestore: []StreamWithMode{
+			{Stream: streamName, Mode: ReplayModeFromCursor},
+		},
+	}
+
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-detached": {
+				Status: session.StatusDetached,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+			},
+		},
+		policy,
+	)
+
+	plan, err := coord.RestoreFocus(context.Background(), "sess-detached")
+	require.NoError(t, err)
+	require.Len(t, plan.Streams, 1)
+	assert.Equal(t, streamName, plan.Streams[0].Stream)
+	assert.Equal(t, ReplayModeFromCursor, plan.Streams[0].Mode)
+}
+
+func TestRestoreFocusIncludesPresentingStream(t *testing.T) {
+	targetID := ulid.MustNew(ulid.Now(), nil)
+	streamName := "scene:" + targetID.String() + ":ic"
+
+	policy := &stubPolicy{
+		kind:    session.FocusKindScene,
+		streams: []string{streamName},
+		onRestore: []StreamWithMode{
+			{Stream: streamName, Mode: ReplayModeFromCursor},
+		},
+	}
+
+	presenting := session.FocusKey{Kind: session.FocusKindScene, TargetID: targetID}
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-1": {
+				Status: session.StatusActive,
+				FocusMemberships: []session.FocusMembership{
+					{Kind: session.FocusKindScene, TargetID: targetID, JoinedAt: time.Now()},
+				},
+				PresentingFocus: &presenting,
+			},
+		},
+		policy,
+	)
+
+	plan, err := coord.RestoreFocus(context.Background(), "sess-1")
+	require.NoError(t, err)
+	assert.Equal(t, streamName, plan.PresentingStream)
+}
+
+func TestRestoreFocusRejectsExpiredSession(t *testing.T) {
+	coord, _ := newTestCoordinator(t,
+		map[string]*session.Info{
+			"sess-expired": {Status: session.StatusExpired},
+		},
+	)
+
+	_, err := coord.RestoreFocus(context.Background(), "sess-expired")
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_EXPIRED")
+}

--- a/internal/grpc/focus/scenepolicy/policy.go
+++ b/internal/grpc/focus/scenepolicy/policy.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package scenepolicy implements the KindPolicy for scene-type focused
+// contexts. ScenePolicy derives two streams per scene: an IC (in-character)
+// stream and an OOC (out-of-character) stream.
+package scenepolicy
+
+import (
+	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
+)
+
+// ScenePolicy implements focus.KindPolicy for FocusKindScene.
+// It is stateless (I-9) and pure — no store access, no side effects.
+type ScenePolicy struct{}
+
+// New creates a ScenePolicy.
+func New() *ScenePolicy { return &ScenePolicy{} }
+
+// Kind returns FocusKindScene.
+func (p *ScenePolicy) Kind() session.FocusKind { return session.FocusKindScene }
+
+// StreamsFor returns the IC and OOC stream names for a scene target.
+// IC is first (primary for PresentingFocus default resolution).
+func (p *ScenePolicy) StreamsFor(target session.FocusKey) []string {
+	id := target.TargetID.String()
+	return []string{
+		"scene:" + id + ":ic",
+		"scene:" + id + ":ooc",
+	}
+}
+
+// OnJoin returns BoundedTail(N) for IC and LiveOnly for OOC.
+func (p *ScenePolicy) OnJoin(pctx focus.PolicyContext) ([]focus.StreamWithMode, error) {
+	streams := p.StreamsFor(pctx.Target)
+	return []focus.StreamWithMode{
+		{Stream: streams[0], Mode: focus.ReplayModeBoundedTail, TailCount: pctx.SceneFocusReplayTail},
+		{Stream: streams[1], Mode: focus.ReplayModeLiveOnly},
+	}, nil
+}
+
+// OnRestore returns FromCursor for both IC and OOC (cursor-faithful replay).
+func (p *ScenePolicy) OnRestore(pctx focus.PolicyContext) ([]focus.StreamWithMode, error) {
+	streams := p.StreamsFor(pctx.Target)
+	return []focus.StreamWithMode{
+		{Stream: streams[0], Mode: focus.ReplayModeFromCursor},
+		{Stream: streams[1], Mode: focus.ReplayModeFromCursor},
+	}, nil
+}

--- a/internal/grpc/focus/scenepolicy/policy_test.go
+++ b/internal/grpc/focus/scenepolicy/policy_test.go
@@ -86,10 +86,12 @@ func TestScenePolicyIsPureAcrossDifferentTargets(t *testing.T) {
 	id1, id2 := ulid.Make(), ulid.Make()
 
 	pctx.Target = session.FocusKey{Kind: session.FocusKindScene, TargetID: id1}
-	result1, _ := p.OnJoin(pctx)
+	result1, err := p.OnJoin(pctx)
+	require.NoError(t, err)
 
 	pctx.Target = session.FocusKey{Kind: session.FocusKindScene, TargetID: id2}
-	result2, _ := p.OnJoin(pctx)
+	result2, err := p.OnJoin(pctx)
+	require.NoError(t, err)
 
 	require.Len(t, result1, len(result2))
 	for i := range result1 {

--- a/internal/grpc/focus/scenepolicy/policy_test.go
+++ b/internal/grpc/focus/scenepolicy/policy_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package scenepolicy
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
+)
+
+func TestScenePolicyKindReturnsScene(t *testing.T) {
+	p := New()
+	assert.Equal(t, session.FocusKindScene, p.Kind())
+}
+
+func TestScenePolicyStreamsForReturnsTwoStreams(t *testing.T) {
+	p := New()
+	sceneID := ulid.Make()
+	streams := p.StreamsFor(session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID})
+	require.Len(t, streams, 2)
+	assert.Equal(t, "scene:"+sceneID.String()+":ic", streams[0])
+	assert.Equal(t, "scene:"+sceneID.String()+":ooc", streams[1])
+}
+
+func TestScenePolicyStreamsForPrimaryIsIC(t *testing.T) {
+	p := New()
+	streams := p.StreamsFor(session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()})
+	assert.Contains(t, streams[0], ":ic")
+}
+
+func TestScenePolicyOnJoinReturnsBoundedTailForICAndLiveOnlyForOOC(t *testing.T) {
+	p := New()
+	sceneID := ulid.Make()
+	pctx := focus.PolicyContext{
+		SessionID:            "sess-1",
+		Target:               session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID},
+		SceneFocusReplayTail: 5,
+	}
+	result, err := p.OnJoin(pctx)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, "scene:"+sceneID.String()+":ic", result[0].Stream)
+	assert.Equal(t, focus.ReplayModeBoundedTail, result[0].Mode)
+	assert.Equal(t, 5, result[0].TailCount)
+	assert.Equal(t, "scene:"+sceneID.String()+":ooc", result[1].Stream)
+	assert.Equal(t, focus.ReplayModeLiveOnly, result[1].Mode)
+}
+
+func TestScenePolicyOnJoinUsesZeroTailCountWhenConfiguredToZero(t *testing.T) {
+	p := New()
+	pctx := focus.PolicyContext{
+		SessionID:            "sess-1",
+		Target:               session.FocusKey{Kind: session.FocusKindScene, TargetID: ulid.Make()},
+		SceneFocusReplayTail: 0,
+	}
+	result, err := p.OnJoin(pctx)
+	require.NoError(t, err)
+	assert.Equal(t, focus.ReplayModeBoundedTail, result[0].Mode)
+	assert.Equal(t, 0, result[0].TailCount)
+}
+
+func TestScenePolicyOnRestoreReturnsFromCursorForBothStreams(t *testing.T) {
+	p := New()
+	sceneID := ulid.Make()
+	pctx := focus.PolicyContext{
+		SessionID:            "sess-1",
+		Target:               session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID},
+		SceneFocusReplayTail: 5,
+	}
+	result, err := p.OnRestore(pctx)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, focus.ReplayModeFromCursor, result[0].Mode)
+	assert.Equal(t, focus.ReplayModeFromCursor, result[1].Mode)
+}
+
+func TestScenePolicyIsPureAcrossDifferentTargets(t *testing.T) {
+	p := New()
+	pctx := focus.PolicyContext{SessionID: "sess-1", SceneFocusReplayTail: 3}
+	id1, id2 := ulid.Make(), ulid.Make()
+
+	pctx.Target = session.FocusKey{Kind: session.FocusKindScene, TargetID: id1}
+	result1, _ := p.OnJoin(pctx)
+
+	pctx.Target = session.FocusKey{Kind: session.FocusKindScene, TargetID: id2}
+	result2, _ := p.OnJoin(pctx)
+
+	require.Len(t, result1, len(result2))
+	for i := range result1 {
+		assert.Equal(t, result1[i].Mode, result2[i].Mode)
+		assert.Equal(t, result1[i].TailCount, result2[i].TailCount)
+	}
+}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
@@ -124,6 +125,10 @@ type CoreServer struct {
 	// Plugin stream contribution and mid-session stream control.
 	streamContributor SessionStreamContributor
 	streamRegistry    *SessionStreamRegistry
+
+	// focusCoordinator manages session focus memberships and replay policy.
+	// Nil until the Subscribe handler refactor (B7) wires it into the live loop.
+	focusCoordinator focus.FocusCoordinator
 
 	// afterLISTENHook fires between LISTEN setup and replay — used in tests.
 	afterLISTENHook func()
@@ -224,6 +229,11 @@ func WithStreamContributor(c SessionStreamContributor) CoreServerOption {
 // WithStreamRegistry sets the session stream registry for mid-session stream control.
 func WithStreamRegistry(r *SessionStreamRegistry) CoreServerOption {
 	return func(s *CoreServer) { s.streamRegistry = r }
+}
+
+// WithFocusCoordinator sets the focus coordinator for session focus management.
+func WithFocusCoordinator(fc focus.FocusCoordinator) CoreServerOption {
+	return func(s *CoreServer) { s.focusCoordinator = fc }
 }
 
 // WithAfterLISTENHook sets a callback fired between LISTEN setup and replay.

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -128,7 +128,7 @@ type CoreServer struct {
 
 	// focusCoordinator manages session focus memberships and replay policy.
 	// Nil until the Subscribe handler refactor (B7) wires it into the live loop.
-	focusCoordinator focus.FocusCoordinator
+	focusCoordinator focus.Coordinator
 
 	// afterLISTENHook fires between LISTEN setup and replay — used in tests.
 	afterLISTENHook func()
@@ -232,7 +232,7 @@ func WithStreamRegistry(r *SessionStreamRegistry) CoreServerOption {
 }
 
 // WithFocusCoordinator sets the focus coordinator for session focus management.
-func WithFocusCoordinator(fc focus.FocusCoordinator) CoreServerOption {
+func WithFocusCoordinator(fc focus.Coordinator) CoreServerOption {
 	return func(s *CoreServer) { s.focusCoordinator = fc }
 }
 

--- a/internal/grpc/stream_registry.go
+++ b/internal/grpc/stream_registry.go
@@ -97,3 +97,23 @@ func (r *SessionStreamRegistry) AddStream(_ context.Context, sessionID, stream s
 func (r *SessionStreamRegistry) RemoveStream(_ context.Context, sessionID, stream string) error {
 	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: false})
 }
+
+// StreamSenderAdapter wraps SessionStreamRegistry to satisfy focus.StreamSender.
+// It calls Send directly (not AddStream) to pass explicit ReplayMode values.
+type StreamSenderAdapter struct {
+	registry *SessionStreamRegistry
+}
+
+// NewStreamSenderAdapter creates a StreamSenderAdapter.
+func NewStreamSenderAdapter(r *SessionStreamRegistry) *StreamSenderAdapter {
+	return &StreamSenderAdapter{registry: r}
+}
+
+// Send implements focus.StreamSender.
+func (a *StreamSenderAdapter) Send(sessionID, stream string, add bool, mode focus.ReplayMode) error {
+	return a.registry.Send(sessionID, sessionStreamUpdate{
+		stream:     stream,
+		add:        add,
+		replayMode: mode,
+	})
+}

--- a/internal/grpc/stream_registry.go
+++ b/internal/grpc/stream_registry.go
@@ -18,8 +18,8 @@ type sessionStreamUpdate struct {
 	stream     string
 	add        bool             // true = subscribe, false = unsubscribe
 	replayMode focus.ReplayMode // only meaningful when add == true
-	tailCount  int              // valid when replayMode == focus.ReplayModeBoundedTail
-	notBefore  time.Time        // valid when replayMode == focus.ReplayModeBoundedTail
+	tailCount  int       //nolint:unused // forward-declared for B7 live-loop replay dispatch
+	notBefore  time.Time //nolint:unused // forward-declared for B7 live-loop replay dispatch
 }
 
 // SessionStreamRegistry maps active session IDs to their Subscribe control channels.

--- a/internal/grpc/stream_registry.go
+++ b/internal/grpc/stream_registry.go
@@ -6,14 +6,20 @@ package grpc
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/grpc/focus"
 )
 
 // sessionStreamUpdate is sent on a session's control channel to add or remove a stream.
 type sessionStreamUpdate struct {
-	stream string
-	add    bool // true = subscribe, false = unsubscribe
+	stream     string
+	add        bool             // true = subscribe, false = unsubscribe
+	replayMode focus.ReplayMode // only meaningful when add == true
+	tailCount  int              // valid when replayMode == focus.ReplayModeBoundedTail
+	notBefore  time.Time        // valid when replayMode == focus.ReplayModeBoundedTail
 }
 
 // SessionStreamRegistry maps active session IDs to their Subscribe control channels.
@@ -84,7 +90,7 @@ func (r *SessionStreamRegistry) Send(sessionID string, update sessionStreamUpdat
 
 // AddStream implements plugins.StreamRegistry. Subscribes a session to a stream.
 func (r *SessionStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
-	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true})
+	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true, replayMode: focus.ReplayModeFromCursor})
 }
 
 // RemoveStream implements plugins.StreamRegistry. Unsubscribes a session from a stream.

--- a/internal/grpc/stream_registry_test.go
+++ b/internal/grpc/stream_registry_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
@@ -81,4 +82,23 @@ func TestSessionStreamRegistryRemoveStreamDelegatesToSend(t *testing.T) {
 	update := <-ch
 	assert.Equal(t, "channel:abc", update.stream)
 	assert.False(t, update.add)
+}
+
+func TestSendCarriesReplayMode(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	reg.Register("sess-1", ch)
+	defer reg.Deregister("sess-1", ch)
+
+	err := reg.Send("sess-1", sessionStreamUpdate{
+		stream:     "scene:abc:ic",
+		add:        true,
+		replayMode: focus.ReplayModeBoundedTail,
+	})
+	require.NoError(t, err)
+
+	update := <-ch
+	assert.Equal(t, "scene:abc:ic", update.stream)
+	assert.True(t, update.add)
+	assert.Equal(t, focus.ReplayModeBoundedTail, update.replayMode)
 }

--- a/internal/grpc/stream_registry_test.go
+++ b/internal/grpc/stream_registry_test.go
@@ -84,6 +84,43 @@ func TestSessionStreamRegistryRemoveStreamDelegatesToSend(t *testing.T) {
 	assert.False(t, update.add)
 }
 
+func TestStreamSenderAdapterSendPassesModeToRegistry(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	reg.Register("sess-1", ch)
+	defer reg.Deregister("sess-1", ch)
+
+	adapter := NewStreamSenderAdapter(reg)
+	err := adapter.Send("sess-1", "scene:abc:ic", true, focus.ReplayModeBoundedTail)
+	require.NoError(t, err)
+
+	update := <-ch
+	assert.Equal(t, "scene:abc:ic", update.stream)
+	assert.True(t, update.add)
+	assert.Equal(t, focus.ReplayModeBoundedTail, update.replayMode)
+}
+
+func TestStreamSenderAdapterSendReturnsErrorForMissingSession(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	adapter := NewStreamSenderAdapter(reg)
+	err := adapter.Send("nonexistent", "stream", true, focus.ReplayModeFromCursor)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "SESSION_NOT_FOUND")
+}
+
+func TestAddStreamDefaultsToFromCursor(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 1)
+	reg.Register("sess-1", ch)
+	defer reg.Deregister("sess-1", ch)
+
+	err := reg.AddStream(context.Background(), "sess-1", "character:abc")
+	require.NoError(t, err)
+
+	update := <-ch
+	assert.Equal(t, focus.ReplayModeFromCursor, update.replayMode)
+}
+
 func TestSendCarriesReplayMode(t *testing.T) {
 	reg := NewSessionStreamRegistry()
 	ch := make(chan sessionStreamUpdate, 1)


### PR DESCRIPTION
## Summary

- **B4 (holomush-oy6e.4):** FocusCoordinator scaffolding — `Coordinator` interface with Join/Leave/Present/Restore, `KindPolicy` interface, `ReplayMode` enum, `NullPolicy`, `StreamSenderAdapter`, `CursorLockerAdapter`, wired into CoreServer
- **B6 (holomush-oy6e.6):** ScenePolicy (BoundedTail IC / LiveOnly OOC on join, FromCursor both on restore), `PlayerPrefsAdapter`, `ScenePlayerPreferences` with `*int FocusReplayTail`, preference resolution via settings.Chain + typed player override, all registered in coordinator

### Key architectural decisions
- `ReplayMode` defined in `internal/grpc/focus` (lower-level package), used directly by `internal/grpc` — no type duplication
- `StreamSender` / `CursorLocker` / `PlayerPreferencesReader` narrow interfaces decouple coordinator from concrete grpc types
- Stuttering names removed per revive lint: `FocusCoordinator` → `Coordinator`, `FocusKindPolicy` → `KindPolicy`, `FocusPolicyContext` → `PolicyContext`

### Invariants covered
- I-1 (membership uniqueness) — JoinFocus rejects duplicates
- I-2 (presenting validity) — PresentFocus rejects non-members
- I-6 (server-authoritative mutation) — all mutations via FocusMutator
- I-8 (reconnect pure derivation) — RestoreFocus derives from session state only
- I-9 (kind-policy isolation) — ScenePolicy is stateless/pure
- I-10 (presenting lifecycle) — LeaveFocus clears presenting when pointed at removed target
- I-11 (session status gate) — all methods reject expired sessions

## Test plan
- [x] 5678 unit tests pass (task test)
- [x] 491 integration tests pass (task test:int)
- [x] 0 lint issues (task lint)
- [x] Build clean (task build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene focus coordination: players can join, leave, and present focus targets within sessions
  * Per-player scene preferences to control scene replay tail behavior
  * Stream replay modes added (cursor-based replay, bounded tail, live-only) for subscription control

* **Tests**
  * Expanded unit tests covering focus coordinator behavior, policy logic, adapters, and stream management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->