### PR TITLE
feat(plugin-audit): enforce scene-membership authz at PluginAuditService.QueryHistory

### DIFF
--- a/.claude/agent-memory/design-reviewer/MEMORY.md
+++ b/.claude/agent-memory/design-reviewer/MEMORY.md
@@ -8,7 +8,7 @@ Keep under 200 lines. Curate — don't hoard.
 
 ## Common spec weaknesses in this codebase
 
-<!-- Populated by the agent over time. -->
+- [oops vs gRPC code conflation](feedback_oops_vs_grpc_code_conflation.md) — HoloMUSH specs often call oops codes "gRPC codes"; flag wording, do not block if pattern matches existing codebase convention
 
 ## Interfaces and boundaries that recur
 

--- a/.claude/agent-memory/design-reviewer/feedback_oops_vs_grpc_code_conflation.md
+++ b/.claude/agent-memory/design-reviewer/feedback_oops_vs_grpc_code_conflation.md
@@ -1,0 +1,21 @@
+---
+name: oops code vs gRPC status code conflation in HoloMUSH specs
+description: HoloMUSH specs sometimes describe oops codes as if they were gRPC status codes — flag the wording, but do not block when the design behaves identically to existing pattern
+type: feedback
+---
+
+# oops code vs gRPC status code conflation in HoloMUSH specs
+
+In HoloMUSH, error codes like `STREAM_ACCESS_DENIED`, `SCENE_AUDIT_ACCESS_DENIED`, `AUDIT_PLUGIN_HISTORY_RPC_FAILED` are **oops codes** (constructed via `oops.Code(...).Errorf(...)`), NOT gRPC `codes.Code` values. The codebase asserts them via `errutil.AssertErrorCode(t, err, "STREAM_ACCESS_DENIED")` which inspects the oops chain in-process.
+
+When a spec says "the wire-level gRPC code is `STREAM_ACCESS_DENIED`" it is using "gRPC code" colloquially to mean "what survives in the error chain through an in-process gRPC test." Over a real network, gRPC would marshal a non-status oops error as `codes.Unknown` and the oops chain would be lost.
+
+**Why:** This is a pre-existing convention in `internal/grpc/query_stream_history.go:170,178,203` and `internal/grpc/query_stream_history_test.go:220` — specs inherit it rather than introduce it. The implementer following such a spec will write code that behaves identically to the existing pattern, and intra-process tests will pass.
+
+**How to apply:** When reviewing specs that mix oops codes with gRPC status code language:
+
+- Flag the wording as a non-blocking finding (medium severity)
+- Verify the test the spec proposes is implementable against the existing `errutil.AssertErrorCode` pattern
+- Do NOT block — the design works; the wording is the bug
+- Suggest concrete spec text fix: e.g., "the error chain carries oops code X" rather than "the wire-level gRPC code is X"
+- Real gRPC status codes (`codes.PermissionDenied`, `codes.InvalidArgument`) used in plugin-boundary contexts are correct as written — only flag conflations that affect host-boundary error chains

--- a/.claude/agent-memory/plan-reviewer/MEMORY.md
+++ b/.claude/agent-memory/plan-reviewer/MEMORY.md
@@ -8,8 +8,17 @@ Keep under 200 lines. Curate — don't hoard.
 
 ## Common plan gaps in this codebase
 
