### PR TITLE
docs+test(privacy): correct stale iwzt.16 Task 15 plan + drop vestigial LastReattachAt

### DIFF
--- a/docs/superpowers/plans/2026-05-17-history-scope-privacy.md
+++ b/docs/superpowers/plans/2026-05-17-history-scope-privacy.md
@@ -740,7 +740,6 @@ type Session struct {
     OriginalLocationID ulid.ULID    // set at connect; not mutated by MoveTo
     LocationArrivedAt time.Time
     SessionCreatedAt  time.Time
-    LastReattachAt    time.Time
     Client            corev1.CoreServiceClient
     subscribeCancel   context.CancelFunc
 }
@@ -842,7 +841,7 @@ For each helper, implement against the real `CoreServiceClient`:
 - `SendCommand` → `client.SendCommand(...)`
 - `MoveTo` → invoke `MoveCharacter` via the client (find the appropriate RPC; may need `WorldService` client)
 - `DetachTransport` → close the Subscribe stream and clear `subscribeCancel`
-- `ReattachTransport` → open a new Subscribe stream; record `LastReattachAt = time.Now()`
+- `ReattachTransport` → open a new Subscribe stream (per I-PRIV-3 Round 3 amendment, no `LocationArrivedAt`-derived floor advances on reattach; durable consumer's `OptStartTime` is immutable; filter-at-delivery enforces the original floor)
 - `QueryStreamHistory` → `client.QueryStreamHistory(...)` returns events
 - `Logout` → `client.Logout(...)` or equivalent
 - `JoinScene` → `client.JoinScene(...)` or `FocusCoordinator.JoinScene(...)`
@@ -1886,38 +1885,62 @@ Commit message: `feat(grpc): per-subject filter-at-delivery in Subscribe broadca
 
 ---
 
-### Task 15: Integration test — reconnect-after-detach filter drop (I-PRIV-3)
+### Task 15: Integration test — reconnect-after-detach durable replay (I-PRIV-3)
+
+> **Round 3 spec amendment (2026-05-17):** the original "filter drop" framing
+> for this task was rejected by the design-reviewer when NATS JetStream
+> consumer-immutability constraints (error 10012) made the "advance the
+> consumer's `OptStartTime` on reattach" mechanism impossible. Per the §I-PRIV-3
+> amendment, `Subscribe.ReattachCAS` MUST NOT change the durable consumer's
+> `DeliverPolicy`/`OptStartTime`/`OptStartSeq`, and `LocationArrivedAt` is
+> UNCHANGED across reattach. Events emitted during the detach window have
+> timestamp ≥ `LocationArrivedAt` and therefore PASS the per-event
+> filter-at-delivery — they MUST be delivered to the reattached session via
+> JetStream resume from last-acked-seq. There is no `LastReattachAt` floor
+> in production; the pre-Round-3 wording referring to one was removed from
+> the harness in PR iwzt-16-plan-fix.
 
 **Files:**
 
 - Modify: `test/integration/privacy/privacy_test.go`
+- Dependencies: requires the harness's live Subscribe stream wiring
+  (`Session.DetachTransport`, `Session.ReattachTransport`, `Session.WaitForEvent`)
+  — tracked as precursor bead `holomush-m5nj` so the harness work can land
+  independently of this test.
 
 - [ ] **Step 1: Add the reattach-durability scenario**
 
 ```go
-var _ = Describe("I-PRIV-3: ReattachCAS preserves durable; filter enforces new floor", func() {
-    var ts *privacytest.Server
-    BeforeEach(func() { ts = privacytest.Start(GinkgoT()) })
+var _ = Describe("I-PRIV-3: ReattachCAS preserves durable; Subscribe replay delivers detach-window events", func() {
+    var ts *integrationtest.Server
+    BeforeEach(func() { ts = integrationtest.Start(GinkgoT()) })
     AfterEach(func() { ts.Stop() })
 
-    It("drops events emitted during detach via filter-at-delivery on reattach", func() {
+    It("delivers events emitted during transport detach when transport reattaches", func() {
         ctx := context.Background()
         sessA := ts.ConnectAuthed(ctx, "Felix")
         other := ts.ConnectAuthed(ctx, "Gemma")  // same location
         Expect(sessA.LocationID).To(Equal(other.LocationID))
 
         sessA.DetachTransport(ctx)
-        // While detached, other emits.
-        other.SendCommand(ctx, "say while-felix-detached")
-        other.WaitForEvent(ctx, "core-communication:say")
+        // While Felix's transport is detached, Gemma emits.
+        const detachWindowType = "iwzt16-test:during-detach-marker"
+        Expect(other.EmitDirectEvent(ctx,
+            "location:"+other.LocationID.String(),
+            detachWindowType,
+            []byte(`{"character_name":"Gemma","action":"speaks while Felix is detached."}`))).
+            To(Succeed())
 
         sessA.ReattachTransport(ctx)
-        events := sessA.DrainEvents(ctx, 1*time.Second)
-        for _, ev := range events {
-            Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", sessA.LastReattachAt),
-                "event %q at %s leaked across detach window — I-PRIV-3 broken",
-                ev.GetType(), ev.GetTimestamp().AsTime())
-        }
+        // Subscribe replay MUST deliver the detach-window event via durable
+        // resume — per spec §I-PRIV-3 (Round 3) the filter-at-delivery floor
+        // remains LocationArrivedAt, which is unchanged across reattach;
+        // the detach-window event is at-or-after that floor so it passes.
+        ev := sessA.WaitForEvent(ctx, detachWindowType)
+        Expect(ev).NotTo(BeNil(),
+            "reattach Subscribe replay MUST deliver the detach-window event (I-PRIV-3)")
+        Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", sessA.LocationArrivedAt),
+            "delivered event must be at-or-after the unchanged LocationArrivedAt")
     })
 })
 ```
@@ -1925,7 +1948,7 @@ var _ = Describe("I-PRIV-3: ReattachCAS preserves durable; filter enforces new f
 - [ ] **Step 2: Run + Commit**
 
 `task test:int -- ./test/integration/privacy/`
-Commit message: `test(privacy): I-PRIV-3 reattach durability with filter-at-delivery`.
+Commit message: `test(privacy): I-PRIV-3 reattach durable replay (events delivered across detach window)`.
 
 ---
 

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -432,7 +432,6 @@ func (s *Server) ConnectGuest(ctx context.Context) *Session {
 		OriginalLocationID: s.guestStartLocationID,
 		LocationArrivedAt:  persisted.LocationArrivedAt,
 		SessionCreatedAt:   persisted.CreatedAt,
-		LastReattachAt:     time.Time{},
 		playerSessionToken: rawToken,
 	}
 }
@@ -504,7 +503,6 @@ func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, ro
 		OriginalLocationID: s.guestStartLocationID,
 		LocationArrivedAt:  persisted.LocationArrivedAt,
 		SessionCreatedAt:   persisted.CreatedAt,
-		LastReattachAt:     time.Time{},
 		playerSessionToken: rawToken,
 	}
 }

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -42,9 +42,6 @@ type Session struct {
 	LocationArrivedAt time.Time
 	// SessionCreatedAt is the time the game session was created.
 	SessionCreatedAt time.Time
-	// LastReattachAt is the time of the most recent DetachTransport+ReattachTransport
-	// cycle (zero if none has occurred).
-	LastReattachAt time.Time
 
 	// Reattached is true when the SessionID was returned by SelectCharacter's
 	// reattach branch (i.e. an existing active/detached session row matched
@@ -158,18 +155,25 @@ func (s *Session) MoveTo(ctx context.Context, newLocationID ulid.ULID) {
 // stream (e.g., client closed the connection). The session remains in
 // StatusDetached in Postgres.
 //
-// TODO(iwzt-9): wire subscribe goroutine cancel.
+// TODO(iwzt-16-precursor): wire subscribe goroutine cancel.
 func (s *Session) DetachTransport(_ context.Context) {
-	s.server.t.Fatalf("integrationtest.Session.DetachTransport: TODO iwzt-9 — Subscribe goroutine not yet wired")
+	s.server.t.Fatalf("integrationtest.Session.DetachTransport: TODO iwzt-16-precursor — Subscribe goroutine not yet wired")
 }
 
-// ReattachTransport reopens the Subscribe stream after a DetachTransport,
-// recording LastReattachAt. Mirrors the client's reconnection flow.
+// ReattachTransport reopens the Subscribe stream after a DetachTransport.
+// Mirrors the client's reconnection flow.
 //
-// TODO(iwzt-9): wire subscribe goroutine restart.
+// Per spec I-PRIV-3 (Round 3 amendment), reattach MUST NOT change the
+// session's LocationArrivedAt — the durable JetStream consumer's
+// OptStartTime is immutable post-creation (NATS error 10012) and the
+// filter-at-delivery in dispatchDelivery enforces the original floor.
+// There is therefore NO post-reattach floor for tests to assert against;
+// any pre-Round-3 wording referring to a "LastReattachAt" timestamp does
+// not match production semantics.
+//
+// TODO(iwzt-16-precursor): wire subscribe goroutine restart.
 func (s *Session) ReattachTransport(_ context.Context) {
-	s.LastReattachAt = time.Now()
-	s.server.t.Fatalf("integrationtest.Session.ReattachTransport: TODO iwzt-9 — Subscribe goroutine not yet wired")
+	s.server.t.Fatalf("integrationtest.Session.ReattachTransport: TODO iwzt-16-precursor — Subscribe goroutine not yet wired")
 }
 
 // CreateScene creates a new scene (focus session) and returns its ULID.
@@ -328,7 +332,6 @@ func (p *AuthedPlayer) OpenWebSession(ctx context.Context) *Session {
 		OriginalLocationID: persisted.LocationID,
 		LocationArrivedAt:  persisted.LocationArrivedAt,
 		SessionCreatedAt:   persisted.CreatedAt,
-		LastReattachAt:     time.Time{},
 		Reattached:         selResp.GetReattached(),
 		playerSessionToken: p.rawToken,
 	}


### PR DESCRIPTION
## Summary

Brings the iwzt history-scope-privacy plan + integration-test harness into
alignment with the post-Round-3 spec amendment to I-PRIV-3. No production
code changes; this is a docs/test-infrastructure correction PR.

The plan template for Task 15 (the integration test for `iwzt.16`) was
written before the Round 3 spec amendment landed. It asserted that
detach-window events would be DROPPED on Subscribe reattach, gated by a
hypothetical \`LastReattachAt\` floor. The Round 3 amendment to §I-PRIV-3
(triggered by NATS JetStream consumer-immutability constraints, error 10012)
mandates the OPPOSITE: detach-window events MUST be DELIVERED via durable
replay, with \`LocationArrivedAt\` unchanged across reattach and the
per-event filter-at-delivery enforcing the original floor.

## Changes

- **Plan**: Task 15 rewritten with a Round-3-citing callout, corrected
  assertion (matches on event type + asserts timestamp ≥ \`LocationArrivedAt\`),
  explicit precursor bead dependency, and two small stale-reference cleanups
  in the harness-design section.
- **Harness**: removed the \`Session.LastReattachAt\` field — no production
  callers (\`rg LastReattachAt\` across the repo confirmed it was harness-only
  and tracked a value the post-Round-3 spec rejected). Updated the
  \`DetachTransport\` / \`ReattachTransport\` TODO labels to point at the new
  precursor bead.
- **bead state** (out-of-tree but related): \`holomush-iwzt.16\` description
  amended via \`bd update\` to match Round 3 semantics; new precursor bead
  \`holomush-m5nj\` filed for the Subscribe-stream harness infrastructure that
  iwzt.16 needs to be implementable; \`iwzt.16\` now depends on m5nj.

## Why a separate PR

iwzt.16 itself can't ship without ~200+ lines of Subscribe-stream harness
wiring. That work warrants its own review surface (filed as \`holomush-m5nj\`).
Meanwhile the stale plan template would mislead any implementer who picks up
\`iwzt.16\` or the harness work; correcting it now keeps the design docs
honest and unblocks the precursor work cleanly.

## Test plan

- [x] All 13 privacy integration tests still pass (the \`LastReattachAt\` field
      had zero callers; removing it is a pure dead-code cleanup).
- [x] \`task pr-prep\` — full lane green.
- [x] \`/review-code\` — READY, two trivial non-blocking suggestions; one
      applied (inline the precursor bead ID in the plan's Dependencies line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy implementation plan documentation to align with current design decisions and harness semantics.

* **Tests**
  * Refined session handling in test infrastructure to ensure location state remains consistent during reconnection scenarios and updated related test assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->