### PR TITLE
test(integration/crypto): migrate 3 files to Ginkgo (1hq.26 A3)

### DIFF
--- a/test/integration/crypto/emit_test.go
+++ b/test/integration/crypto/emit_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/proto"
 
 	"github.com/holomush/holomush/internal/core"
@@ -52,158 +52,160 @@ func (f fixedPool) Pool() *pgxpool.Pool { return f.pool }
 // (INV-21). AAD-bind tamper detection (INV-25) is unit-tested in
 // internal/eventbus/codec/xchacha20poly1305_test.go; full decrypt
 // round-trip is Phase 3b's job (subscribe path).
-func TestSensitiveEmitProducesCiphertextOnBusAndInAudit(t *testing.T) {
-	ctx := context.Background()
+var _ = Describe("Sensitive emit produces ciphertext on bus and in audit (INV-21)", func() {
+	It("emits encrypted envelope to JetStream and matching events_audit row", func() {
+		ctx := context.Background()
 
-	// PG: shared container + per-test migrated DB. NewPGPool/StartPostgres
-	// shorthands cited in the plan don't exist in test/testutil; use the
-	// existing SharedPostgres + FreshDatabase + pgxpool pattern that the
-	// rest of test/integration uses.
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.FreshDatabase(t, shared)
-	pool := newPool(t, connStr)
+		// PG: shared container + per-test migrated DB. NewPGPool/StartPostgres
+		// shorthands cited in the plan don't exist in test/testutil; use the
+		// existing SharedPostgres + FreshDatabase + pgxpool pattern that the
+		// rest of test/integration uses.
+		shared := testutil.SharedPostgres(suiteT)
+		connStr := testutil.FreshDatabase(suiteT, shared)
+		pool := newPool(suiteT, connStr)
 
-	bus := testutil.StartEmbeddedJetStream(t)
+		bus := testutil.StartEmbeddedJetStream(suiteT)
 
-	// KEK source: env-backed test KEK (32 random bytes hex-encoded).
-	kekHex := testutil.RandomKEKHex(t)
-	t.Setenv("HOLOMUSH_TEST_KEK", kekHex)
-	kekSource := kek.NewEnvSource("HOLOMUSH_TEST_KEK", false)
+		// KEK source: env-backed test KEK (32 random bytes hex-encoded).
+		kekHex := testutil.RandomKEKHex(suiteT)
+		suiteT.Setenv("HOLOMUSH_TEST_KEK", kekHex)
+		kekSource := kek.NewEnvSource("HOLOMUSH_TEST_KEK", false)
 
-	provider, err := kek.NewLocalAEADProvider(ctx, kekSource, pool)
-	require.NoError(t, err)
+		provider, err := kek.NewLocalAEADProvider(ctx, kekSource, pool)
+		Expect(err).NotTo(HaveOccurred())
 
-	// dek.NewStore(pool) / dek.NewCache(cfg) / dek.NewManager(...)
-	// signatures verified at:
-	//   internal/eventbus/crypto/dek/store.go:77
-	//   internal/eventbus/crypto/dek/cache.go:74
-	//   internal/eventbus/crypto/dek/manager.go:49
-	dekStore := dek.NewStore(pool)
-	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
-	dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
-	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
-		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
-		&dekBindingStub{bindingID: "bind-emit"})
-	require.NoError(t, err)
+		// dek.NewStore(pool) / dek.NewCache(cfg) / dek.NewManager(...)
+		// signatures verified at:
+		//   internal/eventbus/crypto/dek/store.go:77
+		//   internal/eventbus/crypto/dek/cache.go:74
+		//   internal/eventbus/crypto/dek/manager.go:49
+		dekStore := dek.NewStore(pool)
+		dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
+		dekPartCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64})
+		dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
+			func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+			&dekBindingStub{bindingID: "bind-emit"})
+		Expect(err).NotTo(HaveOccurred())
 
-	// Stand up the audit projection so events_audit gets populated.
-	// audit.Config{} (no OwnerMap) means host owns every subject.
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
+		// Stand up the audit projection so events_audit gets populated.
+		// audit.Config{} (no OwnerMap) means host owns every subject.
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
 
-	manifest := &plugins.Manifest{
-		Name:                "test-plugin",
-		Emits:               []string{"scene"},
-		ActorKindsClaimable: []string{"plugin"},
-		Crypto: &plugins.CryptoSection{
-			Emits: []plugins.CryptoEmit{
-				{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+		manifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"scene"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
 			},
-		},
-	}
-	manifestLookup := func(name string) *plugins.Manifest {
-		if name == "test-plugin" {
-			return manifest
 		}
-		return nil
-	}
-	// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
-	// coreActorToEventbusActor rejects non-ULID IDs).
-	testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
-	actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
-		return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
-	}
+		manifestLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return manifest
+			}
+			return nil
+		}
+		// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
+		// coreActorToEventbusActor rejects non-ULID IDs).
+		testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
+		}
 
-	// Verb registry: register test-plugin:whisper so RenderingPublisher
-	// can stamp App-Rendering (the audit projection rejects messages
-	// without it). Uses BootstrapVerbRegistry to pick up the host
-	// builtins, then RegisterWithSource for our plugin verb.
-	registry, err := core.BootstrapVerbRegistry("test")
-	require.NoError(t, err)
-	require.NoError(t, registry.RegisterWithSource(core.VerbRegistration{
-		Type:          "test-plugin:whisper",
-		Category:      "communication",
-		Format:        "speech",
-		Label:         "whispers",
-		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
-		Source:        "test-plugin",
-	}, "1.0.0"))
+		// Verb registry: register test-plugin:whisper so RenderingPublisher
+		// can stamp App-Rendering (the audit projection rejects messages
+		// without it). Uses BootstrapVerbRegistry to pick up the host
+		// builtins, then RegisterWithSource for our plugin verb.
+		registry, err := core.BootstrapVerbRegistry("test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(registry.RegisterWithSource(core.VerbRegistration{
+			Type:          "test-plugin:whisper",
+			Category:      "communication",
+			Format:        "speech",
+			Label:         "whispers",
+			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			Source:        "test-plugin",
+		}, "1.0.0")).NotTo(HaveOccurred())
 
-	// NewJetStreamPublisher signature verified at publisher.go:151:
-	//   func NewJetStreamPublisher(js jetstream.JetStream, cfg Config, opts ...PublishOption) *JetStreamPublisher
-	// bus.JS is the public field on eventbustest.Embedded (embedded.go:50).
-	rawPub := eventbus.NewJetStreamPublisher(
-		bus.JS,
-		eventbus.Config{}.Defaults(),
-		eventbus.WithDEKManager(dekMgr),
-	)
-	// RenderingPublisher stamps the App-Rendering header that the audit
-	// projection requires; it is the single writer of that header.
-	hostPub := eventbus.NewRenderingPublisher(rawPub, registry)
+		// NewJetStreamPublisher signature verified at publisher.go:151:
+		//   func NewJetStreamPublisher(js jetstream.JetStream, cfg Config, opts ...PublishOption) *JetStreamPublisher
+		// bus.JS is the public field on eventbustest.Embedded (embedded.go:50).
+		rawPub := eventbus.NewJetStreamPublisher(
+			bus.JS,
+			eventbus.Config{}.Defaults(),
+			eventbus.WithDEKManager(dekMgr),
+		)
+		// RenderingPublisher stamps the App-Rendering header that the audit
+		// projection requires; it is the single writer of that header.
+		hostPub := eventbus.NewRenderingPublisher(rawPub, registry)
 
