### PR TITLE
fix(sandbox): firewall step uses doctl + extract to scripts; pin doctl/action versions

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -68,11 +68,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Step 1: Install doctl
+      # Step 1: Install doctl. Pin both the action and binary versions:
+      # - action @v2 was a moving tag; pin to a specific release for determinism.
+      # - doctl `version: latest` honored the runner toolcache hit, which on
+      #   Namespace runners was stuck at v1.98.1 (no `doctl spaces` subcommand).
+      #   1.155.0 has every subcommand the bootstrap scripts need.
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          version: "1.155.0"
 
       # Step 2: Configure gh CLI with SECRETS_ADMIN_PAT
       - name: Configure gh CLI
@@ -250,66 +255,16 @@ jobs:
             echo "volume_id=${VOLUME_ID}" >> "$GITHUB_OUTPUT"
           fi
 
-      # Step 9: Resolve or create DO cloud firewall
-      # Uses the DO REST API directly — doctl's --inbound-rules expects a DSL
-      # string (not JSON) and the firewall-sandbox.json shape matches the API
-      # contract after stripping the "comment" fields (not accepted by DO API).
+      # Body lives in scripts/bootstrap-sandbox/firewall.sh — translates the
+      # committed firewall-sandbox.json into doctl's inbound/outbound DSL and
+      # creates (or reuses) the firewall.
       - name: Resolve or create DO cloud firewall
         id: firewall
         env:
-          DO_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           FW_NAME: holomush-sandbox
           DRY_RUN: ${{ inputs.dry_run }}
           SSH_ALLOWLIST: ${{ inputs.ssh_allowlist_cidrs }}
