### PR TITLE
fix(telnet+grpc): close race + leave-event flake in telnet E2E (holomush-umxj)

### DIFF
--- a/internal/grpc/drain_test.go
+++ b/internal/grpc/drain_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// Tests for drainNotificationsUntilQuiet (Destroyed-branch drain in Subscribe).
+// The drain exists so events emitted just before sessionStore.Delete reach the
+// client ahead of STREAM_CLOSED, closing the async-NOTIFY-delivery sub-problem
+// of holomush-umxj Mode B. See server.go drainNotificationsUntilQuiet doc.
+
+func TestDrainNotificationsUntilQuietReturnsImmediatelyWhenNoNotificationsPending(t *testing.T) {
+	sub := newMockSubscription()
+	store := &mockEventStore{}
+	server := &CoreServer{
+		eventStore:  store,
+		cursorLocks: newCursorLockMap(),
+	}
+	info := &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}
+	stream := &mockSubscribeStream{}
+
+	start := time.Now()
+	server.drainNotificationsUntilQuiet(context.Background(), info, sub, stream, nil,
+		50*time.Millisecond, 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond,
+		"drain should wait at least the quiet window for late notifications")
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"drain should not exceed the hard cap when no notifications arrive")
+	assert.Empty(t, stream.events, "no notifications means no sends")
+}
+
+func TestDrainNotificationsUntilQuietDeliversPendingEventsBeforeReturning(t *testing.T) {
+	streamName := "character:abc"
+	eventID := ulid.Make()
+	sub := newMockSubscription()
+	store := &mockEventStore{
+		replayFunc: func(_ context.Context, s string, _ ulid.ULID, _ int) ([]core.Event, error) {
+			if s == streamName {
+				return []core.Event{{ID: eventID, Stream: streamName, Type: core.EventTypeCommandResponse, Payload: []byte(`{}`)}}, nil
+			}
+			return nil, nil
+		},
+	}
+	sessStore := session.NewMemStore()
+	require.NoError(t, sessStore.Set(context.Background(), "s", &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}))
+	server := &CoreServer{
+		eventStore:   store,
+		sessionStore: sessStore,
+		cursorLocks:  newCursorLockMap(),
+	}
+	info := &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}
+	stream := &mockSubscribeStream{}
+
+	sub.notifCh <- core.StreamNotification{Stream: streamName, EventID: eventID}
+
+	server.drainNotificationsUntilQuiet(context.Background(), info, sub, stream, nil,
+		50*time.Millisecond, 500*time.Millisecond)
+
+	require.Len(t, stream.events, 1, "expected the pending event to be delivered")
+	ef, ok := stream.events[0].GetFrame().(*corev1.SubscribeResponse_Event)
+	require.True(t, ok, "expected SubscribeResponse_Event frame")
+	assert.Equal(t, eventID.String(), ef.Event.GetId())
+	assert.Equal(t, eventID, info.EventCursors[streamName],
+		"cursor should be advanced to the last delivered event")
+}
+
+func TestDrainNotificationsUntilQuietReturnsOnCtxCancel(t *testing.T) {
+	sub := newMockSubscription()
+	store := &mockEventStore{}
+	server := &CoreServer{eventStore: store, cursorLocks: newCursorLockMap()}
+	info := &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}
+	stream := &mockSubscribeStream{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	server.drainNotificationsUntilQuiet(ctx, info, sub, stream, nil,
+		10*time.Second, 10*time.Second)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 100*time.Millisecond, "drain should return immediately on ctx.Done")
+}
+
+func TestDrainNotificationsUntilQuietReturnsOnSubscriptionError(t *testing.T) {
+	sub := newMockSubscription()
+	store := &mockEventStore{}
+	server := &CoreServer{eventStore: store, cursorLocks: newCursorLockMap()}
+	info := &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}
+	stream := &mockSubscribeStream{}
+
+	sub.errCh <- assertAnErrorValue
+
+	start := time.Now()
+	server.drainNotificationsUntilQuiet(context.Background(), info, sub, stream, nil,
+		10*time.Second, 10*time.Second)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 100*time.Millisecond, "drain should return immediately when sub.Errors() fires")
+	assert.Empty(t, stream.events)
+}
+
+// assertAnErrorValue is any non-nil error used to fire the sub.Errors() path.
+var assertAnErrorValue = &subscriptionErrorForTests{}
+
+type subscriptionErrorForTests struct{}
+
+func (*subscriptionErrorForTests) Error() string { return "test subscription error" }
+
+func TestDrainNotificationsUntilQuietStopsAtHardCapUnderSustainedNotifications(t *testing.T) {
+	streamName := "character:abc"
+	sub := newMockSubscription()
+	store := &mockEventStore{
+		replayFunc: func(_ context.Context, _ string, _ ulid.ULID, _ int) ([]core.Event, error) {
+			return nil, nil // no events to deliver; just exercise the drain loop
+		},
+	}
+	server := &CoreServer{eventStore: store, cursorLocks: newCursorLockMap()}
+	info := &session.Info{ID: "s", EventCursors: map[string]ulid.ULID{}}
+	stream := &mockSubscribeStream{}
+
+	// Keep feeding notifications until the drain exits, then stop.
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				select {
+				case sub.notifCh <- core.StreamNotification{Stream: streamName, EventID: ulid.Make()}:
+				default:
+				}
+			}
+		}
+	}()
+
+	quiet := 100 * time.Millisecond
+	hardCap := 300 * time.Millisecond
+
+	start := time.Now()
+	server.drainNotificationsUntilQuiet(ctx, info, sub, stream, nil, quiet, hardCap)
+	elapsed := time.Since(start)
+	cancel()
+	<-done
+
+	assert.GreaterOrEqual(t, elapsed, hardCap-50*time.Millisecond,
+		"drain should run for close to hardCap under sustained traffic")
+	assert.Less(t, elapsed, hardCap+200*time.Millisecond,
+		"drain must exit within hardCap plus scheduling slack, not be held indefinitely by resetting quiet timer")
+}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -78,6 +78,30 @@ const defaultMaxReplay = 1000
 // behavior, never worse.
 const cursorCommitTimeout = 1 * time.Second
 
