### PR TITLE
test(internal/admin): migrate approval + readstream to Ginkgo (1hq.26 B2)

### DIFF
--- a/internal/admin/approval/approval_suite_test.go
+++ b/internal/admin/approval/approval_suite_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package approval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+	// testPool is the shared database pool for integration tests.
+	testPool *pgxpool.Pool
+)
+
+func TestApproval(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Approval Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+	connStr := testutil.FreshDatabase(suiteT, sharedPG)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var err error
+	testPool, err = pgxpool.New(ctx, connStr)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(testPool.Close)
+})

--- a/internal/admin/approval/repo_integration_test.go
+++ b/internal/admin/approval/repo_integration_test.go
@@ -7,478 +7,410 @@ package approval_test
 
 import (
 	"context"
-	"os"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/admin/approval"
-	"github.com/holomush/holomush/internal/store"
-	"github.com/holomush/holomush/test/testutil"
 )
-
-// testPool is the shared database pool for integration tests.
-// Declared here (integration build tag) to avoid duplicate declaration with
-// the unit-test file that uses none.
-var testPool *pgxpool.Pool
-
-// TestMain sets up a PostgreSQL testcontainer for integration tests.
-func TestMain(m *testing.M) {
-	ctx := context.Background()
-
-	pgEnv, err := testutil.StartPostgres(ctx)
-	if err != nil {
-		panic("failed to start postgres container: " + err.Error())
-	}
-
-	migrator, err := store.NewMigrator(pgEnv.ConnStr)
-	if err != nil {
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to create migrator: " + err.Error())
-	}
-	if err := migrator.Up(); err != nil {
-		_ = migrator.Close()
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to run migrations: " + err.Error())
-	}
-	_ = migrator.Close()
-
-	pool, err := pgxpool.New(ctx, pgEnv.ConnStr)
-	if err != nil {
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to create pool: " + err.Error())
-	}
-
-	testPool = pool
-
-	code := m.Run()
-
-	pool.Close()
-	_ = pgEnv.Terminate(ctx)
-
-	os.Exit(code)
-}
 
 // insertPlayerForApproval inserts a minimal player row for use as a
 // foreign-key anchor. The username uses the full ULID string to avoid
 // the unique-constraint collision that occurs when concurrent tests
 // generate ULIDs with the same leading 8 chars (same millisecond).
