### PR TITLE
test(privacy): I-PRIV-2 scene-join floor integration test (iwzt.18)

### DIFF
--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -292,10 +292,25 @@ func (s *Server) NewLocation(ctx context.Context) ulid.ULID {
 
 // NewSceneWithoutMember creates a scene with no members and returns its ULID.
 //
-// TODO(iwzt-9): implement via FocusCoordinator once scene RPCs are wired.
+// Scenes are referenced by ULID alone for I-17 / scope-floor purposes — the
+// session's FocusMemberships JSONB carries the per-session membership state,
+// so no backing row is required to make a scene "exist" from the test's
+// perspective. Production scenes are created by the core-scenes plugin via
+// CreateScene RPC; that path is out of scope for privacy-floor tests, which
+// only need a well-formed scene ULID to construct dot-style subjects and
+// FocusMembership entries.
+//
+// Callers add a session as a scene member via Session.JoinScene.
 func (s *Server) NewSceneWithoutMember(_ context.Context) ulid.ULID {
-	s.t.Fatalf("integrationtest.Server.NewSceneWithoutMember: TODO iwzt-9 — scene RPCs not yet wired")
-	return ulid.ULID{}
+	s.t.Helper()
+	return idgen.New()
+}
+
+// GameID returns the embedded NATS JetStream game identifier, used by tests
+// that need to construct dot-style stream subjects of the form
+// `events.<gameID>.scene.<sceneID>.{ic,ooc}` (per INV-P4-1 / ADR holomush-s9nu).
+func (s *Server) GameID() string {
+	return s.bus.Bus.GameID()
 }
 
 // ExpireSession directly marks a session row as expired in Postgres.

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/subjectxlate"
+	"github.com/holomush/holomush/internal/session"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
 
@@ -172,11 +173,38 @@ func (s *Session) CreateScene(_ context.Context) ulid.ULID {
 	return ulid.ULID{}
 }
 
-// JoinScene joins the character to an existing scene.
+// JoinScene adds a FocusMembership{Kind: Scene, TargetID: sceneID} to the
+// session's focus_memberships JSONB, stamped with JoinedAt = time.Now().UTC().
+// Returns the canonical JoinedAt so tests can assert against the exact floor
+// that streamScopeFloor reads — avoids wall-clock skew between the mutator's
+// internal time.Now() and a caller-side snapshot.
 //
-// TODO(iwzt-9): invoke FocusCoordinator.JoinScene once wired.
-func (s *Session) JoinScene(_ context.Context, _ ulid.ULID) {
-	s.server.t.Fatalf("integrationtest.Session.JoinScene: TODO iwzt-9 — scene join RPC not yet wired")
+// Bypasses the production FocusCoordinator path
+// (internal/grpc/focus/join.go::defaultCoordinator.JoinFocus): the
+// coordinator additionally runs the scene policy (OnJoin returns join
+// streams) and notifies the streamSender of the new subscription. JoinFocus
+// itself does NOT consult the ABAC engine — scene-stream reads in
+// QueryStreamHistory are gated purely by the I-17 membership check
+// (sessionHasMembership) and the temporal scope floor (streamScopeFloor),
+// both of which read directly from session.FocusMemberships. The
+// privacy-floor tests care about the floor, not the subscription wiring,
+// so the direct store update is observationally equivalent for the
+// authorization paths under test.
+func (s *Session) JoinScene(ctx context.Context, sceneID ulid.ULID) time.Time {
+	s.server.t.Helper()
+	now := time.Now().UTC()
+	err := s.server.sessionStore.UpdateFocusMemberships(ctx, s.SessionID, session.NewFocusMutator(
+		func(current []session.FocusMembership, presenting *session.FocusKey) ([]session.FocusMembership, *session.FocusKey, error) {
+			current = append(current, session.FocusMembership{
+				Kind:     session.FocusKindScene,
+				TargetID: sceneID,
+				JoinedAt: now,
+			})
+			return current, presenting, nil
+		},
+	))
+	require.NoError(s.server.t, err, "integrationtest.Session.JoinScene: update focus memberships")
+	return now
 }
 
 // QueryStreamHistory fetches the event history for the given stream subject.

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -265,6 +265,100 @@ var _ = Describe("I-PRIV-2: guest name reuse does not leak prior holder's events
 	})
 })
 
