### PR TITLE
feat(grpc): real staffOverride + I-PRIV-6 enforcement (iwzt.20)

### DIFF
--- a/internal/grpc/query_stream_history_test.go
+++ b/internal/grpc/query_stream_history_test.go
@@ -1134,6 +1134,8 @@ func TestQueryStreamHistoryFiltersAuditOnlyEvents(t *testing.T) {
 // TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation verifies
 // that a session requesting a location stream is denied when the session's
 // LocationID does not match the requested location (I-PRIV-1 Tier 1).
+// Uses DenyAllEngine so the staff override path (I-PRIV-6) returns false,
+// exercising the hard-gate denial without ABAC interference.
 func TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(time.Hour)
@@ -1146,7 +1148,13 @@ func TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation(t *testing.
 			ExpiresAt:  &future,
 		},
 	})
-	s := newQueryStreamHistoryServer(t, &fakeHistoryReader{}, sess)
+	// DenyAllEngine ensures staffOverride returns false, so the I-PRIV-1
+	// hard-gate rejects the request when the session is at a different location.
+	s := &CoreServer{
+		sessionStore:  sess,
+		historyReader: &fakeHistoryReader{},
+		accessEngine:  policytest.DenyAllEngine(),
+	}
 
 	resp, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
 		SessionId: "s1",
@@ -1155,4 +1163,48 @@ func TestQueryStreamHistory_LocationHardGate_DeniedWhenNotInLocation(t *testing.
 	require.Nil(t, resp)
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "STREAM_ACCESS_DENIED")
+}
+
+// TestQueryStreamHistory_StaffOverride_BypassesHardGate verifies that a
+// session whose character is granted read_unrestricted_history via ABAC can
+// query a location stream even when not co-located with that location
+// (I-PRIV-6 / ADR wxty). The staff override path bypasses the I-PRIV-1
+// location hard-gate.
+func TestQueryStreamHistory_StaffOverride_BypassesHardGate(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour)
+	locA := ulid.MustParse("01HYXLOCA0000000000000000A")
+	locB := ulid.MustParse("01HYXLOCB0000000000000000B")
+	charID := ulid.MustParse("01HYXCHAR00000000000000001")
+
+	sess := newTestSessionStore(t, map[string]*session.Info{
+		"staff-1": {
+			ID:          "staff-1",
+			CharacterID: charID,
+			LocationID:  locA, // in locA, but will query locB
+			ExpiresAt:   &future,
+		},
+	})
+
+	// staffGrantEngine grants read_unrestricted_history for the character
+	// subject (any resource), matching what the real seed policy does.
+	staffEngine := policytest.NewGrantEngine()
+	staffEngine.Grant(
+		"character:"+charID.String(),
+		"read_unrestricted_history",
+		"stream:*",
+	)
+
+	reader := &fakeHistoryReader{events: nil}
+	s := &CoreServer{
+		sessionStore:  sess,
+		historyReader: reader,
+		accessEngine:  staffEngine,
+	}
+
+	_, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
+		SessionId: "staff-1",
+		Stream:    "location:" + locB.String(),
+	})
+	require.NoError(t, err, "staff role must bypass location hard-gate (I-PRIV-6)")
 }

--- a/internal/grpc/scope_floor.go
+++ b/internal/grpc/scope_floor.go
@@ -89,16 +89,26 @@ func extractLocationID(stream string) string {
 	return strings.TrimPrefix(stream, "location:")
 }
 
