### PR TITLE
feat(grpc): characterNameResolver interface + Repo-backed default impl (holomush-5b2j.6)

### DIFF
--- a/internal/grpc/character_name_resolver.go
+++ b/internal/grpc/character_name_resolver.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/world"
+)
+
+// characterNameResolver resolves character display names by ID. Narrow
+// seam to keep the ListFocusPresence handler free of world-repo plumbing
+// and to make handler tests substitutable.
+type characterNameResolver interface {
+	Names(ctx context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error)
+}
+
+// Compile-time assertion: RepoCharacterNameResolver satisfies characterNameResolver.
+var _ characterNameResolver = (*RepoCharacterNameResolver)(nil)
+
+// RepoCharacterNameResolver is the production implementation, backed by
+// world.CharacterRepository.GetNamesByIDs.
+type RepoCharacterNameResolver struct {
+	repo world.CharacterRepository
+}
+
+// NewRepoCharacterNameResolver constructs a resolver bound to the given repo.
+func NewRepoCharacterNameResolver(repo world.CharacterRepository) *RepoCharacterNameResolver {
+	return &RepoCharacterNameResolver{repo: repo}
+}
+
+// Names returns a map[id]name. Missing IDs are absent from the result.
+// Empty input returns a non-nil empty map with no repo call.
+func (r *RepoCharacterNameResolver) Names(ctx context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	if len(ids) == 0 {
+		return map[ulid.ULID]string{}, nil
+	}
+	names, err := r.repo.GetNamesByIDs(ctx, ids)
+	if err != nil {
+		return nil, oops.Wrap(err)
+	}
+	return names, nil
+}

--- a/internal/grpc/character_name_resolver_test.go
+++ b/internal/grpc/character_name_resolver_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	grpcpkg "github.com/holomush/holomush/internal/grpc"
+	worldmocks "github.com/holomush/holomush/internal/world/worldtest"
+)
+
+func TestRepoCharacterNameResolverReturnsNamesForPresentIDs(t *testing.T) {
+	repo := worldmocks.NewMockCharacterRepository(t)
+	resolver := grpcpkg.NewRepoCharacterNameResolver(repo)
+
+	id1 := ulid.MustParse("01HYXCHAR00000000000000001")
+	id2 := ulid.MustParse("01HYXCHAR00000000000000002")
+	repo.EXPECT().
+		GetNamesByIDs(mock.Anything, []ulid.ULID{id1, id2}).
+		Return(map[ulid.ULID]string{id1: "alice", id2: "bob"}, nil).
+		Once()
+
+	got, err := resolver.Names(context.Background(), []ulid.ULID{id1, id2})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", got[id1])
+	assert.Equal(t, "bob", got[id2])
+}
+
+func TestRepoCharacterNameResolverShortCircuitsOnEmptyInput(t *testing.T) {
+	repo := worldmocks.NewMockCharacterRepository(t)
+	resolver := grpcpkg.NewRepoCharacterNameResolver(repo)
+	// No mock expectation — empty input must short-circuit with no repo call.
+
+	got, err := resolver.Names(context.Background(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got, "empty input MUST return non-nil empty map")
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Summary

T4 of the holomush-5b2j epic — defines a narrow `characterNameResolver` interface and the production `RepoCharacterNameResolver` that wraps `world.CharacterRepository.GetNamesByIDs` (from T3, merged in #4138).

This is the seam T7 (`5b2j.10`) will use for batch character-name resolution inside the presence handler. Keeping the resolver as a small interface keeps the handler decoupled from `world.CharacterRepository` directly and makes handler tests substitutable.

Semantics:

- `Names(ctx, ids)` — empty input short-circuits, returns non-nil empty map with no repo call.
- Non-empty input delegates to `r.repo.GetNamesByIDs(ctx, ids)`; missing IDs are absent from the result (not an error — inherits T3's contract).

## Files

- `internal/grpc/character_name_resolver.go` — interface + impl (~30 lines)
- `internal/grpc/character_name_resolver_test.go` — 2 unit tests (happy path via mockery; empty-input short-circuit with no mock expectation set)

## Notes

- The package-private `characterNameResolver` interface gets a compile-time `var _ characterNameResolver = (*RepoCharacterNameResolver)(nil)` assertion so the unused-lint doesn't fire until T7/T8 wire it in.
- The repo delegation wraps the error with `oops.Wrap` (satisfies `wrapcheck` without a `nolint` directive).

## Bead

`holomush-5b2j.6` (epic: `holomush-5b2j` [E-5B2J]). Unblocks T7 (`5b2j.10`).

## Verification

- [x] `task test -- ./internal/grpc/ -run TestRepoCharacterNameResolver` — 2 tests pass
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for character information resolution services to enhance code organization.

* **Tests**
  * Added test coverage for character name resolution with multiple test scenarios.

**Note:** These are internal infrastructure improvements with no impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->