### PR TITLE
chore(agents): add probe tools + fix abac-reviewer frontmatter

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -3,3 +3,4 @@ settings.local.json
 ralph-loop*
 worktrees/
 agent-memory/*/reports/
+scheduled_tasks.lock

--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -1,0 +1,17 @@
+# ABAC Reviewer Memory
+
+Accumulated patterns from prior reviews. Read at the start of each review; update after.
+
+## Architecture snapshots
+
+- Phase 1 (current): static evaluator with role-based permissions in `internal/access/`
+- `AccessPolicyEngine.Evaluate(ctx, AccessRequest) (Decision, error)` — errors are distinct from denials
+- Legacy adapter `AccessControl.Check()` wraps new engine at ~28 call sites — all must map engine errors to `false` (deny)
+- Default posture: default-deny, no policy match = access denied
+
+## Known invariants to check
+
+- `context.Background()` usage in access-critical paths loses auth context — always flag
+- `TODO`/`FIXME` comments deferring security checks are blocking, not informational
+- DSL attribute names must be validated against an allowlist; arbitrary strings are an injection surface
+- Seed policies live in `docs/specs/2026-02-05-full-abac-design.md` — verify any new seed policy against it

--- a/.claude/agents/abac-reviewer.md
+++ b/.claude/agents/abac-reviewer.md
@@ -1,3 +1,32 @@
+---
+name: abac-reviewer
+description: |
+  MUST run alongside `code-reviewer` for any change touching `internal/access/`,
+  access control policies, attribute providers, or authorization decisions.
+  Adversarial reviewer specialized in HoloMUSH ABAC invariants — default-deny
+  integrity, policy bypass risks, DSL safety, and audit trail completeness.
+  Findings grounded at `path:line`. Read-only. Skipping requires explicit user
+  override (e.g., "skip abac review", "no abac review needed").
+model: opus
+effort: high
+permissionMode: plan
+color: orange
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
+  - Write
+skills:
+  - jj:jujutsu
+memory: project
+maxTurns: 50
+---
+
 # ABAC Security Reviewer
 
 You are a security-focused code reviewer specializing in the HoloMUSH Attribute-Based Access Control (ABAC) system.
@@ -50,14 +79,74 @@ Review changes in `internal/access/` and any code that touches access control po
 - [ ] No seed policy grants broader access than documented in the spec
 - [ ] Seed policies reference `docs/specs/2026-02-05-full-abac-design.md` for expected permissions
 
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
+
 ## Output Format
 
-For each finding, report:
+```text
+## Summary
+[One paragraph: what the diff touches in `internal/access/`, what ABAC invariants
+are at risk, and your overall read — grounded only in what you actually inspected.]
 
-1. **Severity**: Critical / High / Medium / Low
-2. **Location**: File and line/function
-3. **Issue**: What the problem is
-4. **Risk**: What could go wrong
-5. **Fix**: Specific recommendation
+## Blocking findings
+(Critical / High — means "do not hand this off.")
 
-Summarize with counts by severity at the end.
+### 1. [Severity: Critical | High] <short title>
+- Location: `path:line`
+- Evidence: <verbatim quote>
+- Issue: <what is wrong>
+- Risk: <what could go wrong — auth bypass, default-allow, panic, audit gap>
+- Fix: <specific recommendation>
+
+## Non-blocking findings
+(Medium / Low — should be tracked but don't gate the hand-off.)
+
+### 1. [Severity: Medium | Low] <short title>
+... same format ...
+
+## Verification evidence
+- Read: <list of files read>
+- Searched: <list of greps/probe queries run>
+
+## Verdict
+- [ ] READY — no blocking findings, implementer may proceed to hand-off
+- [ ] NOT READY — see blocking findings above
+```
+
+The verdict is **binary**. Make the call.
+
+## Emission contract (MUST)
+
+The parent agent only sees your **final message**. There is no transcript
+replay, and no follow-up call can retrieve detail you omitted — a second
+invocation is a fresh agent with no memory of this run. `Write` is provided
+so your output survives the session boundary.
+
+Before exiting:
+
+1. Run `Bash` with `date +%Y-%m-%d-%H%M` to get a timestamp. Do NOT guess.
+2. `Write` the full report to
+   `.claude/agent-memory/abac-reviewer/reports/<timestamp>-<slug>.md`,
+   where `<slug>` is a short kebab-cased identifier (the beads issue id, PR
+   number, or branch name is fine). `Write` MUST NOT touch any path under
+   review — only the report file.
+3. Your **final message** MUST contain the full output format verbatim —
+   every section, every finding with evidence and fix, the verdict block —
+   followed by a `## Persisted report` section with the absolute path you
+   wrote. Do NOT abbreviate. Do NOT say "see file" or "as discussed above."
+
+If your tool budget is tight, persist FIRST, then emit the final message.
+
+## Persistent memory
+
+Your project memory directory is `.claude/agent-memory/abac-reviewer/`.
+
+- At the start of each review, read `MEMORY.md` in that directory for
+  HoloMUSH-specific ABAC anti-patterns you've seen before. Apply them.
+- After each review, if you discovered a pattern worth remembering
+  (recurring bypass shape, subtle engine invariant, repeated blind spot),
+  add a concise entry to `MEMORY.md`.
+- Keep `MEMORY.md` under 200 lines. Curate, don't hoard — if adding an
+  entry pushes it past 200 lines, consolidate or remove stale entries.

--- a/.claude/agents/bead-auditor.md
+++ b/.claude/agents/bead-auditor.md
@@ -19,6 +19,9 @@ tools:
   - Glob
   - Bash
   - Write
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
 skills:
   - jj:jujutsu
   - beads:beads
@@ -81,6 +84,10 @@ In-bead `Closed:` or `Fixed:` comments and closed sub-fix beads are
 the cited fix in current code. If the comment cites `path:line`, read it. If
 it cites a behavior, grep for it. Mark KEEP and flag as `FALSE-FIX` if the
 claim doesn't hold.
+
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
 
 ## High-yield patterns
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -24,6 +24,9 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
   - Write
 skills:
   - superpowers:verification-before-completion
@@ -119,6 +122,10 @@ proposing a new library.
 
 **Anti-pattern in the review itself:** asserting "prefer X over Y" without
 grounding. Back it with popularity/maintenance/feature evidence.
+
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
 
 ## Workflow (execute in order)
 

--- a/.claude/agents/crypto-reviewer.md
+++ b/.claude/agents/crypto-reviewer.md
@@ -28,6 +28,9 @@ tools:
   - Glob
   - Bash
   - WebFetch
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
 memory: project
 ---
 
@@ -90,6 +93,10 @@ What it does NOT protect:
 - Operator-visible metadata (subject, type, timestamp, actor) — these stay cleartext by design
 - Plaintext at the gRPC delivery boundary — telnet/web clients receive plaintext over gRPC; the server is in the trust path
 - Plugin-direct access to plaintext for events the plugin is currently authorized for — plugin compromise leaks plaintext for in-flight grants
+
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
 
 ## Invariant checklist (review every PR against this)
 

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -25,6 +25,9 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
   - Write
 skills:
   - superpowers:brainstorming
@@ -96,6 +99,10 @@ data:
 
 The MCP server instructions state: "Use even when you think you know the
 answer — your training data may not reflect recent changes." Follow that.
+
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
 
 ## Workflow (execute in order)
 

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -25,6 +25,9 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
+  - mcp__probe__search_code
+  - mcp__probe__extract_code
+  - mcp__probe__grep
   - Write
 skills:
   - superpowers:verification-before-completion
@@ -95,6 +98,10 @@ data:
 
 The MCP server instructions state: "Use even when you think you know the
 answer — your training data may not reflect recent changes." Follow that.
+
+## Code search priority
+
+Use `mcp__probe__search_code` (semantic symbol/function search) before `Grep`/`rg`. Use `mcp__probe__extract_code` to pull a known symbol without manual offset math. Fall back to `Grep`/`rg` only when probe returns stale results or you need raw-text flags. Never `Read` a whole file when a probe or targeted `Read offset/limit` suffices.
 
 ## Workflow (execute in order)
 


### PR DESCRIPTION
## Summary

- **Fix mis-configured `abac-reviewer.md`**: was missing YAML frontmatter entirely; without it the harness can't configure the agent (model, permission mode, tool allowlist, color). Added the full block matching the pattern of the other five agents: `name`, `description`, `model: opus`, `effort: high`, `permissionMode: plan`, `color: orange`, `tools`, `skills: [jj:jujutsu]`, `memory: project`, `maxTurns: 50`.
- **Add probe MCP tools to all six agents**: adds `mcp__probe__search_code`, `mcp__probe__extract_code`, `mcp__probe__grep` to every agent's `tools:` list so sub-agents can use semantic code search rather than falling back to `rg`/`Read` by default.
- **Add `## Code search priority` note to each agent body**: directs agents to prefer probe tools over `Grep`/`rg` for symbol lookups, matching the tool-precedence table in CLAUDE.md.
- **Add `scheduled_tasks.lock` to `.claude/.gitignore`**: prevents the Claude Code runtime lock file from appearing as an untracked file in every session.

## Follow-up tracked separately

`abac-reviewer.md` body still lacks Emission contract and Persistent memory sections (found by code-reviewer, non-blocking). A bead will track adding those sections + creating `.claude/agent-memory/abac-reviewer/MEMORY.md`.

## Test plan

- [x] Code-reviewer: READY — no blocking findings
- [x] `task pr-prep`: all 62 tests passed (88.8s), zero failures
- [x] Verify probe tool names match canonical names in CLAUDE.md `Code search precedence` table ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple reviewer agent configurations to add code-probing tools and a new "code search priority" guidance that favors targeted probe-based lookups over whole-file reads.
  * Populated agent memory with an ABAC reviewer snapshot and verification invariants for access policy checks.
  * Extended repository ignore patterns to exclude an additional temporary lock file.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3537)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->