### PR TITLE
test(integration/plugin): migrate 3 files to Ginkgo (1hq.26 A2)

### DIFF
--- a/internal/eventbus/history/phase7_boundary_meta_test.go
+++ b/internal/eventbus/history/phase7_boundary_meta_test.go
@@ -50,7 +50,13 @@ func TestPhase7InvariantsHaveNamedTests(t *testing.T) {
 		testName string
 	}{
 		{"INV-P7-1", "TestDispatchForwardsCiphertextByteEqual"},
-		{"INV-P7-3", "TestSceneLogHasDekColumns"},
+		// INV-P7-3 was carried by func TestSceneLogHasDekColumns until the
+		// 1hq.26 testify+ginkgo migration converted the spec to a Ginkgo
+		// Describe registered under the suite entry TestBinaryPlugin (see
+		// test/integration/plugin/plugin_migration_test.go). The spec name
+		// "Scene log has DEK columns (INV-P7-3)" remains greppable inside
+		// that file for invariant traceability.
+		{"INV-P7-3", "TestBinaryPlugin"},
 		{"INV-P7-4", "TestAuditRowStructMirrorsProto"},
 		{"INV-P7-5", "TestAuditRowRoundTripPreservesAllFields"},
 		{"INV-P7-6", "TestSceneLogPreservesCiphertextAndAuditHeaders"},

--- a/internal/eventbus/history/phase7_boundary_meta_test.go
+++ b/internal/eventbus/history/phase7_boundary_meta_test.go
@@ -66,7 +66,14 @@ func TestPhase7InvariantsHaveNamedTests(t *testing.T) {
 		// INV-P7-12 shares its named test with INV-P7-6 (one round-trip
 		// covers both cleartext-vs-ciphertext invariants).
 		{"INV-P7-12", "TestSceneLogPreservesCiphertextAndAuditHeaders"},
-		{"INV-P7-13", "TestPluginRoleCannotWriteHostTables"},
+		// INV-P7-13 was carried by func TestPluginRoleCannotWriteHostTables
+		// until the 1hq.26 testify+ginkgo migration converted the spec to a
+		// Ginkgo Describe registered under the suite entry TestBinaryPlugin
+		// (see test/integration/plugin/plugin_role_permissions_test.go).
+		// The meta-test maps to the suite entry — the spec name "Plugin role
+		// cannot write host tables (INV-P7-13)" remains greppable inside
+		// that file for invariant traceability.
+		{"INV-P7-13", "TestBinaryPlugin"},
 		{"INV-P7-15", "TestFenceRefusesUnknownDekRef"},
 		{"INV-P7-16", "TestRoundTripProducesByteEqualAAD"},
 	}

--- a/test/integration/plugin/plugin_migration_test.go
+++ b/test/integration/plugin/plugin_migration_test.go
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/test/testutil"
@@ -91,8 +92,7 @@ func applyPluginMigrationN(t *testing.T, pool *pgxpool.Pool, dir, schema string,
 // hand-offs). The pool is bound to t.Cleanup.
 func pluginMigrationPool(t *testing.T, schema string) *pgxpool.Pool {
 	t.Helper()
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.FreshDatabase(t, shared)
+	connStr := testutil.FreshDatabase(t, sharedPG)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	pool, err := pgxpool.New(ctx, connStr)
@@ -103,7 +103,7 @@ func pluginMigrationPool(t *testing.T, schema string) *pgxpool.Pool {
 	return pool
 }
 
-// listScenLogColumns enumerates dek_ref / dek_version columns in the
+// listSceneLogDekColumns enumerates dek_ref / dek_version columns in the
 // given schema's scene_log table.
 func listSceneLogDekColumns(t *testing.T, pool *pgxpool.Pool, schema string) []string {
 	t.Helper()
@@ -125,69 +125,78 @@ func listSceneLogDekColumns(t *testing.T, pool *pgxpool.Pool, schema string) []s
 	return present
 }
 
-// TestPhase7PluginMigrationStandalone — INV-P7-3 + INV-P7-10. Verifies
+// Phase 7 plugin migration standalone — INV-P7-3 + INV-P7-10. Verifies
 // that migration 000005 adds dek_ref + dek_version on top of the
 // pre-existing migrations 1-4 in isolation, and that re-applying it is
 // a no-op (idempotency via ADD COLUMN IF NOT EXISTS).
-func TestPhase7PluginMigrationStandalone(t *testing.T) {
-	const schema = "plugin_core_scenes_test"
-	pool := pluginMigrationPool(t, schema)
+var _ = Describe("Phase 7 plugin migration standalone (INV-P7-3, INV-P7-10)", func() {
+	It("adds dek_ref + dek_version on migration 5 and is idempotent", func() {
+		const schema = "plugin_core_scenes_test"
+		pool := pluginMigrationPool(suiteT, schema)
 
-	// Apply migrations 1..4 (existing baseline).
-	applyPluginMigrationsUpTo(t, pool, migrationsDirCoreScenes, schema, 4)
+		// Apply migrations 1..4 (existing baseline).
+		applyPluginMigrationsUpTo(suiteT, pool, migrationsDirCoreScenes, schema, 4)
 
-	// Pre-condition: dek columns NOT present after 1-4.
-	preFive := listSceneLogDekColumns(t, pool, schema)
-	require.Empty(t, preFive,
-		"dek_ref/dek_version MUST NOT exist before migration 000005")
+		// Pre-condition: dek columns NOT present after 1-4.
+		preFive := listSceneLogDekColumns(suiteT, pool, schema)
+		Expect(preFive).To(BeEmpty(),
+			"dek_ref/dek_version MUST NOT exist before migration 000005")
 
-	// Apply migration 5 in isolation.
-	applyPluginMigrationN(t, pool, migrationsDirCoreScenes, schema, 5)
+		// Apply migration 5 in isolation.
+		applyPluginMigrationN(suiteT, pool, migrationsDirCoreScenes, schema, 5)
 
-	got := listSceneLogDekColumns(t, pool, schema)
-	assert.Equal(t, []string{"dek_ref", "dek_version"}, got,
-		"INV-P7-3: scene_log MUST have dek_ref + dek_version after migration 5")
+		got := listSceneLogDekColumns(suiteT, pool, schema)
+		Expect(got).To(Equal([]string{"dek_ref", "dek_version"}),
+			"INV-P7-3: scene_log MUST have dek_ref + dek_version after migration 5")
 
-	// Idempotency: re-applying migration 5 is a no-op (CREATE INDEX IF
-	// NOT EXISTS + ADD COLUMN IF NOT EXISTS).
-	applyPluginMigrationN(t, pool, migrationsDirCoreScenes, schema, 5)
-	got = listSceneLogDekColumns(t, pool, schema)
-	assert.Equal(t, []string{"dek_ref", "dek_version"}, got,
-		"INV-P7-10: re-applying migration 5 MUST be idempotent")
-}
+		// Idempotency: re-applying migration 5 is a no-op (CREATE INDEX IF
+		// NOT EXISTS + ADD COLUMN IF NOT EXISTS).
+		applyPluginMigrationN(suiteT, pool, migrationsDirCoreScenes, schema, 5)
+		got = listSceneLogDekColumns(suiteT, pool, schema)
+		Expect(got).To(Equal([]string{"dek_ref", "dek_version"}),
+			"INV-P7-10: re-applying migration 5 MUST be idempotent")
+	})
+})
 
-// TestSceneLogHasDekColumns — production-shape assertion: after the
-// FULL plugin migration sequence (1..N), scene_log carries both columns
-// with the expected SQL types (BIGINT for dek_ref, INTEGER for dek_version).
-func TestSceneLogHasDekColumns(t *testing.T) {
-	const schema = "plugin_core_scenes_full"
-	pool := pluginMigrationPool(t, schema)
+// Scene log dek columns — production-shape assertion: after the FULL
+// plugin migration sequence (1..N), scene_log carries both columns with
+// the expected SQL types (BIGINT for dek_ref, INTEGER for dek_version).
+//
+// INV-P7-3 cross-reference: this spec is the named carrier for the
+// invariant; the phase7_boundary_meta_test.go drift detector maps the
+// invariant to the suite entry TestBinaryPlugin (Ginkgo Describes are
+// not top-level *testing.T funcs).
+var _ = Describe("Scene log has DEK columns (INV-P7-3)", func() {
+	It("has bigint dek_ref + integer dek_version after full migration sequence", func() {
+		const schema = "plugin_core_scenes_full"
+		pool := pluginMigrationPool(suiteT, schema)
 
-	// Discover the highest migration number present and apply through it.
-	matches, err := filepath.Glob(filepath.Join(migrationsDirCoreScenes, "*.up.sql"))
-	require.NoError(t, err)
-	require.NotEmpty(t, matches)
-	sort.Strings(matches)
-	highest := len(matches)
-	// Sanity: filename ordering matches numeric ordering for these
-	// migrations (zero-padded 6 digits).
-	last := filepath.Base(matches[len(matches)-1])
-	require.Truef(t, strings.HasPrefix(last, fmt.Sprintf("%06d_", highest)),
-		"migration filename ordering MUST be sequential — got %s as highest of %d", last, highest)
+		// Discover the highest migration number present and apply through it.
+		matches, err := filepath.Glob(filepath.Join(migrationsDirCoreScenes, "*.up.sql"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matches).NotTo(BeEmpty())
+		sort.Strings(matches)
+		highest := len(matches)
+		// Sanity: filename ordering matches numeric ordering for these
+		// migrations (zero-padded 6 digits).
+		last := filepath.Base(matches[len(matches)-1])
+		Expect(strings.HasPrefix(last, fmt.Sprintf("%06d_", highest))).To(BeTrue(),
+			"migration filename ordering MUST be sequential — got %s as highest of %d", last, highest)
 
-	applyPluginMigrationsUpTo(t, pool, migrationsDirCoreScenes, schema, highest)
+		applyPluginMigrationsUpTo(suiteT, pool, migrationsDirCoreScenes, schema, highest)
 
-	var dekRefType, dekVersionType string
-	require.NoError(t, pool.QueryRow(t.Context(), `
-		SELECT data_type FROM information_schema.columns
-		WHERE table_schema = $1
-		  AND table_name = 'scene_log'
-		  AND column_name = 'dek_ref'`, schema).Scan(&dekRefType))
-	require.NoError(t, pool.QueryRow(t.Context(), `
-		SELECT data_type FROM information_schema.columns
-		WHERE table_schema = $1
-		  AND table_name = 'scene_log'
-		  AND column_name = 'dek_version'`, schema).Scan(&dekVersionType))
-	assert.Equal(t, "bigint", dekRefType)
-	assert.Equal(t, "integer", dekVersionType)
-}
+		var dekRefType, dekVersionType string
+		Expect(pool.QueryRow(suiteT.Context(), `
+			SELECT data_type FROM information_schema.columns
+			WHERE table_schema = $1
+			  AND table_name = 'scene_log'
+			  AND column_name = 'dek_ref'`, schema).Scan(&dekRefType)).NotTo(HaveOccurred())
+		Expect(pool.QueryRow(suiteT.Context(), `
+			SELECT data_type FROM information_schema.columns
+			WHERE table_schema = $1
+			  AND table_name = 'scene_log'
+			  AND column_name = 'dek_version'`, schema).Scan(&dekVersionType)).NotTo(HaveOccurred())
+		Expect(dekRefType).To(Equal("bigint"))
+		Expect(dekVersionType).To(Equal("integer"))
+	})
+})

--- a/test/integration/plugin/plugin_role_permissions_test.go
+++ b/test/integration/plugin/plugin_role_permissions_test.go
@@ -8,17 +8,16 @@ package plugin_test
 import (
 	"context"
 	"strings"
-	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// TestPluginRoleCannotWriteHostTables — INV-P7-13.
+// Plugin role permissions — INV-P7-13.
 //
 // The plugin role provisioned by SchemaProvisioner.ProvisionSchema
 // (internal/plugin/schema_provisioner.go) is granted USAGE+CREATE on its
@@ -27,51 +26,58 @@ import (
 // crypto_keys, etc.) — any attempt MUST fail with PostgreSQL "permission
 // denied" before the row is inserted.
 //
-// This test pins the regression: it provisions a fresh per-plugin role,
+// This spec pins the regression: it provisions a fresh per-plugin role,
 // opens a pool as that role, and asserts an INSERT into events_audit is
 // rejected with permission-denied. The substrate has been in place since
-// schema_provisioner's introduction; this test is the explicit cross-
+// schema_provisioner's introduction; this spec is the explicit cross-
 // cutting check that Phase 7 can rely on it.
-func TestPluginRoleCannotWriteHostTables(t *testing.T) {
-	ctx := context.Background()
+//
+// INV-P7-13 cross-reference: this spec is the named carrier for the
+// invariant; the phase7_boundary_meta_test.go drift detector maps the
+// invariant to the suite entry func TestBinaryPlugin (Ginkgo Describes are
+// not top-level *testing.T funcs).
+var _ = Describe("Plugin role cannot write host tables (INV-P7-13)", func() {
+	It("denies INSERT on host-owned events_audit", func() {
+		ctx := context.Background()
 
-	// FreshDatabase runs the migration template, which includes
-	// 000009_create_events_audit. The connection string uses the holomush
-	// role which has CREATEROLE — required for SchemaProvisioner.Init.
-	connStr := testutil.FreshDatabase(t, testutil.SharedPostgres(t))
+		// FreshDatabase runs the migration template, which includes
+		// 000009_create_events_audit. The connection string uses the holomush
+		// role which has CREATEROLE — required for SchemaProvisioner.Init.
+		connStr := testutil.FreshDatabase(suiteT, sharedPG)
 
-	provisioner := plugins.NewSchemaProvisioner(connStr)
-	require.NoError(t, provisioner.Init(ctx))
-	defer provisioner.Close()
+		provisioner := plugins.NewSchemaProvisioner(connStr)
+		Expect(provisioner.Init(ctx)).NotTo(HaveOccurred())
+		defer provisioner.Close()
 
-	pluginConnStr, err := provisioner.ProvisionSchema(ctx, "test-perm-check")
-	require.NoError(t, err)
+		pluginConnStr, err := provisioner.ProvisionSchema(ctx, "test-perm-check")
+		Expect(err).NotTo(HaveOccurred())
 
-	pluginPool, err := pgxpool.New(ctx, pluginConnStr)
-	require.NoError(t, err)
-	defer pluginPool.Close()
+		pluginPool, err := pgxpool.New(ctx, pluginConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer pluginPool.Close()
 
-	// INV-P7-13: plugin role MUST NOT be able to INSERT into events_audit.
-	//
-	// Schema-qualify the name (public.events_audit) so Postgres surfaces a
-	// permission error rather than the search_path-dependent "relation
-	// does not exist" — the plugin role's search_path does not include
-	// schema public (USAGE was revoked at schema_provisioner.go:165), so
-	// the unqualified name resolves to nothing visible.
-	//
-	// We need a 16-byte ULID-shaped id (events_audit.id is BYTEA NOT NULL).
-	// The Postgres '\x...' bytea literal makes the value explicit.
-	_, err = pluginPool.Exec(ctx, `
-		INSERT INTO public.events_audit (id, subject, type, timestamp, actor_kind, envelope, schema_ver, codec)
-		VALUES ('\x0123456789ABCDEF0123456789ABCDEF', 'events.test.x', 'y', now(), 'system', '\x', 1, 'identity')`)
-	require.Error(t, err, "INV-P7-13: plugin role MUST be denied INSERT on host-owned events_audit")
+		// INV-P7-13: plugin role MUST NOT be able to INSERT into events_audit.
+		//
+		// Schema-qualify the name (public.events_audit) so Postgres surfaces a
+		// permission error rather than the search_path-dependent "relation
+		// does not exist" — the plugin role's search_path does not include
+		// schema public (USAGE was revoked at schema_provisioner.go:165), so
+		// the unqualified name resolves to nothing visible.
+		//
+		// We need a 16-byte ULID-shaped id (events_audit.id is BYTEA NOT NULL).
+		// The Postgres '\x...' bytea literal makes the value explicit.
+		_, err = pluginPool.Exec(ctx, `
+			INSERT INTO public.events_audit (id, subject, type, timestamp, actor_kind, envelope, schema_ver, codec)
+			VALUES ('\x0123456789ABCDEF0123456789ABCDEF', 'events.test.x', 'y', now(), 'system', '\x', 1, 'identity')`)
+		Expect(err).To(HaveOccurred(), "INV-P7-13: plugin role MUST be denied INSERT on host-owned events_audit")
 
-	// The substrate revokes USAGE on schema public from the plugin role
-	// (schema_provisioner.go:165). Postgres surfaces this as
-	// "permission denied for schema public" before it ever evaluates the
-	// table-level INSERT privilege — the schema-USAGE check is the gate
-	// that fails first. Either error wording (schema public OR table
-	// events_audit) satisfies INV-P7-13; assert the shared substring.
-	assert.True(t, strings.Contains(strings.ToLower(err.Error()), "permission denied"),
-		"INV-P7-13: error MUST be a permission-denied (got: %v)", err)
-}
+		// The substrate revokes USAGE on schema public from the plugin role
+		// (schema_provisioner.go:165). Postgres surfaces this as
+		// "permission denied for schema public" before it ever evaluates the
+		// table-level INSERT privilege — the schema-USAGE check is the gate
+		// that fails first. Either error wording (schema public OR table
+		// events_audit) satisfies INV-P7-13; assert the shared substring.
+		Expect(strings.Contains(strings.ToLower(err.Error()), "permission denied")).To(BeTrue(),
+			"INV-P7-13: error MUST be a permission-denied (got: %v)", err)
+	})
+})

--- a/test/integration/plugin/schema_isolation_test.go
+++ b/test/integration/plugin/schema_isolation_test.go
@@ -80,6 +80,12 @@ var _ = Describe("Schema isolation: SchemaProvisioner role + schema lifecycle", 
 		Expect(err).NotTo(HaveOccurred())
 		defer adminConn.Close(ctx)
 
+		// Defensive: drop any stale role from a prior run. Postgres roles
+		// are cluster-level, and a testcontainers reuse-mode container
+		// would otherwise carry this role across `task test:int` runs and
+		// fail the CREATE with "role already exists".
+		_, err = adminConn.Exec(ctx, "DROP ROLE IF EXISTS restricted")
+		Expect(err).NotTo(HaveOccurred())
 		_, err = adminConn.Exec(ctx, "CREATE ROLE restricted LOGIN PASSWORD 'restricted'")
 		Expect(err).NotTo(HaveOccurred())
 		adminConn.Close(ctx)

--- a/test/integration/plugin/schema_isolation_test.go
+++ b/test/integration/plugin/schema_isolation_test.go
@@ -14,7 +14,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"github.com/stretchr/testify/require"
 
 	plugins "github.com/holomush/holomush/internal/plugin"
@@ -35,8 +36,7 @@ func replaceUser(t *testing.T, connStr, user, password string) string {
 // superuser connection strings.
 func setupSchemaTestDB(t *testing.T) (holomushConnStr, adminConnStr string) {
 	t.Helper()
-	shared := testutil.SharedPostgres(t)
-	adminConnStr = testutil.RawDatabase(t, shared)
+	adminConnStr = testutil.RawDatabase(t, sharedPG)
 
 	ctx := context.Background()
 	conn, err := pgx.Connect(ctx, adminConnStr)
@@ -69,266 +69,280 @@ func ddlGrantToHolomush(dbName string) string {
 	return fmt.Sprintf("GRANT ALL ON DATABASE %s TO holomush", dbName)
 }
 
-func TestSchemaProvisionerInitFailsWithoutCreaterole(t *testing.T) {
-	ctx := context.Background()
+var _ = Describe("Schema isolation: SchemaProvisioner role + schema lifecycle", func() {
+	It("Init fails without CREATEROLE", func() {
+		ctx := context.Background()
 
-	_, adminConnStr := setupSchemaTestDB(t)
+		_, adminConnStr := setupSchemaTestDB(suiteT)
 
-	// Create a restricted role WITHOUT CREATEROLE.
-	adminConn, err := pgx.Connect(ctx, adminConnStr)
-	require.NoError(t, err)
-	defer adminConn.Close(ctx)
+		// Create a restricted role WITHOUT CREATEROLE.
+		adminConn, err := pgx.Connect(ctx, adminConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer adminConn.Close(ctx)
 
-	_, err = adminConn.Exec(ctx, "CREATE ROLE restricted LOGIN PASSWORD 'restricted'")
-	require.NoError(t, err)
-	adminConn.Close(ctx)
+		_, err = adminConn.Exec(ctx, "CREATE ROLE restricted LOGIN PASSWORD 'restricted'")
+		Expect(err).NotTo(HaveOccurred())
+		adminConn.Close(ctx)
 
-	restrictedConnStr := replaceUser(t, adminConnStr, "restricted", "restricted")
+		restrictedConnStr := replaceUser(suiteT, adminConnStr, "restricted", "restricted")
 
-	sp := plugins.NewSchemaProvisioner(restrictedConnStr)
-	defer sp.Close()
+		sp := plugins.NewSchemaProvisioner(restrictedConnStr)
+		defer sp.Close()
 
-	err = sp.Init(ctx)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCHEMA_INSUFFICIENT_PRIVILEGES")
-}
+		err = sp.Init(ctx)
+		Expect(err).To(HaveOccurred())
+		errutil.AssertErrorCode(suiteT, err, "SCHEMA_INSUFFICIENT_PRIVILEGES")
+	})
 
-func TestSchemaProvisionerInitSucceedsWithCreaterole(t *testing.T) {
-	ctx := context.Background()
+	It("Init succeeds with CREATEROLE", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
 
-	err := sp.Init(ctx)
-	require.NoError(t, err)
-}
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
+	})
 
-func TestProvisionSchemaCreatesRoleAndSchema(t *testing.T) {
-	ctx := context.Background()
+	It("ProvisionSchema creates role and schema with expected properties", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	_, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		_, err := sp.ProvisionSchema(ctx, "test-plugin")
+		Expect(err).NotTo(HaveOccurred())
 
-	// Verify role properties.
-	pool, err := pgxpool.New(ctx, holomushConnStr)
-	require.NoError(t, err)
-	defer pool.Close()
+		// Verify role properties.
+		pool, err := pgxpool.New(ctx, holomushConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer pool.Close()
 
-	var canLogin, isSuperuser, canCreaterole bool
-	err = pool.QueryRow(
-		ctx,
-		"SELECT rolcanlogin, rolsuper, rolcreaterole FROM pg_roles WHERE rolname = $1",
-		"holomush_plugin_test_plugin",
-	).Scan(&canLogin, &isSuperuser, &canCreaterole)
-	require.NoError(t, err)
-	assert.True(t, canLogin, "plugin role should have LOGIN")
-	assert.False(t, isSuperuser, "plugin role must not be superuser")
-	assert.False(t, canCreaterole, "plugin role must not have CREATEROLE")
+		var canLogin, isSuperuser, canCreaterole bool
+		err = pool.QueryRow(
+			ctx,
+			"SELECT rolcanlogin, rolsuper, rolcreaterole FROM pg_roles WHERE rolname = $1",
+			"holomush_plugin_test_plugin",
+		).Scan(&canLogin, &isSuperuser, &canCreaterole)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(canLogin).To(BeTrue(), "plugin role should have LOGIN")
+		Expect(isSuperuser).To(BeFalse(), "plugin role must not be superuser")
+		Expect(canCreaterole).To(BeFalse(), "plugin role must not have CREATEROLE")
 
-	// Verify schema ownership.
-	var schemaOwner string
-	err = pool.QueryRow(
-		ctx, `
-		SELECT r.rolname
-		FROM pg_namespace n
-		JOIN pg_roles r ON n.nspowner = r.oid
-		WHERE n.nspname = $1`,
-		"plugin_test_plugin",
-	).Scan(&schemaOwner)
-	require.NoError(t, err)
-	assert.Equal(t, "holomush_plugin_test_plugin", schemaOwner)
-}
+		// Verify schema ownership.
+		var schemaOwner string
+		err = pool.QueryRow(
+			ctx, `
+			SELECT r.rolname
+			FROM pg_namespace n
+			JOIN pg_roles r ON n.nspowner = r.oid
+			WHERE n.nspname = $1`,
+			"plugin_test_plugin",
+		).Scan(&schemaOwner)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schemaOwner).To(Equal("holomush_plugin_test_plugin"))
+	})
 
-func TestPluginRoleCanCreateTablesInOwnSchema(t *testing.T) {
-	ctx := context.Background()
+	It("plugin role can create tables in its own schema", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	connStr, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		connStr, err := sp.ProvisionSchema(ctx, "test-plugin")
+		Expect(err).NotTo(HaveOccurred())
 
-	// Connect as the plugin role.
-	pluginConn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	defer pluginConn.Close(ctx)
+		// Connect as the plugin role.
+		pluginConn, err := pgx.Connect(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer pluginConn.Close(ctx)
 
-	_, err = pluginConn.Exec(ctx, "CREATE TABLE items (id serial PRIMARY KEY, name text)")
-	require.NoError(t, err)
+		_, err = pluginConn.Exec(ctx, "CREATE TABLE items (id serial PRIMARY KEY, name text)")
+		Expect(err).NotTo(HaveOccurred())
 
-	_, err = pluginConn.Exec(ctx, "INSERT INTO items (name) VALUES ('sword')")
-	require.NoError(t, err)
+		_, err = pluginConn.Exec(ctx, "INSERT INTO items (name) VALUES ('sword')")
+		Expect(err).NotTo(HaveOccurred())
 
-	var name string
-	err = pluginConn.QueryRow(ctx, "SELECT name FROM items WHERE name = 'sword'").Scan(&name)
-	require.NoError(t, err)
-	assert.Equal(t, "sword", name)
-}
+		var name string
+		err = pluginConn.QueryRow(ctx, "SELECT name FROM items WHERE name = 'sword'").Scan(&name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("sword"))
+	})
 
-func TestPluginRoleCannotAccessPublicSchema(t *testing.T) {
-	ctx := context.Background()
+	It("plugin role cannot access public schema", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	// Create a table in public schema as holomush.
-	adminConn, err := pgx.Connect(ctx, holomushConnStr)
-	require.NoError(t, err)
-	_, err = adminConn.Exec(ctx, "CREATE TABLE public.secrets (id serial, data text)")
-	require.NoError(t, err)
-	_, err = adminConn.Exec(ctx, "INSERT INTO public.secrets (data) VALUES ('top-secret')")
-	require.NoError(t, err)
-	adminConn.Close(ctx)
+		// Create a table in public schema as holomush.
+		adminConn, err := pgx.Connect(ctx, holomushConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = adminConn.Exec(ctx, "CREATE TABLE public.secrets (id serial, data text)")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = adminConn.Exec(ctx, "INSERT INTO public.secrets (data) VALUES ('top-secret')")
+		Expect(err).NotTo(HaveOccurred())
+		adminConn.Close(ctx)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	connStr, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		connStr, err := sp.ProvisionSchema(ctx, "test-plugin")
+		Expect(err).NotTo(HaveOccurred())
 
-	pluginConn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	defer pluginConn.Close(ctx)
+		pluginConn, err := pgx.Connect(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer pluginConn.Close(ctx)
 
-	_, err = pluginConn.Exec(ctx, "SET search_path TO public")
-	require.NoError(t, err)
+		_, err = pluginConn.Exec(ctx, "SET search_path TO public")
+		Expect(err).NotTo(HaveOccurred())
 
-	_, err = pluginConn.Exec(ctx, "SELECT * FROM secrets")
-	require.Error(t, err, "plugin must not be able to read public schema tables")
-}
+		_, err = pluginConn.Exec(ctx, "SELECT * FROM secrets")
+		Expect(err).To(HaveOccurred(), "plugin must not be able to read public schema tables")
+	})
 
-func TestCrossPluginIsolation(t *testing.T) {
-	ctx := context.Background()
+	It("plugins are isolated from each other's schemas", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	connStrA, err := sp.ProvisionSchema(ctx, "plugin-a")
-	require.NoError(t, err)
+		connStrA, err := sp.ProvisionSchema(ctx, "plugin-a")
+		Expect(err).NotTo(HaveOccurred())
 
-	connStrB, err := sp.ProvisionSchema(ctx, "plugin-b")
-	require.NoError(t, err)
+		connStrB, err := sp.ProvisionSchema(ctx, "plugin-b")
+		Expect(err).NotTo(HaveOccurred())
 
-	// Plugin A creates a table and inserts data.
-	connA, err := pgx.Connect(ctx, connStrA)
-	require.NoError(t, err)
-	defer connA.Close(ctx)
+		// Plugin A creates a table and inserts data.
+		connA, err := pgx.Connect(ctx, connStrA)
+		Expect(err).NotTo(HaveOccurred())
+		defer connA.Close(ctx)
 
-	_, err = connA.Exec(ctx, "CREATE TABLE treasure (id serial, loot text)")
-	require.NoError(t, err)
-	_, err = connA.Exec(ctx, "INSERT INTO treasure (loot) VALUES ('gold')")
-	require.NoError(t, err)
+		_, err = connA.Exec(ctx, "CREATE TABLE treasure (id serial, loot text)")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = connA.Exec(ctx, "INSERT INTO treasure (loot) VALUES ('gold')")
+		Expect(err).NotTo(HaveOccurred())
 
-	// Plugin B tries to access Plugin A's schema.
-	connB, err := pgx.Connect(ctx, connStrB)
-	require.NoError(t, err)
-	defer connB.Close(ctx)
+		// Plugin B tries to access Plugin A's schema.
+		connB, err := pgx.Connect(ctx, connStrB)
+		Expect(err).NotTo(HaveOccurred())
+		defer connB.Close(ctx)
 
-	_, err = connB.Exec(ctx, "SET search_path TO plugin_plugin_a")
-	require.NoError(t, err)
+		_, err = connB.Exec(ctx, "SET search_path TO plugin_plugin_a")
+		Expect(err).NotTo(HaveOccurred())
 
-	_, err = connB.Exec(ctx, "SELECT * FROM treasure")
-	require.Error(t, err, "plugin B must not be able to read plugin A's tables")
-}
+		_, err = connB.Exec(ctx, "SELECT * FROM treasure")
+		Expect(err).To(HaveOccurred(), "plugin B must not be able to read plugin A's tables")
+	})
 
-func TestIdempotentProvisionRefreshesPassword(t *testing.T) {
-	ctx := context.Background()
+	It("idempotent provision refreshes password and preserves data", func() {
+		ctx := context.Background()
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	// First provision — create table.
-	connStr1, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		// First provision — create table.
+		connStr1, err := sp.ProvisionSchema(ctx, "test-plugin")
+		Expect(err).NotTo(HaveOccurred())
 
-	conn1, err := pgx.Connect(ctx, connStr1)
-	require.NoError(t, err)
-	_, err = conn1.Exec(ctx, "CREATE TABLE settings (key text PRIMARY KEY, val text)")
-	require.NoError(t, err)
-	_, err = conn1.Exec(ctx, "INSERT INTO settings (key, val) VALUES ('color', 'blue')")
-	require.NoError(t, err)
-	conn1.Close(ctx)
+		conn1, err := pgx.Connect(ctx, connStr1)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = conn1.Exec(ctx, "CREATE TABLE settings (key text PRIMARY KEY, val text)")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = conn1.Exec(ctx, "INSERT INTO settings (key, val) VALUES ('color', 'blue')")
+		Expect(err).NotTo(HaveOccurred())
+		conn1.Close(ctx)
 
-	// Second provision — password refreshed.
-	connStr2, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		// Second provision — password refreshed.
+		connStr2, err := sp.ProvisionSchema(ctx, "test-plugin")
+		Expect(err).NotTo(HaveOccurred())
 
-	// New credentials work and table persists.
-	conn2, err := pgx.Connect(ctx, connStr2)
-	require.NoError(t, err)
-	defer conn2.Close(ctx)
+		// New credentials work and table persists.
+		conn2, err := pgx.Connect(ctx, connStr2)
+		Expect(err).NotTo(HaveOccurred())
+		defer conn2.Close(ctx)
 
-	var val string
-	err = conn2.QueryRow(ctx, "SELECT val FROM settings WHERE key = 'color'").Scan(&val)
-	require.NoError(t, err)
-	assert.Equal(t, "blue", val)
+		var val string
+		err = conn2.QueryRow(ctx, "SELECT val FROM settings WHERE key = 'color'").Scan(&val)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(Equal("blue"))
 
-	// Old credentials must fail.
-	_, err = pgx.Connect(ctx, connStr1)
-	assert.Error(t, err, "old connection string must fail after password refresh")
-}
+		// Old credentials must fail.
+		_, err = pgx.Connect(ctx, connStr1)
+		Expect(err).To(HaveOccurred(), "old connection string must fail after password refresh")
+	})
 
-func TestPurgeSchemaRemovesRoleAndSchema(t *testing.T) {
-	ctx := context.Background()
+	It("PurgeSchema removes role and schema", func() {
+		// Use a unique plugin name. Postgres roles are cluster-level
+		// (not database-level), so roles created by prior specs in this
+		// same suite (e.g., "test-plugin" from the ProvisionSchema and
+		// Idempotent specs above) own objects in their throwaway DBs,
+		// which blocks the role drop with "cannot be dropped because
+		// some objects depend on it (SQLSTATE 2BP01)". The original
+		// per-Test* model isolated this because each Go test recreated
+		// the suite context; Ginkgo shares state across specs in one
+		// Describe. Unique-per-spec name sidesteps the cross-spec
+		// dependency without weakening the assertion.
+		const pluginName = "test-plugin-purge"
+		const roleName = "holomush_plugin_test_plugin_purge"
+		const schemaName = "plugin_test_plugin_purge"
 
-	holomushConnStr, _ := setupSchemaTestDB(t)
+		ctx := context.Background()
 
-	sp := plugins.NewSchemaProvisioner(holomushConnStr)
-	defer sp.Close()
-	require.NoError(t, sp.Init(ctx))
+		holomushConnStr, _ := setupSchemaTestDB(suiteT)
 
-	connStr, err := sp.ProvisionSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		sp := plugins.NewSchemaProvisioner(holomushConnStr)
+		defer sp.Close()
+		Expect(sp.Init(ctx)).NotTo(HaveOccurred())
 
-	// Create a table to prove data exists.
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	_, err = conn.Exec(ctx, "CREATE TABLE ephemeral (id serial)")
-	require.NoError(t, err)
-	conn.Close(ctx)
+		connStr, err := sp.ProvisionSchema(ctx, pluginName)
+		Expect(err).NotTo(HaveOccurred())
 
-	// Purge.
-	err = sp.PurgeSchema(ctx, "test-plugin")
-	require.NoError(t, err)
+		// Create a table to prove data exists.
+		conn, err := pgx.Connect(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = conn.Exec(ctx, "CREATE TABLE ephemeral (id serial)")
+		Expect(err).NotTo(HaveOccurred())
+		conn.Close(ctx)
 
-	// Verify role is gone.
-	pool, err := pgxpool.New(ctx, holomushConnStr)
-	require.NoError(t, err)
-	defer pool.Close()
+		// Purge.
+		Expect(sp.PurgeSchema(ctx, pluginName)).NotTo(HaveOccurred())
 
-	var roleExists bool
-	err = pool.QueryRow(
-		ctx,
-		"SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
-		"holomush_plugin_test_plugin",
-	).Scan(&roleExists)
-	require.NoError(t, err)
-	assert.False(t, roleExists, "role must be removed after purge")
+		// Verify role is gone.
+		pool, err := pgxpool.New(ctx, holomushConnStr)
+		Expect(err).NotTo(HaveOccurred())
+		defer pool.Close()
 
-	// Verify schema is gone.
-	var schemaExists bool
-	err = pool.QueryRow(
-		ctx,
-		"SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1)",
-		"plugin_test_plugin",
-	).Scan(&schemaExists)
-	require.NoError(t, err)
-	assert.False(t, schemaExists, "schema must be removed after purge")
-}
+		var roleExists bool
+		err = pool.QueryRow(
+			ctx,
+			"SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
+			roleName,
+		).Scan(&roleExists)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(roleExists).To(BeFalse(), "role must be removed after purge")
+
+		// Verify schema is gone.
+		var schemaExists bool
+		err = pool.QueryRow(
+			ctx,
+			"SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1)",
+			schemaName,
+		).Scan(&schemaExists)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schemaExists).To(BeFalse(), "schema must be removed after purge")
+	})
+})


### PR DESCRIPTION
## Summary

Migrates three plain-`testing.T` integration test files in `test/integration/plugin/` to Ginkgo specs, registered into the existing `Binary Plugin Integration Suite` (`plugin_suite_test.go:25`). 10 specs total across 3 commits (one commit per file for review tractability).

**Files converted:**
- `plugin_role_permissions_test.go` — 1 spec (carries INV-P7-13)
- `plugin_migration_test.go` — 2 specs (carry INV-P7-3 + INV-P7-10)
- `schema_isolation_test.go` — 8 specs (SchemaProvisioner lifecycle)

**Files intentionally skipped:** `counting_proxy_test.go` is a helper file with 0 test functions (audit verified: `rg -c 'func Test|t.Run' test/integration/plugin/counting_proxy_test.go` → 0). Same misclassification as A1's `core_client_shim_test.go`. Recorded in `bd note holomush-rccc.2`.

## Pattern corrections vs original plan

The plan (`docs/superpowers/plans/2026-05-15-testify-ginkgo-migration-completion-plan.md` Canonical Pattern A) prescribed `GinkgoT()` passed to helpers taking `testing.TB`. That's broken: Go 1.26's `testing.TB` has an unexported `private()` method (intentional design) so no third-party type — including `ginkgo.FullGinkgoTInterface` — can satisfy it. The errutil widening that landed in PR #3950 is harmless-but-useless for its stated purpose.

**Correct pattern (used by ~30 existing specs in this codebase, e.g., `test/integration/auth/`, `test/integration/crypto/`):** capture `*testing.T` at the suite entry into `var suiteT *testing.T` (already declared at `plugin_suite_test.go:18`), pass `suiteT` to helpers. This PR uses that pattern.

## INV-tagged test handling

`internal/eventbus/history/phase7_boundary_meta_test.go` enforces that every Phase 7 invariant has a named top-level `Test*` function via `go/parser` AST walk. Ginkgo `Describe`s are invisible to it. This PR remaps INV-P7-3 and INV-P7-13 to the suite entry `TestBinaryPlugin`, with the INV reference preserved verbatim in each `Describe` name (e.g., `"Scene log has DEK columns (INV-P7-3)"`) so traceability is preserved via grep on the spec name.

## Non-trivial behavior change (preserved assertion strength)

`schema_isolation_test.go` `PurgeSchema removes role and schema` spec uses `pluginName = "test-plugin-purge"` (not `"test-plugin"` as the original). Reason: Postgres roles are cluster-level. Earlier specs in the same Describe call `ProvisionSchema(ctx, "test-plugin")` which creates `holomush_plugin_test_plugin` cluster-wide, and that role accumulates owned tables across throwaway DBs. The Go-test process model isolated this; one Ginkgo suite shares state. Unique-per-spec name sidesteps cross-spec dependency. Both `roleExists==false` and `schemaExists==false` are still asserted on the actual role/schema that PurgeSchema is supposed to destroy. See `schema_isolation_test.go:288-346`.

## Per-PR gates (all green)

```bash
rg -c 'RunSpecs' test/integration/plugin/   # 1
rg 't\.Skip\(' test/integration/plugin/     # 0
rg 'func Test|t\.Run' test/integration/plugin/{plugin_migration,plugin_role_permissions,schema_isolation}_test.go  # 0
```

## Test plan

- [x] `task test:int -- ./test/integration/plugin/...` — full plugin suite green
- [x] `task test:int -- -ginkgo.focus="..."` — focused passes per file
- [x] `task pr-prep` — full pipeline green (lint, format, schema, license, unit, integration, E2E)
- [x] code-reviewer — READY verdict
- [x] Meta-test (`TestPhase7InvariantsHaveNamedTests`) green with updated mappings

Closes holomush-rccc.2. Part of holomush-1hq.26 / holomush-rccc Stage A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated multiple plugin integration tests to a unified Ginkgo/Gomega suite structure (replacing many standalone test functions).
  * Updated plugin migration and permission tests to use shared suite fixtures and Gomega assertions.
  * Updated Phase 7 invariant validation mappings to reflect renamed test suites and added comments preserving historical traceability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/3951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->