### PR TITLE
feat(world): MovementHook interface + character-move session-sync (iwzt.4)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -50,6 +50,7 @@ import (
 	"github.com/holomush/holomush/internal/settings"
 	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/internal/telnet"
+	"github.com/holomush/holomush/internal/world"
 	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
 	worldsetup "github.com/holomush/holomush/internal/world/setup"
 	contentv1 "github.com/holomush/holomush/pkg/proto/holomush/content/v1"
@@ -177,6 +178,12 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	authPlayerRepo := s.cfg.Auth.PlayerRepo()
 	authPlayerSessionRepo := s.cfg.Auth.PlayerSessionStore()
 	sessionStore := s.cfg.Sessions.Store()
+
+	// Wire session store as the movement hook so character moves propagate
+	// LocationID + LocationArrivedAt to active sessions before the move event
+	// is emitted (ADR holomush-kmac; I-PRIV-1 Tier 1).
+	worldService.SetMovementHook(&sessionStoreMovementHook{sessions: sessionStore})
+
 	startLocationID := s.cfg.Bootstrap.StartLocationID()
 	pluginManager := s.cfg.Plugins.Manager()
 	cmdRegistry := s.cfg.Plugins.CommandRegistry()
@@ -616,6 +623,20 @@ func coreActorKindToBus(k core.ActorKind) eventbus.ActorKind {
 		return eventbus.ActorKindUnknown
 	}
 }
+
+// sessionStoreMovementHook implements world.MovementHook by delegating to
+// session.Store.UpdateLocationOnMove. Wired at gRPC subsystem startup so
+// character moves propagate LocationID + LocationArrivedAt to active sessions
+// before the move event is emitted (ADR holomush-kmac; I-PRIV-1 Tier 1).
+type sessionStoreMovementHook struct {
+	sessions session.Store
+}
+
+func (h *sessionStoreMovementHook) OnCharacterMoved(ctx context.Context, characterID, newLocationID ulid.ULID, arrivedAt time.Time) error {
+	return h.sessions.UpdateLocationOnMove(ctx, characterID, newLocationID, arrivedAt)
+}
+
+var _ world.MovementHook = (*sessionStoreMovementHook)(nil)
 
 // busHistoryReaderAdapter bridges eventbus.HistoryReader (QueryHistory) to
 // plugins.HistoryReader (ReplayTail). Used by the plugin subsystem for

--- a/internal/world/movement_hook.go
+++ b/internal/world/movement_hook.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package world
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// MovementHook is invoked by Service.MoveCharacter after the character row
+// is updated but before the move event is emitted. Implementations propagate
+// the new location to dependent stores (e.g., session.Store.UpdateLocationOnMove)
+// so consumers reading those stores observe the new location atomically with
+// the move event.
+//
+// Per holomush-iwzt §5.1 / ADR holomush-kmac.
+//
+// Returning an error from the hook fails the move — caller MUST handle.
+type MovementHook interface {
+	OnCharacterMoved(ctx context.Context, characterID ulid.ULID, newLocationID ulid.ULID, arrivedAt time.Time) error
+}
+
+// NoopMovementHook is the default when no hook is wired (e.g., test contexts).
+type NoopMovementHook struct{}
+
+// OnCharacterMoved is a no-op implementation of MovementHook.OnCharacterMoved.
+func (NoopMovementHook) OnCharacterMoved(_ context.Context, _, _ ulid.ULID, _ time.Time) error {
+	return nil
+}

