### PR TITLE
fix(crypto): P3 audit-correctness cluster — .50 + .54 + .53 (sub-epic E wrap)

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -1261,18 +1261,11 @@ func (a *rekeyAuditPublisherAdapter) PublishAudit(
 		return ulid.ULID{}, oops.Code("DEK_REKEY_AUDIT_INVALID_TYPE").
 			With("type", evType).Wrap(err)
 	}
-	id := core.NewULID()
-	ev := eventbus.Event{
-		ID:        id,
-		Subject:   subj,
-		Type:      etyp,
-		Timestamp: a.clock.Now(),
-		Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-		Payload:   payload,
-	}
+	ev := eventbus.NewEvent(subj, etyp, eventbus.Actor{Kind: eventbus.ActorKindSystem}, payload)
+	ev.Timestamp = a.clock.Now() // honour the injected clock rather than time.Now() inside NewEvent
 	if pubErr := a.publisher.Publish(ctx, ev); pubErr != nil {
 		return ulid.ULID{}, oops.Code("DEK_REKEY_AUDIT_PUBLISH_FAILED").
 			With("subject", subject).Wrap(pubErr)
 	}
-	return id, nil
+	return ev.ID, nil
 }

--- a/internal/admin/policy/emitter.go
+++ b/internal/admin/policy/emitter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/oops"
 
-	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit/chain"
 )
@@ -136,14 +135,8 @@ func EmitCurrentSnapshot(ctx context.Context, deps EmitDeps, policyName string) 
 		return oops.Code("POLICY_EMIT_INVALID_TYPE").Wrap(err)
 	}
 
-	ev := eventbus.Event{
-		ID:        core.NewULID(),
-		Subject:   subj,
-		Type:      evtType,
-		Timestamp: deps.Clock.Now(),
-		Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-		Payload:   body,
-	}
+	ev := eventbus.NewEvent(subj, evtType, eventbus.Actor{Kind: eventbus.ActorKindSystem}, body)
+	ev.Timestamp = deps.Clock.Now() // honour the injected clock rather than time.Now() inside NewEvent
 	if err := deps.Publisher.Publish(ctx, ev); err != nil {
 		return oops.Code("POLICY_EMIT_PUBLISH_FAILED").
 			With("policy_name", policyName).Wrap(err)

--- a/internal/admin/totp_audit/auditing.go
+++ b/internal/admin/totp_audit/auditing.go
@@ -15,7 +15,6 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 
-	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/totp"
 )
@@ -83,14 +82,8 @@ func (a *AuditingService) emit(ctx context.Context, subjectStr, eventTypeStr str
 			"event_type", eventTypeStr, "error", err)
 		return
 	}