+// destroyedDrainQuiet is the maximum idle time the live loop waits for
+// additional PG LISTEN/NOTIFY deliveries after Destroyed arrives, before
+// sending STREAM_CLOSED. It must exceed typical NOTIFY propagation (~1ms)
+// by a comfortable margin so events appended just before sessionStore.Delete
+// (e.g. the quit handler's command_response "Goodbye!") are not dropped.
+// 200ms is two orders of magnitude above observed NOTIFY latency and well
+// under both downstream read windows: the telnet gateway's
+// GatewayHandler.drainUntilClosed drainTimeout
+// (internal/telnet/gateway_handler.go) and the test harness's
+// testTelnetClient.ReadUntil 5s default
+// (test/integration/telnet/e2e_test.go).
+const destroyedDrainQuiet = 200 * time.Millisecond
+
+// destroyedDrainHardCap bounds the total time the live loop will spend in
+// the post-Destroyed drain, regardless of ongoing notification arrivals.
+// Without a hard cap, a busy location stream (many chatty characters) can
+// keep resetting destroyedDrainQuiet indefinitely and delay STREAM_CLOSED
+// past both the gateway's drainUntilClosed timer and the test harness's 5s
+// ReadUntil. 1s leaves comfortable headroom under the 5s ReadUntil while
+// staying well below the gateway's drainTimeout, so the client normally
+// receives the server's STREAM_CLOSED before the gateway falls back to
+// its own "Goodbye!" delivery path.
+const destroyedDrainHardCap = 1 * time.Second
+
 // replayCompleteFrame returns a SubscribeResponse containing the
 // REPLAY_COMPLETE control signal.
 func replayCompleteFrame() *corev1.SubscribeResponse {
@@ -656,6 +680,75 @@ func (s *CoreServer) sendAndCommitEvent(
 	return nil
 }
 
+// drainNotificationsUntilQuiet consumes pending sub.Notifications and
+// forwards their events to the client, returning when one of: no new
+// notification arrives within `quiet`, the aggregate drain time reaches
+// `hardCap`, ctx is cancelled, or sub.Errors() fires. Send errors are
+// logged at Warn (not propagated) because the caller is already about to
+// close the stream with STREAM_CLOSED and the stream may already be
+// half-torn-down; we want a visible signal if this ever hides a real bug.
+//
+// The two deadlines address different failure modes:
+//   - `quiet` covers async NOTIFY delivery lag — the quit handler's
+//     command_response event is Appended synchronously before
+//     sessionStore.Delete, but the PG LISTEN/NOTIFY round-trip to the
+//     pgSubscription goroutine runs in the millisecond range. Without a
+//     small wait here, the drain would often see an empty channel at the
+//     exact moment Destroyed arrives.
+//   - `hardCap` prevents busy location streams (many chatty characters)
+//     from resetting the quiet timer indefinitely and delaying
+//     STREAM_CLOSED past downstream windows.
+//
+// Used from the Destroyed branch of the Subscribe live loop to close
+// holomush-umxj Mode B's NOTIFY-delivery-lag sub-problem. The complementary
+// registration-window sub-problem is closed by the atomic check-and-register
+// inside MemStore / PostgresSessionStore.WatchSession.
+func (s *CoreServer) drainNotificationsUntilQuiet(
+	ctx context.Context,
+	info *session.Info,
+	sub core.Subscription,
+	stream grpc.ServerStreamingServer[corev1.SubscribeResponse],
+	lf *locationFollower,
+	quiet time.Duration,
+	hardCap time.Duration,
+) {
+	quietTimer := time.NewTimer(quiet)
+	defer quietTimer.Stop()
+	hardTimer := time.NewTimer(hardCap)
+	defer hardTimer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-hardTimer.C:
+			return
+		case <-sub.Errors():
+			return
+		case notif := <-sub.Notifications():
+			cursor := ulid.ULID{}
+			if c, ok := info.EventCursors[notif.Stream]; ok {
+				cursor = c
+			}
+			last, sendErr := s.replayAndSend(ctx, info, notif.Stream, cursor, stream, lf)
+			if sendErr != nil {
+				slog.WarnContext(ctx, "drain: send failed",
+					"session_id", info.ID, "stream", notif.Stream, "error", sendErr)
+				return
+			}
+			info.EventCursors[notif.Stream] = last
+			if !quietTimer.Stop() {
+				select {
+				case <-quietTimer.C:
+				default:
+				}
+			}
+			quietTimer.Reset(quiet)
+		case <-quietTimer.C:
+			return
+		}
+	}
+}
+
 // Subscribe opens a stream of events for the session.
 //
 // SECURITY (bd-jv7z): Before opening the stream, the caller's