-<!-- Populated by the agent over time. -->
+- [Verify helper existence](feedback_verify_helper_existence.md) — plans frequently invent methods/helpers on existing types ("extend test file X" with calls that don't exist on X)
+- [No signature placeholders](feedback_no_signature_placeholders.md) — interface signatures and parameter lists must be inlined, never deferred via `/* COPY FROM existing.go */` comments
+- [Verify imports against code blocks](feedback_verify_imports_in_code_blocks.md) — every package qualifier (`slog.`, `timestamppb.`, `status.`) used in a plan's example code must appear in the file's existing imports OR in the plan's "imports needed" directive
 
 ## Decomposition patterns that work here
 
 <!-- Populated by the agent over time. -->
+
+## Review reflexes
+
+- For every `path:line` citation in the plan, run a quick `Read` or `rg` to verify the line range still covers what the plan claims. Drift across PRs is real — the spec under review used `:96-102` for a block, the plan used `:95-102` for the same block. Both can be off after the next merge.
+- Plans that put a `task pr-prep` gate at the END but never run `task lint` per-task accumulate lint debt across N commits. Per project rule (`MUST run task lint before committing`), each commit checkpoint should be lint-clean. Flag this as non-blocking but real.
+- For Ginkgo vs `testing.T`: never assume a `_test.go` file is BDD-style. Verify with `rg "var _ = Describe" path/to/file`. Plain `func TestX(t *testing.T)` is the default in this repo's `eventbus_e2e` integration tree.
+- For the `task test:int` invocation: integration tests in HoloMUSH live in mixed locations. Plugin store integration tests are at `./plugins/<name>/` with `//go:build integration`, NOT at `./test/integration/plugin/...`. Always cross-reference `Taskfile.yaml:test:int` for the canonical package list before approving a path in a plan.

--- a/.claude/agent-memory/plan-reviewer/feedback_no_signature_placeholders.md
+++ b/.claude/agent-memory/plan-reviewer/feedback_no_signature_placeholders.md
@@ -1,0 +1,13 @@
+---
+name: Reject plans containing "COPY VERBATIM FROM existing code" placeholders for type signatures
+description: Interface signatures and function parameter lists must be inlined; deferring them to "look it up at execution time" is a placeholder antipattern
+type: feedback
+---
+
+# Reject plans containing "COPY VERBATIM FROM existing code" placeholders for type signatures
+
+A plan is not allowed to leave interface method signatures or function parameter lists as `/* COPY VERBATIM FROM existing.go */` comments — even when the source is "right there." This is the placeholder antipattern the writing-plans skill explicitly bans.
+
+**Why:** On plan `2026-04-23-plugin-history-authz-plan.md`, two literal `/* COPY PARAMS FROM *SceneAuditStore.queryLog */` placeholders were left in Task 9 — one in the interface declaration, one in the fake's method body. The plan acknowledged the dependency three times but never resolved it. An interface whose method signature has to be derived at execution time is a TODO, not an interface. Tests that instantiate the fake assume it satisfies the interface; if the signature guess is wrong, every test in the task breaks at compile time.
+
+**How to apply:** When reviewing a plan, search for `/* COPY`, `TBD`, `fill in`, `verify against`, `match the existing signature`. Each occurrence in code-blocks is a blocking finding. The plan author has access to the same `Read` tool I do — the signature should be inlined, not deferred. Even when the plan says "this is verifiable today; nothing about the spec changes it," the reviewer's job is to flag it: the executor following the plan should not have to do the discovery.

--- a/.claude/agent-memory/plan-reviewer/feedback_verify_helper_existence.md
+++ b/.claude/agent-memory/plan-reviewer/feedback_verify_helper_existence.md
@@ -1,0 +1,18 @@
+---
+name: Verify helper existence before approving "extend the existing test file" plans
+description: HoloMUSH plans frequently say "extend X test file" but invent helpers/methods that don't exist on the target types
+type: feedback
+---
+
+# Verify helper existence before approving "extend the existing test file" plans
+
+When a plan says "extend the existing test file" or "reuse the existing helper":
+
+**Why:** Two blocking findings on plan `2026-04-23-plugin-history-authz-plan.md` (P1 bug). Plan called `store.CreateScene` and `store.JoinScene` — neither exists on `*SceneStore`. `JoinScene` is on `*SceneServiceImpl`. The store-test helper is `newTestStore`, not the plan's invented `setupSceneStore`. Separately, plan prescribed Ginkgo `Describe`/`It` blocks for `test/integration/eventbus_e2e/plugin_audit_isolation_test.go`, which is a plain `testing.T` test with zero Ginkgo. Six load-bearing tests around invented suite fields and seed helpers.
+
+**How to apply:**
+
+1. For every method call the plan makes on an existing type (e.g. `store.X(...)`), grep: `rg "func \(.*SceneStore\) X" plugins/`. If zero hits, finding is blocking.
+2. For every helper the plan references (e.g. `setupFoo`, `seedX`), grep the test directory: `rg "func setupFoo" path/to/tests/`. Zero hits = invented helper.
+3. For every "extend the Ginkgo suite" instruction, verify the file actually has `var _ = Describe(...)`. Plain `func TestX(t *testing.T)` files are NOT Ginkgo suites.
+4. Plans that hand-wave with "if any are not yet defined, add small wrappers" for 6+ helpers are deferring design to execution — that's the placeholder pattern the writing-plans skill forbids.

--- a/.claude/agent-memory/plan-reviewer/feedback_verify_imports_in_code_blocks.md
+++ b/.claude/agent-memory/plan-reviewer/feedback_verify_imports_in_code_blocks.md
@@ -1,0 +1,20 @@
+---
+name: Verify imports against code blocks
+description: When a plan adds new package-level identifiers to a file (slog., timestamppb., status., codes.), check that the explicit "imports needed" directive lists every missing/new import not already in the target file
+type: feedback
+---
+
+# Verify imports against code blocks
+
+When reviewing a plan that ships an example code block plus an "imports needed" or "add imports" directive, the directive must enumerate every missing/new import the code block references — packages already imported in the target file don't need to be listed.
+
+**Why:** Plans tend to under-list imports because the author writes the code first (compiler-checks would have caught it) and the import list second (manual). Two patterns I've now seen on the same review:
+
+1. New `QueryHistory` body sprinkled with `slog.InfoContext(...)`; `import "log/slog"` not in the directive even though the file currently has no `slog` import.
+2. `fakeAuditStore.queryLog` parameter list uses `*timestamppb.Timestamp`; `timestamppb` not in the test file's import block.
+
+Per writing-plans, every code block must be the actual content the engineer needs. A missing import is a compile error the implementer hits on first run — fast to fix, but it's still a "plan failure" by the skill's checklist.
+
+**How to apply:**
+
+For every code block that references a package qualifier (`pkg.Symbol`), grep the existing target file's imports — confirm the package is already imported, or confirm the plan's "add imports" line lists it. Cross-reference both directions: imports listed but not used (dead) and uses without imports listed (compile error).

--- a/api/proto/holomush/plugin/v1/audit.proto
+++ b/api/proto/holomush/plugin/v1/audit.proto
@@ -39,6 +39,14 @@ message QueryHistoryRequest {
   int32 direction = 5; // 1=forward, 2=backward
   google.protobuf.Timestamp not_before = 6;
   google.protobuf.Timestamp not_after = 7;
+
+  // caller identifies the principal on whose behalf the host is reading.
+  // Plugins implementing PluginAuditService MUST enforce domain-specific
+  // authz (e.g., membership) against this identity before returning rows.
+  // An absent caller, a zero identity, or an unsupported Actor.Kind MUST
+  // be rejected with gRPC PERMISSION_DENIED. The host populates this
+  // field from the authenticated session record; clients never supply it.
+  holomush.eventbus.v1.Actor caller = 8;
 }
 
 message QueryHistoryResponse {

--- a/cmd/holomush/sub_grpc_adapters_test.go
+++ b/cmd/holomush/sub_grpc_adapters_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
@@ -372,4 +374,33 @@ func TestBusHistoryReaderReplayTailRejectsInvalidStream(t *testing.T) {
 	// Empty stream → subjectxlate fails.
 	_, err := adapter.ReplayTail(context.Background(), "", 5, time.Time{}, ulid.ULID{})
 	require.Error(t, err)
+}
+
+// TestBusHistoryReaderAdapterFailsClosedOnPluginOwnedSubjects covers spec
+// §6.5 case 6: when the plugin's PluginAuditService.QueryHistory returns
+// PermissionDenied (e.g., because the plugin-as-caller invariant cannot yet
+// be satisfied — this adapter passes a zero Caller — or because the plugin
+// fails its own membership check), the adapter MUST surface the
+// PermissionDenied to the plugin caller. It MUST NOT swallow or downgrade
+// that into an opaque or generic error: the plugin needs to see the precise
+// gRPC code so it can react (e.g., return an empty page rather than spin).
+//
+// This test pins the §4.4 fail-closed contract for the deferred
+// plugin-as-caller follow-up. If the adapter is later changed to pass a
+// real plugin Caller, this test should still pass — the adapter MUST
+// propagate PermissionDenied unchanged for plugin-owned subjects.
+func TestBusHistoryReaderAdapterFailsClosedOnPluginOwnedSubjects(t *testing.T) {
+	reader := &stubHistoryReader{
+		err: status.Error(codes.PermissionDenied, "caller required"),
+	}
+	adapter := &busHistoryReaderAdapter{
+		reader: reader,
+		gameID: func() string { return "main" },
+	}
+
+	_, err := adapter.ReplayTail(context.Background(),
+		"scene:01HYXSCENE00000000000000CC:ic", 10, time.Time{}, ulid.ULID{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err),
+		"adapter MUST surface the plugin's PermissionDenied for plugin-owned subjects until the plugin-as-caller follow-up lands")
 }

--- a/docs/superpowers/plans/2026-04-23-plugin-history-authz-plan.md
+++ b/docs/superpowers/plans/2026-04-23-plugin-history-authz-plan.md
@@ -1,0 +1,2040 @@
+# Plugin history authz — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce scene-membership authz at the plugin boundary in `PluginAuditService.QueryHistory`, plumbing caller identity from the host session through `eventbus.HistoryQuery` and the gRPC contract, with end-to-end opacity for the client.
+
+**Architecture:** Defense-in-depth. The outer I-17 gate at `CoreServer.QueryStreamHistory` stays unchanged. The plugin gets a new independent membership check against its own `scene_participants` table, fed by a new `caller` field on `QueryHistoryRequest` populated by the host. Errors propagate as gRPC `status.Error` so the router can preserve codes, and `mapHistoryError` collapses plugin-side `PermissionDenied` into the same `STREAM_ACCESS_DENIED` oops code the outer gate uses.
+
+**Tech Stack:** Go 1.22+, hashicorp/go-plugin (subprocess), protobuf (`api/proto/holomush/plugin/v1/audit.proto`), gRPC, samber/oops (structured errors), pgx (PostgreSQL), Ginkgo/Gomega (integration), testify (unit), gotestsum.
+
+**Spec:** [docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md](../specs/2026-04-23-plugin-history-authz-design.md)
+
+**Bead:** `holomush-095g` (P1 bug)
+
+---
+
+## File map
+
+| File | Action | What changes |
+| --- | --- | --- |
+| `api/proto/holomush/plugin/v1/audit.proto` | modify | Append `holomush.eventbus.v1.Actor caller = 8;` to `QueryHistoryRequest` |
+| `pkg/proto/holomush/plugin/v1/audit.pb.go` | regenerate | Auto-generated from above |
+| `internal/eventbus/publisher.go` | modify | Rename `actorToProto` → `ActorToProto`, `actorKindToProto` → `ActorKindToProto` (export). Update in-package call sites. |
+| `internal/eventbus/bus.go` | modify | Add `Caller Actor` field to `HistoryQuery` struct |
+| `internal/eventbus/audit/plugin_router.go` | modify | Two edit sites: (1) populate `req.Caller = ActorToProto(q.Caller)` in `QueryHistory`; (2) gRPC-status pass-through on RPC error and stream Recv error |
+| `internal/eventbus/audit/plugin_router_test.go` | extend | New tests for caller forwarding and gRPC status preservation |
+| `internal/grpc/query_stream_history.go` | modify | Add `caller eventbus.Actor` parameter to `fetchHistoryFramesFromBus`; populate from `info.CharacterID`; extend `mapHistoryError` with gRPC-status dispatch |
+| `internal/grpc/query_stream_history_test.go` | extend | New tests for caller threading + `mapHistoryError` status dispatch |
+| `plugins/core-scenes/store.go` | modify | Add `IsMember(ctx, sceneID, characterID) (bool, error)` method on `SceneStore` |
+| `plugins/core-scenes/store_integration_test.go` | extend | Integration test for `IsMember` |
+| `plugins/core-scenes/audit.go` | modify | Replace permissive `QueryHistory` body with auth-first flow; remove TODO at line 211; rewrite docstring |
+| `plugins/core-scenes/audit_test.go` | create | Unit tests for auth dispatch, subject parsing, early rejection, mid-pagination revocation |
+| `test/integration/eventbus_e2e/plugin_audit_isolation_test.go` | extend | 6 integration cases per spec §6.5 |
+
+---
+
+## Pre-flight
+
+These are setup steps the implementer MUST complete before starting Task 1.
+
+- [ ] **Confirm workspace and branch state**
+
+```bash
+cd /Users/sean/Code/github.com/holomush/.worktrees/095g
+jj st
+jj log -r '@-' --no-graph -T 'commit_id ++ " " ++ description.first_line()'
+```
+
+Expected: working copy is on top of `e069b5a679b7945b85aa106db6d26f4c70153ce2 feat(eventbus): history pagination on JetStream stream sequence with opaque cursors (holomush-suos) (#254)`. The previously-committed spec `docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md` is in the working copy as the only changed file.
+
+- [ ] **Confirm `bd` access from this workspace**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd show holomush-095g
+```
+
+Expected: shows the bead with status `in_progress` (already claimed earlier this session).
+
+- [ ] **Create bead sub-tasks under holomush-095g**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Wire foundations: proto + eventbus exports + HistoryQuery.Caller" \
+  --description="Spec §4.1, §4.2 (proto), §7 steps 1-3. Adds caller=8 to QueryHistoryRequest, exports ActorToProto/ActorKindToProto, adds HistoryQuery.Caller field." \
+  --type=task --priority=1 --parent holomush-095g
+
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Router gRPC status pass-through + caller forwarding" \
+  --description="Spec §5.5, §7 steps 6-7. Two edit sites in plugin_router.go: outer QueryHistory and pluginHistoryStream.Next. Forward q.Caller; preserve plugin gRPC status codes." \
+  --type=task --priority=1 --parent holomush-095g
+
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Host handler caller plumbing + mapHistoryError dispatch" \
+  --description="Spec §4.3, §5.5, §7 steps 5,10. fetchHistoryFramesFromBus gains caller param; mapHistoryError gets gRPC status dispatch step before existing errors.Is chain." \
+  --type=task --priority=1 --parent holomush-095g
+
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Plugin SceneStore.IsMember + SceneAuditServer enforcement" \
+  --description="Spec §5.1-5.4, §7 steps 8-9,12. New IsMember helper; auth-first ordering in QueryHistory; subject parsing; remove TODO; update docstring." \
+  --type=task --priority=1 --parent holomush-095g
+
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Integration tests + verification + follow-up bead" \
+  --description="Spec §6.5 (6 integration cases) and §7 step 13 (file plugin-as-caller follow-up bead). Run task pr-prep." \
+  --type=task --priority=1 --parent holomush-095g
+```
+
+Record the returned bead IDs; they're referenced from each Task's "Step 1: Claim the bead" below as `holomush-XXXX`.
+
+---
+
+## Phase 1: Wire foundations
+
+### Task 1: Add `caller` field to `QueryHistoryRequest` proto
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/audit.proto`
+- Regenerate: `pkg/proto/holomush/plugin/v1/audit.pb.go`
+
+- [ ] **Step 1: Claim the wire-foundations bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <wire-foundations-id> --status=in_progress
+```
+
+- [ ] **Step 2: Edit `api/proto/holomush/plugin/v1/audit.proto`**
+
+Append the new field to `QueryHistoryRequest`. Do NOT modify fields 1–7 or their existing comments.
+
+```proto
+message QueryHistoryRequest {
+  string subject = 1;
+  bytes after = 2; // ULID; empty = from start
+  bytes before = 3; // ULID; empty = unbounded
+  int32 page_size = 4; // host caps at 200
+  int32 direction = 5; // 1=forward, 2=backward
+  google.protobuf.Timestamp not_before = 6;
+  google.protobuf.Timestamp not_after = 7;
+
+  // caller identifies the principal on whose behalf the host is reading.
+  // Plugins implementing PluginAuditService MUST enforce domain-specific
+  // authz (e.g., membership) against this identity before returning rows.
+  // An absent caller, a zero identity, or an unsupported Actor.Kind MUST
+  // be rejected with gRPC PERMISSION_DENIED. The host populates this
+  // field from the authenticated session record; clients never supply it.
+  holomush.eventbus.v1.Actor caller = 8;
+}
+```
+
+- [ ] **Step 3: Regenerate proto**
+
+```bash
+task proto
+```
+
+Expected: `pkg/proto/holomush/plugin/v1/audit.pb.go` is updated; no other files change. `task proto` runs `buf generate`.
+
+- [ ] **Step 4: Verify the generated Go has `Caller` field**
+
+```bash
+rg "Caller \*eventbusv1.Actor" pkg/proto/holomush/plugin/v1/audit.pb.go
+```
+
+Expected: at least one match showing `Caller *eventbusv1.Actor` on the `QueryHistoryRequest` Go struct.
+
+- [ ] **Step 5: Verify build**
+
+```bash
+task build
+```
+
+Expected: success. Existing call sites that construct `QueryHistoryRequest` (`internal/eventbus/audit/plugin_router.go:70-74`) compile fine because `Caller` is just a new optional field.
+
+- [ ] **Step 6: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "feat(plugin-proto): add caller field to PluginAuditService.QueryHistory request
+
+Per spec docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md §4.1.
+Additive proto change; no plugin behavior change yet.
+
+Refs holomush-095g."
+jj new
+```
+
+`jj new` starts a fresh empty change so subsequent task commits don't clobber this one.
+
+---
+
+### Task 2: Export `ActorToProto` and `ActorKindToProto`
+
+**Files:**
+
+- Modify: `internal/eventbus/publisher.go:274,284` (rename + export)
+
+- [ ] **Step 1: Edit `internal/eventbus/publisher.go`**
+
+Find the existing `actorToProto` function around line 274 and rename to `ActorToProto`. Find `actorKindToProto` around line 284 and rename to `ActorKindToProto`. Update the body of `ActorToProto` to call the renamed `ActorKindToProto`.
+
+```go
+// ActorToProto converts an in-process Actor to the proto representation.
+// Exported so audit-router and other cross-package callers can reuse the
+// single source of truth for Actor mapping.
+func ActorToProto(a Actor) *eventbusv1.Actor {
+	p := &eventbusv1.Actor{Kind: ActorKindToProto(a.Kind)}
+	if a.ID != (ulid.ULID{}) {
+		p.Id = a.ID.Bytes()
+	} else if a.LegacyID != "" {
+		p.LegacyId = a.LegacyID
+	}
+	return p
+}
+
+// ActorKindToProto maps the in-process ActorKind enum to the proto enum.
+// ActorKindUnknown (zero) maps to ACTOR_KIND_UNSPECIFIED — there is no
+// proto ACTOR_KIND_UNKNOWN.
+func ActorKindToProto(k ActorKind) eventbusv1.ActorKind {
+	switch k {
+	case ActorKindCharacter:
+		return eventbusv1.ActorKind_ACTOR_KIND_CHARACTER
+	case ActorKindPlayer:
+		return eventbusv1.ActorKind_ACTOR_KIND_PLAYER
+	case ActorKindSystem:
+		return eventbusv1.ActorKind_ACTOR_KIND_SYSTEM
+	case ActorKindPlugin:
+		return eventbusv1.ActorKind_ACTOR_KIND_PLUGIN
+	default:
+		return eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED
+	}
+}
+```
+
+- [ ] **Step 2: Update in-package call sites**
+
+```bash
+rg -n "actorToProto|actorKindToProto" internal/eventbus/
+```
+
+For each match (in `internal/eventbus/publisher.go` and any other files in the same package that call these helpers), update the call to the new exported names. Use `sed` only if you've reviewed every match first; safer to use the Edit tool per file.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+task build
+```
+
+Expected: success across all packages. The rename was contained to one package.
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+```bash
+task test -- ./internal/eventbus/...
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "refactor(eventbus): export ActorToProto / ActorKindToProto
+
+Cross-package callers (audit-router) need the single-source proto mapping.
+No behavior change.
+
+Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 3: Add `Caller` field to `eventbus.HistoryQuery`
+
+**Files:**
+
+- Modify: `internal/eventbus/bus.go` (location of `HistoryQuery` struct)
+
+- [ ] **Step 1: Locate the struct**
+
+```bash
+rg -n "^type HistoryQuery struct" internal/eventbus/
+```
+
+Expected: a single match in `internal/eventbus/bus.go` (or wherever the struct is defined).
+
+- [ ] **Step 2: Add `Caller` field**
+
+Add a new field at the end of the struct definition. The exact ordering doesn't affect wire compat (this is a Go struct, not proto), but appending preserves git diff readability.
+
+```go
+type HistoryQuery struct {
+	Subject   Subject
+	Direction Direction
+	PageSize  int
+	NotBefore time.Time
+	NotAfter  time.Time
+	AfterSeq  uint64
+	AfterID   ulid.ULID
+	BeforeSeq uint64
+	BeforeID  ulid.ULID
+
+	// Caller identifies the principal on whose behalf the read is happening.
+	// Populated by the host's gRPC handler from the authenticated session
+	// record. Public-tier readers (hot JetStream, cold Postgres) ignore this
+	// field; plugin-owned subject routes (PluginHistoryRouter) MUST forward
+	// it to the plugin's PluginAuditService.QueryHistory for membership
+	// enforcement. See spec §4.2.
+	Caller Actor
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+task build
+```
+
+Expected: success. Adding a field doesn't break existing struct-literal constructions because they all use field-name syntax (verified by `rg "HistoryQuery{" --type go -A 1`).
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+```bash
+task test -- ./internal/eventbus/... ./internal/grpc/...
+```
+
+Expected: all green; the new field is unread by any existing path.
+
+- [ ] **Step 5: Close the wire-foundations bead and commit**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd close <wire-foundations-id>
+JJ_EDITOR=true jj --no-pager describe -m "feat(eventbus): add HistoryQuery.Caller field
+
+Required by plugin-router boundary for forwarding caller identity to
+PluginAuditService.QueryHistory. Public-tier readers ignore the field.
+
+Refs holomush-095g."
+jj new
+```
+
+---
+
+## Phase 2: Router gRPC status preservation
+
+### Task 4: Router caller forwarding + outer-call gRPC status pass-through
+
+**Files:**
+
+- Modify: `internal/eventbus/audit/plugin_router.go:70-101`
+- Test: `internal/eventbus/audit/plugin_router_test.go` (extend)
+
+- [ ] **Step 1: Claim the router bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <router-bead-id> --status=in_progress
+```
+
+- [ ] **Step 2: Write failing test for caller forwarding**
+
+Add to `internal/eventbus/audit/plugin_router_test.go` (anywhere after the existing `stubProvider`/`fakeStream` types — those are already defined at lines 60–82):
+
+```go
+func TestPluginHistoryRouterForwardsCallerVerbatim(t *testing.T) {
+	t.Parallel()
+
+	id := core.NewULID()
+	idBytes := id.Bytes()
+	callerID := core.NewULID()
+
+	fs := &fakeStream{
+		resps: []*pluginv1.QueryHistoryResponse{
+			{Event: &eventbusv1.Event{
+				Id:        idBytes[:],
+				Subject:   "events.main.scene.01ABC.ic",
+				Timestamp: timestamppb.New(time.Unix(1, 0)),
+			}},
+		},
+	}
+	fc := &fakeHistoryClient{stream: fs}
+	router := audit.NewPluginHistoryRouter(stubProvider{name: "core-scenes", client: fc})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:   "events.main.scene.01ABC.ic",
+		PageSize:  50,
+		Direction: eventbus.DirectionForward,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   callerID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, fc.lastReq)
+
+	gotCaller := fc.lastReq.GetCaller()
+	require.NotNil(t, gotCaller, "Caller MUST be set on the proto request")
+	assert.Equal(t, eventbusv1.ActorKind_ACTOR_KIND_CHARACTER, gotCaller.GetKind())
+	assert.Equal(t, callerID.Bytes()[:], gotCaller.GetId(), "Id bytes MUST match the caller ULID")
+}
+```
+
+- [ ] **Step 3: Run the test and verify it fails**
+
+```bash
+task test -- -run TestPluginHistoryRouterForwardsCallerVerbatim ./internal/eventbus/audit/
+```
+
+Expected: FAIL because `gotCaller` is nil — the router does not yet populate the field.
+
+- [ ] **Step 4: Edit `internal/eventbus/audit/plugin_router.go` lines 70–74**
+
+Find the `req := &pluginv1.QueryHistoryRequest{...}` construction and add the `Caller` field. The import already includes `"github.com/holomush/holomush/internal/eventbus"`; if the file does not already alias it, ensure the call uses the package-qualified `eventbus.ActorToProto`.
+
+```go
+req := &pluginv1.QueryHistoryRequest{
+	Subject:   string(q.Subject),
+	PageSize:  int32(pageSize),
+	Direction: directionProto(q.Direction),
+	Caller:    eventbus.ActorToProto(q.Caller),
+}
+```
+
+- [ ] **Step 5: Re-run the caller-forwarding test**
+
+```bash
+task test -- -run TestPluginHistoryRouterForwardsCallerVerbatim ./internal/eventbus/audit/
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write failing test for gRPC status pass-through on outer RPC error**
+
+Add another test to the same file. We need a fake client whose `QueryHistory` RPC immediately returns a `status.Error(codes.PermissionDenied, ...)` rather than opening a stream.
+
+```go
+// fakeStatusErrorClient returns a precise status error from QueryHistory.
+type fakeStatusErrorClient struct {
+	pluginv1.PluginAuditServiceClient
+	err error
+}
+
+func (c *fakeStatusErrorClient) QueryHistory(_ context.Context, _ *pluginv1.QueryHistoryRequest, _ ...grpc.CallOption) (pluginv1.PluginAuditService_QueryHistoryClient, error) {
+	return nil, c.err
+}
+
+func TestPluginHistoryRouterPreservesGRPCStatusOnQueryHistoryError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeStatusErrorClient{err: wantErr},
+	})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   core.NewULID(),
+		},
+	})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "router MUST return a recognisable status error, not an oops-wrapped opaque error")
+	assert.Equal(t, codes.PermissionDenied, st.Code(), "router MUST preserve the plugin's gRPC status code")
+}
+
+func TestPluginHistoryRouterWrapsNonStatusErrorOnQueryHistoryError(t *testing.T) {
+	t.Parallel()
+
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeStatusErrorClient{err: errors.New("transport failure")},
+	})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+	})
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "non-status errors MUST be oops-wrapped for diagnostic context")
+	assert.Equal(t, "AUDIT_PLUGIN_HISTORY_RPC_FAILED", oopsErr.Code())
+}
+```
+
+Add new imports as needed: `"errors"`, `"google.golang.org/grpc"`, `"google.golang.org/grpc/codes"`, `"google.golang.org/grpc/status"`, `"github.com/samber/oops"`. The other identifiers (`audit`, `eventbus`, `pluginv1`, `eventbusv1`, `core`) are already imported.
+
+- [ ] **Step 7: Run the new tests and verify they fail**
+
+```bash
+task test -- -run "TestPluginHistoryRouterPreservesGRPCStatusOnQueryHistoryError|TestPluginHistoryRouterWrapsNonStatusErrorOnQueryHistoryError" ./internal/eventbus/audit/
+```
+
+Expected: both FAIL — the existing code wraps every error with `oops.Code("AUDIT_PLUGIN_HISTORY_RPC_FAILED")`, so the status-preservation case fails, and the non-status case happens to pass for a different reason (incidental). Confirm both states.
+
+- [ ] **Step 8: Edit `internal/eventbus/audit/plugin_router.go` lines 95–102**
+
+Replace the existing error-wrap block:
+
+```go
+stream, err := client.QueryHistory(rpcCtx, req)
+if err != nil {
+	cancel()
+	return nil, oops.Code("AUDIT_PLUGIN_HISTORY_RPC_FAILED").
+		With("plugin", pluginName).
+		With("subject", string(q.Subject)).
+		Wrap(err)
+}
+```
+
+with:
+
+```go
+stream, err := client.QueryHistory(rpcCtx, req)
+if err != nil {
+	cancel()
+	// Preserve gRPC status codes from the plugin verbatim — the host's
+	// mapHistoryError relies on status.FromError for opacity translation.
+	// Only wrap non-status errors with our diagnostic oops code.
+	if st, ok := status.FromError(err); ok && st.Code() != codes.Unknown {
+		return nil, err
+	}
+	return nil, oops.Code("AUDIT_PLUGIN_HISTORY_RPC_FAILED").
+		With("plugin", pluginName).
+		With("subject", string(q.Subject)).
+		Wrap(err)
+}
+```
+
+Add imports if missing: `"google.golang.org/grpc/codes"`, `"google.golang.org/grpc/status"`.
+
+- [ ] **Step 9: Re-run the new tests**
+
+```bash
+task test -- -run "TestPluginHistoryRouterPreservesGRPCStatusOnQueryHistoryError|TestPluginHistoryRouterWrapsNonStatusErrorOnQueryHistoryError|TestPluginHistoryRouterForwardsCallerVerbatim" ./internal/eventbus/audit/
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 10: Run the full router test file to catch regressions**
+
+```bash
+task test -- ./internal/eventbus/audit/
+```
+
+Expected: all green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "feat(audit): forward caller and preserve gRPC status in PluginHistoryRouter
+
+- QueryHistory populates QueryHistoryRequest.Caller from q.Caller via
+  the exported eventbus.ActorToProto helper.
+- gRPC status codes from the plugin (e.g., PermissionDenied) round-trip
+  unchanged; only non-status errors get the AUDIT_PLUGIN_HISTORY_RPC_FAILED
+  diagnostic wrap.
+
+Per spec §4.2, §5.5. Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 5: `pluginHistoryStream.Next` gRPC status pass-through
+
+**Files:**
+
+- Modify: `internal/eventbus/audit/plugin_router.go:148-157` (`pluginHistoryStream.Next`)
+- Test: `internal/eventbus/audit/plugin_router_test.go` (extend)
+
+- [ ] **Step 1: Write failing test for stream-level gRPC status pass-through**
+
+Add to `plugin_router_test.go`. We extend `fakeStream` so it can return a mid-stream `status.Error` from `RecvMsg` / `Recv`.
+
+```go
+// fakeStreamWithRecvErr returns the given err from Recv.
+type fakeStreamWithRecvErr struct {
+	fakeStream
+	err error
+}
+
+func (s *fakeStreamWithRecvErr) Recv() (*pluginv1.QueryHistoryResponse, error) {
+	return nil, s.err
+}
+
+// fakeRecvErrClient hands out a stream whose Recv returns the error.
+type fakeRecvErrClient struct {
+	pluginv1.PluginAuditServiceClient
+	streamErr error
+}
+
+func (c *fakeRecvErrClient) QueryHistory(_ context.Context, _ *pluginv1.QueryHistoryRequest, _ ...grpc.CallOption) (pluginv1.PluginAuditService_QueryHistoryClient, error) {
+	return &fakeStreamWithRecvErr{err: c.streamErr}, nil
+}
+
+func TestPluginHistoryStreamPreservesGRPCStatusOnRecvError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeRecvErrClient{streamErr: wantErr},
+	})
+
+	stream, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   core.NewULID(),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = stream.Next(context.Background())
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "stream Next MUST return a recognisable status error from the plugin")
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+task test -- -run TestPluginHistoryStreamPreservesGRPCStatusOnRecvError ./internal/eventbus/audit/
+```
+
+Expected: FAIL — `Next` currently wraps every Recv error with `oops.Code("AUDIT_PLUGIN_HISTORY_RECV_FAILED")`.
+
+- [ ] **Step 3: Edit `internal/eventbus/audit/plugin_router.go` lines 148–157**
+
+Replace:
+
+```go
+resp, err := s.rpc.Recv()
+close(doneCh)
+if err != nil {
+	if errors.Is(err, io.EOF) {
+		return eventbus.Event{}, io.EOF
+	}
+	return eventbus.Event{}, oops.Code("AUDIT_PLUGIN_HISTORY_RECV_FAILED").
+		With("plugin", s.pluginName).
+		With("subject", s.subject).
+		Wrap(err)
+}
+```
+
+with:
+
+```go
+resp, err := s.rpc.Recv()
+close(doneCh)
+if err != nil {
+	if errors.Is(err, io.EOF) {
+		return eventbus.Event{}, io.EOF
+	}
+	// Same pattern as the outer QueryHistory: preserve gRPC status codes
+	// so mapHistoryError can do opacity translation; wrap non-status only.
+	if st, ok := status.FromError(err); ok && st.Code() != codes.Unknown {
+		return eventbus.Event{}, err
+	}
+	return eventbus.Event{}, oops.Code("AUDIT_PLUGIN_HISTORY_RECV_FAILED").
+		With("plugin", s.pluginName).
+		With("subject", s.subject).
+		Wrap(err)
+}
+```
+
+- [ ] **Step 4: Re-run the test**
+
+```bash
+task test -- -run TestPluginHistoryStreamPreservesGRPCStatusOnRecvError ./internal/eventbus/audit/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full audit package tests**
+
+```bash
+task test -- ./internal/eventbus/audit/
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Close the router bead and commit**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd close <router-bead-id>
+JJ_EDITOR=true jj --no-pager describe -m "feat(audit): preserve gRPC status on plugin history stream Recv
+
+Mirror the outer QueryHistory pattern: status.FromError-recognised codes
+round-trip; transport / non-status errors get oops-wrapped.
+
+Per spec §5.5. Refs holomush-095g."
+jj new
+```
+
+---
+
+## Phase 3: Host handler integration
+
+### Task 6: Thread caller through `fetchHistoryFramesFromBus`
+
+**Files:**
+
+- Modify: `internal/grpc/query_stream_history.go:219` (call site) and `:279-308` (function signature + body)
+- Test: `internal/grpc/query_stream_history_test.go` (extend)
+
+- [ ] **Step 1: Claim the host-handler bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <host-handler-bead-id> --status=in_progress
+```
+
+- [ ] **Step 2: Write failing test for caller threading**
+
+The existing `internal/grpc/query_stream_history_test.go` already has the scaffolding we need: `fakeHistoryReader` (line 39) records `gotQ eventbus.HistoryQuery`, and `newQueryStreamHistoryServer(t, reader, sess)` (line 82) is the harness builder. Add a new test that uses both:
+
+```go
+func TestQueryStreamHistoryThreadsCallerFromSession(t *testing.T) {
+	t.Parallel()
+
+	charID := ulid.MustParse("01HYXCHAR0000000000000000C")
+	sessionInfo := &session.Info{
+		CharacterID: charID,
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	sess := newTestSessionStore(t, map[string]*session.Info{"sess-1": sessionInfo})
+
+	reader := &fakeHistoryReader{}
+	server := newQueryStreamHistoryServer(t, reader, sess)
+
+	// Public stream so the I-17 gate doesn't fire — focuses the test on
+	// caller threading. Use ABAC-allow-all (already wired by the harness).
+	_, err := server.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "sess-1",
+		Stream:    "location:01HYXLOC00000000000000000",
+		Count:     10,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, eventbus.ActorKindCharacter, reader.gotQ.Caller.Kind,
+		"handler MUST set Caller.Kind = ActorKindCharacter")
+	assert.Equal(t, charID, reader.gotQ.Caller.ID,
+		"handler MUST set Caller.ID from info.CharacterID")
+}
+```
+
+The exact construction of `*session.Info` and the signature of `newTestSessionStore` are already established by the existing tests in the file (e.g., `TestQueryStreamHistoryRejectsExpiredSession` shows the pattern). If your `session.Info` literal doesn't compile, copy from the nearest existing test in the same file — the type may have additional required fields by the time you implement.
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+```bash
+task test -- -run TestQueryStreamHistoryThreadsCallerFromSession ./internal/grpc/
+```
+
+Expected: FAIL because `reader.gotQuery.Caller` is the zero `Actor{}`.
+
+- [ ] **Step 4: Update `fetchHistoryFramesFromBus` signature**
+
+Edit `internal/grpc/query_stream_history.go` at the function definition (around line 279). Add `caller eventbus.Actor` as the new last parameter, and set it on the constructed `HistoryQuery`.
+
+```go
+func fetchHistoryFramesFromBus(
+	ctx context.Context,
+	reader eventbus.HistoryReader,
+	gameID, legacyStream string,
+	count int,
+	notBefore time.Time,
+	beforeSeq uint64,
+	beforeID ulid.ULID,
+	caller eventbus.Actor,
+) ([]*corev1.EventFrame, error) {
+	natsSubject, err := subjectxlate.Legacy(legacyStream, gameID)
+	if err != nil {
+		return nil, oops.With("stream", legacyStream).Wrap(err)
+	}
+	sub, err := eventbus.NewSubject(natsSubject)
+	if err != nil {
+		return nil, oops.With("stream", legacyStream).Wrap(err)
+	}
+
+	q := eventbus.HistoryQuery{
+		Subject:   sub,
+		Direction: eventbus.DirectionBackward,
+		PageSize:  count + 1,
+		NotBefore: notBefore,
+		Caller:    caller,
+	}
+	if beforeSeq != 0 {
+		q.BeforeSeq = beforeSeq
+		q.BeforeID = beforeID
+	} else if !beforeID.IsZero() {
+		q.BeforeID = beforeID
+	}
+	// ... rest of existing function body unchanged ...
+```
+
+- [ ] **Step 5: Update the call site at line 219**
+
+In the `QueryStreamHistory` handler, after Step 5 (authorization), construct the caller and pass it through:
+
+```go
+caller := eventbus.Actor{
+	Kind: eventbus.ActorKindCharacter,
+	ID:   info.CharacterID,
+}
+frames, fetchErr := fetchHistoryFramesFromBus(
+	ctx, s.historyReader, s.currentGameID(), req.Stream, count,
+	notBefore, beforeSeq, beforeID, caller,
+)
+```
+
+- [ ] **Step 6: Re-run the test**
+
+```bash
+task test -- -run TestQueryStreamHistoryThreadsCallerFromSession ./internal/grpc/
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full handler tests**
+
+```bash
+task test -- ./internal/grpc/
+```
+
+Expected: all green. The signature change to `fetchHistoryFramesFromBus` is contained within the file; no external callers exist (confirm via `rg "fetchHistoryFramesFromBus"`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "feat(grpc): thread caller from session into HistoryQuery
+
+QueryStreamHistory derives Actor{Kind: Character, ID: info.CharacterID}
+and passes it to fetchHistoryFramesFromBus, which sets q.Caller before
+calling reader.QueryHistory.
+
+Per spec §4.3. Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 7: Extend `mapHistoryError` with gRPC status dispatch
+
+**Files:**
+
+- Modify: `internal/grpc/query_stream_history.go:259-270`
+- Test: `internal/grpc/query_stream_history_test.go` (extend)
+
+- [ ] **Step 1: Write failing tests for the new dispatch step**
+
+Add to the same test file:
+
+```go
+func TestMapHistoryErrorTranslatesPermissionDeniedToOpaqueOopsCode(t *testing.T) {
+	t.Parallel()
+
+	pluginErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	got := mapHistoryError(pluginErr)
+	require.Error(t, got)
+
+	oopsErr, ok := oops.AsOops(got)
+	require.True(t, ok, "translated error MUST be oops-wrapped")
+	assert.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
+		"PermissionDenied from the plugin MUST collapse into the same opaque oops code the outer I-17 gate uses")
+}
+
+func TestMapHistoryErrorPassesThroughInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	pluginErr := status.Error(codes.InvalidArgument, "subject malformed")
+	got := mapHistoryError(pluginErr)
+	require.Error(t, got)
+
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestMapHistoryErrorRetainsCursorInvalidDispatchForNonStatusErrors(t *testing.T) {
+	t.Parallel()
+
+	got := mapHistoryError(eventbus.ErrCursorInvalid)
+	require.Error(t, got)
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code(),
+		"existing cursor-error dispatch MUST still apply when no gRPC status is present")
+}
+```
+
+- [ ] **Step 2: Run, verify failures**
+
+```bash
+task test -- -run "TestMapHistoryError" ./internal/grpc/
+```
+
+Expected: the first test FAILS (no oops code on returned err), the second FAILS (no dispatch), the third PASSES already (existing behavior).
+
+- [ ] **Step 3: Edit `internal/grpc/query_stream_history.go` lines 259–270**
+
+Prepend a status-code dispatch step BEFORE the existing `errors.Is` chain:
+
+```go
+func mapHistoryError(err error) error {
+	// gRPC status pass-through with opacity translation. The plugin emits
+	// status.Error directly; the router preserves the code; we run this
+	// dispatch FIRST so the existing cursor-error chain doesn't shadow it.
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.PermissionDenied:
+			// Opaque: collapse plugin-boundary denial into the same oops
+			// code the outer I-17 gate uses. Client cannot distinguish
+			// "outer wall caught" from "plugin wall caught."
+			return oops.Code("STREAM_ACCESS_DENIED").
+				Errorf("not authorized to read stream")
+		case codes.InvalidArgument:
+			return status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		// Other status codes (Internal, Unavailable, …) pass through.
+	}
+	switch {
+	case errors.Is(err, eventbus.ErrCursorInvalid):
+		return status.Errorf(codes.InvalidArgument, "%v", err)
+	case errors.Is(err, eventbus.ErrCursorStale):
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
+	case errors.Is(err, eventbus.ErrCursorLag):
+		return status.Errorf(codes.Unavailable, "%v", err)
+	default:
+		return err // let oops wrap through
+	}
+}
+```
+
+- [ ] **Step 4: Re-run the tests**
+
+```bash
+task test -- -run "TestMapHistoryError" ./internal/grpc/
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run the full handler test package**
+
+```bash
+task test -- ./internal/grpc/
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Close the host-handler bead and commit**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd close <host-handler-bead-id>
+JJ_EDITOR=true jj --no-pager describe -m "feat(grpc): translate plugin PermissionDenied to opaque STREAM_ACCESS_DENIED
+
+mapHistoryError now runs a gRPC-status dispatch step before the existing
+errors.Is chain. PermissionDenied collapses into the same oops code the
+outer I-17 gate uses; InvalidArgument passes through; other codes fall
+through to existing behavior.
+
+Per spec §5.5. Refs holomush-095g."
+jj new
+```
+
+---
+
+## Phase 4: Plugin enforcement
+
+### Task 8: `SceneStore.IsMember` helper
+
+**Files:**
+
+- Modify: `plugins/core-scenes/store.go` (add new method)
+- Test: `plugins/core-scenes/store_integration_test.go` (extend)
+
+- [ ] **Step 1: Claim the plugin bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <plugin-bead-id> --status=in_progress
+```
+
+- [ ] **Step 2: Write failing integration test**
+
+Add to `plugins/core-scenes/store_integration_test.go`. The file already uses testcontainers; locate the existing setup helper (likely `setupSceneStore(t)` or similar) and reuse it. New test:
+
+```go
+func TestSceneStoreIsMemberReturnsTrueForOwner(t *testing.T) {
+	store, cleanup := setupSceneStore(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	sceneID := "01SCENE000000000000000000"
+	ownerID := "01CHAR0OWNER0000000000000"
+
+	_, err := store.CreateScene(ctx, sceneID, ownerID, "Test scene", false)
+	require.NoError(t, err)
+
+	got, err := store.IsMember(ctx, sceneID, ownerID)
+	require.NoError(t, err)
+	assert.True(t, got, "owner MUST be reported as member")
+}
+
+func TestSceneStoreIsMemberReturnsTrueForMember(t *testing.T) {
+	store, cleanup := setupSceneStore(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	sceneID := "01SCENE000000000000000000"
+	ownerID := "01CHAR0OWNER0000000000000"
+	memberID := "01CHAR0MEMBER000000000000"
+
+	_, err := store.CreateScene(ctx, sceneID, ownerID, "Test scene", false)
+	require.NoError(t, err)
+	// Reuse the existing JoinScene path or whatever the file uses to add members.
+	_, err = store.JoinScene(ctx, sceneID, memberID)
+	require.NoError(t, err)
+
+	got, err := store.IsMember(ctx, sceneID, memberID)
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func TestSceneStoreIsMemberReturnsFalseForInvited(t *testing.T) {
+	store, cleanup := setupSceneStore(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	sceneID := "01SCENE000000000000000000"
+	ownerID := "01CHAR0OWNER0000000000000"
+	invitedID := "01CHAR0INVITED00000000000"
+
+	_, err := store.CreateScene(ctx, sceneID, ownerID, "Private scene", true)
+	require.NoError(t, err)
+	err = store.InviteParticipant(ctx, sceneID, ownerID, invitedID)
+	require.NoError(t, err)
+
+	got, err := store.IsMember(ctx, sceneID, invitedID)
+	require.NoError(t, err)
+	assert.False(t, got, "invited-only rows MUST return false — invitation grants join, not read")
+}
+
+func TestSceneStoreIsMemberReturnsFalseForNonParticipant(t *testing.T) {
+	store, cleanup := setupSceneStore(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	sceneID := "01SCENE000000000000000000"
+	ownerID := "01CHAR0OWNER0000000000000"
+	otherID := "01CHAR0OTHER000000000000"
+
+	_, err := store.CreateScene(ctx, sceneID, ownerID, "Test scene", false)
+	require.NoError(t, err)
+
+	got, err := store.IsMember(ctx, sceneID, otherID)
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestSceneStoreIsMemberReturnsFalseForMissingScene(t *testing.T) {
+	store, cleanup := setupSceneStore(t)
+	t.Cleanup(cleanup)
+
+	got, err := store.IsMember(context.Background(),
+		"01SCENE000000000000000000", "01CHAR000000000000000000")
+	require.NoError(t, err, "missing scene MUST be nil error per spec §5.4 (info-hiding)")
+	assert.False(t, got)
+}
+```
+
+If the existing file uses different helper names (`SeedScene`, `AddParticipant`, etc.), adapt the calls. The behavior assertions don't change.
+
+- [ ] **Step 3: Run the integration tests, verify they fail**
+
+```bash
+task test:int -- -run "TestSceneStoreIsMember" ./plugins/core-scenes/
+```
+
+The plugin store integration tests live at `./plugins/core-scenes/` (verified against the canonical package list in `Taskfile.yaml:test:int`, which enumerates `./plugins/core-scenes/` among the integration targets). Expected: FAIL with "store.IsMember undefined."
+
+- [ ] **Step 4: Add `IsMember` to `plugins/core-scenes/store.go`**
+
+Append after `GetWithMembership` (around line 326):
+
+```go
+// IsMember reports whether characterID has an owner or member row in
+// sceneID. Invited-only rows return false — invitation grants join
+// rights, not read rights (see spec §5.4 for the deliberate role-policy
+// tightening).
+//
+// Missing scene and missing row both return (false, nil) by design: the
+// audit-read boundary MUST NOT distinguish "scene doesn't exist" from
+// "you're not a member" because that would leak scene existence to
+// non-members. Internal logs MAY tag the cases distinctly via slog
+// attributes; the function's return type does not.
+func (s *SceneStore) IsMember(ctx context.Context, sceneID, characterID string) (bool, error) {
+	const q = `
+		SELECT 1
+		FROM scene_participants
+		WHERE scene_id = $1
+		  AND character_id = $2
+		  AND role IN ('owner', 'member')
+		LIMIT 1
+	`
+	var one int
+	err := s.pool.QueryRow(ctx, q, sceneID, characterID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, oops.Code("SCENE_STORE_IS_MEMBER_FAILED").
+			With("scene_id", sceneID).
+			With("character_id", characterID).
+			Wrap(err)
+	}
+	return true, nil
+}
+```
+
+If `s.pool` is named differently (e.g., `s.db`), match the file's existing convention. Confirm by reading lines 1–80 of `store.go`. Imports needed: `errors`, `github.com/jackc/pgx/v5`. Add them only if not already present.
+
+- [ ] **Step 5: Re-run the integration tests**
+
+```bash
+task test:int -- -run "TestSceneStoreIsMember" ./plugins/core-scenes/
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "feat(core-scenes): add SceneStore.IsMember helper
+
+Narrow indexed lookup on scene_participants for the audit-read boundary.
+Invited-only rows return false; missing scene returns (false, nil) for
+information-hiding (spec §5.4).
+
+Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 9: Plugin `SceneAuditServer.QueryHistory` enforcement
+
+**Files:**
+
+- Modify: `plugins/core-scenes/audit.go:202-269` (replace `QueryHistory` body and docstring)
+- Test: `plugins/core-scenes/audit_test.go` (create)
+
+- [ ] **Step 1: Create the test scaffolding**
+
+Create `plugins/core-scenes/audit_test.go`. The plugin compiles as `package main`; tests can live in the same package. We need a fake `pluginv1.PluginAuditService_QueryHistoryServer` to capture sends, and a fake store that records whether `queryLog` was called.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// fakeAuditServerStream satisfies pluginv1.PluginAuditService_QueryHistoryServer
+// and records every Send.
+type fakeAuditServerStream struct {
+	grpc.ServerStream
+	ctx       context.Context
+	sends     []*pluginv1.QueryHistoryResponse
+	sendErr   error
+}
+
+func (s *fakeAuditServerStream) Context() context.Context  { return s.ctx }
+func (s *fakeAuditServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeAuditServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeAuditServerStream) SetTrailer(metadata.MD)       {}
+func (s *fakeAuditServerStream) Send(resp *pluginv1.QueryHistoryResponse) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sends = append(s.sends, resp)
+	return nil
+}
+
+// fakeAuditStore records calls made by SceneAuditServer during a test.
+// It satisfies BOTH sceneAuditLogStore and sceneMembershipLookup so a
+// single instance can serve as the test double for both store fields.
+type fakeAuditStore struct {
+	queryLogCalled bool
+	rows           []logRow
+	queryLogErr    error
+	isMemberMap    map[string]bool // key: sceneID|characterID
+}
+
+func (s *fakeAuditStore) IsMember(_ context.Context, sceneID, characterID string) (bool, error) {
+	if s.isMemberMap == nil {
+		return false, nil
+	}
+	return s.isMemberMap[sceneID+"|"+characterID], nil
+}
+
+// queryLog matches *SceneAuditStore.queryLog verbatim (verified against
+// plugins/core-scenes/audit.go before the rewrite — uses *timestamppb.Timestamp,
+// not time.Time, for notBefore/notAfter).
+func (s *fakeAuditStore) queryLog(
+	_ context.Context,
+	_ string,
+	_, _ []byte,
+	_, _ *timestamppb.Timestamp,
+	_ bool,
+	_ int,
+) ([]logRow, error) {
+	s.queryLogCalled = true
+	if s.queryLogErr != nil {
+		return nil, s.queryLogErr
+	}
+	return s.rows, nil
+}
+
+func ulidStringBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	id, err := ulid.Parse(s)
+	require.NoError(t, err)
+	b := id.Bytes()
+	return b[:]
+}
+```
+
+`SceneAuditServer.store` is currently typed as a concrete `*SceneAuditStore`. To make the server testable without a real PG pool AND to give it access to `SceneStore.IsMember` (which lives on the *parent* `*SceneStore`, not the audit store), restructure the server:
+
+1. Open `plugins/core-scenes/audit.go`. Find the existing `SceneAuditStore.queryLog` method signature — copy it verbatim into the interface below. Do NOT rewrite the parameter types; the existing signature passes `*timestamppb.Timestamp` directly (verified against current call site at `audit.go:244-245`). The interface MUST match the existing method exactly so `*SceneAuditStore` satisfies it without code change.
+
+2. Add two interfaces and update the `SceneAuditServer` struct:
+
+```go
+// sceneAuditLogStore is the log-storage surface SceneAuditServer needs.
+// Signature matches *SceneAuditStore.queryLog verbatim (verified at
+// plugins/core-scenes/audit.go before the rewrite).
+type sceneAuditLogStore interface {
+	queryLog(
+		ctx context.Context,
+		subject string,
+		after, before []byte,
+		notBefore, notAfter *timestamppb.Timestamp,
+		reverse bool,
+		pageSize int,
+	) ([]logRow, error)
+}
+
+// sceneMembershipLookup is the membership-check surface SceneAuditServer
+// needs. *SceneStore (Task 8) satisfies this.
+type sceneMembershipLookup interface {
+	IsMember(ctx context.Context, sceneID, characterID string) (bool, error)
+}
+
+type SceneAuditServer struct {
+	pluginv1.UnimplementedPluginAuditServiceServer
+	store        sceneAuditLogStore    // queryLog only
+	memberLookup sceneMembershipLookup // IsMember only
+}
+```
+
+3. Update wiring in `main.go:108`:
+
+```go
+p.auditSrv.store = NewSceneAuditStore(store.Pool())
+p.auditSrv.memberLookup = store // *SceneStore satisfies sceneMembershipLookup
+```
+
+Verify `task build` passes after these structural changes before writing the new tests in Step 2.
+
+- [ ] **Step 2: Write failing auth-dispatch tests**
+
+Append to `plugins/core-scenes/audit_test.go`:
+
+```go
+func TestQueryHistoryRejectsNilCaller(t *testing.T) {
+	srv := &SceneAuditServer{
+		store:        &fakeAuditStore{},
+		memberLookup: &fakeAuditStore{},
+	}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene.01ABC0000000000000000000.ic",
+		Caller:  nil, // explicit
+	}, stream)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "auth denial MUST emit gRPC status")
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+func TestQueryHistoryRejectsCharacterCallerWithZeroID(t *testing.T) {
+	srv := &SceneAuditServer{
+		store:        &fakeAuditStore{},
+		memberLookup: &fakeAuditStore{},
+	}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene.01ABC0000000000000000000.ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   nil, // zero
+		},
+	}, stream)
+
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+func TestQueryHistoryRejectsNonCharacterKinds(t *testing.T) {
+	cases := []eventbusv1.ActorKind{
+		eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED,
+		eventbusv1.ActorKind_ACTOR_KIND_PLAYER,
+		eventbusv1.ActorKind_ACTOR_KIND_SYSTEM,
+		eventbusv1.ActorKind_ACTOR_KIND_PLUGIN,
+	}
+	for _, k := range cases {
+		t.Run(k.String(), func(t *testing.T) {
+			srv := &SceneAuditServer{
+				store:        &fakeAuditStore{},
+				memberLookup: &fakeAuditStore{},
+			}
+			stream := &fakeAuditServerStream{ctx: context.Background()}
+
+			err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+				Subject: "events.main.scene.01ABC0000000000000000000.ic",
+				Caller: &eventbusv1.Actor{
+					Kind: k,
+					Id:   ulidStringBytes(t, "01CHAR000000000000000000"),
+				},
+			}, stream)
+			require.Error(t, err)
+			st, _ := status.FromError(err)
+			assert.Equal(t, codes.PermissionDenied, st.Code())
+		})
+	}
+}
+
+func TestQueryHistoryAllowsMemberAndReturnsRows(t *testing.T) {
+	sceneID := "01ABC0000000000000000000"
+	charIDStr := "01CHAR000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{
+		rows: []logRow{
+			{id: ulidStringBytes(t, "01EVENT00000000000000000"),
+				subject:   "events.main.scene." + sceneID + ".ic",
+				eventType: "scene.pose.posted",
+				timestamp: time.Unix(100, 0),
+			},
+		},
+	}
+	memberStore := &fakeAuditStore{
+		isMemberMap: map[string]bool{sceneID + "|" + charIDStr: true},
+	}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.sends, 1)
+	assert.Equal(t, "scene.pose.posted", stream.sends[0].GetEvent().GetType())
+}
+
+func TestQueryHistoryDeniesNonMemberWithoutHittingLogStore(t *testing.T) {
+	sceneID := "01ABC0000000000000000000"
+	charIDStr := "01CHAR000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{} // no rows; we assert it isn't called
+	memberStore := &fakeAuditStore{isMemberMap: map[string]bool{}}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream)
+
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.False(t, logStore.queryLogCalled,
+		"log store MUST NOT be queried when auth denies — auth is step 1, before any DB work")
+}
+
+func TestQueryHistoryRejectsMalformedSubject(t *testing.T) {
+	cases := []string{
+		"",                                // empty — existing SCENE_AUDIT_SUBJECT_REQUIRED
+		"events.main.location.01XYZ.ic",   // not scene
+		"not.events.prefix.scene.01.ic",   // not events.*
+		"events.main.scene.*.ic",          // wildcard in sceneID
+		"events.main.scene.>",             // wildcard
+		"events.main.scene",               // too few tokens
+	}
+	for _, subj := range cases {
+		t.Run(subj, func(t *testing.T) {
+			srv := &SceneAuditServer{
+				store:        &fakeAuditStore{},
+				memberLookup: &fakeAuditStore{isMemberMap: map[string]bool{}},
+			}
+			stream := &fakeAuditServerStream{ctx: context.Background()}
+
+			err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+				Subject: subj,
+				Caller: &eventbusv1.Actor{
+					Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+					Id:   ulidStringBytes(t, "01CHAR000000000000000000"),
+				},
+			}, stream)
+			require.Error(t, err)
+			st, _ := status.FromError(err)
+			// Empty subject keeps the existing SCENE_AUDIT_SUBJECT_REQUIRED
+			// path (also INVALID_ARGUMENT). All others go through the new
+			// SCENE_AUDIT_SUBJECT_INVALID path.
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+```bash
+task test -- ./plugins/core-scenes/
+```
+
+Expected: all the new tests FAIL — current `QueryHistory` has no caller validation, no membership check, and no subject parsing beyond the empty-string guard.
+
+- [ ] **Step 4: Replace `QueryHistory` in `plugins/core-scenes/audit.go`**
+
+Replace lines 202–269 with the new implementation. Drop the TODO; rewrite the docstring to describe the enforcement contract.
+
+```go
+// QueryHistory streams scene_log rows matching the request after enforcing
+// scene membership at the plugin boundary. Authorisation is step 1 and runs
+// BEFORE cursor decoding or any DB query — the early-rejection ordering
+// avoids timing oracles and is pinned by audit_test.go's
+// TestQueryHistoryDeniesNonMemberWithoutHittingLogStore.
+//
+// The caller (req.Caller) is forwarded verbatim from the host's
+// CoreServer.QueryStreamHistory handler (which derives it from the
+// authenticated session). Plugins MUST NOT trust client-supplied identity;
+// see spec §3.2 for the trust model.
+//
+// Membership policy: only owner and member roles see rows. Invited rows
+// return PERMISSION_DENIED — invitation grants join rights, not passive
+// read rights (spec §5.4). Non-CHARACTER caller kinds are rejected;
+// admin / system / cross-plugin reads are deferred to a future RPC.
+//
+// Errors:
+//   - codes.PermissionDenied — caller missing, kind unsupported, or non-member
+//   - codes.InvalidArgument  — subject empty or malformed
+//   - codes.Internal         — store / DB error
+func (s *SceneAuditServer) QueryHistory(req *pluginv1.QueryHistoryRequest, stream pluginv1.PluginAuditService_QueryHistoryServer) error {
+	if req == nil || req.GetSubject() == "" {
+		return status.Error(codes.InvalidArgument, "subject required")
+	}
+
+	// Auth — step 1, before any other work.
+	caller := req.GetCaller()
+	if caller == nil {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller missing",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller required")
+	}
+	if caller.GetKind() != eventbusv1.ActorKind_ACTOR_KIND_CHARACTER {
+		slog.InfoContext(stream.Context(), "scene audit denied — non-character caller",
+			"subject", req.GetSubject(), "kind", caller.GetKind().String(),
+			"code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "unsupported caller kind")
+	}
+	callerIDBytes := caller.GetId()
+	if len(callerIDBytes) != 16 {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller id wrong length",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller id required")
+	}
+	var callerULID ulid.ULID
+	copy(callerULID[:], callerIDBytes)
+	if callerULID == (ulid.ULID{}) {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller id zero",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller id required")
+	}
+	callerCharID := callerULID.String()
+
+	// Subject parse.
+	sceneID, err := parseSceneSubject(req.GetSubject())
+	if err != nil {
+		slog.InfoContext(stream.Context(), "scene audit denied — subject malformed",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_SUBJECT_INVALID")
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Membership check.
+	ok, err := s.memberLookup.IsMember(stream.Context(), sceneID, callerCharID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "membership lookup failed: %v", err)
+	}
+	if !ok {
+		slog.InfoContext(stream.Context(), "scene audit denied — non-member",
+			"subject", req.GetSubject(), "scene_id", sceneID,
+			"character_id", callerCharID, "code", "SCENE_AUDIT_ACCESS_DENIED")
+		return status.Error(codes.PermissionDenied, "not a participant")
+	}
+
+	// From here, the existing pagination + streaming logic runs unchanged.
+	ctx := stream.Context()
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = auditDefaultPageSize
+	}
+	if pageSize > auditMaxPageSize {
+		pageSize = auditMaxPageSize
+	}
+
+	dir := req.GetDirection()
+	if dir == 0 {
+		dir = directionForward
+	}
+
+	var (
+		afterCursor  []byte
+		beforeCursor []byte
+	)
+	if v := req.GetAfter(); len(v) > 0 {
+		afterCursor = v
+	}
+	if v := req.GetBefore(); len(v) > 0 {
+		beforeCursor = v
+	}
+
+	// IMPORTANT: this call expression MUST match the existing pre-edit
+	// code at audit.go:244-245 verbatim. The current code passes
+	// req.GetNotBefore() / req.GetNotAfter() (proto Timestamps) directly
+	// — do NOT wrap with .AsTime() unless the existing queryLog signature
+	// has changed. Copy the call from the pre-edit version.
+	rows, err := s.store.queryLog(ctx, req.GetSubject(), afterCursor, beforeCursor,
+		req.GetNotBefore(), req.GetNotAfter(), dir == directionBackward, pageSize)
+	if err != nil {
+		return err
+	}
+
+	for i := range rows {
+		row := &rows[i]
+		resp := &pluginv1.QueryHistoryResponse{
+			Event: &eventbusv1.Event{
+				Id:        row.id,
+				Subject:   row.subject,
+				Type:      row.eventType,
+				Timestamp: timestamppb.New(row.timestamp),
+				Actor:     actorProtoFromRow(row.actorKind, row.actorID),
+				Payload:   row.payload,
+			},
+		}
+		if err := stream.Send(resp); err != nil {
+			return status.Errorf(codes.Internal, "send failed for subject %s: %v",
+				req.GetSubject(), err)
+		}
+	}
+	return nil
+}
+
+// parseSceneSubject extracts sceneID from a JetStream-native scene subject.
+// Expected: events.<gameID>.scene.<sceneID>.<channel>[.<...>]. Rejects
+// wildcard tokens and malformed shapes. See spec §5.3.
+func parseSceneSubject(subject string) (string, error) {
+	parts := strings.Split(subject, ".")
+	if len(parts) < 5 {
+		return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+			With("subject", subject).
+			Errorf("subject does not match events.<game>.scene.<id>.<channel>")
+	}
+	if parts[0] != "events" || parts[2] != "scene" {
+		return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+			With("subject", subject).
+			Errorf("subject not owned by core-scenes")
+	}
+	for _, p := range parts {
+		if strings.ContainsAny(p, "*>") {
+			return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+				With("subject", subject).
+				Errorf("wildcard subjects not permitted for QueryHistory")
+		}
+	}
+	return parts[3], nil
+}
+```
+
+Imports needed at top of `audit.go` (verified against the current file: `slog` is NOT yet imported; the others are also new):
+
+- `"log/slog"`
+- `"strings"`
+- `"google.golang.org/grpc/codes"`
+- `"google.golang.org/grpc/status"`
+
+Already imported and unchanged: `"context"`, `"time"`, `"github.com/oklog/ulid/v2"`, `"github.com/samber/oops"`, `"google.golang.org/protobuf/types/known/timestamppb"`, the proto packages.
+
+- [ ] **Step 5: Run unit tests, verify they pass**
+
+```bash
+task test -- ./plugins/core-scenes/
+```
+
+Expected: all green, including the new tests.
+
+- [ ] **Step 6: Run plugin integration tests**
+
+```bash
+task test:int -- ./test/integration/plugin/...
+```
+
+Expected: existing plugin tests still pass. The wire change is additive.
+
+- [ ] **Step 7: Add the early-rejection regression test explicitly**
+
+Confirm `TestQueryHistoryDeniesNonMemberWithoutHittingLogStore` (Step 2) is in the file; this is the load-bearing pin against future ordering regressions per spec §6.1.
+
+- [ ] **Step 8: Add the membership-change-mid-pagination test**
+
+Append to `audit_test.go`:
+
+```go
+func TestQueryHistoryReChecksMembershipAcrossPaginations(t *testing.T) {
+	sceneID := "01ABC0000000000000000000"
+	charIDStr := "01CHAR000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{
+		rows: []logRow{{
+			id:        ulidStringBytes(t, "01EVENT00000000000000000"),
+			subject:   "events.main.scene." + sceneID + ".ic",
+			eventType: "scene.pose.posted",
+			timestamp: time.Unix(100, 0),
+		}},
+	}
+	memberStore := &fakeAuditStore{
+		isMemberMap: map[string]bool{sceneID + "|" + charIDStr: true},
+	}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+
+	// Page 1 — member, rows returned.
+	stream1 := &fakeAuditServerStream{ctx: context.Background()}
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream1)
+	require.NoError(t, err)
+	require.Len(t, stream1.sends, 1)
+
+	// Simulate kick.
+	delete(memberStore.isMemberMap, sceneID+"|"+charIDStr)
+
+	// Page 2 — no longer member, denied.
+	stream2 := &fakeAuditServerStream{ctx: context.Background()}
+	err = srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream2)
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Empty(t, stream2.sends)
+}
+```
+
+- [ ] **Step 9: Re-run the test**
+
+```bash
+task test -- -run TestQueryHistoryReChecksMembershipAcrossPaginations ./plugins/core-scenes/
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "feat(core-scenes): enforce scene membership at PluginAuditService.QueryHistory
+
+Auth runs as step 1: caller validation (kind=CHARACTER, non-zero ID),
+subject parse, membership check via SceneStore.IsMember. Non-members
+(including invited-only) get PERMISSION_DENIED before any log query
+runs. Removes the TODO at audit.go:211.
+
+Per spec §5.1-5.5. Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 10: Run full unit suite for plugin packages
+
+- [ ] **Step 1: Run plugin unit tests**
+
+```bash
+task test -- ./plugins/...
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Close the plugin bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd close <plugin-bead-id>
+```
+
+(No commit — Tasks 8 and 9 already shipped the code.)
+
+---
+
+## Phase 5: Integration & follow-up
+
+### Task 11: Spec §6.5 integration cases — distributed across the right test files
+
+**Files (one per spec case):**
+
+- Modify: `internal/grpc/query_stream_history_test.go` (case 2 — handler-level opacity test)
+- Modify: `cmd/holomush/sub_grpc_adapters_test.go` (case 6 — `busHistoryReaderAdapter` fail-closed)
+- (Cases 1, 3, 4, 5 are already covered — see Step 2 below)
+
+**Test-style note:** the existing files in this repo use plain Go `testing.T`, NOT Ginkgo/Gomega. Verified via `rg "^func Test" test/integration/eventbus_e2e/plugin_audit_isolation_test.go` (single-Test-function file, no `Describe`/`It`). Match the existing style.
+
+- [ ] **Step 1: Claim the integration bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <integration-bead-id> --status=in_progress
+```
+
+- [ ] **Step 2: Map spec §6.5 cases to actual test locations (no work — just verify coverage)**
+
+The spec lists 6 cases. Four of them are already covered by tests written in earlier tasks; only two need new tests:
+
+| §6.5 case | Where it's tested | Status |
+| --- | --- | --- |
+| 1 — outer I-17 catches non-participant | `TestQueryStreamHistoryEnforcesMembershipGateForPrivateStream` (existing, `internal/grpc/query_stream_history_test.go`) | Existing test still applies; verify it still passes after Task 6/7 changes. |
+| 2 — plugin wall catches when outer passes | NEW: `TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode` (this task, Step 3) | NEW |
+| 3 — router PermissionDenied for non-participant Caller | `TestPluginHistoryRouterPreservesGRPCStatusOnQueryHistoryError` (Task 4) + `TestPluginHistoryStreamPreservesGRPCStatusOnRecvError` (Task 5) | Already covered by router unit tests. |
+| 4 — router PermissionDenied for zero Caller | `TestQueryHistoryRejectsNilCaller` and friends (Task 9 plugin unit tests) prove the plugin-side denial; the router-side wiring is exercised by Task 4. | Already covered. |
+| 5 — mid-read revocation | `TestQueryHistoryReChecksMembershipAcrossPaginations` (Task 9, plugin unit) | Already covered at unit level — same enforcement code path; integration adds no signal. |
+| 6 — plugin-host RPC fail-closed | NEW: `TestBusHistoryReaderAdapterFailsClosedOnPluginOwnedSubjects` (this task, Step 4) | NEW |
+
+If any of the existing-test references in the table fail after the earlier tasks land, fix the failure before proceeding. Don't forge ahead.
+
+- [ ] **Step 3: Write case 2 — plugin-wall opacity test**
+
+Add to `internal/grpc/query_stream_history_test.go`. The setup builds a session WITH a focus membership (so I-17 passes) and a `fakeHistoryReader` whose `err` is the plugin's `status.Error(codes.PermissionDenied, ...)`. Assertion: handler's returned error has oops code `STREAM_ACCESS_DENIED` — the SAME code the outer I-17 denial uses, proving opacity.
+
+```go
+func TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode(t *testing.T) {
+	t.Parallel()
+
+	stream, focus := sceneFocusMembership(t)
+	future := time.Now().Add(time.Hour)
+	sess := newTestSessionStore(t, map[string]*session.Info{
+		"s1": {
+			ID:               "s1",
+			CharacterID:      ulid.MustParse("01HYXCHAR0000000000000000C"),
+			ExpiresAt:        &future,
+			FocusMemberships: []session.FocusMembership{focus},
+		},
+	})
+
+	// fakeHistoryReader returns a precise plugin-style status error.
+	reader := &fakeHistoryReader{
+		err: status.Error(codes.PermissionDenied, "scene audit access denied"),
+	}
+	s := newQueryStreamHistoryServer(t, reader, sess)
+
+	_, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "s1",
+		Stream:    stream,
+		Count:     10,
+	})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "STREAM_ACCESS_DENIED",
+		"plugin-boundary PermissionDenied MUST translate to the same opaque oops code that the outer I-17 gate uses")
+}
+```
+
+Imports needed (verify which are missing): `time`, `github.com/oklog/ulid/v2`, `google.golang.org/grpc/codes`, `google.golang.org/grpc/status`. The other identifiers (`session`, `sceneFocusMembership`, `newTestSessionStore`, `newQueryStreamHistoryServer`, `errutil`, `corev1`, `fakeHistoryReader`) are already in scope from the existing file.
+
+If `errutil.AssertErrorCode` doesn't accept a third "message" argument in your version, drop it — the existing tests at lines 220, 291, 310, 329 use the two-argument form.
+
+- [ ] **Step 4: Run case 2 and verify**
+
+```bash
+task test -- -run TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode ./internal/grpc/
+```
+
+Expected: PASS (Task 7 already implemented the `mapHistoryError` dispatch).
+
+If this fails because the `fakeHistoryReader.err` flows through `fetchHistoryFramesFromBus`'s additional wrapping (it calls `mapHistoryError(oops.Code("INTERNAL").With(...).Wrap(fetchErr))` at line 221), inspect: the outer `oops.Code("INTERNAL").Wrap` will mask the inner status. Verify the call site survives a status pass-through. If not, refine Task 7's `mapHistoryError` to look at the wrapped inner error too — `oops.AsOops(err).Cause()` or `errors.Unwrap` walk. Pin this with the test before declaring it green.
+
+- [ ] **Step 5: Write case 6 — `busHistoryReaderAdapter` fail-closed**
+
+Add to `cmd/holomush/sub_grpc_adapters_test.go`. The adapter wraps a `eventbus.HistoryReader`; for plugin-owned subjects the Reader routes to `PluginHistoryRouter`. We can inject a fake Reader that simulates the routed-to-plugin response.
+
+```go
+// fakeReader returns a precise error from QueryHistory, regardless of q.
+type fakeReader struct{ err error }
+
+func (f *fakeReader) QueryHistory(_ context.Context, _ eventbus.HistoryQuery) (eventbus.HistoryStream, error) {
+	return nil, f.err
+}
+
+func TestBusHistoryReaderAdapterFailsClosedOnPluginOwnedSubjects(t *testing.T) {
+	t.Parallel()
+
+	// Simulate what happens when the adapter routes a plugin-owned subject
+	// through the router with zero q.Caller: plugin returns PermissionDenied,
+	// router preserves the status, adapter receives it.
+	reader := &fakeReader{
+		err: status.Error(codes.PermissionDenied, "caller required"),
+	}
+	adapter := &busHistoryReaderAdapter{
+		reader: reader,
+		gameID: func() string { return "main" },
+	}
+
+	_, err := adapter.ReplayTail(context.Background(),
+		"scene:01HYXSCENE00000000000000CC:ic", 10, time.Time{}, ulid.ULID{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err),
+		"adapter MUST surface the plugin's PermissionDenied for plugin-owned subjects until the plugin-as-caller follow-up lands")
+}
+```
+
+The adapter currently wraps every error with `oops.With("stream", ...).Wrap(err)` (sub_grpc.go:521,538,550). That `oops.Wrap` may bury the gRPC status — `status.Code(err)` walks the unwrap chain via `status.FromError`, but if the oops wrap doesn't expose the inner via `Unwrap()` then `status.Code` returns `Unknown`.
+
+If the test fails for that reason, fix: change the three `oops.Wrap` calls in `busHistoryReaderAdapter.ReplayTail` to use the same `status.FromError` pass-through pattern Task 4 introduced for the router. Document this fix as a small extension to Task 5 / 6 that the case 6 test pins.
+
+- [ ] **Step 6: Run case 6**
+
+```bash
+task test -- -run TestBusHistoryReaderAdapterFailsClosedOnPluginOwnedSubjects ./cmd/holomush/
+```
+
+Expected: PASS. If it fails because of the `oops.Wrap` shadowing, see the fix note in Step 5.
+
+- [ ] **Step 7: Run the full unit suite**
+
+```bash
+task test
+```
+
+Expected: all green. The existing `TestQueryStreamHistoryEnforcesMembershipGateForPrivateStream` (case 1 from §6.5) still passes, asserting we didn't regress the outer I-17 path.
+
+- [ ] **Step 8: Run integration suite**
+
+```bash
+task test:int
+```
+
+Expected: all green. The existing `plugin_audit_isolation_test.go` still passes — its scope (audit projection routing, not QueryHistory authz) is orthogonal to our changes, but verify nothing broke.
+
+- [ ] **Step 9: Commit**
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "test: cover spec §6.5 cases 2 and 6 against existing scaffolding
+
+Case 2 (plugin-wall opacity) goes in query_stream_history_test.go using
+the existing fakeHistoryReader to inject a status.Error(PermissionDenied);
+asserts errutil.AssertErrorCode(STREAM_ACCESS_DENIED), proving §5.5's
+translation chain.
+
+Case 6 (busHistoryReaderAdapter fail-closed for plugin-owned subjects)
+goes in sub_grpc_adapters_test.go using a fakeReader that simulates the
+plugin's PermissionDenied; pins the §4.4 deferred behavior.
+
+Cases 1, 3, 4, 5 are already covered by prior task tests (existing
+TestQueryStreamHistoryEnforcesMembershipGateForPrivateStream, the
+router unit tests in Tasks 4-5, and the plugin unit tests in Task 9).
+
+Per spec §6.5. Refs holomush-095g."
+jj new
+```
+
+---
+
+### Task 12: File the follow-up bead for plugin-as-caller identity
+
+**Files:** none (beads only).
+
+- [ ] **Step 1: File the bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd create \
+  --title="Plugin-as-caller identity for PluginHostService.QueryStreamHistory against plugin-owned subjects" \
+  --description="Spec docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md §4.4 deferred this. Today busHistoryReaderAdapter.ReplayTail (cmd/holomush/sub_grpc.go:511) passes zero q.Caller, so plugin-owned subjects routed through PluginHistoryRouter return PERMISSION_DENIED to plugin callers. No in-tree caller currently breaks. Before any plugin starts reading plugin-owned subjects via this path, design: (a) what Actor.Kind a plugin caller carries, (b) what capability grants gate cross-plugin reads, (c) whether plugins can read their own subjects without the gate, (d) how a plugin asserts which character (if any) it reads on behalf of." \
+  --type=task --priority=2 --parent holomush-095g
+```
+
+Record the returned bead ID; reference it in the PR description so reviewers can verify §7 step 13 is satisfied.
+
+- [ ] **Step 2: Update the parent bead with a link**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update <followup-bead-id> --notes="Filed per spec §7 step 13 / §8 second bullet. Blocks any future caller of holomush.query_stream_history against plugin-owned subjects."
+```
+
+---
+
+## Phase 6: Verification & landing
+
+### Task 13: Full CI mirror via `task pr-prep`
+
+- [ ] **Step 1: Run `task pr-prep`**
+
+```bash
+task pr-prep
+```
+
+Expected: ALL CI jobs green — schema, license, lint (Go + proto + markdown), unit, integration, E2E. Per project memory `feedback_pr_prep_must_run`, this MUST be the full run; never substitute partial checks. Per `feedback_pr_prep_gate`, this MUST pass before any push.
+
+If anything fails, fix at the root and re-run the full `task pr-prep`. Do NOT skip jobs.
+
+- [ ] **Step 2: Squash all task commits into one PR commit**
+
+```bash
+jj log -r 'main@origin..@-' --no-graph -T 'change_id ++ " " ++ description.first_line()'
+# review the chain; identify the change-ids to squash.
+JJ_EDITOR=true jj --no-pager squash --from <oldest-change-id> --into <newest-change-id> -m "feat(plugin-audit): enforce scene-membership authz at PluginAuditService.QueryHistory
+
+Closes the TODO at plugins/core-scenes/audit.go:211 by adding defense-in-depth
+membership enforcement at the plugin boundary, complementing the existing
+outer I-17 gate at internal/grpc/query_stream_history.go.
+
+- Adds Actor caller=8 field to QueryHistoryRequest proto (additive).
+- Plumbs caller from session through eventbus.HistoryQuery, the router,
+  and into the plugin RPC.
+- Plugin runs auth-first (caller validation → subject parse → IsMember
+  membership check) before any cursor decode or log query, pinned by a
+  TestQueryHistoryDeniesNonMemberWithoutHittingLogStore test.
+- Plugin emits gRPC status.Error; router preserves status codes; host's
+  mapHistoryError translates PermissionDenied to STREAM_ACCESS_DENIED so
+  the client cannot distinguish outer-wall from plugin-wall denials.
+- 6 integration cases prove the opacity invariant end-to-end and pin the
+  fail-closed behavior at the plugin-host RPC boundary (§4.4).
+- Follow-up bead <followup-bead-id> filed for the deferred plugin-as-caller
+  identity design (spec §4.4 / §7 step 13).
+
+Spec: docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md
+Closes holomush-095g.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Set the bookmark and push**
+
+```bash
+jj bookmark set holomush-095g -r @-
+jj git fetch
+# Per project memory feedback_jj_rebase_targeted: NEVER bare jj rebase -d main.
+jj rebase -r <our-change-id> -d main@origin
+jj git push --branch holomush-095g
+```
+
+Expected: push succeeds; remote `holomush-095g` branch exists with the squashed commit.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(plugin-audit): enforce scene-membership authz at PluginAuditService.QueryHistory" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `Actor caller = 8` to `PluginAuditService.QueryHistory` proto and plumbs the field from the host session through `eventbus.HistoryQuery` → `PluginHistoryRouter` → plugin.
+- Plugin enforces scene-membership authz (auth-first ordering, owner/member only, deliberate exclusion of `invited`) before any DB work.
+- gRPC status codes from the plugin (`PermissionDenied`, `InvalidArgument`) round-trip through the router; `mapHistoryError` collapses plugin-boundary `PermissionDenied` into the same opaque `STREAM_ACCESS_DENIED` oops code the outer I-17 gate uses.
+- Opacity invariant: client cannot distinguish outer-wall denials from plugin-wall denials (load-bearing test in §6.5 case 2).
+
+## Spec
+docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md
+
+## Test plan
+- [x] `task test` (unit)
+- [x] `task test:int` (integration, including 6 new authz cases)
+- [x] `task pr-prep` (full CI mirror)
+
+## Follow-up
+- New bead: <followup-bead-id> — plugin-as-caller identity for `PluginHostService.QueryStreamHistory` against plugin-owned subjects (spec §4.4).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Close the integration bead and the parent bead**
+
+```bash
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd close <integration-bead-id>
+BEADS_DIR=/Volumes/Code/github.com/holomush/holomush/.beads bd update holomush-095g --status=in_review
+```
+
+Hold off on closing `holomush-095g` itself until the PR merges to `main`.
+
+- [ ] **Step 6: Post the PR URL**
+
+Print the PR URL the implementer will see from `gh pr create`. Done.
+
+---
+
+## Self-review notes for the implementer
+
+If at any point you find that:
+
+- A function name in this plan doesn't match the repo's current state — verify with `rg` before editing. Codebases drift.
+- A test relies on a helper that doesn't exist — write the smallest helper that satisfies the test, named per the existing file's conventions.
+- A `task` target named here doesn't exist — check `Taskfile.yaml` and adjust. Never substitute raw `go`/`golangci-lint`/`buf` commands per project rule.
+- A commit fails a hook — fix the underlying issue and create a NEW commit. Do NOT use `--no-verify` per project rule.
+
+If you hit a blocker that requires a design decision not in the spec, stop and surface the question rather than inventing a solution.

--- a/docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md
@@ -1,0 +1,410 @@
+# Plugin history authz — membership enforcement at the plugin boundary
+
+**Bead:** `holomush-095g` (P1 bug)
+**Status:** design — pending implementation plan
+**Author:** Sean Brandt (with AI assistance)
+**Date:** 2026-04-23
+**Supersedes:** none
+
+**Related (not superseded, downstream / adjacent):**
+
+- `docs/superpowers/specs/2026-04-21-cold-tier-js-seq-pagination-design.md` §11.1 asserted that the plugin audit RPC contract is "unchanged" by the cursor rework. That assertion stands for the pagination fields. This spec adds `caller` to the same request message — a new, orthogonal, backward-compatible extension.
+- `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` §6 (plugin-owned subject routing / OwnerMap).
+- Follow-up beads that will become plugin-owned history callers after landing: `holomush-l4kx` (audit-backfill CLI), `holomush-ecbg` (drift detector), `holomush-6nds` (JS rebuild tool).
+
+## 1. Problem statement
+
+F5 of the JetStream EventBus cutover (PR #252) landed `PluginAuditService.QueryHistory` in `plugins/core-scenes/audit.go` without scene-membership enforcement at the plugin side. The plugin currently trusts the host's outer I-17 membership gate (in `CoreServer.QueryStreamHistory`) to authorize callers; the plugin itself returns every row matching the subject.
+
+The TODO at `plugins/core-scenes/audit.go:211` documents the gap:
+
+> `// TODO(holomush-1tvn.12 follow-up): plumb caller identity from the host`
+> `// through the plugin gRPC connection so the membership check can hard-`
+> `// gate non-participant queries at the plugin boundary.`
+
+The current shape is fragile for three reasons:
+
+1. **Trust boundary crosses a process boundary.** The plugin is a `hashicorp/go-plugin` subprocess. Any gRPC that crosses that socket is a public contract from the plugin's perspective — and `docs/superpowers/specs/2026-04-21-cold-tier-js-seq-pagination-design.md` §11.1 deliberately leaves the plugin audit RPC stable through the cursor rework, signalling that this IS a long-lived public interface, not an internal detail.
+2. **Future callers will bypass the outer handler.** Follow-up beads `holomush-l4kx`, `holomush-ecbg`, and `holomush-6nds` are all plugin-owned-history readers that will plausibly not go through the session-bound `CoreServer.QueryStreamHistory` path. Without a plugin-side wall, each of those becomes policy-carrying.
+3. **Dev tooling / test harnesses** dial the plugin socket directly (`plugin_audit_isolation_test.go` already does). Today these get free reads.
+
+## 2. Goals & non-goals
+
+**Goals.**
+
+- Plugin-side defense-in-depth: `PluginAuditService.QueryHistory` MUST enforce domain-specific authz (scene membership) against a caller identity forwarded from the host.
+- The identity requirement MUST be visible on the proto contract, not buried in transport plumbing.
+- The outer I-17 gate at `CoreServer.QueryStreamHistory` MUST remain load-bearing for the session-bound client path. Information-hiding (`STREAM_ACCESS_DENIED` opaque to the client) MUST be preserved end-to-end.
+- The plugin MUST re-check membership per call, never cache across paginations.
+
+**Non-goals.**
+
+- Admin / system-tool bypass. Non-`CHARACTER` caller kinds are rejected at this RPC; administrative access is a future extension with its own capability grant.
+- Per-channel (`ic` vs `ooc`) membership differentiation. Any participant with an `owner` or `member` role can read any channel of that scene. Matches the outer I-17 gate's scene-level granularity.
+- "Preview before joining" semantics for invited characters. Invitation grants join rights; reading follows joining.
+- Any change to `Subscribe`-style RPCs. This spec is QueryHistory only.
+- **Plugin-as-caller identity for the plugin-host `QueryStreamHistory` RPC.** A second router call path exists at `cmd/holomush/sub_grpc.go:511` (`busHistoryReaderAdapter.ReplayTail`), serving `PluginHostService.QueryStreamHistory` (plugin → host). Defining a "plugin reading on its own behalf" identity model — what `Actor.Kind` it carries, what capability grants gate cross-plugin reads, whether plugins can read their own subjects without the gate — is its own design problem. This spec defers it to a follow-up bead. See §4.4 for the concrete consequence (this RPC will return `PERMISSION_DENIED` for plugin-owned subjects after this lands; no in-tree caller breaks because none currently reads plugin-owned subjects).
+
+## 3. Architecture
+
+### 3.1 Trust model
+
+Two walls, both load-bearing:
+
+**Outer wall (unchanged):** `CoreServer.QueryStreamHistory` keeps the I-17 membership gate (`sessionHasMembership`) for scene streams before any routing. This wall catches the session-bound path, checks `info.FocusMemberships` (active session focus → implies membership), and preserves the existing opaque `STREAM_ACCESS_DENIED` response.
+
+**Inner wall (new):** `PluginAuditService.QueryHistory` performs its own membership check against the plugin's authoritative `scene_participants` table. This wall catches any future caller that reaches the plugin without going through the outer handler — follow-up beads, dev tooling, test harnesses, or any future host path that forgets to propagate the session check.
+
+**Why both are load-bearing, not redundant.** The two walls check *complementary* properties:
+
+| Wall | Property checked | Data source |
+| --- | --- | --- |
+| Outer (I-17) | "Is this session currently focused on this scene?" | `session.Info.FocusMemberships` |
+| Inner (plugin) | "Is this character a member of this scene?" | `scene_participants` table |
+
+On the session-bound path, both MUST hold. The outer is strictly stronger (focus implies membership), so the inner is passive defense. For non-session-bound callers (future backfill CLI, drift detector), the outer is not traversed — the plugin wall is the sole gate, and `scene_participants` is the correct authoritative source.
+
+### 3.2 Identity forwarding under trusted transport
+
+The "caller" passed to the plugin is not a self-attestation from the end-user. It is the host forwarding an identity that the host already authenticated. The property the plugin relies on:
+
+- **Only the host can populate `caller`.** The field exists on the host↔plugin RPC, never on any client↔host RPC. The web client holds a session token; the outer handler resolves session → character_id via `sessionStore.Get`; that server-derived value is what crosses into the plugin.
+- **The plugin socket is transport-authenticated.** `hashicorp/go-plugin` uses a handshake cookie known only to the host process. The plugin treats "whoever called me over this socket" as "the host."
+- **The plugin makes its membership decision against local authoritative data** (`scene_participants`), not against any claim the caller makes about membership.
+
+The plugin is not trusting the caller to self-identify correctly; it is trusting the host's authentication and making its own policy decision.
+
+## 4. Wire contract
+
+### 4.1 Proto change (`api/proto/holomush/plugin/v1/audit.proto`)
+
+The change is **purely additive**: append `caller = 8` to the existing `QueryHistoryRequest`. Fields 1–7 retain their existing comments verbatim (`bytes after = 2; // ULID; empty = from start`, etc. — see the current proto file). Implementer MUST NOT touch the existing fields' definitions or comments; this section shows only the new field:
+
+```proto
+// caller identifies the principal on whose behalf the host is reading.
+// Plugins implementing PluginAuditService MUST enforce domain-specific
+// authz (e.g., membership) against this identity before returning rows.
+// An absent caller, a zero identity, or an unsupported Actor.Kind MUST
+// be rejected with gRPC PERMISSION_DENIED. The host populates this
+// field from the authenticated session record; clients never supply it.
+holomush.eventbus.v1.Actor caller = 8;
+```
+
+The proto comment is load-bearing — it is the discoverability property that makes the security requirement contract-visible rather than transport-hidden.
+
+Backward compat: `caller = 8` is an additive field. Today only `core-scenes` implements `PluginAuditService` (verified via `rg "PluginAuditService" plugins/`); no other plugin is affected. A plugin compiled against the old proto would still build, but the spec and proto comment make enforcement MUST-language for any plugin consuming this RPC.
+
+### 4.2 Internal host types (`internal/eventbus`)
+
+`HistoryQuery` gains a `Caller` field:
+
+```go
+type HistoryQuery struct {
+    Subject   Subject
+    Direction Direction
+    PageSize  int
+    NotBefore time.Time
+    NotAfter  time.Time
+    AfterSeq  uint64
+    AfterID   ulid.ULID
+    BeforeSeq uint64
+    BeforeID  ulid.ULID
+    Caller    Actor // NEW
+}
+```
+
+`Caller` is a property of the query (alongside `NotBefore`, `Subject`, etc.). Public-tier readers (hot JetStream, cold Postgres) ignore the field; only the plugin router propagates it.
+
+`PluginHistoryRouter.QueryHistory` signature is unchanged — the router reads `q.Caller` from the query object and maps it into the proto request. Only the diff against the existing implementation (`internal/eventbus/audit/plugin_router.go:70–88`) is shown; the existing `q.AfterID.IsZero()` / `q.BeforeID.IsZero()` / `q.NotBefore` / `q.NotAfter` blocks remain untouched:
+
+```go
+req := &pluginv1.QueryHistoryRequest{
+    Subject:   string(q.Subject),
+    PageSize:  int32(pageSize),
+    Direction: directionProto(q.Direction),
+    Caller:    eventbus.ActorToProto(q.Caller), // NEW
+}
+```
+
+`actorToProto` and `actorKindToProto` currently live in `internal/eventbus/publisher.go:274` as unexported helpers. This spec MUST export them (rename to `ActorToProto` / `ActorKindToProto`) so the audit-router package can reuse the single source of truth for `Actor` ⇄ proto mapping. Duplicating the switch in `audit/plugin_router.go` would silently drift on any future enum extension.
+
+### 4.3 Host handler (`internal/grpc/query_stream_history.go`)
+
+The handler already loads `info.CharacterID` from the authenticated session in Step 1. The existing `fetchHistoryFramesFromBus` helper at `internal/grpc/query_stream_history.go:279` constructs the `HistoryQuery` internally; the handler holds only positional state. The chosen threading mechanism: **extend `fetchHistoryFramesFromBus` with one new parameter `caller eventbus.Actor`** and have it set `q.Caller = caller` at construction time.
+
+Rationale: the function already takes 6 positional args; adding a 7th is minimally disruptive. Refactoring to construct `HistoryQuery` at the handler is a larger surgery and not required to deliver this spec.
+
+New call site:
+
+```go
+// In QueryStreamHistory, after Step 5 (authorization) and before Step 7:
+caller := eventbus.Actor{
+    Kind: eventbus.ActorKindCharacter,
+    ID:   info.CharacterID,
+}
+frames, fetchErr := fetchHistoryFramesFromBus(
+    ctx, s.historyReader, s.currentGameID(), req.Stream, count,
+    notBefore, beforeSeq, beforeID, caller, // NEW
+)
+```
+
+New signature:
+
+```go
+func fetchHistoryFramesFromBus(
+    ctx context.Context,
+    reader eventbus.HistoryReader,
+    gameID, legacyStream string,
+    count int,
+    notBefore time.Time,
+    beforeSeq uint64,
+    beforeID ulid.ULID,
+    caller eventbus.Actor, // NEW
+) ([]*corev1.EventFrame, error)
+```
+
+Inside, the existing `q := eventbus.HistoryQuery{...}` construction adds `Caller: caller`.
+
+The handler MUST derive `caller` from the session record only. It MUST NOT accept a client-supplied character_id from the request body.
+
+### 4.4 Plugin-host `QueryStreamHistory` RPC path
+
+A second router call path exists at `cmd/holomush/sub_grpc.go:511` — the `busHistoryReaderAdapter.ReplayTail` method that satisfies `plugins.HistoryReader` for `PluginHostService.QueryStreamHistory` (plugin → host RPC, used by Lua `holomush.query_stream_history` and the Go SDK `pkg/plugin/focus_client.go` equivalent).
+
+This adapter constructs a `HistoryQuery` (`sub_grpc.go:527–535`) with no `Caller` — it has no caller identity to populate, because plugin callers are not characters and the SDK does not currently carry a per-call character context.
+
+**Behavior after this spec lands:**
+
+- For host-owned subjects (`character:*`, `location:*`, `global`, etc.): the cold/hot tier readers ignore `q.Caller`. No regression.
+- For plugin-owned subjects (e.g., `events.<gid>.scene.<id>.<channel>`): the adapter routes to `PluginHistoryRouter.QueryHistory`, which forwards a zero `caller` to the plugin, which returns `PERMISSION_DENIED` per §5.2. The plugin RPC fails closed.
+
+**Why this is acceptable for this spec:**
+
+- No in-tree caller currently reads plugin-owned subjects via `PluginHostService.QueryStreamHistory`. The cold-tier spec's §11.2 (line 627) verified at spec-write time that no `.lua` plugin calls `holomush.query_stream_history`; the Go SDK has the same status. Failing closed today breaks no caller.
+- The fail-closed behavior matches the spec's goal: non-session-bound callers that lack a vetted identity story MUST NOT read plugin-owned audit logs.
+
+**Required follow-up:**
+
+A new bead MUST be filed before this spec's PR merges, capturing the plugin-as-caller identity design problem: "what `Actor.Kind` does a plugin caller carry, what capability grants gate cross-plugin reads, and how does a plugin assert which character (if any) it is reading on behalf of?" That bead is `holomush-095g`'s direct successor and will land before any in-tree code starts using `PluginHostService.QueryStreamHistory` against plugin-owned subjects.
+
+## 5. Plugin enforcement semantics
+
+### 5.1 Step ordering
+
+Plugin `QueryHistory` MUST execute checks in this order:
+
+1. Validate `req.Subject` is non-empty and non-wildcard.
+2. Validate `req.Caller` is present and has `Kind = ACTOR_KIND_CHARACTER` with a non-zero ID.
+3. Parse `req.Subject` into `sceneID` using the plugin-owned grammar.
+4. Check `scene_participants` membership for `(sceneID, callerID)`.
+5. Only then: decode cursor, compute pagination, query `scene_log`, stream rows.
+
+**Rationale:** auth must run before any DB work to avoid timing oracles and to keep the denial path cheap. A non-participant's request costs one indexed PK lookup, not a full pagination.
+
+### 5.2 Actor kind dispatch
+
+The proto enum (`api/proto/holomush/eventbus/v1/eventbus.proto:13–19`) defines exactly five values: `ACTOR_KIND_UNSPECIFIED` (zero), `_CHARACTER`, `_PLAYER`, `_SYSTEM`, `_PLUGIN`. The Go-side `eventbus.ActorKindUnknown` (zero value of the in-process type) maps to proto `ACTOR_KIND_UNSPECIFIED` via `actorKindToProto`. There is no proto `ACTOR_KIND_UNKNOWN`.
+
+| `caller.Kind` (proto enum)    | Behavior                                                       | oops code                   |
+| ----------------------------- | -------------------------------------------------------------- | --------------------------- |
+| `ACTOR_KIND_UNSPECIFIED` (0)  | PERMISSION_DENIED — host bug or zero value, fail closed        | `SCENE_AUDIT_AUTH_REQUIRED` |
+| `ACTOR_KIND_CHARACTER`        | Proceed to membership check with `caller.Id` as character ULID | —                           |
+| `ACTOR_KIND_PLAYER`           | PERMISSION_DENIED — not supported at this RPC                  | `SCENE_AUDIT_AUTH_REQUIRED` |
+| `ACTOR_KIND_SYSTEM`           | PERMISSION_DENIED — admin tools require a separate capability  | `SCENE_AUDIT_AUTH_REQUIRED` |
+| `ACTOR_KIND_PLUGIN`           | PERMISSION_DENIED — cross-plugin reads not supported (§4.4)    | `SCENE_AUDIT_AUTH_REQUIRED` |
+| any other value (proto drift) | PERMISSION_DENIED                                              | `SCENE_AUDIT_AUTH_REQUIRED` |
+
+A `CHARACTER` kind with a zero-bytes `Id` MUST also be rejected (treat as missing identity) — that check is logically separate from kind dispatch but lives in the same step.
+
+### 5.3 Subject parsing (plugin-owned grammar)
+
+Plugin owns the subject grammar declared in `plugin.yaml` (`events.*.scene.>`). The router forwards `q.Subject` to the plugin in JetStream-native form (`events.<gameID>.scene.<sceneID>.<channel>`); the plugin parses native, not legacy.
+
+**Why the plugin parses native directly rather than calling `subjectxlate.ToLegacy` first:**
+
+`subjectxlate` (`internal/eventbus/subjectxlate/subjectxlate.go`) is a host-domain bridge between native (`events.<game>.<ns>.<rest>`) and legacy colon-delimited (`<ns>:<rest>`) forms. The plugin already receives native subjects on every audit call and writes them to `scene_log` in native form. Routing through `ToLegacy` to obtain `scene:<id>:<channel>` and then splitting on `:` adds a dependency from the plugin to a host-side helper for zero benefit — both paths require the same number of tokens, the same wildcard rejection, and the same error semantics. Direct native parsing keeps the plugin self-contained.
+
+Parse rules:
+
+- Expected shape: `events.<gameID>.scene.<sceneID>.<channel>[.<...>]`
+- Accept: concrete `<sceneID>` token (non-empty, non-wildcard), any `<channel>` suffix.
+- Reject: fewer than 5 tokens, first token not `events`, third token not `scene`, any token containing wildcard characters (`*`, `>`).
+- Plugin does NOT validate `<gameID>` semantically — that's the host's concern — but DOES reject it if it contains wildcards (per the rule above).
+- Malformed subject returns `INVALID_ARGUMENT` with oops `SCENE_AUDIT_SUBJECT_INVALID`.
+
+### 5.4 Membership lookup
+
+**Role-policy change:** the existing function comment at `plugins/core-scenes/audit.go:202–204` describes (but does not enforce) "owner, member, or invited" as the read-permitted set. This spec **deliberately tightens** that policy to "owner or member only" — the previously-documented inclusion of `invited` was aspirational, never enforced (since the function had no auth at all), and conflicts with the principle that invitation grants *join* rights, not *passive read* rights. §7 step 8 captures the docstring update; this change is intentional, not a casual cleanup.
+
+New narrow helper on `SceneStore`:
+
+```go
+// IsMember reports whether characterID has an owner or member row in
+// sceneID. Invited-only rows return false — invitation grants join
+// rights, not read rights. Missing scene or missing row both return
+// false with nil error.
+func (s *SceneStore) IsMember(ctx context.Context, sceneID, characterID string) (bool, error)
+```
+
+Single indexed lookup on `scene_participants` (PK `(scene_id, character_id)`). Predicate `WHERE role IN ('owner', 'member')`. No allocations beyond the boolean. Existing `GetWithMembership` is unchanged; it has other callers (service handler) that need the hydrated scene + slice shape.
+
+**`IsMember` "missing scene = false, nil error" is a deliberate divergence** from the rest of the file. Other helpers (e.g., `SCENE_NOT_FOUND` at the service layer) distinguish "scene missing" from "permission denied." `IsMember` collapses them on purpose: at the audit-read boundary, distinguishing the two would leak scene existence to non-members. Information-hiding wins over diagnostic precision here. Internal logs MAY emit a debug line distinguishing the cases for the operator's benefit, but the function's return type does not.
+
+Non-membership returns PERMISSION_DENIED with oops `SCENE_AUDIT_ACCESS_DENIED`. DB errors return `INTERNAL` wrapped.
+
+### 5.5 Error mapping end-to-end
+
+The host's existing `mapHistoryError` (`internal/grpc/query_stream_history.go:259–270`) switches on `errors.Is(err, eventbus.ErrCursor*)` only. It cannot inspect oops codes through the wrapping chain that `PluginHistoryRouter` adds (`AUDIT_PLUGIN_HISTORY_RPC_FAILED` at `plugin_router.go:98`, `AUDIT_PLUGIN_HISTORY_RECV_FAILED` at `:153`). The end-to-end translation requires three coordinated changes; this section specifies all three.
+
+**1. Plugin-side error emission.** Plugin handlers MUST return errors using `google.golang.org/grpc/status` so the gRPC status code crosses the wire as a structured value, not as a stringified error message. The plugin SHOULD also wrap with oops for log dimensioning, but the wire-level error MUST be a status.Error:
+
+```go
+// In SceneAuditServer.QueryHistory, on access denied:
+return status.Error(codes.PermissionDenied, "scene audit access denied")
+// Internal logs/metrics tag the case via an unwrapped oops sibling:
+slog.InfoContext(ctx, "scene audit access denied",
+    "subject", req.GetSubject(),
+    "code", "SCENE_AUDIT_ACCESS_DENIED",
+)
+```
+
+The oops-code-as-log-attribute pattern (rather than `oops.Code(...).Wrap(status.Error(...))`) avoids burying the gRPC code beneath an oops wrapper. Pure status errors round-trip through gRPC cleanly.
+
+**2. Router-side gRPC status preservation.** `PluginHistoryRouter.QueryHistory` and `pluginHistoryStream.Next` currently wrap every error with their own oops codes (`AUDIT_PLUGIN_HISTORY_RPC_FAILED`, `_RECV_FAILED`). This MUST change to **preserve gRPC status codes from the plugin** while still adding diagnostic context:
+
+```go
+// In plugin_router.go QueryHistory and pluginHistoryStream.Next:
+if err != nil {
+    if st, ok := status.FromError(err); ok && st.Code() != codes.Unknown {
+        // Preserve the plugin's gRPC code; add subject/plugin context as
+        // log attributes, not as an oops wrapper that would shadow it.
+        return ..., err
+    }
+    // Non-status errors (transport failures, etc.) keep the existing
+    // AUDIT_PLUGIN_HISTORY_*_FAILED oops wrapping.
+    return ..., oops.Code("AUDIT_PLUGIN_HISTORY_RPC_FAILED")...
+}
+```
+
+The router becomes a **transparent proxy for gRPC status errors** and an **annotating wrapper for non-status errors**. This is the load-bearing change for end-to-end opacity.
+
+**3. Host handler translation.** `mapHistoryError` gains a status-code dispatch step **before** the existing `errors.Is` chain:
+
+```go
+func mapHistoryError(err error) error {
+    // NEW: gRPC status pass-through with opacity translation.
+    if st, ok := status.FromError(err); ok {
+        switch st.Code() {
+        case codes.PermissionDenied:
+            // Opaque: collapse plugin-boundary denial into the same code
+            // the outer I-17 gate uses. Client cannot distinguish.
+            return oops.Code("STREAM_ACCESS_DENIED").
+                Errorf("not authorized to read stream")
+        case codes.InvalidArgument:
+            return status.Errorf(codes.InvalidArgument, "%v", err)
+        }
+        // Other status codes (Internal, Unavailable, …) pass through.
+    }
+    // Existing cursor-error dispatch unchanged below.
+    switch {
+    case errors.Is(err, eventbus.ErrCursorInvalid):
+        return status.Errorf(codes.InvalidArgument, "%v", err)
+    // …
+    }
+}
+```
+
+End-to-end matrix:
+
+| Condition                  | Plugin emits                                                     | Router behavior          | Host handler emits to client          |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------ | ------------------------------------- |
+| Caller missing / bad kind  | `status.Error(codes.PermissionDenied, …)` + log `SCENE_AUDIT_AUTH_REQUIRED`  | preserve status         | `STREAM_ACCESS_DENIED` (opaque)        |
+| Not a participant          | `status.Error(codes.PermissionDenied, …)` + log `SCENE_AUDIT_ACCESS_DENIED`  | preserve status         | `STREAM_ACCESS_DENIED` (opaque)        |
+| Subject malformed          | `status.Error(codes.InvalidArgument, …)` + log `SCENE_AUDIT_SUBJECT_INVALID` | preserve status         | `INVALID_ARGUMENT` (pass-through)     |
+| Store / DB error           | `status.Error(codes.Internal, …)` (or oops-wrapped non-status)   | preserve / wrap          | `INTERNAL`                             |
+| Plugin transport failure   | gRPC transport error (not from plugin handler)                   | wrap `AUDIT_PLUGIN_HISTORY_RPC_FAILED` | `INTERNAL` (existing default)  |
+
+**Information-hiding invariant:** the client MUST NOT be able to distinguish "outer I-17 denial" from "plugin-boundary denial." Both surface to the client as the same oops-coded error: oops code `STREAM_ACCESS_DENIED`, message `"not authorized to read stream"`, identical context fields. Plugin-internal log attributes (`SCENE_AUDIT_*` codes) preserve operator-side observability without leaking to the client.
+
+**Code-axis vocabulary (used throughout §5.5, §6, §8):**
+
+- *gRPC status code* — a member of `google.golang.org/grpc/codes` (`codes.PermissionDenied`, `codes.InvalidArgument`, etc.). Carried on the wire by `status.Error` / `status.FromError`.
+- *oops code* — a HoloMUSH-internal structured-error tag set via `oops.Code("…")`. Used for log dimensioning and for the existing handler's denial vocabulary (`STREAM_ACCESS_DENIED` is an oops code, not a gRPC code). Currently surfaces to clients via the project's oops→error marshalling, not as a gRPC status.
+- These are independent axes. A test that says "assert STREAM_ACCESS_DENIED" MUST extract the oops code via `oops.AsOops(err).Code()`. A test that says "assert PermissionDenied" MUST extract the gRPC code via `status.Code(err)`.
+
+## 6. Testing
+
+### 6.1 Unit — plugin (`plugins/core-scenes/audit_test.go`, new)
+
+Table-driven auth dispatch matrix covering the kind-× membership cross-product:
+
+- nil caller, zero ID, character member, character owner, character invited-only, character non-participant, each non-character kind.
+- Assertions on oops code and gRPC status.
+
+Table-driven subject parsing:
+
+- Valid `events.*.scene.<id>.ic`, valid `…ooc`, non-scene prefixes, wildcard tokens, too-few tokens, empty subject.
+
+**Early-rejection test:** non-participant call with an otherwise valid request asserts that the `scene_log` store mock is NEVER invoked. Pins the step ordering against future refactors.
+
+**Membership-change-mid-pagination test:** seed N rows for a member; plugin reads page 1 (page_size = N/2, rows returned); delete participant row; plugin reads page 2 → PERMISSION_DENIED. Proves per-call re-check.
+
+### 6.2 Unit — store (`plugins/core-scenes/store_integration_test.go`)
+
+Extend with `IsMember` cases against testcontainers PG:
+
+- Owner → true. Member → true. Invited only → false. No row → false. Missing scene → false.
+
+### 6.3 Unit — router (`internal/eventbus/audit/plugin_router_test.go`)
+
+- `q.Caller` forwarded verbatim into `QueryHistoryRequest.Caller` via `eventbus.ActorToProto` (kind and id bytes).
+- Zero `q.Caller` forwarded as-is (router is pure; plugin enforces).
+- **gRPC status preservation:** when the underlying plugin client returns a `status.Error(codes.PermissionDenied, …)`, the router returns the same status error unchanged (no oops wrapping). Test uses a stub `pluginv1.PluginAuditServiceClient` that returns a precise status from both `QueryHistory` (immediate) and `Recv` (mid-stream).
+- **Non-status passthrough:** when the underlying plugin client returns a non-status transport error (e.g., simulated connection drop), the router wraps with the existing `AUDIT_PLUGIN_HISTORY_RPC_FAILED` / `_RECV_FAILED` oops codes.
+
+### 6.4 Unit — host handler (`internal/grpc/query_stream_history_test.go`)
+
+- **Caller threading:** the handler passes `eventbus.Actor{Kind: ActorKindCharacter, ID: info.CharacterID}` as the new `caller` argument to `fetchHistoryFramesFromBus`. Test injects a fake `HistoryReader` that captures the `q.Caller` it received and asserts it matches the session's character ID.
+- **`mapHistoryError` PERMISSION_DENIED dispatch:** input is a bare `status.Error(codes.PermissionDenied, "scene audit access denied")`; assert the function returns an oops-coded `STREAM_ACCESS_DENIED` error whose message matches the outer I-17 gate's message (so the client cannot distinguish).
+- **`mapHistoryError` INVALID_ARGUMENT pass-through:** input is `status.Error(codes.InvalidArgument, "subject malformed")`; assert pass-through to `codes.InvalidArgument`.
+- **`mapHistoryError` non-status fallback:** input is a plain oops-wrapped error with no gRPC status; assert the existing cursor-error dispatch still applies (no regression on `ErrCursorInvalid` / `Stale` / `Lag`).
+
+### 6.5 Integration (`test/integration/eventbus_e2e/plugin_audit_isolation_test.go`, extend)
+
+Per the `holomush-l60y` consolidation effort, extend the existing file rather than create parallels:
+
+1. **End-to-end non-participant denial:** character X not a member of scene S; X's session invokes `CoreServer.QueryStreamHistory` on `scene:S:ic`. Outer I-17 catches first. Assert the returned error carries oops code `STREAM_ACCESS_DENIED` (extract via `oops.AsOops(err).Code()`) and message `"not authorized to read stream"`. Proves the outer wall is unchanged.
+2. **End-to-end plugin-boundary denial (with outer disabled):** simulate a non-session-bound caller by populating `info.FocusMemberships` to bypass the outer I-17 gate (e.g., add a focus row for the scene), then run with a non-participant `info.CharacterID`. The outer gate now passes; the plugin wall catches. Assert the returned error carries oops code `STREAM_ACCESS_DENIED` (same code as case 1 — opacity invariant). This is the load-bearing test for §5.5: it proves the plugin's `status.Error(codes.PermissionDenied)` round-trips through the router and is collapsed into the same oops code the outer wall uses.
+3. **Plugin-boundary direct (router level):** call `PluginHistoryRouter.QueryHistory` directly with a valid `Caller` that is NOT a participant. Assert the returned error has gRPC status code `codes.PermissionDenied` (extract via `status.Code(err)`) — the plugin's status error round-trips through the router unchanged. Proves the gRPC status is preserved across the router boundary.
+4. **Missing-caller failsafe (router level):** router invoked with zero `q.Caller`. Assert gRPC status code `codes.PermissionDenied`. The "host bug shouldn't silently leak" case.
+5. **Mid-read revocation:** member reads page 1 successfully; kick; page 2 returns gRPC `codes.PermissionDenied` at the router level (case 3 / 4 vocabulary) and oops `STREAM_ACCESS_DENIED` at the outer-handler level (case 1 / 2 vocabulary).
+6. **Plugin-host RPC fail-closed (§4.4):** invoke `PluginHostService.QueryStreamHistory` (the plugin → host RPC, exercised via `busHistoryReaderAdapter.ReplayTail`) against a plugin-owned scene subject. Assert gRPC status code `codes.PermissionDenied` reaches the plugin caller. Documents the deferred-but-correct fail-closed behavior and pins it as a regression guard until the follow-up bead lands the plugin-as-caller identity story.
+
+## 7. Migration & rollout
+
+No two-system overlap. Changes land in a single PR:
+
+1. Proto change (`audit.proto`): append `caller = 8` only; do not touch fields 1–7. Regenerate.
+2. Export `eventbus.ActorToProto` and `eventbus.ActorKindToProto` (rename from unexported `actorToProto` / `actorKindToProto` in `internal/eventbus/publisher.go`). Update existing in-package callers.
+3. Add `Caller eventbus.Actor` field to `eventbus.HistoryQuery`.
+4. Add `caller eventbus.Actor` parameter to `internal/grpc/query_stream_history.go:fetchHistoryFramesFromBus`; set `q.Caller = caller` at construction.
+5. Host handler `QueryStreamHistory`: derive `caller` from `info.CharacterID` and pass to `fetchHistoryFramesFromBus`.
+6. `PluginHistoryRouter.QueryHistory`: populate `req.Caller` via the exported helper; preserve gRPC status codes from the plugin (transparent proxy for `status.FromError`-recognised errors; existing oops wrap only for non-status errors).
+7. `pluginHistoryStream.Next`: same gRPC-status preservation pattern as the router's outer call.
+8. Plugin `SceneAuditServer.QueryHistory`: implement auth ordering (caller validation → subject parse → membership) per §5.1; emit denials via `status.Error(codes.PermissionDenied, …)` with sibling `slog` lines carrying the `SCENE_AUDIT_*` oops codes for log dimensioning.
+9. `SceneStore.IsMember` added (`WHERE role IN ('owner', 'member')`).
+10. `mapHistoryError` (`internal/grpc/query_stream_history.go`): prepend a `status.FromError` dispatch step; map `codes.PermissionDenied` → `STREAM_ACCESS_DENIED` (opaque); pass `codes.InvalidArgument` through.
+11. Tests per §6.
+12. Remove the TODO at `plugins/core-scenes/audit.go:211` and update the function docstring to document the enforcement contract (owner/member only — see §5.4 for the deliberate role-policy departure).
+13. **File a follow-up bead** (before this PR merges) capturing the plugin-as-caller identity design problem flagged in §4.4. Title suggestion: "Plugin-as-caller identity for `PluginHostService.QueryStreamHistory` against plugin-owned subjects." Block any future work on that path on the new bead.
+
+No database migration required. No breaking change to any client API — outer gRPC surface preserves the opaque denial contract.
+
+## 8. Risks & open items
+
+- **Proto field vs. metadata.** We chose the proto field for contract visibility (§4.1). The bead's original framing suggested gRPC metadata. This spec deliberately deviates on the grounds that security fields belong on the wire contract.
+- **Plugin-host caller identity (deferred).** §4.4 documents that `PluginHostService.QueryStreamHistory` will return `PERMISSION_DENIED` for plugin-owned subjects after this lands. No in-tree caller breaks (verified via cold-tier spec line 627 and current SDK survey). The follow-up bead filed per §7 step 13 owns the design for "plugin-as-caller" identity. Until that bead lands, plugins MUST NOT add code paths that read plugin-owned subjects via `holomush.query_stream_history` or its Go SDK equivalent.
+- **System / admin caller.** This spec defers system/admin reads to a separate RPC or capability. A follow-up bead should be filed when the first such caller materializes (likely `holomush-l4kx` audit-backfill CLI) so the capability surface is designed rather than bolted on.
+- **Role policy for `invited`.** Invited characters do NOT pass the plugin check (§5.4 documents this as a deliberate tightening). If product later decides on a "preview before joining" feature, that surfaces as a new capability; it MUST NOT be added by quietly including invited in `IsMember`.
+- **Error-mapping fragility.** The §5.5 design depends on (a) plugins emitting denials via `status.Error`, (b) the router preserving gRPC status codes through `status.FromError` recognition, and (c) `mapHistoryError` running the status dispatch BEFORE the existing `errors.Is` chain. A regression in any of the three silently breaks opacity. The §6.5 case 1 integration test asserts the **top-level** oops code via `oops.AsOops(err).Code()` (NOT a chain-walking helper like `errutil.AssertErrorCode`, which would pass even on a double-wrapped denial); the assertion expects `STREAM_ACCESS_DENIED`, the same code the outer I-17 gate uses, and is the load-bearing regression guard.
+- **Information-hiding vs. debuggability.** The opaque client-facing error makes debugging harder for legitimate users who hit an unexpected denial. Mitigation: plugin-internal `slog` log attributes carry the distinct `SCENE_AUDIT_*` codes, so server logs and metrics can distinguish the cases even when the client sees one collapsed error. Client-side log hints may be useful as a follow-up but are out of scope.

