### PR TITLE
refactor(eventbus): OpenSession + SetFilters use NATS-source-of-truth builder (iwzt.13)

### DIFF
--- a/internal/eventbus/subscriber.go
+++ b/internal/eventbus/subscriber.go
@@ -174,16 +174,22 @@ func (s *JetStreamSubscriber) OpenSession(ctx context.Context, sessionID string,
 			With("session_id", sessionID).
 			Errorf("at least one subject filter required")
 	}
-	cfg := jetstream.ConsumerConfig{
-		Durable:           name,
-		Name:              name,
-		FilterSubjects:    subjects,
-		AckPolicy:         jetstream.AckExplicitPolicy,
-		AckWait:           s.ackWait,
-		MaxAckPending:     s.maxAckPending,
-		InactiveThreshold: s.inactiveThreshold,
-		DeliverPolicy:     jetstream.DeliverAllPolicy,
+	// Compute minFloor across subjects — Phase 3 wires this from session info.
+	// For now (this task only), pass time.Time{} so first-create gets
+	// DeliverAllPolicy, preserving existing behavior. iwzt.14 (Task 13)
+	// replaces the zero value with the real minFloor computation.
+	minFloor := time.Time{}
+
+	cfg, err := buildConsumerConfig(ctx, jsConsumerLookupAdapter{js: s.js}, StreamName, name, subjects, minFloor)
+	if err != nil {
+		return nil, err
 	}
+	// Augment cfg with the non-start-policy defaults that OpenSession owns.
+	cfg.AckPolicy = jetstream.AckExplicitPolicy
+	cfg.AckWait = s.ackWait
+	cfg.MaxAckPending = s.maxAckPending
+	cfg.InactiveThreshold = s.inactiveThreshold
+
 	cons, err := s.js.CreateOrUpdateConsumer(ctx, StreamName, cfg)
 	if err != nil {
 		return nil, oops.Code("EVENTBUS_SESSION_CONSUMER_FAILED").
@@ -345,17 +351,24 @@ func (j *jetStreamSessionStream) SetFilters(ctx context.Context, filters []Subje
 			With("session_id", j.sessionID).
 			Errorf("at least one subject filter required")
 	}
-	cfg := jetstream.ConsumerConfig{
-		Durable:           j.consumerName,
-		Name:              j.consumerName,
-		FilterSubjects:    subjects,
-		AckPolicy:         jetstream.AckExplicitPolicy,
-		AckWait:           j.ackWait,
-		MaxAckPending:     j.maxPending,
-		InactiveThreshold: j.inactiveTTL,
-		DeliverPolicy:     jetstream.DeliverAllPolicy,
+	// SetFilters is called on an existing durable — the builder's
+	// existing-consumer branch preserves DeliverPolicy/OptStartTime/OptStartSeq
+	// from the live consumer, so the cursor is not reset on filter rotation.
+	// minFloor is unused here (the consumer already exists); pass zero.
+	cfg, err := buildConsumerConfig(ctx, jsConsumerLookupAdapter{js: j.js}, StreamName, j.consumerName, subjects, time.Time{})
+	if err != nil {
+		return oops.Code("EVENTBUS_SESSION_SETFILTERS_FAILED").
+			With("session_id", j.sessionID).
+			With("consumer", j.consumerName).
+			Wrap(err)
 	}
-	_, err := j.js.CreateOrUpdateConsumer(ctx, StreamName, cfg)
+	// Augment cfg with the non-start-policy defaults that SetFilters owns.
+	cfg.AckPolicy = jetstream.AckExplicitPolicy
+	cfg.AckWait = j.ackWait
+	cfg.MaxAckPending = j.maxPending
+	cfg.InactiveThreshold = j.inactiveTTL
+
+	_, err = j.js.CreateOrUpdateConsumer(ctx, StreamName, cfg)
 	if err != nil {
 		return oops.Code("EVENTBUS_SESSION_SETFILTERS_FAILED").
 			With("session_id", j.sessionID).

--- a/internal/eventbus/subscriber_consumer_config.go
+++ b/internal/eventbus/subscriber_consumer_config.go
@@ -32,12 +32,9 @@ type consumerLookup interface {
 
 // jsConsumerLookupAdapter wraps a jetstream.JetStream so it satisfies the
 // narrow consumerLookup interface buildConsumerConfig consumes. Wired into
-// OpenSession and SetFilters by Task 12 (holomush-iwzt.13).
-//
-//nolint:unused // production adapter; wired in Task 12 (holomush-iwzt.13)
+// OpenSession and SetFilters by Task 13 (holomush-iwzt.13).
 type jsConsumerLookupAdapter struct{ js jetstream.JetStream }
 
-//nolint:unused // production adapter; wired in Task 12 (holomush-iwzt.13)
 func (a jsConsumerLookupAdapter) LookupConsumer(ctx context.Context, stream, name string) (consumerInfo, error) {
 	c, err := a.js.Consumer(ctx, stream, name)
 	if err != nil {
@@ -63,7 +60,6 @@ func (a jsConsumerLookupAdapter) LookupConsumer(ctx context.Context, stream, nam
 //
 //  3. Any other error: fails closed with EVENTBUS_CONSUMER_LOOKUP_FAILED.
 //     Callers MUST NOT call CreateOrUpdateConsumer when this error is returned.
-//nolint:unparam // streamName is always "STREAM" in unit tests but carries real stream names in production (Task 12 call sites)
 func buildConsumerConfig(
 	ctx context.Context, js consumerLookup,
 	streamName, consumerName string,


### PR DESCRIPTION
Replaces inline `jetstream.ConsumerConfig` construction in `OpenSession` and
`SetFilters` with calls to `buildConsumerConfig` (added in iwzt.12 / PR #4038
landed). The builder encodes the I-PRIV-8 NATS-source-of-truth pattern:

- Existing consumer: copy `DeliverPolicy` / `OptStartTime` / `OptStartSeq` verbatim
- `ErrConsumerNotFound`: compute from `minFloor` (or `DeliverAllPolicy` if zero)
- Other lookup errors: fail closed with `EVENTBUS_CONSUMER_LOOKUP_FAILED`

`minFloor` stays `time.Time{}` for this task — iwzt.14 wires the real
per-subject min-floor computation from session info.

Also drops `//nolint:unused` and `//nolint:unparam` directives in
`subscriber_consumer_config.go` that no longer fire now that the builder
and adapter are called from production.

All 772 tests in the `internal/eventbus/` tree pass; lint clean.

Bead: holomush-iwzt.13
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-8, §6.2)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal event bus subscriber configuration handling has been reorganized for improved code consistency.

---

**Note:** This release includes internal improvements with no user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->