### PR TITLE
test: migrate 4 misc package-level integration tests to Ginkgo (1hq.26 B1)

### DIFF
--- a/cmd/holomush/admin_authenticate_e2e_suite_test.go
+++ b/cmd/holomush/admin_authenticate_e2e_suite_test.go
@@ -32,5 +32,5 @@ var adminAuthSuiteT *testing.T
 func TestAdminAuthenticateE2E(t *testing.T) {
 	adminAuthSuiteT = t
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Admin Authenticate E2E Lifecycle Suite")
+	RunSpecs(t, "Holomush Integration Suite")
 }

--- a/cmd/holomush/automigrate_integration_test.go
+++ b/cmd/holomush/automigrate_integration_test.go
@@ -1,7 +1,7 @@
-//go:build integration
-
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
 
 package main
 
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/holomush/holomush/internal/bootstrap"
@@ -19,15 +19,14 @@ import (
 )
 
 // startPostgresContainer starts a PostgreSQL container for testing.
+// Uses postgres.BasicWaitStrategies() which combines the log wait with
+// wait.ForListeningPort to avoid the Docker port-mapping race documented
+// in holomush-bmcq. Called from both Ginkgo specs (passing suiteT) and
+// plain testing.T helpers (e.g., bootstrap_orphan_test.go).
 func startPostgresContainer(t *testing.T) (string, func()) {
 	t.Helper()
 	ctx := context.Background()
 
-	// Use postgres.BasicWaitStrategies() which combines the log wait
-	// with wait.ForListeningPort. Bare wait.ForLog is documented as
-	// flaky on Mac/Windows because Docker's port-mapping table can lag
-	// the readiness log line; without the port wait, ConnectionString
-	// can fail with `port "5432/tcp" not found`. See holomush-bmcq.
 	container, err := postgres.Run(
 		ctx,
 		"postgres:18-alpine",
@@ -36,10 +35,15 @@ func startPostgresContainer(t *testing.T) (string, func()) {
 		postgres.WithPassword("test"),
 		postgres.BasicWaitStrategies(),
 	)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("startPostgresContainer: run: %v", err)
+	}
 
 	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		t.Fatalf("startPostgresContainer: connection string: %v", err)
+	}
 
 	cleanup := func() {
 		_ = container.Terminate(ctx)
@@ -54,7 +58,7 @@ func schemaTableExists(ctx context.Context, connStr string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 	var exists bool
 	query := `SELECT EXISTS (
@@ -72,7 +76,7 @@ func getMigrationVersion(ctx context.Context, connStr string) (int, bool, error)
 	if err != nil {
 		return 0, false, err
 	}
-	defer conn.Close(ctx)
+	defer conn.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 	var version int
 	var dirty bool
@@ -84,97 +88,81 @@ func getMigrationVersion(ctx context.Context, connStr string) (int, bool, error)
 	return version, dirty, nil
 }
 
-func TestAutoMigrate_Integration_RunsOnStartup(t *testing.T) {
-	ctx := context.Background()
+var _ = Describe("autoMigration", func() {
+	Describe("runAutoMigration integration", func() {
+		It("runs on startup: creates schema_migrations and records a version > 0", func() {
+			ctx := context.Background()
+			connStr, cleanup := startPostgresContainer(adminAuthSuiteT)
+			DeferCleanup(cleanup)
 
-	connStr, cleanup := startPostgresContainer(t)
-	defer cleanup()
+			exists, err := schemaTableExists(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse(), "schema_migrations should not exist before auto-migrate")
 
-	// Verify schema_migrations doesn't exist yet
-	exists, err := schemaTableExists(ctx, connStr)
-	require.NoError(t, err)
-	assert.False(t, exists, "schema_migrations should not exist before auto-migrate")
+			Expect(runAutoMigration(connStr, func(url string) (bootstrap.AutoMigrator, error) {
+				return store.NewMigrator(url)
+			})).NotTo(HaveOccurred())
 
-	// Run auto-migration using the runAutoMigration function
-	err = runAutoMigration(connStr, func(url string) (bootstrap.AutoMigrator, error) {
-		return store.NewMigrator(url)
+			exists, err = schemaTableExists(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "schema_migrations should exist after auto-migrate")
+
+			version, dirty, err := getMigrationVersion(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(BeNumerically(">", 0), "migration version should be > 0 after auto-migrate")
+			Expect(dirty).To(BeFalse(), "database should not be in dirty state after successful migration")
+		})
+
+		It("is skipped when auto-migrate is disabled: schema_migrations is not created", func() {
+			ctx := context.Background()
+			connStr, cleanup := startPostgresContainer(adminAuthSuiteT)
+			DeferCleanup(cleanup)
+
+			exists, err := schemaTableExists(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse(), "schema_migrations should not exist initially")
+
+			deps := &CoreDeps{
+				DatabaseURLGetter: func() string { return connStr },
+				AutoMigrateGetter: func() bool { return false },
+				MigratorFactory: func(url string) (bootstrap.AutoMigrator, error) {
+					Fail("MigratorFactory should not be called when auto-migrate is disabled")
+					return store.NewMigrator(url)
+				},
+			}
+
+			if deps.AutoMigrateGetter() {
+				Expect(runAutoMigration(connStr, deps.MigratorFactory)).NotTo(HaveOccurred())
+			}
+
+			exists, err = schemaTableExists(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse(), "schema_migrations should not exist when auto-migrate is disabled")
+		})
+
+		It("is idempotent: re-running does not change migration version or dirty flag", func() {
+			ctx := context.Background()
+			connStr, cleanup := startPostgresContainer(adminAuthSuiteT)
+			DeferCleanup(cleanup)
+
+			migratorFactory := func(url string) (bootstrap.AutoMigrator, error) {
+				return store.NewMigrator(url)
+			}
+
+			Expect(runAutoMigration(connStr, migratorFactory)).NotTo(HaveOccurred())
+
+			versionAfterFirst, dirtyAfterFirst, err := getMigrationVersion(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versionAfterFirst).To(BeNumerically(">", 0))
+			Expect(dirtyAfterFirst).To(BeFalse())
+
+			Expect(runAutoMigration(connStr, migratorFactory)).NotTo(HaveOccurred())
+
+			versionAfterSecond, dirtyAfterSecond, err := getMigrationVersion(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versionAfterSecond).To(Equal(versionAfterFirst),
+				"version should be unchanged after idempotent re-run")
+			Expect(dirtyAfterSecond).To(BeFalse())
+		})
 	})
-	require.NoError(t, err)
-
-	// Verify schema_migrations now exists
-	exists, err = schemaTableExists(ctx, connStr)
-	require.NoError(t, err)
-	assert.True(t, exists, "schema_migrations should exist after auto-migrate")
-
-	// Verify a migration version was recorded (version > 0)
-	version, dirty, err := getMigrationVersion(ctx, connStr)
-	require.NoError(t, err)
-	assert.Greater(t, version, 0, "migration version should be > 0 after auto-migrate")
-	assert.False(t, dirty, "database should not be in dirty state after successful migration")
-}
-
-func TestAutoMigrate_Integration_SkippedWhenDisabled(t *testing.T) {
-	ctx := context.Background()
-
-	connStr, cleanup := startPostgresContainer(t)
-	defer cleanup()
-
-	// Verify schema_migrations doesn't exist initially
-	exists, err := schemaTableExists(ctx, connStr)
-	require.NoError(t, err)
-	assert.False(t, exists, "schema_migrations should not exist initially")
-
-	// Create CoreDeps with auto-migrate disabled
-	deps := &CoreDeps{
-		DatabaseURLGetter: func() string { return connStr },
-		AutoMigrateGetter: func() bool { return false },
-		MigratorFactory: func(url string) (bootstrap.AutoMigrator, error) {
-			t.Error("MigratorFactory should not be called when auto-migrate is disabled")
-			return store.NewMigrator(url)
-		},
-	}
-
-	// Simulate the auto-migrate check from runCoreWithDeps
-	// We just check the logic branch - if AutoMigrateGetter returns false,
-	// runAutoMigration should not be called
-	if deps.AutoMigrateGetter() {
-		err = runAutoMigration(connStr, deps.MigratorFactory)
-		require.NoError(t, err)
-	}
-
-	// Verify schema_migrations still doesn't exist (no migration ran)
-	exists, err = schemaTableExists(ctx, connStr)
-	require.NoError(t, err)
-	assert.False(t, exists, "schema_migrations should not exist when auto-migrate is disabled")
-}
-
-func TestAutoMigrate_Integration_IdempotentOnRerun(t *testing.T) {
-	ctx := context.Background()
-
-	connStr, cleanup := startPostgresContainer(t)
-	defer cleanup()
-
-	migratorFactory := func(url string) (bootstrap.AutoMigrator, error) {
-		return store.NewMigrator(url)
-	}
-
-	// Run auto-migration first time
-	err := runAutoMigration(connStr, migratorFactory)
-	require.NoError(t, err)
-
-	// Get version after first run
-	versionAfterFirst, dirtyAfterFirst, err := getMigrationVersion(ctx, connStr)
-	require.NoError(t, err)
-	assert.Greater(t, versionAfterFirst, 0)
-	assert.False(t, dirtyAfterFirst)
-
-	// Run auto-migration second time (should be idempotent)
-	err = runAutoMigration(connStr, migratorFactory)
-	require.NoError(t, err)
-
-	// Verify version is unchanged
-	versionAfterSecond, dirtyAfterSecond, err := getMigrationVersion(ctx, connStr)
-	require.NoError(t, err)
-	assert.Equal(t, versionAfterFirst, versionAfterSecond, "version should be unchanged after idempotent re-run")
-	assert.False(t, dirtyAfterSecond)
-}
+})

--- a/internal/eventbus/history/cold_postgres_integration_test.go
+++ b/internal/eventbus/history/cold_postgres_integration_test.go
@@ -9,14 +9,13 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -35,45 +34,41 @@ func newErrorSnapshotForTest(err error) *StreamStateSnapshot {
 	return s
 }
 
-// newTestPool opens a pgxpool against a fresh migrated test database and
-// registers cleanup. Each test gets its own isolated database so rows from
-// one test cannot interfere with another.
-func newTestPool(t *testing.T) *pgxpool.Pool {
-	t.Helper()
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.FreshDatabase(t, shared)
+// newIntegrationPool opens a pgxpool against a fresh migrated test database.
+// Each test gets its own isolated database so rows from one test cannot
+// interfere with another.
+func newIntegrationPool() *pgxpool.Pool {
+	GinkgoHelper()
+	connStr := testutil.FreshDatabase(suiteT, sharedPG)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
-	t.Cleanup(pool.Close)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
 	return pool
 }
 
-// testULID returns a unique ULID for use in tests. The ms parameter is used
-// as the timestamp component to create ordered ULIDs; entropy comes from
+// integrationULID returns a unique ULID for use in tests. The ms parameter is
+// used as the timestamp component to create ordered ULIDs; entropy comes from
 // crypto/rand.
-func testULID(t *testing.T, ms uint64) ulid.ULID {
-	t.Helper()
+func integrationULID(ms uint64) ulid.ULID {
+	GinkgoHelper()
 	u, err := ulid.New(ms, rand.Reader)
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 	return u
 }
 
-// insertAuditRow inserts a minimal events_audit row with the given id, subject,
-// seq, and current timestamp.
-func insertAuditRow(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subject eventbus.Subject, seq uint64) {
-	t.Helper()
-	insertAuditRowAt(t, pool, id, subject, seq, time.Now().UTC())
+// insertIntegrationAuditRow inserts a minimal events_audit row with the given
+// id, subject, seq, and current timestamp.
+func insertIntegrationAuditRow(pool *pgxpool.Pool, id ulid.ULID, subject eventbus.Subject, seq uint64) {
+	GinkgoHelper()
+	insertIntegrationAuditRowAt(pool, id, subject, seq, time.Now().UTC())
 }
 
-// insertAuditRowAt inserts a minimal events_audit row with an explicit timestamp.
-//
-// The envelope column carries a marshaled eventbusv1.Event matching what
-// the audit projection would persist. Required post-Phase 3d Task 5 because
-// the cold reader unmarshals the envelope to recover Subject/Type/Actor.
-func insertAuditRowAt(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subject eventbus.Subject, seq uint64, ts time.Time) {
-	t.Helper()
+// insertIntegrationAuditRowAt inserts a minimal events_audit row with an
+// explicit timestamp.
+func insertIntegrationAuditRowAt(pool *pgxpool.Pool, id ulid.ULID, subject eventbus.Subject, seq uint64, ts time.Time) {
+	GinkgoHelper()
 	envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
 		Id:        id[:],
 		Subject:   string(subject),
@@ -81,266 +76,21 @@ func insertAuditRowAt(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subject ev
 		Timestamp: timestamppb.New(ts),
 		Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
 	})
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
 			envelope, schema_ver, codec, js_seq, rendering
 		) VALUES ($1, $2, 'test.event', $4, 'system', NULL, $5, 1, 'identity', $3, '{}'::jsonb)
 	`, id[:], string(subject), int64(seq), ts, envelopeBytes)
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 }
 
