### PR TITLE
fix(web): close cmdk palette reliably + add focus guard in e2e (holomush-ceon)

### DIFF
--- a/web/e2e/terminal.spec.ts
+++ b/web/e2e/terminal.spec.ts
@@ -553,6 +553,10 @@ test.describe('Terminal UI', () => {
     await connectAsGuest(page);
     await page.keyboard.press('ControlOrMeta+k');
     await expect(page.locator('[data-cmdk-dialog]')).toBeVisible({ timeout: 3000 });
+    // Wait for focus to settle on the cmdk input before typing — without
+    // this guard the test races FocusScope's rAF auto-focus and `theme`
+    // can land in the inline command-input textarea (holomush-ceon).
+    await expect(page.locator('[data-cmdk-input]')).toBeFocused();
     // Type to filter
     await page.keyboard.type('theme');
     await expect(page.locator('[data-cmdk-item]').first()).toContainText(/theme/i);

--- a/web/src/lib/components/terminal/CommandPalette.svelte
+++ b/web/src/lib/components/terminal/CommandPalette.svelte
@@ -6,6 +6,7 @@
   import { Command } from 'cmdk-sv';
   import {
     uiPrefs,
+    openPalette,
     closePalette,
     toggleRail,
     toggleSidebar,
@@ -59,12 +60,29 @@
   }
 </script>
 
+<!--
+  Controlled-mode: pass `open` one-way and route close through onOpenChange.
+  Two-way `bind:open={$store.field}` through cmdk-sv (Svelte 4 compat) into
+  bits-ui v2 ($bindable) is unreliable on rapid open/close — the writeback
+  to the runes-mode store-field expression doesn't always settle before the
+  next event cycle. Controlled mode keeps the store as the single source
+  of truth (holomush-ceon).
+-->
 <Command.Dialog
-  bind:open={$uiPrefs.paletteOpen}
+  open={$uiPrefs.paletteOpen}
   label="Command palette"
-  onOpenChange={(open: boolean) => { if (!open) closePalette(); }}
+  onOpenChange={(open: boolean) => {
+    if (open) openPalette(); else closePalette();
+  }}
 >
-  <Command.Input placeholder="Type a command…" />
+  <!-- autofocus={true} kicks cmdk-sv's 10ms focus action; combined with
+       FocusScope's rAF auto-focus this gives two paths to focus the input
+       before user keystrokes can race past dialog open. -->
+  <Command.Input
+    name="command-palette-query"
+    placeholder="Type a command…"
+    autofocus={true}
+  />
   <Command.List>
     <Command.Empty>No matches</Command.Empty>
     {#each items as item (item.id)}


### PR DESCRIPTION
## Summary

- Switch `CommandPalette` from `bind:open={$store.field}` two-way binding to controlled mode (`open=...` + `onOpenChange` routes to `openPalette`/`closePalette`). The two-way path through cmdk-sv (Svelte 4 compat) → bits-ui v2 (`$bindable`) is unreliable on rapid open/close — the writeback to a runes-mode store-field expression doesn't always settle before the next event cycle.
- Add `autofocus={true}` on `Command.Input` so cmdk-sv's 10ms focus action gets a path beyond just bits-ui FocusScope's rAF.
- Add `toBeFocused()` guard in the Cmd+K E2E between `toBeVisible` and `keyboard.type`. Without it the test races FocusScope's rAF auto-focus and `theme` can land in the inline command-input textarea, leaving the dialog open after Escape.

Fixes holomush-ceon.

## Investigation

| Run | Configuration | Result |
|---|---|---|
| baseline | source-level diag, no fix | 15/20 pass (5 fail: focus on TEXTAREA at Escape time) |
| timing-shifted | + bits-ui internal logs | 20/20 pass (added latency masked the race) |
| **fix applied, no diag** | **40/40 pass with --repeat-each=40** |

Failure fingerprint in baseline: target=TEXTAREA, active=TEXTAREA, defaultPrevented=true, paletteOpen=true, dataState=\"open\". The bits-ui escape layer fired (defaultPrevented) but the close didn't propagate to \$uiPrefs.paletteOpen. Controlled mode makes the store the single source of truth.

## Test plan

- [x] task pr-prep — All PR checks passed (lint, format, schema, license, unit, integration, E2E)
- [x] task test:e2e -- -g \"Cmd\+K opens\" --repeat-each=40 — 40/40 pass
- [x] Adversarial code review (code-reviewer) — VERDICT READY, no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command palette (Cmd+K) focus handling so keyboard input reliably lands in the search field and not elsewhere.
  * Ensured open/close behavior no longer sends keystrokes to alternate inputs during dialog transitions.

* **Improvements**
  * Command palette input now consistently autofocuses when opened for more predictable typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->