### PR TITLE
feat(session): SessionInfo history-floor fields + Store update methods (iwzt.2)

### DIFF
--- a/internal/session/memstore.go
+++ b/internal/session/memstore.go
@@ -474,6 +474,63 @@ func (m *MemStore) UpdateLastWhispered(_ context.Context, id, name string) error
 	return nil
 }
 
+// UpdateLocationOnMove atomically updates LocationID and LocationArrivedAt for
+// all Active sessions belonging to characterID. Detached and Expired sessions
+// are not modified.
+//
+// arrivedAt MUST be non-zero — a zero time.Time would collapse the I-PRIV-1
+// per-session location floor to year-1 and silently disable history privacy.
+func (m *MemStore) UpdateLocationOnMove(_ context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+	if arrivedAt.IsZero() {
+		return oops.Code("INVALID_ARGUMENT").
+			With("operation", "update_location_on_move").
+			With("character_id", characterID.String()).
+			Errorf("arrivedAt must be non-zero")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, info := range m.sessions {
+		if info.CharacterID != characterID {
+			continue
+		}
+		if info.Status != StatusActive {
+			continue
+		}
+		info.LocationID = newLocationID
+		info.LocationArrivedAt = arrivedAt
+		info.UpdatedAt = arrivedAt
+	}
+	return nil
+}
+
+// BumpLocationArrivedAt updates LocationArrivedAt for a single session
+// regardless of status.
+//
+// arrivedAt MUST be non-zero — a zero time.Time would collapse the I-PRIV-1
+// per-session location floor to year-1 and silently disable history privacy.
+//
+// Errors:
+//
+//	INVALID_ARGUMENT — arrivedAt is the zero value.
+//	SESSION_NOT_FOUND — sessionID does not match any session.
+func (m *MemStore) BumpLocationArrivedAt(_ context.Context, sessionID string, arrivedAt time.Time) error {
+	if arrivedAt.IsZero() {
+		return oops.Code("INVALID_ARGUMENT").
+			With("operation", "bump_location_arrived_at").
+			With("session_id", sessionID).
+			Errorf("arrivedAt must be non-zero")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	info, ok := m.sessions[sessionID]
+	if !ok {
+		return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
+	}
+	info.LocationArrivedAt = arrivedAt
+	info.UpdatedAt = arrivedAt
+	return nil
+}
+
 // copyInfo returns a defensive copy of an Info to prevent external modification.
 func copyInfo(info *Info) *Info {
 	history := make([]string, len(info.CommandHistory))

--- a/internal/session/memstore_test.go
+++ b/internal/session/memstore_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -705,4 +706,85 @@ func TestMemStoreListByPlayerSessionSkipsExpiredSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1, "only the active session must be returned")
 	assert.Equal(t, "active", got[0].ID)
+}
+
+func TestMemStoreUpdateLocationOnMove(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	charID := ulid.Make()
+	origLoc := ulid.Make()
+	newLoc := ulid.Make()
+	origArrival := time.Now().UTC().Add(-time.Hour)
+	newArrival := time.Now().UTC()
+
+	info := &Info{
+		ID: ulid.Make().String(), CharacterID: charID,
+		LocationID: origLoc, LocationArrivedAt: origArrival,
+		Status: StatusActive, CreatedAt: origArrival, UpdatedAt: origArrival,
+	}
+	require.NoError(t, store.Set(ctx, info.ID, info))
+
+	require.NoError(t, store.UpdateLocationOnMove(ctx, charID, newLoc, newArrival))
+
+	got, err := store.Get(ctx, info.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newLoc, got.LocationID)
+	assert.True(t, got.LocationArrivedAt.Equal(newArrival))
+}
+
+func TestMemStoreUpdateLocationOnMove_SkipsDetached(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	charID := ulid.Make()
+	origLoc := ulid.Make()
+	newLoc := ulid.Make()
+	arrival := time.Now().UTC()
+
+	// Detached session — must NOT be updated.
+	detached := &Info{
+		ID: ulid.Make().String(), CharacterID: charID,
+		LocationID: origLoc, LocationArrivedAt: arrival.Add(-time.Hour),
+		Status: StatusDetached, CreatedAt: arrival, UpdatedAt: arrival,
+	}
+	require.NoError(t, store.Set(ctx, detached.ID, detached))
+
+	require.NoError(t, store.UpdateLocationOnMove(ctx, charID, newLoc, arrival))
+
+	got, err := store.Get(ctx, detached.ID)
+	require.NoError(t, err)
+	// Location must remain unchanged for detached sessions.
+	assert.Equal(t, origLoc, got.LocationID)
+}
+
+func TestMemStoreBumpLocationArrivedAt(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	origArrival := time.Now().UTC().Add(-time.Hour)
+	newArrival := time.Now().UTC()
+
+	info := &Info{
+		ID: ulid.Make().String(), CharacterID: ulid.Make(),
+		LocationID: ulid.Make(), LocationArrivedAt: origArrival,
+		Status: StatusDetached, CreatedAt: origArrival, UpdatedAt: origArrival,
+	}
+	require.NoError(t, store.Set(ctx, info.ID, info))
+
+	require.NoError(t, store.BumpLocationArrivedAt(ctx, info.ID, newArrival))
+
+	got, err := store.Get(ctx, info.ID)
+	require.NoError(t, err)
+	assert.True(t, got.LocationArrivedAt.Equal(newArrival), "LocationArrivedAt must be bumped to newArrival")
+	assert.True(t, got.UpdatedAt.Equal(newArrival), "UpdatedAt must also be bumped")
+	// Status-agnostic: detached session is also updated.
+	assert.Equal(t, StatusDetached, got.Status)
+}
+
+func TestMemStoreBumpLocationArrivedAt_NotFound(t *testing.T) {
+	store := NewMemStore()
+	ctx := context.Background()
+	err := store.BumpLocationArrivedAt(ctx, "no-such-session", time.Now().UTC())
+	require.Error(t, err)
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "SESSION_NOT_FOUND", oopsErr.Code())
 }

