### PR TITLE
fix(access): providers omit optional location attrs when unresolved (9gtl/ti1b)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -62,20 +62,28 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   `PolicyInstaller.InstallPluginPolicies`) are NOT scanned — same silent-deny
   class can recur for plugin-declared namespaces. Symmetric stale-entry
   direction IS asserted at `seed_coverage_test.go:154-160`.
-- **Co-location seed empty-string equality (2026-05-21)**: all three
-  co-location seeds (`seed:player-character-colocation`,
-  `seed:player-object-colocation`, `seed:player-location-stream-read`)
-  compare `resource.<ns>.location == principal.character.location` as raw
-  strings. Providers emit `attrs["location"] = ""` (NOT absent) when the
-  entity is un-locatable. DSL `evalComparison` treats `"" == ""` as TRUE
-  because both values are present strings; only *missing* attributes
-  short-circuit to false (`internal/access/policy/dsl/evaluator.go:128`).
-  Net: a character with `LocationID == nil` reading any un-locatable
-  resource gets permit. Not a new defect (predates k3ud); not yet fixed.
-  Two viable patches: (a) DSL gate `&& principal.character.has_location
-  && resource.<ns>.has_location` per seed (`has_location` is already in
-  every schema), or (b) providers omit the `location` key entirely when
-  un-locatable. Worth flagging on any co-location-seed work.
+- **Co-location seed empty-string equality — FIXED (holomush-9gtl / ADR ti1b, 2026-05-22)**:
+  three co-location seeds (`seed:player-character-colocation`,
+  `seed:player-object-colocation`, `seed:property-public-read`) compared
+  `resource.<ns>.location == principal.character.location` as raw strings.
+  Pre-fix, Character/Object/Property providers emitted `""` sentinels for
+  unresolved optional location attrs, and DSL `evalComparison` treats
+  `"" == ""` as TRUE (only *missing* keys short-circuit to false per
+  `evaluator.go:128`). Fix landed via option (b): providers OMIT the
+  `location` / `parent_location` key when unresolved. The `has_X` boolean
+  witness stays present. ADR `holomush-ti1b` codifies the invariant
+  ("AttributeProviders MUST omit optional attrs, never emit empty-string
+  sentinels"); rule file `.claude/rules/abac-providers.md` auto-loads on
+  `internal/access/policy/attribute/**`. Follow-up `holomush-awb3` (P3)
+  sweeps the remaining optional attrs (`owner_id`, `held_by_character_id`,
+  `contained_in_object_id`, property `value` / `owner`) — those still emit
+  `""` but are safe against the current seed set because the LHS in those
+  comparisons (e.g. `principal.character.id`) is always a non-empty ULID.
+  Regression locked at `test/integration/access/seed_policies_test.go:239-333`
+  via real-engine fingerprints (NULL `location_id`, containment cycle
+  constructed via raw SQL UPDATE that bypasses `ObjectRepository.Move`'s
+  guard). When reviewing future AttributeProvider edits, flag any
+  `attrs["X"] = ""` followed by `attrs["has_X"] = false` as a fail-open bug.
 - **Wildcard resource IDs (`type:*`) bypass per-instance attrs**:
   `service.CreateLocation` / `service.FindLocationByName` /
   `service.CreateExit` / `service.CreateObject` all call `checkAccess`

--- a/.claude/rules/abac-providers.md
+++ b/.claude/rules/abac-providers.md
@@ -39,7 +39,9 @@ if char.LocationID != nil {
 
 ### `has_X` witness convention
 
-A provider MAY (and is encouraged to) emit a `has_X` boolean witness alongside the optional attribute. The witness MUST always be present (even when false). Omission applies only to the value attribute, not the witness — seeds that need to explicitly check existence via DSL `has` use the witness.
+A provider SHOULD emit a `has_X` boolean witness alongside every optional attribute. When emitted, the witness MUST always be present (true or false on every code path) — omission applies only to the value attribute, never to the witness. Seeds that need to explicitly check existence via DSL `has` use the witness.
+
+A provider MAY skip the witness only when no seed could plausibly want to disambiguate "absent" from "present-but-empty" for that attribute (e.g., enum-typed attrs with a defined absent value). Every current provider in this directory carries the witness; new optional attrs SHOULD ship with theirs on day one.
 
 ## When you see this pattern
 
@@ -47,4 +49,4 @@ If you encounter `attrs["X"] = ""` followed by `attrs["has_X"] = false` (or any 
 
 ## Reference example
 
-`StreamProvider` at `internal/access/policy/attribute/stream.go:46-48` is the canonical reference: `attrs["location"]` is set ONLY when the stream name has the `location:` prefix. For non-location streams, the key is absent and DSL comparisons short-circuit to false.
+`StreamProvider` at `internal/access/policy/attribute/stream.go:40-48` is the canonical reference. The returned bag is initialized with only `type` and `name`; `attrs["location"]` is added ONLY inside the `if strings.HasPrefix(id, "location:")` block. For non-location streams the `location` key is simply absent — the DSL evaluator's missing-attr semantics ([ADR holomush-iv43](../../docs/adr/holomush-iv43-cedar-aligned-fail-safe-type-semantics.md)) handle the rest.

--- a/.claude/rules/abac-providers.md
+++ b/.claude/rules/abac-providers.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "internal/access/policy/attribute/**"
+---
+
+# ABAC AttributeProvider Invariants
+
+This rule auto-loads when editing AttributeProvider implementations under `internal/access/policy/attribute/`. The full rationale lives in [ADR holomush-ti1b](../../docs/adr/holomush-ti1b-providers-omit-optional-attrs.md).
+
+## Optional attribute emission — omit, do not sentinel
+
+**Project invariant: AttributeProviders MUST omit optional attribute keys from the returned bag when the value is unresolved or not applicable. They MUST NOT emit empty-string (or any other type-checking-passable) sentinel values.**
+
+The DSL evaluator's fail-safe semantics ([ADR holomush-iv43](../../docs/adr/holomush-iv43-cedar-aligned-fail-safe-type-semantics.md)) treat MISSING attributes as `false` for every operator. They do NOT treat empty-string values as missing — `"" == ""` evaluates to `true`. Emitting an empty-string sentinel for an absent attribute defeats the fail-safe and creates a fail-open match against any other un-resolved peer attribute.
+
+### Required form
+
+```go
+if char.LocationID != nil {
+    attrs["location"] = char.LocationID.String()
+    attrs["has_location"] = true
+} else {
+    attrs["has_location"] = false
+    // `location` key INTENTIONALLY ABSENT (ADR holomush-9gtl)
+}
+```
+
+### Forbidden form
+
+```go
+if char.LocationID != nil {
+    attrs["location"] = char.LocationID.String()
+    attrs["has_location"] = true
+} else {
+    attrs["location"] = ""   // ← creates a permit-match against any other un-resolved peer
+    attrs["has_location"] = false
+}
+```
+
+### `has_X` witness convention
+
+A provider MAY (and is encouraged to) emit a `has_X` boolean witness alongside the optional attribute. The witness MUST always be present (even when false). Omission applies only to the value attribute, not the witness — seeds that need to explicitly check existence via DSL `has` use the witness.
+
+## When you see this pattern
+
+If you encounter `attrs["X"] = ""` followed by `attrs["has_X"] = false` (or any analogous "present sentinel + false witness" pattern) in an AttributeProvider, treat it as a fail-open bug per `holomush-9gtl`. Replace with the required form above and add a test asserting the key is absent.
+
+## Reference example
+
+`StreamProvider` at `internal/access/policy/attribute/stream.go:46-48` is the canonical reference: `attrs["location"]` is set ONLY when the stream name has the `location:` prefix. For non-location streams, the key is absent and DSL comparisons short-circuit to false.

--- a/docs/adr/holomush-ti1b-providers-omit-optional-attrs.md
+++ b/docs/adr/holomush-ti1b-providers-omit-optional-attrs.md
@@ -97,10 +97,17 @@ if char.LocationID != nil {
 
 ### Companion `has_X` boolean witness
 
-A provider MAY (and is encouraged to) emit a `has_X` boolean witness alongside the
-optional attribute. The witness is for seeds that need to explicitly check existence via
-DSL `has` or `principal.X.has_Y &&` conjunctions. The witness MUST always be present;
-omission applies only to the value attribute.
+A provider SHOULD emit a `has_X` boolean witness alongside every optional attribute. The
+witness lets seeds explicitly check existence via DSL `has` or
+`principal.X.has_Y &&` conjunctions without relying on a sentinel value. When emitted,
+the witness MUST always be present (true or false on every code path) — omission applies
+only to the value attribute, never to the witness.
+
+A provider MAY skip the witness only when no seed could plausibly want to disambiguate
+"absent" from "present-but-empty" for that attribute (e.g., enum-typed attrs whose
+absence has a distinct defined value rather than an absent-data signal). In practice
+every current provider in `internal/access/policy/attribute/` carries the witness, and
+any new optional attribute SHOULD ship with its witness on day one.
 
 ## Scope
 

--- a/docs/adr/holomush-ti1b-providers-omit-optional-attrs.md
+++ b/docs/adr/holomush-ti1b-providers-omit-optional-attrs.md
@@ -1,0 +1,232 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# AttributeProviders MUST Omit Optional Attributes (Not Emit Empty-String Sentinels)
+
+**Date:** 2026-05-22
+**Status:** Accepted
+**Decision:** holomush-ti1b
+**Motivating bug:** holomush-9gtl
+**Deciders:** HoloMUSH Contributors
+**Related:** [holomush-iv43](holomush-iv43-cedar-aligned-fail-safe-type-semantics.md) (Cedar fail-safe DSL semantics — required parent)
+
+## Context
+
+ADR [holomush-iv43](holomush-iv43-cedar-aligned-fail-safe-type-semantics.md) (originally
+ADR 0010) established that the DSL evaluator treats **missing attributes** as `false` for
+every operator (Cedar-aligned fail-safe semantics). This is the DSL-side guarantee.
+
+The **provider side** of the same contract was not stated explicitly until this ADR. As
+the codebase grew, providers diverged in how they represented "this attribute is not
+applicable for this entity":
+
+| Provider          | When the optional attr is unresolved | Behavior |
+| ----------------- | ------------------------------------ | -------- |
+| `StreamProvider`  | Stream is not a `location:*` stream  | OMIT `attrs["location"]` entirely |
+| `CharacterProvider` | Character has no `LocationID`      | Emitted `attrs["location"] = ""` (empty-string sentinel) |
+| `ObjectProvider`  | Container chain cannot resolve to a location | Emitted `attrs["location"] = ""` |
+| `PropertyProvider` | `ParentLocationResolver` returns nil / errors | Emitted `attrs["parent_location"] = ""` |
+
+The empty-string-sentinel approach silently broke fail-safe semantics because the DSL
+evaluator treats `"" == ""` as `true` (both values are *present* strings). The Cedar
+fail-safe guarantee from [holomush-iv43](holomush-iv43-cedar-aligned-fail-safe-type-semantics.md)
+ONLY fires for MISSING attributes (see [`internal/access/policy/dsl/evaluator.go:128-136`](../../internal/access/policy/dsl/evaluator.go),
+function `evalComparison`).
+
+### The bug class this ADR closes
+
+Two seed policies in [`internal/access/policy/seed.go`](../../internal/access/policy/seed.go)
+use the colocation pattern:
+
+```text
+seed:player-character-colocation:
+  permit when { resource.character.location == principal.character.location };
+seed:player-object-colocation:
+  permit when { resource.object.location == principal.character.location };
+```
+
+With empty-string sentinels:
+
+- Two un-locatable characters → `"" == ""` → **permit** (fail-open)
+- Un-locatable character + un-locatable object (cycle/depth-exceeded/broken-chain) →
+  `"" == ""` → **permit** (fail-open)
+
+The window is narrow in practice (characters routinely have `LocationID` set after spawn),
+but the bug class extends to any future seed gating on `resource.X.location` or
+`resource.X.parent_location`. `StreamProvider` already avoided the bug by following the
+correct pattern.
+
+### Why the existing DSL-level fix (ADR holomush-iv43) is necessary but insufficient
+
+Cedar fail-safe semantics on the DSL evaluator are correct: a **missing** attribute
+short-circuits comparisons to `false`. But the evaluator cannot distinguish "missing"
+from "present-with-empty-string-sentinel." The provider must cooperate by genuinely
+omitting the attribute, not encoding "absent" as `""`.
+
+## Decision
+
+**`AttributeProvider` implementations MUST omit optional attribute keys from the
+returned bag when the value is unresolved or not applicable. They MUST NOT emit
+empty-string (or any other type-checking-passable) sentinel values.**
+
+### Required form
+
+```go
+// Correct: omit on unresolved
+if char.LocationID != nil {
+    attrs["location"] = char.LocationID.String()
+    attrs["has_location"] = true
+} else {
+    attrs["has_location"] = false
+    // `location` key is INTENTIONALLY ABSENT
+}
+```
+
+### Forbidden form
+
+```go
+// WRONG: emits empty-string sentinel
+if char.LocationID != nil {
+    attrs["location"] = char.LocationID.String()
+    attrs["has_location"] = true
+} else {
+    attrs["location"] = ""   // ← creates a permit-match against any other un-locatable peer
+    attrs["has_location"] = false
+}
+```
+
+### Companion `has_X` boolean witness
+
+A provider MAY (and is encouraged to) emit a `has_X` boolean witness alongside the
+optional attribute. The witness is for seeds that need to explicitly check existence via
+DSL `has` or `principal.X.has_Y &&` conjunctions. The witness MUST always be present;
+omission applies only to the value attribute.
+
+## Scope
+
+The invariant applies to **every** optional `AttributeProvider` attribute, not only
+location-related ones. This ADR was motivated by the colocation bug (`holomush-9gtl`),
+but the principle is general — any optional attribute that could be the right-hand side
+of a `==` comparison against another un-resolved peer attribute is vulnerable.
+
+Initial application in `holomush-9gtl`:
+
+- `CharacterProvider.location` / `location_id` — fixed
+- `ObjectProvider.location` — fixed
+- `PropertyProvider.parent_location` — fixed
+
+Follow-up `holomush-awb3` extends the pattern to the remaining optional attrs across
+all four providers (e.g., `owner_id`, `held_by_character_id`, `contained_in_object_id`,
+`shadows_id`, property `value`/`owner`).
+
+## Rationale
+
+**Defense-in-depth over single-layer safety.** ADR holomush-iv43 made the DSL evaluator
+fail-safe for missing attrs. This ADR makes the provider side cooperate. Combined, the
+fail-safe guarantee holds end-to-end. Either layer alone is insufficient: a permissive
+provider defeats a strict evaluator, and a strict provider can't fix a permissive
+evaluator.
+
+**Consistency with existing precedent.** `StreamProvider` already follows this pattern
+(`internal/access/policy/attribute/stream.go:46-48` sets `attrs["location"]` only when
+the stream name has the `location:` prefix). Choosing this approach unifies practice
+rather than introducing a third pattern.
+
+**No DSL-side footgun for future seed authors.** The alternative — add explicit
+`has_location` guards in every colocation seed — would work but creates a footgun: a
+new seed author who forgets the guard re-introduces the bug. Provider-level omission is
+automatic and applies to all future seeds.
+
+**Schema declaration is decoupled from runtime emission.** The provider's `Schema()`
+method declares attribute *types* (used at DSL compile time per the eager-resolution
+ADR). Whether the attribute is *present* at runtime is independent. Omitting a
+schema-declared attr at runtime is contract-safe — the DSL compiler still accepts
+references to it, and the evaluator handles missing keys via the iv43 contract.
+
+## Consequences
+
+**Positive:**
+
+- Default-deny preserved end-to-end across colocation and any future seed gating on
+  an optional attribute equality.
+- Provider behavior unified — same pattern across `Character`, `Object`, `Property`,
+  `Stream`, and future providers.
+- Lower cognitive load on seed authors — they don't need to remember to add `has_X`
+  guards for every optional reference.
+
+**Negative:**
+
+- Provider implementations slightly more verbose (must remember to omit, not just emit
+  an empty-string default).
+- A future maintainer who reads only the provider code may assume the attribute is
+  always present (mitigated by the always-present `has_X` witness convention and the
+  rule file at [`.claude/rules/abac-providers.md`](../../.claude/rules/abac-providers.md)
+  that auto-loads on the `internal/access/policy/attribute/` directory).
+
+**Neutral:**
+
+- Tests that explicitly assert `attrs["X"] == ""` need to be updated to assert the key
+  is absent via `_, present := attrs["X"]; assert.False(t, present)`. Existing tests
+  updated as part of `holomush-9gtl`.
+
+## Enforcement
+
+Enforcement is **convention-with-documentation** (no custom linter today):
+
+1. **Rule file at [`.claude/rules/abac-providers.md`](../../.claude/rules/abac-providers.md)**
+   auto-loads when editing the `internal/access/policy/attribute/` directory and
+   restates this invariant inline for any contributor or AI assistant working in that
+   tree.
+2. **Pre-push `abac-reviewer` sub-agent** ([`.claude/agents/abac-reviewer.md`](../../.claude/agents/abac-reviewer.md))
+   is briefed via the rule file and CLAUDE.md gates and MUST flag any new
+   `attrs["X"] = ""` followed by `attrs["has_X"] = false` pattern.
+3. **A static analyzer to enforce this mechanically** is tracked as a future follow-up
+   (`holomush-awb3` may surface or spawn the lint bead). The convention-and-review
+   approach is sufficient for the four-provider population; a custom analyzer is
+   justified only if the provider count grows or if a regression slips past review.
+
+## Alternatives Considered
+
+### Option (a): DSL-side `has_location` guards on every colocation seed
+
+```text
+permit when {
+    principal.character.has_location &&
+    resource.character.has_location &&
+    resource.character.location == principal.character.location
+};
+```
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Localized to the seeds; no provider changes |
+| Weaknesses | Footgun for future seed authors; doesn't generalize to other optional attrs; creates a third pattern (Stream uses omission, providers use sentinel, seeds add guards) |
+
+Rejected: the footgun is the deciding factor. A single forgotten `has_X` clause re-introduces the bug class.
+
+### Option (b): Provider-level omission (this ADR)
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Unifies practice with `StreamProvider`; automatic for all future seeds; smaller surface |
+| Weaknesses | Provider implementations marginally more verbose |
+
+Accepted.
+
+### Option (c): Belt-and-suspenders (both (a) and (b))
+
+| Aspect     | Assessment |
+| ---------- | ---------- |
+| Strengths  | Defense-in-depth |
+| Weaknesses | Redundant given (b) already guarantees the property at the evaluator/provider boundary; adds DSL complexity for no incremental safety |
+
+Rejected: the redundancy is unmotivated. The provider-side fix is the load-bearing one.
+
+## References
+
+- [ADR holomush-iv43: Cedar-Aligned Fail-Safe Type Semantics](holomush-iv43-cedar-aligned-fail-safe-type-semantics.md) — parent decision establishing DSL missing-attr semantics
+- [`internal/access/policy/dsl/evaluator.go`](../../internal/access/policy/dsl/evaluator.go) — `evalComparison` (line 128), `resolveAttrRef` (line 401)
+- [`internal/access/policy/attribute/stream.go`](../../internal/access/policy/attribute/stream.go) — existing precedent for the pattern (lines 46-48)
+- [`internal/access/policy/seed.go`](../../internal/access/policy/seed.go) — colocation seeds affected by the bug class (lines 50, 56, 110)
+- bead `holomush-9gtl` — original bug report and fix bead
+- bead `holomush-awb3` (filed concurrent with this ADR) — sweep remaining optional attrs across the four providers

--- a/internal/access/policy/attribute/character.go
+++ b/internal/access/policy/attribute/character.go
@@ -103,15 +103,21 @@ func (p *CharacterProvider) resolve(ctx context.Context, entityID string) (map[s
 		"roles":       roles,
 	}
 
-	// Handle optional location — expose as both "location_id" (raw) and "location" (for seed policies)
+	// Handle optional location — expose as both "location_id" (raw) and "location" (for seed policies).
+	//
+	// Per ADR holomush-ti1b (motivating bug holomush-9gtl): when has_location=false the `location` and
+	// `location_id` keys MUST be OMITTED from the bag (not emitted as
+	// empty-string sentinels). This leverages the DSL evaluator's
+	// missing-attr-→-false semantics (ADR holomush-iv43 / 0010) to
+	// preserve default-deny on colocation seeds when either side is
+	// un-locatable. Emitting "" would satisfy `"" == ""` and create a
+	// fail-open match (the original 9gtl reproducer).
 	if char.LocationID != nil {
 		locStr := char.LocationID.String()
 		attrs["location_id"] = locStr
 		attrs["location"] = locStr
 		attrs["has_location"] = true
 	} else {
-		attrs["location_id"] = ""
-		attrs["location"] = ""
 		attrs["has_location"] = false
 	}
 

--- a/internal/access/policy/attribute/character_test.go
+++ b/internal/access/policy/attribute/character_test.go
@@ -149,14 +149,16 @@ func TestCharacterProvider_ResolveSubject(t *testing.T) {
 					}, nil
 				}
 			},
+			// Per ADR holomush-ti1b: location and location_id keys are
+			// OMITTED from the bag when has_location=false. The DSL
+			// evaluator's missing-attr-→-false semantics preserve
+			// default-deny on colocation seeds.
 			expectAttrs: map[string]any{
 				"id":           charID.String(),
 				"player_id":    playerID.String(),
 				"name":         "NoLocChar",
 				"description":  "",
 				"roles":        []string{"player"},
-				"location_id":  "",
-				"location":     "",
 				"has_location": false,
 			},
 		},

--- a/internal/access/policy/attribute/object.go
+++ b/internal/access/policy/attribute/object.go
@@ -134,9 +134,19 @@ func (p *ObjectProvider) ResolveResource(ctx context.Context, resourceID string)
 		attrs["is_contained"] = false
 	}
 
-	locStr, ok := p.resolveEffectiveLocation(ctx, obj)
-	attrs["location"] = locStr
-	attrs["has_location"] = ok
+	// Per ADR holomush-ti1b (motivating bug holomush-9gtl): when the containment chain cannot be
+	// resolved (cycle, max-depth, broken parent, holder character
+	// missing, charRepo nil, etc.), the `location` key MUST be OMITTED
+	// from the bag — NOT emitted as an empty-string sentinel. This
+	// leverages the DSL evaluator's missing-attr-→-false semantics
+	// (ADR holomush-iv43 / 0010) to preserve default-deny on
+	// seed:player-object-colocation when either side is un-locatable.
+	if locStr, ok := p.resolveEffectiveLocation(ctx, obj); ok {
+		attrs["location"] = locStr
+		attrs["has_location"] = true
+	} else {
+		attrs["has_location"] = false
+	}
 
 	return attrs, nil
 }

