### PR TITLE
fix(admin/readstream): remove SendWithDeadline orphan-goroutine race + repair F-E16

### DIFF
--- a/cmd/holomush/admin_read_stream_e2e_test.go
+++ b/cmd/holomush/admin_read_stream_e2e_test.go
@@ -2152,6 +2152,14 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 	contexts := []*adminv1.ContextRef{
 		{Type: "scene", Ids: []string{sceneID}},
 	}
+	// INV-F11 idempotent reuse requires that invocation 2's opArgsHash equal
+	// invocation 1's. ResolveBounds defaults missing Since/Until from
+	// time.Now() at the resolve site, so two invocations submitted seconds
+	// apart resolve to DIFFERENT bounds → different hashes → reuse miss →
+	// fall through to WaitForApproval → 5-min dual-control timeout. Pin
+	// explicit bounds so both invocations resolve identically (holomush-7jkr).
+	sinceFixed := time.Now().Add(-30 * time.Minute)
+	untilFixed := time.Now()
 
 	// --- Invocation 1: carol opens an approval, we MarkApproved ---
 	view1Ch := make(chan *adminReadStreamView, 1)
@@ -2159,6 +2167,8 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 		view1Ch <- env.RunAdminReadStream(RunAdminReadStreamArgs{
 			Justification: justification,
 			Contexts:      contexts,
+			Since:         sinceFixed,
+			Until:         untilFixed,
 			DualControl:   true,
 		})
 	}()
@@ -2208,6 +2218,8 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 			SessionToken:  aliceToken,
 			Justification: justification,
 			Context:       contexts,
+			Since:         timestamppb.New(sinceFixed),
+			Until:         timestamppb.New(untilFixed),
 			DualControl:   true,
 		},
 		recorder2,

--- a/internal/admin/readstream/deadline_writer.go
+++ b/internal/admin/readstream/deadline_writer.go
@@ -6,58 +6,110 @@ package readstream
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
+
+	"github.com/samber/oops"
 )
 
-// ErrWriteDeadlineExceeded is returned by SendWithDeadline when the send
-// function does not complete within the specified deadline and the parent
-// context was not cancelled (i.e., the slow path is server-side, not a
-// client disconnect).
+// ErrWriteDeadlineExceeded is returned by SendWithDeadline when the per-frame
+// write deadline elapses before send completes and the parent context was
+// not cancelled (i.e., the slow path is server-side, not a client disconnect).
 var ErrWriteDeadlineExceeded = errors.New("readstream: write deadline exceeded")
 
-// SendWithDeadline runs send(frame) in a goroutine and enforces a per-frame
-// write deadline (INV-F14).
+// SendWithDeadline enforces a per-frame write deadline (INV-F14) using a
+// hybrid mechanism:
+//
+//  1. setDeadline(now+deadline) primes the underlying conn's write deadline so
+//     a blocked production Write fails at the kernel I/O layer.
+//  2. send(frame) runs in a goroutine so an internal timer can also enforce
+//     the deadline at the application layer (this matters for in-process tests
+//     that bypass the conn — they don't see the kernel deadline).
+//  3. When the timer fires before send returns, setDeadline(now) is called to
+//     force any in-flight conn Write to abort immediately; we then wait for
+//     the goroutine to exit before returning. The synchronous wait is the
+//     architectural fix for holomush-v0fy — the prior orphan-goroutine pattern
+//     let the goroutine outlive its caller and race the conn.serve teardown
+//     on the HTTP response writer.
 //
 // Semantics:
