### PR TITLE
test(eventbus_e2e): migrate 14 files + suite rename to Ginkgo (1hq.26 cz4s)

### DIFF
--- a/cmd/holomush/gateway_test.go
+++ b/cmd/holomush/gateway_test.go
@@ -1001,7 +1001,8 @@ func TestAcceptLoopReleasesSlotOnHandlerExit(t *testing.T) {
 
 	loopDone := make(chan struct{})
 	go func() {
-		runTelnetAcceptLoop(ctx, ln, &mockGRPCClient{}, cancel, slots, limits,
+		runTelnetAcceptLoop(
+			ctx, ln, &mockGRPCClient{}, cancel, slots, limits,
 			withOnSlotReleased(func() {
 				select {
 				case released <- struct{}{}:

--- a/cmd/holomush/phase7_fence_wiring_test.go
+++ b/cmd/holomush/phase7_fence_wiring_test.go
@@ -128,7 +128,7 @@ func TestViolationEmitter_NilPublisher_GracefulNoop(t *testing.T) {
 // the newViolationEmitter refactor (rawPub + registry → wraps with
 // RenderingPublisher internally), the publish path is:
 //
-//   errPublisher → RenderingPublisher(EMIT_PUBLISH_FAILED) → EmitViolation(PLUGIN_INTEGRITY_VIOLATION_EMIT_FAILED)
+//	errPublisher → RenderingPublisher(EMIT_PUBLISH_FAILED) → EmitViolation(PLUGIN_INTEGRITY_VIOLATION_EMIT_FAILED)
 //
 // samber/oops returns the DEEPEST oops code via OopsError.Code(), so
 // AsOops surfaces EMIT_PUBLISH_FAILED. The outer

--- a/internal/cluster/clustertest/harness.go
+++ b/internal/cluster/clustertest/harness.go
@@ -257,7 +257,7 @@ func (s memberJoinSignaler) OnMemberJoined(m cluster.Member) {
 	}
 }
 
-func (s memberJoinSignaler) OnMemberLeft(cluster.MemberID, cluster.LeaveReason)         {}
+func (s memberJoinSignaler) OnMemberLeft(cluster.MemberID, cluster.LeaveReason)           {}
 func (s memberJoinSignaler) OnMemberStatusChanged(cluster.MemberID, cluster.MemberStatus) {}
 
 func (h *Harness) snapshot() string {

--- a/internal/eventbus/history/phase7_boundary_meta_test.go
+++ b/internal/eventbus/history/phase7_boundary_meta_test.go
@@ -59,19 +59,40 @@ func TestPhase7InvariantsHaveNamedTests(t *testing.T) {
 		{"INV-P7-3", "TestBinaryPlugin"},
 		{"INV-P7-4", "TestAuditRowStructMirrorsProto"},
 		{"INV-P7-5", "TestAuditRowRoundTripPreservesAllFields"},
-		{"INV-P7-6", "TestSceneLogPreservesCiphertextAndAuditHeaders"},
+		// INV-P7-6 was carried by func TestSceneLogPreservesCiphertextAndAuditHeaders
+		// until the holomush-cz4s testify+ginkgo migration converted the spec to a
+		// Ginkgo Describe registered under the suite entry TestEventbusE2E (see
+		// test/integration/eventbus_e2e/plugin_audit_round_trip_test.go). The spec
+		// name "Scene log preserves ciphertext and audit headers (INV-P7-6, INV-P7-12)"
+		// remains greppable inside that file for invariant traceability.
+		{"INV-P7-6", "TestEventbusE2E"},
 		{"INV-P7-7", "TestFenceRefusesIdentityForAlwaysSensitiveType"},
 		// INV-P7-7b — per-row, NOT stream-fatal (the corrected v3 design).
 		{"INV-P7-7b", "TestFenceContinuesStreamAfterRefusal"},
 		{"INV-P7-8", "TestFenceSetBuiltOnceAtBoot"},
 		// INV-P7-C0 — Phase C.0 substrate (auditRow stamp + accessor).
 		{"INV-P7-C0", "TestAuditRowOfStampedByRouter"},
-		{"INV-P7-9", "TestDispatcherAndHotTierShareSelector"},
-		{"INV-P7-10", "TestDowngradeAttackerMaliciousPathRefuses"},
+		// INV-P7-9 was carried by func TestDispatcherAndHotTierShareSelector until
+		// the holomush-cz4s testify+ginkgo migration converted the spec to a Ginkgo
+		// Describe registered under the suite entry TestEventbusE2E (see
+		// test/integration/eventbus_e2e/dispatcher_selector_identity_test.go). The
+		// spec name "Dispatcher and hot tier share selector (INV-P7-9)" remains
+		// greppable inside that file for invariant traceability.
+		{"INV-P7-9", "TestEventbusE2E"},
+		// INV-P7-10 was carried by func TestDowngradeAttackerMaliciousPathRefuses until
+		// the holomush-cz4s testify+ginkgo migration converted the spec to a Ginkgo
+		// Describe registered under the suite entry TestEventbusE2E (see
+		// test/integration/eventbus_e2e/plugin_downgrade_attacker_test.go). The spec
+		// name "Downgrade attacker malicious path refuses (INV-P7-10)" remains
+		// greppable inside that file for invariant traceability.
+		{"INV-P7-10", "TestEventbusE2E"},
 		{"INV-P7-11", "TestDispatchDoesNotDecryptBeforeForward"},
-		// INV-P7-12 shares its named test with INV-P7-6 (one round-trip
-		// covers both cleartext-vs-ciphertext invariants).
-		{"INV-P7-12", "TestSceneLogPreservesCiphertextAndAuditHeaders"},
+		// INV-P7-12 shares its named Ginkgo spec with INV-P7-6 (one round-trip
+		// covers both cleartext-vs-ciphertext invariants). Was carried by func
+		// TestSceneLogPreservesCiphertextAndAuditHeaders until the holomush-cz4s
+		// testify+ginkgo migration; now registered under TestEventbusE2E (see
+		// test/integration/eventbus_e2e/plugin_audit_round_trip_test.go).
+		{"INV-P7-12", "TestEventbusE2E"},
 		// INV-P7-13 was carried by func TestPluginRoleCannotWriteHostTables
 		// until the 1hq.26 testify+ginkgo migration converted the spec to a
 		// Ginkgo Describe registered under the suite entry TestBinaryPlugin

--- a/pkg/plugin/audit_test.go
+++ b/pkg/plugin/audit_test.go
@@ -30,17 +30,26 @@ type fakeJSMsg struct {
 	data    []byte
 }
 
-func (f *fakeJSMsg) Headers() nats.Header                  { return f.headers }
-func (f *fakeJSMsg) Data() []byte                          { return f.data }
-func (f *fakeJSMsg) Subject() string                       { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) Reply() string                         { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) Ack() error                            { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) DoubleAck(_ context.Context) error     { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) Nak() error                            { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) NakWithDelay(_ time.Duration) error    { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) InProgress() error                     { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) Term() error                           { panic("not used in StoreFromMessage tests") }
-func (f *fakeJSMsg) TermWithReason(_ string) error         { panic("not used in StoreFromMessage tests") }
+func (f *fakeJSMsg) Headers() nats.Header { return f.headers }
+func (f *fakeJSMsg) Data() []byte         { return f.data }
+func (f *fakeJSMsg) Subject() string { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) Reply() string { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) Ack() error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) DoubleAck(_ context.Context) error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) Nak() error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) NakWithDelay(_ time.Duration) error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) InProgress() error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) Term() error { panic("not used in StoreFromMessage tests") }
+
+func (f *fakeJSMsg) TermWithReason(_ string) error { panic("not used in StoreFromMessage tests") }
+
 func (f *fakeJSMsg) Metadata() (*jetstream.MsgMetadata, error) {
 	panic("not used in StoreFromMessage tests")
 }

--- a/test/integration/eventbus_e2e/audit_drift_detector_test.go
+++ b/test/integration/eventbus_e2e/audit_drift_detector_test.go
@@ -7,19 +7,19 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestAuditDriftDetectorReportsTamperedRow exercises spec §8 "Audit drift
-// detector -> Tampered row reported with id". The detector is not yet
-// implemented; this test:
+// Audit drift detector specs — covers spec §8 "Audit drift detector ->
+// Tampered row reported with id". The detector is not yet implemented;
+// this skeleton:
 //
 //  1. Publishes a canonical event and waits for it to be projected into
 //     events_audit.
@@ -29,40 +29,42 @@ import (
 //     is returned with a diagnostic reason.
 //
 // The setup is preserved so the follow-up bead only has to add the
-// detector wiring and the final assertion, not rebuild the test.
+// detector wiring and the final assertion, not rebuild the spec.
 //
 // Follow-up: holomush-ecbg — eventbus audit drift detector.
-func TestAuditDriftDetectorReportsTamperedRow(t *testing.T) {
-	t.Skip("TODO(holomush-ecbg): drift detector not yet implemented — skeleton retained for the follow-up bead")
+var _ = Describe("Audit drift detector reports tampered row", func() {
+	It("detects tampered row and reports id with diagnostic reason", func() {
+		Skip("TODO(holomush-ecbg): drift detector not yet implemented — skeleton retained for the follow-up bead")
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	// Stand up the host projection so publishes reach events_audit.
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
+		// Stand up the host projection so publishes reach events_audit.
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
 
-	// Publish one event.
-	pub := bus.Bus.Publisher()
-	evt := mintEvent(eventbus.Subject("events.main.drift.s1"), "scene.pose", `{"x":1}`)
-	require.NoError(t, pub.Publish(ctx, evt))
-	hostSub.AwaitDrained(t, 10*time.Second)
+		// Publish one event.
+		pub := bus.Bus.Publisher()
+		evt := mintEvent(eventbus.Subject("events.main.drift.s1"), "scene.pose", `{"x":1}`)
+		Expect(pub.Publish(ctx, evt)).To(Succeed())
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
 
-	// Tamper: set codec to an unregistered value. The drift detector
-	// must observe that codec resolution fails and report the id.
-	_, err := pool.Exec(ctx,
-		`UPDATE events_audit SET codec = 'not-a-real-codec' WHERE id = $1`,
-		evt.ID.Bytes())
-	require.NoError(t, err)
+		// Tamper: set codec to an unregistered value. The drift detector
+		// must observe that codec resolution fails and report the id.
+		_, err := pool.Exec(ctx,
+			`UPDATE events_audit SET codec = 'not-a-real-codec' WHERE id = $1`,
+			evt.ID.Bytes())
+		Expect(err).NotTo(HaveOccurred())
 
-	// TODO(holomush-ecbg): invoke the detector and assert:
-	//   reports, err := drift.Scan(ctx, pool, codec.DefaultRegistry)
-	//   require.NoError(t, err)
-	//   assert.Len(t, reports, 1)
-	//   assert.Equal(t, evt.ID, reports[0].ID)
-	//   assert.Contains(t, reports[0].Reason, "codec")
-}
+		// TODO(holomush-ecbg): invoke the detector and assert:
+		//   reports, err := drift.Scan(ctx, pool, codec.DefaultRegistry)
+		//   Expect(err).NotTo(HaveOccurred())
+		//   Expect(reports).To(HaveLen(1))
+		//   Expect(reports[0].ID).To(Equal(evt.ID))
+		//   Expect(reports[0].Reason).To(ContainSubstring("codec"))
+	})
+})

--- a/test/integration/eventbus_e2e/audit_drift_detector_test.go
+++ b/test/integration/eventbus_e2e/audit_drift_detector_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Audit drift detector specs — covers spec §8 "Audit drift detector ->
@@ -39,8 +38,8 @@ var _ = Describe("Audit drift detector reports tampered row", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
 		// Stand up the host projection so publishes reach events_audit.
 		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})

--- a/test/integration/eventbus_e2e/audit_only_channel_test.go
+++ b/test/integration/eventbus_e2e/audit_only_channel_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Audit-only channel persistence specs — regression-lock for
@@ -38,8 +37,8 @@ var _ = Describe("Audit-only channel persists to events_audit", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
 		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
 		Expect(hostSub.Start(ctx)).To(Succeed())

--- a/test/integration/eventbus_e2e/audit_only_channel_test.go
+++ b/test/integration/eventbus_e2e/audit_only_channel_test.go
@@ -7,11 +7,10 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
@@ -19,7 +18,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestAuditOnlyChannelPersistsToEventsAudit is the regression-lock for
+// Audit-only channel persistence specs — regression-lock for
 // holomush-jxo8.6.26: sub-epic D's host-emit security audit events
 // (crypto.totp_locked, crypto.totp_cleared, crypto.totp_recovery_code_consumed,
 // crypto.policy_set) MUST persist to events_audit when published through
@@ -32,92 +31,95 @@ import (
 // such event with AUDIT_MISSING_HEADER and the row never landed.
 //
 // Restores INV-D14 (audit emission persists) and INV-D17 (chain genesis
-// emit persists). The test exercises the full publish→persist round-trip
+// emit persists). The spec exercises the full publish→persist round-trip
 // for every host-emit AUDIT_ONLY event type registered in builtins.go.
-func TestAuditOnlyChannelPersistsToEventsAudit(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+var _ = Describe("Audit-only channel persists to events_audit", func() {
+	It("persists every AUDIT_ONLY host-emit event type", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
 
-	registry, err := core.BootstrapVerbRegistry("test-0.1")
-	require.NoError(t, err)
-	pub := eventbus.NewRenderingPublisher(bus.Bus.Publisher(), registry)
+		registry, err := core.BootstrapVerbRegistry("test-0.1")
+		Expect(err).NotTo(HaveOccurred())
+		pub := eventbus.NewRenderingPublisher(bus.Bus.Publisher(), registry)
 
-	// One event per host-emit AUDIT_ONLY type. Subjects mirror the real
-	// patterns produced by internal/totp/audit.go and internal/admin/policy/emitter.go
-	// so the audit row's subject column carries production-shaped values.
-	//
-	// gameID is unique per test run (suffixed with a fresh ULID) so the
-	// downstream events_audit assertions only match rows produced by THIS
-	// run — a fixed "main" would let prior test runs pollute the result
-	// set when Postgres state persists across runs.
-	gameID := "main_" + core.NewULID().String()
-	auditEvents := []struct {
-		subject eventbus.Subject
-		typ     eventbus.Type
-	}{
-		{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERLOCKED.locked"), "crypto.totp_locked"},
-		{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERCLEARD.cleared"), "crypto.totp_cleared"},
-		{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERRECOVD.recovery_consumed"), "crypto.totp_recovery_code_consumed"},
-		{eventbus.Subject("events." + gameID + ".system.crypto_policy.dual_control_required"), "crypto.policy_set"},
-	}
-
-	for _, ae := range auditEvents {
-		ev := eventbus.Event{
-			ID:        core.NewULID(),
-			Subject:   ae.subject,
-			Type:      ae.typ,
-			Timestamp: time.Now().UTC(),
-			Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-			Payload:   []byte(`{}`),
+		// One event per host-emit AUDIT_ONLY type. Subjects mirror the real
+		// patterns produced by internal/totp/audit.go and internal/admin/policy/emitter.go
+		// so the audit row's subject column carries production-shaped values.
+		//
+		// gameID is unique per test run (suffixed with a fresh ULID) so the
+		// downstream events_audit assertions only match rows produced by THIS
+		// run — a fixed "main" would let prior test runs pollute the result
+		// set when Postgres state persists across runs.
+		gameID := "main_" + core.NewULID().String()
+		auditEvents := []struct {
+			subject eventbus.Subject
+			typ     eventbus.Type
+		}{
+			{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERLOCKED.locked"), "crypto.totp_locked"},
+			{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERCLEARD.cleared"), "crypto.totp_cleared"},
+			{eventbus.Subject("events." + gameID + ".system.crypto_totp.01TESTPLAYERRECOVD.recovery_consumed"), "crypto.totp_recovery_code_consumed"},
+			{eventbus.Subject("events." + gameID + ".system.crypto_policy.dual_control_required"), "crypto.policy_set"},
 		}
-		require.NoError(t, pub.Publish(ctx, ev), "publish %s", ae.typ)
-	}
 
-	hostSub.AwaitDrained(t, 10*time.Second)
-	require.Eventually(t, func() bool {
-		var count int
-		err := pool.QueryRow(
-			ctx,
-			`SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1`,
-			"events."+gameID+".%",
-		).Scan(&count)
-		return err == nil && count >= len(auditEvents)
-	}, 10*time.Second, 100*time.Millisecond, "audit projection did not drain all AUDIT_ONLY events")
+		for _, ae := range auditEvents {
+			ev := eventbus.Event{
+				ID:        core.NewULID(),
+				Subject:   ae.subject,
+				Type:      ae.typ,
+				Timestamp: time.Now().UTC(),
+				Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
+				Payload:   []byte(`{}`),
+			}
+			Expect(pub.Publish(ctx, ev)).To(Succeed(), "publish %s", ae.typ)
+		}
 
-	// Every AUDIT_ONLY event lands with display_target = "EVENT_CHANNEL_AUDIT_ONLY"
-	// in the rendering JSONB, source_plugin="builtin", and category="system".
-	for _, ae := range auditEvents {
-		var (
-			displayTarget string
-			sourcePlugin  string
-			category      string
-		)
-		err := pool.QueryRow(
-			ctx,
-			`SELECT rendering->>'display_target',
-			        rendering->>'source_plugin',
-			        rendering->>'category'
-			   FROM events_audit
-			  WHERE type = $1
-			    AND subject LIKE $2
-			  ORDER BY js_seq DESC
-			  LIMIT 1`,
-			string(ae.typ),
-			"events."+gameID+".%",
-		).Scan(&displayTarget, &sourcePlugin, &category)
-		require.NoError(t, err, "no events_audit row for type=%s — pre-fix bug?", ae.typ)
-		assert.Equal(t, "EVENT_CHANNEL_AUDIT_ONLY", displayTarget,
-			"type=%s rendering.display_target", ae.typ)
-		assert.Equal(t, "builtin", sourcePlugin,
-			"type=%s rendering.source_plugin", ae.typ)
-		assert.Equal(t, "system", category,
-			"type=%s rendering.category", ae.typ)
-	}
-}
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
+		Eventually(func() bool {
+			var count int
+			qerr := pool.QueryRow(
+				ctx,
+				`SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1`,
+				"events."+gameID+".%",
+			).Scan(&count)
+			return qerr == nil && count >= len(auditEvents)
+		}, 10*time.Second, 100*time.Millisecond).Should(BeTrue(),
+			"audit projection did not drain all AUDIT_ONLY events")
+
+		// Every AUDIT_ONLY event lands with display_target = "EVENT_CHANNEL_AUDIT_ONLY"
+		// in the rendering JSONB, source_plugin="builtin", and category="system".
+		for _, ae := range auditEvents {
+			var (
+				displayTarget string
+				sourcePlugin  string
+				category      string
+			)
+			qerr := pool.QueryRow(
+				ctx,
+				`SELECT rendering->>'display_target',
+				        rendering->>'source_plugin',
+				        rendering->>'category'
+				   FROM events_audit
+				  WHERE type = $1
+				    AND subject LIKE $2
+				  ORDER BY js_seq DESC
+				  LIMIT 1`,
+				string(ae.typ),
+				"events."+gameID+".%",
+			).Scan(&displayTarget, &sourcePlugin, &category)
+			Expect(qerr).NotTo(HaveOccurred(), "no events_audit row for type=%s — pre-fix bug?", ae.typ)
+			Expect(displayTarget).To(Equal("EVENT_CHANNEL_AUDIT_ONLY"),
+				"type=%s rendering.display_target", ae.typ)
+			Expect(sourcePlugin).To(Equal("builtin"),
+				"type=%s rendering.source_plugin", ae.typ)
+			Expect(category).To(Equal("system"),
+				"type=%s rendering.category", ae.typ)
+		}
+	})
+})

--- a/test/integration/eventbus_e2e/backfill_rebuild_test.go
+++ b/test/integration/eventbus_e2e/backfill_rebuild_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Backfill rebuild specs — covers spec §8 "Backfill rebuild ->
@@ -31,8 +30,8 @@ var _ = Describe("Audit backfill produces matching counts", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 		pub := bus.Bus.Publisher()
 
 		// Publish N events while the audit projection is NOT running, so

--- a/test/integration/eventbus_e2e/backfill_rebuild_test.go
+++ b/test/integration/eventbus_e2e/backfill_rebuild_test.go
@@ -7,53 +7,55 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestAuditBackfillProducesMatchingCounts covers spec §8 "Backfill
-// rebuild -> bin/holomush audit-backfill produces matching counts".
-// The audit-backfill CLI subcommand does not exist yet; this test
-// stands up the JS stream with content and defers the CLI invocation
-// + post-invocation count parity assertion to the follow-up bead.
+// Backfill rebuild specs — covers spec §8 "Backfill rebuild ->
+// bin/holomush audit-backfill produces matching counts".
+// The audit-backfill CLI subcommand does not exist yet; this skeleton
+// stands up the JS stream with content and defers the CLI invocation +
+// post-invocation count parity assertion to the follow-up bead.
 //
 // Follow-up: holomush-l4kx — holomush audit-backfill CLI subcommand.
-func TestAuditBackfillProducesMatchingCounts(t *testing.T) {
-	t.Skip("TODO(holomush-l4kx): audit-backfill CLI not yet implemented — skeleton retained for the follow-up bead")
+var _ = Describe("Audit backfill produces matching counts", func() {
+	It("bin/holomush audit-backfill produces matching counts", func() {
+		Skip("TODO(holomush-l4kx): audit-backfill CLI not yet implemented — skeleton retained for the follow-up bead")
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
-	pub := bus.Bus.Publisher()
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
+		pub := bus.Bus.Publisher()
 
-	// Publish N events while the audit projection is NOT running, so
-	// events_audit stays empty while JS accumulates the stream.
-	const count = 20
-	for i := 0; i < count; i++ {
-		require.NoError(t, pub.Publish(ctx, mintEvent(
-			eventbus.Subject("events.main.backfill.s1"),
-			"scene.pose",
-			`{"n":`+itoa(i)+`}`,
-		)))
-	}
-	// Sanity: events_audit is empty right now (no projection running).
+		// Publish N events while the audit projection is NOT running, so
+		// events_audit stays empty while JS accumulates the stream.
+		const count = 20
+		for i := 0; i < count; i++ {
+			Expect(pub.Publish(ctx, mintEvent(
+				eventbus.Subject("events.main.backfill.s1"),
+				"scene.pose",
+				`{"n":`+itoa(i)+`}`,
+			))).To(Succeed())
+		}
+		// Sanity: events_audit is empty right now (no projection running).
 
-	// TODO(holomush-l4kx): Exec the subcommand:
-	//   cmd := exec.Command("bin/holomush", "audit-backfill", "--dsn", connStr)
-	//   out, err := cmd.CombinedOutput()
-	//   require.NoError(t, err, "%s", out)
-	//
-	// After:
-	//   Assertion: events_audit row count == JS stream LastSeq.
+		// TODO(holomush-l4kx): Exec the subcommand:
+		//   cmd := exec.Command("bin/holomush", "audit-backfill", "--dsn", connStr)
+		//   out, err := cmd.CombinedOutput()
+		//   Expect(err).NotTo(HaveOccurred(), "%s", out)
+		//
+		// After:
+		//   Assertion: events_audit row count == JS stream LastSeq.
 
-	_ = audit.DefaultConsumerName // silence unused import if imports change
-	_ = pool
-}
+		_ = audit.DefaultConsumerName // silence unused import if imports change
+		_ = pool
+	})
+})

--- a/test/integration/eventbus_e2e/cross_tier_query_test.go
+++ b/test/integration/eventbus_e2e/cross_tier_query_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -28,7 +28,7 @@ import (
 	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
 )
 
-// TestCrossTierQueryEndToEnd mirrors the 12-scenario tier suite from
+// Cross-tier query end-to-end specs — mirrors the 12-scenario tier suite from
 // internal/eventbus/history/tier_test.go but runs against the real
 // JetStream hot tier + real PostgreSQL cold tier. The in-memory suite
 // uses fakeTier; this suite uses the JS-backed and PG-backed real
@@ -49,385 +49,404 @@ import (
 //   - Per scenario we assert:
 //     (a) the right set of events is returned in the right order,
 //     (b) tier-specific counters/assertions match spec expectations.
-func TestCrossTierQueryEndToEnd(t *testing.T) {
-	// A single bus + pool serve all subtests to keep setup cost down.
-	// Each subtest picks a distinct subject so there's no cross-talk on
-	// events_audit or on the EVENTS stream.
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+var _ = Describe("Cross-tier query end-to-end", func() {
+	var (
+		bus          *eventbustest.Embedded
+		pool         *pgxpool.Pool
+		pub          eventbus.Publisher
+		streamMaxAge time.Duration
+		baseNow      time.Time
+		edge         time.Time
+	)
 
-	streamMaxAge := 30 * 24 * time.Hour // matches production default
-	safety := time.Hour
+	BeforeEach(func() {
+		// A single bus + pool serve all specs to keep setup cost down.
+		// Each spec picks a distinct subject so there's no cross-talk on
+		// events_audit or on the EVENTS stream.
+		bus = eventbustest.New(suiteT)
+		pool = freshPool(suiteT)
 
-	// "now" for every subtest. Edge = now - 30d + 1h.
-	baseNow := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
-	edge := baseNow.Add(-streamMaxAge).Add(safety)
+		streamMaxAge = 30 * 24 * time.Hour // matches production default
+		safety := time.Hour
 
-	// Shared pub for JS seeding.
-	pub := bus.Bus.Publisher()
-	require.NotNil(t, pub)
+		// "now" for every spec. Edge = now - 30d + 1h.
+		baseNow = time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+		edge = baseNow.Add(-streamMaxAge).Add(safety)
 
-	scenarios := []struct {
-		name string
-		run  func(t *testing.T, ctx context.Context, subject eventbus.Subject)
-	}{
-		{
-			name: "scenario1_cursor_within_js_retention",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// All events recent; Reader served entirely from JS, zero PG.
-				hot := []eventbus.Event{
-					mintAt(subject, baseNow.Add(-2*time.Hour), "a"),
-					mintAt(subject, baseNow.Add(-1*time.Hour), "b"),
-				}
-				publishAll(ctx, t, pub, hot)
-				// Barrier so JS has committed before we read.
-				bus.AwaitStreamLastSeq(t, currentStreamLastSeq(t, bus)+0, 5*time.Second)
+		// Shared pub for JS seeding.
+		pub = bus.Bus.Publisher()
+		Expect(pub).NotTo(BeNil())
+	})
 
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: baseNow.Add(-3 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  50,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
+	It("scenario1: cursor within JS retention serves entirely from hot tier", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(1))
 
-				got := drainStream(t, stream)
-				require.Len(t, got, len(hot))
-				assert.Equal(t, hot[0].ID, got[0].ID)
-				assert.Equal(t, hot[1].ID, got[1].ID)
-			},
-		},
-		{
-			name: "scenario2_cursor_older_than_retention",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// All events aged — projected directly to events_audit.
-				cold := []eventbus.Event{
-					mintAt(subject, edge.Add(-10*24*time.Hour), "a"),
-					mintAt(subject, edge.Add(-5*24*time.Hour), "b"),
-				}
-				insertAuditRows(ctx, t, bus, pub, pool, cold)
+		// All events recent; Reader served entirely from JS, zero PG.
+		hot := []eventbus.Event{
+			mintAt(subject, baseNow.Add(-2*time.Hour), "a"),
+			mintAt(subject, baseNow.Add(-1*time.Hour), "b"),
+		}
+		publishAll(ctx, suiteT, pub, hot)
+		// Barrier so JS has committed before we read.
+		bus.AwaitStreamLastSeq(suiteT, currentStreamLastSeq(suiteT, bus)+0, 5*time.Second)
 
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(-20 * 24 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  50,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, len(cold))
-				assert.Equal(t, cold[0].ID, got[0].ID)
-				assert.Equal(t, cold[1].ID, got[1].ID)
-			},
-		},
-		{
-			name: "scenario3_cursor_at_boundary_edge",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// Event exactly at edge — routes to JS per "ties go hot".
-				atEdge := mintAt(subject, edge, "edge")
-				publishAll(ctx, t, pub, []eventbus.Event{atEdge})
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge,
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 1)
-				assert.Equal(t, atEdge.ID, got[0].ID)
-			},
-		},
-		{
-			name: "scenario4_page_boundary_crosses",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				cold := []eventbus.Event{
-					mintAt(subject, edge.Add(-3*time.Hour), "c1"),
-					mintAt(subject, edge.Add(-2*time.Hour), "c2"),
-				}
-				hot := []eventbus.Event{
-					mintAt(subject, edge.Add(time.Hour), "h1"),
-					mintAt(subject, edge.Add(2*time.Hour), "h2"),
-				}
-				insertAuditRows(ctx, t, bus, pub, pool, cold)
-				publishAll(ctx, t, pub, hot)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(-5 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 4, "all 4 across both tiers")
-				for i := 1; i < len(got); i++ {
-					assert.True(t, got[i-1].ID.Compare(got[i].ID) < 0,
-						"expected strictly ascending ULID at position %d", i)
-				}
-			},
-		},
-		{
-			name: "scenario5_clock_skew_absorbed",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// Place an event at edge-5s: within safetyMargin window. It
-				// lives in JS; we also INSERT it in PG to represent the
-				// "lagging projection" overlap. Dedup must suppress the dup.
-				dup := mintAt(subject, edge.Add(-5*time.Second), "overlap")
-				seqBefore := currentStreamLastSeq(t, bus)
-				publishAll(ctx, t, pub, []eventbus.Event{dup})
-				bus.AwaitStreamLastSeq(t, seqBefore+1, 5*time.Second)
-				dupSeq := currentStreamLastSeq(t, bus)
-				// Insert into cold with the SAME JS seq so seenSeqs dedup
-				// recognises the overlap event as already delivered.
-				insertAuditRowWithSeq(ctx, t, pool, dup, dupSeq)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(-24 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 1, "ULID dedup must suppress the duplicate")
-				assert.Equal(t, dup.ID, got[0].ID)
-			},
-		},
-		{
-			name: "scenario6_forward_direction",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				cold := []eventbus.Event{
-					mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
-					mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
-				}
-				hot := []eventbus.Event{
-					mintAt(subject, edge.Add(time.Hour), "h1"),
-					mintAt(subject, edge.Add(10*time.Hour), "h2"),
-				}
-				insertAuditRows(ctx, t, bus, pub, pool, cold)
-				publishAll(ctx, t, pub, hot)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(-100 * 24 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 4)
-				// Oldest -> newest.
-				assert.Equal(t, cold[0].ID, got[0].ID)
-				assert.Equal(t, hot[1].ID, got[3].ID)
-			},
-		},
-		{
-			name: "scenario7_backward_direction",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				cold := []eventbus.Event{
-					mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
-					mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
-				}
-				hot := []eventbus.Event{
-					mintAt(subject, edge.Add(time.Hour), "h1"),
-					mintAt(subject, edge.Add(10*time.Hour), "h2"),
-				}
-				insertAuditRows(ctx, t, bus, pub, pool, cold)
-				publishAll(ctx, t, pub, hot)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotAfter:  baseNow,
-					Direction: eventbus.DirectionBackward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 4)
-				// Newest -> oldest.
-				assert.Equal(t, hot[1].ID, got[0].ID)
-				assert.Equal(t, cold[0].ID, got[3].ID)
-			},
-		},
-		{
-			name: "scenario8_empty_pg_full_js",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				hot := []eventbus.Event{
-					mintAt(subject, edge.Add(time.Hour), "h1"),
-					mintAt(subject, edge.Add(2*time.Hour), "h2"),
-				}
-				publishAll(ctx, t, pub, hot)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(30 * time.Minute),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 2)
-			},
-		},
-		{
-			name: "scenario9_empty_js_full_pg",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				cold := []eventbus.Event{
-					mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
-					mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
-				}
-				insertAuditRows(ctx, t, bus, pub, pool, cold)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: edge.Add(-30 * 24 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 2)
-			},
-		},
-		{
-			name: "scenario10_both_empty",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				_, nerr := stream.Next(ctx)
-				assert.ErrorIs(t, nerr, io.EOF)
-			},
-		},
-		{
-			name: "scenario11_nonexistent_subject",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// Seed events on a DIFFERENT subject; query for ours.
-				other := eventbus.Subject("events.main.elsewhere.zzz")
-				publishAll(ctx, t, pub, []eventbus.Event{mintAt(other, edge.Add(time.Hour), "x")})
-				insertAuditRows(ctx, t, bus, pub, pool, []eventbus.Event{mintAt(other, edge.Add(-time.Hour), "y")})
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				_, nerr := stream.Next(ctx)
-				assert.ErrorIs(t, nerr, io.EOF)
-			},
-		},
-		{
-			name: "scenario_w9ml_plugin_actor_ulid_round_trip",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// Post-w9ml: plugin actors carry a ULID via Actor.ID
-				// (resolved at stamp time via IdentityRegistry.IDByName).
-				// This scenario asserts a publishd plugin-actor event
-				// round-trips through JS hot tier with the ULID intact —
-				// i.e., publisher serializes ULID bytes into the proto
-				// envelope, subscriber/reader reconstructs them, and the
-				// resulting eventbus.Event.Actor preserves both Kind and ID.
-				pluginULID := plugintest.PluginULIDFromName("core-scenes")
-				pluginEv := mintAt(subject, baseNow.Add(-30*time.Minute), "plugin")
-				pluginEv.Actor = eventbus.Actor{
-					Kind: eventbus.ActorKindPlugin,
-					ID:   pluginULID,
-				}
-				publishAll(ctx, t, pub, []eventbus.Event{pluginEv})
-				bus.AwaitStreamLastSeq(t, currentStreamLastSeq(t, bus)+0, 5*time.Second)
-
-				r := buildReader(bus, pool, streamMaxAge, baseNow)
-				stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   subject,
-					NotBefore: baseNow.Add(-1 * time.Hour),
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.NoError(t, err)
-				t.Cleanup(func() { _ = stream.Close() })
-
-				got := drainStream(t, stream)
-				require.Len(t, got, 1)
-				assert.Equal(t, pluginEv.ID, got[0].ID)
-				assert.Equal(t, eventbus.ActorKindPlugin, got[0].Actor.Kind,
-					"plugin Actor.Kind MUST round-trip through hot tier")
-				assert.Equal(t, pluginULID, got[0].Actor.ID,
-					"plugin Actor.ID (ULID) MUST round-trip byte-equal through hot tier")
-			},
-		},
-		{
-			name: "scenario12_plugin_owned_subject_routes_to_plugin",
-			run: func(t *testing.T, ctx context.Context, subject eventbus.Subject) {
-				// For plugin-owned subjects the Reader MUST NOT fall back
-				// to host tiers. Without a router wired, we expect the
-				// explicit EVENTBUS_PLUGIN_HISTORY_NOT_WIRED error. This
-				// is the documented F4 ship state; wiring a real router
-				// is exercised by the plugin_audit_isolation_test.
-				owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
-					{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
-				})
-				require.NoError(t, err)
-				r := buildReader(bus, pool, streamMaxAge, baseNow, history.WithOwners(owners))
-				pluginSubject := eventbus.Subject("events.main.scene.01ABC.ic")
-				_, qerr := r.QueryHistory(ctx, eventbus.HistoryQuery{
-					Subject:   pluginSubject,
-					Direction: eventbus.DirectionForward,
-					PageSize:  10,
-				})
-				require.Error(t, qerr)
-				assert.Contains(t, qerr.Error(), "plugin-owned subject requires PluginHistoryRouter")
-			},
-		},
-	}
-
-	for i, sc := range scenarios {
-		sc := sc
-		t.Run(sc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-			defer cancel()
-			// Per-subtest subject so state doesn't leak between scenarios.
-			subject := eventbus.Subject(subjectForScenario(i))
-			sc.run(t, ctx, subject)
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: baseNow.Add(-3 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  50,
 		})
-	}
-}
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(len(hot)))
+		Expect(got[0].ID).To(Equal(hot[0].ID))
+		Expect(got[1].ID).To(Equal(hot[1].ID))
+	})
+
+	It("scenario2: cursor older than retention serves from cold tier", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(2))
+
+		// All events aged — projected directly to events_audit.
+		cold := []eventbus.Event{
+			mintAt(subject, edge.Add(-10*24*time.Hour), "a"),
+			mintAt(subject, edge.Add(-5*24*time.Hour), "b"),
+		}
+		insertAuditRows(ctx, suiteT, bus, pub, pool, cold)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(-20 * 24 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  50,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(len(cold)))
+		Expect(got[0].ID).To(Equal(cold[0].ID))
+		Expect(got[1].ID).To(Equal(cold[1].ID))
+	})
+
+	It("scenario3: cursor at boundary edge routes to JS per ties-go-hot", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(3))
+
+		// Event exactly at edge — routes to JS per "ties go hot".
+		atEdge := mintAt(subject, edge, "edge")
+		publishAll(ctx, suiteT, pub, []eventbus.Event{atEdge})
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge,
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(1))
+		Expect(got[0].ID).To(Equal(atEdge.ID))
+	})
+
+	It("scenario4: page boundary crosses tiers returning all events in order", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(4))
+
+		cold := []eventbus.Event{
+			mintAt(subject, edge.Add(-3*time.Hour), "c1"),
+			mintAt(subject, edge.Add(-2*time.Hour), "c2"),
+		}
+		hot := []eventbus.Event{
+			mintAt(subject, edge.Add(time.Hour), "h1"),
+			mintAt(subject, edge.Add(2*time.Hour), "h2"),
+		}
+		insertAuditRows(ctx, suiteT, bus, pub, pool, cold)
+		publishAll(ctx, suiteT, pub, hot)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(-5 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(4), "all 4 across both tiers")
+		for i := 1; i < len(got); i++ {
+			Expect(got[i-1].ID.Compare(got[i].ID)).To(BeNumerically("<", 0),
+				"expected strictly ascending ULID at position %d", i)
+		}
+	})
+
+	It("scenario5: clock skew within safety margin is absorbed by ULID dedup", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(5))
+
+		// Place an event at edge-5s: within safetyMargin window. It
+		// lives in JS; we also INSERT it in PG to represent the
+		// "lagging projection" overlap. Dedup must suppress the dup.
+		dup := mintAt(subject, edge.Add(-5*time.Second), "overlap")
+		seqBefore := currentStreamLastSeq(suiteT, bus)
+		publishAll(ctx, suiteT, pub, []eventbus.Event{dup})
+		bus.AwaitStreamLastSeq(suiteT, seqBefore+1, 5*time.Second)
+		dupSeq := currentStreamLastSeq(suiteT, bus)
+		// Insert into cold with the SAME JS seq so seenSeqs dedup
+		// recognises the overlap event as already delivered.
+		insertAuditRowWithSeq(ctx, suiteT, pool, dup, dupSeq)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(-24 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(1), "ULID dedup must suppress the duplicate")
+		Expect(got[0].ID).To(Equal(dup.ID))
+	})
+
+	It("scenario6: forward direction returns events oldest to newest", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(6))
+
+		cold := []eventbus.Event{
+			mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
+			mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
+		}
+		hot := []eventbus.Event{
+			mintAt(subject, edge.Add(time.Hour), "h1"),
+			mintAt(subject, edge.Add(10*time.Hour), "h2"),
+		}
+		insertAuditRows(ctx, suiteT, bus, pub, pool, cold)
+		publishAll(ctx, suiteT, pub, hot)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(-100 * 24 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(4))
+		// Oldest -> newest.
+		Expect(got[0].ID).To(Equal(cold[0].ID))
+		Expect(got[3].ID).To(Equal(hot[1].ID))
+	})
+
+	It("scenario7: backward direction returns events newest to oldest", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(7))
+
+		cold := []eventbus.Event{
+			mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
+			mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
+		}
+		hot := []eventbus.Event{
+			mintAt(subject, edge.Add(time.Hour), "h1"),
+			mintAt(subject, edge.Add(10*time.Hour), "h2"),
+		}
+		insertAuditRows(ctx, suiteT, bus, pub, pool, cold)
+		publishAll(ctx, suiteT, pub, hot)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotAfter:  baseNow,
+			Direction: eventbus.DirectionBackward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(4))
+		// Newest -> oldest.
+		Expect(got[0].ID).To(Equal(hot[1].ID))
+		Expect(got[3].ID).To(Equal(cold[0].ID))
+	})
+
+	It("scenario8: empty PG with hot-tier events returns hot events", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(8))
+
+		hot := []eventbus.Event{
+			mintAt(subject, edge.Add(time.Hour), "h1"),
+			mintAt(subject, edge.Add(2*time.Hour), "h2"),
+		}
+		publishAll(ctx, suiteT, pub, hot)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(30 * time.Minute),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(2))
+	})
+
+	It("scenario9: empty JS with cold-tier events returns cold events", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(9))
+
+		cold := []eventbus.Event{
+			mintAt(subject, edge.Add(-10*24*time.Hour), "c1"),
+			mintAt(subject, edge.Add(-5*24*time.Hour), "c2"),
+		}
+		insertAuditRows(ctx, suiteT, bus, pub, pool, cold)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: edge.Add(-30 * 24 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(2))
+	})
+
+	It("scenario10: both tiers empty yields EOF immediately", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(10))
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		_, nerr := stream.Next(ctx)
+		Expect(errors.Is(nerr, io.EOF)).To(BeTrue())
+	})
+
+	It("scenario11: nonexistent subject returns no events", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(11))
+
+		// Seed events on a DIFFERENT subject; query for ours.
+		other := eventbus.Subject("events.main.elsewhere.zzz")
+		publishAll(ctx, suiteT, pub, []eventbus.Event{mintAt(other, edge.Add(time.Hour), "x")})
+		insertAuditRows(ctx, suiteT, bus, pub, pool, []eventbus.Event{mintAt(other, edge.Add(-time.Hour), "y")})
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		_, nerr := stream.Next(ctx)
+		Expect(errors.Is(nerr, io.EOF)).To(BeTrue())
+	})
+
+	It("scenario_w9ml: plugin actor ULID round-trips through hot tier byte-equal", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+		subject := eventbus.Subject(subjectForScenario(12))
+
+		// Post-w9ml: plugin actors carry a ULID via Actor.ID
+		// (resolved at stamp time via IdentityRegistry.IDByName).
+		// This scenario asserts a published plugin-actor event
+		// round-trips through JS hot tier with the ULID intact —
+		// i.e., publisher serializes ULID bytes into the proto
+		// envelope, subscriber/reader reconstructs them, and the
+		// resulting eventbus.Event.Actor preserves both Kind and ID.
+		pluginULID := plugintest.PluginULIDFromName("core-scenes")
+		pluginEv := mintAt(subject, baseNow.Add(-30*time.Minute), "plugin")
+		pluginEv.Actor = eventbus.Actor{
+			Kind: eventbus.ActorKindPlugin,
+			ID:   pluginULID,
+		}
+		publishAll(ctx, suiteT, pub, []eventbus.Event{pluginEv})
+		bus.AwaitStreamLastSeq(suiteT, currentStreamLastSeq(suiteT, bus)+0, 5*time.Second)
+
+		r := buildReader(bus, pool, streamMaxAge, baseNow)
+		stream, err := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   subject,
+			NotBefore: baseNow.Add(-1 * time.Hour),
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		got := drainStream(suiteT, stream)
+		Expect(got).To(HaveLen(1))
+		Expect(got[0].ID).To(Equal(pluginEv.ID))
+		Expect(got[0].Actor.Kind).To(Equal(eventbus.ActorKindPlugin),
+			"plugin Actor.Kind MUST round-trip through hot tier")
+		Expect(got[0].Actor.ID).To(Equal(pluginULID),
+			"plugin Actor.ID (ULID) MUST round-trip byte-equal through hot tier")
+	})
+
+	It("scenario12: plugin-owned subject returns EVENTBUS_PLUGIN_HISTORY_NOT_WIRED error", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
+
+		// For plugin-owned subjects the Reader MUST NOT fall back
+		// to host tiers. Without a router wired, we expect the
+		// explicit EVENTBUS_PLUGIN_HISTORY_NOT_WIRED error. This
+		// is the documented F4 ship state; wiring a real router
+		// is exercised by the plugin_audit_isolation_test.
+		owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
+			{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		r := buildReader(bus, pool, streamMaxAge, baseNow, history.WithOwners(owners))
+		pluginSubject := eventbus.Subject("events.main.scene.01ABC.ic")
+		_, qerr := r.QueryHistory(ctx, eventbus.HistoryQuery{
+			Subject:   pluginSubject,
+			Direction: eventbus.DirectionForward,
+			PageSize:  10,
+		})
+		Expect(qerr).To(HaveOccurred())
+		Expect(qerr.Error()).To(ContainSubstring("plugin-owned subject requires PluginHistoryRouter"))
+	})
+})
 
 // subjectForScenario produces a unique subject per scenario index. Kept
 // out-of-band so scenarios are identified by their deterministic slot.
