### PR TITLE
fix(crypto/dek): zeroize plaintext DEK byte slices on all return paths

### DIFF
--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -217,6 +217,12 @@ func (m *manager) GetOrCreate(ctx context.Context, ctxID ContextID, initial []Pa
 
 	// Mint a fresh DEK and INSERT.
 	dekBytes := make([]byte, DEKByteLength)
+	// Defense-in-depth (e49r.4): zero the plaintext DEK on every return path
+	// so heap dumps / coredumps after this function exits don't carry the
+	// key material. NewMaterial copies into the Material below, and
+	// provider.Wrap consumes the bytes for its wrap output, so neither
+	// depends on the slice after this defer runs.
+	defer clear(dekBytes)
 	if _, err := io.ReadFull(rand.Reader, dekBytes); err != nil {
 		return codec.Key{}, oops.Code("DEK_RNG_FAILED").Wrap(err)
 	}
@@ -379,6 +385,12 @@ func (m *manager) Rotate(ctx context.Context, ctxID ContextID,
 	}
 
 	dekBytes := make([]byte, DEKByteLength)
+	// Defense-in-depth (e49r.4): zero the plaintext DEK on every return path
+	// so heap dumps / coredumps after this function exits don't carry the
+	// key material. NewMaterial copies into the Material below, and
+	// provider.Wrap consumes the bytes for its wrap output, so neither
+	// depends on the slice after this defer runs.
+	defer clear(dekBytes)
 	if _, err = io.ReadFull(rand.Reader, dekBytes); err != nil {
 		return oops.Code("DEK_RNG_FAILED").Wrap(err)
 	}
@@ -468,6 +480,10 @@ func (m *manager) unwrapAndCache(ctx context.Context, r row) (codec.Key, error) 
 			With("version", r.Version).
 			Wrap(err)
 	}
+	// Defense-in-depth (e49r.4): zero plaintext DEK once Material has its
+	// defensive copy. The provider's unwrap output is owned by us after
+	// return per the kek.Provider contract.
+	defer clear(dekBytes)
 	if err := validateProviderUnwrapOutput(dekBytes, r.ID, r.Version); err != nil {
 		return codec.Key{}, err
 	}
@@ -503,6 +519,10 @@ func (m *manager) MintNewDEKForRekey(ctx context.Context, oldDEKID int64) (int64
 		return 0, oops.Code("DEK_REKEY_OLD_ROW_LOOKUP_FAILED").Wrap(err)
 	}
 	var newDEK [DEKByteLength]byte
+	// Defense-in-depth (e49r.4): zero plaintext DEK on every return path.
+	// The underlying array may escape to the heap when newDEK[:] is passed
+	// to provider.Wrap below.
+	defer clear(newDEK[:])
 	if _, rngErr := io.ReadFull(rand.Reader, newDEK[:]); rngErr != nil {
 		return 0, oops.Code("DEK_REKEY_GEN_NEW_DEK_FAILED").Wrap(rngErr)
 	}

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -904,3 +904,99 @@ func TestManager_Add_WithExplicitBindingIDSkipsResolver(t *testing.T) {
 	require.Len(t, parts, 2)
 	assert.Equal(t, "bind-explicit", parts[1].BindingID)
 }
