### PR TITLE
fix(access): seed-coverage validator + CharacterProvider hardening (xxel)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -52,6 +52,16 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   `internal/world/service.go:1068` silently default-denies). ExitProvider
   and SceneProvider are also unregistered but happen to be NoOp because
   their seeds are target-only (no `when` clause).
+- **xxel coverage-validator scope (2026-05-21)**: `warnOnMissingSeedCoverage`
+  (`internal/access/setup/seed_coverage.go`) regex-scans `policy.SeedPolicies()`
+  for `(principal|resource).<ns>.<attr>` and WARNs per unregistered namespace.
+  Two structural gaps to remember on future reviews: (1) `productionRegistered`
+  in `seed_coverage_test.go:132` is a hardcoded mirror, not live introspection
+  of `BuildABACStack` — a refactor dropping a provider passes the test but
+  fires the runtime WARN; (2) plugin-installed policies (via
+  `PolicyInstaller.InstallPluginPolicies`) are NOT scanned — same silent-deny
+  class can recur for plugin-declared namespaces. Symmetric stale-entry
+  direction IS asserted at `seed_coverage_test.go:154-160`.
 - **Wildcard resource IDs (`type:*`) bypass per-instance attrs**:
   `service.CreateLocation` / `service.FindLocationByName` /
   `service.CreateExit` / `service.CreateObject` all call `checkAccess`

