### PR TITLE
test(privacy): I-PRIV-1 character move resets location floor (holomush-iwzt.10)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -229,5 +229,7 @@ Keep under 200 lines. Curate — don't hoard.
   for the Ginkgo `Describe` label in source, not just in plan docs; (b) the Ginkgo
   filter is `-ginkgo.focus=`, not `-run` (which matches Go test functions, not Ginkgo
   descriptions); (c) a seed event is planted before the floor so a breakage is
-  detectable. Encountered: iwzt.9 review (2026-05-21), I-PRIV-1 test in
-  `test/integration/privacy/privacy_test.go:150-156`.
+  detectable. Encountered: iwzt.9 (2026-05-21, `privacy_test.go:150-156`) and iwzt.10
+  (2026-05-21, `privacy_test.go:331-349` — second `It` in move-floor test plants a post-move
+  event via `EmitDirectEvent` but omits `Expect(events).NotTo(BeEmpty())`. `EmitDirectEvent`
+  returns post-JetStream-ack so the race is slim but the vacuity gap persists).

--- a/internal/testsupport/privacytest/privacy_harness.go
+++ b/internal/testsupport/privacytest/privacy_harness.go
@@ -83,6 +83,24 @@ type Server struct {
 	guestStartLocationID ulid.ULID
 }
 
+// StartOption tunes Start construction. Tests pass options to override
+// harness defaults (e.g., the ABAC policy engine).
+type StartOption func(*startConfig)
+
+// startConfig holds resolved Start options.
+type startConfig struct {
+	accessEngine types.AccessPolicyEngine
+}
+
+// WithPolicyEngine overrides the harness's default allow-all ABAC engine.
+// Tests that need to exercise denial paths — e.g., the I-PRIV-1 hard-gate
+// (iwzt.10) or the I-PRIV-5 wire-opacity meta-test (iwzt.11) — pass a
+// stricter engine such as policytest.DenyAllEngine so staffOverride
+// returns false and the hard-gate is exercised end-to-end.
+func WithPolicyEngine(eng types.AccessPolicyEngine) StartOption {
+	return func(c *startConfig) { c.accessEngine = eng }
+}
+
 // Start bootstraps a full in-process holomush stack and returns a Server.
 // The caller MUST call Stop() (typically via defer) to release resources.
 //
