### PR TITLE
feat(grpc): ListFocusPresence handler — ABAC + happy path + dedup (holomush-5b2j.10 + .11)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -445,7 +445,11 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	if focusErr != nil {
 		return oops.Code("FOCUS_COORDINATOR_FAILED").Wrap(focusErr)
 	}
-	coreServerOpts = append(coreServerOpts, holoGRPC.WithFocusCoordinator(focusCoord))
+	// 5b2j: inject the character-name resolver used by ListFocusPresence to
+	// batch-resolve names for the presence snapshot.
+	coreServerOpts = append(coreServerOpts,
+		holoGRPC.WithFocusCoordinator(focusCoord),
+		holoGRPC.WithCharacterNameResolver(holoGRPC.NewRepoCharacterNameResolver(charRepo)))
 
 	// 8b. Inject focus coordinator + history reader into plugin hosts (late-binding).
 	// The plugin subsystem started before gRPC, so these deps were not available

--- a/internal/grpc/list_focus_presence.go
+++ b/internal/grpc/list_focus_presence.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/auth"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
@@ -88,6 +91,98 @@ func (s *CoreServer) ListFocusPresence(ctx context.Context, req *corev1.ListFocu
 		}, nil
 	}
 
-	// TODO(holomush-5b2j): T7 (5b2j.10) adds ABAC gate + store query + name resolution.
-	return nil, oops.Code("UNIMPLEMENTED").Errorf("ABAC + resolver not yet wired")
+	// Guard optional deps against nil. Both fields are option-injected on
+	// CoreServer (WithAccessEngine / WithCharacterNameResolver); production
+	// wire-up at cmd/holomush/sub_grpc.go always sets them, but tests and
+	// future construction sites might not. Fail-closed for the ABAC engine
+	// (missing engine = default-deny); INTERNAL for the resolver (it's a
+	// misconfiguration, not a security boundary).
+	if s.accessEngine == nil {
+		slog.ErrorContext(ctx, "list focus presence: access engine not configured",
+			"request_id", requestID, "session_id", req.SessionId)
+		return nil, oops.Code("PERMISSION_DENIED").
+			With("session_id", req.SessionId).
+			With("reason", "access_engine_not_configured").
+			Errorf("permission denied")
+	}
+	if s.characterNameResolver == nil {
+		slog.ErrorContext(ctx, "list focus presence: name resolver not configured",
+			"request_id", requestID, "session_id", req.SessionId)
+		return nil, oops.Code("INTERNAL").Errorf("character name resolver not configured")
+	}
+
+	// ABAC gate (I-PRES-4). Default-deny; same-location subjects allowed via
+	// seed:player-location-list-presence; admin via the admin super-rule.
+	accessReq, err := types.NewAccessRequest(
+		access.CharacterSubject(info.CharacterID.String()),
+		"list_presence",
+		access.LocationResource(info.LocationID.String()),
+		nil, // no extra context attributes
+	)
+	if err != nil {
+		return nil, oops.Code("INTERNAL").Wrap(err)
+	}
+	decision, err := s.accessEngine.Evaluate(ctx, accessReq)
+	if err != nil {
+		slog.ErrorContext(ctx, "list focus presence ABAC error",
+			"request_id", requestID, "error", err)
+		return nil, oops.Code("INTERNAL").Wrap(err)
+	}
+	if !decision.IsAllowed() {
+		return nil, oops.Code("PERMISSION_DENIED").
+			With("session_id", req.SessionId).
+			With("action", "list_presence").
+			With("resource", info.LocationID.String()).
+			Errorf("permission denied")
+	}
+
+	// Fetch active sessions at the location.
+	sessions, err := s.sessionStore.ListActiveByLocation(ctx, info.LocationID)
+	if err != nil {
+		slog.ErrorContext(ctx, "list active by location failed",
+			"request_id", requestID, "location_id", info.LocationID.String(), "error", err)
+		return nil, oops.Code("INTERNAL").Wrap(err)
+	}
+
+	// Build the unique character-ID set (I-PRES-9 dedup defense).
+	seen := make(map[ulid.ULID]struct{}, len(sessions))
+	uniqueIDs := make([]ulid.ULID, 0, len(sessions))
+	for _, sess := range sessions {
+		if _, dup := seen[sess.CharacterID]; dup {
+			continue
+		}
+		seen[sess.CharacterID] = struct{}{}
+		uniqueIDs = append(uniqueIDs, sess.CharacterID)
+	}
+
+	// Batch character-name resolution.
+	names, err := s.characterNameResolver.Names(ctx, uniqueIDs)
+	if err != nil {
+		slog.ErrorContext(ctx, "character name resolution failed",
+			"request_id", requestID, "count", len(uniqueIDs), "error", err)
+		return nil, oops.Code("INTERNAL").Wrap(err)
+	}
+
+	// Assemble entries; skip any without a resolved name (graceful degradation).
+	entries := make([]*corev1.PresenceEntry, 0, len(uniqueIDs))
+	for _, id := range uniqueIDs {
+		name, ok := names[id]
+		if !ok || name == "" {
+			slog.WarnContext(ctx, "presence entry skipped — name unresolved",
+				"request_id", requestID, "character_id", id.String())
+			continue
+		}
+		entries = append(entries, &corev1.PresenceEntry{
+			CharacterId:   id.String(),
+			CharacterName: name,
+			State:         corev1.PresenceState_PRESENCE_STATE_ACTIVE,
+		})
+	}
+
+	return &corev1.ListFocusPresenceResponse{
+		Meta:      responseMeta(requestID),
+		Context:   corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION,
+		ContextId: info.LocationID.String(),
+		Entries:   entries,
+	}, nil
 }

