### PR TITLE
ci: right-size CI runners based on empirical wall-time data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -164,7 +164,7 @@ jobs:
 
   integration:
     name: Integration Test
-    runs-on: namespace-profile-linux-amd64-8x16
+    runs-on: namespace-profile-linux-amd64-4x8
     needs: [test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -207,7 +207,7 @@ jobs:
 
   e2e:
     name: E2E Test
-    runs-on: namespace-profile-linux-amd64-8x16
+    runs-on: namespace-profile-linux-amd64-4x8
     needs: [test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -260,7 +260,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: namespace-profile-linux-amd64-4x8
+    runs-on: namespace-profile-linux-amd64-2x4
     needs: [lint, test, integration, e2e]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Surveyed integration + e2e job durations before/after #4119's 4x8 → 8x16 bump. Doubling cores didn't help — these workloads are I/O-bound on testcontainers (Postgres + NATS) and Docker compose, not CPU-bound.

## Wall-time data (May 19, 2026)

**Integration Test** (n=9 each):

| Runner | Mean | Range |
|---|---|---|
| 4x8 | **5m 24s** | 5m 09s – 5m 40s |
| 8x16 | **6m 25s** | 5m 45s – 7m 41s |

Doubling the cores made integration **~1 minute slower** and added variance. Containers spinning up + waiting on socket round-trips is the bottleneck.

**E2E Test** (smaller sample):

| Runner | Mean | Notes |
|---|---|---|
| 4x8 | ~3m 24s | n=6, narrow band |
| 8x16 | ~3m 5s | n=2, marginal at best |

Single core+gateway stack behind Playwright is the bottleneck; extra cores idle.

## Profile shifts

| Job | Before | After | Why |
|---|---|---|---|
| Lint | 4x8 | **2x4** | golangci-lint v2 saturates ~2 cores; ~1m runtime |
| Test | 4x8 | 4x8 (keep) | `-race` + `-p $(nproc)` genuinely parallel across packages |
| Integration | 8x16 | **4x8** | Containers + I/O dominate; extra cores idle |
| E2E | 8x16 | **4x8** | Single backend stack, no observable benefit at 8 cores |
| Build | 4x8 | **2x4** | Go single-binary + Vite; marginal beyond 2 cores |

Test is the only job that actually scales with cores. Everything else is either I/O-bound or under-utilizing.

## Out of scope

- `nightly-soak.yml` (8x16) — soak is also I/O-bound in principle, but the 30m sustained-load profile is different; profile separately if it ever pays off looking at.
- `release.yaml` `goreleaser` (8x16) — multi-target cross-compilation may actually use cores. Not touched.
- Bootstrap, buf, site, release sub-jobs already on 2x4 — no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI runner resource allocation across pipeline jobs to improve build efficiency and infrastructure utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->