@@ -473,7 +492,9 @@ func mintAt(subject eventbus.Subject, ts time.Time, body string) eventbus.Event 
 func publishAll(ctx context.Context, t *testing.T, pub eventbus.Publisher, events []eventbus.Event) {
 	t.Helper()
 	for _, e := range events {
-		require.NoError(t, pub.Publish(ctx, e))
+		if err := pub.Publish(ctx, e); err != nil {
+			t.Fatalf("publishAll: %v", err)
+		}
 	}
 }
 
@@ -495,7 +516,9 @@ func insertAuditRows(ctx context.Context, t *testing.T, bus *eventbustest.Embedd
 	t.Helper()
 	for _, e := range events {
 		seqBefore := currentStreamLastSeq(t, bus)
-		require.NoError(t, pub.Publish(ctx, e))
+		if err := pub.Publish(ctx, e); err != nil {
+			t.Fatalf("insertAuditRows publish: %v", err)
+		}
 		bus.AwaitStreamLastSeq(t, seqBefore+1, 5*time.Second)
 		seq := currentStreamLastSeq(t, bus)
 		insertAuditRowWithSeq(ctx, t, pool, e, seq)
@@ -527,8 +550,10 @@ func insertAuditRowWithSeq(ctx context.Context, t *testing.T, pool *pgxpool.Pool
 		},
 		Payload: e.Payload,
 	})
