### PR TITLE
feat(eventbus): NATS-source-of-truth consumer-config builder (iwzt.12)

### DIFF
--- a/internal/eventbus/subscriber_consumer_config.go
+++ b/internal/eventbus/subscriber_consumer_config.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/samber/oops"
+)
+
+// consumerInfo is the narrow surface buildConsumerConfig needs from an
+// existing JetStream consumer — just enough to read its config. The real
+// jetstream.Consumer satisfies this trivially. Tests provide a stub that
+// implements ONLY CachedInfo without touching the full ~7-method
+// jetstream.Consumer surface.
+type consumerInfo interface {
+	CachedInfo() *jetstream.ConsumerInfo
+}
+
+// consumerLookup is the narrow surface buildConsumerConfig needs from a
+// JetStream context. Returns the local consumerInfo (NOT jetstream.Consumer)
+// so test stubs do not need to satisfy the full jetstream.Consumer interface.
+// Production callers pass a thin adapter that wraps js.Consumer(...) and
+// returns its result as a consumerInfo.
+type consumerLookup interface {
+	LookupConsumer(ctx context.Context, stream, consumer string) (consumerInfo, error)
+}
+
+// jsConsumerLookupAdapter wraps a jetstream.JetStream so it satisfies the
+// narrow consumerLookup interface buildConsumerConfig consumes. Wired into
+// OpenSession and SetFilters by Task 12 (holomush-iwzt.13).
+//
+//nolint:unused // production adapter; wired in Task 12 (holomush-iwzt.13)
+type jsConsumerLookupAdapter struct{ js jetstream.JetStream }
+
+//nolint:unused // production adapter; wired in Task 12 (holomush-iwzt.13)
+func (a jsConsumerLookupAdapter) LookupConsumer(ctx context.Context, stream, name string) (consumerInfo, error) {
+	c, err := a.js.Consumer(ctx, stream, name)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // caller (buildConsumerConfig) wraps with EVENTBUS_CONSUMER_LOOKUP_FAILED
+	}
+	return c, nil // jetstream.Consumer satisfies consumerInfo (has CachedInfo)
+}
+
+// buildConsumerConfig produces a jetstream.ConsumerConfig that is safe to pass
+// to CreateOrUpdateConsumer regardless of whether the durable already exists.
+// Implements the NATS-source-of-truth pattern per holomush-iwzt §6.2 / I-PRIV-8.
+//
+// Three branches:
+//
+//  1. Existing consumer hit (lookupErr == nil && existing != nil): copies
+//     DeliverPolicy, OptStartSeq, and OptStartTime verbatim from the existing
+//     consumer's cached config. Only FilterSubjects is set fresh. OptStartTime
+//     is *time.Time — nil vs. non-nil is preserved exactly.
+//
+//  2. ErrConsumerNotFound: builds a fresh config. If minFloor.IsZero(),
+//     uses DeliverAllPolicy. Otherwise DeliverByStartTimePolicy with
+//     OptStartTime = &minFloor.
+//
+//  3. Any other error: fails closed with EVENTBUS_CONSUMER_LOOKUP_FAILED.
+//     Callers MUST NOT call CreateOrUpdateConsumer when this error is returned.
+//nolint:unparam // streamName is always "STREAM" in unit tests but carries real stream names in production (Task 12 call sites)
+func buildConsumerConfig(
+	ctx context.Context, js consumerLookup,
+	streamName, consumerName string,
+	filterSubjects []string, minFloor time.Time,
+) (jetstream.ConsumerConfig, error) {
+	existing, lookupErr := js.LookupConsumer(ctx, streamName, consumerName)
+	switch {
+	case lookupErr == nil && existing != nil:
+		info := existing.CachedInfo()
+		if info == nil {
+			return jetstream.ConsumerConfig{}, oops.Code("EVENTBUS_CONSUMER_LOOKUP_FAILED").
+				With("stream", streamName).With("consumer", consumerName).
+				Errorf("existing consumer returned nil CachedInfo")
+		}
+		cur := info.Config
+		cfg := jetstream.ConsumerConfig{
+			Durable:        consumerName,
+			Name:           consumerName,
+			FilterSubjects: filterSubjects,
+			DeliverPolicy:  cur.DeliverPolicy,
+			OptStartSeq:    cur.OptStartSeq,
+		}
+		// OptStartTime is *time.Time — preserve nil vs. non-nil verbatim.
+		if cur.OptStartTime != nil {
+			t := *cur.OptStartTime
+			cfg.OptStartTime = &t
+		}
+		return cfg, nil
+
+	case errors.Is(lookupErr, jetstream.ErrConsumerNotFound):
+		cfg := jetstream.ConsumerConfig{
+			Durable:        consumerName,
+			Name:           consumerName,
+			FilterSubjects: filterSubjects,
+		}
+		if !minFloor.IsZero() {
+			cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+			cfg.OptStartTime = &minFloor
+		} else {
+			cfg.DeliverPolicy = jetstream.DeliverAllPolicy
+		}
+		return cfg, nil
+
+	default:
+		return jetstream.ConsumerConfig{}, oops.Code("EVENTBUS_CONSUMER_LOOKUP_FAILED").
+			With("stream", streamName).With("consumer", consumerName).
+			Wrap(lookupErr)
+	}
+}