-	// Phase 3a sensitivity fence is gated behind WithCryptoEnabled —
-	// this E2E exercises the enabled path end-to-end (encrypt + audit).
-	emitter := plugins.NewPluginEventEmitter(
-		hostPub, manifestLookup, actorResolver,
-		plugins.WithCryptoEnabled(true),
-	)
+		// Phase 3a sensitivity fence is gated behind WithCryptoEnabled —
+		// this E2E exercises the enabled path end-to-end (encrypt + audit).
+		emitter := plugins.NewPluginEventEmitter(
+			hostPub, manifestLookup, actorResolver,
+			plugins.WithCryptoEnabled(true),
+		)
 
-	const plaintext = `{"text":"hello, secret world"}`
-	intent := pluginsdk.EmitIntent{
-		Subject:   "scene:01HXXXTESTSCENE000000000",
-		Type:      pluginsdk.EventType("test-plugin:whisper"),
-		Payload:   plaintext,
-		Sensitive: true,
-	}
-	require.NoError(t, emitter.Emit(ctx, "test-plugin", intent))
+		const plaintext = `{"text":"hello, secret world"}`
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene:01HXXXTESTSCENE000000000",
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   plaintext,
+			Sensitive: true,
+		}
+		Expect(emitter.Emit(ctx, "test-plugin", intent)).NotTo(HaveOccurred())
 
-	// 1. Bus assertion. The emitter's subjectxlate.Legacy translates
-	// scene:<id> → events.main.scene.<id>; subscribe to events.> to
-	// avoid coupling to the exact translated subject shape.
-	msg := testutil.WaitForOneJetStreamMsg(t, bus, "events.>", testutil.DefaultWait)
-	headers := msg.Headers()
-	assert.Equal(t, "xchacha20poly1305-v1", headers.Get(eventbus.HeaderCodec))
-	dekRefHdr := headers.Get(eventbus.HeaderDekRef)
-	dekVerHdr := headers.Get(eventbus.HeaderDekVersion)
-	require.NotEmpty(t, dekRefHdr)
-	require.NotEmpty(t, dekVerHdr)
-	assert.NotEqual(t, []byte(plaintext), msg.Data(), "payload must be ciphertext")
+		// 1. Bus assertion. The emitter's subjectxlate.Legacy translates
+		// scene:<id> → events.main.scene.<id>; subscribe to events.> to
+		// avoid coupling to the exact translated subject shape.
+		msg := testutil.WaitForOneJetStreamMsg(suiteT, bus, "events.>", testutil.DefaultWait)
+		headers := msg.Headers()
+		Expect(headers.Get(eventbus.HeaderCodec)).To(Equal("xchacha20poly1305-v1"))
+		dekRefHdr := headers.Get(eventbus.HeaderDekRef)
+		dekVerHdr := headers.Get(eventbus.HeaderDekVersion)
+		Expect(dekRefHdr).NotTo(BeEmpty())
+		Expect(dekVerHdr).NotTo(BeEmpty())
+		Expect(msg.Data()).NotTo(Equal([]byte(plaintext)), "payload must be ciphertext")
 
-	// 2. Audit row mirrors bus (INV-21). Wait for the projection to
-	// drain so the INSERT lands before we query.
-	hostSub.AwaitDrained(t, 10*time.Second)
+		// 2. Audit row mirrors bus (INV-21). Wait for the projection to
+		// drain so the INSERT lands before we query.
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
 
-	natsMsgID := headers.Get("Nats-Msg-Id")
-	require.NotEmpty(t, natsMsgID)
-	idBytes := testutil.MustParseULID(t, natsMsgID).Bytes()
-	row := testutil.QueryEventsAuditByID(t, pool, idBytes)
-	assert.Equal(t, "xchacha20poly1305-v1", row.Codec)
-	require.NotNil(t, row.DekRef)
-	gotRef, err := strconv.ParseInt(dekRefHdr, 10, 64)
-	require.NoError(t, err)
-	assert.Equal(t, gotRef, *row.DekRef)
-	require.NotNil(t, row.DekVersion)
-	gotVer, err := strconv.ParseInt(dekVerHdr, 10, 32)
-	require.NoError(t, err)
-	assert.Equal(t, int32(gotVer), *row.DekVersion) //nolint:gosec // G115: ParseInt with bitSize=32 already bounds the value to int32.
-	assert.Equal(t, msg.Data(), row.Envelope, "INV-21: bus and audit envelope bytes must be byte-equal")
+		natsMsgID := headers.Get("Nats-Msg-Id")
+		Expect(natsMsgID).NotTo(BeEmpty())
+		idBytes := testutil.MustParseULID(suiteT, natsMsgID).Bytes()
+		row := testutil.QueryEventsAuditByID(suiteT, pool, idBytes)
+		Expect(row.Codec).To(Equal("xchacha20poly1305-v1"))
+		Expect(row.DekRef).NotTo(BeNil())
+		gotRef, err := strconv.ParseInt(dekRefHdr, 10, 64)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotRef).To(Equal(*row.DekRef))
+		Expect(row.DekVersion).NotTo(BeNil())
+		gotVer, err := strconv.ParseInt(dekVerHdr, 10, 32)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(int32(gotVer)).To(Equal(*row.DekVersion)) //nolint:gosec // G115: ParseInt with bitSize=32 already bounds the value to int32.
+		Expect(msg.Data()).To(Equal(row.Envelope), "INV-21: bus and audit envelope bytes must be byte-equal")
 
-	// Decision 0: msg.Data is the marshaled envelope (cleartext metadata
-	// fields + ciphertext payload field), NOT a single ciphertext blob.
-	var wireEnvelope eventbusv1.Event
-	require.NoError(t, proto.Unmarshal(msg.Data(), &wireEnvelope), "msg.Data MUST unmarshal as eventbusv1.Event")
-	assert.NotEqual(t, []byte(plaintext), wireEnvelope.Payload, "envelope.Payload MUST be ciphertext, not plaintext")
-	assert.Equal(t, "events.main.scene.01HXXXTESTSCENE000000000", wireEnvelope.Subject, "envelope.Subject MUST be cleartext on the wire")
-	assert.Equal(t, "test-plugin:whisper", wireEnvelope.Type, "envelope.Type MUST be cleartext on the wire")
-	require.NotNil(t, wireEnvelope.Timestamp, "envelope.Timestamp MUST be cleartext on the wire")
-	require.NotNil(t, wireEnvelope.Actor, "envelope.Actor MUST be cleartext on the wire")
+		// Decision 0: msg.Data is the marshaled envelope (cleartext metadata
+		// fields + ciphertext payload field), NOT a single ciphertext blob.
+		var wireEnvelope eventbusv1.Event
+		Expect(proto.Unmarshal(msg.Data(), &wireEnvelope)).NotTo(HaveOccurred(), "msg.Data MUST unmarshal as eventbusv1.Event")
+		Expect(wireEnvelope.Payload).NotTo(Equal([]byte(plaintext)), "envelope.Payload MUST be ciphertext, not plaintext")
+		Expect(wireEnvelope.Subject).To(Equal("events.main.scene.01HXXXTESTSCENE000000000"), "envelope.Subject MUST be cleartext on the wire")
+		Expect(wireEnvelope.Type).To(Equal("test-plugin:whisper"), "envelope.Type MUST be cleartext on the wire")
+		Expect(wireEnvelope.Timestamp).NotTo(BeNil(), "envelope.Timestamp MUST be cleartext on the wire")
+		Expect(wireEnvelope.Actor).NotTo(BeNil(), "envelope.Actor MUST be cleartext on the wire")
 
