### PR TITLE
fix(access): wire ObjectProvider into BuildABACStack with transitive location resolution (k3ud)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -62,6 +62,20 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   `PolicyInstaller.InstallPluginPolicies`) are NOT scanned — same silent-deny
   class can recur for plugin-declared namespaces. Symmetric stale-entry
   direction IS asserted at `seed_coverage_test.go:154-160`.
+- **Co-location seed empty-string equality (2026-05-21)**: all three
+  co-location seeds (`seed:player-character-colocation`,
+  `seed:player-object-colocation`, `seed:player-location-stream-read`)
+  compare `resource.<ns>.location == principal.character.location` as raw
+  strings. Providers emit `attrs["location"] = ""` (NOT absent) when the
+  entity is un-locatable. DSL `evalComparison` treats `"" == ""` as TRUE
+  because both values are present strings; only *missing* attributes
+  short-circuit to false (`internal/access/policy/dsl/evaluator.go:128`).
+  Net: a character with `LocationID == nil` reading any un-locatable
+  resource gets permit. Not a new defect (predates k3ud); not yet fixed.
+  Two viable patches: (a) DSL gate `&& principal.character.has_location
+  && resource.<ns>.has_location` per seed (`has_location` is already in
+  every schema), or (b) providers omit the `location` key entirely when
+  un-locatable. Worth flagging on any co-location-seed work.
 - **Wildcard resource IDs (`type:*`) bypass per-instance attrs**:
   `service.CreateLocation` / `service.FindLocationByName` /
   `service.CreateExit` / `service.CreateObject` all call `checkAccess`

--- a/internal/access/policy/attribute/location.go
+++ b/internal/access/policy/attribute/location.go
@@ -5,12 +5,12 @@ package attribute
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/world"
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
 )
 
 // LocationProvider resolves attributes for location entities.
