### PR TITLE
chore(claude): sharpen reviewer triggers + add pre-action reminder hook

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,10 +1,13 @@
 ---
 name: code-reviewer
 description: |
-  Use proactively before claiming a beads task complete, before `jj git push`,
-  or before creating a PR. Adversarial independent reviewer — not the
-  implementer's ally. All findings must be grounded in the repo and cited.
-  Read-only.
+  MUST run before any of: `jj git push`, `git push`, `gh pr create`, `bd close`,
+  or before responding to user text containing "push", "open a PR", "create a
+  PR", "merge", "ship", "land", "ready to push", "ready to merge", "ready to
+  ship", "close the bead", "mark done", "mark complete", "wrap up", "finalize".
+  Adversarial independent reviewer — not the implementer's ally. Findings
+  grounded in the repo at `path:line`. Read-only. Skipping requires explicit
+  user override (e.g., "skip review", "no review needed").
 model: opus
 effort: high
 permissionMode: plan

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,11 +1,14 @@
 ---
 name: design-reviewer
 description: |
-  Use proactively after `superpowers:brainstorming` writes a spec to
-  `docs/superpowers/specs/` or `docs/specs/`, before `superpowers:writing-plans`
-  is invoked. Adversarial independent reviewer — not the designer's ally.
-  All findings must be grounded in the spec, the stated goals, and repo
-  reality. Read-only.
+  MUST run after `superpowers:brainstorming` writes any spec to `docs/specs/`
+  or `docs/superpowers/specs/`, BEFORE `superpowers:writing-plans` is invoked
+  on it. Also MUST run before responding to user text containing "write the
+  plan", "plan this", "spec is ready", "ready for planning", "design is
+  done", "approve the design", "approved". Adversarial independent reviewer —
+  not the designer's ally. Findings grounded in spec, stated goals, and
+  repo reality, cited by section. Read-only. Skipping requires explicit user
+  override.
 model: opus
 effort: high
 permissionMode: plan

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -1,11 +1,14 @@
 ---
 name: plan-reviewer
 description: |
-  Use proactively after `superpowers:writing-plans` produces an
-  implementation plan, before `superpowers:executing-plans` or
-  `superpowers:subagent-driven-development` runs. Adversarial independent
-  reviewer — not the planner's ally. All findings must be grounded in the
-  plan, spec, and repo state. Read-only.
+  MUST run after `superpowers:writing-plans` writes any plan to
+  `docs/plans/` or `docs/superpowers/plans/`, BEFORE `superpowers:executing-plans`
+  or `superpowers:subagent-driven-development` consumes it. Also MUST run
+  before responding to user text containing "execute the plan", "run the
+  plan", "start implementing", "begin the plan", "plan is ready", "approve
+  the plan", "approved". Adversarial independent reviewer — not the planner's
+  ally. Findings grounded in the plan, spec, and repo state, cited by step.
+  Read-only. Skipping requires explicit user override.
 model: opus
 effort: high
 permissionMode: plan

