### PR TITLE
docs(history-scope-privacy): spec + plan + 5 ADRs for iwzt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,13 +101,12 @@ Work is tracked in `bd` (see `.claude/rules/beads-project.md` and `bd prime`). S
 
 | Stage | Skill / Action                                  | Gate before next stage         |
 | ----- | ----------------------------------------------- | ------------------------------ |
-| 1     | `superpowers:brainstorming`                     | (conversation only)            |
+| 1     | `dev-flow:brainstorming`                        | (conversation only)            |
 | 2     | (writes spec from brainstorming)                | `design-reviewer` — READY      |
-| 3     | `superpowers:writing-plans`                     | `plan-reviewer` — READY        |
-| 4     | `bead-chain-design`                             | user reviews proposed split    |
-| 5     | `bead-chain-from-plan`                          | user reviews dry-run manifest  |
-| 6     | `superpowers:subagent-driven-development`       | `code-reviewer` (+ `crypto-reviewer` / `abac-reviewer` when applicable) before push |
-| 7     | `gh pr create`                                  | `task pr-prep` green; `/autofix <PR#>` for CodeRabbit |
+| 3     | `dev-flow:writing-plans`                        | `plan-reviewer` — READY        |
+| 4     | `dev-flow:plan-to-beads` (auto-fired by writing-plans on READY; preceded by `dev-flow:capture-adrs`) | user reviews dry-run manifest before materialization |
+| 5     | `dev-flow:subagent-driven-development`          | `code-reviewer` (+ `crypto-reviewer` / `abac-reviewer` when applicable) before push |
+| 6     | `gh pr create`                                  | `task pr-prep` green; `/autofix <PR#>` for CodeRabbit |
 
 Detail on each gate is in `## Pre-Push Review Gates`. Skipping requires explicit user override.
 
@@ -123,13 +122,11 @@ All tasks MUST be reviewed before completion via `pr-review-toolkit:review-pr`. 
 | **MUST** address all findings              | Fix issues or document why not applicable            |
 | **MUST NOT** skip review                   | Even for "simple" changes                            |
 
-### Plan → Bead Chain convention
+### Plan → bd materialization
 
-Plans with multiple tracked tasks MUST contain a `## Bead chain structure` section (level-2, exact wording, case-sensitive) covering: parent epic, each task bead, supersessions, follow-up beads, and `bd dep add` edges.
+Plans drive bd state via `dev-flow:plan-to-beads`, which reads the plan's task table (each `### Task N:` heading inside a `## Phase N:` section) and materializes the epic + child beads + dependency graph in one pass. **Plans do NOT carry a `## Bead chain structure` section** — bd is the source of truth for graph topology (per the `dev-flow:plan-to-beads` skill spec Rule 4). The ancestor `bead-chain-design` / `bead-chain-from-plan` convention is superseded.
 
-Each task bead's `--description` MUST include all 8 sections: **Goal**, **Design reference**, **Plan reference**, **TDD acceptance criteria**, **Verification steps**, **Files touched**, **Dependencies**, **Out of scope**.
-
-Skills `bead-chain-design` (writes the section) and `bead-chain-from-plan` (materializes `bd` issues + edges + parent linkage) operate on this convention. If the chain section is missing, `bead-chain-from-plan` delegates to `bead-chain-design` first.
+Per Rule 3, each task bead's `--description` is **narrative only** (Goal, Plan reference, Files touched, Out of scope). Acceptance criteria, verification commands, dependencies, and labels live in their dedicated bd flags (`--acceptance`, `--deps`, `--labels`, `--skills`).
 
 ## Pre-Push Review Gates
 
@@ -139,8 +136,8 @@ by providing an earlier, in-session review pass.
 
 | Agent             | Fires before                                                                           | Invocation                              |
 | ----------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
-| `design-reviewer` | `superpowers:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
-| `plan-reviewer`   | `superpowers:executing-plans` or `superpowers:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
+| `design-reviewer` | `dev-flow:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
+| `plan-reviewer`   | `dev-flow:executing-plans` or `dev-flow:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
 | `code-reviewer`   | `bd close`, `jj git push`, or PR creation                                              | `/review-code [<target>]` or auto       |
 | `crypto-reviewer` | `code-reviewer` (runs FIRST), for changes touching `internal/eventbus/crypto/`, `internal/eventbus/codec/`, `internal/eventbus/history/dispatcher.go`, `internal/eventbus/history/cold_postgres.go`, `internal/plugin/event_emitter.go::Emit`, `internal/eventbus/audit/projection.go`, plugin manifest `crypto.emits` declarations, or migrations on `crypto_keys` / `events_audit` | `/review-crypto` or auto via `remind-pre-action-review.sh` |
 | `abac-reviewer`   | `code-reviewer` (runs alongside), for changes touching `internal/access/`              | `/review-abac` or auto via `remind-pre-action-review.sh` |
@@ -200,7 +197,7 @@ Detail in `.claude/rules/testing.md` (auto-loads when editing test files): cover
 
 | Always-on rule                       | Description                                                                  |
 | ------------------------------------ | ---------------------------------------------------------------------------- |
-| **MUST** write tests before impl     | TDD — see `superpowers:test-driven-development`                              |
+| **MUST** write tests before impl     | TDD — see `dev-flow:test-driven-development`                              |
 | **MUST** maintain >80% coverage      | Per-package; verify with `task test:cover`                                   |
 | **MUST** use Ginkgo/Gomega for E2E   | Build tag `//go:build integration`; runs via `task test:int`                 |
 | **MUST** run `task test:int` on refactors | `task test` does NOT compile integration files — refactors of shared types break silently otherwise |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,13 +102,12 @@ Work is tracked in `bd` (see `.claude/rules/beads-project.md` and `bd prime`). S
 
 | Stage | Skill / Action                                  | Gate before next stage         |
 | ----- | ----------------------------------------------- | ------------------------------ |
-| 1     | `superpowers:brainstorming`                     | (conversation only)            |
+| 1     | `dev-flow:brainstorming`                        | (conversation only)            |
 | 2     | (writes spec from brainstorming)                | `design-reviewer` — READY      |
-| 3     | `superpowers:writing-plans`                     | `plan-reviewer` — READY        |
-| 4     | `bead-chain-design`                             | user reviews proposed split    |
-| 5     | `bead-chain-from-plan`                          | user reviews dry-run manifest  |
-| 6     | `superpowers:subagent-driven-development`       | `code-reviewer` (+ `crypto-reviewer` / `abac-reviewer` when applicable) before push |
-| 7     | `gh pr create`                                  | `task pr-prep` green; `/autofix <PR#>` for CodeRabbit |
+| 3     | `dev-flow:writing-plans`                        | `plan-reviewer` — READY        |
+| 4     | `dev-flow:plan-to-beads` (auto-fired by writing-plans on READY; preceded by `dev-flow:capture-adrs`) | user reviews dry-run manifest before materialization |
+| 5     | `dev-flow:subagent-driven-development`          | `code-reviewer` (+ `crypto-reviewer` / `abac-reviewer` when applicable) before push |
+| 6     | `gh pr create`                                  | `task pr-prep` green; `/autofix <PR#>` for CodeRabbit |
 
 Detail on each gate is in `## Pre-Push Review Gates`. Skipping requires explicit user override.
 
@@ -124,13 +123,11 @@ All tasks MUST be reviewed before completion via `pr-review-toolkit:review-pr`. 
 | **MUST** address all findings              | Fix issues or document why not applicable            |
 | **MUST NOT** skip review                   | Even for "simple" changes                            |
 
-### Plan → Bead Chain convention
+### Plan → bd materialization
 
-Plans with multiple tracked tasks MUST contain a `## Bead chain structure` section (level-2, exact wording, case-sensitive) covering: parent epic, each task bead, supersessions, follow-up beads, and `bd dep add` edges.
+Plans drive bd state via `dev-flow:plan-to-beads`, which reads the plan's task table (each `### Task N:` heading inside a `## Phase N:` section) and materializes the epic + child beads + dependency graph in one pass. **Plans do NOT carry a `## Bead chain structure` section** — bd is the source of truth for graph topology (per the `dev-flow:plan-to-beads` skill spec Rule 4). The ancestor `bead-chain-design` / `bead-chain-from-plan` convention is superseded.
 
-Each task bead's `--description` MUST include all 8 sections: **Goal**, **Design reference**, **Plan reference**, **TDD acceptance criteria**, **Verification steps**, **Files touched**, **Dependencies**, **Out of scope**.
-
-Skills `bead-chain-design` (writes the section) and `bead-chain-from-plan` (materializes `bd` issues + edges + parent linkage) operate on this convention. If the chain section is missing, `bead-chain-from-plan` delegates to `bead-chain-design` first.
+Per Rule 3, each task bead's `--description` is **narrative only** (Goal, Plan reference, Files touched, Out of scope). Acceptance criteria, verification commands, dependencies, and labels live in their dedicated bd flags (`--acceptance`, `--deps`, `--labels`, `--skills`).
 
 ## Strategic Themes
 
@@ -163,8 +160,8 @@ by providing an earlier, in-session review pass.
 
 | Agent             | Fires before                                                                           | Invocation                              |
 | ----------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
-| `design-reviewer` | `superpowers:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
-| `plan-reviewer`   | `superpowers:executing-plans` or `superpowers:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
+| `design-reviewer` | `dev-flow:writing-plans` is invoked on a spec                                       | `/review-design [<spec-path>]` or auto  |
+| `plan-reviewer`   | `dev-flow:executing-plans` or `dev-flow:subagent-driven-development` runs a plan | `/review-plan [<plan-path>]` or auto    |
 | `code-reviewer`   | `bd close`, `jj git push`, or PR creation                                              | `/review-code [<target>]` or auto       |
 | `crypto-reviewer` | `code-reviewer` (runs FIRST), for changes touching `internal/eventbus/crypto/`, `internal/eventbus/codec/`, `internal/eventbus/history/dispatcher.go`, `internal/eventbus/history/cold_postgres.go`, `internal/plugin/event_emitter.go::Emit`, `internal/eventbus/audit/projection.go`, plugin manifest `crypto.emits` declarations, or migrations on `crypto_keys` / `events_audit` | `/review-crypto` or auto via `remind-pre-action-review.sh` |
 | `abac-reviewer`   | `code-reviewer` (runs alongside), for changes touching `internal/access/`              | `/review-abac` or auto via `remind-pre-action-review.sh` |
@@ -224,7 +221,7 @@ Detail in `.claude/rules/testing.md` (auto-loads when editing test files): cover
 
 | Always-on rule                       | Description                                                                  |
 | ------------------------------------ | ---------------------------------------------------------------------------- |
