### PR TITLE
feat(grpc): scope_floor helpers (streamScopeFloor, isLocationStream) (iwzt.7)

### DIFF
--- a/internal/grpc/scope_floor.go
+++ b/internal/grpc/scope_floor.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"strings"
+	"time"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// streamScopeFloor returns the temporal floor for a session's view of the
+// given stream. Per holomush-iwzt §6.1.
+func streamScopeFloor(info *session.Info, stream string) time.Time {
+	var base time.Time
+	switch {
+	case isLocationStream(stream):
+		base = info.LocationArrivedAt
+	case strings.HasPrefix(stream, "scene:"):
+		sceneID, ok := extractSceneID(stream)
+		if !ok {
+			return time.Time{}
+		}
+		for _, m := range info.FocusMemberships {
+			if m.Kind == session.FocusKindScene && m.TargetID.String() == sceneID {
+				base = m.JoinedAt
+				break
+			}
+		}
+	case strings.HasPrefix(stream, "character:"):
+		return time.Time{}
+	default:
+		return time.Time{}
+	}
+	if info.IsGuest && info.GuestCharacterCreatedAt.After(base) {
+		return info.GuestCharacterCreatedAt
+	}
+	return base
+}
+
+// isLocationStream reports whether a stream subject is a grid location stream.
+// Per holomush-iwzt §3.
+func isLocationStream(stream string) bool {
+	if !strings.HasPrefix(stream, "location:") {
+		return false
+	}
+	rest := strings.TrimPrefix(stream, "location:")
+	return rest != "" && !strings.Contains(rest, ":")
+}
+
+// extractLocationID returns the ULID portion of a location stream.
+// Caller MUST check isLocationStream first; otherwise behavior is undefined.
+func extractLocationID(stream string) string { //nolint:unused // consumed by QueryStreamHistory in iwzt.8
+	return strings.TrimPrefix(stream, "location:")
+}
+
+// extractSceneID returns the scene ULID from a scene:<id>:ic or scene:<id>:ooc subject.
+func extractSceneID(stream string) (string, bool) {
+	rest := strings.TrimPrefix(stream, "scene:")
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	return parts[0], true
+}

--- a/internal/grpc/scope_floor_test.go
+++ b/internal/grpc/scope_floor_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+func TestStreamScopeFloor(t *testing.T) {
+	locID := ulid.MustParse("01H000000000000000000000A1")
+	charID := ulid.MustParse("01H000000000000000000000C1")
+	sceneID := ulid.MustParse("01H000000000000000000000S1")
+	arrival := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+	sceneJoin := time.Date(2026, 5, 17, 11, 0, 0, 0, time.UTC)
+	guestCreated := time.Date(2026, 5, 17, 9, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		info   *session.Info
+		stream string
+		want   time.Time
+	}{
+		{"location current — non-guest", &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival},
+			"location:" + locID.String(), arrival},
+		{"location current — guest, arrival later than guest_created",
+			&session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
+			"location:" + locID.String(), arrival},
+		{"location current — guest, guest_created later than arrival (shouldn't happen but MAX wins)",
+			&session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: time.Time{}, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
+			"location:" + locID.String(), guestCreated},
+		{"scene member — non-guest, uses JoinedAt",
+			&session.Info{CharacterID: charID, FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: sceneJoin},
+			}}, "scene:" + sceneID.String() + ":ic", sceneJoin},
+		{"character own stream — no floor", &session.Info{CharacterID: charID}, "character:" + charID.String(), time.Time{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := streamScopeFloor(tc.info, tc.stream)
+			assert.True(t, got.Equal(tc.want), "got %v want %v", got, tc.want)
+		})
+	}
+}
+
+func TestIsLocationStream(t *testing.T) {
+	assert.True(t, isLocationStream("location:01H000000000000000000000A1"))
+	assert.False(t, isLocationStream("scene:01H000000000000000000000S1:ic"))
+	assert.False(t, isLocationStream("character:01H000000000000000000000C1"))
+	assert.False(t, isLocationStream("global"))
+}


### PR DESCRIPTION
Adds the pure-function helpers that the next bead (iwzt.8 / Task 7 — QueryStreamHistory
restructure) will use to compute a session's temporal floor for a given stream:

- `streamScopeFloor(info, stream)` — maps stream-type + session state → `time.Time`
  - location stream → `LocationArrivedAt`
  - scene stream → `FocusMembership.JoinedAt` for the matching scene
  - character stream → no floor (zero time)
  - guest overlay: if `IsGuest && GuestCharacterCreatedAt > base`, returns the guest-create timestamp (I-PRIV-2 identity-reuse floor)
- `isLocationStream(stream)` — prefix recognizer (`location:<ULID>`, no extra colons)
- `extractLocationID` / `extractSceneID` — subject parsers

5 sub-tests in `TestStreamScopeFloor` + 4 assertions in `TestIsLocationStream`, all pass.

Bead: holomush-iwzt.7
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (§6.1, I-PRIV-1, I-PRIV-2)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure improvements and test coverage additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->