### PR TITLE
ci/pr-prep: drop duplicate steps (yp2t.6)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,9 +101,6 @@ jobs:
       - name: Check license headers
         run: task license:check
 
-      - name: Check access control migration
-        run: task lint:access-migration
-
       - name: Lint
         run: task lint
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -618,7 +618,6 @@ tasks:
       - echo "▸ Running bats shell tests..."
       - task: test:bats
       - echo "▸ Verifying schema is current..."
-      - task: generate:schema
       - cmd: |
           SCHEMA=schemas/plugin.schema.json
           BEFORE=$(sha256sum "$SCHEMA" | cut -d' ' -f1)


### PR DESCRIPTION
## Summary

Two small CI/pr-prep hygiene fixes captured during the yp2t docs-fast-lane audit. Net **-4 lines** across two files; each change independently reversible.

- **`ci.yaml` drop duplicate `Check access control migration` step:** `task lint:access-migration` already runs from inside `task lint` (the umbrella). The standalone CI step was duplicate work; ~5s saved per Lint job; coverage unchanged.
- **`Taskfile.yaml` drop redundant `generate:schema` task call in `pr-prep:run`:** the immediately-following `cmd:` block runs `go generate ./internal/plugin/` directly between `BEFORE`/`AFTER` `sha256sum` of `schemas/plugin.schema.json` — identical to what `generate:schema` does. The explicit task call above was pure noise.

## Reverted from initial PR scope

This PR was initially bundled with **yp2t.3** (move Build off integration+e2e critical path: `needs: [lint, test, integration, e2e]` → `[lint, test]`). On closer analysis, the original `needs:` chain was deliberate fail-fast resource management:

- GitHub Actions `needs:` blocks the dependent job when an upstream **fails**, not just on completion. So the original chain meant: Integration/E2E fail → Build SKIPPED → Build's ~1 min compute saved.
- The "Build feedback 5 min earlier" win materializes only when Build is the broken thing — rare, because Build is just `go build -tags realweb`.
- The cost (wasted Build runs on every Integration/E2E flake) is recurring and non-trivial.

Reverted; yp2t.3 stays open with the reflected analysis. Will re-evaluate if a `realweb`-only break pattern actually surfaces.

## Beads

- **`holomush-yp2t.6`** — closes on merge.
- **`holomush-yp2t.3`** — re-opened, NOT closed by this PR. Decision deferred per analysis above.

## Verification

- `task lint` ✓
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yaml` exit 0
- `task pr-prep` ✓ (pre-revert verified the full 834-line pipeline on the original diff; post-revert is strictly a superset since the dropped duplicate work was the only structural change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline to shorten build dependency chain and avoid unnecessary checks, speeding up merges.
  * Strengthened pre-merge verification to catch mismatches in generated schema artifacts early, preventing accidental changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3836)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->