-// staffOverride is a stub for Phase 5 (staff ABAC override). Returns false
-// unconditionally so the location hard-gate is exercised in Phase 2.
-// Phase 5 / iwzt.20 replaces with a real
-//
-//	s.accessEngine.Evaluate(ctx, NewAccessRequest("character:"+info.CharacterID.String(),
-//	                                               "read_unrestricted_history", "stream", nil))
-//
-// per ADR wxty / I-PRIV-6.
-func staffOverride(_ context.Context, _ *session.Info, _ accessTypes.AccessPolicyEngine) bool {
-	return false
+// staffOverride reports whether the session's character has been granted the
+// read_unrestricted_history action via ABAC (I-PRIV-6 / ADR wxty). When true,
+// the location hard-gate (I-PRIV-1) is bypassed; the temporal floor still
+// applies. Returns false if the engine is nil or if evaluation fails
+// (fail-closed).
+func staffOverride(ctx context.Context, info *session.Info, engine accessTypes.AccessPolicyEngine) bool {
+	if engine == nil {
+		return false
+	}
+	accessReq, err := accessTypes.NewAccessRequest(
+		"character:"+info.CharacterID.String(),
+		"read_unrestricted_history",
+		"stream:*",
+		nil,
+	)
+	if err != nil {
+		return false
+	}
+	decision, evalErr := engine.Evaluate(ctx, accessReq)
+	return evalErr == nil && decision.IsAllowed()
 }
 
 // extractSceneID returns the scene ULID from a scene:<id>:ic or scene:<id>:ooc subject.

--- a/internal/testsupport/privacytest/privacy_harness.go
+++ b/internal/testsupport/privacytest/privacy_harness.go
@@ -35,6 +35,7 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
+	"github.com/holomush/holomush/internal/eventbus/history"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/naming"
@@ -157,6 +158,13 @@ func Start(t *testing.T) *Server {
 	// Core engine with a no-op event appender.
 	engine := core.NewEngine(&noopEventAppender{})
 
+	// HistoryReader: minimal wiring against the embedded bus's JetStream
+	// and the test Postgres pool. All crypto/audit/fence options are
+	// nil-defaulted — the production newHistoryReader in
+	// cmd/holomush/sub_grpc.go layers those on, but for privacy-invariant
+	// tests the bare JS+Postgres tier is sufficient.
+	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now)
+
 	// CoreServer wired with all required subsystems.
 	coreServer := holoGRPC.NewCoreServer(
 		engine,
@@ -172,6 +180,15 @@ func Start(t *testing.T) *Server {
 		// Wire embedded bus subscriber so Subscribe calls succeed for
 		// WaitForEvent / DrainEvents paths.
 		holoGRPC.WithSubscriber(bus.Bus.Subscriber()),
+		// HistoryReader powers QueryStreamHistory end-to-end so privacy
+		// integration tests can exercise the full RPC path.
+		holoGRPC.WithHistoryReader(historyReader),
+		// AccessEngine drives staffOverride() in QueryStreamHistory; with
+		// it unwired, every override check returns false (the nil-engine
+		// short-circuit), defeating I-PRIV-6 tests. The harness uses
+		// allowAllPolicyEngine so override semantics are exercised
+		// without the operational complexity of seeded ABAC policies.
+		holoGRPC.WithAccessEngine(pe),
 	)
 
 	return &Server{
@@ -255,7 +272,11 @@ func (s *Server) ConnectGuest(ctx context.Context) *Session {
 	require.True(s.t, selResp.GetSuccess(),
 		"privacytest.ConnectGuest: SelectCharacter failed: %s", selResp.GetErrorMessage())
 
-	now := time.Now()
+	// Hydrate session timestamps from the persisted row, NOT from time.Now() —
+	// see the parallel block in ConnectAuthedWithRoles for the rationale.
+	persisted, getErr := s.sessionStore.Get(ctx, selResp.GetSessionId())
+	require.NoError(s.t, getErr, "privacytest.ConnectGuest: read persisted session")
+
 	return &Session{
 		server:             s,
 		SessionID:          selResp.GetSessionId(),
@@ -263,28 +284,83 @@ func (s *Server) ConnectGuest(ctx context.Context) *Session {
 		CharacterName:      selResp.GetCharacterName(),
 		LocationID:         s.guestStartLocationID,
 		OriginalLocationID: s.guestStartLocationID,
-		LocationArrivedAt:  now,
-		SessionCreatedAt:   now,
+		LocationArrivedAt:  persisted.LocationArrivedAt,
+		SessionCreatedAt:   persisted.CreatedAt,
 		LastReattachAt:     time.Time{},
 		playerSessionToken: rawToken,
 	}
 }
 
 // ConnectAuthed creates a named player+character and opens a game session.
-//
-// TODO(iwzt-9): implement authed-player creation path.
-func (s *Server) ConnectAuthed(_ context.Context, _ string) *Session {
-	s.t.Fatalf("privacytest.Server.ConnectAuthed: TODO iwzt-9 — authed player creation not yet wired")
-	return nil
+// The character is placed at the server's guest start location.
+func (s *Server) ConnectAuthed(ctx context.Context, charName string) *Session {
+	return s.ConnectAuthedWithRoles(ctx, charName, nil)
 }
 
 // ConnectAuthedWithRoles creates a named player+character with the given
-// roles and opens a game session.
-//
-// TODO(iwzt-9): implement role assignment path.
-func (s *Server) ConnectAuthedWithRoles(_ context.Context, _ string, _ []string) *Session {
-	s.t.Fatalf("privacytest.Server.ConnectAuthedWithRoles: TODO iwzt-9 — role-bearing player creation not yet wired")
-	return nil
+// roles and opens a game session. If roles is non-nil, each role is inserted
+// into character_roles directly via Postgres (bypassing ABAC for harness
+// convenience).
+func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, roles []string) *Session {
+	s.t.Helper()
+
+	// Unique username per character name to avoid collisions across tests.
+	username := charName + "_" + idgen.New().String()[:8]
+	password := "TestPassword1!"
+
+	// Register the player account.
+	player, playerSession, rawToken, err := s.authService.CreatePlayer(ctx, username, password, "")
+	require.NoError(s.t, err, "privacytest.ConnectAuthedWithRoles: CreatePlayer")
+
+	// Persist the player session so SelectCharacter can resolve the token.
+	require.NoError(s.t, s.playerSessionStore.Create(ctx, playerSession),
+		"privacytest.ConnectAuthedWithRoles: persist player session")
+
+	// Create the character directly (bypasses characterService wiring).
+	startLocID := s.guestStartLocationID
+	char, err := world.NewCharacter(player.ID, charName)
+	require.NoError(s.t, err, "privacytest.ConnectAuthedWithRoles: NewCharacter")
+	char.LocationID = &startLocID
+	// authCharRepoAdapter.Create delegates to worldpg.CharacterRepository.Create.
+	require.NoError(s.t, s.charRepo.Create(ctx, char),
+		"privacytest.ConnectAuthedWithRoles: persist character")
+
+	// Stamp roles into character_roles.
+	for _, role := range roles {
+		_, roleErr := s.pool.Exec(ctx,
+			`INSERT INTO character_roles (character_id, role) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+			char.ID.String(), role)
+		require.NoError(s.t, roleErr, "privacytest.ConnectAuthedWithRoles: insert role %q", role)
+	}
+
+	// Open a game session by selecting the character.
+	selResp, err := s.coreServer.SelectCharacter(ctx, &corev1.SelectCharacterRequest{
+		PlayerSessionToken: rawToken,
+		CharacterId:        char.ID.String(),
+	})
+	require.NoError(s.t, err, "privacytest.ConnectAuthedWithRoles: SelectCharacter RPC")
+	require.True(s.t, selResp.GetSuccess(),
+		"privacytest.ConnectAuthedWithRoles: SelectCharacter failed: %s", selResp.GetErrorMessage())
+
+	// Hydrate session timestamps from the persisted session row, NOT from
+	// time.Now() — the server-side LocationArrivedAt drives the I-PRIV-1 /
+	// I-PRIV-6 floor in QueryStreamHistory, so tests that assert against
+	// it MUST see the canonical value (per CodeRabbit thread on PR #4048).
+	persisted, getErr := s.sessionStore.Get(ctx, selResp.GetSessionId())
+	require.NoError(s.t, getErr, "privacytest.ConnectAuthedWithRoles: read persisted session")
+
+	return &Session{
+		server:             s,
+		SessionID:          selResp.GetSessionId(),
+		CharacterID:        char.ID,
+		CharacterName:      selResp.GetCharacterName(),
+		LocationID:         s.guestStartLocationID,
+		OriginalLocationID: s.guestStartLocationID,
+		LocationArrivedAt:  persisted.LocationArrivedAt,
+		SessionCreatedAt:   persisted.CreatedAt,
+		LastReattachAt:     time.Time{},
+		playerSessionToken: rawToken,
+	}
 }
 
 // AuthedPlayer returns an AuthedPlayer handle for multi-session continuity tests.

--- a/internal/testsupport/privacytest/privacy_session.go
+++ b/internal/testsupport/privacytest/privacy_session.go
@@ -65,8 +65,8 @@ func (s *Session) SendCommand(ctx context.Context, cmd string) error {
 		return oops.Code("COMMAND_REJECTED").
 			With("operation", "send_command").
 			With("command", cmd).
-			With("error_message", resp.GetErrorMessage()).
-			Errorf("command rejected by server: %s", resp.GetErrorMessage())
+			With("error_message", resp.GetError()).
+			Errorf("command rejected by server: %s", resp.GetError())
 	}
 	return nil
 }
@@ -160,14 +160,18 @@ func (s *Session) JoinScene(_ context.Context, _ ulid.ULID) {
 }
 
 // QueryStreamHistory fetches the event history for the given stream subject.
-// Returns the full page of events (up to the server's default page size).
-//
-// TODO(iwzt-9): wire historyReader into the CoreServer so
-// QueryStreamHistory can actually serve results. Until then this panics
-// because CoreServer.historyReader is nil and returns INTERNAL.
-func (s *Session) QueryStreamHistory(_ context.Context, _ string) []*corev1.EventFrame {
-	s.server.t.Fatalf("privacytest.Session.QueryStreamHistory: TODO iwzt-9 — historyReader not yet wired")
-	return nil
+// Returns the events from the response (may be empty if no history exists).
+// The caller must pass a stream the session is authorized to read; access
+// denials propagate as test failures via the returned error.
+func (s *Session) QueryStreamHistory(ctx context.Context, stream string) ([]*corev1.EventFrame, error) {
+	resp, err := s.server.coreServer.QueryStreamHistory(ctx, &corev1.QueryStreamHistoryRequest{
+		SessionId: s.SessionID,
+		Stream:    stream,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetEvents(), nil
 }
 
 // AuthedPlayer represents a named player (with hashed password) that can

--- a/test/integration/privacy/privacy_suite_test.go
+++ b/test/integration/privacy/privacy_suite_test.go
@@ -12,7 +12,13 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 )
 
+// suiteT exposes the *testing.T from TestPrivacy so Ginkgo Describe blocks
+// can pass it to privacytest.Start (which requires *testing.T — Ginkgo's
+// GinkgoT() does not satisfy that interface directly).
+var suiteT *testing.T
+
 func TestPrivacy(t *testing.T) {
+	suiteT = t
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "iwzt history-scope privacy")
 }

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -3,10 +3,21 @@
 
 //go:build integration
 
+// Package privacy_test contains integration tests for holomush-iwzt
+// history-scope privacy invariants.
+//
+// Test IDs follow the I-PRIV-N convention from the design spec at
+// docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md.
 package privacy_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/privacytest"
 )
 
 // I-PRIV-7 placeholder: no plugin currently declares history_scope: custom.
@@ -17,5 +28,68 @@ import (
 var _ = Describe("I-PRIV-7: plugin-owned history_scope semantics", func() {
 	It("exercises a plugin that declared custom history_scope (placeholder)", func() {
 		Skip("no plugin currently declares history_scope: custom — re-enable when a plugin adopts this field")
+	})
+})
+
+// I-PRIV-6 gate-bypass arm only: a character granted
+// read_unrestricted_history MUST bypass the I-PRIV-1 location hard-gate.
+//
+// I-PRIV-6 also asserts the floor-preservation arm — staff querying a
+// location they're not in still sees only events from their own
+// LocationArrivedAt forward. That arm requires emitting events with
+// controlled timestamps across the staff session's LocationArrivedAt
+// boundary; today's privacytest harness can't do that (the dispatcher
+// is wired with an empty command registry, so SendCommand("say ...")
+// has nothing to invoke, and direct emit helpers that bypass the
+// command layer don't yet exist). The gate-bypass half is exercised
+// here; the floor-preservation half is tracked separately.
+//
+// Per ADR wxty. The harness uses allowAllPolicyEngine which grants
+// read_unrestricted_history for all requests, exercising the
+// staffOverride → gate-bypass code path end-to-end.
+var _ = Describe("I-PRIV-6 (gate-bypass arm): staff override bypasses the location hard-gate", func() {
+	var (
+		ts    *privacytest.Server
+		ctx   context.Context
+		staff *privacytest.Session
+		locB  string
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = privacytest.Start(suiteT)
+
+		// Create a second location (not the staff member's location).
+		locBID := ts.NewLocation(ctx)
+		locB = "location:" + locBID.String()
+
+		// Staff session is at the guest start location (locA), which differs from locB.
+		// ConnectAuthedWithRoles stamps "staff" into character_roles and opens a game session.
+		staff = ts.ConnectAuthedWithRoles(ctx, "StaffMira", []string{"staff"})
+	})
+
+	AfterEach(func() {
+		if staff != nil {
+			staff.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("returns success (not STREAM_ACCESS_DENIED) when staff queries a location they are not in", func() {
+		// Staff is at the guest start location (locA); locB is a different
+		// location they're not in. The harness's allowAllPolicyEngine
+		// permits read_unrestricted_history for every principal, so
+		// staffOverride returns true and the I-PRIV-1 location hard-gate
+		// (session.LocationID == requested-location) is bypassed.
+		// LocB has no events, so the response is an empty (non-nil) slice.
+		// This asserts ONLY the gate-bypass — the floor-preservation arm
+		// of I-PRIV-6 is tracked separately (no harness event-emit yet).
+		events, err := staff.QueryStreamHistory(ctx, locB)
+		Expect(err).NotTo(HaveOccurred(),
+			"staff with read_unrestricted_history MUST bypass the location hard-gate (I-PRIV-6 gate-bypass arm)")
+		Expect(events).NotTo(BeNil(),
+			"response events must be a non-nil slice (empty is fine; locB has no history)")
+		Expect(events).To(BeEmpty(),
+			"locB has no events; response should be empty")
 	})
 })


### PR DESCRIPTION
Replaces the `staffOverride` stub from iwzt.8 with a real ABAC call against the
`read_unrestricted_history` action (seeded in iwzt.19 / PR #4035).

Per ADR wxty / I-PRIV-6:
- Staff/admin role bypasses the location hard-gate.
- Staff/admin still observes the per-session temporal floor — staff cannot read
  events older than their own `LocationArrivedAt`.

Adds:
- `TestQueryStreamHistory_StaffOverride_BypassesHardGate` (unit) covering the
  bypass code path.
- I-PRIV-6 Describe block in `test/integration/privacy/privacy_test.go` —
  currently `Skip` pending the privacytest harness `QueryStreamHistory` helper
  (still a TODO stub from iwzt.6). Intent recorded; unit test covers the bypass
  code path until the harness is wired.
- Harness fill-ins: `ConnectAuthed`, `ConnectAuthedWithRoles` (stamps roles
  onto the test character), `Logout`.
- `suiteT *testing.T` package var in `privacy_suite_test.go` so Describe blocks
  can pass it to `privacytest.Start` (Ginkgo's `GinkgoT()` doesn't satisfy
  `*testing.T` directly).

Bead: holomush-iwzt.20
Spec: docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md (I-PRIV-6)
Plan: docs/superpowers/plans/2026-05-17-history-scope-privacy.md §Task 19
ADR:  docs/adr/holomush-wxty-hard-gate-current-location-only.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit and integration tests verifying staff override bypasses location hard-gates and improved test-suite wiring for reuse in integration runs.

* **Bug Fixes**
  * Staff-override now evaluates access via the policy engine (no longer a fixed false), ensuring proper allow/deny behavior.

* **Chores**
  * Enhanced test harness and session helpers: end-to-end authenticated flows, hydrated session timestamps, RPC-backed history query helpers, and clearer command-rejection errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->