### PR TITLE
feat(scenes): B10 — core-scenes plugin adoption (focus substrate)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md
+++ b/docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md
@@ -62,7 +62,7 @@ Files by responsibility (per spec §8):
 
 Phases are bite-sized enough to execute independently. Dependencies:
 
-```
+```text
 Phase 0 (preflight)
    ↓
 Phase 1 (SDK FocusClient)      ←— Opus; single-session; design decisions
@@ -116,7 +116,7 @@ Expected: both show `"status": "closed"`.
 
 Run from main repo dir:
 
-```
+```text
 cd /Volumes/Code/github.com/holomush/holomush && \
 bd create \
   --title "Host-side LeaveFocusByTarget(FocusKey) sweep for scene-end fan-out" \
@@ -1952,7 +1952,7 @@ Note: `-r @-` because `@` is always an empty new change after `jj commit`; `@-` 
 
 Run (heredoc to preserve formatting):
 
-```
+```text
 gh pr create --head b10-core-scenes-adoption --title "feat(scenes): B10 — core-scenes plugin adoption (focus substrate)" --body "$(cat <<'EOF'
 ## Summary
 
@@ -2076,9 +2076,11 @@ Expected: bead marked closed.
 - [ ] **Step 2: Append a session note to the epic.**
 
 Run: `cd /Volumes/Code/github.com/holomush/holomush && bd update holomush-oy6e --notes "$(cat <<'EOF'
+
 ## Session 2026-04-?? — B10 closed (PR #???)
 
-### B10 (holomush-oy6e.10) — core-scenes plugin adoption:
+### B10 (holomush-oy6e.10) — core-scenes plugin adoption
+
 - SDK FocusClient facade in pkg/plugin (parallel to EventSink), single shared conn with broker dialer.
 - Command-path-only wiring in plugins/core-scenes (DB first, focus second, no compensating writes).
 - scene switch subcommand added.
@@ -2086,6 +2088,7 @@ Run: `cd /Volumes/Code/github.com/holomush/holomush && bd update holomush-oy6e -
 - Multi-session EndScene fan-out deferred to follow-up bead <ID> (LeaveFocusByTarget).
 
 ### Epic progress: 10/13 beads complete (77%)
+
 - B10 closed. Scenes Phase 4 (holomush-5rh.13) now unblocked.
 - Next: B11 (core-channels adoption), B12 (architecture doc overhaul), B13 (web client QueryStreamHistory).
 EOF

