### PR TITLE
fix(test): race-free TestAcceptLoopReleasesSlotOnHandlerExit (holomush-rfzb)

### DIFF
--- a/cmd/holomush/gateway.go
+++ b/cmd/holomush/gateway.go
@@ -422,6 +422,27 @@ func (b *acceptBackoff) wait() time.Duration {
 	return b.current
 }
 
+// acceptLoopHooks bundles test-only observability seams. Production callers
+// pass no options; tests use withOnSlotReleased to receive a deterministic
+// signal when a handler goroutine exits and frees its semaphore slot.
+//
+// Without this seam, tests must poll the `telnet.ConnectionsActive` Prometheus
+// gauge with `require.Eventually`, which is timing-sensitive under CI
+// contention (handler.Handle's deadline-driven exit + goroutine scheduling +
+// gauge propagation can together exceed a 2s ceiling on a busy runner — see
+// bead holomush-rfzb).
+type acceptLoopHooks struct {
+	onSlotReleased func()
+}
+
+type acceptLoopOption func(*acceptLoopHooks)
+
+// withOnSlotReleased sets a callback fired after the handler goroutine
+// drains its slot and decrements the active-connections gauge. Test-only.
+func withOnSlotReleased(cb func()) acceptLoopOption {
+	return func(h *acceptLoopHooks) { h.onSlotReleased = cb }
+}
+
 // runTelnetAcceptLoop accepts telnet connections with exponential backoff on errors.
 // slots bounds the number of concurrent handler goroutines; a full slots channel
 // triggers immediate refusal via RefuseOverCapacity. The cancel function is called
