### PR TITLE
test/refactor(admin/socket): peercred follow-ups (jxo8.4.1.1 + .3)

### DIFF
--- a/internal/admin/socket/peercred_darwin.go
+++ b/internal/admin/socket/peercred_darwin.go
@@ -7,7 +7,6 @@ package socket
 
 import (
 	"net"
-	"syscall"
 
 	"github.com/samber/oops"
 	"golang.org/x/sys/unix"
@@ -16,7 +15,7 @@ import (
 // readPeerCred reads peer credentials from the UNIX domain socket on Darwin
 // using two getsockopt calls:
 //   - unix.GetsockoptXucred(SOL_LOCAL, LOCAL_PEERCRED) → uid, gid
-//   - syscall.GetsockoptInt(SOL_LOCAL, LOCAL_PEERPID)  → pid
+//   - unix.GetsockoptInt(SOL_LOCAL, LOCAL_PEERPID)     → pid
 func readPeerCred(conn *net.UnixConn) (PeerCred, error) {
 	rawConn, err := conn.SyscallConn()
 	if err != nil {
@@ -32,7 +31,7 @@ func readPeerCred(conn *net.UnixConn) (PeerCred, error) {
 			return
 		}
 
-		pid, err := syscall.GetsockoptInt(int(fd), int(unix.SOL_LOCAL), int(unix.LOCAL_PEERPID)) //nolint:gosec // G115: fd and SOL_LOCAL/LOCAL_PEERPID are syscall constants; conversions are safe
+		pid, err := unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID) //nolint:gosec // G115: fd is a valid file descriptor; uintptr→int is safe at syscall boundaries
 		if err != nil {
 			ctrlErr = oops.Code("PEERCRED_PEERPID_FAILED").Wrap(err)
 			return

--- a/internal/admin/socket/peercred_linux_test.go
+++ b/internal/admin/socket/peercred_linux_test.go
@@ -55,6 +55,6 @@ func TestReadPeerCredReturnsNonZeroValuesOnLinux(t *testing.T) {
 	cred, err := readPeerCred(serverConn)
 	require.NoError(t, err)
 	assert.NotZero(t, cred.UID, "UID must be non-zero")
+	assert.NotZero(t, cred.GID, "GID must be non-zero")
 	assert.NotZero(t, cred.PID, "PID must be non-zero")
-	// GID is intentionally not asserted non-zero: GID=0 is valid for root processes.
 }


### PR DESCRIPTION
## Summary

Two small Phase-5 sub-epic-C peercred follow-up findings deferred from the original PR. Tight surface (~6 LOC net across 2 files in `internal/admin/socket/`):

- **`holomush-jxo8.4.1.1` (P2)** — `peercred_linux_test.go` was missing a `cred.GID` assertion that the Darwin counterpart already had. Add the assertion and drop the misleading "GID=0 is valid for root" comment (UID has the same root-process property and is already asserted — the comment didn't reflect the test's actual policy).

- **`holomush-jxo8.4.1.3` (P2)** — `peercred_darwin.go` mixed `syscall.GetsockoptInt` with `unix.GetsockoptInt` arguments for package-level inconsistency. Switch to `unix.GetsockoptInt` end-to-end and drop the stdlib `syscall` import. The `//nolint:gosec` on the `int(fd)` conversion stays — it applies regardless of which package provides `GetsockoptInt`, and is rephrased to match the wording on the `unix.GetsockoptXucred` call directly above.

Third bead in the original triage cluster (`holomush-jxo8.4.1.2`, the hardcoded subsystem-count test) was closed as stale — `cmd/holomush/core_subsystems_test.go:71-73` now correctly expects 15 subsystems and `SubsystemAdminSocket` is wired into `productionSubsystems()` (lines 47, 92, 120, 126).

## Stacked on

This PR is stacked on top of **#3828** (`v0fy-race-fix`) which is the prerequisite for `task pr-prep` to pass on a clean main. Both #3828 issues (`holomush-v0fy` race + `holomush-7jkr` F-E16 hash drift) blocked pr-prep before this PR could run. Merge order: #3828 first, then this PR rebases automatically.

## Test plan

- [x] `task lint` clean
- [x] `task test` — all unit tests pass (Linux test gated by `//go:build linux` and verified via `GOOS=linux go vet`)
- [x] `task pr-prep` — full mirror of CI, end-to-end green on the stacked branch tip
- [x] Adversarial `code-reviewer` agent ran on these two commits earlier in the session: READY

## Beads

- Closes holomush-jxo8.4.1.1
- Closes holomush-jxo8.4.1.3
- holomush-jxo8.4.1.2 was already closed as stale (no code change in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer credential retrieval on macOS
  * Enhanced peer credential validation on Linux

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3829)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->