### PR TITLE
feat(access): wire PropertyProvider into BuildABACStack (rmsi.2)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -95,3 +95,28 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   fail-closes the entire bootstrap chain. See
   `internal/access/policy/attribute/location.go:54-62` for the canonical
   shape (line-scoped `//nolint:nilerr` with rationale).
+- **WARN-when-missing wiring pattern (g776 → k3ud → 72ou, 2026-05-22)**:
+  three serial applications now in `setup.go` (`8b. Location`, `8c. Object`,
+  `8d. Property`). The pattern: ABACConfig field for repo(+ optional helper);
+  `if cfg.X != nil { register } else { slog.WarnContext(...) }`; production
+  wiring always passes the dep; the WARN names affected seeds + bead ID;
+  unit test mirrors the namespace into `productionRegistered`; integration
+  drift-detector at `buildabacstack_seed_coverage_integ_test.go` exercises
+  the REAL stack and asserts the actual-missing set equals
+  `AcknowledgedMissingSeedNamespaces`. Property block (72ou) adds
+  `property_repo_set` / `parent_location_resolver_set` boolean structured
+  fields in the WARN — improvement over prior precedent for two-dep
+  providers. When auditing future provider-wiring PRs, check that the WARN
+  test EXISTS (precedent `setup_warn_integ_test.go`) and exercises the
+  else-branch by INTENTIONALLY omitting deps. Note: drift-detector only
+  catches if it's actually invoked with the production-shape config —
+  verify the integration test passes BOTH new deps, not just the new
+  ABACConfig field with nil values.
+- **Property wiring (72ou) does NOT fix `service.go:1068` shape bug**:
+  `Service.ListPropertiesByParent` emits `access.PropertyResource(parentType + ":" + parentID.String())`
+  — a 3-segment composite (`property:location:01HXXX`) where the ID is
+  non-ULID. PropertyProvider correctly returns `(nil, nil)` for non-ULID IDs
+  (wildcard tolerance precedent at `location.go:54-62`), so the seeds still
+  default-deny for that caller. Task 3 (`rmsi.3` / future) fixes the
+  caller's resource shape. No fail-open risk; behavior is identical
+  before/after this PR for that call site.

