### PR TITLE
feat(world): add GetNamesByIDs batch lookup to CharacterRepository (holomush-5b2j.3)

### DIFF
--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -65,6 +65,10 @@ func (m *mockCharacterRepository) IsOwnedByPlayer(_ context.Context, _, _ ulid.U
 	return false, errors.New("not implemented")
 }
 
+func (m *mockCharacterRepository) GetNamesByIDs(_ context.Context, _ []ulid.ULID) (map[ulid.ULID]string, error) {
+	return nil, errors.New("not implemented")
+}
+
 func TestCharacterProviderContract(t *testing.T) {
 	assertProviderContract(t, NewCharacterProvider(&mockCharacterRepository{}, nil))
 }

--- a/internal/world/postgres/character_repo.go
+++ b/internal/world/postgres/character_repo.go
@@ -206,5 +206,40 @@ func scanCharacters(rows pgx.Rows) ([]*world.Character, error) {
 	return characters, nil
 }
 
+// GetNamesByIDs returns a map[id]name for the given character IDs.
+// Missing IDs are absent from the result (not an error).
+func (r *CharacterRepository) GetNamesByIDs(ctx context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	if len(ids) == 0 {
+		return map[ulid.ULID]string{}, nil
+	}
+	strs := make([]string, len(ids))
+	for i, id := range ids {
+		strs[i] = id.String()
+	}
+	rows, err := r.pool.Query(ctx, `SELECT id, name FROM characters WHERE id = ANY($1)`, strs)
+	if err != nil {
+		return nil, oops.With("operation", "get_names_by_ids").
+			With("count", len(ids)).Wrap(err)
+	}
+	defer rows.Close()
+
+	out := make(map[ulid.ULID]string, len(ids))
+	for rows.Next() {
+		var idStr, name string
+		if err := rows.Scan(&idStr, &name); err != nil {
+			return nil, oops.With("operation", "scan_get_names").Wrap(err)
+		}
+		id, perr := ulid.Parse(idStr)
+		if perr != nil {
+			return nil, oops.With("operation", "parse_ulid").With("id_str", idStr).Wrap(perr)
+		}
+		out[id] = name
+	}
+	if err := rows.Err(); err != nil {
+		return nil, oops.With("operation", "rows_err_get_names").Wrap(err)
+	}
+	return out, nil
+}
+
 // Compile-time interface check.
 var _ world.CharacterRepository = (*CharacterRepository)(nil)

--- a/internal/world/postgres/character_repo_test.go
+++ b/internal/world/postgres/character_repo_test.go
@@ -443,6 +443,57 @@ func TestCharacterRepository_IsOwnedByPlayer(t *testing.T) {
 	})
 }
 