@@ -91,8 +109,10 @@ type Server struct {
 //   - An embedded NATS JetStream server (in-memory, per-test isolation)
 //   - An in-process CoreServer wired to the above
 //
-// AllowAll ABAC engine: tests focus on privacy gates, not role enforcement.
-func Start(t *testing.T) *Server {
+// AllowAll ABAC engine is the default — privacy tests focus on session/
+// history gates, not role enforcement. Pass WithPolicyEngine to override
+// for tests that need denial-path coverage.
+func Start(t *testing.T, opts ...StartOption) *Server {
 	t.Helper()
 
 	ctx := context.Background()
@@ -146,10 +166,14 @@ func Start(t *testing.T) *Server {
 	// Embedded NATS bus (in-memory, cleaned up via t.Cleanup).
 	bus := eventbustest.New(t)
 
-	// AllowAll ABAC engine — privacy tests focus on session/history gates,
-	// not role enforcement. We use a local implementation to avoid importing
-	// the policytest helper package from non-_test.go code.
-	pe := &allowAllPolicyEngine{}
+	// Resolve options. Default ABAC engine is allowAll (privacy tests focus
+	// on session/history gates, not role enforcement). Tests that need
+	// denial-path coverage override via WithPolicyEngine.
+	cfg := &startConfig{accessEngine: &allowAllPolicyEngine{}}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	pe := cfg.accessEngine
 
 	// Command dispatcher (minimal: no commands registered).
 	dispatcher, err := command.NewDispatcher(command.NewRegistry(), pe)

--- a/internal/testsupport/privacytest/privacy_session.go
+++ b/internal/testsupport/privacytest/privacy_session.go
@@ -117,15 +117,33 @@ func (s *Session) Logout(ctx context.Context) {
 	require.NoError(s.server.t, err, "privacytest.Session.Logout")
 }
 
-// MoveTo moves the character to a new location. Updates LocationID.
-// OriginalLocationID is never mutated.
+// MoveTo simulates a character move by updating the session row's
+// location_id + location_arrived_at columns directly in Postgres. Mirrors
+// the post-MovementHook state (per holomush-iwzt.4) that production would
+// produce without invoking the full world.Service.MoveCharacter pipeline,
+// which is out of scope for privacy-floor tests.
 //
-// TODO(iwzt-9): invoke MoveCharacter RPC once the world movement path is
-// wired into the test harness.
-func (s *Session) MoveTo(_ context.Context, newLocationID ulid.ULID) {
-	// Update the harness-side LocationID so tests can assert on it.
+// Scope: only the `sessions` row is updated. `characters.location_id` is
+// NOT changed. Tests that query the world repo (e.g.,
+// GetCharactersByLocation) will see stale character placement; tests that
+// read via the session store (QueryStreamHistory's hard-gate, presence
+// snapshot) see the updated value.
+//
+// Updates the harness-side Session.LocationID + LocationArrivedAt so test
+// assertions read the same values the server-side session row carries.
+// OriginalLocationID is never mutated — tests can compare before/after.
+func (s *Session) MoveTo(ctx context.Context, newLocationID ulid.ULID) {
+	s.server.t.Helper()
+	now := time.Now().UTC()
+	tag, err := s.server.pool.Exec(ctx,
+		`UPDATE sessions SET location_id = $1, location_arrived_at = $2, updated_at = $2 WHERE id = $3`,
+		newLocationID.String(), now, s.SessionID)
+	require.NoError(s.server.t, err, "privacytest.Session.MoveTo")
+	require.Equalf(s.server.t, int64(1), tag.RowsAffected(),
+		"privacytest.Session.MoveTo: expected 1 row affected, got %d (sessionID=%s)",
+		tag.RowsAffected(), s.SessionID)
 	s.LocationID = newLocationID
-	s.server.t.Fatalf("privacytest.Session.MoveTo: TODO iwzt-9 — MoveCharacter RPC not yet wired")
+	s.LocationArrivedAt = now
 }
 
 // DetachTransport simulates a client disconnect by cancelling the Subscribe

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -14,9 +14,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/samber/oops"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
 
+	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/testsupport/privacytest"
 )
 
@@ -259,6 +261,95 @@ var _ = Describe("I-PRIV-2: guest name reuse does not leak prior holder's events
 			Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", reusedGuest.SessionCreatedAt),
 				"event %q at %s leaked from prior holder of name %q (floor=%s)",
 				ev.GetType(), ev.GetTimestamp().AsTime(), firstName, reusedGuest.SessionCreatedAt)
+		}
+	})
+})
+
+// I-PRIV-1 (character move): when a character moves from locA to locB, the
+// floor MUST reset to the new location's arrival time and the hard-gate
+// MUST deny queries against the prior location. This is the location-
+// switching arm of I-PRIV-1.
+//
+// Harness contract: this test uses WithPolicyEngine(DenyAllEngine) so the
+// staffOverride bypass in QueryStreamHistory returns false — without that
+// override, the harness's default allowAll engine grants
+// read_unrestricted_history and the hard-gate denial path can't be
+// exercised (see internal/grpc/scope_floor.go::staffOverride +
+// query_stream_history.go hard-gate branch).
+var _ = Describe("I-PRIV-1: character move resets location floor", func() {
+	var (
+		ts       *privacytest.Server
+		ctx      context.Context
+		mover    *privacytest.Session
+		startLoc string
+		destLoc  string
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		// DenyAll engine: staffOverride returns false → hard-gate fires when
+		// session.LocationID != requested stream's location.
+		ts = privacytest.Start(suiteT, privacytest.WithPolicyEngine(policytest.DenyAllEngine()))
+
+		mover = ts.ConnectAuthed(ctx, "Mover")
+		startLoc = "location:" + mover.LocationID.String()
+
+		// Pre-move: emit a seed event at locA so we can verify the post-move
+		// hard-gate denial is content-independent (denial fires before any
+		// query reads the underlying stream).
+		Expect(mover.EmitDirectEvent(ctx, startLoc, "core-communication:pose",
+			[]byte(`{"character_name":"Mover","action":"pauses before leaving."}`))).
+			To(Succeed(), "pre-move seed event MUST publish")
+
+		// Move to a fresh location.
+		destLocID := ts.NewLocation(ctx)
+		destLoc = "location:" + destLocID.String()
+		mover.MoveTo(ctx, destLocID)
+	})
+
+	AfterEach(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if mover != nil {
+			mover.Logout(cleanupCtx)
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("denies queries against the prior location (hard-gate)", func() {
+		_, err := mover.QueryStreamHistory(ctx, startLoc)
+		Expect(err).To(HaveOccurred(),
+			"I-PRIV-1 hard-gate: query against prior location MUST fail after move")
+		oopsErr, ok := oops.AsOops(err)
+		Expect(ok).To(BeTrue(), "denial must surface as an oops error")
+		Expect(oopsErr.Code()).To(Equal("STREAM_ACCESS_DENIED"),
+			"denial MUST collapse to STREAM_ACCESS_DENIED — denial reason 'wrong_location'")
+	})
+
+	It("floors queries against the new location at arrival time", func() {
+		// Emit a post-move event at the destination. It MUST appear in the
+		// query result (timestamp is strictly >= mover.LocationArrivedAt).
+		postPayload := []byte(`{"character_name":"Mover","action":"arrives and looks around."}`)
+		Expect(mover.EmitDirectEvent(ctx, destLoc, "core-communication:pose", postPayload)).
+			To(Succeed(), "post-move emit MUST publish")
+
+		events, err := mover.QueryStreamHistory(ctx, destLoc)
+		Expect(err).NotTo(HaveOccurred(),
+			"I-PRIV-1: same-location query at the destination MUST succeed")
+		// Guard against vacuous pass: the post-move event must be visible.
+		// Without this assertion, a regression that over-filters everything
+		// to nil would silently pass the floor loop below.
+		Expect(events).NotTo(BeEmpty(),
+			"post-move emit must be visible in history (vacuous-pass guard)")
+
+		// Floor at the new location is LocationArrivedAt (updated by MoveTo).
+		// Any returned event with timestamp before that is an I-PRIV-1 leak.
+		for _, ev := range events {
+			Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", mover.LocationArrivedAt),
+				"event %q at %s leaked before mover.LocationArrivedAt %s after move",
+				ev.GetType(), ev.GetTimestamp().AsTime(), mover.LocationArrivedAt)
 		}
 	})
 })