-func insertPlayerForApproval(t *testing.T, id string) {
-	t.Helper()
+func insertPlayerForApproval(id string) {
+	GinkgoHelper()
 	ctx := context.Background()
 	// Prefix + full ULID keeps username unique across concurrent tests.
 	username := "apr-" + id
 	_, err := testPool.Exec(ctx,
 		`INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'x')`,
 		id, username)
-	require.NoError(t, err, "insertPlayerForApproval")
-	t.Cleanup(func() {
+	Expect(err).NotTo(HaveOccurred(), "insertPlayerForApproval")
+	DeferCleanup(func() {
 		_, _ = testPool.Exec(ctx, `DELETE FROM players WHERE id = $1`, id)
 	})
 }
 
 // assertCode verifies err is an oops error with the expected code.
-func assertCode(t *testing.T, err error, want string) {
-	t.Helper()
-	require.Error(t, err)
+func assertCode(err error, want string) {
+	GinkgoHelper()
+	Expect(err).To(HaveOccurred())
 	oopsErr, ok := oops.AsOops(err)
-	require.True(t, ok, "expected oops error, got %T", err)
-	assert.Equal(t, want, oopsErr.Code())
+	Expect(ok).To(BeTrue(), "expected oops error, got %T", err)
+	Expect(oopsErr.Code()).To(Equal(want))
 }
 
-// TestRepoOpenAndGet verifies that Open inserts a row and Get retrieves it.
-func TestRepoOpenAndGet(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
+var _ = Describe("Approval Repo", func() {
+	Describe("Open and Get", func() {
+		It("inserts a row via Open and retrieves it via Get", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := r.Get(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.PrimaryPlayerID).To(Equal(primary))
+			Expect(got.OpKind).To(Equal("rekey"))
+			Expect(got.CreatedAt.IsZero()).To(BeFalse())
+			Expect(got.ApprovedAt).To(BeNil())
+		})
 	})
-	require.NoError(t, err)
 
-	got, err := r.Get(context.Background(), id)
-	require.NoError(t, err)
-	assert.Equal(t, primary, got.PrimaryPlayerID)
-	assert.Equal(t, "rekey", got.OpKind)
-	assert.False(t, got.CreatedAt.IsZero())
-	assert.Nil(t, got.ApprovedAt)
-}
+	Describe("Get filters expired rows (INV-D5)", func() {
+		It("returns APPROVAL_NOT_FOUND for expired rows", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
 
-// TestRepoReadFiltersExpired verifies Get returns APPROVAL_NOT_FOUND for
-// expired rows (INV-D5).
-func TestRepoReadFiltersExpired(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			// Force expiry server-side.
+			tag, err := testPool.Exec(context.Background(),
+				`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
+				id[:])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tag.RowsAffected()).To(Equal(int64(1)), "expected exactly one approval row to be force-expired")
+
+			_, err = r.Get(context.Background(), id)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "APPROVAL_NOT_FOUND")
+		})
 	})
-	require.NoError(t, err)
 
-	// Force expiry server-side.
-	tag, err := testPool.Exec(context.Background(),
-		`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
-		id[:])
-	require.NoError(t, err)
-	require.Equal(t, int64(1), tag.RowsAffected(), "expected exactly one approval row to be force-expired")
+	Describe("MarkApproved", func() {
+		It("records the second-op approver on the happy path", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
 
-	_, err = r.Get(context.Background(), id)
-	require.Error(t, err)
-	assertCode(t, err, "APPROVAL_NOT_FOUND")
-}
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoMarkApproved verifies the happy-path second-op approval.
-func TestRepoMarkApproved(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
+			Expect(r.MarkApproved(context.Background(), id, secondOp)).To(Succeed())
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
-	})
-	require.NoError(t, err)
+			got, err := r.Get(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ApprovedAt).NotTo(BeNil())
+			Expect(got.ApprovedByPlayerID).To(Equal(secondOp))
+		})
 
-	require.NoError(t, r.MarkApproved(context.Background(), id, secondOp))
+		It("rejects self-approval at the SQL layer (INV-D6)", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
 
-	got, err := r.Get(context.Background(), id)
-	require.NoError(t, err)
-	require.NotNil(t, got.ApprovedAt)
-	assert.Equal(t, secondOp, got.ApprovedByPlayerID)
-}
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoMarkApprovedRejectsSelfApproval verifies INV-D6: self-approval is
-// rejected at the SQL WHERE-predicate layer.
-func TestRepoMarkApprovedRejectsSelfApproval(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
+			err = r.MarkApproved(context.Background(), id, primary)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "DENY_DUAL_CONTROL_SELF")
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
-	})
-	require.NoError(t, err)
+			got, err := r.Get(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ApprovedAt).To(BeNil(), "row must remain pending after self-approval rejection")
+		})
 
-	err = r.MarkApproved(context.Background(), id, primary)
-	require.Error(t, err)
-	assertCode(t, err, "DENY_DUAL_CONTROL_SELF")
+		It("rejects approval of an expired row (INV-D5)", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
 
-	got, err := r.Get(context.Background(), id)
-	require.NoError(t, err)
-	assert.Nil(t, got.ApprovedAt, "row must remain pending after self-approval rejection")
-}
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoMarkApprovedRejectsExpiredRow verifies INV-D5: MarkApproved on an
-// expired row returns DENY_APPROVAL_EXPIRED.
-func TestRepoMarkApprovedRejectsExpiredRow(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
+			tag, err := testPool.Exec(context.Background(),
+				`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
+				id[:])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tag.RowsAffected()).To(Equal(int64(1)), "expected exactly one approval row to be force-expired")
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
-	})
-	require.NoError(t, err)
+			err = r.MarkApproved(context.Background(), id, secondOp)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "DENY_APPROVAL_EXPIRED")
+		})
 
-	tag, err := testPool.Exec(context.Background(),
-		`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
-		id[:])
-	require.NoError(t, err)
-	require.Equal(t, int64(1), tag.RowsAffected(), "expected exactly one approval row to be force-expired")
+		It("rejects a second MarkApproved on an already-approved row (INV-D7)", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
 
-	err = r.MarkApproved(context.Background(), id, secondOp)
-	require.Error(t, err)
-	assertCode(t, err, "DENY_APPROVAL_EXPIRED")
-}
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoMarkApprovedRejectsAlreadyApproved verifies INV-D7: a second
-// MarkApproved on an already-approved row returns DENY_APPROVAL_ALREADY_APPROVED.
-func TestRepoMarkApprovedRejectsAlreadyApproved(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
+			Expect(r.MarkApproved(context.Background(), id, secondOp)).To(Succeed())
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
-	})
-	require.NoError(t, err)
+			err = r.MarkApproved(context.Background(), id, secondOp)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "DENY_APPROVAL_ALREADY_APPROVED")
+		})
 
-	require.NoError(t, r.MarkApproved(context.Background(), id, secondOp))
+		It("serializes concurrent calls: exactly one succeeds, rest get ALREADY_APPROVED", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
 
-	err = r.MarkApproved(context.Background(), id, secondOp)
-	require.Error(t, err)
-	assertCode(t, err, "DENY_APPROVAL_ALREADY_APPROVED")
-}
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoConcurrentMarkApproved verifies that concurrent MarkApproved calls
-// are serialized by the atomic UPDATE: exactly one succeeds, the rest get
-// DENY_APPROVAL_ALREADY_APPROVED.
-func TestRepoConcurrentMarkApproved(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
-	})
-	require.NoError(t, err)
-
-	const N = 50
-	secondOps := make([]string, N)
-	for i := range secondOps {
-		secondOps[i] = ulid.Make().String()
-		insertPlayerForApproval(t, secondOps[i])
-	}
-
-	var success atomic.Int32
-	var alreadyApproved atomic.Int32
-	var wg sync.WaitGroup
-	wg.Add(N)
-	for i := 0; i < N; i++ {
-		i := i
-		go func() {
-			defer wg.Done()
-			err := r.MarkApproved(context.Background(), id, secondOps[i])
-			if err == nil {
-				success.Add(1)
-				return
+			const N = 50
+			secondOps := make([]string, N)
+			for i := range secondOps {
+				secondOps[i] = ulid.Make().String()
+				insertPlayerForApproval(secondOps[i])
 			}
-			oopsErr, ok := oops.AsOops(err)
-			if ok && oopsErr.Code() == "DENY_APPROVAL_ALREADY_APPROVED" {
-				alreadyApproved.Add(1)
+
+			var success atomic.Int32
+			var alreadyApproved atomic.Int32
+			var wg sync.WaitGroup
+			wg.Add(N)
+			for i := 0; i < N; i++ {
+				i := i
+				go func() {
+					defer wg.Done()
+					err := r.MarkApproved(context.Background(), id, secondOps[i])
+					if err == nil {
+						success.Add(1)
+						return
+					}
+					oopsErr, ok := oops.AsOops(err)
+					if ok && oopsErr.Code() == "DENY_APPROVAL_ALREADY_APPROVED" {
+						alreadyApproved.Add(1)
+					}
+				}()
 			}
-		}()
-	}
-	wg.Wait()
-	assert.Equal(t, int32(1), success.Load(), "exactly one MarkApproved should succeed")
-	assert.Equal(t, int32(N-1), alreadyApproved.Load(), "all losers should see ALREADY_APPROVED")
-}
-
-// TestRepoWaitForApprovalReturnsOnApproval verifies that WaitForApproval
-// returns the approved row once MarkApproved is called concurrently.
-func TestRepoWaitForApprovalReturnsOnApproval(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
-
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			wg.Wait()
+			Expect(success.Load()).To(Equal(int32(1)), "exactly one MarkApproved should succeed")
+			Expect(alreadyApproved.Load()).To(Equal(int32(N-1)), "all losers should see ALREADY_APPROVED")
+		})
 	})
