### PR TITLE
chore(coderabbit): use app/<name> username form per CR's own review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,6 +7,6 @@ reviews:
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
     ignore_usernames:
-      - "dependabot[bot]"
-      - "renovate[bot]"
-      - "github-actions[bot]"
+      - "app/dependabot"
+      - "app/renovate"
+      - "app/github-actions"


### PR DESCRIPTION
## Summary

Follow-up to #4115. CodeRabbit reviewed that PR ([thread](https://github.com/holomush/holomush/pull/4115#discussion_r3266595674)) and flagged the `ignore_usernames` entries as a mismatch:

> The configuration specifies `renovate[bot]`, `github-actions[bot]`, and `dependabot[bot]`, but the actual GitHub PR author usernames in your repository are `app/renovate` and `app/github-actions`. Since the schema requires exact username matching, the ignore rules won't apply with the current values.

I initially dismissed this on the basis that the raw GitHub REST API returns the `[bot]` form — but how CR's ingestion layer normalizes the author login is CR's implementation detail. CR is authoritative for its own matching semantics.

## Test the corrected form

Switching to `app/dependabot`, `app/renovate`, `app/github-actions` and re-running the same hypothesis test as before:

- Land this on main.
- Wait for (or trigger) a renovate rebase onto post-merge main.
- Observe whether CR auto-posts `CodeRabbit: success ("Review skipped")` on the rebased head.

If yes → CR was right, hypothesis confirmed, the 49-PR backlog will clear naturally as it rebases.
If no → narrows the gap to either dashboard-tier filter or silent-skip-with-no-status, both of which need the GH Actions bridge workflow to satisfy the required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration to improve bot integration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->