### PR TITLE
fix(crypto): persist + rehydrate Justification on rekey checkpoint (holomush-jxo8.7.55)

### DIFF
--- a/internal/cluster/clustertest/harness.go
+++ b/internal/cluster/clustertest/harness.go
@@ -46,13 +46,28 @@ type HarnessMember struct {
 	MemberID   cluster.MemberID
 }
 
+// Option is a functional option for [New]. Use [WithPillRateLimit] etc. to
+// override harness defaults from inside a specific test.
+type Option func(*cluster.Config)
+
+// WithPillRateLimit overrides the harness's default PillRateLimit (1s).
+// Use this in rate-limit assertion tests where the intermediate work between
+// pill calls can exceed the default window on slow CI runners — bumping the
+// window beyond plausible inter-call latency eliminates the wall-clock race.
+//
+// Resolves holomush-ivnc (P1 flake).
+func WithPillRateLimit(d time.Duration) Option {
+	return func(cfg *cluster.Config) { cfg.PillRateLimit = d }
+}
+
 // New constructs a Harness with n Registry members on a shared NATS
-// connection. All members use cluster_id=clusterID.
+// connection. All members use cluster_id=clusterID. Optional [Option] values
+// override the harness defaults (e.g. [WithPillRateLimit]).
 //
 // Accepts TB so callers can pass either *testing.T (plain Go
 // tests) or ginkgo.GinkgoT() (Ginkgo specs); both satisfy the Helper /
 // Fatalf / Cleanup methods this harness uses.