-	require.NoError(t, err)
-	_, err = pool.Exec(
+	if err != nil {
+		t.Fatalf("insertAuditRowWithSeq marshal: %v", err)
+	}
+	_, qerr := pool.Exec(
 		ctx, `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
@@ -547,7 +572,9 @@ func insertAuditRowWithSeq(ctx context.Context, t *testing.T, pool *pgxpool.Pool
 		int64(seq), //nolint:gosec // G115: seq is always a positive JetStream sequence; fits safely in int64
 		[]byte(`{}`),
 	)
-	require.NoError(t, err)
+	if qerr != nil {
+		t.Fatalf("insertAuditRowWithSeq exec: %v", qerr)
+	}
 }
 
 // actorKindToProto maps the eventbus.ActorKind enum to its proto twin.
@@ -579,7 +606,9 @@ func drainStream(t *testing.T, stream eventbus.HistoryStream) []eventbus.Event {
 		if errors.Is(err, io.EOF) {
 			return out
 		}
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("drainStream: %v", err)
+		}
 		out = append(out, e)
 	}
 }
@@ -589,7 +618,7 @@ func drainStream(t *testing.T, stream eventbus.HistoryStream) []eventbus.Event {
 // "no offset known yet").
 func currentStreamLastSeq(t *testing.T, bus *eventbustest.Embedded) uint64 {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	s, err := bus.JS.Stream(ctx, eventbus.StreamName)
 	if err != nil {

--- a/test/integration/eventbus_e2e/cross_tier_query_test.go
+++ b/test/integration/eventbus_e2e/cross_tier_query_test.go
@@ -63,8 +63,8 @@ var _ = Describe("Cross-tier query end-to-end", func() {
 		// A single bus + pool serve all specs to keep setup cost down.
 		// Each spec picks a distinct subject so there's no cross-talk on
 		// events_audit or on the EVENTS stream.
-		bus = eventbustest.New(suiteT)
-		pool = freshPool(suiteT)
+		bus = freshBus()
+		pool = freshPool()
 
 		streamMaxAge = 30 * 24 * time.Hour // matches production default
 		safety := time.Hour

--- a/test/integration/eventbus_e2e/cross_tier_query_test.go
+++ b/test/integration/eventbus_e2e/cross_tier_query_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/eventbus/history"
 	"github.com/holomush/holomush/internal/plugin/plugintest"
+	"github.com/holomush/holomush/pkg/errutil"
 	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
 )
 
@@ -444,7 +445,7 @@ var _ = Describe("Cross-tier query end-to-end", func() {
 			PageSize:  10,
 		})
 		Expect(qerr).To(HaveOccurred())
-		Expect(qerr.Error()).To(ContainSubstring("plugin-owned subject requires PluginHistoryRouter"))
+		errutil.AssertErrorCode(suiteT, qerr, "EVENTBUS_PLUGIN_HISTORY_NOT_WIRED")
 	})
 })
 

--- a/test/integration/eventbus_e2e/cursor_concurrent_suite_test.go
+++ b/test/integration/eventbus_e2e/cursor_concurrent_suite_test.go
@@ -15,17 +15,15 @@ import (
 // suiteT captures the testing.T from the Ginkgo bootstrap so spec bodies can
 // invoke local helpers (freshPool, drainStream, currentStreamLastSeq,
 // buildReader) which take *testing.T. Mirrors the world_suite_test.go pattern.
-//
-// Other test files in this package use plain testing.T directly; they don't
-// run through the Ginkgo entry point and ignore suiteT. Filed as
-// holomush-suos.2 to convert the rest of the directory.
 var suiteT *testing.T
 
-// TestCursorConcurrentSpecs is the Ginkgo entry point for the
-// cursor_concurrent_test.go specs. Other Test* functions in this package
-// run independently of this entry point.
-func TestCursorConcurrentSpecs(t *testing.T) {
+// TestEventbusE2E is the Ginkgo entry point for the entire eventbus_e2e
+// package. Renamed from TestCursorConcurrentSpecs when holomush-cz4s
+// landed the rest of the directory's conversions; the variable suiteT
+// (set on line below) is still required by cursor_concurrent_test.go's
+// helpers which take *testing.T.
+func TestEventbusE2E(t *testing.T) {
 	suiteT = t
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cursor Concurrent Pagination Specs")
+	RunSpecs(t, "EventbusE2E Suite")
 }

--- a/test/integration/eventbus_e2e/cursor_concurrent_test.go
+++ b/test/integration/eventbus_e2e/cursor_concurrent_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Cursor concurrent pagination specs reproduce the exact scenario the
@@ -93,8 +92,8 @@ var _ = Describe("Cursor pagination under concurrent publishers with drifted ULI
 
 	Context("backward direction (newest → oldest)", func() {
 		It("returns exactly totalEvents in strictly decreasing seq order with no duplicates", func() {
-			bus := eventbustest.New(suiteT)
-			pool := freshPool(suiteT)
+			bus := freshBus()
+			pool := freshPool()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			DeferCleanup(cancel)
@@ -162,8 +161,8 @@ var _ = Describe("Cursor pagination under concurrent publishers with drifted ULI
 
 	Context("forward direction (oldest → newest)", func() {
 		It("returns exactly totalEvents in strictly increasing seq order with no duplicates", func() {
-			bus := eventbustest.New(suiteT)
-			pool := freshPool(suiteT)
+			bus := freshBus()
+			pool := freshPool()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			DeferCleanup(cancel)

--- a/test/integration/eventbus_e2e/dispatcher_selector_identity_test.go
+++ b/test/integration/eventbus_e2e/dispatcher_selector_identity_test.go
@@ -8,14 +8,14 @@ package eventbus_e2e_test
 import (
 	"context"
 	"reflect"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/history"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // fakeKeySelectorForIdentityTest is a no-op selector — the test only
@@ -30,39 +30,39 @@ func (fakeKeySelectorForIdentityTest) SelectForDecrypt(_ context.Context, _ code
 	return codec.NoKey, nil
 }
 
-// TestDispatcherAndHotTierShareSelector — INV-P7-9. Mirrors the
+// Dispatcher and hot tier share selector specs — INV-P7-9. Mirrors the
 // production wiring path at cmd/holomush/core.go:488 +
 // cmd/holomush/sub_grpc.go::newHistoryReader: a single
 // codec.KeySelector instance is constructed once at boot and threaded
 // into both PluginConsumerManager (via WithKeySelector) and
 // history.Reader (via WithCodecSelector). E.3 (1r0v.5) lands the
-// production wiring; this test guards the contract.
-func TestDispatcherAndHotTierShareSelector(t *testing.T) {
-	t.Parallel()
+// production wiring; this spec guards the contract.
+var _ = Describe("Dispatcher and hot tier share selector (INV-P7-9)", func() {
+	It("PluginConsumerManager and history.Reader hold the same KeySelector instance", func() {
+		// The single shared selector instance — INV-P7-9 requires both
+		// substrates to hold this exact pointer. Pointer (not value) so
+		// reflect.ValueOf(iface).Pointer() returns the address at line 68
+		// rather than panicking on a struct-kind interface value.
+		selector := &fakeKeySelectorForIdentityTest{}
 
-	// The single shared selector instance — INV-P7-9 requires both
-	// substrates to hold this exact pointer. Pointer (not value) so
-	// reflect.ValueOf(iface).Pointer() returns the address at line 68
-	// rather than panicking on a struct-kind interface value.
-	selector := &fakeKeySelectorForIdentityTest{}
+		// Mirror cmd/holomush/core.go:488 — Phase 7 production threads the
+		// shared selector into the consumer manager via WithKeySelector.
+		pcm := audit.NewPluginConsumerManager(nil, /* js — not exercised here */
+			audit.WithKeySelector(selector))
 
-	// Mirror cmd/holomush/core.go:488 — Phase 7 production threads the
-	// shared selector into the consumer manager via WithKeySelector.
-	pcm := audit.NewPluginConsumerManager(nil, /* js — not exercised here */
-		audit.WithKeySelector(selector))
+		// Mirror cmd/holomush/sub_grpc.go's history.NewReader call — both
+		// halves get the same selector instance.
+		reader := history.NewReader(nil, nil, time.Hour, time.Now,
+			history.WithCodecSelector(selector))
 
-	// Mirror cmd/holomush/sub_grpc.go's history.NewReader call — both
-	// halves get the same selector instance.
-	reader := history.NewReader(nil, nil, time.Hour, time.Now,
-		history.WithCodecSelector(selector))
+		pcmSel := pcm.KeySelectorForTest()
+		readerSel := reader.KeySelectorForTest()
 
-	pcmSel := pcm.KeySelectorForTest()
-	readerSel := reader.KeySelectorForTest()
-
-	require.NotNil(t, readerSel,
-		"history.Reader MUST hold the shared selector (substrate already wired)")
-	assert.NotNil(t, pcmSel,
-		"INV-P7-9: PluginConsumerManager MUST hold the shared selector — wiring lands in Task E.3 (1r0v.5)")
-	assert.True(t, pcmSel != nil && reflect.ValueOf(pcmSel).Pointer() == reflect.ValueOf(readerSel).Pointer(),
-		"INV-P7-9: PluginConsumerManager and history.Reader MUST share the same KeySelector instance")
-}
+		Expect(readerSel).NotTo(BeNil(),
+			"history.Reader MUST hold the shared selector (substrate already wired)")
+		Expect(pcmSel).NotTo(BeNil(),
+			"INV-P7-9: PluginConsumerManager MUST hold the shared selector — wiring lands in Task E.3 (1r0v.5)")
+		Expect(pcmSel != nil && reflect.ValueOf(pcmSel).Pointer() == reflect.ValueOf(readerSel).Pointer()).To(BeTrue(),
+			"INV-P7-9: PluginConsumerManager and history.Reader MUST share the same KeySelector instance")
+	})
+})

--- a/test/integration/eventbus_e2e/js_storage_corruption_test.go
+++ b/test/integration/eventbus_e2e/js_storage_corruption_test.go
@@ -7,18 +7,18 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestJSStorageCorruptionRebuildFromPGAuditPreservesULIDs covers spec §8
-// "Embedded JS storage corruption -> Rebuild from PG audit; ULIDs stable".
+// JS storage corruption specs — covers spec §8 "Embedded JS storage
+// corruption -> Rebuild from PG audit; ULIDs stable".
 //
 // Preserved ULIDs is the load-bearing invariant: the PG audit row id MUST
 // equal the original publish ULID, so a rebuild that republishes via the
@@ -34,40 +34,42 @@ import (
 //  4. TODO: asserts the new JS stream has the same N ULIDs in the same order.
 //
 // Follow-up: holomush-6nds — JS storage rebuild from PG audit.
-func TestJSStorageCorruptionRebuildFromPGAuditPreservesULIDs(t *testing.T) {
-	t.Skip("TODO(holomush-6nds): JS storage rebuild tool not yet implemented — skeleton retained for the follow-up bead")
+var _ = Describe("JS storage corruption rebuild from PG audit preserves ULIDs", func() {
+	It("rebuild from PG audit preserves original ULIDs in same order", func() {
+		Skip("TODO(holomush-6nds): JS storage rebuild tool not yet implemented — skeleton retained for the follow-up bead")
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
 
-	pub := bus.Bus.Publisher()
-	const count = 10
-	originalIDs := make([][]byte, 0, count)
-	for i := 0; i < count; i++ {
-		evt := mintEvent(eventbus.Subject("events.main.jsrebuild.s1"), "scene.pose", `{"n":`+itoa(i)+`}`)
-		require.NoError(t, pub.Publish(ctx, evt))
-		originalIDs = append(originalIDs, evt.ID.Bytes())
-	}
-	hostSub.AwaitDrained(t, 10*time.Second)
+		pub := bus.Bus.Publisher()
+		const count = 10
+		originalIDs := make([][]byte, 0, count)
+		for i := 0; i < count; i++ {
+			evt := mintEvent(eventbus.Subject("events.main.jsrebuild.s1"), "scene.pose", `{"n":`+itoa(i)+`}`)
+			Expect(pub.Publish(ctx, evt)).To(Succeed())
+			originalIDs = append(originalIDs, evt.ID.Bytes())
+		}
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
 
-	// Purge the EVENTS stream to simulate JS storage loss.
-	stream, err := bus.JS.Stream(ctx, eventbus.StreamName)
-	require.NoError(t, err)
-	require.NoError(t, stream.Purge(ctx))
+		// Purge the EVENTS stream to simulate JS storage loss.
+		stream, err := bus.JS.Stream(ctx, eventbus.StreamName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stream.Purge(ctx)).To(Succeed())
 
-	// TODO(holomush-6nds): invoke rebuild tool, e.g.:
-	//   require.NoError(t, rebuild.FromPGAudit(ctx, pool, bus.Bus.Publisher()))
-	//
-	// After rebuild:
-	//   Assertion: stream.Info LastSeq == count
-	//   Assertion: every original ULID is present (via audit OR via a drain)
+		// TODO(holomush-6nds): invoke rebuild tool, e.g.:
+		//   Expect(rebuild.FromPGAudit(ctx, pool, bus.Bus.Publisher())).To(Succeed())
+		//
+		// After rebuild:
+		//   Assertion: stream.Info LastSeq == count
+		//   Assertion: every original ULID is present (via audit OR via a drain)
 
-	_ = originalIDs
-}
+		_ = originalIDs
+	})
+})

--- a/test/integration/eventbus_e2e/js_storage_corruption_test.go
+++ b/test/integration/eventbus_e2e/js_storage_corruption_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // JS storage corruption specs — covers spec §8 "Embedded JS storage
@@ -41,8 +40,8 @@ var _ = Describe("JS storage corruption rebuild from PG audit preserves ULIDs", 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
 		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
 		Expect(hostSub.Start(ctx)).To(Succeed())

--- a/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
+++ b/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
@@ -7,23 +7,23 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestMultiProtocolFanoutTelnetAndWebSeeSamePose covers spec §8 "Multi-
-// protocol fan-out -> Telnet + web in same scene see same pose".
+// Multi-protocol fan-out specs — covers spec §8 "Multi-protocol fan-out ->
+// Telnet + web in same scene see same pose".
 //
 // The assertion shape is: two distinct protocol adapters subscribed to
 // the same scene subject both receive the same pose event with the same
 // ULID and stream seq. The JetStream invariant (all subscribers of a
 // subject get the same seq in the same order) already backstops this;
-// the test exists to verify the full protocol-translation layer does not
+// the spec exists to verify the full protocol-translation layer does not
 // introduce dedup bugs on the way out.
 //
 // The Go test harness does not currently stand up the telnet adapter +
@@ -32,45 +32,47 @@ import (
 // adapters"; the real adapters will replace these in the follow-up bead.
 //
 // Follow-up: holomush-nko7 — multi-protocol fan-out e2e harness.
-func TestMultiProtocolFanoutTelnetAndWebSeeSamePose(t *testing.T) {
-	t.Skip("TODO(holomush-nko7): telnet + web adapter harness not reachable from Go test — skeleton retained for the follow-up bead")
+var _ = Describe("Multi-protocol fan-out telnet and web see same pose", func() {
+	It("telnet and web in same scene see same pose event", func() {
+		Skip("TODO(holomush-nko7): telnet + web adapter harness not reachable from Go test — skeleton retained for the follow-up bead")
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pub := bus.Bus.Publisher()
-	subSvc := bus.Bus.Subscriber()
+		bus := eventbustest.New(suiteT)
+		pub := bus.Bus.Publisher()
+		subSvc := bus.Bus.Subscriber()
 
-	subject := eventbus.Subject("events.main.scene.01ABC.ic")
+		subject := eventbus.Subject("events.main.scene.01ABC.ic")
 
-	// Two subscribers on the same subject simulate two protocol adapters.
-	testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-	s1, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = s1.Close() })
-	s2, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = s2.Close() })
+		// Two subscribers on the same subject simulate two protocol adapters.
+		testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
+		s1, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = s1.Close() })
+		s2, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = s2.Close() })
 
-	evt := mintEvent(subject, "scene.pose", `{"action":"bows"}`)
-	require.NoError(t, pub.Publish(ctx, evt))
+		evt := mintEvent(subject, "scene.pose", `{"action":"bows"}`)
+		Expect(pub.Publish(ctx, evt)).To(Succeed())
 
-	// Both must observe the identical ULID.
-	d1ctx, c1 := context.WithTimeout(ctx, 5*time.Second)
-	d1, err := s1.Next(d1ctx)
-	c1()
-	require.NoError(t, err)
-	d2ctx, c2 := context.WithTimeout(ctx, 5*time.Second)
-	d2, err := s2.Next(d2ctx)
-	c2()
-	require.NoError(t, err)
-	require.Equal(t, evt.ID, d1.Event().ID)
-	require.Equal(t, evt.ID, d2.Event().ID)
+		// Both must observe the identical ULID.
+		d1ctx, c1 := context.WithTimeout(ctx, 5*time.Second)
+		d1, err := s1.Next(d1ctx)
+		c1()
+		Expect(err).NotTo(HaveOccurred())
+		d2ctx, c2 := context.WithTimeout(ctx, 5*time.Second)
+		d2, err := s2.Next(d2ctx)
+		c2()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(d1.Event().ID).To(Equal(evt.ID))
+		Expect(d2.Event().ID).To(Equal(evt.ID))
 
-	// TODO(holomush-nko7): replace s1/s2 with real telnet + web adapters
-	// and assert the pose flows through the protocol translation correctly
-	// (e.g., telnet sees rendered text, web sees the JSON envelope).
-	require.NoError(t, d1.Ack())
-	require.NoError(t, d2.Ack())
-}
+		// TODO(holomush-nko7): replace s1/s2 with real telnet + web adapters
+		// and assert the pose flows through the protocol translation correctly
+		// (e.g., telnet sees rendered text, web sees the JSON envelope).
+		Expect(d1.Ack()).To(Succeed())
+		Expect(d2.Ack()).To(Succeed())
+	})
+})

--- a/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
+++ b/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Multi-protocol fan-out specs — covers spec §8 "Multi-protocol fan-out ->
@@ -39,7 +38,7 @@ var _ = Describe("Multi-protocol fan-out telnet and web see same pose", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
+		bus := freshBus()
 		pub := bus.Bus.Publisher()
 		subSvc := bus.Bus.Subscriber()
 

--- a/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
@@ -7,13 +7,12 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
@@ -23,137 +22,139 @@ import (
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
-// TestPluginAuditIsolation exercises spec §8 "Plugin audit isolation":
+// Plugin audit isolation specs — exercises spec §8 "Plugin audit isolation":
 //
 //   - Plugin-owned subjects (events.*.scene.>) MUST NOT appear in the host
 //     events_audit table.
 //   - They MUST flow through the per-plugin consumer into the plugin's
 //     audit schema (plugin_core_scenes.scene_log).
 //
-// The test stands up the real host projection (via audit.NewSubsystem)
+// The spec stands up the real host projection (via audit.NewSubsystem)
 // wired to an OwnerMap that routes scene subjects to a fake plugin audit
 // client. That client persists into plugin_core_scenes.scene_log using
 // the same schema the real plugin ships (plugins/core-scenes/migrations/
 // 000004_create_scene_log.up.sql).
-func TestPluginAuditIsolation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+var _ = Describe("Plugin audit isolation", func() {
+	It("routes plugin-owned subjects to plugin schema and not host events_audit", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	// Create the plugin's audit schema + scene_log table by hand. In
-	// production the schema provisioner runs the plugin's migrations; for
-	// this test we inline the DDL so there's no dependency on the plugin
-	// loader.
-	ensurePluginSchema(ctx, t, pool, "plugin_core_scenes", `
-		CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
-			id          BYTEA PRIMARY KEY,
-			subject     TEXT NOT NULL,
-			type        TEXT NOT NULL,
-			timestamp   TIMESTAMPTZ NOT NULL,
-			actor_kind  TEXT NOT NULL,
-			actor_id    BYTEA,
-			payload     BYTEA NOT NULL,
-			schema_ver  SMALLINT NOT NULL,
-			codec       TEXT NOT NULL,
-			js_seq      BIGINT,
-			dek_ref     BIGINT,
-			dek_version INTEGER,
-			inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
-		);
-	`)
+		// Create the plugin's audit schema + scene_log table by hand. In
+		// production the schema provisioner runs the plugin's migrations; for
+		// this test we inline the DDL so there's no dependency on the plugin
+		// loader.
+		ensurePluginSchema(ctx, suiteT, pool, "plugin_core_scenes", `
+			CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
+				id          BYTEA PRIMARY KEY,
+				subject     TEXT NOT NULL,
+				type        TEXT NOT NULL,
+				timestamp   TIMESTAMPTZ NOT NULL,
+				actor_kind  TEXT NOT NULL,
+				actor_id    BYTEA,
+				payload     BYTEA NOT NULL,
+				schema_ver  SMALLINT NOT NULL,
+				codec       TEXT NOT NULL,
+				js_seq      BIGINT,
+				inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			);
+		`)
 
-	// Build the ownership map — scene subjects belong to core-scenes.
-	owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
-		{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		// Build the ownership map — scene subjects belong to core-scenes.
+		owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
+			{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Host projection: ack-and-skips plugin-owned subjects.
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
+			Owners: owners,
+		})
+
+		// Per-plugin manager: routes events.*.scene.> into our fake client.
+		pluginMgr := audit.NewPluginConsumerManager(bus.JS)
+		client := &pgSceneLogClient{pool: pool}
+		Expect(pluginMgr.Add(ctx, audit.PluginConsumerConfig{
+			PluginName: "core-scenes",
+			Subjects:   []string{"events.*.scene.>"},
+			Client:     client,
+		})).To(Succeed())
+
+		// Wire the manager into the host subsystem so Start/Stop are a unit.
+		hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
+			return owners, pluginMgr
+		})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
+
+		rawPub := bus.Bus.Publisher()
+		Expect(rawPub).NotTo(BeNil())
+
+		// RenderingPublisher stamps the App-Rendering header required by the
+		// audit projection (events_audit.rendering NOT NULL after migration 000012).
+		// location_state is registered as a builtin, so the lookup succeeds.
+		registry, err := core.BootstrapVerbRegistry("test")
+		Expect(err).NotTo(HaveOccurred())
+		hostPub := eventbus.NewRenderingPublisher(rawPub, registry)
+
+		// Publish 3 scene (plugin-owned) events and 2 host-owned events.
+		// Scene events use the raw publisher — the OwnerMap routes them to the
+		// plugin consumer (ack-and-skip in host projection, no persist() call).
+		// Host events use the wrapped publisher so App-Rendering is stamped.
+		sceneEvents := []eventbus.Event{
+			mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":1}`),
+			mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":2}`),
+			mintEvent("events.main.scene.01DEF.ic", "scene.pose", `{"n":3}`),
+		}
+		hostEvents := []eventbus.Event{
+			// Use location_state (underscore) — the canonical builtin type registered
+			// in BootstrapVerbRegistry, valid per typeRe (no separator needed).
+			mintEvent("events.main.loc.01HOST.out", "location_state", `{"h":1}`),
+			mintEvent("events.main.loc.01HOST.out", "location_state", `{"h":2}`),
+		}
+		for _, e := range sceneEvents {
+			Expect(rawPub.Publish(ctx, e)).To(Succeed())
+		}
+		for _, e := range hostEvents {
+			Expect(hostPub.Publish(ctx, e)).To(Succeed())
+		}
+
+		// Wait for the host projection to drain (host rows + ack-skipped
+		// plugin rows both advance its cursor). Plugin consumer drains in
+		// parallel; we separately poll scene_log to assert arrival.
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
+		Eventually(func() bool {
+			return countRows(pool, "plugin_core_scenes.scene_log", "") == len(sceneEvents)
+		}, 10*time.Second, 20*time.Millisecond).Should(BeTrue(),
+			"plugin scene_log did not see all plugin-owned events")
+
+		// Host audit table MUST NOT contain plugin-owned rows.
+		Expect(countRows(pool, "events_audit", "subject LIKE 'events.main.scene.%'")).To(BeZero(),
+			"events_audit must be empty for plugin-owned subjects")
+
+		// Host audit table MUST contain the host-owned rows.
+		Expect(countRows(pool, "events_audit", "subject LIKE 'events.main.loc.%'")).To(Equal(len(hostEvents)),
+			"events_audit must hold host-owned rows")
+
+		// Plugin scene_log MUST contain exactly the plugin-owned rows.
+		Expect(countRows(pool, "plugin_core_scenes.scene_log", "")).To(Equal(len(sceneEvents)),
+			"plugin scene_log must hold exactly the plugin-owned rows")
 	})
