### PR TITLE
chore(claude): persist subagent reviewer reports + emission contract

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -2,3 +2,4 @@ settings.local.json
 *.local.json
 ralph-loop*
 worktrees/
+agent-memory/*/reports/

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -21,6 +21,7 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - Write
 skills:
   - superpowers:verification-before-completion
   - code-review-excellence
@@ -193,6 +194,29 @@ your overall read — grounded only in what you actually inspected.]
 The verdict is **binary**. "Mostly ready with minor concerns" is not an
 option — those are non-blocking findings with a READY verdict, OR blocking
 findings with a NOT READY verdict. Make the call.
+
+## Emission contract (MUST)
+
+The parent agent only sees your **final message**. There is no transcript
+replay, and no follow-up call can retrieve detail you omitted — a second
+invocation is a fresh agent with no memory of this run. `Write` is provided
+so your output survives the session boundary.
+
+Before exiting:
+
+1. Run `Bash` with `date +%Y-%m-%d-%H%M` to get a timestamp. Do NOT guess.
+2. `Write` the full report to
+   `.claude/agent-memory/code-reviewer/reports/<timestamp>-<slug>.md`,
+   where `<slug>` is a short kebab-cased identifier (the beads issue id, PR
+   number, or branch name is fine). `Write` MUST NOT touch any path under
+   review — only the report file.
+3. Your **final message** MUST contain the full output format verbatim —
+   every section, every finding with evidence and required resolution, the
+   verdict block — followed by a `## Persisted report` section with the
+   absolute path you wrote. Do NOT abbreviate. Do NOT say "see file" or
+   "as discussed above."
+
+If your tool budget is tight, persist FIRST, then emit the final message.
 
 ## Persistent memory
 

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -22,6 +22,7 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - Write
 skills:
   - superpowers:brainstorming
   - superpowers:writing-plans
@@ -185,6 +186,29 @@ your overall read — grounded only in what you actually inspected.]
 ```
 
 The verdict is **binary**. Make the call.
+
+## Emission contract (MUST)
+
+The parent agent only sees your **final message**. There is no transcript
+replay, and no follow-up call can retrieve detail you omitted — a second
+invocation is a fresh agent with no memory of this run. `Write` is provided
+so your output survives the session boundary.
+
+Before exiting:
+
+1. Run `Bash` with `date +%Y-%m-%d-%H%M` to get a timestamp. Do NOT guess.
+2. `Write` the full report to
+   `.claude/agent-memory/design-reviewer/reports/<timestamp>-<slug>.md`,
+   where `<slug>` is a short kebab-cased identifier (the spec's filename
+   stem is fine). `Write` MUST NOT touch the spec or any other path — only
+   the report file.
+3. Your **final message** MUST contain the full output format verbatim —
+   every section, every finding with evidence and required resolution, the
+   verdict block — followed by a `## Persisted report` section with the
+   absolute path you wrote. Do NOT abbreviate. Do NOT say "see file" or
+   "as discussed above."
+
+If your tool budget is tight, persist FIRST, then emit the final message.
 
 ## Persistent memory
 

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -22,6 +22,7 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - Write
 skills:
   - superpowers:verification-before-completion
   - elements-of-style:writing-clearly-and-concisely
@@ -179,6 +180,28 @@ implement, your overall read — grounded only in what you actually inspected.]
 ```
 
 The verdict is **binary**. Make the call.
+
+## Emission contract (MUST)
+
+The parent agent only sees your **final message**. There is no transcript
+replay, and no follow-up call can retrieve detail you omitted — a second
+invocation is a fresh agent with no memory of this run. `Write` is provided
+so your output survives the session boundary.
+
+Before exiting:
+
+1. Run `Bash` with `date +%Y-%m-%d-%H%M` to get a timestamp. Do NOT guess.
+2. `Write` the full report to
+   `.claude/agent-memory/plan-reviewer/reports/<timestamp>-<slug>.md`,
+   where `<slug>` is a short kebab-cased identifier (the plan's filename
+   stem is fine). `Write` MUST NOT touch any other path.
+3. Your **final message** MUST contain the full output format verbatim —
+   every section, every finding with evidence and required resolution, the
+   verdict block — followed by a `## Persisted report` section with the
+   absolute path you wrote. Do NOT abbreviate. Do NOT say "see file" or
+   "as discussed above."
+
+If your tool budget is tight, persist FIRST, then emit the final message.
 
 ## Persistent memory
 

--- a/.claude/commands/review-code.md
+++ b/.claude/commands/review-code.md
@@ -25,3 +25,10 @@ Apply the adversarial stance and grounding discipline from your system
 prompt. Run the external-grounding MCPs (`context7`, `deepwiki`, `exa`) for
 any library/API/version claims. Produce the standard findings report with a
 binary READY / NOT READY verdict.
+
+**On receipt:** the agent's response IS the full report — read it. The agent
+also persists the full report to `.claude/agent-memory/code-reviewer/reports/`.
+Do NOT spawn a second agent to "retrieve full findings"; subagents are
+stateless across invocations and a fresh one has nothing to retrieve. If the
+response looks truncated, read the persisted file from disk directly with
+`Read`.

--- a/.claude/commands/review-design.md
+++ b/.claude/commands/review-design.md
@@ -19,3 +19,10 @@ prompt. Run the required-section pass, the testability pass, the consistency
 pass, the repo-reality pass (including overlap-with-existing-specs), and the
 scope pass. Produce the standard findings report with a binary READY /
 NOT READY verdict.
+
+**On receipt:** the agent's response IS the full report — read it. The agent
+also persists the full report to `.claude/agent-memory/design-reviewer/reports/`.
+Do NOT spawn a second agent to "retrieve full findings"; subagents are
+stateless across invocations and a fresh one has nothing to retrieve. If the
+response looks truncated, read the persisted file from disk directly with
+`Read`.

--- a/.claude/commands/review-plan.md
+++ b/.claude/commands/review-plan.md
@@ -19,3 +19,10 @@ prompt. Run the traceability passes (spec → plan, plan → spec), the
 definition-of-done pass, the decomposition pass, and the repo-reality pass.
 Produce the standard findings report with a binary READY / NOT READY
 verdict.
+
+**On receipt:** the agent's response IS the full report — read it. The agent
+also persists the full report to `.claude/agent-memory/plan-reviewer/reports/`.
+Do NOT spawn a second agent to "retrieve full findings"; subagents are
+stateless across invocations and a fresh one has nothing to retrieve. If the
+response looks truncated, read the persisted file from disk directly with
+`Read`.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"168489c2-2062-4cf4-ab9e-08fa5c249bb3","pid":37906,"procStart":"Sat Apr 25 04:01:07 2026","acquiredAt":1777091728929}


### PR DESCRIPTION
## Summary

Subagents are stateless across invocations: the parent only sees the
agent's final message, and there's no way for a follow-up call to retrieve
detail an agent omitted. With high tool use, the final message often
compresses to just verdict + finding titles, losing the full report — and a
second invocation is a fresh agent with no memory.

This change makes the three adversarial pre-push reviewers (`plan-reviewer`,
`code-reviewer`, `design-reviewer`) persist their full report to disk before
exiting and contractually emit the full output format in the final message.

### Changes

**Agents** (`.claude/agents/{plan,code,design}-reviewer.md`):
- Add `Write` to `tools:` (scoped via prompt to `.claude/agent-memory/<agent>/reports/` only — the artifact under review stays untouched).
- Add an "Emission contract (MUST)" section requiring:
  1. Timestamp via `Bash` (`date +%Y-%m-%d-%H%M`)
  2. `Write` the full report to `.claude/agent-memory/<agent>/reports/<timestamp>-<slug>.md`
  3. Final message contains the full output format verbatim plus a `## Persisted report` section with the absolute file path
- Explicitly state the parent only sees the final message and there's no follow-up retrieval path.

**Slash commands** (`.claude/commands/review-{plan,code,design}.md`):
- Append a brief "On receipt" block reminding the parent that the response IS the full report, that it's also persisted to disk, and that spawning a second agent to "retrieve full findings" is futile (stateless invocations).

**`.claude/.gitignore`**:
- Add `agent-memory/*/reports/` so individual review artifacts stay local. `MEMORY.md` files in each agent dir remain checked in.

## Test plan

- [x] Reviewer agent prompts updated and pass YAML lint
- [x] `task pr-prep` green (run with `GOWORK=off` due to env issue — see env note below)
- [ ] Validate end-to-end on next `/review-plan`, `/review-code`, or `/review-design` invocation: confirm a `.claude/agent-memory/<agent>/reports/<timestamp>-<slug>.md` file is written and the final message contains the full report + path.

## Env note

`task pr-prep` was run with `GOWORK=off` because the local `go.work`
contains multiple jj workspaces of the same `github.com/holomush/holomush`
module, which Go workspace mode rejects with `module appears multiple times
in workspace`. This is a structural problem with `task gowork`, not a
problem introduced by this PR. Filed as `holomush-rmo2` (P2 bug).

CI will run pr-prep on the clean checkout where `go.work` is single-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code review, design review, and plan review reports are now automatically persisted with timestamps, enabling access to historical outputs across sessions.

* **Chores**
  * Updated agent configurations and command directives to support structured report persistence and file-based retrieval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->