### PR TITLE
ci: tune Namespace runner capacity

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,4 +3,6 @@
 
 self-hosted-runner:
   labels:
+    - namespace-profile-linux-amd64-2x4
     - namespace-profile-linux-amd64-4x8
+    - namespace-profile-linux-amd64-8x16

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,6 +75,7 @@
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "commitMessagePrefix": "deps:",
   "commitMessageAction": "bump",
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2
+  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 2,
+  "prHourlyLimit": 1
 }

--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -63,7 +63,7 @@ permissions:
 jobs:
   bootstrap:
     name: Bootstrap Sandbox Infrastructure
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   lint:
     name: Buf Lint
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: bufbuild/buf-action@b46cbc051dd8fd10a3c2213e784498790d3fe388 # v1.0.3
@@ -39,7 +39,7 @@ jobs:
 
   push:
     name: Buf Push to BSR
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [lint]
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ on:
       - LICENSE_HEADER
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -164,7 +168,7 @@ jobs:
 
   integration:
     name: Integration Test
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-8x16
     needs: [test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -207,7 +211,7 @@ jobs:
 
   e2e:
     name: E2E Test
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-8x16
     needs: [test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   soak:
     name: Event Bus Soak
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-8x16
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     if: github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -38,7 +38,7 @@ jobs:
 
   goreleaser:
     name: Build, Sign, and Release
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-8x16
     needs: release-please
     if: needs.release-please.outputs.release_created || startsWith(github.ref, 'refs/tags/')
     outputs:
@@ -148,7 +148,7 @@ jobs:
   # This adds SLSA provenance to the already-signed artifacts.
   attest-provenance:
     name: Attest Provenance
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     needs: goreleaser
     permissions:
       id-token: write
@@ -179,7 +179,7 @@ jobs:
   # Attest container images for provenance
   attest-containers:
     name: Attest Container Provenance
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     needs: goreleaser
     permissions:
       id-token: write
@@ -231,7 +231,7 @@ jobs:
   # Final verification step - ensures all signing and attestation succeeded
   verify-release:
     name: Verify Release
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     needs: [goreleaser, attest-provenance, attest-containers]
     permissions:
       contents: read
@@ -299,7 +299,7 @@ jobs:
 
   deploy-sandbox:
     name: Deploy Sandbox
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     needs: [verify-release]
     # On tag push: wait for verify-release to succeed. On workflow_dispatch
     # (redeploy an existing release): run independently since goreleaser +

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     permissions:
       contents: read
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 2,
+  "prHourlyLimit": 1,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

- Route GitHub Actions jobs across Namespace `2x4`, `4x8`, and `8x16` runner profiles instead of sending every Namespace job to `4x8`.
- Add CI workflow concurrency so newer PR pushes cancel superseded CI runs for the same branch.
- Tighten Renovate throughput with `prConcurrentLimit`, `branchConcurrentLimit`, and `prHourlyLimit` set to reduce dependency-update CI bursts.
- Add the new Namespace labels to actionlint configuration.

## Runner profile intent

- `namespace-profile-linux-amd64-2x4`: light metadata/network jobs such as Buf, site, release attestation/verification, and sandbox bootstrap/deploy.
- `namespace-profile-linux-amd64-4x8`: normal lint, unit test, build, and benchmark jobs.
- `namespace-profile-linux-amd64-8x16`: heavier integration, E2E, GoReleaser, and nightly soak jobs.

## Operational follow-up

Namespace profile caps are not repo-configurable. After this lands, create the `2x4` and `8x16` runner profiles in Namespace if they do not already exist, and ask Namespace support to set per-profile max concurrency so low-priority/heavy profiles cannot starve the Team-plan Linux pool.

## Verification

- `task lint:actions`
- `task lint:yaml`
- `jq empty .github/renovate.json renovate.json`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json renovate.json`
- `task pr-prep`

## Review note

Attempted local CodeRabbit review with `coderabbit review --agent -t uncommitted`, but the CLI does not recognize this jj workspace as a Git repository. Please rely on PR review automation for the external review pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure resource allocations and runner configurations across multiple workflows for improved build performance.
  * Modified Renovate dependency update concurrency and rate limits to reduce simultaneous pull requests.
  * Added concurrency control to CI workflows to cancel in-progress runs when new commits are pushed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->