### PR TITLE
feat(world): postgres.ParentLocationResolver for property parent_location attribute (rmsi.1)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -145,7 +145,7 @@ tasks:
         ./cmd/holomush/ ./internal/access/setup/ ./internal/admin/approval/ ./internal/admin/socket/ ./internal/auth/postgres/
         ./internal/content/ ./internal/eventbus/audit/ ./internal/eventbus/audit/chain/ ./internal/admin/policy/ ./internal/eventbus/crypto/dek/
         ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/store/ ./plugins/core-scenes/ ./test/testutil/
-        ./test/integration/...
+        ./internal/world/postgres/ ./test/integration/...
 
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)

--- a/internal/world/postgres/parent_location_resolver.go
+++ b/internal/world/postgres/parent_location_resolver.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+)
+
+// maxParentChainDepth bounds the recursive CTE that walks an object's
+// containment chain to its effective location. The bound is the SOLE
+// cycle defense — a true containment cycle terminates at depth
+// exhaustion rather than via revisit-detection, and the resolver's
+// contract (nil on un-resolvable) holds either way. Mirrors the
+// depth-only precedent of object_repo.go::checkCircularContainmentTx
+// (which uses internal/world/postgres/helpers.go::maxCTERecursionDepth).
+// The 20-step value matches docs/specs/abac/03-property-model.md:188.
+const maxParentChainDepth = 20
+
+// ParentLocationResolver implements attribute.ParentLocationResolver
+// against a PostgreSQL pool. It resolves the effective location of a
+// property's parent entity. Per docs/specs/abac/03-property-model.md:
+//
+//   - parent_type=location → return parent_id directly (no DB query)
+//   - parent_type=character → JOIN characters.location_id
+//   - parent_type=object → recursive CTE walking
+//     held_by_character_id / contained_in_object_id chain, bounded by
+//     maxParentChainDepth and terminated via depth exhaustion for cycles.
+//   - any other parent_type → return nil (the property's parent_location
+//     attribute will be omitted, per ADR holomush-ti1b)
+type ParentLocationResolver struct {
+	pool *pgxpool.Pool
+}
+
+// NewParentLocationResolver constructs a new resolver bound to pool.
+func NewParentLocationResolver(pool *pgxpool.Pool) *ParentLocationResolver {
+	return &ParentLocationResolver{pool: pool}
+}
+
+// Compile-time interface check.
+var _ attribute.ParentLocationResolver = (*ParentLocationResolver)(nil)
+
+// ResolveParentLocation returns the ULID of the parent entity's
+// effective location, or nil if unresolvable (NULL location, broken
+// chain, cycle exhausted via depth bound, unknown parent_type).
+func (r *ParentLocationResolver) ResolveParentLocation(
+	ctx context.Context, parentType string, parentID ulid.ULID,
+) (*ulid.ULID, error) {
+	switch parentType {
+	case "location":
+		// Short-circuit: the location IS the parent.
+		id := parentID
+		return &id, nil
+
+	case "character":
+		var locStr *string
+		err := r.pool.QueryRow(ctx, `
+			SELECT location_id FROM characters WHERE id = $1
+		`, parentID.String()).Scan(&locStr)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, oops.
+				With("operation", "resolve character parent_location").
+				With("character_id", parentID.String()).
+				Wrap(err)
+		}
+		if locStr == nil {
+			return nil, nil
+		}
+		parsed, perr := ulid.Parse(*locStr)
+		if perr != nil {
+			return nil, oops.
+				With("operation", "parse character location_id").
+				With("character_id", parentID.String()).
+				Wrap(perr)
+		}
+		return &parsed, nil
+
+	case "object":
+		// Recursive CTE: walk the chain via contained_in_object_id, then
+		// pick the first terminator row (location_id non-NULL, or
+		// held_by_character_id non-NULL → JOIN characters for location_id).
+		// Bounded by maxParentChainDepth as the sole cycle defense.
+		//
+		// COALESCE(direct, held) is correct, not biased: the schema
+		// constraint chk_exactly_one_containment (migration
+		// 000001_baseline.up.sql:146) guarantees each row has EXACTLY
+		// ONE of {location_id, held_by_character_id, contained_in_object_id}
+		// non-NULL. The chain recurses only via contained_in_object_id, so
+		// intermediate rows have NULL location AND NULL held — only the
+		// terminator row has either field non-NULL, never both. The
+		// direct and held subqueries are therefore mutually exclusive;
+		// at most ONE returns a row across both. COALESCE picks
+		// whichever is non-empty without ambiguity.
+		var locStr *string
+		err := r.pool.QueryRow(ctx, `
+			WITH RECURSIVE chain AS (
+				SELECT id, location_id, held_by_character_id, contained_in_object_id, 1 AS depth
+				FROM objects WHERE id = $1
+				UNION ALL
+				SELECT o.id, o.location_id, o.held_by_character_id, o.contained_in_object_id, c.depth + 1
+				FROM objects o
+				JOIN chain c ON o.id = c.contained_in_object_id
+				WHERE c.depth < $2
+			),
+			direct AS (
+				SELECT location_id, depth FROM chain WHERE location_id IS NOT NULL
+				ORDER BY depth ASC LIMIT 1
+			),
+			held AS (
+				SELECT ch.location_id, c.depth FROM chain c
+				JOIN characters ch ON ch.id = c.held_by_character_id
+				WHERE c.held_by_character_id IS NOT NULL
+				ORDER BY c.depth ASC LIMIT 1
+			)
+			SELECT COALESCE(
+				(SELECT location_id FROM direct),
+				(SELECT location_id FROM held)
+			) AS location_id
+		`, parentID.String(), maxParentChainDepth).Scan(&locStr)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, oops.
+				With("operation", "resolve object parent_location").
+				With("object_id", parentID.String()).
+				Wrap(err)
+		}
+		if locStr == nil {
+			return nil, nil
+		}
+		parsed, perr := ulid.Parse(*locStr)
+		if perr != nil {
+			return nil, oops.
+				With("operation", "parse object location_id").
+				With("object_id", parentID.String()).
+				Wrap(perr)
+		}
+		return &parsed, nil
+
+	default:
+		// Unknown parent_type — return nil so the property's
+		// parent_location attr is OMITTED per ADR holomush-ti1b.
+		return nil, nil
+	}
+}

