### PR TITLE
ci+web: bats tests on CI + logout navigation race fix (yp2t.7 + zhjl)

### DIFF
--- a/.github/workflows/scripts-tests.yaml
+++ b/.github/workflows/scripts-tests.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - "scripts/**"
+      - "Taskfile.yaml"
+      - ".github/workflows/scripts-tests.yaml"
 
 permissions:
   contents: read
@@ -32,3 +34,44 @@ jobs:
         run: |-
           uv run --group dev ruff check .
           uv run --group dev ruff format --check .
+
+  bats:
+    name: Bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup bats + bats-support + bats-assert
+        # Installs bats + plugins. The action exposes the install location
+        # as the `lib-path` STEP OUTPUT (not as $GITHUB_ENV), so the
+        # subsequent run step wires it into BATS_LIB_PATH explicitly.
+        id: setup-bats
+        uses: bats-core/bats-action@4.0.0
+
+      - name: Install yq (mikefarah)
+        # Required by scripts/docs-paths-regex.sh + scripts/lint-docs-paths-sync.sh.
+        # Ubuntu's apt `yq` is the python kislyuk wrapper with different syntax;
+        # we need mikefarah's Go implementation. Pinned + SHA256-verified to
+        # match the project's ci.yaml install pattern.
+        run: |-
+          YQ_VERSION="v4.53.2"
+          YQ_SHA256="d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
+          YQ_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo curl -fsSL "${YQ_URL}" -o /usr/local/bin/yq
+          echo "${YQ_SHA256}  /usr/local/bin/yq" | sudo sha256sum -c -
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run bats
+        # Plumb the bats-action install path into BATS_LIB_PATH so
+        # `bats_load_library bats-support` / `bats-assert` resolve.
+        # Taskfile's test:bats respects an externally-set BATS_LIB_PATH.
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: task test:bats

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -207,12 +207,15 @@ tasks:
 
   test:bats:
     desc: Run bats shell tests under scripts/tests/
-    # bats_load_library searches BATS_LIB_PATH for bats-support/bats-assert.
-    # Cover macOS (Homebrew arm64+x86) and Linux (apt/manual install) paths.
-    env:
-      BATS_LIB_PATH: /opt/homebrew/lib:/usr/local/lib:/usr/lib
     cmds:
-      - bats scripts/tests/
+      # bats_load_library searches BATS_LIB_PATH for bats-support/bats-assert.
+      # Default covers macOS (Homebrew arm64+x86) and Linux (apt/manual install).
+      # Respect an externally-set BATS_LIB_PATH so CI workflows that install
+      # bats helpers to a custom location (e.g., bats-core/bats-action) work
+      # without requiring this default to match.
+      - cmd: |
+          BATS_LIB_PATH="${BATS_LIB_PATH:-/opt/homebrew/lib:/usr/local/lib:/usr/lib}" \
+            bats scripts/tests/
 
   test:bench:
     desc: Run benchmarks

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -22,6 +22,7 @@
   import { pushCommand } from '$lib/stores/commandHistoryStore';
   import * as Resizable from '$lib/components/ui/resizable';
   import { authState, clearAuth, clearCharacterSession } from '$lib/stores/authStore';
+  import { get } from 'svelte/store';
   import TerminalView from '$lib/components/terminal/TerminalView.svelte';
   import CommandInput from '$lib/components/terminal/CommandInput.svelte';
   import Rail from '$lib/components/terminal/Rail.svelte';
@@ -264,12 +265,20 @@
                   false,
                 );
               }
+              // If TopBar's logout already cleared player auth, that handler
+              // owns the navigation (to /). Skipping our own goto('/characters')
+              // here prevents a navigation race that strands the user on
+              // /characters with the (authed) layout's auth check still
+              // racing the server-side session teardown (zhjl).
+              const isLoggingOut = !get(authState).isPlayerAuthenticated;
               clearCharacterSession();
               connected = false;
               sessionId = '';
               rejectStreamReady(generation, new Error(ctrl.message || 'Stream closed'));
               setConnectionStatus('disconnected');
