### PR TITLE
scene: Phase 4 reviewer NITs cleanup (ww55)

### DIFF
--- a/plugins/core-scenes/audit.go
+++ b/plugins/core-scenes/audit.go
@@ -397,6 +397,26 @@ func (s *SceneAuditServer) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 	// transactionally per T7/INV-P4-10); all other event types route
 	// through plain Insert (existing behaviour).
 	if eventType == "scene_pose" {
+		// scene_pose MUST come from a character actor carrying a full
+		// 16-byte ULID. Earlier code copied actorID into a fixed array
+		// with `copy(posedCharULID[:], actorID)`, which silently zero-
+		// pads short payloads (or truncates long ones); the participant
+		// UPDATE then no-ops by design while total_pose_count still
+		// committed. Reject malformed inputs at ingest so the audit row
+		// never lands in scene_log.
+		if actorKind != eventbusv1.ActorKind_ACTOR_KIND_CHARACTER.String() {
+			return nil, oops.Code("SCENE_AUDIT_INVALID_ACTOR_KIND").
+				With("event_type", eventType).
+				With("actor_kind", actorKind).
+				Errorf("scene_pose requires character actor")
+		}
+		if len(actorID) != 16 {
+			return nil, oops.Code("SCENE_AUDIT_INVALID_ACTOR_ID").
+				With("event_type", eventType).
+				With("actor_id_len", len(actorID)).
+				Errorf("scene_pose requires 16-byte character ULID")
+		}
+
 		sceneID, err := parseSceneSubject(subject)
 		if err != nil {
 			// parseSceneSubject already wraps with SCENE_AUDIT_SUBJECT_INVALID

--- a/plugins/core-scenes/audit_integration_test.go
+++ b/plugins/core-scenes/audit_integration_test.go
@@ -333,7 +333,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 			"total_pose_count MUST NOT be bumped by non-scene_pose events (plain Insert path)")
 	})
 
