### PR TITLE
fix(world): per-property ABAC filter loop in ListPropertiesByParent (rmsi.3)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -120,3 +120,23 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   default-deny for that caller. Task 3 (`rmsi.3` / future) fixes the
   caller's resource shape. No fail-open risk; behavior is identical
   before/after this PR for that call site.
+- **rmsi.3 per-property filter shape (2026-05-22)**: `ListPropertiesByParent`
+  (`internal/world/service.go:1077-1104`) now fetches all properties then
+  loops, issuing one `checkAccess(ctx, subject, "read", access.PropertyResource(prop.ID.String()), prefixProperty)`
+  per property. INV-1 (per-property ULID resource shape, NOT parent-shaped
+  composite) is pinned by the unit-test "mixed permit/deny" case at
+  `service_test.go:7684-7693` via `strings.Contains(rid, p2ID.String())`.
+  INV-2 (silent default-deny filter) implemented via
+  `errors.Is(checkErr, ErrPermissionDenied)` no-op branch. INV-2b (infra
+  failure propagation) implemented via `errors.Is(checkErr,
+  ErrAccessEvaluationFailed)` early-return; defensive default case ALSO
+  fail-closes on unrecognized errors (good belt-and-suspenders).
+  `checkAccess` distinguishes infra-vs-deny via `decision.IsInfraFailure()`
+  (PolicyID prefix "infra:") at `service.go:164`. Test covers both
+  Evaluate-returns-error AND Evaluate-returns-InfraFailure-decision paths.
+  Information-leak about property count: caller who can't read any
+  property still triggers `propertyRepo.ListByParent`; trade-off is
+  documented in spec §2 and is acceptable because pre-fix already
+  default-denied uniformly (no info leak DELTA). Caller surface
+  unchanged: `internal/command/types.go:71` & `internal/plugin/hostfunc/cap_property.go:28`
+  return shape unchanged.

--- a/internal/world/service.go
+++ b/internal/world/service.go
@@ -1059,19 +1059,46 @@ func (s *Service) GetObjectsByLocation(ctx context.Context, subjectID string, lo
 	return objs, nil
 }
 
-// ListPropertiesByParent returns all properties for the given parent entity
-// after checking read authorization on the parent.
+// ListPropertiesByParent returns the subset of properties on the given
+// parent that the principal is permitted to read. Implements per-property
+// ABAC filtering: fetches all properties from the repository, then
+// invokes the access engine once per property with a property-shaped
+// resource. Outcomes per property:
+//
+//   - permit → property included in the returned slice
+//   - ErrPermissionDenied (deny decision) → property filtered out SILENTLY
+//     (normal case — most properties on another principal default-deny)
+//   - ErrAccessEvaluationFailed (engine error, resolver timeout, etc.)
+//     → propagate wrapped error, abort the call
+//
+// Infra failures MUST be visible to callers; silently masking them as
+// "no visible properties" would create ghost-data scenarios. Per
+// holomush-72ou design spec INV-2 + INV-2b.
 func (s *Service) ListPropertiesByParent(ctx context.Context, subjectID, parentType string, parentID ulid.ULID) ([]*EntityProperty, error) {
 	if s.propertyRepo == nil {
 		return nil, oops.Code("PROPERTY_QUERY_FAILED").Errorf("property repository not configured")
 	}
-	resource := access.PropertyResource(parentType + ":" + parentID.String())
-	if err := s.checkAccess(ctx, subjectID, "read", resource, prefixProperty); err != nil {
-		return nil, err
-	}
-	props, err := s.propertyRepo.ListByParent(ctx, parentType, parentID)
+	all, err := s.propertyRepo.ListByParent(ctx, parentType, parentID)
 	if err != nil {
 		return nil, oops.Code("PROPERTY_QUERY_FAILED").Wrapf(err, "list properties for %s %s", parentType, parentID)
 	}
-	return props, nil
+	visible := make([]*EntityProperty, 0, len(all))
+	for _, prop := range all {
+		resource := access.PropertyResource(prop.ID.String())
+		checkErr := s.checkAccess(ctx, subjectID, "read", resource, prefixProperty)
+		switch {
+		case checkErr == nil:
+			visible = append(visible, prop)
+		case errors.Is(checkErr, ErrPermissionDenied):
+			// Normal default-deny — filter silently. Continue.
+		case errors.Is(checkErr, ErrAccessEvaluationFailed):
+			// Infra failure — abort the call. INV-2b: no ghost-data.
+			return nil, checkErr
+		default:
+			// Defensive: unrecognized error from checkAccess. Treat as
+			// infra failure (fail-closed) and propagate.
+			return nil, checkErr
+		}
+	}
+	return visible, nil
 }

