### PR TITLE
feat(web): WebListFocusPresence gateway forwarder (holomush-5b2j.12)

### DIFF
--- a/cmd/holomush/deps.go
+++ b/cmd/holomush/deps.go
@@ -165,6 +165,8 @@ type GRPCClient interface {
 	ListPlayerSessions(ctx context.Context, req *corev1.ListPlayerSessionsRequest) (*corev1.ListPlayerSessionsResponse, error)
 	RevokePlayerSession(ctx context.Context, req *corev1.RevokePlayerSessionRequest) (*corev1.RevokePlayerSessionResponse, error)
 	RevokeOtherPlayerSessions(ctx context.Context, req *corev1.RevokeOtherPlayerSessionsRequest) (*corev1.RevokeOtherPlayerSessionsResponse, error)
+	// Presence RPCs
+	ListFocusPresence(ctx context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error)
 	// Content RPCs
 	GetContent(ctx context.Context, req *contentv1.GetContentRequest) (*contentv1.GetContentResponse, error)
 	ListContent(ctx context.Context, req *contentv1.ListContentRequest) (*contentv1.ListContentResponse, error)

--- a/cmd/holomush/deps_test.go
+++ b/cmd/holomush/deps_test.go
@@ -170,6 +170,10 @@ func (m *mockGRPCClient) RevokeOtherPlayerSessions(_ context.Context, _ *corev1.
 	return nil, nil
 }
 
+func (m *mockGRPCClient) ListFocusPresence(_ context.Context, _ *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error) {
+	return nil, nil
+}
+
 func (m *mockGRPCClient) GetContent(_ context.Context, _ *contentv1.GetContentRequest) (*contentv1.GetContentResponse, error) {
 	return nil, nil
 }

--- a/internal/grpc/client.go
+++ b/internal/grpc/client.go
@@ -290,6 +290,15 @@ func (c *Client) RevokeOtherPlayerSessions(ctx context.Context, req *corev1.Revo
 	return resp, nil
 }
 
+// ListFocusPresence returns the presence entries for the session's focus context.
+func (c *Client) ListFocusPresence(ctx context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error) {
+	resp, err := c.client.ListFocusPresence(ctx, req)
+	if err != nil {
+		return nil, oops.Code("RPC_FAILED").With("method", "ListFocusPresence").Wrap(err)
+	}
+	return resp, nil
+}
+
 // GetContent retrieves a single content item by key from the content service.
 func (c *Client) GetContent(ctx context.Context, req *contentv1.GetContentRequest) (*contentv1.GetContentResponse, error) {
 	resp, err := c.contentClient.GetContent(ctx, req)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -54,6 +54,8 @@ type CoreClient interface {
 	ListPlayerSessions(ctx context.Context, req *corev1.ListPlayerSessionsRequest) (*corev1.ListPlayerSessionsResponse, error)
 	RevokePlayerSession(ctx context.Context, req *corev1.RevokePlayerSessionRequest) (*corev1.RevokePlayerSessionResponse, error)
 	RevokeOtherPlayerSessions(ctx context.Context, req *corev1.RevokeOtherPlayerSessionsRequest) (*corev1.RevokeOtherPlayerSessionsResponse, error)
+	// Presence RPCs
+	ListFocusPresence(ctx context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error)
 }
 
 // ContentClient is the gRPC interface used by Handler to communicate with the
@@ -463,12 +465,76 @@ func (h *Handler) WebListSessionStreams(ctx context.Context, req *connect.Reques
 	}), nil
 }
 