--- a/internal/eventbus/audit/plugin_router.go
+++ b/internal/eventbus/audit/plugin_router.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/eventbus"
@@ -71,6 +73,7 @@ func (r *PluginHistoryRouter) QueryHistory(
 		Subject:   string(q.Subject),
 		PageSize:  int32(pageSize),
 		Direction: directionProto(q.Direction),
+		Caller:    eventbus.ActorToProto(q.Caller),
 	}
 	if !q.AfterID.IsZero() {
 		b := q.AfterID.Bytes()
@@ -95,6 +98,14 @@ func (r *PluginHistoryRouter) QueryHistory(
 	stream, err := client.QueryHistory(rpcCtx, req)
 	if err != nil {
 		cancel()
+		// Preserve gRPC status codes from the plugin verbatim. The host's error-
+		// translation chain (mapHistoryError + the gRPC server-streaming layer)
+		// uses status.FromError to extract the code; wrapping with oops here
+		// would shadow it. Only wrap non-status errors with the diagnostic
+		// AUDIT_PLUGIN_HISTORY_RPC_FAILED oops code.
+		if st, ok := status.FromError(err); ok && st.Code() != codes.Unknown {
+			return nil, err //nolint:wrapcheck // intentional: preserve plugin's gRPC status code for downstream status.FromError-based translation
+		}
 		return nil, oops.Code("AUDIT_PLUGIN_HISTORY_RPC_FAILED").
 			With("plugin", pluginName).
 			With("subject", string(q.Subject)).
@@ -149,6 +160,14 @@ func (s *pluginHistoryStream) Next(ctx context.Context) (eventbus.Event, error) 
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return eventbus.Event{}, io.EOF
+		}
+		// Preserve gRPC status codes from the plugin verbatim. The host's
+		// error-translation chain (mapHistoryError + the gRPC server-streaming
+		// layer) uses status.FromError to extract the code; wrapping with oops
+		// here would shadow it. Only wrap non-status errors with the diagnostic
+		// AUDIT_PLUGIN_HISTORY_RECV_FAILED oops code.
+		if st, ok := status.FromError(err); ok && st.Code() != codes.Unknown {
+			return eventbus.Event{}, err //nolint:wrapcheck // preserve plugin's gRPC status code for downstream status.FromError-based translation
 		}
 		return eventbus.Event{}, oops.Code("AUDIT_PLUGIN_HISTORY_RECV_FAILED").
 			With("plugin", s.pluginName).

--- a/internal/eventbus/audit/plugin_router_test.go
+++ b/internal/eventbus/audit/plugin_router_test.go
@@ -10,10 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/core"
@@ -246,6 +249,158 @@ func TestPluginHistoryStreamCloseIsIdempotent(t *testing.T) {
 	// A Next after Close returns EOF per contract.
 	_, err = stream.Next(context.Background())
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestPluginHistoryRouterForwardsCallerVerbatim(t *testing.T) {
+	t.Parallel()
+
+	id := core.NewULID()
+	idBytes := id.Bytes()
+	callerID := core.NewULID()
+
+	fs := &fakeStream{
+		resps: []*pluginv1.QueryHistoryResponse{
+			{Event: &eventbusv1.Event{
+				Id:        idBytes[:],
+				Subject:   "events.main.scene.01ABC.ic",
+				Type:      "scene.lifecycle.created",
+				Timestamp: timestamppb.New(time.Unix(1, 0)),
+				Payload:   []byte(`{"k":"v"}`),
+			}},
+		},
+	}
+	fc := &fakeHistoryClient{stream: fs}
+	router := audit.NewPluginHistoryRouter(stubProvider{name: "core-scenes", client: fc})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:   "events.main.scene.01ABC.ic",
+		PageSize:  50,
+		Direction: eventbus.DirectionForward,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   callerID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, fc.lastReq)
+
+	gotCaller := fc.lastReq.GetCaller()
+	require.NotNil(t, gotCaller, "Caller MUST be set on the proto request")
+	assert.Equal(t, eventbusv1.ActorKind_ACTOR_KIND_CHARACTER, gotCaller.GetKind())
+	callerBytes := callerID.Bytes()
+	assert.Equal(t, callerBytes[:], gotCaller.GetId(), "Id bytes MUST match the caller ULID")
+}
+
+// fakeStatusErrorClient returns a precise status error from QueryHistory.
+type fakeStatusErrorClient struct {
+	pluginv1.PluginAuditServiceClient
+	err error
+}
+
+func (c *fakeStatusErrorClient) QueryHistory(_ context.Context, _ *pluginv1.QueryHistoryRequest, _ ...grpc.CallOption) (pluginv1.PluginAuditService_QueryHistoryClient, error) {
+	return nil, c.err
+}
+
+func TestPluginHistoryRouterPreservesGRPCStatusOnQueryHistoryError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeStatusErrorClient{err: wantErr},
+	})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   core.NewULID(),
+		},
+	})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "router MUST return a recognisable status error, not an oops-wrapped opaque error")
+	assert.Equal(t, codes.PermissionDenied, st.Code(), "router MUST preserve the plugin's gRPC status code")
+
+	// The router MUST return the status error verbatim — not wrapped in an
+	// oops envelope. mapHistoryError downstream relies on status.FromError,
+	// which works either way, but other callers may type-assert directly.
+	assert.ErrorIs(t, err, wantErr, "router MUST return the status error verbatim, not wrapped")
+	_, isOops := oops.AsOops(err)
+	assert.False(t, isOops, "router MUST NOT wrap status errors with oops; got %T", err)
+}
+
+// fakeStreamWithRecvErr returns the given err from Recv.
+type fakeStreamWithRecvErr struct {
+	fakeStream
+	err error
+}
+
+func (s *fakeStreamWithRecvErr) Recv() (*pluginv1.QueryHistoryResponse, error) {
+	return nil, s.err
+}
+
+// fakeRecvErrClient hands out a stream whose Recv returns the error.
+type fakeRecvErrClient struct {
+	pluginv1.PluginAuditServiceClient
+	streamErr error
+}
+
+func (c *fakeRecvErrClient) QueryHistory(_ context.Context, _ *pluginv1.QueryHistoryRequest, _ ...grpc.CallOption) (pluginv1.PluginAuditService_QueryHistoryClient, error) {
+	return &fakeStreamWithRecvErr{err: c.streamErr}, nil
+}
+
+func TestPluginHistoryStreamPreservesGRPCStatusOnRecvError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeRecvErrClient{streamErr: wantErr},
+	})
+
+	stream, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+		Caller: eventbus.Actor{
+			Kind: eventbus.ActorKindCharacter,
+			ID:   core.NewULID(),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = stream.Next(context.Background())
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "stream Next MUST return a recognisable status error from the plugin")
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+
+	// Strengthening (matches Task 4's pattern): the error should NOT be
+	// oops-wrapped; it should be the verbatim status error.
+	_, isOops := oops.AsOops(err)
+	assert.False(t, isOops, "stream Next MUST return the verbatim status error, not an oops-wrapped envelope")
+}
+
+func TestPluginHistoryRouterWrapsNonStatusErrorOnQueryHistoryError(t *testing.T) {
+	t.Parallel()
+
+	router := audit.NewPluginHistoryRouter(stubProvider{
+		name:   "core-scenes",
+		client: &fakeStatusErrorClient{err: errors.New("transport failure")},
+	})
+
+	_, err := router.QueryHistory(context.Background(), "core-scenes", eventbus.HistoryQuery{
+		Subject:  "events.main.scene.01ABC.ic",
+		PageSize: 50,
+	})
+	require.Error(t, err)
+
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "non-status errors MUST be oops-wrapped for diagnostic context")
+	assert.Equal(t, "AUDIT_PLUGIN_HISTORY_RPC_FAILED", oopsErr.Code())
 }
 
 func TestPluginHistoryRouterForwardsCursors(t *testing.T) {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -61,8 +61,13 @@ type SessionStream interface {
 	Close() error
 }
 
-// HistoryQuery describes a paginated history read. Auth flows via
-// context.Context (auth.WithSession), not via this struct.
+// HistoryQuery describes a paginated history read. Caller identity is
+// carried on the `Caller` field below — populated by the host's gRPC
+// handler from the authenticated session record. Public-tier readers
+// (hot JetStream, cold Postgres) ignore Caller; plugin-owned subject
+// routes (PluginHistoryRouter) MUST forward it to the plugin's
+// PluginAuditService.QueryHistory for membership enforcement. See
+// spec §4.2.
 //
 // Pagination ordering is by JetStream stream sequence (js_seq), not by
 // ULID. Cursors are (seq, id) pairs: AfterSeq/AfterID for forward reads,
@@ -87,6 +92,14 @@ type HistoryQuery struct {
 	NotAfter  time.Time
 	Direction Direction
 	PageSize  int
+
+	// Caller identifies the principal on whose behalf the read is happening.
+	// Populated by the host's gRPC handler from the authenticated session
+	// record. Public-tier readers (hot JetStream, cold Postgres) ignore this
+	// field; plugin-owned subject routes (PluginHistoryRouter) MUST forward
+	// it to the plugin's PluginAuditService.QueryHistory for membership
+	// enforcement. See spec §4.2.
+	Caller Actor
 }
 
 // HistoryStream is a server-streaming handle. Caller iterates Next()

--- a/internal/eventbus/cursor/cursorv1/cursor.pb.go
+++ b/internal/eventbus/cursor/cursorv1/cursor.pb.go
@@ -5,8 +5,9 @@
 // api/proto/. Clients see only the marshaled bytes; this proto is the
 // host's private encoding.
 //
-// Forward compatibility: leading `version` field discriminates the wire
-// format. Today only version=1 is defined.
+// Version compatibility: Decode() accepts ONLY CurrentVersion (today=1).
+// Any other version value causes EVENTBUS_CURSOR_INVALID; there is no
+// forward- or backward-compatibility between versions.
 //
 // See docs/superpowers/specs/2026-04-21-cold-tier-js-seq-pagination-design.md §4.5.
 

--- a/internal/eventbus/publisher.go
+++ b/internal/eventbus/publisher.go
@@ -158,7 +158,7 @@ func (p *JetStreamPublisher) Publish(ctx context.Context, event Event) error {
 		Subject:   string(event.Subject),
 		Type:      string(event.Type),
 		Timestamp: timestamppb.New(event.Timestamp),
-		Actor:     actorToProto(event.Actor),
+		Actor:     ActorToProto(event.Actor),
 		Payload:   event.Payload,
 	}
 	plainBytes, err := proto.Marshal(envelope)
@@ -271,8 +271,11 @@ func (k ActorKind) String() string {
 	}
 }
 
