### PR TITLE
fix(beads): make gh CLI work in jj workspaces (kwwu)

### DIFF
--- a/.claude/hooks/enforce-bd-beads-dir.sh
+++ b/.claude/hooks/enforce-bd-beads-dir.sh
@@ -44,6 +44,31 @@ strip_leading_ws() {
   echo "${s#"${s%%[![:space:]]*}"}"
 }
 
+# Whitespace-aware first-token extraction. ${seg%% *} only splits on
+# space, so `time\tbd ready` would slip through as the single word
+# "time\tbd". `read` honours IFS (default: space + tab + newline).
+first_token() {
+  local _w _rest
+  read -r _w _rest <<< "$1"
+  echo "$_w"
+}
+
+# Returns 0 if the WHOLE segment is a standalone BEADS_DIR assignment
+# (with optional `export`). Used to track `export BEADS_DIR=…` followed
+# by `bd …` in a later segment.
+is_standalone_beads_dir_assignment() {
+  local s
+  s=$(strip_leading_ws "$1")
+  if [[ "$s" =~ ^export[[:space:]]+ ]]; then
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  fi
+  if [[ "$s" =~ ^BEADS_DIR=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]]*$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
 # Returns 0 if the segment's env-var prefix sets BEADS_DIR, else 1.
 # Matches BEADS_DIR=anything (quoted or not) before the first non-assignment word.
 has_beads_dir_env() {
@@ -76,16 +101,20 @@ first_cmd_word() {
   local segment="$1"
   segment=$(strip_leading_ws "$segment")
   segment=$(strip_env_vars "$segment")
-  local word="${segment%% *}"
-  while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup)$ ]]; do
+  local word
+  word=$(first_token "$segment")
+  while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup|time|builtin)$ ]]; do
     segment="${segment#"$word"}"
     segment=$(strip_leading_ws "$segment")
-    while [[ "${segment%% *}" == -* ]]; do
-      segment="${segment#"${segment%% *}"}"
+    local peek
+    peek=$(first_token "$segment")
+    while [[ "$peek" == -* ]]; do
+      segment="${segment#"$peek"}"
       segment=$(strip_leading_ws "$segment")
+      peek=$(first_token "$segment")
     done
     segment=$(strip_env_vars "$segment")
-    word="${segment%% *}"
+    word=$(first_token "$segment")
   done
   echo "$word"
 }
@@ -118,17 +147,37 @@ fi
 # Same segment-splitting pattern as enforce-task-runner.sh.
 SEGMENTS=$(echo "$COMMAND" | awk '{gsub(/ *&& */, "\n"); gsub(/ *; */, "\n"); gsub(/ *\|\| */, "\n"); print}')
 
+# Track whether an earlier segment exported BEADS_DIR so chained
+# commands like `export BEADS_DIR=...; bd ready` aren't false-positive
+# blocked.
+beads_dir_seen=0
+
 while IFS= read -r segment; do
   [[ -z "$segment" ]] && continue
-  before_pipe="${segment%%|*}"
 
-  # If the user explicitly set BEADS_DIR=... in this segment, trust them.
-  if has_beads_dir_env "$before_pipe"; then
+  # Standalone BEADS_DIR assignment in a prior segment opts out of the gate.
+  if is_standalone_beads_dir_assignment "$segment"; then
+    beads_dir_seen=1
     continue
   fi
 
