### PR TITLE
feat(eventbus/codec): M2 — codec interface, IdentityCodec, closed registry

### DIFF
--- a/internal/eventbus/codec/codec.go
+++ b/internal/eventbus/codec/codec.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package codec defines the host-owned codec interface for event payload
+// encoding/decoding. The Identity codec is the pass-through default;
+// future encryption codecs (e.g., aes-gcm-v1) plug in via the registry.
+//
+// Per the spec (§9), the codec is a narrow crypto primitive — it does
+// NOT know about subjects or routing. Subject→key mapping lives in a
+// separate KeySelector (also defined here, no production implementation
+// yet).
+package codec
+
+import "context"
+
+// Name is a closed enumeration of host-known codecs. Plugins MUST NOT
+// register codecs.
+type Name string
+
+const (
+	// NameIdentity is the built-in pass-through codec that leaves payloads unchanged.
+	NameIdentity Name = "identity"
+	// Future:
+	// NameAESGCMv1        Name = "aes-gcm-v1"
+	// NameXChaCha20v1     Name = "xchacha20poly1305-v1"
+)
+
+// Codec encodes and decodes event payload bytes. Implementations MUST be
+// stateless and safe for concurrent use.
+type Codec interface {
+	Name() Name
+	Encode(ctx context.Context, plaintext []byte, key Key) ([]byte, error)
+	Decode(ctx context.Context, ciphertext []byte, key Key) ([]byte, error)
+}
+
+// Key is the opaque cryptographic material a codec uses to encrypt/decrypt.
+// IdentityCodec ignores it and accepts NoKey.
+type Key struct {
+	ID    KeyID
+	Bytes []byte
+	// Codec-specific metadata may be carried inside Bytes; codecs are free
+	// to interpret as they need.
+}
+
+// NoKey is the sentinel passed to keyless codecs (IdentityCodec).
+var NoKey = Key{}
+
+// KeyID is a stable identifier for a key version. Stored in the codec's
+// internal envelope so Decode can pick the right key on rotation.
+type KeyID uint64
+
+// KeyLabel is a logical purpose name (e.g., "scene-content", "dm-content")
+// used by KeyProvider.Active to look up the current key for that purpose.
+type KeyLabel string
+
+// KeyProvider supplies keys to codecs.
+type KeyProvider interface {
+	Active(ctx context.Context, label KeyLabel) (Key, error)
+	ByID(ctx context.Context, id KeyID) (Key, error)
+}
+
+// KeySelector maps a publish-time subject to (codec name, key label) per
+// the deployment's encryption policy. Lives upstream of Codec.
+type KeySelector interface {
+	SelectForEncrypt(ctx context.Context, subject string) (Name, KeyLabel, error)
+	SelectForDecrypt(ctx context.Context, codec Name, keyID KeyID) (Key, error)
+}
+
+// IdentityCodec is the default no-op codec. It returns plaintext unchanged.
+type IdentityCodec struct{}
+
+// Name returns NameIdentity.
+func (IdentityCodec) Name() Name { return NameIdentity }
+
+// Encode returns plaintext unchanged.
+func (IdentityCodec) Encode(_ context.Context, plaintext []byte, _ Key) ([]byte, error) {
+	return plaintext, nil
+}
+
+// Decode returns ciphertext unchanged.
+func (IdentityCodec) Decode(_ context.Context, ciphertext []byte, _ Key) ([]byte, error) {
+	return ciphertext, nil
+}

--- a/internal/eventbus/codec/codec_test.go
+++ b/internal/eventbus/codec/codec_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+func TestIdentityCodecRoundTripPreservesBytes(t *testing.T) {
+	c := codec.IdentityCodec{}
+	plaintext := []byte("hello, scene 01JABC")
+
+	encoded, err := c.Encode(context.Background(), plaintext, codec.NoKey)
+	require.NoError(t, err)
+
+	decoded, err := c.Decode(context.Background(), encoded, codec.NoKey)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decoded)
+}
+
+func TestIdentityCodecHandlesEmptyPlaintext(t *testing.T) {
+	c := codec.IdentityCodec{}
+	encoded, err := c.Encode(context.Background(), nil, codec.NoKey)
+	require.NoError(t, err)
+	decoded, err := c.Decode(context.Background(), encoded, codec.NoKey)
+	require.NoError(t, err)
+	require.Empty(t, decoded)
+}
+
+func TestIdentityCodecName(t *testing.T) {
+	c := codec.IdentityCodec{}
+	require.Equal(t, codec.NameIdentity, c.Name())
+}