@@ -52,7 +52,9 @@ func (p *LocationProvider) ResolveSubject(_ context.Context, _ string) (map[stri
 func (p *LocationProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
 	parts := strings.SplitN(resourceID, ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid resource ID format: expected 'type:id'")
+		return nil, oops.Code("INVALID_RESOURCE_ID").
+			With("resource_id", resourceID).
+			Errorf("invalid resource ID format: expected 'type:id'")
 	}
 
 	entityType, idStr := parts[0], parts[1]
@@ -72,7 +74,9 @@ func (p *LocationProvider) ResolveResource(ctx context.Context, resourceID strin
 
 	loc, err := p.repo.Get(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("fetch location %s: %w", id, err)
+		return nil, oops.Code("LOCATION_FETCH_FAILED").
+			With("location_id", id.String()).
+			Wrapf(err, "fetch location %s", id)
 	}
 
 	attrs := map[string]any{

--- a/internal/access/policy/attribute/object.go
+++ b/internal/access/policy/attribute/object.go
@@ -5,7 +5,6 @@ package attribute
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/world"
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
 )
 
 // maxObjectChainDepth bounds the containment-chain walk inside
@@ -76,7 +76,9 @@ func (p *ObjectProvider) ResolveSubject(_ context.Context, _ string) (map[string
 func (p *ObjectProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
 	parts := strings.SplitN(resourceID, ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid resource ID format: expected 'type:id'")
+		return nil, oops.Code("INVALID_RESOURCE_ID").
+			With("resource_id", resourceID).
+			Errorf("invalid resource ID format: expected 'type:id'")
 	}
 
 	entityType, idStr := parts[0], parts[1]
@@ -92,12 +94,32 @@ func (p *ObjectProvider) ResolveResource(ctx context.Context, resourceID string)
 		// without per-instance attrs. Returning the parse error here
 		// would fail-closed every CreateObject call. Mirrors
 		// LocationProvider holomush-g776.
-		return nil, nil //nolint:nilerr // wildcard refs intentionally bypass provider; documented above
+		return nil, nil
 	}
 
-	obj, err := p.repo.Get(ctx, id)
+	// CodeRabbit #2 (PR #4163): bound the top-level Get with the same
+	// 250ms budget as the chain walk. Previously only the chain walk
+	// (resolveEffectiveLocation) was time-bounded, so a slow DB on the
+	// initial lookup could stall ABAC eval beyond the chain's budget.
+	getCtx, cancel := context.WithTimeout(ctx, objectChainTimeout)
+	defer cancel()
+
+	obj, err := p.repo.Get(getCtx, id)
 	if err != nil {
-		return nil, fmt.Errorf("fetch object %s: %w", id, err)
+		return nil, oops.Code("OBJECT_FETCH_FAILED").
+			With("object_id", id.String()).
+			Wrapf(err, "fetch object %s", id)
+	}
+	// CodeRabbit #3 (PR #4163): defensive guard against the repository
+	// contract violation case `(nil, nil)`. The postgres impl at
+	// internal/world/postgres/object_repo.go:46-51 returns `(nil, err)`
+	// or `(obj, nil)` and never `(nil, nil)`, but the interface contract
+	// does not enforce non-nil-on-nil-err. Fail fast with a clear code
+	// instead of panicking on the obj.ID dereference below.
+	if obj == nil {
+		return nil, oops.Code("OBJECT_FETCH_FAILED").
+			With("object_id", id.String()).
+			Errorf("object repository returned nil with no error")
 	}
 
 	attrs := map[string]any{
@@ -179,6 +201,18 @@ func (p *ObjectProvider) resolveEffectiveLocation(ctx context.Context, obj *worl
 					"error", err)
 				return "", false
 			}
+			// CodeRabbit #3 (PR #4163): defensive guard for the
+			// `(nil, nil)` repo contract violation case. The postgres
+			// CharacterRepository.Get never returns this, but the
+			// interface does not enforce it — fail-closed instead of
+			// panicking on char.LocationID below.
+			if char == nil {
+				slog.WarnContext(ctx,
+					"object provider: holder character lookup returned nil",
+					"object_id", obj.ID.String(),
+					"character_id", cur.HeldByCharacterID().String())
+				return "", false
+			}
 			if char.LocationID == nil {
 				return "", false
 			}
@@ -201,6 +235,16 @@ func (p *ObjectProvider) resolveEffectiveLocation(ctx context.Context, obj *worl
 					"object_id", obj.ID.String(),
 					"parent_id", parentID.String(),
 					"error", err)
+				return "", false
+			}
+			// CodeRabbit #3 (PR #4163): defensive guard for the
+			// `(nil, nil)` repo contract violation case. Parallel to
+			// the holder-character guard above.
+			if parent == nil {
+				slog.WarnContext(ctx,
+					"object provider: parent container lookup returned nil",
+					"object_id", obj.ID.String(),
+					"parent_id", parentID.String())
 				return "", false
 			}
 			cur = parent

--- a/internal/access/policy/attribute/object.go
+++ b/internal/access/policy/attribute/object.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+)
+
+// maxObjectChainDepth bounds the containment-chain walk inside
+// resolveEffectiveLocation. The postgres layer enforces a smaller
+// nesting depth (DefaultMaxNestingDepth = 3) on writes; the resolver
+// uses a more generous bound because (a) it must tolerate any data the
+// database might already hold and (b) the per-step cost is one indexed
+// primary-key Get. The visited-set in resolveEffectiveLocation guards
+// against cycles independently of this cap.
+const maxObjectChainDepth = 16
+
+// objectChainTimeout caps total chain-walk wall time so a slow database
+// cannot stall ABAC eval indefinitely. Mirrors PropertyProvider's
+// 100ms timeout on its resolver call, with extra headroom for the
+// (worst-case) multi-step walk through container chains and one
+// terminal character.Get.
+const objectChainTimeout = 250 * time.Millisecond
+
+// ObjectProvider resolves attributes for object entities.
+//
+// The effective `location` attribute walks the containment chain:
+// LocationID set → that location; HeldByCharacterID → the holder's
+// location; ContainedInObjectID → recurse on the container. The walk
+// is bounded by maxObjectChainDepth and a visited-set to defend
+// against cycles or pathologically deep data.
+type ObjectProvider struct {
+	repo     world.ObjectRepository
+	charRepo world.CharacterRepository
+}
+
+// NewObjectProvider creates a new object attribute provider.
+//
+// charRepo MAY be nil — the provider will tolerate the gap by treating
+// held-by-character objects as un-locatable (has_location=false). The
+// LocationProvider precedent (holomush-g776) is for repositories to be
+// optional with a documented WARN at construction time in BuildABACStack.
+func NewObjectProvider(repo world.ObjectRepository, charRepo world.CharacterRepository) *ObjectProvider {
+	return &ObjectProvider{repo: repo, charRepo: charRepo}
+}
+
+// Namespace returns "object".
+func (p *ObjectProvider) Namespace() string {
+	return "object"
+}
+
+// ResolveSubject returns nil — objects are never subjects.
+func (p *ObjectProvider) ResolveSubject(_ context.Context, _ string) (map[string]any, error) {
+	return nil, nil
+}
+
+// ResolveResource resolves object attributes for a resource.
+// Returns (nil, nil) for non-object entity types AND for non-ULID IDs.
+//
+// The canonical non-ULID case is "object:*" — the literal wildcard the
+// CreateObject capability check emits at service.go:449. Mirroring the
+// LocationProvider tolerance from holomush-g776, returning the parse
+// error here would fail-closed every CreateObject call. The bootstrap-
+// chain seed selects via DSL `resource is object` target-type match,
+// not a `when`-clause pattern, so per-instance attributes are not
+// needed for those checks.
+func (p *ObjectProvider) ResolveResource(ctx context.Context, resourceID string) (map[string]any, error) {
+	parts := strings.SplitN(resourceID, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid resource ID format: expected 'type:id'")
+	}
+
+	entityType, idStr := parts[0], parts[1]
+	if entityType != "object" {
+		return nil, nil
+	}
+
+	id, err := ulid.Parse(idStr)
+	if err != nil {
+		// Non-ULID object reference (e.g., "object:*" wildcard from
+		// CreateObject capability grants at service.go:449). Skip
+		// attribute resolution; the engine evaluates wildcard patterns
+		// without per-instance attrs. Returning the parse error here
+		// would fail-closed every CreateObject call. Mirrors
+		// LocationProvider holomush-g776.
+		return nil, nil //nolint:nilerr // wildcard refs intentionally bypass provider; documented above
+	}
+
+	obj, err := p.repo.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("fetch object %s: %w", id, err)
+	}
+
+	attrs := map[string]any{
+		"id":           obj.ID.String(),
+		"name":         obj.Name,
+		"description":  obj.Description,
+		"is_container": obj.IsContainer,
+	}
+
+	if obj.OwnerID != nil {
+		attrs["owner_id"] = obj.OwnerID.String()
+		attrs["has_owner"] = true
+	} else {
+		attrs["owner_id"] = ""
+		attrs["has_owner"] = false
+	}
+
+	if held := obj.HeldByCharacterID(); held != nil {
+		attrs["held_by_character_id"] = held.String()
+		attrs["is_held"] = true
+	} else {
+		attrs["held_by_character_id"] = ""
+		attrs["is_held"] = false
+	}
+
+	if container := obj.ContainedInObjectID(); container != nil {
+		attrs["contained_in_object_id"] = container.String()
+		attrs["is_contained"] = true
+	} else {
+		attrs["contained_in_object_id"] = ""
+		attrs["is_contained"] = false
+	}
+
+	locStr, ok := p.resolveEffectiveLocation(ctx, obj)
+	attrs["location"] = locStr
+	attrs["has_location"] = ok
+
+	return attrs, nil
+}
+
+// resolveEffectiveLocation walks the containment chain to find the
+// terminal location for an object. Returns ("", false) if the chain
+// cannot be resolved (cycle detected, exceeded max depth, repo error,
+// holder character missing, holder has no location, charRepo nil, etc.).
+//
+// Bounded by maxObjectChainDepth and a visited-set; total wall time
+// bounded by objectChainTimeout via a derived context.
+//
+// Diagnostic WARNs use the parent ctx so they still emit even when the
+// derived resolveCtx has been cancelled by the timeout — otherwise a
+// timed-out walk would silently lose both the resolution and the audit
+// trail for why (per abac-reviewer #2 on holomush-k3ud).
+func (p *ObjectProvider) resolveEffectiveLocation(ctx context.Context, obj *world.Object) (string, bool) {
+	resolveCtx, cancel := context.WithTimeout(ctx, objectChainTimeout)
+	defer cancel()
+
+	visited := map[ulid.ULID]struct{}{obj.ID: {}}
+	cur := obj
+
+	for depth := 0; depth < maxObjectChainDepth; depth++ {
+		switch {
+		case cur.LocationID() != nil:
+			return cur.LocationID().String(), true
+
+		case cur.HeldByCharacterID() != nil:
+			if p.charRepo == nil {
+				slog.WarnContext(ctx,
+					"object provider: charRepo nil — cannot resolve held-by-character location",
+					"object_id", obj.ID.String(),
+					"character_id", cur.HeldByCharacterID().String())
+				return "", false
+			}
+			char, err := p.charRepo.Get(resolveCtx, *cur.HeldByCharacterID())
+			if err != nil {
+				slog.WarnContext(ctx,
+					"object provider: failed to fetch holder character",
+					"object_id", obj.ID.String(),
+					"character_id", cur.HeldByCharacterID().String(),
+					"error", err)
+				return "", false
+			}
+			if char.LocationID == nil {
+				return "", false
+			}
+			return char.LocationID.String(), true
+
+		case cur.ContainedInObjectID() != nil:
+			parentID := *cur.ContainedInObjectID()
+			if _, seen := visited[parentID]; seen {
+				slog.WarnContext(ctx,
+					"object provider: cycle detected in containment chain",
+					"object_id", obj.ID.String(),
+					"cycle_at", parentID.String())
+				return "", false
+			}
+			visited[parentID] = struct{}{}
+			parent, err := p.repo.Get(resolveCtx, parentID)
+			if err != nil {
+				slog.WarnContext(ctx,
+					"object provider: failed to fetch parent container",
+					"object_id", obj.ID.String(),
+					"parent_id", parentID.String(),
+					"error", err)
+				return "", false
+			}
+			cur = parent
+
+		default:
+			// Object has no containment set. SetContainment / DB
+			// constraints should prevent this; treat as un-locatable.
+			return "", false
+		}
+	}
+
+	slog.WarnContext(ctx,
+		"object provider: containment chain exceeded max depth",
+		"object_id", obj.ID.String(),
+		"max_depth", maxObjectChainDepth)
+	return "", false
+}
+
+// Schema returns the namespace schema for object attributes.
+func (p *ObjectProvider) Schema() *types.NamespaceSchema {
+	return &types.NamespaceSchema{
+		Attributes: map[string]types.AttrType{
+			"id":                     types.AttrTypeString,
+			"name":                   types.AttrTypeString,
+			"description":            types.AttrTypeString,
+			"owner_id":               types.AttrTypeString,
+			"has_owner":              types.AttrTypeBool,
+			"location":               types.AttrTypeString,
+			"has_location":           types.AttrTypeBool,
+			"is_container":           types.AttrTypeBool,
+			"held_by_character_id":   types.AttrTypeString,
+			"is_held":                types.AttrTypeBool,
+			"contained_in_object_id": types.AttrTypeString,
+			"is_contained":           types.AttrTypeBool,
+		},
+	}
+}

--- a/internal/access/policy/attribute/object_test.go
+++ b/internal/access/policy/attribute/object_test.go
@@ -505,3 +505,68 @@ func TestObjectProviderResolveResource_NilCharacterRepoIsTolerated(t *testing.T)
 	assert.Equal(t, "", attrs["location"])
 	assert.Equal(t, charID.String(), attrs["held_by_character_id"])
 }
+
+// TestObjectProviderResolveResource_NilRepoReturnsAreGuarded pins the
+// CodeRabbit #3 defensive guards (PR #4163): when a repository violates
+// the (obj|nil, err|nil) contract by returning (nil, nil), the provider
+// must fail-closed (top-level Get) or treat as un-locatable (chain walk)
+// instead of panicking on a nil-pointer dereference. The production
+// repo impls at internal/world/postgres/{object,character}_repo.go
+// never return (nil, nil); these tests lock the defensive guards.
+func TestObjectProviderResolveResource_NilRepoReturnsAreGuarded(t *testing.T) {
+	objID := ulid.Make()
+	charID := ulid.Make()
+	containerID := ulid.Make()
+
+	t.Run("top-level Get returns (nil, nil) → fail-closed with OBJECT_FETCH_FAILED", func(t *testing.T) {
+		objRepo := &mockObjectRepository{
+			getFunc: func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+				return nil, nil //nolint:nilnil // intentional contract violation under test
+			},
+		}
+		provider := NewObjectProvider(objRepo, &mockCharacterRepository{})
+
+		attrs, err := provider.ResolveResource(context.Background(), "object:"+objID.String())
+		require.Error(t, err)
+		assert.Nil(t, attrs)
+		assert.Contains(t, err.Error(), "object repository returned nil")
+	})
+
+	t.Run("holder character Get returns (nil, nil) → un-locatable, no panic", func(t *testing.T) {
+		objRepo := &mockObjectRepository{
+			getFunc: func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+				return newObjectHeldByCharacter(t, objID, charID, "Item"), nil
+			},
+		}
+		charRepo := &mockCharacterRepository{
+			getFunc: func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+				return nil, nil //nolint:nilnil // intentional contract violation under test
+			},
+		}
+		provider := NewObjectProvider(objRepo, charRepo)
+
+		attrs, err := provider.ResolveResource(context.Background(), "object:"+objID.String())
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+		assert.Equal(t, false, attrs["has_location"])
+		assert.Equal(t, "", attrs["location"])
+	})
+
+	t.Run("parent container Get returns (nil, nil) → un-locatable, no panic", func(t *testing.T) {
+		objRepo := &mockObjectRepository{
+			getFunc: func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+				if id == objID {
+					return newObjectContainedIn(t, objID, containerID, "Coin"), nil
+				}
+				return nil, nil //nolint:nilnil // intentional contract violation under test
+			},
+		}
+		provider := NewObjectProvider(objRepo, &mockCharacterRepository{})
+
+		attrs, err := provider.ResolveResource(context.Background(), "object:"+objID.String())
+		require.NoError(t, err)
+		require.NotNil(t, attrs)
+		assert.Equal(t, false, attrs["has_location"])
+		assert.Equal(t, "", attrs["location"])
+	})
+}

