### PR TITLE
feat(crypto): Phase 4 — Add + Rotate DEK lifecycle ops (holomush-fi0n)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
+++ b/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
@@ -1,0 +1,1741 @@
+# Phase 4: Add + Rotate Lifecycle Ops — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `dek.Manager.Add` (append participant, no key rotation) and `dek.Manager.Rotate` (mint new DEK version, mark old rotated) with synchronous N-of-N cache invalidation.
+
+**Architecture:** Two new types (`Invalidator` func, `BindingResolver` interface) are injected into `dek.NewManager`. `Add` does a pre-select → idempotent JSONB append → invalidation publish. `Rotate` does INSERT new row → cache seed → invalidation → mark old rotated; on invalidation failure, rolls back by evicting caches + marking the new row destroyed. Store gains 4 methods: `updateParticipants`, `markRotated`, `markDestroyed`, `selectByBindingID`.
+
+**Tech Stack:** Go 1.26, PostgreSQL JSONB, NATS request-reply (via `invalidation.Coordinator`), testify, pgx
+
+**Spec reference:** [docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md](../specs/2026-05-06-phase4-add-rotate-design.md)
+
+**Grounding spec:** [docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md](../specs/2026-04-25-event-payload-crypto-design.md)
+
+---
+
+## Files touched
+
+| File | Responsibility |
+|---|---|
+| `internal/eventbus/crypto/dek/manager.go` | `Invalidator` + `BindingResolver` types, updated `NewManager`, `manager` struct, `Add`/`Rotate` impl |
+| `internal/eventbus/crypto/dek/store.go` | `updateParticipants`, `markRotated`, `markDestroyed`, `selectByBindingID` |
+| `internal/eventbus/crypto/dek/store_add_rotate_test.go` | Tests for new Store methods |
+| `internal/eventbus/crypto/dek/manager_test.go` | Nil-guard tests for new params |
+| `internal/eventbus/crypto/dek/manager_integration_test.go` | Call-site updates, Add/Rotate unit + integration tests, INV tests |
+| `internal/eventbus/crypto/dek/store_integration_test.go` | Call-site updates (2 calls) |
+| `test/integration/crypto/e2e_test.go` | Call-site update |
+| `test/integration/crypto/emit_test.go` | Call-site update |
+| `test/integration/crypto/metadata_only_test.go` | Call-site update |
+| `test/integration/crypto/plugin_decrypt_test.go` | Call-site update |
+
+---
+
+## Decomposition & sequencing
+
+```
+T1: Store methods (no Manager dependency, can land first)
+├── T2: Invalidator + BindingResolver types + NewManager sig change + call-site migration
+├── T3: Manager.Add implementation + unit tests
+├── T4: Manager.Rotate implementation + unit tests
+├── T5: INV-12 + INV-13 + INV-29 integration tests
+└── T6: INV-37 — startup integrity check for crashed Rotate recovery
+```
+
+---
+
+### Task 1: Store methods — updateParticipants, markRotated, markDestroyed, selectByBindingID
+
+**Files:**
+- Create: `internal/eventbus/crypto/dek/store_add_rotate_test.go`
+- Modify: `internal/eventbus/crypto/dek/store.go`
+
+- [ ] **Step 1: Write failing tests for Store methods**
+
+Create `internal/eventbus/crypto/dek/store_add_rotate_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dek
+
+import (
+    "context"
+    "encoding/json"
+    "testing"
+    "time"
+
+    "github.com/jackc/pgx/v5/pgxpool"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+
+    "github.com/holomush/holomush/internal/eventbus/codec"
+    "github.com/holomush/holomush/internal/store"
+    "github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+// testPool creates a testcontainer-backed *pgxpool.Pool with migrations
+// applied. Teardown is registered on t.Cleanup.
+func testPool(t *testing.T) *pgxpool.Pool {
+    t.Helper()
+    ctx := context.Background()
+    pgContainer, err := postgres.Run(ctx,
+        "postgres:18-alpine",
+        postgres.WithDatabase("test"),
+        postgres.WithUsername("test"),
+        postgres.WithPassword("test"),
+        postgres.BasicWaitStrategies(),
+    )
+    require.NoError(t, err)
+    t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+    connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+    require.NoError(t, err)
+    migrator, err := store.NewMigrator(connStr)
+    require.NoError(t, err)
+    require.NoError(t, migrator.Up())
+    migrator.Close()
+    pool, err := pgxpool.New(ctx, connStr)
+    require.NoError(t, err)
+    t.Cleanup(pool.Close)
+    return pool
+}
+
+// storeAddRotateTestEnv holds the test dependencies.
+type storeAddRotateTestEnv struct {
+    pool  *pgxpool.Pool
+    store *Store
+}
+
+// setupStoreAddRotateTest creates the store and a test DEK row.
+func setupStoreAddRotateTest(t *testing.T) (*storeAddRotateTestEnv, ContextID) {
+    t.Helper()
+    pool := testPool(t)
+    store := NewStore(pool)
+    ctxID := ContextID{Type: "scene", ID: "test-scene-1"}
+
+    // Insert a DEK row so updateParticipants/markRotated have a target.
+    initial := []Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "b1", JoinedAt: time.Now().UTC()},
+    }
+    row := row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 1,
+        WrappedDEK:   []byte("fake-dek-bytes-for-testing-only"),
+        WrapProvider: "test", WrapKeyID: "k1",
+        Participants: initial,
+    }
+    _, err := store.insert(context.Background(), row)
+    require.NoError(t, err)
+
+    return &storeAddRotateTestEnv{pool: pool, store: store}, ctxID
+}
+
+// TestStore_UpdateParticipants_AppendsNewParticipant verifies updateParticipants
+// adds a new participant to the JSONB array.
+func TestStore_UpdateParticipants_AppendsNewParticipant(t *testing.T) {
+    env, ctxID := setupStoreAddRotateTest(t)
+
+    p := Participant{
+        PlayerID: "p2", CharacterID: "c2", BindingID: "b2",
+        JoinedAt: time.Now().UTC(), AddedVia: "test",
+    }
+    result, err := env.store.updateParticipants(context.Background(), ctxID, p)
+    require.NoError(t, err)
+
+    assert.Equal(t, uint32(1), result.Version)
+    require.Len(t, result.Participants, 2)
+    assert.Equal(t, "p2", result.Participants[1].PlayerID)
+    assert.Equal(t, "b2", result.Participants[1].BindingID)
+}
+
+// TestStore_UpdateParticipants_NoopOnDuplicate verifies idempotency:
+// adding the same (player_id, binding_id) returns the active row unchanged.
+func TestStore_UpdateParticipants_NoopOnDuplicate(t *testing.T) {
+    env, ctxID := setupStoreAddRotateTest(t)
+
+    p := Participant{
+        PlayerID: "p1", CharacterID: "c1", BindingID: "b1",
+        JoinedAt: time.Now().UTC(), AddedVia: "test",
+    }
+    result, err := env.store.updateParticipants(context.Background(), ctxID, p)
+    require.NoError(t, err)
+
+    // Should return the active row with exactly 1 participant (no duplication).
+    assert.Equal(t, uint32(1), result.Version)
+    require.Len(t, result.Participants, 1)
+}
+
+// TestStore_UpdateParticipants_NoActiveDEK verifies DEK_NOT_FOUND when
+// no active DEK exists for the context.
+func TestStore_UpdateParticipants_NoActiveDEK(t *testing.T) {
+    pool := testPool(t)
+    store := NewStore(pool)
+    ctxID := ContextID{Type: "scene", ID: "nonexistent"}
+
+    _, err := store.updateParticipants(context.Background(), ctxID, Participant{
+        PlayerID: "p1", CharacterID: "c1", BindingID: "b1",
+        JoinedAt: time.Now().UTC(),
+    })
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "pgx.ErrNoRows")
+}
+
+// TestStore_MarkRotated_SetsRotatedAtAndSupersededBy verifies markRotated
+// sets both columns on the target row.
+func TestStore_MarkRotated_SetsRotatedAtAndSupersededBy(t *testing.T) {
+    env, ctxID := setupStoreAddRotateTest(t)
+
+    // First insert a second row as the successor.
+    newRow := row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 2,
+        WrappedDEK:   []byte("fake-dek-v2"),
+        WrapProvider: "test", WrapKeyID: "k1",
+        Participants: []Participant{
+            {PlayerID: "p1", CharacterID: "c1", BindingID: "b1", JoinedAt: time.Now().UTC()},
+        },
+    }
+    newID, err := env.store.insert(context.Background(), newRow)
+    require.NoError(t, err)
+
+    // Mark v1 as rotated.
+    err = env.store.markRotated(context.Background(), 1, 1, newID)
+    require.NoError(t, err)
+
+    // Verify the row is now rotated.
+    _, err = env.store.selectActive(context.Background(), ctxID)
+    require.NoError(t, err) // should find v2 as active
+
+    // selectByID on v1 should show rotated_at set.
+    r, err := env.store.selectByID(context.Background(), codec.KeyID(1), 1)
+    require.NoError(t, err)
+    assert.NotNil(t, r.RotatedAt)
+}
+
+// TestStore_MarkDestroyed_SetsDestroyedAt verifies the rollback helper.
+func TestStore_MarkDestroyed_SetsDestroyedAt(t *testing.T) {
+    env, ctxID := setupStoreAddRotateTest(t)
+
+    // Insert a second row to destroy.
+    newRow := row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 2,
+        WrappedDEK:   []byte("fake-dek-v2"),
+        WrapProvider: "test", WrapKeyID: "k1",
+        Participants: []Participant{
+            {PlayerID: "p1", CharacterID: "c1", BindingID: "b1", JoinedAt: time.Now().UTC()},
+        },
+    }
+    newID, err := env.store.insert(context.Background(), newRow)
+    require.NoError(t, err)
+
+    err = env.store.markDestroyed(context.Background(), codec.KeyID(newID), 2)
+    require.NoError(t, err)
+
+    // selectByID should now fail with pgx.ErrNoRows (destroyed rows filtered).
+    _, err = env.store.selectByID(context.Background(), codec.KeyID(newID), 2)
+    require.Error(t, err)
+}
+
+// TestStore_SelectByBindingID_FindsMatchingRows verifies the JSONB @>
+// containment query finds DEKs that include the target binding.
+func TestStore_SelectByBindingID_FindsMatchingRows(t *testing.T) {
+    env, _ := setupStoreAddRotateTest(t)
+
+    rows, err := env.store.selectByBindingID(context.Background(), "b1")
+    require.NoError(t, err)
+    require.Len(t, rows, 1)
+    assert.Equal(t, "scene", rows[0].ContextType)
+
+    // b2 should not exist.
+    rows, err = env.store.selectByBindingID(context.Background(), "b2")
+    require.NoError(t, err)
+    assert.Len(t, rows, 0)
+}
+```
+
+Run: `task test:int`
+Expected: FAIL — methods not defined
+
+- [ ] **Step 2: Implement updateParticipants**
+
+In `internal/eventbus/crypto/dek/store.go`, append after `insert`:
+
+```go
+// updateParticipants appends p to the active DEK's participant set.
+// Idempotent on (player_id, binding_id) — duplicate returns the active
+// row unchanged. Returns the active row wrapped in a pgx.ErrNoRows
+// sentinel when no active DEK exists.
+func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, error) {
+    active, err := s.selectActive(ctx, ctxID)
+    if err != nil {
+        return row{}, err // pgx.ErrNoRows → DEK_NOT_FOUND for caller
+    }
+
+    participantJSON, err := json.Marshal(p)
+    if err != nil {
+        return row{}, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
+    }
+
+    tag, err := s.pool.Exec(ctx, `
+        UPDATE crypto_keys
+           SET participants = participants || $3::jsonb
+         WHERE context_type = $1 AND context_id = $2
+           AND rotated_at IS NULL AND destroyed_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM jsonb_array_elements(participants) AS part
+             WHERE part->>'player_id' = $4 AND part->>'binding_id' = $5
+           )`,
+        ctxID.Type, ctxID.ID, participantJSON, p.PlayerID, p.BindingID,
+    )
+    if err != nil {
+        return row{}, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").
+            With("context_type", ctxID.Type).
+            With("context_id", ctxID.ID).Wrap(err)
+    }
+    if tag.RowsAffected() == 0 {
+        return active, nil // duplicate — idempotent no-op
+    }
+
+    return s.selectActive(ctx, ctxID)
+}
+```
+
+- [ ] **Step 3: Implement markRotated**
+
+Append after `updateParticipants` in `internal/eventbus/crypto/dek/store.go`:
+
+```go
+// markRotated sets rotated_at and superseded_by on the target row.
+func (s *Store) markRotated(ctx context.Context, keyID codec.KeyID, version uint32, supersededBy int64) error {
+    tag, err := s.pool.Exec(ctx, `
+        UPDATE crypto_keys
+           SET rotated_at = NOW(), superseded_by = $4
+         WHERE id = $1 AND version = $2 AND rotated_at IS NULL AND destroyed_at IS NULL`,
+        int64(keyID), version, supersededBy,
+    )
+    if err != nil {
+        return oops.Code("DEK_MARK_ROTATED_FAILED").
+            With("key_id", uint64(keyID)).
+            With("version", version).Wrap(err)
+    }
+    if tag.RowsAffected() == 0 {
+        return oops.Code("DEK_MARK_ROTATED_NOT_FOUND").
+            With("key_id", uint64(keyID)).
+            With("version", version).
+            Errorf("no unrotated row for key %d v%d", keyID, version)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Implement markDestroyed**
+
+Append after `markRotated` in `internal/eventbus/crypto/dek/store.go`:
+
+```go
+// markDestroyed sets destroyed_at on the target row. Best-effort
+// rollback helper — used when Rotate's invalidation fails.
+func (s *Store) markDestroyed(ctx context.Context, keyID codec.KeyID, version uint32) error {
+    _, err := s.pool.Exec(ctx, `
+        UPDATE crypto_keys
+           SET destroyed_at = NOW()
+         WHERE id = $1 AND version = $2 AND destroyed_at IS NULL`,
+        int64(keyID), version,
+    )
+    if err != nil {
+        return oops.Code("DEK_MARK_DESTROYED_FAILED").
+            With("key_id", uint64(keyID)).
+            With("version", version).Wrap(err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 5: Implement selectByBindingID**
+
+Append after `markDestroyed` in `internal/eventbus/crypto/dek/store.go`:
+
+```go
+// selectByBindingID returns all active DEK rows whose participants
+// array contains an element with the given binding_id. Used by the
+// wizard-transfer rebind handler to find affected DEKs.
+func (s *Store) selectByBindingID(ctx context.Context, bindingID string) ([]row, error) {
+    probe := []Participant{{BindingID: bindingID}}
+    probeJSON, err := json.Marshal(probe)
+    if err != nil {
+        return nil, oops.Code("DEK_BINDING_PROBE_MARSHAL_FAILED").Wrap(err)
+    }
+
+    rows, err := s.pool.Query(ctx, `
+        SELECT id, context_type, context_id, version, wrapped_dek,
+               wrap_provider, wrap_key_id, participants, created_at, rotated_at
+          FROM crypto_keys
+         WHERE participants @> $1::jsonb
+           AND rotated_at IS NULL AND destroyed_at IS NULL
+         ORDER BY id`,
+        probeJSON,
+    )
+    if err != nil {
+        return nil, oops.Code("DEK_SELECT_BY_BINDING_FAILED").Wrap(err)
+    }
+    defer rows.Close()
+
+    var out []row
+    for rows.Next() {
+        var r row
+        var participantsJSON []byte
+        if err := rows.Scan(
+            &r.ID, &r.ContextType, &r.ContextID, &r.Version, &r.WrappedDEK,
+            &r.WrapProvider, &r.WrapKeyID, &participantsJSON, &r.CreatedAt, &r.RotatedAt,
+        ); err != nil {
+            return nil, oops.Code("DEK_SELECT_BY_BINDING_SCAN_FAILED").Wrap(err)
+        }
+        if err := json.Unmarshal(participantsJSON, &r.Participants); err != nil {
+            return nil, oops.Code("DEK_PARTICIPANTS_UNMARSHAL_FAILED").Wrap(err)
+        }
+        out = append(out, r)
+    }
+    return out, rows.Err()
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+---
+
+### Task 2: Invalidator + BindingResolver types, NewManager signature change, call-site migration
+
+**Files:**
+- Modify: `internal/eventbus/crypto/dek/manager.go`
+- Modify: `internal/eventbus/crypto/dek/manager_test.go`
+- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+- Modify: `internal/eventbus/crypto/dek/store_integration_test.go`
+- Modify: `test/integration/crypto/e2e_test.go`
+- Modify: `test/integration/crypto/emit_test.go`
+- Modify: `test/integration/crypto/metadata_only_test.go`
+- Modify: `test/integration/crypto/plugin_decrypt_test.go`
+
+- [ ] **Step 1: Add Invalidator and BindingResolver types**
+
+In `internal/eventbus/crypto/dek/manager.go`, add before `NewManager`:
+
+```go
+// Invalidator publishes a cache-invalidation request to all replicas.
+// action is one of "rotate", "participants_changed", or "rekey".
+type Invalidator func(ctx context.Context, ctxID ContextID, action string, version, successorVersion uint32) error
+
+// BindingResolver resolves a character's current binding_id.
+type BindingResolver interface {
+    Current(ctx context.Context, characterID string) (string, error)
+}
+```
+
+- [ ] **Step 2: Update manager struct and NewManager signature**
+
+In `internal/eventbus/crypto/dek/manager.go`, update the `manager` struct to add `invalidate` and `bindings` fields:
+
+```go
+type manager struct {
+    provider   kek.Provider
+    store      *Store
+    cache      *Cache
+    partCache  *ParticipantsCache
+    invalidate Invalidator
+    bindings   BindingResolver
+}
+```
+
+Update `NewManager` to take the two new params:
+
+```go
+func NewManager(
+    provider kek.Provider,
+    store *Store,
+    cache *Cache,
+    partCache *ParticipantsCache,
+    invalidate Invalidator,
+    bindings BindingResolver,
+) (Manager, error) {
+    switch {
+    case provider == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "provider").
+            Errorf("dek.NewManager requires a non-nil kek.Provider")
+    case store == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "store").
+            Errorf("dek.NewManager requires a non-nil *Store")
+    case cache == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "cache").
+            Errorf("dek.NewManager requires a non-nil *Cache")
+    case partCache == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "partCache").
+            Errorf("dek.NewManager requires a non-nil *ParticipantsCache")
+    case invalidate == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "invalidate").
+            Errorf("dek.NewManager requires a non-nil Invalidator")
+    case bindings == nil:
+        return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "bindings").
+            Errorf("dek.NewManager requires a non-nil BindingResolver")
+    }
+    return &manager{
+        provider: provider, store: store, cache: cache,
+        partCache: partCache, invalidate: invalidate, bindings: bindings,
+    }, nil
+}
+```
+
+- [ ] **Step 3: Update NewManagerForUnitTest**
+
+`NewManagerForUnitTest` returns a manager with nil fields — update `configured()` accordingly (no change needed, it already checks the 4 original fields; Add/Rotate have their own nil guards).
+
+- [ ] **Step 4: Write tests for new nil guards**
+
+In `internal/eventbus/crypto/dek/manager_test.go`, append:
+
+```go
+// TestNewManager_RejectsNilInvalidator verifies the nil guard on the
+// new Invalidator parameter.
+func TestNewManager_RejectsNilInvalidator(t *testing.T) {
+    _, err := dek.NewManager(
+        kek.NewNoneProviderForUnitTest(),
+        &dek.Store{},
+        dek.NewCache(dek.CacheConfig{}),
+        dek.NewParticipantsCache(dek.CacheConfig{}),
+        nil,
+        &stubBindingResolver{},
+    )
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
+}
+
+// TestNewManager_RejectsNilBindingResolver verifies the nil guard on the
+// new BindingResolver parameter.
+func TestNewManager_RejectsNilBindingResolver(t *testing.T) {
+    _, err := dek.NewManager(
+        kek.NewNoneProviderForUnitTest(),
+        &dek.Store{},
+        dek.NewCache(dek.CacheConfig{}),
+        dek.NewParticipantsCache(dek.CacheConfig{}),
+        func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+        nil,
+    )
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
+}
+```
+
+Add the stub helper at the top of `manager_test.go`:
+
+```go
+// stubBindingResolver implements dek.BindingResolver for tests.
+type stubBindingResolver struct {
+    bindingID string
+    err       error
+}
+
+func (s *stubBindingResolver) Current(_ context.Context, _ string) (string, error) {
+    return s.bindingID, s.err
+}
+```
+
+- [ ] **Step 5: Update all existing test call sites**
+
+Every call site that passes 4 args must now pass `nil, nil` for the two new params. Update the following files:
+
+`internal/eventbus/crypto/dek/manager_test.go` (4 call sites at lines 22, 30, 38, 48):
+```go
+// Line 22: add nil, nil
+_, err := dek.NewManager(nil, &dek.Store{}, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
+// Line 30:
+_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), nil, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
+// Line 38:
+_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, nil, dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
+// Line 48:
+_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, dek.NewCache(dek.CacheConfig{}), nil, nil, nil)
+```
+
+`internal/eventbus/crypto/dek/store_integration_test.go` (2 call sites at lines 46, 103):
+```go
+mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+mgr, err := dek.NewManager(provider, store, cache, partCache, nil, nil)
+```
+
+`internal/eventbus/crypto/dek/manager_integration_test.go` (8 call sites at lines 126, 161, 185, 206, 235, 282, 284, 344):
+```go
+// Each adds nil, nil as the last two args.
+mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+// etc. for all 8 call sites
+```
+
+`test/integration/crypto/e2e_test.go` (line 106):
+```go
+dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+```
+
+`test/integration/crypto/emit_test.go` (line 84):
+```go
+dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+```
+
+`test/integration/crypto/metadata_only_test.go` (line 78):
+```go
+dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+```
+
+`test/integration/crypto/plugin_decrypt_test.go` (line 173):
+```go
+dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+```
+
+- [ ] **Step 6: Run tests to verify compilation**
+
+Run: `task test -- ./internal/eventbus/crypto/dek/`
+Expected: PASS (compiles and passes)
+
+Run: `task test:int`
+Expected: PASS (integration tests compile and pass with nil, nil)
+
+- [ ] **Step 7: Commit**
+
+---
+
+### Task 3: Manager.Add implementation
+
+**Files:**
+- Modify: `internal/eventbus/crypto/dek/manager.go`
+- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+
+- [ ] **Step 1: Add testIntegrationPool helper**
+
+In `internal/eventbus/crypto/dek/manager_integration_test.go`, add before the first test function:
+
+```go
+// testIntegrationPool creates a testcontainer-backed *pgxpool.Pool with
+// migrations applied. Used by Add, Rotate, and INV integration tests.
+func testIntegrationPool(t *testing.T) *pgxpool.Pool {
+    t.Helper()
+    connStr, cleanup := newTestPGPool(t)
+    t.Cleanup(cleanup)
+    pool, err := pgxpool.New(context.Background(), connStr)
+    require.NoError(t, err)
+    t.Cleanup(pool.Close)
+    return pool
+}
+```
+
+- [ ] **Step 2: Write failing tests for Manager.Add**
+
+Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+
+```go
+// stubInvalidator records invalidation calls for assertions.
+type stubInvalidator struct {
+    calls []invalidationCall
+}
+
+type invalidationCall struct {
+    ctxID            dek.ContextID
+    action           string
+    version          uint32
+    successorVersion uint32
+}
+
+func (s *stubInvalidator) call() dek.Invalidator {
+    return func(_ context.Context, ctxID dek.ContextID, action string, v, sv uint32) error {
+        s.calls = append(s.calls, invalidationCall{
+            ctxID: ctxID, action: action, version: v, successorVersion: sv,
+        })
+        return nil
+    }
+}
+
+// TestManager_Add_AppendsParticipantAndPublishesInvalidation is INV-12.
+func TestManager_Add_AppendsParticipantAndPublishesInvalidation(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+    ctxID := dek.ContextID{Type: "scene", ID: "add-test"}
+
+    // Create a DEK via GetOrCreate first.
+    mgr, err := dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        nil, // invalidator — nil here during setup
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+    }
+    _, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    // Now build a real stub invalidator and inject it into a new manager.
+    invStub := &stubInvalidator{}
+    mgr, err = dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        invStub.call(),
+        &stubBindingResolver{bindingID: "bind-2"},
+    )
+    require.NoError(t, err)
+
+    err = mgr.Add(context.Background(), ctxID, dek.Participant{
+        PlayerID: "p2", CharacterID: "c2", JoinedAt: time.Now().UTC(),
+    })
+    require.NoError(t, err)
+
+    // Verify invalidation was published.
+    require.Len(t, invStub.calls, 1)
+    assert.Equal(t, "participants_changed", invStub.calls[0].action)
+    assert.Equal(t, uint32(1), invStub.calls[0].version)
+    assert.Equal(t, uint32(0), invStub.calls[0].successorVersion)
+
+    // Verify the participant set was updated.
+    parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+    require.NoError(t, err)
+    require.Len(t, parts, 2)
+    assert.Equal(t, "p2", parts[1].PlayerID)
+    assert.Equal(t, "bind-2", parts[1].BindingID)
+}
+
+// TestManager_Add_IdempotentOnBindingID verifies second Add is a no-op.
+func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+    ctxID := dek.ContextID{Type: "scene", ID: "idempotent-test"}
+
+    mgr, err := dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        nil,
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+    }
+    _, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    invStub := &stubInvalidator{}
+    mgr, err = dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        invStub.call(),
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    // First Add should succeed.
+    err = mgr.Add(context.Background(), ctxID, dek.Participant{
+        PlayerID: "p1", CharacterID: "c1",
+    })
+    require.NoError(t, err)
+    require.Len(t, invStub.calls, 1)
+
+    // Second Add with same (player_id, binding_id) should be no-op.
+    err = mgr.Add(context.Background(), ctxID, dek.Participant{
+        PlayerID: "p1", CharacterID: "c1",
+    })
+    require.NoError(t, err)
+    // Only one invalidation call total — second was a no-op.
+    require.Len(t, invStub.calls, 1)
+
+    // Participants should still have exactly 1 entry.
+    parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+    require.NoError(t, err)
+    require.Len(t, parts, 1)
+}
+
+// TestManager_Add_BindingMissingFails verifies BINDING_NOT_FOUND when
+// no active binding exists.
+func TestManager_Add_BindingMissingFails(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+    ctxID := dek.ContextID{Type: "scene", ID: "binding-missing-test"}
+
+    mgr, err := dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        nil,
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+    }
+    _, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    invStub := &stubInvalidator{}
+    mgr, err = dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        invStub.call(),
+        &stubBindingResolver{err: oops.Code("BINDING_NOT_FOUND").
+            Errorf("no active binding for character c3")},
+    )
+    require.NoError(t, err)
+
+    err = mgr.Add(context.Background(), ctxID, dek.Participant{
+        PlayerID: "p2", CharacterID: "c3",
+    })
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "BINDING_NOT_FOUND")
+    // No invalidation should have been published.
+    assert.Len(t, invStub.calls, 0)
+}
+```
+
+Run: `task test:int`
+Expected: FAIL — Manager.Add is a stub returning DEK_ADD_NOT_IMPLEMENTED
+
+- [ ] **Step 3: Implement Manager.Add**
+
+Replace the stub body at `internal/eventbus/crypto/dek/manager.go`:
+
+```go
+// Add appends a participant to the active DEK's set without rotating.
+func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error {
+    if err := m.configured(); err != nil {
+        return err
+    }
+    if m.invalidate == nil {
+        return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "Invalidator").
+            Errorf("Add requires a non-nil Invalidator — pass invalidation.Coordinator adapter")
+    }
+    if m.bindings == nil {
+        return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "BindingResolver").
+            Errorf("Add requires a non-nil BindingResolver")
+    }
+
+    if p.BindingID == "" {
+        bindingID, err := m.bindings.Current(ctx, p.CharacterID)
+        if err != nil {
+            return err // propagates BINDING_NOT_FOUND from binding repo
+        }
+        p.BindingID = bindingID
+    }
+
+    row, err := m.store.updateParticipants(ctx, ctxID, p)
+    if err != nil {
+        return err
+    }
+
+    return m.invalidate(ctx, ctxID, "participants_changed", row.Version, 0)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 5: Run unit test suite**
+
+Run: `task test -- ./internal/eventbus/crypto/dek/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+---
+
+### Task 4: Manager.Rotate implementation
+
+**Files:**
+- Modify: `internal/eventbus/crypto/dek/manager.go`
+- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+
+- [ ] **Step 1: Write failing tests for Manager.Rotate**
+
+Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+
+```go
+// TestManager_Rotate_MintsFreshDEKAndMarksOldRotated is INV-13.
+func TestManager_Rotate_MintsFreshDEKAndMarksOldRotated(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+    ctxID := dek.ContextID{Type: "scene", ID: "rotate-test"}
+
+    mgr, err := dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        nil,
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+    }
+    _, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    invStub := &stubInvalidator{}
+    mgr, err = dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        invStub.call(),
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    newParticipants := []dek.Participant{
+        {PlayerID: "p2", CharacterID: "c2", BindingID: "bind-2", JoinedAt: time.Now().UTC()},
+    }
+    err = mgr.Rotate(context.Background(), ctxID, newParticipants, "test departure")
+    require.NoError(t, err)
+
+    // Verify invalidation was published.
+    require.Len(t, invStub.calls, 1)
+    assert.Equal(t, "rotate", invStub.calls[0].action)
+    assert.Equal(t, uint32(1), invStub.calls[0].version)
+    assert.Equal(t, uint32(2), invStub.calls[0].successorVersion)
+
+    // Old DEK (v1) should still be unwrappable (INV-13).
+    _, err = mgr.Resolve(context.Background(), codec.KeyID(1), 1)
+    require.NoError(t, err)
+
+    // New DEK (v2) should be active.
+    _, err = mgr.Resolve(context.Background(), codec.KeyID(2), 2)
+    require.NoError(t, err)
+
+    // New participants are on v2.
+    parts, err := mgr.Participants(context.Background(), codec.KeyID(2), 2)
+    require.NoError(t, err)
+    require.Len(t, parts, 1)
+    assert.Equal(t, "p2", parts[0].PlayerID)
+}
+
+// TestManager_Rotate_RollsBackOnInvalidationFailure is INV-29.
+func TestManager_Rotate_RollsBackOnInvalidationFailure(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+    ctxID := dek.ContextID{Type: "scene", ID: "rotate-fail-test"}
+
+    mgr, err := dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        nil,
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+    }
+    key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    // Build a stub that fails on invalidation.
+    mgr, err = dek.NewManager(
+        newTestProvider(t), store, cache, partCache,
+        func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error {
+            return oops.Code("INVALIDATION_PARTIAL_FAILURE").Errorf("simulated failure")
+        },
+        &stubBindingResolver{bindingID: "bind-1"},
+    )
+    require.NoError(t, err)
+
+    newParticipants := []dek.Participant{
+        {PlayerID: "p2", CharacterID: "c2", BindingID: "bind-2", JoinedAt: time.Now().UTC()},
+    }
+    err = mgr.Rotate(context.Background(), ctxID, newParticipants, "test")
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "INVALIDATION_PARTIAL_FAILURE")
+
+    // The original DEK should still be the active one.
+    parts, err := mgr.Participants(context.Background(), key.KeyID, key.Version)
+    require.NoError(t, err)
+    assert.Len(t, parts, 1)
+    assert.Equal(t, "p1", parts[0].PlayerID)
+
+    // No new DEK version should exist.
+    _, err = mgr.Resolve(context.Background(), codec.KeyID(uint64(key.KeyID)+1), key.Version+1)
+    require.Error(t, err)
+}
+```
+
+Run: `task test:int`
+Expected: FAIL — Manager.Rotate is a stub returning DEK_ROTATE_NOT_IMPLEMENTED
+
+- [ ] **Step 2: Implement Manager.Rotate**
+
+Replace the stub body at `internal/eventbus/crypto/dek/manager.go`:
+
+```go
+// Rotate mints a new DEK version and marks the old one rotated.
+func (m *manager) Rotate(ctx context.Context, ctxID ContextID,
+    newParticipants []Participant, reason string) error {
+
+    if err := m.configured(); err != nil {
+        return err
+    }
+    if m.invalidate == nil {
+        return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            With("dependency", "Invalidator").
+            Errorf("Rotate requires a non-nil Invalidator")
+    }
+
+    activeRow, err := m.store.selectActive(ctx, ctxID)
+    if err != nil {
+        return err
+    }
+
+    dekBytes := make([]byte, DEKByteLength)
+    if _, err := io.ReadFull(rand.Reader, dekBytes); err != nil {
+        return oops.Code("DEK_RNG_FAILED").Wrap(err)
+    }
+    wrapped, kekKeyID, err := m.provider.Wrap(ctx, dekBytes)
+    if err != nil {
+        return oops.Code("DEK_WRAP_FAILED").Wrap(err)
+    }
+    if err := validateProviderWrapOutput(wrapped, kekKeyID); err != nil {
+        return err
+    }
+
+    newRow := row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID,
+        Version:      activeRow.Version + 1,
+        WrappedDEK:   wrapped,
+        WrapProvider: m.provider.Name(),
+        WrapKeyID:    kekKeyID,
+        Participants: newParticipants,
+    }
+    newID, err := m.store.insert(ctx, newRow)
+    if err != nil {
+        return oops.Code("DEK_STORE_INSERT_FAILED").Wrap(err)
+    }
+
+    //nolint:gosec // G115: newID is a DB BIGSERIAL value
+    newKeyID := codec.KeyID(newID)
+    newVersion := newRow.Version
+
+    material := NewMaterial(dekBytes)
+    m.cache.Put(CacheKey{KeyID: newKeyID, Version: newVersion}, ctxID, material)
+    m.partCache.Put(ParticipantsCacheKey{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newVersion,
+    }, newParticipants)
+
+    //nolint:gosec // G115: activeRow.ID is a DB BIGSERIAL value
+    if err := m.invalidate(ctx, ctxID, "rotate",
+        activeRow.Version, newVersion); err != nil {
+        // Rollback: evict caches + mark new row destroyed.
+        m.cache.Invalidate(CacheKey{KeyID: newKeyID, Version: newVersion})
+        m.partCache.Invalidate(ParticipantsCacheKey{
+            ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newVersion,
+        })
+        _ = m.store.markDestroyed(ctx, newKeyID, newVersion)
+        return err
+    }
+
+    return m.store.markRotated(ctx,
+        codec.KeyID(activeRow.ID), activeRow.Version, newID)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 4: Run unit test suite**
+
+Run: `task test -- ./internal/eventbus/crypto/dek/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 5: Integration tests — INV-12, INV-13, INV-29 with real PG + NATS
+
+**Files:**
+- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+
+These tests use the embedded NATS `eventbustest` harness and a real PG testcontainer. They exercise the full Add/Rotate lifecycle with a real `invalidation.Coordinator`.
+
+- [ ] **Step 1: Add the integration tests**
+
+Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+
+```go
+// TestIntegration_Add_GrantsImmediateReadAccess is INV-12:
+// After Add(participant), the new participant can decrypt events
+// that were emitted before they joined.
+func TestIntegration_Add_GrantsImmediateReadAccess(t *testing.T) {
+    if testing.Short() {
+        t.Skip("integration test requires NATS + PG")
+    }
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    provider := newTestProvider(t)
+    ctxID := dek.ContextID{Type: "scene", ID: "inv12-" + randomSuffix()}
+
+    embedded := eventbustest.New(t)
+    coordCfg := invalidation.Config{ClusterID: "test-cluster", InvalidateTimeout: 5 * time.Second}.Defaults()
+    coord, err := invalidation.New(coordCfg, invalidation.Deps{
+        Conn: embedded.Conn, Registry: &singleMemberRegistry{},
+        DEKCache: cache, PartCache: partCache, Logger: slog.Default(),
+    })
+    require.NoError(t, err)
+    require.NoError(t, coord.Start(context.Background()))
+    defer func() { _ = coord.Stop(context.Background()) }()
+
+    invalidator := func(ctx context.Context, cid dek.ContextID, action string, v, sv uint32) error {
+        return coord.RequestInvalidation(ctx, cid, invalidation.Action(action), v, sv)
+    }
+
+    mgr, err := dek.NewManager(provider, store, cache, partCache,
+        invalidator,
+        &stubBindingResolver{bindingID: "bind-carol"},
+    )
+    require.NoError(t, err)
+
+    // Create the DEK with initial participants (Alice only).
+    initial := []dek.Participant{
+        {PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
+    }
+    key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    // Add Carol after DEK creation.
+    err = mgr.Add(context.Background(), ctxID, dek.Participant{
+        PlayerID: "carol", CharacterID: "c-carol", BindingID: "bind-carol", JoinedAt: time.Now().UTC(),
+    })
+    require.NoError(t, err)
+
+    // Carol should be in the participant set now.
+    parts, err := mgr.Participants(context.Background(), key.KeyID, key.Version)
+    require.NoError(t, err)
+    require.Len(t, parts, 2)
+    assert.Equal(t, "carol", parts[1].PlayerID)
+
+    // Verify the DEK is still v1 (no rotation).
+    assert.Equal(t, uint32(1), key.Version)
+}
+
+// TestIntegration_Rotate_PreservesOldDEK is INV-13:
+// After Rotate, old events encrypted under the old DEK are still
+// decryptable.
+func TestIntegration_Rotate_PreservesOldDEK(t *testing.T) {
+    if testing.Short() {
+        t.Skip("integration test requires NATS + PG")
+    }
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    provider := newTestProvider(t)
+    ctxID := dek.ContextID{Type: "scene", ID: "inv13-" + randomSuffix()}
+
+    embedded := eventbustest.New(t)
+    coordCfg := invalidation.Config{ClusterID: "test-cluster"}.Defaults()
+    coord, err := invalidation.New(coordCfg, invalidation.Deps{
+        Conn: embedded.Conn, Registry: &singleMemberRegistry{},
+        DEKCache: cache, PartCache: partCache, Logger: slog.Default(),
+    })
+    require.NoError(t, err)
+    require.NoError(t, coord.Start(context.Background()))
+    defer func() { _ = coord.Stop(context.Background()) }()
+
+    invalidator := func(ctx context.Context, cid dek.ContextID, action string, v, sv uint32) error {
+        return coord.RequestInvalidation(ctx, cid, invalidation.Action(action), v, sv)
+    }
+
+    mgr, err := dek.NewManager(provider, store, cache, partCache,
+        invalidator,
+        &stubBindingResolver{bindingID: "bind-alice"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
+    }
+    key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    // Rotate to new participants.
+    err = mgr.Rotate(context.Background(), ctxID, []dek.Participant{
+        {PlayerID: "bob", CharacterID: "c-bob", BindingID: "bind-bob", JoinedAt: time.Now().UTC()},
+    }, "alice left")
+    require.NoError(t, err)
+
+    // Old DEK (v1) should still be resolvable.
+    oldKey, err := mgr.Resolve(context.Background(), key.KeyID, key.Version)
+    require.NoError(t, err)
+    assert.Equal(t, key.KeyID, oldKey.KeyID)
+    assert.Equal(t, uint32(1), oldKey.Version)
+
+    // New DEK (v2) should also be resolvable.
+    _, err = mgr.Resolve(context.Background(),
+        codec.KeyID(uint64(key.KeyID)+1), key.Version+1)
+    require.NoError(t, err)
+}
+
+// TestIntegration_Rotate_DeletesNewRowOnInvalidationFailure is INV-29:
+// When invalidation fails, Rotate rolls back: the new row is destroyed
+// and the old DEK remains the sole active row.
+func TestIntegration_Rotate_DeletesNewRowOnInvalidationFailure(t *testing.T) {
+    if testing.Short() {
+        t.Skip("integration test requires NATS + PG")
+    }
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+    cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: 5 * time.Minute})
+    provider := newTestProvider(t)
+    ctxID := dek.ContextID{Type: "scene", ID: "inv29-" + randomSuffix()}
+
+    mgr, err := dek.NewManager(provider, store, cache, partCache,
+        nil,
+        &stubBindingResolver{bindingID: "bind-alice"},
+    )
+    require.NoError(t, err)
+
+    initial := []dek.Participant{
+        {PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
+    }
+    key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
+    require.NoError(t, err)
+
+    // Build a manager whose invalidator always fails.
+    mgr, err = dek.NewManager(provider, store, cache, partCache,
+        func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error {
+            return oops.Code("INVALIDATION_PARTIAL_FAILURE").
+                Errorf("simulated NATS failure")
+        },
+        &stubBindingResolver{bindingID: "bind-alice"},
+    )
+    require.NoError(t, err)
+
+    err = mgr.Rotate(context.Background(), ctxID, []dek.Participant{
+        {PlayerID: "bob", CharacterID: "c-bob", BindingID: "bind-bob", JoinedAt: time.Now().UTC()},
+    }, "alice left")
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "INVALIDATION_PARTIAL_FAILURE")
+
+    // Old DEK should still be active.
+    _, err = mgr.Resolve(context.Background(), key.KeyID, key.Version)
+    require.NoError(t, err)
+
+    // The inserted-but-destroyed row should not appear.
+    _, err = mgr.Resolve(context.Background(),
+        codec.KeyID(uint64(key.KeyID)+1), key.Version+1)
+    require.Error(t, err)
+}
+```
+
+Run: `task test:int`
+Expected: FAIL — types/helpers not yet defined (randomSuffix, singleMemberRegistry, etc.)
+
+- [ ] **Step 2: Add test helpers**
+
+Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+
+```go
+// randomSuffix returns a short random string for unique test IDs.
+func randomSuffix() string {
+    b := make([]byte, 4)
+    _, _ = rand.Read(b)
+    return fmt.Sprintf("%x", b)
+}
+
+// singleMemberRegistry implements cluster.Registry for single-replica tests.
+type singleMemberRegistry struct{}
+
+func (s *singleMemberRegistry) ID() lifecycle.SubsystemID                { return "single-member-registry" }
+func (s *singleMemberRegistry) DependsOn() []lifecycle.SubsystemID        { return nil }
+func (s *singleMemberRegistry) Start(_ context.Context) error             { return nil }
+func (s *singleMemberRegistry) Stop(_ context.Context) error              { return nil }
+func (s *singleMemberRegistry) Self() cluster.MemberID                    { return "self-1" }
+func (s *singleMemberRegistry) LiveMembers() []cluster.Member             { return []cluster.Member{{ID: "self-1"}} }
+func (s *singleMemberRegistry) LiveCount() int                            { return 1 }
+func (s *singleMemberRegistry) Member(_ cluster.MemberID) (cluster.Member, bool) { return cluster.Member{}, false }
+func (s *singleMemberRegistry) ProbeAndPill(_ context.Context, _ cluster.MemberID, _ cluster.PillReason) error { return nil }
+func (s *singleMemberRegistry) Subscribe(_ cluster.MemberObserver) (cancel func()) { return func() {} }
+```
+
+Add imports:
+```go
+import (
+    "crypto/rand"
+    "fmt"
+    "log/slog"
+
+    "github.com/holomush/holomush/internal/cluster"
+    "github.com/holomush/holomush/internal/eventbus/crypto/invalidation"
+    "github.com/holomush/holomush/internal/eventbus/eventbustest"
+    "github.com/holomush/holomush/internal/lifecycle"
+)
+```
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `task test -- ./internal/eventbus/crypto/dek/`
+Expected: PASS
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 6: INV-37 — Startup integrity check for crashed Rotate recovery
+
+**Files:**
+- Modify: `internal/eventbus/crypto/dek/store.go`
+- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+
+INV-37 requires that a crashed Rotate (two unrotated rows for the same context) be resolvable by a startup integrity check without manual intervention.
+
+- [ ] **Step 1: Write failing integration test**
+
+Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+
+```go
+// TestIntegration_StartupIntegrity_ResolvesCrashedRotate is INV-37.
+// Simulates a crashed Rotate by directly inserting a second unrotated row
+// (bypassing Manager.Rotate), then verifies the integrity check resolves it.
+func TestIntegration_StartupIntegrity_ResolvesCrashedRotate(t *testing.T) {
+    pool := testIntegrationPool(t)
+    store := dek.NewStore(pool)
+
+    ctxID := dek.ContextID{Type: "scene", ID: "inv37-" + randomSuffix()}
+
+    // Insert v1 directly via store.
+    r1 := dek.Row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 1,
+        WrappedDEK:   []byte("fake-dek-v1"),
+        WrapProvider: "test", WrapKeyID: "k1",
+        Participants: []dek.Participant{
+            {PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
+        },
+    }
+    _, err := store.Insert(context.Background(), r1)
+    require.NoError(t, err)
+
+    // Simulate crashed Rotate: insert v2 without marking v1 rotated.
+    r2 := dek.Row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 2,
+        WrappedDEK:   []byte("fake-dek-v2"),
+        WrapProvider: "test", WrapKeyID: "k1",
+        Participants: []dek.Participant{
+            {PlayerID: "bob", CharacterID: "c-bob", BindingID: "bind-bob", JoinedAt: time.Now().UTC()},
+        },
+    }
+    _, err = store.Insert(context.Background(), r2)
+    require.NoError(t, err)
+
+    // Both rows exist with rotated_at IS NULL. Verify pre-condition.
+    connStr, cleanup := newTestPGPool(t)
+    defer cleanup()
+    rawPool, err := pgxpool.New(context.Background(), connStr)
+    require.NoError(t, err)
+    defer rawPool.Close()
+
+    var count int
+    err = rawPool.QueryRow(context.Background(), `
+        SELECT COUNT(*) FROM crypto_keys
+         WHERE context_type = $1 AND context_id = $2
+           AND rotated_at IS NULL AND destroyed_at IS NULL`,
+        ctxID.Type, ctxID.ID).Scan(&count)
+    require.NoError(t, err)
+    assert.Equal(t, 2, count, "pre-condition: two unrotated rows simulate crashed Rotate")
+
+    // Run the integrity check.
+    err = store.ResolveIntegrity(context.Background())
+    require.NoError(t, err)
+
+    // After resolution, only v2 should remain unrotated.
+    err = rawPool.QueryRow(context.Background(), `
+        SELECT COUNT(*) FROM crypto_keys
+         WHERE context_type = $1 AND context_id = $2
+           AND rotated_at IS NULL AND destroyed_at IS NULL`,
+        ctxID.Type, ctxID.ID).Scan(&count)
+    require.NoError(t, err)
+    assert.Equal(t, 1, count, "post-resolution: exactly one unrotated row")
+
+    // v1 should be marked rotated.
+    var rotatedAt *time.Time
+    err = rawPool.QueryRow(context.Background(), `
+        SELECT rotated_at FROM crypto_keys
+         WHERE context_type = $1 AND context_id = $2 AND version = 1`,
+        ctxID.Type, ctxID.ID).Scan(&rotatedAt)
+    require.NoError(t, err)
+    assert.NotNil(t, rotatedAt, "v1 should be marked rotated by integrity check")
+}
+```
+
+Note: `Store.Insert` and `Store.ResolveIntegrity` are exported wrappers — see Step 2 and Step 3.
+
+Run: `task test:int`
+Expected: FAIL — Insert / ResolveIntegrity not defined
+
+- [ ] **Step 2: Add exported Insert helper to Store**
+
+In `internal/eventbus/crypto/dek/store.go`, add a thin exported wrapper around the unexported `insert` method for test use:
+
+```go
+// Insert is the exported test seam for the unexported insert method.
+// Tests simulating a crashed Rotate use this to insert a second unrotated
+// row without going through Manager.Rotate. Production code uses the
+// Manager; this exists solely for INV-37 integration tests.
+func (s *Store) Insert(ctx context.Context, r Row) (int64, error) {
+    return s.insert(ctx, row{
+        ContextType:  r.ContextType,
+        ContextID:    r.ContextID,
+        Version:      r.Version,
+        WrappedDEK:   r.WrappedDEK,
+        WrapProvider: r.WrapProvider,
+        WrapKeyID:    r.WrapKeyID,
+        Participants: r.Participants,
+    })
+}
+
+// Row is the exported type alias for test use. Mirrors the unexported row.
+type Row struct {
+    ContextType, ContextID string
+    Version                uint32
+    WrappedDEK             []byte
+    WrapProvider, WrapKeyID string
+    Participants           []Participant
+}
+```
+
+- [ ] **Step 3: Add ResolveIntegrity to Store**
+
+Append after `markDestroyed` in `internal/eventbus/crypto/dek/store.go`:
+
+```go
+// ResolveIntegrity finds contexts with multiple unrotated, undestroyed
+// rows (crashed Rotate) and marks the earlier versions rotated, keeping
+// only the max version active. Idempotent — safe to run at every startup.
+func (s *Store) ResolveIntegrity(ctx context.Context) error {
+    rows, err := s.pool.Query(ctx, `
+        SELECT context_type, context_id
+          FROM crypto_keys
+         WHERE rotated_at IS NULL AND destroyed_at IS NULL
+         GROUP BY context_type, context_id
+        HAVING COUNT(*) > 1`)
+    if err != nil {
+        return oops.Code("DEK_INTEGRITY_QUERY_FAILED").Wrap(err)
+    }
+    defer rows.Close()
+
+    type ctxKey struct {
+        ctxType, ctxID string
+    }
+    var conflicted []ctxKey
+    for rows.Next() {
+        var ck ctxKey
+        if err := rows.Scan(&ck.ctxType, &ck.ctxID); err != nil {
+            return oops.Code("DEK_INTEGRITY_SCAN_FAILED").Wrap(err)
+        }
+        conflicted = append(conflicted, ck)
+    }
+    if err := rows.Err(); err != nil {
+        return oops.Code("DEK_INTEGRITY_ROWS_ERR").Wrap(err)
+    }
+
+    for _, ck := range conflicted {
+        // Mark all but the max-version row as rotated.
+        _, err := s.pool.Exec(ctx, `
+            UPDATE crypto_keys
+               SET rotated_at = NOW()
+             WHERE context_type = $1 AND context_id = $2
+               AND rotated_at IS NULL AND destroyed_at IS NULL
+               AND version < (
+                   SELECT MAX(version) FROM crypto_keys
+                    WHERE context_type = $1 AND context_id = $2
+                      AND rotated_at IS NULL AND destroyed_at IS NULL
+               )`,
+            ck.ctxType, ck.ctxID,
+        )
+        if err != nil {
+            return oops.Code("DEK_INTEGRITY_RESOLVE_FAILED").
+                With("context_type", ck.ctxType).
+                With("context_id", ck.ctxID).Wrap(err)
+        }
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run integration tests**
+
+Run: `task test:int`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task lint` green
+- [ ] `task fmt` green
+- [ ] `task test -- ./internal/eventbus/crypto/dek/` green
+- [ ] `task test:int` green (integration tests compile and pass)
+- [ ] `task pr-prep` green
+- [ ] `bd close` for task beads
+- [ ] PR opened, reviewed, squash-merged
+
+## Bead chain structure
+
+```text
+holomush-fi0n                    (existing epic — Phase 4 Add + Rotate)
+├── holomush-fi0n.1              (done — FileSource.Persist)
+├── holomush-fi0n.2              (existing — composite index, deferred to Phase 5)
+├── holomush-fi0n.3              (NEW — Store methods)
+├── holomush-fi0n.4              (NEW — Invalidator/BindingResolver + NewManager sig + call-site migration)
+├── holomush-fi0n.5              (NEW — Manager.Add implementation)
+├── holomush-fi0n.6              (NEW — Manager.Rotate implementation)
+├── holomush-fi0n.7              (NEW — INV-12/INV-13/INV-29 integration tests)
+└── holomush-fi0n.8              (NEW — INV-37 startup integrity for crashed Rotate recovery)
+```
+
+### holomush-fi0n.3: Store methods
+
+```bash
+bd create \
+  --title "Phase 4: Store — updateParticipants, markRotated, markDestroyed, selectByBindingID" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Add four Store methods needed by Add/Rotate: updateParticipants (idempotent JSONB append), markRotated, markDestroyed (rollback helper), selectByBindingID (JSONB @> containment query).
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § New Store methods
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 1
+
+**TDD acceptance criteria:**
+- TestStore_UpdateParticipants_AppendsNewParticipant — appends to JSONB array
+- TestStore_UpdateParticipants_NoopOnDuplicate — idempotent on (player_id, binding_id)
+- TestStore_UpdateParticipants_NoActiveDEK — returns pgx.ErrNoRows
+- TestStore_MarkRotated_SetsRotatedAtAndSupersededBy — sets both columns
+- TestStore_MarkDestroyed_SetsDestroyedAt — sets destroyed_at so row is filtered out
+- TestStore_SelectByBindingID_FindsMatchingRows — JSONB @> containment works
+
+**Verification steps:**
+- task lint
+- task test:int (integration-tagged Store tests)
+
+**Files touched:**
+- internal/eventbus/crypto/dek/store_add_rotate_test.go — tests for updateParticipants, markRotated, markDestroyed, selectByBindingID
+- internal/eventbus/crypto/dek/store.go — add updateParticipants, markRotated, markDestroyed, selectByBindingID
+
+**Dependencies:** none (Store is self-contained; no Manager changes needed)
+
+**Out of scope:** Rekey-specific Store methods; composite index (fi0n.2 — deferred to Phase 5)
+EOF
+)"
+```
+
+### holomush-fi0n.4: Invalidator + BindingResolver types, NewManager signature change, call-site migration
+
+```bash
+bd create \
+  --title "Phase 4: Invalidator/BindingResolver types + NewManager(6 params) + call-site migration" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Define Invalidator func type and BindingResolver interface in dek, expand NewManager from 4 to 6 params, update all call sites (8 files, ~15 calls).
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § Dependency injection
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 2
+
+**TDD acceptance criteria:**
+- TestNewManager_RejectsNilInvalidator — nil guard returns DEK_MANAGER_DEPENDENCY_NIL
+- TestNewManager_RejectsNilBindingResolver — nil guard returns DEK_MANAGER_DEPENDENCY_NIL
+- All existing tests compile and pass with nil, nil appended
+- task test:int compiles and passes
+
+**Verification steps:**
+- task lint
+- task test -- ./internal/eventbus/crypto/dek/
+- task test:int
+
+**Files touched:**
+- internal/eventbus/crypto/dek/manager.go — add Invalidator type, BindingResolver interface; update NewManager signature and manager struct
+- internal/eventbus/crypto/dek/manager_test.go — add nil-guard tests, stubBindingResolver helper, update 4 call sites
+- internal/eventbus/crypto/dek/manager_integration_test.go — update 8 call sites
+- internal/eventbus/crypto/dek/store_integration_test.go — update 2 call sites
+- test/integration/crypto/e2e_test.go — update 1 call site
+- test/integration/crypto/emit_test.go — update 1 call site
+- test/integration/crypto/metadata_only_test.go — update 1 call site
+- test/integration/crypto/plugin_decrypt_test.go — update 1 call site
+
+**Dependencies:** holomush-fi0n.3 (Store methods must exist first)
+
+**Out of scope:** Actual Add/Rotate implementation (Tasks 3/4); production wiring of real Invalidator (rebind handler — future task)
+EOF
+)"
+```
+
+### holomush-fi0n.5: Manager.Add
+
+```bash
+bd create \
+  --title "Phase 4: Manager.Add — append participant + publish invalidation" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Implement Manager.Add: resolve binding_id → idempotent JSONB append → publish participants_changed invalidation.
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § Manager.Add — §6.1
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 3
+
+**TDD acceptance criteria:**
+- TestManager_Add_AppendsParticipantAndPublishesInvalidation — participant appended, invalidation published
+- TestManager_Add_IdempotentOnBindingID — second Add with same (player_id, binding_id) is no-op
+- TestManager_Add_BindingMissingFails — BINDING_NOT_FOUND when no active binding
+
+**Verification steps:**
+- task lint
+- task test:int (Add integration tests)
+- task test -- ./internal/eventbus/crypto/dek/
+
+**Files touched:**
+- internal/eventbus/crypto/dek/manager.go — replace Add stub with implementation
+- internal/eventbus/crypto/dek/manager_integration_test.go — testIntegrationPool, stubInvalidator type, Add tests
+
+**Dependencies:** holomush-fi0n.4 (Invalidator/BindingResolver types + NewManager sig must exist)
+
+**Out of scope:** Integration tests with real NATS (Task 5); production call site wiring (future phases)
+EOF
+)"
+```
+
+### holomush-fi0n.6: Manager.Rotate
+
+```bash
+bd create \
+  --title "Phase 4: Manager.Rotate — mint new DEK version + mark old rotated + invalidation" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Implement Manager.Rotate: mint fresh DEK → INSERT new row → seed caches → publish rotate invalidation → mark old rotated. On invalidation failure, roll back (evict caches + markDestroyed).
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § Manager.Rotate — §6.2
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 4
+
+**TDD acceptance criteria:**
+- TestManager_Rotate_MintsFreshDEKAndMarksOldRotated — new row inserted, old row preserved (INV-13), invalidation published (INV-29)
+- TestManager_Rotate_RollsBackOnInvalidationFailure — old DEK remains sole active row, inserted row destroyed
+
+**Verification steps:**
+- task lint
+- task test:int (Rotate integration tests)
+- task test -- ./internal/eventbus/crypto/dek/
+
+**Files touched:**
+- internal/eventbus/crypto/dek/manager.go — replace Rotate stub with implementation
+- internal/eventbus/crypto/dek/manager_integration_test.go — Rotate tests
+
+**Dependencies:** holomush-fi0n.5 (Manager.Add — Rotate reuses Invalidator pattern)
+
+**Out of scope:** Startup integrity check (INV-37 — deferred to production wiring task); Rekey (Phase 5); scheduled/explicit rotate triggers
+EOF
+)"
+```
+
+### holomush-fi0n.7: INV-12/INV-13/INV-29 integration tests
+
+```bash
+bd create \
+  --title "Phase 4: Integration tests — Add+Rotate with real NATS invalidation" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Write integration tests exercising Add + Rotate with real embedded NATS + invalidation.Coordinator.
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § Test plan
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 5
+
+**TDD acceptance criteria:**
+- TestIntegration_Add_GrantsImmediateReadAccess (INV-12) — Carol added to participant set after DEK creation
+- TestIntegration_Rotate_PreservesOldDEK (INV-13) — old DEK still resolvable after Rotate
+- TestIntegration_Rotate_DeletesNewRowOnInvalidationFailure (INV-29) — old DEK remains sole active after invalidation failure
+
+**Verification steps:**
+- task lint
+- task test:int
+- task test -- ./internal/eventbus/crypto/dek/
+
+**Files touched:**
+- internal/eventbus/crypto/dek/manager_integration_test.go — 3 integration tests + helpers (randomSuffix, singleMemberRegistry)
+
+**Dependencies:** holomush-fi0n.6 (Manager.Rotate must exist)
+
+**Out of scope:** Full E2E with testcontainers (crypto/e2e_test.go covers that surface); multi-replica N>1 tests (cluster harness exists but orchestration is Phase 5)
+EOF
+)"
+```
+
+### holomush-fi0n.8: INV-37 startup integrity for crashed Rotate recovery
+
+```bash
+bd create \
+  --title "Phase 4: INV-37 — startup integrity check resolves crashed Rotate" \
+  --type task \
+  --priority 2 \
+  --parent holomush-fi0n \
+  --description "$(cat <<'EOF'
+**Goal:** Implement Store.ResolveIntegrity to detect and auto-resolve contexts with multiple unrotated rows (crashed Rotate), marking earlier versions rotated and keeping max-version active.
+
+**Design reference:** docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md § Crash recovery (INV-37)
+**Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 6
+
+**TDD acceptance criteria:**
+- TestIntegration_StartupIntegrity_ResolvesCrashedRotate — two unrotated rows → integrity check resolves, v1 marked rotated, v2 sole active
+
+**Verification steps:**
+- task lint
+- task test:int
+- task test -- ./internal/eventbus/crypto/dek/
+
+**Files touched:**
+- internal/eventbus/crypto/dek/store.go — add ResolveIntegrity method, Insert/Row exported test seams
+- internal/eventbus/crypto/dek/manager_integration_test.go — INV-37 integration test
+
+**Dependencies:** holomush-fi0n.7 (integration test helpers defined in T5)
+
+**Out of scope:** Production wiring of ResolveIntegrity at server startup (separate task — call site in cmd/holomush/); multi-row crash scenarios beyond the basic two-row case
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
+++ b/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
@@ -69,6 +69,7 @@ import (
     "testing"
     "time"
 
+    "github.com/jackc/pgx/v5"
     "github.com/jackc/pgx/v5/pgxpool"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
@@ -180,7 +181,7 @@ func TestStore_UpdateParticipants_NoActiveDEK(t *testing.T) {
         JoinedAt: time.Now().UTC(),
     })
     require.Error(t, err)
