### PR TITLE
chore(claude): wire WorktreeCreate/WorktreeRemove hooks for jj workspace isolation

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# WorktreeCreate hook: maps Claude Code's `isolation: "worktree"` request to
+# a fresh jj workspace under <repo-parent>/.worktrees/<name> via the existing
+# `task workspace:new -- <name>` primitive (which is idempotent and fetches
+# main@origin first).
+#
+# Contract (from https://code.claude.com/docs/en/hooks.md):
+#   - Stdin: JSON event with common fields (session_id, cwd, hook_event_name).
+#     Runtime-provided event-specific fields (e.g. worktree_path, base_ref)
+#     are not part of the public spec and may vary; we read them tolerantly.
+#   - Stdout (success): absolute path of the worktree, plain text.
+#   - Exit non-zero: aborts subagent creation.
+#
+# Strategy:
+#   1. Read stdin JSON.
+#   2. Derive a workspace NAME:
+#        - If runtime provided worktree_path/.path/.name, use its basename.
+#        - Sanitize to match the [A-Za-z0-9._-]+ regex `task workspace:new`
+#          enforces; fall back to "agent-<short-session-id>" if empty.
+#   3. Run `task workspace:new -- <NAME>`; its stdout is the absolute path.
+#   4. Print the absolute path on stdout.
+#
+# All diagnostic output goes to stderr so it doesn't pollute the path
+# stdout the runtime parses.
+
+set -euo pipefail
+
+# jq is required. With jq missing, parse failures would silently invent
+# `agent-<datetime>` and ignore the runtime-supplied worktree_path,
+# producing a workspace at a path the runtime didn't ask for. Fail loud:
+# WorktreeCreate is blocking, so non-zero exit aborts the subagent
+# dispatch — preferable to a name mismatch.
+command -v jq >/dev/null || {
+  echo "worktree-create.sh: jq not found in PATH; required to parse hook payload" >&2
+  exit 1
+}
+
+# Read stdin JSON (may be empty if invoked manually for testing).
+INPUT="$(cat || true)"
+
+# Tolerant extraction. jq's // operator falls through nulls in order.
+RAW_NAME="$(
+  printf '%s' "$INPUT" | jq -r '
+    (.worktree_path // .worktreePath // .path // .name // "") as $v
+    | $v | sub(".*/"; "")
+  '
+)"
+
+SHORT_SID="$(
+  printf '%s' "$INPUT" | jq -r '.session_id // ""' \
+    | tr -d -c 'A-Za-z0-9' \
+    | cut -c1-8
+)"
+
+# Sanitize: strip anything outside [A-Za-z0-9._-]; replace runs with '-'.
+SAFE_NAME="$(printf '%s' "$RAW_NAME" | LC_ALL=C tr -c 'A-Za-z0-9._-' '-' | sed -E 's/^-+|-+$//g; s/-+/-/g')"
+
+# Reject `.`, `..`, anything containing `..`, or empty.
+case "$SAFE_NAME" in
+  ''|'.'|'..'|*..*) SAFE_NAME='' ;;
+esac
+
+if [ -z "$SAFE_NAME" ]; then
+  if [ -n "$SHORT_SID" ]; then
+    SAFE_NAME="agent-${SHORT_SID}"
+  else
+    SAFE_NAME="agent-$(date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+# Resolve a working directory we can run task from. The hook's cwd may be
+# any worktree (or the main repo); jj workspace root works in either.
+WS_ROOT="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$WS_ROOT" ]; then
+  echo "ERROR: worktree-create.sh: not in a jj repo (jj workspace root failed)" >&2
+  exit 1
+fi
+cd "$WS_ROOT"
+
+# `task workspace:new` is idempotent: if .worktrees/<NAME> already exists it
+# prints the path and exits 0. `task` already routes its diagnostic echoes
+# to fd 2 by default, so capturing stdout via $(...) gives us path-only on
+# our stdout. The post-check is defense-in-depth against future changes
+# to the `workspace:new` task definition.
+NEW_PATH="$(task workspace:new -- "$SAFE_NAME" | tail -n 1)"
+
+if [ -z "$NEW_PATH" ] || [ ! -d "$NEW_PATH" ]; then
+  echo "ERROR: worktree-create.sh: task workspace:new produced no usable path (got: '${NEW_PATH}')" >&2
+  exit 1
+fi
+
+printf '%s\n' "$NEW_PATH"