-	require.NoError(t, err)
-
-	// Host projection: ack-and-skips plugin-owned subjects.
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
-		Owners: owners,
-	})
-
-	// Per-plugin manager: routes events.*.scene.> into our fake client.
-	pluginMgr := audit.NewPluginConsumerManager(bus.JS)
-	client := &pgSceneLogClient{pool: pool}
-	require.NoError(t, pluginMgr.Add(ctx, audit.PluginConsumerConfig{
-		PluginName: "core-scenes",
-		Subjects:   []string{"events.*.scene.>"},
-		Client:     client,
-	}))
-
-	// Wire the manager into the host subsystem so Start/Stop are a unit.
-	hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
-		return owners, pluginMgr
-	})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
-
-	rawPub := bus.Bus.Publisher()
-	require.NotNil(t, rawPub)
-
-	// RenderingPublisher stamps the App-Rendering header required by the
-	// audit projection (events_audit.rendering NOT NULL after migration 000012).
-	// location_state is registered as a builtin, so the lookup succeeds.
-	registry, err := core.BootstrapVerbRegistry("test")
-	require.NoError(t, err)
-	hostPub := eventbus.NewRenderingPublisher(rawPub, registry)
-
-	// Publish 3 scene (plugin-owned) events and 2 host-owned events.
-	// Scene events use the raw publisher — the OwnerMap routes them to the
-	// plugin consumer (ack-and-skip in host projection, no persist() call).
-	// Host events use the wrapped publisher so App-Rendering is stamped.
-	sceneEvents := []eventbus.Event{
-		mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":1}`),
-		mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":2}`),
-		mintEvent("events.main.scene.01DEF.ic", "scene.pose", `{"n":3}`),
-	}
-	hostEvents := []eventbus.Event{
-		// Use location_state (underscore) — the canonical builtin type registered
-		// in BootstrapVerbRegistry, valid per typeRe (no separator needed).
-		mintEvent("events.main.loc.01HOST.out", "location_state", `{"h":1}`),
-		mintEvent("events.main.loc.01HOST.out", "location_state", `{"h":2}`),
-	}
-	for _, e := range sceneEvents {
-		require.NoError(t, rawPub.Publish(ctx, e))
-	}
-	for _, e := range hostEvents {
-		require.NoError(t, hostPub.Publish(ctx, e))
-	}
-
-	// Wait for the host projection to drain (host rows + ack-skipped
-	// plugin rows both advance its cursor). Plugin consumer drains in
-	// parallel; we separately poll scene_log to assert arrival.
-	hostSub.AwaitDrained(t, 10*time.Second)
-	require.Eventually(t, func() bool {
-		return countRows(t, pool, "plugin_core_scenes.scene_log", "") == len(sceneEvents)
-	}, 10*time.Second, 20*time.Millisecond, "plugin scene_log did not see all plugin-owned events")
-
-	// Host audit table MUST NOT contain plugin-owned rows.
-	assert.Equal(t, 0, countRows(t, pool, "events_audit", "subject LIKE 'events.main.scene.%'"),
-		"events_audit must be empty for plugin-owned subjects")
-
-	// Host audit table MUST contain the host-owned rows.
-	assert.Equal(t, len(hostEvents), countRows(t, pool, "events_audit", "subject LIKE 'events.main.loc.%'"),
-		"events_audit must hold host-owned rows")
-
-	// Plugin scene_log MUST contain exactly the plugin-owned rows.
-	assert.Equal(t, len(sceneEvents), countRows(t, pool, "plugin_core_scenes.scene_log", ""),
-		"plugin scene_log must hold exactly the plugin-owned rows")
-}
+})
 
 // countRows counts rows in `table` with optional WHERE clause (pass "" for none).
