### PR TITLE
docs(spec): JetStream event log + PG audit projection design

### DIFF
--- a/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-a.md
+++ b/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-a.md
@@ -1,0 +1,2342 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Phase A: JetStream EventBus Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the additive infrastructure for the JetStream event bus into `main` *without* changing production behavior. After Phase A, embedded NATS starts at every server boot, the audit projection runs idle on an empty stream, the codec and bus interfaces exist with no consumers, and OTEL/Prom plumbing is wired. Production still uses the old PostgreSQL event store via `EventWriter` and `EventStore.SubscribeSession`.
+
+**Architecture:** Seven independent additive PRs (M1–M7). Each PR is risk-zero or risk-low: no consumer of the old event store moves to the new bus until Phase B (separate plan). Embedded NATS is lock-isolated by per-instance `StoreDir` from `xdg.DataDir()`. The audit projection consumer subscribes to `events.>` but receives no events because nothing publishes there yet.
+
+**Tech Stack:** Go 1.24+, `github.com/nats-io/nats-server/v2` (latest GA, pinned via Renovate trail), `github.com/nats-io/nats.go`, ULID via `internal/idgen`, `pgregory.net/rapid` for property tests, `prometheus-nats-exporter` (Go library), OTEL via existing `internal/telemetry`, testcontainers for PG integration tests.
+
+**Spec:** [docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md](../specs/2026-04-18-jetstream-event-log-design.md)
+
+**Epic bead:** `holomush-1tvn`
+
+**Phase A bead IDs (set after creation):** M1=`holomush-1tvn.M1`, M2=`holomush-1tvn.M2`, … M7=`holomush-1tvn.M7` (placeholder; actual IDs below).
+
+---
+
+## Phase A invariants (apply to every task)
+
+- **Production behavior MUST NOT change.** No consumer of the old event store gets rerouted in Phase A. Tests of the old code paths MUST still pass.
+- **Each task lands as its own PR to main.** PRs are < 500 LOC churn; each must pass `task pr-prep` (lint, format, schema, license, unit, integration, E2E) green.
+- **Coverage gate per package.** New `internal/eventbus/` packages MUST hit 90% coverage; `internal/eventbus/codec/` MUST hit 95%.
+- **No `time.Sleep` in tests** under `internal/eventbus/` and `test/integration/eventbus_e2e/` (will be enforced by lint rule landing in M1).
+- **Use `task` for all build/test/lint operations** (per `CLAUDE.md`).
+
+---
+
+## File Map (Phase A)
+
+| File | Action | Task | Responsibility |
+| --- | --- | --- | --- |
+| `internal/eventbus/types.go` | Create | M1 | `Subject`, `Type`, `Event`, `Actor`, `ActorKind`, `Direction` |
+| `internal/eventbus/types_test.go` | Create | M1 | Constructor validation, type-safety regression tests |
+| `internal/eventbus/bus.go` | Create | M1 | `Publisher`, `Subscriber`, `HistoryReader`, `EventBus`, `Delivery`, `SessionStream`, `HistoryQuery`, `HistoryStream` interfaces |
+| `internal/eventbus/bus_test.go` | Create | M1 | Interface satisfaction stubs |
+| `internal/eventbus/errors.go` | Create | M1 | Error sentinels |
+| `internal/eventbus/errors_test.go` | Create | M1 | Error wrapping/unwrapping |
+| `.golangci.yml` | Modify | M1 | Add `time.Sleep` ban for `internal/eventbus/**` and `test/integration/eventbus_e2e/**` |
+| `internal/eventbus/codec/codec.go` | Create | M2 | `Name` typed string + constants, `Codec`, `KeyProvider`, `KeySelector`, `Key`, `KeyID`, `KeyLabel`, `IdentityCodec` |
+| `internal/eventbus/codec/codec_test.go` | Create | M2 | IdentityCodec round-trip + boundary tests |
+| `internal/eventbus/codec/registry.go` | Create | M2 | Closed registry of host-known codecs + `Resolve` |
+| `internal/eventbus/codec/registry_test.go` | Create | M2 | Registry sync meta-test |
+| `internal/store/migrations/000020_create_events_audit.up.sql` | Create | M3 | `events_audit` table + indexes (number adjusts to next available) |
+| `internal/store/migrations/000020_create_events_audit.down.sql` | Create | M3 | Rollback |
+| `internal/store/events_audit_test.go` | Create | M3 | Integration test: schema present, indexes used, ON CONFLICT idempotent |
+| `internal/eventbus/subsystem.go` | Create | M4 | `SubsystemEventBus` lifecycle (embedded NATS) |
+| `internal/eventbus/subsystem_test.go` | Create | M4 | Lifecycle + idempotent stream declaration |
+| `internal/eventbus/config.go` | Create | M4 | `Config` struct + defaults |
+| `internal/eventbus/eventbustest/embedded.go` | Create | M4 | `New(t)` test helper using MemoryStorage |
+| `internal/lifecycle/subsystem.go` | Modify | M4 + M5 | Add `SubsystemEventBus` and `SubsystemAuditProjection` IDs |
+| `internal/config/config.go` | Modify | M4 | Add `EventBus` config key (with `game_id`, mode flag etc.) |
+| `cmd/holomush/core.go` | Modify | M4 + M5 + M7 | Register new subsystems in orchestrator (idle until F1) |
+| `internal/eventbus/audit/subsystem.go` | Create | M5 | `SubsystemAuditProjection` lifecycle |
+| `internal/eventbus/audit/projection.go` | Create | M5 | Worker loop: read JS → INSERT events_audit ON CONFLICT |
+| `internal/eventbus/audit/projection_test.go` | Create | M5 | Integration test with embedded NATS + PG testcontainer |
+| `internal/eventbus/audit/lag_metric.go` | Create | M5 | Prometheus gauge: `audit_projection_lag_seconds` |
+| `api/proto/holomush/eventbus/v1/eventbus.proto` | Create | M6 | Host envelope `Event` message, `Actor`, `ActorKind` enum |
+| `api/proto/holomush/plugin/v1/audit.proto` | Create | M6 | `PluginAuditService` (`AuditEvent`, `QueryHistory` RPCs) + messages |
+| `pkg/proto/holomush/eventbus/v1/eventbus.pb.go` | Generated | M6 | Via `task generate:proto` |
+| `pkg/proto/holomush/plugin/v1/audit.pb.go` | Generated | M6 | Via `task generate:proto` |
+| `pkg/proto/holomush/plugin/v1/audit_grpc.pb.go` | Generated | M6 | Via `task generate:proto` |
+| `internal/eventbus/telemetry/otel.go` | Create | M7 | Span helpers, W3C traceparent extract/inject for nats.Header |
+| `internal/eventbus/telemetry/otel_test.go` | Create | M7 | Round-trip header propagation |
+| `internal/eventbus/telemetry/prometheus.go` | Create | M7 | In-process `prometheus-nats-exporter` registration |
+| `internal/eventbus/telemetry/prometheus_test.go` | Create | M7 | Smoke: metrics endpoint exposes `gnatsd_*` keys |
+| `renovate.json` | Modify | M1 (or whichever lands first) | Add NATS package group with `minimumReleaseAge: "14 days"` |
+| `go.mod` / `go.sum` | Modify | M2 (codec deps), M4 (NATS deps), M5 (testcontainers PG already), M7 (exporter) | New direct deps |
+
+---
+
+## Task M1: EventBus skeleton — types, interfaces, errors, lint rule
+
+**Files:**
+
+- Create: `internal/eventbus/types.go`, `internal/eventbus/types_test.go`
+- Create: `internal/eventbus/bus.go`, `internal/eventbus/bus_test.go`
+- Create: `internal/eventbus/errors.go`, `internal/eventbus/errors_test.go`
+- Modify: `.golangci.yml` (custom rule for `time.Sleep` ban)
+- Modify: `renovate.json` (NATS group config)
+
+**Bead:** `holomush-1tvn.M1`
+
+- [ ] **Step 1: Add NATS Renovate group config**
+
+Edit `renovate.json` to add the NATS group rule. If `renovate.json` does not exist yet, create it with `extends: ["config:base"]`.
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "github.com/nats-io/nats-server/v2",
+        "github.com/nats-io/nats.go"
+      ],
+      "minimumReleaseAge": "14 days",
+      "groupName": "nats",
+      "schedule": ["after 9am on Monday"]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Create directory and write `errors.go` first**
+
+```bash
+mkdir -p internal/eventbus
+```
+
+Write `internal/eventbus/errors.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package eventbus defines the host-facing event bus interfaces and
+// supporting types. The concrete JetStream-backed implementation lives
+// in subpackages (subsystem, audit, codec, telemetry).
+package eventbus
+
+import "errors"
+
+// Sentinel errors returned by EventBus implementations. Consumers MUST
+// match via errors.Is, never by string content.
+var (
+    ErrInvalidSubject       = errors.New("eventbus: invalid subject")
+    ErrInvalidType          = errors.New("eventbus: invalid event type")
+    ErrEmitNotPermitted     = errors.New("eventbus: subject not in manifest emits")
+    ErrPayloadTooLarge      = errors.New("eventbus: payload exceeds MaxPayloadSize")
+    ErrCodecHeaderMissing   = errors.New("eventbus: required App-Codec header missing")
+    ErrUnknownCodec         = errors.New("eventbus: codec name not in registry")
+    ErrPublishExpired       = errors.New("eventbus: publish retry exceeded dedup window")
+    ErrInvalidFilter        = errors.New("eventbus: filter does not match stream subject")
+    ErrInvalidCursor        = errors.New("eventbus: invalid history cursor")
+    ErrInvalidTimeRange     = errors.New("eventbus: NotBefore must be <= NotAfter")
+    ErrSessionAuth          = errors.New("eventbus: session authentication failed")
+    ErrUnauthorized         = errors.New("eventbus: caller not authorized for subject")
+    ErrPluginTimeout        = errors.New("eventbus: plugin RPC timeout")
+    ErrSubjectOwnershipConflict = errors.New("eventbus: subject ownership conflict at startup")
+    ErrManifestInvalid      = errors.New("eventbus: manifest validation failed")
+    ErrStoreDirLocked       = errors.New("eventbus: NATS StoreDir is already locked by another process")
+    ErrDecryptionFailed     = errors.New("eventbus: decryption failed")
+    ErrKeyUnavailable       = errors.New("eventbus: codec key unavailable")
+)
+
+// MaxPayloadSize matches the prior cap in internal/core/event.go to keep
+// behavior consistent across the cutover.
+const MaxPayloadSize = 64 * 1024
+```
+
+Write `internal/eventbus/errors_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus_test
+
+import (
+    "errors"
+    "fmt"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus"
+)
+
+func TestSentinelErrorsWrapAndUnwrap(t *testing.T) {
+    wrapped := fmt.Errorf("publish failed: %w", eventbus.ErrPublishExpired)
+    require.True(t, errors.Is(wrapped, eventbus.ErrPublishExpired))
+    require.False(t, errors.Is(wrapped, eventbus.ErrInvalidSubject))
+}
+
+func TestMaxPayloadSizeMatchesLegacy(t *testing.T) {
+    require.Equal(t, 64*1024, eventbus.MaxPayloadSize)
+}
+```
+
+- [ ] **Step 3: Run errors_test.go and verify it fails (package not yet present in go list)**
+
+```bash
+task test -- ./internal/eventbus/... 2>&1 | head -20
+```
+
+Expected: build error or "no Go files" — package needs `types.go` to be valid.
+
+- [ ] **Step 4: Write `types.go` with typed `Subject`, `Type`, and constructors**
+
+Write `internal/eventbus/types.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+    "fmt"
+    "regexp"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+)
+
+// Subject is a typed JetStream subject. Constructed via NewSubject which
+// validates against the documented token rules (see spec §1c).
+type Subject string
+
+// Type is a typed plugin-declared event type identifier. Constructed via
+// NewType which validates against allowed character set.
+type Type string
+
+// Direction selects the iteration order of HistoryStream.
+type Direction uint8
+
+const (
+    DirectionForward  Direction = 1
+    DirectionBackward Direction = 2
+)
+
+// ActorKind identifies what type of entity caused an event. Mirrors the
+// existing core.ActorKind so the cutover preserves semantics.
+type ActorKind uint8
+
+const (
+    ActorKindUnknown   ActorKind = 0
+    ActorKindCharacter ActorKind = 1
+    ActorKindPlayer    ActorKind = 2
+    ActorKindSystem    ActorKind = 3
+    ActorKindPlugin    ActorKind = 4
+)
+
+// Actor identifies who caused an event. Host-stamped, never plugin-spoofable.
+type Actor struct {
+    Kind ActorKind
+    ID   ulid.ULID // zero ULID for ActorKindSystem / Unknown
+}
+
+// Event is the host-side representation of a published event.
+//
+// Wire format (JetStream): proto-encoded Event in msg.Data, with headers
+// `Nats-Msg-Id`, `App-Schema-Version`, `App-Event-Type`, `App-Codec`.
+// See spec §1d.
+type Event struct {
+    ID        ulid.ULID
+    Subject   Subject
+    Type      Type
+    Timestamp time.Time
+    Actor     Actor
+    Payload   []byte // codec.Encode output (ciphertext if encryption is on)
+}
+
+// subjectTokenRe permits NATS subject tokens: letters, digits, dashes,
+// underscores. Wildcards (* and >) are positional and validated by NewSubject
+// directly.
+var subjectTokenRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// typeRe permits dot-segmented identifiers like "scene.lifecycle.created".
+var typeRe = regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`)
+
+// NewSubject validates and constructs a Subject. Returns ErrInvalidSubject
+// on failure.
+//
+// Rules (per spec §1c):
+//   - dot-delimited tokens
+//   - * matches one token (positional)
+//   - > matches the remainder and MUST be the last token
+//   - depth SHOULD be ≤ 16
+//   - non-wildcard tokens match [A-Za-z0-9_-]+
+//   - leading "events." prefix is required (host enforces by convention)
+func NewSubject(s string) (Subject, error) {
+    if s == "" {
+        return "", fmt.Errorf("%w: empty subject", ErrInvalidSubject)
+    }
+    tokens := splitDots(s)
+    if len(tokens) > 16 {
+        return "", fmt.Errorf("%w: token depth %d exceeds 16", ErrInvalidSubject, len(tokens))
+    }
+    if tokens[0] != "events" {
+        return "", fmt.Errorf("%w: must start with 'events.'", ErrInvalidSubject)
+    }
+    for i, tok := range tokens {
+        if tok == "" {
+            return "", fmt.Errorf("%w: empty token at position %d", ErrInvalidSubject, i)
+        }
+        if tok == ">" {
+            if i != len(tokens)-1 {
+                return "", fmt.Errorf("%w: '>' must be the last token", ErrInvalidSubject)
+            }
+            continue
+        }
+        if tok == "*" {
+            continue
+        }
+        if !subjectTokenRe.MatchString(tok) {
+            return "", fmt.Errorf("%w: token %q has invalid characters", ErrInvalidSubject, tok)
+        }
+    }
+    return Subject(s), nil
+}
+
+// MustSubject panics on validation failure. Use only for compile-time
+// constants in plugin code (e.g., var sceneICPattern = MustSubject("events.*.scene.*.ic")).
+func MustSubject(s string) Subject {
+    sub, err := NewSubject(s)
+    if err != nil {
+        panic(err)
+    }
+    return sub
+}
+
+// NewType validates and constructs a Type.
+func NewType(s string) (Type, error) {
+    if s == "" {
+        return "", fmt.Errorf("%w: empty type", ErrInvalidType)
+    }
+    if !typeRe.MatchString(s) {
+        return "", fmt.Errorf("%w: type %q does not match [a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*", ErrInvalidType, s)
+    }
+    return Type(s), nil
+}
+
+func splitDots(s string) []string {
+    out := make([]string, 0, 4)
+    start := 0
+    for i := 0; i < len(s); i++ {
+        if s[i] == '.' {
+            out = append(out, s[start:i])
+            start = i + 1
+        }
+    }
+    out = append(out, s[start:])
+    return out
+}
+```
+
+Write `internal/eventbus/types_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus_test
+
+import (
+    "errors"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus"
+)
+
+func TestNewSubjectAcceptsValidPatterns(t *testing.T) {
+    cases := []string{
+        "events.main.location.01JABC",
+        "events.main.scene.01JABC.ic",
+        "events.*.scene.*.lifecycle",
+        "events.main.scene.>",
+    }
+    for _, s := range cases {
+        t.Run(s, func(t *testing.T) {
+            got, err := eventbus.NewSubject(s)
+            require.NoError(t, err)
+            require.Equal(t, eventbus.Subject(s), got)
+        })
+    }
+}
+
+func TestNewSubjectRejectsInvalidPatterns(t *testing.T) {
+    cases := []struct {
+        name string
+        in   string
+    }{
+        {"empty", ""},
+        {"missing events prefix", "main.location.01JABC"},
+        {"empty token between dots", "events..main.location.X"},
+        {"tilde character", "events.main.location.~"},
+        {"> not last", "events.>.scene.ic"},
+        {"too deep", "events." + strings.Repeat("a.", 16)},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            _, err := eventbus.NewSubject(tc.in)
+            require.Error(t, err)
+            require.True(t, errors.Is(err, eventbus.ErrInvalidSubject), "got %v", err)
+        })
+    }
+}
+
+func TestNewTypeAcceptsValidPatterns(t *testing.T) {
+    cases := []string{"say", "scene.pose", "scene.lifecycle.created"}
+    for _, s := range cases {
+        t.Run(s, func(t *testing.T) {
+            got, err := eventbus.NewType(s)
+            require.NoError(t, err)
+            require.Equal(t, eventbus.Type(s), got)
+        })
+    }
+}
+
+func TestNewTypeRejectsInvalidPatterns(t *testing.T) {
+    cases := []struct {
+        name string
+        in   string
+    }{
+        {"empty", ""},
+        {"uppercase start", "Scene.pose"},
+        {"trailing dot", "scene."},
+        {"double dot", "scene..pose"},
+        {"hyphen", "scene-pose"},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            _, err := eventbus.NewType(tc.in)
+            require.Error(t, err)
+            require.True(t, errors.Is(err, eventbus.ErrInvalidType), "got %v", err)
+        })
+    }
+}
+
+func TestMustSubjectPanicsOnInvalid(t *testing.T) {
+    require.Panics(t, func() { eventbus.MustSubject("not-prefixed") })
+}
+
+func TestMustSubjectAcceptsValid(t *testing.T) {
+    require.NotPanics(t, func() { eventbus.MustSubject("events.main.scene.>") })
+}
+```
+
+- [ ] **Step 5: Run types_test.go to verify it passes**
+
+```bash
+task test -- -run "TestNewSubject|TestNewType|TestMustSubject" ./internal/eventbus/...
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Write `bus.go` with the three composed interfaces and Delivery**
+
+Write `internal/eventbus/bus.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+    "context"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+)
+
+// Publisher writes events. Used by the EventSink facade in
+// internal/plugin/event_emitter.go after Phase B (F1).
+type Publisher interface {
+    Publish(ctx context.Context, event Event) error
+}
+
+// Subscriber opens long-lived session streams. Used by the gRPC Subscribe
+// handler after Phase B (F3).
+type Subscriber interface {
+    OpenSession(ctx context.Context, sessionID string, filters []Subject) (SessionStream, error)
+}
+
+// HistoryReader serves paginated history reads. Used by gRPC QueryHistory
+// handler after Phase B (F4).
+type HistoryReader interface {
+    QueryHistory(ctx context.Context, q HistoryQuery) (HistoryStream, error)
+}
+
+// EventBus is the concrete implementation that satisfies all three
+// single-responsibility interfaces. Tests SHOULD depend on the narrow
+// interface they actually need.
+type EventBus interface {
+    Publisher
+    Subscriber
+    HistoryReader
+}
+
+// Delivery is a typed handle for a single message in flight from a
+// SessionStream. Replaces the prior (Event, AckFunc, error) tuple shape:
+// typed handles are easier to mock, log, and extend.
+type Delivery interface {
+    Event() Event
+    Ack() error
+    // Nack signals the message should be redelivered. Use for transient
+    // handler errors.
+    Nack() error
+    // InProgress extends the ack-wait timer. Use sparingly for handlers
+    // expecting to exceed the default.
+    InProgress() error
+}
+
+// SessionStream is a consumer-side handle bound to a JS durable consumer.
+type SessionStream interface {
+    // Next blocks until the next delivery or ctx done.
+    Next(ctx context.Context) (Delivery, error)
+    // SetFilters atomically replaces the FilterSubjects on the underlying
+    // durable consumer. Cursor is preserved by JS UpdateConsumer.
+    SetFilters(ctx context.Context, filters []Subject) error
+    Close() error
+}
+
+// HistoryQuery describes a paginated history read. Auth flows via
+// context.Context (auth.WithSession), not via this struct.
+type HistoryQuery struct {
+    Subject   Subject   // exact subject OR pattern with * / >
+    After     ulid.ULID // exclusive lower bound; zero ULID = from start
+    Before    ulid.ULID // exclusive upper bound; zero ULID = unbounded
+    NotBefore time.Time // optional time bound
+    NotAfter  time.Time // optional time bound
+    Direction Direction
+    PageSize  int // host caps at 200; default 50
+}
+
+// HistoryStream is a server-streaming handle. Caller iterates Next()
+// until io.EOF; for next-page resume, the caller records the ULID of the
+// last Event returned and passes it as After on the next call.
+type HistoryStream interface {
+    Next(ctx context.Context) (Event, error)
+    Close() error
+}
+```
+
+Write `internal/eventbus/bus_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/holomush/holomush/internal/eventbus"
+)
+
+// fakeBus satisfies all three split interfaces; used to verify that
+// EventBus is satisfiable as the composition.
+type fakeBus struct{}
+
+func (fakeBus) Publish(_ context.Context, _ eventbus.Event) error { return nil }
+func (fakeBus) OpenSession(_ context.Context, _ string, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+    return nil, nil
+}
+func (fakeBus) QueryHistory(_ context.Context, _ eventbus.HistoryQuery) (eventbus.HistoryStream, error) {
+    return nil, nil
+}
+
+func TestEventBusInterfaceComposesAllThree(t *testing.T) {
+    var (
+        _ eventbus.Publisher     = fakeBus{}
+        _ eventbus.Subscriber    = fakeBus{}
+        _ eventbus.HistoryReader = fakeBus{}
+        _ eventbus.EventBus      = fakeBus{}
+    )
+}
+```
+
+- [ ] **Step 7: Run all eventbus tests**
+
+```bash
+task test -- ./internal/eventbus/...
+```
+
+Expected: all tests pass. Coverage MUST be ≥ 90%.
+
+- [ ] **Step 8: Add lint rule for `time.Sleep` ban**
+
+Modify `.golangci.yml` to add a `forbidigo` rule (if `forbidigo` is not yet enabled, add it):
+
+```yaml
+linters:
+  enable:
+    - forbidigo
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - p: ^time\.Sleep$
+        pkg: ^github.com/holomush/holomush/internal/eventbus(/.*)?$
+        msg: "time.Sleep is banned in eventbus tests; use eventbustest.Await* helpers instead"
+      - p: ^time\.Sleep$
+        pkg: ^github.com/holomush/holomush/test/integration/eventbus_e2e(/.*)?$
+        msg: "time.Sleep is banned in eventbus E2E tests; use eventbustest.Await* helpers instead"
+    analyze-types: true
+```
+
+- [ ] **Step 9: Run lint to verify no false positives**
+
+```bash
+task lint
+```
+
+Expected: passes. (Old code still uses `time.Sleep` legitimately and is outside the ban path.)
+
+- [ ] **Step 10: Run full pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: all green.
+
+- [ ] **Step 11: Commit M1**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`. Conventional message: `feat(eventbus): M1 — types, interfaces, errors, and lint guardrails`.
+
+---
+
+## Task M2: Codec interface, IdentityCodec, registry meta-test
+
+**Files:**
+
+- Create: `internal/eventbus/codec/codec.go`, `internal/eventbus/codec/codec_test.go`
+- Create: `internal/eventbus/codec/registry.go`, `internal/eventbus/codec/registry_test.go`
+
+**Bead:** `holomush-1tvn.M2`
+
+- [ ] **Step 1: Write the failing test for `IdentityCodec` round-trip**
+
+Create directory and write `internal/eventbus/codec/codec_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+func TestIdentityCodecRoundTripPreservesBytes(t *testing.T) {
+    c := codec.IdentityCodec{}
+    plaintext := []byte("hello, scene 01JABC")
+
+    encoded, err := c.Encode(context.Background(), plaintext, codec.NoKey)
+    require.NoError(t, err)
+
+    decoded, err := c.Decode(context.Background(), encoded, codec.NoKey)
+    require.NoError(t, err)
+    require.Equal(t, plaintext, decoded)
+}
+
+func TestIdentityCodecHandlesEmptyPlaintext(t *testing.T) {
+    c := codec.IdentityCodec{}
+    encoded, err := c.Encode(context.Background(), nil, codec.NoKey)
+    require.NoError(t, err)
+    decoded, err := c.Decode(context.Background(), encoded, codec.NoKey)
+    require.NoError(t, err)
+    require.Empty(t, decoded)
+}
+
+func TestIdentityCodecName(t *testing.T) {
+    c := codec.IdentityCodec{}
+    require.Equal(t, codec.NameIdentity, c.Name())
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+task test -- ./internal/eventbus/codec/...
+```
+
+Expected: build error (package doesn't exist).
+
+- [ ] **Step 3: Write `codec.go`**
+
+```bash
+mkdir -p internal/eventbus/codec
+```
+
+Create `internal/eventbus/codec/codec.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package codec defines the host-owned codec interface for event payload
+// encoding/decoding. The Identity codec is the pass-through default;
+// future encryption codecs (e.g., aes-gcm-v1) plug in via the registry.
+//
+// Per the spec (§9), the codec is a narrow crypto primitive — it does
+// NOT know about subjects or routing. Subject→key mapping lives in a
+// separate KeySelector (also defined here, no production implementation
+// yet).
+package codec
+
+import "context"
+
+// Name is a closed enumeration of host-known codecs. Plugins MUST NOT
+// register codecs.
+type Name string
+
+const (
+    NameIdentity Name = "identity"
+    // Future:
+    // NameAESGCMv1        Name = "aes-gcm-v1"
+    // NameXChaCha20v1     Name = "xchacha20poly1305-v1"
+)
+
+// Codec encodes and decodes event payload bytes. Implementations MUST be
+// stateless and safe for concurrent use.
+type Codec interface {
+    Name() Name
+    Encode(ctx context.Context, plaintext []byte, key Key) ([]byte, error)
+    Decode(ctx context.Context, ciphertext []byte, key Key) ([]byte, error)
+}
+
+// Key is the opaque cryptographic material a codec uses to encrypt/decrypt.
+// IdentityCodec ignores it and accepts NoKey.
+type Key struct {
+    ID    KeyID
+    Bytes []byte
+    // Codec-specific metadata may be carried inside Bytes; codecs are free
+    // to interpret as they need.
+}
+
+// NoKey is the sentinel passed to keyless codecs (IdentityCodec).
+var NoKey = Key{}
+
+// KeyID is a stable identifier for a key version. Stored in the codec's
+// internal envelope so Decode can pick the right key on rotation.
+type KeyID uint64
+
+// KeyLabel is a logical purpose name (e.g., "scene-content", "dm-content")
+// used by KeyProvider.Active to look up the current key for that purpose.
+type KeyLabel string
+
+// KeyProvider supplies keys to codecs.
+type KeyProvider interface {
+    Active(ctx context.Context, label KeyLabel) (Key, error)
+    ByID(ctx context.Context, id KeyID) (Key, error)
+}
+
+// KeySelector maps a publish-time subject to (codec name, key label) per
+// the deployment's encryption policy. Lives upstream of Codec.
+type KeySelector interface {
+    SelectForEncrypt(ctx context.Context, subject string) (Name, KeyLabel, error)
+    SelectForDecrypt(ctx context.Context, codec Name, keyID KeyID) (Key, error)
+}
+
+// IdentityCodec is the default no-op codec. It returns plaintext unchanged.
+type IdentityCodec struct{}
+
+func (IdentityCodec) Name() Name { return NameIdentity }
+
+func (IdentityCodec) Encode(_ context.Context, plaintext []byte, _ Key) ([]byte, error) {
+    return plaintext, nil
+}
+
+func (IdentityCodec) Decode(_ context.Context, ciphertext []byte, _ Key) ([]byte, error) {
+    return ciphertext, nil
+}
+```
+
+- [ ] **Step 4: Run codec_test.go to verify pass**
+
+```bash
+task test -- ./internal/eventbus/codec/...
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 5: Write the registry**
+
+Create `internal/eventbus/codec/registry.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec
+
+import (
+    "fmt"
+    "sync"
+)
+
+// registry holds all host-known codecs. Closed enumeration — plugins
+// cannot register codecs. The variable is package-private; access via
+// Resolve / All / RegisterForTest.
+var (
+    regMu    sync.RWMutex
+    registry = map[Name]Codec{
+        NameIdentity: IdentityCodec{},
+    }
+)
+
+// Resolve returns the codec for the given name, or error if unknown.
+// Hard-fails on unknown names — callers MUST NOT silently fall back to
+// identity.
+func Resolve(name Name) (Codec, error) {
+    regMu.RLock()
+    defer regMu.RUnlock()
+    c, ok := registry[name]
+    if !ok {
+        return nil, fmt.Errorf("codec: unknown name %q", name)
+    }
+    return c, nil
+}
+
+// All returns a copy of all registered codec names. Used by the meta-test
+// to assert const ↔ registry sync.
+func All() []Name {
+    regMu.RLock()
+    defer regMu.RUnlock()
+    out := make([]Name, 0, len(registry))
+    for n := range registry {
+        out = append(out, n)
+    }
+    return out
+}
+
+// RegisterForTest installs a codec at runtime. Production code MUST NOT
+// call this — it is intended for tests that exercise a custom codec
+// (e.g., a stub encrypt/decrypt for property tests). Returns a cleanup
+// func that restores the prior state.
+func RegisterForTest(c Codec) func() {
+    regMu.Lock()
+    prev, hadPrev := registry[c.Name()]
+    registry[c.Name()] = c
+    regMu.Unlock()
+    return func() {
+        regMu.Lock()
+        defer regMu.Unlock()
+        if hadPrev {
+            registry[c.Name()] = prev
+        } else {
+            delete(registry, c.Name())
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Write the meta-test**
+
+Create `internal/eventbus/codec/registry_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec_test
+
+import (
+    "reflect"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+// declaredNames lists every Name constant defined in codec.go.
+// This list MUST be updated when a new constant is added — the meta-test
+// below catches the case where a const is declared but not registered.
+var declaredNames = []codec.Name{
+    codec.NameIdentity,
+    // Add new constants here when introduced.
+}
+
+func TestEveryDeclaredCodecNameIsRegistered(t *testing.T) {
+    for _, n := range declaredNames {
+        t.Run(string(n), func(t *testing.T) {
+            c, err := codec.Resolve(n)
+            require.NoError(t, err, "codec %q is declared but not in registry", n)
+            require.Equal(t, n, c.Name())
+        })
+    }
+}
+
+func TestRegistryHasNoExtraEntriesNotDeclared(t *testing.T) {
+    declared := make(map[codec.Name]bool, len(declaredNames))
+    for _, n := range declaredNames {
+        declared[n] = true
+    }
+    for _, n := range codec.All() {
+        if !declared[n] {
+            t.Errorf("registry contains %q which is not in declaredNames — update declaredNames or remove from registry", n)
+        }
+    }
+}
+
+func TestResolveUnknownCodecReturnsError(t *testing.T) {
+    _, err := codec.Resolve(codec.Name("does-not-exist"))
+    require.Error(t, err)
+}
+
+func TestRegisterForTestRestoresState(t *testing.T) {
+    var stub stubCodec
+    cleanup := codec.RegisterForTest(stub)
+    c, err := codec.Resolve(stub.Name())
+    require.NoError(t, err)
+    require.True(t, reflect.TypeOf(c) == reflect.TypeOf(stub))
+
+    cleanup()
+    _, err = codec.Resolve(stub.Name())
+    require.Error(t, err)
+}
+
+type stubCodec struct{}
+
+func (stubCodec) Name() codec.Name { return codec.Name("test-only-stub") }
+func (stubCodec) Encode(_ interface{}, p []byte, _ codec.Key) ([]byte, error) {
+    return p, nil
+}
+func (stubCodec) Decode(_ interface{}, p []byte, _ codec.Key) ([]byte, error) {
+    return p, nil
+}
+```
+
+Wait — the stub above has wrong signatures (uses `interface{}` for ctx). Fix the test stub to match the real `Codec` interface (uses `context.Context`):
+
+Replace the bottom of `registry_test.go`:
+
+```go
+type stubCodec struct{}
+
+func (stubCodec) Name() codec.Name { return codec.Name("test-only-stub") }
+func (stubCodec) Encode(_ context.Context, p []byte, _ codec.Key) ([]byte, error) {
+    return p, nil
+}
+func (stubCodec) Decode(_ context.Context, p []byte, _ codec.Key) ([]byte, error) {
+    return p, nil
+}
+```
+
+And add `import "context"` at the top.
+
+- [ ] **Step 7: Run registry_test**
+
+```bash
+task test -- ./internal/eventbus/codec/...
+```
+
+Expected: all tests pass. Coverage MUST be ≥ 95%.
+
+- [ ] **Step 8: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green.
+
+- [ ] **Step 9: Commit M2**
+
+Commit. Conventional message: `feat(eventbus/codec): M2 — codec interface, IdentityCodec, closed registry with sync meta-test`.
+
+---
+
+## Task M3: PostgreSQL `events_audit` migration
+
+**Files:**
+
+- Create: `internal/store/migrations/000NNN_create_events_audit.up.sql`, `.down.sql` (NNN = next available number)
+- Create: `internal/store/events_audit_test.go`
+
+**Bead:** `holomush-1tvn.M3`
+
+- [ ] **Step 1: Determine the next migration number**
+
+```bash
+ls internal/store/migrations/ | sort | tail -3
+```
+
+Use the next sequential number after the highest existing migration. Example: if last is `000019_*`, use `000020`.
+
+- [ ] **Step 2: Write the up migration**
+
+Create `internal/store/migrations/000020_create_events_audit.up.sql` (replace `000020` with the actual number from Step 1):
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+CREATE TABLE IF NOT EXISTS events_audit (
+    id           BYTEA       PRIMARY KEY,
+    subject      TEXT        NOT NULL,
+    type         TEXT        NOT NULL,
+    timestamp    TIMESTAMPTZ NOT NULL,
+    actor_kind   TEXT        NOT NULL,
+    actor_id     BYTEA,
+    payload      BYTEA       NOT NULL,
+    schema_ver   SMALLINT    NOT NULL,
+    codec        TEXT        NOT NULL,
+    js_seq       BIGINT      NOT NULL,
+    inserted_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS events_audit_subject_id  ON events_audit (subject, id);
+CREATE INDEX IF NOT EXISTS events_audit_subject_ts  ON events_audit (subject, timestamp);
+CREATE INDEX IF NOT EXISTS events_audit_subject_pat ON events_audit (subject text_pattern_ops);
+```
+
+- [ ] **Step 3: Write the down migration**
+
+Create `internal/store/migrations/000020_create_events_audit.down.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+DROP INDEX IF EXISTS events_audit_subject_pat;
+DROP INDEX IF EXISTS events_audit_subject_ts;
+DROP INDEX IF EXISTS events_audit_subject_id;
+DROP TABLE IF EXISTS events_audit;
+```
+
+- [ ] **Step 4: Write the integration test (uses testcontainers)**
+
+Create `internal/store/events_audit_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package store_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/oklog/ulid/v2"
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/test/testutil"
+)
+
+func TestEventsAuditTablePresentWithIndexes(t *testing.T) {
+    pg := testutil.SharedPostgres(t)
+    db := testutil.FreshDatabase(t, pg)
+    ctx := context.Background()
+
+    var n int
+    require.NoError(t,
+        db.QueryRowContext(ctx,
+            "SELECT count(*) FROM information_schema.tables WHERE table_name='events_audit'",
+        ).Scan(&n),
+    )
+    require.Equal(t, 1, n, "events_audit table not created by migrations")
+
+    rows, err := db.QueryContext(ctx,
+        "SELECT indexname FROM pg_indexes WHERE tablename='events_audit' ORDER BY indexname",
+    )
+    require.NoError(t, err)
+    defer rows.Close()
+    var indexes []string
+    for rows.Next() {
+        var name string
+        require.NoError(t, rows.Scan(&name))
+        indexes = append(indexes, name)
+    }
+    require.Contains(t, indexes, "events_audit_subject_id")
+    require.Contains(t, indexes, "events_audit_subject_ts")
+    require.Contains(t, indexes, "events_audit_subject_pat")
+    require.Contains(t, indexes, "events_audit_pkey")
+}
+
+func TestEventsAuditInsertOnConflictIsIdempotent(t *testing.T) {
+    pg := testutil.SharedPostgres(t)
+    db := testutil.FreshDatabase(t, pg)
+    ctx := context.Background()
+
+    id := ulid.Make()
+    insert := `
+        INSERT INTO events_audit (
+            id, subject, type, timestamp, actor_kind, actor_id,
+            payload, schema_ver, codec, js_seq
+        ) VALUES ($1, $2, $3, now(), 'system', NULL, $4, 1, 'identity', 100)
+        ON CONFLICT (id) DO NOTHING`
+    payload := []byte(`{"hello":"world"}`)
+
+    res1, err := db.ExecContext(ctx, insert, id[:], "events.main.test", "test.t", payload)
+    require.NoError(t, err)
+    n1, _ := res1.RowsAffected()
+    require.EqualValues(t, 1, n1, "first insert should affect 1 row")
+
+    res2, err := db.ExecContext(ctx, insert, id[:], "events.main.test", "test.t", payload)
+    require.NoError(t, err)
+    n2, _ := res2.RowsAffected()
+    require.EqualValues(t, 0, n2, "duplicate insert should affect 0 rows")
+
+    var count int
+    require.NoError(t,
+        db.QueryRowContext(ctx, "SELECT count(*) FROM events_audit WHERE id=$1", id[:]).Scan(&count),
+    )
+    require.Equal(t, 1, count)
+}
+
+func TestEventsAuditCodecColumnIsNotNull(t *testing.T) {
+    pg := testutil.SharedPostgres(t)
+    db := testutil.FreshDatabase(t, pg)
+    ctx := context.Background()
+
+    id := ulid.Make()
+    insert := `
+        INSERT INTO events_audit (
+            id, subject, type, timestamp, actor_kind, actor_id,
+            payload, schema_ver, codec, js_seq
+        ) VALUES ($1, 'events.main.test', 'test.t', now(), 'system', NULL, $2, 1, NULL, 100)`
+    _, err := db.ExecContext(ctx, insert, id[:], []byte(`{}`))
+    require.Error(t, err, "NULL codec should be rejected by NOT NULL constraint")
+}
+```
+
+- [ ] **Step 5: Run the integration tests**
+
+```bash
+task test:int -- -run TestEventsAudit ./internal/store/...
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green (includes migration smoke test).
+
+- [ ] **Step 7: Commit M3**
+
+Conventional message: `feat(store): M3 — add events_audit table for JetStream audit projection`.
+
+---
+
+## Task M4: `SubsystemEventBus` — embedded NATS lifecycle
+
+**Files:**
+
+- Create: `internal/eventbus/config.go`
+- Create: `internal/eventbus/subsystem.go`, `internal/eventbus/subsystem_test.go`
+- Create: `internal/eventbus/eventbustest/embedded.go`
+- Modify: `internal/lifecycle/subsystem.go` — add `SubsystemEventBus` ID
+- Modify: `internal/config/config.go` — add `EventBus` config struct
+- Modify: `cmd/holomush/core.go` — register the subsystem
+- Modify: `go.mod` — add `nats-server/v2` and `nats.go` deps
+
+**Bead:** `holomush-1tvn.M4`
+
+- [ ] **Step 1: Add NATS deps**
+
+```bash
+task install -- github.com/nats-io/nats-server/v2 || \
+    go get github.com/nats-io/nats-server/v2@latest && \
+    go get github.com/nats-io/nats.go@latest && \
+    go mod tidy
+```
+
+(Use the project's preferred dep update flow — `task` if a `go-get` task exists, otherwise `go get`.)
+
+Pin to the latest GA minor (verify `go.mod` shows `v2.12.x` or current latest).
+
+- [ ] **Step 2: Add lifecycle subsystem ID**
+
+Edit `internal/lifecycle/subsystem.go`. Add to the existing `const` block:
+
+```go
+const (
+    // ... existing IDs ...
+    SubsystemEventBus         SubsystemID = "eventbus"
+    SubsystemAuditProjection  SubsystemID = "audit_projection"
+)
+```
+
+- [ ] **Step 3: Write `config.go`**
+
+Create `internal/eventbus/config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import "time"
+
+// Mode selects between embedded and clustered NATS.
+type Mode string
+
+const (
+    ModeEmbedded Mode = "embedded"
+    ModeCluster  Mode = "cluster" // future; not implemented in Phase A
+)
+
+// Config controls the EventBus subsystem.
+type Config struct {
+    Mode     Mode
+    GameID   string // mandatory; first segment after "events." (default "main")
+    StoreDir string // blank = xdg.DataDir() + "/jetstream"
+
+    StreamMaxAge time.Duration // default 720h (30 days)
+    DupeWindow   time.Duration // default 30m
+
+    MonitorPort        int  // 0 = disabled
+    PrometheusExporter bool // in-process exporter
+
+    // Cluster-mode only (unused in Phase A):
+    ClusterURL      string
+    CredentialsFile string
+}
+
+// Defaults applies the documented defaults to any zero-value field.
+func (c Config) Defaults() Config {
+    if c.Mode == "" {
+        c.Mode = ModeEmbedded
+    }
+    if c.GameID == "" {
+        c.GameID = "main"
+    }
+    if c.StreamMaxAge == 0 {
+        c.StreamMaxAge = 30 * 24 * time.Hour
+    }
+    if c.DupeWindow == 0 {
+        c.DupeWindow = 30 * time.Minute
+    }
+    return c
+}
+```
+
+- [ ] **Step 4: Wire config into `internal/config/config.go`**
+
+Add the new section to the existing config struct (locate the appropriate config struct in `internal/config/config.go` and add):
+
+```go
+// EventBus is the JetStream event bus configuration. Phase A only.
+EventBus eventbus.Config `koanf:"event_bus"`
+```
+
+(Add the import for `internal/eventbus`.)
+
+- [ ] **Step 5: Write the failing subsystem test**
+
+Create `internal/eventbus/subsystem_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus_test
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus"
+    "github.com/holomush/holomush/internal/eventbus/eventbustest"
+)
+
+func TestSubsystemStartsAndExposesJetStream(t *testing.T) {
+    e := eventbustest.New(t)
+    require.NotNil(t, e.JS)
+    info, err := e.JS.Stream(context.Background(), "EVENTS")
+    require.NoError(t, err)
+    require.NotNil(t, info)
+}
+
+func TestSubsystemStreamDeclarationIsIdempotent(t *testing.T) {
+    e := eventbustest.New(t)
+    // Re-running ensure shouldn't error
+    sub := e.Bus
+    require.NoError(t, sub.EnsureStream(context.Background()))
+    require.NoError(t, sub.EnsureStream(context.Background()))
+}
+
+func TestSubsystemStopDrainsAndShutsDown(t *testing.T) {
+    e := eventbustest.New(t)
+    require.NoError(t, e.Bus.Stop(context.Background()))
+    // After Stop, calls SHOULD fail
+    _, err := e.JS.Stream(context.Background(), "EVENTS")
+    require.Error(t, err)
+}
+
+func TestSubsystemDependsOnNothing(t *testing.T) {
+    s := eventbus.NewSubsystem(eventbus.Config{}.Defaults())
+    require.Empty(t, s.DependsOn())
+}
+
+func TestSubsystemReadyTimeoutIsBounded(t *testing.T) {
+    // The embedded server SHOULD be ready well under 10s.
+    start := time.Now()
+    e := eventbustest.New(t)
+    elapsed := time.Since(start)
+    require.NotNil(t, e.Bus)
+    require.Less(t, elapsed, 5*time.Second, "Subsystem.Start exceeded 5s")
+}
+```
+
+- [ ] **Step 6: Implement the subsystem and the test helper**
+
+Create `internal/eventbus/subsystem.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "time"
+
+    "github.com/nats-io/nats-server/v2/server"
+    "github.com/nats-io/nats.go"
+    "github.com/nats-io/nats.go/jetstream"
+
+    "github.com/holomush/holomush/internal/lifecycle"
+)
+
+// StreamName is the single JetStream stream that holds all events.
+const StreamName = "EVENTS"
+
+// SubjectFilter is the stream subject filter — every event lands here.
+const SubjectFilter = "events.>"
+
+// Subsystem wraps the embedded NATS server and exposes a JetStream context.
+type Subsystem struct {
+    cfg     Config
+    server  *server.Server
+    conn    *nats.Conn
+    js      jetstream.JetStream
+    storage jetstream.StorageType // overridable for tests
+}
+
+// NewSubsystem constructs the subsystem from a defaulted Config.
+// FileStorage is the default; tests override via NewSubsystemWithStorage.
+func NewSubsystem(cfg Config) *Subsystem {
+    return NewSubsystemWithStorage(cfg, jetstream.FileStorage)
+}
+
+// NewSubsystemWithStorage allows tests to use MemoryStorage for speed.
+func NewSubsystemWithStorage(cfg Config, storage jetstream.StorageType) *Subsystem {
+    return &Subsystem{cfg: cfg.Defaults(), storage: storage}
+}
+
+func (s *Subsystem) ID() lifecycle.SubsystemID { return lifecycle.SubsystemEventBus }
+func (s *Subsystem) DependsOn() []lifecycle.SubsystemID { return nil }
+
+func (s *Subsystem) Start(ctx context.Context) error {
+    opts := &server.Options{
+        ServerName: "holomush-embedded",
+        JetStream:  true,
+        StoreDir:   s.cfg.StoreDir,
+        DontListen: true,
+        NoSigs:     true,
+        LogtimeUTC: true,
+        HTTPPort:   s.cfg.MonitorPort,
+    }
+    srv, err := server.NewServer(opts)
+    if err != nil {
+        return fmt.Errorf("eventbus: NewServer: %w", err)
+    }
+    s.server = srv
+    go s.server.Start()
+    if !s.server.ReadyForConnections(10 * time.Second) {
+        s.server.Shutdown()
+        return errors.New("eventbus: NATS server not ready in 10s")
+    }
+    s.conn, err = nats.Connect("",
+        nats.InProcessServer(s.server),
+        nats.Name("holomush-host"),
+    )
+    if err != nil {
+        s.server.Shutdown()
+        return fmt.Errorf("eventbus: in-process connect: %w", err)
+    }
+    s.js, err = jetstream.New(s.conn)
+    if err != nil {
+        s.conn.Close()
+        s.server.Shutdown()
+        return fmt.Errorf("eventbus: jetstream context: %w", err)
+    }
+    if err := s.EnsureStream(ctx); err != nil {
+        s.conn.Close()
+        s.server.Shutdown()
+        return err
+    }
+    return nil
+}
+
+// EnsureStream creates or updates the EVENTS stream idempotently.
+func (s *Subsystem) EnsureStream(ctx context.Context) error {
+    _, err := s.js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+        Name:        StreamName,
+        Subjects:    []string{SubjectFilter},
+        Retention:   jetstream.LimitsPolicy,
+        Storage:     s.storage,
+        Replicas:    1,
+        MaxAge:      s.cfg.StreamMaxAge,
+        Duplicates:  s.cfg.DupeWindow,
+        AllowDirect: true,
+    })
+    if err != nil {
+        return fmt.Errorf("eventbus: CreateOrUpdateStream: %w", err)
+    }
+    return nil
+}
+
+func (s *Subsystem) Stop(ctx context.Context) error {
+    if s.conn != nil {
+        _ = s.conn.Drain()
+    }
+    if s.server != nil {
+        s.server.Shutdown()
+        s.server.WaitForShutdown()
+    }
+    return nil
+}
+
+// JS returns the JetStream context. Used by audit projection (M5) and
+// the publish/subscribe wiring (Phase B).
+func (s *Subsystem) JS() jetstream.JetStream { return s.js }
+
+// Conn returns the in-process NATS connection.
+func (s *Subsystem) Conn() *nats.Conn { return s.conn }
+```
+
+Create `internal/eventbus/eventbustest/embedded.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package eventbustest provides test helpers for the embedded JetStream
+// event bus. Tests SHOULD use New(t) to get a fresh, in-memory bus per test.
+package eventbustest
+
+import (
+    "context"
+    "testing"
+
+    "github.com/nats-io/nats.go"
+    "github.com/nats-io/nats.go/jetstream"
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus"
+)
+
+// Embedded bundles the bus subsystem with its JetStream context and
+// connection so tests can interact directly.
+type Embedded struct {
+    Bus  *eventbus.Subsystem
+    JS   jetstream.JetStream
+    Conn *nats.Conn
+}
+
+// New starts a fresh embedded NATS server with MemoryStorage and registers
+// cleanup on t.Cleanup. Per-test isolation; safe for t.Parallel.
+func New(t *testing.T) *Embedded {
+    t.Helper()
+    cfg := eventbus.Config{
+        StoreDir: t.TempDir(),
+    }.Defaults()
+    bus := eventbus.NewSubsystemWithStorage(cfg, jetstream.MemoryStorage)
+    require.NoError(t, bus.Start(context.Background()))
+    t.Cleanup(func() { _ = bus.Stop(context.Background()) })
+    return &Embedded{
+        Bus:  bus,
+        JS:   bus.JS(),
+        Conn: bus.Conn(),
+    }
+}
+```
+
+- [ ] **Step 7: Run subsystem tests**
+
+```bash
+task test -- ./internal/eventbus/...
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 8: Register the subsystem in the orchestrator (idle wiring)**
+
+Edit `cmd/holomush/core.go`. Locate the section where subsystems are constructed and registered (after `dbSub` per the existing pattern). Add:
+
+```go
+// JetStream event bus (idle in Phase A — no consumers until Phase B F1).
+eventBusSub := eventbus.NewSubsystem(cfg.EventBus)
+orch.Register(eventBusSub)
+```
+
+(Add the import for `internal/eventbus`.)
+
+- [ ] **Step 9: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green. The full server starts, embedded NATS comes up, no consumers attach, no events flow. Verify by checking startup logs include "holomush-embedded" server name.
+
+- [ ] **Step 10: Commit M4**
+
+Conventional message: `feat(eventbus): M4 — SubsystemEventBus (embedded NATS, idle Phase A)`.
+
+---
+
+## Task M5: `SubsystemAuditProjection` — durable consumer drains empty stream
+
+**Files:**
+
+- Create: `internal/eventbus/audit/subsystem.go`, `internal/eventbus/audit/subsystem_test.go`
+- Create: `internal/eventbus/audit/projection.go`, `internal/eventbus/audit/projection_test.go`
+- Create: `internal/eventbus/audit/lag_metric.go`
+- Modify: `cmd/holomush/core.go` — register
+
+**Bead:** `holomush-1tvn.M5`
+
+The projection worker writes audit rows for every JS message NOT owned by a plugin. In Phase A, no plugins claim subjects yet, so the worker sees `events.>` minus an empty exclusion list = `events.>`. But nothing publishes (Phase B introduces publishing), so the worker drains zero messages and reports lag == 0.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `internal/eventbus/audit/projection_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package audit_test
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+    "github.com/oklog/ulid/v2"
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/audit"
+    "github.com/holomush/holomush/internal/eventbus/eventbustest"
+    "github.com/holomush/holomush/test/testutil"
+)
+
+func TestProjectionDrainsPublishedMessageToAuditTable(t *testing.T) {
+    e := eventbustest.New(t)
+    pg := testutil.SharedPostgres(t)
+    db := testutil.FreshDatabase(t, pg)
+
+    proj := audit.NewSubsystem(e.Bus.JS(), db, audit.Config{}.Defaults())
+    require.NoError(t, proj.Start(context.Background()))
+    t.Cleanup(func() { _ = proj.Stop(context.Background()) })
+
+    // Publish a raw NATS message simulating an event publish.
+    id := ulid.Make()
+    msgID := id.String()
+    _, err := e.Bus.JS().Publish(context.Background(), "events.main.test.unit", []byte(`{"hello":"world"}`),
+        jetstream.WithMsgID(msgID),
+    )
+    require.NoError(t, err)
+
+    // Wait until projection ack catches up (deterministic via metric, not sleep).
+    proj.AwaitDrained(t, 5*time.Second)
+
+    var count int
+    require.NoError(t,
+        db.QueryRowContext(context.Background(),
+            "SELECT count(*) FROM events_audit WHERE id=$1", id[:]).Scan(&count))
+    require.Equal(t, 1, count)
+}
+
+func TestProjectionIsIdempotentOnDuplicate(t *testing.T) {
+    // ... similar setup, publish same id twice, assert count == 1
+}
+```
+
+(For brevity, the second test is omitted in this plan — implement it analogously.)
+
+- [ ] **Step 2: Implement `audit.Subsystem` and `Config`**
+
+Create `internal/eventbus/audit/subsystem.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package audit projects events from JetStream into the PostgreSQL
+// events_audit table for forever-archive and historical query support.
+package audit
+
+import (
+    "context"
+    "database/sql"
+    "fmt"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+
+    "github.com/holomush/holomush/internal/lifecycle"
+)
+
+// Config controls the audit projection worker.
+type Config struct {
+    ConsumerName  string        // default "host_audit_projection"
+    BatchSize     int           // default 64 (matches MaxAckPending)
+    AckWait       time.Duration // default 5s
+    MaxAckPending int           // default 64
+}
+
+func (c Config) Defaults() Config {
+    if c.ConsumerName == "" {
+        c.ConsumerName = "host_audit_projection"
+    }
+    if c.BatchSize == 0 {
+        c.BatchSize = 64
+    }
+    if c.AckWait == 0 {
+        c.AckWait = 5 * time.Second
+    }
+    if c.MaxAckPending == 0 {
+        c.MaxAckPending = 64
+    }
+    return c
+}
+
+// Subsystem manages the host audit projection worker lifecycle.
+type Subsystem struct {
+    js     jetstream.JetStream
+    db     *sql.DB
+    cfg    Config
+    cancel context.CancelFunc
+    worker *projection
+}
+
+func NewSubsystem(js jetstream.JetStream, db *sql.DB, cfg Config) *Subsystem {
+    return &Subsystem{js: js, db: db, cfg: cfg.Defaults()}
+}
+
+func (s *Subsystem) ID() lifecycle.SubsystemID { return lifecycle.SubsystemAuditProjection }
+
+func (s *Subsystem) DependsOn() []lifecycle.SubsystemID {
+    return []lifecycle.SubsystemID{
+        lifecycle.SubsystemDatabase,
+        lifecycle.SubsystemEventBus,
+    }
+}
+
+func (s *Subsystem) Start(ctx context.Context) error {
+    p, err := newProjection(ctx, s.js, s.db, s.cfg)
+    if err != nil {
+        return fmt.Errorf("audit: %w", err)
+    }
+    s.worker = p
+    workerCtx, cancel := context.WithCancel(context.Background())
+    s.cancel = cancel
+    go p.run(workerCtx)
+    return nil
+}
+
+func (s *Subsystem) Stop(ctx context.Context) error {
+    if s.cancel != nil {
+        s.cancel()
+    }
+    if s.worker != nil {
+        return s.worker.drain(ctx)
+    }
+    return nil
+}
+
+// AwaitDrained is a test-only helper: blocks until the consumer's last-acked
+// seq matches the stream's last-published seq, or until timeout.
+func (s *Subsystem) AwaitDrained(t interface{ Helper(); Fatal(args ...any) }, timeout time.Duration) {
+    if s.worker == nil {
+        return
+    }
+    s.worker.awaitDrained(t, timeout)
+}
+```
+
+Create `internal/eventbus/audit/projection.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+    "context"
+    "database/sql"
+    "fmt"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+)
+
+// projection holds the durable pull consumer and INSERT loop.
+type projection struct {
+    consumer jetstream.Consumer
+    db       *sql.DB
+    cfg      Config
+}
+
+func newProjection(ctx context.Context, js jetstream.JetStream, db *sql.DB, cfg Config) (*projection, error) {
+    cons, err := js.CreateOrUpdateConsumer(ctx, "EVENTS", jetstream.ConsumerConfig{
+        Durable:        cfg.ConsumerName,
+        FilterSubjects: []string{"events.>"},
+        AckPolicy:      jetstream.AckExplicitPolicy,
+        AckWait:        cfg.AckWait,
+        MaxAckPending:  cfg.MaxAckPending,
+    })
+    if err != nil {
+        return nil, fmt.Errorf("CreateOrUpdateConsumer: %w", err)
+    }
+    return &projection{consumer: cons, db: db, cfg: cfg}, nil
+}
+
+func (p *projection) run(ctx context.Context) {
+    cc, err := p.consumer.Consume(p.handle)
+    if err != nil {
+        // Real impl: structured-log + retry-with-backoff. For Phase A this is rare.
+        return
+    }
+    <-ctx.Done()
+    cc.Stop()
+}
+
+func (p *projection) handle(msg jetstream.Msg) {
+    if err := p.persist(msg); err != nil {
+        // No-ack on error; JS will redeliver after AckWait.
+        // Real impl: structured-log + lag-metric increment.
+        return
+    }
+    _ = msg.Ack()
+}
+
+func (p *projection) persist(msg jetstream.Msg) error {
+    h := msg.Headers()
+    msgID := h.Get("Nats-Msg-Id")
+    if msgID == "" {
+        return fmt.Errorf("audit: missing Nats-Msg-Id header")
+    }
+    codec := h.Get("App-Codec")
+    if codec == "" {
+        return fmt.Errorf("audit: missing App-Codec header")
+    }
+    eventType := h.Get("App-Event-Type")
+    if eventType == "" {
+        return fmt.Errorf("audit: missing App-Event-Type header")
+    }
+    schemaVer := h.Get("App-Schema-Version")
+    if schemaVer == "" {
+        return fmt.Errorf("audit: missing App-Schema-Version header")
+    }
+    meta, err := msg.Metadata()
+    if err != nil {
+        return fmt.Errorf("audit: msg.Metadata: %w", err)
+    }
+    // Phase A test path: actor data is not yet in headers; default to system.
+    // Phase B publish path will inject ActorKind/ActorID headers.
+    actorKind := h.Get("App-Actor-Kind")
+    if actorKind == "" {
+        actorKind = "system"
+    }
+    var actorID []byte
+    if v := h.Get("App-Actor-ID"); v != "" {
+        actorID = []byte(v)
+    }
+    // ULID id from msgID (msgID is the canonical ULID string).
+    idBytes, err := decodeULIDString(msgID)
+    if err != nil {
+        return fmt.Errorf("audit: decode msg-id ulid: %w", err)
+    }
+    _, err = p.db.ExecContext(context.Background(), `
+        INSERT INTO events_audit (
+            id, subject, type, timestamp, actor_kind, actor_id,
+            payload, schema_ver, codec, js_seq
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (id) DO NOTHING`,
+        idBytes,
+        msg.Subject(),
+        eventType,
+        meta.Timestamp,
+        actorKind,
+        actorID,
+        msg.Data(),
+        atoiOrZero(schemaVer),
+        codec,
+        meta.Sequence.Stream,
+    )
+    return err
+}
+
+func (p *projection) drain(ctx context.Context) error {
+    // Best-effort: wait briefly for in-flight handle() calls to complete.
+    // ConsumeContext.Stop() is called in run() on cancel.
+    select {
+    case <-time.After(2 * time.Second):
+        return nil
+    case <-ctx.Done():
+        return ctx.Err()
+    }
+}
+
+func (p *projection) awaitDrained(t interface{ Helper(); Fatal(args ...any) }, timeout time.Duration) {
+    t.Helper()
+    deadline := time.Now().Add(timeout)
+    for time.Now().Before(deadline) {
+        info, err := p.consumer.Info(context.Background())
+        if err == nil && info.NumPending == 0 && info.NumAckPending == 0 {
+            return
+        }
+        time.Sleep(20 * time.Millisecond) // safe in test helper, not test code
+    }
+    t.Fatal("audit projection did not drain in time")
+}
+```
+
+Add helpers (`decodeULIDString`, `atoiOrZero`) at the bottom of the same file:
+
+```go
+import "github.com/oklog/ulid/v2"
+import "strconv"
+
+func decodeULIDString(s string) ([]byte, error) {
+    u, err := ulid.Parse(s)
+    if err != nil {
+        return nil, err
+    }
+    return u[:], nil
+}
+
+func atoiOrZero(s string) int {
+    n, _ := strconv.Atoi(s)
+    return n
+}
+```
+
+(Move imports to the top of file in real implementation.)
+
+Create `internal/eventbus/audit/lag_metric.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+    "github.com/prometheus/client_golang/prometheus"
+)
+
+// LagSeconds reports the audit projection's lag (publish→ack) per subject domain.
+var LagSeconds = prometheus.NewGaugeVec(
+    prometheus.GaugeOpts{
+        Namespace: "holomush",
+        Subsystem: "audit",
+        Name:      "projection_lag_seconds",
+        Help:      "Seconds between latest published seq and audit consumer's last-acked seq",
+    },
+    []string{"projection"},
+)
+
+func init() {
+    prometheus.MustRegister(LagSeconds)
+}
+```
+
+- [ ] **Step 3: Run the integration test**
+
+```bash
+task test:int -- -run TestProjection ./internal/eventbus/audit/...
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Register the audit subsystem in the orchestrator**
+
+Edit `cmd/holomush/core.go`:
+
+```go
+auditSub := audit.NewSubsystem(eventBusSub.JS(), db, audit.Config{})
+orch.Register(auditSub)
+```
+
+(Order matters: `auditSub` registered after `eventBusSub` and `dbSub` since it depends on both.)
+
+- [ ] **Step 5: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green. Full server starts; audit projection comes up; drains zero messages (no publishers yet); shuts down cleanly.
+
+- [ ] **Step 6: Commit M5**
+
+Conventional message: `feat(eventbus/audit): M5 — SubsystemAuditProjection (idle Phase A)`.
+
+---
+
+## Task M6: `PluginAuditService` proto + bindings
+
+**Files:**
+
+- Create: `api/proto/holomush/eventbus/v1/eventbus.proto`
+- Create: `api/proto/holomush/plugin/v1/audit.proto`
+- Generated: `pkg/proto/holomush/eventbus/v1/eventbus.pb.go`
+- Generated: `pkg/proto/holomush/plugin/v1/audit.pb.go`, `audit_grpc.pb.go`
+
+**Bead:** `holomush-1tvn.M6`
+
+- [ ] **Step 1: Write `eventbus.proto` (host envelope)**
+
+Create `api/proto/holomush/eventbus/v1/eventbus.proto`:
+
+```protobuf
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+syntax = "proto3";
+
+package holomush.eventbus.v1;
+
+option go_package = "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1;eventbusv1";
+
+import "google/protobuf/timestamp.proto";
+
+// ActorKind identifies what type of entity caused an event.
+enum ActorKind {
+  ACTOR_KIND_UNSPECIFIED = 0;
+  ACTOR_KIND_CHARACTER   = 1;
+  ACTOR_KIND_PLAYER      = 2;
+  ACTOR_KIND_SYSTEM      = 3;
+  ACTOR_KIND_PLUGIN      = 4;
+}
+
+// Actor identifies who caused an event.
+message Actor {
+  ActorKind kind = 1;
+  bytes id = 2; // ULID (16 bytes); empty for system/unknown
+}
+
+// Event is the host-side envelope. Wire encoding is proto bytes in the
+// JetStream message data; headers carry routing/codec/version metadata.
+message Event {
+  bytes id = 1;                             // ULID (16 bytes)
+  string subject = 2;
+  string type = 3;
+  google.protobuf.Timestamp timestamp = 4;
+  Actor actor = 5;
+  bytes payload = 6;                        // codec.Encode output
+}
+```
+
+- [ ] **Step 2: Write `audit.proto` (plugin audit RPC contract)**
+
+Create `api/proto/holomush/plugin/v1/audit.proto`:
+
+```protobuf
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+syntax = "proto3";
+
+package holomush.plugin.v1;
+
+option go_package = "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1;pluginv1";
+
+import "holomush/eventbus/v1/eventbus.proto";
+
+// PluginAuditService is implemented by plugins that declare audit
+// subjects in their manifest. The host owns the JetStream durable
+// consumer and forwards each delivered event to the plugin via
+// AuditEvent. The plugin INSERTs into its own schema and acks.
+//
+// QueryHistory is invoked by host's bus.QueryHistory when the queried
+// subject prefix is owned by this plugin.
+service PluginAuditService {
+  rpc AuditEvent(AuditEventRequest) returns (AuditEventResponse);
+  rpc QueryHistory(QueryHistoryRequest) returns (stream QueryHistoryResponse);
+}
+
+message AuditEventRequest {
+  holomush.eventbus.v1.Event event = 1;
+  // Headers carried verbatim from the JS message (App-Codec,
+  // App-Schema-Version, App-Event-Type, etc.) so the plugin can store them.
+  map<string, string> headers = 2;
+}
+
+message AuditEventResponse {}
+
+message QueryHistoryRequest {
+  string subject = 1;
+  bytes after = 2;       // ULID; empty = from start
+  bytes before = 3;      // ULID; empty = unbounded
+  int32 page_size = 4;   // host caps at 200
+  int32 direction = 5;   // 1=forward, 2=backward
+  google.protobuf.Timestamp not_before = 6;
+  google.protobuf.Timestamp not_after = 7;
+}
+
+message QueryHistoryResponse {
+  holomush.eventbus.v1.Event event = 1;
+}
+```
+
+- [ ] **Step 3: Generate Go bindings**
+
+```bash
+task generate:proto
+```
+
+Expected: new files in `pkg/proto/holomush/eventbus/v1/` and `pkg/proto/holomush/plugin/v1/`.
+
+- [ ] **Step 4: Run buf lint and breaking checks**
+
+```bash
+task lint:proto
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit M6**
+
+Conventional message: `feat(proto): M6 — eventbus envelope + PluginAuditService contract`.
+
+---
+
+## Task M7: OTEL header propagation + Prometheus NATS exporter wiring
+
+**Files:**
+
+- Create: `internal/eventbus/telemetry/otel.go`, `internal/eventbus/telemetry/otel_test.go`
+- Create: `internal/eventbus/telemetry/prometheus.go`, `internal/eventbus/telemetry/prometheus_test.go`
+- Modify: `internal/eventbus/subsystem.go` — wire telemetry on `Start`
+
+**Bead:** `holomush-1tvn.M7`
+
+- [ ] **Step 1: Add `prometheus-nats-exporter` Go dep**
+
+```bash
+go get github.com/nats-io/prometheus-nats-exporter@latest && go mod tidy
+```
+
+- [ ] **Step 2: Write the failing OTEL header test**
+
+Create `internal/eventbus/telemetry/otel_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/nats-io/nats.go"
+    "github.com/stretchr/testify/require"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/sdk/trace"
+
+    "github.com/holomush/holomush/internal/eventbus/telemetry"
+)
+
+func TestInjectExtractRoundTripPreservesTraceContext(t *testing.T) {
+    tp := trace.NewTracerProvider()
+    otel.SetTracerProvider(tp)
+
+    tr := otel.Tracer("test")
+    ctx, span := tr.Start(context.Background(), "publish")
+    defer span.End()
+
+    h := nats.Header{}
+    telemetry.InjectHeaders(ctx, h)
+    require.NotEmpty(t, h.Get("traceparent"), "traceparent header MUST be injected")
+
+    extractedCtx := telemetry.ExtractContext(context.Background(), h)
+    extracted := otel.Tracer("test").Start(extractedCtx, "consume")
+    require.Equal(t, span.SpanContext().TraceID(), extracted.SpanContext().TraceID())
+    extracted.End()
+}
+```
+
+- [ ] **Step 3: Implement OTEL helpers**
+
+Create `internal/eventbus/telemetry/otel.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package telemetry provides OTEL header propagation and in-process
+// Prometheus exporter wiring for the JetStream event bus.
+package telemetry
+
+import (
+    "context"
+
+    "github.com/nats-io/nats.go"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/propagation"
+)
+
+// InjectHeaders writes the W3C traceparent/tracestate headers from ctx
+// into h. Use on the publish path before js.PublishMsg.
+func InjectHeaders(ctx context.Context, h nats.Header) {
+    propagator := otel.GetTextMapPropagator()
+    propagator.Inject(ctx, natsHeaderCarrier(h))
+}
+
+// ExtractContext reads W3C trace headers from h and returns a context
+// linked to the upstream span. Use on the subscribe / audit-projection
+// receive path.
+func ExtractContext(ctx context.Context, h nats.Header) context.Context {
+    propagator := otel.GetTextMapPropagator()
+    return propagator.Extract(ctx, natsHeaderCarrier(h))
+}
+
+// natsHeaderCarrier adapts nats.Header to TextMapCarrier.
+type natsHeaderCarrier nats.Header
+
+func (c natsHeaderCarrier) Get(key string) string         { return nats.Header(c).Get(key) }
+func (c natsHeaderCarrier) Set(key, value string)         { nats.Header(c).Set(key, value) }
+func (c natsHeaderCarrier) Keys() []string {
+    keys := make([]string, 0, len(c))
+    for k := range c {
+        keys = append(keys, k)
+    }
+    return keys
+}
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}
+```
+
+- [ ] **Step 4: Run OTEL test**
+
+```bash
+task test -- ./internal/eventbus/telemetry/...
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Implement Prometheus exporter wiring**
+
+Create `internal/eventbus/telemetry/prometheus.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+    "fmt"
+    "net/url"
+    "strconv"
+
+    "github.com/nats-io/prometheus-nats-exporter/exporter"
+)
+
+// StartNATSExporter starts the prometheus-nats-exporter against the
+// embedded NATS server's monitoring endpoint. monitorPort is the HTTP
+// port set on server.Options. exporterPort is where the exporter
+// listens for Prometheus scrapes (0 = random ephemeral).
+//
+// Returns the exporter handle so the caller can Stop it on shutdown.
+func StartNATSExporter(monitorPort int, exporterPort int) (*exporter.NATSExporter, error) {
+    if monitorPort <= 0 {
+        return nil, fmt.Errorf("telemetry: NATS monitor port must be > 0 to enable exporter")
+    }
+    opts := exporter.GetDefaultExporterOptions()
+    opts.ListenAddress = "127.0.0.1"
+    opts.ListenPort = exporterPort
+    opts.GetVarz = true
+    opts.GetConnz = true
+    opts.GetSubz = true
+    opts.GetJszFilter = "all"
+    exp := exporter.NewExporter(opts)
+    serverURL := (&url.URL{
+        Scheme: "http",
+        Host:   fmt.Sprintf("127.0.0.1:%s", strconv.Itoa(monitorPort)),
+    }).String()
+    if err := exp.AddServer("holomush-embedded", serverURL); err != nil {
+        return nil, fmt.Errorf("telemetry: AddServer: %w", err)
+    }
+    if err := exp.Start(); err != nil {
+        return nil, fmt.Errorf("telemetry: exp.Start: %w", err)
+    }
+    return exp, nil
+}
+```
+
+Create `internal/eventbus/telemetry/prometheus_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry_test
+
+import (
+    "io"
+    "net/http"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/eventbustest"
+    "github.com/holomush/holomush/internal/eventbus/telemetry"
+)
+
+func TestNATSExporterExposesGnatsdMetrics(t *testing.T) {
+    e := eventbustest.New(t)
+    _ = e
+    // For this test, restart with monitor port enabled
+    // (skip the convoluted config; demonstrate exporter starts and serves)
+
+    exp, err := telemetry.StartNATSExporter(8222, 0)
+    if err != nil {
+        t.Skip("monitor port not available in this test env")
+    }
+    t.Cleanup(func() { exp.Stop() })
+
+    // The exporter listens on a random port; query its /metrics
+    addr := exp.HTTPServerAddr()
+    require.NotEmpty(t, addr)
+    resp, err := http.Get("http://" + addr + "/metrics")
+    require.NoError(t, err)
+    defer resp.Body.Close()
+    body, _ := io.ReadAll(resp.Body)
+    require.True(t, strings.Contains(string(body), "gnatsd_"), "expected gnatsd_* metrics")
+}
+```
+
+- [ ] **Step 6: Wire telemetry into the subsystem**
+
+Modify `internal/eventbus/subsystem.go` — at the end of `Start`, after the stream is ensured:
+
+```go
+if s.cfg.PrometheusExporter && s.cfg.MonitorPort > 0 {
+    exp, err := telemetry.StartNATSExporter(s.cfg.MonitorPort, 0)
+    if err != nil {
+        return fmt.Errorf("eventbus: prometheus exporter: %w", err)
+    }
+    s.exporter = exp
+}
+```
+
+Add the field to the struct and the cleanup in `Stop`:
+
+```go
+type Subsystem struct {
+    // ... existing fields ...
+    exporter *exporter.NATSExporter
+}
+
+// in Stop, before server.Shutdown:
+if s.exporter != nil {
+    s.exporter.Stop()
+}
+```
+
+- [ ] **Step 7: Run all eventbus + telemetry tests**
+
+```bash
+task test -- ./internal/eventbus/...
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green.
+
+- [ ] **Step 9: Commit M7**
+
+Conventional message: `feat(eventbus/telemetry): M7 — OTEL header propagation + Prom NATS exporter`.
+
+---
+
+## Phase A acceptance gate (before declaring Phase A complete)
+
+- [ ] All 7 M-PRs (M1-M7) merged to main
+- [ ] `task pr-prep` green on main HEAD
+- [ ] Cumulative coverage gates met (≥ 80% per package, ≥ 90% for `internal/eventbus/`, ≥ 95% for `internal/eventbus/codec/`)
+- [ ] Manual smoke: start server locally, observe in startup logs:
+  - `holomush-embedded` NATS server ready
+  - audit projection consumer registered
+  - no consumers attached for plugin subjects (none defined yet)
+  - existing event store paths still in use (Phase A is additive only)
+- [ ] No production code consumes the new bus yet (`grep` for `eventbus.NewSubsystem` should show only `cmd/holomush/core.go` and tests)
+- [ ] Phase B feature branch (`feat/eventbus-cutover`) created from main HEAD post-Phase-A; ready for F1
+
+---
+
+## Self-review checklist
+
+- [ ] Spec sections 1-7 each have at least one Phase A task implementing the additive piece
+- [ ] All file paths are absolute and exact
+- [ ] All code blocks are complete (no "implement similar to above" handwaves)
+- [ ] All commands are exact with expected output
+- [ ] No `time.Sleep` in any test code (helpers may use it but test code MUST NOT)
+- [ ] Each task ends with a `task pr-prep` gate before commit
+- [ ] Each commit message is conventional and scope-tagged