-// TestColdReadValidatesAndDiscardsCursorEcho: forward read with a valid
-// cursor returns rows after the cursor, having validated and discarded
-// the cursor row from the result.
-func TestColdReadValidatesAndDiscardsCursorEcho(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCAAA0000000000A")
-	id1 := testULID(t, 1000001)
-	id2 := testULID(t, 1000002)
-	id3 := testULID(t, 1000003)
-
-	insertAuditRow(t, pool, id1, subject, 1)
-	insertAuditRow(t, pool, id2, subject, 2)
-	insertAuditRow(t, pool, id3, subject, 3)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  1,
-		AfterID:   id1,
-		Direction: eventbus.DirectionForward,
-	}
-	out, err := tier.Read(ctx, q, time.Time{}, 10, nil)
-	require.NoError(t, err)
-	require.Len(t, out, 2, "should return events after cursor; cursor row is discarded")
-	assert.Equal(t, uint64(2), out[0].Seq)
-	assert.Equal(t, id2, out[0].ID)
-	assert.Equal(t, uint64(3), out[1].Seq)
-	assert.Equal(t, id3, out[1].ID)
-}
-
-// TestColdReadReturnsStaleOnIDMismatch: cursor seq matches a row but the id
-// does not — returns ErrCursorStale.
-func TestColdReadReturnsStaleOnIDMismatch(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCBBB0000000000B")
-	idActual := testULID(t, 2000001)
-	idCursor := testULID(t, 2000099) // different id for the same seq
-
-	insertAuditRow(t, pool, idActual, subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  1,
-		AfterID:   idCursor, // mismatched id for seq 1
-		Direction: eventbus.DirectionForward,
-	}
-	_, err := tier.Read(ctx, q, time.Time{}, 10, nil)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorStale)
-}
-
-// TestColdReadReturnsStaleOnMissingCursorSeq: cursor seq does not exist in
-// events_audit — returns ErrCursorStale.
-func TestColdReadReturnsStaleOnMissingCursorSeq(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCCCC0000000000C")
-	insertAuditRow(t, pool, testULID(t, 3000001), subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  99, // seq 99 does not exist
-		AfterID:   testULID(t, 3000099),
-		Direction: eventbus.DirectionForward,
-	}
-	_, err := tier.Read(ctx, q, time.Time{}, 10, nil)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorStale)
-}
-
-// TestColdReadCursorAtEdgePassesEdgeFilter: when an edge time is supplied and
-// the cursor row is AT or before the edge, the cursor echo is validated and
-// discarded; rows after the edge are excluded. The page is empty because
-// the only available post-cursor row falls after the edge timestamp.
-func TestColdReadCursorAtEdgePassesEdgeFilter(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCDDD0000000000D")
-	idAtEdge := testULID(t, 4000005)
-	idAfterEdge := testULID(t, 4000006)
-
-	now := time.Now().UTC()
-	insertAuditRowAt(t, pool, idAtEdge, subject, 5, now.Add(-1*time.Hour))
-	insertAuditRowAt(t, pool, idAfterEdge, subject, 6, now)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  5,
-		AfterID:   idAtEdge,
-		Direction: eventbus.DirectionForward,
-	}
-	edge := now.Add(-30 * time.Minute)
-	out, err := tier.Read(ctx, q, edge, 10, nil)
-	require.NoError(t, err)
-	// Cursor echo is validated and discarded; idAfterEdge is filtered by edge.
-	assert.Empty(t, out)
-}
-
-// TestColdReadReturnsLagWhenCursorSeqMissingFromColdButPresentInJS uses a
-// stubbed snapshot to simulate cursor.Seq=50 being in JS (LastSeq=100) but
-// not yet projected into cold. Expect ErrCursorLag.
-func TestColdReadReturnsLagWhenCursorSeqMissingFromColdButPresentInJS(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCEEE0000000000E")
-	// Insert seq=1 only; cursor will point to seq=50 which is absent.
-	insertAuditRow(t, pool, testULID(t, 5000001), subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  50,
-		AfterID:   testULID(t, 5000050),
-		Direction: eventbus.DirectionForward,
-		PageSize:  10,
-	}
-	// Snapshot: JS contains seqs 1..100; cursor.Seq=50 is within [1,100] → LAG.
-	snap := newSnapshotForTest(1, 100)
-	_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorLag,
-		"cursor seq within JS range must be LAG, not STALE")
-}
-
-// TestColdReadReturnsStaleWhenCursorSeqBeyondJS uses a stubbed snapshot where
-// cursor.Seq exceeds the snapshot's LastSeq — the seq doesn't exist anywhere,
-// so it's truly STALE.
-func TestColdReadReturnsStaleWhenCursorSeqBeyondJS(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCFFF0000000000F")
-	// Insert seq=1 only; cursor will point to seq=200 which exceeds JS.
-	insertAuditRow(t, pool, testULID(t, 6000001), subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  200,
-		AfterID:   testULID(t, 6000200),
-		Direction: eventbus.DirectionForward,
-		PageSize:  10,
-	}
-	// Snapshot: JS only has seqs 1..100; cursor.Seq=200 > lastSeq=100 → STALE.
-	snap := newSnapshotForTest(1, 100)
-	_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorStale,
-		"cursor seq beyond JS range must be STALE")
-}
-
-// TestColdReadReturnsStaleWhenCursorBelowJSFirstSeq verifies that a cursor
-// whose seq is below the snapshot's firstSeq (i.e., retention has aged it
-// out of JS but it was never projected into cold) returns ErrCursorStale.
-func TestColdReadReturnsStaleWhenCursorBelowJSFirstSeq(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	// Snapshot: JS has seq=10..100; cursor points to seq=5 which is below firstSeq.
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCHHH0000000000H")
-	// No cold row for the cursor seq (absent from cold).
-	insertAuditRow(t, pool, testULID(t, 8000001), subject, 99)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  5,
-		AfterID:   testULID(t, 8000005),
-		Direction: eventbus.DirectionForward,
-		PageSize:  10,
-	}
-	// Snapshot: firstSeq=10 > cursorSeq=5 → not in LAG range → STALE.
-	snap := newSnapshotForTest(10, 100)
-	_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorStale,
-		"cursor seq below JS firstSeq must be STALE (retention aged it out)")
-}
-
-// TestColdReadPropagatesSnapshotError verifies that an error returned by
-// the snapshot's Get() propagates to the caller unchanged and is NOT
-// classified as ErrCursorStale or ErrCursorLag.
-func TestColdReadPropagatesSnapshotError(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	// Insert one row so the query reaches the cursor-validation branch.
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCIII0000000000I")
-	insertAuditRow(t, pool, testULID(t, 9000001), subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  50,
-		AfterID:   testULID(t, 9000050),
-		Direction: eventbus.DirectionForward,
-		PageSize:  10,
-	}
-	snapErr := oops.Code("EVENTBUS_HISTORY_STREAM_LOOKUP_FAILED").Errorf("js unreachable")
-	snap := newErrorSnapshotForTest(snapErr)
-	_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
-	require.Error(t, err)
-	assert.False(t, errors.Is(err, eventbus.ErrCursorStale),
-		"snapshot error must not be classified as ErrCursorStale")
-	assert.False(t, errors.Is(err, eventbus.ErrCursorLag),
-		"snapshot error must not be classified as ErrCursorLag")
-	// The infra error propagates as-is.
-	assert.ErrorIs(t, err, snapErr)
-}
-
-// TestColdReadReturnsStaleWhenNoSnapshotAndCursorMissing verifies that without
-// a snapshot (nil), a missing cursor seq always returns ErrCursorStale
-// (can't distinguish LAG from STALE).
-func TestColdReadReturnsStaleWhenNoSnapshotAndCursorMissing(t *testing.T) {
-	pool := newTestPool(t)
-	ctx := context.Background()
-
-	subject := eventbus.Subject("events.main.location.01HXTESTLOCGGG0000000000G")
-	insertAuditRow(t, pool, testULID(t, 7000001), subject, 1)
-
-	tier := newPostgresColdTier(pool)
-	q := eventbus.HistoryQuery{
-		Subject:   subject,
-		AfterSeq:  50,
-		AfterID:   testULID(t, 7000050),
-		Direction: eventbus.DirectionForward,
-		PageSize:  10,
-	}
-	// No snapshot — falls back to STALE.
-	_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, nil)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, eventbus.ErrCursorStale,
-		"without snapshot, missing cursor must be STALE")
-}
-
-// insertColdRowWithDEK inserts a minimal events_audit row with dek_ref and
-// dek_version set. Used by LookupByID tests to verify that the DEK columns
-// round-trip through the Envelope accessors.
-func insertColdRowWithDEK(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subject, evType string, dekRef int64, dekVersion int32) {
-	t.Helper()
+// insertIntegrationColdRowWithDEK inserts a minimal events_audit row with
+// dek_ref and dek_version set. Used by LookupByID tests to verify that the
+// DEK columns round-trip through the Envelope accessors.
+func insertIntegrationColdRowWithDEK(pool *pgxpool.Pool, id ulid.ULID, subject, evType string, dekRef int64, dekVersion int32) {
+	GinkgoHelper()
 	envelopeBytes, err := proto.Marshal(&eventbusv1.Event{
 		Id:        id[:],
 		Subject:   subject,
@@ -348,7 +98,7 @@ func insertColdRowWithDEK(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subjec
 		Timestamp: timestamppb.New(time.Now().UTC()),
 		Actor:     &eventbusv1.Actor{Kind: eventbusv1.ActorKind_ACTOR_KIND_SYSTEM},
 	})
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
@@ -356,37 +106,256 @@ func insertColdRowWithDEK(t *testing.T, pool *pgxpool.Pool, id ulid.ULID, subjec
 			dek_ref, dek_version
 		) VALUES ($1, $2, $3, now(), 'system', NULL, $4, 1, 'xchacha20v1', 1, '{}'::jsonb, $5, $6)
 	`, id[:], subject, evType, envelopeBytes, dekRef, dekVersion)
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 }
 
-// TestReader_LookupByID_ReturnsEnvelope verifies that LookupByID returns the
-// Envelope with correct EventID, KeyID, and KeyVersion from the cold tier row.
-// This is the INV-39 seam: FallbackResolver calls LookupByID when the hot-tier
-// DEK lookup fails (post-Rekey stale dek_ref).
-func TestReader_LookupByID_ReturnsEnvelope(t *testing.T) {
-	pool := newTestPool(t)
+var _ = Describe("PostgresColdTier", func() {
+	Describe("forward read cursor validation and discard", func() {
+		It("validates and discards cursor echo, returning rows after cursor", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
 
-	eventID := testULID(t, 10000001)
-	insertColdRowWithDEK(t, pool, eventID, "events.g1.scene.A.ic", "scene.event", 42, 7)
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCAAA0000000000A")
+			id1 := integrationULID(1000001)
+			id2 := integrationULID(1000002)
+			id3 := integrationULID(1000003)
 
-	tier := newPostgresColdTier(pool)
-	env, found, err := tier.LookupByID(context.Background(), eventID)
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Equal(t, eventID, env.EventID())
-	require.Equal(t, codec.KeyID(42), env.KeyID())
-	require.Equal(t, uint32(7), env.KeyVersion())
-}
+			insertIntegrationAuditRow(pool, id1, subject, 1)
+			insertIntegrationAuditRow(pool, id2, subject, 2)
+			insertIntegrationAuditRow(pool, id3, subject, 3)
 
-// TestReader_LookupByID_NotFound verifies that LookupByID returns (zero, false, nil)
-// when no row exists for the given event ID — the not-found sentinel that
-// FallbackResolver uses to trigger the cold_dek_miss metric path.
-func TestReader_LookupByID_NotFound(t *testing.T) {
-	pool := newTestPool(t)
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  1,
+				AfterID:   id1,
+				Direction: eventbus.DirectionForward,
+			}
+			out, err := tier.Read(ctx, q, time.Time{}, 10, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(HaveLen(2), "should return events after cursor; cursor row is discarded")
+			Expect(out[0].Seq).To(Equal(uint64(2)))
+			Expect(out[0].ID).To(Equal(id2))
+			Expect(out[1].Seq).To(Equal(uint64(3)))
+			Expect(out[1].ID).To(Equal(id3))
+		})
+	})
 
-	tier := newPostgresColdTier(pool)
-	nonExistent := testULID(t, 99999999)
-	_, found, err := tier.LookupByID(context.Background(), nonExistent)
-	require.NoError(t, err)
-	require.False(t, found)
-}
+	Describe("cursor stale and lag detection", func() {
+		It("returns ErrCursorStale when cursor seq matches a row but id does not", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCBBB0000000000B")
+			idActual := integrationULID(2000001)
+			idCursor := integrationULID(2000099) // different id for the same seq
+
+			insertIntegrationAuditRow(pool, idActual, subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  1,
+				AfterID:   idCursor, // mismatched id for seq 1
+				Direction: eventbus.DirectionForward,
+			}
+			_, err := tier.Read(ctx, q, time.Time{}, 10, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeTrue())
+		})
+
+		It("returns ErrCursorStale when cursor seq does not exist in events_audit", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCCCC0000000000C")
+			insertIntegrationAuditRow(pool, integrationULID(3000001), subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  99, // seq 99 does not exist
+				AfterID:   integrationULID(3000099),
+				Direction: eventbus.DirectionForward,
+			}
+			_, err := tier.Read(ctx, q, time.Time{}, 10, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeTrue())
+		})
+
+		It("validates and discards cursor echo at edge; filters post-edge rows, returning empty page", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCDDD0000000000D")
+			idAtEdge := integrationULID(4000005)
+			idAfterEdge := integrationULID(4000006)
+
+			now := time.Now().UTC()
+			insertIntegrationAuditRowAt(pool, idAtEdge, subject, 5, now.Add(-1*time.Hour))
+			insertIntegrationAuditRowAt(pool, idAfterEdge, subject, 6, now)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  5,
+				AfterID:   idAtEdge,
+				Direction: eventbus.DirectionForward,
+			}
+			edge := now.Add(-30 * time.Minute)
+			out, err := tier.Read(ctx, q, edge, 10, nil)
+			Expect(err).NotTo(HaveOccurred())
+			// Cursor echo is validated and discarded; idAfterEdge is filtered by edge.
+			Expect(out).To(BeEmpty())
+		})
+
+		It("returns ErrCursorLag when cursor seq is within JS range but missing from cold", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCEEE0000000000E")
+			// Insert seq=1 only; cursor will point to seq=50 which is absent.
+			insertIntegrationAuditRow(pool, integrationULID(5000001), subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  50,
+				AfterID:   integrationULID(5000050),
+				Direction: eventbus.DirectionForward,
+				PageSize:  10,
+			}
+			// Snapshot: JS contains seqs 1..100; cursor.Seq=50 is within [1,100] → LAG.
+			snap := newSnapshotForTest(1, 100)
+			_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorLag)).To(BeTrue(),
+				"cursor seq within JS range must be LAG, not STALE")
+		})
+
+		It("returns ErrCursorStale when cursor seq exceeds JS snapshot lastSeq", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCFFF0000000000F")
+			// Insert seq=1 only; cursor will point to seq=200 which exceeds JS.
+			insertIntegrationAuditRow(pool, integrationULID(6000001), subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  200,
+				AfterID:   integrationULID(6000200),
+				Direction: eventbus.DirectionForward,
+				PageSize:  10,
+			}
+			// Snapshot: JS only has seqs 1..100; cursor.Seq=200 > lastSeq=100 → STALE.
+			snap := newSnapshotForTest(1, 100)
+			_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeTrue(),
+				"cursor seq beyond JS range must be STALE")
+		})
+
+		It("returns ErrCursorStale when cursor seq is below JS snapshot firstSeq (retention aged out)", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			// Snapshot: JS has seq=10..100; cursor points to seq=5 which is below firstSeq.
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCHHH0000000000H")
+			// No cold row for the cursor seq (absent from cold).
+			insertIntegrationAuditRow(pool, integrationULID(8000001), subject, 99)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  5,
+				AfterID:   integrationULID(8000005),
+				Direction: eventbus.DirectionForward,
+				PageSize:  10,
+			}
+			// Snapshot: firstSeq=10 > cursorSeq=5 → not in LAG range → STALE.
+			snap := newSnapshotForTest(10, 100)
+			_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeTrue(),
+				"cursor seq below JS firstSeq must be STALE (retention aged it out)")
+		})
+
+		It("propagates snapshot error unchanged, not classified as cursor error", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			// Insert one row so the query reaches the cursor-validation branch.
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCIII0000000000I")
+			insertIntegrationAuditRow(pool, integrationULID(9000001), subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  50,
+				AfterID:   integrationULID(9000050),
+				Direction: eventbus.DirectionForward,
+				PageSize:  10,
+			}
+			snapErr := oops.Code("EVENTBUS_HISTORY_STREAM_LOOKUP_FAILED").Errorf("js unreachable")
+			snap := newErrorSnapshotForTest(snapErr)
+			_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, snap)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeFalse(),
+				"snapshot error must not be classified as ErrCursorStale")
+			Expect(errors.Is(err, eventbus.ErrCursorLag)).To(BeFalse(),
+				"snapshot error must not be classified as ErrCursorLag")
+			Expect(errors.Is(err, snapErr)).To(BeTrue())
+		})
+
+		It("returns ErrCursorStale when no snapshot and cursor seq is missing", func() {
+			pool := newIntegrationPool()
+			ctx := context.Background()
+
+			subject := eventbus.Subject("events.main.location.01HXTESTLOCGGG0000000000G")
+			insertIntegrationAuditRow(pool, integrationULID(7000001), subject, 1)
+
+			tier := newPostgresColdTier(pool)
+			q := eventbus.HistoryQuery{
+				Subject:   subject,
+				AfterSeq:  50,
+				AfterID:   integrationULID(7000050),
+				Direction: eventbus.DirectionForward,
+				PageSize:  10,
+			}
+			// No snapshot — falls back to STALE.
+			_, err := tier.Read(ctx, q, time.Time{}, q.PageSize, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, eventbus.ErrCursorStale)).To(BeTrue(),
+				"without snapshot, missing cursor must be STALE")
+		})
+	})
+
+	Describe("LookupByID", func() {
+		It("returns Envelope with correct EventID, KeyID, and KeyVersion from cold tier row", func() {
+			pool := newIntegrationPool()
+
+			eventID := integrationULID(10000001)
+			insertIntegrationColdRowWithDEK(pool, eventID, "events.g1.scene.A.ic", "scene.event", 42, 7)
+
+			tier := newPostgresColdTier(pool)
+			env, found, err := tier.LookupByID(context.Background(), eventID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(env.EventID()).To(Equal(eventID))
+			Expect(env.KeyID()).To(Equal(codec.KeyID(42)))
+			Expect(env.KeyVersion()).To(Equal(uint32(7)))
+		})
+
+		It("returns (zero, false, nil) when no row exists for the given event ID", func() {
+			pool := newIntegrationPool()
+
+			tier := newPostgresColdTier(pool)
+			nonExistent := integrationULID(99999999)
+			_, found, err := tier.LookupByID(context.Background(), nonExistent)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
+		})
+	})
+})

--- a/internal/eventbus/history/cold_postgres_integration_test.go
+++ b/internal/eventbus/history/cold_postgres_integration_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
-	"github.com/samber/oops"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/samber/oops"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 

--- a/internal/eventbus/history/history_suite_test.go
+++ b/internal/eventbus/history/history_suite_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package history
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+)
+
+func TestHistoryIntegration(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "History Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+})

--- a/internal/totp/repo_integration_test.go
+++ b/internal/totp/repo_integration_test.go
@@ -122,14 +122,29 @@ var _ = Describe("TOTPRepository", func() {
 				},
 			}
 
-			// First call succeeds.
-			err := repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
-			Expect(err).NotTo(HaveOccurred(), "first BootstrapEnrollAtomic should succeed")
+			// Pre-enroll so that BootstrapEnrollAtomic's InsertEnrollment
+			// step fails on duplicate player_id (PK violation on
+			// totp_enrollments.player_id). This forces the rollback path.
+			Expect(repo.InsertEnrollment(ctx, rec)).NotTo(HaveOccurred(),
+				"setup: pre-enrolling player_id should succeed")
 
-			// Second call with same key must fail with TOTP_BOOTSTRAP_CONSUMED.
-			err = repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
-			Expect(err).To(HaveOccurred())
-			errutil.AssertErrorCode(suiteT, err, "TOTP_BOOTSTRAP_CONSUMED")
+			// BootstrapEnrollAtomic must fail during the InsertEnrollment
+			// step (duplicate PK) and roll back the BootstrapClaim it just
+			// inserted in the same transaction.
+			err := repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
+			Expect(err).To(HaveOccurred(),
+				"BootstrapEnrollAtomic must fail when InsertEnrollment hits duplicate player_id")
+
+			// Rollback assertion: the bootstrap claim was NOT persisted,
+			// so a different player can still successfully claim the same
+			// key. If the rollback were broken, the claim row would
+			// survive and this call would return TOTP_BOOTSTRAP_CONSUMED.
+			otherPID := ulid.Make().String()
+			insertTOTPPlayer(pool, otherPID, "uatm_other_"+otherPID)
+			ok, claimErr := repo.BootstrapClaim(ctx, key, otherPID, now)
+			Expect(claimErr).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue(),
+				"BootstrapClaim should still win for a different player after the prior atomic call rolled back")
 		})
 	})
 

--- a/internal/totp/repo_integration_test.go
+++ b/internal/totp/repo_integration_test.go
@@ -180,6 +180,7 @@ var _ = Describe("TOTPRepository", func() {
 
 			_, err := repo.PlayerIDFromUsername(ctx, "no_such_user_ever")
 			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "TOTP_REPO_PLAYER_NOT_FOUND")
 		})
 	})
 

--- a/internal/totp/repo_integration_test.go
+++ b/internal/totp/repo_integration_test.go
@@ -129,11 +129,13 @@ var _ = Describe("TOTPRepository", func() {
 				"setup: pre-enrolling player_id should succeed")
 
 			// BootstrapEnrollAtomic must fail during the InsertEnrollment
-			// step (duplicate PK) and roll back the BootstrapClaim it just
-			// inserted in the same transaction.
+			// step (duplicate PK on player_totp.player_id, wrapped in
+			// TOTP_REPO_INSERT_TOTP at repo.go:168) and roll back the
+			// BootstrapClaim it just inserted in the same transaction.
 			err := repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
 			Expect(err).To(HaveOccurred(),
 				"BootstrapEnrollAtomic must fail when InsertEnrollment hits duplicate player_id")
+			errutil.AssertErrorCode(suiteT, err, "TOTP_REPO_INSERT_TOTP")
 
 			// Rollback assertion: the bootstrap claim was NOT persisted,
 			// so a different player can still successfully claim the same

--- a/internal/totp/repo_integration_test.go
+++ b/internal/totp/repo_integration_test.go
@@ -7,74 +7,42 @@ package totp_test
 
 import (
 	"context"
-	"os"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
-	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/internal/totp"
 	"github.com/holomush/holomush/pkg/errutil"
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// testPool is the shared database pool for integration tests.
-var testPool *pgxpool.Pool
-
-// TestMain sets up a PostgreSQL testcontainer for integration tests.
-func TestMain(m *testing.M) {
-	ctx := context.Background()
-
-	pgEnv, err := testutil.StartPostgres(ctx)
-	if err != nil {
-		panic("failed to start postgres container: " + err.Error())
-	}
-
-	migrator, err := store.NewMigrator(pgEnv.ConnStr)
-	if err != nil {
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to create migrator: " + err.Error())
-	}
-	if err := migrator.Up(); err != nil {
-		_ = migrator.Close()
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to run migrations: " + err.Error())
-	}
-	_ = migrator.Close()
-
-	pool, err := pgxpool.New(ctx, pgEnv.ConnStr)
-	if err != nil {
-		_ = pgEnv.Terminate(ctx)
-		panic("failed to create pool: " + err.Error())
-	}
-
-	testPool = pool
-
-	code := m.Run()
-
-	pool.Close()
-	_ = pgEnv.Terminate(ctx)
-
-	os.Exit(code)
+// newTOTPPool opens a pgxpool against a fresh migrated test database.
+// Each spec gets its own isolated database.
+func newTOTPPool() *pgxpool.Pool {
+	GinkgoHelper()
+	connStr := testutil.FreshDatabase(suiteT, sharedPG)
+	pool, err := pgxpool.New(context.Background(), connStr)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
+	return pool
 }
 
-// insertPlayer inserts a minimal player row for use as a foreign-key anchor.
-func insertPlayer(t *testing.T, pool *pgxpool.Pool, id, username string) {
-	t.Helper()
+// insertTOTPPlayer inserts a minimal player row for use as a foreign-key anchor.
+func insertTOTPPlayer(pool *pgxpool.Pool, id, username string) {
+	GinkgoHelper()
 	ctx := context.Background()
 	_, err := pool.Exec(
 		ctx,
 		`INSERT INTO players (id, username, password_hash) VALUES ($1, $2, $3)`,
 		id, username, "hash-placeholder",
 	)
-	require.NoError(t, err, "insertPlayer")
-	t.Cleanup(func() {
-		_, _ = pool.Exec(ctx, `DELETE FROM players WHERE id = $1`, id)
+	Expect(err).NotTo(HaveOccurred(), "insertTOTPPlayer")
+	DeferCleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM players WHERE id = $1`, id)
 	})
 }
 
