### PR TITLE
test(meta): I-PRES-* invariant coverage assertion (holomush-5b2j.17)

### DIFF
--- a/internal/grpc/list_focus_presence_test.go
+++ b/internal/grpc/list_focus_presence_test.go
@@ -88,6 +88,7 @@ func TestListFocusPresenceReturnsInvalidArgumentOnEmptySessionID(t *testing.T) {
 	assert.Equal(t, "INVALID_ARGUMENT", o.Code())
 }
 
+// Verifies: I-PRES-3
 func TestListFocusPresenceReturnsSessionNotFoundOnUnknownSession(t *testing.T) {
 	s := &CoreServer{
 		sessionStore:      newTestSessionStore(t, nil),
@@ -104,6 +105,7 @@ func TestListFocusPresenceReturnsSessionNotFoundOnUnknownSession(t *testing.T) {
 	assert.Equal(t, "SESSION_NOT_FOUND", o.Code())
 }
 
+// Verifies: I-PRES-3
 func TestListFocusPresenceCollapsesOwnershipMismatchToNotFound(t *testing.T) {
 	// Caller's player_session_token resolves to a player session with a
 	// different PlayerID than the target session's PlayerID — ownership
@@ -173,6 +175,7 @@ func TestListFocusPresenceReturnsSessionExpiredForExpiredSession(t *testing.T) {
 	assert.Equal(t, "SESSION_EXPIRED", o.Code())
 }
 
+// Verifies: I-PRES-5
 func TestListFocusPresenceReturnsUnimplementedForSceneFocus(t *testing.T) {
 	sess := mkOwnedSession("sess-1", func(s *session.Info) {
 		s.CharacterID = ulid.MustParse("01HYXCHAR0000000000000000C")
@@ -216,7 +219,7 @@ func TestListFocusPresenceReturnsEmptyEntriesWhenLocationUnset(t *testing.T) {
 
 // ---------- T7 tests ----------
 
-// I-PRES-4: ABAC denial → PERMISSION_DENIED.
+// Verifies: I-PRES-4
 func TestListFocusPresenceReturnsPermissionDeniedWhenABACDenies(t *testing.T) {
 	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
 	loc := ulid.MustParse("01HYXLOCATION0000000000001")
@@ -236,8 +239,9 @@ func TestListFocusPresenceReturnsPermissionDeniedWhenABACDenies(t *testing.T) {
 	assert.Equal(t, "PERMISSION_DENIED", o.Code())
 }
 
-// I-PRES-1 + I-PRES-6: two Active sessions at same location, both returned
-// with state=ACTIVE; caller is included in the result.
+// Verifies: I-PRES-1
+// Verifies: I-PRES-4
+// Verifies: I-PRES-6
 func TestListFocusPresenceReturnsCallerAndOtherSessions(t *testing.T) {
 	char1 := ulid.MustParse("01HYXCHARALICE0000000000AA")
 	char2 := ulid.MustParse("01HYXCHARBOB000000000000BB")
@@ -297,8 +301,7 @@ func TestListFocusPresenceSkipsEntryWhenNameUnresolved(t *testing.T) {
 	assert.Equal(t, "alice", resp.Entries[0].CharacterName)
 }
 
-// I-PRES-9: defense-in-depth dedup — two sessions for the same character_id
-// must collapse to a single presence entry.
+// Verifies: I-PRES-9
 func TestListFocusPresenceDeduplicatesByCharacterID(t *testing.T) {
 	char := ulid.MustParse("01HYXCHARALICE0000000000AA")
 	loc := ulid.MustParse("01HYXLOCATION0000000000001")
@@ -322,8 +325,7 @@ func TestListFocusPresenceDeduplicatesByCharacterID(t *testing.T) {
 	assert.Len(t, resp.Entries, 1, "duplicate character_id must collapse to single entry")
 }
 
-// I-PRES-1 cross-location: the handler trusts ListActiveByLocation to filter;
-// sessions at a different location must not appear in the response.
+// Verifies: I-PRES-1
 func TestListFocusPresenceDoesNotLeakSessionsFromOtherLocations(t *testing.T) {
 	char1 := ulid.MustParse("01HYXCHARALICE0000000000AA")
 	char2 := ulid.MustParse("01HYXCHARBOB000000000000BB")
@@ -369,6 +371,25 @@ func TestListFocusPresenceReturnsPermissionDeniedWhenAccessEngineIsNil(t *testin
 	o, ok := oops.AsOops(err)
 	require.True(t, ok)
 	assert.Equal(t, "PERMISSION_DENIED", o.Code())
+}
+
+// Verifies: I-PRES-7
+// PresenceEntry wire shape must contain exactly 3 fields: character_id,
+// character_name, state. No timestamps or duration-of-presence fields.
+// Uses proto reflection to assert field count stays exactly 3 — any
+// proto addition that would leak timing data fails this test.
+func TestPresenceEntryHasExactlyThreeFields(t *testing.T) {
+	entry := &corev1.PresenceEntry{}
+	fields := entry.ProtoReflect().Descriptor().Fields()
+	const wantFields = 3
+	if fields.Len() != wantFields {
+		names := make([]string, fields.Len())
+		for i := range fields.Len() {
+			names[i] = string(fields.Get(i).Name())
+		}
+		t.Errorf("I-PRES-7: PresenceEntry MUST have exactly %d fields (character_id, character_name, state); got %d: %v",
+			wantFields, fields.Len(), names)
+	}
 }
 
 // Missing characterNameResolver → INTERNAL (misconfiguration; not a security

--- a/test/integration/presence/presence_test.go
+++ b/test/integration/presence/presence_test.go
@@ -22,6 +22,8 @@ import (
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
 
+// Verifies: I-PRES-1
+// Verifies: I-PRES-6
 // AC4: A connects, B then connects to the same location, B's ListFocusPresence
 // MUST include A within 1s of session open. Proves the snapshot RPC populates
 // presence independent of event replay — the architectural pattern that
@@ -103,6 +105,7 @@ var _ = Describe("AC4: joiner sees prior presence", func() {
 // upgrade this scenario to also exercise an active filter (e.g., via a
 // WithTier2FilterActive harness option). Until then, the future-floor
 // write + architectural assertion is the strongest available shape.
+// Verifies: I-PRES-2
 var _ = Describe("AC3 / I-PRES-2: snapshot bypasses I-PRIV-1 temporal floor", func() {
 	var (
 		ts    *privacytest.Server

--- a/test/meta/i_pres_coverage_test.go
+++ b/test/meta/i_pres_coverage_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package meta contains repository-wide meta-tests that enforce structural
+// invariants — for example, that every I-PRES-N invariant declared in the
+// presence-snapshot design spec has at least one concrete test binding via a
+// `// Verifies: I-PRES-N` annotation (or, for I-PRES-8, a frontend test).
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// iPresInvariants enumerates the I-PRES invariants (I-PRES-1..9) that MUST
+// each have at least one test binding (or, for I-PRES-8, a frontend vitest
+// file). Update this list when a new I-PRES invariant is added to
+// docs/superpowers/specs/2026-05-19-presence-snapshot-design.md.
+//
+// Invariant summaries (from §7 of the spec):
+//   - I-PRES-1: Snapshot returns only Active sessions; Detached/Expired excluded.
+//   - I-PRES-2: Snapshot exempt from I-PRIV-1 temporal floor (timeless current state).
+//   - I-PRES-3: Ownership failures collapse to SESSION_NOT_FOUND (enumeration-safe).
+//   - I-PRES-4: RPC ABAC-gated by action="list_presence" on resource="location:<id>".
+//   - I-PRES-5: Non-empty FocusMemberships → UNIMPLEMENTED; no silent fallback.
+//   - I-PRES-6: Caller's own session included when status+location qualify.
+//   - I-PRES-7: PresenceEntry has exactly 3 fields: character_id, character_name, state.
+//   - I-PRES-8: Client presence map keyed by character_id; idempotent add/remove.
+//   - I-PRES-9: Response deduplicates by character_id (defense-in-depth).
+var iPresInvariants = []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+// iPresExternalBinding lists invariants whose binding lives outside Go test
+// files. I-PRES-8 is enforced by the frontend PresenceStore vitest suite at
+// web/src/lib/presence/ (store.test.ts, mirror.test.ts). The meta-test
+// verifies the path exists so drift (rename, deletion) causes an immediate
+// failure rather than a silent pass.
+var iPresExternalBinding = map[int]string{
+	8: filepath.Join("web", "src", "lib", "presence"),
+}
+
+// iPresVerifiesRE matches `// Verifies: I-PRES-<digits>` annotations in
+// test files. Anchored on whitespace so it tolerates both `// Verifies:`
+// and `//  Verifies:` forms consistently with the precedent in
+// inv_binding_test.go.
+var iPresVerifiesRE = regexp.MustCompile(`//\s*Verifies:\s*I-PRES-(\d+)`)
+
+func TestEveryIPRESInvariantHasAtLeastOneTestBinding(t *testing.T) {
+	root := findRepoRoot(t)
+
+	// Use os.Root for race-free, symlink-safe file reads inside the repo
+	// tree (gosec G122). All paths produced by WalkDir below are converted
+	// to root-relative form before being opened via Root.Open.
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatalf("open repo root %q: %v", root, err)
+	}
+	defer func() { _ = rootFS.Close() }()
+
+	// Verify external-binding paths exist before scanning for Go bindings.
+	// This prevents a renamed/deleted frontend directory from causing a
+	// silent pass when the invariant is marked external-only. Use os.Stat
+	// rather than rootFS.Open so we don't leak file descriptors — mirrors
+	// the path-existence pattern in inv_binding_test.go:112.
+	for inv, rel := range iPresExternalBinding {
+		if _, statErr := os.Stat(filepath.Join(root, rel)); statErr != nil {
+			t.Errorf("I-PRES-%d: external-binding path %q does not exist: %v (was the frontend directory renamed or deleted?)", inv, rel, statErr)
+		}
+	}
+
+	bindings := make(map[int][]string) // I-PRES-N -> list of file paths
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		f, openErr := rootFS.Open(rel)
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		closeErr := f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		matches := iPresVerifiesRE.FindAllSubmatch(data, -1)
+		for _, m := range matches {
+			n, convErr := strconv.Atoi(string(m[1]))
+			if convErr != nil {
+				continue
+			}
+			bindings[n] = append(bindings[n], rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+
+	for _, inv := range iPresInvariants {
+		if _, external := iPresExternalBinding[inv]; external {
+			// Binding is a frontend test (path existence verified above).
+			continue
+		}
+		if len(bindings[inv]) == 0 {
+			t.Errorf("I-PRES-%d: no test binding found (expected at least one `// Verifies: I-PRES-%d` comment in a *_test.go file)", inv, inv)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a meta-test that asserts every I-PRES-N invariant (1..9) declared in the presence-snapshot design spec has at least one test binding in the repo. This is **T15** of holomush-5b2j. Together with T13 (AC4) and T14 (AC3 / I-PRES-2), this closes the test-coverage gate for the epic. T17 (final pr-prep + push) becomes unblocked once T16 (doc cross-references) also lands.

## Changes

**New meta-test** (`test/meta/i_pres_coverage_test.go`):
- `TestEveryIPRESInvariantHasAtLeastOneTestBinding` walks all `*_test.go` files under the repo root and matches `// Verifies: I-PRES-N` annotations.
- Models on the existing `test/meta/inv_binding_test.go` precedent — **no build tag** (runs under default `go test` + `task pr-prep`), uses `filepath.WalkDir` + `os.Stat` instead of the plan template's `exec.Command` + `rg` shell-out (more portable, no rg dependency).
- I-PRES-8 is frontend-only (PresenceStore vitest); handled via the `iPresExternalBinding` map pointing at `web/src/lib/presence/`. The meta-test verifies the path exists via `os.Stat` so a rename/delete fails loudly rather than silently passing.
- Reuses `findRepoRoot` and `skipDirs` from `inv_binding_test.go` (same `package meta`, no redeclaration).

**Annotated existing tests** (`internal/grpc/list_focus_presence_test.go`, `test/integration/presence/presence_test.go`):
- Added `// Verifies: I-PRES-N` comments above each test that pins a specific invariant. Mapping follows the spec §8 coverage table.

**One new unit test** (`internal/grpc/list_focus_presence_test.go`):
- `TestPresenceEntryHasExactlyThreeFields` uses proto reflection (`PresenceEntry.ProtoReflect().Descriptor().Fields().Len()`) to assert the wire shape stays exactly 3 fields. Binds I-PRES-7 — any future field addition (timing or otherwise) trips this guard. Pre-existing test plan §8.1 U-17 specified this test but it had not been implemented; without it I-PRES-7 had no binding and the meta-test would have failed.

## Coverage map

| Invariant | Binding |
|-----------|---------|
| I-PRES-1 | `TestListFocusPresenceReturnsCallerAndOtherSessions`, `TestListFocusPresenceDoesNotLeakSessionsFromOtherLocations`, AC4 integration |
| I-PRES-2 | AC3 integration |
| I-PRES-3 | `TestListFocusPresenceReturnsSessionNotFoundOnUnknownSession`, `TestListFocusPresenceCollapsesOwnershipMismatchToNotFound` |
| I-PRES-4 | `TestListFocusPresenceReturnsPermissionDeniedWhenABACDenies`, `TestListFocusPresenceReturnsCallerAndOtherSessions` |
| I-PRES-5 | `TestListFocusPresenceReturnsUnimplementedForSceneFocus` |
| I-PRES-6 | `TestListFocusPresenceReturnsCallerAndOtherSessions`, AC4 integration |
| I-PRES-7 | `TestPresenceEntryHasExactlyThreeFields` (new) |
| I-PRES-8 | external — `web/src/lib/presence/` directory existence check |
| I-PRES-9 | `TestListFocusPresenceDeduplicatesByCharacterID` |

## Reviewer notes

- `code-reviewer` pre-push gate: **READY** with one LOW non-blocking finding (file-handle leak in the external-binding existence check using `rootFS.Open`) — addressed inline by switching to `os.Stat`, matching the precedent in `inv_binding_test.go:112`.
- Two deviations from the plan template: (a) NO `//go:build meta` build tag (would have caused the meta-test to silently skip under default `go test` + CI); (b) NO `exec.Command("rg", ...)` shell-out (fragile dependency on `rg` being installed, hardcoded paths drift over time). Both deviations match the existing `inv_binding_test.go` precedent.

## Test plan

- [x] `task test -- ./test/meta/...` — PASS (both meta-tests green, 1.433s)
- [x] `task test -- ./internal/grpc/` — PASS (323 tests; +1 from new `TestPresenceEntryHasExactlyThreeFields`)
- [x] `task pr-prep` — green (full lane)
- [x] No workspace drift — diff is exactly the three expected files

## Beads

Closes holomush-5b2j.17. T17 (final pr-prep + push) remains blocked on T16 (doc cross-references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage validation for presence functionality.
  * Added automated verification ensuring comprehensive test binding coverage across all presence invariants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->