### PR TITLE
docs(superpowers): mark testify+ginkgo migration spec + plan as SUPERSEDED

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Use suiteT Capture Pattern Instead of GinkgoT() for testing.TB](holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md) | 2026-05-16 | Accepted | `holomush-1f1w` |
+| [Remap INV-Pinned Test\* Functions to Ginkgo Suite Entries on Migration](holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md) | 2026-05-16 | Accepted | `holomush-iv7l` |
 | [AdminReadStream Bypasses HistoryReader/Dispatcher](holomush-8f2x-adminreadstream-bypasses-historyreaderdispatcher.md) | 2026-05-12 | Accepted | `holomush-8f2x` |
 | [Custom Go-Native ABAC Engine](holomush-kokk-custom-go-native-abac-engine.md) | 2026-02-05 | Accepted | `holomush-kokk` |
 | [Cedar-Aligned Fail-Safe Type Semantics](holomush-iv43-cedar-aligned-fail-safe-type-semantics.md) | 2026-02-05 | Accepted | `holomush-iv43` |

--- a/docs/adr/holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md
+++ b/docs/adr/holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md
@@ -1,0 +1,119 @@
+# Use suiteT capture pattern instead of GinkgoT() for testing.TB
+
+**Date:** 2026-05-16
+**Status:** Accepted
+**Decision:** holomush-1f1w
+**Deciders:** Sean Brandt
+
+## Context
+
+Go 1.26's `testing.TB` interface contains an unexported `private()` method.
+This is intentional Go design: it prevents any third-party type — including
+`ginkgo.FullGinkgoTInterface` (the type returned by `GinkgoT()`) — from
+satisfying `testing.TB`. The constraint is enforced at compile time, not
+documented as a lint or runtime warning.
+
+The original Canonical Pattern A in
+`docs/superpowers/specs/2026-05-15-testify-ginkgo-migration-completion-design.md`
+prescribed passing `GinkgoT()` to helpers taking `testing.TB`, and Task A1 of
+the corresponding plan shipped a prerequisite errutil widening from
+`*testing.T` to `testing.TB` (PR #3950) on that premise. That prescription
+was discovered to be structurally unsatisfiable during execution of the
+Ginkgo migration: any spec attempting to compile `helper(GinkgoT())` against
+a `testing.TB`-typed parameter fails to build.
+
+The codebase already contained ~30 Ginkgo specs that worked correctly before
+the migration. Inspection of those specs surfaced an existing alternative
+pattern that does NOT depend on `testing.TB` satisfaction.
+
+## Decision
+
+Every Ginkgo suite bootstrap in this codebase MUST:
+
+1. Declare `var suiteT *testing.T` at package level.
+2. Capture `suiteT = t` inside the `TestX` entry function BEFORE
+   `RunSpecs(t, "...")`.
+3. Spec bodies (`It(...)`, `BeforeEach(...)`, etc.) MUST pass `suiteT` (a
+   real `*testing.T`) to any helper that takes `*testing.T` or `testing.TB`.
+
+DO NOT use `GinkgoT()` to satisfy `*testing.T` or `testing.TB` parameters.
+`GinkgoT()` remains valid for Ginkgo's own machinery (`AddReportEntry`,
+`DeferCleanup` invocations through the Ginkgo interface) — it just cannot
+adapt to standard-library testing types.
+
+## Rationale
+
+- **Compile correctness:** `*testing.T` satisfies both `*testing.T` and
+  `testing.TB` parameter types with no interface gymnastics or shim layer.
+- **Convention precedent:** ~30 pre-existing Ginkgo specs in the codebase
+  already use this pattern; codifying it makes the convention explicit
+  rather than implicit, and gives future migrations a documented anchor.
+- **No helper changes required:** every helper that accepts `*testing.T`
+  (e.g., `errutil.AssertErrorCode`, `testutil.SharedPostgres`,
+  `testutil.FreshDatabase`) continues to work unchanged.
+- **Documented Go behavior:** the `private()` method on `testing.TB` is a
+  deliberate stdlib design choice (see Go issue tracker discussions on
+  testing.TB extensibility). Working around it via wrappers would fight
+  the language.
+
+## Alternatives Considered
+
+### `GinkgoT()` passed directly to `testing.TB` helpers (REJECTED)
+
+**Strengths:** Idiomatic-looking Ginkgo pattern; documented in Ginkgo's own
+FAQ and tutorials.
+
+**Weaknesses:** Fails to compile under Go 1.26+. `ginkgo.FullGinkgoTInterface`
+implements every exported method on `testing.TB` but cannot satisfy the
+unexported `private()` method. Any widening shim (e.g., the errutil
+`testing.T → testing.TB` widening from PR #3950) is harmless but useless for
+this purpose — it does not enable `GinkgoT()` to satisfy `testing.TB`.
+
+### `suiteT` capture pattern (ACCEPTED)
+
+**Strengths:** Uses a real `*testing.T`; satisfies both `*testing.T` and
+`testing.TB` parameters; pattern already in use across ~30 existing specs;
+no interface gymnastics.
+
+**Weaknesses:** `suiteT` is suite-scoped (it's the `*testing.T` from the
+suite entry func, not from any individual spec). Callers MUST use Ginkgo's
+`DeferCleanup` for spec-scoped cleanup and explicit `os.Setenv` + restore
+for spec-scoped env mutation, NOT `suiteT.Cleanup` or `suiteT.Setenv`. This
+constraint is documented alongside the pattern.
+
+## Consequences
+
+### Positive
+
+- All Ginkgo specs compile and run correctly under Go 1.26+.
+- No shim or wrapper type needed for `testing.TB` compatibility.
+- Consistent with pre-existing specs that contributors already read as
+  examples.
+- Future Ginkgo migrations have a known-good pattern; no rediscovery cost.
+
+### Negative
+
+- `suiteT.Cleanup` and `suiteT.Setenv` are suite-scoped and silently leak
+  across specs within a `Describe`. Contributors MUST know to use
+  `DeferCleanup` for cleanup and per-spec `os.Setenv` + restore for env
+  isolation. PR #4015 demonstrates the leak symptom and fix.
+- The pattern is invisible to contributors who consult only Ginkgo's
+  upstream documentation (which still prescribes `GinkgoT()`).
+
+### Neutral
+
+- The errutil widening shipped via PR #3950 is harmless and remains valid
+  for any non-Ginkgo caller passing `*testing.B` or `*testing.F`. It just
+  does not solve the Ginkgo case it was originally prescribed for.
+
+## References
+
+- Canonical worked example: PR #3951
+  (`test/integration/plugin/plugin_role_permissions_test.go`,
+  `test/integration/plugin/plugin_suite_test.go`)
+- Spec-scoped cleanup demonstration: PR #4015 (`specTB` adapter,
+  `freshBus()`, `freshPool()` no-arg helpers in
+  `test/integration/eventbus_e2e/suite_test.go`)
+- Superseded design doc:
+  `docs/superpowers/specs/2026-05-15-testify-ginkgo-migration-completion-design.md`
+- Closed epic: holomush-rccc

