### PR TITLE
chore(beads): sync bead state — PR #225 closures + holomush-3saa re-eval

### DIFF
--- a/.beads/export-state.json
+++ b/.beads/export-state.json
@@ -1,0 +1,1 @@
+{"last_dolt_commit":"bpph21bqiq1cckgd657glueo20tcs19i","timestamp":"2026-04-16T20:50:21.132611-04:00","issues":3046,"memories":33}


### PR DESCRIPTION
## Summary

Syncs \`.beads/issues.jsonl\` with bead state after the PR #225 merge and the re-evaluation of \`holomush-3saa\`.

**Changes:**
- Closes PR #225 follow-up beads: \`jv7z\`, \`urbq\`, \`j2xj\`
- Closes \`holomush-3saa\` (P0) as obsolete — the 'compromised plugin with \`storage:postgres\`' vector is already mitigated by schema-role isolation (\`internal/plugin/schema_provisioner.go\`, landed 2026-04-05). Plugins run as \`holomush_plugin_<name>\` roles with \`REVOKE ALL ON SCHEMA public\` and cannot touch the events table at all. Core queries are parameterized, so SQL injection isn't a realistic vector either.
- Adds \`holomush-upga\` (P3, \`security-finding\`) — the remaining hygiene-level risk (a future commit silently adding \`UPDATE events\` / \`DELETE FROM events\`) is covered by a meta-test in PR #227.

## Test plan

- [x] \`.beads/issues.jsonl\` reflects current bead state
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)