### PR TITLE
fix(eventbus/audit): anchor AwaitDrained to stream LastSeq (closes holomush-1nl7)

### DIFF
--- a/internal/eventbus/audit/projection.go
+++ b/internal/eventbus/audit/projection.go
@@ -43,10 +43,15 @@ const persistTimeout = DefaultDrainTimeout
 // projection holds the durable pull consumer and the INSERT loop.
 type projection struct {
 	consumer jetstream.Consumer
-	pool     *pgxpool.Pool
-	cfg      Config
-	owners   *OwnerMap // may be nil: nil ⇒ host owns every subject
-	cc       jetstream.ConsumeContext
+	// js is retained solely so AwaitDrained (a test helper) can resolve
+	// the underlying stream to read its LastSeq. Avoids a cold-start race
+	// where the consumer's pending count momentarily reports 0 before it
+	// has synced with a just-published message.
+	js     jetstream.JetStream
+	pool   *pgxpool.Pool
+	cfg    Config
+	owners *OwnerMap // may be nil: nil ⇒ host owns every subject
+	cc     jetstream.ConsumeContext
 	// workerCtx is stored at start() time so persist() can derive its
 	// Exec context from it. Subsystem.Stop cancels workerCtx; any
 	// pending INSERT then cancels as well, so drain() cannot return
@@ -81,7 +86,7 @@ func newProjection(ctx context.Context, js jetstream.JetStream, pool *pgxpool.Po
 			With("consumer", cfg.ConsumerName).
 			Wrap(err)
 	}
-	return &projection{consumer: cons, pool: pool, cfg: cfg, owners: cfg.Owners}, nil
+	return &projection{consumer: cons, js: js, pool: pool, cfg: cfg, owners: cfg.Owners}, nil
 }
 
 // start attaches the Consume callback synchronously so Subsystem.Start
@@ -294,15 +299,40 @@ func (p *projection) drain(ctx context.Context) error {
 	}
 }
 