-//   - If send completes before the deadline, its return value is propagated.
-//   - If the deadline elapses first and ctx is already cancelled (client
-//     disconnect), ctx.Err() is returned (context.Canceled / DeadlineExceeded).
-//   - If the deadline elapses first and ctx is NOT cancelled, ErrWriteDeadlineExceeded
-//     is returned IMMEDIATELY without waiting for the orphaned goroutine.
+//   - send completes successfully within the deadline → nil is returned.
+//   - send returns os.ErrDeadlineExceeded (the kernel-level signal that the
+//     write deadline tripped) AND ctx is live → ErrWriteDeadlineExceeded.
+//   - send returns os.ErrDeadlineExceeded BUT ctx is also cancelled →
+//     ctx.Err() wins (attribution: client disconnect, not server timeout).
+//   - The internal timer fires before send returns AND ctx is live → wait for
+//     send to exit (forced via setDeadline(now)), then return
+//     ErrWriteDeadlineExceeded.
+//   - The internal timer fires AND ctx is cancelled → wait for send to exit,
+//     return ctx.Err().
+//   - ctx fires before timer and send → wait for send to exit (forced via
+//     setDeadline(now)), return ctx.Err().
+//   - send returns any non-deadline error → that error passes through
+//     verbatim (unless ctx is cancelled, in which case ctx.Err() wins).
+//   - setDeadline itself fails on the initial call → wrapped + returned
+//     WITHOUT invoking send.
 //