--- a/internal/access/policy/attribute/object_test.go
+++ b/internal/access/policy/attribute/object_test.go
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package attribute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/holomush/holomush/internal/access"
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/world"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockObjectRepository is a simple mock for testing.
+type mockObjectRepository struct {
+	getFunc func(ctx context.Context, id ulid.ULID) (*world.Object, error)
+}
+
+func (m *mockObjectRepository) Get(ctx context.Context, id ulid.ULID) (*world.Object, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, id)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) Create(_ context.Context, _ *world.Object) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) Update(_ context.Context, _ *world.Object) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) Delete(_ context.Context, _ ulid.ULID) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) ListAtLocation(_ context.Context, _ ulid.ULID) ([]*world.Object, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) ListHeldBy(_ context.Context, _ ulid.ULID) ([]*world.Object, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) ListContainedIn(_ context.Context, _ ulid.ULID) ([]*world.Object, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockObjectRepository) Move(_ context.Context, _ ulid.ULID, _ world.Containment) error {
+	return errors.New("not implemented")
+}
+
+// newObjectInLocation builds a test Object directly in a location.
+// Uses the unexported field-injection path via SetContainment to bypass NewObject's name validation.
+func newObjectInLocation(t *testing.T, id, locationID ulid.ULID, name string) *world.Object {
+	t.Helper()
+	obj := &world.Object{
+		ID:        id,
+		Name:      name,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, obj.SetContainment(world.InLocation(locationID)))
+	return obj
+}
+
+func newObjectHeldByCharacter(t *testing.T, id, characterID ulid.ULID, name string) *world.Object {
+	t.Helper()
+	obj := &world.Object{
+		ID:        id,
+		Name:      name,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, obj.SetContainment(world.HeldByCharacter(characterID)))
+	return obj
+}
+
+func newObjectContainedIn(t *testing.T, id, containerID ulid.ULID, name string) *world.Object {
+	t.Helper()
+	obj := &world.Object{
+		ID:        id,
+		Name:      name,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, obj.SetContainment(world.ContainedInObject(containerID)))
+	return obj
+}
+
+func TestObjectProviderContract(t *testing.T) {
+	assertProviderContract(t, NewObjectProvider(&mockObjectRepository{}, &mockCharacterRepository{}))
+}
+
+func TestObjectProviderNamespace(t *testing.T) {
+	t.Parallel()
+	provider := NewObjectProvider(&mockObjectRepository{}, &mockCharacterRepository{})
+	assert.Equal(t, "object", provider.Namespace())
+}
+
+func TestObjectProviderSchema(t *testing.T) {
+	t.Parallel()
+	provider := NewObjectProvider(&mockObjectRepository{}, &mockCharacterRepository{})
+
+	schema := provider.Schema()
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Attributes)
+
+	// Per holomush-k3ud acceptance: object provider populates attrs needed by
+	// seed:player-object-colocation (location) + future builder/admin seeds
+	// that may gate on owner/container shape.
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["id"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["name"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["description"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["owner_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_owner"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["location"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["has_location"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["is_container"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["held_by_character_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["is_held"])
+	assert.Equal(t, types.AttrTypeString, schema.Attributes["contained_in_object_id"])
+	assert.Equal(t, types.AttrTypeBool, schema.Attributes["is_contained"])
+}
+
+func TestObjectProviderResolveSubjectAlwaysNil(t *testing.T) {
+	t.Parallel()
+	provider := NewObjectProvider(&mockObjectRepository{}, &mockCharacterRepository{})
+
+	attrs, err := provider.ResolveSubject(context.Background(), "object:"+ulid.Make().String())
+	require.NoError(t, err)
+	assert.Nil(t, attrs, "objects are never subjects — ResolveSubject MUST always return nil")
+}
+
+func TestObjectProviderResolveResource(t *testing.T) {
+	objID := ulid.Make()
+	locID := ulid.Make()
+	ownerID := ulid.Make()
+	charID := ulid.Make()
+	containerID := ulid.Make()
+
+	tests := []struct {
+		name         string
+		resourceID   string
+		setupObjRepo func(*mockObjectRepository)
+		setupChrRepo func(*mockCharacterRepository)
+		expectAttrs  map[string]any
+		// Only a subset of attrs are asserted via expectSubset; this keeps
+		// table cases focused on what each case is actually verifying.
+		expectSubset map[string]any
+		expectNil    bool
+		expectErr    bool
+		errSubstring string
+	}{
+		{
+			name:       "object directly in location",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					assert.Equal(t, objID, id)
+					obj := newObjectInLocation(t, objID, locID, "Lantern")
+					obj.Description = "A brass lantern."
+					obj.OwnerID = &ownerID
+					obj.IsContainer = false
+					return obj, nil
+				}
+			},
+			expectAttrs: map[string]any{
+				"id":                     objID.String(),
+				"name":                   "Lantern",
+				"description":            "A brass lantern.",
+				"owner_id":               ownerID.String(),
+				"has_owner":              true,
+				"location":               locID.String(),
+				"has_location":           true,
+				"is_container":           false,
+				"held_by_character_id":   "",
+				"is_held":                false,
+				"contained_in_object_id": "",
+				"is_contained":           false,
+			},
+		},
+		{
+			name:       "container object in location",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+					obj := newObjectInLocation(t, objID, locID, "Chest")
+					obj.IsContainer = true
+					return obj, nil
+				}
+			},
+			expectSubset: map[string]any{
+				"is_container": true,
+				"has_owner":    false,
+				"owner_id":     "",
+				"location":     locID.String(),
+			},
+		},
+		{
+			name:       "object held by character — resolves to character's location",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					assert.Equal(t, objID, id)
+					return newObjectHeldByCharacter(t, objID, charID, "Note"), nil
+				}
+			},
+			setupChrRepo: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Character, error) {
+					assert.Equal(t, charID, id)
+					return &world.Character{
+						ID:         charID,
+						PlayerID:   ulid.Make(),
+						Name:       "Holder",
+						LocationID: &locID,
+					}, nil
+				}
+			},
+			expectSubset: map[string]any{
+				"location":             locID.String(),
+				"has_location":         true,
+				"held_by_character_id": charID.String(),
+				"is_held":              true,
+			},
+		},
+		{
+			name:       "object held by character without location → has_location=false",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+					return newObjectHeldByCharacter(t, objID, charID, "Pocket note"), nil
+				}
+			},
+			setupChrRepo: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return &world.Character{
+						ID:         charID,
+						PlayerID:   ulid.Make(),
+						Name:       "Wanderer",
+						LocationID: nil,
+					}, nil
+				}
+			},
+			expectSubset: map[string]any{
+				"location":             "",
+				"has_location":         false,
+				"held_by_character_id": charID.String(),
+				"is_held":              true,
+			},
+		},
+		{
+			name:       "object inside a container — walks one level to find location",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					switch id {
+					case objID:
+						return newObjectContainedIn(t, objID, containerID, "Coin"), nil
+					case containerID:
+						return newObjectInLocation(t, containerID, locID, "Chest"), nil
+					default:
+						t.Fatalf("unexpected object lookup: %s", id)
+						return nil, nil
+					}
+				}
+			},
+			expectSubset: map[string]any{
+				"location":               locID.String(),
+				"has_location":           true,
+				"contained_in_object_id": containerID.String(),
+				"is_contained":           true,
+			},
+		},
+		{
+			name:       "object inside container inside container — multi-level walk",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				outer := ulid.Make()
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					switch id {
+					case objID:
+						return newObjectContainedIn(t, objID, containerID, "Coin"), nil
+					case containerID:
+						return newObjectContainedIn(t, containerID, outer, "Pouch"), nil
+					case outer:
+						return newObjectInLocation(t, outer, locID, "Chest"), nil
+					default:
+						t.Fatalf("unexpected object lookup: %s", id)
+						return nil, nil
+					}
+				}
+			},
+			expectSubset: map[string]any{
+				"location":     locID.String(),
+				"has_location": true,
+			},
+		},
+		{
+			name:       "object inside a container held by a character — walks through both",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					switch id {
+					case objID:
+						return newObjectContainedIn(t, objID, containerID, "Coin"), nil
+					case containerID:
+						return newObjectHeldByCharacter(t, containerID, charID, "Pouch"), nil
+					default:
+						t.Fatalf("unexpected object lookup: %s", id)
+						return nil, nil
+					}
+				}
+			},
+			setupChrRepo: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return &world.Character{
+						ID:         charID,
+						PlayerID:   ulid.Make(),
+						Name:       "Holder",
+						LocationID: &locID,
+					}, nil
+				}
+			},
+			expectSubset: map[string]any{
+				"location":     locID.String(),
+				"has_location": true,
+			},
+		},
+		{
+			name:       "container chain breaks (parent not found) → has_location=false but other attrs populated",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					if id == objID {
+						return newObjectContainedIn(t, objID, containerID, "Orphan coin"), nil
+					}
+					return nil, errors.New("not found")
+				}
+			},
+			expectSubset: map[string]any{
+				"id":                     objID.String(),
+				"contained_in_object_id": containerID.String(),
+				"is_contained":           true,
+				"location":               "",
+				"has_location":           false,
+			},
+		},
+		{
+			name:       "character holder lookup fails → has_location=false but other attrs populated",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+					return newObjectHeldByCharacter(t, objID, charID, "Note"), nil
+				}
+			},
+			setupChrRepo: func(m *mockCharacterRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Character, error) {
+					return nil, errors.New("character not found")
+				}
+			},
+			expectSubset: map[string]any{
+				"id":                   objID.String(),
+				"held_by_character_id": charID.String(),
+				"is_held":              true,
+				"location":             "",
+				"has_location":         false,
+			},
+		},
+		{
+			name:       "circular containment → bounded by visited-set, has_location=false",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				// A is contained in B; B is contained in A — a corrupted DB
+				// state the engine MUST tolerate without infinite recursion.
+				m.getFunc = func(_ context.Context, id ulid.ULID) (*world.Object, error) {
+					switch id {
+					case objID:
+						return newObjectContainedIn(t, objID, containerID, "A"), nil
+					case containerID:
+						return newObjectContainedIn(t, containerID, objID, "B"), nil
+					}
+					return nil, errors.New("unexpected")
+				}
+			},
+			expectSubset: map[string]any{
+				"has_location": false,
+				"location":     "",
+			},
+		},
+		{
+			name:         "wrong entity type (location)",
+			resourceID:   "location:" + ulid.Make().String(),
+			setupObjRepo: func(_ *mockObjectRepository) {},
+			expectNil:    true,
+		},
+		{
+			name:         "wrong entity type (character)",
+			resourceID:   access.CharacterResource(ulid.Make().String()),
+			setupObjRepo: func(_ *mockObjectRepository) {},
+			expectNil:    true,
+		},
+		{
+			// Mirror of holomush-g776 LocationProvider wildcard tolerance —
+			// service.go:449 emits access.ObjectResource("*") for the
+			// CreateObject capability check. Returning a parse error would
+			// fail-closed every CreateObject call. The seed selects via
+			// `resource is object` target match, no per-instance attrs
+			// needed.
+			name:         "wildcard ID — bypass (mirrors holomush-g776)",
+			resourceID:   "object:*",
+			setupObjRepo: func(_ *mockObjectRepository) {},
+			expectNil:    true,
+		},
+		{
+			name:         "invalid ULID — bypass",
+			resourceID:   "object:not-a-ulid",
+			setupObjRepo: func(_ *mockObjectRepository) {},
+			expectNil:    true,
+		},
+		{
+			name:         "missing colon separator",
+			resourceID:   "object" + objID.String(),
+			setupObjRepo: func(_ *mockObjectRepository) {},
+			expectErr:    true,
+			errSubstring: "invalid resource ID format",
+		},
+		{
+			name:       "repository error on top-level Get",
+			resourceID: "object:" + objID.String(),
+			setupObjRepo: func(m *mockObjectRepository) {
+				m.getFunc = func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+					return nil, errors.New("database error")
+				}
+			},
+			expectErr:    true,
+			errSubstring: "database error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objRepo := &mockObjectRepository{}
+			chrRepo := &mockCharacterRepository{}
+			tt.setupObjRepo(objRepo)
+			if tt.setupChrRepo != nil {
+				tt.setupChrRepo(chrRepo)
+			}
+			provider := NewObjectProvider(objRepo, chrRepo)
+
+			attrs, err := provider.ResolveResource(context.Background(), tt.resourceID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.errSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expectNil {
+				assert.Nil(t, attrs)
+				return
+			}
+
+			require.NotNil(t, attrs)
+			if tt.expectAttrs != nil {
+				assert.Equal(t, tt.expectAttrs, attrs)
+				return
+			}
+			for k, want := range tt.expectSubset {
+				assert.Equal(t, want, attrs[k], "attribute %q", k)
+			}
+		})
+	}
+}
+
+// TestObjectProviderResolveResource_NilCharacterRepoIsTolerated guards a
+// production wiring slip: the LocationProvider/PropertyProvider precedent is
+// for repositories to be optional with a documented WARN at construction
+// time. The provider MUST NOT panic if charRepo is nil — it should treat
+// held-by-character objects as un-locatable (has_location=false) and let
+// the seed-coverage validator surface the wiring gap. Defensive shape only;
+// production wiring at subsystem.go ALWAYS supplies both repos.
+func TestObjectProviderResolveResource_NilCharacterRepoIsTolerated(t *testing.T) {
+	t.Parallel()
+	objID := ulid.Make()
+	charID := ulid.Make()
+	objRepo := &mockObjectRepository{
+		getFunc: func(_ context.Context, _ ulid.ULID) (*world.Object, error) {
+			return newObjectHeldByCharacter(t, objID, charID, "Item"), nil
+		},
+	}
+	provider := NewObjectProvider(objRepo, nil)
+
+	attrs, err := provider.ResolveResource(context.Background(), "object:"+objID.String())
+	require.NoError(t, err)
+	require.NotNil(t, attrs)
+	assert.Equal(t, false, attrs["has_location"])
+	assert.Equal(t, "", attrs["location"])
+	assert.Equal(t, charID.String(), attrs["held_by_character_id"])
+}

