### PR TITLE
test(integration): presence snapshot bypasses Tier 2 floor (AC3, I-PRES-2) (holomush-5b2j.16)

### DIFF
--- a/internal/testsupport/privacytest/privacy_harness.go
+++ b/internal/testsupport/privacytest/privacy_harness.go
@@ -253,6 +253,21 @@ func (s *Server) ExpireSession(ctx context.Context, sessionID string) {
 		"privacytest.Server.ExpireSession: expected 1 row affected, got %d (sessionID=%s)", tag.RowsAffected(), sessionID)
 }
 
+// SetLocationArrivedAt directly mutates a session's location_arrived_at column
+// in Postgres. Used by 5b2j tests to exercise floor-bypass semantics
+// (I-PRES-2): the snapshot RPC reads sessionStore directly and is exempt from
+// the I-PRIV-1 temporal floor, so manipulating this column should NOT affect
+// ListFocusPresence's behavior.
+func (s *Server) SetLocationArrivedAt(ctx context.Context, sessionID string, t time.Time) {
+	s.t.Helper()
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE sessions SET location_arrived_at = $1, updated_at = $1 WHERE id = $2`,
+		t.UTC(), sessionID)
+	require.NoError(s.t, err, "privacytest.Server.SetLocationArrivedAt")
+	require.Equalf(s.t, int64(1), tag.RowsAffected(),
+		"privacytest.Server.SetLocationArrivedAt: expected 1 row affected, got %d (sessionID=%s)", tag.RowsAffected(), sessionID)
+}
+
 // ConnectGuest creates a guest player+character and opens a game session.
 // The returned Session is ready for SendCommand / DrainEvents / Logout calls.
 func (s *Server) ConnectGuest(ctx context.Context) *Session {

--- a/test/integration/presence/presence_test.go
+++ b/test/integration/presence/presence_test.go
@@ -84,6 +84,76 @@ var _ = Describe("AC4: joiner sees prior presence", func() {
 	})
 })
 
+// AC3 / I-PRES-2: the snapshot RPC MUST be exempt from the I-PRIV-1 temporal
+// floor (LocationArrivedAt). Manipulate bob's LocationArrivedAt to 1 hour in
+// the future — under any temporal-floor-based filter (e.g., iwzt.15 Tier 2),
+// alice's arrive event would be filtered out. The snapshot reads sessionStore
+// directly and never traverses event delivery, so alice MUST still appear.
+//
+// Note: Tier 2 filter is currently a structural no-op in production (see
+// internal/grpc/scope_floor.go:22 comment) because of a stream-subject
+// format mismatch. This test asserts the architectural property the filter
+// would gate against — independent of whether the filter itself is active.
+// The future-LocationArrivedAt write is currently inert to the handler path
+// (ListActiveByLocation has no temporal predicate) but acts as a regression
+// tripwire: if anyone adds floor filtering at the snapshot layer, alice
+// vanishes from the response and this test fails.
+//
+// TODO(iwzt.15): once the Tier 2 filter is no longer a structural no-op,
+// upgrade this scenario to also exercise an active filter (e.g., via a
+// WithTier2FilterActive harness option). Until then, the future-floor
+// write + architectural assertion is the strongest available shape.
+var _ = Describe("AC3 / I-PRES-2: snapshot bypasses I-PRIV-1 temporal floor", func() {
+	var (
+		ts    *privacytest.Server
+		ctx   context.Context
+		alice *privacytest.Session
+		bob   *privacytest.Session
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = privacytest.Start(suiteT)
+		alice = ts.ConnectAuthed(ctx, "Alice")
+		bob = ts.ConnectAuthed(ctx, "Bob")
+		// Push bob's LocationArrivedAt 1 hour into the future. Any temporal-
+		// floor-based event filter would exclude alice's earlier arrive event
+		// under this regime. The snapshot RPC must remain unaffected.
+		ts.SetLocationArrivedAt(ctx, bob.SessionID, time.Now().Add(time.Hour))
+	})
+
+	AfterEach(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if bob != nil {
+			bob.Logout(cleanupCtx)
+		}
+		if alice != nil {
+			alice.Logout(cleanupCtx)
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("alice still appears in bob's ListFocusPresence response", func() {
+		Expect(alice.LocationID).To(Equal(bob.LocationID),
+			"preconditions: both sessions must be at the same location")
+
+		Eventually(func(g Gomega) {
+			resp, err := bob.ListFocusPresence(ctx)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"ListFocusPresence MUST succeed for a same-location query (seed:player-location-list-presence)")
+			g.Expect(resp).NotTo(BeNil())
+			g.Expect(resp.GetContext()).To(Equal(corev1.PresenceContext_PRESENCE_CONTEXT_LOCATION))
+			g.Expect(entryNames(resp.GetEntries())).To(ContainElement("Alice"),
+				"I-PRES-2: snapshot MUST surface alice despite bob's strict LocationArrivedAt floor")
+			g.Expect(entryNames(resp.GetEntries())).To(ContainElement("Bob"),
+				"I-PRES-6: caller's own session MUST be in the response")
+		}, time.Second, 50*time.Millisecond).Should(Succeed())
+	})
+})
+
 // entryNames extracts character names from PresenceEntry slice for ConsistOf
 // matching. Mirrors the plan template's entryNames helper.
 func entryNames(entries []*corev1.PresenceEntry) []string {


### PR DESCRIPTION
## Summary

Adds the AC3 / I-PRES-2 integration scenario to the presence test suite. Locks the invariant: **the snapshot RPC MUST be exempt from the I-PRIV-1 temporal floor** (`LocationArrivedAt`). Connects alice + bob to the same location, pushes bob's `LocationArrivedAt` 1 hour into the future, then asserts bob's `ListFocusPresence` response still contains alice.

This is **T14** of holomush-5b2j. Together with T13 (AC4, PR #4148), this closes the integration-test gate for the epic. T15 (meta-test) and T17 (final pr-prep + push) become unblocked.

## Changes

**Harness extension** (`internal/testsupport/privacytest/`):
- `privacy_harness.go`: new `Server.SetLocationArrivedAt(ctx, sessionID, t)` method, modeled on the existing `ExpireSession` pattern. Direct parameterized UPDATE on `sessions.location_arrived_at`. Column verified against migration `000037_add_session_history_floor_columns`.

**Test** (`test/integration/presence/presence_test.go`):
- New `Describe("AC3 / I-PRES-2: snapshot bypasses I-PRIV-1 temporal floor", ...)` block. Uses the same fresh-harness-per-scenario pattern as the existing AC4 block. Reuses the package-level `entryNames` helper.

## Documented caveat

The Tier 2 filter is a **structural no-op in production today** — see `internal/grpc/scope_floor.go:22` (stream-subject format mismatch). So the test does NOT activate the filter (there is no `WithTier2FilterActive` harness option — the plan template invented one); instead it asserts the **architectural property** the filter would gate against: snapshot reads `sessionStore` directly and never traverses event delivery.

The future-`LocationArrivedAt` write is currently **inert to the handler path** (`ListActiveByLocation` has no temporal predicate) but acts as a **regression tripwire** — if anyone adds floor filtering at the snapshot layer in the future, alice vanishes and the test fails. A `TODO(iwzt.15)` inline points the iwzt.15 implementer at the upgrade path for when the Tier 2 filter is no longer a no-op.

## Reviewer notes

- `code-reviewer` pre-push gate: **READY** with one MEDIUM non-blocking observation (the load-bearing mutation is currently inert) — addressed inline by adding the regression-tripwire / TODO comment block before push.
- Two follow-up beads are implied by the documented caveat but not filed here: (a) closing the `streamScopeFloor` stream-subject format mismatch, and (b) the `WithTier2FilterActive` harness option once (a) is done. Both belong to the iwzt epic, not 5b2j.

## Test plan

- [x] `task test:int -- ./test/integration/presence/` — PASS (both AC4 + AC3 scenarios green, ~5s for the package; 1585 total tests in 84s)
- [x] `task pr-prep` — green (full lane)
- [x] No workspace drift — diff is exactly the two expected files

## Beads

Closes holomush-5b2j.16. Unblocks holomush-5b2j.17 (T15 — meta-test) and holomush-5b2j.18 (T17 — final pr-prep + push, still blocked on T15 + T16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new integration test suite verifying presence behavior verification across various timing scenarios.
  * Extended test infrastructure with utilities enabling advanced session state manipulation for integration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->