-  word=$(first_cmd_word "$before_pipe")
-  if [ "$word" = "bd" ]; then
+  # Inspect every component of the pipeline, not just the leftmost.
+  # `git log | bd ...` would otherwise silently bypass the gate.
+  PIPE_PARTS=$(printf '%s\n' "$segment" | awk '{gsub(/ *\| */, "\n"); print}')
+  triggered_part=""
+  while IFS= read -r part; do
+    [[ -z "$part" ]] && continue
+    if has_beads_dir_env "$part" || [[ $beads_dir_seen -eq 1 ]]; then
+      continue
+    fi
+    word=$(first_cmd_word "$part")
+    if [ "$word" = "bd" ]; then
+      triggered_part="$part"
+      break
+    fi
+  done <<< "$PIPE_PARTS"
+
+  if [ -n "$triggered_part" ]; then
     cat >&2 <<EOF
 \`bd\` invoked from a jj workspace ($WS_ROOT)
 without BEADS_DIR set. The workspace's .beads/ is empty; bd's lookup will
@@ -136,8 +185,8 @@ fail with "no beads database found".
 
 Pick one:
 
-  • Prepend BEADS_DIR to this single command:
-        BEADS_DIR='$MAIN_REPO/.beads' $segment
+  • Prepend BEADS_DIR to the bd command:
+        BEADS_DIR='$MAIN_REPO/.beads' $triggered_part
 
   • Permanent fix for this workspace (one-time, then bd works bare):
         printf '%s\n' '$MAIN_REPO/.beads' > '$WS_ROOT/.beads/redirect'

--- a/.claude/hooks/enforce-gh-repo.sh
+++ b/.claude/hooks/enforce-gh-repo.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# PreToolUse hook: keep `gh` invocations from a jj workspace from failing
+# with the cryptic "fatal: not a git repository ... Stopping at filesystem
+# boundary" error.
+#
+# jj workspaces under `<repo-parent>/.worktrees/<name>/` don't materialise
+# a `.git/` directory — only the main checkout has one. `gh` follows git's
+# repo-discovery algorithm starting from cwd, walks up to the filesystem
+# boundary at `/Volumes`, and bails. This hook intercepts the failure mode
+# at the Bash boundary so the assistant gets an actionable message
+# pointing at the two valid fixes (-R / GH_REPO=) instead of having to
+# debug git's discovery rules.
+#
+# Companion to enforce-bd-beads-dir.sh (same shape, different tool). Unlike
+# bd, many `gh` subcommands are repo-agnostic (auth, config, version,
+# extension, gist, …) and would be false positives if blocked. We maintain
+# a small allowlist of those subcommands; everything else is treated as
+# repo-aware and gated.
+#
+# Error strategy: same as enforce-task-runner.sh / enforce-bd-beads-dir.sh
+# — fail open on parse errors, block reliably when we know there's a
+# problem.
+
+set -uo pipefail
+
+# --- Parse phase: fail open on malformed input ---
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || {
+  echo "enforce-gh-repo: failed to parse input — enforcement disabled for this command" >&2
+  exit 0
+}
+
+[[ -z "$COMMAND" ]] && exit 0
+
+# --- Enforcement phase ---
+trap - ERR
+
+strip_leading_ws() {
+  local s="$1"
+  echo "${s#"${s%%[![:space:]]*}"}"
+}
+
+# Whitespace-aware first-token extraction. Unlike ${seg%% *}, which only
+# splits on space and lets tab-separated commands like `time\tgh pr list`
+# slip through as the single word "time\tgh", `read` honours IFS
+# (default: space + tab + newline) and gives us the true first token.
+first_token() {
+  local _w _rest
+  read -r _w _rest <<< "$1"
+  echo "$_w"
+}
+
+# Returns 0 if the WHOLE segment is a standalone GH_REPO assignment
+# (with optional `export`), no command after it. Used to track
+# `export GH_REPO=foo/bar` followed by `gh pr list` in a later segment.
+is_standalone_gh_repo_assignment() {
+  local s
+  s=$(strip_leading_ws "$1")
+  if [[ "$s" =~ ^export[[:space:]]+ ]]; then
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  fi
+  if [[ "$s" =~ ^GH_REPO=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]]*$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Returns 0 if segment's env-var prefix sets GH_REPO, else 1.
+has_gh_repo_env() {
+  local s
+  s=$(strip_leading_ws "$1")
+  while [[ "$s" =~ ^([A-Za-z_][A-Za-z_0-9]*)=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
+    if [[ "${BASH_REMATCH[1]}" == "GH_REPO" ]]; then
+      return 0
+    fi
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  done
+  return 1
+}
+
+strip_env_vars() {
+  local s="$1"
+  while [[ "$s" =~ ^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|\'[^\']*\'|[^[:space:]]*)[[:space:]] ]]; do
+    s="${s#"${BASH_REMATCH[0]}"}"
+    s=$(strip_leading_ws "$s")
+  done
+  echo "$s"
+}
+
+first_cmd_word() {
+  local segment="$1"
+  segment=$(strip_leading_ws "$segment")
+  segment=$(strip_env_vars "$segment")
+  local word
+  word=$(first_token "$segment")
+  while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup|time|builtin)$ ]]; do
+    segment="${segment#"$word"}"
+    segment=$(strip_leading_ws "$segment")
+    local peek
+    peek=$(first_token "$segment")
+    while [[ "$peek" == -* ]]; do
+      segment="${segment#"$peek"}"
+      segment=$(strip_leading_ws "$segment")
+      peek=$(first_token "$segment")
+    done
+    segment=$(strip_env_vars "$segment")
+    word=$(first_token "$segment")
+  done
+  echo "$word"
+}
+
+# Returns the gh subcommand (first non-flag arg after `gh`) by skipping
+# any leading global flags like `--help`, `--version`. Echoes empty if
+# none found (e.g., bare `gh`).
+gh_subcommand() {
+  local segment="$1"
+  segment=$(strip_leading_ws "$segment")
+  segment=$(strip_env_vars "$segment")
+  # Strip wrappers and their flags (env, sudo, etc.)
+  local word
+  word=$(first_token "$segment")
+  while [[ "$word" =~ ^(env|command|exec|sudo|nice|nohup|time|builtin)$ ]]; do
+    segment="${segment#"$word"}"
+    segment=$(strip_leading_ws "$segment")
+    local peek
+    peek=$(first_token "$segment")
+    while [[ "$peek" == -* ]]; do
+      segment="${segment#"$peek"}"
+      segment=$(strip_leading_ws "$segment")
+      peek=$(first_token "$segment")
+    done
+    segment=$(strip_env_vars "$segment")
+    word=$(first_token "$segment")
+  done
+  # word is now `gh`. Drop it.
+  segment="${segment#"$word"}"
+  segment=$(strip_leading_ws "$segment")
+  # Walk forward, skipping flags, until we hit a non-flag arg.
+  while [[ -n "$segment" ]]; do
+    word=$(first_token "$segment")
+    case "$word" in
+      --) # End-of-flags marker; whatever follows is positional.
+        segment="${segment#"$word"}"
+        segment=$(strip_leading_ws "$segment")
+        first_token "$segment"
+        return
+        ;;
+      -*) # A flag; skip it. (We don't try to consume its value here —
+          # known limitation: `gh -X POST api ...` would surface `POST`
+          # as the subcommand. False positive, but harmless: POST is
+          # not in the allowlist so it'd be gated, then -R/GH_REPO
+          # bypass kicks in for the user's actual gh api call.)
+        segment="${segment#"$word"}"
+        segment=$(strip_leading_ws "$segment")
+        ;;
+      *)
+        echo "$word"
+        return
+        ;;
+    esac
+  done
+  echo ""
+}
+
+# Returns 0 if the segment contains `-R <val>`, `--repo <val>`, or
+# `--repo=<val>` anywhere after `gh`. Permissive — we don't validate
+# that <val> looks like owner/repo; gh will reject malformed values.
+has_repo_flag() {
+  local segment="$1"
+  # Tokenise on whitespace; check for known flag forms.
+  local in_gh=0
+  for tok in $segment; do
+    if (( in_gh == 0 )); then
+      [[ "$tok" == "gh" ]] && in_gh=1
+      continue
+    fi
+    case "$tok" in
+      -R|--repo) return 0 ;;
+      --repo=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Resolve workspace context. Same pattern as enforce-bd-beads-dir.sh.
+WS_ROOT="$(jj workspace root 2>/dev/null || true)"
+if [ -z "$WS_ROOT" ] || [ ! -e "$WS_ROOT/scripts/jj-main-repo.sh" ]; then
+  exit 0
+fi
+
+# shellcheck source=../../scripts/jj-main-repo.sh
+( cd "$WS_ROOT" && . "$WS_ROOT/scripts/jj-main-repo.sh" >/dev/null 2>&1 ) || exit 0
+cd "$WS_ROOT" || exit 0
+# shellcheck source=../../scripts/jj-main-repo.sh
+. "$WS_ROOT/scripts/jj-main-repo.sh"
+
+# In the main repo? cwd has .git/, gh discovery succeeds. Allow.
+if [ "${IS_DEFAULT:-no}" = "yes" ]; then
+  exit 0
+fi
+
+# Defensive: if somehow the workspace has a usable .git/, gh works. Allow.
+if [ -d "$WS_ROOT/.git" ] || [ -f "$WS_ROOT/.git" ]; then
+  exit 0
+fi
+
+# Repo-agnostic gh subcommands. These don't need a repo and gh won't try
+# to discover one for them. Keeping the list short and conservative —
+# false negatives (treating an agnostic command as repo-aware) are
+# recoverable via -R/GH_REPO; false positives in the OTHER direction
+# (letting a repo-aware command through that then fails with the cryptic
+# git error) are exactly what we're trying to prevent.
+is_repo_agnostic_subcmd() {
+  # `browse` and `secret` are intentionally NOT here: both fall back to
+  # git repo discovery when no -R/--org/--user is given, which is exactly
+  # the failure mode this hook is preventing. The has_repo_flag check
+  # earlier in the loop already lets `gh browse -R …` and `gh secret list
+  # -R …` through.
+  case "$1" in
+    auth|config|version|completion|extension|gist|help|status|alias|"")
+      return 0 ;;
+    ssh-key|codespace|search|attestation)
+      # These take their own scoping (--org, --user, query strings) and
+      # don't fall back to repo discovery when no -R is given.
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# Resolve the project's <owner>/<repo> for the suggestion text.
+# Best-effort: parse the main checkout's origin URL. If anything fails
+# (unusual remote, no git, etc.), fall back to "<owner>/<repo>" as a
+# placeholder so the help text still reads.
+GH_REPO_HINT="<owner>/<repo>"
+if origin_url=$(git -C "$MAIN_REPO" remote get-url origin 2>/dev/null); then
+  # Match git@host:OWNER/REPO, https://host/OWNER/REPO, or ssh://user@host/OWNER/REPO,
+  # with optional trailing .git and optional trailing slash.
+  parsed=$(printf '%s\n' "$origin_url" \
+    | sed -nE 's#(git@[^:]+:|ssh://[^/]+/|https?://[^/]+/)([^/]+/[^/]+)#\2#p' \
+    | sed -E 's#/+$##; s/\.git$//')
+  [ -n "$parsed" ] && GH_REPO_HINT="$parsed"
+fi
+
+SEGMENTS=$(echo "$COMMAND" | awk '{gsub(/ *&& */, "\n"); gsub(/ *; */, "\n"); gsub(/ *\|\| */, "\n"); print}')
+
+# Track whether an earlier segment exported GH_REPO so chained commands like
+# `export GH_REPO=foo/bar; gh pr list` aren't false-positive blocked.
+gh_repo_seen=0
+
+while IFS= read -r segment; do
+  [[ -z "$segment" ]] && continue
+
+  # If this segment is a standalone GH_REPO assignment, remember it for
+  # subsequent segments and move on.
+  if is_standalone_gh_repo_assignment "$segment"; then
+    gh_repo_seen=1
+    continue
+  fi
+
+  # Inspect every component of the pipeline, not just the leftmost.
+  # `jq ... | gh ...` would otherwise silently bypass the gate.
+  PIPE_PARTS=$(printf '%s\n' "$segment" | awk '{gsub(/ *\| */, "\n"); print}')
+  triggered=0
+  triggered_part=""
+  while IFS= read -r part; do
+    [[ -z "$part" ]] && continue
+    word=$(first_cmd_word "$part")
+    [ "$word" = "gh" ] || continue
+
+    # User opted in via env prefix on this command, or via a prior
+    # `export GH_REPO=...` segment.
+    if has_gh_repo_env "$part" || [[ $gh_repo_seen -eq 1 ]]; then
+      continue
+    fi
+
+    # User opted in via -R/--repo flag.
+    if has_repo_flag "$part"; then
+      continue
+    fi
+
+    # Subcommand is repo-agnostic — gh handles it without a repo.
+    subcmd=$(gh_subcommand "$part")
+    if is_repo_agnostic_subcmd "$subcmd"; then
+      continue
+    fi
+
+    triggered=1
+    triggered_part="$part"
+    break
+  done <<< "$PIPE_PARTS"
+
+  [[ $triggered -eq 0 ]] && continue
+
+  cat >&2 <<EOF
+\`gh\` invoked from a jj workspace ($WS_ROOT)
+without a repo specifier. jj workspaces don't have their own .git/, so gh
+will fail with: "fatal: not a git repository ... Stopping at filesystem
+boundary".
+
+Pick one:
+
+  • Set GH_REPO and re-run the gh command:
+        GH_REPO='$GH_REPO_HINT' $triggered_part
+
+  • Or pass -R/--repo to gh (e.g., -R '$GH_REPO_HINT').
+
+  • Or set GH_REPO for the whole session (lowest friction for repeated
+    gh use):
+        export GH_REPO='$GH_REPO_HINT'
+
+Tracked: holomush-kwwu.
+EOF
+  exit 2
+done <<< "$SEGMENTS"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,10 @@
           {
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-bd-beads-dir.sh",
             "type": "command"
+          },
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-gh-repo.sh",
+            "type": "command"
           }
         ],
         "matcher": "Bash"


### PR DESCRIPTION
## Summary

Companion to #3455 (bd hook). Adds a PreToolUse Bash hook that intercepts `gh` invocations from a jj workspace and blocks them when neither `-R/--repo` is in argv nor `GH_REPO=` is in the env prefix, with an actionable message pointing at the three valid fixes.

### Why

jj workspaces under `<repo-parent>/.worktrees/<name>/` don't have their own `.git/`. `gh` follows git's repo-discovery algorithm from cwd, walks up to the filesystem boundary, and bails with:

```
fatal: not a git repository (or any parent up to mount point /Volumes)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