--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# WorktreeRemove hook: cleans up the jj workspace + on-disk directory that
+# WorktreeCreate provisioned. Mirrors the manual cleanup documented in
+# CLAUDE.md "Landing the Plane":
+#
+#     cd <repo-root>
+#     jj workspace forget <name>
+#     rm -rf <path>
+#
+# Contract (from https://code.claude.com/docs/en/hooks.md):
+#   - Fire-and-forget. No decision control. Failures are logged in debug
+#     mode only; the runtime proceeds regardless. We still try to be
+#     idempotent and silent on the happy path.
+#   - Stdin: JSON event with common fields and (per runtime) worktree_path.
+#
+# Safety:
+#   - We refuse to touch any path not strictly under the project's
+#     <repo-parent>/.worktrees/ directory. The guard is symlink-resolved
+#     via `pwd -P` and rejects `..` segments lexically *before* resolution,
+#     because a non-existent path with `..` would otherwise fall through
+#     `cd` and bypass a pure prefix check (`/parent/.worktrees/../../etc`
+#     lexically matches `/parent/.worktrees/*`).
+
+set -euo pipefail
+
+# jq is required — silently inventing names on parse failure would let a
+# spoofed/missing payload still trigger work. Be loud and exit non-zero.
+command -v jq >/dev/null || {
+  echo "worktree-remove.sh: jq not found in PATH; cannot parse hook payload" >&2
+  exit 0  # fire-and-forget: do not block runtime
+}
+
+INPUT="$(cat || true)"
+
+WT_PATH="$(printf '%s' "$INPUT" | jq -r '.worktree_path // .worktreePath // .path // ""')"
+
+if [ -z "$WT_PATH" ]; then
+  echo "worktree-remove.sh: no worktree_path in payload; nothing to do" >&2
+  exit 0
+fi
+
+# Lexical reject of `..` segments BEFORE any path resolution. This is the
+# load-bearing safety check — `pwd -P` cannot canonicalize a non-existent
+# path on macOS (no GNU `realpath -m`), so we must refuse traversal
+# tokens up front. Trailing slash is also rejected to avoid an empty
+# basename downstream. Match only true segment-boundary `..` so that
+# legitimate filenames containing `..` (e.g. `acme..labs`) are not
+# falsely refused.
+case "$WT_PATH" in
+  ..|*/..|*/../*|*/)
+    echo "worktree-remove.sh: refusing path with '..' segments or trailing '/': $WT_PATH" >&2
+    exit 0
+    ;;
+esac
+
+# Require the path to actually exist on disk before we touch it. If it
+# doesn't, there's nothing to clean up and we cannot symlink-resolve.
+if [ ! -d "$WT_PATH" ]; then
+  echo "worktree-remove.sh: path does not exist or is not a directory: $WT_PATH" >&2
+  exit 0
+fi
+
+# Resolve repo root and the .worktrees parent. jj workspace root works from
+# any workspace, including the one being removed (we'll cd out of it before
+# calling `jj workspace forget`).
+WS_ROOT="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$WS_ROOT" ]; then
+  echo "worktree-remove.sh: not in a jj repo; skipping" >&2
+  exit 0
+fi
+cd "$WS_ROOT"
+# shellcheck source=../../scripts/jj-main-repo.sh
+. "$WS_ROOT/scripts/jj-main-repo.sh"
+
+# WORKTREES is set by jj-main-repo.sh as <repo-parent>/.worktrees. Both
+# sides are now symlink-resolved (the existence check above guarantees
+# the cd succeeds).
+ABS_WT="$(cd "$WT_PATH" && pwd -P)"
+ABS_PARENT="$(cd "$WORKTREES" && pwd -P)"
+
+case "$ABS_WT" in
+  "$ABS_PARENT"/*) : ;;
+  *)
+    echo "worktree-remove.sh: refusing to remove '$ABS_WT' — not under '$ABS_PARENT'" >&2
+    exit 0
+    ;;
+esac
+
+NAME="${ABS_WT##*/}"
+[ -n "$NAME" ] || {
+  echo "worktree-remove.sh: empty workspace name from path '$ABS_WT'" >&2
+  exit 0
+}
+
+# Run from the main repo so `jj workspace forget` is unambiguous and we
+# don't try to forget the workspace whose working copy is our cwd.
+cd "$MAIN_REPO"
+
+# Order: rm-rf first, then jj workspace forget. The dominant failure mode
+# of two-step cleanup is "step 1 succeeds, step 2 fails". With this order
+# the recoverable orphan is a dangling jj workspace ref (which `jj
+# workspace forget` cleanly handles on next attempt). The opposite order
+# leaves an on-disk orphan dir under .worktrees/ that `task workspace:new`
+# would silently re-adopt via its idempotent `[ -d "$TARGET" ]` branch.
+rm -rf -- "$ABS_WT"
+jj workspace forget "$NAME" || \
+  echo "worktree-remove.sh: jj workspace forget '$NAME' failed (already forgotten?)" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,26 @@
         ],
         "matcher": ""
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-create.sh",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-remove.sh",
+            "type": "command"
+          }
+        ]
+      }
     ]
   },
   "permissions": {


### PR DESCRIPTION
## Summary

Maps Claude Code's Agent-tool `isolation: "worktree"` option to a fresh `jj workspace` under `<repo-parent>/.worktrees/<name>` via the existing `task workspace:new -- <name>` primitive. Closes holomush-8722.

**Why:** Without these hooks, `isolation: "worktree"` errors with *"not in a git repository and no WorktreeCreate hooks are configured"* — Claude Code's default worktree path is git-only. Subagents that write to disk (review agents persisting `.claude/agent-memory/`, analysis agents writing reports) without isolation snapshot into the parent session's jj workspace concurrently with the parent's edits, producing divergent commits with the same change ID. Hit live during the pr-prep concurrency-safety design session on 2026-04-26 — required `jj edit + jj abandon` recovery.

## Changes

- `.claude/hooks/worktree-create.sh` — wraps `task workspace:new`, emits absolute path on stdout (the runtime contract). Loud-fails when `jq` is missing.
- `.claude/hooks/worktree-remove.sh` — mirrors CLAUDE.md "Landing the Plane" cleanup. Multi-layer safety:
  - Lexical reject of `..` segments and trailing slashes (`pwd -P` cannot canonicalize non-existent paths on macOS — no GNU `realpath -m`).
  - Require directory to exist on disk before touching it.
  - Symlink-resolved prefix check against `<repo-parent>/.worktrees/`.
  - Empty-name guard before `jj workspace forget`.
  - Order: `rm -rf` first, then `jj workspace forget`. The dominant failure mode of two-step cleanup is "step 1 succeeds, step 2 fails"; this order leaves a recoverable dangling jj ref instead of an orphan dir that `task workspace:new`'s idempotent branch would silently re-adopt.
- `.claude/settings.json` — register both hooks under `WorktreeCreate` / `WorktreeRemove` keys (additive, all existing entries preserved verbatim).

## Test plan

- [x] Pipe-tested `worktree-create.sh` happy path → absolute path on stdout, exit 0.
- [x] Pipe-tested idempotence — re-run on existing workspace returns same path.
- [x] Pipe-tested `worktree-remove.sh` round-trip — workspace gone from `jj workspace list`, directory removed.
- [x] Adversarial pipe-tests against the safety guard:
  - \`..\` traversal in non-existent path: refused.
  - Trailing slash in non-existent path: refused.
  - Path entirely outside \`.worktrees/\`: refused.
  - Symlink escape from inside \`.worktrees/\`: refused (resolution via \`pwd -P\`).
- [x] \`shellcheck\` clean (excluding informational SC1091 dynamic-source advisory, matching existing \`warn-default-workspace.sh\` convention).
- [x] \`task pr-prep\` passed (schema, license, plugin builds, lint, fmt, 6387 unit tests, 681 integration tests, 61 E2E tests). Initial E2E run hit a Docker infra flake (gateway DNS, postgres connection terminated, SIGKILL on \`docker compose down\`); rerun passed clean in 84.5s.
- [ ] **Live verification deferred to post-merge:** the runtime's settings watcher only re-reads the file it loaded at session start, so confirming \`isolation: \"worktree\"\` actually triggers these hooks requires a fresh session whose \`CLAUDE_PROJECT_DIR\` includes the new keys.

## Adversarial review

\`code-reviewer\` flagged two blocking findings on the first iteration; both fixed in the same revision:

1. **Critical:** \`cd \"\$WT_PATH\" 2>/dev/null && pwd -P || printf '%s' \"\$WT_PATH\"\` fell through to the unresolved literal for non-existent paths, so \`..\` segments survived into the prefix check (\`/parent/.worktrees/../../escape\` lexically matches \`/parent/.worktrees/*\`).
2. **High:** Same fallback + trailing slash → \`\${ABS_WT##*/}\` empty → \`jj workspace forget \"\"\`.

Three lower-severity items (loud \`jq\`-missing, drop no-op \`2>&2\` redirects, reorder \`rm\` before \`forget\`) also addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated creation of isolated workspaces with name sanitization and deterministic fallback naming when needed.
  * Automated, non-blocking removal of isolated workspaces with safety checks, path validation, and cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->