--- a/internal/access/policy/attribute/object_test.go
+++ b/internal/access/policy/attribute/object_test.go
@@ -152,6 +152,12 @@ func TestObjectProviderResolveResource(t *testing.T) {
 		// Only a subset of attrs are asserted via expectSubset; this keeps
 		// table cases focused on what each case is actually verifying.
 		expectSubset map[string]any
+		// expectAbsent lists keys that MUST NOT be present in attrs.
+		// Per ADR holomush-ti1b: providers omit optional attrs when
+		// unresolved (e.g., `location` when has_location=false), so the
+		// DSL evaluator's missing-attr-→-false semantics preserve
+		// default-deny on colocation seeds.
+		expectAbsent []string
 		expectNil    bool
 		expectErr    bool
 		errSubstring string
@@ -247,11 +253,11 @@ func TestObjectProviderResolveResource(t *testing.T) {
 				}
 			},
 			expectSubset: map[string]any{
-				"location":             "",
 				"has_location":         false,
 				"held_by_character_id": charID.String(),
 				"is_held":              true,
 			},
+			expectAbsent: []string{"location"},
 		},
 		{
 			name:       "object inside a container — walks one level to find location",
@@ -346,9 +352,9 @@ func TestObjectProviderResolveResource(t *testing.T) {
 				"id":                     objID.String(),
 				"contained_in_object_id": containerID.String(),
 				"is_contained":           true,
-				"location":               "",
 				"has_location":           false,
 			},
+			expectAbsent: []string{"location"},
 		},
 		{
 			name:       "character holder lookup fails → has_location=false but other attrs populated",
@@ -367,9 +373,9 @@ func TestObjectProviderResolveResource(t *testing.T) {
 				"id":                   objID.String(),
 				"held_by_character_id": charID.String(),
 				"is_held":              true,
-				"location":             "",
 				"has_location":         false,
 			},
+			expectAbsent: []string{"location"},
 		},
 		{
 			name:       "circular containment → bounded by visited-set, has_location=false",
@@ -389,8 +395,8 @@ func TestObjectProviderResolveResource(t *testing.T) {
 			},
 			expectSubset: map[string]any{
 				"has_location": false,
-				"location":     "",
 			},
+			expectAbsent: []string{"location"},
 		},
 		{
 			name:         "wrong entity type (location)",
@@ -476,6 +482,11 @@ func TestObjectProviderResolveResource(t *testing.T) {
 			for k, want := range tt.expectSubset {
 				assert.Equal(t, want, attrs[k], "attribute %q", k)
 			}
+			for _, k := range tt.expectAbsent {
+				_, present := attrs[k]
+				assert.False(t, present,
+					"attribute %q MUST be absent per ADR holomush-ti1b (un-locatable → omit, not empty-string sentinel)", k)
+			}
 		})
 	}
 }
