### PR TITLE
perf(test): speed up crypto integration suite 4x via shared PG container + bulk seed

### DIFF
--- a/internal/testsupport/holomushtest/server.go
+++ b/internal/testsupport/holomushtest/server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
-	postgrestc "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
@@ -44,9 +43,9 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
-	"github.com/holomush/holomush/internal/store"
 	adminv1 "github.com/holomush/holomush/pkg/proto/holomush/admin/v1"
 	"github.com/holomush/holomush/pkg/proto/holomush/admin/v1/adminv1connect"
+	"github.com/holomush/holomush/test/testutil"
 )
 
 // PlayerCreds holds the credentials seeded for a test operator.
@@ -215,8 +214,10 @@ func StartEmbeddedNATS(t *testing.T) string {
 	return bus.Conn.ConnectedUrl()
 }
 
-// StartPG starts a dedicated Postgres testcontainer with migrations applied
-// and returns an open pgxpool.Pool. Cleanup is registered on t.Cleanup.
+// StartPG returns a pgxpool.Pool bound to a fresh per-test database on the
+// process-wide shared Postgres testcontainer (migrations already applied via
+// the template DB). The container outlives any single test; per-test
+// databases are dropped on t.Cleanup, and the pool is closed on t.Cleanup.
 func StartPG(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	return startPGPool(t)
@@ -470,30 +471,16 @@ func buildServer(t *testing.T, cfg ServerConfig) *Server {
 	}
 }
 
-// startPGPool creates a testcontainer-backed pgxpool.Pool with migrations applied.
+// startPGPool opens a pgxpool.Pool against a fresh per-test database
+// template-cloned from testutil.SharedPostgres. The Postgres container is
+// process-scope (started once per test binary); the database itself is
+// dropped on t.Cleanup, and the pool is closed on t.Cleanup.
 func startPGPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	ctx := context.Background()
 
-	pgContainer, err := postgrestc.Run(
-		ctx,
-		"postgres:18-alpine",
-		postgrestc.WithDatabase("holomush_e2e"),
-		postgrestc.WithUsername("test"),
-		postgrestc.WithPassword("test"),
-		postgrestc.BasicWaitStrategies(),
-	)
-	require.NoError(t, err, "holomushtest.startPGPool: start postgres container")
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err, "holomushtest.startPGPool: get connection string")
-
-	migrator, err := store.NewMigrator(connStr)
-	require.NoError(t, err, "holomushtest.startPGPool: create migrator")
-	require.NoError(t, migrator.Up(), "holomushtest.startPGPool: run migrations")
-	migrator.Close() //nolint:errcheck // best-effort cleanup
-
-	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) }) //nolint:errcheck // test cleanup
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
 
 	pool, err := pgxpool.New(ctx, connStr)
 	require.NoError(t, err, "holomushtest.startPGPool: open pool")

--- a/test/integration/crypto/harness_impl_test.go
+++ b/test/integration/crypto/harness_impl_test.go
@@ -177,19 +177,32 @@ func (h *Harness) seedDEKAndEvents(t *testing.T, cfg HarnessConfig) {
 		Expect(err).NotTo(HaveOccurred(), "seedDEKAndEvents: GetOrCreate DEK")
 	}
 