--- a/internal/world/postgres/parent_location_resolver_test.go
+++ b/internal/world/postgres/parent_location_resolver_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	worldpg "github.com/holomush/holomush/internal/world/postgres"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+// helpers (insertCharacterAt, insertLocation, insertObjectAtLocation,
+// insertContainerAtLocation, insertObjectHeldBy, insertObjectContainedIn,
+// newTestPool) are defined at the bottom of this file.
+
+func TestParentLocationResolver_LocationParent_ReturnsParentIDDirectly(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	locID := ulid.Make()
+
+	// No DB insert: location parent_type short-circuits without query.
+	got, err := resolver.ResolveParentLocation(context.Background(), "location", locID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, locID, *got)
+}
+
+func TestParentLocationResolver_CharacterParent_JoinsLocationID(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	locID := insertLocation(t, pool, "TestLoc")
+	charID := insertCharacterAt(t, pool, "TestChar", &locID)
+
+	got, err := resolver.ResolveParentLocation(ctx, "character", charID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, locID, *got)
+}
+
+func TestParentLocationResolver_CharacterParent_NullLocation_ReturnsNil(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	charID := insertCharacterAt(t, pool, "Wanderer", nil)
+
+	got, err := resolver.ResolveParentLocation(ctx, "character", charID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestParentLocationResolver_ObjectParent_DirectLocation(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	locID := insertLocation(t, pool, "Library")
+	objID := insertObjectAtLocation(t, pool, "Book", locID)
+
+	got, err := resolver.ResolveParentLocation(ctx, "object", objID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, locID, *got)
+}
+
+func TestParentLocationResolver_ObjectParent_HeldByCharacter(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	locID := insertLocation(t, pool, "Town")
+	charID := insertCharacterAt(t, pool, "Holder", &locID)
+	objID := insertObjectHeldBy(t, pool, "Note", charID)
+
+	got, err := resolver.ResolveParentLocation(ctx, "object", objID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, locID, *got)
+}
+
+func TestParentLocationResolver_ObjectParent_ContainedRecursive(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	locID := insertLocation(t, pool, "Vault")
+	chest := insertContainerAtLocation(t, pool, "Chest", locID)
+	coin := insertObjectContainedIn(t, pool, "Coin", chest)
+
+	got, err := resolver.ResolveParentLocation(ctx, "object", coin)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, locID, *got)
+}
+
+func TestParentLocationResolver_ObjectParent_Cycle_ReturnsNil(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	// Construct a cycle by direct UPDATE (bypasses ObjectRepo.Move's guard).
+	locID := insertLocation(t, pool, "Anchor")
+	a := insertContainerAtLocation(t, pool, "A", locID)
+	b := insertObjectContainedIn(t, pool, "B", a)
+	// Now make A point at B (cycle): A.contained_in=B, B.contained_in=A.
+	_, err := pool.Exec(ctx, `UPDATE objects SET location_id = NULL, contained_in_object_id = $1 WHERE id = $2`,
+		b.String(), a.String())
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveParentLocation(ctx, "object", a)
+	require.NoError(t, err)
+	assert.Nil(t, got, "cycle MUST terminate via depth bound and return nil")
+}
+
+func TestParentLocationResolver_ObjectParent_MaxDepthExceeded_ReturnsNil(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	ctx := context.Background()
+
+	locID := insertLocation(t, pool, "Bottom")
+	// Build a chain of 21 objects: obj0 in locID, obj1 in obj0, obj2 in obj1, ..., obj20 in obj19.
+	// The resolver's depth cap is 20 — resolving obj20's location MUST exhaust depth and return nil.
+	prev := insertContainerAtLocation(t, pool, "obj0", locID)
+	for i := 1; i <= 20; i++ {
+		prev = insertObjectContainedIn(t, pool, fmt.Sprintf("obj%d", i), prev)
+	}
+	// prev is obj20. Walking from obj20 needs to traverse 20 hops up the chain to reach obj0
+	// which has the location_id. With maxParentChainDepth=20, the CTE stops before reaching it.
+
+	got, err := resolver.ResolveParentLocation(ctx, "object", prev)
+	require.NoError(t, err)
+	assert.Nil(t, got, "depth bound (20) MUST be enforced — chain of 21 returns nil")
+}
+
+func TestParentLocationResolver_UnknownParentType_ReturnsNil(t *testing.T) {
+	pool := newTestPool(t)
+	resolver := worldpg.NewParentLocationResolver(pool)
+	got, err := resolver.ResolveParentLocation(context.Background(), "exit", ulid.Make())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// ----- helpers below -----
+
+func newTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
+	pool, err := pgxpool.New(context.Background(), connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func insertLocation(t *testing.T, pool *pgxpool.Pool, name string) ulid.ULID {
+	t.Helper()
+	id := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO locations (id, name, description, type, replay_policy)
+		VALUES ($1, $2, '', 'persistent', 'last:0')`,
+		id.String(), name)
+	require.NoError(t, err)
+	return id
+}
+
+func insertCharacterAt(t *testing.T, pool *pgxpool.Pool, name string, locID *ulid.ULID) ulid.ULID {
+	t.Helper()
+	playerID := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO players (id, username, password_hash)
+		VALUES ($1, $2, 'hash')`,
+		playerID.String(), "p_"+playerID.String())
+	require.NoError(t, err)
+	charID := ulid.Make()
+	if locID != nil {
+		_, err = pool.Exec(context.Background(), `
+			INSERT INTO characters (id, player_id, name, location_id)
+			VALUES ($1, $2, $3, $4)`,
+			charID.String(), playerID.String(), name, locID.String())
+	} else {
+		_, err = pool.Exec(context.Background(), `
+			INSERT INTO characters (id, player_id, name, location_id)
+			VALUES ($1, $2, $3, NULL)`,
+			charID.String(), playerID.String(), name)
+	}
+	require.NoError(t, err)
+	return charID
+}
+
+func insertObjectAtLocation(t *testing.T, pool *pgxpool.Pool, name string, locID ulid.ULID) ulid.ULID {
+	t.Helper()
+	id := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO objects (id, name, description, location_id, is_container)
+		VALUES ($1, $2, '', $3, false)`,
+		id.String(), name, locID.String())
+	require.NoError(t, err)
+	return id
+}
+
+func insertContainerAtLocation(t *testing.T, pool *pgxpool.Pool, name string, locID ulid.ULID) ulid.ULID {
+	t.Helper()
+	id := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO objects (id, name, description, location_id, is_container)
+		VALUES ($1, $2, '', $3, true)`,
+		id.String(), name, locID.String())
+	require.NoError(t, err)
+	return id
+}
+
+func insertObjectHeldBy(t *testing.T, pool *pgxpool.Pool, name string, charID ulid.ULID) ulid.ULID {
+	t.Helper()
+	id := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO objects (id, name, description, held_by_character_id, is_container)
+		VALUES ($1, $2, '', $3, false)`,
+		id.String(), name, charID.String())
+	require.NoError(t, err)
+	return id
+}
+
+func insertObjectContainedIn(t *testing.T, pool *pgxpool.Pool, name string, containerID ulid.ULID) ulid.ULID {
+	t.Helper()
+	id := ulid.Make()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+		VALUES ($1, $2, '', $3, false)`,
+		id.String(), name, containerID.String())
+	require.NoError(t, err)
+	return id
+}