-// awaitDrained polls ConsumerInfo until NumPending and NumAckPending are
-// both zero, or until timeout. Uses time.After (not time.Sleep) because
-// forbidigo bans time.Sleep across the eventbus package tree.
+// awaitDrained polls ConsumerInfo until the consumer's AckFloor has
+// caught up to the stream's LastSeq AND there are no acks in flight, or
+// until timeout. Anchoring to the stream's LastSeq (rather than only the
+// consumer's NumPending) eliminates a cold-start race:
+//
+// When AwaitDrained is called immediately after a publish, the consumer's
+// view can briefly report NumPending==0 and NumAckPending==0 before it
+// has synced with the stream and observed the new message. A check that
+// only looks at consumer pending counts returns "drained" in that window,
+// causing tests to query the audit table before the INSERT has run
+// (observed flake: TestProjectionDrainsPublishedMessageToAuditTable
+// returning sql.ErrNoRows on projection_test.go:159, bd holomush-1nl7).
+//
+// Stream.Info() is authoritative for "is there a message?" — if a publish
+// has been ack'd by the server, LastSeq reflects it. We wait until the
+// consumer's AckFloor.Stream has advanced through that LastSeq, which
+// requires the consumer to have observed AND acknowledged the message.
+//
+// Uses time.After (not time.Sleep) because the forbidigo linter bans
+// time.Sleep across the eventbus package tree.
 func (p *projection) awaitDrained(t AwaitT, timeout time.Duration) {
 	t.Helper()
+	stream, err := p.js.Stream(context.Background(), eventbus.StreamName)
+	if err != nil {
+		t.Fatalf("audit projection awaitDrained: stream lookup failed: %v", err)
+		return
+	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		info, err := p.consumer.Info(context.Background())
-		if err == nil && info.NumPending == 0 && info.NumAckPending == 0 {
+		cInfo, cErr := p.consumer.Info(context.Background())
+		sInfo, sErr := stream.Info(context.Background())
+		if cErr == nil && sErr == nil &&
+			cInfo.NumAckPending == 0 &&
+			cInfo.AckFloor.Stream >= sInfo.State.LastSeq {
 			return
 		}
 		<-time.After(AwaitPollInterval)

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -2338,11 +2338,11 @@ func TestGuestSessionCarriesCharacterCreatedAt(t *testing.T) {
 	charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
 		Return([]*world.Character{
 			{
-				ID:        charID,
-				PlayerID:  playerID,
-				Name:      "Sapphire Diamond",
+				ID:         charID,
+				PlayerID:   playerID,
+				Name:       "Sapphire Diamond",
 				LocationID: &locID,
-				CreatedAt: charCreatedAt,
+				CreatedAt:  charCreatedAt,
 			},
 		}, nil)
 

--- a/internal/grpc/scope_floor_test.go
+++ b/internal/grpc/scope_floor_test.go
@@ -27,18 +27,26 @@ func TestStreamScopeFloor(t *testing.T) {
 		stream string
 		want   time.Time
 	}{
-		{"location current — non-guest", &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival},
-			"location:" + locID.String(), arrival},
-		{"location current — guest, arrival later than guest_created",
+		{
+			"location current — non-guest", &session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival},
+			"location:" + locID.String(), arrival,
+		},
+		{
+			"location current — guest, arrival later than guest_created",
 			&session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: arrival, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
-			"location:" + locID.String(), arrival},
-		{"location current — guest, guest_created later than arrival (shouldn't happen but MAX wins)",
+			"location:" + locID.String(), arrival,
+		},
+		{
+			"location current — guest, guest_created later than arrival (shouldn't happen but MAX wins)",
 			&session.Info{CharacterID: charID, LocationID: locID, LocationArrivedAt: time.Time{}, IsGuest: true, GuestCharacterCreatedAt: guestCreated},
-			"location:" + locID.String(), guestCreated},
-		{"scene member — non-guest, uses JoinedAt",
+			"location:" + locID.String(), guestCreated,
+		},
+		{
+			"scene member — non-guest, uses JoinedAt",
 			&session.Info{CharacterID: charID, FocusMemberships: []session.FocusMembership{
 				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: sceneJoin},
-			}}, "scene:" + sceneID.String() + ":ic", sceneJoin},
+			}}, "scene:" + sceneID.String() + ":ic", sceneJoin,
+		},
 		{"character own stream — no floor", &session.Info{CharacterID: charID}, "character:" + charID.String(), time.Time{}},
 	}
 	for _, tc := range cases {
@@ -85,8 +93,11 @@ func TestMaxStreamScopeFloor(t *testing.T) {
 		{"location + character — MAX is location", []string{locStream, charStream}, arrival},
 		{"location + scene — MAX is scene (later)", []string{locStream, sceneStream}, sceneJoin},
 		{"scene + location — order-independent — MAX is scene", []string{sceneStream, locStream}, sceneJoin},
-		{"unknown subjects fall through to zero — MAX with known still wins",
-			[]string{"global", "events.gid.location.unknown", locStream}, arrival},
+		{
+			"unknown subjects fall through to zero — MAX with known still wins",
+			[]string{"global", "events.gid.location.unknown", locStream},
+			arrival,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/plugin/emit_type_validator_test.go
+++ b/internal/plugin/emit_type_validator_test.go
@@ -20,13 +20,13 @@ func TestValidateEmitTypeSetEquality(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                     string
-		declared                 []string
-		registered               []string
-		wantMismatch             bool
-		wantDeclaredButUnreg     []string
-		wantRegisteredButUndecl  []string
-		assertMsg                string
+		name                    string
+		declared                []string
+		registered              []string
+		wantMismatch            bool
+		wantDeclaredButUnreg    []string
+		wantRegisteredButUndecl []string
+		assertMsg               string
 	}{
 		{
 			name:       "matching sets produce no mismatch",

--- a/internal/plugin/goplugin/manager_parity_test.go
+++ b/internal/plugin/goplugin/manager_parity_test.go
@@ -64,7 +64,8 @@ func TestManager_INVS5_ParityAcrossRuntimes(t *testing.T) {
 			luaHost := pluginlua.NewHostWithFunctions(hostfunc.New(nil))
 			t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
 
-			mgr, mgrErr := plugins.NewManager(pluginsDir,
+			mgr, mgrErr := plugins.NewManager(
+				pluginsDir,
 				plugins.WithLuaHost(luaHost),
 				plugins.WithVerbRegistry(core.NewVerbRegistry()),
 			)
@@ -99,7 +100,8 @@ func TestManager_INVS5_ParityAcrossRuntimes(t *testing.T) {
 			})
 			t.Cleanup(func() { _ = host.Close(context.Background()) })
 
-			mgr, mgrErr := plugins.NewManager(pluginsDir,
+			mgr, mgrErr := plugins.NewManager(
+				pluginsDir,
 				plugins.WithVerbRegistry(core.NewVerbRegistry()),
 			)
 			require.NoError(t, mgrErr)

--- a/internal/plugin/identity_registry_test.go
+++ b/internal/plugin/identity_registry_test.go
@@ -309,9 +309,9 @@ func (h *unloadStubHost) DeliverCommand(_ context.Context, _ string, _ pluginsdk
 func (h *unloadStubHost) QuerySessionStreams(_ context.Context, _ string, _ SessionStreamsRequest) ([]string, error) {
 	return nil, nil
 }
-func (h *unloadStubHost) Plugins() []string                              { return nil }
-func (h *unloadStubHost) PluginEmitRegistry(_ string) ([]string, bool)   { return nil, false }
-func (h *unloadStubHost) Close(_ context.Context) error                  { return nil }
+func (h *unloadStubHost) Plugins() []string                            { return nil }
+func (h *unloadStubHost) PluginEmitRegistry(_ string) ([]string, bool) { return nil, false }
+func (h *unloadStubHost) Close(_ context.Context) error                { return nil }
 
 // unloadStubPolicyInstaller satisfies PluginPolicyInstaller and lets tests
 // inject a configurable error from RemovePluginPolicies.

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -2055,7 +2055,8 @@ func TestManagerLoadAll_INVS5(t *testing.T) {
 			luaHost := pluginlua.NewHostWithFunctions(hostfunc.New(nil))
 			t.Cleanup(func() { _ = luaHost.Close(context.Background()) })
 
-			mgr, mgrErr := plugins.NewManager(pluginsDir,
+			mgr, mgrErr := plugins.NewManager(
+				pluginsDir,
 				plugins.WithLuaHost(luaHost),
 				plugins.WithVerbRegistry(core.NewVerbRegistry()),
 			)

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -2470,9 +2470,9 @@ lua-plugin:
 
 func TestManifest_HistoryScopeValidation(t *testing.T) {
 	tests := []struct {
-		name      string
-		yaml      string
-		wantErr   bool
+		name        string
+		yaml        string
+		wantErr     bool
 		errContains string
 	}{
 		{

--- a/internal/plugin/subscriber_actor_test.go
+++ b/internal/plugin/subscriber_actor_test.go
@@ -29,11 +29,12 @@ type actorCapturingHost struct {
 	called      bool
 }
 
-func (h *actorCapturingHost) Load(context.Context, *Manifest, string) error    { return nil }
-func (h *actorCapturingHost) Unload(context.Context, string) error              { return nil }
-func (h *actorCapturingHost) Plugins() []string                                 { return []string{"test-plugin"} }
-func (h *actorCapturingHost) PluginEmitRegistry(string) ([]string, bool)        { return nil, false }
-func (h *actorCapturingHost) Close(context.Context) error                       { return nil }
+func (h *actorCapturingHost) Load(context.Context, *Manifest, string) error { return nil }
+func (h *actorCapturingHost) Unload(context.Context, string) error          { return nil }
+func (h *actorCapturingHost) Plugins() []string { return []string{"test-plugin"} }
+
+func (h *actorCapturingHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
+func (h *actorCapturingHost) Close(context.Context) error                { return nil }
 
 func (h *actorCapturingHost) DeliverCommand(_ context.Context, _ string, _ pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error) {
 	return nil, nil

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -33,9 +33,10 @@ type subscriberHost struct {
 
 func (h *subscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
 func (h *subscriberHost) Unload(context.Context, string) error                  { return nil }
-func (h *subscriberHost) Plugins() []string                                     { return []string{"test"} }
-func (h *subscriberHost) PluginEmitRegistry(string) ([]string, bool)            { return nil, false }
-func (h *subscriberHost) Close(context.Context) error                           { return nil }
+func (h *subscriberHost) Plugins() []string { return []string{"test"} }
+
+func (h *subscriberHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
+func (h *subscriberHost) Close(context.Context) error                { return nil }
 
 func (h *subscriberHost) DeliverCommand(_ context.Context, _ string, _ pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error) {
 	return nil, nil
@@ -531,9 +532,10 @@ type slowSubscriberHost struct {
 
 func (h *slowSubscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
 func (h *slowSubscriberHost) Unload(context.Context, string) error                  { return nil }
-func (h *slowSubscriberHost) Plugins() []string                                     { return []string{"test"} }
-func (h *slowSubscriberHost) PluginEmitRegistry(string) ([]string, bool)            { return nil, false }
-func (h *slowSubscriberHost) Close(context.Context) error                           { return nil }
+func (h *slowSubscriberHost) Plugins() []string { return []string{"test"} }
+
+func (h *slowSubscriberHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
+func (h *slowSubscriberHost) Close(context.Context) error                { return nil }
 
 func (h *slowSubscriberHost) DeliverCommand(_ context.Context, _ string, _ pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error) {
 	return nil, nil

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -152,17 +152,17 @@ type Info struct {
 	// queries (invariant I-PRIV-2). Zero for non-guest sessions.
 	GuestCharacterCreatedAt time.Time
 	IsGuest                 bool
-	Status          Status
-	GridPresent     bool
-	CommandHistory  []string
-	TTLSeconds      int
-	MaxHistory      int
-	DetachedAt      *time.Time
-	ExpiresAt       *time.Time
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	LastPaged       string
-	LastWhispered   string
+	Status                  Status
+	GridPresent             bool
+	CommandHistory          []string
+	TTLSeconds              int
+	MaxHistory              int
+	DetachedAt              *time.Time
+	ExpiresAt               *time.Time
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	LastPaged               string
+	LastWhispered           string
 
 	// FocusMemberships is the set of focused contexts this session is
 	// actively participating in. Mutated only via FocusCoordinator

--- a/pkg/plugin/audit_test.go
+++ b/pkg/plugin/audit_test.go
@@ -32,7 +32,7 @@ type fakeJSMsg struct {
 
 func (f *fakeJSMsg) Headers() nats.Header { return f.headers }
 func (f *fakeJSMsg) Data() []byte         { return f.data }
-func (f *fakeJSMsg) Subject() string { panic("not used in StoreFromMessage tests") }
+func (f *fakeJSMsg) Subject() string      { panic("not used in StoreFromMessage tests") }
 
 func (f *fakeJSMsg) Reply() string { panic("not used in StoreFromMessage tests") }
 

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/oklog/ulid/v2"
-	"github.com/samber/oops"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/samber/oops"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 

--- a/test/integration/eventbus_e2e/rendering_completeness_test.go
+++ b/test/integration/eventbus_e2e/rendering_completeness_test.go
@@ -70,7 +70,8 @@ var _ = Describe("Rendering completeness", func() {
 		hostSub.AwaitDrained(suiteT, 10*time.Second)
 		Eventually(func() bool {
 			var count int
-			qerr := pool.QueryRow(ctx,
+			qerr := pool.QueryRow(
+				ctx,
 				"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1",
 				subjectLike,
 			).Scan(&count)
@@ -82,7 +83,8 @@ var _ = Describe("Rendering completeness", func() {
 		// enforces NOT NULL, but we assert here so a regression that drops the
 		// constraint or writes 'null' JSONB is caught.
 		var nullCount int
-		Expect(pool.QueryRow(ctx,
+		Expect(pool.QueryRow(
+			ctx,
 			"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1 AND rendering IS NULL",
 			subjectLike,
 		).Scan(&nullCount)).To(Succeed())
@@ -92,14 +94,16 @@ var _ = Describe("Rendering completeness", func() {
 		// publisher. Spot-check the first row's source_plugin, then verify
 		// every host-builtin row reports source_plugin="builtin".
 		var sourcePlugin string
-		Expect(pool.QueryRow(ctx,
+		Expect(pool.QueryRow(
+			ctx,
 			"SELECT rendering->>'source_plugin' FROM events_audit WHERE subject LIKE $1 ORDER BY js_seq LIMIT 1",
 			subjectLike,
 		).Scan(&sourcePlugin)).To(Succeed())
 		Expect(sourcePlugin).To(Equal("builtin"))
 
 		var nonBuiltinCount int
-		Expect(pool.QueryRow(ctx,
+		Expect(pool.QueryRow(
+			ctx,
 			"SELECT COUNT(*) FROM events_audit WHERE subject LIKE $1 AND rendering->>'source_plugin' <> 'builtin'",
 			subjectLike,
 		).Scan(&nonBuiltinCount)).To(Succeed())


### PR DESCRIPTION
## Summary

`TestProjectionDrainsPublishedMessageToAuditTable` was flaking on PR runs today (observed on #4088 and #4130; main itself passes) with:

```
projection_test.go:159: Error: no rows in result set
Test: TestProjectionDrainsPublishedMessageToAuditTable
```

The test publishes one message, calls `sub.AwaitDrained(t, 3s)`, and queries `events_audit` expecting one row. The helper returned before the INSERT had run.

## Root cause

`awaitDrained` polled only `ConsumerInfo` and returned when `NumPending==0 && NumAckPending==0`. When called immediately after `publishTestMessage`, the consumer's view briefly reports `0/0` *before* it has synced with the stream and observed the just-published message — a false-positive "drained". `nats-server` v2.14.0 (landed #4126 today) appears to have widened that pre-sync window enough to surface the latent race.

## Fix

Anchor the wait to the stream's `LastSeq`, which is authoritative for "is there a message?" — if a publish has been ack'd by the server, `LastSeq` reflects it. New condition:

```go
cInfo.NumAckPending == 0 && cInfo.AckFloor.Stream >= sInfo.State.LastSeq
```

This requires the consumer to have observed AND acknowledged through the stream's last sequence. Two cases handled:

- **Cold-start** (publish then await): `LastSeq=1`, `AckFloor.Stream=0` initially → keeps waiting → after deliver+ack → `AckFloor.Stream=1` → drained.
- **Durable-resume** (no new publishes; `TestProjectionResumesAfterRestart`): `LastSeq=N`, `AckFloor.Stream=N` from prior session → returns on first poll, as before.

## Verification

Locally:

- `task fmt -- ./internal/eventbus/audit/` clean
- `task test -- ./internal/eventbus/audit/...` — 117 tests pass

Integration test verification defers to CI (`task test:int` requires Docker).

## Why not just rerun the failing CI?

Per CLAUDE.md memory `feedback_no_flakes_investigate`: don't `gh run rerun` flaky tests. Name the race, fix it. This commit names it and fixes it.

## bd reference

Closes `holomush-1nl7` (P1 bug, ci-flake + eventbus + audit labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in event processing that could cause test flakiness.

* **Tests**
  * Improved test infrastructure and formatting across multiple test files for better maintainability.

* **Style**
  * Code formatting and organization improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->