### PR TITLE
feat(session): migration 037 — session history-floor columns (iwzt.1)

### DIFF
--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Migrator", func() {
 
 			version, dirty, err = migrator.Version()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(uint(36)))
+			Expect(version).To(Equal(uint(37)))
 			Expect(dirty).To(BeFalse())
 
 			tables = queryTableNames(suiteT, ctx, connStr)
@@ -174,7 +174,7 @@ var _ = Describe("Migrator", func() {
 
 			version, dirty, err = migrator.Version()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(uint(36)))
+			Expect(version).To(Equal(uint(37)))
 			Expect(dirty).To(BeFalse())
 
 			tables = queryTableNames(suiteT, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,7 +278,7 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-20, 30, 31, 32, 33, 34, 35, and 36 should be pending
+	// At version 0, migrations 1-20, 30, 31, 32, 33, 34, 35, 36, and 37 should be pending
 	// (baseline + is_guest + alias_source + session_player_id + audit_source_component +
 	// session_focus + seed_scene_defaults + session_player_fk + create_events_audit +
 	// drop_events_and_cursors + events_audit_js_seq_index + events_audit_rendering +
@@ -287,16 +287,17 @@ func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testin
 	// create_player_totp + create_admin_approvals + replace_bootstrap_metadata +
 	// create_crypto_rekey_checkpoints + create_setting_bootstrap_state +
 	// add_justification_to_checkpoints + add_phase3_count_to_checkpoints +
-	// drop_checkpoint_dek_fks + admin_approvals_op_args_hash_idx)
+	// drop_checkpoint_dek_fks + admin_approvals_op_args_hash_idx +
+	// add_session_history_floor_columns)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34, 35, 36}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34, 35, 36, 37}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 36 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 36}}
+	// At version 37 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 37}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000037_add_session_history_floor_columns.down.sql
+++ b/internal/store/migrations/000037_add_session_history_floor_columns.down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS location_arrived_at,
+    DROP COLUMN IF EXISTS guest_character_created_at;

--- a/internal/store/migrations/000037_add_session_history_floor_columns.up.sql
+++ b/internal/store/migrations/000037_add_session_history_floor_columns.up.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS location_arrived_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS guest_character_created_at TIMESTAMPTZ NOT NULL DEFAULT 'epoch';


### PR DESCRIPTION
Adds two columns to `sessions` for the holomush-iwzt history-scope privacy work:

- `location_arrived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
- `guest_character_created_at TIMESTAMPTZ NOT NULL DEFAULT 'epoch'`

Pure schema change; no behavioral effect. Fields will be populated in T2 and consumed starting T7.

Also updates `migrate_test.go` and `migrate_integration_test.go` to expect version 37 as the latest migration.

Bead: holomush-iwzt.1
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 1
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1, I-PRIV-3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to enhance session history tracking with improved timestamp data recording capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->