### PR TITLE
test(privacy): I-PRIV-3 reattach durable replay (iwzt.16)

### DIFF
--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -96,6 +96,109 @@ var _ = Describe("I-PRIV-6 (gate-bypass arm): staff override bypasses the locati
 	})
 })
 
+// I-PRIV-3 (Subscribe-replay path): when a session's transport drops and later
+// reattaches within TTL, events emitted during the detach window MUST be
+// DELIVERED via the live Subscribe stream's durable replay (NOT dropped by
+// the filter-at-delivery). The durable consumer's OptStartTime is immutable
+// per NATS error 10012 (I-PRIV-8) and LocationArrivedAt is unchanged across
+// reattach (I-PRIV-3); detach-window event timestamps are therefore at-or-after
+// the unchanged filter floor and pass through.
+//
+// Companion to the QueryStreamHistory-path version asserted by the
+// "I-PRIV-3 / I-PRIV-4: detach/reattach preserves session floor and replays
+// events" block below. Both share the same LocationArrivedAt floor invariant
+// but exercise different production code paths:
+//
+//   - This test: dispatchDelivery filter-at-delivery → live Subscribe stream
+//     (internal/grpc/server.go:1053 filter + the broadcaster's stream.Send)
+//   - Below: HistoryReader-bounded query (internal/grpc/query_stream_history.go)
+//
+// Per spec §8 reattach-durability test: open A at T0 (durable created with
+// OptStartTime=T0), third party emits at T1, A detaches at T2, third party
+// emits at T3 (during detach window), A reattaches at T4 — A's Subscribe
+// replay MUST deliver both T1 and T3 events.
+var _ = Describe("I-PRIV-3: ReattachCAS preserves durable; Subscribe replay delivers detach-window events", func() {
+	// Unique event type for the during-detach emit so WaitForEvent matches
+	// exactly the seeded event (not any later same-typed event). Mirrors the
+	// pattern in the I-PRIV-3 QueryStreamHistory test below.
+	const detachWindowType = "iwzt16-test:during-detach-marker"
+
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		felix *integrationtest.Session
+		gemma *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		ctx, _ = context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel unused in test lifecycle
+		ts = integrationtest.Start(suiteT)
+
+		felix = ts.ConnectAuthed(ctx, "Felix")
+		gemma = ts.ConnectAuthed(ctx, "Gemma")
+		Expect(felix.LocationID).To(Equal(gemma.LocationID),
+			"precondition: both characters at the guest start location so Gemma's emits land in Felix's location stream")
+	})
+
+	AfterEach(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if gemma != nil {
+			gemma.Logout(cleanupCtx)
+		}
+		if felix != nil {
+			felix.Logout(cleanupCtx)
+		}
+		if ts != nil {
+			ts.Stop()
+		}
+	})
+
+	It("delivers events emitted during transport detach when transport reattaches", func() {
+		// Capture LocationArrivedAt before any state-changing op so we can
+		// assert it's UNCHANGED after reattach (the load-bearing I-PRIV-3
+		// claim — together with iwzt.17's QueryStreamHistory assertion,
+		// this proves the floor is preserved on BOTH code paths).
+		preDetachFloor := felix.LocationArrivedAt
+
+		felix.DetachTransport(ctx)
+
+		// Gemma emits during Felix's detach window. The event lands in
+		// Felix's durable JetStream consumer (per-session durable, immutable
+		// OptStartTime); reattach replay below MUST deliver it.
+		Expect(gemma.EmitDirectEvent(ctx,
+			"location:"+gemma.LocationID.String(),
+			detachWindowType,
+			[]byte(`{"character_name":"Gemma","action":"speaks while Felix is detached."}`))).
+			To(Succeed(), "during-detach emit MUST publish into Felix's durable consumer")
+
+		felix.ReattachTransport(ctx)
+
+		// WaitForEvent reads from the post-reattach live Subscribe stream
+		// until the marker arrives (or waitCtx cancels / transport exits).
+		// The production filter-at-delivery (internal/grpc/server.go:1053)
+		// uses streamScopeFloor → LocationArrivedAt (unchanged) as the
+		// per-event floor; the marker's JetStream-stamped timestamp is
+		// strictly after that floor, so it passes through.
+		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer waitCancel()
+		ev := felix.WaitForEvent(waitCtx, detachWindowType)
+		Expect(ev).NotTo(BeNil(),
+			"I-PRIV-3 (Subscribe replay): durable replay MUST deliver the during-detach event to the reattached transport")
+		Expect(ev.GetType()).To(Equal(detachWindowType),
+			"delivered event type must match the seeded marker")
+		Expect(ev.GetTimestamp().AsTime()).To(BeTemporally(">=", preDetachFloor),
+			"I-PRIV-3 floor preservation: delivered event timestamp must be at-or-after the unchanged LocationArrivedAt — "+
+				"if production accidentally advanced the floor on reattach (e.g. by re-running auth_handlers.go:331's "+
+				"session-create logic in the reattach branch), the marker's pre-reattach timestamp would be below the "+
+				"advanced floor and dispatchDelivery's filter at internal/grpc/server.go:1053 would have dropped it. "+
+				"That the marker reached WaitForEvent at all is the load-bearing assertion. "+
+				"(A direct re-read of sessions.location_arrived_at post-reattach would harden this further; tracked as a "+
+				"future Session.RefreshFromPersisted helper. Asserting felix.LocationArrivedAt against preDetachFloor "+
+				"would be tautological — that field is set once at ConnectAuthed and is never mutated by the harness.)")
+	})
+})
+
 // I-PRIV-3 / I-PRIV-4 / spec §2 "transport-continuity worked example":
 // the session row is the unit of continuity, not the transport connection.
 // When a session detaches (transport drop) and later reattaches within TTL,


