### PR TITLE
feat(store): M3 — add events_audit table for JetStream audit projection

### DIFF
--- a/internal/store/events_audit_test.go
+++ b/internal/store/events_audit_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	// Register pgx stdlib driver for database/sql.
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+func TestEventsAuditTablePresentWithIndexes(t *testing.T) {
+	pg := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, pg)
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var n int
+	require.NoError(t,
+		db.QueryRowContext(ctx,
+			"SELECT count(*) FROM information_schema.tables WHERE table_name='events_audit'",
+		).Scan(&n),
+	)
+	require.Equal(t, 1, n, "events_audit table not created by migrations")
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT indexname FROM pg_indexes WHERE tablename='events_audit' ORDER BY indexname",
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var indexes []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		indexes = append(indexes, name)
+	}
+	require.NoError(t, rows.Err())
+	require.Contains(t, indexes, "events_audit_subject_id")
+	require.Contains(t, indexes, "events_audit_subject_ts")
+	require.Contains(t, indexes, "events_audit_subject_pat")
+	require.Contains(t, indexes, "events_audit_pkey")
+}
+
+func TestEventsAuditInsertOnConflictIsIdempotent(t *testing.T) {
+	pg := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, pg)
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	id := ulid.Make()
+	insert := `
+		INSERT INTO events_audit (
+			id, subject, type, timestamp, actor_kind, actor_id,
+			payload, schema_ver, codec, js_seq
+		) VALUES ($1, $2, $3, now(), 'system', NULL, $4, 1, 'identity', 100)
+		ON CONFLICT (id) DO NOTHING`
+	payload := []byte(`{"hello":"world"}`)
+
+	res1, err := db.ExecContext(ctx, insert, id[:], "events.main.test", "test.t", payload)
+	require.NoError(t, err)
+	n1, _ := res1.RowsAffected()
+	require.EqualValues(t, 1, n1, "first insert should affect 1 row")
+
+	res2, err := db.ExecContext(ctx, insert, id[:], "events.main.test", "test.t", payload)
+	require.NoError(t, err)
+	n2, _ := res2.RowsAffected()
+	require.EqualValues(t, 0, n2, "duplicate insert should affect 0 rows")
+
+	var count int
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT count(*) FROM events_audit WHERE id=$1", id[:]).Scan(&count),
+	)
+	require.Equal(t, 1, count)
+}
+
+func TestEventsAuditCodecColumnIsNotNull(t *testing.T) {
+	pg := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, pg)
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	id := ulid.Make()
+	insert := `
+		INSERT INTO events_audit (
+			id, subject, type, timestamp, actor_kind, actor_id,
+			payload, schema_ver, codec, js_seq
+		) VALUES ($1, 'events.main.test', 'test.t', now(), 'system', NULL, $2, 1, NULL, 100)`
+	_, err = db.ExecContext(ctx, insert, id[:], []byte(`{}`))
+	require.Error(t, err, "NULL codec should be rejected by NOT NULL constraint")
+}

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -32,6 +32,7 @@ var expectedTables = []string{
 	"content_items",
 	"entity_properties",
 	"events",
+	"events_audit",
 	"exits",
 	"holomush_system_info",
 	"locations",
@@ -140,7 +141,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(8), version)
+	assert.Equal(t, uint(9), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -165,7 +166,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(8), version)
+	assert.Equal(t, uint(9), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,18 +278,18 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-8 should be pending (baseline + is_guest +
+	// At version 0, migrations 1-9 should be pending (baseline + is_guest +
 	// alias_source + session_player_id + audit_source_component + session_focus +
-	// seed_scene_defaults + session_player_fk)
+	// seed_scene_defaults + session_player_fk + create_events_audit)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 8 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 8}}
+	// At version 9 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 9}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000009_create_events_audit.down.sql
+++ b/internal/store/migrations/000009_create_events_audit.down.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+DROP INDEX IF EXISTS events_audit_subject_pat;
+DROP INDEX IF EXISTS events_audit_subject_ts;
+DROP INDEX IF EXISTS events_audit_subject_id;
+DROP TABLE IF EXISTS events_audit;

--- a/internal/store/migrations/000009_create_events_audit.up.sql
+++ b/internal/store/migrations/000009_create_events_audit.up.sql
@@ -1,0 +1,20 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+CREATE TABLE IF NOT EXISTS events_audit (
+    id           BYTEA       PRIMARY KEY,
+    subject      TEXT        NOT NULL,
+    type         TEXT        NOT NULL,
+    timestamp    TIMESTAMPTZ NOT NULL,
+    actor_kind   TEXT        NOT NULL,
+    actor_id     BYTEA,
+    payload      BYTEA       NOT NULL,
+    schema_ver   SMALLINT    NOT NULL,
+    codec        TEXT        NOT NULL,
+    js_seq       BIGINT      NOT NULL,
+    inserted_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS events_audit_subject_id  ON events_audit (subject, id);
+CREATE INDEX IF NOT EXISTS events_audit_subject_ts  ON events_audit (subject, timestamp);
+CREATE INDEX IF NOT EXISTS events_audit_subject_pat ON events_audit (subject text_pattern_ops);


### PR DESCRIPTION
## Summary

Task **M3** of the JetStream EventBus Phase A plan — PostgreSQL audit projection target for the cutover.

- \`events_audit\` (ULID PK, subject, type, timestamp, actor_kind, actor_id, payload bytes, schema_ver, codec, js_seq, inserted_at)
- \`codec\` column is **NOT NULL** — every row stores its codec name explicitly; NULL means a bug. Go is the only writer, so no CHECK constraint (avoids migration churn when adding codecs)
- Three indexes:
  - \`(subject, id)\` — history queries
  - \`(subject, timestamp)\` — time-bounded queries
  - \`(subject text_pattern_ops)\` — LIKE prefix matching in projection routing

Additive only — no writer exists yet (audit projection worker lands in M5, wired in Phase B F2). Production \`events\` table is untouched.

Existing hardcoded migration-count and table-list tests (\`migrate_test.go\`, \`migrate_integration_test.go\`) were updated to include migration 9 and \`events_audit\` — test-local fixture updates only.

## References

- Epic: \`holomush-1tvn\`
- Bead: \`holomush-1tvn.3\`
- Plan: \`docs/superpowers/plans/2026-04-18-jetstream-eventbus-phase-a.md\` — Task M3
- Spec: \`docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md\` §6

## Test plan

- [x] \`task test:int -- -run TestEventsAudit ./internal/store/...\` — 3 new tests pass; full integration suite 545/545 green
- [x] \`task pr-prep\` green (62/62 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)