--- a/internal/eventbus/codec/registry.go
+++ b/internal/eventbus/codec/registry.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec
+
+import (
+	"fmt"
+	"sync"
+)
+
+// registry holds all host-known codecs. Closed enumeration — plugins
+// cannot register codecs. The variable is package-private; access via
+// Resolve / All / RegisterForTest.
+var (
+	regMu    sync.RWMutex
+	registry = map[Name]Codec{
+		NameIdentity: IdentityCodec{},
+	}
+)
+
+// Resolve returns the codec for the given name, or error if unknown.
+// Hard-fails on unknown names — callers MUST NOT silently fall back to
+// identity.
+func Resolve(name Name) (Codec, error) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	c, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("codec: unknown name %q", name)
+	}
+	return c, nil
+}
+
+// All returns a copy of all registered codec names. Used by the meta-test
+// to assert const ↔ registry sync.
+func All() []Name {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]Name, 0, len(registry))
+	for n := range registry {
+		out = append(out, n)
+	}
+	return out
+}
+
+// RegisterForTest installs a codec at runtime. Production code MUST NOT
+// call this — it is intended for tests that exercise a custom codec
+// (e.g., a stub encrypt/decrypt for property tests). Returns a cleanup
+// func that restores the prior state.
+func RegisterForTest(c Codec) func() {
+	regMu.Lock()
+	prev, hadPrev := registry[c.Name()]
+	registry[c.Name()] = c
+	regMu.Unlock()
+	return func() {
+		regMu.Lock()
+		defer regMu.Unlock()
+		if hadPrev {
+			registry[c.Name()] = prev
+		} else {
+			delete(registry, c.Name())
+		}
+	}
+}

--- a/internal/eventbus/codec/registry_test.go
+++ b/internal/eventbus/codec/registry_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package codec_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+// declaredNames lists every Name constant defined in codec.go.
+// This list MUST be updated when a new constant is added — the meta-test
+// below catches the case where a const is declared but not registered.
+var declaredNames = []codec.Name{
+	codec.NameIdentity,
+	// Add new constants here when introduced.
+}
+
+func TestEveryDeclaredCodecNameIsRegistered(t *testing.T) {
+	for _, n := range declaredNames {
+		t.Run(string(n), func(t *testing.T) {
+			c, err := codec.Resolve(n)
+			require.NoError(t, err, "codec %q is declared but not in registry", n)
+			require.Equal(t, n, c.Name())
+		})
+	}
+}
+
+func TestRegistryHasNoExtraEntriesNotDeclared(t *testing.T) {
+	declared := make(map[codec.Name]bool, len(declaredNames))
+	for _, n := range declaredNames {
+		declared[n] = true
+	}
+	for _, n := range codec.All() {
+		if !declared[n] {
+			t.Errorf("registry contains %q which is not in declaredNames — update declaredNames or remove from registry", n)
+		}
+	}
+}
+
+func TestResolveUnknownCodecReturnsError(t *testing.T) {
+	_, err := codec.Resolve(codec.Name("does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestRegisterForTestRestoresState(t *testing.T) {
+	var stub stubCodec
+	cleanup := codec.RegisterForTest(stub)
+	c, err := codec.Resolve(stub.Name())
+	require.NoError(t, err)
+	require.True(t, reflect.TypeOf(c) == reflect.TypeOf(stub))
+
+	cleanup()
+	_, err = codec.Resolve(stub.Name())
+	require.Error(t, err)
+}
+
+type stubCodec struct{}
+
+func (stubCodec) Name() codec.Name { return codec.Name("test-only-stub") }
+func (stubCodec) Encode(_ context.Context, p []byte, _ codec.Key) ([]byte, error) {
+	return p, nil
+}
+func (stubCodec) Decode(_ context.Context, p []byte, _ codec.Key) ([]byte, error) {
+	return p, nil
+}


### PR DESCRIPTION
## Summary

Task **M2** of the JetStream EventBus Phase A plan — introduces the host-owned codec layer for event payload encoding/decoding.

- Closed enumeration of codec \`Name\` constants; plugins MUST NOT register
- \`IdentityCodec\` is the default pass-through; future encryption codecs (\`aes-gcm-v1\`, \`xchacha20poly1305-v1\`) plug in via the registry
- \`Codec\` interface is a narrow crypto primitive — it does **not** know about subjects or routing; \`KeySelector\` (scaffolded, no impl) owns that policy concern
- Registry sync meta-test enforces \`Name\` constants ↔ registry parity
- \`RegisterForTest\` provides a test-only seam with a restoring cleanup func

Additive only — no consumer wires codecs into production paths yet (that happens in Phase B F1). Production behavior unchanged.

## References

- Epic: \`holomush-1tvn\`
- Bead: \`holomush-1tvn.2\`
- Plan: \`docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-a.md\` — Task M2
- Spec: \`docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md\` §9

## Test plan

- [x] \`task test -- ./internal/eventbus/codec/...\` — 8 tests pass
- [x] Coverage 96.0% (gate: ≥95%)
- [x] \`task pr-prep\` green (lint, format, schema, license, unit, integration, 62 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)