--- a/internal/access/policy/attribute/character.go
+++ b/internal/access/policy/attribute/character.go
@@ -81,14 +81,16 @@ func (p *CharacterProvider) resolve(ctx context.Context, entityID string) (map[s
 		return nil, nil
 	}
 
-	// Parse ULID
+	// Parse ULID. Non-ULID IDs are the canonical wildcard form (e.g.,
+	// "character:*") used by capability-grant checks; return (nil, nil) so
+	// the resolver does not fail-closed the engine — symmetric with
+	// LocationProvider's tolerance from holomush-g776. No production call
+	// emits "character:*" today (dormant); this is defense-in-depth so a
+	// future capability check that mirrors CreateLocation's wildcard
+	// pattern doesn't re-introduce the same fail-closed bug.
 	id, err := ulid.Parse(idStr)
 	if err != nil {
-		return nil, oops.
-			Code("INVALID_CHARACTER_ID").
-			With("entity_id", entityID).
-			With("id_part", idStr).
-			Wrapf(err, "invalid character ID")
+		return nil, nil //nolint:nilerr // wildcard refs intentionally bypass provider; documented above (holomush-xxel)
 	}
 
 	// Fetch character from repository

--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -175,11 +175,27 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:           "invalid ULID format",
-			subjectID:      "character:not-a-ulid",
-			setupMock:      func(_ *mockCharacterRepository) {},
-			expectError:    true,
-			errorSubstring: "invalid character ID",
+			// Per holomush-xxel: non-ULID character refs (canonical case is
+			// "character:*" wildcard) MUST be skipped gracefully — symmetric
+			// with LocationProvider's tolerance from g776. Returning the
+			// parse error here would fail-closed the engine for any future
+			// capability check that emits the wildcard form.
+			name:        "invalid ULID format — bypass (holomush-xxel)",
+			subjectID:   "character:not-a-ulid",
+			setupMock:   func(_ *mockCharacterRepository) {},
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			// Companion to the case above — literal wildcard form a future
+			// capability-grant check would emit. Same expectation: provider
+			// politely declines, engine handles the pattern at the target
+			// layer.
+			name:        "wildcard ID — bypass (holomush-xxel)",
+			subjectID:   "character:*",
+			setupMock:   func(_ *mockCharacterRepository) {},
+			expectNil:   true,
+			expectError: false,
 		},
 		{
 			name:           "missing colon separator",

--- a/internal/access/policy/attribute/resolver.go
+++ b/internal/access/policy/attribute/resolver.go
@@ -117,6 +117,21 @@ func (r *Resolver) UnregisterProvider(namespace string) bool {
 	return true
 }
 
+// RegisteredNamespaces returns the namespaces registered by RegisterProvider,
+// in registration order. The returned slice is a defensive copy — caller may
+// modify it freely. Environment-provider namespaces are NOT included; use
+// RegisteredEnvironmentNamespaces for those.
+//
+// Used by internal/access/setup.warnOnMissingSeedCoverage (holomush-xxel) to
+// validate that every namespace referenced by seed-policy DSL has a
+// registered provider — without this introspection seam, a typo or missed
+// wire silently default-denies every check against the affected seeds.
+func (r *Resolver) RegisteredNamespaces() []string {
+	out := make([]string, len(r.providerOrder))
+	copy(out, r.providerOrder)
+	return out
+}
+
 // RegisterEnvironmentProvider registers an environment provider
 func (r *Resolver) RegisterEnvironmentProvider(provider EnvironmentProvider) error {
 	namespace := provider.Namespace()

--- a/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
+++ b/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package setup
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy"
+	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+// TestBuildABACStack_SeedCoverageMatchesAcknowledged is the DRIFT DETECTOR
+// for holomush-xxel: it builds the REAL BuildABACStack against a fresh
+// Postgres pool and asserts that the registered providers leave EXACTLY the
+// set of namespaces in setup.AcknowledgedMissingSeedNamespaces uncovered —
+// no more (a NEW seed gap snuck in), no fewer (a tracked gap was fixed but
+// the acknowledgment wasn't removed).
+//
+// Why this matters: the companion unit test
+// (TestValidateSeedProviderCoverage_ProductionCorpusIsCovered) takes a
+// hardcoded mirror of "what BuildABACStack registers." If a future refactor
+// drops a provider registration from BuildABACStack, the hardcoded mirror
+// still claims the namespace is registered and the unit test still passes
+// — re-introducing the g776/xxel bug class with no signal. This integration
+// test eliminates that drift by introspecting the actual stack.
+//
+// Per abac-reviewer finding #1 on holomush-xxel.
+func TestBuildABACStack_SeedCoverageMatchesAcknowledged(t *testing.T) {
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	stack, err := BuildABACStack(ctx, ABACConfig{
+		Pool:          pool,
+		CharacterRepo: worldpostgres.NewCharacterRepository(pool),
+		LocationRepo:  worldpostgres.NewLocationRepository(pool),
+		// RoleStore intentionally nil; CryptoOperators intentionally empty —
+		// production wiring at subsystem.go always passes these too, but the
+		// presence/absence does not affect provider registration coverage.
+	})
+	require.NoError(t, err, "BuildABACStack MUST succeed with the production-shape ABACConfig")
+	t.Cleanup(func() { _ = stack.Close() })
+
+	registered := stack.Resolver.RegisteredNamespaces()
+	t.Logf("BuildABACStack registered namespaces: %v", registered)
+
+	// Compute which seed-corpus namespaces are NOT covered by the actually-
+	// registered providers, then verify it equals the acknowledged set.
+	missing := validateSeedProviderCoverage(registered, policy.SeedPolicies())
+	actualMissing := sortedKeysOf(missing)
+
+	expectedMissing := make([]string, 0, len(AcknowledgedMissingSeedNamespaces))
+	for ns := range AcknowledgedMissingSeedNamespaces {
+		expectedMissing = append(expectedMissing, ns)
+	}
+	sort.Strings(expectedMissing)
+
+	assert.ElementsMatch(t, expectedMissing, actualMissing,
+		"DRIFT: BuildABACStack's actual provider registrations + the live seed corpus "+
+			"produce a missing-namespace set that does NOT match "+
+			"setup.AcknowledgedMissingSeedNamespaces. "+
+			"Either (a) a provider was dropped from BuildABACStack — restore it, or "+
+			"(b) a new gap appeared — file a follow-up bead and add it to "+
+			"AcknowledgedMissingSeedNamespaces, or (c) a tracked gap was fixed — "+
+			"remove it from AcknowledgedMissingSeedNamespaces. Per holomush-xxel.")
+}
+
+func sortedKeysOf(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/access/setup/seed_coverage.go
+++ b/internal/access/setup/seed_coverage.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package setup
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"sort"
+
+	"github.com/holomush/holomush/internal/access/policy"
+)
+
+// seedNamespaceRefPattern matches `(principal|resource).<namespace>.<attr>`
+// references in seed policy DSL text. The first capture group is "principal"
+// or "resource"; the second is the namespace name. Top-level refs like
+// `principal.id` or `resource.id` (no trailing `.<attr>`) are intentionally
+// NOT matched — they are injected directly by the resolver and need no
+// provider (resolver.go:182-184, 197-199).
+var seedNamespaceRefPattern = regexp.MustCompile(`\b(principal|resource)\.([a-z_]+)\.[a-z_]+`)
+
+// validateSeedProviderCoverage walks the SEED CORPUS and identifies any
+// `(principal|resource).<ns>.<attr>` references whose namespace is not in the
+// set of registered providers. Returns the missing-namespace → affected-seed
+// names map (sorted for stable output).
+//
+// Scope: this validator covers ONLY policies returned by
+// `policy.SeedPolicies()` (the host-installed defaults). Plugin-installed
+// policies are loaded later via the plugin manager's PolicyInstaller and
+// are NOT scanned here — a plugin manifest that gates on `resource.kv.X`
+// while no `kv` provider exists hits the SAME silent default-deny class
+// this validator was written to surface, but it would not be caught.
+// Plugin-policy validation is a separate concern; tracked as a follow-up.
+//
+// This catches the holomush-g776 / holomush-xxel bug class at construction
+// time: when a seed gates on `resource.location.id` but no provider for the
+// "location" namespace is registered, the attribute is never populated, and
+// every check against that seed silently default-denies. The validator
+// surfaces the gap loudly at startup instead of waiting for an e2e symptom.
+//
+// Returns an empty map when coverage is complete.
+func validateSeedProviderCoverage(registered []string, seeds []policy.SeedPolicy) map[string][]string {
+	registeredSet := make(map[string]struct{}, len(registered))
+	for _, ns := range registered {
+		registeredSet[ns] = struct{}{}
+	}
+
+	// namespace → set of seed names that reference it
+	missing := make(map[string]map[string]struct{})
+	for _, seed := range seeds {
+		for _, match := range seedNamespaceRefPattern.FindAllStringSubmatch(seed.DSLText, -1) {
+			// match[1] = "principal" | "resource"; match[2] = namespace name
+			namespace := match[2]
+			if _, ok := registeredSet[namespace]; ok {
+				continue
+			}
+			if missing[namespace] == nil {
+				missing[namespace] = make(map[string]struct{})
+			}
+			missing[namespace][seed.Name] = struct{}{}
+		}
+	}
+
+	out := make(map[string][]string, len(missing))
+	for ns, seedSet := range missing {
+		names := make([]string, 0, len(seedSet))
+		for n := range seedSet {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		out[ns] = names
+	}
+	return out
+}
+
+// warnOnMissingSeedCoverage logs one WARN per uncovered namespace, naming the
+// seeds affected. Non-fatal by design — the original holomush-g776 bug shipped
+// because the gap was silent at startup; this surfaces it loudly while keeping
+// production resilient if a build accidentally omits a provider. A future
+// hardening pass MAY upgrade to fail-closed once the seed corpus is stable and
+// the test gap (privacytest harness bypasses real ABAC) is closed.
+func warnOnMissingSeedCoverage(ctx context.Context, registered []string, seeds []policy.SeedPolicy) {
+	missing := validateSeedProviderCoverage(registered, seeds)
+	for _, namespace := range sortedKeys(missing) {
+		slog.WarnContext(ctx,
+			"ABAC setup: seed coverage gap — namespace referenced by seeds but no provider registered (all such seeds silently default-deny)",
+			"namespace", namespace,
+			"affected_seeds", missing[namespace],
+			"reference", "holomush-xxel")
+	}
+}
+
+// sortedKeys returns the keys of m sorted lexicographically. Used to make
+// WARN output deterministic for log-analysis tooling.
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/access/setup/seed_coverage_test.go
+++ b/internal/access/setup/seed_coverage_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package setup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/access/policy"
+)
+
+// TestValidateSeedProviderCoverage_AllRegistered pins the green path: when
+// every namespace referenced by the DSL has a registered provider, the
+// missing-set is empty.
+func TestValidateSeedProviderCoverage_AllRegistered(t *testing.T) {
+	t.Parallel()
+	seeds := []policy.SeedPolicy{
+		{
+			Name:    "test:location-read",
+			DSLText: `permit(principal is character, action in ["read"], resource is location) when { resource.location.id == principal.character.location };`,
+		},
+	}
+	registered := []string{"character", "location"}
+
+	missing := validateSeedProviderCoverage(registered, seeds)
+	assert.Empty(t, missing,
+		"all referenced namespaces are registered; missing set MUST be empty")
+}
+
+// TestValidateSeedProviderCoverage_MissingNamespace is the holomush-g776
+// regression case: a seed gates on resource.location.id but LocationProvider
+// is not registered. The validator MUST surface this gap with the affected
+// seed names — without this surfacing, the bug stays silent at startup and
+// only manifests via e2e symptoms (as g776 did for 6+ weeks).
+func TestValidateSeedProviderCoverage_MissingNamespace(t *testing.T) {
+	t.Parallel()
+	seeds := []policy.SeedPolicy{
+		{
+			Name:    "seed:player-location-read",
+			DSLText: `permit(principal is character, action in ["read"], resource is location) when { resource.location.id == principal.character.location };`,
+		},
+		{
+			Name:    "seed:player-location-list-presence",
+			DSLText: `permit(principal is character, action in ["list_presence"], resource is location) when { resource.location.id == principal.character.location };`,
+		},
+		{
+			Name:    "seed:unaffected",
+			DSLText: `permit(principal is character, action in ["read"], resource is character) when { resource.character.id == principal.character.id };`,
+		},
+	}
+	// CharacterProvider is registered, LocationProvider is NOT (the g776 bug).
+	registered := []string{"character"}
+
+	missing := validateSeedProviderCoverage(registered, seeds)
+	assert.Len(t, missing, 1,
+		"only the location namespace is missing; character is registered")
+	assert.ElementsMatch(t, []string{
+		"seed:player-location-read",
+		"seed:player-location-list-presence",
+	}, missing["location"],
+		"both affected seeds MUST appear in the missing-namespace's seed list")
+}
+
+// TestValidateSeedProviderCoverage_PrincipalReferenceCounts asserts that
+// principal.<ns>.<attr> references count for coverage the same as resource
+// references. PlayerProvider is the canonical case: principal.player.grants
+// is the only access path to the player namespace from a seed condition.
+func TestValidateSeedProviderCoverage_PrincipalReferenceCounts(t *testing.T) {
+	t.Parallel()
+	seeds := []policy.SeedPolicy{
+		{
+			Name:    "test:player-grants",
+			DSLText: `permit(principal is player, action in ["totp_initialize"], resource is character) when { "crypto.operator" in principal.player.grants };`,
+		},
+	}
+	// PlayerProvider not registered — should surface even though the
+	// reference is on the principal (subject) side, not resource.
+	registered := []string{"character"}
+
+	missing := validateSeedProviderCoverage(registered, seeds)
+	assert.Contains(t, missing, "player",
+		"missing-set MUST include namespaces referenced via principal.X.Y, not just resource.X.Y")
+	assert.Equal(t, []string{"test:player-grants"}, missing["player"])
+}
+
+// TestValidateSeedProviderCoverage_TopLevelIDsNotFlagged asserts that
+// `principal.id` and `resource.id` (no namespace, injected directly by the
+// resolver at resolver.go:182-184, 197-199) are NOT misidentified as missing
+// namespace references. The regex requires a `.<attr>` after the namespace
+// segment, which `principal.id` lacks.
+func TestValidateSeedProviderCoverage_TopLevelIDsNotFlagged(t *testing.T) {
+	t.Parallel()
+	seeds := []policy.SeedPolicy{
+		{
+			Name:    "test:self",
+			DSLText: `permit(principal is character, action in ["read"], resource is character) when { resource.id == principal.id };`,
+		},
+	}
+	registered := []string{"character"}
+
+	missing := validateSeedProviderCoverage(registered, seeds)
+	assert.Empty(t, missing,
+		"top-level `principal.id` / `resource.id` MUST NOT be flagged as missing — they are injected by the resolver, no provider needed")
+}
+
+// AcknowledgedMissingSeedNamespaces lists production-seed namespaces that
+// have NO registered provider today, each tied to a tracking bead. When a
+// bead closes (provider wired or seed removed), REMOVE the entry here AND
+// verify the validator's runtime WARN no longer fires at server boot.
+//
+// EXPORTED so an integration test exercising the REAL BuildABACStack can
+// share this list with the seed-corpus regression below — the alternative
+// (hardcoded mirror of "what BuildABACStack registers") suffers silent
+// drift if a future refactor drops a registration. Per abac-reviewer
+// finding on holomush-xxel.
+var AcknowledgedMissingSeedNamespaces = map[string]string{
+	"property": "holomush-72ou", // PropertyProvider design pass: resource format mismatch
+	"object":   "holomush-k3ud", // ObjectProvider type does not exist yet
+}
+
+// TestValidateSeedProviderCoverage_ProductionCorpusIsCovered is the
+// load-bearing regression lock at the UNIT level: it verifies the validator
+// CORRECTLY identifies the known-missing namespaces (property, object) for
+// the production seed corpus. The companion integration test
+// TestBuildABACStack_SeedCoverageMatchesAcknowledged
+// (internal/access/setup/buildabacstack_seed_coverage_integ_test.go) is the
+// drift-detector: it builds the REAL BuildABACStack and asserts its actual
+// registered namespaces leave EXACTLY the acknowledged-missing set
+// uncovered. The unit + integration pair together close the gap that a
+// hardcoded mirror leaves open.
+//
+// If this test fails: (a) a NEW namespace appeared in seeds → add the
+// provider to BuildABACStack and to (or remove from) AcknowledgedMissing
+// above, or (b) you intentionally deleted a seed → remove its namespace
+// from AcknowledgedMissing if no other seed needs that namespace.
+func TestValidateSeedProviderCoverage_ProductionCorpusIsCovered(t *testing.T) {
+	t.Parallel()
+	// productionRegistered MUST stay in sync with BuildABACStack's actual
+	// registrations. The integration test asserts no drift.
+	productionRegistered := []string{
+		"character", "location", "player", "command", "stream", "plugin",
+	}
+
+	missing := validateSeedProviderCoverage(productionRegistered, policy.SeedPolicies())
+
+	for ns := range missing {
+		bead, known := AcknowledgedMissingSeedNamespaces[ns]
+		assert.True(t, known,
+			"NEW namespace %q referenced by seeds but no provider registered. "+
+				"Either add the provider to internal/access/setup/setup.go::BuildABACStack, "+
+				"or file a follow-up bead and add `%q: \"holomush-<id>\"` to "+
+				"AcknowledgedMissingSeedNamespaces in this file. Per holomush-xxel.",
+			ns, ns)
+		t.Logf("seed-coverage gap acknowledged for namespace %q: tracked by %s; seeds: %v",
+			ns, bead, missing[ns])
+	}
+	for ns, bead := range AcknowledgedMissingSeedNamespaces {
+		if _, stillMissing := missing[ns]; !stillMissing {
+			t.Errorf("namespace %q is in AcknowledgedMissingSeedNamespaces (bead %s) but "+
+				"is no longer flagged by the validator. If %s landed, REMOVE it from "+
+				"AcknowledgedMissingSeedNamespaces.", ns, bead, bead)
+		}
+	}
+}
+
+// TestValidateSeedProviderCoverage_TargetOnlyMatchesNotFlagged pins the
+// intentional regex semantics per abac-reviewer finding #4: seeds that
+// reference a namespace ONLY via `principal is X` or `resource is X`
+// target-type matchers (no `principal.X.attr` / `resource.X.attr` when-clause
+// references) are NOT flagged as missing. The bug class this PR catches is
+// "WHEN clause accesses a namespace attribute that no provider populates";
+// target-only matchers don't access attributes, so the engine doesn't need
+// the provider to evaluate them. Without this test, a well-meaning future
+// edit that "broadens the regex to also catch target types" would silently
+// start producing false positives for plugin / scene / exit seeds that
+// intentionally use target-only matching.
+func TestValidateSeedProviderCoverage_TargetOnlyMatchesNotFlagged(t *testing.T) {
+	t.Parallel()
+	seeds := []policy.SeedPolicy{
+		{
+			Name:    "test:target-only-plugin",
+			DSLText: `permit(principal is plugin, action in ["emit_event"], resource is event);`,
+		},
+		{
+			Name:    "test:target-only-scene",
+			DSLText: `permit(principal is character, action in ["write"], resource is scene);`,
+		},
+	}
+	// Neither "plugin" nor "scene" namespace registered, but the seeds
+	// don't reference any plugin.X.Y / scene.X.Y in a when clause — they
+	// only target-match. The validator MUST NOT flag them.
+	registered := []string{"character"}
+
+	missing := validateSeedProviderCoverage(registered, seeds)
+	assert.Empty(t, missing,
+		"target-only matchers (resource is X, principal is X) do NOT need a provider; "+
+			"only when-clause attribute references do. Regex must not flag them.")
+}

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -168,6 +168,18 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 		return nil, eb.Wrapf(err, "register plugin provider")
 	}
 
+	// 10a. Seed-coverage validator (holomush-xxel). After all providers are
+	// registered, walk the seed corpus and WARN per namespace referenced by
+	// any seed but not registered. Catches the holomush-g776 / xxel bug
+	// class at construction time: a missing provider means every seed
+	// gating on `resource.<ns>.*` silently default-denies, with no startup
+	// signal. The validator is non-fatal by design — production resilience
+	// over fail-closed-at-boot for an issue that was historically silent
+	// anyway. Specific provider-nil branches above (CharacterRepo,
+	// LocationRepo) already WARN at their own grain; this is the corpus-
+	// level sweep that catches a missing provider regardless of cause.
+	warnOnMissingSeedCoverage(ctx, resolver.RegisteredNamespaces(), policy.SeedPolicies())
+
 	// 10-11. SQL bridge for audit writer
 	sqlDB := stdlib.OpenDBFromPool(cfg.Pool)
 	if err := sqlDB.PingContext(ctx); err != nil {


### PR DESCRIPTION
## Summary

**Bug-class fix** following [PR #4159](https://github.com/holomush/holomush/pull/4159) (`holomush-g776`): LocationProvider was missing from `BuildABACStack`, silently default-denying every `list_presence` / `list_characters` / `read-location` request. That fix patched the one instance. This PR (`xxel`) addresses the **class**: a startup-time validator that catches the same shape at boot for any future missing provider.

## What's in

| Change | File | Purpose |
| ------ | ---- | ------- |
| Seed-coverage validator | `internal/access/setup/seed_coverage.go` | Walks `policy.SeedPolicies()` via regex `(principal\|resource).<ns>.<attr>`; emits one `slog.WarnContext` per missing-provider namespace |
| Validator call site | `internal/access/setup/setup.go` | Runs at end of `BuildABACStack` |
| CharacterProvider hardening | `internal/access/policy/attribute/character.go` | `(nil, nil)` for non-ULID character IDs — symmetric with LocationProvider's g776 fix |
| Resolver introspection | `internal/access/policy/attribute/resolver.go` | New `RegisteredNamespaces()` accessor |
| Unit tests | `internal/access/setup/seed_coverage_test.go` | 5 tests pinning validator semantics including target-only-matches-NOT-flagged |
| Integration drift detector | `internal/access/setup/buildabacstack_seed_coverage_integ_test.go` | Builds REAL `BuildABACStack` against fresh Postgres, asserts no drift between actual registrations + `AcknowledgedMissingSeedNamespaces` |

## Acknowledged-missing namespaces (filed)

The validator immediately surfaced two known-missing namespaces:

| Namespace | Bead | Status |
| --------- | ---- | ------ |
| `property` | **holomush-72ou** (P1) | Design mismatch — production callers emit `property:<parentType>:<parentID>` but seeds gate on individual `property.*` attrs. Needs design pass, not one-line wiring |
| `object` | **holomush-k3ud** (P1) | `ObjectProvider` type does NOT exist yet — 5 production callers in `service.go` silently default-deny today |

Both are tracked in `setup.AcknowledgedMissingSeedNamespaces`. When either lands, the integration test fails until the entry is removed.

## Out of scope (filed)

- **holomush-rooy** (P2) — plugin-installed policies bypass this validator (validator scoped to host seeds only per abac-reviewer finding)

## Review

- **code-reviewer**: READY (5 non-blocking)
- **abac-reviewer**: READY (3 non-blocking; both MEDIUM-severity findings addressed inline — drift-detector integration test + scoped docstring)
- `task pr-prep`: GREEN full lane, all 1653 integration tests + 62 e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added startup-time ABAC seed coverage validation to detect and warn when access policies reference attribute providers that aren't registered, preventing silent default-deny security failures.

* **Bug Fixes**
  * Non-ULID character references (like wildcards) are now handled gracefully instead of failing with errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->