### PR TITLE
fix(crypto/phase7): 4 P3 follow-ups post-merge polish

### DIFF
--- a/internal/eventbus/audit_row_access.go
+++ b/internal/eventbus/audit_row_access.go
@@ -38,6 +38,49 @@ func AuditRowOf(ev Event) *pluginauditpb.AuditRow {
 // Plugin-runtime symmetry: Lua and binary plugins that surface rows
 // via the same router both flow through here, so the field is stamped
 // uniformly regardless of plugin runtime.
+//
+// Unique-pointer contract: callers MUST pass a row pointer that is
+// uniquely owned by ev. Sharing a single *pluginauditpb.AuditRow
+// across multiple events causes Event.Refused to mutate all aliases
+// (the method nils auditRow.Payload through the shared pointer); the
+// production router satisfies this by allocating a fresh row per
+// gRPC Recv.
 func StampAuditRow(ev *Event, row *pluginauditpb.AuditRow) {
 	ev.auditRow = row
+}
+
+// Refused returns a metadata-only value-copy of e with the supplied
+// NoPlaintextReason stamped. Payload is cleared and — critically —
+// the embedded auditRow's Payload is also nilled so a future reader
+// of the row metadata via the proto field (e.g. an operator-read
+// classifier extending its inspection to plugin rows) cannot recover
+// the original cleartext. Diagnostic metadata (codec, dek_ref,
+// dek_version, etc.) is preserved on the auditRow.
+//
+// Aliasing note: the auditRow pointer is copied verbatim into the
+// returned value-copy, so nilling auditRow.Payload also strips the
+// proto field on the original e.auditRow. This is intentional given
+// the StampAuditRow unique-pointer contract — the row was freshly
+// allocated for this Event by the router, so no other Event aliases
+// it. Master spec INV-26 (refused row payload empty).
+//
+// Slice-header semantics: nilling Payload drops the slice header but
+// does not zero the underlying byte array. Concurrent readers that
+// captured a slice copy BEFORE the refusal still see the bytes; this
+// is acceptable because INV-26 governs proto-field reachability, not
+// GC-bounded in-memory residue.
+//
+// This method lives in package eventbus because auditRow is unexported;
+// callers in sibling packages (e.g. history.PluginDowngradeFence) MUST
+// use this single canonical "refuse" semantic rather than rolling their
+// own — keeps the invariant local to the field's owning package.
+func (e Event) Refused(reason NoPlaintextReason) Event {
+	refused := e
+	refused.MetadataOnly = true
+	refused.NoPlaintextReason = reason
+	refused.Payload = nil
+	if refused.auditRow != nil {
+		refused.auditRow.Payload = nil
+	}
+	return refused
 }

--- a/internal/eventbus/history/plugin_downgrade_fence.go
+++ b/internal/eventbus/history/plugin_downgrade_fence.go
@@ -238,10 +238,11 @@ func (s *fencedStream) Close() error {
 	return s.inner.Close()
 }
 
-// refuseEvent returns a copy of ev with the metadata-only stamp set
-// and the per-branch refusal reason. Critically operates on a value
-// copy (Event is a struct, not a pointer at internal/eventbus/types.go),
-// so mutating the returned copy does not affect any caller-held event.
+// refuseEvent wraps eventbus.Event.Refused with the fence's reason
+// taxonomy in one place. Delegates payload + auditRow.Payload clearing
+// to eventbus.Event.Refused, which is the canonical refusal semantic
+// (master spec INV-26: refused row payload empty — both Event.Payload
+// AND the embedded plugin-source-of-truth auditRow's Payload).
 //
 // The reason MUST distinguish the spec-mandated branches:
 //   - INV-P7-7 downgrade detected → NoPlaintextReasonDowngradeRefused
@@ -253,11 +254,7 @@ func (s *fencedStream) Close() error {
 //     (configuration failure — production wiring at E.3 always supplies a
 //     non-nil lookup; only test fakes hit this fail-closed branch).
 func refuseEvent(ev eventbus.Event, reason eventbus.NoPlaintextReason) eventbus.Event {
-	refused := ev
-	refused.MetadataOnly = true
-	refused.NoPlaintextReason = reason
-	refused.Payload = nil
-	return refused
+	return ev.Refused(reason)
 }
 
 // emitViolationBounded fires the INV-P7-7 audit emit synchronously

--- a/internal/eventbus/history/plugin_downgrade_fence_test.go
+++ b/internal/eventbus/history/plugin_downgrade_fence_test.go
@@ -344,6 +344,100 @@ func TestFenceRefusesAbsentDekRefForNonIdentityCodec(t *testing.T) {
 		"INV-P7-15 absent-dek_ref MUST report DEKMissing (Rekey-destroyed lookalike), NOT DowngradeRefused")
 }
 
+// TestFenceRefusalClearsEmbeddedAuditRowPayload — master spec INV-26
+// (refused row payload empty). Pre-1r0v.9, refuseEvent nilled the
+// outer Event.Payload but left the embedded *pluginauditpb.AuditRow
+// intact — the value-copied refused.auditRow still pointed at the
+// original row, which retained the plugin-supplied cleartext bytes.
+//
+// A future feature that surfaces auditRow metadata (e.g. operator-read
+// classifier extending its inspection to plugin rows) would silently
+// re-leak the cleartext. eventbus.Event.Refused now strips both the
+// outer Payload AND the embedded auditRow.Payload; this test gates
+// that contract end-to-end through the fence.
+func TestFenceRefusalClearsEmbeddedAuditRowPayload(t *testing.T) {
+	t.Parallel()
+
+	row := &pluginauditpb.AuditRow{
+		Id:      []byte("0123456789ABCDEF"),
+		Subject: "events.test.scene.01ABC.ic",
+		Type:    "test-plugin:secret",
+		Codec:   "identity",
+		Payload: []byte("malicious-cleartext-leak"),
+	}
+	stream := &fakeFenceStream{events: []eventbus.Event{stampedEvent(row)}}
+	fence := history.NewPluginDowngradeFence(
+		&fakeRouter{stream: stream},
+		history.WithAlwaysSensitiveTypes(sensitiveSet("test-plugin:secret")),
+		history.WithCryptoKeysLookup(&stubLookupAlwaysFound{}),
+		history.WithViolationEmitter(&recordingEmitter{}),
+	)
+
+	out, err := fence.QueryHistory(context.Background(), "test-plugin", eventbus.HistoryQuery{
+		Subject: "events.test.scene.01ABC.ic",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	ev, err := out.Next(context.Background())
+	require.NoError(t, err)
+	require.True(t, ev.MetadataOnly, "test precondition: row MUST have been refused")
+	require.Nil(t, ev.Payload, "outer Event.Payload MUST be nil on refusal")
+
+	embedded := eventbus.AuditRowOf(ev)
+	require.NotNil(t, embedded, "embedded auditRow MUST survive refusal (diagnostic metadata preserved)")
+	assert.Empty(t, embedded.GetPayload(),
+		"INV-26: refused row MUST NOT carry cleartext anywhere — embedded auditRow.Payload MUST be empty")
+	// Diagnostic metadata (codec) is intentionally preserved so an
+	// operator-read classifier can still see WHY the row was refused.
+	assert.Equal(t, "identity", embedded.GetCodec(),
+		"diagnostic metadata (codec) MUST survive refusal — only Payload is stripped")
+}
+
+// TestFenceFailsClosedWithNilCryptoKeysLookup — INV-P7-15 fail-closed
+// guard. Production wiring (E.3) always supplies a non-nil lookup, but
+// a future change to the default ("nil → refuse" to "nil → pass") would
+// silently weaken the fence. A non-identity codec + dek_ref-present row
+// fed through a fence built WITHOUT WithCryptoKeysLookup MUST be
+// refused with NoPlaintextReasonInternal (the configuration-failure
+// reason — distinct from DEKMissing, which is the legitimate
+// Rekey-destroyed case).
+func TestFenceFailsClosedWithNilCryptoKeysLookup(t *testing.T) {
+	t.Parallel()
+
+	dr := uint64(42)
+	dv := uint32(1)
+	row := &pluginauditpb.AuditRow{
+		Id:         []byte("0123456789ABCDEF"),
+		Subject:    "events.test.scene.01ABC.ic",
+		Type:       "test-plugin:secret",
+		Codec:      "xchacha20poly1305-v1",
+		Payload:    []byte("ciphertext"),
+		DekRef:     &dr,
+		DekVersion: &dv,
+	}
+	stream := &fakeFenceStream{events: []eventbus.Event{stampedEvent(row)}}
+	fence := history.NewPluginDowngradeFence(
+		&fakeRouter{stream: stream},
+		history.WithAlwaysSensitiveTypes(sensitiveSet("test-plugin:secret")),
+		// WithCryptoKeysLookup intentionally omitted — exercises
+		// the fail-closed branch at plugin_downgrade_fence.go.
+		history.WithViolationEmitter(&recordingEmitter{}),
+	)
+
+	out, err := fence.QueryHistory(context.Background(), "test-plugin", eventbus.HistoryQuery{
+		Subject: "events.test.scene.01ABC.ic",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+
+	ev, err := out.Next(context.Background())
+	require.NoError(t, err, "nil-lookup fail-closed MUST be per-row refusal, not stream-fatal")
+	assert.True(t, ev.MetadataOnly)
+	assert.Equal(t, eventbus.NoPlaintextReasonInternal, ev.NoPlaintextReason,
+		"nil cryptoKeysLookup is a configuration failure — MUST report Internal, NOT DEKMissing or DowngradeRefused")
+}
+
 // TestFenceForwardsCryptoKeysLookupError — INV-P7-15 error path. A
 // non-nil error from the crypto_keys lookup is infrastructure failure,
 // stream-fatal — distinguishes "DEK doesn't exist" (per-row refusal)

--- a/internal/eventbus/publisher_test.go
+++ b/internal/eventbus/publisher_test.go
@@ -302,6 +302,55 @@ func TestPublisherStampsAllRequiredHeaders(t *testing.T) {
 	require.NoError(t, d.Ack())
 }
 
+// TestPublisherTruncatesTimestampToMicrosecond gates INV-P7-16. The
+// publisher MUST truncate the event timestamp to microsecond precision
+// before marshaling, so AAD reconstruction at read time (which sees the
+// PG-TIMESTAMPTZ-truncated value) is byte-equal to encrypt-side AAD.
+//
+// Other tests (plugin_aad_reconstruction_test.go) mirror the truncation
+// locally because they exercise aad.Build directly. This test drives the
+// full publisher and inspects the on-wire envelope, so a future change
+// that removes the truncation at publisher.go fails HERE — the AAD tests
+// would still pass because they pre-truncate their input.
+func TestPublisherTruncatesTimestampToMicrosecond(t *testing.T) {
+	embedded := eventbustest.New(t)
+	pub := embedded.Bus.Publisher()
+	sub := embedded.Bus.Subscriber()
+
+	subject := eventbus.Subject("events.main.pub.truncate")
+	sessID := freshSessionID()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stream.Close() })
+
+	// Build an event whose nanosecond component carries sub-µs digits
+	// (the trailing "789"). The publisher MUST drop these; without the
+	// fix at publisher.go:202 the body envelope retains them and the
+	// assertion below fails.
+	ev := goodEvent(subject)
+	ev.Timestamp = time.Date(2026, 5, 14, 12, 34, 56, 123456789, time.UTC)
+	require.Equal(t, 789, ev.Timestamp.Nanosecond()%1000,
+		"test fixture sanity: pre-publish timestamp MUST carry sub-µs nanos")
+
+	require.NoError(t, pub.Publish(ctx, ev))
+
+	d, err := stream.Next(ctx)
+	require.NoError(t, err)
+	got := d.Event()
+	require.NoError(t, d.Ack())
+
+	// The actual gate: on-wire timestamp's nanosecond component is a
+	// multiple of 1000 (= no sub-µs precision). The full µs portion
+	// (123456 µs) is preserved.
+	assert.Zero(t, got.Timestamp.Nanosecond()%1000,
+		"INV-P7-16: publisher MUST truncate timestamp to microsecond precision before marshaling — sub-µs nanos leak otherwise")
+	assert.Equal(t, ev.Timestamp.Truncate(time.Microsecond), got.Timestamp.UTC(),
+		"publisher truncation MUST preserve the µs portion exactly, only dropping sub-µs digits")
+}
+
 func TestActorKindStringCoversAllVariants(t *testing.T) {
 	t.Parallel()
 	cases := map[eventbus.ActorKind]string{

--- a/plugins/core-scenes/audit.go
+++ b/plugins/core-scenes/audit.go
@@ -537,11 +537,13 @@ func actorProtoFromRow(kind string, id []byte) *eventbusv1.Actor {
 	}
 }
 
-// actorKindFromString maps the stored string back to the proto enum. The
-// host projection writes one of "character" / "system" / "plugin" via the
-// proto enum's String() method, so the reverse mapping is keyed the same
-// way. Unknown values fall through to ACTOR_KIND_UNSPECIFIED, matching
-// the spec's tolerance for publisher contract drift.
+// actorKindFromString maps the stored string back to the proto enum.
+// AuditEvent writes the enum's String() form (e.g. "ACTOR_KIND_PLAYER"),
+// while older or external publishers may write the lowercase variant
+// ("player"); both are accepted here so the read path round-trips every
+// kind the write path can produce. Unknown values fall through to
+// ACTOR_KIND_UNSPECIFIED, matching the spec's tolerance for publisher
+// contract drift.
 func actorKindFromString(s string) eventbusv1.ActorKind {
 	switch s {
 	case "ACTOR_KIND_CHARACTER", "character":
@@ -550,6 +552,8 @@ func actorKindFromString(s string) eventbusv1.ActorKind {
 		return eventbusv1.ActorKind_ACTOR_KIND_SYSTEM
 	case "ACTOR_KIND_PLUGIN", "plugin":
 		return eventbusv1.ActorKind_ACTOR_KIND_PLUGIN
+	case "ACTOR_KIND_PLAYER", "player":
+		return eventbusv1.ActorKind_ACTOR_KIND_PLAYER
 	default:
 		return eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED
 	}

--- a/plugins/core-scenes/audit_test.go
+++ b/plugins/core-scenes/audit_test.go
@@ -445,3 +445,81 @@ func TestAuditEventHappyPathPersistsViaStore(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, resp, "successful AuditEvent MUST return a non-nil response")
 }
+
+// TestActorKindFromStringCoversAllVariants gates the read-side mapping
+// against publisher contract drift: AuditEvent stores enum.String()
+// ("ACTOR_KIND_PLAYER"), while pre-spec writers used the lowercase form
+// ("player"). Both MUST round-trip to the same enum, and unknown values
+// MUST fall through to UNSPECIFIED per the spec's tolerance.
+func TestActorKindFromStringCoversAllVariants(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want eventbusv1.ActorKind
+	}{
+		{"ACTOR_KIND_UNSPECIFIED", eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED},
+		{"unspecified", eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED},
+		{"ACTOR_KIND_CHARACTER", eventbusv1.ActorKind_ACTOR_KIND_CHARACTER},
+		{"character", eventbusv1.ActorKind_ACTOR_KIND_CHARACTER},
+		{"ACTOR_KIND_SYSTEM", eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
+		{"system", eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
+		{"ACTOR_KIND_PLUGIN", eventbusv1.ActorKind_ACTOR_KIND_PLUGIN},
+		{"plugin", eventbusv1.ActorKind_ACTOR_KIND_PLUGIN},
+		{"ACTOR_KIND_PLAYER", eventbusv1.ActorKind_ACTOR_KIND_PLAYER},
+		{"player", eventbusv1.ActorKind_ACTOR_KIND_PLAYER},
+		{"", eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED},
+		{"garbage", eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, actorKindFromString(tc.in))
+		})
+	}
+}
+
+// TestQueryHistoryPreservesPlayerActorKind is the round-trip gate: a row
+// stored with the PLAYER enum's String() form MUST surface as
+// ACTOR_KIND_PLAYER on QueryHistory. Without the PLAYER case in
+// actorKindFromString this resolved to UNSPECIFIED, silently dropping
+// the attribution.
+func TestQueryHistoryPreservesPlayerActorKind(t *testing.T) {
+	sceneID := "01ABC000000000000000000000"
+	charIDStr := "01CHAR00000000000000000000"
+	charBytes := ulidStringBytes(t, charIDStr)
+	playerID := ulidStringBytes(t, "01PXAYER000000000000000000")
+
+	logStore := &fakeAuditStore{
+		rows: []logRow{
+			{
+				id:        ulidStringBytes(t, "01EVENT0000000000000000000"),
+				subject:   "events.main.scene." + sceneID + ".ic",
+				eventType: "scene.pose.posted",
+				timestamp: time.Unix(100, 0),
+				actorKind: eventbusv1.ActorKind_ACTOR_KIND_PLAYER.String(),
+				actorID:   playerID,
+			},
+		},
+	}
+	memberStore := &fakeAuditStore{
+		isMemberMap: map[string]bool{sceneID + "|" + charIDStr: true},
+	}
+
+	srv := &SceneAuditServer{store: logStore, memberLookup: memberStore}
+	stream := &fakeAuditServerStream{ctx: context.Background()}
+
+	err := srv.QueryHistory(&pluginv1.QueryHistoryRequest{
+		Subject: "events.main.scene." + sceneID + ".ic",
+		Caller: &eventbusv1.Actor{
+			Kind: eventbusv1.ActorKind_ACTOR_KIND_CHARACTER,
+			Id:   charBytes,
+		},
+	}, stream)
+
+	require.NoError(t, err)
+	require.Len(t, stream.sends, 1)
+	actor := stream.sends[0].GetRow().GetActor()
+	require.NotNil(t, actor, "PLAYER actor MUST survive read-back")
+	assert.Equal(t, eventbusv1.ActorKind_ACTOR_KIND_PLAYER, actor.GetKind())
+	assert.Equal(t, playerID, actor.GetId())
+}


### PR DESCRIPTION
## Summary

Four P3 follow-ups deferred from autofix rounds 1–4 on PR #3839 (Phase 7, merged 2026-05-14). None block production; each closes a real (mostly latent) defect or test-coverage gap. Single bundled PR per CLAUDE.md "skip the chain for small fixes."

- **holomush-1r0v.6** (BUG) — `actorKindFromString` in `plugins/core-scenes/audit.go` silently dropped PLAYER actor kind on `QueryHistory` round-trip. `AuditEvent` stores `enum.String()` form (`ACTOR_KIND_PLAYER`) but the reverse mapping had no case, returning UNSPECIFIED. Adds the missing case + table-driven coverage for all 5 enum variants in upper- and lowercase + a round-trip test through `fakeAuditStore`.

- **holomush-1r0v.8** — Tightens INV-P7-16 publisher truncation gate. The existing AAD-reconstruction tests mirror the truncation inline, so a future implementer who removes `publisher.go:202` would not be caught. New `TestPublisherTruncatesTimestampToMicrosecond` drives the full publisher path (sub-µs nanos in, µs-truncated nanos out via embedded JetStream + subscriber decode).

- **holomush-1r0v.9** (BUG) — Fence refusal leaked plugin-supplied cleartext via the embedded `*pluginauditpb.AuditRow`. Pre-fix, `refuseEvent` nilled the outer `Event.Payload` but the value-copied `refused.auditRow` still pointed at the original row whose Payload bytes were intact — a future feature reading row metadata could resurrect the cleartext. Adds `func (e Event) Refused(reason NoPlaintextReason) Event` in `package eventbus` as the single canonical refusal semantic (auditRow is unexported, so it MUST live in that package); fence's `refuseEvent` collapses to a one-line wrapper. Doc comment seals the unique-pointer / aliasing / slice-header semantics. Master spec INV-26.

- **holomush-1r0v.10** — Adds `TestFenceFailsClosedWithNilCryptoKeysLookup`. The fail-closed branch (`NewPluginDowngradeFence` without `WithCryptoKeysLookup` → non-identity row with `dek_ref` present → refused with `NoPlaintextReasonInternal`) was untested. An inadvertent flip of the default ('nil → refuse' to 'nil → pass') would now be caught.

## Pre-push gates

- ✅ `crypto-reviewer`: READY (3 NIT-level findings, 2 addressed via doc-comment tightening)
- ✅ `code-reviewer`: READY (4 low-severity non-blocking findings; ULID-fixture cosmetic nit fixed)
- ✅ `task pr-prep`: green (lint, format, schema, license, unit, integration, E2E 62 passed)

## Test plan

- [x] \`task test -- ./plugins/core-scenes/ ./internal/eventbus/...\` — 929 tests pass
- [x] \`task pr-prep\` — full pipeline green (62 E2E pass, no flakes)
- [x] Manual: PLAYER round-trip via new \`TestQueryHistoryPreservesPlayerActorKind\`
- [x] Manual: timestamp truncation gate via new \`TestPublisherTruncatesTimestampToMicrosecond\`
- [x] Manual: refused-row auditRow.Payload clearing via new \`TestFenceRefusalClearsEmbeddedAuditRowPayload\`
- [x] Manual: fail-closed nil-lookup branch via new \`TestFenceFailsClosedWithNilCryptoKeysLookup\`

## Out of scope

- 1r0v.11 (violationEmitter rewrap doc), 1r0v.12 (KEK-backed KeySelector), 1r0v.14 (Ginkgo conversion of \`eventbus_e2e\`) — deferred per the original scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for audit row payload handling and refused event behavior.
  * Added tests for actor-kind string parsing in audit logs.
  * Added verification test for timestamp truncation behavior.

* **Refactor**
  * Consolidated internal event refusal handling logic for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3842)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->