### PR TITLE
feat(core): forward character_id (ULID) in location_state.present[] payload (holomush-e4qo)

### DIFF
--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -88,9 +88,15 @@ type LocationStateExit struct {
 }
 
 // LocationStateChar describes a character present in the current location.
+//
+// CharacterID is the ULID identifying the character; it MUST be populated by
+// the emit site (internal/grpc/location_follow.go) so client-side stores can
+// key by stable identity rather than display name. The wire-format gap that
+// pre-dated this field is documented in bead holomush-e4qo.
 type LocationStateChar struct {
-	Name string `json:"name"`
-	Idle bool   `json:"idle"`
+	CharacterID string `json:"character_id"`
+	Name        string `json:"name"`
+	Idle        bool   `json:"idle"`
 }
 
 // ExitUpdatePayload is the JSON payload for exit_update events, providing a

--- a/internal/grpc/location_follow.go
+++ b/internal/grpc/location_follow.go
@@ -209,8 +209,9 @@ func (lf *locationFollower) buildLocationState(ctx context.Context, locationID u
 			present = make([]core.LocationStateChar, 0, len(sessions))
 			for _, sess := range sessions {
 				present = append(present, core.LocationStateChar{
-					Name: sess.CharacterName,
-					Idle: false,
+					CharacterID: sess.CharacterID.String(),
+					Name:        sess.CharacterName,
+					Idle:        false,
 				})
 			}
 		}

--- a/internal/grpc/location_follow_test.go
+++ b/internal/grpc/location_follow_test.go
@@ -244,6 +244,9 @@ func TestLocationFollower_BuildLocationState(t *testing.T) {
 	assert.Len(t, payload.Exits, 1)
 	assert.Len(t, payload.Present, 1)
 	assert.Equal(t, "Alice", payload.Present[0].Name)
+	// holomush-e4qo: emit site MUST populate CharacterID (ULID) so the web
+	// PresenceStore can key entries by ULID rather than display name.
+	assert.Equal(t, charID.String(), payload.Present[0].CharacterID)
 }
 
 // recordingUpdater captures add/remove stream calls so tests can assert

--- a/internal/web/translate_test.go
+++ b/internal/web/translate_test.go
@@ -240,8 +240,11 @@ func TestTranslateEvent_LocationState(t *testing.T) {
 			{Direction: "east", Name: "Library", Locked: true},
 		},
 		Present: []core.LocationStateChar{
-			{Name: "Alice", Idle: false},
-			{Name: "Bob", Idle: true},
+			// CharacterID is opaque to translate.go (no parsing), so test
+			// fixtures use clearly-fake strings consistent with the surrounding
+			// "loc-123" convention rather than fake-ULID strings.
+			{CharacterID: "char-alice", Name: "Alice", Idle: false},
+			{CharacterID: "char-bob", Name: "Bob", Idle: true},
 		},
 	}
 

--- a/web/src/lib/stores/sidebarStore.ts
+++ b/web/src/lib/stores/sidebarStore.ts
@@ -36,24 +36,19 @@ export function applyLocationState(metadata: Record<string, unknown>) {
   if (loc) location.set(loc);
   const ex = metadata.exits as RoomExit[] | undefined;
   if (ex) exits.set(ex);
-  const pr = metadata.present as Array<{ name?: string; idle?: boolean }> | undefined;
+  const pr = metadata.present as Array<{ character_id?: string; name?: string; idle?: boolean }> | undefined;
   if (pr) {
     // Keep the legacy writable populated for any remaining consumer.
     presence.set(pr.map((c) => ({ name: c.name ?? '', idle: c.idle ?? false })));
     // Seed the new PresenceStore from the location_state snapshot.
-    // CONCERN: location_state.present[] (core.LocationStateChar) carries only
-    // `name` and `idle` — no `characterId` field is emitted by the server.
-    // We use `name` as the characterId key here as a fallback. This means the
-    // store is keyed by display name, not ULID, for location_state-sourced
-    // entries. The authoritative snapshot seeded by webListFocusPresence in
-    // +page.svelte uses ULIDs when available. A follow-up should add
-    // characterId to LocationStateChar on the server side so this path
-    // produces proper ULID keys.
+    // Prefer the server-emitted character_id (ULID); fall back to name only if
+    // it is absent — that's the forward-compat path for events from older
+    // servers. New servers MUST populate character_id (see holomush-e4qo).
     presenceStore.seed(
       pr
         .filter((c) => c.name)
         .map((c) => ({
-          characterId: c.name as string,
+          characterId: c.character_id ?? (c.name as string),
           name: c.name as string,
           state: 'ACTIVE' as const,
         })),


### PR DESCRIPTION
## Summary

Closes the wire-format gap left by holomush-5b2j.14: the web `PresenceStore` (snapshot-based source of truth for the sidebar, introduced in T10) is keyed by `characterId` ULID, but the `location_state` seed path was falling back to display name because `core.LocationStateChar` only carried `name` + `idle`. Result: transient duplicate entries (same character keyed by both `name` and ULID) until the snapshot or live deltas reconciled.

Same wire-format gap pattern as the `actor_id` forward bundled into PR #4144 (5b2j.13) for `GameEvent` — the server has the ULID internally, the payload boundary drops it. **No proto change needed** because `location_state` is JSON inside a Struct payload, not a typed message.

## Changes

**Server:**
- `internal/core/event.go` — add `CharacterID string \`json:"character_id"\`` to `LocationStateChar` (placed first; doc comment explains the wire-format guarantee).
- `internal/grpc/location_follow.go:212` — populate `CharacterID: sess.CharacterID.String()` at the emit site.
- `internal/grpc/location_follow_test.go:248` — lock the new field's emit via `assert.Equal(t, charID.String(), payload.Present[0].CharacterID)`.

**Web:**
- `web/src/lib/stores/sidebarStore.ts:39-60` — read `c.character_id` from each `location_state` entry; fall back to `c.name` only when `character_id` is absent (forward-compat with older servers). Updated the inline CONCERN comment block.

**Test fixtures:**
- `internal/web/translate_test.go:242-247` — added `CharacterID` to the two `LocationStateChar` fixtures. Used opaque `"char-alice"`/`"char-bob"` strings matching the surrounding `ID: "loc-123"` convention rather than fake-ULID strings (the field is opaque string at the translate layer, no parsing happens there).

## Reviewer notes

- `code-reviewer` pre-push gate: **READY** with one Low non-blocking observation (emit-site test wasn't asserting the new field) — addressed inline before push.
- Subagent's initial pass used 27-char fake-ULID strings with Crockford-forbidden letters (`I`,`L`,`O`) in test fixtures — parent corrected to opaque test strings matching the file's existing convention. Same plan-deviation pattern surfaced multiple times during the 5b2j epic.

## Test plan

- [x] `task test -- ./internal/core/ ./internal/grpc/ ./internal/web/` — PASS (621 tests)
- [x] `cd web && pnpm check && pnpm test:unit` — PASS (60/60)
- [x] `task pr-prep` — green (full lane)
- [x] No workspace drift — exactly 5 files changed (1 added test assertion in addition to the 4 originally planned)

## Beads

Closes holomush-e4qo (P2 cleanup, filed during 5b2j epic T11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Character presence tracking now uses unique, stable identifiers instead of display names, improving system reliability and consistency when character display names are updated.
  * Client-side character store now leverages stable identifiers for more accurate presence lookups and tracking.

* **Tests**
  * Enhanced test coverage to validate character identifier handling throughout the location state system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->