### PR TITLE
fix(sandbox): track main by default; decouple REF/VERSION; better cloud-init diagnostics

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -87,7 +87,71 @@ jobs:
           set -euo pipefail
           gh auth setup-git
 
-      # Step 3: Resolve or create KOPIA_SANDBOX_PASSWORD secret
+      # Step 3: Resolve sandbox source ref + image tag, and verify the GHCR
+      # image actually exists. Runs BEFORE any paid resource (volume, droplet)
+      # is created so a missing :latest / :version image fails fast with a
+      # clear error instead of leaving an unused volume + droplet behind.
+      - name: Resolve image ref and verify GHCR tag exists
+        id: image
+        env:
+          GH_TOKEN: ${{ secrets.SECRETS_ADMIN_PAT }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Identical resolution logic to scripts/cloud-init.sh:
+          #   HOLOMUSH_REF      → source ref for raw.githubusercontent.com
+          #   HOLOMUSH_VERSION  → docker image tag pulled from ghcr.io
+          # Latest GitHub release tag if one exists; else REF=main + VERSION=latest.
+          HOLOMUSH_REF=$(gh release list -R holomush/holomush --limit 10 --json tagName,isLatest \
+            --jq '.[] | select(.isLatest) | .tagName' 2>/dev/null | head -1 || true)
+          if [ -z "${HOLOMUSH_REF}" ]; then
+            HOLOMUSH_REF=$(gh release list -R holomush/holomush --limit 1 --json tagName \
+              --jq '.[0].tagName' 2>/dev/null || true)
+          fi
+          if [ -z "${HOLOMUSH_REF}" ]; then
+            HOLOMUSH_REF="main"
+            HOLOMUSH_VERSION="latest"
+          else
+            HOLOMUSH_VERSION="${HOLOMUSH_REF#v}"
+          fi
+
+          echo "::notice::Will deploy ref=${HOLOMUSH_REF} image=ghcr.io/holomush/holomush:${HOLOMUSH_VERSION}"
+          echo "holomush_ref=${HOLOMUSH_REF}" >> "$GITHUB_OUTPUT"
+          echo "holomush_version=${HOLOMUSH_VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "[dry-run] skipping GHCR manifest probe"
+            exit 0
+          fi
+
+          # Probe GHCR for the manifest. Public-image pull flow: fetch a
+          # short-lived anonymous token, then HEAD the manifest endpoint.
+          # 200 = exists; 404 = missing tag; anything else = unexpected error.
+          TOKEN=$(curl -fsS \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:holomush/holomush:pull" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))")
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::Could not fetch GHCR pull token"
+            exit 1
+          fi
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/holomush/holomush/manifests/${HOLOMUSH_VERSION}")
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "::error::Image ghcr.io/holomush/holomush:${HOLOMUSH_VERSION} not found in GHCR (HTTP ${HTTP_CODE})."
+            echo "::error::Either cut a release first (merge the release-please PR so goreleaser publishes the image), or pass HOLOMUSH_REF/HOLOMUSH_VERSION pointing to an existing tag."
+            exit 1
+          fi
+          echo "::notice::GHCR manifest verified (HTTP 200)"
+
+      # Step 4: Resolve or create KOPIA_SANDBOX_PASSWORD secret
       # Emits `password` as a step output so step 11 can reference the freshly
       # generated value on the first-run path — `secrets.KOPIA_SANDBOX_PASSWORD`
       # is a snapshot taken at workflow-start and does not see secrets created
@@ -284,6 +348,9 @@ jobs:
           BUCKET_NAME: ${{ inputs.bucket_name }}
           REGION: ${{ inputs.region }}
           DRY_RUN: ${{ inputs.dry_run }}
+          # REF + VERSION are computed and verified by the early `image` step.
+          HOLOMUSH_REF: ${{ steps.image.outputs.holomush_ref }}
+          HOLOMUSH_VERSION: ${{ steps.image.outputs.holomush_version }}
           TUNNEL_TOKEN: ${{ steps.tunnel.outputs.tunnel_token }}
           PG_PASSWORD: ${{ steps.pg.outputs.password }}
           # KOPIA and Spaces secrets fall back to the secrets context when
@@ -305,17 +372,12 @@ jobs:
           echo "::add-mask::${KOPIA_PASSWORD}"
           echo "::add-mask::${BACKUP_S3_SECRET_KEY_VAL}"
 
-          HOLOMUSH_VERSION=$(gh release list -R holomush/holomush --limit 10 --json tagName,isLatest \
-            --jq '.[] | select(.isLatest) | .tagName' 2>/dev/null | head -1 || true)
-          if [ -z "${HOLOMUSH_VERSION}" ]; then
-            HOLOMUSH_VERSION=$(gh release list -R holomush/holomush --limit 1 --json tagName \
-              --jq '.[0].tagName' 2>/dev/null || echo "0.1.0")
-          fi
-          # scripts/cloud-init.sh prepends "v" when building RELEASE_URL, so
-          # strip any leading "v" here to avoid "vv0.1.0" double-prefix.
-          HOLOMUSH_VERSION="${HOLOMUSH_VERSION#v}"
+          # HOLOMUSH_REF and HOLOMUSH_VERSION arrive from the `image` step's
+          # outputs, where they were also probed against GHCR before any paid
+          # resource was created. Trust them here; do not recompute.
 
           python3 - \
+            "${HOLOMUSH_REF}" \
             "${HOLOMUSH_VERSION}" \
             "${DOMAIN}" \
             "${TUNNEL_TOKEN}" \
@@ -328,15 +390,16 @@ jobs:
             <<'PYEOF'
           import sys
 
-          version        = sys.argv[1]
-          domain         = sys.argv[2]
-          cf_token       = sys.argv[3]
-          pg_pwd         = sys.argv[4]
-          bucket         = sys.argv[5]
-          region         = sys.argv[6]
-          kopia_pwd      = sys.argv[7]
-          s3_access_key  = sys.argv[8]
-          s3_secret_key  = sys.argv[9]
+          ref            = sys.argv[1]
+          version        = sys.argv[2]
+          domain         = sys.argv[3]
+          cf_token       = sys.argv[4]
+          pg_pwd         = sys.argv[5]
+          bucket         = sys.argv[6]
+          region         = sys.argv[7]
+          kopia_pwd      = sys.argv[8]
+          s3_access_key  = sys.argv[9]
+          s3_secret_key  = sys.argv[10]
 
           cloud_config = """\
           #cloud-config
@@ -358,6 +421,7 @@ jobs:
           env_header = f"""\
           #!/bin/bash
           # env injected by bootstrap-sandbox workflow
+          export HOLOMUSH_REF="{ref}"
           export HOLOMUSH_VERSION="{version}"
           export HOLOMUSH_DOMAIN="{domain}"
           export HOLOMUSH_INGRESS="tunnel"
@@ -527,11 +591,28 @@ jobs:
           ssh-keyscan -H "${DROPLET_IP}" >> ~/.ssh/known_hosts 2>/dev/null
 
           echo "Waiting for cloud-init to complete..."
-          ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
-            "cloud-init status --wait --long" \
-            || { ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
-                   "cloud-init status; journalctl -u cloud-init-local -u cloud-init --no-pager -n 50" \
-                 && exit 1; }
+          if ! ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
+                 "cloud-init status --wait --long"; then
+            # On failure, surface the *user-data script* output (where part-002
+            # errors actually live) plus modern systemd unit logs. The legacy
+            # unit names cloud-init-local/cloud-init don't exist on Ubuntu 24.04;
+            # use the ".target" form so journalctl picks up cloud-config,
+            # cloud-final, etc., regardless of which one logged the error.
+            echo "::group::cloud-init-output.log (last 200 lines)"
+            ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
+              "tail -n 200 /var/log/cloud-init-output.log || true"
+            echo "::endgroup::"
+            echo "::group::cloud-init.log (last 100 lines)"
+            ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
+              "tail -n 100 /var/log/cloud-init.log || true"
+            echo "::endgroup::"
+            echo "::group::journalctl cloud-init.target (last 100 lines)"
+            ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" \
+              "journalctl --no-pager -n 100 -u 'cloud-init*' || true"
+            echo "::endgroup::"
+            ssh -o StrictHostKeyChecking=no "root@${DROPLET_IP}" "cloud-init status --long || true"
+            exit 1
+          fi
           echo "::notice::cloud-init completed successfully"
 
       # Step 16: Create Cloudflare DNS records

--- a/scripts/cloud-init.sh
+++ b/scripts/cloud-init.sh
@@ -13,9 +13,34 @@ set -euo pipefail
 
 HOLOMUSH_DIR="/opt/holomush"
 HOLOMUSH_USER="holomush"
-# Set this to the release you want to deploy (e.g., "0.1.0").
-HOLOMUSH_VERSION="${HOLOMUSH_VERSION:-0.1.0}"
-RELEASE_URL="https://raw.githubusercontent.com/holomush/holomush/v${HOLOMUSH_VERSION}"
+# Source ref to fetch compose files and config from. Any git ref works:
+#   - branch  (e.g. "main", "develop") — sandbox tracking-mode
+#   - tag     (e.g. "v0.1.0") — pinned production deployment
+#   - commit  (e.g. "abc1234") — exact reproduce
+# Default is "main" so a fresh sandbox boots from the latest committed code
+# rather than depending on a released tag that may not exist yet.
+# Backward-compat: legacy callers that only set HOLOMUSH_VERSION map to a
+# matching v-prefixed ref. `latest` is special-cased — it's a docker image
+# tag, not a git ref — so it resolves to `main`. Idempotent on a leading "v"
+# (so HOLOMUSH_VERSION=v0.1.0 doesn't double-prefix).
+if [ -z "${HOLOMUSH_REF:-}" ]; then
+  case "${HOLOMUSH_VERSION:-}" in
+    ""|latest) HOLOMUSH_REF="main" ;;
+    *)         HOLOMUSH_REF="v${HOLOMUSH_VERSION#v}" ;;
+  esac
+fi
+# HOLOMUSH_VERSION is the docker image tag (separate concept from the source
+# ref above). If unset (e.g. standalone runs that only specify HOLOMUSH_REF),
+# derive it from the ref: a vX.Y.Z tag drops the leading "v" to match the
+# image tag goreleaser publishes; anything else (branch/sha) falls back to
+# the floating `latest` tag.
+if [ -z "${HOLOMUSH_VERSION:-}" ]; then
+  case "${HOLOMUSH_REF}" in
+    v[0-9]*) HOLOMUSH_VERSION="${HOLOMUSH_REF#v}" ;;
+    *)       HOLOMUSH_VERSION="latest" ;;
+  esac
+fi
+RELEASE_URL="https://raw.githubusercontent.com/holomush/holomush/${HOLOMUSH_REF}"
 
 # Ingress mode: "caddy" (default, public 80/443 with Let's Encrypt) or
 # "tunnel" (cloudflared, no public HTTP ports).