--- a/docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md
+++ b/docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md
@@ -1,0 +1,2143 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# B10 core-scenes Plugin Adoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt the server-owned focus substrate inside `core-scenes` so that `scene join`, `scene leave`, `scene end`, and a new `scene switch` command drive session focus state via the host's `PluginHostService.{JoinFocus,LeaveFocus,PresentFocus}` RPCs, unblocking Scenes Phase 4 (`holomush-5rh.13`).
+
+**Architecture:** Add a single-purpose `FocusClient` facade to the binary-plugin SDK (parallel to `EventSink`), injected via a new `FocusClientAware` interface during plugin `Init`, sharing one broker-dialed `*grpc.ClientConn` with `EventSink`. Wire focus calls in `core-scenes` command handlers only (DB-first, focus-second ordering, no compensation). Add Phase 4 acceptance integration tests under `test/integration/scenes/`. Spec: [`2026-04-16-b10-core-scenes-adoption-design.md`](../specs/2026-04-16-b10-core-scenes-adoption-design.md).
+
+**Tech Stack:** Go 1.23, `pkg/plugin` SDK, `pkg/proto/holomush/plugin/v1` (B8-landed focus RPCs), `samber/oops`, hashicorp/go-plugin broker, Ginkgo/Gomega + testcontainers for integration, jj VCS, `task` for all build/test.
+
+**Bead:** `holomush-oy6e.10` (already claimed, in_progress).
+**Workspace:** `/Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes` (jj, branched from `main` at `aa325c0297`).
+**Spec commit:** `0b0225cc15` in this workspace.
+
+---
+
+## File Structure
+
+Files by responsibility (per spec §8):
+
+**SDK — pkg/plugin (new & modified)**
+
+| Path | Responsibility |
+|---|---|
+| `pkg/plugin/focus_client.go` (new) | `FocusClient` interface; `FocusKey`, `FocusKind`, `QueryStreamHistoryRequest` types; `FocusClientAware`; private `pluginHostFocusClient` impl; `newFocusClientFromBroker`. |
+| `pkg/plugin/focus_client_test.go` (new) | Unit tests: error mapping table, happy-path RPC invocation, broker-dial error paths. |
+| `pkg/plugin/broker.go` (modify) | Factor out a single `dialPluginHost(broker, services)` helper returning a shared `*grpc.ClientConn` so `EventSink` and `FocusClient` share one conn. |
+| `pkg/plugin/event_sink.go` (modify) | `newEventSinkFromBroker` uses the shared dial helper. |
+| `pkg/plugin/sdk.go` (modify) | `pluginServerAdapter.Init` detects `FocusClientAware` and injects a `FocusClient` built from the same conn as `EventSink`. |
+| `pkg/plugin/service_test.go` (modify) | New `focusClientInitProvider` test double mirroring `eventSinkInitProvider`, plus adapter-injection test. |
+
+**Plugin — plugins/core-scenes (modified)**
+
+| Path | Responsibility |
+|---|---|
+| `plugins/core-scenes/main.go` | Add `focusClient pluginsdk.FocusClient` field on `scenePlugin`, implement `SetFocusClient`. |
+| `plugins/core-scenes/commands.go` | Extend `dispatchCommand`; rewrite `handleJoin`, `handleLeave`, `handleEnd`; add `handleSwitch`. |
+| `plugins/core-scenes/commands_test.go` | Add `fakeFocusClient`; 11 unit tests from spec §5.1. |
+
+**Integration tests — test/integration/scenes (new)**
+
+| Path | Responsibility |
+|---|---|
+| `test/integration/scenes/scenes_suite_test.go` | Ginkgo suite entrypoint, build tag `integration`. |
+| `test/integration/scenes/helpers_test.go` | Shared harness: testcontainers Postgres, core server bootstrap, core-scenes binary plugin loaded, telnet adapter client helpers. |
+| `test/integration/scenes/focus_reconnect_test.go` | `TestTelnetReconnectResumesSceneWithUnseenEvents`. |
+| `test/integration/scenes/focus_switch_test.go` | `TestFocusSwitchCatchUpUsesBoundedIC`, `TestFocusSwitchSkipsHistoricalOOC`, `TestFocusSwitchHonorsPlayerPreference` (if not covered by B6). |
+| `test/integration/scenes/focus_leave_test.go` | `TestLeaveFocusClearsPresentingWhenReferenced` (if not covered by B4/B6), stretch: `TestMultiSceneMembershipReconnect`. |
+
+**Docs**
+
+| Path | Responsibility |
+|---|---|
+| `site/docs/extending/binary-plugins.md` (modify) | Add section documenting `FocusClient` and `FocusClientAware`. |
+
+---
+
+## Phase Map & Model Selection
+
+Phases are bite-sized enough to execute independently. Dependencies:
+
+```
+Phase 0 (preflight)
+   ↓
+Phase 1 (SDK FocusClient)      ←— Opus; single-session; design decisions
+   ↓
+Phase 2 (command wiring)        ←— Opus; UX + error-flow decisions
+   ↓
+Phase 3 (integration tests)    ←— Opus; test harness design is subtle
+   ↓
+Phase 4 (docs)                 ←— Sonnet; mechanical writing
+   ↓
+Phase 5 (PR prep + review)     ←— Sonnet orchestrator, Opus for nontrivial fixes
+   ↓
+Phase 6 (post-merge cleanup)   ←— Haiku/Sonnet; mechanical
+```
+
+**Parallelism:** Phase 2 CAN begin concurrently with Phase 1 once Task 1.1 has locked the `FocusClient` interface shape — Phase 2 uses the `fakeFocusClient` stub. Default: serialize for simplicity; parallelize only if time-pressed.
+
+---
+
+## Phase 0 — Preflight
+
+### Task 0.1: Verify workspace and bead state
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm current jj workspace is `b10`.**
+
+Run: `jj --no-pager workspace list`
+Expected output includes: `b10: ... (empty) (no description set)` and `default: ...`. Current directory must be `/Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes`.
+
+- [ ] **Step 2: Confirm working copy is based on main.**
+
+Run: `jj --no-pager log -r 'main::@' -T 'commit_id.short(10) ++ " " ++ description.first_line() ++ "\n"' --no-graph`
+Expected: two lines — the spec commit (`0b0225cc15 docs(spec): B10 core-scenes adoption design`) followed by the main tip (`aa325c0297 feat(auth): session identity...`).
+
+- [ ] **Step 3: Confirm bead is in_progress.**
+
+Run from main repo dir: `cd /Volumes/Code/github.com/holomush/holomush && bd show holomush-oy6e.10 --json 2>&1 | head -20`
+Expected: status field contains `in_progress`.
+
+- [ ] **Step 4: Confirm B8 and B9 are closed.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && bd show holomush-oy6e.8 --json 2>&1 | grep status && bd show holomush-oy6e.9 --json 2>&1 | grep status`
+Expected: both show `"status": "closed"`.
+
+### Task 0.2: File follow-up bead for scene-end fan-out
+
+**Files:** none (bd operation only).
+
+- [ ] **Step 1: Create the follow-up bead.**
+
+Run from main repo dir:
+
+```
+cd /Volumes/Code/github.com/holomush/holomush && \
+bd create \
+  --title "Host-side LeaveFocusByTarget(FocusKey) sweep for scene-end fan-out" \
+  --description "Add FocusCoordinator.LeaveFocusByTarget(ctx, target) (count int, err error) that iterates all sessions whose FocusMemberships include the given key and calls LeaveFocus per-session. Expose via new PluginHostService.LeaveFocusByTarget RPC. Add SDK FocusClient.LeaveFocusByTarget. Call from core-scenes EndScene handler after DB transition commits.
+
+Motivation: B10 (core-scenes adoption) ships without cross-session fan-out on scene end; only the caller's session gets LeaveFocus. Non-owner participants retain stale FocusMemberships for the ended scene — cosmetic leak, not a correctness failure. See B10 spec §6.1 (docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md)." \
+  --type task \
+  --priority 2 \
+  --deps "discovered-from:holomush-oy6e.10" \
+  --parent holomush-oy6e \
+  --json
+```
+
+Expected: JSON with new bead ID. Record it in the task output for reference in Phase 6.
+
+- [ ] **Step 2: Confirm the new bead exists and depends correctly.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && bd show <new-bead-id> --json 2>&1 | head -30`
+Expected: `"parent": "holomush-oy6e"`, `discovered-from` dependency on `holomush-oy6e.10`.
+
+---
+
+## Phase 1 — SDK FocusClient Facade
+
+**Model:** Opus. Interface shape decisions, error mapping, broker-conn sharing.
+
+### Task 1.1: Write failing tests for FocusClient types and error mapping
+
+**Files:**
+
+- Test: `pkg/plugin/focus_client_test.go`
+
+- [ ] **Step 1: Create the test file with compile-time interface checks and error-mapping tests.**
+
+Create `pkg/plugin/focus_client_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// --- compile-time interface checks ---
+
+func TestFocusClient_InterfaceShape(_ *testing.T) {
+	var _ FocusClient = (*pluginHostFocusClient)(nil)
+}
+
+// --- error mapping ---
+
+func TestPluginHostFocusClient_JoinFocusMapsSessionNotFound(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.NotFound, "SESSION_NOT_FOUND: missing")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "SESSION_NOT_FOUND", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusMapsAlreadyMember(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.AlreadyExists, "FOCUS_ALREADY_MEMBER: duplicate")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_ALREADY_MEMBER", oe.Code())
+}
+
+func TestPluginHostFocusClient_PresentFocusMapsNotMember(t *testing.T) {
+	srv := &focusTestServer{presentErr: status.Error(codes.NotFound, "FOCUS_NOT_MEMBER: not joined")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.PresentFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_NOT_MEMBER", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.joinReqs, 1)
+	assert.Equal(t, "sess-1", srv.joinReqs[0].GetSessionId())
+	assert.Equal(t, "scene-1", srv.joinReqs[0].GetTarget().GetTargetId())
+	assert.Equal(t, pluginv1.FocusKind_FOCUS_KIND_SCENE, srv.joinReqs[0].GetTarget().GetKind())
+}
+
+func TestPluginHostFocusClient_LeaveFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.LeaveFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.leaveReqs, 1)
+	assert.Equal(t, "sess-1", srv.leaveReqs[0].GetSessionId())
+}
+
+func TestPluginHostFocusClient_PresentFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.PresentFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.presentReqs, 1)
+}
+
+func TestPluginHostFocusClient_QueryStreamHistoryHappyPath(t *testing.T) {
+	wantEvt := &pluginv1.Event{Id: "01EVT", Stream: "scene:1:ic", Type: "say", Payload: []byte(`{"m":"hi"}`)}
+	srv := &focusTestServer{historyResp: &pluginv1.PluginHostServiceQueryStreamHistoryResponse{Events: []*pluginv1.Event{wantEvt}}}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	events, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream: "scene:1:ic",
+		Count:  10,
+	})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "01EVT", events[0].ID)
+	assert.Equal(t, "scene:1:ic", events[0].Stream)
+	assert.Equal(t, EventType("say"), events[0].Type)
+	assert.Equal(t, `{"m":"hi"}`, events[0].Payload)
+}
+
+func TestPluginHostFocusClient_NilClientReturnsError(t *testing.T) {
+	client := &pluginHostFocusClient{}
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestNewFocusClientFromBroker_MissingBroker(t *testing.T) {
+	c, err := newFocusClientFromBroker(nil, map[string]string{PluginHostServiceName: "broker:7"})
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "broker is not configured")
+}
+
+func TestNewFocusClientFromBroker_MissingHostService(t *testing.T) {
+	c, err := newFocusClientFromBroker(&testBrokerDialer{}, map[string]string{})
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), PluginHostServiceName)
+}
+
+func TestQueryStreamHistoryRequestNotBeforeIsPassedThrough(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	notBefore := time.UnixMilli(1_700_000_000_000)
+	_, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream:    "scene:1:ic",
+		Count:     5,
+		NotBefore: notBefore,
+	})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.historyReqs, 1)
+	assert.Equal(t, int64(1_700_000_000_000), srv.historyReqs[0].GetNotBeforeMs())
+}
+
+// --- test double: PluginHostService with per-RPC hooks ---
+
+type focusTestServer struct {
+	pluginv1.UnimplementedPluginHostServiceServer
+	mu          sync.Mutex
+	joinReqs    []*pluginv1.PluginHostServiceJoinFocusRequest
+	leaveReqs   []*pluginv1.PluginHostServiceLeaveFocusRequest
+	presentReqs []*pluginv1.PluginHostServicePresentFocusRequest
+	historyReqs []*pluginv1.PluginHostServiceQueryStreamHistoryRequest
+
+	joinErr     error
+	leaveErr    error
+	presentErr  error
+	historyResp *pluginv1.PluginHostServiceQueryStreamHistoryResponse
+	historyErr  error
+}
+
+func (s *focusTestServer) JoinFocus(_ context.Context, req *pluginv1.PluginHostServiceJoinFocusRequest) (*pluginv1.PluginHostServiceJoinFocusResponse, error) {
+	s.mu.Lock()
+	s.joinReqs = append(s.joinReqs, req)
+	s.mu.Unlock()
+	if s.joinErr != nil {
+		return nil, s.joinErr
+	}
+	return &pluginv1.PluginHostServiceJoinFocusResponse{}, nil
+}
+
+func (s *focusTestServer) LeaveFocus(_ context.Context, req *pluginv1.PluginHostServiceLeaveFocusRequest) (*pluginv1.PluginHostServiceLeaveFocusResponse, error) {
+	s.mu.Lock()
+	s.leaveReqs = append(s.leaveReqs, req)
+	s.mu.Unlock()
+	if s.leaveErr != nil {
+		return nil, s.leaveErr
+	}
+	return &pluginv1.PluginHostServiceLeaveFocusResponse{}, nil
+}
+
+func (s *focusTestServer) PresentFocus(_ context.Context, req *pluginv1.PluginHostServicePresentFocusRequest) (*pluginv1.PluginHostServicePresentFocusResponse, error) {
+	s.mu.Lock()
+	s.presentReqs = append(s.presentReqs, req)
+	s.mu.Unlock()
+	if s.presentErr != nil {
+		return nil, s.presentErr
+	}
+	return &pluginv1.PluginHostServicePresentFocusResponse{}, nil
+}
+
+func (s *focusTestServer) QueryStreamHistory(_ context.Context, req *pluginv1.PluginHostServiceQueryStreamHistoryRequest) (*pluginv1.PluginHostServiceQueryStreamHistoryResponse, error) {
+	s.mu.Lock()
+	s.historyReqs = append(s.historyReqs, req)
+	s.mu.Unlock()
+	if s.historyErr != nil {
+		return nil, s.historyErr
+	}
+	if s.historyResp != nil {
+		return s.historyResp, nil
+	}
+	return &pluginv1.PluginHostServiceQueryStreamHistoryResponse{}, nil
+}
+
+// Satisfy unused-variable checks when the broker-dial paths don't trigger dial.
+var _ = grpc.DialOption(nil)
+var _ = errors.New
+```
+
+Note: `startPluginHostServiceTestServer` and `testBrokerDialer` are already defined in `pkg/plugin/service_test.go`; reuse them.
+
+- [ ] **Step 2: Run the tests — they MUST fail with undefined-identifier errors.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestFocusClient ./pkg/plugin/...`
+Expected: build failure referencing undefined `FocusClient`, `FocusKey`, `FocusKind`, `FocusKindScene`, `QueryStreamHistoryRequest`, `pluginHostFocusClient`, `newFocusClientFromBroker`, `PluginHostServiceName`.
+
+### Task 1.2: Implement FocusClient types and private pluginHostFocusClient
+
+**Files:**
+
+- Create: `pkg/plugin/focus_client.go`
+
+- [ ] **Step 1: Write the implementation.**
+
+Create `pkg/plugin/focus_client.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/oops"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FocusClient is the SDK-facing facade binary-plugin code uses to drive the
+// server-owned focus substrate on behalf of a session. All calls cross the
+// plugin broker (mTLS) to the host's PluginHostService.
+//
+// See docs/superpowers/specs/2026-04-11-focus-substrate-design.md §3.4 for
+// the host-side interface this wraps, and §4.3/4.4/4.5 for the transition
+// semantics. Plugins MUST NOT mutate session.FocusMemberships directly
+// (invariant I-6); all mutations flow through this interface.
+type FocusClient interface {
+	// JoinFocus adds a focus membership and applies the kind-specific
+	// server-owned replay policy. Callers provide the target (kind + id);
+	// the server determines streams, replay mode, cursor baselines, and
+	// subscription updates. Callers MUST NOT declare replay mode or stream
+	// names (invariant I-7).
+	JoinFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// PresentFocus updates the session's presenting-focus pointer. Target
+	// MUST already exist in the session's FocusMemberships.
+	PresentFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only (I-13): does not mutate cursors, subscriptions, or session
+	// state. The host clamps Count server-side at 500.
+	QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error)
+}
+
+// FocusKey identifies a focus membership within a session.
+type FocusKey struct {
+	Kind     FocusKind
+	TargetID string
+}
+
+// FocusKind enumerates the kinds of focused contexts. Mirrors
+// session.FocusKind on the host side; the SDK re-declares the enum so
+// plugins do not take a dependency on internal/ packages.
+type FocusKind string
+
+const (
+	// FocusKindScene marks a scene membership. The ScenePolicy on the
+	// host derives streams "scene:<target_id>:ic" and "scene:<target_id>:ooc".
+	FocusKindScene FocusKind = "scene"
+)
+
+// QueryStreamHistoryRequest describes a bounded tail read.
+type QueryStreamHistoryRequest struct {
+	Stream    string
+	Count     int       // server clamps to 500
+	NotBefore time.Time // zero means no time floor
+}
+
+// FocusClientAware is the optional interface service providers implement to
+// receive a FocusClient during Init, parallel to EventSinkAware.
+type FocusClientAware interface {
+	SetFocusClient(FocusClient)
+}
+
+// pluginHostFocusClient is the broker-backed FocusClient implementation.
+type pluginHostFocusClient struct {
+	client pluginv1.PluginHostServiceClient
+}
+
+// newPluginHostFocusClient constructs a FocusClient wrapping the given
+// PluginHostServiceClient. Exposed to the adapter for wiring; test code
+// constructs a pluginHostFocusClient directly.
+func newPluginHostFocusClient(client pluginv1.PluginHostServiceClient) FocusClient {
+	return &pluginHostFocusClient{client: client}
+}
+
+func toProtoFocusKind(k FocusKind) pluginv1.FocusKind {
+	switch k {
+	case FocusKindScene:
+		return pluginv1.FocusKind_FOCUS_KIND_SCENE
+	default:
+		return pluginv1.FocusKind_FOCUS_KIND_UNSPECIFIED
+	}
+}
+
+func toProtoFocusKey(key FocusKey) *pluginv1.FocusKey {
+	return &pluginv1.FocusKey{
+		Kind:     toProtoFocusKind(key.Kind),
+		TargetId: key.TargetID,
+	}
+}
+
+func (c *pluginHostFocusClient) JoinFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.JoinFocus(ctx, &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "JoinFocus", sessionID, target)
+}
+
+func (c *pluginHostFocusClient) LeaveFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.LeaveFocus(ctx, &pluginv1.PluginHostServiceLeaveFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "LeaveFocus", sessionID, target)
+}
+
+func (c *pluginHostFocusClient) PresentFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.PresentFocus(ctx, &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "PresentFocus", sessionID, target)
+}
+
+func (c *pluginHostFocusClient) QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error) {
+	if c.client == nil {
+		return nil, oops.New("plugin host focus client is not configured")
+	}
+	var notBeforeMs int64
+	if !req.NotBefore.IsZero() {
+		notBeforeMs = req.NotBefore.UnixMilli()
+	}
+	// Protect against int overflow when mapping to proto int32.
+	var count int32
+	switch {
+	case req.Count < 0:
+		count = 0
+	case req.Count > (1 << 30):
+		count = 1 << 30
+	default:
+		count = int32(req.Count)
+	}
+	resp, err := c.client.QueryStreamHistory(ctx, &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream:      req.Stream,
+		Count:       count,
+		NotBeforeMs: notBeforeMs,
+	})
+	if err != nil {
+		return nil, oops.With("stream", req.Stream).Wrap(err)
+	}
+	events := make([]Event, 0, len(resp.GetEvents()))
+	for _, e := range resp.GetEvents() {
+		events = append(events, Event{
+			ID:        e.GetId(),
+			Stream:    e.GetStream(),
+			Type:      EventType(e.GetType()),
+			Timestamp: e.GetTimestamp().AsTime().UnixMilli(),
+			ActorKind: protoActorKindToActorKind(e.GetActorKind()),
+			ActorID:   e.GetActorId(),
+			Payload:   string(e.GetPayload()),
+		})
+	}
+	return events, nil
+}
+
+// wrapFocusError maps gRPC codes returned by the host's focus RPCs into
+// oops-coded errors that callers can switch on via errors.As + oe.Code().
+// Unknown codes pass through with a generic wrap.
+func wrapFocusError(err error, op, sessionID string, target FocusKey) error {
+	if err == nil {
+		return nil
+	}
+	base := oops.With("operation", op).With("session_id", sessionID).With("focus_kind", string(target.Kind)).With("target_id", target.TargetID)
+	st, ok := status.FromError(err)
+	if !ok {
+		return base.Wrap(err)
+	}
+	code := codeFromStatus(st)
+	if code == "" {
+		return base.Wrap(err)
+	}
+	return base.Code(code).Wrap(err)
+}
+
+// codeFromStatus returns the expected oops code for a gRPC status, or ""
+// if the code-message pair does not match a known focus-RPC error.
+func codeFromStatus(st *status.Status) string {
+	// Host's PluginHostService focus RPCs encode the oops code as the prefix
+	// of the gRPC message, e.g. "SESSION_NOT_FOUND: ...".
+	codes := []string{
+		"SESSION_NOT_FOUND",
+		"SESSION_EXPIRED",
+		"FOCUS_ALREADY_MEMBER",
+		"FOCUS_KIND_UNREGISTERED",
+		"FOCUS_POLICY_FAILED",
+		"FOCUS_NOT_MEMBER",
+	}
+	for _, c := range codes {
+		if len(st.Message()) >= len(c) && st.Message()[:len(c)] == c {
+			return c
+		}
+	}
+	// Fallback: map by gRPC code alone for callers that set codes without
+	// a prefix message.
+	switch st.Code() {
+	case codes.NotFound:
+		return "SESSION_NOT_FOUND" // approximate; host convention sets this code for missing sessions
+	case codes.AlreadyExists:
+		return "FOCUS_ALREADY_MEMBER"
+	case codes.FailedPrecondition:
+		return "SESSION_EXPIRED"
+	case codes.InvalidArgument:
+		return "FOCUS_KIND_UNREGISTERED"
+	case codes.Internal:
+		return "FOCUS_POLICY_FAILED"
+	}
+	return ""
+}
+
+// newFocusClientFromBroker dials the plugin host service via the broker
+// and returns a FocusClient. See broker.go for the shared dial helper.
+func newFocusClientFromBroker(broker brokerDialer, services map[string]string) (FocusClient, error) {
+	if broker == nil {
+		return nil, oops.New("plugin host broker is not configured")
+	}
+	conn, err := dialPluginHost(broker, services)
+	if err != nil {
+		return nil, err
+	}
+	return newPluginHostFocusClient(pluginv1.NewPluginHostServiceClient(conn)), nil
+}
+```
+
+The `google.golang.org/grpc` import is used implicitly via `pluginv1.NewPluginHostServiceClient(conn)` whose argument type is `*grpc.ClientConn`, but the `grpc` package itself is only referenced if tests or the file take a `*grpc.ClientConn` directly. If the compiler rejects the import as unused, either pass the conn through as a typed parameter or remove the import — do not add a sentinel `var _ grpc.DialOption = nil`.
+
+- [ ] **Step 2: Add the shared dial helper in broker.go.**
+
+Modify `pkg/plugin/broker.go`. Add the following function (keeping existing `PluginHostServiceName` constant and `BrokerServiceID` helper):
+
+```go
+// dialPluginHost dials the plugin host service via the given broker and
+// returns a *grpc.ClientConn. Callers wrap the conn in service-specific
+// clients (EventSink, FocusClient). This helper exists so a single
+// plugin process holds one connection to the host for all host-facing
+// SDK facades.
+func dialPluginHost(broker brokerDialer, services map[string]string) (*grpc.ClientConn, error) {
+	if broker == nil {
+		return nil, oops.New("plugin host broker is not configured")
+	}
+	brokerID, err := BrokerServiceID(services, PluginHostServiceName)
+	if err != nil {
+		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
+	}
+	conn, err := broker.DialWithOptions(brokerID, grpc.WithAuthority("holomush-plugin-host"))
+	if err != nil {
+		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
+	}
+	return conn, nil
+}
+```
+
+Ensure `broker.go` imports `"github.com/samber/oops"` and `"google.golang.org/grpc"`. Move the `brokerDialer` interface here if it currently lives in `event_sink.go`, or keep it there — either works, but it must be accessible from `focus_client.go`. Pick the option that requires fewer changes; if `brokerDialer` is already in `event_sink.go`, leave it and just ensure `focus_client.go` is in the same package (it is).
+
+- [ ] **Step 3: Refactor `newEventSinkFromBroker` to use `dialPluginHost`.**
+
+Modify `pkg/plugin/event_sink.go`. Replace the body of `newEventSinkFromBroker`:
+
+```go
+func newEventSinkFromBroker(broker brokerDialer, services map[string]string) (EventSink, error) {
+	if broker == nil {
+		return nil, oops.New("plugin host broker is not configured")
+	}
+	conn, err := dialPluginHost(broker, services)
+	if err != nil {
+		return nil, err
+	}
+	return &pluginHostEventSink{
+		client: pluginv1.NewPluginHostServiceClient(conn),
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run focus_client_test.go tests.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestFocusClient -run TestPluginHostFocusClient -run TestNewFocusClientFromBroker -run TestQueryStreamHistoryRequest ./pkg/plugin/...`
+Expected: all 10 tests PASS.
+
+- [ ] **Step 5: Run existing pkg/plugin tests — they MUST NOT regress.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- ./pkg/plugin/...`
+Expected: all tests PASS (new + existing).
+
+- [ ] **Step 6: Commit.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "feat(sdk): FocusClient facade for binary plugins
+
+Add a single-purpose FocusClient facade to pkg/plugin that wraps the four
+PluginHostService focus RPCs (JoinFocus, LeaveFocus, PresentFocus,
+QueryStreamHistory) landed in B8.
+
+- Interface: FocusClient, FocusKey, FocusKind (scene), QueryStreamHistoryRequest.
+- Optional injection: FocusClientAware.SetFocusClient (parallel to EventSinkAware).
+- Broker-backed impl pluginHostFocusClient with typed oops error codes.
+- broker.go gains dialPluginHost helper; newEventSinkFromBroker uses it.
+  Single grpc.ClientConn per plugin for the host service (shared with EventSink).
+
+Tests cover happy paths, error mapping by code+message prefix, nil-client
+guard, and QueryStreamHistory time plumbing.
+
+Part of holomush-oy6e.10."`
+
+### Task 1.3: Wire FocusClientAware injection into pluginServerAdapter.Init
+
+**Files:**
+
+- Modify: `pkg/plugin/sdk.go`
+- Modify: `pkg/plugin/service_test.go` (add test provider + test case)
+
+- [ ] **Step 1: Add a failing adapter-injection test in `service_test.go`.**
+
+Append to `pkg/plugin/service_test.go`:
+
+```go
+// --- FocusClient injection ---
+
+type focusClientInitProvider struct {
+	initCalled  bool
+	focusClient FocusClient
+}
+
+func (p *focusClientInitProvider) RegisterServices(_ grpc.ServiceRegistrar) {}
+
+func (p *focusClientInitProvider) Init(ctx context.Context, _ *pluginv1.ServiceConfig) error {
+	p.initCalled = true
+	if p.focusClient == nil {
+		return errors.New("focus client not injected")
+	}
+	// Exercise the injected client to prove it reaches the host.
+	return p.focusClient.JoinFocus(ctx, "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+}
+
+func (p *focusClientInitProvider) SetFocusClient(client FocusClient) {
+	p.focusClient = client
+}
+
+func TestPluginServerAdapterInitInjectsFocusClientIntoServiceProvider(t *testing.T) {
+	srv := &focusTestServer{}
+	hostConn := startPluginHostServiceTestServer(t, srv)
+
+	provider := &focusClientInitProvider{}
+	adapter := &pluginServerAdapter{
+		handler:         &adapterTestHandler{},
+		serviceProvider: provider,
+		brokerDialer: &testBrokerDialer{
+			conns: map[uint32]*grpc.ClientConn{7: hostConn},
+		},
+	}
+
+	_, err := adapter.Init(context.Background(), &pluginv1.InitRequest{
+		Config: &pluginv1.ServiceConfig{
+			RequiredServices: map[string]string{
+				PluginHostServiceName: "broker:7",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, provider.initCalled, "expected provider.Init to run")
+	require.NotNil(t, provider.focusClient, "expected FocusClient to be injected")
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.joinReqs, 1, "expected the injected client's JoinFocus call to reach the host")
+	assert.Equal(t, "sess-1", srv.joinReqs[0].GetSessionId())
+}
+
+// A provider that implements BOTH EventSinkAware and FocusClientAware to
+// verify both injections occur from a single Init.
+type dualAwareProvider struct {
+	focusClient FocusClient
+	sink        EventSink
+}
+
+func (p *dualAwareProvider) RegisterServices(_ grpc.ServiceRegistrar)                {}
+func (p *dualAwareProvider) Init(_ context.Context, _ *pluginv1.ServiceConfig) error { return nil }
+func (p *dualAwareProvider) SetEventSink(s EventSink)                                { p.sink = s }
+func (p *dualAwareProvider) SetFocusClient(c FocusClient)                            { p.focusClient = c }
+
+func TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient(t *testing.T) {
+	hostConn := startPluginHostServiceTestServer(t, &focusTestServer{})
+
+	provider := &dualAwareProvider{}
+	adapter := &pluginServerAdapter{
+		handler:         &adapterTestHandler{},
+		serviceProvider: provider,
+		brokerDialer: &testBrokerDialer{
+			conns: map[uint32]*grpc.ClientConn{7: hostConn},
+		},
+	}
+
+	_, err := adapter.Init(context.Background(), &pluginv1.InitRequest{
+		Config: &pluginv1.ServiceConfig{
+			RequiredServices: map[string]string{
+				PluginHostServiceName: "broker:7",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, provider.sink, "expected EventSink injection")
+	assert.NotNil(t, provider.focusClient, "expected FocusClient injection")
+}
+```
+
+- [ ] **Step 2: Run the new tests — they MUST fail.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestPluginServerAdapterInitInjectsFocusClient -run TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient ./pkg/plugin/...`
+Expected: FAIL — `focus client not injected` message.
+
+- [ ] **Step 3: Modify `pluginServerAdapter.Init` in `pkg/plugin/sdk.go` to inject FocusClient.**
+
+Current `Init` body (sdk.go around line 141-163) has the `if sinkAware, ok := a.serviceProvider.(EventSinkAware); ok { ... }` block. Add a parallel block for FocusClient immediately after it. The ideal form factors the shared conn:
+
+```go
+func (a *pluginServerAdapter) Init(ctx context.Context, req *pluginv1.InitRequest) (*pluginv1.InitResponse, error) {
+	var config *pluginv1.ServiceConfig
+	if req != nil {
+		config = req.GetConfig()
+	}
+
+	// Shared plugin-host gRPC connection for all host-facing SDK facades
+	// (EventSink, FocusClient). nil if the provider needs neither.
+	var hostConn *grpc.ClientConn
+	needsHost := false
+	if _, ok := a.serviceProvider.(EventSinkAware); ok {
+		needsHost = true
+	}
+	if _, ok := a.serviceProvider.(FocusClientAware); ok {
+		needsHost = true
+	}
+	if needsHost && a.brokerDialer != nil && config != nil {
+		var err error
+		hostConn, err = dialPluginHost(a.brokerDialer, config.GetRequiredServices())
+		if err != nil {
+			return nil, oops.With("phase", "init").With("service", PluginHostServiceName).Wrap(err)
+		}
+	}
+
+	if sinkAware, ok := a.serviceProvider.(EventSinkAware); ok {
+		if hostConn == nil {
+			return nil, oops.With("phase", "init").With("service", PluginHostServiceName).New("EventSink injection requires broker + services config")
+		}
+		sinkAware.SetEventSink(&pluginHostEventSink{
+			client: pluginv1.NewPluginHostServiceClient(hostConn),
+		})
+	}
+
+	if fcAware, ok := a.serviceProvider.(FocusClientAware); ok {
+		if hostConn == nil {
+			return nil, oops.With("phase", "init").With("service", PluginHostServiceName).New("FocusClient injection requires broker + services config")
+		}
+		fcAware.SetFocusClient(newPluginHostFocusClient(pluginv1.NewPluginHostServiceClient(hostConn)))
+	}
+
+	if a.serviceProvider == nil {
+		return &pluginv1.InitResponse{}, nil
+	}
+	if err := a.serviceProvider.Init(ctx, config); err != nil {
+		return nil, oops.With("phase", "init").Wrap(err)
+	}
+	return &pluginv1.InitResponse{}, nil
+}
+```
+
+Note: the existing `newEventSinkFromBroker` path is preserved as a thin wrapper (still dials fresh — used only by any caller outside of Init); the shared path above replaces that usage inside Init.
+
+- [ ] **Step 4: Clean up unused grpc import in `focus_client.go` if the compiler flags it.**
+
+After the adapter wires through the shared conn directly, `newFocusClientFromBroker` remains for library consumers who want a standalone client. The `grpc` package import is used transitively via `pluginv1.NewPluginHostServiceClient`. If `go vet` / golangci-lint flags it as unused, remove the import; do not add a sentinel.
+
+- [ ] **Step 5: Run new tests — they MUST pass.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestPluginServerAdapterInitInjectsFocusClient -run TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient ./pkg/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole pkg/plugin test suite — no regressions.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- ./pkg/plugin/...`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Run `task lint`.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "feat(sdk): inject FocusClient via FocusClientAware during plugin Init
+
+pluginServerAdapter.Init now dials a single plugin-host gRPC connection
+and shares it across EventSink and FocusClient injections, so a binary
+plugin holds exactly one conn to PluginHostService regardless of how
+many host-facing SDK facades it wires.
+
+EventSinkAware + FocusClientAware may be implemented independently or
+together. Test coverage added for both paths and the dual-aware case.
+
+Part of holomush-oy6e.10."`
+
+---
+
+## Phase 2 — core-scenes Command-Path Wiring
+
+**Model:** Opus. UX, error-flow decisions, command-handler refactor.
+
+### Task 2.1: Add fakeFocusClient test double and failing unit tests
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands_test.go`
+
+- [ ] **Step 1: Append the fake and new tests to `commands_test.go`.**
+
+Append to `plugins/core-scenes/commands_test.go`:
+
+```go
+// --- fakeFocusClient ---
+
+type focusCall struct {
+	sessionID string
+	target    pluginsdk.FocusKey
+}
+
+type fakeFocusClient struct {
+	joinCalls    []focusCall
+	leaveCalls   []focusCall
+	presentCalls []focusCall
+
+	joinErr    error
+	leaveErr   error
+	presentErr error
+}
+
+func (f *fakeFocusClient) JoinFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.joinCalls = append(f.joinCalls, focusCall{sessionID: sid, target: t})
+	return f.joinErr
+}
+
+func (f *fakeFocusClient) LeaveFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.leaveCalls = append(f.leaveCalls, focusCall{sessionID: sid, target: t})
+	return f.leaveErr
+}
+
+func (f *fakeFocusClient) PresentFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.presentCalls = append(f.presentCalls, focusCall{sessionID: sid, target: t})
+	return f.presentErr
+}
+
+func (f *fakeFocusClient) QueryStreamHistory(_ context.Context, _ pluginsdk.QueryStreamHistoryRequest) ([]pluginsdk.Event, error) {
+	return nil, nil
+}
+
+// newTestPluginWithFocus returns a scenePlugin wired with a fakeFocusClient
+// and a fakeStore-backed SceneServiceImpl. Tests that exercise the
+// command-path focus wiring use this in place of newTestPlugin.
+func newTestPluginWithFocus() (*scenePlugin, *fakeFocusClient) {
+	p := newTestPlugin()
+	fc := &fakeFocusClient{}
+	p.focusClient = fc
+	return p, fc
+}
+
+// --- scene join / leave / end / switch focus-wiring tests ---
+
+func TestSceneJoinCallsFocusClientJoinFocus(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	// Pre-create a scene to join.
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.joinCalls, 1)
+	assert.Equal(t, "sess-bob", fc.joinCalls[0].sessionID)
+	assert.Equal(t, pluginsdk.FocusKindScene, fc.joinCalls[0].target.Kind)
+	assert.Equal(t, sceneID, fc.joinCalls[0].target.TargetID)
+}
+
+func TestSceneJoinPropagatesJoinSceneError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join scene-does-not-exist",
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Empty(t, fc.joinCalls, "JoinFocus MUST NOT run when service.JoinScene fails")
+}
+
+func TestSceneJoinHandlesJoinFocusError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.joinErr = oops.Code("FOCUS_POLICY_FAILED").Errorf("policy rejected")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "retry")
+}
+
+func TestSceneJoinTreatsFocusAlreadyMemberAsSuccess(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.joinErr = oops.Code("FOCUS_ALREADY_MEMBER").Errorf("duplicate")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+}
+
+func TestSceneLeaveCallsLeaveScene(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	// Owner creates, bob joins.
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	_, err = p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "join " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+
+	// Reset the fake to assert only the leave path.
+	fc.joinCalls = nil
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.leaveCalls, 1)
+	assert.Equal(t, "sess-bob", fc.leaveCalls[0].sessionID)
+	assert.Equal(t, sceneID, fc.leaveCalls[0].target.TargetID)
+}
+
+func TestSceneLeaveRejectsOwnerBeforeFocusChange(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-owner", SessionID: "sess-owner",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Empty(t, fc.leaveCalls, "LeaveFocus MUST NOT run when owner-leave is rejected")
+}
+
+func TestSceneLeaveToleratesLeaveFocusError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.leaveErr = errors.New("transient host error")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	_, err = p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "join " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status, "DB leave succeeded; focus-side failure is logged, not surfaced")
+}
+
+func TestSceneEndCallsLeaveFocusForOwner(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "end " + sceneID, CharacterID: "char-owner", SessionID: "sess-owner",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.leaveCalls, 1)
+	assert.Equal(t, "sess-owner", fc.leaveCalls[0].sessionID)
+	assert.Equal(t, sceneID, fc.leaveCalls[0].target.TargetID)
+}
+
+func TestSceneSwitchCallsPresentFocus(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "switch scene-01", CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.presentCalls, 1)
+	assert.Equal(t, "sess-bob", fc.presentCalls[0].sessionID)
+	assert.Equal(t, pluginsdk.FocusKindScene, fc.presentCalls[0].target.Kind)
+	assert.Equal(t, "scene-01", fc.presentCalls[0].target.TargetID)
+}
+
+func TestSceneSwitchReturnsNotMemberError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.presentErr = oops.Code("FOCUS_NOT_MEMBER").Errorf("not joined")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "switch scene-01", CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "not a member")
+	assert.Contains(t, resp.Output, "scene join")
+}
+
+func TestSceneSwitchStrictArity(t *testing.T) {
+	p, _ := newTestPluginWithFocus()
+
+	tests := []struct {
+		name string
+		args string
+	}{
+		{"rejects empty", "switch"},
+		{"rejects trailing tokens", "switch scene-01 trailing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command: "scene", Args: tt.args, CharacterID: "char-bob", SessionID: "sess-bob",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, pluginsdk.CommandError, resp.Status)
+			assert.Contains(t, resp.Output, "Usage")
+		})
+	}
+}
+
+// extractSceneID parses a "Scene created: <id>" output into the id substring.
+func extractSceneID(t *testing.T, output string) string {
+	t.Helper()
+	parts := strings.Split(output, "Scene created:")
+	require.Len(t, parts, 2)
+	return strings.TrimSpace(parts[1])
+}
+```
+
+Make sure imports at the top include `"errors"` and `"github.com/samber/oops"` if not already present.
+
+- [ ] **Step 2: Run the new tests — they MUST fail (scenePlugin has no focusClient field, commands.go has no switch subcommand).**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestScene -run TestSceneJoin -run TestSceneLeave -run TestSceneEnd -run TestSceneSwitch ./plugins/core-scenes/...`
+Expected: build failure referencing undefined `scenePlugin.focusClient` and/or failed tests.
+
+### Task 2.2: Add focusClient field and SetFocusClient to scenePlugin
+
+**Files:**
+
+- Modify: `plugins/core-scenes/main.go`
+
+- [ ] **Step 1: Extend the plugin struct.**
+
+Replace the `scenePlugin` struct declaration (currently lines ~31-35 of main.go):
+
+```go
+type scenePlugin struct {
+	store       *SceneStore
+	service     *SceneServiceImpl
+	resolver    *SceneResolver
+	focusClient pluginsdk.FocusClient
+}
+```
+
+- [ ] **Step 2: Add the `SetFocusClient` method adjacent to `SetEventSink`.**
+
+Append:
+
+```go
+// SetFocusClient is called by the SDK adapter during Init when the plugin
+// declares FocusClientAware. The client is used by command handlers to
+// drive session focus state via PluginHostService.{JoinFocus,LeaveFocus,
+// PresentFocus}.
+func (p *scenePlugin) SetFocusClient(client pluginsdk.FocusClient) {
+	p.focusClient = client
+}
+```
+
+- [ ] **Step 3: Run build to verify compile.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestHandleCommandReturnsUsageWhenSubcommandIsMissing ./plugins/core-scenes/...`
+Expected: existing test PASS; new focus tests still FAIL (not yet wired in commands.go).
+
+### Task 2.3: Wire handleJoin
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+
+- [ ] **Step 1: Rewrite handleJoin (currently lines ~288-310).**
+
+Replace the function with:
+
+```go
+//nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
+func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+	fields := strings.Fields(args)
+	if len(fields) != 1 {
+		return pluginsdk.Errorf("Usage: scene join <scene id>"), nil
+	}
+	sceneID := fields[0]
+
+	if _, err := p.service.JoinScene(ctx, &scenev1.JoinSceneRequest{
+		CharacterId: req.CharacterID,
+		SceneId:     sceneID,
+	}); err != nil {
+		return pluginsdk.Errorf("Failed to join scene: %v", err), nil
+	}
+
+	if p.focusClient == nil {
+		// focusClient was never injected (test or misconfiguration). The
+		// DB participant row is already written; surface a clear error so
+		// operators notice the misconfiguration.
+		slog.WarnContext(ctx, "scene.command.join focus client not configured; subscription not updated",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+		)
+		return pluginsdk.Errorf(
+			"Joined scene in database, but your session could not subscribe (focus client not configured). "+
+				"Please retry `scene join %s`.", sceneID), nil
+	}
+
+	err := p.focusClient.JoinFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+		Kind:     pluginsdk.FocusKindScene,
+		TargetID: sceneID,
+	})
+	if err != nil {
+		var oe oops.OopsError
+		if errors.As(err, &oe) && oe.Code() == "FOCUS_ALREADY_MEMBER" {
+			// Idempotent: treat as success.
+			return &pluginsdk.CommandResponse{
+				Status: pluginsdk.CommandOK,
+				Output: fmt.Sprintf("Joined scene %s.", sceneID),
+			}, nil
+		}
+		slog.WarnContext(ctx, "scene.command.join focus join failed",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+			"error", err,
+		)
+		return pluginsdk.Errorf(
+			"Joined scene in database, but your session could not subscribe (%v). "+
+				"Please retry `scene join %s`.", err, sceneID), nil
+	}
+
+	return &pluginsdk.CommandResponse{
+		Status: pluginsdk.CommandOK,
+		Output: fmt.Sprintf("Joined scene %s.", sceneID),
+	}, nil
+}
+```
+
+Ensure `commands.go` imports `"errors"`, `"github.com/samber/oops"`, and `"log/slog"` if not already present.
+
+- [ ] **Step 2: Run join tests — they MUST pass.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestSceneJoin ./plugins/core-scenes/...`
+Expected: all 4 TestSceneJoin* tests PASS.
+
+### Task 2.4: Wire handleLeave
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+
+- [ ] **Step 1: Rewrite handleLeave.**
+
+Replace the function with:
+
+```go
+//nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
+func (p *scenePlugin) handleLeave(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+	fields := strings.Fields(args)
+	if len(fields) != 1 {
+		return pluginsdk.Errorf("Usage: scene leave <scene id>"), nil
+	}
+	sceneID := fields[0]
+
+	if _, err := p.service.LeaveScene(ctx, &scenev1.LeaveSceneRequest{
+		CharacterId: req.CharacterID,
+		SceneId:     sceneID,
+	}); err != nil {
+		return pluginsdk.Errorf("Failed to leave scene: %v", err), nil
+	}
+
+	if p.focusClient != nil {
+		if err := p.focusClient.LeaveFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+			Kind:     pluginsdk.FocusKindScene,
+			TargetID: sceneID,
+		}); err != nil {
+			// DB write succeeded; focus unsubscribe is eventually-consistent.
+			slog.WarnContext(ctx, "scene.command.leave focus leave failed",
+				"subject_id", req.CharacterID,
+				"session_id", req.SessionID,
+				"scene_id", sceneID,
+				"error", err,
+			)
+		}
+	}
+
+	return &pluginsdk.CommandResponse{
+		Status: pluginsdk.CommandOK,
+		Output: fmt.Sprintf("Left scene %s.", sceneID),
+	}, nil
+}
+```
+
+- [ ] **Step 2: Run leave tests.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestSceneLeave ./plugins/core-scenes/...`
+Expected: all 3 TestSceneLeave* tests PASS.
+
+### Task 2.5: Wire handleEnd
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+
+- [ ] **Step 1: Rewrite handleEnd.**
+
+Replace the function with:
+
+```go
+//nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
+func (p *scenePlugin) handleEnd(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+	sceneID := strings.TrimSpace(args)
+	if sceneID == "" {
+		return pluginsdk.Errorf("Usage: scene end <scene id>"), nil
+	}
+
+	if _, err := p.service.EndScene(ctx, &scenev1.EndSceneRequest{
+		CharacterId: req.CharacterID,
+		SceneId:     sceneID,
+	}); err != nil {
+		return pluginsdk.Errorf("Failed to end scene: %v", err), nil
+	}
+
+	if p.focusClient != nil {
+		if err := p.focusClient.LeaveFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+			Kind:     pluginsdk.FocusKindScene,
+			TargetID: sceneID,
+		}); err != nil {
+			// Only the owner's session focus is removed here; other
+			// participants' stale memberships are a known cosmetic leak
+			// (see spec §6.1; follow-up bead).
+			slog.WarnContext(ctx, "scene.command.end focus leave failed for owner session",
+				"subject_id", req.CharacterID,
+				"session_id", req.SessionID,
+				"scene_id", sceneID,
+				"error", err,
+			)
+		}
+	}
+
+	return &pluginsdk.CommandResponse{
+		Status: pluginsdk.CommandOK,
+		Output: fmt.Sprintf("Scene %s ended.", sceneID),
+	}, nil
+}
+```
+
+- [ ] **Step 2: Run end tests.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestSceneEnd ./plugins/core-scenes/...`
+Expected: `TestSceneEndCallsLeaveFocusForOwner` PASSES. Also verify no existing TestHandleCommandEnd* tests regress.
+
+### Task 2.6: Add handleSwitch
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+
+- [ ] **Step 1: Add the new handler.**
+
+Append after `handleTransfer` (or adjacent to the other handlers — match existing style):
+
+```go
+// handleSwitch implements `scene switch <scene id>`. The coordinator's
+// PresentFocus is a pure session-state column update; the session MUST
+// already be a member of the target scene (enforced server-side via
+// FOCUS_NOT_MEMBER). No DB write happens here — scene membership and
+// subscriptions are unchanged by switch.
+//
+//nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
+func (p *scenePlugin) handleSwitch(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+	fields := strings.Fields(args)
+	if len(fields) != 1 {
+		return pluginsdk.Errorf("Usage: scene switch <scene id>"), nil
+	}
+	sceneID := fields[0]
+
+	if p.focusClient == nil {
+		slog.WarnContext(ctx, "scene.command.switch focus client not configured",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+		)
+		return pluginsdk.Errorf("Failed to switch scene: focus client not configured"), nil
+	}
+
+	if err := p.focusClient.PresentFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+		Kind:     pluginsdk.FocusKindScene,
+		TargetID: sceneID,
+	}); err != nil {
+		var oe oops.OopsError
+		if errors.As(err, &oe) && oe.Code() == "FOCUS_NOT_MEMBER" {
+			return pluginsdk.Errorf(
+				"You are not a member of scene %s. Use `scene join %s` first.", sceneID, sceneID), nil
+		}
+		slog.WarnContext(ctx, "scene.command.switch focus present failed",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+			"error", err,
+		)
+		return pluginsdk.Errorf("Failed to switch scene: %v", err), nil
+	}
+
+	return &pluginsdk.CommandResponse{
+		Status: pluginsdk.CommandOK,
+		Output: fmt.Sprintf("Switched to scene %s.", sceneID),
+	}, nil
+}
+```
+
+### Task 2.7: Register `switch` in dispatchCommand and update usage text
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+
+- [ ] **Step 1: Add the `switch` case to `dispatchCommand`.**
+
+Modify the `switch sub` statement in `dispatchCommand` (currently ends with `"transfer": return p.handleTransfer(...)`). Add:
+
+```go
+	case "switch":
+		return p.handleSwitch(ctx, req, rest)
+```
+
+- [ ] **Step 2: Update the usage strings in `dispatchCommand` to include `switch`.**
+
+Replace the two existing strings (empty-subcommand and unknown-subcommand branches) so both list `switch` in the alphabetical subcommand list:
+
+```go
+	if sub == "" {
+		return pluginsdk.Errorf("Usage: scene <subcommand> [args]\nKnown subcommands: create, end, info, invite, join, kick, leave, pause, resume, set, switch, transfer"), nil
+	}
+	// ...
+	default:
+		return pluginsdk.Errorf("Unknown scene subcommand %q. Known subcommands: create, end, info, invite, join, kick, leave, pause, resume, set, switch, transfer.", sub), nil
+```
+
+- [ ] **Step 3: Run all scene switch tests.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- -run TestSceneSwitch ./plugins/core-scenes/...`
+Expected: all 3 TestSceneSwitch* tests PASS.
+
+- [ ] **Step 4: Run the entire core-scenes test package.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test -- ./plugins/core-scenes/...`
+Expected: all tests PASS (new + existing).
+
+- [ ] **Step 5: Run `task lint`.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "feat(core-scenes): adopt focus substrate in command handlers
+
+Wire focus-substrate RPCs into scene command handlers so session state
+tracks scene membership automatically:
+
+- handleJoin: service.JoinScene then focusClient.JoinFocus; FOCUS_ALREADY_MEMBER
+  treated as success; failure after DB write surfaces explicit retry hint.
+- handleLeave: service.LeaveScene then focusClient.LeaveFocus; focus errors
+  logged but do not fail the command (DB is source of truth for membership).
+- handleEnd: service.EndScene then focusClient.LeaveFocus for owner session
+  only. Multi-session fan-out deferred to a follow-up bead (spec §6.1).
+- handleSwitch: new subcommand mapping to focusClient.PresentFocus;
+  FOCUS_NOT_MEMBER returns an actionable error.
+- dispatchCommand and usage help text extended with 'switch'.
+
+scenePlugin implements FocusClientAware.SetFocusClient so the SDK adapter
+injects the broker-backed client during Init.
+
+service.go is unchanged — it stays session-unaware (spec §3.1).
+
+Part of holomush-oy6e.10."`
+
+---
+
+## Phase 3 — Phase 4 Acceptance Integration Tests
+
+**Model:** Opus. Integration-test design requires understanding the substrate + gateway + telnet-adapter interaction.
+
+### Task 3.1: Inventory existing §7.2 coverage to avoid duplication
+
+**Files:** none — inventory only.
+
+- [ ] **Step 1: Search for existing `FocusSwitchHonorsPlayerPreference` and `FocusSwitchFallsBackToGameSetting` coverage.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && rg -l "FocusSwitch|SceneFocusReplayTail|replay_tail_default" internal/grpc/focus/ test/integration/`
+Record which §7.2 tests are already covered in `internal/grpc/focus/` (B6 coordinator tests). For each already-covered test, skip writing a duplicate integration test. Instead, note coverage location in the PR description.
+
+- [ ] **Step 2: Search for existing `LeaveFocusClearsPresenting` coverage.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && rg -l "clearsPresenting|PresentingFocus|leave.*present" internal/grpc/focus/ test/integration/`
+Record findings.
+
+### Task 3.2: Create the scenes integration suite harness
+
+**Files:**
+
+- Create: `test/integration/scenes/scenes_suite_test.go`
+- Create: `test/integration/scenes/helpers_test.go`
+
+- [ ] **Step 1: Write the Ginkgo suite entrypoint.**
+
+Create `test/integration/scenes/scenes_suite_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+var suiteT *testing.T
+
+func TestScenesE2E(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scenes Focus-Substrate Integration Suite")
+}
+```
+
+- [ ] **Step 2: Write `helpers_test.go`.**
+
+This file MUST bring up a core server with the `core-scenes` binary plugin loaded via testcontainers Postgres and expose telnet-adapter-style helpers. Follow the pattern in `test/integration/telnet/e2e_test.go` and `test/integration/plugin/binary_plugin_test.go`. Key responsibilities:
+
+- Bootstrap testcontainers Postgres.
+- Build `core-scenes` plugin binary (`task plugin:build -- core-scenes`).
+- Start core server with plugin manager configured to load `core-scenes`.
+- Expose: `createPlayerAndCharacter(name)`, `attachSession(charID)`, `sendCommand(sess, cmd)`, `collectEvents(sess, timeout)`, `detach(sess)`, `reattach(sess)`.
+- Expose: `setPlayerScenePref(playerID, tail int)` for the preference test.
+
+Content — ~250 lines, closely following the existing harness patterns. The executing agent SHOULD read `test/integration/telnet/e2e_test.go` and `test/integration/plugin/binary_plugin_test.go` before writing this file to match conventions.
+
+- [ ] **Step 3: Build plugins as part of suite bootstrap and verify with a smoke Describe block.**
+
+Add a minimal Describe("scenes-suite bootstrap") with It("builds core-scenes plugin and starts server") that just exercises createPlayer→attach→list-scenes-returns-empty to validate the harness.
+
+- [ ] **Step 4: Run the suite with the smoke block only.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration ./test/integration/scenes/...`
+Expected: PASS. Docker must be running (testcontainers).
+
+- [ ] **Step 5: Commit the harness.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "test(scenes): bootstrap focus-substrate integration suite
+
+Ginkgo suite harness for Phase 4 §7.2 acceptance tests. Testcontainers
+Postgres + core server + core-scenes binary plugin + telnet-style
+command helpers. Minimal smoke Describe block validates the bootstrap."`
+
+### Task 3.3: TestTelnetReconnectResumesSceneWithUnseenEvents
+
+**Files:**
+
+- Create: `test/integration/scenes/focus_reconnect_test.go`
+
+- [ ] **Step 1: Write the spec.**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+var _ = Describe("Telnet reconnect resumes scene with unseen events", func() {
+	It("delivers scene IC events committed during the detach window", func() {
+		// 1. Owner creates a scene; Bob joins.
+		owner := createPlayerAndCharacter("owner")
+		bob := createPlayerAndCharacter("bob")
+		ownerSess := attachSession(owner.CharID)
+		bobSess := attachSession(bob.CharID)
+
+		sendCommand(ownerSess, "scene create The Gate").Should(BeOK())
+		sceneID := lastSceneID(ownerSess)
+		sendCommand(bobSess, "scene join "+sceneID).Should(BeOK())
+
+		// 2. Bob detaches.
+		detach(bobSess)
+
+		// 3. Owner poses while Bob is detached.
+		sendCommand(ownerSess, "pose The gate looms.").Should(BeOK())
+		sendCommand(ownerSess, "pose Somewhere a bell tolls.").Should(BeOK())
+
+		// 4. Bob reattaches; MUST receive both poses in order.
+		bobSess2 := reattachSession(bob.CharID, bobSess)
+		events := collectEvents(bobSess2, "3s")
+		Expect(eventPayloads(events, "scene:"+sceneID+":ic")).To(ContainElements(
+			HavePrefix("The gate looms"),
+			HavePrefix("Somewhere a bell tolls"),
+		))
+	})
+})
+```
+
+The `BeOK`, `lastSceneID`, `detach`, `reattachSession`, `collectEvents`, `eventPayloads` helpers live in `helpers_test.go` — wire them in Task 3.2 or extend as needed here.
+
+- [ ] **Step 2: Run the test.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration -run 'Telnet reconnect resumes' ./test/integration/scenes/...`
+Expected: PASS. If FAIL, inspect whether the bug is in B10 wiring or in upstream (B7/B8); fix or file a bead.
+
+- [ ] **Step 3: Commit.**
+
+`cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "test(scenes): reconnect resumes scene with unseen events (§7.2)"`
+
+### Task 3.4: TestFocusSwitchCatchUpUsesBoundedIC
+
+**Files:**
+
+- Create: `test/integration/scenes/focus_switch_test.go`
+
+- [ ] **Step 1: Write the test.**
+
+```go
+var _ = Describe("scene switch bounded catch-up", func() {
+	It("replays the last N IC events when switching into a scene", func() {
+		// Default preference resolves to 3 via coordinator substrate default.
+		owner := createPlayerAndCharacter("owner")
+		bob := createPlayerAndCharacter("bob")
+		ownerSess := attachSession(owner.CharID)
+		bobSess := attachSession(bob.CharID)
+
+		// Scene 1 and 2 exist; Bob joins both.
+		sendCommand(ownerSess, "scene create Gate").Should(BeOK())
+		gate := lastSceneID(ownerSess)
+		sendCommand(ownerSess, "scene create Tower").Should(BeOK())
+		tower := lastSceneID(ownerSess)
+		sendCommand(bobSess, "scene join "+gate).Should(BeOK())
+		sendCommand(bobSess, "scene join "+tower).Should(BeOK())
+		sendCommand(bobSess, "scene switch "+gate).Should(BeOK())
+
+		// Emit 5 IC events on Tower while Bob is focused on Gate.
+		for i := 0; i < 5; i++ {
+			sendCommand(ownerSess, "scene switch "+tower).Should(BeOK())
+			sendCommand(ownerSess, "pose tower pose "+itoa(i)).Should(BeOK())
+		}
+
+		drainEvents(bobSess)
+
+		// Switch Bob into Tower. He should receive the last 3 tower poses.
+		sendCommand(bobSess, "scene switch "+tower).Should(BeOK())
+		events := collectEvents(bobSess, "3s")
+		Expect(eventPayloads(events, "scene:"+tower+":ic")).To(HaveLen(3))
+	})
+})
+```
+
+- [ ] **Step 2: Run the test.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration -run 'bounded catch-up' ./test/integration/scenes/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+`cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "test(scenes): focus switch bounded IC catch-up (§7.2)"`
+
+### Task 3.5: TestFocusSwitchSkipsHistoricalOOC
+
+**Files:**
+
+- Modify: `test/integration/scenes/focus_switch_test.go`
+
+- [ ] **Step 1: Add the spec.**
+
+```go
+var _ = Describe("scene switch OOC live-only", func() {
+	It("does NOT replay historical OOC events when switching", func() {
+		owner := createPlayerAndCharacter("owner")
+		bob := createPlayerAndCharacter("bob")
+		ownerSess := attachSession(owner.CharID)
+		bobSess := attachSession(bob.CharID)
+
+		sendCommand(ownerSess, "scene create Gate").Should(BeOK())
+		gate := lastSceneID(ownerSess)
+		sendCommand(bobSess, "scene join "+gate).Should(BeOK())
+
+		// Owner emits an OOC notice; Bob is focused, receives it live.
+		sendCommand(ownerSess, "scene invite "+gate+" someone-else").ShouldNot(BeOK()) // just to generate OOC; exact command TBD per plugin
+		drainEvents(bobSess)
+
+		// Bob switches away and back; OOC history must NOT be replayed.
+		sendCommand(ownerSess, "scene create Tower").Should(BeOK())
+		tower := lastSceneID(ownerSess)
+		sendCommand(bobSess, "scene join "+tower).Should(BeOK())
+		sendCommand(bobSess, "scene switch "+tower).Should(BeOK())
+		sendCommand(bobSess, "scene switch "+gate).Should(BeOK())
+		events := collectEvents(bobSess, "1s")
+		Expect(eventPayloads(events, "scene:"+gate+":ooc")).To(BeEmpty())
+	})
+})
+```
+
+Note: if the `scene invite` OOC event does not exist in Phase 4 wiring, substitute whatever OOC-stream event is available. The test's essential claim is "OOC stream replay on switch is empty for historical events." Adapt.
+
+- [ ] **Step 2: Run the test.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration -run 'OOC live-only' ./test/integration/scenes/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+`cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "test(scenes): focus switch OOC live-only (§7.2)"`
+
+### Task 3.6: Conditional tests — FocusSwitchHonorsPlayerPreference & LeaveFocusClearsPresentingWhenReferenced
+
+**Files:**
+
+- Conditionally modify: `test/integration/scenes/focus_switch_test.go`, `test/integration/scenes/focus_leave_test.go`
+
+- [ ] **Step 1: Based on Task 3.1 inventory, decide per test.**
+
+If already covered in `internal/grpc/focus/*_test.go`: skip. Document in PR description with a reference to the existing test(s).
+If not covered at the integration layer: write the test, following the pattern from Task 3.5 for the setup and the parent spec §7.2 for the expected behavior. Specifically:
+
+- `TestFocusSwitchHonorsPlayerPreference`: set the player's `scenes.focus.replay_tail_default` preference to 1 via `setPlayerScenePref`; emit 5 IC events; switch into the scene; assert exactly 1 event delivered.
+- `TestLeaveFocusClearsPresentingWhenReferenced`: join scenes A and B; present A; leave A; verify `PresentingFocus` is either nil or B (session store read exposed via a helper).
+
+- [ ] **Step 2: Run them.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration -run 'honors player preference|clears presenting' ./test/integration/scenes/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+`cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "test(scenes): honors preference + clears presenting on leave (§7.2)"` (adjust message if only one was written).
+
+### Task 3.7: (Stretch) TestMultiSceneMembershipReconnect
+
+**Files:**
+
+- Create: `test/integration/scenes/focus_leave_test.go` (or extend)
+
+- [ ] **Step 1: Write the test.**
+
+Bob joins 3 scenes, detaches, each scene owner emits IC events, Bob reattaches. Merge-sorted delivery by ULID across the 3 scene IC streams.
+
+- [ ] **Step 2: Run.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration -run 'multi-scene' ./test/integration/scenes/...`
+Expected: PASS. If test is flaky under merge-sort, mark `Skip` with a reference to the substrate invariant (I-15) — do not block B10 on stretch.
+
+- [ ] **Step 3: Commit (or skip commit if the test was not written).**
+
+### Task 3.8: Full integration run
+
+**Files:** none.
+
+- [ ] **Step 1: Run the scenes integration suite end-to-end.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && go test -race -v -tags=integration ./test/integration/scenes/...`
+Expected: all written specs PASS.
+
+- [ ] **Step 2: Run the full integration suite (no regressions).**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test:int`
+Expected: green.
+
+---
+
+## Phase 4 — Documentation
+
+**Model:** Sonnet. Mechanical writing.
+
+### Task 4.1: Update binary-plugins docs
+
+**Files:**
+
+- Modify: `site/docs/extending/binary-plugins.md`
+
+- [ ] **Step 1: Read the current document to find the EventSink section.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && grep -n "EventSink\|EventSinkAware\|SetEventSink" site/docs/extending/binary-plugins.md | head -10`
+Locate the section that documents EventSink injection. The new FocusClient section goes immediately after it with parallel structure.
+
+- [ ] **Step 2: Add a `## FocusClient` section.**
+
+Content (adapt surrounding markdown style to existing document):
+
+- One-paragraph summary: what `FocusClient` is, when to use it.
+- Table of the four methods with purposes.
+- A minimal code example of a plugin struct implementing `FocusClientAware` and calling `JoinFocus` from a command handler.
+- Note: `EventSink` and `FocusClient` share one gRPC connection; implementing both `EventSinkAware` and `FocusClientAware` on the same provider is the common case for binary plugins that drive focus state (e.g., core-scenes).
+- Link to spec: `docs/superpowers/specs/2026-04-11-focus-substrate-design.md` and this bead's spec.
+
+- [ ] **Step 3: Run docs lint.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task lint:docs`
+Expected: clean.
+
+- [ ] **Step 4: Run docs build (optional — sanity check).**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task docs:build`
+Expected: build completes without errors.
+
+- [ ] **Step 5: Commit.**
+
+`cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager commit -m "docs(extending): FocusClient facade and FocusClientAware injection
+
+Document the new binary-plugin SDK facade added in B10. Parallel structure
+to the existing EventSink documentation. Links to the focus substrate
+design spec and the B10 spec."`
+
+---
+
+## Phase 5 — PR Preparation and Review
+
+**Model:** Sonnet for orchestration; Opus for nontrivial finding fixes.
+
+### Task 5.1: Simplify pass
+
+**Files:** any touched in Phases 1-4.
+
+- [ ] **Step 1: Invoke the `simplify` skill on the changed files.**
+
+Skill: `Skill(skill="simplify", args="Review all files changed in this branch (pkg/plugin/*, plugins/core-scenes/*, test/integration/scenes/*, site/docs/extending/binary-plugins.md) for reuse, DRY, and clarity. Do NOT change semantics. Commit any changes as their own revision.")`
+
+- [ ] **Step 2: Verify tests still pass after simplification.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task test`
+Expected: green.
+
+### Task 5.2: Full pr-prep
+
+**Files:** none.
+
+- [ ] **Step 1: Run the full `task pr-prep` suite.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task pr-prep`
+Expected: every sub-job green. MUST be full — never approximate (feedback memory `feedback_pr_prep_must_run`).
+
+- [ ] **Step 2: If anything fails, fix it and re-run `task pr-prep` until all green.**
+
+Do NOT skip. Do NOT push without green.
+
+### Task 5.3: Create the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Set the bookmark on the latest commit and push.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager bookmark set b10-core-scenes-adoption -r @- && jj --no-pager git push -b b10-core-scenes-adoption`
+Expected: push succeeds, remote tracks the new bookmark.
+
+Note: `-r @-` because `@` is always an empty new change after `jj commit`; `@-` is the last real commit.
+
+- [ ] **Step 2: Open the PR.**
+
+Run (heredoc to preserve formatting):
+
+```
+gh pr create --head b10-core-scenes-adoption --title "feat(scenes): B10 — core-scenes plugin adoption (focus substrate)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `FocusClient` SDK facade to `pkg/plugin`, parallel to `EventSink`, wrapping the four `PluginHostService` focus RPCs landed in B8.
+- Wires `core-scenes` command handlers (`scene join/leave/end/switch`) to drive session focus state via the coordinator.
+- Adds Phase 4 §7.2 acceptance tests under `test/integration/scenes/`.
+- Unblocks Scenes Phase 4 (`holomush-5rh.13`).
+
+## Design
+
+- Spec: `docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md`
+- Plan: `docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md`
+- Parent epic spec: `docs/superpowers/specs/2026-04-11-focus-substrate-design.md`
+
+## Key decisions
+
+- Command-path only (no scene proto `session_id` field). Rationale in spec §3.1: `SceneService` has no external callers; PR #225 already IDOR-hardened `HandleCommand` so the `SessionID` arriving at the plugin is trusted.
+- DB-first, focus-second ordering with no compensating writes. `JoinScene` is idempotent (P3.D5); retries heal.
+- `EndScene` LeaveFocus for the caller's session only. Multi-session fan-out deferred to follow-up bead (see §6.1).
+
+## Test plan
+
+- [x] Unit: `pkg/plugin/focus_client_test.go` (error mapping, happy paths, nil guards).
+- [x] Unit: `plugins/core-scenes/commands_test.go` (11 new tests for join/leave/end/switch).
+- [x] Integration: Phase 4 §7.2 tests under `test/integration/scenes/`.
+- [x] `task pr-prep` green.
+- [x] `task lint:docs` green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL returned.
+
+### Task 5.4: Review-PR orchestrator
+
+**Files:** any.
+
+- [ ] **Step 1: Invoke the review-pr orchestrator.**
+
+Skill: `Skill(skill="pr-review-toolkit:review-pr", args="PR URL from Task 5.3; focus areas: SDK facade correctness, plugin command wiring, integration test design, invariant preservation (I-6, I-7, I-13).")`
+
+- [ ] **Step 2: Address each finding.**
+
+For each finding, either fix in a new commit on the same bookmark or document why it does not apply in a PR comment. Follow-up work discovered during review MUST be filed as beads (use `bd create` with `discovered-from:holomush-oy6e.10`).
+
+- [ ] **Step 3: Re-run `task pr-prep` after fixes.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task pr-prep`
+Expected: green.
+
+- [ ] **Step 4: Push fixes.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager bookmark set b10-core-scenes-adoption -r @- && jj --no-pager git push -b b10-core-scenes-adoption`
+
+### Task 5.5: Squash-merge on GitHub
+
+**Files:** none.
+
+- [ ] **Step 1: User-driven step.**
+
+After all findings addressed and CI green, have the PR squash-merged on GitHub per project convention. The plan assumes merge is performed manually or via gh CLI by the user.
+
+---
+
+## Phase 6 — Post-Merge Cleanup
+
+**Model:** Haiku or Sonnet. Mechanical VCS + bd ops.
+
+### Task 6.1: Reconcile the workspace after squash-merge
+
+**Files:** none.
+
+- [ ] **Step 1: Capture the bead commit's change ID before fetching (squash-merge on GitHub will produce a NEW commit hash, so the change ID is the stable handle).**
+
+Run from the b10 workspace: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager log -r '@- | @--' -T 'change_id.short(12) ++ " " ++ description.first_line() ++ "\n"' --no-graph | head -5`
+Record the change ID of the top bead commit.
+
+- [ ] **Step 2: Fetch.**
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager git fetch`
+
+- [ ] **Step 3: Rebase onto new main — TARGETED.**
+
+**CRITICAL: use `-r <change-id>` (NOT bare `-d main`).** Per memory `feedback_jj_rebase_targeted`, bare rebase sweeps other agents' parallel work.
+
+Run: `cd /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes && jj --no-pager rebase -r <change-id-from-step-1> -d main --skip-emptied`
+Expected: the top commit is either rebased onto main (becomes empty → auto-abandoned) or rebased with any residual changes.
+
+- [ ] **Step 4: Delete the bookmark.**
+
+Run: `jj --no-pager bookmark delete b10-core-scenes-adoption`
+
+### Task 6.2: Tear down the workspace
+
+**Files:** none.
+
+- [ ] **Step 1: Forget the jj workspace.**
+
+Run from any workspace: `jj --no-pager workspace forget b10`
+
+- [ ] **Step 2: Delete the worktree directory.**
+
+Run: `rm -rf /Users/sean/Code/github.com/holomush/.worktrees/b10-core-scenes`
+
+- [ ] **Step 3: Regenerate go.work.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && task gowork`
+Expected: go.work written with remaining active workspaces.
+
+### Task 6.3: Close the bead and update the epic
+
+**Files:** none.
+
+- [ ] **Step 1: Close B10.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && bd close holomush-oy6e.10 --reason "core-scenes adopted focus substrate via command-path wiring; Phase 4 §7.2 acceptance tests pass; blocks holomush-5rh.13 now cleared. Follow-up bead filed for LeaveFocusByTarget multi-session fan-out. PR <link-to-merged-PR>."`
+Expected: bead marked closed.
+
+- [ ] **Step 2: Append a session note to the epic.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && bd update holomush-oy6e --notes "$(cat <<'EOF'
+## Session 2026-04-?? — B10 closed (PR #???)
+
+### B10 (holomush-oy6e.10) — core-scenes plugin adoption:
+- SDK FocusClient facade in pkg/plugin (parallel to EventSink), single shared conn with broker dialer.
+- Command-path-only wiring in plugins/core-scenes (DB first, focus second, no compensating writes).
+- scene switch subcommand added.
+- 11 unit tests + N integration tests (Phase 4 §7.2 subset; others covered by B4/B6 coordinator tests).
+- Multi-session EndScene fan-out deferred to follow-up bead <ID> (LeaveFocusByTarget).
+
+### Epic progress: 10/13 beads complete (77%)
+- B10 closed. Scenes Phase 4 (holomush-5rh.13) now unblocked.
+- Next: B11 (core-channels adoption), B12 (architecture doc overhaul), B13 (web client QueryStreamHistory).
+EOF
+)"`
+(Fill in the real PR number, date, and follow-up bead ID.)
+
+### Task 6.4: Verify cleanup
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm nothing stranded.**
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && git status`
+Expected: on main, clean working copy (or on whichever workspace you're in).
+
+Run: `cd /Volumes/Code/github.com/holomush/holomush && bd ready --json 2>&1 | head -30`
+Expected: B10 no longer appears; follow-up bead appears as backlog.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- §1.1 item 1 (SDK facade): Phase 1 tasks 1.1-1.3. ✓
+- §1.1 item 2 (command-path wiring): Phase 2 tasks 2.1-2.7. ✓
+- §1.1 item 3 (plugin-local fakes): Phase 2 task 2.1. ✓
+- §1.1 item 4 (§7.2 tests): Phase 3 tasks 3.2-3.7. ✓
+- §1.1 item 5 (docs): Phase 4. ✓
+- §6.1 follow-up bead: Phase 0 task 0.2 + Phase 6 task 6.3. ✓
+- Post-merge cleanup discipline (parent spec §8.0 phase 5): Phase 6. ✓
+
+**Placeholder scan:** No "TBD/TODO" in any task step. Each step has exact commands or exact code. Integration-test helpers (Task 3.2) reference existing patterns rather than inlining the full harness — the executing agent is expected to read `test/integration/telnet/e2e_test.go` and `test/integration/plugin/binary_plugin_test.go` to ground the implementation. This is acceptable: harness code mirrors an established project pattern and is too long (~250 lines) to inline verbatim without bloat.
+
+**Type consistency:**
+
+- `FocusClient` interface: same signature across focus_client.go, focus_client_test.go, sdk.go, commands_test.go, commands.go.
+- `FocusKey{Kind, TargetID}`: consistent.
+- `fakeFocusClient.joinCalls/leaveCalls/presentCalls`: consistent between Task 2.1 (definition) and Tasks 2.3-2.6 (assertions).
+
+**One inconsistency to fix:** Task 1.2 step 1 imports `"google.golang.org/grpc"` but Task 1.3 step 4 suggests removing the `var _ grpc.DialOption = nil` sentinel, which would strand the import. The executing agent should either use the grpc import for a real purpose or delete both. Leaving this as a judgment call — no-op for the plan's correctness.
+
+**Gap found:** Task 3.1 may determine that `TestFocusSwitchHonorsPlayerPreference` is not reachable in integration without surfaces for setting player preferences end-to-end. If so, mark it as "covered by B6 coordinator tests" rather than forcing a weak integration equivalent. Task 3.6 already accommodates this.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Model per phase: Phases 1-3 use Opus, Phases 4-6 use Sonnet.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
+++ b/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
@@ -515,7 +515,19 @@ covered by prior beads (B2, B4, B6, B7, B8). B10 does not affect them.
 - `pkg/plugin/focus_client_test.go` — unit tests for impl (broker dial, error mapping).
 - `docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md` — this document.
 - `docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md` — implementation plan (next step via writing-plans).
-- `test/integration/scenes/focus_*_test.go` — Phase 4 acceptance tests.
+
+### Deferred (NOT added in this PR)
+
+- `test/integration/scenes/focus_*_test.go` — Phase 4 end-to-end acceptance
+  tests. Scoped out of B10 during execution because every invariant listed
+  in §5.2 that's reachable today is already covered by unit tests in
+  `internal/grpc/focus/` (B4/B6) and `pkg/plugin/` (B8). The remaining tests
+  (`TestTelnetReconnectResumesSceneWithUnseenEvents`, the full switch
+  catch-up flow, multi-scene merge-sort) exercise pose-order + stream
+  plumbing that is Phase 4's responsibility — they belong in
+  `holomush-5rh.13` alongside the pose-order work, not B10. The PR
+  description lists the specific unit-test locations that cover each
+  §5.2 invariant at unit level.
 
 ### Modified
 

--- a/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
+++ b/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
@@ -1,0 +1,556 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# B10 — core-scenes Plugin Adoption Design
+
+**Status:** Draft (awaiting user review)
+**Date:** 2026-04-16
+**Bead:** `holomush-oy6e.10`
+**Epic:** `holomush-oy6e` — Server-Owned Focus Substrate
+**Blocks:** `holomush-5rh.13` — Scenes Phase 4: Event streams + pose order
+**Depends on:** `holomush-oy6e.8` (plugin host focus RPCs — merged PR #216), `holomush-oy6e.9` (client QueryStreamHistory — merged PR #223), PR #225 (session identity — merged 2026-04-16)
+
+**Parent spec:** [`2026-04-11-focus-substrate-design.md`](./2026-04-11-focus-substrate-design.md). This document is B10-specific and assumes familiarity with the parent spec's invariants (I-1 … I-16), focus transition flows (§4.3, §4.4, §4.5), and plugin host proto (§3.4).
+
+## RFC2119 Keywords
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document are to be interpreted as described in RFC 2119.
+
+---
+
+## Section 1: Scope
+
+### 1.1 What B10 delivers
+
+1. A binary-plugin SDK facade (`FocusClient`) in `pkg/plugin` that exposes
+   the four host focus RPCs (`JoinFocus`, `LeaveFocus`, `PresentFocus`,
+   `QueryStreamHistory`) to plugin Go code, parallel in shape to the
+   existing `EventSink` facade.
+2. `core-scenes` command-path wiring — DB first, focus second, symmetric
+   across all state-changing commands:
+    - `scene join <id>` → `service.JoinScene` (DB), then `focusClient.JoinFocus`.
+    - `scene leave <id>` → `service.LeaveScene` (DB), then `focusClient.LeaveFocus`.
+    - `scene end <id>` → `service.EndScene` (DB), then `focusClient.LeaveFocus`
+      for the calling (owner's) session.
+    - `scene switch <id>` — new subcommand — `focusClient.PresentFocus` (no DB
+      write).
+3. Plugin-local test doubles for `FocusClient` (a `fakeFocusClient` parallel
+   to the existing `fakeEventSink` pattern).
+4. The Phase 4 §7.2 acceptance tests that are reachable at B10 scope.
+5. Documentation updates in `site/docs/extending/binary-plugins.md` for the
+   new `FocusClient` facade and `FocusClientAware` interface.
+
+### 1.2 What B10 explicitly does NOT deliver
+
+- **No `session_id` field added to any scene proto request.** The scene
+  plugin service (`SceneService`) remains character-id-only. Justification
+  in §3.1.
+- **No multi-session fan-out on `EndScene`.** When a non-owner participant
+  remains in a scene that ends, their session's `FocusMembership` for that
+  scene persists as a cosmetic leak. The scene stops emitting IC events, so
+  no stale deliveries occur, but the cursor table retains the row. Fix is
+  filed as a follow-up bead (§6.1).
+- **No auto-join on `scene switch`.** If target is not already in the
+  session's `FocusMemberships`, the command errors with the coordinator's
+  `FOCUS_NOT_MEMBER`. No implicit `JoinFocus` call.
+- **No Lua plugin adoption.** `core-scenes` is a binary plugin. Channel
+  adoption (Lua or binary) is B11, channel-specific.
+- **No changes to scene lifecycle event emission.** `service.go`'s existing
+  `eventSink.Emit` calls for scene creation/pause/resume/end remain
+  unchanged — they publish on the `scene:<id>` stream independent of
+  subscription state.
+
+### 1.3 Success criteria
+
+1. `task pr-prep` green.
+2. Every new code path has a unit test asserting behavior with the
+   `fakeFocusClient` stub.
+3. The five Phase 4 §7.2 tests listed in §5.2 pass.
+4. No regressions in existing `core-scenes` tests.
+5. No changes to `session.FocusMemberships` in any plugin code path —
+   all mutations go through `focusClient` (invariant I-6 enforced by
+   the facade not exposing a direct-mutation method).
+
+---
+
+## Section 2: SDK Facade — `FocusClient`
+
+### 2.1 Shape
+
+A single-purpose facade in `pkg/plugin`, parallel to `EventSink`. New file
+`pkg/plugin/focus_client.go`:
+
+```go
+// FocusClient is the SDK-facing facade binary-plugin code uses to drive the
+// server-owned focus substrate on behalf of a session. All calls cross the
+// plugin broker (mTLS) to the host's PluginHostService.
+type FocusClient interface {
+    // JoinFocus adds a focus membership and applies the kind-specific
+    // server-owned replay policy. Caller provides the target (kind + id);
+    // the server determines streams, replay mode, cursor baselines, and
+    // subscription updates. Callers MUST NOT declare replay mode or stream
+    // names — this is invariant I-7 at the proto boundary.
+    JoinFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+    // LeaveFocus removes a focus membership. Idempotent on non-member.
+    LeaveFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+    // PresentFocus updates the session's presenting pointer. Target MUST
+    // already be in FocusMemberships.
+    PresentFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+    // QueryStreamHistory reads the tail of a stream. Read-only (I-13):
+    // does not mutate cursors, subscriptions, or session state.
+    QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error)
+}
+
+// FocusKey identifies a focus membership within a session.
+type FocusKey struct {
+    Kind     FocusKind
+    TargetID string
+}
+
+// FocusKind mirrors session.FocusKind, scoped to the SDK.
+type FocusKind string
+
+const (
+    FocusKindScene FocusKind = "scene"
+)
+
+// QueryStreamHistoryRequest describes a bounded tail read.
+type QueryStreamHistoryRequest struct {
+    Stream    string
+    Count     int       // server clamps to 500
+    NotBefore time.Time // zero == no time floor
+}
+
+// FocusClientAware is the optional interface service providers implement to
+// receive a FocusClient during Init, parallel to EventSinkAware.
+type FocusClientAware interface {
+    SetFocusClient(FocusClient)
+}
+```
+
+### 2.2 Injection
+
+The plugin SDK adapter (`pkg/plugin/sdk.go`'s `pluginServerAdapter.Init`)
+gains a parallel injection path:
+
+```go
+if fcAware, ok := a.serviceProvider.(FocusClientAware); ok {
+    client, err := newFocusClientFromBroker(a.brokerDialer, requiredServices)
+    if err != nil {
+        return nil, oops.With("phase", "init").With("service", PluginHostServiceName).Wrap(err)
+    }
+    fcAware.SetFocusClient(client)
+}
+```
+
+`newFocusClientFromBroker` dials the same broker service as `EventSink`
+(`PluginHostServiceName = "holomush.plugin.v1.PluginHostService"`),
+reusing broker ID resolution and authority string. Only ONE grpc.ClientConn
+is dialed per plugin for the host service — `EventSink` and `FocusClient`
+MUST share the underlying connection, not open two. Implementation:
+construct both from a single cached conn inside Init.
+
+### 2.3 Error mapping
+
+The host returns typed gRPC codes from B8's landed RPCs:
+
+| Host code | SDK behavior |
+|---|---|
+| `codes.NotFound` + `SESSION_NOT_FOUND` | wrap with `oops.Code("SESSION_NOT_FOUND")` |
+| `codes.FailedPrecondition` + `SESSION_EXPIRED` | wrap with `oops.Code("SESSION_EXPIRED")` |
+| `codes.AlreadyExists` + `FOCUS_ALREADY_MEMBER` | wrap with `oops.Code("FOCUS_ALREADY_MEMBER")` |
+| `codes.InvalidArgument` + `FOCUS_KIND_UNREGISTERED` | wrap with `oops.Code("FOCUS_KIND_UNREGISTERED")` |
+| `codes.Internal` + `FOCUS_POLICY_FAILED` | wrap with `oops.Code("FOCUS_POLICY_FAILED")` |
+| `codes.NotFound` + `FOCUS_NOT_MEMBER` | wrap with `oops.Code("FOCUS_NOT_MEMBER")` |
+
+Other gRPC errors pass through with `oops.Wrap`. Callers distinguish via
+`errutil.IsErrorCode(err, "FOCUS_ALREADY_MEMBER")` etc.
+
+### 2.4 No new host RPCs
+
+`PluginHostService` is unchanged. All four RPCs B10 calls were landed in B8.
+B10 adds only client-side Go code and plugin-side adoption.
+
+---
+
+## Section 3: Command-path wiring
+
+### 3.1 Why command-path-only
+
+The SceneService gRPC surface is plugin-internal: the only callers are
+(a) the `core-scenes` plugin's own command handlers via local Go method
+calls, and (b) unit/integration tests. No external-facing gateway (web or
+telnet) invokes `SceneServiceClient.JoinScene` directly — scene mutations
+arrive via `CoreService.HandleCommand` → plugin dispatcher → plugin's
+internal service method.
+
+PR #225 (session identity, 2026-04-16) codified this pattern at the layer
+below: `HandleCommand` now requires `player_session_token` and validates
+ownership via `auth.ValidateSessionOwnership`. `CommandRequest.SessionID`
+arriving at the plugin is therefore rigorously trusted as owned by the
+authenticated player. Scene plugin adoption rides on this.
+
+Adding `session_id` to scene proto requests now would:
+- Solve a non-problem (no current caller needs it).
+- Diverge from the established "external → HandleCommand" pattern.
+- Couple scene proto evolution to session-identity decisions.
+
+**Decision:** focus wiring lives in `plugins/core-scenes/commands.go`
+handlers, NOT in `service.go`. `service.go` stays session-unaware.
+
+When a future caller does need session-aware scene RPCs (e.g., a rich
+web client's scene management pane), the correct remedy is to add
+`session_id` + `player_session_token` fields to the specific RPCs at
+that time — not to speculatively add them now. File a tracking bead at
+that time; do not pre-wire.
+
+### 3.2 Wired commands
+
+#### 3.2.1 `scene join <scene-id>`
+
+```
+handleJoin(ctx, req, args):
+    service.JoinScene(ctx, {character_id: req.CharacterID, scene_id: id})
+      ├── OK            → continue
+      ├── OpNoChange    → user is already a member; still call JoinFocus
+      │                   (may FOCUS_ALREADY_MEMBER; treat as success)
+      └── error         → return pluginsdk.Errorf("Failed to join scene: %v", err)
+
+    focusClient.JoinFocus(ctx, req.SessionID, FocusKey{Kind: Scene, TargetID: id})
+      ├── OK                    → return OK("Joined scene %s.", id)
+      ├── FOCUS_ALREADY_MEMBER  → return OK (idempotent)
+      └── error                 → return pluginsdk.Errorf(
+                                      "Joined scene in database, but your session could not subscribe (%v). "+
+                                      "Please retry `scene join %s`.", err, id)
+```
+
+**Failure-window analysis.** Between `service.JoinScene` success and
+`focusClient.JoinFocus` failure, the DB says the character is a scene
+member but the session has no `FocusMembership`. Consequences:
+- Pose events emitted on `scene:<id>:ic` are NOT delivered to this
+  session (it's not subscribed).
+- Reconnect-restore does NOT heal the gap, because `RestoreFocus`
+  iterates `session.FocusMemberships`, which never gained the row.
+- User retry (`scene join X` again) is safe: `service.JoinScene` is
+  idempotent (returns `OpNoChange`), and `focusClient.JoinFocus`
+  re-attempts. If it now succeeds, state is consistent. If it also
+  returns `FOCUS_ALREADY_MEMBER` because the first call did partially
+  succeed at the coordinator, treat it as success.
+
+This failure mode is visible and user-correctable. No compensation
+write is required.
+
+#### 3.2.2 `scene leave <scene-id>`
+
+```
+handleLeave(ctx, req, args):
+    service.LeaveScene(ctx, {character_id: req.CharacterID, scene_id: id})
+      ├── OK          → continue
+      └── error       → return pluginsdk.Errorf("Failed to leave scene: %v", err)
+
+    focusClient.LeaveFocus(ctx, req.SessionID, FocusKey{Kind: Scene, TargetID: id})
+      ├── OK          → return OK("Left scene %s.", id)
+      └── error       → log warn, return OK (DB write succeeded; session
+                        unsubscribe is eventually-consistent — stale focus
+                        is cosmetic because the user is no longer a scene
+                        member so ABAC blocks writes on the streams)
+```
+
+**Order rationale — DB first, focus second.** Symmetric with `scene join`.
+
+- Owner-leave rejection (P3.D7) fires inside `service.LeaveScene` before
+  any state is mutated. If `LeaveFocus` ran first, the owner would lose
+  their focus subscription before being told they cannot leave — wrong.
+- `LeaveFocus` is idempotent on the coordinator (§4.4 of parent spec).
+  A failure after a successful DB write leaves the session subscribed
+  to a scene it is no longer a DB member of. The scene's ABAC write
+  policy (`write-scene-as-participant`) rejects further pose/ooc writes,
+  so no incorrect effect occurs. Stream delivery on ambient scene events
+  is cosmetic noise until reconnect-resume (which will not re-add the
+  membership because the DB write removed it).
+- The coordinator-side fix for this stale-focus window is `LeaveFocusByTarget`
+  (§6.1). B10 accepts the cosmetic leak.
+
+#### 3.2.3 `scene end <scene-id>`
+
+```
+handleEnd(ctx, req, args):
+    service.EndScene(ctx, {character_id, scene_id})
+      └── error → return pluginsdk.Errorf(...)
+
+    focusClient.LeaveFocus(ctx, req.SessionID, FocusKey{Kind: Scene, TargetID: id})
+      ├── OK    → return OK("Scene %s ended.", id)
+      └── error → log warn, return OK (same rationale as Leave)
+```
+
+Only the caller's (owner's) session has its focus removed. Other
+participants are NOT fanned-out in B10; see §1.2 and §6.1.
+
+#### 3.2.4 `scene switch <scene-id>` — new subcommand
+
+```
+handleSwitch(ctx, req, args):
+    focusClient.PresentFocus(ctx, req.SessionID, FocusKey{Kind: Scene, TargetID: id})
+      ├── OK               → return OK("Switched to scene %s.", id)
+      ├── FOCUS_NOT_MEMBER → return pluginsdk.Errorf(
+                                 "You are not a member of scene %s. Use `scene join %s` first.", id, id)
+      └── error            → return pluginsdk.Errorf("Failed to switch scene: %v", err)
+```
+
+Must be added to `dispatchCommand`'s switch in `commands.go` and to the
+help text.
+
+### 3.3 Plugin wiring
+
+`plugins/core-scenes/main.go`:
+
+```go
+type scenePlugin struct {
+    store       *SceneStore
+    service     *SceneServiceImpl
+    resolver    *SceneResolver
+    focusClient pluginsdk.FocusClient   // new
+}
+
+func (p *scenePlugin) SetFocusClient(client pluginsdk.FocusClient) {
+    p.focusClient = client
+}
+```
+
+No change to `Init`, `RegisterServices`, `RegisterAttributeResolver`. The
+`FocusClientAware` interface is detected by the SDK adapter during Init.
+
+Command handlers access the client via `p.focusClient`. Unit tests inject
+a `fakeFocusClient` (see §5.3).
+
+### 3.4 ABAC gating
+
+`scene join`, `scene leave`, `scene end` already have ABAC policies in
+`plugin.yaml` (`join-open-scene`, `leave-scene`, `end-own-scene`, etc.).
+These continue to gate the underlying service calls; no changes.
+
+`scene switch` is a pure session-state operation that does not touch
+scene resources. It is a subcommand of the existing `scene` command, so
+the Layer-1 `execute-scene-commands` policy already permits dispatch. No
+new ABAC policy is required. The coordinator's `FOCUS_NOT_MEMBER` check
+is the correctness gate — a player cannot switch to a scene they are
+not a member of.
+
+---
+
+## Section 4: Error handling summary
+
+| Scenario | Behavior |
+|---|---|
+| `JoinScene` DB error | Command errors; no `JoinFocus` call; user sees DB error. |
+| `JoinScene` OK, `JoinFocus` error | Command returns Error status with explicit retry instruction. DB retains participant row; user retry is idempotent. |
+| `JoinFocus` `FOCUS_ALREADY_MEMBER` | Treated as success; return OK to user. |
+| `LeaveScene` DB error (incl. owner-leave) | Command errors; no `LeaveFocus` called; no state changed. |
+| `LeaveScene` OK, `LeaveFocus` error | Log warn, return OK to user. Cosmetic stale membership. |
+| `EndScene` DB error | Command errors; no `LeaveFocus` called. |
+| `EndScene` OK, `LeaveFocus` error | Log warn, return OK. |
+| `PresentFocus` `FOCUS_NOT_MEMBER` | User-facing error with hint. |
+| `PresentFocus` other error | Command errors with generic message. |
+
+No compensating writes in any path. No panics. All error logs are `slog.WarnContext` with `session_id`, `scene_id`, and wrapped `err`.
+
+---
+
+## Section 5: Testing
+
+### 5.1 Unit tests — plugin command handlers
+
+Location: `plugins/core-scenes/commands_test.go` (extended).
+
+New tests, with a `fakeFocusClient` injected:
+
+| Test | Asserts |
+|---|---|
+| `TestSceneJoinCallsFocusClientJoinFocus` | `service.JoinScene` + `focusClient.JoinFocus` both called; OK returned. |
+| `TestSceneJoinPropagatesJoinSceneError` | DB error returns Error; `JoinFocus` NOT called. |
+| `TestSceneJoinHandlesJoinFocusError` | DB OK but `JoinFocus` err returns Error with retry hint. |
+| `TestSceneJoinTreatsFocusAlreadyMemberAsSuccess` | `FOCUS_ALREADY_MEMBER` → OK. |
+| `TestSceneLeaveCallsLeaveScene` | DB `LeaveScene` called first; if OK, `LeaveFocus` called. |
+| `TestSceneLeaveRejectsOwnerBeforeFocusChange` | Owner-leave DB error → `LeaveFocus` NOT called. |
+| `TestSceneLeaveToleratesLeaveFocusError` | DB OK + focus err → OK status + warn log. |
+| `TestSceneEndCallsLeaveFocusForOwner` | DB `EndScene` OK + `LeaveFocus` called with owner session. |
+| `TestSceneSwitchCallsPresentFocus` | Routes to `PresentFocus` with correct FocusKey. |
+| `TestSceneSwitchReturnsNotMemberError` | `FOCUS_NOT_MEMBER` → Error with usage hint. |
+| `TestSceneSwitchStrictArity` | Rejects empty and trailing-args inputs. |
+
+### 5.2 Integration / Phase 4 §7.2 acceptance tests
+
+Reachable at B10 scope (have a running substrate + scene plugin + telnet):
+
+| Test from spec §7.2 | In B10? | Location |
+|---|---|---|
+| `TestTelnetReconnectResumesSceneWithUnseenEvents` | ✓ | `test/integration/scenes/` |
+| `TestFocusSwitchCatchUpUsesBoundedIC` | ✓ | `test/integration/scenes/` |
+| `TestFocusSwitchSkipsHistoricalOOC` | ✓ | `test/integration/scenes/` |
+| `TestFocusSwitchHonorsPlayerPreference` | ✓ | `test/integration/scenes/` |
+| `TestLeaveFocusClearsPresentingWhenReferenced` | ✓ | `test/integration/scenes/` |
+| `TestFocusSwitchFallsBackToGameSetting` | covered by B6 coordinator tests | — |
+| `TestFocusSwitchClampsOutOfRange` | covered by B6 coordinator tests | — |
+| `TestMultiSceneMembershipReconnect` | ✓ stretch | `test/integration/scenes/` |
+| `TestPoseOrderConsistentAcrossAllParticipants` | ✗ — requires Phase 4 pose-order wiring, deferred to `holomush-5rh.13` |
+| `TestChannelJoinLiveOnlyAndHistoryDisplay` | ✗ — channels, deferred to B11 |
+
+Each integration test uses testcontainers Postgres, creates players +
+characters + a scene via the plugin host, sends commands through the
+telnet adapter, asserts event delivery (or non-delivery) on the expected
+streams.
+
+### 5.3 Test doubles
+
+New in `plugins/core-scenes/commands_test.go`:
+
+```go
+type fakeFocusClient struct {
+    joinCalls    []focusCall
+    leaveCalls   []focusCall
+    presentCalls []focusCall
+    joinErr      error
+    leaveErr     error
+    presentErr   error
+}
+
+type focusCall struct {
+    sessionID string
+    target    pluginsdk.FocusKey
+}
+
+func (f *fakeFocusClient) JoinFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+    f.joinCalls = append(f.joinCalls, focusCall{sid, t})
+    return f.joinErr
+}
+// ... LeaveFocus, PresentFocus, QueryStreamHistory analogous.
+```
+
+No SDK-level `FakeFocusClient` is published yet — plugin-local is
+sufficient. Promote to `pkg/plugin` only if B11 (channels) duplicates
+the fake (write-it-once-then-copy, hoist on third use).
+
+### 5.4 Non-regression
+
+- All existing `plugins/core-scenes/*_test.go` tests MUST continue to pass.
+- Existing `task pr-prep` gates (lint, fmt, license, unit, integration,
+  E2E) MUST pass.
+- Finding 1 cursor-lock tests and session-identity tests MUST NOT regress.
+
+---
+
+## Section 6: Known limitations / follow-ups
+
+### 6.1 EndScene multi-session fan-out
+
+**Issue.** When `scene end` executes, only the owner's session gets
+`LeaveFocus`. Other participant sessions retain a `FocusMembership` for
+the now-ended scene. The scene stops emitting IC events, so no stale
+delivery occurs, but the cursor table has a dangling row per stale
+membership.
+
+**Remedy.** A new host-side operation `LeaveFocusByTarget(FocusKey)` that
+sweeps all sessions whose `FocusMemberships` include the given key. This
+is a pure host operation (coordinator + session store); no plugin broker
+plumbing needed except exposing the RPC.
+
+**Work.** File a follow-up bead, P2, depends on `holomush-oy6e.10`:
+- Add `FocusCoordinator.LeaveFocusByTarget(ctx, target) (count int, err error)`.
+- Add `PluginHostService.LeaveFocusByTarget` RPC.
+- Extend SDK `FocusClient` with the new method.
+- Call from `core-scenes` `EndScene` after DB transition commits.
+
+### 6.2 Non-command scene API surface
+
+**Issue.** `SceneService.JoinScene` etc. take only `character_id`. Any
+future non-command caller (rich web client, admin tool) that needs to
+trigger focus mutations cannot do so through `SceneService` today.
+
+**Remedy when needed.** Add `session_id` + `player_session_token` to the
+specific RPC request, apply `auth.ValidateSessionOwnership` at the
+handler, then mirror the command-path focus wiring inside the service
+method. Matches PR #225's pattern.
+
+**Work.** No bead filed now — premature. File on demand.
+
+### 6.3 `scene switch` UX for non-member target
+
+**Issue.** Player types `scene switch 1064` having never joined scene
+1064. Gets `FOCUS_NOT_MEMBER` error with hint to `scene join` first.
+
+**Potential future UX.** Auto-join followed by switch. Not in scope;
+auto-join changes the operational semantics of `switch`. If desired,
+file a separate bead with explicit UX rationale.
+
+---
+
+## Section 7: Invariant coverage
+
+| Invariant | How B10 preserves |
+|---|---|
+| I-1 Focus Membership Uniqueness | `FOCUS_ALREADY_MEMBER` passthrough; no plugin-side duplicate attempt. |
+| I-4 Atomic Focus Transition | Coordinator owns atomicity; plugin makes a single RPC per operation. |
+| I-6 Server-Authoritative Mutation | Plugin never touches `session.FocusMemberships`; facade exposes no direct-mutation method. |
+| I-7 Plugin Declaration-Only API | `FocusClient` surface takes only `sessionID` + `FocusKey`; no cursors, no replay modes, no stream names. |
+| I-9 Kind-Policy Isolation | No scene-specific logic in the SDK facade; `FocusKind` enum is the only kind-parameter. |
+| I-13 Read-Only Plugin History Access | `QueryStreamHistory` returns events; plugin code does not advance cursors. |
+
+Invariants I-3, I-5, I-8, I-10, I-11, I-14, I-15 are host-side concerns
+covered by prior beads (B2, B4, B6, B7, B8). B10 does not affect them.
+
+---
+
+## Section 8: File-by-file change list
+
+### Added
+
+- `pkg/plugin/focus_client.go` — `FocusClient` interface, types, `FocusClientAware`, private impl.
+- `pkg/plugin/focus_client_test.go` — unit tests for impl (broker dial, error mapping).
+- `docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md` — this document.
+- `docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md` — implementation plan (next step via writing-plans).
+- `test/integration/scenes/focus_*_test.go` — Phase 4 acceptance tests.
+
+### Modified
+
+- `pkg/plugin/sdk.go` — `pluginServerAdapter.Init` detects `FocusClientAware`, injects client sharing the `EventSink` broker conn.
+- `pkg/plugin/event_sink.go` OR new shared helper — refactor broker-dial so `EventSink` and `FocusClient` share a single `*grpc.ClientConn`.
+- `plugins/core-scenes/main.go` — add `focusClient` field and `SetFocusClient` method.
+- `plugins/core-scenes/commands.go` — extend `dispatchCommand` with `switch` subcommand; update `handleJoin`, `handleLeave`, `handleEnd`, add `handleSwitch`.
+- `plugins/core-scenes/commands_test.go` — add `fakeFocusClient`, the 11 unit tests from §5.1.
+- `plugins/core-scenes/plugin.yaml` — (no changes expected; existing `execute-scene-commands` policy already permits all subcommands).
+- `site/docs/extending/binary-plugins.md` — document `FocusClient` facade and `FocusClientAware`.
+
+### Reserved / deliberate no-ops
+
+- `api/proto/holomush/scene/v1/scene.proto` — no change.
+- `api/proto/holomush/plugin/v1/hostfunc.proto` — no change.
+- `plugins/core-scenes/service.go` — no change (session-unaware).
+- `internal/core/` — no change (plugin boundary preserved).
+
+---
+
+## Section 9: Acceptance checklist
+
+- [ ] `pkg/plugin/focus_client.go` implements `FocusClient` over broker-dialed `PluginHostServiceClient` with typed error wrapping.
+- [ ] `pkg/plugin/sdk.go` injects `FocusClient` via `FocusClientAware.SetFocusClient` during `Init`.
+- [ ] `EventSink` and `FocusClient` share a single `grpc.ClientConn` in-process.
+- [ ] `plugins/core-scenes/main.go` implements `FocusClientAware`.
+- [ ] `plugins/core-scenes/commands.go`:
+    - [ ] `handleJoin` calls `service.JoinScene` then `focusClient.JoinFocus`.
+    - [ ] `handleLeave` calls `service.LeaveScene` then `focusClient.LeaveFocus`.
+    - [ ] `handleEnd` calls `service.EndScene` then `focusClient.LeaveFocus` for owner session.
+    - [ ] `handleSwitch` added, calls `focusClient.PresentFocus`.
+    - [ ] `dispatchCommand` switch and usage-help text updated for `switch`.
+- [ ] All 11 unit tests in §5.1 present and passing.
+- [ ] 5 Phase 4 §7.2 integration tests from §5.2 present and passing.
+- [ ] `task lint` clean.
+- [ ] `task pr-prep` clean.
+- [ ] `task lint:docs` clean.
+- [ ] `site/docs/extending/binary-plugins.md` updated.
+- [ ] Follow-up bead filed for `LeaveFocusByTarget` (§6.1).
+- [ ] PR reviewed via `pr-review-toolkit:review-pr`; all findings resolved.
+- [ ] Post-squash-merge reconciliation per epic §8.0 phase 5 discipline (`jj rebase -r <change-id> -d main --skip-emptied`).

--- a/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
+++ b/docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md
@@ -29,12 +29,12 @@ this document are to be interpreted as described in RFC 2119.
    existing `EventSink` facade.
 2. `core-scenes` command-path wiring — DB first, focus second, symmetric
    across all state-changing commands:
-    - `scene join <id>` → `service.JoinScene` (DB), then `focusClient.JoinFocus`.
-    - `scene leave <id>` → `service.LeaveScene` (DB), then `focusClient.LeaveFocus`.
-    - `scene end <id>` → `service.EndScene` (DB), then `focusClient.LeaveFocus`
-      for the calling (owner's) session.
-    - `scene switch <id>` — new subcommand — `focusClient.PresentFocus` (no DB
-      write).
+   - `scene join <id>` → `service.JoinScene` (DB), then `focusClient.JoinFocus`.
+   - `scene leave <id>` → `service.LeaveScene` (DB), then `focusClient.LeaveFocus`.
+   - `scene end <id>` → `service.EndScene` (DB), then `focusClient.LeaveFocus`
+     for the calling (owner's) session.
+   - `scene switch <id>` — new subcommand — `focusClient.PresentFocus` (no DB
+     write).
 3. Plugin-local test doubles for `FocusClient` (a `fakeFocusClient` parallel
    to the existing `fakeEventSink` pattern).
 4. The Phase 4 §7.2 acceptance tests that are reachable at B10 scope.
@@ -195,6 +195,7 @@ arriving at the plugin is therefore rigorously trusted as owned by the
 authenticated player. Scene plugin adoption rides on this.
 
 Adding `session_id` to scene proto requests now would:
+
 - Solve a non-problem (no current caller needs it).
 - Diverge from the established "external → HandleCommand" pattern.
 - Couple scene proto evolution to session-identity decisions.
@@ -212,7 +213,7 @@ that time; do not pre-wire.
 
 #### 3.2.1 `scene join <scene-id>`
 
-```
+```text
 handleJoin(ctx, req, args):
     service.JoinScene(ctx, {character_id: req.CharacterID, scene_id: id})
       ├── OK            → continue
@@ -231,6 +232,7 @@ handleJoin(ctx, req, args):
 **Failure-window analysis.** Between `service.JoinScene` success and
 `focusClient.JoinFocus` failure, the DB says the character is a scene
 member but the session has no `FocusMembership`. Consequences:
+
 - Pose events emitted on `scene:<id>:ic` are NOT delivered to this
   session (it's not subscribed).
 - Reconnect-restore does NOT heal the gap, because `RestoreFocus`
@@ -246,7 +248,7 @@ write is required.
 
 #### 3.2.2 `scene leave <scene-id>`
 
-```
+```text
 handleLeave(ctx, req, args):
     service.LeaveScene(ctx, {character_id: req.CharacterID, scene_id: id})
       ├── OK          → continue
@@ -277,7 +279,7 @@ handleLeave(ctx, req, args):
 
 #### 3.2.3 `scene end <scene-id>`
 
-```
+```text
 handleEnd(ctx, req, args):
     service.EndScene(ctx, {character_id, scene_id})
       └── error → return pluginsdk.Errorf(...)
@@ -292,7 +294,7 @@ participants are NOT fanned-out in B10; see §1.2 and §6.1.
 
 #### 3.2.4 `scene switch <scene-id>` — new subcommand
 
-```
+```text
 handleSwitch(ctx, req, args):
     focusClient.PresentFocus(ctx, req.SessionID, FocusKey{Kind: Scene, TargetID: id})
       ├── OK               → return OK("Switched to scene %s.", id)
@@ -396,8 +398,8 @@ Reachable at B10 scope (have a running substrate + scene plugin + telnet):
 | `TestFocusSwitchFallsBackToGameSetting` | covered by B6 coordinator tests | — |
 | `TestFocusSwitchClampsOutOfRange` | covered by B6 coordinator tests | — |
 | `TestMultiSceneMembershipReconnect` | ✓ stretch | `test/integration/scenes/` |
-| `TestPoseOrderConsistentAcrossAllParticipants` | ✗ — requires Phase 4 pose-order wiring, deferred to `holomush-5rh.13` |
-| `TestChannelJoinLiveOnlyAndHistoryDisplay` | ✗ — channels, deferred to B11 |
+| `TestPoseOrderConsistentAcrossAllParticipants` | ✗ — requires Phase 4 pose-order wiring, deferred to `holomush-5rh.13` |  |
+| `TestChannelJoinLiveOnlyAndHistoryDisplay` | ✗ — channels, deferred to B11 |  |
 
 Each integration test uses testcontainers Postgres, creates players +
 characters + a scene via the plugin host, sends commands through the
@@ -459,6 +461,7 @@ is a pure host operation (coordinator + session store); no plugin broker
 plumbing needed except exposing the RPC.
 
 **Work.** File a follow-up bead, P2, depends on `holomush-oy6e.10`:
+
 - Add `FocusCoordinator.LeaveFocusByTarget(ctx, target) (count int, err error)`.
 - Add `PluginHostService.LeaveFocusByTarget` RPC.
 - Extend SDK `FocusClient` with the new method.
@@ -540,11 +543,11 @@ covered by prior beads (B2, B4, B6, B7, B8). B10 does not affect them.
 - [ ] `EventSink` and `FocusClient` share a single `grpc.ClientConn` in-process.
 - [ ] `plugins/core-scenes/main.go` implements `FocusClientAware`.
 - [ ] `plugins/core-scenes/commands.go`:
-    - [ ] `handleJoin` calls `service.JoinScene` then `focusClient.JoinFocus`.
-    - [ ] `handleLeave` calls `service.LeaveScene` then `focusClient.LeaveFocus`.
-    - [ ] `handleEnd` calls `service.EndScene` then `focusClient.LeaveFocus` for owner session.
-    - [ ] `handleSwitch` added, calls `focusClient.PresentFocus`.
-    - [ ] `dispatchCommand` switch and usage-help text updated for `switch`.
+  - [ ] `handleJoin` calls `service.JoinScene` then `focusClient.JoinFocus`.
+  - [ ] `handleLeave` calls `service.LeaveScene` then `focusClient.LeaveFocus`.
+  - [ ] `handleEnd` calls `service.EndScene` then `focusClient.LeaveFocus` for owner session.
+  - [ ] `handleSwitch` added, calls `focusClient.PresentFocus`.
+  - [ ] `dispatchCommand` switch and usage-help text updated for `switch`.
 - [ ] All 11 unit tests in §5.1 present and passing.
 - [ ] 5 Phase 4 §7.2 integration tests from §5.2 present and passing.
 - [ ] `task lint` clean.

--- a/pkg/plugin/broker.go
+++ b/pkg/plugin/broker.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/samber/oops"
+	"google.golang.org/grpc"
 )
 
 const brokerPrefix = "broker:"
@@ -47,4 +50,24 @@ func BrokerServiceID(services map[string]string, serviceName string) (uint32, er
 		return 0, fmt.Errorf("service %q not found in required services", serviceName)
 	}
 	return id, nil
+}
+
+// dialPluginHost dials the plugin host service via the given broker and
+// returns a *grpc.ClientConn. Callers wrap the conn in service-specific
+// clients (EventSink, FocusClient). This helper exists so a single
+// plugin process holds one connection to the host for all host-facing
+// SDK facades.
+func dialPluginHost(broker brokerDialer, services map[string]string) (*grpc.ClientConn, error) {
+	if broker == nil {
+		return nil, oops.New("plugin host broker is not configured")
+	}
+	brokerID, err := BrokerServiceID(services, PluginHostServiceName)
+	if err != nil {
+		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
+	}
+	conn, err := broker.DialWithOptions(brokerID, grpc.WithAuthority("holomush-plugin-host"))
+	if err != nil {
+		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
+	}
+	return conn, nil
 }

--- a/pkg/plugin/event_sink.go
+++ b/pkg/plugin/event_sink.go
@@ -54,13 +54,9 @@ func newEventSinkFromBroker(broker brokerDialer, services map[string]string) (Ev
 	if broker == nil {
 		return nil, oops.New("plugin host broker is not configured")
 	}
-	brokerID, err := BrokerServiceID(services, PluginHostServiceName)
+	conn, err := dialPluginHost(broker, services)
 	if err != nil {
-		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
-	}
-	conn, err := broker.DialWithOptions(brokerID, grpc.WithAuthority("holomush-plugin-host"))
-	if err != nil {
-		return nil, oops.With("service", PluginHostServiceName).Wrap(err)
+		return nil, err
 	}
 	return &pluginHostEventSink{
 		client: pluginv1.NewPluginHostServiceClient(conn),

--- a/pkg/plugin/focus_client.go
+++ b/pkg/plugin/focus_client.go
@@ -135,11 +135,13 @@ func (c *pluginHostFocusClient) PresentFocus(ctx context.Context, sessionID stri
 	return wrapFocusError(err, "PresentFocus", sessionID, target)
 }
 
-// queryStreamHistoryCountMax matches the host-side clamp cap at 500. The
-// client does not enforce the clamp — the host does — but defensive bounds
-// keep int→int32 conversion safe even if a caller passes pathological
-// values.
-const queryStreamHistoryCountMax int32 = 1 << 30
+// queryStreamHistoryCountConversionMax is only a defensive int32 conversion
+// bound — it keeps pathological int inputs (negative overflow or values
+// larger than math.MaxInt32) from producing garbage on the wire. The
+// host applies the semantic 500-event clamp; this client does NOT attempt
+// to mirror that, intentionally, so the host remains the single source
+// of truth for the cap.
+const queryStreamHistoryCountConversionMax int32 = 1 << 30
 
 func (c *pluginHostFocusClient) QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error) {
 	if c.client == nil {
@@ -153,8 +155,8 @@ func (c *pluginHostFocusClient) QueryStreamHistory(ctx context.Context, req Quer
 	switch {
 	case req.Count < 0:
 		count = 0
-	case int64(req.Count) > int64(queryStreamHistoryCountMax):
-		count = queryStreamHistoryCountMax
+	case int64(req.Count) > int64(queryStreamHistoryCountConversionMax):
+		count = queryStreamHistoryCountConversionMax
 	default:
 		count = int32(req.Count) // bounds-checked above
 	}

--- a/pkg/plugin/focus_client.go
+++ b/pkg/plugin/focus_client.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/oops"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// FocusClient is the SDK-facing facade binary-plugin code uses to drive the
+// server-owned focus substrate on behalf of a session. All calls cross the
+// plugin broker (mTLS) to the host's PluginHostService.
+//
+// See docs/superpowers/specs/2026-04-11-focus-substrate-design.md §3.4 for
+// the host-side interface this wraps, and §4.3/4.4/4.5 for transition
+// semantics. Plugins MUST NOT mutate session.FocusMemberships directly
+// (invariant I-6); all mutations flow through this interface.
+type FocusClient interface {
+	// JoinFocus adds a focus membership and applies the kind-specific
+	// server-owned replay policy. Callers provide the target (kind + id);
+	// the server determines streams, replay mode, cursor baselines, and
+	// subscription updates. Callers MUST NOT declare replay mode or stream
+	// names (invariant I-7).
+	JoinFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// LeaveFocus removes a focus membership. Idempotent on non-member.
+	LeaveFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// PresentFocus updates the session's presenting-focus pointer. Target
+	// MUST already exist in the session's FocusMemberships.
+	PresentFocus(ctx context.Context, sessionID string, target FocusKey) error
+
+	// QueryStreamHistory reads the tail of a stream for plugin-side display.
+	// Read-only (I-13): does not mutate cursors, subscriptions, or session
+	// state. The host clamps Count server-side at 500.
+	QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error)
+}
+
+// FocusKey identifies a focus membership within a session.
+type FocusKey struct {
+	Kind     FocusKind
+	TargetID string
+}
+
+// FocusKind enumerates the kinds of focused contexts. Mirrors
+// session.FocusKind on the host side; the SDK re-declares the enum so
+// plugins do not take a dependency on internal/ packages.
+type FocusKind string
+
+const (
+	// FocusKindScene marks a scene membership. The ScenePolicy on the
+	// host derives streams "scene:<target_id>:ic" and "scene:<target_id>:ooc".
+	FocusKindScene FocusKind = "scene"
+)
+
+// QueryStreamHistoryRequest describes a bounded tail read.
+type QueryStreamHistoryRequest struct {
+	Stream    string
+	Count     int       // server clamps to 500
+	NotBefore time.Time // zero means no time floor
+}
+
+// FocusClientAware is the optional interface service providers implement to
+// receive a FocusClient during Init, parallel to EventSinkAware.
+type FocusClientAware interface {
+	SetFocusClient(FocusClient)
+}
+
+// pluginHostFocusClient is the broker-backed FocusClient implementation.
+type pluginHostFocusClient struct {
+	client pluginv1.PluginHostServiceClient
+}
+
+// newPluginHostFocusClient constructs a FocusClient wrapping the given
+// PluginHostServiceClient. Exposed to the adapter for wiring; test code
+// constructs a pluginHostFocusClient directly.
+func newPluginHostFocusClient(client pluginv1.PluginHostServiceClient) FocusClient {
+	return &pluginHostFocusClient{client: client}
+}
+
+func toProtoFocusKind(k FocusKind) pluginv1.FocusKind {
+	switch k {
+	case FocusKindScene:
+		return pluginv1.FocusKind_FOCUS_KIND_SCENE
+	default:
+		return pluginv1.FocusKind_FOCUS_KIND_UNSPECIFIED
+	}
+}
+
+func toProtoFocusKey(key FocusKey) *pluginv1.FocusKey {
+	return &pluginv1.FocusKey{
+		Kind:     toProtoFocusKind(key.Kind),
+		TargetId: key.TargetID,
+	}
+}
+
+func (c *pluginHostFocusClient) JoinFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.JoinFocus(ctx, &pluginv1.PluginHostServiceJoinFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "JoinFocus", sessionID, target)
+}
+
+func (c *pluginHostFocusClient) LeaveFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.LeaveFocus(ctx, &pluginv1.PluginHostServiceLeaveFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "LeaveFocus", sessionID, target)
+}
+
+func (c *pluginHostFocusClient) PresentFocus(ctx context.Context, sessionID string, target FocusKey) error {
+	if c.client == nil {
+		return oops.New("plugin host focus client is not configured")
+	}
+	_, err := c.client.PresentFocus(ctx, &pluginv1.PluginHostServicePresentFocusRequest{
+		SessionId: sessionID,
+		Target:    toProtoFocusKey(target),
+	})
+	return wrapFocusError(err, "PresentFocus", sessionID, target)
+}
+
+// queryStreamHistoryCountMax matches the host-side clamp cap at 500. The
+// client does not enforce the clamp — the host does — but defensive bounds
+// keep int→int32 conversion safe even if a caller passes pathological
+// values.
+const queryStreamHistoryCountMax int32 = 1 << 30
+
+func (c *pluginHostFocusClient) QueryStreamHistory(ctx context.Context, req QueryStreamHistoryRequest) ([]Event, error) {
+	if c.client == nil {
+		return nil, oops.New("plugin host focus client is not configured")
+	}
+	var notBeforeMs int64
+	if !req.NotBefore.IsZero() {
+		notBeforeMs = req.NotBefore.UnixMilli()
+	}
+	var count int32
+	switch {
+	case req.Count < 0:
+		count = 0
+	case int64(req.Count) > int64(queryStreamHistoryCountMax):
+		count = queryStreamHistoryCountMax
+	default:
+		count = int32(req.Count) // bounds-checked above
+	}
+	resp, err := c.client.QueryStreamHistory(ctx, &pluginv1.PluginHostServiceQueryStreamHistoryRequest{
+		Stream:      req.Stream,
+		Count:       count,
+		NotBeforeMs: notBeforeMs,
+	})
+	if err != nil {
+		return nil, oops.With("stream", req.Stream).Wrap(err)
+	}
+	events := make([]Event, 0, len(resp.GetEvents()))
+	for _, e := range resp.GetEvents() {
+		events = append(events, Event{
+			ID:        e.GetId(),
+			Stream:    e.GetStream(),
+			Type:      EventType(e.GetType()),
+			Timestamp: e.GetTimestamp(),
+			ActorKind: protoActorKindToActorKind(e.GetActorKind()),
+			ActorID:   e.GetActorId(),
+			Payload:   e.GetPayload(),
+		})
+	}
+	return events, nil
+}
+
+// wrapFocusError maps gRPC codes returned by the host's focus RPCs into
+// oops-coded errors that callers can switch on via errors.As + oe.Code().
+// Unknown codes pass through with a generic wrap.
+func wrapFocusError(err error, op, sessionID string, target FocusKey) error {
+	if err == nil {
+		return nil
+	}
+	base := oops.With("operation", op).
+		With("session_id", sessionID).
+		With("focus_kind", string(target.Kind)).
+		With("target_id", target.TargetID)
+	st, ok := status.FromError(err)
+	if !ok {
+		return base.Wrap(err)
+	}
+	code := codeFromStatus(st)
+	if code == "" {
+		return base.Wrap(err)
+	}
+	return base.Code(code).Wrap(err)
+}
+
+// focusErrorCodePrefixes enumerates the recognized oops codes the host
+// prepends to its gRPC status messages for focus RPCs.
+var focusErrorCodePrefixes = []string{
+	"SESSION_NOT_FOUND",
+	"SESSION_EXPIRED",
+	"FOCUS_ALREADY_MEMBER",
+	"FOCUS_KIND_UNREGISTERED",
+	"FOCUS_POLICY_FAILED",
+	"FOCUS_NOT_MEMBER",
+}
+
+// codeFromStatus returns the expected oops code for a gRPC status, or ""
+// if the code-message pair does not match a known focus-RPC error. The
+// host stamps the oops code as a "CODE: ..." prefix on the status message;
+// this function detects it and falls back to gRPC code mapping only when
+// the prefix is absent.
+func codeFromStatus(st *status.Status) string {
+	msg := st.Message()
+	for _, c := range focusErrorCodePrefixes {
+		if len(msg) >= len(c) && msg[:len(c)] == c {
+			return c
+		}
+	}
+	switch st.Code() {
+	case codes.NotFound:
+		return "SESSION_NOT_FOUND"
+	case codes.AlreadyExists:
+		return "FOCUS_ALREADY_MEMBER"
+	case codes.FailedPrecondition:
+		return "SESSION_EXPIRED"
+	case codes.InvalidArgument:
+		return "FOCUS_KIND_UNREGISTERED"
+	case codes.Internal:
+		return "FOCUS_POLICY_FAILED"
+	}
+	return ""
+}
+
+// newFocusClientFromBroker dials the plugin host service via the broker
+// and returns a FocusClient. See broker.go for the shared dial helper.
+func newFocusClientFromBroker(broker brokerDialer, services map[string]string) (FocusClient, error) {
+	if broker == nil {
+		return nil, oops.New("plugin host broker is not configured")
+	}
+	conn, err := dialPluginHost(broker, services)
+	if err != nil {
+		return nil, err
+	}
+	return newPluginHostFocusClient(pluginv1.NewPluginHostServiceClient(conn)), nil
+}

--- a/pkg/plugin/focus_client.go
+++ b/pkg/plugin/focus_client.go
@@ -5,6 +5,7 @@ package pluginsdk
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/samber/oops"
@@ -221,7 +222,10 @@ var focusErrorCodePrefixes = []string{
 func codeFromStatus(st *status.Status) string {
 	msg := st.Message()
 	for _, c := range focusErrorCodePrefixes {
-		if len(msg) >= len(c) && msg[:len(c)] == c {
+		// Require the ':' delimiter the host stamps, or an exact match.
+		// A plain prefix match would bind a future code like
+		// FOCUS_NOT_MEMBER_EXTRA to FOCUS_NOT_MEMBER silently.
+		if msg == c || strings.HasPrefix(msg, c+":") {
 			return c
 		}
 	}

--- a/pkg/plugin/focus_client_test.go
+++ b/pkg/plugin/focus_client_test.go
@@ -5,6 +5,8 @@ package pluginsdk
 
 import (
 	"context"
+	"errors"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -139,6 +141,221 @@ func TestNewFocusClientFromBroker_MissingHostService(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, c)
 	assert.Contains(t, err.Error(), PluginHostServiceName)
+}
+
+// --- Group A: nil-client guards for LeaveFocus, PresentFocus, QueryStreamHistory ---
+
+func TestPluginHostFocusClient_LeaveFocusNilClientReturnsError(t *testing.T) {
+	client := &pluginHostFocusClient{}
+	err := client.LeaveFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestPluginHostFocusClient_PresentFocusNilClientReturnsError(t *testing.T) {
+	client := &pluginHostFocusClient{}
+	err := client.PresentFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestPluginHostFocusClient_QueryStreamHistoryNilClientReturnsError(t *testing.T) {
+	client := &pluginHostFocusClient{}
+	events, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{Stream: "scene:1:ic", Count: 5})
+	require.Error(t, err)
+	assert.Nil(t, events)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+// --- Group A: QueryStreamHistory count clamping ---
+
+func TestPluginHostFocusClient_QueryStreamHistoryClampsNegativeCount(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	_, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream: "scene:1:ic",
+		Count:  -5,
+	})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.historyReqs, 1)
+	assert.Equal(t, int32(0), srv.historyReqs[0].GetCount())
+}
+
+func TestPluginHostFocusClient_QueryStreamHistoryClampsOverflow(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	_, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream: "scene:1:ic",
+		Count:  math.MaxInt,
+	})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.historyReqs, 1)
+	assert.Equal(t, int32(1<<30), srv.historyReqs[0].GetCount())
+}
+
+func TestPluginHostFocusClient_QueryStreamHistoryPropagatesHostError(t *testing.T) {
+	srv := &focusTestServer{historyErr: status.Error(codes.Internal, "storage failure")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	events, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream: "scene:1:ic",
+		Count:  5,
+	})
+	require.Error(t, err)
+	assert.Nil(t, events)
+	// The stream name is attached as oops context, not embedded in the message string.
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "scene:1:ic", oe.Context()["stream"])
+}
+
+// --- Group A: wrapFocusError unit tests ---
+
+func TestWrapFocusErrorNilErrorReturnsNil(t *testing.T) {
+	err := wrapFocusError(nil, "JoinFocus", "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	assert.NoError(t, err)
+}
+
+func TestWrapFocusErrorNonStatusErrorPassesThrough(t *testing.T) {
+	plain := errors.New("boom")
+	err := wrapFocusError(plain, "JoinFocus", "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	// Non-status errors get context wrapping but no oops code (Code() returns nil).
+	assert.Nil(t, oe.Code())
+}
+
+// --- Group A: codeFromStatus gRPC-code fallbacks ---
+
+func TestCodeFromStatus_AllGRPCCodeFallbacks(t *testing.T) {
+	tests := []struct {
+		name         string
+		grpcCode     codes.Code
+		message      string
+		expectedCode string
+	}{
+		{
+			name:         "NotFound without prefix falls back to SESSION_NOT_FOUND",
+			grpcCode:     codes.NotFound,
+			message:      "generic not found",
+			expectedCode: "SESSION_NOT_FOUND",
+		},
+		{
+			name:         "AlreadyExists without prefix falls back to FOCUS_ALREADY_MEMBER",
+			grpcCode:     codes.AlreadyExists,
+			message:      "generic already exists",
+			expectedCode: "FOCUS_ALREADY_MEMBER",
+		},
+		{
+			name:         "FailedPrecondition without prefix falls back to SESSION_EXPIRED",
+			grpcCode:     codes.FailedPrecondition,
+			message:      "generic precondition",
+			expectedCode: "SESSION_EXPIRED",
+		},
+		{
+			name:         "InvalidArgument without prefix falls back to FOCUS_KIND_UNREGISTERED",
+			grpcCode:     codes.InvalidArgument,
+			message:      "generic invalid",
+			expectedCode: "FOCUS_KIND_UNREGISTERED",
+		},
+		{
+			name:         "Internal without prefix falls back to FOCUS_POLICY_FAILED",
+			grpcCode:     codes.Internal,
+			message:      "generic internal",
+			expectedCode: "FOCUS_POLICY_FAILED",
+		},
+		{
+			name:         "Unavailable without prefix returns empty code",
+			grpcCode:     codes.Unavailable,
+			message:      "generic unavailable",
+			expectedCode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := status.New(tt.grpcCode, tt.message)
+			got := codeFromStatus(st)
+			assert.Equal(t, tt.expectedCode, got)
+		})
+	}
+}
+
+// --- Group A: JoinFocus gRPC-code mappings (FailedPrecondition, InvalidArgument, Internal) ---
+
+func TestPluginHostFocusClient_JoinFocusMapsSessionExpired(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.FailedPrecondition, "SESSION_EXPIRED: ttl elapsed")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "SESSION_EXPIRED", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusMapsFocusKindUnregistered(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.InvalidArgument, "FOCUS_KIND_UNREGISTERED: no policy")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_KIND_UNREGISTERED", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusMapsFocusPolicyFailed(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.Internal, "FOCUS_POLICY_FAILED: rejected")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_POLICY_FAILED", oe.Code())
+}
+
+// --- Group A: toProtoFocusKind unknown kind ---
+
+func TestToProtoFocusKindUnknownReturnsUnspecified(t *testing.T) {
+	// Exercise toProtoFocusKind indirectly: pass an unknown FocusKind to JoinFocus
+	// and verify the server received FOCUS_KIND_UNSPECIFIED.
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	_ = client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKind("nonexistent"), TargetID: "target-1"})
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.joinReqs, 1)
+	assert.Equal(t, pluginv1.FocusKind_FOCUS_KIND_UNSPECIFIED, srv.joinReqs[0].GetTarget().GetKind())
+}
+
+// --- Group B: newFocusClientFromBroker dial failure ---
+
+func TestNewFocusClientFromBroker_DialFailureWrapsError(t *testing.T) {
+	// testBrokerDialer has no entry for the requested broker ID; dial will fail.
+	c, err := newFocusClientFromBroker(&testBrokerDialer{}, map[string]string{
+		PluginHostServiceName: "broker:99",
+	})
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "unknown broker id")
 }
 
 func TestQueryStreamHistoryRequestNotBeforeIsPassedThrough(t *testing.T) {

--- a/pkg/plugin/focus_client_test.go
+++ b/pkg/plugin/focus_client_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// --- compile-time interface checks ---
+
+func TestFocusClient_InterfaceShape(_ *testing.T) {
+	var _ FocusClient = (*pluginHostFocusClient)(nil)
+}
+
+// --- error mapping ---
+
+func TestPluginHostFocusClient_JoinFocusMapsSessionNotFound(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.NotFound, "SESSION_NOT_FOUND: missing")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "SESSION_NOT_FOUND", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusMapsAlreadyMember(t *testing.T) {
+	srv := &focusTestServer{joinErr: status.Error(codes.AlreadyExists, "FOCUS_ALREADY_MEMBER: duplicate")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_ALREADY_MEMBER", oe.Code())
+}
+
+func TestPluginHostFocusClient_PresentFocusMapsNotMember(t *testing.T) {
+	srv := &focusTestServer{presentErr: status.Error(codes.NotFound, "FOCUS_NOT_MEMBER: not joined")}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.PresentFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	var oe oops.OopsError
+	require.ErrorAs(t, err, &oe)
+	assert.Equal(t, "FOCUS_NOT_MEMBER", oe.Code())
+}
+
+func TestPluginHostFocusClient_JoinFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.joinReqs, 1)
+	assert.Equal(t, "sess-1", srv.joinReqs[0].GetSessionId())
+	assert.Equal(t, "scene-1", srv.joinReqs[0].GetTarget().GetTargetId())
+	assert.Equal(t, pluginv1.FocusKind_FOCUS_KIND_SCENE, srv.joinReqs[0].GetTarget().GetKind())
+}
+
+func TestPluginHostFocusClient_LeaveFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.LeaveFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.leaveReqs, 1)
+	assert.Equal(t, "sess-1", srv.leaveReqs[0].GetSessionId())
+}
+
+func TestPluginHostFocusClient_PresentFocusHappyPath(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	err := client.PresentFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.presentReqs, 1)
+}
+
+func TestPluginHostFocusClient_QueryStreamHistoryHappyPath(t *testing.T) {
+	wantEvt := &pluginv1.Event{Id: "01EVT", Stream: "scene:1:ic", Type: "say", Payload: `{"m":"hi"}`}
+	srv := &focusTestServer{historyResp: &pluginv1.PluginHostServiceQueryStreamHistoryResponse{Events: []*pluginv1.Event{wantEvt}}}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	events, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream: "scene:1:ic",
+		Count:  10,
+	})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "01EVT", events[0].ID)
+	assert.Equal(t, "scene:1:ic", events[0].Stream)
+	assert.Equal(t, EventType("say"), events[0].Type)
+	assert.Equal(t, `{"m":"hi"}`, events[0].Payload)
+}
+
+func TestPluginHostFocusClient_NilClientReturnsError(t *testing.T) {
+	client := &pluginHostFocusClient{}
+	err := client.JoinFocus(context.Background(), "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestNewFocusClientFromBroker_MissingBroker(t *testing.T) {
+	c, err := newFocusClientFromBroker(nil, map[string]string{PluginHostServiceName: "broker:7"})
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "broker is not configured")
+}
+
+func TestNewFocusClientFromBroker_MissingHostService(t *testing.T) {
+	c, err := newFocusClientFromBroker(&testBrokerDialer{}, map[string]string{})
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), PluginHostServiceName)
+}
+
+func TestQueryStreamHistoryRequestNotBeforeIsPassedThrough(t *testing.T) {
+	srv := &focusTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &pluginHostFocusClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	notBefore := time.UnixMilli(1_700_000_000_000)
+	_, err := client.QueryStreamHistory(context.Background(), QueryStreamHistoryRequest{
+		Stream:    "scene:1:ic",
+		Count:     5,
+		NotBefore: notBefore,
+	})
+	require.NoError(t, err)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.historyReqs, 1)
+	assert.Equal(t, int64(1_700_000_000_000), srv.historyReqs[0].GetNotBeforeMs())
+}
+
+// --- test double: PluginHostService with per-RPC hooks ---
+
+type focusTestServer struct {
+	pluginv1.UnimplementedPluginHostServiceServer
+	mu          sync.Mutex
+	joinReqs    []*pluginv1.PluginHostServiceJoinFocusRequest
+	leaveReqs   []*pluginv1.PluginHostServiceLeaveFocusRequest
+	presentReqs []*pluginv1.PluginHostServicePresentFocusRequest
+	historyReqs []*pluginv1.PluginHostServiceQueryStreamHistoryRequest
+
+	joinErr     error
+	leaveErr    error
+	presentErr  error
+	historyResp *pluginv1.PluginHostServiceQueryStreamHistoryResponse
+	historyErr  error
+}
+
+func (s *focusTestServer) JoinFocus(_ context.Context, req *pluginv1.PluginHostServiceJoinFocusRequest) (*pluginv1.PluginHostServiceJoinFocusResponse, error) {
+	s.mu.Lock()
+	s.joinReqs = append(s.joinReqs, req)
+	s.mu.Unlock()
+	if s.joinErr != nil {
+		return nil, s.joinErr
+	}
+	return &pluginv1.PluginHostServiceJoinFocusResponse{}, nil
+}
+
+func (s *focusTestServer) LeaveFocus(_ context.Context, req *pluginv1.PluginHostServiceLeaveFocusRequest) (*pluginv1.PluginHostServiceLeaveFocusResponse, error) {
+	s.mu.Lock()
+	s.leaveReqs = append(s.leaveReqs, req)
+	s.mu.Unlock()
+	if s.leaveErr != nil {
+		return nil, s.leaveErr
+	}
+	return &pluginv1.PluginHostServiceLeaveFocusResponse{}, nil
+}
+
+func (s *focusTestServer) PresentFocus(_ context.Context, req *pluginv1.PluginHostServicePresentFocusRequest) (*pluginv1.PluginHostServicePresentFocusResponse, error) {
+	s.mu.Lock()
+	s.presentReqs = append(s.presentReqs, req)
+	s.mu.Unlock()
+	if s.presentErr != nil {
+		return nil, s.presentErr
+	}
+	return &pluginv1.PluginHostServicePresentFocusResponse{}, nil
+}
+
+func (s *focusTestServer) QueryStreamHistory(_ context.Context, req *pluginv1.PluginHostServiceQueryStreamHistoryRequest) (*pluginv1.PluginHostServiceQueryStreamHistoryResponse, error) {
+	s.mu.Lock()
+	s.historyReqs = append(s.historyReqs, req)
+	s.mu.Unlock()
+	if s.historyErr != nil {
+		return nil, s.historyErr
+	}
+	if s.historyResp != nil {
+		return s.historyResp, nil
+	}
+	return &pluginv1.PluginHostServiceQueryStreamHistoryResponse{}, nil
+}

--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -138,22 +138,49 @@ type pluginServerAdapter struct {
 
 // Init implements pluginv1.PluginServiceServer. When a ServiceProvider is set,
 // it delegates to the provider's Init; otherwise it returns an empty response.
+//
+// Before delegating to the provider, Init optionally injects host-facing SDK
+// facades based on which optional interfaces the provider implements:
+//
+//   - EventSinkAware  -> provider.SetEventSink(...)
+//   - FocusClientAware -> provider.SetFocusClient(...)
+//
+// To avoid opening one broker connection per facade, Init dials the plugin
+// host exactly once and shares that *grpc.ClientConn across every facade
+// the provider consents to receive. A plugin that opts into neither
+// interface pays no connection cost.
 func (a *pluginServerAdapter) Init(ctx context.Context, req *pluginv1.InitRequest) (*pluginv1.InitResponse, error) {
 	var config *pluginv1.ServiceConfig
 	if req != nil {
 		config = req.GetConfig()
 	}
-	if sinkAware, ok := a.serviceProvider.(EventSinkAware); ok {
+
+	_, wantsSink := a.serviceProvider.(EventSinkAware)
+	_, wantsFocus := a.serviceProvider.(FocusClientAware)
+
+	// Lazily dial a single plugin-host gRPC connection shared by every
+	// host-facing SDK facade the provider opts into. If the provider opts
+	// into none, we never dial.
+	var hostClient pluginv1.PluginHostServiceClient
+	if wantsSink || wantsFocus {
 		requiredServices := map[string]string(nil)
 		if config != nil {
 			requiredServices = config.GetRequiredServices()
 		}
-		sink, err := newEventSinkFromBroker(a.brokerDialer, requiredServices)
+		conn, err := dialPluginHost(a.brokerDialer, requiredServices)
 		if err != nil {
 			return nil, oops.With("phase", "init").With("service", PluginHostServiceName).Wrap(err)
 		}
-		sinkAware.SetEventSink(sink)
+		hostClient = pluginv1.NewPluginHostServiceClient(conn)
 	}
+
+	if sinkAware, ok := a.serviceProvider.(EventSinkAware); ok {
+		sinkAware.SetEventSink(&pluginHostEventSink{client: hostClient})
+	}
+	if focusAware, ok := a.serviceProvider.(FocusClientAware); ok {
+		focusAware.SetFocusClient(newPluginHostFocusClient(hostClient))
+	}
+
 	if a.serviceProvider == nil {
 		return &pluginv1.InitResponse{}, nil
 	}

--- a/pkg/plugin/service_test.go
+++ b/pkg/plugin/service_test.go
@@ -465,7 +465,7 @@ func startPluginHostServiceTestServer(t *testing.T, srv pluginv1.PluginHostServi
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return listener.Dial()
 		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(insecure.NewCredentials()), // nosemgrep: go.grpc.tls.grpc-client-new-insecure-connection.grpc-client-new-insecure-connection -- bufconn test client
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
@@ -479,4 +479,89 @@ type testFullAdapterHandler struct {
 
 func (h *testFullAdapterHandler) HandleCommand(_ context.Context, req CommandRequest) (*CommandResponse, error) {
 	return OK("handled: " + req.Command), nil
+}
+
+// --- FocusClient injection ---
+
+type focusClientInitProvider struct {
+	initCalled  bool
+	focusClient FocusClient
+}
+
+func (p *focusClientInitProvider) RegisterServices(_ grpc.ServiceRegistrar) {}
+
+func (p *focusClientInitProvider) Init(ctx context.Context, _ *pluginv1.ServiceConfig) error {
+	p.initCalled = true
+	if p.focusClient == nil {
+		return errors.New("focus client not injected")
+	}
+	// Exercise the injected client to prove it reaches the host.
+	return p.focusClient.JoinFocus(ctx, "sess-1", FocusKey{Kind: FocusKindScene, TargetID: "scene-1"})
+}
+
+func (p *focusClientInitProvider) SetFocusClient(client FocusClient) {
+	p.focusClient = client
+}
+
+func TestPluginServerAdapterInitInjectsFocusClientIntoServiceProvider(t *testing.T) {
+	srv := &focusTestServer{}
+	hostConn := startPluginHostServiceTestServer(t, srv)
+
+	provider := &focusClientInitProvider{}
+	adapter := &pluginServerAdapter{
+		handler:         &adapterTestHandler{},
+		serviceProvider: provider,
+		brokerDialer: &testBrokerDialer{
+			conns: map[uint32]*grpc.ClientConn{7: hostConn},
+		},
+	}
+
+	_, err := adapter.Init(context.Background(), &pluginv1.InitRequest{
+		Config: &pluginv1.ServiceConfig{
+			RequiredServices: map[string]string{
+				PluginHostServiceName: "broker:7",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, provider.initCalled, "expected provider.Init to run")
+	require.NotNil(t, provider.focusClient, "expected FocusClient to be injected")
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	require.Len(t, srv.joinReqs, 1, "expected the injected client's JoinFocus call to reach the host")
+	assert.Equal(t, "sess-1", srv.joinReqs[0].GetSessionId())
+}
+
+type dualAwareProvider struct {
+	focusClient FocusClient
+	sink        EventSink
+}
+
+func (p *dualAwareProvider) RegisterServices(_ grpc.ServiceRegistrar)                {}
+func (p *dualAwareProvider) Init(_ context.Context, _ *pluginv1.ServiceConfig) error { return nil }
+func (p *dualAwareProvider) SetEventSink(s EventSink)                                { p.sink = s }
+func (p *dualAwareProvider) SetFocusClient(c FocusClient)                            { p.focusClient = c }
+
+func TestPluginServerAdapterInitInjectsBothEventSinkAndFocusClient(t *testing.T) {
+	hostConn := startPluginHostServiceTestServer(t, &focusTestServer{})
+
+	provider := &dualAwareProvider{}
+	adapter := &pluginServerAdapter{
+		handler:         &adapterTestHandler{},
+		serviceProvider: provider,
+		brokerDialer: &testBrokerDialer{
+			conns: map[uint32]*grpc.ClientConn{7: hostConn},
+		},
+	}
+
+	_, err := adapter.Init(context.Background(), &pluginv1.InitRequest{
+		Config: &pluginv1.ServiceConfig{
+			RequiredServices: map[string]string{
+				PluginHostServiceName: "broker:7",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, provider.sink, "expected EventSink injection")
+	assert.NotNil(t, provider.focusClient, "expected FocusClient injection")
 }

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -321,14 +321,18 @@ func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandReque
 	}
 
 	if p.focusClient == nil {
+		// Misconfiguration, not a transient error: retries will hit the
+		// same nil guard. Surface the operator-action hint rather than the
+		// user-retry hint used for transient JoinFocus failures below.
 		slog.WarnContext(ctx, "scene.command.join focus client not configured; subscription not updated",
 			"subject_id", req.CharacterID,
 			"session_id", req.SessionID,
 			"scene_id", sceneID,
 		)
 		return pluginsdk.Errorf(
-			"Joined scene in database, but your session could not subscribe (focus client not configured). "+
-				"Please retry `scene join %s`.", sceneID), nil
+			"Joined scene in database, but your session could not subscribe " +
+				"(focus client not configured — this is a server configuration error, " +
+				"please contact an administrator)."), nil
 	}
 
 	err := p.focusClient.JoinFocus(ctx, req.SessionID, pluginsdk.FocusKey{

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -5,9 +5,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
+	"github.com/samber/oops"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -34,7 +37,7 @@ func (p *scenePlugin) dispatchCommand(ctx context.Context, req pluginsdk.Command
 	span.SetAttributes(attribute.String("subcommand", sub))
 
 	if sub == "" {
-		return pluginsdk.Errorf("Usage: scene <subcommand> [args]\nKnown subcommands: create, info, end, pause, resume, set, join, leave, invite, kick, transfer"), nil
+		return pluginsdk.Errorf("Usage: scene <subcommand> [args]\nKnown subcommands: create, end, info, invite, join, kick, leave, pause, resume, set, switch, transfer"), nil
 	}
 
 	switch sub {
@@ -60,8 +63,10 @@ func (p *scenePlugin) dispatchCommand(ctx context.Context, req pluginsdk.Command
 		return p.handleKick(ctx, req, rest)
 	case "transfer":
 		return p.handleTransfer(ctx, req, rest)
+	case "switch":
+		return p.handleSwitch(ctx, req, rest)
 	default:
-		return pluginsdk.Errorf("Unknown scene subcommand %q. Known subcommands: create, info, end, pause, resume, set, join, leave, invite, kick, transfer.", sub), nil
+		return pluginsdk.Errorf("Unknown scene subcommand %q. Known subcommands: create, end, info, invite, join, kick, leave, pause, resume, set, switch, transfer.", sub), nil
 	}
 }
 
@@ -132,7 +137,9 @@ func (p *scenePlugin) handleInfo(ctx context.Context, req pluginsdk.CommandReque
 // handleEnd ends the specified scene. Owner ABAC enforcement is gateway-side
 // (the host's ABAC engine evaluates end-own-scene before this code runs in
 // production); in unit tests, ABAC is bypassed so the test must use the
-// scene owner's character ID.
+// scene owner's character ID. After the DB write, focusClient.LeaveFocus is
+// called for the owner's session only; multi-session fan-out is deferred to a
+// follow-up bead (spec §6.1).
 //
 //nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
 func (p *scenePlugin) handleEnd(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
@@ -141,12 +148,25 @@ func (p *scenePlugin) handleEnd(ctx context.Context, req pluginsdk.CommandReques
 		return pluginsdk.Errorf("Usage: scene end <scene id>"), nil
 	}
 
-	_, err := p.service.EndScene(ctx, &scenev1.EndSceneRequest{
+	if _, err := p.service.EndScene(ctx, &scenev1.EndSceneRequest{
 		CharacterId: req.CharacterID,
 		SceneId:     sceneID,
-	})
-	if err != nil {
+	}); err != nil {
 		return pluginsdk.Errorf("Failed to end scene: %v", err), nil
+	}
+
+	if p.focusClient != nil {
+		if err := p.focusClient.LeaveFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+			Kind:     pluginsdk.FocusKindScene,
+			TargetID: sceneID,
+		}); err != nil {
+			slog.WarnContext(ctx, "scene.command.end focus leave failed for owner session",
+				"subject_id", req.CharacterID,
+				"session_id", req.SessionID,
+				"scene_id", sceneID,
+				"error", err,
+			)
+		}
 	}
 
 	return &pluginsdk.CommandResponse{
@@ -282,25 +302,56 @@ func splitSubcommand(args string) (sub, rest string) {
 	return args[:idx], strings.TrimSpace(args[idx+1:])
 }
 
-// handleJoin parses "scene join <scene-id>" and calls JoinScene.
+// handleJoin parses "scene join <scene-id>", calls JoinScene, then calls
+// focusClient.JoinFocus to register the session as a subscriber.
 //
 //nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
 func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	// Strict arity: reject empty args AND trailing tokens. Without this,
-	// `scene join scn123 typo` would pass "scn123 typo" as SceneId and
-	// produce a confusing RPC error instead of a usage message.
 	fields := strings.Fields(args)
 	if len(fields) != 1 {
 		return pluginsdk.Errorf("Usage: scene join <scene id>"), nil
 	}
 	sceneID := fields[0]
 
-	_, err := p.service.JoinScene(ctx, &scenev1.JoinSceneRequest{
+	if _, err := p.service.JoinScene(ctx, &scenev1.JoinSceneRequest{
 		CharacterId: req.CharacterID,
 		SceneId:     sceneID,
+	}); err != nil {
+		return pluginsdk.Errorf("Failed to join scene: %v", err), nil
+	}
+
+	if p.focusClient == nil {
+		slog.WarnContext(ctx, "scene.command.join focus client not configured; subscription not updated",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+		)
+		return pluginsdk.Errorf(
+			"Joined scene in database, but your session could not subscribe (focus client not configured). "+
+				"Please retry `scene join %s`.", sceneID), nil
+	}
+
+	err := p.focusClient.JoinFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+		Kind:     pluginsdk.FocusKindScene,
+		TargetID: sceneID,
 	})
 	if err != nil {
-		return pluginsdk.Errorf("Failed to join scene: %v", err), nil
+		var oe oops.OopsError
+		if errors.As(err, &oe) && oe.Code() == "FOCUS_ALREADY_MEMBER" {
+			return &pluginsdk.CommandResponse{
+				Status: pluginsdk.CommandOK,
+				Output: fmt.Sprintf("Joined scene %s.", sceneID),
+			}, nil
+		}
+		slog.WarnContext(ctx, "scene.command.join focus join failed",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+			"error", err,
+		)
+		return pluginsdk.Errorf(
+			"Joined scene in database, but your session could not subscribe (%v). "+
+				"Please retry `scene join %s`.", err, sceneID), nil
 	}
 
 	return &pluginsdk.CommandResponse{
@@ -309,23 +360,37 @@ func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandReque
 	}, nil
 }
 
-// handleLeave parses "scene leave <scene-id>" and calls LeaveScene.
+// handleLeave parses "scene leave <scene-id>", calls LeaveScene, then calls
+// focusClient.LeaveFocus. Focus errors are logged but do not fail the command
+// since the DB is the source of truth for scene membership.
 //
 //nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
 func (p *scenePlugin) handleLeave(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	// Strict arity: reject empty args AND trailing tokens — see handleJoin.
 	fields := strings.Fields(args)
 	if len(fields) != 1 {
 		return pluginsdk.Errorf("Usage: scene leave <scene id>"), nil
 	}
 	sceneID := fields[0]
 
-	_, err := p.service.LeaveScene(ctx, &scenev1.LeaveSceneRequest{
+	if _, err := p.service.LeaveScene(ctx, &scenev1.LeaveSceneRequest{
 		CharacterId: req.CharacterID,
 		SceneId:     sceneID,
-	})
-	if err != nil {
+	}); err != nil {
 		return pluginsdk.Errorf("Failed to leave scene: %v", err), nil
+	}
+
+	if p.focusClient != nil {
+		if err := p.focusClient.LeaveFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+			Kind:     pluginsdk.FocusKindScene,
+			TargetID: sceneID,
+		}); err != nil {
+			slog.WarnContext(ctx, "scene.command.leave focus leave failed",
+				"subject_id", req.CharacterID,
+				"session_id", req.SessionID,
+				"scene_id", sceneID,
+				"error", err,
+			)
+		}
 	}
 
 	return &pluginsdk.CommandResponse{
@@ -409,5 +474,52 @@ func (p *scenePlugin) handleTransfer(ctx context.Context, req pluginsdk.CommandR
 	return &pluginsdk.CommandResponse{
 		Status: pluginsdk.CommandOK,
 		Output: fmt.Sprintf("Transferred ownership of scene %s to %s.", sceneID, target),
+	}, nil
+}
+
+// handleSwitch implements `scene switch <scene id>`. The coordinator's
+// PresentFocus is a pure session-state column update; the session MUST
+// already be a member of the target scene (enforced server-side via
+// FOCUS_NOT_MEMBER). No DB write happens here — scene membership and
+// subscriptions are unchanged by switch.
+//
+//nolint:unparam // plugin SDK Handler contract requires (*CommandResponse, error); errors are conveyed via pluginsdk.Errorf returning a CommandError status response, not via Go error returns
+func (p *scenePlugin) handleSwitch(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+	fields := strings.Fields(args)
+	if len(fields) != 1 {
+		return pluginsdk.Errorf("Usage: scene switch <scene id>"), nil
+	}
+	sceneID := fields[0]
+
+	if p.focusClient == nil {
+		slog.WarnContext(ctx, "scene.command.switch focus client not configured",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+		)
+		return pluginsdk.Errorf("Failed to switch scene: focus client not configured"), nil
+	}
+
+	if err := p.focusClient.PresentFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+		Kind:     pluginsdk.FocusKindScene,
+		TargetID: sceneID,
+	}); err != nil {
+		var oe oops.OopsError
+		if errors.As(err, &oe) && oe.Code() == "FOCUS_NOT_MEMBER" {
+			return pluginsdk.Errorf(
+				"You are not a member of scene %s. Use `scene join %s` first.", sceneID, sceneID), nil
+		}
+		slog.WarnContext(ctx, "scene.command.switch focus present failed",
+			"subject_id", req.CharacterID,
+			"session_id", req.SessionID,
+			"scene_id", sceneID,
+			"error", err,
+		)
+		return pluginsdk.Errorf("Failed to switch scene: %v", err), nil
+	}
+
+	return &pluginsdk.CommandResponse{
+		Status: pluginsdk.CommandOK,
+		Output: fmt.Sprintf("Switched to scene %s.", sceneID),
 	}, nil
 }

--- a/plugins/core-scenes/commands_test.go
+++ b/plugins/core-scenes/commands_test.go
@@ -733,7 +733,10 @@ func TestSceneJoinReturnsErrorWhenFocusClientNotConfigured(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pluginsdk.CommandError, resp.Status)
 	assert.Contains(t, resp.Output, "focus client not configured")
-	assert.Contains(t, resp.Output, "retry")
+	assert.Contains(t, resp.Output, "administrator",
+		"nil focusClient is a misconfiguration, not transient; message should direct operator, not user-retry")
+	assert.NotContains(t, resp.Output, "retry",
+		"nil focusClient retries hit the same guard; do not mislead the user")
 }
 
 func TestSceneSwitchReturnsErrorWhenFocusClientNotConfigured(t *testing.T) {

--- a/plugins/core-scenes/commands_test.go
+++ b/plugins/core-scenes/commands_test.go
@@ -259,16 +259,20 @@ func TestSceneCommandJoinForwardsToServiceWithCorrectSceneID(t *testing.T) {
 		ID: "scene-cmd-j", OwnerID: "char-alice",
 		State: string(SceneStateActive), Visibility: string(SceneVisibilityOpen),
 	}))
-	plugin := &scenePlugin{service: NewSceneServiceImpl(store)}
+	fc := &fakeFocusClient{}
+	plugin := &scenePlugin{service: NewSceneServiceImpl(store), focusClient: fc}
 
 	resp, err := plugin.dispatchCommand(context.Background(), pluginsdk.CommandRequest{
 		Command:     "scene",
 		Args:        "join scene-cmd-j",
 		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "Joined scene scene-cmd-j")
+	require.Len(t, fc.joinCalls, 1)
+	assert.Equal(t, "scene-cmd-j", fc.joinCalls[0].target.TargetID)
 }
 
 func TestSceneCommandLeaveRejectsMissingSceneID(t *testing.T) {

--- a/plugins/core-scenes/commands_test.go
+++ b/plugins/core-scenes/commands_test.go
@@ -710,3 +710,103 @@ func TestSceneSwitchStrictArity(t *testing.T) {
 		})
 	}
 }
+
+// --- Group C: focusClient-not-configured branches ---
+
+func TestSceneJoinReturnsErrorWhenFocusClientNotConfigured(t *testing.T) {
+	// newTestPlugin() has no focusClient wired in.
+	p := newTestPlugin()
+
+	// Create a scene first so JoinScene succeeds before hitting the nil-client guard.
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "focus client not configured")
+	assert.Contains(t, resp.Output, "retry")
+}
+
+func TestSceneSwitchReturnsErrorWhenFocusClientNotConfigured(t *testing.T) {
+	p := newTestPlugin()
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "switch scene-01",
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "focus client not configured")
+}
+
+func TestSceneSwitchReturnsGenericErrorForUnknownFailure(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.presentErr = errors.New("unexpected storage error")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "switch scene-01",
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.True(t, strings.HasPrefix(resp.Output, "Failed to switch scene:"),
+		"output should start with 'Failed to switch scene:'; got: %q", resp.Output)
+}
+
+func TestSceneEndToleratesLeaveFocusError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	// Set a transient focus error after the scene exists.
+	fc.leaveErr = errors.New("host blip")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "end " + sceneID,
+		CharacterID: "char-owner",
+		SessionID:   "sess-owner",
+	})
+	require.NoError(t, err)
+	// DB write succeeded; focus error is logged, not surfaced.
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	assert.Contains(t, resp.Output, "ended")
+}
+
+func TestSceneEndReturnsOKWhenFocusClientNotConfigured(t *testing.T) {
+	// handleEnd skips LeaveFocus when focusClient is nil and returns OK.
+	p := newTestPlugin()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "end " + sceneID,
+		CharacterID: "char-owner",
+		SessionID:   "sess-owner",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	assert.Contains(t, resp.Output, "ended")
+}

--- a/plugins/core-scenes/commands_test.go
+++ b/plugins/core-scenes/commands_test.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -434,6 +436,273 @@ func TestMembershipCommandsRejectExtraPositionalTokens(t *testing.T) {
 				"expected CommandError for args %q", tt.args)
 			assert.Contains(t, resp.Output, tt.wantUsage,
 				"expected usage hint for args %q", tt.args)
+		})
+	}
+}
+
+// --- fakeFocusClient ---
+
+type focusCall struct {
+	sessionID string
+	target    pluginsdk.FocusKey
+}
+
+type fakeFocusClient struct {
+	joinCalls    []focusCall
+	leaveCalls   []focusCall
+	presentCalls []focusCall
+
+	joinErr    error
+	leaveErr   error
+	presentErr error
+}
+
+func (f *fakeFocusClient) JoinFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.joinCalls = append(f.joinCalls, focusCall{sessionID: sid, target: t})
+	return f.joinErr
+}
+
+func (f *fakeFocusClient) LeaveFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.leaveCalls = append(f.leaveCalls, focusCall{sessionID: sid, target: t})
+	return f.leaveErr
+}
+
+func (f *fakeFocusClient) PresentFocus(_ context.Context, sid string, t pluginsdk.FocusKey) error {
+	f.presentCalls = append(f.presentCalls, focusCall{sessionID: sid, target: t})
+	return f.presentErr
+}
+
+func (f *fakeFocusClient) QueryStreamHistory(_ context.Context, _ pluginsdk.QueryStreamHistoryRequest) ([]pluginsdk.Event, error) {
+	return nil, nil
+}
+
+// newTestPluginWithFocus returns a scenePlugin wired with a fakeFocusClient
+// and a fakeStore-backed SceneServiceImpl. Tests that exercise the
+// command-path focus wiring use this in place of newTestPlugin.
+func newTestPluginWithFocus() (*scenePlugin, *fakeFocusClient) {
+	p := newTestPlugin()
+	fc := &fakeFocusClient{}
+	p.focusClient = fc
+	return p, fc
+}
+
+// extractSceneID parses a "Scene created: <id>" output into the id substring.
+func extractSceneID(t *testing.T, output string) string {
+	t.Helper()
+	parts := strings.Split(output, "Scene created:")
+	require.Len(t, parts, 2)
+	return strings.TrimSpace(parts[1])
+}
+
+// --- scene join / leave / end / switch focus-wiring tests ---
+
+func TestSceneJoinCallsFocusClientJoinFocus(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.joinCalls, 1)
+	assert.Equal(t, "sess-bob", fc.joinCalls[0].sessionID)
+	assert.Equal(t, pluginsdk.FocusKindScene, fc.joinCalls[0].target.Kind)
+	assert.Equal(t, sceneID, fc.joinCalls[0].target.TargetID)
+}
+
+func TestSceneJoinPropagatesJoinSceneError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join scene-does-not-exist",
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Empty(t, fc.joinCalls, "JoinFocus MUST NOT run when service.JoinScene fails")
+}
+
+func TestSceneJoinHandlesJoinFocusError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.joinErr = oops.Code("FOCUS_POLICY_FAILED").Errorf("policy rejected")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "retry")
+}
+
+func TestSceneJoinTreatsFocusAlreadyMemberAsSuccess(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.joinErr = oops.Code("FOCUS_ALREADY_MEMBER").Errorf("duplicate")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command:     "scene",
+		Args:        "join " + sceneID,
+		CharacterID: "char-bob",
+		SessionID:   "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+}
+
+func TestSceneLeaveCallsLeaveScene(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	_, err = p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "join " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+
+	fc.joinCalls = nil
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.leaveCalls, 1)
+	assert.Equal(t, "sess-bob", fc.leaveCalls[0].sessionID)
+	assert.Equal(t, sceneID, fc.leaveCalls[0].target.TargetID)
+}
+
+func TestSceneLeaveRejectsOwnerBeforeFocusChange(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-owner", SessionID: "sess-owner",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Empty(t, fc.leaveCalls, "LeaveFocus MUST NOT run when owner-leave is rejected")
+}
+
+func TestSceneLeaveToleratesLeaveFocusError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.leaveErr = errors.New("transient host error")
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	_, err = p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "join " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "leave " + sceneID, CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status, "DB leave succeeded; focus-side failure is logged, not surfaced")
+}
+
+func TestSceneEndCallsLeaveFocusForOwner(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+	})
+	require.NoError(t, err)
+	sceneID := extractSceneID(t, createResp.Output)
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "end " + sceneID, CharacterID: "char-owner", SessionID: "sess-owner",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.leaveCalls, 1)
+	assert.Equal(t, "sess-owner", fc.leaveCalls[0].sessionID)
+	assert.Equal(t, sceneID, fc.leaveCalls[0].target.TargetID)
+}
+
+func TestSceneSwitchCallsPresentFocus(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "switch scene-01", CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+	require.Len(t, fc.presentCalls, 1)
+	assert.Equal(t, "sess-bob", fc.presentCalls[0].sessionID)
+	assert.Equal(t, pluginsdk.FocusKindScene, fc.presentCalls[0].target.Kind)
+	assert.Equal(t, "scene-01", fc.presentCalls[0].target.TargetID)
+}
+
+func TestSceneSwitchReturnsNotMemberError(t *testing.T) {
+	p, fc := newTestPluginWithFocus()
+	fc.presentErr = oops.Code("FOCUS_NOT_MEMBER").Errorf("not joined")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "switch scene-01", CharacterID: "char-bob", SessionID: "sess-bob",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "not a member")
+	assert.Contains(t, resp.Output, "scene join")
+}
+
+func TestSceneSwitchStrictArity(t *testing.T) {
+	p, _ := newTestPluginWithFocus()
+
+	tests := []struct {
+		name string
+		args string
+	}{
+		{"rejects empty", "switch"},
+		{"rejects trailing tokens", "switch scene-01 trailing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command: "scene", Args: tt.args, CharacterID: "char-bob", SessionID: "sess-bob",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, pluginsdk.CommandError, resp.Status)
+			assert.Contains(t, resp.Output, "Usage")
 		})
 	}
 }

--- a/plugins/core-scenes/main.go
+++ b/plugins/core-scenes/main.go
@@ -29,9 +29,10 @@ import (
 // runs before Init) has valid receivers. Init wires the store into both
 // after NewSceneStore returns.
 type scenePlugin struct {
-	store    *SceneStore
-	service  *SceneServiceImpl
-	resolver *SceneResolver
+	store       *SceneStore
+	service     *SceneServiceImpl
+	resolver    *SceneResolver
+	focusClient pluginsdk.FocusClient
 }
 
 // HandleEvent is a no-op for Phase 1. The scene plugin does not subscribe
@@ -61,6 +62,14 @@ func (p *scenePlugin) RegisterServices(registrar grpc.ServiceRegistrar) {
 // during policy evaluation.
 func (p *scenePlugin) RegisterAttributeResolver(registrar grpc.ServiceRegistrar) {
 	pluginv1.RegisterAttributeResolverServiceServer(registrar, p.resolver)
+}
+
+// SetFocusClient is called by the SDK adapter during Init when the plugin
+// declares FocusClientAware. The client is used by command handlers to
+// drive session focus state via PluginHostService.{JoinFocus,LeaveFocus,
+// PresentFocus}.
+func (p *scenePlugin) SetFocusClient(client pluginsdk.FocusClient) {
+	p.focusClient = client
 }
 
 // SetEventSink forwards the SDK-injected event sink to the scene service so

--- a/site/docs/extending/binary-plugins.md
+++ b/site/docs/extending/binary-plugins.md
@@ -503,3 +503,109 @@ The host discovers plugins at startup by scanning the `plugins/` directory for
 | Function              | Purpose                                        |
 | --------------------- | ---------------------------------------------- |
 | `ParseBrokerServices` | Parse required_services map into broker IDs    |
+
+### EventSink
+
+The `EventSink` facade is the plugin-side entry point for emitting events on
+behalf of the plugin. Plugins that need to publish events to the host's event
+store (rather than returning them from `HandleEvent`) call `EventSink.Emit`
+directly. The SDK adapter detects `EventSinkAware` during `Init` and injects a
+broker-backed sink.
+
+#### Declaring EventSinkAware
+
+```go
+type myPlugin struct {
+    sink pluginsdk.EventSink
+}
+
+func (p *myPlugin) SetEventSink(sink pluginsdk.EventSink) {
+    p.sink = sink
+}
+
+func (p *myPlugin) someMethod(ctx context.Context, stream string) error {
+    return p.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Stream:  stream,
+        Type:    "my_event",
+        Payload: `{"key":"value"}`,
+    })
+}
+```
+
+### FocusClient
+
+The `FocusClient` facade is the plugin-side entry point for driving
+server-owned session focus state. Plugins that need to declare a
+character's participation in a focused context — scenes today,
+mail/admin-views in the future — call `FocusClient` rather than
+mutating session state directly. All calls cross the plugin broker
+(mTLS) to the host's `PluginHostService`.
+
+#### Methods
+
+| Method | Purpose |
+| --- | --- |
+| `JoinFocus(ctx, sessionID, target)` | Add a focus membership. The server determines streams, replay mode, and cursor baselines based on the target's `FocusKind`. Idempotent — treat `FOCUS_ALREADY_MEMBER` as success. |
+| `LeaveFocus(ctx, sessionID, target)` | Remove a focus membership. Idempotent on non-member. Clears `PresentingFocus` if it pointed at the removed target. |
+| `PresentFocus(ctx, sessionID, target)` | Update the session's presenting-focus pointer. The target MUST already be a member; non-members get `FOCUS_NOT_MEMBER`. No replay or subscription change — pure bookkeeping. |
+| `QueryStreamHistory(ctx, req)` | Read the tail of a stream for plugin-side display (e.g., last 20 messages on join). Read-only — does not mutate cursors. The host clamps `Count` at 500. |
+
+#### Declaring FocusClientAware
+
+A plugin opts in by implementing `FocusClientAware`:
+
+```go
+type scenePlugin struct {
+    focusClient pluginsdk.FocusClient
+}
+
+func (p *scenePlugin) SetFocusClient(client pluginsdk.FocusClient) {
+    p.focusClient = client
+}
+
+func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+    sceneID := strings.TrimSpace(args)
+    // ... persist the DB row first ...
+
+    err := p.focusClient.JoinFocus(ctx, req.SessionID, pluginsdk.FocusKey{
+        Kind:     pluginsdk.FocusKindScene,
+        TargetID: sceneID,
+    })
+    if err != nil {
+        // Inspect oops error code; FOCUS_ALREADY_MEMBER is idempotent-success.
+        return pluginsdk.Errorf("failed to join scene: %v", err), nil
+    }
+    return pluginsdk.OK(fmt.Sprintf("Joined scene %s.", sceneID)), nil
+}
+```
+
+The SDK adapter detects `FocusClientAware` during `Init` and injects a
+broker-backed client. `EventSink` and `FocusClient` share a single
+`*grpc.ClientConn` to `PluginHostService`, so a plugin implementing both
+`EventSinkAware` and `FocusClientAware` opens ONE connection — not two.
+
+#### Error codes
+
+`FocusClient` methods return `oops`-coded errors; inspect via `errors.As`:
+
+| Code | Meaning |
+| --- | --- |
+| `SESSION_NOT_FOUND` | The session does not exist. |
+| `SESSION_EXPIRED` | The session is past its TTL. |
+| `FOCUS_ALREADY_MEMBER` | Membership already exists — treat as idempotent success. |
+| `FOCUS_KIND_UNREGISTERED` | The host has no policy registered for this `FocusKind`. |
+| `FOCUS_POLICY_FAILED` | The kind policy rejected the join. |
+| `FOCUS_NOT_MEMBER` | (`PresentFocus` only) Target is not in the session's memberships. |
+
+#### Invariants
+
+- Plugins MUST NOT mutate `session.FocusMemberships` directly. The facade is
+  the only sanctioned path.
+- Plugins MUST NOT declare replay modes or stream names on focus RPCs — the
+  server owns those decisions.
+- `QueryStreamHistory` is strictly read-only.
+
+#### References
+
+- Plugin adoption spec: [B10 core-scenes Adoption](../../../docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md)
+- Implementation: `pkg/plugin/focus_client.go`


### PR DESCRIPTION
## Summary

- Adds `FocusClient` SDK facade to `pkg/plugin`, parallel to `EventSink`, wrapping the four `PluginHostService` focus RPCs landed in B8.
- Wires `core-scenes` command handlers (`scene join/leave/end/switch`) to drive session focus state via the coordinator.
- Unblocks Scenes Phase 4 (`holomush-5rh.13`).

## Design

- Spec: `docs/superpowers/specs/2026-04-16-b10-core-scenes-adoption-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-b10-core-scenes-adoption.md`

## Key decisions

- **Command-path only** (no scene proto `session_id` field). Rationale in spec §3.1: `SceneService` has no external callers; PR #225 already IDOR-hardened `HandleCommand` so the `SessionID` arriving at the plugin is trusted.
- **DB-first, focus-second** ordering with no compensating writes. `JoinScene` is idempotent (P3.D5); retries heal.
- **EndScene LeaveFocus for caller session only**. Multi-session fan-out deferred to follow-up bead \`holomush-oy6e.14\` (LeaveFocusByTarget).
- **Single shared gRPC conn** for EventSink + FocusClient inside the SDK adapter.

## Phase 4 §7.2 acceptance test coverage

B10 relies on existing unit-level coverage for Phase 4 invariants:

| Spec §7.2 test | Where covered |
|---|---|
| TestLeaveFocusClearsPresentingWhenReferenced | internal/grpc/focus/leave_test.go (B4) |
| TestFocusSwitchHonorsPlayerPreference | internal/grpc/focus/prefs_test.go (B6) |
| TestFocusSwitchClampsOutOfRange | internal/grpc/focus/prefs_test.go (B6) |
| TestFocusSwitchCatchUpUsesBoundedIC (policy layer) | internal/grpc/focus/scenepolicy/policy_test.go (B6) |
| End-to-end telnet reconnect, multi-scene merge-sort, pose-order fairness | Deferred to holomush-5rh.13 (Phase 4) |

B10-new unit coverage:
- pkg/plugin/focus_client_test.go — 12 tests: error-code mapping, happy paths, broker-dial error paths.
- pkg/plugin/service_test.go — 2 new tests covering shared-conn injection.
- plugins/core-scenes/commands_test.go — 11 new tests covering DB-first/focus-second ordering.

## Test plan

- [x] Unit: pkg/plugin/... — 96 tests pass.
- [x] Unit: plugins/core-scenes/... — 113 tests pass.
- [x] task pr-prep green (unit + integration + E2E 54/54 passed).
- [x] task lint green.

## Follow-up beads filed

- holomush-oy6e.14 — Host-side LeaveFocusByTarget(FocusKey) sweep (P2).
- holomush-h8xj — task gowork produces go.work that Go 1.26.x rejects (P1, orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `scene switch` subcommand to change the active scene.
  * Integrated server-managed focus support into core-scenes so scene join/leave/switch operations register with the server.

* **Documentation**
  * Updated binary-plugin author guide with FocusClient and EventSink SDK docs, examples, and error-code guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->