-	It("returns SCENE_POSE_SUBJECT_PARSE_FAILED on malformed subject for scene_pose", func() {
+	It("rejects scene_pose with malformed subject as SCENE_AUDIT_SUBJECT_INVALID", func() {
 		store := newTestStore()
 		audit := NewSceneAuditStore(store.Pool())
 		srv := &SceneAuditServer{store: audit}
@@ -344,10 +344,92 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 		req := makeAuditRow(eventID, "events.main.bad", "scene_pose", timestamppb.Now(), newPoseULID())
 		_, err := srv.AuditEvent(ctx, req)
 		Expect(err).To(HaveOccurred())
-		// AssertErrorCode returns the DEEPEST oops code. parseSceneSubject
-		// wraps with SCENE_AUDIT_SUBJECT_INVALID; AuditEvent's outer
-		// SCENE_POSE_SUBJECT_PARSE_FAILED is a shallower wrapper and is
-		// not the code errutil.AssertErrorCode observes.
+		// parseSceneSubject is the sole oops wrapper on this path; the
+		// dispatcher returns the parser's error as-is so the deepest
+		// (and only) code is the one we assert.
 		errutil.AssertErrorCode(suiteT, err, "SCENE_AUDIT_SUBJECT_INVALID")
+	})
+
+	It("rejects scene_pose with a non-character actor as SCENE_AUDIT_INVALID_ACTOR_KIND", func() {
+		store := newTestStore()
+		audit := NewSceneAuditStore(store.Pool())
+		srv := &SceneAuditServer{store: audit}
+		ctx := context.Background()
+
+		sceneID := "scene-disp-bad-actor-kind"
+		row := &SceneRow{
+			ID: sceneID, Title: "T", OwnerID: ulid.Make().String(),
+			State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+			Visibility:      string(SceneVisibilityOpen),
+			ContentWarnings: []string{}, Tags: []string{},
+		}
+		Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+		eventID := newPoseULID()
+		subject := "events.main.scene." + sceneID + ".ic"
+		actorID := newPoseULID()
+
+		req := &pluginv1.AuditEventRequest{
+			Row: &pluginv1.AuditRow{
+				Id:        eventID,
+				Subject:   subject,
+				Type:      "scene_pose",
+				Timestamp: timestamppb.Now(),
+				Actor: &eventbusv1.Actor{
+					Kind: eventbusv1.ActorKind_ACTOR_KIND_PLUGIN,
+					Id:   actorID,
+				},
+				Payload:   []byte(`{}`),
+				SchemaVer: 1,
+				Codec:     "identity",
+			},
+		}
+		_, err := srv.AuditEvent(ctx, req)
+		Expect(err).To(HaveOccurred())
+		errutil.AssertErrorCode(suiteT, err, "SCENE_AUDIT_INVALID_ACTOR_KIND")
+
+		// Defense-in-depth: total_pose_count MUST remain at 0 because
+		// the rejected row never reached InsertScenePose.
+		var total int
+		Expect(store.Pool().QueryRow(
+			ctx,
+			`SELECT total_pose_count FROM scenes WHERE id = $1`, sceneID,
+		).Scan(&total)).NotTo(HaveOccurred())
+		Expect(total).To(Equal(0),
+			"total_pose_count MUST stay 0 when scene_pose is rejected for non-character actor")
+	})
+
+	It("rejects scene_pose with a malformed actor ID length as SCENE_AUDIT_INVALID_ACTOR_ID", func() {
+		store := newTestStore()
+		audit := NewSceneAuditStore(store.Pool())
+		srv := &SceneAuditServer{store: audit}
+		ctx := context.Background()
+
+		sceneID := "scene-disp-bad-actor-id"
+		row := &SceneRow{
+			ID: sceneID, Title: "T", OwnerID: ulid.Make().String(),
+			State: string(SceneStateActive), PoseOrder: string(PoseOrderModeFree),
+			Visibility:      string(SceneVisibilityOpen),
+			ContentWarnings: []string{}, Tags: []string{},
+		}
+		Expect(store.CreateWithOwner(ctx, row)).NotTo(HaveOccurred())
+
+		eventID := newPoseULID()
+		subject := "events.main.scene." + sceneID + ".ic"
+		shortActor := []byte{0x01, 0x02, 0x03} // not 16 bytes
+
+		req := makeAuditRow(eventID, subject, "scene_pose", timestamppb.Now(), shortActor)
+		_, err := srv.AuditEvent(ctx, req)
+		Expect(err).To(HaveOccurred())
+		errutil.AssertErrorCode(suiteT, err, "SCENE_AUDIT_INVALID_ACTOR_ID")
+
+		// Defense-in-depth: total_pose_count MUST remain at 0.
+		var total int
+		Expect(store.Pool().QueryRow(
+			ctx,
+			`SELECT total_pose_count FROM scenes WHERE id = $1`, sceneID,
+		).Scan(&total)).NotTo(HaveOccurred())
+		Expect(total).To(Equal(0),
+			"total_pose_count MUST stay 0 when scene_pose is rejected for malformed actor ID")
 	})
 })

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -787,7 +787,13 @@ func renderPoseOrder(sceneID string, resp *scenev1.GetPoseOrderResponse) string 
 				if e.PosesSinceLast != nil {
 					psl = *e.PosesSinceLast
 				}
-				needs := threshold - psl
+				// Guard against future Compute changes that could push
+				// psl >= threshold while still surfacing the entry in
+				// the cooldown bucket; without this, uint32 wraps.
+				var needs uint32
+				if psl < threshold {
+					needs = threshold - psl
+				}
 				fmt.Fprintf(&b, "    %s (needs %d more)\n", poseOrderDisplayName(e), needs)
 			}
 		}