--- a/site/docs/operating/sandbox-operations.md
+++ b/site/docs/operating/sandbox-operations.md
@@ -97,7 +97,8 @@ From your local machine:
 ```bash
 # Render user-data from scripts/sandbox.env.example + real secrets,
 # then merge with scripts/cloud-init.sh as user-data.
-export HOLOMUSH_VERSION=0.1.0  # without leading "v" — cloud-init prepends it
+export HOLOMUSH_REF=v0.1.0     # source ref for cloud-init (tag/branch/sha; defaults to "main")
+export HOLOMUSH_VERSION=0.1.0  # docker image tag pulled from ghcr.io (without "v")
 export HOLOMUSH_DOMAIN=game.holomush.dev
 export HOLOMUSH_INGRESS=tunnel
 export CLOUDFLARE_TUNNEL_TOKEN="..."


### PR DESCRIPTION
## Summary

Sandbox bootstrap run [24921183654](https://github.com/holomush/holomush/actions/runs/24921183654) progressed past the firewall step (#262) and hit cloud-init failure on the droplet. The workflow's `Wait for cloud-init` step printed `-- No entries --` from journalctl, so the actual error was invisible from CI logs.

I SSH'd into the droplet and tailed `/var/log/cloud-init-output.log`:

```
Creating /opt/holomush...
Downloading compose files...
curl: (22) The requested URL returned error: 404
```

`scripts/cloud-init.sh` was fetching `https://raw.githubusercontent.com/holomush/holomush/v0.1.0/compose.prod.yaml`, which 404s because no `v0.1.0` tag has been cut yet (release-please PR #7 still open). The render step's "fall back to 0.1.0 if no release exists" path predicted a tag that never existed.