-	// AAD-bind verification (INV-25 round-trip) is unit-tested at
-	// internal/eventbus/codec/xchacha20poly1305_test.go::TestXChaCha20Poly1305DetectsAADTamper.
-	// Decrypt-on-fanout E2E (full plaintext recovery via the subscriber
-	// path) is Phase 3b.
-}
+		// AAD-bind verification (INV-25 round-trip) is unit-tested at
+		// internal/eventbus/codec/xchacha20poly1305_test.go::TestXChaCha20Poly1305DetectsAADTamper.
+		// Decrypt-on-fanout E2E (full plaintext recovery via the subscriber
+		// path) is Phase 3b.
+	})
+})
 
 // newPool opens a pgxpool against a caller-supplied connection string.
 // t.Cleanup handles Close — callers do not.
@@ -212,7 +214,9 @@ func newPool(t *testing.T, connStr string) *pgxpool.Pool {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("newPool: %v", err)
+	}
 	t.Cleanup(pool.Close)
 	return pool
 }

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/core"
@@ -70,7 +70,9 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 	kekSource := kek.NewEnvSource("HOLOMUSH_TEST_SUBSCRIBER_KEK", false)
 
 	provider, err := kek.NewLocalAEADProvider(ctx, kekSource, pool)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: NewLocalAEADProvider: %v", err)
+	}
 
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
@@ -78,27 +80,35 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
 		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
 		&dekBindingStub{bindingID: "bind-metadata"})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: NewManager: %v", err)
+	}
 
 	// Audit subsystem: needed so events_audit is populated (same pattern as
 	// emit_test.go). Not strictly required for subscribe assertions but keeps
 	// the test environment representative.
 	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
+	if err := hostSub.Start(ctx); err != nil {
+		t.Fatalf("buildSubscribeHarness: hostSub.Start: %v", err)
+	}
 	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
 
 	// Verb registry: the RenderingPublisher requires test-plugin:whisper to be
 	// registered so the App-Rendering header is stamped correctly.
 	registry, err := core.BootstrapVerbRegistry("test")
-	require.NoError(t, err)
-	require.NoError(t, registry.RegisterWithSource(core.VerbRegistration{
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: BootstrapVerbRegistry: %v", err)
+	}
+	if err := registry.RegisterWithSource(core.VerbRegistration{
 		Type:          "test-plugin:whisper",
 		Category:      "communication",
 		Format:        "speech",
 		Label:         "whispers",
 		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
 		Source:        "test-plugin",
-	}, "1.0.0"))
+	}, "1.0.0"); err != nil {
+		t.Fatalf("buildSubscribeHarness: RegisterWithSource: %v", err)
+	}
 
 	rawPub := eventbus.NewJetStreamPublisher(
 		bus.JS,
@@ -115,21 +125,27 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 	participantLookup := authguard.NewDEKParticipantLookup(dekMgr)
 	abacEngine := policytest.AllowAllEngine()
 	guard, err := authguard.New(participantLookup, alwaysDenyManifest{}, abacEngine, noopBackpressure{})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: authguard.New: %v", err)
+	}
 
 	sessionGuard := authguard.NewSessionBridgeGuard(guard)
 
 	// Audit emitter for plugin decrypt records. nil is safe for character
 	// sessions; pass it anyway so WithSubscriberDecryptAuditEmitter is wired.
 	auditEmitter, err := guardaudit.NewQueuedEmitter(rawPub)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: NewQueuedEmitter: %v", err)
+	}
 	t.Cleanup(func() {
 		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		_ = auditEmitter.Shutdown(shutCtx)
 	})
 	sessionAuditEmitter, err := guardaudit.NewSessionBridgeEmitter(auditEmitter)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildSubscribeHarness: NewSessionBridgeEmitter: %v", err)
+	}
 
 	sub := eventbus.NewJetStreamSubscriber(
 		bus.JS,
@@ -154,107 +170,109 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 //   - Publishes a sensitive event whose DEK has exactly one participant.
 //   - Opens a session as a different identity (non-participant binding_id).
 //   - Asserts: MetadataOnly()==true, Event().Payload is empty.
-func TestSubscribeWithNonParticipantIdentityDeliversMetadataOnly(t *testing.T) {
-	ctx := context.Background()
-	h := buildSubscribeHarness(t)
+var _ = Describe("Subscribe with non-participant identity delivers MetadataOnly (INV-26, INV-9)", func() {
+	It("non-participant receives MetadataOnly=true with empty payload", func() {
+		ctx := context.Background()
+		h := buildSubscribeHarness(suiteT)
 
-	const (
-		participantPlayerID    = "01PARTICIPANTPLAYER00000"
-		participantCharacterID = "01PARTICIPANTCHARACT0000"
-		participantBindingID   = "01PARTICIPANTBINDING0000"
+		const (
+			participantPlayerID    = "01PARTICIPANTPLAYER00000"
+			participantCharacterID = "01PARTICIPANTCHARACT0000"
+			participantBindingID   = "01PARTICIPANTBINDING0000"
 
-		nonParticipantPlayerID    = "01NONPARTICIPANTPLAYER00"
-		nonParticipantCharacterID = "01NONPARTICIPANTCHARACT0"
-		nonParticipantBindingID   = "01NONPARTICIPANTBINDING0"
-	)
+			nonParticipantPlayerID    = "01NONPARTICIPANTPLAYER00"
+			nonParticipantCharacterID = "01NONPARTICIPANTCHARACT0"
+			nonParticipantBindingID   = "01NONPARTICIPANTBINDING0"
+		)
 
-	sceneID := "01HXXXTESTSCENE000000001"
+		sceneID := "01HXXXTESTSCENE000000001"
 
-	// Pre-create the DEK with the participant set BEFORE the publisher calls
-	// GetOrCreate. Because GetOrCreate is idempotent (INSERT or SELECT), the
-	// publisher's subsequent GetOrCreate(ctx, ctxID, nil) call will return the
-	// existing DEK row — with participants already stored.
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
-			PlayerID:    participantPlayerID,
-			CharacterID: participantCharacterID,
-			BindingID:   participantBindingID,
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
-	})
-	require.NoError(t, err, "pre-create DEK with participant")
-
-	// Emit the sensitive event. The publisher resolves the ContextID from the
-	// translated subject (events.main.scene.<sceneID>) and calls GetOrCreate
-	// which returns the existing DEK (participants already set).
-	manifest := &plugins.Manifest{
-		Name:                "test-plugin",
-		Emits:               []string{"scene"},
-		ActorKindsClaimable: []string{"plugin"},
-		Crypto: &plugins.CryptoSection{
-			Emits: []plugins.CryptoEmit{
-				{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+		// Pre-create the DEK with the participant set BEFORE the publisher calls
+		// GetOrCreate. Because GetOrCreate is idempotent (INSERT or SELECT), the
+		// publisher's subsequent GetOrCreate(ctx, ctxID, nil) call will return the
+		// existing DEK row — with participants already stored.
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    participantPlayerID,
+				CharacterID: participantCharacterID,
+				BindingID:   participantBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
 			},
-		},
-	}
-	manifestLookup := func(name string) *plugins.Manifest {
-		if name == "test-plugin" {
-			return manifest
+		})
+		Expect(err).NotTo(HaveOccurred(), "pre-create DEK with participant")
+
+		// Emit the sensitive event. The publisher resolves the ContextID from the
+		// translated subject (events.main.scene.<sceneID>) and calls GetOrCreate
+		// which returns the existing DEK (participants already set).
+		manifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"scene"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
+			},
 		}
-		return nil
-	}
-	// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
-	// coreActorToEventbusActor rejects non-ULID IDs).
-	testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
-	actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
-		return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
-	}
-	emitter := plugins.NewPluginEventEmitter(
-		h.publisher, manifestLookup, actorResolver,
-		plugins.WithCryptoEnabled(true),
-	)
+		manifestLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return manifest
+			}
+			return nil
+		}
+		// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
+		// coreActorToEventbusActor rejects non-ULID IDs).
+		testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
+		}
+		emitter := plugins.NewPluginEventEmitter(
+			h.publisher, manifestLookup, actorResolver,
+			plugins.WithCryptoEnabled(true),
+		)
 
