### PR TITLE
test(internal/store): migrate 4 integration tests to Ginkgo (1hq.60 / 1hq.26 B3)

### DIFF
--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -112,508 +114,509 @@ func verifySeedData(t *testing.T, ctx context.Context, connStr string) {
 	assert.Equal(t, 1, charCount, "should have 'TestChar' character")
 }
 
-func TestMigrator_FullCycle(t *testing.T) {
-	ctx := context.Background()
-
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator.Close()
-
-	// Phase 1: Fresh database — version 0, no tables
-	version, dirty, err := migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(0), version)
-	assert.False(t, dirty)
-
-	tables := queryTableNames(t, ctx, connStr)
-	assert.Empty(t, tables, "fresh database should have no user tables")
-
-	// Phase 2: Up — apply all migrations, verify all tables
-	err = migrator.Up()
-	require.NoError(t, err)
-
-	version, dirty, err = migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(36), version)
-	assert.False(t, dirty)
-
-	tables = queryTableNames(t, ctx, connStr)
-	assert.Equal(t, expectedTables, tables, "Up() should create all expected tables")
-	verifySeedData(t, ctx, connStr)
-
-	// Phase 3: Down — rollback, verify all tables gone
-	err = migrator.Down()
-	require.NoError(t, err)
-
-	version, dirty, err = migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(0), version)
-	assert.False(t, dirty)
-
-	tables = queryTableNames(t, ctx, connStr)
-	assert.Empty(t, tables, "Down() should remove all user tables")
-
-	// Phase 4: Re-apply — prove idempotency
-	err = migrator.Up()
-	require.NoError(t, err)
-
-	version, dirty, err = migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(36), version)
-	assert.False(t, dirty)
-
-	tables = queryTableNames(t, ctx, connStr)
-	assert.Equal(t, expectedTables, tables, "second Up() should recreate all tables")
-	verifySeedData(t, ctx, connStr)
-}
-
-func TestMigrator_DirtyStateRecovery(t *testing.T) {
-	ctx := context.Background()
-
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Create migrator and apply migrations
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator.Close()
-
-	err = migrator.Up()
-	require.NoError(t, err)
-
-	// Capture current version before simulating dirty state
-	currentVersion, dirty, err := migrator.Version()
-	require.NoError(t, err)
-	require.False(t, dirty, "database should start clean")
-	require.Greater(t, currentVersion, uint(0), "should have at least one migration applied")
-
-	// Simulate dirty state using raw SQL
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	defer conn.Close(ctx)
-
-	_, err = conn.Exec(ctx, "UPDATE schema_migrations SET dirty = true")
-	require.NoError(t, err)
-
-	// Verify dirty state is reflected
-	version, dirty, err := migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, version)
-	assert.True(t, dirty, "database should be dirty after manual update")
-
-	// Verify Up() fails when database is dirty
-	// golang-migrate returns ErrDirty when trying to run migrations on a dirty database
-	err = migrator.Up()
-	require.Error(t, err, "Up() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	// Verify Steps() also fails when dirty
-	err = migrator.Steps(1)
-	require.Error(t, err, "Steps() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	// Use Force() to recover from dirty state
-	err = migrator.Force(int(currentVersion))
-	require.NoError(t, err, "Force() should succeed and clear dirty flag")
-
-	// Verify dirty flag is cleared
-	version, dirty, err = migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, version, "version should remain unchanged after Force()")
-	assert.False(t, dirty, "dirty flag should be cleared after Force()")
-
-	// Verify migrations can continue - Up() should succeed (or return no change)
-	err = migrator.Up()
-	require.NoError(t, err, "Up() should succeed after Force() clears dirty state")
-}
-
-func TestMigrator_ConcurrentUp(t *testing.T) {
-	ctx := context.Background()
-
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Create two migrators pointing to the same database
-	migrator1, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator1.Close()
-
-	migrator2, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator2.Close()
-
-	// Run migrations concurrently
-	var wg sync.WaitGroup
-	var err1, err2 error
-
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		err1 = migrator1.Up()
-	}()
-	go func() {
-		defer wg.Done()
-		err2 = migrator2.Up()
-	}()
-	wg.Wait()
-
-	// At least one should succeed (or both if sequential lock acquisition)
-	// ErrNoChange is acceptable (means migrations already applied)
-	// Both succeeding is fine due to lock serialization
-	successCount := 0
-	if err1 == nil {
-		successCount++
-	}
-	if err2 == nil {
-		successCount++
-	}
-	assert.GreaterOrEqual(t, successCount, 1, "at least one migration should succeed")
-
-	// Verify consistent final state using a fresh migrator
-	verifier, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer verifier.Close()
-
-	version, dirty, err := verifier.Version()
-	require.NoError(t, err)
-	assert.Greater(t, version, uint(0), "migrations should have been applied")
-	assert.False(t, dirty, "database should not be in dirty state")
-
-	// Verify both migrators report same version
-	v1, dirty1, err := migrator1.Version()
-	require.NoError(t, err)
-	assert.Equal(t, version, v1, "migrator1 should report same version")
-	assert.False(t, dirty1)
-
-	v2, dirty2, err := migrator2.Version()
-	require.NoError(t, err)
-	assert.Equal(t, version, v2, "migrator2 should report same version")
-	assert.False(t, dirty2)
-}
-
-// TestMigrator_Force_VersionExceedsAvailable documents the behavior when
-// Force() is called with a version higher than available migrations.
-//
-// While Force() accepts any version value, the consequences are:
-// - Version() returns the forced version (999)
-// - Up() returns an error (migration file not found)
-// - PendingMigrations() returns empty (thinks we're past all migrations)
-//
-// This is dangerous because PendingMigrations() indicates nothing is pending,
-// but Up() will fail. The only recovery is to Force() back to a valid version.
-//
-// Force() should only be used for recovery from dirty state, never to
-// artificially advance the version.
-func TestMigrator_Force_VersionExceedsAvailable(t *testing.T) {
-	ctx := context.Background()
-
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Create migrator
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator.Close()
-
-	// Apply all available migrations first
-	err = migrator.Up()
-	require.NoError(t, err)
-
-	// Verify we're at the latest version
-	latestVersion, dirty, err := migrator.Version()
-	require.NoError(t, err)
-	require.False(t, dirty)
-	require.Greater(t, latestVersion, uint(0), "should have at least one migration")
-
-	// DANGEROUS: Force version to a value higher than any available migration
-	// This should NOT be done in production - only for documenting behavior
-	err = migrator.Force(999)
-	require.NoError(t, err, "Force() accepts any version, even non-existent ones")
-
-	// Verify version is now 999
-	version, dirty, err := migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(999), version, "Force() sets version to arbitrary value")
-	assert.False(t, dirty, "Force() clears dirty flag")
-
-	// Up() returns an error because there's no migration file for version 999
-	// golang-migrate tries to read the current version's down migration and fails
-	err = migrator.Up()
-	require.Error(t, err, "Up() should fail when forced to non-existent version")
-	assert.Contains(t, err.Error(), "999",
-		"error message should reference the invalid version")
-
-	// PendingMigrations() returns empty because version 999 > all migrations
-	// This is misleading since Up() will actually fail
-	pending, err := migrator.PendingMigrations()
-	require.NoError(t, err)
-	assert.Empty(t, pending, "PendingMigrations() returns empty when version exceeds all migrations")
-
-	// Version remains 999
-	version, _, err = migrator.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(999), version, "version unchanged after failed Up()")
-}
-
-// TestMigrator_ConcurrentMigrationDirtyStateHandling verifies that dirty state
-// detection works correctly when multiple migrators access the same database
-// and one experiences a partial failure (simulated via dirty flag).
-//
-// This test simulates the scenario where:
-// 1. Two migrators point to the same database
-// 2. A migration fails partway through (leaving dirty state)
-// 3. Both migrators detect the dirty state
-// 4. Force() can recover the database to a clean state
-func TestMigrator_ConcurrentMigrationDirtyStateHandling(t *testing.T) {
-	ctx := context.Background()
-
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Apply migrations first to establish baseline
-	migrator1, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator1.Close()
-
-	err = migrator1.Up()
-	require.NoError(t, err)
-
-	baseVersion, dirty, err := migrator1.Version()
-	require.NoError(t, err)
-	require.False(t, dirty, "database should start clean")
-	require.Greater(t, baseVersion, uint(0), "should have at least one migration applied")
-
-	// Roll back to version 0 so we can simulate concurrent migration attempts
-	err = migrator1.Down()
-	require.NoError(t, err)
-
-	version, dirty, err := migrator1.Version()
-	require.NoError(t, err)
-	assert.Equal(t, uint(0), version, "should be at version 0 after Down()")
-	assert.False(t, dirty)
-
-	// Now simulate a concurrent scenario where one migrator sets dirty state
-	// mid-execution (as would happen if a migration fails partway through).
-	// We'll:
-	// 1. Start migrator2
-	// 2. Manually set dirty state (simulating mid-migration crash)
-	// 3. Verify both migrators detect the dirty state
-	// 4. Verify Force() recovery works
-
-	migrator2, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator2.Close()
-
-	// First, apply one migration step to create the schema_migrations table
-	// and establish a version for dirty state simulation
-	err = migrator1.Steps(1)
-	require.NoError(t, err)
-
-	currentVersion, dirty, err := migrator1.Version()
-	require.NoError(t, err)
-	require.False(t, dirty)
-	require.Greater(t, currentVersion, uint(0))
-
-	// Simulate a partial migration failure by setting dirty flag directly.
-	// This simulates what happens when a migration crashes mid-execution:
-	// the database is left in a dirty state at the current version.
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	defer conn.Close(ctx)
-
-	_, err = conn.Exec(ctx, "UPDATE schema_migrations SET dirty = true")
-	require.NoError(t, err)
-
-	// Test: Both migrators detect the dirty state
-	v1, dirty1, err := migrator1.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, v1, "migrator1 should report correct version")
-	assert.True(t, dirty1, "migrator1 should detect dirty state")
-
-	v2, dirty2, err := migrator2.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, v2, "migrator2 should report correct version")
-	assert.True(t, dirty2, "migrator2 should detect dirty state")
-
-	// Test: Up() fails for both migrators due to dirty state
-	err = migrator1.Up()
-	require.Error(t, err, "migrator1.Up() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	err = migrator2.Up()
-	require.Error(t, err, "migrator2.Up() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	// Test: Steps() fails for both migrators due to dirty state
-	err = migrator1.Steps(1)
-	require.Error(t, err, "migrator1.Steps() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	err = migrator2.Steps(1)
-	require.Error(t, err, "migrator2.Steps() should fail when database is dirty")
-	assert.Contains(t, err.Error(), "Dirty", "error should indicate dirty state")
-
-	// Test: Force() can recover from dirty state
-	// Using migrator1 to force the version clears dirty flag
-	err = migrator1.Force(int(currentVersion))
-	require.NoError(t, err, "migrator1.Force() should succeed")
-
-	// Test: Both migrators now see clean state
-	v1, dirty1, err = migrator1.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, v1)
-	assert.False(t, dirty1, "migrator1 should see dirty flag cleared after Force()")
-
-	v2, dirty2, err = migrator2.Version()
-	require.NoError(t, err)
-	assert.Equal(t, currentVersion, v2)
-	assert.False(t, dirty2, "migrator2 should see dirty flag cleared after Force()")
-
-	// Test: Migrations can continue after Force() recovery
-	err = migrator1.Up()
-	require.NoError(t, err, "migrator1.Up() should succeed after Force() recovery")
-
-	// Verify final state
-	finalVersion, dirty, err := migrator1.Version()
-	require.NoError(t, err)
-	assert.Equal(t, baseVersion, finalVersion, "should reach final version after recovery")
-	assert.False(t, dirty, "database should be clean after recovery and Up()")
-
-	// migrator2 should also see the consistent final state
-	v2Final, dirty2Final, err := migrator2.Version()
-	require.NoError(t, err)
-	assert.Equal(t, finalVersion, v2Final, "migrator2 should see same final version")
-	assert.False(t, dirty2Final, "migrator2 should see clean state")
-}
-
-// TestMigration000035_DropsCryptoRekeyCheckpointFKs asserts the load-bearing
-// post-condition of migration 000035 (holomush-jxo8.7.48): no foreign-key
-// constraints remain on crypto_rekey_checkpoints.{new_dek_id,old_dek_id}.
-//
-// Without this assertion, a future regression that names the constraints
-// differently (e.g. explicit CONSTRAINT clause in 000031) would silently
-// leave the FKs in place — the migration's DROP CONSTRAINT IF EXISTS would
-// match nothing, no error, no test failure. Asserting the actual
-// information_schema state is the load-bearing check.
-func TestMigration000035_DropsCryptoRekeyCheckpointFKs(t *testing.T) {
-	ctx := context.Background()
-
-	pgContainer, err := postgres.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		postgres.BasicWaitStrategies(),
-	)
-	require.NoError(t, err)
-	defer pgContainer.Terminate(ctx)
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	defer migrator.Close()
-
-	require.NoError(t, migrator.Up())
-
-	conn, err := pgx.Connect(ctx, connStr)
-	require.NoError(t, err)
-	defer conn.Close(ctx)
-
-	// Count remaining FK constraints on crypto_rekey_checkpoints. After
-	// migration 000035 there MUST be zero. (The table itself still has
-	// PRIMARY KEY, CHECK, and UNIQUE constraints — those are unaffected.)
-	var fkCount int
-	err = conn.QueryRow(ctx, `
-        SELECT COUNT(*)
-          FROM information_schema.table_constraints
-         WHERE table_name = 'crypto_rekey_checkpoints'
-           AND constraint_type = 'FOREIGN KEY'
-    `).Scan(&fkCount)
-	require.NoError(t, err)
-	assert.Equal(t, 0, fkCount,
-		"migration 000035 (holomush-jxo8.7.48) MUST drop both FKs on crypto_rekey_checkpoints "+
-			"(new_dek_id, old_dek_id). Future migrations that re-introduce a FK to crypto_keys "+
-			"would defeat the no-prod-shape design — see spec §3.6.1.")
-
-	// Defense-in-depth: also confirm the specific column FKs aren't present
-	// (an FK to a different table wouldn't be caught by the count-zero
-	// check above, but it would be even worse).
-	var perColumnFKCount int
-	err = conn.QueryRow(ctx, `
-        SELECT COUNT(*)
-          FROM information_schema.referential_constraints rc
-          JOIN information_schema.key_column_usage kcu
-            ON kcu.constraint_name = rc.constraint_name
-         WHERE kcu.table_name = 'crypto_rekey_checkpoints'
-           AND kcu.column_name IN ('new_dek_id', 'old_dek_id')
-    `).Scan(&perColumnFKCount)
-	require.NoError(t, err)
-	assert.Equal(t, 0, perColumnFKCount,
-		"no FK from crypto_rekey_checkpoints.{new_dek_id,old_dek_id} to any table is permitted "+
-			"after migration 000035")
-}
+var _ = Describe("Migrator", func() {
+	Describe("FullCycle", func() {
+		It("applies all migrations, rolls back to zero, and is idempotent on re-apply", func() {
+			ctx := context.Background()
+
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator.Close()
+
+			// Phase 1: Fresh database — version 0, no tables
+			version, dirty, err := migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(0)))
+			Expect(dirty).To(BeFalse())
+
+			tables := queryTableNames(suiteT, ctx, connStr)
+			Expect(tables).To(BeEmpty(), "fresh database should have no user tables")
+
+			// Phase 2: Up — apply all migrations, verify all tables
+			Expect(migrator.Up()).To(Succeed())
+
+			version, dirty, err = migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(36)))
+			Expect(dirty).To(BeFalse())
+
+			tables = queryTableNames(suiteT, ctx, connStr)
+			Expect(tables).To(Equal(expectedTables), "Up() should create all expected tables")
+			verifySeedData(suiteT, ctx, connStr)
+
+			// Phase 3: Down — rollback, verify all tables gone
+			Expect(migrator.Down()).To(Succeed())
+
+			version, dirty, err = migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(0)))
+			Expect(dirty).To(BeFalse())
+
+			tables = queryTableNames(suiteT, ctx, connStr)
+			Expect(tables).To(BeEmpty(), "Down() should remove all user tables")
+
+			// Phase 4: Re-apply — prove idempotency
+			Expect(migrator.Up()).To(Succeed())
+
+			version, dirty, err = migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(36)))
+			Expect(dirty).To(BeFalse())
+
+			tables = queryTableNames(suiteT, ctx, connStr)
+			Expect(tables).To(Equal(expectedTables), "second Up() should recreate all tables")
+			verifySeedData(suiteT, ctx, connStr)
+		})
+	})
+
+	Describe("DirtyStateRecovery", func() {
+		It("detects dirty state and recovers via Force()", func() {
+			ctx := context.Background()
+
+			// Start PostgreSQL container
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create migrator and apply migrations
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator.Close()
+
+			Expect(migrator.Up()).To(Succeed())
+
+			// Capture current version before simulating dirty state
+			currentVersion, dirty, err := migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dirty).To(BeFalse(), "database should start clean")
+			Expect(currentVersion).To(BeNumerically(">", uint(0)), "should have at least one migration applied")
+
+			// Simulate dirty state using raw SQL
+			conn, err := pgx.Connect(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close(ctx)
+
+			_, err = conn.Exec(ctx, "UPDATE schema_migrations SET dirty = true")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify dirty state is reflected
+			version, dirty, err := migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(currentVersion))
+			Expect(dirty).To(BeTrue(), "database should be dirty after manual update")
+
+			// Verify Up() fails when database is dirty
+			// golang-migrate returns ErrDirty when trying to run migrations on a dirty database
+			err = migrator.Up()
+			Expect(err).To(HaveOccurred(), "Up() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			// Verify Steps() also fails when dirty
+			err = migrator.Steps(1)
+			Expect(err).To(HaveOccurred(), "Steps() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			// Use Force() to recover from dirty state
+			Expect(migrator.Force(int(currentVersion))).To(Succeed(), "Force() should succeed and clear dirty flag")
+
+			// Verify dirty flag is cleared
+			version, dirty, err = migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(currentVersion), "version should remain unchanged after Force()")
+			Expect(dirty).To(BeFalse(), "dirty flag should be cleared after Force()")
+
+			// Verify migrations can continue - Up() should succeed (or return no change)
+			Expect(migrator.Up()).To(Succeed(), "Up() should succeed after Force() clears dirty state")
+		})
+	})
+
+	Describe("ConcurrentUp", func() {
+		It("allows at least one concurrent Up() to succeed with consistent final state", func() {
+			ctx := context.Background()
+
+			// Start PostgreSQL container
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create two migrators pointing to the same database
+			migrator1, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator1.Close()
+
+			migrator2, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator2.Close()
+
+			// Run migrations concurrently
+			var wg sync.WaitGroup
+			var err1, err2 error
+
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				err1 = migrator1.Up()
+			}()
+			go func() {
+				defer wg.Done()
+				err2 = migrator2.Up()
+			}()
+			wg.Wait()
+
+			// At least one should succeed (or both if sequential lock acquisition)
+			// ErrNoChange is acceptable (means migrations already applied)
+			// Both succeeding is fine due to lock serialization
+			successCount := 0
+			if err1 == nil {
+				successCount++
+			}
+			if err2 == nil {
+				successCount++
+			}
+			Expect(successCount).To(BeNumerically(">=", 1), "at least one migration should succeed")
+
+			// Verify consistent final state using a fresh migrator
+			verifier, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer verifier.Close()
+
+			version, dirty, err := verifier.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(BeNumerically(">", uint(0)), "migrations should have been applied")
+			Expect(dirty).To(BeFalse(), "database should not be in dirty state")
+
+			// Verify both migrators report same version
+			v1, dirty1, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v1).To(Equal(version), "migrator1 should report same version")
+			Expect(dirty1).To(BeFalse())
+
+			v2, dirty2, err := migrator2.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v2).To(Equal(version), "migrator2 should report same version")
+			Expect(dirty2).To(BeFalse())
+		})
+	})
+
+	// Force_VersionExceedsAvailable documents the behavior when Force() is called
+	// with a version higher than available migrations.
+	//
+	// While Force() accepts any version value, the consequences are:
+	//   - Version() returns the forced version (999)
+	//   - Up() returns an error (migration file not found)
+	//   - PendingMigrations() returns empty (thinks we're past all migrations)
+	//
+	// This is dangerous because PendingMigrations() indicates nothing is pending,
+	// but Up() will actually fail. The only recovery is to Force() back to a valid version.
+	//
+	// Force() should only be used for recovery from dirty state, never to
+	// artificially advance the version.
+	Describe("Force_VersionExceedsAvailable", func() {
+		It("documents dangerous behavior: PendingMigrations() returns empty but Up() fails", func() {
+			ctx := context.Background()
+
+			// Start PostgreSQL container
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create migrator
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator.Close()
+
+			// Apply all available migrations first
+			Expect(migrator.Up()).To(Succeed())
+
+			// Verify we're at the latest version
+			latestVersion, dirty, err := migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dirty).To(BeFalse())
+			Expect(latestVersion).To(BeNumerically(">", uint(0)), "should have at least one migration")
+
+			// DANGEROUS: Force version to a value higher than any available migration
+			// This should NOT be done in production - only for documenting behavior
+			Expect(migrator.Force(999)).To(Succeed(), "Force() accepts any version, even non-existent ones")
+
+			// Verify version is now 999
+			version, dirty, err := migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(999)), "Force() sets version to arbitrary value")
+			Expect(dirty).To(BeFalse(), "Force() clears dirty flag")
+
+			// Up() returns an error because there's no migration file for version 999
+			// golang-migrate tries to read the current version's down migration and fails
+			err = migrator.Up()
+			Expect(err).To(HaveOccurred(), "Up() should fail when forced to non-existent version")
+			Expect(err.Error()).To(ContainSubstring("999"),
+				"error message should reference the invalid version")
+
+			// PendingMigrations() returns empty because version 999 > all migrations
+			// This is misleading since Up() will actually fail
+			pending, err := migrator.PendingMigrations()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pending).To(BeEmpty(), "PendingMigrations() returns empty when version exceeds all migrations")
+
+			// Version remains 999
+			version, _, err = migrator.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(999)), "version unchanged after failed Up()")
+		})
+	})
+
+	// ConcurrentMigrationDirtyStateHandling verifies that dirty state
+	// detection works correctly when multiple migrators access the same database
+	// and one experiences a partial failure (simulated via dirty flag).
+	//
+	// This test simulates the scenario where:
+	// 1. Two migrators point to the same database
+	// 2. A migration fails partway through (leaving dirty state)
+	// 3. Both migrators detect the dirty state
+	// 4. Force() can recover the database to a clean state
+	Describe("ConcurrentMigrationDirtyStateHandling", func() {
+		It("both migrators detect dirty state and recover via Force()", func() {
+			ctx := context.Background()
+
+			// Start PostgreSQL container
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Apply migrations first to establish baseline
+			migrator1, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator1.Close()
+
+			Expect(migrator1.Up()).To(Succeed())
+
+			baseVersion, dirty, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dirty).To(BeFalse(), "database should start clean")
+			Expect(baseVersion).To(BeNumerically(">", uint(0)), "should have at least one migration applied")
+
+			// Roll back to version 0 so we can simulate concurrent migration attempts
+			Expect(migrator1.Down()).To(Succeed())
+
+			version, dirty, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(uint(0)), "should be at version 0 after Down()")
+			Expect(dirty).To(BeFalse())
+
+			// Now simulate a concurrent scenario where one migrator sets dirty state
+			// mid-execution (as would happen if a migration fails partway through).
+			// We'll:
+			// 1. Start migrator2
+			// 2. Manually set dirty state (simulating mid-migration crash)
+			// 3. Verify both migrators detect the dirty state
+			// 4. Verify Force() recovery works
+
+			migrator2, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator2.Close()
+
+			// First, apply one migration step to create the schema_migrations table
+			// and establish a version for dirty state simulation
+			Expect(migrator1.Steps(1)).To(Succeed())
+
+			currentVersion, dirty, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dirty).To(BeFalse())
+			Expect(currentVersion).To(BeNumerically(">", uint(0)))
+
+			// Simulate a partial migration failure by setting dirty flag directly.
+			// This simulates what happens when a migration crashes mid-execution:
+			// the database is left in a dirty state at the current version.
+			conn, err := pgx.Connect(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close(ctx)
+
+			_, err = conn.Exec(ctx, "UPDATE schema_migrations SET dirty = true")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Test: Both migrators detect the dirty state
+			v1, dirty1, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v1).To(Equal(currentVersion), "migrator1 should report correct version")
+			Expect(dirty1).To(BeTrue(), "migrator1 should detect dirty state")
+
+			v2, dirty2, err := migrator2.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v2).To(Equal(currentVersion), "migrator2 should report correct version")
+			Expect(dirty2).To(BeTrue(), "migrator2 should detect dirty state")
+
+			// Test: Up() fails for both migrators due to dirty state
+			err = migrator1.Up()
+			Expect(err).To(HaveOccurred(), "migrator1.Up() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			err = migrator2.Up()
+			Expect(err).To(HaveOccurred(), "migrator2.Up() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			// Test: Steps() fails for both migrators due to dirty state
+			err = migrator1.Steps(1)
+			Expect(err).To(HaveOccurred(), "migrator1.Steps() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			err = migrator2.Steps(1)
+			Expect(err).To(HaveOccurred(), "migrator2.Steps() should fail when database is dirty")
+			Expect(err.Error()).To(ContainSubstring("Dirty"), "error should indicate dirty state")
+
+			// Test: Force() can recover from dirty state
+			// Using migrator1 to force the version clears dirty flag
+			Expect(migrator1.Force(int(currentVersion))).To(Succeed(), "migrator1.Force() should succeed")
+
+			// Test: Both migrators now see clean state
+			v1, dirty1, err = migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v1).To(Equal(currentVersion))
+			Expect(dirty1).To(BeFalse(), "migrator1 should see dirty flag cleared after Force()")
+
+			v2, dirty2, err = migrator2.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v2).To(Equal(currentVersion))
+			Expect(dirty2).To(BeFalse(), "migrator2 should see dirty flag cleared after Force()")
+
+			// Test: Migrations can continue after Force() recovery
+			Expect(migrator1.Up()).To(Succeed(), "migrator1.Up() should succeed after Force() recovery")
+
+			// Verify final state
+			finalVersion, dirty, err := migrator1.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(finalVersion).To(Equal(baseVersion), "should reach final version after recovery")
+			Expect(dirty).To(BeFalse(), "database should be clean after recovery and Up()")
+
+			// migrator2 should also see the consistent final state
+			v2Final, dirty2Final, err := migrator2.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v2Final).To(Equal(finalVersion), "migrator2 should see same final version")
+			Expect(dirty2Final).To(BeFalse(), "migrator2 should see clean state")
+		})
+	})
+
+	// Migration000035_DropsCryptoRekeyCheckpointFKs asserts the load-bearing
+	// post-condition of migration 000035 (holomush-jxo8.7.48): no foreign-key
+	// constraints remain on crypto_rekey_checkpoints.{new_dek_id,old_dek_id}.
+	//
+	// Without this assertion, a future regression that names the constraints
+	// differently (e.g. explicit CONSTRAINT clause in 000031) would silently
+	// leave the FKs in place — the migration's DROP CONSTRAINT IF EXISTS would
+	// match nothing, no error, no test failure. Asserting the actual
+	// information_schema state is the load-bearing check.
+	Describe("Migration000035_DropsCryptoRekeyCheckpointFKs", func() {
+		It("drops both FK constraints on crypto_rekey_checkpoints after migration 000035", func() {
+			ctx := context.Background()
+
+			pgContainer, err := postgres.Run(
+				ctx,
+				"postgres:18-alpine",
+				postgres.WithDatabase("test"),
+				postgres.WithUsername("test"),
+				postgres.WithPassword("test"),
+				postgres.BasicWaitStrategies(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer pgContainer.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+
+			connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+			Expect(err).NotTo(HaveOccurred())
+
+			migrator, err := store.NewMigrator(connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer migrator.Close()
+
+			Expect(migrator.Up()).To(Succeed())
+
+			conn, err := pgx.Connect(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close(ctx)
+
+			// Count remaining FK constraints on crypto_rekey_checkpoints. After
+			// migration 000035 there MUST be zero. (The table itself still has
+			// PRIMARY KEY, CHECK, and UNIQUE constraints — those are unaffected.)
+			var fkCount int
+			err = conn.QueryRow(ctx, `
+		        SELECT COUNT(*)
+		          FROM information_schema.table_constraints
+		         WHERE table_name = 'crypto_rekey_checkpoints'
+		           AND constraint_type = 'FOREIGN KEY'
+		    `).Scan(&fkCount)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fkCount).To(Equal(0),
+				"migration 000035 (holomush-jxo8.7.48) MUST drop both FKs on crypto_rekey_checkpoints "+
+					"(new_dek_id, old_dek_id). Future migrations that re-introduce a FK to crypto_keys "+
+					"would defeat the no-prod-shape design — see spec §3.6.1.")
+
+			// Defense-in-depth: also confirm the specific column FKs aren't present
+			// (an FK to a different table wouldn't be caught by the count-zero
+			// check above, but it would be even worse).
+			var perColumnFKCount int
+			err = conn.QueryRow(ctx, `
+		        SELECT COUNT(*)
+		          FROM information_schema.referential_constraints rc
+		          JOIN information_schema.key_column_usage kcu
+		            ON kcu.constraint_name = rc.constraint_name
+		         WHERE kcu.table_name = 'crypto_rekey_checkpoints'
+		           AND kcu.column_name IN ('new_dek_id', 'old_dek_id')
+		    `).Scan(&perColumnFKCount)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(perColumnFKCount).To(Equal(0),
+				"no FK from crypto_rekey_checkpoints.{new_dek_id,old_dek_id} to any table is permitted "+
+					"after migration 000035")
+		})
+	})
+})

--- a/internal/store/migrate_plugins_integration_test.go
+++ b/internal/store/migrate_plugins_integration_test.go
@@ -7,65 +7,71 @@ package store_test
 
 import (
 	"context"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 )
 
-func TestMigration000018CreatesPluginsTable(t *testing.T) {
-	ctx := context.Background()
-	pool, cleanup := newTestPool(t)
-	defer cleanup()
+var _ = Describe("Migration 000018", func() {
+	Describe("plugins table", func() {
+		It("creates plugins table with exactly 9 expected columns and partial unique index", func() {
+			ctx := context.Background()
+			pool, cleanup := newTestPool(suiteT)
+			defer cleanup()
 
-	require.NoError(t, runMigrations(ctx, pool, 18))
+			Expect(runMigrations(ctx, pool, 18)).To(Succeed())
 
-	// Assert each expected column is present...
-	var matched int
-	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT COUNT(*) FROM information_schema.columns
-		WHERE table_name = 'plugins'
-		  AND column_name IN ('id','name','display_name','version',
-		                      'manifest_hash','content_hash',
-		                      'first_seen_at','last_seen_at','gc_at')
-	`).Scan(&matched))
-	assert.Equal(t, 9, matched, "plugins must have all 9 expected columns")
-	// ...and assert there are NO extras (catches contract drift if a future
-	// migration adds a column without updating the named-column whitelist).
-	var total int
-	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT COUNT(*) FROM information_schema.columns
-		WHERE table_name = 'plugins'
-	`).Scan(&total))
-	assert.Equal(t, 9, total, "plugins MUST have exactly 9 columns (no extras)")
+			// Assert each expected column is present...
+			var matched int
+			Expect(pool.QueryRow(ctx, `
+				SELECT COUNT(*) FROM information_schema.columns
+				WHERE table_name = 'plugins'
+				  AND column_name IN ('id','name','display_name','version',
+				                      'manifest_hash','content_hash',
+				                      'first_seen_at','last_seen_at','gc_at')
+			`).Scan(&matched)).To(Succeed())
+			Expect(matched).To(Equal(9), "plugins must have all 9 expected columns")
 
-	var indexExists bool
-	require.NoError(t, pool.QueryRow(ctx, `
-		SELECT EXISTS (
-		    SELECT 1 FROM pg_indexes
-		    WHERE indexname = 'plugins_name_active'
-		      AND indexdef LIKE '%WHERE (gc_at IS NULL)%'
-		)
-	`).Scan(&indexExists))
-	assert.True(t, indexExists, "partial UNIQUE index plugins_name_active must exist")
-}
+			// ...and assert there are NO extras (catches contract drift if a future
+			// migration adds a column without updating the named-column whitelist).
+			var total int
+			Expect(pool.QueryRow(ctx, `
+				SELECT COUNT(*) FROM information_schema.columns
+				WHERE table_name = 'plugins'
+			`).Scan(&total)).To(Succeed())
+			Expect(total).To(Equal(9), "plugins MUST have exactly 9 columns (no extras)")
 
-func TestMigration000018TruncatesEventsAudit(t *testing.T) {
-	ctx := context.Background()
-	pool, cleanup := newTestPool(t)
-	defer cleanup()
+			var indexExists bool
+			Expect(pool.QueryRow(ctx, `
+				SELECT EXISTS (
+				    SELECT 1 FROM pg_indexes
+				    WHERE indexname = 'plugins_name_active'
+				      AND indexdef LIKE '%WHERE (gc_at IS NULL)%'
+				)
+			`).Scan(&indexExists)).To(Succeed())
+			Expect(indexExists).To(BeTrue(), "partial UNIQUE index plugins_name_active must exist")
+		})
+	})
 
-	require.NoError(t, runMigrations(ctx, pool, 17))
-	_, err := pool.Exec(ctx, `
-		INSERT INTO events_audit (id, subject, type, timestamp, actor_kind,
-		                         envelope, schema_ver, codec, js_seq, rendering)
-		VALUES ($1, 'test', 'test', now(), 'plugin', '\x00', 1, 'identity', 1, '{}'::jsonb)
-	`, []byte("0123456789abcdef"))
-	require.NoError(t, err)
+	Describe("events_audit truncation", func() {
+		It("truncates events_audit when applying migration 000018", func() {
+			ctx := context.Background()
+			pool, cleanup := newTestPool(suiteT)
+			defer cleanup()
 
-	require.NoError(t, runMigrations(ctx, pool, 18))
+			Expect(runMigrations(ctx, pool, 17)).To(Succeed())
+			_, err := pool.Exec(ctx, `
+				INSERT INTO events_audit (id, subject, type, timestamp, actor_kind,
+				                         envelope, schema_ver, codec, js_seq, rendering)
+				VALUES ($1, 'test', 'test', now(), 'plugin', '\x00', 1, 'identity', 1, '{}'::jsonb)
+			`, []byte("0123456789abcdef"))
+			Expect(err).NotTo(HaveOccurred())
 
-	var n int
-	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM events_audit`).Scan(&n))
-	assert.Equal(t, 0, n, "events_audit MUST be empty after migration 000018")
-}
+			Expect(runMigrations(ctx, pool, 18)).To(Succeed())
+
+			var n int
+			Expect(pool.QueryRow(ctx, `SELECT COUNT(*) FROM events_audit`).Scan(&n)).To(Succeed())
+			Expect(n).To(Equal(0), "events_audit MUST be empty after migration 000018")
+		})
+	})
+})

--- a/internal/store/migrations_audit_shape_integration_test.go
+++ b/internal/store/migrations_audit_shape_integration_test.go
@@ -8,287 +8,286 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"testing"
 	"time"
 
 	// Register pgx stdlib driver for database/sql.
 	_ "github.com/jackc/pgx/v5/stdlib"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// TestMigration000005AuditSourceComponentAppliesCleanly applies all migrations
-// against a fresh Postgres instance and asserts that the access_audit_log
-// table has the expected shape after 000005 has run: renamed event_id/event_name
-// columns, new source/component/message columns (NOT NULL), the old policy_id/
-// policy_name columns gone, and the idx_audit_log_source_component index created.
-func TestMigration000005AuditSourceComponentAppliesCleanly(t *testing.T) {
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.RawDatabase(t, shared)
-
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up())
-	require.NoError(t, migrator.Close())
-
-	db, err := sql.Open("pgx", connStr)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	// Assert the renamed columns exist.
-	assertColumnExists(t, db, "access_audit_log", "event_id")
-	assertColumnExists(t, db, "access_audit_log", "event_name")
-
-	// Assert the new columns exist with NOT NULL constraint.
-	assertColumnExistsNotNull(t, db, "access_audit_log", "source")
-	assertColumnExistsNotNull(t, db, "access_audit_log", "component")
-	assertColumnExistsNotNull(t, db, "access_audit_log", "message")
-
-	// Assert the old column names no longer exist.
-	assertColumnDoesNotExist(t, db, "access_audit_log", "policy_id")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "policy_name")
-
-	// Assert the source/component index was created.
-	assertIndexExists(t, db, "idx_audit_log_source_component")
-}
-
-// TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape
-// applies all migrations, then rolls back exactly one step via Steps(-1) and
-// verifies the access_audit_log schema is back to its pre-000005 shape:
-// policy_id/policy_name restored, source/component/message gone, and the
-// idx_audit_log_source_component index dropped.
-func TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape(t *testing.T) {
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.RawDatabase(t, shared)
-
-	// Apply all migrations (including 000005).
-	migratorUp, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migratorUp.Up())
-	require.NoError(t, migratorUp.Close())
-
-	db, err := sql.Open("pgx", connStr)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	// Sanity: after Up, 000005 is applied and the new shape is present.
-	migratorCheck, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	version, dirty, err := migratorCheck.Version()
-	require.NoError(t, err)
-	assert.GreaterOrEqual(t, version, uint(5), "000005 must be applied before testing rollback")
-	assert.False(t, dirty)
-	require.NoError(t, migratorCheck.Close())
-	assertColumnExists(t, db, "access_audit_log", "event_id")
-	assertColumnExists(t, db, "access_audit_log", "source")
-
-	// Migrate down to version 4 (just before 000005_audit_source_component)
-	// to restore the pre-000005 audit schema shape. Using Migrate(4) instead
-	// of Steps(-N) so the test doesn't break when new migrations are added.
-	migratorDown, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migratorDown.Migrate(4))
-	require.NoError(t, migratorDown.Close())
-
-	// After down, the original shape is restored.
-	assertColumnExists(t, db, "access_audit_log", "policy_id")
-	assertColumnExists(t, db, "access_audit_log", "policy_name")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "event_id")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "event_name")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "source")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "component")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "message")
-
-	// Index should also be dropped.
-	var count int
-	require.NoError(t, db.QueryRow(
-		`SELECT count(*) FROM pg_indexes WHERE indexname = $1`,
-		"idx_audit_log_source_component",
-	).Scan(&count))
-	assert.Equal(t, 0, count, "source/component index should be dropped on rollback")
-}
-
-// TestMigration000005AuditSourceComponentBackfillsExistingRows stops migrations
-// at version 4 (pre-000005), inserts a row using the old policy_id/policy_name
-// schema, then applies 000005 and verifies the row was preserved under the
-// renamed columns and backfilled with the migration's default source/component/
-// message values.
-//
-// The table is partitioned by timestamp, so the test must first create a
-// partition covering the row's timestamp before INSERT.
-func TestMigration000005AuditSourceComponentBackfillsExistingRows(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.RawDatabase(t, shared)
-
-	// Apply migrations up to and including 000004 (but NOT 000005).
-	// The project's Migrator does not have a Migrate(version) method; it
-	// exposes Steps(n), so we apply exactly 4 steps from a fresh database.
-	migratorEarly, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migratorEarly.Steps(4))
-	require.NoError(t, migratorEarly.Close())
-
-	db, err := sql.Open("pgx", connStr)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	// Sanity: we should be at version 4 with the OLD schema shape.
-	assertColumnExists(t, db, "access_audit_log", "policy_id")
-	assertColumnExists(t, db, "access_audit_log", "policy_name")
-	assertColumnDoesNotExist(t, db, "access_audit_log", "source")
-
-	// Create a partition for the row we are about to insert. The audit
-	// table is partitioned by RANGE(timestamp); production creates these
-	// at bootstrap, not in migrations, so the test must do it explicitly.
-	_, err = db.ExecContext(ctx, `
-		CREATE TABLE access_audit_log_2026_04 PARTITION OF access_audit_log
-		FOR VALUES FROM ('2026-04-01') TO ('2026-05-01')
-	`)
-	require.NoError(t, err)
-
-	// Insert a row into access_audit_log using the pre-000005 schema
-	// (policy_id/policy_name columns, no source/component/message).
-	_, err = db.ExecContext(ctx, `
-		INSERT INTO access_audit_log (
-			id, timestamp, subject, action, resource, effect,
-			policy_id, policy_name, attributes, duration_us
-		) VALUES (
-			'seed-test-id',
-			'2026-04-15T12:00:00Z'::timestamptz,
-			'character:01ABC', 'read', 'location:01XYZ', 'allow',
-			'allow-read', 'Allow Read', '{}'::jsonb, 100
-		)
-	`)
-	require.NoError(t, err)
-
-	// Now apply 000005.
-	migratorFinal, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migratorFinal.Up())
-	require.NoError(t, migratorFinal.Close())
-
-	// Query the existing row through the new column names — it should
-	// have been preserved, and the new columns should contain the
-	// migration defaults.
-	var source, component, message, eventID, eventName string
-	err = db.QueryRow(`
-		SELECT source, component, message, event_id, event_name
-		FROM access_audit_log
-		WHERE id = $1
-	`, "seed-test-id").Scan(&source, &component, &message, &eventID, &eventName)
-	require.NoError(t, err)
-
-	assert.Equal(t, "engine", source, "pre-existing rows should be backfilled with source='engine'")
-	assert.Equal(t, "abac", component, "pre-existing rows should be backfilled with component='abac'")
-	assert.Equal(t, "", message, "pre-existing rows should have empty message")
-	assert.Equal(t, "allow-read", eventID, "existing policy_id value should be renamed to event_id")
-	assert.Equal(t, "Allow Read", eventName, "existing policy_name value should be renamed to event_name")
-}
-
-// TestEventsAuditHasDEKColumnsAfterMigration014 applies all migrations against
-// a fresh Postgres instance and asserts the events_audit table has the
-// dek_ref BIGINT and dek_version INTEGER columns (both nullable) plus the
-// partial index events_audit_dek_ref ON (dek_ref) WHERE dek_ref IS NOT NULL
-// after migration 000014 has run.
-func TestEventsAuditHasDEKColumnsAfterMigration014(t *testing.T) {
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.RawDatabase(t, shared)
-
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err)
-	require.NoError(t, migrator.Up())
-	require.NoError(t, migrator.Close())
-
-	db, err := sql.Open("pgx", connStr)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	// dek_ref column — BIGINT, nullable.
-	var dataType, isNullable string
-	err = db.QueryRow(`
-		SELECT data_type, is_nullable
-		  FROM information_schema.columns
-		 WHERE table_name = 'events_audit' AND column_name = 'dek_ref'
-	`).Scan(&dataType, &isNullable)
-	require.NoError(t, err)
-	assert.Equal(t, "bigint", dataType)
-	assert.Equal(t, "YES", isNullable)
-
-	// dek_version column — INTEGER, nullable.
-	err = db.QueryRow(`
-		SELECT data_type, is_nullable
-		  FROM information_schema.columns
-		 WHERE table_name = 'events_audit' AND column_name = 'dek_version'
-	`).Scan(&dataType, &isNullable)
-	require.NoError(t, err)
-	assert.Equal(t, "integer", dataType)
-	assert.Equal(t, "YES", isNullable)
-
-	// Partial index on dek_ref.
-	var indexCount int
-	err = db.QueryRow(`
-		SELECT count(*)
-		  FROM pg_indexes
-		 WHERE tablename = 'events_audit' AND indexname = 'events_audit_dek_ref'
-	`).Scan(&indexCount)
-	require.NoError(t, err)
-	assert.Equal(t, 1, indexCount)
-}
-
-// assertColumnExists fails the test if table.column is not present in
+// assertColumnExists fails the spec if table.column is not present in
 // information_schema.columns.
-func assertColumnExists(t *testing.T, db *sql.DB, table, column string) {
-	t.Helper()
+func assertColumnExists(db *sql.DB, table, column string) {
+	GinkgoHelper()
 	var count int
 	err := db.QueryRow(`
 		SELECT count(*) FROM information_schema.columns
 		WHERE table_name = $1 AND column_name = $2
 	`, table, column).Scan(&count)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count, "expected column %s.%s to exist", table, column)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(count).To(Equal(1), "expected column %s.%s to exist", table, column)
 }
 
-// assertColumnExistsNotNull fails the test if table.column is missing or is
+// assertColumnExistsNotNull fails the spec if table.column is missing or is
 // nullable.
-func assertColumnExistsNotNull(t *testing.T, db *sql.DB, table, column string) {
-	t.Helper()
+func assertColumnExistsNotNull(db *sql.DB, table, column string) {
+	GinkgoHelper()
 	var isNullable string
 	err := db.QueryRow(`
 		SELECT is_nullable FROM information_schema.columns
 		WHERE table_name = $1 AND column_name = $2
 	`, table, column).Scan(&isNullable)
-	require.NoError(t, err, "column %s.%s not found", table, column)
-	assert.Equal(t, "NO", isNullable, "column %s.%s should be NOT NULL", table, column)
+	Expect(err).NotTo(HaveOccurred(), "column %s.%s not found", table, column)
+	Expect(isNullable).To(Equal("NO"), "column %s.%s should be NOT NULL", table, column)
 }
 
-// assertColumnDoesNotExist fails the test if table.column IS present in
+// assertColumnDoesNotExist fails the spec if table.column IS present in
 // information_schema.columns.
-func assertColumnDoesNotExist(t *testing.T, db *sql.DB, table, column string) {
-	t.Helper()
+func assertColumnDoesNotExist(db *sql.DB, table, column string) {
+	GinkgoHelper()
 	var count int
 	err := db.QueryRow(`
 		SELECT count(*) FROM information_schema.columns
 		WHERE table_name = $1 AND column_name = $2
 	`, table, column).Scan(&count)
-	require.NoError(t, err)
-	assert.Equal(t, 0, count, "expected column %s.%s to NOT exist after migration", table, column)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(count).To(Equal(0), "expected column %s.%s to NOT exist after migration", table, column)
 }
 
-// assertIndexExists fails the test if the named index is not present in
+// assertIndexExists fails the spec if the named index is not present in
 // pg_indexes.
-func assertIndexExists(t *testing.T, db *sql.DB, indexName string) {
-	t.Helper()
+func assertIndexExists(db *sql.DB, indexName string) {
+	GinkgoHelper()
 	var count int
 	err := db.QueryRow(`
 		SELECT count(*) FROM pg_indexes
 		WHERE indexname = $1
 	`, indexName).Scan(&count)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count, "expected index %s to exist", indexName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(count).To(Equal(1), "expected index %s to exist", indexName)
 }
+
+var _ = Describe("Migration 000005 audit source/component", func() {
+	// TestMigration000005AuditSourceComponentAppliesCleanly applies all migrations
+	// against a fresh Postgres instance and asserts that the access_audit_log
+	// table has the expected shape after 000005 has run: renamed event_id/event_name
+	// columns, new source/component/message columns (NOT NULL), the old policy_id/
+	// policy_name columns gone, and the idx_audit_log_source_component index created.
+	It("applies cleanly and produces expected access_audit_log shape", func() {
+		connStr := testutil.RawDatabase(suiteT, sharedPG)
+
+		migrator, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrator.Up()).To(Succeed())
+		Expect(migrator.Close()).To(Succeed())
+
+		db, err := sql.Open("pgx", connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+
+		// Assert the renamed columns exist.
+		assertColumnExists(db, "access_audit_log", "event_id")
+		assertColumnExists(db, "access_audit_log", "event_name")
+
+		// Assert the new columns exist with NOT NULL constraint.
+		assertColumnExistsNotNull(db, "access_audit_log", "source")
+		assertColumnExistsNotNull(db, "access_audit_log", "component")
+		assertColumnExistsNotNull(db, "access_audit_log", "message")
+
+		// Assert the old column names no longer exist.
+		assertColumnDoesNotExist(db, "access_audit_log", "policy_id")
+		assertColumnDoesNotExist(db, "access_audit_log", "policy_name")
+
+		// Assert the source/component index was created.
+		assertIndexExists(db, "idx_audit_log_source_component")
+	})
+
+	// TestMigration000005AuditSourceComponentRollbackReturnsSchemaToOriginalShape
+	// applies all migrations, then rolls back exactly one step via Steps(-1) and
+	// verifies the access_audit_log schema is back to its pre-000005 shape:
+	// policy_id/policy_name restored, source/component/message gone, and the
+	// idx_audit_log_source_component index dropped.
+	It("rollback returns access_audit_log schema to original pre-000005 shape", func() {
+		connStr := testutil.RawDatabase(suiteT, sharedPG)
+
+		// Apply all migrations (including 000005).
+		migratorUp, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migratorUp.Up()).To(Succeed())
+		Expect(migratorUp.Close()).To(Succeed())
+
+		db, err := sql.Open("pgx", connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+
+		// Sanity: after Up, 000005 is applied and the new shape is present.
+		migratorCheck, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		version, dirty, err := migratorCheck.Version()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(BeNumerically(">=", uint(5)), "000005 must be applied before testing rollback")
+		Expect(dirty).To(BeFalse())
+		Expect(migratorCheck.Close()).To(Succeed())
+		assertColumnExists(db, "access_audit_log", "event_id")
+		assertColumnExists(db, "access_audit_log", "source")
+
+		// Migrate down to version 4 (just before 000005_audit_source_component)
+		// to restore the pre-000005 audit schema shape. Using Migrate(4) instead
+		// of Steps(-N) so the test doesn't break when new migrations are added.
+		migratorDown, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migratorDown.Migrate(4)).To(Succeed())
+		Expect(migratorDown.Close()).To(Succeed())
+
+		// After down, the original shape is restored.
+		assertColumnExists(db, "access_audit_log", "policy_id")
+		assertColumnExists(db, "access_audit_log", "policy_name")
+		assertColumnDoesNotExist(db, "access_audit_log", "event_id")
+		assertColumnDoesNotExist(db, "access_audit_log", "event_name")
+		assertColumnDoesNotExist(db, "access_audit_log", "source")
+		assertColumnDoesNotExist(db, "access_audit_log", "component")
+		assertColumnDoesNotExist(db, "access_audit_log", "message")
+
+		// Index should also be dropped.
+		var count int
+		Expect(db.QueryRow(
+			`SELECT count(*) FROM pg_indexes WHERE indexname = $1`,
+			"idx_audit_log_source_component",
+		).Scan(&count)).To(Succeed())
+		Expect(count).To(Equal(0), "source/component index should be dropped on rollback")
+	})
+
+	// TestMigration000005AuditSourceComponentBackfillsExistingRows stops migrations
+	// at version 4 (pre-000005), inserts a row using the old policy_id/policy_name
+	// schema, then applies 000005 and verifies the row was preserved under the
+	// renamed columns and backfilled with the migration's default source/component/
+	// message values.
+	//
+	// The table is partitioned by timestamp, so the test must first create a
+	// partition covering the row's timestamp before INSERT.
+	It("backfills existing rows with default source/component/message values", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		connStr := testutil.RawDatabase(suiteT, sharedPG)
+
+		// Apply migrations up to and including 000004 (but NOT 000005).
+		// The project's Migrator does not have a Migrate(version) method; it
+		// exposes Steps(n), so we apply exactly 4 steps from a fresh database.
+		migratorEarly, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migratorEarly.Steps(4)).To(Succeed())
+		Expect(migratorEarly.Close()).To(Succeed())
+
+		db, err := sql.Open("pgx", connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+
+		// Sanity: we should be at version 4 with the OLD schema shape.
+		assertColumnExists(db, "access_audit_log", "policy_id")
+		assertColumnExists(db, "access_audit_log", "policy_name")
+		assertColumnDoesNotExist(db, "access_audit_log", "source")
+
+		// Create a partition for the row we are about to insert. The audit
+		// table is partitioned by RANGE(timestamp); production creates these
+		// at bootstrap, not in migrations, so the test must do it explicitly.
+		_, err = db.ExecContext(ctx, `
+			CREATE TABLE access_audit_log_2026_04 PARTITION OF access_audit_log
+			FOR VALUES FROM ('2026-04-01') TO ('2026-05-01')
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Insert a row into access_audit_log using the pre-000005 schema
+		// (policy_id/policy_name columns, no source/component/message).
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO access_audit_log (
+				id, timestamp, subject, action, resource, effect,
+				policy_id, policy_name, attributes, duration_us
+			) VALUES (
+				'seed-test-id',
+				'2026-04-15T12:00:00Z'::timestamptz,
+				'character:01ABC', 'read', 'location:01XYZ', 'allow',
+				'allow-read', 'Allow Read', '{}'::jsonb, 100
+			)
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Now apply 000005.
+		migratorFinal, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migratorFinal.Up()).To(Succeed())
+		Expect(migratorFinal.Close()).To(Succeed())
+
+		// Query the existing row through the new column names — it should
+		// have been preserved, and the new columns should contain the
+		// migration defaults.
+		var source, component, message, eventID, eventName string
+		err = db.QueryRow(`
+			SELECT source, component, message, event_id, event_name
+			FROM access_audit_log
+			WHERE id = $1
+		`, "seed-test-id").Scan(&source, &component, &message, &eventID, &eventName)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(source).To(Equal("engine"), "pre-existing rows should be backfilled with source='engine'")
+		Expect(component).To(Equal("abac"), "pre-existing rows should be backfilled with component='abac'")
+		Expect(message).To(Equal(""), "pre-existing rows should have empty message")
+		Expect(eventID).To(Equal("allow-read"), "existing policy_id value should be renamed to event_id")
+		Expect(eventName).To(Equal("Allow Read"), "existing policy_name value should be renamed to event_name")
+	})
+})
+
+var _ = Describe("Migration 000014 events_audit DEK columns", func() {
+	// TestEventsAuditHasDEKColumnsAfterMigration014 applies all migrations against
+	// a fresh Postgres instance and asserts the events_audit table has the
+	// dek_ref BIGINT and dek_version INTEGER columns (both nullable) plus the
+	// partial index events_audit_dek_ref ON (dek_ref) WHERE dek_ref IS NOT NULL
+	// after migration 000014 has run.
+	It("has dek_ref BIGINT, dek_version INTEGER (both nullable), and partial index after migration 000014", func() {
+		connStr := testutil.RawDatabase(suiteT, sharedPG)
+
+		migrator, err := store.NewMigrator(connStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrator.Up()).To(Succeed())
+		Expect(migrator.Close()).To(Succeed())
+
+		db, err := sql.Open("pgx", connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(db.Close)
+
+		// dek_ref column — BIGINT, nullable.
+		var dataType, isNullable string
+		err = db.QueryRow(`
+			SELECT data_type, is_nullable
+			  FROM information_schema.columns
+			 WHERE table_name = 'events_audit' AND column_name = 'dek_ref'
+		`).Scan(&dataType, &isNullable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dataType).To(Equal("bigint"))
+		Expect(isNullable).To(Equal("YES"))
+
+		// dek_version column — INTEGER, nullable.
+		err = db.QueryRow(`
+			SELECT data_type, is_nullable
+			  FROM information_schema.columns
+			 WHERE table_name = 'events_audit' AND column_name = 'dek_version'
+		`).Scan(&dataType, &isNullable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dataType).To(Equal("integer"))
+		Expect(isNullable).To(Equal("YES"))
+
+		// Partial index on dek_ref.
+		var indexCount int
+		err = db.QueryRow(`
+			SELECT count(*)
+			  FROM pg_indexes
+			 WHERE tablename = 'events_audit' AND indexname = 'events_audit_dek_ref'
+		`).Scan(&indexCount)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(indexCount).To(Equal(1))
+	})
+})

--- a/internal/store/role_store_integration_test.go
+++ b/internal/store/role_store_integration_test.go
@@ -8,11 +8,11 @@ package store_test
 import (
 	"context"
 
-	"github.com/oklog/ulid/v2"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/store"
 )
 
@@ -24,8 +24,8 @@ var _ = Describe("RoleStore", func() {
 			defer cleanup()
 			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
-			playerID := ulid.Make().String()
-			charID := ulid.Make().String()
+			playerID := idgen.New().String()
+			charID := idgen.New().String()
 			_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
 				VALUES ($1, $2, $3, now(), now())`, playerID, "alice-"+playerID[:8], "hash")
 			Expect(err).NotTo(HaveOccurred())
@@ -47,8 +47,8 @@ var _ = Describe("RoleStore", func() {
 			defer cleanup()
 			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
-			playerID := ulid.Make().String()
-			charID := ulid.Make().String()
+			playerID := idgen.New().String()
+			charID := idgen.New().String()
 			_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
 				VALUES ($1, $2, $3, now(), now())`, playerID, "bob-"+playerID[:8], "hash")
 			Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("RoleStore", func() {
 			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
 			rs := store.NewPostgresRoleStore(pool)
-			has, err := rs.PlayerHasRole(ctx, ulid.Make().String(), access.RoleAdmin)
+			has, err := rs.PlayerHasRole(ctx, idgen.New().String(), access.RoleAdmin)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(has).To(BeFalse())
 		})

--- a/internal/store/role_store_integration_test.go
+++ b/internal/store/role_store_integration_test.go
@@ -7,71 +7,75 @@ package store_test
 
 import (
 	"context"
-	"testing"
 
 	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/store"
 )
 
-func TestPlayerHasRole_ReturnsTrueForPlayerWithAdminCharacter(t *testing.T) {
-	ctx := context.Background()
-	pool, cleanup := newTestPool(t)
-	defer cleanup()
-	require.NoError(t, runMigrations(ctx, pool, 20))
+var _ = Describe("RoleStore", func() {
+	Describe("PlayerHasRole", func() {
+		It("returns true for player with admin character", func() {
+			ctx := context.Background()
+			pool, cleanup := newTestPool(suiteT)
+			defer cleanup()
+			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
-	playerID := ulid.Make().String()
-	charID := ulid.Make().String()
-	_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
-		VALUES ($1, $2, $3, now(), now())`, playerID, "alice-"+playerID[:8], "hash")
-	require.NoError(t, err)
-	_, err = pool.Exec(ctx, `INSERT INTO characters (id, player_id, name)
-		VALUES ($1, $2, $3)`, charID, playerID, "Alice-"+charID[:8])
-	require.NoError(t, err)
+			playerID := ulid.Make().String()
+			charID := ulid.Make().String()
+			_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
+				VALUES ($1, $2, $3, now(), now())`, playerID, "alice-"+playerID[:8], "hash")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = pool.Exec(ctx, `INSERT INTO characters (id, player_id, name)
+				VALUES ($1, $2, $3)`, charID, playerID, "Alice-"+charID[:8])
+			Expect(err).NotTo(HaveOccurred())
 
-	rs := store.NewPostgresRoleStore(pool)
-	require.NoError(t, rs.AddRole(ctx, charID, access.RoleAdmin))
+			rs := store.NewPostgresRoleStore(pool)
+			Expect(rs.AddRole(ctx, charID, access.RoleAdmin)).To(Succeed())
 
-	has, err := rs.PlayerHasRole(ctx, playerID, access.RoleAdmin)
-	require.NoError(t, err)
-	require.True(t, has)
-}
+			has, err := rs.PlayerHasRole(ctx, playerID, access.RoleAdmin)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(has).To(BeTrue())
+		})
 
-func TestPlayerHasRole_ReturnsFalseForPlayerWithoutAnyAdminCharacter(t *testing.T) {
-	ctx := context.Background()
-	pool, cleanup := newTestPool(t)
-	defer cleanup()
-	require.NoError(t, runMigrations(ctx, pool, 20))
+		It("returns false for player without any admin character", func() {
+			ctx := context.Background()
+			pool, cleanup := newTestPool(suiteT)
+			defer cleanup()
+			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
-	playerID := ulid.Make().String()
-	charID := ulid.Make().String()
-	_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
-		VALUES ($1, $2, $3, now(), now())`, playerID, "bob-"+playerID[:8], "hash")
-	require.NoError(t, err)
-	_, err = pool.Exec(ctx, `INSERT INTO characters (id, player_id, name)
-		VALUES ($1, $2, $3)`, charID, playerID, "Bob-"+charID[:8])
-	require.NoError(t, err)
+			playerID := ulid.Make().String()
+			charID := ulid.Make().String()
+			_, err := pool.Exec(ctx, `INSERT INTO players (id, username, password_hash, created_at, updated_at)
+				VALUES ($1, $2, $3, now(), now())`, playerID, "bob-"+playerID[:8], "hash")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = pool.Exec(ctx, `INSERT INTO characters (id, player_id, name)
+				VALUES ($1, $2, $3)`, charID, playerID, "Bob-"+charID[:8])
+			Expect(err).NotTo(HaveOccurred())
 
-	rs := store.NewPostgresRoleStore(pool)
-	// Add and then remove to assert the negative path explicitly.
-	require.NoError(t, rs.AddRole(ctx, charID, access.RoleAdmin))
-	require.NoError(t, rs.RemoveRole(ctx, charID, access.RoleAdmin))
+			rs := store.NewPostgresRoleStore(pool)
+			// Add and then remove to assert the negative path explicitly.
+			Expect(rs.AddRole(ctx, charID, access.RoleAdmin)).To(Succeed())
+			Expect(rs.RemoveRole(ctx, charID, access.RoleAdmin)).To(Succeed())
 
-	has, err := rs.PlayerHasRole(ctx, playerID, access.RoleAdmin)
-	require.NoError(t, err)
-	require.False(t, has)
-}
+			has, err := rs.PlayerHasRole(ctx, playerID, access.RoleAdmin)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
 
-func TestPlayerHasRole_ReturnsFalseForUnknownPlayer(t *testing.T) {
-	ctx := context.Background()
-	pool, cleanup := newTestPool(t)
-	defer cleanup()
-	require.NoError(t, runMigrations(ctx, pool, 20))
+		It("returns false for unknown player", func() {
+			ctx := context.Background()
+			pool, cleanup := newTestPool(suiteT)
+			defer cleanup()
+			Expect(runMigrations(ctx, pool, 20)).To(Succeed())
 
-	rs := store.NewPostgresRoleStore(pool)
-	has, err := rs.PlayerHasRole(ctx, ulid.Make().String(), access.RoleAdmin)
-	require.NoError(t, err)
-	require.False(t, has)
-}
+			rs := store.NewPostgresRoleStore(pool)
+			has, err := rs.PlayerHasRole(ctx, ulid.Make().String(), access.RoleAdmin)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+	})
+})

--- a/internal/store/store_suite_test.go
+++ b/internal/store/store_suite_test.go
@@ -10,12 +10,21 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
 )
 
-var suiteT *testing.T
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+)
 
 func TestStore(t *testing.T) {
 	suiteT = t
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Store Suite")
 }
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+})


### PR DESCRIPTION
## Summary

Part of holomush-1hq.26 / holomush-rccc Stage B (re-purposed bead holomush-1hq.60). Converts 4 plain-`testing.T` integration test files in `internal/store/` to Ginkgo specs registered into the existing `Store Suite` at `store_suite_test.go:20`. Single commit.

**Files:** migrate_integration_test.go (6 funcs, 619 lines), migrate_plugins_integration_test.go (2 funcs), migrations_audit_shape_integration_test.go (4 funcs — schema-sensitive, assertion ordering preserved), role_store_integration_test.go (3 funcs).

## Pattern

Uses the `suiteT` capture pattern (the cluster of ~30 existing Ginkgo specs in this codebase do) — not `GinkgoT()`, which cannot satisfy `testing.TB` due to Go 1.26's intentional `private()` method. Matches the corrected pattern established in PR #3951.

No INV-P7-N carrier funcs in scope; no meta-test edits required.

Closes holomush-1hq.60.

## Test plan

- [x] Per-PR gates: \`rg -c 'RunSpecs' internal/store/\` = 1; \`rg 't.Skip(' internal/store/\` = 0; converted files have 0 \`func Test\`/\`t.Run\`
- [ ] CI gates: lint, test, integration, E2E (this PR's CI run is the authoritative gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Rewrote and consolidated integration tests for migrations and store behavior into a Ginkgo/Gomega test suite; preserved existing scenarios and validation coverage.
* **Chores**
  * Introduced a shared Postgres test environment for the suite.

No user-visible changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->