-// Goroutine lifecycle: when the deadline fires, the send goroutine becomes
-// orphaned. It will complete when send(frame) eventually returns (or the
-// parent context is cancelled). Because doneCh is buffered (cap 1), the
-// orphan can always write its result without blocking, so it never leaks
-// permanently. The next SendWithDeadline call allocates a fresh doneCh,
-// so there is no race between the orphan and subsequent sends.
-func SendWithDeadline[T any](ctx context.Context, send func(T) error, frame T, deadline time.Duration) error {
+// setDeadline is REQUIRED and MUST be safe to call from a different goroutine
+// than the one that started the send (because the timer/ctx path calls it to
+// abort the in-flight send). Production callers obtain it from
+// socket.UnixConnFromContext(ctx).SetWriteDeadline, which is safe per
+// net.Conn's documented thread-safety. Unit tests inject a recording or
+// no-op stub.
+//
+// Goroutine lifecycle: SendWithDeadline always waits for the send goroutine
+// to exit before returning. No orphan, no response-writer race.
+func SendWithDeadline[T any](
+	ctx context.Context,
+	send func(T) error,
+	frame T,
+	deadline time.Duration,
+	setDeadline func(time.Time) error,
+) error {
+	if err := setDeadline(time.Now().Add(deadline)); err != nil {
+		return oops.Code("READSTREAM_SET_WRITE_DEADLINE_FAILED").Wrap(err)
+	}
+	// Clear the deadline before returning so subsequent writes on the same
+	// conn (e.g., the terminator frame after the per-row loop) start fresh.
+	defer func() { _ = setDeadline(time.Time{}) }() //nolint:errcheck // best-effort deadline clear; subsequent writes can re-set as needed
+
 	doneCh := make(chan error, 1)
+	go func() { doneCh <- send(frame) }()
 
-	timerCtx, cancel := context.WithTimeout(ctx, deadline)
-	defer cancel()
-
-	go func() {
-		doneCh <- send(frame)
-	}()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
 
 	select {
 	case err := <-doneCh:
-		// Send completed within deadline.
+		// send completed within the deadline window. Map kernel deadline
+		// error → sentinel; otherwise pass through (ctx error wins).
+		if ctx.Err() != nil {
+			return ctx.Err() //nolint:wrapcheck // context sentinels pass through verbatim; wrapping hides the semantic
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			return ErrWriteDeadlineExceeded
+		}
 		return err
 
-	case <-timerCtx.Done():
-		// Either the per-frame deadline fired, or the parent ctx was cancelled.
-
-		// Distinguish client disconnect from deadline expiry.
+	case <-timer.C:
+		// Application-level deadline fired before send returned. Force the
+		// conn to abort the in-flight Write so the goroutine exits quickly,
+		// then wait for it. In production, conn.SetWriteDeadline(now) makes
+		// the next Write call return os.ErrDeadlineExceeded immediately; in
+		// in-process tests where setDeadline is a no-op, we wait for send
+		// to complete naturally. Either way: NO ORPHAN.
+		_ = setDeadline(time.Now()) //nolint:errcheck // best-effort force-abort; we wait for the goroutine regardless
+		<-doneCh
 		if ctx.Err() != nil {
-			// Parent context cancelled — client disconnected.
-			return ctx.Err() //nolint:wrapcheck // context sentinel errors (Canceled/DeadlineExceeded) pass through verbatim; wrapping hides the semantic
+			return ctx.Err() //nolint:wrapcheck // context sentinels pass through verbatim
 		}
-		// Only the timer fired; parent is still live.
-		// Return immediately — do NOT drain doneCh. The orphaned goroutine will
-		// write to doneCh (buffered) and exit without blocking, so it does not
-		// leak. Blocking here would defeat the purpose of the deadline.
 		return ErrWriteDeadlineExceeded
+
+	case <-ctx.Done():
+		// Parent ctx fired (client disconnect / server shutdown). Force the
+		// in-flight Write to abort, then wait for the goroutine to exit.
+		_ = setDeadline(time.Now()) //nolint:errcheck // best-effort force-abort
+		<-doneCh
+		return ctx.Err() //nolint:wrapcheck // context sentinels pass through verbatim
 	}
 }

--- a/internal/admin/readstream/deadline_writer_test.go
+++ b/internal/admin/readstream/deadline_writer_test.go
@@ -6,6 +6,7 @@ package readstream_test
 import (
 	"context"
 	"errors"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,128 +17,196 @@ import (
 	"github.com/holomush/holomush/internal/admin/readstream"
 )
 
-// TestSendWithDeadline_FastPasses verifies that a sender completing before the
-// deadline returns nil.
-func TestSendWithDeadline_FastPasses(t *testing.T) {
-	ctx := context.Background()
-	frame := "hello"
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		return nil // instant
-	}, frame, 500*time.Millisecond)
-	require.NoError(t, err)
+// recordingSetDeadline returns a setDeadline stub plus a pointer to the slice
+// that captures every time argument passed to it. Used by tests that assert
+// on the deadline-set call pattern (set, then clear).
+func recordingSetDeadline() (func(time.Time) error, *[]time.Time) {
+	calls := &[]time.Time{}
+	return func(t time.Time) error {
+		*calls = append(*calls, t)
+		return nil
+	}, calls
 }
 
-// TestINV_F14_SendWithDeadlineTrips verifies that a slow sender triggers
-// ErrWriteDeadlineExceeded when the deadline elapses before the send
-// completes.
+// noopSetDeadline is the canonical "I don't care about deadlines" stub used by
+// tests that aren't asserting on the deadline-set call pattern.
+func noopSetDeadline(_ time.Time) error { return nil }
+
+// TestSendWithDeadline_FastPasses verifies that a sender completing
+// successfully returns nil AND that the deadline is set + cleared
+// across the call.
+func TestSendWithDeadline_FastPasses(t *testing.T) {
+	setDeadline, calls := recordingSetDeadline()
+	err := readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error { return nil },
+		"hello",
+		500*time.Millisecond,
+		setDeadline,
+	)
+	require.NoError(t, err)
+	require.Len(t, *calls, 2, "setDeadline MUST be called twice: once to set, once to clear")
+	assert.False(t, (*calls)[0].IsZero(), "first call sets a real (non-zero) deadline")
+	assert.True(t, (*calls)[1].IsZero(), "second call clears the deadline (zero time)")
+}
+
+// TestSendWithDeadline_PassesDeadlineToSetter verifies the first call to
+// setDeadline supplies now+deadline (within a tolerance window).
+func TestSendWithDeadline_PassesDeadlineToSetter(t *testing.T) {
+	setDeadline, calls := recordingSetDeadline()
+	const dur = 100 * time.Millisecond
+	before := time.Now()
+	_ = readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error { return nil },
+		"frame",
+		dur,
+		setDeadline,
+	)
+	after := time.Now()
+	require.Len(t, *calls, 2)
+	assert.False(t, (*calls)[0].Before(before.Add(dur)),
+		"first call must set deadline ≥ before+dur; got %v (before+dur=%v)", (*calls)[0], before.Add(dur))
+	assert.False(t, (*calls)[0].After(after.Add(dur)),
+		"first call must set deadline ≤ after+dur; got %v (after+dur=%v)", (*calls)[0], after.Add(dur))
+}
+
+// TestINV_F14_SendWithDeadlineTrips verifies that when send returns
+// os.ErrDeadlineExceeded (the kernel-level signal that the write deadline
+// tripped at the conn), SendWithDeadline returns ErrWriteDeadlineExceeded.
 func TestINV_F14_SendWithDeadlineTrips(t *testing.T) {
-	ctx := context.Background()
-	frame := "slow"
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		time.Sleep(200 * time.Millisecond) // longer than deadline
-		return nil
-	}, frame, 50*time.Millisecond)
+	err := readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error { return os.ErrDeadlineExceeded },
+		"slow",
+		50*time.Millisecond,
+		noopSetDeadline,
+	)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded),
 		"expected ErrWriteDeadlineExceeded, got %v", err)
 }
 
