### PR TITLE
docs(roadmap): add Maintenance section for repo audit 2026-05-13

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,6 +167,38 @@ Site docs at `site/docs/operating/` are substantial; future themes here
 might cover observability dashboards, deployment patterns, sandbox
 operations refinements. Not yet shaped as multi-epic work.
 
+## Maintenance (not strategic themes, but worth surfacing)
+
+Hygiene work that's tracked but isn't shaped as a multi-epic narrative.
+Listed here so future sessions know it exists without grepping `docs/`.
+
+### Repo audit 2026-05-13 (4 reports)
+
+Four read-only audit reports live at `docs/repository-audit/2026-05-13/`:
+
+| Report                       | Tracking epic   | State                                                               |
+| ---------------------------- | --------------- | ------------------------------------------------------------------- |
+| `architecture-audit.md`      | `holomush-dj95` | 13 children materialized; in-flight                                 |
+| `design-alignment-review.md` | `holomush-yvdm` | empty container; high-leverage findings re-filed as top-level beads |
+| `humanization-review.md`     | `holomush-89o9` | empty container; high-leverage findings re-filed as top-level beads |
+| `layer-review.md`            | `holomush-1bft` | empty container; high-leverage findings re-filed as top-level beads |
+
+The reports' own framing (esp. humanization): **"rolling-cleanup territory,
+not a mega-PR — treat as gardening: do a little, regularly."** A handful of
+high-leverage findings have been re-filed as top-level beads carrying the
+`repo-audit` label plus `mechanical`/`design-needed` so they surface in
+`bd ready`. The tracking epics remain as containers for the rest of the
+findings if/when someone decides to drive the cleanup more aggressively.
+
+Query the high-leverage cohort:
+
+```bash
+bd list -l repo-audit --limit 0 --json | \
+  jq -r '.[] | select(.status != "closed") |
+         select((.labels // []) | any(. == "mechanical" or . == "design-needed")) |
+         "P\(.priority) \(.id) \(.title)"' | sort
+```
+
 ## Conventions
 
 - **Theme label format**: `theme:<kebab-case-slug>`. Examples: `theme:social-spaces`, `theme:hardening`. No nesting (flat namespace).


### PR DESCRIPTION
## Summary

Adds a **Maintenance (not strategic themes, but worth surfacing)** section to `docs/roadmap.md` covering the 4 repository audit reports from 2026-05-13 (architecture, design-alignment, humanization, layer-review) and their tracking epics (`dj95`, `yvdm`, `89o9`, `1bft`).

Six high-leverage findings re-filed as top-level beads carrying the `repo-audit` label + `mechanical`/`design-needed` labels so they surface in `bd ready`:

| Bead | P | Title |
|------|---|-------|
| `holomush-tcf7` | P0 | Add `//go:build !integration` to `eventbustest/embedded.go` |
| `holomush-2oc3` | P0 | Delete dead `core.Engine.HandleSay/HandlePose` |
| `holomush-vakk` | P1 | Move plugin payload structs out of `internal/core/event.go` |
| `holomush-r20h` | P1 | Wire active session-consumer GC on quit |
| `holomush-evpt` | P1 | `AGENTS.md` symlink/stub + drift hook |
| `holomush-cbkx` | P2 | Merge `NewX`+`NewXWithLogger` via functional options |

Tracking epics remain as empty containers for future deeper decomposition (per auditors' framing: "rolling cleanup, do a little regularly").

## Test plan

- [x] `task pr-prep:docs` (docs-only diff) — passed
- [x] Markdown lint clean (rumdl: 397 + 58 files)
- [x] Single-file change (`docs/roadmap.md` +32 lines); no code or CI touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Maintenance section to the roadmap to track ongoing hygiene work
  * Introduced repository audit tracking with dated clusters and associated reports
  * Included guidance on maintenance framing and labeling conventions for high-leverage findings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->