### PR TITLE
docs(jj): defer chain-safe rebase to jj:jujutsu skill + retire dup prose (holomush-lfri)

### DIFF
--- a/.claude/commands/landing-sequence.md
+++ b/.claude/commands/landing-sequence.md
@@ -25,12 +25,18 @@ for push; otherwise infer from the current jj workspace).
    - If pr-prep fails: STOP, surface the failure, do not push.
    - For `.claude/`-touching changes, additionally verify `task lint:docs-symmetry` passes (the docs-symmetry lint runs as part of `task lint`, which `task pr-prep` invokes — but call it out separately if a CLAUDE.md/AGENTS.md edit was the primary motivation).
 
-4. **Targeted rebase**
-   - `jj git fetch`
-   - `jj rebase -r <change-id> -d main@origin` — scope to YOUR change only. NEVER bare `jj rebase -d main`. Reason: bare rebase sweeps up descendants of other agents' in-flight work in other workspaces.
+4. **Pre-push rebase** — defer to the `jj:jujutsu` skill's "Pre-Push Rebase" section. The chain-safe recipe handles single-commit PRs and chains identically:
+
+   ```bash
+   jj git fetch
+   jj rebase -s "$(jj --no-pager log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)')" -o main@origin --skip-emptied
+   ```
+
+   The `guard-jj-rebase-chain` PreToolUse hook (shipped with the `jj` plugin) BLOCKS the truncation-prone `jj rebase -r @ -o <trunk>` shape — the failure mode that lost 8 of 9 commits on PR #4049 (`holomush-lfri`). If you genuinely need to extract `@` alone (confirmed single-commit PR), append `# jj-exempt` to escalate-to-ASK.
 
 5. **Push**
    - `jj bookmark set <branch> -r @-` (or whichever rev is the tip)
+   - Sanity-check the chain length one more time before push: `jj log -r 'main@origin..@' --no-pager --no-graph -T 'change_id ++ "\n"' | wc -l`. If it dropped unexpectedly between sessions (e.g., 9 → 1), STOP — investigate before pushing.
    - `jj git push --branch <branch>`
    - `jj st` to verify
 

--- a/.claude/rules/landing-the-plane.md
+++ b/.claude/rules/landing-the-plane.md
@@ -9,8 +9,8 @@ When ending a work session, work is **NOT complete until changes are pushed**. T
 3. **Update issue status** — `bd close` what's done; `bd update` what's still in flight
 4. **Push:**
    - `jj git fetch`
-   - Targeted rebase: `jj rebase -r <change-id> -d main@origin` — **never bare `jj rebase -d main`**. Reason: bare rebase sweeps up descendants of other agents' in-flight work.
-   - Set bookmark: `jj bookmark set <branch> -r @-` (or whichever rev)
+   - **Pre-push rebase**: follow the `jj:jujutsu` skill's "Pre-Push Rebase" section. The chain-safe `jj rebase -s "$(jj log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)')" -o main@origin --skip-emptied` shape works for single-commit PRs *and* chains. The `guard-jj-rebase-chain` PreToolUse hook blocks the truncation-prone `jj rebase -r @ -o <trunk>` shape (PR #4049 lost 8 of 9 commits to it). Bypass via `# jj-exempt` only when extracting `@` alone is intentional.
+   - Set bookmark: `jj bookmark set <branch> -r @-` (or whichever rev is the tip)
    - `jj git push --branch <branch>`
    - Verify with `jj st`
 5. **Clean up workspace:**
@@ -28,7 +28,7 @@ When ending a work session, work is **NOT complete until changes are pushed**. T
 - NEVER stop before pushing — that leaves work stranded locally
 - NEVER say "ready to push when you are" — YOU must push
 - If push fails, resolve and retry until it succeeds
-- NEVER use `jj op restore` to "fix" an unexpected state without explicit user direction. Reason: the op log is repo-global; rewinding from one workspace silently wipes other agents' in-flight work in every other workspace. Treat it like `git push --force` to a shared branch.
+- `jj op restore` / `jj op abandon` rewind the global op log and silently corrupt sibling workspaces — both are gated by the `jj:jujutsu` plugin's `guard-jj-mutating` PreToolUse hook (bypass: `# jj-op-approved`). Recovery ladder (`jj undo`, `jj op revert`, etc.) is documented in the skill.
 
 ## Skipping the chain
 

--- a/.claude/rules/subagent-briefing.md
+++ b/.claude/rules/subagent-briefing.md
@@ -21,7 +21,7 @@ context, skills, or tool habits from the parent session.
 | TDD | run `task test -- ./<package>` per change; use Ginkgo for integration tests (build tag `//go:build integration`) |
 | Sub-agent dispatch | model floor is `sonnet` (never `haiku` for sub-agents) |
 | jj workspace work | verify `jj st` is clean BEFORE they run `jj describe` — otherwise their describe clobbers the in-flight change's description |
-| Anything destructive | NEVER `jj op restore`. Reason: op log is repo-global; rewinding from one workspace silently wipes other agents' in-flight work in every other workspace. |
+| Op-log mutations | `jj op restore` / `jj op abandon` are gated by the `jj:jujutsu` plugin's `guard-jj-mutating` hook (bypass: `# jj-op-approved`); ensure the sub-agent's frontmatter lists `jj:jujutsu` in `skills:` so they read the recovery ladder before reaching for either command |
 | Closing beads | grounded evidence required; in-bead "Closed:"/"Fixed:" comments are NOT proof — verify the cited fix in current code (the `bead-auditor` agent caught false-fix cases on `wfza.21`, `wfza.62`) |
 
 ## Anti-patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,5 @@ runes patterns.
 ## Landing the Plane (Session Completion)
 
 Work is NOT complete until `jj git push` succeeds. The full session-completion checklist lives in `.claude/rules/landing-the-plane.md` (always loaded). Skip the chain only for small fixes (typo, dependency bump, single-file bug).