-	const plaintext = `{"text":"secret message for participant only"}`
-	intent := pluginsdk.EmitIntent{
-		Subject:   "scene:" + sceneID,
-		Type:      pluginsdk.EventType("test-plugin:whisper"),
-		Payload:   plaintext,
-		Sensitive: true,
-	}
-	require.NoError(t, emitter.Emit(ctx, "test-plugin", intent))
+		const plaintext = `{"text":"secret message for participant only"}`
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene:" + sceneID,
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   plaintext,
+			Sensitive: true,
+		}
+		Expect(emitter.Emit(ctx, "test-plugin", intent)).NotTo(HaveOccurred())
 
-	// Open a session as the NON-participant identity.
-	nonParticipantID := eventbus.SessionIdentity{
-		Kind:        eventbus.IdentityKindCharacter,
-		PlayerID:    nonParticipantPlayerID,
-		CharacterID: nonParticipantCharacterID,
-		BindingID:   nonParticipantBindingID,
-	}
-	sessionID := "nonparticipant-session-" + sceneID
+		// Open a session as the NON-participant identity.
+		nonParticipantID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    nonParticipantPlayerID,
+			CharacterID: nonParticipantCharacterID,
+			BindingID:   nonParticipantBindingID,
+		}
+		sessionID := "nonparticipant-session-" + sceneID
 
-	stream, err := h.subscriber.OpenSession(ctx, sessionID, nonParticipantID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, nonParticipantID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
 
-	receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer cancel()
+		receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
 
-	delivery, err := stream.Next(receiveCtx)
-	require.NoError(t, err, "expected delivery from stream")
-	require.NoError(t, delivery.Ack())
+		delivery, err := stream.Next(receiveCtx)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery from stream")
+		Expect(delivery.Ack()).NotTo(HaveOccurred())
 
-	// INV-26: non-participant must receive metadata-only delivery (no plaintext).
-	assert.True(t, delivery.MetadataOnly(), "INV-26: non-participant must receive MetadataOnly=true")
-	// INV-9: the delivery payload must be empty — no plaintext visible to non-participant.
-	assert.Empty(t, delivery.Event().Payload, "INV-9: non-participant payload must be empty bytes")
+		// INV-26: non-participant must receive metadata-only delivery (no plaintext).
+		Expect(delivery.MetadataOnly()).To(BeTrue(), "INV-26: non-participant must receive MetadataOnly=true")
+		// INV-9: the delivery payload must be empty — no plaintext visible to non-participant.
+		Expect(delivery.Event().Payload).To(BeEmpty(), "INV-9: non-participant payload must be empty bytes")
 
-	// Metadata fields must still be present.
-	assert.Equal(t, eventbus.Type("test-plugin:whisper"), delivery.Event().Type,
-		"metadata: event type must be visible to non-participant")
-	assert.NotZero(t, delivery.Event().Timestamp, "metadata: timestamp must be visible")
-}
+		// Metadata fields must still be present.
+		Expect(delivery.Event().Type).To(Equal(eventbus.Type("test-plugin:whisper")),
+			"metadata: event type must be visible to non-participant")
+		Expect(delivery.Event().Timestamp).NotTo(BeZero(), "metadata: timestamp must be visible")
+	})
+})
 
 // TestSubscribeWithParticipantIdentityDeliversPlaintext covers INV-26
 // (delivery contract — permit path):
@@ -262,99 +280,101 @@ func TestSubscribeWithNonParticipantIdentityDeliversMetadataOnly(t *testing.T) {
 //   - Same setup as the non-participant test above, but opens the session
 //     as the participant identity.
 //   - Asserts: MetadataOnly()==false, Event().Payload equals the original JSON.
-func TestSubscribeWithParticipantIdentityDeliversPlaintext(t *testing.T) {
-	ctx := context.Background()
-	h := buildSubscribeHarness(t)
+var _ = Describe("Subscribe with participant identity delivers plaintext (INV-26)", func() {
+	It("participant receives MetadataOnly=false with original plaintext", func() {
+		ctx := context.Background()
+		h := buildSubscribeHarness(suiteT)
 
-	const (
-		participantPlayerID    = "01PARTICIPANTPLAYER00001"
-		participantCharacterID = "01PARTICIPANTCHARACT0001"
-		participantBindingID   = "01PARTICIPANTBINDING0001"
-	)
+		const (
+			participantPlayerID    = "01PARTICIPANTPLAYER00001"
+			participantCharacterID = "01PARTICIPANTCHARACT0001"
+			participantBindingID   = "01PARTICIPANTBINDING0001"
+		)
 
-	sceneID := "01HXXXTESTSCENE000000002"
+		sceneID := "01HXXXTESTSCENE000000002"
 
-	// Pre-create DEK with participant.
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
+		// Pre-create DEK with participant.
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    participantPlayerID,
+				CharacterID: participantCharacterID,
+				BindingID:   participantBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred(), "pre-create DEK with participant")
+
+		// Emit the sensitive event.
+		manifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"scene"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
+			},
+		}
+		manifestLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return manifest
+			}
+			return nil
+		}
+		// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
+		// coreActorToEventbusActor rejects non-ULID IDs).
+		testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
+		}
+		emitter := plugins.NewPluginEventEmitter(
+			h.publisher, manifestLookup, actorResolver,
+			plugins.WithCryptoEnabled(true),
+		)
+
+		const plaintext = `{"text":"hello participant"}`
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene:" + sceneID,
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   plaintext,
+			Sensitive: true,
+		}
+		Expect(emitter.Emit(ctx, "test-plugin", intent)).NotTo(HaveOccurred())
+
+		// Open a session as the PARTICIPANT identity.
+		participantID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
 			PlayerID:    participantPlayerID,
 			CharacterID: participantCharacterID,
 			BindingID:   participantBindingID,
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
-	})
-	require.NoError(t, err, "pre-create DEK with participant")
-
-	// Emit the sensitive event.
-	manifest := &plugins.Manifest{
-		Name:                "test-plugin",
-		Emits:               []string{"scene"},
-		ActorKindsClaimable: []string{"plugin"},
-		Crypto: &plugins.CryptoSection{
-			Emits: []plugins.CryptoEmit{
-				{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
-			},
-		},
-	}
-	manifestLookup := func(name string) *plugins.Manifest {
-		if name == "test-plugin" {
-			return manifest
 		}
-		return nil
-	}
-	// Post-w9ml: Actor.ID MUST be a ULID string (strict-gate
-	// coreActorToEventbusActor rejects non-ULID IDs).
-	testPluginActorID := plugintest.PluginULIDFromName("test-plugin").String()
-	actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
-		return core.Actor{Kind: core.ActorPlugin, ID: testPluginActorID}, nil
-	}
-	emitter := plugins.NewPluginEventEmitter(
-		h.publisher, manifestLookup, actorResolver,
-		plugins.WithCryptoEnabled(true),
-	)
+		sessionID := "participant-session-" + sceneID
 
-	const plaintext = `{"text":"hello participant"}`
-	intent := pluginsdk.EmitIntent{
-		Subject:   "scene:" + sceneID,
-		Type:      pluginsdk.EventType("test-plugin:whisper"),
-		Payload:   plaintext,
-		Sensitive: true,
-	}
-	require.NoError(t, emitter.Emit(ctx, "test-plugin", intent))
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, participantID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
 