-    assert.Contains(t, err.Error(), "pgx.ErrNoRows")
+    assert.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 // TestStore_MarkRotated_SetsRotatedAtAndSupersededBy verifies markRotated

--- a/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
+++ b/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
@@ -21,6 +21,7 @@
 | `internal/eventbus/crypto/dek/manager.go` | `Invalidator` + `BindingResolver` types, updated `NewManager`, `manager` struct, `Add`/`Rotate` impl |
 | `internal/eventbus/crypto/dek/store.go` | `updateParticipants`, `markRotated`, `markDestroyed`, `selectByBindingID` |
 | `internal/eventbus/crypto/dek/store_add_rotate_test.go` | Tests for new Store methods |
+| `internal/eventbus/crypto/dek/store_integrity_test.go` | INV-37 startup integrity test |
 | `internal/eventbus/crypto/dek/manager_test.go` | Nil-guard tests for new params |
 | `internal/eventbus/crypto/dek/manager_integration_test.go` | Call-site updates, Add/Rotate unit + integration tests, INV tests |
 | `internal/eventbus/crypto/dek/store_integration_test.go` | Call-site updates (2 calls) |
@@ -310,7 +311,7 @@ Append after `updateParticipants` in `internal/eventbus/crypto/dek/store.go`:
 func (s *Store) markRotated(ctx context.Context, keyID codec.KeyID, version uint32, supersededBy int64) error {
     tag, err := s.pool.Exec(ctx, `
         UPDATE crypto_keys
-           SET rotated_at = NOW(), superseded_by = $4
+           SET rotated_at = NOW(), superseded_by = $3
          WHERE id = $1 AND version = $2 AND rotated_at IS NULL AND destroyed_at IS NULL`,
         int64(keyID), version, supersededBy,
     )
@@ -1315,57 +1316,69 @@ Expected: PASS
 
 **Files:**
 - Modify: `internal/eventbus/crypto/dek/store.go`
-- Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
+- Create: `internal/eventbus/crypto/dek/store_integrity_test.go`
 
 INV-37 requires that a crashed Rotate (two unrotated rows for the same context) be resolvable by a startup integrity check without manual intervention.
 
 - [ ] **Step 1: Write failing integration test**
 
-Append to `internal/eventbus/crypto/dek/manager_integration_test.go`:
+Create `internal/eventbus/crypto/dek/store_integrity_test.go` in package `dek` (internal test — accesses unexported `row` and `insert` directly, avoiding both the `Row` name collision with the existing exported `Row` type and the INV-27 `[]byte` field guard):
 
 ```go
-// TestIntegration_StartupIntegrity_ResolvesCrashedRotate is INV-37.
-// Simulates a crashed Rotate by directly inserting a second unrotated row
-// (bypassing Manager.Rotate), then verifies the integrity check resolves it.
-func TestIntegration_StartupIntegrity_ResolvesCrashedRotate(t *testing.T) {
-    pool := testIntegrationPool(t)
-    store := dek.NewStore(pool)
+//go:build integration
 
-    ctxID := dek.ContextID{Type: "scene", ID: "inv37-" + randomSuffix()}
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
 
-    // Insert v1 directly via store.
-    r1 := dek.Row{
+package dek
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/jackc/pgx/v5/pgxpool"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestStore_ResolveIntegrity_ResolvesCrashedRotate is INV-37.
+// Simulates a crashed Rotate by directly inserting two unrotated rows
+// (bypassing Manager.Rotate via package-internal access), then verifies
+// ResolveIntegrity resolves them.
+func TestStore_ResolveIntegrity_ResolvesCrashedRotate(t *testing.T) {
+    pool := testPool(t)
+    store := NewStore(pool)
+
+    ctxID := ContextID{Type: "scene", ID: "inv37-test"}
+
+    // Insert v1 — unexported insert + row accessible from package dek.
+    r1 := row{
         ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 1,
         WrappedDEK:   []byte("fake-dek-v1"),
         WrapProvider: "test", WrapKeyID: "k1",
-        Participants: []dek.Participant{
+        Participants: []Participant{
             {PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
         },
     }
-    _, err := store.Insert(context.Background(), r1)
+    _, err := store.insert(context.Background(), r1)
     require.NoError(t, err)
 
     // Simulate crashed Rotate: insert v2 without marking v1 rotated.
-    r2 := dek.Row{
+    r2 := row{
         ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 2,
         WrappedDEK:   []byte("fake-dek-v2"),
         WrapProvider: "test", WrapKeyID: "k1",
-        Participants: []dek.Participant{
+        Participants: []Participant{
             {PlayerID: "bob", CharacterID: "c-bob", BindingID: "bind-bob", JoinedAt: time.Now().UTC()},
         },
     }
-    _, err = store.Insert(context.Background(), r2)
+    _, err = store.insert(context.Background(), r2)
     require.NoError(t, err)
 
     // Both rows exist with rotated_at IS NULL. Verify pre-condition.
-    connStr, cleanup := newTestPGPool(t)
-    defer cleanup()
-    rawPool, err := pgxpool.New(context.Background(), connStr)
-    require.NoError(t, err)
-    defer rawPool.Close()
-
     var count int
-    err = rawPool.QueryRow(context.Background(), `
+    err = pool.QueryRow(context.Background(), `
         SELECT COUNT(*) FROM crypto_keys
          WHERE context_type = $1 AND context_id = $2
            AND rotated_at IS NULL AND destroyed_at IS NULL`,
@@ -1378,7 +1391,7 @@ func TestIntegration_StartupIntegrity_ResolvesCrashedRotate(t *testing.T) {
     require.NoError(t, err)
 
     // After resolution, only v2 should remain unrotated.
-    err = rawPool.QueryRow(context.Background(), `
+    err = pool.QueryRow(context.Background(), `
         SELECT COUNT(*) FROM crypto_keys
          WHERE context_type = $1 AND context_id = $2
            AND rotated_at IS NULL AND destroyed_at IS NULL`,
@@ -1388,7 +1401,7 @@ func TestIntegration_StartupIntegrity_ResolvesCrashedRotate(t *testing.T) {
 
     // v1 should be marked rotated.
     var rotatedAt *time.Time
-    err = rawPool.QueryRow(context.Background(), `
+    err = pool.QueryRow(context.Background(), `
         SELECT rotated_at FROM crypto_keys
          WHERE context_type = $1 AND context_id = $2 AND version = 1`,
         ctxID.Type, ctxID.ID).Scan(&rotatedAt)
@@ -1397,43 +1410,10 @@ func TestIntegration_StartupIntegrity_ResolvesCrashedRotate(t *testing.T) {
 }
 ```
 
-Note: `Store.Insert` and `Store.ResolveIntegrity` are exported wrappers — see Step 2 and Step 3.
-
 Run: `task test:int`
-Expected: FAIL — Insert / ResolveIntegrity not defined
+Expected: FAIL — ResolveIntegrity not defined
 
-- [ ] **Step 2: Add exported Insert helper to Store**
-
-In `internal/eventbus/crypto/dek/store.go`, add a thin exported wrapper around the unexported `insert` method for test use:
-
-```go
-// Insert is the exported test seam for the unexported insert method.
-// Tests simulating a crashed Rotate use this to insert a second unrotated
-// row without going through Manager.Rotate. Production code uses the
-// Manager; this exists solely for INV-37 integration tests.
-func (s *Store) Insert(ctx context.Context, r Row) (int64, error) {
-    return s.insert(ctx, row{
-        ContextType:  r.ContextType,
-        ContextID:    r.ContextID,
-        Version:      r.Version,
-        WrappedDEK:   r.WrappedDEK,
-        WrapProvider: r.WrapProvider,
-        WrapKeyID:    r.WrapKeyID,
-        Participants: r.Participants,
-    })
-}
-
-// Row is the exported type alias for test use. Mirrors the unexported row.
-type Row struct {
-    ContextType, ContextID string
-    Version                uint32
-    WrappedDEK             []byte
-    WrapProvider, WrapKeyID string
-    Participants           []Participant
-}
-```
-
-- [ ] **Step 3: Add ResolveIntegrity to Store**
+- [ ] **Step 2: Add ResolveIntegrity to Store**
 
 Append after `markDestroyed` in `internal/eventbus/crypto/dek/store.go`:
 
@@ -1492,12 +1472,12 @@ func (s *Store) ResolveIntegrity(ctx context.Context) error {
 }
 ```
 
-- [ ] **Step 4: Run integration tests**
+- [ ] **Step 3: Run integration tests**
 
 Run: `task test:int`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ---
 
@@ -1722,7 +1702,7 @@ bd create \
 **Plan reference:** docs/superpowers/plans/2026-05-06-phase4-add-rotate.md § Task 6
 
 **TDD acceptance criteria:**
-- TestIntegration_StartupIntegrity_ResolvesCrashedRotate — two unrotated rows → integrity check resolves, v1 marked rotated, v2 sole active
+- TestStore_ResolveIntegrity_ResolvesCrashedRotate — two unrotated rows → integrity check resolves, v1 marked rotated, v2 sole active
 
 **Verification steps:**
 - task lint
@@ -1730,10 +1710,10 @@ bd create \
 - task test -- ./internal/eventbus/crypto/dek/
 
 **Files touched:**
-- internal/eventbus/crypto/dek/store.go — add ResolveIntegrity method, Insert/Row exported test seams
-- internal/eventbus/crypto/dek/manager_integration_test.go — INV-37 integration test
+- internal/eventbus/crypto/dek/store.go — add ResolveIntegrity method
+- internal/eventbus/crypto/dek/store_integrity_test.go — INV-37 integration test (package dek, accesses unexported row/insert)
 
-**Dependencies:** holomush-fi0n.7 (integration test helpers defined in T5)
+**Dependencies:** holomush-fi0n.3 (testPool helper)
 
 **Out of scope:** Production wiring of ResolveIntegrity at server startup (separate task — call site in cmd/holomush/); multi-row crash scenarios beyond the basic two-row case
 EOF

--- a/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
+++ b/docs/superpowers/plans/2026-05-06-phase4-add-rotate.md
@@ -34,7 +34,7 @@
 
 ## Decomposition & sequencing
 
-```
+```text
 T1: Store methods (no Manager dependency, can land first)
 ├── T2: Invalidator + BindingResolver types + NewManager sig change + call-site migration
 ├── T3: Manager.Add implementation + unit tests
@@ -48,6 +48,7 @@ T1: Store methods (no Manager dependency, can land first)
 ### Task 1: Store methods — updateParticipants, markRotated, markDestroyed, selectByBindingID
 
 **Files:**
+
 - Create: `internal/eventbus/crypto/dek/store_add_rotate_test.go`
 - Modify: `internal/eventbus/crypto/dek/store.go`
 
@@ -414,6 +415,7 @@ Expected: PASS
 ### Task 2: Invalidator + BindingResolver types, NewManager signature change, call-site migration
 
 **Files:**
+
 - Modify: `internal/eventbus/crypto/dek/manager.go`
 - Modify: `internal/eventbus/crypto/dek/manager_test.go`
 - Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
@@ -556,6 +558,7 @@ func (s *stubBindingResolver) Current(_ context.Context, _ string) (string, erro
 Every call site that passes 4 args must now pass `nil, nil` for the two new params. Update the following files:
 
 `internal/eventbus/crypto/dek/manager_test.go` (4 call sites at lines 22, 30, 38, 48):
+
 ```go
 // Line 22: add nil, nil
 _, err := dek.NewManager(nil, &dek.Store{}, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
@@ -568,12 +571,14 @@ _, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, dek.New
 ```
 
 `internal/eventbus/crypto/dek/store_integration_test.go` (2 call sites at lines 46, 103):
+
 ```go
 mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 mgr, err := dek.NewManager(provider, store, cache, partCache, nil, nil)
 ```
 
 `internal/eventbus/crypto/dek/manager_integration_test.go` (8 call sites at lines 126, 161, 185, 206, 235, 282, 284, 344):
+
 ```go
 // Each adds nil, nil as the last two args.
 mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
@@ -581,21 +586,25 @@ mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, 
 ```
 
 `test/integration/crypto/e2e_test.go` (line 106):
+
 ```go
 dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 ```
 
 `test/integration/crypto/emit_test.go` (line 84):
+
 ```go
 dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 ```
 
 `test/integration/crypto/metadata_only_test.go` (line 78):
+
 ```go
 dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 ```
 
 `test/integration/crypto/plugin_decrypt_test.go` (line 173):
+
 ```go
 dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 ```
@@ -615,6 +624,7 @@ Expected: PASS (integration tests compile and pass with nil, nil)
 ### Task 3: Manager.Add implementation
 
 **Files:**
+
 - Modify: `internal/eventbus/crypto/dek/manager.go`
 - Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
 
@@ -864,6 +874,7 @@ Expected: PASS
 ### Task 4: Manager.Rotate implementation
 
 **Files:**
+
 - Modify: `internal/eventbus/crypto/dek/manager.go`
 - Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
 
@@ -1075,6 +1086,7 @@ Expected: PASS
 ### Task 5: Integration tests — INV-12, INV-13, INV-29 with real PG + NATS
 
 **Files:**
+
 - Modify: `internal/eventbus/crypto/dek/manager_integration_test.go`
 
 These tests use the embedded NATS `eventbustest` harness and a real PG testcontainer. They exercise the full Add/Rotate lifecycle with a real `invalidation.Coordinator`.
@@ -1283,6 +1295,7 @@ func (s *singleMemberRegistry) Subscribe(_ cluster.MemberObserver) (cancel func(
 ```
 
 Add imports:
+
 ```go
 import (
     "crypto/rand"
@@ -1316,6 +1329,7 @@ Expected: PASS
 ### Task 6: INV-37 — Startup integrity check for crashed Rotate recovery
 
 **Files:**
+
 - Modify: `internal/eventbus/crypto/dek/store.go`
 - Create: `internal/eventbus/crypto/dek/store_integrity_test.go`
 

--- a/docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md
+++ b/docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md
@@ -1,0 +1,425 @@
+# Phase 4: Add + Rotate Lifecycle Ops — Design
+
+## Status
+
+Design approved 2026-05-06.
+
+Builds on: [docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md](2026-04-25-event-payload-crypto-design.md)
+Phase 3 complete. `dek.Manager.Add` / `Rotate` are stubs; invalidation substrate
+(`invalidation.Coordinator.RequestInvalidation`) shipped in Phase 3c.
+
+## Authors
+
+- Sean Brandt
+- Claude Opus 4.7 (collaborator)
+
+## Date
+
+2026-05-06
+
+---
+
+## Goals
+
+1. Implement `dek.Manager.Add(ctx, ctxID, participant)` — append a participant to an
+   active DEK without rotating the key (spec §6.1).
+2. Implement `dek.Manager.Rotate(ctx, ctxID, newParticipants, reason)` — mint a new DEK
+   version and mark the old version rotated (spec §6.2).
+3. Wire `Rotate` into the wizard-transfer (player rebind) path so that rebinding a
+   character correctly rotates all affected DEKs.
+4. Add `Store` methods: `updateParticipants`, `markRotated`, `selectByBindingID`.
+5. Satisfy invariants INV-12, INV-13, INV-29, INV-37.
+
+## Non-goals
+
+- `Rekey` implementation (Phase 5, `holomush-jxo8`).
+- Scene-join, channel-invite, or DM-auto-create call sites for `Add` — those call
+  `Manager.Add` when their subsystems land; the Manager method is available but
+  no production code calls it in Phase 4.
+- Scheduled rotation and scene-policy explicit rotate triggers for `Rotate` — same
+  reasoning: `Manager.Rotate` exists but only rebind invokes it in Phase 4.
+- KEK rotation (`RotateKEK`) — Phase 5+ surface.
+- Migration for composite index on `events_audit` (`holomush-fi0n.2`) — deferred to
+  Phase 5 profiling.
+
+---
+
+## Context
+
+Phase 4 of `holomush-e49r` (Event Payload Cryptography) delivers membership-mutation
+lifecycle operations. Phase 3 shipped the encrypt/decrypt/AuthGuard/downgrade-fence
+substrate; events can be encrypted and decrypted but the participant set of a DEK is
+static after creation. Phase 4 makes membership mutable.
+
+The invalidation substrate (`invalidation.Coordinator.RequestInvalidation` with
+`ActionParticipantsChanged` and `ActionRotate`) shipped in Phase 3c. The
+`ParticipantsCache` is invalidation-aware. What's missing is the actual `Manager.Add`
+and `Manager.Rotate` implementations that mutate state and publish invalidations.
+
+## Architecture
+
+```text
+Production callers (Phase 4)
+  wizard transfer handler ──→ Manager.Rotate()
+  (scene/channel/DM callers —— future phases)
+
+dek.Manager
+  Add(ctx, ctxID, participant) error
+    1. Bindings.Current(character_id) → binding_id
+    2. Store.updateParticipants(append to JSONB)
+    3. InvalidationFunc(participants_changed, version=N)
+
+  Rotate(ctx, ctxID, newParticipants, reason) error
+    1. Mint fresh DEK, Provider.Wrap
+    2. Store.insert(version=N+1, new participants)
+    3. InvalidationFunc(rotate, version=N, successor=N+1)
+       → on failure: roll back (evict caches + mark new row destroyed)
+    4. Store.markRotated(version=N, superseded_by=newID)
+
+dek.Store (new methods)
+  updateParticipants — append participant to JSONB array
+  markRotated — set rotated_at, superseded_by
+  selectByBindingID — find DEKs whose participants[] contains a binding_id
+  markDestroyed — set destroyed_at, used to roll back a failed Rotate
+
+invalidation.Coordinator (Phase 3c, unchanged)
+  N-of-N NATS request-reply, 5s timeout
+  Receive-side evicts ParticipantsCache
+```
+
+### Dependency injection
+
+`dek.NewManager` gains a func-typed parameter and a BindingResolver:
+
+```go
+func NewManager(
+    provider kek.Provider,
+    store *Store,
+    cache *Cache,
+    partCache *ParticipantsCache,
+    invalidate Invalidator,       // NEW
+    bindings BindingResolver,     // NEW
+) (Manager, error)
+```
+
+`Invalidator` is a func type defined in `dek` to avoid importing the `invalidation`
+package (which would create a cycle, since `invalidation` already imports `dek`):
+
+```go
+// Invalidator publishes a cache-invalidation request to all replicas.
+// Production passes a closure that calls invalidation.Coordinator.
+// action is one of "rotate", "participants_changed", or "rekey".
+type Invalidator func(ctx context.Context, ctxID ContextID, action string, version, successorVersion uint32) error
+```
+
+Using a func type instead of an interface avoids Go's named-type matching rules:
+`invalidation.Action` (`type Action string`) would not satisfy an `action string`
+parameter in an interface, so `*invalidation.Coordinator` couldn't structurally
+satisfy the interface. The func type sidesteps this — production wiring casts:
+
+```go
+invalidate := func(ctx context.Context, ctxID dek.ContextID, action string, v, sv uint32) error {
+    return coord.RequestInvalidation(ctx, ctxID, invalidation.Action(action), v, sv)
+}
+```
+
+```go
+// BindingResolver resolves a character's current binding_id.
+// Implemented by the package that owns player_character_bindings
+// (shipped in Phase 3b).
+type BindingResolver interface {
+    Current(ctx context.Context, characterID string) (string, error)
+}
+```
+
+Both follow the existing nil-guard pattern in `NewManager` (returns
+`DEK_MANAGER_DEPENDENCY_NIL` when nil).
+
+## `Manager.Add` — §6.1
+
+```go
+func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error {
+    if err := m.configured(); err != nil { return err }
+    if m.invalidate == nil || m.bindings == nil {
+        return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            Errorf("Add requires non-nil Invalidator and BindingResolver")
+    }
+
+    if p.BindingID == "" {
+        bindingID, err := m.bindings.Current(ctx, p.CharacterID)
+        if err != nil {
+            return err  // propagates BINDING_NOT_FOUND from binding repo
+        }
+        p.BindingID = bindingID
+    }
+
+    row, err := m.store.updateParticipants(ctx, ctxID, p)
+    if err != nil { return err }
+
+    return m.invalidate(ctx, ctxID, "participants_changed", row.Version, 0)
+}
+```
+
+**Store.updateParticipants** appends a participant to the active DEK's JSONB array.
+To distinguish "no active DEK" from "duplicate participant" (both produce zero
+RETURNING rows), the method does a pre-select then an idempotent UPDATE:
+
+```go
+func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, error) {
+    // Pre-select: if no active DEK exists, return DEK_NOT_FOUND.
+    active, err := s.selectActive(ctx, ctxID)
+    if err != nil {
+        return row{}, err  // pgx.ErrNoRows surfaces as DEK_NOT_FOUND wrapped by selectActive
+    }
+
+    participantJSON, err := json.Marshal(p)
+    if err != nil {
+        return row{}, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
+    }
+
+    // Append participant, skipping if already present on (player_id, binding_id).
+    tag, err := s.pool.Exec(ctx, `
+        UPDATE crypto_keys
+           SET participants = participants || $3::jsonb
+         WHERE context_type = $1 AND context_id = $2
+           AND rotated_at IS NULL AND destroyed_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM jsonb_array_elements(participants) AS p
+             WHERE p->>'player_id' = $4 AND p->>'binding_id' = $5
+           )`,
+        ctxID.Type, ctxID.ID, participantJSON, p.PlayerID, p.BindingID,
+    )
+    if err != nil {
+        return row{}, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").Wrap(err)
+    }
+    if tag.RowsAffected() == 0 {
+        // Duplicate participant — idempotent no-op.
+        return active, nil
+    }
+
+    // Re-read to return the updated row.
+    return s.selectActive(ctx, ctxID)
+}
+```
+
+Idempotent on `(player_id, binding_id)` — second Add returns the active row with no
+error and no participant duplication. Concurrent Add + Rotate is serialized via PG
+row-level lock on `crypto_keys`; Add blocks, then re-reads against the new active
+version.
+
+**Error cases:**
+
+| Condition | Error code |
+|---|---|
+| No active binding | `BINDING_NOT_FOUND` (propagated from binding repo) |
+| No active DEK row | `DEK_NOT_FOUND` (caller should have called `GetOrCreate` first) |
+| Coordinator timeout | `INVALIDATION_PARTIAL_FAILURE` (Add succeeded locally; cache staleness bounded by 5m TTL) |
+
+## `Manager.Rotate` — §6.2
+
+**Triggers:**
+
+- Participant removal (someone leaves a scene/channel)
+- Player rebind on a character whose binding is in the participant set
+- Scene-policy explicit rotate
+- Scheduled rotation per context-type policy
+
+```go
+func (m *manager) Rotate(ctx context.Context, ctxID ContextID,
+    newParticipants []Participant, reason string) error {
+
+    if err := m.configured(); err != nil { return err }
+    if m.invalidate == nil || m.bindings == nil {
+        return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+            Errorf("Rotate requires non-nil Invalidator and BindingResolver")
+    }
+
+    activeRow, err := m.store.selectActive(ctx, ctxID)
+    if err != nil { return err }
+
+    dekBytes := make([]byte, DEKByteLength)
+    io.ReadFull(rand.Reader, dekBytes)
+    wrapped, kekKeyID, err := m.provider.Wrap(ctx, dekBytes)
+    if err != nil { return oops.Code("DEK_WRAP_FAILED").Wrap(err) }
+
+    newRow := row{
+        ContextType: ctxID.Type, ContextID: ctxID.ID,
+        Version: activeRow.Version + 1,
+        WrappedDEK: wrapped, WrapProvider: m.provider.Name(),
+        WrapKeyID: kekKeyID, Participants: newParticipants,
+    }
+    newID, err := m.store.insert(ctx, newRow)
+    //nolint:gosec // G115: newID is a DB BIGSERIAL value; positive serial ids fit in uint64
+    newKeyID := codec.KeyID(newID)
+    if err != nil { return oops.Code("DEK_STORE_INSERT_FAILED").Wrap(err) }
+
+    material := NewMaterial(dekBytes)
+    m.cache.Put(CacheKey{KeyID: newKeyID, Version: newRow.Version}, ctxID, material)
+    m.partCache.Put(ParticipantsCacheKey{
+        ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newRow.Version,
+    }, newParticipants)
+
+    // INV-29: on invalidation failure, roll back per master spec contract.
+    if err := m.invalidate(ctx, ctxID, "rotate",
+        activeRow.Version, newRow.Version); err != nil {
+        // Rollback: evict caches + mark new row destroyed.
+        m.cache.Invalidate(CacheKey{KeyID: newKeyID, Version: newRow.Version})
+        m.partCache.Invalidate(ParticipantsCacheKey{
+            ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newRow.Version,
+        })
+        _ = m.store.markDestroyed(ctx, newKeyID, newRow.Version)
+        return err
+    }
+
+    //nolint:gosec // G115: activeRow.ID is a DB BIGSERIAL value
+    return m.store.markRotated(ctx,
+        codec.KeyID(activeRow.ID), activeRow.Version, newID)
+}
+```
+
+**Store.markRotated:**
+
+```sql
+UPDATE crypto_keys
+SET rotated_at = NOW(), superseded_by = $4
+WHERE id = $1 AND version = $2 AND rotated_at IS NULL
+```
+
+**Store.markDestroyed (rollback helper):**
+
+```sql
+UPDATE crypto_keys
+SET destroyed_at = NOW()
+WHERE id = $1 AND version = $2 AND destroyed_at IS NULL
+```
+
+The rollback is best-effort: if the process crashes between `insert` and the
+`invalidate` failure, the old row isn't yet marked rotated — startup integrity
+(INV-37) resolves the two unrotated rows by picking max version as active.
+The destroyed row is filtered out by all other queries (`WHERE destroyed_at IS NULL`).
+
+**Crash recovery (INV-37):** if the process crashes between INSERT and markRotated,
+both rows exist with `rotated_at IS NULL`. Startup integrity check:
+
+```sql
+SELECT context_type, context_id
+FROM crypto_keys
+WHERE rotated_at IS NULL AND destroyed_at IS NULL
+GROUP BY context_type, context_id
+HAVING COUNT(*) > 1
+```
+
+Resolution: pick max version as active, mark earlier rows `rotated_at = NOW()`.
+Idempotent.
+
+## Rebind integration
+
+Wizard transfer handler:
+
+1. Steps 1-3 in one PG transaction:
+   - UPDATE old binding: `ended_at = now()`, `ended_reason = 'wizard_transfer'`
+   - INSERT new binding: (new_player_id, character_id)
+   - `Store.selectByBindingID(old_binding_id)` → affected DEKs
+2. After commit, step 4: for each affected DEK, compute new participant set
+   (replace old binding_id with new binding_id), call
+   `Manager.Rotate(ctxID, newParticipants, "rebind")`
+
+**Store.selectByBindingID:**
+
+The probe JSONB value is `[{"binding_id": "<old_binding_id>"}]` — a single-element
+array so PostgreSQL `@>` containment matches.
+
+```go
+func (s *Store) selectByBindingID(ctx context.Context, bindingID string) ([]row, error) {
+    probe := []Participant{{BindingID: bindingID}}
+    probeJSON, _ := json.Marshal(probe)
+    // SELECT ... FROM crypto_keys WHERE participants @> $1::jsonb ...
+}
+```
+
+```sql
+SELECT id, context_type, context_id, version, wrapped_dek,
+       wrap_provider, wrap_key_id, participants, created_at, rotated_at
+FROM crypto_keys
+WHERE participants @> $1::jsonb
+  AND rotated_at IS NULL AND destroyed_at IS NULL
+```
+
+## New Store methods
+
+| Method | SQL pattern | Used by |
+|---|---|---|
+| `updateParticipants` | `UPDATE ... SET participants = participants \|\| $3::jsonb ... RETURNING *` | `Manager.Add` |
+| `markRotated` | `UPDATE ... SET rotated_at = NOW(), superseded_by = $4` | `Manager.Rotate` |
+| `markDestroyed` | `UPDATE ... SET destroyed_at = NOW()` | `Manager.Rotate` rollback |
+| `selectByBindingID` | `SELECT * WHERE participants @> $1::jsonb` | rebind handler |
+
+## Call-site migration
+
+Every call site that constructs a Manager via `NewManager` MUST pass the two new
+arguments. Run `rg "dek\.NewManager\b|\.NewManager\b"` to find all call sites.
+In Phase 4, all production call sites pass `nil, nil` (no invalidation,
+no binding resolver) because Add/Rotate are available but not yet wired in production.
+The rebind handler is the first production call site to pass real values.
+
+Tests that exercise Add/Rotate MUST pass a non-nil `Invalidator` (real or stub).
+
+## Invariants
+
+### INV-12 — Add grants immediate read access
+
+`Add(participant)` MUST grant immediate read access to all existing DEK history
+without rotating the DEK.
+
+Test: Integration — after Add, new participant decrypts events emitted before
+they joined.
+
+### INV-13 — Rotate preserves old DEK
+
+`Rotate(context)` MUST preserve the old DEK ciphertext and the old DEK record
+unchanged.
+
+Test: Unit + Integration — old events still decryptable with old DEK after rotate.
+
+### INV-29 — Synchronous invalidation with rollback
+
+`Rotate(context)` MUST issue a NATS request-reply ping and MUST receive N-of-N
+replica acks before returning success. On failure, the operation MUST roll back
+(evict seeded caches + mark the inserted row destroyed). Single-replica degenerates
+to N=1. Timeout = 5s.
+
+Test: Integration — verify rollback leaves the original row as the sole active DEK.
+
+### INV-37 — Crashed Rotate recovery
+
+A crashed `Rotate` MUST be resolvable by startup integrity check without manual
+intervention.
+
+Test: Integration — two unrotated rows for same context → auto-resolved.
+
+## Definition of Done
+
+- [ ] `Manager.Add` is no longer a stub — appends participant, publishes invalidation
+- [ ] `Manager.Rotate` is no longer a stub — mints new DEK, publishes invalidation,
+      marks old row rotated; rolls back on invalidation failure
+- [ ] `Store.updateParticipants`, `markRotated`, `markDestroyed`, `selectByBindingID`
+      implemented with tests
+- [ ] INV-12 passes: new participant reads pre-join history
+- [ ] INV-13 passes: old events still decryptable after rotate
+- [ ] INV-29 passes: Rotate rollback on invalidation failure
+- [ ] INV-37 passes: startup integrity resolves crashed Rotate
+- [ ] All existing tests continue to pass (`NewManager` call sites updated with
+      `nil, nil`)
+- [ ] `task lint` and `task test` green
+- [ ] PR opened, reviewed, squash-merged
+
+## Fi0n.2 disposition
+
+`holomush-fi0n.2` (composite index on `events_audit (dek_ref, dek_version)`)
+remains open under the Phase 4 epic. The Phase 4 query pattern uses `@>`
+containment on `crypto_keys.participants`, not index scans on `events_audit`.
+The composite index is a Phase 5 `Rekey` concern; defer final decision until
+Phase 5 profiling determines whether the existing partial single-column index
+suffices.
+
+---

--- a/internal/eventbus/crypto/dek/api_test.go
+++ b/internal/eventbus/crypto/dek/api_test.go
@@ -139,24 +139,6 @@ func TestManagerStubsCarryTrackingBeadFromAllowSet(t *testing.T) {
 		wantCode  string
 	}{
 		{
-			name: "Add",
-			invoke: func() error {
-				return m.Add(context.Background(), dek.ContextID{Type: "scene", ID: "x"}, dek.Participant{})
-			},
-			wantBead:  "holomush-fi0n",
-			wantPhase: 4,
-			wantCode:  "DEK_ADD_NOT_IMPLEMENTED",
-		},
-		{
-			name: "Rotate",
-			invoke: func() error {
-				return m.Rotate(context.Background(), dek.ContextID{Type: "scene", ID: "x"}, nil, "test")
-			},
-			wantBead:  "holomush-fi0n",
-			wantPhase: 4,
-			wantCode:  "DEK_ROTATE_NOT_IMPLEMENTED",
-		},
-		{
 			name: "Rekey",
 			invoke: func() error {
 				return m.Rekey(context.Background(), dek.ContextID{Type: "scene", ID: "x"}, "test", dek.OperatorFactors{})

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -40,12 +40,23 @@ type Manager interface {
 	Rekey(ctx context.Context, ctxID ContextID, justification string, ops OperatorFactors) error
 }
 
+// Invalidator publishes a cache-invalidation request to all replicas.
+// action is one of "rotate", "participants_changed", or "rekey".
+type Invalidator func(ctx context.Context, ctxID ContextID, action string, version, successorVersion uint32) error
+
+// BindingResolver resolves a character's current binding_id.
+type BindingResolver interface {
+	Current(ctx context.Context, characterID string) (string, error)
+}
+
 // manager is the concrete impl.
 type manager struct {
-	provider  kek.Provider
-	store     *Store
-	cache     *Cache
-	partCache *ParticipantsCache
+	provider   kek.Provider
+	store      *Store
+	cache      *Cache
+	partCache  *ParticipantsCache
+	invalidate Invalidator
+	bindings   BindingResolver
 }
 
 // NewManager constructs a real Manager. Production callers (Phase 3+)
@@ -53,7 +64,14 @@ type manager struct {
 // Cache, and participants Cache. All four collaborators are required;
 // a nil argument returns DEK_MANAGER_DEPENDENCY_NIL rather than
 // letting GetOrCreate/Resolve/Participants dereference nil at runtime.
-func NewManager(provider kek.Provider, store *Store, cache *Cache, partCache *ParticipantsCache) (Manager, error) {
+func NewManager(
+	provider kek.Provider,
+	store *Store,
+	cache *Cache,
+	partCache *ParticipantsCache,
+	invalidate Invalidator,
+	bindings BindingResolver,
+) (Manager, error) {
 	switch {
 	case provider == nil:
 		return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
@@ -71,8 +89,19 @@ func NewManager(provider kek.Provider, store *Store, cache *Cache, partCache *Pa
 		return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
 			With("dependency", "partCache").
 			Errorf("dek.NewManager requires a non-nil *ParticipantsCache")
+	case invalidate == nil:
+		return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+			With("dependency", "invalidate").
+			Errorf("dek.NewManager requires a non-nil Invalidator")
+	case bindings == nil:
+		return nil, oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+			With("dependency", "bindings").
+			Errorf("dek.NewManager requires a non-nil BindingResolver")
 	}
-	return &manager{provider: provider, store: store, cache: cache, partCache: partCache}, nil
+	return &manager{
+		provider: provider, store: store, cache: cache,
+		partCache: partCache, invalidate: invalidate, bindings: bindings,
+	}, nil
 }
 
 // NewManagerForUnitTest constructs a Manager with no DB or KEK access.
@@ -214,20 +243,108 @@ func (m *manager) Participants(ctx context.Context, keyID codec.KeyID, version u
 	return r.Participants, nil
 }
 
-// Add lands in Phase 4 (epic holomush-fi0n).
-func (m *manager) Add(_ context.Context, _ ContextID, _ Participant) error {
-	return oops.Code("DEK_ADD_NOT_IMPLEMENTED").
-		With("tracking_bead", "holomush-fi0n").
-		With("phase", 4).
-		Errorf("Manager.Add lands in Phase 4 (epic holomush-fi0n)")
+// Add appends a participant to the active DEK's set without rotating.
+func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error {
+	if err := m.configured(); err != nil {
+		return err
+	}
+	if m.invalidate == nil {
+		return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+			With("dependency", "Invalidator").
+			Errorf("Add requires a non-nil Invalidator — pass invalidation.Coordinator adapter")
+	}
+	if m.bindings == nil {
+		return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+			With("dependency", "BindingResolver").
+			Errorf("Add requires a non-nil BindingResolver")
+	}
+
+	if p.BindingID == "" {
+		bindingID, err := m.bindings.Current(ctx, p.CharacterID)
+		if err != nil {
+			return oops.Code("DEK_BINDING_RESOLVE_FAILED").
+				With("character_id", p.CharacterID).Wrap(err)
+		}
+		p.BindingID = bindingID
+	}
+
+	activeRow, err := m.store.updateParticipants(ctx, ctxID, p)
+	if err != nil {
+		return err
+	}
+
+	return m.invalidate(ctx, ctxID, "participants_changed", activeRow.Version, 0)
 }
 
-// Rotate lands in Phase 4 (epic holomush-fi0n).
-func (m *manager) Rotate(_ context.Context, _ ContextID, _ []Participant, _ string) error {
-	return oops.Code("DEK_ROTATE_NOT_IMPLEMENTED").
-		With("tracking_bead", "holomush-fi0n").
-		With("phase", 4).
-		Errorf("Manager.Rotate lands in Phase 4 (epic holomush-fi0n)")
+// Rotate mints a new DEK version and marks the old one rotated.
+func (m *manager) Rotate(ctx context.Context, ctxID ContextID,
+	newParticipants []Participant, _ string) error {
+
+	if err := m.configured(); err != nil {
+		return err
+	}
+	if m.invalidate == nil {
+		return oops.Code("DEK_MANAGER_DEPENDENCY_NIL").
+			With("dependency", "Invalidator").
+			Errorf("Rotate requires a non-nil Invalidator")
+	}
+
+	activeRow, err := m.store.selectActive(ctx, ctxID)
+	if err != nil {
+		return err
+	}
+
+	dekBytes := make([]byte, DEKByteLength)
+	if _, err = io.ReadFull(rand.Reader, dekBytes); err != nil {
+		return oops.Code("DEK_RNG_FAILED").Wrap(err)
+	}
+	wrapped, kekKeyID, err := m.provider.Wrap(ctx, dekBytes)
+	if err != nil {
+		return oops.Code("DEK_WRAP_FAILED").Wrap(err)
+	}
+	err = validateProviderWrapOutput(wrapped, kekKeyID)
+	if err != nil {
+		return err
+	}
+
+	newRow := row{
+		ContextType: ctxID.Type, ContextID: ctxID.ID,
+		Version:      activeRow.Version + 1,
+		WrappedDEK:   wrapped,
+		WrapProvider: m.provider.Name(),
+		WrapKeyID:    kekKeyID,
+		Participants: newParticipants,
+	}
+	newID, err := m.store.insert(ctx, newRow)
+	if err != nil {
+		return oops.Code("DEK_STORE_INSERT_FAILED").Wrap(err)
+	}
+
+	//nolint:gosec // G115: newID is a DB BIGSERIAL value
+	newKeyID := codec.KeyID(newID)
+	newVersion := newRow.Version
+
+	material := NewMaterial(dekBytes)
+	m.cache.Put(CacheKey{KeyID: newKeyID, Version: newVersion}, ctxID, material)
+	m.partCache.Put(ParticipantsCacheKey{
+		ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newVersion,
+	}, newParticipants)
+
+	if err := m.invalidate(ctx, ctxID, "rotate",
+		activeRow.Version, newVersion); err != nil {
+		// Rollback: evict caches + mark new row destroyed.
+		m.cache.Invalidate(CacheKey{KeyID: newKeyID, Version: newVersion})
+		m.partCache.Invalidate(ParticipantsCacheKey{
+			ContextType: ctxID.Type, ContextID: ctxID.ID, Version: newVersion,
+		})
+		//nolint:errcheck // best-effort rollback; don't mask the original error
+		_ = m.store.markDestroyed(ctx, newKeyID, newVersion)
+		return err
+	}
+
+	return m.store.markRotated(ctx,
+		//nolint:gosec // G115: activeRow.ID is a DB BIGSERIAL value
+		codec.KeyID(activeRow.ID), activeRow.Version, newID)
 }
 
 // Rekey lands in Phase 5 (epic holomush-jxo8).

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -268,10 +268,18 @@ func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error
 		p.BindingID = bindingID
 	}
 
-	activeRow, err := m.store.updateParticipants(ctx, ctxID, p)
+	activeRow, added, err := m.store.updateParticipants(ctx, ctxID, p)
 	if err != nil {
 		return err
 	}
+	if !added {
+		return nil // idempotent no-op — participant already present
+	}
+
+	m.partCache.Put(
+		ParticipantsCacheKey{ContextType: ctxID.Type, ContextID: ctxID.ID, Version: activeRow.Version},
+		activeRow.Participants,
+	)
 
 	return m.invalidate(ctx, ctxID, "participants_changed", activeRow.Version, 0)
 }

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -440,7 +440,7 @@ func TestManager_Add_AppendsParticipantAndPublishesInvalidation(t *testing.T) {
 	initial := []dek.Participant{
 		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
 	}
-	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	dekKey, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
 	require.NoError(t, err)
 
 	// Now build a real stub invalidator and inject it into a new manager.
@@ -464,7 +464,7 @@ func TestManager_Add_AppendsParticipantAndPublishesInvalidation(t *testing.T) {
 	assert.Equal(t, uint32(0), invStub.calls[0].successorVersion)
 
 	// Verify the participant set was updated.
-	parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+	parts, err := mgr.Participants(context.Background(), dekKey.ID, dekKey.Version)
 	require.NoError(t, err)
 	require.Len(t, parts, 2)
 	assert.Equal(t, "p2", parts[1].PlayerID)
@@ -490,7 +490,7 @@ func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
 	initial := []dek.Participant{
 		{PlayerID: "p0", CharacterID: "c0", BindingID: "bind-0", JoinedAt: time.Now().UTC()},
 	}
-	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	dekKey, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
 	require.NoError(t, err)
 
 	invStub := &stubInvalidator{}
@@ -517,7 +517,7 @@ func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
 	require.Len(t, invStub.calls, 1)
 
 	// Participants should have both entries (initial + added).
-	parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+	parts, err := mgr.Participants(context.Background(), dekKey.ID, dekKey.Version)
 	require.NoError(t, err)
 	require.Len(t, parts, 2)
 }
@@ -582,8 +582,9 @@ func TestManager_Rotate_MintsFreshDEKAndMarksOldRotated(t *testing.T) {
 	initial := []dek.Participant{
 		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
 	}
-	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	v1Key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
 	require.NoError(t, err)
+	v1Version := v1Key.Version
 
 	invStub := &stubInvalidator{}
 	mgr, err = dek.NewManager(
@@ -606,15 +607,22 @@ func TestManager_Rotate_MintsFreshDEKAndMarksOldRotated(t *testing.T) {
 	assert.Equal(t, uint32(2), invStub.calls[0].successorVersion)
 
 	// Old DEK (v1) should still be unwrappable (INV-13).
-	_, err = mgr.Resolve(context.Background(), codec.KeyID(1), 1)
+	_, err = mgr.Resolve(context.Background(), v1Key.ID, v1Version)
 	require.NoError(t, err)
 
-	// New DEK (v2) should be active.
-	_, err = mgr.Resolve(context.Background(), codec.KeyID(2), 2)
+	// Fetch the active (v2) DEK via GetOrCreate — no mint since v2 exists.
+	activeKey, err := mgr.GetOrCreate(context.Background(), ctxID, nil)
+	require.NoError(t, err)
+
+	// New DEK (v2) should have incremented version.
+	assert.Equal(t, v1Version+1, activeKey.Version)
+
+	// New DEK should be resolvable.
+	_, err = mgr.Resolve(context.Background(), activeKey.ID, activeKey.Version)
 	require.NoError(t, err)
 
 	// New participants are on v2.
-	parts, err := mgr.Participants(context.Background(), codec.KeyID(2), 2)
+	parts, err := mgr.Participants(context.Background(), activeKey.ID, activeKey.Version)
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	assert.Equal(t, "p2", parts[0].PlayerID)

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -808,19 +808,23 @@ func TestManager_Add_ConcurrentDistinctParticipantsPreservesBoth(t *testing.T) {
 	// Concurrently add DISTINCT participants — both must persist.
 	var wg sync.WaitGroup
 	var errA, errB error
+	readyCh := make(chan struct{})
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
+		<-readyCh
 		errA = mgrA.Add(ctx, ctxID, dek.Participant{
 			PlayerID: "pA", CharacterID: "cA",
 		})
 	}()
 	go func() {
 		defer wg.Done()
+		<-readyCh
 		errB = mgrB.Add(ctx, ctxID, dek.Participant{
 			PlayerID: "pB", CharacterID: "cB",
 		})
 	}()
+	close(readyCh)
 	wg.Wait()
 
 	require.NoError(t, errA)
@@ -830,8 +834,16 @@ func TestManager_Add_ConcurrentDistinctParticipantsPreservesBoth(t *testing.T) {
 	assert.Len(t, invA.calls, 1)
 	assert.Len(t, invB.calls, 1)
 
-	// Both added participants must appear in the final set.
-	parts, err := mgrA.Participants(ctx, dekKey.ID, dekKey.Version)
+	// Query from a fresh manager with clean caches to avoid reading
+	// stale cache state from mgrA/mgrB (which each seeded only their
+	// own participant during Add).
+	freshMgr, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		noopInvalidator, &stubBindingResolver{bindingID: "fresh"},
+	)
+	require.NoError(t, err)
+	parts, err := freshMgr.Participants(ctx, dekKey.ID, dekKey.Version)
 	require.NoError(t, err)
 	require.Len(t, parts, 3, "initial p0 + pA + pB = 3")
 	players := map[string]bool{"p0": true, "pA": true, "pB": true}

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -27,6 +27,10 @@ import (
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
+// noopInvalidator is a no-op Invalidator for tests that exercise
+// GetOrCreate / Resolve / Participants but never Add / Rotate.
+var noopInvalidator = func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil }
+
 func newTestPGPool(t *testing.T) (string, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -158,7 +162,7 @@ func TestManager_GetOrCreate_MintsAndPersists(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "01ABCDEF"}
@@ -193,7 +197,7 @@ func TestManager_Resolve_ByKeyIDAndVersion(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "dm", ID: "01ABCDEF-01FFFFFF"}
@@ -219,7 +223,7 @@ func TestManager_Resolve_NotFound_ReturnsErrDEKNotFound(t *testing.T) {
 
 	mgr, err := dek.NewManager(newTestProvider(t), dek.NewStore(pool),
 		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
-		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}), nil, nil)
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}), noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	_, err = mgr.Resolve(ctx, codec.KeyID(99999), 1)
@@ -238,7 +242,7 @@ func TestManagerParticipantsRoundTrip(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	initial := []dek.Participant{
@@ -269,7 +273,7 @@ func TestManagerParticipantsNotFoundReturnsTypedError(t *testing.T) {
 
 	mgr, err := dek.NewManager(newTestProvider(t), dek.NewStore(pool),
 		dek.NewCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}),
-		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}), nil, nil)
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}), noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	_, err = mgr.Participants(ctx, codec.KeyID(99999), 1)
@@ -314,9 +318,9 @@ func TestManager_GetOrCreate_ConcurrentMintRace(t *testing.T) {
 	cacheB := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCacheA := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCacheB := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgrA, err := dek.NewManager(provider, storeA, cacheA, partCacheA, nil, nil)
+	mgrA, err := dek.NewManager(provider, storeA, cacheA, partCacheA, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
-	mgrB, err := dek.NewManager(provider, storeB, cacheB, partCacheB, nil, nil)
+	mgrB, err := dek.NewManager(provider, storeB, cacheB, partCacheB, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "race-01"}
@@ -376,7 +380,7 @@ func TestManagerParticipantsHitsCacheOnSecondCall(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "01HSCENE_T7"}
@@ -428,7 +432,7 @@ func TestManager_Add_AppendsParticipantAndPublishesInvalidation(t *testing.T) {
 	// Create a DEK via GetOrCreate first.
 	mgr, err := dek.NewManager(
 		newTestProvider(t), store, cache, partCache,
-		nil, // invalidator — nil here during setup
+		noopInvalidator, // invalidator — no-op during setup
 		&stubBindingResolver{bindingID: "bind-1"},
 	)
 	require.NoError(t, err)
@@ -478,13 +482,13 @@ func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
 
 	mgr, err := dek.NewManager(
 		newTestProvider(t), store, cache, partCache,
-		nil,
+		noopInvalidator,
 		&stubBindingResolver{bindingID: "bind-1"},
 	)
 	require.NoError(t, err)
 
 	initial := []dek.Participant{
-		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+		{PlayerID: "p0", CharacterID: "c0", BindingID: "bind-0", JoinedAt: time.Now().UTC()},
 	}
 	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
 	require.NoError(t, err)
@@ -512,10 +516,10 @@ func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
 	// Only one invalidation call total — second was a no-op.
 	require.Len(t, invStub.calls, 1)
 
-	// Participants should still have exactly 1 entry.
+	// Participants should have both entries (initial + added).
 	parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
 	require.NoError(t, err)
-	require.Len(t, parts, 1)
+	require.Len(t, parts, 2)
 }
 
 // TestManager_Add_BindingMissingFails verifies BINDING_NOT_FOUND when
@@ -530,7 +534,7 @@ func TestManager_Add_BindingMissingFails(t *testing.T) {
 
 	mgr, err := dek.NewManager(
 		newTestProvider(t), store, cache, partCache,
-		nil,
+		noopInvalidator,
 		&stubBindingResolver{bindingID: "bind-1"},
 	)
 	require.NoError(t, err)
@@ -570,7 +574,7 @@ func TestManager_Rotate_MintsFreshDEKAndMarksOldRotated(t *testing.T) {
 
 	mgr, err := dek.NewManager(
 		newTestProvider(t), store, cache, partCache,
-		nil,
+		noopInvalidator,
 		&stubBindingResolver{bindingID: "bind-1"},
 	)
 	require.NoError(t, err)
@@ -627,7 +631,7 @@ func TestManager_Rotate_RollsBackOnInvalidationFailure(t *testing.T) {
 
 	mgr, err := dek.NewManager(
 		newTestProvider(t), store, cache, partCache,
-		nil,
+		noopInvalidator,
 		&stubBindingResolver{bindingID: "bind-1"},
 	)
 	require.NoError(t, err)
@@ -656,12 +660,12 @@ func TestManager_Rotate_RollsBackOnInvalidationFailure(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "INVALIDATION_PARTIAL_FAILURE")
 
 	// The original DEK should still be the active one.
-	parts, err := mgr.Participants(context.Background(), key.KeyID, key.Version)
+	parts, err := mgr.Participants(context.Background(), key.ID, key.Version)
 	require.NoError(t, err)
 	assert.Len(t, parts, 1)
 	assert.Equal(t, "p1", parts[0].PlayerID)
 
 	// No new DEK version should exist.
-	_, err = mgr.Resolve(context.Background(), codec.KeyID(uint64(key.KeyID)+1), key.Version+1)
+	_, err = mgr.Resolve(context.Background(), codec.KeyID(uint64(key.ID)+1), key.Version+1)
 	require.Error(t, err)
 }

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -677,3 +677,131 @@ func TestManager_Rotate_RollsBackOnInvalidationFailure(t *testing.T) {
 	_, err = mgr.Resolve(context.Background(), codec.KeyID(uint64(key.ID)+1), key.Version+1)
 	require.Error(t, err)
 }
+
+// TestManager_Add_ConcurrentSameBindingIsIdempotent verifies that
+// concurrent Adds with the same (player_id, binding_id) are both
+// idempotent — one succeeds, the other detects the duplicate and
+// returns no-op. Final participant count is exactly 2 (initial + 1 added).
+func TestManager_Add_ConcurrentSameBindingIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	connStr, teardown := newTestPGPool(t)
+	defer teardown()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	store := dek.NewStore(pool)
+	provider := newTestProvider(t)
+
+	// Seed: create the DEK with one initial participant.
+	ctxID := dek.ContextID{Type: "scene", ID: "concurrent-add"}
+	setupMgr, err := dek.NewManager(provider, store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		noopInvalidator, &stubBindingResolver{bindingID: "bind-initial"},
+	)
+	require.NoError(t, err)
+	initial := []dek.Participant{
+		{PlayerID: "p0", CharacterID: "c0", BindingID: "bind-0", JoinedAt: time.Now().UTC()},
+	}
+	dekKey, err := setupMgr.GetOrCreate(ctx, ctxID, initial)
+	require.NoError(t, err)
+
+	// Two managers with separate caches but shared DB.
+	invA := &stubInvalidator{}
+	invB := &stubInvalidator{}
+	mgrA, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		invA.call(), &stubBindingResolver{bindingID: "bind-concurrent"},
+	)
+	require.NoError(t, err)
+	mgrB, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		invB.call(), &stubBindingResolver{bindingID: "bind-concurrent"},
+	)
+	require.NoError(t, err)
+
+	// Concurrently add the same participant (same player_id, same resolved binding_id).
+	var wg sync.WaitGroup
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errA = mgrA.Add(ctx, ctxID, dek.Participant{
+			PlayerID: "p1", CharacterID: "c1",
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		errB = mgrB.Add(ctx, ctxID, dek.Participant{
+			PlayerID: "p1", CharacterID: "c1",
+		})
+	}()
+	wg.Wait()
+
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+
+	// At least one must have published an invalidation. Both may return
+	// added=true if the scheduler interleaves their selectActive calls
+	// (read-modify-write TOCTOU), in which case totalCalls == 2.
+	totalCalls := len(invA.calls) + len(invB.calls)
+	assert.True(t, totalCalls >= 1,
+		"at least one concurrent Add must publish invalidation; got %d", totalCalls)
+
+	// Query via mgrA (whose partCache was seeded by Add) rather than setupMgr
+	// (whose cache is stale — it was seeded by GetOrCreate and never updated).
+	parts, err := mgrA.Participants(ctx, dekKey.ID, dekKey.Version)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	players := map[string]bool{"p0": true, "p1": true}
+	for _, p := range parts {
+		assert.True(t, players[p.PlayerID], "unexpected player %s", p.PlayerID)
+	}
+}
+
+// TestManager_Add_WithExplicitBindingIDSkipsResolver covers the code path
+// where Add is called with a pre-set BindingID (p.BindingID != ""), so
+// the BindingResolver is never invoked.
+func TestManager_Add_WithExplicitBindingIDSkipsResolver(t *testing.T) {
+	ctx := context.Background()
+	connStr, teardown := newTestPGPool(t)
+	defer teardown()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	store := dek.NewStore(pool)
+
+	// This stub returns an error if called — the test fails if Add invokes it.
+	invStub := &stubInvalidator{}
+	mgr, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		invStub.call(), &stubBindingResolver{bindingID: "should-not-be-used"},
+	)
+	require.NoError(t, err)
+
+	ctxID := dek.ContextID{Type: "scene", ID: "explicit-binding"}
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	dekKey, err := mgr.GetOrCreate(ctx, ctxID, initial)
+	require.NoError(t, err)
+
+	// Add with an explicit BindingID — skips the resolver entirely.
+	err = mgr.Add(ctx, ctxID, dek.Participant{
+		PlayerID: "p2", CharacterID: "c2", BindingID: "bind-explicit",
+		JoinedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.Len(t, invStub.calls, 1)
+	assert.Equal(t, "participants_changed", invStub.calls[0].action)
+
+	parts, err := mgr.Participants(ctx, dekKey.ID, dekKey.Version)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "bind-explicit", parts[1].BindingID)
+}

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
+	"github.com/samber/oops"
+
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
@@ -112,6 +114,39 @@ func sanitizeEnvName(s string) string {
 	return string(out)
 }
 
+// testIntegrationPool creates a testcontainer-backed *pgxpool.Pool with
+// migrations applied. Used by Add, Rotate, and INV integration tests.
+func testIntegrationPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	connStr, cleanup := newTestPGPool(t)
+	t.Cleanup(cleanup)
+	pool, err := pgxpool.New(context.Background(), connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// stubInvalidator records invalidation calls for assertions.
+type stubInvalidator struct {
+	calls []invalidationCall
+}
+
+type invalidationCall struct {
+	ctxID            dek.ContextID
+	action           string
+	version          uint32
+	successorVersion uint32
+}
+
+func (s *stubInvalidator) call() dek.Invalidator {
+	return func(_ context.Context, ctxID dek.ContextID, action string, v, sv uint32) error {
+		s.calls = append(s.calls, invalidationCall{
+			ctxID: ctxID, action: action, version: v, successorVersion: sv,
+		})
+		return nil
+	}
+}
+
 func TestManager_GetOrCreate_MintsAndPersists(t *testing.T) {
 	ctx := context.Background()
 	connStr, teardown := newTestPGPool(t)
@@ -123,7 +158,7 @@ func TestManager_GetOrCreate_MintsAndPersists(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "01ABCDEF"}
@@ -158,7 +193,7 @@ func TestManager_Resolve_ByKeyIDAndVersion(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "dm", ID: "01ABCDEF-01FFFFFF"}
@@ -184,7 +219,7 @@ func TestManager_Resolve_NotFound_ReturnsErrDEKNotFound(t *testing.T) {
 
 	mgr, err := dek.NewManager(newTestProvider(t), dek.NewStore(pool),
 		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
-		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}))
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}), nil, nil)
 	require.NoError(t, err)
 
 	_, err = mgr.Resolve(ctx, codec.KeyID(99999), 1)
@@ -203,7 +238,7 @@ func TestManagerParticipantsRoundTrip(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	initial := []dek.Participant{
@@ -234,7 +269,7 @@ func TestManagerParticipantsNotFoundReturnsTypedError(t *testing.T) {
 
 	mgr, err := dek.NewManager(newTestProvider(t), dek.NewStore(pool),
 		dek.NewCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}),
-		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}))
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64, TTL: time.Minute}), nil, nil)
 	require.NoError(t, err)
 
 	_, err = mgr.Participants(ctx, codec.KeyID(99999), 1)
@@ -279,9 +314,9 @@ func TestManager_GetOrCreate_ConcurrentMintRace(t *testing.T) {
 	cacheB := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCacheA := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCacheB := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgrA, err := dek.NewManager(provider, storeA, cacheA, partCacheA)
+	mgrA, err := dek.NewManager(provider, storeA, cacheA, partCacheA, nil, nil)
 	require.NoError(t, err)
-	mgrB, err := dek.NewManager(provider, storeB, cacheB, partCacheB)
+	mgrB, err := dek.NewManager(provider, storeB, cacheB, partCacheB, nil, nil)
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "race-01"}
@@ -341,7 +376,7 @@ func TestManagerParticipantsHitsCacheOnSecondCall(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	ctxID := dek.ContextID{Type: "scene", ID: "01HSCENE_T7"}
@@ -379,4 +414,254 @@ func TestManagerParticipantsHitsCacheOnSecondCall(t *testing.T) {
 	if _, ok := partCache.Get(pck); !ok {
 		t.Error("ParticipantsCache miss after fall-through; expected re-seed")
 	}
+}
+
+// TestManager_Add_AppendsParticipantAndPublishesInvalidation is INV-12.
+func TestManager_Add_AppendsParticipantAndPublishesInvalidation(t *testing.T) {
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	ctxID := dek.ContextID{Type: "scene", ID: "add-test"}
+
+	// Create a DEK via GetOrCreate first.
+	mgr, err := dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		nil, // invalidator — nil here during setup
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	require.NoError(t, err)
+
+	// Now build a real stub invalidator and inject it into a new manager.
+	invStub := &stubInvalidator{}
+	mgr, err = dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		invStub.call(),
+		&stubBindingResolver{bindingID: "bind-2"},
+	)
+	require.NoError(t, err)
+
+	err = mgr.Add(context.Background(), ctxID, dek.Participant{
+		PlayerID: "p2", CharacterID: "c2", JoinedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	// Verify invalidation was published.
+	require.Len(t, invStub.calls, 1)
+	assert.Equal(t, "participants_changed", invStub.calls[0].action)
+	assert.Equal(t, uint32(1), invStub.calls[0].version)
+	assert.Equal(t, uint32(0), invStub.calls[0].successorVersion)
+
+	// Verify the participant set was updated.
+	parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "p2", parts[1].PlayerID)
+	assert.Equal(t, "bind-2", parts[1].BindingID)
+}
+
+// TestManager_Add_IdempotentOnBindingID verifies second Add is a no-op.
+func TestManager_Add_IdempotentOnBindingID(t *testing.T) {
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	ctxID := dek.ContextID{Type: "scene", ID: "idempotent-test"}
+
+	mgr, err := dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		nil,
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	require.NoError(t, err)
+
+	invStub := &stubInvalidator{}
+	mgr, err = dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		invStub.call(),
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	// First Add should succeed.
+	err = mgr.Add(context.Background(), ctxID, dek.Participant{
+		PlayerID: "p1", CharacterID: "c1",
+	})
+	require.NoError(t, err)
+	require.Len(t, invStub.calls, 1)
+
+	// Second Add with same (player_id, binding_id) should be no-op.
+	err = mgr.Add(context.Background(), ctxID, dek.Participant{
+		PlayerID: "p1", CharacterID: "c1",
+	})
+	require.NoError(t, err)
+	// Only one invalidation call total — second was a no-op.
+	require.Len(t, invStub.calls, 1)
+
+	// Participants should still have exactly 1 entry.
+	parts, err := mgr.Participants(context.Background(), codec.KeyID(1), 1)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+}
+
+// TestManager_Add_BindingMissingFails verifies BINDING_NOT_FOUND when
+// no active binding exists.
+func TestManager_Add_BindingMissingFails(t *testing.T) {
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	ctxID := dek.ContextID{Type: "scene", ID: "binding-missing-test"}
+
+	mgr, err := dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		nil,
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	require.NoError(t, err)
+
+	invStub := &stubInvalidator{}
+	mgr, err = dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		invStub.call(),
+		&stubBindingResolver{err: oops.Code("BINDING_NOT_FOUND").
+			Errorf("no active binding for character c3")},
+	)
+	require.NoError(t, err)
+
+	err = mgr.Add(context.Background(), ctxID, dek.Participant{
+		PlayerID: "p2", CharacterID: "c3",
+	})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "BINDING_NOT_FOUND")
+	// No invalidation should have been published.
+	assert.Len(t, invStub.calls, 0)
+}
+
+// TestManager_Rotate_MintsFreshDEKAndMarksOldRotated is INV-13.
+func TestManager_Rotate_MintsFreshDEKAndMarksOldRotated(t *testing.T) {
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	ctxID := dek.ContextID{Type: "scene", ID: "rotate-test"}
+
+	mgr, err := dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		nil,
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	_, err = mgr.GetOrCreate(context.Background(), ctxID, initial)
+	require.NoError(t, err)
+
+	invStub := &stubInvalidator{}
+	mgr, err = dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		invStub.call(),
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	newParticipants := []dek.Participant{
+		{PlayerID: "p2", CharacterID: "c2", BindingID: "bind-2", JoinedAt: time.Now().UTC()},
+	}
+	err = mgr.Rotate(context.Background(), ctxID, newParticipants, "test departure")
+	require.NoError(t, err)
+
+	// Verify invalidation was published.
+	require.Len(t, invStub.calls, 1)
+	assert.Equal(t, "rotate", invStub.calls[0].action)
+	assert.Equal(t, uint32(1), invStub.calls[0].version)
+	assert.Equal(t, uint32(2), invStub.calls[0].successorVersion)
+
+	// Old DEK (v1) should still be unwrappable (INV-13).
+	_, err = mgr.Resolve(context.Background(), codec.KeyID(1), 1)
+	require.NoError(t, err)
+
+	// New DEK (v2) should be active.
+	_, err = mgr.Resolve(context.Background(), codec.KeyID(2), 2)
+	require.NoError(t, err)
+
+	// New participants are on v2.
+	parts, err := mgr.Participants(context.Background(), codec.KeyID(2), 2)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	assert.Equal(t, "p2", parts[0].PlayerID)
+}
+
+// TestManager_Rotate_RollsBackOnInvalidationFailure is INV-29.
+func TestManager_Rotate_RollsBackOnInvalidationFailure(t *testing.T) {
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	ctxID := dek.ContextID{Type: "scene", ID: "rotate-fail-test"}
+
+	mgr, err := dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		nil,
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	initial := []dek.Participant{
+		{PlayerID: "p1", CharacterID: "c1", BindingID: "bind-1", JoinedAt: time.Now().UTC()},
+	}
+	key, err := mgr.GetOrCreate(context.Background(), ctxID, initial)
+	require.NoError(t, err)
+
+	// Build a stub that fails on invalidation.
+	mgr, err = dek.NewManager(
+		newTestProvider(t), store, cache, partCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error {
+			return oops.Code("INVALIDATION_PARTIAL_FAILURE").Errorf("simulated failure")
+		},
+		&stubBindingResolver{bindingID: "bind-1"},
+	)
+	require.NoError(t, err)
+
+	newParticipants := []dek.Participant{
+		{PlayerID: "p2", CharacterID: "c2", BindingID: "bind-2", JoinedAt: time.Now().UTC()},
+	}
+	err = mgr.Rotate(context.Background(), ctxID, newParticipants, "test")
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "INVALIDATION_PARTIAL_FAILURE")
+
+	// The original DEK should still be the active one.
+	parts, err := mgr.Participants(context.Background(), key.KeyID, key.Version)
+	require.NoError(t, err)
+	assert.Len(t, parts, 1)
+	assert.Equal(t, "p1", parts[0].PlayerID)
+
+	// No new DEK version should exist.
+	_, err = mgr.Resolve(context.Background(), codec.KeyID(uint64(key.KeyID)+1), key.Version+1)
+	require.Error(t, err)
 }

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -744,12 +744,12 @@ func TestManager_Add_ConcurrentSameBindingIsIdempotent(t *testing.T) {
 	require.NoError(t, errA)
 	require.NoError(t, errB)
 
-	// At least one must have published an invalidation. Both may return
-	// added=true if the scheduler interleaves their selectActive calls
-	// (read-modify-write TOCTOU), in which case totalCalls == 2.
+	// Exactly one must have published an invalidation — the second
+	// goroutine serializes on the FOR UPDATE row lock and sees the
+	// duplicate, returning added=false without publishing.
 	totalCalls := len(invA.calls) + len(invB.calls)
-	assert.True(t, totalCalls >= 1,
-		"at least one concurrent Add must publish invalidation; got %d", totalCalls)
+	assert.Equal(t, 1, totalCalls,
+		"exactly one concurrent Add must publish invalidation; got %d", totalCalls)
 
 	// Query via mgrA (whose partCache was seeded by Add) rather than setupMgr
 	// (whose cache is stale — it was seeded by GetOrCreate and never updated).
@@ -757,6 +757,84 @@ func TestManager_Add_ConcurrentSameBindingIsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, parts, 2)
 	players := map[string]bool{"p0": true, "p1": true}
+	for _, p := range parts {
+		assert.True(t, players[p.PlayerID], "unexpected player %s", p.PlayerID)
+	}
+}
+
+// TestManager_Add_ConcurrentDistinctParticipantsPreservesBoth is the
+// regression test for holomush-fi0n.9 (TOCTOU race in updateParticipants).
+// Two goroutines concurrently add different participants to the same DEK.
+// With SELECT ... FOR UPDATE, the second goroutine blocks on the first's
+// row lock and reads the updated participant list; both entries persist.
+// Without the lock, the second read-modify-write can silently discard the
+// first write (final count would be 2 instead of 3).
+func TestManager_Add_ConcurrentDistinctParticipantsPreservesBoth(t *testing.T) {
+	ctx := context.Background()
+	pool := testIntegrationPool(t)
+	store := dek.NewStore(pool)
+
+	ctxID := dek.ContextID{Type: "scene", ID: "concurrent-distinct"}
+
+	// Seed: create the DEK with one initial participant.
+	setupMgr, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		noopInvalidator, &stubBindingResolver{bindingID: "bind-0"},
+	)
+	require.NoError(t, err)
+	initial := []dek.Participant{
+		{PlayerID: "p0", CharacterID: "c0", BindingID: "bind-0", JoinedAt: time.Now().UTC()},
+	}
+	dekKey, err := setupMgr.GetOrCreate(ctx, ctxID, initial)
+	require.NoError(t, err)
+
+	// Two managers with separate caches but shared DB.
+	invA := &stubInvalidator{}
+	invB := &stubInvalidator{}
+	mgrA, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		invA.call(), &stubBindingResolver{bindingID: "bind-A"},
+	)
+	require.NoError(t, err)
+	mgrB, err := dek.NewManager(newTestProvider(t), store,
+		dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute}),
+		invB.call(), &stubBindingResolver{bindingID: "bind-B"},
+	)
+	require.NoError(t, err)
+
+	// Concurrently add DISTINCT participants — both must persist.
+	var wg sync.WaitGroup
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errA = mgrA.Add(ctx, ctxID, dek.Participant{
+			PlayerID: "pA", CharacterID: "cA",
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		errB = mgrB.Add(ctx, ctxID, dek.Participant{
+			PlayerID: "pB", CharacterID: "cB",
+		})
+	}()
+	wg.Wait()
+
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+
+	// Both must have published invalidation.
+	assert.Len(t, invA.calls, 1)
+	assert.Len(t, invB.calls, 1)
+
+	// Both added participants must appear in the final set.
+	parts, err := mgrA.Participants(ctx, dekKey.ID, dekKey.Version)
+	require.NoError(t, err)
+	require.Len(t, parts, 3, "initial p0 + pA + pB = 3")
+	players := map[string]bool{"p0": true, "pA": true, "pB": true}
 	for _, p := range parts {
 		assert.True(t, players[p.PlayerID], "unexpected player %s", p.PlayerID)
 	}

--- a/internal/eventbus/crypto/dek/manager_test.go
+++ b/internal/eventbus/crypto/dek/manager_test.go
@@ -15,11 +15,21 @@ import (
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
+// stubBindingResolver implements dek.BindingResolver for tests.
+type stubBindingResolver struct {
+	bindingID string
+	err       error
+}
+
+func (s *stubBindingResolver) Current(_ context.Context, _ string) (string, error) {
+	return s.bindingID, s.err
+}
+
 // TestNewManager_RejectsNilProvider verifies NewManager returns
 // DEK_MANAGER_DEPENDENCY_NIL when the kek.Provider argument is nil,
 // rather than returning a Manager that nil-panics on first GetOrCreate.
 func TestNewManager_RejectsNilProvider(t *testing.T) {
-	_, err := dek.NewManager(nil, &dek.Store{}, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}))
+	_, err := dek.NewManager(nil, &dek.Store{}, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
 	errutil.AssertErrorContext(t, err, "dependency", "provider")
@@ -27,7 +37,7 @@ func TestNewManager_RejectsNilProvider(t *testing.T) {
 
 // TestNewManager_RejectsNilStore verifies the store nil-check path.
 func TestNewManager_RejectsNilStore(t *testing.T) {
-	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), nil, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}))
+	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), nil, dek.NewCache(dek.CacheConfig{}), dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
 	errutil.AssertErrorContext(t, err, "dependency", "store")
@@ -35,7 +45,7 @@ func TestNewManager_RejectsNilStore(t *testing.T) {
 
 // TestNewManager_RejectsNilCache verifies the cache nil-check path.
 func TestNewManager_RejectsNilCache(t *testing.T) {
-	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, nil, dek.NewParticipantsCache(dek.CacheConfig{}))
+	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, nil, dek.NewParticipantsCache(dek.CacheConfig{}), nil, nil)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
 	errutil.AssertErrorContext(t, err, "dependency", "cache")
@@ -45,7 +55,7 @@ func TestNewManager_RejectsNilCache(t *testing.T) {
 // nil-check path. Phase 3c (T7) adds ParticipantsCache as a required
 // collaborator; the dependency-nil error path covers it like the others.
 func TestNewManager_RejectsNilParticipantsCache(t *testing.T) {
-	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, dek.NewCache(dek.CacheConfig{}), nil)
+	_, err := dek.NewManager(kek.NewNoneProviderForUnitTest(), &dek.Store{}, dek.NewCache(dek.CacheConfig{}), nil, nil, nil)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
 	errutil.AssertErrorContext(t, err, "dependency", "partCache")
@@ -68,4 +78,34 @@ func TestManager_NotConfigured_GuardsResolve(t *testing.T) {
 	_, err := m.Resolve(context.Background(), codec.KeyID(1), 1)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "DEK_MANAGER_NOT_CONFIGURED")
+}
+
+// TestNewManager_RejectsNilInvalidator verifies the nil guard on the
+// new Invalidator parameter.
+func TestNewManager_RejectsNilInvalidator(t *testing.T) {
+	_, err := dek.NewManager(
+		kek.NewNoneProviderForUnitTest(),
+		&dek.Store{},
+		dek.NewCache(dek.CacheConfig{}),
+		dek.NewParticipantsCache(dek.CacheConfig{}),
+		nil,
+		&stubBindingResolver{},
+	)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
+}
+
+// TestNewManager_RejectsNilBindingResolver verifies the nil guard on the
+// new BindingResolver parameter.
+func TestNewManager_RejectsNilBindingResolver(t *testing.T) {
+	_, err := dek.NewManager(
+		kek.NewNoneProviderForUnitTest(),
+		&dek.Store{},
+		dek.NewCache(dek.CacheConfig{}),
+		dek.NewParticipantsCache(dek.CacheConfig{}),
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		nil,
+	)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "DEK_MANAGER_DEPENDENCY_NIL")
 }

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -200,7 +200,7 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 			With("context_type", ctxID.Type).
 			With("context_id", ctxID.ID).Wrap(err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }() // no-op after Commit
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // no-op after Commit
 
 	// SELECT the active row and lock it until the transaction commits.
 	var active row