--- a/internal/eventbus/subscriber_consumer_config_test.go
+++ b/internal/eventbus/subscriber_consumer_config_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// stubJS satisfies the narrow consumerLookup interface.
+// LookupConsumer returns a consumerInfo (NOT jetstream.Consumer) so the
+// test stub does NOT need to implement the full jetstream.Consumer surface.
+type stubJS struct {
+	info        consumerInfo // nil → not found
+	lookupErr   error
+	lookupCalls int
+}
+
+func (s *stubJS) LookupConsumer(_ context.Context, _, _ string) (consumerInfo, error) {
+	s.lookupCalls++
+	if s.lookupErr != nil {
+		return nil, s.lookupErr
+	}
+	return s.info, nil
+}
+
+// stubConsumer satisfies the narrow consumerInfo interface — just CachedInfo().
+type stubConsumer struct {
+	cfg jetstream.ConsumerConfig
+}
+
+func (s *stubConsumer) CachedInfo() *jetstream.ConsumerInfo {
+	return &jetstream.ConsumerInfo{Config: s.cfg}
+}
+
+// TestBuildConsumerConfig_FreshOpenSession_ComputesMinFloor verifies that
+// when no durable consumer exists (ErrConsumerNotFound), the builder
+// produces DeliverByStartTimePolicy with OptStartTime = minFloor.
+func TestBuildConsumerConfig_FreshOpenSession_ComputesMinFloor(t *testing.T) {
+	minFloor := time.Now().Add(-time.Hour)
+	js := &stubJS{info: nil, lookupErr: jetstream.ErrConsumerNotFound}
+
+	cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+		[]string{"events.gid.location.X"}, minFloor)
+
+	require.NoError(t, err)
+	assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
+	require.NotNil(t, cfg.OptStartTime)
+	assert.True(t, cfg.OptStartTime.Equal(minFloor))
+}
+
+// TestBuildConsumerConfig_FreshOpenSession_ZeroMinFloor_UsesDeliverAll verifies
+// the other half of the ErrConsumerNotFound branch: when minFloor is the zero
+// time.Time, the builder produces DeliverAllPolicy (no OptStartTime). Without
+// this case the zero-minFloor path is reachable but unverified.
+func TestBuildConsumerConfig_FreshOpenSession_ZeroMinFloor_UsesDeliverAll(t *testing.T) {
+	js := &stubJS{info: nil, lookupErr: jetstream.ErrConsumerNotFound}
+
+	cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+		[]string{"events.gid.location.X"}, time.Time{})
+
+	require.NoError(t, err)
+	assert.Equal(t, jetstream.DeliverAllPolicy, cfg.DeliverPolicy)
+	assert.Nil(t, cfg.OptStartTime, "DeliverAllPolicy MUST NOT set OptStartTime")
+}
+
+// TestBuildConsumerConfig_ExistingConsumer_PreservesStartPolicy verifies that
+// when a durable consumer already exists, the builder copies DeliverPolicy and
+// OptStartTime verbatim from the existing config and does NOT use the fresh
+// minFloor passed by the caller. This is the core I-PRIV-8 invariant.
+func TestBuildConsumerConfig_ExistingConsumer_PreservesStartPolicy(t *testing.T) {
+	origStart := time.Now().Add(-2 * time.Hour)
+	js := &stubJS{info: &stubConsumer{cfg: jetstream.ConsumerConfig{
+		DeliverPolicy: jetstream.DeliverByStartTimePolicy,
+		OptStartTime:  &origStart,
+	}}}
+
+	cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+		[]string{"events.gid.location.X", "events.gid.scene.Y.ic"}, time.Now())
+
+	require.NoError(t, err)
+	assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
+	require.NotNil(t, cfg.OptStartTime)
+	assert.True(t, cfg.OptStartTime.Equal(origStart), "MUST copy existing OptStartTime verbatim — I-PRIV-8")
+	assert.ElementsMatch(t, []string{"events.gid.location.X", "events.gid.scene.Y.ic"}, cfg.FilterSubjects)
+}
+
+// TestBuildConsumerConfig_SetFilters_PreservesStartPolicy verifies that
+// rotating FilterSubjects (simulating a SetFilters call on an established
+// durable) does NOT regress the start-policy. The builder copies existing
+// policy verbatim and only replaces FilterSubjects.
+func TestBuildConsumerConfig_SetFilters_PreservesStartPolicy(t *testing.T) {
+	origStart := time.Now().Add(-3 * time.Hour)
+	js := &stubJS{info: &stubConsumer{cfg: jetstream.ConsumerConfig{
+		DeliverPolicy: jetstream.DeliverByStartTimePolicy,
+		OptStartTime:  &origStart,
+	}}}
+	newFilters := []string{"events.gid.scene.Z.ic", "events.gid.location.W"}
+
+	cfg, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+		newFilters, time.Now())
+
+	require.NoError(t, err)
+	assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
+	require.NotNil(t, cfg.OptStartTime)
+	assert.True(t, cfg.OptStartTime.Equal(origStart), "filter rotation MUST NOT regress start-policy — I-PRIV-8")
+	assert.ElementsMatch(t, newFilters, cfg.FilterSubjects)
+}
+
+// TestBuildConsumerConfig_TransientLookupError_FailsClosed verifies that
+// any non-NotFound lookup error causes the builder to fail closed with
+// EVENTBUS_CONSUMER_LOOKUP_FAILED. CreateOrUpdateConsumer MUST NOT be called
+// (the caller receives an error and must abort the operation).
+func TestBuildConsumerConfig_TransientLookupError_FailsClosed(t *testing.T) {
+	js := &stubJS{lookupErr: errors.New("nats: connection closed")}
+
+	_, err := buildConsumerConfig(context.Background(), js, "STREAM", "consumer-name",
+		[]string{"events.gid.location.X"}, time.Now())
+
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "EVENTBUS_CONSUMER_LOOKUP_FAILED")
+	assert.Equal(t, 1, js.lookupCalls, "LookupConsumer MUST be called exactly once")
+}


