### PR TITLE
chore(coderabbit): explicitly skip bot-authored PRs via ignore_usernames

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,4 +6,7 @@ reviews:
     enabled: true
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
-    ignore_usernames: []
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"


### PR DESCRIPTION
## Summary

Hypothesis test for the bot-PR review gap diagnosed during #4055 follow-up.

After #4055 landed `commit_status: true`, CR's auto-trigger still doesn't fire on renovate-authored PRs — 49 open renovate PRs sat with zero CR activity for hours, while `@coderabbitai review` posted manually on PR #4064 worked end-to-end and produced a `CodeRabbit: success` commit status within ~1 minute.

This adds explicit YAML-tier ignore entries for the bots we don't want CR reviewing anyway (renovate, dependabot, github-actions). The behavior we're testing:

> CR processes the event → sees bot in `ignore_usernames` → posts `CodeRabbit: success ("Review skipped")` → required-status-check clears with no review consumed.

## Outcomes

- **If it works**: clean auto-skip for dep bumps, no manual `@coderabbitai review` comments needed. The 49-PR backlog will rebase onto main, CR skips each in <1s with a success status, auto-merge fires for the ones with `automerge: true` in renovate config.
- **If it doesn't work**: confirms the bot filter is dashboard-tier (before YAML evaluation), and the only paths forward are the CR dashboard toggle or the mechanical `@coderabbitai review` GitHub Actions workflow.

This PR itself is human-authored, so its own CR run will be the normal review path and shouldn't be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to exclude automated bot accounts from review handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->