### PR TITLE
test(grpc): close patch coverage gaps from PR #271

### DIFF
--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -1192,6 +1192,129 @@ func TestCheckPlayerSessionInfraFailureNotTranslated(t *testing.T) {
 	assert.Equal(t, "NOT_CONFIGURED", oopsErr.Code())
 }
 
+// TestIsPlayerSessionAuthError covers the predicate's branches that the
+// multi-tab session isolation work (PR #271) added as part of the gateway's
+// cookie-collision gate. It runs through each of the four branches:
+//   - errors.Is matches auth.ErrNotFound (sentinel error → true)
+//   - non-oops error → false
+//   - oops error with a known auth-failure code → true
+//   - oops error with an unrelated code → false
+func TestIsPlayerSessionAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "returns true for auth.ErrNotFound sentinel",
+			err:  auth.ErrNotFound,
+			want: true,
+		},
+		{
+			name: "returns false for plain stdlib error that is not an oops",
+			err:  errors.New("transport flake"),
+			want: false,
+		},
+		{
+			name: "returns true for oops error coded PLAYER_SESSION_NOT_FOUND",
+			err:  samberOops.Code("PLAYER_SESSION_NOT_FOUND").Errorf("unknown token"),
+			want: true,
+		},
+		{
+			name: "returns true for oops error coded PLAYER_SESSION_EXPIRED",
+			err:  samberOops.Code("PLAYER_SESSION_EXPIRED").Errorf("expired token"),
+			want: true,
+		},
+		{
+			name: "returns true for oops error coded NOT_CONFIGURED",
+			err:  samberOops.Code("NOT_CONFIGURED").Errorf("session service not configured"),
+			want: true,
+		},
+		{
+			name: "returns false for oops error with unrelated code",
+			err:  samberOops.Code("DATABASE_UNAVAILABLE").Errorf("pg down"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPlayerSessionAuthError(tt.err))
+		})
+	}
+}
+
+// TestCheckPlayerSessionWrapsPlayerLookupFailureAsPlayerLookupFailed pins the
+// failure-shape contract for the multi-tab session isolation work: when the
+// player session resolves but the underlying player record lookup fails (e.g.,
+// pg connection error), the handler MUST surface a PLAYER_LOOKUP_FAILED oops
+// code rather than leaking the raw repository error.
+func TestCheckPlayerSessionWrapsPlayerLookupFailureAsPlayerLookupFailed(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	ps := makePlayerSession(playerID)
+	sessionRepo := setupSessionRepo(t, ps)
+
+	playerRepo := authmocks.NewMockPlayerRepository(t)
+	playerRepo.EXPECT().GetByID(mock.Anything, playerID).
+		Return(nil, errors.New("connection refused"))
+
+	server := &CoreServer{
+		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:      session.NewMemStore(),
+		playerSessionRepo: sessionRepo,
+		playerRepo:        playerRepo,
+	}
+
+	resp, err := server.CheckPlayerSession(ctx, &corev1.CheckPlayerSessionRequest{
+		PlayerSessionToken: validToken,
+	})
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var oopsErr samberOops.OopsError
+	require.ErrorAs(t, err, &oopsErr)
+	assert.Equal(t, "PLAYER_LOOKUP_FAILED", oopsErr.Code())
+}
+
+// TestCheckPlayerSessionWrapsCharacterLookupFailureAsCharacterLookupFailed pins
+// the failure-shape contract when player resolution succeeds but the character
+// summary build (charRepo.ListByPlayer) fails. The handler MUST surface a
+// CHARACTER_LOOKUP_FAILED oops code so the client can distinguish auth
+// failures from infrastructure failures in this code path.
+func TestCheckPlayerSessionWrapsCharacterLookupFailureAsCharacterLookupFailed(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	ps := makePlayerSession(playerID)
+	sessionRepo := setupSessionRepo(t, ps)
+
+	playerRepo := authmocks.NewMockPlayerRepository(t)
+	playerRepo.EXPECT().GetByID(mock.Anything, playerID).
+		Return(&auth.Player{ID: playerID, Username: "alice"}, nil)
+
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return(nil, errors.New("char repo down"))
+
+	server := &CoreServer{
+		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:      session.NewMemStore(),
+		playerSessionRepo: sessionRepo,
+		playerRepo:        playerRepo,
+		charRepo:          charRepo,
+	}
+
+	resp, err := server.CheckPlayerSession(ctx, &corev1.CheckPlayerSessionRequest{
+		PlayerSessionToken: validToken,
+	})
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var oopsErr samberOops.OopsError
+	require.ErrorAs(t, err, &oopsErr)
+	assert.Equal(t, "CHARACTER_LOOKUP_FAILED", oopsErr.Code())
+}
+
 // --- AuthenticatePlayer additional paths ---
 
 func TestAuthenticatePlayer_SessionRepoCreateFails(t *testing.T) {

--- a/internal/grpc/client_test.go
+++ b/internal/grpc/client_test.go
@@ -580,3 +580,63 @@ func TestTranslateCheckPlayerSessionErrPreservesAuthFailureAcrossWire(t *testing
 		})
 	}
 }
