### PR TITLE
fix(sandbox): drop --tag-names from firewall create

### DIFF
--- a/scripts/bootstrap-sandbox/firewall.sh
+++ b/scripts/bootstrap-sandbox/firewall.sh
@@ -83,11 +83,15 @@ for r in fw.get("outbound_rules", []):
 print(" ".join(parts))
 ')
 
+  # NB: do NOT pass --tag-names. DO requires the tag to pre-exist (returns
+  # 422 "tag X does not exist" on a fresh account). Our flow attaches the
+  # firewall to the droplet explicitly via firewall-attach.sh, so a tag on
+  # the firewall is redundant. The droplet uses --tag-names separately —
+  # `doctl compute droplet create --tag-names X` auto-creates X.
   FW_ID=$(doctl compute firewall create \
     --name "${FW_NAME}" \
     --inbound-rules "${IN_RULES}" \
     --outbound-rules "${OUT_RULES}" \
-    --tag-names "${FW_NAME}" \
     --format ID --no-header)
 
   if [ -z "${FW_ID}" ]; then


### PR DESCRIPTION
## Summary

Bootstrap Sandbox run [24920940987](https://github.com/holomush/holomush/actions/runs/24920940987) failed at the firewall step with — for the first time — a clean, properly-surfaced API error (the doctl conversion in #261 worked):

```
Error: POST /v2/firewalls: 422 tag holomush-sandbox does not exist
```

`firewall.sh` was passing `--tag-names "${FW_NAME}"` on create, but DigitalOcean requires the tag to **already exist** before it can be applied (returns 422 if not). On a fresh account, the tag has never been created.

## Fix

Drop `--tag-names` from the `doctl compute firewall create` invocation. Our flow uses `firewall-attach.sh` (explicit `doctl compute firewall add-droplets`) for the droplet↔firewall association, so a tag on the firewall is redundant. The droplet's own `--tag-names` flag (in step 14) auto-creates the tag — so it's available for any future tag-based filtering — but the firewall doesn't need it.

Comment in the script explains this so it doesn't get re-added.

## Test plan

- [x] `task lint:actions`, `task lint:yaml` — clean
- [x] `shellcheck scripts/bootstrap-sandbox/firewall.sh` — clean
- [x] `task pr-prep` — full run green (`✓ All PR checks passed.`)
- [ ] **Operator after merge**: re-dispatch `Bootstrap Sandbox`. Firewall step should now create successfully; flow continues to droplet/cloud-init.

## Beads

- holomush-5i20 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where firewall creation would fail with a "tag does not exist" error on fresh accounts. Tag attachment is now handled separately through the droplet attachment flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->