-func actorToProto(a Actor) *eventbusv1.Actor {
-	p := &eventbusv1.Actor{Kind: actorKindToProto(a.Kind)}
+// ActorToProto converts an in-process Actor to the proto representation.
+// Exported so audit-router and other cross-package callers can reuse the
+// single source of truth for Actor mapping.
+func ActorToProto(a Actor) *eventbusv1.Actor {
+	p := &eventbusv1.Actor{Kind: ActorKindToProto(a.Kind)}
 	if a.ID != (ulid.ULID{}) {
 		p.Id = a.ID.Bytes()
 	} else if a.LegacyID != "" {
@@ -281,7 +284,10 @@ func actorToProto(a Actor) *eventbusv1.Actor {
 	return p
 }
 
-func actorKindToProto(k ActorKind) eventbusv1.ActorKind {
+// ActorKindToProto maps the in-process ActorKind enum to the proto enum.
+// ActorKindUnknown (zero) maps to ACTOR_KIND_UNSPECIFIED — there is no
+// proto ACTOR_KIND_UNKNOWN.
+func ActorKindToProto(k ActorKind) eventbusv1.ActorKind {
 	switch k {
 	case ActorKindCharacter:
 		return eventbusv1.ActorKind_ACTOR_KIND_CHARACTER

--- a/internal/grpc/query_stream_history.go
+++ b/internal/grpc/query_stream_history.go
@@ -216,7 +216,19 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 	// Step 7: Fetch count+1 to detect has_more.
 	// Delegate to the JetStream/PostgreSQL tier crossover reader (F4+).
 	// Both paths produce ascending (oldest→newest) slices of count+1 events maximum.
-	frames, fetchErr := fetchHistoryFramesFromBus(ctx, s.historyReader, s.currentGameID(), req.Stream, count, notBefore, beforeSeq, beforeID)
+	//
+	// Caller MUST be derived from the authenticated session record only.
+	// We never trust a client-supplied character_id from the request body.
+	// The plugin-owned subject path forwards this through PluginAuditService
+	// to enforce per-plugin membership (spec §4.2 + §4.3).
+	caller := eventbus.Actor{
+		Kind: eventbus.ActorKindCharacter,
+		ID:   info.CharacterID,
+	}
+	frames, fetchErr := fetchHistoryFramesFromBus(
+		ctx, s.historyReader, s.currentGameID(), req.Stream, count,
+		notBefore, beforeSeq, beforeID, caller,
+	)
 	if fetchErr != nil {
 		return nil, mapHistoryError(oops.Code("INTERNAL").
 			With("stream", req.Stream).
@@ -257,6 +269,27 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 
 // mapHistoryError translates eventbus cursor errors to gRPC status codes.
 func mapHistoryError(err error) error {
+	// gRPC status pass-through with opacity translation. The plugin emits
+	// status.Error directly; the router preserves the code; we run this
+	// dispatch FIRST so the existing cursor-error chain doesn't shadow it.
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.PermissionDenied:
+			// Opaque: collapse plugin-boundary denial into the same oops
+			// code the outer I-17 gate uses. Client cannot distinguish
+			// "outer wall caught" from "plugin wall caught."
+			return oops.Code("STREAM_ACCESS_DENIED").
+				Errorf("not authorized to read stream")
+		case codes.InvalidArgument:
+			// Use the extracted status message — using "%v" on err would
+			// include the host-side oops wrapper text in the client-visible
+			// message (e.g., "stream=...: subject required" instead of just
+			// "subject required"). st.Message() is the plugin's original.
+			return status.Errorf(codes.InvalidArgument, "%s", st.Message())
+		}
+		// Other status codes (Internal, Unavailable, …) pass through to the
+		// existing dispatch below, which falls through to default.
+	}
 	switch {
 	case errors.Is(err, eventbus.ErrCursorInvalid):
 		return status.Errorf(codes.InvalidArgument, "%v", err)
@@ -284,6 +317,7 @@ func fetchHistoryFramesFromBus(
 	notBefore time.Time,
 	beforeSeq uint64,
 	beforeID ulid.ULID,
+	caller eventbus.Actor,
 ) ([]*corev1.EventFrame, error) {
 	natsSubject, err := subjectxlate.Legacy(legacyStream, gameID)
 	if err != nil {
@@ -299,6 +333,7 @@ func fetchHistoryFramesFromBus(
 		Direction: eventbus.DirectionBackward,
 		PageSize:  count + 1,
 		NotBefore: notBefore,
+		Caller:    caller,
 	}
 	if beforeSeq != 0 {
 		q.BeforeSeq = beforeSeq
@@ -309,7 +344,11 @@ func fetchHistoryFramesFromBus(
 
 	stream, err := reader.QueryHistory(ctx, q)
 	if err != nil {
-		return nil, mapHistoryError(oops.With("subject", string(sub)).Wrap(err))
+		// Do NOT call mapHistoryError here — translation runs once, at the
+		// outer QueryStreamHistory call site (see :233). Translating twice
+		// produces an oops("INTERNAL").Wrap(oops("STREAM_ACCESS_DENIED")...)
+		// chain whose top code is INTERNAL, breaking the §5.5 opacity contract.
+		return nil, oops.With("subject", string(sub)).Wrap(err)
 	}
 	defer stream.Close() //nolint:errcheck // best-effort iterator close
 

--- a/internal/grpc/query_stream_history_test.go
+++ b/internal/grpc/query_stream_history_test.go
@@ -740,6 +740,51 @@ func TestMapHistoryErrorPassesThroughUnknownError(t *testing.T) {
 	assert.Equal(t, orig, got)
 }
 
+// TestMapHistoryErrorTranslatesPermissionDeniedToOpaqueOopsCode verifies that
+// a gRPC PermissionDenied returned by the plugin collapses into the same
+// opaque oops code the outer I-17 gate uses, preventing information leak
+// about which authorization wall caught the caller.
+func TestMapHistoryErrorTranslatesPermissionDeniedToOpaqueOopsCode(t *testing.T) {
+	t.Parallel()
+
+	pluginErr := status.Error(codes.PermissionDenied, "scene audit access denied")
+	got := mapHistoryError(pluginErr)
+	require.Error(t, got)
+
+	oopsErr, ok := oops.AsOops(got)
+	require.True(t, ok, "translated error MUST be oops-wrapped")
+	assert.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
+		"PermissionDenied from the plugin MUST collapse into the same opaque oops code the outer I-17 gate uses")
+}
+
+// TestMapHistoryErrorPassesThroughInvalidArgument verifies that an
+// InvalidArgument status from the plugin propagates as-is to the client.
+func TestMapHistoryErrorPassesThroughInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	pluginErr := status.Error(codes.InvalidArgument, "subject malformed")
+	got := mapHistoryError(pluginErr)
+	require.Error(t, got)
+
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestMapHistoryErrorRetainsCursorInvalidDispatchForNonStatusErrors verifies
+// that the existing eventbus.ErrCursorInvalid → InvalidArgument dispatch
+// still applies when no gRPC status is present on the error.
+func TestMapHistoryErrorRetainsCursorInvalidDispatchForNonStatusErrors(t *testing.T) {
+	t.Parallel()
+
+	got := mapHistoryError(eventbus.ErrCursorInvalid)
+	require.Error(t, got)
+	st, ok := status.FromError(got)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code(),
+		"existing cursor-error dispatch MUST still apply when no gRPC status is present")
+}
+
 // TestQueryStreamHistoryEncodeEventCursorWithZeroSeq verifies that
 // encodeEventCursor still produces a decodable OwnerHost cursor when Seq==0
 // (no JetStream metadata populated).
@@ -774,4 +819,86 @@ func TestQueryStreamHistoryEncodeEventCursorWithZeroSeq(t *testing.T) {
 	decoded, decErr := cursor.Decode(frameCursor)
 	require.NoError(t, decErr)
 	assert.Equal(t, uint64(0), decoded.Host.Seq)
+}
+
+// TestQueryStreamHistoryThreadsCallerFromSession asserts that the handler
+// derives Caller (Actor) from the authenticated session record and threads
+// it through to the HistoryReader's HistoryQuery. This is the producer side
+// of the I-23 caller invariant: plugin-owned subjects gate on q.Caller.
+func TestQueryStreamHistoryThreadsCallerFromSession(t *testing.T) {
+	t.Parallel()
+
+	charID := ulid.MustParse("01HYXCHAR0000000000000000C")
+	future := time.Now().Add(time.Hour)
+	sess := newTestSessionStore(t, map[string]*session.Info{
+		"sess-1": {
+			ID:          "sess-1",
+			CharacterID: charID,
+			ExpiresAt:   &future,
+		},
+	})
+
+	reader := &fakeHistoryReader{}
+	server := newQueryStreamHistoryServer(t, reader, sess)
+
+	// Public stream so the I-17 gate doesn't fire — focuses the test on
+	// caller threading. The harness wires policytest.AllowAllEngine() by
+	// default per newQueryStreamHistoryServer.
+	_, err := server.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "sess-1",
+		Stream:    "location:01HYXLOC00000000000000000",
+		Count:     10,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, eventbus.ActorKindCharacter, reader.gotQ.Caller.Kind,
+		"handler MUST set Caller.Kind = ActorKindCharacter")
+	assert.Equal(t, charID, reader.gotQ.Caller.ID,
+		"handler MUST set Caller.ID from info.CharacterID")
+}
+
+// TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode covers
+// spec §6.5 case 2: the outer I-17 membership gate passes (the session is a
+// scene member), so the request reaches the HistoryReader. The plugin then
+// returns a gRPC PermissionDenied (e.g., due to a mid-read membership
+// revocation, or a plugin-internal authz wall). The handler MUST collapse
+// this into the SAME opaque STREAM_ACCESS_DENIED oops code the outer gate
+// uses — clients cannot distinguish "outer wall caught" from "plugin wall
+// caught", preventing information leak about authz topology.
+func TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode(t *testing.T) {
+	t.Parallel()
+
+	stream, focus := sceneFocusMembership(t)
+	future := time.Now().Add(time.Hour)
+	sess := newTestSessionStore(t, map[string]*session.Info{
+		"s1": {
+			ID:               "s1",
+			CharacterID:      ulid.MustParse("01HYXCHAR0000000000000000C"),
+			ExpiresAt:        &future,
+			FocusMemberships: []session.FocusMembership{focus},
+		},
+	})
+
+	reader := &fakeHistoryReader{
+		err: status.Error(codes.PermissionDenied, "scene audit access denied"),
+	}
+	s := newQueryStreamHistoryServer(t, reader, sess)
+
+	_, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "s1",
+		Stream:    stream,
+		Count:     10,
+	})
+	require.Error(t, err)
+
+	// Assert the TOP-LEVEL oops code, not any code somewhere in the chain.
+	// errutil.AssertErrorCode walks the chain via errors.Is, which would
+	// pass even if the handler double-wrapped STREAM_ACCESS_DENIED inside
+	// an outer INTERNAL — defeating the opacity contract. oops.AsOops
+	// returns the OUTERMOST oops node, so .Code() asserts the actual
+	// client-visible top-level code.
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "translated error MUST be an oops error at the top level")
+	assert.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
+		"top-level oops code MUST equal the outer I-17 gate's code (no double-wrap with INTERNAL)")
 }

--- a/pkg/proto/holomush/plugin/v1/audit.pb.go
+++ b/pkg/proto/holomush/plugin/v1/audit.pb.go
@@ -117,14 +117,21 @@ func (*AuditEventResponse) Descriptor() ([]byte, []int) {
 }
 
 type QueryHistoryRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Subject       string                 `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
-	After         []byte                 `protobuf:"bytes,2,opt,name=after,proto3" json:"after,omitempty"`                        // ULID; empty = from start
-	Before        []byte                 `protobuf:"bytes,3,opt,name=before,proto3" json:"before,omitempty"`                      // ULID; empty = unbounded
-	PageSize      int32                  `protobuf:"varint,4,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"` // host caps at 200
-	Direction     int32                  `protobuf:"varint,5,opt,name=direction,proto3" json:"direction,omitempty"`               // 1=forward, 2=backward
-	NotBefore     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=not_before,json=notBefore,proto3" json:"not_before,omitempty"`
-	NotAfter      *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=not_after,json=notAfter,proto3" json:"not_after,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Subject   string                 `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
+	After     []byte                 `protobuf:"bytes,2,opt,name=after,proto3" json:"after,omitempty"`                        // ULID; empty = from start
+	Before    []byte                 `protobuf:"bytes,3,opt,name=before,proto3" json:"before,omitempty"`                      // ULID; empty = unbounded
+	PageSize  int32                  `protobuf:"varint,4,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"` // host caps at 200
+	Direction int32                  `protobuf:"varint,5,opt,name=direction,proto3" json:"direction,omitempty"`               // 1=forward, 2=backward
+	NotBefore *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=not_before,json=notBefore,proto3" json:"not_before,omitempty"`
+	NotAfter  *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=not_after,json=notAfter,proto3" json:"not_after,omitempty"`
+	// caller identifies the principal on whose behalf the host is reading.
+	// Plugins implementing PluginAuditService MUST enforce domain-specific
+	// authz (e.g., membership) against this identity before returning rows.
+	// An absent caller, a zero identity, or an unsupported Actor.Kind MUST
+	// be rejected with gRPC PERMISSION_DENIED. The host populates this
+	// field from the authenticated session record; clients never supply it.
+	Caller        *v1.Actor `protobuf:"bytes,8,opt,name=caller,proto3" json:"caller,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -208,6 +215,13 @@ func (x *QueryHistoryRequest) GetNotAfter() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *QueryHistoryRequest) GetCaller() *v1.Actor {
+	if x != nil {
+		return x.Caller
+	}
+	return nil
+}
+
 type QueryHistoryResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Event         *v1.Event              `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
@@ -263,7 +277,7 @@ const file_holomush_plugin_v1_audit_proto_rawDesc = "" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x14\n" +
-	"\x12AuditEventResponse\"\x8c\x02\n" +
+	"\x12AuditEventResponse\"\xc1\x02\n" +
 	"\x13QueryHistoryRequest\x12\x18\n" +
 	"\asubject\x18\x01 \x01(\tR\asubject\x12\x14\n" +
 	"\x05after\x18\x02 \x01(\fR\x05after\x12\x16\n" +
@@ -272,7 +286,8 @@ const file_holomush_plugin_v1_audit_proto_rawDesc = "" +
 	"\tdirection\x18\x05 \x01(\x05R\tdirection\x129\n" +
 	"\n" +
 	"not_before\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tnotBefore\x127\n" +
-	"\tnot_after\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\bnotAfter\"I\n" +
+	"\tnot_after\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\bnotAfter\x123\n" +
+	"\x06caller\x18\b \x01(\v2\x1b.holomush.eventbus.v1.ActorR\x06caller\"I\n" +
 	"\x14QueryHistoryResponse\x121\n" +
 	"\x05event\x18\x01 \x01(\v2\x1b.holomush.eventbus.v1.EventR\x05event2\xd6\x01\n" +
 	"\x12PluginAuditService\x12[\n" +
@@ -303,22 +318,24 @@ var file_holomush_plugin_v1_audit_proto_goTypes = []any{
 	nil,                           // 4: holomush.plugin.v1.AuditEventRequest.HeadersEntry
 	(*v1.Event)(nil),              // 5: holomush.eventbus.v1.Event
 	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
+	(*v1.Actor)(nil),              // 7: holomush.eventbus.v1.Actor
 }
 var file_holomush_plugin_v1_audit_proto_depIdxs = []int32{
 	5, // 0: holomush.plugin.v1.AuditEventRequest.event:type_name -> holomush.eventbus.v1.Event
 	4, // 1: holomush.plugin.v1.AuditEventRequest.headers:type_name -> holomush.plugin.v1.AuditEventRequest.HeadersEntry
 	6, // 2: holomush.plugin.v1.QueryHistoryRequest.not_before:type_name -> google.protobuf.Timestamp
 	6, // 3: holomush.plugin.v1.QueryHistoryRequest.not_after:type_name -> google.protobuf.Timestamp
-	5, // 4: holomush.plugin.v1.QueryHistoryResponse.event:type_name -> holomush.eventbus.v1.Event
-	0, // 5: holomush.plugin.v1.PluginAuditService.AuditEvent:input_type -> holomush.plugin.v1.AuditEventRequest
-	2, // 6: holomush.plugin.v1.PluginAuditService.QueryHistory:input_type -> holomush.plugin.v1.QueryHistoryRequest
-	1, // 7: holomush.plugin.v1.PluginAuditService.AuditEvent:output_type -> holomush.plugin.v1.AuditEventResponse
-	3, // 8: holomush.plugin.v1.PluginAuditService.QueryHistory:output_type -> holomush.plugin.v1.QueryHistoryResponse
-	7, // [7:9] is the sub-list for method output_type
-	5, // [5:7] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	7, // 4: holomush.plugin.v1.QueryHistoryRequest.caller:type_name -> holomush.eventbus.v1.Actor
+	5, // 5: holomush.plugin.v1.QueryHistoryResponse.event:type_name -> holomush.eventbus.v1.Event
+	0, // 6: holomush.plugin.v1.PluginAuditService.AuditEvent:input_type -> holomush.plugin.v1.AuditEventRequest
+	2, // 7: holomush.plugin.v1.PluginAuditService.QueryHistory:input_type -> holomush.plugin.v1.QueryHistoryRequest
+	1, // 8: holomush.plugin.v1.PluginAuditService.AuditEvent:output_type -> holomush.plugin.v1.AuditEventResponse
+	3, // 9: holomush.plugin.v1.PluginAuditService.QueryHistory:output_type -> holomush.plugin.v1.QueryHistoryResponse
+	8, // [8:10] is the sub-list for method output_type
+	6, // [6:8] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_holomush_plugin_v1_audit_proto_init() }

--- a/plugins/core-scenes/audit.go
+++ b/plugins/core-scenes/audit.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
@@ -48,6 +51,37 @@ const (
 	directionBackward = int32(2)
 )
 
+// sceneAuditLogStore is the log-storage surface SceneAuditServer needs.
+// Insert / queryLog signatures match *SceneAuditStore verbatim so the
+// concrete store satisfies the interface without adapter shims.
+type sceneAuditLogStore interface {
+	Insert(
+		ctx context.Context,
+		id []byte,
+		subject, eventType string,
+		timestamp *timestamppb.Timestamp,
+		actorKind string,
+		actorID []byte,
+		payload []byte,
+		schemaVer int,
+		codec string,
+	) error
+	queryLog(
+		ctx context.Context,
+		subject string,
+		after, before []byte,
+		notBefore, notAfter *timestamppb.Timestamp,
+		reverse bool,
+		pageSize int,
+	) ([]logRow, error)
+}
+
+// sceneMembershipLookup is the membership-check surface SceneAuditServer
+// needs. *SceneStore (Task 8) satisfies this.
+type sceneMembershipLookup interface {
+	IsMember(ctx context.Context, sceneID, characterID string) (bool, error)
+}
+
 // SceneAuditServer implements PluginAuditService for core-scenes.
 //
 // AuditEvent is invoked by the host per-plugin audit consumer for every
@@ -61,7 +95,8 @@ const (
 // format used by the host events_audit table.
 type SceneAuditServer struct {
 	pluginv1.UnimplementedPluginAuditServiceServer
-	store *SceneAuditStore
+	store        sceneAuditLogStore    // queryLog only
+	memberLookup sceneMembershipLookup // IsMember only
 }
 
 // SceneAuditStore wraps the pgx pool with audit-specific SQL helpers. Kept
@@ -193,30 +228,100 @@ func (s *SceneAuditServer) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 		ver,
 		codec,
 	); err != nil {
-		return nil, err
+		// SceneAuditStore.Insert already wraps with SCENE_AUDIT_INSERT_FAILED
+		// and the same subject/type context — propagate as-is.
+		return nil, err //nolint:wrapcheck // already wrapped by Insert with SCENE_AUDIT_INSERT_FAILED
 	}
 
 	return &pluginv1.AuditEventResponse{}, nil
 }
 
-// QueryHistory streams scene_log rows matching the request. The plugin
-// enforces authorisation via a membership check: the caller MUST be a
-// participant of the queried scene (owner, member, or invited). Absent
-// auth context, the plugin rejects the call — the host is expected to
-// propagate the character's identity via gRPC metadata, but in the
-// current wiring the host is a trusted caller; until auth context is
-// plumbed through the plugin transport, the plugin permits any query
-// and relies on the host gatekeeping at the outer gRPC boundary.
+// QueryHistory streams scene_log rows matching the request after enforcing
+// scene membership at the plugin boundary. Authorisation is step 1 and runs
+// BEFORE cursor decoding or any DB query — the early-rejection ordering
+// avoids timing oracles and is pinned by audit_test.go's
+// TestQueryHistoryDeniesNonMemberWithoutHittingLogStore.
 //
-// TODO(holomush-1tvn.12 follow-up): plumb caller identity from the host
-// through the plugin gRPC connection so the membership check can hard-
-// gate non-participant queries at the plugin boundary.
+// The caller (req.Caller) is forwarded verbatim from the host's
+// CoreServer.QueryStreamHistory handler (which derives it from the
+// authenticated session). Plugins MUST NOT trust client-supplied identity;
+// see spec §3.2 for the trust model.
+//
+// Membership policy: only owner and member roles see rows. Invited rows
+// return PERMISSION_DENIED — invitation grants join rights, not passive
+// read rights (spec §5.4). Non-CHARACTER caller kinds are rejected;
+// admin / system / cross-plugin reads are deferred to a future RPC.
+//
+// Errors:
+//   - codes.PermissionDenied — caller missing, kind unsupported, or non-member
+//   - codes.InvalidArgument  — subject empty or malformed
+//   - codes.Internal         — store / DB error
 func (s *SceneAuditServer) QueryHistory(req *pluginv1.QueryHistoryRequest, stream pluginv1.PluginAuditService_QueryHistoryServer) error {
 	if req == nil || req.GetSubject() == "" {
-		return oops.Code("SCENE_AUDIT_SUBJECT_REQUIRED").Errorf("subject required")
+		return status.Error(codes.InvalidArgument, "subject required") //nolint:wrapcheck // intentional: gRPC status is the documented contract for this handler; wrapping would shadow the code visible to mapHistoryError
 	}
-	ctx := stream.Context()
 
+	// Auth — step 1, before any other work.
+	caller := req.GetCaller()
+	if caller == nil {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller missing",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller required") //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+	if caller.GetKind() != eventbusv1.ActorKind_ACTOR_KIND_CHARACTER {
+		slog.InfoContext(stream.Context(), "scene audit denied — non-character caller",
+			"subject", req.GetSubject(), "kind", caller.GetKind().String(),
+			"code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "unsupported caller kind") //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+	callerIDBytes := caller.GetId()
+	if len(callerIDBytes) != 16 {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller id wrong length",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller id required") //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+	var callerULID ulid.ULID
+	copy(callerULID[:], callerIDBytes)
+	if callerULID == (ulid.ULID{}) {
+		slog.InfoContext(stream.Context(), "scene audit denied — caller id zero",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_AUTH_REQUIRED")
+		return status.Error(codes.PermissionDenied, "caller id required") //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+	callerCharID := callerULID.String()
+
+	// Subject parse.
+	sceneID, err := parseSceneSubject(req.GetSubject())
+	if err != nil {
+		slog.InfoContext(stream.Context(), "scene audit denied — subject malformed",
+			"subject", req.GetSubject(), "code", "SCENE_AUDIT_SUBJECT_INVALID")
+		return status.Error(codes.InvalidArgument, err.Error()) //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+
+	// Membership check. Fail closed if memberLookup wasn't wired — the
+	// server uses field injection (main.go:108-109), so a missed setup
+	// would otherwise panic on the first audit read.
+	if s.memberLookup == nil {
+		return status.Error(codes.Internal, "membership lookup not configured") //nolint:wrapcheck // gRPC status is the contract; oops would shadow the code
+	}
+	ok, err := s.memberLookup.IsMember(stream.Context(), sceneID, callerCharID)
+	if err != nil {
+		// Log the underlying error server-side; return a generic message
+		// so internal store/transport details don't leak past the plugin
+		// boundary. This path is not rewritten by host's mapHistoryError.
+		slog.ErrorContext(stream.Context(), "scene audit membership lookup failed",
+			"subject", req.GetSubject(), "scene_id", sceneID,
+			"character_id", callerCharID, "err", err.Error())
+		return status.Error(codes.Internal, "membership lookup failed") //nolint:wrapcheck // gRPC status is the contract; oops would shadow the code
+	}
+	if !ok {
+		slog.InfoContext(stream.Context(), "scene audit denied — non-member",
+			"subject", req.GetSubject(), "scene_id", sceneID,
+			"character_id", callerCharID, "code", "SCENE_AUDIT_ACCESS_DENIED")
+		return status.Error(codes.PermissionDenied, "not a participant") //nolint:wrapcheck // preserve gRPC status code for mapHistoryError
+	}
+
+	// From here, the existing pagination + streaming logic runs unchanged.
+	ctx := stream.Context()
 	pageSize := int(req.GetPageSize())
 	if pageSize <= 0 {
 		pageSize = auditDefaultPageSize
@@ -260,12 +365,42 @@ func (s *SceneAuditServer) QueryHistory(req *pluginv1.QueryHistoryRequest, strea
 			},
 		}
 		if err := stream.Send(resp); err != nil {
-			return oops.Code("SCENE_AUDIT_STREAM_SEND_FAILED").
-				With("subject", req.GetSubject()).
-				Wrap(err)
+			// Log server-side; return a generic message so transport details
+			// don't leak past the plugin boundary (path not rewritten by host).
+			slog.ErrorContext(ctx, "scene audit stream send failed",
+				"subject", req.GetSubject(), "err", err.Error())
+			return status.Error(codes.Internal, "stream send failed") //nolint:wrapcheck // gRPC status is the contract; oops would shadow the code
 		}
 	}
 	return nil
+}
+
+// parseSceneSubject extracts sceneID from a JetStream-native scene subject.
+// Expected: events.<gameID>.scene.<sceneID>.<channel>[.<...>]. Rejects
+// wildcard tokens and malformed shapes. See spec §5.3.
+func parseSceneSubject(subject string) (string, error) {
+	parts := strings.Split(subject, ".")
+	if len(parts) < 5 {
+		return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+			With("subject", subject).
+			Errorf("subject does not match events.<game>.scene.<id>.<channel>")
+	}
+	if parts[0] != "events" || parts[2] != "scene" {
+		return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+			With("subject", subject).
+			Errorf("subject not owned by core-scenes")
+	}
+	for _, p := range parts {
+		// Empty token (e.g., "events.main.scene..ic") MUST also be rejected;
+		// otherwise parts[3] returns "" and falls through to membership
+		// denial instead of the InvalidArgument the contract specifies.
+		if p == "" || strings.ContainsAny(p, "*>") {
+			return "", oops.Code("SCENE_AUDIT_SUBJECT_INVALID").
+				With("subject", subject).
+				Errorf("empty or wildcard subject tokens not permitted for QueryHistory")
+		}
+	}
+	return parts[3], nil
 }
 
 // logRow is the scanned representation of one scene_log row.

--- a/plugins/core-scenes/audit_test.go
+++ b/plugins/core-scenes/audit_test.go
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// fakeAuditServerStream satisfies pluginv1.PluginAuditService_QueryHistoryServer
+// and records every Send.
+type fakeAuditServerStream struct {
+	grpc.ServerStream
+	ctx     context.Context
+	sends   []*pluginv1.QueryHistoryResponse
+	sendErr error
+}
+
+func (s *fakeAuditServerStream) Context() context.Context     { return s.ctx }
+func (s *fakeAuditServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeAuditServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeAuditServerStream) SetTrailer(metadata.MD)       {}
+func (s *fakeAuditServerStream) Send(resp *pluginv1.QueryHistoryResponse) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sends = append(s.sends, resp)
+	return nil
+}
+
+// fakeAuditStore records calls made by SceneAuditServer during a test.
+// Satisfies BOTH sceneAuditLogStore and sceneMembershipLookup so a single
+// instance can serve as the test double for both store fields.
+type fakeAuditStore struct {
+	queryLogCalled bool
+	rows           []logRow
+	queryLogErr    error
+	isMemberMap    map[string]bool // key: sceneID|characterID
+}
+
+func (s *fakeAuditStore) IsMember(_ context.Context, sceneID, characterID string) (bool, error) {
+	if s.isMemberMap == nil {
+		return false, nil
+	}
+	return s.isMemberMap[sceneID+"|"+characterID], nil
+}
+
+// Insert is a no-op for tests that exercise QueryHistory (Insert is the
+// AuditEvent path and not under test here, but the interface requires it).
+func (s *fakeAuditStore) Insert(
+	_ context.Context,
+	_ []byte,
+	_, _ string,
+	_ *timestamppb.Timestamp,
+	_ string,
+	_ []byte,
+	_ []byte,
+	_ int,
+	_ string,
+) error {
+	return nil
+}
+
+// queryLog matches *SceneAuditStore.queryLog verbatim.
+func (s *fakeAuditStore) queryLog(
+	_ context.Context,
+	_ string,
+	_, _ []byte,
+	_, _ *timestamppb.Timestamp,
+	_ bool,
+	_ int,
+) ([]logRow, error) {
+	s.queryLogCalled = true
+	if s.queryLogErr != nil {
+		return nil, s.queryLogErr
+	}
+	return s.rows, nil
+}
+
+func ulidStringBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	id, err := ulid.Parse(s)
+	require.NoError(t, err)
+	b := id.Bytes()
+	return b[:]
+}
+
+func TestQueryHistoryRejectsNilCaller(t *testing.T) {
+	srv := &SceneAuditServer{
+		store:        &fakeAuditStore{},
+		memberLookup: &fakeAuditStore{},
+	}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene.01ABC000000000000000000000.ic",
+		Caller:  nil,
+	}, stream)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "auth denial MUST emit gRPC status")
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+func TestQueryHistoryRejectsCharacterCallerWithZeroID(t *testing.T) {
+	srv := &SceneAuditServer{
+		store:        &fakeAuditStore{},
+		memberLookup: &fakeAuditStore{},
+	}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene.01ABC000000000000000000000.ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   nil,
+		},
+	}, stream)
+
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+func TestQueryHistoryRejectsNonCharacterKinds(t *testing.T) {
+	cases := []eventbusv1.ActorKind{
+		eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED,
+		eventbusv1.ActorKind_ACTOR_KIND_PLAYER,
+		eventbusv1.ActorKind_ACTOR_KIND_SYSTEM,
+		eventbusv1.ActorKind_ACTOR_KIND_PLUGIN,
+	}
+	for _, k := range cases {
+		t.Run(k.String(), func(t *testing.T) {
+			srv := &SceneAuditServer{
+				store:        &fakeAuditStore{},
+				memberLookup: &fakeAuditStore{},
+			}
+			stream := &fakeAuditServerStream{ctx: context.Background()}
+
+			err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+				Subject: "events.main.scene.01ABC000000000000000000000.ic",
+				Caller: &eventbusv1.Actor{
+					Kind: k,
+					Id:   ulidStringBytes(t, "01CHAR00000000000000000000"),
+				},
+			}, stream)
+			require.Error(t, err)
+			st, _ := status.FromError(err)
+			assert.Equal(t, codes.PermissionDenied, st.Code())
+		})
+	}
+}
+
+func TestQueryHistoryAllowsMemberAndReturnsRows(t *testing.T) {
+	sceneID := "01ABC000000000000000000000"
+	charIDStr := "01CHAR00000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{
+		rows: []logRow{
+			{id: ulidStringBytes(t, "01EVENT0000000000000000000"),
+				subject:   "events.main.scene." + sceneID + ".ic",
+				eventType: "scene.pose.posted",
+				timestamp: time.Unix(100, 0),
+			},
+		},
+	}
+	memberStore := &fakeAuditStore{
+		isMemberMap: map[string]bool{sceneID + "|" + charIDStr: true},
+	}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.sends, 1)
+	assert.Equal(t, "scene.pose.posted", stream.sends[0].GetEvent().GetType())
+}
+
+func TestQueryHistoryDeniesNonMemberWithoutHittingLogStore(t *testing.T) {
+	sceneID := "01ABC000000000000000000000"
+	charIDStr := "01CHAR00000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{}
+	memberStore := &fakeAuditStore{isMemberMap: map[string]bool{}}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream)
+
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.False(t, logStore.queryLogCalled,
+		"log store MUST NOT be queried when auth denies — auth is step 1, before any DB work")
+}
+
+func TestQueryHistoryReChecksMembershipAcrossPaginations(t *testing.T) {
+	sceneID := "01ABC000000000000000000000"
+	charIDStr := "01CHAR00000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+
+	logStore := &fakeAuditStore{
+		rows: []logRow{{
+			id:        ulidStringBytes(t, "01EVENT0000000000000000000"),
+			subject:   "events.main.scene." + sceneID + ".ic",
+			eventType: "scene.pose.posted",
+			timestamp: time.Unix(100, 0),
+		}},
+	}
+	memberStore := &fakeAuditStore{
+		isMemberMap: map[string]bool{sceneID + "|" + charIDStr: true},
+	}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+
+	// Page 1 — member, rows returned.
+	stream1 := &fakeAuditServerStream{ctx: context.Background()}
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream1)
+	require.NoError(t, err)
+	require.Len(t, stream1.sends, 1)
+
+	// Simulate kick.
+	delete(memberStore.isMemberMap, sceneID+"|"+charIDStr)
+
+	// Page 2 — no longer member, denied.
+	stream2 := &fakeAuditServerStream{ctx: context.Background()}
+	err = srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream2)
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Empty(t, stream2.sends)
+}
+
+func TestQueryHistoryRejectsMalformedSubject(t *testing.T) {
+	cases := []string{
+		"",
+		"events.main.location.01XYZ.ic",
+		"not.events.prefix.scene.01.ic",
+		"events.main.scene.*.ic",
+		"events.main.scene.>",
+		"events.main.scene",
+		"events.main.scene..ic",  // empty sceneID token (regression guard for empty-token rejection)
+		"events..scene.01ABC.ic", // empty gameID token
+	}
+	for _, subj := range cases {
+		t.Run(subj, func(t *testing.T) {
+			srv := &SceneAuditServer{
+				store:        &fakeAuditStore{},
+				memberLookup: &fakeAuditStore{isMemberMap: map[string]bool{}},
+			}
+			stream := &fakeAuditServerStream{ctx: context.Background()}
+
+			err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+				Subject: subj,
+				Caller: &eventbusv1.Actor{
+					Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+					Id:   ulidStringBytes(t, "01CHAR00000000000000000000"),
+				},
+			}, stream)
+			require.Error(t, err)
+			st, _ := status.FromError(err)
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+		})
+	}
+}
+
+// TestQueryHistoryFailsClosedWhenMemberLookupNotConfigured pins the
+// defensive nil-check at the membership-lookup boundary. SceneAuditServer
+// uses field injection (main.go:108-109); a missed wire-up would otherwise
+// produce a runtime panic on the first audit read instead of a structured
+// Internal error.
+func TestQueryHistoryFailsClosedWhenMemberLookupNotConfigured(t *testing.T) {
+	srv := &SceneAuditServer{
+		store:        &fakeAuditStore{},
+		memberLookup: nil, // simulate missed field injection
+	}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene.01ABC000000000000000000000.ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   ulidStringBytes(t, "01CHAR00000000000000000000"),
+		},
+	}, stream)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "nil memberLookup MUST surface as a gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code(),
+		"nil memberLookup MUST fail closed with codes.Internal, not panic")
+}