## Fix

Three orthogonal changes:

### 1. Decouple source ref from image tag

These were conflated in a single `HOLOMUSH_VERSION` variable doing two jobs:

- **`HOLOMUSH_REF`** — source ref (tag/branch/sha) for cloud-init's `raw.githubusercontent.com` fetch of compose files. Now accepts anything git understands. Defaults to `main` so a fresh sandbox can boot off the trunk without a release first.
- **`HOLOMUSH_VERSION`** — docker image tag pulled by `compose.prod.yaml` from `ghcr.io/holomush/holomush`. Defaults to `latest`.

When a GitHub release exists, both come from the release tag (REF=`v0.1.0`, VERSION=`0.1.0`). When no release exists, fallback is REF=`main` + VERSION=`latest`.

`cloud-init.sh` accepts `HOLOMUSH_REF` directly with backward-compat: an existing `HOLOMUSH_VERSION` env still works via implicit `v${VERSION}` translation.

### 2. Cloud-init failure diagnostic

Step 15's failure path was using legacy systemd unit names that don't exist on Ubuntu 24.04, so journalctl returned nothing. Updated to:

- Tail `/var/log/cloud-init-output.log` (last 200 lines) — the **canonical place user-data script output lands**, including stdout/stderr from `scripts/cloud-init.sh`. This alone would have made today's hour-long debug a 5-second read.
- Tail `/var/log/cloud-init.log` (last 100 lines).
- `journalctl -u 'cloud-init*'` (pattern match) — picks up `cloud-final`, `cloud-config`, etc. on any cloud-init version.
- All wrapped in `::group::` annotations so they collapse cleanly in the GH Actions UI.