@@ -502,7 +513,8 @@ func TestObjectProviderResolveResource_NilCharacterRepoIsTolerated(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, attrs)
 	assert.Equal(t, false, attrs["has_location"])
-	assert.Equal(t, "", attrs["location"])
+	_, present := attrs["location"]
+	assert.False(t, present, "ADR holomush-ti1b: un-locatable → omit 'location' key")
 	assert.Equal(t, charID.String(), attrs["held_by_character_id"])
 }
 
@@ -549,7 +561,8 @@ func TestObjectProviderResolveResource_NilRepoReturnsAreGuarded(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
 		assert.Equal(t, false, attrs["has_location"])
-		assert.Equal(t, "", attrs["location"])
+		_, present := attrs["location"]
+		assert.False(t, present, "ADR holomush-ti1b: un-locatable → omit 'location' key")
 	})
 
 	t.Run("parent container Get returns (nil, nil) → un-locatable, no panic", func(t *testing.T) {
@@ -567,6 +580,7 @@ func TestObjectProviderResolveResource_NilRepoReturnsAreGuarded(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, attrs)
 		assert.Equal(t, false, attrs["has_location"])
-		assert.Equal(t, "", attrs["location"])
+		_, present := attrs["location"]
+		assert.False(t, present, "ADR holomush-ti1b: un-locatable → omit 'location' key")
 	})
 }