+
+// dekCapturingProvider wraps a real kek.Provider and captures the
+// plaintext byte slices flowing through Wrap (input) and Unwrap (output)
+// so tests can inspect post-call zeroize behavior (holomush-e49r.4).
+type dekCapturingProvider struct {
+	inner       kek.Provider
+	wrapPlain   [][]byte
+	unwrapPlain [][]byte
+}
+
+func (p *dekCapturingProvider) Name() string {
+	return p.inner.Name()
+}
+
+func (p *dekCapturingProvider) RotateKEK(ctx context.Context) (string, error) {
+	return p.inner.RotateKEK(ctx) //nolint:wrapcheck // pass-through in spy
+}
+
+func (p *dekCapturingProvider) HealthCheck(ctx context.Context) error {
+	return p.inner.HealthCheck(ctx) //nolint:wrapcheck // pass-through in spy
+}
+
+func (p *dekCapturingProvider) Wrap(ctx context.Context, plaintext []byte) ([]byte, string, error) {
+	p.wrapPlain = append(p.wrapPlain, plaintext)
+	return p.inner.Wrap(ctx, plaintext) //nolint:wrapcheck // pass-through in spy
+}
+
+func (p *dekCapturingProvider) Unwrap(ctx context.Context, wrapped []byte, kekKeyID string) ([]byte, error) {
+	plaintext, err := p.inner.Unwrap(ctx, wrapped, kekKeyID)
+	if err == nil {
+		p.unwrapPlain = append(p.unwrapPlain, plaintext)
+	}
+	return plaintext, err //nolint:wrapcheck // pass-through in spy
+}
+
+// TestE49R4_GetOrCreateZeroizesPlaintextDEK verifies the defense-in-depth
+// invariant (bead holomush-e49r.4): after GetOrCreate returns, the plaintext
+// DEK byte slice the provider's Wrap call saw is zeroed, preventing
+// long-lived heap-resident DEK material from surfacing in coredumps or
+// heap dumps.
+func TestE49R4_GetOrCreateZeroizesPlaintextDEK(t *testing.T) {
+	ctx := context.Background()
+	pool := testIntegrationPool(t)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	spy := &dekCapturingProvider{inner: newTestProvider(t)}
+	mgr, err := dek.NewManager(spy, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+	require.NoError(t, err)
+
+	ctxID := dek.ContextID{Type: "scene", ID: "e49r4-getorcreate"}
+	_, err = mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	require.NoError(t, err)
+
+	require.Len(t, spy.wrapPlain, 1, "Wrap MUST have been called exactly once during fresh GetOrCreate")
+	captured := spy.wrapPlain[0]
+	require.Len(t, captured, dek.DEKByteLength, "captured plaintext must be DEK-length")
+	for i, b := range captured {
+		require.Zerof(t, b,
+			"captured plaintext byte[%d] MUST be zeroed after GetOrCreate returns (e49r.4 defense-in-depth)", i)
+	}
+}
+
+// TestE49R4_ResolveZeroizesUnwrappedDEK verifies the same defense-in-depth
+// invariant on the unwrapAndCache path: after Resolve returns, the plaintext
+// DEK returned by provider.Unwrap is zeroed.
+func TestE49R4_ResolveZeroizesUnwrappedDEK(t *testing.T) {
+	ctx := context.Background()
+	pool := testIntegrationPool(t)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+
+	spy := &dekCapturingProvider{inner: newTestProvider(t)}
+	mgr, err := dek.NewManager(spy, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+	require.NoError(t, err)
+
+	ctxID := dek.ContextID{Type: "scene", ID: "e49r4-resolve"}
+	key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	require.NoError(t, err)
+
+	// Drop cache so Resolve must call provider.Unwrap, then reset the
+	// capture so we only inspect the unwrap-path plaintext.
+	cache.Invalidate(dek.CacheKey{KeyID: key.ID, Version: 1})
+	spy.unwrapPlain = nil
+
+	_, err = mgr.Resolve(ctx, key.ID, 1)
+	require.NoError(t, err)
+
+	require.Len(t, spy.unwrapPlain, 1, "Unwrap MUST have been called exactly once after cache eviction")
+	captured := spy.unwrapPlain[0]
+	require.Len(t, captured, dek.DEKByteLength, "captured plaintext must be DEK-length")
+	for i, b := range captured {
+		require.Zerof(t, b,
+			"unwrapped plaintext byte[%d] MUST be zeroed after Resolve returns (e49r.4 defense-in-depth)", i)
+	}
+}


### PR DESCRIPTION
## Summary

Closes **holomush-e49r.4** (P2 defense-in-depth gap surfaced by the 2026-05-13 bead-auditor sweep of the e49r tail).

`dek.manager.GetOrCreate` and its three sibling mint/unwrap call sites held plaintext DEK bytes on the heap indefinitely after they were no longer needed. `NewMaterial` makes a defensive copy ([material.go:30-31](internal/eventbus/crypto/dek/material.go#L30-L31)) and the KEK provider's `Wrap` consumes the bytes synchronously for its wrap output, so neither depends on the original slice after the call — but the slice still lingered until the GC reclaimed it. Any heap dump / coredump from a running server would include live DEK material.

## Fix

Added `defer clear(...)` immediately after the mint at four sites so the plaintext is zeroed on every return path (success and error alike):

- `manager.go::GetOrCreate` (line 219)
- `manager.go::Rotate` (line 388)
- `manager.go::unwrapAndCache` (after `provider.Unwrap` — owned by us per the kek.Provider contract)
- `manager.go::MintNewDEKForRekey` (stack-decl array, but `newDEK[:]` escapes when passed to `provider.Wrap`)

The `defer` pattern is correct under the kek.Provider contract: `Wrap` returns the wrapped ciphertext synchronously, so by the time the deferred `clear` runs (function exit), the provider can no longer be holding a live reference to the plaintext slice. NewMaterial's copy is independent.

## Tests

Two integration tests in `manager_integration_test.go` using a new `dekCapturingProvider` spy that wraps the real provider and captures the plaintext slices flowing through `Wrap` (input) and `Unwrap` (output). The tests assert each captured slice contains all zeros after the public manager call returns:

- `TestE49R4_GetOrCreateZeroizesPlaintextDEK` (Wrap path)
- `TestE49R4_ResolveZeroizesUnwrappedDEK` (Unwrap path)

Both tests use the existing testcontainers PG harness and the existing `newTestProvider` real-KEK helper, so the slice references captured during Wrap/Unwrap point at the actual production allocation — not synthetic test slices.

## Test plan

- [x] `task test` (all unit tests pass)
- [x] `task lint` (clean)
- [x] `task pr-prep` (full mirror of CI — passed end-to-end)
- [x] Adversarial `code-reviewer` agent: READY with two non-blocking nits, both addressed:
  - Nit 1 (inconsistent comment depth across defer sites) — `Rotate` comment expanded to match the `GetOrCreate` rationale.
  - Nit 2 (cache-resident plaintext still long-lived after defer fires) — filed as standalone P3 `holomush-m88d` for a separate follow-up. Out of scope for the transient-buffer fix.

## Beads

- Closes holomush-e49r.4
- Filed holomush-m88d (P3, separate follow-up: bound cache-resident Material plaintext lifetime via `Material.Zeroize` on cache eviction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure memory handling for cryptographic keys to enhance protection against potential memory-based security risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3830)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->