### PR DESCRIPTION
## Summary

Integration test for the **location-switching arm of I-PRIV-1**: when a character moves from locA to locB, the floor MUST reset to the new location's arrival time AND the hard-gate MUST deny queries against the prior location.

This is **T9** of the iwzt epic — third PR shipped from the integration test batch this session (after iwzt.9 #4158 and iwzt.21 #4160).

## Changes

**Harness extensions** (`internal/testsupport/privacytest/`):

- **`privacy_harness.go`** — new `StartOption` pattern + `WithPolicyEngine(eng)`. Tests that need denial-path coverage (the I-PRIV-1 hard-gate; the I-PRIV-5 wire-opacity test under iwzt.11) pass a stricter engine like `policytest.DenyAllEngine` so `staffOverride` returns false. Default remains `allowAllPolicyEngine` for back-compat with existing tests. **Variadic signature change is back-compat** — all 4 existing `Start(suiteT)` callers compile and behave identically.

- **`privacy_session.go`** — `Session.MoveTo` replaces the TODO-fatal stub. Direct SQL UPDATE on `sessions.location_id` + `location_arrived_at`; mirrors the post-MovementHook state without invoking the full `world.Service.MoveCharacter` pipeline. Scope explicitly documented: only the session row is updated; `characters.location_id` is NOT changed (out-of-scope for floor tests; tests that read via WorldQuerier would observe stale character placement).

**Test** (`test/integration/privacy/privacy_test.go`):

- New `Describe("I-PRIV-1: character move resets location floor", ...)` with 2 `It` blocks:
  - **Hard-gate denial**: `QueryStreamHistory` against the prior location returns `STREAM_ACCESS_DENIED` via `oops.AsOops(err).Code()` (top-level code assertion per `.claude/rules/grpc-errors.md`).
  - **Floor at new location**: emits a post-move event, asserts the result is non-empty (vacuous-pass guard), then asserts every returned event has `Timestamp >= mover.LocationArrivedAt`.
- Uses `WithPolicyEngine(policytest.DenyAllEngine())` so `staffOverride` returns false and the hard-gate is exercised end-to-end.

## Reviewer notes

- `code-reviewer` pre-push gate: **READY** with 2 non-blocking observations — both addressed inline before push:
  1. Floor assertion vacuously passes if `events` is empty → added `Expect(events).NotTo(BeEmpty())` as a vacuous-pass guard.
  2. `MoveTo` doc-comment omitted the character-row scope limitation → added an explicit "only the session row is updated; characters.location_id is NOT changed" note.

## Test plan

- [x] `task test:int -- -ginkgo.focus='I-PRIV-1: character move resets' ./test/integration/privacy/` — PASS (privacy package 21.7s, +2 tests in this Describe block)
- [x] Full `task pr-prep` — green
- [x] No back-compat breaks — all 4 existing `Start(suiteT)` callers compile and run unchanged

## Beads

Closes holomush-iwzt.10. Unblocks the rest of the iwzt test batch that needs hard-gate-denial coverage (iwzt.11 wire-opacity meta-test can now use the same `WithPolicyEngine(DenyAllEngine())` pattern). Remaining: iwzt.11/.16/.17/.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test harness now supports configurable access-policy behavior for more flexible security testing scenarios.
  * Session movement functionality fully implemented with proper state synchronization.
  * Added integration test for character movement with access control verification and event visibility validation.

* **Documentation**
  * Updated regression testing guidance with additional examples and checklist enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->