### PR TITLE
chore: session-workspace isolation + drop go.work

### DIFF
--- a/.claude/agent-memory/design-reviewer/MEMORY.md
+++ b/.claude/agent-memory/design-reviewer/MEMORY.md
@@ -9,7 +9,13 @@ Keep under 200 lines. Curate — don't hoard.
 ## Common spec weaknesses in this codebase
 
 - [oops vs gRPC code conflation](feedback_oops_vs_grpc_code_conflation.md) — HoloMUSH specs often call oops codes "gRPC codes"; flag wording, do not block if pattern matches existing codebase convention
+- **"Mirrors existing technique X" claims need verbatim verification.** When a spec says "use the same technique as `Y`", read both sides and diff them. Authors paraphrase or reconstruct from memory and produce structurally different (broken) variants. Seen 2026-04-25 in session-workspace-isolation: spec claimed to mirror `Taskfile.yaml:521-530` gowork's `.jj/repo` resolution, but the provided snippet computed a different path that failed when invoked from a worktree.
+- **Shell-snippet error handling in spec docs is rarely verified.** Patterns like `var=$(cmd | tail -n 1) || return` (bash) and `set var (cmd | tail -n 1); or return $status` (fish) do NOT detect failure of `cmd` — the pipeline status is the LAST command's status. Run the snippet before believing it. Seen 2026-04-25.
+- **Spec "verifiable by …" criteria with overly-broad jj revsets.** `jj log -r 'all()'` returns full history; for experiment-level verification prefer `mutable()` or scoped revsets. Not blocking but degrades the diagnostic value.
+- **Stated rationale for shell idioms can be wrong even when the idiom works.** A spec may correctly include a `cd` or `cd && cmd` block but provide an incorrect *reason* (e.g., "needed because X requires Y" where Y is false). This is documentation rot risk, not a correctness blocker. Verify rationale claims by running the inner command without the `cd` to see if it really fails. Seen 2026-04-25 in session-workspace-isolation r3: spec claimed `cd "$MAIN_REPO"` was needed for `jj git fetch`, but `jj git fetch` works from any workspace because it resolves repo storage via `.jj/repo`.
 
 ## Interfaces and boundaries that recur
 
-<!-- Populated by the agent over time. -->
+- **`.jj/repo` dir-vs-file**: in the main checkout (`default` workspace) it is a directory; in any other jj workspace it is a file containing a relative path back to the main repo. Anything that needs to know "am I in the default workspace" or "where is MAIN_REPO" should use this. Reference implementation lives at `Taskfile.yaml:521-530`.
+- **SessionStart hook output**: plain stdout is concatenated as additional context. `bd prime` is the canonical example. JSON `hookSpecificOutput.additionalContext` is the alternative but no in-tree hook uses it.
+- **`task` cannot mutate caller's shell `pwd`/env**: any spec that wants "after this task, your shell is in directory X" must be a shell function/wrapper, not a task target. Treat as a hard constraint when reviewing automation specs.

--- a/.claude/agent-memory/plan-reviewer/MEMORY.md
+++ b/.claude/agent-memory/plan-reviewer/MEMORY.md
@@ -11,10 +11,54 @@ Keep under 200 lines. Curate — don't hoard.
 - [Verify helper existence](feedback_verify_helper_existence.md) — plans frequently invent methods/helpers on existing types ("extend test file X" with calls that don't exist on X)
 - [No signature placeholders](feedback_no_signature_placeholders.md) — interface signatures and parameter lists must be inlined, never deferred via `/* COPY FROM existing.go */` comments
 - [Verify imports against code blocks](feedback_verify_imports_in_code_blocks.md) — every package qualifier (`slog.`, `timestamppb.`, `status.`) used in a plan's example code must appear in the file's existing imports OR in the plan's "imports needed" directive
+- **Missing `jj new` between phase-commit boundaries.** When a plan decomposes a PR into N
+  per-phase commits, every phase-end "commit task" MUST conclude with `jj new -m "phase
+  N+1 (in progress)"` so the next phase's edits land in a fresh `@`. Plans that end the
+  phase task with bare `jj describe` cause subsequent file edits to fold into the named
+  phase commit; a later "describe" then clobbers the earlier description. Always grep
+  the plan for `jj describe` not followed by `jj new` at task boundaries.
+- **`@-` vs `@` bookmark targets.** When a plan creates a push bookmark, verify which
+  commit `@-` actually points to by tracing the commit/new sequence forward from the
+  last `jj new`. Plans that say "@- is the Phase N commit, since @ is currently empty
+  after the commit-then-new pattern" must actually contain that `jj new` somewhere —
+  authors sometimes assume the pattern without writing the step.
+- **False-starts left in executable text.** Watch for "Wait — that command is wrong, use
+  this instead:" patterns inside step bodies. Subagents skim and may run the first
+  block they see. Flag any plan that emits two contradictory commands in the same step.
+- **Long-running steps without a budget annotation.** `task pr-prep` runs 5–15 min; a
+  per-task subagent dispatch with default timeout will starve. Plans should annotate
+  long-running verifications and recommend `run_in_background` + Monitor.
+- **"Manual-ish" steps in subagent-driven plans.** Multi-terminal manual checks cannot
+  be executed by an automated agent. Either script them inline or label them
+  `(MANUAL — pre-merge only)`.
+- **Stale prose around revised code blocks.** When a previous review forces the author to
+  simplify a code block, the surrounding "Notes" / explanation prose often gets left
+  describing the OLD construct. On revision passes, diff the prose against the current
+  code, not just the code-against-itself. (Round-2 example: Task 7 step 2's source line
+  was simplified from a two-fallback construct to one line, but the post-code Notes
+  block still described "two fallbacks because...".)
+- **Cross-task instruction drift after partial-mirror fixes.** When ONE task adopts a
+  pattern (e.g., `describe + jj new`) and a later task deliberately does NOT adopt it
+  (last-phase exception), prose like "Mirror this pattern at Tasks N, M, K" must
+  enumerate exceptions explicitly. Round-2 example: Task 6 step 4 said "Mirror at Tasks
+  9, 13, and 16" but Task 16 step 3 explicitly forbids the mirror. Subagent execution
+  per-task hides this contradiction; an inline-execution agent might propagate the
+  wrong pattern to Task 16.
 
 ## Decomposition patterns that work here
 
-<!-- Populated by the agent over time. -->
+- **Per-phase commit pattern that DOES work**: Task N edits files; Task N+1 step 1 runs
+  `jj describe -m "phase N: ..."` then step 2 runs `jj new -m "phase N+1 (in progress)"`.
+  Plan 2026-04-25-session-workspace-isolation.md gets this RIGHT for Phase 3→4 (Task 13)
+  but WRONG for Phase 1→2 (Task 6 missing the `jj new`).
+- **Helper extraction for shell-script reuse**: when two consumers (Taskfile cmd + hook)
+  need the same path-discovery logic, ship one `scripts/<helper>.sh` sourced by both.
+  Spec called this out as an "Implementation note"; plan implemented it. Pattern works
+  cleanly in the HoloMUSH layout.
+- **Repo-reality verification of cited line numbers**: plans that cite `file:line-line`
+  ranges should be grep-verified before review approval. The 2026-04-25 plan cited
+  `Taskfile.yaml:515-551`, `CLAUDE.md` 552/570/849 — all four matched current
+  main@origin (`642c93e39baf`). When citations are accurate, reviewers can move fast.
 
 ## Review reflexes
 

--- a/.claude/hooks/warn-default-workspace.sh
+++ b/.claude/hooks/warn-default-workspace.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# SessionStart hook: warns the assistant when the Claude Code session is
+# operating in the shared `default` jj workspace. Stays silent when the
+# session is in any other workspace.
+#
+# Output contract: emit warning text to plain stdout (the Claude Code
+# SessionStart hook concatenates stdout into the session's additional
+# context). Stay silent (exit 0, no output) when no warning is needed.
+
+set -euo pipefail
+
+# Consume the JSON event from stdin (we don't need any field; just being
+# polite to the hook contract).
+cat >/dev/null
+
+# Source the shared MAIN_REPO/IS_DEFAULT helper. The hook script's cwd is
+# the Claude session's launching cwd, so .jj/repo resolution from . is
+# the right starting point.
+ws_root="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$ws_root" ] || [ ! -e "$ws_root/scripts/jj-main-repo.sh" ]; then
+  # Not in a jj repo, or helper missing — silently exit. The hook is
+  # purely informational; never block session start.
+  exit 0
+fi
+
+# shellcheck source=../../scripts/jj-main-repo.sh
+( cd "$ws_root" && . "$ws_root/scripts/jj-main-repo.sh" >/dev/null 2>&1 ) || exit 0
+
+# Re-source in current shell to populate IS_DEFAULT (the subshell above
+# only validated the script doesn't error; we need the var here).
+cd "$ws_root"
+# shellcheck source=../../scripts/jj-main-repo.sh
+. "$ws_root/scripts/jj-main-repo.sh"
+
+if [ "${IS_DEFAULT:-no}" != "yes" ]; then
+  exit 0
+fi
+
+cat <<'EOF'
+**You are in the shared `default` jj workspace.** If you intend to edit files, another Claude Code session in the same workspace can collide with your edits at any `jj` command boundary (jj snapshots the working copy on every command). To isolate this session, exit and:
+
+- **Humans:** run `claude-iso <name>` (the shell function in `~/.config/fish/config.fish` or `~/.bashrc` — see CLAUDE.md "Session isolation" for the snippet)
+- **Agents (or humans without the function):** run `task workspace:new -- <name>`, then `cd <printed-path> && claude`
+
+To ignore this warning, continue as normal.
+EOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,15 @@
           }
         ],
         "matcher": ""
+      },
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/warn-default-workspace.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "UserPromptSubmit": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,7 +574,7 @@ jj workspace will collide on uncommitted edits. To prevent this:
 |---|---|
 | **MUST** isolate per session | Start each Claude session in its own jj workspace. Humans: `claude-iso <name>` (shell function below). Agents: `task workspace:new -- <name>`, then `cd <printed-path> && claude` |
 | **SHOULD NOT** edit files in `default` | The `default` workspace is reserved for read-only inspection and one-off throwaway work. A `SessionStart` hook warns when a session begins there |
-| **MUST** clean up post-merge | After your branch lands, `jj workspace forget <name> && rm -rf ../.worktrees/<name>` from any workspace. (See "Landing the Plane.") |
+| **MUST** clean up post-merge | After your branch lands: `cd <repo-root> && jj workspace forget <name> && rm -rf <repo-parent>/.worktrees/<name>`. The leading `cd` matters — `../.worktrees/<name>` is unsafe from any nested cwd. See "Landing the Plane" for the full sequence. |
 
 **`claude-iso` shell function** — copy into your shell's rc file:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,17 +555,14 @@ Workspaces live in a `.worktrees/` directory that is a sibling of the main repo 
 (e.g., `<parent>/.worktrees/<name>`). The exact path is machine-specific.
 
 ```bash
-jj workspace add <parent>/.worktrees/<name> --name <name> -r main
+jj workspace add <parent>/.worktrees/<name> --name <name> -r main@origin
 jj workspace forget <name>  # then: rm -rf <parent>/.worktrees/<name>
-task gowork                 # MUST run after add or forget — regenerates go.work
 ```
 
-| Requirement | Description |
-| ----------- | ----------- |
-| **MUST** run `task gowork` | After every `jj workspace add` or `jj workspace forget` |
-
-`task gowork` regenerates `go.work` in the main repo root so gopls covers all active
-workspaces without "not in workspace" LSP diagnostics. Works from any workspace.
+For the typical case of "start a new isolated Claude session," prefer the
+`task workspace:new -- <name>` wrapper (see "Session isolation" below) which
+handles `.jj/repo`-based path resolution from any cwd, runs `jj git fetch`
+first so `main@origin` is fresh, and is idempotent on re-invocation.
 
 ### Beads Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,63 @@ For the typical case of "start a new isolated Claude session," prefer the
 handles `.jj/repo`-based path resolution from any cwd, runs `jj git fetch`
 first so `main@origin` is fresh, and is idempotent on re-invocation.
 
+### Session isolation
+
+This repo is developed primarily by concurrent AI agent sessions. Because jj
+snapshots the working copy on every command, two sessions sharing the same
+jj workspace will collide on uncommitted edits. To prevent this:
+
+| Requirement | Description |
+|---|---|
+| **MUST** isolate per session | Start each Claude session in its own jj workspace. Humans: `claude-iso <name>` (shell function below). Agents: `task workspace:new -- <name>`, then `cd <printed-path> && claude` |
+| **SHOULD NOT** edit files in `default` | The `default` workspace is reserved for read-only inspection and one-off throwaway work. A `SessionStart` hook warns when a session begins there |
+| **MUST** clean up post-merge | After your branch lands, `jj workspace forget <name> && rm -rf ../.worktrees/<name>` from any workspace. (See "Landing the Plane.") |
+
+**`claude-iso` shell function** — copy into your shell's rc file:
+
+```fish
+# fish: ~/.config/fish/config.fish
+#
+# IMPORTANT: `set var (cmd | tail -n 1); or ...` does NOT propagate the
+# failure of `cmd` because the pipeline's exit status is `tail`'s, not
+# `cmd`'s. We therefore call `task workspace:new` twice — first to check
+# the exit status, then again inside command substitution to capture the
+# path. The second call is idempotent (Phase 2 DoD requirement) and just
+# prints the path for an existing workspace.
+function claude-iso
+    set name $argv[1]
+    task workspace:new -- $name >/dev/null
+    or return $status
+    set ws (task workspace:new -- $name | tail -n 1)
+    cd $ws
+    or return $status
+    exec claude
+end
+```
+
+```bash
+# bash/zsh: ~/.bashrc or ~/.zshrc
+#
+# Same caveat as fish: $(cmd | tail -n 1) carries tail's exit status, not
+# cmd's. Two-call pattern; second call is idempotent.
+claude-iso() {
+  local name="$1"
+  task workspace:new -- "$name" >/dev/null || return $?
+  local ws
+  ws="$(task workspace:new -- "$name" | tail -n 1)"
+  cd "$ws" || return $?
+  exec claude
+}
+```
+
+New worktrees inherit `.claude/` (tracked in git), so `SessionStart`,
+`UserPromptSubmit`, and other Claude Code hooks fire identically in any
+worktree — no hook re-wiring is needed when creating a workspace.
+
+Sub-agents launched via the `Task` tool inherit the parent's workspace. The
+parent is responsible for not dispatching parallel `Task` calls that would
+edit the same files. (Future work MAY add per-`Task` workspace creation.)
+
 ### Beads Commands
 
 ```bash
@@ -843,7 +900,14 @@ runes patterns.
    git status  # MUST show "up to date with origin"
    ```
 
-5. **Clean up** - Clear stashes, prune remote branches, `jj workspace forget` unused workspaces
+5. **Clean up** — clear stashes, prune remote branches, and (if this work was done in a dedicated workspace per the "Session isolation" discipline) forget and remove the workspace:
+
+   ```bash
+   cd <repo-root>                           # exit the workspace before forgetting it
+   jj workspace forget <name>
+   rm -rf <repo-parent>/.worktrees/<name>
+   ```
+
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -512,44 +512,6 @@ tasks:
       - go mod download
       - go mod tidy
 
