### PR TITLE
chore(coderabbit,renovate): label-based skip for renovate PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,5 @@ reviews:
     enabled: true
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
-    ignore_usernames:
-      - "app/dependabot"
-      - "app/renovate"
-      - "app/github-actions"
+    labels:
+      - "!renovate-bot"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   ],
   "schedule": ["before 9am on monday"],
   "timezone": "America/New_York",
-  "labels": ["dependencies"],
+  "labels": ["dependencies", "renovate-bot"],
   "platformAutomerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Empirical testing in #4115 and #4118 confirmed that CodeRabbit's `ignore_usernames` does **not** clear the required `CodeRabbit` status check for bot-authored PRs under any username form (`renovate[bot]`, `app/renovate`). No commit status is posted at all — CR is silent for bot authors regardless of YAML config.

Switching to a label-based filter:

- **`.github/renovate.json`** — add `renovate-bot` to top-level labels. Renovate applies these on PR creation; existing open PRs need a backfill (handled separately).
- **`.coderabbit.yaml`** — replace `ignore_usernames` with `auto_review.labels: ["!renovate-bot"]`. The `!`-prefix is CR's negative-match syntax per the schema.

## Hypothesis under test

CR's label-based skip is a separate code path from username matching. It might:

1. **Post `CodeRabbit: success ("Review skipped")` on labeled PRs** → required-status-check clears, 49-PR backlog drains naturally on next rebase + backfill. ✅
2. **Be silent like ignore_usernames** → confirms the merge-gate problem cannot be solved by YAML config under any form. Bridge workflow (GH Action posting `@coderabbitai review` on bot PRs) becomes the only remaining path.

Either outcome is informative; we've systematically ruled out username-based approaches.

## Test plan

1. Merge.
2. Backfill `renovate-bot` label onto all 49 open renovate PRs via `gh pr edit`.
3. Wait for or trigger a rebase onto post-merge main.
4. Observe `CodeRabbit` commit status on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration to refine settings management.
  * Updated dependency update tool configuration to enhance PR organization and labeling for improved workflow tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->