@@ -87,315 +55,307 @@ func (fakeHasher) Verify(rawCode, encodedHash string) (bool, error) {
 	return rawCode == encodedHash, nil
 }
 
-// --- INV-A2: concurrent BootstrapClaim atomicity ---
+var _ = Describe("TOTPRepository", func() {
+	Describe("BootstrapClaim concurrent atomicity (INV-A2)", func() {
+		It("exactly one goroutine wins when N goroutines race to claim the same bootstrap key", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-// TestRepoBootstrapClaimConcurrentExactlyOneSucceeds verifies INV-A2: when N
-// goroutines race to claim the same bootstrap key, exactly one succeeds.
-func TestRepoBootstrapClaimConcurrentExactlyOneSucceeds(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	const N = 8
-	players := make([]string, N)
-	for i := range players {
-		players[i] = ulid.Make().String()
-		insertPlayer(t, testPool, players[i], "u"+players[i])
-	}
-
-	now := time.Now().UTC()
-	key := "totp_v1_concurrent_" + ulid.Make().String() // unique per test run
-	var (
-		wg        sync.WaitGroup
-		successes int
-		mu        sync.Mutex
-	)
-	wg.Add(N)
-	for i := 0; i < N; i++ {
-		pid := players[i]
-		go func() {
-			defer wg.Done()
-			ok, err := repo.BootstrapClaim(ctx, key, pid, now)
-			// Don't use require.NoError here — t.FailNow must be called only
-			// from the goroutine running the test; mark + return instead.
-			if err != nil {
-				mu.Lock()
-				t.Errorf("BootstrapClaim returned error: %v", err)
-				mu.Unlock()
-				return
+			const N = 8
+			players := make([]string, N)
+			for i := range players {
+				players[i] = ulid.Make().String()
+				insertTOTPPlayer(pool, players[i], "u"+players[i])
 			}
-			if ok {
-				mu.Lock()
-				successes++
-				mu.Unlock()
+
+			now := time.Now().UTC()
+			key := "totp_v1_concurrent_" + ulid.Make().String() // unique per test run
+			var (
+				wg        sync.WaitGroup
+				successes int
+				errs      []error
+				mu        sync.Mutex
+			)
+			wg.Add(N)
+			for i := 0; i < N; i++ {
+				pid := players[i]
+				go func() {
+					defer wg.Done()
+					ok, err := repo.BootstrapClaim(ctx, key, pid, now)
+					mu.Lock()
+					defer mu.Unlock()
+					if err != nil {
+						errs = append(errs, err)
+						return
+					}
+					if ok {
+						successes++
+					}
+				}()
 			}
-		}()
-	}
-	wg.Wait()
-	assert.Equal(t, 1, successes, "exactly one BootstrapClaim must win (INV-A2)")
-}
-
-// --- BootstrapEnrollAtomic rollback ---
-
-// TestRepoBootstrapEnrollAtomicRollsBackOnInsertError verifies that when
-// InsertEnrollment fails (duplicate player_id), the BootstrapClaim row is
-// also rolled back, leaving the key available for re-claim.
-func TestRepoBootstrapEnrollAtomicRollsBackOnInsertError(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "uatm"+pid)
-
-	now := time.Now().UTC()
-	key := "totp_atomic_rollback_" + ulid.Make().String()
-
-	rec := totp.EnrollmentRecord{
-		PlayerID:      pid,
-		WrappedSecret: []byte("secret"),
-		WrapKeyID:     "wk1",
-		EnrolledAt:    now,
-		RecoveryCodes: []totp.HashedRecoveryCode{
-			{ID: ulid.Make(), CodeHash: "code1", CreatedAt: now},
-		},
-	}
-
-	// First call succeeds.
-	err := repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
-	require.NoError(t, err, "first BootstrapEnrollAtomic should succeed")
-
-	// Second call with same key must fail with TOTP_BOOTSTRAP_CONSUMED.
-	err = repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "TOTP_BOOTSTRAP_CONSUMED")
-}
-
-// --- PlayerExists ---
-
-// TestRepoPlayerExistsReturnsTrueForExistingPlayer verifies the happy path.
-func TestRepoPlayerExistsReturnsTrueForExistingPlayer(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "upex"+pid)
-
-	exists, err := repo.PlayerExists(ctx, pid)
-	require.NoError(t, err)
-	assert.True(t, exists)
-}
-
-// TestRepoPlayerExistsReturnsFalseForMissingPlayer verifies the not-found path.
-func TestRepoPlayerExistsReturnsFalseForMissingPlayer(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	exists, err := repo.PlayerExists(ctx, ulid.Make().String())
-	require.NoError(t, err)
-	assert.False(t, exists)
-}
-
-// --- PlayerIDFromUsername ---
-
-// TestRepoPlayerIDFromUsernameReturnsIDForKnownUsername verifies the happy path.
-func TestRepoPlayerIDFromUsernameReturnsIDForKnownUsername(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	pid := ulid.Make().String()
-	username := "uname_" + pid[:6]
-	insertPlayer(t, testPool, pid, username)
-
-	got, err := repo.PlayerIDFromUsername(ctx, username)
-	require.NoError(t, err)
-	assert.Equal(t, pid, got)
-}
-
-// TestRepoPlayerIDFromUsernameReturnsErrorForUnknownUsername verifies error on miss.
-func TestRepoPlayerIDFromUsernameReturnsErrorForUnknownUsername(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	_, err := repo.PlayerIDFromUsername(ctx, "no_such_user_ever")
-	require.Error(t, err)
-}
-
-// --- InsertEnrollment round-trip ---
-
-// TestRepoInsertEnrollmentRoundTrip verifies that an enrollment written by
-// InsertEnrollment is subsequently readable via IsEnrolled and LoadEnrollment.
-func TestRepoInsertEnrollmentRoundTrip(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
-
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "uins"+pid)
-
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	rec := totp.EnrollmentRecord{
-		PlayerID:      pid,
-		WrappedSecret: []byte("mysecret"),
-		WrapKeyID:     "wk-test",
-		EnrolledAt:    now,
-		RecoveryCodes: []totp.HashedRecoveryCode{
-			{ID: ulid.Make(), CodeHash: "h1", CreatedAt: now},
-			{ID: ulid.Make(), CodeHash: "h2", CreatedAt: now},
-		},
-	}
-	err := repo.InsertEnrollment(ctx, rec)
-	require.NoError(t, err)
-
-	enrolled, err := repo.IsEnrolled(ctx, pid)
-	require.NoError(t, err)
-	assert.True(t, enrolled)
-
-	// LoadEnrollment requires a transaction (FOR UPDATE).
-	var state totp.VerifyState
-	txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
-		var e error
-		state, e = repo.LoadEnrollment(txCtx, pid)
-		return e
+			wg.Wait()
+			Expect(errs).To(BeEmpty(), "BootstrapClaim goroutines returned errors")
+			Expect(successes).To(Equal(1), "exactly one BootstrapClaim must win (INV-A2)")
+		})
 	})
-	require.NoError(t, txErr)
-	assert.Equal(t, pid, state.PlayerID)
-	assert.Equal(t, []byte("mysecret"), state.WrappedSecret)
-	assert.Equal(t, "wk-test", state.WrapKeyID)
-	assert.Equal(t, 0, state.FailedAttempts)
-	assert.Nil(t, state.LockedUntil)
-}
 
-// --- LoadEnrollment ErrNotEnrolled ---
+	Describe("BootstrapEnrollAtomic rollback", func() {
+		It("rolls back BootstrapClaim when InsertEnrollment fails with duplicate player_id", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-// TestRepoLoadEnrollmentReturnsErrNotEnrolled verifies that LoadEnrollment
-// returns ErrNotEnrolled when no enrollment exists for the player.
-func TestRepoLoadEnrollmentReturnsErrNotEnrolled(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "uatm"+pid)
 
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "ulen"+pid)
+			now := time.Now().UTC()
+			key := "totp_atomic_rollback_" + ulid.Make().String()
 
-	txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
-		_, err := repo.LoadEnrollment(txCtx, pid)
-		return err
+			rec := totp.EnrollmentRecord{
+				PlayerID:      pid,
+				WrappedSecret: []byte("secret"),
+				WrapKeyID:     "wk1",
+				EnrolledAt:    now,
+				RecoveryCodes: []totp.HashedRecoveryCode{
+					{ID: ulid.Make(), CodeHash: "code1", CreatedAt: now},
+				},
+			}
+
+			// First call succeeds.
+			err := repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
+			Expect(err).NotTo(HaveOccurred(), "first BootstrapEnrollAtomic should succeed")
+
+			// Second call with same key must fail with TOTP_BOOTSTRAP_CONSUMED.
+			err = repo.BootstrapEnrollAtomic(ctx, key, pid, rec)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "TOTP_BOOTSTRAP_CONSUMED")
+		})
 	})
-	errutil.AssertErrorCode(t, txErr, "TOTP_NOT_ENROLLED")
-}
 
-// --- MarkVerified ---
+	Describe("PlayerExists", func() {
+		It("returns true for an existing player", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-// TestRepoMarkVerifiedResetsLockoutFields verifies that MarkVerified zeroes
-// failed_attempts, clears locked_until, and sets last_used_step.
-func TestRepoMarkVerifiedResetsLockoutFields(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "upex"+pid)
 
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "umv"+pid)
+			exists, err := repo.PlayerExists(ctx, pid)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	rec := totp.EnrollmentRecord{
-		PlayerID:      pid,
-		WrappedSecret: []byte("s"),
-		WrapKeyID:     "k",
-		EnrolledAt:    now,
-	}
-	require.NoError(t, repo.InsertEnrollment(ctx, rec))
+		It("returns false for a missing player", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-	// Artificially set failed_attempts and locked_until.
-	_, err := testPool.Exec(
-		ctx,
-		`UPDATE player_totp SET failed_attempts = 5, locked_until = $1 WHERE player_id = $2`,
-		now.Add(15*time.Minute), pid,
-	)
-	require.NoError(t, err)
-
-	step := int64(42)
-	require.NoError(t, repo.MarkVerified(ctx, pid, step, now))
-
-	var state totp.VerifyState
-	txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
-		var e error
-		state, e = repo.LoadEnrollment(txCtx, pid)
-		return e
+			exists, err := repo.PlayerExists(ctx, ulid.Make().String())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
 	})
-	require.NoError(t, txErr)
-	assert.Equal(t, 0, state.FailedAttempts)
-	assert.Nil(t, state.LockedUntil)
-	require.NotNil(t, state.LastUsedStep)
-	assert.Equal(t, step, *state.LastUsedStep)
-}
 
-// --- ConsumeRecoveryCode single-use ---
+	Describe("PlayerIDFromUsername", func() {
+		It("returns player ID for a known username", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-// TestRepoConsumeRecoveryCodeSingleUse verifies that a recovery code can only
-// be consumed once; the second attempt returns ErrInvalidRecoveryCode.
-func TestRepoConsumeRecoveryCodeSingleUse(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
+			pid := ulid.Make().String()
+			username := "uname_" + pid[:6]
+			insertTOTPPlayer(pool, pid, username)
 
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "ucrc"+pid)
+			got, err := repo.PlayerIDFromUsername(ctx, username)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(pid))
+		})
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	rawCode := "test-recovery-code"
-	codeID := ulid.Make()
-	rec := totp.EnrollmentRecord{
-		PlayerID:      pid,
-		WrappedSecret: []byte("s"),
-		WrapKeyID:     "k",
-		EnrolledAt:    now,
-		RecoveryCodes: []totp.HashedRecoveryCode{
-			// fakeHasher stores the raw value as the hash.
-			{ID: codeID, CodeHash: rawCode, CreatedAt: now},
-		},
-	}
-	require.NoError(t, repo.InsertEnrollment(ctx, rec))
+		It("returns an error for an unknown username", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-	hasher := fakeHasher{}
+			_, err := repo.PlayerIDFromUsername(ctx, "no_such_user_ever")
+			Expect(err).To(HaveOccurred())
+		})
+	})
 