-	// Open a session as the PARTICIPANT identity.
-	participantID := eventbus.SessionIdentity{
-		Kind:        eventbus.IdentityKindCharacter,
-		PlayerID:    participantPlayerID,
-		CharacterID: participantCharacterID,
-		BindingID:   participantBindingID,
-	}
-	sessionID := "participant-session-" + sceneID
+		receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
 
-	stream, err := h.subscriber.OpenSession(ctx, sessionID, participantID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
+		delivery, err := stream.Next(receiveCtx)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery from stream")
+		Expect(delivery.Ack()).NotTo(HaveOccurred())
 
-	receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer cancel()
+		// INV-26: participant must receive full plaintext (MetadataOnly=false).
+		Expect(delivery.MetadataOnly()).To(BeFalse(), "INV-26: participant must receive MetadataOnly=false")
 
-	delivery, err := stream.Next(receiveCtx)
-	require.NoError(t, err, "expected delivery from stream")
-	require.NoError(t, delivery.Ack())
+		// INV-9 (permit path): payload must be the original plaintext.
+		// The publisher encrypts event.Payload (the JSON bytes) and the subscriber
+		// decrypts to recover the original bytes.
+		Expect(delivery.Event().Payload).To(Equal([]byte(plaintext)),
+			"INV-26: participant payload must equal original plaintext")
 
-	// INV-26: participant must receive full plaintext (MetadataOnly=false).
-	assert.False(t, delivery.MetadataOnly(), "INV-26: participant must receive MetadataOnly=false")
-
-	// INV-9 (permit path): payload must be the original plaintext.
-	// The publisher encrypts event.Payload (the JSON bytes) and the subscriber
-	// decrypts to recover the original bytes.
-	assert.Equal(t, []byte(plaintext), delivery.Event().Payload,
-		"INV-26: participant payload must equal original plaintext")
-
-	// Metadata fields also present.
-	assert.Equal(t, eventbus.Type("test-plugin:whisper"), delivery.Event().Type,
-		"metadata: event type must be visible to participant")
-	assert.NotZero(t, delivery.Event().Timestamp, "metadata: timestamp must be visible")
-}
+		// Metadata fields also present.
+		Expect(delivery.Event().Type).To(Equal(eventbus.Type("test-plugin:whisper")),
+			"metadata: event type must be visible to participant")
+		Expect(delivery.Event().Timestamp).NotTo(BeZero(), "metadata: timestamp must be visible")
+	})
+})

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -158,14 +158,18 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 		Subjects: []string{"audit.>"},
 		Storage:  jetstream.MemoryStorage,
 	})
-	require.NoError(t, err, "create AUDIT JetStream stream")
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: CreateOrUpdateStream AUDIT: %v", err)
+	}
 
 	kekHex := testutil.RandomKEKHex(t)
 	t.Setenv("HOLOMUSH_PLUGIN_DECRYPT_KEK", kekHex)
 	kekSource := kek.NewEnvSource("HOLOMUSH_PLUGIN_DECRYPT_KEK", false)
 
 	provider, err := kek.NewLocalAEADProvider(ctx, kekSource, pool)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: NewLocalAEADProvider: %v", err)
+	}
 
 	dekStore := dek.NewStore(pool)
 	dekCache := dek.NewCache(dek.CacheConfig{Capacity: 64})
@@ -173,24 +177,32 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 	dekMgr, err := dek.NewManager(provider, dekStore, dekCache, dekPartCache,
 		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
 		&dekBindingStub{bindingID: "bind-decrypt"})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: NewManager: %v", err)
+	}
 
 	// Host audit subsystem: populates events_audit. Handle stays local —
 	// no test calls AwaitDrained on it.
 	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
+	if err := hostSub.Start(ctx); err != nil {
+		t.Fatalf("buildPluginDecryptHarness: hostSub.Start: %v", err)
+	}
 	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
 
 	registry, err := core.BootstrapVerbRegistry("test")
-	require.NoError(t, err)
-	require.NoError(t, registry.RegisterWithSource(core.VerbRegistration{
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: BootstrapVerbRegistry: %v", err)
+	}
+	if err := registry.RegisterWithSource(core.VerbRegistration{
 		Type:          "test-plugin:whisper",
 		Category:      "communication",
 		Format:        "speech",
 		Label:         "whispers",
 		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
 		Source:        "test-plugin",
-	}, "1.0.0"))
+	}, "1.0.0"); err != nil {
+		t.Fatalf("buildPluginDecryptHarness: RegisterWithSource: %v", err)
+	}
 
 	rawPub := eventbus.NewJetStreamPublisher(
 		bus.JS,
@@ -205,7 +217,9 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 
 	participantLookup := authguard.NewDEKParticipantLookup(dekMgr)
 	guard, err := authguard.New(participantLookup, manifests, abacEngine, noopBackpressure{})
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: authguard.New: %v", err)
+	}
 
 	sessionGuard := authguard.NewSessionBridgeGuard(guard)
 
@@ -216,14 +230,18 @@ func buildPluginDecryptHarness(t *testing.T) *pluginDecryptHarness {
 	// for audit events and publishes directly to JetStream.
 	auditPub := &auditPassthroughPublisher{inner: rawPub, js: bus.JS}
 	auditEmitter, err := guardaudit.NewQueuedEmitter(auditPub)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: NewQueuedEmitter: %v", err)
+	}
 	t.Cleanup(func() {
 		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		_ = auditEmitter.Shutdown(shutCtx)
 	})
 	sessionAuditEmitter, err := guardaudit.NewSessionBridgeEmitter(auditEmitter)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("buildPluginDecryptHarness: NewSessionBridgeEmitter: %v", err)
+	}
 
 	sub := eventbus.NewJetStreamSubscriber(
 		bus.JS,
@@ -281,7 +299,9 @@ func emitSensitiveWhisper(t *testing.T, h *pluginDecryptHarness, sceneID, plaint
 		Payload:   plaintext,
 		Sensitive: true,
 	}
-	require.NoError(t, emitter.Emit(ctx, "test-plugin", intent))
+	if err := emitter.Emit(ctx, "test-plugin", intent); err != nil {
+		t.Fatalf("emitSensitiveWhisper: %v", err)
+	}
 }
 
 // TestPluginDecryptManifestGateDeniesWithoutDeclaration verifies INV-17:
@@ -289,126 +309,130 @@ func emitSensitiveWhisper(t *testing.T, h *pluginDecryptHarness, sceneID, plaint
 // receive metadata-only delivery for events of that class, regardless of
 // subject subscription. The manifest gate fires before the ABAC evaluation
 // (guard.go:123), so even with an ABAC grant, the plugin is denied.
-func TestPluginDecryptManifestGateDeniesWithoutDeclaration(t *testing.T) {
-	h := buildPluginDecryptHarness(t)
+var _ = Describe("Plugin decrypt manifest gate denies without declaration (INV-17)", func() {
+	It("plugin without requests_decryption receives MetadataOnly=true", func() {
+		h := buildPluginDecryptHarness(suiteT)
 
-	const (
-		sceneID              = "01HXXXINV17SCENE00000001"
-		pluginName           = "inv17-no-manifest"
-		sessionID            = "inv17-session"
-		participantBindingID = "01INV17PARTICIPANTBIND00"
-	)
+		const (
+			sceneID              = "01HXXXINV17SCENE00000001"
+			pluginName           = "inv17-no-manifest"
+			sessionID            = "inv17-session"
+			participantBindingID = "01INV17PARTICIPANTBIND00"
+		)
 
-	// Pre-create DEK with a participant so the event is encryptable.
-	ctx := context.Background()
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
-			PlayerID:    "01INV17PLAYER00000000",
-			CharacterID: "01INV17CHARACT00000000",
-			BindingID:   participantBindingID,
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
+		// Pre-create DEK with a participant so the event is encryptable.
+		ctx := context.Background()
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    "01INV17PLAYER00000000",
+				CharacterID: "01INV17CHARACT00000000",
+				BindingID:   participantBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Register a grant for this plugin to prove the manifest gate fires
+		// before ABAC evaluation — the ABAC engine would permit, but the
+		// manifest gate denies first.
+		h.abacEngine.Grant("plugin:"+pluginName, "decrypt", "dek:1:1")
+
+		// Do NOT register the plugin in manifests — this is the INV-17 condition.
+
+		const plaintext = `{"text":"inv17 secret"}`
+		emitSensitiveWhisper(suiteT, h, sceneID, plaintext)
+
+		pluginID := eventbus.SessionIdentity{
+			Kind:       eventbus.IdentityKindPlugin,
+			PluginName: pluginName,
+		}
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
+
+		delivery, err := stream.Next(receiveCtx)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery from stream")
+		Expect(delivery.Ack()).NotTo(HaveOccurred())
+
+		// Verifies: INV-17
+		Expect(delivery.MetadataOnly()).To(BeTrue(), "INV-17: plugin without requests_decryption must receive MetadataOnly=true")
+		Expect(delivery.Event().Payload).To(BeEmpty(), "INV-17: metadata-only delivery must have empty payload")
 	})
-	require.NoError(t, err)
-
-	// Register a grant for this plugin to prove the manifest gate fires
-	// before ABAC evaluation — the ABAC engine would permit, but the
-	// manifest gate denies first.
-	h.abacEngine.Grant("plugin:"+pluginName, "decrypt", "dek:1:1")
-
-	// Do NOT register the plugin in manifests — this is the INV-17 condition.
-
-	const plaintext = `{"text":"inv17 secret"}`
-	emitSensitiveWhisper(t, h, sceneID, plaintext)
-
-	pluginID := eventbus.SessionIdentity{
-		Kind:       eventbus.IdentityKindPlugin,
-		PluginName: pluginName,
-	}
-	stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
-
-	receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer cancel()
-
-	delivery, err := stream.Next(receiveCtx)
-	require.NoError(t, err, "expected delivery from stream")
-	require.NoError(t, delivery.Ack())
-
-	// Verifies: INV-17
-	assert.True(t, delivery.MetadataOnly(), "INV-17: plugin without requests_decryption must receive MetadataOnly=true")
-	assert.Empty(t, delivery.Event().Payload, "INV-17: metadata-only delivery must have empty payload")
-}
+})
 
 // TestPluginDecryptABACGateDeniesWithoutGrant verifies INV-18: a plugin
 // with manifest declaration but without an active ABAC grant MUST receive
 // metadata-only. The manifest gate passes (requests_decryption declared)
 // but the ABAC evaluation denies (guard.go:143-144).
-func TestPluginDecryptABACGateDeniesWithoutGrant(t *testing.T) {
-	h := buildPluginDecryptHarness(t)
+var _ = Describe("Plugin decrypt ABAC gate denies without grant (INV-18)", func() {
+	It("plugin with manifest but no ABAC grant receives MetadataOnly=true", func() {
+		h := buildPluginDecryptHarness(suiteT)
 
-	const (
-		sceneID    = "01HXXXINV18SCENE00000002"
-		pluginName = "inv18-has-manifest"
-		sessionID  = "inv18-session"
-	)
+		const (
+			sceneID    = "01HXXXINV18SCENE00000002"
+			pluginName = "inv18-has-manifest"
+			sessionID  = "inv18-session"
+		)
 
-	// Pre-create DEK with a participant.
-	ctx := context.Background()
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
-			PlayerID:    "01INV18PLAYER00000000",
-			CharacterID: "01INV18CHARACT00000000",
-			BindingID:   "01INV18PARTICIPANTBIND00",
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
-	})
-	require.NoError(t, err)
+		// Pre-create DEK with a participant.
+		ctx := context.Background()
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    "01INV18PLAYER00000000",
+				CharacterID: "01INV18CHARACT00000000",
+				BindingID:   "01INV18PARTICIPANTBIND00",
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 
-	// Register the plugin's manifest with requests_decryption — this
-	// passes the manifest gate (guard.go:123) but ABAC will deny because
-	// no grant is configured for this plugin in the GrantEngine.
-	h.manifests[pluginName] = &plugins.Manifest{
-		Name: pluginName,
-		Crypto: &plugins.CryptoSection{
-			Consumes: []plugins.CryptoConsume{
-				{
-					Subjects:           []string{"events.>"},
-					RequestsDecryption: []string{"test-plugin:whisper"},
+		// Register the plugin's manifest with requests_decryption — this
+		// passes the manifest gate (guard.go:123) but ABAC will deny because
+		// no grant is configured for this plugin in the GrantEngine.
+		h.manifests[pluginName] = &plugins.Manifest{
+			Name: pluginName,
+			Crypto: &plugins.CryptoSection{
+				Consumes: []plugins.CryptoConsume{
+					{
+						Subjects:           []string{"events.>"},
+						RequestsDecryption: []string{"test-plugin:whisper"},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	// Do NOT call h.abacEngine.Grant — this is the INV-18 condition.
+		// Do NOT call h.abacEngine.Grant — this is the INV-18 condition.
 
-	const plaintext = `{"text":"inv18 secret"}`
-	emitSensitiveWhisper(t, h, sceneID, plaintext)
+		const plaintext = `{"text":"inv18 secret"}`
+		emitSensitiveWhisper(suiteT, h, sceneID, plaintext)
 
-	pluginID := eventbus.SessionIdentity{
-		Kind:       eventbus.IdentityKindPlugin,
-		PluginName: pluginName,
-	}
-	stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
+		pluginID := eventbus.SessionIdentity{
+			Kind:       eventbus.IdentityKindPlugin,
+			PluginName: pluginName,
+		}
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
 
-	receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer cancel()
+		receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
 
-	delivery, err := stream.Next(receiveCtx)
-	require.NoError(t, err, "expected delivery from stream")
-	require.NoError(t, delivery.Ack())
+		delivery, err := stream.Next(receiveCtx)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery from stream")
+		Expect(delivery.Ack()).NotTo(HaveOccurred())
 
-	// Verifies: INV-18
-	assert.True(t, delivery.MetadataOnly(), "INV-18: plugin with manifest but no ABAC grant must receive MetadataOnly=true")
-	assert.Empty(t, delivery.Event().Payload, "INV-18: metadata-only delivery must have empty payload")
-}
+		// Verifies: INV-18
+		Expect(delivery.MetadataOnly()).To(BeTrue(), "INV-18: plugin with manifest but no ABAC grant must receive MetadataOnly=true")
+		Expect(delivery.Event().Payload).To(BeEmpty(), "INV-18: metadata-only delivery must have empty payload")
+	})
+})
 
 // TestPluginDecryptEmitsAuditOnPermitAndIsolation verifies INV-19: every
 // plugin decryption MUST emit an audit event on a subject the plugin cannot
@@ -417,97 +441,99 @@ func TestPluginDecryptABACGateDeniesWithoutGrant(t *testing.T) {
 // gameID to "holomush" per emitter.go:29), which is outside the events.>
 // subject namespace. The plugin session subscribes to events.> only, so
 // the audit event is invisible by construction.
-func TestPluginDecryptEmitsAuditOnPermitAndIsolation(t *testing.T) {
-	h := buildPluginDecryptHarness(t)
+var _ = Describe("Plugin decrypt emits audit on permit and isolation (INV-19)", func() {
+	It("permitted plugin receives plaintext and audit event is isolated from plugin session", func() {
+		h := buildPluginDecryptHarness(suiteT)
 
-	const (
-		sceneID    = "01HXXXINV19SCENE00000003"
-		pluginName = "inv19-audit-plugin"
-		sessionID  = "inv19-session"
-	)
+		const (
+			sceneID    = "01HXXXINV19SCENE00000003"
+			pluginName = "inv19-audit-plugin"
+			sessionID  = "inv19-session"
+		)
 
-	ctx := context.Background()
+		ctx := context.Background()
 
-	// Pre-create DEK with a participant and capture the key coordinates
-	// for the ABAC grant (guard.go:127-129 constructs resource as
-	// "dek:<keyID>:<version>").
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	key, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
-			PlayerID:    "01INV19PLAYER00000000",
-			CharacterID: "01INV19CHARACT00000000",
-			BindingID:   "01INV19PARTICIPANTBIND00",
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
-	})
-	require.NoError(t, err)
+		// Pre-create DEK with a participant and capture the key coordinates
+		// for the ABAC grant (guard.go:127-129 constructs resource as
+		// "dek:<keyID>:<version>").
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		key, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    "01INV19PLAYER00000000",
+				CharacterID: "01INV19CHARACT00000000",
+				BindingID:   "01INV19PARTICIPANTBIND00",
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 
-	// Register the manifest with requests_decryption.
-	h.manifests[pluginName] = &plugins.Manifest{
-		Name: pluginName,
-		Crypto: &plugins.CryptoSection{
-			Consumes: []plugins.CryptoConsume{
-				{
-					Subjects:           []string{"events.>"},
-					RequestsDecryption: []string{"test-plugin:whisper"},
+		// Register the manifest with requests_decryption.
+		h.manifests[pluginName] = &plugins.Manifest{
+			Name: pluginName,
+			Crypto: &plugins.CryptoSection{
+				Consumes: []plugins.CryptoConsume{
+					{
+						Subjects:           []string{"events.>"},
+						RequestsDecryption: []string{"test-plugin:whisper"},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	// Grant the ABAC permission using the captured DEK coordinates.
-	h.abacEngine.Grant(
-		"plugin:"+pluginName,
-		"decrypt",
-		fmt.Sprintf("dek:%d:%d", key.ID, key.Version),
-	)
+		// Grant the ABAC permission using the captured DEK coordinates.
+		h.abacEngine.Grant(
+			"plugin:"+pluginName,
+			"decrypt",
+			fmt.Sprintf("dek:%d:%d", key.ID, key.Version),
+		)
 
-	const plaintext = `{"text":"inv19 audit secret"}`
-	emitSensitiveWhisper(t, h, sceneID, plaintext)
+		const plaintext = `{"text":"inv19 audit secret"}`
+		emitSensitiveWhisper(suiteT, h, sceneID, plaintext)
 
-	// Open the plugin session.
-	pluginID := eventbus.SessionIdentity{
-		Kind:       eventbus.IdentityKindPlugin,
-		PluginName: pluginName,
-	}
-	stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
+		// Open the plugin session.
+		pluginID := eventbus.SessionIdentity{
+			Kind:       eventbus.IdentityKindPlugin,
+			PluginName: pluginName,
+		}
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
 
-	receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer cancel()
+		receiveCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
 
-	delivery, err := stream.Next(receiveCtx)
-	require.NoError(t, err, "expected delivery from stream")
-	require.NoError(t, delivery.Ack())
+		delivery, err := stream.Next(receiveCtx)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery from stream")
+		Expect(delivery.Ack()).NotTo(HaveOccurred())
 
-	// Assertion 1: plugin received plaintext (permit path).
-	// Verifies: INV-19 (permit branch)
-	assert.False(t, delivery.MetadataOnly(), "INV-19: permitted plugin must receive MetadataOnly=false")
-	assert.Equal(t, []byte(plaintext), delivery.Event().Payload, "INV-19: permitted plugin must receive original plaintext")
+		// Assertion 1: plugin received plaintext (permit path).
+		// Verifies: INV-19 (permit branch)
+		Expect(delivery.MetadataOnly()).To(BeFalse(), "INV-19: permitted plugin must receive MetadataOnly=false")
+		Expect(delivery.Event().Payload).To(Equal([]byte(plaintext)), "INV-19: permitted plugin must receive original plaintext")
 
-	// Assertion 2: audit event exists on audit.holomush.plugin_decrypt.inv19-audit-plugin.
-	// The guardaudit.Emitter publishes to the AUDIT stream (not events.>).
-	// Verifies: INV-19 (audit-on-permit)
-	auditSubject := "audit.holomush.plugin_decrypt." + pluginName
-	auditMsg := testutil.WaitForOneJetStreamMsgOnStream(t, h.bus, "AUDIT", auditSubject, testutil.DefaultWait)
-	assert.Equal(t, "audit:plugin_decrypt", auditMsg.Headers().Get("App-Event-Type"),
-		"INV-19: audit event must have type audit:plugin_decrypt")
+		// Assertion 2: audit event exists on audit.holomush.plugin_decrypt.inv19-audit-plugin.
+		// The guardaudit.Emitter publishes to the AUDIT stream (not events.>).
+		// Verifies: INV-19 (audit-on-permit)
+		auditSubject := "audit.holomush.plugin_decrypt." + pluginName
+		auditMsg := testutil.WaitForOneJetStreamMsgOnStream(suiteT, h.bus, "AUDIT", auditSubject, testutil.DefaultWait)
+		Expect(auditMsg.Headers().Get("App-Event-Type")).To(Equal("audit:plugin_decrypt"),
+			"INV-19: audit event must have type audit:plugin_decrypt")
 
-	// Assertion 3: the plugin session did NOT receive the audit event.
-	// The session subscribes to events.>; the audit event is on audit.>,
-	// which is outside the filter. We verify this by draining the session
-	// with a short timeout — only the sensitive event should appear.
-	//
-	// The session already consumed the sensitive event above. If the audit
-	// event were visible on events.>, stream.Next would return it.
-	// Instead, we expect a timeout (no more messages).
-	noMoreCtx, noMoreCancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer noMoreCancel()
-	_, noMoreErr := stream.Next(noMoreCtx)
-	assert.Error(t, noMoreErr, "INV-19: plugin session must not receive audit events (audit.> is outside events.> filter)")
-}
+		// Assertion 3: the plugin session did NOT receive the audit event.
+		// The session subscribes to events.>; the audit event is on audit.>,
+		// which is outside the filter. We verify this by draining the session
+		// with a short timeout — only the sensitive event should appear.
+		//
+		// The session already consumed the sensitive event above. If the audit
+		// event were visible on events.>, stream.Next would return it.
+		// Instead, we expect a timeout (no more messages).
+		noMoreCtx, noMoreCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer noMoreCancel()
+		_, noMoreErr := stream.Next(noMoreCtx)
+		Expect(noMoreErr).To(HaveOccurred(), "INV-19: plugin session must not receive audit events (audit.> is outside events.> filter)")
+	})
+})
 
 // TestPluginDecryptDenialDoesNotBlockFanout verifies INV-20: a plugin
 // authorization failure MUST NOT block fan-out to other recipients.
@@ -516,82 +542,84 @@ func TestPluginDecryptEmitsAuditOnPermitAndIsolation(t *testing.T) {
 // test asserts both receive the event — the character gets plaintext
 // and the plugin gets metadata-only — proving that the plugin's deny
 // did not block the character's delivery.
-func TestPluginDecryptDenialDoesNotBlockFanout(t *testing.T) {
-	h := buildPluginDecryptHarness(t)
+var _ = Describe("Plugin decrypt denial does not block fanout (INV-20)", func() {
+	It("character receives plaintext and denied plugin receives MetadataOnly without blocking each other", func() {
+		h := buildPluginDecryptHarness(suiteT)
 
-	const (
-		sceneID              = "01HXXXINV20SCENE00000004"
-		participantPlayerID  = "01INV20PLAYER00000000"
-		participantCharID    = "01INV20CHARACT00000000"
-		participantBindingID = "01INV20PARTICIPANTBIND00"
-		deniedPluginName     = "inv20-denied-plugin"
-		characterSessionID   = "inv20-character-session"
-		pluginSessionID      = "inv20-plugin-session"
-	)
+		const (
+			sceneID              = "01HXXXINV20SCENE00000004"
+			participantPlayerID  = "01INV20PLAYER00000000"
+			participantCharID    = "01INV20CHARACT00000000"
+			participantBindingID = "01INV20PARTICIPANTBIND00"
+			deniedPluginName     = "inv20-denied-plugin"
+			characterSessionID   = "inv20-character-session"
+			pluginSessionID      = "inv20-plugin-session"
+		)
 
-	// Pre-create DEK with a participant (for the character session).
-	ctx := context.Background()
-	ctxID := dek.ContextID{Type: "scene", ID: sceneID}
-	_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
-		{
+		// Pre-create DEK with a participant (for the character session).
+		ctx := context.Background()
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    participantPlayerID,
+				CharacterID: participantCharID,
+				BindingID:   participantBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Do NOT register the denied plugin's manifest — INV-20 condition.
+
+		const plaintext = `{"text":"inv20 fanout secret"}`
+
+		// Open character session (participant — permitted).
+		charID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
 			PlayerID:    participantPlayerID,
 			CharacterID: participantCharID,
 			BindingID:   participantBindingID,
-			JoinedAt:    time.Now().UTC(),
-			AddedVia:    "test_setup",
-		},
+		}
+		charStream, err := h.subscriber.OpenSession(ctx, characterSessionID, charID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = charStream.Close() })
+
+		// Open plugin session (no manifest — denied).
+		pluginID := eventbus.SessionIdentity{
+			Kind:       eventbus.IdentityKindPlugin,
+			PluginName: deniedPluginName,
+		}
+		pluginStream, err := h.subscriber.OpenSession(ctx, pluginSessionID, pluginID, []eventbus.Subject{"events.>"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = pluginStream.Close() })
+
+		// Publish the sensitive event after both sessions are open.
+		emitSensitiveWhisper(suiteT, h, sceneID, plaintext)
+
+		// Receive from character session.
+		charRecvCtx, charCancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer charCancel()
+
+		charDelivery, err := charStream.Next(charRecvCtx)
+		Expect(err).NotTo(HaveOccurred(), "character session must receive the event")
+		Expect(charDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Receive from plugin session.
+		pluginRecvCtx, pluginCancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer pluginCancel()
+
+		pluginDelivery, err := pluginStream.Next(pluginRecvCtx)
+		Expect(err).NotTo(HaveOccurred(), "plugin session must receive the event (metadata-only)")
+		Expect(pluginDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Verifies: INV-20 — the character's plaintext delivery proves the
+		// plugin's deny did not block fan-out to other recipients.
+		Expect(charDelivery.MetadataOnly()).To(BeFalse(), "INV-20: character participant must receive MetadataOnly=false (plaintext)")
+		Expect(charDelivery.Event().Payload).To(Equal([]byte(plaintext)), "INV-20: character must receive original plaintext")
+
+		// The plugin's deny is expected (INV-17 manifest gate).
+		Expect(pluginDelivery.MetadataOnly()).To(BeTrue(), "INV-20: denied plugin must receive MetadataOnly=true")
+		Expect(pluginDelivery.Event().Payload).To(BeEmpty(), "INV-20: denied plugin payload must be empty")
 	})
-	require.NoError(t, err)
-
-	// Do NOT register the denied plugin's manifest — INV-20 condition.
-
-	const plaintext = `{"text":"inv20 fanout secret"}`
-
-	// Open character session (participant — permitted).
-	charID := eventbus.SessionIdentity{
-		Kind:        eventbus.IdentityKindCharacter,
-		PlayerID:    participantPlayerID,
-		CharacterID: participantCharID,
-		BindingID:   participantBindingID,
-	}
-	charStream, err := h.subscriber.OpenSession(ctx, characterSessionID, charID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = charStream.Close() })
-
-	// Open plugin session (no manifest — denied).
-	pluginID := eventbus.SessionIdentity{
-		Kind:       eventbus.IdentityKindPlugin,
-		PluginName: deniedPluginName,
-	}
-	pluginStream, err := h.subscriber.OpenSession(ctx, pluginSessionID, pluginID, []eventbus.Subject{"events.>"})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = pluginStream.Close() })
-
-	// Publish the sensitive event after both sessions are open.
-	emitSensitiveWhisper(t, h, sceneID, plaintext)
-
-	// Receive from character session.
-	charRecvCtx, charCancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer charCancel()
-
-	charDelivery, err := charStream.Next(charRecvCtx)
-	require.NoError(t, err, "character session must receive the event")
-	require.NoError(t, charDelivery.Ack())
-
-	// Receive from plugin session.
-	pluginRecvCtx, pluginCancel := context.WithTimeout(ctx, testutil.DefaultWait)
-	defer pluginCancel()
-
-	pluginDelivery, err := pluginStream.Next(pluginRecvCtx)
-	require.NoError(t, err, "plugin session must receive the event (metadata-only)")
-	require.NoError(t, pluginDelivery.Ack())
-
-	// Verifies: INV-20 — the character's plaintext delivery proves the
-	// plugin's deny did not block fan-out to other recipients.
-	assert.False(t, charDelivery.MetadataOnly(), "INV-20: character participant must receive MetadataOnly=false (plaintext)")
-	assert.Equal(t, []byte(plaintext), charDelivery.Event().Payload, "INV-20: character must receive original plaintext")
-
-	// The plugin's deny is expected (INV-17 manifest gate).
-	assert.True(t, pluginDelivery.MetadataOnly(), "INV-20: denied plugin must receive MetadataOnly=true")
-	assert.Empty(t, pluginDelivery.Event().Payload, "INV-20: denied plugin payload must be empty")
-}
+})


### PR DESCRIPTION
## Summary

Part of holomush-1hq.26 / holomush-rccc Stage A. Converts 3 plain-`testing.T` integration test files in `test/integration/crypto/` to Ginkgo specs registered into the existing `Crypto Integration Suite` at `crypto_suite_test.go:26`. One commit per file.

**Files:** emit_test.go (1 func, 218 lines — AAD-binding assertions use `Expect(...).To(Equal(...))` deep compare), metadata_only_test.go (2 funcs, 360 lines — Phase 7 MetadataOnly/NoPlaintextReason shape preserved), plugin_decrypt_test.go (4 funcs, 597 lines).

## Pattern

`suiteT` capture (corrected pattern, matches ~30 existing Ginkgo specs in this codebase) — not `GinkgoT()`, which cannot satisfy `testing.TB`. Matches PR #3951.

No INV-P7-N carrier funcs in scope; no meta-test edits required.

Closes holomush-rccc.3.

## Test plan

- [x] Per-PR gates: \`rg -c 'RunSpecs' test/integration/crypto/\` = 1; \`rg 't.Skip(' test/integration/crypto/\` = 0; converted files have 0 \`func Test\`/\`t.Run\`
- [ ] CI gates: this PR's CI run is the authoritative gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized integration test infrastructure across crypto-related test suites.

---

**Note:** This release contains internal test framework enhancements with no visible changes to end-user functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->