### PR TITLE
feat(grpc): set LocationArrivedAt on fresh+reattach session paths (iwzt.3)

### DIFF
--- a/internal/grpc/auth_handlers.go
+++ b/internal/grpc/auth_handlers.go
@@ -299,7 +299,11 @@ func (s *CoreServer) SelectCharacter(ctx context.Context, req *corev1.SelectChar
 			session.StatusActive, nil, nil); updateErr != nil {
 			slog.WarnContext(ctx, "failed to reactivate session", "error", updateErr)
 		}
+		if loErr := s.sessionStore.BumpLocationArrivedAt(ctx, existingSession.ID, now); loErr != nil {
+			slog.WarnContext(ctx, "failed to reset LocationArrivedAt on reattach", "error", loErr)
+		}
 		existingSession.Status = session.StatusActive
+		existingSession.LocationArrivedAt = now
 		existingSession.UpdatedAt = now
 
 		return &corev1.SelectCharacterResponse{
@@ -329,18 +333,19 @@ func (s *CoreServer) SelectCharacter(ctx context.Context, req *corev1.SelectChar
 	}
 
 	sessionInfo := &session.Info{
-		ID:              sessionID.String(),
-		CharacterID:     charID,
-		PlayerID:        playerSession.PlayerID,
-		PlayerSessionID: playerSession.ID,
-		CharacterName:   selectedChar.Name,
-		LocationID:      locationID,
-		Status:          session.StatusActive,
-		GridPresent:     true,
-		TTLSeconds:      ttlSeconds,
-		MaxHistory:      maxHistory,
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		ID:                sessionID.String(),
+		CharacterID:       charID,
+		PlayerID:          playerSession.PlayerID,
+		PlayerSessionID:   playerSession.ID,
+		CharacterName:     selectedChar.Name,
+		LocationID:        locationID,
+		Status:            session.StatusActive,
+		GridPresent:       true,
+		TTLSeconds:        ttlSeconds,
+		MaxHistory:        maxHistory,
+		LocationArrivedAt: now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
 	}
 
 	if err := s.sessionStore.Set(ctx, sessionID.String(), sessionInfo); err != nil {

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -378,6 +378,102 @@ func TestSelectCharacter_SameTokenTwice(t *testing.T) {
 	assert.True(t, resp2.Reattached)
 }
 
+func TestSelectCharacter_FreshSession_SetsLocationArrivedAt(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	charID := ulid.Make()
+	locID := ulid.Make()
+	sessionID := core.NewULID()
+
+	ps := makePlayerSession(playerID)
+	sessionRepo := setupSessionRepo(t, ps)
+
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{
+			{ID: charID, PlayerID: playerID, Name: "Alice", LocationID: &locID},
+		}, nil)
+
+	sessionStore := session.NewMemStore()
+
+	before := time.Now()
+	server := &CoreServer{
+		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:      sessionStore,
+		playerSessionRepo: sessionRepo,
+		charRepo:          charRepo,
+		newSessionID:      func() ulid.ULID { return sessionID },
+	}
+
+	resp, err := server.SelectCharacter(ctx, &corev1.SelectCharacterRequest{
+		PlayerSessionToken: validToken,
+		CharacterId:        charID.String(),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	assert.False(t, resp.Reattached)
+
+	stored, err := sessionStore.Get(ctx, sessionID.String())
+	require.NoError(t, err)
+	assert.False(t, stored.LocationArrivedAt.IsZero(),
+		"LocationArrivedAt must be set on fresh session create")
+	assert.False(t, stored.LocationArrivedAt.Before(before),
+		"LocationArrivedAt must not be before the test started")
+}
+
+func TestSelectCharacter_Reattach_ResetsLocationArrivedAt(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	charID := ulid.Make()
+	locID := ulid.Make()
+	existingSessionID := core.NewULID().String()
+
+	ps := makePlayerSession(playerID)
+	sessionRepo := setupSessionRepo(t, ps)
+
+	charRepo := authmocks.NewMockCharacterRepository(t)
+	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
+		Return([]*world.Character{
+			{ID: charID, PlayerID: playerID, Name: "Alice", LocationID: &locID},
+		}, nil)
+
+	oldArrival := time.Now().Add(-2 * time.Hour)
+	sessionStore := session.NewMemStore()
+	require.NoError(t, sessionStore.Set(ctx, existingSessionID, &session.Info{
+		ID:                existingSessionID,
+		CharacterID:       charID,
+		CharacterName:     "Alice",
+		LocationID:        locID,
+		Status:            session.StatusDetached,
+		LocationArrivedAt: oldArrival,
+		CreatedAt:         oldArrival,
+		UpdatedAt:         oldArrival,
+	}))
+
+	before := time.Now()
+	server := &CoreServer{
+		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		sessionStore:      sessionStore,
+		playerSessionRepo: sessionRepo,
+		charRepo:          charRepo,
+		newSessionID:      func() ulid.ULID { return core.NewULID() },
+	}
+
+	resp, err := server.SelectCharacter(ctx, &corev1.SelectCharacterRequest{
+		PlayerSessionToken: validToken,
+		CharacterId:        charID.String(),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	assert.True(t, resp.Reattached)
+
+	stored, err := sessionStore.Get(ctx, existingSessionID)
+	require.NoError(t, err)
+	assert.False(t, stored.LocationArrivedAt.Before(before),
+		"LocationArrivedAt must be reset to at least the time of reattach, got %v, before=%v",
+		stored.LocationArrivedAt, before)
+}
+
 // --- CreatePlayer ---
 
 func TestCreatePlayer_Success(t *testing.T) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -775,6 +775,15 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 				With("session_id", req.SessionId).
 				Errorf("session reattach CAS lost — another handler won the race")
 		}
+		now := time.Now()
+		// Use a detached context like RemoveConnection above — this is
+		// best-effort cleanup that must run independent of stream
+		// cancellation if the client disconnects mid-reattach.
+		bumpCtx, bumpCancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		if loErr := s.sessionStore.BumpLocationArrivedAt(bumpCtx, req.SessionId, now); loErr != nil {
+			slog.WarnContext(ctx, "failed to reset LocationArrivedAt on ReattachCAS", "error", loErr)
+		}
+		bumpCancel()
 	}
 
 	// RestoreFocus — produces the full stream list and replay modes.

--- a/internal/grpc/subscribe_server_test.go
+++ b/internal/grpc/subscribe_server_test.go
@@ -372,3 +372,53 @@ func (c *identityCapturingSubscriber) OpenSession(_ context.Context, _ string, i
 }
 
 var _ eventbus.Subscriber = (*identityCapturingSubscriber)(nil)
+
+func TestSubscribeReattachCAS_AdvancesLocationArrivedAt(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour)
+	oldArrival := time.Now().Add(-2 * time.Hour)
+	info := &session.Info{
+		ID:                "s1",
+		ExpiresAt:         &future,
+		Status:            session.StatusDetached,
+		CharacterID:       core.NewULID(),
+		LocationArrivedAt: oldArrival,
+	}
+	bs := newFakeSessionStream()
+	sub := &fakeSubscriber{stream: bs}
+	sessStore := newTestSessionStore(t, map[string]*session.Info{"s1": info})
+	s := &CoreServer{
+		subscriber:        sub,
+		sessionStore:      sessStore,
+		playerSessionRepo: newFakePlayerSessionRepo(ulid.ULID{}),
+	}
+
+	before := time.Now()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := &concurrentSubscribeStream{ctx: ctx}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Subscribe(&corev1.SubscribeRequest{
+			SessionId:          "s1",
+			PlayerSessionToken: testPlayerSessionToken,
+		}, stream)
+	}()
+
+	require.Eventually(t, func() bool {
+		return stream.sentLen() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+	cancel()
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return after ctx cancel")
+	}
+
+	stored, err := sessStore.Get(context.Background(), "s1")
+	require.NoError(t, err)
+	assert.False(t, stored.LocationArrivedAt.Before(before),
+		"LocationArrivedAt must be advanced on ReattachCAS, got %v, before=%v",
+		stored.LocationArrivedAt, before)
+}


### PR DESCRIPTION
Populates `session.Info.LocationArrivedAt` at all session-create/reattach paths
so the I-PRIV-1 per-session location floor is set correctly:

- **SelectCharacter fresh branch** — sets `LocationArrivedAt: now` on the new
  `session.Info` struct literal at creation time.
- **SelectCharacter reattach branch** — calls `BumpLocationArrivedAt(sessionID, now)`
  after `UpdateStatus(active)` and mirrors the value into the in-memory `Info`.
- **Subscribe.ReattachCAS** — calls `BumpLocationArrivedAt(sessionID, now)` after
  the successful CAS win.

Both reattach paths use `BumpLocationArrivedAt` (single-session, status-agnostic)
rather than `UpdateLocationOnMove` to avoid the SQL `WHERE status = 'active'`
race against the just-issued `UpdateStatus(active)`.

3 new tests in `internal/grpc/`:
- `TestSelectCharacter_FreshSession_SetsLocationArrivedAt`
- `TestSelectCharacter_Reattach_ResetsLocationArrivedAt`
- `TestSubscribeReattachCAS_AdvancesLocationArrivedAt`

All 287 tests in the `grpc` package pass; lint clean.

Bead: holomush-iwzt.3
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1, I-PRIV-3)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timestamp handling when selecting characters and reattaching disconnected sessions; arrival timestamps are now reset/updated reliably during new session creation and reattachment flows.

* **Tests**
  * Added tests validating that session arrival timestamps advance correctly on fresh sessions and when reattaching, ensuring consistent timestamp behavior across flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->