--- a/plugins/core-scenes/poseorder.go
+++ b/plugins/core-scenes/poseorder.go
@@ -147,14 +147,17 @@ func eligibleByThreshold(totalPoseCount uint32, lastPoseSeq *int32, threshold ui
 	if lastPoseSeq == nil {
 		return true
 	}
-	// Guard against negative or unexpectedly-large seq values. The
-	// schema (migration 000006) constrains last_pose_seq <=
-	// total_pose_count, so this branch is defensive.
+	// Guard against negative or unexpectedly-large seq values.
+	// InsertScenePose writes last_pose_seq from the RETURNING value of
+	// the same total_pose_count UPDATE that just bumped the counter,
+	// so the (last_pose_seq <= total_pose_count) relationship holds
+	// at commit time. This branch is defense-in-depth for operator
+	// drift or future writers that don't share that transaction.
 	if *lastPoseSeq < 0 {
 		return true
 	}
 	// Safe conversion: the *lastPoseSeq < 0 guard above ensures the
-	// value fits in uint32 (schema CHECK constraint reinforces this).
+	// value fits in uint32.
 	seq := uint32(*lastPoseSeq)
 	if seq > totalPoseCount {
 		// Logically impossible per schema; treat as never-posed-equivalent.
@@ -174,7 +177,7 @@ func posesSinceLast(totalPoseCount uint32, lastPoseSeq *int32) uint32 {
 		return totalPoseCount
 	}
 	// Safe conversion: the *lastPoseSeq < 0 guard above ensures the
-	// value fits in uint32 (schema CHECK constraint reinforces this).
+	// value fits in uint32.
 	seq := uint32(*lastPoseSeq)
 	if seq > totalPoseCount {
 		return 0

--- a/plugins/core-scenes/service.go
+++ b/plugins/core-scenes/service.go
@@ -923,7 +923,10 @@ func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPos
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to check participant: %v", err)
+		// Do not surface the underlying pgx/wrap text to the client —
+		// it can leak schema/connection detail across the gRPC boundary.
+		// The server-side log above carries the diagnostic.
+		return nil, status.Error(codes.Internal, "participant check failed") //nolint:wrapcheck // gRPC status errors pass through as-is
 	}
 	if !ok {
 		return nil, status.Error(codes.PermissionDenied, "not a participant of scene") //nolint:wrapcheck // gRPC status errors pass through as-is
@@ -948,7 +951,7 @@ func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPos
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to load scene: %v", err)
+		return nil, status.Error(codes.Internal, "scene lookup failed") //nolint:wrapcheck // gRPC status errors pass through as-is
 	}
 
 	poseMeta, err := s.store.ListParticipantsWithPoseMeta(ctx, req.GetSceneId())
@@ -960,7 +963,7 @@ func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPos
 			"scene_id", req.GetSceneId(),
 			"error", err,
 		)
-		return nil, status.Errorf(codes.Internal, "failed to load pose metadata: %v", err)
+		return nil, status.Error(codes.Internal, "pose metadata lookup failed") //nolint:wrapcheck // gRPC status errors pass through as-is
 	}
 
 	// Compute pose order. Names map is nil for Phase 4; Compute


### PR DESCRIPTION
## Summary

Follow-up to PR #4153. Addresses the 6 NITs surfaced by the three pre-push reviewers (crypto, abac, code) — none gated the original Phase 4 push.

**Hardening (load-bearing):**
- `AuditEvent` rejects malformed `scene_pose` at ingest:
  - non-CHARACTER actor → `SCENE_AUDIT_INVALID_ACTOR_KIND`
  - actor ID length ≠ 16 → `SCENE_AUDIT_INVALID_ACTOR_ID`

  Flagged by both crypto-reviewer and code-reviewer. The earlier code zero-padded short actor IDs into a 16-byte ULID; the participant UPDATE then no-oped while `total_pose_count` still committed. PR #4153's autofix gated UPDATEs behind insert `RowsAffected` (preventing redelivery inflation), but a fresh INSERT with malformed actor data could still land a bogus row. This stops it at the ingest boundary.

**Surface tightening:**
- `GetPoseOrder` no longer surfaces underlying pgx/wrap text past the gRPC boundary (3 sites). Diagnostics remain in server-side slog.

**Cosmetics:**
- `poseorder.go`: drop false claim that migration 000006 adds a CHECK constraint; reword as defense-in-depth comment.
- `commands.go::renderPoseOrder` cooldown branch: guard `uint32` underflow when `psl >= threshold`.
- `audit_integration_test.go`: rename subject-parse-failure spec to the deepest-code wording it actually asserts (`SCENE_AUDIT_SUBJECT_INVALID`).

**Out of scope:**
- Item 5 (location stream still colon-style in `scope_floor.go::isLocationStream`) — tracking only; the location-subject migration is a separate initiative (`holomush-rops`).

## Test plan

- [x] `task pr-prep` — full lane green (lint + format + schema + license + unit + integration + 62 E2E)
- [x] 2 new Ginkgo integration specs pinning actor-kind + actor-id-length rejection + defense-in-depth (`total_pose_count` stays at 0 when rejected)

**Bead:** `holomush-ww55`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reject malformed scene pose submissions with invalid actor kind or ID to prevent silent data issues
  * Prevent pose cooldown underflow/wraparound so cooldowns compute correctly
  * Stop internal error details from being exposed in API responses

* **Documentation**
  * Clarified inline documentation around pose-sequence guards and conversions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->