-func New(t TB, clusterID string, n int) *Harness {
+func New(t TB, clusterID string, n int, opts ...Option) *Harness {
 	t.Helper()
 	emb := eventbustest.New(t)
 
@@ -67,6 +82,9 @@ func New(t TB, clusterID string, n int) *Harness {
 		ProbeTimeout:      50 * time.Millisecond,
 		PillRateLimit:     1 * time.Second,
 		SkewWarnThreshold: 30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	for i := 0; i < n; i++ {

--- a/internal/eventbus/crypto/dek/checkpoint.go
+++ b/internal/eventbus/crypto/dek/checkpoint.go
@@ -35,15 +35,20 @@ type CheckpointOpenRequest struct {
 	policyHash      []byte // exactly 32 bytes
 	PrimaryPlayerID string
 	OldDEKID        int64
+	Justification   string
 }
 
 // NewCheckpointOpenRequest constructs a CheckpointOpenRequest. Both
-// opArgsHash and policyHash must be exactly 32 bytes.
+// opArgsHash and policyHash must be exactly 32 bytes. Justification is the
+// operator-supplied free-text reason recorded on the checkpoint row at
+// Phase 1 (holomush-jxo8.7.55) so RunByRequestID can rehydrate it into the
+// Phase 7 audit payload on the explicit-resume path.
 func NewCheckpointOpenRequest(
 	contextType, contextID string,
 	opArgsHash, policyHash []byte,
 	primaryPlayerID string,
 	oldDEKID int64,
+	justification string,
 ) (CheckpointOpenRequest, error) {
 	if len(opArgsHash) != 32 {
 		return CheckpointOpenRequest{}, oops.Code("DEK_REKEY_BAD_OP_ARGS_HASH").
@@ -60,6 +65,7 @@ func NewCheckpointOpenRequest(
 		policyHash:      policyHash,
 		PrimaryPlayerID: primaryPlayerID,
 		OldDEKID:        oldDEKID,
+		Justification:   justification,
 	}, nil
 }
 
@@ -73,6 +79,7 @@ type Checkpoint struct {
 	opArgsHash           []byte
 	policyHash           []byte
 	PrimaryPlayerID      string
+	Justification        string
 	Status               CheckpointStatus
 	lastProcessedEventID []byte
 	NewDEKID             *int64
@@ -188,10 +195,10 @@ func (r *CheckpointRepo) Open(ctx context.Context, req CheckpointOpenRequest) (R
 	_, err := r.pool.Exec(ctx, `
         INSERT INTO crypto_rekey_checkpoints
           (request_id, context_type, context_id, op_args_hash, policy_hash,
-           primary_player_id, status, old_dek_id)
-        VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7)
+           primary_player_id, status, old_dek_id, justification)
+        VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8)
     `, rid[:], req.ContextType, req.ContextID, req.opArgsHash, req.policyHash,
-		req.PrimaryPlayerID, req.OldDEKID)
+		req.PrimaryPlayerID, req.OldDEKID, req.Justification)
 	if err != nil {
 		if isUniqueViolation(err, "crypto_rekey_checkpoints_one_active_per_context") {
 			return RequestID{}, oops.Code("DEK_REKEY_ALREADY_IN_PROGRESS").
@@ -209,7 +216,7 @@ func (r *CheckpointRepo) Open(ctx context.Context, req CheckpointOpenRequest) (R
 func (r *CheckpointRepo) Get(ctx context.Context, rid RequestID) (Checkpoint, error) {
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
-               primary_player_id, status, last_processed_event_id, new_dek_id,
+               primary_player_id, justification, status, last_processed_event_id, new_dek_id,
                old_dek_id, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
@@ -272,7 +279,7 @@ func (r *CheckpointRepo) Heartbeat(ctx context.Context, rid RequestID) error {
 func (r *CheckpointRepo) FindByContextAndArgs(ctx context.Context, ctxType, ctxID string, opArgsHash []byte) (Checkpoint, bool, error) {
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
-               primary_player_id, status, last_processed_event_id, new_dek_id,
+               primary_player_id, justification, status, last_processed_event_id, new_dek_id,
                old_dek_id, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
@@ -297,7 +304,7 @@ func (r *CheckpointRepo) FindByContextAndArgs(ctx context.Context, ctxType, ctxI
 func (r *CheckpointRepo) FindNonTerminalByContext(ctx context.Context, ctxType, ctxID string) (Checkpoint, bool, error) {
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
-               primary_player_id, status, last_processed_event_id, new_dek_id,
+               primary_player_id, justification, status, last_processed_event_id, new_dek_id,
                old_dek_id, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
@@ -322,7 +329,7 @@ func (r *CheckpointRepo) FindNonTerminalByContext(ctx context.Context, ctxType, 
 func (r *CheckpointRepo) ListExpired(ctx context.Context, ttl time.Duration) ([]Checkpoint, error) {
 	rows, err := r.pool.Query(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
-               primary_player_id, status, last_processed_event_id, new_dek_id,
+               primary_player_id, justification, status, last_processed_event_id, new_dek_id,
                old_dek_id, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
@@ -545,7 +552,7 @@ func (r *CheckpointRepo) ListFiltered(ctx context.Context, f CheckpointListFilte
 	args = append(args, limit)
 	q := fmt.Sprintf(`
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
-               primary_player_id, status, last_processed_event_id, new_dek_id,
+               primary_player_id, justification, status, last_processed_event_id, new_dek_id,
                old_dek_id, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
@@ -581,7 +588,7 @@ func scanCheckpoint(s checkpointScanner) (Checkpoint, error) {
 	var rid []byte
 	err := s.Scan(
 		&rid, &c.ContextType, &c.ContextID, &c.opArgsHash, &c.policyHash,
-		&c.PrimaryPlayerID, &c.Status, &c.lastProcessedEventID, &c.NewDEKID,
+		&c.PrimaryPlayerID, &c.Justification, &c.Status, &c.lastProcessedEventID, &c.NewDEKID,
 		&c.OldDEKID, &c.Phase5AttemptCount, &c.phase5MissingMembers,
 		&c.ForceDestroy, &c.StartedAt, &c.LastHeartbeatAt, &c.CompletedAt,
 		&c.AbortedAt, &c.AbortedReason,

--- a/internal/eventbus/crypto/dek/checkpoint_integration_test.go
+++ b/internal/eventbus/crypto/dek/checkpoint_integration_test.go
@@ -35,6 +35,7 @@ func mustOpenCheckpoint(t *testing.T, repo *dek.CheckpointRepo, ctxID string, ol
 		"scene", ctxID,
 		make([]byte, 32), make([]byte, 32),
 		"01PLAYER", oldDEK,
+		"",
 	)
 	require.NoError(t, err)
 	rid, err := repo.Open(context.Background(), req)
@@ -51,6 +52,7 @@ func TestCheckpointRepo_Open_ReturnsRequestID(t *testing.T) {
 		"scene", "01ABC",
 		make([]byte, 32), make([]byte, 32),
 		"01PLAYER", 100,
+		"",
 	)
 	require.NoError(t, err)
 	rid, err := repo.Open(context.Background(), req)
@@ -67,6 +69,7 @@ func TestCheckpointRepo_Open_ConcurrentSameContext_Rejected(t *testing.T) {
 		"scene", "01ABC",
 		make([]byte, 32), make([]byte, 32),
 		"01P1", 100,
+		"",
 	)
 	require.NoError(t, err)
 	_, err = repo.Open(context.Background(), req1)
@@ -76,6 +79,7 @@ func TestCheckpointRepo_Open_ConcurrentSameContext_Rejected(t *testing.T) {
 		"scene", "01ABC",
 		make([]byte, 32), make([]byte, 32),
 		"01P2", 100,
+		"",
 	)
 	require.NoError(t, err)
 	_, err = repo.Open(context.Background(), req2)
@@ -131,6 +135,7 @@ func TestCheckpointRepo_FindByContextAndArgs_Resume(t *testing.T) {
 		"scene", "01ABC",
 		opArgs, policy,
 		"01PLAYER", 100,
+		"",
 	)
 	require.NoError(t, err)
 	rid, err := repo.Open(context.Background(), req)

--- a/internal/eventbus/crypto/dek/rekey_orchestrator.go
+++ b/internal/eventbus/crypto/dek/rekey_orchestrator.go
@@ -185,6 +185,7 @@ func (o *Orchestrator) RunPhase1Fresh(ctx context.Context, req RekeyRequest) (Re
 		policyHash,
 		req.Operator.PlayerID,
 		activeRow.ID,
+		req.Justification,
 	)
 	if err != nil {
 		return RequestID{}, oops.Code("DEK_REKEY_CHECKPOINT_OPEN_ARGS_INVALID").Wrap(err)

--- a/internal/eventbus/crypto/dek/rekey_orchestrator_test.go
+++ b/internal/eventbus/crypto/dek/rekey_orchestrator_test.go
@@ -326,6 +326,7 @@ func TestOrchestrator_Phase2_RequiresPreconditionPhase1Auth(t *testing.T) {
 		"scene", "01DEF",
 		make([]byte, 32), make([]byte, 32),
 		"01PLAYER", 200,
+		"",
 	)
 	require.NoError(t, err)
 	rid, err := repo.Open(context.Background(), openReq)

--- a/internal/eventbus/crypto/dek/rekey_phase5_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase5_integration_test.go
@@ -389,6 +389,7 @@ func TestOrchestrator_Phase5_RejectsWrongStatus(t *testing.T) {
 		"scene", "01WRONG",
 		make([]byte, 32), make([]byte, 32),
 		"01PLAYER", setup.oldDEKID,
+		"",
 	)
 	require.NoError(t, err)
 	rid, err := setup.Repo.Open(context.Background(), req)

--- a/internal/eventbus/crypto/dek/rekey_run.go
+++ b/internal/eventbus/crypto/dek/rekey_run.go
@@ -333,11 +333,10 @@ func (o *Orchestrator) runPhase7AndSetResumed(ctx context.Context, rid RequestID
 //  3. Enforces the operator-binding invariant (INV-E16): if the checkpoint's
 //     primary_player_id does not match req.Operator.PlayerID, returns
 //     DEK_REKEY_RESUME_OPERATOR_MISMATCH.
-//  4. Calls driveToCompletion with the checkpoint's ContextType and ContextID
-//     inserted into the request (needed by RunPhase7's audit payload).
-//     Justification is NOT stored in the checkpoint row; it is intentionally
-//     omitted from the resume-path audit record (the original justification
-//     was recorded in Phase 1).
+//  4. Calls driveToCompletion with the checkpoint's ContextType, ContextID,
+//     and Justification rehydrated from the stored checkpoint row (so that
+//     RunPhase7's audit payload carries the operator's original justification
+//     on the explicit-resume path).
 //
 // req.ForceDestroy is honored on the resume path per INV-E11.
 func (o *Orchestrator) RunByRequestID(ctx context.Context, rid RequestID, req RekeyRequest) (RekeyOutcome, error) {
@@ -371,15 +370,14 @@ func (o *Orchestrator) RunByRequestID(ctx context.Context, rid RequestID, req Re
 	}
 
 	// Populate context fields from the stored checkpoint row so RunPhase7's
-	// audit payload carries accurate context metadata. Justification is NOT
-	// stored in the checkpoint; it is omitted on the explicit-resume path.
+	// audit payload carries accurate context metadata, including the original
+	// justification rehydrated from the checkpoint row (holomush-jxo8.7.55).
 	resumeReq := RekeyRequest{
-		ContextType:  ckpt.ContextType,
-		ContextID:    ckpt.ContextID,
-		Operator:     req.Operator,
-		ForceDestroy: req.ForceDestroy,
-		// Justification intentionally zero: not stored in checkpoint.
-		// The original justification was captured at Phase 1.
+		ContextType:   ckpt.ContextType,
+		ContextID:     ckpt.ContextID,
+		Operator:      req.Operator,
+		ForceDestroy:  req.ForceDestroy,
+		Justification: ckpt.Justification,
 	}
 
 	return o.driveToCompletion(ctx, rid, resumeReq, true)

--- a/internal/eventbus/crypto/dek/rekey_run_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_run_integration_test.go
@@ -346,6 +346,58 @@ var _ = Describe("Orchestrator_Run_ResumeFromPhase7Audit_ManualRecovery (INV-E4,
 	})
 })
 
+var _ = Describe("Orchestrator_RunByRequestID_PreservesJustificationInAudit (holomush-jxo8.7.55)", func() {
+	It("rehydrates the original justification into the Phase 7 audit payload on the explicit-resume path", func() {
+		setup := newRunTestSetup("01RUN11")
+		const originalJustification = "X"
+
+		// Fresh run with justification 'X': drives Phase 1 only so the
+		// checkpoint stays non-terminal (status=phase1_auth).
+		req := dek.RekeyRequest{
+			ContextType:   setup.contextType,
+			ContextID:     setup.contextID,
+			Justification: originalJustification,
+			Operator:      dek.OperatorIdentity{PlayerID: "01PRIM"},
+		}
+		rid, err := setup.Orch.RunPhase1Fresh(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Resume via RunByRequestID — operator supplies a DIFFERENT
+		// justification on the resume request. This pins the
+		// rehydration-wins semantic (INV-E25 analog): the checkpoint row's
+		// Justification is authoritative, the resume-call value MUST be
+		// ignored. Without this sentinel, a regression that accidentally
+		// honored req.Justification would only be caught if the resume
+		// value happened to differ from the stored one. (crypto-reviewer
+		// finding #1 on PR #3673)
+		const overrideAttempt = "ATTEMPT-TO-OVERRIDE-MUST-BE-IGNORED"
+		resumeReq := dek.RekeyRequest{
+			Operator:      dek.OperatorIdentity{PlayerID: "01PRIM"},
+			Justification: overrideAttempt,
+		}
+		out, err := setup.Orch.RunByRequestID(context.Background(), rid, resumeReq)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.RequestID).To(Equal(rid))
+
+		// Phase 7 must have emitted exactly one audit event.
+		Expect(setup.Audit.emitted).To(HaveLen(1),
+			"Phase 7 must emit exactly one audit event on the RunByRequestID path")
+
+		// The emitted payload MUST carry the original justification (X)
+		// and MUST NOT carry the resume-call override attempt.
+		emittedPayload := setup.Audit.emitted[0]
+		Expect(emittedPayload.Justification).To(Equal(originalJustification),
+			"RunByRequestID must rehydrate justification from checkpoint row into Phase 7 audit payload")
+		Expect(emittedPayload.Justification).NotTo(Equal(overrideAttempt),
+			"resume-call Justification MUST NOT win over the stored checkpoint value (INV-E25 analog)")
+
+		// Sanity: checkpoint reached complete.
+		ckpt, err := setup.Repo.Get(context.Background(), rid)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusComplete))
+	})
+})
+
 // opArgsHashForReq computes the op_args_hash for a request — mirrors the
 // dek.ComputeRekeyArgsHash production path so seeded checkpoint rows match
 // what FindByContextAndArgs looks up.

--- a/internal/eventbus/crypto/invalidation/coordinator_send_test.go
+++ b/internal/eventbus/crypto/invalidation/coordinator_send_test.go
@@ -59,8 +59,13 @@ func TestCoordinatorRequestInvalidationReturnsRateLimitedWhenProbeAndPillRefuses
 	// member 0 issues one pill against member 1. Coordinator's second
 	// call within the rate-limit window returns ErrRateLimited via
 	// the surfaced ErrPillRateLimited.
-
-	h := clustertest.New(t, "test-game", 2)
+	//
+	// PillRateLimit bumped to 10s (default 1s) to eliminate the wall-clock
+	// race on slow CI: the intermediate AwaitMemberPresent at line ~103
+	// can take up to 1s on a slow runner, pushing the second call out of
+	// the default 1s window and breaking the rate-limit assertion. The
+	// race is documented in holomush-ivnc.
+	h := clustertest.New(t, "test-game", 2, clustertest.WithPillRateLimit(10*time.Second))
 	h.AwaitConverged(t, 2*time.Second)
 
 	// Stop member 1 to make it unresponsive.

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -148,7 +148,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(32), version)
+	assert.Equal(t, uint(33), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -173,7 +173,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(32), version)
+	assert.Equal(t, uint(33), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,23 +278,24 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-20, 30, 31, and 32 should be pending (baseline + is_guest +
+	// At version 0, migrations 1-20, 30, 31, 32, and 33 should be pending (baseline + is_guest +
 	// alias_source + session_player_id + audit_source_component + session_focus +
 	// seed_scene_defaults + session_player_fk + create_events_audit +
 	// drop_events_and_cursors + events_audit_js_seq_index + events_audit_rendering +
 	// create_crypto_keys + events_audit_dek_columns + create_player_character_bindings +
 	// crypto_keys_destroyed_at + events_audit_envelope_rename + create_plugins +
 	// create_player_totp + create_admin_approvals + replace_bootstrap_metadata +
-	// create_crypto_rekey_checkpoints + create_setting_bootstrap_state)
+	// create_crypto_rekey_checkpoints + create_setting_bootstrap_state +
+	// add_justification_to_checkpoints)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 32 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 32}}
+	// At version 33 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 33}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000033_add_justification_to_checkpoints.down.sql
+++ b/internal/store/migrations/000033_add_justification_to_checkpoints.down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+-- Reverse: remove justification column from crypto_rekey_checkpoints.
+
+ALTER TABLE crypto_rekey_checkpoints
+    DROP COLUMN IF EXISTS justification;

--- a/internal/store/migrations/000033_add_justification_to_checkpoints.up.sql
+++ b/internal/store/migrations/000033_add_justification_to_checkpoints.up.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+-- Add justification column to crypto_rekey_checkpoints so that the
+-- RunByRequestID explicit-resume path can rehydrate the operator's
+-- original justification into the Phase 7 audit payload (holomush-jxo8.7.55).
+
+ALTER TABLE crypto_rekey_checkpoints
+    ADD COLUMN IF NOT EXISTS justification text NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

Closes audit-completeness gap on the explicit-resume path of Rekey: \`RunByRequestID\` was dropping the operator's original \`Justification\`, so Phase 7 audit payloads on the RekeyResume RPC path carried a blank justification field. Now persisted on \`crypto_rekey_checkpoints\` at Phase 1, rehydrated on resume.

Auto-resume (the \`Rekey\` RPC's same-args path) already worked correctly because \`ComputeRekeyArgsHash\` includes justification.

Resolves bead \`holomush-jxo8.7.55\` (P2 bug, originally filed during PR #3670 review).

## Implementation

| File | Change |
|---|---|
| \`internal/store/migrations/000033_add_justification_to_checkpoints.{up,down}.sql\` | New migration. \`ADD COLUMN IF NOT EXISTS justification text NOT NULL DEFAULT ''\` |
| \`internal/eventbus/crypto/dek/checkpoint.go\` | \`Justification string\` on \`CheckpointOpenRequest\` + \`Checkpoint\`. Constructor takes it as final param (preserves "all fields mandatory" contract). Threaded through INSERT + 5 SELECT sites + \`scanCheckpoint\` |
| \`internal/eventbus/crypto/dek/rekey_orchestrator.go\` | Phase 1 passes \`req.Justification\` to constructor |
| \`internal/eventbus/crypto/dek/rekey_run.go\` | \`RunByRequestID\` rehydrates \`Justification: ckpt.Justification\`; doc comment updated |
| \`internal/eventbus/crypto/dek/rekey_run_integration_test.go\` | New Ginkgo spec asserts rehydration wins over a sentinel \`ATTEMPT-TO-OVERRIDE\` resume value (INV-E25 analog) |
| \`internal/store/migrate{_test,_integration_test}.go\` | Version assertions bumped to 33 |

## Verification

- \`task pr-prep\` green: 7521 unit + 1637 integration tests pass
- Adversarial \`crypto-reviewer\` agent: **READY** (3 NIT findings, #1 + #3 addressed)
- Adversarial \`code-reviewer\` agent: **READY** (3 Low findings, #1 addressed inline as constructor refactor; #2 noted as cosmetic; #3 N/A)

## Follow-up

- \`holomush-g9vf\` (P3) — add \`MaxJustificationLength\` cap (suggest 4000, matching \`MaxDescriptionLength\`) validated in \`buildRekeyRequest\`. Defense-in-depth against operator-supplied free-text bloat in audit rows; pre-existing exposure made newly load-bearing by this PR's persistence on the checkpoint row.

## Test plan

- [ ] CI green (lint + unit + integration + E2E)
- [ ] Verify \`task test:int -- ./internal/eventbus/crypto/dek/\` covers the new \`PreservesJustificationInAudit\` spec

Refs: \`holomush-jxo8.7.55\` (P2 bug); follow-up \`holomush-g9vf\` (P3 length cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a DB migration to store a non-empty justification field on rekey checkpoints.
  * Made the test cluster harness configurable to reduce timing flakiness in tests.

* **Refactor**
  * Checkpoint open requests and resume logic now capture and preserve justification through the operation lifecycle and audit payloads.

* **Tests**
  * Updated and added integration tests validating justification persistence and explicit-resume behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3673)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->