### PR DESCRIPTION
## Summary

The final iwzt integration test. Asserts the I-PRIV-3 Subscribe-replay
invariant end-to-end via the m5nj harness wiring landed in PR #4178:
when a transport detaches and later reattaches within TTL, events emitted
during the detach window MUST be delivered via JetStream durable replay
(NOT dropped by the per-event filter-at-delivery).

## What it asserts

1. Two characters at the same location (Felix detaches/reattaches; Gemma
   is the publisher).
2. Felix.DetachTransport — Felix's transport closes; session row transitions
   to Detached via production Disconnect.
3. Gemma emits a uniquely-typed marker event into the location stream
   during Felix's detach window. The event lands in Felix's per-session
   durable JetStream consumer.
4. Felix.ReattachTransport — production ReattachCAS flips the row back to
   Active; a new Subscribe stream is wired against the same durable.
5. Felix.WaitForEvent receives the marker via durable replay.
6. The delivered event's timestamp is at-or-after the preDetachFloor —
   confirming the filter-at-delivery's \`LocationArrivedAt\` was preserved
   across reattach (any production regression that surreptitiously advanced
   the floor would have caused the per-event filter at
   \`internal/grpc/server.go:1053\` to drop the marker, and WaitForEvent
   would have hung until the test timed out).

## Companion to iwzt.17

iwzt.17's existing I-PRIV-3 / I-PRIV-4 block in the same file asserts
the same invariant via the QueryStreamHistory code path. This new block
exercises the parallel live-Subscribe path. Both gate on the same
\`LocationArrivedAt\` filter floor; together they cover both production
read paths.

## Reviewer notes

- Spec §I-PRIV-3 + §8 "reattach durability" test description is the
  source of truth. Round 3 spec amendment forbade advancing the
  durable's \`OptStartTime\` on reattach (NATS error 10012); enforcement
  moved to the per-event filter against the unchanged \`LocationArrivedAt\`.
- The code-reviewer flagged a tautological pre/post LocationArrivedAt
  check against the in-memory \`Session.LocationArrivedAt\` (set once at
  ConnectAuthed, never mutated by Detach/Reattach). Removed in favor
  of consolidating the meaningful timestamp-floor check's failure
  message; filed \`holomush-q2qt\` (P3) for a future
  \`Session.RefreshFromPersisted\` helper that would let tests re-read
  the persisted sessions row directly for tighter assertions.

Closes holomush-iwzt.16.

## Test plan

- [x] \`task test:int -- ./test/integration/privacy/... -ginkgo.focus='I-PRIV-3: ReattachCAS preserves durable'\` — passes
- [x] \`task pr-prep\` — full lane green
- [x] \`/review-code\` — READY, one Medium tautology finding applied inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test verifying Subscribe replay delivery when a session's transport is detached and reattached within TTL, ensuring events emitted during disconnection are properly delivered through the live Subscribe stream with correct timestamp preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->