-// TestSendWithDeadline_PropagatesSenderError verifies that the sender's error
-// is returned verbatim when it completes before the deadline.
+// TestSendWithDeadline_PropagatesSenderError verifies a non-deadline sender
+// error is returned verbatim.
 func TestSendWithDeadline_PropagatesSenderError(t *testing.T) {
-	ctx := context.Background()
 	sentinelErr := errors.New("send failed: stream closed")
-	frame := "payload"
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		return sentinelErr
-	}, frame, 500*time.Millisecond)
+	err := readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error { return sentinelErr },
+		"payload",
+		500*time.Millisecond,
+		noopSetDeadline,
+	)
 	require.Error(t, err)
-	assert.Equal(t, sentinelErr, err)
+	assert.ErrorIs(t, err, sentinelErr)
 	assert.False(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded))
 }
 
-// TestSendWithDeadline_DeadlineReturnsImmediately verifies that
-// SendWithDeadline returns ErrWriteDeadlineExceeded promptly — without
-// blocking on the orphaned send goroutine completing. The orphaned goroutine
-// is allowed to complete asynchronously after the function returns.
-func TestSendWithDeadline_DeadlineReturnsImmediately(t *testing.T) {
-	ctx := context.Background()
-	frame := "slow"
-	const deadlineDur = 30 * time.Millisecond
-	const sendDur = 300 * time.Millisecond // 10× the deadline
-
+// TestSendWithDeadline_NoOrphanGoroutine is the regression test for
+// holomush-v0fy. The previous design spawned a goroutine that could continue
+// writing to the HTTP response after SendWithDeadline returned, racing the
+// conn.serve teardown. This test verifies that send completes BEFORE
+// SendWithDeadline returns — synchronous semantics, no orphan, no race.
+func TestSendWithDeadline_NoOrphanGoroutine(t *testing.T) {
+	var sendCompleted atomic.Bool
 	start := time.Now()
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		time.Sleep(sendDur)
-		return nil
-	}, frame, deadlineDur)
+	err := readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error {
+			// Simulate a slow Write that the kernel cuts off after the
+			// deadline. In production, conn.SetWriteDeadline does the
+			// cutting; here we approximate with a Sleep + ErrDeadlineExceeded.
+			time.Sleep(40 * time.Millisecond)
+			sendCompleted.Store(true)
+			return os.ErrDeadlineExceeded
+		},
+		"frame",
+		10*time.Millisecond,
+		noopSetDeadline,
+	)
 	elapsed := time.Since(start)
