### PR TITLE
chore(renovate): batch non-major npm bumps into a single grouped PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,9 +31,10 @@
       "addLabels": ["docker"]
     },
     {
-      "description": "Auto-merge npm minor/patch (incl. lockfile-only updates)",
+      "description": "Batch all non-major npm/pnpm bumps into a single PR",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm dependencies",
       "automerge": true,
       "addLabels": ["npm"]
     },


### PR DESCRIPTION
## Summary

Adds `groupName: "npm dependencies"` to the existing npm minor/patch rule. Collapses all currently-individual non-major npm PRs (pg, jsdom, bits-ui, `@sveltejs/kit`, `@playwright/test`, svelte, protobufjs, tailwind-merge, etc.) into a single batched PR per renovate run.

## Trade-offs

| | Before (per-package) | After (single batch) |
|---|---|---|
| PR count | ~10+/week | ~1/week |
| CI runs | N concurrent | 1 |
| Failure isolation | One bump blocks itself | One bad bump blocks the batch |
| Recovery | Close one PR | Pin out one package via packageRules |

Worth it for an SSR webapp where the JS deps move together anyway and a flake in one rarely indicates a fundamental break.

Major bumps still per-PR (handled by the existing `matchUpdateTypes: ["major"]` rule, never grouped).

## Effective scope

Affects only the `npm` manager (covers npm/pnpm/yarn projects, which is what we use). gomod, github-actions, dockerfile, etc. retain their current per-rule grouping or per-package shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved npm dependency update automation to batch all non-major updates into single pull requests for streamlined review and management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->