### 3. Removed misleading hard-coded fallback

The render step's `|| echo "0.1.0"` predicted a tag that never existed. Replaced with explicit `main`-fallback + `latest`-image, with a comment explaining the dependency: even with this fallback, the operator still needs **at least one release to have run goreleaser** so the `:latest` GHCR image is published.

## Operator note

This PR makes the sandbox's source-fetch path graceful when no release exists, but the docker image side still requires a published `:latest` (or specific version tag). Currently neither exists. Path forward:

- **Merge release-please PR #7** → `v0.1.0` tag → goreleaser publishes `ghcr.io/holomush/holomush:0.1.0` AND `:latest` → sandbox boots cleanly via either tracking-mode or pinned-mode.

## Test plan

- [x] `task lint:actions`, `task lint:yaml` — clean
- [x] `shellcheck scripts/cloud-init.sh` — no new findings (one pre-existing SC1091 info on `/etc/os-release` source-following, unchanged)
- [x] Local unit-test of REF resolution: 5 cases (unset/REF/legacy-VERSION/REF-overrides-VERSION/sha-ref) all resolve as expected
- [x] `task pr-prep` — green (`✓ All PR checks passed.`)
- [ ] **Operator after merge**: merge release-please PR #7, then re-dispatch Bootstrap Sandbox. Or, if you prefer to keep tracking main: ensure a release has run goreleaser at least once so `:latest` exists on GHCR

## Bead

- holomush-v40m (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added image verification step to validate Docker images exist before sandbox bootstrap, preventing deployment failures.

* **Bug Fixes**
  * Enhanced error diagnostics to surface cloud-init logs and system messages when sandbox initialization fails.

* **Documentation**
  * Updated sandbox bootstrap instructions to clarify version and reference configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->