### PR TITLE
feat(plugin): plugin host API — focus RPCs + ReplayMode + Lua hostfuncs (B8)

### DIFF
--- a/api/proto/holomush/plugin/v1/plugin.proto
+++ b/api/proto/holomush/plugin/v1/plugin.proto
@@ -49,6 +49,22 @@ service PluginHostService {
   // RemoveSessionStream unsubscribes an active session from a stream.
   // Idempotent: returns success if stream is not subscribed.
   rpc RemoveSessionStream(PluginHostServiceRemoveSessionStreamRequest) returns (PluginHostServiceRemoveSessionStreamResponse);
+
+  // JoinFocus adds a focus membership to an active or detached session.
+  // Plugins declare intent; the server applies kind-specific replay policy.
+  rpc JoinFocus(PluginHostServiceJoinFocusRequest) returns (PluginHostServiceJoinFocusResponse);
+
+  // LeaveFocus removes a focus membership. Idempotent on non-member.
+  rpc LeaveFocus(PluginHostServiceLeaveFocusRequest) returns (PluginHostServiceLeaveFocusResponse);
+
+  // PresentFocus updates the session's PresentingFocus pointer.
+  // Target MUST already exist in FocusMemberships.
+  rpc PresentFocus(PluginHostServicePresentFocusRequest) returns (PluginHostServicePresentFocusResponse);
+
+  // QueryStreamHistory reads the tail of a stream for plugin-side display.
+  // Read-only: does not advance cursors or affect session state.
+  // Count capped at 500 server-side.
+  rpc QueryStreamHistory(PluginHostServiceQueryStreamHistoryRequest) returns (PluginHostServiceQueryStreamHistoryResponse);
 }
 
 // ServiceConfig carries initialization data from the host to the plugin.