@@ -230,14 +230,19 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 			With("context_type", ctxID.Type).
 			With("context_id", ctxID.ID).Wrap(err)
 	}
-	if err := json.Unmarshal(participantsJSON, &active.Participants); err != nil {
+	if err = json.Unmarshal(participantsJSON, &active.Participants); err != nil {
 		return row{}, false, oops.Code("DEK_PARTICIPANTS_UNMARSHAL_FAILED").Wrap(err)
 	}
 
 	// Check for existing duplicate.
 	for _, existing := range active.Participants {
 		if existing.PlayerID == p.PlayerID && existing.BindingID == p.BindingID {
-			return active, false, tx.Commit(ctx)
+			if err = tx.Commit(ctx); err != nil {
+				return row{}, false, oops.Code("DEK_TX_COMMIT_FAILED").
+					With("context_type", ctxID.Type).
+					With("context_id", ctxID.ID).Wrap(err)
+			}
+			return active, false, nil
 		}
 	}
 
@@ -261,7 +266,7 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 			With("context_id", ctxID.ID).Wrap(err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
+	if err = tx.Commit(ctx); err != nil {
 		return row{}, false, oops.Code("DEK_TX_COMMIT_FAILED").
 			With("context_type", ctxID.Type).
 			With("context_id", ctxID.ID).Wrap(err)

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -182,6 +182,184 @@ func IsUniqueViolation(err error) bool {
 	return false
 }
 
+// updateParticipants appends p to the active DEK's participant set.
+// Idempotent on (player_id, binding_id) — duplicate returns the active
+// row unchanged. Returns the active row wrapped in a pgx.ErrNoRows
+// sentinel when no active DEK exists.
+func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, error) {
+	active, err := s.selectActive(ctx, ctxID)
+	if err != nil {
+		return row{}, err // pgx.ErrNoRows → DEK_NOT_FOUND for caller
+	}
+
+	participantJSON, err := json.Marshal(p)
+	if err != nil {
+		return row{}, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
+	}
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE crypto_keys
+		   SET participants = participants || $3::jsonb
+		 WHERE context_type = $1 AND context_id = $2
+		   AND rotated_at IS NULL AND destroyed_at IS NULL
+		   AND NOT EXISTS (
+		     SELECT 1 FROM jsonb_array_elements(participants) AS part
+		     WHERE part->>'player_id' = $4 AND part->>'binding_id' = $5
+		   )`,
+		ctxID.Type, ctxID.ID, participantJSON, p.PlayerID, p.BindingID,
+	)
+	if err != nil {
+		return row{}, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").
+			With("context_type", ctxID.Type).
+			With("context_id", ctxID.ID).Wrap(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return active, nil // duplicate — idempotent no-op
+	}
+
+	return s.selectActive(ctx, ctxID)
+}
+
+// markRotated sets rotated_at and superseded_by on the target row.
+func (s *Store) markRotated(ctx context.Context, keyID codec.KeyID, version uint32, supersededBy int64) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE crypto_keys
+		   SET rotated_at = NOW(), superseded_by = $3
+		 WHERE id = $1 AND version = $2 AND rotated_at IS NULL AND destroyed_at IS NULL`,
+		//nolint:gosec // G115: keyID is a DB BIGSERIAL value; positive serial ids fit in int64
+		int64(keyID), version, supersededBy,
+	)
+	if err != nil {
+		return oops.Code("DEK_MARK_ROTATED_FAILED").
+			With("key_id", uint64(keyID)).
+			With("version", version).Wrap(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return oops.Code("DEK_MARK_ROTATED_NOT_FOUND").
+			With("key_id", uint64(keyID)).
+			With("version", version).
+			Errorf("no unrotated row for key %d v%d", keyID, version)
+	}
+	return nil
+}
+
+// markDestroyed sets destroyed_at on the target row. Best-effort
+// rollback helper — used when Rotate's invalidation fails.
+func (s *Store) markDestroyed(ctx context.Context, keyID codec.KeyID, version uint32) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE crypto_keys
+		   SET destroyed_at = NOW()
+		 WHERE id = $1 AND version = $2 AND destroyed_at IS NULL`,
+		//nolint:gosec // G115: keyID is a DB BIGSERIAL value; positive serial ids fit in int64
+		int64(keyID), version,
+	)
+	if err != nil {
+		return oops.Code("DEK_MARK_DESTROYED_FAILED").
+			With("key_id", uint64(keyID)).
+			With("version", version).Wrap(err)
+	}
+	return nil
+}
+
+//nolint:unused // used by rebind handler (Phase 4 integration, TBD)
+// selectByBindingID returns all active DEK rows whose participants
+// array contains an element with the given binding_id. Used by the
+// wizard-transfer rebind handler to find affected DEKs.
+func (s *Store) selectByBindingID(ctx context.Context, bindingID string) ([]row, error) {
+	probe := []Participant{{BindingID: bindingID}}
+	probeJSON, err := json.Marshal(probe)
+	if err != nil {
+		return nil, oops.Code("DEK_BINDING_PROBE_MARSHAL_FAILED").Wrap(err)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, context_type, context_id, version, wrapped_dek,
+		       wrap_provider, wrap_key_id, participants, created_at, rotated_at
+		  FROM crypto_keys
+		 WHERE participants @> $1::jsonb
+		   AND rotated_at IS NULL AND destroyed_at IS NULL
+		 ORDER BY id`,
+		probeJSON,
+	)
+	if err != nil {
+		return nil, oops.Code("DEK_SELECT_BY_BINDING_FAILED").Wrap(err)
+	}
+	defer rows.Close()
+
+	var out []row
+	for rows.Next() {
+		var r row
+		var participantsJSON []byte
+		if err := rows.Scan(
+			&r.ID, &r.ContextType, &r.ContextID, &r.Version, &r.WrappedDEK,
+			&r.WrapProvider, &r.WrapKeyID, &participantsJSON, &r.CreatedAt, &r.RotatedAt,
+		); err != nil {
+			return nil, oops.Code("DEK_SELECT_BY_BINDING_SCAN_FAILED").Wrap(err)
+		}
+		if err := json.Unmarshal(participantsJSON, &r.Participants); err != nil {
+			return nil, oops.Code("DEK_PARTICIPANTS_UNMARSHAL_FAILED").Wrap(err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, oops.Code("DEK_SELECT_BY_BINDING_ROWS_ERR").Wrap(err)
+	}
+	return out, nil
+}
+
+// ResolveIntegrity finds contexts with multiple unrotated, undestroyed
+// rows (crashed Rotate) and marks the earlier versions rotated, keeping
+// only the max version active. Idempotent — safe to run at every startup.
+func (s *Store) ResolveIntegrity(ctx context.Context) error {
+	rows, err := s.pool.Query(ctx, `
+		SELECT context_type, context_id
+		  FROM crypto_keys
+		 WHERE rotated_at IS NULL AND destroyed_at IS NULL
+		 GROUP BY context_type, context_id
+		HAVING COUNT(*) > 1`)
+	if err != nil {
+		return oops.Code("DEK_INTEGRITY_QUERY_FAILED").Wrap(err)
+	}
+	defer rows.Close()
+
+	type ctxKey struct {
+		ctxType, ctxID string
+	}
+	var conflicted []ctxKey
+	for rows.Next() {
+		var ck ctxKey
+		if err := rows.Scan(&ck.ctxType, &ck.ctxID); err != nil {
+			return oops.Code("DEK_INTEGRITY_SCAN_FAILED").Wrap(err)
+		}
+		conflicted = append(conflicted, ck)
+	}
+	if err := rows.Err(); err != nil {
+		return oops.Code("DEK_INTEGRITY_ROWS_ERR").Wrap(err)
+	}
+
+	for _, ck := range conflicted {
+		// Mark all but the max-version row as rotated.
+		_, err := s.pool.Exec(ctx, `
+			UPDATE crypto_keys
+			   SET rotated_at = NOW()
+			 WHERE context_type = $1 AND context_id = $2
+			   AND rotated_at IS NULL AND destroyed_at IS NULL
+			   AND version < (
+			       SELECT MAX(version) FROM crypto_keys
+			        WHERE context_type = $1 AND context_id = $2
+			          AND rotated_at IS NULL AND destroyed_at IS NULL
+			   )`,
+			ck.ctxType, ck.ctxID,
+		)
+		if err != nil {
+			return oops.Code("DEK_INTEGRITY_RESOLVE_FAILED").
+				With("context_type", ck.ctxType).
+				With("context_id", ck.ctxID).Wrap(err)
+		}
+	}
+	return nil
+}
+
 // Row is the exported view of a crypto_keys row. Mirrors the internal
 // `row` struct but adds DestroyedAt (only populated by SelectAnyByID).
 //

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -256,9 +256,9 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 	_, err = tx.Exec(ctx, `
 		UPDATE crypto_keys
 		   SET participants = $3
-		 WHERE context_type = $1 AND context_id = $2
+		 WHERE id = $1 AND version = $2
 		   AND rotated_at IS NULL AND destroyed_at IS NULL`,
-		ctxID.Type, ctxID.ID, newJSON,
+		active.ID, active.Version, newJSON,
 	)
 	if err != nil {
 		return row{}, false, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").
@@ -321,7 +321,7 @@ func (s *Store) markDestroyed(ctx context.Context, keyID codec.KeyID, version ui
 // array contains an element with the given binding_id. Used by the
 // wizard-transfer rebind handler to find affected DEKs.
 func (s *Store) selectByBindingID(ctx context.Context, bindingID string) ([]row, error) {
-	probe := []Participant{{BindingID: bindingID}}
+	probe := []map[string]string{{"binding_id": bindingID}}
 	probeJSON, err := json.Marshal(probe)
 	if err != nil {
 		return nil, oops.Code("DEK_BINDING_PROBE_MARSHAL_FAILED").Wrap(err)

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -184,40 +184,43 @@ func IsUniqueViolation(err error) bool {
 
 // updateParticipants appends p to the active DEK's participant set.
 // Idempotent on (player_id, binding_id) — duplicate returns the active
-// row unchanged. Returns the active row wrapped in a pgx.ErrNoRows
-// sentinel when no active DEK exists.
-func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, error) {
+// row unchanged with added=false. Returns the active row wrapped in a
+// pgx.ErrNoRows sentinel when no active DEK exists.
+func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, bool, error) {
 	active, err := s.selectActive(ctx, ctxID)
 	if err != nil {
-		return row{}, err // pgx.ErrNoRows → DEK_NOT_FOUND for caller
+		return row{}, false, err // pgx.ErrNoRows → DEK_NOT_FOUND for caller
 	}
 
-	participantJSON, err := json.Marshal(p)
+	// Check for existing duplicate.
+	for _, existing := range active.Participants {
+		if existing.PlayerID == p.PlayerID && existing.BindingID == p.BindingID {
+			return active, false, nil
+		}
+	}
+
+	// Append and write back.
+	active.Participants = append(active.Participants, p)
+	newJSON, err := json.Marshal(active.Participants)
 	if err != nil {
-		return row{}, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
+		return row{}, false, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
 	}
 
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE crypto_keys
-		   SET participants = participants || $3::jsonb
+		   SET participants = $3
 		 WHERE context_type = $1 AND context_id = $2
-		   AND rotated_at IS NULL AND destroyed_at IS NULL
-		   AND NOT EXISTS (
-		     SELECT 1 FROM jsonb_array_elements(participants) AS part
-		     WHERE part->>'player_id' = $4 AND part->>'binding_id' = $5
-		   )`,
-		ctxID.Type, ctxID.ID, participantJSON, p.PlayerID, p.BindingID,
+		   AND rotated_at IS NULL AND destroyed_at IS NULL`,
+		ctxID.Type, ctxID.ID, newJSON,
 	)
 	if err != nil {
-		return row{}, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").
+		return row{}, false, oops.Code("DEK_PARTICIPANTS_UPDATE_FAILED").
 			With("context_type", ctxID.Type).
 			With("context_id", ctxID.ID).Wrap(err)
 	}
-	if tag.RowsAffected() == 0 {
-		return active, nil // duplicate — idempotent no-op
-	}
+	_ = tag.RowsAffected() // pgx may report 0 for jsonb no-change rows; trust the UPDATE
 
-	return s.selectActive(ctx, ctxID)
+	return active, true, nil
 }
 
 // markRotated sets rotated_at and superseded_by on the target row.

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/oops"
@@ -186,16 +187,57 @@ func IsUniqueViolation(err error) bool {
 // Idempotent on (player_id, binding_id) — duplicate returns the active
 // row unchanged with added=false. Returns the active row wrapped in a
 // pgx.ErrNoRows sentinel when no active DEK exists.
+//
+// Uses SELECT ... FOR UPDATE within a transaction to serialize concurrent
+// Add calls on the same (context_type, context_id). Without the row lock,
+// two concurrent Adds of distinct participants can both read the same
+// participant list, each append their own entry, and the second write
+// silently discards the first (holomush-fi0n.9).
 func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Participant) (row, bool, error) {
-	active, err := s.selectActive(ctx, ctxID)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return row{}, false, err // pgx.ErrNoRows → DEK_NOT_FOUND for caller
+		return row{}, false, oops.Code("DEK_TX_BEGIN_FAILED").
+			With("context_type", ctxID.Type).
+			With("context_id", ctxID.ID).Wrap(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op after Commit
+
+	// SELECT the active row and lock it until the transaction commits.
+	var active row
+	var participantsJSON []byte
+	err = tx.QueryRow(ctx, `
+		SELECT id, context_type, context_id, version, wrapped_dek,
+		       wrap_provider, wrap_key_id, participants, created_at, rotated_at
+		  FROM crypto_keys
+		 WHERE context_type=$1 AND context_id=$2
+		   AND rotated_at IS NULL AND destroyed_at IS NULL
+		 ORDER BY version DESC
+		 LIMIT 1
+		 FOR UPDATE`,
+		ctxID.Type, ctxID.ID,
+	).Scan(
+		&active.ID, &active.ContextType, &active.ContextID, &active.Version,
+		&active.WrappedDEK, &active.WrapProvider, &active.WrapKeyID,
+		&participantsJSON, &active.CreatedAt, &active.RotatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return row{}, false, oops.With("operation", "select_active_dek_for_update").
+				With("context_type", ctxID.Type).
+				With("context_id", ctxID.ID).Wrap(err)
+		}
+		return row{}, false, oops.Code("DEK_STORE_SELECT_FAILED").
+			With("context_type", ctxID.Type).
+			With("context_id", ctxID.ID).Wrap(err)
+	}
+	if err := json.Unmarshal(participantsJSON, &active.Participants); err != nil {
+		return row{}, false, oops.Code("DEK_PARTICIPANTS_UNMARSHAL_FAILED").Wrap(err)
 	}
 
 	// Check for existing duplicate.
 	for _, existing := range active.Participants {
 		if existing.PlayerID == p.PlayerID && existing.BindingID == p.BindingID {
-			return active, false, nil
+			return active, false, tx.Commit(ctx)
 		}
 	}
 
@@ -206,7 +248,7 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 		return row{}, false, oops.Code("DEK_PARTICIPANTS_MARSHAL_FAILED").Wrap(err)
 	}
 
-	tag, err := s.pool.Exec(ctx, `
+	_, err = tx.Exec(ctx, `
 		UPDATE crypto_keys
 		   SET participants = $3
 		 WHERE context_type = $1 AND context_id = $2
@@ -218,7 +260,12 @@ func (s *Store) updateParticipants(ctx context.Context, ctxID ContextID, p Parti
 			With("context_type", ctxID.Type).
 			With("context_id", ctxID.ID).Wrap(err)
 	}
-	_ = tag.RowsAffected() // pgx may report 0 for jsonb no-change rows; trust the UPDATE
+
+	if err := tx.Commit(ctx); err != nil {
+		return row{}, false, oops.Code("DEK_TX_COMMIT_FAILED").
+			With("context_type", ctxID.Type).
+			With("context_id", ctxID.ID).Wrap(err)
+	}
 
 	return active, true, nil
 }

--- a/internal/eventbus/crypto/dek/store_integration_test.go
+++ b/internal/eventbus/crypto/dek/store_integration_test.go
@@ -43,7 +43,7 @@ func TestSoftDeletedDEKAppearsAsNoRowsForProductionReads(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	// Mint a DEK via the public API.
@@ -100,7 +100,7 @@ func TestSelectAnyByIDReturnsDestroyedRows(t *testing.T) {
 	store := dek.NewStore(pool)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, store, cache, partCache)
+	mgr, err := dek.NewManager(provider, store, cache, partCache, nil, nil)
 	require.NoError(t, err)
 
 	// Insert via Manager so the row matches production shape.

--- a/internal/eventbus/crypto/dek/store_integration_test.go
+++ b/internal/eventbus/crypto/dek/store_integration_test.go
@@ -19,6 +19,19 @@ import (
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
+// testBindingStub implements dek.BindingResolver for tests.
+type testBindingStub struct {
+	bindingID string
+	err       error
+}
+
+func (s *testBindingStub) Current(_ context.Context, _ string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.bindingID, nil
+}
+
 // TestSoftDeletedDEKAppearsAsNoRowsForProductionReads asserts that
 // rows with destroyed_at IS NOT NULL are invisible to the production
 // read predicates: selectByID (exercised via Manager.Resolve, which
@@ -43,7 +56,9 @@ func TestSoftDeletedDEKAppearsAsNoRowsForProductionReads(t *testing.T) {
 	provider := newTestProvider(t)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&testBindingStub{bindingID: "bind-test"})
 	require.NoError(t, err)
 
 	// Mint a DEK via the public API.
@@ -100,7 +115,9 @@ func TestSelectAnyByIDReturnsDestroyedRows(t *testing.T) {
 	store := dek.NewStore(pool)
 	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
 	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-	mgr, err := dek.NewManager(provider, store, cache, partCache, nil, nil)
+	mgr, err := dek.NewManager(provider, store, cache, partCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&testBindingStub{bindingID: "bind-test"})
 	require.NoError(t, err)
 
 	// Insert via Manager so the row matches production shape.

--- a/internal/eventbus/crypto/dek/store_integrity_test.go
+++ b/internal/eventbus/crypto/dek/store_integrity_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package dek
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/holomush/holomush/internal/store"
+)
+
+// testPool creates a testcontainer-backed *pgxpool.Pool with migrations
+// applied. Teardown is registered on t.Cleanup.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:18-alpine",
+		postgres.WithDatabase("test"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		postgres.BasicWaitStrategies(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	migrator, err := store.NewMigrator(connStr)
+	require.NoError(t, err)
+	require.NoError(t, migrator.Up())
+	migrator.Close()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestStore_ResolveIntegrity_ResolvesCrashedRotate is INV-37.
+// Simulates a crashed Rotate by directly inserting two unrotated rows
+// (bypassing Manager.Rotate via package-internal access), then verifies
+// ResolveIntegrity resolves them.
+func TestStore_ResolveIntegrity_ResolvesCrashedRotate(t *testing.T) {
+	pool := testPool(t)
+	store := NewStore(pool)
+
+	ctxID := ContextID{Type: "scene", ID: "inv37-test"}
+
+	// Insert v1 — unexported insert + row accessible from package dek.
+	r1 := row{
+		ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 1,
+		WrappedDEK:   []byte("fake-dek-v1"),
+		WrapProvider: "test", WrapKeyID: "k1",
+		Participants: []Participant{
+			{PlayerID: "alice", CharacterID: "c-alice", BindingID: "bind-alice", JoinedAt: time.Now().UTC()},
+		},
+	}
+	_, err := store.insert(context.Background(), r1)
+	require.NoError(t, err)
+
+	// Simulate crashed Rotate: insert v2 without marking v1 rotated.
+	r2 := row{
+		ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 2,
+		WrappedDEK:   []byte("fake-dek-v2"),
+		WrapProvider: "test", WrapKeyID: "k1",
+		Participants: []Participant{
+			{PlayerID: "bob", CharacterID: "c-bob", BindingID: "bind-bob", JoinedAt: time.Now().UTC()},
+		},
+	}
+	_, err = store.insert(context.Background(), r2)
+	require.NoError(t, err)
+
+	// Both rows exist with rotated_at IS NULL. Verify pre-condition.
+	var count int
+	err = pool.QueryRow(context.Background(), `
+		SELECT COUNT(*) FROM crypto_keys
+		 WHERE context_type = $1 AND context_id = $2
+		   AND rotated_at IS NULL AND destroyed_at IS NULL`,
+		ctxID.Type, ctxID.ID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "pre-condition: two unrotated rows simulate crashed Rotate")
+
+	// Run the integrity check.
+	err = store.ResolveIntegrity(context.Background())
+	require.NoError(t, err)
+
+	// After resolution, only v2 should remain unrotated.
+	err = pool.QueryRow(context.Background(), `
+		SELECT COUNT(*) FROM crypto_keys
+		 WHERE context_type = $1 AND context_id = $2
+		   AND rotated_at IS NULL AND destroyed_at IS NULL`,
+		ctxID.Type, ctxID.ID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "post-resolution: exactly one unrotated row")
+
+	// v1 should be marked rotated.
+	var rotatedAt *time.Time
+	err = pool.QueryRow(context.Background(), `
+		SELECT rotated_at FROM crypto_keys
+		 WHERE context_type = $1 AND context_id = $2 AND version = 1`,
+		ctxID.Type, ctxID.ID).Scan(&rotatedAt)
+	require.NoError(t, err)
+	assert.NotNil(t, rotatedAt, "v1 should be marked rotated by integrity check")
+}

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -59,6 +59,16 @@ import (
 	"github.com/holomush/holomush/test/testutil"
 )
 
+// dekBindingStub implements dek.BindingResolver for single-process E2E tests
+// where no real wizard binding store exists.
+type dekBindingStub struct {
+	bindingID string
+}
+
+func (s *dekBindingStub) Current(_ context.Context, _ string) (string, error) {
+	return s.bindingID, nil
+}
+
 // e2eEnv groups the bus + crypto + audit + reader fixture used by the
 // happy-path BDD spec. Built per BeforeEach to keep PG/JS isolation.
 type e2eEnv struct {
@@ -103,7 +113,9 @@ func setupE2EEnv(ctx context.Context, t *testing.T) *e2eEnv {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&dekBindingStub{bindingID: "bind-e2e"})
 	require.NoError(t, err)
 
 	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -103,7 +103,7 @@ func setupE2EEnv(ctx context.Context, t *testing.T) *e2eEnv {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 	require.NoError(t, err)
 
 	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})

--- a/test/integration/crypto/emit_test.go
+++ b/test/integration/crypto/emit_test.go
@@ -81,7 +81,7 @@ func TestSensitiveEmitProducesCiphertextOnBusAndInAudit(t *testing.T) {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 	require.NoError(t, err)
 
 	// Stand up the audit projection so events_audit gets populated.

--- a/test/integration/crypto/emit_test.go
+++ b/test/integration/crypto/emit_test.go
@@ -81,7 +81,9 @@ func TestSensitiveEmitProducesCiphertextOnBusAndInAudit(t *testing.T) {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&dekBindingStub{bindingID: "bind-emit"})
 	require.NoError(t, err)
 
 	// Stand up the audit projection so events_audit gets populated.

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -75,7 +75,7 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 	require.NoError(t, err)
 
 	// Audit subsystem: needed so events_audit is populated (same pattern as

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -75,7 +75,9 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&dekBindingStub{bindingID: "bind-metadata"})
 	require.NoError(t, err)
 
 	// Audit subsystem: needed so events_audit is populated (same pattern as

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -170,7 +170,7 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
 	require.NoError(t, err)
 
 	// Host audit subsystem: populates events_audit. Handle stays local —

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -170,7 +170,9 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
 	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache, nil, nil)
+	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+		&dekBindingStub{bindingID: "bind-decrypt"})
 	require.NoError(t, err)
 
 	// Host audit subsystem: populates events_audit. Handle stays local —


### PR DESCRIPTION
## Summary

Implements Phase 4 of Event Payload Cryptography: Add and Rotate DEK lifecycle
operations. This wires the real implementations behind `Manager.Add` and
`Manager.Rotate` (previously stubs returning `DEK_ADD_NOT_IMPLEMENTED` /
`DEK_ROTATE_NOT_IMPLEMENTED`).

- **Add**: appends a participant to the active DEK's participant set,
  idempotent on `(player_id, binding_id)`, publishes `participants_changed`
  cache invalidation
- **Rotate**: mints a new DEK version with fresh key material, marks the
  old version rotated, publishes `rotate` cache invalidation; rolls back
  (evicts caches + marks new row destroyed) on invalidation failure
- **ResolveIntegrity**: startup integrity check that detects contexts with
  multiple unrotated rows (crashed Rotate) and marks earlier versions
  rotated, keeping the max-version row active
- **Store**: 4 new methods — `updateParticipants` (read-modify-write,
  idempotent), `markRotated`, `markDestroyed`, `selectByBindingID`
- **Manager**: grows `NewManager` from 4 to 6 params (`Invalidator`,
  `BindingResolver`); 18 call sites migrated

Closes #3533.

## Key design decisions

- `updateParticipants` uses read-modify-write in a transaction with
  `SELECT ... FOR UPDATE` to serialize concurrent Add calls on the same
  (context_type, context_id). Without the row lock, two concurrent Adds
  of distinct participants can silently lose data (TOCTOU race, #3533).
- `Add` seeds the participants cache after a successful append so subsequent
  `Participants()` calls see the update without a DB round-trip
- The `RowsAffected()` guard in `updateParticipants` is dropped — pgx
  under-reports for jsonb no-change updates

## Test plan

- [x] `task test:int` — 1164 tests, 0 failures
- [x] `task test:e2e` — 62/62 passing
- [x] `task lint` — 0 issues
- [x] `task pr-prep` — all green

## References

- Design spec: `docs/superpowers/specs/2026-05-06-phase4-add-rotate-design.md`
- Plan: `docs/superpowers/plans/2026-05-06-phase4-add-rotate.md`
- Master crypto spec: `docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md`
- Epic: `holomush-fi0n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 4 rollout plan and detailed design for Add+Rotate lifecycle ops, crash-recovery, invariants, and acceptance criteria.

* **New Features**
  * Idempotent participant additions to active encryption keys with participant-change notifications.
  * Safe rotation that promotes new key versions, publishes rotate notifications, and performs rollback on invalidation failures.
  * Startup integrity routine to resolve incomplete rotations.

* **Tests**
  * Expanded unit, integration, and end-to-end tests covering idempotency, invalidation, rollback, concurrency, and integrity recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->