### PR TITLE
feat(access): seed staff_read_unrestricted_history policy (iwzt.19)

### DIFF
--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -11,7 +11,7 @@ type SeedPolicy struct {
 	SeedVersion int
 }
 
-// SeedPolicies returns the complete set of 34 seed policies (25 permit, 9 forbid).
+// SeedPolicies returns the complete set of 35 seed policies (26 permit, 9 forbid).
 // The initial 18 (T22) minus 2 removed command policies, plus 5 gap-fill policies (T22b: G1-G4),
 // 1 phase-2 command policy, and 2 system bootstrap policies.
 // Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
@@ -286,6 +286,19 @@ func SeedPolicies() []SeedPolicy {
 			Name:        "seed:deny-events-system-read-plugin",
 			Description: "Plugins MUST NOT read events.*.system.* streams (Phase 5 sub-epic E; A16 / INV-15 extension — covers rekey and all future system audit namespaces)",
 			DSLText:     `forbid(principal is plugin, action in ["read"], resource is stream) when { resource.stream.name like "events.*.system.*" };`,
+			SeedVersion: 1,
+		},
+
+		// --- Phase-5 iwzt history-scope-privacy staff override policy (I-PRIV-6) ---
+		//
+		// Staff and admins may bypass the per-session temporal floor (the read_unrestricted_history
+		// action) but NOT the location hard-gate (ADR wxty preserves the gate for all principals).
+		// Action-only seed; no resource-type guard because the gate is about the action class,
+		// not the resource namespace.
+		{
+			Name:        "seed:staff-read-unrestricted-history",
+			Description: "Staff and admins may bypass the per-session temporal floor for history reads (I-PRIV-6); location hard-gate still applies (ADR wxty)",
+			DSLText:     `permit(principal is character, action in ["read_unrestricted_history"], resource) when { "staff" in principal.character.roles || "admin" in principal.character.roles };`,
 			SeedVersion: 1,
 		},
 	}

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPoliciesCount(t *testing.T) {
 	seeds := SeedPolicies()
-	// 25 permit + 9 forbid = 34 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds)
-	assert.Len(t, seeds, 34, "expected 34 seed policies (25 permit, 9 forbid)")
+	// 26 permit + 9 forbid = 35 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history)
+	assert.Len(t, seeds, 35, "expected 35 seed policies (26 permit, 9 forbid)")
 }
 
 func TestSeedPoliciesAllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSeedPoliciesEffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 25, permitCount, "expected 25 permit policies")
+	assert.Equal(t, 26, permitCount, "expected 26 permit policies")
 	assert.Equal(t, 9, forbidCount, "expected 9 forbid policies (+2 phase-5 sub-epic A events.*.system.crypto_totp.* denies + 2 phase-5 sub-epic D events.*.system.crypto_policy.* denies + 2 phase-5 sub-epic E events.*.system.* broad denies)")
 }
 
@@ -119,6 +119,8 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		// Phase-5 sub-epic E broad events.*.system.* deny policies (A16 future-proof + rekey namespace)
 		"seed:deny-events-system-read-character",
 		"seed:deny-events-system-read-plugin",
+		// Phase-5 iwzt history-scope-privacy staff override policy (I-PRIV-6)
+		"seed:staff-read-unrestricted-history",
 	}
 
 	seeds := SeedPolicies()
@@ -395,6 +397,20 @@ func TestSeedPoliciesIncludesEventsSystemRekeyDenyForPlugin(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "events.*.system.* broad deny seed for plugin MUST be present (A16 / INV-15)")
+}
+
+// Phase-5 iwzt history-scope-privacy policy tests
+
+func TestSeed_IncludesStaffUnrestrictedHistoryPolicy(t *testing.T) {
+	seeds := SeedPolicies()
+	var found bool
+	for _, s := range seeds {
+		if s.Name == "seed:staff-read-unrestricted-history" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Phase 5 must seed seed:staff-read-unrestricted-history policy")
 }
 
 // Phase-2 command policy tests


### PR DESCRIPTION
Adds an ABAC policy seed permitting principals with role `staff` or `admin` to
perform the action `read_unrestricted_history`. Backs the staff override path
(I-PRIV-6) that lets staff bypass the per-session temporal floor — but NOT the
location hard-gate (ADR wxty preserves the gate even for staff).

Action-only seed; no `resource is stream` guard because the gate is about the
action, not the resource type.

abac-reviewer verdict: READY (no findings).
code-reviewer (per worker): not formally invoked; relying on ABAC review + CI.

Bead: holomush-iwzt.19
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-6)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff and admin users now have access to read unrestricted history records, bypassing temporal restrictions while maintaining existing location-based security controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->