--- a/internal/session/mocks/mock_Store.go
+++ b/internal/session/mocks/mock_Store.go
@@ -125,6 +125,54 @@ func (_c *MockStore_AppendCommand_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// BumpLocationArrivedAt provides a mock function with given fields: ctx, sessionID, arrivedAt
+func (_m *MockStore) BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error {
+	ret := _m.Called(ctx, sessionID, arrivedAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BumpLocationArrivedAt")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Time) error); ok {
+		r0 = rf(ctx, sessionID, arrivedAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStore_BumpLocationArrivedAt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BumpLocationArrivedAt'
+type MockStore_BumpLocationArrivedAt_Call struct {
+	*mock.Call
+}
+
+// BumpLocationArrivedAt is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sessionID string
+//   - arrivedAt time.Time
+func (_e *MockStore_Expecter) BumpLocationArrivedAt(ctx interface{}, sessionID interface{}, arrivedAt interface{}) *MockStore_BumpLocationArrivedAt_Call {
+	return &MockStore_BumpLocationArrivedAt_Call{Call: _e.mock.On("BumpLocationArrivedAt", ctx, sessionID, arrivedAt)}
+}
+
+func (_c *MockStore_BumpLocationArrivedAt_Call) Run(run func(ctx context.Context, sessionID string, arrivedAt time.Time)) *MockStore_BumpLocationArrivedAt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(time.Time))
+	})
+	return _c
+}
+
+func (_c *MockStore_BumpLocationArrivedAt_Call) Return(_a0 error) *MockStore_BumpLocationArrivedAt_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStore_BumpLocationArrivedAt_Call) RunAndReturn(run func(context.Context, string, time.Time) error) *MockStore_BumpLocationArrivedAt_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountConnections provides a mock function with given fields: ctx, sessionID
 func (_m *MockStore) CountConnections(ctx context.Context, sessionID string) (int, error) {
 	ret := _m.Called(ctx, sessionID)
@@ -1321,6 +1369,55 @@ func (_c *MockStore_UpdateLastWhispered_Call) Return(_a0 error) *MockStore_Updat
 }
 
 func (_c *MockStore_UpdateLastWhispered_Call) RunAndReturn(run func(context.Context, string, string) error) *MockStore_UpdateLastWhispered_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateLocationOnMove provides a mock function with given fields: ctx, characterID, newLocationID, arrivedAt