-func countRows(t *testing.T, pool *pgxpool.Pool, table, where string) int {
-	t.Helper()
+func countRows(pool *pgxpool.Pool, table, where string) int {
 	q := "SELECT count(*) FROM " + table
 	if where != "" {
 		q += " WHERE " + where
 	}
 	var n int
-	err := pool.QueryRow(t.Context(), q).Scan(&n)
-	require.NoError(t, err)
+	err := pool.QueryRow(context.Background(), q).Scan(&n)
+	if err != nil {
+		panic("countRows: " + err.Error())
+	}
 	return n
 }
 
@@ -175,10 +176,6 @@ type pgSceneLogClient struct {
 }
 
 func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEventRequest) (*pluginv1.AuditEventResponse, error) {
-	// Phase 7 (INV-P7-1, INV-P7-3): the host dispatcher's buildAuditRow
-	// populates Row.{Codec,SchemaVer,DekRef,DekVersion} from the JS
-	// headers; the test stub mirrors the real plugin Insert by carrying
-	// those fields verbatim into the plugin's scene_log table.
 	row := req.GetRow()
 	if row == nil {
 		return nil, errPluginEnvelope("nil row")
@@ -188,47 +185,33 @@ func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 	if a := row.GetActor(); a != nil && len(a.GetId()) == 16 {
 		actorID = a.GetId()
 	}
-	schemaVer := int16(1)
-	if v := row.GetSchemaVer(); v > 0 && v <= 32767 {
-		schemaVer = int16(v) //nolint:gosec // bounded above by the >0 && <=32767 guard
-	}
 	codecName := row.GetCodec()
 	if codecName == "" {
 		codecName = "identity"
 	}
-	var dekRef *int64
-	if row.DekRef != nil {
-		v := int64(*row.DekRef) //nolint:gosec // dek_ref column is BIGINT (signed) — uint64→int64 widening matches column shape
-		dekRef = &v
-	}
-	var dekVersion *int32
-	if row.DekVersion != nil {
-		v := int32(*row.DekVersion) //nolint:gosec // dek_version column is INTEGER (signed) — uint32→int32 matches column shape
-		dekVersion = &v
+	schemaVer := int16(row.GetSchemaVer())
+	if schemaVer == 0 {
+		schemaVer = 1
 	}
 	_, err := c.pool.Exec(
 		ctx, `
 		INSERT INTO plugin_core_scenes.scene_log (
 			id, subject, type, timestamp, actor_kind, actor_id,
-			payload, schema_ver, codec, js_seq, dek_ref, dek_version
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			payload, schema_ver, codec, js_seq
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		ON CONFLICT (id) DO NOTHING`,
 		row.GetId(),
 		row.GetSubject(),
 		row.GetType(),
 		ts,
-		actorKindString(row.GetActor()),
+		actorKindStringFromRow(row.GetActor()),
 		actorID,
 		row.GetPayload(),
 		schemaVer,
 		codecName,
-		// Plugin dispatch path does not carry the JS seq explicitly; the
-		// plugin can use it for its own ordering by spying on headers in
-		// a future proto revision. For this test, 0 is acceptable
+		// Plugin dispatch path does not carry the JS seq; 0 is acceptable
 		// (scene_log.js_seq is nullable).
 		int64(0),
-		dekRef,
-		dekVersion,
 	)
 	if err != nil {
 		//nolint:wrapcheck // test dispatcher — surface raw DB error
@@ -237,7 +220,7 @@ func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 	return &pluginv1.AuditEventResponse{}, nil
 }
 
-func actorKindString(a *eventbusv1.Actor) string {
+func actorKindStringFromRow(a *eventbusv1.Actor) string {
 	if a == nil {
 		return "system"
 	}

--- a/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
@@ -39,8 +38,8 @@ var _ = Describe("Plugin audit isolation", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
 		// Create the plugin's audit schema + scene_log table by hand. In
 		// production the schema provisioner runs the plugin's migrations; for
@@ -58,6 +57,8 @@ var _ = Describe("Plugin audit isolation", func() {
 				schema_ver  SMALLINT NOT NULL,
 				codec       TEXT NOT NULL,
 				js_seq      BIGINT,
+				dek_ref     BIGINT,
+				dek_version INTEGER,
 				inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
 			);
 		`)

--- a/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
@@ -127,35 +127,35 @@ var _ = Describe("Plugin audit isolation", func() {
 		// parallel; we separately poll scene_log to assert arrival.
 		hostSub.AwaitDrained(suiteT, 10*time.Second)
 		Eventually(func() bool {
-			return countRows(pool, "plugin_core_scenes.scene_log", "") == len(sceneEvents)
+			return countRows(ctx, pool, "plugin_core_scenes.scene_log", "") == len(sceneEvents)
 		}, 10*time.Second, 20*time.Millisecond).Should(BeTrue(),
 			"plugin scene_log did not see all plugin-owned events")
 
 		// Host audit table MUST NOT contain plugin-owned rows.
-		Expect(countRows(pool, "events_audit", "subject LIKE 'events.main.scene.%'")).To(BeZero(),
+		Expect(countRows(ctx, pool, "events_audit", "subject LIKE 'events.main.scene.%'")).To(BeZero(),
 			"events_audit must be empty for plugin-owned subjects")
 
 		// Host audit table MUST contain the host-owned rows.
-		Expect(countRows(pool, "events_audit", "subject LIKE 'events.main.loc.%'")).To(Equal(len(hostEvents)),
+		Expect(countRows(ctx, pool, "events_audit", "subject LIKE 'events.main.loc.%'")).To(Equal(len(hostEvents)),
 			"events_audit must hold host-owned rows")
 
 		// Plugin scene_log MUST contain exactly the plugin-owned rows.
-		Expect(countRows(pool, "plugin_core_scenes.scene_log", "")).To(Equal(len(sceneEvents)),
+		Expect(countRows(ctx, pool, "plugin_core_scenes.scene_log", "")).To(Equal(len(sceneEvents)),
 			"plugin scene_log must hold exactly the plugin-owned rows")
 	})
 })
 
 // countRows counts rows in `table` with optional WHERE clause (pass "" for none).
-func countRows(pool *pgxpool.Pool, table, where string) int {
+// Takes the spec's context so the query respects the It's deadline (vs the
+// previous context.Background() which sidestepped the spec timeout) and uses a
+// Gomega assertion instead of panic so failures surface as proper spec failures.
+func countRows(ctx context.Context, pool *pgxpool.Pool, table, where string) int {
 	q := "SELECT count(*) FROM " + table
 	if where != "" {
 		q += " WHERE " + where
 	}
 	var n int
-	err := pool.QueryRow(context.Background(), q).Scan(&n)
-	if err != nil {
-		panic("countRows: " + err.Error())
-	}
+	Expect(pool.QueryRow(ctx, q).Scan(&n)).To(Succeed())
 	return n
 }
 

--- a/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_isolation_test.go
@@ -176,6 +176,10 @@ type pgSceneLogClient struct {
 }
 
 func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEventRequest) (*pluginv1.AuditEventResponse, error) {
+	// Phase 7 (INV-P7-1, INV-P7-3): the host dispatcher's buildAuditRow
+	// populates Row.{Codec,SchemaVer,DekRef,DekVersion} from the JS
+	// headers; the test stub mirrors the real plugin Insert by carrying
+	// those fields verbatim into the plugin's scene_log table.
 	row := req.GetRow()
 	if row == nil {
 		return nil, errPluginEnvelope("nil row")
@@ -185,20 +189,30 @@ func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 	if a := row.GetActor(); a != nil && len(a.GetId()) == 16 {
 		actorID = a.GetId()
 	}
+	schemaVer := int16(1)
+	if v := row.GetSchemaVer(); v > 0 && v <= 32767 {
+		schemaVer = int16(v) //nolint:gosec // bounded above by the >0 && <=32767 guard
+	}
 	codecName := row.GetCodec()
 	if codecName == "" {
 		codecName = "identity"
 	}
-	schemaVer := int16(row.GetSchemaVer())
-	if schemaVer == 0 {
-		schemaVer = 1
+	var dekRef *int64
+	if row.DekRef != nil {
+		v := int64(*row.DekRef) //nolint:gosec // dek_ref column is BIGINT (signed) — uint64→int64 widening matches column shape
+		dekRef = &v
+	}
+	var dekVersion *int32
+	if row.DekVersion != nil {
+		v := int32(*row.DekVersion) //nolint:gosec // dek_version column is INTEGER (signed) — uint32→int32 matches column shape
+		dekVersion = &v
 	}
 	_, err := c.pool.Exec(
 		ctx, `
 		INSERT INTO plugin_core_scenes.scene_log (
 			id, subject, type, timestamp, actor_kind, actor_id,
-			payload, schema_ver, codec, js_seq
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			payload, schema_ver, codec, js_seq, dek_ref, dek_version
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (id) DO NOTHING`,
 		row.GetId(),
 		row.GetSubject(),
@@ -209,9 +223,13 @@ func (c *pgSceneLogClient) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 		row.GetPayload(),
 		schemaVer,
 		codecName,
-		// Plugin dispatch path does not carry the JS seq; 0 is acceptable
+		// Plugin dispatch path does not carry the JS seq explicitly; the
+		// plugin can use it for its own ordering by spying on headers in
+		// a future proto revision. For this test, 0 is acceptable
 		// (scene_log.js_seq is nullable).
 		int64(0),
+		dekRef,
+		dekVersion,
 	)
 	if err != nil {
 		//nolint:wrapcheck // test dispatcher — surface raw DB error

--- a/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
@@ -47,8 +47,8 @@ var _ = Describe("Scene log preserves ciphertext and audit headers (INV-P7-6, IN
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		pool := freshPool(suiteT)
-		bus := testutil.StartEmbeddedJetStream(suiteT)
+		pool := freshPool()
+		bus := freshBus()
 
 		// scene_log schema. Matches plugins/core-scenes/migrations/000004 +
 		// 000005 (Phase 7 dek_ref + dek_version).

--- a/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
@@ -7,6 +7,7 @@ package eventbus_e2e_test
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -72,7 +73,18 @@ var _ = Describe("Scene log preserves ciphertext and audit headers (INV-P7-6, IN
 
 		// KEK + DEK manager (mirrors test/integration/crypto/emit_test.go setup).
 		kekHex := testutil.RandomKEKHex(suiteT)
-		suiteT.Setenv("HOLOMUSH_TEST_ROUND_TRIP_KEK", kekHex)
+		// Per-spec env var with restore (NOT suiteT.Setenv — that's suite-scoped
+		// and would leak across specs through the shared *testing.T).
+		const kekEnv = "HOLOMUSH_TEST_ROUND_TRIP_KEK"
+		prevKek, prevKekSet := os.LookupEnv(kekEnv)
+		Expect(os.Setenv(kekEnv, kekHex)).To(Succeed())
+		DeferCleanup(func() {
+			if prevKekSet {
+				_ = os.Setenv(kekEnv, prevKek)
+			} else {
+				_ = os.Unsetenv(kekEnv)
+			}
+		})
 		provider, err := kek.NewLocalAEADProvider(ctx,
 			kek.NewEnvSource("HOLOMUSH_TEST_ROUND_TRIP_KEK", false), pool)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
+++ b/test/integration/eventbus_e2e/plugin_audit_round_trip_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/proto"
 
 	"github.com/holomush/holomush/internal/eventbus"
@@ -33,7 +33,7 @@ func (s *dekBindingStubE2E) Current(_ context.Context, _ string) (string, error)
 	return s.id, nil
 }
 
-// TestSceneLogPreservesCiphertextAndAuditHeaders — INV-P7-6 + INV-P7-12.
+// Scene log ciphertext and audit header round-trip specs — INV-P7-6 + INV-P7-12.
 //
 // Emits one sensitive event under a plugin-owned subject and asserts:
 //
@@ -42,115 +42,117 @@ func (s *dekBindingStubE2E) Current(_ context.Context, _ string) (string, error)
 //     payload (INV-P7-6: plugin storage MUST mirror the bus byte-for-byte).
 //   - The plugin row carries dek_ref + dek_version populated from the
 //     bus headers (INV-P7-3 column shape, INV-P7-1 wire shape).
-func TestSceneLogPreservesCiphertextAndAuditHeaders(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+var _ = Describe("Scene log preserves ciphertext and audit headers (INV-P7-6, INV-P7-12)", func() {
+	It("plugin scene_log row is ciphertext byte-equal to bus envelope payload", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	pool := freshPool(t)
-	bus := testutil.StartEmbeddedJetStream(t)
+		pool := freshPool(suiteT)
+		bus := testutil.StartEmbeddedJetStream(suiteT)
 
-	// scene_log schema. Matches plugins/core-scenes/migrations/000004 +
-	// 000005 (Phase 7 dek_ref + dek_version).
-	ensurePluginSchema(ctx, t, pool, "plugin_core_scenes", `
-		CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
-			id          BYTEA PRIMARY KEY,
-			subject     TEXT NOT NULL,
-			type        TEXT NOT NULL,
-			timestamp   TIMESTAMPTZ NOT NULL,
-			actor_kind  TEXT NOT NULL,
-			actor_id    BYTEA,
-			payload     BYTEA NOT NULL,
-			schema_ver  SMALLINT NOT NULL,
-			codec       TEXT NOT NULL,
-			js_seq      BIGINT,
-			dek_ref     BIGINT,
-			dek_version INTEGER,
-			inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
-		);
-	`)
+		// scene_log schema. Matches plugins/core-scenes/migrations/000004 +
+		// 000005 (Phase 7 dek_ref + dek_version).
+		ensurePluginSchema(ctx, suiteT, pool, "plugin_core_scenes", `
+			CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
+				id          BYTEA PRIMARY KEY,
+				subject     TEXT NOT NULL,
+				type        TEXT NOT NULL,
+				timestamp   TIMESTAMPTZ NOT NULL,
+				actor_kind  TEXT NOT NULL,
+				actor_id    BYTEA,
+				payload     BYTEA NOT NULL,
+				schema_ver  SMALLINT NOT NULL,
+				codec       TEXT NOT NULL,
+				js_seq      BIGINT,
+				dek_ref     BIGINT,
+				dek_version INTEGER,
+				inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			);
+		`)
 
-	// KEK + DEK manager (mirrors test/integration/crypto/emit_test.go setup).
-	kekHex := testutil.RandomKEKHex(t)
-	t.Setenv("HOLOMUSH_TEST_ROUND_TRIP_KEK", kekHex)
-	provider, err := kek.NewLocalAEADProvider(ctx,
-		kek.NewEnvSource("HOLOMUSH_TEST_ROUND_TRIP_KEK", false), pool)
-	require.NoError(t, err)
-	dekMgr, err := dek.NewManager(provider,
-		dek.NewStore(pool),
-		dek.NewCache(dek.CacheConfig{Capacity: 64}),
-		dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64}),
-		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
-		&dekBindingStubE2E{id: "bind-roundtrip"})
-	require.NoError(t, err)
+		// KEK + DEK manager (mirrors test/integration/crypto/emit_test.go setup).
+		kekHex := testutil.RandomKEKHex(suiteT)
+		suiteT.Setenv("HOLOMUSH_TEST_ROUND_TRIP_KEK", kekHex)
+		provider, err := kek.NewLocalAEADProvider(ctx,
+			kek.NewEnvSource("HOLOMUSH_TEST_ROUND_TRIP_KEK", false), pool)
+		Expect(err).NotTo(HaveOccurred())
+		dekMgr, err := dek.NewManager(provider,
+			dek.NewStore(pool),
+			dek.NewCache(dek.CacheConfig{Capacity: 64}),
+			dek.NewParticipantsCache(dek.CacheConfig{Capacity: 64}),
+			func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil },
+			&dekBindingStubE2E{id: "bind-roundtrip"})
+		Expect(err).NotTo(HaveOccurred())
 
-	// Encrypting publisher — Sensitive=true events flow through the DEK
-	// manager and end up encrypted on the bus.
-	encryptingPub := eventbus.NewJetStreamPublisher(
-		bus.JS,
-		eventbus.Config{}.Defaults(),
-		eventbus.WithDEKManager(dekMgr),
-	)
+		// Encrypting publisher — Sensitive=true events flow through the DEK
+		// manager and end up encrypted on the bus.
+		encryptingPub := eventbus.NewJetStreamPublisher(
+			bus.JS,
+			eventbus.Config{}.Defaults(),
+			eventbus.WithDEKManager(dekMgr),
+		)
 
-	// OwnerMap + per-plugin consumer (ack-and-skip in host projection;
-	// scene subjects flow through the per-plugin consumer client).
-	owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
-		{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		// OwnerMap + per-plugin consumer (ack-and-skip in host projection;
+		// scene subjects flow through the per-plugin consumer client).
+		owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
+			{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
+			Owners: owners,
+		})
+		pluginMgr := audit.NewPluginConsumerManager(bus.JS)
+		Expect(pluginMgr.Add(ctx, audit.PluginConsumerConfig{
+			PluginName: "core-scenes",
+			Subjects:   []string{"events.*.scene.>"},
+			Client:     &pgSceneLogClient{pool: pool},
+		})).To(Succeed())
+		hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
+			return owners, pluginMgr
+		})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
+
+		// Publish one sensitive event on a plugin-owned subject.
+		const plaintext = `{"text":"the original plaintext"}`
+		eventID := ulid.Make()
+		subject := eventbus.Subject("events.main.scene.01ABC.ic")
+		Expect(encryptingPub.Publish(ctx, eventbus.Event{
+			ID:        eventID,
+			Subject:   subject,
+			Type:      eventbus.Type("scene.whisper"),
+			Timestamp: time.Now().UTC(),
+			Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
+			Payload:   []byte(plaintext),
+			Sensitive: true,
+		})).To(Succeed())
+
+		// Wait for the plugin's per-plugin consumer to land the row.
+		waitForRowInSceneLog(suiteT, pool, eventID.Bytes(), 10*time.Second)
+
+		// Read back the persisted row.
+		pluginRow := readSceneLogRow(suiteT, pool, eventID.Bytes())
+
+		// INV-P7-12: plugin row payload MUST be ciphertext, not plaintext.
+		Expect(pluginRow.codec).To(Equal("xchacha20poly1305-v1"))
+		Expect(pluginRow.payload).NotTo(Equal([]byte(plaintext)),
+			"INV-P7-12: plugin row MUST hold ciphertext for sensitive events")
+		Expect(pluginRow.payload).NotTo(BeEmpty())
+
+		// INV-P7-3: dek_ref + dek_version present.
+		Expect(pluginRow.dekRef).NotTo(BeNil())
+		Expect(pluginRow.dekVersion).NotTo(BeNil())
+
+		// INV-P7-6: plugin payload byte-equal to the bus envelope payload.
+		busPayload := lookupBusEnvelopePayload(suiteT, bus, eventID)
+		Expect(pluginRow.payload).To(Equal(busPayload),
+			"INV-P7-6: plugin storage MUST be byte-equal to bus envelope payload")
+
+		// Cross-check: bus payload itself MUST be ciphertext (sanity).
+		Expect(busPayload).NotTo(Equal([]byte(plaintext)),
+			"sanity: bus envelope payload MUST be ciphertext for sensitive events")
 	})
-	require.NoError(t, err)
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
-		Owners: owners,
-	})
-	pluginMgr := audit.NewPluginConsumerManager(bus.JS)
-	require.NoError(t, pluginMgr.Add(ctx, audit.PluginConsumerConfig{
-		PluginName: "core-scenes",
-		Subjects:   []string{"events.*.scene.>"},
-		Client:     &pgSceneLogClient{pool: pool},
-	}))
-	hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
-		return owners, pluginMgr
-	})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
-
-	// Publish one sensitive event on a plugin-owned subject.
-	const plaintext = `{"text":"the original plaintext"}`
-	eventID := ulid.Make()
-	subject := eventbus.Subject("events.main.scene.01ABC.ic")
-	require.NoError(t, encryptingPub.Publish(ctx, eventbus.Event{
-		ID:        eventID,
-		Subject:   subject,
-		Type:      eventbus.Type("scene.whisper"),
-		Timestamp: time.Now().UTC(),
-		Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-		Payload:   []byte(plaintext),
-		Sensitive: true,
-	}))
-
-	// Wait for the plugin's per-plugin consumer to land the row.
-	waitForRowInSceneLog(t, pool, eventID.Bytes(), 10*time.Second)
-
-	// Read back the persisted row.
-	pluginRow := readSceneLogRow(t, pool, eventID.Bytes())
-
-	// INV-P7-12: plugin row payload MUST be ciphertext, not plaintext.
-	assert.Equal(t, "xchacha20poly1305-v1", pluginRow.codec)
-	assert.NotEqual(t, []byte(plaintext), pluginRow.payload,
-		"INV-P7-12: plugin row MUST hold ciphertext for sensitive events")
-	assert.NotEmpty(t, pluginRow.payload)
-
-	// INV-P7-3: dek_ref + dek_version present.
-	require.NotNil(t, pluginRow.dekRef)
-	require.NotNil(t, pluginRow.dekVersion)
-
-	// INV-P7-6: plugin payload byte-equal to the bus envelope payload.
-	busPayload := lookupBusEnvelopePayload(t, bus, eventID)
-	assert.Equal(t, busPayload, pluginRow.payload,
-		"INV-P7-6: plugin storage MUST be byte-equal to bus envelope payload")
-
-	// Cross-check: bus payload itself MUST be ciphertext (sanity).
-	assert.NotEqual(t, []byte(plaintext), busPayload,
-		"sanity: bus envelope payload MUST be ciphertext for sensitive events")
-}
+})
 
 // readSceneLogRow scans the post-Phase-7 scene_log columns for a single id.
 type roundTripRow struct {
@@ -163,10 +165,12 @@ type roundTripRow struct {
 func readSceneLogRow(t *testing.T, pool *pgxpool.Pool, eventID []byte) roundTripRow {
 	t.Helper()
 	var r roundTripRow
-	require.NoError(t, pool.QueryRow(t.Context(), `
+	if err := pool.QueryRow(t.Context(), `
 		SELECT codec, payload, dek_ref, dek_version
 		FROM plugin_core_scenes.scene_log
-		WHERE id = $1`, eventID).Scan(&r.codec, &r.payload, &r.dekRef, &r.dekVersion))
+		WHERE id = $1`, eventID).Scan(&r.codec, &r.payload, &r.dekRef, &r.dekVersion); err != nil {
+		t.Fatalf("readSceneLogRow: %v", err)
+	}
 	return r
 }
 
@@ -184,12 +188,19 @@ func lookupBusEnvelopePayload(t *testing.T, bus *testutil.EmbeddedBus, eventID u
 			continue
 		}
 		var env eventbusv1.Event
-		require.NoError(t, proto.Unmarshal(msg.Data(), &env))
+		if err := proto.Unmarshal(msg.Data(), &env); err != nil {
+			t.Fatalf("lookupBusEnvelopePayload unmarshal: %v", err)
+		}
 		// Sanity: assert the headers carry the crypto fields too.
-		require.NotEmpty(t, msg.Headers().Get(eventbus.HeaderDekRef))
-		require.NotEmpty(t, msg.Headers().Get(eventbus.HeaderDekVersion))
-		_, err := strconv.ParseInt(msg.Headers().Get(eventbus.HeaderDekRef), 10, 64)
-		require.NoError(t, err)
+		if msg.Headers().Get(eventbus.HeaderDekRef) == "" {
+			t.Fatalf("bus envelope missing HeaderDekRef")
+		}
+		if msg.Headers().Get(eventbus.HeaderDekVersion) == "" {
+			t.Fatalf("bus envelope missing HeaderDekVersion")
+		}
+		if _, err := strconv.ParseInt(msg.Headers().Get(eventbus.HeaderDekRef), 10, 64); err != nil {
+			t.Fatalf("lookupBusEnvelopePayload ParseInt: %v", err)
+		}
 		return env.GetPayload()
 	}
 	t.Fatalf("timed out waiting for bus envelope for event %s", idStr)

--- a/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
+++ b/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
@@ -9,11 +9,10 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
@@ -21,95 +20,94 @@ import (
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
-// TestPluginCrashResilienceDoesNotDuplicate exercises spec §8 "Plugin
-// process crash mid-deliver -> Restart drains; PK ON CONFLICT prevents
-// dups". A plugin audit client is scripted to panic on its first
-// AuditEvent call, then succeed on subsequent calls. The per-plugin
-// JetStream consumer MUST redeliver after AckWait expires; the plugin's
-// idempotent INSERT (ON CONFLICT DO NOTHING on the id PK) MUST then
-// absorb the redelivered message without producing a duplicate row.
+// Plugin crash resilience specs — exercises spec §8 "Plugin process crash
+// mid-deliver -> Restart drains; PK ON CONFLICT prevents dups". A plugin
+// audit client is scripted to return an error on its first AuditEvent call,
+// then succeed on subsequent calls. The per-plugin JetStream consumer MUST
+// redeliver after AckWait expires; the plugin's idempotent INSERT (ON CONFLICT
+// DO NOTHING on the id PK) MUST then absorb the redelivered message without
+// producing a duplicate row.
 //
-// This uses a fake PluginAuditClient that simulates a crash via panic
+// This uses a fake PluginAuditClient that simulates a crash via error return
 // rather than actually killing a plugin subprocess — that's what the
-// ack/redelivery contract tests, and what the plugin's PK asserts it
-// handles.
-func TestPluginCrashResilienceDoesNotDuplicate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+// ack/redelivery contract tests, and what the plugin's PK asserts it handles.
+var _ = Describe("Plugin crash resilience", func() {
+	It("does not duplicate rows under redelivery after a failed first dispatch", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	// scene_log schema. Matches plugins/core-scenes/migrations/000004 +
-	// 000005 (Phase 7: dek_ref + dek_version per INV-P7-3).
-	ensurePluginSchema(ctx, t, pool, "plugin_core_scenes", `
-		CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
-			id          BYTEA PRIMARY KEY,
-			subject     TEXT NOT NULL,
-			type        TEXT NOT NULL,
-			timestamp   TIMESTAMPTZ NOT NULL,
-			actor_kind  TEXT NOT NULL,
-			actor_id    BYTEA,
-			payload     BYTEA NOT NULL,
-			schema_ver  SMALLINT NOT NULL,
-			codec       TEXT NOT NULL,
-			js_seq      BIGINT,
-			dek_ref     BIGINT,
-			dek_version INTEGER,
-			inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
-		);
-	`)
+		// scene_log schema. Matches plugins/core-scenes/migrations/000004.
+		ensurePluginSchema(ctx, suiteT, pool, "plugin_core_scenes", `
+			CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
+				id          BYTEA PRIMARY KEY,
+				subject     TEXT NOT NULL,
+				type        TEXT NOT NULL,
+				timestamp   TIMESTAMPTZ NOT NULL,
+				actor_kind  TEXT NOT NULL,
+				actor_id    BYTEA,
+				payload     BYTEA NOT NULL,
+				schema_ver  SMALLINT NOT NULL,
+				codec       TEXT NOT NULL,
+				js_seq      BIGINT,
+				inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			);
+		`)
 
-	owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
-		{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		owners, err := audit.NewOwnerMap([]audit.SubjectOwner{
+			{PluginName: "core-scenes", Pattern: "events.*.scene.>"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The failFirstClient returns an error on the first N calls so the
+		// JetStream consumer is forced to redeliver. After that it delegates
+		// to the real INSERT client.
+		inner := &pgSceneLogClient{pool: pool}
+		unstable := &failFirstClient{inner: inner, failN: 1}
+
+		pluginMgr := audit.NewPluginConsumerManager(bus.JS)
+		Expect(pluginMgr.Add(ctx, audit.PluginConsumerConfig{
+			PluginName:    "core-scenes",
+			Subjects:      []string{"events.*.scene.>"},
+			Client:        unstable,
+			AckWait:       100 * time.Millisecond, // aggressive so redelivery fires fast
+			MaxAckPending: 32,
+			MaxDeliver:    5, // plenty of room to redeliver a couple of times
+		})).To(Succeed())
+
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
+			Owners: owners,
+		})
+		hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
+			return owners, pluginMgr
+		})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
+
+		// Publish one plugin-owned event.
+		pub := bus.Bus.Publisher()
+		evt := mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":1}`)
+		Expect(pub.Publish(ctx, evt)).To(Succeed())
+
+		// Wait until scene_log has the row (implies redelivery succeeded).
+		Eventually(func() bool {
+			return countRows(pool, "plugin_core_scenes.scene_log",
+				"id = '\\x"+bytesToHex(evt.ID.Bytes())+"'") == 1
+		}, 5*time.Second, 20*time.Millisecond).Should(BeTrue(),
+			"plugin must persist the redelivered event exactly once")
+
+		// There must be exactly one row even though the first dispatch failed.
+		Expect(countRows(pool, "plugin_core_scenes.scene_log", "")).To(Equal(1),
+			"ON CONFLICT DO NOTHING must prevent duplicate rows under redelivery")
+
+		// And the client saw at least 2 calls (initial failure + successful
+		// redelivery).
+		Expect(unstable.calls()).To(BeNumerically(">=", int32(2)),
+			"expected at least one failing call plus a successful retry")
 	})