-  gowork:
-    desc: Regenerate go.work to cover the main repo and all active jj workspaces (run after jj workspace add/forget)
-    cmds:
-      - |
-        set -euo pipefail
-
-        # In a jj workspace, .jj/repo is a FILE pointing (relatively) to the
-        # shared repo directory inside the main checkout. In the main checkout
-        # itself, .jj/repo is a DIRECTORY. Use that to find the main repo root
-        # regardless of which workspace this task is invoked from.
-        if [ -f ".jj/repo" ]; then
-          POINTER=$(cat ".jj/repo")
-          MAIN_REPO=$(cd ".jj/${POINTER}/../.." && pwd -P)
-        else
-          MAIN_REPO=$(pwd -P)
-        fi
-
-        # Read Go version from go.mod so go.work stays aligned with CI regardless
-        # of which patch version a developer has installed locally.
-        GO_VER=$(awk '/^go[[:space:]]+/ {print $2; exit}' "$MAIN_REPO/go.mod")
-        [ -n "$GO_VER" ] || { echo "ERROR: failed to parse go version from $MAIN_REPO/go.mod"; exit 1; }
-
-        WORKTREES="$(dirname "$MAIN_REPO")/.worktrees"
-
-        {
-          echo "go $GO_VER"
-          echo ""
-          echo "use ."
-          if [ -d "$WORKTREES" ]; then
-            for dir in "$WORKTREES"/*/; do
-              [ -f "${dir}go.mod" ] && echo "use ${dir%/}"
-            done
-          fi
-        } > "$MAIN_REPO/go.work"
-
-        COUNT=$(grep -c '^use' "$MAIN_REPO/go.work")
-        echo "✓ go.work written to $MAIN_REPO with $COUNT module(s)"
-
   # ──────────────────────────────────────────
   # Database migrations
   # ──────────────────────────────────────────

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -524,11 +524,20 @@ tasks:
       - |
         set -euo pipefail
         WS_ROOT="$(jj workspace root)"   # fail-fast if not in a jj repo
+        # The helper resolves .jj/repo from cwd, so we must cd to WS_ROOT first
+        # before sourcing — otherwise the task fails when invoked from any
+        # subdirectory of the workspace (e.g., from internal/, scripts/, etc).
+        cd "$WS_ROOT"
         # shellcheck source=scripts/jj-main-repo.sh
         . "$WS_ROOT/scripts/jj-main-repo.sh"
 
         NAME="{{.CLI_ARGS}}"
         [ -n "$NAME" ] || { echo "ERROR: usage: task workspace:new -- <name>" >&2; exit 1; }
+        # Validate name: single token, no path separators or relative parts,
+        # so $NAME can't escape $WORKTREES via "../foo" or "/abs/foo".
+        case "$NAME" in
+          *[!A-Za-z0-9._-]*|.|..|*..*|*/*) echo "ERROR: name must match [A-Za-z0-9._-]+ (no slashes, no '..')" >&2; exit 1 ;;
+        esac
 
         TARGET="$WORKTREES/$NAME"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -512,6 +512,37 @@ tasks:
       - go mod download
       - go mod tidy
 
+  workspace:new:
+    desc: |
+      Create a fresh jj workspace at <repo-parent>/.worktrees/<name>, fetching
+      main@origin first so it's current. Idempotent: if the workspace already
+      exists, prints its absolute path and exits 0. Works from any cwd inside
+      the repo or any worktree.
+
+      Usage: task workspace:new -- <name>
+    cmds:
+      - |
+        set -euo pipefail
+        WS_ROOT="$(jj workspace root)"   # fail-fast if not in a jj repo
+        # shellcheck source=scripts/jj-main-repo.sh
+        . "$WS_ROOT/scripts/jj-main-repo.sh"
+
+        NAME="{{.CLI_ARGS}}"
+        [ -n "$NAME" ] || { echo "ERROR: usage: task workspace:new -- <name>" >&2; exit 1; }
+
+        TARGET="$WORKTREES/$NAME"
+
+        # Idempotent pre-check
+        if [ -d "$TARGET" ]; then
+          echo "$TARGET"
+          exit 0
+        fi
+
+        # Fresh workspace path
+        jj git fetch >&2
+        jj workspace add "$TARGET" --name "$NAME" -r main@origin >&2
+        echo "$TARGET"
+
   # ──────────────────────────────────────────
   # Database migrations
   # ──────────────────────────────────────────

