### PR TITLE
feat(abac): add list_presence ABAC seed policy (holomush-5b2j.2)

### DIFF
--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -11,8 +11,8 @@ type SeedPolicy struct {
 	SeedVersion int
 }
 
-// SeedPolicies returns the complete set of 35 seed policies (26 permit, 9 forbid).
-// The initial 18 (T22) minus 2 removed command policies, plus 5 gap-fill policies (T22b: G1-G4),
+// SeedPolicies returns the complete set of 36 seed policies (27 permit, 9 forbid).
+// The initial 18 (T22) minus 2 removed command policies, plus 5 gap-fill policies (T22b: G1-G5),
 // 1 phase-2 command policy, and 2 system bootstrap policies.
 // Default deny behavior is provided by EffectDefaultDeny (no matching policy = denied).
 // See ADR 087 for rationale on default-deny instead of explicit forbid for system properties.
@@ -163,6 +163,13 @@ func SeedPolicies() []SeedPolicy {
 			Description: "Characters can list other characters in their current location",
 			DSLText:     `permit(principal is character, action in ["list_characters"], resource is location) when { resource.location.id == principal.character.location };`,
 			SeedVersion: 2,
+		},
+		// G5: Players can query presence at their current location.
+		{
+			Name:        "seed:player-location-list-presence",
+			Description: "Allow characters to query presence at their current location",
+			DSLText:     `permit(principal is character, action in ["list_presence"], resource is location) when { resource.location.id == principal.character.location };`,
+			SeedVersion: 6,
 		},
 		// G4: Scene participant access (target matching only; scene provider is a stub).
 		{

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -844,6 +844,71 @@ func TestSeedSmokeCharacterDeniedEventsSystemRekeyStream(t *testing.T) {
 		decision.Effect(), decision.Reason())
 }
 
+func TestSeedSmokePlayerLocationListPresence(t *testing.T) {
+	locID := "01LOC000PPPPPPPPPPPPPPPPP"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "roles": []string{"player"}, "location": locID},
+			nil,
+		),
+		locationProvider(map[string]any{"id": locID, "name": "Plaza"}),
+	})
+
+	// list_presence on current location → permit (list_presence_same_location)
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "list_presence",
+		Resource: "location:" + locID,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "player should list presence at current location; got: %s — %s", decision.Effect(), decision.Reason())
+}
+
+func TestSeedSmokePlayerDeniedListPresenceNonCurrentLocation(t *testing.T) {
+	currentLocID := "01LOC000QQQQQQQQQQQQQQQQQ"
+	otherLocID := "01LOC000RRRRRRRRRRRRRRRRR"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01CHAR01", "roles": []string{"player"}, "location": currentLocID},
+			nil,
+		),
+		locationProvider(map[string]any{"id": otherLocID, "name": "Other Room"}),
+	})
+
+	// Player at currentLocID should NOT list_presence at otherLocID.
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01CHAR01",
+		Action:   "list_presence",
+		Resource: "location:" + otherLocID,
+	})
+	require.NoError(t, err)
+	assert.False(t, decision.IsAllowed(), "player should NOT list presence at non-current location; got: %s — %s", decision.Effect(), decision.Reason())
+}
+
+func TestSeedSmokeAdminRemoteListPresence(t *testing.T) {
+	adminLocID := "01LOC000SSSSSSSSSSSSSSSSS"
+	remoteLocID := "01LOC000TTTTTTTTTTTTTTTTT"
+
+	engine := createSeedEngine(t, []attribute.AttributeProvider{
+		characterProvider(
+			map[string]any{"id": "01ADMIN1", "roles": []string{"admin"}, "location": adminLocID},
+			nil,
+		),
+		locationProvider(map[string]any{"id": remoteLocID, "name": "Remote Room"}),
+	})
+
+	// Admin at a different location → permit via seed:admin-full-access super-rule
+	decision, err := engine.Evaluate(context.Background(), types.AccessRequest{
+		Subject:  "character:01ADMIN1",
+		Action:   "list_presence",
+		Resource: "location:" + remoteLocID,
+	})
+	require.NoError(t, err)
+	assert.True(t, decision.IsAllowed(), "admin should list presence at remote location via super-rule; got: %s — %s", decision.Effect(), decision.Reason())
+}
+
 func TestSeedSmokePluginDeniedEventsSystemRekeyStream(t *testing.T) {
 	// A plugin principal must NOT read the rekey audit stream.
 	// The broad seed:deny-events-system-read-plugin forbid must fire.

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSeedPoliciesCount(t *testing.T) {
 	seeds := SeedPolicies()
-	// 26 permit + 9 forbid = 35 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history)
-	assert.Len(t, seeds, 35, "expected 35 seed policies (26 permit, 9 forbid)")
+	// 27 permit + 9 forbid = 36 total (18 base − 2 removed command policies + 5 gap-fill from T22b + 1 phase-2 command + 2 system bootstrap + 1 location-stream read + 2 phase-3b audit deny + 2 phase-5 sub-epic A events.*.system.crypto_totp.* deny seeds + 2 phase-5 sub-epic D events.*.system.crypto_policy.* deny seeds + 2 phase-5 sub-epic E events.*.system.* broad deny seeds + 1 phase-5 iwzt staff-read-unrestricted-history + 1 presence list_presence_same_location)
+	assert.Len(t, seeds, 36, "expected 36 seed policies (27 permit, 9 forbid)")
 }
 
 func TestSeedPoliciesAllNamesHaveSeedPrefix(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSeedPoliciesEffectDistribution(t *testing.T) {
 			forbidCount++
 		}
 	}
-	assert.Equal(t, 26, permitCount, "expected 26 permit policies")
+	assert.Equal(t, 27, permitCount, "expected 27 permit policies")
 	assert.Equal(t, 9, forbidCount, "expected 9 forbid policies (+2 phase-5 sub-epic A events.*.system.crypto_totp.* denies + 2 phase-5 sub-epic D events.*.system.crypto_policy.* denies + 2 phase-5 sub-epic E events.*.system.* broad denies)")
 }
 