-        run: |
-          set -euo pipefail
-
-          # Required input; fail fast if the operator didn't supply one.
-          if [ -z "${SSH_ALLOWLIST// /}" ]; then
-            echo "::error::ssh_allowlist_cidrs is required — supply one or more CIDRs (e.g. 203.0.113.5/32)"
-            exit 1
-          fi
-
-          # Check for existing firewall by name
-          EXISTING_FW_ID=$(curl -fsS \
-            -H "Authorization: Bearer ${DO_TOKEN}" \
-            "https://api.digitalocean.com/v2/firewalls?per_page=200" \
-            | python3 -c "
-          import sys,json
-          d=json.load(sys.stdin)
-          fws=[f for f in d.get('firewalls',[]) if f.get('name')=='${FW_NAME}']
-          print(fws[0]['id'] if fws else '')
-          " 2>/dev/null || true)
-
-          if [ -n "${EXISTING_FW_ID}" ]; then
-            echo "::notice::Reusing existing firewall: ${FW_NAME} (${EXISTING_FW_ID})"
-            FW_ID="${EXISTING_FW_ID}"
-          elif [ "${DRY_RUN}" = "true" ]; then
-            echo "::notice::[dry-run] Would create firewall ${FW_NAME} (SSH allowlist: ${SSH_ALLOWLIST})"
-            FW_ID="dry-run-fw-id"
-          else
-            # Strip "comment" fields (DO API rejects them) and apply the
-            # operator-supplied SSH CIDR allowlist in place of the file's
-            # default 0.0.0.0/0, per CodeRabbit review.
-            FW_JSON=$(python3 -c "
-          import json, os
-          ssh_cidrs=[c.strip() for c in os.environ['SSH_ALLOWLIST'].split(',') if c.strip()]
-          fw=json.load(open('deploy/doctl/firewall-sandbox.json'))
-          for r in fw.get('inbound_rules',[]):
-              r.pop('comment',None)
-              if r.get('protocol')=='tcp' and r.get('ports')=='22':
-                  r['sources']={'addresses': ssh_cidrs}
-          print(json.dumps(fw))
-          ")
-            FW_ID=$(curl -fsS -X POST \
-              -H "Authorization: Bearer ${DO_TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d "${FW_JSON}" \
-              "https://api.digitalocean.com/v2/firewalls" \
-              | python3 -c "import sys,json; print(json.load(sys.stdin)['firewall']['id'])")
-            echo "::notice::Created firewall: ${FW_NAME} (${FW_ID}, SSH allowlist: ${SSH_ALLOWLIST})"
-          fi
-          echo "firewall_id=${FW_ID}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/bootstrap-sandbox/firewall.sh
 
       # Step 10: Generate POSTGRES_PASSWORD (ephemeral — lives on droplet only)
       - name: Generate POSTGRES_PASSWORD
@@ -528,40 +483,13 @@ jobs:
             echo "::notice::Attached volume ${VOLUME_ID} to droplet ${DROPLET_ID}"
           fi
 
-      # Step 14: Apply firewall to droplet
+      # Body lives in scripts/bootstrap-sandbox/firewall-attach.sh.
       - name: Apply firewall to droplet
         env:
-          DO_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           FIREWALL_ID: ${{ steps.firewall.outputs.firewall_id }}
           DROPLET_ID: ${{ steps.droplet.outputs.droplet_id }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-
-          # Check if firewall is already applied to this droplet
-          ALREADY_APPLIED=$(curl -fsS \
-            -H "Authorization: Bearer ${DO_TOKEN}" \
-            "https://api.digitalocean.com/v2/firewalls/${FIREWALL_ID}" \
-            | python3 -c "
-          import sys,json
-          d=json.load(sys.stdin)
-          ids=d.get('firewall',{}).get('droplet_ids',[])
-          droplet_id=int('${DROPLET_ID}') if '${DROPLET_ID}'.isdigit() else None
-          print('yes' if droplet_id in ids else '')
-          " 2>/dev/null || true)
-
-          if [ -n "${ALREADY_APPLIED}" ]; then
-            echo "::notice::Firewall already applied to droplet ${DROPLET_ID}"
-          elif [ "${DRY_RUN}" = "true" ]; then
-            echo "::notice::[dry-run] Would apply firewall ${FIREWALL_ID} to droplet ${DROPLET_ID}"
-          else
-            curl -fsS -X POST \
-              -H "Authorization: Bearer ${DO_TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d "{\"droplet_ids\":[${DROPLET_ID}]}" \
-              "https://api.digitalocean.com/v2/firewalls/${FIREWALL_ID}/droplets"
-            echo "::notice::Applied firewall ${FIREWALL_ID} to droplet ${DROPLET_ID}"
-          fi
+        run: ./scripts/bootstrap-sandbox/firewall-attach.sh
 
       # Step 15: Wait for cloud-init to finish
       - name: Wait for cloud-init

--- a/scripts/bootstrap-sandbox/README.md
+++ b/scripts/bootstrap-sandbox/README.md
@@ -11,10 +11,12 @@ The workflow YAML and scripts stay in sync as each step is extracted.
 
 ## Currently extracted
 
-| Order | Script              | Responsibility                                           |
-| ----- | ------------------- | -------------------------------------------------------- |
-| 1     | `spaces-bucket.sh`  | Ensure the DO Spaces bucket exists (temp-key dance)      |
-| 2     | `spaces-key.sh`     | Mint a permanent readwrite key scoped to the bucket      |
+| Order | Script                | Responsibility                                                       |
+| ----- | --------------------- | -------------------------------------------------------------------- |
+| 1     | `spaces-bucket.sh`    | Ensure the DO Spaces bucket exists (temp-key dance)                  |
+| 2     | `spaces-key.sh`       | Mint a permanent readwrite key scoped to the bucket                  |
+| 3     | `firewall.sh`         | Resolve or create the cloud firewall (translates JSON → doctl DSL)   |
+| 4     | `firewall-attach.sh`  | Idempotently attach the firewall to the droplet                      |
 
 The bucket must be created before the key because DO's `/v2/spaces/keys`
 rejects grants whose bucket does not exist (`403 invalid grant`). Since

--- a/scripts/bootstrap-sandbox/firewall-attach.sh
+++ b/scripts/bootstrap-sandbox/firewall-attach.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Attach the cloud firewall to the droplet, idempotently.
+#
+# Required env:
+#   FIREWALL_ID  ID of the firewall (from scripts/bootstrap-sandbox/firewall.sh)
+#   DROPLET_ID   ID of the droplet to attach
+#   DRY_RUN      "true" to echo and exit
+#
+# Prerequisites: doctl (authenticated).
+
+set -euo pipefail
+
+: "${FIREWALL_ID:?FIREWALL_ID must be set}"
+: "${DROPLET_ID:?DROPLET_ID must be set}"
+: "${DRY_RUN:?DRY_RUN must be set}"
+
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "::notice::[dry-run] Would apply firewall ${FIREWALL_ID} to droplet ${DROPLET_ID}"
+  exit 0
+fi
+
+# `doctl compute firewall get --format DropletIDs` returns the column with a
+# bracketed list (e.g. `[12345 67890]`). Check membership textually.
+APPLIED_DROPLET_IDS=$(doctl compute firewall get "${FIREWALL_ID}" \
+  --format DropletIDs --no-header)
+
+# Match the droplet ID as a whole token to avoid 1234 matching 12345.
+if echo "${APPLIED_DROPLET_IDS}" | grep -qE "(^|[[:space:]\\[])${DROPLET_ID}([[:space:]\\]]|$)"; then
+  echo "::notice::Firewall already applied to droplet ${DROPLET_ID}"
+else
+  doctl compute firewall add-droplets "${FIREWALL_ID}" --droplet-ids "${DROPLET_ID}"
+  echo "::notice::Applied firewall ${FIREWALL_ID} to droplet ${DROPLET_ID}"
+fi

--- a/scripts/bootstrap-sandbox/firewall.sh
+++ b/scripts/bootstrap-sandbox/firewall.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Resolve or create the DigitalOcean cloud firewall used by the sandbox.
+#
+# Idempotent: if a firewall named ${FW_NAME} already exists, reuse it.
+# Otherwise translate `deploy/doctl/firewall-sandbox.json` into doctl's
+# inbound/outbound DSL and create it. The committed JSON ships a placeholder
+# `127.0.0.1/32` for the SSH source; the operator's actual SSH allowlist
+# (SSH_ALLOWLIST env, comma-separated CIDRs) replaces that on creation.
+#
+# Required env:
+#   FW_NAME         Firewall name (e.g. holomush-sandbox)
+#   SSH_ALLOWLIST   Comma-separated CIDRs allowed to reach SSH (port 22).
+#                   Operator-specified — empty is rejected.
+#   DRY_RUN         "true" to echo and exit
+#
+# Outputs ($GITHUB_OUTPUT if set):
+#   firewall_id  ID of the resolved or created firewall
+#
+# Prerequisites: doctl (authenticated, >= v1.110 for current DSL semantics),
+#                python3.
+
+set -euo pipefail
+
+: "${FW_NAME:?FW_NAME must be set}"
+: "${SSH_ALLOWLIST:?SSH_ALLOWLIST must be set (comma-separated CIDRs)}"
+: "${DRY_RUN:?DRY_RUN must be set (\"true\" or \"false\")}"
+
+if [ -z "${SSH_ALLOWLIST// /}" ]; then
+  echo "::error::SSH_ALLOWLIST must contain at least one CIDR (e.g. 203.0.113.5/32)"
+  exit 1
+fi
+
+# Look up by name. doctl exits non-zero on auth/scope errors, so set -e
+# aborts loudly instead of silently masking with || true.
+EXISTING_FW_ID=$(doctl compute firewall list --format Name,ID --no-header \
+  | awk -v name="${FW_NAME}" '$1==name {print $2; exit}')
+
+if [ -n "${EXISTING_FW_ID}" ]; then
+  echo "::notice::Reusing existing firewall: ${FW_NAME} (${EXISTING_FW_ID})"
+  FW_ID="${EXISTING_FW_ID}"
+elif [ "${DRY_RUN}" = "true" ]; then
+  echo "::notice::[dry-run] Would create firewall ${FW_NAME} (SSH allowlist: ${SSH_ALLOWLIST})"
+  FW_ID="dry-run-fw-id"
+else
+  # Build doctl's --inbound-rules / --outbound-rules DSL from the committed
+  # JSON. The DSL is space-separated rules, each a comma-separated list of
+  # key:value pairs (protocol, ports, address — `address:` repeated per CIDR).
+  IN_RULES=$(SSH_ALLOWLIST="${SSH_ALLOWLIST}" python3 -c '
+import json, os
+ssh = [c.strip() for c in os.environ["SSH_ALLOWLIST"].split(",") if c.strip()]
+fw = json.load(open("deploy/doctl/firewall-sandbox.json"))
+parts = []
+for r in fw.get("inbound_rules", []):
+    proto = r.get("protocol")
+    ports = r.get("ports")
+    addrs = list((r.get("sources") or {}).get("addresses", []))
+    if proto == "tcp" and ports == "22":
+        addrs = ssh
+    rp = [f"protocol:{proto}"]
+    if ports is not None:
+        rp.append(f"ports:{ports}")
+    rp += [f"address:{a}" for a in addrs]
+    parts.append(",".join(rp))
+print(" ".join(parts))
+')
+
+  OUT_RULES=$(python3 -c '
+import json
+fw = json.load(open("deploy/doctl/firewall-sandbox.json"))
+parts = []
+for r in fw.get("outbound_rules", []):
+    proto = r.get("protocol")
+    ports = r.get("ports")
+    addrs = list((r.get("destinations") or {}).get("addresses", []))
+    rp = [f"protocol:{proto}"]
+    if ports is not None:
+        rp.append(f"ports:{ports}")
+    rp += [f"address:{a}" for a in addrs]
+    parts.append(",".join(rp))
+print(" ".join(parts))
+')
+
+  FW_ID=$(doctl compute firewall create \
+    --name "${FW_NAME}" \
+    --inbound-rules "${IN_RULES}" \
+    --outbound-rules "${OUT_RULES}" \
+    --tag-names "${FW_NAME}" \
+    --format ID --no-header)
+
+  if [ -z "${FW_ID}" ]; then
+    echo "::error::doctl compute firewall create returned empty ID"
+    exit 1
+  fi
+  echo "::notice::Created firewall: ${FW_NAME} (${FW_ID}, SSH allowlist: ${SSH_ALLOWLIST})"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "firewall_id=${FW_ID}" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary

Bootstrap Sandbox run [24917851691](https://github.com/holomush/holomush/actions/runs/24917851691) failed at the firewall step with 403, then the unrelated re-run failed at \`spaces-bucket.sh\` with \`Error: unknown command "spaces" for "doctl"\`. Two distinct underlying issues addressed:

### 1. action-doctl was installing v1.98.1, not latest

\`digitalocean/action-doctl@v2\` with \`version: latest\` honored the Namespace runner's toolcache hit, which was stuck at v1.98.1 — predates the \`doctl spaces\` subcommand. Pinned both:

- Action: \`@v2\` → \`@v2.5.2\` (the moving \`v2\` tag is non-deterministic; latest release on this date)
- Binary: \`version: latest\` → \`version: "1.155.0"\` (latest stable; has every subcommand the bootstrap scripts need)

### 2. Firewall step was raw curl with swallowed errors

The step did \`curl ... | python3 ... 2>/dev/null || true\` so a 403 from \`GET /v2/firewalls\` produced an empty body, then python crashed on \`JSONDecodeError\` and the step exited with no useful diagnostic. Converted to \`doctl compute firewall list/create\` + extracted to scripts following the established pattern from \`spaces-bucket.sh\` / \`spaces-key.sh\`:

- New \`scripts/bootstrap-sandbox/firewall.sh\` — translates committed \`deploy/doctl/firewall-sandbox.json\` into doctl's \`--inbound-rules\`/\`--outbound-rules\` DSL and creates (or reuses) the firewall.
- New \`scripts/bootstrap-sandbox/firewall-attach.sh\` — uses \`doctl compute firewall add-droplets\` + \`doctl compute firewall get --format DropletIDs\` for the idempotent attach.

Workflow step bodies become single-line script invocations. Net: \`bootstrap-sandbox.yaml\` -90 lines, \`scripts/bootstrap-sandbox/\` +138 lines.

### Why doctl over curl

Per direction \"use doctl for everything we possibly can\":

- doctl exits non-zero on auth/scope errors so \`set -e\` aborts loudly with the real error, no \`|| true\` masking.
- Auth handled once at install time; no per-step token plumbing.
- doctl validates flags + grant enums up front (this is what caught the original \`read_write\` typo on PR #256).

Remaining curl uses in this workflow are all Cloudflare-API (no doctl equivalent) or the final \`/healthz\` smoke test.

## Test plan

- [x] \`task lint:actions\`, \`task lint:yaml\` — clean
- [x] \`shellcheck scripts/bootstrap-sandbox/*.sh\` — clean
- [x] DSL generator unit-tested locally with \`SSH_ALLOWLIST\` substitution; \`icmp\` rule correctly drops the \`ports:\` field
- [ ] **Operator after merge**: re-dispatch \`Bootstrap Sandbox\` workflow. The firewall step should now (a) install doctl 1.155.0 (b) call \`doctl compute firewall list\` (c) emit a real DO error if the token still lacks scope (d) succeed if the token has firewall:read+write

## Pre-existing flake noted

\`task test:e2e\` reproduced \`Terminal UI › Cmd+K opens palette, Escape closes it\` failing twice in a row locally — this PR doesn't touch web/, the failure is pre-existing and now blocking. Tracked in \`holomush-ceon\` (bumped to P1).

## Beads

- holomush-0l3i (this PR)
- holomush-ceon (Cmd+K E2E flake — bumped to P1, unrelated to this work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Pinned critical dependency versions for more reliable and reproducible sandbox bootstrapping
* Refactored firewall management into dedicated idempotent helper scripts for improved maintainability  
* Introduced dry-run mode support for sandbox firewall operations to validate changes before applying them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->