This hook surfaces an actionable retry path before the cryptic error fires (hit while opening #3455 from within `.worktrees/bd-jj-fix/`).

### Behavior

| Scenario | Hook |
|---|---|
| `gh pr list` from a workspace | Block with help text |
| `gh pr list -R foo/bar` | Pass (`-R`/`--repo` in argv) |
| `GH_REPO=foo/bar gh pr list` | Pass (`GH_REPO=` in env prefix) |
| `gh auth status`, `gh config list`, `gh version`, etc. | Pass (allowlist) |
| `gh secret/ssh-key/codespace/search` | Pass (allowlist — these don't fall back to repo discovery) |
| `gh pr list` from main repo | Pass (cwd has `.git/`) |
| Any non-`gh` command | Pass (matcher exits early) |

The `<owner>/<repo>` hint in the error message is resolved from `git -C $MAIN_REPO remote get-url origin` and handles `git@`, `https://`, `ssh://` remotes with optional `.git`/trailing slashes — so the suggestion is project-portable, not hardcoded to holomush.

## Test plan

- [x] 22+ direct hook invocations covering block-cases, allowlist-cases, escape hatches, and non-`gh` commands (all pass)
- [x] `gh secret/ssh-key/codespace/search/alias/browse` correctly bypass via extended allowlist
- [x] URL parser produces `holomush/holomush` for `git@`, `https://`, `ssh://`, with/without `.git`, with/without trailing slash
- [x] Adversarial \`code-reviewer\` agent: READY, 5 low/non-blocking findings (4 inherited shape limitations, 2 polished)
- [x] \`task pr-prep\` green (lint + format + schema + license + unit + integration + E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-tool enforcement that blocks GitHub CLI usage lacking repository context and prints actionable diagnostics with a suggested repository hint.
* **Improvements**
  * Improved BEADS_DIR enforcement to detect wrapped and piped commands more accurately and offer precise, component-specific suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->