### PR TITLE
feat(history): plumb crypto auth options to both hot and cold tiers (holomush-ojw1.7)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -657,6 +657,17 @@ func (a *focusStreamContributorAdapter) QuerySessionStreams(ctx context.Context,
 // be nil only when owners is also nil — the Reader surfaces
 // EVENTBUS_PLUGIN_HISTORY_NOT_WIRED when a plugin-owned subject is
 // queried without a router.
+//
+// guard, dekMgr, and auditEm are optional crypto dependencies. All three
+// MUST be non-nil for any to take effect — partial wiring is a
+// misconfiguration and is rejected silently (the Reader falls back to
+// nil-auth passthrough, same as today). The all-or-nothing contract
+// prevents half-configured states where, e.g., the AuthGuard can permit
+// a decrypt but the DEKManager is nil and panics in decodeAuthorizeAndDispatch.
+//
+// When all three are non-nil, WithHistoryAuth forwards them symmetrically
+// to both hot and cold tiers. When all three are nil (production today),
+// behavior is unchanged — sensitive events surface EVENTBUS_HISTORY_AUTH_GUARD_NIL.
 func newHistoryReader(
 	js jetstream.JetStream,
 	pool *pgxpool.Pool,

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -294,7 +294,7 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	js := s.cfg.EventBus.JS()
 	owners := historyOwnersFromPlugins(pluginManager)
 	router := audit.NewPluginHistoryRouter(pluginAuditClientProvider{mgr: pluginManager})
-	historyReader := newHistoryReader(js, pool, s.cfg.EventBus.Config(), owners, router)
+	historyReader := newHistoryReader(js, pool, s.cfg.EventBus.Config(), owners, router, nil, nil, nil)
 
 	coreServerOpts := []holoGRPC.CoreServerOption{
 		holoGRPC.WithEventStore(eventStore),
@@ -663,6 +663,9 @@ func newHistoryReader(
 	cfg eventbus.Config,
 	owners *audit.OwnerMap,
 	router history.PluginHistoryRouter,
+	guard eventbus.SessionAuthGuard, // nil = passthrough (current behavior)
+	dekMgr eventbus.SessionDEKManager, // nil = passthrough (current behavior)
+	auditEm eventbus.SessionAuditEmitter, // nil = passthrough (current behavior)
 ) eventbus.HistoryReader {
 	opts := []history.Option{}
 	if owners != nil {
@@ -670,6 +673,9 @@ func newHistoryReader(
 	}
 	if router != nil {
 		opts = append(opts, history.WithPluginRouter(router))
+	}
+	if guard != nil && dekMgr != nil && auditEm != nil {
+		opts = append(opts, history.WithHistoryAuth(guard, dekMgr, auditEm))
 	}
 	return history.NewReader(js, pool, cfg.StreamMaxAge, time.Now, opts...)
 }

--- a/cmd/holomush/sub_grpc_test.go
+++ b/cmd/holomush/sub_grpc_test.go
@@ -134,3 +134,12 @@ func TestGrpcSubsystemWrapPublisherWithoutRegistry(t *testing.T) {
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "GRPC_VERB_REGISTRY_MISSING")
 }
+
+// TestNewHistoryReaderNilPreservesNilAuth asserts INV-6: calling
+// newHistoryReader with nil guard/dekMgr/auditEm must preserve
+// the existing nil-auth behavior (no WithHistoryAuth appended).
+func TestNewHistoryReaderNilPreservesNilAuth(t *testing.T) {
+	cfg := eventbus.Config{}.Defaults()
+	reader := newHistoryReader(nil, nil, cfg, nil, nil, nil, nil, nil)
+	assert.NotNil(t, reader, "nil auth must still return a valid HistoryReader")
+}

--- a/docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md
+++ b/docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md
@@ -1,0 +1,632 @@
+# History Reader Crypto Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hot-tier crypto option forwarding to `history.NewReader` (parity with existing `WithCryptoCold`), a convenience `WithHistoryAuth` bundle for both tiers, production wiring at `sub_grpc.go`, and elimination of the E2E `e2eColdTier` shim.
+
+**Architecture:** Three additions to `tier.go` (`hotOpts` field, `WithCryptoHot`, `WithHistoryAuth`) complete the Reader-level option surface. `newHistoryReader` in `sub_grpc.go` gains three optional auth params (nil = passthrough, same behavior as today). The E2E test's 145-line `e2eColdTier` shim is replaced by calling the real `newPostgresColdTier` via `WithHistoryAuth`.
+
+**Tech Stack:** Go, testify, Ginkgo/Gomega (integration)
+
+**Spec:** [docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md](../specs/2026-05-05-history-reader-crypto-options-design.md)
+
+---
+
+### Task 1: Add `hotOpts` field, `WithCryptoHot`, `WithHistoryAuth`, and wire `NewReader`
+
+**Files:**
+
+- Modify: `internal/eventbus/history/tier.go`
+
+- [ ] **Step 1: Add `hotOpts` field to `Reader` struct**
+
+Insert after the `coldOpts` field (after line 212):
+
+```go
+// hotOpts accumulates HotTierOption values supplied via
+// WithCryptoHot(...). They are forwarded to newJetStreamHotTier
+// when NewReader builds the default hot tier. Ignored when the
+// caller injects a test fake via WithHotTier (that path owns its
+// own option wiring).
+hotOpts []HotTierOption
+```
+
+- [ ] **Step 2: Add `WithCryptoHot` function**
+
+Insert after `WithCryptoCold` (after line 161):
+
+```go
+// WithCryptoHot forwards HotTierOption values to the default
+// JetStream hot tier when NewReader builds it. Mirrors WithCryptoCold
+// for hot/cold parity:
+//
+//	history.NewReader(js, pool, max, now,
+//	    history.WithCryptoHot(
+//	        history.WithHistoryAuthGuard(g),
+//	        history.WithHistoryDEKManager(m),
+//	        history.WithHistoryDecryptAuditEmitter(em),
+//	    ),
+//	)
+//
+// No-op when the caller supplies WithHotTier (the test-fake path) —
+// the injected HotTier owns its own option wiring. Multiple
+// WithCryptoHot calls accumulate (last-writer-wins semantics inherited
+// from the underlying HotTierOption setters).
+func WithCryptoHot(opts ...HotTierOption) Option {
+	return func(r *Reader) { r.hotOpts = append(r.hotOpts, opts...) }
+}
+```
+
+- [ ] **Step 3: Add `WithHistoryAuth` function**
+
+Insert after `WithCryptoHot` (after the new function from Step 2):
+
+```go
+// WithHistoryAuth wires AuthGuard + DEKManager + DecryptAuditEmitter
+// into BOTH hot and cold tiers. This is the common case — production
+// and tests always configure tiers symmetrically. Equivalent to
+// calling WithCryptoHot and WithCryptoCold with the matching
+// per-tier option constructors.
+func WithHistoryAuth(
+	g eventbus.SessionAuthGuard,
+	m eventbus.SessionDEKManager,
+	em eventbus.SessionAuditEmitter,
+) Option {
+	return func(r *Reader) {
+		r.hotOpts = append(r.hotOpts,
+			WithHistoryAuthGuard(g),
+			WithHistoryDEKManager(m),
+			WithHistoryDecryptAuditEmitter(em),
+		)
+		r.coldOpts = append(r.coldOpts,
+			WithColdHistoryAuthGuard(g),
+			WithColdHistoryDEKManager(m),
+			WithColdHistoryDecryptAuditEmitter(em),
+		)
+	}
+}
+```
+
+- [ ] **Step 4: Wire `hotOpts` in `NewReader`**
+
+At line 247, change:
+
+```go
+if r.hot == nil && r.js != nil {
+	r.hot = newJetStreamHotTier(r.js, r.selector, r.now)
+}
+```
+
+To:
+
+```go
+if r.hot == nil && r.js != nil {
+	r.hot = newJetStreamHotTier(r.js, r.selector, r.now, r.hotOpts...)
+}
+```
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cd internal/eventbus/history && go build ./...
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(history): add WithCryptoHot, WithHistoryAuth, hotOpts forwarding to NewReader"
+```
+
+---
+
+### Task 2: Unit tests for option forwarding invariants
+
+**Files:**
+
+- Create: `internal/eventbus/history/tier_crypto_options_test.go`
+
+Tests live in `package history` (internal) to access unexported `Reader` fields (`hotOpts`, `coldOpts`). All mocks are minimal stubs compiled inline; no new mockery-generated types.
+
+- [ ] **Step 1: Create the test file with stub types and INV-1**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package history
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+// --- stub types (compile-time interface satisfaction) ---
+
+type stubAuthGuard struct{}
+
+var _ eventbus.SessionAuthGuard = (*stubAuthGuard)(nil)
+
+func (*stubAuthGuard) Check(_ context.Context, _ eventbus.SessionCheckRequest) (eventbus.SessionDecision, error) {
+	return eventbus.SessionDecision{Permit: true}, nil
+}
+
+type stubDEKManager struct{}
+
+var _ eventbus.SessionDEKManager = (*stubDEKManager)(nil)
+
+func (*stubDEKManager) Resolve(_ context.Context, _ codec.KeyID, _ uint32) (codec.Key, error) {
+	return codec.Key{}, nil
+}
+
+type stubAuditEmitter struct{}
+
+var _ eventbus.SessionAuditEmitter = (*stubAuditEmitter)(nil)
+
+func (*stubAuditEmitter) EmitPluginDecrypt(_ context.Context, _ eventbus.PluginDecryptRecord) error {
+	return nil
+}
+
+// TestWithHistoryAuthProducesSameColdOptsAsCryptoCold asserts INV-1:
+// WithHistoryAuth(g, m, em) populates coldOpts identically to calling
+// WithCryptoCold with the matching per-tier constructors.
+func TestWithHistoryAuthProducesSameColdOptsAsCryptoCold(t *testing.T) {
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	bundleR := &Reader{}
+	WithHistoryAuth(g, m, em)(bundleR)
+
+	explicitR := &Reader{}
+	WithCryptoCold(
+		WithColdHistoryAuthGuard(g),
+		WithColdHistoryDEKManager(m),
+		WithColdHistoryDecryptAuditEmitter(em),
+	)(explicitR)
+
+	require.Len(t, bundleR.coldOpts, 3, "WithHistoryAuth produces 3 coldOpts")
+	require.Len(t, explicitR.coldOpts, 3, "WithCryptoCold produces 3 coldOpts")
+
+	// Apply both option sets to fresh tiers and compare results.
+	bundleCT := &postgresColdTier{}
+	for _, o := range bundleR.coldOpts {
+		o(bundleCT)
+	}
+	explicitCT := &postgresColdTier{}
+	for _, o := range explicitR.coldOpts {
+		o(explicitCT)
+	}
+
+	assert.Equal(t, explicitCT.authGuard, bundleCT.authGuard, "authGuard must match")
+	assert.Equal(t, explicitCT.dekManager, bundleCT.dekManager, "dekManager must match")
+	assert.Equal(t, explicitCT.auditEmitter, bundleCT.auditEmitter, "auditEmitter must match")
+}
+```
+
+- [ ] **Step 2: Add INV-2 test (hotOpts symmetry)**
+
+Append to the same file:
+
+```go
+// TestWithHistoryAuthProducesSameHotOptsAsCryptoHot asserts INV-2:
+// WithHistoryAuth(g, m, em) populates hotOpts identically to calling
+// WithCryptoHot with the matching per-tier constructors.
+func TestWithHistoryAuthProducesSameHotOptsAsCryptoHot(t *testing.T) {
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	bundleR := &Reader{}
+	WithHistoryAuth(g, m, em)(bundleR)
+
+	explicitR := &Reader{}
+	WithCryptoHot(
+		WithHistoryAuthGuard(g),
+		WithHistoryDEKManager(m),
+		WithHistoryDecryptAuditEmitter(em),
+	)(explicitR)
+
+	require.Len(t, bundleR.hotOpts, 3, "WithHistoryAuth produces 3 hotOpts")
+	require.Len(t, explicitR.hotOpts, 3, "WithCryptoHot produces 3 hotOpts")
+
+	bundleHT := &jetStreamHotTier{}
+	for _, o := range bundleR.hotOpts {
+		o(bundleHT)
+	}
+	explicitHT := &jetStreamHotTier{}
+	for _, o := range explicitR.hotOpts {
+		o(explicitHT)
+	}
+
+	assert.Equal(t, explicitHT.authGuard, bundleHT.authGuard, "authGuard must match")
+	assert.Equal(t, explicitHT.dekManager, bundleHT.dekManager, "dekManager must match")
+	assert.Equal(t, explicitHT.auditEmitter, bundleHT.auditEmitter, "auditEmitter must match")
+}
+```
+
+- [ ] **Step 3: Add INV-3 test (NewReader forwards hotOpts to hot tier)**
+
+Append to the same file. Uses `eventbustest.New(t)` for an embedded JetStream with MemoryStorage:
+
+```go
+// TestNewReaderForwardsHotOptsToHotTier asserts INV-3: when NewReader builds
+// the default hot tier, HotTierOption values accumulated via WithCryptoHot are
+// forwarded to newJetStreamHotTier. A sentinel option sets a detectable field
+// on the hot tier; after NewReader returns, the sentinel must be visible.
+func TestNewReaderForwardsHotOptsToHotTier(t *testing.T) {
+	embedded := eventbustest.New(t)
+
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	reader := NewReader(
+		embedded.JS,
+		nil,               // no pool — cold tier not needed
+		24*time.Hour,      // streamMaxAge (arbitrary)
+		time.Now,
+		WithCryptoHot(
+			WithHistoryAuthGuard(g),
+			WithHistoryDEKManager(m),
+			WithHistoryDecryptAuditEmitter(em),
+		),
+	)
+
+	ht, ok := reader.hot.(*jetStreamHotTier)
+	require.True(t, ok, "default hot tier must be *jetStreamHotTier")
+	assert.Equal(t, g, ht.authGuard, "authGuard forwarded to hot tier")
+	assert.Equal(t, m, ht.dekManager, "dekManager forwarded to hot tier")
+	assert.Equal(t, em, ht.auditEmitter, "auditEmitter forwarded to hot tier")
+}
+```
+
+Add the required imports to the test file:
+
+```go
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/eventbustest"
+)
+```
+
+The `time` import is needed for `24*time.Hour` in NewReader's streamMaxAge argument and the `time.Now` clock function.
+
+- [ ] **Step 4: Add INV-4 test (WithHotTier bypasses WithCryptoHot)**
+
+Append to the same file:
+
+```go
+// TestWithCryptoHotIgnoredWhenCustomHotTier asserts INV-4:
+// WithCryptoHot options are not forwarded to a custom tier supplied
+// via WithHotTier. The custom tier retains its original fields.
+func TestWithCryptoHotIgnoredWhenCustomHotTier(t *testing.T) {
+	customTier := &jetStreamHotTier{}
+
+	r := &Reader{}
+	WithCryptoHot(WithHistoryAuthGuard(&stubAuthGuard{}))(r) // crypto option
+	WithHotTier(customTier)(r)                                // custom tier, wins
+
+	// cryptoGuard stores the option, but it was never applied —
+	// the custom tier (set by WithHotTier) has nil authGuard.
+	assert.Len(t, r.hotOpts, 1, "hotOpts are accumulated regardless")
+	assert.Same(t, customTier, r.hot, "custom tier is installed")
+	assert.Nil(t, customTier.authGuard, "custom tier authGuard unchanged — crypto not forwarded")
+}
+```
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+task test -- ./internal/eventbus/history/ -run 'TestWithHistoryAuth|TestWithCryptoHot|TestNewReaderForwards'
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 6: Run full history package tests to verify no regressions**
+
+```bash
+task test -- ./internal/eventbus/history/
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "test(history): INV-1/2/3/4 crypto option forwarding unit tests"
+```
+
+---
+
+### Task 3: Production wiring in `sub_grpc.go`
+
+**Files:**
+
+- Modify: `cmd/holomush/sub_grpc.go`
+
+- [ ] **Step 1: Change `newHistoryReader` signature**
+
+At line 661, change:
+
+```go
+func newHistoryReader(
+	js jetstream.JetStream,
+	pool *pgxpool.Pool,
+	cfg eventbus.Config,
+	owners *audit.OwnerMap,
+	router history.PluginHistoryRouter,
+) eventbus.HistoryReader {
+```
+
+To:
+
+```go
+func newHistoryReader(
+	js jetstream.JetStream,
+	pool *pgxpool.Pool,
+	cfg eventbus.Config,
+	owners *audit.OwnerMap,
+	router history.PluginHistoryRouter,
+	guard eventbus.SessionAuthGuard,     // nil = passthrough (current behavior)
+	dekMgr eventbus.SessionDEKManager,   // nil = passthrough (current behavior)
+	auditEm eventbus.SessionAuditEmitter, // nil = passthrough (current behavior)
+) eventbus.HistoryReader {
+```
+
+- [ ] **Step 2: Append `WithHistoryAuth` when non-nil**
+
+Inside `newHistoryReader`, after the `if router != nil` block (after line 673), add:
+
+```go
+	if guard != nil && dekMgr != nil && auditEm != nil {
+		opts = append(opts, history.WithHistoryAuth(guard, dekMgr, auditEm))
+	}
+```
+
+Full function body after changes:
+
+```go
+	opts := []history.Option{}
+	if owners != nil {
+		opts = append(opts, history.WithOwners(owners))
+	}
+	if router != nil {
+		opts = append(opts, history.WithPluginRouter(router))
+	}
+	if guard != nil && dekMgr != nil && auditEm != nil {
+		opts = append(opts, history.WithHistoryAuth(guard, dekMgr, auditEm))
+	}
+	return history.NewReader(js, pool, cfg.StreamMaxAge, time.Now, opts...)
+```
+
+- [ ] **Step 3: Update call site to pass nil**
+
+At line 297, change:
+
+```go
+historyReader := newHistoryReader(js, pool, s.cfg.EventBus.Config(), owners, router)
+```
+
+To:
+
+```go
+historyReader := newHistoryReader(js, pool, s.cfg.EventBus.Config(), owners, router, nil, nil, nil)
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+cd cmd/holomush && go build ./...
+```
+
+Expected: zero errors.
+
+- [ ] **Step 5: Run cmd-level tests**
+
+```bash
+task test -- ./cmd/holomush/
+```
+
+Expected: all tests PASS (existing tests cover the nil-passthrough path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(cmd): plumb crypto auth options through newHistoryReader"
+```
+
+---
+
+### Task 4: Production wiring test for INV-6
+
+**Files:**
+
+- Modify: `cmd/holomush/sub_grpc_test.go`
+
+- [ ] **Step 1: Check if sub_grpc_test.go exists**
+
+```bash
+ls cmd/holomush/sub_grpc_test.go
+```
+
+If the file exists, append to it. If not, create it.
+
+- [ ] **Step 2: Add INV-6 test**
+
+```go
+// TestNewHistoryReaderNilPreservesNilAuth asserts INV-6: calling
+// newHistoryReader with nil guard/dekMgr/auditEm must preserve
+// the existing nil-auth behavior (no WithHistoryAuth appended).
+func TestNewHistoryReaderNilPreservesNilAuth(t *testing.T) {
+	// newHistoryReader(nil, nil, cfg, nil, nil, nil, nil, nil)
+	// must not panic and must return a valid Reader.
+	cfg := eventbus.Config{}.Defaults()
+	reader := newHistoryReader(nil, nil, cfg, nil, nil, nil, nil, nil)
+	assert.NotNil(t, reader, "nil auth must still return a valid HistoryReader")
+}
+```
+
+The existing imports in `sub_grpc_test.go` already include `testing`, `testify/assert`, and `eventbus` — no new imports needed.
+
+- [ ] **Step 3: Run the test**
+
+```bash
+task test -- ./cmd/holomush/ -run TestNewHistoryReaderNil
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "test(cmd): INV-6 nil-auth passthrough for newHistoryReader"
+```
+
+---
+
+### Task 5: Replace E2E `e2eColdTier` shim with `WithHistoryAuth`
+
+**Files:**
+
+- Modify: `test/integration/crypto/e2e_test.go`
+
+- [ ] **Step 1: Delete `e2eColdTier` type and `Read` method**
+
+Delete lines 285-333 (the `e2eColdTier` struct and its `Read` method):
+
+```go
+// Delete: type e2eColdTier struct { ... }
+// Delete: func (c *e2eColdTier) Read(...) { ... }
+```
+
+- [ ] **Step 2: Delete `dispatchColdRow`**
+
+Delete lines 335-399 (the `dispatchColdRow` function):
+
+```go
+// Delete: func dispatchColdRow(...) { ... }
+```
+
+- [ ] **Step 3: Delete `eventFromEnvelope`**
+
+Delete lines 401-423 (the `eventFromEnvelope` function):
+
+```go
+// Delete: func eventFromEnvelope(...) { ... }
+```
+
+- [ ] **Step 4: Delete `protoActorKindToEventbus`**
+
+Delete lines 425-438 (the `protoActorKindToEventbus` function):
+
+```go
+// Delete: func protoActorKindToEventbus(...) { ... }
+```
+
+- [ ] **Step 5: Replace `buildColdReader`**
+
+At the current location of `buildColdReader` (shifts after deletions above), replace:
+
+```go
+func buildColdReader(env *e2eEnv) *history.Reader {
+	coldTier := &e2eColdTier{
+		pool:    env.pool,
+		guard:   env.guard,
+		dekMgr:  env.dekMgr,
+		auditEm: env.auditEm,
+	}
+	farFuture := time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
+	return history.NewReader(env.bus.JS, env.pool,
+		eventbus.Config{}.Defaults().StreamMaxAge,
+		func() time.Time { return farFuture },
+		history.WithColdTier(coldTier),
+	)
+}
+```
+
+With:
+
+```go
+func buildColdReader(env *e2eEnv) *history.Reader {
+	farFuture := time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
+	return history.NewReader(env.bus.JS, env.pool,
+		eventbus.Config{}.Defaults().StreamMaxAge,
+		func() time.Time { return farFuture },
+		history.WithHistoryAuth(env.guard, env.dekMgr, env.auditEm),
+	)
+}
+```
+
+- [ ] **Step 6: Remove unused imports**
+
+After deleting `dispatchColdRow` (which used `proto.Unmarshal`), `eventFromEnvelope` (which used `protoactorKindToEventbus`), and `e2eColdTier` (which used `sql.NullInt64`), the following imports become unused and MUST be removed:
+
+- `database/sql` (only used by `e2eColdTier.Read`'s `sql.NullInt64` scan)
+- `google.golang.org/protobuf/proto` (only used by `dispatchColdRow`'s `proto.Unmarshal`)
+- `eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"` (only used by `dispatchColdRow`, `eventFromEnvelope`, `protoActorKindToEventbus`)
+
+Import removal is verified by `task lint` (Step 8) and `task test:int` (Step 7) — both compile with `-tags=integration`.
+
+- [ ] **Step 7: Run integration tests to verify INV-5**
+
+```bash
+task test:int
+```
+
+Expected: all integration tests PASS, including the 3 cold-tier BDD scenarios in `e2e_test.go`:
+- "delivers plaintext to the participant via cold tier"
+- "delivers metadata-only to a non-participant via cold tier"
+- "round-trips through cold tier with Actor.legacy_id preserved"
+
+- [ ] **Step 8: Run `task lint`**
+
+```bash
+task lint
+```
+
+Expected: zero lint errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj commit -m "test(crypto): replace e2eColdTier shim with WithHistoryAuth (INV-5)"
+```
+
+---
+
+## Post-Implementation: Verification
+
+- [ ] Run `task test` — all unit tests pass
+- [ ] Run `task test:int` — all integration tests pass (INV-5)
+- [ ] Run `task lint` — zero lint errors
+- [ ] Run `task fmt` — no diff
+- [ ] Verify `WithHistoryAuth(nil, nil, nil)` does nothing (INV-6)
+- [ ] Verify `buildColdReader` uses real `newPostgresColdTier` not shim
+- [ ] Verify `e2eColdTier`, `dispatchColdRow`, `eventFromEnvelope`, `protoActorKindToEventbus` are deleted
+
+## Invariant Coverage
+
+| Invariant | Task | Test |
+|-----------|------|------|
+| INV-1: `WithHistoryAuth` coldOpts = `WithCryptoCold(...)` | Task 2 Step 1 | `TestWithHistoryAuthProducesSameColdOptsAsCryptoCold` |
+| INV-2: `WithHistoryAuth` hotOpts = `WithCryptoHot(...)` | Task 2 Step 2 | `TestWithHistoryAuthProducesSameHotOptsAsCryptoHot` |
+| INV-3: `NewReader` forwards `hotOpts` | Task 2 Step 3 | `TestNewReaderForwardsHotOptsToHotTier` (embedded NATS + sentinel) |
+| INV-4: `WithCryptoHot` no-op with `WithHotTier` | Task 2 Step 4 | `TestWithCryptoHotIgnoredWhenCustomHotTier` |
+| INV-5: E2E cold-tier tests unchanged | Task 5 Step 7 | Existing Ginkgo scenarios |
+| INV-6: `newHistoryReader(nil, nil, nil)` preserves nil-auth | Task 4 Step 2 | `TestNewHistoryReaderNilPreservesNilAuth` |

--- a/docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md
+++ b/docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md
@@ -12,7 +12,7 @@
 
 ---
 
-### Task 1: Add `hotOpts` field, `WithCryptoHot`, `WithHistoryAuth`, and wire `NewReader`
+## Task 1: Add `hotOpts` field, `WithCryptoHot`, `WithHistoryAuth`, and wire `NewReader`
 
 **Files:**
 
@@ -590,6 +590,7 @@ task test:int
 ```
 
 Expected: all integration tests PASS, including the 3 cold-tier BDD scenarios in `e2e_test.go`:
+
 - "delivers plaintext to the participant via cold tier"
 - "delivers metadata-only to a non-participant via cold tier"
 - "round-trips through cold tier with Actor.legacy_id preserved"
@@ -630,3 +631,129 @@ jj commit -m "test(crypto): replace e2eColdTier shim with WithHistoryAuth (INV-5
 | INV-4: `WithCryptoHot` no-op with `WithHotTier` | Task 2 Step 4 | `TestWithCryptoHotIgnoredWhenCustomHotTier` |
 | INV-5: E2E cold-tier tests unchanged | Task 5 Step 7 | Existing Ginkgo scenarios |
 | INV-6: `newHistoryReader(nil, nil, nil)` preserves nil-auth | Task 4 Step 2 | `TestNewHistoryReaderNilPreservesNilAuth` |
+
+---
+
+## Bead chain structure
+
+```text
+holomush-ojw1                   (existing epic — Phase 3: EventSink encrypt + AuthGuard + decrypt-on-fanout + downgrade fence)
+└── holomush-ojw1.7             (existing task — plumb cold-tier auth options through history.NewReader)
+    ├── holomush-ojw1.7.1       Reader options + unit tests (INV-1/2/3/4)
+    ├── holomush-ojw1.7.2       Production wiring + INV-6 test
+    └── holomush-ojw1.7.3       Replace e2eColdTier shim with WithHistoryAuth (INV-5)
+```
+
+### holomush-ojw1.7.1
+
+```bash
+bd create \
+  --title "Reader options + unit tests (INV-1/2/3/4)" \
+  --type task \
+  --priority 2 \
+  --parent holomush-ojw1.7 \
+  --description "$(cat <<'EOF'
+**Goal:** Add hotOpts field, WithCryptoHot, WithHistoryAuth to history.Reader, wire hotOpts in NewReader, and write unit tests for invariants INV-1 through INV-4.
+
+**Design reference:** docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md §1 (Reader struct), §2 (Option functions), Invariants table
+
+**Plan reference:** docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md Task 1 + Task 2
+
+**TDD acceptance criteria:**
+- TestWithHistoryAuthProducesSameColdOptsAsCryptoCold (INV-1)
+- TestWithHistoryAuthProducesSameHotOptsAsCryptoHot (INV-2)
+- TestNewReaderForwardsHotOptsToHotTier (INV-3) — uses eventbustest.New(t) for embedded NATS
+- TestWithCryptoHotIgnoredWhenCustomHotTier (INV-4)
+
+**Verification steps:**
+- task test -- ./internal/eventbus/history/ -run 'TestWithHistoryAuth|TestWithCryptoHot|TestNewReaderForwards'
+- task test -- ./internal/eventbus/history/ (full package, verify no regressions)
+
+**Files touched:**
+- internal/eventbus/history/tier.go:191-247 — add hotOpts field, WithCryptoHot, WithHistoryAuth, wire NewReader
+- internal/eventbus/history/tier_crypto_options_test.go — new file, 4 tests in package history (internal)
+
+**Dependencies:** none (can start immediately)
+
+**Out of scope:** Crypto component construction (dek.Manager, authguard.Guard, guardaudit.Emitter); hot-tier subscriber path changes
+EOF
+)"
+```
+
+### holomush-ojw1.7.2
+
+```bash
+bd create \
+  --title "Production wiring + INV-6 test" \
+  --type task \
+  --priority 2 \
+  --parent holomush-ojw1.7 \
+  --description "$(cat <<'EOF'
+**Goal:** Add optional auth params to newHistoryReader in sub_grpc.go, pass nil at the call site, and add INV-6 unit test for nil-auth passthrough.
+
+**Design reference:** docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md §3 (Production wiring)
+
+**Plan reference:** docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md Task 3 + Task 4
+
+**TDD acceptance criteria:**
+- TestNewHistoryReaderNilPreservesNilAuth (INV-6) — nil guard/dekMgr/auditEm must return valid HistoryReader without panic
+
+**Verification steps:**
+- cd cmd/holomush && go build ./... (compile check)
+- task test -- ./cmd/holomush/ (existing tests + INV-6)
+- task test -- ./cmd/holomush/ -run TestNewHistoryReaderNil
+
+**Files touched:**
+- cmd/holomush/sub_grpc.go:661-676 — add 3 auth params to newHistoryReader, append WithHistoryAuth when non-nil
+- cmd/holomush/sub_grpc.go:297 — pass nil, nil, nil at call site
+- cmd/holomush/sub_grpc_test.go — INV-6 nil-passthrough test
+
+**Dependencies:** holomush-ojw1.7.1 (needs WithHistoryAuth to exist before wiring)
+
+**Out of scope:** Crypto component construction in production; non-nil auth wiring (separate future task)
+EOF
+)"
+```
+
+### holomush-ojw1.7.3
+
+```bash
+bd create \
+  --title "Replace e2eColdTier shim with WithHistoryAuth (INV-5)" \
+  --type task \
+  --priority 2 \
+  --parent holomush-ojw1.7 \
+  --description "$(cat <<'EOF'
+**Goal:** Delete the 145-line e2eColdTier shim (e2eColdTier type, dispatchColdRow, eventFromEnvelope, protoActorKindToEventbus), replace buildColdReader to use WithHistoryAuth with the real newPostgresColdTier, and verify E2E cold-tier tests produce identical results.
+
+**Design reference:** docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md §4 (E2E test cleanup)
+
+**Plan reference:** docs/superpowers/plans/2026-05-06-history-reader-crypto-options.md Task 5
+
+**TDD acceptance criteria:**
+- INV-5: Existing Ginkgo BDD scenarios pass unchanged:
+  - "delivers plaintext to the participant via cold tier"
+  - "delivers metadata-only to a non-participant via cold tier"
+  - "round-trips through cold tier with Actor.legacy_id preserved"
+
+**Verification steps:**
+- task test:int (all integration tests, including 3 cold-tier scenarios)
+- task lint (catches unused imports: database/sql, proto, eventbusv1)
+- Verify e2eColdTier, dispatchColdRow, eventFromEnvelope, protoActorKindToEventbus are deleted
+
+**Files touched:**
+- test/integration/crypto/e2e_test.go:285-458 — delete e2eColdTier type+Read, dispatchColdRow, eventFromEnvelope, protoActorKindToEventbus; replace buildColdReader
+
+**Dependencies:** holomush-ojw1.7.2 (needs production wiring complete before shim removal)
+
+**Out of scope:** Production crypto construction; new E2E scenarios beyond existing cold-tier coverage
+EOF
+)"
+```
+
+### `bd dep add` edges
+
+```bash
+bd dep add holomush-ojw1.7.2 holomush-ojw1.7.1   # 7.2 depends on WithHistoryAuth from 7.1
+bd dep add holomush-ojw1.7.3 holomush-ojw1.7.2   # 7.3 depends on production wiring from 7.2
+```

--- a/docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md
+++ b/docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md
@@ -1,0 +1,153 @@
+# History Reader Crypto Options — Design Spec
+
+**Date:** 2026-05-05
+**Bead:** `holomush-ojw1.7`
+**Parent epic:** `holomush-ojw1` Phase 3: EventSink encrypt + AuthGuard + decrypt-on-fanout + downgrade fence
+
+## Problem
+
+`history.NewReader` cannot forward crypto dependencies (AuthGuard, DEKManager, DecryptAuditEmitter) to its default hot and cold tiers. The per-tier option types exist (`HotTierOption` at `hot_jetstream.go:28`, `ColdTierOption` at `cold_postgres.go:43`) and `WithCryptoCold` already forwards cold-tier options, but:
+
+- No `WithCryptoHot` equivalent exists — the hot tier is built bare at `tier.go:247`
+- Production at `sub_grpc.go:newHistoryReader` passes no crypto options
+- The E2E test (`e2e_test.go`) reinvents the cold dispatch chain with a 145-line `e2eColdTier` shim rather than using the real `newPostgresColdTier` with options
+
+## Goals
+
+- History Reader MUST support forwarding crypto options to the default hot tier, achieving parity with the existing `WithCryptoCold` cold-tier path
+- A convenience option MUST exist to wire both tiers with the same AuthGuard, DEKManager, and DecryptAuditEmitter in a single call
+- Production MUST have a call-site API (`newHistoryReader`) that accepts (or skips) crypto dependencies
+- E2E tests MUST use the real production cold tier wired via options rather than a duplicated 145-line shim
+- Crypto component construction in production is explicitly OUT OF SCOPE — this task delivers the plumbing; a separate task provides the water
+
+## Design
+
+### 1. Reader struct changes (`tier.go`)
+
+Add `hotOpts` field mirroring existing `coldOpts`:
+
+```go
+hotOpts []HotTierOption  // forwarded to newJetStreamHotTier; mirror of coldOpts
+```
+
+Wire it in `NewReader` at line 247:
+
+```go
+// Before:
+r.hot = newJetStreamHotTier(r.js, r.selector, r.now)
+// After:
+r.hot = newJetStreamHotTier(r.js, r.selector, r.now, r.hotOpts...)
+```
+
+### 2. New Option functions (`tier.go`)
+
+Three additions near `WithCryptoCold` (line 159):
+
+```go
+// WithCryptoHot forwards HotTierOption values to the default JetStream hot
+// tier when NewReader builds it. Mirrors WithCryptoCold for hot/cold parity.
+// No-op when the caller supplies WithHotTier. Multiple calls accumulate.
+func WithCryptoHot(opts ...HotTierOption) Option {
+    return func(r *Reader) { r.hotOpts = append(r.hotOpts, opts...) }
+}
+
+// WithHistoryAuth wires AuthGuard + DEKManager + DecryptAuditEmitter into
+// BOTH hot and cold tiers. This is the common case — production and tests
+// always configure tiers symmetrically.
+func WithHistoryAuth(
+    g eventbus.SessionAuthGuard,
+    m eventbus.SessionDEKManager,
+    em eventbus.SessionAuditEmitter,
+) Option {
+    return func(r *Reader) {
+        r.hotOpts = append(r.hotOpts,
+            WithHistoryAuthGuard(g),
+            WithHistoryDEKManager(m),
+            WithHistoryDecryptAuditEmitter(em),
+        )
+        r.coldOpts = append(r.coldOpts,
+            WithColdHistoryAuthGuard(g),
+            WithColdHistoryDEKManager(m),
+            WithColdHistoryDecryptAuditEmitter(em),
+        )
+    }
+}
+```
+
+### 3. Production wiring (`sub_grpc.go`)
+
+Change `newHistoryReader` signature to accept optional auth parameters:
+
+```go
+func newHistoryReader(
+    js jetstream.JetStream,
+    pool *pgxpool.Pool,
+    cfg eventbus.Config,
+    owners *audit.OwnerMap,
+    router history.PluginHistoryRouter,
+    guard eventbus.SessionAuthGuard,     // NEW — nil = passthrough
+    dekMgr eventbus.SessionDEKManager,   // NEW — nil = passthrough
+    auditEm eventbus.SessionAuditEmitter, // NEW — nil = passthrough
+) eventbus.HistoryReader {
+```
+
+At the call site in `Start()` (line 297), pass nil for all three:
+
+```go
+historyReader := newHistoryReader(js, pool, s.cfg.EventBus.Config(), owners, router, nil, nil, nil)
+```
+
+When non-nil, `newHistoryReader` appends `WithHistoryAuth(guard, dekMgr, auditEm)` to opts. Behavior unchanged when nil — `decodeAuthorizeAndDispatch` returns `EVENTBUS_HISTORY_AUTH_GUARD_NIL` for sensitive events (same as today).
+
+### 4. E2E test cleanup (`e2e_test.go`)
+
+Replace `buildColdReader` to use `WithHistoryAuth` instead of the `e2eColdTier` shim:
+
+```go
+func buildColdReader(env *e2eEnv) *history.Reader {
+    farFuture := time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
+    return history.NewReader(env.bus.JS, env.pool,
+        eventbus.Config{}.Defaults().StreamMaxAge,
+        func() time.Time { return farFuture },
+        history.WithHistoryAuth(env.guard, env.dekMgr, env.auditEm),
+    )
+}
+```
+
+Delete the following (no longer needed):
+- `e2eColdTier` type (lines 290-295)
+- `e2eColdTier.Read` (lines 297-333)
+- `dispatchColdRow` (lines 338-399)
+- `eventFromEnvelope` (lines 402-423)
+- `protoActorKindToEventbus` (lines 425-438)
+
+The test assertions (lines 560-640) are unchanged — they call `reader.QueryHistory` and verify the same fields.
+
+## What this does NOT do
+
+- Does NOT construct `dek.Manager` / `authguard.Guard` / `guardaudit.Emitter` in production. Those require a production KEK source (env var, file, or Vault) and are deferred to a separate task.
+- Does NOT change the hot-tier subscriber path (`JetStreamSubscriber`) — that is already wired with auth options.
+- Does NOT add hot-tier auth options to any existing production code path. The pipes are built; water flows when crypto bootstrap lands.
+
+## Invariants
+
+| ID | Invariant | Verification |
+|----|-----------|-------------|
+| INV-1 | `WithHistoryAuth(g, m, em)` produces the same `coldOpts` as `WithCryptoCold(WithColdHistoryAuthGuard(g), WithColdHistoryDEKManager(m), WithColdHistoryDecryptAuditEmitter(em))` | Unit test — construct two Readers, deep-equal their `coldOpts` |
+| INV-2 | `WithHistoryAuth(g, m, em)` produces the same `hotOpts` as `WithCryptoHot(WithHistoryAuthGuard(g), WithHistoryDEKManager(m), WithHistoryDecryptAuditEmitter(em))` | Unit test — construct two Readers, deep-equal their `hotOpts` |
+| INV-3 | `NewReader` forwards `hotOpts` to `newJetStreamHotTier` when building the default hot tier | Unit test — inject mock HotTierOption that sets a sentinel, verify sentinel propagated |
+| INV-4 | `WithCryptoHot` is a no-op when `WithHotTier` is also supplied | Unit test — supply both, verify `hotOpts` not forwarded to custom tier |
+| INV-5 | E2E cold-tier tests produce identical results with `WithHistoryAuth` as with the `e2eColdTier` shim | Integration — existing Ginkgo tests pass unchanged |
+| INV-6 | `newHistoryReader(nil, nil, nil)` preserves existing nil-auth behavior | Unit test — verify `WithHistoryAuth` not appended when all three params are nil |
+
+INV-1 through INV-4 require access to unexported `Reader` fields (`hotOpts`, `coldOpts`). These tests MUST live in `package history` (internal), not `package history_test`. The `internal/eventbus/history/` directory already has 10 internal test files; add to one or create a new one.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `internal/eventbus/history/tier.go` | Add `hotOpts` field, `WithCryptoHot`, `WithHistoryAuth`, wire `hotOpts` in `NewReader` |
+| `internal/eventbus/history/tier_test.go` | Tests for INV-1 through INV-4, INV-6 |
+| `cmd/holomush/sub_grpc.go` | Add auth params to `newHistoryReader` signature, pass nil at call site |
+| `cmd/holomush/sub_grpc_test.go` | Test for nil-passthrough behavior (INV-6) |
+| `test/integration/crypto/e2e_test.go` | Replace `e2eColdTier` shim with `WithHistoryAuth`, delete dead code |

--- a/docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md
+++ b/docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md
@@ -115,6 +115,7 @@ func buildColdReader(env *e2eEnv) *history.Reader {
 ```
 
 Delete the following (no longer needed):
+
 - `e2eColdTier` type (lines 290-295)
 - `e2eColdTier.Read` (lines 297-333)
 - `dispatchColdRow` (lines 338-399)

--- a/internal/eventbus/history/tier.go
+++ b/internal/eventbus/history/tier.go
@@ -160,6 +160,50 @@ func WithCryptoCold(opts ...ColdTierOption) Option {
 	return func(r *Reader) { r.coldOpts = append(r.coldOpts, opts...) }
 }
 
+// WithCryptoHot forwards HotTierOption values to the default
+// JetStream hot tier when NewReader builds it. Mirrors WithCryptoCold
+// for hot/cold parity:
+//
+//	history.NewReader(js, pool, max, now,
+//	    history.WithCryptoHot(
+//	        history.WithHistoryAuthGuard(g),
+//	        history.WithHistoryDEKManager(m),
+//	        history.WithHistoryDecryptAuditEmitter(em),
+//	    ),
+//	)
+//
+// No-op when the caller supplies WithHotTier (the test-fake path) —
+// the injected HotTier owns its own option wiring. Multiple
+// WithCryptoHot calls accumulate (last-writer-wins semantics inherited
+// from the underlying HotTierOption setters).
+func WithCryptoHot(opts ...HotTierOption) Option {
+	return func(r *Reader) { r.hotOpts = append(r.hotOpts, opts...) }
+}
+
+// WithHistoryAuth wires AuthGuard + DEKManager + DecryptAuditEmitter
+// into BOTH hot and cold tiers. This is the common case — production
+// and tests always configure tiers symmetrically. Equivalent to
+// calling WithCryptoHot and WithCryptoCold with the matching
+// per-tier option constructors.
+func WithHistoryAuth(
+	g eventbus.SessionAuthGuard,
+	m eventbus.SessionDEKManager,
+	em eventbus.SessionAuditEmitter,
+) Option {
+	return func(r *Reader) {
+		r.hotOpts = append(r.hotOpts,
+			WithHistoryAuthGuard(g),
+			WithHistoryDEKManager(m),
+			WithHistoryDecryptAuditEmitter(em),
+		)
+		r.coldOpts = append(r.coldOpts,
+			WithColdHistoryAuthGuard(g),
+			WithColdHistoryDEKManager(m),
+			WithColdHistoryDecryptAuditEmitter(em),
+		)
+	}
+}
+
 // HotTier reads the JetStream-hosted recent slice of history. Exported so
 // tests and alternate storage backends can plug in.
 type HotTier interface {
@@ -210,6 +254,13 @@ type Reader struct {
 	// caller injects a test fake via WithColdTier (that path owns its
 	// own option wiring).
 	coldOpts []ColdTierOption
+
+	// hotOpts accumulates HotTierOption values supplied via
+	// WithCryptoHot(...). They are forwarded to newJetStreamHotTier
+	// when NewReader builds the default hot tier. Ignored when the
+	// caller injects a test fake via WithHotTier (that path owns its
+	// own option wiring).
+	hotOpts []HotTierOption
 }
 
 // NewReader constructs a Reader. `js` and `pool` MAY be nil if the caller
@@ -244,7 +295,7 @@ func NewReader(js jetstream.JetStream, pool *pgxpool.Pool, streamMaxAge time.Dur
 	// tier nil when its resource is nil is legitimate — e.g. a pure-unit
 	// test that only exercises cold-side logic.
 	if r.hot == nil && r.js != nil {
-		r.hot = newJetStreamHotTier(r.js, r.selector, r.now)
+		r.hot = newJetStreamHotTier(r.js, r.selector, r.now, r.hotOpts...)
 	}
 	if r.cold == nil && r.pool != nil {
 		r.cold = newPostgresColdTier(r.pool, r.coldOpts...)

--- a/internal/eventbus/history/tier_crypto_options_test.go
+++ b/internal/eventbus/history/tier_crypto_options_test.go
@@ -156,3 +156,23 @@ func TestWithCryptoHotIgnoredWhenCustomHotTier(t *testing.T) {
 	assert.Same(t, customTier, r.hot, "custom tier is installed")
 	assert.Nil(t, customTier.authGuard, "custom tier authGuard unchanged — crypto not forwarded")
 }
+
+// TestNewReaderDefaultNoAuthOptions asserts INV-6 (internal check):
+// NewReader without WithCryptoHot, WithCryptoCold, or WithHistoryAuth
+// must produce a Reader whose hotOpts and coldOpts are empty — the
+// zero-value nil-auth passthrough path.
+func TestNewReaderDefaultNoAuthOptions(t *testing.T) {
+	embedded := eventbustest.New(t)
+
+	reader := NewReader(
+		embedded.JS,
+		nil,
+		24*time.Hour,
+		time.Now,
+		// No WithCryptoHot, WithCryptoCold, or WithHistoryAuth
+	)
+
+	assert.Empty(t, reader.hotOpts, "hotOpts must be empty when no crypto options passed")
+	assert.Empty(t, reader.coldOpts, "coldOpts must be empty when no crypto options passed")
+	assert.NotNil(t, reader.hot, "default hot tier still constructed")
+}

--- a/internal/eventbus/history/tier_crypto_options_test.go
+++ b/internal/eventbus/history/tier_crypto_options_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package history
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/eventbustest"
+)
+
+// --- stub types (compile-time interface satisfaction) ---
+
+type stubAuthGuard struct{}
+
+var _ eventbus.SessionAuthGuard = (*stubAuthGuard)(nil)
+
+func (*stubAuthGuard) Check(_ context.Context, _ eventbus.SessionCheckRequest) (eventbus.SessionDecision, error) {
+	return eventbus.SessionDecision{Permit: true}, nil
+}
+
+type stubDEKManager struct{}
+
+var _ eventbus.SessionDEKManager = (*stubDEKManager)(nil)
+
+func (*stubDEKManager) Resolve(_ context.Context, _ codec.KeyID, _ uint32) (codec.Key, error) {
+	return codec.Key{}, nil
+}
+
+type stubAuditEmitter struct{}
+
+var _ eventbus.SessionAuditEmitter = (*stubAuditEmitter)(nil)
+
+func (*stubAuditEmitter) EmitPluginDecrypt(_ context.Context, _ eventbus.PluginDecryptRecord) error {
+	return nil
+}
+
+// TestWithHistoryAuthProducesSameColdOptsAsCryptoCold asserts INV-1:
+// WithHistoryAuth(g, m, em) populates coldOpts identically to calling
+// WithCryptoCold with the matching per-tier constructors.
+func TestWithHistoryAuthProducesSameColdOptsAsCryptoCold(t *testing.T) {
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	bundleR := &Reader{}
+	WithHistoryAuth(g, m, em)(bundleR)
+
+	explicitR := &Reader{}
+	WithCryptoCold(
+		WithColdHistoryAuthGuard(g),
+		WithColdHistoryDEKManager(m),
+		WithColdHistoryDecryptAuditEmitter(em),
+	)(explicitR)
+
+	require.Len(t, bundleR.coldOpts, 3, "WithHistoryAuth produces 3 coldOpts")
+	require.Len(t, explicitR.coldOpts, 3, "WithCryptoCold produces 3 coldOpts")
+
+	bundleCT := &postgresColdTier{}
+	for _, o := range bundleR.coldOpts {
+		o(bundleCT)
+	}
+	explicitCT := &postgresColdTier{}
+	for _, o := range explicitR.coldOpts {
+		o(explicitCT)
+	}
+
+	assert.Equal(t, explicitCT.authGuard, bundleCT.authGuard, "authGuard must match")
+	assert.Equal(t, explicitCT.dekManager, bundleCT.dekManager, "dekManager must match")
+	assert.Equal(t, explicitCT.auditEmitter, bundleCT.auditEmitter, "auditEmitter must match")
+}
+
+// TestWithHistoryAuthProducesSameHotOptsAsCryptoHot asserts INV-2:
+// WithHistoryAuth(g, m, em) populates hotOpts identically to calling
+// WithCryptoHot with the matching per-tier constructors.
+func TestWithHistoryAuthProducesSameHotOptsAsCryptoHot(t *testing.T) {
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	bundleR := &Reader{}
+	WithHistoryAuth(g, m, em)(bundleR)
+
+	explicitR := &Reader{}
+	WithCryptoHot(
+		WithHistoryAuthGuard(g),
+		WithHistoryDEKManager(m),
+		WithHistoryDecryptAuditEmitter(em),
+	)(explicitR)
+
+	require.Len(t, bundleR.hotOpts, 3, "WithHistoryAuth produces 3 hotOpts")
+	require.Len(t, explicitR.hotOpts, 3, "WithCryptoHot produces 3 hotOpts")
+
+	bundleHT := &jetStreamHotTier{}
+	for _, o := range bundleR.hotOpts {
+		o(bundleHT)
+	}
+	explicitHT := &jetStreamHotTier{}
+	for _, o := range explicitR.hotOpts {
+		o(explicitHT)
+	}
+
+	assert.Equal(t, explicitHT.authGuard, bundleHT.authGuard, "authGuard must match")
+	assert.Equal(t, explicitHT.dekManager, bundleHT.dekManager, "dekManager must match")
+	assert.Equal(t, explicitHT.auditEmitter, bundleHT.auditEmitter, "auditEmitter must match")
+}
+
+// TestNewReaderForwardsHotOptsToHotTier asserts INV-3: when NewReader builds
+// the default hot tier, HotTierOption values accumulated via WithCryptoHot are
+// forwarded to newJetStreamHotTier. A sentinel option sets a detectable field
+// on the hot tier; after NewReader returns, the sentinel must be visible.
+func TestNewReaderForwardsHotOptsToHotTier(t *testing.T) {
+	embedded := eventbustest.New(t)
+
+	g := &stubAuthGuard{}
+	m := &stubDEKManager{}
+	em := &stubAuditEmitter{}
+
+	reader := NewReader(
+		embedded.JS,
+		nil,
+		24*time.Hour,
+		time.Now,
+		WithCryptoHot(
+			WithHistoryAuthGuard(g),
+			WithHistoryDEKManager(m),
+			WithHistoryDecryptAuditEmitter(em),
+		),
+	)
+
+	ht, ok := reader.hot.(*jetStreamHotTier)
+	require.True(t, ok, "default hot tier must be *jetStreamHotTier")
+	assert.Equal(t, g, ht.authGuard, "authGuard forwarded to hot tier")
+	assert.Equal(t, m, ht.dekManager, "dekManager forwarded to hot tier")
+	assert.Equal(t, em, ht.auditEmitter, "auditEmitter forwarded to hot tier")
+}
+
+// TestWithCryptoHotIgnoredWhenCustomHotTier asserts INV-4:
+// WithCryptoHot options are not forwarded to a custom tier supplied
+// via WithHotTier. The custom tier retains its original fields.
+func TestWithCryptoHotIgnoredWhenCustomHotTier(t *testing.T) {
+	customTier := &jetStreamHotTier{}
+
+	r := &Reader{}
+	WithCryptoHot(WithHistoryAuthGuard(&stubAuthGuard{}))(r)
+	WithHotTier(customTier)(r)
+
+	assert.Len(t, r.hotOpts, 1, "hotOpts are accumulated regardless")
+	assert.Same(t, customTier, r.hot, "custom tier is installed")
+	assert.Nil(t, customTier.authGuard, "custom tier authGuard unchanged — crypto not forwarded")
+}

--- a/internal/plugin/identity_registry_test.go
+++ b/internal/plugin/identity_registry_test.go
@@ -48,7 +48,7 @@ func (s *stubPluginRepo) Upsert(_ context.Context, in store.PluginUpsertInput) (
 		}
 	}
 	id := ulid.ULID{}
-	copy(id[:], []byte(in.Name+"00000000000000000000")[:16])
+	copy(id[:], []byte(in.Name + "00000000000000000000")[:16])
 	return id, nil, nil
 }
 
@@ -299,9 +299,11 @@ func (h *unloadStubHost) Unload(_ context.Context, _ string) error { return h.un
 func (h *unloadStubHost) DeliverEvent(_ context.Context, _ string, _ pluginsdk.Event) ([]pluginsdk.EmitEvent, error) {
 	return nil, nil
 }
+
 func (h *unloadStubHost) DeliverCommand(_ context.Context, _ string, _ pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error) {
 	return nil, nil
 }
+
 func (h *unloadStubHost) QuerySessionStreams(_ context.Context, _ string, _ SessionStreamsRequest) ([]string, error) {
 	return nil, nil
 }
@@ -317,15 +319,19 @@ type unloadStubPolicyInstaller struct {
 func (p *unloadStubPolicyInstaller) InstallPluginPolicies(_ context.Context, _ string, _ []ManifestPolicy) error {
 	return nil
 }
+
 func (p *unloadStubPolicyInstaller) InstallPluginPoliciesWithManifest(_ context.Context, _ *Manifest, _ []ManifestPolicy) error {
 	return nil
 }
+
 func (p *unloadStubPolicyInstaller) RemovePluginPolicies(_ context.Context, _ string) error {
 	return p.removeErr
 }
+
 func (p *unloadStubPolicyInstaller) ReplacePluginPolicies(_ context.Context, _ string, _ []ManifestPolicy) error {
 	return nil
 }
+
 func (p *unloadStubPolicyInstaller) ReplacePluginPoliciesWithManifest(_ context.Context, _ *Manifest, _ []ManifestPolicy) error {
 	return nil
 }

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -10,24 +10,16 @@
 // character-binding (the participant scenario) and plugin-actor (the
 // Decision 5 regression lock).
 //
-// Cold-tier wiring note: as of CodeRabbit autofix Pass 2 (PR #3521,
-// 2026-05-04), history.NewReader exposes WithCryptoCold(opts...) which
-// forwards ColdTierOption values to the default postgres cold tier. The
-// cold-read tests in this file still use a local e2eColdTier shim
-// because they exercise additional fixture-specific control surfaces
-// (e.g., bypassing the hot tier deterministically); the shim's
-// correctness w.r.t. the production dispatcher is locked by the
-// unit-level tests in internal/eventbus/history/cold_postgres_test.go
-// (TestColdPostgresUnmarshalsEnvelope) and dispatcher_test.go. New
-// callers wiring crypto into production cold reads should use
-// history.WithCryptoCold(history.WithColdHistoryAuthGuard(g),
-// history.WithColdHistoryDEKManager(m),
-// history.WithColdHistoryDecryptAuditEmitter(em)).
+// Cold-tier wiring: as of holomush-ojw1.7 (2026-05-06), history.NewReader
+// exposes WithHistoryAuth(g, m, em) which wires both hot and cold tiers
+// symmetrically. The cold-read tests use buildColdReader which calls the
+// real production postgres cold tier via WithHistoryAuth. Bypassing the
+// hot tier deterministically is achieved by setting the clock to "far
+// future" so every query routes to cold.
 package crypto_test
 
 import (
 	"context"
-	"database/sql"
 	"strconv"
 	"testing"
 	"time"
@@ -35,7 +27,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
@@ -46,8 +37,6 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/authguard"
 	guardaudit "github.com/holomush/holomush/internal/eventbus/authguard/audit"
-	"github.com/holomush/holomush/internal/eventbus/codec"
-	"github.com/holomush/holomush/internal/eventbus/crypto/aad"
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/eventbus/history"
@@ -55,7 +44,7 @@ import (
 	"github.com/holomush/holomush/internal/plugin/plugintest"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
-	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
+
 	"github.com/holomush/holomush/test/testutil"
 )
 
@@ -293,177 +282,18 @@ func contextIDFromLegacySubject(subject string) (dek.ContextID, bool) {
 	return dek.ContextID{}, false
 }
 
-// e2eColdTier reads from events_audit and runs each row through the
-// production codec / AAD / authguard chain — equivalent to what the cold
-// reader's dispatcher does, but accessible from a test that wires its
-// own dependencies (history.NewReader's cold-crypto options aren't yet
-// exposed as Reader-level options).
-type e2eColdTier struct {
-	pool    *pgxpool.Pool
-	guard   eventbus.SessionAuthGuard
-	dekMgr  eventbus.SessionDEKManager
-	auditEm eventbus.SessionAuditEmitter
-}
-
-func (c *e2eColdTier) Read(ctx context.Context, q eventbus.HistoryQuery, _ time.Time, pageSize int, _ *history.StreamStateSnapshot) ([]eventbus.Event, error) {
-	rows, err := c.pool.Query(ctx, `
-		SELECT id, envelope, js_seq, codec, dek_ref, dek_version
-		FROM events_audit
-		WHERE subject = $1
-		ORDER BY js_seq ASC
-		LIMIT $2`, string(q.Subject), pageSize)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []eventbus.Event
-	for rows.Next() {
-		var (
-			idBytes       []byte
-			envelopeBytes []byte
-			seq           int64
-			codecStr      string
-			dekRef        sql.NullInt64
-			dekVersion    sql.NullInt32
-		)
-		if scanErr := rows.Scan(&idBytes, &envelopeBytes, &seq, &codecStr, &dekRef, &dekVersion); scanErr != nil {
-			return nil, scanErr
-		}
-		ev, metaOnly, dispatchErr := dispatchColdRow(ctx, envelopeBytes, codecStr, dekRef, dekVersion, q.Identity, c.guard, c.dekMgr)
-		if dispatchErr != nil {
-			return nil, dispatchErr
-		}
-		var id ulid.ULID
-		copy(id[:], idBytes)
-		ev.ID = id
-		ev.Seq = uint64(seq) //nolint:gosec
-		ev.MetadataOnly = metaOnly
-		out = append(out, ev)
-	}
-	return out, rows.Err()
-}
-
-// dispatchColdRow mirrors history.decodeAuthorizeAndDispatch for the cold
-// path. The duplication is exact w.r.t. the production codec + AAD + decode
-// chain because we import the same aad.Build and codec.Resolve.
-func dispatchColdRow(
-	ctx context.Context,
-	envelopeBytes []byte,
-	codecStr string,
-	dekRefCol sql.NullInt64,
-	dekVerCol sql.NullInt32,
-	identity eventbus.SessionIdentity,
-	guard eventbus.SessionAuthGuard,
-	dekMgr eventbus.SessionDEKManager,
-) (eventbus.Event, bool, error) {
-	var pbEnvelope eventbusv1.Event
-	if err := proto.Unmarshal(envelopeBytes, &pbEnvelope); err != nil {
-		return eventbus.Event{}, false, err
-	}
-	codecName := codec.Name(codecStr)
-	if codecName == codec.NameIdentity {
-		return eventFromEnvelope(&pbEnvelope, pbEnvelope.GetPayload()), false, nil
-	}
-	var keyID codec.KeyID
-	var keyVer uint32
-	if dekRefCol.Valid {
-		keyID = codec.KeyID(dekRefCol.Int64) //nolint:gosec
-	}
-	if dekVerCol.Valid {
-		keyVer = uint32(dekVerCol.Int32) //nolint:gosec
-	}
-	var eventID ulid.ULID
-	if raw := pbEnvelope.GetId(); len(raw) == 16 {
-		copy(eventID[:], raw)
-	}
-	req := eventbus.SessionCheckRequest{
-		Identity:   identity,
-		KeyID:      keyID,
-		KeyVersion: keyVer,
-		EventType:  pbEnvelope.GetType(),
-		EventID:    eventID,
-	}
-	decision, err := guard.Check(ctx, req)
-	if err != nil {
-		return eventbus.Event{}, false, err
-	}
-	if !decision.Permit {
-		return eventFromEnvelope(&pbEnvelope, nil), true, nil
-	}
-	key, err := dekMgr.Resolve(ctx, keyID, keyVer)
-	if err != nil {
-		return eventbus.Event{}, false, err
-	}
-	aadBytes, err := aad.Build(&pbEnvelope, codecStr, uint64(keyID), keyVer)
-	if err != nil {
-		return eventbus.Event{}, false, err
-	}
-	cdc, err := codec.Resolve(codecName)
-	if err != nil {
-		return eventbus.Event{}, false, err
-	}
-	plaintext, err := cdc.Decode(ctx, pbEnvelope.GetPayload(), key, aadBytes)
-	if err != nil {
-		return eventbus.Event{}, false, err
-	}
-	return eventFromEnvelope(&pbEnvelope, plaintext), false, nil
-}
-
-// eventFromEnvelope mirrors history.buildHistoryEventFromEnvelope.
-func eventFromEnvelope(env *eventbusv1.Event, payload []byte) eventbus.Event {
-	var id ulid.ULID
-	if raw := env.GetId(); len(raw) == 16 {
-		copy(id[:], raw)
-	}
-	var actorID ulid.ULID
-	if raw := env.GetActor().GetId(); len(raw) == 16 {
-		copy(actorID[:], raw)
-	}
-	return eventbus.Event{
-		ID:        id,
-		Subject:   eventbus.Subject(env.GetSubject()),
-		Type:      eventbus.Type(env.GetType()),
-		Timestamp: env.GetTimestamp().AsTime(),
-		Actor: eventbus.Actor{
-			Kind: protoActorKindToEventbus(env.GetActor().GetKind()),
-			ID:   actorID,
-		},
-		Payload: payload,
-	}
-}
-
-func protoActorKindToEventbus(k eventbusv1.ActorKind) eventbus.ActorKind {
-	switch k {
-	case eventbusv1.ActorKind_ACTOR_KIND_CHARACTER:
-		return eventbus.ActorKindCharacter
-	case eventbusv1.ActorKind_ACTOR_KIND_PLAYER:
-		return eventbus.ActorKindPlayer
-	case eventbusv1.ActorKind_ACTOR_KIND_SYSTEM:
-		return eventbus.ActorKindSystem
-	case eventbusv1.ActorKind_ACTOR_KIND_PLUGIN:
-		return eventbus.ActorKindPlugin
-	default:
-		return eventbus.ActorKindUnknown
-	}
-}
-
-// buildColdReader wires a Reader with a custom cold tier whose dispatcher
-// chain has the AuthGuard + DEKManager + AuditEmitter populated. The hot
-// tier is left as the default (it sees the same JetStream the publisher
+// buildColdReader wires a Reader using WithHistoryAuth so the real
+// production cold tier (postgresColdTier) handles decodeAuthAndDispatch
+// with the AuthGuard + DEKManager + AuditEmitter populated. The hot tier
+// is left as the default (it sees the same JetStream the publisher
 // just wrote to), but our queries set the clock to "far future" so every
 // event is read from cold.
 func buildColdReader(env *e2eEnv) *history.Reader {
-	coldTier := &e2eColdTier{
-		pool:    env.pool,
-		guard:   env.guard,
-		dekMgr:  env.dekMgr,
-		auditEm: env.auditEm,
-	}
 	farFuture := time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
 	return history.NewReader(env.bus.JS, env.pool,
 		eventbus.Config{}.Defaults().StreamMaxAge,
 		func() time.Time { return farFuture },
-		history.WithColdTier(coldTier),
+		history.WithHistoryAuth(env.guard, env.dekMgr, env.auditEm),
 	)
 }
 


### PR DESCRIPTION
## Summary

- Adds `hotOpts` field + `WithCryptoHot` + `WithHistoryAuth` to `history.Reader`, achieving hot/cold crypto option parity  
- Wires `hotOpts` through `NewReader` to `newJetStreamHotTier`  
- Plumbs optional auth params through `sub_grpc.go::newHistoryReader` (nil = passthrough)  
- Replaces the 145-line `e2eColdTier` shim with `WithHistoryAuth` using the real production cold tier  
- Crypto component construction in production is deferred to a future task  

## Test plan

- [x] 6 invariants verified (INV-1 through INV-6)  
- [x] `task test` — all unit tests pass  
- [x] `task test:int` — 1160 integration tests pass (INV-5)  
- [x] `task lint` — 0 issues  

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-session authentication, key-management, and audit wiring for history reads across hot and cold tiers.

* **Tests**
  * Added unit and end-to-end tests validating crypto-option forwarding, nil-passthrough semantics, and production cold-tier crypto wiring.

* **Documentation**
  * Added design and rollout plans describing the crypto-option surface, invariants, and production/test wiring steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->