-	require.NoError(t, err)
 
-	deadline := time.Now().Add(10 * time.Second)
+	Describe("WaitForApproval", func() {
+		It("returns the approved row once MarkApproved is called concurrently", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
 
-	// Approve in a goroutine after a short delay.
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		_ = r.MarkApproved(context.Background(), id, secondOp)
-	}()
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-	got, err := r.WaitForApproval(context.Background(), id, deadline)
-	require.NoError(t, err)
-	require.NotNil(t, got.ApprovedAt)
-	assert.Equal(t, secondOp, got.ApprovedByPlayerID)
-}
+			deadline := time.Now().Add(10 * time.Second)
 
-// TestRepoWaitForApprovalDeadlineExpires verifies that WaitForApproval returns
-// APPROVAL_WAIT_DEADLINE when the deadline passes without approval.
-func TestRepoWaitForApprovalDeadlineExpires(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
+			// Approve in a goroutine after a short delay.
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				_ = r.MarkApproved(context.Background(), id, secondOp)
+			}()
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			got, err := r.WaitForApproval(context.Background(), id, deadline)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ApprovedAt).NotTo(BeNil())
+			Expect(got.ApprovedByPlayerID).To(Equal(secondOp))
+		})
+
+		It("returns APPROVAL_WAIT_DEADLINE when the deadline has already passed", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
+
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Deadline already in the past.
+			deadline := time.Now().Add(-1 * time.Second)
+			_, err = r.WaitForApproval(context.Background(), id, deadline)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "APPROVAL_WAIT_DEADLINE")
+		})
+
+		It("surfaces DENY_APPROVAL_EXPIRED immediately on force-expired row (CodeRabbit #4)", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			insertPlayerForApproval(primary)
+
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Force-expire the row so the next poll observes expires_at < now().
+			tag, err := testPool.Exec(context.Background(),
+				`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
+				id[:])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tag.RowsAffected()).To(Equal(int64(1)), "expected exactly one approval row to be force-expired")
+
+			// Use a generous deadline; the call MUST return well before then.
+			deadline := time.Now().Add(30 * time.Second)
+			start := time.Now()
+			_, err = r.WaitForApproval(context.Background(), id, deadline)
+			elapsed := time.Since(start)
+
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "DENY_APPROVAL_EXPIRED")
+			// Sanity: the call must short-circuit on expiry, not run to deadline.
+			// Allow generous slack (1s) for goroutine scheduling and DB roundtrip.
+			Expect(elapsed).To(BeNumerically("<", 1*time.Second),
+				"WaitForApproval MUST return DENY_APPROVAL_EXPIRED quickly, not poll until deadline")
+		})
 	})
-	require.NoError(t, err)
 
-	// Deadline already in the past.
-	deadline := time.Now().Add(-1 * time.Second)
-	_, err = r.WaitForApproval(context.Background(), id, deadline)
-	require.Error(t, err)
-	assertCode(t, err, "APPROVAL_WAIT_DEADLINE")
-}
+	Describe("GetByOpArgsHash (INV-F17)", func() {
+		// openAndApprove is a spec-local helper that opens a fresh approval and
+		// immediately marks it approved by secondOp, returning the resulting Approval.
+		openAndApprove := func(r *approval.PostgresRepo, primary, secondOp, opKind string, opArgsHash []byte) approval.Approval {
+			GinkgoHelper()
+			id, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: opKind, OpArgsHash: opArgsHash,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r.MarkApproved(context.Background(), id, secondOp)).To(Succeed())
+			a, err := r.Get(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+			return a
+		}
 
-// TestRepoWaitForApprovalSurfacesExpiry locks in CodeRabbit #4: when the
-// row's expires_at has passed, WaitForApproval MUST return
-// DENY_APPROVAL_EXPIRED immediately rather than polling past the
-// server-enforced TTL until the caller's deadline. The previous
-// implementation called Get(), which hides expired rows behind
-// APPROVAL_NOT_FOUND, so the loop slept past expiry and dropped the
-// intended DENY_APPROVAL_EXPIRED signal.
-func TestRepoWaitForApprovalSurfacesExpiry(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
+		It("returns an approved non-expired row not authored by excludePlayerID", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			other := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
 
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: []byte("h"),
+			hash := []byte("hash-happy")
+			openAndApprove(r, primary, secondOp, "rekey", hash)
+
+			got, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.PrimaryPlayerID).To(Equal(primary))
+			Expect(got.ApprovedAt).NotTo(BeNil())
+		})
+
+		It("returns APPROVAL_NOT_FOUND for rows where expires_at <= now()", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			other := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
+
+			hash := []byte("hash-expired")
+			a := openAndApprove(r, primary, secondOp, "rekey", hash)
+
+			// Force-expire the row.
+			_, err := testPool.Exec(context.Background(),
+				`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
+				a.RequestID[:])
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "APPROVAL_NOT_FOUND")
+		})
+
+		It("returns APPROVAL_NOT_FOUND when primary_player_id == excludePlayerID", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			secondOp := ulid.Make().String()
+			insertPlayerForApproval(primary)
+			insertPlayerForApproval(secondOp)
+
+			hash := []byte("hash-self-author")
+			openAndApprove(r, primary, secondOp, "rekey", hash)
+
+			// Exclude the primary author — should be filtered.
+			_, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, primary)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "APPROVAL_NOT_FOUND")
+		})
+
+		It("returns APPROVAL_NOT_FOUND for rows where approved_at IS NULL", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary := ulid.Make().String()
+			other := ulid.Make().String()
+			insertPlayerForApproval(primary)
+
+			hash := []byte("hash-unapproved")
+			// Open without approving — approved_at stays NULL.
+			_, err := r.Open(context.Background(), approval.OpenRequest{
+				PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: hash,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
+			Expect(err).To(HaveOccurred())
+			assertCode(err, "APPROVAL_NOT_FOUND")
+		})
+
+		It("returns the most-recently-approved row when two rows match", func() {
+			r := approval.NewPostgresRepo(testPool, nil)
+			primary1 := ulid.Make().String()
+			primary2 := ulid.Make().String()
+			secondOp1 := ulid.Make().String()
+			secondOp2 := ulid.Make().String()
+			other := ulid.Make().String()
+			insertPlayerForApproval(primary1)
+			insertPlayerForApproval(primary2)
+			insertPlayerForApproval(secondOp1)
+			insertPlayerForApproval(secondOp2)
+
+			hash := []byte("hash-tiebreaker")
+
+			// Insert first approval and capture its request_id.
+			a1 := openAndApprove(r, primary1, secondOp1, "rekey", hash)
+
+			// Insert second approval with a later approved_at.
+			a2 := openAndApprove(r, primary2, secondOp2, "rekey", hash)
+
+			// Force a1.approved_at to be clearly earlier so the ORDER BY is deterministic.
+			_, err := testPool.Exec(context.Background(),
+				`UPDATE admin_approvals SET approved_at = now() - interval '10 minutes' WHERE request_id = $1`,
+				a1.RequestID[:])
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
+			Expect(err).NotTo(HaveOccurred())
+			// Should return the row approved most recently (a2).
+			Expect(got.PrimaryPlayerID).To(Equal(a2.PrimaryPlayerID),
+				"GetByOpArgsHash must return the most-recently-approved matching row")
+		})
 	})
