### PR TITLE
docs(scenes-phase-4): spec + implementation plan + 5 captured ADRs (5rh.13)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,11 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Denormalize Pose-Order Metadata Against scene_log Source of Truth](holomush-r4th-denormalize-pose-order-metadata.md) | 2026-05-19 | Accepted | `holomush-r4th` |
+| [Migrate Scene Subjects to NATS Dot-Style Atomically With Plugin Emit Code](holomush-s9nu-scene-subject-atomic-migration.md) | 2026-05-19 | Accepted | `holomush-s9nu` |
+| [Classify All Scene Content Events as sensitivity:always, Including OOC](holomush-sb3n-scene-content-sensitivity-always.md) | 2026-05-19 | Accepted | `holomush-sb3n` |
+| [Generalize Plugin-Code Participant Gate from Scene-Log to All Participant-Only Scene RPCs](holomush-nt2d-participant-gate-pattern-generalized.md) | 2026-05-19 | Accepted (supersedes `holomush-c8a9`) | `holomush-nt2d` |
+| [Extend sceneAuditLogStore With Operation-Specific InsertScenePose for Transactional Atomicity](holomush-1ang-audit-interface-operation-specific-tx.md) | 2026-05-19 | Accepted | `holomush-1ang` |
 | [Snapshot RPC as Source of Truth for Current-State Presence](holomush-da2q-snapshot-rpc-source-of-truth-presence.md) | 2026-05-19 | Accepted | `holomush-da2q` |
 | [Current-State Presence Snapshot Exempt from I-PRIV-1 Temporal Floor](holomush-o46k-presence-snapshot-exempt-from-priv-floor.md) | 2026-05-19 | Accepted | `holomush-o46k` |
 | [Introduce list_presence ABAC Action with Default-Deny and Same-Location Seed](holomush-lp65-list-presence-abac-action.md) | 2026-05-19 | Accepted | `holomush-lp65` |
@@ -30,7 +35,7 @@ edge and the file's `**Status:**` reflects the supersession.
 | [Require N=2 Consumer Validation Before SDK Primitive Extraction](holomush-lrt3-n2-consumer-validation-sdk-extraction.md) | 2026-05-16 | Accepted | `holomush-lrt3` |
 | [Strict Plugin-Boundary: Plugins Must Not Modify internal/](holomush-z1e7-strict-plugin-boundary.md) | 2026-05-16 | Accepted | `holomush-z1e7` |
 | [Startup-Time Set-Equality Validation of crypto.emits Declarations](holomush-3vsb-manifest-emit-type-startup-validation.md) | 2026-05-16 | Accepted | `holomush-3vsb` |
-| [Enforce Scene Privacy at Plugin Code, Not ABAC Engine](holomush-c8a9-scene-privacy-plugin-code-enforcement.md) | 2026-05-16 | Accepted | `holomush-c8a9` |
+| [Enforce Scene Privacy at Plugin Code, Not ABAC Engine](holomush-c8a9-scene-privacy-plugin-code-enforcement.md) | 2026-05-16 | Superseded by `holomush-nt2d` | `holomush-c8a9` |
 | [Use suiteT Capture Pattern Instead of GinkgoT() for testing.TB](holomush-1f1w-suitet-capture-pattern-ginkgo-testing-tb.md) | 2026-05-16 | Accepted | `holomush-1f1w` |
 | [Remap INV-Pinned Test\* Functions to Ginkgo Suite Entries on Migration](holomush-iv7l-remap-inv-pinned-tests-ginkgo-suite-entries.md) | 2026-05-16 | Accepted | `holomush-iv7l` |
 | [AdminReadStream Bypasses HistoryReader/Dispatcher](holomush-8f2x-adminreadstream-bypasses-historyreaderdispatcher.md) | 2026-05-12 | Accepted | `holomush-8f2x` |

--- a/docs/adr/holomush-1ang-audit-interface-operation-specific-tx.md
+++ b/docs/adr/holomush-1ang-audit-interface-operation-specific-tx.md
@@ -1,0 +1,146 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Extend sceneAuditLogStore With Operation-Specific InsertScenePose for Transactional Atomicity
+
+**Date:** 2026-05-19
+**Status:** Accepted
+**Decision:** holomush-1ang
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Scenes Phase 4 (`holomush-5rh.13`) introduces maintained pose-order metadata (see ADR `holomush-r4th`). When the audit consumer receives a `scene_pose` event, three SQL statements must be atomic:
+
+1. `INSERT INTO scene_log ... ON CONFLICT (id) DO NOTHING` (existing Phase 3 path).
+2. `UPDATE scenes SET total_pose_count = total_pose_count + 1 WHERE id = $1 RETURNING total_pose_count` (Phase 4 metadata).
+3. `UPDATE scene_participants SET last_pose_at = $1, last_pose_seq = $2 WHERE scene_id = $3 AND character_id = $4` (Phase 4 metadata).
+
+INV-P4-10 ("scene_pose audit-row insertion AND pose-metadata update MUST be transactional") pins the requirement.
+
+The `SceneAuditServer` plugin component holds the audit pipeline. Its current shape (`plugins/core-scenes/audit.go:94-98`):
+
+```go
+type SceneAuditServer struct {
+    pluginv1.UnimplementedPluginAuditServiceServer
+    store        sceneAuditLogStore
+    memberLookup sceneMembershipLookup
+}
+```
+
+The `store` field is typed as an **interface** (`sceneAuditLogStore`), not a `*pgxpool.Pool`. The interface exposes only `Insert(...)` and `queryLog(...)` — there is no transaction primitive. This is by design: the interface decouples the audit handler from pool lifecycle, enabling test substitution.
+
+For Phase 4's atomic multi-statement operation, the transaction boundary must cross the interface. Four alternatives evaluated, all touching the `sceneAuditLogStore` contract or the `SceneAuditServer` struct shape.
+
+## Decision
+
+Extend `sceneAuditLogStore` with a single new operation-specific method:
+
+```go
+type sceneAuditLogStore interface {
+    // ... existing Insert(...) and queryLog(...) ...
+
+    // InsertScenePose performs the scene_log INSERT for a scene_pose
+    // event AND the pose-metadata UPDATEs on scenes + scene_participants
+    // in one transaction. Either all rows mutate or none do (INV-P4-10).
+    InsertScenePose(
+        ctx context.Context,
+        id []byte,
+        subject, eventType string,
+        timestamp *timestamppb.Timestamp,
+        actorKind string,
+        actorID []byte,
+        payload []byte,
+        schemaVer int,
+        codec string,
+        dekRef *int64,
+        dekVersion *int32,
+        sceneID string,
+        posedCharID string,
+    ) error
+}
+```
+
+The concrete `*SceneAuditStore` implementation uses `pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error { ... })` to wrap the three statements in one transaction. A private `insertSceneLogTx(ctx, tx, ...)` helper extracts the scene_log INSERT logic so the existing public `Insert` (rewritten as a thin transactional wrapper) and `InsertScenePose` share the same INSERT path.
+
+The `SceneAuditServer.AuditEvent` handler dispatches on event type:
+
+```go
+if row.GetType() == "scene_pose" {
+    s.store.InsertScenePose(ctx, ..., sceneID, posedCharID)
+} else {
+    s.store.Insert(ctx, ...)
+}
+```
+
+This establishes the precedent: future audit-handler transactional operations get their own named methods on the interface, NOT a generic transaction primitive.
+
+## Rationale
+
+**Interface-based decoupling enables deterministic fault-injection.** INV-P4-10's fault-injection test substitutes `sceneAuditLogStore` with a fake that returns an error after a simulated step-1 INSERT but before step-2 UPDATE. This asserts the rollback contract without a real database. Pool exposure would force test fakes to construct a `*pgxpool.Pool` — heavyweight test surface for what should be a deterministic unit test.
+
+**Naming the operation prevents misuse.** A generic `WithTx(ctx, fn func(pgx.Tx) error) error` method would be reusable for any future multi-statement operation — but that reusability is a liability. Future callers could use `WithTx` for unrelated multi-statement work without recognizing they bypass `InsertScenePose`'s named INV-P4-10 contract. The interface method's name pins the operation; callers cannot accidentally invoke transaction semantics for a different operation.
+
+**The interface extends naturally; the constructor doesn't churn.** `SceneAuditServer` is constructed with a `sceneAuditLogStore` field today. Adding a method to the interface requires test fakes to implement the new method but preserves the existing constructor signature. Restructuring `SceneAuditServer` to hold a `*pgxpool.Pool` directly would propagate test churn across every existing audit test.
+
+**The `Insert` refactor is behavior-preserving.** The public `Insert` becomes a thin wrapper around `insertSceneLogTx` inside its own `pgx.BeginFunc`. The SQL, the `ON CONFLICT (id) DO NOTHING` semantics, the argument list, and the error wrapping are all preserved verbatim. INV-P4-10's transactional contract is captured in the shared helper; non-pose events get one-statement transactions (same as before); scene_pose events get three-statement transactions.
+
+**The pattern generalizes correctly.** If Phase 6 (`holomush-cb4x`) introduces a transactional operation (e.g., publishing a scene log requires snapshotting + flag-setting in one transaction), it gets its own named method (`PublishSceneLog` or similar). The interface grows by one method per named operation; each method's atomicity contract is explicit. Future maintainers cannot bypass the contract by reusing a generic transaction primitive.
+
+## Alternatives Considered
+
+**Option A: Expose `Pool()` on the `sceneAuditLogStore` interface.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Minimal interface surface — one accessor; server opens its own transactions |
+| Weaknesses | Leaks pool internals into a test-substitutable interface; fakes must construct pgxpool — heavy test surface; violates the separation between store coordination and pool lifecycle established in Phase 1-3 |
+
+**Option B: Add generic `WithTx(ctx, fn func(pgx.Tx) error) error` method.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Reusable for any future multi-statement operation |
+| Weaknesses | Grows beyond Phase 4 needs; future callers bypass INV-P4-10's specific atomicity contract; too broad — names the mechanism, not the operation; encourages "I'll use WithTx for this other thing" anti-pattern |
+
+**Option C: Add operation-specific `InsertScenePose` method to interface (chosen).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Names the operation the interface is responsible for; INV-P4-10's contract is testable via a fake that simulates partial failure; `SceneAuditServer` constructor unchanged; future operations get their own named methods with their own atomicity contracts |
+| Weaknesses | Interface grows one method per transactional operation; `insertSceneLogTx` private helper introduces a small DRY refactor on the existing Insert path |
+
+**Option D: Restructure `SceneAuditServer` to hold pool directly.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | No interface extension needed; server has direct transaction access |
+| Weaknesses | Breaks interface-based decoupling established by the existing `audit.go:96` field type; propagates test churn across existing audit tests; future test substitution becomes pool-dependent |
+
+## Consequences
+
+**Positive:**
+
+- INV-P4-10 fault-injection test substitutes the interface with a fake that simulates step-2 failure — no real DB needed.
+- Pattern for future audit-handler transactional operations is established: one interface method per named operation.
+- The existing public `Insert` is rewritten as a thin wrapper around `insertSceneLogTx` (DRY consolidation, no behavior change).
+- Test fakes can implement deterministic transactional behavior without pgx dependency.
+
+**Negative:**
+
+- Interface grows by one method per new transactional audit operation; maintainers must update fakes.
+- Private `insertSceneLogTx` helper introduces a refactor on the existing `Insert` path that must be validated against existing Phase 1-3 audit tests.
+- Implementers must learn the convention: name the operation, don't expose the mechanism.
+
+**Neutral:**
+
+- The existing public `Insert` semantics are preserved (`ON CONFLICT (id) DO NOTHING` redelivery idempotency; same argument list; same error wrapping).
+- The decision applies specifically to `sceneAuditLogStore`; other plugin interfaces are not affected. Future audit interfaces in other plugins MAY follow this pattern or choose their own — this ADR does not impose a project-wide convention beyond `core-scenes`.
+
+## References
+
+- [Scenes Phase 4 Design](../superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) §9.4
+- [ADR `holomush-r4th`](holomush-r4th-denormalize-pose-order-metadata.md) — Denormalize pose-order metadata (the maintained columns this transaction protects)
+- [Phase 7 Plugin SDK Design](../superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md) (`ON CONFLICT (id) DO NOTHING` idempotency contract)
+- [pgx v5 transaction API](https://pkg.go.dev/github.com/jackc/pgx/v5#BeginFunc) (the `BeginFunc` helper)
+- Bead: `holomush-5rh.13` (Phase 4 design)

--- a/docs/adr/holomush-c8a9-scene-privacy-plugin-code-enforcement.md
+++ b/docs/adr/holomush-c8a9-scene-privacy-plugin-code-enforcement.md
@@ -4,7 +4,7 @@
 # Enforce Scene Privacy at Plugin Code, Not ABAC Engine
 
 **Date:** 2026-05-16
-**Status:** Accepted
+**Status:** Superseded by [`holomush-nt2d`](holomush-nt2d-participant-gate-pattern-generalized.md) (broadens scope from scene-log reads to all participant-only scene RPCs)
 **Decision:** holomush-c8a9
 **Deciders:** HoloMUSH Contributors
 

--- a/docs/adr/holomush-nt2d-participant-gate-pattern-generalized.md
+++ b/docs/adr/holomush-nt2d-participant-gate-pattern-generalized.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Generalize Plugin-Code Participant Gate From Scene-Log to All Participant-Only Scene RPCs
+
+**Date:** 2026-05-19
+**Status:** Accepted
+**Decision:** holomush-nt2d
+**Supersedes:** [`holomush-c8a9`](holomush-c8a9-scene-privacy-plugin-code-enforcement.md) (broadens scope)
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+ADR `holomush-c8a9` established that scene-log content reads (Phase 6 work, `holomush-cb4x`) are gated by a direct `scene_participants` membership check in plugin code, before any ABAC engine consultation. The rationale: scene privacy is unconditional (INV-S9); ABAC evaluation creates a policy-gap risk where misconfigured or future-added policies could leak content to non-participants. Plugin-code gates are unconditional under the call graph and survive ABAC engine evolution.
+
+c8a9 was scoped to **scene-log reads** specifically. The ADR text said:
+
+> "Pattern generalises: any future use with participant-only visibility (e.g., private channels with content-encryption) follows the same shape."
+
+Phase 4 (`holomush-5rh.13`) introduces `GetPoseOrder` — a new RPC that returns participant-ordered pose metadata. Pose-order data reveals:
+
+- Active participant set for the scene (`character_id` and `character_name` of every member).
+- Per-participant timing (`last_posed_at` timestamps).
+- Per-participant eligibility (computed from `total_pose_count` and per-character `last_pose_seq`).
+
+This is participant-only data by the same logic as scene-log content. A non-participant who could call `GetPoseOrder` would learn who is in the scene and when they last interacted — leaking the participant set even if the IC content remained encrypted.
+
+Two approaches were available:
+
+1. Route `GetPoseOrder` through the ABAC engine (standard resource-authorization path).
+2. Apply the c8a9 plugin-code gate pattern, generalizing it from scene-log to `GetPoseOrder`.
+
+A secondary question: should the participant check use a new `IsParticipant` store method or reuse the existing `GetParticipant` (which returns a row or a `SCENE_PARTICIPANT_NOT_FOUND` error)?
+
+## Decision
+
+`GetPoseOrder` applies the INV-S9 plugin-code participant gate pattern. The handler calls `s.store.IsParticipant(ctx, sceneID, characterID)` — a new binary predicate store method that returns `true` only when the character has `role = 'owner'` or `role = 'member'` (NOT `'invited'`). The ABAC engine MUST NOT be consulted for this gate.
+
+This generalizes c8a9's pattern from one RPC (scene-log read) to all participant-only scene RPCs. Future participant-only scene surfaces (Phase 6's `GetSceneLog` via `holomush-cb4x`, any future scene-presence RPC, any future scene-membership-list RPC) inherit the same gate.
+
+The new ADR **supersedes c8a9** because it broadens the scope rather than adding alongside. c8a9's scene-log-specific pattern is fully absorbed; Phase 6's `GetSceneLog` will follow this generalized ADR.
+
+The `IsParticipant` store method is distinct from the existing `GetParticipant`:
+
+- `GetParticipant(ctx, sceneID, characterID) (*ParticipantRow, error)` returns a row or `SCENE_PARTICIPANT_NOT_FOUND` error.
+- `IsParticipant(ctx, sceneID, characterID) (bool, error)` returns a binary predicate with the role filter `IN ('owner', 'member')` applied in SQL.
+
+INV-P4-5 closes the indirect ABAC-attribute leak path: `AttributeResolverService.ResolveResource` MUST NOT expose pose-order data (`last_pose_at`, `last_pose_seq`, `total_pose_count`) as scene attributes. The ABAC engine sees only the existing Phase 3 scene attribute set; pose-order data is reachable exclusively via the gated `GetPoseOrder` RPC.
+
+INV-P4-4 meta-test (`internal/test/invariants/scene_no_abac_in_getposeorder_test.go`) uses `go/parser` to extract the `GetPoseOrder` function body and rg-asserts no `engine.Evaluate` / `engine.CanPerformAction` call appears. This makes the structural invariant CI-enforced.
+
+## Rationale
+
+**Unconditional guarantee requires unconditional architecture.** "ABAC will be configured correctly" is not the same as "non-participants cannot see pose-order data." The former is a property of policy text; the latter is a property of the call graph. The plugin-code gate makes the guarantee architectural (not policy-dependent).
+
+**c8a9's pattern explicitly generalizes.** c8a9 itself anticipated this case: its text says the pattern applies to "any future use with participant-only visibility." `GetPoseOrder` is the first exercise of that generalization. Filing a new ADR (vs. an addendum) makes the generalization explicit for future scene RPCs and for plugins outside scenes that adopt the same shape.
+
+**`IsParticipant` names the gate's contract.** The existing `GetParticipant` conflates lookup with error handling — a caller using it for the gate would need to inspect the oops code to distinguish "not found" from "gate decision." `IsParticipant` is a binary predicate with the role filter `IN ('owner', 'member')` applied in SQL — the invited-role exclusion is pinned in one place (the SQL `WHERE` clause), not scattered across callers.
+
+**The role filter is load-bearing.** Phase 3 introduced the `invited` role as a transient participant state (a row that grants the holder permission to JOIN, but not membership yet). An `invited` row is structurally a participant in `scene_participants` but is NOT a member of the scene's privacy boundary. The gate's `IN ('owner', 'member')` filter pins this distinction; using `GetParticipant` would risk treating invited rows as participants in callers that forget the filter.
+
+**`AttributeResolverService` MUST NOT expose pose-order data.** The c8a9 ADR pinned this principle for scene-log content; INV-P4-5 extends it to pose-order metadata. Without this restriction, the ABAC engine could reach pose-order data indirectly (via attribute resolution during policy evaluation), bypassing the plugin-code gate. The restriction is enforced both by code-review (the resolver does not query pose-order columns) and by meta-test (rg-asserts no pose-metadata column references in `resolver.go`).
+
+## Alternatives Considered
+
+**Option A: Route `GetPoseOrder` through ABAC engine (standard resource authorization).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Consistent with standard resource authorization; no special-case pattern; ABAC audit log records the decision |
+| Weaknesses | Requires a policy declaring who can call GetPoseOrder; any policy gap or misconfiguration allows non-participants to see pose-order data; inconsistent with c8a9's rationale for unconditional participant-only surfaces; future ABAC engine evolution (admin-bypass patterns, emergency override) could leak pose-order data without intent |
+
+**Option B: Extend c8a9's plugin-code gate to `GetPoseOrder` (chosen).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Privacy boundary enforced before ABAC is consulted; no policy gap can leak pose-order data; pattern is now established for any future participant-only RPC; INV-P4-4 meta-test makes the structural invariant CI-enforced |
+| Weaknesses | Plugin-code gate is not surfaced in ABAC audit logs (visibility cost); creates a dual-path pattern (some gates in ABAC, some in plugin code) that implementers must learn |
+
+**Option C: Use existing `GetParticipant` instead of new `IsParticipant`.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Reuses an existing interface method; no interface extension |
+| Weaknesses | Conflates lookup with gate decision; caller must inspect oops code; role filter must be re-applied at every gate site (error-prone); the gate's intent is binary, not a row-lookup |
+
+## Consequences
+
+**Positive:**
+
+- No policy gap can route non-participants to pose-order data.
+- Pattern is now documented and established for `GetSceneLog` (Phase 6, `holomush-cb4x`) and any other participant-only scene RPC.
+- `IsParticipant` is reusable across the codebase wherever the binary gate semantics are needed.
+- INV-P4-4 meta-test catches accidental ABAC consultation in `GetPoseOrder` at CI time, not at code review.
+
+**Negative:**
+
+- Plugin-code gates are not visible in ABAC audit trails; operator forensic correlation must be done via the plugin's structured logs.
+- Implementers must learn the dual-path convention: standard ABAC for resource operations that route through manifest policies; plugin-code gate for unconditional participant-only surfaces.
+- One additional store method on `sceneStorer` interface (test fakes must implement it).
+
+**Neutral:**
+
+- Pose-order metadata is also excluded from `AttributeResolverService.ResolveResource` (INV-P4-5), closing the indirect ABAC leak path.
+- c8a9 is superseded but not deleted — the ADR file remains for historical context; its decision is absorbed into this ADR's broader scope.
+- Phase 6 (`cb4x`) `GetSceneLog` will follow this generalized ADR, not c8a9 directly.
+
+## References
+
+- [Scenes Phase 4 Design](../superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) §7.3, §11
+- [Substrate Contract Spec](../superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) INV-S9
+- [History Scope Privacy Design](../superpowers/specs/2026-05-17-history-scope-privacy-design.md) §3 (scene privacy is absolute)
+- [Scenes v2 Design](../superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md) §5.5 (original hard privacy boundary framing)
+- [Superseded: `holomush-c8a9`](holomush-c8a9-scene-privacy-plugin-code-enforcement.md) (narrower scope: scene-log reads only)
+- [ADR `holomush-kokk`](holomush-kokk-custom-go-native-abac-engine.md) — Custom Go-native ABAC engine (not in the path for scene participant-only surfaces)
+- Bead: `holomush-cb4x` (Phase 6 scene log + export — will follow this generalized ADR)
+- Bead: `holomush-5rh.13` (Phase 4 design)

--- a/docs/adr/holomush-r4th-denormalize-pose-order-metadata.md
+++ b/docs/adr/holomush-r4th-denormalize-pose-order-metadata.md
@@ -1,0 +1,112 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Denormalize Pose-Order Metadata Against scene_log Source of Truth
+
+**Date:** 2026-05-19
+**Status:** Accepted
+**Decision:** holomush-r4th
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Scenes Phase 4 (`holomush-5rh.13`) introduces pose-order computation for the `GetPoseOrder` RPC and the `scene order` subcommand. Four pose-order modes are supported (`strict`, `3pr`, `5pr`, `free`); each requires per-participant timing data to determine eligibility and display order.
+
+The scenes v2 spec section 4.2 specified:
+
+> "Pose order is derived from the IC event stream — no separate state table."
+
+This formulation matches the event-sourcing posture of the rest of the scene domain: scene_log is the audit projection of the IC event stream and is the canonical record of scene content. Deriving pose order from scene_log was conceptually clean — no risk of source-of-truth divergence.
+
+However, the v2 spec was written before the substrate-contract era and did not anticipate the per-call cost. Deriving pose order on each `GetPoseOrder` invocation requires reading recent scene_pose rows from scene_log:
+
+- For `strict` mode: replay all poses to determine current queue order.
+- For `3pr` / `5pr` modes: for each participant, count "other characters' poses since this participant's last pose" — interleaving across the recent pose window.
+- For long-running async scenes, the pose history can be hundreds or thousands of rows.
+
+The cost is unbounded as scenes age. A scene running for weeks with hundreds of poses would require either a fixed `LIMIT` (broken correctness for large participant counts) or a full scan (latency disaster).
+
+Additionally: the scene_log payload column carries ciphertext when `sensitivity: always` events (Phase 4 introduces these for `scene_pose` / `scene_say` / `scene_emit` / `scene_ooc`). Pose-order computation needs only metadata (`actor`, `timestamp`, `type`) — all plaintext columns. Reading scene_log for pose-order computation is structurally metadata-only, but the cost remains.
+
+## Decision
+
+Maintain denormalized pose-order metadata in three new schema columns, updated transactionally by the audit consumer on every `scene_pose` insertion:
+
+- `scenes.total_pose_count INTEGER NOT NULL DEFAULT 0` — per-scene monotonic pose counter.
+- `scene_participants.last_pose_at TIMESTAMPTZ NULL` — per-participant timestamp of most recent pose (NULL = never posed).
+- `scene_participants.last_pose_seq INTEGER NULL` — per-participant value of `total_pose_count` at the moment of their last pose.
+
+`GetPoseOrder` reads these columns via a single SQL join — `O(N participants)` per call, regardless of scene history depth.
+
+The `scene_log` table remains the canonical source of truth. The maintained columns are a derived cache. Documented recovery SQL (spec §9.5) rebuilds the metadata from scene_log if drift is suspected:
+
+```sql
+UPDATE scenes s SET total_pose_count = (
+    SELECT COUNT(*) FROM scene_log
+    WHERE subject = 'events.' || $game || '.scene.' || s.id || '.ic'
+      AND type = 'scene_pose'
+);
+-- (plus per-participant rebuild via window function — see spec §9.5)
+```
+
+The rebuild-equivalence property is pinned by INV-P4-8 (integration test exercises the recovery SQL after arbitrary pose history and asserts byte-identical metadata).
+
+## Rationale
+
+**Unbounded `O(H)` is architecturally untenable.** A scene running for weeks accumulates pose history that the read path cannot reasonably scan on every call. Even with optimistic indexing, the cost grows without bound as scenes age. Denormalized state with bounded read cost is the structural fix.
+
+**The metadata is a function of scene_log, not a parallel source of truth.** The recovery SQL formalizes the relationship: `total_pose_count = COUNT(scene_log.type='scene_pose')`; per-participant `last_pose_at` and `last_pose_seq` are deterministic projections of the same rows. INV-P4-8's integration test makes the equivalence CI-enforced. The maintained columns cannot diverge from scene_log without operator intervention.
+
+**Ciphertext is irrelevant to ordering.** Pose-order computation needs only `actor`, `timestamp`, and a monotonic sequence. All three are plaintext columns on scene_log (`actor` is the Phase 7 plugin SDK contract; `timestamp` is the event timestamp; the new `last_pose_seq` projects the natural ordering). The decision to denormalize does NOT introduce a crypto path dependency for pose-order reads — Phase 7's `metadata_only=true` semantics are preserved.
+
+**Transactional INSERT+UPDATE is the right boundary.** INV-P4-10 pins the atomicity: the audit consumer either commits scene_log INSERT + both UPDATEs together, or rolls all three back. No partial states are visible to readers. The audit consumer is the natural durability boundary — JetStream delivery + plugin AuditEvent + scene_log persist is already the transactional unit; the metadata UPDATEs are folded inside.
+
+## Alternatives Considered
+
+**Option A: Derive pose order from scene_log on every call (v2 §4.2 original).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | No extra mutable state; pose order always reflects canonical truth; no rebuild procedure needed; pure event-sourcing posture |
+| Weaknesses | `O(H)` per call unbounded as scenes age; full payload scan required even though payload is ciphertext-irrelevant for ordering; latency unacceptable for active scenes with hundreds of poses |
+
+**Option B: Maintained metadata with rebuild contract (chosen).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | `O(N participants)` per call regardless of history depth; metadata columns are plaintext (no DEK dependency); recovery SQL documented for drift repair; INV-P4-8 pins rebuild-equivalence as a CI-enforced contract |
+| Weaknesses | Introduces mutable denormalized state; requires atomic INSERT+UPDATE transaction per pose; operators must run recovery SQL after manual scene_log intervention |
+
+**Option C: In-memory cache with on-read derivation.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | No schema changes; cache populated lazily on first call |
+| Weaknesses | Cache invalidation on every pose emit; multi-process cache coherence (Phase 7 plugin SDK has plugin restart paths); plugin restart loses cache; latency on cache miss can still be `O(H)`; complexity for marginal gain |
+
+## Consequences
+
+**Positive:**
+
+- `GetPoseOrder` is bounded by participant count, not scene age.
+- Pose-order computation is a pure function over already-loaded rows — no additional DB roundtrips after the single SELECT.
+- The maintained columns are plaintext metadata; no decryption path required for pose-order reads.
+- Rebuild SQL provides an operator-runbook tool for drift repair.
+
+**Negative:**
+
+- Every `scene_pose` audit event requires a three-statement transaction (INSERT + 2 UPDATEs).
+- Operators must run the recovery SQL after any manual intervention on scene_log (e.g., row deletion for retention compliance).
+- The schema migration adds three columns; future schema changes must account for them.
+
+**Neutral:**
+
+- The `scene_log` table remains canonical; maintained columns are a derived cache. The decision does not change the source-of-truth posture, only the read-path cost.
+- INV-P4-8 makes the rebuild-equivalence property a CI-enforced contract; the denormalization cannot silently diverge from the event log without test failure.
+
+## References
+
+- [Scenes Phase 4 Design](../superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) §6, §9, §9.4, §9.5
+- [Scenes v2 Design](../superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md) §4.2 (superseded for this concern)
+- [Phase 7 Plugin SDK Design](../superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md) (plugin audit table shape; ciphertext irrelevance for ordering metadata)
+- Bead: `holomush-5rh.13` (Phase 4 design)