+
+**Pre-push rebase** — defer to the `jj:jujutsu` skill's "Pre-Push Rebase" section. Use `jj rebase -s "$(jj log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)')" -o main@origin --skip-emptied` — it's chain-safe for single-commit and multi-commit PRs alike. The `guard-jj-rebase-chain` PreToolUse hook blocks the truncation-prone `jj rebase -r @ -o <trunk>` shape (PR #4049 incident).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,3 +403,5 @@ runes patterns.
 ## Landing the Plane (Session Completion)
 
 Work is NOT complete until `jj git push` succeeds. The full session-completion checklist lives in `.claude/rules/landing-the-plane.md` (always loaded). Skip the chain only for small fixes (typo, dependency bump, single-file bug).
+
+**Pre-push rebase** — defer to the `jj:jujutsu` skill's "Pre-Push Rebase" section. Use `jj rebase -s "$(jj log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)')" -o main@origin --skip-emptied` — it's chain-safe for single-commit and multi-commit PRs alike. The `guard-jj-rebase-chain` PreToolUse hook blocks the truncation-prone `jj rebase -r @ -o <trunk>` shape (PR #4049 incident).


### PR DESCRIPTION
## Summary

The `jj@fzymgc-house-skills` plugin v0.6.1 (released 2026-05-19) shipped:

- A `skills/jujutsu/SKILL.md` **"Pre-Push Rebase: Use `-s`, Not `-r`"** section with the chain-safe `-s roots(trunk()..@)` recipe.
- A `hooks/guard-jj-rebase-chain` PreToolUse hook that **blocks** `jj rebase -r @ -o <trunk>` at the tool boundary (bypass: `# jj-exempt`).
- A `hooks/guard-jj-mutating` PreToolUse hook that **gates** `jj op restore` / `jj op abandon` (bypass: `# jj-op-approved`).

The hook source even cites the holomush PR #4049 / `jg9b.3` incident as motivation — the upstream fix landed the same day this bead was filed.

This PR slims the repo's duplicated prose down to thin pointers at the authoritative skill / hooks, and retires warnings that the upstream hooks now enforce at runtime.

## Changes

- `.claude/rules/landing-the-plane.md`
  - Step 4 push → 1-paragraph pointer to `jj:jujutsu` "Pre-Push Rebase" + `guard-jj-rebase-chain`.
  - Critical-rule for `jj op restore` → pointer to `guard-jj-mutating` + skill's "Recovery ladder".
- `.claude/commands/landing-sequence.md`
  - Step 4 chain-aware branching → defers to skill; Step 5 retains a sanity-check count.
- `.claude/rules/subagent-briefing.md`
  - "Anything destructive (NEVER op restore)" row → "Op-log mutations (gated by `guard-jj-mutating`; ensure sub-agent `skills:` lists `jj:jujutsu`)" — backstop hook works only at the Bash boundary, but sub-agents still need the skill for *reasoning* about recovery.
- `CLAUDE.md` / `AGENTS.md`
  - "Landing the Plane" section: 1-sentence chain-hazard pointer to the skill + hook (byte-symmetric across both files).

### Drift fixed along the way

- `-d main@origin` → `-o main@origin` (deprecated → modern flag; plugin recipe is `-o`).
- `roots(main@origin..@)` → `roots(trunk()..@)` (plugin's trunk-name-portable revset).
- `# jj-exempt` / `# jj-op-approved` escape hatches now documented at every repo surface that mentions the gated commands.

## Why two reviewer passes happened

Originally this bead was scoped as "add chain-aware rebase recipe to the repo's landing-sequence docs". After implementing that, a comparison with the `jj` plugin's just-released v0.6.1 showed the recipe (and the runtime defense) was already upstream. The bead was reframed mid-stream to slim duplicates rather than ship a second copy. `code-reviewer` was run twice — once on the original chain-aware recipe (found a `-T` template bug, fixed it), once on the slim-down (returned READY with 3 low-severity nits; 2 fixed inline, 1 declined as style-only).

## Follow-up

- `holomush-f7t2` (P2, filed in this session) — make `AGENTS.md` ↔ `CLAUDE.md` a symlink, so the byte-symmetry I had to fix manually here becomes structurally impossible.

## Test plan

- [x] `task lint` — green (markdown, docs-symmetry, ADR, plugin-manifests, docs-paths-sync, license, etc.)
- [x] `task pr-prep` — full pipeline GREEN end-to-end (lint + format + schema + license + unit + integration + 62/62 E2E)
- [x] `code-reviewer` adversarial pass — READY
- [x] Smoke-tested the chain-safe revset live in this worktree: `jj log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)'` returns the expected single chain root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-push rebase workflow guidance with safer, chain-safe command patterns and improved emptied-commit handling
  * Added explicit warnings about truncation-prone rebase operations and documented bypass procedures for special cases
  * Enhanced safety guidelines for dangerous version control operations with new guardrail controls
  * Clarified exemption markers and approval processes for advanced repository operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->