### PR TITLE
feat(grpc): ListFocusPresence — expired/focus/empty-location dispatch (holomush-5b2j.9)

### DIFF
--- a/internal/grpc/list_focus_presence.go
+++ b/internal/grpc/list_focus_presence.go
@@ -53,7 +53,41 @@ func (s *CoreServer) ListFocusPresence(ctx context.Context, req *corev1.ListFocu
 			Errorf("session not found")
 	}
 
-	// TODO(holomush-5b2j): T6 adds expired/empty-location/focus dispatch;
-	// T7 adds ABAC gate + store query + name resolution + response.
-	return nil, oops.Code("UNIMPLEMENTED").Errorf("not implemented")
+	// Re-Get the session info (ValidateSessionOwnership returned the player
+	// session, not the user session). Mirrors ListSessionStreams pattern.
+	info, err := s.sessionStore.Get(ctx, req.SessionId)
+	if err != nil {
+		if oopsErr, ok := oops.AsOops(err); ok && oopsErr.Code() == "SESSION_NOT_FOUND" {
+			return nil, oops.Code("SESSION_NOT_FOUND").
+				With("session_id", req.SessionId).Errorf("session not found")
+		}
+		return nil, oops.Code("INTERNAL").Wrap(err)
+	}
+	if info.IsExpired() {
+		return nil, oops.Code("SESSION_EXPIRED").
+			With("session_id", req.SessionId).Errorf("session expired")
+	}
+
+	// Scene-focused sessions are out of 5b2j scope (spec D-2). Return
+	// UNIMPLEMENTED so the gap is loud, not silently degraded to a
+	// location-list fallback.
+	if len(info.FocusMemberships) > 0 {
+		return nil, oops.Code("UNIMPLEMENTED").
+			With("session_id", req.SessionId).
+			With("focus_memberships", len(info.FocusMemberships)).
+			Errorf("scene-focused presence not yet implemented")
+	}
+
+	// Session has no location yet (e.g., between create and SelectCharacter).
+	// Not an error — return an empty list under LOCATION context.
+	if info.LocationID.IsZero() {
+		return &corev1.ListFocusPresenceResponse{
+			Meta:    responseMeta(requestID),
+			Context: corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION,
+			Entries: []*corev1.PresenceEntry{},
+		}, nil
+	}
+
+	// TODO(holomush-5b2j): T7 (5b2j.10) adds ABAC gate + store query + name resolution.
+	return nil, oops.Code("UNIMPLEMENTED").Errorf("ABAC + resolver not yet wired")
 }

