### PR TITLE
test(integration): joiner sees prior presence (AC4) (holomush-5b2j.15)

### DIFF
--- a/internal/testsupport/privacytest/privacy_harness.go
+++ b/internal/testsupport/privacytest/privacy_harness.go
@@ -115,7 +115,8 @@ func Start(t *testing.T) *Server {
 	authService, err := auth.NewAuthService(playerRepo, playerSessionStore, hasher)
 	require.NoError(t, err, "privacytest.Start: create auth service")
 
-	charRepo := &authCharRepoAdapter{pool: pool, charRepo: worldpg.NewCharacterRepository(pool)}
+	worldCharRepo := worldpg.NewCharacterRepository(pool)
+	charRepo := &authCharRepoAdapter{pool: pool, charRepo: worldCharRepo}
 	sessionStoreInst := store.NewPostgresSessionStore(pool)
 	locRepo := worldpg.NewLocationRepository(pool)
 
@@ -175,6 +176,7 @@ func Start(t *testing.T) *Server {
 		holoGRPC.WithPlayerSessionRepo(playerSessionStore),
 		holoGRPC.WithPlayerRepo(playerRepo),
 		holoGRPC.WithCharacterRepo(charRepo),
+		holoGRPC.WithCharacterNameResolver(holoGRPC.NewRepoCharacterNameResolver(worldCharRepo)),
 		holoGRPC.WithSessionStore(sessionStoreInst),
 		holoGRPC.WithGuestService(guestSvc),
 		// Wire embedded bus subscriber so Subscribe calls succeed for

--- a/internal/testsupport/privacytest/privacy_session.go
+++ b/internal/testsupport/privacytest/privacy_session.go
@@ -174,6 +174,17 @@ func (s *Session) QueryStreamHistory(ctx context.Context, stream string) ([]*cor
 	return resp.GetEvents(), nil
 }
 
+// ListFocusPresence calls the snapshot RPC for the session's current focus
+// (location-scoped) and returns the response. The caller is responsible for
+// asserting on response.Entries / response.Context / response.ContextId.
+// Access denials propagate as test failures via the returned error.
+func (s *Session) ListFocusPresence(ctx context.Context) (*corev1.ListFocusPresenceResponse, error) {
+	return s.server.coreServer.ListFocusPresence(ctx, &corev1.ListFocusPresenceRequest{
+		SessionId:          s.SessionID,
+		PlayerSessionToken: s.playerSessionToken,
+	})
+}
+
 // AuthedPlayer represents a named player (with hashed password) that can
 // open multiple concurrent game sessions for the same character, used by
 // multi-session continuity tests (iwzt.9+).

--- a/test/integration/presence/presence_suite_test.go
+++ b/test/integration/presence/presence_suite_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package presence_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+// suiteT exposes the *testing.T from TestPresence so Ginkgo Describe blocks
+// can pass it to privacytest.Start (which requires *testing.T — Ginkgo's
+// GinkgoT() does not satisfy that interface directly).
+var suiteT *testing.T
+
+func TestPresence(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "5b2j presence snapshot — current-state semantics")
+}

--- a/test/integration/presence/presence_test.go
+++ b/test/integration/presence/presence_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+// Package presence_test contains integration tests for holomush-5b2j
+// presence snapshot semantics.
+//
+// Test IDs follow the AC-N convention from the epic acceptance criteria
+// at bd holomush-5b2j and the design spec at
+// docs/superpowers/specs/2026-05-19-presence-snapshot-design.md.
+package presence_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/privacytest"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// AC4: A connects, B then connects to the same location, B's ListFocusPresence
+// MUST include A within 1s of session open. Proves the snapshot RPC populates
+// presence independent of event replay — the architectural pattern that
+// unblocks iwzt.15 (Tier 2 history-scope filter).
+var _ = Describe("AC4: joiner sees prior presence", func() {
+	var (
+		ts    *privacytest.Server
+		ctx   context.Context
+		alice *privacytest.Session
+		bob   *privacytest.Session
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = privacytest.Start(suiteT)
+		alice = ts.ConnectAuthed(ctx, "Alice")
+		// Let alice's connect settle before bob joins. The snapshot RPC reads
+		// session state directly so does NOT depend on this delay for
+		// correctness — kept for parity with the AC4 acceptance scenario
+		// (B joins AFTER A is established).
+		time.Sleep(200 * time.Millisecond)
+		bob = ts.ConnectAuthed(ctx, "Bob")
+	})
+
+	AfterEach(func() {
+		// Use a fresh cleanup context independent of the BeforeEach ctx (which
+		// could in principle be expired by AfterEach time) and nil-check ts in
+		// case privacytest.Start panicked before assigning. Ginkgo runs
+		// AfterEach even when BeforeEach failed.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if bob != nil {
+			bob.Logout(cleanupCtx)
+		}
+		if alice != nil {
+			alice.Logout(cleanupCtx)
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("B's ListFocusPresence response includes A AND B within 1s", func() {
+		Expect(alice.LocationID).To(Equal(bob.LocationID),
+			"preconditions: both sessions must be at the same location for AC4")
+
+		Eventually(func(g Gomega) {
+			resp, err := bob.ListFocusPresence(ctx)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"ListFocusPresence MUST succeed for a session in a same-location query (seed:player-location-list-presence)")
+			g.Expect(resp).NotTo(BeNil())
+			g.Expect(resp.GetContext()).To(Equal(corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION),
+				"context MUST be LOCATION when session has no FocusMemberships")
+			g.Expect(resp.GetContextId()).To(Equal(bob.LocationID.String()),
+				"context_id MUST be the queried location's ULID")
+			g.Expect(entryNames(resp.GetEntries())).To(ConsistOf("Alice", "Bob"),
+				"presence MUST include both sessions in the location")
+		}, time.Second, 50*time.Millisecond).Should(Succeed())
+	})
+})
+
+// entryNames extracts character names from PresenceEntry slice for ConsistOf
+// matching. Mirrors the plan template's entryNames helper.
+func entryNames(entries []*corev1.PresenceEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.GetCharacterName())
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

Adds the end-to-end Ginkgo integration test that proves the snapshot RPC architecture works for the holomush-5b2j epic. Specifically: when session B connects to a location where session A is already present, B's call to `CoreService.ListFocusPresence` returns BOTH characters within 1 second of connect — validating **AC4** of the epic.

This is task **T13** of holomush-5b2j (Phase 5). Architecture is already on `main` through T12; this PR is the test that locks the behavior in. Unblocks T14 (Tier 2 compat test) and T15 (meta-test), which together unblock T17 (final pr-prep + push).

## Changes

**Test-harness extensions** (`internal/testsupport/privacytest/`):
- `privacy_harness.go`: lift `worldpg.NewCharacterRepository(pool)` into a shared local so the same repo backs both the auth adapter and the name resolver. Wire `holoGRPC.WithCharacterNameResolver(...)` into the in-process `CoreServer` construction, mirroring production wire at `cmd/holomush/sub_grpc.go:452`. Zero behavior change for existing iwzt privacy tests (the resolver is only consulted by `ListFocusPresence`).
- `privacy_session.go`: add `Session.ListFocusPresence(ctx)` helper mirroring the existing `Session.QueryStreamHistory` shape.

**New integration package** (`test/integration/presence/`):
- `presence_suite_test.go` — Ginkgo entry mirroring `privacy_suite_test.go`.
- `presence_test.go` — AC4 spec. Uses `ConnectAuthed("Alice")`, then `ConnectAuthed("Bob")`; polls `bob.ListFocusPresence(ctx)` with `Eventually(1s, 50ms)` and asserts both characters appear, `Context == PRESENCE_CONTEXT_LOCATION`, `ContextId == bob.LocationID`.

## Reviewer notes

- The `privacytest` harness is reused (despite the iwzt-historical name) because it's general-purpose enough; the integration test boundary stays clean via the separate `test/integration/presence/` package.
- The harness's `allowAllPolicyEngine` satisfies the ABAC gate (`seed:player-location-list-presence`) trivially — the snapshot RPC behavior is what's being exercised end-to-end, not the seed policy itself. Seed-policy enforcement is locked separately in `internal/grpc/list_focus_presence_test.go`.
- `code-reviewer` pre-push gate: **READY** with two non-blocking minor findings (cosmetic 200ms sleep in `BeforeEach`; harmless `entryNames` helper duplication across test packages). Both kept as-is for AC4 scenario legibility.

## Test plan

- [x] `task test:int -- ./test/integration/presence/` — PASS (3.927s for the new package)
- [x] `task pr-prep` — green (full lane)
- [x] No workspace drift — diff is exactly the four expected files

## Beads

Closes holomush-5b2j.15. Unblocks holomush-5b2j.16 (T14 — Tier 2 compat) and holomush-5b2j.17 (T15 — meta-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration test suite for presence snapshot semantics
  * New tests validate location-scoped presence snapshots when multiple players connect
  * Tests verify presence entries include all characters and meet current-state timing expectations

* **Chores**
  * Improved test harness to support fetching presence snapshots and resolving character names during tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->