@@ -102,6 +102,7 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		"seed:player-location-list-characters", // G3
 		"seed:player-scene-participant",        // G4
 		"seed:player-scene-read",               // G4
+		"seed:player-location-list-presence",   // G5
 		// Phase-2 command policies
 		"seed:player-teleport", // all players can execute home and teleport
 		// System bootstrap policies


### PR DESCRIPTION
## Summary

T2 of the holomush-5b2j epic — adds the ABAC seed policy that gates the new `ListFocusPresence` RPC. Characters can query presence at their current location; admin remote-presence is already covered by the existing admin super-rule.

DSL (mirrors the existing `list_characters_same_location` pattern):

```text
permit(principal is character, action in ["list_presence"], resource is location)
  when { resource.location.id == principal.character.location };
```

## Plan deviations (caught + fixed by the implementer)

- **Seed policy `Name` field uses `seed:` prefix.** Plan called the policy `list_presence_same_location`, but the repo enforces a `seed:` prefix via `TestSeedPoliciesAllNamesHaveSeedPrefix`. Renamed to `seed:player-location-list-presence` to match the analog `seed:player-location-list-characters`.

## Files

- `internal/access/policy/seed.go` — added the seed entry (`SeedVersion: 6`)
- `internal/access/policy/seed_smoke_test.go` — added 3 smoke-test cases: same-location allowed, different-location denied, admin remote allowed via super-rule
- `internal/access/policy/seed_test.go` — incidental test maintenance (e.g., policy-list-size assertion)

## Bead

`holomush-5b2j.2` (epic: `holomush-5b2j` [E-5B2J]). With T2 merged, T7 (`5b2j.10` — handler ABAC + happy path + dedup) is fully unblocked.

## Verification

- [x] `task test -- ./internal/access/policy/ -run TestSeedSmoke` — 3 new rows pass
- [x] `task test -- ./internal/access/policy/` — 326 tests pass (no regressions)
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new access control permission allowing characters to view presence information at their current location, while preventing access to other locations.

* **Tests**
  * Added comprehensive test coverage for the new presence-checking permission across different character locations and administrative scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->