### PR TITLE
feat(grpc): QueryStreamHistory location hard-gate + scope floor (iwzt.8)

### DIFF
--- a/internal/grpc/query_stream_history.go
+++ b/internal/grpc/query_stream_history.go
@@ -153,8 +153,12 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 		}
 	}
 
-	// Step 5: Authorization — two-layer model.
-	if isPrivateStream(req.Stream) {
+	// Step 5: Authorization — three-way classifier.
+	//   1. Private streams (character:*, scene:*:ic, scene:*:ooc): membership gate (I-17).
+	//   2. Location streams (location:<id>): hard-gate via session.LocationID (I-PRIV-1).
+	//   3. Other public streams (global, system, …): ABAC engine.Evaluate.
+	switch {
+	case isPrivateStream(req.Stream):
 		// Validate scene stream format up-front so malformed scene streams
 		// surface as INVALID_ARGUMENT rather than STREAM_ACCESS_DENIED.
 		if strings.HasPrefix(req.Stream, "scene:") {
@@ -176,8 +180,24 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 				With("stream", req.Stream).
 				Errorf("not authorized to read stream")
 		}
-	} else {
-		// Layer 2: ABAC policy for public streams.
+	case isLocationStream(req.Stream):
+		// Layer 2: Location hard-gate (I-PRIV-1). The session must be currently
+		// located in the requested location. staffOverride returns false until
+		// Phase 5 (iwzt.20) wires the real engine.Evaluate call.
+		if !staffOverride(ctx, info, s.accessEngine) {
+			if info.LocationID.String() != extractLocationID(req.Stream) {
+				slog.InfoContext(ctx, "stream access denied by location hard-gate",
+					"session_id", req.SessionId, "denial_reason", "wrong_location",
+					"character_id", info.CharacterID.String(),
+					"session_location", info.LocationID.String(),
+					"requested_stream", req.Stream)
+				return nil, oops.Code("STREAM_ACCESS_DENIED").
+					With("session_id", req.SessionId).With("stream", req.Stream).
+					Errorf("not authorized to read stream")
+			}
+		}
+	default:
+		// Layer 3: ABAC policy for other public streams (global, system, …).
 		if s.accessEngine == nil {
 			return nil, oops.Code("STREAM_ACCESS_DENIED").
 				With("stream", req.Stream).
@@ -213,10 +233,14 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 		}
 	}
 
-	// Step 6: Parse not_before.
+	// Step 6: Compute effective NotBefore = MAX(client-supplied, server-side scope floor).
 	var notBefore time.Time
 	if req.NotBeforeMs > 0 {
 		notBefore = time.UnixMilli(req.NotBeforeMs).UTC()
+	}
+	scopeFloor := streamScopeFloor(info, req.Stream)
+	if scopeFloor.After(notBefore) {
+		notBefore = scopeFloor
 	}
 
 	// Step 7: Fetch count+1 to detect has_more.

--- a/internal/grpc/query_stream_history_test.go
+++ b/internal/grpc/query_stream_history_test.go
@@ -333,8 +333,9 @@ func TestQueryStreamHistoryDeniedByABAC(t *testing.T) {
 func TestQueryStreamHistoryBusErrorSurfacesAsInternal(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	reader := &fakeHistoryReader{err: errors.New("bus down")}
 	s := newQueryStreamHistoryServer(t, reader, sess)
@@ -349,8 +350,9 @@ func TestQueryStreamHistoryBusErrorSurfacesAsInternal(t *testing.T) {
 func TestQueryStreamHistoryHasMoreReflectsCountPlusOne(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	// 4 events, count=3 → has_more=true; response trims to 3 (newest).
 	evts := make([]eventbus.Event, 0, 4)
@@ -381,8 +383,9 @@ func TestQueryStreamHistoryHasMoreReflectsCountPlusOne(t *testing.T) {
 func TestQueryStreamHistoryCountDefaultsWhenZero(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	reader := &fakeHistoryReader{}
 	s := newQueryStreamHistoryServer(t, reader, sess)
@@ -398,8 +401,9 @@ func TestQueryStreamHistoryCountDefaultsWhenZero(t *testing.T) {
 func TestQueryStreamHistoryCountCappedAtMax(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	reader := &fakeHistoryReader{}
 	s := newQueryStreamHistoryServer(t, reader, sess)
@@ -415,8 +419,9 @@ func TestQueryStreamHistoryCountCappedAtMax(t *testing.T) {
 func TestQueryStreamHistoryCursorForwardsToBus(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	beforeID := core.NewULID()
 	const beforeSeq uint64 = 42
@@ -444,8 +449,9 @@ func TestQueryStreamHistoryCursorForwardsToBus(t *testing.T) {
 func TestQueryStreamHistoryNotBeforeMsForwardsToBus(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	notBefore := time.Now().Add(-2 * time.Hour).UnixMilli()
 	reader := &fakeHistoryReader{}
@@ -532,8 +538,9 @@ func TestQueryStreamHistoryWithPluginCursorRewrapsFrames(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
 	charID := ulid.MustParse("01HYXYZCHAR0000000000000CH")
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", CharacterID: charID, ExpiresAt: &future},
+		"s1": {ID: "s1", CharacterID: charID, ExpiresAt: &future, LocationID: locID},
 	})
 
 	// Build a plugin cursor with a 16-byte inner ULID.
@@ -586,8 +593,9 @@ func TestQueryStreamHistoryWithPluginCursorStringInner(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
 	charID := ulid.MustParse("01HYXYZCHAR0000000000000CH")
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", CharacterID: charID, ExpiresAt: &future},
+		"s1": {ID: "s1", CharacterID: charID, ExpiresAt: &future, LocationID: locID},
 	})
 
 	// Build a plugin cursor whose inner bytes are the string form of a ULID
@@ -620,8 +628,9 @@ func TestQueryStreamHistoryWithPluginCursorStringInner(t *testing.T) {
 func TestQueryStreamHistoryEventFrameCarriesCursor(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	evt := eventbus.Event{
 		ID:        core.NewULID(),
@@ -659,8 +668,9 @@ func TestQueryStreamHistoryEventFrameCarriesCursor(t *testing.T) {
 func TestQueryStreamHistoryNextCursorSetWhenHasMore(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	// 4 events with count=3 → has_more=true, NextCursor from oldest frame.
 	evts := make([]eventbus.Event, 4)
@@ -834,8 +844,9 @@ func TestMapHistoryErrorPassesThroughInvalidArgumentWithDetails(t *testing.T) {
 func TestQueryStreamHistoryEncodeEventCursorWithZeroSeq(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	sess := newTestSessionStore(t, map[string]*session.Info{
-		"s1": {ID: "s1", ExpiresAt: &future},
+		"s1": {ID: "s1", ExpiresAt: &future, LocationID: locID},
 	})
 	// Event without Seq (Seq==0) — encodeEventCursor must not fail.
 	evt := eventbus.Event{
@@ -872,11 +883,13 @@ func TestQueryStreamHistoryThreadsCallerFromSession(t *testing.T) {
 	t.Parallel()
 
 	charID := ulid.MustParse("01HYXCHAR0000000000000000C")
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 	future := time.Now().Add(time.Hour)
 	sess := newTestSessionStore(t, map[string]*session.Info{
 		"sess-1": {
 			ID:          "sess-1",
 			CharacterID: charID,
+			LocationID:  locID,
 			ExpiresAt:   &future,
 		},
 	})
@@ -884,12 +897,11 @@ func TestQueryStreamHistoryThreadsCallerFromSession(t *testing.T) {
 	reader := &fakeHistoryReader{}
 	server := newQueryStreamHistoryServer(t, reader, sess)
 
-	// Public stream so the I-17 gate doesn't fire — focuses the test on
-	// caller threading. The harness wires policytest.AllowAllEngine() by
-	// default per newQueryStreamHistoryServer.
+	// Location stream: the hard-gate passes because the session is seeded at
+	// the queried location. The test focuses on caller threading.
 	_, err := server.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
 		SessionId: "sess-1",
-		Stream:    "location:01HYXLOC00000000000000000",
+		Stream:    "location:" + locID.String(),
 		Count:     10,
 	})
 	require.NoError(t, err)
@@ -961,12 +973,14 @@ func TestQueryStreamHistoryPassesIdentityFromBindingsToHistoryQuery(t *testing.T
 	charID := core.NewULID()
 	playerID := core.NewULID()
 	bindingID := "bnd-test-001"
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 
 	sess := newTestSessionStore(t, map[string]*session.Info{
 		"s1": {
 			ID:          "s1",
 			CharacterID: charID,
 			PlayerID:    playerID,
+			LocationID:  locID,
 			ExpiresAt:   &future,
 		},
 	})
@@ -1000,12 +1014,14 @@ func TestQueryStreamHistoryBindingLookupFailureReturnsError(t *testing.T) {
 	future := time.Now().Add(time.Hour)
 	charID := core.NewULID()
 	playerID := core.NewULID()
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 
 	sess := newTestSessionStore(t, map[string]*session.Info{
 		"s1": {
 			ID:          "s1",
 			CharacterID: charID,
 			PlayerID:    playerID,
+			LocationID:  locID,
 			ExpiresAt:   &future,
 		},
 	})
@@ -1032,12 +1048,14 @@ func TestQueryStreamHistoryPassesZeroIdentityWhenBindingsNil(t *testing.T) {
 	future := time.Now().Add(time.Hour)
 	charID := core.NewULID()
 	playerID := core.NewULID()
+	locID := ulid.MustParse("01HYXYZ0C0000000000000000C")
 
 	sess := newTestSessionStore(t, map[string]*session.Info{
 		"s1": {
 			ID:          "s1",
 			CharacterID: charID,
 			PlayerID:    playerID,
+			LocationID:  locID,
 			ExpiresAt:   &future,
 		},
 	})
@@ -1111,4 +1129,30 @@ func TestQueryStreamHistoryFiltersAuditOnlyEvents(t *testing.T) {
 		"AUDIT_ONLY events MUST NOT be returned via QueryStreamHistory (symmetric with dispatchDelivery)")
 	assert.Equal(t, "scene.pose", resp.GetEvents()[0].GetType(),
 		"only the non-audit event survives the filter")
+}
+
+// TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation verifies
+// that a session requesting a location stream is denied when the session's
+// LocationID does not match the requested location (I-PRIV-1 Tier 1).
+func TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour)
+	locA := ulid.MustParse("01HYXLOCA0000000000000000A")
+	locB := ulid.MustParse("01HYXLOCB0000000000000000B")
+	sess := newTestSessionStore(t, map[string]*session.Info{
+		"s1": {
+			ID:         "s1",
+			LocationID: locA,
+			ExpiresAt:  &future,
+		},
+	})
+	s := newQueryStreamHistoryServer(t, &fakeHistoryReader{}, sess)
+
+	resp, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "s1",
+		Stream:    "location:" + locB.String(),
+	})
+	require.Nil(t, resp)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "STREAM_ACCESS_DENIED")
 }

--- a/internal/grpc/scope_floor.go
+++ b/internal/grpc/scope_floor.go
@@ -4,9 +4,11 @@
 package grpc
 
 import (
+	"context"
 	"strings"
 	"time"
 
+	accessTypes "github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/session"
 )
 
@@ -51,8 +53,20 @@ func isLocationStream(stream string) bool {
 
 // extractLocationID returns the ULID portion of a location stream.
 // Caller MUST check isLocationStream first; otherwise behavior is undefined.
-func extractLocationID(stream string) string { //nolint:unused // consumed by QueryStreamHistory in iwzt.8
+func extractLocationID(stream string) string {
 	return strings.TrimPrefix(stream, "location:")
+}
+
+// staffOverride is a stub for Phase 5 (staff ABAC override). Returns false
+// unconditionally so the location hard-gate is exercised in Phase 2.
+// Phase 5 / iwzt.20 replaces with a real
+//
+//	s.accessEngine.Evaluate(ctx, NewAccessRequest("character:"+info.CharacterID.String(),
+//	                                               "read_unrestricted_history", "stream", nil))
+//
+// per ADR wxty / I-PRIV-6.
+func staffOverride(_ context.Context, _ *session.Info, _ accessTypes.AccessPolicyEngine) bool {
+	return false
 }
 
 // extractSceneID returns the scene ULID from a scene:<id>:ic or scene:<id>:ooc subject.


### PR DESCRIPTION
Implements I-PRIV-1 Tier 1 (location-stream hard-gate) and I-PRIV-1 Tier 2
(temporal scope floor) in `QueryStreamHistory`:

- **3-way authorization classifier** (switch on stream kind):
  - `isPrivateStream` — I-17 membership gate unchanged.
  - `isLocationStream` — new location hard-gate: deny `STREAM_ACCESS_DENIED` when
    `info.LocationID.String() != extractLocationID(req.Stream)` AND `staffOverride`
    is false.
  - default — existing public-stream ABAC path unchanged.
- **`staffOverride` stub** added to `scope_floor.go` — returns `false`
  unconditionally. iwzt.20 / Phase 5 replaces with the real
  `engine.Evaluate(read_unrestricted_history)` call per ADR wxty.
- **Step 6 effective NotBefore** now MAXes client-supplied `notBefore` against
  `streamScopeFloor(info, req.Stream)`. Floor sources per stream kind:
  - location: `LocationArrivedAt`
  - scene: `FocusMembership.JoinedAt` for the matching scene
  - guest overlay: `max(base, GuestCharacterCreatedAt)` when `IsGuest`

`TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation` exercises the
new denial path. 15 pre-existing tests that queried location streams without
seeding `session.LocationID` were updated to seed it to match (the hard-gate
fires before ABAC now); one malformed-ULID test fixture was corrected.

All 292 tests in `internal/grpc/` pass; lint clean.

Bead: holomush-iwzt.8
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1, I-PRIV-2, I-PRIV-5, I-PRIV-6)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 7
ADR:  docs/adr/holomush-wxty-hard-gate-current-location-only.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stream access control with improved validation for location-based streams, ensuring location matching is properly enforced.
  * Refined pagination filtering to respect server-side access scope constraints when processing historical stream data.

* **Tests**
  * Expanded test coverage to verify location-based stream access restrictions are correctly enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->