-              goto('/characters');
+              if (!isLoggingOut) {
+                goto('/characters');
+              }
               return;
             }
           } else if (response.frame.case === 'event') {


### PR DESCRIPTION
## Summary

Two bundled fixes captured during yp2t.7 implementation:

### yp2t.7 — Run bats shell tests in CI

`task test:bats` runs locally in `pr-prep:run` but no GitHub Actions workflow runs it. With yp2t.2's docs-only fast lane skipping bats on documentation PRs, regressions to the 44 bats cases (pr-prep-lock, pr-prep-docs-detection, docs-paths-regex, lint-docs-paths-sync) could reach main undetected.

**Changes:**
- `.github/workflows/scripts-tests.yaml` — new `bats` job alongside the existing Python `test` job. Uses `bats-core/bats-action@4.0.0` for bats install (plus `bats-support` / `bats-assert`), pins mikefarah's `yq v4.53.2` with SHA256 verification (matches the repo's curl-pin pattern in `ci.yaml`). Workflow trigger expanded from `paths: scripts/**` to also cover `Taskfile.yaml` and the workflow file itself (bats tests invoke task commands via the fixture mechanism).
- `Taskfile.yaml` — `test:bats` task: moved `BATS_LIB_PATH` from task-level `env:` (which overrides inherited env) into the `cmd:` body with bash defaulting (`${BATS_LIB_PATH:-...}`), so CI's `bats-core/bats-action`-set value (passed via `BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}`) is respected while local dev defaults still work.

**NOT** added to branch-protection required checks — bats stays advisory like the existing Python tests job. Required checks remain `Build`, `Lint`, `Test`, `CodeRabbit`.

### zhjl — Logout navigation race (P1 bug)

Discovered during yp2t.7's `pr-prep` E2E run: `character-switcher.spec.ts:70 → logout button navigates to home and clears session` was failing deterministically. Logout left the URL stuck at `/characters` with 401s instead of redirecting to `/`.

**Root cause** (commit message has the full timeline): navigation race between `TopBar.handleLogout`'s `goto('/')` and `terminal/+page.svelte`'s STREAM_CLOSED handler firing `goto('/characters')` when the server-side session teardown propagates back to the open `Subscribe` stream. The later `goto` wins; `/characters` is in the `(authed)` group but its layout's auth-check redirect doesn't beat Playwright's 10s URL-polling timeout.

**Fix:** in the STREAM_CLOSED handler, check `isPlayerAuthenticated` before issuing `goto('/characters')`. If auth was already cleared (i.e., user is logging out via TopBar), skip the redundant navigation — TopBar already owns it. ~10-line change.

**Why bundled with yp2t.7:** zhjl is unrelated to the bats CI work in scope, but it was strictly blocking yp2t.7's pr-prep gate and the fix is small + isolated. Per project convention (precedent: peercred follow-ups #3829, yp2t.3+yp2t.6 #3836), bundling multi-bead hygiene/fix PRs is acceptable when each change is independently reviewable.

## Verification

- `task lint` ✓ green
- `task test:bats` ✓ 44/44
- `task test:e2e -- --grep "logout button"` ✓ 1/1 in 1.9s (zhjl fix verified isolated)
- `task pr-prep` ✓ green end-to-end (752-line output, exit 0)
- `actionlint` ✓ + `yamlfmt -lint` ✓
- Adversarial code-reviewer pass on yp2t.7 was NOT READY before zhjl fix (E2E failure); the fix resolved the blocker

## Beads

- `holomush-yp2t.7` — closes on merge
- `holomush-zhjl` — closes on merge

## Test plan

- [ ] On merge, observe `Scripts Tests` workflow runs and the new `Bats tests` job is green.
- [ ] Open a follow-up draft PR that deliberately breaks a bats test → confirm the new job fails.
- [ ] Test the logout flow in a manual browser session — TopBar logout from `/terminal` lands on `/`, not `/characters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed terminal page behavior to properly handle logout state, preventing unnecessary navigation redirects when authentication is already cleared.

* **Chores**
  * Enhanced CI/CD workflow trigger configuration and updated test task execution setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3838)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->