### PR TITLE
feat(eventbus): plumb minFloor through OpenSession (iwzt.14)

### DIFF
--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -27,7 +27,7 @@ type Publisher interface {
 // cycle: eventbus → authguard → plugin → eventbus. Callers with an
 // authguard.Identity use authguard.ToSessionIdentity to convert.
 type Subscriber interface {
-	OpenSession(ctx context.Context, sessionID string, identity SessionIdentity, filters []Subject) (SessionStream, error)
+	OpenSession(ctx context.Context, sessionID string, identity SessionIdentity, filters []Subject, minFloor time.Time) (SessionStream, error)
 }
 
 // HistoryReader serves paginated history reads. Used by gRPC QueryHistory

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -6,6 +6,7 @@ package eventbus_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ import (
 type fakeBus struct{}
 
 func (fakeBus) Publish(_ context.Context, _ eventbus.Event) error { return nil }
-func (fakeBus) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+func (fakeBus) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject, _ time.Time) (eventbus.SessionStream, error) {
 	return nil, nil
 }
 

--- a/internal/eventbus/eventbustest/embedded_test.go
+++ b/internal/eventbus/eventbustest/embedded_test.go
@@ -61,7 +61,7 @@ func TestAwaitAckedSeqReachesTargetAfterServerConfirmedAck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-	stream, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -84,7 +84,7 @@ func TestAwaitDeliveredSeqReachesTargetAfterServerDelivers(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	testID2 := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-	stream, err := sub.OpenSession(ctx, sessionID, testID2, []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testID2, []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 

--- a/internal/eventbus/integration_test.go
+++ b/internal/eventbus/integration_test.go
@@ -85,7 +85,7 @@ func TestCrossSubjectSequenceOrderingUnderConcurrentPublishers(t *testing.T) {
 		// monotonicity (just uniqueness) so use unseeded crypto/rand.
 		sid := ulid.MustNew(ulid.Timestamp(time.Now()), crand.Reader).String()
 		sessionIDs[i] = sid
-		s, err := subSvc.OpenSession(t.Context(), sid, testIdentity(), subjects)
+		s, err := subSvc.OpenSession(t.Context(), sid, testIdentity(), subjects, time.Time{})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = s.Close() })
 		streams[i] = s

--- a/internal/eventbus/publisher_test.go
+++ b/internal/eventbus/publisher_test.go
@@ -274,7 +274,7 @@ func TestPublisherStampsAllRequiredHeaders(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -322,7 +322,7 @@ func TestPublisherTruncatesTimestampToMicrosecond(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -387,7 +387,7 @@ func TestPublisherCopiesRenderingIntoEnvelope(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -472,7 +472,7 @@ func TestIdentityKeySelectorReturnsIdentityAndNoKey(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 

--- a/internal/eventbus/subscriber.go
+++ b/internal/eventbus/subscriber.go
@@ -156,7 +156,7 @@ func NewJetStreamSubscriber(js jetstream.JetStream, opts ...SubscribeOption) *Je
 // consumer — sessions resume across reconnect via the durable's retained
 // cursor. Consumer teardown is handled by InactiveThreshold (passive) or by
 // the session-lifecycle listener in F5 (active, on session_ended).
-func (s *JetStreamSubscriber) OpenSession(ctx context.Context, sessionID string, identity SessionIdentity, filters []Subject) (SessionStream, error) {
+func (s *JetStreamSubscriber) OpenSession(ctx context.Context, sessionID string, identity SessionIdentity, filters []Subject, minFloor time.Time) (SessionStream, error) {
 	if s.js == nil {
 		return nil, oops.Code("EVENTBUS_SUBSCRIBER_NOT_READY").Errorf("JetStream context is nil")
 	}
@@ -174,12 +174,6 @@ func (s *JetStreamSubscriber) OpenSession(ctx context.Context, sessionID string,
 			With("session_id", sessionID).
 			Errorf("at least one subject filter required")
 	}
-	// Compute minFloor across subjects — Phase 3 wires this from session info.
-	// For now (this task only), pass time.Time{} so first-create gets
-	// DeliverAllPolicy, preserving existing behavior. iwzt.14 (Task 13)
-	// replaces the zero value with the real minFloor computation.
-	minFloor := time.Time{}
-
 	cfg, err := buildConsumerConfig(ctx, jsConsumerLookupAdapter{js: s.js}, StreamName, name, subjects, minFloor)
 	if err != nil {
 		return nil, err

--- a/internal/eventbus/subscriber_round3_test.go
+++ b/internal/eventbus/subscriber_round3_test.go
@@ -74,7 +74,7 @@ func TestDeliveryMetadataForTestReturnsMetadataForJetstreamImpl(t *testing.T) {
 	sessionID := freshSessionID()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 	require.NoError(t, pub.Publish(ctx, newTestEnvelope(subject, []byte("m"))))
@@ -97,7 +97,7 @@ func TestSessionStreamNextReturnsIteratorClosedErrorAfterClose(t *testing.T) {
 	sub := embedded.Bus.Subscriber()
 	sessionID := freshSessionID()
 	stream, err := sub.OpenSession(context.Background(), sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.close.next")})
+		[]eventbus.Subject{eventbus.Subject("events.main.close.next")}, time.Time{})
 	require.NoError(t, err)
 	// Close first; next call observes the closed channel.
 	require.NoError(t, stream.Close())

--- a/internal/eventbus/subscriber_test.go
+++ b/internal/eventbus/subscriber_test.go
@@ -90,7 +90,7 @@ func TestOpenSessionDeliversPublishedEventMatchingFilter(t *testing.T) {
 	subject := eventbus.Subject("events.main.scene.abc.ic")
 	sessionID := freshSessionID()
 
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -120,7 +120,7 @@ func TestOpenSessionIsIdempotentAcrossReopens(t *testing.T) {
 	// otherwise the durable consumer's last-acked cursor can race the
 	// reopen and redeliver evt1.
 	bgCtx := context.Background()
-	s1, err := sub.OpenSession(bgCtx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	s1, err := sub.OpenSession(bgCtx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	evt1 := newTestEnvelope(subject, []byte("first"))
 	require.NoError(t, pub.Publish(bgCtx, evt1))
@@ -141,7 +141,7 @@ func TestOpenSessionIsIdempotentAcrossReopens(t *testing.T) {
 	evt2 := newTestEnvelope(subject, []byte("second"))
 	require.NoError(t, pub.Publish(bgCtx, evt2))
 
-	s2, err := sub.OpenSession(bgCtx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	s2, err := sub.OpenSession(bgCtx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s2.Close() })
 	ctx2, cancel2 := context.WithTimeout(bgCtx, 10*time.Second)
@@ -156,7 +156,7 @@ func TestOpenSessionRejectsUnstartedSubsystem(t *testing.T) {
 	// NewJetStreamSubscriber with a nil JS context is a programming bug —
 	// surface via a coded error so callers get a breadcrumb.
 	s := eventbus.NewJetStreamSubscriber(nil)
-	_, err := s.OpenSession(context.Background(), "sess", eventbus.SessionIdentity{}, nil)
+	_, err := s.OpenSession(context.Background(), "sess", eventbus.SessionIdentity{}, nil, time.Time{})
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "EVENTBUS_SUBSCRIBER_NOT_READY")
 }
@@ -164,7 +164,7 @@ func TestOpenSessionRejectsUnstartedSubsystem(t *testing.T) {
 func TestOpenSessionRejectsEmptySessionID(t *testing.T) {
 	embedded := eventbustest.New(t)
 	s := embedded.Bus.Subscriber()
-	_, err := s.OpenSession(context.Background(), "", eventbus.SessionIdentity{}, nil)
+	_, err := s.OpenSession(context.Background(), "", eventbus.SessionIdentity{}, nil, time.Time{})
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "EVENTBUS_INVALID_SESSION_ID")
 }
@@ -180,7 +180,7 @@ func TestSessionStreamNextUnblocksOnContextCancel(t *testing.T) {
 	sub := embedded.Bus.Subscriber()
 	sessionID := freshSessionID()
 	stream, err := sub.OpenSession(context.Background(), sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.nothing.here")})
+		[]eventbus.Subject{eventbus.Subject("events.main.nothing.here")}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -201,7 +201,7 @@ func TestSessionStreamCloseIsIdempotent(t *testing.T) {
 	sub := embedded.Bus.Subscriber()
 	sessionID := freshSessionID()
 	stream, err := sub.OpenSession(context.Background(), sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.x.y")})
+		[]eventbus.Subject{eventbus.Subject("events.main.x.y")}, time.Time{})
 	require.NoError(t, err)
 	require.NoError(t, stream.Close())
 	// Second Close is a no-op per contract.
@@ -220,7 +220,7 @@ func TestSetFiltersReplacesFilterSubjectsAtomically(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{alpha})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{alpha}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -291,7 +291,7 @@ func TestSubscribeFilterMonotonicityUnderSetFilters(t *testing.T) {
 		defer cancel()
 
 		initial := drawFilterSet(rt, "initial_filter")
-		stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), initial)
+		stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), initial, time.Time{})
 		require.NoError(rt, err)
 		defer func() { _ = stream.Close() }()
 
@@ -359,7 +359,7 @@ func TestJetStreamSubscriberUsesSessionConsumerName(t *testing.T) {
 	sessionID := freshSessionID()
 	ctx := context.Background()
 	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.a.b")})
+		[]eventbus.Subject{eventbus.Subject("events.main.a.b")}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -380,7 +380,7 @@ func TestOpenSessionRejectsEmptyFilters(t *testing.T) {
 	// restore cannot leak the entire EVENTS stream into a session.
 	embedded := eventbustest.New(t)
 	sub := embedded.Bus.Subscriber()
-	_, err := sub.OpenSession(context.Background(), freshSessionID(), testIdentity(), nil)
+	_, err := sub.OpenSession(context.Background(), freshSessionID(), testIdentity(), nil, time.Time{})
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "EVENTBUS_SESSION_FILTERS_REQUIRED")
 }
@@ -391,7 +391,7 @@ func TestSetFiltersRejectsEmptyFilters(t *testing.T) {
 	sub := embedded.Bus.Subscriber()
 	sessionID := freshSessionID()
 	stream, err := sub.OpenSession(context.Background(), sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.x.y")})
+		[]eventbus.Subject{eventbus.Subject("events.main.x.y")}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -413,7 +413,7 @@ func TestDeliveryNackAndInProgressForwardToMsg(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -437,7 +437,7 @@ func TestSubscriberOptionsOverrideDefaults(t *testing.T) {
 	)
 	sessionID := freshSessionID()
 	stream, err := sub.OpenSession(context.Background(), sessionID, testIdentity(),
-		[]eventbus.Subject{eventbus.Subject("events.main.opts.check")})
+		[]eventbus.Subject{eventbus.Subject("events.main.opts.check")}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -463,7 +463,7 @@ func TestJetStreamSubscriberRejectsUnknownCodec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 
@@ -497,7 +497,7 @@ func TestOpenSessionDeliveriesCarryNonZeroJetStreamSequence(t *testing.T) {
 	subject := eventbus.Subject("events.main.scene.seqtest.ic")
 	sessionID := freshSessionID()
 
-	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject})
+	stream, err := sub.OpenSession(ctx, sessionID, testIdentity(), []eventbus.Subject{subject}, time.Time{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = stream.Close() })
 

--- a/internal/grpc/scope_floor.go
+++ b/internal/grpc/scope_floor.go
@@ -12,6 +12,31 @@ import (
 	"github.com/holomush/holomush/internal/session"
 )
 
+// maxStreamScopeFloor returns MAX(streamScopeFloor(info, subj)) across every
+// filter subject — the per-session aggregate floor used at OpenSession entry.
+// Per holomush-iwzt §6.2 Tier 1: MAX (not MIN) yields the smallest set that
+// includes events visible to at least one subject; iwzt.15 then drops events
+// below the per-subject floor at delivery time.
+//
+// NOTE: streamScopeFloor currently inspects legacy stream-name prefixes
+// ("location:", "scene:"), but production callers pass NATS subjects
+// ("events.<gid>.location.X"), so the loop returns time.Time{} for every
+// real-world subject today. Until that format mismatch is closed (tracked
+// as a separate follow-up bead), the aggregate floor is effectively zero —
+// preserving the pre-iwzt DeliverAllPolicy behavior. The helper exists so
+// the MAX-semantics are testable in isolation and the wiring is in place
+// when the format gap is closed.
+func maxStreamScopeFloor(info *session.Info, filters []string) time.Time {
+	var minFloor time.Time
+	for _, subj := range filters {
+		f := streamScopeFloor(info, subj)
+		if f.After(minFloor) {
+			minFloor = f
+		}
+	}
+	return minFloor
+}
+
 // streamScopeFloor returns the temporal floor for a session's view of the
 // given stream. Per holomush-iwzt §6.1.
 func streamScopeFloor(info *session.Info, stream string) time.Time {

--- a/internal/grpc/scope_floor_test.go
+++ b/internal/grpc/scope_floor_test.go
@@ -49,6 +49,53 @@ func TestStreamScopeFloor(t *testing.T) {
 	}
 }
 
+// TestMaxStreamScopeFloor covers the Subscribe-path MAX aggregation used by
+// CoreServer.Subscribe to compute the minFloor it forwards to OpenSession.
+// The helper takes legacy stream-name format ("location:X", "scene:Y:ic",
+// "character:Z"); production callers pass NATS subjects today, so these tests
+// exercise the function as designed independent of that pending format-gap.
+func TestMaxStreamScopeFloor(t *testing.T) {
+	locID := ulid.MustParse("01H000000000000000000000A1")
+	sceneID := ulid.MustParse("01H000000000000000000000S1")
+	charID := ulid.MustParse("01H000000000000000000000C1")
+	arrival := time.Date(2026, 5, 17, 10, 0, 0, 0, time.UTC)
+	sceneJoin := time.Date(2026, 5, 17, 11, 0, 0, 0, time.UTC)
+
+	info := &session.Info{
+		CharacterID:       charID,
+		LocationID:        locID,
+		LocationArrivedAt: arrival,
+		FocusMemberships: []session.FocusMembership{
+			{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: sceneJoin},
+		},
+	}
+	locStream := "location:" + locID.String()
+	sceneStream := "scene:" + sceneID.String() + ":ic"
+	charStream := "character:" + charID.String()
+
+	cases := []struct {
+		name    string
+		filters []string
+		want    time.Time
+	}{
+		{"empty filter set returns zero", nil, time.Time{}},
+		{"only character — no floor — returns zero", []string{charStream}, time.Time{}},
+		{"only location — returns LocationArrivedAt", []string{locStream}, arrival},
+		{"only scene — returns FocusMembership.JoinedAt", []string{sceneStream}, sceneJoin},
+		{"location + character — MAX is location", []string{locStream, charStream}, arrival},
+		{"location + scene — MAX is scene (later)", []string{locStream, sceneStream}, sceneJoin},
+		{"scene + location — order-independent — MAX is scene", []string{sceneStream, locStream}, sceneJoin},
+		{"unknown subjects fall through to zero — MAX with known still wins",
+			[]string{"global", "events.gid.location.unknown", locStream}, arrival},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maxStreamScopeFloor(info, tc.filters)
+			assert.True(t, got.Equal(tc.want), "got %v want %v", got, tc.want)
+		})
+	}
+}
+
 func TestIsLocationStream(t *testing.T) {
 	assert.True(t, isLocationStream("location:01H000000000000000000000A1"))
 	assert.False(t, isLocationStream("scene:01H000000000000000000000S1:ic"))

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -855,10 +855,19 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		sessionIdentity = authguard.ToSessionIdentity(identity)
 	}
 
+	// Compute minFloor across all subscribed subjects per holomush-iwzt §6.2 Tier 1.
+	// See maxStreamScopeFloor in scope_floor.go for MAX semantics + the legacy-vs-NATS
+	// subject format gap that currently keeps minFloor at zero for production filters.
+	filterStrings := make([]string, len(filters))
+	for i, subj := range filters {
+		filterStrings[i] = string(subj)
+	}
+	minFloor := maxStreamScopeFloor(info, filterStrings)
+
 	// Open the bus session. JS preserves the durable consumer's cursor
 	// across reconnect, so events not acked last time get redelivered
 	// automatically; there is no explicit replay phase.
-	busStream, subErr := s.subscriber.OpenSession(ctx, req.SessionId, sessionIdentity, filters)
+	busStream, subErr := s.subscriber.OpenSession(ctx, req.SessionId, sessionIdentity, filters, minFloor)
 	if subErr != nil {
 		return oops.Code("SUBSCRIBE_FAILED").With("session_id", req.SessionId).Wrap(subErr)
 	}

--- a/internal/grpc/server_helpers_test.go
+++ b/internal/grpc/server_helpers_test.go
@@ -189,7 +189,7 @@ func TestSubscribeRejectsUnknownSession(t *testing.T) {
 // stubSubscriber is a minimal eventbus.Subscriber that errors on OpenSession.
 type stubSubscriber struct{}
 
-func (stubSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+func (stubSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject, _ time.Time) (eventbus.SessionStream, error) {
 	return nil, oops.Errorf("stub subscriber")
 }
 

--- a/internal/grpc/subscribe_server_test.go
+++ b/internal/grpc/subscribe_server_test.go
@@ -70,7 +70,7 @@ type fakeSubscriber struct {
 	opens   int
 }
 
-func (f *fakeSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+func (f *fakeSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject, _ time.Time) (eventbus.SessionStream, error) {
 	f.opens++
 	if f.openErr != nil {
 		return nil, f.openErr
@@ -365,7 +365,7 @@ type identityCapturingSubscriber struct {
 	capturedIdentity eventbus.SessionIdentity
 }
 
-func (c *identityCapturingSubscriber) OpenSession(_ context.Context, _ string, identity eventbus.SessionIdentity, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+func (c *identityCapturingSubscriber) OpenSession(_ context.Context, _ string, identity eventbus.SessionIdentity, _ []eventbus.Subject, _ time.Time) (eventbus.SessionStream, error) {
 	c.opens++
 	c.capturedIdentity = identity
 	return c.stream, nil

--- a/test/integration/auth/auth_suite_test.go
+++ b/test/integration/auth/auth_suite_test.go
@@ -8,6 +8,7 @@ package auth_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
@@ -362,7 +363,7 @@ var _ core.EventAppender = (*noopEventStore)(nil)
 // the spec asserts on.
 type unusedSubscriber struct{}
 
-func (unusedSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject) (eventbus.SessionStream, error) {
+func (unusedSubscriber) OpenSession(_ context.Context, _ string, _ eventbus.SessionIdentity, _ []eventbus.Subject, _ time.Time) (eventbus.SessionStream, error) {
 	return nil, oops.Code("TEST_SUITE_BUG").Errorf("unusedSubscriber.OpenSession invoked: a spec reached the subscriber call without expecting to")
 }
 

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Sensitive event end-to-end", func() {
 				"test-plugin",
 			)
 
-			stream, err := env.subscriber.OpenSession(ctx, "hot-part-"+sceneID, participantID, []eventbus.Subject{"events.>"})
+			stream, err := env.subscriber.OpenSession(ctx, "hot-part-"+sceneID, participantID, []eventbus.Subject{"events.>"}, time.Time{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func() { _ = stream.Close() })
 
@@ -399,7 +399,7 @@ var _ = Describe("Sensitive event end-to-end", func() {
 				BindingID:   "01BINDCC0000000000000000",
 			}
 			sessID := "hot-nonpart-" + strconv.Itoa(int(time.Now().UnixNano()))
-			stream, err := env.subscriber.OpenSession(ctx, sessID, nonParticipantID, []eventbus.Subject{"events.>"})
+			stream, err := env.subscriber.OpenSession(ctx, sessID, nonParticipantID, []eventbus.Subject{"events.>"}, time.Time{})
 			Expect(err).NotTo(HaveOccurred())
 			DeferCleanup(func() { _ = stream.Close() })
 

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Subscribe with non-participant identity delivers MetadataOnly 
 		}
 		sessionID := "nonparticipant-session-" + sceneID
 
-		stream, err := h.subscriber.OpenSession(ctx, sessionID, nonParticipantID, []eventbus.Subject{"events.>"})
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, nonParticipantID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = stream.Close() })
 
@@ -352,7 +352,7 @@ var _ = Describe("Subscribe with participant identity delivers plaintext (INV-26
 		}
 		sessionID := "participant-session-" + sceneID
 
-		stream, err := h.subscriber.OpenSession(ctx, sessionID, participantID, []eventbus.Subject{"events.>"})
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, participantID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = stream.Close() })
 

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Plugin decrypt manifest gate denies without declaration (INV-1
 			Kind:       eventbus.IdentityKindPlugin,
 			PluginName: pluginName,
 		}
-		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = stream.Close() })
 
@@ -417,7 +417,7 @@ var _ = Describe("Plugin decrypt ABAC gate denies without grant (INV-18)", func(
 			Kind:       eventbus.IdentityKindPlugin,
 			PluginName: pluginName,
 		}
-		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = stream.Close() })
 
@@ -496,7 +496,7 @@ var _ = Describe("Plugin decrypt emits audit on permit and isolation (INV-19)", 
 			Kind:       eventbus.IdentityKindPlugin,
 			PluginName: pluginName,
 		}
-		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"})
+		stream, err := h.subscriber.OpenSession(ctx, sessionID, pluginID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = stream.Close() })
 
@@ -581,7 +581,7 @@ var _ = Describe("Plugin decrypt denial does not block fanout (INV-20)", func() 
 			CharacterID: participantCharID,
 			BindingID:   participantBindingID,
 		}
-		charStream, err := h.subscriber.OpenSession(ctx, characterSessionID, charID, []eventbus.Subject{"events.>"})
+		charStream, err := h.subscriber.OpenSession(ctx, characterSessionID, charID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = charStream.Close() })
 
@@ -590,7 +590,7 @@ var _ = Describe("Plugin decrypt denial does not block fanout (INV-20)", func() 
 			Kind:       eventbus.IdentityKindPlugin,
 			PluginName: deniedPluginName,
 		}
-		pluginStream, err := h.subscriber.OpenSession(ctx, pluginSessionID, pluginID, []eventbus.Subject{"events.>"})
+		pluginStream, err := h.subscriber.OpenSession(ctx, pluginSessionID, pluginID, []eventbus.Subject{"events.>"}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = pluginStream.Close() })
 

--- a/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
+++ b/test/integration/eventbus_e2e/multi_protocol_fanout_test.go
@@ -46,10 +46,10 @@ var _ = Describe("Multi-protocol fan-out telnet and web see same pose", func() {
 
 		// Two subscribers on the same subject simulate two protocol adapters.
 		testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-		s1, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
+		s1, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = s1.Close() })
-		s2, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject})
+		s2, err := subSvc.OpenSession(ctx, freshSessionID(), testID, []eventbus.Subject{subject}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = s2.Close() })
 

--- a/test/integration/eventbus_e2e/reconnect_resume_test.go
+++ b/test/integration/eventbus_e2e/reconnect_resume_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Reconnect resume", func() {
 
 		// Open, consume + ack 3 events.
 		testID := eventbus.SessionIdentity{Kind: eventbus.IdentityKindCharacter, PlayerID: "01TESTPLAYER01234567890A", CharacterID: "01TESTCHARACTER0123456A", BindingID: "01TESTBINDING01234567AB"}
-		s1, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
+		s1, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 
 		const beforeDisconnect = 3
@@ -78,7 +78,7 @@ var _ = Describe("Reconnect resume", func() {
 		}
 
 		// Reconnect.
-		s2, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject})
+		s2, err := sub.OpenSession(ctx, sessionID, testID, []eventbus.Subject{subject}, time.Time{})
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { _ = s2.Close() })
 


### PR DESCRIPTION
Extends `Subscriber.OpenSession` with a new `minFloor time.Time` parameter
and computes it at the gRPC production caller as
`MAX(streamScopeFloor(info, subj))` across all subscribed subjects (per
spec §6.2 — MAX yields the smallest superset of events visible to at least
one subject; per-subject filter-at-delivery in iwzt.15 drops events below
the per-subject floor).

`SetFilters` was NOT extended: it lives on `SessionStream` and only ever
hits the existing-consumer branch in `buildConsumerConfig`, which preserves
the live consumer's `DeliverPolicy` / `OptStartTime` / `OptStartSeq` verbatim
per I-PRIV-8. Threading a new `minFloor` would be dead code.

Test callsites pass `time.Time{}` (zero) to preserve existing
`DeliverAllPolicy` behavior — tests don't exercise floor semantics.

Files touched (11): interface in `bus.go`, impl in `subscriber.go`,
production caller in `grpc/server.go`, 3 test mocks (`fakeBus`,
`fakeSubscriber`, `stubSubscriber`), and ~25 test callsites updated.

468 tests in `internal/eventbus/` pass; all `internal/grpc/` tests pass;
lint clean.

Bead: holomush-iwzt.14
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-1 Tier 1, §6.2)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session startup now accepts an explicit time floor and the server computes a minimum floor from subscription filters.
* **Tests**
  * Updated integration, e2e, and unit tests to match the new session-opening contract.
  * Added a unit test validating aggregation of per-filter time floors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->