-	// First consume succeeds and returns the right ULID.
-	gotID, err := repo.ConsumeRecoveryCode(ctx, pid, rawCode, hasher, now)
-	require.NoError(t, err)
-	assert.Equal(t, codeID, gotID)
+	Describe("InsertEnrollment round-trip", func() {
+		It("enrollment written by InsertEnrollment is readable via IsEnrolled and LoadEnrollment", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-	// Second consume on the same code must fail.
-	_, err = repo.ConsumeRecoveryCode(ctx, pid, rawCode, hasher, now)
-	errutil.AssertErrorCode(t, err, "TOTP_INVALID_RECOVERY_CODE")
-}
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "uins"+pid)
 
-// --- ClearEnrollment ---
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			rec := totp.EnrollmentRecord{
+				PlayerID:      pid,
+				WrappedSecret: []byte("mysecret"),
+				WrapKeyID:     "wk-test",
+				EnrolledAt:    now,
+				RecoveryCodes: []totp.HashedRecoveryCode{
+					{ID: ulid.Make(), CodeHash: "h1", CreatedAt: now},
+					{ID: ulid.Make(), CodeHash: "h2", CreatedAt: now},
+				},
+			}
+			err := repo.InsertEnrollment(ctx, rec)
+			Expect(err).NotTo(HaveOccurred())
 
-// TestRepoClearEnrollmentReturnsWasEnrolled verifies that ClearEnrollment
-// returns wasEnrolled=true for an enrolled player and false for a non-enrolled player.
-func TestRepoClearEnrollmentReturnsWasEnrolled(t *testing.T) {
-	repo := totp.NewRepository(testPool)
-	ctx := context.Background()
+			enrolled, err := repo.IsEnrolled(ctx, pid)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enrolled).To(BeTrue())
 
-	// Enrolled player.
-	pid := ulid.Make().String()
-	insertPlayer(t, testPool, pid, "uclea"+pid)
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	require.NoError(t, repo.InsertEnrollment(ctx, totp.EnrollmentRecord{
-		PlayerID:      pid,
-		WrappedSecret: []byte("s"),
-		WrapKeyID:     "k",
-		EnrolledAt:    now,
-	}))
+			// LoadEnrollment requires a transaction (FOR UPDATE).
+			var state totp.VerifyState
+			txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
+				var e error
+				state, e = repo.LoadEnrollment(txCtx, pid)
+				return e
+			})
+			Expect(txErr).NotTo(HaveOccurred())
+			Expect(state.PlayerID).To(Equal(pid))
+			Expect(state.WrappedSecret).To(Equal([]byte("mysecret")))
+			Expect(state.WrapKeyID).To(Equal("wk-test"))
+			Expect(state.FailedAttempts).To(Equal(0))
+			Expect(state.LockedUntil).To(BeNil())
+		})
+	})
 
-	wasEnrolled, err := repo.ClearEnrollment(ctx, pid)
-	require.NoError(t, err)
-	assert.True(t, wasEnrolled, "ClearEnrollment should return wasEnrolled=true")
+	Describe("LoadEnrollment ErrNotEnrolled", func() {
+		It("returns TOTP_NOT_ENROLLED when no enrollment exists for the player", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
 
-	// Confirm enrollment is gone.
-	enrolled, err := repo.IsEnrolled(ctx, pid)
-	require.NoError(t, err)
-	assert.False(t, enrolled)
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "ulen"+pid)
 
-	// Not-enrolled player.
-	pid2 := ulid.Make().String()
-	insertPlayer(t, testPool, pid2, "ucleb"+pid2)
+			txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
+				_, err := repo.LoadEnrollment(txCtx, pid)
+				return err
+			})
+			errutil.AssertErrorCode(suiteT, txErr, "TOTP_NOT_ENROLLED")
+		})
+	})
 
-	wasEnrolled2, err := repo.ClearEnrollment(ctx, pid2)
-	require.NoError(t, err)
-	assert.False(t, wasEnrolled2, "ClearEnrollment on non-enrolled player should return wasEnrolled=false")
-}
+	Describe("MarkVerified", func() {
+		It("zeroes failed_attempts, clears locked_until, and sets last_used_step", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
+
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "umv"+pid)
+
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			rec := totp.EnrollmentRecord{
+				PlayerID:      pid,
+				WrappedSecret: []byte("s"),
+				WrapKeyID:     "k",
+				EnrolledAt:    now,
+			}
+			Expect(repo.InsertEnrollment(ctx, rec)).NotTo(HaveOccurred())
+
+			// Artificially set failed_attempts and locked_until.
+			_, err := pool.Exec(
+				ctx,
+				`UPDATE player_totp SET failed_attempts = 5, locked_until = $1 WHERE player_id = $2`,
+				now.Add(15*time.Minute), pid,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			step := int64(42)
+			Expect(repo.MarkVerified(ctx, pid, step, now)).NotTo(HaveOccurred())
+
+			var state totp.VerifyState
+			txErr := repo.InTransaction(ctx, func(txCtx context.Context) error {
+				var e error
+				state, e = repo.LoadEnrollment(txCtx, pid)
+				return e
+			})
+			Expect(txErr).NotTo(HaveOccurred())
+			Expect(state.FailedAttempts).To(Equal(0))
+			Expect(state.LockedUntil).To(BeNil())
+			Expect(state.LastUsedStep).NotTo(BeNil())
+			Expect(*state.LastUsedStep).To(Equal(step))
+		})
+	})
+
+	Describe("ConsumeRecoveryCode single-use", func() {
+		It("recovery code can only be consumed once; second attempt returns TOTP_INVALID_RECOVERY_CODE", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
+
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "ucrc"+pid)
+
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			rawCode := "test-recovery-code"
+			codeID := ulid.Make()
+			rec := totp.EnrollmentRecord{
+				PlayerID:      pid,
+				WrappedSecret: []byte("s"),
+				WrapKeyID:     "k",
+				EnrolledAt:    now,
+				RecoveryCodes: []totp.HashedRecoveryCode{
+					// fakeHasher stores the raw value as the hash.
+					{ID: codeID, CodeHash: rawCode, CreatedAt: now},
+				},
+			}
+			Expect(repo.InsertEnrollment(ctx, rec)).NotTo(HaveOccurred())
+
+			hasher := fakeHasher{}
+
+			// First consume succeeds and returns the right ULID.
+			gotID, err := repo.ConsumeRecoveryCode(ctx, pid, rawCode, hasher, now)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotID).To(Equal(codeID))
+
+			// Second consume on the same code must fail.
+			_, err = repo.ConsumeRecoveryCode(ctx, pid, rawCode, hasher, now)
+			errutil.AssertErrorCode(suiteT, err, "TOTP_INVALID_RECOVERY_CODE")
+		})
+	})
+
+	Describe("ClearEnrollment", func() {
+		It("returns wasEnrolled=true for enrolled player and false for non-enrolled player", func() {
+			pool := newTOTPPool()
+			repo := totp.NewRepository(pool)
+			ctx := context.Background()
+
+			// Enrolled player.
+			pid := ulid.Make().String()
+			insertTOTPPlayer(pool, pid, "uclea"+pid)
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			Expect(repo.InsertEnrollment(ctx, totp.EnrollmentRecord{
+				PlayerID:      pid,
+				WrappedSecret: []byte("s"),
+				WrapKeyID:     "k",
+				EnrolledAt:    now,
+			})).NotTo(HaveOccurred())
+
+			wasEnrolled, err := repo.ClearEnrollment(ctx, pid)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wasEnrolled).To(BeTrue(), "ClearEnrollment should return wasEnrolled=true")
+
+			// Confirm enrollment is gone.
+			enrolled, err := repo.IsEnrolled(ctx, pid)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enrolled).To(BeFalse())
+
+			// Not-enrolled player.
+			pid2 := ulid.Make().String()
+			insertTOTPPlayer(pool, pid2, "ucleb"+pid2)
+
+			wasEnrolled2, err := repo.ClearEnrollment(ctx, pid2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wasEnrolled2).To(BeFalse(), "ClearEnrollment on non-enrolled player should return wasEnrolled=false")
+		})
+	})
+})

--- a/internal/totp/totp_suite_test.go
+++ b/internal/totp/totp_suite_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package totp_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+)
+
+func TestTOTPIntegration(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TOTP Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+})