@@ -700,7 +793,7 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		return oops.Code("SESSION_NOT_FOUND").With("session_id", req.SessionId).Errorf("session not found")
 	}
 
-	// 1. Session lookup under cursor lock (Finding 1 closure).
+	// 1. Session lookup under the cursor lock (Finding 1 closure).
 	info, err := func() (*session.Info, error) {
 		unlock := s.cursorLocks.lock(req.SessionId)
 		defer unlock()
@@ -708,6 +801,33 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	}()
 	if err != nil {
 		return oops.Code("SESSION_NOT_FOUND").With("session_id", req.SessionId).Errorf("session not found")
+	}
+
+	// Register the lifecycle watcher immediately, before replay, so any
+	// Delete fired during the rest of Subscribe setup (AddConnection,
+	// ReattachCAS, RestoreFocus, SubscribeSession, replay) is captured.
+	//
+	// Atomicity note: Get above and WatchSession below do NOT run under a
+	// shared mu — the cursor lock is released before WatchSession is
+	// called. Closure of the Get↔WatchSession window is instead provided
+	// by the store itself: MemStore / PostgresSessionStore.WatchSession
+	// takes its own internal mu, checks session existence, and if the
+	// session has already been deleted by the time mu is acquired it
+	// returns a channel pre-loaded with Destroyed and closed. This makes
+	// the live loop handle the late-delete case as if the notification
+	// had arrived normally. See holomush-umxj Mode B.
+	sessionCh, watchErr := s.sessionStore.WatchSession(ctx, req.SessionId)
+	if watchErr != nil {
+		slog.Warn("failed to watch session lifecycle",
+			"session_id", req.SessionId, "error", watchErr)
+	}
+	// Guard: the Store interface permits (nil, err). A receive on a nil
+	// channel blocks forever, which would leave the live loop observing
+	// no lifecycle events and hanging until ctx cancel. Substitute a
+	// never-firing channel so the select still terminates on ctx.Done()
+	// and sub.Errors() as expected.
+	if sessionCh == nil {
+		sessionCh = make(chan session.Event)
 	}
 
 	// Register the caller's connection in core (bd-j2xj). Connection
