### PR TITLE
fix(grpc): stamp RenderingMetadata on synthetic location_state events (holomush-4wdu)

### DIFF
--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -418,6 +418,11 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 		holoGRPC.WithHistoryReader(historyReader),
 		holoGRPC.WithGameID(s.cfg.EventBus.GameID),
 		holoGRPC.WithIdentityRegistry(pluginManager),
+		// VerbRegistry feeds the synthetic-location_state emit path's
+		// RenderingMetadata stamp. Without it, the locationFollower's
+		// fallback EventFrame has nil Rendering and the gateway drops
+		// every synthetic event per INV-GW-5 (holomush-4wdu).
+		holoGRPC.WithVerbRegistry(s.cfg.VerbRegistry),
 	}
 	if s.cfg.StreamRegistry != nil {
 		coreServerOpts = append(coreServerOpts, holoGRPC.WithStreamRegistry(s.cfg.StreamRegistry))

--- a/internal/grpc/location_follow.go
+++ b/internal/grpc/location_follow.go
@@ -41,6 +41,12 @@ type locationFollower struct {
 	sessionStore  session.Store
 	locStreamName string
 	updateFilters locationFilterUpdater
+	// verbRegistry is the source of rendering metadata for the synthetic
+	// location_state events this follower emits. Required: events emitted
+	// without RenderingMetadata are dropped by the gateway per INV-GW-5
+	// (internal/web/translate.go:42-60), so a nil registry guarantees every
+	// synthetic emit silently disappears at the gateway boundary.
+	verbRegistry *core.VerbRegistry
 }
 
 // handleEvent checks if the event is a character move for the tracked character.
@@ -153,7 +159,10 @@ func (lf *locationFollower) switchLocationSubscription(ctx context.Context, newL
 }
 
 // sendSynthetic sends the initial synthetic location_state for the current
-// location. Best-effort: errors are logged and swallowed.
+// location. Best-effort at the RPC level (a build failure won't abort the
+// Subscribe RPC), but builds are NOT silent: errors are logged so a
+// registry-misconfiguration regression doesn't reproduce the
+// holomush-4wdu silent-drop symptom this method's fix targets.
 func (lf *locationFollower) sendSynthetic(
 	ctx context.Context,
 	stream grpc.ServerStreamingServer[corev1.SubscribeResponse],
@@ -163,7 +172,17 @@ func (lf *locationFollower) sendSynthetic(
 	}
 	locState, err := lf.buildLocationState(ctx, lf.currentLocID)
 	if err != nil {
-		return nil //nolint:nilerr // best-effort: synthetic location_state failure is non-fatal
+		// Surface the failure so a verbRegistry misconfiguration in
+		// production doesn't silently drop every initial-attach
+		// location_state event (holomush-4wdu: the original bug had no
+		// log at all; fail-closed surfacing was added in this fix, so
+		// it MUST actually log).
+		slog.WarnContext(
+			ctx, "location_state: synthetic emit failed at initial attach",
+			"location_id", lf.currentLocID.String(),
+			"error", err,
+		)
+		return nil
 	}
 	return oops.Wrap(stream.Send(locState))
 }
@@ -228,6 +247,16 @@ func (lf *locationFollower) buildLocationState(ctx context.Context, locationID u
 		return nil, oops.Wrapf(err, "marshal location_state")
 	}
 
+	// Stamp RenderingMetadata from the verb registry so the gateway's INV-GW-5
+	// guard (internal/web/translate.go:42-60) doesn't drop this synthetic
+	// event. This path bypasses the bus (and therefore RenderingPublisher),
+	// so we must do the same lookup here that RenderingPublisher.Publish
+	// would do at internal/eventbus/rendering_publisher.go:58-73.
+	rendering, err := buildLocationStateRendering(lf.verbRegistry)
+	if err != nil {
+		return nil, err
+	}
+
 	return &corev1.SubscribeResponse{
 		Frame: &corev1.SubscribeResponse_Event{
 			Event: &corev1.EventFrame{
@@ -238,8 +267,38 @@ func (lf *locationFollower) buildLocationState(ctx context.Context, locationID u
 				ActorType: core.ActorSystem.String(),
 				ActorId:   "system",
 				Payload:   payloadJSON,
+				Rendering: rendering,
 			},
 		},
+	}, nil
+}
+
+// buildLocationStateRendering looks up the location_state verb registration
+// and constructs the RenderingMetadata proto. Mirrors what RenderingPublisher
+// does for bus-routed events (internal/eventbus/rendering_publisher.go:58-73).
+//
+// Fails closed when the registry is nil or the verb is unregistered — a
+// missing registration means the synthetic event would be dropped at the
+// gateway anyway, so an explicit error at emit time surfaces the bug instead
+// of silently losing every location_state event in production.
+func buildLocationStateRendering(registry *core.VerbRegistry) (*corev1.RenderingMetadata, error) {
+	if registry == nil {
+		return nil, oops.Code("LOCATION_STATE_NO_REGISTRY").
+			Errorf("verb registry not configured; synthetic location_state would fail INV-GW-5 at gateway")
+	}
+	reg, ok := registry.Lookup(string(core.EventTypeLocationState))
+	if !ok {
+		return nil, oops.Code("LOCATION_STATE_UNREGISTERED").
+			With("event_type", string(core.EventTypeLocationState)).
+			Errorf("location_state verb not registered; synthetic emit would fail INV-GW-5 at gateway")
+	}
+	return &corev1.RenderingMetadata{
+		Category:            reg.Category,
+		Format:              reg.Format,
+		Label:               reg.Label,
+		DisplayTarget:       reg.DisplayTarget,
+		SourcePlugin:        reg.Source,
+		SourcePluginVersion: registry.SourceVersion(reg.Source),
 	}, nil
 }
 

--- a/internal/grpc/location_follow_test.go
+++ b/internal/grpc/location_follow_test.go
@@ -18,12 +18,24 @@ import (
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/world"
+	"github.com/holomush/holomush/pkg/errutil"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 	corecomm "github.com/holomush/holomush/plugins/core-communication"
 )
 
 // Compile-time check that *world.Service satisfies WorldQuerier.
 var _ WorldQuerier = (*world.Service)(nil)
+
+// testVerbRegistry returns a freshly-bootstrapped registry with the builtin
+// verbs (including location_state) registered. Used by the locationFollower
+// tests since buildLocationState now requires a non-nil registry to stamp
+// RenderingMetadata on synthetic events (per INV-GW-5 at internal/web/translate.go:42-60).
+func testVerbRegistry(t *testing.T) *core.VerbRegistry {
+	t.Helper()
+	r, err := core.BootstrapVerbRegistry("test")
+	require.NoError(t, err)
+	return r
+}
 
 // mockWorldQuerier implements WorldQuerier for tests.
 type mockWorldQuerier struct {
@@ -81,6 +93,7 @@ func TestLocationFollower_HandleEvent_DetectsCharacterMove(t *testing.T) {
 		characterID:  charID,
 		currentLocID: oldLocID,
 		worldQuerier: wq,
+		verbRegistry: testVerbRegistry(t),
 	}
 
 	movePayload, err := json.Marshal(world.MovePayload{
@@ -228,7 +241,7 @@ func TestLocationFollower_BuildLocationState(t *testing.T) {
 		Status:        session.StatusActive,
 	})
 
-	lf := &locationFollower{worldQuerier: wq, sessionStore: ss}
+	lf := &locationFollower{worldQuerier: wq, sessionStore: ss, verbRegistry: testVerbRegistry(t)}
 	ev, err := lf.buildLocationState(context.Background(), locID)
 	require.NoError(t, err)
 	require.NotNil(t, ev)
@@ -237,6 +250,15 @@ func TestLocationFollower_BuildLocationState(t *testing.T) {
 	assert.Equal(t, string(core.EventTypeLocationState), ef.GetType())
 	assert.Equal(t, "system", ef.GetActorType())
 	assert.Equal(t, world.LocationStream(locID), ef.GetStream())
+
+	// holomush-4wdu: RenderingMetadata MUST be stamped on synthetic
+	// location_state events so the gateway's INV-GW-5 guard doesn't drop them.
+	rendering := ef.GetRendering()
+	require.NotNil(t, rendering, "synthetic location_state MUST carry RenderingMetadata (INV-GW-5)")
+	assert.Equal(t, "state", rendering.GetCategory())
+	assert.Equal(t, "snapshot", rendering.GetFormat())
+	assert.Equal(t, corev1.EventChannel_EVENT_CHANNEL_STATE, rendering.GetDisplayTarget())
+	assert.Equal(t, "builtin", rendering.GetSourcePlugin())
 
 	var payload core.LocationStatePayload
 	require.NoError(t, json.Unmarshal(ef.GetPayload(), &payload))
@@ -315,6 +337,7 @@ func TestSendSyntheticSendsLocationStateForCurrentLocation(t *testing.T) {
 		currentLocID: locID,
 		worldQuerier: wq,
 		sessionStore: session.NewMemStore(),
+		verbRegistry: testVerbRegistry(t),
 	}
 
 	stream := &capturingStream{ctx: context.Background()}
@@ -323,6 +346,32 @@ func TestSendSyntheticSendsLocationStateForCurrentLocation(t *testing.T) {
 
 	require.Len(t, stream.sent, 1)
 	assert.Equal(t, string(core.EventTypeLocationState), stream.sent[0].GetEvent().GetType())
+	// holomush-4wdu: synthetic location_state MUST carry RenderingMetadata
+	// (gateway drops nil-Rendering events per INV-GW-5).
+	require.NotNil(t, stream.sent[0].GetEvent().GetRendering(),
+		"synthetic location_state MUST carry RenderingMetadata (INV-GW-5)")
+}
+
+// TestBuildLocationStateRendering_NilRegistryFailsClosed asserts the
+// fail-closed branch when verbRegistry is unset. Locks in the
+// LOCATION_STATE_NO_REGISTRY error code so external log monitoring can key
+// alerts off it. Per holomush-4wdu: the original silent-drop symptom MUST
+// be surfaced loudly, not silently dropped a second way.
+func TestBuildLocationStateRendering_NilRegistryFailsClosed(t *testing.T) {
+	_, err := buildLocationStateRendering(nil)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "LOCATION_STATE_NO_REGISTRY")
+}
+
+// TestBuildLocationStateRendering_UnregisteredVerbFailsClosed asserts the
+// fail-closed branch when the location_state verb is missing from an
+// otherwise-valid registry. Locks in LOCATION_STATE_UNREGISTERED.
+func TestBuildLocationStateRendering_UnregisteredVerbFailsClosed(t *testing.T) {
+	// Empty registry — no builtins registered.
+	r := core.NewVerbRegistry()
+	_, err := buildLocationStateRendering(r)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "LOCATION_STATE_UNREGISTERED")
 }
 
 func TestSendSyntheticReturnsNilWhenWorldQuerierNil(t *testing.T) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -906,6 +906,7 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		sessionStore:  s.sessionStore,
 		locStreamName: locStreamName,
 		updateFilters: s.makeFilterUpdater(busStream, filterSet),
+		verbRegistry:  s.verbRegistry,
 	}
 	if sendErr := lf.sendSynthetic(ctx, stream); sendErr != nil {
 		return oops.Code("SEND_FAILED").With("session_id", req.SessionId).Wrap(sendErr)

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -224,6 +224,13 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	// tests the bare JS+Postgres tier is sufficient.
 	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now)
 
+	// VerbRegistry — required by the locationFollower's synthetic
+	// location_state emit path so RenderingMetadata is stamped on the
+	// EventFrame (gateway drops nil-Rendering events per INV-GW-5,
+	// holomush-4wdu). Production also wires this in cmd/holomush/sub_grpc.go.
+	verbRegistry, err := core.BootstrapVerbRegistry("test")
+	require.NoError(t, err, "integrationtest.Start: BootstrapVerbRegistry")
+
 	// CoreServer wired with all required subsystems.
 	coreServer := holoGRPC.NewCoreServer(
 		engine,
@@ -249,6 +256,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		// allowAllPolicyEngine so override semantics are exercised
 		// without the operational complexity of seeded ABAC policies.
 		holoGRPC.WithAccessEngine(pe),
+		holoGRPC.WithVerbRegistry(verbRegistry),
 	)
 
 	return &Server{


### PR DESCRIPTION
## Summary

Fixes the P1 gateway-drop bug: every \`location_state\` snapshot event emitted
by the locationFollower (initial Subscribe attach + post-move synthetic) was
arriving at the web gateway with nil \`Rendering\`, triggering INV-GW-5 at
\`internal/web/translate.go:42-60\` and being dropped before reaching the
client. Observed in local dev as repeated \`web: dropping event with nil
Rendering (INV-GW-5)\` ERROR-level log lines per move.

## Root cause

\`internal/grpc/location_follow.go::buildLocationState\` constructs a
\`corev1.EventFrame\` directly for in-process Subscribe stream delivery — it
bypasses the bus path (where \`RenderingPublisher\` would have stamped
\`Rendering\` automatically). The synthetic emit therefore had no Rendering
field, and the gateway dropped it.

Upstream of that: production \`cmd/holomush/sub_grpc.go\` never wired
\`WithVerbRegistry\` into \`CoreServer\` construction, so even if
\`buildLocationState\` HAD tried to look up the rendering, it had no registry.

## Fix

1. **\`internal/grpc/location_follow.go\`**: \`locationFollower\` gains a
   \`verbRegistry *core.VerbRegistry\` field. New \`buildLocationStateRendering\`
   helper mirrors \`RenderingPublisher.Publish\`'s lookup pattern. Returns
   fail-closed errors (\`LOCATION_STATE_NO_REGISTRY\` /
   \`LOCATION_STATE_UNREGISTERED\`) if registry is unset or location_state
   isn't registered — surfaces misconfiguration loudly instead of reproducing
   the silent-drop symptom under a different cause. \`sendSynthetic\` and
   \`handleEvent\` both \`slog.WarnContext\` on error (handleEvent already did;
   sendSynthetic now does too — code-reviewer-fix).

2. **\`internal/grpc/server.go\`**: \`locationFollower\` constructor now passes
   \`s.verbRegistry\`.

3. **\`cmd/holomush/sub_grpc.go\`**: adds \`holoGRPC.WithVerbRegistry(s.cfg.VerbRegistry)\`
   to \`coreServerOpts\` — production wiring that was previously missing.

4. **\`internal/testsupport/integrationtest/harness.go\`**: bootstraps a
   verb registry via \`core.BootstrapVerbRegistry("test")\` and passes via
   \`WithVerbRegistry\` so harness mirrors production.

5. **\`internal/grpc/location_follow_test.go\`**: 3 existing tests updated
   to inject \`verbRegistry: testVerbRegistry(t)\`; 2 existing tests gained
   assertions on the new Rendering field; 2 new fail-closed tests
   (\`TestBuildLocationStateRendering_NilRegistryFailsClosed\`,
   \`TestBuildLocationStateRendering_UnregisteredVerbFailsClosed\`) lock in
   the error codes.

## Reviewer notes

- \`/review-code\` round 1: NOT READY (1 blocking, 3 non-blocking). Blocking finding
  was that \`sendSynthetic\` swallowed my new fail-closed error without logging —
  defeating the surfacing goal. Fixed by adding \`slog.WarnContext\` matching
  \`handleEvent\`'s style. Non-blocking #1 (negative-path tests) applied as
  bonus coverage. Non-blocking #2 (helper-placement) accepted as-is (free
  function in a single call site). Non-blocking #3 (4 other CoreServer
  construction sites in tests not wiring \`WithVerbRegistry\`): verified safe —
  none of them wire \`worldQuerier\` either, so \`sendSynthetic\`'s early-return
  at line 167 prevents the registry lookup from running.

## Test plan

- [x] \`task test -- ./internal/grpc/... -run 'TestBuildLocationStateRendering|TestLocationFollower|TestSendSynthetic'\` — 11/11 pass
- [x] \`task pr-prep\` — full lane green (lint, format, schema, license, unit, integration, E2E)
- [x] \`/review-code\` round 2: blocking finding addressed; all other findings addressed or documented as accepted-as-is

Closes \`holomush-4wdu\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Location state events now include rendering metadata for consistent event stamping.
  * Synthetic event failures now surface as warnings for better error visibility.

* **Bug Fixes**
  * Enhanced error handling when verb registry is missing or location_state verb is unregistered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->