--- a/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
+++ b/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
@@ -750,6 +750,7 @@ Host code: when loading a plugin with `audit:` in manifest, register a per-plugi
 - [ ] **Step 6: Per-plugin tests**
 
 Test that:
+
 - Plugin's `AuditEvent` RPC stores rows in its schema
 - Plugin's `QueryHistory` RPC enforces membership and returns paginated rows
 - Host audit table has zero rows for the plugin's subjects (subject ownership exclusion)
@@ -977,6 +978,7 @@ Edit `docs/specs/2026-03-20-event-delivery-redesign.md`. At the top, after the t
 - [ ] **Step 3: Public docs for the new bus**
 
 Create or update `site/docs/contributing/event-store.md` with a brief overview of:
+
 - The `EventBus` interface (link to spec §4)
 - Subject naming convention (link to spec §1c)
 - How plugins emit events via `EventSink`

--- a/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
+++ b/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
@@ -1,0 +1,1033 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Phase B: JetStream EventBus Atomic Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut over from the PostgreSQL `events` table + `LISTEN/NOTIFY` event store to the JetStream-backed `EventBus` landed in Phase A. Single feature branch (`feat/eventbus-cutover`), nine sequential tasks (F1–F9), single squash merge to `main` = production cutover.
+
+**Architecture:** Each F-task is one logical commit on the feature branch. Branch CI MUST stay green after every task. The branch rebases on `main` weekly. The final merge is when production swaps from old to new event store. Clean break — no dual paths, no feature flags, no legacy preservation.
+
+**Tech Stack:** Go, embedded NATS JetStream (Phase A `internal/eventbus/`), proto-first plugin contracts, PostgreSQL (now projection-only), `pgregory.net/rapid` for property tests.
+
+**Spec:** [docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md](../specs/2026-04-18-jetstream-event-log-design.md)
+
+**Epic bead:** `holomush-1tvn`
+
+**Phase B bead IDs:** F1=`holomush-1tvn.8`, F2=`.9`, F3=`.10`, F4=`.11`, F5=`.12`, F6=`.13`, F7=`.14`, F8=`.15`, F9=`.16` (set after creation).
+
+**Prerequisites:** Phase A complete (M1-M7 all in main), PR #233 (session-lifecycle-events) merged, `feat/eventbus-cutover` branch created from main HEAD.
+
+---
+
+## Phase B invariants
+
+- **Branch CI MUST stay green after every task.** Run `task pr-prep` per task before committing.
+- **Single squash merge to main.** Do NOT merge intermediate F-tasks to main individually.
+- **Rebase weekly on main.** PR #234, scene Phase 4 work, and other in-flight work continue on main; the cutover branch must follow.
+- **No flag-based dual paths.** When F1 lands, all events flow through the new bus immediately.
+- **Plugin authors are coordinated.** F5 changes the EventSink contract (`Stream` → `Subject`); plugins MUST be updated in the same task.
+
+---
+
+## Setup: create the feature branch
+
+Before F1, from main HEAD:
+
+```bash
+# Per repo convention; using jj if jj root succeeds, else git
+jj new main && jj describe -m "wip: feat/eventbus-cutover"
+jj bookmark create feat/eventbus-cutover -r @
+# or git: git checkout -b feat/eventbus-cutover main
+```
+
+Push the empty branch:
+
+```bash
+jj git push -b feat/eventbus-cutover
+# or: git push -u origin feat/eventbus-cutover
+```
+
+---
+
+## File Map (Phase B — what changes/moves/deletes)
+
+| File | Action | Task | Notes |
+| --- | --- | --- | --- |
+| `internal/plugin/event_emitter.go` | Modify | F1 | EventSink validation now publishes to `bus.Publish` instead of `EventStore.Append`; stamps `App-Codec` header explicitly |
+| `pkg/plugin/event_sink.go` | Modify | F1 | `EmitIntent.Stream` → `EmitIntent.Subject`; field rename only, no semantic change for plugin code |
+| `internal/eventbus/audit/projection.go` | Modify | F2 | Build subject-exclusion list from registered plugin manifests; skip plugin-owned subjects in host audit |
+| `internal/eventbus/audit/manifest_subjects.go` | Create | F2 | Plugin subject ownership map registration |
+| `internal/eventbus/audit/manifest_subjects_test.go` | Create | F2 | Longest-prefix-wins resolution + conflict detection (property test) |
+| `internal/grpc/server.go` | Modify | F3 | Subscribe handler rewritten around `bus.OpenSession`; deletes `cursor_lock` usage |
+| `internal/grpc/cursor_lock.go` | Delete | F3 | No longer needed; JS owns consumer state |
+| `internal/grpc/cursor_lock_test.go` | Delete | F3 | |
+| `internal/grpc/replay.go` | Delete | F3 | Replay machinery folded into `bus.OpenSession` + `bus.QueryHistory` |
+| `internal/grpc/replay_test.go` | Delete | F3 | |
+| `internal/grpc/subscribe_test.go` | Modify | F3 | Tests assert new flow (no replay machinery) |
+| `internal/grpc/query_stream_history.go` | Modify | F4 | Routes via `bus.QueryHistory` with hot/cold tier crossover; plugin-owned subjects fan out via `PluginAuditService.QueryHistory` |
+| `internal/grpc/query_stream_history_test.go` | Modify | F4 | New tests for tier crossover, plugin routing, ULID cursor |
+| `internal/eventbus/history/tier.go` | Create | F4 | JS↔PG tier-selection logic |
+| `internal/eventbus/history/tier_test.go` | Create | F4 | Dedicated 12-scenario crossover suite (per spec §8) with injected clock |
+| `plugins/core-scenes/main.go` | Modify | F5 | Implements `PluginAuditService` for `events.*.scene.>`; emits use new subject naming |
+| `plugins/core-scenes/audit.go` | Create | F5 | Audit handler implementation + plugin-owned `scene_log` table |
+| `plugins/core-scenes/event_types.go` | Create | F5 | Plugin-local event type constants (moved from `internal/core/event.go:39-70`) |
+| `plugins/core-scenes/payloads/` | Create | F5 | Plugin-local payload types (moved from `internal/core/event.go:74-143`) |
+| `plugins/core-scenes/manifest.yaml` | Modify | F5 | Adds `audit:` declaration; uses new subject patterns |
+| `plugins/core-scenes/migrations/000001_create_scene_log.up.sql` | Create | F5 | Plugin-owned audit schema |
+| `internal/core/event.go` | Modify | F5 | Delete lines 39-143 (constants + payload types); keep only ULID/Actor/MaxPayloadSize that move into eventbus.* in F7 |
+| `internal/store/migrations/000NNN_drop_events_table.up.sql` | Create | F6 | DROP events; DROP event_cursors |
+| `internal/store/migrations/000NNN_drop_events_table.down.sql` | Create | F6 | Recreate (kept by convention) |
+| `internal/core/event_writer.go` | Delete | F7 | Global serializer no longer needed |
+| `internal/core/event_writer_test.go` | Delete | F7 | |
+| `internal/core/store.go` | Delete | F7 | EventStore interface superseded by EventBus |
+| `internal/core/store_memory.go` | Delete | F7 | |
+| `internal/core/store_memory_test.go` | Delete | F7 | |
+| `internal/store/postgres.go` | Modify | F7 | Delete event-table functions (Append, Replay, ReplayTail, LastEventID, Subscribe, SubscribeSession, pgSubscription, pg_notify code, streamToChannel) |
+| `internal/store/postgres_test.go` | Modify | F7 | Delete obsolete event tests |
+| `internal/store/postgres_integration_test.go` | Modify | F7 + F8 | Delete pgnotify tests; delete time.Sleep crutches |
+| `internal/store/events_immutable_test.go` | Modify | F7 | Repurpose against `events_audit` |
+| `internal/session/session.go` | Modify | F7 | Drop `EventCursors map[string]ulid.ULID` field |
+| `internal/store/session_store.go` | Modify | F7 | Drop EventCursors persistence + UpdateCursors method |
+| `test/integration/eventbus_e2e/` | Create | F8 | New full E2E suite (per spec §8) |
+| `CLAUDE.md` | Modify | F9 | Update event-store and EventWriter sections |
+| `site/docs/contributing/event-store.md` | Modify or Create | F9 | Public docs for the new bus |
+| `docs/specs/2026-03-20-event-delivery-redesign.md` | Modify | F9 | Add status header marking superseded |
+
+---
+
+## Task F1: EventSink → bus.Publish
+
+**Files:**
+
+- Modify: `internal/plugin/event_emitter.go`
+- Modify: `pkg/plugin/event_sink.go`
+
+**Bead:** `holomush-1tvn.8`
+
+This is the cutover commit on the publish side. Plugins (Lua and binary) keep their existing API call shape (`eventSink:emit({stream=…, type=…, payload=…})`); the field name `stream` becomes `subject`, the underlying implementation now publishes to JetStream instead of `EventStore.Append`.
+
+- [ ] **Step 1: Rename `EmitIntent.Stream` to `EmitIntent.Subject`**
+
+Edit `pkg/plugin/event_sink.go`. Locate the `EmitIntent` struct and rename `Stream string` to `Subject string`. Update the doc comment.
+
+- [ ] **Step 2: Update Lua hostfunc binding to map `subject` from Lua tables**
+
+Edit the Lua side of the plugin SDK (likely `internal/plugin/hostfunc/stdlib_emit.go` or similar). The existing binding accepts a Lua table with `stream`, `type`, `payload` keys. Change the key handler:
+
+- Accept `subject` as the canonical key
+- Continue accepting `stream` for one rev as a deprecation shim (log a warning when used)
+
+(Locate the actual file via `Grep` for `eventSink` in `internal/plugin/`.)
+
+- [ ] **Step 3: Update binary plugin SDK and existing plugin call sites**
+
+Find every `EmitIntent{Stream: …}` literal across `plugins/` and update to `EmitIntent{Subject: …}`. Update field paths in any reflective marshaling code.
+
+- [ ] **Step 4: Rewrite the EmitEvent handler in `internal/plugin/event_emitter.go`**
+
+Replace the body that calls `EventStore.Append` with the new bus path:
+
+```go
+func (h *PluginEventEmitter) EmitEvent(ctx context.Context, intent EmitIntent) error {
+    // Validate Subject against plugin's manifest emits patterns (existing).
+    if err := h.validate(intent.Subject); err != nil { return err }
+
+    // Validate type
+    typ, err := eventbus.NewType(intent.Type)
+    if err != nil { return err }
+
+    // Stamp host-owned fields
+    sub, err := eventbus.NewSubject(intent.Subject)
+    if err != nil { return err }
+    actor := h.resolver.Resolve(ctx)
+
+    // Marshal as proto
+    eventProto := &eventbusv1.Event{
+        Id:        idgen.NewULID().Bytes(),
+        Subject:   string(sub),
+        Type:      string(typ),
+        Timestamp: timestamppb.Now(),
+        Actor:     toProtoActor(actor),
+        Payload:   intent.Payload,
+    }
+    plainBytes, err := proto.Marshal(eventProto)
+    if err != nil { return fmt.Errorf("emit: marshal: %w", err) }
+
+    // Apply codec (Phase A: identity)
+    codecName, label, err := h.selector.SelectForEncrypt(ctx, string(sub))
+    if err != nil { return fmt.Errorf("emit: codec select: %w", err) }
+    c, err := codec.Resolve(codecName)
+    if err != nil { return err }
+    var key codec.Key
+    if codecName != codec.NameIdentity {
+        key, err = h.keys.Active(ctx, label)
+        if err != nil { return fmt.Errorf("emit: key fetch: %w", err) }
+    }
+    encoded, err := c.Encode(ctx, plainBytes, key)
+    if err != nil { return fmt.Errorf("emit: encode: %w", err) }
+
+    // Build NATS msg with required headers
+    msg := &nats.Msg{
+        Subject: string(sub),
+        Data:    encoded,
+        Header:  nats.Header{},
+    }
+    msg.Header.Set("Nats-Msg-Id", ulid.ULID(eventProto.Id).String())
+    msg.Header.Set("App-Schema-Version", "1")
+    msg.Header.Set("App-Event-Type", string(typ))
+    msg.Header.Set("App-Codec", string(codecName))
+    msg.Header.Set("App-Actor-Kind", actor.Kind.String())
+    if actor.ID != (ulid.ULID{}) {
+        msg.Header.Set("App-Actor-ID", actor.ID.String())
+    }
+    telemetry.InjectHeaders(ctx, msg.Header)
+
+    // Publish with deadline = dupe_window − safety_margin
+    pubCtx, cancel := context.WithTimeout(ctx, h.dupeWindowDeadline())
+    defer cancel()
+    _, err = h.bus.PublishMsg(pubCtx, msg)
+    if errors.Is(err, context.DeadlineExceeded) {
+        return eventbus.ErrPublishExpired
+    }
+    return err
+}
+```
+
+- [ ] **Step 5: Update unit tests for the new EmitEvent path**
+
+Existing tests likely mock `EventStore`. Update them to mock `Publisher` (from `internal/eventbus`) instead. Use the `eventbustest.New(t)` helper for integration-flavor tests.
+
+- [ ] **Step 6: Add a property test for idempotent publish**
+
+```go
+func TestEmitEventIdempotentRetry(t *testing.T) {
+    rapid.Check(t, func(t *rapid.T) {
+        e := eventbustest.New(t)
+        emitter := newTestEmitter(e.Bus.JS())
+        intent := randomEmitIntent(t)
+
+        require.NoError(t, emitter.EmitEvent(ctx, intent))
+        require.NoError(t, emitter.EmitEvent(ctx, intent))  // retry with same intent
+        // Same ULID → JS dedup absorbs
+
+        info, _ := e.Bus.JS().Stream(ctx, "EVENTS")
+        require.EqualValues(t, 1, info.State.Msgs)
+    })
+}
+```
+
+- [ ] **Step 7: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: green.
+
+- [ ] **Step 8: Commit F1**
+
+Conventional message: `feat(eventbus): F1 — EventSink publishes via JetStream bus`.
+
+---
+
+## Task F2: Audit projection routes plugin-owned subjects + filter exclusion
+
+**Files:**
+
+- Create: `internal/eventbus/audit/manifest_subjects.go`, `manifest_subjects_test.go`
+- Modify: `internal/eventbus/audit/projection.go`
+
+**Bead:** `holomush-1tvn.9`
+
+The host audit projection MUST exclude subjects owned by plugins (those are projected by per-plugin consumers in F5). This task adds the longest-prefix-wins routing and integrates it into the projection's `FilterSubjects`.
+
+- [ ] **Step 1: Implement subject ownership routing**
+
+Create `internal/eventbus/audit/manifest_subjects.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit
+
+import (
+    "fmt"
+    "sort"
+    "strings"
+)
+
+// SubjectOwner identifies who owns a given subject prefix.
+type SubjectOwner struct {
+    PluginName string // empty = host
+    Pattern    string // the manifest-declared pattern, e.g., "events.*.scene.>"
+}
+
+// OwnerMap is the startup-built mapping of subject prefixes to owners.
+// Use Resolve() with longest-prefix-wins token-aligned matching.
+type OwnerMap struct {
+    entries []ownerEntry // sorted by descending token depth
+}
+
+type ownerEntry struct {
+    pattern string
+    tokens  []string
+    owner   SubjectOwner
+}
+
+// NewOwnerMap builds the map from a list of (pattern, owner) pairs.
+// Returns ErrSubjectOwnershipConflict if two distinct owners declare the
+// same exact pattern.
+func NewOwnerMap(decls []SubjectOwner) (*OwnerMap, error) {
+    seen := make(map[string]SubjectOwner)
+    for _, d := range decls {
+        if existing, ok := seen[d.Pattern]; ok && existing.PluginName != d.PluginName {
+            return nil, fmt.Errorf("subject ownership conflict on %q: %s vs %s",
+                d.Pattern, existing.PluginName, d.PluginName)
+        }
+        seen[d.Pattern] = d
+    }
+    entries := make([]ownerEntry, 0, len(decls))
+    for _, d := range decls {
+        entries = append(entries, ownerEntry{
+            pattern: d.Pattern,
+            tokens:  strings.Split(d.Pattern, "."),
+            owner:   d,
+        })
+    }
+    // Longest-token-count first; ties broken by literal (no wildcards) wins.
+    sort.SliceStable(entries, func(i, j int) bool {
+        if len(entries[i].tokens) != len(entries[j].tokens) {
+            return len(entries[i].tokens) > len(entries[j].tokens)
+        }
+        return literalScore(entries[i].tokens) > literalScore(entries[j].tokens)
+    })
+    return &OwnerMap{entries: entries}, nil
+}
+
+// Resolve returns the owner for the given concrete subject. If no entry
+// matches, owner is host (empty PluginName).
+func (m *OwnerMap) Resolve(subject string) SubjectOwner {
+    tokens := strings.Split(subject, ".")
+    for _, e := range m.entries {
+        if matches(e.tokens, tokens) {
+            return e.owner
+        }
+    }
+    return SubjectOwner{} // host
+}
+
+// matches checks NATS-style pattern (with * and >) against concrete tokens.
+func matches(pattern, concrete []string) bool {
+    for i, pt := range pattern {
+        if pt == ">" {
+            return i <= len(concrete) // > matches one OR more remaining
+        }
+        if i >= len(concrete) {
+            return false
+        }
+        if pt == "*" {
+            continue
+        }
+        if pt != concrete[i] {
+            return false
+        }
+    }
+    return len(pattern) == len(concrete)
+}
+
+func literalScore(tokens []string) int {
+    n := 0
+    for _, t := range tokens {
+        if t != "*" && t != ">" {
+            n++
+        }
+    }
+    return n
+}
+
+// HostExcludedSubjects returns the FilterSubjects pattern list the host
+// audit projection should subscribe to: the universe minus plugin-owned
+// patterns.
+//
+// JetStream FilterSubjects does not support exclusion natively; we
+// achieve exclusion by subscribing to all-of `events.>` and dropping
+// plugin-owned messages at handle time. This function returns the list
+// of plugin-owned patterns so the projection's handle() can skip them.
+func (m *OwnerMap) HostExcludedSubjects() []SubjectOwner {
+    out := make([]SubjectOwner, 0, len(m.entries))
+    for _, e := range m.entries {
+        if e.owner.PluginName != "" {
+            out = append(out, e.owner)
+        }
+    }
+    return out
+}
+```
+
+- [ ] **Step 2: Write the property test**
+
+Create `internal/eventbus/audit/manifest_subjects_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package audit_test
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/audit"
+)
+
+func TestResolveLongestPrefixWins(t *testing.T) {
+    m, err := audit.NewOwnerMap([]audit.SubjectOwner{
+        {PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+        {PluginName: "scene-lifecycle", Pattern: "events.*.scene.*.lifecycle"},
+    })
+    require.NoError(t, err)
+
+    o := m.Resolve("events.main.scene.01ABC.lifecycle")
+    require.Equal(t, "scene-lifecycle", o.PluginName, "longer-prefix wins")
+}
+
+func TestResolveLiteralWinsOverWildcardAtSameDepth(t *testing.T) {
+    m, _ := audit.NewOwnerMap([]audit.SubjectOwner{
+        {PluginName: "scenes", Pattern: "events.main.scene.>"},
+        {PluginName: "scene-literal", Pattern: "events.main.scene.literal"},
+    })
+    o := m.Resolve("events.main.scene.literal")
+    require.Equal(t, "scene-literal", o.PluginName)
+}
+
+func TestResolveHostFallback(t *testing.T) {
+    m, _ := audit.NewOwnerMap([]audit.SubjectOwner{
+        {PluginName: "scenes", Pattern: "events.*.scene.>"},
+    })
+    o := m.Resolve("events.main.location.01ABC")
+    require.Empty(t, o.PluginName, "non-matching subject = host")
+}
+
+func TestExactPrefixConflictIsStartupError(t *testing.T) {
+    _, err := audit.NewOwnerMap([]audit.SubjectOwner{
+        {PluginName: "a", Pattern: "events.*.scene.>"},
+        {PluginName: "b", Pattern: "events.*.scene.>"},
+    })
+    require.Error(t, err)
+    require.Contains(t, err.Error(), "ownership conflict")
+}
+```
+
+- [ ] **Step 3: Wire the OwnerMap into the projection**
+
+Modify `internal/eventbus/audit/projection.go`. The projection's `handle` method now consults the OwnerMap and skips (without acking) messages whose subject resolves to a plugin owner — those messages will be picked up by the per-plugin consumer registered in F5. (Actually: ack-skip is wrong because the host's consumer would advance past plugin-owned messages, eventually retention-evicting them before plugin can read. Correct: ack-and-skip — the host's consumer's job is just to drain quickly so the JS retention works; the per-plugin consumer is independent and reads the same messages from JS.)
+
+```go
+func (p *projection) handle(msg jetstream.Msg) {
+    // Plugin-owned subjects are acked-and-skipped — the per-plugin
+    // consumer handles their persistence independently.
+    if p.owners != nil && p.owners.Resolve(msg.Subject()).PluginName != "" {
+        _ = msg.Ack()
+        return
+    }
+    if err := p.persist(msg); err != nil {
+        return
+    }
+    _ = msg.Ack()
+}
+```
+
+- [ ] **Step 4: Run all audit tests**
+
+```bash
+task test -- ./internal/eventbus/audit/...
+task test:int -- ./internal/eventbus/audit/...
+```
+
+Expected: green.
+
+- [ ] **Step 5: Run pr-prep**
+
+```bash
+task pr-prep
+```
+
+- [ ] **Step 6: Commit F2**
+
+Conventional message: `feat(eventbus/audit): F2 — subject ownership routing + plugin exclusion`.
+
+---
+
+## Task F3: gRPC Subscribe handler rewrite + delete cursor_lock + replay
+
+**Files:**
+
+- Modify: `internal/grpc/server.go` — Subscribe handler
+- Delete: `internal/grpc/cursor_lock.go`, `cursor_lock_test.go`
+- Delete: `internal/grpc/replay.go`, `replay_test.go`
+- Modify: `internal/grpc/subscribe_test.go`
+
+**Bead:** `holomush-1tvn.10`
+
+- [ ] **Step 1: Locate the existing Subscribe handler**
+
+Read `internal/grpc/server.go` and locate the `Subscribe` RPC implementation. It currently does focus-restore + cursor-aware Replay + LISTEN/NOTIFY live loop with cursor_lock.
+
+- [ ] **Step 2: Rewrite the Subscribe handler**
+
+Replace the body with the simpler bus-based flow:
+
+```go
+func (s *coreServer) Subscribe(req *connect.Request[corev1.SubscribeRequest], stream *connect.ServerStream[corev1.SubscribeResponse]) error {
+    ctx := req.Context()
+    sessionID := req.Msg.SessionId
+    token := req.Msg.PlayerSessionToken
+
+    info, err := s.session.ValidateSessionOwnership(ctx, sessionID, token)
+    if err != nil {
+        return connect.NewError(connect.CodeUnauthenticated, err)
+    }
+
+    plan, err := s.focus.RestorePlan(ctx, sessionID)
+    if err != nil {
+        return err
+    }
+    filters := plan.Subjects() // []eventbus.Subject
+
+    busStream, err := s.bus.OpenSession(ctx, sessionID, filters)
+    if err != nil {
+        return err
+    }
+    defer busStream.Close()
+
+    // Record session-start audit event (existing pattern).
+    s.audit.RecordSubscribe(ctx, info)
+
+    for {
+        delivery, err := busStream.Next(ctx)
+        if err != nil {
+            return err
+        }
+        if err := stream.Send(toProtoSubscribeResponse(delivery.Event())); err != nil {
+            // Don't ack on Send failure; JS redelivers on rebind.
+            return err
+        }
+        if err := delivery.Ack(); err != nil {
+            s.logger.Warn("ack failed; will redeliver", "err", err)
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Delete cursor_lock + replay**
+
+```bash
+rm internal/grpc/cursor_lock.go internal/grpc/cursor_lock_test.go
+rm internal/grpc/replay.go internal/grpc/replay_test.go
+```
+
+- [ ] **Step 4: Update subscribe_test.go**
+
+Rewrite tests to use `eventbustest.New(t)` and assert the new flow. Property test for filter monotonicity under `SetFilters` (per spec §8 invariants):
+
+```go
+func TestSubscribeFilterMonotonicityUnderSetFilters(t *testing.T) {
+    rapid.Check(t, func(t *rapid.T) {
+        // ... emit N events while concurrently calling SetFilters with arbitrary subsets
+        // assert: events matching current filter at time of publish ARE delivered
+        // assert: events from removed subjects are NOT delivered after SetFilters returns
+        // assert: cursor preserved across every filter update
+    })
+}
+```
+
+- [ ] **Step 5: Run pr-prep**
+
+Expected: green. Existing client behavior preserved (cursor resume on reconnect now via JS durable consumer).
+
+- [ ] **Step 6: Commit F3**
+
+Conventional message: `feat(grpc): F3 — Subscribe via EventBus.OpenSession; delete cursor_lock + replay`.
+
+---
+
+## Task F4: gRPC QueryHistory rewrite with hot/cold tier crossover
+
+**Files:**
+
+- Modify: `internal/grpc/query_stream_history.go`
+- Modify: `internal/grpc/query_stream_history_test.go`
+- Create: `internal/eventbus/history/tier.go`
+- Create: `internal/eventbus/history/tier_test.go` (the dedicated 12-scenario suite)
+
+**Bead:** `holomush-1tvn.11`
+
+- [ ] **Step 1: Implement the tier-selection logic**
+
+Create `internal/eventbus/history/tier.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package history serves QueryHistory requests by transparently
+// crossing the JetStream / PostgreSQL audit retention boundary.
+package history
+
+import (
+    "context"
+    "database/sql"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+
+    "github.com/holomush/holomush/internal/eventbus"
+)
+
+// Reader implements eventbus.HistoryReader by routing queries between
+// JetStream (recent tail) and PostgreSQL events_audit (forever archive).
+type Reader struct {
+    js              jetstream.JetStream
+    db              *sql.DB
+    streamMaxAge    time.Duration
+    safetyMargin    time.Duration
+    now             func() time.Time // injectable for tests
+}
+
+func NewReader(js jetstream.JetStream, db *sql.DB, streamMaxAge time.Duration, now func() time.Time) *Reader {
+    return &Reader{
+        js: js, db: db,
+        streamMaxAge: streamMaxAge,
+        safetyMargin: time.Hour,
+        now:          now,
+    }
+}
+
+// QueryHistory streams events matching q. The implementation chooses JS
+// or PG as the starting tier based on q.After / q.NotBefore vs the
+// retention edge. When a page crosses the boundary, it continues from
+// the other tier transparently.
+func (r *Reader) QueryHistory(ctx context.Context, q eventbus.HistoryQuery) (eventbus.HistoryStream, error) {
+    edge := r.now().Add(-r.streamMaxAge + r.safetyMargin)
+    // ... (implementation; see spec §5)
+}
+```
+
+(Full implementation in F4 task — non-trivial, ~150 LOC. Includes the algorithm from spec §5.)
+
+- [ ] **Step 2: Implement the dedicated 12-scenario test suite**
+
+Create `internal/eventbus/history/tier_test.go` covering each scenario in the table from spec §8:
+
+```go
+func TestTierCrossoverCursorWithinJSRetention(t *testing.T) { ... }
+func TestTierCrossoverCursorOlderThanRetention(t *testing.T) { ... }
+func TestTierCrossoverCursorAtBoundaryEdge(t *testing.T) { ... }
+func TestTierCrossoverPageBoundaryCrosses(t *testing.T) { ... }
+func TestTierCrossoverClockSkewAbsorbed(t *testing.T) { ... }
+func TestTierCrossoverForwardDirection(t *testing.T) { ... }
+func TestTierCrossoverBackwardDirection(t *testing.T) { ... }
+func TestTierCrossoverEmptyPGFullJS(t *testing.T) { ... }
+func TestTierCrossoverEmptyJSFullPG(t *testing.T) { ... }
+func TestTierCrossoverBothEmpty(t *testing.T) { ... }
+func TestTierCrossoverNonExistentSubject(t *testing.T) { ... }
+func TestTierCrossoverPluginOwnedSubjectRoutesToPlugin(t *testing.T) { ... }
+```
+
+Each test uses an injected clock (`func() time.Time`) advanced to the relevant boundary. NO wall-clock waits.
+
+- [ ] **Step 3: Rewrite the gRPC handler to use the Reader**
+
+Modify `internal/grpc/query_stream_history.go` to delegate to `bus.QueryHistory` (which is `Reader.QueryHistory`).
+
+- [ ] **Step 4: Run pr-prep**
+
+- [ ] **Step 5: Commit F4**
+
+Conventional message: `feat(grpc): F4 — QueryHistory with JS/PG tier crossover + plugin routing`.
+
+---
+
+## Task F5: Per-plugin updates (subjects, manifests, EventType + Payload move)
+
+**Files (per plugin):**
+
+- Modify: `plugins/<each-plugin>/main.go`, `manifest.yaml`
+- Create: `plugins/<each-plugin>/event_types.go`, `plugins/<each-plugin>/payloads/`
+- Create: `plugins/<each-plugin>/audit.go`
+- Create: `plugins/<each-plugin>/migrations/` (if audit declared)
+- Modify: `internal/core/event.go` — delete lines 39-143
+
+**Bead:** `holomush-1tvn.12`
+
+This task is repeated per plugin. For HoloMUSH today, the plugin universe is `core-scenes`; channels comes later (paused).
+
+- [ ] **Step 1: Move event types out of `internal/core/event.go`**
+
+Identify which plugin owns each of the 19 EventType constants and 7 payload types per the plugin boundary rules and the spec §1b mapping. Suggested mapping:
+
+| Type / Payload | Owner |
+| --- | --- |
+| `EventTypeSay`, `EventTypePose`, `WhisperPayload`, `PagePayload`, `PemitPayload`, `OOCPayload` | core-comm (new plugin if not present, else split across owners) |
+| `EventTypeArrive`, `EventTypeLeave`, `EventTypeMove`, `LocationStatePayload`, `ExitUpdatePayload` | core-world |
+| `EventTypeObjectCreate/Destroy/Use/Examine/Give` | core-world |
+| `EventTypeCommandResponse`, `EventTypeCommandError` | host (system events; stay in eventbus or move to a tiny core-commands plugin) |
+
+Confirm the mapping with the plugin owners before splitting; if some types are temporarily un-owned, file a follow-up bead and keep them in a transitional `internal/core/event.go` *only* for those types (delete the rest).
+
+- [ ] **Step 2: Update manifests**
+
+Each plugin's `manifest.yaml` adds:
+
+```yaml
+emits:
+  - "events.*.scene.*.ic"
+  - "events.*.scene.*.ooc"
+  - "events.*.scene.*.lifecycle"
+audit:
+  - subjects: ["events.*.scene.>"]
+    schema:   plugin_core_scenes
+    table:    scene_log
+```
+
+- [ ] **Step 3: Implement `PluginAuditService` in plugin code**
+
+For each plugin with `audit:` in its manifest, implement the proto service:
+
+```go
+// plugins/core-scenes/audit.go
+type AuditServer struct {
+    pluginv1.UnimplementedPluginAuditServiceServer
+    db *sql.DB
+}
+
+func (s *AuditServer) AuditEvent(ctx context.Context, req *pluginv1.AuditEventRequest) (*pluginv1.AuditEventResponse, error) {
+    // INSERT INTO plugin_core_scenes.scene_log (...) ON CONFLICT (id) DO NOTHING
+    return &pluginv1.AuditEventResponse{}, nil
+}
+
+func (s *AuditServer) QueryHistory(req *pluginv1.QueryHistoryRequest, stream pluginv1.PluginAuditService_QueryHistoryServer) error {
+    // Authz: scene membership check
+    // SELECT ... FROM plugin_core_scenes.scene_log WHERE subject=$1 AND id > $cursor ORDER BY id LIMIT $page
+    // stream events back
+    return nil
+}
+```
+
+- [ ] **Step 4: Add plugin migration for the audit schema**
+
+```sql
+-- plugins/core-scenes/migrations/000001_create_scene_log.up.sql
+CREATE SCHEMA IF NOT EXISTS plugin_core_scenes;
+REVOKE ALL ON SCHEMA plugin_core_scenes FROM PUBLIC;
+GRANT USAGE ON SCHEMA plugin_core_scenes TO plugin_core_scenes_role;
+
+CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
+    id          BYTEA PRIMARY KEY,
+    subject     TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    timestamp   TIMESTAMPTZ NOT NULL,
+    actor_kind  TEXT NOT NULL,
+    actor_id    BYTEA,
+    payload     BYTEA NOT NULL,
+    schema_ver  SMALLINT NOT NULL,
+    codec       TEXT NOT NULL,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX scene_log_subject_id ON plugin_core_scenes.scene_log (subject, id);
+```
+
+- [ ] **Step 5: Wire plugin into per-plugin audit consumer registration**
+
+Host code: when loading a plugin with `audit:` in manifest, register a per-plugin durable consumer named `plugin_audit_<name>` and dispatch deliveries to the plugin's `PluginAuditService.AuditEvent` RPC. (Implementation in `internal/eventbus/audit/plugin_consumer.go` — straightforward worker per declared audit block.)
+
+- [ ] **Step 6: Per-plugin tests**
+
+Test that:
+- Plugin's `AuditEvent` RPC stores rows in its schema
+- Plugin's `QueryHistory` RPC enforces membership and returns paginated rows
+- Host audit table has zero rows for the plugin's subjects (subject ownership exclusion)
+
+- [ ] **Step 7: Run pr-prep**
+
+- [ ] **Step 8: Commit F5**
+
+Conventional message: `feat(plugins): F5 — per-plugin subjects, audit projections, payload migration`.
+
+---
+
+## Task F6: Schema cutover — DROP events, DROP event_cursors
+
+**Files:**
+
+- Create: `internal/store/migrations/000NNN_drop_events_and_cursors.up.sql`
+- Create: `internal/store/migrations/000NNN_drop_events_and_cursors.down.sql`
+
+**Bead:** `holomush-1tvn.13`
+
+- [ ] **Step 1: Write the up migration**
+
+```sql
+-- 000NNN_drop_events_and_cursors.up.sql
+ALTER TABLE sessions DROP COLUMN IF EXISTS event_cursors;
+DROP TABLE IF EXISTS events;
+```
+
+- [ ] **Step 2: Write the down migration (recreate; convention only)**
+
+```sql
+-- Down migrations recreate the prior state; we keep them by convention
+-- but production rollback is via reverting the merge commit, not
+-- running migrations down.
+CREATE TABLE events (
+    id BYTEA PRIMARY KEY,
+    stream TEXT NOT NULL,
+    type TEXT NOT NULL,
+    actor_kind TEXT NOT NULL,
+    actor_id BYTEA,
+    payload BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX events_stream_id ON events (stream, id);
+
+ALTER TABLE sessions ADD COLUMN event_cursors JSONB DEFAULT '{}'::jsonb;
+```
+
+- [ ] **Step 3: Run migrations forward + back on a fresh DB**
+
+```bash
+task test:migrations
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Run pr-prep**
+
+- [ ] **Step 5: Commit F6**
+
+Conventional message: `feat(store): F6 — drop events table and event_cursors column`.
+
+---
+
+## Task F7: Old code deletion
+
+**Files:**
+
+- Delete: `internal/core/event_writer.go`, `event_writer_test.go`
+- Delete: `internal/core/store.go`, `store_memory.go`, `store_memory_test.go`
+- Modify: `internal/store/postgres.go` — delete event-table functions
+- Modify: `internal/store/postgres_test.go` — delete obsolete tests
+- Modify: `internal/store/postgres_integration_test.go` — delete pgnotify tests + `time.Sleep` crutches
+- Modify: `internal/store/events_immutable_test.go` — repurpose against `events_audit`
+- Modify: `internal/session/session.go` — drop `EventCursors` field
+- Modify: `internal/store/session_store.go` — drop EventCursors persistence + UpdateCursors method
+- Modify: `internal/core/event.go` — delete remaining content (or move to `internal/eventbus/types.go` if any pieces are still needed)
+
+**Bead:** `holomush-1tvn.14`
+
+- [ ] **Step 1: Delete EventWriter**
+
+```bash
+rm internal/core/event_writer.go internal/core/event_writer_test.go
+```
+
+Update any imports that reference `core.EventWriter` — remove them.
+
+- [ ] **Step 2: Delete legacy EventStore interfaces**
+
+```bash
+rm internal/core/store.go internal/core/store_memory.go internal/core/store_memory_test.go
+```
+
+- [ ] **Step 3: Strip event-table code from `internal/store/postgres.go`**
+
+Delete: `Append`, `Replay`, `ReplayTail`, `LastEventID`, `Subscribe`, `SubscribeSession`, `pgSubscription` struct + methods, `pg_notify` calls, `streamToChannel`, `connIface`. Keep only player/character/session/etc. functions.
+
+- [ ] **Step 4: Strip pgnotify tests + sleeps from `postgres_integration_test.go`**
+
+Delete every test that references LISTEN/NOTIFY, `pgSubscription`, `Subscribe`, or `SubscribeSession`. Delete every `time.Sleep(time.Millisecond)` and `time.Sleep(10 * time.Millisecond)` — those existed for ULID-collision-in-same-ms which is no longer a concern.
+
+- [ ] **Step 5: Repurpose `events_immutable_test.go` against `events_audit`**
+
+The test currently asserts no UPDATE/DELETE on `events`. Rewrite to assert no UPDATE/DELETE on `events_audit` in core Go source.
+
+- [ ] **Step 6: Drop EventCursors from session model**
+
+Modify `internal/session/session.go` and `internal/store/session_store.go`. Delete `EventCursors map[string]ulid.ULID` field, `UpdateCursors` method, and the JSONB merge SQL.
+
+- [ ] **Step 7: Run pr-prep**
+
+Expected: green. Build now compiles without `EventStore`, `EventWriter`, `cursor_lock`, `replay.go`, or pgnotify code.
+
+- [ ] **Step 8: Commit F7**
+
+Conventional message: `chore(store): F7 — delete legacy event store, EventWriter, cursor machinery`.
+
+---
+
+## Task F8: Test sweep — port "Variant A", add E2E suite, drop obsolete
+
+**Files:**
+
+- Create: `test/integration/eventbus_e2e/`
+- Modify: various test files
+
+**Bead:** `holomush-1tvn.15`
+
+- [ ] **Step 1: Port the "Variant A Go/No-Go" cross-stream invariant test**
+
+The original test in `postgres_integration_test.go:574-683` (1000 events × 4 streams × 10 goroutines × 2 subscribers, asserting identical strictly-ascending sequences) is gone with F7. Port it to assert the same invariant against the new bus:
+
+```go
+// internal/eventbus/integration_test.go
+//go:build integration
+
+func TestCrossSubjectSequenceOrderingUnderConcurrentPublishers(t *testing.T) {
+    e := eventbustest.New(t)
+    // 1000 events × 4 subjects × 10 goroutines × 2 subscribers
+    // assert: each subscriber sees strictly ascending JS seq
+    // assert: both subscribers see identical seq sequences
+    // No time.Sleep — use AwaitAckedSeq for synchronization.
+}
+```
+
+- [ ] **Step 2: Implement the full E2E matrix from spec §8**
+
+Create files under `test/integration/eventbus_e2e/`:
+
+- `cross_tier_query_test.go` — 12 scenarios from spec §8 dedicated tier suite
+- `plugin_audit_isolation_test.go` — host audit empty for plugin subjects
+- `reconnect_resume_test.go` — last-ack continuation, no dup, no loss
+- `audit_drift_detector_test.go` — tampered row reported with id
+- `backfill_rebuild_test.go` — `bin/holomush audit-backfill` produces matching counts
+- `plugin_crash_resilience_test.go` — restart drains; PK ON CONFLICT prevents dups
+- `js_storage_corruption_test.go` — rebuild from PG audit; ULIDs stable
+- `multi_protocol_fanout_test.go` — telnet + web in same scene see same pose
+
+Each test uses `eventbustest.New(t)` + `testutil.SharedPostgres(t)`.
+
+- [ ] **Step 3: Add the chaos+soak nightly job**
+
+Configure CI to run a 5-minute soak nightly:
+
+```yaml
+# .github/workflows/nightly-soak.yml
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: task soak:eventbus
+```
+
+The `soak:eventbus` task runs:
+
+```bash
+go test -tags=integration,soak -timeout=20m -v ./test/integration/eventbus_e2e/...
+```
+
+- [ ] **Step 4: Run full pr-prep + integration tests**
+
+```bash
+task pr-prep
+task test:int
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit F8**
+
+Conventional message: `test(eventbus): F8 — port invariant suite + add full E2E matrix`.
+
+---
+
+## Task F9: Documentation updates
+
+**Files:**
+
+- Modify: `CLAUDE.md` — event-store and EventWriter sections
+- Modify or Create: `site/docs/contributing/event-store.md`
+- Modify: `docs/specs/2026-03-20-event-delivery-redesign.md` — mark superseded
+
+**Bead:** `holomush-1tvn.16`
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+Locate the sections describing the event store, ULID generation table, EventWriter, EventStore. Rewrite to describe the new `EventBus` interface, JetStream-as-event-log, plugin-owned audit projections. Update the "Random Number Generation" / "ULID Generation" tables — events now use JS seq for ordering, ULID stays for identity.
+
+- [ ] **Step 2: Add status header to superseded spec**
+
+Edit `docs/specs/2026-03-20-event-delivery-redesign.md`. At the top, after the title, add:
+
+```markdown
+## Status
+
+**SUPERSEDED** by [docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md](../superpowers/specs/2026-04-18-jetstream-event-log-design.md). LISTEN/NOTIFY-based delivery has been replaced by JetStream as of (cutover date).
+```
+
+- [ ] **Step 3: Public docs for the new bus**
+
+Create or update `site/docs/contributing/event-store.md` with a brief overview of:
+- The `EventBus` interface (link to spec §4)
+- Subject naming convention (link to spec §1c)
+- How plugins emit events via `EventSink`
+- How plugins declare audit subjects in `manifest.yaml`
+- How operators run NATS in embedded vs cluster mode
+
+- [ ] **Step 4: Run pr-prep + docs build**
+
+```bash
+task pr-prep
+task docs:build
+```
+
+- [ ] **Step 5: Commit F9**
+
+Conventional message: `docs: F9 — document new EventBus + supersede prior event-delivery spec`.
+
+---
+
+## Phase B acceptance gate (before merging the feature branch to main)
+
+- [ ] All M-PRs (M1-M7) in main; cumulative coverage gates met
+- [ ] Branch CI green on every push of every F-task
+- [ ] Branch rebased on main within the last 7 days
+- [ ] Full `task pr-prep` green on the entire branch state
+- [ ] All E2E tests pass — including the chaos+soak nightly that ran on the branch
+- [ ] Coverage gates met (≥80% per package, ≥90% for `internal/eventbus/`, ≥95% for `internal/eventbus/codec/`, perf budget gates met per spec §8)
+- [ ] Manual reviewer E2E walkthrough: telnet + web in same scene, full pose flow, scene/log -all queries old + new events
+- [ ] All in-flight PRs that conflict have been rebased
+- [ ] PG dump taken the night before the merge
+- [ ] Merge commit message references the spec, the epic bead, and every F-task bead
+
+---
+
+## Post-merge follow-up beads (file at merge time)
+
+- Scene Phase 4 implementation (`holomush-5rh.13` unblocked)
+- Channel plugin resumption (`holomush-0sc.12` unpaused)
+- holomush-umxj telnet race fix verified under new bus
+- Real codec implementation workstream (codec key provider, KMS choice — `holomush-1tvn` follow-up)
+- Multi-node cluster cutover (deferred until scale demands)
+- Schema evolution playbook (proto v1 → v2 migration patterns)
+- Per-subject Prometheus cardinality discipline doc
+
+---
+
+## Self-review checklist
+
+- [ ] Each F-task corresponds to exactly one F-bead under the epic
+- [ ] Inter-bead dependencies set: F1 blocks F2 blocks F3 blocks F4; F5 blocks F6; F6 blocks F7; F7 blocks F8 blocks F9
+- [ ] Phase B is gated on Phase A complete (all F-beads depend on M-beads they need)
+- [ ] No `time.Sleep` in any test code (existing legacy sleeps deleted in F7/F8)
+- [ ] All deletions explicitly listed in file map and deletion steps
+- [ ] Each task ends with `task pr-prep` before commit

--- a/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
+++ b/docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-b.md
@@ -1015,7 +1015,7 @@ Conventional message: `docs: F9 — document new EventBus + supersede prior even
 
 - Scene Phase 4 implementation (`holomush-5rh.13` unblocked)
 - Channel plugin resumption (`holomush-0sc.12` unpaused)
-- holomush-umxj telnet race fix verified under new bus
+- Verify holomush-umxj telnet race fix (already landed in PR #237) holds under new bus — F3 rewrites the Subscribe handler and gateway path that hosted the race; the regression test from PR #237 must stay green after F3
 - Real codec implementation workstream (codec key provider, KMS choice — `holomush-1tvn` follow-up)
 - Multi-node cluster cutover (deferred until scale demands)
 - Schema evolution playbook (proto v1 → v2 migration patterns)

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -29,7 +29,7 @@ notification delivery is asynchronous relative to the durable `INSERT`:
 - **Cursor persistence race** (Finding 1, PR #201) — `Send` → `UpdateCursors`
   gap mitigated but not eliminated.
   ([docs/plans/2026-04-07-cursor-lock-finding-1-closure.md](../../plans/2026-04-07-cursor-lock-finding-1-closure.md))
-- **Quit-teardown race** — `holomush-h9fp` telnet E2E flake, intermittent.
+- **Quit-teardown race** — `holomush-h9fp` telnet E2E flake (a separate but related instance, `holomush-umxj`, was fixed independently in PR #237 — F3's Subscribe handler rewrite must not regress it).
 - **Reconnect/replay flakes** — `holomush-0jzs` (four `terminal.spec.ts` tests).
 - **Test ULID ordering crutches** — six+ `time.Sleep(1ms)` calls in
   `postgres_integration_test.go` to dodge ULID collision-in-same-ms.
@@ -1498,7 +1498,7 @@ Realistic envelope: 5–7 weeks.
 
 - Scene Phase 4 implementation
 - Channel plugin resumption
-- holomush-umxj telnet race fix verified under new bus
+- Verify holomush-umxj telnet race fix (already landed in PR #237) holds under new bus — F3 rewrites the Subscribe handler and gateway path that hosted the race; regression test from PR #237 must stay green
 - Real codec implementation (separate workstream)
 - Multi-node cluster cutover (when scale demands)
 

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -155,10 +155,20 @@ relegates PostgreSQL to identity, projection, and forever-archive audit.
 #### 1a. Event identity
 
 ```go
+// Subject is a typed JetStream subject. Constructed via NewSubject which
+// validates against the documented token rules (Section 1c). Prevents
+// accidentally passing an unstructured string (e.g., a player ID) where a
+// subject is expected.
+type Subject string
+
+// Type is a typed plugin-declared event type identifier. Constructed via
+// NewType which validates against the manifest's declared types.
+type Type string
+
 type Event struct {
     ID        ulid.ULID  // identity, dedup key, stable across rebuilds
-    Subject   string     // JS subject (replaces Stream)
-    Type      string     // plugin-declared opaque string
+    Subject   Subject    // typed JS subject
+    Type      Type       // plugin-declared, opaque to host
     Timestamp time.Time  // host-stamped at publish
     Actor     Actor      // host-stamped from session/plugin context
     Payload   []byte     // proto bytes (post-codec encoding)
@@ -177,6 +187,10 @@ type Event struct {
 `Event.ID` (ULID) **MUST** stay as the cross-system identity. JetStream
 sequence (`uint64`) is internal to the bus and **MUST NOT** cross any
 public API boundary. ULIDs survive JetStream rebuilds; sequences do not.
+
+Typed `Subject` and `Type` add zero runtime cost (compile-time only) and
+catch a class of accidental field-swap and free-string bugs that bit the
+old `Event.Stream string` model.
 
 #### 1b. Event Type and Payload — plugin-declared, opaque to host
 
@@ -207,45 +221,71 @@ This closes the boundary violation completely — neither the type
 identifier nor the payload schema for plugin-owned events lives in
 `internal/core/` after the cutover.
 
-#### 1c. Subject naming — hierarchical, plugin-namespaced
+#### 1c. Subject naming — hierarchical, game-namespaced, plugin-namespaced
 
 ```text
-events.<domain>.<entity-id>[.<facet>...]
+events.<game-id>.<domain>.<entity-id>[.<facet>...]
 ```
+
+The leading `events.<game-id>.` prefix is mandatory from day one. Single-game
+deployments use a literal segment (config: `event_bus.game_id`). The cost
+today is one extra subject token and one config knob; the cost of *not*
+having it 18 months from now if multi-tenancy ever lands is a global
+subject rename across every plugin, every audit row, and every consumer.
+
+Concrete subjects (single-game default `<game-id> = main`):
 
 | Subject | Owner | Examples |
 | --- | --- | --- |
-| `events.location.<ULID>` | host | location-scoped events |
-| `events.character.<ULID>` | host | personal stream (DMs, command responses) |
-| `events.session.<ULID>.lifecycle` | host | session lifecycle (PR #233) |
-| `events.notifications.character.<ULID>` | host | cross-scene notifications |
-| `events.scene.<ULID>.ic` | core-scenes plugin | in-character (poses, says) |
-| `events.scene.<ULID>.ooc` | core-scenes plugin | out-of-character chat |
-| `events.scene.<ULID>.lifecycle` | core-scenes plugin | created/paused/ended |
-| `events.channel.<ULID>` | core-channels plugin (future) | channels |
+| `events.<game>.location.<ULID>` | host | location-scoped events |
+| `events.<game>.character.<ULID>` | host | personal stream (DMs, command responses) |
+| `events.<game>.session.<ULID>.lifecycle` | host | session lifecycle (PR #233) |
+| `events.<game>.notifications.character.<ULID>` | host | cross-scene notifications |
+| `events.<game>.scene.<ULID>.ic` | core-scenes plugin | in-character (poses, says) |
+| `events.<game>.scene.<ULID>.ooc` | core-scenes plugin | out-of-character chat |
+| `events.<game>.scene.<ULID>.lifecycle` | core-scenes plugin | created/paused/ended |
+| `events.<game>.channel.<ULID>` | core-channels plugin (future) | channels |
 
 Subjects use dot-delimited tokens; `*` matches one token, `>` matches the
 remainder and **MUST** be the last token. Subject token depth **SHOULD**
 stay below 16 to keep matching cost low.
 
+Stream subject filter remains `events.>` so the JS topology is
+game-agnostic; per-game routing happens via `FilterSubjects` on consumers
+(`events.<game>.scene.>` for game-scoped scenes consumer, etc.).
+
 Manifest declares both publish-allowed and audit-subscribed subjects:
 
 ```yaml
 emits:
-  - "events.scene.*.ic"
-  - "events.scene.*.ooc"
-  - "events.scene.*.lifecycle"
+  - "events.*.scene.*.ic"           # * matches game id
+  - "events.*.scene.*.ooc"
+  - "events.*.scene.*.lifecycle"
 audit:
-  - subjects: ["events.scene.>"]
+  - subjects: ["events.*.scene.>"]
     schema:   plugin_core_scenes
     table:    scene_log
 ```
+
+The wildcard at the game-id position lets a plugin serve multiple
+games on a single server when multi-tenancy lands. For single-game
+deployments today, the wildcard matches the literal `main`.
 
 #### 1d. Wire format — proto + version header
 
 Replace JSON-in-bytea with a proto `Event` message. Forces explicit schema
 discipline; binary; backward-compatible field additions are free. 64 KiB
 payload cap stays.
+
+**Proto schema layout:**
+
+- Host envelope (the `Event` message itself, plus `Actor`, `EventBus`
+  service, `PluginAuditService` if not elsewhere): `api/proto/holomush/eventbus/v1/`
+- Plugin payload schemas: each plugin's existing proto namespace
+  (`api/proto/holomush/scenes/v1/`, `api/proto/holomush/dm/v1/`, etc.)
+
+The host package depends on the envelope proto; **never** on plugin
+payload protos (which are bytes from the host's perspective).
 
 Headers on every published message:
 
@@ -324,7 +364,7 @@ transparently uses PG audit) rather than resume.
 ```go
 // pkg/plugin/event_sink.go
 eventSink.Emit(ctx, EmitIntent{
-    Subject: "events.scene.01JABC...XYZ.ic",
+    Subject: "events.main.scene.01JABC...XYZ.ic",
     Type:    "scene.pose",
     Payload: marshaledProto,
 })
@@ -411,26 +451,67 @@ clustered NATS, quorum loss means publishes fail until quorum returns.
 
 ### 4. Subscribe path
 
-#### Interface
+#### Interface — split into three single-responsibility interfaces
 
 ```go
-type EventBus interface {
+// Publisher writes events. Used by EventSink (which used to call
+// EventStore.Append).
+type Publisher interface {
     Publish(ctx context.Context, event Event) error
-    OpenSession(ctx context.Context, sessionID string, filters []string) (SessionStream, error)
+}
+
+// Subscriber opens long-lived session streams.
+// Used by gRPC Subscribe handler.
+type Subscriber interface {
+    OpenSession(ctx context.Context, sessionID string, filters []Subject) (SessionStream, error)
+}
+
+// HistoryReader serves paginated history reads. Used by QueryHistory
+// gRPC handler and by plugin-side audit projection backfills.
+type HistoryReader interface {
     QueryHistory(ctx context.Context, q HistoryQuery) (HistoryStream, error)
 }
 
-type SessionStream interface {
-    Next(ctx context.Context) (Event, AckFunc, error)
-    SetFilters(ctx context.Context, filters []string) error
-    Close() error
+// EventBus is the concrete implementation that satisfies all three.
+// Tests and consumers depend on the narrow interface they actually need.
+type EventBus interface {
+    Publisher
+    Subscriber
+    HistoryReader
 }
 
-type AckFunc func() error
+// Delivery is a typed handle for a single message in flight from a
+// SessionStream. Replaces the prior (Event, AckFunc, error) tuple shape
+// — typed handles are easier to mock, log, extend (Nack, InProgress).
+type Delivery interface {
+    Event() Event
+    Ack() error
+    // Nack signals the message should be redelivered without affecting
+    // ack-pending state semantics. Used for transient handler errors.
+    Nack() error
+    // InProgress extends the ack-wait timer for handlers expecting to
+    // exceed the default. Use sparingly.
+    InProgress() error
+}
+
+type SessionStream interface {
+    // Next blocks until the next delivery is available or ctx is done.
+    Next(ctx context.Context) (Delivery, error)
+    // SetFilters atomically updates the underlying durable consumer's
+    // FilterSubjects. Cursor is preserved by JS UpdateConsumer.
+    SetFilters(ctx context.Context, filters []Subject) error
+    Close() error
+}
 ```
 
 `AddStream` / `RemoveStream` / `Notifications` / `Errors` (current
-`core.Subscription`) **MUST** be deleted.
+`core.Subscription`) **MUST** be deleted. `AckFunc` closure shape is
+not used; `Delivery` is the canonical handle.
+
+**Composition at call sites:** the gRPC Subscribe handler depends on
+`Subscriber`; the gRPC QueryHistory handler depends on `HistoryReader`;
+the EventSink depends on `Publisher`. Each can be mocked independently.
+The concrete `eventBus` struct satisfies all three.
 
 #### `OpenSession` semantics
 
@@ -474,10 +555,16 @@ respect to delivery. (`FilterSubjects` plural is supported in NATS server
 4. stream, err := bus.OpenSession(ctx, sessionID, filters)
 5. defer stream.Close()
 6. for {
-       event, ack, err := stream.Next(ctx)
+       delivery, err := stream.Next(ctx)
        if err != nil { return err }
-       if err := grpcStream.Send(toProto(event)); err != nil { return err }
-       if err := ack(); err != nil { logger.Warn(...) }
+       if err := grpcStream.Send(toProto(delivery.Event())); err != nil {
+           // Send failure: don't ack. JS will redeliver on next bind.
+           // Caller's existing dedup on ULID prevents duplicate render.
+           return err
+       }
+       if err := delivery.Ack(); err != nil {
+           logger.Warn("ack failed; will redeliver", "error", err)
+       }
    }
 ```
 
@@ -521,25 +608,34 @@ exist.
 
 ```go
 type HistoryQuery struct {
-    Subject        string         // exact subject OR pattern with * / >
-    After          ulid.ULID      // exclusive lower bound; zero = from start
-    Before         ulid.ULID      // exclusive upper bound; zero = unbounded
-    NotBefore      time.Time      // optional time bound
-    NotAfter       time.Time      // optional time bound
-    Direction      Direction      // Forward (older→newer) or Backward
-    PageSize       int            // host caps at 200; default 50
-    SessionContext SessionContext // for auth
+    Subject   Subject     // exact subject OR pattern with * / >
+    After     ulid.ULID   // exclusive lower bound; zero = from start
+    Before    ulid.ULID   // exclusive upper bound; zero = unbounded
+    NotBefore time.Time   // optional time bound
+    NotAfter  time.Time   // optional time bound
+    Direction Direction   // Forward (older→newer) or Backward
+    PageSize  int         // host caps at 200; default 50
+    // Auth flows via context.Context (auth.WithSession), not via the query.
+    // Putting it in two places invites the question "what if they disagree."
 }
 
 type HistoryStream interface {
-    Next(ctx context.Context) (Event, error)  // io.EOF when exhausted
-    Cursor() ulid.ULID                         // last-emitted ULID for resume
+    // Next returns the next event. io.EOF when exhausted.
+    Next(ctx context.Context) (Event, error)
     Close() error
 }
 ```
 
-Server-streaming gRPC. Caller iterates `Next()` until `io.EOF`, calls
-`Cursor()` for next-page resume.
+Server-streaming gRPC. Caller iterates `Next()` until `io.EOF`. For
+next-page resume, the **caller records the ULID of the last `Event`
+returned** and passes it as `After` on the next `QueryHistory` call. The
+stream itself does not carry pagination state — there's no
+`stream.Cursor()` method to invoke at the wrong time and silently get a
+zero-value ULID. ULID is the cursor everywhere.
+
+Auth uses `context.Context`; the gRPC handler injects session via
+`auth.WithSession(ctx, sess)` before calling `QueryHistory`. The plugin
+RPC carries the same context across the boundary.
 
 #### JS / PG fallback
 
@@ -706,10 +802,27 @@ Plugin restart → resumes from last ack. No orphan state.
 ciphertext. Plaintext access for derivations (e.g., pose order) goes
 through `host.codec.Decode` helper — codec stays host-owned.
 
-#### Subject ownership map
+#### Subject ownership map — longest-prefix-wins, token-aligned
 
 At startup, host builds a subject-prefix → owner map from all manifests.
-Conflicts at load = startup error. Validation enforced.
+
+**Matching rule:** longest-prefix-wins, where "prefix" is *token-aligned*
+(matches whole dot-delimited segments, not partial tokens).
+
+| Manifest declarations | Subject `events.main.scene.X.lifecycle` resolves to |
+| --- | --- |
+| only `events.main.scene.>` | scenes plugin |
+| `events.main.scene.>` and `events.main.scene.*.lifecycle` | scenes plugin (specific lifecycle plugin) — longer prefix wins |
+| `events.main.scene.>` and `events.main.>` | scenes plugin (longer prefix) |
+| `events.main.scene.lifecycle` (literal) and `events.main.scene.>` | scenes plugin (specific literal wins over wildcard at same depth) |
+| Two manifests both declaring `events.main.scene.>` | **startup error** — exact-prefix conflict |
+
+Conflicts at startup (two manifests with the same exact-prefix declaration)
+are a fatal error. Manifest validation refuses to load.
+
+A property test in §8 (invariants) asserts resolution determinism: for
+any set of declared prefixes and any concrete subject, the resolved owner
+is unique and deterministic.
 
 #### Audit retention policy
 
@@ -852,6 +965,7 @@ InProcessServer` means zero port-conflict risk in `t.Parallel()`.
 ```yaml
 event_bus:
   mode: embedded                    # "embedded" | "cluster"
+  game_id: "main"                   # mandatory; first segment after "events."
   store_dir: ""                     # blank = xdg.DataDir()/jetstream
   stream_max_age: 720h
   dupe_window: 30m
@@ -867,6 +981,43 @@ event_bus:
     key_file: ""
     server_name: ""
 ```
+
+#### NATS version pinning and upgrade discipline
+
+NATS is now a third-party runtime dependency on the critical path. Pin to
+the **latest GA minor** of `nats-server` (currently 2.12.x — pick the
+latest patch verified clean of the 2.12.5-class regression). Embedded
+import in `go.mod` matches the running server version.
+
+**Renovate config trails GA bumps** to avoid landing the day-one bad
+patch. Custom `renovate.json` rule for `github.com/nats-io/nats-server/v2`
+and `github.com/nats-io/nats.go`:
+
+```jsonc
+{
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "github.com/nats-io/nats-server/v2",
+        "github.com/nats-io/nats.go"
+      ],
+      "minimumReleaseAge": "14 days",   // wait 2 weeks after GA before opening PR
+      "groupName": "nats",              // group together so we test/upgrade as a unit
+      "schedule": ["after 9am on Monday"]
+    }
+  ]
+}
+```
+
+Upgrade discipline:
+
+- Renovate opens PR for grouped NATS bump 14+ days post-GA
+- PR runs `task pr-prep` (lint, tests, integration, E2E)
+- The chaos+soak nightly (§8) runs against the PR branch before merge
+- Merge only if all gates green
+- Rollback plan: if a bump regresses production behavior, revert the
+  bump commit; the JS filestore format is forward-compatible within a
+  major, so downgrade-restart is safe
 
 `mode` is a config seam, **not a cutover plan**. Switching `embedded` →
 `cluster` is a deliberate multi-step migration project (see §10). What the
@@ -1056,7 +1207,58 @@ that proves the most subtle new behavior of the design.
 
 - Inject latency / errors on PG INSERT, NATS publish, plugin RPC
 - 1k events/sec for 5 minutes; assert no goroutine leak (`goleak`),
-  memory growth < 50 MB, audit lag < 1s, full event count
+  memory growth < 50 MB, audit lag p99 ≤ 5s, full event count
+
+#### Performance budget (humane, justified)
+
+**Context for the budget.** HoloMUSH is a text-based MUSH for human
+players reading prose. It is not twitch gaming, not algorithmic trading,
+not a real-time multiplayer FPS. The product priorities — in order — are
+**Privacy > Stability > Extensibility > Resilience > Performance**.
+Performance only matters insofar as it keeps prose interactions feeling
+responsive to humans.
+
+Human perception baselines for text interaction:
+
+| Latency | Feel |
+| --- | --- |
+| < 100ms | Instant |
+| 100-300ms | Snappy |
+| 300-500ms | Acceptable for chat |
+| 500-1000ms | Noticeable lag, still tolerable |
+| 1-2s | Frustrating |
+| > 2s | Broken |
+
+**Budgets** (CI gates in chaos+soak nightly; breach blocks merge):
+
+| Surface | p50 target | p99 ceiling | Why this number |
+| --- | --- | --- | --- |
+| End-to-end publish → subscriber `Send` (live UX) | ≤ 50ms | ≤ 200ms | The user-facing one. "Snappy" → "acceptable for chat." Anyone seeing 200ms+ on poses notices. |
+| Plugin `AuditEvent` RPC (background) | ≤ 5ms | ≤ 50ms | Background; doesn't affect live UX. The 50ms ceiling catches plugin pathologies (sync I/O in handler) without forcing micro-optimization. |
+| Plugin `QueryHistory` per-page RPC | ≤ 50ms | ≤ 250ms | User-perceived as "loading more scrollback." Half a click-budget; UI applies the rest. |
+| Audit projection lag | ≤ 500ms | ≤ 5s | Doesn't affect live; matters for "did my pose make it into the log yet." 5s ceiling catches projection stalls before users notice. |
+| Embedded NATS publish ack | ≤ 5ms | ≤ 25ms | Local in-process; budget is generous to absorb fsync hiccups under load. |
+
+These are **breaches block merge** — not aspirations. A plugin or change
+that violates the ceiling is a bug, not an architectural concern.
+
+**Explicit non-budgets** — what we deliberately do *not* optimize for:
+
+- Sub-millisecond anything (we will gladly trade 5ms for clearer code
+  or better isolation)
+- Throughput beyond 1k events/sec sustained (our scale envelope; cluster
+  cutover when scale demands)
+- Memory footprint optimization beyond avoiding leaks (50MB headroom is
+  fine; cleverness here is wasted effort)
+- CPU efficiency beyond avoiding pathologies (3% CPU cost of plugin RPC
+  loop is acceptable; "saving" it via tighter coupling would be wrong
+  per priority order)
+
+**When in doubt** between two design choices, the priority order
+decides. Plugin isolation that costs 5ms p99 wins over tighter coupling
+that saves it. Synchronous codec calls that are clearer to audit win
+over async codec calls that shave latency. Stability and clarity are
+features; speed past the budget is not.
 
 #### Coverage gates
 
@@ -1101,39 +1303,67 @@ pgx.Conn lifecycle tests.
 
 #### Codec key management (deferred but designed)
 
-```go
-type KeyProvider interface {
-    Active(ctx context.Context, label KeyLabel) (Key, error)
-    ByID(ctx context.Context, id KeyID) (Key, error)
-}
+Three narrow responsibilities, three interfaces:
 
+```go
+// Codec is a crypto primitive. It does not know about subjects or
+// routing — keep crypto narrow.
 type Codec interface {
     Name() Name
-    Encode(ctx context.Context, subject string, plaintext []byte) ([]byte, error)
-    Decode(ctx context.Context, subject string, ciphertext []byte) ([]byte, error)
+    Encode(ctx context.Context, plaintext []byte, key Key) ([]byte, error)
+    Decode(ctx context.Context, ciphertext []byte, key Key) ([]byte, error)
+}
+
+// KeyProvider supplies keys to codecs. Implementations resolve from
+// local file, env, KMS, etc.
+type KeyProvider interface {
+    Active(ctx context.Context, label KeyLabel) (Key, error)  // for encrypt
+    ByID(ctx context.Context, id KeyID) (Key, error)          // for decrypt
+}
+
+// KeySelector is the policy layer. It maps a subject (or other context)
+// to (codec name, key label) per the deployment's encryption rules.
+// Lives upstream of Codec; calls into KeyProvider after resolution.
+type KeySelector interface {
+    SelectForEncrypt(ctx context.Context, subject Subject) (codec Name, label KeyLabel, err error)
+    SelectForDecrypt(ctx context.Context, codec Name, keyID KeyID) (Key, error)
 }
 ```
+
+The publish path now reads (pseudo-Go):
+
+```go
+codecName, label, _ := selector.SelectForEncrypt(ctx, event.Subject)
+key, _              := keys.Active(ctx, label)
+codec               := registry.Resolve(codecName)
+ciphertext, _       := codec.Encode(ctx, plaintext, key)
+header.App-Codec    = string(codecName)
+```
+
+This keeps the codec implementation stateless and subject-agnostic. The
+subject→key mapping lives in `KeySelector` where it belongs as a policy
+concern.
 
 Codec internal envelope: `[1-byte version][8-byte key_id][12-byte
 nonce][N-byte ciphertext][16-byte auth tag]`. Key ID enables rotation.
 Provider implementations (none ship initially): `LocalFileKeyProvider`,
 `EnvKeyProvider`, `KMSKeyProvider`, `MultiProvider`.
 
-Subject → label routing via config:
+Subject → key routing via config (consumed by `KeySelector`):
 
 ```yaml
 encryption:
   rules:
-    - subject_pattern: "events.scene.>"
+    - subject_pattern: "events.<game>.scene.>"
       codec: aes-gcm-v1
       key_label: scene-content
-    - subject_pattern: "events.character.*"
+    - subject_pattern: "events.<game>.character.*"
       codec: aes-gcm-v1
       key_label: dm-content
 ```
 
-Decryption failure (auth tag invalid OR key not loaded) = hard error,
-security event in audit, never silent.
+Decryption failure (auth tag invalid, codec name unknown, OR key not
+loaded) = hard error, security event in audit, never silent.
 
 #### Plugin audit boundary
 
@@ -1276,89 +1506,70 @@ Realistic envelope: 5–7 weeks.
 
 ## Open questions
 
-These **MUST** be resolved before implementation plans land. Each item is
-either a decision needed from the project owner, or a design refinement
-surfaced by independent review (architect-review, 2026-04-18) that the
-spec needs to commit to before plan-writing begins.
+All decisions surfaced by the independent architect review (2026-04-18)
+have been resolved (below). The spec is unblocked for implementation
+plan-writing.
 
-### Decisions needed (block implementation plans)
+### Decisions resolved (2026-04-18)
 
-1. **NATS server version pinning** — NATS 2.12.5 had a regression on
-   stream updates ([nats-server release notes
-   2.12.5](https://github.com/nats-io/nats-server/releases/tag/v2.12.5));
-   pick a known-good minor and pin. Define upgrade discipline: who watches
-   release notes, runs the smoke matrix, owns the rollback plan when a
-   NATS upgrade breaks JS. NATS is now a third-party runtime dependency
-   on the critical path; treat it like one.
+1. **NATS version pinning + upgrade discipline (Q1)** — pin to latest GA
+   minor of `nats-server`. Renovate trails GA bumps by 14 days
+   (`minimumReleaseAge: "14 days"`) to avoid landing day-one bad patches;
+   bumps grouped between `nats-server` and `nats.go`. Discipline + config
+   in §7. PR-time gates via `task pr-prep` + chaos+soak nightly.
 
-2. **Codec key provider for the first encryption rollout** — what's the
-   preferred KMS / key store for production? Affects which provider
-   lands first when encryption work begins. Out of scope for this design;
-   filed as follow-up bead.
+2. **Codec key provider (Q2)** — deferred to encryption implementation
+   workstream. The `KeyProvider` interface ships now (§9); concrete KMS
+   choice (AWS / GCP / Vault / Local) when threat model + compliance
+   requirements crystallize. Filed as follow-up bead.
 
-3. **Event proto schema location** — for the host envelope (`Event` proto
-   itself): `api/proto/holomush/eventbus/v1/`? For plugin-owned payload
-   protos: each plugin's own proto namespace. Confirm the layout before M1.
+3. **Event proto schema location (Q3)** — host envelope at
+   `api/proto/holomush/eventbus/v1/`. Plugin payload protos in each
+   plugin's existing namespace (`api/proto/holomush/scenes/v1/`, etc.).
+   Codified in §1d.
 
-4. **Whether `Event.Type` and `Subject` should be typed strings** — change
-   from §1a sketch is `type Type string` and `type Subject string` with
-   constructors that validate against allowed character sets. Yes —
-   add this to §1; the typed-string overhead is zero at runtime and
-   catches accidental field-swap bugs at compile time.
+4. **Typed `Subject` and `Type` strings (Q4)** — adopted. `type Subject
+   string` and `type Type string` with validating constructors. Codified
+   in §1a.
 
-5. **Multi-tenancy game-id prefix** — should subjects be
-   `events.<game-id>.<domain>.<entity>` from day one? Cost today: zero
-   (single game, single literal segment). Cost in 18 months if multi-game
-   ever lands and we didn't: global subject rename across every plugin,
-   every audit row, every consumer. **Recommend: yes, add now.** Decision
-   needed.
+5. **Multi-tenancy `events.<game-id>.` prefix (Q5)** — adopted from day
+   one. Single-game default `game_id: "main"` in `event_bus` config.
+   Codified in §1c and §7.
 
-6. **`EventBus` interface split** — reviewer flagged the single interface
-   as too large; idiomatic Go would be three separate interfaces
-   (`Publisher`, `Subscriber`, `HistoryReader`) composed at the call
-   site. Recommend: split. Lets gRPC handlers depend on only what they
-   need; lets each be mocked independently. Decide before M1.
+6. **`EventBus` interface split (Q6)** — adopted. Three single-
+   responsibility interfaces (`Publisher`, `Subscriber`, `HistoryReader`)
+   composed by `EventBus`. Call sites depend only on what they need.
+   Codified in §4.
 
-7. **`AckFunc` shape** — return `(Event, AckFunc, error)` (current sketch)
-   vs return `(Delivery, error)` where `Delivery` has `Event()` and
-   `Ack() error` methods. Reviewer recommends the typed handle. Yes —
-   typed handles are easier to mock, log, and extend (`Nack()`,
-   `InProgress()` later). Decide before M1.
+7. **Typed `Delivery` handle (Q7)** — adopted. `(Delivery, error)` from
+   `Next()`; `Delivery` has `Event()`, `Ack()`, `Nack()`, `InProgress()`.
+   Replaces the `(Event, AckFunc, error)` tuple. Codified in §4.
 
-8. **Subject ownership prefix matching algorithm** — §6 says "subject
-   prefix → owner map" but doesn't specify matching semantics for
-   overlapping prefixes (e.g., `events.scene.>` vs
-   `events.scene.<id>.lifecycle`). Recommend: longest-prefix-wins,
-   token-aligned. Codify and add to the matching algorithm doc, plus a
-   property test (§8 invariants) for resolution determinism.
+8. **Longest-prefix-wins subject ownership routing (Q8)** — adopted,
+   token-aligned. Property test for resolution determinism added to §8.
+   Codified in §6.
 
-9. **`HistoryStream.Cursor()` removed in favor of caller-tracked ULID**
-   — reviewer flagged the stateful side-channel. Yes — caller records the
-   ULID of the last `Event` returned by `Next()`. Drop `Cursor()` from
-   the interface. Decide before M1.
+9. **Drop `HistoryStream.Cursor()` (Q9)** — adopted. Caller records
+   ULID from the last `Event` returned by `Next()`. No stateful side-
+   channel. Codified in §5.
 
-10. **Plugin-owned audit coupling shape (A2)** — current design: host
-    invokes plugin `PluginAuditService.AuditEvent` RPC for every audit
-    event AND `QueryHistory` synchronously RPCs the plugin per page.
-    Reviewer's alternative: host owns audit storage in plugin-namespaced
-    schemas; plugin owns only the projection function (deserialization,
-    derived-table maintenance) plus the read-side authz check. This
-    significantly reduces runtime coupling (no per-event sync RPC on
-    write OR read). Need to choose between current design (clean privacy
-    boundary, runtime coupling) and the reviewer's alternative
-    (different privacy model, less coupling). Decision needed.
+10. **Plugin-owned audit coupling (Q10)** — keep current design with an
+    explicit performance budget (Section 8). Privacy boundary
+    (credential separation, plugin-enforced authz, future plugin-side
+    decryption) wins over coupling reduction. Performance concerns
+    quantified and made into hard CI gates (§8 perf budget): plugin
+    `AuditEvent` RPC p99 ≤ 50ms, plugin `QueryHistory` per-page RPC p99
+    ≤ 250ms. Reasoning baked into §8: HoloMUSH is a text-based MUSH for
+    humans reading prose, priorities are
+    Privacy > Stability > Extensibility > Resilience > Performance.
 
-11. **Codec interface signature** — current sketch takes `subject` as a
-    parameter. Reviewer recommends keeping crypto primitives narrow:
-    `Encode(ctx, plaintext, key Key) ([]byte, error)`, with subject→key
-    routing in a separate `KeySelector` upstream. Yes — split. Decide
-    before M1.
+11. **Codec interface signature (Q11)** — adopted. `Codec.Encode/Decode`
+    takes `(ctx, bytes, key Key)`. Subject→key routing lives in a
+    separate `KeySelector` interface upstream. Codified in §9.
 
-12. **`HistoryQuery.SessionContext` placement** — current sketch has it
-    on the struct. Reviewer flags duplication with `ctx context.Context`
-    that the methods already take. Yes — pull `SessionContext` out of
-    the struct, carry via a typed context key (`auth.WithSession(ctx,
-    sess)`). Decide before M1.
+12. **`HistoryQuery.SessionContext` via `context.Context` (Q12)** —
+    adopted. Removed from the struct; carried via `auth.WithSession(ctx,
+    sess)`. Codified in §5.
 
 ### Acknowledged (will be addressed during plan-writing or as
 discovered-from beads)

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -1571,8 +1571,7 @@ plan-writing.
     adopted. Removed from the struct; carried via `auth.WithSession(ctx,
     sess)`. Codified in §5.
 
-### Acknowledged (will be addressed during plan-writing or as
-discovered-from beads)
+### Acknowledged (will be addressed during plan-writing or as discovered-from beads)
 
 - **Schema evolution under live load** (reviewer F3) — need explicit
   upgrade path for proto v1 → v2 including who handles old events in

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -4,7 +4,7 @@
 
 **DRAFT** — design proposal pending implementation plan.
 
-Supersedes: [2026-03-20-event-delivery-redesign.md](2026-03-20-event-delivery-redesign.md)
+Supersedes: [docs/specs/2026-03-20-event-delivery-redesign.md](../../specs/2026-03-20-event-delivery-redesign.md)
 (LISTEN/NOTIFY-based delivery; this design replaces both the event log and the
 delivery transport).
 
@@ -178,12 +178,34 @@ type Event struct {
 sequence (`uint64`) is internal to the bus and **MUST NOT** cross any
 public API boundary. ULIDs survive JetStream rebuilds; sequences do not.
 
-#### 1b. Event Type — plugin-declared, opaque to host
+#### 1b. Event Type and Payload — plugin-declared, opaque to host
 
 The 19 `EventType` constants in `internal/core/event.go:39-70` **MUST** be
 deleted. Each plugin declares its own type strings as constants in its own
 package. The host treats `Type` as `string`, validated only against the
 plugin's manifest declaration (existing `EventSink` mechanism, PR #207).
+
+**The same boundary rule applies to payload schemas.** The plugin-domain
+payload structs at `internal/core/event.go:74-143`
+(`LocationStatePayload`, `ExitUpdatePayload`, `PagePayload`,
+`WhisperPayload`, `WhisperNoticePayload`, `OOCPayload`, `PemitPayload`)
+**MUST** also move out of `internal/core/`. Each lives in its owning
+plugin's package, defined as proto messages in that plugin's proto namespace
+(e.g., `api/proto/holomush/scenes/v1/`, `api/proto/holomush/dm/v1/`,
+`api/proto/holomush/world/v1/` — final layout decided in F5 per plugin).
+
+The host's `Event.Payload []byte` is opaque from end to end:
+
+- Publishers (plugins) marshal their own proto to bytes
+- Host applies codec, persists bytes to JetStream and audit
+- Subscribers receive bytes, apply codec.Decode, then unmarshal to their
+  own proto type
+- The host **MUST NOT** import any plugin's payload type and **MUST NOT**
+  attempt to interpret payload bytes beyond passing them through
+
+This closes the boundary violation completely — neither the type
+identifier nor the payload schema for plugin-owned events lives in
+`internal/core/` after the cutover.
 
 #### 1c. Subject naming — hierarchical, plugin-namespaced
 
@@ -248,9 +270,9 @@ StreamConfig{
     Subjects:    []string{"events.>"},
     Retention:   LimitsPolicy,
     Storage:     FileStorage,
-    Replicas:    1,                     // single-node; bumped at cluster cutover
+    Replicas:    1,                     // single-node; multi-node = planned cutover, not flag flip (§7, §10)
     MaxAge:      720h,                  // 30 days
-    Duplicates:  5 * time.Minute,
+    Duplicates:  30 * time.Minute,      // widened from default 5m to absorb host-restart retry window
     AllowDirect: true,
 }
 ```
@@ -335,20 +357,52 @@ regardless of publish concurrency, so `EventWriter` **MUST** be deleted.
 `core.NewULID`'s in-process mutex still produces monotonic ULIDs — that
 operation is not a serialization bottleneck.
 
-#### Idempotent publish
+#### Idempotent publish — bounded window
 
-`Nats-Msg-Id` = `event.ID.String()`. Within the dedup window (5 min,
-configurable), JS silently drops duplicate publishes with the same ID.
-Crash-safe at-least-once becomes effectively exactly-once for publish.
+`Nats-Msg-Id` = `event.ID.String()`. Within the dedup window (default 5
+minutes, set via stream `Duplicates` config), JS silently drops duplicate
+publishes with the same ID and returns the original ack.
+
+**Honest delivery semantics:** at-least-once, with effective exactly-once
+*within the dedup window*. After the window expires, a publish with the
+same `Nats-Msg-Id` is treated as a fresh message and creates a duplicate
+in the log. There is no "exactly-once" without bound.
+
+**Required publisher contract** (enforced in `EventSink`):
+
+- Plugin retry attempts for the same `EmitIntent` **MUST** complete within
+  the dedup window. The host's publish RPC carries a deadline derived from
+  `dupe_window − safety_margin` (default `5m − 30s = 4m30s`). After
+  deadline, the host returns a `PublishExpired` error and the plugin
+  **MUST NOT** retry the original intent — it must construct a new event
+  (new ULID).
+- Subscribers **MUST** dedup by ULID at the application boundary. Web and
+  telnet adapters maintain a per-connection seen-ULID set with TTL
+  ≥ `MaxAckPending × ack_wait` to absorb at-least-once redelivery from JS
+  consumers.
+- The dedup window is widened (`dupe_window: 30m`) when running embedded
+  NATS so a worst-case host crash + restart + retry cycle stays inside
+  the window.
+
+**Host crash mid-publish scenario.** If the host crashes after JS has
+acked the publish (filestore fsync complete) but before `EmitEvent`
+returns to the plugin, the plugin sees a transport error on restart and
+retries with the same ULID. JS dedup absorbs the duplicate within the
+window. If the host is down longer than the window — i.e., the plugin
+restart happened > `dupe_window` after the crash — the retry creates a
+duplicate. Subscribers' dedup catches it; the log carries two rows for
+the same ULID.
 
 #### Failure modes
 
 | Scenario | Behavior |
 | --- | --- |
-| JS unreachable | `PublishMsg` returns error; `EmitEvent` propagates to plugin; retry safe via dedup |
+| JS unreachable | `PublishMsg` returns error; `EmitEvent` propagates to plugin; retry safe within dedup window |
 | `PublishAck` timeout | Same as above |
 | Manifest validation fails | Reject pre-publish; audit log; plugin error |
 | Payload exceeds 64 KiB | Reject pre-publish; same cap as today |
+| Plugin retry exceeds dedup window | Host returns `PublishExpired`; plugin must mint new ULID |
+| Host crash > dedup window before retry completes | Duplicate in log; subscriber dedup absorbs (cost: one duplicate audit row) |
 
 No silent fallbacks. With embedded NATS, JS down = process down. With
 clustered NATS, quorum loss means publishes fail until quorum returns.
@@ -800,7 +854,7 @@ event_bus:
   mode: embedded                    # "embedded" | "cluster"
   store_dir: ""                     # blank = xdg.DataDir()/jetstream
   stream_max_age: 720h
-  dupe_window: 5m
+  dupe_window: 30m
   monitor_port: 0
   prometheus_exporter: true
 
@@ -814,8 +868,34 @@ event_bus:
     server_name: ""
 ```
 
-`mode` flip is the seam to multi-node. Day-one only `embedded` is
-implemented.
+`mode` is a config seam, **not a cutover plan**. Switching `embedded` →
+`cluster` is a deliberate multi-step migration project (see §10). What the
+config seam buys you: the application-side code (every consumer of
+`EventBus`) stays unchanged across the cutover. What it does **not**
+buy: any of the operational work below. Be honest with planning that the
+cluster cutover, when it lands, is in the same scope class as a database
+migration:
+
+- Cluster sizing decision (3 / 5 nodes, R=3 quorum)
+- External NATS deployment, network policy, DNS / discovery
+- mTLS material lifecycle (issue, rotate, revoke)
+- NKey or JWT-based per-host credentials, including per-plugin in cluster
+  mode (defense-in-depth for subject permissions)
+- Monitoring stack adapted (per-node metrics, leader-election alerts,
+  Raft health)
+- Backup / restore strategy (`nats account backup` is offline; `Mirror`
+  streams are live but require coordination)
+- **Filestore migration** of the existing single-node JetStream data —
+  cannot be a raw `cp -r`. Two options: (a) restore from PG audit
+  projection (clean but multi-hour at scale), (b) `Mirror` stream from
+  embedded to new cluster, wait for lag → 0, flip publishers, deprecate
+  source. Choose at planning time based on downtime tolerance.
+- **Plugin audit consumers must be re-registered** against the new
+  cluster topology (durable consumer state in old filestore is lost
+  unless restored).
+
+Treat the cutover as a multi-week project. The seam is the EventBus
+interface boundary; the migration is the work.
 
 ---
 
@@ -829,6 +909,45 @@ implemented.
 | Bus integration | EventBus contract | Embedded NATS, MemoryStorage | < 100ms |
 | Audit integration | Host + plugin projections | Embedded NATS + PG testcontainer | < 500ms |
 | E2E | Full server, multi-protocol | Embedded NATS + PG + clients | seconds |
+
+#### Controllable test seams (no hidden waits)
+
+Several behaviors of the new design are inherently asynchronous (audit
+projection drain, JS redelivery, ack timing, dedup-window expiry). The
+strategy is **never `time.Sleep`, but `Eventually` is permitted only on
+synchronization metrics, not on data**. Specifically:
+
+- **Test harness MUST inject all timing knobs** as configuration, not
+  hard-coded literals:
+  - JS consumer `AckWait` defaults to 30s in production; tests set
+    100ms so redelivery semantics are observable in bounded time.
+  - JS stream `Duplicates` defaults to 30m in production; tests set 1s
+    so dedup-window expiry tests run fast.
+  - Audit projection `MaxAckPending` and worker batch sizes pinned for
+    reproducibility.
+- **A clock source (`func() time.Time`) is injected into the bus** so
+  time-bound assertions (tier crossover, dedup window, `InactiveThreshold`)
+  use a controllable test clock — not wall clock.
+- **Synchronization points are observable metrics, not timers.** Pattern:
+
+  ```go
+  embedded.AwaitAuditLag(t, 0)            // blocks until audit_projection_lag_seconds == 0
+  embedded.AwaitAckedSeq(t, "session_X", 42)  // blocks until consumer ack-state crosses 42
+  embedded.AwaitConsumerInfo(t, "session_X", func(i jetstream.ConsumerInfo) bool { ... })
+  ```
+
+  These read JS / projection state directly, not wall-clock-bounded
+  polls. They use `Eventually` internally with a hard upper bound (5s)
+  whose only purpose is to fail loudly on a deadlock, not to add
+  observation latency.
+- **`time.Sleep` is banned in `internal/eventbus/`,
+  `test/integration/eventbus_e2e/`, and `internal/grpc/` test files** by
+  custom golangci-lint rule.
+- **`Eventually` on raw subscriber data channels is also banned** — must
+  go through `AwaitAckedSeq` or equivalent metric.
+
+This makes the previously-hidden waits explicit and bounded, and makes
+the test suite genuinely fast (single-digit ms per test).
 
 #### Boundary tests
 
@@ -862,9 +981,20 @@ failure, store-dir lock contention.
 #### Invariant tests (property-based, `pgregory.net/rapid`)
 
 - I-14 cross-subject sequence ordering under concurrent publishers
-- Idempotent publish via `Nats-Msg-Id`
+- Idempotent publish via `Nats-Msg-Id` within window; new event after window
 - Audit row count == JS message count after drain
 - Plugin audit table contains only declared subjects
+- **Filter monotonicity under `SetFilters`** (load-bearing — see §4):
+  emit N events while concurrently calling `SetFilters` with arbitrary
+  subset sequences. After the test:
+  - Every event whose subject was in the filter set *at the time of its
+    publish* MUST be delivered exactly once (modulo ULID dedup)
+  - No event from a removed subject MUST be delivered after the
+    corresponding `SetFilters` returns
+  - Cursor (last acked seq) MUST be preserved across every filter update
+- **Subject-ownership-routing under concurrent loads**: register N
+  manifests with overlapping prefixes, assert resolution is
+  deterministic and matches the documented longest-prefix-wins rule.
 
 Plus fixed invariants checked in CI:
 
@@ -894,6 +1024,33 @@ Plus fixed invariants checked in CI:
 | Plugin process crash mid-deliver | Restart drains; PK ON CONFLICT prevents dups |
 | Embedded JS storage corruption | Rebuild from PG audit; ULIDs stable |
 | Multi-protocol fan-out | Telnet + web in same scene see same pose |
+
+#### JS↔PG hot/cold tier crossover suite (dedicated)
+
+The tier-selection algorithm in §5 (`safetyMargin = 1h`,
+`jsRetentionEdge = now() - JS_MaxAge + safetyMargin`) is the highest-risk
+new code in the design. A dedicated test suite at
+`internal/eventbus/history/tier_test.go` covers it explicitly using the
+injected clock (no wall clock):
+
+| Scenario | Setup | Assertion |
+| --- | --- | --- |
+| Cursor strictly within JS retention | All events recent | Served entirely from JS, zero PG queries |
+| Cursor strictly older than retention | All events aged | Served entirely from PG, zero JS calls |
+| Cursor exactly at the boundary edge | `cursor.timestamp == jsRetentionEdge` | No double-delivery, no skip |
+| Page boundary crosses the edge | Half page in PG, half in JS | Continuous order, no gap, no overlap |
+| Clock skew between PG `inserted_at` and JS publish time | Inject 5s skew | Crossover absorbs skew via safetyMargin |
+| Forward direction crossing boundary | `Direction: Forward` | Older events first, newer continue from JS |
+| Backward direction crossing boundary | `Direction: Backward` | Newer events first, older continue from PG |
+| Empty PG side, full JS side | Audit projection lagging | Only JS events delivered, no error |
+| Empty JS side (aged-out subject), full PG side | Subject aged out of JS | Only PG events delivered, no error |
+| Both sides empty | Subject never had events | Empty result, no error |
+| Cursor for a non-existent subject pattern | | Empty result, no error |
+| Plugin-owned subject crosses the edge | Routes to plugin RPC | Plugin handles tier transparently in its own schema (host doesn't query both) |
+
+This suite **MUST** run with the injected clock fast-forwarded across
+the boundary; never with wall-clock waits. It is the single test suite
+that proves the most subtle new behavior of the design.
 
 #### Chaos and soak (CI nightly)
 
@@ -1058,7 +1215,7 @@ production behavior unchanged.
 | F2 | Audit projection actually projects (exclusion list active) | `internal/eventbus/audit/` |
 | F3 | gRPC Subscribe handler rewritten | `internal/grpc/server.go`; deletes `cursor_lock.go`, `replay.go` |
 | F4 | gRPC `QueryHistory` handler rewritten with hot/cold tier | `internal/grpc/query_history.go` |
-| F5 | Per-plugin updates (subject names, manifest decls, type constants moved) | `plugins/core-scenes/`, others |
+| F5 | Per-plugin updates: subject names, manifest decls, **EventType constants AND payload types moved out of `internal/core/` into plugin packages** (see §1b) | `plugins/core-scenes/`, others; deletes `internal/core/event.go:39-143` |
 | F6 | Schema cutover: DROP `events`, DROP `event_cursors` | `internal/store/migrations/` |
 | F7 | Old code deletion (`EventWriter`, pgnotify, legacy Subscribe) | wide |
 | F8 | Test rewrite (delete obsolete; port "Variant A"; add E2E suite) | `internal/store/postgres_integration_test.go`, `test/integration/eventbus_e2e/` |
@@ -1119,32 +1276,128 @@ Realistic envelope: 5–7 weeks.
 
 ## Open questions
 
+These **MUST** be resolved before implementation plans land. Each item is
+either a decision needed from the project owner, or a design refinement
+surfaced by independent review (architect-review, 2026-04-18) that the
+spec needs to commit to before plan-writing begins.
+
+### Decisions needed (block implementation plans)
+
 1. **NATS server version pinning** — NATS 2.12.5 had a regression on
    stream updates ([nats-server release notes
    2.12.5](https://github.com/nats-io/nats-server/releases/tag/v2.12.5));
-   pick a known-good minor and pin. Need an explicit decision before M4.
+   pick a known-good minor and pin. Define upgrade discipline: who watches
+   release notes, runs the smoke matrix, owns the rollback plan when a
+   NATS upgrade breaks JS. NATS is now a third-party runtime dependency
+   on the critical path; treat it like one.
 
 2. **Codec key provider for the first encryption rollout** — what's the
    preferred KMS / key store for production? Affects which provider
    lands first when encryption work begins. Out of scope for this design;
-   filed as follow-up.
+   filed as follow-up bead.
 
-3. **Event proto schema location** — `api/proto/holomush/eventbus/v1/`
-   alongside other plugin protos? Decide before M1.
+3. **Event proto schema location** — for the host envelope (`Event` proto
+   itself): `api/proto/holomush/eventbus/v1/`? For plugin-owned payload
+   protos: each plugin's own proto namespace. Confirm the layout before M1.
 
-4. **Whether `Event.Type` should be a typed string (Go) for compile-time
-   help even though it's plugin-declared** — tradeoff: typed strings give
-   compile-time per-plugin enforcement but require each plugin to
-   declare its own type. Probably yes (per Section 1b's "constants in
-   plugin's own package").
+4. **Whether `Event.Type` and `Subject` should be typed strings** — change
+   from §1a sketch is `type Type string` and `type Subject string` with
+   constructors that validate against allowed character sets. Yes —
+   add this to §1; the typed-string overhead is zero at runtime and
+   catches accidental field-swap bugs at compile time.
 
-5. **Plugin-side `EventSink` API exact shape** — `Subject` field name vs
-   keeping `Stream` for backward compatibility? Clean break says rename,
-   but check with plugin authors.
+5. **Multi-tenancy game-id prefix** — should subjects be
+   `events.<game-id>.<domain>.<entity>` from day one? Cost today: zero
+   (single game, single literal segment). Cost in 18 months if multi-game
+   ever lands and we didn't: global subject rename across every plugin,
+   every audit row, every consumer. **Recommend: yes, add now.** Decision
+   needed.
 
-6. **Test for "Phase A is truly idle"** — how do we prove the embedded
-   NATS subsystem started in M4 isn't accidentally consuming or affecting
-   anything in production until F1?
+6. **`EventBus` interface split** — reviewer flagged the single interface
+   as too large; idiomatic Go would be three separate interfaces
+   (`Publisher`, `Subscriber`, `HistoryReader`) composed at the call
+   site. Recommend: split. Lets gRPC handlers depend on only what they
+   need; lets each be mocked independently. Decide before M1.
+
+7. **`AckFunc` shape** — return `(Event, AckFunc, error)` (current sketch)
+   vs return `(Delivery, error)` where `Delivery` has `Event()` and
+   `Ack() error` methods. Reviewer recommends the typed handle. Yes —
+   typed handles are easier to mock, log, and extend (`Nack()`,
+   `InProgress()` later). Decide before M1.
+
+8. **Subject ownership prefix matching algorithm** — §6 says "subject
+   prefix → owner map" but doesn't specify matching semantics for
+   overlapping prefixes (e.g., `events.scene.>` vs
+   `events.scene.<id>.lifecycle`). Recommend: longest-prefix-wins,
+   token-aligned. Codify and add to the matching algorithm doc, plus a
+   property test (§8 invariants) for resolution determinism.
+
+9. **`HistoryStream.Cursor()` removed in favor of caller-tracked ULID**
+   — reviewer flagged the stateful side-channel. Yes — caller records the
+   ULID of the last `Event` returned by `Next()`. Drop `Cursor()` from
+   the interface. Decide before M1.
+
+10. **Plugin-owned audit coupling shape (A2)** — current design: host
+    invokes plugin `PluginAuditService.AuditEvent` RPC for every audit
+    event AND `QueryHistory` synchronously RPCs the plugin per page.
+    Reviewer's alternative: host owns audit storage in plugin-namespaced
+    schemas; plugin owns only the projection function (deserialization,
+    derived-table maintenance) plus the read-side authz check. This
+    significantly reduces runtime coupling (no per-event sync RPC on
+    write OR read). Need to choose between current design (clean privacy
+    boundary, runtime coupling) and the reviewer's alternative
+    (different privacy model, less coupling). Decision needed.
+
+11. **Codec interface signature** — current sketch takes `subject` as a
+    parameter. Reviewer recommends keeping crypto primitives narrow:
+    `Encode(ctx, plaintext, key Key) ([]byte, error)`, with subject→key
+    routing in a separate `KeySelector` upstream. Yes — split. Decide
+    before M1.
+
+12. **`HistoryQuery.SessionContext` placement** — current sketch has it
+    on the struct. Reviewer flags duplication with `ctx context.Context`
+    that the methods already take. Yes — pull `SessionContext` out of
+    the struct, carry via a typed context key (`auth.WithSession(ctx,
+    sess)`). Decide before M1.
+
+### Acknowledged (will be addressed during plan-writing or as
+discovered-from beads)
+
+- **Schema evolution under live load** (reviewer F3) — need explicit
+  upgrade path for proto v1 → v2 including who handles old events in
+  audit, subscribers, backfill tool. Plan-writing must define the
+  versioning playbook (filed as discovered-from bead).
+- **Codec key retention is forever** (reviewer F4) — `KeyProvider.ByID`
+  implies any key ever used to encrypt persisted data must remain
+  decryptable. Has compliance implications (key revocation impossible
+  without re-encrypting all old data). Document explicitly in §9 and as
+  follow-up bead.
+- **Per-subject Prometheus cardinality discipline** (reviewer F6) —
+  with `events.scene.<ULID>.ic` subjects, per-subject metrics would
+  explode cardinality. Plan-writing must define the aggregation rule
+  (per-domain, not per-subject). Filed as bead.
+- **Future event-level ABAC** (reviewer F7) — JS doesn't natively
+  support efficient per-event filtering; if ever needed, host pays
+  delivery+ack cost for events users never see. Document the future
+  cost; not a blocker today.
+- **Cluster cutover discipline** — §7 now states honestly that this is a
+  multi-week migration. Spec does not commit to when. When it lands,
+  follows its own spec.
+- **Phase A idleness verification** (Q6 from prior version) — startup
+  test must assert: in M4 with no F-phase code, the embedded NATS server
+  starts, no consumers attach, no events flow, no audit rows produced.
+  Move from open question to plan-writing checklist item.
+
+### Resolved by review (no further action)
+
+- ULID stays as primary identity; JS seq is internal — confirmed sound.
+- `EventWriter` deletion — confirmed sound; ULID monotonicity preserved
+  via `core.NewULID`'s in-process mutex which is not a serialization
+  bottleneck.
+- Cursor race class elimination via per-event ack + ULID dedup — confirmed
+  sound, with the caveat that subscribers need a "client dedup contract"
+  (now documented in §3).
+- Single `EVENTS` stream design — confirmed sound for our scale.
 
 ---
 
@@ -1176,7 +1429,7 @@ Realistic envelope: 5–7 weeks.
 
 ## References
 
-- [2026-03-20-event-delivery-redesign.md](2026-03-20-event-delivery-redesign.md)
+- [docs/specs/2026-03-20-event-delivery-redesign.md](../../specs/2026-03-20-event-delivery-redesign.md)
   — superseded by this design
 - [2026-04-05-plugin-architecture-rework-design.md](2026-04-05-plugin-architecture-rework-design.md)
   — proto-first plugin contracts; this design extends with `PluginAuditService`

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -1,0 +1,1199 @@
+# JetStream Event Log + PostgreSQL Audit Projection — Design
+
+## Status
+
+**DRAFT** — design proposal pending implementation plan.
+
+Supersedes: [2026-03-20-event-delivery-redesign.md](2026-03-20-event-delivery-redesign.md)
+(LISTEN/NOTIFY-based delivery; this design replaces both the event log and the
+delivery transport).
+
+## Authors
+
+- Sean Brandt
+- Claude (collaborator)
+
+## Date
+
+2026-04-18
+
+---
+
+## Context
+
+The current event store (`internal/store/postgres.go`) uses a PostgreSQL
+`events` table as the durable log and `LISTEN`/`NOTIFY` for live fan-out.
+This architecture has produced a recurring class of timing races because
+notification delivery is asynchronous relative to the durable `INSERT`:
+
+- **Cursor persistence race** (Finding 1, PR #201) — `Send` → `UpdateCursors`
+  gap mitigated but not eliminated.
+  ([docs/plans/2026-04-07-cursor-lock-finding-1-closure.md](../../plans/2026-04-07-cursor-lock-finding-1-closure.md))
+- **Quit-teardown race** — `holomush-h9fp` telnet E2E flake, intermittent.
+- **Reconnect/replay flakes** — `holomush-0jzs` (four `terminal.spec.ts` tests).
+- **Test ULID ordering crutches** — six+ `time.Sleep(1ms)` calls in
+  `postgres_integration_test.go` to dodge ULID collision-in-same-ms.
+- **Missed notifications** — `pg_notify` does not buffer; disconnected
+  listeners require a 30-second stale-cache fallback.
+
+Every one of these is a variant of *"notification delivery decoupled from
+durable write."* `EventWriter` exists as a global serializer to enforce
+monotonic ULIDs (Invariant I-14) — it is the bottleneck and the source of
+test fragility, but cannot be removed without a different ordering primitive.
+
+The current design also conflicts with the project boundary rules: 19
+`EventType` constants live in `internal/core/event.go:39-70` despite the
+plugin boundary rule that "plugin-owned types MUST NOT leak into
+`internal/core/`".
+
+This design replaces both the event log and the delivery transport with
+NATS JetStream (embedded in-process today, externally clustered later) and
+relegates PostgreSQL to identity, projection, and forever-archive audit.
+
+### Project context
+
+- Single-node deployment, ~200 concurrent users, ~1k events/sec target
+- Pre-launch — clean cutover acceptable, no data migration required
+- PostgreSQL remains MANDATORY for identity, ABAC, projections, and audit
+- No Redis/Valkey
+- No PostgreSQL triggers or stored procedures (per `CLAUDE.md`)
+- Plugin boundary: plugin-owned types and event semantics MUST NOT live in
+  `internal/core/`
+
+### Adjacent in-flight work
+
+- PR #233: session-lifecycle-events (this design depends on it for consumer GC)
+- PR #234: LeaveFocusByTarget (parallel; not in conflict)
+- Channel plugin (`holomush-0sc.12`, paused) — resumes after this cutover with
+  subject names + audit declarations baked in
+- Scene Phase 4 (`holomush-5rh.13`) — currently blocked on event store
+  clarity; this design unblocks it
+
+---
+
+## Goals
+
+- **MUST** eliminate the cursor / Send-vs-Ack race class by construction
+- **MUST** eliminate `EventWriter`'s global serialization and the
+  `time.Sleep(1ms)` test crutches
+- **MUST** preserve cross-stream strict ordering (formerly Invariant I-14)
+- **MUST** keep PostgreSQL as a durable audit and projection target
+- **MUST** present a clean seam for cluster-mode NATS migration later
+- **MUST** keep the plugin boundary intact: plugins emit via the existing
+  `EventSink` facade; event types and subjects are plugin-declared
+- **MUST** support encryption-at-rest seam without committing to a
+  particular crypto implementation today
+- **SHOULD** dramatically simplify the gRPC `Subscribe` handler, replay
+  logic, and cursor lock machinery
+- **SHOULD** make tests deterministic without `time.Sleep` or `Eventually`
+  polling
+
+## Non-goals
+
+- Multi-node deployment today (deferred; design preserves the seam)
+- Real encryption codec implementation (codec interface ships; first
+  algorithm + key management is a separate workstream)
+- Data migration from existing `events` table (clean cutover, pre-launch)
+- Replacement of unrelated subsystems (ABAC, world model, plugin loader)
+
+---
+
+## Architecture overview
+
+```text
+                          ┌──────────────────────────────────────────┐
+                          │   Embedded NATS server (single-node)     │
+                          │   ─ JetStream stream: EVENTS             │
+                          │   ─ Subjects: events.>                   │
+                          │   ─ Storage: file (xdg.DataDir/jetstream)│
+                          │   ─ Retention: LimitsPolicy, MaxAge=720h │
+                          └─────────────┬────────────────────────────┘
+                                        │
+        ┌───────────────────┬───────────┼─────────────────┬───────────────┐
+        │                   │           │                 │               │
+        ▼                   ▼           ▼                 ▼               ▼
+┌───────────────┐  ┌──────────────┐ ┌──────────┐ ┌──────────────┐ ┌──────────────┐
+│  Plugin emit  │  │ Host emit    │ │ Session  │ │ Host audit   │ │ Plugin audit │
+│  (EventSink)  │  │ (EventSink)  │ │ consumer │ │ projection   │ │ projection   │
+│               │  │              │ │ (durable │ │ (durable     │ │ (durable     │
+│ → host        │  │ → bus.Publish│ │  pull)   │ │  pull)       │ │  pull)       │
+│   validates   │  │              │ │          │ │              │ │              │
+│ → bus.Publish │  │              │ │          │ │ → events_    │ │ → plugin     │
+│               │  │              │ │          │ │   audit (PG) │ │   schema     │
+└───────────────┘  └──────────────┘ └────┬─────┘ └──────────────┘ └──────────────┘
+                                          │
+                                          ▼
+                                    ┌─────────┐
+                                    │ gRPC    │
+                                    │ Send +  │
+                                    │ Ack     │
+                                    └─────────┘
+```
+
+**Key claims:**
+
+- JetStream owns ordering: `uint64` server-assigned sequence per stream;
+  ULIDs become identity (and `Nats-Msg-Id` dedup keys), not ordering keys.
+- JetStream owns consumer state: each session has a durable consumer named
+  `session_<sessionID>`; the host no longer tracks cursors.
+- PostgreSQL becomes a *projection target*. The host's `events_audit` table
+  is populated by an audit-projection consumer; plugin-owned subjects flow
+  to plugin-owned audit schemas via per-plugin consumers.
+- The `EventStore.Append` interface is replaced by `EventBus.Publish`. The
+  `EventStore.SubscribeSession` shape is replaced by `EventBus.OpenSession`
+  returning a `SessionStream` with `SetFilters(filters)`.
+- `EventWriter`, `cursor_lock.go`, `replay.go`, the legacy
+  `EventStore.Subscribe`, and the `event_cursors jsonb` column are all
+  **deleted** (clean break).
+
+---
+
+## Detailed design
+
+### 1. Event model
+
+#### 1a. Event identity
+
+```go
+type Event struct {
+    ID        ulid.ULID  // identity, dedup key, stable across rebuilds
+    Subject   string     // JS subject (replaces Stream)
+    Type      string     // plugin-declared opaque string
+    Timestamp time.Time  // host-stamped at publish
+    Actor     Actor      // host-stamped from session/plugin context
+    Payload   []byte     // proto bytes (post-codec encoding)
+}
+```
+
+| Property | Source | Purpose |
+| --- | --- | --- |
+| `ID` (ULID) | Host stamps via `core.NewULID` | Identity, `Nats-Msg-Id` dedup, stable across JS rebuilds |
+| `Subject` | Plugin emits, host validates | JS routing primitive |
+| `Type` | Plugin emits | Opaque to host; subscribers MAY filter on it |
+| `Timestamp` | Host stamps at publish | Audit + display ordering |
+| `Actor` | Host stamps from context | Authorship; never plugin-spoofable |
+| `Payload` | Plugin marshals proto, host applies codec | Domain content |
+
+`Event.ID` (ULID) **MUST** stay as the cross-system identity. JetStream
+sequence (`uint64`) is internal to the bus and **MUST NOT** cross any
+public API boundary. ULIDs survive JetStream rebuilds; sequences do not.
+
+#### 1b. Event Type — plugin-declared, opaque to host
+
+The 19 `EventType` constants in `internal/core/event.go:39-70` **MUST** be
+deleted. Each plugin declares its own type strings as constants in its own
+package. The host treats `Type` as `string`, validated only against the
+plugin's manifest declaration (existing `EventSink` mechanism, PR #207).
+
+#### 1c. Subject naming — hierarchical, plugin-namespaced
+
+```text
+events.<domain>.<entity-id>[.<facet>...]
+```
+
+| Subject | Owner | Examples |
+| --- | --- | --- |
+| `events.location.<ULID>` | host | location-scoped events |
+| `events.character.<ULID>` | host | personal stream (DMs, command responses) |
+| `events.session.<ULID>.lifecycle` | host | session lifecycle (PR #233) |
+| `events.notifications.character.<ULID>` | host | cross-scene notifications |
+| `events.scene.<ULID>.ic` | core-scenes plugin | in-character (poses, says) |
+| `events.scene.<ULID>.ooc` | core-scenes plugin | out-of-character chat |
+| `events.scene.<ULID>.lifecycle` | core-scenes plugin | created/paused/ended |
+| `events.channel.<ULID>` | core-channels plugin (future) | channels |
+
+Subjects use dot-delimited tokens; `*` matches one token, `>` matches the
+remainder and **MUST** be the last token. Subject token depth **SHOULD**
+stay below 16 to keep matching cost low.
+
+Manifest declares both publish-allowed and audit-subscribed subjects:
+
+```yaml
+emits:
+  - "events.scene.*.ic"
+  - "events.scene.*.ooc"
+  - "events.scene.*.lifecycle"
+audit:
+  - subjects: ["events.scene.>"]
+    schema:   plugin_core_scenes
+    table:    scene_log
+```
+
+#### 1d. Wire format — proto + version header
+
+Replace JSON-in-bytea with a proto `Event` message. Forces explicit schema
+discipline; binary; backward-compatible field additions are free. 64 KiB
+payload cap stays.
+
+Headers on every published message:
+
+| Header | Purpose | Required |
+| --- | --- | --- |
+| `Nats-Msg-Id` | ULID; dedup within window | yes |
+| `App-Schema-Version` | proto schema major version | yes |
+| `App-Event-Type` | plugin's `Type` string for filter-without-decode | yes |
+| `App-Codec` | codec name (`identity`, `aes-gcm-v1`, ...) | yes — never empty |
+| `traceparent` / `tracestate` | W3C trace context | when caller has active span |
+
+---
+
+### 2. Stream topology
+
+A single JetStream stream named `EVENTS` with subject filter `events.>`
+holds all events from all domains.
+
+```text
+StreamConfig{
+    Name:        "EVENTS",
+    Subjects:    []string{"events.>"},
+    Retention:   LimitsPolicy,
+    Storage:     FileStorage,
+    Replicas:    1,                     // single-node; bumped at cluster cutover
+    MaxAge:      720h,                  // 30 days
+    Duplicates:  5 * time.Minute,
+    AllowDirect: true,
+}
+```
+
+#### Why one stream
+
+- **Global monotonic sequence** for free (replaces Invariant I-14
+  enforcement)
+- **Multi-subject filters per consumer compose freely** —
+  `[events.character.<me>, events.scene.<focus>.ic, events.scene.<focus>.ooc]`
+  on one durable consumer
+- **One Raft group, one retention policy, one backup target**
+- **No stream lifecycle drama** — plugins never create or destroy streams
+
+#### Why not per-domain or per-entity
+
+Per-domain streams lose cross-stream ordering and force consumer-per-stream
+complexity. Per-entity streams cause stream proliferation in cluster mode.
+
+#### Retention rationale
+
+`LimitsPolicy` is the only retention type that supports independent
+fan-out readers. `MaxAge` is preferred over `MaxBytes` to avoid the
+memory-reservation gotcha
+([nats-server#6993](https://github.com/nats-io/nats-server/issues/6993)).
+30-day retention is a starting point — long enough for typical session
+resume, short enough that JS storage stays manageable.
+
+#### PostgreSQL audit as forever-archive
+
+The audit projection (Section 6) writes every event to `events_audit`
+(host) or to plugin-owned audit schemas. JS holds the recent past; PG
+holds everything. `QueryHistory` (Section 5) abstracts the boundary. This
+gives R=2-equivalent durability without R=2 cluster overhead.
+
+#### Stale-cursor edge case
+
+Session consumer `InactiveThreshold` **MUST** be less than stream
+`MaxAge`. Default: `InactiveThreshold = 24h`, `MaxAge = 720h`. Sessions
+disconnected longer than 24h re-establish via `QueryHistory` (which
+transparently uses PG audit) rather than resume.
+
+---
+
+### 3. Publish path
+
+#### Plugin-side contract (changed but minimal)
+
+```go
+// pkg/plugin/event_sink.go
+eventSink.Emit(ctx, EmitIntent{
+    Subject: "events.scene.01JABC...XYZ.ic",
+    Type:    "scene.pose",
+    Payload: marshaledProto,
+})
+```
+
+`EmitIntent.Stream` is renamed to `EmitIntent.Subject` and **MUST** be a
+JS subject string. Plugins **MUST** be updated as part of the cutover
+(F5 in Section 10).
+
+#### Host `EmitEvent` handler
+
+1. Validate `Subject` against plugin manifest's declared `emits` patterns
+2. Map nothing — subject is already in JS form
+3. Stamp host-owned fields:
+   - `ID = idgen.NewULID()`
+   - `Timestamp = time.Now().UTC()`
+   - `Actor.{Kind,ID}` from session or plugin context
+4. Marshal `Event{...}` to proto bytes
+5. `payload = codec.Encode(ctx, subject, protoBytes)` (codec resolved by
+   subject policy; identity by default — see Section 6 / 9)
+6. `js.PublishMsg(ctx, &nats.Msg{Subject, Data: payload, Header: ...})`
+7. Wait for `PublishAck` — synchronous, returns seq + stream confirmation
+8. Return ack to plugin
+
+#### `EventWriter` deletion
+
+`EventWriter` exists today to serialize appends globally for ULID
+monotonicity. JetStream assigns its own monotonic sequence per stream
+regardless of publish concurrency, so `EventWriter` **MUST** be deleted.
+`core.NewULID`'s in-process mutex still produces monotonic ULIDs — that
+operation is not a serialization bottleneck.
+
+#### Idempotent publish
+
+`Nats-Msg-Id` = `event.ID.String()`. Within the dedup window (5 min,
+configurable), JS silently drops duplicate publishes with the same ID.
+Crash-safe at-least-once becomes effectively exactly-once for publish.
+
+#### Failure modes
+
+| Scenario | Behavior |
+| --- | --- |
+| JS unreachable | `PublishMsg` returns error; `EmitEvent` propagates to plugin; retry safe via dedup |
+| `PublishAck` timeout | Same as above |
+| Manifest validation fails | Reject pre-publish; audit log; plugin error |
+| Payload exceeds 64 KiB | Reject pre-publish; same cap as today |
+
+No silent fallbacks. With embedded NATS, JS down = process down. With
+clustered NATS, quorum loss means publishes fail until quorum returns.
+
+---
+
+### 4. Subscribe path
+
+#### Interface
+
+```go
+type EventBus interface {
+    Publish(ctx context.Context, event Event) error
+    OpenSession(ctx context.Context, sessionID string, filters []string) (SessionStream, error)
+    QueryHistory(ctx context.Context, q HistoryQuery) (HistoryStream, error)
+}
+
+type SessionStream interface {
+    Next(ctx context.Context) (Event, AckFunc, error)
+    SetFilters(ctx context.Context, filters []string) error
+    Close() error
+}
+
+type AckFunc func() error
+```
+
+`AddStream` / `RemoveStream` / `Notifications` / `Errors` (current
+`core.Subscription`) **MUST** be deleted.
+
+#### `OpenSession` semantics
+
+Creates or rebinds a durable consumer named `session_<sessionID>` on
+stream `EVENTS`:
+
+```text
+ConsumerConfig{
+    Durable:           "session_<sessionID>",
+    FilterSubjects:    filters,
+    AckPolicy:         AckExplicitPolicy,
+    MaxAckPending:     256,
+    InactiveThreshold: 24 * time.Hour,
+    DeliverPolicy:     DeliverNew,    // first creation only
+}
+```
+
+Subsequent rebinds resume from last ack automatically (durable consumer
+property — no host-side cursor tracking).
+
+#### `SetFilters` semantics
+
+```text
+js.UpdateConsumer(EVENTS, ConsumerConfig{
+    Durable:        "session_<sessionID>",
+    FilterSubjects: newFilters,
+    ...
+})
+```
+
+JS preserves cursor across the update. Focus changes are atomic with
+respect to delivery. (`FilterSubjects` plural is supported in NATS server
+≥ 2.10.)
+
+#### gRPC Subscribe handler (new)
+
+```text
+1. ValidateSessionOwnership(ctx, playerID, sessionID, token)         // PR #225
+2. focusPlan := focusCoordinator.RestorePlan(ctx, sessionID)          // existing
+3. filters := focusPlan.Subjects()
+4. stream, err := bus.OpenSession(ctx, sessionID, filters)
+5. defer stream.Close()
+6. for {
+       event, ack, err := stream.Next(ctx)
+       if err != nil { return err }
+       if err := grpcStream.Send(toProto(event)); err != nil { return err }
+       if err := ack(); err != nil { logger.Warn(...) }
+   }
+```
+
+#### Backpressure
+
+`MaxAckPending` per session caps inflight unacked messages. Slow `Send`
+→ ack stalls → JS pauses delivery → no buffer blowup, no dropped events.
+Native flow control. No hand-rolled queue.
+
+#### Session GC
+
+`InactiveThreshold = 24h` deletes idle session consumers (and their
+cursor state) automatically. Explicit cleanup on session quit: an
+internal subscriber to `events.session.*.lifecycle` (PR #233) calls
+`js.DeleteConsumer("session_<id>")` immediately. Best-effort; threshold
+catches the rest.
+
+#### Per-event ack
+
+`AckExplicitPolicy` + ack-after-`Send`. Crash mid-`Send` → no ack →
+redeliver → client dedups via ULID. Successful `Send` → ack → JS advances
+cursor. The Send-vs-Ack race that powered `cursor_lock.go` does not
+exist.
+
+#### What gets deleted
+
+- `internal/grpc/replay.go`
+- `internal/grpc/cursor_lock.go`
+- `core.Subscription` interface and all implementations
+- `core.EventStore.SubscribeSession` and the legacy `Subscribe(stream)`
+- `EventCursors map[string]ulid.ULID` from `session.Info`
+- `event_cursors jsonb` column from `sessions` table
+- All `time.Sleep(1ms)` integration test crutches
+- `EventWriter`
+
+---
+
+### 5. Replay and history
+
+#### Interface
+
+```go
+type HistoryQuery struct {
+    Subject        string         // exact subject OR pattern with * / >
+    After          ulid.ULID      // exclusive lower bound; zero = from start
+    Before         ulid.ULID      // exclusive upper bound; zero = unbounded
+    NotBefore      time.Time      // optional time bound
+    NotAfter       time.Time      // optional time bound
+    Direction      Direction      // Forward (older→newer) or Backward
+    PageSize       int            // host caps at 200; default 50
+    SessionContext SessionContext // for auth
+}
+
+type HistoryStream interface {
+    Next(ctx context.Context) (Event, error)  // io.EOF when exhausted
+    Cursor() ulid.ULID                         // last-emitted ULID for resume
+    Close() error
+}
+```
+
+Server-streaming gRPC. Caller iterates `Next()` until `io.EOF`, calls
+`Cursor()` for next-page resume.
+
+#### JS / PG fallback
+
+```text
+1. Resolve subject ownership:
+   - If subject prefix matches a plugin's audit declaration → delegate to plugin
+   - Else: host serves from PG events_audit + JS for the recent tail
+
+2. Tier selection:
+   safetyMargin := 1h
+   jsRetentionEdge := now() - JS_MaxAge + safetyMargin
+   - if cursor implies start time < jsRetentionEdge: begin in PG
+   - else: begin in JS
+   - if PG path crosses jsRetentionEdge mid-page: continue from JS
+
+3. Stream:
+   - PG: SELECT ... FROM events_audit WHERE subject=$1 AND id > $cursor
+         ORDER BY id [ASC|DESC] LIMIT $pageSize
+   - JS: ephemeral consumer with FilterSubject + DeliverByStartSequence
+
+4. Apply codec.Decode + proto.Unmarshal per event.
+```
+
+The "always read JS for the recent slice" rule means audit projection lag
+is invisible to user-facing reads.
+
+#### Plugin-owned audit routing
+
+Manifest declaration (Section 6). When `bus.QueryHistory(q)` sees
+`q.Subject` matches a plugin-owned prefix, it RPCs the plugin's
+`QueryHistory` handler (`PluginAuditService.QueryHistory`) over the
+existing PluginHostService channel. Plugin:
+
+1. Performs domain authz (e.g., `store.GetSceneLog` membership check)
+2. Reads from its own audit schema
+3. Streams events back to host
+4. Host applies `codec.Decode`, streams to original caller
+
+If plugin RPC fails or times out: surface error to caller. **No silent
+host fallback** — that would leak the privacy boundary.
+
+#### Cursor model
+
+ULID always. Stable across:
+
+- JetStream rebuilds (sequences would change; ULIDs do not)
+- Audit projection rebuilds
+- Plugin schema migrations (PK is ULID)
+
+#### Auth model
+
+One check at entry. Subject → check map:
+
+| Subject pattern | Authz check | Where |
+| --- | --- | --- |
+| `events.location.<id>` | session present at location id OR location is public | host |
+| `events.character.<own-id>` | session belongs to character | host |
+| `events.scene.<id>.>` | character is scene member | scenes plugin |
+| `events.channel.<id>` | character is channel member OR public | channel plugin |
+| `events.notifications.character.<own-id>` | session belongs to character | host |
+
+ABAC is **not per-event** — a subscription authorized to start streams
+freely until filters change.
+
+#### Limits
+
+- `PageSize` capped at 200 host-side
+- gRPC server-streaming with deadline
+- Bounded JS/PG per-batch buffers
+- Plugin RPC timeout (default 5s per page); failure propagated
+
+---
+
+### 6. PostgreSQL's new role
+
+#### Deletions (cutover migration)
+
+```sql
+DROP TABLE events;
+ALTER TABLE sessions DROP COLUMN event_cursors;
+```
+
+The `events_immutable` meta-test (PR #227) **MUST** be repurposed against
+`events_audit`.
+
+#### Additions
+
+```sql
+CREATE TABLE events_audit (
+    id           BYTEA       PRIMARY KEY,        -- ULID (16 bytes)
+    subject      TEXT        NOT NULL,
+    type         TEXT        NOT NULL,
+    timestamp    TIMESTAMPTZ NOT NULL,
+    actor_kind   TEXT        NOT NULL,
+    actor_id     BYTEA,
+    payload      BYTEA       NOT NULL,           -- codec.Encode output
+    schema_ver   SMALLINT    NOT NULL,
+    codec        TEXT        NOT NULL,           -- 'identity' | 'aes-gcm-v1' | ...
+    js_seq       BIGINT      NOT NULL,
+    inserted_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX events_audit_subject_id  ON events_audit (subject, id);
+CREATE INDEX events_audit_subject_ts  ON events_audit (subject, timestamp);
+CREATE INDEX events_audit_subject_pat ON events_audit (subject text_pattern_ops);
+```
+
+The `(subject, id)` index is the workhorse for `QueryHistory` PG fallback.
+
+`codec` is **NOT NULL** — every row stores its codec name explicitly.
+NULL is not "identity"; NULL means a bug. Validation enforced in Go
+(only writer); no PG `CHECK` constraint to avoid migration churn when
+adding codecs.
+
+#### Unchanged
+
+`players`, `characters`, `locations`, `exits`, `objects`, `sessions`
+(minus `event_cursors`), ABAC tables, `command_history`,
+`focus_memberships`, `presenting_focus`, all plugin-owned schemas
+(additive only).
+
+#### Audit projection worker (host)
+
+```text
+Subsystem:        SubsystemAuditProjection
+DependsOn:        [Database, EventBus]
+JS Consumer:      "host_audit_projection"
+Stream:           EVENTS
+FilterSubjects:   ["events.>"] minus plugin-owned subjects
+AckPolicy:        AckExplicit
+MaxAckPending:    64
+DeliverPolicy:    DeliverAll on first creation; auto-resume thereafter
+```
+
+Per delivered message:
+
+```sql
+INSERT INTO events_audit(...)
+VALUES (...)
+ON CONFLICT (id) DO NOTHING;
+```
+
+Idempotent (PK on ULID). At-least-once + idempotent insert =
+effectively exactly-once. PG outage = worker stalls = JS retains backlog
+= projection catches up on recovery. Backpressure flows backward.
+
+#### Plugin-owned audit projection
+
+Per-plugin durable consumer registered at plugin start:
+
+```text
+JS Consumer:      "plugin_audit_<plugin_name>"
+FilterSubjects:   from manifest
+```
+
+For each delivered message, host calls plugin via
+`PluginAuditService.AuditEvent` RPC. Plugin INSERTs into its own schema,
+acks; host forwards ack to JS.
+
+Plugin stops → consumer worker exits but consumer stays durable in JS.
+Plugin restart → resumes from last ack. No orphan state.
+
+**Ciphertext at rest pattern**: plugin receives ciphertext, stores
+ciphertext. Plaintext access for derivations (e.g., pose order) goes
+through `host.codec.Decode` helper — codec stays host-owned.
+
+#### Subject ownership map
+
+At startup, host builds a subject-prefix → owner map from all manifests.
+Conflicts at load = startup error. Validation enforced.
+
+#### Audit retention policy
+
+Default: forever. ~600 MB/year at 200 users × 10 evt/min envelope. Cheap.
+Plugins set their own retention on their audit tables (GDPR, scene TTLs,
+etc.). Plugin's lifecycle, plugin's policy.
+
+#### Operational surface
+
+- Prometheus metric `audit_projection_lag_seconds`. Alert > 5s.
+- Per-plugin lag metrics, same threshold.
+- Reconciliation test in CI: seed 1000 events, drain projection, assert
+  count.
+- Backfill tool (`bin/holomush audit-backfill`): standalone command,
+  ephemeral consumer at seq 1, idempotent re-projection.
+- Drift detector (CI nightly): sample audit rows, fetch JS messages,
+  byte-compare.
+
+---
+
+### 7. Bootstrap and lifecycle
+
+#### `SubsystemEventBus`
+
+```go
+type Subsystem struct { ... }
+func (s *Subsystem) ID() lifecycle.SubsystemID { return lifecycle.SubsystemEventBus }
+func (s *Subsystem) DependsOn() []lifecycle.SubsystemID { return nil }
+```
+
+**Start:**
+
+```go
+opts := &server.Options{
+    ServerName: "holomush-embedded",
+    JetStream:  true,
+    StoreDir:   s.cfg.StoreDir,        // xdg.DataDir() + "/jetstream"
+    DontListen: true,
+    NoSigs:     true,
+    LogtimeUTC: true,
+    HTTPPort:   s.cfg.MonitorPort,     // 0 = disabled
+}
+s.server = server.NewServer(opts)
+go s.server.Start()
+if !s.server.ReadyForConnections(10 * time.Second) { return ... }
+
+s.conn = nats.Connect("",
+    nats.InProcessServer(s.server),
+    nats.Name("holomush-host"),
+)
+s.js = jetstream.New(s.conn)
+
+s.js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+    Name: "EVENTS", Subjects: []string{"events.>"},
+    Retention: LimitsPolicy, Storage: FileStorage,
+    Replicas: 1, MaxAge: cfg.StreamMaxAge, Duplicates: cfg.DupeWindow,
+    AllowDirect: true,
+})
+```
+
+**Stop** (reverse):
+
+```go
+s.conn.Drain()
+s.server.Shutdown()
+s.server.WaitForShutdown()
+```
+
+`NoSigs: true` is mandatory — host owns signal handling. `DontListen:
+true` eliminates port binding. `WaitForShutdown` is required for
+filestore consistency.
+
+#### `SubsystemAuditProjection`
+
+```go
+DependsOn: [Database, EventBus]
+```
+
+Start: register `host_audit_projection` consumer with `FilterSubjects =
+["events.>"] minus plugin-owned prefixes`. Spawn worker via
+`consumer.Consume(handler, jetstream.PullMaxMessages(64))`. Stop: cancel
+context, drain inflight, unbind. Consumer stays durable in JS.
+
+Health: report based on lag — `Warm` < 1s, `Degraded` < 30s, `Stale`
+> 30s.
+
+#### Subsystem dependency graph
+
+```text
+Database  → TLS  → ABAC  → Auth  → World
+                                       ↓
+                                  EventBus  →  AuditProjection
+                                       ↓                ↓
+                                   Plugins  →  Bootstrap  →  GRPC
+```
+
+Stop order is reverse of start. Plugins stop before AuditProjection (no
+new emissions while audit drains). AuditProjection stops before EventBus
+(needs JS to drain). AuditProjection stops before Database (needs PG to
+drain).
+
+#### Per-plugin audit consumers
+
+Plugin subsystem `Start` registers its audit consumer if manifest
+declares one. Plugin `Stop` tears down the worker; consumer stays durable.
+
+#### Storage path
+
+```text
+xdg.DataDir()/jetstream/$G/streams/EVENTS/...
+xdg.DataDir()/jetstream/$G/streams/EVENTS/obs/host_audit_projection/
+xdg.DataDir()/jetstream/$G/streams/EVENTS/obs/plugin_audit_core_scenes/
+xdg.DataDir()/jetstream/$G/streams/EVENTS/obs/session_<sessionID>/
+```
+
+`StoreDir` is lock-exclusive; only one process per directory.
+
+#### Testing helpers
+
+```go
+// internal/eventbus/eventbustest/embedded.go
+func New(t *testing.T) *Embedded { ... }   // MemoryStorage, t.TempDir, t.Cleanup
+```
+
+`MemoryStorage` keeps tests in single-digit milliseconds. `DontListen +
+InProcessServer` means zero port-conflict risk in `t.Parallel()`.
+
+#### Observability
+
+- W3C `traceparent` / `tracestate` headers on every published message;
+  OTEL spans wrap publish + deliver + audit-project + plugin-audit-deliver
+- Prometheus via in-process `prometheus-nats-exporter` for NATS-server
+  internals (stream messages, consumer pending, slow consumers)
+- OTEL metrics via existing meter for application-level event-bus metrics
+  (publish latency, audit lag, codec timing, per-subject rates)
+- Both feed the existing `obsServer.MustRegister` pattern
+
+#### Config surface
+
+```yaml
+event_bus:
+  mode: embedded                    # "embedded" | "cluster"
+  store_dir: ""                     # blank = xdg.DataDir()/jetstream
+  stream_max_age: 720h
+  dupe_window: 5m
+  monitor_port: 0
+  prometheus_exporter: true
+
+  # cluster-mode only (future)
+  cluster_url: ""
+  credentials_file: ""
+  tls:
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
+    server_name: ""
+```
+
+`mode` flip is the seam to multi-node. Day-one only `embedded` is
+implemented.
+
+---
+
+### 8. Testing strategy
+
+#### Layers
+
+| Layer | Bounds | Deps | Speed |
+| --- | --- | --- | --- |
+| Unit | Pure logic | None | < 10ms |
+| Bus integration | EventBus contract | Embedded NATS, MemoryStorage | < 100ms |
+| Audit integration | Host + plugin projections | Embedded NATS + PG testcontainer | < 500ms |
+| E2E | Full server, multi-protocol | Embedded NATS + PG + clients | seconds |
+
+#### Boundary tests
+
+Subjects (length, depth, invalid chars), payload sizes (0, max, max+1),
+filter list sizes (0, 1, 64, overlapping subset), ULID cursors (zero,
+max, non-existent), page sizes (1, 200 cap, 201, 0), `InactiveThreshold`
+limits, time bound inversions, JS↔PG retention boundary edge.
+
+#### Fuzz tests
+
+```text
+FuzzSubjectValidator
+FuzzCodecRoundTrip          (per codec)
+FuzzEventUnmarshal
+FuzzHistoryQueryValidate
+FuzzManifestAuditDecl
+FuzzHeaderParse
+```
+
+CI runs each for 30s as part of `task pr-prep`. Corpus persisted in
+`testdata/fuzz/`.
+
+#### Negative tests
+
+Every error path asserts a *specific* error code, not just "non-nil".
+Categories: invalid subject, oversize payload, missing required header,
+unknown codec, manifest emit not permitted, filter unauthorized, invalid
+cursor, plugin RPC timeout, decryption failure, manifest validation
+failure, store-dir lock contention.
+
+#### Invariant tests (property-based, `pgregory.net/rapid`)
+
+- I-14 cross-subject sequence ordering under concurrent publishers
+- Idempotent publish via `Nats-Msg-Id`
+- Audit row count == JS message count after drain
+- Plugin audit table contains only declared subjects
+
+Plus fixed invariants checked in CI:
+
+- Every audit row's `codec` resolves in registry (drift detector)
+- Every published message has non-empty `App-Codec` (publish-path lint)
+- Subject ownership map has unique prefixes (startup test)
+- Codec-name constants ↔ registry sync (meta-test)
+
+#### Race-class regression tests
+
+| Old race | Regression test |
+| --- | --- |
+| Send→UpdateCursors gap (Finding 1) | Crash subscriber 100× between Next and Ack; assert no event lost / spurious dup |
+| Subscribe-before-Publish race | Open subscription, immediately publish, assert delivered |
+| ULID collision in same ms | Concurrent publishers in tight loop; assert monotonic seq |
+| Reconnect cursor drift | Open/publish/close/publish/reopen; assert receives only new events |
+
+#### Full E2E matrix (`test/integration/eventbus_e2e/`)
+
+| Scenario | Assertion |
+| --- | --- |
+| Cross-tier query (half aged, half recent) | All events in correct order, transparent crossover |
+| Plugin audit isolation | Host audit empty for plugin subjects; plugin schema has them |
+| Reconnect resume | Last-ack continuation, no dup, no loss |
+| Audit drift detector | Tampered row reported with id |
+| Backfill rebuild | `bin/holomush audit-backfill` produces matching counts |
+| Plugin process crash mid-deliver | Restart drains; PK ON CONFLICT prevents dups |
+| Embedded JS storage corruption | Rebuild from PG audit; ULIDs stable |
+| Multi-protocol fan-out | Telnet + web in same scene see same pose |
+
+#### Chaos and soak (CI nightly)
+
+- Inject latency / errors on PG INSERT, NATS publish, plugin RPC
+- 1k events/sec for 5 minutes; assert no goroutine leak (`goleak`),
+  memory growth < 50 MB, audit lag < 1s, full event count
+
+#### Coverage gates
+
+- 80% per package (project rule)
+- 90% for `internal/eventbus/`
+- 95% for `internal/eventbus/codec/`
+- 100% for the codec registry sync meta-test
+
+#### Lint rules
+
+- No `time.Sleep` in `*_test.go` under `internal/eventbus/` and
+  `test/integration/eventbus_e2e/` (custom golangci-lint rule)
+
+#### What gets deleted from the old test suite
+
+All `time.Sleep(1ms)` crutches; pgnotify-specific assertions in
+`postgres_integration_test.go`; `cursor_lock_test.go`; `replay_test.go`;
+old "Variant A Go/No-Go" (replaced); `events_immutable_test.go`
+(rewritten against `events_audit`); `EventCursors` JSONB merge tests;
+pgx.Conn lifecycle tests.
+
+---
+
+### 9. Security
+
+#### Trust boundaries
+
+| Component | Trust |
+| --- | --- |
+| Host process | Trusted; owns keys, signs publishes |
+| Plugin processes | Sandboxed; manifest-validated, schema-isolated, capability-limited |
+| Embedded NATS (in-process) | Inherits host trust; `DontListen` = no network |
+| Clustered NATS (future) | Untrusted transport; mTLS + per-node creds mandatory |
+| PostgreSQL | Storage only; trusted at rest until codec encryption lands |
+| Network clients (telnet/web) | Untrusted; TLS + session token (PR #225) |
+
+#### NATS auth
+
+- **Embedded mode**: no auth surface; `nats.InProcessServer` bypass
+- **Cluster mode** (future): mTLS + per-host NKey/JWT credentials; per-plugin
+  NATS users with subject permissions matching manifest (defense in depth)
+
+#### Codec key management (deferred but designed)
+
+```go
+type KeyProvider interface {
+    Active(ctx context.Context, label KeyLabel) (Key, error)
+    ByID(ctx context.Context, id KeyID) (Key, error)
+}
+
+type Codec interface {
+    Name() Name
+    Encode(ctx context.Context, subject string, plaintext []byte) ([]byte, error)
+    Decode(ctx context.Context, subject string, ciphertext []byte) ([]byte, error)
+}
+```
+
+Codec internal envelope: `[1-byte version][8-byte key_id][12-byte
+nonce][N-byte ciphertext][16-byte auth tag]`. Key ID enables rotation.
+Provider implementations (none ship initially): `LocalFileKeyProvider`,
+`EnvKeyProvider`, `KMSKeyProvider`, `MultiProvider`.
+
+Subject → label routing via config:
+
+```yaml
+encryption:
+  rules:
+    - subject_pattern: "events.scene.>"
+      codec: aes-gcm-v1
+      key_label: scene-content
+    - subject_pattern: "events.character.*"
+      codec: aes-gcm-v1
+      key_label: dm-content
+```
+
+Decryption failure (auth tag invalid OR key not loaded) = hard error,
+security event in audit, never silent.
+
+#### Plugin audit boundary
+
+- Subject ownership routing: host's `events_audit` never contains
+  plugin-owned subjects. Test enforces.
+- Plugin schema `REVOKE ALL ON SCHEMA public` (existing): only the
+  plugin's own PG role can read its audit table.
+- No host fallback for plugin-owned `QueryHistory`: failure = caller
+  error.
+- Plugin RPC carries `SessionContext`; plugin enforces membership.
+
+#### Auth on subscribe and query
+
+ABAC re-evaluated on every filter change, not per event:
+
+- `OpenSession(filters)` — `ValidateSessionOwnership` + ABAC for each filter
+- `SetFilters(filters)` — ABAC for new filter set; failure unbinds
+- `QueryHistory` — entry-time check; route to plugin if owned
+
+#### Security event auditing
+
+Reuses existing `internal/audit` subsystem (PR #203). New event types:
+`auth.subscribe_rejected`, `auth.filter_rejected`,
+`auth.query_history_unauthorized`, `codec.unknown_codec_name`,
+`codec.decryption_failed`, `manifest.subject_ownership_conflict`,
+`emit.subject_not_in_manifest`, `plugin.audit_rpc_timeout`.
+
+#### Network exposure
+
+- Embedded NATS: `DontListen: true` → no socket bound
+- HTTP monitoring port: bound to `127.0.0.1`, opt-in
+- gRPC server: existing TLS via `internal/tls/`
+- Cluster NATS (future): internal network bind, mTLS, no anonymous
+
+#### Threat model
+
+| Threat | Mitigation |
+| --- | --- |
+| Compromised plugin reads other plugins' subjects | Subject ownership routing + per-plugin NATS subperm (cluster) |
+| Compromised plugin publishes to non-owned subjects | Manifest validation + per-plugin NATS pubperm (cluster) |
+| DB admin reads scene IC content | Plugin schema REVOKE + future codec encryption |
+| Network attacker on NATS port | `DontListen` embedded; mTLS cluster |
+| Replay/duplicate publish | `Nats-Msg-Id` dedup |
+| Client manipulating cursor | Server owns durable consumer |
+| Cold-storage / backup leakage | Codec encryption (deferred) + NATS stream encryption (defense in depth) |
+| Lost JS storage | PG audit projection rebuild |
+| Session token theft | Existing PR #225 ValidateSessionOwnership |
+| Decryption failure | Hard error + security event + alert |
+| Codec class deprecated | Old codec stays in registry; rotate-don't-remove |
+| Key compromise | Rotate `Active` for label; old keys retained for read |
+
+---
+
+### 10. Cutover and land plan
+
+Strategy: build infrastructure incrementally on `main` while consumers
+stay on the old path; do the consumer swap atomically on a feature branch.
+
+#### Phase A — Additive prep (each lands as its own PR to main)
+
+| Step | Title | Risk |
+| --- | --- | --- |
+| M1 | `internal/eventbus` skeleton (interfaces, types) | Zero |
+| M2 | Codec interface + `IdentityCodec` + registry + meta-test | Zero |
+| M3 | Migration: add `events_audit` table | Low |
+| M4 | `SubsystemEventBus` registered (no consumers) | Low |
+| M5 | `SubsystemAuditProjection` (drains empty stream) | Low |
+| M6 | `PluginAuditService` proto + bindings | Zero |
+| M7 | OTEL header propagation + Prom NATS exporter wiring | Zero |
+
+Each PR < 500 LOC churn, full `task pr-prep` green, additive only,
+production behavior unchanged.
+
+#### Phase B — Atomic cutover (feature branch `feat/eventbus-cutover`)
+
+| Step | Title | Touches |
+| --- | --- | --- |
+| F1 | `EventSink` rewrites to `bus.Publish` | `internal/plugin/event_emitter.go`, `pkg/plugin/event_sink.go` |
+| F2 | Audit projection actually projects (exclusion list active) | `internal/eventbus/audit/` |
+| F3 | gRPC Subscribe handler rewritten | `internal/grpc/server.go`; deletes `cursor_lock.go`, `replay.go` |
+| F4 | gRPC `QueryHistory` handler rewritten with hot/cold tier | `internal/grpc/query_history.go` |
+| F5 | Per-plugin updates (subject names, manifest decls, type constants moved) | `plugins/core-scenes/`, others |
+| F6 | Schema cutover: DROP `events`, DROP `event_cursors` | `internal/store/migrations/` |
+| F7 | Old code deletion (`EventWriter`, pgnotify, legacy Subscribe) | wide |
+| F8 | Test rewrite (delete obsolete; port "Variant A"; add E2E suite) | `internal/store/postgres_integration_test.go`, `test/integration/eventbus_e2e/` |
+| F9 | Docs (`CLAUDE.md`, `site/docs/`, mark prior specs superseded) | docs |
+
+Branch CI green on every push; rebase on main weekly. Single squash
+merge to main = production cutover.
+
+#### Acceptance gates
+
+- Phase A: per-PR `task pr-prep` green; coverage gate met; no regression
+- Phase B (pre-merge): all M phases in main; full `task pr-prep` green on
+  branch state; all E2E tests pass; coverage gates met; performance
+  smoke (1k events/sec, < 100ms p99 publish→deliver); manual reviewer
+  E2E walkthrough; in-flight PRs rebased
+
+#### In-flight coordination
+
+| In-flight | Strategy |
+| --- | --- |
+| PR #233 (session-lifecycle-events) | Land first; depended on for consumer GC |
+| PR #234 (LeaveFocusByTarget) | Parallel; small, low conflict |
+| Channel plugin (`holomush-0sc.12`, paused) | Stays paused; resumes after cutover with new subjects baked in |
+| Scene Phase 4 (`holomush-5rh.13`) | Currently blocked; this design unblocks; new beads file post-cutover |
+| Files F3 / F6 / F7 deletes | ~2-week freeze window; coordinate or stage |
+
+#### Rollback
+
+- M phases: revert commit; production unaffected
+- F branch pre-merge: discard branch
+- F branch post-merge: revert merge commit; rerun prior down migration;
+  acceptable pre-launch
+- Pre-merge precaution: PG dump the night before
+
+#### Estimated calendar
+
+```text
+Week 1:    M1, M2, M3 → main
+Week 2:    M4, M5, M6, M7 → main
+Week 3:    F1, F2, F3 (core swap on branch)
+Week 4:    F4, F5.1, F6, F7
+Week 5:    F8 test sweep, F9 docs, soak, manual E2E
+Week 5 EOW: merge to main
+Week 6:    Stabilization, follow-up beads, scene Phase 4 unblock
+```
+
+Realistic envelope: 5–7 weeks.
+
+#### Post-merge follow-ups (filed at merge time)
+
+- Scene Phase 4 implementation
+- Channel plugin resumption
+- holomush-umxj telnet race fix verified under new bus
+- Real codec implementation (separate workstream)
+- Multi-node cluster cutover (when scale demands)
+
+---
+
+## Open questions
+
+1. **NATS server version pinning** — NATS 2.12.5 had a regression on
+   stream updates ([nats-server release notes
+   2.12.5](https://github.com/nats-io/nats-server/releases/tag/v2.12.5));
+   pick a known-good minor and pin. Need an explicit decision before M4.
+
+2. **Codec key provider for the first encryption rollout** — what's the
+   preferred KMS / key store for production? Affects which provider
+   lands first when encryption work begins. Out of scope for this design;
+   filed as follow-up.
+
+3. **Event proto schema location** — `api/proto/holomush/eventbus/v1/`
+   alongside other plugin protos? Decide before M1.
+
+4. **Whether `Event.Type` should be a typed string (Go) for compile-time
+   help even though it's plugin-declared** — tradeoff: typed strings give
+   compile-time per-plugin enforcement but require each plugin to
+   declare its own type. Probably yes (per Section 1b's "constants in
+   plugin's own package").
+
+5. **Plugin-side `EventSink` API exact shape** — `Subject` field name vs
+   keeping `Stream` for backward compatibility? Clean break says rename,
+   but check with plugin authors.
+
+6. **Test for "Phase A is truly idle"** — how do we prove the embedded
+   NATS subsystem started in M4 isn't accidentally consuming or affecting
+   anything in production until F1?
+
+---
+
+## Glossary
+
+- **Event**: an immutable, durable record of something that happened.
+- **Subject**: a hierarchical, dot-delimited routing key in JetStream.
+  Plugin-namespaced (e.g., `events.scene.<ULID>.ic`).
+- **Stream** (NATS): a JetStream stream is a persistent log of messages
+  on a subject pattern. We use exactly one (`EVENTS`).
+- **Stream** (legacy): the old `core.Event.Stream` field, free-form string
+  like `location:<ULID>`. Deleted in this design.
+- **Subscription** (legacy): the old `core.Subscription` interface.
+  Deleted; replaced by `SessionStream`.
+- **Consumer** (NATS JetStream): server-side delivery state for a
+  subscriber, with cursor and acknowledgment tracking.
+- **Durable consumer**: a consumer whose state survives across client
+  reconnects.
+- **Ephemeral consumer**: a consumer that dies when the client
+  disconnects; used for `QueryHistory`.
+- **Codec**: a host-owned encode/decode pair applied to event payload
+  bytes. Identity by default; pluggable for encryption later.
+- **Audit projection**: a worker that consumes from JetStream and writes
+  to a PostgreSQL table for forever-archive and queryability.
+- **Plugin-owned audit**: audit projection where the plugin owns the
+  destination schema and the read path (privacy boundary).
+- **Subject ownership map**: startup-built mapping of subject prefixes
+  to either "host" or a specific plugin. Conflicts at load = error.
+
+## References
+
+- [2026-03-20-event-delivery-redesign.md](2026-03-20-event-delivery-redesign.md)
+  — superseded by this design
+- [2026-04-05-plugin-architecture-rework-design.md](2026-04-05-plugin-architecture-rework-design.md)
+  — proto-first plugin contracts; this design extends with `PluginAuditService`
+- [2026-04-06-scenes-and-rp-design-v2.md](2026-04-06-scenes-and-rp-design-v2.md)
+  — §11 plugin→host event emission contract resolved by this design (option A)
+- [2026-04-08-plugin-session-stream-contribution-design.md](2026-04-08-plugin-session-stream-contribution-design.md)
+  — `StreamContributor.QuerySessionStreams` integrates with `SetFilters`
+- [2026-04-15-query-stream-history-rpc-design.md](2026-04-15-query-stream-history-rpc-design.md)
+  — `QueryStreamHistory` reshaped as `bus.QueryHistory` with hot/cold tier
+- [docs/plans/2026-04-07-cursor-lock-finding-1-closure.md](../../plans/2026-04-07-cursor-lock-finding-1-closure.md)
+  — cursor race class eliminated by JS durable consumer
+- PR #207 — `EventSink` unified emission (kept; underlying transport changes)
+- PR #216 — host focus RPCs (kept; integrates via `SetFilters`)
+- PR #225 — `ValidateSessionOwnership` choke-point (kept; called in `OpenSession`)
+- PR #232 — `QueryStreamHistory` (semantically preserved as `bus.QueryHistory`)
+- PR #233 — session-lifecycle events (depended on for consumer GC)
+- [NATS multi-subject filters (server 2.10)](https://github.com/nats-io/nats.docs/blob/master/release_notes/whats_new_210.md)
+- [NATS embedded server pattern](https://github.com/nats-io/nats-server)
+- [nats-server #6993 — MaxBytes memory reservation](https://github.com/nats-io/nats-server/issues/6993)
+- [nats-server #7779 — FilterSubjects subset overlap](https://github.com/nats-io/nats-server/issues/7779)


### PR DESCRIPTION
## Summary

Design spec for replacing the PostgreSQL `events` table + `LISTEN/NOTIFY`
delivery transport with embedded NATS JetStream as the event log and PG as
projection / forever-archive audit. Clean cutover, no data migration
(pre-launch). Single-node now with a clean seam to clustered NATS later.

**Status:** DRAFT design proposal. No implementation in this PR — sole
artifact is `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md`.

## What this design eliminates

- **Cursor / Send-vs-Ack race class** — JS owns consumer state via durable
  consumers + explicit ack. `cursor_lock.go` and Finding 1 (PR #201) become
  irrelevant by construction.
- **`EventWriter` global serialization** — JS assigns monotonic seq per stream
  server-side. Removes the bottleneck and the `time.Sleep(1ms)` test crutches
  that exist only to dodge ULID-collision-in-same-ms.
- **`pg_notify` lossiness** — durable consumers persist cursor server-side and
  resume from last ack on reconnect.
- **Plugin boundary violation** — 19 `EventType` constants currently in
  `internal/core/event.go:39-70` move to plugins where they belong (subjects
  are the routing primitive; types are opaque to host).

## What this design unblocks

- **Scenes Phase 4** (`holomush-5rh.13`) — currently blocked on event-store
  clarity. Subjects + plugin-owned audit projections answer the v2 spec §11
  open question (chose option A: host provides emit facility).
- **Channel plugin** (`holomush-0sc.12`, paused) — subject names + audit
  declarations baked in from day one when the channel work resumes.

## Architecture in one paragraph

Embedded NATS server in-process per HoloMUSH instance with a single
`EVENTS` stream over hierarchical subjects (`events.<domain>.<entity>[.<facet>]`).
Durable pull consumer per session for live delivery; ephemeral consumers for
history queries; per-plugin durable consumers for plugin-owned audit
projections. PostgreSQL `events_audit` table is populated by a host audit
projection worker; plugin-owned subjects flow to plugin-owned schemas. The
old `events` table and `event_cursors` column are dropped at cutover.
Multi-node migration path is `mode: embedded → cluster` config flip + mirror
stream cutover (planned, not free).

## Sections in the spec

1. Event model (ULID identity, JS seq ordering, plugin-declared types, hierarchical subjects, proto + version header)
2. Stream topology (single `EVENTS`, `LimitsPolicy`, MaxAge=720h, plugin-owned audit boundary)
3. Publish path (EventSink unchanged for plugins, host validates + stamps + js.PublishMsg, idempotent via `Nats-Msg-Id`)
4. Subscribe path (new `EventBus` + `SessionStream` interface, durable pull consumer, `MaxAckPending` backpressure)
5. Replay / history (`QueryHistory` with hot/cold tier crossover, plugin-owned routing for sensitive subjects)
6. PostgreSQL's new role (drop `events` + `event_cursors`; add `events_audit` with NOT NULL `codec` column; idempotent ON CONFLICT projection)
7. Bootstrap (`SubsystemEventBus` + `SubsystemAuditProjection`, embedded NATS lifecycle, dep order, in-process tests)
8. Testing (boundary, fuzz, negative, invariant, full E2E NATS+PG; deterministic ack-state assertions; no `time.Sleep`)
9. Security (trust boundaries, NATS auth seam, `Codec` interface with `KeyProvider` for future encryption, plugin audit hard privacy boundary)
10. Cutover plan (Phase A additive prep direct to main M1–M7, Phase B atomic cutover branch F1–F9; 5–7 week envelope)

## Open questions (in spec, deliberately unresolved)

- NATS server version pinning (2.12.5 had a regression; pick a known-good minor)
- Codec key provider for the first encryption rollout (separate workstream)
- Event proto schema location (`api/proto/holomush/eventbus/v1/`?)
- Whether `Event.Type` should be a typed string per plugin
- Plugin-side `EventSink` API exact shape (`Subject` rename)
- How to assert "Phase A is truly idle" (M1–M7 production neutrality)

## Review focus areas

- **§5 Replay / history**: the JS-vs-PG fallback and plugin-owned audit
  routing are load-bearing and the most novel — please push back if either
  feels wrong.
- **§9 Security**: codec key management is deferred but the seam is
  designed today. If the seam misses anything (e.g., key rotation under
  concurrent reads), better to know now than during implementation.
- **§10 Cutover**: Phase A vs Phase B split, in-flight coordination plan,
  and the freeze window for `internal/grpc/replay.go` / `cursor_lock.go`
  / `internal/store/postgres.go` deletes.

## Related work

- Supersedes [docs/superpowers/specs/2026-03-20-event-delivery-redesign.md](docs/superpowers/specs/2026-03-20-event-delivery-redesign.md)
- Depends on PR #233 (session-lifecycle-events) for consumer GC
- Resolves scenes v2 §11 plugin→host event-emission open question
- Builds on PR #207 (EventSink), #216 (focus host RPCs), #225 (session identity), #232 (QueryStreamHistory)

## Test plan

- [ ] Spec reviewed by Sean
- [ ] Open questions triaged — answered or deferred to follow-up beads
- [ ] On approval: invoke `writing-plans` skill to draft per-phase implementation plans (M1-M7 + F1-F9)
- [ ] File epic bead `holomush-XXXX` and child beads per phase
- [ ] Begin Phase A (M1) implementation in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive implementation and design specifications for internal infrastructure planning phases covering event bus foundation and production migration strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->