+// I-PRIV-2 (scene-join floor): when a character joins a scene at time T, the
+// I-PRIV-2 scene branch of streamScopeFloor MUST floor the joiner's view of
+// the scene at FocusMembership.JoinedAt. Events emitted to the scene BEFORE
+// the joiner's join time are invisible; events at or after the join time are
+// visible.
+//
+// Harness contract: scene streams use the NATS-native dot-style subject
+// `events.<gameID>.scene.<sceneID>.ic` (per INV-P4-1 / ADR holomush-s9nu) —
+// the legacy colon-style `scene:<id>:ic` falls through to the ABAC default
+// branch and would defeat the I-17 / scope-floor codepaths. The harness's
+// default allow-all engine is sufficient here: scene streams are
+// membership-gated (I-17), not ABAC-gated, so the policy engine is never
+// consulted on the visible-events path.
+var _ = Describe("I-PRIV-2 (scene): scene events before join are invisible", func() {
+	var (
+		ts          *integrationtest.Server
+		ctx         context.Context
+		owner       *integrationtest.Session
+		joiner      *integrationtest.Session
+		sceneStream string
+		joinedAt    time.Time
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = integrationtest.Start(suiteT)
+
+		// Owner connects and emits a pre-join event into the scene stream.
+		// The owner doesn't need to be a scene member to publish — the bus
+		// publisher is unrestricted; only the read side (I-17 gate) requires
+		// membership. This keeps the test focused on the join-time floor.
+		owner = ts.ConnectAuthed(ctx, "Jamie")
+		sceneID := ts.NewSceneWithoutMember(ctx)
+		sceneStream = "events." + ts.GameID() + ".scene." + sceneID.String() + ".ic"
+
+		prePayload := []byte(`{"character_name":"Jamie","action":"speaks before Kai arrives."}`)
+		Expect(owner.EmitDirectEvent(ctx, sceneStream, "core-scenes:pose", prePayload)).
+			To(Succeed(), "pre-join seed event MUST publish")
+
+		// Brief gap so the joiner's JoinedAt is strictly later than the
+		// pre-join emit. Mirrors the I-PRIV-1 fresh-guest pattern above —
+		// the embedded bus publish is synchronous, but the wall-clock gap
+		// makes timestamp ordering unambiguous.
+		time.Sleep(50 * time.Millisecond)
+
+		// Joiner connects and joins the scene. JoinScene stamps the
+		// session's FocusMemberships with JoinedAt = time.Now() and returns
+		// that exact timestamp so the test can assert against the canonical
+		// floor (avoids wall-clock skew between mutator-internal and
+		// caller-side time.Now() snapshots).
+		joiner = ts.ConnectAuthed(ctx, "Kai")
+		joinedAt = joiner.JoinScene(ctx, sceneID)
+
+		// Owner emits a post-join event. This MUST be visible to the
+		// joiner (guard against vacuous-pass via Expect(events).NotTo(BeEmpty)
+		// below — without it, a regression that filtered every event would
+		// silently pass the floor loop).
+		postPayload := []byte(`{"character_name":"Jamie","action":"speaks after Kai arrives."}`)
+		Expect(owner.EmitDirectEvent(ctx, sceneStream, "core-scenes:pose", postPayload)).
+			To(Succeed(), "post-join emit MUST publish")
+	})
+
+	AfterEach(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if joiner != nil {
+			joiner.Logout(cleanupCtx)
+		}
+		if owner != nil {
+			owner.Logout(cleanupCtx)
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("floors scene history at FocusMembership.JoinedAt", func() {
+		events, err := joiner.QueryStreamHistory(ctx, sceneStream)
+		Expect(err).NotTo(HaveOccurred(),
+			"I-PRIV-2 (scene): joiner with FocusMembership MUST pass the I-17 gate")
+		// Vacuous-pass guard — the post-join emit must be visible. Without
+		// this, a regression that floored every scene event to time.Now()
+		// would return an empty slice and the loop below would pass.
+		Expect(events).NotTo(BeEmpty(),
+			"post-join scene emit must be visible (vacuous-pass guard)")
+
+		for _, ev := range events {
+			Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", joinedAt),
+				"event %q at %s leaked before joiner's JoinedAt %s",
+				ev.GetType(), ev.GetTimestamp().AsTime(), joinedAt)
+		}
+	})
+})
+
 // I-PRIV-1 (character move): when a character moves from locA to locB, the
 // floor MUST reset to the new location's arrival time and the hard-gate
 // MUST deny queries against the prior location. This is the location-


### PR DESCRIPTION
## Summary

- Adds the I-PRIV-2 (scene) integration test asserting that scene events
  emitted before a character's `FocusMembership.JoinedAt` are invisible
  to that character, and events at or after are visible.
- Wires the minimal harness needed: `Server.GameID()` (for dot-style
  subject construction), real bodies for `Server.NewSceneWithoutMember`
  and `Session.JoinScene` (previously TODO-fatal stubs).
- `Session.JoinScene` returns the canonical `JoinedAt` from inside the
  mutator so tests assert against the exact floor that `streamScopeFloor`
  reads — avoids wall-clock skew between mutator-internal `time.Now()`
  and any caller-side snapshot.

Scene streams use the NATS-native dot-style subject
`events.<gameID>.scene.<sceneID>.ic` per INV-P4-1 / ADR `holomush-s9nu`.
The Phase 4 `isSceneStream` / `extractSceneID` helpers reject the
legacy colon-style, so dot-style is mandatory.

The harness writes `FocusMembership` directly via
`sessionStore.UpdateFocusMemberships`, bypassing
`internal/grpc/focus/join.go::defaultCoordinator.JoinFocus` — the
coordinator's only additional side effects are scene-policy `OnJoin`
(returns join streams) and `streamSender.Send` (live-subscription
notification), neither of which is observable from `QueryStreamHistory`.
Production `JoinFocus` itself never consults the ABAC engine, so the
test path is observationally equivalent for the I-17 membership gate
and the temporal scope floor — both of which read directly from
`session.FocusMemberships`.

Closes holomush-iwzt.18.

## Test plan

- [x] `task test:int -- ./test/integration/privacy/... -ginkgo.focus='I-PRIV-2 \(scene\)' -ginkgo.v` — new spec runs and passes (1 of 7 specs, others Skipped by focus)
- [x] `task pr-prep` — full lane (lint, format, schema, license, unit, integration, E2E) green
- [x] `/review-code` — READY, no blocking findings
- [x] `/review-abac` — READY, no blocking findings (test-only direct membership write does not bypass any ABAC gate because scene-stream reads are membership-gated, never ABAC-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure and helper functions for scene membership and session management operations.
  * Implemented previously non-functional test helpers, enabling proper testing of scene creation and joining workflows.
  * Added integration test suite validating scene event privacy enforcement, confirming users cannot access events that occurred before they joined a scene.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->