--- a/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
+++ b/internal/access/setup/buildabacstack_seed_coverage_integ_test.go
@@ -45,10 +45,12 @@ func TestBuildABACStack_SeedCoverageMatchesAcknowledged(t *testing.T) {
 	t.Cleanup(pool.Close)
 
 	stack, err := BuildABACStack(ctx, ABACConfig{
-		Pool:          pool,
-		CharacterRepo: worldpostgres.NewCharacterRepository(pool),
-		LocationRepo:  worldpostgres.NewLocationRepository(pool),
-		ObjectRepo:    worldpostgres.NewObjectRepository(pool),
+		Pool:                   pool,
+		CharacterRepo:          worldpostgres.NewCharacterRepository(pool),
+		LocationRepo:           worldpostgres.NewLocationRepository(pool),
+		ObjectRepo:             worldpostgres.NewObjectRepository(pool),
+		PropertyRepo:           worldpostgres.NewPropertyRepository(pool),
+		ParentLocationResolver: worldpostgres.NewParentLocationResolver(pool),
 		// RoleStore intentionally nil; CryptoOperators intentionally empty —
 		// production wiring at subsystem.go always passes these too, but the
 		// presence/absence does not affect provider registration coverage.

--- a/internal/access/setup/seed_coverage_test.go
+++ b/internal/access/setup/seed_coverage_test.go
@@ -115,9 +115,7 @@ func TestValidateSeedProviderCoverage_TopLevelIDsNotFlagged(t *testing.T) {
 // (hardcoded mirror of "what BuildABACStack registers") suffers silent
 // drift if a future refactor drops a registration. Per abac-reviewer
 // finding on holomush-xxel.
-var AcknowledgedMissingSeedNamespaces = map[string]string{
-	"property": "holomush-72ou", // PropertyProvider design pass: resource format mismatch
-}
+var AcknowledgedMissingSeedNamespaces = map[string]string{}
 
 // TestValidateSeedProviderCoverage_ProductionCorpusIsCovered is the
 // load-bearing regression lock at the UNIT level: it verifies the validator
@@ -139,7 +137,7 @@ func TestValidateSeedProviderCoverage_ProductionCorpusIsCovered(t *testing.T) {
 	// productionRegistered MUST stay in sync with BuildABACStack's actual
 	// registrations. The integration test asserts no drift.
 	productionRegistered := []string{
-		"character", "location", "object", "player", "command", "stream", "plugin",
+		"character", "location", "object", "property", "player", "command", "stream", "plugin",
 	}
 
 	missing := validateSeedProviderCoverage(productionRegistered, policy.SeedPolicies())

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -73,8 +73,21 @@ type ABACConfig struct {
 	// also needs CharacterRepo to resolve transitive locations for objects
 	// held by characters. Per holomush-k3ud.
 	ObjectRepo world.ObjectRepository
-	RoleStore  store.RoleStore
-	AuditMode  audit.Mode
+	// PropertyRepo is required for any seed that gates on resource.property.*
+	// (e.g., seed:property-public-read, seed:property-private-read,
+	// seed:property-restricted-visible-to). Without it the PropertyProvider
+	// is not registered, no provider populates resource.property.*, and
+	// every such seed silently default-denies — the same fingerprint as
+	// the original holomush-g776 bug. Per holomush-72ou.
+	PropertyRepo world.PropertyRepository
+	// ParentLocationResolver resolves a property's parent entity's
+	// effective location at evaluation time. Required alongside PropertyRepo
+	// for PropertyProvider registration. The production wiring at
+	// internal/access/setup/subsystem.go passes
+	// postgres.NewParentLocationResolver(pool). Per holomush-72ou.
+	ParentLocationResolver attribute.ParentLocationResolver
+	RoleStore              store.RoleStore
+	AuditMode              audit.Mode
 	// CryptoOperators is the list of player IDs (ULIDs) holding the
 	// crypto.operator capability. Passed to PlayerAttributeProvider at
 	// construction. Empty / nil → no operators (break-glass disabled).
@@ -175,6 +188,32 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 			"ABAC setup: ObjectRepo not provided — seeds referencing resource.object.* will silently default-deny",
 			"affected_seeds", "seed:player-object-colocation",
 			"reference", "holomush-k3ud")
+	}
+
+	// 8d. Property provider (optional in signature; required in practice for
+	// any seed gating on resource.property.*). Without this, all six
+	// property visibility seeds silently default-deny:
+	// seed:property-public-read, seed:property-private-read,
+	// seed:property-admin-read, seed:property-owner-write,
+	// seed:property-restricted-visible-to, seed:property-restricted-excluded
+	// — same fingerprint as holomush-g776 (location) and holomush-k3ud (object).
+	//
+	// Production wiring at internal/access/setup/subsystem.go ALWAYS
+	// supplies both PropertyRepo and ParentLocationResolver. Loud WARN when
+	// either is missing so any future caller that drops the dependency
+	// gets a recurrence signal. Per holomush-72ou.
+	if cfg.PropertyRepo != nil && cfg.ParentLocationResolver != nil {
+		propProvider := attribute.NewPropertyProvider(cfg.PropertyRepo, cfg.ParentLocationResolver)
+		if err := resolver.RegisterProvider(propProvider); err != nil {
+			return nil, eb.Wrapf(err, "register property provider")
+		}
+	} else {
+		slog.WarnContext(ctx,
+			"ABAC setup: PropertyRepo or ParentLocationResolver not provided — seeds referencing resource.property.* will silently default-deny",
+			"property_repo_set", cfg.PropertyRepo != nil,
+			"parent_location_resolver_set", cfg.ParentLocationResolver != nil,
+			"affected_seeds", "seed:property-public-read, seed:property-private-read, seed:property-admin-read, seed:property-owner-write, seed:property-restricted-visible-to, seed:property-restricted-excluded",
+			"reference", "holomush-72ou")
 	}
 
 	// 8a. Player provider (subject namespace; resolves player.id and

--- a/internal/access/setup/setup_warn_integ_test.go
+++ b/internal/access/setup/setup_warn_integ_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package setup_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/setup"
+	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+func TestBuildABACStack_WarnsWhenPropertyRepoMissing(t *testing.T) {
+	// Capture slog output; assert the WARN names the affected seeds.
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
+	pool, err := pgxpool.New(context.Background(), connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	_, err = setup.BuildABACStack(context.Background(), setup.ABACConfig{
+		Pool:          pool,
+		CharacterRepo: worldpostgres.NewCharacterRepository(pool),
+		LocationRepo:  worldpostgres.NewLocationRepository(pool),
+		ObjectRepo:    worldpostgres.NewObjectRepository(pool),
+		// PropertyRepo + ParentLocationResolver INTENTIONALLY OMITTED — exercises
+		// the 8d. else-branch WARN path. Per holomush-72ou INV-4.
+	})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "PropertyRepo or ParentLocationResolver not provided")
+	assert.Contains(t, out, "seed:property-public-read")
+	assert.Contains(t, out, "holomush-72ou")
+}

--- a/internal/access/setup/subsystem.go
+++ b/internal/access/setup/subsystem.go
@@ -77,13 +77,15 @@ func (s *ABACSubsystem) Start(ctx context.Context) error {
 
 	roleStore := store.NewPostgresRoleStore(pool)
 	stack, err := BuildABACStack(ctx, ABACConfig{
-		Pool:            pool,
-		CharacterRepo:   postgres.NewCharacterRepository(pool),
-		LocationRepo:    postgres.NewLocationRepository(pool),
-		ObjectRepo:      postgres.NewObjectRepository(pool),
-		RoleStore:       roleStore,
-		AuditMode:       s.cfg.AuditMode,
-		CryptoOperators: s.cfg.CryptoOperators,
+		Pool:                   pool,
+		CharacterRepo:          postgres.NewCharacterRepository(pool),
+		LocationRepo:           postgres.NewLocationRepository(pool),
+		ObjectRepo:             postgres.NewObjectRepository(pool),
+		PropertyRepo:           postgres.NewPropertyRepository(pool),
+		ParentLocationResolver: postgres.NewParentLocationResolver(pool),
+		RoleStore:              roleStore,
+		AuditMode:              s.cfg.AuditMode,
+		CryptoOperators:        s.cfg.CryptoOperators,
 	})
 	if err != nil {
 		return oops.Code("ABAC_SETUP_FAILED").Wrap(err)


### PR DESCRIPTION
## Summary

Wires `PropertyProvider` into `BuildABACStack` mirroring the established `holomush-g776` (LocationProvider) and `holomush-k3ud` (ObjectProvider) precedents. **Task 2 of 5** in the property authz redesign epic (`holomush-72ou`).

Depends on PR #4172 (`holomush-rmsi.1`, `postgres.ParentLocationResolver`) — merged.

## Atomic 5-file commit

The drift-detector `TestBuildABACStack_SeedCoverageMatchesAcknowledged` fails mid-state if these don't all land together:

| File | Change |
|---|---|
| `internal/access/setup/setup.go` | `ABACConfig` gains `PropertyRepo` + `ParentLocationResolver`; new `8d. Property provider` registration block |
| `internal/access/setup/subsystem.go` | Wires `postgres.NewPropertyRepository(pool)` + `postgres.NewParentLocationResolver(pool)` |
| `internal/access/setup/seed_coverage_test.go` | Drops `"property"` from `AcknowledgedMissingSeedNamespaces`; adds `"property"` to `productionRegistered` |
| `internal/access/setup/buildabacstack_seed_coverage_integ_test.go` | Drift-detector now exercises property registration |
| **NEW** `internal/access/setup/setup_warn_integ_test.go` | `TestBuildABACStack_WarnsWhenPropertyRepoMissing` pins INV-4 |

## What this does

The PropertyProvider registers when BOTH `PropertyRepo` AND `ParentLocationResolver` are non-nil in `ABACConfig`. When either is missing, a loud WARN logs at construction time naming all six affected property visibility seeds + `holomush-72ou`. The WARN-when-missing branch is observability, not a permissive shortcut — default-deny is preserved (no provider → seeds continue to default-deny).

## Default-deny preservation

This PR does NOT change runtime authz behavior on its own:

- Before: no PropertyProvider registered → `resource.property.*` un-populated → six seeds silently default-deny.
- After: PropertyProvider registered → `resource.property.*` populated → six seeds evaluate against real attrs. BUT the production caller `Service.ListPropertiesByParent` at `internal/world/service.go:1068` STILL emits a wrong-shape resource (parent-shaped). That caller's filter-loop fix is `holomush-rmsi.3` (Task 3, blocked on this PR).

Net runtime behavior for `ListPropertiesByParent`: identical default-deny before AND after this PR. Direct per-property reads with correct ULID resource shape now work.

## Reviews

Both pre-push reviewers `READY` (no blocking findings):

- **code-reviewer**: one Low (pre-existing `setup_player_test.go` WARN noise — same pattern as 8b/8c; follow-up)
- **abac-reviewer**: one Low (WARN log adds `property_repo_set` / `parent_location_resolver_set` booleans — improvement over `8b`/`8c` precedents); one Low acknowledging `service.go:1068` wrong-shape resource is `rmsi.3` scope, not regressed by this PR

## Test plan

- [x] `task test -- ./internal/access/setup/` — 11 tests pass
- [x] `task test:int -- ./internal/access/setup/` — drift-detector + new WARN test both pass
- [x] `task pr-prep` — full lane green
- [x] `task lint` clean
- [x] Pre-push gates: code-reviewer + abac-reviewer both READY

## Bd state

- `holomush-rmsi.2` — `in_progress` (claimed). Closes via `bd close` on merge.
- Unblocks: `holomush-rmsi.3` (Service filter loop).
- Already-ready siblings: `holomush-rmsi.4` (#4173, prefixProperty error codes — independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Property-based resource access control policies are now supported and evaluated within the access management system

* **Improvements**
  * Added diagnostic warnings to alert administrators when property access control dependencies are not configured, preventing scenarios where access would be silently denied due to incomplete setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->