-	ev := eventbus.Event{
-		ID:        core.NewULID(),
-		Subject:   subj,
-		Type:      evtType,
-		Timestamp: a.clock.Now(),
-		Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-		Payload:   body,
-	}
+	ev := eventbus.NewEvent(subj, evtType, eventbus.Actor{Kind: eventbus.ActorKindSystem}, body)
+	ev.Timestamp = a.clock.Now() // honour the injected clock rather than time.Now() inside NewEvent
 	if err := a.pub.Publish(ctx, ev); err != nil {
 		a.logger.Warn("totp_audit: Publish failed; audit event lost (informational, INV-D14)",
 			"event_type", eventTypeStr, "subject", subjectStr, "publish_error", err)

--- a/internal/eventbus/crypto/dek/checkpoint.go
+++ b/internal/eventbus/crypto/dek/checkpoint.go
@@ -73,25 +73,26 @@ func NewCheckpointOpenRequest(
 // Byte-slice fields are intentionally unexported (INV-27): they are
 // populated by scanCheckpoint and read only within this package.
 type Checkpoint struct {
-	RequestID            RequestID
-	ContextType          string
-	ContextID            string
-	opArgsHash           []byte
-	policyHash           []byte
-	PrimaryPlayerID      string
-	Justification        string
-	Status               CheckpointStatus
-	lastProcessedEventID []byte
-	NewDEKID             *int64
-	OldDEKID             int64
-	Phase5AttemptCount   int
-	phase5MissingMembers []byte
-	ForceDestroy         bool
-	StartedAt            time.Time
-	LastHeartbeatAt      time.Time
-	CompletedAt          *time.Time
-	AbortedAt            *time.Time
-	AbortedReason        *string
+	RequestID              RequestID
+	ContextType            string
+	ContextID              string
+	opArgsHash             []byte
+	policyHash             []byte
+	PrimaryPlayerID        string
+	Justification          string
+	Status                 CheckpointStatus
+	lastProcessedEventID   []byte
+	NewDEKID               *int64
+	OldDEKID               int64
+	Phase3RowsRewritten    int
+	Phase5AttemptCount     int
+	phase5MissingMembers   []byte
+	ForceDestroy           bool
+	StartedAt              time.Time
+	LastHeartbeatAt        time.Time
+	CompletedAt            *time.Time
+	AbortedAt              *time.Time
+	AbortedReason          *string
 }
 
 // PolicyHash returns the policy_hash captured at Phase 1 (INV-E25) as a
@@ -217,7 +218,7 @@ func (r *CheckpointRepo) Get(ctx context.Context, rid RequestID) (Checkpoint, er
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
                primary_player_id, justification, status, last_processed_event_id, new_dek_id,
-               old_dek_id, phase5_attempt_count, phase5_missing_members,
+               old_dek_id, phase3_rows_rewritten, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
           FROM crypto_rekey_checkpoints
@@ -280,7 +281,7 @@ func (r *CheckpointRepo) FindByContextAndArgs(ctx context.Context, ctxType, ctxI
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
                primary_player_id, justification, status, last_processed_event_id, new_dek_id,
-               old_dek_id, phase5_attempt_count, phase5_missing_members,
+               old_dek_id, phase3_rows_rewritten, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
           FROM crypto_rekey_checkpoints
@@ -305,7 +306,7 @@ func (r *CheckpointRepo) FindNonTerminalByContext(ctx context.Context, ctxType, 
 	row := r.pool.QueryRow(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
                primary_player_id, justification, status, last_processed_event_id, new_dek_id,
-               old_dek_id, phase5_attempt_count, phase5_missing_members,
+               old_dek_id, phase3_rows_rewritten, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
           FROM crypto_rekey_checkpoints
@@ -330,7 +331,7 @@ func (r *CheckpointRepo) ListExpired(ctx context.Context, ttl time.Duration) ([]
 	rows, err := r.pool.Query(ctx, `
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
                primary_player_id, justification, status, last_processed_event_id, new_dek_id,
-               old_dek_id, phase5_attempt_count, phase5_missing_members,
+               old_dek_id, phase3_rows_rewritten, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
           FROM crypto_rekey_checkpoints
@@ -427,6 +428,39 @@ func (r *CheckpointRepo) UpdateStatusForceDestroy(ctx context.Context, rid Reque
 		return oops.Code("DEK_REKEY_STALE_TRANSITION").
 			With("request_id", rid.String()).
 			Errorf("force_destroy predicate failed")
+	}
+	return nil
+}
+
+// IncrementPhase3Count atomically increments the cumulative Phase 3
+// row-rewrite count on the checkpoint row by delta. Called by
+// processPhase3Batch INSIDE the batch transaction so the count, the row
+// rewrites, and the cursor advance all commit atomically (INV-E7).
+// Crash-resume correctness: any successfully-committed batch is reflected
+// in the count; a crashed-mid-batch run leaves the count consistent with
+// the cursor (both unchanged from before the batch began).
+// The CAS predicate requires status='phase3_reencrypt_cold'.
+//
+// holomush-jxo8.7.54 — crypto-reviewer crash-resume correctness fix.
+func (r *CheckpointRepo) IncrementPhase3Count(ctx context.Context, tx pgx.Tx, rid RequestID, delta int) error {
+	tag, err := tx.Exec(ctx, `
+        UPDATE crypto_rekey_checkpoints
+           SET phase3_rows_rewritten = phase3_rows_rewritten + $2,
+               last_heartbeat_at = now()
+         WHERE request_id = $1 AND status = 'phase3_reencrypt_cold'
+    `, rid[:], delta)
+	if err != nil {
+		return oops.Code("DEK_REKEY_PHASE3_COUNT_INCREMENT_FAILED").Wrap(err)
+	}
+	if tag.RowsAffected() != 1 {
+		// Same code as AdvanceCursor / UpdateStatus / MarkAborted / etc. —
+		// the CAS predicate (status='phase3_reencrypt_cold') is the canonical
+		// stale-transition guard and operator-facing dashboards already
+		// classify this code class. Don't proliferate per-method codes.
+		return oops.Code("DEK_REKEY_STALE_TRANSITION").
+			With("request_id", rid.String()).
+			With("operation", "IncrementPhase3Count").
+			Errorf("expected 1 row affected, got %d (status drift from phase3_reencrypt_cold)", tag.RowsAffected())
 	}
 	return nil
 }
@@ -553,7 +587,7 @@ func (r *CheckpointRepo) ListFiltered(ctx context.Context, f CheckpointListFilte
 	q := fmt.Sprintf(`
         SELECT request_id, context_type, context_id, op_args_hash, policy_hash,
                primary_player_id, justification, status, last_processed_event_id, new_dek_id,
-               old_dek_id, phase5_attempt_count, phase5_missing_members,
+               old_dek_id, phase3_rows_rewritten, phase5_attempt_count, phase5_missing_members,
                force_destroy, started_at, last_heartbeat_at, completed_at,
                aborted_at, aborted_reason
           FROM crypto_rekey_checkpoints
@@ -589,7 +623,7 @@ func scanCheckpoint(s checkpointScanner) (Checkpoint, error) {
 	err := s.Scan(
 		&rid, &c.ContextType, &c.ContextID, &c.opArgsHash, &c.policyHash,
 		&c.PrimaryPlayerID, &c.Justification, &c.Status, &c.lastProcessedEventID, &c.NewDEKID,
-		&c.OldDEKID, &c.Phase5AttemptCount, &c.phase5MissingMembers,
+		&c.OldDEKID, &c.Phase3RowsRewritten, &c.Phase5AttemptCount, &c.phase5MissingMembers,
 		&c.ForceDestroy, &c.StartedAt, &c.LastHeartbeatAt, &c.CompletedAt,
 		&c.AbortedAt, &c.AbortedReason,
 	)

--- a/internal/eventbus/crypto/dek/rekey_phase3.go
+++ b/internal/eventbus/crypto/dek/rekey_phase3.go
@@ -5,7 +5,6 @@ package dek
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -190,11 +189,18 @@ func (o *Orchestrator) RunPhase3(ctx context.Context, rid RequestID) (int, error
 		}
 	}
 
-	// All rows rewritten — leave status at phase3_reencrypt_cold. Phase 5
-	// (.22) advances to phase5_invalidate. Don't transition here; the
-	// FSM only allows phase3_reencrypt_cold → phase5_invalidate, not a
-	// "phase3_complete" intermediate, and adding such a state crosses the
-	// out-of-scope line for this bead.
+	// The Phase 3 row count is now incremented atomically inside each
+	// batch transaction via IncrementPhase3Count (see processPhase3Batch).
+	// No post-loop persist call is needed: by the time we reach here, the
+	// checkpoint row's phase3_rows_rewritten column already reflects every
+	// committed batch's contribution. Crash-resume correctness is durable
+	// (holomush-jxo8.7.54 — crypto-reviewer correctness fix).
+
+	// Leave status at phase3_reencrypt_cold. Phase 5 (.22) advances to
+	// phase5_invalidate. Don't transition here; the FSM only allows
+	// phase3_reencrypt_cold → phase5_invalidate, not a "phase3_complete"
+	// intermediate, and adding such a state crosses the out-of-scope line
+	// for this bead.
 	return totalRewritten, nil
 }
 
@@ -373,6 +379,15 @@ func (o *Orchestrator) processPhase3Batch(
 		lastID = r.eventID
 	}
 
+	// Increment the per-batch row count INSIDE the transaction so the
+	// count, the row rewrites, and the cursor advance all commit
+	// atomically. A crash mid-batch rolls back all three; a crash AFTER
+	// commit leaves them consistent. This is load-bearing for audit-payload
+	// truth across crash-resume cycles (holomush-jxo8.7.54).
+	if countErr := o.repo.IncrementPhase3Count(ctx, tx, rid, len(batch)); countErr != nil {
+		return 0, nil, countErr
+	}
+
 	// Advance the cursor as the FINAL action inside the transaction so a
 	// rollback reverts both the row UPDATEs and the cursor advance
 	// atomically (INV-E7-COLD-RESUME-CURSOR). The CAS predicate inside
@@ -402,7 +417,3 @@ func hexEncodeBytes(b []byte) string {
 	return string(out)
 }
 
-// guard against "errors" being unused if the file is refactored to no
-// longer reference errors.Is; kept here so callers in the package can
-// extend with errors.Is matches without re-importing.
-var _ = errors.Is

--- a/internal/eventbus/crypto/dek/rekey_phase3_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase3_integration_test.go
@@ -366,6 +366,17 @@ var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", fun
 		Expect(ckptFinal.NewDEKID).NotTo(BeNil())
 		setup.AssertAllRowsReferenceDEK(*ckptFinal.NewDEKID)
 
+		// holomush-jxo8.7.54 — Phase 3 row count must be CUMULATIVE across
+		// the crash + resume cycle. IncrementPhase3Count runs inside each
+		// batch's transaction, so committed batches contribute to the
+		// count and rolled-back batches don't. The final count MUST equal
+		// the total row count, NOT just the resume invocation's count.
+		// Without the in-tx increment fix, this would report only the
+		// resume-invocation's contribution (eventCount-firstAttemptCount)
+		// and silently drop the firstAttemptCount rows from the audit trail.
+		Expect(ckptFinal.Phase3RowsRewritten).To(Equal(eventCount),
+			"INV-E7 + jxo8.7.54: Phase3RowsRewritten on checkpoint must be cumulative across crash-resume cycles")
+
 		// Plaintext round-trip: decrypt each rewritten row under the NEW
 		// DEK + new AAD; bytes MUST equal the seeded plaintext for that
 		// row. This is the strongest form of INV-E7 (final state is

--- a/internal/eventbus/crypto/dek/rekey_phase7.go
+++ b/internal/eventbus/crypto/dek/rekey_phase7.go
@@ -156,6 +156,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 		// INV-E25: encoded verbatim from the row — never re-queried.
 		PolicyHash: fmt.Sprintf("sha256:%s", hex.EncodeToString(policyHashArr[:])),
 		Phases: RekeyAuditPhases{
+			Phase3RowsRewritten:       ckpt.Phase3RowsRewritten,
 			Phase5Attempts:            ckpt.Phase5AttemptCount,
 			Phase5FinalMissingMembers: missingMembers,
 			Phase6DestroyedAt:         time.Now(), // approximate; canonical record is DB state

--- a/internal/eventbus/crypto/dek/rekey_run_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_run_integration_test.go
@@ -406,3 +406,61 @@ func opArgsHashForReq(req dek.RekeyRequest) []byte {
 	Expect(err).NotTo(HaveOccurred())
 	return h[:]
 }
+
+var _ = Describe("Orchestrator_Phase7_AuditPayloadHasNonZeroPhase3Count (holomush-jxo8.7.54)", func() {
+	It("Phase 7 audit payload Phase3RowsRewritten is > 0 and matches actual rewrite count", func() {
+		// Use the phase3TestSetup to get a real encrypted-rows harness
+		// (real DEK, real events_audit rows encrypted under oldDEK).
+		ph3 := newPhase3TestSetup()
+
+		const rowCount = 3
+		ph3.InsertEncryptedRows(rowCount)
+
+		// Drive Phase 3 — rewrites the seeded rows under the new DEK.
+		// processPhase3Batch calls IncrementPhase3Count INSIDE each batch tx
+		// so ckpt.Phase3RowsRewritten accumulates atomically with the row
+		// rewrites and cursor advance.
+		n, err := ph3.orch.RunPhase3(context.Background(), ph3.RequestID())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(rowCount), "RunPhase3 must rewrite all seeded rows")
+
+		// Verify the count is persisted on the checkpoint row.
+		ckpt, err := ph3.repo.Get(context.Background(), ph3.RequestID())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ckpt.Phase3RowsRewritten).To(Equal(rowCount),
+			"checkpoint.Phase3RowsRewritten must be persisted after RunPhase3")
+
+		// Wire Phase 5 (fake coordinator) + Phase 6 + Phase 7 onto the same orchestrator
+		// to drive to completion and capture the Phase 7 payload.
+		coord := &fakePhase5Coordinator{}
+		coord.SetSuccess()
+		ph3.orch.SetPhase5Coordinator(coord)
+		ph3.orch.SetDestroyer(ph3.manager)
+		auditEmitter := &fakeAuditEmitter{}
+		ph3.orch.SetAuditEmitter(auditEmitter)
+		ph3.orch.SetDataDir(GinkgoT().TempDir())
+
+		// RunPhase5 + RunPhase6 + RunPhase7 in sequence.
+		Expect(ph3.orch.RunPhase5(context.Background(), ph3.RequestID())).To(Succeed())
+		Expect(ph3.orch.RunPhase6(context.Background(), ph3.RequestID())).To(Succeed())
+
+		req := dek.RekeyRequest{
+			ContextType:   "scene",
+			ContextID:     "01PH3",
+			Justification: "test",
+			Operator:      dek.OperatorIdentity{PlayerID: "01PLAYER"},
+		}
+		outcome, err := ph3.orch.RunPhase7(context.Background(), ph3.RequestID(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outcome.Phase3RowCount).To(Equal(rowCount),
+			"RekeyOutcome.Phase3RowCount must equal the number of rows rewritten by Phase 3")
+
+		// The emitted payload must also carry the count.
+		Expect(auditEmitter.emitted).To(HaveLen(1))
+		payload := auditEmitter.emitted[0]
+		Expect(payload.Phases.Phase3RowsRewritten).To(Equal(rowCount),
+			"RekeyAuditPayload.Phases.Phase3RowsRewritten must match actual rewrite count")
+		Expect(payload.Phases.Phase3RowsRewritten).To(BeNumerically(">", 0),
+			"Phase3RowsRewritten must be > 0 (the canonical fix for holomush-jxo8.7.54)")
+	})
+})

--- a/internal/eventbus/history/source/fallback.go
+++ b/internal/eventbus/history/source/fallback.go
@@ -83,8 +83,14 @@ func (r *FallbackResolver) Resolve(ctx context.Context, hot eventbus.Envelope) (
 	}
 
 	// Step 5: attempt to resolve the cold-tier DEK.
+	// Mirror the hot-tier classification: typed DEK_NOT_FOUND / DEK_DESTROYED
+	// → ErrMetadataOnly; any other error is a transient DB failure and MUST
+	// propagate so callers can distinguish retryable from permanent misses.
 	coldKey, err := r.DEKManager.Resolve(ctx, coldEnv.KeyID(), coldEnv.KeyVersion())
 	if err != nil {
+		if !isDEKMissing(err) {
+			return ResolvedSource{}, oops.Code("DEK_RESOLVE_TRANSIENT").Wrap(err)
+		}
 		r.Metrics.ColdDEKMiss.Inc()
 		return ResolvedSource{}, ErrMetadataOnly
 	}

--- a/internal/eventbus/history/source/fallback_test.go
+++ b/internal/eventbus/history/source/fallback_test.go
@@ -190,3 +190,27 @@ func TestFallback_Case8_ColdReaderError_Wrapped(t *testing.T) {
 	require.True(t, ok, "cold lookup error MUST be wrapped as oops error")
 	assert.Equal(t, "EVENTBUS_SOURCE_COLD_LOOKUP_FAILED", oopsErr.Code())
 }
+
+// Case 9: cold DEK resolution returns a transient (non-typed) error.
+// The error MUST propagate as DEK_RESOLVE_TRANSIENT, NOT be masked as ErrMetadataOnly.
+func TestFallback_Case9_ColdTransientError_Propagates(t *testing.T) {
+	env := makeCiphertextEnvelope(t, 42, 3)
+	coldEnv := makeCiphertextEnvelope(t, 99, 4)
+	transient := errors.New("pg: connection reset by peer")
+	dm := &fakeDEKManager{fn: func(k codec.KeyID, _ uint32) (codec.Key, error) {
+		if k == 42 {
+			// Hot DEK is destroyed — triggers cold-tier fallback.
+			return codec.Key{}, oops.Code("DEK_DESTROYED").Errorf("rekey'd")
+		}
+		// Cold DEK resolution hits a transient DB error (not typed as DEK_NOT_FOUND / DEK_DESTROYED).
+		return codec.Key{}, transient
+	}}
+	cr := &fakeColdReader{env: coldEnv, found: true}
+	r := source.NewFallbackResolver(dm, cr, newTestMetrics(), slog.Default())
+	_, err := r.Resolve(context.Background(), env)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, source.ErrMetadataOnly, "transient cold-DEK error MUST NOT be masked as ErrMetadataOnly")
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "transient cold-DEK error MUST be wrapped as oops error")
+	assert.Equal(t, "DEK_RESOLVE_TRANSIENT", oopsErr.Code(), "transient cold-DEK error MUST carry DEK_RESOLVE_TRANSIENT code")
+}

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/core"
 )
 
 // Subject is a typed JetStream subject. Constructed via NewSubject which
@@ -140,6 +142,26 @@ type Event struct {
 	// EventFrame.metadata_only from this field (Phase 3b T10).
 	// NEVER serialized to the wire event envelope; never persisted.
 	MetadataOnly bool
+}
+
+// NewEvent constructs an Event with a monotonic ULID (from core.NewULID()),
+// the current timestamp, and the provided fields. This is the canonical
+// construction path for eventbus.Event values that will be published — it
+// mirrors the core.NewEvent() convention and prevents accidental omission of
+// the ID stamp (holomush-jxo8.7.53).
+//
+// Callers that need to override specific fields after construction (e.g.
+// Sensitive, Headers, Rendering) MUST still use NewEvent for the base value
+// rather than a raw Event{} literal.
+func NewEvent(subject Subject, typ Type, actor Actor, payload []byte) Event {
+	return Event{
+		ID:        core.NewULID(),
+		Subject:   subject,
+		Type:      typ,
+		Timestamp: time.Now(),
+		Actor:     actor,
+		Payload:   payload,
+	}
 }
 
 // subjectTokenRe permits NATS subject tokens: letters, digits, dashes,

--- a/internal/eventbus/types_test.go
+++ b/internal/eventbus/types_test.go
@@ -112,3 +112,28 @@ func TestEventSeqPreservesLiteralValueWhenSet(t *testing.T) {
 	e := eventbus.Event{Seq: 42}
 	assert.Equal(t, uint64(42), e.Seq)
 }
+
+// TestEventbus_NewEvent_AutoStampsULID verifies that eventbus.NewEvent()
+// returns an Event with a non-zero ULID ID and that the provided fields are
+// preserved (holomush-jxo8.7.53).
+func TestEventbus_NewEvent_AutoStampsULID(t *testing.T) {
+	t.Parallel()
+	subj := eventbus.MustSubject("events.main.scene.01TEST")
+	typ, err := eventbus.NewType("test.event")
+	require.NoError(t, err)
+	actor := eventbus.Actor{Kind: eventbus.ActorKindSystem}
+	payload := []byte(`{"hello":"world"}`)
+
+	ev := eventbus.NewEvent(subj, typ, actor, payload)
+
+	assert.NotEmpty(t, ev.ID, "NewEvent must stamp a non-zero ULID")
+	assert.Equal(t, subj, ev.Subject)
+	assert.Equal(t, typ, ev.Type)
+	assert.Equal(t, actor.Kind, ev.Actor.Kind)
+	assert.Equal(t, payload, ev.Payload)
+	assert.False(t, ev.Timestamp.IsZero(), "NewEvent must stamp a non-zero Timestamp")
+
+	// Two consecutive NewEvent calls MUST mint distinct ULIDs (monotonic).
+	ev2 := eventbus.NewEvent(subj, typ, actor, payload)
+	assert.NotEqual(t, ev.ID, ev2.ID, "each NewEvent call must mint a unique ULID")
+}

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -148,7 +148,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(33), version)
+	assert.Equal(t, uint(34), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -173,7 +173,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(33), version)
+	assert.Equal(t, uint(34), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,7 +278,7 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-20, 30, 31, 32, and 33 should be pending (baseline + is_guest +
+	// At version 0, migrations 1-20, 30, 31, 32, 33, and 34 should be pending (baseline + is_guest +
 	// alias_source + session_player_id + audit_source_component + session_focus +
 	// seed_scene_defaults + session_player_fk + create_events_audit +
 	// drop_events_and_cursors + events_audit_js_seq_index + events_audit_rendering +
@@ -286,16 +286,16 @@ func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testin
 	// crypto_keys_destroyed_at + events_audit_envelope_rename + create_plugins +
 	// create_player_totp + create_admin_approvals + replace_bootstrap_metadata +
 	// create_crypto_rekey_checkpoints + create_setting_bootstrap_state +
-	// add_justification_to_checkpoints)
+	// add_justification_to_checkpoints + add_phase3_count_to_checkpoints)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 33 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 33}}
+	// At version 34 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 34}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000034_add_phase3_count_to_checkpoints.down.sql
+++ b/internal/store/migrations/000034_add_phase3_count_to_checkpoints.down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+-- Reverse: remove phase3_rows_rewritten column from crypto_rekey_checkpoints.
+
+ALTER TABLE crypto_rekey_checkpoints
+    DROP COLUMN IF EXISTS phase3_rows_rewritten;

--- a/internal/store/migrations/000034_add_phase3_count_to_checkpoints.up.sql
+++ b/internal/store/migrations/000034_add_phase3_count_to_checkpoints.up.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+-- Add phase3_rows_rewritten column to crypto_rekey_checkpoints so the Phase 3
+-- row count is persisted and available to Phase 7 for the RekeyAuditPayload
+-- (holomush-jxo8.7.54). NOT NULL DEFAULT 0 gives existing rows a sensible value.
+
+ALTER TABLE crypto_rekey_checkpoints
+    ADD COLUMN IF NOT EXISTS phase3_rows_rewritten int NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

Bundles three P3 follow-ups from PR #3670 review. Each is small and individually independent; bundled because they share the audit-correctness theme and benefit from one review cycle.

| Bead | What | Why |
|---|---|---|
| \`.50\` | \`FallbackResolver.Resolve\` cold path mirrors \`isDEKMissing()\` | Without this, transient cold-DEK pg errors collapse to \`ErrMetadataOnly\`, silently masking flaky cold tier as legitimate destruction |
| \`.54\` | Phase 3 row count populated in audit payload | The whole point: \`RekeyOutcome.Phase3RowCount\` was always 0 |
| \`.53\` | \`eventbus.NewEvent()\` constructor + 3 call site cutovers | CLAUDE.md's \`core.Event{}\` rule extended to \`eventbus.Event{}\` |

## .54 — crash-resume correctness (load-bearing)

crypto-reviewer caught a real bug on the first pass: the initial implementation used a post-loop absolute \`UpdatePhase3Count\` write. On crash-resume, the per-invocation \`totalRewritten\` would overwrite the cumulative figure, masking earlier successful batches in the audit payload.

**Fix:** \`IncrementPhase3Count(ctx, tx, rid, delta)\` runs INSIDE each \`processPhase3Batch\` transaction, right before \`AdvanceCursor\`. The increment, the row UPDATEs, and the cursor advance commit atomically. Crashed batches roll back all three; successful batches persist all three. Migration 000034 adds the column.

**Test:** existing \`Phase3_CrashResumeIdempotent\` Ginkgo spec strengthened with \`Equal(eventCount)\` assertion. Under the original (buggy) implementation this would have shown 1500 / 2500 — bug caught.

## sub_grpc.go intentionally excluded from .53

\`cmd/holomush/sub_grpc.go:548\` bridges a \`core.Event\` into an \`eventbus.Event\` for re-emission and MUST preserve the caller's existing \`event.ID\` for \`Nats-Msg-Id\` dedup correlation. Both implementer subagent and crypto-reviewer ratified.

## Verification

- \`task pr-prep\` green: 7523 unit + 1637 integration tests
- \`crypto-reviewer\`: **READY** after one iteration (caught + verified .54 crash-resume fix)
- \`code-reviewer\`: **READY** (4 Low findings addressed inline: dead \`errors\` import deleted, stale doc comment updated, error code unified to \`DEK_REKEY_STALE_TRANSITION\` per sibling pattern, Case 8/9 test ordering fixed)

## Sub-epic E status post-merge

Will leave 6 follow-ups under \`jxo8.7\` epic:
- 5 P3s: \`.2\` (composite index), \`.47\` (verifier scope cross-check), \`.48\` (FK docs), \`.49\` (INV-E meta-test), \`ojw1.6\` (client stale-DEK signaling)
- 1 P4: \`.52\` (abort justification — correctness)

All P1/P2 work + the load-bearing P3 correctness items will be done.

## Test plan

- [ ] CI green
- [ ] Verify the new \`Equal(eventCount)\` assertion in \`Phase3_CrashResumeIdempotent\` runs and passes
- [ ] Verify \`Equal(rowCount)\` assertion in \`Orchestrator_Phase7_AuditPayloadHasNonZeroPhase3Count\` runs and passes

Refs: \`holomush-jxo8.7.50\`, \`holomush-jxo8.7.54\`, \`holomush-jxo8.7.53\` (all P3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logs now include complete Phase 3 row-rewrite counts during encryption key rotation operations.

* **Bug Fixes**
  * Improved transient error handling for cold-tier key resolution; non-typed errors are now properly distinguished from missing keys.
  * Key rotation crash recovery now correctly preserves cumulative rewrite counts across restart cycles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->