### PR TITLE
docs(rules): document bd github sync ban + dolt tag convention

### DIFF
--- a/.claude/rules/beads-project.md
+++ b/.claude/rules/beads-project.md
@@ -8,8 +8,10 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 - Use `bd ready` to find available work
 - Use `bd create` to track new issues/tasks/bugs
 - Use `bd dolt push` at end of session to sync the beads database with remote
+- **NEVER run `bd github sync`** — bidirectional GH-Issues bridge with `--prefer-newer` default that flips local closures back to open (regression hit 2026-05-16 and 2026-05-17, see `feedback_bd_dolt_vs_github` memory). `bd dolt` is canonical; manage GitHub Issues manually if a public-facing surface is needed.
 - Run `bd prime` for complete workflow context (SSOT for operational commands)
 - **VCS**: This repo is **jj-colocated** (`.jj/` present) — prefer `jj` over `git`. `bd dolt push` syncs the beads DB only; pushing code is a separate step (see [Landing the Plane](../../CLAUDE.md#landing-the-plane-session-completion) in CLAUDE.md)
+- **Dolt tags (recovery checkpoints)**: tag the dolt DB at confirmed-good states. Use the `dolt` CLI directly (not `bd dolt`), `cd "$HOME/.beads/shared-server/dolt/holomush" && dolt tag -m "<msg>" <tag>`. Convention: `safe-YYYY-MM-DD` for date-stamped snapshots, `last-known-good` as rolling pointer to most-recent snapshot. Snapshots are pointers, not copies — cheap to keep. **Retention: prune `safe-*` tags older than 30 days** (manual sweep; the rolling pointer keeps the latest accessible).
 - **Strategic themes**: multi-epic clusters use `theme:<slug>` labels paired with a narrative section in [`docs/roadmap.md`](../../docs/roadmap.md). When adding a `theme:*` label to a bead, MUST also add/update the roadmap section. When closing all work in a theme, MUST move its roadmap section to "Completed themes" with a date. Full directive at root CLAUDE.md "Strategic Themes".
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

Adds two operational rules to `.claude/rules/beads-project.md` after today's bd recovery work:

1. **NEVER run `bd github sync`** — bidirectional GH-Issues bridge with `--prefer-newer` default that flips local closures back open. Caused regressions on 2026-05-16 (~1,100 beads) and 2026-05-17 (~819 beads). `bd dolt` is canonical; manage GitHub Issues manually if needed. See `feedback_bd_dolt_vs_github` memory entry.

2. **Dolt tag convention for recovery checkpoints**:
   - `safe-YYYY-MM-DD` for date-stamped immutable snapshots
   - `last-known-good` as rolling pointer to most-recent snapshot
   - 30-day retention on `safe-*` tags (manual prune)
   - Use `dolt` CLI directly in `/Users/sean/.beads/shared-server/dolt/holomush` (not `bd dolt` — bd doesn't expose tag operations)

Established 2026-05-17: tags `safe-2026-05-17` + `last-known-good` created at recovery state and pushed to DoltHub `origin` remote.

## Test plan

- [x] \`task pr-prep:docs\` (docs-only fast lane) — passed
- [x] Markdown lint clean
- [x] Single-file change (.claude/rules/beads-project.md); no code touched

\`\`\`
Reviewer-gate: skipped — docs-only change (.claude/rules/), no code or crypto surface
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified issue-tracking and VCS guidelines; automated GitHub issue sync is now explicitly disallowed and "bd dolt" is the canonical flow with manual GitHub issue handling when needed
  * Added recovery checkpoint procedures: create Dolt DB tags via CLI, naming conventions (safe-YYYY-MM-DD, last-known-good) and prune safe-* tags older than 30 days

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->