--- a/plugins/core-scenes/main.go
+++ b/plugins/core-scenes/main.go
@@ -106,6 +106,7 @@ func (p *scenePlugin) Init(ctx context.Context, config *pluginv1.ServiceConfig) 
 	p.service.store = store
 	p.resolver.store = store
 	p.auditSrv.store = NewSceneAuditStore(store.Pool())
+	p.auditSrv.memberLookup = store // *SceneStore satisfies sceneMembershipLookup
 
 	slog.InfoContext(ctx, "core-scenes plugin initialised",
 		"storage", "postgres",

--- a/plugins/core-scenes/store.go
+++ b/plugins/core-scenes/store.go
@@ -302,6 +302,46 @@ func (s *SceneStore) GetWithMembership(ctx context.Context, id string) (scene *S
 	return row, participants, invitees, nil
 }
 
+// IsMember reports whether characterID has an owner or member row in
+// sceneID. Invited-only rows return false — invitation grants join
+// rights, not read rights (see spec §5.4 for the deliberate role-policy
+// tightening).
+//
+// Missing scene and missing row both return (false, nil) by design: the
+// audit-read boundary MUST NOT distinguish "scene doesn't exist" from
+// "you're not a member" because that would leak scene existence to
+// non-members. Internal logs MAY tag the cases distinctly via slog
+// attributes; the function's return type does not.
+func (s *SceneStore) IsMember(ctx context.Context, sceneID, characterID string) (bool, error) {
+	ctx, span := startSpan(ctx, "scene.store.is_member",
+		attribute.String("scene_id", sceneID),
+		attribute.String("character_id", characterID),
+	)
+	defer span.End()
+
+	const q = `
+		SELECT 1
+		FROM scene_participants
+		WHERE scene_id = $1
+		  AND character_id = $2
+		  AND role IN ('owner', 'member')
+		LIMIT 1
+	`
+	var one int
+	err := s.pool.QueryRow(ctx, q, sceneID, characterID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		recordError(span, err)
+		return false, oops.Code("SCENE_STORE_IS_MEMBER_FAILED").
+			With("scene_id", sceneID).
+			With("character_id", characterID).
+			Wrap(err)
+	}
+	return true, nil
+}
+
 // End transitions a scene to the `ended` state and returns the post-update
 // row. Only scenes currently in `active` or `paused` states can be ended;
 // the WHERE clause enforces this at the database level so concurrent

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -1681,3 +1681,100 @@ func TestOpsEventsCannotBeUpdatedOrDeletedByApplicationCode(t *testing.T) {
 			"%s contains DELETE on scene_ops_events — events must be immutable", fname)
 	}
 }
