### PR TITLE
fix(access): register LocationProvider in BuildABACStack (g776)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -38,3 +38,28 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   `final_missing_members` in the audit *payload* (chain row), not only in slog.
   Phase 5 sub-epic E correctly captures both in `RekeyAuditPayload.ForceDestroy` /
   `Phases.Phase5FinalMissingMembers` (`internal/eventbus/crypto/dek/rekey_phase7.go:158,161`).
+- **Missing-provider class bug (holomush-g776, 2026-05-21)**: `BuildABACStack`
+  in `internal/access/setup/setup.go` registers providers explicitly per
+  namespace. If a seed's `when` clause references `resource.<ns>.<attr>` and
+  no provider is registered for `<ns>`, the seed silently default-denies in
+  production. Smoke tests at `internal/access/policy/seed_smoke_test.go`
+  use hand-rolled mock providers (`locationProvider`, `streamProvider`)
+  and pass despite the gap — they catch DSL/seed bugs, not wiring bugs.
+  **Always audit `BuildABACStack` provider registrations vs every namespace
+  referenced in `internal/access/policy/seed.go`'s `when` clauses.** Current
+  known gaps after g776 fix: PropertyProvider is NOT registered (6 seeds
+  depend at `seed.go:108-141`; production caller at
+  `internal/world/service.go:1068` silently default-denies). ExitProvider
+  and SceneProvider are also unregistered but happen to be NoOp because
+  their seeds are target-only (no `when` clause).
+- **Wildcard resource IDs (`type:*`) bypass per-instance attrs**:
+  `service.CreateLocation` / `service.FindLocationByName` /
+  `service.CreateExit` / `service.CreateObject` all call `checkAccess`
+  with `access.LocationResource("*")` etc. (`service.go:209,319,449,1033`).
+  Engine matches these against seeds via `target.ResourceType`
+  (`engine.go:401-405`, `parseEntityType("location:*") == "location"`), NOT
+  via `when`-clause pattern matching. Providers MUST tolerate non-ULID IDs
+  by returning `(nil, nil)` for wildcards — raising a parse error
+  fail-closes the entire bootstrap chain. See
+  `internal/access/policy/attribute/location.go:54-62` for the canonical
+  shape (line-scoped `//nolint:nilerr` with rationale).