--- a/plugins/core-scenes/core_scenes_suite_test.go
+++ b/plugins/core-scenes/core_scenes_suite_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/test/testutil"
+)
+
+var (
+	suiteT   *testing.T
+	sharedPG *testutil.PostgresEnv
+)
+
+func TestCoreScenesIntegration(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Core Scenes Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	sharedPG = testutil.SharedPostgres(suiteT)
+})

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -1609,7 +1609,8 @@ var _ = Describe("SceneStore", func() {
 	})
 
 	Describe("IsMember", func() {
-		DescribeTable("returns expected result by role and scene state",
+		DescribeTable(
+			"returns expected result by role and scene state",
 			func(sceneID string, visible SceneVisibility, setupFn func(*SceneStore), probe string, want bool, wantMsg string) {
 				store := newTestStore()
 				ctx := context.Background()
@@ -1636,12 +1637,14 @@ var _ = Describe("SceneStore", func() {
 					Expect(got).To(Equal(want))
 				}
 			},
-			Entry("returns true for owner",
+			Entry(
+				"returns true for owner",
 				"scene-isM-1", SceneVisibilityOpen,
 				nil,
 				"char-alice", true, "owner MUST be reported as member",
 			),
-			Entry("returns true for joined member",
+			Entry(
+				"returns true for joined member",
 				"scene-isM-2", SceneVisibilityOpen,
 				func(store *SceneStore) {
 					_, _, err := store.AddParticipant(context.Background(), "scene-isM-2", "char-bob")
@@ -1649,7 +1652,8 @@ var _ = Describe("SceneStore", func() {
 				},
 				"char-bob", true, "",
 			),
-			Entry("returns false for invited-only",
+			Entry(
+				"returns false for invited-only",
 				"scene-isM-3", SceneVisibilityPrivate,
 				func(store *SceneStore) {
 					_, err := store.InviteParticipant(context.Background(), "scene-isM-3", "char-alice", "char-bob")
@@ -1657,12 +1661,14 @@ var _ = Describe("SceneStore", func() {
 				},
 				"char-bob", false, "invited-only rows MUST return false — invitation grants join, not read",
 			),
-			Entry("returns false for non-participant",
+			Entry(
+				"returns false for non-participant",
 				"scene-isM-4", SceneVisibilityOpen,
 				nil,
 				"char-stranger", false, "",
 			),
-			Entry("returns false for missing scene",
+			Entry(
+				"returns false for missing scene",
 				"scene-isM-missing", SceneVisibility(""), // sentinel: skip scene creation
 				nil,
 				"char-alice", false, "missing scene MUST be nil error per spec §5.4 (info-hiding)",

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -12,12 +12,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
 	"github.com/holomush/holomush/pkg/errutil"
 	"github.com/holomush/holomush/test/testutil"
@@ -31,18 +30,17 @@ import (
 // creates a legacy scene_participants table with FK to locations(id), which
 // conflicts with the plugin's scene_participants that references scenes(id).
 // A blank database avoids the conflict and lets the plugin own its schema.
-func newTestStore(t *testing.T) *SceneStore {
-	t.Helper()
+func newTestStore() *SceneStore {
+	GinkgoHelper()
 
 	setupCtx, cancelSetup := context.WithTimeout(context.Background(), 2*time.Minute)
-	t.Cleanup(cancelSetup)
+	DeferCleanup(cancelSetup)
 
-	shared := testutil.SharedPostgres(t)
-	connStr := testutil.RawDatabase(t, shared)
+	connStr := testutil.RawDatabase(suiteT, sharedPG)
 
 	store, err := NewSceneStore(setupCtx, connStr)
-	require.NoError(t, err, "failed to open scene store")
-	t.Cleanup(store.Close)
+	Expect(err).NotTo(HaveOccurred(), "failed to open scene store")
+	DeferCleanup(store.Close)
 
 	return store
 }
@@ -50,9 +48,9 @@ func newTestStore(t *testing.T) *SceneStore {
 // mustCreateScene inserts a minimal scene row directly via the store's
 // Phase 1 Create method. Used by Phase 3 tests that need a pre-existing
 // scene but don't care about the participant/ops event side effects of
-// CreateWithOwner. Once Task 5 lands, prefer mustCreateSceneWithOwner.
-func mustCreateScene(t *testing.T, store *SceneStore, sceneID, ownerID, visibility string) *SceneRow {
-	t.Helper()
+// CreateWithOwner.
+func mustCreateScene(store *SceneStore, sceneID, ownerID, visibility string) *SceneRow {
+	GinkgoHelper()
 	row := &SceneRow{
 		ID:              sceneID,
 		Title:           "Test Scene " + sceneID,
@@ -63,59 +61,51 @@ func mustCreateScene(t *testing.T, store *SceneStore, sceneID, ownerID, visibili
 		ContentWarnings: []string{},
 		Tags:            []string{},
 	}
-	require.NoError(t, store.Create(context.Background(), row))
+	Expect(store.Create(context.Background(), row)).NotTo(HaveOccurred())
 	return row
 }
 
 // assertParticipantRowExists asserts that a row exists in scene_participants
-// for the given (sceneID, characterID) pair with the expected role. Queries
-// the database directly rather than going through any store method, so the
-// assertion is independent of the methods under test.
-func assertParticipantRowExists(t *testing.T, store *SceneStore, sceneID, characterID, expectedRole string) {
-	t.Helper()
+// for the given (sceneID, characterID) pair with the expected role.
+func assertParticipantRowExists(store *SceneStore, sceneID, characterID, expectedRole string) {
+	GinkgoHelper()
 	var role string
 	err := store.pool.QueryRow(
 		context.Background(),
 		`SELECT role FROM scene_participants WHERE scene_id = $1 AND character_id = $2`,
 		sceneID, characterID,
 	).Scan(&role)
-	require.NoError(t, err, "expected participant row for (%s, %s) but query failed", sceneID, characterID)
-	assert.Equal(t, expectedRole, role)
+	Expect(err).NotTo(HaveOccurred(), "expected participant row for (%s, %s) but query failed", sceneID, characterID)
+	Expect(role).To(Equal(expectedRole))
 }
 
 // assertParticipantRowAbsent asserts that no row exists in scene_participants
-// for the given (sceneID, characterID) pair. Used to verify deletes.
-func assertParticipantRowAbsent(t *testing.T, store *SceneStore, sceneID, characterID string) {
-	t.Helper()
+// for the given (sceneID, characterID) pair.
+func assertParticipantRowAbsent(store *SceneStore, sceneID, characterID string) {
+	GinkgoHelper()
 	var role string
 	err := store.pool.QueryRow(
 		context.Background(),
 		`SELECT role FROM scene_participants WHERE scene_id = $1 AND character_id = $2`,
 		sceneID, characterID,
 	).Scan(&role)
-	assert.ErrorIs(t, err, pgx.ErrNoRows, "expected participant row for (%s, %s) to be absent", sceneID, characterID)
+	Expect(err).To(MatchError(pgx.ErrNoRows), "expected participant row for (%s, %s) to be absent", sceneID, characterID)
 }
 
 // assertOpsEventRecorded asserts that EXACTLY one row exists in
 // scene_ops_events for the given scene with the given kind. Returns the
 // payload JSON for the caller to inspect kind-specific fields.
-//
-// The count check is required to catch duplicate-emission bugs: a previous
-// version of this helper used `ORDER BY ... LIMIT 1` which silently passed
-// when a mutation accidentally emitted the same ops event twice. The
-// idempotent-retry contract (P3.D5) requires "exactly one event per
-// successful mutation, zero events for OpNoChange retries".
-func assertOpsEventRecorded(t *testing.T, store *SceneStore, sceneID string, kind OpsEventKind, expectedActor, expectedTarget string) map[string]any {
-	t.Helper()
+func assertOpsEventRecorded(store *SceneStore, sceneID string, kind OpsEventKind, expectedActor, expectedTarget string) map[string]any {
+	GinkgoHelper()
 
 	// Step 1: assert exactly one matching row exists.
 	var count int
-	require.NoError(t, store.pool.QueryRow(
+	Expect(store.pool.QueryRow(
 		context.Background(),
 		`SELECT COUNT(*) FROM scene_ops_events WHERE scene_id = $1 AND kind = $2`,
 		sceneID, string(kind),
-	).Scan(&count))
-	require.Equal(t, 1, count, "expected exactly one ops event %s for scene %s, found %d", kind, sceneID, count)
+	).Scan(&count)).NotTo(HaveOccurred())
+	Expect(count).To(Equal(1), "expected exactly one ops event %s for scene %s, found %d", kind, sceneID, count)
 
 	// Step 2: read the single row and verify actor/target/payload.
 	var (
@@ -129,23 +119,23 @@ func assertOpsEventRecorded(t *testing.T, store *SceneStore, sceneID string, kin
 		WHERE scene_id = $1 AND kind = $2`,
 		sceneID, string(kind),
 	).Scan(&actor, &target, &payload)
-	require.NoError(t, err, "expected ops event %s for scene %s but query failed", kind, sceneID)
-	assert.Equal(t, expectedActor, actor)
+	Expect(err).NotTo(HaveOccurred(), "expected ops event %s for scene %s but query failed", kind, sceneID)
+	Expect(actor).To(Equal(expectedActor))
 	if expectedTarget == "" {
-		assert.Nil(t, target)
+		Expect(target).To(BeNil())
 	} else {
-		require.NotNil(t, target)
-		assert.Equal(t, expectedTarget, *target)
+		Expect(target).NotTo(BeNil())
+		Expect(*target).To(Equal(expectedTarget))
 	}
 	var p map[string]any
-	require.NoError(t, json.Unmarshal(payload, &p))
+	Expect(json.Unmarshal(payload, &p)).NotTo(HaveOccurred())
 	return p
 }
 
 // countOpsEvents returns the number of scene_ops_events rows for a scene,
 // optionally filtered by kind. Pass an empty string for kind to count all.
-func countOpsEvents(t *testing.T, store *SceneStore, sceneID string, kind OpsEventKind) int {
-	t.Helper()
+func countOpsEvents(store *SceneStore, sceneID string, kind OpsEventKind) int {
+	GinkgoHelper()
 	var n int
 	var err error
 	if kind == "" {
@@ -161,1630 +151,1522 @@ func countOpsEvents(t *testing.T, store *SceneStore, sceneID string, kind OpsEve
 			sceneID, string(kind),
 		).Scan(&n)
 	}
-	require.NoError(t, err)
+	Expect(err).NotTo(HaveOccurred())
 	return n
 }
 
-func TestSceneStoreCreatePersistsAllSceneFields(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	locationID := "loc-01"
-	row := &SceneRow{
-		ID:              "scene-01HXYZ",
-		Title:           "A Decades-Crossed Meeting",
-		Description:     "Off-grid private meeting",
-		LocationID:      &locationID,
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{"plot", "social"},
-	}
-
-	err := store.Create(ctx, row)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, row.ID, got.ID)
-	assert.Equal(t, row.Title, got.Title)
-	assert.Equal(t, row.Description, got.Description)
-	require.NotNil(t, got.LocationID)
-	assert.Equal(t, locationID, *got.LocationID)
-	assert.Equal(t, row.OwnerID, got.OwnerID)
-	assert.Equal(t, row.State, got.State)
-	assert.Equal(t, row.PoseOrder, got.PoseOrder)
-	assert.Equal(t, row.Visibility, got.Visibility)
-	assert.ElementsMatch(t, row.Tags, got.Tags)
-	assert.NotZero(t, got.CreatedAt)
-}
-
-func TestSceneStoreGetReturnsNotFoundForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-
-	_, err := store.Get(ctx, "scene-does-not-exist")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_FOUND")
-	// Use errutil.AssertErrorContext so the scene_id context is asserted
-	// unconditionally — a conditional errors.As block lets the test pass
-	// silently if the context ever stops being attached.
-	errutil.AssertErrorContext(t, err, "scene_id", "scene-does-not-exist")
-}
-
-func TestSceneStoreCreateRejectsDuplicateID(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-dup",
-		Title:           "Original",
-		OwnerID:         "char-bob",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-
-	err := store.Create(ctx, row)
-	require.NoError(t, err)
-
-	err = store.Create(ctx, row)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_CREATE_FAILED")
-}
-
-func TestSceneStoreEndTransitionsActiveToEnded(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-end-active",
-		Title:           "End from active",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	got, err := store.End(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, string(SceneStateEnded), got.State)
-	require.NotNil(t, got.EndedAt, "ended_at should be set")
-
-	reread, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, got.State, reread.State)
-}
-
-func TestSceneStoreEndTransitionsPausedToEnded(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-end-paused",
-		Title:           "End from paused",
-		OwnerID:         "char-alice",
-		State:           string(SceneStatePaused),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	got, err := store.End(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, string(SceneStateEnded), got.State)
-	require.NotNil(t, got.EndedAt)
-}
-
-func TestSceneStoreEndRejectsAlreadyEnded(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-end-twice",
-		Title:           "Already ended",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateEnded),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	_, err := store.End(ctx, row.ID)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSITION_FORBIDDEN")
-}
-
-func TestSceneStoreEndReturnsNotFoundForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	_, err := store.End(ctx, "scene-does-not-exist")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_FOUND")
-}
-
-func TestSceneStorePauseTransitionsActiveToPaused(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-pause",
-		Title:           "Pause from active",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	got, err := store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, string(SceneStatePaused), got.State)
-}
-
-func TestSceneStorePauseRejectsAlreadyPaused(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-pause-twice",
-		Title:           "Already paused",
-		OwnerID:         "char-alice",
-		State:           string(SceneStatePaused),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	_, err := store.Pause(ctx, row.ID)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSITION_FORBIDDEN")
-}
-
-func TestSceneStoreResumeTransitionsPausedToActive(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-resume",
-		Title:           "Resume from paused",
-		OwnerID:         "char-alice",
-		State:           string(SceneStatePaused),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	got, err := store.Resume(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, string(SceneStateActive), got.State)
-}
-
-func TestSceneStoreResumeRejectsActiveScene(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-resume-active",
-		Title:           "Already active",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	_, err := store.Resume(ctx, row.ID)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSITION_FORBIDDEN")
-}
-
-func TestSceneStoreUpdateAppliesTitleOnly(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-title",
-		Title:           "Original",
-		Description:     "Original description",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{"violence"},
-		Tags:            []string{"plot"},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	newTitle := "Renamed"
-	update := &SceneUpdate{Title: &newTitle}
-	_, err := store.Update(ctx, row.ID, update)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "Renamed", got.Title)
-	assert.Equal(t, "Original description", got.Description)
-	assert.ElementsMatch(t, []string{"violence"}, got.ContentWarnings)
-	assert.ElementsMatch(t, []string{"plot"}, got.Tags)
-}
-
-func TestSceneStoreUpdateAppliesMultipleFields(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-many",
-		Title:           "Title 1",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	title := "Title 2"
-	desc := "New description"
-	vis := "private"
-	update := &SceneUpdate{
-		Title:       &title,
-		Description: &desc,
-		Visibility:  &vis,
-	}
-	_, err := store.Update(ctx, row.ID, update)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "Title 2", got.Title)
-	assert.Equal(t, "New description", got.Description)
-	assert.Equal(t, "private", got.Visibility)
-}
-
-func TestSceneStoreUpdateRepeatedFieldsRespectFlag(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-repeated",
-		Title:           "T",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{"violence"},
-		Tags:            []string{"plot", "social"},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	// Only update content_warnings; leave tags alone.
-	update := &SceneUpdate{
-		ContentWarnings:       []string{"violence", "death"},
-		UpdateContentWarnings: true,
-		Tags:                  nil,
-		UpdateTags:            false, // explicitly NOT updating
-	}
-	_, err := store.Update(ctx, row.ID, update)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"violence", "death"}, got.ContentWarnings)
-	assert.ElementsMatch(t, []string{"plot", "social"}, got.Tags, "tags should be unchanged")
-}
-
-func TestSceneStoreUpdateClearsRepeatedFieldWithEmptySlice(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-clear",
-		Title:           "T",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{"violence"},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	update := &SceneUpdate{
-		ContentWarnings:       []string{},
-		UpdateContentWarnings: true, // explicit clear
-	}
-	_, err := store.Update(ctx, row.ID, update)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Empty(t, got.ContentWarnings, "content_warnings should be cleared to empty slice")
-}
-
-func TestSceneStoreUpdateRejectsEndedScene(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-ended",
-		Title:           "Ended",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateEnded),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	title := "Try to rename"
-	update := &SceneUpdate{Title: &title}
-	_, err := store.Update(ctx, row.ID, update)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSITION_FORBIDDEN")
-}
-
-func TestSceneStoreUpdateReturnsNotFoundForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	title := "Anything"
-	update := &SceneUpdate{Title: &title}
-	_, err := store.Update(ctx, "scene-does-not-exist", update)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_FOUND")
-}
-
-func TestSceneStoreUpdateNoFieldsIsNoOp(t *testing.T) {
-	store := newTestStore(t)
-
-	ctx := context.Background()
-	row := &SceneRow{
-		ID:              "scene-update-noop",
-		Title:           "Unchanged",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.Create(ctx, row))
-
-	// Empty update — no fields specified
-	update := &SceneUpdate{}
-	_, err := store.Update(ctx, row.ID, update)
-	require.NoError(t, err)
-
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "Unchanged", got.Title)
-}
-
-func TestRecordOpsEventTxWritesRowWithExpectedKindAndPayload(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	scene := mustCreateScene(t, store, "scene-ope-1", "char-alice", string(SceneVisibilityOpen))
-
-	tx, err := store.pool.Begin(ctx)
-	require.NoError(t, err)
-	defer tx.Rollback(ctx)
-
-	err = recordOpsEventTx(ctx, tx, scene.ID, OpsKindMembershipJoin, "char-alice", "char-alice",
-		map[string]any{"visibility": "open", "from_invited": false})
-	require.NoError(t, err)
-	require.NoError(t, tx.Commit(ctx))
-
-	payload := assertOpsEventRecorded(t, store, scene.ID, OpsKindMembershipJoin, "char-alice", "char-alice")
-	assert.Equal(t, "open", payload["visibility"])
-	assert.Equal(t, false, payload["from_invited"])
-}
-
-func TestRecordOpsEventTxRejectsUnknownKind(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	mustCreateScene(t, store, "scene-ope-2", "char-alice", string(SceneVisibilityOpen))
-
-	tx, err := store.pool.Begin(ctx)
-	require.NoError(t, err)
-	defer tx.Rollback(ctx)
-
-	err = recordOpsEventTx(ctx, tx, "scene-ope-2", OpsEventKind("bogus.kind"), "char-alice", "", nil)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_OPS_EVENT_INVALID_KIND")
-}
-
-func TestRecordOpsEventTxAcceptsNilPayloadAsEmptyObject(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	mustCreateScene(t, store, "scene-ope-3", "char-alice", string(SceneVisibilityOpen))
-
-	tx, err := store.pool.Begin(ctx)
-	require.NoError(t, err)
-	defer tx.Rollback(ctx)
-
-	err = recordOpsEventTx(ctx, tx, "scene-ope-3", OpsKindLifecyclePaused, "char-alice", "", nil)
-	require.NoError(t, err)
-	require.NoError(t, tx.Commit(ctx))
-
-	payload := assertOpsEventRecorded(t, store, "scene-ope-3", OpsKindLifecyclePaused, "char-alice", "")
-	assert.Empty(t, payload)
-}
-
-func TestCreateWithOwnerInsertsSceneAndOwnerParticipantAndOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID:              "scene-cwo-1",
-		Title:           "Owned scene",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-
-	err := store.CreateWithOwner(ctx, row)
-	require.NoError(t, err)
-
-	// 1. Scene row exists
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, row.OwnerID, got.OwnerID)
-
-	// 2. Owner participant row exists with role='owner'
-	assertParticipantRowExists(t, store, row.ID, row.OwnerID, "owner")
-
-	// 3. lifecycle.created ops event recorded
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindLifecycleCreated, row.OwnerID, "")
-	assert.Equal(t, "private", payload["visibility"])
-	assert.Equal(t, false, payload["from_template"])
-}
-
-func TestCreateWithOwnerRollsBackWhenSceneIDIsDuplicate(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID:              "scene-cwo-dup",
-		Title:           "First",
-		OwnerID:         "char-alice",
-		State:           string(SceneStateActive),
-		PoseOrder:       string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{},
-		Tags:            []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// Second insert with same ID — must fail and leave scene_participants /
-	// scene_ops_events untouched (no orphan rows from a partial transaction).
-	rowDup := *row
-	rowDup.OwnerID = "char-bob" // different owner attempt
-	err := store.CreateWithOwner(ctx, &rowDup)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_CREATE_FAILED")
-
-	// char-bob must NOT have a participant row for this scene.
-	assertParticipantRowAbsent(t, store, row.ID, "char-bob")
-
-	// Exactly one lifecycle.created event for this scene (the first call).
-	assert.Equal(t, 1, countOpsEvents(t, store, row.ID, OpsKindLifecycleCreated))
-}
-
-func TestGetWithMembershipReturnsParticipantsAndInviteesLists(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	// Create a scene with the owner.
-	row := &SceneRow{
-		ID: "scene-gwm-1", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// Manually insert a member and an invitee row to test the partition.
-	_, err := store.pool.Exec(ctx,
-		`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-bob', 'member')`,
-		row.ID)
-	require.NoError(t, err)
-	_, err = store.pool.Exec(ctx,
-		`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-carol', 'invited')`,
-		row.ID)
-	require.NoError(t, err)
-
-	got, participants, invitees, err := store.GetWithMembership(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "char-alice", got.OwnerID)
-	assert.ElementsMatch(t, []string{"char-alice", "char-bob"}, participants)
-	assert.ElementsMatch(t, []string{"char-carol"}, invitees)
-}
-
-func TestGetWithMembershipReturnsEmptyListsWhenSceneHasNoParticipants(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	// Use Phase 1 Create to skip the auto-owner-row insertion of CreateWithOwner.
-	mustCreateScene(t, store, "scene-gwm-empty", "char-alice", string(SceneVisibilityOpen))
-
-	row, participants, invitees, err := store.GetWithMembership(ctx, "scene-gwm-empty")
-	require.NoError(t, err)
-	assert.Equal(t, "char-alice", row.OwnerID)
-	assert.Empty(t, participants)
-	assert.Empty(t, invitees)
-}
-
-func TestGetWithMembershipReturnsNotFoundForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	_, _, _, err := store.GetWithMembership(ctx, "scene-gwm-missing")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_FOUND")
-}
-
-func TestAddParticipantInsertsFreshMemberRowForOpenScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-ap-1", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpInserted, result)
-	assert.Equal(t, "char-bob", got.CharacterID)
-	assert.Equal(t, "member", got.Role)
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "member")
-	assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipJoin, "char-bob", "char-bob")
-}
-
-func TestAddParticipantPromotesInvitedRowToMemberOnPrivateScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-ap-promote", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// Pre-insert an invitation for char-bob.
-	_, err := store.pool.Exec(ctx,
-		`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-bob', 'invited')`,
-		row.ID)
-	require.NoError(t, err)
-
-	got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpPromoted, result)
-	assert.Equal(t, "member", got.Role)
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "member")
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipJoin, "char-bob", "char-bob")
-	assert.Equal(t, "private", payload["visibility"])
-	assert.Equal(t, true, payload["from_invited"])
-}
-
-func TestAddParticipantReturnsOpNoChangeForExistingMember(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-ap-noop", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// First join — OpInserted.
-	_, result1, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpInserted, result1)
-
-	// Second join (retry) — OpNoChange, no new ops event.
-	_, result2, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpNoChange, result2)
-
-	// Exactly one membership.join event for this scene.
-	assert.Equal(t, 1, countOpsEvents(t, store, row.ID, OpsKindMembershipJoin))
-}
-
-func TestAddParticipantRejectsPrivateSceneWithoutInvitation(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-ap-priv", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_JOIN_NOT_INVITED")
-	errutil.AssertErrorContext(t, err, "scene_id", row.ID)
-	errutil.AssertErrorContext(t, err, "character_id", "char-bob")
-}
-
-func TestAddParticipantRejectsEndedScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-ap-ended", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, err := store.End(ctx, row.ID)
-	require.NoError(t, err)
-
-	_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSITION_FORBIDDEN")
-	errutil.AssertErrorContext(t, err, "current_state", "ended")
-}
-
-func TestAddParticipantReturnsNotFoundForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-	_, _, err := store.AddParticipant(context.Background(), "scene-nope", "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_FOUND")
-}
-
-func TestRemoveParticipantDeletesMemberRowAndEmitsOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-rp-1", Title: "T", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	got, err := store.RemoveParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, "member", got.Role)
-	assertParticipantRowAbsent(t, store, row.ID, "char-bob")
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipLeave, "char-bob", "char-bob")
-	assert.Equal(t, "member", payload["prior_role"])
-}
-
-func TestRemoveParticipantRefusesToRemoveOwner(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-rp-owner", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility: string(SceneVisibilityOpen), Title: "T",
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.RemoveParticipant(ctx, row.ID, "char-alice")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_OWNER_CANNOT_LEAVE")
-	assertParticipantRowExists(t, store, row.ID, "char-alice", "owner")
-}
-
-func TestRemoveParticipantReturnsNotFoundForMissingParticipant(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-rp-missing", OwnerID: "char-alice",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility: string(SceneVisibilityOpen), Title: "T",
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.RemoveParticipant(ctx, row.ID, "char-ghost")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_PARTICIPANT_NOT_FOUND")
-}
-
-func TestInviteParticipantInsertsInvitedRowAndEmitsOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-inv-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	got, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, "invited", got.Role)
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "invited")
-	assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipInvite, "char-alice", "char-bob")
-}
-
-func TestInviteParticipantIsIdempotentForExistingInvitee(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-inv-2", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	// Second invite — no error, no second event.
-	_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 1, countOpsEvents(t, store, row.ID, OpsKindMembershipInvite))
-}
-
-func TestInviteParticipantRejectsExistingMember(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-inv-3", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_INVITE_TARGET_ALREADY_MEMBER")
-}
-
-func TestKickParticipantRemovesMemberRowAndEmitsOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-kp-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	got, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, "member", got.Role)
-	assertParticipantRowAbsent(t, store, row.ID, "char-bob")
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipKick, "char-alice", "char-bob")
-	assert.Equal(t, "member", payload["prior_role"])
-}
-
-func TestKickParticipantRemovesInvitedRowAndPayloadReflectsPriorRole(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-kp-inv", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-
-	got, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, "invited", got.Role)
-	assertParticipantRowAbsent(t, store, row.ID, "char-bob")
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipKick, "char-alice", "char-bob")
-	assert.Equal(t, "invited", payload["prior_role"])
-}
-
-func TestKickParticipantRefusesToKickOwner(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-kp-owner", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-alice")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_KICK_FORBIDDEN")
-	assertParticipantRowExists(t, store, row.ID, "char-alice", "owner")
-}
-
-func TestTransferOwnershipUpdatesParticipantsAndScenesRowAtomically(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-to-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	err = store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-
-	// Previous owner is now a member.
-	assertParticipantRowExists(t, store, row.ID, "char-alice", "member")
-	// New owner.
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "owner")
-	// Denormalised scenes.owner_id updated.
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "char-bob", got.OwnerID)
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindMembershipOwnershipTransferred, "char-alice", "char-bob")
-	assert.Equal(t, "char-alice", payload["from"])
-}
-
-func TestTransferOwnershipRejectsNonMemberTarget(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-to-nm", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	err := store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_TRANSFER_TARGET_NOT_MEMBER")
-}
-
-func TestTransferOwnershipRejectsNonOwnerCaller(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-to-no", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	_, _, err = store.AddParticipant(ctx, row.ID, "char-carol")
-	require.NoError(t, err)
-
-	// char-bob (not owner) tries to transfer ownership of the scene to char-carol.
-	err = store.TransferOwnership(ctx, row.ID, "char-bob", "char-carol")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_NOT_OWNER")
-}
-
-func TestTransferOwnershipIsNoOpWhenTargetEqualsCurrentOwner(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-to-self", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	err := store.TransferOwnership(ctx, row.ID, "char-alice", "char-alice")
-	require.NoError(t, err) // idempotent no-op
-	assertParticipantRowExists(t, store, row.ID, "char-alice", "owner")
-	// No transfer ops event emitted.
-	assert.Equal(t, 0, countOpsEvents(t, store, row.ID, OpsKindMembershipOwnershipTransferred))
-}
-
-func TestListParticipantsReturnsAllRolesOrderedByJoinedAt(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-lp-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	got, err := store.ListParticipants(ctx, row.ID)
-	require.NoError(t, err)
-	require.Len(t, got, 2)
-	assert.Equal(t, "char-alice", got[0].CharacterID) // joined first via CreateWithOwner
-	assert.Equal(t, "owner", got[0].Role)
-	assert.Equal(t, "char-bob", got[1].CharacterID)
-	assert.Equal(t, "member", got[1].Role)
-}
-
-// TestListParticipantsReturnsEmptyForMissingScene locks in the contract that
-// ListParticipants is a list operation, not a Get-style lookup: a missing
-// scene returns (empty slice, nil error), the same as a scene that exists
-// with zero participants. This is intentional Postgres SELECT-WHERE semantics
-// — there's no way to distinguish "scene doesn't exist" from "scene exists
-// but has no rows" via a single query, and the caller can verify scene
-// existence via Get if they need that distinction.
-//
-// Negative-path coverage per project guideline (every exported function needs
-// at least one positive and one negative test).
-func TestListParticipantsReturnsEmptyForMissingScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	got, err := store.ListParticipants(ctx, "scene-does-not-exist")
-	require.NoError(t, err)
-	assert.Empty(t, got)
-}
-
-func TestGetParticipantReturnsRowWhenPresent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-gp-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	got, err := store.GetParticipant(ctx, row.ID, "char-alice")
-	require.NoError(t, err)
-	assert.Equal(t, "owner", got.Role)
-}
-
-func TestGetParticipantReturnsNotFoundForMissingParticipant(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-gp-missing", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.GetParticipant(ctx, row.ID, "char-ghost")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_PARTICIPANT_NOT_FOUND")
-}
-
-func TestEndEmitsLifecycleEndedOpsEventInSameTransaction(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-end-ope", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.End(ctx, row.ID)
-	require.NoError(t, err)
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindLifecycleEnded, row.OwnerID, "")
-	assert.Equal(t, "active", payload["prior_state"])
-}
-
-func TestPauseEmitsLifecyclePausedOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-pause-ope", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-	assertOpsEventRecorded(t, store, row.ID, OpsKindLifecyclePaused, row.OwnerID, "")
-}
-
-func TestResumeEmitsLifecycleResumedOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-resume-ope", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, err := store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-
-	_, err = store.Resume(ctx, row.ID)
-	require.NoError(t, err)
-	assertOpsEventRecorded(t, store, row.ID, OpsKindLifecycleResumed, row.OwnerID, "")
-}
-
-func TestUpdateEmitsSettingsUpdatedOpsEventWithMaskPaths(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-upd-ope", OwnerID: "char-alice", Title: "Old",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	newTitle := "New"
-	_, err := store.Update(ctx, row.ID, &SceneUpdate{Title: &newTitle})
-	require.NoError(t, err)
-
-	payload := assertOpsEventRecorded(t, store, row.ID, OpsKindSettingsUpdated, row.OwnerID, "")
-	paths, ok := payload["paths"].([]any)
-	require.True(t, ok)
-	assert.Contains(t, paths, "title")
-}
-
-func TestOwnerCanReadOwnSceneViaParticipantPolicy(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-1", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// CreateWithOwner must have inserted the owner participant row.
-	// This is the regression-locking assertion: an owner without a
-	// participant row would lose access under Phase 3's member-based
-	// read policy.
-	_, participants, _, err := store.GetWithMembership(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Contains(t, participants, "char-alice", "owner must be in participants list")
-}
-
-func TestMemberCanResumePausedScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-resume", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	_, err = store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-
-	// char-bob is in the participants list — the resume-scene-as-participant
-	// policy should permit them. Verify by reading the resolver attributes.
-	_, participants, _, err := store.GetWithMembership(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Contains(t, participants, "char-bob",
-		"member must be in participants list for resume-scene-as-participant policy")
-}
-
-func TestKickedCharacterImmediatelyDisappearsFromParticipants(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-kick", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	// Verify char-bob is in participants pre-kick.
-	_, before, _, err := store.GetWithMembership(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Contains(t, before, "char-bob")
-
-	// Kick char-bob.
-	_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-
-	// IMMEDIATELY (no cache, so no TTL) char-bob is gone.
-	_, after, _, err := store.GetWithMembership(ctx, row.ID)
-	require.NoError(t, err)
-	assert.NotContains(t, after, "char-bob",
-		"kicked character must immediately disappear from participants list")
-}
-
-func TestInviteeCanJoinPrivateScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-pj", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-
-	got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpPromoted, result)
-	assert.Equal(t, "member", got.Role)
-}
-
-func TestNonInviteeCannotJoinPrivateScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-pj-no", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_JOIN_NOT_INVITED")
-}
-
-func TestOwnerCannotLeaveOwnScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-ol", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	_, err := store.RemoveParticipant(ctx, row.ID, "char-alice")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_OWNER_CANNOT_LEAVE")
-}
-
-func TestOwnerCanTransferToMemberAndPreviousOwnerBecomesMember(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-locks-xfer", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-
-	require.NoError(t, store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob"))
-
-	// Verify all three changes landed in one transaction:
-	assertParticipantRowExists(t, store, row.ID, "char-alice", "member") // demoted
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "owner")    // promoted
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "char-bob", got.OwnerID) // denorm updated
-
-	// Now char-alice (no longer owner) CAN leave.
-	_, err = store.RemoveParticipant(ctx, row.ID, "char-alice")
-	require.NoError(t, err)
-	assertParticipantRowAbsent(t, store, row.ID, "char-alice")
-}
-
-func TestAddParticipantWorksOnPausedScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-bnd-pj", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, err := store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-
-	// Joining a PAUSED scene must succeed (state IN ('active', 'paused')).
-	got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, OpInserted, result)
-	assert.Equal(t, "member", got.Role)
-}
-
-func TestKickParticipantWorksOnPausedScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-bnd-pk", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	_, err = store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-
-	// Kicking from a PAUSED scene must succeed (no state filter on kick;
-	// scene state is irrelevant to the membership operation itself).
-	_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assertParticipantRowAbsent(t, store, row.ID, "char-bob")
-}
-
-func TestTransferOwnershipWorksOnPausedScene(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-bnd-pt", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	_, err = store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-
-	// Transfer must work in paused state (paused scenes can have admin
-	// operations including ownership transfer).
-	require.NoError(t, store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob"))
-	assertParticipantRowExists(t, store, row.ID, "char-bob", "owner")
-	got, err := store.Get(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, "char-bob", got.OwnerID)
-	assert.Equal(t, "paused", got.State, "transfer must not affect scene state")
-}
-
-func TestInviteParticipantRejectsOwnerTarget(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-bnd-io", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// Inviting the owner must reject — they're already a participant with
-	// the highest role. The existing-role check in InviteParticipant catches
-	// this via the SCENE_INVITE_TARGET_ALREADY_MEMBER code path.
-	_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-alice")
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "SCENE_INVITE_TARGET_ALREADY_MEMBER")
-	errutil.AssertErrorContext(t, err, "current_role", "owner")
-}
-
-func TestSceneOwnerIDDenormAlwaysMatchesParticipantOwnerRow(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	// Helper that asserts the invariant for a given scene at the current moment.
-	assertInvariant := func(sceneID string) {
-		t.Helper()
-		var (
-			denormOwnerID    string
-			participantOwner string
-		)
-		require.NoError(t, store.pool.QueryRow(
-			ctx,
-			`SELECT owner_id FROM scenes WHERE id = $1`, sceneID,
-		).Scan(&denormOwnerID))
-		require.NoError(t, store.pool.QueryRow(
-			ctx,
-			`SELECT character_id FROM scene_participants WHERE scene_id = $1 AND role = 'owner'`,
-			sceneID,
-		).Scan(&participantOwner))
-		assert.Equal(t, denormOwnerID, participantOwner,
-			"scenes.owner_id must always match the participant row with role='owner'")
-	}
-
-	row := &SceneRow{
-		ID: "scene-inv-denorm", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-
-	// Initial state after CreateWithOwner.
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	assertInvariant(row.ID)
-
-	// After adding a regular member — denorm unchanged.
-	_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assertInvariant(row.ID)
-
-	// After ownership transfer — denorm MUST update.
-	require.NoError(t, store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob"))
-	assertInvariant(row.ID)
-
-	// After old owner (now member) leaves — denorm unchanged.
-	_, err = store.RemoveParticipant(ctx, row.ID, "char-alice")
-	require.NoError(t, err)
-	assertInvariant(row.ID)
-}
-
-func TestEachMembershipMutationProducesExactlyOneOpsEvent(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	row := &SceneRow{
-		ID: "scene-inv-count", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityPrivate),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-
-	// CreateWithOwner produces 1 ops event: lifecycle.created.
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-	assert.Equal(t, 1, countOpsEvents(t, store, row.ID, ""), "after create")
-
-	// Invite produces 1 event: membership.invite.
-	_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 2, countOpsEvents(t, store, row.ID, ""), "after invite")
-
-	// Re-invite is idempotent: NO new event.
-	_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 2, countOpsEvents(t, store, row.ID, ""), "after redundant invite")
-
-	// Join (promotes invited→member) produces 1 event: membership.join.
-	_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 3, countOpsEvents(t, store, row.ID, ""), "after join")
-
-	// Retry of join (OpNoChange) produces NO new event.
-	_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 3, countOpsEvents(t, store, row.ID, ""), "after redundant join")
-
-	// Kick produces 1 event: membership.kick.
-	_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
-	require.NoError(t, err)
-	assert.Equal(t, 4, countOpsEvents(t, store, row.ID, ""), "after kick")
-
-	// Pause + Resume each produce 1 event.
-	_, err = store.Pause(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, 5, countOpsEvents(t, store, row.ID, ""), "after pause")
-	_, err = store.Resume(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, 6, countOpsEvents(t, store, row.ID, ""), "after resume")
-
-	// End produces 1 event.
-	_, err = store.End(ctx, row.ID)
-	require.NoError(t, err)
-	assert.Equal(t, 7, countOpsEvents(t, store, row.ID, ""), "after end")
-}
-
-func TestParticipantPrimaryKeyPreventsDoubleInsertion(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-	row := &SceneRow{
-		ID: "scene-inv-pk", OwnerID: "char-alice", Title: "T",
-		State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
-		Visibility:      string(SceneVisibilityOpen),
-		ContentWarnings: []string{}, Tags: []string{},
-	}
-	require.NoError(t, store.CreateWithOwner(ctx, row))
-
-	// Direct insert of a duplicate row MUST fail at the PK constraint.
-	// This proves the schema, not the store API, prevents duplicates.
-	_, err := store.pool.Exec(
-		ctx,
-		`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, $2, 'member')`,
-		row.ID, "char-alice", // char-alice is already the owner row
-	)
-	require.Error(t, err, "duplicate (scene_id, character_id) must violate PK")
-
-	// Verify exactly one row exists for char-alice.
-	var count int
-	require.NoError(t, store.pool.QueryRow(
-		ctx,
-		`SELECT COUNT(*) FROM scene_participants WHERE scene_id = $1 AND character_id = $2`,
-		row.ID, "char-alice",
-	).Scan(&count))
-	assert.Equal(t, 1, count)
-}
-
-func TestOpsEventsCannotBeUpdatedOrDeletedByApplicationCode(t *testing.T) {
-	// This is a meta-test: assert that the codebase contains no UPDATE or
-	// DELETE statements against scene_ops_events. Append-only is enforced
-	// by convention (the recordOpsEventTx helper is the only writer); this
-	// test catches accidental future violations.
-	//
-	// Per project policy (CLAUDE.md: "MUST NOT use triggers or functions —
-	// All logic lives in Go; PostgreSQL is storage only"), we cannot enforce
-	// append-only via a database trigger. This static check IS the
-	// enforcement, so it must be robust:
-	//
-	//   - Discover production .go files dynamically via filepath.Glob, so
-	//     a future file added to the package is automatically scanned. The
-	//     previous fixed-file list could be bypassed by adding a new file.
-	//   - Fail loudly on read errors (require.NoError), not silently skip.
-	//   - Match case-insensitively after whitespace folding, so a mutation
-	//     formatted as `delete\nfrom scene_ops_events` or with mixed case
-	//     still trips the check.
-	//
-	// Test files (`*_test.go`) are excluded because tests legitimately
-	// query scene_ops_events for assertions; only production code is
-	// scrutinized.
-
-	goFiles, err := filepath.Glob("*.go")
-	require.NoError(t, err)
-	require.NotEmpty(t, goFiles, "expected at least one .go file in package directory")
-
-	whitespace := regexp.MustCompile(`\s+`)
-	for _, fname := range goFiles {
-		if strings.HasSuffix(fname, "_test.go") {
-			continue
-		}
-		data, err := os.ReadFile(fname)
-		require.NoError(t, err, "failed to read %s", fname)
-		// Lowercase + collapse whitespace so multi-line / mixed-case SQL
-		// like `DELETE\n  FROM scene_ops_events` is normalised to
-		// `delete from scene_ops_events`.
-		content := whitespace.ReplaceAllString(strings.ToLower(string(data)), " ")
-		assert.NotContains(t, content, "update scene_ops_events",
-			"%s contains UPDATE on scene_ops_events — events must be immutable", fname)
-		assert.NotContains(t, content, "delete from scene_ops_events",
-			"%s contains DELETE on scene_ops_events — events must be immutable", fname)
-	}
-}
-
-func TestSceneStoreIsMemberReturnsExpectedByRoleAndSceneState(t *testing.T) {
-	const (
-		alice    = "char-alice"
-		bob      = "char-bob"
-		stranger = "char-stranger"
-	)
-
-	tests := []struct {
-		name    string
-		sceneID string
-		visible SceneVisibility
-		setup   func(t *testing.T, store *SceneStore, sceneID string)
-		probe   string
-		want    bool
-		wantMsg string
-	}{
-		{
-			name:    "returns true for owner",
-			sceneID: "scene-isM-1",
-			visible: SceneVisibilityOpen,
-			setup:   nil,
-			probe:   alice,
-			want:    true,
-			wantMsg: "owner MUST be reported as member",
-		},
-		{
-			name:    "returns true for joined member",
-			sceneID: "scene-isM-2",
-			visible: SceneVisibilityOpen,
-			setup: func(t *testing.T, store *SceneStore, sceneID string) {
-				_, _, err := store.AddParticipant(context.Background(), sceneID, bob)
-				require.NoError(t, err)
-			},
-			probe: bob,
-			want:  true,
-		},
-		{
-			name:    "returns false for invited-only",
-			sceneID: "scene-isM-3",
-			visible: SceneVisibilityPrivate,
-			setup: func(t *testing.T, store *SceneStore, sceneID string) {
-				_, err := store.InviteParticipant(context.Background(), sceneID, alice, bob)
-				require.NoError(t, err)
-			},
-			probe:   bob,
-			want:    false,
-			wantMsg: "invited-only rows MUST return false — invitation grants join, not read",
-		},
-		{
-			name:    "returns false for non-participant",
-			sceneID: "scene-isM-4",
-			visible: SceneVisibilityOpen,
-			setup:   nil,
-			probe:   stranger,
-			want:    false,
-		},
-		{
-			name:    "returns false for missing scene",
-			sceneID: "scene-isM-missing",
-			visible: "", // sentinel: skip scene creation
-			setup:   nil,
-			probe:   alice,
-			want:    false,
-			wantMsg: "missing scene MUST be nil error per spec §5.4 (info-hiding)",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := newTestStore(t)
+var _ = Describe("SceneStore", func() {
+	Describe("Create", func() {
+		It("persists all scene fields", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			locationID := "loc-01"
+			row := &SceneRow{
+				ID:              "scene-01HXYZ",
+				Title:           "A Decades-Crossed Meeting",
+				Description:     "Off-grid private meeting",
+				LocationID:      &locationID,
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{"plot", "social"},
+			}
+
+			err := store.Create(ctx, row)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ID).To(Equal(row.ID))
+			Expect(got.Title).To(Equal(row.Title))
+			Expect(got.Description).To(Equal(row.Description))
+			Expect(got.LocationID).NotTo(BeNil())
+			Expect(*got.LocationID).To(Equal(locationID))
+			Expect(got.OwnerID).To(Equal(row.OwnerID))
+			Expect(got.State).To(Equal(row.State))
+			Expect(got.PoseOrder).To(Equal(row.PoseOrder))
+			Expect(got.Visibility).To(Equal(row.Visibility))
+			Expect(got.Tags).To(ConsistOf(row.Tags))
+			Expect(got.CreatedAt).NotTo(BeZero())
+		})
+
+		It("rejects duplicate scene ID", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-dup",
+				Title:           "Original",
+				OwnerID:         "char-bob",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+			err := store.Create(ctx, row)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_CREATE_FAILED")
+		})
+	})
+
+	Describe("Get", func() {
+		It("returns SCENE_NOT_FOUND for missing scene", func() {
+			store := newTestStore()
 			ctx := context.Background()
 
-			if tt.visible != "" {
-				row := &SceneRow{
-					ID: tt.sceneID, OwnerID: alice, Title: "T",
-					State:           string(SceneStateActive),
-					PoseOrder:       string(PoseOrderModeFree),
-					Visibility:      string(tt.visible),
-					ContentWarnings: []string{}, Tags: []string{},
-				}
-				require.NoError(t, store.CreateWithOwner(ctx, row))
+			_, err := store.Get(ctx, "scene-does-not-exist")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_FOUND")
+			errutil.AssertErrorContext(suiteT, err, "scene_id", "scene-does-not-exist")
+		})
+	})
+
+	Describe("End", func() {
+		It("transitions active scene to ended", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-end-active",
+				Title:           "End from active",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
 			}
-			if tt.setup != nil {
-				tt.setup(t, store, tt.sceneID)
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.End(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.State).To(Equal(string(SceneStateEnded)))
+			Expect(got.EndedAt).NotTo(BeNil(), "ended_at should be set")
+
+			reread, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reread.State).To(Equal(got.State))
+		})
+
+		It("transitions paused scene to ended", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-end-paused",
+				Title:           "End from paused",
+				OwnerID:         "char-alice",
+				State:           string(SceneStatePaused),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.End(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.State).To(Equal(string(SceneStateEnded)))
+			Expect(got.EndedAt).NotTo(BeNil())
+		})
+
+		It("rejects already ended scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-end-twice",
+				Title:           "Already ended",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateEnded),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.End(ctx, row.ID)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSITION_FORBIDDEN")
+		})
+
+		It("returns SCENE_NOT_FOUND for missing scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			_, err := store.End(ctx, "scene-does-not-exist")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_FOUND")
+		})
+	})
+
+	Describe("Pause", func() {
+		It("transitions active scene to paused", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-pause",
+				Title:           "Pause from active",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.State).To(Equal(string(SceneStatePaused)))
+		})
+
+		It("rejects already paused scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-pause-twice",
+				Title:           "Already paused",
+				OwnerID:         "char-alice",
+				State:           string(SceneStatePaused),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.Pause(ctx, row.ID)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSITION_FORBIDDEN")
+		})
+	})
+
+	Describe("Resume", func() {
+		It("transitions paused scene to active", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-resume",
+				Title:           "Resume from paused",
+				OwnerID:         "char-alice",
+				State:           string(SceneStatePaused),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.Resume(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.State).To(Equal(string(SceneStateActive)))
+		})
+
+		It("rejects already active scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-resume-active",
+				Title:           "Already active",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.Resume(ctx, row.ID)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSITION_FORBIDDEN")
+		})
+	})
+
+	Describe("Update", func() {
+		It("applies title only when only title is specified", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-title",
+				Title:           "Original",
+				Description:     "Original description",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{"violence"},
+				Tags:            []string{"plot"},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			newTitle := "Renamed"
+			update := &SceneUpdate{Title: &newTitle}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Title).To(Equal("Renamed"))
+			Expect(got.Description).To(Equal("Original description"))
+			Expect(got.ContentWarnings).To(ConsistOf("violence"))
+			Expect(got.Tags).To(ConsistOf("plot"))
+		})
+
+		It("applies multiple fields simultaneously", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-many",
+				Title:           "Title 1",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			title := "Title 2"
+			desc := "New description"
+			vis := "private"
+			update := &SceneUpdate{
+				Title:       &title,
+				Description: &desc,
+				Visibility:  &vis,
+			}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Title).To(Equal("Title 2"))
+			Expect(got.Description).To(Equal("New description"))
+			Expect(got.Visibility).To(Equal("private"))
+		})
+
+		It("respects repeated fields update flag", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-repeated",
+				Title:           "T",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{"violence"},
+				Tags:            []string{"plot", "social"},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			// Only update content_warnings; leave tags alone.
+			update := &SceneUpdate{
+				ContentWarnings:       []string{"violence", "death"},
+				UpdateContentWarnings: true,
+				Tags:                  nil,
+				UpdateTags:            false, // explicitly NOT updating
+			}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ContentWarnings).To(ConsistOf("violence", "death"))
+			Expect(got.Tags).To(ConsistOf("plot", "social"), "tags should be unchanged")
+		})
+
+		It("clears repeated field when empty slice is provided with update flag", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-clear",
+				Title:           "T",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{"violence"},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			update := &SceneUpdate{
+				ContentWarnings:       []string{},
+				UpdateContentWarnings: true, // explicit clear
+			}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ContentWarnings).To(BeEmpty(), "content_warnings should be cleared to empty slice")
+		})
+
+		It("rejects update on ended scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-ended",
+				Title:           "Ended",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateEnded),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			title := "Try to rename"
+			update := &SceneUpdate{Title: &title}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSITION_FORBIDDEN")
+		})
+
+		It("returns SCENE_NOT_FOUND for missing scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			title := "Anything"
+			update := &SceneUpdate{Title: &title}
+			_, err := store.Update(ctx, "scene-does-not-exist", update)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_FOUND")
+		})
+
+		It("is a no-op when no fields are specified", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID:              "scene-update-noop",
+				Title:           "Unchanged",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.Create(ctx, row)).NotTo(HaveOccurred())
+
+			update := &SceneUpdate{}
+			_, err := store.Update(ctx, row.ID, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Title).To(Equal("Unchanged"))
+		})
+	})
+
+	Describe("recordOpsEventTx", func() {
+		It("writes row with expected kind and payload", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			scene := mustCreateScene(store, "scene-ope-1", "char-alice", string(SceneVisibilityOpen))
+
+			tx, err := store.pool.Begin(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+			err = recordOpsEventTx(ctx, tx, scene.ID, OpsKindMembershipJoin, "char-alice", "char-alice",
+				map[string]any{"visibility": "open", "from_invited": false})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tx.Commit(ctx)).NotTo(HaveOccurred())
+
+			payload := assertOpsEventRecorded(store, scene.ID, OpsKindMembershipJoin, "char-alice", "char-alice")
+			Expect(payload["visibility"]).To(Equal("open"))
+			Expect(payload["from_invited"]).To(Equal(false))
+		})
+
+		It("rejects unknown ops event kind", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			mustCreateScene(store, "scene-ope-2", "char-alice", string(SceneVisibilityOpen))
+
+			tx, err := store.pool.Begin(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+			err = recordOpsEventTx(ctx, tx, "scene-ope-2", OpsEventKind("bogus.kind"), "char-alice", "", nil)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_OPS_EVENT_INVALID_KIND")
+		})
+
+		It("accepts nil payload as empty object", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			mustCreateScene(store, "scene-ope-3", "char-alice", string(SceneVisibilityOpen))
+
+			tx, err := store.pool.Begin(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+			err = recordOpsEventTx(ctx, tx, "scene-ope-3", OpsKindLifecyclePaused, "char-alice", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tx.Commit(ctx)).NotTo(HaveOccurred())
+
+			payload := assertOpsEventRecorded(store, "scene-ope-3", OpsKindLifecyclePaused, "char-alice", "")
+			Expect(payload).To(BeEmpty())
+		})
+	})
+
+	Describe("CreateWithOwner", func() {
+		It("inserts scene, owner participant row, and lifecycle.created ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID:              "scene-cwo-1",
+				Title:           "Owned scene",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{},
+				Tags:            []string{},
 			}
 
-			got, err := store.IsMember(ctx, tt.sceneID, tt.probe)
-			require.NoError(t, err, tt.wantMsg)
-			if tt.wantMsg != "" {
-				assert.Equal(t, tt.want, got, tt.wantMsg)
-			} else {
-				assert.Equal(t, tt.want, got)
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.OwnerID).To(Equal(row.OwnerID))
+
+			assertParticipantRowExists(store, row.ID, row.OwnerID, "owner")
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindLifecycleCreated, row.OwnerID, "")
+			Expect(payload["visibility"]).To(Equal("private"))
+			Expect(payload["from_template"]).To(Equal(false))
+		})
+
+		It("rolls back when scene ID is duplicate", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID:              "scene-cwo-dup",
+				Title:           "First",
+				OwnerID:         "char-alice",
+				State:           string(SceneStateActive),
+				PoseOrder:       string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{},
+				Tags:            []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			rowDup := *row
+			rowDup.OwnerID = "char-bob"
+			err := store.CreateWithOwner(ctx, &rowDup)
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_CREATE_FAILED")
+
+			assertParticipantRowAbsent(store, row.ID, "char-bob")
+			Expect(countOpsEvents(store, row.ID, OpsKindLifecycleCreated)).To(Equal(1))
+		})
+	})
+
+	Describe("GetWithMembership", func() {
+		It("returns participants and invitees lists", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-gwm-1", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.pool.Exec(ctx,
+				`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-bob', 'member')`,
+				row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = store.pool.Exec(ctx,
+				`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-carol', 'invited')`,
+				row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, participants, invitees, err := store.GetWithMembership(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.OwnerID).To(Equal("char-alice"))
+			Expect(participants).To(ConsistOf("char-alice", "char-bob"))
+			Expect(invitees).To(ConsistOf("char-carol"))
+		})
+
+		It("returns empty lists when scene has no participants", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			mustCreateScene(store, "scene-gwm-empty", "char-alice", string(SceneVisibilityOpen))
+
+			row, participants, invitees, err := store.GetWithMembership(ctx, "scene-gwm-empty")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(row.OwnerID).To(Equal("char-alice"))
+			Expect(participants).To(BeEmpty())
+			Expect(invitees).To(BeEmpty())
+		})
+
+		It("returns SCENE_NOT_FOUND for missing scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			_, _, _, err := store.GetWithMembership(ctx, "scene-gwm-missing")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_FOUND")
+		})
+	})
+
+	Describe("AddParticipant", func() {
+		It("inserts fresh member row for open scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-ap-1", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(OpInserted))
+			Expect(got.CharacterID).To(Equal("char-bob"))
+			Expect(got.Role).To(Equal("member"))
+			assertParticipantRowExists(store, row.ID, "char-bob", "member")
+			assertOpsEventRecorded(store, row.ID, OpsKindMembershipJoin, "char-bob", "char-bob")
+		})
+
+		It("promotes invited row to member on private scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-ap-promote", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.pool.Exec(ctx,
+				`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, 'char-bob', 'invited')`,
+				row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(OpPromoted))
+			Expect(got.Role).To(Equal("member"))
+			assertParticipantRowExists(store, row.ID, "char-bob", "member")
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindMembershipJoin, "char-bob", "char-bob")
+			Expect(payload["visibility"]).To(Equal("private"))
+			Expect(payload["from_invited"]).To(Equal(true))
+		})
+
+		It("returns OpNoChange for existing member without emitting new ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-ap-noop", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, result1, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result1).To(Equal(OpInserted))
+
+			_, result2, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result2).To(Equal(OpNoChange))
+
+			Expect(countOpsEvents(store, row.ID, OpsKindMembershipJoin)).To(Equal(1))
+		})
+
+		It("rejects private scene without invitation", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-ap-priv", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_JOIN_NOT_INVITED")
+			errutil.AssertErrorContext(suiteT, err, "scene_id", row.ID)
+			errutil.AssertErrorContext(suiteT, err, "character_id", "char-bob")
+		})
+
+		It("rejects ended scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-ap-ended", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, err := store.End(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSITION_FORBIDDEN")
+			errutil.AssertErrorContext(suiteT, err, "current_state", "ended")
+		})
+
+		It("returns SCENE_NOT_FOUND for missing scene", func() {
+			store := newTestStore()
+			_, _, err := store.AddParticipant(context.Background(), "scene-nope", "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_FOUND")
+		})
+
+		It("works on paused scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-bnd-pj", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, err := store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(OpInserted))
+			Expect(got.Role).To(Equal("member"))
+		})
+	})
+
+	Describe("RemoveParticipant", func() {
+		It("deletes member row and emits ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-rp-1", Title: "T", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.RemoveParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Role).To(Equal("member"))
+			assertParticipantRowAbsent(store, row.ID, "char-bob")
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindMembershipLeave, "char-bob", "char-bob")
+			Expect(payload["prior_role"]).To(Equal("member"))
+		})
+
+		It("refuses to remove owner", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-rp-owner", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility: string(SceneVisibilityOpen), Title: "T",
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.RemoveParticipant(ctx, row.ID, "char-alice")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_OWNER_CANNOT_LEAVE")
+			assertParticipantRowExists(store, row.ID, "char-alice", "owner")
+		})
+
+		It("returns SCENE_PARTICIPANT_NOT_FOUND for missing participant", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-rp-missing", OwnerID: "char-alice",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility: string(SceneVisibilityOpen), Title: "T",
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.RemoveParticipant(ctx, row.ID, "char-ghost")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_PARTICIPANT_NOT_FOUND")
+		})
+	})
+
+	Describe("InviteParticipant", func() {
+		It("inserts invited row and emits ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-inv-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Role).To(Equal("invited"))
+			assertParticipantRowExists(store, row.ID, "char-bob", "invited")
+			assertOpsEventRecorded(store, row.ID, OpsKindMembershipInvite, "char-alice", "char-bob")
+		})
+
+		It("is idempotent for existing invitee (no second ops event)", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-inv-2", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, OpsKindMembershipInvite)).To(Equal(1))
+		})
+
+		It("rejects existing member", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-inv-3", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_INVITE_TARGET_ALREADY_MEMBER")
+		})
+
+		It("rejects owner as invite target", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-bnd-io", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-alice")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_INVITE_TARGET_ALREADY_MEMBER")
+			errutil.AssertErrorContext(suiteT, err, "current_role", "owner")
+		})
+	})
+
+	Describe("KickParticipant", func() {
+		It("removes member row and emits ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-kp-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Role).To(Equal("member"))
+			assertParticipantRowAbsent(store, row.ID, "char-bob")
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindMembershipKick, "char-alice", "char-bob")
+			Expect(payload["prior_role"]).To(Equal("member"))
+		})
+
+		It("removes invited row and payload reflects prior role", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-kp-inv", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Role).To(Equal("invited"))
+			assertParticipantRowAbsent(store, row.ID, "char-bob")
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindMembershipKick, "char-alice", "char-bob")
+			Expect(payload["prior_role"]).To(Equal("invited"))
+		})
+
+		It("refuses to kick owner", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-kp-owner", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.KickParticipant(ctx, row.ID, "char-alice", "char-alice")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_KICK_FORBIDDEN")
+			assertParticipantRowExists(store, row.ID, "char-alice", "owner")
+		})
+
+		It("works on paused scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-bnd-pk", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			assertParticipantRowAbsent(store, row.ID, "char-bob")
+		})
+	})
+
+	Describe("TransferOwnership", func() {
+		It("updates participants and scenes row atomically", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-to-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")).NotTo(HaveOccurred())
+
+			assertParticipantRowExists(store, row.ID, "char-alice", "member")
+			assertParticipantRowExists(store, row.ID, "char-bob", "owner")
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.OwnerID).To(Equal("char-bob"))
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindMembershipOwnershipTransferred, "char-alice", "char-bob")
+			Expect(payload["from"]).To(Equal("char-alice"))
+		})
+
+		It("rejects non-member target", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-to-nm", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			err := store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_TRANSFER_TARGET_NOT_MEMBER")
+		})
+
+		It("rejects non-owner caller", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-to-no", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			_, _, err = store.AddParticipant(ctx, row.ID, "char-carol")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = store.TransferOwnership(ctx, row.ID, "char-bob", "char-carol")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_NOT_OWNER")
+		})
+
+		It("is a no-op when target equals current owner", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-to-self", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			Expect(store.TransferOwnership(ctx, row.ID, "char-alice", "char-alice")).NotTo(HaveOccurred())
+			assertParticipantRowExists(store, row.ID, "char-alice", "owner")
+			Expect(countOpsEvents(store, row.ID, OpsKindMembershipOwnershipTransferred)).To(Equal(0))
+		})
+
+		It("works on paused scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-bnd-pt", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")).NotTo(HaveOccurred())
+			assertParticipantRowExists(store, row.ID, "char-bob", "owner")
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.OwnerID).To(Equal("char-bob"))
+			Expect(got.State).To(Equal("paused"), "transfer must not affect scene state")
+		})
+	})
+
+	Describe("ListParticipants", func() {
+		It("returns all roles ordered by joined_at", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-lp-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := store.ListParticipants(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(HaveLen(2))
+			Expect(got[0].CharacterID).To(Equal("char-alice"))
+			Expect(got[0].Role).To(Equal("owner"))
+			Expect(got[1].CharacterID).To(Equal("char-bob"))
+			Expect(got[1].Role).To(Equal("member"))
+		})
+
+		It("returns empty slice for missing scene (no error)", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			got, err := store.ListParticipants(ctx, "scene-does-not-exist")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeEmpty())
+		})
+	})
+
+	Describe("GetParticipant", func() {
+		It("returns row when participant is present", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-gp-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			got, err := store.GetParticipant(ctx, row.ID, "char-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Role).To(Equal("owner"))
+		})
+
+		It("returns SCENE_PARTICIPANT_NOT_FOUND for missing participant", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-gp-missing", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.GetParticipant(ctx, row.ID, "char-ghost")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_PARTICIPANT_NOT_FOUND")
+		})
+	})
+
+	Describe("lifecycle ops events", func() {
+		It("End emits lifecycle.ended ops event in same transaction", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-end-ope", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.End(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindLifecycleEnded, row.OwnerID, "")
+			Expect(payload["prior_state"]).To(Equal("active"))
+		})
+
+		It("Pause emits lifecycle.paused ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-pause-ope", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			assertOpsEventRecorded(store, row.ID, OpsKindLifecyclePaused, row.OwnerID, "")
+		})
+
+		It("Resume emits lifecycle.resumed ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-resume-ope", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, err := store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = store.Resume(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			assertOpsEventRecorded(store, row.ID, OpsKindLifecycleResumed, row.OwnerID, "")
+		})
+
+		It("Update emits settings.updated ops event with mask paths", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-upd-ope", OwnerID: "char-alice", Title: "Old",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			newTitle := "New"
+			_, err := store.Update(ctx, row.ID, &SceneUpdate{Title: &newTitle})
+			Expect(err).NotTo(HaveOccurred())
+
+			payload := assertOpsEventRecorded(store, row.ID, OpsKindSettingsUpdated, row.OwnerID, "")
+			paths, ok := payload["paths"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(paths).To(ContainElement("title"))
+		})
+	})
+
+	Describe("access policy invariants", func() {
+		It("owner can read own scene via participant policy", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-1", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, participants, _, err := store.GetWithMembership(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(participants).To(ContainElement("char-alice"), "owner must be in participants list")
+		})
+
+		It("member appears in participants list for resume-scene-as-participant policy", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-resume", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, participants, _, err := store.GetWithMembership(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(participants).To(ContainElement("char-bob"),
+				"member must be in participants list for resume-scene-as-participant policy")
+		})
+
+		It("kicked character immediately disappears from participants", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-kick", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, before, _, err := store.GetWithMembership(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(before).To(ContainElement("char-bob"))
+
+			_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, after, _, err := store.GetWithMembership(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(after).NotTo(ContainElement("char-bob"),
+				"kicked character must immediately disappear from participants list")
+		})
+
+		It("invitee can join private scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-pj", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			got, result, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(OpPromoted))
+			Expect(got.Role).To(Equal("member"))
+		})
+
+		It("non-invitee cannot join private scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-pj-no", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_JOIN_NOT_INVITED")
+		})
+
+		It("owner cannot leave own scene", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-ol", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.RemoveParticipant(ctx, row.ID, "char-alice")
+			Expect(err).To(HaveOccurred())
+			errutil.AssertErrorCode(suiteT, err, "SCENE_OWNER_CANNOT_LEAVE")
+		})
+
+		It("owner can transfer to member, and previous owner becomes member", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-locks-xfer", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")).NotTo(HaveOccurred())
+
+			assertParticipantRowExists(store, row.ID, "char-alice", "member")
+			assertParticipantRowExists(store, row.ID, "char-bob", "owner")
+			got, err := store.Get(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.OwnerID).To(Equal("char-bob"))
+
+			// Now char-alice (no longer owner) CAN leave.
+			_, err = store.RemoveParticipant(ctx, row.ID, "char-alice")
+			Expect(err).NotTo(HaveOccurred())
+			assertParticipantRowAbsent(store, row.ID, "char-alice")
+		})
+	})
+
+	Describe("database schema invariants", func() {
+		It("scenes.owner_id denorm always matches participant owner row", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			assertInvariant := func(sceneID string) {
+				GinkgoHelper()
+				var (
+					denormOwnerID    string
+					participantOwner string
+				)
+				Expect(store.pool.QueryRow(
+					ctx,
+					`SELECT owner_id FROM scenes WHERE id = $1`, sceneID,
+				).Scan(&denormOwnerID)).NotTo(HaveOccurred())
+				Expect(store.pool.QueryRow(
+					ctx,
+					`SELECT character_id FROM scene_participants WHERE scene_id = $1 AND role = 'owner'`,
+					sceneID,
+				).Scan(&participantOwner)).NotTo(HaveOccurred())
+				Expect(denormOwnerID).To(Equal(participantOwner),
+					"scenes.owner_id must always match the participant row with role='owner'")
+			}
+
+			row := &SceneRow{
+				ID: "scene-inv-denorm", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			assertInvariant(row.ID)
+
+			_, _, err := store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			assertInvariant(row.ID)
+
+			Expect(store.TransferOwnership(ctx, row.ID, "char-alice", "char-bob")).NotTo(HaveOccurred())
+			assertInvariant(row.ID)
+
+			_, err = store.RemoveParticipant(ctx, row.ID, "char-alice")
+			Expect(err).NotTo(HaveOccurred())
+			assertInvariant(row.ID)
+		})
+
+		It("each membership mutation produces exactly one ops event", func() {
+			store := newTestStore()
+			ctx := context.Background()
+
+			row := &SceneRow{
+				ID: "scene-inv-count", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityPrivate),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(1), "after create")
+
+			_, err := store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(2), "after invite")
+
+			_, err = store.InviteParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(2), "after redundant invite")
+
+			_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(3), "after join")
+
+			_, _, err = store.AddParticipant(ctx, row.ID, "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(3), "after redundant join")
+
+			_, err = store.KickParticipant(ctx, row.ID, "char-alice", "char-bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(4), "after kick")
+
+			_, err = store.Pause(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(5), "after pause")
+			_, err = store.Resume(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(6), "after resume")
+
+			_, err = store.End(ctx, row.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countOpsEvents(store, row.ID, "")).To(Equal(7), "after end")
+		})
+
+		It("participant primary key prevents double insertion", func() {
+			store := newTestStore()
+			ctx := context.Background()
+			row := &SceneRow{
+				ID: "scene-inv-pk", OwnerID: "char-alice", Title: "T",
+				State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+				Visibility:      string(SceneVisibilityOpen),
+				ContentWarnings: []string{}, Tags: []string{},
+			}
+			Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+			_, err := store.pool.Exec(
+				ctx,
+				`INSERT INTO scene_participants (scene_id, character_id, role) VALUES ($1, $2, 'member')`,
+				row.ID, "char-alice",
+			)
+			Expect(err).To(HaveOccurred(), "duplicate (scene_id, character_id) must violate PK")
+
+			var count int
+			Expect(store.pool.QueryRow(
+				ctx,
+				`SELECT COUNT(*) FROM scene_participants WHERE scene_id = $1 AND character_id = $2`,
+				row.ID, "char-alice",
+			).Scan(&count)).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
+		})
+
+		It("ops events cannot be updated or deleted by application code (static check)", func() {
+			// This is a meta-test: assert that the codebase contains no UPDATE or
+			// DELETE statements against scene_ops_events. Append-only is enforced
+			// by convention (the recordOpsEventTx helper is the only writer); this
+			// test catches accidental future violations.
+			goFiles, err := filepath.Glob("*.go")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(goFiles).NotTo(BeEmpty(), "expected at least one .go file in package directory")
+
+			whitespace := regexp.MustCompile(`\s+`)
+			for _, fname := range goFiles {
+				if strings.HasSuffix(fname, "_test.go") {
+					continue
+				}
+				data, err := os.ReadFile(fname)
+				Expect(err).NotTo(HaveOccurred(), "failed to read %s", fname)
+				content := whitespace.ReplaceAllString(strings.ToLower(string(data)), " ")
+				Expect(content).NotTo(ContainSubstring("update scene_ops_events"),
+					"%s contains UPDATE on scene_ops_events — events must be immutable", fname)
+				Expect(content).NotTo(ContainSubstring("delete from scene_ops_events"),
+					"%s contains DELETE on scene_ops_events — events must be immutable", fname)
 			}
 		})
