### PR TITLE
fix(beads): make bd work in jj workspaces (k98d, i15i)

### DIFF
--- a/.claude/hooks/enforce-bd-beads-dir.sh
+++ b/.claude/hooks/enforce-bd-beads-dir.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PreToolUse hook: keep `bd` invocations from a jj workspace from failing
+# with the unhelpful "no beads database found" error.
+#
+# Each jj workspace under `<repo-parent>/.worktrees/<name>/` materialises an
+# empty `.beads/` (only the tracked config + .gitignore land there; the Dolt
+# database lives in the main repo's `.beads/dolt/`). When `bd` is invoked
+# from such a workspace, its lookup terminates on the empty `.beads/` and
+# fails. This hook intercepts the failure mode at the Bash boundary so the
+# assistant gets an actionable message instead of having to debug bd's
+# resolution logic.
+#
+# `task workspace:new` (and bd's own `.beads/redirect` mechanism) is the
+# proper fix: when a workspace is created we write `.beads/redirect`
+# pointing at the main repo's `.beads/`. This hook detects that the fix is
+# in place and stays silent. It only fires for legacy workspaces created
+# before the redirect-writing change landed.
+#
+# Error strategy: same as enforce-task-runner.sh — fail open on parse
+# errors (bd command proceeds and bd's own error surfaces if it still
+# can't find the DB), block reliably when we know there's a problem.
+
+set -uo pipefail
+
+# --- Parse phase: fail open on malformed input ---
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || {
+  echo "enforce-bd-beads-dir: failed to parse input — enforcement disabled for this command" >&2
+  exit 0
+}
+
+[[ -z "$COMMAND" ]] && exit 0
+
+# --- Enforcement phase ---
+trap - ERR
+
+strip_leading_ws() {
+  local s="$1"
+  echo "${s#"${s%%[![:space:]]*}"}"
+}
+
+# Returns 0 if the segment's env-var prefix sets BEADS_DIR, else 1.
+# Matches BEADS_DIR=anything (quoted or not) before the first non-assignment word.
+has_beads_dir_env() {
+  local s
+  s=$(strip_leading_ws "$1")
+  while [[ "$s" =~ ^([A-Za-z_][A-Za-z_0-9]*)=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
+    if [[ "${BASH_REMATCH[1]}" == "BEADS_DIR" ]]; then
+      return 0
+    fi
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  done
+  return 1
+}
+
+# Same env-stripping shape as enforce-task-runner.sh::first_cmd_word, but
+# duplicated rather than sourced — the existing helper inlines its
+# state-mutation logic, and copying keeps each hook independently
+# testable and replaceable.
+strip_env_vars() {
+  local s="$1"
+  while [[ "$s" =~ ^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  done
+  echo "$s"
+}
+
+first_cmd_word() {
+  local segment="$1"
+  segment=$(strip_leading_ws "$segment")
+  segment=$(strip_env_vars "$segment")
+  local word="${segment%% *}"
+  while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup)$ ]]; do
+    segment="${segment#"$word"}"
+    segment=$(strip_leading_ws "$segment")
+    while [[ "${segment%% *}" == -* ]]; do
+      segment="${segment#"${segment%% *}"}"
+      segment=$(strip_leading_ws "$segment")
+    done
+    segment=$(strip_env_vars "$segment")
+    word="${segment%% *}"
+  done
+  echo "$word"
+}
+
+# Resolve workspace context. If we can't determine the main repo, fail
+# open — bd's own error message will surface for the user.
+WS_ROOT="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$WS_ROOT" ] || [ ! -e "$WS_ROOT/scripts/jj-main-repo.sh" ]; then
+  exit 0
+fi
+
+# shellcheck source=../../scripts/jj-main-repo.sh
+( cd "$WS_ROOT" && . "$WS_ROOT/scripts/jj-main-repo.sh" >/dev/null 2>&1 ) || exit 0
+cd "$WS_ROOT" || exit 0
+# shellcheck source=../../scripts/jj-main-repo.sh
+. "$WS_ROOT/scripts/jj-main-repo.sh"
+
+# In the main repo? bd's lookup will find the real .beads/ in cwd. Allow.
+if [ "${IS_DEFAULT:-no}" = "yes" ]; then
+  exit 0
+fi
+
+# Proper fix already in place for this workspace? Allow.
+# - .beads/redirect: bd's own per-worktree override (preferred form)
+# - .beads/dolt/: the Dolt directory got materialised here somehow
+if [ -f "$WS_ROOT/.beads/redirect" ] || [ -d "$WS_ROOT/.beads/dolt" ]; then
+  exit 0
+fi
+
+# Same segment-splitting pattern as enforce-task-runner.sh.
+SEGMENTS=$(echo "$COMMAND" | awk '{gsub(/ *&& */, "\n"); gsub(/ *; */, "\n"); gsub(/ *\|\| */, "\n"); print}')
+
+while IFS= read -r segment; do
+  [[ -z "$segment" ]] && continue
+  before_pipe="${segment%%|*}"
+
+  # If the user explicitly set BEADS_DIR=... in this segment, trust them.
+  if has_beads_dir_env "$before_pipe"; then
+    continue
+  fi
+
+  word=$(first_cmd_word "$before_pipe")
+  if [ "$word" = "bd" ]; then
+    cat >&2 <<EOF
+\`bd\` invoked from a jj workspace ($WS_ROOT)
+without BEADS_DIR set. The workspace's .beads/ is empty; bd's lookup will
+fail with "no beads database found".
+
+Pick one:
+
+  • Prepend BEADS_DIR to this single command:
+        BEADS_DIR='$MAIN_REPO/.beads' $segment
+
+  • Permanent fix for this workspace (one-time, then bd works bare):
+        printf '%s\n' '$MAIN_REPO/.beads' > '$WS_ROOT/.beads/redirect'
+
+The permanent fix uses bd's own per-worktree redirect mechanism;
+\`task workspace:new\` writes it automatically for new workspaces, but
+this workspace predates that change (holomush-k98d).
+EOF
+    exit 2
+  fi
+done <<< "$SEGMENTS"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,10 @@
           {
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-task-runner.sh",
             "type": "command"
+          },
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-bd-beads-dir.sh",
+            "type": "command"
           }
         ],
         "matcher": "Bash"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -624,15 +624,27 @@ tasks:
 
         TARGET="$WORKTREES/$NAME"
 
-        # Idempotent pre-check
-        if [ -d "$TARGET" ]; then
-          echo "$TARGET"
-          exit 0
+        # Create the workspace if it doesn't exist. The redirect-file step
+        # below runs unconditionally so older workspaces self-heal when
+        # task workspace:new is re-invoked for them.
+        if [ ! -d "$TARGET" ]; then
+          jj git fetch >&2
+          jj workspace add "$TARGET" --name "$NAME" -r main@origin >&2
         fi
 
-        # Fresh workspace path
-        jj git fetch >&2
-        jj workspace add "$TARGET" --name "$NAME" -r main@origin >&2
+        # Point bd at the main repo's .beads/. Each jj workspace
+        # materialises an empty .beads/ (only tracked config + .gitignore;
+        # the Dolt DB lives in the main repo's .beads/dolt/), so bd run
+        # from the workspace would fail with "no beads database found".
+        # `.beads/redirect` is bd's documented per-worktree override and
+        # is already in .beads/.gitignore, so it never gets committed
+        # (holomush-k98d). Don't overwrite an existing redirect — a user
+        # may have repointed it at a federation peer or alternate DB.
+        mkdir -p "$TARGET/.beads"
+        if [ ! -f "$TARGET/.beads/redirect" ]; then
+          printf '%s\n' "$MAIN_REPO/.beads" > "$TARGET/.beads/redirect"
+        fi
+
         echo "$TARGET"
 
   # ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two-part fix for the recurring "no beads database found" failure when `bd` is invoked from a jj workspace under `<repo-parent>/.worktrees/<name>/`. Each workspace materialises an empty `.beads/` (only tracked config + .gitignore land there; the Dolt DB lives in main `.beads/dolt/`), so bd's lookup terminates on the empty workspace `.beads/` and fails.

### 1. Proper fix — `task workspace:new` writes `.beads/redirect` (holomush-k98d)

`bd` already supports a `.beads/redirect` file as its documented per-worktree override (verified by string-grepping the bd binary: "NEW: Per-worktree .beads/redirect override" / "FIX: MCP plugin follows .beads/redirect files"). The file is already in `.beads/.gitignore` (lines 30-32) so it never gets committed.

`task workspace:new` now writes the file unconditionally after `jj workspace add`, but skips when a redirect already exists — so older workspaces self-heal on re-invocation while a user-customised redirect (e.g., to a federation peer's DB) is preserved.

### 2. Stopgap hook — pre-empt the failure (holomush-i15i)

New PreToolUse Bash hook `.claude/hooks/enforce-bd-beads-dir.sh` blocks `bd` invocations from a jj workspace when neither `BEADS_DIR=` is set in the env prefix nor `.beads/redirect`/`.beads/dolt/` exists, with an actionable message pointing to the two valid fixes. Self-deactivates once the redirect is in place — pure safety net for legacy workspaces that predate the workspace:new change.

## Test plan

- [x] `bd ready` works from this workspace via the redirect file (live-tested)
- [x] Hook blocks bare `bd` when no redirect (live-tested all branches)
- [x] Hook passes when `BEADS_DIR=...` is set in the env prefix
- [x] Hook passes when `.beads/redirect` exists
- [x] Re-running `task workspace:new -- <existing>` does not clobber a hand-customised redirect
- [x] Adversarial `code-reviewer` agent: READY, 5 low/non-blocking findings (2 inherited from `enforce-task-runner.sh`, 2 polished, 1 non-issue)
- [x] `task pr-prep` green (lint + format + schema + license + unit + integration + E2E 62/62)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved workspace initialization with self-healing capabilities that automatically repair and configure existing worktrees, eliminating manual cleanup requirements.
  * Introduced workspace configuration validation to ensure consistent build directory setup across all development environments and prevent misconfiguration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->