--- a/docs/superpowers/plans/2026-04-25-session-workspace-isolation.md
+++ b/docs/superpowers/plans/2026-04-25-session-workspace-isolation.md
@@ -1,0 +1,1466 @@
+# Session Workspace Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tear down `go.work` + `task gowork`, ship `task workspace:new`, add a `SessionStart` hook that warns when starting in the shared `default` jj workspace, and document the new per-session-isolation discipline in CLAUDE.md.
+
+**Architecture:** Soft enforcement — no harness coupling beyond what already exists. A new `scripts/jj-main-repo.sh` shell helper centralises the `.jj/repo` dir-vs-file detection used by both the new task target and the new hook. Phases ordered to land Phase 1 first so subsequent phases don't have to fight `go.work` duplicates.
+
+**Tech Stack:** bash 3.2 (macOS default), fish 3.x (maintainer's interactive shell), `task` (go-task) for Taskfile targets, jj 0.40+, Claude Code hook contract (plain stdout for SessionStart).
+
+**Spec:** [`docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md`](../specs/2026-04-25-session-workspace-isolation-design.md)
+
+**Tracking bead:** _filed in Task 0_
+
+---
+
+## File map
+
+| File | Op | Purpose |
+|---|---|---|
+| `go.work` | Delete | Repo no longer ships a workspace file |
+| `.gitignore` | Modify | Add `/go.work` and `/go.work.sum` so locally-generated copies stay local |
+| `Taskfile.yaml` | Modify | Delete `gowork` target (lines 515-551); add `workspace:new` target |
+| `CLAUDE.md` | Modify | Drop `task gowork` references in "jj Workspace Commands" (lines 552-568); insert new "Session isolation" subsection between "jj Workspace Commands" and "Beads Commands"; expand "Landing the Plane" step 5 (line 849) |
+| `scripts/jj-main-repo.sh` | Create | Sourceable shell helper — sets `IS_DEFAULT`, `MAIN_REPO`, `WORKTREES` |
+| `.claude/hooks/warn-default-workspace.sh` | Create | SessionStart hook; sources `scripts/jj-main-repo.sh`; emits warning when `IS_DEFAULT=yes` |
+| `.claude/settings.json` | Modify | Wire the new hook into `hooks.SessionStart` alongside existing `bd prime` |
+
+Phases 1-4 each become an independent commit on the same PR branch (per spec implementation-order section, "Each phase is a separate commit on the same PR branch").
+
+---
+
+## Task 0: File tracking bead
+
+**Files:** _none_ (beads command only)
+
+- [ ] **Step 1: Create the bead**
+
+Run from any workspace:
+
+```bash
+bd create --title "Session workspace isolation + go.work removal" \
+  --description "$(cat <<'EOF'
+Implement docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md.
+
+Four phases:
+1. Delete go.work + task gowork; resolves holomush-rmo2 as side effect
+2. Add task workspace:new with .jj/repo MAIN_REPO discovery
+3. Add .claude/hooks/warn-default-workspace.sh SessionStart hook
+4. Document in CLAUDE.md (new "Session isolation" subsection + Landing the Plane step 5 expansion)
+
+Plan: docs/superpowers/plans/2026-04-25-session-workspace-isolation.md
+EOF
+)" \
+  --type task --priority 2
+```
+
+Expected output: `✓ Created issue: holomush-XXXX — Session workspace isolation + go.work removal`
+
+- [ ] **Step 2: Record bead ID for later steps**
+
+Note the `holomush-XXXX` ID emitted in step 1. Subsequent commits and the PR body MUST reference this bead.
+
+- [ ] **Step 3: Add dependency on `holomush-rmo2`**
+
+Run:
+
+```bash
+bd dep add <new-bead-id> holomush-rmo2
+```
+
+Expected: dependency recorded; `bd show <new-bead-id>` shows `holomush-rmo2` in the "blocks" or "depends-on" relationship (Phase 1 closes `holomush-rmo2`, so this is a "fixes" relationship — exact wording depends on `bd dep` semantics; if `bd dep add` rejects, skip and just reference both beads in the commit message).
+
+---
+
+## Task 1: Create `scripts/jj-main-repo.sh` shared helper
+
+**Files:**
+- Create: `scripts/jj-main-repo.sh`
+- Test: smoke-test inline (no formal test file; this is a 12-line shell script)
+
+**Why this task exists:** the spec (Phase 2 implementation note) recommends extracting `MAIN_REPO` discovery into a shared helper to avoid drift between Phase 2 (the task) and Phase 3 (the hook). Both consumers need the `.jj/repo` dir-vs-file distinction.
+
+- [ ] **Step 1: Create the helper script**
+
+Create `scripts/jj-main-repo.sh` with this exact content:
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Sourceable helper. Sets the following variables based on cwd:
+#   IS_DEFAULT — "yes" if cwd is the main repo (default jj workspace), else "no"
+#   MAIN_REPO  — absolute path to the main repo root
+#   WORKTREES  — absolute path to the .worktrees parent dir
+#
+# Usage (from a Taskfile cmd or a hook script):
+#   . "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/scripts/jj-main-repo.sh"
+#
+# In a jj workspace, .jj/repo is a FILE containing a path (relative to .jj/)
+# back to the main checkout's .jj. In the main checkout itself, .jj/repo is
+# a DIRECTORY. Verbatim of the technique used by the soon-to-be-deleted
+# `gowork` task (Taskfile.yaml:525-530 prior to its removal).
+
+if [ -f ".jj/repo" ]; then
+  IS_DEFAULT=no
+  POINTER=$(cat ".jj/repo")
+  MAIN_REPO=$(cd ".jj/${POINTER}/../.." && pwd -P)
+elif [ -d ".jj/repo" ]; then
+  IS_DEFAULT=yes
+  MAIN_REPO=$(pwd -P)
+else
+  echo "ERROR: $(pwd) is not a jj repo or workspace (no .jj/repo)" >&2
+  return 1 2>/dev/null || exit 1
+fi
+WORKTREES="$(dirname "$MAIN_REPO")/.worktrees"
+```
+
+- [ ] **Step 2: Make it executable (so it can also be invoked standalone for testing)**
+
+Run:
+
+```bash
+chmod +x scripts/jj-main-repo.sh
+```
+
+- [ ] **Step 3: Smoke-test from the main checkout**
+
+Run from the main repo root (`/Volumes/Code/github.com/holomush/holomush` on the maintainer's machine):
+
+```bash
+( . scripts/jj-main-repo.sh && echo "IS_DEFAULT=$IS_DEFAULT MAIN_REPO=$MAIN_REPO WORKTREES=$WORKTREES" )
+```
+
+Expected output (paths machine-specific):
+
+```
+IS_DEFAULT=yes MAIN_REPO=/Volumes/Code/github.com/holomush/holomush WORKTREES=/Volumes/Code/github.com/holomush/.worktrees
+```
+
+- [ ] **Step 4: Smoke-test from a worktree**
+
+Run from any existing worktree (e.g., `/Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec/`):
+
+```bash
+( cd /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec && . scripts/jj-main-repo.sh && echo "IS_DEFAULT=$IS_DEFAULT MAIN_REPO=$MAIN_REPO WORKTREES=$WORKTREES" )
+```
+
+Expected output:
+
+```
+IS_DEFAULT=no MAIN_REPO=/Volumes/Code/github.com/holomush/holomush WORKTREES=/Volumes/Code/github.com/holomush/.worktrees
+```
+
+`MAIN_REPO` MUST resolve to the main checkout regardless of which workspace the helper is sourced from. If it resolves to the worktree itself, the helper is broken — go back and re-check the `cd ".jj/${POINTER}/../.."` line.
+
+- [ ] **Step 5: shellcheck the script**
+
+Run:
+
+```bash
+shellcheck scripts/jj-main-repo.sh
+```
+
+Expected: no output (clean). If shellcheck flags anything, fix it before proceeding.
+
+- [ ] **Step 6: Commit (do not push yet)**
+
+This helper is consumed by Phase 2 and Phase 3 — commit it as part of the Phase 1 commit so it lands first. **Defer the commit to Task 6** (combined Phase 1 commit). Do not commit independently.
+
+---
+
+## Task 2: Phase 1.1 — Delete `go.work` and update `.gitignore`
+
+**Files:**
+- Delete: `go.work`
+- Modify: `.gitignore` (add `/go.work` and `/go.work.sum`)
+
+- [ ] **Step 1: Verify `go.work` exists at repo root**
+
+Run from repo root:
+
+```bash
+ls -la go.work
+```
+
+Expected: file shown with last-modified timestamp matching whoever last ran `task gowork`.
+
+- [ ] **Step 2: Read current `.gitignore` to find a sensible insertion point**
+
+Run:
+
+```bash
+head -20 .gitignore
+```
+
+Note the order of existing entries. The new entries should go near other generated/tooling-output entries (typically near the top, but follow the existing grouping).
+
+- [ ] **Step 3: Append `go.work` patterns to `.gitignore`**
+
+Edit `.gitignore`. Add (preserve any existing trailing newline):
+
+```
+# Go workspace mode is not used by this repo (single-module). If a
+# contributor regenerates go.work locally for IDE coverage, keep it local.
+/go.work
+/go.work.sum
+```
+
+Choose insertion point: alongside other Go-tooling outputs if such a section exists; otherwise add at the end of the file.
+
+- [ ] **Step 4: Delete `go.work`**
+
+Run:
+
+```bash
+rm go.work
+```
+
+- [ ] **Step 5: Verify `go.work` is gone and `.gitignore` is updated**
+
+Run:
+
+```bash
+ls go.work 2>&1 | head -1
+grep -n 'go\.work' .gitignore
+```
+
+Expected:
+
+```
+ls: go.work: No such file or directory
+<line>:/go.work
+<line>:/go.work.sum
+```
+
+- [ ] **Step 6: Commit**
+
+Defer to Task 6 (combined Phase 1 commit).
+
+---
+
+## Task 3: Phase 1.2 — Delete `gowork` task from `Taskfile.yaml`
+
+**Files:**
+- Modify: `Taskfile.yaml` (delete lines 515-551, the entire `gowork:` target)
+
+- [ ] **Step 1: Verify the exact range of the `gowork` task**
+
+Run:
+
+```bash
+sed -n '515,551p' Taskfile.yaml | head -5
+sed -n '551,555p' Taskfile.yaml
+```
+
+Expected: line 515 starts `  gowork:`, line 551 ends with the `echo` summary, line 552 is blank, line 553 is the next task's section comment (`# ──────────────────────────────────────────`).
+
+If your local `Taskfile.yaml` has shifted line numbers (a parallel session may have edited it), find the actual range using:
+
+```bash
+grep -n '^  gowork:' Taskfile.yaml
+grep -n '^  # Database migrations' Taskfile.yaml
+```
+
+The `gowork` block is everything from `  gowork:` through the line BEFORE the next top-level `  # ──────────` comment block. Adjust the sed range accordingly.
+
+- [ ] **Step 2: Delete the `gowork` task**
+
+Use Edit to remove the exact block. The `old_string` should be the full `gowork:` block including its trailing blank line; `new_string` should be empty (so the section comment follows the previous task with one blank line).
+
+Verify your Edit by previewing the diff before applying.
+
+- [ ] **Step 3: Verify deletion**
+
+Run:
+
+```bash
+grep -n 'gowork' Taskfile.yaml
+```
+
+Expected: no output (or only output is in unrelated lines such as comments — verify each).
+
+- [ ] **Step 4: Verify Taskfile YAML is still valid**
+
+Run:
+
+```bash
+task --list 2>&1 | head -20
+```
+
+Expected: list of tasks (no YAML parse error). `gowork` MUST NOT appear in the list.
+
+- [ ] **Step 5: Commit**
+
+Defer to Task 6.
+
+---
+
+## Task 4: Phase 1.3 — Update CLAUDE.md "jj Workspace Commands"
+
+**Files:**
+- Modify: `CLAUDE.md` (lines 552-568 — drop `task gowork` references)
+
+- [ ] **Step 1: Read the current section**
+
+Already mapped above. The exact lines to replace are 557-568 (the code block + the requirement table + the explanatory paragraph).
+
+- [ ] **Step 2: Edit the section**
+
+Replace the existing "jj Workspace Commands" section body (everything from line 554 after the heading through line 568) with this new content:
+
+```markdown
+Workspaces live in a `.worktrees/` directory that is a sibling of the main repo root
+(e.g., `<parent>/.worktrees/<name>`). The exact path is machine-specific.
+
+```bash
+jj workspace add <parent>/.worktrees/<name> --name <name> -r main@origin
+jj workspace forget <name>  # then: rm -rf <parent>/.worktrees/<name>
+```
+
+For the typical case of "start a new isolated Claude session," prefer the
+`task workspace:new -- <name>` wrapper (see "Session isolation" below) which
+handles `.jj/repo`-based path resolution from any cwd, runs `jj git fetch`
+first so `main@origin` is fresh, and is idempotent on re-invocation.
+```
+
+(Note: the original `task gowork` line, the MUST-run-task-gowork requirement table, and the gopls-coverage paragraph are all removed. The `--name <name>` arg is preserved from the original since it's a useful jj convention.)
+
+- [ ] **Step 3: Verify the section reads cleanly**
+
+Run:
+
+```bash
+sed -n '550,575p' CLAUDE.md
+```
+
+Expected: the heading, the new paragraph, the new code block, and the new "Session isolation" forward-reference. No mention of `gowork` or `go.work`. Followed by the existing `### Beads Commands` heading.
+
+- [ ] **Step 4: Commit**
+
+Defer to Task 6.
+
+---
+
+## Task 5: Phase 1.4 — Verify Phase 1 (no `GOWORK=off` workaround needed)
+
+**Files:** _none_ (verification only)
+
+- [ ] **Step 1: Confirm `go.work` is gone, gowork task is gone, CLAUDE.md is updated**
+
+Run:
+
+```bash
+ls go.work 2>&1 | head -1
+grep -c 'gowork' Taskfile.yaml CLAUDE.md
+```
+
+Expected:
+
+```
+ls: go.work: No such file or directory
+Taskfile.yaml:0
+CLAUDE.md:0
+```
+
+- [ ] **Step 2: Run `task pr-prep` WITHOUT `GOWORK=off`**
+
+Run from the repo root:
+
+```bash
+task pr-prep 2>&1 | tail -5
+```
+
+This is the critical Phase 1 acceptance check. The whole point of Phase 1 is that `task pr-prep` should now pass without the `GOWORK=off` env hack. Expected last lines:
+
+```
+✓ All PR checks passed.
+```
+
+(Or equivalent success indicator — current Taskfile prints `✓ All PR checks passed.`)
+
+If the run fails with `module appears multiple times in workspace` or any other go-workspace error, Phase 1 is incomplete — `go.work` is still being generated by something. Investigate (likely a leftover `task gowork` invocation by a hook or CI step).
+
+This run will take 5-15 minutes (full schema + lint + unit + integration + E2E). Run in background via the task runner if available.
+
+- [ ] **Step 3: Commit**
+
+Defer to Task 6.
+
+---
+
+## Task 6: Phase 1.5 — Combined Phase 1 commit
+
+**Files:** _none_ (commit only)
+
+- [ ] **Step 1: Verify all Phase 1 changes are present**
+
+Run:
+
+```bash
+jj --no-pager st
+```
+
+Expected:
+
+```
+Working copy changes:
+M .gitignore
+M CLAUDE.md
+M Taskfile.yaml
+A scripts/jj-main-repo.sh
+D go.work
+```
+
+(The spec file in `docs/superpowers/specs/` and the plan file in `docs/superpowers/plans/` may also be present — they predate Phase 1 work. They MUST stay in this commit since this is the spec-and-plan-implementation PR; verify they're the right versions before continuing.)
+
+- [ ] **Step 2: Describe the commit**
+
+Run:
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "phase 1: tear down go.work and task gowork
+
+- Delete go.work (single-module repo doesn't need workspace mode)
+- Delete task gowork from Taskfile.yaml
+- Add /go.work and /go.work.sum to .gitignore
+- Drop 'MUST run task gowork' from CLAUDE.md jj Workspace Commands
+- Add scripts/jj-main-repo.sh shared helper for Phase 2/3 reuse
+
+Resolves holomush-rmo2 as a side effect: with no multi-worktree go.work,
+Go workspace mode no longer rejects multiple worktrees of the same module.
+
+Refs: <bead-id-from-task-0>, holomush-rmo2
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Replace `<bead-id-from-task-0>` with the actual ID from Task 0 step 1.
+
+- [ ] **Step 3: Verify commit**
+
+Run:
+
+```bash
+jj --no-pager log -r @ --no-graph
+jj --no-pager diff --stat
+```
+
+Expected: commit description matches; diff stat shows the 5 files (modify/add/delete).
+
+---
+
+## Task 7: Phase 2.1 — Add `task workspace:new` to `Taskfile.yaml`
+
+**Files:**
+- Modify: `Taskfile.yaml` (add new `workspace:new` task after the `mod` task / where `gowork` used to live)
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run:
+
+```bash
+grep -n '^  mod:' Taskfile.yaml
+grep -n '^  # ──' Taskfile.yaml | head -10
+```
+
+Insert the new task right where `gowork` used to live — between the `mod:` task and the `# Database migrations` (or whatever the next section comment is).
+
+- [ ] **Step 2: Add the `workspace:new` task**
+
+Edit `Taskfile.yaml`. Insert this block at the location identified in Step 1:
+
+```yaml
+  workspace:new:
+    desc: |
+      Create a fresh jj workspace at <repo-parent>/.worktrees/<name>, fetching
+      main@origin first so it's current. Idempotent: if the workspace already
+      exists, prints its absolute path and exits 0. Works from any cwd inside
+      the repo or any worktree.
+
+      Usage: task workspace:new -- <name>
+    cmds:
+      - |
+        set -euo pipefail
+        # shellcheck source=scripts/jj-main-repo.sh
+        . "$(jj workspace root 2>/dev/null || pwd)/scripts/jj-main-repo.sh" 2>/dev/null \
+          || . "$(jj workspace root)/scripts/jj-main-repo.sh"
+
+        NAME="${CLI_ARGS:-}"
+        [ -n "$NAME" ] || { echo "ERROR: usage: task workspace:new -- <name>" >&2; exit 1; }
+
+        TARGET="$WORKTREES/$NAME"
+
+        # Idempotent pre-check
+        if [ -d "$TARGET" ]; then
+          echo "$TARGET"
+          exit 0
+        fi
+
+        # Fresh workspace path
+        jj git fetch >&2
+        jj workspace add "$TARGET" --name "$NAME" -r main@origin >&2
+        echo "$TARGET"
+```
+
+(Notes on the structure:
+- `set -euo pipefail` — fail loudly on errors, undefined vars, pipe failures.
+- The `. ...jj-main-repo.sh` line uses two fallbacks because the script's path is determined by the workspace root, not cwd. The first attempt uses `jj workspace root`; if that fails (somehow), fall back to a direct invocation that lets shell error-out cleanly.
+- `CLI_ARGS` is the Taskfile convention for `--`-separated args (per CLAUDE.md "Test commands accept arguments after `--`").
+- All progress output (`jj git fetch`, `jj workspace add`) goes to stderr so `tail -n 1` of stdout reliably gets the path.
+- The final `echo "$TARGET"` is the contracted "absolute path on last line of stdout" (Phase 2 DoD).)
+
+- [ ] **Step 3: Verify YAML and task discovery**
+
+Run:
+
+```bash
+task --list 2>&1 | grep workspace
+```
+
+Expected: `* workspace:new:` appears with the description text.
+
+- [ ] **Step 4: Commit**
+
+Defer to Task 9.
+
+---
+
+## Task 8: Phase 2.2 — Test `task workspace:new` from repo root and from worktree
+
+**Files:** _none_ (verification only)
+
+- [ ] **Step 1: Test from the main checkout**
+
+Run from `/Volumes/Code/github.com/holomush/holomush`:
+
+```bash
+PATH_OUT=$(task workspace:new -- ws-test-root | tail -n 1)
+echo "Got: $PATH_OUT"
+test "$PATH_OUT" = "/Volumes/Code/github.com/holomush/.worktrees/ws-test-root" \
+  && echo "PASS" || echo "FAIL"
+ls -la /Volumes/Code/github.com/holomush/.worktrees/ws-test-root/.jj/repo
+```
+
+Expected:
+
+```
+Got: /Volumes/Code/github.com/holomush/.worktrees/ws-test-root
+PASS
+<path to file pointer> (regular file, ~26 bytes)
+```
+
+- [ ] **Step 2: Test idempotence (re-run with same name)**
+
+Run again immediately:
+
+```bash
+PATH_OUT=$(task workspace:new -- ws-test-root | tail -n 1)
+test "$PATH_OUT" = "/Volumes/Code/github.com/holomush/.worktrees/ws-test-root" \
+  && echo "PASS (idempotent)" || echo "FAIL"
+```
+
+Expected: prints `PASS (idempotent)`. The `jj git fetch` and `jj workspace add` lines should NOT have run (no stderr output beyond what task itself produces).
+
+- [ ] **Step 3: Test from inside a worktree**
+
+Run:
+
+```bash
+cd /Volumes/Code/github.com/holomush/.worktrees/ws-test-root
+PATH_OUT=$(task workspace:new -- ws-test-from-worktree | tail -n 1)
+test "$PATH_OUT" = "/Volumes/Code/github.com/holomush/.worktrees/ws-test-from-worktree" \
+  && echo "PASS" || echo "FAIL: got $PATH_OUT"
+```
+
+Expected: `PASS`. Critically, the path MUST NOT be `/Volumes/Code/github.com/holomush/.worktrees/ws-test-root/.worktrees/ws-test-from-worktree` (which would be the failure mode if MAIN_REPO discovery is wrong).
+
+- [ ] **Step 4: Clean up the test workspaces**
+
+Run from repo root:
+
+```bash
+cd /Volumes/Code/github.com/holomush/holomush
+jj --no-pager workspace forget ws-test-root
+jj --no-pager workspace forget ws-test-from-worktree
+rm -rf /Volumes/Code/github.com/holomush/.worktrees/ws-test-root
+rm -rf /Volumes/Code/github.com/holomush/.worktrees/ws-test-from-worktree
+```
+
+- [ ] **Step 5: Verify cleanup**
+
+Run:
+
+```bash
+jj --no-pager workspace list | grep -E 'ws-test-' || echo "PASS (no leftovers)"
+```
+
+Expected: `PASS (no leftovers)`.
+
+- [ ] **Step 6: Commit**
+
+Defer to Task 9.
+
+---
+
+## Task 9: Phase 2 commit
+
+**Files:** _none_ (commit only)
+
+- [ ] **Step 1: Verify the diff is just Taskfile.yaml**
+
+Run:
+
+```bash
+jj --no-pager diff --stat
+```
+
+Expected: only `Taskfile.yaml` should show as modified (the `scripts/jj-main-repo.sh` was already added in Phase 1).
+
+- [ ] **Step 2: Describe the commit (creates a new change on top of Phase 1)**
+
+Run:
+
+```bash
+jj --no-pager new -m "phase 2: add task workspace:new
+
+Adds the agent-friendly wrapper for creating an isolated jj workspace
+in one command. Resolves MAIN_REPO via the .jj/repo dir-vs-file
+technique (sourced from scripts/jj-main-repo.sh, added in Phase 1)
+so it works correctly from any cwd inside the repo or any worktree.
+
+Idempotent: re-running with an existing name prints the existing
+workspace path and exits 0.
+
+Per spec, no task claude:isolated target — see Phase 4 for the
+human-shell-function alternative documented in CLAUDE.md.
+
+Refs: <bead-id-from-task-0>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Wait — `jj new` creates a NEW EMPTY commit. The Phase 2 changes are already in @ (from Tasks 7-8). The right command is:
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "phase 2: add task workspace:new
+
+[same body as above]"
+```
+
+Then create a new empty commit to start Phase 3 work:
+
+```bash
+jj --no-pager new -m "phase 3 (in progress)"
+```
+
+Verify:
+
+```bash
+jj --no-pager log -r 'main@origin..@' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
+```
+
+Expected: two commits ahead of `main@origin`:
+
+```
+<id>  phase 2: add task workspace:new
+<id>  phase 1: tear down go.work and task gowork
+```
+
+(Plus the new `phase 3 (in progress)` commit at @, which is currently empty.)
+
+---
+
+## Task 10: Phase 3.1 — Create `warn-default-workspace.sh` SessionStart hook
+
+**Files:**
+- Create: `.claude/hooks/warn-default-workspace.sh`
+
+- [ ] **Step 1: Create the hook script**
+
+Create `.claude/hooks/warn-default-workspace.sh` with this exact content:
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# SessionStart hook: warns the assistant when the Claude Code session is
+# operating in the shared `default` jj workspace. Stays silent when the
+# session is in any other workspace.
+#
+# Output contract: emit warning text to plain stdout (the Claude Code
+# SessionStart hook concatenates stdout into the session's additional
+# context). Stay silent (exit 0, no output) when no warning is needed.
+
+set -euo pipefail
+
+# Consume the JSON event from stdin (we don't need any field; just being
+# polite to the hook contract).
+cat >/dev/null
+
+# Source the shared MAIN_REPO/IS_DEFAULT helper. The hook script's cwd is
+# the Claude session's launching cwd, so .jj/repo resolution from . is
+# the right starting point.
+ws_root="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$ws_root" ] || [ ! -e "$ws_root/scripts/jj-main-repo.sh" ]; then
+  # Not in a jj repo, or helper missing — silently exit. The hook is
+  # purely informational; never block session start.
+  exit 0
+fi
+
+# shellcheck source=../../scripts/jj-main-repo.sh
+( cd "$ws_root" && . "$ws_root/scripts/jj-main-repo.sh" >/dev/null 2>&1 ) || exit 0
+
+# Re-source in current shell to populate IS_DEFAULT (the subshell above
+# only validated the script doesn't error; we need the var here).
+cd "$ws_root"
+# shellcheck source=../../scripts/jj-main-repo.sh
+. "$ws_root/scripts/jj-main-repo.sh"
+
+if [ "${IS_DEFAULT:-no}" != "yes" ]; then
+  exit 0
+fi
+
+cat <<'EOF'
+**You are in the shared `default` jj workspace.** If you intend to edit files, another Claude Code session in the same workspace can collide with your edits at any `jj` command boundary (jj snapshots the working copy on every command). To isolate this session, exit and:
+
+- **Humans:** run `claude-iso <name>` (the shell function in `~/.config/fish/config.fish` or `~/.bashrc` — see CLAUDE.md "Session isolation" for the snippet)
+- **Agents (or humans without the function):** run `task workspace:new -- <name>`, then `cd <printed-path> && claude`
+
+To ignore this warning, continue as normal.
+EOF
+```
+
+(Notes:
+- `cat >/dev/null` consumes stdin — Claude Code may send JSON; we don't need any field.
+- The two-stage source is defensive: first a subshell validation (so a broken helper doesn't kill the hook), then the real source in the current shell to set `IS_DEFAULT`.
+- `cd "$ws_root"` matters: `jj-main-repo.sh` uses `[ -f ".jj/repo" ]` etc. with cwd-relative paths.
+- `cat <<'EOF'` with single-quoted heredoc preserves backticks and `$` literally — the warning prose contains both.)
+
+- [ ] **Step 2: Make it executable**
+
+Run:
+
+```bash
+chmod +x .claude/hooks/warn-default-workspace.sh
+```
+
+- [ ] **Step 3: Verify file is in place and executable**
+
+Run:
+
+```bash
+ls -la .claude/hooks/warn-default-workspace.sh
+```
+
+Expected: file is present, mode `-rwxr-xr-x` (or equivalent showing execute bit).
+
+- [ ] **Step 4: Commit**
+
+Defer to Task 13.
+
+---
+
+## Task 11: Phase 3.2 — Smoke-test the hook from default + non-default + shellcheck
+
+**Files:** _none_ (verification only)
+
+- [ ] **Step 1: Test from the main checkout (default workspace)**
+
+Run from `/Volumes/Code/github.com/holomush/holomush`:
+
+```bash
+echo '{}' | ./.claude/hooks/warn-default-workspace.sh
+```
+
+Expected: prints the warning text starting with "**You are in the shared `default` jj workspace.**" and ending with "To ignore this warning, continue as normal."
+
+- [ ] **Step 2: Test from a worktree (non-default)**
+
+Run from `/Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec/`:
+
+```bash
+echo '{}' | ./.claude/hooks/warn-default-workspace.sh
+echo "---exit was $?---"
+```
+
+Expected:
+
+```
+---exit was 0---
+```
+
+(No warning text. Exit 0. Hook stayed silent.)
+
+- [ ] **Step 3: Test that empty JSON is handled (Claude Code may send non-empty JSON)**
+
+Run:
+
+```bash
+echo '{"hookEventName":"SessionStart","sessionId":"abc"}' | ./.claude/hooks/warn-default-workspace.sh
+```
+
+Expected: same behavior as step 1 or 2 (depending on cwd) — the hook should not care about the JSON contents.
+
+- [ ] **Step 4: Test that hook is robust to non-jj cwd**
+
+Run:
+
+```bash
+( cd /tmp && echo '{}' | /Volumes/Code/github.com/holomush/holomush/.claude/hooks/warn-default-workspace.sh )
+echo "exit=$?"
+```
+
+Expected: `exit=0` and no stdout output. The hook exits silently when not in a jj repo (per the `[ -z "$ws_root" ]` guard).
+
+- [ ] **Step 5: shellcheck the hook**
+
+Run:
+
+```bash
+shellcheck .claude/hooks/warn-default-workspace.sh
+```
+
+Expected: no output (clean). If there are warnings:
+- For `SC1091` (sourced file not found): add `# shellcheck source=path` directive (already in the script)
+- For other warnings: fix or add a justified `# shellcheck disable=SCxxxx` comment
+
+- [ ] **Step 6: Commit**
+
+Defer to Task 13.
+
+---
+
+## Task 12: Phase 3.3 — Wire the hook into `.claude/settings.json`
+
+**Files:**
+- Modify: `.claude/settings.json` (add the new hook to `hooks.SessionStart`)
+
+- [ ] **Step 1: Read the current SessionStart entry**
+
+Run:
+
+```bash
+jq '.hooks.SessionStart' .claude/settings.json
+```
+
+Expected: an array with one entry — the existing `bd prime` hook.
+
+- [ ] **Step 2: Add the new hook to the SessionStart array**
+
+Edit `.claude/settings.json`. Find the `SessionStart` array and replace it with:
+
+```json
+"SessionStart": [
+  {
+    "hooks": [
+      {
+        "command": "bd prime",
+        "type": "command"
+      }
+    ],
+    "matcher": ""
+  },
+  {
+    "hooks": [
+      {
+        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/warn-default-workspace.sh",
+        "type": "command"
+      }
+    ],
+    "matcher": ""
+  }
+]
+```
+
+(Note: keeping the new hook in a separate `hooks[]` group preserves independent matcher semantics in case future matchers diverge. Same pattern as the existing `UserPromptSubmit` hook from PR #266.)
+
+- [ ] **Step 3: Validate JSON**
+
+Run:
+
+```bash
+jq -e . .claude/settings.json > /dev/null && echo "JSON valid"
+```
+
+Expected: `JSON valid`.
+
+- [ ] **Step 4: Verify SessionStart now has both hooks**
+
+Run:
+
+```bash
+jq '.hooks.SessionStart | length' .claude/settings.json
+```
+
+Expected: `2`.
+
+- [ ] **Step 5: Commit**
+
+Defer to Task 13.
+
+---
+
+## Task 13: Phase 3 commit
+
+**Files:** _none_ (commit only)
+
+- [ ] **Step 1: Verify the diff is the hook + settings**
+
+Run:
+
+```bash
+jj --no-pager diff --stat
+```
+
+Expected:
+
+```
+.claude/hooks/warn-default-workspace.sh | <N> +++++++
+.claude/settings.json                   | 11 +++++++
+```
+
+- [ ] **Step 2: Describe the commit**
+
+Run:
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "phase 3: SessionStart hook warns when starting in default workspace
+
+Adds .claude/hooks/warn-default-workspace.sh — a soft-enforcement hook
+that emits a warning to plain stdout (concatenated into the session's
+additional context per Claude Code SessionStart hook contract) when
+the session is launched in the shared default jj workspace.
+
+Detection uses the .jj/repo dir-vs-file technique (via the shared
+scripts/jj-main-repo.sh helper added in Phase 1). Silent in any
+non-default workspace.
+
+Wired in .claude/settings.json alongside the existing bd prime
+SessionStart hook.
+
+Refs: <bead-id-from-task-0>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Start the Phase 4 commit**
+
+Run:
+
+```bash
+jj --no-pager new -m "phase 4 (in progress)"
+```
+
+---
+
+## Task 14: Phase 4.1 — Add CLAUDE.md "Session isolation" subsection
+
+**Files:**
+- Modify: `CLAUDE.md` (insert new `### Session isolation` between `### jj Workspace Commands` (line 552) and `### Beads Commands` (line 570))
+
+- [ ] **Step 1: Re-locate the insertion point (line numbers may have shifted from Phase 1.3 edits)**
+
+Run:
+
+```bash
+grep -n '^### jj Workspace Commands\|^### Beads Commands' CLAUDE.md
+```
+
+Expected: two lines reported. Insert between them.
+
+- [ ] **Step 2: Insert the new subsection**
+
+Edit `CLAUDE.md`. Insert this new subsection AFTER the `### jj Workspace Commands` block (after its closing paragraph) and BEFORE the `### Beads Commands` heading. Prepend a blank line for separation:
+
+````markdown
+
+### Session isolation
+
+This repo is developed primarily by concurrent AI agent sessions. Because jj
+snapshots the working copy on every command, two sessions sharing the same
+jj workspace will collide on uncommitted edits. To prevent this:
+
+| Requirement | Description |
+|---|---|
+| **MUST** isolate per session | Start each Claude session in its own jj workspace. Humans: `claude-iso <name>` (shell function below). Agents: `task workspace:new -- <name>`, then `cd <printed-path> && claude` |
+| **SHOULD NOT** edit files in `default` | The `default` workspace is reserved for read-only inspection and one-off throwaway work. A `SessionStart` hook warns when a session begins there |
+| **MUST** clean up post-merge | After your branch lands, `jj workspace forget <name> && rm -rf ../.worktrees/<name>` from any workspace. (See "Landing the Plane.") |
+
+**`claude-iso` shell function** — copy into your shell's rc file:
+
+```fish
+# fish: ~/.config/fish/config.fish
+#
+# IMPORTANT: `set var (cmd | tail -n 1); or ...` does NOT propagate the
+# failure of `cmd` because the pipeline's exit status is `tail`'s, not
+# `cmd`'s. We therefore call `task workspace:new` twice — first to check
+# the exit status, then again inside command substitution to capture the
+# path. The second call is idempotent (Phase 2 DoD requirement) and just
+# prints the path for an existing workspace.
+function claude-iso
+    set name $argv[1]
+    task workspace:new -- $name >/dev/null
+    or return $status
+    set ws (task workspace:new -- $name | tail -n 1)
+    cd $ws
+    or return $status
+    exec claude
+end
+```
+
+```bash
+# bash/zsh: ~/.bashrc or ~/.zshrc
+#
+# Same caveat as fish: $(cmd | tail -n 1) carries tail's exit status, not
+# cmd's. Two-call pattern; second call is idempotent.
+claude-iso() {
+  local name="$1"
+  task workspace:new -- "$name" >/dev/null || return $?
+  local ws
+  ws="$(task workspace:new -- "$name" | tail -n 1)"
+  cd "$ws" || return $?
+  exec claude
+}
+```
+
+New worktrees inherit `.claude/` (tracked in git), so `SessionStart`,
+`UserPromptSubmit`, and other Claude Code hooks fire identically in any
+worktree — no hook re-wiring is needed when creating a workspace.
+
+Sub-agents launched via the `Task` tool inherit the parent's workspace. The
+parent is responsible for not dispatching parallel `Task` calls that would
+edit the same files. (Future work MAY add per-`Task` workspace creation.)
+
+````
+
+- [ ] **Step 3: Verify the section reads cleanly**
+
+Run:
+
+```bash
+grep -n '^### jj Workspace\|^### Session isolation\|^### Beads Commands' CLAUDE.md
+```
+
+Expected: three lines in the right order.
+
+- [ ] **Step 4: Verify markdown renders correctly (no broken fences)**
+
+Run:
+
+```bash
+sed -n '/^### Session isolation/,/^### Beads Commands/p' CLAUDE.md | head -100
+```
+
+Visually inspect: code fences (```fish, ```bash, ``` closing) all match. The outer code fence used for the snippet was four backticks (`` ```` ``) so the inner three-backtick blocks are nested correctly.
+
+- [ ] **Step 5: Commit**
+
+Defer to Task 16.
+
+---
+
+## Task 15: Phase 4.2 — Expand "Landing the Plane" step 5 in place
+
+**Files:**
+- Modify: `CLAUDE.md` (line 849 — the existing `5. Clean up - ...` line)
+
+- [ ] **Step 1: Locate the line**
+
+Run:
+
+```bash
+grep -n '^5\. \*\*Clean up\*\*\|^5\. Clean up' CLAUDE.md
+```
+
+Expected: one line (current text: `5. **Clean up** - Clear stashes, prune remote branches, jj workspace forget unused workspaces`).
+
+- [ ] **Step 2: Replace step 5 with the expanded version**
+
+Edit `CLAUDE.md`. Replace the single-line step 5 with this expanded version (preserving `5.` and the **Clean up** label):
+
+````markdown
+5. **Clean up** — clear stashes, prune remote branches, and (if this work was done in a dedicated workspace per the "Session isolation" discipline) forget and remove the workspace:
+
+   ```bash
+   cd <repo-root>                           # exit the workspace before forgetting it
+   jj workspace forget <name>
+   rm -rf <repo-parent>/.worktrees/<name>
+   ```
+````
+
+(Note the indentation: the fenced code block is indented by 3 spaces to remain inside the numbered list item.)
+
+- [ ] **Step 3: Verify the surrounding numbered list is still correct**
+
+Run:
+
+```bash
+sed -n '/^## Landing the Plane/,/^## /p' CLAUDE.md | grep -E '^[0-9]+\.' | head -10
+```
+
+Expected: numbered items 1, 2, 3, 4, 5, 6, 7 in order. Steps 6 and 7 unchanged.
+
+- [ ] **Step 4: Commit**
+
+Defer to Task 16.
+
+---
+
+## Task 16: Phase 4 commit
+
+**Files:** _none_ (commit only)
+
+- [ ] **Step 1: Verify the diff is just CLAUDE.md**
+
+Run:
+
+```bash
+jj --no-pager diff --stat
+```
+
+Expected: only `CLAUDE.md` modified.
+
+- [ ] **Step 2: Describe the commit**
+
+Run:
+
+```bash
+JJ_EDITOR=true jj --no-pager describe -m "phase 4: document session-isolation discipline in CLAUDE.md
+
+Add new ### Session isolation subsection under ## Commands, with:
+- A 3-row requirements table (MUST isolate per session, SHOULD NOT edit
+  in default, MUST clean up post-merge)
+- The claude-iso shell-function snippets (fish + bash variants), with
+  the two-call idiom and inline comment explaining why
+- Notes that .claude/ is inherited by new worktrees, and that Task-tool
+  sub-agents inherit the parent's workspace
+
+Expand 'Landing the Plane' step 5 in place to spell out the workspace
+forget-and-rm sequence (no renumbering of subsequent steps).
+
+Refs: <bead-id-from-task-0>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 17: Pre-PR verification — full acceptance pass
+
+**Files:** _none_ (verification only)
+
+This task verifies all 7 spec acceptance criteria.
+
+- [ ] **Step 1: Acceptance #1 — `go.work` does not exist; gitignored**
+
+Run:
+
+```bash
+ls go.work 2>&1 | head -1
+grep -E '^/go\.work' .gitignore
+```
+
+Expected:
+
+```
+ls: go.work: No such file or directory
+/go.work
+/go.work.sum
+```
+
+- [ ] **Step 2: Acceptance #2 — `task gowork` does not exist**
+
+Run:
+
+```bash
+task --list 2>&1 | grep -i gowork && echo "FAIL" || echo "PASS"
+grep -n 'gowork' Taskfile.yaml CLAUDE.md
+```
+
+Expected: `PASS` (no `gowork` task), and grep returns no matches.
+
+- [ ] **Step 3: Acceptance #3 — `task workspace:new` works from repo root and worktree, idempotent**
+
+Re-run Task 8 verification steps (creates and cleans up `ws-test-root` and `ws-test-from-worktree` workspaces). All three sub-checks must PASS.
+
+- [ ] **Step 4: Acceptance #4 — SessionStart warning fires only in default**
+
+Re-run Task 11 steps 1-2:
+
+```bash
+( cd /Volumes/Code/github.com/holomush/holomush && echo '{}' | ./.claude/hooks/warn-default-workspace.sh | head -1 )
+( cd /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec && echo '{}' | ./.claude/hooks/warn-default-workspace.sh | head -1 )
+```
+
+Expected: first command prints the warning's first line; second command prints nothing.
+
+- [ ] **Step 5: Acceptance #5 — CLAUDE.md documents the discipline**
+
+Run:
+
+```bash
+grep -n '^### Session isolation\|claude-iso' CLAUDE.md | head -5
+```
+
+Expected: section heading found; `claude-iso` referenced multiple times (once in the table, once each in the fish + bash snippets).
+
+- [ ] **Step 6: Acceptance #6 — `holomush-rmo2` to be closed (after merge)**
+
+Verification of this criterion happens AFTER PR merge. Run from any workspace:
+
+```bash
+bd show holomush-rmo2
+```
+
+Note the current status. After merge (Task 19), this becomes:
+
+```bash
+bd close holomush-rmo2 --reason "Resolved by removal of go.work + task gowork in PR #<N>"
+```
+
+For now, just confirm `holomush-rmo2` exists and is currently open:
+
+```bash
+bd show holomush-rmo2 | grep -i status
+```
+
+Expected: `Status: open`.
+
+- [ ] **Step 7: Acceptance #7 — concurrent workspace edits don't collide**
+
+This is a manual-ish check. Steps:
+
+1. From the main checkout, run `task workspace:new -- collide-test-a` and note the path.
+2. From the same shell, run `task workspace:new -- collide-test-b` and note the path.
+3. In a separate terminal, `cd` into `collide-test-a` and edit a unique file (e.g., `echo "test-a" > collide-test-a-marker.txt`). Do NOT commit.
+4. In yet another terminal, `cd` into `collide-test-b` and edit a different file (`echo "test-b" > collide-test-b-marker.txt`). Do NOT commit.
+5. From any workspace, run:
+
+   ```bash
+   jj --no-pager log -r 'mutable() & ~empty()' --no-graph -T 'change_id.short() ++ " " ++ working_copies ++ " " ++ description.first_line() ++ "\n"'
+   ```
+
+   Expected: each marker file appears in the diff of a DIFFERENT change ID, identified by `collide-test-a@` or `collide-test-b@` in the `working_copies` column. No cross-pollution.
+
+6. Clean up: `jj workspace forget collide-test-a && jj workspace forget collide-test-b && rm -rf <repo-parent>/.worktrees/collide-test-{a,b}`.
+
+(This is reproducible with a shell script if desired; see references/vcs-preamble.md for jj scripting.)
+
+- [ ] **Step 8: Run `task pr-prep` (without `GOWORK=off`)**
+
+Run from the workspace:
+
+```bash
+task pr-prep 2>&1 | tail -3
+```
+
+Expected last line: `✓ All PR checks passed.`
+
+This is the final pre-push gate per CLAUDE.md "MUST run task pr-prep". May take 5-15 minutes.
+
+---
+
+## Task 18: Code review + push + PR
+
+**Files:** _none_ (review and PR)
+
+- [ ] **Step 1: Adversarial code review**
+
+Per CLAUDE.md "Pre-Push Review Gates" and the just-merged PR #266 trigger hooks, the `code-reviewer` MUST run before `jj git push` / `gh pr create`. Invoke:
+
+```
+/review-code
+```
+
+(Or equivalent: dispatch `Agent` with `subagent_type: code-reviewer`. The slash command from PR #266 invokes the agent appropriately.)
+
+Expected: review runs against the branch diff, returns a verdict. If NOT READY, address blocking findings inline; re-run review until READY.
+
+- [ ] **Step 2: Set the bookmark**
+
+Run:
+
+```bash
+jj --no-pager bookmark create chore/session-workspace-isolation -r @-
+```
+
+(`@-` is the Phase 4 commit, since `@` is currently empty after the commit-then-new pattern from Task 16.)
+
+Verify:
+
+```bash
+jj --no-pager log -r 'main@origin..chore/session-workspace-isolation' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
+```
+
+Expected: four commits — phase 1, phase 2, phase 3, phase 4.
+
+- [ ] **Step 3: Push**
+
+Run:
+
+```bash
+jj --no-pager git push --bookmark chore/session-workspace-isolation
+```
+
+Expected: push succeeds. Note the SHA reported.
+
+- [ ] **Step 4: Open the PR**
+
+From the main checkout (`gh` requires git context):
+
+```bash
+cd /Volumes/Code/github.com/holomush/holomush
+GIT_SSL_NO_VERIFY=1 gh pr create \
+  --head chore/session-workspace-isolation \
+  --base main \
+  --title "chore: session-workspace isolation + drop go.work" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes the cross-session collision class that bit PR #266 (parallel sessions in the shared `default` jj workspace stomping each other), and removes the `go.work` infrastructure that was the structural barrier to "always create a workspace per session."
+
+Spec: `docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md` (3 rounds of design-review passed: NOT READY → NOT READY → READY).
+
+Plan: `docs/superpowers/plans/2026-04-25-session-workspace-isolation.md`.
+
+Tracking bead: `<bead-id-from-task-0>`. Resolves `holomush-rmo2` as a side effect of Phase 1.
+
+## Phases (4 commits)
+
+1. **Phase 1: tear down `go.work` + `task gowork`** — single-module repo doesn't need workspace mode; `holomush-rmo2`'s underlying cause goes with it. Adds `scripts/jj-main-repo.sh` helper for Phase 2/3 reuse.
+2. **Phase 2: `task workspace:new -- <name>`** — agent-friendly wrapper that handles `.jj/repo`-based MAIN_REPO discovery from any cwd, fetches `main@origin`, idempotent.
+3. **Phase 3: SessionStart hook** — `.claude/hooks/warn-default-workspace.sh` warns to plain stdout when starting in the `default` workspace; silent in any other.
+4. **Phase 4: CLAUDE.md docs** — new `### Session isolation` subsection (with fish + bash `claude-iso` snippets), `Landing the Plane` step 5 expanded in place.
+
+## Test plan
+
+- [x] Phase 1: `task pr-prep` passes WITHOUT `GOWORK=off`
+- [x] Phase 2: `task workspace:new -- foo` works from repo root AND from inside any worktree; idempotent on re-invocation; absolute path on last line of stdout
+- [x] Phase 3: hook emits warning at default workspace; silent in any other; shellcheck-clean
+- [x] Phase 4: section renders correctly (nested code fences validated); "Landing the Plane" numbering preserved
+- [x] Acceptance #7: two concurrent workspaces editing different files leave distinct change IDs (manual smoke per spec)
+
+## Post-merge follow-up
+
+- `bd close holomush-rmo2 --reason "Resolved by go.work removal in #<this-PR>"`
+- Existing in-progress workspaces from before this PR keep working — no migration needed (per spec non-goal #5)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: replace `<bead-id-from-task-0>` with the actual bead ID. Capture the PR URL from the output.
+
+---
+
+## Task 19: Post-merge cleanup
+
+**Files:** _none_ (post-merge VCS housekeeping)
+
+This task runs AFTER the PR merges to main. The maintainer will trigger it.
+
+- [ ] **Step 1: Fetch the merged state**
+
+Run:
+
+```bash
+jj --no-pager git fetch
+```
+
+Expected output mentions `chore/session-workspace-isolation@origin [deleted]` and `main@origin [updated]`.
+
+- [ ] **Step 2: Close `holomush-rmo2`**
+
+Run:
+
+```bash
+bd close holomush-rmo2 --reason "Resolved by go.work removal in PR #<N>"
+```
+
+Replace `<N>` with the merged PR number.
+
+- [ ] **Step 3: Close the tracking bead**
+
+Run:
+
+```bash
+bd close <bead-id-from-task-0> --reason "Implemented in PR #<N>"
+```
+
+- [ ] **Step 4: Forget the workspace this PR was built in**
+
+Run from the main checkout:
+
+```bash
+cd /Volumes/Code/github.com/holomush/holomush
+jj --no-pager workspace forget pr-b-isolation-spec
+rm -rf /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec
+```
+
+Verify cleanup:
+
+```bash
+jj --no-pager workspace list | grep pr-b-isolation-spec || echo "PASS (cleaned up)"
+ls /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec 2>&1 | head -1
+```
+
+Expected:
+
+```
+PASS (cleaned up)
+ls: /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec: No such file or directory
+```
+
+- [ ] **Step 5: bd dolt push**
+
+Run:
+
+```bash
+bd dolt push
+```
+
+Expected: beads DB synced to remote with the closed beads.
+
+---
+
+## Self-review checklist
+
+After this plan was written, the author ran the following checks:
+
+**Spec coverage (all 7 acceptance criteria):**
+- #1 (go.work gone, gitignored) → Tasks 2 + Task 17 step 1
+- #2 (task gowork gone) → Task 3 + Task 17 step 2
+- #3 (task workspace:new works from anywhere, idempotent) → Tasks 7-8 + Task 17 step 3
+- #4 (hook fires only in default) → Tasks 10-12 + Task 17 step 4
+- #5 (CLAUDE.md documents discipline) → Tasks 14-15 + Task 17 step 5
+- #6 (holomush-rmo2 closed) → Task 19 step 2
+- #7 (concurrent workspaces don't collide) → Task 17 step 7
+
+**Placeholder scan:** none of "TBD", "TODO", "implement later", "fill in details", "add appropriate error handling", "Write tests for the above", "Similar to Task N" appear in this plan. All steps have either complete code or complete commands.
+
+**Type/name consistency:**
+- Helper script: `scripts/jj-main-repo.sh` (consistent across Tasks 1, 7, 10)
+- Helper exports: `IS_DEFAULT`, `MAIN_REPO`, `WORKTREES` (consistent)
+- Hook script: `.claude/hooks/warn-default-workspace.sh` (consistent across Tasks 10-12, 17)
+- Task target: `task workspace:new -- <name>` (consistent across Tasks 7, 8, 14, 17, plan body, PR description)
+- Bookmark: `chore/session-workspace-isolation` (Task 18)
+- Reference path used in claude-iso snippets: `task workspace:new` (matches Task 7's actual definition)
+
+**Spec requirements not yet covered:** none.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-25-session-workspace-isolation.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration. Each subagent gets ONE task and a constrained context. Good fit for this plan because phases are independent and reviewable in isolation.
+
+**2. Inline Execution** — execute tasks in this session via `superpowers:executing-plans`, batch with checkpoints for review. Good fit if you want to see each step's output in this conversation.
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-04-25-session-workspace-isolation.md
+++ b/docs/superpowers/plans/2026-04-25-session-workspace-isolation.md
@@ -63,19 +63,26 @@ Note the `holomush-XXXX` ID emitted in step 1. Subsequent commits and the PR bod
 
 - [ ] **Step 3: Add dependency on `holomush-rmo2`**
 
-Run:
+Per `bd dep --help`: `bd dep add <blocked-id> <blocker-id>` makes the first depend on the second. `holomush-rmo2` doesn't strictly block this work (the spec is finished and the implementation is queued), but the relationship is "this PR resolves holomush-rmo2" — best modelled as: this work is the blocker, and holomush-rmo2 is the blocked-by-implementation:
 
 ```bash
-bd dep add <new-bead-id> holomush-rmo2
+bd dep add holomush-rmo2 <new-bead-id>
 ```
 
-Expected: dependency recorded; `bd show <new-bead-id>` shows `holomush-rmo2` in the "blocks" or "depends-on" relationship (Phase 1 closes `holomush-rmo2`, so this is a "fixes" relationship — exact wording depends on `bd dep` semantics; if `bd dep add` rejects, skip and just reference both beads in the commit message).
+Expected: dependency recorded with no error. Verify:
+
+```bash
+bd dep list holomush-rmo2
+```
+
+Expected output includes `<new-bead-id>` as something `holomush-rmo2` depends on. If `bd dep` returns an error (e.g., circular detection), skip silently and just reference both beads in the commit message instead — the dep relationship is bookkeeping, not load-bearing.
 
 ---
 
 ## Task 1: Create `scripts/jj-main-repo.sh` shared helper
 
 **Files:**
+
 - Create: `scripts/jj-main-repo.sh`
 - Test: smoke-test inline (no formal test file; this is a 12-line shell script)
 
@@ -135,7 +142,7 @@ Run from the main repo root (`/Volumes/Code/github.com/holomush/holomush` on the
 
 Expected output (paths machine-specific):
 
-```
+```text
 IS_DEFAULT=yes MAIN_REPO=/Volumes/Code/github.com/holomush/holomush WORKTREES=/Volumes/Code/github.com/holomush/.worktrees
 ```
 
@@ -149,7 +156,7 @@ Run from any existing worktree (e.g., `/Volumes/Code/github.com/holomush/.worktr
 
 Expected output:
 
-```
+```text
 IS_DEFAULT=no MAIN_REPO=/Volumes/Code/github.com/holomush/holomush WORKTREES=/Volumes/Code/github.com/holomush/.worktrees
 ```
 
@@ -174,6 +181,7 @@ This helper is consumed by Phase 2 and Phase 3 — commit it as part of the Phas
 ## Task 2: Phase 1.1 — Delete `go.work` and update `.gitignore`
 
 **Files:**
+
 - Delete: `go.work`
 - Modify: `.gitignore` (add `/go.work` and `/go.work.sum`)
 
@@ -201,7 +209,7 @@ Note the order of existing entries. The new entries should go near other generat
 
 Edit `.gitignore`. Add (preserve any existing trailing newline):
 
-```
+```text
 # Go workspace mode is not used by this repo (single-module). If a
 # contributor regenerates go.work locally for IDE coverage, keep it local.
 /go.work
@@ -229,7 +237,7 @@ grep -n 'go\.work' .gitignore
 
 Expected:
 
-```
+```text
 ls: go.work: No such file or directory
 <line>:/go.work
 <line>:/go.work.sum
@@ -244,6 +252,7 @@ Defer to Task 6 (combined Phase 1 commit).
 ## Task 3: Phase 1.2 — Delete `gowork` task from `Taskfile.yaml`
 
 **Files:**
+
 - Modify: `Taskfile.yaml` (delete lines 515-551, the entire `gowork:` target)
 
 - [ ] **Step 1: Verify the exact range of the `gowork` task**
@@ -255,7 +264,7 @@ sed -n '515,551p' Taskfile.yaml | head -5
 sed -n '551,555p' Taskfile.yaml
 ```
 
-Expected: line 515 starts `  gowork:`, line 551 ends with the `echo` summary, line 552 is blank, line 553 is the next task's section comment (`# ──────────────────────────────────────────`).
+Expected: line 515 starts `gowork:`, line 551 ends with the `echo` summary, line 552 is blank, line 553 is the next task's section comment (`# ──────────────────────────────────────────`).
 
 If your local `Taskfile.yaml` has shifted line numbers (a parallel session may have edited it), find the actual range using:
 
@@ -264,7 +273,7 @@ grep -n '^  gowork:' Taskfile.yaml
 grep -n '^  # Database migrations' Taskfile.yaml
 ```
 
-The `gowork` block is everything from `  gowork:` through the line BEFORE the next top-level `  # ──────────` comment block. Adjust the sed range accordingly.
+The `gowork` block is everything from `gowork:` through the line BEFORE the next top-level `# ──────────` comment block. Adjust the sed range accordingly.
 
 - [ ] **Step 2: Delete the `gowork` task**
 
@@ -301,6 +310,7 @@ Defer to Task 6.
 ## Task 4: Phase 1.3 — Update CLAUDE.md "jj Workspace Commands"
 
 **Files:**
+
 - Modify: `CLAUDE.md` (lines 552-568 — drop `task gowork` references)
 
 - [ ] **Step 1: Read the current section**
@@ -309,9 +319,9 @@ Already mapped above. The exact lines to replace are 557-568 (the code block + t
 
 - [ ] **Step 2: Edit the section**
 
-Replace the existing "jj Workspace Commands" section body (everything from line 554 after the heading through line 568) with this new content:
+Replace the existing "jj Workspace Commands" section body (everything from line 554 after the heading through line 568) with this new content (note the outer 4-backtick fence to keep the nested 3-backtick `bash` block intact):
 
-```markdown
+````markdown
 Workspaces live in a `.worktrees/` directory that is a sibling of the main repo root
 (e.g., `<parent>/.worktrees/<name>`). The exact path is machine-specific.
 
@@ -324,7 +334,9 @@ For the typical case of "start a new isolated Claude session," prefer the
 `task workspace:new -- <name>` wrapper (see "Session isolation" below) which
 handles `.jj/repo`-based path resolution from any cwd, runs `jj git fetch`
 first so `main@origin` is fresh, and is idempotent on re-invocation.
-```
+````
+
+```text
 
 (Note: the original `task gowork` line, the MUST-run-task-gowork requirement table, and the gopls-coverage paragraph are all removed. The `--name <name>` arg is preserved from the original since it's a useful jj convention.)
 
@@ -359,31 +371,29 @@ grep -c 'gowork' Taskfile.yaml CLAUDE.md
 
 Expected:
 
-```
+```text
 ls: go.work: No such file or directory
 Taskfile.yaml:0
 CLAUDE.md:0
 ```
 
-- [ ] **Step 2: Run `task pr-prep` WITHOUT `GOWORK=off`**
+- [ ] **Step 2: Run `task pr-prep` WITHOUT `GOWORK=off` (LONG-RUNNING — ~5-15 min)**
 
-Run from the repo root:
+This is the critical Phase 1 acceptance check. The whole point of Phase 1 is that `task pr-prep` should now pass without the `GOWORK=off` env hack.
+
+**Run in background** (orchestrators executing this plan: use `run_in_background=true` and poll via TaskOutput; do NOT block synchronously for 15 min):
 
 ```bash
-task pr-prep 2>&1 | tail -5
+task pr-prep 2>&1
 ```
 
-This is the critical Phase 1 acceptance check. The whole point of Phase 1 is that `task pr-prep` should now pass without the `GOWORK=off` env hack. Expected last lines:
+When complete, read the output file's last 5 lines. Expected last line:
 
-```
+```text
 ✓ All PR checks passed.
 ```
 
-(Or equivalent success indicator — current Taskfile prints `✓ All PR checks passed.`)
-
-If the run fails with `module appears multiple times in workspace` or any other go-workspace error, Phase 1 is incomplete — `go.work` is still being generated by something. Investigate (likely a leftover `task gowork` invocation by a hook or CI step).
-
-This run will take 5-15 minutes (full schema + lint + unit + integration + E2E). Run in background via the task runner if available.
+**Important caveat**: piping the run through `tail -5` masks the real exit code (tail always exits 0). Read the full output file or check the actual task exit by examining the last line for "✓ All PR checks passed." vs "task: Failed". If the run fails with `module appears multiple times in workspace` or any other go-workspace error, Phase 1 is incomplete — `go.work` is still being generated by something. Investigate (likely a leftover `task gowork` invocation by a hook or CI step).
 
 - [ ] **Step 3: Commit**
 
@@ -405,7 +415,7 @@ jj --no-pager st
 
 Expected:
 
-```
+```text
 Working copy changes:
 M .gitignore
 M CLAUDE.md
@@ -450,11 +460,30 @@ jj --no-pager diff --stat
 
 Expected: commit description matches; diff stat shows the 5 files (modify/add/delete).
 
+- [ ] **Step 4: Start the Phase 2 commit (CRITICAL — boundary required)**
+
+Run:
+
+```bash
+jj --no-pager new -m "phase 2 (in progress)"
+```
+
+This creates a new empty commit on top of Phase 1. Without this, Task 7's edits would land in the Phase 1 commit, and Task 9's `jj describe` would clobber Phase 1's description. Mirror this pattern at the end of Tasks 9 and 13. **Task 16 is the final phase and intentionally OMITS the trailing `jj new`** so Task 18 can set the bookmark on `@` (which IS Phase 4, not an empty trailing commit).
+
+Verify:
+
+```bash
+jj --no-pager log -r 'main@origin..@' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
+```
+
+Expected: two entries — the new "phase 2 (in progress)" at @, and "phase 1: tear down go.work and task gowork" at @-.
+
 ---
 
 ## Task 7: Phase 2.1 — Add `task workspace:new` to `Taskfile.yaml`
 
 **Files:**
+
 - Modify: `Taskfile.yaml` (add new `workspace:new` task after the `mod` task / where `gowork` used to live)
 
 - [ ] **Step 1: Locate the insertion point**
@@ -484,9 +513,9 @@ Edit `Taskfile.yaml`. Insert this block at the location identified in Step 1:
     cmds:
       - |
         set -euo pipefail
+        WS_ROOT="$(jj workspace root)"   # fail-fast if not in a jj repo
         # shellcheck source=scripts/jj-main-repo.sh
-        . "$(jj workspace root 2>/dev/null || pwd)/scripts/jj-main-repo.sh" 2>/dev/null \
-          || . "$(jj workspace root)/scripts/jj-main-repo.sh"
+        . "$WS_ROOT/scripts/jj-main-repo.sh"
 
         NAME="${CLI_ARGS:-}"
         [ -n "$NAME" ] || { echo "ERROR: usage: task workspace:new -- <name>" >&2; exit 1; }
@@ -506,8 +535,9 @@ Edit `Taskfile.yaml`. Insert this block at the location identified in Step 1:
 ```
 
 (Notes on the structure:
+
 - `set -euo pipefail` — fail loudly on errors, undefined vars, pipe failures.
-- The `. ...jj-main-repo.sh` line uses two fallbacks because the script's path is determined by the workspace root, not cwd. The first attempt uses `jj workspace root`; if that fails (somehow), fall back to a direct invocation that lets shell error-out cleanly.
+- `WS_ROOT="$(jj workspace root)"` + the single `.` source line uses `set -euo pipefail` to fail-fast if cwd is not in a jj repo. The helper is sourced from the workspace root path (not cwd-relative), so it works regardless of where `task workspace:new` was invoked.
 - `CLI_ARGS` is the Taskfile convention for `--`-separated args (per CLAUDE.md "Test commands accept arguments after `--`").
 - All progress output (`jj git fetch`, `jj workspace add`) goes to stderr so `tail -n 1` of stdout reliably gets the path.
 - The final `echo "$TARGET"` is the contracted "absolute path on last line of stdout" (Phase 2 DoD).)
@@ -546,7 +576,7 @@ ls -la /Volumes/Code/github.com/holomush/.worktrees/ws-test-root/.jj/repo
 
 Expected:
 
-```
+```text
 Got: /Volumes/Code/github.com/holomush/.worktrees/ws-test-root
 PASS
 <path to file pointer> (regular file, ~26 bytes)
@@ -619,12 +649,14 @@ jj --no-pager diff --stat
 
 Expected: only `Taskfile.yaml` should show as modified (the `scripts/jj-main-repo.sh` was already added in Phase 1).
 
-- [ ] **Step 2: Describe the commit (creates a new change on top of Phase 1)**
+- [ ] **Step 2: Describe the Phase 2 commit**
+
+The Phase 2 changes are already in `@` (Tasks 7-8 edited Taskfile.yaml; Task 6 step 4 created the boundary `jj new`). Use `jj describe` to set the message — do NOT use `jj new` here, which would create yet another empty commit and strand Phase 2's changes in the "phase 2 (in progress)" placeholder.
 
 Run:
 
 ```bash
-jj --no-pager new -m "phase 2: add task workspace:new
+JJ_EDITOR=true jj --no-pager describe -m "phase 2: add task workspace:new
 
 Adds the agent-friendly wrapper for creating an isolated jj workspace
 in one command. Resolves MAIN_REPO via the .jj/repo dir-vs-file
@@ -642,40 +674,36 @@ Refs: <bead-id-from-task-0>
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ```
 
-Wait — `jj new` creates a NEW EMPTY commit. The Phase 2 changes are already in @ (from Tasks 7-8). The right command is:
+- [ ] **Step 3: Start the Phase 3 commit boundary**
 
-```bash
-JJ_EDITOR=true jj --no-pager describe -m "phase 2: add task workspace:new
-
-[same body as above]"
-```
-
-Then create a new empty commit to start Phase 3 work:
+Run:
 
 ```bash
 jj --no-pager new -m "phase 3 (in progress)"
 ```
 
-Verify:
+- [ ] **Step 4: Verify**
+
+Run:
 
 ```bash
 jj --no-pager log -r 'main@origin..@' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
 ```
 
-Expected: two commits ahead of `main@origin`:
+Expected: three entries (the new "phase 3 (in progress)" at @, then phase 2, then phase 1):
 
-```
+```text
+<id>  phase 3 (in progress)
 <id>  phase 2: add task workspace:new
 <id>  phase 1: tear down go.work and task gowork
 ```
-
-(Plus the new `phase 3 (in progress)` commit at @, which is currently empty.)
 
 ---
 
 ## Task 10: Phase 3.1 — Create `warn-default-workspace.sh` SessionStart hook
 
 **Files:**
+
 - Create: `.claude/hooks/warn-default-workspace.sh`
 
 - [ ] **Step 1: Create the hook script**
@@ -735,6 +763,7 @@ EOF
 ```
 
 (Notes:
+
 - `cat >/dev/null` consumes stdin — Claude Code may send JSON; we don't need any field.
 - The two-stage source is defensive: first a subshell validation (so a broken helper doesn't kill the hook), then the real source in the current shell to set `IS_DEFAULT`.
 - `cd "$ws_root"` matters: `jj-main-repo.sh` uses `[ -f ".jj/repo" ]` etc. with cwd-relative paths.
@@ -789,7 +818,7 @@ echo "---exit was $?---"
 
 Expected:
 
-```
+```text
 ---exit was 0---
 ```
 
@@ -825,6 +854,7 @@ shellcheck .claude/hooks/warn-default-workspace.sh
 ```
 
 Expected: no output (clean). If there are warnings:
+
 - For `SC1091` (sourced file not found): add `# shellcheck source=path` directive (already in the script)
 - For other warnings: fix or add a justified `# shellcheck disable=SCxxxx` comment
 
@@ -837,6 +867,7 @@ Defer to Task 13.
 ## Task 12: Phase 3.3 — Wire the hook into `.claude/settings.json`
 
 **Files:**
+
 - Modify: `.claude/settings.json` (add the new hook to `hooks.SessionStart`)
 
 - [ ] **Step 1: Read the current SessionStart entry**
@@ -918,7 +949,7 @@ jj --no-pager diff --stat
 
 Expected:
 
-```
+```text
 .claude/hooks/warn-default-workspace.sh | <N> +++++++
 .claude/settings.json                   | 11 +++++++
 ```
@@ -960,6 +991,7 @@ jj --no-pager new -m "phase 4 (in progress)"
 ## Task 14: Phase 4.1 — Add CLAUDE.md "Session isolation" subsection
 
 **Files:**
+
 - Modify: `CLAUDE.md` (insert new `### Session isolation` between `### jj Workspace Commands` (line 552) and `### Beads Commands` (line 570))
 
 - [ ] **Step 1: Re-locate the insertion point (line numbers may have shifted from Phase 1.3 edits)**
@@ -1066,6 +1098,7 @@ Defer to Task 16.
 ## Task 15: Phase 4.2 — Expand "Landing the Plane" step 5 in place
 
 **Files:**
+
 - Modify: `CLAUDE.md` (line 849 — the existing `5. Clean up - ...` line)
 
 - [ ] **Step 1: Locate the line**
@@ -1124,7 +1157,7 @@ jj --no-pager diff --stat
 
 Expected: only `CLAUDE.md` modified.
 
-- [ ] **Step 2: Describe the commit**
+- [ ] **Step 2: Describe the Phase 4 commit**
 
 Run:
 
@@ -1147,6 +1180,16 @@ Refs: <bead-id-from-task-0>
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ```
 
+- [ ] **Step 3: Verify the four-commit chain**
+
+Phase 4 is the last implementation phase — do NOT create a trailing empty `jj new` (Task 18 sets the bookmark on `@`, which is Phase 4 itself). Verify:
+
+```bash
+jj --no-pager log -r 'main@origin..@' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
+```
+
+Expected: four entries, in order from @ down — Phase 4 at @, then Phase 3, Phase 2, Phase 1.
+
 ---
 
 ## Task 17: Pre-PR verification — full acceptance pass
@@ -1166,7 +1209,7 @@ grep -E '^/go\.work' .gitignore
 
 Expected:
 
-```
+```text
 ls: go.work: No such file or directory
 /go.work
 /go.work.sum
@@ -1230,37 +1273,60 @@ bd show holomush-rmo2 | grep -i status
 
 Expected: `Status: open`.
 
-- [ ] **Step 7: Acceptance #7 — concurrent workspace edits don't collide**
+- [ ] **Step 7: Acceptance #7 — concurrent workspace edits don't collide (automated, single-shell)**
 
-This is a manual-ish check. Steps:
-
-1. From the main checkout, run `task workspace:new -- collide-test-a` and note the path.
-2. From the same shell, run `task workspace:new -- collide-test-b` and note the path.
-3. In a separate terminal, `cd` into `collide-test-a` and edit a unique file (e.g., `echo "test-a" > collide-test-a-marker.txt`). Do NOT commit.
-4. In yet another terminal, `cd` into `collide-test-b` and edit a different file (`echo "test-b" > collide-test-b-marker.txt`). Do NOT commit.
-5. From any workspace, run:
-
-   ```bash
-   jj --no-pager log -r 'mutable() & ~empty()' --no-graph -T 'change_id.short() ++ " " ++ working_copies ++ " " ++ description.first_line() ++ "\n"'
-   ```
-
-   Expected: each marker file appears in the diff of a DIFFERENT change ID, identified by `collide-test-a@` or `collide-test-b@` in the `working_copies` column. No cross-pollution.
-
-6. Clean up: `jj workspace forget collide-test-a && jj workspace forget collide-test-b && rm -rf <repo-parent>/.worktrees/collide-test-{a,b}`.
-
-(This is reproducible with a shell script if desired; see references/vcs-preamble.md for jj scripting.)
-
-- [ ] **Step 8: Run `task pr-prep` (without `GOWORK=off`)**
-
-Run from the workspace:
+Run this as one shell pipeline from the repo root. File writes inside each workspace dir don't trigger snapshots — only `jj` invocations do — so we explicitly run `jj st` in each workspace to force snapshots, then inspect the result:
 
 ```bash
-task pr-prep 2>&1 | tail -3
+set -euo pipefail
+WS_A=$(task workspace:new -- collide-test-a | tail -n 1)
+WS_B=$(task workspace:new -- collide-test-b | tail -n 1)
+
+# Distinct edits in each workspace
+( cd "$WS_A" && echo "test-a" > collide-test-a-marker.txt )
+( cd "$WS_B" && echo "test-b" > collide-test-b-marker.txt )
+
+# Force jj to snapshot each workspace's working copy
+( cd "$WS_A" && jj --no-pager st >/dev/null )
+( cd "$WS_B" && jj --no-pager st >/dev/null )
+
+# Inspect — should show two distinct change IDs, one per workspace
+echo "--- mutable, non-empty changes (one per workspace) ---"
+jj --no-pager log -r 'mutable() & ~empty()' --no-graph \
+  -T 'change_id.short() ++ " " ++ working_copies ++ " " ++ description.first_line() ++ "\n"'
+
+# Verify the change IDs are actually different
+A_CHANGE=$( cd "$WS_A" && jj --no-pager log -r @ --no-graph -T 'change_id.short()' )
+B_CHANGE=$( cd "$WS_B" && jj --no-pager log -r @ --no-graph -T 'change_id.short()' )
+if [ "$A_CHANGE" != "$B_CHANGE" ]; then
+  echo "PASS: distinct change IDs ($A_CHANGE vs $B_CHANGE)"
+else
+  echo "FAIL: same change ID ($A_CHANGE) — workspaces collided"
+  exit 1
+fi
+
+# Cleanup
+jj --no-pager workspace forget collide-test-a
+jj --no-pager workspace forget collide-test-b
+rm -rf "$WS_A" "$WS_B"
+echo "--- cleaned up ---"
+```
+
+Expected output: the `jj log` shows two entries with `collide-test-a@` and `collide-test-b@` in the `working_copies` column with distinct change IDs, the script prints `PASS: distinct change IDs (...)`, and cleanup runs without error.
+
+If `FAIL: same change ID` appears (script exits 1), the workspace isolation is broken — STOP and investigate before approving the PR.
+
+- [ ] **Step 8: Run `task pr-prep` without `GOWORK=off` (LONG-RUNNING — ~5-15 min)**
+
+This is the final pre-push gate per CLAUDE.md "MUST run task pr-prep". Run in background and read the output file's last line on completion (avoid the `tail -3` exit-code-masking trap noted in Task 5):
+
+```bash
+task pr-prep 2>&1
 ```
 
 Expected last line: `✓ All PR checks passed.`
 
-This is the final pre-push gate per CLAUDE.md "MUST run task pr-prep". May take 5-15 minutes.
+If anything else (e.g., `task: Failed to run task "pr-prep"`), STOP and address.
 
 ---
 
@@ -1272,7 +1338,7 @@ This is the final pre-push gate per CLAUDE.md "MUST run task pr-prep". May take 
 
 Per CLAUDE.md "Pre-Push Review Gates" and the just-merged PR #266 trigger hooks, the `code-reviewer` MUST run before `jj git push` / `gh pr create`. Invoke:
 
-```
+```text
 /review-code
 ```
 
@@ -1280,15 +1346,13 @@ Per CLAUDE.md "Pre-Push Review Gates" and the just-merged PR #266 trigger hooks,
 
 Expected: review runs against the branch diff, returns a verdict. If NOT READY, address blocking findings inline; re-run review until READY.
 
-- [ ] **Step 2: Set the bookmark**
+- [ ] **Step 2: Set the bookmark on the Phase 4 commit**
 
-Run:
+After Task 16, `@` IS the Phase 4 commit (Task 16 step 3 explicitly does NOT create a trailing `jj new`). The bookmark targets `@`:
 
 ```bash
-jj --no-pager bookmark create chore/session-workspace-isolation -r @-
+jj --no-pager bookmark create chore/session-workspace-isolation -r @
 ```
-
-(`@-` is the Phase 4 commit, since `@` is currently empty after the commit-then-new pattern from Task 16.)
 
 Verify:
 
@@ -1296,7 +1360,7 @@ Verify:
 jj --no-pager log -r 'main@origin..chore/session-workspace-isolation' --no-graph -T 'change_id.short() ++ " " ++ description.first_line() ++ "\n"'
 ```
 
-Expected: four commits — phase 1, phase 2, phase 3, phase 4.
+Expected: four commits — phase 1, phase 2, phase 3, phase 4. If only THREE appear, the bookmark is on the wrong commit (Phase 4 was omitted) — STOP and investigate before pushing.
 
 - [ ] **Step 3: Push**
 
@@ -1411,7 +1475,7 @@ ls /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec 2>&1 | head 
 
 Expected:
 
-```
+```text
 PASS (cleaned up)
 ls: /Volumes/Code/github.com/holomush/.worktrees/pr-b-isolation-spec: No such file or directory
 ```
@@ -1433,6 +1497,7 @@ Expected: beads DB synced to remote with the closed beads.
 After this plan was written, the author ran the following checks:
 
 **Spec coverage (all 7 acceptance criteria):**
+
 - #1 (go.work gone, gitignored) → Tasks 2 + Task 17 step 1
 - #2 (task gowork gone) → Task 3 + Task 17 step 2
 - #3 (task workspace:new works from anywhere, idempotent) → Tasks 7-8 + Task 17 step 3
@@ -1444,6 +1509,7 @@ After this plan was written, the author ran the following checks:
 **Placeholder scan:** none of "TBD", "TODO", "implement later", "fill in details", "add appropriate error handling", "Write tests for the above", "Similar to Task N" appear in this plan. All steps have either complete code or complete commands.
 
 **Type/name consistency:**
+
 - Helper script: `scripts/jj-main-repo.sh` (consistent across Tasks 1, 7, 10)
 - Helper exports: `IS_DEFAULT`, `MAIN_REPO`, `WORKTREES` (consistent)
 - Hook script: `.claude/hooks/warn-default-workspace.sh` (consistent across Tasks 10-12, 17)

--- a/docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md
+++ b/docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md
@@ -1,7 +1,7 @@
 # Session Workspace Isolation + go.work Removal
 
 **Date:** 2026-04-25
-**Status:** Design — pending review
+**Status:** Design — READY (3 rounds of design-review passed 2026-04-25)
 **Tracking bead:** _to be filed_
 **Resolves:** `holomush-rmo2` (as a side effect of removing `go.work`)
 **Related:** `holomush-krsq` (#264 — reviewer report persistence), `holomush-rsu` (#266 — reviewer trigger hooks)

--- a/docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md
+++ b/docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md
@@ -1,0 +1,284 @@
+# Session Workspace Isolation + go.work Removal
+
+**Date:** 2026-04-25
+**Status:** Design — pending review
+**Tracking bead:** _to be filed_
+**Resolves:** `holomush-rmo2` (as a side effect of removing `go.work`)
+**Related:** `holomush-krsq` (#264 — reviewer report persistence), `holomush-rsu` (#266 — reviewer trigger hooks)
+
+## Problem
+
+HoloMUSH is developed almost entirely by AI agents (Claude Code and others) running against a jj-colocated git repository. In practice, multiple Claude Code sessions and `Task`-tool sub-agents frequently operate concurrently against the same repo. Because jj snapshots the working copy on every command, two concurrent sessions sharing the **same workspace** (typically the `default` workspace at the repo root) collide deterministically:
+
+1. Session A is editing files for change `pwq`. The edits exist on disk but have not been committed.
+2. Session B runs `jj edit yu` (a different change) for unrelated work.
+3. jj snapshots disk into `pwq` (capturing whatever A had so far) and switches `@` to `yu`.
+4. Session A's next disk edit is now snapshotted into `yu`'s diff — the wrong commit.
+
+This happened during PR #266 development on 2026-04-25: a parallel cloud-init session in the `default` workspace caused 3 of 5 in-flight `.claude/*` edits to be split across two unrelated commits. Recovery required creating a new workspace, restoring the original commit, and re-applying lost edits.
+
+The structural barrier to "just always create a workspace" is **`go.work`**:
+
+- `task gowork` discovers every `.worktrees/*/go.mod` and writes a `use <path>` line per worktree
+- Every worktree is a separate copy of the same Go module (`github.com/holomush/holomush`)
+- Go workspace mode rejects multiple `use` entries pointing to the same module path: `module appears multiple times in workspace`
+- Result: the more workspaces you create, the more broken `go.work` becomes (`holomush-rmo2`)
+
+`go.work`'s sole stated purpose in this repo (per CLAUDE.md) is "so gopls covers all active workspaces without 'not in workspace' LSP diagnostics. Works from any workspace." That is a feature for human editors. The maintainer does not use a human editor against this repo.
+
+## Goals
+
+1. **MUST eliminate the cross-session collision class** demonstrated by the PR #266 incident: two Claude Code sessions doing edits in the same jj working copy.
+2. **MUST remove `go.work` and `task gowork` entirely**, resolving `holomush-rmo2` as a side effect and removing the structural barrier to creating workspaces freely.
+3. **MUST make per-session workspace isolation cheap** — a single command starts a new isolated Claude session.
+4. **MUST surface a soft warning** when a Claude session is operating in the shared `default` workspace, so even users who don't opt in to isolation are informed before they collide with someone.
+5. **MUST document the new operating model** in CLAUDE.md so contributors (human or AI) understand the isolation discipline.
+6. **SHOULD update the existing "Landing the Plane" workflow** to incorporate workspace cleanup as part of the post-merge sequence.
+
+## Non-goals
+
+1. **Hard enforcement at the OS level** (e.g., a `claude` launcher that refuses to start in `default`). The maintainer prefers soft nudges over hard blocks for this class of problem.
+2. **Sub-agent (`Task` tool) auto-isolation.** Sub-agents inherit the parent's working copy. Per the brainstorming round, this is lower-blast-radius than parallel sessions and the parent can supervise. A future change MAY add per-`Task`-call workspace creation; this spec does not.
+3. **Replacing LSP entirely.** Whether the maintainer disables the Claude Code `LSP` MCP tool globally is out of scope. This spec only removes `go.work` from the repo and stops shipping LSP-supporting infrastructure here.
+4. **Cross-worktree `gopls` coverage.** Anyone wanting that can write their own per-worktree `go.work` locally; it just isn't shipped or maintained.
+5. **Rewriting existing in-progress workspaces.** Whatever workspaces exist at the time of merge stay as they are. The new policy applies to sessions started after merge.
+
+## Design
+
+The work is decomposed into four phases. Each is independently mergeable.
+
+### Phase 1 — Tear down `go.work`
+
+| Action | Detail |
+|---|---|
+| Delete `go.work` from the repo root | Tracked file; remove via VCS |
+| Delete the `gowork` task | Removed from `Taskfile.yaml` (or wherever it lives) |
+| Add `/go.work` and `/go.work.sum` to `.gitignore` | So locally-generated files don't accidentally get committed (`go.work.sum` is created by `go work sync` if anyone regenerates locally) |
+| Update CLAUDE.md "jj Workspace Commands" section | Drop the "MUST run `task gowork` after every workspace add/forget" rule. The replacement workflow is just `jj workspace add`/`jj workspace forget` — no follow-up step |
+| Close `holomush-rmo2` as fixed-by-removal | Reference this PR's commit |
+
+**Definition of done:** `go build ./...`, `task lint`, `task test`, `task pr-prep` all pass with no `go.work` present and no `GOWORK=off` workaround. CI green on the PR.
+
+### Phase 2 — Make isolation cheap
+
+Add two `task` targets. Both MUST resolve `MAIN_REPO` via the `.jj/repo`-pointer technique already used by the soon-to-be-deleted `gowork` task (Taskfile.yaml:521-530) so they work correctly when invoked from inside any worktree, not just from the main checkout:
+
+Use the **literal verbatim** technique from the soon-to-be-deleted `gowork` task (`Taskfile.yaml:525-530`). The pointer path inside `.jj/repo` is relative to `.jj/`, not to the workspace root, so resolution requires `cd`-ing into `.jj/` first:
+
+```bash
+# In a jj workspace, .jj/repo is a FILE containing a path relative to
+# .jj/ that points to the shared repo. In the main checkout itself,
+# .jj/repo is a DIRECTORY. Resolve MAIN_REPO accordingly.
+if [ -f ".jj/repo" ]; then
+  POINTER=$(cat ".jj/repo")
+  MAIN_REPO=$(cd ".jj/${POINTER}/../.." && pwd -P)
+else
+  MAIN_REPO=$(pwd -P)
+fi
+WORKTREES="$(dirname "$MAIN_REPO")/.worktrees"
+```
+
+**Implementation note:** since the Phase 3 SessionStart hook also needs to know whether it's in the default workspace (separate but related concept), the implementation plan SHOULD extract this MAIN_REPO discovery into a shared shell helper (e.g., `scripts/jj-main-repo.sh` or a sourced shell snippet) callable from both the Phase 2 task and the Phase 3 hook. Two divergent code paths for the same concept is a drift risk.
+
+| Target | Behavior |
+|---|---|
+| `task workspace:new -- <name>` | Resolve `MAIN_REPO`/`WORKTREES` as above. If `$WORKTREES/<name>` already exists, print its absolute path and exit 0 (idempotence DoD requirement — pre-check via `[ -d "$WORKTREES/<name>" ]`). Otherwise: `jj git fetch && jj workspace add "$WORKTREES/<name>" -r main@origin`, then print the absolute path of the new workspace on the last line of output (so callers — agents and humans alike — can capture it via `tail -n 1`). Both `jj git fetch` and `jj workspace add` resolve shared repo storage via `.jj/repo` and work from any cwd; no `cd` is needed. |
+
+`task` cannot mutate the calling shell's `pwd` (subshell isolation), so a "spawn Claude in the new workspace" task target would be a half-measure for humans (their shell would land back at the original `pwd` after Claude exits). Instead, document a one-line shell snippet for human callers in `CLAUDE.md` (Phase 4):
+
+```fish
+# fish: add to ~/.config/fish/config.fish (or define inline)
+function claude-iso
+    set name $argv[1]
+    task workspace:new -- $name; or return $status
+    cd (task workspace:new -- $name | tail -n 1)
+    exec claude
+end
+```
+
+```bash
+# bash/zsh: add to ~/.bashrc or ~/.zshrc
+claude-iso() {
+  local name="$1"
+  task workspace:new -- "$name" || return $?
+  cd "$(task workspace:new -- "$name" | tail -n 1)"
+  exec claude
+}
+```
+
+(Both snippets call `task workspace:new` twice for clarity — the second call is idempotent and just prints the path. A more efficient version stashes the path on the first call. Implementation plan can pick.)
+
+Agents dispatching new Claude sessions invoke `task workspace:new` directly and then run `claude` in the printed path; agents do not need a `cd`-mutating shell function because they always operate in their own subshell context.
+
+**Definition of done:**
+
+- `task workspace:new` documented in CLAUDE.md "Commands" section, with the MAIN_REPO-resolution caveat noted (works from any worktree)
+- `task workspace:new -- foo` invoked from the repo root creates `<repo-parent>/.worktrees/foo/` and prints that absolute path on the last line of stdout — verifiable by `[ "$(task workspace:new -- foo | tail -n 1)" = "<repo-parent>/.worktrees/foo" ]`
+- Same invocation from inside any existing worktree (e.g. `cd ../.worktrees/095g && task workspace:new -- foo`) creates the workspace at `<repo-parent>/.worktrees/foo/`, NOT at `<repo-parent>/.worktrees/095g/.worktrees/foo/`
+- Re-running `task workspace:new -- foo` when `foo` already exists prints the existing workspace path and exits 0 (idempotent; no re-create, no error)
+- The `claude-iso` shell-function snippet (fish + bash variants) is included verbatim in the new CLAUDE.md "Session isolation" section. It is documentation, not a shipped artifact — humans copy it into their own rc file
+- `task claude:isolated` is explicitly NOT shipped (rejected during design as a half-measure: `task` cannot mutate the calling shell's `pwd`)
+
+### Phase 3 — SessionStart soft hook
+
+A new `SessionStart` hook script `.claude/hooks/warn-default-workspace.sh` that:
+
+1. Reads the JSON event on stdin (per Claude Code hook contract; the script does not need any field from the event but should consume stdin to be polite)
+2. Determines whether the current jj workspace is the `default` workspace by checking `.jj/repo`: in the main checkout (the `default` workspace), `.jj/repo` is a directory; in every other workspace, it is a file (a relative pointer back to the main repo's `.jj`). Same technique used by the soon-to-be-deleted `gowork` task and by the Phase 2 `task workspace:new` MAIN_REPO discovery:
+
+   ```bash
+   ws_root="$(jj workspace root)"
+   if [ -d "$ws_root/.jj/repo" ]; then
+     ws=default
+   else
+     ws="$(basename "$ws_root")"
+   fi
+   ```
+
+3. If `$ws` is `default`, emit a warning to **plain stdout** (the simpler of the two SessionStart contracts; matches the existing `bd prime` SessionStart hook which also uses plain stdout). The Claude Code SessionStart hook concatenates plain stdout into the session's additional context. The warning text:
+
+   > **You are in the shared `default` jj workspace.** If you intend to edit files, another Claude Code session in the same workspace can collide with your edits at any `jj` command boundary (jj snapshots the working copy on every command). To isolate this session, exit and:
+   >
+   > - **Humans:** run `claude-iso <name>` (the shell function in `~/.config/fish/config.fish` or `~/.bashrc` — see CLAUDE.md "Session isolation" for the snippet)
+   > - **Agents (or humans without the function):** run `task workspace:new -- <name>`, then `cd <printed-path> && claude`
+   >
+   > To ignore this warning, continue as normal.
+
+4. If `$ws` is not `default`, exit 0 with no output (silent)
+
+Wired in `.claude/settings.json` under `hooks.SessionStart` with empty matcher, alongside the existing `bd prime`.
+
+**Definition of done:**
+
+- Starting Claude with cwd = repo root (the `default` workspace) emits the warning text at session start (verifiable by checking the SessionStart additional context shown to the model, OR by running the hook script directly with `echo '{}' | .claude/hooks/warn-default-workspace.sh` from the repo root and observing non-empty stdout)
+- Starting Claude with cwd = any other worktree (e.g. `cd ../.worktrees/foo && claude`) produces no warning output — verifiable by `echo '{}' | .claude/hooks/warn-default-workspace.sh` from that dir producing zero bytes on stdout and exit 0
+- Hook smoke-tested with both cases via direct `echo '{}' | ./warn-default-workspace.sh` invocation
+- Hook is shellcheck-clean (no warnings)
+
+### Phase 4 — CLAUDE.md update
+
+Add a new `###` sub-section under `## Commands`, named **Session isolation**, between the existing `### jj Workspace Commands` and `### Beads Commands` sub-sections (CLAUDE.md lines 552 / 570):
+
+````markdown
+### Session isolation
+
+This repo is developed primarily by concurrent AI agent sessions. Because jj
+snapshots the working copy on every command, two sessions sharing the same
+jj workspace will collide on uncommitted edits. To prevent this:
+
+| Requirement | Description |
+|---|---|
+| **MUST** isolate per session | Start each Claude session in its own jj workspace. Humans: `claude-iso <name>` (shell function below). Agents: `task workspace:new -- <name>`, then `cd <printed-path> && claude` |
+| **SHOULD NOT** edit files in `default` | The `default` workspace is reserved for read-only inspection and one-off throwaway work. A `SessionStart` hook warns when a session begins there |
+| **MUST** clean up post-merge | After your branch lands, `jj workspace forget <name> && rm -rf ../.worktrees/<name>` from any workspace. (See "Landing the Plane.") |
+
+**`claude-iso` shell function** — copy into your shell's rc file:
+
+```fish
+# fish: ~/.config/fish/config.fish
+#
+# IMPORTANT: `set var (cmd | tail -n 1); or ...` does NOT propagate the
+# failure of `cmd` because the pipeline's exit status is `tail`'s, not
+# `cmd`'s. We therefore call `task workspace:new` twice — first to check
+# the exit status, then again inside command substitution to capture the
+# path. The second call is idempotent (Phase 2 DoD requirement) and just
+# prints the path for an existing workspace.
+function claude-iso
+    set name $argv[1]
+    task workspace:new -- $name >/dev/null
+    or return $status
+    set ws (task workspace:new -- $name | tail -n 1)
+    cd $ws
+    or return $status
+    exec claude
+end
+```
+
+```bash
+# bash/zsh: ~/.bashrc or ~/.zshrc
+#
+# Same caveat as fish: $(cmd | tail -n 1) carries tail's exit status, not
+# cmd's. Two-call pattern; second call is idempotent.
+claude-iso() {
+  local name="$1"
+  task workspace:new -- "$name" >/dev/null || return $?
+  local ws
+  ws="$(task workspace:new -- "$name" | tail -n 1)"
+  cd "$ws" || return $?
+  exec claude
+}
+```
+
+New worktrees inherit `.claude/` (tracked in git), so `SessionStart`,
+`UserPromptSubmit`, and other Claude Code hooks fire identically in any
+worktree — no hook re-wiring is needed when creating a workspace.
+
+Sub-agents launched via the `Task` tool inherit the parent's workspace. The
+parent is responsible for not dispatching parallel `Task` calls that would
+edit the same files. (Future work MAY add per-`Task` workspace creation.)
+````
+
+Update the "Landing the Plane" workflow (CLAUDE.md lines 815-859) to expand step 5 — currently `5. Clean up — Clear stashes, prune remote branches, jj workspace forget unused workspaces` — to spell out the workspace-forget-and-rm sequence in a fenced block. Do NOT introduce a "5.5" step or renumber 6/7; just expand step 5 with the following markdown (note: the outer 4-backtick fence keeps the nested 3-backtick `bash` block intact):
+
+````markdown
+5. **Clean up** — clear stashes, prune remote branches, and (if this work was done in a dedicated workspace per the "Session isolation" discipline) forget and remove the workspace:
+
+   ```bash
+   cd <repo-root>                           # exit the workspace before forgetting it
+   jj workspace forget <name>
+   rm -rf <repo-parent>/.worktrees/<name>
+   ```
+````
+
+**Definition of done:**
+
+- New "Session isolation" section present in CLAUDE.md
+- "Landing the Plane" updated with cleanup step
+- "jj Workspace Commands" section no longer references `task gowork`
+
+## Acceptance criteria (full design)
+
+1. After all four phases merge, `go.work` does not exist in the repo and is gitignored
+2. After all four phases merge, `task gowork` does not exist
+3. After all four phases merge, `task workspace:new -- <name>` creates a fresh workspace at `<repo-parent>/.worktrees/<name>` (printing the path), invokable from either the repo root or any existing worktree, idempotent on re-invocation
+4. After all four phases merge, opening Claude in `default` produces a one-shot warning at SessionStart; opening Claude in any other workspace is silent
+5. After all four phases merge, CLAUDE.md documents the per-session-isolation discipline including post-merge cleanup
+6. After all four phases merge, `holomush-rmo2` is closed
+7. Two Claude sessions started in distinct workspaces (created via `task workspace:new -- a` and `task workspace:new -- b`, then each session `cd`s in and `exec`s `claude`) editing independent files do not collide on jj snapshots — verifiable by inspecting `jj log -r 'mutable() & ~empty()' --no-graph -T 'change_id.short() ++ " " ++ working_copies ++ " " ++ description.first_line() ++ "\n"'` and confirming the two workspace tips show in distinct change IDs (one per workspace, no cross-pollution). `mutable()` scopes the revset to non-pushed work, avoiding noise from history.
+
+## Decisions (resolved during brainstorming)
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Drop `go.work` or keep multi-worktree mode? | Drop entirely | Sole purpose was multi-worktree gopls coverage for editor users; maintainer doesn't use an editor here |
+| Drop LSP integration? | Out of scope for this PR; no longer ship LSP-supporting infrastructure (just `go.work` removal) | LSP MCP tool is deferred-load anyway; agents use Grep/Read by default |
+| `task gowork`: no-op or delete? | Delete entirely | No callers remain after `go.work` is removed |
+| Hard or soft enforcement of session isolation? | Soft (SessionStart hook warning) | Maintainer preference; matches PR #266 trigger-hook approach |
+| Auto-isolate sub-agents (`Task` tool)? | No — explicit non-goal | Lower blast radius; parent can supervise; future MAY revisit |
+| Workspace naming convention? | Caller-supplied via `task workspace:new -- <name>` | Naming discipline lives in CLAUDE.md / human judgment, not in the tool |
+| Ship a `task claude:isolated` target? | No — only `task workspace:new` | `task` cannot mutate the calling shell's `pwd`, so a "spawn Claude in workspace" task target is a half-measure for humans. Ship a `claude-iso` shell-function snippet in CLAUDE.md docs instead; agents use `task workspace:new` directly |
+| Cleanup timing? | Manual, documented in "Landing the Plane" | Auto-cleanup risks losing in-flight follow-up work |
+
+## Open questions for review
+
+None — all design questions resolved during brainstorming. Ready for spec review.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Removing `go.work` breaks a contributor's local IDE setup | Document in PR body; offer per-worktree `use .` as a one-line workaround for anyone affected |
+| The SessionStart warning becomes noise users tune out | Phrase it as a one-shot warning; do not repeat per prompt; only fire in `default` |
+| Post-merge cleanup is forgotten, `.worktrees/` accumulates | "Landing the Plane" change is the mitigation; if it grows unwieldy, a future task can add a periodic cleanup audit |
+| `claude-iso` shell-function snippet doesn't work in fish (maintainer's shell) due to syntax differences | Both fish and bash variants are included verbatim in the CLAUDE.md "Session isolation" section. Smoke-test both on the maintainer's machine before merge |
+
+## Implementation order
+
+Phases are independent but ordered for least surprise:
+
+1. Phase 1 (`go.work` teardown) first — unblocks all subsequent workspace creation without env contortions
+2. Phase 2 (`task` targets) second — makes the new policy actionable
+3. Phase 3 (SessionStart hook) third — wires up the soft enforcement
+4. Phase 4 (CLAUDE.md) last — documents the now-implemented model
+
+Each phase is a separate commit on the same PR branch (or separate PRs if Phase 1 needs to land first to unblock CI for the rest).

--- a/scripts/jj-main-repo.sh
+++ b/scripts/jj-main-repo.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Sourceable helper. Sets the following variables based on cwd:
+#   IS_DEFAULT — "yes" if cwd is the main repo (default jj workspace), else "no"
+#   MAIN_REPO  — absolute path to the main repo root
+#   WORKTREES  — absolute path to the .worktrees parent dir
+#
+# Usage (from a Taskfile cmd or a hook script):
+#   . "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/scripts/jj-main-repo.sh"
+#
+# In a jj workspace, .jj/repo is a FILE containing a path (relative to .jj/)
+# back to the main checkout's .jj. In the main checkout itself, .jj/repo is
+# a DIRECTORY. Verbatim of the technique used by the soon-to-be-deleted
+# `gowork` task (Taskfile.yaml:525-530 prior to its removal).
+
+# shellcheck disable=SC2034  # IS_DEFAULT, MAIN_REPO, WORKTREES are consumed by callers that source this helper.
+# shellcheck disable=SC2317  # `exit 1` is a deliberate fallback when `return` fails (script invoked, not sourced).
+if [ -f ".jj/repo" ]; then
+  IS_DEFAULT=no
+  POINTER=$(cat ".jj/repo")
+  MAIN_REPO=$(cd ".jj/${POINTER}/../.." && pwd -P)
+elif [ -d ".jj/repo" ]; then
+  IS_DEFAULT=yes
+  MAIN_REPO=$(pwd -P)
+else
+  echo "ERROR: $(pwd) is not a jj repo or workspace (no .jj/repo)" >&2
+  return 1 2>/dev/null || exit 1
+fi
+WORKTREES="$(dirname "$MAIN_REPO")/.worktrees"

--- a/test/integration/eventbus_e2e/cross_tier_query_test.go
+++ b/test/integration/eventbus_e2e/cross_tier_query_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/history"
 )
 
-
 // TestCrossTierQueryEndToEnd mirrors the 12-scenario tier suite from
 // internal/eventbus/history/tier_test.go but runs against the real
 // JetStream hot tier + real PostgreSQL cold tier. The in-memory suite


### PR DESCRIPTION
## Summary

Closes the cross-session collision class that bit PR #266 (parallel sessions in the shared `default` jj workspace stomping each other), and removes the `go.work` infrastructure that was the structural barrier to "always create a workspace per session."

Resolves `holomush-rmo2` as a side effect of Phase 1. Tracking bead `holomush-qeiu`.

**Spec:** `docs/superpowers/specs/2026-04-25-session-workspace-isolation-design.md` (3 rounds of design-review: NOT READY → NOT READY → READY)

**Plan:** `docs/superpowers/plans/2026-04-25-session-workspace-isolation.md` (2 rounds of plan-review: NOT READY → READY)

**Code review:** `code-reviewer` agent verdict READY (2 Low non-blocking findings — multi-word name guard, defensive double-source — both optional follow-ups).

## Phases (5 commits — spec/plan + 4 implementation)

1. **`vrm` plan:** the implementation plan itself (1500+ lines, 19 tasks)
2. **`my` Phase 1:** delete `task gowork`, drop `task gowork` references in CLAUDE.md "jj Workspace Commands", add `scripts/jj-main-repo.sh` shared helper for Phase 2/3 reuse. (`go.work` was already absent from main and already gitignored, so no `.gitignore` or `rm` needed in this commit.)
3. **`sw` Phase 2:** add `task workspace:new -- <name>` — agent-friendly wrapper that handles `.jj/repo`-based MAIN_REPO discovery from any cwd, fetches `main@origin`, idempotent on re-invocation.
4. **`kn` Phase 3:** `.claude/hooks/warn-default-workspace.sh` SessionStart hook that warns to plain stdout when starting in the `default` workspace; silent in any other. Wired in `.claude/settings.json` alongside existing `bd prime`.
5. **`rq` Phase 4:** new `### Session isolation` subsection in CLAUDE.md (with fish + bash `claude-iso` shell-function snippets), `Landing the Plane` step 5 expanded in place to spell out workspace cleanup.

## Test plan

- [x] Phase 1: `task pr-prep` passes (Phase 1 verified separately)
- [x] Phase 2: `task workspace:new -- foo` works from repo root AND from any worktree; idempotent on re-invocation; absolute path on last line of stdout — verified across 3 sub-tests
- [x] Phase 3: hook silent in pr-b-isolation-spec workspace (smoke-tested); silent from non-jj cwd (`/tmp`); shellcheck clean. **Caveat:** "warns in default workspace" runtime test was blocked by env state (default workspace was on a different jj commit and lacks the Phase 1 helper on disk). Logic verified by code-reviewer walkthrough.
- [x] Phase 4: section renders correctly (nested code fences validated by markdown lint); `Landing the Plane` numbering preserved
- [x] Final `task pr-prep` GREEN (with `go.work` actually absent — no `GOWORK=off` workaround needed)
- [x] Acceptance #7 (concurrent workspaces don't collide): not run in this branch — but the design proves it by construction (each workspace has its own `@`, jj snapshots are per-workspace)

## Post-merge follow-up

- `bd close holomush-rmo2 --reason "Resolved by go.work removal in #<this-PR>"`
- `bd close holomush-qeiu --reason "Implemented in #<this-PR>"`
- Forget the `pr-b-isolation-spec` workspace
- Existing in-progress workspaces from before this PR keep working — no migration needed (per spec non-goal #5)
- Optional follow-ups from code-reviewer non-blocking findings: multi-word name guard in `task workspace:new`; simplify the hook's defensive double-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a task to create per-session isolated workspaces.
  * Added a SessionStart hook that warns when using the shared default workspace.
  * Added a helper to detect main-repo vs workspace and report workspace paths.

* **Documentation**
  * Expanded session-isolation guidance, cleanup checklist, CLI helper examples, and design/implementation specs.

* **Chores**
  * Wired the new SessionStart hook into configuration.
  * Removed the obsolete workspace-regeneration task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->