--- a/.claude/hooks/remind-pre-action-review.sh
+++ b/.claude/hooks/remind-pre-action-review.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# UserPromptSubmit hook: scans the user's prompt for intent verbs that imply a
+# pre-push, pre-execute, or pre-plan reviewer gate, and injects a short
+# reminder so the assistant invokes the right adversarial sub-agent before
+# acting. Soft nudge — does not block.
+#
+# Output contract: emit additionalContext text on stdout. Stay silent (exit 0)
+# when no trigger matches.
+
+set -euo pipefail
+
+# Read the JSON event from stdin. We only need .prompt; jq keeps us safe from
+# embedded newlines and quotes in user input.
+prompt="$(jq -r '.prompt // ""')"
+
+# Lowercase once for cheap case-insensitive matching.
+lower="$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')"
+
+reminders=()
+
+# code-reviewer triggers: anything that implies the work is leaving the session.
+if printf '%s' "$lower" | grep -qE '(\bpush\b|jj[[:space:]]+git[[:space:]]+push|git[[:space:]]+push|gh[[:space:]]+pr[[:space:]]+create|bd[[:space:]]+close|open[[:space:]]+(a[[:space:]]+)?pr|create[[:space:]]+(a[[:space:]]+)?pr|\bmerge\b|\bship\b|\bland\b|ready[[:space:]]+to[[:space:]]+(push|merge|ship)|close[[:space:]]+(the[[:space:]]+)?bead|mark[[:space:]]+(done|complete)|wrap[[:space:]]+up|finalize)'; then
+  reminders+=("**Pre-hand-off gate:** Before you run \`jj git push\`, \`gh pr create\`, or \`bd close\` for this work, the \`code-reviewer\` adversarial sub-agent MUST run on the branch diff. Invoke \`/review-code\` (or \`Agent\` with \`subagent_type: code-reviewer\`) now if it has not already run for the current branch tip. To skip, the user must explicitly say so (e.g. \"skip review\").")
+fi
+
+# plan-reviewer triggers: anything that implies a plan is about to be executed.
+if printf '%s' "$lower" | grep -qE '(execute[[:space:]]+(the[[:space:]]+)?plan|run[[:space:]]+(the[[:space:]]+)?plan|start[[:space:]]+implementing|begin[[:space:]]+(the[[:space:]]+)?plan|plan[[:space:]]+is[[:space:]]+ready|approve[[:space:]]+(the[[:space:]]+)?plan|\bapproved\b)'; then
+  reminders+=("**Pre-execute gate:** Before \`superpowers:executing-plans\` or \`superpowers:subagent-driven-development\` consumes a plan, the \`plan-reviewer\` adversarial sub-agent MUST run on it. Invoke \`/review-plan\` now if it has not already run for the latest revision of the plan.")
+fi
+
+# design-reviewer triggers: anything that implies a spec is about to be planned.
+if printf '%s' "$lower" | grep -qE '(write[[:space:]]+(the[[:space:]]+)?plan|plan[[:space:]]+this|spec[[:space:]]+is[[:space:]]+ready|ready[[:space:]]+for[[:space:]]+planning|design[[:space:]]+is[[:space:]]+done|approve[[:space:]]+(the[[:space:]]+)?design|\bapproved\b)'; then
+  reminders+=("**Pre-plan gate:** Before \`superpowers:writing-plans\` is invoked on a spec, the \`design-reviewer\` adversarial sub-agent MUST run on it. Invoke \`/review-design\` now if it has not already run for the latest revision of the spec.")
+fi
+
+if [ ${#reminders[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# Print all matched reminders. Each is its own paragraph.
+printf '## Reviewer-gate reminder (auto-injected)\n\n'
+for r in "${reminders[@]}"; do
+  printf '%s\n\n' "$r"
+done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,17 @@
         "matcher": ""
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/remind-pre-action-review.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

The previous PR (#264) made the three adversarial reviewer sub-agents
(`plan-reviewer`, `code-reviewer`, `design-reviewer`) persist their reports
to disk and emit the full output in the final message. But the *triggering*
of these gates was still purely advisory ("Use proactively before X") — so
in practice the parent agent could (and did) skip them.

This PR makes the gates harder to skip with two coordinated changes:

### 1. Sharpen agent description triggers (`.claude/agents/*-reviewer.md`)

Each description now opens with **MUST**, lists the concrete tool calls AND
user-typed phrases that trigger the gate, and ends with the explicit-bypass
clause. The pattern matches the strong skill descriptions that already work
reliably (e.g. `superpowers:brainstorming`).

- **code-reviewer**: triggers on `jj git push`, `git push`, `gh pr create`,
  `bd close`, plus user text like "push", "open a PR", "merge", "ship",
  "land", "ready to push/merge/ship", "close the bead", "mark done", "wrap
  up", "finalize".
- **plan-reviewer**: triggers on `superpowers:writing-plans` output, plus
  user text like "execute the plan", "start implementing", "plan is ready",
  "approved".
- **design-reviewer**: triggers on `superpowers:brainstorming` output, plus
  user text like "write the plan", "spec is ready", "ready for planning",
  "design is done".

### 2. UserPromptSubmit hook (`.claude/hooks/remind-pre-action-review.sh`)

Soft-injects a reminder into the prompt when the user's text matches any of
the trigger phrases above. Runs on every prompt (cheap shell+grep), stays
silent when nothing matches, prints a `## Reviewer-gate reminder
(auto-injected)` section with the relevant gate(s) when matched.

Wired in `.claude/settings.json` under `hooks.UserPromptSubmit` with empty
matcher.

## Why two layers

The agent description is read when the LLM decides whether to invoke. The
hook injection arrives *with* the user's prompt, before the LLM has even
started planning. Belt-and-suspenders: either layer firing alone gives a
much higher chance of compliance than today's "use proactively" hint.

## Test plan

- [x] Hook smoke-tested with three positive prompts (push / execute /
      write-plan) and one negative ("hello world") — all three positives
      emitted the expected reminder, negative stayed silent.
- [x] `jq -e .` validates the new `settings.json`.
- [x] `task pr-prep` green (run with `GOWORK=off` per `holomush-rmo2`).
- [ ] Validate end-to-end on next session: confirm a prompt containing
      "push" produces the auto-injected reminder block, and confirm
      `code-reviewer` invocation rate goes up.

## Workspace note

This PR was assembled in a dedicated jj workspace
(`.worktrees/claude-reviewer-triggers`) after a parallel session in the
default workspace stomped on the in-flight commit. The deeper "agents
should auto-isolate to their own jj workspace" issue is being tracked
separately for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automated pre-action reminders that prompt required reviews before push/PR/merge/execute/start actions are taken.

* **Chores**
  * Tightens reviewer gating so design/plan/code reviewers must run and provide cited findings unless explicitly skipped by the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->