### PR TITLE
test(privacy): I-PRIV-7 placeholder skip (iwzt.23)

### DIFF
--- a/test/integration/privacy/privacy_suite_test.go
+++ b/test/integration/privacy/privacy_suite_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package privacy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+func TestPrivacy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "iwzt history-scope privacy")
+}

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package privacy_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+)
+
+// I-PRIV-7 placeholder: no plugin currently declares history_scope: custom.
+// The full scenario will exercise a plugin whose history_scope semantics
+// diverge from grid/scene; until that plugin lands, the test is skipped
+// to record the invariant requirement explicitly. Replace Skip with the
+// real assertion when a custom-scope plugin adopts the field.
+var _ = Describe("I-PRIV-7: plugin-owned history_scope semantics", func() {
+	It("exercises a plugin that declared custom history_scope (placeholder)", func() {
+		Skip("no plugin currently declares history_scope: custom — re-enable when a plugin adopts this field")
+	})
+})


### PR DESCRIPTION
Adds `test/integration/privacy/` with a Ginkgo suite scaffold and a single Skip
placeholder for the I-PRIV-7 plugin-owned `history_scope` semantics test.

No plugin currently declares `history_scope: custom`, so the full scenario
can't be exercised yet. The placeholder records the invariant requirement
explicitly; replace the `Skip` with the real assertion when a custom-scope
plugin adopts the field.

All 1584 integration tests pass (the new spec is Skipped); lint clean.

Bead: holomush-iwzt.23
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-7)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for privacy and history_scope functionality validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->