### PR TITLE
fix(crypto): drop FK from crypto_rekey_checkpoints to crypto_keys (holomush-jxo8.7.48)

### DIFF
--- a/docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md
+++ b/docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md
@@ -198,8 +198,8 @@ CREATE TABLE crypto_rekey_checkpoints (
     primary_player_id       text        NOT NULL,               -- ULID; resume must match this
     status                  text        NOT NULL,               -- CheckpointStatus enum (§3.2)
     last_processed_event_id bytea,                              -- ULID, Phase 3 cursor (nullable)
-    new_dek_id              bigint      REFERENCES crypto_keys(id),  -- nullable until Phase 2
-    old_dek_id              bigint      NOT NULL REFERENCES crypto_keys(id),
+    new_dek_id              bigint,                                 -- nullable until Phase 2; no FK (see §3.6.1)
+    old_dek_id              bigint      NOT NULL,                   -- no FK (see §3.6.1)
     phase5_attempt_count    int         NOT NULL DEFAULT 0,
     phase5_missing_members  jsonb,                              -- last attempt's missing list
     force_destroy           boolean     NOT NULL DEFAULT false, -- true when --force-destroy used
@@ -237,6 +237,44 @@ Notes:
 - `phase5_missing_members` is `jsonb`, matching the on-the-wire shape of
   `invalidation.Reply` and naturally JSON-serializable.
 - The CHECK constraint enforces terminal-state consistency at the DB layer.
+
+#### §3.6.1 DEK-id referential integrity (no FK)
+
+`new_dek_id` and `old_dek_id` carry `crypto_keys.id` bigint values but are
+**deliberately not declared as foreign keys** (migration 000035,
+`holomush-jxo8.7.48`). This matches the existing precedent for
+`events_audit.dek_ref` (also no FK to `crypto_keys`) and removes an inherited
+operational dead-end for future hard-cleanup tooling.
+
+**Rationale:** Phase 6 of the Rekey lifecycle SOFT-deletes DEK rows
+(`destroyed_at = NOW()`, row stays); the FK would not block soft-delete but
+WOULD block any future hard-cleanup script
+(e.g. `DELETE FROM crypto_keys WHERE destroyed_at < now() - interval '90 days'`).
+A blocked cleanup forces either (i) lockstep hard-deletion of audit-trail
+checkpoint rows (data loss on the operator record of a rekey), (ii) a strict
+archival ordering between checkpoint and DEK pruning (operational coupling),
+or (iii) a production foot-gun where the cleanup script errors at runtime.
+
+**Integrity model (application-enforced):**
+
+- **Phase 1** (`RunPhase1Fresh`) verifies the old DEK row exists at INSERT
+  time: it selects the active DEK row for the context BEFORE opening the
+  checkpoint and stamps its `id` into `old_dek_id`. A missing old DEK is a
+  fail-closed precondition error
+  (`DEK_REKEY_NO_ACTIVE_DEK_FOR_CONTEXT`), not silent corruption.
+- **Phase 2** (`RunPhase2`) inserts the new DEK row and stamps `new_dek_id`
+  on the checkpoint atomically (single repo call,
+  `SetNewDEKAndAdvance`).
+- **Future hard-cleanup scripts** can prune old DEK rows freely;
+  checkpoint rows referencing pruned DEKs retain the `bigint` id as a
+  historical record. Operator joins to `crypto_keys` MUST tolerate
+  unmatched ids (LEFT JOIN) and surface them as "DEK retired before audit
+  pruning" in reports.
+
+Per the `no-prod-shape-for-undeployed` project rule (CLAUDE.md): the
+constraint shape ships in DDL, not in operational scripts, so the prod
+policy is fixed at deployment time even though the cleanup tooling does
+not yet exist.
 
 ### 3.2 `CheckpointStatus` enum
 

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -148,7 +148,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(34), version)
+	assert.Equal(t, uint(35), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -173,7 +173,7 @@ func TestMigrator_FullCycle(t *testing.T) {
 
 	version, dirty, err = migrator.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(34), version)
+	assert.Equal(t, uint(35), version)
 	assert.False(t, dirty)
 
 	tables = queryTableNames(t, ctx, connStr)
@@ -546,4 +546,74 @@ func TestMigrator_ConcurrentMigrationDirtyStateHandling(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, finalVersion, v2Final, "migrator2 should see same final version")
 	assert.False(t, dirty2Final, "migrator2 should see clean state")
+}
+
+// TestMigration000035_DropsCryptoRekeyCheckpointFKs asserts the load-bearing
+// post-condition of migration 000035 (holomush-jxo8.7.48): no foreign-key
+// constraints remain on crypto_rekey_checkpoints.{new_dek_id,old_dek_id}.
+//
+// Without this assertion, a future regression that names the constraints
+// differently (e.g. explicit CONSTRAINT clause in 000031) would silently
+// leave the FKs in place — the migration's DROP CONSTRAINT IF EXISTS would
+// match nothing, no error, no test failure. Asserting the actual
+// information_schema state is the load-bearing check.
+func TestMigration000035_DropsCryptoRekeyCheckpointFKs(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(
+		ctx,
+		"postgres:18-alpine",
+		postgres.WithDatabase("test"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		postgres.BasicWaitStrategies(),
+	)
+	require.NoError(t, err)
+	defer pgContainer.Terminate(ctx)
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	migrator, err := store.NewMigrator(connStr)
+	require.NoError(t, err)
+	defer migrator.Close()
+
+	require.NoError(t, migrator.Up())
+
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Count remaining FK constraints on crypto_rekey_checkpoints. After
+	// migration 000035 there MUST be zero. (The table itself still has
+	// PRIMARY KEY, CHECK, and UNIQUE constraints — those are unaffected.)
+	var fkCount int
+	err = conn.QueryRow(ctx, `
+        SELECT COUNT(*)
+          FROM information_schema.table_constraints
+         WHERE table_name = 'crypto_rekey_checkpoints'
+           AND constraint_type = 'FOREIGN KEY'
+    `).Scan(&fkCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, fkCount,
+		"migration 000035 (holomush-jxo8.7.48) MUST drop both FKs on crypto_rekey_checkpoints "+
+			"(new_dek_id, old_dek_id). Future migrations that re-introduce a FK to crypto_keys "+
+			"would defeat the no-prod-shape design — see spec §3.6.1.")
+
+	// Defense-in-depth: also confirm the specific column FKs aren't present
+	// (an FK to a different table wouldn't be caught by the count-zero
+	// check above, but it would be even worse).
+	var perColumnFKCount int
+	err = conn.QueryRow(ctx, `
+        SELECT COUNT(*)
+          FROM information_schema.referential_constraints rc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = rc.constraint_name
+         WHERE kcu.table_name = 'crypto_rekey_checkpoints'
+           AND kcu.column_name IN ('new_dek_id', 'old_dek_id')
+    `).Scan(&perColumnFKCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, perColumnFKCount,
+		"no FK from crypto_rekey_checkpoints.{new_dek_id,old_dek_id} to any table is permitted "+
+			"after migration 000035")
 }

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,7 +278,7 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-20, 30, 31, 32, 33, and 34 should be pending (baseline + is_guest +
+	// At version 0, migrations 1-20, 30, 31, 32, 33, 34, and 35 should be pending (baseline + is_guest +
 	// alias_source + session_player_id + audit_source_component + session_focus +
 	// seed_scene_defaults + session_player_fk + create_events_audit +
 	// drop_events_and_cursors + events_audit_js_seq_index + events_audit_rendering +
@@ -286,16 +286,17 @@ func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testin
 	// crypto_keys_destroyed_at + events_audit_envelope_rename + create_plugins +
 	// create_player_totp + create_admin_approvals + replace_bootstrap_metadata +
 	// create_crypto_rekey_checkpoints + create_setting_bootstrap_state +
-	// add_justification_to_checkpoints + add_phase3_count_to_checkpoints)
+	// add_justification_to_checkpoints + add_phase3_count_to_checkpoints +
+	// drop_checkpoint_dek_fks)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34, 35}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 34 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 34}}
+	// At version 35 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 35}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000035_drop_checkpoint_dek_fks.down.sql
+++ b/internal/store/migrations/000035_drop_checkpoint_dek_fks.down.sql
@@ -1,0 +1,20 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+--
+-- Reverse: restore the original FK constraints from
+-- crypto_rekey_checkpoints.{new_dek_id,old_dek_id} to crypto_keys(id).
+--
+-- Note: this rollback only succeeds if every existing checkpoint row's
+-- new_dek_id (when non-NULL) and old_dek_id reference a still-extant
+-- crypto_keys.id. After production deployment, hard-deleted DEK rows
+-- referenced by old checkpoint rows would make this rollback fail. That
+-- is an explicit downside of the down migration; the up direction is the
+-- intended steady-state.
+
+ALTER TABLE crypto_rekey_checkpoints
+    ADD CONSTRAINT crypto_rekey_checkpoints_new_dek_id_fkey
+        FOREIGN KEY (new_dek_id) REFERENCES crypto_keys(id);
+
+ALTER TABLE crypto_rekey_checkpoints
+    ADD CONSTRAINT crypto_rekey_checkpoints_old_dek_id_fkey
+        FOREIGN KEY (old_dek_id) REFERENCES crypto_keys(id);

--- a/internal/store/migrations/000035_drop_checkpoint_dek_fks.up.sql
+++ b/internal/store/migrations/000035_drop_checkpoint_dek_fks.up.sql
@@ -1,0 +1,43 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+--
+-- Drop the FK constraints from crypto_rekey_checkpoints.{new_dek_id,old_dek_id}
+-- to crypto_keys(id). Matches the existing precedent for events_audit.dek_ref
+-- (no FK to crypto_keys) and prevents an inherited operational dead-end for
+-- future DEK hard-cleanup scripts.
+--
+-- Rationale (holomush-jxo8.7.48):
+--
+-- Phase 6 of the Rekey lifecycle SOFT-deletes DEK rows (destroyed_at = NOW(),
+-- row stays). The FKs from crypto_rekey_checkpoints would not block soft-delete
+-- but WOULD block any future hard-cleanup tool (e.g. DELETE FROM crypto_keys
+-- WHERE destroyed_at < now() - interval '90 days'). The blocked cleanup forces
+-- either (i) lockstep hard-deletion of audit-trail checkpoint rows (data loss
+-- on the operator record of a rekey), (ii) a strict archival ordering between
+-- checkpoint and DEK pruning (operational coupling), or (iii) a production
+-- foot-gun where the cleanup script errors at runtime.
+--
+-- Following the same shape as events_audit.dek_ref (no FK), application
+-- invariants enforce referential integrity:
+--
+--   - Phase 1 (RunPhase1Fresh) verifies old DEK exists at INSERT time
+--     (crypto_rekey_checkpoints.old_dek_id NOT NULL + Phase 1 selects the
+--     active DEK row before opening the checkpoint).
+--   - Phase 2 (RunPhase2) inserts the new DEK row and stamps new_dek_id on
+--     the checkpoint atomically.
+--   - Future hard-cleanup scripts can prune old DEK rows freely; checkpoint
+--     rows referencing them retain the bigint id as a historical record.
+--
+-- See docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md §3.6
+-- "no-prod-shape-for-undeployed" — design the prod policy now, not later.
+--
+-- Constraint names are PostgreSQL defaults (table_column_fkey). IF EXISTS so
+-- the migration applies cleanly to fresh DBs where 000031 may not yet have
+-- run (defensive — the migration chain is sequential, but idempotency is
+-- the convention).
+
+ALTER TABLE crypto_rekey_checkpoints
+    DROP CONSTRAINT IF EXISTS crypto_rekey_checkpoints_new_dek_id_fkey;
+
+ALTER TABLE crypto_rekey_checkpoints
+    DROP CONSTRAINT IF EXISTS crypto_rekey_checkpoints_old_dek_id_fkey;


### PR DESCRIPTION
## Summary

Drops the FK constraints from \`crypto_rekey_checkpoints.{new_dek_id,old_dek_id}\` to \`crypto_keys(id)\`. Matches the existing precedent for \`events_audit.dek_ref\` (also no FK to \`crypto_keys\`) and removes an inherited operational dead-end for future DEK hard-cleanup tooling.

Implements **option (a)** from \`holomush-jxo8.7.48\`: drop FKs + spec amendment. Originally flagged by \`crypto-reviewer\` R1 'general finding' on PR #3670.

## The trap (avoided)

Phase 6 of the Rekey lifecycle SOFT-deletes DEK rows (\`destroyed_at = NOW()\`, row stays). The FKs would not block soft-delete but **would block any future hard-cleanup script** (e.g. \`DELETE FROM crypto_keys WHERE destroyed_at < now() - interval '90 days'\`). The blocked cleanup forces:

1. Lockstep hard-deletion of audit-trail checkpoint rows (data loss on operator record of rekey), OR
2. Strict archival ordering between checkpoint and DEK pruning (operational coupling), OR
3. A production foot-gun where the cleanup script errors at runtime

Per the \`no-prod-shape-for-undeployed\` rule (CLAUDE.md / spec §3.6) the constraint shape ships in DDL, so the prod policy must be fixed now.

## Integrity model (application-enforced)

- **Phase 1** (\`RunPhase1Fresh\`) selects the active DEK row BEFORE opening the checkpoint and stamps its \`id\` into \`old_dek_id\`. A missing old DEK is fail-closed (\`DEK_REKEY_NO_ACTIVE_DEK_FOR_CONTEXT\`), not silent corruption.
- **Phase 2** (\`SetNewDEKAndAdvance\`) inserts the new DEK and stamps \`new_dek_id\` atomically.
- Future hard-cleanup scripts can prune old DEK rows freely; checkpoint rows retain the bigint id as a historical record. Operator joins MUST tolerate unmatched ids via LEFT JOIN.

## Files

| File | Change |
|---|---|
| \`internal/store/migrations/000035_drop_checkpoint_dek_fks.{up,down}.sql\` | New. Idempotent \`ALTER TABLE ... DROP CONSTRAINT IF EXISTS\`. Down restores FKs (best-effort; may fail after hard-delete of referenced rows). |
| \`internal/store/migrate{_test,_integration_test}.go\` | Version assertions 34 → 35. |
| \`internal/store/migrate_integration_test.go\` | New \`TestMigration000035_DropsCryptoRekeyCheckpointFKs\` asserts post-condition via \`information_schema\` introspection — catches future regressions where the FKs survive an \`IF EXISTS\` drop (e.g. if 000031 is amended to name them explicitly). |
| \`docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md\` | DDL example at §3.6 updated; new §3.6.1 documents rationale, integrity model, and operator-tooling contract. |

## Verification

- \`task pr-prep\` green: 7525 unit + 1639 integration tests
- New \`TestMigration000035_*\` confirms FK constraints are gone via \`information_schema.table_constraints\` AND \`information_schema.referential_constraints\` (per-column)
- One Docker testcontainer startup flake on first pr-prep attempt (rekey_chain_verifier_refuses_boot); passed on retry. Unrelated to migration logic. Filed as \`holomush-tmrv\` (P2).

## Test plan

- [ ] CI green
- [ ] Verify \`TestMigration000035_DropsCryptoRekeyCheckpointFKs\` runs (asserts both FKs are dropped)

Refs: \`holomush-jxo8.7.48\` (P3); related \`holomush-tmrv\` (Docker flake, P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated specifications for cryptographic key management schema design and referential integrity approach.

* **Chores**
  * Database schema migration applied to manage cryptographic checkpoint references with application-level integrity enforcement.

* **Tests**
  * Added integration tests for database migration validation and updated migration version tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3676)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->