--- a/internal/grpc/list_focus_presence_test.go
+++ b/internal/grpc/list_focus_presence_test.go
@@ -63,19 +63,19 @@ func TestListFocusPresenceReturnsSessionNotFoundOnUnknownSession(t *testing.T) {
 
 func TestListFocusPresenceCollapsesOwnershipMismatchToNotFound(t *testing.T) {
 	// Caller's player_session_token resolves to a player session with a
-	// different ID than the target session's PlayerSessionID — ownership
+	// different PlayerID than the target session's PlayerID — ownership
 	// mismatch MUST collapse to SESSION_NOT_FOUND (enumeration-safe).
 	future := time.Now().Add(time.Hour)
 	foreignSess := &session.Info{
-		ID:              "foreign-sess",
-		PlayerSessionID: ulid.MustParse("01HYXPLAYER000000000000XYZ"),
-		ExpiresAt:       &future,
+		ID:        "foreign-sess",
+		PlayerID:  ulid.MustParse("01HYXPLAYER000000000000XYZ"),
+		ExpiresAt: &future,
 	}
 	s := &CoreServer{
 		sessionStore: newTestSessionStore(t,
 			map[string]*session.Info{"foreign-sess": foreignSess}),
 		// newFakePlayerSessionRepo binds testPlayerSessionToken to the given
-		// player_session_id; passing a DIFFERENT ID below forces mismatch.
+		// player_id; passing a DIFFERENT ID below forces mismatch.
 		playerSessionRepo: newFakePlayerSessionRepo(
 			ulid.MustParse("01HYXPLAYER111111111111ABC"),
 		),
@@ -89,4 +89,84 @@ func TestListFocusPresenceCollapsesOwnershipMismatchToNotFound(t *testing.T) {
 	o, ok := oops.AsOops(err)
 	require.True(t, ok)
 	assert.Equal(t, "SESSION_NOT_FOUND", o.Code())
+}
+
+// ownedPlayerID is the player ID that newFakePlayerSessionRepo will return
+// when called with this value, and the session.Info.PlayerID that mkOwnedSession
+// seeds — ensuring ownership validation succeeds.
+var ownedPlayerID = ulid.MustParse("01HYXOWN0000000000000000PS")
+
+// mkOwnedSession returns a session.Info whose PlayerID matches ownedPlayerID,
+// so that newFakePlayerSessionRepo(ownedPlayerID) passes ownership validation.
+func mkOwnedSession(id string, opts ...func(*session.Info)) *session.Info {
+	future := time.Now().Add(time.Hour)
+	s := &session.Info{
+		ID:        id,
+		Status:    session.StatusActive,
+		ExpiresAt: &future,
+		PlayerID:  ownedPlayerID,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func TestListFocusPresenceReturnsSessionExpiredForExpiredSession(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	sess := mkOwnedSession("sess-expired")
+	sess.ExpiresAt = &past
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, map[string]*session.Info{"sess-expired": sess}),
+		playerSessionRepo: newFakePlayerSessionRepo(ownedPlayerID),
+	}
+	_, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId:          "sess-expired",
+		PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "SESSION_EXPIRED", o.Code())
+}
+
+func TestListFocusPresenceReturnsUnimplementedForSceneFocus(t *testing.T) {
+	sess := mkOwnedSession("sess-1", func(s *session.Info) {
+		s.CharacterID = ulid.MustParse("01HYXCHAR0000000000000000C")
+		s.LocationID = ulid.MustParse("01HYXLOC00000000000000000L")
+		s.FocusMemberships = []session.FocusMembership{
+			{Kind: session.FocusKindScene, TargetID: ulid.MustParse("01HYXSCENE0000000000000000")},
+		}
+	})
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, map[string]*session.Info{"sess-1": sess}),
+		playerSessionRepo: newFakePlayerSessionRepo(ownedPlayerID),
+	}
+	_, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId:          "sess-1",
+		PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "UNIMPLEMENTED", o.Code())
+}
+
+func TestListFocusPresenceReturnsEmptyEntriesWhenLocationUnset(t *testing.T) {
+	sess := mkOwnedSession("sess-1", func(s *session.Info) {
+		s.CharacterID = ulid.MustParse("01HYXCHAR0000000000000000C")
+		// LocationID intentionally zero
+	})
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, map[string]*session.Info{"sess-1": sess}),
+		playerSessionRepo: newFakePlayerSessionRepo(ownedPlayerID),
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId:          "sess-1",
+		PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION, resp.Context)
+	assert.Equal(t, "", resp.ContextId)
+	assert.Empty(t, resp.Entries)
 }


### PR DESCRIPTION
## Summary

T6 of the holomush-5b2j epic — extends the `ListFocusPresence` handler with three guards between ownership validation (T5) and the still-pending ABAC gate (T7).

Guards added, in order:

1. `info.IsExpired()` → `SESSION_EXPIRED`
2. `len(info.FocusMemberships) > 0` → `UNIMPLEMENTED` (loud signal that the scene resolver is deferred per spec D-2)
3. `info.LocationID.IsZero()` → return `PRESENCE_CONTEXT_LOCATION` with empty `entries` (not an error — session hasn't selected a character yet)

After the three guards, the handler still returns `UNIMPLEMENTED` — T7 (`holomush-5b2j.10`) adds the ABAC gate, `ListActiveByLocation` query, name resolution, and the real response.

## Plan deviations (caught + fixed by the implementer)

- **`PlayerSessionID` → `PlayerID` in the test helper.** Plan's `mkOwnedSession` set `PlayerSessionID` on `session.Info`, but `auth.ValidateSessionOwnership` (`internal/auth/session_ownership.go:75`) compares `info.PlayerID` against the player session's `PlayerID`. Corrected.
- **Invalid ULID literals.** Plan's example ULIDs were 27 chars (one off from the 26-char Crockford Base32 spec). Fixed to valid 26-char ULIDs.

## Files

- `internal/grpc/list_focus_presence.go` — added the 3 guards block + helper var/funcs in handler
- `internal/grpc/list_focus_presence_test.go` — added `mkOwnedSession` helper + 3 new tests

## Bead

`holomush-5b2j.9` (epic: `holomush-5b2j` [E-5B2J]). Unblocks T7 (`5b2j.10`).

## Verification

- [x] `task test -- ./internal/grpc/ -run TestListFocusPresence` — 7 tests pass (4 from T5 + 3 new) in 1.6s
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

## Test plan

- [x] Local pr-prep green
- [ ] CI green
- [ ] Merge unlocks T7 (`holomush-5b2j.10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for session-related requests with better detection and reporting of expired sessions.
  * Enhanced session ownership validation with more specific and accurate error responses.
  * Added comprehensive state checks to validate location information and session data integrity.
  * Returns more precise error states instead of generic responses, improving reliability and debugging capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->