### PR TITLE
test(integration): pin Subscribe-path stale-token rejection wire shape

### DIFF
--- a/test/integration/auth/auth_suite_test.go
+++ b/test/integration/auth/auth_suite_test.go
@@ -20,6 +20,7 @@ import (
 	authpg "github.com/holomush/holomush/internal/auth/postgres"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/naming"
 	"github.com/holomush/holomush/internal/store"
@@ -151,6 +152,14 @@ func setupTestEnv() (*testEnv, error) {
 		holoGRPC.WithCharacterRepo(charRepo),
 		holoGRPC.WithSessionStore(sessionStore),
 		holoGRPC.WithGuestService(guestService),
+		// Wire a stub Subscriber so Subscribe gets past the early
+		// nil-subscriber guard at internal/grpc/server.go:657 and reaches
+		// the ownership-validation path that the multi-tab Subscribe-path
+		// post-logout spec asserts on. The stub is never actually invoked
+		// in any spec — every Subscribe call in this suite uses a
+		// stale/invalid token, so ValidateSessionOwnership rejects before
+		// OpenSession would be called.
+		holoGRPC.WithSubscriber(&unusedSubscriber{}),
 	)
 
 	webHandler := web.NewHandler(&coreClientShim{s: coreServer})
@@ -335,3 +344,19 @@ type noopEventStore struct{}
 func (n *noopEventStore) Append(_ context.Context, _ core.Event) error { return nil }
 
 var _ core.EventAppender = (*noopEventStore)(nil)
+
+// unusedSubscriber satisfies eventbus.Subscriber so the Subscribe handler
+// reaches the ownership-validation path. Returns an error if OpenSession
+// is ever called — that would mean a spec advanced past validation, which
+// no spec in this suite is meant to do (every Subscribe call uses a
+// stale/invalid token). The returned error is distinctively coded so a
+// reorder regression in CoreServer.Subscribe (validation moved after
+// OpenSession) would surface as TEST_SUITE_BUG, not as the SESSION_NOT_FOUND
+// the spec asserts on.
+type unusedSubscriber struct{}
+
+func (unusedSubscriber) OpenSession(_ context.Context, _ string, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+	return nil, oops.Code("TEST_SUITE_BUG").Errorf("unusedSubscriber.OpenSession invoked: a spec reached the subscriber call without expecting to")
+}
+
+var _ eventbus.Subscriber = unusedSubscriber{}

--- a/test/integration/auth/multi_tab_test.go
+++ b/test/integration/auth/multi_tab_test.go
@@ -15,6 +15,9 @@ import (
 	"connectrpc.com/connect"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/samber/oops"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/holomush/holomush/internal/web"
 	"github.com/holomush/holomush/internal/world"
@@ -498,6 +501,112 @@ var _ = Describe("Multi-tab session isolation — logout in tab 1, action in tab
 		Expect(histResp.GetError()).To(ContainSubstring("session not found"))
 	})
 })