-	require.NoError(t, err)
-
-	// The failFirstClient returns an error on the first N calls so the
-	// JetStream consumer is forced to redeliver. After that it delegates
-	// to the real INSERT client.
-	inner := &pgSceneLogClient{pool: pool}
-	unstable := &failFirstClient{inner: inner, failN: 1}
-
-	pluginMgr := audit.NewPluginConsumerManager(bus.JS)
-	require.NoError(t, pluginMgr.Add(ctx, audit.PluginConsumerConfig{
-		PluginName:    "core-scenes",
-		Subjects:      []string{"events.*.scene.>"},
-		Client:        unstable,
-		AckWait:       100 * time.Millisecond, // aggressive so redelivery fires fast
-		MaxAckPending: 32,
-		MaxDeliver:    5, // plenty of room to redeliver a couple of times
-	}))
-
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{
-		Owners: owners,
-	})
-	hostSub.SetLateInitProvider(func() (*audit.OwnerMap, *audit.PluginConsumerManager) {
-		return owners, pluginMgr
-	})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
-
-	// Publish one plugin-owned event.
-	pub := bus.Bus.Publisher()
-	evt := mintEvent("events.main.scene.01ABC.ic", "scene.pose", `{"n":1}`)
-	require.NoError(t, pub.Publish(ctx, evt))
-
-	// Wait until scene_log has the row (implies redelivery succeeded).
-	require.Eventually(t, func() bool {
-		return countRows(t, pool, "plugin_core_scenes.scene_log",
-			"id = '\\x"+bytesToHex(evt.ID.Bytes())+"'") == 1
-	}, 5*time.Second, 20*time.Millisecond, "plugin must persist the redelivered event exactly once")
-
-	// There must be exactly one row even though the first dispatch failed.
-	assert.Equal(t, 1, countRows(t, pool, "plugin_core_scenes.scene_log", ""),
-		"ON CONFLICT DO NOTHING must prevent duplicate rows under redelivery")
-
-	// And the client saw at least 2 calls (initial failure + successful
-	// redelivery).
-	assert.GreaterOrEqual(t, unstable.calls(), int32(2),
-		"expected at least one failing call plus a successful retry")
-}
+})
 
 // failFirstClient is a PluginAuditClient that returns an error for its
 // first failN calls, then delegates to inner. Counts attempts so the test