-	require.NoError(t, err)
-
-	// Force-expire the row so the next poll observes expires_at < now().
-	tag, err := testPool.Exec(context.Background(),
-		`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
-		id[:])
-	require.NoError(t, err)
-	require.Equal(t, int64(1), tag.RowsAffected(), "expected exactly one approval row to be force-expired")
-
-	// Use a generous deadline; the call MUST return well before then.
-	deadline := time.Now().Add(30 * time.Second)
-	start := time.Now()
-	_, err = r.WaitForApproval(context.Background(), id, deadline)
-	elapsed := time.Since(start)
-
-	require.Error(t, err)
-	assertCode(t, err, "DENY_APPROVAL_EXPIRED")
-	// Sanity: the call must short-circuit on expiry, not run to deadline.
-	// Allow generous slack (1s) for goroutine scheduling and DB roundtrip.
-	assert.Less(t, elapsed, 1*time.Second,
-		"WaitForApproval MUST return DENY_APPROVAL_EXPIRED quickly, not poll until deadline")
-}
-
-// openAndApprove is a test helper that opens a fresh approval and immediately
-// marks it approved by secondOp, returning the resulting Approval.
-func openAndApprove(t *testing.T, r *approval.PostgresRepo, primary, secondOp, opKind string, opArgsHash []byte) approval.Approval {
-	t.Helper()
-	id, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: opKind, OpArgsHash: opArgsHash,
-	})
-	require.NoError(t, err)
-	require.NoError(t, r.MarkApproved(context.Background(), id, secondOp))
-	a, err := r.Get(context.Background(), id)
-	require.NoError(t, err)
-	return a
-}
-
-// TestINV_F17_GetByOpArgsHashMatrix_ReturnsApproved is the INV-F17 happy path:
-// an approved, non-expired row not authored by excludePlayerID is returned.
-func TestINV_F17_GetByOpArgsHashMatrix_ReturnsApproved(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	other := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
-
-	hash := []byte("hash-happy")
-	openAndApprove(t, r, primary, secondOp, "rekey", hash)
-
-	got, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
-	require.NoError(t, err)
-	assert.Equal(t, primary, got.PrimaryPlayerID)
-	assert.NotNil(t, got.ApprovedAt)
-}
-
-// TestINV_F17_GetByOpArgsHashMatrix_FiltersExpired verifies that GetByOpArgsHash
-// returns APPROVAL_NOT_FOUND for rows where expires_at <= now().
-func TestINV_F17_GetByOpArgsHashMatrix_FiltersExpired(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	other := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
-
-	hash := []byte("hash-expired")
-	a := openAndApprove(t, r, primary, secondOp, "rekey", hash)
-
-	// Force-expire the row.
-	_, err := testPool.Exec(context.Background(),
-		`UPDATE admin_approvals SET expires_at = now() - interval '1 minute' WHERE request_id = $1`,
-		a.RequestID[:])
-	require.NoError(t, err)
-
-	_, err = r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
-	require.Error(t, err)
-	assertCode(t, err, "APPROVAL_NOT_FOUND")
-}
-
-// TestINV_F17_GetByOpArgsHashFiltersOwnAuthor verifies that GetByOpArgsHash
-// returns APPROVAL_NOT_FOUND when primary_player_id == excludePlayerID.
-func TestINV_F17_GetByOpArgsHashFiltersOwnAuthor(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	secondOp := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-	insertPlayerForApproval(t, secondOp)
-
-	hash := []byte("hash-self-author")
-	openAndApprove(t, r, primary, secondOp, "rekey", hash)
-
-	// Exclude the primary author — should be filtered.
-	_, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, primary)
-	require.Error(t, err)
-	assertCode(t, err, "APPROVAL_NOT_FOUND")
-}
-
-// TestINV_F17_GetByOpArgsHashMatrix_FiltersUnapproved verifies that
-// GetByOpArgsHash returns APPROVAL_NOT_FOUND for rows where approved_at IS NULL.
-func TestINV_F17_GetByOpArgsHashMatrix_FiltersUnapproved(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary := ulid.Make().String()
-	other := ulid.Make().String()
-	insertPlayerForApproval(t, primary)
-
-	hash := []byte("hash-unapproved")
-	// Open without approving — approved_at stays NULL.
-	_, err := r.Open(context.Background(), approval.OpenRequest{
-		PrimaryPlayerID: primary, OpKind: "rekey", OpArgsHash: hash,
-	})
-	require.NoError(t, err)
-
-	_, err = r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
-	require.Error(t, err)
-	assertCode(t, err, "APPROVAL_NOT_FOUND")
-}
-
-// TestINV_F17_GetByOpArgsHashMatrix_TiebreakerMostRecent verifies that when
-// two approved rows match, GetByOpArgsHash returns the most-recently-approved.
-func TestINV_F17_GetByOpArgsHashMatrix_TiebreakerMostRecent(t *testing.T) {
-	r := approval.NewPostgresRepo(testPool, nil)
-	primary1 := ulid.Make().String()
-	primary2 := ulid.Make().String()
-	secondOp1 := ulid.Make().String()
-	secondOp2 := ulid.Make().String()
-	other := ulid.Make().String()
-	insertPlayerForApproval(t, primary1)
-	insertPlayerForApproval(t, primary2)
-	insertPlayerForApproval(t, secondOp1)
-	insertPlayerForApproval(t, secondOp2)
-
-	hash := []byte("hash-tiebreaker")
-
-	// Insert first approval and capture its request_id.
-	a1 := openAndApprove(t, r, primary1, secondOp1, "rekey", hash)
-
-	// Insert second approval with a later approved_at.
-	a2 := openAndApprove(t, r, primary2, secondOp2, "rekey", hash)
-
-	// Force a1.approved_at to be clearly earlier so the ORDER BY is deterministic.
-	_, err := testPool.Exec(context.Background(),
-		`UPDATE admin_approvals SET approved_at = now() - interval '10 minutes' WHERE request_id = $1`,
-		a1.RequestID[:])
-	require.NoError(t, err)
-
-	got, err := r.GetByOpArgsHash(context.Background(), "rekey", hash, other)
-	require.NoError(t, err)
-	// Should return the row approved most recently (a2).
-	assert.Equal(t, a2.PrimaryPlayerID, got.PrimaryPlayerID,
-		"GetByOpArgsHash must return the most-recently-approved matching row")
-}
+})

--- a/internal/admin/readstream/cold_reader_integration_test.go
+++ b/internal/admin/readstream/cold_reader_integration_test.go
@@ -8,15 +8,15 @@ package readstream
 import (
 	"context"
 	"crypto/rand"
-	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/pkg/errutil"
@@ -24,38 +24,36 @@ import (
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// newTestPool opens a pgxpool against a fresh migrated test database.
-func newColdReaderTestPool(t *testing.T) *pgxpool.Pool {
-	t.Helper()
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.FreshDatabase(t, shared)
+// newColdReaderTestPool opens a pgxpool against a fresh migrated test database.
+func newColdReaderTestPool() *pgxpool.Pool {
+	GinkgoHelper()
+	connStr := testutil.FreshDatabase(suiteT, sharedPG)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
-	t.Cleanup(pool.Close)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
 	return pool
 }
 
 // testULIDAt returns a ULID with the given millisecond timestamp component.
-func testULIDAt(t *testing.T, ms uint64) ulid.ULID {
-	t.Helper()
+func testULIDAt(ms uint64) ulid.ULID {
+	GinkgoHelper()
 	u, err := ulid.New(ms, rand.Reader)
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 	return u
 }
 
 // insertEncryptedAuditRow inserts an events_audit row with a non-NULL dek_ref
 // (simulating an encrypted/sensitive event).
 func insertEncryptedAuditRow(
-	t *testing.T,
 	pool *pgxpool.Pool,
 	id ulid.ULID,
 	subject eventbus.Subject,
 	seq uint64,
 	ts time.Time,
 ) {
-	t.Helper()
+	GinkgoHelper()
 	envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
 		Id:        id[:],
 		Subject:   string(subject),
@@ -63,7 +61,7 @@ func insertEncryptedAuditRow(
 		Timestamp: timestamppb.New(ts),
 		Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
 	})
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
@@ -74,20 +72,19 @@ func insertEncryptedAuditRow(
 		          $4, 1, 'aes256-gcm', $5,
 		          42, 1)
 	`, id[:], string(subject), ts, envelopeBytes, int64(seq))
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 // insertIdentityAuditRow inserts an events_audit row with NULL dek_ref
 // (identity-codec, cleartext event — should be excluded by the filter).
 func insertIdentityAuditRow(
-	t *testing.T,
 	pool *pgxpool.Pool,
 	id ulid.ULID,
 	subject eventbus.Subject,
 	seq uint64,
 	ts time.Time,
 ) {
-	t.Helper()
+	GinkgoHelper()
 	envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
 		Id:        id[:],
 		Subject:   string(subject),
@@ -95,7 +92,7 @@ func insertIdentityAuditRow(
 		Timestamp: timestamppb.New(ts),
 		Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
 	})
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
@@ -104,164 +101,164 @@ func insertIdentityAuditRow(
 		) VALUES ($1, $2, 'test.cleartext', $3, 'system', NULL,
 		          $4, 1, 'identity', $5)
 	`, id[:], string(subject), ts, envelopeBytes, int64(seq))
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 }
 
-// TestColdReader_MultiSubjectUnion: two subjects with 3 rows each → 6 rows returned.
-func TestColdReader_MultiSubjectUnion(t *testing.T) {
-	pool := newColdReaderTestPool(t)
-	now := time.Now().UTC()
+var _ = Describe("ColdReader", func() {
+	Describe("MultiSubjectUnion", func() {
+		It("unions two subjects and returns all rows from both", func() {
+			pool := newColdReaderTestPool()
+			now := time.Now().UTC()
 
-	subjectA := eventbus.Subject("events.game.scene.AAAAAAA.>")
-	subjectB := eventbus.Subject("events.game.scene.BBBBBBB.>")
+			subjectA := eventbus.Subject("events.game.scene.AAAAAAA.>")
+			subjectB := eventbus.Subject("events.game.scene.BBBBBBB.>")
 
-	for i := range 3 {
-		insertEncryptedAuditRow(t, pool, testULIDAt(t, uint64(1000+i)), subjectA, uint64(1+i), now.Add(time.Duration(i)*time.Millisecond))
-	}
-	for i := range 3 {
-		insertEncryptedAuditRow(t, pool, testULIDAt(t, uint64(2000+i)), subjectB, uint64(4+i), now.Add(time.Duration(3+i)*time.Millisecond))
-	}
+			for i := range 3 {
+				insertEncryptedAuditRow(pool, testULIDAt(uint64(1000+i)), subjectA, uint64(1+i), now.Add(time.Duration(i)*time.Millisecond))
+			}
+			for i := range 3 {
+				insertEncryptedAuditRow(pool, testULIDAt(uint64(2000+i)), subjectB, uint64(4+i), now.Add(time.Duration(3+i)*time.Millisecond))
+			}
 
-	cr := NewColdReader(pool)
-	rows, err := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{subjectA, subjectB},
+			cr := NewColdReader(pool)
+			rows, err := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{subjectA, subjectB},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rows).To(HaveLen(6), "both subjects combined should yield 6 rows")
+		})
 	})
-	require.NoError(t, err)
-	assert.Len(t, rows, 6, "both subjects combined should yield 6 rows")
-}
 
-// TestColdReader_TimeBoundsApplied: rows outside the Since/Until window are excluded.
-func TestColdReader_TimeBoundsApplied(t *testing.T) {
-	pool := newColdReaderTestPool(t)
+	Describe("TimeBoundsApplied", func() {
+		It("excludes rows outside the Since/Until window", func() {
+			pool := newColdReaderTestPool()
 
-	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
-	subject := eventbus.Subject("events.game.scene.TIMEBND.>")
+			base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+			subject := eventbus.Subject("events.game.scene.TIMEBND.>")
 
-	// Before window
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 1001), subject, 1, base.Add(-2*time.Hour))
-	// Inside window
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 1002), subject, 2, base.Add(1*time.Hour))
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 1003), subject, 3, base.Add(2*time.Hour))
-	// After window
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 1004), subject, 4, base.Add(5*time.Hour))
+			// Before window
+			insertEncryptedAuditRow(pool, testULIDAt(1001), subject, 1, base.Add(-2*time.Hour))
+			// Inside window
+			insertEncryptedAuditRow(pool, testULIDAt(1002), subject, 2, base.Add(1*time.Hour))
+			insertEncryptedAuditRow(pool, testULIDAt(1003), subject, 3, base.Add(2*time.Hour))
+			// After window
+			insertEncryptedAuditRow(pool, testULIDAt(1004), subject, 4, base.Add(5*time.Hour))
 
-	cr := NewColdReader(pool)
-	rows, err := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{subject},
-		Since:    base,
-		Until:    base.Add(3 * time.Hour),
+			cr := NewColdReader(pool)
+			rows, err := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{subject},
+				Since:    base,
+				Until:    base.Add(3 * time.Hour),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rows).To(HaveLen(2), "only rows within [Since, Until] are returned")
+		})
 	})
-	require.NoError(t, err)
-	assert.Len(t, rows, 2, "only rows within [Since, Until] are returned")
-}
 
-// TestColdReader_FiltersByDekRefNotNull: identity-codec rows are excluded.
-func TestColdReader_FiltersByDekRefNotNull(t *testing.T) {
-	pool := newColdReaderTestPool(t)
-	now := time.Now().UTC()
+	Describe("FiltersByDekRefNotNull", func() {
+		It("excludes identity-codec rows with NULL dek_ref", func() {
+			pool := newColdReaderTestPool()
+			now := time.Now().UTC()
 
-	subject := eventbus.Subject("events.game.scene.DEKFILT.>")
+			subject := eventbus.Subject("events.game.scene.DEKFILT.>")
 
-	// Encrypted row (dek_ref NOT NULL) — should be returned
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 3001), subject, 1, now)
-	// Cleartext row (dek_ref NULL, codec=identity) — must NOT be returned
-	insertIdentityAuditRow(t, pool, testULIDAt(t, 3002), subject, 2, now.Add(time.Millisecond))
+			// Encrypted row (dek_ref NOT NULL) — should be returned
+			insertEncryptedAuditRow(pool, testULIDAt(3001), subject, 1, now)
+			// Cleartext row (dek_ref NULL, codec=identity) — must NOT be returned
+			insertIdentityAuditRow(pool, testULIDAt(3002), subject, 2, now.Add(time.Millisecond))
 
-	cr := NewColdReader(pool)
-	rows, err := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{subject},
+			cr := NewColdReader(pool)
+			rows, err := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{subject},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rows).To(HaveLen(1), "only the encrypted row is returned")
+			Expect(string(rows[0].Codec)).To(Equal("aes256-gcm"))
+		})
 	})
-	require.NoError(t, err)
-	require.Len(t, rows, 1, "only the encrypted row is returned")
-	assert.Equal(t, "aes256-gcm", string(rows[0].Codec))
-}
 
-// TestColdReader_OrderByTimestampAsc: rows are returned in monotonically
-// ascending timestamp order regardless of insertion order.
-func TestColdReader_OrderByTimestampAsc(t *testing.T) {
-	pool := newColdReaderTestPool(t)
+	Describe("OrderByTimestampAsc", func() {
+		It("returns rows in monotonically ascending timestamp order regardless of insertion order", func() {
+			pool := newColdReaderTestPool()
 
-	base := time.Now().UTC().Truncate(time.Millisecond)
-	subject := eventbus.Subject("events.game.scene.ORDERBY.>")
+			base := time.Now().UTC().Truncate(time.Millisecond)
+			subject := eventbus.Subject("events.game.scene.ORDERBY.>")
 
-	// Insert in reverse time order
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 5003), subject, 3, base.Add(3*time.Second))
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 5001), subject, 1, base.Add(1*time.Second))
-	insertEncryptedAuditRow(t, pool, testULIDAt(t, 5002), subject, 2, base.Add(2*time.Second))
+			// Insert in reverse time order
+			insertEncryptedAuditRow(pool, testULIDAt(5003), subject, 3, base.Add(3*time.Second))
+			insertEncryptedAuditRow(pool, testULIDAt(5001), subject, 1, base.Add(1*time.Second))
+			insertEncryptedAuditRow(pool, testULIDAt(5002), subject, 2, base.Add(2*time.Second))
 
-	cr := NewColdReader(pool)
-	rows, err := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{subject},
+			cr := NewColdReader(pool)
+			rows, err := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{subject},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rows).To(HaveLen(3))
+
+			// Verify monotonically ascending timestamps
+			for i := 1; i < len(rows); i++ {
+				Expect(rows[i].Timestamp.Before(rows[i-1].Timestamp)).To(BeFalse(),
+					"rows[%d].Timestamp=%v must be >= rows[%d].Timestamp=%v",
+					i, rows[i].Timestamp, i-1, rows[i-1].Timestamp)
+			}
+			// Verify ascending JsSeq as tiebreaker
+			Expect(rows[0].JsSeq).To(Equal(uint64(1)))
+			Expect(rows[1].JsSeq).To(Equal(uint64(2)))
+			Expect(rows[2].JsSeq).To(Equal(uint64(3)))
+		})
 	})
-	require.NoError(t, err)
-	require.Len(t, rows, 3)
 
-	// Verify monotonically ascending timestamps
-	for i := 1; i < len(rows); i++ {
-		assert.True(
-			t,
-			!rows[i].Timestamp.Before(rows[i-1].Timestamp),
-			"rows[%d].Timestamp=%v must be >= rows[%d].Timestamp=%v",
-			i, rows[i].Timestamp, i-1, rows[i-1].Timestamp,
-		)
-	}
-	// Verify ascending JsSeq as tiebreaker
-	assert.Equal(t, uint64(1), rows[0].JsSeq)
-	assert.Equal(t, uint64(2), rows[1].JsSeq)
-	assert.Equal(t, uint64(3), rows[2].JsSeq)
-}
+	Describe("EmptyResultEofTermination", func() {
+		It("returns a nil slice with nil error when no rows match", func() {
+			pool := newColdReaderTestPool()
 
-// TestColdReader_EmptyResultEofTermination: a query that matches no rows
-// returns an empty slice with nil error — not an EOF or other error.
-func TestColdReader_EmptyResultEofTermination(t *testing.T) {
-	pool := newColdReaderTestPool(t)
-
-	cr := NewColdReader(pool)
-	rows, err := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{"events.game.scene.EMPTY.>"},
-		Since:    time.Now().Add(-time.Hour),
-		Until:    time.Now(),
+			cr := NewColdReader(pool)
+			rows, err := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{"events.game.scene.EMPTY.>"},
+				Since:    time.Now().Add(-time.Hour),
+				Until:    time.Now(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rows).To(BeNil(), "empty result must be nil slice, not an error")
+		})
 	})
-	require.NoError(t, err)
-	assert.Nil(t, rows, "empty result must be nil slice, not an error")
-}
 
-// TestColdReader_DEKVersionNullWithDEKRefPresent tests Finding 1 (R.20): when a
-// row has dek_ref IS NOT NULL but dek_version IS NULL, Read returns
-// ADMIN_READSTREAM_COLD_DEK_VERSION_NULL rather than silently producing
-// keyVersion=0 which would misroute to DEK_NOT_FOUND/STALE_DEK (INV-49).
-func TestColdReader_DEKVersionNullWithDEKRefPresent(t *testing.T) {
-	pool := newColdReaderTestPool(t)
-	now := time.Now().UTC()
-	subject := eventbus.Subject("events.game.scene.DEKVNULL.>")
-	id := testULIDAt(t, 9001)
+	Describe("DEKVersionNullWithDEKRefPresent", func() {
+		It("returns ADMIN_READSTREAM_COLD_DEK_VERSION_NULL for row with dek_ref NOT NULL but dek_version NULL (INV-49)", func() {
+			pool := newColdReaderTestPool()
+			now := time.Now().UTC()
+			subject := eventbus.Subject("events.game.scene.DEKVNULL.>")
+			id := testULIDAt(9001)
 
-	envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
-		Id:        id[:],
-		Subject:   string(subject),
-		Type:      "test.encrypted",
-		Timestamp: timestamppb.New(now),
-		Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
+			envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
+				Id:        id[:],
+				Subject:   string(subject),
+				Type:      "test.encrypted",
+				Timestamp: timestamppb.New(now),
+				Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Insert a row with dek_ref set but dek_version explicitly NULL.
+			// This violates INV-49 and must be detected by the scanner.
+			_, err = pool.Exec(context.Background(), `
+				INSERT INTO events_audit (
+					id, subject, type, timestamp, actor_kind, actor_id,
+					envelope, schema_ver, codec, js_seq,
+					dek_ref, dek_version
+				) VALUES ($1, $2, 'test.encrypted', $3, 'system', NULL,
+				          $4, 1, 'xchacha20poly1305-v1', $5,
+				          42, NULL)
+			`, id[:], string(subject), now, envelopeBytes, int64(9001))
+			Expect(err).NotTo(HaveOccurred())
+
+			cr := NewColdReader(pool)
+			_, readErr := cr.Read(context.Background(), ColdQuery{
+				Subjects: []eventbus.Subject{subject},
+			})
+			Expect(readErr).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, readErr, "ADMIN_READSTREAM_COLD_DEK_VERSION_NULL")
+		})
 	})
-	require.NoError(t, err)
-
-	// Insert a row with dek_ref set but dek_version explicitly NULL.
-	// This violates INV-49 and must be detected by the scanner.
-	_, err = pool.Exec(context.Background(), `
-		INSERT INTO events_audit (
-			id, subject, type, timestamp, actor_kind, actor_id,
-			envelope, schema_ver, codec, js_seq,
-			dek_ref, dek_version
-		) VALUES ($1, $2, 'test.encrypted', $3, 'system', NULL,
-		          $4, 1, 'xchacha20poly1305-v1', $5,
-		          42, NULL)
-	`, id[:], string(subject), now, envelopeBytes, int64(9001))
-	require.NoError(t, err)
-
-	cr := NewColdReader(pool)
-	_, readErr := cr.Read(context.Background(), ColdQuery{
-		Subjects: []eventbus.Subject{subject},
-	})
-	require.Error(t, readErr)
-	errutil.AssertErrorCode(t, readErr, "ADMIN_READSTREAM_COLD_DEK_VERSION_NULL")
-}
+})

--- a/internal/admin/readstream/readstream_suite_test.go
+++ b/internal/admin/readstream/readstream_suite_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package readstream
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+)
+
+func TestReadstream(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Readstream Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+})


### PR DESCRIPTION
## Summary

Part of holomush-1hq.26 / holomush-rccc Stage B. Converts 2 plain-`testing.T` integration test files (across 2 separate Go packages) to Ginkgo, with one new suite bootstrap per sub-package.

**Files modified:**
- `internal/admin/approval/repo_integration_test.go` (16 specs)
- `internal/admin/readstream/cold_reader_integration_test.go` (6 specs)

**Files created:**
- `internal/admin/approval/approval_suite_test.go` ("Approval Integration Suite")
- `internal/admin/readstream/readstream_suite_test.go` ("Readstream Integration Suite")

## Pattern

`suiteT` capture (corrected pattern from PR #3951) — not `GinkgoT()`. Existing testify helpers preserved unchanged.

No INV-P7-N carrier funcs; no meta-test edits required.

Closes holomush-rccc.5.

## Test plan

- [x] Per-PR gates: RunSpecs = 1 per sub-package; 0 t.Skip; converted files have 0 `func Test`/`t.Run`
- [ ] CI gates: authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized integration test infrastructure and testing framework across multiple packages
  * Updated test runners, assertions, cleanup procedures, and database helper initialization
  * Reorganized test structure and harness setup to improve consistency and maintainability
  * Consolidated shared test environment initialization and lifecycle management
  * Maintained comprehensive test coverage for all validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->