### PR TITLE
fix(test): use postgres.BasicWaitStrategies to close MappedPort race (holomush-bmcq)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -8,6 +8,26 @@ Keep under 200 lines. Curate — don't hoard.
 
 ## Anti-patterns
 
+- **Incomplete pattern-fix scope**: when a fix replaces an anti-pattern at
+  N "identified" sites, always re-grep the WHOLE pattern (not just the
+  spelling of the call the implementer happened to find) across the repo
+  before approving. For testcontainers postgres: the canonical search is
+  `rg "wait\\.ForLog|testcontainers\\.WithWaitStrategy" --type go`. Only
+  `test/testutil/postgres.go` should remain on `wait.ForLog` (correctly
+  paired with `ForListeningPort`); every other site should use
+  `postgres.BasicWaitStrategies()`. holomush-bmcq fix touched 3 of 5
+  affected sites; `internal/eventbus/crypto/dek/manager_integration_test.go`
+  and `internal/eventbus/crypto/kek/none_integration_test.go` were missed.
+
+- **`BasicWaitStrategies()` semantics (testcontainers-go v0.41.0)**: it
+  uses `WithAdditionalWaitStrategy` (additive), but `postgres.Run` does
+  NOT install a default `WaitingFor`, so `req.WaitingFor == nil` and the
+  net behavior is identical to `WithWaitStrategy` for first invocation.
+  Default deadline is 60s (longer than the typical 30s
+  `WithStartupTimeout` callsites used). Source:
+  `testcontainers-go@v0.41.0/options.go:365-399` and
+  `modules/postgres@v0.41.0/postgres.go:146-168`.
+
 - **Stale-base diff illusion**: When reviewing a stack pre-push, always check
   `jj log -r 'main@origin'` head against the branch's fork point. A bare
   `jj diff main@origin..@` will conflate the branch's actual changes with

--- a/cmd/holomush/automigrate_integration_test.go
+++ b/cmd/holomush/automigrate_integration_test.go
@@ -8,14 +8,11 @@ package main
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/holomush/holomush/internal/bootstrap"
 	"github.com/holomush/holomush/internal/store"
@@ -26,16 +23,17 @@ func startPostgresContainer(t *testing.T) (string, func()) {
 	t.Helper()
 	ctx := context.Background()
 
+	// Use postgres.BasicWaitStrategies() which combines the log wait
+	// with wait.ForListeningPort. Bare wait.ForLog is documented as
+	// flaky on Mac/Windows because Docker's port-mapping table can lag
+	// the readiness log line; without the port wait, ConnectionString
+	// can fail with `port "5432/tcp" not found`. See holomush-bmcq.
 	container, err := postgres.Run(ctx,
 		"postgres:18-alpine",
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
-		),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
@@ -35,9 +33,7 @@ func newTestPGPool(t *testing.T) (string, func()) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")

--- a/internal/eventbus/crypto/kek/local_aead_integration_test.go
+++ b/internal/eventbus/crypto/kek/local_aead_integration_test.go
@@ -13,9 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/store"
@@ -27,14 +25,17 @@ import (
 // wrap_key_id the current provider cannot unwrap.
 func TestLocalAEADProvider_Startup_RefusesIfWrapKeyIDUnknown(t *testing.T) {
 	ctx := context.Background()
+	// Use postgres.BasicWaitStrategies() which combines the log wait
+	// with wait.ForListeningPort. Bare wait.ForLog is documented as
+	// flaky on Mac/Windows because Docker's port-mapping table can lag
+	// the readiness log line; without the port wait, ConnectionString
+	// can fail with `port "5432/tcp" not found`. See holomush-bmcq.
 	pgContainer, err := postgres.Run(ctx,
 		"postgres:18-alpine",
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)

--- a/internal/eventbus/crypto/kek/none_integration_test.go
+++ b/internal/eventbus/crypto/kek/none_integration_test.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/store"
@@ -30,9 +28,7 @@ func TestNoneProvider_Constructor_RefusesIfCryptoKeysNonempty(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/holomush/holomush/internal/store"
 )
@@ -114,9 +112,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)
@@ -185,9 +181,7 @@ func TestMigrator_DirtyStateRecovery(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)
@@ -258,9 +252,7 @@ func TestMigrator_ConcurrentUp(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)
@@ -348,9 +340,7 @@ func TestMigrator_Force_VersionExceedsAvailable(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)
@@ -421,9 +411,7 @@ func TestMigrator_ConcurrentMigrationDirtyStateHandling(t *testing.T) {
 		postgres.WithDatabase("test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2)),
+		postgres.BasicWaitStrategies(),
 	)
 	require.NoError(t, err)
 	defer pgContainer.Terminate(ctx)


### PR DESCRIPTION
## Summary

Fixes a P1 testcontainers MappedPort race that produced `port "5432/tcp" not found` during `task pr-prep` for PR #3458.

### Root cause

Bare `wait.ForLog(...)` waits only for log lines in container stdout — it makes no guarantee about Docker's port mapping table being populated. When the postgres readiness log appears under heavy daemon load (e.g., 20+ parallel test:int packages spinning up containers), `MappedPort` can be called before `NetworkSettings.Ports` has 5432/tcp.

Upstream testcontainers-go documents this exact failure mode at `modules/postgres/wait_strategies.go:8-26`:

> Without this, the tests will be flaky on those OSes!

and ships `postgres.BasicWaitStrategies()` as the canonical fix — it pairs `ForLog` with `ForListeningPort` so `MappedPort` only fires after Docker has both started AND port-mapped postgres.

### Investigation

- Confirmed upstream behavior by reading testcontainers-go v0.41.0 source (filesystem-cached via `go mod`).
- Tried to reproduce the race via a 20-way parallel stress harness on M2 Mac. Could not deterministically trigger under low load — consistent with upstream's characterization that the race is OS- and load-dependent. Inability to reproduce under low load is not evidence the bug isn't there; the upstream documentation is sufficient grounding.
- Verified the fix works: 10x `go test -count=10` of the kek test stays green; cold-cache `task pr-prep` is green end-to-end.

### Sites fixed

Five integration test sites had drifted away from the shared `test/testutil/postgres.go` helper (which already does the right thing) and rolled their own log-only wait:

- `internal/eventbus/crypto/kek/local_aead_integration_test.go` (the bead's primary repro site)
- `internal/eventbus/crypto/kek/none_integration_test.go`
- `internal/eventbus/crypto/dek/manager_integration_test.go`
- `cmd/holomush/automigrate_integration_test.go`
- `internal/store/migrate_integration_test.go` (5 occurrences in one file)

Each replaced with `postgres.BasicWaitStrategies()`. Repo-wide `rg` post-fix confirms only `test/testutil/postgres.go` remains as a `ForLog` callsite (correctly paired with `ForListeningPort`).

## Test plan

- [x] `task lint:go` clean
- [x] 10x stress run of TestLocalAEADProvider_Startup_RefusesIfWrapKeyIDUnknown stable
- [x] Cold-cache `task pr-prep` green (lint, fmt, schema, license, unit, integration, e2e)
- [x] code-reviewer adversarial pass: READY (after addressing initially-missed sites)

Closes holomush-bmcq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PostgreSQL container initialization across multiple integration tests to use standardized readiness strategies.

* **Chores**
  * Simplified database startup configuration in the integration test suite with unified container initialization approach.

* **Documentation**
  * Added PostgreSQL container configuration patterns and anti-patterns to internal code-reviewer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->