### PR TITLE
errutil(testing): widen Assert* helpers to testing.TB (1hq.26 A1)

### DIFF
--- a/pkg/errutil/testing.go
+++ b/pkg/errutil/testing.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AssertErrorCode asserts that err is an oops error with the given code.
-func AssertErrorCode(t *testing.T, err error, code string) {
+func AssertErrorCode(t testing.TB, err error, code string) {
 	t.Helper()
 	oopsErr, ok := oops.AsOops(err)
 	require.True(t, ok, "expected oops error, got %T", err)
@@ -20,7 +20,7 @@ func AssertErrorCode(t *testing.T, err error, code string) {
 }
 
 // AssertErrorContext asserts that err is an oops error with the given context key/value.
-func AssertErrorContext(t *testing.T, err error, key string, value any) {
+func AssertErrorContext(t testing.TB, err error, key string, value any) {
 	t.Helper()
 	oopsErr, ok := oops.AsOops(err)
 	require.True(t, ok, "expected oops error, got %T", err)


### PR DESCRIPTION
## Summary

Widens `errutil.AssertErrorCode` and `errutil.AssertErrorContext` from `*testing.T` to `testing.TB` so the same helpers work in Ginkgo specs (where `GinkgoT()` returns `ginkgo.FullGinkgoTInterface`, satisfying `testing.TB` but not the concrete `*testing.T`).

This is the prerequisite for `holomush-1hq.26` testify+ginkgo migration completion. Originally bundled with the `test/integration/auth/` conversion as task A1 of plan [`2026-05-15-testify-ginkgo-migration-completion-plan.md`](docs/superpowers/plans/2026-05-15-testify-ginkgo-migration-completion-plan.md). After audit, `test/integration/auth/core_client_shim_test.go` turned out to be a helper file with zero test functions (verified: `rg -c 'func Test|t.Run' test/integration/auth/core_client_shim_test.go` returns 0), so this PR ships only the widening.

A repo-wide audit of all 40 plan-scoped files identified one other helper misclassification (`test/integration/plugin/counting_proxy_test.go`, also zero test funcs). True conversion scope is 38 files, not 40 — to be reflected in subsequent stage beads.

## Compatibility

- `*testing.T` already satisfies `testing.TB`, so all 155 existing callers compile without source changes.
- testify's `require.*`/`assert.*` accept the narrower `TestingT` interface (subset of `testing.TB`), so behavior is unchanged.
- `t.Helper()` is on `testing.TB` — no shim needed.

Closes holomush-rccc.1. Part of holomush-1hq.26 / holomush-rccc Stage A.

## Test plan

- [x] `task build` — passes (compile check across all callers)
- [x] `task test -- ./pkg/errutil/...` — 6 tests green
- [x] `task pr-prep` — full pipeline green (lint, format, schema, license, unit, integration, E2E)
- [x] code-reviewer — READY verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Testing utilities now support a broader range of testing contexts, improving compatibility across different testing scenarios and implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->