+
+func TestSceneStoreIsMemberReturnsExpectedByRoleAndSceneState(t *testing.T) {
+	const (
+		alice    = "char-alice"
+		bob      = "char-bob"
+		stranger = "char-stranger"
+	)
+
+	tests := []struct {
+		name     string
+		sceneID  string
+		visible  SceneVisibility
+		setup    func(t *testing.T, store *SceneStore, sceneID string)
+		probe    string
+		want     bool
+		wantMsg  string
+	}{
+		{
+			name:    "returns true for owner",
+			sceneID: "scene-isM-1",
+			visible: SceneVisibilityOpen,
+			setup:   nil,
+			probe:   alice,
+			want:    true,
+			wantMsg: "owner MUST be reported as member",
+		},
+		{
+			name:    "returns true for joined member",
+			sceneID: "scene-isM-2",
+			visible: SceneVisibilityOpen,
+			setup: func(t *testing.T, store *SceneStore, sceneID string) {
+				_, _, err := store.AddParticipant(context.Background(), sceneID, bob)
+				require.NoError(t, err)
+			},
+			probe: bob,
+			want:  true,
+		},
+		{
+			name:    "returns false for invited-only",
+			sceneID: "scene-isM-3",
+			visible: SceneVisibilityPrivate,
+			setup: func(t *testing.T, store *SceneStore, sceneID string) {
+				_, err := store.InviteParticipant(context.Background(), sceneID, alice, bob)
+				require.NoError(t, err)
+			},
+			probe:   bob,
+			want:    false,
+			wantMsg: "invited-only rows MUST return false — invitation grants join, not read",
+		},
+		{
+			name:    "returns false for non-participant",
+			sceneID: "scene-isM-4",
+			visible: SceneVisibilityOpen,
+			setup:   nil,
+			probe:   stranger,
+			want:    false,
+		},
+		{
+			name:    "returns false for missing scene",
+			sceneID: "scene-isM-missing",
+			visible: "", // sentinel: skip scene creation
+			setup:   nil,
+			probe:   alice,
+			want:    false,
+			wantMsg: "missing scene MUST be nil error per spec §5.4 (info-hiding)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t)
+			ctx := context.Background()
+
+			if tt.visible != "" {
+				row := &SceneRow{
+					ID: tt.sceneID, OwnerID: alice, Title: "T",
+					State:           string(SceneStateActive),
+					PoseOrder:       string(PoseOrderModeFree),
+					Visibility:      string(tt.visible),
+					ContentWarnings: []string{}, Tags: []string{},
+				}
+				require.NoError(t, store.CreateWithOwner(ctx, row))
+			}
+			if tt.setup != nil {
+				tt.setup(t, store, tt.sceneID)
+			}
+
+			got, err := store.IsMember(ctx, tt.sceneID, tt.probe)
+			require.NoError(t, err, tt.wantMsg)
+			if tt.wantMsg != "" {
+				assert.Equal(t, tt.want, got, tt.wantMsg)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/web/src/lib/connect/holomush/plugin/v1/audit_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/audit_pb.ts
@@ -9,7 +9,7 @@ import type { GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegen
 import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
 import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import { file_google_protobuf_timestamp } from "@bufbuild/protobuf/wkt";
-import type { Event } from "../../eventbus/v1/eventbus_pb";
+import type { Actor, Event } from "../../eventbus/v1/eventbus_pb";
 import { file_holomush_eventbus_v1_eventbus } from "../../eventbus/v1/eventbus_pb";
 import type { Message } from "@bufbuild/protobuf";
 
@@ -17,7 +17,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file holomush/plugin/v1/audit.proto.
  */
 export const file_holomush_plugin_v1_audit: GenFile = /*@__PURE__*/
-  fileDesc("Ch5ob2xvbXVzaC9wbHVnaW4vdjEvYXVkaXQucHJvdG8SEmhvbG9tdXNoLnBsdWdpbi52MSK0AQoRQXVkaXRFdmVudFJlcXVlc3QSKgoFZXZlbnQYASABKAsyGy5ob2xvbXVzaC5ldmVudGJ1cy52MS5FdmVudBJDCgdoZWFkZXJzGAIgAygLMjIuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXF1ZXN0LkhlYWRlcnNFbnRyeRouCgxIZWFkZXJzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASIUChJBdWRpdEV2ZW50UmVzcG9uc2UiygEKE1F1ZXJ5SGlzdG9yeVJlcXVlc3QSDwoHc3ViamVjdBgBIAEoCRINCgVhZnRlchgCIAEoDBIOCgZiZWZvcmUYAyABKAwSEQoJcGFnZV9zaXplGAQgASgFEhEKCWRpcmVjdGlvbhgFIAEoBRIuCgpub3RfYmVmb3JlGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBItCglub3RfYWZ0ZXIYByABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIkIKFFF1ZXJ5SGlzdG9yeVJlc3BvbnNlEioKBWV2ZW50GAEgASgLMhsuaG9sb211c2guZXZlbnRidXMudjEuRXZlbnQy1gEKElBsdWdpbkF1ZGl0U2VydmljZRJbCgpBdWRpdEV2ZW50EiUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXF1ZXN0GiYuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXNwb25zZRJjCgxRdWVyeUhpc3RvcnkSJy5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlIaXN0b3J5UmVxdWVzdBooLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUhpc3RvcnlSZXNwb25zZTABQkRaQmdpdGh1Yi5jb20vaG9sb211c2gvaG9sb211c2gvcGtnL3Byb3RvL2hvbG9tdXNoL3BsdWdpbi92MTtwbHVnaW52MWIGcHJvdG8z", [file_google_protobuf_timestamp, file_holomush_eventbus_v1_eventbus]);
+  fileDesc("Ch5ob2xvbXVzaC9wbHVnaW4vdjEvYXVkaXQucHJvdG8SEmhvbG9tdXNoLnBsdWdpbi52MSK0AQoRQXVkaXRFdmVudFJlcXVlc3QSKgoFZXZlbnQYASABKAsyGy5ob2xvbXVzaC5ldmVudGJ1cy52MS5FdmVudBJDCgdoZWFkZXJzGAIgAygLMjIuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXF1ZXN0LkhlYWRlcnNFbnRyeRouCgxIZWFkZXJzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASIUChJBdWRpdEV2ZW50UmVzcG9uc2Ui9wEKE1F1ZXJ5SGlzdG9yeVJlcXVlc3QSDwoHc3ViamVjdBgBIAEoCRINCgVhZnRlchgCIAEoDBIOCgZiZWZvcmUYAyABKAwSEQoJcGFnZV9zaXplGAQgASgFEhEKCWRpcmVjdGlvbhgFIAEoBRIuCgpub3RfYmVmb3JlGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBItCglub3RfYWZ0ZXIYByABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEisKBmNhbGxlchgIIAEoCzIbLmhvbG9tdXNoLmV2ZW50YnVzLnYxLkFjdG9yIkIKFFF1ZXJ5SGlzdG9yeVJlc3BvbnNlEioKBWV2ZW50GAEgASgLMhsuaG9sb211c2guZXZlbnRidXMudjEuRXZlbnQy1gEKElBsdWdpbkF1ZGl0U2VydmljZRJbCgpBdWRpdEV2ZW50EiUuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXF1ZXN0GiYuaG9sb211c2gucGx1Z2luLnYxLkF1ZGl0RXZlbnRSZXNwb25zZRJjCgxRdWVyeUhpc3RvcnkSJy5ob2xvbXVzaC5wbHVnaW4udjEuUXVlcnlIaXN0b3J5UmVxdWVzdBooLmhvbG9tdXNoLnBsdWdpbi52MS5RdWVyeUhpc3RvcnlSZXNwb25zZTABQkRaQmdpdGh1Yi5jb20vaG9sb211c2gvaG9sb211c2gvcGtnL3Byb3RvL2hvbG9tdXNoL3BsdWdpbi92MTtwbHVnaW52MWIGcHJvdG8z", [file_google_protobuf_timestamp, file_holomush_eventbus_v1_eventbus]);
 
 /**
  * @generated from message holomush.plugin.v1.AuditEventRequest
@@ -103,6 +103,18 @@ export type QueryHistoryRequest = Message<"holomush.plugin.v1.QueryHistoryReques
    * @generated from field: google.protobuf.Timestamp not_after = 7;
    */
   notAfter?: Timestamp | undefined;
+
+  /**
+   * caller identifies the principal on whose behalf the host is reading.
+   * Plugins implementing PluginAuditService MUST enforce domain-specific
+   * authz (e.g., membership) against this identity before returning rows.
+   * An absent caller, a zero identity, or an unsupported Actor.Kind MUST
+   * be rejected with gRPC PERMISSION_DENIED. The host populates this
+   * field from the authenticated session record; clients never supply it.
+   *
+   * @generated from field: holomush.eventbus.v1.Actor caller = 8;
+   */
+  caller?: Actor | undefined;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `Actor caller = 8` to `PluginAuditService.QueryHistory` proto and plumbs the field from the host session through `eventbus.HistoryQuery` → `PluginHistoryRouter` → plugin.
- Plugin enforces scene-membership authz (auth-first ordering, owner/member only, deliberate exclusion of `invited`) before any DB work.
- gRPC status codes from the plugin (`PermissionDenied`, `InvalidArgument`) round-trip through the router; `mapHistoryError` collapses plugin-boundary `PermissionDenied` into the same opaque `STREAM_ACCESS_DENIED` oops code the outer I-17 gate uses.
- Opacity invariant: client cannot distinguish outer-wall denials from plugin-wall denials (load-bearing test in `TestQueryStreamHistoryTranslatesPluginPermissionDeniedToOpaqueCode`).

## Spec
docs/superpowers/specs/2026-04-23-plugin-history-authz-design.md

## Test plan
- [x] `task test` — all unit packages green
- [x] `task test:int` — integration including 2 new authz cases
- [x] `task pr-prep` — full CI mirror green (lint, schema, license, unit, integration, E2E 61/61)

## Follow-ups
- `holomush-095g.7` (P2) — plugin-as-caller identity for `PluginHostService.QueryStreamHistory` against plugin-owned subjects (spec §4.4).
- `holomush-095g.6` (P3) — preserve session/stream log context across `mapHistoryError` (observability polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History queries now carry caller identity; plugins enforce scene-membership checks and actor identity helpers/client bindings updated.

* **Bug Fixes**
  * Plugin gRPC status codes are preserved across boundaries; PermissionDenied denials map to the intended opaque client-facing denial while InvalidArgument is propagated.

* **Tests**
  * Expanded unit/integration tests covering authz, membership, caller threading, pagination gating, and status-preservation.

* **Documentation**
  * New design, rollout plan, and multiple reviewer guidance/feedback rules and memory updates for history authz and error wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->