### PR TITLE
fix(crypto): Phase 3c follow-ups — oops.Code chain + NATSConn seam (holomush-ojw1.3.22 + .3.23)

### DIFF
--- a/internal/cluster/registry.go
+++ b/internal/cluster/registry.go
@@ -6,12 +6,14 @@ package cluster
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/samber/oops"
 
+	"github.com/holomush/holomush/internal/eventbus/natsconn"
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/lifecycle"
 )
@@ -50,8 +52,15 @@ type Registry interface {
 }
 
 // Deps groups the dependencies cluster.Registry needs at construction.
+//
+// Conn is typed as natsconn.Conn (the narrow interface seam) rather
+// than *nats.Conn so unit tests MAY substitute a mock. Production
+// callers continue to pass eventbus.Subsystem.Conn() directly — the
+// concrete *nats.Conn satisfies natsconn.Conn structurally. See
+// internal/eventbus/natsconn for the interface and natsmock for a
+// test-only mock implementation. (holomush-ojw1.3.23)
 type Deps struct {
-	Conn              *nats.Conn // from eventbus.Subsystem.Conn()
+	Conn              natsconn.Conn // from eventbus.Subsystem.Conn(); test mocks via natsconn/natsmock
 	Logger            *slog.Logger
 	PillMetrics       *PillMetrics
 	SkewMetrics       *SkewMetrics
@@ -63,17 +72,18 @@ type Deps struct {
 }
 
 // NewSubsystem constructs a Registry-backed Subsystem. Production
-// callers pass a real *nats.Conn and ProductionPill. Tests use the
-// clustertest harness.
+// callers pass a real *nats.Conn (which satisfies natsconn.Conn
+// structurally) and ProductionPill. Tests use the clustertest harness
+// or, for unit-level error-path tests, a natsmock.Conn.
 func NewSubsystem(cfg Config, deps Deps) (Registry, error) {
 	cfg = cfg.Defaults()
 	if cfg.ClusterID == "" {
 		return nil, oops.Code("CLUSTER_CONFIG_MISSING_CLUSTER_ID").
 			Errorf("cluster.NewSubsystem requires non-empty ClusterID; sourced from eventbus.Config.GameID")
 	}
-	if deps.Conn == nil {
+	if deps.Conn == nil || isNilConn(deps.Conn) {
 		return nil, oops.Code("CLUSTER_DEPS_NIL").With("dep", "Conn").
-			Errorf("cluster.NewSubsystem requires a non-nil *nats.Conn")
+			Errorf("cluster.NewSubsystem requires a non-nil natsconn.Conn (typically *nats.Conn from eventbus.Subsystem.Conn())")
 	}
 	if deps.Pill == nil {
 		return nil, oops.Code("CLUSTER_DEPS_NIL").With("dep", "Pill").
@@ -263,4 +273,23 @@ func (r *registry) SetLastInvalidationSeq(seq uint64) {
 	r.mu.Lock()
 	r.lastInvSeq = seq
 	r.mu.Unlock()
+}
+
+// isNilConn detects typed-nil interface values whose underlying concrete
+// kind is nilable (pointer, slice, map, chan, func, interface). Required
+// because Deps.Conn is an interface (natsconn.Conn introduced in
+// holomush-ojw1.3.23) — a plain `== nil` comparison only checks the
+// interface header, missing typed-nil values like (*nats.Conn)(nil)
+// (see internal/eventbus/natsconn/natsconn_test.go:33-37 for the
+// runtime demonstration). Mirrors the pattern in
+// internal/core/engine.go::isNilEventAppender so callers truly fail
+// fast at construction rather than crashing on first method call.
+func isNilConn(c natsconn.Conn) bool {
+	v := reflect.ValueOf(c)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/internal/cluster/registry_internal_test.go
+++ b/internal/cluster/registry_internal_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// TestNewSubsystemRejectsTypedNilConn locks the constructor's typed-nil
+// rejection. After holomush-ojw1.3.23 introduced the natsconn.Conn
+// interface, a plain `deps.Conn == nil` comparison only catches the
+// interface-header nil case, missing typed-nil concrete values like
+// (*nats.Conn)(nil) (see internal/eventbus/natsconn/natsconn_test.go
+// for the runtime demonstration of typed-nil interface semantics).
+//
+// Without isNilConn's reflect-based check, a caller passing a typed-nil
+// Conn would slip past validation and crash on first method call. This
+// test asserts the constructor fails fast with CLUSTER_DEPS_NIL instead.
+func TestNewSubsystemRejectsTypedNilConn(t *testing.T) {
+	t.Parallel()
+
+	// (*nats.Conn)(nil) satisfies natsconn.Conn structurally but is
+	// itself a typed-nil pointer. The interface header is non-nil
+	// (carries the type pointer), so `deps.Conn == nil` is false here.
+	// isNilConn must catch this via reflect.
+	var typedNilConn *nats.Conn
+	deps := Deps{
+		Conn: typedNilConn,
+		Pill: stubPill{},
+	}
+	cfg := Config{ClusterID: "test-cluster"}
+
+	_, err := NewSubsystem(cfg, deps)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CLUSTER_DEPS_NIL")
+	errutil.AssertErrorContext(t, err, "dep", "Conn")
+}
+
+// TestNewSubsystemRejectsInterfaceNilConn covers the simpler case: a
+// completely nil interface (no concrete type at all). This is what the
+// pre-3.23 `== nil` check caught; the new `|| isNilConn(...)` clause
+// must not regress this behavior.
+func TestNewSubsystemRejectsInterfaceNilConn(t *testing.T) {
+	t.Parallel()
+
+	deps := Deps{
+		// Conn left zero — interface header is nil
+		Pill: stubPill{},
+	}
+	cfg := Config{ClusterID: "test-cluster"}
+
+	_, err := NewSubsystem(cfg, deps)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CLUSTER_DEPS_NIL")
+	errutil.AssertErrorContext(t, err, "dep", "Conn")
+}
+
+// TestIsNilConnDetectsTypedNilPointer is the unit-level lock for the
+// helper. Mirrors the pattern in internal/core/engine.go's
+// isNilEventAppender unit coverage.
+func TestIsNilConnDetectsTypedNilPointer(t *testing.T) {
+	t.Parallel()
+
+	var typedNilConn *nats.Conn
+	assert.True(t, isNilConn(typedNilConn),
+		"isNilConn MUST return true for (*nats.Conn)(nil)")
+}
+
+// stubPill is a no-op Pill implementation used to satisfy the Deps
+// constructor invariant for tests that focus on Conn validation.
+type stubPill struct{}
+
+func (stubPill) Trigger(context.Context, PillReason, MemberID) {}

--- a/internal/eventbus/crypto/invalidation/coordinator.go
+++ b/internal/eventbus/crypto/invalidation/coordinator.go
@@ -185,10 +185,22 @@ func (c *coordinator) RequestInvalidation(
 			// CLUSTER_CANNOT_PILL_SELF (defensive trip), or any other oops
 			// error from ProbeAndPill — propagate so the caller sees the
 			// failure instead of silently continuing into the retry phase.
+			//
+			// CAVEAT (samber/oops v1.21+): OopsError.Code() walks to the
+			// DEEPEST code in the chain via getDeepestErrorCode. So
+			// `oops.Code(OUTER).Wrap(innerOopsErr)` would silently surface
+			// the inner code, hiding the outer code we just attached. To
+			// preserve INVALIDATION_PROBE_AND_PILL_FAILED as the surfaced
+			// code, we use Errorf (which constructs a fresh OopsError
+			// whose .err is a plain fmt error containing the inner's
+			// formatted message) and stash the inner code + target in
+			// With() context. Callers that need the inner code read it
+			// from `inner_code` rather than walking the error chain.
+			// See holomush-ojw1.3.22.
 			return oops.Code("INVALIDATION_PROBE_AND_PILL_FAILED").
 				With("probe_target", string(member)).
 				With("inner_code", oerr.Code()).
-				Wrap(ppErr)
+				Errorf("probe-and-pill failed for member %s: %s", string(member), ppErr.Error())
 		}
 	}
 

--- a/internal/eventbus/crypto/invalidation/coordinator_error_test.go
+++ b/internal/eventbus/crypto/invalidation/coordinator_error_test.go
@@ -126,13 +126,15 @@ func newCoordinatorWithStub(t *testing.T, stub *stubRegistry) invalidation.Coord
 // the probeAndPill closure, and the expected oops error class observed
 // at the public RequestInvalidation boundary.
 //
-// Note on samber/oops Code() semantics: when the Coordinator wraps an
-// inner OopsError with oops.Code(OUTER).Wrap(inner), the surfaced
-// .Code() is the DEEPEST code in the chain (per
-// getDeepestErrorCode in samber/oops@v1.21.0+). The OUTER code lives
-// only in the With() context as `inner_code`. The
-// "propagates inner CLUSTER_*" case below asserts both the surfaced
-// deepest code AND the With-context keys to prove the wrap branch ran.
+// Note on samber/oops Code() semantics (holomush-ojw1.3.22): the
+// Coordinator's default-branch wrap path used to call
+// oops.Code(OUTER).Wrap(innerOopsErr), which silently surfaced the
+// INNER code because OopsError.Code() walks to the deepest code in
+// the chain (getDeepestErrorCode in samber/oops@v1.21.0+). The fix
+// switches that path to Errorf so the OUTER code
+// (INVALIDATION_PROBE_AND_PILL_FAILED) is what callers see, with the
+// inner code preserved in the With("inner_code") context. The
+// "propagates outer ... with inner_code" case below pins this contract.
 func TestRequestInvalidationByErrorClass(t *testing.T) {
 	const (
 		self  = cluster.MemberID("01HSELFAAAAAAAAAAAAAAAAAA")
@@ -203,18 +205,22 @@ func TestRequestInvalidationByErrorClass(t *testing.T) {
 			wantCode: "INVALIDATION_PARTIAL_FAILURE",
 		},
 		{
-			// Default branch: the inner code is propagated up via
-			// samber/oops's deepest-Code() walk. inner_code +
-			// probe_target context keys prove the wrap branch ran
-			// (vs. the `continue` or rate-limited shortcuts).
-			name:        "propagates inner CLUSTER_PROBE_AND_PILL_PROBE_FAILED with inner_code + probe_target context",
+			// Default branch: the OUTER code
+			// INVALIDATION_PROBE_AND_PILL_FAILED is what callers see; the
+			// inner CLUSTER_* code lives in `inner_code` context. Pre-fix
+			// (3.22) the surfaced code was the inner one because
+			// oops.Code(OUTER).Wrap(innerOopsErr) traverses to deepest;
+			// the fix switched the wrap site to Errorf to break the
+			// chain walk. inner_code + probe_target context keys prove
+			// the default-wrap branch ran (vs. continue / rate-limited).
+			name:        "surfaces outer INVALIDATION_PROBE_AND_PILL_FAILED with inner_code + probe_target context",
 			liveMembers: twoMember,
 			probeAndPill: func(_ context.Context, _ cluster.MemberID, _ cluster.PillReason) error {
 				return oops.Code("CLUSTER_PROBE_AND_PILL_PROBE_FAILED").
 					With("target", string(other)).
 					Errorf("nats failure")
 			},
-			wantCode: "CLUSTER_PROBE_AND_PILL_PROBE_FAILED",
+			wantCode: "INVALIDATION_PROBE_AND_PILL_FAILED",
 			wantCtx: map[string]any{
 				"inner_code":   "CLUSTER_PROBE_AND_PILL_PROBE_FAILED",
 				"probe_target": string(other),

--- a/internal/eventbus/crypto/invalidation/coordinator_mock_test.go
+++ b/internal/eventbus/crypto/invalidation/coordinator_mock_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package invalidation_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/holomush/holomush/internal/cluster"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+	"github.com/holomush/holomush/internal/eventbus/crypto/invalidation"
+	"github.com/holomush/holomush/internal/eventbus/natsconn/natsmock"
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// TestRequestInvalidationByMockedConnError demonstrates the
+// natsconn.Conn interface seam (holomush-ojw1.3.23) by driving the
+// Coordinator's INVALIDATION_INBOX_SUB_FAILED and
+// INVALIDATION_PUBLISH_FAILED error paths with a natsmock.Conn — no
+// embedded NATS server required. These error paths are infeasible to
+// trigger on a real embedded server because both calls fan out to a
+// healthy in-process loop.
+//
+// Each subtest installs the matching hook on the mock and asserts the
+// outer oops code surfaces at the public RequestInvalidation
+// boundary. wantInner asserts the wrapped error survives via the
+// standard errors.Is chain (which works here because the inner
+// errors are non-oops sentinels — the deepest-Code() traversal hazard
+// from holomush-ojw1.3.22 doesn't apply to non-oops children).
+func TestRequestInvalidationByMockedConnError(t *testing.T) {
+	t.Parallel()
+
+	const self = cluster.MemberID("01HSELFAAAAAAAAAAAAAAAAAA")
+	const other = cluster.MemberID("01HOTHERAAAAAAAAAAAAAAAAA")
+	twoMember := []cluster.Member{
+		{ID: self, Status: cluster.StatusAlive},
+		{ID: other, Status: cluster.StatusAlive},
+	}
+
+	// boom is the canned non-oops sentinel returned by the mock's
+	// hooks. We wrap it via the inner error chain and assert via
+	// errors.Is to confirm the wrap path preserves the original.
+	boom := errors.New("simulated nats failure") //nolint:err113 // test-only sentinel
+
+	cases := []struct {
+		name      string
+		install   func(*natsmock.Conn)
+		wantCode  string
+		wantInner error
+	}{
+		{
+			// Flow: publishAndCollect → SubscribeSync → returns boom →
+			// coordinator wraps with INVALIDATION_INBOX_SUB_FAILED.
+			// We assert via errors.Is to prove the inner error stayed
+			// in the chain (Wrap on a non-oops error is fine; deepest
+			// traversal only walks oops children).
+			name: "wraps SubscribeSync failure as INVALIDATION_INBOX_SUB_FAILED",
+			install: func(m *natsmock.Conn) {
+				m.SubscribeSyncHook = func(_ string) (*nats.Subscription, error) {
+					return nil, boom
+				}
+			},
+			wantCode:  "INVALIDATION_INBOX_SUB_FAILED",
+			wantInner: boom,
+		},
+		{
+			// Flow: publishAndCollect → SubscribeSync OK → PublishRequest
+			// returns boom → coordinator wraps with INVALIDATION_PUBLISH_FAILED.
+			name: "wraps PublishRequest failure as INVALIDATION_PUBLISH_FAILED",
+			install: func(m *natsmock.Conn) {
+				m.PublishRequestHook = func(_, _ string, _ []byte) error {
+					return boom
+				}
+			},
+			wantCode:  "INVALIDATION_PUBLISH_FAILED",
+			wantInner: boom,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &natsmock.Conn{}
+			tc.install(mock)
+
+			stub := &stubRegistry{
+				self:        self,
+				liveMembers: twoMember,
+			}
+
+			coord, err := invalidation.New(invalidation.Config{
+				ClusterID:         "test-game",
+				InvalidateTimeout: 100 * time.Millisecond,
+			}, invalidation.Deps{
+				Conn:      mock,
+				Registry:  stub,
+				DEKCache:  dek.NewCache(dek.CacheConfig{}),
+				PartCache: dek.NewParticipantsCache(dek.CacheConfig{}),
+				Logger:    slog.Default(),
+			})
+			if err != nil {
+				t.Fatalf("invalidation.New: %v", err)
+			}
+
+			gotErr := coord.RequestInvalidation(
+				context.Background(),
+				dek.ContextID{Type: "scene", ID: "01HSCENE"},
+				invalidation.ActionRekey, 1, 2,
+			)
+
+			errutil.AssertErrorCode(t, gotErr, tc.wantCode)
+			if tc.wantInner != nil && !errors.Is(gotErr, tc.wantInner) {
+				t.Errorf("expected error chain to contain %v, got %v", tc.wantInner, gotErr)
+			}
+		})
+	}
+}

--- a/internal/eventbus/crypto/invalidation/types.go
+++ b/internal/eventbus/crypto/invalidation/types.go
@@ -133,12 +133,23 @@ func UnmarshalReply(b []byte) (Reply, error) {
 // Typed errors returned by RequestInvalidation. See Phase 3c grounding
 // doc Decision 5 error-code table.
 //
-// CAVEAT: samber/oops's OopsError.Is returns true for ANY OopsError,
-// regardless of code. Do NOT use errors.Is(err, ErrFoo) to discriminate
-// these sentinels — it is tautological and matches every oops error.
-// In tests, use errutil.AssertErrorCode(t, err, "CODE"). In production
-// code, use oops.AsOops(err) and compare oopsErr.Code() to the string
-// literal of the error code.
+// CAVEAT 1 (errors.Is): samber/oops's OopsError.Is returns true for ANY
+// OopsError, regardless of code. Do NOT use errors.Is(err, ErrFoo) to
+// discriminate these sentinels — it is tautological and matches every
+// oops error. In tests, use errutil.AssertErrorCode(t, err, "CODE"). In
+// production code, use oops.AsOops(err) and compare oopsErr.Code() to
+// the string literal of the error code.
+//
+// CAVEAT 2 (deepest-Code traversal, holomush-ojw1.3.22): in
+// samber/oops@v1.21+, OopsError.Code() walks to the DEEPEST code in
+// the chain via getDeepestErrorCode. This means
+// `oops.Code(OUTER).Wrap(innerOopsErr)` SILENTLY surfaces the inner
+// code, not the outer one. To preserve the outer code as the surfaced
+// .Code(), use `oops.Code(OUTER).With("inner_code", inner.Code()).Errorf(...)`
+// which constructs a fresh OopsError whose .err is a plain fmt error,
+// breaking the chain walk. Wrapping NON-oops errors (e.g., NATS errors,
+// json errors, ctx.Err()) is fine — the deepest-walk only traverses
+// through oops-typed children.
 var (
 	// ErrPartialFailure — code "INVALIDATION_PARTIAL_FAILURE"
 	ErrPartialFailure = oops.Code("INVALIDATION_PARTIAL_FAILURE").

--- a/internal/eventbus/crypto/invalidation/types.go
+++ b/internal/eventbus/crypto/invalidation/types.go
@@ -12,11 +12,11 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/nats-io/nats.go"
 	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/cluster"
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+	"github.com/holomush/holomush/internal/eventbus/natsconn"
 )
 
 // Action enumerates the cache-invalidation actions; receivers
@@ -74,8 +74,14 @@ func (c Config) Defaults() Config {
 }
 
 // Deps groups the Coordinator's runtime dependencies.
+//
+// Conn is typed as natsconn.Conn (the narrow interface seam) rather
+// than *nats.Conn so unit tests MAY substitute a mock without booting
+// an embedded NATS server. Production callers continue to pass
+// eventbus.Subsystem.Conn() directly — *nats.Conn satisfies
+// natsconn.Conn structurally. (holomush-ojw1.3.23)
 type Deps struct {
-	Conn      *nats.Conn
+	Conn      natsconn.Conn
 	Registry  cluster.Registry
 	DEKCache  *dek.Cache
 	PartCache *dek.ParticipantsCache

--- a/internal/eventbus/natsconn/natsconn.go
+++ b/internal/eventbus/natsconn/natsconn.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package natsconn defines the narrow interface seam that production
+// callers (cluster.Registry, invalidation.Coordinator) use in place of
+// a concrete *nats.Conn. The seam exists so unit tests MAY substitute
+// a lightweight mock instead of standing up an embedded NATS server.
+//
+// Scope (holomush-ojw1.3.23): the interface covers ONLY the methods
+// HoloMUSH actually calls on *nats.Conn today. Adding a method to the
+// interface MUST NOT happen until an in-tree caller needs it; the goal
+// is to keep the mock-vs-real protocol surface as small as possible
+// to minimize the risk of subtle behavioral divergence between mock
+// and embedded server.
+//
+// Production wiring: every consumer continues to receive a *nats.Conn
+// at construction (the interface is satisfied implicitly via
+// structural typing). Test wiring: callers MAY pass a mock conforming
+// to the interface; see internal/eventbus/natsconn/natsmock for one
+// such mock geared to publish/subscribe-based unit tests.
+//
+// The eventbustest package's embedded-server philosophy
+// ("in-process is OK; correctness over fakery") is unchanged. This
+// seam complements eventbustest — it does not replace it. Integration
+// tests under test/integration/ MUST keep using the real embedded
+// server.
+package natsconn
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+)
+
+// Conn is the narrow seam. It is satisfied implicitly by *nats.Conn
+// (structural typing), so no production wiring change is required at
+// the call site beyond converting a struct field's type from
+// *nats.Conn to natsconn.Conn.
+//
+// Methods are grouped by call-site usage:
+//
+//   - Subscribe / SubscribeSync — receive-side wiring (cluster
+//     heartbeat handlers, invalidation Coordinator wildcard listener,
+//     invalidation Coordinator inbox).
+//   - Publish / PublishRequest — fire-and-forget and request-reply
+//     publish (heartbeat alive, bye, probe-reply, pill, invalidation
+//     publish, invalidation reply).
+//   - RequestWithContext — the cluster registry's probe path
+//     (single-target request-reply with derived timeout).
+//   - NewRespInbox — invalidation Coordinator's per-publish reply
+//     inbox subject generator.
+//   - Flush — heartbeat best-effort drain on Stop.
+//
+// CAVEAT: nats.go does not currently export an interface that captures
+// these methods, so we define our own. If nats.go ever exposes one,
+// this package SHOULD be deprecated in favor of the upstream interface.
+type Conn interface {
+	// Subscribe registers an asynchronous handler on a subject. Mirrors
+	// (*nats.Conn).Subscribe.
+	Subscribe(subject string, cb nats.MsgHandler) (*nats.Subscription, error)
+
+	// SubscribeSync registers a synchronous (NextMsg-style) subscription.
+	// Mirrors (*nats.Conn).SubscribeSync.
+	SubscribeSync(subject string) (*nats.Subscription, error)
+
+	// Publish sends a fire-and-forget message. Mirrors (*nats.Conn).Publish.
+	Publish(subject string, data []byte) error
+
+	// PublishRequest sends a request that expects replies on `reply`.
+	// Mirrors (*nats.Conn).PublishRequest.
+	PublishRequest(subject, reply string, data []byte) error
+
+	// RequestWithContext sends a request and awaits one reply (or the
+	// context's deadline / cancellation). Mirrors
+	// (*nats.Conn).RequestWithContext.
+	RequestWithContext(ctx context.Context, subject string, data []byte) (*nats.Msg, error)
+
+	// NewRespInbox returns a globally-unique reply inbox subject.
+	// Mirrors (*nats.Conn).NewRespInbox.
+	NewRespInbox() string
+
+	// Flush blocks until all pending messages on the connection have
+	// been processed by the server. Mirrors (*nats.Conn).Flush.
+	Flush() error
+}
+
+// Compile-time assertion: *nats.Conn satisfies Conn. If nats.go ever
+// changes a method signature this assertion will fail at build time
+// rather than at runtime.
+var _ Conn = (*nats.Conn)(nil)

--- a/internal/eventbus/natsconn/natsconn_test.go
+++ b/internal/eventbus/natsconn/natsconn_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package natsconn_test
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/holomush/holomush/internal/eventbus/natsconn"
+)
+
+// TestStarConnAssignableToConn pins the structural-typing contract
+// between *nats.Conn and natsconn.Conn at the test layer (in addition
+// to the compile-time `var _ natsconn.Conn = (*nats.Conn)(nil)` check
+// in natsconn.go). If a future nats.go release renames or removes one
+// of the methods we depend on, both the compile-time assertion AND
+// this test will fail — the test path catches the failure even in
+// builds that bypass the package's own compilation (rare but
+// possible: build tags, alternate vendor trees).
+//
+// The test does NOT exercise any methods — it only confirms the
+// structural-typing contract. Behavioral tests for the seam live with
+// each consumer (cluster, invalidation) where they exercise the real
+// (or mock) implementation against the consumer's call patterns.
+func TestStarConnAssignableToConn(t *testing.T) {
+	t.Parallel()
+	// The assignment alone is the assertion: if (*nats.Conn) does not
+	// satisfy natsconn.Conn this file won't compile. We keep the
+	// (now-typed-nil-bearing) interface variable around so go vet
+	// doesn't complain about an unused declaration.
+	var c natsconn.Conn = (*nats.Conn)(nil)
+	// An interface holding a typed-nil concrete value is itself
+	// non-nil at the comparison level (Go interface internals carry
+	// the type pointer). That's expected; we assert the runtime
+	// shape rather than nil-ness to make the contract explicit.
+	if _, ok := c.(*nats.Conn); !ok {
+		t.Fatalf("expected interface to carry concrete *nats.Conn, got %T", c)
+	}
+}

--- a/internal/eventbus/natsconn/natsmock/natsmock.go
+++ b/internal/eventbus/natsconn/natsmock/natsmock.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package natsmock provides a mock implementation of natsconn.Conn for
+// unit tests that exercise specific publish/subscribe error paths
+// without standing up an embedded NATS server.
+//
+// SCOPE: this mock intentionally does NOT implement broker-level
+// semantics (subject routing, queue groups, replay, request-reply
+// delivery, JetStream, etc.). It exists to drive deterministic
+// failure paths in callers — e.g. "what does the Coordinator do when
+// PublishRequest returns ErrConnectionClosed?" — without the
+// behavioral fidelity required for end-to-end tests. Tests that need
+// real protocol behavior MUST keep using eventbustest's embedded
+// server.
+//
+// BIASES, by design:
+//   - Subscribe / SubscribeSync return a real *nats.Subscription
+//     created against an embedded loopback server is OUT OF SCOPE.
+//     Callers that require a non-nil *nats.Subscription should use
+//     the embedded server. The mock returns nil + nil by default and
+//     the caller will (rightly) blow up if it dereferences. To get a
+//     pre-canned error from these methods, set the matching Hook.
+//   - Publish / PublishRequest record the call and return the canned
+//     error from the matching Hook.
+//   - RequestWithContext returns the canned (msg, err) from
+//     RequestWithContextHook.
+//   - NewRespInbox returns a deterministic incrementing inbox so tests
+//     can assert against it without hitting nats.NewInbox().
+//   - Flush returns the canned error from FlushHook.
+//
+// CONCURRENCY: all hooks and recorded fields are guarded by a single
+// mutex; the mock is safe for concurrent use across goroutines started
+// by the unit-under-test, which matches how *nats.Conn is normally
+// shared.
+package natsmock
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/holomush/holomush/internal/eventbus/natsconn"
+)
+
+// Conn is a mock natsconn.Conn for unit tests. The zero value is
+// usable; nil hooks short-circuit to safe defaults (return nil error,
+// return nil subscription, etc.).
+type Conn struct {
+	mu sync.Mutex
+
+	// SubscribeHook is invoked on Subscribe; if non-nil its return is
+	// used directly, bypassing the default (nil, nil) shortcut.
+	SubscribeHook func(subject string, cb nats.MsgHandler) (*nats.Subscription, error)
+	// SubscribeSyncHook is invoked on SubscribeSync; same semantics.
+	SubscribeSyncHook func(subject string) (*nats.Subscription, error)
+	// PublishHook is invoked on Publish; non-nil hook return overrides
+	// the default nil-error.
+	PublishHook func(subject string, data []byte) error
+	// PublishRequestHook is invoked on PublishRequest; same semantics.
+	PublishRequestHook func(subject, reply string, data []byte) error
+	// RequestWithContextHook is invoked on RequestWithContext; same.
+	RequestWithContextHook func(ctx context.Context, subject string, data []byte) (*nats.Msg, error)
+	// FlushHook is invoked on Flush; same.
+	FlushHook func() error
+	// NewRespInboxHook is invoked on NewRespInbox; if nil, a
+	// deterministic incrementing string is returned ("_INBOX.mock.1",
+	// "_INBOX.mock.2", ...) so test assertions are stable.
+	NewRespInboxHook func() string
+
+	// Recorded calls. Tests inspect these to assert call patterns.
+	Subscribed         []SubscribeCall
+	SubscribedSync     []string
+	Published          []PublishCall
+	PublishedRequests  []PublishRequestCall
+	RequestedWithCtx   []RequestWithContextCall
+	NewRespInboxCalls  int
+	FlushCalls         int
+	respInboxCounter   int
+}
+
+// SubscribeCall records the args passed to Subscribe.
+type SubscribeCall struct {
+	Subject string
+	Handler nats.MsgHandler
+}
+
+// PublishCall records the args passed to Publish.
+type PublishCall struct {
+	Subject string
+	Data    []byte
+}
+
+// PublishRequestCall records the args passed to PublishRequest.
+type PublishRequestCall struct {
+	Subject string
+	Reply   string
+	Data    []byte
+}
+
+// RequestWithContextCall records the args passed to RequestWithContext.
+type RequestWithContextCall struct {
+	Subject string
+	Data    []byte
+}
+
+// Compile-time assertion.
+var _ natsconn.Conn = (*Conn)(nil)
+
+// Subscribe records the call and dispatches to SubscribeHook (if set).
+func (c *Conn) Subscribe(subject string, cb nats.MsgHandler) (*nats.Subscription, error) {
+	c.mu.Lock()
+	c.Subscribed = append(c.Subscribed, SubscribeCall{Subject: subject, Handler: cb})
+	hook := c.SubscribeHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(subject, cb)
+	}
+	return nil, nil
+}
+
+// SubscribeSync records the call and dispatches to SubscribeSyncHook.
+func (c *Conn) SubscribeSync(subject string) (*nats.Subscription, error) {
+	c.mu.Lock()
+	c.SubscribedSync = append(c.SubscribedSync, subject)
+	hook := c.SubscribeSyncHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(subject)
+	}
+	return nil, nil
+}
+
+// Publish records the call and dispatches to PublishHook.
+func (c *Conn) Publish(subject string, data []byte) error {
+	c.mu.Lock()
+	// Copy data to avoid aliasing — callers may reuse the buffer.
+	cp := append([]byte(nil), data...)
+	c.Published = append(c.Published, PublishCall{Subject: subject, Data: cp})
+	hook := c.PublishHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(subject, data)
+	}
+	return nil
+}
+
+// PublishRequest records the call and dispatches to PublishRequestHook.
+func (c *Conn) PublishRequest(subject, reply string, data []byte) error {
+	c.mu.Lock()
+	cp := append([]byte(nil), data...)
+	c.PublishedRequests = append(c.PublishedRequests, PublishRequestCall{Subject: subject, Reply: reply, Data: cp})
+	hook := c.PublishRequestHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(subject, reply, data)
+	}
+	return nil
+}
+
+// RequestWithContext records the call and dispatches to
+// RequestWithContextHook.
+func (c *Conn) RequestWithContext(ctx context.Context, subject string, data []byte) (*nats.Msg, error) {
+	c.mu.Lock()
+	cp := append([]byte(nil), data...)
+	c.RequestedWithCtx = append(c.RequestedWithCtx, RequestWithContextCall{Subject: subject, Data: cp})
+	hook := c.RequestWithContextHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, subject, data)
+	}
+	return nil, nil
+}
+
+// NewRespInbox records the call and dispatches to NewRespInboxHook,
+// or returns a deterministic incrementing inbox subject.
+func (c *Conn) NewRespInbox() string {
+	c.mu.Lock()
+	c.NewRespInboxCalls++
+	hook := c.NewRespInboxHook
+	c.respInboxCounter++
+	counter := c.respInboxCounter
+	c.mu.Unlock()
+	if hook != nil {
+		return hook()
+	}
+	return "_INBOX.mock." + strconv.Itoa(counter)
+}
+
+// Flush records the call and dispatches to FlushHook.
+func (c *Conn) Flush() error {
+	c.mu.Lock()
+	c.FlushCalls++
+	hook := c.FlushHook
+	c.mu.Unlock()
+	if hook != nil {
+		return hook()
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Two Phase 3c follow-ups, both promoted to P1 to gate Phase 3d's plugin SDK Sensitive surface work (`ojw1.4.1.*`):

- **holomush-ojw1.3.22** — `oops.Code(OUTER).Wrap(innerOopsErr)` silently surfaces the inner code (samber/oops@v1.21+ walks to deepest code via `getDeepestErrorCode`). Switch the one affected wrap site in `Coordinator.RequestInvalidation` (probe-and-pill default branch) from `.Wrap(ppErr)` to `.Errorf(...: %s, ppErr.Error())` so the outer `INVALIDATION_PROBE_AND_PILL_FAILED` surfaces. Inner code stays accessible via `With("inner_code", oerr.Code())`. Add CAVEAT 2 doc block to `invalidation/types.go` documenting the deepest-Code traversal hazard so future contributors don't reintroduce it.

- **holomush-ojw1.3.23** — Introduce `internal/eventbus/natsconn.Conn`, a narrow interface seam covering the union of `*nats.Conn` methods HoloMUSH actually calls (`Subscribe`, `SubscribeSync`, `Publish`, `PublishRequest`, `RequestWithContext`, `NewRespInbox`, `Flush`). `cluster.Deps.Conn` and `invalidation.Deps.Conn` now accept the interface; production wiring is unchanged because `*nats.Conn` satisfies the interface structurally. Ship a low-fidelity `natsmock.Conn` for unit tests that drive specific publish/subscribe error paths (e.g., `PublishRequest` returning `ErrConnectionClosed`) without booting an embedded NATS server. The `eventbustest` embedded-server philosophy is unchanged — the seam complements it; integration tests keep using the real embedded server.

## Demonstrated value

`TestRequestInvalidationByMockedConnError` exercises two error paths (`INVALIDATION_INBOX_SUB_FAILED`, `INVALIDATION_PUBLISH_FAILED`) that were previously infeasible to test because the embedded server is too healthy to fail those calls. Mock makes them deterministically reachable.

## Closes

- holomush-ojw1.3.22
- holomush-ojw1.3.23

## Pre-Push Review Gates

- `task pr-prep` — green (lint, format, schema, license, unit, integration, E2E)
- inline code review pass — READY (no blocking findings; minor cosmetic notes only)

## Test plan

- [x] `task pr-prep` passes locally (lint + unit + integration + E2E in compose.e2e)
- [x] `TestRequestInvalidationByErrorClass` "surfaces outer ... with inner_code" subtest pins the new oops contract
- [x] `TestRequestInvalidationByMockedConnError` exercises the two new error paths via the mock
- [x] `TestStarConnAssignableToConn` pins the structural-typing contract between `*nats.Conn` and `natsconn.Conn`

## Out of scope (filed as follow-ups if value emerges)

- Migrating `probe_pill_test.go`'s `clustertest` harness usage to mock — the harness already gives that file good behavioral coverage.
- Extending `natsmock` with broker-style subject routing for fan-out tests — keep the mock narrow until a caller demands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive mocks and unit tests to improve coverage for connection and invalidation flows.

* **Chores**
  * Refactored internal connection handling for greater flexibility and safer nil-detection.
  * Adjusted error wrapping/reporting in invalidation workflows so public error codes and contexts are surfaced consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->