-	// Seed EventCount plaintext events_audit rows. The rows use a fixed
-	// subject matching HarnessConfig.EventSubject. For fixture purposes
-	// the envelope is a minimal identity-codec JSON payload; E2E specs
-	// exercise Phase 3 cold re-encryption which transforms these rows.
-	for i := 0; i < cfg.EventCount; i++ {
-		payload := []byte(`{"type":"test","seq":` + itoa(i) + `}`)
-		_, err := h.DB.Exec(ctx,
-			`INSERT INTO events_audit
-			   (id, subject, type, timestamp, actor_kind, envelope, schema_ver, codec, js_seq, rendering)
-			 VALUES (gen_random_bytes(16), $1, 'test.event', now(), 'system', $2, 1, 'identity', $3, '{}'::jsonb)`,
-			cfg.EventSubject, payload, int64(i+1))
-		Expect(err).NotTo(HaveOccurred(), "seedDEKAndEvents: insert event %d", i)
-	}
+	// Seed EventCount plaintext events_audit rows in a single round-trip.
+	// The rows use a fixed subject matching HarnessConfig.EventSubject. For
+	// fixture purposes the envelope is a minimal identity-codec JSON payload
+	// (`{"type":"test","seq":N}`, N starting at 0); E2E specs exercise Phase 3
+	// cold re-encryption which transforms these rows. js_seq is 1-indexed.
+	//
+	// Note: now() evaluates once per statement, so all seeded rows share one
+	// timestamp. Specs that need a deterministic order over the seed rows
+	// MUST order by js_seq, not timestamp.
+	_, err := h.DB.Exec(ctx, `
+		INSERT INTO events_audit
+		    (id, subject, type, timestamp, actor_kind, envelope, schema_ver, codec, js_seq, rendering)
+		SELECT
+		    gen_random_bytes(16),
+		    $1,
+		    'test.event',
+		    now(),
+		    'system',
+		    convert_to('{"type":"test","seq":' || (g.i - 1)::text || '}', 'UTF8'),
+		    1,
+		    'identity',
+		    g.i,
+		    '{}'::jsonb
+		FROM generate_series(1, $2::int) AS g(i)`,
+		cfg.EventSubject, cfg.EventCount)
+	Expect(err).NotTo(HaveOccurred(), "seedDEKAndEvents: bulk insert events")
 }
 
 // --- Assertion helpers ---
@@ -322,26 +335,6 @@ func (h *Harness) findCheckpointByID(rid dek.RequestID) (dek.Checkpoint, error) 
 // repo is a convenience accessor for the primary's CheckpointRepo.
 func (h *Harness) repo() *dek.CheckpointRepo {
 	return h.Primary.GetCheckpointRepo()
-}
-
-// itoa converts an int to its decimal string representation without importing fmt.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	buf := make([]byte, 0, 20)
-	for n > 0 {
-		buf = append([]byte{byte('0' + n%10)}, buf...)
-		n /= 10
-	}
-	if neg {
-		buf = append([]byte{'-'}, buf...)
-	}
-	return string(buf)
 }
 
 // --- Status/list helpers (Task 48) ---


### PR DESCRIPTION
## Summary

`test/integration/crypto` drops from **~2m43s → ~50s** (4× speedup) by reusing two existing patterns:

1. **`internal/testsupport/holomushtest/server.go`** — `startPGPool` now uses `testutil.SharedPostgres` + `testutil.FreshDatabase` (singleton container + template-clone per test DB). Same pattern `internal/testsupport/privacytest/privacy_harness.go:101-102` already uses. Container start + migrations now happen once per process instead of once per spec (47 specs × full bootstrap → 1 bootstrap).
2. **`test/integration/crypto/harness_impl_test.go`** — `seedDEKAndEvents` replaces a 1000-iteration `INSERT` loop with one `INSERT … SELECT FROM generate_series`. Drops the now-unused `itoa` helper.

Docstrings on `StartPG` / `startPGPool` updated to reflect the new lifecycle (template-cloned DB, process-scope container). Comment in `seedDEKAndEvents` notes that `now()` evaluates once per statement so specs needing deterministic ordering MUST order by `js_seq`.

Closes holomush-wgrj.

## Test plan

- [x] `task pr-prep` — green (7892 unit tests + 1584 integration tests + E2E pass)
- [x] `test/integration/crypto` measured: **49.67s** on rebased tip (was ~163s)
- [x] All 47 crypto Ginkgo `It` blocks still pass
- [x] No other callers of `holomushtest.StartPG` outside crypto suite (verified via probe)
- [x] Adversarial code review: READY, 2 low-severity non-blocking findings addressed (docstring rot + timestamp-ordering note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized integration test database provisioning with shared template-based approach for improved efficiency
  * Enhanced test data seeding performance through bulk database operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->