### PR TITLE
fix(sandbox): doctl --output json for Spaces keys; postgres:18 data-dir mount

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -228,8 +228,13 @@ jobs:
           # Rotate any stale key of the same name so create never collides.
           # doctl validates the permission enum (read|readwrite|fullaccess), so
           # this path can't silently send a bad value like the prior curl did.
-          EXISTING_ACCESS_KEY=$(doctl spaces keys list --format Name,AccessKey --no-header \
-            | awk '$1=="holomush-sandbox" {print $2}')
+          # NOTE: use --output json (a global flag) rather than --format; the
+          # doctl shipped by digitalocean/action-doctl@v2 lacks --format on
+          # `spaces keys create`. JSON parsing uses python3 for consistency
+          # with the Cloudflare and firewall steps in this workflow.
+          EXISTING_JSON=$(doctl spaces keys list --output json)
+          EXISTING_ACCESS_KEY=$(echo "${EXISTING_JSON}" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); keys=[k for k in d if k.get('name')=='holomush-sandbox']; print(keys[0].get('access_key','') if keys else '')")
           if [ -n "${EXISTING_ACCESS_KEY}" ]; then
             echo "Found existing key 'holomush-sandbox' — deleting before recreate"
             doctl spaces keys delete "${EXISTING_ACCESS_KEY}" --force
@@ -237,9 +242,13 @@ jobs:
 
           CREATED=$(doctl spaces keys create holomush-sandbox \
             --grants "bucket=${BUCKET_NAME};permission=readwrite" \
-            --format AccessKey,SecretKey --no-header)
-          ACCESS_KEY=$(echo "${CREATED}" | awk '{print $1}')
-          SECRET_KEY=$(echo "${CREATED}" | awk '{print $2}')
+            --output json)
+          # doctl wraps single-item create results in a one-element array;
+          # `.[0] if list else .` accepts either shape defensively.
+          ACCESS_KEY=$(echo "${CREATED}" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('access_key',''))")
+          SECRET_KEY=$(echo "${CREATED}" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('secret_key',''))")
 
           if [ -z "${ACCESS_KEY}" ] || [ -z "${SECRET_KEY}" ]; then
             echo "::error::doctl spaces keys create returned empty access/secret key"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -15,18 +15,22 @@ services:
       POSTGRES_DB: holomush
     # Enable TLS so DATABASE_URL can use sslmode=require. A self-signed
     # certificate is generated on first boot and stored on the data
-    # volume. Connections from core use sslmode=require (encrypt, but
-    # do not verify CA), which is appropriate for an intra-stack
-    # backend network. Operators who need verify-full SHOULD mount
-    # their own CA-signed cert at /var/lib/postgresql/data/server.crt|key
-    # and set sslmode=verify-full in DATABASE_URL.
+    # volume (under /var/lib/postgresql/ssl, outside PGDATA so it
+    # survives postgres major-version upgrades). Connections from core
+    # use sslmode=require (encrypt, but do not verify CA), which is
+    # appropriate for an intra-stack backend network. Operators who
+    # need verify-full SHOULD mount their own CA-signed cert at
+    # /var/lib/postgresql/ssl/server.crt|key and set sslmode=verify-full
+    # in DATABASE_URL.
     command:
       - sh
       - -c
       - |
         set -e
-        CRT=/var/lib/postgresql/data/server.crt
-        KEY=/var/lib/postgresql/data/server.key
+        SSL_DIR=/var/lib/postgresql/ssl
+        CRT=$$SSL_DIR/server.crt
+        KEY=$$SSL_DIR/server.key
+        mkdir -p "$$SSL_DIR"
         if [ ! -s "$$CRT" ] || [ ! -s "$$KEY" ]; then
           apk add --no-cache openssl >/dev/null
           openssl req -new -x509 -days 3650 -nodes -subj "/CN=holomush-postgres" -out "$$CRT" -keyout "$$KEY"
@@ -36,7 +40,9 @@ services:
         fi
         exec docker-entrypoint.sh postgres -c ssl=on -c ssl_cert_file=$$CRT -c ssl_key_file=$$KEY
     volumes:
