### PR TITLE
feat(claude): add crypto-reviewer agent + bead-chain-from-plan + handoff-prompt skills

### DIFF
--- a/.claude/agents/crypto-reviewer.md
+++ b/.claude/agents/crypto-reviewer.md
@@ -1,0 +1,202 @@
+---
+name: crypto-reviewer
+description: |
+  MUST run BEFORE `code-reviewer` for any change touching the event-payload-cryptography
+  surface: `internal/eventbus/crypto/`, `internal/eventbus/codec/`,
+  `internal/eventbus/history/dispatcher.go`, `internal/eventbus/history/cold_postgres.go`
+  (DEK column handling), `internal/plugin/event_emitter.go::Emit` (downgrade fence),
+  `internal/eventbus/audit/projection.go` (header→column or envelope projection),
+  plugin manifest `crypto.emits` declarations, or any migration touching
+  `crypto_keys` / `events_audit`.
+
+  Also fires before responding to user text containing "ship the crypto", "crypto
+  is ready", "rekey", "AuthGuard", "DEK", "AAD", or any phrasing that suggests
+  pushing crypto-domain code without a domain-specialist review pass first.
+
+  Adversarial reviewer specialized in the holomush event-payload-cryptography
+  invariants. Findings grounded in `docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md`
+  (the master spec) cross-referenced against repo state at `path:line`.
+  Read-only. Skipping requires explicit user override (e.g., "skip crypto
+  review", "no crypto review needed"). Output verdict: READY / NOT READY.
+model: opus
+effort: high
+permissionMode: plan
+color: red
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+memory: project
+---
+
+# Crypto Reviewer
+
+You are an adversarial domain-specialist reviewer for HoloMUSH's event-payload-cryptography surface. Your job is to find what's wrong with crypto-domain changes before they reach the generic `code-reviewer` adversarial gate. The generic reviewer looks at code quality, security in the abstract, and project conventions; you look at the *specific* invariants of the crypto design and the *specific* failure modes that the Phase 3 review cycles hammered out.
+
+## Why this agent exists
+
+Phase 3 of the crypto epic (`holomush-ojw1`) shipped across four sub-phases in 2026-04 → 2026-05. Each sub-phase ran 2-4 design-reviewer cycles plus 1-3 plan-reviewer cycles plus 1-2 code-reviewer cycles plus 1-2 CodeRabbit autofix passes. The findings repeatedly clustered on the same crypto-specific concerns:
+
+1. AAD canonicalization completeness across hot/cold tiers (legacy_id, nanosecond Timestamp, codec name as part of AAD)
+2. DEK column state validation on the cold tier (sensitive rows must carry `dek_ref` + `dek_version`; identity rows must not)
+3. Identity-codec dispatcher passthrough (must not call AuthGuard for plaintext)
+4. Nil-guard panics (cold-tier production wiring leaves `authGuard`/`dekManager`/`auditEmitter` nil; sensitive read must fail-closed not panic)
+5. Downgrade fence symmetry between Lua and binary plugin runtimes (per `CLAUDE.md` "Plugin Runtime Symmetry" invariant)
+6. Sensitive flag round-trip through the full plugin chain (proto → SDK → buffer → manager → EmitIntent → fence)
+7. Migration idempotency on `events_audit` / `crypto_keys` (project rule per CLAUDE.md / AGENTS.md "Database Migrations")
+
+These concerns generalize. Phases 4-7 will each touch the same surface and re-encounter the same risks. This agent front-runs the cycle.
+
+A separate, one-time architectural realization from Phase 3d (Decision 4)
+amended master spec §7.7: game-topic NATS is single-principal by design;
+ABAC at the gRPC subscribe handler is the authoritative isolation gate;
+NATS-level account-level deny rules do not apply because no plugin or
+character NATS principal exists in any planned topology. This isn't a
+recurring failure mode but it IS a load-bearing framing the reviewer must
+preserve when reviewing future changes that touch subject-isolation
+concerns (e.g. operator audit query, external-NATS deploy).
+
+## Required reading before reviewing
+
+Pre-load the following before issuing findings:
+
+1. **Master spec** — `docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md`. Pay particular attention to:
+   - §2 (Invariants & testable proofs) — the INV table is your primary reference
+   - §3 (Architecture overview) — emit, fan-out, cold-tier flows; trust boundaries
+   - §4.1 (Event envelope), §4.2 (AAD binding), §4.7 (events_audit migration)
+   - §5 (Crypto provider interface)
+   - §7 (Plugin authorization & decryption audit) — AuthGuard branches; INV-15 ABAC reword
+   - §7.7 (Audit-stream isolation) — Phase 3d amendment per Appendix A of the Phase 3d grounding
+   - §8 (Cold tier handling) — INV-21, INV-39, INV-49, INV-50
+   - §10 (Failure modes) — error code reference
+   - §11.1 (Phasing) — current phase status
+
+2. **Phase 3 grounding docs** — these record decisions made during sub-phase brainstorming and amendments to the master spec:
+   - `docs/superpowers/specs/2026-05-02-event-payload-crypto-phase3a-grounding.md`
+   - `docs/superpowers/specs/2026-05-03-event-payload-crypto-phase3d-grounding.md` (especially Appendix A — the verbatim §7.7 replacement)
+
+3. **Repo state** — verify each spec claim against actual code via `Read` + `Grep` + `Glob`. Never accept a documentation claim without confirming it.
+
+## Trust model — what the crypto layer protects
+
+- **Plaintext payload of sensitive events at rest** (in `events_audit` and JetStream message store)
+- **Plaintext payload of sensitive events on the bus** (between server and any subscriber that is not a permitted participant, host, or operator)
+- **Forward secrecy through `Rekey`** — `Rekey(context)` re-encrypts historical ciphertext under a new DEK and soft-deletes the old DEK record (`destroyed_at = NOW()`); production reads filter `destroyed_at IS NULL`, so the old wrapped DEK is unreachable through normal queries. Pre-`Rekey` backups of `events_audit` plus the (filtered-out) old wrapped-DEK record become unreadable once the master key is rotated and the wrapping key for the old DEK is destroyed. This is the only path to forward secrecy in v1; Rekey is destructive and operator-invoked, never automatic. (Per master spec §6.3 and INV-14.)
+
+What it does NOT protect:
+
+- Operator-visible metadata (subject, type, timestamp, actor) — these stay cleartext by design
+- Plaintext at the gRPC delivery boundary — telnet/web clients receive plaintext over gRPC; the server is in the trust path
+- Plugin-direct access to plaintext for events the plugin is currently authorized for — plugin compromise leaks plaintext for in-flight grants
+
+## Invariant checklist (review every PR against this)
+
+### AAD canonicalization (INV-21, INV-49, AAD-binding §4.2)
+
+- [ ] All AAD inputs come from byte-equal sources between hot and cold tiers
+- [ ] `Actor.legacy_id` round-trips through cold tier. Today (post-Phase-3d, pre-`legacy_id`-elimination): the legacy_id rides via envelope unmarshal — the `events_audit.envelope` column carries the marshaled `Event` proto verbatim, and `proto.Unmarshal` on the cold path recovers `Actor.LegacyID` from the bytes. There is NO dedicated `actor_legacy_id` column. After the `holomush-w9ml` legacy_id-elimination epic lands: legacy_id is gone entirely; all actors carry uniform ULIDs and this checklist item retires.
+- [ ] `Timestamp` precision is preserved end-to-end (nanosecond via proto encoding; PG `TIMESTAMPTZ` truncates to microseconds, so the source of truth on cold reads MUST be the marshaled envelope, not the column)
+- [ ] Codec name and DEK keyID/keyVersion are inputs to AAD on both paths
+- [ ] No code path computes AAD from a partially-reconstructed Event proto
+- [ ] Test coverage explicitly includes plugin-authored sensitive emits (Actor.kind=PLUGIN, Actor.legacy_id set) — character-only coverage masks this regression class
+
+### Codec dispatch (INV-21 byte equality, codec.NameIdentity passthrough)
+
+- [ ] Identity codec rows pass through without AuthGuard.Check (plaintext is not gated)
+- [ ] Sensitive codec rows MUST go through AuthGuard before any decrypt attempt
+- [ ] Codec name comes from `App-Codec` header (hot) or `codec` column (cold); both paths converge on the same `codec.Lookup` call
+- [ ] No code path silently treats an unknown codec as identity
+
+### DEK column handling (cold tier — INV-49)
+
+- [ ] Sensitive rows MUST have non-NULL `dek_ref` AND `dek_version`; missing → fail-closed `EVENTBUS_COLD_DEK_COLUMNS_MISSING`
+- [ ] Identity rows MUST have NULL DEK columns; populated → `AUDIT_ROW_CRYPTO_INCONSISTENT` or equivalent
+- [ ] Negative DEK column values rejected (`EVENTBUS_COLD_BAD_DEK_COLUMNS`); BIGSERIAL / non-negative INTEGER contracts assumed
+- [ ] Type conversions from PG (sql.NullInt64 / sql.NullInt32) to `codec.KeyID` / `uint32` validated, not blindly cast
+
+### Nil-fields handling (production wiring is intentionally nullable)
+
+- [ ] `authGuard == nil` for sensitive read → fail-closed `EVENTBUS_HISTORY_AUTH_GUARD_NIL`, never panic on `guard.Check`
+- [ ] `dekManager == nil` for sensitive read → fail-closed `EVENTBUS_HISTORY_DEK_MANAGER_NIL`, never panic on `dekMgr.Resolve`
+- [ ] `auditEmitter == nil` for plugin-decrypt audit emission → fail-closed or no-op-with-warning, but never panic
+- [ ] Identity-codec rows MUST early-return BEFORE any of these nil-checks fire (plaintext path doesn't need them)
+
+### Downgrade fence symmetry (Plugin Runtime Symmetry invariant)
+
+- [ ] Lua and binary plugin runtimes MUST flow through the SAME `event_emitter.go::Emit` fence point
+- [ ] Per-event `Sensitive` claim plumbs through ALL layers for both runtimes:
+  - Lua: `holo.emit.X(..., {sensitive=true})` → readSensitiveOpts → Emitter.LocationSensitive → pluginsdk.EmitEvent.Sensitive → emitFlush serialization → parseEmitEvents read → manager.EmitPluginEvent → EmitIntent.Sensitive → fence
+  - Binary: `req.Sensitive` (proto field) → goplugin host_service.EmitEvent → EmitIntent.Sensitive → fence
+- [ ] Manifest gate (manifest=never/may/always) applies identically to both runtimes
+- [ ] No host-side trust check applies to one runtime but not the other
+- [ ] Asymmetry is acceptable ONLY at runtime-specific layers (e.g., gRPC token authentication for binary plugins, where the forgery surface differs)
+
+### Migration safety (`events_audit`, `crypto_keys`, related)
+
+- [ ] All DDL idempotent via `IF EXISTS` / `IF NOT EXISTS` / `DO $$ BEGIN ... END $$` guards (CLAUDE.md / AGENTS.md project rule)
+- [ ] Up and down migrations symmetric and reversible
+- [ ] No triggers, functions, or stored procedures introduced (project rule: all logic in Go)
+- [ ] No FK constraint on `dek_ref` referencing `crypto_keys`. Rationale (post-Phase-3c soft-delete): `Rekey` sets `destroyed_at = NOW()` rather than physically deleting the row, so an FK would still resolve structurally. But production reads filter `destroyed_at IS NULL` (operational equivalent of hard-delete), and `events_audit` rows that pre-date a Rekey reference DEK rows whose application-visible state is "gone." An FK is operationally unhelpful: it doesn't prevent the dangling-reference case (filtered-out DEK), and it would block any future operator-initiated cleanup of soft-deleted DEK rows. Integrity is enforced by application-level handling: INV-39 (cold-tier stale-DEK fallback — deferred to Phase 5/Rekey-prep) and `EVENTBUS_COLD_DEK_COLUMNS_MISSING` validation in `decodeColdRow`
+- [ ] Migration version bump propagates to `internal/store/migrate_test.go` and `internal/store/migrate_integration_test.go` assertions
+
+### NATS subject isolation (post-Phase-3d §7.7)
+
+- [ ] Game-topic NATS (`events.>`, `audit.>`, `internal.>`) treated as single-principal by design — only the holomush server connects in any planned topology
+- [ ] No code path adds a per-principal NATS account / deny rule for plugins or characters (those have no game-topic NATS surface)
+- [ ] ABAC at the gRPC subscribe handler is the authoritative gate (INV-15 post-reword)
+- [ ] Operator audit query goes through the localhost UNIX admin socket (Phase 5+), NOT NATS subscribe
+- [ ] External-NATS deploy concerns (server-account scoping, optional read-only operator account) live under `holomush-s5ts`, not in any Phase 3 sub-phase scope
+
+### DEK lifecycle (Phase 4-5 territory)
+
+- [ ] `Add(participant)` MUST grant immediate read access to existing DEK history without rotating the DEK (INV-12)
+- [ ] `Rotate(context)` MUST preserve the old DEK ciphertext and old DEK record unchanged (INV-13); Phase 3c soft-delete preserves this
+- [ ] `Rekey(context)` MUST re-encrypt historical ciphertext under the new DEK and soft-delete the old DEK record (`destroyed_at = NOW()`); production reads filter `destroyed_at IS NULL` (INV-14)
+- [ ] `Rekey` MUST emit a system audit event with operator identity, context, and justification on `audit.>` (INV-15)
+- [ ] `Rekey` MUST NOT be invocable from any in-game command or public gRPC service (INV-16)
+
+### Plugin-owned audit (Phase 7 territory)
+
+- [ ] INV-50 downgrade fence: host's `QueryStreamHistory` refuses plugin-returned rows where `codec='identity'` for an event type whose manifest declares `sensitivity: always`
+- [ ] Plugins NEVER hold a DEK directly; plaintext flows from server's decrypt-and-deliver path under AuthGuard control
+- [ ] Plugin-owned audit tables mirror the `events_audit` shape for crypto fields: store `envelope BYTEA, codec TEXT, dek_ref BIGINT, dek_version INT` byte-for-byte from the bus message
+
+## Output format
+
+Issue findings grounded in `path:line` for code claims and `§N.N` for spec claims. For each finding:
+
+```text
+### [Severity: BLOCK | NONBLOCKING | NIT] — <short title>
+
+- **Location:** <path:line> or <doc>:§N.N
+- **Invariant:** <INV-N or "AAD-binding completeness" or "Plugin Runtime Symmetry" etc.>
+- **Problem:** <what is wrong, in 1-3 sentences>
+- **Repo evidence:** <quote the actual offending code; cite the spec text it violates>
+- **Why it matters:** <consequence — what fails, what gets leaked, what panics, what regresses>
+- **Required fix:** <smallest correct change; reference the canonical pattern from the spec or a sibling code path>
+```
+
+End with a binary verdict on its own line:
+
+```text
+**Verdict: READY** (no blocking findings)
+```
+
+OR
+
+```text
+**Verdict: NOT READY** (N blocking findings)
+```
+
+## Scope discipline
+
+- You are read-only. Do not edit code. Do not propose code changes outside the "Required fix" line per finding.
+- Do not duplicate `code-reviewer`'s scope — generic code quality, naming, formatting, idiomatic Go style, concurrency safety in the abstract are out of scope. Stay on crypto invariants.
+- Do not duplicate `abac-reviewer`'s scope when the change is purely ABAC policy (no crypto code path). The seam: anything reaching `internal/access/policy/seed.go` audit-stream deny rules is yours; pure policy DSL or attribute-resolver work is theirs.
+- Do not extend coverage to crypto features that haven't shipped yet — only review the surface present in the diff. If a sub-phase's invariants don't apply (e.g., reviewing Phase 3a-only code, INV-39 stale-DEK is N/A), say so explicitly.
+
+## When in doubt
+
+If a change has unclear crypto implications and the spec doesn't address the situation, surface it as a finding labeled `NEEDS DESIGN` rather than auto-approving or auto-rejecting. The author should clarify intent or open a design grounding doc before the change merges.

--- a/.claude/commands/review-abac.md
+++ b/.claude/commands/review-abac.md
@@ -1,0 +1,34 @@
+---
+description: Adversarially review ABAC-domain code changes against the access-control spec before code-reviewer runs
+---
+
+@agent-abac-reviewer Review the ABAC-domain code changes described below
+against the access-control architecture in `internal/access/`. This gate runs
+ALONGSIDE `code-reviewer` for any change touching the access control surface
+(`internal/access/`, policy DSL, attribute providers, authorization decision
+points, seed policies). For purely ABAC-scoped changes, run it BEFORE
+`code-reviewer` since it carries the dispositive verdict.
+
+**Target:** $ARGUMENTS
+
+**If no target was given:** review the full branch diff against the merge
+base. Use `jj diff --from $(jj log -r 'trunk()' --no-graph -T commit_id --limit 1)`
+(or the git equivalent) to get the diff. Review the diff AND the full files
+it touches.
+
+**If a target was given:** treat it as either a path (review that file's
+changes vs merge base), a commit revset (review that revset's diff), or a
+PR number (fetch with `gh pr diff <n>` and review).
+
+**Before writing findings:** read `docs/specs/2026-02-05-full-abac-design.md`
+(the ABAC design spec) and any seed-policy changes against
+`internal/access/policy/seed.go` and `seed_test.go`. You MUST understand the
+default-deny posture and the policy DSL before judging compliance.
+
+Apply the adversarial stance and review checklist from your agent prompt.
+Produce findings grounded in `path:line` for code claims, with a binary
+verdict.
+
+**Ordering:** this gate runs alongside `/review-code` (or before, when a
+change is purely ABAC-scoped). After abac-reviewer returns its verdict, then
+invoke `/review-code` for the generic adversarial pass.

--- a/.claude/commands/review-crypto.md
+++ b/.claude/commands/review-crypto.md
@@ -1,0 +1,46 @@
+---
+description: Adversarially review crypto-domain code changes against the master spec invariants before code-reviewer runs
+---
+
+@agent-crypto-reviewer Review the crypto-domain code changes described below
+against `docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md` (the
+master spec) and the Phase 3a/3d grounding docs. This gate runs BEFORE
+`code-reviewer` for any change touching the event-payload-cryptography surface
+(`internal/eventbus/crypto/`, `internal/eventbus/codec/`,
+`internal/eventbus/history/dispatcher.go`,
+`internal/eventbus/history/cold_postgres.go`,
+`internal/plugin/event_emitter.go::Emit`,
+`internal/eventbus/audit/projection.go`, plugin manifest `crypto.emits`
+declarations, or migrations affecting `crypto_keys` / `events_audit`).
+
+**Target:** $ARGUMENTS
+
+**If no target was given:** review the full branch diff against the merge
+base. Use `jj diff --from $(jj log -r 'trunk()' --no-graph -T commit_id --limit 1)`
+(or the git equivalent) to get the diff. Review the diff AND the full files
+it touches.
+
+**If a target was given:** treat it as either a path (review that file's
+changes vs merge base), a commit revset (review that revset's diff), or a
+PR number (fetch with `gh pr diff <n>` and review).
+
+**Before writing findings:** read the master spec sections cited in the
+agent's "Required reading" section — at minimum §2 (Invariants), §3
+(Architecture), §4.2 (AAD binding), §7 (Plugin authorization), §8 (Cold tier
+handling), and the Phase 3d grounding doc Appendix A (§7.7 amendment). You
+MUST know the invariants before judging compliance with them.
+
+Apply the adversarial stance and invariant checklist from your agent prompt.
+Produce findings grounded in `path:line` for code claims and `§N.N` for spec
+claims, with a binary READY / NOT READY verdict.
+
+**On receipt:** the agent's response IS the full report — read it. The agent
+also persists the full report to `.claude/agent-memory/crypto-reviewer/reports/`
+when it has memory configured. Do NOT spawn a second agent to "retrieve full
+findings"; subagents are stateless across invocations.
+
+**Ordering:** this gate runs BEFORE `/review-code`. After crypto-reviewer
+returns READY, then invoke `/review-code` for the generic adversarial pass.
+If crypto-reviewer returns NOT READY, address findings before invoking
+code-reviewer (so code-reviewer doesn't waste a pass on code that's still
+crypto-broken).

--- a/.claude/hooks/remind-pre-action-review.sh
+++ b/.claude/hooks/remind-pre-action-review.sh
@@ -19,11 +19,55 @@ prompt="$(jq -r '.prompt // ""')"
 # Lowercase once for cheap case-insensitive matching.
 lower="$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')"
 
+# Best-effort: collect changed files vs trunk so domain reminders can fire when
+# the prompt is generic ("push this branch") but the diff actually touches
+# crypto/ABAC paths. Silent on failure (no jj/git, detached state, etc.).
+changed_paths=""
+if command -v jj >/dev/null 2>&1; then
+  changed_paths="$(jj diff --name-only --from 'trunk()' --to '@' 2>/dev/null || true)"
+fi
+if [ -z "$changed_paths" ] && command -v git >/dev/null 2>&1; then
+  base="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+  if [ -n "$base" ]; then
+    changed_paths="$(git diff --name-only "$base"...HEAD 2>/dev/null || true)"
+  fi
+fi
+
 reminders=()
 
-# code-reviewer triggers: anything that implies the work is leaving the session.
+# Detect handoff-intent verbs (push/ship/close/PR creation). Cached so multiple
+# downstream gates can reuse it without re-running grep.
+handoff_intent=0
 if printf '%s' "$lower" | grep -qE '(\bpush\b|jj[[:space:]]+git[[:space:]]+push|git[[:space:]]+push|gh[[:space:]]+pr[[:space:]]+create|bd[[:space:]]+close|open[[:space:]]+(a[[:space:]]+)?pr|create[[:space:]]+(a[[:space:]]+)?pr|\bmerge\b|\bship\b|\bland\b|ready[[:space:]]+to[[:space:]]+(push|merge|ship)|close[[:space:]]+(the[[:space:]]+)?bead|mark[[:space:]]+(done|complete)|wrap[[:space:]]+up|finalize)'; then
+  handoff_intent=1
+fi
+
+# code-reviewer triggers: anything that implies the work is leaving the session.
+if [ "$handoff_intent" = "1" ]; then
   reminders+=("**Pre-hand-off gate:** Before you run \`jj git push\`, \`gh pr create\`, or \`bd close\` for this work, the \`code-reviewer\` adversarial sub-agent MUST run on the branch diff. Invoke \`/review-code\` (or \`Agent\` with \`subagent_type: code-reviewer\`) now if it has not already run for the current branch tip. To skip, the user must explicitly say so (e.g. \"skip review\").")
+fi
+
+# crypto-reviewer triggers: handoff intent AND (crypto-domain mention in prompt
+# OR crypto-domain paths in the diff). Path-based detection closes the gap
+# where a generic handoff like "push this branch" would otherwise miss the
+# crypto gate when the diff actually touches the crypto surface. Combines
+# with the code-reviewer reminder so the user gets BOTH: crypto-reviewer
+# first, then code-reviewer.
+if [ "$handoff_intent" = "1" ] && {
+     printf '%s' "$lower" | grep -qE '(internal/eventbus/crypto|internal/eventbus/codec|internal/eventbus/history/dispatcher|internal/eventbus/history/cold_postgres|internal/plugin/event_emitter|internal/eventbus/audit/projection|crypto_keys|events_audit|\baad\b|\bdek\b|authguard|rekey|encrypt|decrypt|crypto\.emits)' ||
+     printf '%s' "$changed_paths" | grep -qE '(internal/eventbus/crypto/|internal/eventbus/codec/|internal/eventbus/history/dispatcher\.go|internal/eventbus/history/cold_postgres\.go|internal/plugin/event_emitter\.go|internal/eventbus/audit/projection\.go|migrations/.*crypto_keys|migrations/.*events_audit)';
+   }; then
+  reminders+=("**Pre-hand-off crypto gate:** Changes touch the event-payload-cryptography surface. \`crypto-reviewer\` MUST run BEFORE \`code-reviewer\`. Invoke \`/review-crypto\` (or \`Agent\` with \`subagent_type: crypto-reviewer\`) first; address NOT-READY findings; then invoke \`/review-code\`. To skip, the user must explicitly say so (e.g. \"skip crypto review\").")
+fi
+
+# abac-reviewer triggers: handoff intent AND (access-control mention in prompt
+# OR access-control paths in the diff). Same OR pattern as crypto so the gate
+# fires even when the prompt is generic but the diff touches internal/access/.
+if [ "$handoff_intent" = "1" ] && {
+     printf '%s' "$lower" | grep -qE '(internal/access|access[[:space:]]*control|abac|access[[:space:]]+policy|policy[[:space:]]+dsl|attribute[[:space:]]+provider|access[[:space:]]+decision)' ||
+     printf '%s' "$changed_paths" | grep -qE '(internal/access/)';
+   }; then
+  reminders+=("**Pre-hand-off ABAC gate:** Changes touch the access-control surface. \`abac-reviewer\` MUST run alongside \`code-reviewer\`. Invoke \`/review-abac\` (or \`Agent\` with \`subagent_type: abac-reviewer\`) before pushing. To skip, the user must explicitly say so (e.g. \"skip ABAC review\").")
 fi
 
 # plan-reviewer triggers: anything that implies a plan is about to be executed.

--- a/.claude/skills/bead-chain-design/SKILL.md
+++ b/.claude/skills/bead-chain-design/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: bead-chain-design
+description: |
+  Generate the `## Bead chain structure` section into an implementation plan
+  that lacks one. Implements the Plan → Bead Chain convention defined in
+  CLAUDE.md / AGENTS.md "Plan → Bead Chain". Use after
+  `superpowers:writing-plans` produces a plan, BEFORE `bead-chain-from-plan`
+  is invoked. The skill reads the plan's task table and parent epic context,
+  proposes a chain mapping (1:1 or merged or split), generates each task
+  bead's full 8-section description, and writes the section into the plan
+  (or a sidecar file when the plan is read-only).
+
+  Both Claude and the user can invoke. ALWAYS preview the proposed chain
+  shape and obtain explicit user approval before writing anything to disk.
+---
+
+# Bead Chain Design
+
+Translate an implementation plan's task table and parent-epic context into
+the `## Bead chain structure` section that the project's Plan → Bead Chain
+convention requires (CLAUDE.md / AGENTS.md). This is the missing-skill step
+between `superpowers:writing-plans` (produces the plan body) and
+`bead-chain-from-plan` (materializes the chain into `bd` issues).
+
+## When to invoke
+
+- Right after `superpowers:writing-plans` saves a plan and the user wants to
+  track the work in beads
+- When `bead-chain-from-plan` reports the plan lacks a `## Bead chain
+  structure` section and asks to generate one
+- When the user says "add the bead chain", "write the chain section",
+  "design the bead chain", "generate the chain structure"
+
+The skill does not auto-fire. The user (or controller agent) explicitly
+invokes it; this avoids designing chains for plans that may still be in
+revision.
+
+## Inputs
+
+- **Plan path** (positional arg or detected from recent context): a markdown
+  file under `docs/superpowers/plans/` or `docs/plans/`.
+- **Parent epic ID** (optional): the existing `bd` epic the chain hangs from.
+  If absent, the skill infers from the plan's `Refs:` lines or the recent
+  conversation. If still ambiguous, ask the user.
+
+If neither is supplied, ask the user which plan and which epic to design
+against.
+
+## Workflow
+
+### Step 1: Read the plan + parent epic
+
+Read the entire plan file. Locate:
+
+1. The plan's task table (typically the `## Decomposition & sequencing` or
+   `## Tasks` section, with rows naming task IDs like `T1`, `T2`, etc.).
+2. The plan's "Files touched" / architecture table — used to populate each
+   task bead's "Files touched" section.
+3. The grounding doc / design spec the plan references (typically named in
+   the plan header `**Spec reference:**`).
+4. The parent epic via `bd show <parent-epic-id>` — used to confirm the
+   chain has an owning epic and to extract description context for the
+   epic-level Refs.
+
+If any input is missing or ambiguous, surface it and ask before continuing.
+
+### Step 2: Propose the bead split
+
+Map plan tasks to bead beads. Three common shapes:
+
+| Shape         | When to use                                                           | Example                                                  |
+| ------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
+| **1:1**       | Each plan task = one bead. Default for moderate-granularity plans.    | T1 → ojw1.4.3; T2 → ojw1.4.4; ...                        |
+| **Merged**    | Multiple closely-coupled plan tasks share one bead.                   | T1 + T2 + T3 (all column-rename steps) → ojw1.4.3        |
+| **Split**     | One plan task spans multiple beads with their own review surfaces.    | T6+T7+T8 (proto + goplugin + Lua) → ojw1.4.1.1, .2, .3   |
+
+The split decision is informed by:
+
+- Whether the tasks share a single `task pr-prep` cycle (merged) or
+  separate review surfaces (split)
+- Bead numbering depth — four-level (e.g. `ojw1.4.1.3`) is supported in this
+  project but should be reserved for cases with genuine three-level
+  hierarchy (epic → sub-epic → task)
+- Plan-task dependencies — if T2 depends only on T1 and they hit the same
+  files, merging is fine; if T2 depends on T1 but they hit different review
+  surfaces, split
+
+Propose the mapping as a table for user review:
+
+```text
+Proposed bead split for <plan-path>
+
+| Plan task | Bead | Title                                            | Notes        |
+|-----------|------|--------------------------------------------------|--------------|
+| T0        | -    | (plan-time pre-state verification, no bead)      | housekeeping |
+| T1+T2+T3  | <p>.3 | Cold-tier envelope rename + dispatcher refactor | merged       |
+| T4        | <p>.4 | Crypto.Enabled default flip                      | 1:1          |
+| ...       |       |                                                  |              |
+```
+
+Where `<p>` is the parent epic ID (e.g. `holomush-ojw1.4`). Ask the user
+to approve, modify, or reject the split before continuing.
+
+### Step 3: Generate per-bead descriptions
+
+For each bead in the approved split, generate the 8-section description per
+CLAUDE.md "Plan → Bead Chain" requirements:
+
+1. **Goal** — one-sentence scope, derived from the plan task's title /
+   purpose
+2. **Design reference** — the grounding spec / design doc named in the plan
+   header, with the most-relevant section anchor
+3. **Plan reference** — the plan path with the task ID anchor
+   (`docs/superpowers/plans/<plan>.md` § Task Tn)
+4. **TDD acceptance criteria** — pulled from the plan's task TDD steps; for
+   merged beads, the union of the merged tasks' tests
+5. **Verification steps** — pulled from the plan's task verification block;
+   typically `task lint`, `task test -- ./pkg/`, `task pr-prep` for the
+   closing bead
+6. **Files touched** — pulled from the plan's architecture table for the
+   relevant tasks
+7. **Dependencies** — derived from the plan task's dependency column and
+   translated to `bd dep add` edges using the bead IDs from Step 2
+8. **Out of scope** — explicit non-goals; pulled from the plan's "Out of
+   scope" section if present, otherwise generated from the design doc's
+   deferred items
+
+Generate descriptions in heredoc form so they're directly usable by
+`bd create`:
+
+```bash
+bd create \
+  --title "<title>" \
+  --type <task|feature|bug|epic> \
+  --priority <0-4> \
+  --parent <parent-epic-id> \
+  --description "$(cat <<'EOF'
+**Goal:** <one-sentence>
+
+**Design reference:** <doc>:<section>
+**Plan reference:** <plan>:<task-id>
+
+**TDD acceptance criteria:**
+- <test name 1>
+- <test name 2>
+- ...
+
+**Verification steps:**
+- task lint
+- task test -- ./<pkg>/
+- ...
+
+**Files touched:**
+- <path>:<line> — <one-line what>
+- ...
+
+**Dependencies:** <list of bead IDs this depends on>
+
+**Out of scope:** <explicit non-goals>
+EOF
+)"
+```
+
+### Step 4: Compose the section
+
+Assemble the generated content into a `## Bead chain structure` section
+following the Phase 3d grounding doc's shape:
+
+```markdown
+## Bead chain structure
+
+\`\`\`text
+<parent-epic>                   (existing epic — <one-line scope>)
+└── <parent-epic>.<n>           (existing or NEW — <one-line scope>)
+    ├── <child-1>               <one-line scope>
+    ├── <child-2>               <one-line scope>
+    │   • Splits into <child-2>.<n.m> sub-beads (per the plan)
+    └── ...
+\`\`\`
+
+<Per-bead `bd create` blocks, one per child, in the order from the tree>
+
+### Closing-out operations
+
+- Existing beads to close with rationale: <list>
+- Existing beads to update (priority / parent / description): <list>
+- Follow-up beads to file: <list>
+
+### `bd dep add` edges
+
+\`\`\`bash
+bd dep add <child-X> <child-Y>   # X depends on Y
+...
+\`\`\`
+```
+
+The section is self-contained: a reader can take this section alone and
+hand it to `bead-chain-from-plan` for materialization.
+
+### Step 5: Get user approval (REQUIRED)
+
+First **resolve the destination** using the rules in Step 6 (preferred:
+`<plan-path>` itself; sidecar `<plan-path-without-ext>-bead-chain.md` only if
+the plan is read-only or the user has asked for a sidecar). The approval prompt
+MUST name the resolved destination so the user's `yes` covers the exact file
+that will be mutated.
+
+Display the assembled section in full, then ask explicitly with the resolved
+destination interpolated:
+
+> "Write this `## Bead chain structure` section into `<resolved-destination>`?
+> (yes / no / modify)"
+>
+> - `yes` — write to `<resolved-destination>`
+> - `no` — exit without changes
+> - `modify` — describe edits (drop a bead, change a description, adjust
+>   the split). After edits, re-display and prompt again with the same
+>   question. Only proceed to write when the user replies `yes` against
+>   the current state.
+
+Do NOT write anything to disk without affirmative `yes` against the displayed
+content AND the named destination.
+
+### Step 6: Write the section
+
+Write to the destination resolved in Step 5. Insertion points (in order of preference):
+
+1. After the plan's `## Decomposition & sequencing` section (the natural
+   spot — task table flows into bead chain)
+2. After `## Architecture & components touched` if no Decomposition section
+   exists
+3. As a new section before any closing `## References` or `## Out of scope`
+4. Append to end of file as last resort
+
+If the plan file is read-only or the user prefers a sidecar:
+
+- Write to `<plan-path-without-ext>-bead-chain.md` (sibling file, same
+  directory, `-bead-chain` suffix before `.md`)
+- The `bead-chain-from-plan` skill reads the sidecar if the plan itself
+  lacks the section
+
+After writing, run `task lint:markdown` to verify rumdl passes.
+
+### Step 7: Hand off
+
+Print:
+
+```text
+✓ Bead chain structure written to <path>
+  Lines added: <N>
+  Beads designed: <count>
+  Edges: <count>
+
+Next: invoke `bead-chain-from-plan` to materialize the chain into bd issues.
+```
+
+## Constraints
+
+- **Never write without explicit user approval.** Step 5 confirmation is
+  load-bearing. The `modify` flow MUST re-display the updated content and
+  re-ask before write.
+- **Never invent design content.** Every "Design reference" link, every
+  "Files touched" path, every TDD acceptance criterion MUST come from the
+  plan or the referenced grounding doc. If the plan lacks the data, ask
+  the user rather than fabricating.
+- **Never skip the 8 sections.** Every task bead's description MUST have
+  all 8. If the plan doesn't supply enough information for one of the
+  sections, surface the gap to the user — don't invent and don't omit.
+- **Match parent-epic numbering.** Sub-bead IDs follow the existing project
+  pattern (e.g. children of `holomush-ojw1.4` are `holomush-ojw1.4.1`,
+  `.4.2`, etc.). Verify the next-available index via
+  `bd show <parent-epic>` before assigning.
+- **Don't pre-create beads.** This skill writes the SECTION; it doesn't run
+  `bd create`. Bead materialization is `bead-chain-from-plan`'s job. Keep
+  the responsibilities separate so the user can review the section before
+  any `bd` mutation.
+- **Idempotency**: if the plan already has a `## Bead chain structure`
+  section, surface the conflict and ask whether to (a) overwrite, (b)
+  merge, or (c) abort. Default: abort.
+
+## Failure modes
+
+- **Plan task table missing or ambiguous**: ask the user to specify the
+  task list (or refine the plan's task structure first).
+- **Parent epic not found**: ask the user for the correct epic ID, or for
+  permission to create a new one.
+- **Grounding doc not referenced in plan**: ask the user for the path; the
+  Design reference cannot be fabricated.
+- **Plan describes non-bead-tracked work** (e.g., a one-off doc fix with no
+  multi-task structure): tell the user the Plan → Bead Chain convention
+  applies to multi-task plans only; suggest skipping bead chain for this
+  plan.
+- **`task lint:markdown` fails after write**: surface the error; ask the
+  user whether to attempt auto-fix (`task fmt:markdown`) or revert.
+
+## Example session
+
+User says: *"Generate the bead chain structure for
+`docs/superpowers/plans/2026-05-15-legacy-id-elimination.md` under epic
+`holomush-w9ml`."*
+
+Skill:
+
+1. Reads the plan, finds the task table at `## Decomposition & sequencing`
+   with 9 tasks (T0-T8).
+2. Reads `bd show holomush-w9ml` for parent epic context.
+3. Proposes 1:1 split for T1-T8 (T0 is plan-housekeeping, no bead).
+4. Shows the proposed split table; asks for approval.
+5. User: "merge T2+T3 (both proto schema work); split T7 into three sub-beads
+   for proto, registry, ABAC migration".
+6. Re-displays the revised split.
+7. User: "yes".
+8. Generates 8-section descriptions for each bead, pulling test names from
+   the plan's TDD blocks and file lists from the architecture table.
+9. Composes the `## Bead chain structure` section.
+10. Displays the assembled section in full; asks to write.
+11. User: "yes".
+12. Appends to the plan after `## Decomposition & sequencing`.
+13. Runs `task lint:markdown`; reports success.
+14. Hands off to `bead-chain-from-plan` for materialization.

--- a/.claude/skills/bead-chain-from-plan/SKILL.md
+++ b/.claude/skills/bead-chain-from-plan/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: bead-chain-from-plan
+description: |
+  Materialize the `## Bead chain structure` section of an implementation plan
+  into actual `bd` issues, dependency edges, and parent linkages, per the
+  Plan → Bead Chain convention defined in CLAUDE.md / AGENTS.md. Use after
+  the plan has both a task body AND the chain section. If the plan lacks
+  the chain section, this skill delegates to `bead-chain-design` to generate
+  it first, then materializes it.
+
+  Use whenever the user asks to "create the beads", "set up the bead chain",
+  "materialize the chain", or names a plan path and asks to track the work.
+
+  Both Claude and the user can invoke. ALWAYS preview the chain (dry-run) and
+  obtain explicit user approval before any `bd create` / `bd dep add` /
+  `bd update` execution. Never auto-apply without confirmation.
+---
+
+# Bead Chain From Plan
+
+Translate the `## Bead chain structure` section of an implementation plan
+into a concrete sequence of `bd` operations: bead creation, dependency
+edges, parent linkages, priority bumps, follow-up bead filing.
+
+The Plan → Bead Chain convention (CLAUDE.md / AGENTS.md) requires every
+non-trivial plan to include the chain section. `superpowers:writing-plans`
+produces the plan body; `bead-chain-design` generates the chain section
+when one is missing; this skill consumes the chain section and materializes
+it into `bd` state. Keep the responsibilities separate so the user can
+review the chain shape (in the plan) before any `bd` mutation.
+
+## When to invoke
+
+- After `superpowers:writing-plans` and `bead-chain-design` have both run on
+  the plan, and the plan-reviewer gate has returned READY
+- Whenever the user says "create the beads", "set up the bead chain",
+  "materialize the chain", or names a plan path and asks to track the work
+- Before invoking `superpowers:subagent-driven-development` or
+  `superpowers:executing-plans` if the plan's tasks should be tracked as beads
+  during execution
+
+The skill does NOT auto-fire by hook — the user (or controller agent)
+explicitly invokes it. This avoids burning beads on plans that turn out to
+need revision.
+
+If the plan lacks the `## Bead chain structure` section, this skill delegates
+to `bead-chain-design` BEFORE proceeding (see Step 1 below).
+
+## Inputs
+
+- **Plan path** (positional arg or detected from recent context): a markdown
+  file under `docs/superpowers/plans/` or `docs/plans/` with a section
+  headed `## Bead chain structure` (case-sensitive, level-2 heading).
+
+If no path is supplied, look in the conversation for the most recent plan
+file path mentioned. If still ambiguous, ask the user which plan.
+
+## Workflow
+
+### Step 1: Read the plan (or sidecar)
+
+Read the entire plan file. Locate the `## Bead chain structure` section
+(level-2 heading, exact wording per CLAUDE.md "Plan → Bead Chain"
+convention).
+
+**If the section is missing:** check for a sidecar file at
+`<plan-path-without-ext>-bead-chain.md` (the location `bead-chain-design`
+writes to when the plan itself is read-only). If neither exists:
+
+1. Surface to the user: "The plan at `<path>` lacks a `## Bead chain
+   structure` section. Generate one via `bead-chain-design` before
+   materializing? (yes / no / abort)"
+2. On `yes`: invoke `bead-chain-design` against the plan, wait for it to
+   complete, then re-read the plan (or sidecar). Proceed to Step 2.
+3. On `no`: ask the user whether the plan is meant to skip bead creation
+   (some plans are too small to warrant a chain). If skip, exit gracefully.
+4. On `abort`: exit without changes.
+
+**If the section is present:** extract:
+
+1. The bead chain tree (typically a fenced text block) showing parent epic,
+   child task beads, grandchildren if four-level.
+2. Each task bead's `bd create` invocation block (fenced bash block with
+   the full `--description` heredoc inline).
+3. Bead update operations: priority bumps (`bd update --priority`), parent
+   re-linkage (`bd update --parent`), close-with-rationale (`bd close`).
+4. Dependency edges (`bd dep add`).
+5. Follow-up beads to file (typically under a "Closing-out operations" or
+   "File new follow-up beads" subheading).
+
+If the section exists but its sub-structure is non-standard (operations
+inline rather than sub-sectioned), parse defensively — look for any
+`bd create`, `bd update`, `bd dep add`, `bd close` invocations inside
+fenced bash blocks within the section.
+
+### Step 2: Validate task bead descriptions
+
+Per CLAUDE.md / AGENTS.md "Plan → Bead Chain" → "Task bead description
+requirement", every `bd create` for a task bead MUST have a description
+with all 8 sections:
+
+1. **Goal** — one-sentence scope
+2. **Design reference** — link to the grounding spec / design doc
+3. **Plan reference** — link to the impl plan with task ID anchor
+4. **TDD acceptance criteria** — named tests or test conditions
+5. **Verification steps** — concrete `task` / `bd` / `jj` commands
+6. **Files touched** — explicit list per the architecture table
+7. **Dependencies** — `bd dep add` edges matching the task graph
+8. **Out of scope** — explicit non-goals
+
+For each `bd create` in the plan's chain section:
+
+- Confirm the description heredoc contains each section heading (case-
+  insensitive match on the bold-title prefix `**Goal:**`, `**Design
+  reference:**`, etc.)
+- **If any section is missing, STOP.** The Plan → Bead Chain convention
+  (CLAUDE.md / AGENTS.md) declares the 8 sections at MUST-level. Materializing
+  a non-compliant task bead would create technical debt at the bead corpus
+  level and break the bead-only-readers invariant. Surface the gap to the
+  user and require one of:
+  - Amend the plan to add the missing sections
+  - Invoke `bead-chain-design` to regenerate the chain section with all 8
+    headings in place
+
+  Only proceed to materialization once every task bead's description is
+  fully compliant.
+
+### Step 3: Pre-state check
+
+Before any execution:
+
+```bash
+bd dolt pull            # Sync from remote so local state is fresh
+bd ready                # Quick sanity check that bd is functional
+```
+
+For each existing bead the plan references (parent epics, beads to update,
+beads to close):
+
+```bash
+bd show <bead-id>
+```
+
+Confirm the bead exists, its current state (open/closed, priority), and its
+description. If the plan says "close `holomush-X`" but the bead is already
+closed, FLAG it. If the plan says "update parent linkage" but the parent has
+moved, FLAG it.
+
+### Step 4: Generate the operation manifest
+
+Build an in-memory list of operations in the order they should execute:
+
+1. **New parent epic** if the chain introduces one (rare — usually the parent already exists). MUST come before any `--parent` linkage updates that reference it.
+2. **Pre-existing-bead updates** (priority bumps, parent linkage, description rewrites) — safe to land once the parent exists.
+3. **`bd close` of supersession candidates** (e.g., a bead that's being closed because the new epic supersedes it).
+4. **New child task beads** in the order their dependencies resolve (topological sort by `Dependencies` declared in each).
+5. **`bd dep add` edges** between newly-created beads.
+6. **Follow-up beads** filed under `holomush-ojw1` or as top-level epics — typically lowest priority, can come last.
+7. **Final sync** — `bd dolt push` to publish.
+
+Display the manifest as a table:
+
+```text
+Bead Chain Manifest for <plan-path>
+
+| # | Op | Target | Description / Title (truncated) |
+|---|----|--------|----------------------------------|
+| 1 | update | holomush-ojw1.3.22 | bump priority P3 → P1 |
+| 2 | update | holomush-ojw1.3.23 | bump priority P3 → P1 |
+| 3 | close  | holomush-ojw1.4.2  | reason: architecturally not applicable |
+| 4 | create | (NEW under ojw1.4) | Phase 3d.3: Cold-tier envelope rename |
+| 5 | create | (NEW under ojw1.4) | Phase 3d.4: Crypto.Enabled default flip |
+| 6 | dep add | ojw1.4.4 → ojw1.4.3 | flag flip blocks on cold-tier |
+| ... |
+```
+
+For new bead creations, show enough of the description that the user can
+spot a missing section or an obviously-wrong scope. Don't dump the entire
+heredoc — show the title + first 100 chars of the Goal section.
+
+### Step 5: Get user confirmation (REQUIRED)
+
+Present the manifest and explicitly ask:
+
+> "Apply N operations to the bead chain? (yes / no / modify)"
+>
+> - `yes` — execute all operations in order, sync at end
+> - `no` — exit without changes
+> - `modify` — describe edits (drop an op, change a description, etc.); after
+>   the edits, re-display the updated manifest and prompt again with the same
+>   `(yes / no / modify)` question. Only proceed to execute when the user
+>   replies with an explicit `yes` against the current manifest state.
+
+Do NOT proceed without an affirmative `yes` against the manifest as currently
+displayed. Do NOT batch-apply. Do NOT execute partial edits inferred from the
+`modify` request without re-displaying the result and getting fresh approval.
+
+### Step 6: Execute operations
+
+For each operation in the approved manifest:
+
+1. Print the exact `bd` command being executed
+2. Run it
+3. Capture the output (especially the new bead ID for `bd create`)
+4. On any failure: STOP, surface the error, ask the user how to proceed
+   (retry, skip, abort)
+
+After `bd create`, the new bead ID is needed for subsequent `bd dep add`
+operations. Maintain a name-to-id mapping during execution. The plan often
+uses placeholder IDs (`ojw1.4.3`, `ojw1.4.4`, etc.) — substitute the real
+IDs returned by `bd create` when running `bd dep add`.
+
+### Step 7: Post-state verification
+
+After all operations succeed:
+
+```bash
+bd show <parent-epic>     # Confirm children list reflects new beads
+bd ready                  # Confirm dep edges produce the right unblocked set
+bd dolt push              # Sync to remote
+```
+
+Print a final summary:
+
+```text
+✓ Bead chain materialized for <plan-path>
+
+Created: N new beads (ojw1.4.3, ojw1.4.4, ...)
+Updated: M existing beads (priority bumps, parent linkage)
+Closed:  K beads (with rationale)
+Edges:   E dependency edges added
+Synced:  bd dolt push complete
+
+First ready task: <bd ready output, top entry>
+```
+
+## Constraints
+
+- **Never use `--force` flags** without explicit user direction (per `bd memories force` → `never-bd-close-force-an-epic-with-open`: closing an epic with open children via `--force` requires user confirmation; the rule generalizes to any destructive `--force` operation).
+- **Never close a bead by re-parenting it** to bypass the dependency check — re-parenting before close is OK only when the new parent legitimately owns the work.
+- **Always run `bd dolt pull` before reading state** and `bd dolt push` after committing changes.
+- **Respect `--parent` long-form** (project rule: don't use `-p` short form).
+- **Always pass `--description`** explicitly; never let `bd create` open an editor.
+- **Use heredoc with `'EOF'` quoting** for descriptions so backticks and `$()` substitutions are preserved verbatim in the bead body.
+- If the plan's description heredoc references markdown-formatted content (links like `[X](path)`), preserve it exactly — bd renders some of this when shown.
+
+## Failure modes
+
+- **Plan section missing**: if no `## Bead chain structure` heading exists in the plan or its sidecar, follow Step 1's delegation flow — offer to invoke `bead-chain-design` to generate the section. If the user declines, ask whether the plan is meant to skip bead creation entirely (some single-task plans are too small to warrant a chain).
+- **Description section missing**: per Step 2, this is a HARD STOP. Materialization MUST NOT proceed until the plan is amended (or regenerated via `bead-chain-design`) so every task bead description includes all 8 required sections. The Plan → Bead Chain convention is MUST-level; non-compliant beads are not acceptable.
+- **Bead already exists**: if `bd show` returns a bead the plan says to create as new (collision), abort and ask the user.
+- **Forward-reference bead**: if a `bd create` description references an ID that doesn't exist yet but will be created later in this run, that's expected — the cross-reference will resolve naturally once the run completes. Do NOT pre-validate cross-references.
+- **`bd dolt push` failure**: common. Retry once. If it persists, leave the local state with the changes applied and ask the user to debug remote sync separately.
+
+## Example session
+
+User says: *"create the beads from `docs/superpowers/plans/2026-05-03-event-payload-crypto-phase3d.md`"*
+
+Skill:
+
+1. Reads the plan, finds the `## Bead chain structure` section at line ~1620.
+2. Validates each task bead description has all 8 sections — finds `ojw1.4.4`'s description is missing the "Out of scope" section.
+3. STOPS and surfaces: "ojw1.4.4 is missing **Out of scope** (8-section MUST per Plan → Bead Chain). Materialization blocked. Options: (a) amend the plan to add the section, or (b) invoke `bead-chain-design` to regenerate."
+4. User picks option (a), edits the plan, re-invokes the skill.
+5. Validation passes; builds manifest of 14 operations (2 priority bumps, 1 close, 7 creates, 11 dep-add edges, 3 follow-up filings).
+6. Shows the manifest table.
+7. Asks for approval. User: "yes".
+8. Executes operations in order, captures new bead IDs, substitutes them into dep-add commands.
+9. Final summary with `bd ready` showing the unblocked tasks.
+
+The user can now invoke `superpowers:subagent-driven-development` against
+the plan with the bead chain already in place.

--- a/.claude/skills/handoff-prompt/SKILL.md
+++ b/.claude/skills/handoff-prompt/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: handoff-prompt
+description: |
+  Generate a self-contained briefing prompt that a fresh Claude session can
+  use to pick up a piece of work without inheriting the current session's
+  context. Use when the user asks for "a handoff", "kickoff prompt", "session
+  starter", "resume prompt", or describes wanting to spin up a separate
+  session for a specific bead, epic, or task. Both Claude and the user can
+  invoke; output is markdown text the user copy-pastes into a new session.
+---
+
+# Handoff Prompt
+
+Generate a paste-ready briefing for a fresh Claude session. The pattern
+recurs whenever a piece of work is large enough to warrant its own session
+and needs full context bootstrapped without inheriting the current
+conversation history.
+
+## When to invoke
+
+- User says: "give me a handoff prompt", "kickoff prompt for that", "a prompt
+  to start it in a new session", "session resume for X", "spin up X in its
+  own session"
+- User completes one phase and wants to start the next one fresh (clean
+  context budget, independent review cadence)
+- A bead is large enough to need its own brainstorm → spec → plan → execute
+  cycle and the work shouldn't ride alongside other in-flight work in the
+  current session
+
+The handoff is FOR a new Claude session that has zero context from the
+current one. Treat it as briefing a smart colleague who just walked into
+the room.
+
+## Inputs
+
+- **Bead ID** (primary anchor): the `bd` issue the new session will work on.
+  If a bead doesn't exist yet, ask whether to file one first.
+- **Optional: spec / design doc path** if the work has one already.
+- **Optional: plan path** if the work has one already.
+- **Optional: cross-cutting surface notes** the user wants to surface.
+
+## Workflow
+
+### Step 1: Gather grounding from the current session
+
+Read the bead in full:
+
+```bash
+bd show <bead-id>
+```
+
+If the bead references a design doc, plan, or other beads, follow those
+references and pull what's relevant. Don't deep-dive — extract enough that
+the prompt is self-contained without becoming the work itself.
+
+If the work spans multiple beads (epic + children, or a chain), capture the
+chain structure briefly.
+
+### Step 2: Identify the cross-cutting surface
+
+Run targeted greps to map the file surface the new session will touch:
+
+```bash
+rg -l "<key-symbol>" --type=go --type=proto --type=ts --type=md
+```
+
+The handoff should name the specific files, not a vague "the auth module".
+Examples that worked well in prior handoffs:
+
+- Concrete file lists with line citations: `internal/eventbus/publisher.go:316,431`
+- Verb-and-symbol map: "drop `LegacyId` field; update consumer paths at X, Y, Z"
+- Pre-read order — which docs to load before any code action
+
+### Step 3: Surface design questions
+
+What decisions does the new session need to make? List them as numbered
+questions, NOT as pre-decided answers. Examples that recur:
+
+- Where does X live? (new column vs new table vs new package)
+- Timing of Y? (at install vs at first use vs on demand)
+- Backwards compat for Z? (drop, deprecate, dual-write)
+- Wire-format transition: one PR or staged?
+- Migration of existing data: required, optional, or skip?
+
+The questions are the framing. The new session's brainstorming pass is what
+answers them.
+
+### Step 4: Restate workflow + safety
+
+Every handoff includes a workflow block that names the project's
+conventions:
+
+- Workspace isolation (`task workspace:new -- <name>`)
+- The brainstorm → spec → plan → execute cycle with adversarial review gates
+  between phases (design-reviewer before plan-writing, plan-reviewer before
+  execution); code-reviewer + crypto-reviewer + abac-reviewer run as
+  PRE-PUSH gates, not between phases
+- Beads-driven tracking (no TodoWrite)
+- Bead chain creation via `bead-chain-from-plan` skill if applicable
+- `task pr-prep` before push
+
+This keeps the new session from re-discovering the project's gates.
+
+### Step 5: List explicit out-of-scope items
+
+The new session will encounter related work and feel pulled to fix it.
+Pre-empt that by listing what's deliberately not part of this scope. Recent
+examples:
+
+- "Reworking core.Actor itself beyond what legacy_id removal needs"
+- "Anything in the broader Phase 4-7 crypto epic line"
+- "Integration tests covering legacy_id behavior in pre-Phase-3a paths"
+
+If the work has known follow-up beads filed, name them so the new session
+doesn't re-file duplicates.
+
+### Step 6: Surface mitigating context / safety nets
+
+What's already in place that makes this work safer than it might appear?
+Examples:
+
+- "Phase 3d's envelope persistence means existing audit rows ARE readable
+  indefinitely with their legacy_id intact"
+- "No external API consumers depend on this surface"
+- "The Phase 3d code-review locked the regression class via
+  TestColdPostgresUnmarshalsEnvelope"
+
+This is morale-preserving and honest about risk.
+
+### Step 7: Format the prompt
+
+Output as a single markdown code block (text fence) so the user can copy
+the whole thing in one paste. The prompt itself uses subheadings and bullet
+lists for the new session's readability.
+
+Standard structure:
+
+````markdown
+```text
+Starting <work title> — `<bead-id>` (<priority>, <epic-or-task>). <One-line
+context: why now, why single-stream-or-parallel, what triggers this.>
+
+**Why this is needed:**
+
+<2-3 sentence motivation. Reference the source decision (grounding doc,
+issue, prior PR review). Be specific about what failure mode this prevents
+or what capability it unlocks.>
+
+**Read first (bead descriptions are sources of truth):**
+
+  bd show <bead-id>          # this work
+  bd show <related-bead>     # closely related; verify scope overlap
+
+**Cross-cutting surface (verify scope by grepping at design time):**
+
+  rg -n "<key-symbol>" --type=<lang>
+
+Per the bead description, at minimum these need updates:
+
+  - <file>:<line> — <one-line what>
+  - <file> — <one-line what>
+  - ...
+
+**Key design questions to surface in brainstorming:**
+
+  1. <question> — <hint at the trade-off space, not the answer>
+  2. <question> — ...
+  3. ...
+
+**Workflow per project conventions (CLAUDE.md / AGENTS.md):**
+
+  1. Set up isolated workspace:
+       task workspace:new -- <session-name>
+       cd <printed-path>
+
+  2. Use `bd ready` to claim, work via beads, never TodoWrite.
+
+  3. Brainstorm → spec → plan → execute, with adversarial review gates
+     between each step:
+       superpowers:brainstorming  (then design-reviewer agent)
+       superpowers:writing-plans  (then plan-reviewer agent)
+       bead-chain-from-plan       (materialize the chain in beads)
+       superpowers:subagent-driven-development
+     Plus pre-push code-reviewer + crypto-reviewer (when crypto-touching)
+     and `task pr-prep`.
+
+  4. The Plan → Bead Chain convention applies (CLAUDE.md / AGENTS.md):
+     parent epic gets task children created from the impl plan; each task
+     bead's description includes the 8 sections (Goal / Design ref / Plan
+     ref / TDD acceptance / Verification / Files touched / Dependencies /
+     Out of scope). Use `bead-chain-design` to write the chain section into
+     the plan, then `bead-chain-from-plan` to materialize.
+
+**Out of scope for <bead-id> (don't accidentally bundle):**
+
+  - <out-of-scope item 1>
+  - <out-of-scope item 2>
+  - ...
+
+**Mitigating context:**
+
+  - <safety net 1>
+  - <safety net 2>
+  - ...
+
+Start with `superpowers:brainstorming` to surface the design questions
+listed above before touching any code.
+```
+````
+
+### Step 8: Show the user
+
+Print the prompt as the markdown code block above, with no editorial
+commentary inside the block. After the block, briefly note:
+
+- The bead ID and any related beads referenced
+- That the new session should be started in a fresh workspace
+  (`task workspace:new -- <suggested-name>`)
+- Whether any of the design decisions have known leaning answers worth
+  flagging in the prompt vs. leaving open
+
+## Constraints
+
+- **No editorial content INSIDE the prompt block.** The prompt is for the
+  new session, not the current one. Any "this is hard because..." comments
+  go after the block, in conversation with the current user.
+- **Keep the prompt under ~80 lines** when reasonable. A new session reading
+  a 200-line briefing is being micromanaged. Trust the brainstorming skill
+  to expand.
+- **Never embed credentials, tokens, or local-machine paths** like
+  `~/.config/...` in the prompt.
+- **Cite the source decision** for any "this is needed because..." claim —
+  link the grounding doc, the bead, or the PR review.
+- **Don't pre-decide design questions** that the new session should answer.
+  Surface the trade-off space; let brainstorming pick.
+- **Respect the project's session-isolation discipline** — every handoff
+  recommends `task workspace:new -- <name>` for the new session.
+- **Match the structure in Step 7.** The shape was extracted from two
+  recent kickoff prompts (Phase 3d resume; `legacy_id` elimination
+  kickoff) and codified here as the convention going forward. New
+  handoffs should follow the same shape so readers develop muscle memory;
+  if the shape doesn't fit a particular work item, surface that to the
+  user rather than silently diverging.
+
+## Origin
+
+The shape codified in Step 7 was extracted from two ad-hoc kickoff prompts
+written by hand in May 2026:
+
+1. **Phase 3d resume** (2026-05-03) — briefed a fresh session on resuming
+   Phase 3d work after Phase 3c had merged. Included current bead state,
+   scope per spec, workspace setup, parallel-eligible work, project
+   conventions, memory hooks worth recalling.
+
+2. **`legacy_id` elimination kickoff** (2026-05-04) — briefed a fresh
+   session on starting a top-level tech-debt epic. Included motivation,
+   read-first list, cross-cutting surface (file map), design questions,
+   workflow per conventions, out-of-scope list, mitigating context.
+
+Both prompts shared a recognizable structure that this skill formalizes.
+Neither was a tested template at the time; the skill is the first place
+where the structure is named as the project's handoff convention.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1024 @@
-CLAUDE.md
+# HoloMUSH Development Guide
+
+This document provides instructions for AI coding assistants working on HoloMUSH.
+
+## Project Overview
+
+HoloMUSH is a modern MUSH platform with:
+
+- Go core with event-oriented architecture
+- Dual protocol support (telnet + web)
+- Plugin system: Lua (gopher-lua), binary (hashicorp/go-plugin), and setting plugins
+- PostgreSQL for all data
+- SvelteKit PWA for web client
+
+**Architecture Reference**: [docs/plans/2026-01-18-holomush-roadmap-design.md](docs/plans/2026-01-18-holomush-roadmap-design.md)
+
+**EventBus Design**: [docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md](docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md)
+
+---
+
+## Documentation Structure
+
+| Directory                | Purpose                                      | Audience                |
+| ------------------------ | -------------------------------------------- | ----------------------- |
+| `site/docs/`             | Public documentation website (zensical)      | All users               |
+| `docs/plans/`            | Implementation plans, in-progress work       | Contributors (internal) |
+| `docs/specs/`            | Design specifications, architectural designs | Contributors (internal) |
+| `docs/superpowers/plans/`| AI-generated implementation plans (superpowers skill) | Contributors (internal) |
+| `docs/superpowers/specs/`| AI-generated design specifications (superpowers skill) | Contributors (internal) |
+
+**Site documentation** (`site/docs/`) is organized by audience:
+
+- `guide/` — For players and game designers
+- `operating/` — For people running HoloMUSH servers
+- `extending/` — For plugin developers building on HoloMUSH
+- `contributing/` — For people contributing to the HoloMUSH codebase
+- `reference/` — Auto-generated API and event references
+
+**Build commands:**
+
+```bash
+task docs:setup   # Install documentation dependencies
+task docs:serve   # Start local dev server
+task docs:build   # Build static site
+```
+
+For sandbox operations at `game.holomush.dev`, see
+[site/docs/operating/sandbox-operations.md](site/docs/operating/sandbox-operations.md)
+and [site/docs/operating/sandbox-restore.md](site/docs/operating/sandbox-restore.md).
+
+---
+
+## ⚠️ Protected Branch Policy
+
+**`main` is a protected branch.** Direct commits to main are not allowed.
+
+| Requirement                        | Description                                         |
+| ---------------------------------- | --------------------------------------------------- |
+| **MUST** create feature branch     | All work happens on feature branches, not main      |
+| **MUST** submit PR for review      | All changes to main require a pull request          |
+| **MUST** pass CI checks            | Tests and linting must pass before merge            |
+| **MUST** use squash merge          | All PRs are squash merged to maintain clean history |
+| **MUST NOT** push directly to main | Branch protection enforces this                     |
+
+**See:** [Pull Request Guide](site/docs/contributing/pr-guide.md) for the complete workflow.
+
+---
+
+## Development Principles
+
+### Test-Driven Development
+
+- Tests MUST be written before implementation
+- Tests MUST pass before any task is complete
+- Use table-driven tests for comprehensive coverage
+- Mock external dependencies (database, network)
+
+### Spec-Driven Development
+
+- Work MUST NOT start without a spec/design/plan
+- Specs live in `docs/specs/` or `docs/superpowers/specs/`
+- Plans live in `docs/plans/` or `docs/superpowers/plans/`
+- The `docs/superpowers/` subdirectories are used by AI tooling (superpowers skills) and are equally valid
+- All specs and plans MUST use RFC2119 keywords
+
+### RFC2119 Keywords
+
+| Keyword        | Meaning                                    |
+| -------------- | ------------------------------------------ |
+| **MUST**       | Absolute requirement                       |
+| **MUST NOT**   | Absolute prohibition                       |
+| **SHOULD**     | Recommended, may ignore with justification |
+| **SHOULD NOT** | Not recommended                            |
+| **MAY**        | Optional                                   |
+
+## Workflow
+
+### Beads-Driven Task Management
+
+All work is tracked via [beads](https://github.com/steveyegge/beads):
+
+```text
+Spec (docs/specs/)
+    ↓
+Epic (bd create "..." --epic)
+    ↓
+Implementation Plan (docs/plans/ — produced by `superpowers:writing-plans`)
+    ↓
+Tasks (bd create "..." -p <epic>)
+    - Dependencies based on file overlap
+    - Dependencies based on conceptual overlap
+```
+
+### Canonical workflow for non-trivial work
+
+For multi-task work (a feature, an epic sub-phase, a substantive refactor),
+the project uses a stage-gated workflow with named skills and adversarial
+review agents between stages. Each stage produces an artifact reviewed by
+the next stage's gate before proceeding.
+
+| Stage | Skill                                                                                         | Output                                                                       | Pre-gate review agent                                              | Notes                                                                |
+| ----- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| 1     | `superpowers:brainstorming`                                                                   | Design decisions surfaced                                                    | (none — conversation only)                                         | Resolves design questions before any artifact lands.                 |
+| 2     | (writes from brainstorming)                                                                   | Grounding spec in `docs/superpowers/specs/`                                  | `design-reviewer` (MUST run; READY/NOT READY)                      | Adversarial gate before plan-writing. Findings cited `path:line`.    |
+| 3     | `superpowers:writing-plans`                                                                   | Impl plan in `docs/superpowers/plans/`                                       | `plan-reviewer` (MUST run; READY/NOT READY)                        | Adversarial gate before bead-chain or execution.                     |
+| 4     | `bead-chain-design`                                                                           | `## Bead chain structure` section in plan                                    | (user reviews proposed split before write)                         | See `### Plan → Bead Chain` for the convention.                      |
+| 5     | `bead-chain-from-plan`                                                                        | `bd` issues + dep edges + parent linkage                                     | (user reviews operation manifest before execute)                   | Materializes the chain. Idempotent dry-run by default.               |
+| 6     | `superpowers:subagent-driven-development` (preferred) or `superpowers:executing-plans`        | Implementation commits                                                       | `crypto-reviewer` / `abac-reviewer` (when applicable) + `code-reviewer` (MUST run before push) | Subagent-driven dispatches per task with two-stage review per task. |
+| 7     | (manual: `gh pr create`)                                                                      | Open PR                                                                      | `task pr-prep` (MUST pass green) + CodeRabbit (auto on push)       | Then `/autofix <PR#>` for the CodeRabbit pass.                       |
+
+**Gate enforcement:** stages 2, 3, and 6 have MUST-run adversarial review
+agents per `## Pre-Push Review Gates`. Skipping requires explicit user
+override (e.g., "skip review", "no review needed").
+
+**When to skip stages:** for small fixes (typo, dependency bump, single-file
+bug fix), skip stages 1-5. Direct bead creation + execution + code-review
+
+- PR is the right shape. The full chain is for multi-task work that
+benefits from explicit decomposition.
+
+### Daily Workflow
+
+```bash
+# 1. Find ready tasks
+bd ready
+
+# 2. Select task, understand context
+bd show <task-id>
+
+# 3. Write failing tests
+
+# 4. Implement until tests pass
+task test
+
+# 5. Update documentation
+
+# 6. Request code review (REQUIRED)
+
+# 7. Address all review findings
+
+# 8. Mark complete
+bd close <task-id>
+```
+
+### Code Review Requirement
+
+All tasks MUST be reviewed before completion. See
+[Pull Request Guide](site/docs/contributing/pr-guide.md) for the complete workflow.
+
+| Requirement                                | Description                                          |
+| ------------------------------------------ | ---------------------------------------------------- |
+| **MUST** use `pr-review-toolkit:review-pr` | Launch comprehensive review using specialized agents |
+| **MUST** address all findings              | Fix issues or document why not applicable            |
+| **MUST NOT** skip review                   | Even for "simple" changes                            |
+
+**Quick workflow:**
+
+1. Complete implementation and tests
+2. Run `task test` and `task lint`
+3. Invoke `/pr-review-toolkit:review-pr`
+4. Address all findings
+5. Create PR or mark task complete
+
+### Plan → Bead Chain
+
+Implementation plans for non-trivial work (multiple tasks under a parent epic)
+MUST include a bead chain that tracks the work in `bd`. Plans without matching
+bead chains drift from execution; bead chains without matching plans duplicate
+the design surface across two sources of truth.
+
+Convention established 2026-05-04 (formalized retrospectively from the Phase 3d
+landing). Plans written before this date may not follow it.
+
+**Plan section requirement:**
+
+Every plan with multiple tracked tasks MUST contain a `## Bead chain structure`
+section (level-2 heading, exact wording, case-sensitive) that:
+
+| Requirement                       | Description                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| **MUST** name the parent epic     | Reference the existing `bd` epic the chain hangs from (or note "create new epic" + scope). |
+| **MUST** list each task bead      | One per `bd create` operation; include grandchildren when four-level depth applies.        |
+| **MUST** note supersession        | Existing beads being closed / superseded with rationale.                                   |
+| **MUST** list follow-up beads     | Beads to file at chain-completion time (deferred work, follow-on epics).                   |
+| **MUST** declare dependencies     | `bd dep add` edges that match the task table's dependency column.                          |
+
+**Task bead description requirement:**
+
+Every `bd create` for a task bead in the chain MUST include all 8 sections in
+its `--description` body:
+
+| Section                       | Required content                                                            |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| **Goal**                      | One-sentence scope statement                                                |
+| **Design reference**          | Link to grounding spec / design doc with section anchor                     |
+| **Plan reference**            | Link to impl plan with task ID anchor                                       |
+| **TDD acceptance criteria**   | Named tests that MUST exist before the task is "done"                       |
+| **Verification steps**        | Concrete commands (`task lint`, `task test -- ./pkg/`, etc.)                |
+| **Files touched**             | Explicit list of paths the task modifies                                    |
+| **Dependencies**              | `bd dep add` edges matching the task graph                                  |
+| **Out of scope**              | Explicit non-goals to prevent scope creep                                   |
+
+The 8 sections enable bead-only readers to understand a task's scope without
+chasing into the plan, and enable plan-only readers to understand task tracking
+without chasing into beads.
+
+**Skills that operate on the chain:**
+
+| Skill                    | Purpose                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| `bead-chain-design`      | Generates the `## Bead chain structure` section into a plan when missing. Runs after `superpowers:writing-plans`. |
+| `bead-chain-from-plan`   | Materializes the chain into actual `bd` issues, dep edges, parent linkages, priority bumps, and follow-up bead filings. Runs after the plan + chain section both exist. |
+
+If a plan lacks the chain section, `bead-chain-from-plan` delegates to
+`bead-chain-design` to create it; the user is consulted before either skill
+mutates state.
+
+## Pre-Push Review Gates
+
+Three adversarial read-only sub-agents gate hand-offs BEFORE the PR surface.
+These complement `pr-review-toolkit:review-pr` (which runs on the PR itself)
+by providing an earlier, in-session review pass.
+
+| Agent             | Fires before                                                                           | Invocation                              |
+| ----------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
+| `design-reviewer` | `superpowers:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
+| `plan-reviewer`   | `superpowers:executing-plans` or `superpowers:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
+| `code-reviewer`   | `bd close`, `jj git push`, or PR creation                                              | `/review-code [<target>]` or auto       |
+| `crypto-reviewer` | `code-reviewer` (runs FIRST), for changes touching `internal/eventbus/crypto/`, `internal/eventbus/codec/`, `internal/eventbus/history/dispatcher.go`, `internal/eventbus/history/cold_postgres.go`, `internal/plugin/event_emitter.go::Emit`, `internal/eventbus/audit/projection.go`, plugin manifest `crypto.emits` declarations, or migrations on `crypto_keys` / `events_audit` | `/review-crypto` or auto via `remind-pre-action-review.sh` |
+| `abac-reviewer`   | `code-reviewer` (runs alongside), for changes touching `internal/access/`              | `/review-abac` or auto via `remind-pre-action-review.sh` |
+
+| Requirement                         | Description                                                                             |
+| ----------------------------------- | --------------------------------------------------------------------------------------- |
+| **MUST** produce grounded findings  | Every finding cites `path:line` for code, `section` for docs, or a verified external source |
+| **MUST** produce a binary verdict   | READY or NOT READY — no "mostly ready with minor concerns"                              |
+| **MUST NOT** apply fixes            | Read-only by construction (`permissionMode: plan` + explicit tool allowlist)            |
+| **MAY** be skipped                  | Only with explicit justification in the commit message or PR description                |
+
+Agent definitions live in `.claude/agents/`; slash commands in
+`.claude/commands/`; persistent memory in `.claude/agent-memory/`
+(checked into VCS).
+
+## Code Conventions
+
+### Go Idioms
+
+- Accept interfaces, return structs
+- Errors are values - handle them explicitly
+- Use context for cancellation and timeouts
+- Prefer composition over inheritance
+- When using accessor methods (e.g., `decision.Reason()`), always include `()` — without parens, Go creates a method value (func pointer) that compiles silently when passed to `...any` parameters (`oops.With`, `slog`)
+
+### Random Number Generation
+
+Always use `crypto/rand`, never `math/rand`. For picking from slices, use a
+`crypto/rand` + `math/big` helper. The `internal/naming` package has `cryptoIntN(n)`
+as an example.
+
+### ULID Generation
+
+Two ULID generators exist; the choice matters for correctness.
+
+| Use case | Generator | Why |
+| --- | --- | --- |
+| **Event IDs** (`core.Event.ID`), session IDs | `core.NewULID()` | Identity and dedup key. Set as `Nats-Msg-Id` header for JetStream dedup within the dedup window; stable across JetStream rebuilds (sequences are not). Ordering is owned by JetStream's per-stream `uint64` seq — **not** ULID lex order. |
+| **Entity primary keys** (players, locations, characters, exits, objects, policies) | `idgen.New()` | Identity, not ordering. Fresh `crypto/rand` entropy per call. |
+
+`core.Event{}` struct literals must use `core.NewEvent()` rather than a raw
+struct literal — `core.NewEvent()` stamps a monotonic ULID via
+`core.NewULID()`. Never construct a `core.Event{}` literal with a manually
+supplied ID (e.g., from `idgen.New()`).
+
+### Error Handling
+
+Use oops for structured errors with context:
+
+```go
+// Wrap existing error with context
+return oops.With("plugin", name).With("operation", "load").Wrap(err)
+
+// Create new error
+return oops.Errorf("validation failed").With("field", fieldName)
+
+// At API boundaries, add error code
+return oops.Code("PLUGIN_LOAD_FAILED").With("plugin", name).Wrap(err)
+```
+
+For logging oops errors, use pkg/errutil:
+
+```go
+errutil.LogError(logger, "operation failed", err)
+```
+
+For testing error codes:
+
+```go
+errutil.AssertErrorCode(t, err, "EXPECTED_CODE")
+errutil.AssertErrorContext(t, err, "key", expectedValue)
+```
+
+### Logging
+
+- Use structured logging (slog)
+- Log at appropriate levels (debug, info, warn, error)
+- Include relevant context in log entries
+
+### Naming
+
+- Use clear, descriptive names
+- Avoid abbreviations except well-known ones (ID, URL, HTTP)
+- Package names are lowercase, single words when possible
+
+### Database Migrations
+
+Migrations live in `internal/store/migrations/` and are embedded at compile time.
+See the full guide at [site/docs/contributing/database-migrations.md](site/docs/contributing/database-migrations.md).
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** use sequential numbering | `000002_`, `000003_`, etc. after baseline |
+| **MUST** provide both `.up.sql` and `.down.sql` | Every migration needs a reversible pair |
+| **MUST** be idempotent | Use `IF NOT EXISTS`, `IF EXISTS`, `ON CONFLICT DO NOTHING` |
+| **MUST NOT** modify the baseline | Add new migrations instead of editing `000001_baseline` |
+| **MUST NOT** use triggers or functions | All logic lives in Go; PostgreSQL is storage only |
+
+### License Headers
+
+All source files MUST include SPDX license headers at the top:
+
+**Go files:**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package foo ...
+package foo
+```
+
+**Shell scripts:**
+
+```bash
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+```
+
+**Protobuf files:**
+
+```protobuf
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+syntax = "proto3";
+```
+
+**YAML files (workflows, configs):**
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+```
+
+| Requirement                         | Description                                         |
+| ----------------------------------- | --------------------------------------------------- |
+| **MUST** include SPDX header        | All `.go`, `.sh`, `.proto` files                    |
+| **SHOULD** include SPDX header      | YAML configuration files where appropriate          |
+| **MUST NOT** add to generated files | Skip `*.pb.go` files                                |
+| **SHOULD** use `task license:add`   | Automatically adds headers to files missing them    |
+| **Auto-added on commit**            | Lefthook pre-commit hook adds headers automatically |
+
+**Directories checked:** `api/`, `cmd/`, `internal/`, `pkg/`, `plugins/`, `scripts/`
+
+**Commands:**
+
+```bash
+task license:check   # Verify all files have headers
+task license:add     # Add missing headers
+```
+
+## Testing
+
+### Coverage Requirements
+
+| Requirement                      | Description                                           |
+| -------------------------------- | ----------------------------------------------------- |
+| **MUST** maintain >80% coverage  | Per-package coverage must exceed 80%                  |
+| **MUST** run `task test:cover`   | To verify coverage before completing work             |
+| **SHOULD** target 90%+ coverage  | For core packages (`internal/core`, `internal/world`) |
+
+### Integration Tests and Refactoring
+
+`task test` does NOT compile `//go:build integration` files. When refactoring
+shared types, interfaces, or packages, always run `task test:int` to catch
+breakage that unit tests miss.
+
+### Test Files
+
+- Tests live next to implementation: `foo.go` → `foo_test.go`
+- Integration tests in `*_integration_test.go`
+- Use build tags for integration tests: `//go:build integration`
+
+### Test Naming
+
+Test names MUST be sentences that communicate behavior. Follow the ACE
+framework: **Action** (what), **Condition** (when/given), **Expectation**
+(then/result).
+
+Reference: [Test Names Should Be Sentences](https://bitfieldconsulting.com/posts/test-names)
+
+**Functions without subtests** — the function name itself is the sentence:
+
+| Pattern | Example |
+| ------- | ------- |
+| Good | `TestConfigDirUsesXDGEnvVarWhenSet` |
+| Good | `TestEnsureDirFailsWhenParentIsAFile` |
+| Bad | `TestConfigDir_EnvVar` |
+| Bad | `TestEnsureDir_Error` |
+
+**Functions with subtests** — parent name identifies the unit under test,
+subtest names carry the sentence:
+
+```go
+func TestHashPassword(t *testing.T) {
+    t.Run("produces valid argon2id hash", func(t *testing.T) { ... })
+    t.Run("rejects empty password", func(t *testing.T) { ... })
+}
+```
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** follow ACE | Every test name communicates action, condition, and expectation |
+| **MUST** use PascalCase | Top-level function names: `TestConfigDirFallsBackToHomeDotConfig` |
+| **SHOULD NOT** use underscores | Exception: `TestType_Method` with subtests (e.g., `TestEngine_Evaluate`) |
+| **MUST** use lowercase subtests | Subtest strings: `"returns ErrNotFound for missing character"` |
+| **MUST NOT** use vague names | No `"success"`, `"error case"`, `"test 1"` |
+
+### Table-Driven Tests
+
+```go
+func TestEventType_String(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    EventType
+        expected string
+    }{
+        {"returns say for event type say", EventTypeSay, "say"},
+        {"returns pose for event type pose", EventTypePose, "pose"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.expected, tt.input.String())
+        })
+    }
+}
+```
+
+### Mocking
+
+- Use interfaces for dependencies
+- Create mock implementations for tests
+- Consider using testify/mock for complex mocks
+
+### Plugin Tests (`internal/plugin`)
+
+Lua plugins use gopher-lua which creates fresh VM state per event delivery.
+Binary plugins use hashicorp/go-plugin and communicate via gRPC.
+
+| Principle                     | Description                                         |
+| ----------------------------- | --------------------------------------------------- |
+| State isolation (Lua)         | Each `DeliverEvent` creates a new Lua state         |
+| No shared state between tests | No need for special test helpers or shared fixtures |
+| Fast startup (Lua)            | ~50μs per Lua state                                 |
+| Process isolation (binary)    | Binary plugins run as separate processes via go-plugin |
+
+### Assertions
+
+Use testify for unit test assertions:
+
+```go
+// Equality
+assert.Equal(t, expected, got)
+
+// Error checking
+require.NoError(t, err)
+assert.Error(t, err)
+
+// Contains
+assert.Contains(t, slice, element)
+```
+
+### Test Quality
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** test both paths | Every exported function needs at least one positive and one negative test |
+| **MUST** assert behavior | No zero-assertion "don't panic" tests |
+| **MUST** focus each test | One behavior per test/subtest — if it needs "and," split it |
+| **SHOULD** use error codes | Prefer `errutil.AssertErrorCode` or `assert.ErrorIs` over string matching |
+| **MUST** use `require` for preconditions | `require.NoError` for setup, `assert.*` for the check under test |
+
+### Mocking with Mockery
+
+Generate mocks with mockery:
+
+```bash
+mockery # Uses .mockery.yaml config
+```
+
+Use generated mocks:
+
+```go
+pub := mocks.NewMockPublisher(t)
+pub.EXPECT().Publish(mock.Anything, mock.Anything).Return(nil)
+```
+
+### Test Engine Helpers
+
+Use `policytest.GrantEngine` for authorization in tests:
+
+```go
+mockAccess := policytest.NewGrantEngine()
+mockAccess.GrantCommandExecution(subject, "say", "look") // Layer 1 grants
+mockAccess.Grant(subject, "emit", "stream")              // Layer 2 / capability grants
+```
+
+Other test engines: `AllowAllEngine()`, `DenyAllEngine()`, `NewErrorEngine(err)`, `NewInfraFailureEngine(t, reason, policyID)`.
+
+### EventBus test harness
+
+`internal/eventbus/eventbustest.New(t)` provides an in-process embedded NATS
+server with `MemoryStorage` for unit and bus-integration tests. It MUST NOT be
+used in E2E tests. E2E tests use the full server stack with a real PG
+testcontainer. The `//go:build !integration` tag on the harness file enforces
+this at compile time.
+
+### Integration Tests with Ginkgo/Gomega (BDD)
+
+| Requirement                           | Description                                |
+| ------------------------------------- | ------------------------------------------ |
+| **MUST** use Ginkgo/Gomega            | All integration tests use BDD-style specs  |
+| **MUST** write feature specs          | User stories become `Describe`/`It` blocks |
+| **MUST** use `//go:build integration` | Tag all integration test files             |
+| **SHOULD** use testcontainers         | For database integration tests             |
+
+**Structure:** Feature specs live in `test/integration/<domain>/`:
+
+```go
+//go:build integration
+
+var _ = Describe("Feature Name", func() {
+    Describe("User story or capability", func() {
+        It("expected behavior in plain English", func() {
+            // Given/When/Then pattern
+            Expect(result).To(Equal(expected))
+        })
+    })
+})
+```
+
+**Async operations:**
+
+```go
+Eventually(func() int {
+    return len(results)
+}).Should(Equal(expected))
+```
+
+**Run integration tests:**
+
+```bash
+go test -race -v -tags=integration ./test/integration/...
+```
+
+## Commands
+
+### Task Commands (Required)
+
+**MUST use `task` for all build, test, lint, and format operations.** Do NOT run `go build`, `go test`, `golangci-lint`, etc. directly.
+
+```bash
+task lint      # Run all linters
+task fmt       # Format all files
+task test      # Run unit tests (compact output via gotestsum)
+task build     # Build binary
+task dev       # Run dev server
+task plugin:build-all              # Discover and compile all binary plugins for linux/amd64
+task plugin:build -- core-scenes   # Build a single binary plugin
+```
+
+**Test commands accept arguments after `--`:**
+
+```bash
+task test                                        # All unit tests
+task test -- ./internal/command/                  # Single package
+task test -- -run TestCapability ./internal/command/  # Specific test
+task test:verbose -- ./internal/command/          # Full verbose output
+task test:int                                    # Integration tests (needs Docker)
+```
+
+| Requirement                            | Description                                       |
+| -------------------------------------- | ------------------------------------------------- |
+| **MUST** use `task`                    | Never run Go/lint/fmt commands directly            |
+| **MUST** run `task test`               | Before claiming any implementation is complete     |
+| **MUST** run `task lint`               | Before committing changes                          |
+| **MUST NOT** disable lint/format rules | Without explicit user confirmation                 |
+| **SHOULD** run `task fmt`              | Before committing to ensure consistent formatting  |
+
+**MUST** run `task pr-prep` before creating a PR or pushing to a PR branch.
+This mirrors all CI jobs (lint, format, schema, license, unit, integration,
+E2E) and MUST pass with zero failures. Do NOT push to a PR branch without
+a green `task pr-prep`. Docker is always available — never skip E2E tests.
+The gate is serialized per user — only one `task pr-prep` runs at a time on
+a given machine. See [pr-prep](site/docs/contributing/pr-prep.md) for
+collision behavior.
+
+### jj Workspace Commands
+
+Workspaces live in a `.worktrees/` directory that is a sibling of the main repo root
+(e.g., `<parent>/.worktrees/<name>`). The exact path is machine-specific.
+
+```bash
+jj workspace add <parent>/.worktrees/<name> --name <name> -r main@origin
+jj workspace forget <name>  # then: rm -rf <parent>/.worktrees/<name>
+```
+
+For the typical case of "start a new isolated Claude session," prefer the
+`task workspace:new -- <name>` wrapper (see "Session isolation" below) which
+handles `.jj/repo`-based path resolution from any cwd, runs `jj git fetch`
+first so `main@origin` is fresh, and is idempotent on re-invocation.
+
+### Session isolation
+
+This repo is developed primarily by concurrent AI agent sessions. Because jj
+snapshots the working copy on every command, two sessions sharing the same
+jj workspace will collide on uncommitted edits. To prevent this:
+
+| Requirement | Description |
+|---|---|
+| **MUST** isolate per session | Start each Claude session in its own jj workspace. Humans: `claude-iso <name>` (shell function below). Agents: `task workspace:new -- <name>`, then `cd <printed-path> && claude` |
+| **SHOULD NOT** edit files in `default` | The `default` workspace is reserved for read-only inspection and one-off throwaway work. A `SessionStart` hook warns when a session begins there |
+| **MUST** clean up post-merge | After your branch lands: `cd <repo-root> && jj workspace forget <name> && rm -rf <repo-parent>/.worktrees/<name>`. The leading `cd` matters — `../.worktrees/<name>` is unsafe from any nested cwd. See "Landing the Plane" for the full sequence. |
+
+**`claude-iso` shell function** — copy into your shell's rc file:
+
+```fish
+# fish: ~/.config/fish/config.fish
+#
+# IMPORTANT: `set var (cmd | tail -n 1); or ...` does NOT propagate the
+# failure of `cmd` because the pipeline's exit status is `tail`'s, not
+# `cmd`'s. We therefore call `task workspace:new` twice — first to check
+# the exit status, then again inside command substitution to capture the
+# path. The second call is idempotent (Phase 2 DoD requirement) and just
+# prints the path for an existing workspace.
+function claude-iso
+    set name $argv[1]
+    task workspace:new -- $name >/dev/null
+    or return $status
+    set ws (task workspace:new -- $name | tail -n 1)
+    cd $ws
+    or return $status
+    exec claude
+end
+```
+
+```bash
+# bash/zsh: ~/.bashrc or ~/.zshrc
+#
+# Same caveat as fish: $(cmd | tail -n 1) carries tail's exit status, not
+# cmd's. Two-call pattern; second call is idempotent.
+claude-iso() {
+  local name="$1"
+  task workspace:new -- "$name" >/dev/null || return $?
+  local ws
+  ws="$(task workspace:new -- "$name" | tail -n 1)"
+  cd "$ws" || return $?
+  exec claude
+}
+```
+
+New worktrees inherit `.claude/` (tracked in git), so `SessionStart`,
+`UserPromptSubmit`, and other Claude Code hooks fire identically in any
+worktree — no hook re-wiring is needed when creating a workspace.
+
+Sub-agents launched via the `Task` tool inherit the parent's workspace. The
+parent is responsible for not dispatching parallel `Task` calls that would
+edit the same files. (Future work MAY add per-`Task` workspace creation.)
+
+### Beads Commands
+
+```bash
+bd ready              # List unblocked tasks
+bd create "title"     # Create task
+bd show <id>          # View task details
+bd close <id>         # Complete task
+bd dep add <a> <b>    # Add dependency
+```
+
+## Directory Structure
+
+```text
+api/                 # Protocol definitions
+  proto/             # Protobuf service definitions
+build/
+  plugins/           # Compiled binary plugin output (gitignored)
+cmd/holomush/        # Server entry point
+docs/
+  plans/             # Implementation plans (internal, in-progress work)
+  specs/             # Design specifications (internal)
+site/                # Documentation website (zensical)
+  docs/
+    guide/           # For players and game designers
+    operating/       # For server operators
+    extending/       # For plugin developers
+    contributing/    # For codebase contributors
+    reference/       # Auto-generated references
+internal/            # Private implementation
+  access/            # ABAC access control system
+  control/           # Control plane (admin API)
+  core/              # Event system, sessions
+  grpc/              # gRPC server implementation
+  logging/           # Structured logging setup
+  observability/     # Metrics and health endpoints
+  plugin/            # Plugin system (Lua, binary, settings; manifests, registry, DAG loader)
+  store/             # PostgreSQL implementations
+  telnet/            # Telnet protocol adapter
+  tls/               # TLS certificate management
+  web/               # WebSocket adapter (future)
+  world/             # World model (objects, locations, exits, scenes)
+  xdg/               # XDG base directory support
+pkg/                 # Public plugin API
+  plugin/            # Plugin SDK types and ServiceProvider interface
+  errutil/           # Error handling utilities
+plugins/             # Lua and binary plugins (each with manifest.yaml)
+scripts/             # Build and utility scripts
+  build-plugins.sh   # Plugin build discovery script
+test/                # Integration tests
+  integration/       # End-to-end test suites
+```
+
+## Key Interfaces
+
+### EventBus (`internal/eventbus`)
+
+The EventBus replaced the former `EventStore.Append` / `LISTEN`/`NOTIFY` stack
+as of the F1-F7 JetStream cutover. The old `EventStore` interface is deleted.
+
+Three narrow interfaces cover the three consumer roles:
+
+```go
+// Publisher — used by EventSink (emit path from plugins and host).
+type Publisher interface {
+    Publish(ctx context.Context, event Event) error
+}
+
+// Subscriber — used by the gRPC Subscribe handler.
+type Subscriber interface {
+    OpenSession(ctx context.Context, sessionID string, filters []Subject) (SessionStream, error)
+}
+
+// HistoryReader — used by the gRPC QueryHistory handler.
+type HistoryReader interface {
+    QueryHistory(ctx context.Context, q HistoryQuery) (HistoryStream, error)
+}
+
+// EventBus is the concrete implementation satisfying all three.
+type EventBus interface {
+    Publisher
+    Subscriber
+    HistoryReader
+}
+```
+
+Ordering is owned by JetStream's per-stream `uint64` sequence. Event ULIDs
+(`core.Event.ID`) are identity and dedup keys, not ordering keys.
+
+Durable audit lives in the `events_audit` PostgreSQL table (host-owned subjects)
+and in plugin-owned audit tables (plugin-declared subjects; e.g.,
+`plugin_core_scenes.scene_log`). `HistoryReader.QueryHistory` transparently
+falls back from JetStream (recent) to PostgreSQL audit (older than JS retention)
+so callers never see the boundary.
+
+Subject naming follows NATS dot-delimited conventions:
+`events.<game_id>.<domain>.<entity-id>[.<facet>...]`. The legacy colon-style
+subjects (e.g., `scene:01ABC`) are translated at the EventSink boundary by
+`internal/eventbus/subjectxlate/`.
+
+See [docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md](docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md)
+for the full design (§3 publish, §4 subscribe, §5 history, §6 PostgreSQL role).
+
+See [site/docs/contributing/event-store.md](site/docs/contributing/event-store.md)
+for contributor-oriented examples (plugin emit, manifest audit declarations,
+embedded vs cluster NATS).
+
+### ServiceRegistry (`internal/plugin`)
+
+Maps proto service names (e.g., `holomush.scene.v1.SceneService`) to registered
+service implementations. Used by the plugin loader to wire up service
+dependencies between plugins.
+
+### ServiceProvider (`pkg/plugin`)
+
+Interface implemented by binary plugins that provide gRPC services. The plugin
+host calls `RegisterServices` during plugin startup to let the plugin register
+its service implementations with the server.
+
+## Architecture Invariants
+
+### Gateway Boundary
+
+The gateway (`cmd/holomush/gateway.go`, `internal/web/`) is a **protocol
+translation layer only**. It MUST NOT access internal services directly:
+
+| Allowed                                  | Prohibited                                    |
+| ---------------------------------------- | --------------------------------------------- |
+| gRPC calls to core server                | Direct access to `WorldService`               |
+| Connection management (register/remove)  | Direct access to `SessionStore` for queries   |
+| Protocol translation (ConnectRPC ↔ gRPC) | Direct access to repositories or the database |
+| Static file serving                      | Business logic or data aggregation            |
+
+All game state queries (location state, presence, characters) MUST flow
+through core server RPCs. The gateway proxies; it does not compute.
+
+## Terminology
+
+Consistent terminology prevents confusion. Use these terms exactly:
+
+| Correct term     | Incorrect / ambiguous | Notes                                                         |
+| ---------------- | --------------------- | ------------------------------------------------------------- |
+| **location**     | room, area, zone      | A place in the world model. Event type: `location_state`.     |
+| **exit**         | door, path, passage   | A connection between locations.                               |
+| **character**    | player, user, avatar  | An in-game entity controlled by a player.                     |
+| **player**       | user, account         | The human behind one or more characters.                      |
+| **session**      | connection            | Server-side state for a character's ongoing presence.         |
+| **connection**   | socket, client        | A single client attachment to a session (terminal/telnet/etc).|
+| **presence**     | who's here, occupants | Active sessions at a location. Derived from session store.    |
+| **grid present** | online, visible       | Character is visible on the grid (has terminal/telnet conn).  |
+| **scene**        | RP scene              | A structured roleplay encounter with participants.            |
+
+**MUST NOT** mix terms. `room` is never used in code, comments, types, events,
+or variable names. The spatial concept is always `location`.
+
+## Core Systems
+
+### World Model (`internal/world`)
+
+The world model provides the spatial foundation:
+
+- **Objects** - Base entity type with ULID identifiers
+- **Locations** - Rooms/areas that contain objects
+- **Exits** - Connections between locations (with optional locks)
+- **Scenes** - RP scenes with participants and privacy settings
+
+All world operations go through `WorldService` which validates constraints and
+persists to PostgreSQL via the repository interface.
+
+### Plugin System (`internal/plugin`)
+
+Three plugin types:
+
+| Type        | Runtime                  | Use case                                    |
+| ----------- | ------------------------ | ------------------------------------------- |
+| `lua`       | gopher-lua VM            | Lightweight event handlers, game logic      |
+| `binary`    | hashicorp/go-plugin subprocess | Complex services with proto contracts  |
+| `setting`   | Bootstrap only           | Configuration-only plugins (no runtime)     |
+
+**Manifest schema** (`manifest.yaml`): Each plugin declares `requires` (proto
+services it depends on), `provides` (proto services it implements), and
+`storage` (database tables it needs). The plugin loader performs DAG dependency
+resolution to determine load order and validates that all `requires` are
+satisfied by another plugin's `provides`.
+
+**Service registry**: Maps proto service names to implementations. Binary
+plugins register services over gRPC; Lua plugins register via the Lua host.
+
+**Plugin admin commands:**
+
+```bash
+plugin list            # List loaded plugins with name, type, version
+plugin info <name>     # Detailed plugin info (requires, provides, storage, commands)
+```
+
+### Plugin Runtime Symmetry
+
+<!-- BEGIN: plugin-runtime-symmetry -->
+
+**Project invariant: Binary and Lua plugins MUST be treated identically by the host.**
+
+Any host-side trust check, validation, or feature MUST apply to both binary and Lua plugins. Asymmetric behavior between plugin runtimes is forbidden — it creates a privilege gradient that violates the core plugin-system design.
+
+When designing security or authorization features that touch plugins:
+
+1. Find the **common code path** that handles both runtimes (e.g., `internal/plugin/event_emitter.go::Emit` is the shared emit boundary for both Lua return-value emits and binary gRPC emits).
+2. Place the gate at the common path so both runtimes are enforced uniformly.
+3. Runtime-specific code (e.g., the gRPC token mechanism for binary plugins, Lua state lifecycle) is acceptable for runtime-specific concerns (e.g., the binary forgery surface that doesn't exist on the Lua path), but MUST NOT differ in policy / trust / manifest-gate dimensions.
+
+Example (this PR — `holomush-ec22.1`): the `actor_kinds_claimable` manifest gate fires at `event_emitter.go::Emit` for both runtimes; the supplemental token-authentication mechanism applies only to the binary gRPC `EmitEvent` boundary because that's where the forgery surface exists. Both runtimes reach the same policy enforcement.
+
+<!-- END: plugin-runtime-symmetry -->
+
+### Access Control (`internal/access`)
+
+Attribute-Based Access Control (ABAC) with phased implementation:
+
+- **Phase 1 (current):** Static evaluator with role-based permissions
+- **Phase 2 (future):** Full ABAC with policies and attributes
+
+```go
+// Check if subject can perform action on resource
+allowed := evaluator.Evaluate(ctx, subject, action, resource)
+```
+
+Default deny - explicit permission required for all operations.
+
+### Command Authorization
+
+Commands use two-layer authorization at dispatch time:
+
+1. **Layer 1 — Command Execution:** `engine.Evaluate(subject, "execute", "command:<name>")` — can this character run this command?
+2. **Layer 2 — Capability Pre-Flight:** `engine.CanPerformAction(subject, action, resource, scope)` per declared capability — does this character have the class of permissions this command needs?
+
+Commands declare capabilities as structured objects:
+
+```go
+Capabilities: []command.Capability{
+    {Action: "write", Resource: "location", Scope: command.ScopeLocal},
+}
+```
+
+Scope: `ScopeSelf` (default, own character), `ScopeLocal` (current location), `ScopeGlobal` (server-wide).
+
+## Patterns
+
+### Event Sourcing
+
+- All game actions produce events
+- Events are immutable and ordered
+- State is derived from event replay
+
+### HTTP Middleware
+
+When wrapping `http.ResponseWriter` (e.g., cookie middleware), the wrapper
+MUST implement `http.Flusher` and `Unwrap()` — ConnectRPC server-streaming
+calls `Flush()` after each frame and will error if the interface is missing.
+
+### Web Client
+
+See `web/CLAUDE.md` for SvelteKit-specific patterns including theme system
+architecture, shadcn-svelte conventions, Tailwind v4 guidance, and Svelte 5
+runes patterns.
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until changes are pushed to the remote. This project is a **jj-colocated repo** — prefer `jj` commands when `.jj/` is present, fall back to plain `git` otherwise.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - `task pr-prep` (mirrors CI)
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY. Detect the VCS first:
+
+   ```bash
+   # Detect: jj-colocated repo?
+   test -d .jj && echo "jj" || echo "git"
+   ```
+
+   **jj-colocated repo** (this project's default):
+
+   ```bash
+   jj git fetch
+   jj rebase -r <change-id> -d main@origin   # rebase ONLY your change (see memory: feedback_jj_rebase_targeted)
+   jj bookmark set <branch> -r @-            # move branch to the commit you want to push
+   jj git push --branch <branch>
+   jj st                                     # verify clean
+   ```
+
+   **Plain git repo** (fallback):
+
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+
+5. **Clean up** — clear stashes, prune remote branches, and (if this work was done in a dedicated workspace per the "Session isolation" discipline) forget and remove the workspace:
+
+   ```bash
+   cd <repo-root>                           # exit the workspace before forgetting it
+   jj workspace forget <name>
+   rm -rf <repo-parent>/.worktrees/<name>
+   ```
+
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+
+- Work is NOT complete until the push succeeds (`jj git push` or `git push`)
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+- **jj-specific**: NEVER use bare `jj rebase -d main` — always scope with `-r <change-id>` to avoid sweeping up other agents' work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,12 +104,39 @@ Spec (docs/specs/)
     ↓
 Epic (bd create "..." --epic)
     ↓
-Implementation Plan (docs/plans/)
+Implementation Plan (docs/plans/ — produced by `superpowers:writing-plans`)
     ↓
 Tasks (bd create "..." -p <epic>)
     - Dependencies based on file overlap
     - Dependencies based on conceptual overlap
 ```
+
+### Canonical workflow for non-trivial work
+
+For multi-task work (a feature, an epic sub-phase, a substantive refactor),
+the project uses a stage-gated workflow with named skills and adversarial
+review agents between stages. Each stage produces an artifact reviewed by
+the next stage's gate before proceeding.
+
+| Stage | Skill                                                                                         | Output                                                                       | Pre-gate review agent                                              | Notes                                                                |
+| ----- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| 1     | `superpowers:brainstorming`                                                                   | Design decisions surfaced                                                    | (none — conversation only)                                         | Resolves design questions before any artifact lands.                 |
+| 2     | (writes from brainstorming)                                                                   | Grounding spec in `docs/superpowers/specs/`                                  | `design-reviewer` (MUST run; READY/NOT READY)                      | Adversarial gate before plan-writing. Findings cited `path:line`.    |
+| 3     | `superpowers:writing-plans`                                                                   | Impl plan in `docs/superpowers/plans/`                                       | `plan-reviewer` (MUST run; READY/NOT READY)                        | Adversarial gate before bead-chain or execution.                     |
+| 4     | `bead-chain-design`                                                                           | `## Bead chain structure` section in plan                                    | (user reviews proposed split before write)                         | See `### Plan → Bead Chain` for the convention.                      |
+| 5     | `bead-chain-from-plan`                                                                        | `bd` issues + dep edges + parent linkage                                     | (user reviews operation manifest before execute)                   | Materializes the chain. Idempotent dry-run by default.               |
+| 6     | `superpowers:subagent-driven-development` (preferred) or `superpowers:executing-plans`        | Implementation commits                                                       | `crypto-reviewer` / `abac-reviewer` (when applicable) + `code-reviewer` (MUST run before push) | Subagent-driven dispatches per task with two-stage review per task. |
+| 7     | (manual: `gh pr create`)                                                                      | Open PR                                                                      | `task pr-prep` (MUST pass green) + CodeRabbit (auto on push)       | Then `/autofix <PR#>` for the CodeRabbit pass.                       |
+
+**Gate enforcement:** stages 2, 3, and 6 have MUST-run adversarial review
+agents per `## Pre-Push Review Gates`. Skipping requires explicit user
+override (e.g., "skip review", "no review needed").
+
+**When to skip stages:** for small fixes (typo, dependency bump, single-file
+bug fix), skip stages 1-5. Direct bead creation + execution + code-review
+
+- PR is the right shape. The full chain is for multi-task work that
+benefits from explicit decomposition.
 
 ### Daily Workflow
 
@@ -154,6 +181,60 @@ All tasks MUST be reviewed before completion. See
 4. Address all findings
 5. Create PR or mark task complete
 
+### Plan → Bead Chain
+
+Implementation plans for non-trivial work (multiple tasks under a parent epic)
+MUST include a bead chain that tracks the work in `bd`. Plans without matching
+bead chains drift from execution; bead chains without matching plans duplicate
+the design surface across two sources of truth.
+
+Convention established 2026-05-04 (formalized retrospectively from the Phase 3d
+landing). Plans written before this date may not follow it.
+
+**Plan section requirement:**
+
+Every plan with multiple tracked tasks MUST contain a `## Bead chain structure`
+section (level-2 heading, exact wording, case-sensitive) that:
+
+| Requirement                       | Description                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| **MUST** name the parent epic     | Reference the existing `bd` epic the chain hangs from (or note "create new epic" + scope). |
+| **MUST** list each task bead      | One per `bd create` operation; include grandchildren when four-level depth applies.        |
+| **MUST** note supersession        | Existing beads being closed / superseded with rationale.                                   |
+| **MUST** list follow-up beads     | Beads to file at chain-completion time (deferred work, follow-on epics).                   |
+| **MUST** declare dependencies     | `bd dep add` edges that match the task table's dependency column.                          |
+
+**Task bead description requirement:**
+
+Every `bd create` for a task bead in the chain MUST include all 8 sections in
+its `--description` body:
+
+| Section                       | Required content                                                            |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| **Goal**                      | One-sentence scope statement                                                |
+| **Design reference**          | Link to grounding spec / design doc with section anchor                     |
+| **Plan reference**            | Link to impl plan with task ID anchor                                       |
+| **TDD acceptance criteria**   | Named tests that MUST exist before the task is "done"                       |
+| **Verification steps**        | Concrete commands (`task lint`, `task test -- ./pkg/`, etc.)                |
+| **Files touched**             | Explicit list of paths the task modifies                                    |
+| **Dependencies**              | `bd dep add` edges matching the task graph                                  |
+| **Out of scope**              | Explicit non-goals to prevent scope creep                                   |
+
+The 8 sections enable bead-only readers to understand a task's scope without
+chasing into the plan, and enable plan-only readers to understand task tracking
+without chasing into beads.
+
+**Skills that operate on the chain:**
+
+| Skill                    | Purpose                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| `bead-chain-design`      | Generates the `## Bead chain structure` section into a plan when missing. Runs after `superpowers:writing-plans`. |
+| `bead-chain-from-plan`   | Materializes the chain into actual `bd` issues, dep edges, parent linkages, priority bumps, and follow-up bead filings. Runs after the plan + chain section both exist. |
+
+If a plan lacks the chain section, `bead-chain-from-plan` delegates to
+`bead-chain-design` to create it; the user is consulted before either skill
+mutates state.
+
 ## Pre-Push Review Gates
 
 Three adversarial read-only sub-agents gate hand-offs BEFORE the PR surface.
@@ -165,6 +246,8 @@ by providing an earlier, in-session review pass.
 | `design-reviewer` | `superpowers:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
 | `plan-reviewer`   | `superpowers:executing-plans` or `superpowers:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
 | `code-reviewer`   | `bd close`, `jj git push`, or PR creation                                              | `/review-code [<target>]` or auto       |
+| `crypto-reviewer` | `code-reviewer` (runs FIRST), for changes touching `internal/eventbus/crypto/`, `internal/eventbus/codec/`, `internal/eventbus/history/dispatcher.go`, `internal/eventbus/history/cold_postgres.go`, `internal/plugin/event_emitter.go::Emit`, `internal/eventbus/audit/projection.go`, plugin manifest `crypto.emits` declarations, or migrations on `crypto_keys` / `events_audit` | `/review-crypto` or auto via `remind-pre-action-review.sh` |
+| `abac-reviewer`   | `code-reviewer` (runs alongside), for changes touching `internal/access/`              | `/review-abac` or auto via `remind-pre-action-review.sh` |
 
 | Requirement                         | Description                                                                             |
 | ----------------------------------- | --------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Three additions to the project's Claude Code automation surface, motivated by friction observed across the four sub-phases of the Phase 3 crypto epic (`holomush-ojw1`).

### 1. `crypto-reviewer` agent (`.claude/agents/crypto-reviewer.md`)

Adversarial domain-specialist reviewer for changes touching the event-payload-cryptography surface. Pre-loaded with the master spec's invariant table, the AAD/DEK/AuthGuard architecture, and the recurring failure modes that the Phase 3 review cycles surfaced repeatedly.

Triggers BEFORE the generic `code-reviewer` for any change touching `internal/eventbus/crypto/`, `codec/`, `history/dispatcher.go`, `event_emitter.go::Emit`, or migrations affecting `crypto_keys` / `events_audit`.

Output: grounded findings cited `path:line` + spec `§N.N`; binary READY / NOT READY verdict.

### 2. `bead-chain-from-plan` skill

Materialize the bead chain described in an implementation plan's `## Bead chain structure` section into actual `bd` issues, dep edges, parent linkages, priority bumps, and follow-up bead filings.

Both Claude and user invocable. ALWAYS dry-runs the operation manifest first and obtains explicit user confirmation before executing any `bd create` / `bd dep add` / `bd update` / `bd close`. Validates each task bead description has all 8 required sections per CLAUDE.md.

Phase 3d created 7 task beads by hand from the plan's bead chain section; this skill makes that repeatable for Phases 4-8 (and the imminent `legacy_id` elimination epic `holomush-w9ml`).

### 3. `handoff-prompt` skill

Generate a paste-ready briefing for a fresh Claude session. Pattern recurs whenever a piece of work is large enough to warrant its own session and needs full context bootstrapped without inheriting current conversation history.

Standard structure: motivation, read-first list, cross-cutting surface (file map), design questions to surface, workflow per project conventions, out-of-scope list, mitigating context.

Motivated by two recent handoffs (Phase 3d resume; `legacy_id` elimination kickoff) that followed the same shape. Codifies the pattern so future handoffs stay consistent.

## Test plan

- [x] `task lint:markdown` clean (all three files)
- [x] Agent frontmatter follows the project's existing pattern (matches `design-reviewer.md` / `plan-reviewer.md` / `code-reviewer.md` shape)
- [x] Skill frontmatter does NOT use `disable-model-invocation` (per user direction — both invocable, with confirmation gates inside the skill body)
- [ ] First real-world use: `legacy_id` elimination epic kickoff (`holomush-w9ml`) will exercise both `handoff-prompt` and `bead-chain-from-plan`
- [ ] First real-world use: Phase 4 (`holomush-fi0n`) lifecycle ops work will exercise `crypto-reviewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bead-chain design and materialization skills (interactive dry-run, explicit approval, required 8-section task descriptions) and a standardized handoff prompt for session handoffs.
  * New agent commands to run focused crypto and ABAC adversarial reviews that produce binary READY/NOT READY verdicts.

* **Chores**
  * Introduced read-only, adversarial crypto/ABAC pre-review gates (crypto gate runs before generic code review) and pre-action hook reminders for relevant work.

* **Documentation**
  * Added comprehensive agents guide and formalized the Plan → Bead chain convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->