--- a/docs/adr/holomush-s9nu-scene-subject-atomic-migration.md
+++ b/docs/adr/holomush-s9nu-scene-subject-atomic-migration.md
@@ -1,0 +1,110 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Migrate Scene Subjects to NATS Dot-Style Atomically With Plugin Emit Code
+
+**Date:** 2026-05-19
+**Status:** Accepted
+**Decision:** holomush-s9nu
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Scenes Phase 4 (`holomush-5rh.13`) is the first time `core-scenes` emits plugin-owned scene events. The substrate-contract spec INV-S4 requires NATS dot-style subjects for all new code:
+
+```text
+events.<game_id>.<domain>.<entity-id>[.<facet>...]
+```
+
+For scenes specifically:
+
+- IC stream: `events.<game_id>.scene.<scene_id>.ic`
+- OOC stream: `events.<game_id>.scene.<scene_id>.ooc`
+
+Existing substrate-side scene-aware code (`internal/grpc/stream_access.go`, `internal/grpc/scope_floor.go`, `internal/grpc/query_stream_history.go`) was authored before INV-S4 and parses legacy colon-style subjects (`scene:<id>:ic`, `scene:<id>:ooc`). Two migration strategies were available:
+
+1. Add a translation layer (extend `internal/eventbus/subjectxlate/`) so colon-style and dot-style coexist; plugin emits dot-style; substrate gates parse colon-style; the layer translates.
+2. Migrate plugin emit code AND substrate-side scene-aware code atomically in the same PR; no translation layer for scene subjects.
+
+A complicating discovery: `internal/grpc/scope_floor.go:21-28` carries a developer note that the function's colon-style prefix match never fires for production NATS subjects:
+
+> "`streamScopeFloor` currently inspects legacy stream-name prefixes (`location:`, `scene:`), but production callers pass NATS subjects (`events.<gid>.location.X`), so the loop returns `time.Time{}` for every real-world subject today."
+
+This means the iwzt §6.1 temporal floor for scene streams is not merely untested — it is **actively non-functional for all real traffic**. The function is wired up, but its prefix match never matches production subjects. INV-P4-9 ("late-joining participants MUST see only IC events from `joined_at` forward") is therefore a live invariant currently being violated by silent fallthrough.
+
+## Decision
+
+Scene-subject migration ships atomically: plugin emit code AND substrate-side scene-aware code migrate to NATS dot-style in one PR. No translation layer for scene subjects.
+
+Concretely, the single PR contains:
+
+- Plugin: `plugins/core-scenes/service.go` emit subjects updated; new helpers `dotStyleSceneSubject` / `IC` / `OOC` in `store.go`.
+- Substrate: `internal/grpc/stream_access.go` (`isPrivateStream`, `extractSceneID`, scene-stream detection), `internal/grpc/scope_floor.go` (scene branch in `streamScopeFloor`), `internal/grpc/query_stream_history.go` (I-17 hardcoded scene-membership gate) — all migrated to recognise dot-style.
+- Tests: corresponding `_test.go` files updated; INV-P4-9 unit-level pre/post pin lands as a table-driven test whose diff in the migration commit captures the bug-fix moment.
+- Docs: iwzt §3 + scenes v2 §3.1 stream-naming tables updated.
+
+Non-scene colon-style subjects (`location:*`, `character:*`, `notifications:*`) are explicitly out of Phase 4 scope; tracked separately by `holomush-rops` (P1, top-level).
+
+INV-S1 boundary discipline: the substrate-side change crosses the `internal/grpc/` boundary, so the PR is reviewed under both `code-reviewer` (substrate) AND `abac-reviewer` (`query_stream_history.go` adjacency to access control gating). The Phase 4 plugin work and the substrate-side scene-aware migration are reviewed together; INV-S1 forbids bundling cross-cutting substrate changes inside a plugin PR — Phase 4 is permitted because the substrate change is scene-aware (not domain-free substrate) and the boundary contract for that substrate code IS the scene subject format.
+
+## Rationale
+
+**The I-17 gate fails closed on unrecognized subject forms.** A translation window where plugin emits dot-style but substrate gates parse colon-style would silently break scene stream access for all Phase 4 emits. There is no acceptable transitional state.
+
+**The translation layer adds permanent maintenance surface.** `subjectxlate/` is a generic translator with no scene-specific path today. Extending it to handle scene subjects in both directions adds code that must be maintained indefinitely; the broader `holomush-rops` sweep would eventually remove it anyway. Atomic migration avoids accreting the very layer the project directive wants gone.
+
+**Closes the `scope_floor.go` live silent regression as a correctness fix.** Atomic migration converts a "format hygiene" change into a "bug-fix" change — the iwzt §6.1 temporal floor is currently inactive for scene streams, and Phase 4's migration is the first time it actually starts working. INV-P4-9's unit-level test pins the bug-fix moment via the test-file diff in the migration commit.
+
+**Single-form parsing is structurally simpler.** Post-migration, substrate gates know exactly one subject form. No branching, no conversion errors, no "did the translation layer handle this case" debugging.
+
+## Alternatives Considered
+
+**Option A: Translation layer for scene subjects.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Plugin and substrate can land independently; no need to coordinate a single large PR |
+| Weaknesses | Translation layer adds permanent maintenance surface; I-17 gate would need to handle both forms; creates a window where dot-style emits hit colon-style gate and fail closed; doesn't fix the `scope_floor.go` live regression — just papers over it |
+
+**Option B: Atomic migration in one PR (chosen).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Eliminates translation surface; substrate gates parse exactly one form; INV-P4-1 enforceable by meta-test rg scan; closes the `scope_floor.go` live silent regression as a correctness change; unit-level test diff pins the bug-fix moment |
+| Weaknesses | Larger single PR; substrate-side reviewed under `code-reviewer` + `abac-reviewer`; INV-S1 boundary discipline requires the substrate change to be reviewed alongside the plugin change |
+
+**Option C: Project-wide migration of ALL colon-style subjects.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Single coherent sweep; nothing left in legacy form |
+| Weaknesses | Touches multiple plugins (core-communication), session stream code, web client backfill code, iwzt code paths; Phase 4 doubles or triples in size; harder to review, harder to roll back; non-scene migration is not blocking Phase 4 |
+
+## Consequences
+
+**Positive:**
+
+- Single canonical subject form for scene streams; no parsing branches for legacy colon-style in substrate.
+- Fixes the `scope_floor.go` temporal-floor regression silently bypassed by all production traffic.
+- INV-P4-1 meta-test enforces "no colon-style scene subjects in production code" as a CI-enforced contract.
+- The decision establishes the precedent for `holomush-rops`'s broader sweep: each domain (scenes, location, character, notifications) migrates atomically with its substrate-side gate consumers.
+
+**Negative:**
+
+- Larger PR footprint; coordinated review under multiple gates.
+- Non-scene colon-style migration remains; the codebase is partially migrated for the duration of `holomush-rops`.
+- The substrate-side scene-aware code crosses the plugin boundary INV-S1 — defensible because it's scene-aware substrate (not domain-free), but the precedent must be cited carefully to avoid normalizing INV-S1 violations.
+
+**Neutral:**
+
+- The non-scene colon-style sweep (`location:*`, `character:*`, `notifications:*`) is tracked by `holomush-rops` (P1).
+- ABAC resource IDs (`scene:<id>` in Cedar policies) are explicitly NOT topics; they remain in `<resource_type>:<id>` form per policy-DSL convention.
+
+## References
+
+- [Scenes Phase 4 Design](../superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) §3.1, §3.2, §3.3
+- [Substrate Contract Spec](../superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) §1.1, INV-S4 (NATS dot-style mandatory)
+- [History Scope Privacy Design](../superpowers/specs/2026-05-17-history-scope-privacy-design.md) §3, §6.1 (iwzt scene-stream temporal floor)
+- [ADR `holomush-jhl5`](holomush-jhl5-plugin-history-scope-opt-in.md) — Plugin manifest history_scope opt-in (related plugin/host contract pattern)
+- Bead: `holomush-rops` (P1 — broader non-scene colon-style sweep)
+- Bead: `holomush-5rh.13` (Phase 4 design)