--- a/internal/world/movement_hook_test.go
+++ b/internal/world/movement_hook_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package world_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/holomush/holomush/internal/world/worldtest"
+)
+
+// movementHookFn adapts a plain function to the world.MovementHook interface.
+type movementHookFn func(ctx context.Context, charID, locID ulid.ULID, ts time.Time) error
+
+func (f movementHookFn) OnCharacterMoved(ctx context.Context, charID, locID ulid.ULID, ts time.Time) error {
+	return f(ctx, charID, locID, ts)
+}
+
+// testMoveHookFixture holds all test dependencies for MovementHook tests.
+type testMoveHookFixture struct {
+	svc      *world.Service
+	engine   *policytest.GrantEngine
+	charRepo *worldtest.MockCharacterRepository
+	locRepo  *worldtest.MockLocationRepository
+}
+
+// newTestServiceWithHook builds a world.Service with mock repos, a GrantEngine,
+// and installs the given MovementHook.
+func newTestServiceWithHook(t *testing.T, hook world.MovementHook) testMoveHookFixture {
+	t.Helper()
+	engine := policytest.NewGrantEngine()
+	charRepo := worldtest.NewMockCharacterRepository(t)
+	locRepo := worldtest.NewMockLocationRepository(t)
+	emitter := &mockEventEmitter{}
+	svc := world.NewService(world.ServiceConfig{
+		CharacterRepo: charRepo,
+		LocationRepo:  locRepo,
+		Engine:        engine,
+		EventEmitter:  emitter,
+	})
+	svc.SetMovementHook(hook)
+	return testMoveHookFixture{svc: svc, engine: engine, charRepo: charRepo, locRepo: locRepo}
+}
+
+// seedCharacterAndTwoLocations sets up mock expectations for a complete MoveCharacter
+// call: a character at fromLoc and a destination toLoc. Returns the IDs.
+// The caller must pass subjectID so access can be granted.
+func seedCharacterAndTwoLocations(
+	t *testing.T,
+	fix testMoveHookFixture,
+	subjectID string,
+) (charID, fromLocID, toLocID ulid.ULID) {
+	t.Helper()
+	charID = ulid.Make()
+	fromLocID = ulid.Make()
+	toLocID = ulid.Make()
+
+	fix.engine.Grant(subjectID, "write", "character:"+charID.String())
+
+	existingChar := &world.Character{
+		ID:         charID,
+		Name:       "Hook Test Character",
+		LocationID: &fromLocID,
+	}
+
+	fix.charRepo.EXPECT().Get(context.Background(), charID).Return(existingChar, nil)
+	fix.locRepo.EXPECT().Get(context.Background(), toLocID).Return(&world.Location{ID: toLocID}, nil)
+	fix.charRepo.EXPECT().UpdateLocation(context.Background(), charID, &toLocID).Return(nil)
+
+	return charID, fromLocID, toLocID
+}
+
+func TestMoveCharacter_FiresMovementHook(t *testing.T) {
+	ctx := context.Background()
+	subjectID := access.CharacterSubject(ulid.Make().String())
+
+	var captured struct {
+		charID, locID ulid.ULID
+		ts            time.Time
+	}
+	var hookFired bool
+	hook := movementHookFn(func(_ context.Context, charID, locID ulid.ULID, ts time.Time) error {
+		hookFired = true
+		captured.charID, captured.locID, captured.ts = charID, locID, ts
+		return nil
+	})
+
+	fix := newTestServiceWithHook(t, hook)
+	charID, _, toLocID := seedCharacterAndTwoLocations(t, fix, subjectID)
+
+	require.NoError(t, fix.svc.MoveCharacter(ctx, subjectID, charID, toLocID))
+
+	require.True(t, hookFired)
+	assert.Equal(t, charID, captured.charID)
+	assert.Equal(t, toLocID, captured.locID)
+	assert.WithinDuration(t, time.Now(), captured.ts, 5*time.Second)
+}

--- a/internal/world/service.go
+++ b/internal/world/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
@@ -51,6 +52,7 @@ type Service struct {
 	engine        types.AccessPolicyEngine
 	eventEmitter  EventEmitter
 	transactor    Transactor
+	movementHook  MovementHook
 }
 
 // NewService creates a new Service with the given configuration.
@@ -75,7 +77,19 @@ func NewService(cfg ServiceConfig) *Service {
 		engine:        cfg.Engine,
 		eventEmitter:  cfg.EventEmitter,
 		transactor:    cfg.Transactor,
+		movementHook:  NoopMovementHook{},
 	}
+}
+
+// SetMovementHook registers a hook that is invoked after each successful
+// character location update and before the move event is emitted.
+// Passing nil resets to the no-op default.
+func (s *Service) SetMovementHook(h MovementHook) {
+	if h == nil {
+		s.movementHook = NoopMovementHook{}
+		return
+	}
+	s.movementHook = h
 }
 
 // entityPrefix is a typed string for checkAccess error code prefixes.
@@ -788,6 +802,21 @@ func (s *Service) MoveCharacter(ctx context.Context, subjectID string, character
 	// Update character location
 	if err := s.characterRepo.UpdateLocation(ctx, characterID, &toLocationID); err != nil {
 		return oops.Code("CHARACTER_MOVE_FAILED").Wrapf(err, "update character %s location", characterID)
+	}
+
+	// Fire movement hook — propagates new location to dependent stores (e.g. session store)
+	// before the move event is emitted so consumers see a consistent view.
+	arrivedAt := time.Now().UTC()
+	if hookErr := s.movementHook.OnCharacterMoved(ctx, characterID, toLocationID, arrivedAt); hookErr != nil {
+		// move_succeeded=true: the character row was already committed (line
+		// 803 above). Callers MUST NOT retry the move as if it were atomic
+		// with the hook; this attribute lets them distinguish the partial-
+		// failure case from a pre-DB-commit failure.
+		return oops.Code("CHARACTER_MOVE_FAILED").
+			With("character_id", characterID.String()).
+			With("phase", "movement_hook").
+			With("move_succeeded", true).
+			Wrap(hookErr)
 	}
 
 	// Build move payload


### PR DESCRIPTION
Adds `world.MovementHook` interface fired by `Service.MoveCharacter` after the
character row update and before the move event is emitted. Default is
`NoopMovementHook{}`.

Wires `sessionStoreMovementHook` at server startup so character moves
propagate to `session.Store.UpdateLocationOnMove`, keeping `sessions.location_id`
in sync with `characters.location_id`.

Per ADR kmac: avoids a `world → session` import cycle by inverting the
dependency through an interface owned by `world` and implemented by
core-server (`cmd/holomush/sub_grpc.go`).

`TestMoveCharacter_FiresMovementHook` exercises the hook firing path with a
test-local `movementHookFn` adapter; all 1286 tests across the affected
packages pass; lint clean.

Bead: holomush-iwzt.4
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1 Tier 1)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 4
ADR:  docs/adr/holomush-kmac-movement-hook.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pluggable movement hooks to run during character moves, enabling custom handling at move time.

* **Chores**
  * Improved session location state updates so active sessions reflect character moves more reliably.

* **Tests**
  * Added tests to verify movement hook invocation and session location synchronization during moves.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->