-// WebListFocusPresence is the gateway proxy for CoreService.ListFocusPresence.
-// The real forwarder lands in holomush-5b2j.12 (T9); this stub keeps *Handler
-// satisfying webv1connect.WebServiceHandler so the proto addition can land
-// independently of the gateway implementation.
-func (h *Handler) WebListFocusPresence(_ context.Context, _ *connect.Request[webv1.WebListFocusPresenceRequest]) (*connect.Response[webv1.WebListFocusPresenceResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, oops.Errorf("WebListFocusPresence pending — see holomush-5b2j.12"))
+// WebListFocusPresence forwards to CoreService.ListFocusPresence. The
+// player_session_token is read from the request header (not the wire
+// request body); core enforces ownership.
+func (h *Handler) WebListFocusPresence(ctx context.Context, req *connect.Request[webv1.WebListFocusPresenceRequest]) (*connect.Response[webv1.WebListFocusPresenceResponse], error) {
+	slog.DebugContext(ctx, "web: WebListFocusPresence",
+		"session_id", req.Msg.GetSessionId())
+
+	token := req.Header().Get(headerInjectSessionToken)
+
+	rpcCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+
+	coreResp, err := h.client.ListFocusPresence(rpcCtx, &corev1.ListFocusPresenceRequest{
+		SessionId:          req.Msg.GetSessionId(),
+		PlayerSessionToken: token,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "web: list focus presence RPC failed",
+			"session_id", req.Msg.GetSessionId(), "error", err)
+		return nil, err //nolint:wrapcheck // gRPC status errors pass through so clients can distinguish PERMISSION_DENIED / UNIMPLEMENTED / SESSION_NOT_FOUND.
+	}
+
+	return connect.NewResponse(&webv1.WebListFocusPresenceResponse{
+		Context:   translatePresenceContext(coreResp.GetContext()),
+		ContextId: coreResp.GetContextId(),
+		Entries:   translatePresenceEntries(coreResp.GetEntries()),
+	}), nil
+}
+
+func translatePresenceContext(c corev1.PresenceContext) webv1.WebPresenceContext {
+	switch c {
+	case corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION:
+		return webv1.WebPresenceContext_WEB_PRESENCE_CONTEXT_LOCATION
+	case corev1.PresenceContext_PRESENCE_CONTEXT_SCENE:
+		return webv1.WebPresenceContext_WEB_PRESENCE_CONTEXT_SCENE
+	default:
+		return webv1.WebPresenceContext_WEB_PRESENCE_CONTEXT_UNSPECIFIED
+	}
+}
+
+func translatePresenceState(s corev1.PresenceState) webv1.WebPresenceState {
+	switch s {
+	case corev1.PresenceState_PRESENCE_STATE_ACTIVE:
+		return webv1.WebPresenceState_WEB_PRESENCE_STATE_ACTIVE
+	case corev1.PresenceState_PRESENCE_STATE_DETACHED:
+		return webv1.WebPresenceState_WEB_PRESENCE_STATE_DETACHED
+	case corev1.PresenceState_PRESENCE_STATE_INACTIVE:
+		return webv1.WebPresenceState_WEB_PRESENCE_STATE_INACTIVE
+	default:
+		return webv1.WebPresenceState_WEB_PRESENCE_STATE_UNSPECIFIED
+	}
+}
+
+func translatePresenceEntries(in []*corev1.PresenceEntry) []*webv1.WebPresenceEntry {
+	out := make([]*webv1.WebPresenceEntry, 0, len(in))
+	for _, e := range in {
+		// Defense: skip nil entries. Protobuf Get* methods are nil-safe (would
+		// return zero values), so this only prevents emitting an entry with
+		// empty character_id / character_name to clients. Core never sends
+		// nil entries today; this is belt-and-suspenders against future drift.
+		if e == nil {
+			continue
+		}
+		out = append(out, &webv1.WebPresenceEntry{
+			CharacterId:   e.GetCharacterId(),
+			CharacterName: e.GetCharacterName(),
+			State:         translatePresenceState(e.GetState()),
+		})
+	}
+	return out
 }
 
 // WebListContent returns content items matching a key prefix.

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -99,6 +99,10 @@ type mockCoreClient struct {
 	revokeOtherResp *corev1.RevokeOtherPlayerSessionsResponse
 	revokeOtherErr  error
 	revokeOtherReq  *corev1.RevokeOtherPlayerSessionsRequest // captured for assertion
+
+	listFocusPresenceResp *corev1.ListFocusPresenceResponse
+	listFocusPresenceErr  error
+	listFocusPresenceReq  *corev1.ListFocusPresenceRequest // captured for assertion
 }
 
 func (m *mockCoreClient) HandleCommand(_ context.Context, req *corev1.HandleCommandRequest) (*corev1.HandleCommandResponse, error) {
@@ -203,6 +207,11 @@ func (m *mockCoreClient) RevokePlayerSession(_ context.Context, req *corev1.Revo
 func (m *mockCoreClient) RevokeOtherPlayerSessions(_ context.Context, req *corev1.RevokeOtherPlayerSessionsRequest) (*corev1.RevokeOtherPlayerSessionsResponse, error) {
 	m.revokeOtherReq = req
 	return m.revokeOtherResp, m.revokeOtherErr
+}
+
+func (m *mockCoreClient) ListFocusPresence(_ context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error) {
+	m.listFocusPresenceReq = req
+	return m.listFocusPresenceResp, m.listFocusPresenceErr
 }
 
 func TestHandler_SendCommand_Success(t *testing.T) {
@@ -779,4 +788,41 @@ func TestWebListSessionStreamsForwardsPlayerSessionToken(t *testing.T) {
 	require.NotNil(t, client.listSessionStreamsReq, "ListSessionStreams should have been called")
 	assert.Equal(t, token, client.listSessionStreamsReq.GetPlayerSessionToken())
 	assert.Equal(t, "sess-5", client.listSessionStreamsReq.GetSessionId())
+}
+
+func TestWebListFocusPresenceForwardsToCoreService(t *testing.T) {
+	sessID := "sess-1"
+	token := "tok-from-header"
+	coreResp := &corev1.ListFocusPresenceResponse{
+		Context:   corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION,
+		ContextId: "01HYXLOCATION0000000000001",
+		Entries: []*corev1.PresenceEntry{
+			{
+				CharacterId:   "01HYXCHARALICE0000000000AA",
+				CharacterName: "alice",
+				State:         corev1.PresenceState_PRESENCE_STATE_ACTIVE,
+			},
+		},
+	}
+	client := &mockCoreClient{
+		listFocusPresenceResp: coreResp,
+	}
+	h := NewHandler(client)
+
+	req := connect.NewRequest(&webv1.WebListFocusPresenceRequest{SessionId: sessID})
+	req.Header().Set(headerInjectSessionToken, token)
+
+	resp, err := h.WebListFocusPresence(context.Background(), req)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.listFocusPresenceReq, "ListFocusPresence should have been called")
+	assert.Equal(t, sessID, client.listFocusPresenceReq.GetSessionId())
+	assert.Equal(t, token, client.listFocusPresenceReq.GetPlayerSessionToken())
+
+	msg := resp.Msg
+	assert.Equal(t, webv1.WebPresenceContext_WEB_PRESENCE_CONTEXT_LOCATION, msg.GetContext())
+	assert.Equal(t, "01HYXLOCATION0000000000001", msg.GetContextId())
+	require.Len(t, msg.GetEntries(), 1)
+	assert.Equal(t, "alice", msg.GetEntries()[0].GetCharacterName())
+	assert.Equal(t, webv1.WebPresenceState_WEB_PRESENCE_STATE_ACTIVE, msg.GetEntries()[0].GetState())
 }

--- a/test/integration/auth/core_client_shim_test.go
+++ b/test/integration/auth/core_client_shim_test.go
@@ -102,6 +102,10 @@ func (c *coreClientShim) RevokeOtherPlayerSessions(ctx context.Context, req *cor
 	return c.s.RevokeOtherPlayerSessions(ctx, req)
 }
 
+func (c *coreClientShim) ListFocusPresence(ctx context.Context, req *corev1.ListFocusPresenceRequest) (*corev1.ListFocusPresenceResponse, error) {
+	return c.s.ListFocusPresence(ctx, req)
+}
+
 // Compile-time check that coreClientShim satisfies the interface. If
 // web.CoreClient gains a method, this fails to build until the shim is updated.
 var _ web.CoreClient = (*coreClientShim)(nil)


### PR DESCRIPTION
## Summary

T9 of the holomush-5b2j epic — replaces the T1 stub `*Handler.WebListFocusPresence` with the real gateway forwarder.

- Uses ConnectRPC wrapper types (`*connect.Request[T]` / `*connect.Response[T]`).
- Reads `player_session_token` from `req.Header().Get(headerInjectSessionToken)` (not the wire body).
- Forwards to `h.client.ListFocusPresence(rpcCtx, ...)` with the standard `rpcTimeout` context wrapper.
- Translates `corev1` → `webv1`: context enum, per-entry state enum, entries.

Mirrors `WebListSessionStreams` exactly.

## Interface cascade

Adding `ListFocusPresence` to the package-private `web.CoreClient` interface required matching method declarations / stubs on every implementor / mock / shim:

- `cmd/holomush/deps.go` — `GRPCClient` interface
- `cmd/holomush/deps_test.go` — `mockGRPCClient`
- `internal/grpc/client.go` — production `*Client` (satisfies `TestCoreClient_SatisfiedByGRPCClient`)
- `internal/web/handler_test.go` — `mockCoreClient`
- `test/integration/auth/core_client_shim_test.go` — `coreClientShim`

## Files

- `internal/web/handler.go` — real forwarder + 3 translate helpers; interface extension
- `internal/web/handler_test.go` — added test + mock method
- `internal/grpc/client.go` — production client method
- `cmd/holomush/deps.go` + `deps_test.go` — interface + mock
- `test/integration/auth/core_client_shim_test.go` — shim passthrough

## Bead

`holomush-5b2j.12` (epic: `holomush-5b2j` [E-5B2J]). Unblocks T11 (`5b2j.13` — web client snapshot fetch).

## Verification

- [x] `task test -- ./internal/web/ -run TestWebListFocusPresenceForwardsToCoreService` — PASS
- [x] All 1042 unit tests across `internal/web`, `internal/grpc`, `cmd/holomush` — PASS
- [x] `task pr-prep` full lane green
- [x] `task lint:go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web API endpoint to list focus presence, returning active presence entries (character name, context, and state) and requiring session authentication.

* **Tests**
  * Added unit and integration tests covering request forwarding, session handling, response mapping, error propagation, and end-to-end presence listing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->