### PR TITLE
feat(web): presence store with idempotent set/delete semantics (holomush-5b2j.5)

### DIFF
--- a/web/src/lib/presence/store.test.ts
+++ b/web/src/lib/presence/store.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { describe, it, expect } from 'vitest';
+import { createPresenceStore } from './store';
+
+describe('presence store', () => {
+  it('seeds from snapshot', () => {
+    const s = createPresenceStore();
+    s.seed([
+      { characterId: 'c1', name: 'alice', state: 'ACTIVE' },
+      { characterId: 'c2', name: 'bob',   state: 'ACTIVE' },
+    ]);
+    expect(s.size()).toBe(2);
+    expect(s.has('c1')).toBe(true);
+    expect(s.has('c2')).toBe(true);
+  });
+
+  it('idempotent add', () => {
+    const s = createPresenceStore();
+    s.seed([{ characterId: 'c1', name: 'alice', state: 'ACTIVE' }]);
+    s.upsert({ characterId: 'c1', name: 'alice', state: 'ACTIVE' });
+    s.upsert({ characterId: 'c1', name: 'alice', state: 'ACTIVE' });
+    expect(s.size()).toBe(1);
+  });
+
+  it('idempotent remove of absent id is a no-op', () => {
+    const s = createPresenceStore();
+    s.seed([{ characterId: 'c1', name: 'alice', state: 'ACTIVE' }]);
+    s.remove('c999');
+    expect(s.size()).toBe(1);
+    expect(s.has('c1')).toBe(true);
+  });
+
+  it('clear() resets the store', () => {
+    const s = createPresenceStore();
+    s.seed([{ characterId: 'c1', name: 'alice', state: 'ACTIVE' }]);
+    s.clear();
+    expect(s.size()).toBe(0);
+  });
+
+  it('entries() returns array of current state', () => {
+    const s = createPresenceStore();
+    s.upsert({ characterId: 'c1', name: 'alice', state: 'ACTIVE' });
+    s.upsert({ characterId: 'c2', name: 'bob',   state: 'ACTIVE' });
+    const list = s.entries();
+    expect(list).toHaveLength(2);
+    expect(list.map(e => e.characterId).sort()).toEqual(['c1', 'c2']);
+  });
+});

--- a/web/src/lib/presence/store.ts
+++ b/web/src/lib/presence/store.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { SvelteMap } from 'svelte/reactivity';
+
+export type PresenceState = 'UNSPECIFIED' | 'ACTIVE' | 'DETACHED' | 'INACTIVE';
+
+export interface PresenceEntry {
+  characterId: string;
+  name: string;
+  state: PresenceState;
+}
+
+export interface PresenceStore {
+  seed(entries: PresenceEntry[]): void;
+  upsert(entry: PresenceEntry): void;
+  remove(characterId: string): void;
+  clear(): void;
+  has(characterId: string): boolean;
+  size(): number;
+  entries(): PresenceEntry[];
+  readonly map: SvelteMap<string, PresenceEntry>;
+}
+
+export function createPresenceStore(): PresenceStore {
+  const m = new SvelteMap<string, PresenceEntry>();
+  return {
+    seed(entries) {
+      m.clear();
+      for (const e of entries) m.set(e.characterId, e);
+    },
+    upsert(entry) {
+      m.set(entry.characterId, entry);
+    },
+    remove(characterId) {
+      m.delete(characterId);
+    },
+    clear() {
+      m.clear();
+    },
+    has(characterId) {
+      return m.has(characterId);
+    },
+    size() {
+      return m.size;
+    },
+    entries() {
+      return Array.from(m.values());
+    },
+    map: m,
+  };
+}


### PR DESCRIPTION
## Summary

T10 of the holomush-5b2j epic — extracts a SvelteMap-backed presence store module that T11 (`5b2j.13`) will use to manage the terminal's presence list.

`createPresenceStore()` returns a `PresenceStore` interface backed by `SvelteMap<string, PresenceEntry>` (keyed by `characterId`). All operations are idempotent: `upsert` of an existing key is a no-op for size; `remove` of an absent key is a no-op. This is the load-bearing semantic that lets snapshot + Subscribe-delta merging "just work" — any race between the two collapses to set-membership semantics (per spec §D-8).

Public surface:

```ts
export type PresenceState = 'UNSPECIFIED' | 'ACTIVE' | 'DETACHED' | 'INACTIVE';
export interface PresenceEntry { characterId; name; state }
export interface PresenceStore {
  seed(entries); upsert(entry); remove(characterId); clear();
  has(characterId); size(); entries();
  readonly map: SvelteMap<string, PresenceEntry>;
}
export function createPresenceStore(): PresenceStore;
```

## Files

- `web/src/lib/presence/store.ts` — module
- `web/src/lib/presence/store.test.ts` — 5 vitest cases (seed; idempotent upsert; idempotent remove; clear; entries)

## Bead

`holomush-5b2j.5` (epic: `holomush-5b2j` [E-5B2J]). Independent — doesn't block on any other open bead. Unblocks T11 (`5b2j.13`).

## Verification

- [x] `cd web && pnpm run test:unit` — 53 tests pass (48 existing + 5 new)
- [x] `cd web && pnpm check` — 0 errors, 0 warnings
- [x] `task pr-prep` full lane green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added presence tracking system to manage and monitor character/user status within the application, including the ability to add, update, and remove presence entries.

* **Tests**
  * Comprehensive test coverage for presence store functionality, validating core operations like entry management, state clearing, and data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->