-
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded),
-		"expected ErrWriteDeadlineExceeded, got %v", err)
-
-	// Must return well before the slow send completes. Allow 5× the deadline
-	// to absorb CI scheduling jitter; still far less than sendDur.
-	assert.Less(t, elapsed, 5*deadlineDur,
-		"SendWithDeadline must return promptly after deadline fires, not block on orphan: elapsed=%v", elapsed)
-}
-
-// TestSendWithDeadline_OrphanedGoroutineEventuallyCompletes verifies the
-// buffered-channel guarantee: the orphaned goroutine can always write its
-// result to doneCh (cap 1) and exits without blocking, even after the caller
-// has long since returned.
-func TestSendWithDeadline_OrphanedGoroutineEventuallyCompletes(t *testing.T) {
-	ctx := context.Background()
-	frame := "slow"
-
-	var completed atomic.Bool
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		time.Sleep(150 * time.Millisecond)
-		completed.Store(true)
-		return nil
-	}, frame, 30*time.Millisecond)
-
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded))
-
-	// The goroutine completes asynchronously after SendWithDeadline returns.
-	// Poll for up to 500ms to let it finish without blocking the test.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for !completed.Load() {
-		if time.Now().After(deadline) {
-			t.Fatal("orphaned goroutine did not complete within 500ms")
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	assert.True(t, completed.Load(), "orphaned goroutine must eventually complete (buffered channel)")
+	assert.True(t, sendCompleted.Load(),
+		"send MUST complete before SendWithDeadline returns; orphan-goroutine pattern FORBIDDEN per holomush-v0fy")
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond,
+		"SendWithDeadline must block until send returns (no premature return); elapsed=%v", elapsed)
 }
 
-// TestSendWithDeadline_ClientDisconnect verifies that when the parent context
-// is cancelled (client disconnect) while the sender is running, the function
+// TestSendWithDeadline_ClientDisconnect verifies that when the parent
+// context is cancelled and the sender returns ctx.Err(), SendWithDeadline
 // returns context.Canceled — NOT ErrWriteDeadlineExceeded.
 func TestSendWithDeadline_ClientDisconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	started := make(chan struct{})
-	frame := "payload"
-
-	go func() {
-		<-started
-		// Cancel the parent context while the sender is mid-flight.
-		time.Sleep(10 * time.Millisecond)
-		cancel()
-	}()
-
-	err := readstream.SendWithDeadline(ctx, func(_ string) error {
-		close(started)
-		time.Sleep(300 * time.Millisecond) // slow send
-		return nil
-	}, frame, 500*time.Millisecond) // deadline is generous — cancel fires first
-
+	err := readstream.SendWithDeadline(
+		ctx,
+		func(_ string) error { return ctx.Err() },
+		"payload",
+		500*time.Millisecond,
+		noopSetDeadline,
+	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled,
 		"client disconnect must return context.Canceled, not ErrWriteDeadlineExceeded")
-	assert.False(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded),
-		"must NOT return ErrWriteDeadlineExceeded on client disconnect")
+	assert.False(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded))
+}
+
+// TestSendWithDeadline_ClientDisconnectWithDeadlineErr verifies that if send
+// returns os.ErrDeadlineExceeded BUT ctx is also cancelled, the context
+// error wins (so callers can distinguish operator timeout from a client
+// drop that incidentally also tripped the conn deadline).
+func TestSendWithDeadline_ClientDisconnectWithDeadlineErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := readstream.SendWithDeadline(
+		ctx,
+		func(_ string) error { return os.ErrDeadlineExceeded },
+		"payload",
+		500*time.Millisecond,
+		noopSetDeadline,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled,
+		"cancelled ctx MUST win over kernel deadline error; attribution must be client-side")
+	assert.False(t, errors.Is(err, readstream.ErrWriteDeadlineExceeded))
+}
+
+// TestSendWithDeadline_SetDeadlineErrorSurfaces verifies that a failure to
+// set the deadline is wrapped + returned WITHOUT invoking send.
+func TestSendWithDeadline_SetDeadlineErrorSurfaces(t *testing.T) {
+	sentinel := errors.New("setsockopt: bad descriptor")
+	var sendCalled atomic.Bool
+	err := readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error {
+			sendCalled.Store(true)
+			return nil
+		},
+		"payload",
+		100*time.Millisecond,
+		func(_ time.Time) error { return sentinel },
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "setDeadline error must surface to the caller")
+	assert.False(t, sendCalled.Load(), "send MUST NOT be called when setDeadline fails")
+}
+
+// TestSendWithDeadline_DeadlineClearedAfterSendError verifies the
+// defer-clear fires even when send returns a non-deadline error, so
+// subsequent writes on the same conn start with no stale deadline.
+func TestSendWithDeadline_DeadlineClearedAfterSendError(t *testing.T) {
+	setDeadline, calls := recordingSetDeadline()
+	_ = readstream.SendWithDeadline(
+		context.Background(),
+		func(_ string) error { return errors.New("send err") },
+		"payload",
+		100*time.Millisecond,
+		setDeadline,
+	)
+	require.Len(t, *calls, 2, "setDeadline must be cleared even on send error")
+	assert.True(t, (*calls)[1].IsZero(), "deadline cleared (zero time)")
 }

