### PR TITLE
docs(roadmap): update theme:social-spaces with substrate-contract (jg9b.5)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,6 +41,51 @@ Scenes work triggered the JetStream cutover. Now that the diversion has
 shipped, scenes Phase 4+ can resume on the substrate it pulled into
 existence.
 
+#### Substrate-contract (shipped — `holomush-jg9b`)
+
+The substrate pivots listed above were all in place by mid-May 2026, but the
+formal contract binding uses to substrate had not been written. Epic `jg9b`
+filled that gap.
+
+**What shipped:**
+
+- **INV-S5 (emit-type set-equality)** — startup-time validator that enforces
+  plugin `crypto.emits` manifest declarations match code-registered emit types
+  in both directions (declared-but-unregistered AND registered-but-undeclared
+  both fail load). Shipped as a single coherent change in PR #4049 (`jg9b.3`):
+  substrate cap, binary proto extension, Lua Load-pass, and adoption by
+  `core-scenes`. Orientation page shipped via PR #4137 (`jg9b.4`).
+- **Boundary invariants** (INV-S1 through INV-S10) — codified in the substrate-
+  contract spec below. Key ones: substrate stays domain-free (INV-S2), Go+Lua
+  runtime parity for every new host RPC (INV-S3), per-plugin Postgres schema
+  isolation enforced by Postgres roles (INV-S6), ABAC engine stays out of the
+  scene-log read path (INV-S9).
+
+**Future primitives named but not yet built (INV-S7):**
+
+`eventkit` (`pkg/plugin/eventkit/`) and `groupkit` (`pkg/plugin/groupkit/`) are
+co-designed in the substrate-contract spec as SDK bundles for joint patterns
+across uses. INV-S7 mandates N=2 consumer validation before either primitive
+lands as substrate code — the second consumer (`0sc.12` channels rework) must
+adopt cleanly before any extraction. Both are named here so future brainstorms
+know they exist; neither has code yet.
+
+**Unblocked by `jg9b.3`:**
+
+- **Scenes Phase 4** (`5rh.13`) — IC/OOC event emission + pose order. Was
+  blocked on INV-S5 enforcement landing (Phase 4 will add `crypto.emits:
+  [scene_ic, scene_ooc]` to core-scenes, which is only safe with the
+  fail-closed validator in place).
+- **Channels rework** (`0sc.12`) — channel plugin rebuild on plugin ABAC
+  substrate. Depends on the substrate contract being written so the channels
+  design brainstorm binds to the correct invariants (esp. INV-S7 for groupkit
+  adoption).
+
+**Specs:**
+
+- [Substrate-contract design](superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) — boundary invariants, substrate inventory, INV-S1 – INV-S10
+- [INV-S5 mechanism design](superpowers/specs/2026-05-17-inv-s5-mechanism-design.md) — runtime validator (Load-pass + proto extension)
+
 #### Uses (in development, in priority order)
 
 | Use          | Epic           | Frontier bead                                                | State                                    |

--- a/internal/plugin/subscriber_actor_test.go
+++ b/internal/plugin/subscriber_actor_test.go
@@ -31,7 +31,7 @@ type actorCapturingHost struct {
 
 func (h *actorCapturingHost) Load(context.Context, *Manifest, string) error { return nil }
 func (h *actorCapturingHost) Unload(context.Context, string) error          { return nil }
-func (h *actorCapturingHost) Plugins() []string { return []string{"test-plugin"} }
+func (h *actorCapturingHost) Plugins() []string                             { return []string{"test-plugin"} }
 
 func (h *actorCapturingHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
 func (h *actorCapturingHost) Close(context.Context) error                { return nil }

--- a/internal/plugin/subscriber_test.go
+++ b/internal/plugin/subscriber_test.go
@@ -33,7 +33,7 @@ type subscriberHost struct {
 
 func (h *subscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
 func (h *subscriberHost) Unload(context.Context, string) error                  { return nil }
-func (h *subscriberHost) Plugins() []string { return []string{"test"} }
+func (h *subscriberHost) Plugins() []string                                     { return []string{"test"} }
 
 func (h *subscriberHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
 func (h *subscriberHost) Close(context.Context) error                { return nil }
@@ -532,7 +532,7 @@ type slowSubscriberHost struct {
 
 func (h *slowSubscriberHost) Load(context.Context, *plugins.Manifest, string) error { return nil }
 func (h *slowSubscriberHost) Unload(context.Context, string) error                  { return nil }
-func (h *slowSubscriberHost) Plugins() []string { return []string{"test"} }
+func (h *slowSubscriberHost) Plugins() []string                                     { return []string{"test"} }
 
 func (h *slowSubscriberHost) PluginEmitRegistry(string) ([]string, bool) { return nil, false }
 func (h *slowSubscriberHost) Close(context.Context) error                { return nil }


### PR DESCRIPTION
## Summary

Reflects the substrate-contract landings in `docs/roadmap.md`'s `theme:social-spaces` section.

- Substrate shipped via PR #4049 (jg9b.3 — atomic INV-S5 cap + plugin adoptions) and PR #4137 (jg9b.4 — orientation page)
- Names `eventkit` + `groupkit` as future primitives per INV-S7 (N=2-validated extraction after `0sc.12` channels rework)
- Marks INV-S5 substrate work shipped under epic `holomush-jg9b`
- Notes `5rh.13` (scenes phase 4) + `0sc.12` (channels rework) both unblocked

Single file edit in `docs/roadmap.md`. Two `internal/plugin/subscriber_*_test.go` files also touched as a `task fmt` side-effect (gofumpt method-signature column alignment, whitespace-only).

## Reviews

- ✓ Code-reviewer: VERDICT: READY (scope clean, spec links resolve, fmt diff is whitespace-only)

## Test plan

- [x] `task lint:markdown` green
- [x] `task pr-prep` end-to-end green (lint + format + schema + license + unit + integration + e2e)
- [x] Spec cross-references resolve on disk

Refs: holomush-jg9b.5 (will close on merge)
Plan: docs/superpowers/plans/2026-05-17-social-spaces-substrate-contract-plan.md Task 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap documentation with information on shipped contract functionality, including validation mechanisms, future required primitives, and unblocked work items with reference links.

* **Style**
  * Applied formatting adjustments for consistency throughout the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->