-      - ${DATA_DIR:-/opt/holomush/data}/postgres:/var/lib/postgresql/data
+      # postgres:18+ stores data under /var/lib/postgresql/<major>/docker;
+      # mount the parent so both PGDATA and the ssl/ dir are persisted.
+      - ${DATA_DIR:-/opt/holomush/data}/postgres:/var/lib/postgresql
     networks:
       - backend
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,11 @@ services:
       POSTGRES_DB: holomush
     volumes:
       - ./docker/postgres/init-role.sh:/docker-entrypoint-initdb.d/01-init-role.sh
-      - pgdata:/var/lib/postgresql/data
+      # postgres:18+ stores data in a major-version-specific subdir
+      # (/var/lib/postgresql/18/docker) rather than /var/lib/postgresql/data.
+      # Mount the parent so the subdir is persisted. Pre-18 volumes are not
+      # upgraded in place — drop them with `docker compose down -v`.
+      - pgdata:/var/lib/postgresql
     networks:
       - backend
     healthcheck:


### PR DESCRIPTION
## Summary

Two independent fixes needed to get the sandbox bootstrap end-to-end. Bundled because they're both small and the second was caught while verifying the first. Clean break — any pre-18 `pgdata` volumes must be dropped (`docker compose down -v`); sandbox has never successfully provisioned, so no production data to migrate.

### 1. doctl: `--output json` instead of per-command `--format`

Follow-up to #256. Next bootstrap run ([24892599340](https://github.com/holomush/holomush/actions/runs/24892599340)) failed at the same step:

```
Error: unknown flag: --format
```

The doctl shipped by `digitalocean/action-doctl@v2` predates per-command `--format` on `spaces keys create`. Only the global `-o, --output [text|json]` is available on that version.

- Switch `list` and `create` to `--output json`.
- Parse JSON with inline `python3 -c` to match the Cloudflare and firewall steps in this same workflow.
- `create` may wrap the single result in a one-element array; parse defensively (`d[0] if isinstance(d,list) else d`).

### 2. postgres:18-alpine data-dir mount

Reproduced deterministically while running `task pr-prep` — `holomush-e2e-postgres-1 exited (1)` with:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).
       ...
       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory...
```

Ref: [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259). Postgres 18 stores data under `/var/lib/postgresql/<major>/<cluster>` rather than `/var/lib/postgresql/data`. Our compose mounts at `/var/lib/postgresql/data` were no longer correct.

This is also why the E2E job has been flaky on recent main runs (#254, #255, and the first attempt on #256) — when a Namespace runner happened to reuse a prior pgdata state it'd work, otherwise it'd fail.

- `compose.yaml`: mount `pgdata:/var/lib/postgresql` (was `/var/lib/postgresql/data`).
- `compose.prod.yaml`: same; additionally relocate self-signed TLS cert to `/var/lib/postgresql/ssl/server.{crt,key}` (outside PGDATA) so it survives future major-version upgrades without chasing the data-dir path.
- Added migration notes inline.

**Breaking change for anyone with a pre-existing postgres:17 `pgdata` volume.** Drop the volume and let compose re-initialize. Sandbox has never provisioned so no production data exists yet.

## Context

Bead: holomush-q7on (follow-up to holomush-7ugz).

## Test plan

- [x] `task lint:actions` / `task lint:yaml` — clean
- [x] Local repro of postgres container exit-1, fixed with new mount; stack starts healthy
- [x] `task pr-prep` — full run green: schema/license/plugin-build/lint/fmt/unit/integration/E2E all pass (`✓ All PR checks passed.`)
- [ ] CI
- [ ] **Operator**: re-dispatch the `Bootstrap Sandbox` workflow after merge. Both step 9 (Spaces keys) and any downstream postgres-in-droplet step should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * More robust sandbox credential handling that tolerates varied JSON formats and parsing issues.
* **Bug Fixes**
  * Postgres TLS files are stored outside the data subdirectory so certs/keys persist across upgrades.
  * Adjusted persistent storage mapping and added guidance for Postgres 18+ layout to avoid data-loss during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->