@@ -433,7 +454,13 @@ func runTelnetAcceptLoop(
 	cancel func(),
 	slots chan struct{},
 	limits telnet.Limits,
+	opts ...acceptLoopOption,
 ) {
+	var hooks acceptLoopHooks
+	for _, opt := range opts {
+		opt(&hooks)
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error(
@@ -479,6 +506,9 @@ func runTelnetAcceptLoop(
 				defer func() {
 					<-slots
 					telnet.DecConnectionsActive()
+					if hooks.onSlotReleased != nil {
+						hooks.onSlotReleased()
+					}
 				}()
 				handler.Handle(ctx)
 			}()

--- a/cmd/holomush/gateway_test.go
+++ b/cmd/holomush/gateway_test.go
@@ -974,6 +974,13 @@ func TestAcceptLoopRefusesAtCapacity(t *testing.T) {
 // TestAcceptLoopReleasesSlotOnHandlerExit verifies that when a handler
 // goroutine exits, its slot is released back to the semaphore so later
 // accepts can proceed.
+//
+// Slot-release is observed via the production-supplied withOnSlotReleased
+// test hook (a deterministic channel signal) rather than polling the
+// telnet.ConnectionsActive Prometheus gauge with require.Eventually. The
+// gauge-polling variant was flaky under CI contention because handler exit
+// is event-driven (deadline expiry + goroutine scheduling) and a 2s polling
+// ceiling is borderline on slow runners. See bead holomush-rfzb.
 func TestAcceptLoopReleasesSlotOnHandlerExit(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -988,9 +995,20 @@ func TestAcceptLoopReleasesSlotOnHandlerExit(t *testing.T) {
 
 	slots := make(chan struct{}, 1)
 
+	// Buffered to absorb the release signal even if the test goroutine is
+	// not yet receiving when the deferred onSlotReleased fires.
+	released := make(chan struct{}, 4)
+
 	loopDone := make(chan struct{})
 	go func() {
-		runTelnetAcceptLoop(ctx, ln, &mockGRPCClient{}, cancel, slots, limits)
+		runTelnetAcceptLoop(ctx, ln, &mockGRPCClient{}, cancel, slots, limits,
+			withOnSlotReleased(func() {
+				select {
+				case released <- struct{}{}:
+				default:
+				}
+			}),
+		)
 		close(loopDone)
 	}()
 
@@ -999,19 +1017,27 @@ func TestAcceptLoopReleasesSlotOnHandlerExit(t *testing.T) {
 	require.NoError(t, err)
 	_ = c.Close()
 
-	// Wait for slot to free.
-	require.Eventually(t, func() bool {
-		return testutil.ToFloat64(telnet.ConnectionsActive) == 0
-	}, 2*time.Second, 10*time.Millisecond)
+	// Wait deterministically for the handler to exit and free its slot.
+	// 10s is the worst-case CI-runner timeout; under normal load this fires
+	// within tens of milliseconds (handler hits IdleReadTimeout=200ms above
+	// when it sees the closed peer).
+	select {
+	case <-released:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler did not release slot within 10s")
+	}
 
 	// Second connection MUST succeed (slot was freed).
 	c2, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
 	defer func() { _ = c2.Close() }()
 
+	// Slot-acquire path: dial returns once TCP handshake completes, and the
+	// accept loop's Inc fires shortly after. Polling the gauge is fine here
+	// (no event-vs-poll mismatch); generous ceiling for CI contention.
 	require.Eventually(t, func() bool {
 		return testutil.ToFloat64(telnet.ConnectionsActive) >= 1
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 10*time.Second, 10*time.Millisecond)
 
 	cancel()
 	_ = ln.Close()


### PR DESCRIPTION
## Summary

Replaces a polling `require.Eventually(... ConnectionsActive == 0, 2s)` with a deterministic channel signal from a new `acceptLoopHooks` test seam in `cmd/holomush/gateway.go`. Race-free; 20 iterations green; 1.75s total.

**Bead:** `holomush-rfzb` (filed when the flake surfaced on PR #3833's CI).

## Race named

Slot-release is **event-driven**: handler.Handle returns (deadline expiry + Go scheduler scheduling its return), then a deferred `<-slots; DecConnectionsActive` runs. The original test polled the `telnet.ConnectionsActive` Prometheus gauge with `require.Eventually(..., 2s)` — wrong tool for an event, with a borderline ceiling. Under CI contention this fails intermittently with `Condition never satisfied`.

Observed: PR #3833 Test job run 25868673268, `cmd/holomush TestAcceptLoopReleasesSlotOnHandlerExit (2.00s) Condition never satisfied`.

## Fix

- **Production code** (`cmd/holomush/gateway.go`): adds an unexported `acceptLoopHooks` struct + `withOnSlotReleased` functional option on `runTelnetAcceptLoop`. **Signature is variadic; production call sites pass no options; production behavior unchanged.**
- **Test** (`cmd/holomush/gateway_test.go`): passes `withOnSlotReleased(...)` that pushes to a buffered `released` channel from inside the handler-exit defer. Test then `<-released` with a 10s safety timeout (worst-case CI; normal load fires within tens of ms).
- **Slot-acquire side** (second `Eventually` waiting for `ConnectionsActive >= 1` after the next Dial) keeps gauge polling because it's not event-vs-poll mismatch (Dial returns once TCP handshake completes; Inc fires shortly after). Timeout bumped to 10s as defensive margin against CI contention.

## Test plan

- [x] `task test -- -race -count=20 -run TestAcceptLoopReleasesSlotOnHandlerExit ./cmd/holomush/` → 20/20 pass in 1.75s
- [x] `task test -- -race ./cmd/holomush/` → 504/504 pass
- [x] `task lint:go` → 0 issues
- [x] `task pr-prep` → ✓ All PR checks passed (full CI mirror, 62 e2e tests included)

## Out of scope

- The other `Eventually` in `TestAcceptLoopRefusesOverCapacity:951` (acquire-side, 2s ceiling) — not currently flaking, but the bumped acquire-side timeout pattern in this test could be a pattern for that one too if it ever fires. Filing as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced telnet connection handler synchronization testing for improved reliability and deterministic test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3835)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->