--- a/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
+++ b/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
@@ -95,13 +95,13 @@ var _ = Describe("Plugin crash resilience", func() {
 
 		// Wait until scene_log has the row (implies redelivery succeeded).
 		Eventually(func() bool {
-			return countRows(pool, "plugin_core_scenes.scene_log",
+			return countRows(ctx, pool, "plugin_core_scenes.scene_log",
 				"id = '\\x"+bytesToHex(evt.ID.Bytes())+"'") == 1
 		}, 5*time.Second, 20*time.Millisecond).Should(BeTrue(),
 			"plugin must persist the redelivered event exactly once")
 
 		// There must be exactly one row even though the first dispatch failed.
-		Expect(countRows(pool, "plugin_core_scenes.scene_log", "")).To(Equal(1),
+		Expect(countRows(ctx, pool, "plugin_core_scenes.scene_log", "")).To(Equal(1),
 			"ON CONFLICT DO NOTHING must prevent duplicate rows under redelivery")
 
 		// And the client saw at least 2 calls (initial failure + successful

--- a/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
+++ b/test/integration/eventbus_e2e/plugin_crash_resilience_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
@@ -36,10 +35,11 @@ var _ = Describe("Plugin crash resilience", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
-		// scene_log schema. Matches plugins/core-scenes/migrations/000004.
+		// scene_log schema. Matches plugins/core-scenes/migrations/000004 +
+		// 000005 (Phase 7 dek_ref + dek_version columns).
 		ensurePluginSchema(ctx, suiteT, pool, "plugin_core_scenes", `
 			CREATE TABLE IF NOT EXISTS plugin_core_scenes.scene_log (
 				id          BYTEA PRIMARY KEY,
@@ -52,6 +52,8 @@ var _ = Describe("Plugin crash resilience", func() {
 				schema_ver  SMALLINT NOT NULL,
 				codec       TEXT NOT NULL,
 				js_seq      BIGINT,
+				dek_ref     BIGINT,
+				dek_version INTEGER,
 				inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
 			);
 		`)

--- a/test/integration/eventbus_e2e/plugin_downgrade_attacker_test.go
+++ b/test/integration/eventbus_e2e/plugin_downgrade_attacker_test.go
@@ -14,11 +14,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/eventbus"
@@ -63,31 +62,29 @@ const (
 	downgradeAttackerCachedDekVer = uint32(1)
 )
 
-// newDowngradeAttackerSuite compiles the fixture, spawns it via the real
-// goplugin.Host, and assembles a fence over a real PluginHistoryRouter.
-// Cleanup (host shutdown, binary removal) is registered on t.Cleanup.
-func newDowngradeAttackerSuite(t *testing.T) *downgradeAttackerSuite {
-	t.Helper()
-
-	pluginDir, manifest := buildDowngradeAttackerBinary(t)
+// newDowngradeAttackerSuiteForGinkgo compiles the fixture, spawns it via
+// the real goplugin.Host, and assembles a fence over a real
+// PluginHistoryRouter. Cleanup is registered via DeferCleanup.
+func newDowngradeAttackerSuiteForGinkgo() *downgradeAttackerSuite {
+	pluginDir, manifest := buildDowngradeAttackerBinary(suiteT)
 
 	host := goplugin.NewHost(
 		goplugin.WithIdentityRegistry(plugintest.NewStubRegistry(downgradeAttackerPluginName)),
 	)
-	t.Cleanup(func() {
-		// Use a fresh ctx — t.Context() is cancelled on Cleanup ordering.
+	DeferCleanup(func() {
+		// Use a fresh ctx — context may be cancelled by the time cleanup runs.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = host.Close(ctx)
 	})
 
-	loadCtx, loadCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	loadCtx, loadCancel := context.WithTimeout(suiteT.Context(), 30*time.Second)
 	defer loadCancel()
-	require.NoError(t, host.Load(loadCtx, manifest, pluginDir),
+	Expect(host.Load(loadCtx, manifest, pluginDir)).To(Succeed(),
 		"goplugin host MUST load the test_downgrade_attacker fixture")
 
 	auditCli := host.PluginAuditClient(downgradeAttackerPluginName)
-	require.NotNil(t, auditCli,
+	Expect(auditCli).NotTo(BeNil(),
 		"fixture MUST register PluginAuditService — manifest provides it")
 
 	provider := singletonAuditProvider{
@@ -116,12 +113,11 @@ func newDowngradeAttackerSuite(t *testing.T) *downgradeAttackerSuite {
 	}
 }
 
-// PrimeHonestCache populates the fixture's in-memory row cache via the
+// primeHonestCache populates the fixture's in-memory row cache via the
 // real AuditEvent RPC. The honest QueryHistory branch returns the cached
 // row byte-equal; supplying a non-identity codec + dek_ref simulates an
 // encrypted payload the host would later decrypt.
-func (s *downgradeAttackerSuite) PrimeHonestCache(t *testing.T, payload []byte) {
-	t.Helper()
+func (s *downgradeAttackerSuite) primeHonestCache(payload []byte) {
 	dekRef := downgradeAttackerCachedDekRef
 	dekVer := downgradeAttackerCachedDekVer
 	row := &pluginauditpb.AuditRow{
@@ -135,32 +131,31 @@ func (s *downgradeAttackerSuite) PrimeHonestCache(t *testing.T, payload []byte) 
 		DekVersion: &dekVer,
 		SchemaVer:  1,
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(suiteT.Context(), 5*time.Second)
 	defer cancel()
 	_, err := s.auditCli.AuditEvent(ctx, &pluginauditpb.AuditEventRequest{Row: row})
-	require.NoError(t, err, "AuditEvent RPC MUST succeed against the fixture")
+	Expect(err).NotTo(HaveOccurred(), "AuditEvent RPC MUST succeed against the fixture")
 }
 
-// QueryFenced runs subject through the PluginDowngradeFence and drains
+// queryFenced runs subject through the PluginDowngradeFence and drains
 // the resulting stream. Returns the events the fence delivered.
-func (s *downgradeAttackerSuite) QueryFenced(t *testing.T, subject string) []eventbus.Event {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+func (s *downgradeAttackerSuite) queryFenced(subject string) []eventbus.Event {
+	ctx, cancel := context.WithTimeout(suiteT.Context(), 10*time.Second)
 	defer cancel()
 
 	stream, err := s.fence.QueryHistory(ctx, s.pluginName, eventbus.HistoryQuery{
 		Subject:  eventbus.Subject(subject),
 		PageSize: 10,
 	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = stream.Close() })
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { _ = stream.Close() })
 
 	var out []eventbus.Event
 	for {
 		ev, nextErr := stream.Next(ctx)
 		if nextErr != nil {
-			// io.EOF terminates cleanly; any other error fails the test.
-			require.True(t, errors.Is(nextErr, io.EOF), "stream MUST end with EOF, got %v", nextErr)
+			// io.EOF terminates cleanly; any other error fails the spec.
+			Expect(errors.Is(nextErr, io.EOF)).To(BeTrue(), "stream MUST end with EOF, got %v", nextErr)
 			break
 		}
 		out = append(out, ev)
@@ -168,69 +163,61 @@ func (s *downgradeAttackerSuite) QueryFenced(t *testing.T, subject string) []eve
 	return out
 }
 
-// TestDowngradeAttackerHonestPathDelivers — INV-P7-10 honest path.
-// Honest mode replays the AuditEvent-cached row byte-equal. The fence
-// passes it through (codec=xchacha20poly1305-v1, dek_ref present, fake
-// CryptoKeysLookup reports Exists=true). The caller observes the row's
-// payload verbatim — host-side decryption is exercised by the existing
-// crypto round-trip tests; this test pins the wire-level pass-through.
-func TestDowngradeAttackerHonestPathDelivers(t *testing.T) {
-	suite := newDowngradeAttackerSuite(t)
+// Downgrade attacker specs — INV-P7-10. Covers both the honest path and the
+// malicious path of the PluginDowngradeFence via a real binary fixture.
+var _ = Describe("Downgrade attacker malicious path refuses (INV-P7-10)", func() {
+	It("fence refuses malicious downgrade row with metadata_only and violation signal", func() {
+		suite := newDowngradeAttackerSuiteForGinkgo()
 
-	cachedPayload := []byte("ciphertext-bytes-from-publisher")
-	suite.PrimeHonestCache(t, cachedPayload)
+		// No primeHonestCache — malicious branch fabricates its own row.
+		events := suite.queryFenced(downgradeMaliciousSubject)
+		Expect(events).To(HaveLen(1), "malicious mode MUST yield exactly one fabricated row")
 
-	events := suite.QueryFenced(t, downgradeHonestSubject)
-	require.Len(t, events, 1, "honest mode MUST replay exactly one cached row")
+		got := events[0]
+		Expect(got.MetadataOnly).To(BeTrue(),
+			"INV-P7-10: malicious downgrade row MUST surface as metadata_only=true")
+		Expect(got.NoPlaintextReason).To(Equal(eventbus.NoPlaintextReasonDowngradeRefused),
+			"INV-P7-10: refusal reason MUST be DowngradeRefused")
+		Expect(got.Payload).To(BeEmpty(),
+			"INV-P7-10: refused row MUST NOT leak plaintext payload")
 
-	got := events[0]
-	assert.False(t, got.MetadataOnly,
-		"INV-P7-10 honest path: row MUST NOT be marked metadata_only")
-	assert.Equal(t, eventbus.NoPlaintextReasonUnspecified, got.NoPlaintextReason,
-		"INV-P7-10 honest path: NoPlaintextReason MUST be unset for clean rows")
-	assert.Equal(t, cachedPayload, got.Payload,
-		"INV-P7-10 honest path: fence MUST pass payload through byte-equal")
+		violations := suite.emitter.snapshot()
+		Expect(violations).To(HaveLen(1),
+			"INV-P7-10: violation emitter MUST fire exactly once for the refused row")
+		Expect(violations[0].pluginName).To(Equal(downgradeAttackerPluginName))
+		Expect(violations[0].rowType).To(Equal(downgradeAttackerSensitive))
+		Expect(violations[0].refusalCode).To(Equal("AUDIT_ROW_DOWNGRADE_DETECTED"))
+	})
+})
 
-	row := eventbus.AuditRowOf(got)
-	require.NotNil(t, row, "router MUST stamp the source-of-truth AuditRow")
-	assert.Equal(t, downgradeAttackerCachedCodec, row.GetCodec())
-	require.NotNil(t, row.DekRef)
-	assert.Equal(t, downgradeAttackerCachedDekRef, *row.DekRef)
+var _ = Describe("Downgrade attacker honest path delivers", func() {
+	It("fence passes honest encrypted row through byte-equal with no violation signal", func() {
+		suite := newDowngradeAttackerSuiteForGinkgo()
 
-	require.Empty(t, suite.emitter.snapshot(),
-		"INV-P7-10 honest path: violation emitter MUST NOT fire")
-}
+		cachedPayload := []byte("ciphertext-bytes-from-publisher")
+		suite.primeHonestCache(cachedPayload)
 
-// TestDowngradeAttackerMaliciousPathRefuses — INV-P7-10 attack path.
-// Malicious mode fabricates a row with codec=identity + cleartext payload
-// for an always-sensitive type. The fence MUST refuse per-row
-// (metadata_only=true, NoPlaintextReason=DowngradeRefused, Payload=nil)
-// AND emit a plugin_integrity_violation audit with refusal_code=
-// AUDIT_ROW_DOWNGRADE_DETECTED. Refusal is per-row, NOT stream-fatal —
-// a malicious plugin that puts a downgrade row first MUST NOT DoS
-// subsequent honest rows on the same stream (Task C.3.3 rule 3).
-func TestDowngradeAttackerMaliciousPathRefuses(t *testing.T) {
-	suite := newDowngradeAttackerSuite(t)
+		events := suite.queryFenced(downgradeHonestSubject)
+		Expect(events).To(HaveLen(1), "honest mode MUST replay exactly one cached row")
 
-	// No PrimeHonestCache — malicious branch fabricates its own row.
-	events := suite.QueryFenced(t, downgradeMaliciousSubject)
-	require.Len(t, events, 1, "malicious mode MUST yield exactly one fabricated row")
+		got := events[0]
+		Expect(got.MetadataOnly).To(BeFalse(),
+			"INV-P7-10 honest path: row MUST NOT be marked metadata_only")
+		Expect(got.NoPlaintextReason).To(Equal(eventbus.NoPlaintextReasonUnspecified),
+			"INV-P7-10 honest path: NoPlaintextReason MUST be unset for clean rows")
+		Expect(got.Payload).To(Equal(cachedPayload),
+			"INV-P7-10 honest path: fence MUST pass payload through byte-equal")
 
-	got := events[0]
-	assert.True(t, got.MetadataOnly,
-		"INV-P7-10: malicious downgrade row MUST surface as metadata_only=true")
-	assert.Equal(t, eventbus.NoPlaintextReasonDowngradeRefused, got.NoPlaintextReason,
-		"INV-P7-10: refusal reason MUST be DowngradeRefused")
-	assert.Empty(t, got.Payload,
-		"INV-P7-10: refused row MUST NOT leak plaintext payload")
+		row := eventbus.AuditRowOf(got)
+		Expect(row).NotTo(BeNil(), "router MUST stamp the source-of-truth AuditRow")
+		Expect(row.GetCodec()).To(Equal(downgradeAttackerCachedCodec))
+		Expect(row.DekRef).NotTo(BeNil())
+		Expect(*row.DekRef).To(Equal(downgradeAttackerCachedDekRef))
 
-	violations := suite.emitter.snapshot()
-	require.Len(t, violations, 1,
-		"INV-P7-10: violation emitter MUST fire exactly once for the refused row")
-	assert.Equal(t, downgradeAttackerPluginName, violations[0].pluginName)
-	assert.Equal(t, downgradeAttackerSensitive, violations[0].rowType)
-	assert.Equal(t, "AUDIT_ROW_DOWNGRADE_DETECTED", violations[0].refusalCode)
-}
+		Expect(suite.emitter.snapshot()).To(BeEmpty(),
+			"INV-P7-10 honest path: violation emitter MUST NOT fire")
+	})
+})
 
 // --- Test helpers ---
 
@@ -259,7 +246,7 @@ func (fenceLookupAlwaysFound) Exists(_ context.Context, _ uint64) (bool, error) 
 }
 
 // capturingViolationEmitter records EmitViolation calls so the malicious
-// test can assert the audit signal fired with the expected refusal code.
+// spec can assert the audit signal fired with the expected refusal code.
 type capturingViolationEmitter struct {
 	mu    sync.Mutex
 	calls []capturedViolation
@@ -316,27 +303,40 @@ func alwaysSensitiveFromManifest(m *plugins.Manifest) map[string]struct{} {
 //	<tempdir>/plugin.yaml
 //	<tempdir>/<os>-<arch>/test-downgrade-attacker
 //
-// The compiled binary is removed via t.Cleanup. Returns the plugin
+// The compiled binary is removed via suiteT.Cleanup. Returns the plugin
 // directory and the parsed manifest.
-func buildDowngradeAttackerBinary(t *testing.T) (string, *plugins.Manifest) {
-	t.Helper()
-
+func buildDowngradeAttackerBinary(t interface {
+	Helper()
+	Fatalf(string, ...any)
+	Cleanup(func())
+	TempDir() string
+	Context() context.Context
+},
+) (string, *plugins.Manifest) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
 	src := filepath.Join(repoRoot, "test", "integration", "plugin", "testdata", "test_downgrade_attacker")
 
 	manifestPath := filepath.Join(src, "plugin.yaml")
 	manifestData, err := os.ReadFile(manifestPath) //nolint:gosec // test fixture path under repo root
-	require.NoError(t, err, "fixture manifest MUST exist at %s", manifestPath)
+	if err != nil {
+		t.Fatalf("fixture manifest MUST exist at %s: %v", manifestPath, err)
+	}
 
 	manifest, err := plugins.ParseManifest(manifestData)
-	require.NoError(t, err, "fixture manifest MUST parse")
+	if err != nil {
+		t.Fatalf("fixture manifest MUST parse: %v", err)
+	}
 
 	pluginDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), manifestData, 0o644)) //nolint:gosec // test artifact under TempDir
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), manifestData, 0o644); err != nil { //nolint:gosec // test artifact under TempDir
+		t.Fatalf("write plugin.yaml: %v", err)
+	}
 
 	platformDir := filepath.Join(pluginDir, runtime.GOOS+"-"+runtime.GOARCH)
-	require.NoError(t, os.MkdirAll(platformDir, 0o755))
+	if err := os.MkdirAll(platformDir, 0o755); err != nil {
+		t.Fatalf("mkdir platformDir: %v", err)
+	}
 
 	exe := filepath.Join(platformDir, manifest.BinaryPlugin.Executable)
 
@@ -346,7 +346,9 @@ func buildDowngradeAttackerBinary(t *testing.T) (string, *plugins.Manifest) {
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	out, buildErr := cmd.CombinedOutput()
-	require.NoError(t, buildErr, "go build of fixture MUST succeed:\n%s", string(out))
+	if buildErr != nil {
+		t.Fatalf("go build of fixture MUST succeed:\n%s", string(out))
+	}
 
 	t.Cleanup(func() {
 		// pluginDir is a TempDir — Go's testing.TempDir auto-cleans, but

--- a/test/integration/eventbus_e2e/reconnect_resume_test.go
+++ b/test/integration/eventbus_e2e/reconnect_resume_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Reconnect-resume specs — assert the reconnect-resume contract from spec §8:
@@ -31,7 +30,7 @@ var _ = Describe("Reconnect resume", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
+		bus := freshBus()
 		pub := bus.Bus.Publisher()
 		sub := bus.Bus.Subscriber()
 		Expect(pub).NotTo(BeNil())

--- a/test/integration/eventbus_e2e/reconnect_resume_test.go
+++ b/test/integration/eventbus_e2e/reconnect_resume_test.go
@@ -7,17 +7,16 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestReconnectResume asserts the reconnect-resume contract from spec §8:
+// Reconnect-resume specs — assert the reconnect-resume contract from spec §8:
 //
 //   - A subscriber that closes its SessionStream and re-opens with the
 //     same sessionID MUST resume at the last acked seq.
@@ -27,78 +26,80 @@ import (
 //
 // This is the JetStream-era replacement for the legacy per-session cursor
 // lock regression test.
-func TestReconnectResume(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+var _ = Describe("Reconnect resume", func() {
+	It("resumes at last acked seq with no dup and no loss", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pub := bus.Bus.Publisher()
-	sub := bus.Bus.Subscriber()
-	require.NotNil(t, pub)
-	require.NotNil(t, sub)
+		bus := eventbustest.New(suiteT)
+		pub := bus.Bus.Publisher()
+		sub := bus.Bus.Subscriber()
+		Expect(pub).NotTo(BeNil())
+		Expect(sub).NotTo(BeNil())
 
-	subject := eventbus.Subject("events.main.reconnect.s1")
-	sessionID := freshSessionID()
+		subject := eventbus.Subject("events.main.reconnect.s1")
+		sessionID := freshSessionID()
 
-	// Open, consume + ack 3 events.
-	testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-	s1, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
-	require.NoError(t, err)
+		// Open, consume + ack 3 events.
+		testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
+		s1, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
+		Expect(err).NotTo(HaveOccurred())
 
-	const beforeDisconnect = 3
-	for i := 0; i < beforeDisconnect; i++ {
-		require.NoError(t, pub.Publish(ctx, mintEvent(subject, "scene.pose", `{"k":"pre"}`)))
-	}
-
-	for i := 0; i < beforeDisconnect; i++ {
-		d, err := s1.Next(ctx)
-		require.NoError(t, err)
-		// Use sync ack on the last one so the server has confirmed the
-		// ack before we close. Server-confirmed ack prevents the cursor
-		// race that the reconnect contract promises to close.
-		if i == beforeDisconnect-1 {
-			syncCtx, syncCancel := context.WithTimeout(ctx, 2*time.Second)
-			require.NoError(t, eventbus.AckSyncForTest(syncCtx, d))
-			syncCancel()
-		} else {
-			require.NoError(t, d.Ack())
+		const beforeDisconnect = 3
+		for i := 0; i < beforeDisconnect; i++ {
+			Expect(pub.Publish(ctx, mintEvent(subject, "scene.pose", `{"k":"pre"}`))).To(Succeed())
 		}
-	}
-	// Barrier: AckFloor reaches the last published seq. This is the
-	// synchronization primitive the spec's §8 §"Controllable test seams"
-	// calls out — no time.Sleep; read server state.
-	bus.AwaitAckedSeq(t, "session_"+sessionID, beforeDisconnect, 5*time.Second)
 
-	// Disconnect (close local iterator; server-side durable persists).
-	require.NoError(t, s1.Close())
+		for i := 0; i < beforeDisconnect; i++ {
+			d, nerr := s1.Next(ctx)
+			Expect(nerr).NotTo(HaveOccurred())
+			// Use sync ack on the last one so the server has confirmed the
+			// ack before we close. Server-confirmed ack prevents the cursor
+			// race that the reconnect contract promises to close.
+			if i == beforeDisconnect-1 {
+				syncCtx, syncCancel := context.WithTimeout(ctx, 2*time.Second)
+				Expect(eventbus.AckSyncForTest(syncCtx, d)).To(Succeed())
+				syncCancel()
+			} else {
+				Expect(d.Ack()).To(Succeed())
+			}
+		}
+		// Barrier: AckFloor reaches the last published seq. This is the
+		// synchronization primitive the spec's §8 §"Controllable test seams"
+		// calls out — no time.Sleep; read server state.
+		bus.AwaitAckedSeq(suiteT, "session_"+sessionID, beforeDisconnect, 5*time.Second)
 
-	// Publish additional events while disconnected.
-	const whileDisconnected = 2
-	for i := 0; i < whileDisconnected; i++ {
-		require.NoError(t, pub.Publish(ctx, mintEvent(subject, "scene.pose", `{"k":"post"}`)))
-	}
+		// Disconnect (close local iterator; server-side durable persists).
+		Expect(s1.Close()).To(Succeed())
 
-	// Reconnect.
-	s2, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = s2.Close() })
+		// Publish additional events while disconnected.
+		const whileDisconnected = 2
+		for i := 0; i < whileDisconnected; i++ {
+			Expect(pub.Publish(ctx, mintEvent(subject, "scene.pose", `{"k":"post"}`))).To(Succeed())
+		}
 
-	// Must deliver exactly the whileDisconnected events; no dup, no loss.
-	seenIDs := make(map[string]struct{}, whileDisconnected)
-	for i := 0; i < whileDisconnected; i++ {
-		dctx, dcancel := context.WithTimeout(ctx, 5*time.Second)
-		d, err := s2.Next(dctx)
-		dcancel()
-		require.NoError(t, err, "expected %d deliveries after reconnect, got %d", whileDisconnected, i)
-		id := d.Event().ID.String()
-		_, dup := seenIDs[id]
-		assert.False(t, dup, "duplicate delivery on reconnect: %s", id)
-		seenIDs[id] = struct{}{}
-		require.NoError(t, d.Ack())
-	}
-	// Draining more with a short deadline confirms no-loss (by absence).
-	probeCtx, probeCancel := context.WithTimeout(ctx, 300*time.Millisecond)
-	_, probeErr := s2.Next(probeCtx)
-	probeCancel()
-	require.Error(t, probeErr, "no further events expected after draining exactly %d", whileDisconnected)
-}
+		// Reconnect.
+		s2, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = s2.Close() })
+
+		// Must deliver exactly the whileDisconnected events; no dup, no loss.
+		seenIDs := make(map[string]struct{}, whileDisconnected)
+		for i := 0; i < whileDisconnected; i++ {
+			dctx, dcancel := context.WithTimeout(ctx, 5*time.Second)
+			d, nerr := s2.Next(dctx)
+			dcancel()
+			Expect(nerr).NotTo(HaveOccurred(), "expected %d deliveries after reconnect, got %d", whileDisconnected, i)
+			id := d.Event().ID.String()
+			_, dup := seenIDs[id]
+			Expect(dup).To(BeFalse(), "duplicate delivery on reconnect: %s", id)
+			seenIDs[id] = struct{}{}
+			Expect(d.Ack()).To(Succeed())
+		}
+		// Draining more with a short deadline confirms no-loss (by absence).
+		probeCtx, probeCancel := context.WithTimeout(ctx, 300*time.Millisecond)
+		_, probeErr := s2.Next(probeCtx)
+		probeCancel()
+		Expect(probeErr).To(HaveOccurred(), "no further events expected after draining exactly %d", whileDisconnected)
+	})
+})

--- a/test/integration/eventbus_e2e/rendering_completeness_test.go
+++ b/test/integration/eventbus_e2e/rendering_completeness_test.go
@@ -46,12 +46,18 @@ var _ = Describe("Rendering completeness", func() {
 
 		// Publish three host-builtin events of different types. The OwnerMap is
 		// empty (default Config), so every subject is host-owned and lands in
-		// events_audit.
+		// events_audit. Use a run-scoped subject prefix so assertions only
+		// consider rows from THIS spec invocation (events_audit accumulates
+		// across specs in the same Ginkgo run; the original "events.main.test.*"
+		// subjects would be contaminated by prior runs in the same container).
+		gameID := "rc_" + core.NewULID().String()
+		subjectPrefix := "events." + gameID + ".test."
+		subjectLike := "events." + gameID + ".%"
 		types := []eventbus.Type{"arrive", "leave", "system"}
 		for i, typ := range types {
 			ev := eventbus.Event{
 				ID:        core.NewULID(),
-				Subject:   eventbus.Subject("events.main.test." + string(typ)),
+				Subject:   eventbus.Subject(subjectPrefix + string(typ)),
 				Type:      typ,
 				Timestamp: time.Now().UTC(),
 				Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
@@ -64,7 +70,10 @@ var _ = Describe("Rendering completeness", func() {
 		hostSub.AwaitDrained(suiteT, 10*time.Second)
 		Eventually(func() bool {
 			var count int
-			qerr := pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit").Scan(&count)
+			qerr := pool.QueryRow(ctx,
+				"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1",
+				subjectLike,
+			).Scan(&count)
 			return qerr == nil && count >= len(types)
 		}, 10*time.Second, 100*time.Millisecond).Should(BeTrue(),
 			"audit projection did not drain all events")
@@ -73,23 +82,26 @@ var _ = Describe("Rendering completeness", func() {
 		// enforces NOT NULL, but we assert here so a regression that drops the
 		// constraint or writes 'null' JSONB is caught.
 		var nullCount int
-		Expect(pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit WHERE rendering IS NULL").Scan(&nullCount)).To(Succeed())
+		Expect(pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1 AND rendering IS NULL",
+			subjectLike,
+		).Scan(&nullCount)).To(Succeed())
 		Expect(nullCount).To(BeZero(), "INV-GW-6: every events_audit row MUST have non-null rendering")
 
 		// INV-GW-13: rendering column carries the metadata stamped by the
 		// publisher. Spot-check the first row's source_plugin, then verify
 		// every host-builtin row reports source_plugin="builtin".
 		var sourcePlugin string
-		Expect(pool.QueryRow(
-			ctx,
-			"SELECT rendering->>'source_plugin' FROM events_audit ORDER BY js_seq LIMIT 1",
+		Expect(pool.QueryRow(ctx,
+			"SELECT rendering->>'source_plugin' FROM events_audit WHERE subject LIKE $1 ORDER BY js_seq LIMIT 1",
+			subjectLike,
 		).Scan(&sourcePlugin)).To(Succeed())
 		Expect(sourcePlugin).To(Equal("builtin"))
 
 		var nonBuiltinCount int
-		Expect(pool.QueryRow(
-			ctx,
-			"SELECT COUNT(*) FROM events_audit WHERE rendering->>'source_plugin' <> 'builtin'",
+		Expect(pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1 AND rendering->>'source_plugin' <> 'builtin'",
+			subjectLike,
 		).Scan(&nonBuiltinCount)).To(Succeed())
 		Expect(nonBuiltinCount).To(BeZero(),
 			"INV-GW-13: every host-builtin row must report source_plugin='builtin'")

--- a/test/integration/eventbus_e2e/rendering_completeness_test.go
+++ b/test/integration/eventbus_e2e/rendering_completeness_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Rendering completeness specs — covers INV-GW-6 + INV-GW-13. After
@@ -32,8 +31,8 @@ var _ = Describe("Rendering completeness", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 
 		// Stand up the host audit projection so publishes reach events_audit.
 		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})

--- a/test/integration/eventbus_e2e/rendering_completeness_test.go
+++ b/test/integration/eventbus_e2e/rendering_completeness_test.go
@@ -7,11 +7,10 @@ package eventbus_e2e_test
 
 import (
 	"context"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
@@ -19,81 +18,81 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestRenderingCompleteness covers INV-GW-6 + INV-GW-13. After publishing
-// host-builtin events through RenderingPublisher, every events_audit row
-// MUST have a non-null rendering JSONB column populated from the
-// App-Rendering NATS header by the audit projection.
+// Rendering completeness specs — covers INV-GW-6 + INV-GW-13. After
+// publishing host-builtin events through RenderingPublisher, every
+// events_audit row MUST have a non-null rendering JSONB column populated
+// from the App-Rendering NATS header by the audit projection.
 //
 //   - INV-GW-6: events_audit.rendering is NOT NULL for every projected row.
 //   - INV-GW-13: the rendering column carries the same metadata stamped by
 //     the publisher (verified here via source_plugin = "builtin" for all
 //     host-owned event types).
-func TestRenderingCompleteness(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+var _ = Describe("Rendering completeness", func() {
+	It("every events_audit row has non-null rendering with correct source_plugin (INV-GW-6, INV-GW-13)", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		DeferCleanup(cancel)
 
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
 
-	// Stand up the host audit projection so publishes reach events_audit.
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
+		// Stand up the host audit projection so publishes reach events_audit.
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
 
-	// Build the wrapped publisher: BootstrapVerbRegistry + RenderingPublisher.
-	registry, err := core.BootstrapVerbRegistry("test-0.1")
-	require.NoError(t, err)
-	pub := eventbus.NewRenderingPublisher(bus.Bus.Publisher(), registry)
+		// Build the wrapped publisher: BootstrapVerbRegistry + RenderingPublisher.
+		registry, err := core.BootstrapVerbRegistry("test-0.1")
+		Expect(err).NotTo(HaveOccurred())
+		pub := eventbus.NewRenderingPublisher(bus.Bus.Publisher(), registry)
 
-	// Publish three host-builtin events of different types. The OwnerMap is
-	// empty (default Config), so every subject is host-owned and lands in
-	// events_audit.
-	types := []eventbus.Type{"arrive", "leave", "system"}
-	for i, typ := range types {
-		ev := eventbus.Event{
-			ID:        core.NewULID(),
-			Subject:   eventbus.Subject("events.main.test." + string(typ)),
-			Type:      typ,
-			Timestamp: time.Now().UTC(),
-			Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
-			Payload:   []byte(`{}`),
+		// Publish three host-builtin events of different types. The OwnerMap is
+		// empty (default Config), so every subject is host-owned and lands in
+		// events_audit.
+		types := []eventbus.Type{"arrive", "leave", "system"}
+		for i, typ := range types {
+			ev := eventbus.Event{
+				ID:        core.NewULID(),
+				Subject:   eventbus.Subject("events.main.test." + string(typ)),
+				Type:      typ,
+				Timestamp: time.Now().UTC(),
+				Actor:     eventbus.Actor{Kind: eventbus.ActorKindSystem},
+				Payload:   []byte(`{}`),
+			}
+			Expect(pub.Publish(ctx, ev)).To(Succeed(), "publish %d type=%s", i, typ)
 		}
-		require.NoError(t, pub.Publish(ctx, ev), "publish %d type=%s", i, typ)
-	}
 
-	// Wait for the projection to drain.
-	hostSub.AwaitDrained(t, 10*time.Second)
-	require.Eventually(t, func() bool {
-		var count int
-		err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit").Scan(&count)
-		return err == nil && count >= len(types)
-	}, 10*time.Second, 100*time.Millisecond, "audit projection did not drain all events")
+		// Wait for the projection to drain.
+		hostSub.AwaitDrained(suiteT, 10*time.Second)
+		Eventually(func() bool {
+			var count int
+			qerr := pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit").Scan(&count)
+			return qerr == nil && count >= len(types)
+		}, 10*time.Second, 100*time.Millisecond).Should(BeTrue(),
+			"audit projection did not drain all events")
 
-	// INV-GW-6: every row has a non-null rendering JSONB column. Schema
-	// enforces NOT NULL, but we assert here so a regression that drops the
-	// constraint or writes 'null' JSONB is caught.
-	var nullCount int
-	err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit WHERE rendering IS NULL").Scan(&nullCount)
-	require.NoError(t, err)
-	assert.Zero(t, nullCount, "INV-GW-6: every events_audit row MUST have non-null rendering")
+		// INV-GW-6: every row has a non-null rendering JSONB column. Schema
+		// enforces NOT NULL, but we assert here so a regression that drops the
+		// constraint or writes 'null' JSONB is caught.
+		var nullCount int
+		Expect(pool.QueryRow(ctx, "SELECT COUNT(*) FROM events_audit WHERE rendering IS NULL").Scan(&nullCount)).To(Succeed())
+		Expect(nullCount).To(BeZero(), "INV-GW-6: every events_audit row MUST have non-null rendering")
 
-	// INV-GW-13: rendering column carries the metadata stamped by the
-	// publisher. Spot-check the first row's source_plugin, then verify
-	// every host-builtin row reports source_plugin="builtin".
-	var sourcePlugin string
-	err = pool.QueryRow(
-		ctx,
-		"SELECT rendering->>'source_plugin' FROM events_audit ORDER BY js_seq LIMIT 1",
-	).Scan(&sourcePlugin)
-	require.NoError(t, err)
-	assert.Equal(t, "builtin", sourcePlugin)
+		// INV-GW-13: rendering column carries the metadata stamped by the
+		// publisher. Spot-check the first row's source_plugin, then verify
+		// every host-builtin row reports source_plugin="builtin".
+		var sourcePlugin string
+		Expect(pool.QueryRow(
+			ctx,
+			"SELECT rendering->>'source_plugin' FROM events_audit ORDER BY js_seq LIMIT 1",
+		).Scan(&sourcePlugin)).To(Succeed())
+		Expect(sourcePlugin).To(Equal("builtin"))
 
-	var nonBuiltinCount int
-	err = pool.QueryRow(
-		ctx,
-		"SELECT COUNT(*) FROM events_audit WHERE rendering->>'source_plugin' <> 'builtin'",
-	).Scan(&nonBuiltinCount)
-	require.NoError(t, err)
-	assert.Zero(t, nonBuiltinCount,
-		"INV-GW-13: every host-builtin row must report source_plugin='builtin'")
-}
+		var nonBuiltinCount int
+		Expect(pool.QueryRow(
+			ctx,
+			"SELECT COUNT(*) FROM events_audit WHERE rendering->>'source_plugin' <> 'builtin'",
+		).Scan(&nonBuiltinCount)).To(Succeed())
+		Expect(nonBuiltinCount).To(BeZero(),
+			"INV-GW-13: every host-builtin row must report source_plugin='builtin'")
+	})
+})

--- a/test/integration/eventbus_e2e/soak_test.go
+++ b/test/integration/eventbus_e2e/soak_test.go
@@ -14,20 +14,19 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
-// TestSoakPublish1kPerSecondFor5Minutes matches spec §8 "Chaos and soak —
-// 1k events/sec for 5 minutes; assert no goroutine leak, memory growth
-// < 50 MB, audit lag p99 ≤ 5s, full event count".
+// Soak specs — matches spec §8 "Chaos and soak — 1k events/sec for
+// 5 minutes; assert no goroutine leak, memory growth < 50 MB, audit lag
+// p99 ≤ 5s, full event count".
 //
 // Implementation notes:
 //
@@ -42,99 +41,100 @@ import (
 // The full 5-minute run is heavy; callers can shorten via env
 // SOAK_DURATION (e.g. "30s" for a local smoke run). The nightly CI sets
 // no override, getting the full matrix.
-func TestSoakPublish1kPerSecondFor5Minutes(t *testing.T) {
-	duration := 5 * time.Minute
-	if override := os.Getenv("SOAK_DURATION"); override != "" {
-		if d, err := time.ParseDuration(override); err == nil && d > 0 {
-			duration = d
-			t.Logf("SOAK_DURATION override: %s", duration)
-		}
-	}
-
-	baselineRoutines := runtime.NumGoroutine()
-	var memBefore runtime.MemStats
-	runtime.ReadMemStats(&memBefore)
-
-	ctx, cancel := context.WithTimeout(t.Context(), duration+2*time.Minute)
-	defer cancel()
-
-	bus := eventbustest.New(t)
-	pool := freshPool(t)
-	hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
-	require.NoError(t, hostSub.Start(ctx))
-	t.Cleanup(func() { _ = hostSub.Stop(context.Background()) })
-
-	pub := bus.Bus.Publisher()
-	subject := eventbus.Subject("events.main.soak.s1")
-
-	// 1000 events/sec = one event per ms. Ten concurrent publishers
-	// smooths the load so no single goroutine has to spin.
-	const publishers = 10
-	ratePerPublisher := time.Second / (1000 / publishers) // 10ms per publisher
-
-	var published int64
-	var pubMu sync.Mutex
-	var wg sync.WaitGroup
-	// stopCh must close so every publisher goroutine observes the stop
-	// signal — `time.After` can only be received once, which is why the
-	// prior shape deadlocked all but the first goroutine.
-	stopCh := make(chan struct{})
-	go func() {
-		select {
-		case <-time.After(duration):
-		case <-ctx.Done():
-		}
-		close(stopCh)
-	}()
-	for p := 0; p < publishers; p++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ticker := time.NewTicker(ratePerPublisher)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-stopCh:
-					return
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					evt := mintEvent(subject, "scene.pose", `{"k":"soak"}`)
-					if err := pub.Publish(ctx, evt); err != nil {
-						// Publish errors are expected-ish under pressure;
-						// log and keep going so the loop measures
-						// end-to-end throughput instead of panicking on
-						// the first transient failure.
-						t.Logf("soak publish: %v", err)
-						continue
-					}
-					pubMu.Lock()
-					published++
-					pubMu.Unlock()
-				}
+var _ = Describe("Soak publish 1k/sec for 5 minutes", func() {
+	It("maintains row parity, no goroutine leak, no memory growth > 50MB", func() {
+		duration := 5 * time.Minute
+		if override := os.Getenv("SOAK_DURATION"); override != "" {
+			if d, err := time.ParseDuration(override); err == nil && d > 0 {
+				duration = d
+				GinkgoWriter.Printf("SOAK_DURATION override: %s\n", duration)
 			}
+		}
+
+		baselineRoutines := runtime.NumGoroutine()
+		var memBefore runtime.MemStats
+		runtime.ReadMemStats(&memBefore)
+
+		ctx, cancel := context.WithTimeout(context.Background(), duration+2*time.Minute)
+		DeferCleanup(cancel)
+
+		bus := eventbustest.New(suiteT)
+		pool := freshPool(suiteT)
+		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
+		Expect(hostSub.Start(ctx)).To(Succeed())
+		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })
+
+		pub := bus.Bus.Publisher()
+		subject := eventbus.Subject("events.main.soak.s1")
+
+		// 1000 events/sec = one event per ms. Ten concurrent publishers
+		// smooths the load so no single goroutine has to spin.
+		const publishers = 10
+		ratePerPublisher := time.Second / (1000 / publishers) // 10ms per publisher
+
+		var published int64
+		var pubMu sync.Mutex
+		var wg sync.WaitGroup
+		// stopCh must close so every publisher goroutine observes the stop
+		// signal — `time.After` can only be received once, which is why the
+		// prior shape deadlocked all but the first goroutine.
+		stopCh := make(chan struct{})
+		go func() {
+			select {
+			case <-time.After(duration):
+			case <-ctx.Done():
+			}
+			close(stopCh)
 		}()
-	}
-	wg.Wait()
+		for p := 0; p < publishers; p++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ticker := time.NewTicker(ratePerPublisher)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-stopCh:
+						return
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						evt := mintEvent(subject, "scene.pose", `{"k":"soak"}`)
+						if err := pub.Publish(ctx, evt); err != nil {
+							// Publish errors are expected-ish under pressure;
+							// log and keep going so the loop measures
+							// end-to-end throughput instead of failing.
+							GinkgoWriter.Printf("soak publish: %v\n", err)
+							continue
+						}
+						pubMu.Lock()
+						published++
+						pubMu.Unlock()
+					}
+				}
+			}()
+		}
+		wg.Wait()
 
-	// Give the projection generous time to drain after publish stop.
-	hostSub.AwaitDrained(t, 60*time.Second)
+		// Give the projection generous time to drain after publish stop.
+		hostSub.AwaitDrained(suiteT, 60*time.Second)
 
-	// Row-count parity — every published event lands in events_audit.
-	assert.Equal(t, int(published), countRows(t, pool, "events_audit", ""),
-		"audit row count must equal published count after drain")
+		// Row-count parity — every published event lands in events_audit.
+		Expect(countRows(pool, "events_audit", "")).To(Equal(int(published)),
+			"audit row count must equal published count after drain")
 
-	// Goroutine leak check. 10 × publishers exit; allow some slack for
-	// the bus/projection internal workers.
-	runtime.GC()
-	after := runtime.NumGoroutine()
-	assert.Less(t, after, baselineRoutines+50,
-		"goroutine count grew from %d to %d — likely a leak", baselineRoutines, after)
+		// Goroutine leak check. 10 × publishers exit; allow some slack for
+		// the bus/projection internal workers.
+		runtime.GC()
+		after := runtime.NumGoroutine()
+		Expect(after).To(BeNumerically("<", baselineRoutines+50),
+			"goroutine count grew from %d to %d — likely a leak", baselineRoutines, after)
 
-	// Memory ceiling: 50 MB growth per spec §8.
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	growth := int64(memAfter.HeapAlloc) - int64(memBefore.HeapAlloc)
-	assert.Less(t, growth, int64(50*1024*1024),
-		"heap growth %d bytes exceeds 50MB soak ceiling", growth)
-}
+		// Memory ceiling: 50 MB growth per spec §8.
+		var memAfter runtime.MemStats
+		runtime.ReadMemStats(&memAfter)
+		growth := int64(memAfter.HeapAlloc) - int64(memBefore.HeapAlloc)
+		Expect(growth).To(BeNumerically("<", int64(50*1024*1024)),
+			"heap growth %d bytes exceeds 50MB soak ceiling", growth)
+	})
+})

--- a/test/integration/eventbus_e2e/soak_test.go
+++ b/test/integration/eventbus_e2e/soak_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Soak publish 1k/sec for 5 minutes", func() {
 		hostSub.AwaitDrained(suiteT, 60*time.Second)
 
 		// Row-count parity — every published event lands in events_audit.
-		Expect(countRows(pool, "events_audit", "")).To(Equal(int(published)),
+		Expect(countRows(ctx, pool, "events_audit", "")).To(Equal(int(published)),
 			"audit row count must equal published count after drain")
 
 		// Goroutine leak check. 10 × publishers exit; allow some slack for

--- a/test/integration/eventbus_e2e/soak_test.go
+++ b/test/integration/eventbus_e2e/soak_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
-	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 )
 
 // Soak specs — matches spec §8 "Chaos and soak — 1k events/sec for
@@ -58,8 +57,8 @@ var _ = Describe("Soak publish 1k/sec for 5 minutes", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), duration+2*time.Minute)
 		DeferCleanup(cancel)
 
-		bus := eventbustest.New(suiteT)
-		pool := freshPool(suiteT)
+		bus := freshBus()
+		pool := freshPool()
 		hostSub := audit.NewSubsystem(fixedJS{js: bus.JS}, fixedPool{pool: pool}, audit.Config{})
 		Expect(hostSub.Start(ctx)).To(Succeed())
 		DeferCleanup(func() { _ = hostSub.Stop(context.Background()) })

--- a/test/integration/eventbus_e2e/suite_test.go
+++ b/test/integration/eventbus_e2e/suite_test.go
@@ -89,15 +89,6 @@ func ensurePluginSchema(ctx context.Context, t *testing.T, pool *pgxpool.Pool, s
 	require.NoError(t, err)
 }
 
-// TestMainCompiles keeps `go test -tags=integration ./...` from failing
-// when the package contains only skeleton tests. Without at least one
-// top-level Test func, `go test` reports "no test files" under some Go
-// toolchains; keep this minimal guard alongside any real tests.
-func TestSuiteCompiles(t *testing.T) {
-	t.Parallel()
-	// No assertions — presence is the contract.
-}
-
 // waitForRowInSceneLog polls plugin_core_scenes.scene_log for a row with
 // the given event id (raw 16-byte ULID) until it appears or the timeout
 // fires. Used by the Phase 7 round-trip + plugin-isolation tests

--- a/test/integration/eventbus_e2e/suite_test.go
+++ b/test/integration/eventbus_e2e/suite_test.go
@@ -28,11 +28,38 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/test/testutil"
 )
+
+// specTB wraps the suite-level *testing.T but redirects Cleanup to Ginkgo's
+// DeferCleanup so resources scoped per spec (NATS embedded bus, pgxpool) are
+// torn down when the It finishes — not when the whole suite ends. Without
+// this, every spec's eventbustest.New + freshPool would accumulate live NATS
+// servers and pgxpool connections for the entire suite run, eventually
+// starving the suite of resources and producing NATS request timeouts.
+//
+// Errorf + FailNow are NOT remapped — Ginkgo's Fail handler is registered
+// against the suite's Fail callback, and any Gomega Expect failure goes
+// through Ginkgo directly.
+type specTB struct {
+	*testing.T
+}
+
+func (s *specTB) Cleanup(fn func()) {
+	DeferCleanup(fn)
+}
+
+// freshBus returns an embedded NATS+JetStream bus whose cleanup is scoped to
+// the current Ginkgo spec (not the whole suite). Use this in spec bodies
+// (BeforeEach or It) instead of eventbustest.New(suiteT).
+func freshBus() *eventbustest.Embedded {
+	return eventbustest.New(&specTB{T: suiteT})
+}
 
 // newPool opens a pgxpool against a caller-supplied connection string.
 // t.Cleanup handles Close — callers do not.
@@ -47,8 +74,23 @@ func newPool(t *testing.T, connStr string) *pgxpool.Pool {
 }
 
 // freshPool spins up a migrated PG database and returns a ready pool.
-// Convenience wrapper for the common test setup pattern.
-func freshPool(t *testing.T) *pgxpool.Pool {
+// Pool close is scoped to the current Ginkgo spec via DeferCleanup (NOT the
+// suite), so per-spec pools don't accumulate connections across the run.
+// Use in It / BeforeEach bodies (where Ginkgo's context is active).
+func freshPool() *pgxpool.Pool {
+	shared := testutil.SharedPostgres(suiteT)
+	connStr := testutil.FreshDatabase(suiteT, shared)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(suiteT, err)
+	DeferCleanup(pool.Close)
+	return pool
+}
+
+// freshPoolT is the legacy *testing.T-shaped variant. Retained for callers
+// outside Ginkgo specs (none today, kept for parity with newPool).
+func freshPoolT(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	shared := testutil.SharedPostgres(t)
 	connStr := testutil.FreshDatabase(t, shared)


### PR DESCRIPTION
## Summary

Part of holomush-1hq.26 / holomush-rccc Stage A. Biggest stage of the migration. Converts 14 plain-`testing.T` integration files (10 live + 4 skeletons) in `test/integration/eventbus_e2e/` to Ginkgo. Includes suite rename and meta-test mapping updates.

**Suite rename:** `Cursor Concurrent Pagination Specs` → `EventbusE2E Suite`. Function `TestCursorConcurrentSpecs` → `TestEventbusE2E`. `var suiteT *testing.T` preserved (10 callers in cursor_concurrent_test.go). Stale `holomush-suos.2` reference removed.

**14 files converted** — 10 live + 4 skeletons (Pattern B: `Skip()` inside `It`, both TODO refs preserved).

**Meta-test updates** (`internal/eventbus/history/phase7_boundary_meta_test.go`):
- INV-P7-6 → TestEventbusE2E
- INV-P7-9 → TestEventbusE2E
- INV-P7-10 → TestEventbusE2E
- INV-P7-12 → TestEventbusE2E

INV refs preserved in `Describe` spec names for grep-ability.

## Pattern

`suiteT` capture (corrected pattern from PR #3951) — not `GinkgoT()`.

Closes holomush-cz4s.

## Test plan

- [x] Per-PR gates: RunSpecs = 1; 8 TODO holomush-{ecbg,l4kx,6nds,nko7} refs across skeletons
- [ ] CI gates: authoritative
- [ ] code-reviewer pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated many integration tests from Go testing/testify to Ginkgo v2/Gomega: Test... entrypoints replaced by Describe/It specs, suite entrypoints renamed, helpers adapted, and lifecycle/assertion patterns updated. Several exported test functions were removed or renamed; some specs are intentionally skipped pending feature implementation.

* **Chores**
  * Minor formatting, comment, and whitespace refinements across test code; helper error-handling updated to match Ginkgo/Gomega style.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->