--- a/docs/adr/holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md
+++ b/docs/adr/holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md
@@ -1,0 +1,75 @@
+# Remap INV-pinned Test* functions to Ginkgo suite entries on migration
+
+**Date:** 2026-05-16
+**Status:** Accepted
+**Decision:** holomush-iv7l
+**Deciders:** Sean Brandt
+
+## Context
+
+`internal/eventbus/history/phase7_boundary_meta_test.go` is a drift detector for the Phase 7 invariant table. For each `INV-P7-N` invariant, it asserts that a named top-level `Test*` function exists somewhere in the `*_test.go` corpus, via a `go/parser` AST walk that enumerates top-level `func TestXxx(t *testing.T)` declarations.
+
+Ginkgo `Describe` and `It` blocks register specs via `var _ = Describe(...)` package-init expressions. Those expressions are invisible to the top-level-function AST walk: the meta-test sees a Ginkgo spec file as having zero `Test*` functions of the named form. When a Ginkgo conversion removes an INV-pinned `Test*` func and replaces it with a `Describe`/`It` registration, the drift detector silently loses coverage of that invariant — the meta-test fails with "named test X NOT FOUND", and the underlying invariant assertion goes from "pinned to a discoverable test" to "pinned to nothing the detector can see."
+
+This was discovered during Phase A of the testify+ginkgo migration. Pull requests PR-3951 (INV-P7-3, INV-P7-13) and PR-4015 (INV-P7-6, INV-P7-9, INV-P7-10, INV-P7-12) each remove INV-pinned `Test*` funcs as part of a `Describe`/`It` conversion.
+
+## Decision
+
+Every Ginkgo migration PR that removes an INV-pinned `Test*` function MUST:
+
+1. **Remap the meta-test mapping** in `internal/eventbus/history/phase7_boundary_meta_test.go` from the removed `TestXxx` name to the Ginkgo suite entry func name (e.g., `TestBinaryPlugin`, `TestEventbusE2E`, `TestStore`).
+2. **Preserve the INV reference inside the spec's `Describe` name string**, e.g., `Describe("Plugin role cannot write host tables (INV-P7-13)", ...)`, so the INV-to-spec linkage stays grep-discoverable from code.
+3. **Add a brief doc comment** above the remapped meta-test entry naming the original `Test*` function (now removed), the spec file, and the spec `Describe` string. This documents the trail for future readers.
+
+## Rationale
+
+- **Zero meta-test infrastructure changes.** Updating the `inv → testName` map to point at a suite entry preserves the drift detector's coverage semantics with no AST-walker rewrite.
+- **Suite entry funcs are real `Test*` functions.** Every Ginkgo bootstrap has a `func TestX(t *testing.T) { RunSpecs(...) }` entry — this satisfies the AST walk by construction.
+- **INV reference greppability.** Embedding the INV string in the spec's `Describe` name keeps `rg "INV-P7-13"` working as a way to locate the spec from the invariant, just as it located the named test func before.
+- **Lightweight per-PR protocol.** No coordination is required across PRs; each conversion bundles its own remap. The worked-example PRs cited in References demonstrate the protocol is small enough to fit alongside the conversion itself.
+
+## Alternatives Considered
+
+### Keep individual `Test*` stub functions alongside Ginkgo specs (REJECTED)
+
+**Strengths:** Meta-test AST walk continues to find the named function without modification.
+
+**Weaknesses:** Defeats the purpose of migration — the named func becomes a dead stub or a thin wrapper that runs nothing. Adds confusion: contributors must learn that the "real" test lives in a `Describe` block elsewhere. Pure maintenance overhead with no semantic value.
+
+### Update the meta-test AST walker to understand Ginkgo `Describe`/`It` naming (REJECTED)
+
+**Strengths:** Removes the per-PR protocol; meta-test becomes Ginkgo-aware once and forever.
+
+**Weaknesses:** Non-trivial AST rewrite. Ginkgo's `Describe`/`It` names are string literals passed as function arguments, not function declarations — the walker would need to interpret call expressions in package-init positions and parse `var _ = Describe(...)` chains, including nested `Context`/`When`/`Describe` blocks. Adds fragility: the meta-test would silently lose coverage if a spec used a non-literal name expression (variable or concatenation). Meta-test maintenance burden grows.
+
+### Remap INV mapping to suite entry; INV reference greppable in `Describe` name (ACCEPTED)
+
+**Strengths:** Zero meta-test code change; INV reference remains grep-discoverable; suite entry func IS a real `Test*` func visible to AST walk; minimal protocol overhead per migration PR.
+
+**Weaknesses:** Mapping becomes one-to-many when multiple INVs share a suite (e.g., 4 INVs all map to `TestEventbusE2E` after PR-4015). Contributors MUST know the remap protocol or the drift detector silently loses coverage on future conversions. No automated enforcement.
+
+## Consequences
+
+### Positive
+
+- Drift detector (`phase7_boundary_meta_test.go`) continues to enforce INV coverage after Ginkgo migration without infrastructure changes.
+- INV references remain grep-discoverable in spec `Describe` strings.
+- Pattern composes: a single suite can carry many INVs (PR-4015 maps four INVs to `TestEventbusE2E`).
+
+### Negative
+
+- Protocol must be followed explicitly on every Ginkgo migration PR that touches an INV-pinned file. No automated enforcement of the remap step — the meta-test fails loudly if missed, but only after the conversion PR is pushed.
+- INV-to-suite-entry mapping becomes implicit documentation in the meta-test rather than a 1:1 function name.
+
+### Neutral
+
+- PR-3951 and PR-4015 serve as canonical worked examples (see References).
+
+## References
+
+- Drift detector: `internal/eventbus/history/phase7_boundary_meta_test.go`
+- Worked examples:
+  - <https://github.com/holomush/holomush/pull/3951> (INV-P7-3 → `TestBinaryPlugin`; INV-P7-13 → `TestBinaryPlugin`)
+  - <https://github.com/holomush/holomush/pull/4015> (INV-P7-6, INV-P7-9, INV-P7-10, INV-P7-12 → `TestEventbusE2E`)
+- Superseded design doc: `docs/superpowers/specs/2026-05-15-testify-ginkgo-migration-completion-design.md`
+- Closed epic: holomush-rccc