--- a/internal/grpc/list_focus_presence_test.go
+++ b/internal/grpc/list_focus_presence_test.go
@@ -13,9 +13,52 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/session"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
+
+// ---------- T7 test helpers ----------
+
+// stubNameResolver is an in-process characterNameResolver for T7 tests.
+type stubNameResolver struct {
+	names map[ulid.ULID]string
+}
+
+func (s *stubNameResolver) Names(_ context.Context, ids []ulid.ULID) (map[ulid.ULID]string, error) {
+	out := make(map[ulid.ULID]string, len(ids))
+	for _, id := range ids {
+		if n, ok := s.names[id]; ok {
+			out[id] = n
+		}
+	}
+	return out, nil
+}
+
+// mkActiveAt returns a session.Info with Status=Active, non-zero ExpiresAt,
+// and the given characterID / locationID. PlayerID matches ownedPlayerID so
+// that newFakePlayerSessionRepo(ownedPlayerID) passes ownership validation.
+func mkActiveAt(id string, characterID, locationID ulid.ULID) *session.Info {
+	future := time.Now().Add(time.Hour)
+	return &session.Info{
+		ID:          id,
+		Status:      session.StatusActive,
+		ExpiresAt:   &future,
+		CharacterID: characterID,
+		LocationID:  locationID,
+		PlayerID:    ownedPlayerID,
+	}
+}
+
+// entryNames extracts CharacterName from each PresenceEntry, for compact assertions.
+func entryNames(entries []*corev1.PresenceEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.CharacterName)
+	}
+	return out
+}
 
 func TestListFocusPresenceReturnsInvalidArgumentOnNilRequest(t *testing.T) {
 	// Defends against direct-call misuse (test or wrapping code passing nil).
@@ -169,4 +212,184 @@ func TestListFocusPresenceReturnsEmptyEntriesWhenLocationUnset(t *testing.T) {
 	assert.Equal(t, corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION, resp.Context)
 	assert.Equal(t, "", resp.ContextId)
 	assert.Empty(t, resp.Entries)
+}
+
+// ---------- T7 tests ----------
+
+// I-PRES-4: ABAC denial → PERMISSION_DENIED.
+func TestListFocusPresenceReturnsPermissionDeniedWhenABACDenies(t *testing.T) {
+	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	sess := mkActiveAt("sess-1", char, loc)
+	s := &CoreServer{
+		sessionStore:          newTestSessionStore(t, map[string]*session.Info{"sess-1": sess}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          policytest.DenyAllEngine(),
+		characterNameResolver: &stubNameResolver{},
+	}
+	_, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "PERMISSION_DENIED", o.Code())
+}
+
+// I-PRES-1 + I-PRES-6: two Active sessions at same location, both returned
+// with state=ACTIVE; caller is included in the result.
+func TestListFocusPresenceReturnsCallerAndOtherSessions(t *testing.T) {
+	char1 := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	char2 := ulid.MustParse("01HYXCHARBOB000000000000BB")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	caller := mkActiveAt("sess-1", char1, loc)
+	other := mkActiveAt("sess-2", char2, loc)
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char1.String()), "list_presence", access.LocationResource(loc.String()))
+
+	s := &CoreServer{
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			"sess-1": caller, "sess-2": other,
+		}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          grant,
+		characterNameResolver: &stubNameResolver{names: map[ulid.ULID]string{char1: "alice", char2: "bob"}},
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION, resp.Context)
+	assert.Equal(t, loc.String(), resp.ContextId)
+	require.Len(t, resp.Entries, 2)
+	for _, e := range resp.Entries {
+		assert.Equal(t, corev1.PresenceState_PRESENCE_STATE_ACTIVE, e.State)
+	}
+	names := entryNames(resp.Entries)
+	assert.Contains(t, names, "alice")
+	assert.Contains(t, names, "bob")
+}
+
+// Name resolution missing → entry skipped; other entries still returned.
+func TestListFocusPresenceSkipsEntryWhenNameUnresolved(t *testing.T) {
+	char1 := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	char2 := ulid.MustParse("01HYXCHARBOB000000000000BB")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	caller := mkActiveAt("sess-1", char1, loc)
+	other := mkActiveAt("sess-2", char2, loc)
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char1.String()), "list_presence", access.LocationResource(loc.String()))
+
+	s := &CoreServer{
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			"sess-1": caller, "sess-2": other,
+		}),
+		playerSessionRepo: newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:      grant,
+		// char2 absent — its entry must be skipped.
+		characterNameResolver: &stubNameResolver{names: map[ulid.ULID]string{char1: "alice"}},
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "alice", resp.Entries[0].CharacterName)
+}
+
+// I-PRES-9: defense-in-depth dedup — two sessions for the same character_id
+// must collapse to a single presence entry.
+func TestListFocusPresenceDeduplicatesByCharacterID(t *testing.T) {
+	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	caller := mkActiveAt("sess-1", char, loc)
+	dup := mkActiveAt("sess-2", char, loc)
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char.String()), "list_presence", access.LocationResource(loc.String()))
+
+	s := &CoreServer{
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			"sess-1": caller, "sess-2": dup,
+		}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          grant,
+		characterNameResolver: &stubNameResolver{names: map[ulid.ULID]string{char: "alice"}},
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Entries, 1, "duplicate character_id must collapse to single entry")
+}
+
+// I-PRES-1 cross-location: the handler trusts ListActiveByLocation to filter;
+// sessions at a different location must not appear in the response.
+func TestListFocusPresenceDoesNotLeakSessionsFromOtherLocations(t *testing.T) {
+	char1 := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	char2 := ulid.MustParse("01HYXCHARBOB000000000000BB")
+	loc1 := ulid.MustParse("01HYXLOCATION0000000000001")
+	loc2 := ulid.MustParse("01HYXLOCATION0000000000002")
+	caller := mkActiveAt("sess-1", char1, loc1)
+	elsewhere := mkActiveAt("sess-2", char2, loc2) // different location
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char1.String()), "list_presence", access.LocationResource(loc1.String()))
+
+	s := &CoreServer{
+		sessionStore: newTestSessionStore(t, map[string]*session.Info{
+			"sess-1": caller, "sess-2": elsewhere,
+		}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          grant,
+		characterNameResolver: &stubNameResolver{names: map[ulid.ULID]string{char1: "alice"}},
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "alice", resp.Entries[0].CharacterName)
+}
+
+// Missing accessEngine → PERMISSION_DENIED (fail-closed; defense against
+// misconfigured construction paths that omit WithAccessEngine).
+func TestListFocusPresenceReturnsPermissionDeniedWhenAccessEngineIsNil(t *testing.T) {
+	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	sess := mkActiveAt("sess-1", char, loc)
+	s := &CoreServer{
+		sessionStore:          newTestSessionStore(t, map[string]*session.Info{"sess-1": sess}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          nil, // explicit
+		characterNameResolver: &stubNameResolver{},
+	}
+	_, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "PERMISSION_DENIED", o.Code())
+}
+
+// Missing characterNameResolver → INTERNAL (misconfiguration; not a security
+// boundary, so we don't fail-closed with PERMISSION_DENIED).
+func TestListFocusPresenceReturnsInternalWhenNameResolverIsNil(t *testing.T) {
+	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	sess := mkActiveAt("sess-1", char, loc)
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char.String()), "list_presence", access.LocationResource(loc.String()))
+	s := &CoreServer{
+		sessionStore:          newTestSessionStore(t, map[string]*session.Info{"sess-1": sess}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          grant,
+		characterNameResolver: nil, // explicit
+	}
+	_, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	o, ok := oops.AsOops(err)
+	require.True(t, ok)
+	assert.Equal(t, "INTERNAL", o.Code())
 }

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -162,6 +162,10 @@ type CoreServer struct {
 	// Nil if ABAC is not configured (public stream reads will be denied).
 	accessEngine accessTypes.AccessPolicyEngine
 
+	// characterNameResolver resolves character display names by ID for
+	// ListFocusPresence and other current-state RPCs (5b2j).
+	characterNameResolver characterNameResolver
+
 	// subscriber opens per-session durable consumers against the JetStream
 	// event bus. Post-F3 Subscribe delegates its live loop to subscribe
 	// streams; nil subscriber causes Subscribe to error early. Wired via
@@ -254,6 +258,11 @@ func WithIdentityRegistry(reg plugins.IdentityRegistry) CoreServerOption {
 // WithAccessEngine sets the ABAC policy engine for stream read authorization.
 func WithAccessEngine(engine accessTypes.AccessPolicyEngine) CoreServerOption {
 	return func(s *CoreServer) { s.accessEngine = engine }
+}
+
+// WithCharacterNameResolver sets the character name resolver for ListFocusPresence (5b2j).
+func WithCharacterNameResolver(r characterNameResolver) CoreServerOption {
+	return func(s *CoreServer) { s.characterNameResolver = r }
 }
 
 // WithSubscriber wires the JetStream EventBus subscriber into the Subscribe


### PR DESCRIPTION
## Summary

T7 of the holomush-5b2j epic — the heart of the handler. Transforms `ListFocusPresence` from a stub that returns `UNIMPLEMENTED` past the empty-location guard into a fully functional RPC.

Pipeline:

1. **ABAC gate** — `types.NewAccessRequest(CharacterSubject(charID), "list_presence", LocationResource(locID), nil)` → `accessEngine.Evaluate` → on deny: `PERMISSION_DENIED`.
2. **Store query** — `sessionStore.ListActiveByLocation(info.LocationID)`.
3. **Dedup by character_id** — defense in depth (I-PRES-9; schema's unique partial index does the real work).
4. **Batch name resolution** — `characterNameResolver.Names(uniqueIDs)`.
5. **Skip unresolved names** — warn log, graceful degradation.
6. **Response** — `context=LOCATION`, `context_id=info.LocationID`, `entries[]{character_id, character_name, state=ACTIVE}`.

## Bundled scope — T8 (5b2j.11) production wire-up

T7 alone would nil-deref `s.characterNameResolver` in production because the field is only assigned via the new `WithCharacterNameResolver` option. T8's bead is exactly the wire-up step; bundling avoids a window where the binary builds but crashes on the new RPC.

- `cmd/holomush/sub_grpc.go` now passes `WithCharacterNameResolver(NewRepoCharacterNameResolver(charRepo))` alongside `WithFocusCoordinator(focusCoord)` to `NewCoreServer`.

On merge, both `holomush-5b2j.10` and `holomush-5b2j.11` should be closed.

## Files

- `internal/grpc/server.go` — added `characterNameResolver characterNameResolver` field on `CoreServer` + `WithCharacterNameResolver` option.
- `internal/grpc/list_focus_presence.go` — replaced final `UNIMPLEMENTED` return with the full implementation.
- `internal/grpc/list_focus_presence_test.go` — added `stubNameResolver`, `mkActiveAt`, `entryNames` helpers + 5 new tests (ABAC deny, two-session happy path, missing-name skip, dedup, cross-location isolation).
- `cmd/holomush/sub_grpc.go` — production wire-up via the new option.

## Beads

- `holomush-5b2j.10` (T7 — heart of the handler)
- `holomush-5b2j.11` (T8 — production wire-up) — bundled, will close on merge

With T7+T8 landed, downstream tasks unblock: T9 (gateway proxy), T11 (web snapshot fetch), and the integration tests.

## Verification

- [x] `task test -- ./internal/grpc/ -run TestListFocusPresence` — **12 tests pass** (4 T5 + 3 T6 + 5 T7)
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Location presence visibility: see who else is currently present in your location with automatic duplicate detection, batch character-name resolution, and access-control enforced visibility.

* **Tests**
  * Added comprehensive tests covering presence listing, access-control denial, missing/failed name resolution (skips unresolved entries), deduplication, cross-location filtering, and fail-fast behavior when core components are misconfigured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->