### PR TITLE
fix(sandbox): temp-key dance for bucket create; extract Spaces steps to scripts

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -20,7 +20,7 @@ on:
         description: "DigitalOcean region slug"
         required: true
         type: string
-        default: "sfo3"
+        default: "nyc3"
       droplet_size:
         description: "Droplet size slug"
         required: true
@@ -200,107 +200,25 @@ jobs:
             echo "::notice::Tunnel ingress configured: ${DOMAIN} -> gateway:8080"
           fi
 
-      # Step 6: Resolve or create DO Spaces access key
-      # Must run BEFORE bucket creation — access keys are account-scoped and
-      # don't require a pre-existing bucket.
+      # Spaces provisioning — bucket MUST be created before the scoped key.
+      # DO's /v2/spaces/keys rejects grants whose bucket doesn't yet exist
+      # (403 invalid grant). Step bodies live in scripts/bootstrap-sandbox/
+      # so they can be exercised locally during debugging.
+      - name: Resolve or create DO Spaces bucket
+        id: bucket
+        env:
+          BUCKET_NAME: ${{ inputs.bucket_name }}
+          REGION: ${{ inputs.region }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: ./scripts/bootstrap-sandbox/spaces-bucket.sh
+
       - name: Resolve or create DO Spaces access key
         id: spaces_key
         env:
           BUCKET_NAME: ${{ inputs.bucket_name }}
           GH_TOKEN: ${{ secrets.SECRETS_ADMIN_PAT }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-
-          if [ "${DRY_RUN}" = "true" ]; then
-            echo "DRY RUN: would resolve or create Spaces access key 'holomush-sandbox'"
-            exit 0
-          fi
-
-          HAS_ACCESS_KEY=$(gh secret list --app actions | grep -c '^DO_SPACES_ACCESS_KEY' || true)
-          HAS_SECRET_KEY=$(gh secret list --app actions | grep -c '^DO_SPACES_SECRET_KEY' || true)
-
-          if [ "${HAS_ACCESS_KEY}" -gt "0" ] && [ "${HAS_SECRET_KEY}" -gt "0" ]; then
-            echo "::notice::DO_SPACES_ACCESS_KEY and DO_SPACES_SECRET_KEY already set — skipping"
-            exit 0
-          fi
-
-          # Rotate any stale key of the same name so create never collides.
-          # doctl validates the permission enum (read|readwrite|fullaccess), so
-          # this path can't silently send a bad value like the prior curl did.
-          # NOTE: use --output json (a global flag) rather than --format; the
-          # doctl shipped by digitalocean/action-doctl@v2 lacks --format on
-          # `spaces keys create`. JSON parsing uses python3 for consistency
-          # with the Cloudflare and firewall steps in this workflow.
-          EXISTING_JSON=$(doctl spaces keys list --output json)
-          EXISTING_ACCESS_KEY=$(echo "${EXISTING_JSON}" | python3 -c \
-            "import sys,json; d=json.load(sys.stdin); keys=[k for k in d if k.get('name')=='holomush-sandbox']; print(keys[0].get('access_key','') if keys else '')")
-          if [ -n "${EXISTING_ACCESS_KEY}" ]; then
-            echo "Found existing key 'holomush-sandbox' — deleting before recreate"
-            doctl spaces keys delete "${EXISTING_ACCESS_KEY}" --force
-          fi
-
-          CREATED=$(doctl spaces keys create holomush-sandbox \
-            --grants "bucket=${BUCKET_NAME};permission=readwrite" \
-            --output json)
-          # doctl wraps single-item create results in a one-element array;
-          # `.[0] if list else .` accepts either shape defensively.
-          ACCESS_KEY=$(echo "${CREATED}" | python3 -c \
-            "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('access_key',''))")
-          SECRET_KEY=$(echo "${CREATED}" | python3 -c \
-            "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('secret_key',''))")
-
-          if [ -z "${ACCESS_KEY}" ] || [ -z "${SECRET_KEY}" ]; then
-            echo "::error::doctl spaces keys create returned empty access/secret key"
-            exit 1
-          fi
-
-          echo "::add-mask::${SECRET_KEY}"
-          echo "access_key=${ACCESS_KEY}" >> "$GITHUB_OUTPUT"
-          echo "secret_key=${SECRET_KEY}" >> "$GITHUB_OUTPUT"
-          echo "${ACCESS_KEY}" | gh secret set DO_SPACES_ACCESS_KEY
-          echo "${SECRET_KEY}" | gh secret set DO_SPACES_SECRET_KEY
-          echo "::notice::Created Spaces access key 'holomush-sandbox' and stored in GH Secrets"
-
-      # Step 7: Resolve or create DO Spaces bucket
-      # Uses S3-compatible HEAD check (the DO v2/spaces/<name> endpoint does not exist).
-      - name: Resolve or create DO Spaces bucket
-        id: bucket
-        env:
-          BUCKET_NAME: ${{ inputs.bucket_name }}
-          REGION: ${{ inputs.region }}
-          DO_SPACES_ACCESS_KEY_EXISTING: ${{ steps.spaces_key.outputs.access_key != '' && steps.spaces_key.outputs.access_key
-            || secrets.DO_SPACES_ACCESS_KEY }}
-          DO_SPACES_SECRET_KEY_EXISTING: ${{ steps.spaces_key.outputs.secret_key != '' && steps.spaces_key.outputs.secret_key
-            || secrets.DO_SPACES_SECRET_KEY }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-
-          if [ "${DRY_RUN}" = "true" ]; then
-            echo "::notice::[dry-run] Would ensure Spaces bucket ${BUCKET_NAME} exists in ${REGION}"
-            echo "spaces_endpoint=${REGION}.digitaloceanspaces.com" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Existence check via SigV4 head-bucket (curl + basic auth does NOT
-          # authenticate against S3-compatible APIs — CodeRabbit review catch).
-          aws configure set aws_access_key_id "${DO_SPACES_ACCESS_KEY_EXISTING}" \
-            --profile dospaces
-          aws configure set aws_secret_access_key "${DO_SPACES_SECRET_KEY_EXISTING}" \
-            --profile dospaces
-
-          if aws --profile dospaces \
-              --endpoint-url "https://${REGION}.digitaloceanspaces.com" \
-              s3api head-bucket --bucket "${BUCKET_NAME}" 2>/dev/null; then
-            echo "::notice::Reusing existing Spaces bucket: ${BUCKET_NAME}"
-          else
-            aws --profile dospaces \
-              --endpoint-url "https://${REGION}.digitaloceanspaces.com" \
-              s3api create-bucket --bucket "${BUCKET_NAME}"
-            echo "::notice::Created Spaces bucket: ${BUCKET_NAME}"
-          fi
-          echo "spaces_endpoint=${REGION}.digitaloceanspaces.com" >> "$GITHUB_OUTPUT"
+        run: ./scripts/bootstrap-sandbox/spaces-key.sh
 
       # Step 8: Resolve or create DO block volume
       - name: Resolve or create DO block volume

--- a/scripts/bootstrap-sandbox/README.md
+++ b/scripts/bootstrap-sandbox/README.md
@@ -1,0 +1,88 @@
+# Bootstrap Sandbox — per-step scripts
+
+Each file in this directory encapsulates one step of the
+[`.github/workflows/bootstrap-sandbox.yaml`](../../.github/workflows/bootstrap-sandbox.yaml)
+GitHub Actions workflow. The workflow `run:` blocks delegate to these scripts
+so each step is testable locally against a real DigitalOcean / Cloudflare /
+GitHub account without dispatching the whole workflow through GitHub.
+
+Extraction is incremental: steps move here when they need iteration for a bug.
+The workflow YAML and scripts stay in sync as each step is extracted.
+
+## Currently extracted
+
+| Order | Script              | Responsibility                                           |
+| ----- | ------------------- | -------------------------------------------------------- |
+| 1     | `spaces-bucket.sh`  | Ensure the DO Spaces bucket exists (temp-key dance)      |
+| 2     | `spaces-key.sh`     | Mint a permanent readwrite key scoped to the bucket      |
+
+The bucket must be created before the key because DO's `/v2/spaces/keys`
+rejects grants whose bucket does not exist (`403 invalid grant`). Since
+buckets can only be created via the S3-compatible API (which itself needs a
+key), `spaces-bucket.sh` uses an ephemeral `fullaccess` key to create the
+bucket and deletes that key before exiting. This keeps the permanent key
+scoped tightly to one bucket.
+
+## Conventions
+
+Each script:
+
+- Is **idempotent** — safe to rerun without side effects on resources that
+  already exist.
+- Declares required env at the top with `: "${VAR:?}"` guards so missing
+  config fails fast with a clear message.
+- Uses `set -euo pipefail`.
+- Writes outputs to `$GITHUB_OUTPUT` only when that variable is set, so
+  local runs don't fail on a missing file.
+- Honors `SKIP_GH_SECRET_WRITE=1` to skip `gh secret set` calls when the
+  script would normally mutate repo secrets — useful when exercising the
+  DO API end-to-end without touching GitHub state.
+
+## Local testing
+
+Prerequisites:
+
+```bash
+# DigitalOcean API access (same scopes the workflow requires)
+doctl auth init
+
+# GitHub CLI (only needed if NOT using SKIP_GH_SECRET_WRITE)
+gh auth status
+```
+
+Run a single step, e.g.:
+
+```bash
+export BUCKET_NAME=holomush-sandbox-backups
+export REGION=sfo3
+export DRY_RUN=false
+./scripts/bootstrap-sandbox/spaces-bucket.sh
+
+export GH_TOKEN="$(gh auth token)"
+export SKIP_GH_SECRET_WRITE=1   # don't mutate real repo secrets
+./scripts/bootstrap-sandbox/spaces-key.sh
+```
+
+Set `DRY_RUN=true` to exercise the shell logic without API calls — useful
+for syntax/flow testing.
+
+## Cleanup
+
+If you run in non-dry-run mode, the scripts may create real resources (DO
+Spaces keys, buckets). `spaces-bucket.sh` cleans up its temp key on exit
+(including error paths); permanent resources created by `spaces-key.sh` or
+`spaces-bucket.sh` persist by design.
+
+To remove them manually:
+
+```bash
+# Keys — the default table output is human-readable; copy the access_key_id
+# column from the row you want to remove.
+doctl spaces keys list
+doctl spaces keys delete <access_key_id> --force
+
+# Bucket (fails if non-empty — must empty first). Substitute the
+# region slug and bucket name you used at provisioning time.
+aws --endpoint-url "https://${REGION}.digitaloceanspaces.com" \
+    s3api delete-bucket --bucket "${BUCKET_NAME}"
+```

--- a/scripts/bootstrap-sandbox/spaces-bucket.sh
+++ b/scripts/bootstrap-sandbox/spaces-bucket.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Ensure the DO Spaces bucket exists.
+#
+# Self-contained: mints a short-lived `fullaccess` Spaces key, uses it via the
+# S3-compatible endpoint to HEAD-or-CREATE the bucket, then deletes the key.
+# The key is deleted even on failure (trap EXIT).
+#
+# Why the temp-key dance: DO's /v2/spaces/keys rejects grants whose bucket
+# does not exist ("403 invalid grant"). Buckets can only be created via the
+# S3-compatible API, which needs a key. So we use a throwaway key here and
+# let scripts/bootstrap-sandbox/spaces-key.sh mint the permanent, bucket-
+# scoped `readwrite` key afterwards.
+#
+# Required env:
+#   BUCKET_NAME  Bucket to ensure
+#   REGION       DO region slug (e.g. sfo3)
+#   DRY_RUN      "true" to echo and exit
+#
+# Outputs ($GITHUB_OUTPUT if set):
+#   spaces_endpoint  Regional S3 endpoint (e.g. sfo3.digitaloceanspaces.com)
+#
+# Prerequisites: doctl (authenticated), aws CLI, python3.
+
+set -euo pipefail
+
+: "${BUCKET_NAME:?BUCKET_NAME must be set}"
+: "${REGION:?REGION must be set}"
+: "${DRY_RUN:?DRY_RUN must be set (\"true\" or \"false\")}"
+
+ENDPOINT="https://${REGION}.digitaloceanspaces.com"
+
+# Strip `secret_key` from a DO Spaces JSON response before logging. Used on
+# error paths where the unparsed body would otherwise leak a credential.
+redact_secret_key() {
+  python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    items = d if isinstance(d, list) else [d]
+    for it in items:
+        if isinstance(it, dict) and "secret_key" in it:
+            it["secret_key"] = "***REDACTED***"
+    print(json.dumps(d))
+except Exception:
+    print("<unparseable response>")
+'
+}
+
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "::notice::[dry-run] Would ensure Spaces bucket ${BUCKET_NAME} exists in ${REGION}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "spaces_endpoint=${REGION}.digitaloceanspaces.com" >> "${GITHUB_OUTPUT}"
+  fi
+  exit 0
+fi
+
+TEMP_KEY_NAME="holomush-sandbox-bootstrap-$$"
+TEMP_ACCESS_KEY=""
+
+cleanup_temp_key() {
+  if [ -n "${TEMP_ACCESS_KEY}" ]; then
+    echo "Deleting temporary bootstrap key ${TEMP_KEY_NAME}"
+    doctl spaces keys delete "${TEMP_ACCESS_KEY}" --force \
+      || echo "::warning::Failed to delete temporary Spaces key ${TEMP_KEY_NAME} (${TEMP_ACCESS_KEY}) — delete it manually"
+  fi
+}
+trap cleanup_temp_key EXIT
+
+TEMP_CREATED=$(doctl spaces keys create "${TEMP_KEY_NAME}" \
+  --grants "bucket=;permission=fullaccess" \
+  --output json)
+TEMP_ACCESS_KEY=$(echo "${TEMP_CREATED}" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('access_key',''))")
+TEMP_SECRET_KEY=$(echo "${TEMP_CREATED}" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('secret_key',''))")
+
+if [ -z "${TEMP_ACCESS_KEY}" ] || [ -z "${TEMP_SECRET_KEY}" ]; then
+  REDACTED=$(echo "${TEMP_CREATED}" | redact_secret_key)
+  echo "::error::Failed to create temporary Spaces key ${TEMP_KEY_NAME}"
+  echo "Response body (redacted): ${REDACTED}"
+  exit 1
+fi
+echo "::add-mask::${TEMP_SECRET_KEY}"
+
+aws configure set aws_access_key_id "${TEMP_ACCESS_KEY}" --profile dospaces-boot
+aws configure set aws_secret_access_key "${TEMP_SECRET_KEY}" --profile dospaces-boot
+
+if aws --profile dospaces-boot --endpoint-url "${ENDPOINT}" \
+     s3api head-bucket --bucket "${BUCKET_NAME}" 2>/dev/null; then
+  echo "::notice::Reusing existing Spaces bucket: ${BUCKET_NAME}"
+else
+  aws --profile dospaces-boot --endpoint-url "${ENDPOINT}" \
+    s3api create-bucket --bucket "${BUCKET_NAME}"
+  echo "::notice::Created Spaces bucket: ${BUCKET_NAME}"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "spaces_endpoint=${REGION}.digitaloceanspaces.com" >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/bootstrap-sandbox/spaces-key.sh
+++ b/scripts/bootstrap-sandbox/spaces-key.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Resolve or create the permanent DO Spaces access key for the sandbox,
+# scoped `readwrite` to BUCKET_NAME.
+#
+# Precondition: BUCKET_NAME must already exist. DO's /v2/spaces/keys rejects
+# grants that reference a non-existent bucket with "403 invalid grant". Run
+# scripts/bootstrap-sandbox/spaces-bucket.sh first.
+#
+# Idempotent: no-op when (a) both GH Secrets DO_SPACES_ACCESS_KEY and
+# DO_SPACES_SECRET_KEY are populated AND (b) the existing DO-side
+# `holomush-sandbox` key's grant matches BUCKET_NAME with `readwrite`.
+# Otherwise rotate (delete any stale key by name, create fresh) and write
+# the new access/secret to GH Secrets.
+#
+# Required env:
+#   BUCKET_NAME  Bucket to scope the grant to (must already exist)
+#   GH_TOKEN     PAT with repo and secrets:write scopes
+#   DRY_RUN      "true" to echo and exit
+#
+# Optional env (local testing):
+#   SKIP_GH_SECRET_WRITE=1   Skip `gh secret set` calls
+#
+# Outputs ($GITHUB_OUTPUT if set):
+#   access_key / secret_key
+#
+# Prerequisites: doctl (authenticated), gh (authenticated), python3.
+
+set -euo pipefail
+
+: "${BUCKET_NAME:?BUCKET_NAME must be set}"
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+: "${DRY_RUN:?DRY_RUN must be set (\"true\" or \"false\")}"
+
+KEY_NAME="holomush-sandbox"
+
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "DRY RUN: would resolve or create Spaces access key '${KEY_NAME}'"
+  exit 0
+fi
+
+# Strip `secret_key` from a DO Spaces JSON response before logging. Used on
+# error paths where the unparsed body would otherwise leak a credential.
+redact_secret_key() {
+  python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    items = d if isinstance(d, list) else [d]
+    for it in items:
+        if isinstance(it, dict) and "secret_key" in it:
+            it["secret_key"] = "***REDACTED***"
+    print(json.dumps(d))
+except Exception:
+    print("<unparseable response>")
+'
+}
+
+# Fail closed on `gh secret list` errors — a network/auth failure must not be
+# silently interpreted as "secrets missing" and push us into rotation.
+# The `|| true` guards ONLY grep's 0-match exit (1), not the gh call itself.
+SECRET_LIST=$(gh secret list --app actions)
+HAS_ACCESS_KEY=$(echo "${SECRET_LIST}" | grep -c '^DO_SPACES_ACCESS_KEY' || true)
+HAS_SECRET_KEY=$(echo "${SECRET_LIST}" | grep -c '^DO_SPACES_SECRET_KEY' || true)
+
+# Look up the server-side key and determine whether its grant still matches
+# the requested BUCKET_NAME. The operator can rerun the workflow with a
+# different bucket_name input; in that case existing DO_SPACES_* secrets
+# would be stale (scoped to the old bucket) and must be rotated.
+EXISTING_JSON=$(doctl spaces keys list --output json)
+GRANT_STATUS=$(BUCKET_NAME="${BUCKET_NAME}" KEY_NAME="${KEY_NAME}" \
+  python3 -c '
+import os, sys, json
+d = json.load(sys.stdin)
+keys = [k for k in d if k.get("name") == os.environ["KEY_NAME"]]
+if not keys:
+    print("absent")
+else:
+    grants = keys[0].get("grants", []) or []
+    ok = any(
+        g.get("bucket") == os.environ["BUCKET_NAME"]
+        and g.get("permission") == "readwrite"
+        for g in grants
+    )
+    print("match" if ok else "mismatch")
+' <<<"${EXISTING_JSON}")
+
+if [ "${HAS_ACCESS_KEY}" -gt "0" ] \
+   && [ "${HAS_SECRET_KEY}" -gt "0" ] \
+   && [ "${GRANT_STATUS}" = "match" ]; then
+  echo "::notice::DO_SPACES_ACCESS_KEY/SECRET_KEY already set and scoped to ${BUCKET_NAME} — skipping"
+  exit 0
+fi
+
+# Rotate: delete any pre-existing key by name (doctl's secret_key is never
+# returned on list, so a pre-existing key is useless to us — we must mint a
+# fresh one even when the grant already matches).
+EXISTING_ACCESS_KEY=$(KEY_NAME="${KEY_NAME}" \
+  python3 -c '
+import os, sys, json
+d = json.load(sys.stdin)
+keys = [k for k in d if k.get("name") == os.environ["KEY_NAME"]]
+print(keys[0].get("access_key", "") if keys else "")
+' <<<"${EXISTING_JSON}")
+
+if [ -n "${EXISTING_ACCESS_KEY}" ]; then
+  case "${GRANT_STATUS}" in
+    match)    echo "Existing key has correct grant but GH Secrets are missing/stale — rotating" ;;
+    mismatch) echo "Existing key is scoped to a different bucket — rotating" ;;
+  esac
+  doctl spaces keys delete "${EXISTING_ACCESS_KEY}" --force
+fi
+
+CREATED=$(doctl spaces keys create "${KEY_NAME}" \
+  --grants "bucket=${BUCKET_NAME};permission=readwrite" \
+  --output json)
+ACCESS_KEY=$(echo "${CREATED}" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('access_key',''))")
+SECRET_KEY=$(echo "${CREATED}" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); o=d[0] if isinstance(d,list) else d; print(o.get('secret_key',''))")
+
+if [ -z "${ACCESS_KEY}" ] || [ -z "${SECRET_KEY}" ]; then
+  REDACTED=$(echo "${CREATED}" | redact_secret_key)
+  echo "::error::doctl spaces keys create returned empty access/secret key"
+  echo "Response body (redacted): ${REDACTED}"
+  exit 1
+fi
+
+echo "::add-mask::${SECRET_KEY}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "access_key=${ACCESS_KEY}" >> "${GITHUB_OUTPUT}"
+  echo "secret_key=${SECRET_KEY}" >> "${GITHUB_OUTPUT}"
+fi
+
+if [ -z "${SKIP_GH_SECRET_WRITE:-}" ]; then
+  echo "${ACCESS_KEY}" | gh secret set DO_SPACES_ACCESS_KEY
+  echo "${SECRET_KEY}" | gh secret set DO_SPACES_SECRET_KEY
+  echo "::notice::Created Spaces access key '${KEY_NAME}' and stored in GH Secrets"
+else
+  echo "SKIP_GH_SECRET_WRITE set — not writing DO_SPACES_ACCESS_KEY/SECRET_KEY to GH Secrets"
+fi

--- a/site/docs/operating/sandbox-operations.md
+++ b/site/docs/operating/sandbox-operations.md
@@ -71,7 +71,7 @@ In the Cloudflare dashboard:
 
 ### 2. Create the Spaces bucket and Kopia password
 
-1. DigitalOcean → **Spaces → Create a Space** in `sfo3`, name
+1. DigitalOcean → **Spaces → Create a Space** in `nyc3`, name
    `holomush-sandbox-backups`.
 2. Generate an access key pair: **API → Spaces Keys → Generate New Key**.
 3. Save both values into GitHub Secrets as `DO_SPACES_ACCESS_KEY` and
@@ -103,7 +103,7 @@ export HOLOMUSH_INGRESS=tunnel
 export CLOUDFLARE_TUNNEL_TOKEN="..."
 export POSTGRES_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)"
 export BACKUP_S3_BUCKET=holomush-sandbox-backups
-export BACKUP_S3_ENDPOINT=sfo3.digitaloceanspaces.com
+export BACKUP_S3_ENDPOINT=nyc3.digitaloceanspaces.com
 export BACKUP_S3_ACCESS_KEY="..."
 export BACKUP_S3_SECRET_KEY="..."
 export KOPIA_PASSWORD="..."   # from KOPIA_SANDBOX_PASSWORD secret
@@ -128,7 +128,7 @@ first, then pass its ID via `--volumes` at droplet-create time:
 
 ```bash
 VOLUME_ID=$(doctl compute volume create holomush-sandbox-data \
-  --region sfo3 --size 25GiB --fs-type ext4 --format ID --no-header)
+  --region nyc3 --size 25GiB --fs-type ext4 --format ID --no-header)
 ```
 
 ### 5. Create the droplet with the volume attached at boot
@@ -137,7 +137,7 @@ VOLUME_ID=$(doctl compute volume create holomush-sandbox-data \
 doctl compute droplet create holomush-sandbox-game \
   --image ubuntu-24-04-x64 \
   --size s-2vcpu-2gb-amd \
-  --region sfo3 \
+  --region nyc3 \
   --ssh-keys "$(doctl compute ssh-key list --format ID --no-header | head -1)" \
   --tag-names holomush-sandbox \
   --volumes "${VOLUME_ID}" \
@@ -333,7 +333,7 @@ If the droplet is compromised or misconfigured beyond repair:
     doctl compute droplet create holomush-sandbox-game \
       --image ubuntu-24-04-x64 \
       --size s-2vcpu-2gb-amd \
-      --region sfo3 \
+      --region nyc3 \
       --ssh-keys "$(doctl compute ssh-key list --format ID --no-header | head -1)" \
       --tag-names holomush-sandbox \
       --volumes "${VOLUME_ID}" \

--- a/site/docs/operating/sandbox-restore.md
+++ b/site/docs/operating/sandbox-restore.md
@@ -39,7 +39,7 @@ export AWS_ACCESS_KEY_ID="<your-DO_SPACES_ACCESS_KEY>"
 export AWS_SECRET_ACCESS_KEY="<your-DO_SPACES_SECRET_KEY>"
 kopia repository connect s3 \
   --bucket=holomush-sandbox-backups \
-  --endpoint=sfo3.digitaloceanspaces.com
+  --endpoint=nyc3.digitaloceanspaces.com
 
 # Pull the chosen snapshot contents to a file
 kopia snapshot restore <snapshot-id> ./backup.sql


### PR DESCRIPTION
## Summary

Real root cause of the Bootstrap Sandbox failure at step 9 (after #258's diagnostic trace):

```
POST /v2/spaces/keys: 403 invalid grant
```

DO's API rejects a grant of `bucket=<name>;permission=readwrite` when `<name>` does not yet exist. The prior flow created the scoped key BEFORE the bucket — chicken-and-egg: the bucket can only be created via the S3-compatible API, which itself needs a Spaces key.

## Fix

- **Reorder**: bucket step runs first, key step second.
- **`spaces-bucket.sh`** mints an ephemeral `fullaccess` key via `doctl`, uses it with `aws s3api` to HEAD-or-CREATE the bucket, then deletes that key. Temp key is cleaned up even on error via `trap EXIT`.
- **`spaces-key.sh`** mints the permanent key scoped `bucket=<BUCKET_NAME>;permission=readwrite` — now succeeds because the bucket exists.

The permanent key is tightly scoped; the only account-wide credential (`fullaccess`) is short-lived and bounded to this one step.

## Extraction to scripts

Both step bodies move to [`scripts/bootstrap-sandbox/`](./scripts/bootstrap-sandbox/). This was planned as a follow-up but is bundled here because rewriting the inline YAML would have been a similarly large diff and the script form is meaningfully easier to exercise locally (see README).

- `spaces-bucket.sh` — bucket provisioning with temp-key dance
- `spaces-key.sh` — permanent key provisioning
- `README.md` — conventions + local-run instructions, including `SKIP_GH_SECRET_WRITE=1` so local runs don't mutate repo secrets

## Diagnostic scaffolding removal

PR #258 (unmerged) added `set -x` + `doctl --verbose` to track down this bug. That PR can be closed — this PR supersedes it; the trace has served its purpose and the real fix makes it unnecessary.

## Test plan

- [x] \`shellcheck scripts/bootstrap-sandbox/*.sh\` — clean
- [x] \`task lint:actions\` / \`task lint:yaml\` — clean
- [x] \`task pr-prep\` — full run green (\`✓ All PR checks passed.\`)
- [ ] **Operator after merge**: re-dispatch \`Bootstrap Sandbox\`. Expected flow: bucket step mints temp key → creates bucket → deletes temp key → key step mints scoped permanent key → stored in GH secrets. Downstream volume/firewall/droplet steps proceed as before

## Local testing (answers "how do we test this locally?")

```bash
doctl auth init
export BUCKET_NAME=holomush-sandbox-backups
export REGION=sfo3
export DRY_RUN=false
./scripts/bootstrap-sandbox/spaces-bucket.sh

export GH_TOKEN=\"\$(gh auth token)\"
export SKIP_GH_SECRET_WRITE=1
./scripts/bootstrap-sandbox/spaces-key.sh
```

Set \`DRY_RUN=true\` for logic-only testing with no API calls.

## Beads

- holomush-a6zi (this PR)
- holomush-7ugz (original sandbox blocker — should be closable once bootstrap reaches the verify step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split sandbox provisioning into distinct bucket and scoped-key steps, improving reliability, idempotence, safer credential handling, and local dry-run testing.

* **Documentation**
  * Added a bootstrap guide documenting per-step execution, prerequisites, dry-run/testing, fail-fast conventions, and cleanup guidance.
  * Updated sandbox operating and restore docs to use the nyc3 region and corresponding endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->