--- a/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
+++ b/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
@@ -48,6 +48,7 @@ func TestBuildABACStack_SeedCoverageMatchesAcknowledged(t *testing.T) {
 		Pool:          pool,
 		CharacterRepo: worldpostgres.NewCharacterRepository(pool),
 		LocationRepo:  worldpostgres.NewLocationRepository(pool),
+		ObjectRepo:    worldpostgres.NewObjectRepository(pool),
 		// RoleStore intentionally nil; CryptoOperators intentionally empty —
 		// production wiring at subsystem.go always passes these too, but the
 		// presence/absence does not affect provider registration coverage.

--- a/internal/access/setup/seed_coverage_test.go
+++ b/internal/access/setup/seed_coverage_test.go
@@ -117,7 +117,6 @@ func TestValidateSeedProviderCoverage_TopLevelIDsNotFlagged(t *testing.T) {
 // finding on holomush-xxel.
 var AcknowledgedMissingSeedNamespaces = map[string]string{
 	"property": "holomush-72ou", // PropertyProvider design pass: resource format mismatch
-	"object":   "holomush-k3ud", // ObjectProvider type does not exist yet
 }
 
 // TestValidateSeedProviderCoverage_ProductionCorpusIsCovered is the
@@ -140,7 +139,7 @@ func TestValidateSeedProviderCoverage_ProductionCorpusIsCovered(t *testing.T) {
 	// productionRegistered MUST stay in sync with BuildABACStack's actual
 	// registrations. The integration test asserts no drift.
 	productionRegistered := []string{
-		"character", "location", "player", "command", "stream", "plugin",
+		"character", "location", "object", "player", "command", "stream", "plugin",
 	}
 
 	missing := validateSeedProviderCoverage(productionRegistered, policy.SeedPolicies())

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -65,8 +65,16 @@ type ABACConfig struct {
 	// is not registered, no provider populates `resource.location.*`, and
 	// every such seed silently default-denies. Per holomush-g776.
 	LocationRepo world.LocationRepository
-	RoleStore    store.RoleStore
-	AuditMode    audit.Mode
+	// ObjectRepo is required for any seed that compares
+	// `resource.object.X` (e.g., seed:player-object-colocation). Without
+	// it the ObjectProvider is not registered, no provider populates
+	// `resource.object.*`, and every such seed silently default-denies —
+	// the same fingerprint as the original holomush-g776 bug. The provider
+	// also needs CharacterRepo to resolve transitive locations for objects
+	// held by characters. Per holomush-k3ud.
+	ObjectRepo world.ObjectRepository
+	RoleStore  store.RoleStore
+	AuditMode  audit.Mode
 	// CryptoOperators is the list of player IDs (ULIDs) holding the
 	// crypto.operator capability. Passed to PlayerAttributeProvider at
 	// construction. Empty / nil → no operators (break-glass disabled).
@@ -140,6 +148,33 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 			"ABAC setup: LocationRepo not provided — seeds referencing resource.location.* will silently default-deny",
 			"affected_seeds", "seed:player-location-read, seed:player-location-list-characters, seed:player-location-list-presence",
 			"reference", "holomush-g776")
+	}
+
+	// 8c. Object provider (optional in signature, required in practice for
+	// any seed referencing resource.object.*). Without this,
+	// seed:player-object-colocation silently default-denies and every
+	// object read/write/move/delete via internal/world/service.go (six
+	// production call sites at GetObject, CreateObject, UpdateObject,
+	// DeleteObject, MoveObject, plus the look-into-object check in the
+	// command pipeline at service.go:940) returns "no policies satisfied".
+	// Mirrors LocationProvider/CharacterProvider wildcard tolerance —
+	// CreateObject emits access.ObjectResource("*") at service.go:449.
+	//
+	// Production wiring at internal/access/setup/subsystem.go ALWAYS
+	// supplies both ObjectRepo and CharacterRepo. Loud WARN when missing
+	// so any future caller that drops the repo gets a recurrence signal;
+	// the original g776 bug was silent at startup and only manifested via
+	// e2e symptoms. Per holomush-k3ud.
+	if cfg.ObjectRepo != nil {
+		objProvider := attribute.NewObjectProvider(cfg.ObjectRepo, cfg.CharacterRepo)
+		if err := resolver.RegisterProvider(objProvider); err != nil {
+			return nil, eb.Wrapf(err, "register object provider")
+		}
+	} else {
+		slog.WarnContext(ctx,
+			"ABAC setup: ObjectRepo not provided — seeds referencing resource.object.* will silently default-deny",
+			"affected_seeds", "seed:player-object-colocation",
+			"reference", "holomush-k3ud")
 	}
 
 	// 8a. Player provider (subject namespace; resolves player.id and

--- a/internal/access/setup/setup_player_test.go
+++ b/internal/access/setup/setup_player_test.go
@@ -32,8 +32,8 @@ func freshABACStack(t *testing.T, operators []string) (*setup.ABACStack, func())
 	require.NoError(t, err)
 
 	stack, err := setup.BuildABACStack(ctx, setup.ABACConfig{
-		Pool:            pool,
-		CharacterRepo:   nil, // optional per setup.go
+		Pool:          pool,
+		CharacterRepo: nil, // optional per setup.go
 		// LocationRepo wired so the build does NOT emit the missing-provider
 		// WARN (holomush-g776). The PlayerProvider tests don't exercise the
 		// location seeds, but the production wiring always supplies the

--- a/internal/access/setup/subsystem.go
+++ b/internal/access/setup/subsystem.go
@@ -80,6 +80,7 @@ func (s *ABACSubsystem) Start(ctx context.Context) error {
 		Pool:            pool,
 		CharacterRepo:   postgres.NewCharacterRepository(pool),
 		LocationRepo:    postgres.NewLocationRepository(pool),
+		ObjectRepo:      postgres.NewObjectRepository(pool),
 		RoleStore:       roleStore,
 		AuditMode:       s.cfg.AuditMode,
 		CryptoOperators: s.cfg.CryptoOperators,

--- a/internal/grpc/subscribe_loop_test.go
+++ b/internal/grpc/subscribe_loop_test.go
@@ -379,7 +379,7 @@ func TestDispatchDeliveryDropsBelowScopeFloor(t *testing.T) {
 	stream := &fakeSubscribeStream{ctx: context.Background()}
 
 	// Event timestamp one hour BEFORE LocationArrivedAt → below floor.
-	d := makeLocationDelivery(t, locID.String(),arrivedAt.Add(-time.Hour))
+	d := makeLocationDelivery(t, locID.String(), arrivedAt.Add(-time.Hour))
 
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestDispatchDeliveryForwardsAtOrAboveScopeFloor(t *testing.T) {
 	stream := &fakeSubscribeStream{ctx: context.Background()}
 
 	// Event timestamp one minute AFTER LocationArrivedAt → above floor.
-	d := makeLocationDelivery(t, locID.String(),arrivedAt.Add(time.Minute))
+	d := makeLocationDelivery(t, locID.String(), arrivedAt.Add(time.Minute))
 
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err)
@@ -441,7 +441,7 @@ func TestDispatchDeliveryFallsBackToCachedInfoOnLookupFailure(t *testing.T) {
 
 	// Event timestamp AFTER cached LocationArrivedAt → above cached floor.
 	// With fallback to cached info, the event passes through.
-	d := makeLocationDelivery(t, locID.String(),arrivedAt.Add(time.Minute))
+	d := makeLocationDelivery(t, locID.String(), arrivedAt.Add(time.Minute))
 
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err,
@@ -470,7 +470,7 @@ func TestDispatchDeliveryUsesCachedFloorOnLookupFailure(t *testing.T) {
 	stream := &fakeSubscribeStream{ctx: context.Background()}
 
 	// Event timestamp BEFORE cached LocationArrivedAt → still dropped.
-	d := makeLocationDelivery(t, locID.String(),arrivedAt.Add(-time.Hour))
+	d := makeLocationDelivery(t, locID.String(), arrivedAt.Add(-time.Hour))
 
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err)

--- a/test/integration/access/access_suite_test.go
+++ b/test/integration/access/access_suite_test.go
@@ -43,6 +43,7 @@ type accessTestEnv struct {
 	cache       *policy.Cache
 	charRepo    *worldpg.CharacterRepository
 	locRepo     *worldpg.LocationRepository
+	objRepo     *worldpg.ObjectRepository
 	auditWriter *testAuditWriter
 	auditLogger *audit.Logger
 }
@@ -133,6 +134,7 @@ func setupAccessTestEnv() (*accessTestEnv, error) {
 
 	charRepo := worldpg.NewCharacterRepository(pool)
 	locRepo := worldpg.NewLocationRepository(pool)
+	objRepo := worldpg.NewObjectRepository(pool)
 
 	roleResolver := &staticRoleResolver{roles: make(map[string][]string)}
 
@@ -144,6 +146,17 @@ func setupAccessTestEnv() (*accessTestEnv, error) {
 
 	locProvider := attribute.NewLocationProvider(locRepo)
 	if err := resolver.RegisterProvider(locProvider); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
+	// holomush-k3ud: ObjectProvider needs charRepo to walk held-by-character
+	// chains. Registered here so seed:player-object-colocation evaluates via
+	// the REAL provider stack (privacytest harness uses allowAllPolicyEngine
+	// and would silently pass even with the provider missing — exactly the
+	// blind spot that hid the g776/xxel/k3ud bugs for weeks).
+	objProvider := attribute.NewObjectProvider(objRepo, charRepo)
+	if err := resolver.RegisterProvider(objProvider); err != nil {
 		pool.Close()
 		return nil, err
 	}
@@ -176,6 +189,7 @@ func setupAccessTestEnv() (*accessTestEnv, error) {
 		cache:       cache,
 		charRepo:    charRepo,
 		locRepo:     locRepo,
+		objRepo:     objRepo,
 		auditWriter: testWriter,
 		auditLogger: auditLogger,
 	}, nil

--- a/test/integration/access/evaluation_test.go
+++ b/test/integration/access/evaluation_test.go
@@ -25,6 +25,12 @@ var _ = Describe("ABAC Full Evaluation Path (Canary)", func() {
 
 		_, err := env.pool.Exec(ctx, "DELETE FROM player_character_bindings")
 		Expect(err).NotTo(HaveOccurred())
+		// Must precede characters/locations: held_by_character_id and
+		// location_id FKs are ON DELETE SET NULL, which would clear all
+		// three containment fields on any leftover object and violate
+		// chk_exactly_one_containment. Per holomush-k3ud regression test.
+		_, err = env.pool.Exec(ctx, "DELETE FROM objects")
+		Expect(err).NotTo(HaveOccurred())
 		_, err = env.pool.Exec(ctx, "DELETE FROM characters")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = env.pool.Exec(ctx, "DELETE FROM players")

--- a/test/integration/access/seed_policies_test.go
+++ b/test/integration/access/seed_policies_test.go
@@ -30,6 +30,12 @@ var _ = Describe("Seed Policy Behavior", func() {
 
 		_, err := env.pool.Exec(ctx, "DELETE FROM player_character_bindings")
 		Expect(err).NotTo(HaveOccurred())
+		// Must precede characters/locations: held_by_character_id and
+		// location_id FKs are ON DELETE SET NULL, which would clear all
+		// three containment fields on any leftover object and violate
+		// chk_exactly_one_containment. Per holomush-k3ud regression test.
+		_, err = env.pool.Exec(ctx, "DELETE FROM objects")
+		Expect(err).NotTo(HaveOccurred())
 		_, err = env.pool.Exec(ctx, "DELETE FROM characters")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = env.pool.Exec(ctx, "DELETE FROM players")
@@ -126,6 +132,90 @@ var _ = Describe("Seed Policy Behavior", func() {
 	Describe("Default deny", func() {
 		It("denies when no policies match", func() {
 			decision := evalAccess("character:"+charID1.String(), "admin_nuke", "location:"+locID1.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
+		})
+	})
+
+	// holomush-k3ud: regression lock for seed:player-object-colocation,
+	// exercised through the REAL ObjectProvider (transitive location walk
+	// included). Pins the bug fingerprint: without ObjectProvider
+	// registered, both 'allows reading a co-located object' AND 'allows
+	// reading an object held by a co-located character' would silently
+	// default-deny — the same default-deny shape as the original g776
+	// bug. The privacytest harness uses allowAllPolicyEngine and cannot
+	// catch this class of regression.
+	Describe("Object co-location (holomush-k3ud)", func() {
+		var (
+			objIDDirect ulid.ULID
+			objIDHeld   ulid.ULID
+			objIDNested ulid.ULID
+			containerID ulid.ULID
+		)
+
+		BeforeEach(func() {
+			ctx := context.Background()
+			_, err := env.pool.Exec(ctx, "DELETE FROM objects")
+			Expect(err).NotTo(HaveOccurred())
+
+			// 1. Object directly in locID1 (same as charID1's location).
+			objIDDirect = core.NewULID()
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, location_id, is_container)
+				VALUES ($1, 'Lantern', 'A brass lantern.', $2, false)`,
+				objIDDirect.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			// 2. Object held by charID2 (who is at locID1, same as charID1).
+			objIDHeld = core.NewULID()
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, held_by_character_id, is_container)
+				VALUES ($1, 'Note', 'A folded note.', $2, false)`,
+				objIDHeld.String(), charID2.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			// 3. Object inside a container at locID1 — exercises the
+			//    container-chain walk (a nested case the LocationProvider
+			//    fix did not cover).
+			containerID = core.NewULID()
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, location_id, is_container)
+				VALUES ($1, 'Chest', 'A wooden chest.', $2, true)`,
+				containerID.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			objIDNested = core.NewULID()
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+				VALUES ($1, 'Coin', 'A gold coin.', $2, false)`,
+				objIDNested.String(), containerID.String())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows reading a co-located object", func() {
+			decision := evalAccess("character:"+charID1.String(), "read", "object:"+objIDDirect.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("allows reading an object held by a co-located character", func() {
+			decision := evalAccess("character:"+charID1.String(), "read", "object:"+objIDHeld.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("allows reading an object inside a co-located container (container-chain walk)", func() {
+			decision := evalAccess("character:"+charID1.String(), "read", "object:"+objIDNested.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("denies reading an object in a different location", func() {
+			ctx := context.Background()
+			otherObj := core.NewULID()
+			_, err := env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, location_id, is_container)
+				VALUES ($1, 'Distant rock', '', $2, false)`,
+				otherObj.String(), locID2.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			decision := evalAccess("character:"+charID1.String(), "read", "object:"+otherObj.String())
 			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
 		})
 	})

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/samber/oops"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/samber/oops"
 
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/testsupport/privacytest"

--- a/test/integration/session/session_list_active_by_location_test.go
+++ b/test/integration/session/session_list_active_by_location_test.go
@@ -33,7 +33,8 @@ var _ = Describe("PostgresSessionStore.ListActiveByLocation (I-PRES-1)", func() 
 	// table. Only the columns that have no DEFAULT or are required for the
 	// test assertions are supplied; the rest rely on column DEFAULTs.
 	seedSession := func(id string, charID ulid.ULID, locID ulid.ULID, status string) {
-		_, err := env.pool.Exec(env.ctx,
+		_, err := env.pool.Exec(
+			env.ctx,
 			`INSERT INTO sessions (id, character_id, character_name, location_id, status)
 			 VALUES ($1, $2, $3, $4, $5)`,
 			id, charID.String(), "TestChar-"+id, locID.String(), status,
@@ -104,14 +105,16 @@ var _ = Describe("PostgresSessionStore.ListActiveByLocation (I-PRES-1)", func() 
 		charID := idgen.New()
 		futureExpiry := time.Now().Add(time.Hour)
 
-		_, err := env.pool.Exec(env.ctx,
+		_, err := env.pool.Exec(
+			env.ctx,
 			`INSERT INTO sessions (id, character_id, character_name, location_id, status, expires_at)
 			 VALUES ($1, $2, $3, $4, 'active', $5)`,
 			"dup-1", charID.String(), "DupChar", loc.String(), futureExpiry,
 		)
 		Expect(err).NotTo(HaveOccurred(), "first insert must succeed")
 
-		_, err = env.pool.Exec(env.ctx,
+		_, err = env.pool.Exec(
+			env.ctx,
 			`INSERT INTO sessions (id, character_id, character_name, location_id, status, expires_at)
 			 VALUES ($1, $2, $3, $4, 'active', $5)`,
 			"dup-2", charID.String(), "DupChar", loc.String(), futureExpiry,


### PR DESCRIPTION
## Summary

Closes `holomush-k3ud` (P1 bug). `ObjectProvider` was missing entirely from `internal/access/policy/attribute/` — the third silent default-deny gap after location (`holomush-g776`) and property (`holomush-72ou`) — caught by the startup-time seed-coverage validator from `holomush-xxel`. Six production callers in `internal/world/service.go` silently default-denied every check because `seed:player-object-colocation` gates on `resource.object.location`, which no provider populated.

## What this PR does

- **New** `internal/access/policy/attribute/object.go` — `ObjectProvider` with transitive-location walk via the containment chain (`LocationID` → that location; `HeldByCharacterID` → holder's location via `charRepo.Get`; `ContainedInObjectID` → recurse on container).
- Walk is bounded by `maxObjectChainDepth=16` + visited-set (cycle defense) + `objectChainTimeout=250ms` on the derived ctx. Diagnostic WARNs use the parent ctx so they still emit if the walk times out (abac-reviewer #2).
- `ResolveResource` is wildcard-tolerant (`object:*` from `Service.CreateObject` at `service.go:449`) per the `holomush-g776` pattern.
- Wired into `BuildABACStack` (mirroring the `LocationProvider` shape, with WARN when `ObjectRepo` is missing) and registered from `subsystem.go` via `postgres.NewObjectRepository(pool)`.
- Drops `"object"` from `AcknowledgedMissingSeedNamespaces`; the integration drift-detector (`TestBuildABACStack_SeedCoverageMatchesAcknowledged`) passes.

## Tests

- **Unit**: 19 cases in `object_test.go` — direct location, held-by-character (resolved & nil), multi-level container chain, circular containment (visited-set defense), `nil` charRepo tolerance, wildcard, repo errors.
- **Integration**: New `"Object co-location (holomush-k3ud)"` `Describe` block in `test/integration/access/seed_policies_test.go` exercises the REAL `engine.Evaluate` path with `seed:player-object-colocation` — three permit cases (direct location, held-by-co-located-character, inside-co-located-container) plus one default-deny case (different location). The `privacytest` harness uses `allowAllPolicyEngine` and cannot catch this class of bug — per the `holomush-g776` lesson.

## Drive-by

- `DELETE FROM objects` added to two integration `BeforeEach` blocks (`seed_policies_test.go`, `evaluation_test.go`) — without it, the `held_by_character_id` FK `ON DELETE SET NULL` violates `chk_exactly_one_containment` when test 1 leaves objects behind for test 2's character cleanup.
- Three trivial `gofumpt` fixes (missing-space-after-comma) in pre-existing main drift that `task fmt` picked up.

## Review

Both pre-push reviewers verdict `READY` (non-blocking findings only):

- `code-reviewer`: integration container-chain test only walks one hop (unit tests cover deeper); duplicate WARN seed-list (corpus sweep is authoritative).
- `abac-reviewer #1`: empty-string colocation collision when both sides un-locatable — pre-existing pattern in `seed:player-character-colocation`; filed as `holomush-9gtl` (P2).

`task pr-prep` green on full lane: lint, format, schema, license, unit, integration (1653 tests), E2E (62/62 in 79.5s).

## Follow-ups filed

- `holomush-o8g6` (P2) — Unify `<type>:<ulid>` parsing across Location/Character/Property/Object providers.
- `holomush-9gtl` (P2) — DSL `has_location` guard on colocation seeds (closes the empty-string-equality hole that pre-dates this PR for characters and is extended to objects here).

## Test plan

- [x] `task test -- ./internal/access/policy/attribute/ ./internal/access/setup/` — 263 tests pass
- [x] `task test:int -- ./test/integration/access/` — 21/21 Ginkgo specs pass (incl. new `Object co-location` block + drift-detector)
- [x] `task pr-prep` — full lane green
- [x] `task lint` — clean
- [x] `task build` — clean
- [x] Both pre-push review gates: `code-reviewer` READY, `abac-reviewer` READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for object-scoped access control, resolving transitive location info for objects placed in locations, held by characters, or nested in containers.

* **Documentation**
  * Documented an edge case where empty-string location attributes can compare equal for un-locatable entities and suggested mitigation approaches.

* **Tests**
  * Expanded unit and integration coverage for object attribute resolution, containment traversal, co-location regression, and seed-provider coverage validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->