--- a/internal/world/service_test.go
+++ b/internal/world/service_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -7640,4 +7641,158 @@ func TestWorldService_GetLocation_AllowWithInfraPrefix(t *testing.T) {
 	loc, err := svc.GetLocation(ctx, subjectID, locID)
 	require.NoError(t, err, "allow decision must succeed even with infra: prefix policyID")
 	assert.Equal(t, expectedLoc, loc)
+}
+
+func TestService_ListPropertiesByParent(t *testing.T) {
+	parentType := "character"
+	parentID := ulid.Make()
+	p1ID, p2ID, p3ID := ulid.Make(), ulid.Make(), ulid.Make()
+	p1 := &world.EntityProperty{ID: p1ID, ParentType: parentType, ParentID: parentID, Name: "name1", Visibility: "public"}
+	p2 := &world.EntityProperty{ID: p2ID, ParentType: parentType, ParentID: parentID, Name: "name2", Visibility: "private"}
+	p3 := &world.EntityProperty{ID: p3ID, ParentType: parentType, ParentID: parentID, Name: "name3", Visibility: "public"}
+
+	tests := []struct {
+		name           string
+		repoProps      []*world.EntityProperty
+		repoErr        error
+		engineDecide   func(resourceID string) (types.Decision, error)
+		expectIDs      []ulid.ULID
+		expectErr      bool
+		expectErrCode  string
+		expectErrIsAny []error
+	}{
+		{
+			name:         "empty parent → empty list, nil error",
+			repoProps:    nil,
+			engineDecide: alwaysAllow,
+			expectIDs:    nil,
+		},
+		{
+			name:         "all-permit → full list, nil error",
+			repoProps:    []*world.EntityProperty{p1, p2, p3},
+			engineDecide: alwaysAllow,
+			expectIDs:    []ulid.ULID{p1ID, p2ID, p3ID},
+		},
+		{
+			name:         "all-deny → empty list, nil error",
+			repoProps:    []*world.EntityProperty{p1, p2, p3},
+			engineDecide: alwaysDeny,
+			expectIDs:    nil,
+		},
+		{
+			name:      "mixed permit/deny → filtered subset, nil error",
+			repoProps: []*world.EntityProperty{p1, p2, p3},
+			engineDecide: func(rid string) (types.Decision, error) {
+				if strings.Contains(rid, p2ID.String()) {
+					return types.NewDecision(types.EffectDefaultDeny, "private", "seed:test"), nil
+				}
+				return types.NewDecision(types.EffectAllow, "permit", "seed:test"), nil
+			},
+			expectIDs: []ulid.ULID{p1ID, p3ID},
+		},
+		{
+			name:          "repo error → wrapped PROPERTY_QUERY_FAILED",
+			repoProps:     nil,
+			repoErr:       errors.New("db down"),
+			engineDecide:  alwaysAllow,
+			expectErr:     true,
+			expectErrCode: "PROPERTY_QUERY_FAILED",
+		},
+		{
+			name:      "engine returns Evaluate error on one prop → wrapped ErrAccessEvaluationFailed",
+			repoProps: []*world.EntityProperty{p1, p2, p3},
+			engineDecide: func(rid string) (types.Decision, error) {
+				if strings.Contains(rid, p2ID.String()) {
+					return types.Decision{}, errors.New("engine boom")
+				}
+				return types.NewDecision(types.EffectAllow, "permit", "seed:test"), nil
+			},
+			expectErr:      true,
+			expectErrCode:  "PROPERTY_ACCESS_EVALUATION_FAILED",
+			expectErrIsAny: []error{world.ErrAccessEvaluationFailed},
+		},
+		{
+			// IsInfraFailure() is detected via PolicyID prefix "infra:"
+			// (see internal/access/policy/types/types.go). Construct an
+			// infra-failure Decision by passing an "infra:" PolicyID with
+			// EffectDefaultDeny — checkAccess in service.go then takes
+			// the IsInfraFailure() branch.
+			name:      "engine returns InfraFailure decision on one prop → wrapped ErrAccessEvaluationFailed",
+			repoProps: []*world.EntityProperty{p1, p2, p3},
+			engineDecide: func(rid string) (types.Decision, error) {
+				if strings.Contains(rid, p2ID.String()) {
+					return types.NewDecision(types.EffectDefaultDeny, "resolver down", "infra:session"), nil
+				}
+				return types.NewDecision(types.EffectAllow, "permit", "seed:test"), nil
+			},
+			expectErr:      true,
+			expectErrCode:  "PROPERTY_ACCESS_EVALUATION_FAILED",
+			expectErrIsAny: []error{world.ErrAccessEvaluationFailed},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockProp := worldtest.NewMockPropertyRepository(t)
+			mockEng := policytest.NewMockAccessPolicyEngine(t)
+			mockProp.EXPECT().ListByParent(mock.Anything, parentType, parentID).Return(tt.repoProps, tt.repoErr).Once()
+
+			// Observed resource strings — used to pin INV-1 (per-property
+			// shape, not parent-shaped). Collected per-call inside the
+			// engineDecide closure.
+			var observedResources []string
+			if tt.repoErr == nil {
+				for range tt.repoProps {
+					// .Maybe() allows the expectation to be UNCONSUMED:
+					// abort cases (engine-error / infra-failure) short-
+					// circuit the loop after the failing property, so
+					// the remaining expectations would otherwise fail
+					// AssertExpectations in cleanup.
+					mockEng.EXPECT().Evaluate(mock.Anything, mock.Anything).
+						RunAndReturn(func(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+							observedResources = append(observedResources, req.Resource)
+							return tt.engineDecide(req.Resource)
+						}).Maybe()
+				}
+			}
+			svc := world.NewService(world.ServiceConfig{
+				PropertyRepo: mockProp, Engine: mockEng,
+			})
+
+			got, err := svc.ListPropertiesByParent(context.Background(), "character:"+ulid.Make().String(), parentType, parentID)
+
+			// INV-1 pin: every resource passed to engine.Evaluate MUST
+			// be exactly "property:<ulid>" — not a parent-shaped composite
+			// like "property:character:<ulid>".
+			for _, rid := range observedResources {
+				assert.Regexp(t, `^property:[0-9A-Z]{26}$`, rid,
+					"INV-1: per-property resource shape MUST be property:<ulid>, not parent-shaped")
+			}
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.expectErrCode != "" {
+					errutil.AssertErrorCode(t, err, tt.expectErrCode)
+				}
+				for _, target := range tt.expectErrIsAny {
+					assert.ErrorIs(t, err, target)
+				}
+				return
+			}
+			require.NoError(t, err)
+			var gotIDs []ulid.ULID
+			for _, p := range got {
+				gotIDs = append(gotIDs, p.ID)
+			}
+			assert.Equal(t, tt.expectIDs, gotIDs)
+		})
+	}
+}
+
+func alwaysAllow(_ string) (types.Decision, error) {
+	return types.NewDecision(types.EffectAllow, "permit", "seed:test"), nil
+}
+
+func alwaysDeny(_ string) (types.Decision, error) {
+	return types.NewDecision(types.EffectDefaultDeny, "default deny", "seed:test"), nil
 }


