### PR TITLE
refactor(web): migrate PresenceList to PresenceStore + drop transitional dual-write (holomush-5b2j.14)

### DIFF
--- a/web/src/lib/components/sidebar/PresenceList.svelte
+++ b/web/src/lib/components/sidebar/PresenceList.svelte
@@ -3,7 +3,10 @@
   Copyright 2026 HoloMUSH Contributors
 -->
 <script lang="ts">
-  import { presence } from '$lib/stores/sidebarStore';
+  import { presenceStore } from '$lib/presence/store';
+
+  // idle/lastMode fields are not carried by PresenceEntry — future enhancement
+  // tracked in holomush-uhiz.
 
   function initials(name: string): string {
     const parts = name.split(/\s+/).filter(Boolean);
@@ -12,17 +15,17 @@
   }
 </script>
 
-{#if $presence.length > 0}
+{#if presenceStore.map.size > 0}
   <section class="card presence-list" data-testid="presence-card">
     <header class="card-head">
       <h3>Present</h3>
-      <span class="count">{$presence.length}</span>
+      <span class="count">{presenceStore.map.size}</span>
     </header>
     <ul class="rows">
-      {#each $presence as char}
-        <li class="pres-row" class:is-idle={char.isIdle ?? char.idle}>
-          <span class="avatar {char.lastMode ?? 'sys'}" aria-hidden="true">{initials(char.name)}</span>
-          <span class="name">{char.name}</span>
+      {#each [...presenceStore.map.values()] as char (char.characterId)}
+        <li class="pres-row">
+          <span class="avatar sys" aria-hidden="true">{initials(char.name || char.characterId)}</span>
+          <span class="name">{char.name || char.characterId}</span>
           <span class="status-dot" aria-hidden="true"></span>
         </li>
       {/each}

--- a/web/src/lib/presence/store.ts
+++ b/web/src/lib/presence/store.ts
@@ -50,3 +50,10 @@ export function createPresenceStore(): PresenceStore {
     map: m,
   };
 }
+
+/**
+ * Module-level singleton presence store consumed by the terminal sidebar.
+ * Tests should use `createPresenceStore()` for isolation; production code
+ * imports this singleton.
+ */
+export const presenceStore: PresenceStore = createPresenceStore();

--- a/web/src/lib/stores/eventRouter.ts
+++ b/web/src/lib/stores/eventRouter.ts
@@ -4,7 +4,7 @@
 import { exits } from './sidebarStore';
 import type { RoomExit } from './sidebarStore';
 import { appendLine, replayActive } from './terminalStore';
-import { applyLocationState, addPresence, removePresence } from './sidebarStore';
+import { applyLocationState } from './sidebarStore';
 import type { GameEvent } from '$lib/connect/holomush/web/v1/web_pb';
 
 // DisplayTarget values from the GameEvent proto (renamed from EventChannel).
@@ -35,15 +35,13 @@ export function routeEvent(event: GameEvent, replayed: boolean) {
 function routeToSidebar(event: GameEvent, replayed: boolean) {
   const data = metadataToPlain(event.metadata);
   const category = (event as Record<string, unknown>).category as string | undefined;
-  const actor = (event as Record<string, unknown>).actor as string | undefined;
 
   switch (category) {
     case 'state':
       routeStateEvent(event.type, data, replayed);
       break;
-    case 'movement':
-      routeMovementEvent(event.type, actor, replayed);
-      break;
+    // 'movement': no-op here — mirrorMovementPresence in +page.svelte is the
+    // sole writer for live movement events to the PresenceStore (T12, holomush-5b2j.14).
   }
 }
 
@@ -61,18 +59,6 @@ function routeStateEvent(type: string, data: Record<string, unknown> | null, rep
       if (!replayed && data?.exits) {
         exits.set(data.exits as RoomExit[]);
       }
-      break;
-  }
-}
-
-function routeMovementEvent(type: string, actor: string | undefined, replayed: boolean) {
-  if (replayed || !actor) return;
-  switch (type) {
-    case 'arrive':
-      addPresence(actor);
-      break;
-    case 'leave':
-      removePresence(actor);
       break;
   }
 }

--- a/web/src/lib/stores/sidebarStore.ts
+++ b/web/src/lib/stores/sidebarStore.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 HoloMUSH Contributors
 
 import { writable } from 'svelte/store';
+import { presenceStore } from '$lib/presence/store';
 
 export interface RoomLocation {
   id: string;
@@ -25,6 +26,9 @@ export interface RoomCharacter {
 
 export const location = writable<RoomLocation | null>(null);
 export const exits = writable<RoomExit[]>([]);
+// The `presence` writable is kept for any consumers that still read it
+// (TopBar, RoomInfo, ExitList do not; only the now-migrated PresenceList did).
+// It is no longer the authoritative source for the sidebar UI.
 export const presence = writable<RoomCharacter[]>([]);
 
 export function applyLocationState(metadata: Record<string, unknown>) {
@@ -32,19 +36,27 @@ export function applyLocationState(metadata: Record<string, unknown>) {
   if (loc) location.set(loc);
   const ex = metadata.exits as RoomExit[] | undefined;
   if (ex) exits.set(ex);
-  const pr = metadata.present as RoomCharacter[] | undefined;
-  if (pr) presence.set(pr);
-}
-
-export function addPresence(name: string) {
-  presence.update((list) => {
-    if (!list.some((c) => c.name === name)) {
-      return [...list, { name, idle: false }];
-    }
-    return list;
-  });
-}
-
-export function removePresence(name: string) {
-  presence.update((list) => list.filter((c) => c.name !== name));
+  const pr = metadata.present as Array<{ name?: string; idle?: boolean }> | undefined;
+  if (pr) {
+    // Keep the legacy writable populated for any remaining consumer.
+    presence.set(pr.map((c) => ({ name: c.name ?? '', idle: c.idle ?? false })));
+    // Seed the new PresenceStore from the location_state snapshot.
+    // CONCERN: location_state.present[] (core.LocationStateChar) carries only
+    // `name` and `idle` — no `characterId` field is emitted by the server.
+    // We use `name` as the characterId key here as a fallback. This means the
+    // store is keyed by display name, not ULID, for location_state-sourced
+    // entries. The authoritative snapshot seeded by webListFocusPresence in
+    // +page.svelte uses ULIDs when available. A follow-up should add
+    // characterId to LocationStateChar on the server side so this path
+    // produces proper ULID keys.
+    presenceStore.seed(
+      pr
+        .filter((c) => c.name)
+        .map((c) => ({
+          characterId: c.name as string,
+          name: c.name as string,
+          state: 'ACTIVE' as const,
+        })),
+    );
+  }
 }

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -10,9 +10,8 @@
   import { ControlSignal } from '$lib/connect/holomush/web/v1/web_pb';
   import { routeEvent } from '$lib/stores/eventRouter';
   import { appendLine, clearLines, replayActive } from '$lib/stores/terminalStore';
-  import { createPresenceStore, type PresenceState } from '$lib/presence/store';
+  import { presenceStore as presence, type PresenceState } from '$lib/presence/store';
   import { mirrorMovementPresence as mirrorMovementPresenceFn } from '$lib/presence/mirror';
-  import { addPresence, removePresence } from '$lib/stores/sidebarStore';
   import { WebPresenceState, type WebPresenceEntry } from '$lib/connect/holomush/web/v1/web_pb';
   import { themePreferences, terminalBlackOverrideVars } from '$lib/stores/themeStore';
   import { setConnectionStatus } from '$lib/stores/connectionStore';
@@ -39,10 +38,6 @@
 
   const client = createClient(WebService, transport);
 
-  // Presence store — keyed by characterId (ULID from snapshot; name as fallback
-  // for live arrive/leave events that don't carry the character ULID on the web wire).
-  const presence = createPresenceStore();
-
   function presenceStateFromProto(s: WebPresenceState): PresenceState {
     switch (s) {
       case WebPresenceState.ACTIVE: return 'ACTIVE';
@@ -52,12 +47,11 @@
     }
   }
 
-  // Bind the testable mirrorMovementPresence helper to the local presence
-  // store and the legacy sidebar functions. The pure function lives in
-  // $lib/presence/mirror and is covered by mirror.test.ts. T12 drops the
-  // legacy parameter once PresenceList.svelte migrates its binding.
+  // Bind the testable mirrorMovementPresence helper to the singleton presence
+  // store. Legacy dual-write removed: PresenceList.svelte now reads from
+  // presenceStore directly (T12, holomush-5b2j.14).
   function mirrorMovementPresence(ev: GameEvent) {
-    mirrorMovementPresenceFn(ev, presence, { add: addPresence, remove: removePresence });
+    mirrorMovementPresenceFn(ev, presence);
   }
 
   async function handleStaleSession() {
@@ -227,6 +221,13 @@
   async function hydrateAndStream() {
     abortController?.abort();
     abortController = new AbortController();
+    // Clear the module-level singleton presence store at the start of every
+    // hydrate so a reconnect / new-session does not render stale entries from
+    // a prior session. snapshot.seed() also clears internally as its first
+    // step, but it can be seconds away (backfill in parallel + RPC roundtrip
+    // + the 3s timeout fallback). Clearing here closes that visible-stale
+    // window.
+    presence.clear();
     // Snapshot the controller to a local so handlers resolving after a
     // concurrent re-invocation replaced the shared `abortController` do
     // not read a stale/foreign signal. Side-effect writes below are also
@@ -452,19 +453,13 @@
         replayActive.set(false);
         // Drain Subscribe events that arrived during backfill, deduping.
         for (const ev of liveBuffer) {
-          // Mirror every movement event to BOTH presence stores. The
-          // routeEvent path below also calls addPresence/removePresence via
-          // eventRouter for non-replayed events — that's idempotent on the
-          // OLD store (set-based, no name dupes) and only fires for the
-          // non-dedup branch. The mirror call here covers the dedup branch
-          // (where routeEvent is skipped) and ensures the NEW PresenceStore
-          // sees every movement regardless of branch.
+          // Mirror movement events to the PresenceStore. The mirror call
+          // covers the dedup branch (where routeEvent is skipped) and
+          // ensures the PresenceStore sees every movement regardless of branch.
           mirrorMovementPresence(ev);
           if (ev.eventId && seenEventIds.has(ev.eventId)) {
             // Terminal dedup: suppress duplicate output. Presence sidebar
             // update already happened via mirrorMovementPresence above.
-            // TODO(holomush-1tvn.15): once backfill excludes events published
-            // after subscribe started, this whole branch can be removed.
             continue;
           }
           if (ev.eventId) seenEventIds.add(ev.eventId);


### PR DESCRIPTION
## Summary

T12 of the holomush-5b2j epic — closes the loop on the snapshot-based architecture by migrating the sidebar UI to the new `PresenceStore` and removing the transitional dual-write code from T11.

**This is the PR where `terminal.spec.ts:136` (the canonical 5b2j e2e) passes end-to-end through the new architecture for the first time.** Previously it passed through the OLD `sidebarStore` path that T11 kept as a transitional bridge.

## Architecture changes

1. **PresenceStore singleton** — `web/src/lib/presence/store.ts` now exports a module-level `presenceStore` instance alongside the `createPresenceStore()` factory (still used by tests for isolation). Components import the singleton; tests use the factory.

2. **PresenceList.svelte** binds to `presenceStore.map` directly. SvelteMap is reactive natively in Svelte 5. Iterates `[...presenceStore.map.values()]` keyed by `characterId`. Falls back to `char.name || char.characterId` for empty-name forward-compat. Drops `lastMode` / `idle` styling — those depend on fields the new `PresenceEntry` doesn't carry (filed as `holomush-uhiz`-class future work).

3. **`applyLocationState` seeds `presenceStore`** from `location_state.present[]`. See known-limitation note below.

4. **`mirrorMovementPresence` called without `legacy` parameter** — no more dual-write to `sidebarStore`. The pure function from T11's extraction is now used as designed.

5. **`eventRouter.routeMovementEvent` removed entirely** — `+page.svelte` is now the sole writer for live movement events (via mirror).

6. **`+page.svelte` no longer imports `addPresence`/`removePresence`** and uses the singleton `presenceStore` instead of a local `createPresenceStore()` call.

## Known limitation (filed as `holomush-e4qo`)

`core.LocationStateChar` (the JSON payload shape inside `location_state` events) carries only `name` and `idle` — no `character_id`. `applyLocationState` therefore seeds the PresenceStore with `name`-keyed entries for now. The same character could appear twice transiently — once name-keyed (from `location_state`) and once ULID-keyed (from snapshot / live arrive). The snapshot eventually overrides.

This is the same wire-format gap pattern we fixed for `actor_id` on `GameEvent` in T11 (PR #4146). The fix is small (add `character_id` to `LocationStateChar` + emit-site populator + client read change) and isolated to a follow-up. Filed as `holomush-e4qo` (P2).

The e2e `terminal.spec.ts:136` passes today because the snapshot RPC path is the primary source and uses correct ULID keys.

## Files

- `web/src/lib/presence/store.ts` — added singleton export
- `web/src/lib/components/sidebar/PresenceList.svelte` — migrated to singleton
- `web/src/lib/stores/sidebarStore.ts` — `applyLocationState` seeds new store
- `web/src/lib/stores/eventRouter.ts` — removed `routeMovementEvent`
- `web/src/routes/(authed)/terminal/+page.svelte` — uses singleton; drops dual-write

## Bead

`holomush-5b2j.14` (epic: `holomush-5b2j` [E-5B2J]). With this merged, only 4 beads remain in the epic: T4.5 (`5b2j.4`), T13 (`5b2j.15`), T14 (`5b2j.16`), T15 (`5b2j.17`), T16 (`5b2j.8`), T17 (`5b2j.18`).

## Verification

- [x] `cd web && pnpm run test:unit` — 60 cases pass
- [x] `cd web && pnpm check` — 0 errors (5 unused-CSS warnings on PresenceList retained for `holomush-uhiz` future use)
- [x] `task pr-prep` full lane green **including `terminal.spec.ts:136`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized presence management into a shared store and updated sidebar to show character names with fallback to IDs.
  * Simplified event routing so presence is handled consistently.

* **Bug Fixes**
  * Clears shared presence on reconnects to avoid stale entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->