### PR TITLE
fix(agents): remove duplicate probe tool entries

### DIFF
--- a/.claude/agents/bead-auditor.md
+++ b/.claude/agents/bead-auditor.md
@@ -22,9 +22,6 @@ tools:
   - mcp__probe__grep
   - Bash
   - Write
-  - mcp__probe__search_code
-  - mcp__probe__extract_code
-  - mcp__probe__grep
 skills:
   - jj:jujutsu
   - beads:beads

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -27,9 +27,6 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
-  - mcp__probe__search_code
-  - mcp__probe__extract_code
-  - mcp__probe__grep
   - Write
 skills:
   - superpowers:verification-before-completion

--- a/.claude/agents/crypto-reviewer.md
+++ b/.claude/agents/crypto-reviewer.md
@@ -31,9 +31,6 @@ tools:
   - mcp__probe__grep
   - Bash
   - WebFetch
-  - mcp__probe__search_code
-  - mcp__probe__extract_code
-  - mcp__probe__grep
 memory: project
 ---
 

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -28,9 +28,6 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
-  - mcp__probe__search_code
-  - mcp__probe__extract_code
-  - mcp__probe__grep
   - Write
 skills:
   - superpowers:brainstorming

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -28,9 +28,6 @@ tools:
   - mcp__deepwiki__read_wiki_contents
   - mcp__exa__web_search_exa
   - mcp__exa__get_code_context_exa
-  - mcp__probe__search_code
-  - mcp__probe__extract_code
-  - mcp__probe__grep
   - Write
 skills:
   - superpowers:verification-before-completion


### PR DESCRIPTION
## Summary

Squash-merge of #3537 introduced duplicate `mcp__probe__*` entries in five agent tool lists — each probe tool ended up listed twice: once in the early position (before `Bash`, grouped with `Read`/`Grep`/`Glob`) and once at the original insertion point later in the list.

This removes the late-position duplicates from `bead-auditor`, `code-reviewer`, `crypto-reviewer`, `design-reviewer`, and `plan-reviewer`. `abac-reviewer` was unaffected (created fresh in #3537 with a single occurrence).

**Diff:** `0 insertions(+), 15 deletions(-)` — 3 lines removed per file × 5 files.

## Test plan

- [x] Code-reviewer: READY — single occurrence of each probe tool per file verified
- [x] `abac-reviewer.md` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent configurations to optimize tool availability and reduce redundancy across review agents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->