### PR DESCRIPTION
## Summary

Replaces the wrong parent-shaped resource check at `internal/world/service.go:1068` with a per-property filter loop. **Task 3 of 5** in the property authz redesign epic (`holomush-72ou`).

Combined with `rmsi.1` (PR #4172, `ParentLocationResolver`) and `rmsi.2` (PR #4174, `PropertyProvider` wired into `BuildABACStack`), this completes the runtime authz path for property reads. Once #4177 (Task 5, integration tests) lands, the epic closes.

## What this does

| State | Behavior |
|---|---|
| Before | `Service.ListPropertiesByParent` emitted ONE check against a parent-shaped resource (`property:<parentType>:<parentID>`). The PropertyProvider can only resolve a property by its own ULID, so every check silently default-denied. |
| After | Fetches all properties via `propertyRepo.ListByParent`; per-property calls `checkAccess(ctx, subj, "read", access.PropertyResource(prop.ID.String()), prefixProperty)`. Returns only the permitting subset. |

## Invariants

- **INV-1** (per-property resource shape): emits `property:<ulid>` per property, NOT a parent-shaped composite. Pinned via explicit regex assertion in the unit test against observed engine.Evaluate resource arguments.
- **INV-2** (silent filter on deny): `errors.Is(err, ErrPermissionDenied)` → property dropped from result slice silently.
- **INV-2b** (propagate infra failure): `errors.Is(err, ErrAccessEvaluationFailed)` → wrapped error returned, function aborts. No ghost-data (caller can't mistake "engine error" for "no visible properties").
- **Defensive default**: unknown error class fail-closed.

## Tests

New `TestService_ListPropertiesByParent` (7 subtests) with mock `AccessPolicyEngine`:

1. empty parent → `[]`, no error
2. all-permit → full list
3. all-deny → `[]`, no error
4. mixed → filtered subset
5. repo error → wrapped `PROPERTY_QUERY_FAILED` oops code
6. engine `Evaluate` returns error on one prop → wrapped `PROPERTY_ACCESS_EVALUATION_FAILED` (`errors.Is(.., ErrAccessEvaluationFailed)`)
7. engine returns `EffectInfraFailure` decision (`infra:` PolicyID) on one prop → same wrapped error

`task pr-prep` full lane green.

## Pre-push reviews

Both pre-push reviewers READY (no blocking findings). Three Low findings addressed inline:

- **Mock cardinality fragility** (both reviewers) — abort cases (6, 7) registered N expectations but only 2 consumed. Fixed with `.Maybe()` on each expectation so AssertExpectations doesn't fail on un-consumed entries.
- **INV-1 pin was indirect** (both reviewers) — was `strings.Contains(rid, p2ID.String())`, would pass a hybrid composite. Added explicit regex `^property:[0-9A-Z]{26}$` assertion against all observed resources passed to `engine.Evaluate`.
- **Repo-error case didn't pin oops code** (abac-reviewer) — was `expectErrCode: ""`. Now pins `PROPERTY_QUERY_FAILED`.

## Test deviations from plan (acknowledged)

1. Used `policytest.NewMockAccessPolicyEngine` instead of `worldtest.NewMockAccessPolicyEngine` — the latter is incomplete (missing `CanPerformAction`).
2. Removed `noopEmitter{}` / `noopTx{}` from `ServiceConfig` — not actual types; not needed for this method.
3. Used `var gotIDs []ulid.ULID` (nil) instead of `make(..., 0, len)` to match `expectIDs: nil` for empty cases.

## Bd state

- `holomush-rmsi.3` — `in_progress` (claimed). Closes via `bd close` on merge.
- Unblocks: `holomush-rmsi.5` (integration regression tests) — the final task in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Property listings now apply individual access controls to each property instead of parent-level authorization, ensuring users only view properties they have permission to access.

* **Tests**
  * Added comprehensive test coverage for per-property authorization filtering behavior, including allow/deny scenarios and error handling cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->