### PR TITLE
docs: cross-reference 5b2j presence-snapshot in I-PRIV-1 + rules + contributor guide (holomush-5b2j.8)

### DIFF
--- a/.claude/rules/event-interfaces.md
+++ b/.claude/rules/event-interfaces.md
@@ -48,6 +48,20 @@ type EventBus interface {
 - `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` — full design (§3 publish, §4 subscribe, §5 history, §6 PostgreSQL role)
 - `site/docs/contributing/event-store.md` — contributor examples (plugin emit, manifest audit declarations, embedded vs cluster NATS)
 
+## Current-state RPCs
+
+Some UX flows need "snapshot of current state" rather than event replay.
+These bypass the EventBus entirely and read the relevant store directly:
+
+| Surface     | RPC                              | Source                               |
+| ----------- | -------------------------------- | ------------------------------------ |
+| Presence    | `CoreService.ListFocusPresence`  | `session.Store.ListActiveByLocation` |
+
+Adding a new current-state surface follows the same shape: a CoreServer
+RPC + an ABAC action on the relevant resource + a narrow store query.
+Do NOT reach for `HistoryReader.QueryHistory` when the requirement is
+"what's the current state" — `HistoryReader` is for historical events.
+
 ## ServiceRegistry (`internal/plugin`)
 
 Maps proto service names (e.g., `holomush.scene.v1.SceneService`) to registered service implementations. Used by the plugin loader to wire up service dependencies between plugins.

--- a/.claude/rules/terminology.md
+++ b/.claude/rules/terminology.md
@@ -20,7 +20,7 @@ Consistent terminology prevents confusion. Use these terms exactly.
 | **player**       | user, account         | The human behind one or more characters. |
 | **session**      | connection            | Server-side state for a character's ongoing presence. |
 | **connection**   | socket, client        | A single client attachment to a session (terminal/telnet/etc). |
-| **presence**     | who's here, occupants | Active sessions at a location. Derived from session store. |
+| **presence**     | who's here, occupants | Active sessions at a location. Derived from session store. Queryable via `CoreService.ListFocusPresence`. |
 | **grid present** | online, visible       | Character is visible on the grid (has terminal/telnet conn). |
 | **scene**        | RP scene              | A structured roleplay encounter with participants. |
 

--- a/docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md
+++ b/docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md
@@ -322,6 +322,11 @@ Phase 1 is privacy-leak-neutral but is NOT semantically inert: the §5.1 session
 ## 9. Invariants (RFC2119)
 
 - **I-PRIV-1 (MUST):** A session SHALL NOT be able to read any event from any stream that occurred outside the time interval during which the **requesting session row itself** has existed for that stream's scope (in any of `StatusActive`, `StatusIdle`, or `StatusDetached`-within-TTL). The session row's lifetime — from `SelectCharacter` creation through quit/logout/boot/reaper-deletion — is the unit of session-level continuity; transport-level detach within TTL does NOT bound the window because the row persists and the durable consumer continues to receive events. Per-session enforcement, no cross-session aggregation; other concurrent sessions for the same character maintain independent floors. Exception: an explicit ABAC override grants `read_unrestricted_history` subject to the limited bypass defined in §6.1 (hard-gate location-match only; temporal floor still applies).
+  Current presence (snapshot) is exempt from this floor — see
+  `docs/superpowers/specs/2026-05-19-presence-snapshot-design.md` (I-PRES-2)
+  for the carve-out rationale. The snapshot is a current-state fact, not a
+  historical event, and is privacy-bounded by minimal-field exposure
+  (no `arrived_at_ms`).
 - **I-PRIV-2 (MUST):** Guest sessions SHALL have a temporal floor of `MAX(scope_floor, guest_character.CreatedAt)` applied to all stream history reads.
 - **I-PRIV-3 (MUST):** `Subscribe.ReattachCAS` (transport reattach) AND `SelectCharacter` reattach SHALL leave the session's `LocationArrivedAt` UNCHANGED. The session row's continuity across the disconnect window (Detached → Active within TTL) is the unit of session-level identity; the floor is set at session-create (§5 row 1) and only advances on character-move (§5 row 5). `Subscribe.ReattachCAS` MUST NOT change `DeliverPolicy`, `OptStartTime`, or `OptStartSeq` on the existing durable consumer; `FilterSubjects` MAY change. Privacy enforcement on reattach is performed by the per-subject filter-at-delivery (§6.2 Tier 2) against the unchanged `LocationArrivedAt`.
 - **I-PRIV-4 (MUST NOT):** Idle status change SHALL NOT advance `LocationArrivedAt`. Other active sessions for the same character SHALL NOT be affected by any one session's reattach.

--- a/site/docs/contributing/event-store.md
+++ b/site/docs/contributing/event-store.md
@@ -66,6 +66,17 @@ see the boundary; the cursor is always a ULID.
 
 ---
 
+## Current-state queries
+
+Some UX surfaces need a "snapshot of who/what is here right now" rather
+than a stream of historical events. These bypass `HistoryReader` entirely:
+they hit the relevant store (e.g., session store for presence) and return
+a current-state list. See `CoreService.ListFocusPresence` (`holomush-5b2j`)
+as the canonical example. Snapshots are NOT subject to the I-PRIV-1
+temporal floor — by design they reflect current state, not history.
+
+---
+
 ## Subject naming convention
 
 Subjects follow NATS dot-delimited conventions (spec §1c):


### PR DESCRIPTION
## Summary

Four targeted doc edits that connect T13-T15's `CoreService.ListFocusPresence` implementation and the I-PRES-2 carve-out into the existing rule/spec/doc surfaces. This is **T16** of holomush-5b2j — the final substantive work before T17 (final pr-prep + push) closes the epic.

## Changes

1. **`docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md`** — append a continuation paragraph to the I-PRIV-1 invariant block noting that the presence snapshot is exempt and pointing at `presence-snapshot-design.md` (I-PRES-2). Used **bullet-continuation indent** to match the surrounding §9 invariant style (the plan template's blockquote shape would have been the deviation).

2. **`.claude/rules/terminology.md`** — append `Queryable via \`CoreService.ListFocusPresence\`.` to the `presence` row's third column.

3. **`.claude/rules/event-interfaces.md`** — new `## Current-state RPCs` section with a table mapping `Presence` → `CoreService.ListFocusPresence` → `session.Store.ListActiveByLocation`. Includes guidance: do NOT reach for `HistoryReader.QueryHistory` when the need is current state.

4. **`site/docs/contributing/event-store.md`** — new `## Current-state queries` section pointing at `CoreService.ListFocusPresence` as the canonical non-HistoryReader read path; notes the I-PRIV-1 exemption.

## Reviewer notes

- `code-reviewer` pre-push gate: **READY** with zero findings. Verification confirmed all cited spec paths exist, all invariant IDs are defined at the cited locations, and all RPC / store method names match the implementation (no stale plan-template names).
- Two minor deviations from the plan template: (a) used `task lint:markdown` instead of the plan's `task lint:docs` (the latter doesn't exist); (b) used bullet-continuation indent in the privacy spec rather than blockquote (matches §9 style).

## Test plan

- [x] `task lint:markdown` — green (59 files, 14ms)
- [x] `task pr-prep` — green
- [x] No workspace drift — exactly 4 files modified, all from the planned scope

## Beads

Closes holomush-5b2j.8. **Unblocks holomush-5b2j.18 (T17 — final pr-prep + push)** — the last remaining task in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified current-state query patterns and their separation from event-based flows
  * Updated privacy design documentation with explicit exemptions for current presence snapshots
  * Enhanced development guidance on implementing current-state surfaces
  * Updated terminology definitions for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->