### PR TITLE
feat(grpc): ListFocusPresence handler skeleton — validation + ownership (holomush-5b2j.7)

### DIFF
--- a/internal/grpc/list_focus_presence.go
+++ b/internal/grpc/list_focus_presence.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/auth"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// ListFocusPresence returns the set of Active sessions at the calling
+// session's location. See docs/superpowers/specs/2026-05-19-presence-snapshot-design.md
+// for the full design.
+//
+// Enumeration safety mirrors ListSessionStreams (internal/grpc/list_session_streams.go):
+// every ownership-validation failure collapses to SESSION_NOT_FOUND.
+//
+// This is the T5 skeleton: subsequent beads (5b2j.9 / T6, 5b2j.10 / T7) add
+// the expired/empty-location/focus dispatch + ABAC gate + store query + response.
+func (s *CoreServer) ListFocusPresence(ctx context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error) {
+	if req == nil {
+		return nil, oops.Code("INVALID_ARGUMENT").Errorf("request is required")
+	}
+	requestID := ""
+	if req.Meta != nil {
+		requestID = req.Meta.RequestId
+	}
+	slog.DebugContext(ctx, "list focus presence",
+		"request_id", requestID,
+		"session_id", req.SessionId)
+
+	if req.SessionId == "" {
+		return nil, oops.Code("INVALID_ARGUMENT").Errorf("session_id is required")
+	}
+
+	// Validate ownership — enumeration-safe collapse to SESSION_NOT_FOUND.
+	if _, err := auth.ValidateSessionOwnership(
+		ctx,
+		s.playerSessionRepo,
+		s.sessionStore,
+		req.GetPlayerSessionToken(),
+		req.GetSessionId(),
+	); err != nil {
+		slog.DebugContext(ctx, "list focus presence ownership validation failed",
+			"request_id", requestID, "session_id", req.SessionId, "error", err)
+		return nil, oops.Code("SESSION_NOT_FOUND").
+			With("session_id", req.SessionId).
+			Errorf("session not found")
+	}
+
+	// TODO(holomush-5b2j): T6 adds expired/empty-location/focus dispatch;
+	// T7 adds ABAC gate + store query + name resolution + response.
+	return nil, oops.Code("UNIMPLEMENTED").Errorf("not implemented")
+}

--- a/internal/grpc/list_focus_presence_test.go
+++ b/internal/grpc/list_focus_presence_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+func TestListFocusPresenceReturnsInvalidArgumentOnNilRequest(t *testing.T) {
+	// Defends against direct-call misuse (test or wrapping code passing nil).
+	// ConnectRPC's wire path never delivers a nil request, but a direct nil
+	// would panic on req.Meta access without this guard.
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, nil),
+		playerSessionRepo: newFakePlayerSessionRepo(ulid.ULID{}),
+	}
+	_, err := s.ListFocusPresence(context.Background(), nil)
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "INVALID_ARGUMENT", o.Code())
+}
+
+func TestListFocusPresenceReturnsInvalidArgumentOnEmptySessionID(t *testing.T) {
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, nil),
+		playerSessionRepo: newFakePlayerSessionRepo(ulid.ULID{}),
+	}
+	_, err := s.ListFocusPresence(context.Background(),
+		&corev1.ListFocusPresenceRequest{SessionId: ""})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "INVALID_ARGUMENT", o.Code())
+}
+
+func TestListFocusPresenceReturnsSessionNotFoundOnUnknownSession(t *testing.T) {
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, nil),
+		playerSessionRepo: newFakePlayerSessionRepo(ulid.ULID{}),
+	}
+	_, err := s.ListFocusPresence(context.Background(),
+		&corev1.ListFocusPresenceRequest{
+			SessionId:          "missing",
+			PlayerSessionToken: testPlayerSessionToken,
+		})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "SESSION_NOT_FOUND", o.Code())
+}
+
+func TestListFocusPresenceCollapsesOwnershipMismatchToNotFound(t *testing.T) {
+	// Caller's player_session_token resolves to a player session with a
+	// different ID than the target session's PlayerSessionID — ownership
+	// mismatch MUST collapse to SESSION_NOT_FOUND (enumeration-safe).
+	future := time.Now().Add(time.Hour)
+	foreignSess := &session.Info{
+		ID:              "foreign-sess",
+		PlayerSessionID: ulid.MustParse("01HYXPLAYER000000000000XYZ"),
+		ExpiresAt:       &future,
+	}
+	s := &CoreServer{
+		sessionStore: newTestSessionStore(t,
+			map[string]*session.Info{"foreign-sess": foreignSess}),
+		// newFakePlayerSessionRepo binds testPlayerSessionToken to the given
+		// player_session_id; passing a DIFFERENT ID below forces mismatch.
+		playerSessionRepo: newFakePlayerSessionRepo(
+			ulid.MustParse("01HYXPLAYER111111111111ABC"),
+		),
+	}
+	_, err := s.ListFocusPresence(context.Background(),
+		&corev1.ListFocusPresenceRequest{
+			SessionId:          "foreign-sess",
+			PlayerSessionToken: testPlayerSessionToken,
+		})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "SESSION_NOT_FOUND", o.Code())
+}


### PR DESCRIPTION
## Summary

T5 of the holomush-5b2j epic — the handler skeleton for `CoreService.ListFocusPresence`. Covers ONLY:

- Empty `session_id` → `INVALID_ARGUMENT`
- `auth.ValidateSessionOwnership` failures (bad token, unknown session, ownership mismatch) collapse to `SESSION_NOT_FOUND` — enumeration-safe per the `ListSessionStreams` pattern at `internal/grpc/list_session_streams.go:30-71`
- After ownership passes, returns `UNIMPLEMENTED` for now

Subsequent beads extend the handler:
- `holomush-5b2j.9` (T6) — expired session, empty-location, FocusMemberships dispatch
- `holomush-5b2j.10` (T7) — ABAC gate + `ListActiveByLocation` query + name resolution + response build

## Files

- `internal/grpc/list_focus_presence.go` — new handler (56 lines)
- `internal/grpc/list_focus_presence_test.go` — 3 unit tests (77 lines)

Test style mirrors `list_session_streams_test.go:97-130` (direct `&CoreServer{...}` construction, package-private test helpers via `package grpc`).

## Bead

`holomush-5b2j.7` (epic: `holomush-5b2j` [E-5B2J]).

## Verification

- [x] `task test -- ./internal/grpc/ -run TestListFocusPresence` — 3 tests pass in 2.2s
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

## Test plan

- [x] Local pr-prep green
- [ ] CI green
- [ ] Merge unlocks T6 (`holomush-5b2j.9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a backend endpoint skeleton with request validation, ownership checks, and call logging; currently returns unimplemented — no user-facing behavior changes yet.
* **Tests**
  * Added unit tests verifying nil/empty request handling, unknown-session responses, and collapsing ownership mismatches into a safe "session not found" outcome.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->