--- a/internal/admin/readstream/handler.go
+++ b/internal/admin/readstream/handler.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/admin/approval"
+	"github.com/holomush/holomush/internal/admin/socket"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/idgen"
 	adminv1 "github.com/holomush/holomush/pkg/proto/holomush/admin/v1"
@@ -429,6 +430,17 @@ func (h *Handler) scanAndStream( //nolint:gocritic // unnamedResult: three-retur
 	var eventsScanned, decryptFails int64
 	send := stream.Send
 
+	// Per INV-F14: per-frame write deadline. Production requests carry the
+	// underlying *net.UnixConn via socket.UnixConnFromContext (wired through
+	// http.Server.ConnContext), so SendWithDeadline enforces the deadline at
+	// the kernel I/O layer with no orphan goroutine. Unit tests that bypass
+	// the admin socket fall back to a no-op setter — the unit tests for
+	// deadline semantics live in deadline_writer_test.go.
+	setDeadline := func(_ time.Time) error { return nil }
+	if conn, ok := socket.UnixConnFromContext(ctx); ok {
+		setDeadline = conn.SetWriteDeadline
+	}
+
 	for i := range rows {
 		row := rows[i]
 		plaintext, reason, fatal, decryptErr := DecryptRow(ctx, row, h.cfg.DEK, h.cfg.Codecs)
@@ -443,7 +455,7 @@ func (h *Handler) scanAndStream( //nolint:gocritic // unnamedResult: three-retur
 			frame = buildPlaintextEventFrame(row, plaintext)
 		}
 
-		if sendErr := SendWithDeadline(ctx, send, frame, h.cfg.WriteDeadline); sendErr != nil {
+		if sendErr := SendWithDeadline(ctx, send, frame, h.cfg.WriteDeadline, setDeadline); sendErr != nil {
 			return eventsScanned, decryptFails, oops.Wrap(sendErr)
 		}
 

--- a/internal/admin/socket/peercred.go
+++ b/internal/admin/socket/peercred.go
@@ -35,6 +35,16 @@ func PeerCredFromContext(ctx context.Context) (PeerCred, bool) {
 	return v, ok
 }
 
+// UnixConnFromContext extracts the *net.UnixConn injected by StoreUnixConn
+// (wired as http.Server.ConnContext). ok is false when the request did not
+// arrive over the admin UDS (e.g., in unit tests that bypass the server).
+// Callers MUST treat a missing conn as a test-only condition — production
+// requests on the admin socket always have one.
+func UnixConnFromContext(ctx context.Context) (*net.UnixConn, bool) {
+	uc, ok := ctx.Value(unixConnContextKey{}).(*net.UnixConn)
+	return uc, ok
+}
+
 // StoreUnixConn is called from http.Server.ConnContext to attach the
 // *net.UnixConn to the connection-level context before any request handler runs.
 func StoreUnixConn(ctx context.Context, c net.Conn) context.Context {


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main` (b6f7a2a61 / PR #3678 Phase 5 sub-epic F) that together prevent `task pr-prep` from passing on a clean worktree:

- **`holomush-v0fy` (P0)** — `internal/admin/readstream/deadline_writer.go::SendWithDeadline` spawned a goroutine that outlived its caller. After the deadline fired the function returned, but the goroutine kept writing to the HTTP response while `net/http`'s `conn.serve` was already making connection-reuse decisions on the same response fields. Caught by the Go race detector during sub-epic F's own E2E sweep.
- **`holomush-7jkr` (P0)** — F-E16 (idempotent dual-control reuse) submitted two AdminReadStream invocations without explicit `Since`/`Until`. `ResolveBounds` defaults missing bounds from `time.Now()` at the resolve site, so the two invocations resolved to different bounds → different `opArgsHash` → `GetByOpArgsHash` missed → 5-minute `WaitForApproval` timeout. The v0fy race had been masking this by failing F-E10 before F-E16 could run.

## Changes

### Commit 1 — v0fy race fix (`internal/admin/readstream/`, `internal/admin/socket/peercred.go`)

`SendWithDeadline` now uses a hybrid mechanism:

1. `setDeadline(now+deadline)` primes the underlying conn's write deadline so a blocked production Write fails at the kernel I/O layer.
2. `send(frame)` runs in a goroutine so an internal timer can also enforce the deadline at the application layer (this matters for in-process tests that bypass the conn — F-E10 specifically).
3. When the timer or ctx fires before send returns, `setDeadline(now)` is called to force any in-flight conn Write to abort immediately; we then **wait** for the goroutine before returning. The synchronous wait is the architectural fix — no orphan, no response-writer race.

API change: `SendWithDeadline` gains a 5th parameter `setDeadline func(time.Time) error`. Production wires it from `socket.UnixConnFromContext(ctx).SetWriteDeadline` (the conn is already plumbed via `http.Server.ConnContext` in `server.go:100`). Unit tests inject recording or no-op stubs.

Tests updated:
- Dropped two orphan-asserting tests (`DeadlineReturnsImmediately`, `OrphanedGoroutineEventuallyCompletes`) — they codified the bug.
- Added `NoOrphanGoroutine` regression: asserts `send` completes before `SendWithDeadline` returns.
- Added `PassesDeadlineToSetter`, `ClientDisconnectWithDeadlineErr`, `SetDeadlineErrorSurfaces`, `DeadlineClearedAfterSendError`.

### Commit 2 — F-E16 hash drift fix (`cmd/holomush/admin_read_stream_e2e_test.go`)

Test-only: pin `sinceFixed`/`untilFixed` before invocation 1 and pass them as explicit `Since`/`Until` to both invocations. `ResolveBounds` no longer defaults from `time.Now()`; both invocations resolve to identical bounds; hashes match; reuse engages.

The general INV-F11 security property (different actual time ranges produce different hashes) is unchanged and remains tested by `handler_test.go::TestComputeReadStreamArgsHash_ResolvedBoundsSemantics`.

## Test plan

- [x] `task test` (7710 unit tests pass)
- [x] `task lint` (clean)
- [x] `task pr-prep` (full mirror of CI — passed end-to-end on this branch tip after both fixes)
- [x] Adversarial `code-reviewer` agent: READY, three non-blocking nits noted in review

## Beads

- Closes holomush-v0fy
- Closes holomush-7jkr

## Notes for reviewers

- The orphan-goroutine pattern was an intentional design choice in #3678 ("Return IMMEDIATELY without waiting for the orphaned goroutine") — see the old comment at `deadline_writer.go:25-32` and the two `DeadlineReturnsImmediately` / `OrphanedGoroutineEventuallyCompletes` tests. Both encoded the bug. The new design's synchronous `<-doneCh` wait is the inverse property.
- `net.Conn.SetWriteDeadline` is documented thread-safe ("Multiple goroutines may invoke methods on a Conn simultaneously"). Concurrent `setDeadline` calls from the main goroutine (timer-fired abort) and the send goroutine (in `conn.Write`) are safe.
- `errors.Is(err, os.ErrDeadlineExceeded)` chains through both connect-go's wrapping (verified at `connect@v1.19.2/error.go:210`) and `oops.Wrap` (verified at `oops@v1.21.0/error.go:79`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced per-frame write deadline enforcement in admin read stream operations with improved kernel-level integration.
  * Fixed error precedence to ensure context cancellation takes priority over deadline exceptions in write operations.

* **Tests**
  * Expanded test coverage for deadline behavior, including deadline-setting invocation verification, error semantics, and goroutine cleanup validation.
  * Improved test determinism for dual-control reuse scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3828)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->