### PR TITLE
chore(coderabbit): publish commit status so required CodeRabbit check clears

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  commit_status: true
+  fail_commit_status: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+    ignore_usernames: []


### PR DESCRIPTION
## Summary

The `protect-main` ruleset requires a status check named `CodeRabbit` from the CodeRabbit GitHub App, but CR only publishes that status when `reviews.commit_status: true` is set. Without it, the required check stays `queued` forever on every PR.

Most visible on renovate PRs because CR's dashboard-side bot-author filter also skips the review entirely, leaving renovate PRs ungate-able without admin override (e.g., #4054).

This config:

- `commit_status: true` — publishes the `CodeRabbit` status so the required check actually clears.
- `fail_commit_status: true` — review-fatal errors surface as a failed gate instead of silent pending.
- `auto_review.ignore_usernames: []` — explicit override so `renovate[bot]` is reviewed.
- `auto_pause_after_reviewed_commits: 0` — re-review on every push (always-fresh per request).

Repo-level `.coderabbit.yaml` overrides any conflicting dashboard config.

## Smoke test

This PR is the smoke test: CR should post a `CodeRabbit` status check on this commit and that check should pass before merge.

## Follow-up

For existing in-flight PRs (#4054 etc.) — once this lands on main, renovate will rebase on its next run and pick up the config. Manually retriggerable in the meantime with `@coderabbitai review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic code reviews with incremental feedback and real-time commit status notifications for enhanced development workflow visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->