+func TestCharacterRepository_GetNamesByIDs(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewCharacterRepository(testPool)
+
+	playerID := createTestPlayer(ctx, t)
+
+	char1 := &world.Character{
+		ID:        ulid.Make(),
+		PlayerID:  playerID,
+		Name:      "alice",
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+	char2 := &world.Character{
+		ID:        ulid.Make(),
+		PlayerID:  playerID,
+		Name:      "bob",
+		CreatedAt: time.Now().UTC().Truncate(time.Microsecond),
+	}
+	require.NoError(t, repo.Create(ctx, char1))
+	require.NoError(t, repo.Create(ctx, char2))
+
+	t.Cleanup(func() {
+		_ = repo.Delete(ctx, char1.ID)
+		_ = repo.Delete(ctx, char2.ID)
+	})
+
+	t.Run("returns names for present IDs, omits missing IDs", func(t *testing.T) {
+		missingID := ulid.Make()
+		names, err := repo.GetNamesByIDs(ctx, []ulid.ULID{char1.ID, char2.ID, missingID})
+		require.NoError(t, err)
+		assert.Equal(t, "alice", names[char1.ID])
+		assert.Equal(t, "bob", names[char2.ID])
+		_, present := names[missingID]
+		assert.False(t, present, "missing id MUST NOT be in result map")
+	})
+
+	t.Run("returns empty map for nil input", func(t *testing.T) {
+		empty, err := repo.GetNamesByIDs(ctx, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, empty, "empty input MUST return non-nil empty map, not nil")
+		assert.Empty(t, empty)
+	})
+
+	t.Run("returns empty map for empty slice", func(t *testing.T) {
+		empty, err := repo.GetNamesByIDs(ctx, []ulid.ULID{})
+		require.NoError(t, err)
+		assert.NotNil(t, empty, "empty input MUST return non-nil empty map, not nil")
+		assert.Empty(t, empty)
+	})
+}
+
 func TestCharacterRepository_UpdateLocation(t *testing.T) {
 	ctx := context.Background()
 	repo := postgres.NewCharacterRepository(testPool)

--- a/internal/world/repository.go
+++ b/internal/world/repository.go
@@ -163,4 +163,9 @@ type CharacterRepository interface {
 	// IsOwnedByPlayer checks if a character is owned by a specific player.
 	// Returns false (not an error) if the character does not exist.
 	IsOwnedByPlayer(ctx context.Context, characterID, playerID ulid.ULID) (bool, error)
+
+	// GetNamesByIDs returns a map[characterID]name for the given IDs.
+	// Missing IDs are omitted from the result map (not an error).
+	// Returns empty map (not nil error) for an empty input slice.
+	GetNamesByIDs(ctx context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error)
 }

--- a/internal/world/worldtest/mock_CharacterRepository.go
+++ b/internal/world/worldtest/mock_CharacterRepository.go
@@ -240,6 +240,65 @@ func (_c *MockCharacterRepository_GetByLocation_Call) RunAndReturn(run func(cont
 	return _c
 }
 
+// GetNamesByIDs provides a mock function with given fields: ctx, ids
+func (_m *MockCharacterRepository) GetNamesByIDs(ctx context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	ret := _m.Called(ctx, ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNamesByIDs")
+	}
+
+	var r0 map[ulid.ULID]string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []ulid.ULID) (map[ulid.ULID]string, error)); ok {
+		return rf(ctx, ids)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []ulid.ULID) map[ulid.ULID]string); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[ulid.ULID]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []ulid.ULID) error); ok {
+		r1 = rf(ctx, ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCharacterRepository_GetNamesByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNamesByIDs'
+type MockCharacterRepository_GetNamesByIDs_Call struct {
+	*mock.Call
+}
+
+// GetNamesByIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ids []ulid.ULID
+func (_e *MockCharacterRepository_Expecter) GetNamesByIDs(ctx interface{}, ids interface{}) *MockCharacterRepository_GetNamesByIDs_Call {
+	return &MockCharacterRepository_GetNamesByIDs_Call{Call: _e.mock.On("GetNamesByIDs", ctx, ids)}
+}
+
+func (_c *MockCharacterRepository_GetNamesByIDs_Call) Run(run func(ctx context.Context, ids []ulid.ULID)) *MockCharacterRepository_GetNamesByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]ulid.ULID))
+	})
+	return _c
+}
+
+func (_c *MockCharacterRepository_GetNamesByIDs_Call) Return(_a0 map[ulid.ULID]string, _a1 error) *MockCharacterRepository_GetNamesByIDs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCharacterRepository_GetNamesByIDs_Call) RunAndReturn(run func(context.Context, []ulid.ULID) (map[ulid.ULID]string, error)) *MockCharacterRepository_GetNamesByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsOwnedByPlayer provides a mock function with given fields: ctx, characterID, playerID
 func (_m *MockCharacterRepository) IsOwnedByPlayer(ctx context.Context, characterID ulid.ULID, playerID ulid.ULID) (bool, error) {
 	ret := _m.Called(ctx, characterID, playerID)


### PR DESCRIPTION
## Summary

T3 of the holomush-5b2j epic — adds a batched `GetNamesByIDs(ctx, []ulid.ULID) (map[ulid.ULID]string, error)` method to `world.CharacterRepository`. This is the storage primitive that T4 (`5b2j.6`) wraps with `characterNameResolver`, which T7 (`5b2j.10`) uses for batch name resolution inside the presence handler.

Semantics:

- Missing IDs are absent from the returned map (not an error).
- Empty input → empty map with no DB query.
- Single Pg query: `SELECT id, name FROM characters WHERE id = ANY($1)`.

## Files

- `internal/world/repository.go` — `GetNamesByIDs` added to interface
- `internal/world/postgres/character_repo.go` — Pg implementation with proper `oops` wrapping
- `internal/world/postgres/character_repo_test.go` — integration test (3 sub-tests: present + missing IDs, nil input, empty slice)
- `internal/world/worldtest/mock_CharacterRepository.go` — regenerated via mockery
- `internal/access/policy/attribute/character_test.go` — added a stub method to the hand-written test mock so it still satisfies the interface (returns `"not implemented"` — the ABAC tests don't exercise name lookup)

## Bead

`holomush-5b2j.3` (epic: `holomush-5b2j` [E-5B2J]). Unblocks T4 (`5b2j.6`).

## Verification

- [x] `task test:int -- ./internal/world/postgres/ -run TestCharacterRepository_GetNamesByIDs` — 3 sub-tests pass
- [x] `task test -- ./internal/world/...` — 959 tests pass
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk character name lookup allowing efficient retrieval of names for multiple character IDs in a single call; missing IDs are omitted and empty inputs return an empty map.

* **Tests**
  * Added comprehensive tests (unit and integration) covering successful lookups, missing IDs, and empty/nil input scenarios to ensure correct behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->