--- a/docs/superpowers/plans/2026-05-15-testify-ginkgo-migration-completion-plan.md
+++ b/docs/superpowers/plans/2026-05-15-testify-ginkgo-migration-completion-plan.md
@@ -1,5 +1,65 @@
 # Testify + Ginkgo Migration Completion Implementation Plan
 
+> **STATUS: SUPERSEDED — 2026-05-16.** Work complete; epic
+> [`holomush-rccc`](https://github.com/holomush/holomush/issues/3884)
+> closed (8 PRs merged: #3950, #3951, #4011, #4012, #4013, #4014, #4015,
+> #4016). Retained for historical record.
+>
+> **CORRECTION (binding for any future migration work):**
+>
+> Canonical Pattern A's prescription to pass `GinkgoT()` to helpers
+> taking `testing.TB` is **WRONG** and the errutil widening (Task A1
+> "Prerequisite") was unnecessary. Go 1.26's `testing.TB` has an
+> unexported `private()` method preventing third-party types (including
+> `ginkgo.FullGinkgoTInterface`) from satisfying it.
+>
+> The **correct pattern** (already used by ~30 pre-existing Ginkgo
+> specs in this codebase) is `suiteT` capture: the suite bootstrap
+> declares `var suiteT *testing.T`, the `TestX` entry captures
+> `suiteT = t`, and spec bodies pass `suiteT` to helpers. See PR
+> [#3951](https://github.com/holomush/holomush/pull/3951)
+> (`test/integration/plugin/plugin_role_permissions_test.go`) as the
+> canonical worked example.
+>
+> Additional lessons learned (captured during execution):
+>
+> - `suiteT.Cleanup` / `suiteT.Setenv` are SUITE-scoped (`*testing.T`
+>   from the entry func), not spec-scoped. Use `DeferCleanup` and
+>   per-spec `os.Setenv` + restore for true per-spec isolation. See
+>   PR [#4015](https://github.com/holomush/holomush/pull/4015) — the
+>   sub-agent's `specTB` adapter and `freshBus()` / `freshPool()`
+>   no-arg helpers prevent resource accumulation across specs.
+> - INV-tagged test funcs that
+>   `internal/eventbus/history/phase7_boundary_meta_test.go` pins are
+>   invisible to its AST walk once converted to `Describe`/`It`.
+>   Remap each INV to the Ginkgo suite entry (e.g., `TestBinaryPlugin`,
+>   `TestEventbusE2E`); keep the INV reference greppable in the spec
+>   `Describe` name.
+> - Cluster-level state (Postgres roles especially) leaks across specs
+>   sharing a Ginkgo `Describe`. Use unique-per-spec role names or
+>   `DROP ROLE IF EXISTS` guards.
+> - Plan's "40 files" inventory swept in 2 helper-only files (zero test
+>   funcs): `test/integration/auth/core_client_shim_test.go` and
+>   `test/integration/plugin/counting_proxy_test.go`. True conversion
+>   scope was 38. Future inventory queries should also filter by
+>   `rg -c 'func Test|t.Run'`.
+> - **Sub-agent fan-out caveats:** parallel `task pr-prep` invocations
+>   are serialized by a machine-wide flock, so parallel sub-agents
+>   stall waiting for the lock. Parallel `task test:int` invocations
+>   from different worktrees hit the SAME shared testcontainer and
+>   produce cross-contamination failures that masquerade as real test
+>   failures. For future fan-outs, sequence the verification steps
+>   (`task test:int` and `task pr-prep`) explicitly rather than letting
+>   each sub-agent run them in parallel.
+> - **Verify sub-agent semantic changes:** one sub-agent silently
+>   stripped `dek_ref` / `dek_version` handling from a test helper as
+>   part of a refactor and the orchestrator-dispatched code-reviewer
+>   missed it; CI surfaced the regression. Future sub-agent dispatch
+>   prompts should explicitly require diff-vs-main verification, not
+>   just `task pr-prep`.
+
+---
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Complete the testify + ginkgo migration tracked under `holomush-1hq.26` by converting the remaining 40 plain-`testing.T` integration test files to Ginkgo / Gomega in two parallel-safe phases across 8 PRs.
@@ -1190,3 +1250,5 @@ Optional but recommended: append a `bd note` to the umbrella `holomush-1hq` epic
 - [ ] `task test:int` is green on `main`.
 
 <!-- adr-capture: sha256=6a2a56a70030199c; session=cli; ts=2026-05-15T17:36:38Z; adrs= -->
+
+<!-- adr-capture: sha256=3084f160f0e9f060; session=cli; ts=2026-05-16T22:31:10Z; adrs=holomush-1f1w,holomush-iv7l -->

--- a/docs/superpowers/specs/2026-05-15-testify-ginkgo-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-05-15-testify-ginkgo-migration-completion-design.md
@@ -1,5 +1,49 @@
 # Testify + Ginkgo Migration Completion Design
 
+> **STATUS: SUPERSEDED — 2026-05-16.** Work complete; design bead
+> [`holomush-rccc`](https://github.com/holomush/holomush/issues/3884)
+> closed (epic 8/8). Retained for historical record.
+>
+> **CORRECTION (binding for any future migration work):** Canonical Pattern A's
+> prescription to pass `GinkgoT()` to helpers taking `testing.TB` is
+> **WRONG**. Go 1.26's `testing.TB` has an unexported `private()` method
+> that prevents third-party types (including `ginkgo.FullGinkgoTInterface`)
+> from satisfying it. The errutil widening shipped under PR #3950 is
+> harmless-but-useless for its stated `GinkgoT()` purpose.
+>
+> The **correct pattern** (used by ~30 pre-existing Ginkgo specs in this
+> codebase before this migration even began) is:
+>
+> 1. Each suite bootstrap declares `var suiteT *testing.T` at package level.
+> 2. The `TestX` entry func captures `suiteT = t` before `RunSpecs`.
+> 3. Spec bodies pass `suiteT` (a real `*testing.T`) to any helper taking
+>    `*testing.T` or `testing.TB`.
+>
+> See PR #3951 (`test/integration/plugin/plugin_role_permissions_test.go`)
+> as the canonical worked example. PR #4015 includes additional cautions:
+> capture-shared `suiteT.Cleanup` and `suiteT.Setenv` leak across specs
+> in one suite — use `DeferCleanup` and per-spec `os.Setenv` + restore
+> instead.
+>
+> **Also relevant for future migrations:**
+>
+> - INV-tagged test names that the AST-walking meta-test at
+>   `internal/eventbus/history/phase7_boundary_meta_test.go` pins must be
+>   remapped to the Ginkgo suite entry func (e.g.,
+>   `TestBinaryPlugin`, `TestEventbusE2E`); the INV reference stays
+>   greppable in the spec's `Describe` name. See PRs #3951 and #4015 for
+>   the protocol.
+> - The plan's "40 files" inventory swept in 2 helper-only files (zero
+>   test funcs) — `test/integration/auth/core_client_shim_test.go` and
+>   `test/integration/plugin/counting_proxy_test.go`. True conversion
+>   scope was 38. Future inventory queries should filter by
+>   `rg -c 'func Test|t.Run'` rather than just by import absence.
+> - Postgres roles are cluster-level; specs in the same Ginkgo `Describe`
+>   share state across calls. Use unique-per-spec role names or
+>   `DROP ROLE IF EXISTS` guards. See PRs #3951 and #4015 for examples.
+
+---
+
 This document defines the execution plan for completing the testify + ginkgo
 test-framework adoption tracked under `holomush-1hq.26`.
 
@@ -471,3 +515,5 @@ None at design time. Section answered by user decisions captured in
   `*_integration_test.go` (40 files total) after re-grounding surfaced 18
   additional plain-`testing.T` integration tests outside the original tree
   (2026-05-15).
+
+<!-- adr-capture: sha256=2ba0d9f8a0c14b93; session=cli; ts=2026-05-16T22:31:10Z; adrs=holomush-1f1w,holomush-iv7l -->


### PR DESCRIPTION
## Summary

Annotates the testify + ginkgo migration completion spec + plan with SUPERSEDED headers, and captures the two architectural decisions discovered during execution as proper ADRs. Work is complete (epic holomush-rccc closed, 8 PRs merged: #3950, #3951, #4011, #4012, #4013, #4014, #4015, #4016). Docs retained as historical record per the `docs/superpowers/` convention.

## ADRs captured

- **`holomush-1f1w`** — Use suiteT capture pattern instead of GinkgoT() for testing.TB. Go 1.26's `testing.TB` has an unexported `private()` method that prevents `ginkgo.FullGinkgoTInterface` from satisfying it. The codebase had ~30 pre-existing Ginkgo specs using the correct pattern (`var suiteT *testing.T` captured at suite entry). This ADR codifies the convention. PR #3951 is the canonical worked example.
- **`holomush-iv7l`** — Remap INV-pinned Test* functions to Ginkgo suite entries on migration. The `phase7_boundary_meta_test.go` drift detector AST-walks for top-level `Test*` funcs; Ginkgo `Describe`/`It` blocks are invisible to it. Protocol: remap each INV to the Ginkgo suite entry func, keep the INV ref greppable in the `Describe` name. PRs #3951 and #4015 are worked examples.

## SUPERSEDED header content

Both the spec and plan get a SUPERSEDED block at the top noting:
- Work complete, link to closed epic `holomush-rccc`
- The `GinkgoT()` correction (binding for future migrations)
- Other lessons learned that didn't rise to architectural-decision threshold: suite-scoped vs spec-scoped cleanup hygiene, cluster-state leaks across specs in a Describe, helper-only-file detection, sub-agent fan-out caveats (pr-prep flock; cross-worktree testcontainer contention; required diff-vs-main verification)

Both files get an `<!-- adr-capture: -->` marker recording the ADR linkage.

## Files

- `docs/superpowers/specs/2026-05-15-...completion-design.md` — SUPERSEDED header + adr-capture marker
- `docs/superpowers/plans/2026-05-15-...completion-plan.md` — SUPERSEDED header + adr-capture marker
- `docs/adr/holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md` — new
- `docs/adr/holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md` — new
- `docs/adr/README.md` — index updated with 2 new entries

## Test plan

- [x] `task pr-prep` — green (docs lane)
- [x] ADR files render correctly after `task fmt:markdown` (rumdl-safe)
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the migration design/plan as superseded and preserved for history.
  * Added a correction standardizing a suite-scoped testing.T capture (avoid using GinkgoT() as a testing.TB substitute).
  * Published two ADRs capturing the new compatibility and INV remapping protocols.
  * Appended lessons learned on cleanup/isolation, INV remapping, Postgres role leaks, inventory sweep scope, sub-agent fan‑out, and CI-detected helper regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->