### PR DESCRIPTION
## Summary

Implements `attribute.ParentLocationResolver` as a postgres-layer type at `internal/world/postgres/parent_location_resolver.go`. **Task 1 of 5** in the property authz redesign epic (`holomush-72ou`).

This is the foundation for the rest of the epic — `holomush-rmsi.2` (wire `PropertyProvider` into `BuildABACStack`) can't land until this constructor exists.

## What this does

| Branch | Behavior |
|---|---|
| `parent_type=location` | Returns `parent_id` directly (no DB query) |
| `parent_type=character` | Single JOIN to `characters.location_id`; NULL → `(nil, nil)` |
| `parent_type=object` | Recursive CTE walking `contained_in_object_id`; terminator via `location_id` non-NULL OR `held_by_character_id` JOIN to characters' location |
| `default` (unknown) | `(nil, nil)` |

Cycle defense is depth-only via `const maxParentChainDepth = 20`. This matches the existing precedent at `object_repo.go::checkCircularContainmentTx` (which uses `maxCTERecursionDepth=100` from `helpers.go`). A visited-set is a future performance MAY-optimize per the spec (ADR `holomush-iv43`-adjacent decision recorded in `holomush-rmsi`'s grounding notes).

## Tests

9 integration tests covering R1-R9 (per plan Task 1 Step 2):

- R1: location parent returns parent_id directly
- R2: character parent JOINs current location_id
- R3: character parent with NULL location returns nil
- R4: object parent at direct location
- R5: object parent held by character resolves via character
- R6: object parent contained in object resolves recursively
- R7: object parent in cycle → nil via depth exhaustion
- R8: chain of 21 objects → nil via depth bound
- R9: unknown parent_type → nil

All 9 pass; `task pr-prep` full lane green.

## Drive-by

Adds `./internal/world/postgres/` to the `task test:int` package list (`Taskfile.yaml:148`). This package was missing from the explicit-list convention documented at `Taskfile.yaml:133-143`, so the new tests AND the pre-existing integration tests in this package (`binding_repo`, `scene_repo`, `exit_repo`, etc.) were silently dark in CI. This is load-bearing for AC-7 verification.

A follow-up bd can investigate whether any other packages were similarly silent — out of scope for this PR.

## Reviews

- **spec-reviewer**: `SPEC_COMPLIANT` — all 8 acceptance criteria met
- **code-reviewer**: `READY` — 3 non-blocking findings (test-pool-pattern inconsistency vs pre-existing tests; CTE prefers `direct` over `held` rather than first-by-depth — neither tested nor spec-required; cosmetic commit-description artifact, fixed)

## Test plan

- [x] `task test:int -- ./internal/world/postgres/ -run TestParentLocationResolver` — 9/9 pass
- [x] `task test:int` — full integration suite passes (1856 tests, up from 1653 due to the activated dark tests)
- [x] `task pr-prep` — full lane green
- [x] `task lint` clean (incl. ADR doctor)
- [x] Spec compliance + code-quality reviews both READY

## Bd state

- `holomush-rmsi.1` — currently `in_progress` (claimed). Closes via `bd close` on merge.
- Unblocks: `holomush-rmsi.2` (wire PropertyProvider into BuildABACStack) — ready when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location resolution for entities with support for location, character, and object parents, including recursive containment with cycle and depth safeguards.

* **Tests**
  * Added integration tests covering all parent types, recursive resolution, cycle handling, depth limits, and unknown parent types.

* **Chores**
  * Updated integration test configuration to include the new PostgreSQL-backed resolver.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->