### PR DESCRIPTION
Extracts `internal/eventbus/subscriber_consumer_config.go` with a narrow-interface
helper that builds a `jetstream.ConsumerConfig` safe to pass to
`CreateOrUpdateConsumer` regardless of whether the durable already exists.

Implements the NATS-source-of-truth pattern per I-PRIV-8:

- Existing consumer → copy `DeliverPolicy` / `OptStartTime` / `OptStartSeq` verbatim
- `ErrConsumerNotFound` → fresh config with `DeliverByStartTimePolicy` + `minFloor`
- Other lookup errors → fail closed with `EVENTBUS_CONSUMER_LOOKUP_FAILED`; the
  caller MUST NOT proceed to `CreateOrUpdateConsumer`

4 unit tests cover all three branches plus a SetFilters re-call case.

Wiring into `OpenSession` / `SetFilters` is the next bead (iwzt.13 / Task 12).

Bead: holomush-iwzt.12
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-8, §6.2)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 11
ADR:  docs/adr/holomush-ghpx-filter-at-delivery.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved event bus consumer configuration handling to preserve existing delivery settings during updates, refresh filter criteria safely, and fail safely when consumer lookup cannot be completed—enhancing reliability of event delivery operations.
* **Tests**
  * Added unit tests covering new lookup outcomes, start-time behaviors, filter rotations, and failure modes to ensure correct, idempotent consumer configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->