### PR TITLE
ci(sandbox): add set -x + doctl --verbose to diagnose Spaces-key silent exit

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -210,7 +210,9 @@ jobs:
           GH_TOKEN: ${{ secrets.SECRETS_ADMIN_PAT }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          set -euo pipefail
+          # -x traces every command so the step log shows which line exits when.
+          # Remove once the step is stable (tracked in bead holomush-7ugz notes).
+          set -euxo pipefail
 
           if [ "${DRY_RUN}" = "true" ]; then
             echo "DRY RUN: would resolve or create Spaces access key 'holomush-sandbox'"
@@ -232,17 +234,18 @@ jobs:
           # doctl shipped by digitalocean/action-doctl@v2 lacks --format on
           # `spaces keys create`. JSON parsing uses python3 for consistency
           # with the Cloudflare and firewall steps in this workflow.
-          EXISTING_JSON=$(doctl spaces keys list --output json)
+          # --verbose surfaces doctl's HTTP layer diagnostics (does NOT log tokens).
+          EXISTING_JSON=$(doctl spaces keys list --verbose --output json)
           EXISTING_ACCESS_KEY=$(echo "${EXISTING_JSON}" | python3 -c \
             "import sys,json; d=json.load(sys.stdin); keys=[k for k in d if k.get('name')=='holomush-sandbox']; print(keys[0].get('access_key','') if keys else '')")
           if [ -n "${EXISTING_ACCESS_KEY}" ]; then
             echo "Found existing key 'holomush-sandbox' — deleting before recreate"
-            doctl spaces keys delete "${EXISTING_ACCESS_KEY}" --force
+            doctl spaces keys delete "${EXISTING_ACCESS_KEY}" --verbose --force
           fi
 
           CREATED=$(doctl spaces keys create holomush-sandbox \
             --grants "bucket=${BUCKET_NAME};permission=readwrite" \
-            --output json)
+            --verbose --output json)
           # doctl wraps single-item create results in a one-element array;
           # `.[0] if list else .` accepts either shape defensively.
           ACCESS_KEY=$(echo "${CREATED}" | python3 -c \


### PR DESCRIPTION
## Summary

After #257 merged, the next `Bootstrap Sandbox` dispatch ([24895961154](https://github.com/holomush/holomush/actions/runs/24895961154/job/72900719077)) failed at step 9 with **5.88s of complete silence then exit 1** — no doctl stdout/stderr visible in the log. Locally `doctl spaces keys list --output json` runs clean against the same account, so the behavior is CI-specific.

This PR adds the minimum diagnostic scaffolding to the step so the next dispatch emits a breadcrumb trail:

- `set -euxo pipefail` — `-x` traces every command before execution, so the log shows the last line reached before exit.
- `doctl spaces keys {list,delete,create} --verbose` — surfaces doctl's HTTP layer diagnostics. Does **not** log tokens.

Temporary scaffolding only; will be removed once the root cause is identified and fixed. Tracked in bead `holomush-mnsk`.

Net: +7 / −4 in the step body.

## Test plan

- [x] `task lint:actions` / `task lint:yaml` — clean
- [x] `task pr-prep` — full run green (`✓ All PR checks passed.`)
- [ ] **After merge:** re-dispatch `Bootstrap Sandbox`. Step 9 log should show the exact command that fails; fix will follow.

## Related

- Bead: holomush-mnsk (this PR) and holomush-7ugz (the original sandbox-bootstrap task)
- Context on why `act` is not a good fit for this specific debugging: answered in the corresponding conversation; TL;DR: step calls real DO + GH APIs, `dry_run: true` short-circuits before them, so `act` can only validate YAML not API behavior. The extract-to-shell-script refactor (option B) is a better long-term investment and may follow as its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostics and logging for internal infrastructure processes to improve operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->