### PR TITLE
test(world): pin PROPERTY_ACCESS_* error codes in TestCheckAccess (rmsi.4)

### DIFF
--- a/internal/world/service_helpers_test.go
+++ b/internal/world/service_helpers_test.go
@@ -120,6 +120,7 @@ func TestCheckAccess(t *testing.T) {
 			{prefixObject, "OBJECT_ACCESS_DENIED"},
 			{prefixCharacter, "CHARACTER_ACCESS_DENIED"},
 			{prefixScene, "SCENE_ACCESS_DENIED"},
+			{prefixProperty, "PROPERTY_ACCESS_DENIED"}, // holomush-rmsi.4
 		}
 
 		for _, tt := range prefixes {
@@ -233,6 +234,7 @@ func TestCheckAccess(t *testing.T) {
 			{prefixObject, "OBJECT_ACCESS_EVALUATION_FAILED"},
 			{prefixExit, "EXIT_ACCESS_EVALUATION_FAILED"},
 			{prefixScene, "SCENE_ACCESS_EVALUATION_FAILED"},
+			{prefixProperty, "PROPERTY_ACCESS_EVALUATION_FAILED"}, // holomush-rmsi.4
 		}
 		infraDecision := types.NewDecision(types.EffectDefaultDeny, "session store unavailable", "infra:session-store-error")
 


### PR DESCRIPTION
## Summary

Closes the test-coverage gap noted by design-reviewer round 1 on the 72ou spec: `prefixProperty` was not exercised in `service_helpers_test.go::TestCheckAccess`'s prefix-to-error-code tables, so `PROPERTY_ACCESS_DENIED` / `PROPERTY_ACCESS_EVALUATION_FAILED` had no explicit pin.

**Task 4 of 5** in the property authz redesign epic (`holomush-72ou`). Independent of the other tasks — can land in any order.

## Changes

Adds `prefixProperty` row to two existing prefix-to-error-code tables in `internal/world/service_helpers_test.go::TestCheckAccess`:

1. `uses entity prefix to generate error codes` — asserts deny path produces `PROPERTY_ACCESS_DENIED`
2. `returns evaluation failure on infrastructure failure decision` — asserts infra-failure path produces `PROPERTY_ACCESS_EVALUATION_FAILED`

Matches the existing rows for Location/Character/Object/Exit/Scene exactly.

## Tests

`task test -- ./internal/world/ -run TestCheckAccess` — 25 tests pass (up from 23; the 2 new prefixProperty subtests cover deny + infra-failure paths).

`task pr-prep` — full lane green.

## Bd state

- `holomush-rmsi.4` — currently `in_progress` (claimed). Closes via `bd close` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for property access validation scenarios, including access denial and evaluation failure error handling.

---

**Note:** This release contains only internal test improvements with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->