-	}
-}
+	})
+
+	Describe("IsMember", func() {
+		DescribeTable("returns expected result by role and scene state",
+			func(sceneID string, visible SceneVisibility, setupFn func(*SceneStore), probe string, want bool, wantMsg string) {
+				store := newTestStore()
+				ctx := context.Background()
+
+				if visible != "" {
+					row := &SceneRow{
+						ID: sceneID, OwnerID: "char-alice", Title: "T",
+						State:           string(SceneStateActive),
+						PoseOrder:       string(PoseOrderModeFree),
+						Visibility:      string(visible),
+						ContentWarnings: []string{}, Tags: []string{},
+					}
+					Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+				}
+				if setupFn != nil {
+					setupFn(store)
+				}
+
+				got, err := store.IsMember(ctx, sceneID, probe)
+				Expect(err).NotTo(HaveOccurred(), wantMsg)
+				if wantMsg != "" {
+					Expect(got).To(Equal(want), wantMsg)
+				} else {
+					Expect(got).To(Equal(want))
+				}
+			},
+			Entry("returns true for owner",
+				"scene-isM-1", SceneVisibilityOpen,
+				nil,
+				"char-alice", true, "owner MUST be reported as member",
+			),
+			Entry("returns true for joined member",
+				"scene-isM-2", SceneVisibilityOpen,
+				func(store *SceneStore) {
+					_, _, err := store.AddParticipant(context.Background(), "scene-isM-2", "char-bob")
+					Expect(err).NotTo(HaveOccurred())
+				},
+				"char-bob", true, "",
+			),
+			Entry("returns false for invited-only",
+				"scene-isM-3", SceneVisibilityPrivate,
+				func(store *SceneStore) {
+					_, err := store.InviteParticipant(context.Background(), "scene-isM-3", "char-alice", "char-bob")
+					Expect(err).NotTo(HaveOccurred())
+				},
+				"char-bob", false, "invited-only rows MUST return false — invitation grants join, not read",
+			),
+			Entry("returns false for non-participant",
+				"scene-isM-4", SceneVisibilityOpen,
+				nil,
+				"char-stranger", false, "",
+			),
+			Entry("returns false for missing scene",
+				"scene-isM-missing", SceneVisibility(""), // sentinel: skip scene creation
+				nil,
+				"char-alice", false, "missing scene MUST be nil error per spec §5.4 (info-hiding)",
+			),
+		)
+	})
+})