--- a/internal/access/policy/attribute/location.go
+++ b/internal/access/policy/attribute/location.go
@@ -34,6 +34,21 @@ func (p *LocationProvider) ResolveSubject(_ context.Context, _ string) (map[stri
 }
 
 // ResolveResource resolves location attributes for a resource.
+// Returns (nil, nil) for non-location entity types AND for non-ULID IDs.
+//
+// The canonical non-ULID case is "location:*" — the literal wildcard the
+// bootstrap chain emits for type-level capability checks (CreateLocation,
+// FindLocationByName). Such checks select seeds via DSL `resource is
+// location` (target-type match in engine.findApplicablePolicies, NOT a
+// `when`-clause pattern), so they do NOT need per-instance attributes.
+// Returning the parse error here would fail-closed the entire bootstrap
+// chain (observed in holomush-g776 once this provider was first wired).
+//
+// CAVEAT: if a future seed adds a `when` clause that compares
+// `resource.location.X` and is expected to match the wildcard path, the
+// provider MUST populate sentinel values for X (or the seed MUST narrow
+// its target via `resource ==`). The bypass below is a target-type-match
+// concession, not a generic wildcard facility.
 func (p *LocationProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
 	parts := strings.SplitN(resourceID, ":", 2)
 	if len(parts) != 2 {
@@ -47,7 +62,12 @@ func (p *LocationProvider) ResolveResource(ctx context.Context, resourceID strin
 
 	id, err := ulid.Parse(idStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid location ID: %w", err)
+		// Non-ULID location reference (e.g., "location:*" wildcard from
+		// bootstrap permission grants). Skip attribute resolution; the
+		// engine evaluates wildcard patterns without per-instance attrs.
+		// Returning the parse error here would fail-closed the entire
+		// bootstrap chain (observed in holomush-g776).
+		return nil, nil //nolint:nilerr // wildcard refs intentionally bypass provider; documented above
 	}
 
 	loc, err := p.repo.Get(ctx, id)

--- a/internal/access/policy/attribute/location_test.go
+++ b/internal/access/policy/attribute/location_test.go
@@ -203,11 +203,30 @@ func TestLocationProvider_ResolveResource(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:           "invalid ULID format",
-			resourceID:     "location:not-a-ulid",
-			setupMock:      func(_ *mockLocationRepository) {},
-			expectError:    true,
-			errorSubstring: "invalid location ID",
+			// Per holomush-g776: non-ULID location refs (the canonical
+			// case is "location:*" wildcard from bootstrap permission
+			// grants) MUST be skipped gracefully — returning the parse
+			// error here would fail-closed the bootstrap chain because
+			// the resolver propagates the error and the engine evaluates
+			// fail-closed. The wildcard pattern matching is handled at
+			// the engine layer without per-instance attributes, so the
+			// provider's job is to politely decline.
+			name:        "invalid ULID format — bypass (holomush-g776)",
+			resourceID:  "location:not-a-ulid",
+			setupMock:   func(_ *mockLocationRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			// Companion to the case above — the literal wildcard form
+			// the bootstrap actually emits when granting "write any
+			// location" capability. Same expectation: provider declines,
+			// engine handles the pattern.
+			name:        "wildcard ID — bypass (holomush-g776)",
+			resourceID:  "location:*",
+			setupMock:   func(_ *mockLocationRepository) {},
+			expectNil:   true,
+			expectError: false,
 		},
 		{
 			name:           "missing colon separator",

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -59,8 +59,14 @@ func (s *ABACStack) Close() error {
 type ABACConfig struct {
 	Pool          *pgxpool.Pool
 	CharacterRepo world.CharacterRepository
-	RoleStore     store.RoleStore
-	AuditMode     audit.Mode
+	// LocationRepo is required for any seed that compares
+	// `resource.location.X` (e.g., seed:player-location-list-presence,
+	// seed:player-location-read). Without it the LocationProvider
+	// is not registered, no provider populates `resource.location.*`, and
+	// every such seed silently default-denies. Per holomush-g776.
+	LocationRepo world.LocationRepository
+	RoleStore    store.RoleStore
+	AuditMode    audit.Mode
 	// CryptoOperators is the list of player IDs (ULIDs) holding the
 	// crypto.operator capability. Passed to PlayerAttributeProvider at
 	// construction. Empty / nil → no operators (break-glass disabled).
@@ -107,6 +113,33 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 		if err := resolver.RegisterProvider(charProvider); err != nil {
 			return nil, eb.Wrapf(err, "register character provider")
 		}
+	}
+
+	// 8b. Location provider (optional in signature, but required in practice
+	// for any seed referencing resource.location.*). Holds the
+	// LocationRepository the provider uses to fetch loc.ID/Name/Type/... for
+	// ABAC evaluation. Without this, three seeds silently default-deny:
+	// seed:player-location-read, seed:player-location-list-characters,
+	// seed:player-location-list-presence — because `resource.location.id` is
+	// never populated in the resource bag (only the un-namespaced `id`
+	// injected by the resolver). Per holomush-g776.
+	//
+	// The optional shape is preserved for tests and alternate entrypoints
+	// that don't need location-resource policies. Production wiring at
+	// internal/access/setup/subsystem.go ALWAYS supplies the repo. Emit a
+	// loud WARN at construction time when it's missing so any future
+	// caller that drops the repo gets a recurrence signal — the original
+	// g776 bug was silent at startup and only manifested via e2e symptoms.
+	if cfg.LocationRepo != nil {
+		locProvider := attribute.NewLocationProvider(cfg.LocationRepo)
+		if err := resolver.RegisterProvider(locProvider); err != nil {
+			return nil, eb.Wrapf(err, "register location provider")
+		}
+	} else {
+		slog.WarnContext(ctx,
+			"ABAC setup: LocationRepo not provided — seeds referencing resource.location.* will silently default-deny",
+			"affected_seeds", "seed:player-location-read, seed:player-location-list-characters, seed:player-location-list-presence",
+			"reference", "holomush-g776")
 	}
 
 	// 8a. Player provider (subject namespace; resolves player.id and

--- a/internal/access/setup/setup_player_test.go
+++ b/internal/access/setup/setup_player_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/setup"
+	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
 	"github.com/holomush/holomush/test/testutil"
 )
 
@@ -33,6 +34,12 @@ func freshABACStack(t *testing.T, operators []string) (*setup.ABACStack, func())
 	stack, err := setup.BuildABACStack(ctx, setup.ABACConfig{
 		Pool:            pool,
 		CharacterRepo:   nil, // optional per setup.go
+		// LocationRepo wired so the build does NOT emit the missing-provider
+		// WARN (holomush-g776). The PlayerProvider tests don't exercise the
+		// location seeds, but the production wiring always supplies the
+		// repo — mirror it here to keep test logs clean and to model the
+		// production shape that catches future g776-class regressions.
+		LocationRepo:    worldpostgres.NewLocationRepository(pool),
 		RoleStore:       nil,
 		CryptoOperators: operators,
 	})

--- a/internal/access/setup/subsystem.go
+++ b/internal/access/setup/subsystem.go
@@ -79,6 +79,7 @@ func (s *ABACSubsystem) Start(ctx context.Context) error {
 	stack, err := BuildABACStack(ctx, ABACConfig{
 		Pool:            pool,
 		CharacterRepo:   postgres.NewCharacterRepository(pool),
+		LocationRepo:    postgres.NewLocationRepository(pool),
 		RoleStore:       roleStore,
 		AuditMode:       s.cfg.AuditMode,
 		CryptoOperators: s.cfg.CryptoOperators,

--- a/test/integration/presence/presence_test.go
+++ b/test/integration/presence/presence_test.go
@@ -157,6 +157,90 @@ var _ = Describe("AC3 / I-PRES-2: snapshot bypasses I-PRIV-1 temporal floor", fu
 	})
 })
 
+// holomush-g776: snapshot scale coverage. Creates N prior guest sessions at
+// the spawn location, then a fresh session, and asserts the snapshot returns
+// ALL N+1 entries. Locks dedup behavior, name resolution at scale, and
+// ListActiveByLocation completeness as the active-session count grows.
+//
+// NOTE: this test runs against `privacytest.allowAllPolicyEngine` (the harness
+// default), so it does NOT exercise the real ABAC stack. The g776 root cause
+// (LocationProvider missing from production wiring in
+// internal/access/setup/setup.go) is regression-locked by the un-fixme'd e2e
+// test at web/e2e/terminal.spec.ts:136, which runs against the real
+// BuildABACStack via the docker-compose stack. The narrow gap — "no
+// integration test exercises BuildABACStack end-to-end for snapshot" —
+// remains an open follow-up; see g776 close notes.
+var _ = Describe("AC4 scale: snapshot returns all active sessions under accumulated state", func() {
+	var (
+		ts        *privacytest.Server
+		ctx       context.Context
+		priorSess []*privacytest.Session
+		fresh     *privacytest.Session
+	)
+
+	const priorCount = 20
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 120*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = privacytest.Start(suiteT)
+		priorSess = make([]*privacytest.Session, 0, priorCount)
+		// Build up prior sessions sequentially so they land at the same spawn
+		// location with monotonically advancing LocationArrivedAt values —
+		// matches what accumulates across the e2e suite.
+		for i := 0; i < priorCount; i++ {
+			s := ts.ConnectGuest(ctx)
+			priorSess = append(priorSess, s)
+		}
+		// Fresh session joins LAST — its snapshot must surface all priorSess
+		// plus self.
+		fresh = ts.ConnectGuest(ctx)
+	})
+
+	AfterEach(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if fresh != nil {
+			fresh.Logout(cleanupCtx)
+		}
+		for _, s := range priorSess {
+			if s != nil {
+				s.Logout(cleanupCtx)
+			}
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("fresh.ListFocusPresence surfaces all priorCount+1 active sessions", func() {
+		// Sanity: all priors share fresh's location.
+		for i, p := range priorSess {
+			Expect(p.LocationID).To(Equal(fresh.LocationID),
+				"precondition: prior session %d MUST share fresh's location", i)
+		}
+
+		Eventually(func(g Gomega) {
+			resp, err := fresh.ListFocusPresence(ctx)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"ListFocusPresence MUST succeed for fresh session")
+			g.Expect(resp).NotTo(BeNil())
+			g.Expect(resp.GetEntries()).To(HaveLen(priorCount+1),
+				"snapshot MUST include all %d prior sessions PLUS fresh (g776 repro)", priorCount)
+
+			// Fresh session's own character MUST be present (I-PRES-6).
+			names := entryNames(resp.GetEntries())
+			g.Expect(names).To(ContainElement(fresh.CharacterName),
+				"I-PRES-6: caller's own session MUST be in the response")
+
+			// Each prior MUST be present too — no silent drops.
+			for i, p := range priorSess {
+				g.Expect(names).To(ContainElement(p.CharacterName),
+					"prior session %d (%s) MUST appear in fresh's snapshot", i, p.CharacterName)
+			}
+		}, time.Second, 50*time.Millisecond).Should(Succeed())
+	})
+})
+
 // entryNames extracts character names from PresenceEntry slice for ConsistOf
 // matching. Mirrors the plan template's entryNames helper.
 func entryNames(entries []*corev1.PresenceEntry) []string {

--- a/web/e2e/terminal.spec.ts
+++ b/web/e2e/terminal.spec.ts
@@ -133,15 +133,7 @@ test.describe('Terminal UI', () => {
     await expect(page.locator('button[title="Toggle sidebar"]')).toBeVisible();
   });
 
-  // Skipped under iwzt.15: this test fails deterministically under full
-  // pr-prep e2e runs once the Tier 2 filter is active (5 runs investigated,
-  // 4 with identical 'count=2 with stale character names from prior tests'
-  // shape; isolated runs pass). Root cause is a pre-existing
-  // snapshot/backfill/presence-update race in +page.svelte:386-451 that
-  // accumulates state from prior tests' guest sessions. Tier 2 filter
-  // timing exposes it. Tracked as P0 holomush-g776. Re-enable from
-  // test.fixme back to test() once g776 lands.
-  test.fixme('presence list shows self and other connections', async ({ browser }) => {
+  test('presence list shows self and other connections', async ({ browser }) => {
     // Two independent browser contexts (separate sessions)
     const context1 = await browser.newContext();
     const context2 = await browser.newContext();


### PR DESCRIPTION
## Summary

Fixes **holomush-g776**: production-only ABAC default-deny on every character action that uses one of three location-targeted seeds.

`internal/access/setup/setup.go::BuildABACStack` did NOT register `LocationProvider`. Three seed policies reference `resource.location.*`:

- `seed:player-location-read` (seed.go:42)
- `seed:player-location-list-characters` (seed.go:162)
- `seed:player-location-list-presence` (seed.go:169)

Without the provider, `resource.location.id` is never populated in the resource bag → the seeds' `when` conditions never match → default deny on every call. The bug shipped with the 5b2j epic.

## Why it wasn't caught

`internal/testsupport/privacytest/privacy_harness.go:481-494` wires `allowAllPolicyEngine`. **Every** AC4 / I-PRES integration test passes the snapshot path without exercising the real seeded ABAC engine. The misdiagnosis during iwzt.15 PR landing — "snapshot/backfill timing race" → `test.fixme()` — was wrong; the real cause is wiring.

## What changed

| File | Change |
| ---- | ------ |
| `internal/access/setup/setup.go` | Added `LocationRepo` to `ABACConfig`; registers `LocationProvider` when supplied; loud WARN at construction when missing |
| `internal/access/setup/subsystem.go` | Passes `postgres.NewLocationRepository(pool)` from the production wiring |
| `internal/access/policy/attribute/location.go` | `ResolveResource` returns `(nil, nil)` for non-ULID location IDs (e.g., `location:*` wildcard from bootstrap). Otherwise the bootstrap fail-closes |
| `internal/access/policy/attribute/location_test.go` | Wildcard-bypass test + updated invalid-ULID case |
| `internal/access/setup/setup_player_test.go` | Wires `LocationRepo` to suppress the new WARN in integration tests |
| `test/integration/presence/presence_test.go` | N=20 snapshot scale test (does NOT regression-lock g776 — comment is explicit) |
| `web/e2e/terminal.spec.ts:136` | **Un-fixme'd** the presence test (was suppressed in iwzt.15 PR) — this is the actual regression lock |

## Wildcard bypass rationale

`internal/access/policy/engine.go::findApplicablePolicies` matches via `target.ResourceType` (parsed entity-type prefix), not via `when`-clause attribute pattern matching. So `location:*` is selected by all `resource is location` seeds without needing per-instance attributes. The fix is safe — verified by abac-reviewer.

## Follow-up filed

- **holomush-xxel (P1)**: `PropertyProvider` is also missing from `BuildABACStack` → 6 property seeds silently default-deny. Same class of bug. Includes folding in the `CharacterProvider` parallel pattern (dormant — no production call emits `character:*` today).

## Review

- **abac-reviewer**: READY (3 non-blocking, all addressed or filed)
- **code-reviewer**: READY (5 non-blocking, all addressed or filed)
- `task pr-prep` full lane: **GREEN**, including 62 e2e tests with the un-fixme'd presence test passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed location-based access control policies that were silently denying access when using wildcard resource identifiers.
  * Improved attribute resolution to properly handle non-standard wildcard references in permission grants.

* **Tests**
  * Added integration test verifying presence list accuracy across multiple concurrent sessions.
  * Reactivated e2e test for presence list display with multiple connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->