-| **MUST** write tests before impl     | TDD — see `superpowers:test-driven-development`                              |
+| **MUST** write tests before impl     | TDD — see `dev-flow:test-driven-development`                              |
 | **MUST** maintain >80% coverage      | Per-package; verify with `task test:cover`                                   |
 | **MUST** use Ginkgo/Gomega for E2E   | Build tag `//go:build integration`; runs via `task test:int`                 |
 | **MUST** run `task test:int` on refactors | `task test` does NOT compile integration files — refactors of shared types break silently otherwise |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,11 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Plugin Manifests Opt-In to history_scope (vs Spec's Exempt-List Framing)](holomush-jhl5-plugin-history-scope-opt-in.md) | 2026-05-17 | Accepted | `holomush-jhl5` |
+| [Hard-Gate (Current-Location-Only) for Location-Stream History Reads](holomush-wxty-hard-gate-location-stream-history.md) | 2026-05-17 | Accepted | `holomush-wxty` |
+| [Per-Session Attach Intervals on SessionInfo for Multi-Session Continuity](holomush-rc8b-per-session-attach-intervals.md) | 2026-05-17 | Accepted | `holomush-rc8b` |
+| [Session-Store Sync Hook on Character Move](holomush-kmac-session-store-sync-hook-character-move.md) | 2026-05-17 | Accepted | `holomush-kmac` |
+| [In-Process Filter-at-Delivery as Load-Bearing Privacy Gate; NATS-as-Source-of-Truth for Consumer Config](holomush-ghpx-filter-at-delivery-and-nats-source-of-truth.md) | 2026-05-17 | Accepted | `holomush-ghpx` |
 | [Use suiteT Capture Pattern Instead of GinkgoT() for testing.TB](holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md) | 2026-05-16 | Accepted | `holomush-1f1w` |
 | [Remap INV-Pinned Test\* Functions to Ginkgo Suite Entries on Migration](holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md) | 2026-05-16 | Accepted | `holomush-iv7l` |
 | [AdminReadStream Bypasses HistoryReader/Dispatcher](holomush-8f2x-adminreadstream-bypasses-historyreaderdispatcher.md) | 2026-05-12 | Accepted | `holomush-8f2x` |

--- a/docs/adr/holomush-ghpx-filter-at-delivery-and-nats-source-of-truth.md
+++ b/docs/adr/holomush-ghpx-filter-at-delivery-and-nats-source-of-truth.md
@@ -1,0 +1,68 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# In-Process Filter-at-Delivery as Load-Bearing Privacy Gate; NATS-as-Source-of-Truth for Consumer Config
+
+**Date:** 2026-05-17
+**Status:** Accepted
+**Decision:** holomush-ghpx
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The `holomush-iwzt` privacy fix needs to apply a temporal floor to events delivered via Subscribe — not only to `QueryStreamHistory`. Subscribe creates one durable JetStream consumer per session with `DeliverAllPolicy` (`internal/eventbus/subscriber.go:177-186`). JetStream consumers accept exactly one `DeliverPolicy` per consumer, and the policy plus `OptStartTime` / `OptStartSeq` are server-side immutable on an existing consumer (NATS server error 10012: "deliver policy can not be updated"; see [NATS consumer config](https://docs.nats.io/nats-concepts/jetstream/consumers), "Editable" column).
+
+Design exploration considered: per-subject consumer fan-out, adding a sequence-from-time API to `HistoryReader`, filter-at-delivery in the broadcaster, recreating the durable on every reattach. Each has different cost and complexity profiles. Six rounds of adversarial review refined the chosen approach.
+
+## Decision
+
+### Two-tier privacy enforcement
+
+**Tier 1** is JetStream's native `DeliverByStartTimePolicy` with `OptStartTime = minFloor` (computed as the maximum scope-floor across all subscribed subjects at consumer creation) as a **performance hint** that bounds how far back JetStream will deliver.
+
+**Tier 2** is per-subject filter-at-delivery in the Subscribe broadcaster (`internal/grpc/server.go` event dispatch loop) that drops any event with `Timestamp < streamScopeFloor(currentSessionInfo, event.Subject)`. **This is the load-bearing privacy gate.**
+
+### NATS-as-source-of-truth for immutable consumer config
+
+Both `OpenSession` (called on every Subscribe, including transport reattach) and `SetFilters` (called on location-following moves) MUST query `s.js.Consumer(ctx, StreamName, name)` before issuing `CreateOrUpdateConsumer`. On hit, copy `DeliverPolicy` / `OptStartTime` / `OptStartSeq` verbatim from `existing.CachedInfo().Config`; only `FilterSubjects` mutates. On `ErrConsumerNotFound`, compute fresh `minFloor`. On any other lookup error, **fail closed** (return wrapped `EVENTBUS_CONSUMER_LOOKUP_FAILED`; do not invoke `CreateOrUpdateConsumer`).
+
+## Rationale
+
+**Privacy correctness cannot depend on JetStream config immutability.** `OptStartTime` is set once at consumer creation. After session reattach or character move, the floor advances — but JetStream config cannot change. Filter-at-delivery is the only mechanism that can enforce the post-reattach floor on already-delivered events.
+
+**`OptStartTime` is still valuable as a perf hint.** It bounds the total volume JetStream will replay on consumer first-create. Without it, `DeliverAllPolicy` would replay the entire retained stream — a latency disaster for the connect-to-live budget tracked at `holomush-87qu`.
+
+**NATS-source-of-truth avoids cache-coherence bugs.** In-process or DB-row caching of `OptStartTime` would diverge across process restarts, consumer reaper actions, and concurrent OpenSession races. Querying NATS on every call is idempotent and serializable; error 10012 is unreachable under the documented call discipline (one in-flight OpenSession per session ID, enforced by the gRPC Subscribe handler being the sole control-plane owner of the session).
+
+**Fail-closed on transient lookup errors** prevents the brief leak window where a missing `DeliverPolicy` in the new config (zero-value = `DeliverAllPolicy`) would be sent against an existing-but-temporarily-unreachable durable.
+
+## Alternatives Considered
+
+**A. Per-subject consumer fan-out (one durable per subject).** Rejected: multiplies JS state per session; more bookkeeping; more reaper attention; gains precision the filter-at-delivery already provides.
+
+**B. Add `HistoryReader.LowerBoundByTime(subject, t) (uint64, error)` API and seed consumer with `DeliverByStartSequencePolicy`.** Rejected (round 3 finding B-R2.1): `HistoryReader` is consumed by `QueryStreamHistory` only, not Subscribe; the cold-tier seq-from-time lookup is unnecessary on the `QueryStreamHistory` path (existing `HistoryQuery.NotBefore` field suffices); JetStream already provides native `DeliverByStartTimePolicy`.
+
+**C. Cache `OptStartTime` in-process on the `jetStreamSessionStream` instance.** Rejected (round 4 finding B-R4.1): the instance is freshly constructed per `OpenSession` call; the cached value does not survive across reattach.
+
+**D. Cache `OptStartTime` in the `sessions` table.** Rejected: persists a perf hint to the durable store; cache-coherence concerns across process restarts; adds a column for a value already canonical in NATS.
+
+**E (selected): NATS-source-of-truth query-then-copy pattern + filter-at-delivery as load-bearing gate.**
+
+## Consequences
+
+- **MUST** apply the per-subject filter-at-delivery check on every event in the Subscribe dispatch loop (I-PRIV-1).
+- **MUST** query `s.js.Consumer(...)` before `CreateOrUpdateConsumer` in both `OpenSession` and `SetFilters` paths (I-PRIV-8).
+- **MUST** preserve `DeliverPolicy` / `OptStartTime` / `OptStartSeq` from existing consumer config verbatim; only `FilterSubjects` may mutate (I-PRIV-3, I-PRIV-8).
+- **MUST NOT** recreate the durable on `Subscribe.ReattachCAS`; the idempotent OpenSession call is effectively a no-op on the existing consumer (I-PRIV-3).
+- **MUST NOT** cache `OptStartTime` in-process or in DB; NATS is the source of truth.
+- **MUST** fail closed on lookup errors other than `ErrConsumerNotFound` — return wrapped error, do not invoke `CreateOrUpdateConsumer`.
+- Adds one NATS round-trip per OpenSession (typically sub-millisecond). Acceptable per `holomush-87qu` latency context — much faster than the alternative cache-coherence machinery.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` §6.2 (full two-tier model), I-PRIV-1, I-PRIV-3, I-PRIV-8
+- Bead: `holomush-iwzt`
+- Related ADRs: `holomush-wxty` (hard-gate for location streams), `holomush-rc8b` (per-session attach intervals)
+- Code: `internal/eventbus/subscriber.go:159-366`, `internal/grpc/server.go:855`, `internal/eventbus/history/hot_jetstream.go:283`
+- NATS: [Consumer config — Editable column](https://docs.nats.io/nats-concepts/jetstream/consumers) (DeliverPolicy = No)
+- NATS error code: [server error 10012 discussion](https://github.com/nats-io/nats.py/issues/657)

--- a/docs/adr/holomush-jhl5-plugin-history-scope-opt-in.md
+++ b/docs/adr/holomush-jhl5-plugin-history-scope-opt-in.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Plugin Manifests Opt-In to history_scope (vs Spec's Exempt-List Framing)
+
+**Date:** 2026-05-17
+**Status:** Accepted
+**Decision:** holomush-jhl5
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The history-scope privacy spec's I-PRIV-7 invariant requires plugin-owned subjects that adopt history-replay semantics divergent from the grid/scene model to declare them. The spec's framing implied an **exempt-list** strategy — plugins emitting under `location:*` or `scene:*:*` get the spec-defined behavior automatically; only "custom" plugin-owned namespaces need an explicit `history_scope:` declaration.
+
+Plan-review surfaced a fundamental ambiguity: the spec's §3 grid/scene rows reference event-stream **prefixes** (`location:01ABC`, `scene:01XYZ:ic`), but plugin manifests use bare **namespace** identifiers (`location`, `scene`, `core-communication`, etc.). The mapping between stream prefix and manifest namespace is not 1:1. An exempt-list strategy invented at plan time (e.g., `nsLocation = "location"; nsScene = "scene"`) would either silently miss real grid-emitting plugins (e.g., `core-communication` emits to `location:*` streams but its manifest namespace identifier is `core-communication`) or accidentally exempt the wrong set.
+
+Concrete cost: `core-scenes` and `core-communication` would either bypass validation incorrectly (silent inheritance — exactly what I-PRIV-7 forbids) or fail to load with a confusing error.
+
+## Decision
+
+**Every plugin manifest with a non-empty `emits:` field MUST declare `history_scope:` explicitly.** No exempt list. Validation runs inside `(*Manifest).Validate` after `validateEmits(m.Emits)` succeeds (`internal/plugin/manifest.go:441`). Valid values are a closed enum: `grid`, `scene`, `custom`.
+
+```go
+if m.HistoryScope != "" && !validHistoryScopes[m.HistoryScope] {
+    return oops.With("plugin", m.Name).
+        Errorf("history_scope %q is invalid; valid: grid, scene, custom", m.HistoryScope)
+}
+if len(m.Emits) > 0 && m.HistoryScope == "" {
+    return oops.With("plugin", m.Name).
+        With("emits", m.Emits).
+        Errorf("plugin emits events but manifest does not declare history_scope (holomush-iwzt I-PRIV-7)")
+}
+```
+
+Existing in-tree plugins MUST migrate as part of the I-PRIV-7 implementation:
+
+- `plugins/core-communication/plugin.yaml` → `history_scope: grid`
+- `plugins/core-scenes/plugin.yaml` → `history_scope: scene`
+- Any future emitting plugin → declare or fail validation
+
+## Rationale
+
+**Closes the silent-inheritance hole I-PRIV-7 forbids.** With an exempt-list, a plugin author can ship a new plugin that emits under an unexpected namespace and silently inherit permissive history semantics. With opt-in, every plugin is forced to make the choice explicit.
+
+**Eliminates the stream-prefix vs manifest-namespace mapping ambiguity.** The spec's §3 references stream subjects; the manifest references namespaces. Either we maintain a mapping table (fragile; missed entries leak), or we don't depend on it. Opt-in removes the dependency entirely.
+
+**One-time migration cost is bounded.** Only two existing plugins (`core-communication`, `core-scenes`) need updates; both have unambiguous correct values. Future plugins pay zero migration cost — they declare on creation.
+
+**Validation runs at manifest load, not at emit time.** Plugins that violate I-PRIV-7 fail at startup; no per-event hot-path cost.
+
+## Alternatives Considered
+
+**A. Exempt-list strategy (spec's original framing).** Rejected: the `location` / `scene` exempt strings are stream prefixes, not manifest namespaces. Would either silently miss real grid/scene plugins or accidentally exempt the wrong ones. No stable mapping exists between the two layers.
+
+**B. Default `history_scope: custom` when omitted, with a warning slog.** Rejected: warnings get ignored. The whole point of I-PRIV-7's "silent inheritance forbidden" is that defaults must not let a plugin author skip the decision. Opt-in is enforcement; default-with-warning is a polite request.
+
+**C. Per-stream-prefix matching at validate time (parse `emits:` strings as if they were stream prefixes).** Rejected: `emits:` is documented as bare namespaces; treating them as stream prefixes is a layering violation and breaks current plugins whose namespace names happen to be `core-communication` / `core-scenes` rather than `location` / `scene`.
+
+**D (selected): opt-in declaration mandatory for all emitting plugins.**
+
+## Consequences
+
+- **MUST** add `history_scope: <value>` to every existing plugin manifest with a non-empty `emits:` field at the same time the I-PRIV-7 validation lands. Otherwise `task test` fails on manifest load for every existing plugin.
+- **MUST** document the closed-enum values (`grid`, `scene`, `custom`) in plugin-author documentation as part of the I-PRIV-7 rollout.
+- **MUST NOT** introduce a default value or warning-on-omission path that lets new plugins skip the decision.
+- Forward-looking: every new plugin author must choose. The cost is one line in the manifest; the benefit is the silent-inheritance hole stays closed.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` I-PRIV-7
+- Plan: `docs/superpowers/plans/2026-05-17-history-scope-privacy.md` Task 21
+- Bead: `holomush-iwzt`
+- Related ADRs: `holomush-ghpx` (NATS source-of-truth — related plugin/host contract pattern)
+- Plan-reviewer findings that drove the decision: round 2 NB1 (stream-prefix vs manifest-namespace), round 3 B-R3.4 (filename/loader correction with migration enumeration)

--- a/docs/adr/holomush-kmac-session-store-sync-hook-character-move.md
+++ b/docs/adr/holomush-kmac-session-store-sync-hook-character-move.md
@@ -1,0 +1,57 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Session-Store Sync Hook on Character Move
+
+**Date:** 2026-05-17
+**Status:** Accepted
+**Decision:** holomush-kmac
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Grounding during the `holomush-iwzt` history-scope design discovered that no code path syncs `sessions.location_id` to `characters.location_id` on character move. `world.Service.MoveCharacter` (`internal/world/service.go:759-790`) updates the character row and emits an `EventTypeMove` event. The Subscribe-side `locationFollower` (`internal/grpc/location_follow.go:60-130`) consumes the event per-Subscribe-stream and switches the bus filter, but it operates on per-stream in-memory state only — it never writes the session store.
+
+As a result, the session-store entry is stale relative to the character row after any move. Confirmed via `rg "UpdateLocation"` across `internal/` — no path writes `sessions.location_id` on move.
+
+The privacy fix (`holomush-iwzt`) requires per-session `LocationArrivedAt` to update atomically with `LocationID` on move. The session-store sync hook is a prerequisite for the privacy fix; it also corrects a latent drift that may already affect other consumers reading `session.LocationID`.
+
+## Decision
+
+**Add an explicit session-store sync hook to the character-move path.** Define `session.Store.UpdateLocationOnMove(ctx, characterID, newLocationID, arrivedAt) error` that atomically updates `LocationID` and `LocationArrivedAt` for all `Active`/`Idle` sessions belonging to the character (single transaction). `world.Service.MoveCharacter` invokes the hook immediately after `characterRepo.UpdateLocation` and before the move-event emit.
+
+The wiring approach (the plan stage selects between the two options below) preserves the gateway/world layering invariant:
+
+- **Preferred:** a `MovementHook` interface implemented by core-server (which holds both `world.Service` and `session.Store` dependencies). Keeps `world.Service` ignorant of sessions.
+- **Alternative:** direct `session.Store` injection into `world.Service`. Simpler but introduces cross-layer coupling.
+
+## Rationale
+
+**Privacy fix prerequisite.** Without the sync hook, `SessionInfo.LocationArrivedAt` cannot be set at the moment of character move — silently leaking history at the moment the per-session floor is most relevant.
+
+**Latent drift correction.** Any consumer reading `session.LocationID` to make a routing or policy decision has, until this fix, observed a value that could be stale relative to the character's actual location. The plan stage MUST audit existing readers; the design-reviewer round 3 verified the drift via grep across `internal/`.
+
+**Atomic invariant.** At the moment a Move event reaches any subscriber, every session in the store MUST already reflect the new `LocationID` and `LocationArrivedAt`. The hook fires before the event emit to maintain this ordering. Asynchronous reconciliation (e.g., consuming the move event in a separate handler) would create a window during which a session's stored `LocationID` lags the character's.
+
+## Alternatives Considered
+
+**A. Asynchronous reconciliation via move-event consumer.** Rejected: race window between event emit and sync write would leak through `QueryStreamHistory` using the still-stale `session.LocationID`.
+
+**B. Direct `session.Store` injection into `world.Service`.** Considered: simplest implementation, but violates the gateway/world layering invariant — `world.Service` knowing about sessions creates coupling that constrains future world-service evolution.
+
+**C (selected): `MovementHook` interface implemented by core-server.** Preserves layering; core-server already holds both dependencies; same pattern useful for future world mutations that need session-store side effects.
+
+## Consequences
+
+- **MUST** update sessions atomically with character-row update in the same transaction context, or in a tightly-following synchronous call before the event emit.
+- **MUST** audit current readers of `session.LocationID` to confirm none rely on the previously-stale value.
+- **MUST NOT** treat the sync as best-effort — fire-and-forget would re-introduce the original drift.
+- Adds a new architectural seam (`MovementHook`) that future world mutations may also want to use.
+- Phase 1 of the privacy fix is privacy-leak-neutral but is NOT semantically inert: this drift correction is a positive change that may surface previously-masked bugs in `session.LocationID` consumers.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` §5.1, §7 Phase 1
+- Bead: `holomush-iwzt`
+- Related ADRs: `holomush-rc8b` (per-session attach intervals — depends on this fix)
+- Code: `internal/world/service.go:759-790`, `internal/grpc/location_follow.go:60-130`, `internal/session/store.go`

--- a/docs/adr/holomush-rc8b-per-session-attach-intervals.md
+++ b/docs/adr/holomush-rc8b-per-session-attach-intervals.md
@@ -1,0 +1,50 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Per-Session Attach Intervals on SessionInfo for Multi-Session Continuity
+
+**Date:** 2026-05-17
+**Status:** Accepted
+**Decision:** holomush-rc8b
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH characters may have multiple concurrent sessions: web tab plus telnet, two devices, web plus iOS. The history-scope privacy invariant (`holomush-iwzt`) is principled at the character level — "a character sees stream history only when actively present" — but the implementation must decide whether to track attach intervals per character (one timestamp per character row) or per session (one timestamp per session row).
+
+The design-reviewer round 2 initially recommended storing `LocationArrivedAt` on the `world.Character` row because it eliminated a session-store sync question. Subsequent analysis of multi-session scenarios revealed that approach breaks legitimate continuity: if a web session drops while telnet stays connected, on web reconnect the character was continuously present via telnet, yet a character-row floor that re-stamps on every session attach would retroactively shrink telnet's visibility — wrong.
+
+## Decision
+
+**Store `LocationArrivedAt` on `SessionInfo` (per-session), not on `world.Character` (per-character).** Each session has its own floor, independent of other sessions for the same character. Query-time floor is read from the requesting session's row only — no aggregation across sessions required.
+
+## Rationale
+
+**Multi-session correctness.** A character continuously attached via at least one session retains that session's visibility. A dropping-then-reconnecting session loses only its own visibility, not the character's overall continuity. The per-session model is honest about per-session attach intervals rather than collapsing to a single per-character timestamp.
+
+**Per-session is the natural granularity.** Sessions already carry transport-level lifecycle (`StatusActive`, `StatusIdle`, `StatusDetached`). A timestamp anchored to lifecycle transitions belongs on the same entity as the lifecycle itself. Character rows do not track per-attach state and adding it there would create a new coupling between world model and session lifecycle.
+
+**No aggregation cost at query time.** Floor is a scalar read from the same session row already loaded for authorization. Per-character aggregation would require enumerating active sessions for the character and computing `MIN` — both query latency cost and complexity cost, both contributing to the connect-to-live latency concern tracked at `holomush-87qu`.
+
+## Alternatives Considered
+
+**A. `world.Character.LocationArrivedAt`, updated on every session create/reattach/move.** Rejected: breaks multi-session continuity. Web reattach would steal telnet's visibility.
+
+**B. Hybrid: `character.last_move_time` (written on move only) plus per-session attach intervals, with query-time `MIN` aggregation across active sessions.** Rejected: more storage and more code paths; the simpler per-session model handles every case the user articulated.
+
+**C (selected): `SessionInfo.LocationArrivedAt` per-session, no character-row column.**
+
+## Consequences
+
+- **MUST** synchronize `session.LocationID` and `session.LocationArrivedAt` on character move across all active sessions for the character (see ADR `holomush-kmac` — session-store sync hook).
+- **MUST** update `LocationArrivedAt` on three lifecycle transitions: fresh `SelectCharacter` (create), `SelectCharacter` reattach, `Subscribe.ReattachCAS` (transport reattach).
+- **MUST NOT** update `LocationArrivedAt` on idle status changes — idle is still "actively attached" per the privacy principle.
+- Each session's floor is independent; debugging multi-session privacy issues requires inspecting per-session state in the session store, not a single character row.
+- Schema: `sessions.location_arrived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` added in Phase 1.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` §2 (multi-session worked example), §4.1, §5, I-PRIV-4
+- Bead: `holomush-iwzt`
+- Related ADRs: `holomush-kmac` (character-move session-sync hook — the prerequisite)
+- Code: `internal/session/session.go:154-158` (SessionInfo struct)

--- a/docs/adr/holomush-wxty-hard-gate-location-stream-history.md
+++ b/docs/adr/holomush-wxty-hard-gate-location-stream-history.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Hard-Gate (Current-Location-Only) for Location-Stream History Reads
+
+**Date:** 2026-05-17
+**Status:** Accepted
+**Decision:** holomush-wxty
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+`QueryStreamHistory` historically routed all public-stream authorization through the ABAC engine (`internal/grpc/query_stream_history.go:179-214`). The history-scope privacy spec (`holomush-iwzt`) introduces an invariant requiring that a character's view of location-stream history be limited to time intervals of active presence. Implementing this via ABAC alone is feasible but couples the privacy invariant to policy-author discipline: a misconfigured policy could re-introduce the leak.
+
+The privacy invariant is fundamental — "a character cannot read a location they are not in" is not context-dependent. The question is where in the stack the invariant lives.
+
+## Decision
+
+**Replace ABAC with a hardcoded gate for location streams specifically.** The gate enforces `session.LocationID.String() == extractLocationID(stream)`, default-deny. ABAC remains active for all other public streams (`global`, `system`, etc.). Staff and admin characters bypass the hard-gate via a separate ABAC predicate (`read_unrestricted_history` action) that is itself restricted to specific roles by seeded policy.
+
+## Rationale
+
+**Trust ownership.** The privacy invariant is fundamental, not contextual. A hardcoded gate places enforcement under the same review discipline as the code itself; an ABAC policy puts it under the discipline of the policy author, who may be a different person. For default-deny invariants, code is the right enforcement boundary.
+
+**Symmetry with scene streams.** Scene streams already use an I-17 hardcoded membership gate (`internal/grpc/query_stream_history.go:157-178`) for the same reason — ABAC is never consulted for private streams; no policy override is possible. Adopting the same pattern for location streams aligns the model: gating the access-or-no-access question is code; policy authoring continues to govern attribute-driven decisions (factions, properties, etc.).
+
+**Staff bypass is the legitimate exception.** Debugging incidents requires staff to read locations they are not in. Routing that through ABAC keeps the bypass auditable (policy ID logged), opt-in (must have role), and revocable (delete the policy). The bypass affects only the hard-gate location-match check; the temporal floor still applies per I-PRIV-6.
+
+## Alternatives Considered
+
+**A. Keep ABAC, add the temporal floor inside the policy.** Rejected: misconfiguration risk; one bad policy edit re-opens the leak. The hardcoded enforcement is precisely what protects against this class of failure.
+
+**B. Hard gate with no override path.** Rejected: blocks legitimate staff/admin debugging. Would force staff to physically move characters to investigate incidents in locations they were not in at the time.
+
+**C. Three-layer model (hard gate by default + ABAC consultation + audit-only fallback).** Rejected: complexity disproportionate to the requirement.
+
+**D (selected): Hard gate by default + ABAC override path via dedicated `read_unrestricted_history` action.**
+
+## Consequences
+
+- **MUST** maintain the seeded `read_unrestricted_history` policy. Removal would break staff debugging.
+- **MUST** apply the temporal floor even under staff override (I-PRIV-6) — debugging "what did guest X see when they connected?" should reproduce the guest's view, not retroactive omniscience.
+- **MUST NOT** rely on ABAC alone for location-stream privacy invariants.
+- Removes one category of policy from ABAC eval cost, slightly improving the public-stream query path.
+- Sets precedent for future privacy invariants: code-enforced default with ABAC override for legitimate bypass.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` §3, §6.1, I-PRIV-1, I-PRIV-6
+- Bead: `holomush-iwzt`
+- Related ADRs: `holomush-kokk` (custom Go-native ABAC engine — staff override leverages this), `holomush-0tq6` (three-layer player access control — different layering pattern for player-level concerns)
+- Code: `internal/grpc/query_stream_history.go:157-214`, `internal/access/policy/seed.go:104` (existing admin role template)

--- a/docs/superpowers/plans/2026-05-17-history-scope-privacy.md
+++ b/docs/superpowers/plans/2026-05-17-history-scope-privacy.md
@@ -1,0 +1,2520 @@
+# History Scope Privacy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `dev-flow:subagent-driven-development` (recommended) or `dev-flow:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the connect-time history leak (`holomush-iwzt`) where new guests and reconnecting characters see prior in-character events from a location.
+
+**Architecture:** Two-tier privacy enforcement. **Tier 1**: per-session `LocationArrivedAt` on `SessionInfo`, populated at session-create / reattach / character-move, used by `QueryStreamHistory` for temporal floor and by Subscribe's `DeliverByStartTimePolicy` as a performance hint. **Tier 2**: per-subject filter-at-delivery in the Subscribe broadcaster as the load-bearing privacy gate. Location streams get a hardcoded current-location-only gate; ABAC remains for staff override only.
+
+**Tech Stack:** Go, PostgreSQL (sqlx + migrations), NATS JetStream (immutable consumer config, query-then-copy pattern), custom ABAC engine (Cedar-inspired DSL), Ginkgo/Gomega integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md`
+**Bead:** `holomush-iwzt` (design); ADRs `wxty`, `rc8b`, `kmac`, `ghpx`.
+
+---
+
+## File structure
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `internal/store/migrations/000037_add_session_history_floor_columns.up.sql` | Add `location_arrived_at` + `guest_character_created_at` columns to `sessions` table |
+| `internal/store/migrations/000037_add_session_history_floor_columns.down.sql` | Drop the two columns |
+| `internal/grpc/scope_floor.go` | `streamScopeFloor`, `isLocationStream`, `extractLocationID` helpers shared by `QueryStreamHistory` and Subscribe |
+| `internal/grpc/scope_floor_test.go` | Unit tests for the helpers (table-driven per stream type) |
+| `internal/world/movement_hook.go` | `MovementHook` interface (defined in world, implemented by core-server) |
+| `test/integration/privacy/privacy_test.go` | Ginkgo integration suite — all `TestPrivacy_*` scenarios from spec §8 |
+| `internal/eventbus/subscriber_consumer_config.go` | NATS-source-of-truth consumer-config builder (extracted helper for testability) |
+| `internal/eventbus/subscriber_consumer_config_test.go` | Unit tests for I-PRIV-8 (4 cases: fresh / reattach-existing / SetFilters-existing / lookup-error) |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `internal/session/session.go` | `Info` struct gains `LocationArrivedAt time.Time` + `GuestCharacterCreatedAt time.Time`; `Store` interface gains `UpdateLocationOnMove` |
+| `internal/session/memstore.go` | In-memory implementation of `UpdateLocationOnMove` |
+| `internal/store/session_store.go` | Postgres implementation of `UpdateLocationOnMove`; `Set`/`scan*` paths include the new columns |
+| `internal/grpc/auth_handlers.go` | Populate `LocationArrivedAt` on fresh `SelectCharacter` (~line 332-352); on `SelectCharacter` reattach (~line 295-310) |
+| `internal/grpc/server.go` | Populate `LocationArrivedAt` on `Subscribe.ReattachCAS` (~line 768-777); per-subject filter-at-delivery in the dispatch loop |
+| `internal/grpc/query_stream_history.go` | Restructure Step 5 (location hard-gate + staff override); Step 6 floor application |
+| `internal/world/service.go` | `MoveCharacter` invokes `MovementHook` after `characterRepo.UpdateLocation`, before event emit |
+| `internal/eventbus/subscriber.go` | `OpenSession` + `SetFilters` use the new NATS-source-of-truth consumer-config builder |
+| `internal/auth/guest_service.go` | Capture `world.Character.CreatedAt` into `SessionInfo.GuestCharacterCreatedAt` at guest session creation |
+| `internal/access/policy/seed.go` | Seed `staff_read_unrestricted_history` policy |
+| `internal/plugin/manifest.go` | `history_scope:` field with closed enum; reject plugin-owned namespaces without declaration |
+| `internal/plugin/manifest_test.go` | I-PRIV-7 manifest validation tests |
+| `test/meta/...` | Meta-test for I-PRIV-1..6, 8 (I-PRIV-7 vacuously satisfied until plugin adoption) |
+
+---
+
+## Phase 1 — Schema + lifecycle (no enforcement yet)
+
+### Task 1: Migration adding session history-floor columns
+
+**Files:**
+
+- Create: `internal/store/migrations/000037_add_session_history_floor_columns.up.sql`
+- Create: `internal/store/migrations/000037_add_session_history_floor_columns.down.sql`
+
+- [ ] **Step 1: Write the up migration**
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS location_arrived_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS guest_character_created_at TIMESTAMPTZ NOT NULL DEFAULT 'epoch';
+```
+
+- [ ] **Step 2: Write the down migration**
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS location_arrived_at,
+    DROP COLUMN IF EXISTS guest_character_created_at;
+```
+
+- [ ] **Step 3: Apply migration to dev DB and verify**
+
+```bash
+task migrate:up
+psql $DATABASE_URL -c "\d sessions" | grep -E "(location_arrived_at|guest_character_created_at)"
+```
+
+Expected: both columns present, `timestamp with time zone, not null`.
+
+- [ ] **Step 4: Verify migration is idempotent (up→down→up cycle)**
+
+```bash
+task migrate:down -- 1 && task migrate:up
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat(session): migration 037 — add history-floor columns to sessions`. Per `references/vcs-preamble.md`.
+
+---
+
+### Task 2: SessionInfo fields + store implementations
+
+**Files:**
+
+- Modify: `internal/session/session.go` — add fields to `Info` struct (~line 154-158); add `UpdateLocationOnMove` to `Store` interface (~line 227+)
+- Modify: `internal/session/memstore.go` — implement `UpdateLocationOnMove`
+- Modify: `internal/store/session_store.go` — implement `UpdateLocationOnMove`; update `Set` and `scan*` helpers
+- Test: `internal/session/memstore_test.go`; `internal/store/session_store_test.go`
+
+- [ ] **Step 1: Write the failing memstore test**
+
+Append to `internal/session/memstore_test.go`:
+
+```go
+func TestMemStoreUpdateLocationOnMove(t *testing.T) {
+    store := NewMemStore()
+    ctx := context.Background()
+    charID := NewULID()
+    origLoc := NewULID()
+    newLoc := NewULID()
+    origArrival := time.Now().UTC().Add(-time.Hour)
+    newArrival := time.Now().UTC()
+
+    info := &Info{
+        ID: NewULID().String(), CharacterID: charID,
+        LocationID: origLoc, LocationArrivedAt: origArrival,
+        Status: StatusActive, CreatedAt: origArrival, UpdatedAt: origArrival,
+    }
+    require.NoError(t, store.Set(ctx, info.ID, info))
+
+    require.NoError(t, store.UpdateLocationOnMove(ctx, charID, newLoc, newArrival))
+
+    got, err := store.Get(ctx, info.ID)
+    require.NoError(t, err)
+    assert.Equal(t, newLoc, got.LocationID)
+    assert.True(t, got.LocationArrivedAt.Equal(newArrival))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+`task test -- -run TestMemStoreUpdateLocationOnMove ./internal/session/`
+Expected: FAIL — method not defined.
+
+- [ ] **Step 3: Add fields to SessionInfo**
+
+In `internal/session/session.go`, in the `Info` struct (locate `LocationID ulid.ULID` ~line 147):
+
+```go
+LocationID              ulid.ULID
+LocationArrivedAt       time.Time // §holomush-iwzt §4.1 — per-session attach floor
+GuestCharacterCreatedAt time.Time // §holomush-iwzt §4.3 — guest identity overlay floor (zero for non-guest)
+IsGuest                 bool
+```
+
+- [ ] **Step 4: Add two methods to Store interface**
+
+In `internal/session/session.go` at the `Store` interface (~line 227, after `UpdateGridPresent` / before `ListActiveByLocation`):
+
+```go
+// UpdateLocationOnMove atomically updates LocationID and LocationArrivedAt
+// for all Active/Idle sessions belonging to characterID. Sessions in other
+// statuses (Detached, Expired) are NOT touched — they reattach with their
+// own LocationArrivedAt update path via BumpLocationArrivedAt. Per
+// holomush-iwzt §5 row 5.
+UpdateLocationOnMove(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error
+
+// BumpLocationArrivedAt updates LocationArrivedAt for a single session by ID,
+// regardless of status. Used by reattach paths (SelectCharacter-reattach,
+// Subscribe.ReattachCAS) where the session may still be in StatusDetached
+// when called, OR where transactional ordering between UpdateStatus(active)
+// and the floor bump matters. Per holomush-iwzt §5 rows 2, 3 + plan-review
+// round 1 finding B6.
+BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error
+```
+
+- [ ] **Step 5: Implement both methods in memstore**
+
+Append to `internal/session/memstore.go`:
+
+```go
+func (m *MemStore) UpdateLocationOnMove(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    for _, info := range m.sessions {
+        if info.CharacterID != characterID {
+            continue
+        }
+        if info.Status != StatusActive && info.Status != StatusIdle {
+            continue
+        }
+        info.LocationID = newLocationID
+        info.LocationArrivedAt = arrivedAt
+        info.UpdatedAt = arrivedAt
+    }
+    return nil
+}
+
+func (m *MemStore) BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    info, ok := m.sessions[sessionID]
+    if !ok {
+        return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
+    }
+    info.LocationArrivedAt = arrivedAt
+    info.UpdatedAt = arrivedAt
+    return nil
+}
+```
+
+- [ ] **Step 6: Implement both methods in postgres session_store**
+
+In `internal/store/session_store.go`, add:
+
+```go
+func (s *SessionStore) UpdateLocationOnMove(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+    query := `UPDATE sessions
+              SET location_id = $1, location_arrived_at = $2, updated_at = $2
+              WHERE character_id = $3 AND status IN ('active', 'idle')`
+    _, err := s.db.ExecContext(ctx, query, newLocationID, arrivedAt, characterID)
+    if err != nil {
+        return oops.With("operation", "update_location_on_move").
+            With("character_id", characterID.String()).
+            Wrap(err)
+    }
+    return nil
+}
+
+func (s *SessionStore) BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error {
+    query := `UPDATE sessions
+              SET location_arrived_at = $1, updated_at = $1
+              WHERE id = $2`
+    res, err := s.db.ExecContext(ctx, query, arrivedAt, sessionID)
+    if err != nil {
+        return oops.With("operation", "bump_location_arrived_at").
+            With("session_id", sessionID).Wrap(err)
+    }
+    n, _ := res.RowsAffected()
+    if n == 0 {
+        return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
+    }
+    return nil
+}
+```
+
+Also: in `Set` and the row-scan helpers (lines around 40-50 and 121-180), add `location_arrived_at` and `guest_character_created_at` to the column lists and scan/value bindings.
+
+- [ ] **Step 7: Run all session tests to verify pass**
+
+`task test -- ./internal/session/ ./internal/store/`
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+Commit message: `feat(session): add LocationArrivedAt + GuestCharacterCreatedAt to SessionInfo + UpdateLocationOnMove`.
+
+---
+
+### Task 3: Populate LocationArrivedAt on all session-create / reattach paths
+
+**Files:**
+
+- Modify: `internal/grpc/auth_handlers.go:295-352` (SelectCharacter — both fresh and reattach)
+- Modify: `internal/grpc/server.go:768-777` (Subscribe.ReattachCAS)
+- Test: `internal/grpc/auth_handlers_test.go`; `internal/grpc/server_test.go`
+
+- [ ] **Step 1: Write failing test for fresh SelectCharacter populates LocationArrivedAt**
+
+Append to `internal/grpc/auth_handlers_test.go`:
+
+```go
+func TestSelectCharacter_FreshSession_SetsLocationArrivedAt(t *testing.T) {
+    server, ctx := newTestCoreServer(t)
+    playerSession := seedPlayerWithCharacter(t, server, "Alyssa", someLocationID)
+
+    before := time.Now()
+    resp, err := server.SelectCharacter(ctx, &corev1.SelectCharacterRequest{
+        PlayerSessionToken: playerSession.Token,
+        CharacterName:      "Alyssa",
+    })
+    require.NoError(t, err)
+
+    info, _ := server.sessionStore.Get(ctx, resp.SessionId)
+    assert.True(t, !info.LocationArrivedAt.Before(before), "LocationArrivedAt should be at-or-after request time")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+`task test -- -run TestSelectCharacter_FreshSession_SetsLocationArrivedAt ./internal/grpc/`
+Expected: FAIL — `LocationArrivedAt` is zero.
+
+- [ ] **Step 3: Update fresh SelectCharacter to populate field**
+
+In `internal/grpc/auth_handlers.go` around line 331-343 (where `sessionInfo := &session.Info{...}` is constructed), add:
+
+```go
+sessionInfo := &session.Info{
+    // ... existing fields ...
+    LocationID:              locationID,
+    LocationArrivedAt:       now,   // NEW
+    Status:                  session.StatusActive,
+    // ... existing fields ...
+    CreatedAt:               now,
+    UpdatedAt:               now,
+}
+```
+
+- [ ] **Step 4: Write failing test for SelectCharacter reattach also resets LocationArrivedAt**
+
+```go
+func TestSelectCharacter_Reattach_ResetsLocationArrivedAt(t *testing.T) {
+    server, ctx := newTestCoreServer(t)
+    playerSession := seedPlayerWithCharacter(t, server, "Bertram", someLocationID)
+    resp1, _ := server.SelectCharacter(ctx, ... /* fresh */)
+    detachSession(t, server, resp1.SessionId)
+    time.Sleep(10 * time.Millisecond) // ensure measurable gap
+
+    before := time.Now()
+    resp2, err := server.SelectCharacter(ctx, &corev1.SelectCharacterRequest{
+        PlayerSessionToken: playerSession.Token, CharacterName: "Bertram",
+    })
+    require.NoError(t, err)
+    require.True(t, resp2.Reattached)
+
+    info, _ := server.sessionStore.Get(ctx, resp2.SessionId)
+    assert.True(t, !info.LocationArrivedAt.Before(before), "reattach must advance LocationArrivedAt — I-PRIV-3")
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+Expected: FAIL — reattach branch doesn't touch `LocationArrivedAt`.
+
+- [ ] **Step 6: Add LocationArrivedAt update to SelectCharacter reattach branch**
+
+In `internal/grpc/auth_handlers.go` around line 297-303 (existing reattach branch). Use `BumpLocationArrivedAt` (single-session, status-agnostic) rather than `UpdateLocationOnMove` to avoid the SQL `WHERE status IN ('active', 'idle')` filter race — `UpdateStatus(active)` must commit before any character-status-filtered UPDATE would see the row as Active:
+
+```go
+now := time.Now()
+if updateErr := s.sessionStore.UpdateStatus(ctx, existingSession.ID,
+    session.StatusActive, nil, nil); updateErr != nil { ... }
+// NEW: bump LocationArrivedAt by ID (no status filter) to enforce I-PRIV-3
+// rule-3 reset semantics. Independent of UpdateStatus commit ordering.
+if loErr := s.sessionStore.BumpLocationArrivedAt(ctx, existingSession.ID, now); loErr != nil {
+    slog.WarnContext(ctx, "failed to reset LocationArrivedAt on reattach", "error", loErr)
+}
+existingSession.Status = session.StatusActive
+existingSession.LocationArrivedAt = now
+existingSession.UpdatedAt = now
+```
+
+- [ ] **Step 7: Write failing test for Subscribe.ReattachCAS reset**
+
+In `internal/grpc/server_test.go`:
+
+```go
+func TestSubscribeReattachCAS_AdvancesLocationArrivedAt(t *testing.T) {
+    server, ctx := newTestCoreServer(t)
+    sessionID := seedDetachedSession(t, server, "Cyrus", someLocationID, /*detachedSinceOffset*/ -time.Hour)
+
+    before := time.Now()
+    stream := openSubscribe(t, server, sessionID)
+    defer stream.CloseSend()
+
+    info, _ := server.sessionStore.Get(ctx, sessionID)
+    assert.True(t, !info.LocationArrivedAt.Before(before), "ReattachCAS must advance LocationArrivedAt — I-PRIV-3")
+}
+```
+
+- [ ] **Step 8: Run test to verify it fails**
+
+Expected: FAIL — `ReattachCAS` doesn't update `LocationArrivedAt`.
+
+- [ ] **Step 9: Add LocationArrivedAt update to Subscribe.ReattachCAS path**
+
+In `internal/grpc/server.go` around line 768-777 (after `sessionStore.ReattachCAS` succeeds). Use `BumpLocationArrivedAt` for the same reason as Step 6 — the CAS sets status to Active but our floor bump should not depend on its commit ordering:
+
+```go
+won, casErr := s.sessionStore.ReattachCAS(ctx, sessionID)
+if casErr != nil { ... }
+if !won {
+    return nil, status.Errorf(codes.FailedPrecondition,
+        "session reattach CAS lost — another handler won the race")
+}
+// NEW: bump LocationArrivedAt by ID to enforce I-PRIV-3 reset semantics.
+now := time.Now()
+if loErr := s.sessionStore.BumpLocationArrivedAt(ctx, sessionID, now); loErr != nil {
+    slog.WarnContext(ctx, "failed to reset LocationArrivedAt on ReattachCAS", "error", loErr)
+}
+```
+
+- [ ] **Step 10: Run all three tests + lint**
+
+`task test -- ./internal/grpc/ && task lint`
+Expected: all PASS, lint clean.
+
+- [ ] **Step 11: Commit**
+
+Commit message: `feat(grpc): set LocationArrivedAt on fresh+reattach session paths (iwzt rule-3)`.
+
+---
+
+### Task 4: MovementHook interface + character-move session sync
+
+**Files:**
+
+- Create: `internal/world/movement_hook.go`
+- Modify: `internal/world/service.go:759-790` (MoveCharacter)
+- Modify: `cmd/holomush/` or wherever core-server wires deps — implement `MovementHook`
+- Test: `internal/world/service_test.go`
+
+- [ ] **Step 1: Define MovementHook interface**
+
+Create `internal/world/movement_hook.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package world
+
+import (
+    "context"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+)
+
+// MovementHook is invoked by Service.MoveCharacter after the character row
+// is updated but before the move event is emitted. Implementations propagate
+// the new location to dependent stores (e.g., session.Store.UpdateLocationOnMove)
+// so consumers reading those stores observe the new location atomically with
+// the move event.
+//
+// Per holomush-iwzt §5.1 / ADR holomush-kmac: this preserves the
+// gateway/world layering invariant by letting core-server (which holds both
+// world.Service and session.Store deps) implement the hook without world.Service
+// gaining a session.Store dependency.
+//
+// Returning an error from the hook fails the move — caller MUST handle.
+type MovementHook interface {
+    OnCharacterMoved(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error
+}
+
+// NoopMovementHook is the default when no hook is wired (e.g., test contexts).
+// Returns nil unconditionally.
+type NoopMovementHook struct{}
+
+func (NoopMovementHook) OnCharacterMoved(_ context.Context, _ ulid.ULID, _ ulid.ULID, _ time.Time) error {
+    return nil
+}
+```
+
+- [ ] **Step 2: Add hook field to Service + setter; locate constructor**
+
+First locate the Service constructor pattern: `rg -nP "func New(Service|ServiceWithConfig|World)\b" internal/world/service.go`. Existing pattern is likely `NewService(...)` returning `*Service`. Read those ~10 lines to identify the field-init style (struct literal vs. options struct).
+
+In `internal/world/service.go` near the struct definition:
+
+```go
+type Service struct {
+    // ... existing fields ...
+    movementHook MovementHook
+}
+```
+
+Update the constructor to default-initialize:
+
+```go
+func NewService(/* existing params */) *Service {
+    return &Service{
+        // ... existing fields ...
+        movementHook: NoopMovementHook{},
+    }
+}
+```
+
+Add the setter for explicit installation by core-server at startup:
+
+```go
+// SetMovementHook installs a MovementHook that fires after each successful
+// character move. Default is NoopMovementHook. Call before MoveCharacter
+// invocations begin (typically at server startup).
+func (s *Service) SetMovementHook(h MovementHook) {
+    if h == nil {
+        s.movementHook = NoopMovementHook{}
+        return
+    }
+    s.movementHook = h
+}
+```
+
+Because the default is non-nil (`NoopMovementHook{}`), the call site in Step 3 can omit the `if s.movementHook != nil` nil-check — the field is always callable. Use that simpler form below.
+
+- [ ] **Step 3: Wire MovementHook into MoveCharacter**
+
+In `internal/world/service.go:759-790`, between `characterRepo.UpdateLocation` (~line 789) and the `MovePayload` build (~line 793):
+
+```go
+if err := s.characterRepo.UpdateLocation(ctx, characterID, &toLocationID); err != nil {
+    return oops.Code("CHARACTER_MOVE_FAILED").Wrapf(err, "update character %s location", characterID)
+}
+
+// Fire MovementHook BEFORE event emit so any consumer observing the move
+// event sees the synchronized state. Per holomush-iwzt §5.1 / ADR kmac.
+// Constructor default-initializes movementHook to NoopMovementHook{}, so
+// no nil-check is required here.
+//
+// Failure mode (known): if the hook returns an error, characterRepo
+// has ALREADY committed the new location (line 789 above). The session
+// store will lag the character row; no move event is emitted. The
+// caller surfaces CHARACTER_MOVE_FAILED with phase="movement_hook"
+// for operator diagnostics. This window is acceptable for v1 — the
+// existing pre-hook state already had `sessions.location_id` lagging
+// `characters.location_id` permanently (the bug being fixed). Filed as
+// follow-up: wrap UpdateLocation + hook + event-emit in a single DB
+// transaction. Tracked as a sub-bullet under Step 7 audit.
+arrivedAt := time.Now().UTC()
+if hookErr := s.movementHook.OnCharacterMoved(ctx, characterID, toLocationID, arrivedAt); hookErr != nil {
+    return oops.Code("CHARACTER_MOVE_FAILED").
+        With("character_id", characterID.String()).
+        With("phase", "movement_hook").
+        Wrap(hookErr)
+}
+
+// Build move payload (existing code follows)...
+```
+
+- [ ] **Step 4: Implement MovementHook in core-server**
+
+Locate where `world.Service` is constructed (likely `cmd/holomush/` or `internal/grpc/`). Add an adapter:
+
+```go
+type sessionStoreMovementHook struct {
+    sessions session.Store
+}
+
+func (h *sessionStoreMovementHook) OnCharacterMoved(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+    return h.sessions.UpdateLocationOnMove(ctx, characterID, newLocationID, arrivedAt)
+}
+```
+
+Then at server startup, after constructing `worldService` and `sessionStore`:
+
+```go
+worldService.SetMovementHook(&sessionStoreMovementHook{sessions: sessionStore})
+```
+
+- [ ] **Step 5: Write integration test for MoveCharacter syncs session**
+
+Append to `internal/world/service_test.go` (or a new test file if appropriate):
+
+```go
+func TestMoveCharacter_FiresMovementHook(t *testing.T) {
+    var captured struct {
+        charID, locID ulid.ULID
+        ts            time.Time
+    }
+    var hookFired bool
+    hook := movementHookFn(func(_ context.Context, charID, locID ulid.ULID, ts time.Time) error {
+        hookFired = true
+        captured.charID, captured.locID, captured.ts = charID, locID, ts
+        return nil
+    })
+    svc := newTestServiceWithHook(t, hook)
+    charID, fromLoc, toLoc := seedCharacterAndTwoLocations(t, svc)
+
+    require.NoError(t, svc.MoveCharacter(ctx, adminSubject, charID, toLoc))
+
+    require.True(t, hookFired)
+    assert.Equal(t, charID, captured.charID)
+    assert.Equal(t, toLoc, captured.locID)
+    assert.WithinDuration(t, time.Now(), captured.ts, 5*time.Second)
+}
+
+type movementHookFn func(ctx context.Context, charID, locID ulid.ULID, ts time.Time) error
+
+func (f movementHookFn) OnCharacterMoved(ctx context.Context, charID, locID ulid.ULID, ts time.Time) error {
+    return f(ctx, charID, locID, ts)
+}
+```
+
+- [ ] **Step 6: Run test + lint**
+
+`task test -- ./internal/world/ ./internal/grpc/ ./internal/session/ && task lint`
+
+- [ ] **Step 7: Audit existing consumers of session.LocationID**
+
+Run `rg -nP "\.LocationID" --type go internal/ | grep -v _test.go | grep -v session.LocationID` and review the call sites. For each, confirm it's safe with the previously-stale value now becoming canonical. Document any concerning consumer in a `bd note holomush-iwzt "consumer audit: <path:line> — <verdict>"`. If any consumer requires special handling, file a follow-up bead.
+
+- [ ] **Step 8: Commit**
+
+Commit message: `feat(world): MovementHook interface + sessions/characters location-sync (iwzt kmac)`.
+
+---
+
+### Task 5: GuestCharacterCreatedAt population at guest session creation
+
+**Files:**
+
+- Modify: `internal/auth/guest_service.go:109-200` (CreateGuest)
+- Modify: `internal/grpc/auth_handlers.go` (wherever guest sessions are minted from GuestService output)
+- Test: `internal/auth/guest_service_test.go`
+
+- [ ] **Step 1: Trace the guest-session creation path**
+
+Run `rg -nP "guestService|CreateGuest|GuestResult" --type go internal/grpc/` to find where `GuestService.CreateGuest`'s `*GuestResult` is consumed and turned into a `SessionInfo`. Likely in `internal/grpc/auth_handlers.go`. Confirm whether the session is built in `auth/guest_service.go` or in the calling handler.
+
+- [ ] **Step 2: Write failing test asserting guest session has GuestCharacterCreatedAt set**
+
+```go
+func TestGuestSessionCarriesCharacterCreatedAt(t *testing.T) {
+    server, ctx := newTestCoreServer(t)
+    resp, err := server.CreateGuestSession(ctx, &corev1.CreateGuestSessionRequest{})
+    require.NoError(t, err)
+    info, _ := server.sessionStore.Get(ctx, resp.SessionId)
+    require.True(t, info.IsGuest)
+    assert.False(t, info.GuestCharacterCreatedAt.IsZero(),
+        "guest session must capture character.CreatedAt for I-PRIV-2 floor")
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Expected: FAIL — `GuestCharacterCreatedAt` is zero.
+
+- [ ] **Step 4: Populate GuestCharacterCreatedAt at the session-build site**
+
+Whichever site constructs the guest `SessionInfo`, add (sourced from `world.Character.CreatedAt` on the just-created character):
+
+```go
+sessionInfo := &session.Info{
+    // ... existing fields ...
+    IsGuest:                 true,
+    GuestCharacterCreatedAt: char.CreatedAt,  // NEW
+    // ... existing fields ...
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+`task test -- -run TestGuestSessionCarriesCharacterCreatedAt ./internal/grpc/`
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat(auth): capture guest character.CreatedAt into SessionInfo (iwzt I-PRIV-2)`.
+
+---
+
+## Phase 2 — Location-stream hard-gate + floor
+
+### Task 5.5: Build the privacy-test harness in `internal/testsupport/privacytest/`
+
+**Files:**
+
+- Create: `internal/testsupport/privacytest/privacy_harness.go`
+- Create: `internal/testsupport/privacytest/privacy_session.go`
+- Create: `internal/testsupport/privacytest/matchers.go`
+
+The integration tests in Tasks 9-22 reference helpers like `ts.ConnectGuest`, `sess.MoveTo`, `sess.DetachTransport`, `MatchOopsCode`. None exist today — the only file in `internal/testsupport/privacytest/` is the admin-socket/rekey-scoped `server.go`. This task builds the missing harness as a self-contained dependency of all later integration tests.
+
+- [ ] **Step 1: Survey existing patterns**
+
+Read `test/integration/plugin/binary_plugin_test.go` and `test/integration/auth/core_client_shim_test.go` to see how integration tests currently bootstrap a server + connect ConnectRPC clients. The harness wraps these patterns.
+
+- [ ] **Step 2: Define the Server type with bootstrap**
+
+`internal/testsupport/privacytest/privacy_harness.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package privacytest
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+    corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// Server is the privacy-test harness wrapping a real holomush stack
+// (Postgres + NATS JetStream + core-server + gateway) for integration
+// testing of holomush-iwzt history-scope invariants.
+type Server struct {
+    t              *testing.T
+    coreClient     corev1.CoreServiceClient
+    sessionStore   sessionStoreAccessor  // exposes UpdateLocationOnMove for test-driven floor manipulation
+    // ... bus, db connections, cleanup funcs
+}
+
+// Start bootstraps a full stack and returns a Server. Caller MUST defer Stop.
+func Start(t *testing.T) *Server { /* spin up testcontainers, run migrations, start core+gateway */ return nil }
+
+// Stop tears down the stack.
+func (s *Server) Stop() { /* ... */ }
+
+// NewLocation creates a fresh location in the world. Returns its ULID.
+func (s *Server) NewLocation(ctx context.Context) ulid.ULID { /* ... */ return ulid.ULID{} }
+
+// NewSceneWithoutMember creates a scene with no members. Returns its ULID.
+func (s *Server) NewSceneWithoutMember(ctx context.Context) ulid.ULID { /* ... */ return ulid.ULID{} }
+```
+
+- [ ] **Step 3: Define the Session type**
+
+`internal/testsupport/privacytest/privacy_session.go`:
+
+```go
+//go:build integration
+
+package privacytest
+
+import (
+    "context"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+    corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// Session wraps an authenticated or guest game session for testing.
+type Session struct {
+    server            *Server
+    SessionID         string
+    CharacterID       ulid.ULID
+    CharacterName     string
+    LocationID        ulid.ULID
+    OriginalLocationID ulid.ULID    // set at connect; not mutated by MoveTo
+    LocationArrivedAt time.Time
+    SessionCreatedAt  time.Time
+    LastReattachAt    time.Time
+    Client            corev1.CoreServiceClient
+    subscribeCancel   context.CancelFunc
+}
+
+// Server-side connect helpers.
+func (s *Server) ConnectGuest(ctx context.Context) *Session                          { /* ... */ return nil }
+func (s *Server) ConnectAuthed(ctx context.Context, charName string) *Session        { /* ... */ return nil }
+func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, roles []string) *Session { /* ... */ return nil }
+func (s *Server) AuthedPlayer(ctx context.Context, charName string) *AuthedPlayer    { /* ... */ return nil }
+
+// AuthedPlayer represents a player with potentially multiple sessions for the
+// same character. Used for multi-session continuity tests.
+type AuthedPlayer struct {
+    PlayerID    ulid.ULID
+    CharacterID ulid.ULID
+    LocationID  ulid.ULID
+    server      *Server
+}
+
+func (p *AuthedPlayer) OpenWebSession(ctx context.Context) *Session    { /* ... */ return nil }
+func (p *AuthedPlayer) OpenTelnetSession(ctx context.Context) *Session { /* ... */ return nil }
+
+// Session command helpers.
+func (s *Session) SendCommand(ctx context.Context, cmd string) error                                       { /* ... */ return nil }
+func (s *Session) WaitForEvent(ctx context.Context, eventType string) *corev1.GameEvent                    { /* ... */ return nil }
+func (s *Session) DrainEvents(ctx context.Context, timeout time.Duration) []*corev1.GameEvent              { /* ... */ return nil }
+func (s *Session) Logout(ctx context.Context)                                                              { /* ... */ }
+func (s *Session) MoveTo(ctx context.Context, newLocationID ulid.ULID)                                     { /* ... */ }
+func (s *Session) DetachTransport(ctx context.Context)                                                     { /* ... */ }
+func (s *Session) ReattachTransport(ctx context.Context)                                                   { /* ... */ }
+func (s *Session) CreateScene(ctx context.Context) ulid.ULID                                               { /* ... */ return ulid.ULID{} }
+func (s *Session) JoinScene(ctx context.Context, sceneID ulid.ULID)                                        { /* ... */ }
+func (s *Session) QueryStreamHistory(ctx context.Context, stream string) []*corev1.GameEvent               { /* ... */ return nil }
+
+// Test-driven session-store manipulation.
+func (s *Server) ExpireSession(ctx context.Context, sessionID string) { /* directly mark the session row expired */ }
+```
+
+- [ ] **Step 4: Define the MatchOopsCode Gomega matcher**
+
+`internal/testsupport/privacytest/matchers.go`:
+
+```go
+//go:build integration
+
+package privacytest
+
+import (
+    "fmt"
+
+    "github.com/onsi/gomega/types"
+    "github.com/samber/oops"
+)
+
+// MatchOopsCode returns a Gomega matcher that succeeds when the actual error
+// is an oops error whose Code() matches expected. Use:
+//   Expect(err).To(MatchOopsCode("STREAM_ACCESS_DENIED"))
+func MatchOopsCode(expected string) types.GomegaMatcher {
+    return &oopsCodeMatcher{expected: expected}
+}
+
+type oopsCodeMatcher struct {
+    expected string
+    gotCode  string
+}
+
+func (m *oopsCodeMatcher) Match(actual interface{}) (bool, error) {
+    err, ok := actual.(error)
+    if !ok || err == nil {
+        return false, fmt.Errorf("MatchOopsCode expects an error, got %T", actual)
+    }
+    oopsErr, ok := oops.AsOops(err)
+    if !ok {
+        return false, nil
+    }
+    m.gotCode = oopsErr.Code()
+    return m.gotCode == m.expected, nil
+}
+
+func (m *oopsCodeMatcher) FailureMessage(actual interface{}) string {
+    return fmt.Sprintf("expected oops code %q, got %q (full err: %v)", m.expected, m.gotCode, actual)
+}
+
+func (m *oopsCodeMatcher) NegatedFailureMessage(actual interface{}) string {
+    return fmt.Sprintf("expected oops code NOT to be %q, but it was", m.expected)
+}
+```
+
+- [ ] **Step 5: Implement the Start bootstrap**
+
+Use testcontainers (per existing integration tests) to spin up Postgres + NATS. Run all migrations via the same path `task migrate:up` uses. Start a core-server bound to those backends. Construct gRPC clients via in-process pipe (per `test/integration/auth/core_client_shim_test.go` pattern). Wire down to teardown all of it in `Stop()`.
+
+Reference the existing `internal/testsupport/privacytest/server.go` for the testcontainers + bus patterns.
+
+- [ ] **Step 6: Implement Session helpers minimally**
+
+For each helper, implement against the real `CoreServiceClient`:
+
+- `SendCommand` → `client.SendCommand(...)`
+- `MoveTo` → invoke `MoveCharacter` via the client (find the appropriate RPC; may need `WorldService` client)
+- `DetachTransport` → close the Subscribe stream and clear `subscribeCancel`
+- `ReattachTransport` → open a new Subscribe stream; record `LastReattachAt = time.Now()`
+- `QueryStreamHistory` → `client.QueryStreamHistory(...)` returns events
+- `Logout` → `client.Logout(...)` or equivalent
+- `JoinScene` → `client.JoinScene(...)` or `FocusCoordinator.JoinScene(...)`
+- `WaitForEvent` → `select`-loop with timeout reading from a per-session events channel populated by the Subscribe goroutine
+
+- [ ] **Step 7: Verify harness compiles**
+
+```bash
+task test -- -tags=integration -run=^$ ./internal/testsupport/privacytest/...
+```
+
+Expected: build succeeds, no tests run (the `-run=^$` matches nothing).
+
+- [ ] **Step 8: Write a smoke test exercising the harness**
+
+`internal/testsupport/privacytest/privacy_harness_smoke_test.go`:
+
+```go
+//go:build integration
+
+package privacytest_test
+
+import (
+    "context"
+    "testing"
+
+    . "github.com/onsi/gomega"
+    "github.com/holomush/holomush/internal/testsupport/privacytest"
+)
+
+func TestPrivacyHarnessSmoke(t *testing.T) {
+    g := NewGomegaWithT(t)
+    ts := privacytest.Start(t)
+    defer ts.Stop()
+
+    ctx := context.Background()
+    guest := ts.ConnectGuest(ctx)
+    g.Expect(guest.SessionID).NotTo(BeEmpty())
+    g.Expect(guest.CharacterName).NotTo(BeEmpty())
+    g.Expect(guest.LocationID.IsZero()).To(BeFalse())
+
+    g.Expect(guest.SendCommand(ctx, "say hello-from-smoke-test")).To(Succeed())
+    ev := guest.WaitForEvent(ctx, "core-communication:say")
+    g.Expect(ev).NotTo(BeNil())
+
+    guest.Logout(ctx)
+}
+```
+
+- [ ] **Step 9: Run smoke test**
+
+```bash
+task test:int -- -run TestPrivacyHarnessSmoke ./internal/testsupport/privacytest/
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+Commit message: `feat(testsupport): privacy-test harness (privacytest.Server + Session + matchers)`.
+
+---
+
+### Task 6: `streamScopeFloor` + `isLocationStream` helpers
+
+**Files:**
+
+- Create: `internal/grpc/scope_floor.go`
+- Create: `internal/grpc/scope_floor_test.go`
+
+- [ ] **Step 1: Write failing unit tests (table-driven)**
+
+`internal/grpc/scope_floor_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+    "testing"
+    "time"
+
+    "github.com/oklog/ulid/v2"
+    "github.com/stretchr/testify/assert"
+
+    "github.com/holomush/holomush/internal/session"
+)
+
+func TestStreamScopeFloor(t *testing.T) {
+    locID := ulid.MustParse("01H000000000000000000000A1")
+    charID := ulid.MustParse("01H000000000000000000000C1")
+    sceneID := ulid.MustParse("01H000000000000000000000S1")
+    arrival := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+    sceneJoin := time.Date(2026, 5, 17, 11, 0, 0, 0, time.UTC)
+    guestCreated := time.Date(2026, 5, 17, 9, 30, 0, 0, time.UTC)
+
+    cases := []struct {
+        name   string
+        info   *session.Info
+        stream string
+        want   time.Time
+    }{
+        {"location current — non-guest", &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival},
+            "location:" + locID.String(), arrival},
+        {"location current — guest, arrival later than guest_created",
+            &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
+            "location:" + locID.String(), arrival},
+        {"location current — guest, guest_created later than arrival (shouldn't happen but MAX wins)",
+            &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: time.Time{}, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
+            "location:" + locID.String(), guestCreated},
+        {"scene member — non-guest, uses JoinedAt",
+            &session.Info{CharacterID: charID, FocusMemberships: []session.FocusMembership{
+                {Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: sceneJoin},
+            }}, "scene:" + sceneID.String() + ":ic", sceneJoin},
+        {"character own stream — no floor", &session.Info{CharacterID: charID}, "character:" + charID.String(), time.Time{}},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := streamScopeFloor(tc.info, tc.stream)
+            assert.True(t, got.Equal(tc.want), "got %v want %v", got, tc.want)
+        })
+    }
+}
+
+func TestIsLocationStream(t *testing.T) {
+    assert.True(t, isLocationStream("location:01H000000000000000000000A1"))
+    assert.False(t, isLocationStream("scene:01H000000000000000000000S1:ic"))
+    assert.False(t, isLocationStream("character:01H000000000000000000000C1"))
+    assert.False(t, isLocationStream("global"))
+}
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+`task test -- ./internal/grpc/ -run TestStreamScopeFloor`
+Expected: FAIL — symbols don't exist.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `internal/grpc/scope_floor.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+    "strings"
+    "time"
+
+    "github.com/holomush/holomush/internal/session"
+)
+
+// streamScopeFloor returns the temporal floor for a session's view of the
+// given stream. Per holomush-iwzt §6.1.
+func streamScopeFloor(info *session.Info, stream string) time.Time {
+    var base time.Time
+    switch {
+    case isLocationStream(stream):
+        base = info.LocationArrivedAt
+    case strings.HasPrefix(stream, "scene:"):
+        sceneID, ok := extractSceneID(stream)
+        if !ok {
+            return time.Time{}
+        }
+        for _, m := range info.FocusMemberships {
+            if m.Kind == session.FocusKindScene && m.TargetID.String() == sceneID {
+                base = m.JoinedAt
+                break
+            }
+        }
+    case strings.HasPrefix(stream, "character:"):
+        return time.Time{}
+    default:
+        return time.Time{}
+    }
+    if info.IsGuest && info.GuestCharacterCreatedAt.After(base) {
+        return info.GuestCharacterCreatedAt
+    }
+    return base
+}
+
+// isLocationStream reports whether a stream subject is a grid location stream.
+// Per holomush-iwzt §3.
+func isLocationStream(stream string) bool {
+    if !strings.HasPrefix(stream, "location:") {
+        return false
+    }
+    rest := strings.TrimPrefix(stream, "location:")
+    return rest != "" && !strings.Contains(rest, ":")
+}
+
+// extractLocationID returns the ULID portion of a location stream.
+// Caller MUST check isLocationStream first; otherwise behavior is undefined.
+func extractLocationID(stream string) string {
+    return strings.TrimPrefix(stream, "location:")
+}
+
+// extractSceneID returns the scene ULID from a scene:<id>:ic or scene:<id>:ooc subject.
+func extractSceneID(stream string) (string, bool) {
+    rest := strings.TrimPrefix(stream, "scene:")
+    parts := strings.SplitN(rest, ":", 2)
+    if len(parts) != 2 {
+        return "", false
+    }
+    return parts[0], true
+}
+```
+
+- [ ] **Step 4: Run tests — verify pass**
+
+`task test -- ./internal/grpc/ -run TestStreamScopeFloor && task test -- ./internal/grpc/ -run TestIsLocationStream`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat(grpc): scope_floor helpers (streamScopeFloor, isLocationStream)`.
+
+---
+
+### Task 7: QueryStreamHistory restructure — hard-gate + floor application
+
+**Files:**
+
+- Modify: `internal/grpc/query_stream_history.go:156-220`
+
+- [ ] **Step 1: Write failing test for hard-gate denial when not in location**
+
+Append to `internal/grpc/query_stream_history_test.go`:
+
+```go
+func TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation(t *testing.T) {
+    server, ctx := newTestCoreServerWithBus(t)
+    sess := seedActiveSessionInLocation(t, server, "Diana", locA)
+
+    resp, err := server.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+        SessionId: sess.ID,
+        Stream:    "location:" + locB.String(),  // different location
+    })
+    require.Nil(t, resp)
+    require.Error(t, err)
+    errutil.AssertErrorCode(t, err, "STREAM_ACCESS_DENIED")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — current code calls ABAC which permits read by default seed policy.
+
+- [ ] **Step 3: Add staffOverride stub**
+
+In `internal/grpc/scope_floor.go` (or a sibling file), add a stub returning false:
+
+```go
+// staffOverride is a stub for Phase 5 (staff ABAC override). Phase 2 ships
+// with this returning false unconditionally so the hard-gate is exercised.
+// Phase 5 replaces with a real ABAC engine.Evaluate call against
+// "read_unrestricted_history".
+func staffOverride(_ context.Context, _ *session.Info, _ accessTypes.AccessPolicyEngine) bool {
+    return false
+}
+
+// staffOverride takes the existing accessTypes.AccessPolicyEngine
+// (`internal/access/policy/types/types.go:474`) rather than declaring a
+// parallel local interface. The existing s.accessEngine field at
+// `internal/grpc/server.go:163` is already typed accessTypes.AccessPolicyEngine,
+// so the stub and real impl below both consume that type directly.
+```
+
+(Adjust imports/type names to match the actual `internal/access` types — verify via `rg "type AccessRequest" internal/access/policy/types/`.)
+
+- [ ] **Step 4: Restructure QueryStreamHistory Step 5**
+
+In `internal/grpc/query_stream_history.go` between lines 156 and 214, replace the public-stream ABAC branch:
+
+```go
+// Step 5: Authorization — three-way classifier.
+if isPrivateStream(req.Stream) {
+    // (existing I-17 membership gate — unchanged)
+    if strings.HasPrefix(req.Stream, "scene:") {
+        if _, keyErr := streamToFocusKey(req.Stream); keyErr != nil {
+            return nil, keyErr
+        }
+    }
+    if !sessionHasMembership(info, req.Stream) {
+        slog.InfoContext(ctx, "stream access denied by I-17 membership gate",
+            "session_id", req.SessionId, "denial_reason", "not_member",
+            "character_id", info.CharacterID.String(), "stream", req.Stream)
+        return nil, oops.Code("STREAM_ACCESS_DENIED").
+            With("session_id", req.SessionId).With("stream", req.Stream).
+            Errorf("not authorized to read stream")
+    }
+} else if isLocationStream(req.Stream) {
+    // NEW: hard-gate for location streams.
+    if !staffOverride(ctx, info, s.accessEngine) {
+        if info.LocationID.String() != extractLocationID(req.Stream) {
+            slog.InfoContext(ctx, "stream access denied by location hard-gate",
+                "session_id", req.SessionId, "denial_reason", "wrong_location",
+                "character_id", info.CharacterID.String(),
+                "session_location", info.LocationID.String(),
+                "requested_stream", req.Stream)
+            return nil, oops.Code("STREAM_ACCESS_DENIED").
+                With("session_id", req.SessionId).With("stream", req.Stream).
+                Errorf("not authorized to read stream")
+        }
+    }
+} else {
+    // Other public streams (global, system) — existing ABAC path unchanged.
+    if s.accessEngine == nil {
+        return nil, oops.Code("STREAM_ACCESS_DENIED").With("stream", req.Stream).
+            Errorf("access engine not configured")
+    }
+    accessReq, reqErr := accessTypes.NewAccessRequest(
+        "character:"+info.CharacterID.String(),
+        accessTypes.ActionRead, "stream:"+req.Stream, nil,
+    )
+    if reqErr != nil { return nil, oops.Code("INTERNAL").Wrap(reqErr) }
+    decision, evalErr := s.accessEngine.Evaluate(ctx, accessReq)
+    if evalErr != nil {
+        return nil, oops.Code("INTERNAL").With("stream", req.Stream).Wrap(evalErr)
+    }
+    if !decision.IsAllowed() {
+        slog.InfoContext(ctx, "stream access denied by ABAC",
+            "session_id", req.SessionId, "denial_reason", "policy_denied",
+            "character_id", info.CharacterID.String(),
+            "stream", req.Stream, "policy_id", decision.PolicyID())
+        return nil, oops.Code("STREAM_ACCESS_DENIED").
+            With("session_id", req.SessionId).With("stream", req.Stream).
+            Errorf("not authorized to read stream")
+    }
+}
+```
+
+- [ ] **Step 5: Apply scope floor in Step 6**
+
+In `internal/grpc/query_stream_history.go` at the existing `// Step 6: Parse not_before.` (~line 216):
+
+```go
+// Step 6: Compute effective NotBefore = MAX(client-supplied, server-side scope floor).
+var notBefore time.Time
+if req.NotBeforeMs > 0 {
+    notBefore = time.UnixMilli(req.NotBeforeMs).UTC()
+}
+scopeFloor := streamScopeFloor(info, req.Stream)
+if scopeFloor.After(notBefore) {
+    notBefore = scopeFloor
+}
+```
+
+- [ ] **Step 6: Run hard-gate test — verify PASS now**
+
+`task test -- ./internal/grpc/ -run TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation`
+
+- [ ] **Step 7: Run all internal/grpc tests + lint**
+
+`task test -- ./internal/grpc/ && task lint`
+Expected: all PASS. Note: existing tests that queried location streams while not-present will now fail — update them to seed the session into the location they query, or to assert the new deny behavior.
+
+- [ ] **Step 8: Commit**
+
+Commit message: `feat(grpc): QueryStreamHistory location hard-gate + scope floor (iwzt Phase 2)`.
+
+---
+
+### Task 8: Integration test — guest sees no pre-arrival history
+
+**Files:**
+
+- Create: `test/integration/privacy/privacy_test.go`
+- Create: `test/integration/privacy/suite_test.go` (Ginkgo bootstrap)
+
+- [ ] **Step 1: Create Ginkgo suite bootstrap**
+
+`test/integration/privacy/suite_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package privacy_test
+
+import (
+    "testing"
+
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+func TestPrivacy(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "Privacy Suite (holomush-iwzt)")
+}
+```
+
+- [ ] **Step 2: Write the failing privacy test**
+
+`test/integration/privacy/privacy_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package privacy_test
+
+import (
+    "context"
+    "time"
+
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+
+    corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+    "github.com/holomush/holomush/internal/testsupport/privacytest"
+)
+
+var _ = Describe("I-PRIV-1: new guest sees no pre-arrival location history", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("returns empty history for events emitted before the guest's session created_at", func() {
+        ctx := context.Background()
+        // Guest A connects, emits a pose, disconnects.
+        guestA := ts.ConnectGuest(ctx)
+        guestA.SendCommand(ctx, "pose hello")
+        guestA.WaitForEvent(ctx, "core-communication:pose")
+        guestA.Logout(ctx)
+
+        // Brief gap so timestamps don't tie.
+        time.Sleep(50 * time.Millisecond)
+
+        // Guest B connects (fresh) into the same location.
+        guestB := ts.ConnectGuest(ctx)
+        Expect(guestB.LocationID).To(Equal(guestA.LocationID))
+
+        resp, err := guestB.Client.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+            SessionId: guestB.SessionID,
+            Stream:    "location:" + guestB.LocationID.String(),
+        })
+        Expect(err).NotTo(HaveOccurred())
+        for _, ev := range resp.GetEvents() {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", guestB.SessionCreatedAt),
+                "event %q at %s leaked before guest B session created_at %s",
+                ev.GetType(), ev.GetTimestamp().AsTime(), guestB.SessionCreatedAt)
+        }
+    })
+})
+```
+
+- [ ] **Step 3: Run integration test to verify it fails before Phase 2 fix**
+
+(Should pass now since Phase 2 already merged; this is the regression guard.)
+
+`task test:int -- ./test/integration/privacy/`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+Commit message: `test(privacy): I-PRIV-1 guest sees no pre-arrival history (integration)`.
+
+---
+
+### Task 9: Integration test — character move resets floor
+
+**Files:**
+
+- Modify: `test/integration/privacy/privacy_test.go`
+
+- [ ] **Step 1: Add the move-resets-floor scenario**
+
+```go
+var _ = Describe("I-PRIV-1: character move resets location floor", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("denies query against the previous location and floors the new", func() {
+        ctx := context.Background()
+        char := ts.ConnectAuthed(ctx, "Diana")  // arrives in locA
+        otherChar := ts.ConnectAuthed(ctx, "Theia")  // in locB
+        otherChar.SendCommand(ctx, "say hello from locB before Diana arrives")
+        otherChar.WaitForEvent(ctx, "core-communication:say")
+
+        // Move Diana to locB.
+        char.MoveTo(ctx, otherChar.LocationID)
+        beforeArrive := time.Now()
+
+        // Query against locA: STREAM_ACCESS_DENIED (Diana is no longer there).
+        _, errA := char.Client.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+            SessionId: char.SessionID,
+            Stream:    "location:" + char.OriginalLocationID.String(),
+        })
+        Expect(errA).To(MatchOopsCode("STREAM_ACCESS_DENIED"))
+
+        // Query against locB: returns events only at-or-after Diana's arrival.
+        respB, errB := char.Client.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+            SessionId: char.SessionID,
+            Stream:    "location:" + otherChar.LocationID.String(),
+        })
+        Expect(errB).NotTo(HaveOccurred())
+        for _, ev := range respB.GetEvents() {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", beforeArrive))
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+`task test:int -- ./test/integration/privacy/` → PASS.
+
+Commit message: `test(privacy): I-PRIV-1 character move resets location floor (integration)`.
+
+---
+
+### Task 10: Integration test — denial wire-opacity (I-PRIV-5)
+
+**Files:**
+
+- Modify: `test/integration/privacy/privacy_test.go`
+
+- [ ] **Step 1: Add the wire-opacity meta-test**
+
+```go
+var _ = Describe("I-PRIV-5: denial wire opacity", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    DescribeTable("returns STREAM_ACCESS_DENIED for every denial reason",
+        func(setup func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest)) {
+            ctx := context.Background()
+            sess, req := setup(ctx)
+            _, err := sess.Client.QueryStreamHistory(ctx, req)
+            Expect(err).To(MatchOopsCode("STREAM_ACCESS_DENIED"),
+                "denial path must collapse to STREAM_ACCESS_DENIED — I-PRIV-5")
+        },
+        Entry("wrong location (hard-gate)", func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest) {
+            sess := ts.ConnectAuthed(ctx, "Alpha")
+            other := ts.NewLocation(ctx)
+            return sess, &corev1.QueryStreamHistoryRequest{SessionId: sess.SessionID, Stream: "location:" + other.String()}
+        }),
+        Entry("not member (I-17 scene)", func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest) {
+            sess := ts.ConnectAuthed(ctx, "Beta")
+            scene := ts.NewSceneWithoutMember(ctx)
+            return sess, &corev1.QueryStreamHistoryRequest{SessionId: sess.SessionID, Stream: "scene:" + scene.String() + ":ic"}
+        }),
+        Entry("ABAC policy denied (other public)", func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest) {
+            sess := ts.ConnectAuthed(ctx, "Gamma")  // no special roles
+            return sess, &corev1.QueryStreamHistoryRequest{SessionId: sess.SessionID, Stream: "admin:audit"}
+        }),
+        Entry("expired session", func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest) {
+            sess := ts.ConnectAuthed(ctx, "Delta")
+            ts.ExpireSession(ctx, sess.SessionID)
+            return sess, &corev1.QueryStreamHistoryRequest{SessionId: sess.SessionID, Stream: "location:" + sess.LocationID.String()}
+        }),
+        Entry("session not found (deleted)", func(ctx context.Context) (*privacytest.Session, *corev1.QueryStreamHistoryRequest) {
+            sess := ts.ConnectAuthed(ctx, "Epsilon")
+            ts.DeleteSession(ctx, sess.SessionID)
+            return sess, &corev1.QueryStreamHistoryRequest{SessionId: sess.SessionID, Stream: "location:" + sess.LocationID.String()}
+        }),
+        // Per I-PRIV-5 (spec §6.3 + §9): missing-session denial collapses to
+        // STREAM_ACCESS_DENIED at the QueryStreamHistory layer. The
+        // implementation MUST translate the inner SESSION_NOT_FOUND from
+        // sessionStore.Get into STREAM_ACCESS_DENIED before returning to the
+        // gRPC wire (denial_reason=session_not_found goes to slog only).
+        // Task 7 Step 4 adds this translation in the existing Get error
+        // branch (query_stream_history.go ~line 65-74), preserving wire
+        // opacity with all other denial paths.
+    )
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+Commit message: `test(privacy): I-PRIV-5 denial wire-opacity meta-test`.
+
+---
+
+## Phase 3 — Subscribe replay floor (NATS-source-of-truth + filter-at-delivery)
+
+### Task 11: Extract consumer-config builder helper
+
+**Files:**
+
+- Create: `internal/eventbus/subscriber_consumer_config.go`
+- Modify: `internal/eventbus/subscriber.go:159-195` (OpenSession) — delegate to builder
+
+- [ ] **Step 1: Write failing unit test for the builder**
+
+Create `internal/eventbus/subscriber_consumer_config_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+    "context"
+    "errors"
+    "testing"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// stubJS satisfies the narrow `consumerLookup` interface.
+// LookupConsumer returns a consumerInfo (NOT jetstream.Consumer) so the
+// test stub does NOT need to implement the full jetstream.Consumer surface.
+type stubJS struct {
+    info           consumerInfo  // nil → not found
+    lookupErr      error
+    lookupCalled   bool
+}
+
+func (s *stubJS) LookupConsumer(_ context.Context, _, _ string) (consumerInfo, error) {
+    s.lookupCalled = true
+    if s.lookupErr != nil {
+        return nil, s.lookupErr
+    }
+    return s.info, nil
+}
+
+// stubConsumer satisfies the narrow consumerInfo interface — just CachedInfo().
+type stubConsumer struct {
+    cfg jetstream.ConsumerConfig
+}
+
+func (s *stubConsumer) CachedInfo() *jetstream.ConsumerInfo {
+    return &jetstream.ConsumerInfo{Config: s.cfg}
+}
+
+func TestBuildConsumerConfig_FreshOpenSession_ComputesMinFloor(t *testing.T) {
+    minFloor := time.Now().Add(-time.Hour)
+    js := &stubJS{info: nil, lookupErr: jetstream.ErrConsumerNotFound}
+    cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+        []string{"events.gid.location.X"}, minFloor)
+    require.NoError(t, err)
+    assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
+    require.NotNil(t, cfg.OptStartTime)
+    assert.True(t, cfg.OptStartTime.Equal(minFloor))
+}
+
+func TestBuildConsumerConfig_ExistingConsumer_PreservesStartPolicy(t *testing.T) {
+    origStart := time.Now().Add(-2 * time.Hour)
+    js := &stubJS{info: &stubConsumer{cfg: jetstream.ConsumerConfig{
+        DeliverPolicy: jetstream.DeliverByStartTimePolicy, OptStartTime: &origStart,
+    }}}
+    cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+        []string{"events.gid.location.X", "events.gid.scene.Y.ic"}, time.Now())
+    require.NoError(t, err)
+    assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
+    require.NotNil(t, cfg.OptStartTime)
+    assert.True(t, cfg.OptStartTime.Equal(origStart), "MUST copy existing OptStartTime verbatim — I-PRIV-8")
+    assert.ElementsMatch(t, []string{"events.gid.location.X", "events.gid.scene.Y.ic"}, cfg.FilterSubjects)
+}
+
+func TestBuildConsumerConfig_TransientLookupError_FailsClosed(t *testing.T) {
+    js := &stubJS{lookupErr: errors.New("nats: connection closed")}
+    _, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+        []string{"events.gid.location.X"}, time.Now())
+    require.Error(t, err)
+    var oopsErr interface{ Code() string }
+    require.True(t, errors.As(err, &oopsErr))
+    assert.Equal(t, "EVENTBUS_CONSUMER_LOOKUP_FAILED", oopsErr.Code())
+}
+
+// (stubConsumer with CachedInfo() helper omitted for brevity — see existing
+// test patterns in internal/eventbus/*_test.go for stub examples.)
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+`task test -- ./internal/eventbus/ -run TestBuildConsumerConfig`
+Expected: FAIL — `buildConsumerConfig` not defined.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `internal/eventbus/subscriber_consumer_config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+    "context"
+    "errors"
+    "time"
+
+    "github.com/nats-io/nats.go/jetstream"
+    "github.com/samber/oops"
+)
+
+// consumerInfo is the narrow surface buildConsumerConfig needs from an
+// existing JetStream consumer — just enough to read its config. Real
+// jetstream.Consumer satisfies this trivially. Tests provide a stub that
+// implements ONLY CachedInfo without touching the full ~7-method
+// jetstream.Consumer surface.
+type consumerInfo interface {
+    CachedInfo() *jetstream.ConsumerInfo
+}
+
+// consumerLookup is the narrow surface buildConsumerConfig needs from a
+// JetStream context. Returns the local consumerInfo (NOT jetstream.Consumer)
+// so test stubs do not need to satisfy the full jetstream.Consumer interface.
+// Production callers pass a thin adapter that wraps s.js.Consumer(...) and
+// returns its result as a consumerInfo.
+type consumerLookup interface {
+    LookupConsumer(ctx context.Context, stream, consumer string) (consumerInfo, error)
+}
+
+// buildConsumerConfig produces a jetstream.ConsumerConfig that is safe to pass
+// to CreateOrUpdateConsumer regardless of whether the durable already exists.
+// Implements the NATS-source-of-truth pattern per holomush-iwzt §6.2 / I-PRIV-8.
+//
+// On existing-durable hit: copies DeliverPolicy/OptStartTime/OptStartSeq verbatim
+// from the existing consumer's config; only FilterSubjects is set fresh.
+//
+// On ErrConsumerNotFound: builds a fresh config with DeliverByStartTimePolicy +
+// minFloor (or DeliverAllPolicy if minFloor is zero).
+//
+// On any other lookup error: fails closed by returning EVENTBUS_CONSUMER_LOOKUP_FAILED.
+// CreateOrUpdateConsumer MUST NOT be invoked.
+func buildConsumerConfig(
+    ctx context.Context, js consumerLookup,
+    streamName, consumerName string,
+    filterSubjects []string, minFloor time.Time,
+) (jetstream.ConsumerConfig, error) {
+    existing, lookupErr := js.LookupConsumer(ctx, streamName, consumerName)
+    switch {
+    case lookupErr == nil && existing != nil:
+        info := existing.CachedInfo()
+        if info == nil {
+            return jetstream.ConsumerConfig{}, oops.Code("EVENTBUS_CONSUMER_LOOKUP_FAILED").
+                With("stream", streamName).With("consumer", consumerName).
+                Errorf("existing consumer returned nil CachedInfo")
+        }
+        cur := info.Config
+        cfg := jetstream.ConsumerConfig{
+            Durable:        consumerName,
+            Name:           consumerName,
+            FilterSubjects: filterSubjects,
+            DeliverPolicy:  cur.DeliverPolicy,
+            OptStartSeq:    cur.OptStartSeq,
+            // Other immutable fields (AckPolicy, AckWait, MaxAckPending,
+            // InactiveThreshold) propagated by the caller via the default
+            // cfg shape established at OpenSession-time.
+        }
+        // OptStartTime is *time.Time — preserve nil vs. non-nil verbatim.
+        if cur.OptStartTime != nil {
+            t := *cur.OptStartTime
+            cfg.OptStartTime = &t
+        }
+        return cfg, nil
+    case errors.Is(lookupErr, jetstream.ErrConsumerNotFound):
+        cfg := jetstream.ConsumerConfig{
+            Durable:        consumerName,
+            Name:           consumerName,
+            FilterSubjects: filterSubjects,
+        }
+        if !minFloor.IsZero() {
+            cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+            cfg.OptStartTime = &minFloor
+        } else {
+            cfg.DeliverPolicy = jetstream.DeliverAllPolicy
+        }
+        return cfg, nil
+    default:
+        return jetstream.ConsumerConfig{}, oops.Code("EVENTBUS_CONSUMER_LOOKUP_FAILED").
+            With("stream", streamName).With("consumer", consumerName).
+            Wrap(lookupErr)
+    }
+}
+```
+
+- [ ] **Step 4: Add the production adapter**
+
+The narrow `consumerLookup` interface returns `consumerInfo`, but the real `jetstream.JetStream.Consumer(...)` returns `jetstream.Consumer`. Add a one-line adapter in `subscriber_consumer_config.go`:
+
+```go
+// jsConsumerLookupAdapter wraps a jetstream.JetStream so it satisfies the
+// narrow consumerLookup interface buildConsumerConfig consumes.
+type jsConsumerLookupAdapter struct{ js jetstream.JetStream }
+
+func (a jsConsumerLookupAdapter) LookupConsumer(ctx context.Context, stream, name string) (consumerInfo, error) {
+    c, err := a.js.Consumer(ctx, stream, name)
+    if err != nil { return nil, err }
+    return c, nil  // jetstream.Consumer satisfies consumerInfo (has CachedInfo)
+}
+```
+
+OpenSession and SetFilters in Task 12 then call `buildConsumerConfig(ctx, jsConsumerLookupAdapter{js: s.js}, ...)`.
+
+- [ ] **Step 5: Run tests — verify PASS**
+
+`task test -- ./internal/eventbus/ -run TestBuildConsumerConfig`
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat(eventbus): NATS-source-of-truth consumer-config builder (iwzt ghpx)`.
+
+---
+
+### Task 12: Wire builder into OpenSession + SetFilters
+
+**Files:**
+
+- Modify: `internal/eventbus/subscriber.go:159-195` (OpenSession)
+- Modify: `internal/eventbus/subscriber.go:336-366` (SetFilters)
+
+- [ ] **Step 1: Refactor OpenSession to use the builder**
+
+In `internal/eventbus/subscriber.go:177-187`, replace the inline cfg construction:
+
+```go
+name := sessionConsumerName(sessionID)
+subjects := subjectsToStrings(filters)
+if len(subjects) == 0 {
+    return nil, oops.Code("EVENTBUS_SESSION_FILTERS_REQUIRED").
+        With("session_id", sessionID).Errorf("at least one subject filter required")
+}
+
+// Compute minFloor across subjects — Phase 3 wires this from session info.
+// For now (this task only), pass time.Time{} so first-create gets DeliverAllPolicy,
+// preserving existing behavior. Phase 3's downstream task replaces the zero value
+// with the real minFloor computation.
+minFloor := time.Time{}
+
+cfg, err := buildConsumerConfig(ctx, jsConsumerLookupAdapter{js: s.js}, StreamName, name, subjects, minFloor)
+if err != nil {
+    return nil, err
+}
+// Augment cfg with the non-start-policy defaults that OpenSession owns:
+cfg.AckPolicy = jetstream.AckExplicitPolicy
+cfg.AckWait = s.ackWait
+cfg.MaxAckPending = s.maxAckPending
+cfg.InactiveThreshold = s.inactiveThreshold
+
+cons, err := s.js.CreateOrUpdateConsumer(ctx, StreamName, cfg)
+if err != nil {
+    return nil, oops.Code("EVENTBUS_SESSION_CONSUMER_FAILED").
+        With("session_id", sessionID).With("consumer", name).Wrap(err)
+}
+```
+
+- [ ] **Step 2: Refactor SetFilters identically**
+
+In `internal/eventbus/subscriber.go:336-366`, apply the same `buildConsumerConfig` pattern. Confirm via existing tests that SetFilters callers still pass.
+
+- [ ] **Step 3: Run all subscriber tests**
+
+`task test -- ./internal/eventbus/`
+Expected: PASS — existing behavior preserved (minFloor=zero → DeliverAllPolicy, same as before).
+
+- [ ] **Step 4: Commit**
+
+Commit message: `refactor(eventbus): OpenSession + SetFilters use NATS-source-of-truth builder`.
+
+---
+
+### Task 13: Compute minFloor at OpenSession entry from session info
+
+**Files:**
+
+- Modify: `internal/eventbus/subscriber.go` — extend `OpenSession` signature to accept the session info needed to compute minFloor, OR add a `MinFloor time.Time` to the call site
+- Modify: caller in `internal/grpc/server.go:855`
+
+Decision (locked here to prevent ambiguity): add a new optional parameter `minFloor time.Time` to `OpenSession`. Caller computes it.
+
+- [ ] **Step 1: Update OpenSession signature**
+
+```go
+func (s *JetStreamSubscriber) OpenSession(
+    ctx context.Context, sessionID string, identity SessionIdentity,
+    filters []Subject, minFloor time.Time,
+) (SessionStream, error) {
+    // ... pass minFloor through to buildConsumerConfig
+}
+```
+
+- [ ] **Step 2: Update Subscriber interface in `bus.go`**
+
+Add `minFloor time.Time` to the `Subscriber.OpenSession` signature.
+
+- [ ] **Step 3: Update server.go caller to compute minFloor**
+
+In `internal/grpc/server.go:855` (before `subscriber.OpenSession`):
+
+```go
+// Compute minFloor across all subscribed subjects per holomush-iwzt §6.2 Tier 1.
+// MAX across subjects (not MIN) — JetStream delivers events >= start time, so
+// MAX gives the smallest set that includes events visible to at least one subject.
+// (Per-subject filter-at-delivery in Tier 2 drops events below per-subject floor.)
+var minFloor time.Time
+for _, subj := range subscribedSubjects {  // adjust var name to match
+    f := streamScopeFloor(info, string(subj))
+    if f.After(minFloor) {
+        minFloor = f
+    }
+}
+sessionStream, err := s.subscriber.OpenSession(ctx, sessionID, identity, subscribedSubjects, minFloor)
+```
+
+- [ ] **Step 4: Update SetFilters signature similarly**
+
+Current signature (verify at `internal/eventbus/subscriber.go:336`): `SetFilters(ctx context.Context, filters []Subject) error`. New signature: `SetFilters(ctx context.Context, filters []Subject, minFloor time.Time) error`. Recompute `minFloor` at each filter change (per holomush-iwzt §6.2 — although immutability rules mean the builder will preserve the original `OptStartTime` regardless; passing the new minFloor still matters for the `ErrConsumerNotFound` branch and future invariants).
+
+- [ ] **Step 5: Find and update ALL OpenSession callsites**
+
+The interface change breaks every caller. Enumerate them first:
+
+```bash
+rg -nP "OpenSession\(" --type go internal/
+```
+
+Expected hits: `internal/eventbus/subscriber.go` (implementation), `internal/eventbus/bus.go` (interface), `internal/grpc/server.go` (the production caller updated above), plus 10-15 test callsites in `internal/eventbus/subscriber*_test.go`, `internal/eventbus/eventbustest/embedded_test.go`, `internal/eventbus/bus_test.go` (fakeBus.OpenSession). Pass `time.Time{}` (zero minFloor) at every test callsite — tests don't exercise floor semantics; zero preserves the existing DeliverAllPolicy behavior in those paths.
+
+Same exercise for `SetFilters(`:
+
+```bash
+rg -nP "SetFilters\(" --type go internal/
+```
+
+- [ ] **Step 6: Run tests**
+
+`task test -- ./internal/eventbus/ ./internal/grpc/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Commit message: `feat(eventbus): plumb minFloor through OpenSession + SetFilters (iwzt Tier 1)`.
+
+---
+
+### Task 14: Per-subject filter-at-delivery in Subscribe broadcaster
+
+**Files:**
+
+- Modify: `internal/grpc/server.go` — locate the Subscribe dispatch loop (look for `stream.Send(...)` calls in the Subscribe handler around line 1000-1100)
+
+- [ ] **Step 1: Write failing test — events below floor are dropped**
+
+In `internal/grpc/server_test.go`:
+
+```go
+func TestSubscribeBroadcaster_DropsBelowScopeFloor(t *testing.T) {
+    server, ctx := newTestCoreServerWithBus(t)
+    sess := seedActiveSessionInLocation(t, server, "Eve", locA)
+    // Manually set LocationArrivedAt to T_now to force a strict floor.
+    require.NoError(t, server.sessionStore.UpdateLocationOnMove(
+        ctx, sess.CharacterID, locA, time.Now()))
+
+    // Emit an event with timestamp BEFORE LocationArrivedAt by injecting at the bus.
+    pastEvent := makeEventAt(time.Now().Add(-time.Hour), "location:"+locA.String())
+    require.NoError(t, server.injectRawBusEvent(pastEvent))
+
+    // Open subscribe; assert pastEvent does NOT arrive.
+    stream := openSubscribe(t, server, sess.ID)
+    select {
+    case ev := <-stream.Events():
+        t.Fatalf("unexpected event delivered below floor: %v", ev)
+    case <-time.After(300 * time.Millisecond):
+        // Pass — event was filtered.
+    }
+}
+```
+
+- [ ] **Step 2: Run test — verify FAIL**
+
+`task test -- -run TestSubscribeBroadcaster_DropsBelowScopeFloor ./internal/grpc/`
+Expected: FAIL — broadcaster does not filter.
+
+- [ ] **Step 3: Add filter at the dispatch site**
+
+The Subscribe event delivery lives in `func (s *CoreServer) dispatchDelivery(...)` at `internal/grpc/server.go:1006-1069` (call site is `internal/grpc/server.go:981`). This is **a single-event function called once per delivery, NOT a for-loop** — so `continue` is invalid. The filter MUST ack the delivery before returning so JetStream does NOT redeliver the same event forever.
+
+Insert at the top of `dispatchDelivery`, BEFORE the existing `stream.Send` and ack logic:
+
+```go
+// Per-subject filter-at-delivery — load-bearing privacy gate per holomush-iwzt §6.2 Tier 2.
+//
+// Read session info per event to pick up post-reattach / post-move floor
+// changes. This is a per-event sessionStore.Get — acceptable for the
+// initial implementation; a follow-up bead (Step 5 below) covers caching
+// this in a per-Subscribe goroutine local when latency profiling shows
+// it matters.
+//
+// Drop path MUST ack the delivery — otherwise JetStream redelivers the
+// same event indefinitely on every consumer reconnect.
+currentInfo, getErr := s.sessionStore.Get(ctx, info.ID)
+if getErr != nil {
+    // Defensive: if we cannot read session info we fail closed and drop
+    // the event. Ack-and-return so JS does not redeliver.
+    slog.WarnContext(ctx, "filter-at-delivery dropped event — session lookup failed",
+        "session_id", info.ID, "error", getErr)
+    if ackErr := delivery.Ack(); ackErr != nil {
+        slog.WarnContext(ctx, "ack failed on filter-drop path", "error", ackErr)
+    }
+    return nil
+}
+floor := streamScopeFloor(currentInfo, string(event.Subject))
+if !floor.IsZero() && event.Timestamp.Before(floor) {
+    slog.DebugContext(ctx, "filter-at-delivery dropped event below scope floor",
+        "session_id", info.ID, "subject", event.Subject,
+        "event_ts", event.Timestamp, "floor", floor)
+    if ackErr := delivery.Ack(); ackErr != nil {
+        slog.WarnContext(ctx, "ack failed on filter-drop path", "error", ackErr)
+    }
+    return nil
+}
+// ... fall through to existing stream.Send + ack ...
+```
+
+- [ ] **Step 4: Run test — verify PASS**
+
+`task test -- -run TestSubscribeBroadcaster_DropsBelowScopeFloor ./internal/grpc/`
+
+- [ ] **Step 5: File optimization follow-up bead**
+
+```bash
+bd create "Optimize filter-at-delivery: cache session floor in per-Subscribe goroutine" \
+  --type task --priority 3 --labels web,perf,follow-up \
+  --description "Initial Subscribe dispatch (iwzt Task 14) does a per-event sessionStore.Get for the filter-at-delivery check. Latency-acceptable for v1 but expected to dominate hot-path for busy locations. Optimization: snapshot relevant SessionInfo fields (LocationID, LocationArrivedAt, IsGuest, GuestCharacterCreatedAt, FocusMemberships) in a per-Subscribe goroutine local, refreshed by lifecycle hooks (BumpLocationArrivedAt, MovementHook fires, Subscribe.ReattachCAS). Requires extending the locationFollower ctrl channel or adding a sibling channel."
+```
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat(grpc): per-subject filter-at-delivery in Subscribe broadcaster (iwzt Tier 2)`.
+
+---
+
+### Task 15: Integration test — reconnect-after-detach filter drop (I-PRIV-3)
+
+**Files:**
+
+- Modify: `test/integration/privacy/privacy_test.go`
+
+- [ ] **Step 1: Add the reattach-durability scenario**
+
+```go
+var _ = Describe("I-PRIV-3: ReattachCAS preserves durable; filter enforces new floor", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("drops events emitted during detach via filter-at-delivery on reattach", func() {
+        ctx := context.Background()
+        sessA := ts.ConnectAuthed(ctx, "Felix")
+        other := ts.ConnectAuthed(ctx, "Gemma")  // same location
+        Expect(sessA.LocationID).To(Equal(other.LocationID))
+
+        sessA.DetachTransport(ctx)
+        // While detached, other emits.
+        other.SendCommand(ctx, "say while-felix-detached")
+        other.WaitForEvent(ctx, "core-communication:say")
+
+        sessA.ReattachTransport(ctx)
+        events := sessA.DrainEvents(ctx, 1*time.Second)
+        for _, ev := range events {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", sessA.LastReattachAt),
+                "event %q at %s leaked across detach window — I-PRIV-3 broken",
+                ev.GetType(), ev.GetTimestamp().AsTime())
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+`task test:int -- ./test/integration/privacy/`
+Commit message: `test(privacy): I-PRIV-3 reattach durability with filter-at-delivery`.
+
+---
+
+### Task 16: Integration test — multi-session continuity
+
+**Files:**
+
+- Modify: `test/integration/privacy/privacy_test.go`
+
+- [ ] **Step 1: Add multi-session continuity test**
+
+```go
+var _ = Describe("I-PRIV-4 / rc8b: per-session floors are independent", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("preserves telnet visibility when web reattaches", func() {
+        ctx := context.Background()
+        char := ts.AuthedPlayer(ctx, "Hugo")
+        webSess := char.OpenWebSession(ctx)       // arrived T0
+        time.Sleep(50 * time.Millisecond)
+        telnetSess := char.OpenTelnetSession(ctx) // arrived T1
+        time.Sleep(50 * time.Millisecond)
+
+        webSess.DetachTransport(ctx)
+        other := ts.ConnectAuthed(ctx, "Iris")  // same location
+        other.SendCommand(ctx, "say t2-event")
+        other.WaitForEvent(ctx, "core-communication:say")
+        webSess.ReattachTransport(ctx)
+        webArrival := time.Now()
+
+        // Telnet's QueryStreamHistory still includes the t2 event.
+        telnetHistory := telnetSess.QueryStreamHistory(ctx, "location:"+char.LocationID.String())
+        Expect(eventTypesAt(telnetHistory)).To(ContainElement("core-communication:say"))
+
+        // Web's QueryStreamHistory does NOT include the t2 event (below web's
+        // post-reattach floor).
+        webHistory := webSess.QueryStreamHistory(ctx, "location:"+char.LocationID.String())
+        for _, ev := range webHistory {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", webArrival))
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+Commit message: `test(privacy): I-PRIV-4 multi-session continuity (web reattach preserves telnet visibility)`.
+
+---
+
+## Phase 4 — Scene-join floor
+
+### Task 17: Extend streamScopeFloor for scene streams (already present in §6.1)
+
+Phase 2 Task 6 already implemented the scene branch in `streamScopeFloor`. Phase 4's enforcement work happens because Task 7 already wires `streamScopeFloor` into Step 6 — scenes pick up the floor automatically. This task verifies via test.
+
+- [ ] **Step 1: Write integration test — scene-join floor**
+
+```go
+var _ = Describe("I-PRIV-2 / scene floor: scene events before join are invisible", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("denies pre-join events and floors post-join history", func() {
+        ctx := context.Background()
+        owner := ts.ConnectAuthed(ctx, "Jamie")
+        scene := owner.CreateScene(ctx)
+        owner.SendCommand(ctx, "say in-scene-before-Kai")  // emits to scene:S:ic
+
+        time.Sleep(50 * time.Millisecond)
+        joiner := ts.ConnectAuthed(ctx, "Kai")
+        joiner.JoinScene(ctx, scene)
+        joinedAt := time.Now()
+
+        history := joiner.QueryStreamHistory(ctx, "scene:"+scene.String()+":ic")
+        for _, ev := range history {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", joinedAt))
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+If the scene floor wasn't already implemented end-to-end in Task 6+7, this test surfaces the gap; iterate on `streamScopeFloor` + Subscribe filter to cover scenes.
+
+Commit message: `test(privacy): I-PRIV-2 scene-join floor enforcement`.
+
+---
+
+## Phase 5 — Staff ABAC override
+
+### Task 18: Seed staff/admin policy
+
+**Files:**
+
+- Modify: `internal/access/policy/seed.go`
+- Test: `internal/access/policy/seed_test.go`
+
+- [ ] **Step 1: Verify the policy DSL idiom against existing seeds**
+
+Before authoring, read `internal/access/policy/seed.go` for the existing resource-type-guard idioms. The DSL accepts `resource is <type>` where `<type>` is one of the registered ResourceProvider namespace types. Confirm whether `stream` is registered as a resource namespace via `rg -nP "ResourceProvider|RegisterResource|namespace.*stream" internal/access/`. If `stream` is NOT a registered resource type, either (a) register it (separate task, out of scope), or (b) use a more permissive seed without the type guard.
+
+For staff override the cleanest seed (no resource-type dependency) is action-only:
+
+```go
+{
+    Name:    "staff_read_unrestricted_history",
+    DSLText: `permit(principal is character, action == "read_unrestricted_history", resource) when { "staff" in principal.character.roles || "admin" in principal.character.roles };`,
+},
+```
+
+(Removing the `resource is stream` type guard so the policy matches any resource passed in — appropriate because the gate is about the action, not the resource type.)
+
+- [ ] **Step 2: Add seed-coverage test asserting policy is loaded**
+
+```go
+func TestSeed_IncludesStaffUnrestrictedHistoryPolicy(t *testing.T) {
+    seeds := AllSeeds()  // or whatever the export is
+    var found bool
+    for _, s := range seeds {
+        if s.Name == "staff_read_unrestricted_history" {
+            found = true
+            break
+        }
+    }
+    require.True(t, found, "Phase 5 must seed staff_read_unrestricted_history policy")
+}
+```
+
+- [ ] **Step 3: Run + Commit**
+
+`task test -- ./internal/access/policy/`
+Commit message: `feat(access): seed staff_read_unrestricted_history policy (iwzt Phase 5)`.
+
+---
+
+### Task 19: Replace staffOverride stub with real ABAC call
+
+**Files:**
+
+- Modify: `internal/grpc/scope_floor.go` (the stub from Task 7)
+
+- [ ] **Step 1: Write failing test — staff override bypasses hard-gate**
+
+In `internal/grpc/query_stream_history_test.go`:
+
+```go
+func TestQueryStreamHistory_StaffOverride_BypassesHardGate(t *testing.T) {
+    server, ctx := newTestCoreServerWithBus(t)
+    staff := seedActiveSessionWithRole(t, server, "AdminAce", locA, []string{"staff"})
+
+    // Staff queries a location they are NOT in — should succeed (bypass).
+    _, err := server.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+        SessionId: staff.ID,
+        Stream:    "location:" + locB.String(),
+    })
+    require.NoError(t, err, "staff role must bypass location hard-gate")
+}
+```
+
+- [ ] **Step 2: Run test — verify FAIL**
+
+Expected: FAIL (stub returns false).
+
+- [ ] **Step 3: Replace stub with real implementation**
+
+In `internal/grpc/scope_floor.go` (the stub's `accessEngine` interface already takes `accessTypes.AccessRequest` by value from Task 7 Step 3, matching `NewAccessRequest`'s return type):
+
+```go
+func staffOverride(ctx context.Context, info *session.Info, engine accessTypes.AccessPolicyEngine) bool {
+    if engine == nil {
+        return false
+    }
+    accessReq, err := accessTypes.NewAccessRequest(
+        "character:"+info.CharacterID.String(),
+        "read_unrestricted_history",
+        "stream:*",  // resource-agnostic — policy is action-scoped
+        nil,
+    )
+    if err != nil { return false }
+    decision, evalErr := engine.Evaluate(ctx, accessReq)
+    return evalErr == nil && decision.IsAllowed()
+}
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+- [ ] **Step 5: Add integration test — staff override does NOT bypass floor (I-PRIV-6)**
+
+```go
+var _ = Describe("I-PRIV-6: staff override bypasses gate, not floor", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("staff in locA querying locB sees events only at-or-after their own arrival floor", func() {
+        ctx := context.Background()
+        staff := ts.ConnectAuthedWithRoles(ctx, "Mira", []string{"staff"})  // in locA
+        other := ts.ConnectAuthed(ctx, "Nadia")  // in locB
+        other.SendCommand(ctx, "say long-before-staff-asks")
+        other.WaitForEvent(ctx, "core-communication:say")
+        time.Sleep(2 * time.Second)
+        staffQueryAt := time.Now()
+
+        // staff arrival to its own location was AT staff connect time, well before staffQueryAt.
+        // But the test focuses on what queries return: staff's floor is its own
+        // LocationArrivedAt in locA. For locB query under override, the floor still applies.
+        resp, err := staff.Client.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+            SessionId: staff.SessionID,
+            Stream:    "location:" + other.LocationID.String(),
+        })
+        Expect(err).NotTo(HaveOccurred())
+        for _, ev := range resp.GetEvents() {
+            // Staff was NOT in locB when the say-event fired; their floor for that
+            // location (computed naturally via the streamScopeFloor MAX) excludes it.
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", staff.LocationArrivedAt))
+        }
+        Expect(resp.GetEvents()).NotTo(ContainElementMatching(func(e *corev1.GameEvent) bool {
+            return e.GetType() == "core-communication:say"
+        }), "the pre-arrival 'long-before-staff-asks' MUST NOT be returned — I-PRIV-6")
+    })
+})
+```
+
+(Spec §6.1 commits to: the temporal floor for staff cross-location reads IS `staff.LocationArrivedAt` (the requesting session's own arrival timestamp at its own location). For a staff member in locA querying locB, the floor is their locA arrival time. This is I-PRIV-6's "bypass hard-gate not floor" applied literally — staff can read across locations, but not retroactively past their own session's lifetime. The test above asserts exactly this semantic. Do NOT change the floor computation for staff queries.)
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat(grpc): real staffOverride + I-PRIV-6 enforcement (iwzt Phase 5)`.
+
+---
+
+## Phase 6 — Guest identity overlay
+
+### Task 20: Wire GuestCharacterCreatedAt into streamScopeFloor MAX
+
+The `streamScopeFloor` helper from Task 6 already includes the `info.IsGuest && info.GuestCharacterCreatedAt.After(base)` overlay. Task 5 already populated the field at guest session creation. Phase 6 verifies end-to-end.
+
+- [ ] **Step 1: Write integration test — guest sees no events from before its character was created**
+
+```go
+var _ = Describe("I-PRIV-2: guest character.CreatedAt floor (name-reuse safety)", func() {
+    var ts *privacytest.Server
+    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+    AfterEach(func() { ts.Stop() })
+
+    It("brand-new guest character with same name as a logged-out prior guest sees nothing of prior history", func() {
+        ctx := context.Background()
+        firstGuest := ts.ConnectGuest(ctx)
+        firstName := firstGuest.CharacterName
+        firstGuest.SendCommand(ctx, "say first-guest-utterance")
+        firstGuest.WaitForEvent(ctx, "core-communication:say")
+        firstGuest.Logout(ctx)
+        // Wait long enough that the namer pool may recycle the name.
+        time.Sleep(100 * time.Millisecond)
+
+        // Spin up many guests until we get one with the same name (test infra trick).
+        var reusedGuest *privacytest.Session
+        for i := 0; i < 50; i++ {
+            g := ts.ConnectGuest(ctx)
+            if g.CharacterName == firstName {
+                reusedGuest = g
+                break
+            }
+            g.Logout(ctx)
+        }
+        if reusedGuest == nil {
+            Skip("namer pool did not produce a name collision within 50 attempts — pool likely too large for this test environment")
+        }
+
+        // The reused-name guest sees NONE of the first guest's events.
+        history := reusedGuest.QueryStreamHistory(ctx, "location:"+reusedGuest.LocationID.String())
+        for _, ev := range history {
+            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", reusedGuest.SessionCreatedAt),
+                "name-reuse leaked event from prior identity — I-PRIV-2 broken")
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run + Commit**
+
+Commit message: `test(privacy): I-PRIV-2 guest name-reuse identity floor`.
+
+---
+
+## I-PRIV-7 — Plugin manifest history_scope validation
+
+### Task 21: Add `history_scope:` field to manifest schema
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go`
+- Modify: `schemas/plugin.schema.json` (run `go generate` to update)
+- Test: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write failing unit tests (4 cases per spec §8)**
+
+```go
+func TestManifest_HistoryScopeValidation(t *testing.T) {
+    cases := []struct {
+        name     string
+        yaml     string
+        wantErr  bool
+        errMatch string
+    }{
+        {
+            name: "plugin with no emits (OK — history_scope not required)",
+            yaml: `name: example`,
+            wantErr: false,
+        },
+        {
+            name: "plugin emitting events, history_scope=grid (OK)",
+            yaml: `name: example
+emits: ["scene"]
+history_scope: grid`,
+            wantErr: false,
+        },
+        {
+            name: "plugin emitting events, history_scope=scene (OK)",
+            yaml: `name: example
+emits: ["scene"]
+history_scope: scene`,
+            wantErr: false,
+        },
+        {
+            name: "plugin emitting events, history_scope=custom (OK)",
+            yaml: `name: example
+emits: ["custom_ns"]
+history_scope: custom`,
+            wantErr: false,
+        },
+        {
+            name: "plugin emitting events without history_scope (REJECT — I-PRIV-7)",
+            yaml: `name: example
+emits: ["scene"]`,
+            wantErr:  true,
+            errMatch: "history_scope",
+        },
+        {
+            name: "plugin with unknown history_scope value (REJECT)",
+            yaml: `name: example
+emits: ["custom_ns"]
+history_scope: nonexistent`,
+            wantErr:  true,
+            errMatch: "history_scope",
+        },
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            _, err := ParseManifest([]byte(tc.yaml))
+            if tc.wantErr {
+                require.Error(t, err)
+                assert.Contains(t, err.Error(), tc.errMatch)
+            } else {
+                require.NoError(t, err)
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify FAIL**
+
+`task test -- ./internal/plugin/ -run TestManifest_HistoryScopeValidation`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `HistoryScope` field to the Manifest struct**
+
+In `internal/plugin/manifest.go`:
+
+```go
+type Manifest struct {
+    // ... existing fields ...
+    HistoryScope string `yaml:"history_scope,omitempty" json:"history_scope,omitempty"`
+}
+
+// Closed enum for valid history_scope values per holomush-iwzt I-PRIV-7.
+var validHistoryScopes = map[string]bool{
+    "grid":   true,
+    "scene":  true,
+    "custom": true,
+}
+```
+
+- [ ] **Step 4: Add a manifest-level validator for I-PRIV-7**
+
+The existing `validateEmits(names []string)` (around line 274-294) takes a string slice with no manifest receiver — it cannot access `m.HistoryScope`. Add the I-PRIV-7 check at the manifest level instead, in `(*Manifest).Validate` (the call site of `validateEmits(m.Emits)` at `internal/plugin/manifest.go:441`).
+
+After the call to `validateEmits(m.Emits)` succeeds inside `Validate`, add:
+
+```go
+// I-PRIV-7: history_scope validation. Two requirements:
+//
+//  1. If declared, the value MUST be one of the closed-enum values.
+//  2. Plugins emitting under any namespace are required to declare
+//     history_scope EXPLICITLY. The default is opt-in, not exempt-list —
+//     this avoids the "stream prefix vs manifest namespace" confusion
+//     identified during plan-review (the spec's §3 grid/scene rows are
+//     stream PREFIXES like `location:X` or `scene:Y:ic`, not manifest
+//     namespace identifiers).
+//
+// Per holomush-iwzt I-PRIV-7.
+if m.HistoryScope != "" && !validHistoryScopes[m.HistoryScope] {
+    return oops.With("plugin", m.Name).
+        Errorf("history_scope %q is invalid; valid: grid, scene, custom", m.HistoryScope)
+}
+if len(m.Emits) > 0 && m.HistoryScope == "" {
+    return oops.With("plugin", m.Name).
+        With("emits", m.Emits).
+        Errorf("plugin emits events but manifest does not declare history_scope (holomush-iwzt I-PRIV-7)")
+}
+```
+
+This opt-in default (every emitting plugin must declare `history_scope`) is more restrictive than the spec's narrow §3-only exemption attempt — but cleanly closes the "silent inheritance" gap I-PRIV-7 forbids. Existing plugin manifests in the repo will need their `manifest.yaml` updated to declare `history_scope: grid` (core-communication) or `history_scope: scene` (core-scenes) — call out as a migration step.
+
+- [ ] **Step 4.5: Update existing plugin manifests**
+
+Manifest filename in this repo is `plugin.yaml` (NOT `manifest.yaml`). Enumerate:
+
+```bash
+rg -nP "^emits:" plugins/*/plugin.yaml
+```
+
+Known-existing manifests requiring migration (verify via the grep above; update each):
+
+- `plugins/core-communication/plugin.yaml` — emits to `location:*` streams (say/pose/whisper/page). Add `history_scope: grid`.
+- `plugins/core-scenes/plugin.yaml` — emits to `scene:*:*` streams. Add `history_scope: scene`.
+- Any other plugin under `plugins/` whose `emits:` field is non-empty MUST get a declaration too. Use `history_scope: grid` for plugins targeting location streams, `history_scope: scene` for scene streams, `history_scope: custom` only for plugins with truly novel semantics.
+
+Without this migration step, `task test` will fail on plugin loading because every existing emitting manifest now fails I-PRIV-7 validation.
+
+- [ ] **Step 5: Run tests — verify PASS**
+
+`task test -- ./internal/plugin/`
+
+- [ ] **Step 6: Run `go generate ./...` to regenerate JSON schema**
+
+```bash
+go generate ./...
+git diff schemas/plugin.schema.json  # verify history_scope is in the schema
+```
+
+- [ ] **Step 7: Commit**
+
+Commit message: `feat(plugin): manifest history_scope field + I-PRIV-7 validation`.
+
+---
+
+### Task 22: Placeholder integration test for plugin-history-scope (I-PRIV-7)
+
+**Files:**
+
+- Modify: `test/integration/privacy/privacy_test.go`
+
+- [ ] **Step 1: Add the skipping placeholder**
+
+```go
+var _ = Describe("I-PRIV-7: plugin-owned history_scope semantics", func() {
+    It("exercises a plugin that declared custom history_scope (placeholder)", func() {
+        Skip("no plugin currently declares history_scope: custom — re-enable when a plugin adopts this field")
+        // When a plugin adopts history_scope: custom, replace Skip with the
+        // real test exercising its divergent semantics.
+    })
+})
+```
+
+- [ ] **Step 2: Commit**
+
+Commit message: `test(privacy): I-PRIV-7 placeholder skip (no plugin uses history_scope yet)`.
+
+---
+
+## Meta-test
+
+### Task 23: Meta-test for I-PRIV-* invariant coverage
+
+**Files:**
+
+- Create or modify: `test/meta/iwzt_invariants_test.go`
+
+- [ ] **Step 1: Write the meta-test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+    "os"
+    "path/filepath"
+    "regexp"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestMeta_IPrivInvariantCoverage asserts that every I-PRIV-N invariant
+// (1..6, 8) declared in the history-scope privacy spec has at least one
+// corresponding test that mentions it by ID. I-PRIV-7 is satisfied
+// vacuously when no plugin declares history_scope: (see spec §8).
+func TestMeta_IPrivInvariantCoverage(t *testing.T) {
+    required := []string{"I-PRIV-1", "I-PRIV-2", "I-PRIV-3", "I-PRIV-4", "I-PRIV-5", "I-PRIV-6", "I-PRIV-8"}
+    found := make(map[string]bool, len(required))
+
+    pat := regexp.MustCompile(`I-PRIV-\d+`)
+    err := filepath.WalkDir(".", func(path string, d os.DirEntry, walkErr error) error {
+        if walkErr != nil { return walkErr }
+        if d.IsDir() || !strings.HasSuffix(path, "_test.go") { return nil }
+        data, _ := os.ReadFile(path)
+        for _, m := range pat.FindAll(data, -1) {
+            found[string(m)] = true
+        }
+        return nil
+    })
+    require.NoError(t, err)
+
+    for _, inv := range required {
+        assert.True(t, found[inv], "invariant %s has no corresponding test mentioning it by ID", inv)
+    }
+    // I-PRIV-7: satisfied vacuously when no plugin manifest declares history_scope.
+    // The manifest-validation unit test in Task 21 partially covers it; full
+    // satisfaction is when a plugin adopts the field and the placeholder test
+    // becomes real.
+}
+```
+
+(Adjust the walk root to encompass `internal/`, `test/integration/`, `plugins/` as appropriate for the repo's `test/meta` directory.)
+
+- [ ] **Step 2: Run + Commit**
+
+`task test:int -- ./test/meta/`
+Commit message: `test(meta): I-PRIV-* invariant coverage assertion`.
+
+---
+
+## Final integration
+
+### Task 24: Run full pr-prep + push
+
+- [ ] **Step 1: Run full pr-prep**
+
+`task pr-prep`
+Expected: green (lint + format + schema + license + unit + integration + E2E).
+
+- [ ] **Step 2: Code-reviewer + abac-reviewer adversarial pass**
+
+Invoke `code-reviewer` and `abac-reviewer` per CLAUDE.md pre-push gates. ABAC reviewer fires because `internal/access/policy/seed.go` was modified.
+
+- [ ] **Step 3: Push branch + open PR**
+
+Per `references/vcs-preamble.md`. Targeted rebase: `jj rebase -r <change> -d main@origin`; set bookmark; push.
+
+- [ ] **Step 4: bd close the relevant beads on merge**
+
+After merge, close: `holomush-iwzt` (design), the four ADR beads remain open (they're decision records, not work items).
+
+---
+
+## Spec coverage check
+
+| Spec section / invariant | Plan task |
+|---|---|
+| §2 principle + multi-session example | Task 16 (integration) |
+| §3 scope grid | Tasks 6, 7, 17 |
+| §4.1 SessionInfo.LocationArrivedAt | Tasks 1, 2 |
+| §4.2 FocusMembership.JoinedAt | Task 6 (read), Task 17 (test) |
+| §4.3 GuestCharacterCreatedAt | Tasks 1, 2, 5, 20 |
+| §5 lifecycle rules (7 transitions) | Tasks 3, 4 |
+| §5.1 character-move sync hook | Task 4 |
+| §6.1 QueryStreamHistory restructure | Task 7 |
+| §6.2 Subscribe replay floor (NATS SoT + filter) | Tasks 11, 12, 13, 14 |
+| §6.3 error opacity | Task 10 |
+| §7 phasing | Tasks 1-22 |
+| §8 tests | Tasks 8, 9, 10, 15, 16, 17, 19 (Step 5), 20, 21 (Step 1), 22, 23 |
+| I-PRIV-1 | Tasks 8, 9 |
+| I-PRIV-2 | Tasks 17, 20 |
+| I-PRIV-3 | Tasks 3, 15 |
+| I-PRIV-4 | Task 16 |
+| I-PRIV-5 | Task 10 |
+| I-PRIV-6 | Task 19 (Step 5) |
+| I-PRIV-7 | Tasks 21, 22 |
+| I-PRIV-8 | Task 11 |

--- a/docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md
+++ b/docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md
@@ -1,0 +1,364 @@
+# History scope privacy — design
+
+**Status:** Draft v6 (2026-05-17) — addressing design-reviewer round 5 findings
+**Bead:** `holomush-iwzt` (design)
+**Authors:** Sean Brandt with Claude (brainstorming session)
+**Triggered by:** New guest "Onyx Radium" observed seeing prior in-character conversation between Emerald and Pearl Radium on 2026-05-17 in the dev environment.
+
+## 1. Problem
+
+Two web-terminal flows leak event history that the requesting character should not be able to see:
+
+- **`QueryStreamHistory`** (`internal/grpc/query_stream_history.go:216-220`) applies a `NotBefore` floor only when the client supplies one. The ABAC step gates "can read this stream at all" but applies no temporal bound, so a fresh guest's empty-cursor backfill returns the location stream's entire retained history.
+- **Subscribe replay-from-cursor** — `internal/grpc/list_session_streams.go:91-100` builds a focus plan with `focus.ReplayModeFromCursor`, and Subscribe (`internal/grpc/server.go`) opens a bus session with the stored cursor. For a session created with no prior cursor, the replay window is effectively "from the earliest event the bus still retains."
+
+The bug is privacy-class. It MUST NOT be deferred behind any other improvement.
+
+## 2. Principle
+
+> A session's view of an event stream's history MUST be limited to the time window during which **the requesting session** has been continuously attached to that stream's scope in `StatusActive` or `StatusIdle`.
+
+Per-session floor, no cross-session aggregation. Transport-level detach with later reattach DOES NOT count as continuous attachment for the detached session — reattach resets that session's floor. Other concurrent sessions for the same character maintain independent floors; one session's reattach does NOT affect another session's visibility.
+
+This is the unified principle covering all three rules from the brainstorming Q&A: pre-arrival exclusion (session's floor starts at its own arrival), during-disconnect exclusion (reattach resets the floor), and the orthogonal guest identity overlay (an additional MAX bound on top, scoped to the same session).
+
+**Multi-session worked example.** Web session A and telnet session B both belong to character X. A attaches at T=0. B attaches at T=10. A drops at T=20; B remains attached. Events emitted at T=25 are visible to B (continuously attached). A reattaches at T=30. After reattach: A's `LocationArrivedAt = 30`; A's `QueryStreamHistory` returns only events with `timestamp >= 30`. B's `LocationArrivedAt` is unchanged (still T=10); B's view of T=25 events is preserved. Each session's floor moves independently.
+
+Plugin-owned subjects (channels, etc.) MAY adopt different semantics per their own design but MUST declare them explicitly (see I-PRIV-7).
+
+## 3. Scope by stream type
+
+| Stream subject | Gate | Temporal floor | ABAC override |
+|---|---|---|---|
+| `location:<id>` | Hard gate — `session.LocationID.String() == <id>` (default-deny) | `MAX(session.LocationArrivedAt, [if IsGuest] session.GuestCharacterCreatedAt)` | Yes — `"staff"` or `"admin"` in `principal.character.roles` bypasses the hard-gate only (temporal floor still applies — see I-PRIV-6) |
+| `scene:<id>:ic`, `scene:<id>:ooc` | Existing I-17 membership gate (unchanged) | `MAX(focusMembership(scene_id).JoinedAt, [if IsGuest] session.GuestCharacterCreatedAt)` | None — scene privacy is absolute |
+| `character:<id>` | Existing membership gate (unchanged) | None (own stream) | N/A |
+| Plugin-owned subjects | Plugin's own router (unchanged) | Plugin-defined | Plugin-defined |
+| Other public (e.g., `global`, `system`) | ABAC `engine.Evaluate` (unchanged) | None | Through normal ABAC policy |
+
+The location-stream hard gate replaces the current ABAC public-stream policy path for `location:*` only. ABAC remains active for all other public streams.
+
+## 4. Data model
+
+### 4.1 `SessionInfo.LocationArrivedAt`
+
+`internal/session/session.go` — extend the `Info` struct:
+
+```go
+type Info struct {
+    // ... existing fields ...
+    LocationID                   ulid.ULID
+    LocationArrivedAt            time.Time   // NEW — §5
+    GuestCharacterCreatedAt      time.Time   // NEW — §4.3
+    // ... existing fields ...
+}
+```
+
+The `sessions` PostgreSQL table MUST gain matching columns:
+
+- `location_arrived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+- `guest_character_created_at TIMESTAMPTZ NOT NULL DEFAULT 'epoch'`
+
+Paired up/down migrations, logic-free (per `site/docs/contributing/database-migrations.md`).
+
+`LocationArrivedAt` is invariant across idle periods. It SHALL be updated only by the seven transitions enumerated in §5.
+
+### 4.2 `FocusMembership.JoinedAt`
+
+Already present at `internal/session/session.go:88`. No schema change. Scene floor computation reads it directly via `session.FocusMemberships` lookup by scene ID.
+
+### 4.3 `SessionInfo.GuestCharacterCreatedAt` (cached at session creation)
+
+Decision: **cache the guest character's `created_at` value into `SessionInfo` at session-creation time**, not per-query lookup. Rationale:
+
+- Per-query DB hit on every `QueryStreamHistory` call would compound the latency surface that `holomush-87qu` already flags.
+- The value is immutable for the lifetime of the session (character row doesn't get recreated mid-session).
+- `IsGuest=false` sessions leave the field as `'epoch'` (or zero `time.Time`); the `MAX(.)` floor is then dominated by `LocationArrivedAt`.
+
+Population path: at `internal/grpc/auth_handlers.go` `SelectCharacter` (and the analogous guest-connect path in `internal/auth/guest_service.go`), read `world.Character.CreatedAt` from the character row and stamp it into the new `SessionInfo`. The existing `SessionInfo.IsGuest` field (already at `internal/session/session.go:148`, populated from `world.Player.IsGuest` per `internal/web/auth_handlers.go:335`) controls whether the floor consults this value.
+
+## 5. Session-lifecycle update rules
+
+Seven explicit transitions covering all paths that affect `SessionInfo.LocationArrivedAt`:
+
+| # | Transition | Code site | `LocationArrivedAt` action |
+|---|---|---|---|
+| 1 | **Fresh `SelectCharacter`** (no existing session row found) | `internal/grpc/auth_handlers.go:331-348` | Set to `now` (equals `CreatedAt`) at session-row creation |
+| 2 | **`SelectCharacter` reattach** (existing detached session matched) | `internal/grpc/auth_handlers.go:295-310` | Set to `now`. **This is rule-3 reset semantics:** player chose to re-select the character, treat as fresh arrival. |
+| 3 | **`Subscribe.ReattachCAS`** (transport-level reattach, session row already exists) | `internal/grpc/server.go:768-777` | Set to `now`, atomic with the CAS status flip. **This is the second rule-3 reset path.** Requires extending `session.Store.ReattachCAS` (or pairing with `UpdateLocationArrivedAt`) so the timestamp moves with the status. |
+| 4 | **Detach** (transport drop, status → `Detached`) | `internal/grpc/server.go:1290-1308` | Unchanged. Preserved for the TTL window; if the session reattaches (#3) the timestamp moves then. |
+| 5 | **Character move** (`world.Service.MoveCharacter`) | `internal/world/service.go:759-790` plus a new session-sync consumer (§5.1) | For every Active/Idle session attached to this character: set `LocationID` to new value AND `LocationArrivedAt` to `now`, atomic update. |
+| 6 | **Explicit logout** | `internal/grpc/auth_handlers.go:538+` | N/A — session ends. Next login (#1) starts fresh. |
+| 7 | **TTL expiry** (reaper) | `internal/session/reaper.go` | N/A — session ends. Next login (#1) starts fresh. |
+
+Idle-status transitions (Active ↔ Idle) DO NOT advance `LocationArrivedAt`. Idle is still "actively attached."
+
+### 5.1 Character-move session sync (Phase-1 sub-task)
+
+Grounding confirmed via design-reviewer round 1: **no existing path syncs `sessions.location_id` to `characters.location_id` on character move.** `world.Service.MoveCharacter` updates the character row and emits `EventTypeMove`; `locationFollower` at `internal/grpc/location_follow.go:60-130` consumes the event per-Subscribe-stream and switches the bus filter, but is per-stream in-memory state — it never writes the session store.
+
+Phase 1 MUST establish a canonical sync path. The recommended approach:
+
+- Add `session.Store.UpdateLocationOnMove(ctx, characterID, newLocationID, arrivedAt time.Time) error` that updates **all** Active/Idle sessions for the character atomically (single transaction).
+- Wire `world.Service.MoveCharacter` to call it immediately after `characterRepo.UpdateLocation` and before the move-event emit. Either:
+  - Direct dependency injection (world.Service gains a session.Store dependency — violates layering)
+  - Or via a `MovementHook` interface that core-server implements and wires (preserves layering).
+
+The plan stage selects the wiring approach. The semantic requirement is non-negotiable: at the moment a Move event reaches any subscriber, every session in the store MUST already reflect the new `LocationID` and `LocationArrivedAt`.
+
+## 6. Server-side enforcement
+
+### 6.1 `QueryStreamHistory` restructure
+
+`internal/grpc/query_stream_history.go:156-220` Step 5 ("Authorization") becomes:
+
+```text
+Step 5: Authorization
+  if isPrivateStream(stream):                       # scene:*:*, character:*
+      I-17 membership gate (unchanged)
+  elif isLocationStream(stream):                    # NEW classification
+      if !staffOverride(ctx, info, accessEngine):
+          if session.LocationID.String() != extractLocationID(stream):
+              return STREAM_ACCESS_DENIED
+      # If staff-overridden: skip the location-match check.
+  else:                                             # global, system, other public
+      ABAC engine.Evaluate (unchanged)
+
+Step 6: Floor
+  baseFloor   := req.NotBeforeMs (as time.Time)
+  scopeFloor  := streamScopeFloor(info, stream)
+  notBefore    = MAX(baseFloor, scopeFloor)
+```
+
+`streamScopeFloor(info, stream) time.Time`:
+
+- For `location:*`: `MAX(info.LocationArrivedAt, info.IsGuest ? info.GuestCharacterCreatedAt : time.Time{})`
+- For `scene:<id>:*`: `MAX(focusMembership(info, scene_id).JoinedAt, info.IsGuest ? info.GuestCharacterCreatedAt : time.Time{})`
+- For `character:<own-id>`: zero (no temporal floor)
+
+`staffOverride` checks the ABAC engine with a fixed request shape (correct field names per `internal/access/policy/types/types.go:132-150`):
+
+```go
+accessReq, err := types.NewAccessRequest(
+    "character:"+info.CharacterID.String(),
+    "read_unrestricted_history",
+    "stream:"+stream,
+    nil,
+)
+if err != nil { return false }
+decision, evalErr := s.accessEngine.Evaluate(ctx, accessReq)
+return evalErr == nil && decision.IsAllowed()
+```
+
+The roles attribute (`principal.character.roles`) is resolved by `CharacterProvider` at `internal/access/policy/attribute/character.go:21-107` via the injected `RoleResolver.GetRoles(ctx, subjectID)`. A new seeded policy in `internal/access/policy/seed.go` grants `read_unrestricted_history` to characters with `"staff"` or `"admin"` in `character.roles`:
+
+```go
+{
+    Name:    "staff_read_unrestricted_history",
+    DSLText: `permit(principal is character, action == "read_unrestricted_history", resource is stream) when { "staff" in principal.character.roles || "admin" in principal.character.roles };`,
+},
+```
+
+**The staff override bypasses the hard-gate location-match check only. The temporal floor STILL applies.** An admin debugging "what did guest X see when they connected?" SHALL get a view that's bounded by their own attachment intervals, NOT retroactive omniscience. This is I-PRIV-6.
+
+### 6.2 Subscribe replay-from-cursor floor — native start-time + filter-at-delivery
+
+Subscribe and `QueryStreamHistory` use **different** event-source paths and must be handled separately.
+
+**Subscribe path** (`internal/eventbus/subscriber.go::JetStreamSubscriber.OpenSession`, line 159-195). Subscribe creates one durable JetStream consumer per session with `DeliverAllPolicy` (line 185). JetStream consumers accept exactly one `DeliverPolicy` per consumer; a multi-subject session cannot have different start positions per filter under a single durable.
+
+**Two-tier enforcement** — perf hint at the consumer (server-side), authoritative filter at the broadcaster (per-event):
+
+#### Tier 1: `OptStartTime` as a perf hint (consumer creation only)
+
+At first call to `OpenSession` for a session, apply the **minimum floor across all subscribed subjects** as the consumer's start time:
+
+```text
+minFloor := time.Time{}  // zero — no floor
+for each subject in filters:
+    f := streamScopeFloor(info, subject)         // §6.1
+    if f.After(minFloor): minFloor = f
+if !minFloor.IsZero():
+    cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+    cfg.OptStartTime  = &minFloor
+```
+
+**`OptStartTime` is a PERFORMANCE HINT, not the privacy enforcement.** It tells JetStream "don't bother delivering events older than this" so we avoid scanning the entire stream for every new session. The privacy gate is Tier 2.
+
+**JetStream immutability constraint.** `DeliverPolicy`, `OptStartTime`, `OptStartSeq` are server-side immutable on existing consumers (NATS server error 10012: "deliver policy can not be updated"; see https://docs.nats.io/nats-concepts/jetstream/consumers, "Editable" column). Both `OpenSession` (called on every Subscribe, including transport reattach per `internal/grpc/server.go:855`) and `SetFilters` (called on location-following moves) issue `CreateOrUpdateConsumer` — both paths must produce a config compatible with the immutable durable.
+
+**Resolution: NATS is the source of truth.** The implementation MUST resolve the immutability constraint by querying the existing durable's config before issuing `CreateOrUpdateConsumer`, NOT by caching `OptStartTime` in-process or in the session row. The flow:
+
+```text
+existing, lookupErr := s.js.Consumer(ctx, StreamName, name)
+switch {
+case lookupErr == nil && existing != nil:
+    info := existing.CachedInfo()
+    cfg.DeliverPolicy = info.Config.DeliverPolicy
+    cfg.OptStartTime  = info.Config.OptStartTime
+    cfg.OptStartSeq   = info.Config.OptStartSeq
+    // Filters from the current call still drive the new cfg — subjects are mutable.
+case errors.Is(lookupErr, jetstream.ErrConsumerNotFound):
+    // First creation for this session — compute fresh minFloor.
+    minFloor := computeMinFloor(info, filters)
+    if !minFloor.IsZero():
+        cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+        cfg.OptStartTime  = &minFloor
+default:
+    // Transient lookup error (connection lost, ctx cancel, JS disabled, etc.):
+    // MUST fail closed. Do not proceed to CreateOrUpdateConsumer — sending a
+    // freshly-computed minFloor against an existing-but-temporarily-unreachable
+    // durable could either trigger NATS error 10012 (immutability) on later
+    // contact OR leak via DeliverAllPolicy zero-value if cfg is unset.
+    return nil, oops.Code("EVENTBUS_CONSUMER_LOOKUP_FAILED").
+        With("session_id", sessionID).
+        With("consumer", name).
+        Wrap(lookupErr)
+}
+// Subjects mutate normally (all other ConsumerConfig fields — Durable, Name,
+// AckPolicy, MaxAckPending, AckWait, InactiveThreshold — MUST match the
+// existing OpenSession/SetFilters defaults; only the three start-policy fields
+// are sourced from existing.CachedInfo().Config above):
+cfg.FilterSubjects = subjectsToStrings(filters)
+cons, err := s.js.CreateOrUpdateConsumer(ctx, StreamName, cfg)
+```
+
+This is idempotent and fail-closed: first call creates the consumer with `minFloor` start time; every subsequent call (OpenSession-on-reattach OR SetFilters-on-move) reads the existing config, preserves the immutable fields verbatim, mutates only the subject filter list. Error 10012 is unreachable under the documented call discipline (one in-flight OpenSession per session ID, enforced by the gRPC Subscribe handler being the sole control-plane owner of the session); transient lookup errors return to the caller without attempting `CreateOrUpdateConsumer`.
+
+`OptStartTime` is a **monotonically-decreasing-from-creation** lower bound: at first creation it equals `minFloor`; subsequent floor advances (per-session reattach, moves) make the in-process filter stricter while `OptStartTime` stays put on the server.
+
+**`Subscribe.ReattachCAS` interaction.** On transport reattach, `server.go:855` calls `s.subscriber.OpenSession(...)` again. The idempotent lookup above means the new `jetStreamSessionStream` instance reads the existing consumer's config and sends an identical-policy `CreateOrUpdateConsumer` — effectively a no-op on the durable. The durable's last-acked-seq is preserved. Privacy enforcement on reattach is performed entirely by §6.2 Tier 2 (per-subject filter-at-delivery) using the post-reattach `streamScopeFloor` — `OptStartTime` is a stale lower bound that JetStream uses as a performance hint only.
+
+**`SetFilters` interaction.** On move, the existing consumer is looked up via the same path, its `DeliverByStartTimePolicy` + `OptStartTime` are preserved, only `FilterSubjects` mutates. No error 10012; no consumer recreation; acked-seq cursor preserved.
+
+#### Tier 2: per-subject filter-at-delivery (authoritative)
+
+The Subscribe broadcaster (`internal/grpc/server.go` event dispatch loop) MUST apply, for every event delivered by JetStream:
+
+```text
+if event.Timestamp < streamScopeFloor(currentSessionInfo, event.Subject) {
+    drop event  // do not forward to client
+}
+```
+
+`currentSessionInfo` is the **post-reattach, post-move** snapshot — re-read from the session store at delivery time or cached and invalidated on lifecycle transitions (plan-stage choice). This is the load-bearing privacy gate.
+
+**Cost analysis:**
+
+- **Steady-state (no reattach, no scope change):** `OptStartTime` bounds JetStream delivery from below at `minFloor`. Over-delivery is per-subject: the filter discards events between `minFloor` and the per-subject floor for subjects whose floor exceeds `minFloor`. Cost is bounded by per-subject floor delta × event rate.
+- **Reattach:** new `LocationArrivedAt` may exceed `OptStartTime`. JetStream resumes from last-acked-seq; events between last-acked and new floor are delivered by JS but dropped by the filter. Scan-then-discard cost bounded by `(new floor − last-acked timestamp) × event rate` for the duration of the reattach burst.
+- **Move:** `SetFilters` swaps filter subjects. The new subject's floor (set to `now` per §5 row 5) means filter rejects any old-timestamp events JetStream might deliver for the new subject. Bounded by per-subject move event rate.
+
+#### `QueryStreamHistory` path (different mechanism)
+
+`internal/grpc/query_stream_history.go` uses `HistoryReader.QueryHistory(HistoryQuery)` — the existing interface already accepts `NotBefore time.Time`. The Phase 2 restructure sets `HistoryQuery.NotBefore = MAX(req.NotBeforeMs as time, streamScopeFloor(info, stream))` before invoking `fetchHistoryFramesFromBus`. No `HistoryReader` API addition; both tier readers (JetStream hot ephemeral consumers and PG audit cold) already honor `NotBefore` per their existing contracts.
+
+The wire protocol is unchanged. The two-tier Subscribe design (immutable `OptStartTime` perf hint + mutable filter-at-delivery enforcement) is documented above as a server-internal implementation choice.
+
+### 6.3 Error opacity
+
+`STREAM_ACCESS_DENIED` is returned for: hard-gate failures, I-17 membership denial, ABAC denial, expired session (already collapsed), missing session (already collapsed). The wire-level error code is identical across all denial reasons — preserving the existing opacity contract (`.claude/rules/grpc-errors.md`).
+
+Server logs SHALL include a structured `denial_reason` slog attribute (values: `wrong_location`, `not_member`, `policy_denied`, `session_expired`, `session_not_found`) for debugging. The slog field never crosses the wire.
+
+## 7. Phasing
+
+Each phase MUST ship as a discrete bead under the parent design epic. Phase 1-3 close the immediate privacy leak; 4-6 complete the model.
+
+| # | Phase | Beads | Closes |
+|---|---|---|---|
+| 1 | Schema + lifecycle | `sessions.location_arrived_at`+`guest_character_created_at` migration; `SessionInfo` fields; populate on fresh `SelectCharacter`; populate on `SelectCharacter` reattach; populate on `Subscribe.ReattachCAS`; **§5.1 character-move session-sync hook** | No semantic change yet (fields unused at query path) |
+| 2 | Location-stream hard-gate + floor | `query_stream_history.go` restructure: location-stream classifier, hard-gate, staff-override stub, scope-floor for location | Primary `iwzt` privacy leak (web `QueryStreamHistory` path) |
+| 3 | Subscribe replay floor | (a) `JetStreamSubscriber.OpenSession` first-create path computes `minFloor` across subjects and seeds `DeliverByStartTimePolicy` (§6.2 Tier 1); (b) both `OpenSession`-on-reattach and `SetFilters` query existing durable via `s.js.Consumer(...)` and preserve `DeliverPolicy`/`OptStartTime`/`OptStartSeq` verbatim (I-PRIV-8 — idempotent reseed); (c) Subscribe broadcaster (`server.go` dispatch) applies per-subject filter-at-delivery using current `streamScopeFloor` (§6.2 Tier 2 — load-bearing privacy gate); (d) `Subscribe.ReattachCAS` does NOT recreate the durable — idempotent OpenSession is a no-op on the consumer | Secondary leak path via Subscribe replay |
+| 4 | Scene-join floor | `scene:*:*` streams use `FocusMembership.JoinedAt` in `streamScopeFloor` | Scene privacy parity |
+| 5 | Staff ABAC override (real) | Seed the staff/admin policy (§6.1); make the `staffOverride` stub from Phase 2 use it; ensure I-PRIV-6 enforcement (floor still applies) | Staff debugging surface without violating I-PRIV-6 |
+| 6 | Guest identity overlay (real) | Populate `SessionInfo.GuestCharacterCreatedAt` at guest-session creation; consult in `streamScopeFloor` when `IsGuest` | Closes name-reuse edge case |
+
+Phase 1 is a prerequisite for all subsequent phases. **Phases 2 and 3 MUST ship together** (closing only one leaves a known-leaky path). Phase 4-6 can ship in any order after 2-3 ship.
+
+Phase 1 explicitly ships the schema columns + population code but leaves `streamScopeFloor` returning zero (no enforcement) until Phase 2 — `QueryStreamHistory` is unchanged in Phase 1.
+
+Phase 1 is privacy-leak-neutral but is NOT semantically inert: the §5.1 session-store sync hook on `MoveCharacter` corrects an undetected drift where `sessions.location_id` and `characters.location_id` were never kept in sync (verified via `rg "UpdateLocation"` across `internal/`; no path writes `sessions.location_id` on character move today). Any code that reads `sessions.location_id` to make a routing/policy decision now observes the same value `characters.location_id` already advertised. This is a positive correction. The plan stage MUST audit current readers of `sessions.location_id` and confirm none rely on the previously-stale value.
+
+## 8. Tests
+
+- **Integration (E2E):** `TestPrivacy_NewGuestSeesNoPreArrivalHistory` — connect guest A, A emits events, disconnect A, connect fresh guest B, assert B's `WebQueryStreamHistory` and Subscribe replay return zero events with timestamp < B's `SessionInfo.LocationArrivedAt`. Fails before Phase 2, passes after.
+- **Integration:** `TestPrivacy_ReconnectAfterDetachResetsFloor` — character A connects, third party emits events at T1, A detaches, third party emits events at T2, A reattaches via `Subscribe.ReattachCAS` at T3, A's subsequent history query returns zero events with timestamp ∈ [T1, T3].
+- **Integration:** `TestPrivacy_MultiSessionContinuity` — character X has web+telnet sessions. Web drops at T1, telnet stays. Events emitted at T2. Web reattaches at T3. Telnet's history query at T4 returns events from telnet's `LocationArrivedAt` forward (including the T2 events). Web's history query at T4 returns events from T3 forward only.
+- **Integration:** `TestPrivacy_CharacterMoveResetsFloor` — character X in location A at T1, character X moves to B at T2, X's history query against location:A returns `STREAM_ACCESS_DENIED`; against location:B returns events from T2 only.
+- **Integration:** `TestPrivacy_StaffOverrideBypassesGateNotFloor` — staff character with `roles=["staff"]` queries a location they're not in. Result: SUCCESS with events from `MAX(staff_arrival_at_other_location, staff_guest_floor)` only. Asserts I-PRIV-6.
+- **Integration:** `TestPrivacy_SceneJoinFloor` — character X joins scene S at T, scene events at T-10..T-1 invisible to X via `QueryStreamHistory` for `scene:S:ic`, events at T+1 onward visible.
+- **Integration (wire-opacity meta-test, I-PRIV-5):** `TestPrivacy_DenialWireOpacity` — exercise all five denial reasons (wrong location, not-member, policy denied, expired session, session not found) and assert wire-level code is identically `STREAM_ACCESS_DENIED` for each.
+- **Unit:** `streamScopeFloor` table-driven cases per stream type (location, scene, character-own, plugin-owned), with and without `IsGuest=true`, with and without scope membership.
+- **Unit:** `JetStreamSubscriber.OpenSession` start-time computation — verify `minFloor = max-across-subjects` and that `DeliverByStartTimePolicy` is set with the computed value; boundary cases (zero floor, single subject, multi-subject with mixed floors).
+- **Unit (I-PRIV-8):** `JetStreamSubscriber` MUST consult `s.js.Consumer(ctx, StreamName, name)` before issuing `CreateOrUpdateConsumer`. Four test cases:
+  - **Fresh OpenSession (no existing durable):** `Consumer(...)` returns `ErrConsumerNotFound`; `CreateOrUpdateConsumer` is called with computed `minFloor` in `OptStartTime`.
+  - **OpenSession on reattach (existing durable):** `Consumer(...)` returns existing consumer with `OptStartTime = T0`; `CreateOrUpdateConsumer` is called with `OptStartTime == T0` (NOT a freshly-computed `minFloor`).
+  - **SetFilters on move (existing durable):** same as reattach — preserve `OptStartTime`, only mutate `FilterSubjects`.
+  - **Transient lookup error (fail closed):** stub `js.Consumer(...)` returns a non-`ErrConsumerNotFound` error (e.g., `nats.ErrConnectionClosed`); `OpenSession` MUST return the wrapped error and MUST NOT call `CreateOrUpdateConsumer`. Asserts the §6.2 third branch.
+  All four failing → reseed/reattach would trigger NATS error 10012 OR a brief DeliverAllPolicy leak window.
+- **Integration (I-PRIV-3 reattach durability):** open session A on character X (creates durable with `OptStartTime = T0`); third party emits events at T1; A detaches at T2; A reattaches at T3 (`LocationArrivedAt` advances to T3); A's Subscribe replay MUST drop events with timestamp ∈ [T0, T3) via filter-at-delivery — JetStream resumes from last-acked-seq with original `OptStartTime`, no durable recreation, filter is sole privacy gate.
+- **Unit:** Subscribe broadcaster per-subject filter-at-delivery — verify events with `Timestamp < streamScopeFloor(subject)` are dropped while events at-or-after the floor pass through.
+- **Unit (manifest validation, I-PRIV-7):** plugin manifest schema (a) accepts an optional `history_scope:` declaration with a closed enum of values (e.g., `grid`, `scene`, `custom`); (b) rejects unknown values; (c) when a plugin manifest's `emits:` declares a namespace that is neither `location` nor `scene` (per `internal/plugin/manifest.go` validation — entries are bare namespaces, not subject patterns), validation MUST fail unless `history_scope:` is present. Test: manifest with plugin-owned namespace (e.g., `emits: ["custom_subject_ns"]`) and no `history_scope:` → validation error. Same manifest plus `history_scope: custom` → validates. This is what enforces "Silent inheritance of permissive semantics is forbidden."
+- **Integration (I-PRIV-7):** an example plugin under `plugins/` declares `history_scope: custom` in its manifest and exercises its divergent semantics — failing this test signals a plugin shipped without honoring I-PRIV-7. Until a real plugin adopts the field, this test is a placeholder `t.Skip("no plugin uses history_scope yet")` paired with a meta-test guard (below) that explicitly counts the skip as I-PRIV-7's coverage tally.
+- **Meta-test (`test/meta`):** assert each of I-PRIV-1 through I-PRIV-6 and I-PRIV-8 has at least one corresponding test asserting it by ID. I-PRIV-7 is satisfied either by the integration test above (when non-skipped) OR by the meta-test enumerating zero plugins with `history_scope:` declared (vacuously true). Failing meta-test signals an unverified invariant. This explicitly scopes I-PRIV-7 differently from I-PRIV-1..6, 8 — the invariant is forward-looking, applying when plugins adopt the field.
+
+## 9. Invariants (RFC2119)
+
+- **I-PRIV-1 (MUST):** A session SHALL NOT be able to read any event from any stream that occurred outside the time interval during which the **requesting session itself** has been continuously attached to that stream's scope in `StatusActive` or `StatusIdle`. Per-session enforcement, no cross-session aggregation; other concurrent sessions for the same character maintain independent floors. Exception: an explicit ABAC override grants `read_unrestricted_history` subject to the limited bypass defined in §6.1 (hard-gate location-match only; temporal floor still applies).
+- **I-PRIV-2 (MUST):** Guest sessions SHALL have a temporal floor of `MAX(scope_floor, guest_character.CreatedAt)` applied to all stream history reads.
+- **I-PRIV-3 (MUST):** `Subscribe.ReattachCAS` (transport reattach) AND `SelectCharacter` reattach SHALL both advance the session's `LocationArrivedAt` to the reattach moment, regardless of whether transport-level disconnect was clean or transient. `Subscribe.ReattachCAS` MUST NOT change `DeliverPolicy`, `OptStartTime`, or `OptStartSeq` on the existing durable consumer; `FilterSubjects` MAY change. Privacy enforcement on reattach is performed by the per-subject filter-at-delivery (§6.2 Tier 2), not by re-seeding `OptStartTime`.
+- **I-PRIV-4 (MUST NOT):** Idle status change SHALL NOT advance `LocationArrivedAt`. Other active sessions for the same character SHALL NOT be affected by any one session's reattach.
+- **I-PRIV-5 (MUST):** All denial paths (hard-gate, I-17, ABAC, expired session, missing session) SHALL return the same wire-level error code (`STREAM_ACCESS_DENIED`). Internal `denial_reason` slog attribute is debugging-only and SHALL NOT cross the wire.
+- **I-PRIV-6 (MUST):** ABAC staff override SHALL bypass the hard-gate location-match check only; it SHALL NOT bypass the temporal floor.
+- **I-PRIV-7 (MUST):** Plugin-owned subjects that adopt history-replay semantics divergent from this spec's grid/scene model SHALL declare their semantics in the plugin's manifest under `history_scope:` and SHALL be exercised by an explicit test. Silent inheritance of permissive semantics is forbidden.
+- **I-PRIV-8 (MUST):** Both `JetStreamSubscriber.OpenSession` (including OpenSession-on-reattach) and `JetStreamSubscriber.SetFilters` SHALL query the existing durable via `s.js.Consumer(ctx, StreamName, name)` before issuing `CreateOrUpdateConsumer`. When the durable exists, the new config's `DeliverPolicy`, `OptStartTime`, and `OptStartSeq` MUST be copied verbatim from `existing.CachedInfo().Config`; only `FilterSubjects` may mutate. When the durable does not exist (`jetstream.ErrConsumerNotFound`), the config is built fresh with `minFloor` semantics per §6.2 Tier 1. Sending a different `DeliverPolicy`/`OptStartTime`/`OptStartSeq` against an existing consumer triggers NATS server error 10012 and breaks the session. NATS is the source of truth for these immutable fields; in-process or DB-row caching MUST NOT be used.
+
+## 10. Out of scope
+
+- Channels (epic `0sc`) — channel history semantics will be designed in that epic; I-PRIV-7 applies.
+- Connect-time latency (`87qu`) — distinct concern; this spec's §6.2 cursor-by-time choice is favorable to that work but does not commit to a latency budget.
+- Connect-time own-event-rendering race (`fujt`) — distinct concern; ships independently.
+- Existing event retention policy (JetStream + PG audit) — unchanged.
+- Cold-tier crypto AAD changes (`dj95.1-4`) — unrelated.
+
+## 11. Related work
+
+- `internal/access/policy/seed.go:104` — existing `admin` role grant template (mirror for `read_unrestricted_history`)
+- `internal/access/policy/attribute/character.go:21-107` — `CharacterProvider` and `RoleResolver` (resolves `principal.character.roles`)
+- `internal/access/policy/types/types.go:132-150` — `AccessRequest` shape (`Subject`, `Action`, `Resource`, `Context`)
+- `.claude/rules/event-interfaces.md` — `HistoryReader` interface, subject naming
+- `.claude/rules/grpc-errors.md` — error opacity and code-translation discipline
+- `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` — replay/cursor model
+- `docs/repository-audit/2026-05-13/layer-review.md` — adjacent audit findings on the same call surface
+
+## 12. Review history
+
+- **Round 1 (2026-05-17):** design-reviewer NOT READY — 5 blocking, 5 non-blocking. All addressed in v2.
+- **Round 2 (2026-05-17):** design-reviewer NOT READY — 2 blocking + 4 non-blocking. Round-1 blockers all resolved; round 2 surfaced a structural error in v2's §6.2 (`LowerBoundByTime` hung on the wrong interface — Subscribe doesn't consume `HistoryReader`) and a missing I-PRIV-7 test. Addressed in this v3:
+  - **B-R2.1:** §6.2 rewritten — drop the invented `HistoryReader.LowerBoundByTime`, use JetStream's native `DeliverByStartTimePolicy` (already at `hot_jetstream.go:283`) with `minFloor` across subjects, paired with per-subject filter-at-delivery in the Subscribe broadcaster for over-delivered events. `QueryStreamHistory` uses the existing `HistoryQuery.NotBefore` field — no API addition.
+  - **B-R2.2:** I-PRIV-7 now has a unit test (manifest validation), an integration test (initially `t.Skip` until a plugin adopts `history_scope:`), and a meta-test scope adjustment that satisfies I-PRIV-7 vacuously when zero plugins have declared.
+  - **N-R2.1, N-R2.2:** §3 staff-override cell rewritten — disjunct phrasing + temporal-floor reminder.
+  - **N-R2.3:** §7 leak-neutrality note rewritten to acknowledge the sessions/characters drift correction.
+  - **N-R2.4:** §2 gains a multi-session worked example.
+
+- **Round 3 (2026-05-17):** design-reviewer NOT READY — 2 blocking + 3 non-blocking. Round 3 caught a NATS JetStream immutability constraint that v3 §6.2 was implicit about. Addressed in v4:
+  - **B-R3.1 (immutability):** §6.2 rewritten into explicit two-tier model: Tier 1 `OptStartTime` as a perf hint set at consumer creation only (immutable per NATS server error 10012); Tier 2 per-subject filter-at-delivery as the load-bearing privacy gate. `SetFilters` MUST replay original `OptStartTime` verbatim. New I-PRIV-8 codifies the constraint.
+  - **B-R3.2 (reattach):** §6.2 explicit reattach paragraph + I-PRIV-3 amendment: `Subscribe.ReattachCAS` MUST NOT recreate the durable; enforcement on reattach is the filter, not `OptStartTime`. New integration test asserts this.
+  - **N-R3.1:** §6.2 cost analysis softened to acknowledge reattach scan-then-discard cost (bounded by `(new floor − last-acked timestamp) × event rate`).
+  - **N-R3.2:** I-PRIV-7 manifest validation strengthened to require closed-enum + rejection of plugin-owned subjects without `history_scope:` declaration. Enforces "silent inheritance forbidden."
+  - **N-R3.3:** Phase 3 row expanded to enumerate `SetFilters` + reattach invariants alongside `OpenSession`.
+- **Round 4 (2026-05-17):** design-reviewer NOT READY — 2 blocking + 3 non-blocking. Round 4 caught that v4's "store `OptStartTime` on the `jetStreamSessionStream`" rule didn't survive across `OpenSession`-on-reattach (fresh struct constructed per call). Addressed in v5:
+  - **B-R4.1:** §6.2 replaces in-process storage with a NATS-source-of-truth pattern — both `OpenSession` (first AND reattach) and `SetFilters` query `s.js.Consumer(...)` first; on hit, copy `DeliverPolicy`/`OptStartTime`/`OptStartSeq` verbatim from existing config; on `ErrConsumerNotFound`, compute fresh `minFloor`. Idempotent by construction; error 10012 impossible.
+  - **B-R4.2:** I-PRIV-8 amended to require the NATS lookup pattern (not in-process or DB-row caching). I-PRIV-3 amended with explicit reattach-not-recreate semantics (idempotent OpenSession is a no-op on the durable). §8 I-PRIV-8 unit test expanded to three cases (fresh create, OpenSession-on-reattach, SetFilters).
+  - **N-R4.1:** I-PRIV-8 moved to end of §9 for monotonic numbering.
+  - **N-R4.2:** §8 I-PRIV-7 manifest test reworded — manifest entries are bare *namespaces* per `internal/plugin/manifest.go` validation (not subject patterns).
+  - **N-R4.3:** subsumed into B-R4.1 fix.
+- **Round 5 (2026-05-17):** design-reviewer NOT READY — 2 blocking + 3 non-blocking. Round 5 caught two last-mile precision issues. Addressed in this v6:
+  - **B-R5.1:** §6.2 pseudocode handled only `nil` and `ErrConsumerNotFound` lookup-error branches; transient errors (NATS connection drop, context cancel) silently fell through with zero `DeliverPolicy` → potential error 10012 or `DeliverAllPolicy` leak window. Added explicit fail-closed third branch returning `EVENTBUS_CONSUMER_LOOKUP_FAILED` without invoking `CreateOrUpdateConsumer`. §8 I-PRIV-8 gains a fourth unit test for the transient-error path. "Impossible by construction" softened to "unreachable under documented call discipline."
+  - **B-R5.2:** I-PRIV-3 "MUST NOT recreate or mutate" reworded to explicitly enumerate the immutable fields — "MUST NOT change `DeliverPolicy`, `OptStartTime`, or `OptStartSeq`; `FilterSubjects` MAY change." Resolves the literal-reading tension with §6.2 design.
+  - **N-R5.1:** §6.2 pseudocode now notes that `Durable`/`Name`/`AckPolicy`/`MaxAckPending`/`AckWait`/`InactiveThreshold` MUST match existing OpenSession/SetFilters defaults — only the three start-policy fields come from `existing.CachedInfo().Config`.
+  - **N-R5.2:** "Impossible by construction" claim softened (paired with B-R5.1 fix).
+  - **N-R5.3:** Fourth unit test added to §8 I-PRIV-8 (paired with B-R5.1 fix).
+
+See bead `holomush-iwzt` notes for full round-by-round audit trail.


### PR DESCRIPTION
## Summary

Pre-positioning documentation for the `holomush-iwzt` history-scope privacy fix. Implementation lands per the 25-task bead chain (`iwzt.1..25`) materialized in `bd`; **this PR ships the design surface only** so subagents executing the bead chain can read from `main`.

Triggered by the 2026-05-17 dev-server observation: new guest "Onyx Radium" seeing prior IC speech between Emerald + Pearl Radium.

## Contents

### Spec (6 rounds of design-reviewer adversarial review → READY)

`docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md`

- 8 RFC2119 invariants (I-PRIV-1..8): active-presence-only history, guest identity floor, reattach reset, idle preservation, wire-opacity, staff override, plugin manifest opt-in, JetStream consumer immutability.
- Two-tier enforcement: `OptStartTime` perf hint + per-subject filter-at-delivery as load-bearing privacy gate.
- NATS-source-of-truth consumer config (query-then-copy pattern).
- 7 lifecycle transitions covering fresh login, `SelectCharacter` reattach, `Subscribe.ReattachCAS`, detach, character move, logout, TTL expiry.

### Plan (4 rounds of plan-reviewer → READY)

`docs/superpowers/plans/2026-05-17-history-scope-privacy.md`

- 25 bite-sized TDD tasks across 6 phases + harness prerequisite + meta-test + pr-prep finalize.
- Coverage matrix maps every spec section and invariant to its implementing task.

### ADRs (5)

- `holomush-wxty`: Hard-gate (current-location-only) replaces ABAC for location-stream history reads; staff override via ABAC predicate.
- `holomush-rc8b`: Per-session attach intervals on `SessionInfo` (not `Character`) for multi-session continuity.
- `holomush-kmac`: Session-store sync hook on character move via `MovementHook` interface (corrects latent sessions/characters drift).
- `holomush-ghpx`: In-process filter-at-delivery as load-bearing privacy gate; NATS-as-source-of-truth for immutable consumer config.
- `holomush-jhl5`: Plugin manifests opt-in to `history_scope` (vs spec's exempt-list framing) — resolves stream-prefix vs manifest-namespace ambiguity.

ADR README index updated.

## Test plan

- [x] `task pr-prep` — green (lint + format + schema + license + unit + integration + E2E 62/62).
- [x] No code changes; docs-only PR.
- [x] Bead chain `iwzt.1..25` materialized in bd with 41 dep edges; `bd ready` correctly surfaces the 5 leaf entry points.

## Follow-ups (separate plans)

- `holomush-fujt` — own-events-rendering race during connect.
- `holomush-87qu` — connect-to-live latency.

Tracks `holomush-iwzt` (P0 epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added five new ADRs addressing history-scope privacy, per-session location timing, session-store move sync, per-subject delivery filtering, and consumer-configuration discipline; updated ADR index.
  * Added a comprehensive history-scope privacy design spec and a detailed implementation plan.
  * Updated workflow and agent guidance, renaming stage-gated skill conventions from superpowers:* to dev-flow:* and clarifying plan→bd materialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->