+
+// TestNewClientWrapsURLParseFailureAsConnectionFailed pins the defensive
+// branch where grpc.NewClient itself rejects the address (URL-parse error).
+// In production this branch should never fire — addresses come from validated
+// config — but the wrap matters when it does so callers see a CONNECTION_FAILED
+// oops code rather than the raw grpc parse error. \x00 is rejected by net/url's
+// invalid-control-character check; this is the only consistent way to provoke
+// grpc.NewClient into returning an error rather than deferring to first-RPC.
+func TestNewClientWrapsURLParseFailureAsConnectionFailed(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := NewClient(ctx, ClientConfig{Address: "\x00"})
+
+	require.Error(t, err)
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "constructor failure must surface as an oops error")
+	assert.Equal(t, "CONNECTION_FAILED", oopsErr.Code())
+}
+
+// TestClientSubscribeWrapsImmediateRPCErrorAsRPCFailed pins the synchronous
+// error path on Client.Subscribe — when the server-side handler returns an
+// error before any frame is sent, c.client.Subscribe returns the error from
+// the initial RPC dispatch and the wrapper MUST surface RPC_FAILED. The
+// existing TestClient_Subscribe_StreamError covers the streaming-error case
+// (error surfaces from stream.Recv after Subscribe returns nil); this test
+// covers the case where Subscribe itself returns the error.
+//
+// In practice grpc-go's server-streaming dispatch typically returns
+// (nonNilStream, nil) and surfaces handler errors on the next Recv. To force
+// the synchronous-error shape that this branch handles, drive the wrapper
+// with a fake gRPC client whose Subscribe returns (nil, err) directly.
+func TestClientSubscribeWrapsImmediateRPCErrorAsRPCFailed(t *testing.T) {
+	ctx := context.Background()
+
+	wrapper := &Client{
+		client: &fakeCoreClient{
+			subscribeErr: status.Error(codes.Internal, "synthetic dispatch failure"),
+		},
+	}
+
+	_, err := wrapper.Subscribe(ctx, &corev1.SubscribeRequest{SessionId: "s"})
+
+	require.Error(t, err)
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "Subscribe error must surface as oops")
+	assert.Equal(t, "RPC_FAILED", oopsErr.Code())
+}
+
+// fakeCoreClient is a minimal corev1.CoreServiceClient that lets a single
+// test exercise the wrapper-level error branch on Client.Subscribe without
+// spinning up a real grpc.Server. Only Subscribe is implemented; other
+// methods panic if invoked, which would surface a test boundary violation.
+type fakeCoreClient struct {
+	corev1.CoreServiceClient
+	subscribeErr error
+}
+
+func (f *fakeCoreClient) Subscribe(_ context.Context, _ *corev1.SubscribeRequest, _ ...grpc.CallOption) (corev1.CoreService_SubscribeClient, error) {
+	return nil, f.subscribeErr
+}


### PR DESCRIPTION
## Summary

Bring four functions touched by the multi-tab session isolation work (#271) to 100% statement coverage by adding targeted tests for the defensive error-handling branches that codecov flagged as missing patch coverage:

| Function | Before | After |
|---|---|---|
| \`isPlayerSessionAuthError\` | 75.0% | **100.0%** |
| \`CheckPlayerSession\` | 86.7% | **100.0%** |
| \`NewClient\` | 92.9% | **100.0%** |
| \`Subscribe\` | 75.0% | **100.0%** |

Per-package \`internal/grpc\` coverage moves from 75.2% → 75.9%.

## Tests added

- \`TestIsPlayerSessionAuthError\` — table-driven, 6 cases covering \`auth.ErrNotFound\` sentinel, non-oops stdlib errors, three known auth-failure oops codes, and an unrelated oops code.
- \`TestCheckPlayerSessionWrapsPlayerLookupFailureAsPlayerLookupFailed\` — pins the failure shape of the \`PLAYER_LOOKUP_FAILED\` branch (mocked playerRepo returns connection error).
- \`TestCheckPlayerSessionWrapsCharacterLookupFailureAsCharacterLookupFailed\` — pins the \`CHARACTER_LOOKUP_FAILED\` branch (mocked charRepo returns error).
- \`TestNewClientWrapsURLParseFailureAsConnectionFailed\` — passes \`\\x00\` (a control character that \`net/url\` rejects) to provoke \`grpc.NewClient\` itself into returning an error rather than deferring to first-RPC; this is the only consistent way to exercise the constructor's defensive \`CONNECTION_FAILED\` wrap.
- \`TestClientSubscribeWrapsImmediateRPCErrorAsRPCFailed\` — uses a tiny \`fakeCoreClient\` (embeds \`corev1.CoreServiceClient\`, only implements \`Subscribe\`) to drive the wrapper's synchronous-error branch where \`c.client.Subscribe\` returns the error rather than surfacing it on \`Recv\`.

## Out of scope

- Web/auth_handlers.go portion of the same codecov gap was already closed in PR #271 round-2 autofix.
- \`Close\` (75.0%) is left at status quo — the \`conn.Close()\` error path is genuinely defensive in production grpc-go ClientConn (close is idempotent and rarely errors); exercising it would require a fake \`net.Conn\` wrapper of disproportionate cost.

## Test plan

- [x] \`task pr-prep\` GREEN (62 e2e tests passing, all CI gates)
- [x] adversarial code-reviewer agent: READY verdict, three non-blocking style observations (no required fixes)
- [x] Independent coverage verification confirmed via \`go tool cover -func\`

Closes holomush-9q8n.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for authentication error handling and client connection error scenarios to strengthen system reliability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->