+
+var _ = Describe("Multi-tab session isolation — Subscribe-path post-logout (spec §4.4.5 Subscribe call site)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		// FK-safe wipe of any state from prior specs (deletes locations among
+		// other tables — see auth_suite_test.go cleanupTestData).
+		cleanupTestData(ctx, env.pool)
+
+		// Re-create the guest start-location row so other specs in this file
+		// remain consistent. This spec uses a registered player and does not
+		// hit the guest start-location FK, but we keep the seed parity with
+		// every other Describe in this file.
+		loc := &world.Location{
+			ID:           env.guestStartLocationID,
+			Name:         "Guest Lobby",
+			Description:  "Guest start location for multi-tab integration tests",
+			Type:         world.LocationTypePersistent,
+			ReplayPolicy: world.DefaultReplayPolicy(world.LocationTypePersistent),
+		}
+		Expect(env.locRepo.Create(ctx, loc)).To(Succeed())
+	})
+
+	It("Subscribe rejects a stale token with SESSION_NOT_FOUND before sending any frame", func() {
+		// Companion to the "logout in tab 1, action in tab 2" spec above. That
+		// spec substituted GetCommandHistory for the Subscribe call site
+		// (spec §4.4.5) because Subscribe is server-streaming and awkward to
+		// drive directly from a Ginkgo spec. Both call sites run through
+		// auth.ValidateSessionOwnership at internal/grpc/server.go (Subscribe
+		// at :645, GetCommandHistory at :1261-1278), so the validation path
+		// is identical — but Subscribe's stream-opening machinery (early-return
+		// vs. error-frame, transport-level vs. response-level signal) could
+		// regress independently. This spec pins the wire-level error shape
+		// that the Subscribe handler returns when ownership validation fails.
+
+		// Seed: registered player + character + persisted PlayerSession (gRPC
+		// handler normally persists; auth.Service constructs but does not).
+		username := "subscribe_logout_player"
+		password := "correct horse battery staple"
+		_, playerSession, rawToken, err := env.authService.CreatePlayer(ctx, username, password, username+"@test.local")
+		Expect(err).NotTo(HaveOccurred(), "seed: create player")
+		Expect(rawToken).NotTo(BeEmpty())
+		Expect(env.playerSessionStore.Create(ctx, playerSession)).To(Succeed(),
+			"seed: persist player session so the rawToken resolves")
+
+		player, err := env.playerRepo.GetByUsername(ctx, username)
+		Expect(err).NotTo(HaveOccurred())
+		// world.Character.Name is "letters and spaces only"; avoid hyphens.
+		loc := createTestLocation(ctx, "Subscribe Lobby")
+		char := createTestCharacter(ctx, player.ID, "Subscribe Hero", loc.ID)
+		charID := char.ID.String()
+
+		// Tab 1: select the character → game session exists.
+		selReq := connect.NewRequest(&webv1.WebSelectCharacterRequest{CharacterId: charID})
+		selReq.Header().Set(web.HeaderInjectSessionToken, rawToken)
+		selResp, err := env.webHandler.WebSelectCharacter(ctx, selReq)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(selResp.Msg.GetSuccess()).To(BeTrue(), "select: %s", selResp.Msg.GetErrorMessage())
+		sessionID := selResp.Msg.GetSessionId()
+		Expect(sessionID).NotTo(BeEmpty())
+
+		// Tab 1: WebLogout deletes the PlayerSession + child game sessions.
+		_, err = env.coreServer.Logout(ctx, &corev1.LogoutRequest{PlayerSessionToken: rawToken})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Tab 2: open Subscribe with the now-stale token. MUST return an
+		// error tagged SESSION_NOT_FOUND, and MUST NOT have sent any frame
+		// on the stream before validation fired.
+		stream := &captureSubscribeStream{ctx: ctx}
+		err = env.coreServer.Subscribe(&corev1.SubscribeRequest{
+			SessionId:          sessionID,
+			PlayerSessionToken: rawToken,
+		}, stream)
+		Expect(err).To(HaveOccurred(), "Subscribe MUST surface stale-session error at the transport level")
+
+		var oerr oops.OopsError
+		Expect(errors.As(err, &oerr)).To(BeTrue(), "Subscribe error MUST be an oops error")
+		Expect(oerr.Code()).To(Equal("SESSION_NOT_FOUND"),
+			"Subscribe MUST collapse stale-token failure to enumeration-safe SESSION_NOT_FOUND")
+		Expect(stream.sent).To(BeEmpty(),
+			"Subscribe MUST NOT send any frame before ownership validation fires")
+	})
+})
+
+// captureSubscribeStream is a test double for grpc.ServerStreamingServer that
+// captures sent frames so specs can assert that no data was streamed before an
+// early validation failure. Mirrors the capturingStream pattern in
+// internal/grpc/location_follow_test.go.
+type captureSubscribeStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	sent []*corev1.SubscribeResponse
+}
+
+func (s *captureSubscribeStream) Send(resp *corev1.SubscribeResponse) error {
+	s.sent = append(s.sent, resp)
+	return nil
+}
+
+func (s *captureSubscribeStream) Context() context.Context     { return s.ctx }
+func (s *captureSubscribeStream) SetHeader(_ metadata.MD) error  { return nil }
+func (s *captureSubscribeStream) SendHeader(_ metadata.MD) error { return nil }
+func (s *captureSubscribeStream) SetTrailer(_ metadata.MD)       {}
+func (s *captureSubscribeStream) SendMsg(_ any) error            { return nil }
+func (s *captureSubscribeStream) RecvMsg(_ any) error            { return nil }
 
 var _ = Describe("Pre-deploy WebCheckSession contract", func() {
 	var gw *web.Handler


### PR DESCRIPTION
## Summary

- Add a Multi-tab session isolation Describe in `test/integration/auth/multi_tab_test.go` that drives `env.coreServer.Subscribe` directly with a stale token after `WebLogout` and asserts:
  - Subscribe returns a transport-level error (not a stream frame)
  - The error is oops-coded `SESSION_NOT_FOUND`
  - No `SubscribeResponse` frame is emitted before validation fires
- Wire a stub `eventbus.Subscriber` into the integration suite so Subscribe gets past its early nil-subscriber guard at `internal/grpc/server.go:657` and reaches the ownership-validation branch. The stub's `OpenSession` returns a `TEST_SUITE_BUG`-coded error so a reorder regression in `CoreServer.Subscribe` (validation moved after `OpenSession`) would surface distinctively rather than masquerading as `SESSION_NOT_FOUND`.

## Why

Companion to the existing \"logout in tab 1, action in tab 2\" spec, which substituted `GetCommandHistory` for the Subscribe call site (per spec §4.4.5 allowance) because Subscribe is server-streaming and awkward to drive directly. Both call sites share `auth.ValidateSessionOwnership`, so the validation path was already covered — this spec specifically pins the wire-level error shape so a regression in Subscribe's framing alone (without changing the validation) would be caught.

## Follow-up filed

`holomush-lyw1` (P3): reorder Subscribe's nil-subscriber guard vs. ownership validation. The current ordering returns `NOT_CONFIGURED` before validation runs — in production this guard cannot fire (subscriber is always wired), but theoretically leaks server-config state to a stale-token caller. Test wiring in this PR mitigates the test-side risk of the ordering being silently changed.

## Test plan

- [x] \`task pr-prep\` GREEN (62 e2e tests passing, all CI gates including new spec)
- [x] adversarial code-reviewer agent: READY verdict, two non-blocking findings (one comment line-citation fix applied; one follow-up bead filed)
- [x] Verified \`captureSubscribeStream\` interface coverage against \`google.golang.org/grpc.ServerStreamingServer[T]\`
- [x] Verified \`oops.OopsError.Code()\` returns the deepest code, and Subscribe at server.go:675 creates a fresh error (no shadowing)

Closes holomush-9q8n.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test infrastructure with improved authentication validation and error detection capabilities.
  * Added integration test verifying proper session isolation and stale token rejection after logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->