@@ -872,14 +992,9 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		return oops.With("session_id", req.SessionId).Wrap(err)
 	}
 
-	// 10. WatchSession for lifecycle events.
-	sessionCh, watchErr := s.sessionStore.WatchSession(ctx, req.SessionId)
-	if watchErr != nil {
-		slog.Warn("failed to watch session lifecycle",
-			"session_id", req.SessionId, "error", watchErr)
-	}
-
-	// 11. Live loop — single select on Subscription notifications + control + session.
+	// 10. Live loop — single select on Subscription notifications + control + session.
+	// sessionCh was registered earlier (step 1) so any Delete during setup
+	// is captured. See the note there for the rationale.
 	for {
 		select {
 		case <-ctx.Done():
@@ -904,9 +1019,25 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 
 		case ev, ok := <-sessionCh:
 			if !ok {
+				// Defensive fallback: current MemStore and
+				// PostgresSessionStore both always buffer a Destroyed
+				// event into the channel before closing it, so the normal
+				// path takes the ev.Type == Destroyed branch below. A
+				// bare channel close without Destroyed would indicate
+				// either a future Store implementation that skips the
+				// buffered event or a programmer error; in either case,
+				// close the stream with an empty message rather than
+				// hang.
+				//nolint:errcheck // best-effort: client may already be disconnected
+				_ = stream.Send(streamClosedFrame(""))
 				return nil
 			}
 			if ev.Type == session.Destroyed {
+				// Drain pending stream notifications (see
+				// drainNotificationsUntilQuiet) so events emitted just
+				// before Delete reach the client ahead of STREAM_CLOSED.
+				s.drainNotificationsUntilQuiet(ctx, info, sub, stream, lf,
+					destroyedDrainQuiet, destroyedDrainHardCap)
 				//nolint:errcheck // best-effort: client may already be disconnected
 				_ = stream.Send(streamClosedFrame(ev.Message))
 				return nil

--- a/internal/session/memstore.go
+++ b/internal/session/memstore.go
@@ -82,10 +82,20 @@ func (m *MemStore) Delete(_ context.Context, id, reason string) error {
 
 // WatchSession returns a channel that receives an Event when
 // the session is destroyed.
+//
+// If the session does not exist at call time (already deleted or never
+// existed), the returned channel is pre-loaded with a Destroyed event and
+// closed. This closes the holomush-umxj Mode B race where a Delete between
+// Get and WatchSession would otherwise register a watcher that never fires.
 func (m *MemStore) WatchSession(_ context.Context, sessionID string) (<-chan Event, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ch := make(chan Event, 1)
+	if _, ok := m.sessions[sessionID]; !ok {
+		ch <- Event{Type: Destroyed}
+		close(ch)
+		return ch, nil
+	}
 	m.watchers[sessionID] = append(m.watchers[sessionID], ch)
 	return ch, nil
 }

--- a/internal/session/memstore_test.go
+++ b/internal/session/memstore_test.go
@@ -268,6 +268,43 @@ func TestMemStore_WatchSession_ChannelClosedOnDelete(t *testing.T) {
 	assert.False(t, ok, "channel should be closed")
 }
 
+func TestMemStoreWatchSessionReturnsPreClosedDestroyedChannelWhenSessionAlreadyDeleted(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	require.NoError(t, store.Set(ctx, "sess-1", &Info{ID: "sess-1"}))
+	require.NoError(t, store.Delete(ctx, "sess-1", "Goodbye!"))
+
+	// Caller registers a watcher AFTER Delete has already removed the
+	// session. The pre-fix behavior was to register a dormant watcher
+	// that would never fire; the fix signals Destroyed immediately so
+	// the live loop can close cleanly.
+	ch, err := store.WatchSession(ctx, "sess-1")
+	require.NoError(t, err)
+
+	ev, ok := <-ch
+	require.True(t, ok, "expected pre-loaded Destroyed event")
+	assert.Equal(t, Destroyed, ev.Type, "expected Destroyed type")
+
+	// Channel must be closed to signal no further events are coming.
+	_, ok = <-ch
+	assert.False(t, ok, "expected channel closed after Destroyed")
+}
+
+func TestMemStoreWatchSessionReturnsPreClosedDestroyedChannelWhenSessionNeverExisted(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+
+	ch, err := store.WatchSession(ctx, "never-existed")
+	require.NoError(t, err)
+
+	ev, ok := <-ch
+	require.True(t, ok, "expected pre-loaded Destroyed event")
+	assert.Equal(t, Destroyed, ev.Type)
+
+	_, ok = <-ch
+	assert.False(t, ok, "expected channel closed")
+}
+
 func TestMemStore_ConcurrentAccess(_ *testing.T) {
 	store := NewMemStore()
 	ctx := context.Background()

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -314,8 +315,24 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 }
 
 // Delete removes a session and notifies any active WatchSession watchers.
+//
+// Ordering: the DB row is deleted BEFORE watchers are notified. This order
+// is load-bearing for the Mode B fix (holomush-umxj): WatchSession decides
+// "session alive or gone" by querying the DB, then registers (or signals
+// Destroyed) under s.mu. If notify ran before the DB delete, a concurrent
+// WatchSession could observe exists=true (DB still has the row), register
+// a watcher, and then sit dormant forever because Delete had already
+// cleared the watchers map. By committing the DB delete first and gating
+// notify behind s.mu, any WatchSession that queries after DB commit sees
+// exists=false and any WatchSession that queries before DB commit will
+// serialize with notify under s.mu — either way, no watcher is orphaned.
 func (s *PostgresSessionStore) Delete(ctx context.Context, id, reason string) error {
+	if _, err := s.pool.Exec(ctx, `DELETE FROM sessions WHERE id = $1`, id); err != nil {
+		return oops.With("operation", "delete session").With("session_id", id).Wrap(err)
+	}
+
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, ch := range s.watchers[id] {
 		select {
 		case ch <- session.Event{Type: session.Destroyed, Message: reason}:
@@ -324,21 +341,54 @@ func (s *PostgresSessionStore) Delete(ctx context.Context, id, reason string) er
 		close(ch)
 	}
 	delete(s.watchers, id)
-	s.mu.Unlock()
-
-	_, err := s.pool.Exec(ctx, `DELETE FROM sessions WHERE id = $1`, id)
-	if err != nil {
-		return oops.With("operation", "delete session").With("session_id", id).Wrap(err)
-	}
 	return nil
 }
 
-// WatchSession returns a channel that receives an Event when
-// the session is destroyed.
-func (s *PostgresSessionStore) WatchSession(_ context.Context, sessionID string) (<-chan session.Event, error) {
+// WatchSession returns a channel that receives an Event when the session
+// is destroyed.
+//
+// If the session does not exist at call time (already deleted or never
+// existed), the returned channel is pre-loaded with a Destroyed event
+// (empty Message) and closed. This closes holomush-umxj Mode B, where a
+// Delete between Get and WatchSession would otherwise register a watcher
+// that never fires.
+//
+// Atomicity: the existence check runs while holding s.mu so that Delete's
+// notify phase cannot slip in between "DB says exists=true" and "watcher
+// registered in the map." Delete's DB row removal runs outside s.mu, so
+// concurrent WatchSession calls only contend on s.mu with Delete's local
+// notify phase (fast), not Delete's DB round-trip. The DB query itself
+// runs under s.mu — acceptable because in practice it's an index-lookup
+// under a millisecond and the alternative (cross-phase check-and-register)
+// requires significantly more state tracking.
+//
+// Fallback: if the existence query errors (transient DB flap), the
+// watcher is registered unconditionally. A concurrent Delete that does
+// notify will still deliver to it; a Delete that already fired is a
+// visible gap, but no worse than the pre-fix behavior. The caller's
+// lifecycle ctx eventually cleans up dormant watchers. Callers that
+// require the stronger atomicity guarantee in the face of DB errors
+// should prefer explicit Get+WatchSession ordering with transaction
+// semantics — out of scope here.
+func (s *PostgresSessionStore) WatchSession(ctx context.Context, sessionID string) (<-chan session.Event, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	ch := make(chan session.Event, 1)
+
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = $1)`, sessionID).Scan(&exists)
+	if err != nil {
+		slog.Warn("watch session: existence check failed",
+			"session_id", sessionID, "error", err)
+		s.watchers[sessionID] = append(s.watchers[sessionID], ch)
+		return ch, nil
+	}
+	if !exists {
+		ch <- session.Event{Type: session.Destroyed}
+		close(ch)
+		return ch, nil
+	}
 	s.watchers[sessionID] = append(s.watchers[sessionID], ch)
 	return ch, nil
 }

--- a/internal/store/session_store_integration_test.go
+++ b/internal/store/session_store_integration_test.go
@@ -761,4 +761,58 @@ var _ = Describe("PostgresSessionStore", func() {
 			Expect(results).To(BeEmpty())
 		})
 	})
+
+	Describe("WatchSession missing-session contract", func() {
+		It("returns a pre-closed Destroyed channel when the session has already been deleted", func() {
+			ctx := context.Background()
+			info := newTestSession("sess-watch-already-deleted")
+
+			Expect(sessionStore.Set(ctx, info.ID, info)).To(Succeed())
+			Expect(sessionStore.Delete(ctx, info.ID, "Goodbye!")).To(Succeed())
+
+			ch, err := sessionStore.WatchSession(ctx, info.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			ev, ok := <-ch
+			Expect(ok).To(BeTrue(), "expected pre-loaded Destroyed event on watcher channel")
+			Expect(ev.Type).To(Equal(session.Destroyed))
+
+			_, ok = <-ch
+			Expect(ok).To(BeFalse(), "expected channel closed after Destroyed")
+		})
+
+		It("returns a pre-closed Destroyed channel when the session never existed", func() {
+			ctx := context.Background()
+
+			ch, err := sessionStore.WatchSession(ctx, "sess-watch-never-existed")
+			Expect(err).NotTo(HaveOccurred())
+
+			ev, ok := <-ch
+			Expect(ok).To(BeTrue())
+			Expect(ev.Type).To(Equal(session.Destroyed))
+
+			_, ok = <-ch
+			Expect(ok).To(BeFalse())
+		})
+
+		It("delivers Destroyed to a watcher registered while the session exists when Delete fires afterward", func() {
+			ctx := context.Background()
+			info := newTestSession("sess-watch-then-delete")
+
+			Expect(sessionStore.Set(ctx, info.ID, info)).To(Succeed())
+
+			ch, err := sessionStore.WatchSession(ctx, info.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(sessionStore.Delete(ctx, info.ID, "reason-xyz")).To(Succeed())
+
+			ev, ok := <-ch
+			Expect(ok).To(BeTrue())
+			Expect(ev.Type).To(Equal(session.Destroyed))
+			Expect(ev.Message).To(Equal("reason-xyz"))
+
+			_, ok = <-ch
+			Expect(ok).To(BeFalse())
+		})
+	})
 })

--- a/internal/telnet/gateway_handler.go
+++ b/internal/telnet/gateway_handler.go
@@ -532,27 +532,33 @@ func (h *GatewayHandler) subscribeAndEnter(ctx context.Context) <-chan *corev1.S
 		return nil
 	}
 
-	h.eventCh = make(chan *corev1.SubscribeResponse, 16)
+	// Capture session ID and event channel as locals so the receive
+	// goroutine never reads from h.* — the main Handle loop mutates those
+	// fields during teardown (quit→character-picker reset), which would
+	// race with concurrent reads here (holomush-umxj Mode A).
+	eventCh := make(chan *corev1.SubscribeResponse, 16)
+	sessionID := h.sessionID
+	h.eventCh = eventCh
 
 	go func() {
-		defer close(h.eventCh)
+		defer close(eventCh)
 		for {
 			resp, recvErr := stream.Recv()
 			if recvErr != nil {
 				if !errors.Is(recvErr, io.EOF) {
-					slog.DebugContext(ctx, "gateway: event stream recv error", "session_id", h.sessionID, "error", recvErr)
+					slog.DebugContext(ctx, "gateway: event stream recv error", "session_id", sessionID, "error", recvErr)
 				}
 				return
 			}
 			select {
-			case h.eventCh <- resp:
+			case eventCh <- resp:
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
 
-	return h.eventCh
+	return eventCh
 }
 
 func (h *GatewayHandler) handleSay(ctx context.Context, message string) {


### PR DESCRIPTION
## Summary

Closes holomush-umxj — the P0 telnet-E2E flake that's been blocking all merges. Two distinct failure modes, both fixed.

- **Mode A — data race:** `subscribeAndEnter`'s recv goroutine reads `h.sessionID` (line 533) while the main `Handle` loop writes it at line 200 during the quit→character-picker reset. Since `stream.Recv()` can outlive `Handle`, the race detector's torn-read warning is legitimate. Fix: capture `sessionID` and `eventCh` as locals at goroutine start so the goroutine never touches `h.*`.
- **Mode B — leave-event spec flake:** `Subscribe` registered its `WatchSession` watcher AFTER replay, giving a window where a concurrent quit's `Delete` would notify and clear the watcher list before registration. The new watcher was permanently silent, live loop blocked, gateway's 2s drain timed out, character picker rendered instead of `"Goodbye!"`. Fix in three layers:
  1. Register the watcher immediately after `Get`, before `SubscribeSession`/replay.
  2. `MemStore`/`PostgresSessionStore.WatchSession` returns a pre-closed `Destroyed` channel when the session is already gone (covers the narrow `Get↔WatchSession` window across the store mu).
  3. On `Destroyed`, drain pending `sub.Notifications` for up to 200ms of quiet time before sending `STREAM_CLOSED` — `LISTEN/NOTIFY` delivery is async and the quit handler's `command_response "Goodbye!"` event can be mid-flight when `Delete` fires.

## Test plan

- [x] `task pr-prep` green: lint clean, format clean, license clean, schema clean, 62/62 unit + 541/541 integration + 56/56 E2E.
- [x] Mode A: 20× `ginkgo --race -repeat=20 --focus="emits leave event on guest disconnect"` — zero race hits (reproduced reliably before fix).
- [x] Mode B: 20× same focus — all passes (reproduced locally before fix with 3 character-picker lines and silence, matching CI fingerprint exactly).
- [x] Full telnet suite ×5 under `-race`: 13/13 each run.
- [x] Unit tests for `session`, `grpc`, `telnet`, `store`: 745 pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)