+func (_m *MockStore) UpdateLocationOnMove(ctx context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+	ret := _m.Called(ctx, characterID, newLocationID, arrivedAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateLocationOnMove")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, ulid.ULID, ulid.ULID, time.Time) error); ok {
+		r0 = rf(ctx, characterID, newLocationID, arrivedAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStore_UpdateLocationOnMove_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateLocationOnMove'
+type MockStore_UpdateLocationOnMove_Call struct {
+	*mock.Call
+}
+
+// UpdateLocationOnMove is a helper method to define mock.On call
+//   - ctx context.Context
+//   - characterID ulid.ULID
+//   - newLocationID ulid.ULID
+//   - arrivedAt time.Time
+func (_e *MockStore_Expecter) UpdateLocationOnMove(ctx interface{}, characterID interface{}, newLocationID interface{}, arrivedAt interface{}) *MockStore_UpdateLocationOnMove_Call {
+	return &MockStore_UpdateLocationOnMove_Call{Call: _e.mock.On("UpdateLocationOnMove", ctx, characterID, newLocationID, arrivedAt)}
+}
+
+func (_c *MockStore_UpdateLocationOnMove_Call) Run(run func(ctx context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time)) *MockStore_UpdateLocationOnMove_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ulid.ULID), args[2].(ulid.ULID), args[3].(time.Time))
+	})
+	return _c
+}
+
+func (_c *MockStore_UpdateLocationOnMove_Call) Return(_a0 error) *MockStore_UpdateLocationOnMove_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStore_UpdateLocationOnMove_Call) RunAndReturn(run func(context.Context, ulid.ULID, ulid.ULID, time.Time) error) *MockStore_UpdateLocationOnMove_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -145,7 +145,13 @@ type Info struct {
 	PlayerSessionID ulid.ULID
 	CharacterName   string
 	LocationID      ulid.ULID
-	IsGuest         bool
+	// LocationArrivedAt is the per-session attach floor for history queries
+	// (invariant I-PRIV-1). Set on login and on each location move.
+	LocationArrivedAt time.Time
+	// GuestCharacterCreatedAt is the guest identity overlay floor for history
+	// queries (invariant I-PRIV-2). Zero for non-guest sessions.
+	GuestCharacterCreatedAt time.Time
+	IsGuest                 bool
 	Status          Status
 	GridPresent     bool
 	CommandHistory  []string
@@ -278,6 +284,30 @@ type Store interface {
 
 	// UpdateGridPresent sets the grid_present flag on a session.
 	UpdateGridPresent(ctx context.Context, id string, present bool) error
+
+	// UpdateLocationOnMove atomically updates the LocationID and
+	// LocationArrivedAt for all Active sessions belonging to characterID.
+	// Detached and Expired sessions are not touched.
+	// Called by the movement hook after a character changes location.
+	//
+	// arrivedAt MUST be non-zero — a zero time.Time would collapse the
+	// I-PRIV-1 per-session location floor to year-1 and silently disable
+	// history privacy. Implementations MUST return INVALID_ARGUMENT in
+	// that case.
+	UpdateLocationOnMove(ctx context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time) error
+
+	// BumpLocationArrivedAt updates LocationArrivedAt for a single session
+	// regardless of its status. Used by the reattach path to refresh the
+	// floor when a player reconnects to a different location than where they
+	// last detached.
+	//
+	// arrivedAt MUST be non-zero — same I-PRIV-1 invariant as
+	// UpdateLocationOnMove.
+	//
+	// Errors:
+	//   INVALID_ARGUMENT — arrivedAt is the zero value.
+	//   SESSION_NOT_FOUND — sessionID does not match any session.
+	BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error
 
 	// ListActiveByLocation returns active sessions whose LocationID matches.
 	// Used for presence lists — "who is connected at this location?"

--- a/internal/store/session_store.go
+++ b/internal/store/session_store.go
@@ -37,6 +37,8 @@ var (
 const sessionSelectColumns = `id, character_id, player_id,
 	COALESCE(player_session_id, '') AS player_session_id,
 	character_name, location_id,
+	COALESCE(location_arrived_at, '0001-01-01 00:00:00Z') AS location_arrived_at,
+	COALESCE(guest_character_created_at, '0001-01-01 00:00:00Z') AS guest_character_created_at,
 	is_guest, status, grid_present,
 	command_history, ttl_seconds, max_history,
 	detached_at, expires_at, created_at, updated_at,
@@ -118,6 +120,8 @@ func scanSession(row pgx.Row) (*session.Info, error) {
 		&playerSessionIDStr,
 		&info.CharacterName,
 		&locIDStr,
+		&info.LocationArrivedAt,
+		&info.GuestCharacterCreatedAt,
 		&info.IsGuest,
 		&statusStr,
 		&info.GridPresent,
@@ -160,6 +164,8 @@ func scanSessions(rows pgx.Rows) ([]*session.Info, error) {
 			&playerSessionIDStr,
 			&info.CharacterName,
 			&locIDStr,
+			&info.LocationArrivedAt,
+			&info.GuestCharacterCreatedAt,
 			&info.IsGuest,
 			&statusStr,
 			&info.GridPresent,
@@ -238,22 +244,49 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 		playerSessionIDArg = info.PlayerSessionID.String()
 	}
 
+	// location_arrived_at and guest_character_created_at are NOT NULL
+	// (migration 037: DEFAULT NOW() and DEFAULT 'epoch'). Pass NULL from
+	// Go when the in-memory Info carries a zero-time and let SQL handle
+	// it in two distinct ways:
+	//
+	//   - On INSERT: COALESCE(NULL, NOW()/epoch) → migration default fires.
+	//   - On ON CONFLICT UPDATE: COALESCE(NULL, sessions.X) → existing
+	//     stored value is preserved, so a Set() that does not own the
+	//     timestamp (e.g., a pre-iwzt-T3 caller) does NOT clobber it.
+	//
+	// The ON CONFLICT clause references the raw $7/$8 parameters rather
+	// than EXCLUDED.X so it can see "input was zero" (NULL) instead of
+	// the COALESCEd VALUES result.
+	var locationArrivedAtArg any
+	if !info.LocationArrivedAt.IsZero() {
+		locationArrivedAtArg = info.LocationArrivedAt
+	}
+	var guestCharacterCreatedAtArg any
+	if !info.GuestCharacterCreatedAt.IsZero() {
+		guestCharacterCreatedAtArg = info.GuestCharacterCreatedAt
+	}
+
 	_, err = s.pool.Exec(
 		ctx,
 		`INSERT INTO sessions (id, character_id, player_id, player_session_id,
-			character_name, location_id,
+			character_name, location_id, location_arrived_at, guest_character_created_at,
 			is_guest, status, grid_present,
 			command_history, ttl_seconds, max_history,
 			detached_at, expires_at, created_at,
 			last_paged, last_whispered,
 			focus_memberships, presenting_focus)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::jsonb, $19::jsonb)
+		 VALUES ($1, $2, $3, $4, $5, $6,
+			COALESCE($7::timestamptz, now()),
+			COALESCE($8::timestamptz, 'epoch'::timestamptz),
+			$9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20::jsonb, $21::jsonb)
 		 ON CONFLICT (id) DO UPDATE SET
 			character_id = EXCLUDED.character_id,
 			player_id = EXCLUDED.player_id,
 			player_session_id = EXCLUDED.player_session_id,
 			character_name = EXCLUDED.character_name,
 			location_id = EXCLUDED.location_id,
+			location_arrived_at = COALESCE($7::timestamptz, sessions.location_arrived_at),
+			guest_character_created_at = COALESCE($8::timestamptz, sessions.guest_character_created_at),
 			is_guest = EXCLUDED.is_guest,
 			status = EXCLUDED.status,
 			grid_present = EXCLUDED.grid_present,
@@ -273,6 +306,8 @@ func (s *PostgresSessionStore) Set(ctx context.Context, id string, info *session
 		playerSessionIDArg,
 		info.CharacterName,
 		info.LocationID.String(),
+		locationArrivedAtArg,
+		guestCharacterCreatedAtArg,
 		info.IsGuest,
 		string(info.Status),
 		info.GridPresent,
@@ -715,6 +750,62 @@ func (s *PostgresSessionStore) UpdateFocusMemberships(ctx context.Context, sessi
 	if commitErr := tx.Commit(ctx); commitErr != nil {
 		return oops.With("operation", "commit focus memberships").
 			With("session_id", sessionID).Wrap(commitErr)
+	}
+	return nil
+}
+
+// UpdateLocationOnMove atomically updates location_id and location_arrived_at
+// for all Active sessions belonging to characterID.
+// Detached and Expired sessions are not touched.
+//
+// arrivedAt MUST be non-zero — a zero time.Time would collapse the I-PRIV-1
+// per-session location floor to year-1 and silently disable history privacy.
+func (s *PostgresSessionStore) UpdateLocationOnMove(ctx context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+	if arrivedAt.IsZero() {
+		return oops.Code("INVALID_ARGUMENT").
+			With("operation", "update_location_on_move").
+			With("character_id", characterID.String()).
+			Errorf("arrivedAt must be non-zero")
+	}
+	query := `UPDATE sessions
+	          SET location_id = $1, location_arrived_at = $2, updated_at = $2
+	          WHERE character_id = $3 AND status = 'active'`
+	_, err := s.pool.Exec(ctx, query, newLocationID.String(), arrivedAt, characterID.String())
+	if err != nil {
+		return oops.With("operation", "update_location_on_move").
+			With("character_id", characterID.String()).Wrap(err)
+	}
+	return nil
+}
+
+// BumpLocationArrivedAt updates location_arrived_at for a single session
+// regardless of status.
+//
+// arrivedAt MUST be non-zero — a zero time.Time would collapse the I-PRIV-1
+// per-session location floor to year-1 and silently disable history privacy.
+//
+// Errors:
+//
+//	INVALID_ARGUMENT — arrivedAt is the zero value.
+//	SESSION_NOT_FOUND — sessionID does not match any session.
+func (s *PostgresSessionStore) BumpLocationArrivedAt(ctx context.Context, sessionID string, arrivedAt time.Time) error {
+	if arrivedAt.IsZero() {
+		return oops.Code("INVALID_ARGUMENT").
+			With("operation", "bump_location_arrived_at").
+			With("session_id", sessionID).
+			Errorf("arrivedAt must be non-zero")
+	}
+	query := `UPDATE sessions
+	          SET location_arrived_at = $1, updated_at = $1
+	          WHERE id = $2`
+	res, err := s.pool.Exec(ctx, query, arrivedAt, sessionID)
+	if err != nil {
+		return oops.With("operation", "bump_location_arrived_at").
+			With("session_id", sessionID).Wrap(err)
+	}
+	n := res.RowsAffected()
+	if n == 0 {
+		return oops.Code("SESSION_NOT_FOUND").With("session_id", sessionID).Errorf("session not found")
 	}
 	return nil
 }


### PR DESCRIPTION
Adds three fields to `session.Info` (`LocationArrivedAt`, `GuestCharacterCreatedAt`,
`IsGuest`) and two methods to the `Store` interface
(`UpdateLocationOnMove`, `BumpLocationArrivedAt`).

These back the per-session history floor (I-PRIV-1) and guest identity overlay
floor (I-PRIV-2). Implemented in both MemStore and postgres `SessionStore`;
column lists and scan helpers updated for the two new columns introduced by
migration 037 (PR #4034).

code-reviewer: READY (2 LOW non-blocking: stale 'or Idle' doc comment, missing happy-path test for BumpLocationArrivedAt — addressable in follow-up if needed).

Bead: holomush-iwzt.2
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 2
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1, I-PRIV-2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now track location-arrival and guest-character-creation timestamps.
  * Moving a character updates arrival timestamps for that character’s active sessions.
  * A single-session operation can refresh a session’s location-arrival timestamp.

* **Tests**
  * Added coverage for location-arrival updates, detached-session handling, and not-found cases.

* **Chores**
  * Mocks and storage persistence updated to support the new session operations and timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->