--- a/internal/access/policy/attribute/property.go
+++ b/internal/access/policy/attribute/property.go
@@ -112,7 +112,15 @@ func (p *PropertyProvider) ResolveResource(ctx context.Context, resourceID strin
 // resolveParentLocation resolves the parent_location attribute.
 // For location parents, parent_location = parent_id.
 // For character/object parents, uses the ParentLocationResolver.
-// Sets parent_location="" and has_parent_location=false on timeout or error.
+//
+// Per ADR holomush-ti1b (motivating bug holomush-9gtl): when the parent location cannot be resolved
+// (timeout, error, character without location, etc.), the
+// `parent_location` key MUST be OMITTED from the bag — NOT emitted as
+// an empty-string sentinel. This leverages the DSL evaluator's
+// missing-attr-→-false semantics (ADR holomush-iv43 / 0010) to preserve
+// default-deny on seed:property-public-read when either side is
+// un-locatable. has_parent_location stays as a boolean witness so the
+// DSL can still check existence via `has` if a future seed needs it.
 func (p *PropertyProvider) resolveParentLocation(ctx context.Context, prop *world.EntityProperty, attrs map[string]any) {
 	// If parent is a location, parent_location = parent_id
 	if prop.ParentType == "location" {
@@ -127,20 +135,18 @@ func (p *PropertyProvider) resolveParentLocation(ctx context.Context, prop *worl
 
 	locationID, err := p.resolver.ResolveParentLocation(resolveCtx, prop.ParentType, prop.ParentID)
 	if err != nil {
-		// Log warning and set parent_location as unresolvable
+		// Log warning and omit parent_location key (un-locatable parent)
 		slog.WarnContext(ctx, "failed to resolve parent location",
 			"property_id", prop.ID.String(),
 			"parent_type", prop.ParentType,
 			"parent_id", prop.ParentID.String(),
 			"error", err)
-		attrs["parent_location"] = ""
 		attrs["has_parent_location"] = false
 		return
 	}
 
 	if locationID == nil {
 		// Unresolvable (e.g., character not in a location)
-		attrs["parent_location"] = ""
 		attrs["has_parent_location"] = false
 		return
 	}

--- a/internal/access/policy/attribute/property_test.go
+++ b/internal/access/policy/attribute/property_test.go
@@ -234,6 +234,8 @@ func TestPropertyProvider_ResolveResource(t *testing.T) {
 				Visibility: "public",
 			},
 			resolverResult: nil,
+			// Per ADR holomush-ti1b: parent_location key OMITTED when
+			// has_parent_location=false (un-locatable parent).
 			expectedAttrs: map[string]any{
 				"id":                  propID.String(),
 				"parent_type":         "character",
@@ -244,7 +246,6 @@ func TestPropertyProvider_ResolveResource(t *testing.T) {
 				"owner":               "owner:01ABC",
 				"has_owner":           true,
 				"visibility":          "public",
-				"parent_location":     "",
 				"has_parent_location": false,
 			},
 			expectResolverCall: true,
@@ -262,6 +263,9 @@ func TestPropertyProvider_ResolveResource(t *testing.T) {
 				Visibility: "public",
 			},
 			resolverErr: errors.New("resolver error"),
+			// Per ADR holomush-ti1b: parent_location key OMITTED when
+			// has_parent_location=false (resolver error treated as
+			// un-locatable parent).
 			expectedAttrs: map[string]any{
 				"id":                  propID.String(),
 				"parent_type":         "character",
@@ -272,7 +276,6 @@ func TestPropertyProvider_ResolveResource(t *testing.T) {
 				"owner":               "owner:01ABC",
 				"has_owner":           true,
 				"visibility":          "public",
-				"parent_location":     "",
 				"has_parent_location": false,
 			},
 			expectResolverCall: true,
@@ -399,7 +402,9 @@ func TestPropertyProviderResolveResourceTimeout(t *testing.T) {
 	attrs, err := provider.ResolveResource(context.Background(), "property:"+propID.String())
 
 	require.NoError(t, err)
-	assert.Equal(t, "", attrs["parent_location"], "parent_location should be empty on timeout")
+	_, present := attrs["parent_location"]
+	assert.False(t, present,
+		"ADR holomush-ti1b: parent_location key MUST be absent on timeout (un-locatable parent)")
 	assert.Equal(t, false, attrs["has_parent_location"], "has_parent_location should be false on timeout")
 }
 

--- a/test/integration/access/seed_policies_test.go
+++ b/test/integration/access/seed_policies_test.go
@@ -219,4 +219,119 @@ var _ = Describe("Seed Policy Behavior", func() {
 			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
 		})
 	})
+
+	// holomush-9gtl: regression lock for the empty-string-equality
+	// permissive-match gap. Before this fix, CharacterProvider and
+	// ObjectProvider emitted location="" when has_location=false, and
+	// PropertyProvider emitted parent_location="" when
+	// has_parent_location=false. The colocation/colocation-style seeds
+	// gate via `resource.X.location == principal.character.location`,
+	// and the DSL evaluator treats `"" == ""` as true (both values are
+	// present strings; only missing keys short-circuit to false per ADR
+	// 0010 / holomush-iv43). Result: any character without a location
+	// could read any object/character/property also in an un-locatable
+	// state — a narrow but real fail-open.
+	//
+	// Fix per ADR holomush-ti1b: providers MUST omit the optional
+	// `location` / `parent_location` key when unresolved. DSL missing-
+	// attribute semantics then short-circuit the comparison to false,
+	// preserving default-deny.
+	Describe("Un-locatable empty-string equality is NOT permissive (holomush-9gtl)", func() {
+		var (
+			unlocChar1 ulid.ULID
+			unlocChar2 ulid.ULID
+		)
+
+		BeforeEach(func() {
+			ctx := context.Background()
+
+			// Two characters with NO location. The pre-9gtl bug:
+			// CharacterProvider emits "location": "" for both, then
+			// `"" == ""` matches → seed:player-character-colocation
+			// permits the read between them.
+			unlocChar1 = core.NewULID()
+			unlocChar2 = core.NewULID()
+			playerA := core.NewULID()
+			playerB := core.NewULID()
+			// Use the ULID itself as the username-uniqueness anchor —
+			// time.Now() in two adjacent inserts can collide on the
+			// 1ms-precision UNIQUE(username) index.
+			_, err := env.pool.Exec(ctx, `
+				INSERT INTO players (id, username, password_hash)
+				VALUES ($1, $2, 'hashA')`,
+				playerA.String(), "unlocA_"+playerA.String())
+			Expect(err).NotTo(HaveOccurred())
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO players (id, username, password_hash)
+				VALUES ($1, $2, 'hashB')`,
+				playerB.String(), "unlocB_"+playerB.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO characters (id, player_id, name, location_id)
+				VALUES ($1, $2, 'Drifter1', NULL)`,
+				unlocChar1.String(), playerA.String())
+			Expect(err).NotTo(HaveOccurred())
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO characters (id, player_id, name, location_id)
+				VALUES ($1, $2, 'Drifter2', NULL)`,
+				unlocChar2.String(), playerB.String())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("denies reading another un-locatable character (character-character)", func() {
+			decision := evalAccess("character:"+unlocChar1.String(), "read", "character:"+unlocChar2.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny),
+				"un-locatable characters MUST NOT see each other via seed:player-character-colocation. "+
+					"The 'location' attr must be omitted (not emitted as empty string) when has_location=false.")
+		})
+
+		It("denies reading an object in a containment cycle (chain walk returns un-locatable)", func() {
+			ctx := context.Background()
+			// Construct a circular containment: A contained in B, B
+			// contained in A. ObjectProvider's chain walk detects the
+			// cycle via visited-set and returns un-locatable
+			// (has_location=false, no `location` attr emitted under the
+			// 9gtl fix). Combined with an un-locatable character
+			// principal, the colocation seed must NOT permit-match via
+			// empty-string equality.
+			objA := core.NewULID()
+			objB := core.NewULID()
+
+			// Seed an anchor location for A so the chk_exactly_one
+			// constraint is satisfied at INSERT time.
+			anchor := core.NewULID()
+			_, err := env.pool.Exec(ctx, `
+				INSERT INTO locations (id, name, description, type, replay_policy)
+				VALUES ($1, 'Anchor', '', 'persistent', 'last:0')`,
+				anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, location_id, is_container)
+				VALUES ($1, 'A', '', $2, true)`,
+				objA.String(), anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = env.pool.Exec(ctx, `
+				INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+				VALUES ($1, 'B', '', $2, true)`,
+				objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Close the cycle: A now contained in B (was in a location).
+			// This direct UPDATE bypasses ObjectRepository.Move's
+			// cycle-detection guard, which is the corruption case we
+			// want to defend against at resolve time.
+			_, err = env.pool.Exec(ctx, `
+				UPDATE objects SET location_id = NULL, contained_in_object_id = $1
+				WHERE id = $2`,
+				objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			decision := evalAccess("character:"+unlocChar1.String(), "read", "object:"+objA.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny),
+				"un-locatable character + cycle-broken object MUST NOT permit-match via empty-string equality")
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Closes `holomush-9gtl` (P2 bug). Captures the architectural invariant as new ADR `holomush-ti1b`. Files follow-up `holomush-awb3` for the broader sweep.

## Bug class

ADR `holomush-iv43` (originally ADR 0010) established that the DSL evaluator treats **MISSING** attributes as `false` for every operator (Cedar-aligned fail-safe semantics). The provider side of the same contract was unstated, and three providers (`CharacterProvider`, `ObjectProvider`, `PropertyProvider`) emitted empty-string sentinels (`""`) when optional attrs were unresolved.

The DSL evaluator can't distinguish "missing" from "present-with-empty-string": `"" == ""` evaluates to `true`. Two seed policies were fail-open:

- `seed:player-character-colocation` — two un-locatable characters could see each other
- `seed:player-object-colocation` — un-locatable character could read any object in a broken containment chain (cycle, max-depth, broken-holder)

`StreamProvider` at `internal/access/policy/attribute/stream.go:46-48` already followed the correct pattern (`location` attr emitted only for `location:*` streams), so this commit unifies practice.

## Fix

`CharacterProvider`, `ObjectProvider`, `PropertyProvider` now **OMIT** the `location` / `parent_location` attr keys when their respective `has_X` witness is `false`. The `has_X` witness remains always-present (`true|false`) so DSL `has` checks still work.

Provider semantics unchanged for the happy path — the omission only applies to the un-resolved branch.

## ADR + rule file

- **`docs/adr/holomush-ti1b-providers-omit-optional-attrs.md`** captures the decision in full (context, rationale, scope, enforcement, alternatives considered a/b/c).
- **`.claude/rules/abac-providers.md`** auto-loads on `internal/access/policy/attribute/**` and restates the invariant inline for any contributor / AI assistant working in that tree. Names `StreamProvider` as the canonical reference.

## Tests

- **NEW integration regression tests** in `test/integration/access/seed_policies_test.go` — `Describe("Un-locatable empty-string equality is NOT permissive (holomush-9gtl)")` block with two reproducer cases (character-character un-locatable, character-broken-chain object). They fail under the pre-fix code, pass under the fix.
- Unit tests updated: assertions on empty-string sentinel removed, replaced with assertions that the optional key is **ABSENT** (`_, present := attrs["location"]; assert.False(t, present)`). `object_test.go` gains an `expectAbsent []string` field in the table struct.

## Scope

Initial fix scoped to the location-related attrs (the actual bug class). Follow-up `holomush-awb3` (P3) extends the pattern to remaining optional attrs: `owner_id`, `held_by_character_id`, `contained_in_object_id`, `shadows_id`, property `value`/`owner`. No current seed depends on those attrs in a vulnerable shape, so the follow-up is invariant-completion not bug-fix.

## Pre-push review

Both adversarial reviewers verdict `READY` (non-blocking findings only):

- `code-reviewer`: ADR-name normalization in test comments (fixed); username collision risk in integration test (fixed via ULID-anchored uniqueness).
- `abac-reviewer`: deferred attrs in object.go/property.go acknowledged (tracked by `awb3`); smoke tests at `seed_smoke_test.go` use hand-rolled mocks but integration test covers the real path (no action); schema declares `location_id` even though it may be absent at runtime (intentional, addressed in ADR Consequences).

`task pr-prep` green on full lane.

## Bead decision

ADR captured as bd decision `holomush-ti1b` (open, historical anchor).

## Test plan

- [x] `task test -- ./internal/access/policy/attribute/` — 264 tests pass
- [x] `task test:int -- ./test/integration/access/` — 23/23 specs pass (incl. new `Un-locatable empty-string equality` block)
- [x] `task pr-prep` — full lane green
- [x] `task lint` — clean (incl. ADR doctor)
- [x] Both pre-push review gates: `code-reviewer` READY, `abac-reviewer` READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed access-control behavior so unresolved optional attributes are omitted (not treated as present/equal), preserving default-deny semantics.

* **Documentation**
  * Added an ADR and a repository rule describing the required provider pattern: omit unresolved attribute keys and emit boolean witnesses.

* **Tests**
  * Updated unit tests and added an integration regression to assert absent-attribute semantics and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->