@@ -264,33 +280,24 @@ message PluginHostServiceKVDeleteRequest {
 
 message PluginHostServiceKVDeleteResponse {}
 
-// PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
 message PluginHostServiceAddSessionStreamRequest {
   // Active session identifier.
-  string session_id = 1;
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
   // Stream name to subscribe to (format: "prefix:id").
-  string stream = 2;
+  string stream = 2 [(buf.validate.field).string.min_len = 1];
+  // replay_mode controls initial replay. Optional; defaults to
+  // FROM_CURSOR if unspecified for backwards compatibility.
+  StreamReplayMode replay_mode = 3;
 }
 
-// PluginHostServiceAddSessionStreamResponse indicates success or failure.
-message PluginHostServiceAddSessionStreamResponse {
-  // Whether the stream was successfully added.
-  bool success = 1;
-}
+message PluginHostServiceAddSessionStreamResponse {}
 
-// PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
 message PluginHostServiceRemoveSessionStreamRequest {
-  // Active session identifier.
-  string session_id = 1;
-  // Stream name to unsubscribe from.
-  string stream = 2;
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  string stream = 2 [(buf.validate.field).string.min_len = 1];
 }
 
-// PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
-message PluginHostServiceRemoveSessionStreamResponse {
-  // Whether the stream was successfully removed (true even if not subscribed).
-  bool success = 1;
-}
+message PluginHostServiceRemoveSessionStreamResponse {}
 
 // QuerySessionStreamsRequest provides session context for stream contribution.
 message QuerySessionStreamsRequest {
@@ -308,4 +315,57 @@ message QuerySessionStreamsResponse {
   repeated string streams = 1;
   // Non-empty indicates a plugin-reported error. Host degrades (logs + skips).
   string error = 2;
+}
+
+// FocusKind enumerates the types of focused contexts a character can
+// participate in. Adding a new kind requires: (a) a new constant here,
+// (b) a matching session.FocusKind constant in Go, (c) a new
+// FocusKindPolicy implementation registered in the coordinator.
+enum FocusKind {
+  FOCUS_KIND_UNSPECIFIED = 0;
+  FOCUS_KIND_SCENE = 1;
+}
+
+// FocusKey identifies a focus membership within a session. A session's
+// focus memberships are unique by (kind, target_id) pair.
+message FocusKey {
+  FocusKind kind = 1;
+  string target_id = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+// StreamReplayMode controls how a stream subscription's initial replay
+// behaves when added via AddSessionStream.
+enum StreamReplayMode {
+  STREAM_REPLAY_MODE_UNSPECIFIED = 0;
+  STREAM_REPLAY_MODE_FROM_CURSOR = 1;
+  STREAM_REPLAY_MODE_LIVE_ONLY = 2;
+}
+
+message PluginHostServiceJoinFocusRequest {
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  FocusKey target = 2;
+}
+message PluginHostServiceJoinFocusResponse {}
+
+message PluginHostServiceLeaveFocusRequest {
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  FocusKey target = 2;
+}
+message PluginHostServiceLeaveFocusResponse {}
+
+message PluginHostServicePresentFocusRequest {
+  string session_id = 1 [(buf.validate.field).string.min_len = 1];
+  FocusKey target = 2;
+}
+message PluginHostServicePresentFocusResponse {}
+
+message PluginHostServiceQueryStreamHistoryRequest {
+  string stream = 1 [(buf.validate.field).string.min_len = 1];
+  int32 count = 2;
+  // Epoch milliseconds. Events before this time are excluded. 0 means no lower bound.
+  int64 not_before_ms = 3;
+}
+
+message PluginHostServiceQueryStreamHistoryResponse {
+  repeated Event events = 1;
 }

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -26,13 +26,13 @@ import (
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
 	holoFocus "github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/grpc/focus/scenepolicy"
-	"github.com/holomush/holomush/internal/settings"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/naming"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	sessionsetup "github.com/holomush/holomush/internal/session/setup"
+	"github.com/holomush/holomush/internal/settings"
 	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/internal/telnet"
 	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
@@ -256,6 +256,13 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 		return oops.Code("FOCUS_COORDINATOR_FAILED").Wrap(focusErr)
 	}
 	coreServerOpts = append(coreServerOpts, holoGRPC.WithFocusCoordinator(focusCoord))
+
+	// 8b. Inject focus coordinator + event store into plugin hosts (late-binding).
+	// The plugin subsystem started before gRPC, so these deps were not available
+	// at host construction time. Binary plugins use them for JoinFocus/LeaveFocus/
+	// PresentFocus/QueryStreamHistory RPCs; Lua plugins use them for holomush.*
+	// hostfuncs.
+	pluginManager.ConfigureFocusDeps(focusCoord, eventStore)
 
 	coreServer := holoGRPC.NewCoreServer(engine, sessionStore, cmdDispatcher, cmdServices, coreServerOpts...)
 	corev1.RegisterCoreServiceServer(s.grpcServer, coreServer)

--- a/internal/grpc/focus/coordinator_test.go
+++ b/internal/grpc/focus/coordinator_test.go
@@ -22,8 +22,8 @@ type stubPolicy struct {
 	onRestore []StreamWithMode
 }
 
-func (p *stubPolicy) Kind() session.FocusKind                               { return p.kind }
-func (p *stubPolicy) StreamsFor(_ session.FocusKey) []string                { return p.streams }
+func (p *stubPolicy) Kind() session.FocusKind                          { return p.kind }
+func (p *stubPolicy) StreamsFor(_ session.FocusKey) []string           { return p.streams }
 func (p *stubPolicy) OnJoin(_ PolicyContext) ([]StreamWithMode, error) { return p.onJoin, p.onJoinErr }
 func (p *stubPolicy) OnRestore(_ PolicyContext) ([]StreamWithMode, error) {
 	return p.onRestore, nil

--- a/internal/grpc/focus/kind_policy.go
+++ b/internal/grpc/focus/kind_policy.go
@@ -5,53 +5,25 @@
 // mutator of a session's focused-context state. It encapsulates transition
 // semantics (join, leave, present, restore) and dispatches per-kind replay
 // policy to KindPolicy implementations.
-//
-// ReplayMode is defined here (not in the parent internal/grpc package)
-// because the dependency graph is grpc → focus. Defining the type in the
-// lower-level package that produces replay decisions avoids duplication
-// and lets grpc use focus.ReplayMode directly.
 package focus
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/holomush/holomush/internal/session"
 )
 
-// ReplayMode controls how the live loop replays events when processing a
-// stream addition. The coordinator and kind policies produce ReplayMode
-// values; the live loop in internal/grpc consumes them.
-type ReplayMode int
+// ReplayMode is an alias for session.ReplayMode. Defined here for
+// backward compatibility with existing focus package consumers.
+// New code SHOULD import session.ReplayMode directly.
+type ReplayMode = session.ReplayMode
 
+// Re-export constants so existing focus.ReplayModeXxx references compile.
 const (
-	// ReplayModeFromCursor replays from the stored per-stream cursor in
-	// session.Info.EventCursors, or from ULID zero if no cursor is set.
-	ReplayModeFromCursor ReplayMode = iota
-
-	// ReplayModeBoundedTail replays the most recent TailCount events on
-	// the stream (optionally bounded by NotBefore), then advances the
-	// cursor to the tail. Used by scene focus-switch IC catch-up.
-	ReplayModeBoundedTail
-
-	// ReplayModeLiveOnly advances the cursor to the current stream tail
-	// without replaying anything. Used by channels for mid-session joins.
-	ReplayModeLiveOnly
+	ReplayModeFromCursor  = session.ReplayModeFromCursor
+	ReplayModeBoundedTail = session.ReplayModeBoundedTail
+	ReplayModeLiveOnly    = session.ReplayModeLiveOnly
 )
-
-// String returns a human-readable name for the replay mode.
-func (m ReplayMode) String() string {
-	switch m {
-	case ReplayModeFromCursor:
-		return "from_cursor"
-	case ReplayModeBoundedTail:
-		return "bounded_tail"
-	case ReplayModeLiveOnly:
-		return "live_only"
-	default:
-		return fmt.Sprintf("unknown(%d)", int(m))
-	}
-}
 
 // StreamWithMode pairs a stream name with its replay mode and optional
 // mode-specific parameters.

--- a/internal/grpc/location_follow_test.go
+++ b/internal/grpc/location_follow_test.go
@@ -249,8 +249,8 @@ func TestLocationFollower_BuildLocationState(t *testing.T) {
 type mockSubscription struct {
 	addedStreams   []string
 	removedStreams []string
-	notifCh       chan core.StreamNotification
-	errCh         chan error
+	notifCh        chan core.StreamNotification
+	errCh          chan error
 }
 
 func newMockSubscription() *mockSubscription {
@@ -271,8 +271,8 @@ func (m *mockSubscription) RemoveStream(_ context.Context, stream string) error 
 }
 
 func (m *mockSubscription) Notifications() <-chan core.StreamNotification { return m.notifCh }
-func (m *mockSubscription) Errors() <-chan error                         { return m.errCh }
-func (m *mockSubscription) Close() error                                 { return nil }
+func (m *mockSubscription) Errors() <-chan error                          { return m.errCh }
+func (m *mockSubscription) Close() error                                  { return nil }
 
 func TestSwitchLocationSubscriptionAddsNewAndRemovesOldStream(t *testing.T) {
 	charID := ulid.Make()

--- a/internal/grpc/stream_registry.go
+++ b/internal/grpc/stream_registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
 )
 
 // sessionStreamUpdate is sent on a session's control channel to add or remove a stream.
@@ -91,6 +92,11 @@ func (r *SessionStreamRegistry) Send(sessionID string, update sessionStreamUpdat
 // AddStream implements plugins.StreamRegistry. Subscribes a session to a stream.
 func (r *SessionStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
 	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true, replayMode: focus.ReplayModeFromCursor})
+}
+
+// AddStreamWithMode implements plugins.StreamRegistry. Subscribes with explicit replay mode.
+func (r *SessionStreamRegistry) AddStreamWithMode(_ context.Context, sessionID, stream string, mode session.ReplayMode) error {
+	return r.Send(sessionID, sessionStreamUpdate{stream: stream, add: true, replayMode: mode})
 }
 
 // RemoveStream implements plugins.StreamRegistry. Unsubscribes a session from a stream.

--- a/internal/grpc/stream_registry_test.go
+++ b/internal/grpc/stream_registry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
@@ -119,6 +120,21 @@ func TestAddStreamDefaultsToFromCursor(t *testing.T) {
 
 	update := <-ch
 	assert.Equal(t, focus.ReplayModeFromCursor, update.replayMode)
+}
+
+func TestAddStreamWithModeSendsReplayModeToControlChannel(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	ch := make(chan sessionStreamUpdate, 4)
+	reg.Register("sess-1", ch)
+	defer reg.Deregister("sess-1", ch)
+
+	err := reg.AddStreamWithMode(context.Background(), "sess-1", "channel:x", session.ReplayModeLiveOnly)
+	require.NoError(t, err)
+
+	update := <-ch
+	assert.Equal(t, "channel:x", update.stream)
+	assert.True(t, update.add)
+	assert.Equal(t, session.ReplayModeLiveOnly, update.replayMode)
 }
 
 func TestSendCarriesReplayMode(t *testing.T) {

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	tlscerts "github.com/holomush/holomush/internal/tls"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
@@ -50,6 +51,7 @@ var (
 	_ plugins.ServiceConnProvider       = (*Host)(nil)
 	_ plugins.AttributeResolverProvider = (*Host)(nil)
 	_ plugins.EventEmitterConfigurer    = (*Host)(nil)
+	_ plugins.FocusDepsConfigurer       = (*Host)(nil)
 )
 
 // PluginClient wraps go-plugin client for testability.
@@ -106,6 +108,18 @@ func WithServiceRegistry(r *plugins.ServiceRegistry) HostOption {
 	return func(h *Host) { h.registry = r }
 }
 
+// WithFocusCoordinator configures the host to inject a focus coordinator
+// into the plugin host service for JoinFocus/LeaveFocus/PresentFocus RPCs.
+func WithFocusCoordinator(fc focus.Coordinator) HostOption {
+	return func(h *Host) { h.focusCoordinator = fc }
+}
+
+// WithEventStore configures the host to inject an event store for
+// QueryStreamHistory RPCs.
+func WithEventStore(es core.EventStore) HostOption {
+	return func(h *Host) { h.eventStore = es }
+}
+
 // Host manages binary plugins via HashiCorp go-plugins.
 type Host struct {
 	clientFactory     ClientFactory
@@ -116,6 +130,8 @@ type Host struct {
 	hostBrokerCert    *tlscerts.ServerCert
 	hostClientCert    *tlscerts.ClientCert
 	eventEmitter      plugins.PluginIntentEmitter
+	focusCoordinator  focus.Coordinator
+	eventStore        core.EventStore
 	plugins           map[string]*loadedPlugin
 	mu                sync.RWMutex
 	closed            bool
@@ -171,6 +187,39 @@ func (h *Host) SetEventEmitter(emitter plugins.PluginIntentEmitter) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.eventEmitter = emitter
+}
+
+// SetFocusCoordinator injects the focus coordinator after construction.
+// This supports late-binding: the plugin subsystem starts before gRPC,
+// so the coordinator is not available at Host construction time. The
+// coordinator is resolved lazily by the plugin host service when a
+// plugin calls JoinFocus/LeaveFocus/PresentFocus.
+func (h *Host) SetFocusCoordinator(fc focus.Coordinator) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.focusCoordinator = fc
+}
+
+// FocusCoordinator returns the current focus coordinator, or nil if not set.
+func (h *Host) FocusCoordinator() focus.Coordinator {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.focusCoordinator
+}
+
+// SetEventStore injects the event store after construction.
+// Same late-binding rationale as SetFocusCoordinator.
+func (h *Host) SetEventStore(es core.EventStore) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.eventStore = es
+}
+
+// EventStore returns the current event store, or nil if not set.
+func (h *Host) EventStore() core.EventStore {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.eventStore
 }
 
 // Load initializes a plugin from its manifest.

--- a/internal/plugin/goplugin/host_service.go
+++ b/internal/plugin/goplugin/host_service.go
@@ -5,11 +5,14 @@ package goplugin
 
 import (
 	"context"
+	"time"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 	"google.golang.org/grpc"
 
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
@@ -64,6 +67,151 @@ func (s *pluginHostServiceServer) EmitEvent(ctx context.Context, req *pluginv1.P
 	}
 
 	return &pluginv1.PluginHostServiceEmitEventResponse{}, nil
+}
+
+func (s *pluginHostServiceServer) JoinFocus(ctx context.Context, req *pluginv1.PluginHostServiceJoinFocusRequest) (*pluginv1.PluginHostServiceJoinFocusResponse, error) {
+	if s.host == nil {
+		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	fc := s.host.FocusCoordinator()
+	if fc == nil {
+		return nil, oops.With("plugin", s.pluginName).New("focus coordinator not configured")
+	}
+
+	key, err := protoToFocusKey(req.GetTarget())
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
+	}
+
+	if err := fc.JoinFocus(ctx, req.GetSessionId(), key); err != nil {
+		return nil, oops.With("plugin", s.pluginName).With("session_id", req.GetSessionId()).Wrap(err)
+	}
+	return &pluginv1.PluginHostServiceJoinFocusResponse{}, nil
+}
+
+func (s *pluginHostServiceServer) LeaveFocus(ctx context.Context, req *pluginv1.PluginHostServiceLeaveFocusRequest) (*pluginv1.PluginHostServiceLeaveFocusResponse, error) {
+	if s.host == nil {
+		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	fc := s.host.FocusCoordinator()
+	if fc == nil {
+		return nil, oops.With("plugin", s.pluginName).New("focus coordinator not configured")
+	}
+
+	key, err := protoToFocusKey(req.GetTarget())
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
+	}
+
+	if err := fc.LeaveFocus(ctx, req.GetSessionId(), key); err != nil {
+		return nil, oops.With("plugin", s.pluginName).With("session_id", req.GetSessionId()).Wrap(err)
+	}
+	return &pluginv1.PluginHostServiceLeaveFocusResponse{}, nil
+}
+
+func (s *pluginHostServiceServer) PresentFocus(ctx context.Context, req *pluginv1.PluginHostServicePresentFocusRequest) (*pluginv1.PluginHostServicePresentFocusResponse, error) {
+	if s.host == nil {
+		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	fc := s.host.FocusCoordinator()
+	if fc == nil {
+		return nil, oops.With("plugin", s.pluginName).New("focus coordinator not configured")
+	}
+
+	key, err := protoToFocusKey(req.GetTarget())
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
+	}
+
+	if err := fc.PresentFocus(ctx, req.GetSessionId(), key); err != nil {
+		return nil, oops.With("plugin", s.pluginName).With("session_id", req.GetSessionId()).Wrap(err)
+	}
+	return &pluginv1.PluginHostServicePresentFocusResponse{}, nil
+}
+
+// protoToFocusKey converts a proto FocusKey to the session.FocusKey domain type.
+func protoToFocusKey(pk *pluginv1.FocusKey) (session.FocusKey, error) {
+	if pk == nil {
+		return session.FocusKey{}, oops.Code("INVALID_ARGUMENT").
+			Errorf("focus key is required")
+	}
+
+	targetID, err := ulid.Parse(pk.GetTargetId())
+	if err != nil {
+		return session.FocusKey{}, oops.Code("INVALID_ARGUMENT").
+			With("target_id", pk.GetTargetId()).
+			Wrap(err)
+	}
+
+	kind, err := protoToFocusKind(pk.GetKind())
+	if err != nil {
+		return session.FocusKey{}, err
+	}
+
+	return session.FocusKey{Kind: kind, TargetID: targetID}, nil
+}
+
+// protoToFocusKind maps proto FocusKind to session.FocusKind.
+func protoToFocusKind(pk pluginv1.FocusKind) (session.FocusKind, error) {
+	switch pk {
+	case pluginv1.FocusKind_FOCUS_KIND_SCENE:
+		return session.FocusKindScene, nil
+	default:
+		return "", oops.Code("FOCUS_KIND_UNREGISTERED").
+			With("kind", pk.String()).
+			Errorf("unsupported focus kind: %s", pk.String())
+	}
+}
+
+const maxQueryStreamHistoryCount = 500
+
+func (s *pluginHostServiceServer) QueryStreamHistory(ctx context.Context, req *pluginv1.PluginHostServiceQueryStreamHistoryRequest) (*pluginv1.PluginHostServiceQueryStreamHistoryResponse, error) {
+	if s.host == nil {
+		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	es := s.host.EventStore()
+	if es == nil {
+		return nil, oops.With("plugin", s.pluginName).New("event store not configured")
+	}
+
+	count := int(req.GetCount())
+	if count < 0 {
+		return nil, oops.Code("INVALID_ARGUMENT").
+			With("count", req.GetCount()).
+			Errorf("count must be non-negative")
+	}
+	if count > maxQueryStreamHistoryCount {
+		count = maxQueryStreamHistoryCount
+	}
+
+	var notBefore time.Time
+	if req.GetNotBeforeMs() > 0 {
+		notBefore = time.UnixMilli(req.GetNotBeforeMs()).UTC()
+	}
+
+	events, err := es.ReplayTail(ctx, req.GetStream(), count, notBefore)
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).With("stream", req.GetStream()).Wrap(err)
+	}
+
+	protoEvents := make([]*pluginv1.Event, 0, len(events))
+	for _, e := range events {
+		protoEvents = append(protoEvents, coreEventToProto(e))
+	}
+	return &pluginv1.PluginHostServiceQueryStreamHistoryResponse{Events: protoEvents}, nil
+}
+
+// coreEventToProto converts a core.Event to the plugin proto Event.
+func coreEventToProto(e core.Event) *pluginv1.Event {
+	return &pluginv1.Event{
+		Id:        e.ID.String(),
+		Stream:    e.Stream,
+		Type:      string(e.Type),
+		Timestamp: e.Timestamp.UnixMilli(),
+		ActorKind: e.Actor.Kind.String(),
+		ActorId:   e.Actor.ID,
+		Payload:   string(e.Payload),
+	}
 }
 
 func sdkActorKindToCore(kind pluginsdk.ActorKind) core.ActorKind {

--- a/internal/plugin/goplugin/host_service_test.go
+++ b/internal/plugin/goplugin/host_service_test.go
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package goplugin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// stubCoordinator records calls for assertion.
+type stubCoordinator struct {
+	joinCalls    []focusCall
+	leaveCalls   []focusCall
+	presentCalls []focusCall
+	joinErr      error
+	leaveErr     error
+	presentErr   error
+}
+
+type focusCall struct {
+	sessionID string
+	key       session.FocusKey
+}
+
+func (s *stubCoordinator) JoinFocus(_ context.Context, sid string, target session.FocusKey) error {
+	s.joinCalls = append(s.joinCalls, focusCall{sid, target})
+	return s.joinErr
+}
+
+func (s *stubCoordinator) LeaveFocus(_ context.Context, sid string, target session.FocusKey) error {
+	s.leaveCalls = append(s.leaveCalls, focusCall{sid, target})
+	return s.leaveErr
+}
+
+func (s *stubCoordinator) PresentFocus(_ context.Context, sid string, target session.FocusKey) error {
+	s.presentCalls = append(s.presentCalls, focusCall{sid, target})
+	return s.presentErr
+}
+
+func (s *stubCoordinator) RestoreFocus(_ context.Context, _ string) (focus.RestorePlan, error) {
+	return focus.RestorePlan{}, nil
+}
+
+var _ focus.Coordinator = (*stubCoordinator)(nil)
+
+// stubEventStore implements core.EventStore with only ReplayTail wired.
+type stubEventStore struct {
+	core.EventStore  // embed to satisfy interface; panics on unimplemented methods
+	replayTailCalls  []replayTailCall
+	replayTailResult []core.Event
+	replayTailErr    error
+}
+
+type replayTailCall struct {
+	stream    string
+	count     int
+	notBefore time.Time
+}
+
+func (s *stubEventStore) ReplayTail(_ context.Context, stream string, count int, notBefore time.Time) ([]core.Event, error) {
+	s.replayTailCalls = append(s.replayTailCalls, replayTailCall{stream, count, notBefore})
+	return s.replayTailResult, s.replayTailErr
+}
+
+func newTestServer(fc focus.Coordinator, es core.EventStore) *pluginHostServiceServer {
+	h := &Host{
+		plugins:          make(map[string]*loadedPlugin),
+		focusCoordinator: fc,
+		eventStore:       es,
+	}
+	return &pluginHostServiceServer{
+		host:       h,
+		pluginName: "test-plugin",
+	}
+}
+
+func TestJoinFocusDelegatesToCoordinatorWithParsedFocusKey(t *testing.T) {
+	fc := &stubCoordinator{}
+	srv := newTestServer(fc, nil)
+
+	targetID := ulid.Make()
+	resp, err := srv.JoinFocus(context.Background(), &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: targetID.String(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, fc.joinCalls, 1)
+	assert.Equal(t, "sess-1", fc.joinCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fc.joinCalls[0].key.Kind)
+	assert.Equal(t, targetID, fc.joinCalls[0].key.TargetID)
+}
+
+func TestJoinFocusReturnsErrorWhenCoordinatorFails(t *testing.T) {
+	fc := &stubCoordinator{joinErr: oops.Code("FOCUS_ALREADY_MEMBER").Errorf("already member")}
+	srv := newTestServer(fc, nil)
+
+	_, err := srv.JoinFocus(context.Background(), &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestJoinFocusReturnsErrorWhenCoordinatorIsNil(t *testing.T) {
+	srv := newTestServer(nil, nil)
+
+	_, err := srv.JoinFocus(context.Background(), &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestLeaveFocusDelegatesToCoordinatorWithParsedFocusKey(t *testing.T) {
+	fc := &stubCoordinator{}
+	srv := newTestServer(fc, nil)
+
+	targetID := ulid.Make()
+	resp, err := srv.LeaveFocus(context.Background(), &pluginv1.PluginHostServiceLeaveFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: targetID.String(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, fc.leaveCalls, 1)
+	assert.Equal(t, "sess-1", fc.leaveCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fc.leaveCalls[0].key.Kind)
+	assert.Equal(t, targetID, fc.leaveCalls[0].key.TargetID)
+}
+
+func TestLeaveFocusReturnsErrorWhenCoordinatorIsNil(t *testing.T) {
+	srv := newTestServer(nil, nil)
+
+	_, err := srv.LeaveFocus(context.Background(), &pluginv1.PluginHostServiceLeaveFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestPresentFocusDelegatesToCoordinatorWithParsedFocusKey(t *testing.T) {
+	fc := &stubCoordinator{}
+	srv := newTestServer(fc, nil)
+
+	targetID := ulid.Make()
+	resp, err := srv.PresentFocus(context.Background(), &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: targetID.String(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, fc.presentCalls, 1)
+	assert.Equal(t, "sess-1", fc.presentCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fc.presentCalls[0].key.Kind)
+	assert.Equal(t, targetID, fc.presentCalls[0].key.TargetID)
+}
+
+func TestPresentFocusReturnsErrorWhenCoordinatorIsNil(t *testing.T) {
+	srv := newTestServer(nil, nil)
+
+	_, err := srv.PresentFocus(context.Background(), &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestPresentFocusReturnsErrorWhenCoordinatorFails(t *testing.T) {
+	fc := &stubCoordinator{presentErr: oops.Code("FOCUS_NOT_MEMBER").Errorf("not member")}
+	srv := newTestServer(fc, nil)
+
+	_, err := srv.PresentFocus(context.Background(), &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestQueryStreamHistoryDelegatesToEventStore(t *testing.T) {
+	es := &stubEventStore{
+		replayTailResult: []core.Event{
+			{Stream: "channel:abc", Type: "say", Payload: []byte(`{"text":"hi"}`)},
+		},
+	}
+	srv := newTestServer(nil, es)
+
+	resp, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream: "channel:abc",
+		Count:  10,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetEvents(), 1)
+	assert.Equal(t, "channel:abc", resp.GetEvents()[0].GetStream())
+
+	require.Len(t, es.replayTailCalls, 1)
+	assert.Equal(t, "channel:abc", es.replayTailCalls[0].stream)
+	assert.Equal(t, 10, es.replayTailCalls[0].count)
+}
+
+func TestQueryStreamHistoryCapsCountAt500(t *testing.T) {
+	es := &stubEventStore{}
+	srv := newTestServer(nil, es)
+
+	_, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream: "channel:abc",
+		Count:  1000,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, es.replayTailCalls, 1)
+	assert.Equal(t, 500, es.replayTailCalls[0].count)
+}
+
+func TestQueryStreamHistoryConvertsNotBeforeMs(t *testing.T) {
+	es := &stubEventStore{}
+	srv := newTestServer(nil, es)
+
+	_, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream:      "channel:abc",
+		Count:       10,
+		NotBeforeMs: 1700000000000,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, es.replayTailCalls, 1)
+	assert.Equal(t, time.UnixMilli(1700000000000).UTC(), es.replayTailCalls[0].notBefore)
+}
+
+func TestQueryStreamHistoryReturnsErrorWhenEventStoreIsNil(t *testing.T) {
+	srv := newTestServer(nil, nil)
+
+	_, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream: "channel:abc",
+		Count:  10,
+	})
+	require.Error(t, err)
+}
+
+func TestJoinFocusReturnsErrorWhenHostIsNil(t *testing.T) {
+	srv := &pluginHostServiceServer{pluginName: "test-plugin"}
+	_, err := srv.JoinFocus(context.Background(), &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin host service is not configured")
+}
+
+func TestLeaveFocusReturnsErrorWhenHostIsNil(t *testing.T) {
+	srv := &pluginHostServiceServer{pluginName: "test-plugin"}
+	_, err := srv.LeaveFocus(context.Background(), &pluginv1.PluginHostServiceLeaveFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin host service is not configured")
+}
+
+func TestPresentFocusReturnsErrorWhenHostIsNil(t *testing.T) {
+	srv := &pluginHostServiceServer{pluginName: "test-plugin"}
+	_, err := srv.PresentFocus(context.Background(), &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: "sess-1",
+		Target: &pluginv1.FocusKey{
+			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+			TargetId: ulid.Make().String(),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin host service is not configured")
+}
+
+func TestQueryStreamHistoryReturnsErrorWhenHostIsNil(t *testing.T) {
+	srv := &pluginHostServiceServer{pluginName: "test-plugin"}
+	_, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream: "channel:abc",
+		Count:  10,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin host service is not configured")
+}
+
+func TestQueryStreamHistoryRejectsNegativeCount(t *testing.T) {
+	es := &stubEventStore{}
+	srv := newTestServer(nil, es)
+
+	_, err := srv.QueryStreamHistory(context.Background(), &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream: "channel:abc",
+		Count:  -5,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count must be non-negative")
+}
+
+func TestProtoToFocusKeyReturnsErrorForNilKey(t *testing.T) {
+	_, err := protoToFocusKey(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "focus key is required")
+}
+
+func TestProtoToFocusKeyReturnsErrorForInvalidULID(t *testing.T) {
+	_, err := protoToFocusKey(&pluginv1.FocusKey{
+		Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
+		TargetId: "not-a-ulid",
+	})
+	require.Error(t, err)
+}
+
+func TestProtoToFocusKindReturnsErrorForUnspecified(t *testing.T) {
+	_, err := protoToFocusKind(pluginv1.FocusKind_FOCUS_KIND_UNSPECIFIED)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported focus kind")
+}
+
+func TestCoreEventToProtoConvertsAllFields(t *testing.T) {
+	eventID := ulid.Make()
+	ts := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
+	e := core.Event{
+		ID:        eventID,
+		Stream:    "scene:abc:ic",
+		Type:      "say",
+		Timestamp: ts,
+		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-1"},
+		Payload:   []byte(`{"text":"hello"}`),
+	}
+
+	pe := coreEventToProto(e)
+	assert.Equal(t, eventID.String(), pe.GetId())
+	assert.Equal(t, "scene:abc:ic", pe.GetStream())
+	assert.Equal(t, "say", pe.GetType())
+	assert.Equal(t, ts.UnixMilli(), pe.GetTimestamp())
+	assert.Equal(t, "character", pe.GetActorKind())
+	assert.Equal(t, "char-1", pe.GetActorId())
+	assert.Equal(t, `{"text":"hello"}`, pe.GetPayload())
+}

--- a/internal/plugin/goplugin/host_test.go
+++ b/internal/plugin/goplugin/host_test.go
@@ -1730,3 +1730,39 @@ func TestGopluginHostQuerySessionStreamsReturnsErrorForUnknownPlugin(t *testing.
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrPluginNotLoaded)
 }
+
+func TestHostFocusCoordinatorReturnsNilByDefault(t *testing.T) {
+	host := NewHost()
+	assert.Nil(t, host.FocusCoordinator())
+}
+
+func TestHostEventStoreReturnsNilByDefault(t *testing.T) {
+	host := NewHost()
+	assert.Nil(t, host.EventStore())
+}
+
+func TestHostSetFocusCoordinatorStoresAndReturnsCoordinator(t *testing.T) {
+	host := NewHost()
+	fc := &stubCoordinator{}
+	host.SetFocusCoordinator(fc)
+	assert.Equal(t, fc, host.FocusCoordinator())
+}
+
+func TestHostSetEventStoreStoresAndReturnsEventStore(t *testing.T) {
+	host := NewHost()
+	es := &stubEventStore{}
+	host.SetEventStore(es)
+	assert.Equal(t, es, host.EventStore())
+}
+
+func TestHostWithFocusCoordinatorOptionSetsCoordinator(t *testing.T) {
+	fc := &stubCoordinator{}
+	host := NewHost(WithFocusCoordinator(fc))
+	assert.Equal(t, fc, host.FocusCoordinator())
+}
+
+func TestHostWithEventStoreOptionSetsEventStore(t *testing.T) {
+	es := &stubEventStore{}
+	host := NewHost(WithEventStore(es))
+	assert.Equal(t, es, host.EventStore())
+}

--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -7,6 +7,9 @@ package plugins
 import (
 	"context"
 
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 	"google.golang.org/grpc"
@@ -24,9 +27,11 @@ type SessionStreamsRequest struct {
 
 // StreamRegistry allows plugins to modify session stream subscriptions mid-session.
 type StreamRegistry interface {
-	// AddStream subscribes a session to an additional stream.
+	// AddStream subscribes a session to an additional stream with default FROM_CURSOR replay.
 	// Returns an error (code SESSION_NOT_FOUND) if the session is not active.
 	AddStream(ctx context.Context, sessionID, stream string) error
+	// AddStreamWithMode subscribes with an explicit replay mode (e.g., LIVE_ONLY for channels).
+	AddStreamWithMode(ctx context.Context, sessionID, stream string, mode session.ReplayMode) error
 	// RemoveStream unsubscribes a session from a stream. Idempotent.
 	RemoveStream(ctx context.Context, sessionID, stream string) error
 }
@@ -86,4 +91,12 @@ type PluginIntentEmitter interface {
 // shared plugin event emitter injected after construction.
 type EventEmitterConfigurer interface {
 	SetEventEmitter(emitter PluginIntentEmitter)
+}
+
+// FocusDepsConfigurer is an optional interface for hosts that need the focus
+// coordinator and event store injected after construction. These dependencies
+// are created during gRPC subsystem Start, which runs after plugin loading.
+type FocusDepsConfigurer interface {
+	SetFocusCoordinator(fc focus.Coordinator)
+	SetEventStore(es core.EventStore)
 }

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -46,6 +46,8 @@ type Functions struct {
 	sessionAccess    session.Access
 	capabilities     *CapabilityRegistry
 	streamRegistry   plugins.StreamRegistry
+	focusOps         FocusOps
+	historyReader    HistoryReader
 }
 
 // Option configures Functions.
@@ -88,6 +90,30 @@ func WithStreamRegistry(r plugins.StreamRegistry) Option {
 	return func(f *Functions) {
 		f.streamRegistry = r
 	}
+}
+
+// WithFocusOps sets the focus coordinator for join/leave/present focus host functions.
+func WithFocusOps(fo FocusOps) Option {
+	return func(f *Functions) { f.focusOps = fo }
+}
+
+// WithHistoryReader sets the event store reader for query_stream_history host function.
+func WithHistoryReader(hr HistoryReader) Option {
+	return func(f *Functions) { f.historyReader = hr }
+}
+
+// SetFocusOps sets the focus coordinator for join/leave/present focus host
+// functions. Supports late-binding: the coordinator is created during gRPC
+// subsystem Start, which runs after plugin loading. Lua VMs are created
+// per-event delivery, so the value is read at Register time.
+func (f *Functions) SetFocusOps(fo FocusOps) {
+	f.focusOps = fo
+}
+
+// SetHistoryReader sets the event store reader for query_stream_history host
+// function. Same late-binding rationale as SetFocusOps.
+func (f *Functions) SetHistoryReader(hr HistoryReader) {
+	f.historyReader = hr
 }
 
 // New creates host functions with dependencies.
@@ -155,6 +181,9 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 
 	// Register stream management functions (always; guard against nil registry inside).
 	RegisterStreamFuncs(ls, mod, f.streamRegistry)
+
+	// Register focus management functions.
+	RegisterFocusFuncs(ls, mod, f.focusOps, f.historyReader)
 
 	ls.SetGlobal("holomush", mod)
 

--- a/internal/plugin/hostfunc/functions_test.go
+++ b/internal/plugin/hostfunc/functions_test.go
@@ -755,3 +755,47 @@ func (s *slowKVStore) Delete(ctx context.Context, _, _ string) error {
 		return fmt.Errorf("slow kv delete: %w", ctx.Err())
 	}
 }
+
+func TestSetFocusOpsLateBindingMakesCallsAvailable(t *testing.T) {
+	hf := hostfunc.New(nil)
+
+	// Before SetFocusOps, calls are no-ops (nil focus ops).
+	L := lua.NewState()
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+	targetID := ulid.Make()
+	require.NoError(t, L.DoString(`holomush.join_focus("s", "scene", "`+targetID.String()+`")`))
+
+	// After SetFocusOps, calls route to the new ops.
+	fo := &mockFocusOps{}
+	hf.SetFocusOps(fo)
+
+	L2 := lua.NewState()
+	defer L2.Close()
+	hf.Register(L2, "test-plugin")
+	targetID2 := ulid.Make()
+	require.NoError(t, L2.DoString(`holomush.join_focus("sess-1", "scene", "`+targetID2.String()+`")`))
+	require.Len(t, fo.joinCalls, 1)
+	assert.Equal(t, "sess-1", fo.joinCalls[0].sessionID)
+}
+
+func TestSetHistoryReaderLateBindingMakesCallsAvailable(t *testing.T) {
+	hf := hostfunc.New(nil)
+
+	// Before SetHistoryReader, calls are no-ops (nil reader).
+	L := lua.NewState()
+	defer L.Close()
+	hf.Register(L, "test-plugin")
+	require.NoError(t, L.DoString(`holomush.query_stream_history("scene:abc:ic", 10)`))
+
+	// After SetHistoryReader, calls route to the new reader.
+	hr := &mockHistoryReader{}
+	hf.SetHistoryReader(hr)
+
+	L2 := lua.NewState()
+	defer L2.Close()
+	hf.Register(L2, "test-plugin")
+	require.NoError(t, L2.DoString(`holomush.query_stream_history("scene:abc:ic", 10)`))
+	require.Len(t, hr.calls, 1)
+	assert.Equal(t, "scene:abc:ic", hr.calls[0].stream)
+}

--- a/internal/plugin/hostfunc/stdlib_focus.go
+++ b/internal/plugin/hostfunc/stdlib_focus.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
+)
+
+const (
+	focusOpsKey      = "__holo_focus_ops"
+	historyReaderKey = "__holo_history_reader"
+)
+
+// FocusOps is a narrow interface for focus coordinator operations exposed to Lua plugins.
+type FocusOps interface {
+	JoinFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+	LeaveFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+	PresentFocus(ctx context.Context, sessionID string, target session.FocusKey) error
+}
+
+// HistoryReader provides read-only event history access for Lua plugins.
+type HistoryReader interface {
+	ReplayTail(ctx context.Context, stream string, count int, notBefore time.Time) ([]core.Event, error)
+}
+
+// RegisterFocusFuncs adds holomush.join_focus, leave_focus, present_focus,
+// and query_stream_history to an existing holomush module table.
+func RegisterFocusFuncs(ls *lua.LState, mod *lua.LTable, fo FocusOps, hr HistoryReader) {
+	if fo != nil {
+		ud := ls.NewUserData()
+		ud.Value = fo
+		ls.SetGlobal(focusOpsKey, ud)
+	}
+	if hr != nil {
+		ud := ls.NewUserData()
+		ud.Value = hr
+		ls.SetGlobal(historyReaderKey, ud)
+	}
+
+	ls.SetField(mod, "join_focus", ls.NewFunction(joinFocusFn))
+	ls.SetField(mod, "leave_focus", ls.NewFunction(leaveFocusFn))
+	ls.SetField(mod, "present_focus", ls.NewFunction(presentFocusFn))
+	ls.SetField(mod, "query_stream_history", ls.NewFunction(queryStreamHistoryFn))
+}
+
+func getFocusOps(ls *lua.LState) FocusOps {
+	ud := ls.GetGlobal(focusOpsKey)
+	if ud.Type() == lua.LTUserData {
+		if userData, ok := ud.(*lua.LUserData); ok {
+			if fo, ok := userData.Value.(FocusOps); ok {
+				return fo
+			}
+		}
+	}
+	return nil
+}
+
+func getHistoryReader(ls *lua.LState) HistoryReader {
+	ud := ls.GetGlobal(historyReaderKey)
+	if ud.Type() == lua.LTUserData {
+		if userData, ok := ud.(*lua.LUserData); ok {
+			if hr, ok := userData.Value.(HistoryReader); ok {
+				return hr
+			}
+		}
+	}
+	return nil
+}
+
+func parseFocusKey(kindStr, targetIDStr string) (session.FocusKey, error) {
+	targetID, err := ulid.Parse(targetIDStr)
+	if err != nil {
+		return session.FocusKey{}, fmt.Errorf("invalid target_id %q: %w", targetIDStr, err)
+	}
+	return session.FocusKey{
+		Kind:     session.FocusKind(kindStr),
+		TargetID: targetID,
+	}, nil
+}
+
+// joinFocusFn implements holomush.join_focus(session_id, kind, target_id).
+// Returns true on success; returns (nil, error_string) on failure.
+func joinFocusFn(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	kind := ls.CheckString(2)
+	targetID := ls.CheckString(3)
+
+	fo := getFocusOps(ls)
+	if fo == nil {
+		slog.Warn("holomush.join_focus: focus ops not initialized")
+		return 0
+	}
+
+	key, err := parseFocusKey(kind, targetID)
+	if err != nil {
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, defaultPluginQueryTimeout)
+	defer cancel()
+
+	if err := fo.JoinFocus(ctx, sessionID, key); err != nil {
+		slog.WarnContext(ctx, "holomush.join_focus failed",
+			"session_id", sessionID, "kind", kind, "target_id", targetID, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// leaveFocusFn implements holomush.leave_focus(session_id, kind, target_id).
+// Returns true on success; returns (nil, error_string) on failure.
+func leaveFocusFn(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	kind := ls.CheckString(2)
+	targetID := ls.CheckString(3)
+
+	fo := getFocusOps(ls)
+	if fo == nil {
+		slog.Warn("holomush.leave_focus: focus ops not initialized")
+		return 0
+	}
+
+	key, err := parseFocusKey(kind, targetID)
+	if err != nil {
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, defaultPluginQueryTimeout)
+	defer cancel()
+
+	if err := fo.LeaveFocus(ctx, sessionID, key); err != nil {
+		slog.WarnContext(ctx, "holomush.leave_focus failed",
+			"session_id", sessionID, "kind", kind, "target_id", targetID, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// presentFocusFn implements holomush.present_focus(session_id, kind, target_id).
+// Returns true on success; returns (nil, error_string) on failure.
+func presentFocusFn(ls *lua.LState) int {
+	sessionID := ls.CheckString(1)
+	kind := ls.CheckString(2)
+	targetID := ls.CheckString(3)
+
+	fo := getFocusOps(ls)
+	if fo == nil {
+		slog.Warn("holomush.present_focus: focus ops not initialized")
+		return 0
+	}
+
+	key, err := parseFocusKey(kind, targetID)
+	if err != nil {
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, defaultPluginQueryTimeout)
+	defer cancel()
+
+	if err := fo.PresentFocus(ctx, sessionID, key); err != nil {
+		slog.WarnContext(ctx, "holomush.present_focus failed",
+			"session_id", sessionID, "kind", kind, "target_id", targetID, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+	ls.Push(lua.LTrue)
+	return 1
+}
+
+// queryStreamHistoryFn implements holomush.query_stream_history(stream, count, [not_before_ms]).
+// Returns a table of event tables on success; returns (nil, error_string) on failure.
+const maxHistoryCount = 500
+
+func queryStreamHistoryFn(ls *lua.LState) int {
+	stream := ls.CheckString(1)
+	count := ls.CheckInt(2)
+	if count > maxHistoryCount {
+		count = maxHistoryCount
+	}
+	if count < 0 {
+		count = 0
+	}
+	notBeforeMs := ls.OptInt64(3, 0)
+
+	hr := getHistoryReader(ls)
+	if hr == nil {
+		slog.Warn("holomush.query_stream_history: history reader not initialized")
+		return 0
+	}
+
+	var notBefore time.Time
+	if notBeforeMs > 0 {
+		notBefore = time.UnixMilli(notBeforeMs).UTC()
+	}
+
+	ctx := ls.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, defaultPluginQueryTimeout)
+	defer cancel()
+
+	events, err := hr.ReplayTail(ctx, stream, count, notBefore)
+	if err != nil {
+		slog.WarnContext(ctx, "holomush.query_stream_history failed",
+			"stream", stream, "error", err)
+		ls.Push(lua.LNil)
+		ls.Push(lua.LString(err.Error()))
+		return 2
+	}
+
+	result := ls.NewTable()
+	for i, e := range events {
+		et := ls.NewTable()
+		ls.SetField(et, "id", lua.LString(e.ID.String()))
+		ls.SetField(et, "stream", lua.LString(e.Stream))
+		ls.SetField(et, "type", lua.LString(string(e.Type)))
+		ls.SetField(et, "timestamp", lua.LNumber(e.Timestamp.UnixMilli()))
+		ls.SetField(et, "actor_kind", lua.LString(e.Actor.Kind.String()))
+		ls.SetField(et, "actor_id", lua.LString(e.Actor.ID))
+		ls.SetField(et, "payload", lua.LString(string(e.Payload)))
+		result.RawSetInt(i+1, et)
+	}
+	ls.Push(result)
+	return 1
+}

--- a/internal/plugin/hostfunc/stdlib_focus_test.go
+++ b/internal/plugin/hostfunc/stdlib_focus_test.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/session"
+)
+
+type mockFocusOps struct {
+	joinCalls    []focusOpCall
+	leaveCalls   []focusOpCall
+	presentCalls []focusOpCall
+	joinErr      error
+	leaveErr     error
+	presentErr   error
+}
+
+type focusOpCall struct {
+	sessionID string
+	key       session.FocusKey
+}
+
+func (m *mockFocusOps) JoinFocus(_ context.Context, sid string, key session.FocusKey) error {
+	m.joinCalls = append(m.joinCalls, focusOpCall{sid, key})
+	return m.joinErr
+}
+
+func (m *mockFocusOps) LeaveFocus(_ context.Context, sid string, key session.FocusKey) error {
+	m.leaveCalls = append(m.leaveCalls, focusOpCall{sid, key})
+	return m.leaveErr
+}
+
+func (m *mockFocusOps) PresentFocus(_ context.Context, sid string, key session.FocusKey) error {
+	m.presentCalls = append(m.presentCalls, focusOpCall{sid, key})
+	return m.presentErr
+}
+
+type mockHistoryReader struct {
+	calls  []historyCall
+	result []core.Event
+	err    error
+}
+
+type historyCall struct {
+	stream    string
+	count     int
+	notBefore time.Time
+}
+
+func (m *mockHistoryReader) ReplayTail(_ context.Context, stream string, count int, notBefore time.Time) ([]core.Event, error) {
+	m.calls = append(m.calls, historyCall{stream, count, notBefore})
+	return m.result, m.err
+}
+
+func newFocusTestState(t *testing.T, fo hostfunc.FocusOps, hr hostfunc.HistoryReader) *lua.LState {
+	t.Helper()
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+	hf := hostfunc.New(nil,
+		hostfunc.WithFocusOps(fo),
+		hostfunc.WithHistoryReader(hr),
+	)
+	hf.Register(L, "test-plugin")
+	return L
+}
+
+func TestJoinFocusCallsCoordinatorWithCorrectArgs(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	targetID := ulid.Make()
+	err := L.DoString(`holomush.join_focus("sess-1", "scene", "` + targetID.String() + `")`)
+	require.NoError(t, err)
+
+	require.Len(t, fo.joinCalls, 1)
+	assert.Equal(t, "sess-1", fo.joinCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fo.joinCalls[0].key.Kind)
+	assert.Equal(t, targetID, fo.joinCalls[0].key.TargetID)
+}
+
+func TestJoinFocusReturnsTrueOnSuccess(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok = holomush.join_focus("sess-1", "scene", "` + ulid.Make().String() + `")
+assert(ok == true, "expected true, got: " .. tostring(ok))
+`)
+	require.NoError(t, err)
+}
+
+func TestJoinFocusReturnsNilAndErrorOnFailure(t *testing.T) {
+	fo := &mockFocusOps{joinErr: errors.New("already member")}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.join_focus("sess-1", "scene", "` + ulid.Make().String() + `")
+assert(ok == nil, "expected nil on error")
+assert(errmsg == "already member", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+}
+
+func TestLeaveFocusCallsCoordinatorWithCorrectArgs(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	targetID := ulid.Make()
+	err := L.DoString(`holomush.leave_focus("sess-2", "scene", "` + targetID.String() + `")`)
+	require.NoError(t, err)
+
+	require.Len(t, fo.leaveCalls, 1)
+	assert.Equal(t, "sess-2", fo.leaveCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fo.leaveCalls[0].key.Kind)
+	assert.Equal(t, targetID, fo.leaveCalls[0].key.TargetID)
+}
+
+func TestLeaveFocusReturnsTrueOnSuccess(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok = holomush.leave_focus("sess-2", "scene", "` + ulid.Make().String() + `")
+assert(ok == true, "expected true, got: " .. tostring(ok))
+`)
+	require.NoError(t, err)
+}
+
+func TestLeaveFocusReturnsNilAndErrorOnFailure(t *testing.T) {
+	fo := &mockFocusOps{leaveErr: errors.New("not a member")}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.leave_focus("sess-2", "scene", "` + ulid.Make().String() + `")
+assert(ok == nil, "expected nil on error")
+assert(errmsg == "not a member", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+}
+
+func TestPresentFocusCallsCoordinatorWithCorrectArgs(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	targetID := ulid.Make()
+	err := L.DoString(`holomush.present_focus("sess-3", "scene", "` + targetID.String() + `")`)
+	require.NoError(t, err)
+
+	require.Len(t, fo.presentCalls, 1)
+	assert.Equal(t, "sess-3", fo.presentCalls[0].sessionID)
+	assert.Equal(t, session.FocusKindScene, fo.presentCalls[0].key.Kind)
+	assert.Equal(t, targetID, fo.presentCalls[0].key.TargetID)
+}
+
+func TestPresentFocusReturnsTrueOnSuccess(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok = holomush.present_focus("sess-3", "scene", "` + ulid.Make().String() + `")
+assert(ok == true, "expected true, got: " .. tostring(ok))
+`)
+	require.NoError(t, err)
+}
+
+func TestPresentFocusReturnsNilAndErrorOnFailure(t *testing.T) {
+	fo := &mockFocusOps{presentErr: errors.New("focus not found")}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.present_focus("sess-3", "scene", "` + ulid.Make().String() + `")
+assert(ok == nil, "expected nil on error")
+assert(errmsg == "focus not found", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+}
+
+func TestQueryStreamHistoryCallsReaderWithCorrectArgs(t *testing.T) {
+	hr := &mockHistoryReader{result: []core.Event{}}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`holomush.query_stream_history("scene:01ABC:ic", 10, 1700000000000)`)
+	require.NoError(t, err)
+
+	require.Len(t, hr.calls, 1)
+	assert.Equal(t, "scene:01ABC:ic", hr.calls[0].stream)
+	assert.Equal(t, 10, hr.calls[0].count)
+	assert.Equal(t, time.UnixMilli(1700000000000).UTC(), hr.calls[0].notBefore)
+}
+
+func TestQueryStreamHistoryReturnsEventTableOnSuccess(t *testing.T) {
+	targetID := ulid.Make()
+	ev := core.Event{
+		ID:        targetID,
+		Stream:    "scene:abc:ic",
+		Type:      core.EventTypeSay,
+		Timestamp: time.UnixMilli(1700000000000).UTC(),
+		Actor:     core.Actor{Kind: core.ActorCharacter, ID: "char-1"},
+		Payload:   []byte(`{"msg":"hello"}`),
+	}
+	hr := &mockHistoryReader{result: []core.Event{ev}}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`
+local events = holomush.query_stream_history("scene:abc:ic", 5)
+assert(type(events) == "table", "expected table, got: " .. type(events))
+assert(#events == 1, "expected 1 event, got: " .. #events)
+local e = events[1]
+assert(e.stream == "scene:abc:ic", "wrong stream: " .. tostring(e.stream))
+assert(e.type == "say", "wrong type: " .. tostring(e.type))
+assert(e.actor_kind == "character", "wrong actor_kind: " .. tostring(e.actor_kind))
+assert(e.actor_id == "char-1", "wrong actor_id: " .. tostring(e.actor_id))
+assert(e.payload == '{"msg":"hello"}', "wrong payload: " .. tostring(e.payload))
+`)
+	require.NoError(t, err)
+}
+
+func TestQueryStreamHistoryReturnsNilAndErrorOnFailure(t *testing.T) {
+	hr := &mockHistoryReader{err: errors.New("store unavailable")}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`
+local events, errmsg = holomush.query_stream_history("scene:abc:ic", 5)
+assert(events == nil, "expected nil on error")
+assert(errmsg == "store unavailable", "expected error message, got: " .. tostring(errmsg))
+`)
+	require.NoError(t, err)
+}
+
+func TestQueryStreamHistoryWithZeroNotBeforePassesZeroTime(t *testing.T) {
+	hr := &mockHistoryReader{result: []core.Event{}}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`holomush.query_stream_history("scene:abc:ic", 5)`)
+	require.NoError(t, err)
+
+	require.Len(t, hr.calls, 1)
+	assert.True(t, hr.calls[0].notBefore.IsZero(), "expected zero time when not_before_ms omitted")
+}
+
+func TestQueryStreamHistoryWithNilReaderIsNoOp(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	err := L.DoString(`holomush.query_stream_history("scene:abc:ic", 10)`)
+	require.NoError(t, err)
+}
+
+func TestFocusFuncsWithNilOpsAreNoOps(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	hf := hostfunc.New(nil)
+	hf.Register(L, "test-plugin")
+
+	require.NoError(t, L.DoString(`holomush.join_focus("s", "scene", "`+ulid.Make().String()+`")`))
+	require.NoError(t, L.DoString(`holomush.leave_focus("s", "scene", "`+ulid.Make().String()+`")`))
+	require.NoError(t, L.DoString(`holomush.present_focus("s", "scene", "`+ulid.Make().String()+`")`))
+}
+
+func TestQueryStreamHistoryClampsCountAbove500ToMax(t *testing.T) {
+	hr := &mockHistoryReader{result: []core.Event{}}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`holomush.query_stream_history("scene:abc:ic", 1000)`)
+	require.NoError(t, err)
+
+	require.Len(t, hr.calls, 1)
+	assert.Equal(t, 500, hr.calls[0].count)
+}
+
+func TestQueryStreamHistoryClampsNegativeCountToZero(t *testing.T) {
+	hr := &mockHistoryReader{result: []core.Event{}}
+	L := newFocusTestState(t, nil, hr)
+
+	err := L.DoString(`holomush.query_stream_history("scene:abc:ic", -5)`)
+	require.NoError(t, err)
+
+	require.Len(t, hr.calls, 1)
+	assert.Equal(t, 0, hr.calls[0].count)
+}
+
+func TestJoinFocusReturnsErrorForInvalidULID(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.join_focus("sess-1", "scene", "not-a-ulid")
+assert(ok == nil, "expected nil on error")
+assert(errmsg ~= nil, "expected error message")
+`)
+	require.NoError(t, err)
+	assert.Empty(t, fo.joinCalls)
+}
+
+func TestLeaveFocusReturnsErrorForInvalidULID(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.leave_focus("sess-1", "scene", "not-a-ulid")
+assert(ok == nil, "expected nil on error")
+assert(errmsg ~= nil, "expected error message")
+`)
+	require.NoError(t, err)
+	assert.Empty(t, fo.leaveCalls)
+}
+
+func TestPresentFocusReturnsErrorForInvalidULID(t *testing.T) {
+	fo := &mockFocusOps{}
+	L := newFocusTestState(t, fo, nil)
+
+	err := L.DoString(`
+local ok, errmsg = holomush.present_focus("sess-1", "scene", "not-a-ulid")
+assert(ok == nil, "expected nil on error")
+assert(errmsg ~= nil, "expected error message")
+`)
+	require.NoError(t, err)
+	assert.Empty(t, fo.presentCalls)
+}

--- a/internal/plugin/hostfunc/stdlib_streams_test.go
+++ b/internal/plugin/hostfunc/stdlib_streams_test.go
@@ -14,6 +14,7 @@ import (
 
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
+	"github.com/holomush/holomush/internal/session"
 )
 
 // mockStreamRegistry records calls for assertion.
@@ -25,6 +26,11 @@ type mockStreamRegistry struct {
 }
 
 func (m *mockStreamRegistry) AddStream(_ context.Context, sessionID, stream string) error {
+	m.addCalls = append(m.addCalls, struct{ sessionID, stream string }{sessionID, stream})
+	return m.addErr
+}
+
+func (m *mockStreamRegistry) AddStreamWithMode(_ context.Context, sessionID, stream string, _ session.ReplayMode) error {
 	m.addCalls = append(m.addCalls, struct{ sessionID, stream string }{sessionID, stream})
 	return m.addErr
 }

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -14,14 +14,19 @@ import (
 	"github.com/samber/oops"
 	lua "github.com/yuin/gopher-lua"
 
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
 	"github.com/holomush/holomush/pkg/holo"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
 
-// Compile-time interface check.
-var _ plugins.Host = (*Host)(nil)
+// Compile-time interface checks.
+var (
+	_ plugins.Host                = (*Host)(nil)
+	_ plugins.FocusDepsConfigurer = (*Host)(nil)
+)
 
 // luaPlugin holds compiled Lua code for a plugins.
 type luaPlugin struct {
@@ -57,6 +62,22 @@ func NewHostWithFunctions(hf *hostfunc.Functions) *Host {
 		factory:   NewStateFactory(),
 		hostFuncs: hf,
 		plugins:   make(map[string]*luaPlugin),
+	}
+}
+
+// SetFocusCoordinator injects the focus coordinator into the underlying
+// hostfunc bridge. The coordinator satisfies hostfunc.FocusOps.
+func (h *Host) SetFocusCoordinator(fc focus.Coordinator) {
+	if h.hostFuncs != nil {
+		h.hostFuncs.SetFocusOps(fc)
+	}
+}
+
+// SetEventStore injects the event store into the underlying hostfunc bridge.
+// The event store satisfies hostfunc.HistoryReader.
+func (h *Host) SetEventStore(es core.EventStore) {
+	if h.hostFuncs != nil {
+		h.hostFuncs.SetHistoryReader(es)
 	}
 }
 

--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/hostfunc"
 	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
+	"github.com/holomush/holomush/internal/session"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 )
 
@@ -1650,4 +1652,67 @@ end
 	})
 	require.NoError(t, err)
 	assert.Nil(t, streams)
+}
+
+// stubLuaTestCoordinator implements focus.Coordinator for lua host tests.
+type stubLuaTestCoordinator struct{}
+
+func (s *stubLuaTestCoordinator) JoinFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubLuaTestCoordinator) LeaveFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubLuaTestCoordinator) PresentFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubLuaTestCoordinator) RestoreFocus(_ context.Context, _ string) (focus.RestorePlan, error) {
+	return focus.RestorePlan{}, nil
+}
+
+var _ focus.Coordinator = (*stubLuaTestCoordinator)(nil)
+
+func TestLuaHostSetFocusCoordinatorWithNilHostFuncsIsNoOp(t *testing.T) {
+	// NewHost() creates a host without hostFuncs — SetFocusCoordinator must not panic.
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	require.NotPanics(t, func() {
+		host.SetFocusCoordinator(&stubLuaTestCoordinator{})
+	})
+}
+
+func TestLuaHostSetEventStoreWithNilHostFuncsIsNoOp(t *testing.T) {
+	// NewHost() creates a host without hostFuncs — SetEventStore must not panic.
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	require.NotPanics(t, func() {
+		host.SetEventStore(nil)
+	})
+}
+
+func TestLuaHostSetFocusCoordinatorWithHostFuncsInjectsOps(t *testing.T) {
+	hf := hostfunc.New(nil)
+	host := pluginlua.NewHostWithFunctions(hf)
+	defer closeHost(t, host)
+
+	fc := &stubLuaTestCoordinator{}
+	require.NotPanics(t, func() {
+		host.SetFocusCoordinator(fc)
+	})
+}
+
+func TestLuaHostSetEventStoreWithHostFuncsInjectsReader(t *testing.T) {
+	hf := hostfunc.New(nil)
+	host := pluginlua.NewHostWithFunctions(hf)
+	defer closeHost(t, host)
+
+	// nil event store is valid (late-binding to clear or defer injection).
+	require.NotPanics(t, func() {
+		host.SetEventStore(nil)
+	})
 }

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 	webv1 "github.com/holomush/holomush/pkg/proto/holomush/web/v1"
@@ -243,6 +244,27 @@ func (m *Manager) ConfigureEventEmitter(store core.EventStore) {
 	if m.luaHost != nil {
 		if configurer := findOptional[EventEmitterConfigurer](m.luaHost); configurer != nil {
 			configurer.SetEventEmitter(m.eventEmitter)
+		}
+	}
+}
+
+// ConfigureFocusDeps injects the focus coordinator and event store into all
+// registered hosts. Production startup MUST call this before plugins handle
+// focus-related RPCs or host functions. Called from the gRPC subsystem's
+// Start after creating the FocusCoordinator and EventWriter.
+func (m *Manager) ConfigureFocusDeps(fc focus.Coordinator, es core.EventStore) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, host := range m.hosts {
+		if configurer := findOptional[FocusDepsConfigurer](host); configurer != nil {
+			configurer.SetFocusCoordinator(fc)
+			configurer.SetEventStore(es)
+		}
+	}
+	if m.luaHost != nil {
+		if configurer := findOptional[FocusDepsConfigurer](m.luaHost); configurer != nil {
+			configurer.SetFocusCoordinator(fc)
+			configurer.SetEventStore(es)
 		}
 	}
 }

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -20,9 +20,12 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/attribute"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
 	pluginlua "github.com/holomush/holomush/internal/plugin/lua"
 	"github.com/holomush/holomush/internal/plugin/mocks"
+	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/pkg/errutil"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
@@ -1731,4 +1734,50 @@ lua-plugin:
 
 	loaded := mgr.ListPlugins()
 	assert.Contains(t, loaded, "verby-plugin")
+}
+
+// stubFocusCoordinator is a minimal focus.Coordinator for manager tests.
+type stubFocusCoordinator struct{}
+
+func (s *stubFocusCoordinator) JoinFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubFocusCoordinator) LeaveFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubFocusCoordinator) PresentFocus(_ context.Context, _ string, _ session.FocusKey) error {
+	return nil
+}
+
+func (s *stubFocusCoordinator) RestoreFocus(_ context.Context, _ string) (focus.RestorePlan, error) {
+	return focus.RestorePlan{}, nil
+}
+
+var _ focus.Coordinator = (*stubFocusCoordinator)(nil)
+
+func TestConfigureFocusDepsInjectsCoordinatorIntoLuaHost(t *testing.T) {
+	hf := hostfunc.New(nil)
+	luaHost := pluginlua.NewHostWithFunctions(hf)
+	t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
+
+	mgr := plugins.NewManager(t.TempDir(), plugins.WithLuaHost(luaHost))
+
+	fc := &stubFocusCoordinator{}
+	var es core.EventStore // nil — acceptable for this test
+
+	// Must not panic; calls SetFocusCoordinator and SetEventStore on all
+	// FocusDepsConfigurer hosts registered in the manager.
+	require.NotPanics(t, func() {
+		mgr.ConfigureFocusDeps(fc, es)
+	})
+}
+
+func TestConfigureFocusDepsWithNilLuaHostDoesNotPanic(t *testing.T) {
+	// Manager without a Lua host — ConfigureFocusDeps must handle nil luaHost.
+	mgr := plugins.NewManager(t.TempDir())
+	require.NotPanics(t, func() {
+		mgr.ConfigureFocusDeps(nil, nil)
+	})
 }

--- a/internal/session/replay_mode.go
+++ b/internal/session/replay_mode.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package session
+
+import "fmt"
+
+// ReplayMode controls how the live loop replays events when processing a
+// stream addition. It determines cursor-initialization semantics:
+// FROM_CURSOR reads the existing watermark, LIVE_ONLY advances to tail,
+// BOUNDED_TAIL sets a new baseline from the last N events.
+//
+// Produced by focus.KindPolicy implementations and the FocusCoordinator.
+// Consumed by the Subscribe live loop in internal/grpc.
+type ReplayMode int
+
+const (
+	// ReplayModeFromCursor replays from the stored per-stream cursor in
+	// session.Info.EventCursors, or from ULID zero if no cursor is set.
+	ReplayModeFromCursor ReplayMode = iota
+
+	// ReplayModeBoundedTail replays the most recent TailCount events on
+	// the stream (optionally bounded by NotBefore), then advances the
+	// cursor to the tail. Used by scene focus-switch IC catch-up.
+	ReplayModeBoundedTail
+
+	// ReplayModeLiveOnly advances the cursor to the current stream tail
+	// without replaying anything. Used by channels for mid-session joins.
+	ReplayModeLiveOnly
+)
+
+// String returns a human-readable name for the replay mode.
+func (m ReplayMode) String() string {
+	switch m {
+	case ReplayModeFromCursor:
+		return "from_cursor"
+	case ReplayModeBoundedTail:
+		return "bounded_tail"
+	case ReplayModeLiveOnly:
+		return "live_only"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -81,7 +81,7 @@ type focusMutatorSentinel struct{}
 // compile time. Any code attempting to construct a FocusMutator from
 // outside grpc/focus fails to compile.
 type FocusMutator struct {
-	_ focusMutatorSentinel // unexported type blocks external construction
+	_      focusMutatorSentinel // unexported type blocks external construction
 	Mutate func(
 		current []FocusMembership,
 		presenting *FocusKey,
@@ -108,7 +108,8 @@ func NewFocusMutator(fn func(
 	next []FocusMembership,
 	nextPresenting *FocusKey,
 	err error,
-)) FocusMutator {
+),
+) FocusMutator {
 	return FocusMutator{Mutate: fn}
 }
 

--- a/internal/settings/player.go
+++ b/internal/settings/player.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-
 	"strconv"
 	"time"
 
@@ -168,10 +167,10 @@ func (j *jsonMapSettings) DurationN(ctx context.Context, key string) (time.Durat
 // emptySettings always returns (zero, false) for all reads.
 type emptySettings struct{}
 
-func (e *emptySettings) StringN(context.Context, string) (string, bool)           { return "", false }
-func (e *emptySettings) IntN(context.Context, string) (int, bool)                 { return 0, false }
-func (e *emptySettings) BoolN(context.Context, string) (value, ok bool)           { return false, false }
-func (e *emptySettings) DurationN(context.Context, string) (time.Duration, bool)  { return 0, false }
+func (e *emptySettings) StringN(context.Context, string) (string, bool)          { return "", false }
+func (e *emptySettings) IntN(context.Context, string) (int, bool)                { return 0, false }
+func (e *emptySettings) BoolN(context.Context, string) (value, ok bool)          { return false, false }
+func (e *emptySettings) DurationN(context.Context, string) (time.Duration, bool) { return 0, false }
 
 // Compile-time interface checks.
 var (

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -376,6 +376,7 @@ func (m *closedMock) Migrate(_ uint) error {
 	}
 	return nil
 }
+
 func (m *closedMock) Force(_ int) error {
 	if m.closed {
 		return errMigratorClosed

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -400,7 +400,7 @@ type pgSubscription struct {
 	cancelWait context.CancelFunc // cancels the current WaitForNotification
 	waitMu     sync.Mutex         // protects cancelWait
 	cancel     context.CancelFunc // cancels parentCtx
-	loopDone   chan struct{}       // closed when notificationLoop exits
+	loopDone   chan struct{}      // closed when notificationLoop exits
 
 	// streams/channels are only accessed inside notificationLoop (sole owner).
 	streams  map[string]string // stream name -> channel name

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -358,14 +358,14 @@ var _ = Describe("PostgresEventStore", func() {
 			e1 := core.Event{
 				ID: core.NewULID(), Stream: "location:ss-a",
 				Type: core.EventTypeSay, Timestamp: time.Now(),
-				Actor: core.Actor{Kind: core.ActorCharacter, ID: "c1"},
+				Actor:   core.Actor{Kind: core.ActorCharacter, ID: "c1"},
 				Payload: []byte(`{}`),
 			}
 			time.Sleep(time.Millisecond)
 			e2 := core.Event{
 				ID: core.NewULID(), Stream: "location:ss-b",
 				Type: core.EventTypeSay, Timestamp: time.Now(),
-				Actor: core.Actor{Kind: core.ActorCharacter, ID: "c2"},
+				Actor:   core.Actor{Kind: core.ActorCharacter, ID: "c2"},
 				Payload: []byte(`{}`),
 			}
 
@@ -395,7 +395,7 @@ var _ = Describe("PostgresEventStore", func() {
 			e := core.Event{
 				ID: core.NewULID(), Stream: "location:ss-remove",
 				Type: core.EventTypeSay, Timestamp: time.Now(),
-				Actor: core.Actor{Kind: core.ActorCharacter, ID: "c1"},
+				Actor:   core.Actor{Kind: core.ActorCharacter, ID: "c1"},
 				Payload: []byte(`{}`),
 			}
 			Expect(eventStore.Append(ctx, e)).To(Succeed())
@@ -421,7 +421,7 @@ var _ = Describe("PostgresEventStore", func() {
 			e := core.Event{
 				ID: core.NewULID(), Stream: "location:iso-a",
 				Type: core.EventTypeSay, Timestamp: time.Now(),
-				Actor: core.Actor{Kind: core.ActorCharacter, ID: "c1"},
+				Actor:   core.Actor{Kind: core.ActorCharacter, ID: "c1"},
 				Payload: []byte(`{}`),
 			}
 			Expect(eventStore.Append(ctx, e)).To(Succeed())
@@ -524,9 +524,9 @@ var _ = Describe("PostgresEventStore", func() {
 
 			const (
 				numStreams    = 4
-				numEvents    = 1000
+				numEvents     = 1000
 				numGoroutines = 10
-				eventsPerGo  = numEvents / numGoroutines
+				eventsPerGo   = numEvents / numGoroutines
 			)
 
 			streams := make([]string, numStreams)

--- a/pkg/proto/holomush/plugin/v1/plugin.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin.pb.go
@@ -137,6 +137,107 @@ func (AuditEffect) EnumDescriptor() ([]byte, []int) {
 	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{1}
 }
 
+// FocusKind enumerates the types of focused contexts a character can
+// participate in. Adding a new kind requires: (a) a new constant here,
+// (b) a matching session.FocusKind constant in Go, (c) a new
+// FocusKindPolicy implementation registered in the coordinator.
+type FocusKind int32
+
+const (
+	FocusKind_FOCUS_KIND_UNSPECIFIED FocusKind = 0
+	FocusKind_FOCUS_KIND_SCENE       FocusKind = 1
+)
+
+// Enum value maps for FocusKind.
+var (
+	FocusKind_name = map[int32]string{
+		0: "FOCUS_KIND_UNSPECIFIED",
+		1: "FOCUS_KIND_SCENE",
+	}
+	FocusKind_value = map[string]int32{
+		"FOCUS_KIND_UNSPECIFIED": 0,
+		"FOCUS_KIND_SCENE":       1,
+	}
+)
+
+func (x FocusKind) Enum() *FocusKind {
+	p := new(FocusKind)
+	*p = x
+	return p
+}
+
+func (x FocusKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_holomush_plugin_v1_plugin_proto_enumTypes[2].Descriptor()
+}
+
+func (FocusKind) Type() protoreflect.EnumType {
+	return &file_holomush_plugin_v1_plugin_proto_enumTypes[2]
+}
+
+func (x FocusKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusKind.Descriptor instead.
+func (FocusKind) EnumDescriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{2}
+}
+
+// StreamReplayMode controls how a stream subscription's initial replay
+// behaves when added via AddSessionStream.
+type StreamReplayMode int32
+
+const (
+	StreamReplayMode_STREAM_REPLAY_MODE_UNSPECIFIED StreamReplayMode = 0
+	StreamReplayMode_STREAM_REPLAY_MODE_FROM_CURSOR StreamReplayMode = 1
+	StreamReplayMode_STREAM_REPLAY_MODE_LIVE_ONLY   StreamReplayMode = 2
+)
+
+// Enum value maps for StreamReplayMode.
+var (
+	StreamReplayMode_name = map[int32]string{
+		0: "STREAM_REPLAY_MODE_UNSPECIFIED",
+		1: "STREAM_REPLAY_MODE_FROM_CURSOR",
+		2: "STREAM_REPLAY_MODE_LIVE_ONLY",
+	}
+	StreamReplayMode_value = map[string]int32{
+		"STREAM_REPLAY_MODE_UNSPECIFIED": 0,
+		"STREAM_REPLAY_MODE_FROM_CURSOR": 1,
+		"STREAM_REPLAY_MODE_LIVE_ONLY":   2,
+	}
+)
+
+func (x StreamReplayMode) Enum() *StreamReplayMode {
+	p := new(StreamReplayMode)
+	*p = x
+	return p
+}
+
+func (x StreamReplayMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (StreamReplayMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_holomush_plugin_v1_plugin_proto_enumTypes[3].Descriptor()
+}
+
+func (StreamReplayMode) Type() protoreflect.EnumType {
+	return &file_holomush_plugin_v1_plugin_proto_enumTypes[3]
+}
+
+func (x StreamReplayMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use StreamReplayMode.Descriptor instead.
+func (StreamReplayMode) EnumDescriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{3}
+}
+
 // ServiceConfig carries initialization data from the host to the plugin.
 type ServiceConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1406,13 +1507,15 @@ func (*PluginHostServiceKVDeleteResponse) Descriptor() ([]byte, []int) {
 	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{21}
 }
 
-// PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
 type PluginHostServiceAddSessionStreamRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Active session identifier.
 	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// Stream name to subscribe to (format: "prefix:id").
-	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	Stream string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	// replay_mode controls initial replay. Optional; defaults to
+	// FROM_CURSOR if unspecified for backwards compatibility.
+	ReplayMode    StreamReplayMode `protobuf:"varint,3,opt,name=replay_mode,json=replayMode,proto3,enum=holomush.plugin.v1.StreamReplayMode" json:"replay_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1461,11 +1564,15 @@ func (x *PluginHostServiceAddSessionStreamRequest) GetStream() string {
 	return ""
 }
 
-// PluginHostServiceAddSessionStreamResponse indicates success or failure.
+func (x *PluginHostServiceAddSessionStreamRequest) GetReplayMode() StreamReplayMode {
+	if x != nil {
+		return x.ReplayMode
+	}
+	return StreamReplayMode_STREAM_REPLAY_MODE_UNSPECIFIED
+}
+
 type PluginHostServiceAddSessionStreamResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Whether the stream was successfully added.
-	Success       bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1500,20 +1607,10 @@ func (*PluginHostServiceAddSessionStreamResponse) Descriptor() ([]byte, []int) {
 	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *PluginHostServiceAddSessionStreamResponse) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
-}
-
-// PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
 type PluginHostServiceRemoveSessionStreamRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Active session identifier.
-	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	// Stream name to unsubscribe from.
-	Stream        string `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Stream        string                 `protobuf:"bytes,2,opt,name=stream,proto3" json:"stream,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1562,11 +1659,8 @@ func (x *PluginHostServiceRemoveSessionStreamRequest) GetStream() string {
 	return ""
 }
 
-// PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
 type PluginHostServiceRemoveSessionStreamResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Whether the stream was successfully removed (true even if not subscribed).
-	Success       bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1599,13 +1693,6 @@ func (x *PluginHostServiceRemoveSessionStreamResponse) ProtoReflect() protorefle
 // Deprecated: Use PluginHostServiceRemoveSessionStreamResponse.ProtoReflect.Descriptor instead.
 func (*PluginHostServiceRemoveSessionStreamResponse) Descriptor() ([]byte, []int) {
 	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{25}
-}
-
-func (x *PluginHostServiceRemoveSessionStreamResponse) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
 }
 
 // QuerySessionStreamsRequest provides session context for stream contribution.
@@ -1727,6 +1814,429 @@ func (x *QuerySessionStreamsResponse) GetError() string {
 	return ""
 }
 
+// FocusKey identifies a focus membership within a session. A session's
+// focus memberships are unique by (kind, target_id) pair.
+type FocusKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          FocusKind              `protobuf:"varint,1,opt,name=kind,proto3,enum=holomush.plugin.v1.FocusKind" json:"kind,omitempty"`
+	TargetId      string                 `protobuf:"bytes,2,opt,name=target_id,json=targetId,proto3" json:"target_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FocusKey) Reset() {
+	*x = FocusKey{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FocusKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FocusKey) ProtoMessage() {}
+
+func (x *FocusKey) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FocusKey.ProtoReflect.Descriptor instead.
+func (*FocusKey) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *FocusKey) GetKind() FocusKind {
+	if x != nil {
+		return x.Kind
+	}
+	return FocusKind_FOCUS_KIND_UNSPECIFIED
+}
+
+func (x *FocusKey) GetTargetId() string {
+	if x != nil {
+		return x.TargetId
+	}
+	return ""
+}
+
+type PluginHostServiceJoinFocusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Target        *FocusKey              `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceJoinFocusRequest) Reset() {
+	*x = PluginHostServiceJoinFocusRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceJoinFocusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceJoinFocusRequest) ProtoMessage() {}
+
+func (x *PluginHostServiceJoinFocusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceJoinFocusRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceJoinFocusRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *PluginHostServiceJoinFocusRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *PluginHostServiceJoinFocusRequest) GetTarget() *FocusKey {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+type PluginHostServiceJoinFocusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceJoinFocusResponse) Reset() {
+	*x = PluginHostServiceJoinFocusResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceJoinFocusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceJoinFocusResponse) ProtoMessage() {}
+
+func (x *PluginHostServiceJoinFocusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceJoinFocusResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceJoinFocusResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{30}
+}
+
+type PluginHostServiceLeaveFocusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Target        *FocusKey              `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceLeaveFocusRequest) Reset() {
+	*x = PluginHostServiceLeaveFocusRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceLeaveFocusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceLeaveFocusRequest) ProtoMessage() {}
+
+func (x *PluginHostServiceLeaveFocusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceLeaveFocusRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceLeaveFocusRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *PluginHostServiceLeaveFocusRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *PluginHostServiceLeaveFocusRequest) GetTarget() *FocusKey {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+type PluginHostServiceLeaveFocusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceLeaveFocusResponse) Reset() {
+	*x = PluginHostServiceLeaveFocusResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceLeaveFocusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceLeaveFocusResponse) ProtoMessage() {}
+
+func (x *PluginHostServiceLeaveFocusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceLeaveFocusResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceLeaveFocusResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{32}
+}
+
+type PluginHostServicePresentFocusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Target        *FocusKey              `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServicePresentFocusRequest) Reset() {
+	*x = PluginHostServicePresentFocusRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServicePresentFocusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServicePresentFocusRequest) ProtoMessage() {}
+
+func (x *PluginHostServicePresentFocusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServicePresentFocusRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServicePresentFocusRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *PluginHostServicePresentFocusRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *PluginHostServicePresentFocusRequest) GetTarget() *FocusKey {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+type PluginHostServicePresentFocusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServicePresentFocusResponse) Reset() {
+	*x = PluginHostServicePresentFocusResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServicePresentFocusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServicePresentFocusResponse) ProtoMessage() {}
+
+func (x *PluginHostServicePresentFocusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServicePresentFocusResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServicePresentFocusResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{34}
+}
+
+type PluginHostServiceQueryStreamHistoryRequest struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Stream string                 `protobuf:"bytes,1,opt,name=stream,proto3" json:"stream,omitempty"`
+	Count  int32                  `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
+	// Epoch milliseconds. Events before this time are excluded. 0 means no lower bound.
+	NotBeforeMs   int64 `protobuf:"varint,3,opt,name=not_before_ms,json=notBeforeMs,proto3" json:"not_before_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) Reset() {
+	*x = PluginHostServiceQueryStreamHistoryRequest{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceQueryStreamHistoryRequest) ProtoMessage() {}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceQueryStreamHistoryRequest.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceQueryStreamHistoryRequest) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) GetStream() string {
+	if x != nil {
+		return x.Stream
+	}
+	return ""
+}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+func (x *PluginHostServiceQueryStreamHistoryRequest) GetNotBeforeMs() int64 {
+	if x != nil {
+		return x.NotBeforeMs
+	}
+	return 0
+}
+
+type PluginHostServiceQueryStreamHistoryResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Events        []*Event               `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginHostServiceQueryStreamHistoryResponse) Reset() {
+	*x = PluginHostServiceQueryStreamHistoryResponse{}
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginHostServiceQueryStreamHistoryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginHostServiceQueryStreamHistoryResponse) ProtoMessage() {}
+
+func (x *PluginHostServiceQueryStreamHistoryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_holomush_plugin_v1_plugin_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginHostServiceQueryStreamHistoryResponse.ProtoReflect.Descriptor instead.
+func (*PluginHostServiceQueryStreamHistoryResponse) Descriptor() ([]byte, []int) {
+	return file_holomush_plugin_v1_plugin_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *PluginHostServiceQueryStreamHistoryResponse) GetEvents() []*Event {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
 var File_holomush_plugin_v1_plugin_proto protoreflect.FileDescriptor
 
 const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
@@ -1822,19 +2332,19 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"\vplugin_name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\n" +
 	"pluginName\x12\x19\n" +
 	"\x03key\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x03key\"#\n" +
-	"!PluginHostServiceKVDeleteResponse\"a\n" +
-	"(PluginHostServiceAddSessionStreamRequest\x12\x1d\n" +
+	"!PluginHostServiceKVDeleteResponse\"\xba\x01\n" +
+	"(PluginHostServiceAddSessionStreamRequest\x12&\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
-	"\x06stream\x18\x02 \x01(\tR\x06stream\"E\n" +
-	")PluginHostServiceAddSessionStreamResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\"d\n" +
-	"+PluginHostServiceRemoveSessionStreamRequest\x12\x1d\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x12\x1f\n" +
+	"\x06stream\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06stream\x12E\n" +
+	"\vreplay_mode\x18\x03 \x01(\x0e2$.holomush.plugin.v1.StreamReplayModeR\n" +
+	"replayMode\"+\n" +
+	")PluginHostServiceAddSessionStreamResponse\"v\n" +
+	"+PluginHostServiceRemoveSessionStreamRequest\x12&\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
-	"\x06stream\x18\x02 \x01(\tR\x06stream\"H\n" +
-	",PluginHostServiceRemoveSessionStreamResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\"{\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x12\x1f\n" +
+	"\x06stream\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06stream\".\n" +
+	",PluginHostServiceRemoveSessionStreamResponse\"{\n" +
 	"\x1aQuerySessionStreamsRequest\x12!\n" +
 	"\fcharacter_id\x18\x01 \x01(\tR\vcharacterId\x12\x1b\n" +
 	"\tplayer_id\x18\x02 \x01(\tR\bplayerId\x12\x1d\n" +
@@ -1842,7 +2352,31 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\"M\n" +
 	"\x1bQuerySessionStreamsResponse\x12\x18\n" +
 	"\astreams\x18\x01 \x03(\tR\astreams\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error*\x96\x01\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"c\n" +
+	"\bFocusKey\x121\n" +
+	"\x04kind\x18\x01 \x01(\x0e2\x1d.holomush.plugin.v1.FocusKindR\x04kind\x12$\n" +
+	"\ttarget_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\btargetId\"\x81\x01\n" +
+	"!PluginHostServiceJoinFocusRequest\x12&\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x124\n" +
+	"\x06target\x18\x02 \x01(\v2\x1c.holomush.plugin.v1.FocusKeyR\x06target\"$\n" +
+	"\"PluginHostServiceJoinFocusResponse\"\x82\x01\n" +
+	"\"PluginHostServiceLeaveFocusRequest\x12&\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x124\n" +
+	"\x06target\x18\x02 \x01(\v2\x1c.holomush.plugin.v1.FocusKeyR\x06target\"%\n" +
+	"#PluginHostServiceLeaveFocusResponse\"\x84\x01\n" +
+	"$PluginHostServicePresentFocusRequest\x12&\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\tsessionId\x124\n" +
+	"\x06target\x18\x02 \x01(\v2\x1c.holomush.plugin.v1.FocusKeyR\x06target\"'\n" +
+	"%PluginHostServicePresentFocusResponse\"\x87\x01\n" +
+	"*PluginHostServiceQueryStreamHistoryRequest\x12\x1f\n" +
+	"\x06stream\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06stream\x12\x14\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\x12\"\n" +
+	"\rnot_before_ms\x18\x03 \x01(\x03R\vnotBeforeMs\"`\n" +
+	"+PluginHostServiceQueryStreamHistoryResponse\x121\n" +
+	"\x06events\x18\x01 \x03(\v2\x19.holomush.plugin.v1.EventR\x06events*\x96\x01\n" +
 	"\rCommandStatus\x12\x1e\n" +
 	"\x1aCOMMAND_STATUS_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11COMMAND_STATUS_OK\x10\x01\x12\x18\n" +
@@ -1852,12 +2386,19 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"\vAuditEffect\x12\x1c\n" +
 	"\x18AUDIT_EFFECT_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11AUDIT_EFFECT_DENY\x10\x01\x12\x16\n" +
-	"\x12AUDIT_EFFECT_ALLOW\x10\x022\x98\x03\n" +
+	"\x12AUDIT_EFFECT_ALLOW\x10\x02*=\n" +
+	"\tFocusKind\x12\x1a\n" +
+	"\x16FOCUS_KIND_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10FOCUS_KIND_SCENE\x10\x01*|\n" +
+	"\x10StreamReplayMode\x12\"\n" +
+	"\x1eSTREAM_REPLAY_MODE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eSTREAM_REPLAY_MODE_FROM_CURSOR\x10\x01\x12 \n" +
+	"\x1cSTREAM_REPLAY_MODE_LIVE_ONLY\x10\x022\x98\x03\n" +
 	"\rPluginService\x12I\n" +
 	"\x04Init\x12\x1f.holomush.plugin.v1.InitRequest\x1a .holomush.plugin.v1.InitResponse\x12^\n" +
 	"\vHandleEvent\x12&.holomush.plugin.v1.HandleEventRequest\x1a'.holomush.plugin.v1.HandleEventResponse\x12d\n" +
 	"\rHandleCommand\x12(.holomush.plugin.v1.HandleCommandRequest\x1a).holomush.plugin.v1.HandleCommandResponse\x12v\n" +
-	"\x13QuerySessionStreams\x12..holomush.plugin.v1.QuerySessionStreamsRequest\x1a/.holomush.plugin.v1.QuerySessionStreamsResponse2\xff\x06\n" +
+	"\x13QuerySessionStreams\x12..holomush.plugin.v1.QuerySessionStreamsRequest\x1a/.holomush.plugin.v1.QuerySessionStreamsResponse2\x98\v\n" +
 	"\x11PluginHostService\x12z\n" +
 	"\tEmitEvent\x125.holomush.plugin.v1.PluginHostServiceEmitEventRequest\x1a6.holomush.plugin.v1.PluginHostServiceEmitEventResponse\x12h\n" +
 	"\x03Log\x12/.holomush.plugin.v1.PluginHostServiceLogRequest\x1a0.holomush.plugin.v1.PluginHostServiceLogResponse\x12n\n" +
@@ -1865,7 +2406,12 @@ const file_holomush_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x05KVSet\x121.holomush.plugin.v1.PluginHostServiceKVSetRequest\x1a2.holomush.plugin.v1.PluginHostServiceKVSetResponse\x12w\n" +
 	"\bKVDelete\x124.holomush.plugin.v1.PluginHostServiceKVDeleteRequest\x1a5.holomush.plugin.v1.PluginHostServiceKVDeleteResponse\x12\x8f\x01\n" +
 	"\x10AddSessionStream\x12<.holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest\x1a=.holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse\x12\x98\x01\n" +
-	"\x13RemoveSessionStream\x12?.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest\x1a@.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponseB\xd3\x01\n" +
+	"\x13RemoveSessionStream\x12?.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest\x1a@.holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse\x12z\n" +
+	"\tJoinFocus\x125.holomush.plugin.v1.PluginHostServiceJoinFocusRequest\x1a6.holomush.plugin.v1.PluginHostServiceJoinFocusResponse\x12}\n" +
+	"\n" +
+	"LeaveFocus\x126.holomush.plugin.v1.PluginHostServiceLeaveFocusRequest\x1a7.holomush.plugin.v1.PluginHostServiceLeaveFocusResponse\x12\x83\x01\n" +
+	"\fPresentFocus\x128.holomush.plugin.v1.PluginHostServicePresentFocusRequest\x1a9.holomush.plugin.v1.PluginHostServicePresentFocusResponse\x12\x95\x01\n" +
+	"\x12QueryStreamHistory\x12>.holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest\x1a?.holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponseB\xd3\x01\n" +
 	"\x16com.holomush.plugin.v1B\vPluginProtoP\x01ZBgithub.com/holomush/holomush/pkg/proto/holomush/plugin/v1;pluginv1\xa2\x02\x03HPX\xaa\x02\x12Holomush.Plugin.V1\xca\x02\x12Holomush\\Plugin\\V1\xe2\x02\x1eHolomush\\Plugin\\V1\\GPBMetadata\xea\x02\x14Holomush::Plugin::V1b\x06proto3"
 
 var (
@@ -1880,81 +2426,106 @@ func file_holomush_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_holomush_plugin_v1_plugin_proto_rawDescData
 }
 
-var file_holomush_plugin_v1_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_holomush_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_holomush_plugin_v1_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_holomush_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_holomush_plugin_v1_plugin_proto_goTypes = []any{
 	(CommandStatus)(0),                                   // 0: holomush.plugin.v1.CommandStatus
 	(AuditEffect)(0),                                     // 1: holomush.plugin.v1.AuditEffect
-	(*ServiceConfig)(nil),                                // 2: holomush.plugin.v1.ServiceConfig
-	(*InitRequest)(nil),                                  // 3: holomush.plugin.v1.InitRequest
-	(*InitResponse)(nil),                                 // 4: holomush.plugin.v1.InitResponse
-	(*Event)(nil),                                        // 5: holomush.plugin.v1.Event
-	(*EmitEvent)(nil),                                    // 6: holomush.plugin.v1.EmitEvent
-	(*HandleEventRequest)(nil),                           // 7: holomush.plugin.v1.HandleEventRequest
-	(*HandleEventResponse)(nil),                          // 8: holomush.plugin.v1.HandleEventResponse
-	(*CommandRequest)(nil),                               // 9: holomush.plugin.v1.CommandRequest
-	(*CommandResponse)(nil),                              // 10: holomush.plugin.v1.CommandResponse
-	(*AuditDecisionHint)(nil),                            // 11: holomush.plugin.v1.AuditDecisionHint
-	(*HandleCommandRequest)(nil),                         // 12: holomush.plugin.v1.HandleCommandRequest
-	(*HandleCommandResponse)(nil),                        // 13: holomush.plugin.v1.HandleCommandResponse
-	(*PluginHostServiceEmitEventRequest)(nil),            // 14: holomush.plugin.v1.PluginHostServiceEmitEventRequest
-	(*PluginHostServiceEmitEventResponse)(nil),           // 15: holomush.plugin.v1.PluginHostServiceEmitEventResponse
-	(*PluginHostServiceLogRequest)(nil),                  // 16: holomush.plugin.v1.PluginHostServiceLogRequest
-	(*PluginHostServiceLogResponse)(nil),                 // 17: holomush.plugin.v1.PluginHostServiceLogResponse
-	(*PluginHostServiceKVGetRequest)(nil),                // 18: holomush.plugin.v1.PluginHostServiceKVGetRequest
-	(*PluginHostServiceKVGetResponse)(nil),               // 19: holomush.plugin.v1.PluginHostServiceKVGetResponse
-	(*PluginHostServiceKVSetRequest)(nil),                // 20: holomush.plugin.v1.PluginHostServiceKVSetRequest
-	(*PluginHostServiceKVSetResponse)(nil),               // 21: holomush.plugin.v1.PluginHostServiceKVSetResponse
-	(*PluginHostServiceKVDeleteRequest)(nil),             // 22: holomush.plugin.v1.PluginHostServiceKVDeleteRequest
-	(*PluginHostServiceKVDeleteResponse)(nil),            // 23: holomush.plugin.v1.PluginHostServiceKVDeleteResponse
-	(*PluginHostServiceAddSessionStreamRequest)(nil),     // 24: holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
-	(*PluginHostServiceAddSessionStreamResponse)(nil),    // 25: holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
-	(*PluginHostServiceRemoveSessionStreamRequest)(nil),  // 26: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
-	(*PluginHostServiceRemoveSessionStreamResponse)(nil), // 27: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
-	(*QuerySessionStreamsRequest)(nil),                   // 28: holomush.plugin.v1.QuerySessionStreamsRequest
-	(*QuerySessionStreamsResponse)(nil),                  // 29: holomush.plugin.v1.QuerySessionStreamsResponse
-	nil,                                                  // 30: holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
-	nil,                                                  // 31: holomush.plugin.v1.AuditDecisionHint.AttributesEntry
+	(FocusKind)(0),                                       // 2: holomush.plugin.v1.FocusKind
+	(StreamReplayMode)(0),                                // 3: holomush.plugin.v1.StreamReplayMode
+	(*ServiceConfig)(nil),                                // 4: holomush.plugin.v1.ServiceConfig
+	(*InitRequest)(nil),                                  // 5: holomush.plugin.v1.InitRequest
+	(*InitResponse)(nil),                                 // 6: holomush.plugin.v1.InitResponse
+	(*Event)(nil),                                        // 7: holomush.plugin.v1.Event
+	(*EmitEvent)(nil),                                    // 8: holomush.plugin.v1.EmitEvent
+	(*HandleEventRequest)(nil),                           // 9: holomush.plugin.v1.HandleEventRequest
+	(*HandleEventResponse)(nil),                          // 10: holomush.plugin.v1.HandleEventResponse
+	(*CommandRequest)(nil),                               // 11: holomush.plugin.v1.CommandRequest
+	(*CommandResponse)(nil),                              // 12: holomush.plugin.v1.CommandResponse
+	(*AuditDecisionHint)(nil),                            // 13: holomush.plugin.v1.AuditDecisionHint
+	(*HandleCommandRequest)(nil),                         // 14: holomush.plugin.v1.HandleCommandRequest
+	(*HandleCommandResponse)(nil),                        // 15: holomush.plugin.v1.HandleCommandResponse
+	(*PluginHostServiceEmitEventRequest)(nil),            // 16: holomush.plugin.v1.PluginHostServiceEmitEventRequest
+	(*PluginHostServiceEmitEventResponse)(nil),           // 17: holomush.plugin.v1.PluginHostServiceEmitEventResponse
+	(*PluginHostServiceLogRequest)(nil),                  // 18: holomush.plugin.v1.PluginHostServiceLogRequest
+	(*PluginHostServiceLogResponse)(nil),                 // 19: holomush.plugin.v1.PluginHostServiceLogResponse
+	(*PluginHostServiceKVGetRequest)(nil),                // 20: holomush.plugin.v1.PluginHostServiceKVGetRequest
+	(*PluginHostServiceKVGetResponse)(nil),               // 21: holomush.plugin.v1.PluginHostServiceKVGetResponse
+	(*PluginHostServiceKVSetRequest)(nil),                // 22: holomush.plugin.v1.PluginHostServiceKVSetRequest
+	(*PluginHostServiceKVSetResponse)(nil),               // 23: holomush.plugin.v1.PluginHostServiceKVSetResponse
+	(*PluginHostServiceKVDeleteRequest)(nil),             // 24: holomush.plugin.v1.PluginHostServiceKVDeleteRequest
+	(*PluginHostServiceKVDeleteResponse)(nil),            // 25: holomush.plugin.v1.PluginHostServiceKVDeleteResponse
+	(*PluginHostServiceAddSessionStreamRequest)(nil),     // 26: holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
+	(*PluginHostServiceAddSessionStreamResponse)(nil),    // 27: holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
+	(*PluginHostServiceRemoveSessionStreamRequest)(nil),  // 28: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
+	(*PluginHostServiceRemoveSessionStreamResponse)(nil), // 29: holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
+	(*QuerySessionStreamsRequest)(nil),                   // 30: holomush.plugin.v1.QuerySessionStreamsRequest
+	(*QuerySessionStreamsResponse)(nil),                  // 31: holomush.plugin.v1.QuerySessionStreamsResponse
+	(*FocusKey)(nil),                                     // 32: holomush.plugin.v1.FocusKey
+	(*PluginHostServiceJoinFocusRequest)(nil),            // 33: holomush.plugin.v1.PluginHostServiceJoinFocusRequest
+	(*PluginHostServiceJoinFocusResponse)(nil),           // 34: holomush.plugin.v1.PluginHostServiceJoinFocusResponse
+	(*PluginHostServiceLeaveFocusRequest)(nil),           // 35: holomush.plugin.v1.PluginHostServiceLeaveFocusRequest
+	(*PluginHostServiceLeaveFocusResponse)(nil),          // 36: holomush.plugin.v1.PluginHostServiceLeaveFocusResponse
+	(*PluginHostServicePresentFocusRequest)(nil),         // 37: holomush.plugin.v1.PluginHostServicePresentFocusRequest
+	(*PluginHostServicePresentFocusResponse)(nil),        // 38: holomush.plugin.v1.PluginHostServicePresentFocusResponse
+	(*PluginHostServiceQueryStreamHistoryRequest)(nil),   // 39: holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest
+	(*PluginHostServiceQueryStreamHistoryResponse)(nil),  // 40: holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse
+	nil, // 41: holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
+	nil, // 42: holomush.plugin.v1.AuditDecisionHint.AttributesEntry
 }
 var file_holomush_plugin_v1_plugin_proto_depIdxs = []int32{
-	30, // 0: holomush.plugin.v1.ServiceConfig.required_services:type_name -> holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
-	2,  // 1: holomush.plugin.v1.InitRequest.config:type_name -> holomush.plugin.v1.ServiceConfig
-	5,  // 2: holomush.plugin.v1.HandleEventRequest.event:type_name -> holomush.plugin.v1.Event
-	6,  // 3: holomush.plugin.v1.HandleEventResponse.emit_events:type_name -> holomush.plugin.v1.EmitEvent
+	41, // 0: holomush.plugin.v1.ServiceConfig.required_services:type_name -> holomush.plugin.v1.ServiceConfig.RequiredServicesEntry
+	4,  // 1: holomush.plugin.v1.InitRequest.config:type_name -> holomush.plugin.v1.ServiceConfig
+	7,  // 2: holomush.plugin.v1.HandleEventRequest.event:type_name -> holomush.plugin.v1.Event
+	8,  // 3: holomush.plugin.v1.HandleEventResponse.emit_events:type_name -> holomush.plugin.v1.EmitEvent
 	0,  // 4: holomush.plugin.v1.CommandResponse.status:type_name -> holomush.plugin.v1.CommandStatus
-	6,  // 5: holomush.plugin.v1.CommandResponse.events:type_name -> holomush.plugin.v1.EmitEvent
-	11, // 6: holomush.plugin.v1.CommandResponse.audit_hints:type_name -> holomush.plugin.v1.AuditDecisionHint
+	8,  // 5: holomush.plugin.v1.CommandResponse.events:type_name -> holomush.plugin.v1.EmitEvent
+	13, // 6: holomush.plugin.v1.CommandResponse.audit_hints:type_name -> holomush.plugin.v1.AuditDecisionHint
 	1,  // 7: holomush.plugin.v1.AuditDecisionHint.effect:type_name -> holomush.plugin.v1.AuditEffect
-	31, // 8: holomush.plugin.v1.AuditDecisionHint.attributes:type_name -> holomush.plugin.v1.AuditDecisionHint.AttributesEntry
-	9,  // 9: holomush.plugin.v1.HandleCommandRequest.command:type_name -> holomush.plugin.v1.CommandRequest
-	10, // 10: holomush.plugin.v1.HandleCommandResponse.response:type_name -> holomush.plugin.v1.CommandResponse
-	3,  // 11: holomush.plugin.v1.PluginService.Init:input_type -> holomush.plugin.v1.InitRequest
-	7,  // 12: holomush.plugin.v1.PluginService.HandleEvent:input_type -> holomush.plugin.v1.HandleEventRequest
-	12, // 13: holomush.plugin.v1.PluginService.HandleCommand:input_type -> holomush.plugin.v1.HandleCommandRequest
-	28, // 14: holomush.plugin.v1.PluginService.QuerySessionStreams:input_type -> holomush.plugin.v1.QuerySessionStreamsRequest
-	14, // 15: holomush.plugin.v1.PluginHostService.EmitEvent:input_type -> holomush.plugin.v1.PluginHostServiceEmitEventRequest
-	16, // 16: holomush.plugin.v1.PluginHostService.Log:input_type -> holomush.plugin.v1.PluginHostServiceLogRequest
-	18, // 17: holomush.plugin.v1.PluginHostService.KVGet:input_type -> holomush.plugin.v1.PluginHostServiceKVGetRequest
-	20, // 18: holomush.plugin.v1.PluginHostService.KVSet:input_type -> holomush.plugin.v1.PluginHostServiceKVSetRequest
-	22, // 19: holomush.plugin.v1.PluginHostService.KVDelete:input_type -> holomush.plugin.v1.PluginHostServiceKVDeleteRequest
-	24, // 20: holomush.plugin.v1.PluginHostService.AddSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
-	26, // 21: holomush.plugin.v1.PluginHostService.RemoveSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
-	4,  // 22: holomush.plugin.v1.PluginService.Init:output_type -> holomush.plugin.v1.InitResponse
-	8,  // 23: holomush.plugin.v1.PluginService.HandleEvent:output_type -> holomush.plugin.v1.HandleEventResponse
-	13, // 24: holomush.plugin.v1.PluginService.HandleCommand:output_type -> holomush.plugin.v1.HandleCommandResponse
-	29, // 25: holomush.plugin.v1.PluginService.QuerySessionStreams:output_type -> holomush.plugin.v1.QuerySessionStreamsResponse
-	15, // 26: holomush.plugin.v1.PluginHostService.EmitEvent:output_type -> holomush.plugin.v1.PluginHostServiceEmitEventResponse
-	17, // 27: holomush.plugin.v1.PluginHostService.Log:output_type -> holomush.plugin.v1.PluginHostServiceLogResponse
-	19, // 28: holomush.plugin.v1.PluginHostService.KVGet:output_type -> holomush.plugin.v1.PluginHostServiceKVGetResponse
-	21, // 29: holomush.plugin.v1.PluginHostService.KVSet:output_type -> holomush.plugin.v1.PluginHostServiceKVSetResponse
-	23, // 30: holomush.plugin.v1.PluginHostService.KVDelete:output_type -> holomush.plugin.v1.PluginHostServiceKVDeleteResponse
-	25, // 31: holomush.plugin.v1.PluginHostService.AddSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
-	27, // 32: holomush.plugin.v1.PluginHostService.RemoveSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
-	22, // [22:33] is the sub-list for method output_type
-	11, // [11:22] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	42, // 8: holomush.plugin.v1.AuditDecisionHint.attributes:type_name -> holomush.plugin.v1.AuditDecisionHint.AttributesEntry
+	11, // 9: holomush.plugin.v1.HandleCommandRequest.command:type_name -> holomush.plugin.v1.CommandRequest
+	12, // 10: holomush.plugin.v1.HandleCommandResponse.response:type_name -> holomush.plugin.v1.CommandResponse
+	3,  // 11: holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest.replay_mode:type_name -> holomush.plugin.v1.StreamReplayMode
+	2,  // 12: holomush.plugin.v1.FocusKey.kind:type_name -> holomush.plugin.v1.FocusKind
+	32, // 13: holomush.plugin.v1.PluginHostServiceJoinFocusRequest.target:type_name -> holomush.plugin.v1.FocusKey
+	32, // 14: holomush.plugin.v1.PluginHostServiceLeaveFocusRequest.target:type_name -> holomush.plugin.v1.FocusKey
+	32, // 15: holomush.plugin.v1.PluginHostServicePresentFocusRequest.target:type_name -> holomush.plugin.v1.FocusKey
+	7,  // 16: holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse.events:type_name -> holomush.plugin.v1.Event
+	5,  // 17: holomush.plugin.v1.PluginService.Init:input_type -> holomush.plugin.v1.InitRequest
+	9,  // 18: holomush.plugin.v1.PluginService.HandleEvent:input_type -> holomush.plugin.v1.HandleEventRequest
+	14, // 19: holomush.plugin.v1.PluginService.HandleCommand:input_type -> holomush.plugin.v1.HandleCommandRequest
+	30, // 20: holomush.plugin.v1.PluginService.QuerySessionStreams:input_type -> holomush.plugin.v1.QuerySessionStreamsRequest
+	16, // 21: holomush.plugin.v1.PluginHostService.EmitEvent:input_type -> holomush.plugin.v1.PluginHostServiceEmitEventRequest
+	18, // 22: holomush.plugin.v1.PluginHostService.Log:input_type -> holomush.plugin.v1.PluginHostServiceLogRequest
+	20, // 23: holomush.plugin.v1.PluginHostService.KVGet:input_type -> holomush.plugin.v1.PluginHostServiceKVGetRequest
+	22, // 24: holomush.plugin.v1.PluginHostService.KVSet:input_type -> holomush.plugin.v1.PluginHostServiceKVSetRequest
+	24, // 25: holomush.plugin.v1.PluginHostService.KVDelete:input_type -> holomush.plugin.v1.PluginHostServiceKVDeleteRequest
+	26, // 26: holomush.plugin.v1.PluginHostService.AddSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
+	28, // 27: holomush.plugin.v1.PluginHostService.RemoveSessionStream:input_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
+	33, // 28: holomush.plugin.v1.PluginHostService.JoinFocus:input_type -> holomush.plugin.v1.PluginHostServiceJoinFocusRequest
+	35, // 29: holomush.plugin.v1.PluginHostService.LeaveFocus:input_type -> holomush.plugin.v1.PluginHostServiceLeaveFocusRequest
+	37, // 30: holomush.plugin.v1.PluginHostService.PresentFocus:input_type -> holomush.plugin.v1.PluginHostServicePresentFocusRequest
+	39, // 31: holomush.plugin.v1.PluginHostService.QueryStreamHistory:input_type -> holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest
+	6,  // 32: holomush.plugin.v1.PluginService.Init:output_type -> holomush.plugin.v1.InitResponse
+	10, // 33: holomush.plugin.v1.PluginService.HandleEvent:output_type -> holomush.plugin.v1.HandleEventResponse
+	15, // 34: holomush.plugin.v1.PluginService.HandleCommand:output_type -> holomush.plugin.v1.HandleCommandResponse
+	31, // 35: holomush.plugin.v1.PluginService.QuerySessionStreams:output_type -> holomush.plugin.v1.QuerySessionStreamsResponse
+	17, // 36: holomush.plugin.v1.PluginHostService.EmitEvent:output_type -> holomush.plugin.v1.PluginHostServiceEmitEventResponse
+	19, // 37: holomush.plugin.v1.PluginHostService.Log:output_type -> holomush.plugin.v1.PluginHostServiceLogResponse
+	21, // 38: holomush.plugin.v1.PluginHostService.KVGet:output_type -> holomush.plugin.v1.PluginHostServiceKVGetResponse
+	23, // 39: holomush.plugin.v1.PluginHostService.KVSet:output_type -> holomush.plugin.v1.PluginHostServiceKVSetResponse
+	25, // 40: holomush.plugin.v1.PluginHostService.KVDelete:output_type -> holomush.plugin.v1.PluginHostServiceKVDeleteResponse
+	27, // 41: holomush.plugin.v1.PluginHostService.AddSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
+	29, // 42: holomush.plugin.v1.PluginHostService.RemoveSessionStream:output_type -> holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
+	34, // 43: holomush.plugin.v1.PluginHostService.JoinFocus:output_type -> holomush.plugin.v1.PluginHostServiceJoinFocusResponse
+	36, // 44: holomush.plugin.v1.PluginHostService.LeaveFocus:output_type -> holomush.plugin.v1.PluginHostServiceLeaveFocusResponse
+	38, // 45: holomush.plugin.v1.PluginHostService.PresentFocus:output_type -> holomush.plugin.v1.PluginHostServicePresentFocusResponse
+	40, // 46: holomush.plugin.v1.PluginHostService.QueryStreamHistory:output_type -> holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse
+	32, // [32:47] is the sub-list for method output_type
+	17, // [17:32] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_holomush_plugin_v1_plugin_proto_init() }
@@ -1967,8 +2538,8 @@ func file_holomush_plugin_v1_plugin_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_holomush_plugin_v1_plugin_proto_rawDesc), len(file_holomush_plugin_v1_plugin_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   30,
+			NumEnums:      4,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
@@ -269,6 +269,10 @@ const (
 	PluginHostService_KVDelete_FullMethodName            = "/holomush.plugin.v1.PluginHostService/KVDelete"
 	PluginHostService_AddSessionStream_FullMethodName    = "/holomush.plugin.v1.PluginHostService/AddSessionStream"
 	PluginHostService_RemoveSessionStream_FullMethodName = "/holomush.plugin.v1.PluginHostService/RemoveSessionStream"
+	PluginHostService_JoinFocus_FullMethodName           = "/holomush.plugin.v1.PluginHostService/JoinFocus"
+	PluginHostService_LeaveFocus_FullMethodName          = "/holomush.plugin.v1.PluginHostService/LeaveFocus"
+	PluginHostService_PresentFocus_FullMethodName        = "/holomush.plugin.v1.PluginHostService/PresentFocus"
+	PluginHostService_QueryStreamHistory_FullMethodName  = "/holomush.plugin.v1.PluginHostService/QueryStreamHistory"
 )
 
 // PluginHostServiceClient is the client API for PluginHostService service.
@@ -294,6 +298,18 @@ type PluginHostServiceClient interface {
 	// RemoveSessionStream unsubscribes an active session from a stream.
 	// Idempotent: returns success if stream is not subscribed.
 	RemoveSessionStream(ctx context.Context, in *PluginHostServiceRemoveSessionStreamRequest, opts ...grpc.CallOption) (*PluginHostServiceRemoveSessionStreamResponse, error)
+	// JoinFocus adds a focus membership to an active or detached session.
+	// Plugins declare intent; the server applies kind-specific replay policy.
+	JoinFocus(ctx context.Context, in *PluginHostServiceJoinFocusRequest, opts ...grpc.CallOption) (*PluginHostServiceJoinFocusResponse, error)
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(ctx context.Context, in *PluginHostServiceLeaveFocusRequest, opts ...grpc.CallOption) (*PluginHostServiceLeaveFocusResponse, error)
+	// PresentFocus updates the session's PresentingFocus pointer.
+	// Target MUST already exist in FocusMemberships.
+	PresentFocus(ctx context.Context, in *PluginHostServicePresentFocusRequest, opts ...grpc.CallOption) (*PluginHostServicePresentFocusResponse, error)
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only: does not advance cursors or affect session state.
+	// Count capped at 500 server-side.
+	QueryStreamHistory(ctx context.Context, in *PluginHostServiceQueryStreamHistoryRequest, opts ...grpc.CallOption) (*PluginHostServiceQueryStreamHistoryResponse, error)
 }
 
 type pluginHostServiceClient struct {
@@ -374,6 +390,46 @@ func (c *pluginHostServiceClient) RemoveSessionStream(ctx context.Context, in *P
 	return out, nil
 }
 
+func (c *pluginHostServiceClient) JoinFocus(ctx context.Context, in *PluginHostServiceJoinFocusRequest, opts ...grpc.CallOption) (*PluginHostServiceJoinFocusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServiceJoinFocusResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_JoinFocus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *pluginHostServiceClient) LeaveFocus(ctx context.Context, in *PluginHostServiceLeaveFocusRequest, opts ...grpc.CallOption) (*PluginHostServiceLeaveFocusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServiceLeaveFocusResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_LeaveFocus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *pluginHostServiceClient) PresentFocus(ctx context.Context, in *PluginHostServicePresentFocusRequest, opts ...grpc.CallOption) (*PluginHostServicePresentFocusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServicePresentFocusResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_PresentFocus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *pluginHostServiceClient) QueryStreamHistory(ctx context.Context, in *PluginHostServiceQueryStreamHistoryRequest, opts ...grpc.CallOption) (*PluginHostServiceQueryStreamHistoryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PluginHostServiceQueryStreamHistoryResponse)
+	err := c.cc.Invoke(ctx, PluginHostService_QueryStreamHistory_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PluginHostServiceServer is the server API for PluginHostService service.
 // All implementations must embed UnimplementedPluginHostServiceServer
 // for forward compatibility.
@@ -397,6 +453,18 @@ type PluginHostServiceServer interface {
 	// RemoveSessionStream unsubscribes an active session from a stream.
 	// Idempotent: returns success if stream is not subscribed.
 	RemoveSessionStream(context.Context, *PluginHostServiceRemoveSessionStreamRequest) (*PluginHostServiceRemoveSessionStreamResponse, error)
+	// JoinFocus adds a focus membership to an active or detached session.
+	// Plugins declare intent; the server applies kind-specific replay policy.
+	JoinFocus(context.Context, *PluginHostServiceJoinFocusRequest) (*PluginHostServiceJoinFocusResponse, error)
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(context.Context, *PluginHostServiceLeaveFocusRequest) (*PluginHostServiceLeaveFocusResponse, error)
+	// PresentFocus updates the session's PresentingFocus pointer.
+	// Target MUST already exist in FocusMemberships.
+	PresentFocus(context.Context, *PluginHostServicePresentFocusRequest) (*PluginHostServicePresentFocusResponse, error)
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only: does not advance cursors or affect session state.
+	// Count capped at 500 server-side.
+	QueryStreamHistory(context.Context, *PluginHostServiceQueryStreamHistoryRequest) (*PluginHostServiceQueryStreamHistoryResponse, error)
 	mustEmbedUnimplementedPluginHostServiceServer()
 }
 
@@ -427,6 +495,18 @@ func (UnimplementedPluginHostServiceServer) AddSessionStream(context.Context, *P
 }
 func (UnimplementedPluginHostServiceServer) RemoveSessionStream(context.Context, *PluginHostServiceRemoveSessionStreamRequest) (*PluginHostServiceRemoveSessionStreamResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveSessionStream not implemented")
+}
+func (UnimplementedPluginHostServiceServer) JoinFocus(context.Context, *PluginHostServiceJoinFocusRequest) (*PluginHostServiceJoinFocusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method JoinFocus not implemented")
+}
+func (UnimplementedPluginHostServiceServer) LeaveFocus(context.Context, *PluginHostServiceLeaveFocusRequest) (*PluginHostServiceLeaveFocusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method LeaveFocus not implemented")
+}
+func (UnimplementedPluginHostServiceServer) PresentFocus(context.Context, *PluginHostServicePresentFocusRequest) (*PluginHostServicePresentFocusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PresentFocus not implemented")
+}
+func (UnimplementedPluginHostServiceServer) QueryStreamHistory(context.Context, *PluginHostServiceQueryStreamHistoryRequest) (*PluginHostServiceQueryStreamHistoryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method QueryStreamHistory not implemented")
 }
 func (UnimplementedPluginHostServiceServer) mustEmbedUnimplementedPluginHostServiceServer() {}
 func (UnimplementedPluginHostServiceServer) testEmbeddedByValue()                           {}
@@ -575,6 +655,78 @@ func _PluginHostService_RemoveSessionStream_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PluginHostService_JoinFocus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServiceJoinFocusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).JoinFocus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_JoinFocus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).JoinFocus(ctx, req.(*PluginHostServiceJoinFocusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PluginHostService_LeaveFocus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServiceLeaveFocusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).LeaveFocus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_LeaveFocus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).LeaveFocus(ctx, req.(*PluginHostServiceLeaveFocusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PluginHostService_PresentFocus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServicePresentFocusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).PresentFocus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_PresentFocus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).PresentFocus(ctx, req.(*PluginHostServicePresentFocusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PluginHostService_QueryStreamHistory_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PluginHostServiceQueryStreamHistoryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PluginHostServiceServer).QueryStreamHistory(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PluginHostService_QueryStreamHistory_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PluginHostServiceServer).QueryStreamHistory(ctx, req.(*PluginHostServiceQueryStreamHistoryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PluginHostService_ServiceDesc is the grpc.ServiceDesc for PluginHostService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -609,6 +761,22 @@ var PluginHostService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RemoveSessionStream",
 			Handler:    _PluginHostService_RemoveSessionStream_Handler,
+		},
+		{
+			MethodName: "JoinFocus",
+			Handler:    _PluginHostService_JoinFocus_Handler,
+		},
+		{
+			MethodName: "LeaveFocus",
+			Handler:    _PluginHostService_LeaveFocus_Handler,
+		},
+		{
+			MethodName: "PresentFocus",
+			Handler:    _PluginHostService_PresentFocus_Handler,
+		},
+		{
+			MethodName: "QueryStreamHistory",
+			Handler:    _PluginHostService_QueryStreamHistory_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
+++ b/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
@@ -69,6 +69,18 @@ const (
 	// PluginHostServiceRemoveSessionStreamProcedure is the fully-qualified name of the
 	// PluginHostService's RemoveSessionStream RPC.
 	PluginHostServiceRemoveSessionStreamProcedure = "/holomush.plugin.v1.PluginHostService/RemoveSessionStream"
+	// PluginHostServiceJoinFocusProcedure is the fully-qualified name of the PluginHostService's
+	// JoinFocus RPC.
+	PluginHostServiceJoinFocusProcedure = "/holomush.plugin.v1.PluginHostService/JoinFocus"
+	// PluginHostServiceLeaveFocusProcedure is the fully-qualified name of the PluginHostService's
+	// LeaveFocus RPC.
+	PluginHostServiceLeaveFocusProcedure = "/holomush.plugin.v1.PluginHostService/LeaveFocus"
+	// PluginHostServicePresentFocusProcedure is the fully-qualified name of the PluginHostService's
+	// PresentFocus RPC.
+	PluginHostServicePresentFocusProcedure = "/holomush.plugin.v1.PluginHostService/PresentFocus"
+	// PluginHostServiceQueryStreamHistoryProcedure is the fully-qualified name of the
+	// PluginHostService's QueryStreamHistory RPC.
+	PluginHostServiceQueryStreamHistoryProcedure = "/holomush.plugin.v1.PluginHostService/QueryStreamHistory"
 )
 
 // PluginServiceClient is a client for the holomush.plugin.v1.PluginService service.
@@ -253,6 +265,18 @@ type PluginHostServiceClient interface {
 	// RemoveSessionStream unsubscribes an active session from a stream.
 	// Idempotent: returns success if stream is not subscribed.
 	RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error)
+	// JoinFocus adds a focus membership to an active or detached session.
+	// Plugins declare intent; the server applies kind-specific replay policy.
+	JoinFocus(context.Context, *connect.Request[v1.PluginHostServiceJoinFocusRequest]) (*connect.Response[v1.PluginHostServiceJoinFocusResponse], error)
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(context.Context, *connect.Request[v1.PluginHostServiceLeaveFocusRequest]) (*connect.Response[v1.PluginHostServiceLeaveFocusResponse], error)
+	// PresentFocus updates the session's PresentingFocus pointer.
+	// Target MUST already exist in FocusMemberships.
+	PresentFocus(context.Context, *connect.Request[v1.PluginHostServicePresentFocusRequest]) (*connect.Response[v1.PluginHostServicePresentFocusResponse], error)
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only: does not advance cursors or affect session state.
+	// Count capped at 500 server-side.
+	QueryStreamHistory(context.Context, *connect.Request[v1.PluginHostServiceQueryStreamHistoryRequest]) (*connect.Response[v1.PluginHostServiceQueryStreamHistoryResponse], error)
 }
 
 // NewPluginHostServiceClient constructs a client for the holomush.plugin.v1.PluginHostService
@@ -308,6 +332,30 @@ func NewPluginHostServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithSchema(pluginHostServiceMethods.ByName("RemoveSessionStream")),
 			connect.WithClientOptions(opts...),
 		),
+		joinFocus: connect.NewClient[v1.PluginHostServiceJoinFocusRequest, v1.PluginHostServiceJoinFocusResponse](
+			httpClient,
+			baseURL+PluginHostServiceJoinFocusProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("JoinFocus")),
+			connect.WithClientOptions(opts...),
+		),
+		leaveFocus: connect.NewClient[v1.PluginHostServiceLeaveFocusRequest, v1.PluginHostServiceLeaveFocusResponse](
+			httpClient,
+			baseURL+PluginHostServiceLeaveFocusProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("LeaveFocus")),
+			connect.WithClientOptions(opts...),
+		),
+		presentFocus: connect.NewClient[v1.PluginHostServicePresentFocusRequest, v1.PluginHostServicePresentFocusResponse](
+			httpClient,
+			baseURL+PluginHostServicePresentFocusProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("PresentFocus")),
+			connect.WithClientOptions(opts...),
+		),
+		queryStreamHistory: connect.NewClient[v1.PluginHostServiceQueryStreamHistoryRequest, v1.PluginHostServiceQueryStreamHistoryResponse](
+			httpClient,
+			baseURL+PluginHostServiceQueryStreamHistoryProcedure,
+			connect.WithSchema(pluginHostServiceMethods.ByName("QueryStreamHistory")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -320,6 +368,10 @@ type pluginHostServiceClient struct {
 	kVDelete            *connect.Client[v1.PluginHostServiceKVDeleteRequest, v1.PluginHostServiceKVDeleteResponse]
 	addSessionStream    *connect.Client[v1.PluginHostServiceAddSessionStreamRequest, v1.PluginHostServiceAddSessionStreamResponse]
 	removeSessionStream *connect.Client[v1.PluginHostServiceRemoveSessionStreamRequest, v1.PluginHostServiceRemoveSessionStreamResponse]
+	joinFocus           *connect.Client[v1.PluginHostServiceJoinFocusRequest, v1.PluginHostServiceJoinFocusResponse]
+	leaveFocus          *connect.Client[v1.PluginHostServiceLeaveFocusRequest, v1.PluginHostServiceLeaveFocusResponse]
+	presentFocus        *connect.Client[v1.PluginHostServicePresentFocusRequest, v1.PluginHostServicePresentFocusResponse]
+	queryStreamHistory  *connect.Client[v1.PluginHostServiceQueryStreamHistoryRequest, v1.PluginHostServiceQueryStreamHistoryResponse]
 }
 
 // EmitEvent calls holomush.plugin.v1.PluginHostService.EmitEvent.
@@ -357,6 +409,26 @@ func (c *pluginHostServiceClient) RemoveSessionStream(ctx context.Context, req *
 	return c.removeSessionStream.CallUnary(ctx, req)
 }
 
+// JoinFocus calls holomush.plugin.v1.PluginHostService.JoinFocus.
+func (c *pluginHostServiceClient) JoinFocus(ctx context.Context, req *connect.Request[v1.PluginHostServiceJoinFocusRequest]) (*connect.Response[v1.PluginHostServiceJoinFocusResponse], error) {
+	return c.joinFocus.CallUnary(ctx, req)
+}
+
+// LeaveFocus calls holomush.plugin.v1.PluginHostService.LeaveFocus.
+func (c *pluginHostServiceClient) LeaveFocus(ctx context.Context, req *connect.Request[v1.PluginHostServiceLeaveFocusRequest]) (*connect.Response[v1.PluginHostServiceLeaveFocusResponse], error) {
+	return c.leaveFocus.CallUnary(ctx, req)
+}
+
+// PresentFocus calls holomush.plugin.v1.PluginHostService.PresentFocus.
+func (c *pluginHostServiceClient) PresentFocus(ctx context.Context, req *connect.Request[v1.PluginHostServicePresentFocusRequest]) (*connect.Response[v1.PluginHostServicePresentFocusResponse], error) {
+	return c.presentFocus.CallUnary(ctx, req)
+}
+
+// QueryStreamHistory calls holomush.plugin.v1.PluginHostService.QueryStreamHistory.
+func (c *pluginHostServiceClient) QueryStreamHistory(ctx context.Context, req *connect.Request[v1.PluginHostServiceQueryStreamHistoryRequest]) (*connect.Response[v1.PluginHostServiceQueryStreamHistoryResponse], error) {
+	return c.queryStreamHistory.CallUnary(ctx, req)
+}
+
 // PluginHostServiceHandler is an implementation of the holomush.plugin.v1.PluginHostService
 // service.
 type PluginHostServiceHandler interface {
@@ -376,6 +448,18 @@ type PluginHostServiceHandler interface {
 	// RemoveSessionStream unsubscribes an active session from a stream.
 	// Idempotent: returns success if stream is not subscribed.
 	RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error)
+	// JoinFocus adds a focus membership to an active or detached session.
+	// Plugins declare intent; the server applies kind-specific replay policy.
+	JoinFocus(context.Context, *connect.Request[v1.PluginHostServiceJoinFocusRequest]) (*connect.Response[v1.PluginHostServiceJoinFocusResponse], error)
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(context.Context, *connect.Request[v1.PluginHostServiceLeaveFocusRequest]) (*connect.Response[v1.PluginHostServiceLeaveFocusResponse], error)
+	// PresentFocus updates the session's PresentingFocus pointer.
+	// Target MUST already exist in FocusMemberships.
+	PresentFocus(context.Context, *connect.Request[v1.PluginHostServicePresentFocusRequest]) (*connect.Response[v1.PluginHostServicePresentFocusResponse], error)
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only: does not advance cursors or affect session state.
+	// Count capped at 500 server-side.
+	QueryStreamHistory(context.Context, *connect.Request[v1.PluginHostServiceQueryStreamHistoryRequest]) (*connect.Response[v1.PluginHostServiceQueryStreamHistoryResponse], error)
 }
 
 // NewPluginHostServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -427,6 +511,30 @@ func NewPluginHostServiceHandler(svc PluginHostServiceHandler, opts ...connect.H
 		connect.WithSchema(pluginHostServiceMethods.ByName("RemoveSessionStream")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pluginHostServiceJoinFocusHandler := connect.NewUnaryHandler(
+		PluginHostServiceJoinFocusProcedure,
+		svc.JoinFocus,
+		connect.WithSchema(pluginHostServiceMethods.ByName("JoinFocus")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pluginHostServiceLeaveFocusHandler := connect.NewUnaryHandler(
+		PluginHostServiceLeaveFocusProcedure,
+		svc.LeaveFocus,
+		connect.WithSchema(pluginHostServiceMethods.ByName("LeaveFocus")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pluginHostServicePresentFocusHandler := connect.NewUnaryHandler(
+		PluginHostServicePresentFocusProcedure,
+		svc.PresentFocus,
+		connect.WithSchema(pluginHostServiceMethods.ByName("PresentFocus")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pluginHostServiceQueryStreamHistoryHandler := connect.NewUnaryHandler(
+		PluginHostServiceQueryStreamHistoryProcedure,
+		svc.QueryStreamHistory,
+		connect.WithSchema(pluginHostServiceMethods.ByName("QueryStreamHistory")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/holomush.plugin.v1.PluginHostService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PluginHostServiceEmitEventProcedure:
@@ -443,6 +551,14 @@ func NewPluginHostServiceHandler(svc PluginHostServiceHandler, opts ...connect.H
 			pluginHostServiceAddSessionStreamHandler.ServeHTTP(w, r)
 		case PluginHostServiceRemoveSessionStreamProcedure:
 			pluginHostServiceRemoveSessionStreamHandler.ServeHTTP(w, r)
+		case PluginHostServiceJoinFocusProcedure:
+			pluginHostServiceJoinFocusHandler.ServeHTTP(w, r)
+		case PluginHostServiceLeaveFocusProcedure:
+			pluginHostServiceLeaveFocusHandler.ServeHTTP(w, r)
+		case PluginHostServicePresentFocusProcedure:
+			pluginHostServicePresentFocusHandler.ServeHTTP(w, r)
+		case PluginHostServiceQueryStreamHistoryProcedure:
+			pluginHostServiceQueryStreamHistoryHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -478,4 +594,20 @@ func (UnimplementedPluginHostServiceHandler) AddSessionStream(context.Context, *
 
 func (UnimplementedPluginHostServiceHandler) RemoveSessionStream(context.Context, *connect.Request[v1.PluginHostServiceRemoveSessionStreamRequest]) (*connect.Response[v1.PluginHostServiceRemoveSessionStreamResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.RemoveSessionStream is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) JoinFocus(context.Context, *connect.Request[v1.PluginHostServiceJoinFocusRequest]) (*connect.Response[v1.PluginHostServiceJoinFocusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.JoinFocus is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) LeaveFocus(context.Context, *connect.Request[v1.PluginHostServiceLeaveFocusRequest]) (*connect.Response[v1.PluginHostServiceLeaveFocusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.LeaveFocus is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) PresentFocus(context.Context, *connect.Request[v1.PluginHostServicePresentFocusRequest]) (*connect.Response[v1.PluginHostServicePresentFocusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.PresentFocus is not implemented"))
+}
+
+func (UnimplementedPluginHostServiceHandler) QueryStreamHistory(context.Context, *connect.Request[v1.PluginHostServiceQueryStreamHistoryRequest]) (*connect.Response[v1.PluginHostServiceQueryStreamHistoryResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("holomush.plugin.v1.PluginHostService.QueryStreamHistory is not implemented"))
 }

--- a/test/integration/session/session_persistence_integration_test.go
+++ b/test/integration/session/session_persistence_integration_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Session Persistence", func() {
 			replayCtx, replayCancel := context.WithTimeout(testCtx, 5*time.Second)
 			defer replayCancel()
 			replayStream, err := grpcCli.Subscribe(replayCtx, &corev1.SubscribeRequest{
-				SessionId:        sessionID,
+				SessionId: sessionID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -594,7 +594,7 @@ var _ = Describe("Session Persistence", func() {
 			subBCtx, subBCancel := context.WithCancel(testCtx)
 			defer subBCancel()
 			streamB, err := grpcCli.Subscribe(subBCtx, &corev1.SubscribeRequest{
-				SessionId:        sessionID,
+				SessionId: sessionID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { HandleCommandRequest, HandleCommandResponse, HandleEventRequest, HandleEventResponse, InitRequest, InitResponse, PluginHostServiceAddSessionStreamRequest, PluginHostServiceAddSessionStreamResponse, PluginHostServiceEmitEventRequest, PluginHostServiceEmitEventResponse, PluginHostServiceKVDeleteRequest, PluginHostServiceKVDeleteResponse, PluginHostServiceKVGetRequest, PluginHostServiceKVGetResponse, PluginHostServiceKVSetRequest, PluginHostServiceKVSetResponse, PluginHostServiceLogRequest, PluginHostServiceLogResponse, PluginHostServiceRemoveSessionStreamRequest, PluginHostServiceRemoveSessionStreamResponse, QuerySessionStreamsRequest, QuerySessionStreamsResponse } from "./plugin_pb.js";
+import { HandleCommandRequest, HandleCommandResponse, HandleEventRequest, HandleEventResponse, InitRequest, InitResponse, PluginHostServiceAddSessionStreamRequest, PluginHostServiceAddSessionStreamResponse, PluginHostServiceEmitEventRequest, PluginHostServiceEmitEventResponse, PluginHostServiceJoinFocusRequest, PluginHostServiceJoinFocusResponse, PluginHostServiceKVDeleteRequest, PluginHostServiceKVDeleteResponse, PluginHostServiceKVGetRequest, PluginHostServiceKVGetResponse, PluginHostServiceKVSetRequest, PluginHostServiceKVSetResponse, PluginHostServiceLeaveFocusRequest, PluginHostServiceLeaveFocusResponse, PluginHostServiceLogRequest, PluginHostServiceLogResponse, PluginHostServicePresentFocusRequest, PluginHostServicePresentFocusResponse, PluginHostServiceQueryStreamHistoryRequest, PluginHostServiceQueryStreamHistoryResponse, PluginHostServiceRemoveSessionStreamRequest, PluginHostServiceRemoveSessionStreamResponse, QuerySessionStreamsRequest, QuerySessionStreamsResponse } from "./plugin_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -157,6 +157,54 @@ export const PluginHostService = {
       name: "RemoveSessionStream",
       I: PluginHostServiceRemoveSessionStreamRequest,
       O: PluginHostServiceRemoveSessionStreamResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * JoinFocus adds a focus membership to an active or detached session.
+     * Plugins declare intent; the server applies kind-specific replay policy.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.JoinFocus
+     */
+    joinFocus: {
+      name: "JoinFocus",
+      I: PluginHostServiceJoinFocusRequest,
+      O: PluginHostServiceJoinFocusResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * LeaveFocus removes a focus membership. Idempotent on non-member.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.LeaveFocus
+     */
+    leaveFocus: {
+      name: "LeaveFocus",
+      I: PluginHostServiceLeaveFocusRequest,
+      O: PluginHostServiceLeaveFocusResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * PresentFocus updates the session's PresentingFocus pointer.
+     * Target MUST already exist in FocusMemberships.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.PresentFocus
+     */
+    presentFocus: {
+      name: "PresentFocus",
+      I: PluginHostServicePresentFocusRequest,
+      O: PluginHostServicePresentFocusResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * QueryStreamHistory reads the tail of a stream for plugin-side display.
+     * Read-only: does not advance cursors or affect session state.
+     * Count capped at 500 server-side.
+     *
+     * @generated from rpc holomush.plugin.v1.PluginHostService.QueryStreamHistory
+     */
+    queryStreamHistory: {
+      name: "QueryStreamHistory",
+      I: PluginHostServiceQueryStreamHistoryRequest,
+      O: PluginHostServiceQueryStreamHistoryResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
@@ -16,7 +16,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file holomush/plugin/v1/plugin.proto.
  */
 export const file_holomush_plugin_v1_plugin: GenFile = /*@__PURE__*/
-  fileDesc("Ch9ob2xvbXVzaC9wbHVnaW4vdjEvcGx1Z2luLnByb3RvEhJob2xvbXVzaC5wbHVnaW4udjEitwEKDVNlcnZpY2VDb25maWcSGQoRY29ubmVjdGlvbl9zdHJpbmcYASABKAkSUgoRcmVxdWlyZWRfc2VydmljZXMYAiADKAsyNy5ob2xvbXVzaC5wbHVnaW4udjEuU2VydmljZUNvbmZpZy5SZXF1aXJlZFNlcnZpY2VzRW50cnkaNwoVUmVxdWlyZWRTZXJ2aWNlc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQAoLSW5pdFJlcXVlc3QSMQoGY29uZmlnGAEgASgLMiEuaG9sb211c2gucGx1Z2luLnYxLlNlcnZpY2VDb25maWciKQoMSW5pdFJlc3BvbnNlEhkKEXByb3ZpZGVkX3NlcnZpY2VzGAEgAygJIrMBCgVFdmVudBITCgJpZBgBIAEoCUIHukgEcgIQARIXCgZzdHJlYW0YAiABKAlCB7pIBHICEAESFQoEdHlwZRgDIAEoCUIHukgEcgIQARIRCgl0aW1lc3RhbXAYBCABKAMSGwoKYWN0b3Jfa2luZBgFIAEoCUIHukgEcgIQARIZCghhY3Rvcl9pZBgGIAEoCUIHukgEcgIQARIaCgdwYXlsb2FkGAcgASgJQgm6SAZyBBiAgAQiVwoJRW1pdEV2ZW50EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIVCgR0eXBlGAIgASgJQge6SARyAhABEhoKB3BheWxvYWQYAyABKAlCCbpIBnIEGICABCI+ChJIYW5kbGVFdmVudFJlcXVlc3QSKAoFZXZlbnQYASABKAsyGS5ob2xvbXVzaC5wbHVnaW4udjEuRXZlbnQiSQoTSGFuZGxlRXZlbnRSZXNwb25zZRIyCgtlbWl0X2V2ZW50cxgBIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQi9gEKDkNvbW1hbmRSZXF1ZXN0EhgKB2NvbW1hbmQYASABKAlCB7pIBHICEAESFgoEYXJncxgCIAEoCUIIukgFcgMYgEASGwoJcmF3X2lucHV0GAMgASgJQgi6SAVyAxiAQBIdCgxjaGFyYWN0ZXJfaWQYBCABKAlCB7pIBHICEAESHwoOY2hhcmFjdGVyX25hbWUYBSABKAlCB7pIBHICEAESHAoLbG9jYXRpb25faWQYBiABKAlCB7pIBHICEAESGwoKc2Vzc2lvbl9pZBgHIAEoCUIHukgEcgIQARIaCglwbGF5ZXJfaWQYCCABKAlCB7pIBHICEAEiyQEKD0NvbW1hbmRSZXNwb25zZRIxCgZzdGF0dXMYASABKA4yIS5ob2xvbXVzaC5wbHVnaW4udjEuQ29tbWFuZFN0YXR1cxIYCgZvdXRwdXQYAiABKAlCCLpIBXIDGIBAEi0KBmV2ZW50cxgDIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQSOgoLYXVkaXRfaGludHMYBCADKAsyJS5ob2xvbXVzaC5wbHVnaW4udjEuQXVkaXREZWNpc2lvbkhpbnQizAIKEUF1ZGl0RGVjaXNpb25IaW50EhYKAmlkGAEgASgJQgq6SAdyBRABGIABEhYKBG5hbWUYAiABKAlCCLpIBXIDGIACEhkKB21lc3NhZ2UYAyABKAlCCLpIBXIDGIAIEi8KBmVmZmVjdBgEIAEoDjIfLmhvbG9tdXNoLnBsdWdpbi52MS5BdWRpdEVmZmVjdBIhChBhY3Rpb25fcXVhbGlmaWVyGAUgASgJQge6SARyAhhAEhoKCHJlc291cmNlGAYgASgJQgi6SAVyAxiAAhJJCgphdHRyaWJ1dGVzGAcgAygLMjUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RGVjaXNpb25IaW50LkF0dHJpYnV0ZXNFbnRyeRoxCg9BdHRyaWJ1dGVzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJLChRIYW5kbGVDb21tYW5kUmVxdWVzdBIzCgdjb21tYW5kGAEgASgLMiIuaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRSZXF1ZXN0Ik4KFUhhbmRsZUNvbW1hbmRSZXNwb25zZRI1CghyZXNwb25zZRgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kUmVzcG9uc2UiagohUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIbCgpldmVudF90eXBlGAIgASgJQge6SARyAhABEg8KB3BheWxvYWQYAyABKAwiJAoiUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXNwb25zZSJQChtQbHVnaW5Ib3N0U2VydmljZUxvZ1JlcXVlc3QSFgoFbGV2ZWwYASABKAlCB7pIBHICEAESGQoHbWVzc2FnZRgCIAEoCUIIukgFcgMYgEAiHgocUGx1Z2luSG9zdFNlcnZpY2VMb2dSZXNwb25zZSJTCh1QbHVnaW5Ib3N0U2VydmljZUtWR2V0UmVxdWVzdBIcCgtwbHVnaW5fbmFtZRgBIAEoCUIHukgEcgIQARIUCgNrZXkYAiABKAlCB7pIBHICEAEiPgoeUGx1Z2luSG9zdFNlcnZpY2VLVkdldFJlc3BvbnNlEg0KBXZhbHVlGAEgASgJEg0KBWZvdW5kGAIgASgIImIKHVBsdWdpbkhvc3RTZXJ2aWNlS1ZTZXRSZXF1ZXN0EhwKC3BsdWdpbl9uYW1lGAEgASgJQge6SARyAhABEhQKA2tleRgCIAEoCUIHukgEcgIQARINCgV2YWx1ZRgDIAEoCSIgCh5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2UiVgogUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QSHAoLcGx1Z2luX25hbWUYASABKAlCB7pIBHICEAESFAoDa2V5GAIgASgJQge6SARyAhABIiMKIVBsdWdpbkhvc3RTZXJ2aWNlS1ZEZWxldGVSZXNwb25zZSJOCihQbHVnaW5Ib3N0U2VydmljZUFkZFNlc3Npb25TdHJlYW1SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkSDgoGc3RyZWFtGAIgASgJIjwKKVBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgiUQorUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg4KBnN0cmVhbRgCIAEoCSI/CixQbHVnaW5Ib3N0U2VydmljZVJlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIIlkKGlF1ZXJ5U2Vzc2lvblN0cmVhbXNSZXF1ZXN0EhQKDGNoYXJhY3Rlcl9pZBgBIAEoCRIRCglwbGF5ZXJfaWQYAiABKAkSEgoKc2Vzc2lvbl9pZBgDIAEoCSI9ChtRdWVyeVNlc3Npb25TdHJlYW1zUmVzcG9uc2USDwoHc3RyZWFtcxgBIAMoCRINCgVlcnJvchgCIAEoCSqWAQoNQ29tbWFuZFN0YXR1cxIeChpDT01NQU5EX1NUQVRVU19VTlNQRUNJRklFRBAAEhUKEUNPTU1BTkRfU1RBVFVTX09LEAESGAoUQ09NTUFORF9TVEFUVVNfRVJST1IQAhIaChZDT01NQU5EX1NUQVRVU19GQUlMVVJFEAMSGAoUQ09NTUFORF9TVEFUVVNfRkFUQUwQBCpaCgtBdWRpdEVmZmVjdBIcChhBVURJVF9FRkZFQ1RfVU5TUEVDSUZJRUQQABIVChFBVURJVF9FRkZFQ1RfREVOWRABEhYKEkFVRElUX0VGRkVDVF9BTExPVxACMpgDCg1QbHVnaW5TZXJ2aWNlEkkKBEluaXQSHy5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlcXVlc3QaIC5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlc3BvbnNlEl4KC0hhbmRsZUV2ZW50EiYuaG9sb211c2gucGx1Z2luLnYxLkhhbmRsZUV2ZW50UmVxdWVzdBonLmhvbG9tdXNoLnBsdWdpbi52MS5IYW5kbGVFdmVudFJlc3BvbnNlEmQKDUhhbmRsZUNvbW1hbmQSKC5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlcXVlc3QaKS5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlc3BvbnNlEnYKE1F1ZXJ5U2Vzc2lvblN0cmVhbXMSLi5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1JlcXVlc3QaLy5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1Jlc3BvbnNlMv8GChFQbHVnaW5Ib3N0U2VydmljZRJ6CglFbWl0RXZlbnQSNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0GjYuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlRW1pdEV2ZW50UmVzcG9uc2USaAoDTG9nEi8uaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlTG9nUmVxdWVzdBowLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUxvZ1Jlc3BvbnNlEm4KBUtWR2V0EjEuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXF1ZXN0GjIuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXNwb25zZRJuCgVLVlNldBIxLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVxdWVzdBoyLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2USdwoIS1ZEZWxldGUSNC5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QaNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlc3BvbnNlEo8BChBBZGRTZXNzaW9uU3RyZWFtEjwuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlcXVlc3QaPS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VBZGRTZXNzaW9uU3RyZWFtUmVzcG9uc2USmAEKE1JlbW92ZVNlc3Npb25TdHJlYW0SPy5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVxdWVzdBpALmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZVJlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZUJEWkJnaXRodWIuY29tL2hvbG9tdXNoL2hvbG9tdXNoL3BrZy9wcm90by9ob2xvbXVzaC9wbHVnaW4vdjE7cGx1Z2ludjFiBnByb3RvMw", [file_buf_validate_validate]);
+  fileDesc("Ch9ob2xvbXVzaC9wbHVnaW4vdjEvcGx1Z2luLnByb3RvEhJob2xvbXVzaC5wbHVnaW4udjEitwEKDVNlcnZpY2VDb25maWcSGQoRY29ubmVjdGlvbl9zdHJpbmcYASABKAkSUgoRcmVxdWlyZWRfc2VydmljZXMYAiADKAsyNy5ob2xvbXVzaC5wbHVnaW4udjEuU2VydmljZUNvbmZpZy5SZXF1aXJlZFNlcnZpY2VzRW50cnkaNwoVUmVxdWlyZWRTZXJ2aWNlc0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQAoLSW5pdFJlcXVlc3QSMQoGY29uZmlnGAEgASgLMiEuaG9sb211c2gucGx1Z2luLnYxLlNlcnZpY2VDb25maWciKQoMSW5pdFJlc3BvbnNlEhkKEXByb3ZpZGVkX3NlcnZpY2VzGAEgAygJIrMBCgVFdmVudBITCgJpZBgBIAEoCUIHukgEcgIQARIXCgZzdHJlYW0YAiABKAlCB7pIBHICEAESFQoEdHlwZRgDIAEoCUIHukgEcgIQARIRCgl0aW1lc3RhbXAYBCABKAMSGwoKYWN0b3Jfa2luZBgFIAEoCUIHukgEcgIQARIZCghhY3Rvcl9pZBgGIAEoCUIHukgEcgIQARIaCgdwYXlsb2FkGAcgASgJQgm6SAZyBBiAgAQiVwoJRW1pdEV2ZW50EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIVCgR0eXBlGAIgASgJQge6SARyAhABEhoKB3BheWxvYWQYAyABKAlCCbpIBnIEGICABCI+ChJIYW5kbGVFdmVudFJlcXVlc3QSKAoFZXZlbnQYASABKAsyGS5ob2xvbXVzaC5wbHVnaW4udjEuRXZlbnQiSQoTSGFuZGxlRXZlbnRSZXNwb25zZRIyCgtlbWl0X2V2ZW50cxgBIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQi9gEKDkNvbW1hbmRSZXF1ZXN0EhgKB2NvbW1hbmQYASABKAlCB7pIBHICEAESFgoEYXJncxgCIAEoCUIIukgFcgMYgEASGwoJcmF3X2lucHV0GAMgASgJQgi6SAVyAxiAQBIdCgxjaGFyYWN0ZXJfaWQYBCABKAlCB7pIBHICEAESHwoOY2hhcmFjdGVyX25hbWUYBSABKAlCB7pIBHICEAESHAoLbG9jYXRpb25faWQYBiABKAlCB7pIBHICEAESGwoKc2Vzc2lvbl9pZBgHIAEoCUIHukgEcgIQARIaCglwbGF5ZXJfaWQYCCABKAlCB7pIBHICEAEiyQEKD0NvbW1hbmRSZXNwb25zZRIxCgZzdGF0dXMYASABKA4yIS5ob2xvbXVzaC5wbHVnaW4udjEuQ29tbWFuZFN0YXR1cxIYCgZvdXRwdXQYAiABKAlCCLpIBXIDGIBAEi0KBmV2ZW50cxgDIAMoCzIdLmhvbG9tdXNoLnBsdWdpbi52MS5FbWl0RXZlbnQSOgoLYXVkaXRfaGludHMYBCADKAsyJS5ob2xvbXVzaC5wbHVnaW4udjEuQXVkaXREZWNpc2lvbkhpbnQizAIKEUF1ZGl0RGVjaXNpb25IaW50EhYKAmlkGAEgASgJQgq6SAdyBRABGIABEhYKBG5hbWUYAiABKAlCCLpIBXIDGIACEhkKB21lc3NhZ2UYAyABKAlCCLpIBXIDGIAIEi8KBmVmZmVjdBgEIAEoDjIfLmhvbG9tdXNoLnBsdWdpbi52MS5BdWRpdEVmZmVjdBIhChBhY3Rpb25fcXVhbGlmaWVyGAUgASgJQge6SARyAhhAEhoKCHJlc291cmNlGAYgASgJQgi6SAVyAxiAAhJJCgphdHRyaWJ1dGVzGAcgAygLMjUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RGVjaXNpb25IaW50LkF0dHJpYnV0ZXNFbnRyeRoxCg9BdHRyaWJ1dGVzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJLChRIYW5kbGVDb21tYW5kUmVxdWVzdBIzCgdjb21tYW5kGAEgASgLMiIuaG9sb211c2gucGx1Z2luLnYxLkNvbW1hbmRSZXF1ZXN0Ik4KFUhhbmRsZUNvbW1hbmRSZXNwb25zZRI1CghyZXNwb25zZRgBIAEoCzIjLmhvbG9tdXNoLnBsdWdpbi52MS5Db21tYW5kUmVzcG9uc2UiagohUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0EhcKBnN0cmVhbRgBIAEoCUIHukgEcgIQARIbCgpldmVudF90eXBlGAIgASgJQge6SARyAhABEg8KB3BheWxvYWQYAyABKAwiJAoiUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXNwb25zZSJQChtQbHVnaW5Ib3N0U2VydmljZUxvZ1JlcXVlc3QSFgoFbGV2ZWwYASABKAlCB7pIBHICEAESGQoHbWVzc2FnZRgCIAEoCUIIukgFcgMYgEAiHgocUGx1Z2luSG9zdFNlcnZpY2VMb2dSZXNwb25zZSJTCh1QbHVnaW5Ib3N0U2VydmljZUtWR2V0UmVxdWVzdBIcCgtwbHVnaW5fbmFtZRgBIAEoCUIHukgEcgIQARIUCgNrZXkYAiABKAlCB7pIBHICEAEiPgoeUGx1Z2luSG9zdFNlcnZpY2VLVkdldFJlc3BvbnNlEg0KBXZhbHVlGAEgASgJEg0KBWZvdW5kGAIgASgIImIKHVBsdWdpbkhvc3RTZXJ2aWNlS1ZTZXRSZXF1ZXN0EhwKC3BsdWdpbl9uYW1lGAEgASgJQge6SARyAhABEhQKA2tleRgCIAEoCUIHukgEcgIQARINCgV2YWx1ZRgDIAEoCSIgCh5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2UiVgogUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QSHAoLcGx1Z2luX25hbWUYASABKAlCB7pIBHICEAESFAoDa2V5GAIgASgJQge6SARyAhABIiMKIVBsdWdpbkhvc3RTZXJ2aWNlS1ZEZWxldGVSZXNwb25zZSKbAQooUGx1Z2luSG9zdFNlcnZpY2VBZGRTZXNzaW9uU3RyZWFtUmVxdWVzdBIbCgpzZXNzaW9uX2lkGAEgASgJQge6SARyAhABEhcKBnN0cmVhbRgCIAEoCUIHukgEcgIQARI5CgtyZXBsYXlfbW9kZRgDIAEoDjIkLmhvbG9tdXNoLnBsdWdpbi52MS5TdHJlYW1SZXBsYXlNb2RlIisKKVBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlc3BvbnNlImMKK1BsdWdpbkhvc3RTZXJ2aWNlUmVtb3ZlU2Vzc2lvblN0cmVhbVJlcXVlc3QSGwoKc2Vzc2lvbl9pZBgBIAEoCUIHukgEcgIQARIXCgZzdHJlYW0YAiABKAlCB7pIBHICEAEiLgosUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVzcG9uc2UiWQoaUXVlcnlTZXNzaW9uU3RyZWFtc1JlcXVlc3QSFAoMY2hhcmFjdGVyX2lkGAEgASgJEhEKCXBsYXllcl9pZBgCIAEoCRISCgpzZXNzaW9uX2lkGAMgASgJIj0KG1F1ZXJ5U2Vzc2lvblN0cmVhbXNSZXNwb25zZRIPCgdzdHJlYW1zGAEgAygJEg0KBWVycm9yGAIgASgJIlMKCEZvY3VzS2V5EisKBGtpbmQYASABKA4yHS5ob2xvbXVzaC5wbHVnaW4udjEuRm9jdXNLaW5kEhoKCXRhcmdldF9pZBgCIAEoCUIHukgEcgIQASJuCiFQbHVnaW5Ib3N0U2VydmljZUpvaW5Gb2N1c1JlcXVlc3QSGwoKc2Vzc2lvbl9pZBgBIAEoCUIHukgEcgIQARIsCgZ0YXJnZXQYAiABKAsyHC5ob2xvbXVzaC5wbHVnaW4udjEuRm9jdXNLZXkiJAoiUGx1Z2luSG9zdFNlcnZpY2VKb2luRm9jdXNSZXNwb25zZSJvCiJQbHVnaW5Ib3N0U2VydmljZUxlYXZlRm9jdXNSZXF1ZXN0EhsKCnNlc3Npb25faWQYASABKAlCB7pIBHICEAESLAoGdGFyZ2V0GAIgASgLMhwuaG9sb211c2gucGx1Z2luLnYxLkZvY3VzS2V5IiUKI1BsdWdpbkhvc3RTZXJ2aWNlTGVhdmVGb2N1c1Jlc3BvbnNlInEKJFBsdWdpbkhvc3RTZXJ2aWNlUHJlc2VudEZvY3VzUmVxdWVzdBIbCgpzZXNzaW9uX2lkGAEgASgJQge6SARyAhABEiwKBnRhcmdldBgCIAEoCzIcLmhvbG9tdXNoLnBsdWdpbi52MS5Gb2N1c0tleSInCiVQbHVnaW5Ib3N0U2VydmljZVByZXNlbnRGb2N1c1Jlc3BvbnNlImsKKlBsdWdpbkhvc3RTZXJ2aWNlUXVlcnlTdHJlYW1IaXN0b3J5UmVxdWVzdBIXCgZzdHJlYW0YASABKAlCB7pIBHICEAESDQoFY291bnQYAiABKAUSFQoNbm90X2JlZm9yZV9tcxgDIAEoAyJYCitQbHVnaW5Ib3N0U2VydmljZVF1ZXJ5U3RyZWFtSGlzdG9yeVJlc3BvbnNlEikKBmV2ZW50cxgBIAMoCzIZLmhvbG9tdXNoLnBsdWdpbi52MS5FdmVudCqWAQoNQ29tbWFuZFN0YXR1cxIeChpDT01NQU5EX1NUQVRVU19VTlNQRUNJRklFRBAAEhUKEUNPTU1BTkRfU1RBVFVTX09LEAESGAoUQ09NTUFORF9TVEFUVVNfRVJST1IQAhIaChZDT01NQU5EX1NUQVRVU19GQUlMVVJFEAMSGAoUQ09NTUFORF9TVEFUVVNfRkFUQUwQBCpaCgtBdWRpdEVmZmVjdBIcChhBVURJVF9FRkZFQ1RfVU5TUEVDSUZJRUQQABIVChFBVURJVF9FRkZFQ1RfREVOWRABEhYKEkFVRElUX0VGRkVDVF9BTExPVxACKj0KCUZvY3VzS2luZBIaChZGT0NVU19LSU5EX1VOU1BFQ0lGSUVEEAASFAoQRk9DVVNfS0lORF9TQ0VORRABKnwKEFN0cmVhbVJlcGxheU1vZGUSIgoeU1RSRUFNX1JFUExBWV9NT0RFX1VOU1BFQ0lGSUVEEAASIgoeU1RSRUFNX1JFUExBWV9NT0RFX0ZST01fQ1VSU09SEAESIAocU1RSRUFNX1JFUExBWV9NT0RFX0xJVkVfT05MWRACMpgDCg1QbHVnaW5TZXJ2aWNlEkkKBEluaXQSHy5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlcXVlc3QaIC5ob2xvbXVzaC5wbHVnaW4udjEuSW5pdFJlc3BvbnNlEl4KC0hhbmRsZUV2ZW50EiYuaG9sb211c2gucGx1Z2luLnYxLkhhbmRsZUV2ZW50UmVxdWVzdBonLmhvbG9tdXNoLnBsdWdpbi52MS5IYW5kbGVFdmVudFJlc3BvbnNlEmQKDUhhbmRsZUNvbW1hbmQSKC5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlcXVlc3QaKS5ob2xvbXVzaC5wbHVnaW4udjEuSGFuZGxlQ29tbWFuZFJlc3BvbnNlEnYKE1F1ZXJ5U2Vzc2lvblN0cmVhbXMSLi5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1JlcXVlc3QaLy5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlTZXNzaW9uU3RyZWFtc1Jlc3BvbnNlMpgLChFQbHVnaW5Ib3N0U2VydmljZRJ6CglFbWl0RXZlbnQSNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VFbWl0RXZlbnRSZXF1ZXN0GjYuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlRW1pdEV2ZW50UmVzcG9uc2USaAoDTG9nEi8uaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlTG9nUmVxdWVzdBowLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUxvZ1Jlc3BvbnNlEm4KBUtWR2V0EjEuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXF1ZXN0GjIuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlS1ZHZXRSZXNwb25zZRJuCgVLVlNldBIxLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVxdWVzdBoyLmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUtWU2V0UmVzcG9uc2USdwoIS1ZEZWxldGUSNC5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlcXVlc3QaNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VLVkRlbGV0ZVJlc3BvbnNlEo8BChBBZGRTZXNzaW9uU3RyZWFtEjwuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlQWRkU2Vzc2lvblN0cmVhbVJlcXVlc3QaPS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VBZGRTZXNzaW9uU3RyZWFtUmVzcG9uc2USmAEKE1JlbW92ZVNlc3Npb25TdHJlYW0SPy5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VSZW1vdmVTZXNzaW9uU3RyZWFtUmVxdWVzdBpALmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZVJlbW92ZVNlc3Npb25TdHJlYW1SZXNwb25zZRJ6CglKb2luRm9jdXMSNS5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VKb2luRm9jdXNSZXF1ZXN0GjYuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlSm9pbkZvY3VzUmVzcG9uc2USfQoKTGVhdmVGb2N1cxI2LmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZUxlYXZlRm9jdXNSZXF1ZXN0GjcuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlTGVhdmVGb2N1c1Jlc3BvbnNlEoMBCgxQcmVzZW50Rm9jdXMSOC5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VQcmVzZW50Rm9jdXNSZXF1ZXN0GjkuaG9sb211c2gucGx1Z2luLnYxLlBsdWdpbkhvc3RTZXJ2aWNlUHJlc2VudEZvY3VzUmVzcG9uc2USlQEKElF1ZXJ5U3RyZWFtSGlzdG9yeRI+LmhvbG9tdXNoLnBsdWdpbi52MS5QbHVnaW5Ib3N0U2VydmljZVF1ZXJ5U3RyZWFtSGlzdG9yeVJlcXVlc3QaPy5ob2xvbXVzaC5wbHVnaW4udjEuUGx1Z2luSG9zdFNlcnZpY2VRdWVyeVN0cmVhbUhpc3RvcnlSZXNwb25zZUJEWkJnaXRodWIuY29tL2hvbG9tdXNoL2hvbG9tdXNoL3BrZy9wcm90by9ob2xvbXVzaC9wbHVnaW4vdjE7cGx1Z2ludjFiBnByb3RvMw", [file_buf_validate_validate]);
 
 /**
  * ServiceConfig carries initialization data from the host to the plugin.
@@ -660,8 +660,6 @@ export const PluginHostServiceKVDeleteResponseSchema: GenMessage<PluginHostServi
   messageDesc(file_holomush_plugin_v1_plugin, 21);
 
 /**
- * PluginHostServiceAddSessionStreamRequest specifies which session and stream to add.
- *
  * @generated from message holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest
  */
 export type PluginHostServiceAddSessionStreamRequest = Message<"holomush.plugin.v1.PluginHostServiceAddSessionStreamRequest"> & {
@@ -678,6 +676,14 @@ export type PluginHostServiceAddSessionStreamRequest = Message<"holomush.plugin.
    * @generated from field: string stream = 2;
    */
   stream: string;
+
+  /**
+   * replay_mode controls initial replay. Optional; defaults to
+   * FROM_CURSOR if unspecified for backwards compatibility.
+   *
+   * @generated from field: holomush.plugin.v1.StreamReplayMode replay_mode = 3;
+   */
+  replayMode: StreamReplayMode;
 };
 
 /**
@@ -688,17 +694,9 @@ export const PluginHostServiceAddSessionStreamRequestSchema: GenMessage<PluginHo
   messageDesc(file_holomush_plugin_v1_plugin, 22);
 
 /**
- * PluginHostServiceAddSessionStreamResponse indicates success or failure.
- *
  * @generated from message holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse
  */
 export type PluginHostServiceAddSessionStreamResponse = Message<"holomush.plugin.v1.PluginHostServiceAddSessionStreamResponse"> & {
-  /**
-   * Whether the stream was successfully added.
-   *
-   * @generated from field: bool success = 1;
-   */
-  success: boolean;
 };
 
 /**
@@ -709,21 +707,15 @@ export const PluginHostServiceAddSessionStreamResponseSchema: GenMessage<PluginH
   messageDesc(file_holomush_plugin_v1_plugin, 23);
 
 /**
- * PluginHostServiceRemoveSessionStreamRequest specifies which stream to remove.
- *
  * @generated from message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest
  */
 export type PluginHostServiceRemoveSessionStreamRequest = Message<"holomush.plugin.v1.PluginHostServiceRemoveSessionStreamRequest"> & {
   /**
-   * Active session identifier.
-   *
    * @generated from field: string session_id = 1;
    */
   sessionId: string;
 
   /**
-   * Stream name to unsubscribe from.
-   *
    * @generated from field: string stream = 2;
    */
   stream: string;
@@ -737,17 +729,9 @@ export const PluginHostServiceRemoveSessionStreamRequestSchema: GenMessage<Plugi
   messageDesc(file_holomush_plugin_v1_plugin, 24);
 
 /**
- * PluginHostServiceRemoveSessionStreamResponse indicates success or failure.
- *
  * @generated from message holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse
  */
 export type PluginHostServiceRemoveSessionStreamResponse = Message<"holomush.plugin.v1.PluginHostServiceRemoveSessionStreamResponse"> & {
-  /**
-   * Whether the stream was successfully removed (true even if not subscribed).
-   *
-   * @generated from field: bool success = 1;
-   */
-  success: boolean;
 };
 
 /**
@@ -821,6 +805,182 @@ export const QuerySessionStreamsResponseSchema: GenMessage<QuerySessionStreamsRe
   messageDesc(file_holomush_plugin_v1_plugin, 27);
 
 /**
+ * FocusKey identifies a focus membership within a session. A session's
+ * focus memberships are unique by (kind, target_id) pair.
+ *
+ * @generated from message holomush.plugin.v1.FocusKey
+ */
+export type FocusKey = Message<"holomush.plugin.v1.FocusKey"> & {
+  /**
+   * @generated from field: holomush.plugin.v1.FocusKind kind = 1;
+   */
+  kind: FocusKind;
+
+  /**
+   * @generated from field: string target_id = 2;
+   */
+  targetId: string;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.FocusKey.
+ * Use `create(FocusKeySchema)` to create a new message.
+ */
+export const FocusKeySchema: GenMessage<FocusKey> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 28);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceJoinFocusRequest
+ */
+export type PluginHostServiceJoinFocusRequest = Message<"holomush.plugin.v1.PluginHostServiceJoinFocusRequest"> & {
+  /**
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * @generated from field: holomush.plugin.v1.FocusKey target = 2;
+   */
+  target?: FocusKey;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceJoinFocusRequest.
+ * Use `create(PluginHostServiceJoinFocusRequestSchema)` to create a new message.
+ */
+export const PluginHostServiceJoinFocusRequestSchema: GenMessage<PluginHostServiceJoinFocusRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 29);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceJoinFocusResponse
+ */
+export type PluginHostServiceJoinFocusResponse = Message<"holomush.plugin.v1.PluginHostServiceJoinFocusResponse"> & {
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceJoinFocusResponse.
+ * Use `create(PluginHostServiceJoinFocusResponseSchema)` to create a new message.
+ */
+export const PluginHostServiceJoinFocusResponseSchema: GenMessage<PluginHostServiceJoinFocusResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 30);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceLeaveFocusRequest
+ */
+export type PluginHostServiceLeaveFocusRequest = Message<"holomush.plugin.v1.PluginHostServiceLeaveFocusRequest"> & {
+  /**
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * @generated from field: holomush.plugin.v1.FocusKey target = 2;
+   */
+  target?: FocusKey;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceLeaveFocusRequest.
+ * Use `create(PluginHostServiceLeaveFocusRequestSchema)` to create a new message.
+ */
+export const PluginHostServiceLeaveFocusRequestSchema: GenMessage<PluginHostServiceLeaveFocusRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 31);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceLeaveFocusResponse
+ */
+export type PluginHostServiceLeaveFocusResponse = Message<"holomush.plugin.v1.PluginHostServiceLeaveFocusResponse"> & {
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceLeaveFocusResponse.
+ * Use `create(PluginHostServiceLeaveFocusResponseSchema)` to create a new message.
+ */
+export const PluginHostServiceLeaveFocusResponseSchema: GenMessage<PluginHostServiceLeaveFocusResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 32);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServicePresentFocusRequest
+ */
+export type PluginHostServicePresentFocusRequest = Message<"holomush.plugin.v1.PluginHostServicePresentFocusRequest"> & {
+  /**
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * @generated from field: holomush.plugin.v1.FocusKey target = 2;
+   */
+  target?: FocusKey;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServicePresentFocusRequest.
+ * Use `create(PluginHostServicePresentFocusRequestSchema)` to create a new message.
+ */
+export const PluginHostServicePresentFocusRequestSchema: GenMessage<PluginHostServicePresentFocusRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 33);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServicePresentFocusResponse
+ */
+export type PluginHostServicePresentFocusResponse = Message<"holomush.plugin.v1.PluginHostServicePresentFocusResponse"> & {
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServicePresentFocusResponse.
+ * Use `create(PluginHostServicePresentFocusResponseSchema)` to create a new message.
+ */
+export const PluginHostServicePresentFocusResponseSchema: GenMessage<PluginHostServicePresentFocusResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 34);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest
+ */
+export type PluginHostServiceQueryStreamHistoryRequest = Message<"holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest"> & {
+  /**
+   * @generated from field: string stream = 1;
+   */
+  stream: string;
+
+  /**
+   * @generated from field: int32 count = 2;
+   */
+  count: number;
+
+  /**
+   * Epoch milliseconds. Events before this time are excluded. 0 means no lower bound.
+   *
+   * @generated from field: int64 not_before_ms = 3;
+   */
+  notBeforeMs: bigint;
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceQueryStreamHistoryRequest.
+ * Use `create(PluginHostServiceQueryStreamHistoryRequestSchema)` to create a new message.
+ */
+export const PluginHostServiceQueryStreamHistoryRequestSchema: GenMessage<PluginHostServiceQueryStreamHistoryRequest> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 35);
+
+/**
+ * @generated from message holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse
+ */
+export type PluginHostServiceQueryStreamHistoryResponse = Message<"holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse"> & {
+  /**
+   * @generated from field: repeated holomush.plugin.v1.Event events = 1;
+   */
+  events: Event[];
+};
+
+/**
+ * Describes the message holomush.plugin.v1.PluginHostServiceQueryStreamHistoryResponse.
+ * Use `create(PluginHostServiceQueryStreamHistoryResponseSchema)` to create a new message.
+ */
+export const PluginHostServiceQueryStreamHistoryResponseSchema: GenMessage<PluginHostServiceQueryStreamHistoryResponse> = /*@__PURE__*/
+  messageDesc(file_holomush_plugin_v1_plugin, 36);
+
+/**
  * CommandStatus maps to pkg/plugin.CommandStatus values.
  *
  * @generated from enum holomush.plugin.v1.CommandStatus
@@ -889,6 +1049,61 @@ export enum AuditEffect {
  */
 export const AuditEffectSchema: GenEnum<AuditEffect> = /*@__PURE__*/
   enumDesc(file_holomush_plugin_v1_plugin, 1);
+
+/**
+ * FocusKind enumerates the types of focused contexts a character can
+ * participate in. Adding a new kind requires: (a) a new constant here,
+ * (b) a matching session.FocusKind constant in Go, (c) a new
+ * FocusKindPolicy implementation registered in the coordinator.
+ *
+ * @generated from enum holomush.plugin.v1.FocusKind
+ */
+export enum FocusKind {
+  /**
+   * @generated from enum value: FOCUS_KIND_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: FOCUS_KIND_SCENE = 1;
+   */
+  SCENE = 1,
+}
+
+/**
+ * Describes the enum holomush.plugin.v1.FocusKind.
+ */
+export const FocusKindSchema: GenEnum<FocusKind> = /*@__PURE__*/
+  enumDesc(file_holomush_plugin_v1_plugin, 2);
+
+/**
+ * StreamReplayMode controls how a stream subscription's initial replay
+ * behaves when added via AddSessionStream.
+ *
+ * @generated from enum holomush.plugin.v1.StreamReplayMode
+ */
+export enum StreamReplayMode {
+  /**
+   * @generated from enum value: STREAM_REPLAY_MODE_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: STREAM_REPLAY_MODE_FROM_CURSOR = 1;
+   */
+  FROM_CURSOR = 1,
+
+  /**
+   * @generated from enum value: STREAM_REPLAY_MODE_LIVE_ONLY = 2;
+   */
+  LIVE_ONLY = 2,
+}
+
+/**
+ * Describes the enum holomush.plugin.v1.StreamReplayMode.
+ */
+export const StreamReplayModeSchema: GenEnum<StreamReplayMode> = /*@__PURE__*/
+  enumDesc(file_holomush_plugin_v1_plugin, 3);
 
 /**
  * PluginService is called by the go-plugin host to send events and commands to binary plugins.
@@ -1022,6 +1237,50 @@ export const PluginHostService: GenService<{
     methodKind: "unary";
     input: typeof PluginHostServiceRemoveSessionStreamRequestSchema;
     output: typeof PluginHostServiceRemoveSessionStreamResponseSchema;
+  },
+  /**
+   * JoinFocus adds a focus membership to an active or detached session.
+   * Plugins declare intent; the server applies kind-specific replay policy.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.JoinFocus
+   */
+  joinFocus: {
+    methodKind: "unary";
+    input: typeof PluginHostServiceJoinFocusRequestSchema;
+    output: typeof PluginHostServiceJoinFocusResponseSchema;
+  },
+  /**
+   * LeaveFocus removes a focus membership. Idempotent on non-member.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.LeaveFocus
+   */
+  leaveFocus: {
+    methodKind: "unary";
+    input: typeof PluginHostServiceLeaveFocusRequestSchema;
+    output: typeof PluginHostServiceLeaveFocusResponseSchema;
+  },
+  /**
+   * PresentFocus updates the session's PresentingFocus pointer.
+   * Target MUST already exist in FocusMemberships.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.PresentFocus
+   */
+  presentFocus: {
+    methodKind: "unary";
+    input: typeof PluginHostServicePresentFocusRequestSchema;
+    output: typeof PluginHostServicePresentFocusResponseSchema;
+  },
+  /**
+   * QueryStreamHistory reads the tail of a stream for plugin-side display.
+   * Read-only: does not advance cursors or affect session state.
+   * Count capped at 500 server-side.
+   *
+   * @generated from rpc holomush.plugin.v1.PluginHostService.QueryStreamHistory
+   */
+  queryStreamHistory: {
+    methodKind: "unary";
+    input: typeof PluginHostServiceQueryStreamHistoryRequestSchema;
+    output: typeof PluginHostServiceQueryStreamHistoryResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_holomush_plugin_v1_plugin, 1);


### PR DESCRIPTION
## Summary

- Add **JoinFocus, LeaveFocus, PresentFocus, QueryStreamHistory** RPCs to PluginHostService for binary plugins (gRPC) and Lua plugins (hostfuncs)
- Extend AddSessionStream with **StreamReplayMode** for ambient LIVE_ONLY subscriptions (spec §4.6)
- Move **ReplayMode** to `internal/session` — cursor-initialization semantics belong with cursors, not focus
- Late-binding **ConfigureFocusDeps** pattern for cross-subsystem dependency injection (matches existing ConfigureEventEmitter)

## What B8 Delivers

| Layer | What |
|-------|------|
| Proto | FocusKind enum, FocusKey message, StreamReplayMode enum, 4 new RPCs on PluginHostService |
| gRPC handlers | JoinFocus/LeaveFocus/PresentFocus delegate to focus.Coordinator; QueryStreamHistory delegates to EventStore.ReplayTail (I-13: read-only) |
| Lua hostfuncs | `holomush.join_focus`, `leave_focus`, `present_focus`, `query_stream_history` |
| StreamRegistry | AddStreamWithMode for explicit replay mode |
| Wiring | ConfigureFocusDeps late-binding pattern |
| Tests | 27 new unit tests |

## Epic Context

Bead `holomush-oy6e.8` in the Server-Owned Focus Substrate epic. Foundation beads B1-B7 merged in PRs #209-215. B8 adds the plugin-facing API layer. Unblocks B10 (core-scenes adoption) and B11 (core-channels adoption).

Spec: `docs/superpowers/specs/2026-04-11-focus-substrate-design.md` §3.4, §4.3-4.6

## Test Plan

- [x] `task pr-prep` passes (lint, format, unit, integration, E2E)
- [x] 5718 unit tests pass, 0 failures
- [x] 27 new tests cover all 4 gRPC handlers and all 4 Lua hostfuncs (success, error, nil-safety paths)
- [x] E2E: 51 tests pass (full Docker compose stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added focus management capabilities (join, leave, present) to enable plugins to coordinate focus/attention on targets.
  * Added stream history querying to retrieve recorded event data with configurable replay modes (from cursor, bounded tail, live-only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->