### PR DESCRIPTION
## Summary

Part of holomush-1hq.26 / holomush-rccc Stage B. Converts 4 plain-`testing.T` integration test files spanning 4 different packages. 5 commits (one per file + suite rename).

**Suite rename** (`cmd/holomush/admin_authenticate_e2e_suite_test.go:35`): `Admin Authenticate E2E Lifecycle Suite` → `Holomush Integration Suite`.

**Bootstraps created:**
- `internal/eventbus/history/history_suite_test.go` ("History Integration Suite")
- `internal/totp/totp_suite_test.go` ("TOTP Integration Suite")
- `plugins/core-scenes/core_scenes_suite_test.go` ("Core Scenes Integration Suite", `package main`)

**Files converted:**
- `cmd/holomush/automigrate_integration_test.go` (3 funcs, 180 lines)
- `internal/eventbus/history/cold_postgres_integration_test.go` (11 funcs, 392 lines)
- `internal/totp/repo_integration_test.go` (12 funcs, 401 lines)
- `plugins/core-scenes/store_integration_test.go` (**69 funcs, 1790 lines** — biggest file in the entire migration)

## Pattern

`suiteT` capture (corrected pattern from PR #3951) — not `GinkgoT()`.

No INV-P7-N carrier funcs; no meta-test edits required.

Closes holomush-rccc.4.

## Test plan

- [x] Per-PR gates: RunSpecs = 1 per package; 0 t.Skip
- [ ] CI gates: authoritative
- [ ] code-reviewer pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated many integration tests to Ginkgo/Gomega for clearer, focused specs.
  * Added and registered new integration suites: History, TOTP, Core Scenes, and Holomush.
  * Consolidated legacy tests into describable specs and standardized assertions.
  * Improved database setup/teardown, container handling, cleanup, idempotency, and migration-related coverage.
  * Reworked concurrency and rollback tests to better validate atomicity and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->