### PR TITLE
ci: disable Benchmark Regression Check on PRs (holomush-61en)

### DIFF
--- a/.github/workflows/benchmark-check.yml
+++ b/.github/workflows/benchmark-check.yml
@@ -1,11 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 HoloMUSH Contributors
+#
+# DISABLED on PRs (holomush-61en) — 2026-05-19.
+#
+# This workflow ran on every PR to main and took 1.5-5 min while contributing
+# no signal for non-policy-engine changes. The benchmarks live in a single
+# package (internal/access/policy/) but the workflow had no path filter, so
+# docs-only PRs (e.g. #4114, #4116) paid the full cost.
+#
+# Re-enable plan tracked in holomush-61en. At minimum, re-enable with:
+#   1. paths-ignore for DOCS_ONLY_PATHS (skip docs-only PRs)
+#   2. paths: filter scoped to internal/access/policy/** + .benchmarks/baseline.txt
+#
+# Until then, the workflow can still be run manually via the Actions tab
+# (workflow_dispatch) to spot-check regressions before merging policy-engine
+# changes.
 
 name: Benchmark Regression Check
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`.github/workflows/benchmark-check.yml` ran on every PR to main and took 1.5-5 min while contributing no signal for the vast majority of changes. The benchmarks live in a single package (`internal/access/policy/`) but the workflow had no path filter, so docs-only PRs (e.g. #4114, #4116) paid the full cost.

This commit changes the trigger from `pull_request:` to `workflow_dispatch:` only, so the workflow still exists and can be invoked manually via the Actions tab to spot-check regressions before merging policy-engine changes — but it stops running automatically on every PR.

The job definition, runner, script invocation, and baselines are left intact — only the trigger changes.

## Why now

Filed during the `holomush-lfri` (PR #4114) + `holomush-f7t2` (PR #4116) sequence. Both were docs-only changes; both triggered the full benchmark suite. The latency was noticeable enough to ask "what does this even do?"

## Re-enable plan

Tracked in **`holomush-61en`** (P3, open). The bead carries the full cost breakdown and a recommended shape:

1. `paths-ignore:` for `DOCS_ONLY_PATHS` (skip docs-only PRs)
2. `paths:` filter scoped to `internal/access/policy/**` + `.benchmarks/baseline.txt` (only run when the policy engine or its baselines change)
3. Optionally: `BENCH_TIME=0.5s` (halves the floor), smaller runner profile, or move to a nightly-soak schedule

## Branch-protection safety

Verified the `protect-main` ruleset's required-status checks: `Build`, `Lint`, `Test`, `CodeRabbit`. **Benchmark Regression Check is NOT required**, so disabling the auto-trigger does not block merges. No other workflow consumes it via `needs:` / `if:`.

## Test plan

- [x] `actionlint` — only the pre-existing namespace-runner-label warning fires; no new issues
- [x] `task lint` — all linters green (incl. new `lint:docs-symmetry` symlink check)
- [x] `task pr-prep` — full pipeline GREEN end-to-end (lint + format + schema + license + unit + integration + 62/62 E2E)
- [x] `code-reviewer` — READY (verified `workflow_dispatch:` is valid GHA syntax + no branch-protection conflicts)
- [x] Verified the workflow can still be invoked manually after the change (via `gh workflow run` / Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated benchmark regression workflow to use manual-only triggering instead of automatic checks on pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->