### PR TITLE
perf(taskfile): cache plugin:build-all + dedup test:int build (yp2t.5)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -118,8 +118,7 @@ tasks:
   test:int:
     desc: Run integration tests (needs Docker for testcontainers)
     cmds:
-      - echo "▸ Building binary plugins for host platform..."
-      - GOOS={{OS}} GOARCH={{ARCH}} ./scripts/build-plugins.sh
+      - task: plugin:build-all
       # The explicit package list is load-bearing: `./...` under `-tags=integration`
       # tries to compile packages like `internal/grpc/` whose unit tests depend on
       # `core.NewMemoryEventStore` (a file with `//go:build !integration`), causing
@@ -140,8 +139,7 @@ tasks:
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)
     cmds:
-      - echo "▸ Building binary plugins for host platform..."
-      - GOOS={{OS}} GOARCH={{ARCH}} ./scripts/build-plugins.sh
+      - task: plugin:build-all
       - gotestsum --format pkgname -- -race -tags=integration -count=1 -timeout 8m github.com/holomush/holomush/test/integration/plugin
         {{.CLI_ARGS}}
 
@@ -238,6 +236,33 @@ tasks:
 
   plugin:build-all:
     desc: Discover and compile all binary plugins (host + linux/amd64 + linux/arm64)
+    # Sources cover the plugin tree, the SDK packages plugins import
+    # (pkg/plugin/**, pkg/proto/**), and the module manifest. pkg/proto
+    # catches `task proto` regenerations; pkg/plugin catches SDK changes;
+    # go.mod/go.sum catch dep bumps.
+    #
+    # NOT covered: internal/** — including it would invalidate the cache
+    # on most pr-prep iterations (internal/ changes frequently), defeating
+    # the whole optimization. Within pr-prep:run, an internal/** change
+    # that breaks plugin builds is caught downstream by `task lint` and
+    # `task test` (both re-compile plugin sources via go vet / go test)
+    # BEFORE `test:int` would exercise a stale subprocess binary.
+    # Direct `task test:int` invocations after an internal/** API change
+    # may run against a stale cached binary; if symptoms are confusing,
+    # `rm -rf build/plugins && task test:int` forces rebuild.
+    sources:
+      - plugins/**/*.go
+      - plugins/**/plugin.yaml
+      - plugins/**/migrations/**
+      - pkg/plugin/**/*.go
+      - pkg/proto/**/*.go
+      - scripts/build-plugins.sh
+      - go.mod
+      - go.sum
+    generates:
+      - build/plugins/*/plugin.yaml
+      - build/plugins/*/*-*/*
+      - build/plugins/*/migrations/**
     cmds:
       - ./scripts/build-plugins.sh
 


### PR DESCRIPTION
## Summary

Add go-task `sources:`/`generates:` gating to `plugin:build-all` so iterative `task pr-prep` runs skip the plugin cross-compile when plugin sources haven't changed. Also dedup the duplicate inline plugin builds in `test:int` and `test:int:focus`.

## Measured behavior

- **Cold:** 5.94s (builds 2 binary plugins × 3 platforms = 6 binaries: core-scenes + test-abac-widget across host + linux/amd64 + linux/arm64).
- **Warm:** 0.024s — `task: Task "plugin:build-all" is up to date`.
- **Content change** to any matched source file → all plugins rebuild.
- **`touch` alone doesn't invalidate** — default checksum method ignores mtime, which is the behavior we want (no spurious rebuilds from `git checkout` / `cp` / branch switches).
- **Within a single `pr-prep:run`:** `plugin:build-all` runs once cold, then the `test:int` and `test:int:focus` invocations (now via `task: plugin:build-all`) hit cache. Verified in the full pr-prep output:
  ```
  line 139: task: [plugin:build-all] ./scripts/build-plugins.sh   # cold
  line 361: task: Task "plugin:build-all" is up to date          # test:int hit
  line 414: task: Task "plugin:build-all" is up to date          # subsequent hit
  ```

The original bead estimated 30-60s saved per warm pr-prep; actual is ~6s because today there are only 2 binary plugins (vs 6+ at the time of the audit). Gating mechanism is the value regardless of current N.

## Changes

### 1. Cache `plugin:build-all`

```yaml
plugin:build-all:
  sources:
    - plugins/**/*.go
    - plugins/**/plugin.yaml
    - plugins/**/migrations/**
    - scripts/build-plugins.sh
    - go.mod
    - go.sum
  generates:
    - build/plugins/*/plugin.yaml
    - build/plugins/*/*-*/*
    - build/plugins/*/migrations/**
```

### 2. Dedup `test:int` / `test:int:focus` plugin builds

Replaced the inline `- GOOS={{OS}} GOARCH={{ARCH}} ./scripts/build-plugins.sh` (and its misleading `echo "Building binary plugins for host platform..."` banner) with `- task: plugin:build-all`. The `GOOS`/`GOARCH` env vars were dead code — `scripts/build-plugins.sh:27-30` hardcodes its platform matrix and ignores them. The banner was misleading because the script always built all 3 platforms.

## Correctness notes

`sources:` covers the plugin tree + `scripts/build-plugins.sh` + `go.mod`/`go.sum`. It does **NOT** cover host packages plugins import (`pkg/plugin/**`, `pkg/proto/**`, `internal/**`). Within `pr-prep:run` this is safe: `task lint` and `task test` re-compile plugin sources via golangci-lint's typechecker and `go test ./...`, surfacing any host-side API break BEFORE `test:int` would exercise a stale subprocess binary. Direct `task test:int` invocations after a host-side API change may run against a stale cached binary; if symptoms confuse, `rm -rf build/plugins && task test:int` forces rebuild. Documented in an inline comment alongside the task.

## Verification

- `task pr-prep` ✓ (755 lines of output, exit 0, "✓ All PR checks passed.")
- `task lint:yaml` ✓
- `task lint:actions` ✓
- Cold/warm/touch/modify cache behavior all match TDD acceptance criteria
- Adversarial code-reviewer pass ✓ READY (one medium-severity finding addressed inline; three low-severity non-blocking)

## Bead

- `holomush-yp2t.5` — closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored integration test build process to invoke plugin compilation via a centralized build task rather than running the build script inline, improving consistency and clarity of test builds.
  * Added source and artifact metadata to the plugin build task to enable caching awareness, reduce redundant builds, and speed up overall build cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3837)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->