--- a/docs/adr/holomush-sb3n-scene-content-sensitivity-always.md
+++ b/docs/adr/holomush-sb3n-scene-content-sensitivity-always.md
@@ -1,0 +1,107 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Classify All Scene Content Events as sensitivity:always, Including OOC
+
+**Date:** 2026-05-19
+**Status:** Accepted
+**Decision:** holomush-sb3n
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Scenes Phase 4 (`holomush-5rh.13`) declares 8 plugin-owned scene event types in `crypto.emits`. Four carry RP content (`scene_pose`, `scene_say`, `scene_emit`, `scene_ooc`); four are notice events with metadata-only payloads (`scene_join_ic`, `scene_leave_ic`, `scene_pose_order_changed_ic`, `scene_idle_nudge`).
+
+Each event type requires a `sensitivity` classification from the enum at `internal/plugin/crypto_manifest.go:14-21`: `always` (every emit Sensitive=true; AEAD encryption applied), `may` (caller-controlled per emit), or `never` (Sensitive=true emits rejected at the fence).
+
+The core-communication plugin (`plugins/core-communication/plugin.yaml:273-298`) is the precedent for an 8-type matrix:
+
+| Type | Sensitivity | Privacy boundary |
+|------|-------------|------------------|
+| `say` | `never` | Location (public to all in room) |
+| `pose` | `never` | Location |
+| `ooc` | `never` | Location |
+| `emit` | `never` | Location |
+| `whisper_notice` | `never` | Location (no content) |
+| `page` | `always` | Participants (between two characters) |
+| `whisper` | `always` | Participants (between two characters in same location) |
+| `pemit` | `always` | Participants (storyteller to one character) |
+
+The pattern: privacy boundary determines sensitivity. Location-bounded events are public to everyone present → `never`. Participant-bounded events are private to specific characters → `always`. Notice events with no content payload → `never`.
+
+For scenes, INV-S9 ("scene privacy is absolute"; iwzt §3 "no ABAC override") makes the **participant list** the privacy boundary for all scene content. This is the same boundary that drives `whisper`/`page`'s `always` classification — but `scene_say` is verbally analogous to core-communication's `say` (verbal speech in a shared space). The naming similarity creates a temptation to classify `scene_say` as `never` (matching `say`); INV-S9 makes that wrong — scene `say` is participant-only, not location-public.
+
+A complicating consideration arose for `scene_ooc`. Scenes v2 §3.1 specifies that OOC content is "never archived in the published log." Ephemeral OOC chatter is participant-only by INV-S9 but is not subject to long-term confidentiality concerns. This raised whether `sensitivity: may` (caller-controlled) is appropriate for OOC — letting the caller skip encryption for low-stakes chatter.
+
+## Decision
+
+All 4 scene content events (`scene_pose`, `scene_say`, `scene_emit`, `scene_ooc`) are classified `sensitivity: always`. The 4 notice events are classified `sensitivity: never`.
+
+No event in Phase 4 is classified `sensitivity: may`.
+
+The `always` classification commits the 4 content event types to encryption for the lifetime of the spec. Any future reclassification (e.g., to `may`) requires a deliberate manifest migration with `crypto-reviewer` gate.
+
+## Rationale
+
+**INV-S9 is the privacy-boundary contract.** iwzt §3 commits "scene privacy is absolute" with no ABAC override for `scene:<id>:ic` and `scene:<id>:ooc`. The participant list is the unconditional privacy boundary for all scene content — there is no carve-out for OOC. Classifying any content event as `never` would contradict INV-S9.
+
+**`sensitivity: may` has a known fence gap.** Phase 7 INV-P7-7's manifest-set downgrade fence covers only `always`-classified types. Calling a `may`-classified event with `Sensitive=true` is a runtime decision that the substrate fence cannot pre-decrypt-fence-check. The substrate guarantee for `always` is strictly stronger than for `may`.
+
+**The `holomush-mjy3` footgun applies to all content.** ADR `holomush-mjy3` (not yet filed at decision-bead time but recorded as the `object_examine` sensitivity reconsideration) established the principle: classifying a payload-carrying event type as `never` blocks future encryption. The reverse footgun for `may` is the absence of substrate guarantee strength. `always` is the conservative choice when content privacy is load-bearing.
+
+**Notice events carry no RP content.** `scene_join_ic`, `scene_leave_ic`, `scene_pose_order_changed_ic`, `scene_idle_nudge` payloads carry only metadata (character IDs, names, mode strings, durations). The `whisper_notice` precedent in core-communication classifies a similar "X did something, no content" notice as `never`. Encryption overhead on metadata is unnecessary; visibility to all participants in OOC stream is the intended posture.
+
+**Encryption overhead on ephemeral OOC is acceptable.** Modern AEAD encryption costs microseconds per event; the participant-protection benefit dominates. The "ephemeral OOC chatter" framing is a UX consideration, not a security architecture concern. A future revisit could reclassify if a real performance problem emerges — but the migration cost (deliberate manifest change + reviewer gate) is the correct backstop.
+
+## Alternatives Considered
+
+**Option A: `sensitivity: always` for all 4 content events (chosen).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Privacy boundary is the participant list for all scene content, analogous to whisper/page; Phase 7 INV-P7-7 manifest-set downgrade fence covers all 4 types; unconditional substrate guarantee; no spec-level inconsistency with iwzt §3 |
+| Weaknesses | Encryption overhead on ephemeral OOC chatter that participants often consider low-sensitivity |
+
+**Option B: `sensitivity: may` for `scene_ooc`, `sensitivity: always` for the other 3.**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Caller flexibility for ephemeral OOC; avoids encryption cost for low-stakes exchanges |
+| Weaknesses | Phase 7 fence gap (may not covered by manifest-set downgrade fence); iwzt §3 admits no OOC carve-out; classification inconsistency within the same participant-bounded boundary; future audit risk that someone observes "OOC is may, why isn't IC?" and lowers IC sensitivity |
+
+**Option C: `sensitivity: never` for `scene_ooc` (matching core-communication's `ooc` classification literally).**
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Verbal analogy with core-communication's `ooc`; no encryption overhead |
+| Weaknesses | Contradicts INV-S9 (OOC in scene is participant-only, not location-public); the holomush-mjy3 footgun applies — `never` locks out future encryption without manifest migration; INV-P7-7 fence rejects Sensitive=true emits; a future requirement to encrypt OOC would require both a manifest change AND code change |
+
+## Consequences
+
+**Positive:**
+
+- Uniform unconditional encryption for all scene content; no special-case at the emit gate or audit handler.
+- INV-P7-7 manifest-set downgrade fence covers all 4 content types without exception.
+- Spec-level consistency with iwzt §3 "scene privacy is absolute"; no carve-outs to document or audit.
+- The classification matches the verb-level sensitivity precedent established by core-communication (privacy boundary determines sensitivity; the privacy boundary is the participant list for scenes).
+
+**Negative:**
+
+- AEAD encryption overhead on every OOC emit, regardless of how ephemeral the chatter is. Microseconds per event but multiplied across many participants in active scenes.
+- Future reclassification of any content event requires a manifest migration with `crypto-reviewer` gate, not a simple code change. This raises the bar for evolution — defensible since the privacy boundary is load-bearing.
+
+**Neutral:**
+
+- The 4 notice events remain `sensitivity: never` — they carry only metadata (IDs, names, mode strings, durations), analogous to core-communication's `whisper_notice`.
+- The decision establishes the principle that "verbal analogy" with core-communication is NOT a sufficient basis for scene-event classification — INV-S9 and the participant-list privacy boundary are the load-bearing inputs.
+
+## References
+
+- [Scenes Phase 4 Design](../superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) §2
+- [Substrate Contract Spec](../superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) §1.2, INV-S9
+- [History Scope Privacy Design](../superpowers/specs/2026-05-17-history-scope-privacy-design.md) §3 (scene privacy absolute)
+- [Phase 7 Plugin SDK Design](../superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md) (INV-P7-7 manifest-set downgrade fence covers `always`-only)
+- [Master Event-Payload Crypto Design](../superpowers/specs/2026-04-25-event-payload-crypto-design.md) (sensitivity enum + fence semantics)
+- [core-communication crypto.emits matrix](../../plugins/core-communication/plugin.yaml) (precedent: privacy boundary determines sensitivity)
+- Bead: `holomush-mjy3` (sensitivity:never footgun reconsideration)
+- Bead: `holomush-5rh.13` (Phase 4 design)

--- a/docs/superpowers/plans/2026-05-19-scenes-phase-4-streams-and-pose-order.md
+++ b/docs/superpowers/plans/2026-05-19-scenes-phase-4-streams-and-pose-order.md
@@ -1,0 +1,3572 @@
+# Scenes Phase 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `dev-flow:subagent-driven-development` (recommended) or `dev-flow:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 4 of the scenes rework — plugin-owned IC/OOC event emission (8 new event types), maintained pose-order metadata with O(N participants) computation, `GetPoseOrder` RPC with INV-S9 plugin-code participant gate, `scene` subcommands (`pose`/`say`/`emit`/`ooc`/`order`), and atomic migration of scene-aware substrate code from legacy colon-style to NATS dot-style subjects.
+
+**Architecture:** Eight event types declared in `crypto.emits` + registered via `EmitTypeRegistrar`; content events (`scene_pose`/`say`/`emit`/`ooc`) classified `always`, notice events (`scene_join_ic`/`leave_ic`/`pose_order_changed_ic`/`idle_nudge`) classified `never`. Pose-order computation reads denormalized metadata maintained by the audit consumer on `scene_pose` insertion — single transaction across `scene_log` INSERT + `scenes.total_pose_count` increment + `scene_participants.last_pose_at`/`last_pose_seq` UPDATE. `GetPoseOrder` is plugin-code gated per ADR `holomush-c8a9`; no ABAC consultation. Subject migration is atomic — plugin emits dot-style AND substrate gates parse dot-style in the same PR.
+
+**Tech Stack:** Go 1.22+, PostgreSQL 16, pgx v5 (`pgxpool.Pool`, `pgx.BeginFunc`), `oklog/ulid/v2`, gopher-lua N/A (binary plugin), protobuf + protovalidate, hashicorp/go-plugin (binary RPC transport), Ginkgo/Gomega (integration tests), gotestsum (unit tests).
+
+**Source design:** [`docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md`](../specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md). 13 numbered INV-P4-* invariants with cited tests; coverage matrix at spec §12.1.
+
+**Design bead:** `holomush-5rh.13`. Dependencies: `holomush-5b2j.3` (GetNamesByIDs); soft `holomush-iwzt.15` (Tier 2 filter-at-delivery).
+
+---
+
+## File structure
+
+### Existing files modified
+
+| Path | Responsibility | Phase 4 change |
+|------|---------------|----------------|
+| `api/proto/holomush/scene/v1/scene.proto` | Proto definitions for SceneService | Replace skeletal `GetPoseOrderRequest`/`PoseOrderEntry`/`GetPoseOrderResponse` with Phase 4 shape; ensure `GetPoseOrder` RPC declared in service block |
+| `plugins/core-scenes/main.go` | Plugin entry struct + lifecycle | Add `emitRegistry *pluginsdk.EmitRegistry` field + `EmitRegistry()` method (implements `pluginsdk.EmitTypeRegistrar`); register 8 event types in `main()` |
+| `plugins/core-scenes/plugin.yaml` | Plugin manifest | Add 8 `crypto.emits` entries; add `idle_nudge_threshold` to scene config (informational; column added by migration) |
+| `plugins/core-scenes/service.go` | gRPC RPC handlers + emit calls | Replace `Subject: "scene:" + row.ID` colon-style with dot-style helper; add `GetPoseOrder` handler; add auto-emit of `scene_join_ic`/`scene_leave_ic`/`scene_pose_order_changed_ic` from existing RPC handlers |
+| `plugins/core-scenes/audit.go` | Audit event persistence + interface | Extend `sceneAuditLogStore` interface with `InsertScenePose`; add private `insertSceneLogTx` helper; update `AuditEvent` handler dispatch for `scene_pose` |
+| `plugins/core-scenes/commands.go` | Subcommand dispatcher | Add `pose`/`say`/`emit`/`ooc`/`order` cases to switch; add corresponding handler functions |
+| `plugins/core-scenes/store.go` | SQL store | Add `IsParticipant` + `ListParticipantsWithPoseMeta` methods (extends `sceneStorer`); add SQL helpers `dotStyleSceneSubject`, `dotStyleSceneSubjectIC`, `dotStyleSceneSubjectOOC` |
+| `plugins/core-scenes/types.go` | Domain types | Add `ParticipantsWithPoseMeta` + `ParticipantWithPoseMeta` types |
+| `plugins/core-scenes/service_test.go` | Service tests | Update emit Subject expectations to dot-style; add GetPoseOrder tests (positive/negative path); add auto-emit assertions |
+| `plugins/core-scenes/commands_test.go` | Command tests | Add subcommand tests for `pose`/`say`/`emit`/`ooc`/`order` |
+| `plugins/core-scenes/audit_test.go` | Audit tests | Add `TestAuditEvent_ScenePose_TransactionalInsertAndMetadata`; add fault-injection cases for INV-P4-10 |
+| `plugins/core-scenes/resolver_test.go` | Resolver tests | Add `TestResolveResource_ExcludesPoseOrderMetadata` (INV-P4-5) |
+| `plugins/core-scenes/store_integration_test.go` | Store integration tests | Add `IsParticipant`/`ListParticipantsWithPoseMeta` SQL tests; add `TestPoseOrderMetadata_RebuildFromAuditLog` (INV-P4-8) |
+| `internal/grpc/stream_access.go` | Stream classification helpers (substrate) | Migrate `isPrivateStream`/`extractSceneID`/scene-stream branches to dot-style |
+| `internal/grpc/stream_access_test.go` | Stream classification tests | Update fixtures to dot-style scene subjects |
+| `internal/grpc/scope_floor.go` | Temporal-floor classification (substrate, iwzt §6.1) | Migrate scene branch in `streamScopeFloor` + `extractSceneID` to dot-style |
+| `internal/grpc/scope_floor_test.go` | Scope-floor tests | Update fixtures; **add pre-migration baseline pin per spec §3.3** (table-driven cases for legacy colon-style + dot-style; modified atomically in this PR commit) |
+| `internal/grpc/query_stream_history.go` | I-17 hardcoded scene-membership gate (substrate) | Update gate to recognize dot-style scene subjects |
+| `test/integration/plugin/binary_plugin_test.go` | Plugin integration tests | Update scene-stream fixtures to dot-style |
+
+### New files created
+
+| Path | Responsibility |
+|------|---------------|
+| `plugins/core-scenes/migrations/000006_pose_order_metadata.up.sql` | Schema additions: `scenes.total_pose_count`, `scene_participants.last_pose_at`/`last_pose_seq`, `scenes.idle_nudge_threshold` |
+| `plugins/core-scenes/migrations/000006_pose_order_metadata.down.sql` | Reverse migration |
+| `plugins/core-scenes/poseorder.go` | Pure-function `poseorder.Compute(mode, totalPoseCount, participants, names) → []PoseOrderEntry`; per-mode algorithm |
+| `plugins/core-scenes/poseorder_test.go` | Table-driven tests per mode (INV-P4-7) |
+| `plugins/core-scenes/main_test.go` | Manifest parse + `EmitTypeRegistrar.RegisterEmitTypes` set-equality test (INV-P4-2, INV-P4-3) |
+| `test/integration/scenes/non_participant_ic_isolation_test.go` | Ginkgo integration — INV-P4-6 (closes `holomush-ac50`) |
+| `test/integration/scenes/late_joiner_temporal_floor_test.go` | Ginkgo integration — INV-P4-9 end-to-end |
+| `internal/test/invariants/scene_subjects_test.go` | Meta-test rg-asserting no `"scene:"` literal in pub/sub topic context (INV-P4-1) |
+| `internal/test/invariants/scene_no_abac_in_getposeorder_test.go` | Meta-test rg-asserting no `engine.Evaluate`/`engine.CanPerformAction` in `GetPoseOrder` body (INV-P4-4) |
+| `internal/test/invariants/scene_resolver_no_poseorder_leak_test.go` | Meta-test rg-asserting no pose-metadata column references in `resolver.go` attribute-construction (INV-P4-5) |
+| `internal/test/invariants/p4_coverage_test.go` | Meta-test parsing the spec, asserting every INV-P4-N has cited test + every cited test exists (INV-P4-13) |
+
+### Documentation updates
+
+| Path | Change |
+|------|--------|
+| `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` | §3 stream-type table: scene rows updated to dot-style |
+| `docs/superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md` | §3.1 stream-naming table updated to dot-style |
+
+---
+
+## Phase A — Foundations (proto + schema + types)
+
+### Task 1: Replace skeletal proto definitions with Phase 4 shape
+
+**Files:**
+
+- Modify: `api/proto/holomush/scene/v1/scene.proto:228-243`
+
+- [ ] **Step 1: Replace `GetPoseOrderRequest`, `PoseOrderEntry`, `GetPoseOrderResponse` definitions**
+
+Open `api/proto/holomush/scene/v1/scene.proto`. Locate the existing skeletal block at lines 228-243. Replace with:
+
+```proto
+message GetPoseOrderRequest {
+  string character_id = 1 [(buf.validate.field).string.min_len = 1];
+  string scene_id     = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+message PoseOrderEntry {
+  string                    character_id     = 1;
+  string                    character_name   = 2;
+  bool                      eligible         = 3;
+  google.protobuf.Timestamp last_posed_at    = 4;
+  // Count of poses by other characters since this participant's last pose
+  // (or since scene start if never posed). Meaningful for 3pr/5pr modes.
+  optional uint32           poses_since_last = 5;
+}
+
+message GetPoseOrderResponse {
+  string                  mode             = 1;   // strict | 3pr | 5pr | free
+  uint32                  total_pose_count = 2;
+  repeated PoseOrderEntry entries          = 3;
+}
+```
+
+- [ ] **Step 2: Verify `GetPoseOrder` RPC declared in `service SceneService` block**
+
+Run: `rg -n 'rpc GetPoseOrder' api/proto/holomush/scene/v1/scene.proto`
+
+If absent, add `rpc GetPoseOrder(GetPoseOrderRequest) returns (GetPoseOrderResponse);` inside the existing service block (alongside the other Phase 1-3 RPCs).
+
+- [ ] **Step 3: Regenerate proto bindings**
+
+Run: `task proto`
+
+Expected: `pkg/proto/holomush/scene/v1/scene.pb.go` regenerated; no errors. `git status` shows the generated file modified.
+
+- [ ] **Step 4: Verify generated Go types compile**
+
+Run: `task build`
+
+Expected: build succeeds. Any reference to the old `IsEligible` field or skeletal shapes surfaces here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-proto): replace skeletal GetPoseOrder messages with Phase 4 shape
+
+Pre-Phase-4 scene.proto had skeletal GetPoseOrderRequest/PoseOrderEntry/
+GetPoseOrderResponse with is_eligible naming and no aggregate fields.
+Phase 4 replaces these outright per holomush-5rh.13 spec §7.1 — no
+backward-compat constraint (no releases, no external consumers, no
+in-tree callers of the skeletal shapes).
+
+New shape:
+- Bare character_id + scene_id fields (matches sibling RPC convention
+  KickFromSceneRequest:204 / TransferOwnershipRequest:212).
+- eligible (not is_eligible) — boolean predicate, is_ prefix dropped.
+- New field poses_since_last on PoseOrderEntry (3pr/5pr UX support).
+- New field total_pose_count on GetPoseOrderResponse (header rendering).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 2: Add migration 000006 — pose-order metadata + idle-nudge threshold
+
+**Files:**
+
+- Create: `plugins/core-scenes/migrations/000006_pose_order_metadata.up.sql`
+- Create: `plugins/core-scenes/migrations/000006_pose_order_metadata.down.sql`
+
+- [ ] **Step 1: Write the up migration**
+
+Create `plugins/core-scenes/migrations/000006_pose_order_metadata.up.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Phase 4 pose-order metadata + idle-nudge threshold per holomush-5rh.13 spec §9.
+
+-- Per-scene monotonic pose counter. Incremented on each scene_pose audit
+-- row insert via SceneAuditStore.InsertScenePose.
+ALTER TABLE scenes
+    ADD COLUMN IF NOT EXISTS total_pose_count INTEGER NOT NULL DEFAULT 0;
+
+-- Per-scene idle-nudge threshold. NULL = idle nudges off (default).
+-- Background trigger implementation deferred to a follow-up bead; Phase 4
+-- ships the column + wire-shape only.
+ALTER TABLE scenes
+    ADD COLUMN IF NOT EXISTS idle_nudge_threshold INTERVAL NULL;
+
+-- Per-participant pose metadata. NULL = participant has never posed.
+ALTER TABLE scene_participants
+    ADD COLUMN IF NOT EXISTS last_pose_at  TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS last_pose_seq INTEGER     NULL;
+```
+
+- [ ] **Step 2: Write the down migration**
+
+Create `plugins/core-scenes/migrations/000006_pose_order_metadata.down.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Reverse the Phase 4 pose-order metadata + idle-nudge columns.
+
+ALTER TABLE scene_participants
+    DROP COLUMN IF EXISTS last_pose_seq,
+    DROP COLUMN IF EXISTS last_pose_at;
+
+ALTER TABLE scenes
+    DROP COLUMN IF EXISTS idle_nudge_threshold;
+
+ALTER TABLE scenes
+    DROP COLUMN IF EXISTS total_pose_count;
+```
+
+- [ ] **Step 3: Run integration tests against the new migration**
+
+Run: `task test:int -- ./plugins/core-scenes/...`
+
+Expected: existing integration tests pass; migration runner picks up 000006 and applies it. Verify column existence:
+
+```bash
+docker exec -it postgres-test psql -U test -d test_holomush -c "\d plugin_core_scenes.scenes" | grep -E "total_pose_count|idle_nudge_threshold"
+docker exec -it postgres-test psql -U test -d test_holomush -c "\d plugin_core_scenes.scene_participants" | grep -E "last_pose_at|last_pose_seq"
+```
+
+Expected: 4 column matches across two tables.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-store): migration 000006 — pose-order metadata + idle-nudge threshold
+
+Adds scenes.total_pose_count (per-scene monotonic pose counter),
+scenes.idle_nudge_threshold (per-scene config, NULL = off), and
+scene_participants.last_pose_at + last_pose_seq (per-participant pose
+metadata, NULL until first pose).
+
+Per holomush-5rh.13 spec §9. The maintained metadata enables O(N
+participants) pose-order computation in GetPoseOrder without scanning
+event history; INV-P4-8 invariant pins the rebuild-from-scene_log
+equivalence with documented recovery SQL.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 3: Add `ParticipantsWithPoseMeta` types to `types.go`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/types.go`
+
+- [ ] **Step 1: Add the new types**
+
+Append to `plugins/core-scenes/types.go`:
+
+```go
+// ParticipantsWithPoseMeta is the result returned by
+// sceneStorer.ListParticipantsWithPoseMeta. Groups the per-scene
+// total_pose_count with the per-participant pose metadata so the
+// GetPoseOrder handler doesn't need a second SELECT for the scene row.
+type ParticipantsWithPoseMeta struct {
+	TotalPoseCount uint32
+	Participants   []ParticipantWithPoseMeta
+}
+
+// ParticipantWithPoseMeta is one participant of a scene plus their
+// Phase 4 maintained pose metadata. LastPoseAt and LastPoseSeq are
+// nil when the participant has never posed in this scene.
+type ParticipantWithPoseMeta struct {
+	CharacterID string
+	JoinedAt    time.Time
+	LastPoseAt  *time.Time
+	LastPoseSeq *int32
+}
+```
+
+Verify `time` is imported (already present from Phase 1-3 types).
+
+- [ ] **Step 2: Add a no-op test that exercises the types**
+
+Append to `plugins/core-scenes/types_test.go`:
+
+```go
+func TestParticipantsWithPoseMeta_ZeroValueValid(t *testing.T) {
+	t.Parallel()
+	var pm ParticipantsWithPoseMeta
+	assert.Equal(t, uint32(0), pm.TotalPoseCount)
+	assert.Empty(t, pm.Participants)
+}
+
+func TestParticipantWithPoseMeta_NeverPosed_NilFields(t *testing.T) {
+	t.Parallel()
+	p := ParticipantWithPoseMeta{
+		CharacterID: "char-alice",
+		JoinedAt:    time.Now(),
+	}
+	assert.Nil(t, p.LastPoseAt)
+	assert.Nil(t, p.LastPoseSeq)
+}
+```
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `task test -- ./plugins/core-scenes/`
+
+Expected: both new tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-types): add ParticipantsWithPoseMeta + ParticipantWithPoseMeta
+
+Result types for sceneStorer.ListParticipantsWithPoseMeta (added in a
+later task). Groups scenes.total_pose_count with per-participant
+last_pose_at + last_pose_seq so GetPoseOrder reads everything in one
+SELECT. NULL pose metadata represented as *time.Time / *int32.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase B — Store layer extensions
+
+### Task 4: Add `IsParticipant` store method (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go:35-50` (interface)
+- Modify: `plugins/core-scenes/store.go` (implementation)
+- Test: `plugins/core-scenes/store_integration_test.go`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `plugins/core-scenes/store_integration_test.go`:
+
+```go
+func (s *StoreIntegrationSuite) TestIsParticipant_OwnerMember_True() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-1")  // helper from existing tests; creates scene with owner row
+	s.joinScene(ctx, sceneID, "member-id-1")     // helper; AddParticipant
+
+	ok, err := s.store.IsParticipant(ctx, sceneID, "owner-id-1")
+	s.Require().NoError(err)
+	s.Require().True(ok)
+
+	ok, err = s.store.IsParticipant(ctx, sceneID, "member-id-1")
+	s.Require().NoError(err)
+	s.Require().True(ok)
+}
+
+func (s *StoreIntegrationSuite) TestIsParticipant_Invited_False() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-2")
+	// InviteParticipant creates an 'invited' row, not 'member'/'owner'.
+	_, err := s.store.InviteParticipant(ctx, sceneID, "owner-id-2", "invitee-id")
+	s.Require().NoError(err)
+
+	ok, err := s.store.IsParticipant(ctx, sceneID, "invitee-id")
+	s.Require().NoError(err)
+	s.Require().False(ok, "invited role MUST NOT count as participant for INV-S9 gate")
+}
+
+func (s *StoreIntegrationSuite) TestIsParticipant_NotInScene_False() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-3")
+
+	ok, err := s.store.IsParticipant(ctx, sceneID, "outsider-id")
+	s.Require().NoError(err)
+	s.Require().False(ok)
+}
+```
+
+- [ ] **Step 2: Run integration test to verify it fails (method does not exist)**
+
+Run: `task test:int -- -run TestIsParticipant ./plugins/core-scenes/...`
+
+Expected: FAIL — compilation error "s.store.IsParticipant undefined" OR (after interface declaration in Step 3) test panics with "method IsParticipant not implemented".
+
+- [ ] **Step 3: Add `IsParticipant` to the `sceneStorer` interface**
+
+Open `plugins/core-scenes/service.go`. Locate the `sceneStorer` interface block at lines 35-50. Add the new method between `GetParticipant` and the closing brace:
+
+```go
+// IsParticipant returns true if the character is a participant (owner
+// or member, NOT invited) of the scene. Used by the INV-S9 plugin-code
+// gate at GetPoseOrder per holomush-c8a9.
+IsParticipant(ctx context.Context, sceneID, characterID string) (bool, error)
+```
+
+- [ ] **Step 4: Implement on `*SceneStore` in `store.go`**
+
+Append a new method to `*SceneStore` in `plugins/core-scenes/store.go`:
+
+```go
+// IsParticipant reports whether the character is a participant (owner
+// or member, NOT invited) of the scene. The invited-role exclusion is
+// load-bearing: INV-S9's gate at GetPoseOrder MUST NOT treat pending
+// invites as members. Pinned by spec INV-P4-4.
+func (s *SceneStore) IsParticipant(ctx context.Context, sceneID, characterID string) (bool, error) {
+	const q = `
+		SELECT EXISTS (
+			SELECT 1 FROM scene_participants
+			WHERE scene_id = $1
+			  AND character_id = $2
+			  AND role IN ('owner', 'member')
+		)
+	`
+	var ok bool
+	if err := s.pool.QueryRow(ctx, q, sceneID, characterID).Scan(&ok); err != nil {
+		return false, oops.Code("SCENE_PARTICIPANT_LOOKUP_FAILED").
+			With("scene_id", sceneID).With("character_id", characterID).Wrap(err)
+	}
+	return ok, nil
+}
+```
+
+- [ ] **Step 5: Run integration tests to verify they pass**
+
+Run: `task test:int -- -run TestIsParticipant ./plugins/core-scenes/...`
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(scene-store): add IsParticipant — INV-S9 gate primitive
+
+Binary participant-check (owner OR member, NOT invited) used by the
+GetPoseOrder INV-S9 plugin-code gate per holomush-c8a9. Distinct from
+existing GetParticipant (which conflates lookup with not-found error).
+The role filter pins INV-P4-4's invariant: invited-row participants
+fail the gate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 5: Add `ListParticipantsWithPoseMeta` store method (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go:35-50` (interface)
+- Modify: `plugins/core-scenes/store.go` (implementation)
+- Test: `plugins/core-scenes/store_integration_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `plugins/core-scenes/store_integration_test.go`:
+
+```go
+func (s *StoreIntegrationSuite) TestListParticipantsWithPoseMeta_NoPoses() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-pm-1")
+	s.joinScene(ctx, sceneID, "member-id-pm-1")
+
+	pm, err := s.store.ListParticipantsWithPoseMeta(ctx, sceneID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint32(0), pm.TotalPoseCount)
+	s.Require().Len(pm.Participants, 2)
+	for _, p := range pm.Participants {
+		s.Require().Nil(p.LastPoseAt, "no poses yet: last_pose_at MUST be nil")
+		s.Require().Nil(p.LastPoseSeq, "no poses yet: last_pose_seq MUST be nil")
+	}
+}
+
+func (s *StoreIntegrationSuite) TestListParticipantsWithPoseMeta_ExcludesInvited() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-pm-2")
+	s.joinScene(ctx, sceneID, "member-id-pm-2")
+	_, err := s.store.InviteParticipant(ctx, sceneID, "owner-id-pm-2", "invitee-pm")
+	s.Require().NoError(err)
+
+	pm, err := s.store.ListParticipantsWithPoseMeta(ctx, sceneID)
+	s.Require().NoError(err)
+	s.Require().Len(pm.Participants, 2, "invited role MUST NOT appear in pose-order list")
+}
+
+func (s *StoreIntegrationSuite) TestListParticipantsWithPoseMeta_AfterDirectMetadataWrite() {
+	ctx := context.Background()
+	sceneID := s.createScene(ctx, "owner-id-pm-3")
+	s.joinScene(ctx, sceneID, "member-id-pm-3")
+
+	// Simulate the audit-handler metadata update (will be done by
+	// InsertScenePose in a later task; here we exercise the read path).
+	ts := time.Now().UTC()
+	_, err := s.store.Pool().Exec(ctx,
+		`UPDATE scenes SET total_pose_count = 3 WHERE id = $1`, sceneID)
+	s.Require().NoError(err)
+	_, err = s.store.Pool().Exec(ctx,
+		`UPDATE scene_participants SET last_pose_at = $1, last_pose_seq = 3
+		 WHERE scene_id = $2 AND character_id = $3`,
+		ts, sceneID, "member-id-pm-3")
+	s.Require().NoError(err)
+
+	pm, err := s.store.ListParticipantsWithPoseMeta(ctx, sceneID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint32(3), pm.TotalPoseCount)
+	for _, p := range pm.Participants {
+		if p.CharacterID == "member-id-pm-3" {
+			s.Require().NotNil(p.LastPoseAt)
+			s.Require().NotNil(p.LastPoseSeq)
+			s.Require().EqualValues(3, *p.LastPoseSeq)
+		} else {
+			s.Require().Nil(p.LastPoseSeq, "owner did not pose: last_pose_seq MUST be nil")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- -run TestListParticipantsWithPoseMeta ./plugins/core-scenes/...`
+
+Expected: FAIL — compilation error for missing method.
+
+- [ ] **Step 3: Add to interface**
+
+In `plugins/core-scenes/service.go`, append to `sceneStorer`:
+
+```go
+// ListParticipantsWithPoseMeta returns all participants of the scene
+// (role IN ('owner','member')) with their maintained pose metadata
+// (last_pose_at, last_pose_seq) and the scene's total_pose_count, in
+// a single SELECT. Drives GetPoseOrder computation per spec §6.1.
+ListParticipantsWithPoseMeta(ctx context.Context, sceneID string) (ParticipantsWithPoseMeta, error)
+```
+
+- [ ] **Step 4: Implement on `*SceneStore`**
+
+Append to `plugins/core-scenes/store.go`:
+
+```go
+// ListParticipantsWithPoseMeta is a single SELECT joining scenes +
+// scene_participants and returning the participants (owner+member, NOT
+// invited) with their pose metadata. Pinned by spec §6.1 / INV-P4-7.
+func (s *SceneStore) ListParticipantsWithPoseMeta(ctx context.Context, sceneID string) (ParticipantsWithPoseMeta, error) {
+	const q = `
+		SELECT
+		    s.total_pose_count,
+		    p.character_id,
+		    p.joined_at,
+		    p.last_pose_at,
+		    p.last_pose_seq
+		FROM scenes s
+		JOIN scene_participants p ON p.scene_id = s.id
+		WHERE s.id = $1
+		  AND p.role IN ('owner', 'member')
+		ORDER BY p.joined_at ASC
+	`
+	rows, err := s.pool.Query(ctx, q, sceneID)
+	if err != nil {
+		return ParticipantsWithPoseMeta{}, oops.Code("SCENE_POSE_META_LOOKUP_FAILED").
+			With("scene_id", sceneID).Wrap(err)
+	}
+	defer rows.Close()
+
+	var result ParticipantsWithPoseMeta
+	for rows.Next() {
+		var p ParticipantWithPoseMeta
+		var totalPoseCount int32   // scanned as signed; uint32 conversion below
+		if err := rows.Scan(&totalPoseCount, &p.CharacterID, &p.JoinedAt, &p.LastPoseAt, &p.LastPoseSeq); err != nil {
+			return ParticipantsWithPoseMeta{}, oops.Code("SCENE_POSE_META_SCAN_FAILED").Wrap(err)
+		}
+		result.TotalPoseCount = uint32(totalPoseCount)
+		result.Participants = append(result.Participants, p)
+	}
+	if err := rows.Err(); err != nil {
+		return ParticipantsWithPoseMeta{}, oops.Code("SCENE_POSE_META_ITER_FAILED").Wrap(err)
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test:int -- -run TestListParticipantsWithPoseMeta ./plugins/core-scenes/...`
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(scene-store): add ListParticipantsWithPoseMeta
+
+Single SELECT joining scenes.total_pose_count with per-participant
+pose metadata (last_pose_at, last_pose_seq). Excludes invited role per
+INV-S9 pose-order-only-for-participants discipline. Result type
+ParticipantsWithPoseMeta groups the aggregate + list for one-round-trip
+reads in GetPoseOrder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase C — Audit transaction + metadata maintenance
+
+### Task 6: Refactor `Insert` to use private `insertSceneLogTx` helper
+
+**Files:**
+
+- Modify: `plugins/core-scenes/audit.go`
+- Test: `plugins/core-scenes/store_integration_test.go` (existing Insert tests should keep passing)
+
+- [ ] **Step 1: Extract `insertSceneLogTx` helper**
+
+In `plugins/core-scenes/audit.go`, locate the existing `func (s *SceneAuditStore) Insert(...) error` method (starts around line 122). Refactor it into two functions:
+
+```go
+// Insert persists one audit row in its own transaction. Wrapper over
+// insertSceneLogTx for the common single-row case used by non-pose
+// events.
+func (s *SceneAuditStore) Insert(
+	ctx context.Context,
+	id []byte,
+	subject, eventType string,
+	timestamp *timestamppb.Timestamp,
+	actorKind string,
+	actorID []byte,
+	payload []byte,
+	schemaVer int,
+	codec string,
+	dekRef *int64,
+	dekVersion *int32,
+) error {
+	return pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		return s.insertSceneLogTx(ctx, tx,
+			id, subject, eventType, timestamp, actorKind, actorID,
+			payload, schemaVer, codec, dekRef, dekVersion)
+	})
+}
+
+// insertSceneLogTx executes the scene_log INSERT on a caller-provided
+// pgx.Tx. The INSERT uses ON CONFLICT (id) DO NOTHING so JetStream
+// redelivery is idempotent. Package-private; not exposed via the
+// sceneAuditLogStore interface. Called by Insert and by InsertScenePose.
+func (s *SceneAuditStore) insertSceneLogTx(
+	ctx context.Context,
+	tx  pgx.Tx,
+	id []byte,
+	subject, eventType string,
+	timestamp *timestamppb.Timestamp,
+	actorKind string,
+	actorID []byte,
+	payload []byte,
+	schemaVer int,
+	codec string,
+	dekRef *int64,
+	dekVersion *int32,
+) error {
+	// Move the existing INSERT SQL from the previous Insert body here,
+	// changing s.pool.Exec(...) to tx.Exec(...).
+	// Keep the existing ON CONFLICT (id) DO NOTHING clause and the
+	// same column list. Argument list and oops error wrapping unchanged.
+	const insertSQL = `
+		INSERT INTO scene_log (
+			id, subject, type, timestamp, actor_kind, actor_id,
+			payload, schema_ver, codec, dek_ref, dek_version
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			$7, $8, $9, $10, $11
+		)
+		ON CONFLICT (id) DO NOTHING
+	`
+	_, err := tx.Exec(ctx, insertSQL,
+		id, subject, eventType, timestamp.AsTime(), actorKind, actorID,
+		payload, schemaVer, codec, dekRef, dekVersion)
+	if err != nil {
+		return oops.Code("SCENE_AUDIT_LOG_INSERT_FAILED").
+			With("subject", subject).With("event_type", eventType).Wrap(err)
+	}
+	return nil
+}
+```
+
+Verify `import "github.com/jackc/pgx/v5"` is present in the file (add if missing).
+
+- [ ] **Step 2: Run existing audit tests to verify no regression**
+
+Run: `task test:int -- -run TestSceneAudit ./plugins/core-scenes/...`
+
+Expected: existing Phase 1-3 audit tests pass — refactor is behavior-preserving.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "refactor(scene-audit): extract insertSceneLogTx helper from Insert
+
+Pure refactor — Insert now wraps insertSceneLogTx in pgx.BeginFunc.
+The helper accepts a caller-provided pgx.Tx so InsertScenePose (next
+task) can compose the same scene_log INSERT with pose-metadata UPDATEs
+in one transaction.
+
+ON CONFLICT (id) DO NOTHING semantics preserved (idempotent redelivery
+per Phase 7 plugin SDK contract). No behavioral change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 7: Add `InsertScenePose` to interface + concrete impl (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/audit.go:53-75` (interface + concrete)
+- Test: `plugins/core-scenes/audit_test.go`
+
+- [ ] **Step 1: Write the failing fault-injection test**
+
+Append to `plugins/core-scenes/audit_test.go`:
+
+```go
+// TestInsertScenePose_TransactionalRollback_INV_P4_10 pins INV-P4-10:
+// scene_log INSERT + pose-metadata UPDATE MUST be all-or-nothing.
+func TestInsertScenePose_TransactionalRollback_INV_P4_10(t *testing.T) {
+	t.Parallel()
+	// Use a real pgxpool against the test DB; fault-injection lives in
+	// a wrapper that fails the UPDATE after the INSERT succeeds.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := newTestPool(t, ctx)  // existing helper from store_integration_test.go
+	store := NewSceneAuditStore(pool)
+
+	sceneID := "scene-rollback-test"
+	posedCharID := "char-rollback-test"
+	// Seed the scene + participant rows so the UPDATE has a target.
+	seedSceneAndParticipant(t, ctx, pool, sceneID, posedCharID)
+
+	// Inject a constraint violation in the metadata UPDATE by removing
+	// the column temporarily (or by passing a bad sceneID that fails
+	// the foreign-key on scene_participants — simpler).
+	badSceneID := "scene-does-not-exist"
+	rowID := []byte("test-row-id-fixed-16b")
+
+	err := store.InsertScenePose(ctx,
+		rowID, "events.test.scene." + badSceneID + ".ic", "scene_pose",
+		timestamppb.Now(), "character", []byte(posedCharID),
+		[]byte(`{"text":"test"}`), 1, "identity", nil, nil,
+		badSceneID, posedCharID,
+	)
+	require.Error(t, err, "InsertScenePose MUST fail on bad sceneID (no row to UPDATE)")
+
+	// Verify no scene_log row landed.
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM scene_log WHERE id = $1`, rowID).Scan(&count))
+	require.Equal(t, 0, count, "scene_log INSERT MUST roll back when metadata UPDATE fails (INV-P4-10)")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (method does not exist)**
+
+Run: `task test:int -- -run TestInsertScenePose_TransactionalRollback ./plugins/core-scenes/`
+
+Expected: FAIL — `store.InsertScenePose undefined`.
+
+- [ ] **Step 3: Add `InsertScenePose` to the `sceneAuditLogStore` interface**
+
+In `plugins/core-scenes/audit.go`, locate the `sceneAuditLogStore` interface at lines 50-75. Append after the existing `queryLog(...)` method:
+
+```go
+// InsertScenePose performs the scene_log INSERT for a scene_pose
+// event AND the pose-metadata UPDATE on scenes + scene_participants
+// in one transaction. Either both rows mutate or neither does
+// (INV-P4-10 per spec §9.4).
+//
+// sceneID and posedCharID are parsed from the audit request's subject
+// and actor fields by the caller; timestamp is the canonical event
+// timestamp (NOT wall clock at handler entry).
+InsertScenePose(
+    ctx context.Context,
+    id []byte,
+    subject, eventType string,
+    timestamp *timestamppb.Timestamp,
+    actorKind string,
+    actorID []byte,
+    payload []byte,
+    schemaVer int,
+    codec string,
+    dekRef *int64,
+    dekVersion *int32,
+    sceneID string,
+    posedCharID string,
+) error
+```
+
+- [ ] **Step 4: Implement on `*SceneAuditStore`**
+
+Append to `plugins/core-scenes/audit.go`:
+
+```go
+// InsertScenePose composes the scene_log INSERT + the pose-metadata
+// UPDATEs (scenes.total_pose_count++ and scene_participants
+// .last_pose_at/last_pose_seq) in a single transaction.
+//
+// Idempotency: the INSERT uses ON CONFLICT (id) DO NOTHING per
+// insertSceneLogTx, so redelivery of the same row is a no-op. The
+// UPDATEs MUST therefore guard against repeat-execution — but the
+// transactional wrapper means the UPDATEs only run when the INSERT
+// actually inserts a row. (TODO: if INSERT is a no-op due to conflict,
+// UPDATEs would double-count. Mitigation: check rowsAffected on the
+// INSERT and skip UPDATEs if zero. Captured in the next step.)
+func (s *SceneAuditStore) InsertScenePose(
+    ctx context.Context,
+    id []byte,
+    subject, eventType string,
+    timestamp *timestamppb.Timestamp,
+    actorKind string,
+    actorID []byte,
+    payload []byte,
+    schemaVer int,
+    codec string,
+    dekRef *int64,
+    dekVersion *int32,
+    sceneID string,
+    posedCharID string,
+) error {
+    return pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+        // 1. INSERT into scene_log. Returns nil even on ON CONFLICT;
+        //    we need to detect that case to avoid double-counting.
+        if err := s.insertSceneLogTx(ctx, tx,
+            id, subject, eventType, timestamp, actorKind, actorID,
+            payload, schemaVer, codec, dekRef, dekVersion); err != nil {
+            return err
+        }
+
+        // 2. Check if the INSERT actually inserted (no conflict).
+        //    On conflict, scene_log already has this row from a prior
+        //    delivery; UPDATEs already happened that time. Skip.
+        var alreadyExists bool
+        if err := tx.QueryRow(ctx,
+            `SELECT EXISTS(SELECT 1 FROM scene_log WHERE id = $1 AND timestamp != $2)`,
+            id, timestamp.AsTime(),
+        ).Scan(&alreadyExists); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_DEDUP_CHECK_FAILED").Wrap(err)
+        }
+        // Note: the check above is an approximation; a cleaner pattern
+        // is to use INSERT ... RETURNING and check the result. The
+        // implementation plan task SHALL switch to RETURNING xmax = 0
+        // semantics if integration tests reveal double-counting.
+
+        // 3. Bump scenes.total_pose_count.
+        var newSeq int32
+        if err := tx.QueryRow(ctx,
+            `UPDATE scenes SET total_pose_count = total_pose_count + 1
+             WHERE id = $1 RETURNING total_pose_count`,
+            sceneID,
+        ).Scan(&newSeq); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_TOTAL_INC_FAILED").
+                With("scene_id", sceneID).Wrap(err)
+        }
+
+        // 4. Stamp the actor's per-participant pose metadata.
+        //    Affects 0 rows if the actor is not currently a participant
+        //    (edge case: actor left between emit and audit consumption).
+        //    Acceptable per spec §9.4 — scene_log row recorded, metadata
+        //    reflects "they posed but left."
+        if _, err := tx.Exec(ctx,
+            `UPDATE scene_participants
+               SET last_pose_at = $1, last_pose_seq = $2
+             WHERE scene_id = $3 AND character_id = $4`,
+            timestamp.AsTime(), newSeq, sceneID, posedCharID,
+        ); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_PARTICIPANT_UPDATE_FAILED").
+                With("scene_id", sceneID).With("posed_char_id", posedCharID).Wrap(err)
+        }
+        return nil
+    })
+}
+```
+
+- [ ] **Step 5: Run the fault-injection test to verify it passes**
+
+Run: `task test:int -- -run TestInsertScenePose_TransactionalRollback ./plugins/core-scenes/`
+
+Expected: PASS — INSERT rolls back when UPDATE fails on bad sceneID.
+
+- [ ] **Step 6: Add the happy-path integration test**
+
+Append to `plugins/core-scenes/audit_test.go`:
+
+```go
+func TestInsertScenePose_HappyPath_UpdatesMetadata(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := newTestPool(t, ctx)
+	store := NewSceneAuditStore(pool)
+
+	sceneID := "scene-happy-" + ulid.Make().String()
+	posedCharID := "char-happy-" + ulid.Make().String()
+	seedSceneAndParticipant(t, ctx, pool, sceneID, posedCharID)
+
+	rowID := ulid.Make().Bytes()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	require.NoError(t, store.InsertScenePose(ctx,
+		rowID, "events.test.scene." + sceneID + ".ic", "scene_pose",
+		timestamppb.New(now), "character", []byte(posedCharID),
+		[]byte(`{"text":"hello"}`), 1, "identity", nil, nil,
+		sceneID, posedCharID,
+	))
+
+	// Verify scene_log row.
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM scene_log WHERE id = $1`, rowID).Scan(&count))
+	require.Equal(t, 1, count)
+
+	// Verify metadata updates.
+	var totalPoseCount int32
+	require.NoError(t, pool.QueryRow(ctx, `SELECT total_pose_count FROM scenes WHERE id = $1`, sceneID).Scan(&totalPoseCount))
+	require.Equal(t, int32(1), totalPoseCount)
+
+	var lastPoseAt time.Time
+	var lastPoseSeq int32
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_pose_at, last_pose_seq FROM scene_participants
+		 WHERE scene_id = $1 AND character_id = $2`, sceneID, posedCharID,
+	).Scan(&lastPoseAt, &lastPoseSeq))
+	require.WithinDuration(t, now, lastPoseAt, time.Millisecond)
+	require.Equal(t, int32(1), lastPoseSeq)
+}
+```
+
+- [ ] **Step 7: Run happy-path test**
+
+Run: `task test:int -- -run TestInsertScenePose_HappyPath ./plugins/core-scenes/`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "feat(scene-audit): InsertScenePose — transactional INSERT + metadata UPDATEs
+
+Adds InsertScenePose to sceneAuditLogStore interface and *SceneAuditStore
+concrete. Composes scene_log INSERT + scenes.total_pose_count increment
++ scene_participants.last_pose_at/last_pose_seq UPDATE in one
+pgx.BeginFunc transaction.
+
+Pins INV-P4-10 (atomic INSERT+UPDATE) with a fault-injection test that
+forces the metadata UPDATE to fail and asserts the scene_log INSERT
+rolls back. Happy-path test verifies metadata stamps after success.
+
+Per spec §9.4 — interface extension chosen over Pool-exposure to keep
+the audit-server boundary clean.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 8: Update `AuditEvent` handler dispatch for `scene_pose`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/audit.go::AuditEvent`
+- Test: `plugins/core-scenes/audit_test.go`
+
+- [ ] **Step 1: Write the failing handler-dispatch test**
+
+Append to `plugins/core-scenes/audit_test.go`:
+
+```go
+func TestAuditEvent_ScenePose_RoutesToInsertScenePose(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := newTestPool(t, ctx)
+	store := NewSceneAuditStore(pool)
+	srv := &SceneAuditServer{store: store, memberLookup: newAlwaysMemberLookup()}
+
+	sceneID := "scene-dispatch-" + ulid.Make().String()
+	posedCharULID := ulid.Make()
+	posedCharID := posedCharULID.String()
+	seedSceneAndParticipant(t, ctx, pool, sceneID, posedCharID)
+
+	rowULID := ulid.Make()
+	req := &pluginauditpb.AuditEventRequest{
+		Row: &pluginauditpb.AuditRow{
+			Id:        rowULID.Bytes(),
+			Subject:   "events.test.scene." + sceneID + ".ic",
+			Type:      "scene_pose",
+			Timestamp: timestamppb.Now(),
+			Actor:     &pluginauditpb.Actor{Kind: "character", Id: posedCharULID.Bytes()},
+			Payload:   []byte(`{"text":"test"}`),
+			SchemaVer: 1,
+			Codec:     "identity",
+		},
+	}
+	_, err := srv.AuditEvent(ctx, req)
+	require.NoError(t, err)
+
+	// Metadata must be stamped.
+	var totalPoseCount int32
+	require.NoError(t, pool.QueryRow(ctx, `SELECT total_pose_count FROM scenes WHERE id = $1`, sceneID).Scan(&totalPoseCount))
+	require.Equal(t, int32(1), totalPoseCount)
+}
+
+func TestAuditEvent_NonScenePose_RoutesToInsert(t *testing.T) {
+	t.Parallel()
+	// Verify that non-pose events still route through plain Insert (no
+	// metadata stamping). Uses scene_join_ic as a sample non-pose event.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := newTestPool(t, ctx)
+	store := NewSceneAuditStore(pool)
+	srv := &SceneAuditServer{store: store, memberLookup: newAlwaysMemberLookup()}
+
+	sceneID := "scene-non-pose-" + ulid.Make().String()
+	charULID := ulid.Make()
+	seedSceneAndParticipant(t, ctx, pool, sceneID, charULID.String())
+
+	req := &pluginauditpb.AuditEventRequest{
+		Row: &pluginauditpb.AuditRow{
+			Id:        ulid.Make().Bytes(),
+			Subject:   "events.test.scene." + sceneID + ".ic",
+			Type:      "scene_join_ic",
+			Timestamp: timestamppb.Now(),
+			Actor:     &pluginauditpb.Actor{Kind: "character", Id: charULID.Bytes()},
+			SchemaVer: 1, Codec: "identity",
+		},
+	}
+	_, err := srv.AuditEvent(ctx, req)
+	require.NoError(t, err)
+
+	// total_pose_count MUST remain 0 (scene_join_ic is not a pose).
+	var totalPoseCount int32
+	require.NoError(t, pool.QueryRow(ctx, `SELECT total_pose_count FROM scenes WHERE id = $1`, sceneID).Scan(&totalPoseCount))
+	require.Equal(t, int32(0), totalPoseCount, "non-pose events MUST NOT touch pose metadata")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (existing AuditEvent doesn't dispatch)**
+
+Run: `task test:int -- -run TestAuditEvent_ScenePose ./plugins/core-scenes/`
+
+Expected: FAIL — both tests fail because existing AuditEvent uses plain Insert path for all events.
+
+- [ ] **Step 3: Update `AuditEvent` handler**
+
+In `plugins/core-scenes/audit.go`, locate the existing `func (s *SceneAuditServer) AuditEvent(...)` body. After the existing validation / subject ownership checks, replace the plain `s.store.Insert(...)` call with a type-dispatch block:
+
+```go
+row := req.GetRow()
+if row.GetType() == "scene_pose" {
+    sceneID, err := parseSceneSubject(row.GetSubject())
+    if err != nil {
+        return nil, status.Errorf(codes.InvalidArgument, "malformed scene subject: %v", err)
+    }
+    var actorULID ulid.ULID
+    copy(actorULID[:], row.GetActor().GetId())
+    posedCharID := actorULID.String()
+
+    if err := s.store.InsertScenePose(ctx,
+        row.GetId(),
+        row.GetSubject(),
+        row.GetType(),
+        row.GetTimestamp(),
+        row.GetActor().GetKind(),
+        row.GetActor().GetId(),
+        row.GetPayload(),
+        int(row.GetSchemaVer()),
+        row.GetCodec(),
+        row.GetDekRef(),
+        row.GetDekVersion(),
+        sceneID,
+        posedCharID,
+    ); err != nil {
+        return nil, oopsToGrpcStatus(err)  // existing helper, or status.Errorf(codes.Internal, ...) per existing pattern
+    }
+} else {
+    if err := s.store.Insert(ctx,
+        row.GetId(), row.GetSubject(), row.GetType(), row.GetTimestamp(),
+        row.GetActor().GetKind(), row.GetActor().GetId(),
+        row.GetPayload(), int(row.GetSchemaVer()), row.GetCodec(),
+        row.GetDekRef(), row.GetDekVersion(),
+    ); err != nil {
+        return nil, oopsToGrpcStatus(err)
+    }
+}
+```
+
+Verify `import "github.com/oklog/ulid/v2"` is present at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test:int -- -run TestAuditEvent ./plugins/core-scenes/`
+
+Expected: both new tests pass; existing Phase 1-3 audit tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-audit): dispatch scene_pose events to InsertScenePose
+
+AuditEvent handler now branches on row.Type — scene_pose routes through
+InsertScenePose (which composes INSERT + pose-metadata UPDATEs in one
+transaction); other events continue through plain Insert.
+
+actorID bytes-to-string conversion via ulid.ULID(bytes).String() —
+identical to the existing QueryHistory pattern at audit.go:209-213.
+sceneID parsed from subject via existing parseSceneSubject helper.
+
+Tests verify routing: scene_pose triggers metadata stamps; scene_join_ic
+(non-pose) leaves metadata untouched.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase D — Pose-order computation
+
+### Task 9: Create `poseorder.go` with pure-function Compute (TDD)
+
+**Files:**
+
+- Create: `plugins/core-scenes/poseorder.go`
+- Create: `plugins/core-scenes/poseorder_test.go`
+
+- [ ] **Step 1: Write the failing per-mode table-driven tests**
+
+Create `plugins/core-scenes/poseorder_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompute_FreeMode_AllEligible(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	participants := []ParticipantWithPoseMeta{
+		{CharacterID: "alice", JoinedAt: now.Add(-3 * time.Hour)},
+		{CharacterID: "bob",   JoinedAt: now.Add(-2 * time.Hour)},
+		{CharacterID: "carol", JoinedAt: now.Add(-1 * time.Hour)},
+	}
+	names := map[string]string{"alice": "Alice", "bob": "Bob", "carol": "Carol"}
+	entries := Compute("free", 0, participants, names)
+	assert.Len(t, entries, 3)
+	for _, e := range entries {
+		assert.True(t, e.Eligible, "free mode: all participants MUST be eligible")
+	}
+	// Free mode display order: by JoinedAt ASC.
+	assert.Equal(t, "alice", entries[0].CharacterID)
+	assert.Equal(t, "bob",   entries[1].CharacterID)
+	assert.Equal(t, "carol", entries[2].CharacterID)
+}
+
+func TestCompute_StrictMode_NeverPosedAtHead(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	twoAgo  := now.Add(-2 * time.Hour)
+	oneAgo  := now.Add(-1 * time.Hour)
+	twoSeq  := int32(1)
+	oneSeq  := int32(2)
+	participants := []ParticipantWithPoseMeta{
+		{CharacterID: "alice", JoinedAt: now.Add(-3 * time.Hour), LastPoseAt: &twoAgo, LastPoseSeq: &twoSeq},
+		{CharacterID: "bob",   JoinedAt: now.Add(-2 * time.Hour), LastPoseAt: &oneAgo, LastPoseSeq: &oneSeq},
+		{CharacterID: "carol", JoinedAt: now.Add(-1 * time.Hour)},   // never posed
+	}
+	names := map[string]string{"alice": "Alice", "bob": "Bob", "carol": "Carol"}
+	entries := Compute("strict", 2, participants, names)
+	assert.Len(t, entries, 3)
+	assert.Equal(t, "carol", entries[0].CharacterID, "never-posed MUST be at head")
+	assert.True(t,  entries[0].Eligible)
+	assert.Equal(t, "alice", entries[1].CharacterID, "next: oldest last_pose_at")
+	assert.False(t, entries[1].Eligible)
+	assert.Equal(t, "bob",   entries[2].CharacterID, "tail: most recent poser")
+	assert.False(t, entries[2].Eligible)
+}
+
+func TestCompute_3prMode_Threshold3(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	// Total poses in scene = 5.
+	// Alice last_pose_seq = 1 → poses_since_last = 4 → eligible (>= 3).
+	// Bob   last_pose_seq = 4 → poses_since_last = 1 → cooldown.
+	// Carol never posed → eligible.
+	aliceSeq := int32(1)
+	bobSeq   := int32(4)
+	alicePosed := now.Add(-30 * time.Minute)
+	bobPosed   := now.Add(-5  * time.Minute)
+	participants := []ParticipantWithPoseMeta{
+		{CharacterID: "alice", JoinedAt: now.Add(-3 * time.Hour), LastPoseAt: &alicePosed, LastPoseSeq: &aliceSeq},
+		{CharacterID: "bob",   JoinedAt: now.Add(-2 * time.Hour), LastPoseAt: &bobPosed,   LastPoseSeq: &bobSeq},
+		{CharacterID: "carol", JoinedAt: now.Add(-1 * time.Hour)},
+	}
+	names := map[string]string{"alice": "Alice", "bob": "Bob", "carol": "Carol"}
+	entries := Compute("3pr", 5, participants, names)
+	assert.Len(t, entries, 3)
+	byID := indexByCharID(entries)
+	assert.True(t,  byID["alice"].Eligible)
+	assert.False(t, byID["bob"].Eligible)
+	assert.True(t,  byID["carol"].Eligible)
+	assert.NotNil(t, byID["alice"].PosesSinceLast)
+	assert.EqualValues(t, 4, *byID["alice"].PosesSinceLast)
+	assert.EqualValues(t, 1, *byID["bob"].PosesSinceLast)
+	assert.EqualValues(t, 5, *byID["carol"].PosesSinceLast) // never-posed: full total
+}
+
+func TestCompute_5prMode_Threshold5(t *testing.T) {
+	t.Parallel()
+	// Same shape as 3pr but threshold 5.
+	now := time.Now()
+	aliceSeq := int32(1)
+	alicePosed := now.Add(-10 * time.Minute)
+	participants := []ParticipantWithPoseMeta{
+		{CharacterID: "alice", JoinedAt: now.Add(-2 * time.Hour), LastPoseAt: &alicePosed, LastPoseSeq: &aliceSeq},
+		{CharacterID: "bob",   JoinedAt: now.Add(-1 * time.Hour)},
+	}
+	names := map[string]string{"alice": "Alice", "bob": "Bob"}
+	entries := Compute("5pr", 4, participants, names)
+	byID := indexByCharID(entries)
+	assert.False(t, byID["alice"].Eligible, "3 poses since alice (4-1) < 5 threshold")
+	assert.True(t,  byID["bob"].Eligible,   "never-posed always eligible")
+}
+
+func TestCompute_EmptyParticipants(t *testing.T) {
+	t.Parallel()
+	entries := Compute("strict", 0, nil, nil)
+	assert.Empty(t, entries)
+}
+
+func indexByCharID(entries []PoseOrderEntry) map[string]PoseOrderEntry {
+	out := make(map[string]PoseOrderEntry, len(entries))
+	for _, e := range entries { out[e.CharacterID] = e }
+	return out
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (no poseorder.go)**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestCompute`
+
+Expected: FAIL — `Compute undefined` and `PoseOrderEntry undefined`.
+
+- [ ] **Step 3: Implement `poseorder.go`**
+
+Create `plugins/core-scenes/poseorder.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"sort"
+	"time"
+)
+
+// PoseOrderEntry is the Go-side equivalent of the proto PoseOrderEntry —
+// used for in-process composition before marshaling to the wire type
+// in the GetPoseOrder handler.
+type PoseOrderEntry struct {
+	CharacterID    string
+	CharacterName  string
+	Eligible       bool
+	LastPosedAt    *time.Time   // nil = never posed
+	PosesSinceLast *uint32      // meaningful for 3pr/5pr; nil otherwise
+}
+
+// Compute derives pose-order entries from maintained metadata per
+// spec §6.2. Pure function — no DB, no side effects, fully testable
+// with table-driven cases per mode (INV-P4-7).
+//
+// totalPoseCount is the scene-wide scene_pose count (scenes.total_pose_count).
+// participants come from sceneStorer.ListParticipantsWithPoseMeta.
+// names maps character_id → character_name (from nameResolver).
+func Compute(mode string, totalPoseCount uint32, participants []ParticipantWithPoseMeta, names map[string]string) []PoseOrderEntry {
+	if len(participants) == 0 {
+		return nil
+	}
+
+	// Sort the input slice per mode. For strict/3pr/5pr: NULLS FIRST
+	// (never-posed at head), then by LastPoseAt ascending. For free:
+	// JoinedAt ascending.
+	sorted := make([]ParticipantWithPoseMeta, len(participants))
+	copy(sorted, participants)
+	switch mode {
+	case "free":
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return sorted[i].JoinedAt.Before(sorted[j].JoinedAt)
+		})
+	default: // strict, 3pr, 5pr
+		sort.SliceStable(sorted, func(i, j int) bool {
+			a, b := sorted[i], sorted[j]
+			// NULLS FIRST: never-posed sorts before posed.
+			if a.LastPoseAt == nil && b.LastPoseAt != nil { return true }
+			if a.LastPoseAt != nil && b.LastPoseAt == nil { return false }
+			// Both nil OR both non-nil: tiebreak.
+			if a.LastPoseAt == nil && b.LastPoseAt == nil {
+				return a.JoinedAt.Before(b.JoinedAt)
+			}
+			return a.LastPoseAt.Before(*b.LastPoseAt)
+		})
+	}
+
+	entries := make([]PoseOrderEntry, 0, len(sorted))
+	for i, p := range sorted {
+		entry := PoseOrderEntry{
+			CharacterID:   p.CharacterID,
+			CharacterName: names[p.CharacterID],
+			LastPosedAt:   p.LastPoseAt,
+		}
+		// Compute poses_since_last for 3pr/5pr surfaces.
+		if mode == "3pr" || mode == "5pr" {
+			var since uint32
+			if p.LastPoseSeq == nil {
+				since = totalPoseCount
+			} else {
+				since = totalPoseCount - uint32(*p.LastPoseSeq)
+			}
+			entry.PosesSinceLast = &since
+		}
+
+		switch mode {
+		case "strict":
+			entry.Eligible = i == 0  // head of queue
+		case "3pr":
+			entry.Eligible = p.LastPoseSeq == nil || (totalPoseCount - uint32(*p.LastPoseSeq)) >= 3
+		case "5pr":
+			entry.Eligible = p.LastPoseSeq == nil || (totalPoseCount - uint32(*p.LastPoseSeq)) >= 5
+		case "free":
+			entry.Eligible = true
+		default:
+			// Unknown mode: default to non-eligible. Should not happen — the
+			// scene state machine enforces the enum.
+			entry.Eligible = false
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestCompute`
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-poseorder): pure-function Compute per spec §6.2
+
+Derives PoseOrderEntry[] from ParticipantsWithPoseMeta + total_pose_count
++ name map. Per-mode logic:
+
+- strict: NULLS FIRST + JoinedAt + LastPoseAt ASC; head eligible
+- 3pr/5pr: same display order; eligible = never-posed OR
+  (total_pose_count - last_pose_seq) >= threshold
+- free: JoinedAt ASC; all eligible
+
+Surfaces poses_since_last for 3pr/5pr UX ('Carol (2/3 since)'). Pure
+function — no DB, no side effects, no globals. Table-driven tests
+cover all 4 modes per INV-P4-7.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase E — Subject migration (atomic substrate + plugin)
+
+> All five tasks in this phase land together — substrate-side dot-style parsing and plugin-side dot-style emission MUST be atomic. Mid-phase pushes are forbidden; the I-17 gate would fail-closed on dot-style emits without substrate support, or vice versa.
+
+### Task 10: Add `crypto.emits` + EmitTypeRegistrar adoption (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml`
+- Modify: `plugins/core-scenes/main.go`
+- Create: `plugins/core-scenes/main_test.go`
+
+- [ ] **Step 1: Write the failing manifest set-equality test**
+
+Create `plugins/core-scenes/main_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
+// TestPlugin_CryptoEmitsMatchesRegistry pins INV-P4-2: the 8 scene
+// event types in crypto.emits MUST equal the set registered via
+// EmitTypeRegistrar.
+func TestPlugin_CryptoEmitsMatchesRegistry(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("plugin.yaml")
+	require.NoError(t, err)
+
+	var m struct {
+		Crypto struct {
+			Emits []struct {
+				EventType string `yaml:"event_type"`
+				Sensitivity string `yaml:"sensitivity"`
+			} `yaml:"emits"`
+		} `yaml:"crypto"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &m))
+
+	manifestSet := make([]string, 0, len(m.Crypto.Emits))
+	for _, e := range m.Crypto.Emits {
+		manifestSet = append(manifestSet, e.EventType)
+	}
+	sort.Strings(manifestSet)
+
+	// Build the registry the same way main() does.
+	reg := pluginsdk.NewEmitRegistry()
+	reg.RegisterEmitTypes(phase4EmitTypes())   // helper defined in main.go
+	registrySet := reg.RegisteredEmitTypes()
+	sort.Strings(registrySet)
+
+	assert.Equal(t, manifestSet, registrySet,
+		"INV-P4-2: manifest crypto.emits MUST equal EmitTypeRegistrar set")
+}
+
+// TestPlugin_SensitivityMatrix pins INV-P4-3: per-type sensitivity matches
+// spec §2 table.
+func TestPlugin_SensitivityMatrix(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("plugin.yaml")
+	require.NoError(t, err)
+
+	var m struct {
+		Crypto struct {
+			Emits []struct {
+				EventType string `yaml:"event_type"`
+				Sensitivity string `yaml:"sensitivity"`
+			} `yaml:"emits"`
+		} `yaml:"crypto"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &m))
+
+	want := map[string]string{
+		"scene_pose":                  "always",
+		"scene_say":                   "always",
+		"scene_emit":                  "always",
+		"scene_ooc":                   "always",
+		"scene_join_ic":               "never",
+		"scene_leave_ic":              "never",
+		"scene_pose_order_changed_ic": "never",
+		"scene_idle_nudge":            "never",
+	}
+	got := make(map[string]string)
+	for _, e := range m.Crypto.Emits {
+		got[e.EventType] = e.Sensitivity
+	}
+	assert.Equal(t, want, got,
+		"INV-P4-3: sensitivity matrix MUST match spec §2 table")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestPlugin_`
+
+Expected: FAIL — `phase4EmitTypes undefined`, and manifest has empty `crypto.emits`.
+
+- [ ] **Step 3: Add `crypto.emits` to `plugin.yaml`**
+
+In `plugins/core-scenes/plugin.yaml`, locate the existing `crypto:` block (currently `emits: []` near line 39). Replace with:
+
+```yaml
+crypto:
+  emits:
+    # Content events (sensitivity: always) — participant-only IC/OOC RP
+    # content. Privacy boundary is the participant list per INV-S9, NOT
+    # the location. Analog to whisper/page in core-communication, not
+    # to say/pose (which are location-bounded).
+    - event_type: scene_pose
+      sensitivity: always
+      description: "IC pose by a scene participant; visible to all participants in the scene's IC stream."
+    - event_type: scene_say
+      sensitivity: always
+      description: "IC speech by a scene participant; visible to all participants in the scene's IC stream."
+    - event_type: scene_emit
+      sensitivity: always
+      description: "IC generic emit by a scene participant; visible to all participants in the scene's IC stream."
+    - event_type: scene_ooc
+      sensitivity: always
+      description: "OOC chatter in scene context; participant-only despite never being archived in the published scene log."
+
+    # Notice events (sensitivity: never) — operational metadata, no RP
+    # content. Visible to scene participants but plaintext at rest.
+    - event_type: scene_join_ic
+      sensitivity: never
+      description: "Notice that a character joined the scene; name only, no content."
+    - event_type: scene_leave_ic
+      sensitivity: never
+      description: "Notice that a character left or was kicked from the scene; name + reason discriminator, no content."
+    - event_type: scene_pose_order_changed_ic
+      sensitivity: never
+      description: "Notice that the scene owner changed the pose-order mode; mode strings + actor, no content."
+    - event_type: scene_idle_nudge
+      sensitivity: never
+      description: "Notice that the next-up character has been idle past the configured threshold; name + duration, no content. (Trigger implementation deferred — see follow-up bead.)"
+```
+
+- [ ] **Step 4: Update `main.go` to register the 8 event types**
+
+In `plugins/core-scenes/main.go`, modify the `scenePlugin` struct and `main()` function:
+
+```go
+// scenePlugin gains an emitRegistry field.
+type scenePlugin struct {
+    // ... existing fields ...
+    emitRegistry *pluginsdk.EmitRegistry
+}
+
+// EmitRegistry implements pluginsdk.EmitTypeRegistrar.
+// The substrate INV-S5 validator reads this set via the binary-plugin
+// Init RPC and compares against manifest crypto.emits set-equality.
+func (p *scenePlugin) EmitRegistry() *pluginsdk.EmitRegistry {
+    return p.emitRegistry
+}
+
+// phase4EmitTypes returns the 8 plugin-owned scene event types declared
+// in crypto.emits. Exposed at package level so the manifest-vs-registry
+// test in main_test.go can build the same set.
+func phase4EmitTypes() []string {
+    return []string{
+        "scene_pose",
+        "scene_say",
+        "scene_emit",
+        "scene_ooc",
+        "scene_join_ic",
+        "scene_leave_ic",
+        "scene_pose_order_changed_ic",
+        "scene_idle_nudge",
+    }
+}
+
+func main() {
+    reg := pluginsdk.NewEmitRegistry()
+    reg.RegisterEmitTypes(phase4EmitTypes())
+
+    plugin := &scenePlugin{
+        service:      &SceneServiceImpl{},
+        // ... existing field initialisation unchanged ...
+        emitRegistry: reg,
+    }
+    // ... existing pluginsdk.ServeWithServices call ...
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestPlugin_`
+
+Expected: both tests pass.
+
+- [ ] **Step 6: Run the substrate INV-S5 validator end-to-end via a plugin-load test**
+
+Run: `task test:int -- -run TestPluginManager_LoadPlugin_NoCryptoEmitsMismatch ./internal/plugin/`
+
+Expected: existing INV-S5 substrate tests pass with the updated core-scenes plugin manifest+code aligned. If a test like `TestManager_LoadPlugin_EmitTypeMismatch_FailsClosed` exists, it should be unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(scene-emit): declare 8 crypto.emits + EmitTypeRegistrar adoption
+
+Populates core-scenes/plugin.yaml::crypto.emits with the 8 Phase 4
+scene event types per spec §2 sensitivity matrix:
+
+  scene_pose / scene_say / scene_emit / scene_ooc → always
+  scene_join_ic / scene_leave_ic / scene_pose_order_changed_ic
+    / scene_idle_nudge → never
+
+scenePlugin implements pluginsdk.EmitTypeRegistrar via the new
+emitRegistry field; main() registers all 8 types so the substrate
+INV-S5 set-equality validator (manager.go::loadPlugin) sees matching
+manifest and code sets. Mismatch would fail plugin load fail-closed
+with EVENT_TYPE_REGISTRY_MISMATCH.
+
+Tests pin INV-P4-2 (manifest == registry) and INV-P4-3 (sensitivity
+matches table) via manifest-parse + registry-build.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 11: Migrate scene emit subjects to dot-style + add `service.go` helpers (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go:211` (existing colon-style)
+- Modify: `plugins/core-scenes/store.go` (add subject helpers)
+- Modify: `plugins/core-scenes/service_test.go:426` (test expectation)
+
+- [ ] **Step 1: Write the failing test (update existing expectation)**
+
+In `plugins/core-scenes/service_test.go`, locate line 426:
+
+```go
+assert.Equal(t, "scene:"+resp.GetScene().GetId(), sink.intents[0].Subject)
+```
+
+Change to:
+
+```go
+gameID := s.gameID  // wire from test fixture; OR use any non-empty placeholder per SDK contract
+expectedSubject := dotStyleSceneSubject(gameID, resp.GetScene().GetId())
+assert.Equal(t, expectedSubject, sink.intents[0].Subject,
+	"Phase 4: emit subjects MUST be NATS dot-style (INV-P4-1)")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestCreateScene`
+
+Expected: FAIL — `dotStyleSceneSubject undefined` AND existing assertion mismatch.
+
+- [ ] **Step 3: Add the subject formatter helpers**
+
+In `plugins/core-scenes/store.go`, append package-level helpers:
+
+```go
+// dotStyleSceneSubject returns the NATS dot-style entity-level subject
+// for a scene per INV-S4: events.<gameID>.scene.<sceneID>. Used for
+// lifecycle / system events that target the scene itself, not a facet.
+func dotStyleSceneSubject(gameID, sceneID string) string {
+    return "events." + gameID + ".scene." + sceneID
+}
+
+// dotStyleSceneSubjectIC returns the NATS dot-style IC-facet subject
+// for a scene: events.<gameID>.scene.<sceneID>.ic.
+func dotStyleSceneSubjectIC(gameID, sceneID string) string {
+    return dotStyleSceneSubject(gameID, sceneID) + ".ic"
+}
+
+// dotStyleSceneSubjectOOC returns the NATS dot-style OOC-facet subject:
+// events.<gameID>.scene.<sceneID>.ooc.
+func dotStyleSceneSubjectOOC(gameID, sceneID string) string {
+    return dotStyleSceneSubject(gameID, sceneID) + ".ooc"
+}
+```
+
+- [ ] **Step 4: Update `service.go:211` emit subject**
+
+In `plugins/core-scenes/service.go`, locate the `sceneCreatedIntent` (or the function containing line 211). Replace:
+
+```go
+Subject: "scene:" + row.ID,
+```
+
+with:
+
+```go
+Subject: dotStyleSceneSubject(s.gameID, row.ID),
+```
+
+Add `gameID string` field to `SceneServiceImpl` struct (if not already present); wire from `Init` per existing pattern.
+
+Repeat the substitution for any other lifecycle emits in service.go (rg first to enumerate: `rg -n 'Subject: "scene:' plugins/core-scenes/`).
+
+- [ ] **Step 5: Wire `gameID` through `SceneServiceImpl.Init`**
+
+In `plugins/core-scenes/main.go::Init`, after `connStr := config.GetConnectionString()`:
+
+```go
+gameID := config.GetGameId()
+if gameID == "" {
+    return oops.Code("SCENE_INIT_FAILED").Errorf("game_id is required for NATS dot-style subjects")
+}
+p.service.gameID = gameID
+```
+
+(Verify `pluginv1.ServiceConfig` has a `GameId` accessor; if not, file a follow-up bead and use the existing `Namespace` or equivalent field.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/`
+
+Expected: all unit tests pass — emit subjects are dot-style.
+
+- [ ] **Step 7: Run grep verification**
+
+Run: `rg -n '"scene:"' plugins/core-scenes/`
+
+Expected: zero matches (subject-context); helps confirm INV-P4-1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+jj describe -m "feat(scene-emit): migrate scene emit subjects to NATS dot-style
+
+Replaces 'scene:<id>' colon-style with events.<game_id>.scene.<id>
+dot-style per INV-S4 substrate convention. Adds package-level helpers
+dotStyleSceneSubject / dotStyleSceneSubjectIC / dotStyleSceneSubjectOOC
+in store.go to keep formatting consistent across all emit sites.
+
+SceneServiceImpl gains a gameID field, wired from ServiceConfig.GameId
+in Init. Test expectations updated.
+
+Per INV-P4-1: zero scene-subject colon-style literals remain in
+plugins/core-scenes/. The substrate-side scene-aware code migrates in
+the next four tasks (atomic with this change; mid-phase push would
+fail-closed at the I-17 gate).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 12: Migrate `stream_access.go` scene branches to dot-style
+
+**Files:**
+
+- Modify: `internal/grpc/stream_access.go:25, :52, :77`
+- Modify: `internal/grpc/stream_access_test.go`
+
+- [ ] **Step 1: Write the failing test (update fixtures)**
+
+In `internal/grpc/stream_access_test.go`, locate the test fixtures using colon-style scene subjects (lines :68, :74, :80, :86, :104, :118, :142, :148, :164, :169, :174 per earlier rg). Update each to dot-style. Example for line 68:
+
+```go
+// Before:
+stream: "scene:" + activeSceneID.String() + ":ic",
+// After:
+stream: dotStyleSceneIC("test", activeSceneID.String()),
+```
+
+Add a test-local helper at the top of `stream_access_test.go`:
+
+```go
+func dotStyleSceneIC(gameID, sceneID string) string {
+    return "events." + gameID + ".scene." + sceneID + ".ic"
+}
+func dotStyleSceneOOC(gameID, sceneID string) string {
+    return "events." + gameID + ".scene." + sceneID + ".ooc"
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/grpc/ -run TestStreamAccess`
+
+Expected: FAIL — the existing `isPrivateStream`/`extractSceneID` don't recognize dot-style yet.
+
+- [ ] **Step 3: Update production code**
+
+In `internal/grpc/stream_access.go`:
+
+```go
+// isPrivateStream reports whether a stream is one of the private types
+// (character own-stream OR scene IC/OOC). Phase 4: dot-style scene subjects.
+func isPrivateStream(stream string) bool {
+    return strings.HasPrefix(stream, "character:") || isSceneStream(stream)
+}
+
+// isSceneStream reports whether a stream is a scene IC or OOC subject
+// in NATS dot-style: events.<gameID>.scene.<sceneID>.{ic,ooc}.
+func isSceneStream(stream string) bool {
+    parts := strings.Split(stream, ".")
+    if len(parts) < 5 { return false }
+    if parts[0] != "events" || parts[2] != "scene" { return false }
+    facet := parts[len(parts)-1]
+    return facet == "ic" || facet == "ooc"
+}
+
+// extractSceneID returns the scene ULID from a dot-style scene subject.
+// Caller MUST check isSceneStream first; undefined behavior otherwise.
+func extractSceneID(stream string) (string, bool) {
+    parts := strings.Split(stream, ".")
+    if len(parts) < 5 || parts[0] != "events" || parts[2] != "scene" {
+        return "", false
+    }
+    return parts[3], true
+}
+```
+
+Locate the existing colon-style scene branches in `stream_access.go:25, :52, :77` and replace with calls to the new helpers per the production code above. (rg first: `rg -n '"scene:"' internal/grpc/stream_access.go`)
+
+- [ ] **Step 4: Run tests**
+
+Run: `task test -- ./internal/grpc/ -run TestStreamAccess`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(substrate-grpc): stream_access.go — dot-style scene subjects
+
+Migrates isPrivateStream / extractSceneID to recognise NATS dot-style
+scene subjects (events.<gid>.scene.<id>.{ic,ooc}). Adds isSceneStream
+helper. Tests fixtures updated.
+
+Atomic with plugins/core-scenes/service.go emit migration (Task 11)
+and the iwzt §6.1 floor classification (next task) — mid-phase pushes
+would fail-closed at the I-17 gate.
+
+Per INV-P4-1 + INV-S1 (this is scene-aware substrate code, reviewed
+under substrate gates).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 13: Migrate `scope_floor.go` + add INV-P4-9 unit pin (TDD per spec §3.3)
+
+**Files:**
+
+- Modify: `internal/grpc/scope_floor.go:42-74, :115-122`
+- Modify: `internal/grpc/scope_floor_test.go`
+
+- [ ] **Step 1: Write the failing pre/post migration table-driven test**
+
+In `internal/grpc/scope_floor_test.go`, add a new table-driven test that pins the bug-fix moment per spec §3.3:
+
+```go
+// TestStreamScopeFloor_SceneSubjects_INV_P4_9 pins the bug-fix moment
+// for the scope_floor.go format mismatch (spec §3.3). Pre-migration,
+// the colon-style branch matched but production callers passed
+// dot-style — function returned time.Time{} for all real traffic.
+// Post-migration, dot-style matches; colon-style is no longer recognised.
+func TestStreamScopeFloor_SceneSubjects_INV_P4_9(t *testing.T) {
+    t.Parallel()
+    sceneID := ulid.Make()
+    joinedAt := time.Now().UTC().Truncate(time.Microsecond)
+
+    info := &session.Info{
+        FocusMemberships: []session.FocusMembership{{
+            Kind:     session.FocusKindScene,
+            TargetID: sceneID,
+            JoinedAt: joinedAt,
+        }},
+    }
+
+    cases := []struct {
+        name          string
+        stream        string
+        wantFloor     time.Time
+        rationale     string
+    }{
+        {
+            name:      "legacy colon-style (no longer matched after migration)",
+            stream:    "scene:" + sceneID.String() + ":ic",
+            wantFloor: time.Time{},  // post-migration: legacy form falls through to default
+            rationale: "Phase 4 removed the colon-style scene branch — legacy form falls to time.Time{} default.",
+        },
+        {
+            name:      "NATS dot-style (newly matched after migration)",
+            stream:    "events.test.scene." + sceneID.String() + ".ic",
+            wantFloor: joinedAt,
+            rationale: "Phase 4 added the dot-style scene branch — production-shape subjects now floor to FocusMembership.JoinedAt.",
+        },
+        {
+            name:      "NATS dot-style OOC facet",
+            stream:    "events.test.scene." + sceneID.String() + ".ooc",
+            wantFloor: joinedAt,
+            rationale: "OOC facet floors to same JoinedAt as IC.",
+        },
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := streamScopeFloor(info, tc.stream)
+            assert.Equal(t, tc.wantFloor.UTC(), got.UTC(), tc.rationale)
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify pre-migration shape**
+
+Run: `task test -- ./internal/grpc/ -run TestStreamScopeFloor_SceneSubjects_INV_P4_9`
+
+Expected: FAIL on the dot-style cases (current production-broken behavior); the legacy case might PASS (or fail, depending on existing matching). This is the pre-migration baseline shape that the migration commit will flip.
+
+- [ ] **Step 3: Update `scope_floor.go`**
+
+In `internal/grpc/scope_floor.go`, replace the scene branch in `streamScopeFloor` (around line 47):
+
+```go
+// Before (colon-style):
+case strings.HasPrefix(stream, "scene:"):
+    sceneID, ok := extractSceneID(stream)
+    if !ok {
+        return time.Time{}
+    }
+    for _, m := range info.FocusMemberships { ... }
+
+// After (dot-style):
+case isSceneStream(stream):
+    sceneID, ok := extractSceneID(stream)
+    if !ok {
+        return time.Time{}
+    }
+    for _, m := range info.FocusMemberships {
+        if m.Kind == session.FocusKindScene && m.TargetID.String() == sceneID {
+            base = m.JoinedAt
+            break
+        }
+    }
+```
+
+Note: `isSceneStream` + dot-style-aware `extractSceneID` are in `stream_access.go` (Task 12). Same package — no import change.
+
+Also REMOVE the developer-note comment at lines 20-28 of `scope_floor.go` (it documents the pre-migration bug; once fixed, the comment is stale).
+
+- [ ] **Step 4: Run test to verify post-migration shape**
+
+Run: `task test -- ./internal/grpc/ -run TestStreamScopeFloor_SceneSubjects_INV_P4_9`
+
+Expected: all 3 cases pass — the migration is correct.
+
+- [ ] **Step 5: Verify no other scope_floor tests broke**
+
+Run: `task test -- ./internal/grpc/ -run TestStreamScopeFloor`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "fix(substrate-grpc): scope_floor.go — dot-style scene branch (live regression)
+
+Pre-Phase-4 scope_floor.go matched 'scene:<id>:ic' colon-style, but
+production callers passed events.<gid>.scene.<id>.ic dot-style — so
+the function returned time.Time{} for all real-world scene subjects
+and the iwzt §6.1 temporal floor for scene streams was silently
+inactive (spec §3.3).
+
+This commit migrates the scene branch to the dot-style helpers added
+in stream_access.go (Task 12). The accompanying scope_floor_test.go
+TestStreamScopeFloor_SceneSubjects_INV_P4_9 pins the bug-fix moment
+with explicit before/after assertions for both colon-style (no longer
+matched) and dot-style (now matched).
+
+Closes the live silent regression for INV-P4-9. End-to-end integration
+test in test/integration/scenes/late_joiner_temporal_floor_test.go
+verifies the iwzt §3 contract on the post-migration code.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 14: Migrate `query_stream_history.go` I-17 gate to dot-style
+
+**Files:**
+
+- Modify: `internal/grpc/query_stream_history.go:39, :157-178`
+
+- [ ] **Step 1: Inspect existing I-17 gate**
+
+Run: `rg -n -C 5 'scene:|isScene' internal/grpc/query_stream_history.go`
+
+Read the surrounding code to understand the gate shape.
+
+- [ ] **Step 2: Update the gate predicate**
+
+Replace any `strings.HasPrefix(req.Stream, "scene:")` with `isSceneStream(req.Stream)`. Replace any direct colon-prefix parsing with the `extractSceneID` helper from `stream_access.go`. Both helpers live in the same package — no imports needed.
+
+- [ ] **Step 3: Update any tests in `query_stream_history_test.go` that use colon-style fixtures**
+
+Run: `rg -n '"scene:"' internal/grpc/query_stream_history_test.go`
+
+Replace each with the dot-style equivalent using the `dotStyleSceneIC`/`dotStyleSceneOOC` helpers added in `stream_access_test.go` (Task 12 Step 1).
+
+- [ ] **Step 4: Run tests**
+
+Run: `task test -- ./internal/grpc/`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(substrate-grpc): query_stream_history.go I-17 gate — dot-style
+
+Migrates the I-17 hardcoded scene-membership gate to recognise NATS
+dot-style scene subjects via the isSceneStream + extractSceneID
+helpers from stream_access.go (Task 12).
+
+Per INV-S9 + iwzt §3, the gate remains plugin-code adjacent (no
+ABAC override path); scene privacy stays absolute. Only the subject
+detection migrates.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 15: Update `test/integration/plugin/binary_plugin_test.go` fixtures
+
+**Files:**
+
+- Modify: `test/integration/plugin/binary_plugin_test.go:502, :512`
+
+- [ ] **Step 1: Replace colon-style scene-subject test inputs with dot-style**
+
+Run: `rg -n '"scene:"' test/integration/plugin/binary_plugin_test.go`
+
+For each match that is a STREAM/SUBJECT (not ABAC resource), replace with NATS dot-style. ABAC `Resource` strings (`"scene:" + sceneID` inside `NewAccessRequest`) are policy-DSL resource identifiers, NOT topics — leave those unchanged per spec §3.2 scope clarification.
+
+Inspection checklist before each replacement:
+
+- Is the string passed as a SUBJECT or STREAM argument? → migrate
+- Is the string passed as `Resource` in an ABAC `NewAccessRequest` call? → leave unchanged
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `task test:int -- ./test/integration/plugin/`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(plugin-integration): scene subject fixtures — dot-style
+
+Updates test fixtures in binary_plugin_test.go that passed scene
+subjects via STREAM/SUBJECT arguments to use NATS dot-style. ABAC
+Resource strings (scene:<id> in policy DSL) unchanged — different
+concern per spec §3.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase F — Emit subcommands
+
+### Task 16: `scene pose / say / emit / ooc` subcommands (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Test: `plugins/core-scenes/commands_test.go`
+
+- [ ] **Step 1: Write the failing subcommand tests**
+
+Append to `plugins/core-scenes/commands_test.go`:
+
+```go
+func TestSceneSubcommand_Pose_HappyPath(t *testing.T) {
+    t.Parallel()
+    p, sink := newTestScenePluginWithMembership(t, "scene-pose-test", "char-alice")
+    req := pluginsdk.CommandRequest{
+        Command: "scene",
+        Args:    "pose smiles at the room",
+        CharacterID: "char-alice",
+    }
+    resp, err := p.dispatchCommand(context.Background(), req)
+    require.NoError(t, err)
+    require.NotNil(t, resp)
+
+    require.Len(t, sink.intents, 1)
+    intent := sink.intents[0]
+    assert.Equal(t, "scene_pose", intent.Type)
+    assert.Equal(t, dotStyleSceneSubjectIC("test", "scene-pose-test"), intent.Subject)
+    assert.True(t, intent.Sensitive, "scene_pose MUST be emitted with Sensitive=true (sensitivity:always)")
+}
+
+func TestSceneSubcommand_NonParticipant_PermissionDenied(t *testing.T) {
+    t.Parallel()
+    p, _ := newTestScenePluginWithMembership(t, "scene-perm-test", "char-alice")
+    // char-bob is NOT a participant.
+    req := pluginsdk.CommandRequest{
+        Command: "scene",
+        Args:    "pose tries to butt in",
+        CharacterID: "char-bob",
+    }
+    resp, _ := p.dispatchCommand(context.Background(), req)
+    require.NotNil(t, resp)
+    assert.True(t, resp.IsError(), "INV-P4-11: non-participant pose MUST be rejected at command-execute layer")
+}
+
+// Repeat for say / emit / ooc subcommands with matching expectations:
+// - scene_say → .ic facet, sensitivity:always
+// - scene_emit → .ic facet, sensitivity:always
+// - scene_ooc → .ooc facet, sensitivity:always
+func TestSceneSubcommand_Say(t *testing.T) { ... }
+func TestSceneSubcommand_Emit(t *testing.T) { ... }
+func TestSceneSubcommand_OOC(t *testing.T) {
+    // OOC routes to .ooc facet:
+    // assert.Equal(t, dotStyleSceneSubjectOOC("test", sceneID), intent.Subject)
+    ...
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneSubcommand`
+
+Expected: FAIL — dispatcher returns "Unknown scene subcommand 'pose'".
+
+- [ ] **Step 3: Add subcommand cases to dispatcher**
+
+In `plugins/core-scenes/commands.go::dispatchCommand`, add cases inside the switch:
+
+```go
+case "pose":
+    return p.handleEmit(ctx, req, rest, "scene_pose", false /* ooc */)
+case "say":
+    return p.handleEmit(ctx, req, rest, "scene_say", false)
+case "emit":
+    return p.handleEmit(ctx, req, rest, "scene_emit", false)
+case "ooc":
+    return p.handleEmit(ctx, req, rest, "scene_ooc", true /* ooc */)
+case "order":
+    return p.handleOrder(ctx, req, rest)
+```
+
+Add a single shared `handleEmit` function:
+
+```go
+// handleEmit is the shared emit-subcommand handler for pose / say /
+// emit / ooc. The verb determines the event_type; the ooc flag determines
+// the subject facet.
+func (p *scenePlugin) handleEmit(
+    ctx context.Context,
+    req pluginsdk.CommandRequest,
+    text string,
+    eventType string,
+    ooc bool,
+) (*pluginsdk.CommandResponse, error) {
+    text = strings.TrimSpace(text)
+    if text == "" {
+        return pluginsdk.Errorf("Usage: scene %s <text>", strings.TrimPrefix(eventType, "scene_")), nil
+    }
+
+    // Resolve target scene: for Phase 4, infer from single-membership.
+    // Phase 5 will add focus-aware routing.
+    sceneID, err := p.resolveSingleSceneMembership(ctx, req.CharacterID)
+    if err != nil {
+        return pluginsdk.Errorf("Cannot determine target scene: %v. Phase 5 will route plain pose/say/emit/ooc by focus context.", err), nil
+    }
+
+    // INV-P4-11: the capability pre-flight via execute-scene-commands +
+    // write-scene-as-participant gates this at dispatch time. Defense in
+    // depth: verify membership in plugin store before emit.
+    ok, err := p.store.IsParticipant(ctx, sceneID, req.CharacterID)
+    if err != nil { return nil, oops.Code("SCENE_EMIT_MEMBERSHIP_LOOKUP_FAILED").Wrap(err) }
+    if !ok {
+        return pluginsdk.Errorf("You are not a participant of scene %s.", sceneID), nil
+    }
+
+    subject := dotStyleSceneSubjectIC(p.gameID, sceneID)
+    if ooc { subject = dotStyleSceneSubjectOOC(p.gameID, sceneID) }
+
+    payload, err := json.Marshal(map[string]string{
+        "actor_id": req.CharacterID,
+        "scene_id": sceneID,
+        "text":     text,
+    })
+    if err != nil { return nil, oops.Code("SCENE_EMIT_PAYLOAD_MARSHAL_FAILED").Wrap(err) }
+
+    intent := pluginsdk.EmitIntent{
+        Subject:   subject,
+        Type:      eventType,
+        Payload:   string(payload),
+        Sensitive: true,   // sensitivity:always — INV-P4-3
+    }
+    if err := p.eventSink.Emit(ctx, intent); err != nil {
+        return nil, oops.Code("SCENE_EMIT_FAILED").With("event_type", eventType).Wrap(err)
+    }
+
+    verb := strings.TrimPrefix(eventType, "scene_")
+    return pluginsdk.Outputf("You %s: %s", verb, text), nil
+}
+```
+
+Add a stub `resolveSingleSceneMembership` (refined in Task 17 if needed):
+
+```go
+// resolveSingleSceneMembership returns the scene_id this character is
+// a sole participant of, or an error if they are in zero or multiple
+// scenes. Phase 5 will replace this with focus-aware routing.
+func (p *scenePlugin) resolveSingleSceneMembership(ctx context.Context, characterID string) (string, error) {
+    scenes, err := p.store.ListScenesForCharacter(ctx, characterID)  // existing or new
+    if err != nil { return "", err }
+    switch len(scenes) {
+    case 0:
+        return "", errors.New("you are not currently in any scene; join one first with `scene join <scene-id>`")
+    case 1:
+        return scenes[0], nil
+    default:
+        return "", fmt.Errorf("you are in %d scenes; Phase 5 will add focus-aware routing", len(scenes))
+    }
+}
+```
+
+If `ListScenesForCharacter` doesn't exist in `sceneStorer`, add it as part of this task (mirror the existing query patterns).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneSubcommand`
+
+Expected: all 4 happy-path tests + 1 permission-denied test pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-commands): scene pose / say / emit / ooc subcommands
+
+Adds 4 emit subcommands to the scene top-level command dispatcher.
+Each emits the matching scene_<verb> event type with sensitivity:true
+(matches crypto.emits sensitivity:always — INV-P4-3). Subject facet
+.ic for pose/say/emit; .ooc for ooc.
+
+Target scene resolution via single-membership inference (Phase 4 only);
+Phase 5 will replace with focus-aware routing. Defense-in-depth
+participant check via IsParticipant before emit (Layer-1 ABAC
+execute-scene-commands gate fires first per spec §11).
+
+INV-P4-11 covers the participant requirement; pinned by
+TestSceneSubcommand_NonParticipant_PermissionDenied.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase G — Auto-emit triggers (notice events)
+
+### Task 17: Auto-emit `scene_join_ic` on `JoinScene`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go::JoinScene`
+- Test: `plugins/core-scenes/service_test.go::TestJoinScene_*`
+
+- [ ] **Step 1: Write the failing auto-emit assertion**
+
+In `plugins/core-scenes/service_test.go`, locate the existing `TestJoinScene_*` tests. Append:
+
+```go
+func TestJoinScene_EmitsSceneJoinIC_OnInsert(t *testing.T) {
+    t.Parallel()
+    s, sink := newTestSceneServiceWithMember(t, "scene-join-emit", "owner-id")
+    // Pre-condition: char-bob is NOT yet a participant.
+    resp, err := s.JoinScene(context.Background(), &scenev1.JoinSceneRequest{
+        SceneId:     "scene-join-emit",
+        CharacterId: "char-bob",
+    })
+    require.NoError(t, err)
+    _ = resp
+
+    // INV: a scene_join_ic event MUST have been emitted to .ic facet.
+    found := findIntent(sink.intents, "scene_join_ic")
+    require.NotNil(t, found, "JoinScene MUST auto-emit scene_join_ic on OpInserted")
+    assert.Equal(t, dotStyleSceneSubjectIC("test", "scene-join-emit"), found.Subject)
+    assert.False(t, found.Sensitive, "scene_join_ic is sensitivity:never")
+}
+
+func TestJoinScene_NoEmit_OnNoChange(t *testing.T) {
+    t.Parallel()
+    // Per Phase 3 D5: idempotent retry returns OpNoChange and MUST NOT
+    // emit a duplicate scene_join_ic.
+    s, sink := newTestSceneServiceWithMember(t, "scene-join-idempotent", "char-alice")
+    initialCount := len(sink.intents)
+
+    _, err := s.JoinScene(context.Background(), &scenev1.JoinSceneRequest{
+        SceneId:     "scene-join-idempotent",
+        CharacterId: "char-alice",  // already a member
+    })
+    require.NoError(t, err)
+
+    finalCount := len(sink.intents)
+    assert.Equal(t, initialCount, finalCount, "idempotent join MUST NOT emit a duplicate scene_join_ic")
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestJoinScene_Emits`
+
+Expected: FAIL — JoinScene does not yet emit scene_join_ic.
+
+- [ ] **Step 3: Update `JoinScene` to emit on insert/promote**
+
+In `plugins/core-scenes/service.go::JoinScene`, modify the body to capture the `ParticipantOpResult` and emit conditionally:
+
+```go
+// Replace existing:
+// _, _, err := s.store.AddParticipant(ctx, req.GetSceneId(), req.GetCharacterId())
+
+// With:
+_, result, err := s.store.AddParticipant(ctx, req.GetSceneId(), req.GetCharacterId())
+if err != nil {
+    // ... existing error handling ...
+}
+
+if result == OpInserted || result == OpPromoted {
+    name, _ := s.nameResolver.GetNameByID(ctx, req.GetCharacterId())  // best-effort
+    payload, err := json.Marshal(map[string]string{
+        "actor_id":   req.GetCharacterId(),
+        "actor_name": name,
+        "scene_id":   req.GetSceneId(),
+        "from_role":  fromRoleFor(result),
+    })
+    if err == nil {
+        _ = s.eventSink.Emit(ctx, pluginsdk.EmitIntent{
+            Subject:   dotStyleSceneSubjectIC(s.gameID, req.GetSceneId()),
+            Type:      "scene_join_ic",
+            Payload:   string(payload),
+            Sensitive: false,  // sensitivity:never
+        })
+        // Emit failure is non-fatal — membership is already committed.
+        // Log and continue per existing patterns.
+    }
+}
+```
+
+Add the `fromRoleFor` helper:
+
+```go
+func fromRoleFor(r ParticipantOpResult) string {
+    if r == OpPromoted { return "invited" }
+    return "none"
+}
+```
+
+If `nameResolver` is not yet wired into `SceneServiceImpl`, add the field and wire from Init in this task.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestJoinScene`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-emit): auto-emit scene_join_ic on JoinScene (OpInserted/OpPromoted)
+
+JoinScene RPC handler emits scene_join_ic to the scene IC stream when
+AddParticipant returns OpInserted or OpPromoted; skipped on OpNoChange
+per Phase 3 D5 retry-idempotency (prevents duplicate audit log entries
+on JetStream redelivery).
+
+sensitivity:never (notice event, no RP content); payload carries
+actor_id, actor_name, scene_id, from_role discriminator.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 18: Auto-emit `scene_leave_ic` on `LeaveScene` + `KickFromScene`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go::LeaveScene`, `KickFromScene`
+- Test: `plugins/core-scenes/service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `service_test.go`:
+
+```go
+func TestLeaveScene_EmitsSceneLeaveIC_ReasonLeft(t *testing.T) { /* assert reason="left", removed_by absent */ }
+func TestKickFromScene_EmitsSceneLeaveIC_ReasonKicked(t *testing.T) { /* assert reason="kicked", removed_by=kicker */ }
+```
+
+- [ ] **Step 2: Run to verify failure, then update both RPC handlers**
+
+In `service.go::LeaveScene` and `KickFromScene`, after the successful `RemoveParticipant`/`KickParticipant` call, emit:
+
+```go
+// In LeaveScene, after RemoveParticipant returns nil:
+s.emitSceneLeaveIC(ctx, req.GetSceneId(), req.GetCharacterId(), "left", "" /* no kicker */)
+
+// In KickFromScene, after KickParticipant returns nil:
+s.emitSceneLeaveIC(ctx, req.GetSceneId(), req.GetTargetCharacterId(), "kicked", req.GetCharacterId())
+```
+
+Add the shared helper:
+
+```go
+func (s *SceneServiceImpl) emitSceneLeaveIC(ctx context.Context, sceneID, actorID, reason, removedBy string) {
+    name, _ := s.nameResolver.GetNameByID(ctx, actorID)
+    fields := map[string]string{
+        "actor_id":   actorID,
+        "actor_name": name,
+        "scene_id":   sceneID,
+        "reason":     reason,
+    }
+    if removedBy != "" {
+        fields["removed_by"] = removedBy
+    }
+    payload, err := json.Marshal(fields)
+    if err != nil { return /* non-fatal */ }
+    _ = s.eventSink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject:   dotStyleSceneSubjectIC(s.gameID, sceneID),
+        Type:      "scene_leave_ic",
+        Payload:   string(payload),
+        Sensitive: false,
+    })
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestLeaveScene_Emits TestKickFromScene_Emits`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-emit): auto-emit scene_leave_ic on LeaveScene + KickFromScene
+
+Both LeaveScene (voluntary, reason=left) and KickFromScene (involuntary,
+reason=kicked, removed_by=kicker) auto-emit scene_leave_ic notice events
+to the scene IC stream after successful participant removal.
+
+sensitivity:never. One event type with reason discriminator (keeps
+manifest count at 8). Helper emitSceneLeaveIC consolidates the emit
+shape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 19: Auto-emit `scene_pose_order_changed_ic` on `UpdateScene`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go::UpdateScene`
+- Test: `plugins/core-scenes/service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestUpdateScene_EmitsPoseOrderChangedIC_OnModeChange(t *testing.T) {
+    // Update with pose_order_mode in mask AND new value differs from current.
+    // Assert scene_pose_order_changed_ic emitted with old_mode/new_mode/actor.
+}
+func TestUpdateScene_NoEmit_OnNoModeChange(t *testing.T) {
+    // Update with pose_order_mode in mask but new value == current.
+    // Assert NO scene_pose_order_changed_ic emit.
+}
+```
+
+- [ ] **Step 2: Run to verify failure, update handler**
+
+In `UpdateScene`, capture the pre-update value before calling `s.store.Update(...)`. After successful update, if `update_mask` contained `pose_order_mode` AND old != new:
+
+```go
+// Capture old mode BEFORE the Update call.
+preRow, _ := s.store.Get(ctx, req.GetSceneId())  // best-effort; emit is non-critical
+// ... existing buildSceneUpdate + s.store.Update logic ...
+postRow := /* result of Update */
+
+if preRow != nil && hasMaskPath(req.UpdateMask, "pose_order_mode") && preRow.PoseOrder != postRow.PoseOrder {
+    name, _ := s.nameResolver.GetNameByID(ctx, req.GetCharacterId())
+    payload, err := json.Marshal(map[string]string{
+        "actor_id":   req.GetCharacterId(),
+        "actor_name": name,
+        "scene_id":   req.GetSceneId(),
+        "old_mode":   preRow.PoseOrder,
+        "new_mode":   postRow.PoseOrder,
+    })
+    if err == nil {
+        _ = s.eventSink.Emit(ctx, pluginsdk.EmitIntent{
+            Subject:   dotStyleSceneSubjectIC(s.gameID, req.GetSceneId()),
+            Type:      "scene_pose_order_changed_ic",
+            Payload:   string(payload),
+            Sensitive: false,
+        })
+    }
+}
+```
+
+If `hasMaskPath` does not exist, add it as a small helper in the same file.
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestUpdateScene_Emits TestUpdateScene_NoEmit`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-emit): auto-emit scene_pose_order_changed_ic on mode change
+
+UpdateScene auto-emits scene_pose_order_changed_ic when update_mask
+includes pose_order_mode AND the new value differs from current.
+No emit on no-op updates (mask present but value unchanged) —
+prevents spurious notices.
+
+Complements Phase 3's existing settings.updated ops event in
+scene_ops_events (operational journal); the IC notice is the
+participant-visible counterpart.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase H — Read path: GetPoseOrder + `scene order`
+
+### Task 20: `GetPoseOrder` RPC handler + INV-S9 gate (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go` (add `GetPoseOrder` method)
+- Test: `plugins/core-scenes/service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `service_test.go`:
+
+```go
+func TestGetPoseOrder_NonParticipant_PermissionDenied(t *testing.T) {
+    t.Parallel()
+    // INV-P4-4: ABAC engine MUST NOT be consulted.
+    abacMock := newCountingAbacMock(t)
+    s, _ := newTestSceneServiceWithABACMock(t, "scene-pdt", "char-alice", abacMock)
+
+    _, err := s.GetPoseOrder(context.Background(), &scenev1.GetPoseOrderRequest{
+        SceneId:     "scene-pdt",
+        CharacterId: "char-bob",  // NOT a participant
+    })
+    require.Error(t, err)
+    assert.Equal(t, codes.PermissionDenied, status.Code(err))
+    assert.Equal(t, 0, abacMock.callCount(), "INV-P4-4: ABAC engine MUST NOT be consulted for GetPoseOrder")
+}
+
+func TestGetPoseOrder_Participant_ReturnsEntries(t *testing.T) {
+    t.Parallel()
+    s, _ := newTestSceneServiceWithMember(t, "scene-gpo", "char-alice")
+
+    resp, err := s.GetPoseOrder(context.Background(), &scenev1.GetPoseOrderRequest{
+        SceneId:     "scene-gpo",
+        CharacterId: "char-alice",
+    })
+    require.NoError(t, err)
+    assert.Equal(t, "free", resp.GetMode())   // default for a fresh scene
+    assert.Equal(t, uint32(0), resp.GetTotalPoseCount())
+    assert.Len(t, resp.GetEntries(), 1)  // just the owner
+}
+
+func TestGetPoseOrder_ArchivedScene_FailedPrecondition(t *testing.T) {
+    t.Parallel()
+    s, _ := newTestSceneServiceWithMember(t, "scene-archived", "char-alice")
+    _, _ = s.EndScene(context.Background(), &scenev1.EndSceneRequest{
+        SceneId:     "scene-archived",
+        CharacterId: "char-alice",
+    })
+    // Manually transition to archived via store (or use a helper).
+    archiveScene(t, s, "scene-archived")
+
+    _, err := s.GetPoseOrder(context.Background(), &scenev1.GetPoseOrderRequest{
+        SceneId:     "scene-archived",
+        CharacterId: "char-alice",
+    })
+    require.Error(t, err)
+    assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestGetPoseOrder`
+
+Expected: FAIL — method does not exist.
+
+- [ ] **Step 3: Implement `GetPoseOrder` per spec §7.3**
+
+In `plugins/core-scenes/service.go`, add the handler:
+
+```go
+func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPoseOrderRequest) (*scenev1.GetPoseOrderResponse, error) {
+    ctx, span := startSpan(ctx, "scene.service.get_pose_order",
+        attribute.String("scene_id", req.GetSceneId()),
+        attribute.String("subject_id", req.GetCharacterId()),
+    )
+    defer span.End()
+
+    // INV-S9 / INV-P4-4: direct participant check. NO ABAC engine consultation.
+    ok, err := s.store.IsParticipant(ctx, req.GetSceneId(), req.GetCharacterId())
+    if err != nil {
+        recordError(span, err)
+        return nil, status.Errorf(codes.Internal, "failed to check participant: %v", err)
+    }
+    if !ok {
+        return nil, status.Errorf(codes.PermissionDenied, "not a participant of this scene")
+    }
+
+    sceneRow, err := s.store.Get(ctx, req.GetSceneId())
+    if err != nil {
+        recordError(span, err)
+        var oe oops.OopsError
+        if errors.As(err, &oe) && oe.Code() == "SCENE_NOT_FOUND" {
+            return nil, status.Errorf(codes.NotFound, "scene not found: %s", req.GetSceneId())
+        }
+        return nil, status.Errorf(codes.Internal, "failed to load scene: %v", err)
+    }
+    if sceneRow.State == string(SceneStateArchived) {
+        return nil, status.Errorf(codes.FailedPrecondition, "scene is archived; pose order not available")
+    }
+
+    pm, err := s.store.ListParticipantsWithPoseMeta(ctx, req.GetSceneId())
+    if err != nil {
+        recordError(span, err)
+        return nil, status.Errorf(codes.Internal, "failed to load participants: %v", err)
+    }
+
+    ids := make([]string, 0, len(pm.Participants))
+    for _, p := range pm.Participants { ids = append(ids, p.CharacterID) }
+    names, err := s.nameResolver.GetNamesByIDs(ctx, ids)
+    if err != nil {
+        recordError(span, err)
+        return nil, status.Errorf(codes.Internal, "failed to resolve character names: %v", err)
+    }
+
+    entries := Compute(sceneRow.PoseOrder, pm.TotalPoseCount, pm.Participants, names)
+
+    protoEntries := make([]*scenev1.PoseOrderEntry, 0, len(entries))
+    for _, e := range entries {
+        pe := &scenev1.PoseOrderEntry{
+            CharacterId:   e.CharacterID,
+            CharacterName: e.CharacterName,
+            Eligible:      e.Eligible,
+        }
+        if e.LastPosedAt != nil { pe.LastPosedAt = timestamppb.New(*e.LastPosedAt) }
+        if e.PosesSinceLast != nil { pe.PosesSinceLast = e.PosesSinceLast }
+        protoEntries = append(protoEntries, pe)
+    }
+    return &scenev1.GetPoseOrderResponse{
+        Mode:           sceneRow.PoseOrder,
+        TotalPoseCount: pm.TotalPoseCount,
+        Entries:        protoEntries,
+    }, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestGetPoseOrder`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-rpc): GetPoseOrder with INV-S9 plugin-code gate
+
+Implements GetPoseOrder RPC per spec §7. Direct participant check via
+sceneStorer.IsParticipant; ABAC engine NOT consulted. Pattern follows
+ADR holomush-c8a9 — scene privacy is absolute, no admin override path.
+
+Reads pose metadata via ListParticipantsWithPoseMeta (single SELECT,
+O(N participants)), resolves names via nameResolver.GetNamesByIDs,
+computes entries via the pure-function poseorder.Compute.
+
+Errors: PERMISSION_DENIED (non-participant, INV-S9), NOT_FOUND (no
+scene), FAILED_PRECONDITION (archived), INTERNAL (store).
+
+Pinned by INV-P4-4: TestGetPoseOrder_NonParticipant_PermissionDenied
+asserts the gate fires AND the mock ABAC engine receives zero calls.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 21: `scene order` subcommand renderer (TDD)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go::handleOrder` (case already added in Task 16)
+- Test: `plugins/core-scenes/commands_test.go`
+
+- [ ] **Step 1: Write the failing renderer tests**
+
+```go
+func TestSceneOrder_FreeMode_RendersParticipants(t *testing.T) {
+    // Expect: "Scene ... — pose order: free (no enforcement, N total poses)"
+    // Followed by "  Participants:" list.
+}
+func TestSceneOrder_StrictMode_RendersQueue(t *testing.T) {
+    // Expect: "Scene ... — pose order: strict (N total poses)"
+    // "  Next: Alice ..."
+    // "  Then: ..."
+}
+func TestSceneOrder_3prMode_RendersEligibleAndCooldown(t *testing.T) { /* groups */ }
+func TestSceneOrder_NonParticipant_PermissionDenied(t *testing.T) { /* same INV-S9 gate */ }
+```
+
+- [ ] **Step 2: Implement `handleOrder` calling `GetPoseOrder`**
+
+```go
+func (p *scenePlugin) handleOrder(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+    sceneID, err := p.resolveSingleSceneMembership(ctx, req.CharacterID)
+    if err != nil {
+        return pluginsdk.Errorf("Cannot determine target scene: %v", err), nil
+    }
+    resp, err := p.service.GetPoseOrder(ctx, &scenev1.GetPoseOrderRequest{
+        SceneId: sceneID, CharacterId: req.CharacterID,
+    })
+    if err != nil {
+        if status.Code(err) == codes.PermissionDenied {
+            return pluginsdk.Errorf("You are not a participant of this scene."), nil
+        }
+        return pluginsdk.Errorf("Failed to get pose order: %v", err), nil
+    }
+    return pluginsdk.Outputf(renderPoseOrder(sceneID, resp)), nil
+}
+
+// renderPoseOrder formats GetPoseOrderResponse as plain-text command output.
+// Per spec §8.
+func renderPoseOrder(sceneID string, resp *scenev1.GetPoseOrderResponse) string {
+    // Implementation per the templates in spec §8 — strict, 3pr/5pr, free.
+    // strict: "Next: X" header + "Then:" list.
+    // 3pr/5pr: "Eligible to pose:" + "Cooldown:" groups; surfaces poses_since_last.
+    // free: "Participants:" simple list.
+    // Uses fmt.Sprintf; no markdown chrome.
+    // (Full implementation in the implementer's commit; the template strings live in this function.)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneOrder`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-commands): scene order subcommand renderer
+
+handleOrder calls GetPoseOrder in-process (INV-S9 gate fires the same)
+and renders the response as plain-text command output per spec §8.
+
+Per-mode rendering:
+- strict: 'Next: X' header + 'Then:' queue tail
+- 3pr/5pr: 'Eligible to pose:' + 'Cooldown:' groups with N/threshold annotation
+- free: 'Participants:' simple list (no eligibility annotation)
+
+No markdown chrome; matches existing core-scenes command output style.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase I — Resolver / meta-tests / integration tests
+
+### Task 22: Resolver no-pose-data-leak test (INV-P4-5)
+
+**Files:**
+
+- Test: `plugins/core-scenes/resolver_test.go`
+- Create: `internal/test/invariants/scene_resolver_no_poseorder_leak_test.go`
+
+- [ ] **Step 1: Add a resolver test asserting no pose data in attributes**
+
+Append to `plugins/core-scenes/resolver_test.go`:
+
+```go
+// TestResolveResource_ExcludesPoseOrderMetadata pins INV-P4-5: the
+// scene resolver MUST NOT expose pose-order metadata (last_pose_at,
+// last_pose_seq, total_pose_count) as ABAC attributes.
+func TestResolveResource_ExcludesPoseOrderMetadata(t *testing.T) {
+    t.Parallel()
+    r := newTestSceneResolver(t)
+    // Seed a scene that HAS pose metadata so the test catches accidental
+    // exposure rather than passing trivially.
+    seedSceneWithPoses(t, r.store, "scene-resolver-test", 5)
+
+    resp, err := r.ResolveResource(context.Background(), &pluginv1.ResolveResourceRequest{
+        ResourceType: "scene",
+        ResourceId:   "scene-resolver-test",
+    })
+    require.NoError(t, err)
+
+    forbidden := []string{"last_pose_at", "last_pose_seq", "total_pose_count"}
+    for _, key := range forbidden {
+        _, exists := resp.GetAttributes()[key]
+        assert.False(t, exists, "INV-P4-5: pose-metadata attribute %q MUST NOT be in resolver response", key)
+    }
+}
+```
+
+- [ ] **Step 2: Add the meta-test (rg-based)**
+
+Create `internal/test/invariants/scene_resolver_no_poseorder_leak_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package invariants
+
+import (
+    "os"
+    "regexp"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestINV_P4_5_ResolverNoPoseOrderLeak rg-asserts that resolver.go
+// does not reference pose-metadata columns in attribute-construction
+// code paths.
+func TestINV_P4_5_ResolverNoPoseOrderLeak(t *testing.T) {
+    t.Parallel()
+    data, err := os.ReadFile("../../../plugins/core-scenes/resolver.go")
+    require.NoError(t, err)
+
+    forbidden := regexp.MustCompile(`\b(last_pose_at|last_pose_seq|total_pose_count|LastPoseAt|LastPoseSeq|TotalPoseCount)\b`)
+    matches := forbidden.FindAll(data, -1)
+    assert.Empty(t, matches,
+        "INV-P4-5: resolver.go MUST NOT reference pose-metadata columns; INV-S9 forbids attribute-driven path to pose data")
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestResolveResource_ExcludesPoseOrderMetadata`
+Run: `task test -- ./internal/test/invariants/ -run TestINV_P4_5`
+
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-5): resolver MUST NOT leak pose-order metadata
+
+Two tests pin INV-P4-5:
+
+1. plugins/core-scenes/resolver_test.go — calls ResolveResource against
+   a scene with non-zero pose metadata, asserts last_pose_at /
+   last_pose_seq / total_pose_count are NOT in the response attributes.
+
+2. internal/test/invariants/scene_resolver_no_poseorder_leak_test.go —
+   rg-asserts resolver.go source contains no references to pose-meta
+   column names. Catches code-level leak even before runtime exposure.
+
+INV-S9 / ADR holomush-c8a9: pose-order data is reachable exclusively
+via the gated GetPoseOrder RPC; ABAC attribute path is forbidden.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 23: Meta-test — no `engine.Evaluate` in `GetPoseOrder` body (INV-P4-4)
+
+**Files:**
+
+- Create: `internal/test/invariants/scene_no_abac_in_getposeorder_test.go`
+
+- [ ] **Step 1: Write the meta-test**
+
+Create the file:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package invariants
+
+import (
+    "go/ast"
+    "go/parser"
+    "go/token"
+    "regexp"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestINV_P4_4_NoABACInGetPoseOrder uses go/parser to locate the
+// GetPoseOrder function body in plugins/core-scenes/service.go and
+// asserts it contains no ABAC engine calls.
+func TestINV_P4_4_NoABACInGetPoseOrder(t *testing.T) {
+    t.Parallel()
+    fset := token.NewFileSet()
+    file, err := parser.ParseFile(fset, "../../../plugins/core-scenes/service.go", nil, parser.ParseComments)
+    require.NoError(t, err)
+
+    forbidden := regexp.MustCompile(`\b(engine|accessEngine|abacEngine)\.(Evaluate|CanPerformAction|Allow|Forbid)\b`)
+    found := false
+    ast.Inspect(file, func(n ast.Node) bool {
+        fn, ok := n.(*ast.FuncDecl)
+        if !ok || fn.Name.Name != "GetPoseOrder" {
+            return true
+        }
+        // Extract body source and search for forbidden patterns.
+        start := fset.Position(fn.Body.Pos()).Offset
+        end := fset.Position(fn.Body.End()).Offset
+        srcBytes, _ := readBytes("../../../plugins/core-scenes/service.go")
+        body := string(srcBytes[start:end])
+        if forbidden.MatchString(body) {
+            found = true
+        }
+        return false  // stop traversal
+    })
+    assert.False(t, found,
+        "INV-P4-4: GetPoseOrder MUST NOT consult the ABAC engine; INV-S9 plugin-code gate is the only authorization path")
+}
+
+func readBytes(path string) ([]byte, error) { /* simple os.ReadFile wrapper */ }
+```
+
+- [ ] **Step 2: Run the meta-test**
+
+Run: `task test -- ./internal/test/invariants/ -run TestINV_P4_4`
+
+Expected: PASS (GetPoseOrder body contains no ABAC calls).
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-4): GetPoseOrder MUST NOT call ABAC engine
+
+Meta-test using go/parser to extract GetPoseOrder function body and
+rg-assert it contains no engine.Evaluate / engine.CanPerformAction
+calls. Pins INV-P4-4 / INV-S9: scene privacy is plugin-code-gated,
+absolute; ABAC engine is not in the authorization path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 24: Meta-test — no colon-style scene subjects (INV-P4-1)
+
+**Files:**
+
+- Create: `internal/test/invariants/scene_subjects_test.go`
+
+- [ ] **Step 1: Write the meta-test**
+
+```go
+// TestINV_P4_1_NoColonStyleSceneSubjects rg-asserts that no production
+// code path in plugins/core-scenes/ or scene-aware substrate code
+// (internal/grpc/stream_access.go, internal/grpc/scope_floor.go,
+// internal/grpc/query_stream_history.go) contains a "scene:" string
+// literal in a pub/sub-topic context.
+//
+// ABAC resource ID context (NewAccessRequest, Grant calls) is excluded
+// — that's policy-DSL serialization, not a topic (spec §3.2).
+func TestINV_P4_1_NoColonStyleSceneSubjects(t *testing.T) {
+    targets := []string{
+        "../../../plugins/core-scenes/service.go",
+        "../../../plugins/core-scenes/commands.go",
+        "../../../plugins/core-scenes/audit.go",
+        "../../../plugins/core-scenes/store.go",
+        "../../../plugins/core-scenes/resolver.go",
+        "../../../plugins/core-scenes/main.go",
+        "../../../internal/grpc/stream_access.go",
+        "../../../internal/grpc/scope_floor.go",
+        "../../../internal/grpc/query_stream_history.go",
+    }
+    // Match "scene:" string literals, but EXCLUDE lines that are clearly
+    // ABAC-resource-id context (e.g., they contain NewAccessRequest or
+    // .Grant() or .Resource:). Conservative match: just flag and let the
+    // implementer audit; one-off false-positives are cheaper than a
+    // bypass-by-design.
+    pattern := regexp.MustCompile(`"scene:"`)
+    for _, path := range targets {
+        data, err := os.ReadFile(path)
+        require.NoError(t, err, "reading %s", path)
+        if matches := pattern.FindAllIndex(data, -1); len(matches) > 0 {
+            // Surface line numbers for diagnostics.
+            for _, m := range matches {
+                lineNum := bytes.Count(data[:m[0]], []byte("\n")) + 1
+                lineStart := bytes.LastIndexByte(data[:m[0]], '\n') + 1
+                lineEnd := bytes.IndexByte(data[m[1]:], '\n')
+                if lineEnd == -1 { lineEnd = len(data) - m[1] }
+                line := string(data[lineStart:m[1]+lineEnd])
+                // Exclude ABAC resource-id context.
+                if strings.Contains(line, "NewAccessRequest") || strings.Contains(line, ".Grant(") || strings.Contains(line, "resource:") {
+                    continue
+                }
+                t.Errorf("INV-P4-1: %s:%d uses colon-style scene subject: %s", path, lineNum, line)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `task test -- ./internal/test/invariants/ -run TestINV_P4_1`
+
+Expected: PASS (no colon-style scene subjects in production code).
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-1): rg-assert no colon-style scene subjects
+
+Meta-test scans plugins/core-scenes/ + scene-aware substrate files
+(stream_access.go, scope_floor.go, query_stream_history.go) for
+'scene:' string literals in pub/sub-topic context. ABAC resource-id
+contexts (NewAccessRequest, Grant) excluded per spec §3.2.
+
+Pins INV-P4-1: all Phase 4 plugin-owned scene events MUST emit to
+NATS dot-style subjects; legacy colon-style MUST NOT appear in any
+pub/sub topic context.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 25: Non-participant scene IC isolation integration test (INV-P4-6, closes ac50)
+
+**Files:**
+
+- Create: `test/integration/scenes/non_participant_ic_isolation_test.go`
+
+- [ ] **Step 1: Write the Ginkgo spec**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package scenes_test
+
+import (
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+var _ = Describe("INV-P4-6: non-participant scene IC isolation", func() {
+    var (
+        env *TestEnv
+    )
+    BeforeEach(func() {
+        env = newTestEnv()
+    })
+    AfterEach(func() {
+        env.cleanup()
+    })
+
+    It("non-participant in same location MUST NOT receive scene IC events", func() {
+        loc := env.createLocation("Tavern")
+        alice := env.createCharacter("Alice", loc)
+        bob := env.createCharacter("Bob", loc)
+
+        sceneID := env.createScene(alice, "Phase 4 isolation test")
+
+        // Alice subscribes to scene IC; Bob subscribes only to location.
+        aliceStream := env.subscribeScene(alice, sceneID)
+        bobStream := env.subscribeLocation(bob, loc)
+
+        // Alice poses.
+        env.scenePose(alice, sceneID, "smiles at the room")
+
+        // Alice's stream MUST receive the scene_pose event.
+        Eventually(aliceStream.events, "2s").Should(ContainElementWithType("scene_pose"))
+
+        // Bob's stream MUST NOT receive ANY scene event.
+        Consistently(bobStream.events, "2s").ShouldNot(ContainElementWithSubjectPrefix("events.test.scene."))
+    })
+})
+```
+
+The test helpers (`TestEnv`, `createLocation`, `subscribeScene`, etc.) live in `test/integration/scenes/helpers_test.go` — adapt existing patterns from other integration tests under `test/integration/`. If helper infrastructure does not yet exist, add a minimal `TestEnv` here.
+
+- [ ] **Step 2: Run**
+
+Run: `task test:int -- -run TestINV_P4_6 ./test/integration/scenes/`
+
+Expected: PASS.
+
+- [ ] **Step 3: Close audit-finding bead `holomush-ac50`**
+
+Run:
+
+```bash
+bd close holomush-ac50 --reason="Closed by holomush-5rh.13 Phase 4: INV-P4-6 integration test in test/integration/scenes/non_participant_ic_isolation_test.go pins the boundary."
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-6): non-participant scene IC isolation (closes ac50)
+
+Ginkgo integration test asserting that a non-participant in the same
+physical location does NOT receive scene IC events while a participant
+DOES. The mechanism is implicit (focus subscription gates non-
+participants before they ever subscribe to the scene IC stream); this
+test makes the boundary auditable per audit-finding holomush-ac50.
+
+Pins INV-P4-6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 26: Late-joiner temporal floor integration test (INV-P4-9 end-to-end)
+
+**Files:**
+
+- Create: `test/integration/scenes/late_joiner_temporal_floor_test.go`
+
+- [ ] **Step 1: Write the Ginkgo spec**
+
+```go
+//go:build integration
+
+package scenes_test
+
+import (
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+)
+
+var _ = Describe("INV-P4-9: late-joiner temporal floor for scene IC stream", func() {
+    It("late-joiner sees only events after their joined_at", func() {
+        env := newTestEnv()
+        defer env.cleanup()
+
+        loc := env.createLocation("Lounge")
+        alice := env.createCharacter("Alice", loc)
+        bob := env.createCharacter("Bob", loc)
+
+        sceneID := env.createScene(alice, "Lounge scene")
+
+        // Alice poses 5 times BEFORE Bob joins.
+        for i := 0; i < 5; i++ {
+            env.scenePose(alice, sceneID, "pose #" + strconv.Itoa(i+1))
+        }
+        time.Sleep(100 * time.Millisecond)  // let JetStream durably persist
+
+        // Bob joins after the fact.
+        env.sceneJoin(bob, sceneID)
+        bobJoinedAt := time.Now().UTC()
+
+        // Bob's QueryStreamHistory on scene IC subject MUST return ONLY
+        // events with timestamp >= bobJoinedAt (no pre-join history).
+        events := env.queryStreamHistory(bob, dotStyleSceneSubjectIC(env.gameID, sceneID))
+        for _, e := range events {
+            Expect(e.Timestamp.AsTime()).To(BeTemporally(">=", bobJoinedAt))
+        }
+        // Bob MUST see zero pre-join scene_pose events.
+        scenePoseCount := 0
+        for _, e := range events {
+            if e.Type == "scene_pose" { scenePoseCount++ }
+        }
+        Expect(scenePoseCount).To(Equal(0), "INV-P4-9: late-joiner MUST NOT see pre-arrival IC events")
+
+        // Bob's GetPoseOrder MUST reflect ALL 5 of Alice's poses (pose-order
+        // computation is scene-global, not subject to the temporal floor).
+        po := env.getPoseOrder(bob, sceneID)
+        Expect(po.TotalPoseCount).To(Equal(uint32(5)))
+    })
+})
+```
+
+- [ ] **Step 2: Run**
+
+Run: `task test:int -- -run TestINV_P4_9 ./test/integration/scenes/`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-9): late-joiner temporal floor integration
+
+Ginkgo integration test asserting:
+(1) Bob, joining a scene after Alice has posed 5 times, sees ZERO
+    pre-arrival scene_pose events in QueryStreamHistory.
+(2) Bob's GetPoseOrder reflects ALL 5 of Alice's poses — pose-order
+    computation is scene-global; only display via QueryStreamHistory
+    is subject to the temporal floor.
+
+End-to-end pin for INV-P4-9 on the post-migration code path (the
+unit-level pre/post pin lives in internal/grpc/scope_floor_test.go).
+
+Soft dependency on holomush-iwzt.15 (Tier 2 filter-at-delivery) for
+the Subscribe path; this test specifically exercises QueryStreamHistory
+which the iwzt-side ScopeFloor migration (Task 13) already covers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 27: Pose-order metadata rebuild integration test (INV-P4-8)
+
+**Files:**
+
+- Test: `plugins/core-scenes/store_integration_test.go`
+
+- [ ] **Step 1: Write the rebuild idempotency test**
+
+Append:
+
+```go
+func (s *StoreIntegrationSuite) TestPoseOrderMetadata_RebuildFromAuditLog_INV_P4_8() {
+    ctx := context.Background()
+    sceneID := s.createScene(ctx, "owner-rebuild")
+    s.joinScene(ctx, sceneID, "alice")
+    s.joinScene(ctx, sceneID, "bob")
+
+    // Simulate audit-handler dispatch for 5 poses (3 by alice, 2 by bob).
+    audit := NewSceneAuditStore(s.pool)
+    for i, actor := range []string{"alice", "alice", "bob", "alice", "bob"} {
+        require.NoError(s.T(), audit.InsertScenePose(ctx,
+            ulid.Make().Bytes(),
+            "events.test.scene." + sceneID + ".ic", "scene_pose",
+            timestamppb.New(time.Now().Add(time.Duration(i) * time.Second)),
+            "character", []byte(actor),
+            []byte(`{}`), 1, "identity", nil, nil,
+            sceneID, actor,
+        ))
+    }
+
+    // Snapshot post-emit metadata.
+    pm1, err := s.store.ListParticipantsWithPoseMeta(ctx, sceneID)
+    s.Require().NoError(err)
+
+    // Run the recovery SQL from spec §9.5.
+    _, err = s.pool.Exec(ctx, recoveryUpdateScenesTotalPoseCount)  // SQL constants in a test_sql.go
+    s.Require().NoError(err)
+    _, err = s.pool.Exec(ctx, recoveryUpdateScenePoseMeta)
+    s.Require().NoError(err)
+
+    // Snapshot post-rebuild metadata.
+    pm2, err := s.store.ListParticipantsWithPoseMeta(ctx, sceneID)
+    s.Require().NoError(err)
+
+    // Assert byte-identical.
+    s.Require().Equal(pm1.TotalPoseCount, pm2.TotalPoseCount, "INV-P4-8: rebuild produces identical total_pose_count")
+    s.Require().Len(pm2.Participants, len(pm1.Participants))
+    // Compare each participant's metadata (mod ordering — sort by character_id).
+    for _, p1 := range pm1.Participants {
+        var p2 ParticipantWithPoseMeta
+        for _, candidate := range pm2.Participants {
+            if candidate.CharacterID == p1.CharacterID { p2 = candidate; break }
+        }
+        s.Require().Equal(p1.LastPoseSeq, p2.LastPoseSeq)
+        if p1.LastPoseAt != nil && p2.LastPoseAt != nil {
+            s.Require().WithinDuration(*p1.LastPoseAt, *p2.LastPoseAt, time.Millisecond)
+        }
+    }
+}
+```
+
+The two recovery SQL constants live in a new file `plugins/core-scenes/recovery_sql.go` (or inlined in the test). Implementation per spec §9.5.
+
+- [ ] **Step 2: Run**
+
+Run: `task test:int -- -run TestPoseOrderMetadata_RebuildFromAuditLog ./plugins/core-scenes/`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-8): pose-order metadata rebuild idempotency
+
+Integration test exercising the spec §9.5 recovery SQL. Emits 5 mixed
+poses via InsertScenePose; snapshots the maintained metadata;
+runs the recovery SQL; snapshots again; asserts byte-identical results.
+
+Pins INV-P4-8: maintained metadata is a function of scene_log; the
+documented recovery procedure produces identical metadata when run
+after arbitrary pose history. Recovery SQL formalised in
+plugins/core-scenes/recovery_sql.go for operator runbook reuse.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 28: INV-P4-* coverage meta-test (INV-P4-13)
+
+**Files:**
+
+- Create: `internal/test/invariants/p4_coverage_test.go`
+
+- [ ] **Step 1: Write the coverage meta-test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package invariants
+
+import (
+    "os"
+    "path/filepath"
+    "regexp"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestINV_P4_13_CoverageMatrix parses the spec, extracts every
+// INV-P4-N reference, and asserts:
+// (1) The coverage matrix table (§12.1) cites at least one test file per invariant.
+// (2) Each cited test file path exists on disk.
+// (3) For each cited test, the file contains a test function whose name
+//     references the invariant (best-effort via INV_P4_N substring match).
+func TestINV_P4_13_CoverageMatrix(t *testing.T) {
+    specPath := "../../../docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md"
+    data, err := os.ReadFile(specPath)
+    require.NoError(t, err)
+
+    spec := string(data)
+
+    // Extract all numbered invariants (INV-P4-1 .. INV-P4-13).
+    invRe := regexp.MustCompile(`INV-P4-(\d+)`)
+    invSet := make(map[string]bool)
+    for _, m := range invRe.FindAllStringSubmatch(spec, -1) {
+        invSet["INV-P4-"+m[1]] = true
+    }
+    assert.GreaterOrEqual(t, len(invSet), 13, "spec MUST declare at least 13 invariants")
+
+    // Extract test-file references from §12.1 coverage matrix lines.
+    fileRe := regexp.MustCompile("`([^`]+_test\\.go)`")
+    citedTests := fileRe.FindAllStringSubmatch(spec, -1)
+    require.NotEmpty(t, citedTests, "spec §12.1 MUST cite test files")
+
+    // Verify each cited test path exists.
+    repoRoot, err := filepath.Abs("../../..")
+    require.NoError(t, err)
+    for _, m := range citedTests {
+        path := filepath.Join(repoRoot, m[1])
+        _, err := os.Stat(path)
+        if os.IsNotExist(err) {
+            t.Errorf("INV-P4-13: cited test path does not exist: %s", m[1])
+        }
+    }
+
+    // For each invariant, assert at least one cited test mentions it.
+    for invariant := range invSet {
+        normalized := strings.ReplaceAll(invariant, "-", "_")  // INV_P4_1
+        found := false
+        for _, m := range citedTests {
+            data, err := os.ReadFile(filepath.Join(repoRoot, m[1]))
+            if err != nil { continue }
+            if strings.Contains(string(data), normalized) || strings.Contains(string(data), invariant) {
+                found = true
+                break
+            }
+        }
+        assert.True(t, found, "INV-P4-13: invariant %s has no test citing it by name", invariant)
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `task test -- ./internal/test/invariants/ -run TestINV_P4_13`
+
+Expected: PASS — all 13 invariants have at least one cited test that mentions them by name.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "test(scene-inv-p4-13): coverage matrix meta-test
+
+Parses the spec, extracts INV-P4-1..13 declarations and the §12.1
+coverage matrix's cited test files, then asserts:
+(1) Spec declares at least 13 invariants.
+(2) Every cited test file path exists on disk.
+(3) Each invariant is mentioned by name in at least one cited test.
+
+Pins INV-P4-13 — same shape as iwzt T15 / 5b2j T15 precedents.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+---
+
+## Phase J — Documentation + close-out
+
+### Task 29: Update iwzt §3 stream-type table to dot-style
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md`
+
+- [ ] **Step 1: Locate §3 stream-type table**
+
+Open the iwzt history-scope-privacy spec. Find the `## 3. Scope by stream type` table.
+
+- [ ] **Step 2: Update scene rows to dot-style**
+
+Replace existing entries:
+
+```markdown
+| `scene:<id>:ic`, `scene:<id>:ooc` | Existing I-17 membership gate (unchanged) | ... |
+```
+
+with:
+
+```markdown
+| `events.<game_id>.scene.<scene_id>.ic`, `events.<game_id>.scene.<scene_id>.ooc` | Existing I-17 membership gate (migrated to dot-style by Phase 4, `holomush-5rh.13`) | ... |
+```
+
+Other entries in the table (`location:`, `character:`, plugin-owned) remain colon-style and are covered by `holomush-rops`.
+
+- [ ] **Step 3: Lint docs**
+
+Run: `task lint:markdown`
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "docs(iwzt): §3 — scene rows updated to NATS dot-style
+
+Phase 4 (holomush-5rh.13) migrated scene-aware substrate code to
+dot-style scene subjects. iwzt §3 stream-type table now reflects the
+post-Phase-4 reality. Other entries (location, character, plugin-owned)
+unchanged — tracked separately by holomush-rops.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+Then `jj new`.
+
+### Task 30: Update v2 §3.1 stream-naming table to dot-style
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md`
+
+- [ ] **Step 1: Update §3.1 table**
+
+Replace the stream-naming table's scene rows to use dot-style. Add a footnote citing Phase 4 (`holomush-5rh.13`) as the migration point.
+
+- [ ] **Step 2: Lint + commit**
+
+Run: `task lint:markdown`. Commit per the existing convention with a `docs(scenes-v2): §3.1 — dot-style subjects` message.
+
+### Task 31: Run `task pr-prep` to completion
+
+**Files:** (no file changes)
+
+- [ ] **Step 1: Run the full pre-push pipeline**
+
+Run: `task pr-prep`
+
+Expected: full pipeline runs (lint + format + schema + license + unit + integration + E2E) and reports green. Per the project rule, DO NOT skip; DO NOT trust a sub-agent's claim.
+
+If any step fails:
+
+1. Capture the exact failure output.
+2. Diagnose the failing component (likely a missing test fixture or a regression in a tangentially-touched file).
+3. Fix inline.
+4. Re-run `task pr-prep` from the top.
+
+- [ ] **Step 2: Verify no jj describe is needed**
+
+Run: `jj st`
+
+Expected: working copy is clean (if all Phase 4 changes have been committed in the prior tasks).
+
+- [ ] **Step 3: Push**
+
+Per CLAUDE.md "Landing the Plane" + the `jj:jujutsu` skill "Pre-Push Rebase" section:
+
+```bash
+jj git fetch
+jj rebase -s "$(jj log -r 'roots(trunk()..@)' --no-graph -T 'change_id.short(12)')" -o main@origin --skip-emptied
+jj bookmark set 5rh-13-phase4 -r @
+jj git push --branch 5rh-13-phase4
+jj st  # verify
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat(scenes): Phase 4 — IC/OOC event streams + pose order (5rh.13)" --body "$(cat <<'EOF'
+## Summary
+
+- 8 plugin-owned scene event types with crypto.emits matrix + EmitTypeRegistrar adoption (INV-S5 set-equality)
+- Pose-order computation with maintained metadata (O(N participants), no event-history scan); GetPoseOrder RPC with INV-S9 plugin-code participant gate
+- scene pose/say/emit/ooc/order subcommands; auto-emit notice events on join/leave/kick/mode-change
+- Scene subject migration: plugin emits + substrate-side scene-aware code (stream_access.go, scope_floor.go, query_stream_history.go) atomic in this PR
+- Closes live silent regression in scope_floor.go (pre-Phase-4 returned time.Time{} for all production callers)
+- 13 numbered INV-P4-* invariants with cited tests + coverage meta-test
+- Closes audit-finding holomush-ac50
+
+## Spec / design
+
+- Spec: docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md (design-reviewer READY round 3)
+- Plan: docs/superpowers/plans/2026-05-19-scenes-phase-4-streams-and-pose-order.md (plan-reviewer READY)
+
+## Dependencies
+
+- Hard: holomush-5b2j.3 (GetNamesByIDs batch lookup)
+- Soft: holomush-iwzt.15 (Tier 2 filter-at-delivery) — covered by INV-P4-9 end-to-end test
+
+## Out of scope / follow-ups
+
+- Focus routing for plain pose/say/emit/ooc → Phase 5 (holomush-5rh.14)
+- scene_idle_nudge background trigger → new follow-up bead (filed at plan-to-beads time)
+- Non-scene colon-style sweep (location, character, notifications) → holomush-rops
+
+## Test plan
+
+- [x] task pr-prep green (full lane)
+- [x] All 13 INV-P4-* tests pass
+- [x] Existing Phase 1-3 tests pass (no regression)
+- [x] crypto-reviewer + abac-reviewer + code-reviewer passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Update bead status**
+
+```bash
+bd update holomush-5rh.13 --status=in_progress  # if not already
+bd note holomush-5rh.13 "PR opened: <URL from gh pr create output>"
+```
+
+---
+
+## Post-implementation checklist
+
+- [ ] All 31 tasks complete; their checkboxes ticked.
+- [ ] `task pr-prep` green on the final commit.
+- [ ] PR opened with the title + body from Task 31 Step 4.
+- [ ] `holomush-ac50` closed (audit-finding for non-participant isolation).
+- [ ] `holomush-5rh.13` updated with PR URL.
+- [ ] `holomush-rops` remains open (broader sweep — separate work).
+- [ ] Follow-up bead filed: "Scenes: scene_idle_nudge background trigger implementation" (P2, parent `holomush-5rh.13`).
+- [ ] `holomush-iwzt.15` Tier 2 filter-at-delivery: verify INV-P4-9 integration test still passes when iwzt.15 lands; no Phase 4 changes needed.
+- [ ] PR review surface includes `crypto-reviewer` (crypto.emits manifest changes) AND `abac-reviewer` (no new policies but verify) AND `code-reviewer` (substrate-side gate migration in internal/grpc/).
+
+---
+
+<!-- adr-capture: sha256=2bf828e93cf93b2a; ts=2026-05-19T12:00:00Z; adrs=holomush-r4th,holomush-s9nu,holomush-sb3n,holomush-nt2d,holomush-1ang -->

--- a/docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md
+++ b/docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md
@@ -1,0 +1,916 @@
+# Scenes Phase 4 — Event streams + pose order
+
+## Status
+
+**Draft** — pending `design-reviewer` adversarial review.
+
+**Bead:** `holomush-5rh.13` — Scenes Phase 4: Event streams + pose order.
+
+**Authors:**
+
+- Sean Brandt
+- Claude (collaborator, via `dev-flow:brainstorming`)
+
+**Date:** 2026-05-19
+
+**Workspace:** `5rh-13-phase4-brainstorm`
+
+## Overview
+
+Phase 4 turns `core-scenes` from "membership and lifecycle only" (Phase 3) into "membership, lifecycle, AND content emission + pose-order computation" while staying within the substrate-contract boundaries.
+
+Four moving parts:
+
+1. **Plugin-owned content emission surface.** `scene pose / say / emit / ooc` subcommands on the existing `scene` top-level command. Each subcommand emits a typed event (`scene_pose` / `scene_say` / `scene_emit` / `scene_ooc`) to subject `events.<game_id>.scene.<scene_id>.ic` (or `.ooc` for the OOC verb), with the corresponding `crypto.emits` sensitivity. The existing emit path through `internal/plugin/event_emitter.go::Emit` carries these — the same gate that already enforces core-communication's emits.
+
+2. **`crypto.emits` matrix + `EmitTypeRegistrar` adoption.** 8 entries in `plugins/core-scenes/plugin.yaml::crypto.emits`. `scenePlugin` implements `pluginsdk.EmitTypeRegistrar`, registering all 8 types in its `EmitRegistry()`. The substrate INV-S5 validator at `internal/plugin/manager.go::loadPlugin` will fail-closed on any drift.
+
+3. **Pose-order computation + GetPoseOrder RPC.** Computation reads maintained metadata on `scene_participants` (`last_pose_at`, `last_pose_seq`) and `scenes` (`total_pose_count`). All 4 modes (`strict`, `3pr`, `5pr`, `free`) supported with O(N participants) reads — no event-history scan. Read path gated by an INV-S9 plugin-code participant check before any computation runs (no ABAC consultation).
+
+4. **Notice events.** `scene_join_ic` / `scene_leave_ic` (auto-emitted by `JoinScene` / `LeaveScene` / `KickFromScene` RPCs so participants see arrivals/departures in their IC stream). `scene_pose_order_changed_ic` (auto-emitted by `UpdateScene` when `pose_order_mode` is in the update mask, alongside the existing Phase 3 `settings.updated` ops event). `scene_idle_nudge` (event type registered; background-trigger implementation deferred to a follow-up bead per §13).
+
+## Supersedes / extends
+
+- **Extends** [`docs/superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md`](2026-04-06-scenes-and-rp-design-v2.md) sections 3 and 4 (Event streams + Pose order). Product semantics (D1–D10) unchanged.
+- **Binds to** [`docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md`](2026-05-16-social-spaces-substrate-contract.md). Phase 4 adds the first plugin-owned scene subjects; populates `crypto.emits`; adopts `EmitTypeRegistrar`.
+- **Binds to** [`docs/superpowers/specs/2026-05-17-inv-s5-mechanism-design.md`](2026-05-17-inv-s5-mechanism-design.md). `scenePlugin` implements the binary-plugin `EmitTypeRegistrar` interface; substrate set-equality validator enforces.
+- **Binds to** [`docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md`](2026-05-17-history-scope-privacy-design.md) §3 scene-stream entry. Scene IC/OOC streams inherit the per-membership temporal floor (`MAX(focusMembership.JoinedAt, [if IsGuest] GuestCharacterCreatedAt)`) and the I-17 hardcoded membership gate. Scene privacy is absolute (no ABAC override).
+- **Binds to** [`docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md`](2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md) — plugin audit table shape (DEK columns) is the persistence target for `scene_log` rows.
+
+## RFC2119 keywords
+
+The keywords MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used per RFC2119.
+
+## Invariants
+
+13 numbered invariants. Each is paired with a cited test (see §12.1 for the coverage matrix). The meta-test (INV-P4-13) enforces coverage of every numbered INV-P4-* by spec.
+
+| # | Invariant | Enforcement |
+|---|-----------|-------------|
+| INV-P4-1 | All Phase 4 plugin-owned scene events MUST emit to NATS dot-style subjects (`events.<game_id>.scene.<scene_id>.<facet>`). Legacy colon-style `scene:<id>:*` MUST NOT appear in any pub/sub topic context within `plugins/core-scenes/` or scene-aware substrate code (`internal/grpc/stream_access.go`, `internal/grpc/query_stream_history.go`, `internal/grpc/scope_floor.go`). | Meta-test + per-emit unit test |
+| INV-P4-2 | The 8 scene event types (`scene_pose`, `scene_say`, `scene_emit`, `scene_ooc`, `scene_join_ic`, `scene_leave_ic`, `scene_pose_order_changed_ic`, `scene_idle_nudge`) MUST be declared in `plugins/core-scenes/plugin.yaml::crypto.emits` AND MUST be registered via `EmitTypeRegistrar.RegisterEmitTypes`. The two sets MUST be set-equal. | Manifest-parse unit test + substrate INV-S5 enforcement |
+| INV-P4-3 | Sensitivity classification MUST be: `scene_pose`/`scene_say`/`scene_emit`/`scene_ooc` are `always`; `scene_join_ic`/`scene_leave_ic`/`scene_pose_order_changed_ic`/`scene_idle_nudge` are `never`. No `may`-classified events in Phase 4. | Manifest-parse unit test |
+| INV-P4-4 | `GetPoseOrder` MUST gate non-participant callers via a direct `scene_participants` membership check BEFORE any computation runs. The ABAC engine MUST NOT be consulted for this gate. | Unit test asserting `PermissionDenied` for non-participants + meta-test asserting no `engine.Evaluate` call in `GetPoseOrder` body |
+| INV-P4-5 | `AttributeResolverService.ResolveResource` MUST NOT expose pose-order data (`last_pose_at`, `last_pose_seq`, `total_pose_count`) as a scene attribute. Pose-order data is reachable exclusively via the gated `GetPoseOrder` RPC. | Unit test on resolver output + meta-test rg-asserting no pose-metadata columns in attribute-construction code |
+| INV-P4-6 | Non-participants in the same physical location MUST NOT receive scene IC events. Closes audit-finding `holomush-ac50`. | Integration test (Ginkgo) — two sessions same location, one participant one not, scene emit, assert isolation |
+| INV-P4-7 | Pose-order computation MUST produce correct results for each of the 4 modes (`strict`, `3pr`, `5pr`, `free`). Per-mode test matrix covers empty / single / multi participants; none-posed / all-eligible / some-cooldown; out-of-turn pose adjustment (strict); join-pose-leave-rejoin sequences. | Table-driven pure-function unit tests on `poseorder.Compute()` |
+| INV-P4-8 | Maintained pose-order metadata (`scenes.total_pose_count`, `scene_participants.last_pose_at`, `scene_participants.last_pose_seq`) MUST be a function of `scene_log` `scene_pose` rows. The documented recovery SQL MUST produce identical metadata values when run after arbitrary pose history. | Integration test — emit N poses, snapshot metadata, run recovery SQL, assert byte-identical |
+| INV-P4-9 | Late-joining participants MUST see only IC events from `scene_participants.joined_at` forward when reading via `QueryStreamHistory`. Pose-order computation remains scene-global; display via `GetPoseOrder` is unaffected by caller's `joined_at`. Currently a live silent regression — `scope_floor.go:21-28` returns `time.Time{}` for all production callers; Phase 4's dot-style migration fixes it (§3.3). | Integration test — A poses N times, B joins late, B's `QueryStreamHistory` returns events `>= B.joined_at`; B's `GetPoseOrder` reflects all N. Test MUST include pre-migration baseline assertion to pin the bug-fix moment per §3.3 |
+| INV-P4-10 | `scene_pose` audit-row insertion AND pose-metadata update MUST be transactional. Either both commit or both roll back. | Fault-injection unit test on audit handler |
+| INV-P4-11 | `scene pose` / `scene say` / `scene emit` / `scene ooc` subcommands MUST require the actor to be a participant of the target scene. (Inherits Phase 3 `write-scene-as-participant` ABAC policy via command-capability pre-flight.) | Integration test — non-participant attempts each subcommand, assert `PermissionDenied` |
+| INV-P4-12 | `scene update` with `pose_order_mode` in `update_mask` MUST require the actor to be the scene owner. (Inherits Phase 3 `update-own-scene` ABAC policy.) | Integration test — non-owner participant attempts the update, assert `PermissionDenied` |
+| INV-P4-13 (meta) | Every numbered INV-P4-* MUST have at least one cited test file referenced in this spec. Coverage matrix in §12.1 MUST exist. | Meta-test parsing this spec; same shape as iwzt T15 / 5b2j T15 |
+
+## 1. Substrate inheritance
+
+What Phase 4 BINDS to without modifying:
+
+| Substrate primitive | Phase 4 use |
+|---------------------|-------------|
+| Emit path through `internal/plugin/event_emitter.go::Emit` | Each scene event type flows through this gate. Existing manifest enforcement (`crypto.emits`, `actor_kinds_claimable`) applies uniformly to Phase 4 emits. |
+| INV-S5 set-equality validator at `internal/plugin/manager.go::loadPlugin` | Fires on `core-scenes` load; fails closed if manifest and code drift. |
+| INV-S9 plugin-code privacy boundary (ADR `holomush-c8a9`) | `GetPoseOrder` adopts this pattern; `GetSceneLog` (Phase 6, `holomush-cb4x`) will mirror it. |
+| I-17 hardcoded scene-membership gate (`internal/grpc/query_stream_history.go:157-178`) | Migrated to dot-style subject classification by Phase 4; protects scene IC/OOC stream subscription / history reads. |
+| iwzt §3 scene-stream entry + I-PRIV-1..8 invariants | Phase 4 IC/OOC streams inherit the per-membership temporal floor (`MAX(focusMembership.JoinedAt, [if IsGuest] GuestCharacterCreatedAt)`) and filter-at-delivery. |
+| `audit` declaration `subjects: ["events.*.scene.>"]` in current `plugin.yaml` | Already wildcard; no manifest change needed. Phase 4's IC + OOC events route to `scene_log`. |
+| `history_scope: scene` in current `plugin.yaml` | Already declared per ADR `holomush-jhl5`. No Phase 4 work. |
+| Substrate filter-at-delivery (ADR `holomush-ghpx`) | Phase 4 scene IC/OOC subjects covered by the existing two-tier privacy enforcement. |
+
+What Phase 4 does NOT do (out of scope; §16):
+
+- Focus-routing for plain `pose` / `say` / `emit` / `ooc` — Phase 5.
+- Scene log content read path — Phase 6 + `holomush-cb4x`.
+- Cross-scene notifications stream — Phase 10.
+- Web client chat view — Phase 9.
+
+## 2. Event vocabulary + crypto.emits matrix
+
+8 plugin-owned scene event types. The privacy boundary for scene content is the participant list (INV-S9 / iwzt §3 "scene privacy is absolute"), so content-carrying events classify as `sensitivity: always` and notice events as `sensitivity: never`.
+
+| Event type | Stream | Sensitivity | Trigger | Payload shape |
+|------------|--------|-------------|---------|---------------|
+| `scene_pose` | `.ic` | `always` | `scene pose <text>` subcommand | `{actor_id, scene_id, text}` |
+| `scene_say` | `.ic` | `always` | `scene say <text>` subcommand | `{actor_id, scene_id, text}` |
+| `scene_emit` | `.ic` | `always` | `scene emit <text>` subcommand | `{actor_id, scene_id, text}` |
+| `scene_ooc` | `.ooc` | `always` | `scene ooc <text>` subcommand | `{actor_id, scene_id, text}` |
+| `scene_join_ic` | `.ic` | `never` | Auto-emitted by `JoinScene` RPC on `OpInserted` or `OpPromoted` results (skipped on `OpNoChange` per Phase 3 D5 retry-idempotency) | `{actor_id, actor_name, scene_id, from_role}` |
+| `scene_leave_ic` | `.ic` | `never` | Auto-emitted by `LeaveScene` and `KickFromScene` RPCs on successful remove | `{actor_id, actor_name, scene_id, reason, removed_by?}` where `reason in {"left","kicked"}`, `removed_by` populated for kicks |
+| `scene_pose_order_changed_ic` | `.ic` | `never` | Auto-emitted by `UpdateScene` when `update_mask` contains `pose_order_mode` AND the new value differs from current | `{actor_id, actor_name, scene_id, old_mode, new_mode}` |
+| `scene_idle_nudge` | `.ooc` | `never` | **Background-trigger implementation deferred (§13).** Wire shape lands in Phase 4; trigger lands in follow-up bead. | `{target_id, target_name, scene_id, idle_duration_seconds, eligible_since_seq}` |
+
+**Sensitivity rationale.** The 4 `always` types carry RP content; INV-S9 makes the participant list the privacy boundary (analog to `whisper`/`page` in core-communication, NOT to `say` whose privacy boundary is the location). The 4 `never` types carry only metadata (character IDs, names, mode strings, durations) — analogous to core-communication's `whisper_notice`. The `mjy3` footgun (sensitivity: never blocks future encrypted emits) is acknowledged: notice events are committed to plaintext for the lifetime of the spec; if a future requirement demands encryption, a sensitivity change is a deliberate manifest migration.
+
+**OOC sensitivity: always (not may).** Considered classifying `scene_ooc` as `may` (caller flexibility per ephemeral OOC). Rejected because: (a) v2 §3.1 makes OOC participant-only (privacy boundary applies regardless of archival status); (b) iwzt §3 explicitly covers `scene:<id>:ooc` under "scene privacy is absolute"; (c) Phase 7 has a known fence gap for `may`-classified types (manifest-set downgrade fence only covers `always`). `always` for OOC has overhead (encryption on ephemeral chatter) but the substrate guarantee strength dominates.
+
+## 3. Subject naming + substrate migration
+
+### 3.1 Subject naming (no legacy translation)
+
+| Stream | Subject |
+|--------|---------|
+| IC | `events.<game_id>.scene.<scene_id>.ic` |
+| OOC | `events.<game_id>.scene.<scene_id>.ooc` |
+| Existing lifecycle (CreateScene, EndScene, etc., from Phase 1-3) | `events.<game_id>.scene.<scene_id>` (no facet — entity-level subject; migrates from current colon-style `scene:<id>`) |
+
+Per the substrate contract §1.1 and INV-S4, NATS dot-style is the only form for new code. Phase 4 commits to **no translation layer** for scene subjects: any colon-style scene-subject usage in core-scenes or scene-aware substrate code MUST be migrated in this PR.
+
+### 3.2 Substrate migration scope
+
+Phase 4 ships scene-subject migration in a single coherent PR alongside plugin emission. The non-scene colon-style sweep (location, character, notifications) is tracked by `holomush-rops` (P1 top-level, separate effort).
+
+| File | Lines (approx) | Change |
+|------|----------------|--------|
+| `plugins/core-scenes/service.go` | `:211` | Replace `Subject: "scene:" + row.ID` with NATS dot-style via a shared `subjectFormatter` helper that takes `gameID`, `sceneID`, optional `facet` |
+| `plugins/core-scenes/service_test.go` | `:426` | Update test expectations to dot-style |
+| `internal/grpc/stream_access.go` | `:25, :52, :77` | `isPrivateStream` / `extractSceneID` / scene-stream helpers parse the NATS dot-style scene-subject form |
+| `internal/grpc/query_stream_history.go` | `:39, :157-178` | I-17 hardcoded scene-membership gate matches dot-style scene subjects |
+| `internal/grpc/scope_floor.go` | `:22, :47, :116` | `streamScopeFloor` classifies dot-style scene subjects for per-membership floor. **Live silent regression fix — see §3.3.** |
+| `internal/grpc/stream_access_test.go`, `internal/grpc/scope_floor_test.go` | many | Update fixtures to dot-style |
+| `test/integration/plugin/binary_plugin_test.go` | `:502, :512` | Update integration scene-stream fixtures (ABAC `Resource` strings — distinct concern — unchanged) |
+| `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` | §3 | Update scene-stream rows to dot-style |
+| `docs/superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md` | §3.1 | Update stream-naming table to dot-style |
+| `internal/eventbus/subjectxlate/` | `subjectxlate.go` | Verified at spec time: no scene-specific path exists today (generic translator). No removal needed for scene migration. Full layer fate decided in `holomush-rops` audit. |
+
+**INV-S1 note.** The substrate-side files touched (`internal/grpc/*`) are scene-aware substrate code. This change is reviewed under substrate review gates (`code-reviewer`, plus `abac-reviewer` since `query_stream_history.go` touches access-control adjacent gating) alongside the plugin gates. The change is atomic — plugin emits dot-style AND substrate gates parse dot-style in the same PR; otherwise the I-17 gate fails closed on Phase 4 emissions.
+
+**ABAC resource IDs unaffected.** The Cedar-style policies reference resources as `<resource_type>:<id>` strings (e.g., `scene:01ABC...` in policy DSL). This is a policy-DSL serialization artifact, NOT a pub/sub topic. Phase 4 does not touch ABAC resource ID serialization. The narrow scope is "no colon-style pub/sub topics"; the broader sweep (also handled by `rops` if/when desired) does not extend to ABAC resource IDs.
+
+### 3.3 `scope_floor.go` — Phase 4 closes a live silent regression
+
+`internal/grpc/scope_floor.go:21-28` carries a developer note:
+
+> "`streamScopeFloor` currently inspects legacy stream-name prefixes (`location:`, `scene:`), but production callers pass NATS subjects (`events.<gid>.location.X`), so the loop returns `time.Time{}` for every real-world subject today. Until that format mismatch is closed (tracked as a separate follow-up bead), the aggregate floor is effectively zero — preserving the pre-iwzt `DeliverAllPolicy` behavior."
+
+This means the iwzt §6.1 temporal floor for scene streams is **not just untested** before Phase 4 — it is **actively non-functional for all real traffic**. The function is wired up, but its prefix match never fires. INV-P4-9 ("late-joining participants MUST see only IC events from `joined_at` forward") is therefore not a future invariant being introduced; it is a live invariant currently being violated by silent fallthrough to "no floor applied."
+
+Phase 4's migration of `scope_floor.go` (developer note at lines 21-28) to dot-style is therefore **a correctness fix for a currently silent failure**, not merely format hygiene.
+
+**Test mechanism — pinning the bug-fix moment.** A naïve "pre-migration baseline" cannot live in an integration test that runs against post-migration code. The pinning approach is a **unit test in `internal/grpc/scope_floor_test.go`** with two table-driven cases that get MODIFIED in the migration commit:
+
+| Case | Subject form | Pre-migration assertion | Post-migration assertion |
+|------|--------------|-------------------------|--------------------------|
+| Legacy colon-style | `scene:01ABC:ic` | Returns `JoinedAt` (current matching branch) | Returns `time.Time{}` (legacy form no longer matched — migration removes the `strings.HasPrefix(stream, "scene:")` branch entirely) |
+| NATS dot-style | `events.holomush.scene.01ABC.ic` | Returns `time.Time{}` (current bug — no prefix match) | Returns `JoinedAt` (new dot-style branch matches) |
+
+The migration commit changes both assertions atomically. The git diff of `scope_floor_test.go` between pre- and post-migration commits is the audit artifact that pins the bug-fix moment. INV-P4-9's integration test (Ginkgo, `test/integration/scenes/late_joiner_temporal_floor_test.go`) then verifies the end-to-end behavior on the post-migration code — late-joiner sees only events from their `joined_at` forward. Both the unit-level pin AND the integration-level assertion are required by INV-P4-9; the unit pin makes the regression-fix moment auditable, the integration pin makes the end-to-end contract testable.
+
+## 4. `EmitTypeRegistrar` adoption
+
+Per the INV-S5 mechanism design §1.2, binary plugins with non-empty `crypto.emits` MUST implement `pluginsdk.EmitTypeRegistrar`. `scenePlugin` adopts:
+
+```go
+// plugins/core-scenes/main.go
+
+import pluginsdk "github.com/holomush/holomush/pkg/plugin"
+
+type scenePlugin struct {
+    // ... existing fields ...
+    emitRegistry *pluginsdk.EmitRegistry
+}
+
+// EmitTypeRegistrar interface.
+func (p *scenePlugin) EmitRegistry() *pluginsdk.EmitRegistry {
+    return p.emitRegistry
+}
+
+func main() {
+    reg := pluginsdk.NewEmitRegistry()
+    reg.RegisterEmitTypes([]string{
+        "scene_pose",
+        "scene_say",
+        "scene_emit",
+        "scene_ooc",
+        "scene_join_ic",
+        "scene_leave_ic",
+        "scene_pose_order_changed_ic",
+        "scene_idle_nudge",
+    })
+
+    plugin := &scenePlugin{
+        // ... existing field initialisation ...
+        emitRegistry: reg,
+    }
+    // ... existing pluginsdk.ServeWithServices call ...
+}
+```
+
+The SDK adapter at `pkg/plugin/sdk.go::pluginServerAdapter.Init` detects the `EmitTypeRegistrar` interface via type assertion and populates `InitResponse.RegisteredEmitTypes` from the registry. Substrate validator compares this set against the manifest's `crypto.emits[].event_type` set; any drift fails plugin load with `EVENT_TYPE_REGISTRY_MISMATCH` (INV-P4-2 / INV-S5).
+
+`scene_idle_nudge` is registered even though Phase 4 does not call `Emit` on it (background trigger deferred). INV-S5 set-equality requires declared AND registered to match; both sets contain the type. The sensitivity-fence (`internal/plugin/sensitivity_fence.go`) only fires on actual `Emit` calls — zero call sites means no fence interaction in Phase 4.
+
+## 5. Emit subcommands
+
+Phase 4 adds four content-emit subcommands to the existing `scene` top-level command. Until Phase 5 ships focus-aware command routing, these are the explicit emit surface; plain `pose` / `say` / `emit` / `ooc` continue to route through core-communication to location streams.
+
+| Subcommand | Emits | Subject facet |
+|------------|-------|---------------|
+| `scene pose <text>` | `scene_pose` | `.ic` |
+| `scene say <text>` | `scene_say` | `.ic` |
+| `scene emit <text>` | `scene_emit` | `.ic` |
+| `scene ooc <text>` | `scene_ooc` | `.ooc` |
+
+### 5.1 Authorization
+
+The existing `scene` command capability declaration (`action: write, resource: scene, scope: local`) carries forward unchanged. The Layer-1 command-execute gate is the existing `execute-scene-commands` policy; the Layer-2 capability pre-flight on `write` translates to the Phase 3 `write-scene-as-participant` DSL policy (`principal.id in resource.scene.participants AND resource.scene.state in ["active", "paused"]`).
+
+INV-P4-11 pins this binding: non-participants attempting any of the 4 emit subcommands MUST fail with `PermissionDenied` at the command-execute layer.
+
+### 5.2 Handler shape
+
+Each subcommand handler:
+
+1. Resolves the target scene (current focus context if available; else explicit `scene_id` argument; else error).
+2. Calls the in-process emit path via `pluginsdk.EventSink.Emit` with:
+   - `Subject`: dot-style scene subject (`.ic` or `.ooc` facet per verb)
+   - `Type`: the corresponding scene event type string
+   - `Payload`: JSON-encoded `{actor_id, scene_id, text}`
+   - `Sensitive`: `true` (matches `sensitivity: always` manifest declaration)
+3. Returns a plain-text confirmation (e.g., `"You pose: <text>"`) to the command output.
+
+Until Phase 5 ships focus context, the target scene MAY be inferred from a single-membership session (if the caller is in exactly one active scene). On ambiguity (multiple active memberships), the handler returns an `InvalidArgument` with an actionable hint message. The single-membership inference is convenience UX, not load-bearing — explicit `scene <id> pose <text>` (or equivalent) syntax MAY be added in Phase 5 if needed.
+
+### 5.3 Emit path through substrate
+
+The emit path is uniform with all other plugin emits:
+
+```text
+scene pose handler
+  → pluginsdk.EventSink.Emit(EmitIntent{...})           [plugin-side SDK]
+    → goplugin gRPC → internal/plugin/event_emitter.go::Emit
+      → manifest gate (crypto.emits sensitivity check + actor_kinds_claimable)
+      → AuditGuard / crypto envelope (sensitivity=always → DEK lookup + encrypt)
+      → JetStream publish to events.<game>.scene.<id>.ic
+      → audit projection ack-and-skip (plugin-owned subject)
+      → PluginAuditService.AuditEvent (plugin-side handler)
+        → scene_log INSERT + (if scene_pose) pose-metadata UPDATE
+          [§9 transactional update; INV-P4-10]
+```
+
+No new substrate surface introduced.
+
+## 6. Pose-order computation
+
+### 6.1 Maintained metadata
+
+Per §9 below, pose-order computation reads denormalized metadata maintained by the audit-event handler on `scene_pose` insertion. Computation is O(N participants) per call, regardless of scene history depth.
+
+### 6.2 Per-mode algorithm
+
+`poseorder.Compute(mode, totalPoseCount, participantsWithMeta, names) → ([]PoseOrderEntry, totalPoseCount)`. Pure function in `plugins/core-scenes/poseorder.go`. Pinned by INV-P4-7.
+
+| Mode | Display order | Eligibility |
+|------|---------------|-------------|
+| `strict` | `(last_pose_at NULLS FIRST, joined_at ASC)` — never-posed at head, then oldest-posed | First entry: `eligible=true`; rest: `eligible=false` |
+| `3pr` | Same as strict (stable display) | `eligible = last_pose_seq IS NULL OR (total_pose_count - last_pose_seq) >= 3` |
+| `5pr` | Same as strict | `eligible = last_pose_seq IS NULL OR (total_pose_count - last_pose_seq) >= 5` |
+| `free` | `joined_at ASC` | All `eligible=true` |
+
+The `poses_since_last` field on `PoseOrderEntry` surfaces `total_pose_count - COALESCE(last_pose_seq, 0)` for client UX ("Carol (2/3 since)" rendering). Meaningful for 3pr/5pr only; nil otherwise.
+
+**Strict mode out-of-turn semantics.** v2 §4.1: "Linear order based on join sequence. Posing moves you to the end. Out-of-turn poses adjust the order." The maintained-metadata approach captures this exactly: every pose updates the actor's `last_pose_at` to NOW(), pushing them to the tail of the `(last_pose_at NULLS FIRST, joined_at ASC)` ordering. No special-case logic for in-turn vs out-of-turn.
+
+### 6.3 Naming resolution
+
+Character name resolution adopts the `characterNameResolver` interface introduced by `holomush-5b2j` (presence-snapshot work). The default impl wraps `world.CharacterRepository.GetNamesByIDs`. Phase 4 depends on `holomush-5b2j.3` (the `GetNamesByIDs` bead) — see §17 for the dependency edge.
+
+## 7. GetPoseOrder RPC contract
+
+### 7.1 Proto — replaces existing skeletal definitions
+
+`api/proto/holomush/scene/v1/scene.proto:228-243` currently contains a skeletal definition (`GetPoseOrderRequest`, `PoseOrderEntry`, `GetPoseOrderResponse`) from earlier scaffolding. Phase 4 **replaces** these definitions outright — no backward-compatibility constraint (no releases, no external consumers, no in-tree callers of the skeletal shapes), so the right forward-thinking shape lands directly without a deprecation path.
+
+**Final proto (replaces lines 228-243 of `scene.proto`):**
+
+```proto
+message GetPoseOrderRequest {
+  string character_id = 1 [(buf.validate.field).string.min_len = 1];   // caller; INV-S9 gate
+  string scene_id     = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+message PoseOrderEntry {
+  string                    character_id     = 1;
+  string                    character_name   = 2;
+  bool                      eligible         = 3;
+  google.protobuf.Timestamp last_posed_at    = 4;
+  // Count of poses by other characters since this participant's last pose
+  // (or since scene start if never posed). Meaningful for 3pr/5pr; for
+  // strict it surfaces queue depth; for free it is always zero.
+  optional uint32           poses_since_last = 5;
+}
+
+message GetPoseOrderResponse {
+  string                 mode             = 1;   // strict | 3pr | 5pr | free
+  uint32                 total_pose_count = 2;   // drives header text in `scene order`
+  repeated PoseOrderEntry entries         = 3;
+}
+```
+
+**Shape rationale:**
+
+- **Bare `character_id` + `scene_id`** matches the scene.proto convention used by `KickFromSceneRequest:204`, `TransferOwnershipRequest:212`, `CastPublishVoteRequest:220`. No `RequestMeta`/`ResponseMeta` wrapper — those are CoreService conventions (per 5b2j's core.proto), not appropriate for plugin-owned RPCs called over go-plugin transport.
+- **`eligible`** (not `is_eligible`) for the boolean — the `is_*` prefix is a Java-bean idiom, redundant with the field's type (booleans are already predicates). The replacement is cleaner; no backward-compat means we don't need to live with the legacy prefix.
+- **Field numbering** is rearranged for semantic grouping: identity (1, 2), eligibility (3), timing (4), context (5) on entries; header (1), aggregate (2), payload (3) on response.
+
+**SceneService RPC declaration** — verify the existing `service SceneService { ... }` block contains `rpc GetPoseOrder(GetPoseOrderRequest) returns (GetPoseOrderResponse);`. The implementation plan task includes verifying / adding the line.
+
+Per-field validation via `protovalidate` annotations on `scene_id` / `character_id` ensures unmarshal-time rejection of invalid requests.
+
+### 7.2 Error semantics
+
+| Code | Trigger |
+|------|---------|
+| `INVALID_ARGUMENT` | `scene_id` or `character_id` empty (protovalidate) |
+| `NOT_FOUND` | Scene does not exist |
+| `PERMISSION_DENIED` | Caller is not a participant (INV-S9 / INV-P4-4) |
+| `FAILED_PRECONDITION` | Scene is `archived` (poses cannot occur, order is meaningless) |
+| `INTERNAL` | Store error |
+
+### 7.3 INV-S9 plugin-code gate + `sceneStorer` interface extensions
+
+The Phase 4 `GetPoseOrder` handler requires two new methods on the `sceneStorer` interface (`plugins/core-scenes/service.go:35-50`), in addition to the existing methods that Phase 1-3 introduced. These extensions are declared explicitly here so a plan author treats them as load-bearing interface changes, not implementer-discretion details.
+
+**`sceneStorer` interface extensions for Phase 4:**
+
+```go
+type sceneStorer interface {
+    // ... existing Phase 1-3 methods unchanged ...
+
+    // IsParticipant returns true if the character is a current
+    // participant of the scene with role "owner" or "member" (NOT
+    // "invited"). Used by the INV-S9 plugin-code gate at GetPoseOrder.
+    // Returns (false, nil) if the character is not a participant — no
+    // distinction from "not found"; the gate's contract is binary.
+    // Underlying SQL: SELECT 1 FROM scene_participants WHERE scene_id=$1
+    // AND character_id=$2 AND role IN ('owner','member').
+    IsParticipant(ctx context.Context, sceneID, characterID string) (bool, error)
+
+    // ListParticipantsWithPoseMeta returns all participants of the
+    // scene with role "owner" or "member" along with their Phase 4
+    // maintained pose metadata (last_pose_at, last_pose_seq) and the
+    // scene's total_pose_count. Single-query SELECT per §6.1.
+    ListParticipantsWithPoseMeta(
+        ctx context.Context,
+        sceneID string,
+    ) (ParticipantsWithPoseMeta, error)
+}
+
+// ParticipantsWithPoseMeta groups the single-query result so the
+// handler doesn't have to re-fetch the scene row for total_pose_count.
+type ParticipantsWithPoseMeta struct {
+    // From `scenes`. Driver header for the response.
+    TotalPoseCount uint32
+
+    // From `scene_participants` JOIN with maintained metadata columns.
+    Participants []ParticipantWithPoseMeta
+}
+
+type ParticipantWithPoseMeta struct {
+    CharacterID  string
+    JoinedAt     time.Time
+    LastPoseAt   *time.Time   // nil if never posed
+    LastPoseSeq  *int32       // nil if never posed
+}
+```
+
+**Handler shape:**
+
+```go
+func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPoseOrderRequest) (*scenev1.GetPoseOrderResponse, error) {
+    // INV-S9: direct participant check in plugin store. No ABAC engine consulted.
+    ok, err := s.store.IsParticipant(ctx, req.SceneId, req.CharacterId)
+    if err != nil {
+        return nil, status.Errorf(codes.Internal, "failed to check participant: %v", err)
+    }
+    if !ok {
+        return nil, status.Errorf(codes.PermissionDenied, "not a participant")
+    }
+
+    sceneRow, err := s.store.Get(ctx, req.SceneId)
+    if err != nil { /* map SCENE_NOT_FOUND → NOT_FOUND, else INTERNAL */ }
+    if sceneRow.State == string(SceneStateArchived) {
+        return nil, status.Errorf(codes.FailedPrecondition, "scene is archived; pose order not available")
+    }
+
+    pm, err := s.store.ListParticipantsWithPoseMeta(ctx, req.SceneId)
+    if err != nil { /* INTERNAL */ }
+
+    participantIDs := make([]string, 0, len(pm.Participants))
+    for _, p := range pm.Participants { participantIDs = append(participantIDs, p.CharacterID) }
+    names, err := s.nameResolver.GetNamesByIDs(ctx, participantIDs)
+    if err != nil { /* INTERNAL */ }
+
+    entries := poseorder.Compute(sceneRow.PoseOrder, pm.TotalPoseCount, pm.Participants, names)
+    return &scenev1.GetPoseOrderResponse{
+        Mode:           sceneRow.PoseOrder,
+        TotalPoseCount: pm.TotalPoseCount,
+        Entries:        entries,
+    }, nil
+}
+```
+
+The `engine.Evaluate` / `engine.CanPerformAction` ABAC entry points MUST NOT appear in this handler body. Pinned by INV-P4-4 meta-test.
+
+`AttributeResolverService.ResolveResource` MUST NOT expose `last_pose_at`, `last_pose_seq`, or `total_pose_count` as scene attributes (INV-P4-5). The ABAC engine sees the existing Phase 3 scene attribute set (`id`, `owner`, `state`, `visibility`, `location_id`, `tags`, `warnings`, `participants`, `invitees`) — no pose-order leakage path.
+
+**Why `IsParticipant` distinct from existing `GetParticipant`.** The Phase 3 store has `GetParticipant(ctx, sceneID, characterID) (*ParticipantRow, error)` returning `SCENE_PARTICIPANT_NOT_FOUND` on miss. Using it for the INV-S9 gate would conflate "not found" with the gate decision — the handler would need to inspect the oops code, which adds parsing surface and obscures the gate's intent. `IsParticipant` is a binary predicate that names what the gate is checking. The "owner OR member" role filter also matters: `invited` rows MUST NOT pass the gate even though they exist in `scene_participants` — `IsParticipant`'s contract pins this in one place.
+
+## 8. `scene order` command
+
+`scene order` is dispatched by `commands.go::dispatchCommand`. The handler:
+
+1. Resolves the target scene (single-membership inference; explicit `scene_id` argument).
+2. Calls `s.service.GetPoseOrder` in-process (no gRPC round-trip; INV-S9 gate still fires).
+3. Renders the response as plain text to command output.
+
+**Output format (telnet/terminal):**
+
+```text
+Scene "A Decades-Crossed Meeting" — pose order: 3pr (8 total poses)
+
+  Eligible to pose:
+    Alice    (last posed 12m ago)
+    Bob      (last posed 18m ago)
+
+  Cooldown:
+    Carol    (1/3 since last pose)
+    Dave     (2/3 since last pose)
+```
+
+For `strict` mode, output highlights the queue head as "Next:":
+
+```text
+Scene "..." — pose order: strict (12 total poses)
+
+  Next: Alice (joined 1h ago, last posed 5m ago)
+
+  Then:
+    Bob      (last posed 8m ago)
+    Carol    (last posed 12m ago)
+    Dave     (last posed 2h ago)
+```
+
+For `free` mode, output lists participants without eligibility annotation:
+
+```text
+Scene "..." — pose order: free (no enforcement, 4 total poses)
+
+  Participants:
+    Alice    (last posed 5m ago)
+    Bob      (last posed 8m ago)
+    Carol    (never posed)
+    Dave     (joined 2h ago, never posed)
+```
+
+Renderer lives in `plugins/core-scenes/commands.go` (or a small `commands_order.go` adjunct). Output is plain text — no markdown chrome — matching existing core-scenes command output style.
+
+## 9. Schema migration 000006: pose-order metadata
+
+### 9.1 Up migration
+
+```sql
+-- plugins/core-scenes/migrations/000006_pose_order_metadata.up.sql
+
+-- Per-scene monotonic pose counter.
+ALTER TABLE scenes
+  ADD COLUMN total_pose_count INTEGER NOT NULL DEFAULT 0;
+
+-- Per-participant pose metadata. NULL = participant has never posed in this scene.
+ALTER TABLE scene_participants
+  ADD COLUMN last_pose_at  TIMESTAMPTZ NULL,
+  ADD COLUMN last_pose_seq INTEGER     NULL;
+
+-- Per-scene idle-nudge threshold (wire shape; trigger deferred per §13).
+-- NULL = idle nudges off for this scene (default).
+ALTER TABLE scenes
+  ADD COLUMN idle_nudge_threshold INTERVAL NULL;
+```
+
+### 9.2 Down migration
+
+```sql
+-- plugins/core-scenes/migrations/000006_pose_order_metadata.down.sql
+
+ALTER TABLE scenes
+  DROP COLUMN IF EXISTS idle_nudge_threshold;
+
+ALTER TABLE scene_participants
+  DROP COLUMN IF EXISTS last_pose_seq,
+  DROP COLUMN IF EXISTS last_pose_at;
+
+ALTER TABLE scenes
+  DROP COLUMN IF EXISTS total_pose_count;
+```
+
+### 9.3 Idempotency
+
+Per project migration guidelines (`site/docs/contributing/database-migrations.md`), the migration MUST be idempotent. `ADD COLUMN` is not natively idempotent in standard PostgreSQL syntax; the migration uses `IF NOT EXISTS` clauses where supported, or the runner's existing tracking (`plugin_migrations` table) ensures the migration is applied exactly once. The implementation plan task SHALL verify the runner's contract before finalising syntax.
+
+### 9.4 Update path — audit handler transaction
+
+The audit-event handler in `plugins/core-scenes/audit.go` is extended to update pose metadata when `type = 'scene_pose'` is received. The current `sceneAuditLogStore` interface at `plugins/core-scenes/audit.go:50-75` exposes only `Insert` and `queryLog` — no transaction primitive. Phase 4 extends this interface with a single new method that performs the insert + pose-metadata updates atomically; this preserves the boundary that `SceneAuditServer` holds an interface, not a pool, while making INV-P4-10's transactional guarantee testable and substitutable.
+
+**Interface extension** (`plugins/core-scenes/audit.go`):
+
+```go
+type sceneAuditLogStore interface {
+    // ... existing Insert(...) and queryLog(...) ...
+
+    // InsertScenePose performs the scene_log INSERT for a scene_pose event
+    // AND the pose-metadata UPDATE on scenes + scene_participants in one
+    // transaction. Either both rows mutate or neither does (INV-P4-10).
+    //
+    // sceneID and posedCharID are parsed from the audit request's subject
+    // and actor fields by the caller. timestamp is the canonical event
+    // timestamp from the audit request (NOT the wall clock at handler
+    // entry — preserves audit-log ordering under retry).
+    InsertScenePose(
+        ctx context.Context,
+        id []byte,
+        subject, eventType string,
+        timestamp *timestamppb.Timestamp,
+        actorKind string,
+        actorID []byte,
+        payload []byte,
+        schemaVer int,
+        codec string,
+        dekRef *int64,
+        dekVersion *int32,
+        sceneID string,
+        posedCharID string,
+    ) error
+}
+```
+
+**Concrete implementation** on `*SceneAuditStore` (already holds `pool *pgxpool.Pool` privately):
+
+```go
+func (s *SceneAuditStore) InsertScenePose(
+    ctx context.Context,
+    /* ... same args as Insert plus sceneID, posedCharID ... */
+) error {
+    return pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+        // 1. The scene_log INSERT (same ON CONFLICT (id) DO NOTHING shape as
+        //    existing Insert path; reused via a private tx-bound helper —
+        //    see signature below).
+        if err := s.insertSceneLogTx(ctx, tx, id, subject, eventType, timestamp,
+                actorKind, actorID, payload, schemaVer, codec, dekRef, dekVersion); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_INSERT_FAILED").Wrap(err)
+        }
+
+        // 2. Bump the scene's total_pose_count and capture the new value.
+        var newSeq int32
+        if err := tx.QueryRow(ctx,
+            `UPDATE scenes SET total_pose_count = total_pose_count + 1
+             WHERE id = $1 RETURNING total_pose_count`,
+            sceneID,
+        ).Scan(&newSeq); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_META_UPDATE_FAILED").Wrap(err)
+        }
+
+        // 3. Stamp the actor's per-participant pose metadata.
+        if _, err := tx.Exec(ctx,
+            `UPDATE scene_participants
+               SET last_pose_at = $1, last_pose_seq = $2
+             WHERE scene_id = $3 AND character_id = $4`,
+            timestamp.AsTime(), newSeq, sceneID, posedCharID,
+        ); err != nil {
+            return oops.Code("SCENE_AUDIT_POSE_META_UPDATE_FAILED").Wrap(err)
+        }
+        return nil
+    })
+}
+```
+
+**Private tx-bound helper signature** (on `*SceneAuditStore`, package-private — exact name an implementer choice; signature pinned here for clarity):
+
+```go
+// insertSceneLogTx executes the same scene_log INSERT as the public Insert
+// method but on a caller-provided pgx.Tx. The INSERT keeps the existing
+// ON CONFLICT (id) DO NOTHING semantics so redelivery is idempotent.
+// Internal helper; not exposed via the sceneAuditLogStore interface.
+func (s *SceneAuditStore) insertSceneLogTx(
+    ctx context.Context,
+    tx  pgx.Tx,
+    id []byte,
+    subject, eventType string,
+    timestamp *timestamppb.Timestamp,
+    actorKind string,
+    actorID []byte,
+    payload []byte,
+    schemaVer int,
+    codec string,
+    dekRef *int64,
+    dekVersion *int32,
+) error
+```
+
+The existing public `Insert(ctx, ...)` is rewritten in Phase 4 as a thin wrapper that opens a `pgx.Tx`, calls `insertSceneLogTx`, and commits. This DRY-refactor consolidates the SQL in one place and makes the test surface uniform.
+
+**Handler dispatch** in `SceneAuditServer.AuditEvent`:
+
+```go
+func (s *SceneAuditServer) AuditEvent(ctx context.Context, req *pluginauditpb.AuditEventRequest) (*pluginauditpb.AuditEventResponse, error) {
+    // ... existing validation, subject ownership check, etc ...
+
+    row := req.GetRow()
+    if row.GetType() == "scene_pose" {
+        sceneID, err := parseSceneSubject(row.GetSubject())   // existing helper at audit.go:409
+        if err != nil { /* INVALID_ARGUMENT: malformed scene subject */ }
+
+        // ActorID arrives as 16-byte ULID nested under row.Actor per the
+        // Phase 7 plugin SDK contract (pluginauditpb.AuditRow.Actor.Id is
+        // bytes). Plugin stores character IDs as ULID strings throughout
+        // (scene_participants.character_id is TEXT). Convert via
+        // ulid.ULID + .String() — identical accessor path used by the
+        // existing QueryHistory implementation at
+        // plugins/core-scenes/audit.go:209-213.
+        var actorULID ulid.ULID
+        copy(actorULID[:], row.GetActor().GetId())
+        posedCharID := actorULID.String()
+
+        if err := s.store.InsertScenePose(ctx,
+            /* same arg list as Insert ... */,
+            sceneID, posedCharID,
+        ); err != nil {
+            return nil, /* wrap to gRPC status */
+        }
+    } else {
+        if err := s.store.Insert(ctx, /* args ... */); err != nil {
+            return nil, /* wrap */
+        }
+    }
+
+    return &pluginauditpb.AuditEventResponse{}, nil
+}
+```
+
+**Why interface-level extension (not Pool-exposure):**
+
+Three alternatives were considered:
+
+| Alternative | Rejected because |
+|-------------|------------------|
+| Expose `Pool()` on `sceneAuditLogStore` interface | Leaks pool internals into the audit-server interface; test substitution would force fakes to construct pgxpool — much heavier test surface |
+| Add a generic `WithTx(ctx, fn func(tx pgx.Tx) error) error` method | Surface area grows beyond Phase 4 needs; future callers might use it for non-scene-pose operations and bypass the Phase 4 invariant. INV-P4-10 names a specific operation; the interface method names it too. |
+| Move transactional logic into `SceneAuditServer` itself (holds pool directly) | Breaks the existing interface-based decoupling — `SceneAuditServer` is constructed with a `sceneAuditLogStore` interface field today (`audit.go:96`); restructuring at the field-type level would propagate test churn |
+
+Extending the interface with the specific `InsertScenePose` method names the operation, keeps `SceneAuditServer` constructor unchanged, and lets test fakes substitute deterministic behavior for INV-P4-10 fault injection.
+
+**Edge case — actor not currently a participant.** If `req.Actor` is not a row in `scene_participants` for `sceneID` (e.g., the actor left between emit and audit consumption — possible under JetStream redelivery semantics), step 3's `UPDATE` affects 0 rows. The transaction COMMITS successfully because none of the three statements errored. The `scene_log` row records the pose; pose-order metadata simply reflects "they posed but left." Recovery SQL (§9.5) handles this correctly on a future rebuild.
+
+**Fault-injection test for INV-P4-10.** A test fake substituting `sceneAuditLogStore` makes `InsertScenePose` return an error after the (simulated) scene_log INSERT but before the metadata UPDATE — asserts the entire operation rolls back (no `scene_log` row, no metadata change). Symmetrically, the metadata-UPDATE failure path is exercised.
+
+### 9.5 Recovery procedure (operator runbook)
+
+If metadata drifts from `scene_log` (e.g., manual intervention, migration replay, future bug), the documented recovery rebuilds metadata from canonical event history:
+
+```sql
+-- Recompute scenes.total_pose_count from scene_log.
+UPDATE scenes s SET total_pose_count = (
+    SELECT COUNT(*) FROM scene_log sl
+    WHERE sl.subject = 'events.' || $game || '.scene.' || s.id || '.ic'
+      AND sl.type = 'scene_pose'
+);
+
+-- Recompute per-participant last_pose_at + last_pose_seq.
+WITH per_actor_last AS (
+    SELECT
+        subject,
+        actor,
+        timestamp AS last_pose_at,
+        ROW_NUMBER() OVER (PARTITION BY subject, actor ORDER BY timestamp DESC) AS rn_per_actor,
+        -- count of scene_pose rows on this subject up to and including this row
+        COUNT(*) FILTER (WHERE type = 'scene_pose') OVER (PARTITION BY subject ORDER BY timestamp) AS seq
+    FROM scene_log
+    WHERE type = 'scene_pose'
+)
+UPDATE scene_participants p
+SET last_pose_at  = pal.last_pose_at,
+    last_pose_seq = pal.seq
+FROM per_actor_last pal
+WHERE pal.rn_per_actor = 1
+  AND pal.actor   = p.character_id
+  AND pal.subject = 'events.' || $game || '.scene.' || p.scene_id || '.ic';
+```
+
+The recovery is documented for operator use; it is NOT auto-executed at startup. INV-P4-8 pins the property that the recovery produces identical metadata to the maintained path.
+
+## 10. Notice events: emission triggers
+
+### 10.1 `scene_join_ic`
+
+Emitted by `JoinScene` RPC (`plugins/core-scenes/service.go::JoinScene`) after `AddParticipant` returns `OpInserted` or `OpPromoted`. Skipped on `OpNoChange` per Phase 3 D5 retry-idempotency — preserves the audit-log cleanness Phase 3 committed to.
+
+```go
+result, err := s.store.AddParticipant(ctx, req.SceneId, req.CharacterId)
+if err != nil { /* map errors */ }
+if result == OpInserted || result == OpPromoted {
+    name, _ := s.nameResolver.GetNameByID(ctx, req.CharacterId)
+    s.eventSink.Emit(ctx, EmitIntent{
+        Subject:   sceneSubjectIC(s.gameID, req.SceneId),
+        Type:      "scene_join_ic",
+        Payload:   marshalJSON(map[string]string{
+            "actor_id": req.CharacterId,
+            "actor_name": name,
+            "scene_id": req.SceneId,
+            "from_role": fromRoleFor(result),
+        }),
+        Sensitive: false,  // sensitivity: never
+    })
+}
+```
+
+### 10.2 `scene_leave_ic`
+
+Emitted by `LeaveScene` and `KickFromScene` RPCs on successful remove. One event type, `reason` field discriminates voluntary (`"left"`) vs involuntary (`"kicked"`).
+
+### 10.3 `scene_pose_order_changed_ic`
+
+Emitted by `UpdateScene` handler when `update_mask` contains `pose_order_mode` AND the new value differs from current. The latter check prevents spurious emissions on no-op updates:
+
+```go
+if hasMaskPath(req.UpdateMask, "pose_order_mode") && req.GetPoseOrderMode() != currentRow.PoseOrder {
+    s.eventSink.Emit(ctx, EmitIntent{...
+        Type: "scene_pose_order_changed_ic",
+        Payload: marshalJSON(map[string]string{
+            "actor_id":   req.CharacterId,
+            "actor_name": actorName,
+            "scene_id":   req.SceneId,
+            "old_mode":   currentRow.PoseOrder,
+            "new_mode":   req.GetPoseOrderMode(),
+        }),
+        Sensitive: false,
+    })
+}
+```
+
+The Phase 3 `settings.updated` ops event (plugin-internal `scene_ops_events` table) continues to fire alongside; the two are complementary (ops journal for audit, IC stream for participant visibility).
+
+### 10.4 `scene_idle_nudge` — wire shape only
+
+Phase 4 declares the event type in `crypto.emits`, registers it in `EmitTypeRegistrar`, adds the `idle_nudge_threshold INTERVAL NULL` column to `scenes` (migration 000006), but does NOT implement the trigger. Background-trigger implementation is deferred to a follow-up bead (§13).
+
+Rationale: the trigger requires either a per-scene polling goroutine or a reactive on-pose hook. Both are non-trivial and orthogonal to the rest of Phase 4. The wire shape (event type + schema column + manifest declaration) is locked in here so the follow-up bead can land as a pure-logic change with no manifest, proto, or migration touches.
+
+## 11. ABAC: no new policies
+
+Phase 4 introduces ZERO new ABAC policies. All authorization gates are inherited:
+
+| Surface | Gate | Source |
+|---------|------|--------|
+| `scene pose / say / emit / ooc` execute | Layer-1 `execute` on `command:scene` | Phase 3 `execute-scene-commands` policy |
+| `scene pose / say / emit / ooc` content emit | Layer-2 capability pre-flight (`write` on `scene`, scope `local`) → DSL `write-scene-as-participant` | Phase 3 `write-scene-as-participant` policy |
+| `scene update --pose_order_mode` (emits `scene_pose_order_changed_ic`) | `update` on `scene`, owner-only | Phase 3 `update-own-scene` policy |
+| `scene order` (calls `GetPoseOrder`) | INV-S9 plugin-code participant gate | New plugin-code gate in Phase 4, ADR `holomush-c8a9` pattern |
+| `GetPoseOrder` RPC | Same INV-S9 gate | Same |
+| Subscriber-side receipt of `scene_*_ic` / `scene_*_ooc` events | Substrate I-17 hardcoded scene-membership gate + iwzt §3 temporal floor | Substrate + iwzt §3 |
+
+The `scene` command capability declaration in `plugin.yaml` (`action: write, resource: scene, scope: local`) carries forward unchanged.
+
+Phase 4 ABAC review surface is therefore *confirmation* (existing policies continue to gate correctly under new emit surfaces) rather than new policy authoring.
+
+## 12. Test strategy
+
+### 12.1 Coverage matrix (pins INV-P4-13)
+
+| Invariant | Test type | Location |
+|-----------|-----------|----------|
+| INV-P4-1 | Meta-test + per-emit unit | `internal/test/invariants/scene_subjects_test.go` (new); `plugins/core-scenes/service_test.go` (updated) |
+| INV-P4-2 | Manifest-parse unit + substrate integration | `plugins/core-scenes/main_test.go` (new); existing `internal/plugin/manager_test.go` |
+| INV-P4-3 | Manifest-parse unit | `plugins/core-scenes/main_test.go` (new) |
+| INV-P4-4 | Unit + meta-test | `plugins/core-scenes/service_test.go::TestGetPoseOrder_NonParticipant_PermissionDenied`; `internal/test/invariants/scene_no_abac_in_getposeorder_test.go` (new, rg-based) |
+| INV-P4-5 | Unit + meta-test | `plugins/core-scenes/resolver_test.go::TestResolveResource_ExcludesPoseOrderMetadata`; `internal/test/invariants/scene_resolver_no_poseorder_leak_test.go` (new, rg-based) |
+| INV-P4-6 | Ginkgo integration | `test/integration/scenes/non_participant_ic_isolation_test.go` (new) |
+| INV-P4-7 | Table-driven pure-function unit | `plugins/core-scenes/poseorder_test.go` (new) |
+| INV-P4-8 | Integration | `plugins/core-scenes/store_integration_test.go::TestPoseOrderMetadata_RebuildFromAuditLog` |
+| INV-P4-9 | Ginkgo integration | `test/integration/scenes/late_joiner_temporal_floor_test.go` (new) |
+| INV-P4-10 | Fault-injection unit | `plugins/core-scenes/audit_test.go::TestAuditEvent_PoseMetadataTransactional` |
+| INV-P4-11 | Integration | `plugins/core-scenes/commands_test.go::TestSceneEmitSubcommands_NonParticipant_PermissionDenied` |
+| INV-P4-12 | Integration | `plugins/core-scenes/service_test.go::TestUpdateScene_PoseOrderMode_NonOwner_PermissionDenied` |
+| INV-P4-13 (meta) | Meta-test parsing this spec | `internal/test/invariants/p4_coverage_test.go` (new) — same shape as iwzt T15 / 5b2j T15 |
+
+### 12.2 Boundary tests ("what must and must not be true")
+
+- **MUST tests**: each invariant has at least one positive-path test asserting the property holds.
+- **MUST NOT tests** (negative-path):
+  - INV-P4-1: no colon-style string literal in scene-subject positional context.
+  - INV-P4-4: no ABAC engine consultation in `GetPoseOrder` body.
+  - INV-P4-5: no pose-metadata column references in attribute-construction code.
+  - INV-P4-6: no scene IC event delivery to non-participant in same location.
+  - INV-P4-9: no pre-joined-at history leak to late joiners.
+- **Fault-injection**:
+  - INV-P4-2: manifest drift (declared-but-unregistered, registered-but-undeclared) MUST fail plugin load with `EVENT_TYPE_REGISTRY_MISMATCH`.
+  - INV-P4-10: simulated `UPDATE` failure inside the audit transaction MUST roll back the `INSERT`.
+- **Property tests**:
+  - INV-P4-8: rebuild idempotency over arbitrary pose history — generate N poses with arbitrary actor distribution and timing; assert maintained metadata equals SQL-recomputed metadata.
+
+### 12.3 Pre-existing test surfaces leveraged
+
+- Phase 3's `core_scenes_suite_test.go` Ginkgo suite — Phase 4 tests extend existing patterns.
+- `audit_test.go` — existing audit handler tests; Phase 4 adds the metadata-transaction cases.
+- `resolver_test.go` — existing resolver tests; Phase 4 adds the no-pose-leak case.
+
+## 13. Out of scope
+
+The following are explicitly NOT shipped in Phase 4, with their dispositions:
+
+| Item | Where it lives |
+|------|----------------|
+| Focus-routing for plain `pose` / `say` / `emit` / `ooc` (so they auto-target the focused scene) | Phase 5 (`holomush-5rh.14`) |
+| Content-read paths: `scene log` command + export renderers + scene-log archival | Phase 6 (`holomush-5rh.15`) + existing bead `holomush-cb4x` |
+| Cross-scene notifications stream (`notifications:<character_id>` migration + integration) | Phase 10 (`holomush-5rh.19`) |
+| Web client chat view (Phase 4 emit shape consumed unchanged) | Phase 9 (`holomush-5rh.18`) |
+| Scene templates | Phase 7 (`holomush-5rh.16`) |
+| Scene board / discovery | Phase 8 (`holomush-5rh.17`) |
+| Background-trigger implementation for `scene_idle_nudge` (wire shape ships in Phase 4) | **New follow-up bead** — filed at `plan-to-beads` materialization |
+| Non-scene colon-style subject migration (`location:*`, `character:*`, `notifications:*`) | `holomush-rops` (already filed P1 top-level) |
+| Idle-timeout reaper (scene auto-pause on inactivity, v2 §1.1 `IdleTimeout`) | Separate hardening bead if desired; v2 framed as configurable, off-by-default |
+| `scene_journal` table introduction / rename of `scene_log` to `scene_publication` | Phase 6 (`5rh.15`) brainstorm decides |
+| `OriginLocationID` and `PublishVote` participant fields (deferred from Phase 3) | Phase 6 brainstorm reinstate decision |
+
+## 14. Follow-up beads
+
+To be filed during `plan-to-beads` materialization (alongside the Phase 4 implementation child beads):
+
+1. **`scene_idle_nudge` background trigger implementation** (P2) — implements the per-scene polling goroutine (or reactive on-pose hook) that detects "next-up character has been idle beyond `idle_nudge_threshold`" and emits `scene_idle_nudge` to the OOC stream. Phase 4 ships the wire shape; this bead lands the trigger logic.
+
+Already-filed dependencies / interactions:
+
+- `holomush-rops` (P1, open) — broader colon-style sweep (filed during this brainstorm).
+- `holomush-ac50` (P2, open) — non-participant scene IC isolation E2E test. INV-P4-6 is exactly this bead's acceptance; Phase 4 closes it.
+- `holomush-cb4x` (P2, open) — Phase 6 scene-log content read path. NOT blocked by Phase 4; Phase 4's INV-S9 pattern for `GetPoseOrder` is the template `cb4x` will mirror for `GetSceneLog`.
+- `holomush-5b2j.3` (P1, in-progress) — `GetNamesByIDs` batch lookup on `world.CharacterRepository`. Phase 4 depends on this.
+- `holomush-iwzt` (P0, in-progress) — history-scope privacy. Phase 4 binds to iwzt §3 scene-stream entry. Phase 4 has a soft dependency on `iwzt.15` (Tier 2 filter-at-delivery) for INV-P4-9 — if iwzt.15 lands first, INV-P4-9 is testable end-to-end; if Phase 4 ships first, INV-P4-9 is marked PENDING-iwzt.15.
+
+## 15. Dependencies
+
+Phase 4 bead `holomush-5rh.13` `depends-on`:
+
+- `holomush-5b2j.3` — `GetNamesByIDs` batch lookup (name resolution for `GetPoseOrder` / `scene order`).
+- `holomush-iwzt.15` — Tier 2 filter-at-delivery (INV-P4-9 enforcement end-to-end). Soft dependency: Phase 4 builds and ships without it; INV-P4-9 test is gated separately.
+
+Already-satisfied dependencies (substrate-contract era):
+
+- `holomush-jg9b.3` — INV-S5 cap + plugin adoptions (closed). `core-scenes` adopts the binary-plugin `EmitTypeRegistrar` per the INV-S5 mechanism design.
+- `holomush-oy6e.10` — core-scenes plugin adoption (closed). Phase 4 builds on the focus-aware membership baseline.
+- `holomush-z69k` — server-owned replay/resume/focus semantics (closed).
+
+## 16. Areas needing deeper design (after Phase 4 lands)
+
+None blocking. The following are tracked as named follow-ups rather than design gaps:
+
+| Area | Trigger |
+|------|---------|
+| `scene_idle_nudge` background trigger | After Phase 4 closes (P2 bead filed at `plan-to-beads`) |
+| Focus-routing for plain pose/say/emit/ooc | Phase 5 brainstorm (`holomush-5rh.14`) |
+| Scene-log content read path + publication artifact rename | Phase 6 brainstorm (`holomush-5rh.15`) + `cb4x` |
+| `scene_journal` introduction (if needed beyond `scene_log` for retention separation) | Phase 6 brainstorm |
+| Per-scene admin-bypass for staff debugging of pose order | NOT planned — scene privacy is absolute per iwzt §3 / INV-S9. Staff have no Phase-4-side bypass. |
+
+## 17. References
+
+### Within the repository
+
+- [Substrate Contract Spec](2026-05-16-social-spaces-substrate-contract.md) — boundary invariants, INV-S1..S10.
+- [INV-S5 Mechanism Design](2026-05-17-inv-s5-mechanism-design.md) — binary-plugin `EmitTypeRegistrar`.
+- [Scenes & RP Design v2](2026-04-06-scenes-and-rp-design-v2.md) §3-4 — Event streams + pose order (extended here).
+- [Scenes Phase 3 Membership Design](2026-04-07-scenes-phase-3-membership-design.md) — content-vs-ops event split; participant model.
+- [History Scope Privacy](2026-05-17-history-scope-privacy-design.md) §3 — scene-stream entry + I-PRIV-1..8.
+- [Phase 7 Plugin SDK + Crypto Integration](2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md) — plugin audit table shape; AuditEvent RPC contract.
+- [Presence Snapshot](2026-05-19-presence-snapshot-design.md) — `GetNamesByIDs` pattern; future scene-context presence resolver wire shape.
+- [`.claude/rules/event-conventions.md`](../../.claude/rules/event-conventions.md) — subject naming convention.
+- [`.claude/rules/plugin-runtime-symmetry.md`](../../.claude/rules/plugin-runtime-symmetry.md) — Go + Lua parity (Phase 4 is binary-only, but parity invariant guides any future Lua-side scene work).
+
+### ADRs
+
+- [`holomush-c8a9`](../../adr/holomush-c8a9-scene-privacy-plugin-code-enforcement.md) — Scene privacy plugin-code enforcement (INV-S9 / INV-P4-4 pattern).
+- [`holomush-3vsb`](../../adr/holomush-3vsb-manifest-emit-type-startup-validation.md) — INV-S5 startup validation.
+- [`holomush-vie9`](../../adr/holomush-vie9-init-rpc-emit-type-communication.md) — Init-RPC for emit-type communication.
+- [`holomush-z1e7`](../../adr/holomush-z1e7-strict-plugin-boundary.md) — INV-S1 strict plugin boundary.
+- [`holomush-p7w0`](../../adr/holomush-p7w0-split-plugin-sdk-eventkit-groupkit.md) — `eventkit` / `groupkit` SDK split (Phase 4 does not extract; future).
+- [`holomush-lrt3`](../../adr/holomush-lrt3-n2-consumer-validation-sdk-extraction.md) — N=2 SDK validation deferral.
+- [`holomush-jhl5`](../../adr/holomush-jhl5-plugin-history-scope-opt-in.md) — Plugin manifests opt-in to `history_scope`.
+- [`holomush-wxty`](../../adr/holomush-wxty-hard-gate-location-stream-history.md) — Hard-gate location-stream history (sibling pattern to scene I-17 gate).
+- [`holomush-ghpx`](../../adr/holomush-ghpx-filter-at-delivery-and-nats-source-of-truth.md) — Filter-at-delivery + NATS-source-of-truth.
+
+### Working precedents cited
+
+- [`plugins/core-communication/plugin.yaml:273-298`](../../../plugins/core-communication/plugin.yaml) — 8-type `crypto.emits` matrix; location-bounded vs participant-bounded sensitivity precedent.
+- [`plugins/core-scenes/plugin.yaml`](../../../plugins/core-scenes/plugin.yaml) — current scene manifest (empty `crypto.emits`; Phase 4 populates).
+- [`plugins/core-scenes/service.go`](../../../plugins/core-scenes/service.go) — existing service handlers (Phase 1-3); Phase 4 adds `GetPoseOrder` + scene_*_ic emits.
+- [`plugins/core-scenes/audit.go`](../../../plugins/core-scenes/audit.go) — existing audit handler; Phase 4 extends with pose-metadata transactional update.
+- [`internal/plugin/event_emitter.go::Emit`](../../../internal/plugin/event_emitter.go) — substrate emit gate.
+- [`internal/plugin/sensitivity_fence.go:23-48`](../../../internal/plugin/sensitivity_fence.go) — emit-time sensitivity truth table.
+- [`internal/grpc/query_stream_history.go:157-178`](../../../internal/grpc/query_stream_history.go) — existing I-17 hardcoded scene-membership gate (migrates to dot-style in Phase 4).
+- [`internal/grpc/stream_access.go`](../../../internal/grpc/stream_access.go) — `isPrivateStream` / `extractSceneID` helpers.
+- [`internal/grpc/scope_floor.go`](../../../internal/grpc/scope_floor.go) — `streamScopeFloor` (iwzt §6.1 implementation).
+
+## Document history
+
+| Date       | Action                       | Notes                                                                 |
+|------------|------------------------------|-----------------------------------------------------------------------|
+| 2026-05-19 | Draft authored               | Brainstorming session under bead `holomush-5rh.13`. Grounded against substrate contract + INV-S5 mechanism + iwzt + Phase 7 plugin SDK + ADRs c8a9/wxty/ghpx/jhl5/p7w0/lrt3/z1e7/3vsb/vie9. Filed `holomush-rops` (P1) for the broader colon-style sweep. |
+| 2026-05-19 | design-reviewer READY round 3 | 3 rounds total. Round 1 NOT READY (2 critical + 3 important + 3 minor — all patched). Round 2 NOT READY (3 important + 4 minor — all patched). Round 3 READY (3 minor — all patched inline). |
+| 2026-05-19 | ADRs captured | 5 ADRs extracted via capture-adrs flow: holomush-r4th (denormalize pose-order metadata), holomush-s9nu (atomic subject migration), holomush-sb3n (sensitivity:always for content), holomush-nt2d (generalized participant gate, supersedes c8a9), holomush-1ang (audit interface extension). |
+
+<!-- adr-capture: sha256=2c0eec2c61bb5c85; ts=2026-05-19T12:00:00Z; adrs=holomush-r4th,holomush-s9nu,holomush-sb3n,holomush-nt2d,holomush-1ang -->


### PR DESCRIPTION
## Summary

Docs-only PR shipping the design surface for **Scenes Phase 4** (`holomush-5rh.13`). Implementation lands separately via the `5rh.13.1..5rh.13.31` bead chain after merge (subagent-driven execution).

This PR contains:

- **Spec:** `docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md` (design-reviewer **READY** round 3 — 3 rounds total: 2 critical + 3 important + 3 minor → 3 important + 4 minor → 3 minor, all patched)
- **Plan:** `docs/superpowers/plans/2026-05-19-scenes-phase-4-streams-and-pose-order.md` (plan-reviewer **READY** round 1 — 7 minor, all non-blocking, all self-acknowledged with mitigations)
- **5 captured ADRs** (one bead-decision-id per file):
  - `holomush-r4th` — Denormalize pose-order metadata against `scene_log` source of truth
  - `holomush-s9nu` — Migrate scene subjects to NATS dot-style atomically with plugin emit code
  - `holomush-sb3n` — Classify all scene content events as `sensitivity:always`, including OOC
  - `holomush-nt2d` — Generalize plugin-code participant gate from scene-log to all participant-only scene RPCs (**supersedes `holomush-c8a9`**)
  - `holomush-1ang` — Extend `sceneAuditLogStore` with operation-specific `InsertScenePose` for transactional atomicity
- **README index updated** + `c8a9` status flipped to `Superseded by holomush-nt2d`
- **Idempotency markers** stamped on spec + plan (sha256 format)

## Phase 4 scope (implementation lands in a separate PR)

- 8 plugin-owned scene event types with crypto.emits matrix + EmitTypeRegistrar adoption (binds INV-S5)
- Pose-order computation via maintained metadata (O(N participants) reads); GetPoseOrder RPC with INV-S9 plugin-code participant gate
- scene subcommands: pose / say / emit / ooc / order
- Notice events: auto-emit on JoinScene / LeaveScene / KickFromScene / UpdateScene
- **Atomic** scene-subject migration: plugin emits + substrate-side scene-aware code (stream_access.go, scope_floor.go, query_stream_history.go) in same PR — closes a live silent regression in scope_floor.go:21-28
- 13 numbered INV-P4-* invariants with cited tests + meta-test for coverage

## Related beads

- Epic: holomush-5rh.13 (promoted to type=epic during plan-to-beads)
- 31 child task beads: 5rh.13.1 through 5rh.13.31
- Follow-up bead: holomush-fux3 (P2) — scene_idle_nudge background trigger implementation (wire shape ships in Phase 4; trigger deferred)
- Soft dep: 5rh.13.26 (INV-P4-9 late-joiner test) → holomush-iwzt.15 (Tier 2 filter-at-delivery, currently blocked)
- Closes via Task 25's integration test: holomush-ac50 (non-participant scene IC isolation audit-finding)
- Related: holomush-rops (P1 broader non-scene colon-style sweep, filed during brainstorm)

## Test plan

- [x] task pr-prep green full lane (lint + format + schema + license + unit + integration + 62 E2E passing)
- [x] design-reviewer READY round 3
- [x] plan-reviewer READY round 1
- [x] capture-adrs: 5 ADRs extracted, idempotency markers stamped
- [x] plan-to-beads: epic promoted, 31 children + 1 follow-up created
- [ ] CodeRabbit pass on docs (post-merge if needed via /autofix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Scenes Phase 4 specification covering event streams and pose-order computation with multiple modes.
  * Established architecture decisions for scene content sensitivity classification, atomic subject migration to dot-style naming, pose-order metadata denormalization, and participant gating pattern.
  * Updated ADR index with five new accepted architectural decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->