### PR TITLE
test(access): property authz integration regression tests + PropertyProvider bugfix (rmsi.5)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -140,3 +140,22 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   default-denied uniformly (no info leak DELTA). Caller surface
   unchanged: `internal/command/types.go:71` & `internal/plugin/hostfunc/cap_property.go:28`
   return shape unchanged.
+- **visible_to/excluded_from provider activation (rmsi.5, 2026-05-22)**:
+  `seed:property-restricted-visible-to` and `seed:property-restricted-excluded` were dead
+  code until this fix — PropertyProvider never emitted those attributes. Fix: emit ONLY
+  when `len(prop.VisibleTo) > 0` / `len(prop.ExcludedFrom) > 0` (omit-when-empty, ti1b
+  pattern). Schema correctly declares `AttrTypeStringList`. No default-deny integrity
+  risk: the PERMIT seed only fires for listed principals, and the FORBID seed only fires
+  for excluded ones. When reviewing future StringList provider additions, verify the `has`
+  guard path: if the provider emits an empty list (`[]any{}`) rather than omitting the
+  key, `resource has X` returns TRUE even when the list is logically absent — same
+  fail-open shape as the empty-string sentinel bug (ti1b). The correct shape is:
+  omit the key entirely, not emit an empty list.
+- **Audit assertion gap in integration property specs (rmsi.5 Low NIT)**:
+  `seed_policies_test.go` S1-S13 reset `auditWriter` in BeforeEach but no spec in the
+  property block reads back `env.auditWriter.Entries()` to verify the decision was
+  recorded. Engine-level audit contract is covered by `evaluation_test.go:68-70` (via
+  `Eventually`), but per-property-seed audit assertion is absent. When reviewing future
+  integration suites that add new seed coverage blocks, check whether the block includes
+  at least one audit-trail assertion — especially for FORBID seeds where audit capture
+  is the primary defense against undetected denials.

--- a/docs/superpowers/specs/2026-05-22-property-authz-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-22-property-authz-redesign-design.md
@@ -149,9 +149,9 @@ Location: `test/integration/access/seed_policies_test.go`. Extends existing patt
 | S5 | `denies non-owner reading a private property` | char1@loc1, char2.props.private-note (owner=char2) | `EffectDefaultDeny` |
 | S6 | `allows admin to read an admin-visibility property` | admin-char, target.props.admin-secret | `EffectAllow` (via `seed:admin-full-access` or `seed:property-admin-read`) |
 | S7 | `denies non-admin reading an admin-visibility property` | player-char, target.props.admin-secret | `EffectDefaultDeny` |
-| S8 | `denies even admins reading a system-visibility property` | admin-char, target.props.system-internal | `EffectDefaultDeny` (no seed permits system) |
+| S8 | `admins can read system-visibility properties via blanket admin grant` | admin-char, target.props.system-internal | `EffectAllow` (via `seed:admin-full-access`; ADR 087 removed `seed:property-system-forbid` — admins have unconditional access) |
 | S9 | `allows visible-to-listed character to read a restricted property` | char1 NOT co-located, char2.props.restricted with `visible_to=[char1.id]` | `EffectAllow` |
-| S10 | `excluded_from beats visible_to (deny-overrides)` | char1 in BOTH visible_to and excluded_from for the same prop | `EffectDefaultDeny` (`seed:property-restricted-excluded` forbid wins) |
+| S10 | `excluded_from beats visible_to (deny-overrides)` | char1 in BOTH visible_to and excluded_from for the same prop | `EffectDeny` (explicit forbid via `seed:property-restricted-excluded`; deny-overrides on a matching forbid policy returns `EffectDeny`, not `EffectDefaultDeny`) |
 | S11 | `allows owner to write their own property` | char1.props (owner=char1) | `EffectAllow` |
 | S12 | `denies non-owner writing a property` | char2.props (owner=char2), principal=char1 | `EffectDefaultDeny` |
 | S13 | `denies reading on an un-locatable property (ti1b reinforcement)` | prop.parent=object with broken-chain | `EffectDefaultDeny` |

--- a/internal/access/policy/attribute/property.go
+++ b/internal/access/policy/attribute/property.go
@@ -103,6 +103,29 @@ func (p *PropertyProvider) ResolveResource(ctx context.Context, resourceID strin
 		attrs["has_owner"] = false
 	}
 
+	// Emit visible_to and excluded_from for restricted-visibility seeds.
+	// seed:property-restricted-visible-to gates on `resource has property.visible_to`
+	// and seed:property-restricted-excluded gates on `resource has property.excluded_from`.
+	// Without these entries in the attribute bag, both seeds silently skip (the `has`
+	// check short-circuits to false) regardless of the stored lists.
+	// Only emit when non-nil/non-empty — the `resource has property.visible_to` DSL
+	// expression mirrors the ti1b pattern: omit the key entirely when the list is
+	// absent so the `has` guard evaluates to false (default-deny preserving).
+	if len(prop.VisibleTo) > 0 {
+		vt := make([]any, len(prop.VisibleTo))
+		for i, s := range prop.VisibleTo {
+			vt[i] = s
+		}
+		attrs["visible_to"] = vt
+	}
+	if len(prop.ExcludedFrom) > 0 {
+		ef := make([]any, len(prop.ExcludedFrom))
+		for i, s := range prop.ExcludedFrom {
+			ef[i] = s
+		}
+		attrs["excluded_from"] = ef
+	}
+
 	// Resolve parent_location
 	p.resolveParentLocation(ctx, prop, attrs)
 
@@ -171,6 +194,13 @@ func (p *PropertyProvider) Schema() *types.NamespaceSchema {
 			"visibility":          types.AttrTypeString,
 			"parent_location":     types.AttrTypeString,
 			"has_parent_location": types.AttrTypeBool,
+			// visible_to and excluded_from are populated for restricted-visibility
+			// properties and used by seed:property-restricted-visible-to and
+			// seed:property-restricted-excluded. Omitted from the bag (and thus
+			// from `resource has property.visible_to`) when the lists are empty,
+			// matching the ti1b omit-when-unresolvable pattern.
+			"visible_to":    types.AttrTypeStringList,
+			"excluded_from": types.AttrTypeStringList,
 		},
 	}
 }

--- a/internal/access/policy/attribute/property_test.go
+++ b/internal/access/policy/attribute/property_test.go
@@ -425,5 +425,9 @@ func TestPropertyProviderSchema(t *testing.T) {
 		"visibility":          types.AttrTypeString,
 		"parent_location":     types.AttrTypeString,
 		"has_parent_location": types.AttrTypeBool,
+		// Registered for restricted-visibility seeds (visible_to/excluded_from
+		// are populated into the bag when non-empty; omitted otherwise per ti1b).
+		"visible_to":    types.AttrTypeStringList,
+		"excluded_from": types.AttrTypeStringList,
 	}, schema.Attributes)
 }

--- a/test/integration/access/access_suite_test.go
+++ b/test/integration/access/access_suite_test.go
@@ -7,12 +7,14 @@ package access_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
@@ -23,8 +25,11 @@ import (
 	policystore "github.com/holomush/holomush/internal/access/policy/store"
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/world"
 	worldpg "github.com/holomush/holomush/internal/world/postgres"
 	"github.com/holomush/holomush/test/testutil"
+	"github.com/oklog/ulid/v2"
 )
 
 var suiteT *testing.T
@@ -36,16 +41,24 @@ func TestAccessIntegration(t *testing.T) {
 }
 
 type accessTestEnv struct {
-	ctx         context.Context
-	pool        *pgxpool.Pool
-	engine      *policy.Engine
-	pStore      policystore.PolicyStore
-	cache       *policy.Cache
-	charRepo    *worldpg.CharacterRepository
-	locRepo     *worldpg.LocationRepository
-	objRepo     *worldpg.ObjectRepository
-	auditWriter *testAuditWriter
-	auditLogger *audit.Logger
+	ctx               context.Context
+	pool              *pgxpool.Pool
+	engine            *policy.Engine
+	pStore            policystore.PolicyStore
+	cache             *policy.Cache
+	charRepo          *worldpg.CharacterRepository
+	locRepo           *worldpg.LocationRepository
+	objRepo           *worldpg.ObjectRepository
+	auditWriter       *testAuditWriter
+	auditLogger       *audit.Logger
+	propRepo          *worldpg.PropertyRepository
+	parentLocResolver *worldpg.ParentLocationResolver
+	propProvider      *attribute.PropertyProvider
+	worldService      *world.Service
+	// roleResolver is exposed so tests can assign roles to subjects
+	// (e.g. env.roleResolver.roles[access.CharacterSubject(adminID)] = []string{"admin"})
+	// for tests that exercise admin-visibility property seeds.
+	roleResolver *staticRoleResolver
 }
 
 type testAuditWriter struct {
@@ -161,6 +174,18 @@ func setupAccessTestEnv() (*accessTestEnv, error) {
 		return nil, err
 	}
 
+	// holomush-72ou: PropertyProvider needs a postgres-layer ParentLocationResolver
+	// so property visibility seeds (public-read / private-read / admin-read /
+	// owner-write / restricted-visible-to / restricted-excluded) evaluate against
+	// real attributes via the REAL ABAC engine. Mirrors the k3ud/g776 pattern.
+	propRepo := worldpg.NewPropertyRepository(pool)
+	parentLocResolver := worldpg.NewParentLocationResolver(pool)
+	propProvider := attribute.NewPropertyProvider(propRepo, parentLocResolver)
+	if err := resolver.RegisterProvider(propProvider); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
 	compiler := policy.NewCompiler(registry.Schema())
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
@@ -181,17 +206,30 @@ func setupAccessTestEnv() (*accessTestEnv, error) {
 
 	engine := policy.NewEngine(resolver, cache, &noopSessionResolver{}, auditLogger)
 
+	// Build world.Service with only PropertyRepo + Engine wired — sufficient
+	// for ListPropertiesByParent integration tests (F1-F5). No EventEmitter
+	// or Transactor needed since we only exercise the read-filter path.
+	worldService := world.NewService(world.ServiceConfig{
+		PropertyRepo: propRepo,
+		Engine:       engine,
+	})
+
 	return &accessTestEnv{
-		ctx:         ctx,
-		pool:        pool,
-		engine:      engine,
-		pStore:      pStore,
-		cache:       cache,
-		charRepo:    charRepo,
-		locRepo:     locRepo,
-		objRepo:     objRepo,
-		auditWriter: testWriter,
-		auditLogger: auditLogger,
+		ctx:               ctx,
+		pool:              pool,
+		engine:            engine,
+		pStore:            pStore,
+		cache:             cache,
+		charRepo:          charRepo,
+		locRepo:           locRepo,
+		objRepo:           objRepo,
+		auditWriter:       testWriter,
+		auditLogger:       auditLogger,
+		propRepo:          propRepo,
+		parentLocResolver: parentLocResolver,
+		propProvider:      propProvider,
+		worldService:      worldService,
+		roleResolver:      roleResolver,
 	}, nil
 }
 
@@ -213,4 +251,76 @@ func evalAccess(subject, action, resource string) types.Decision {
 	decision, err := env.engine.Evaluate(env.ctx, req)
 	Expect(err).NotTo(HaveOccurred())
 	return decision
+}
+
+// insertProperty inserts an entity_properties row via raw SQL for test setup.
+// Reads the package-global env (set in BeforeSuite). Mirrors the production
+// PropertyRepository.Create JSON encoding for visible_to / excluded_from
+// (JSONB columns, not text[]).
+//
+// DB constraint visibility_restricted_requires_lists: when visibility='restricted',
+// BOTH visible_to AND excluded_from must be non-NULL. This helper emits an empty
+// JSON array [] (not SQL NULL) for each omitted list when visibility='restricted'.
+func insertProperty(parentType string, parentID ulid.ULID, name, value, visibility string, owner *ulid.ULID, visibleTo, excludedFrom []ulid.ULID) ulid.ULID {
+	id := core.NewULID()
+	var ownerStr *string
+	if owner != nil {
+		s := owner.String()
+		ownerStr = &s
+	}
+	stringify := func(in []ulid.ULID) []string {
+		if len(in) == 0 {
+			return nil
+		}
+		out := make([]string, len(in))
+		for i, u := range in {
+			out[i] = u.String()
+		}
+		return out
+	}
+
+	vtStrs := stringify(visibleTo)
+	efStrs := stringify(excludedFrom)
+
+	// For restricted visibility the visibility_restricted_requires_lists CHECK
+	// constraint (migration 000001) requires both lists non-NULL. Use an empty
+	// JSON array [] (not SQL NULL) when the caller passed nil.
+	var visibleToJSON, excludedFromJSON []byte
+	var err error
+	if visibility == "restricted" {
+		if vtStrs == nil {
+			vtStrs = []string{}
+		}
+		if efStrs == nil {
+			efStrs = []string{}
+		}
+		visibleToJSON, err = json.Marshal(vtStrs)
+		Expect(err).NotTo(HaveOccurred())
+		excludedFromJSON, err = json.Marshal(efStrs)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		visibleToJSON, err = jsonNullableStringSlice(vtStrs)
+		Expect(err).NotTo(HaveOccurred())
+		excludedFromJSON, err = jsonNullableStringSlice(efStrs)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	now := time.Now().UTC()
+	_, err = env.pool.Exec(env.ctx, `
+		INSERT INTO entity_properties (id, parent_type, parent_id, name, value, owner, visibility, flags, visible_to, excluded_from, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		id.String(), parentType, parentID.String(), name, value, ownerStr, visibility,
+		[]byte("[]"), visibleToJSON, excludedFromJSON, now, now)
+	Expect(err).NotTo(HaveOccurred())
+	return id
+}
+
+// jsonNullableStringSlice mirrors production marshalNullableStringSlice:
+// nil/empty input → SQL NULL (returned as nil []byte), non-empty →
+// JSON-encoded array.
+func jsonNullableStringSlice(s []string) ([]byte, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(s)
 }

--- a/test/integration/access/seed_policies_test.go
+++ b/test/integration/access/seed_policies_test.go
@@ -7,13 +7,17 @@ package access_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
-	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	. "github.com/onsi/ginkgo/v2"         //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"            //nolint:revive // gomega convention
+	. "github.com/onsi/gomega/gstruct"    //nolint:revive // gstruct matchers convention
 
+	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/audit"
 	"github.com/holomush/holomush/internal/core"
 )
 
@@ -35,6 +39,11 @@ var _ = Describe("Seed Policy Behavior", func() {
 		// three containment fields on any leftover object and violate
 		// chk_exactly_one_containment. Per holomush-k3ud regression test.
 		_, err = env.pool.Exec(ctx, "DELETE FROM objects")
+		Expect(err).NotTo(HaveOccurred())
+		// entity_properties references characters, locations, and objects via
+		// parent_id (enforced at the application layer). Delete before
+		// characters/locations to avoid orphaned rows from FK cascade surprises.
+		_, err = env.pool.Exec(ctx, "DELETE FROM entity_properties")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = env.pool.Exec(ctx, "DELETE FROM characters")
 		Expect(err).NotTo(HaveOccurred())
@@ -332,6 +341,410 @@ var _ = Describe("Seed Policy Behavior", func() {
 			decision := evalAccess("character:"+unlocChar1.String(), "read", "object:"+objA.String())
 			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny),
 				"un-locatable character + cycle-broken object MUST NOT permit-match via empty-string equality")
+		})
+	})
+
+	// holomush-72ou: regression lock for the six property visibility seeds
+	// (seed:property-public-read / private-read / admin-read / owner-write /
+	// restricted-visible-to / restricted-excluded). All scenarios exercise the
+	// REAL ABAC engine + REAL PropertyProvider + REAL ParentLocationResolver
+	// registered in setupAccessTestEnv. The integrationtest harness uses
+	// allowAllPolicyEngine and cannot catch this class of regression.
+	Describe("Property visibility seeds (holomush-72ou)", func() {
+		var (
+			adminChar ulid.ULID
+			targetID  ulid.ULID // a "third character" used as parent for several property tests
+		)
+
+		BeforeEach(func() {
+			ctx := context.Background()
+			// Admin character with the "admin" role for S6/S8.
+			adminPlayerID := core.NewULID()
+			_, err := env.pool.Exec(ctx, `INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'h')`,
+				adminPlayerID.String(), "admin_"+adminPlayerID.String())
+			Expect(err).NotTo(HaveOccurred())
+			adminChar = core.NewULID()
+			_, err = env.pool.Exec(ctx, `INSERT INTO characters (id, player_id, name, location_id) VALUES ($1, $2, 'Admin', $3)`,
+				adminChar.String(), adminPlayerID.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+			// Wire the "admin" role on the static role resolver exposed via env.
+			// The subject ID format matches what CharacterProvider passes to RoleResolver.GetRoles.
+			env.roleResolver.roles[access.CharacterSubject(adminChar.String())] = []string{"admin"}
+
+			// Third character "target" at loc2 for various tests.
+			targetPlayerID := core.NewULID()
+			_, err = env.pool.Exec(ctx, `INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'h')`,
+				targetPlayerID.String(), "target_"+targetPlayerID.String())
+			Expect(err).NotTo(HaveOccurred())
+			targetID = core.NewULID()
+			_, err = env.pool.Exec(ctx, `INSERT INTO characters (id, player_id, name, location_id) VALUES ($1, $2, 'Target', $3)`,
+				targetID.String(), targetPlayerID.String(), locID2.String())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// Clean up admin role assignment so it doesn't leak between specs.
+			delete(env.roleResolver.roles, access.CharacterSubject(adminChar.String()))
+		})
+
+		It("S1: allows reading a public property on a co-located character", func() {
+			propID := insertProperty("character", charID2, "bio", "hello", "public", nil, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S2: allows reading a public property on a co-located location", func() {
+			propID := insertProperty("location", locID1, "greeting", "welcome", "public", nil, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S3: denies reading a public property on a different-location parent", func() {
+			propID := insertProperty("character", targetID, "bio", "secret", "public", nil, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
+		})
+
+		It("S4: allows owner to read their own private property (self-as-parent path)", func() {
+			propID := insertProperty("character", charID1, "diary", "secret", "private", &charID1, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S5: denies non-owner reading a private property", func() {
+			propID := insertProperty("character", charID2, "note", "hush", "private", &charID2, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
+		})
+
+		It("S6: allows admin to read an admin-visibility property", func() {
+			propID := insertProperty("character", targetID, "secret", "admin-only", "admin", nil, nil, nil)
+			decision := evalAccess("character:"+adminChar.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S7: denies non-admin reading an admin-visibility property", func() {
+			propID := insertProperty("character", targetID, "secret", "admin-only", "admin", nil, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
+		})
+
+		It("S8: allows admins to read a system-visibility property (ADR 087)", func() {
+			// seed:property-system-forbid was removed per ADR 087. Without an explicit
+			// forbid, seed:admin-full-access (blanket permit for admins) is the only
+			// matching policy, so admins DO get access to system properties.
+			// Non-admin characters still default-deny (no matching permit) — see S7.
+			// The spec test matrix comment "no seed permits system" is inaccurate;
+			// admin-full-access is unconditional and matches all resources.
+			propID := insertProperty("character", targetID, "internal", "system-only", "system", nil, nil, nil)
+			decision := evalAccess("character:"+adminChar.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow),
+				"admin-full-access permits admins to read system properties (ADR 087 removed the forbid)")
+		})
+
+		It("S9: allows visible_to-listed character to read a restricted property", func() {
+			// char1 at loc1; target at loc2 (NOT co-located). visible_to includes char1.
+			propID := insertProperty("character", targetID, "memo", "x", "restricted", nil, []ulid.ULID{charID1}, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S10: excluded_from beats visible_to (deny-overrides)", func() {
+			// char1 in BOTH lists → forbid wins via deny-overrides.
+			// seed:property-restricted-excluded fires as a FORBID → EffectDeny.
+			// seed:property-restricted-visible-to fires as a PERMIT → EffectAllow.
+			// Under deny-overrides, EffectDeny wins over EffectAllow.
+			// Raw-SQL insertProperty bypasses the production overlap validator
+			// (worldpg.validateVisibilityLists); this test exercises the engine's
+			// deny-override semantics directly, not the write-path validator.
+			env.auditWriter.Reset()
+			propID := insertProperty("character", targetID, "split", "x", "restricted",
+				nil, []ulid.ULID{charID1}, []ulid.ULID{charID1})
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDeny))
+
+			// Lock the audit-contract: an explicit forbid MUST emit one
+			// audit entry carrying EffectDeny + a non-empty PolicyID. The
+			// PolicyID is a ULID PK from the policy store, not the seed
+			// slug — name-level binding would require an extra store lookup.
+			Eventually(func() []audit.Event {
+				return env.auditWriter.Entries()
+			}).WithTimeout(2 * time.Second).WithPolling(10 * time.Millisecond).
+				ShouldNot(BeEmpty(), "deny audit entry MUST be recorded")
+			Expect(env.auditWriter.Entries()).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Effect": Equal(types.EffectDeny),
+				"ID":     Not(BeEmpty()),
+			})), "audit entry MUST carry EffectDeny + non-empty PolicyID")
+		})
+
+		It("S11: allows owner to write their own property", func() {
+			propID := insertProperty("character", charID1, "writable", "x", "private", &charID1, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "write", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectAllow))
+		})
+
+		It("S12: denies non-owner writing a property", func() {
+			propID := insertProperty("character", charID2, "owned-by-2", "x", "private", &charID2, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "write", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny))
+		})
+
+		It("S13: denies reading on an un-locatable property (ti1b reinforcement)", func() {
+			// Construct an object containment cycle so parent_location resolves to nil.
+			anchor := core.NewULID()
+			_, err := env.pool.Exec(context.Background(),
+				`INSERT INTO locations (id, name, description, type, replay_policy)
+				 VALUES ($1, 'Anchor', '', 'persistent', 'last:0')`,
+				anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+			objA := core.NewULID()
+			objB := core.NewULID()
+			_, err = env.pool.Exec(context.Background(),
+				`INSERT INTO objects (id, name, description, location_id, is_container)
+				 VALUES ($1, 'A', '', $2, true)`, objA.String(), anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+			_, err = env.pool.Exec(context.Background(),
+				`INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+				 VALUES ($1, 'B', '', $2, true)`, objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+			_, err = env.pool.Exec(context.Background(),
+				`UPDATE objects SET location_id = NULL, contained_in_object_id = $1 WHERE id = $2`,
+				objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			propID := insertProperty("object", objA, "name", "x", "public", nil, nil, nil)
+			decision := evalAccess("character:"+charID1.String(), "read", "property:"+propID.String())
+			Expect(decision.Effect()).To(Equal(types.EffectDefaultDeny),
+				"parent_location omitted (ti1b) → seed:property-public-read can't match")
+		})
+	})
+
+	// holomush-72ou: regression lock for ParentLocationResolver contract.
+	// Exercises the postgres-layer resolver directly (not via the ABAC engine)
+	// to pin location/character/object parent semantics including edge cases.
+	Describe("ParentLocationResolver (holomush-72ou)", func() {
+		It("R1: location parent returns parent_id directly", func() {
+			got, err := env.parentLocResolver.ResolveParentLocation(context.Background(), "location", locID1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(locID1))
+		})
+
+		It("R2: character parent JOINs current location_id", func() {
+			got, err := env.parentLocResolver.ResolveParentLocation(context.Background(), "character", charID1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(locID1))
+		})
+
+		It("R3: character parent with NULL location returns nil", func() {
+			ctx := context.Background()
+			unlocPlayer := core.NewULID()
+			_, err := env.pool.Exec(ctx, `INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'h')`,
+				unlocPlayer.String(), "unloc_"+unlocPlayer.String())
+			Expect(err).NotTo(HaveOccurred())
+			unlocChar := core.NewULID()
+			_, err = env.pool.Exec(ctx, `INSERT INTO characters (id, player_id, name, location_id) VALUES ($1, $2, 'Drifter', NULL)`,
+				unlocChar.String(), unlocPlayer.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "character", unlocChar)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+
+		It("R4: object parent at direct location returns that location", func() {
+			ctx := context.Background()
+			objID := core.NewULID()
+			_, err := env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, location_id, is_container)
+				 VALUES ($1, 'Tome', '', $2, false)`, objID.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "object", objID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(locID1))
+		})
+
+		It("R5: object parent held by character resolves via character location", func() {
+			ctx := context.Background()
+			objID := core.NewULID()
+			_, err := env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, held_by_character_id, is_container)
+				 VALUES ($1, 'Trinket', '', $2, false)`, objID.String(), charID1.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "object", objID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(locID1))
+		})
+
+		It("R6: object parent contained in object resolves recursively", func() {
+			ctx := context.Background()
+			chest := core.NewULID()
+			_, err := env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, location_id, is_container)
+				 VALUES ($1, 'Chest', '', $2, true)`, chest.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+			coin := core.NewULID()
+			_, err = env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+				 VALUES ($1, 'Coin', '', $2, false)`, coin.String(), chest.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "object", coin)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(*got).To(Equal(locID1))
+		})
+
+		It("R7: object parent in containment cycle returns nil", func() {
+			ctx := context.Background()
+			anchor := core.NewULID()
+			_, err := env.pool.Exec(ctx,
+				`INSERT INTO locations (id, name, description, type, replay_policy)
+				 VALUES ($1, 'Anchor2', '', 'persistent', 'last:0')`, anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+			objA := core.NewULID()
+			_, err = env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, location_id, is_container)
+				 VALUES ($1, 'A', '', $2, true)`, objA.String(), anchor.String())
+			Expect(err).NotTo(HaveOccurred())
+			objB := core.NewULID()
+			_, err = env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+				 VALUES ($1, 'B', '', $2, true)`, objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+			// Close the cycle: A now contained in B.
+			_, err = env.pool.Exec(ctx,
+				`UPDATE objects SET location_id = NULL, contained_in_object_id = $1 WHERE id = $2`,
+				objB.String(), objA.String())
+			Expect(err).NotTo(HaveOccurred())
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "object", objA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+
+		It("R8: object parent at max depth exceeded returns nil", func() {
+			ctx := context.Background()
+			prev := core.NewULID()
+			_, err := env.pool.Exec(ctx,
+				`INSERT INTO objects (id, name, description, location_id, is_container)
+				 VALUES ($1, 'obj0', '', $2, true)`, prev.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+			// Build a chain of 20 levels. The resolver's maxParentChainDepth=20
+			// means depth 20 is the last level it scans; depth 21 would be the
+			// object that must be unreachable. We insert 20 additional objects
+			// so the leaf is at depth 21 from the starting object.
+			for i := 1; i <= 20; i++ {
+				next := core.NewULID()
+				_, err := env.pool.Exec(ctx,
+					`INSERT INTO objects (id, name, description, contained_in_object_id, is_container)
+					 VALUES ($1, $2, '', $3, true)`, next.String(), fmt.Sprintf("obj%d", i), prev.String())
+				Expect(err).NotTo(HaveOccurred())
+				prev = next
+			}
+
+			got, err := env.parentLocResolver.ResolveParentLocation(ctx, "object", prev)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil(), "depth bound (20) MUST be enforced")
+		})
+
+		It("R9: unknown parent_type returns nil", func() {
+			got, err := env.parentLocResolver.ResolveParentLocation(context.Background(), "exit", ulid.Make())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+	})
+
+	// holomush-72ou: regression lock for Service.ListPropertiesByParent's
+	// per-property filter loop. Exercises the real ABAC engine end-to-end
+	// to prove the visible subset returned is correct.
+	Describe("Service.ListPropertiesByParent filter (holomush-72ou)", func() {
+		It("F1: returns only properties the principal can read", func() {
+			// 3 props on char2 (co-located with char1 at loc1):
+			//   - public → visible to char1
+			//   - private-owned-by-char2 → invisible to char1
+			//   - private-owned-by-other → invisible to char1
+			public := insertProperty("character", charID2, "bio", "x", "public", nil, nil, nil)
+			_ = insertProperty("character", charID2, "diary", "x", "private", &charID2, nil, nil)
+			otherPlayer := core.NewULID()
+			_, err := env.pool.Exec(context.Background(),
+				`INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'h')`,
+				otherPlayer.String(), "p_"+otherPlayer.String())
+			Expect(err).NotTo(HaveOccurred())
+			otherChar := core.NewULID()
+			_, err = env.pool.Exec(context.Background(),
+				`INSERT INTO characters (id, player_id, name, location_id) VALUES ($1, $2, 'Other', $3)`,
+				otherChar.String(), otherPlayer.String(), locID1.String())
+			Expect(err).NotTo(HaveOccurred())
+			_ = insertProperty("character", charID2, "thirdparty", "x", "private", &otherChar, nil, nil)
+
+			got, err := env.worldService.ListPropertiesByParent(context.Background(),
+				"character:"+charID1.String(), "character", charID2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(HaveLen(1))
+			Expect(got[0].ID).To(Equal(public))
+		})
+
+		It("F2: returns empty list when zero properties are visible (no error)", func() {
+			// char1 at loc1; targetID at loc2 (different location — charID2 is at loc1 per outer BeforeEach).
+			// All props on charID2 are private with charID2 as owner.
+			_ = insertProperty("character", charID2, "p1", "x", "private", &charID2, nil, nil)
+			_ = insertProperty("character", charID2, "p2", "x", "private", &charID2, nil, nil)
+
+			// Use a fresh player+char at loc2 so they're not co-located with char1.
+			remotePlayer := core.NewULID()
+			_, err := env.pool.Exec(context.Background(),
+				`INSERT INTO players (id, username, password_hash) VALUES ($1, $2, 'h')`,
+				remotePlayer.String(), "remote_"+remotePlayer.String())
+			Expect(err).NotTo(HaveOccurred())
+			remoteChar := core.NewULID()
+			_, err = env.pool.Exec(context.Background(),
+				`INSERT INTO characters (id, player_id, name, location_id) VALUES ($1, $2, 'Remote', $3)`,
+				remoteChar.String(), remotePlayer.String(), locID2.String())
+			Expect(err).NotTo(HaveOccurred())
+			_ = insertProperty("character", remoteChar, "hidden", "x", "private", &remoteChar, nil, nil)
+
+			got, err := env.worldService.ListPropertiesByParent(context.Background(),
+				"character:"+charID1.String(), "character", remoteChar)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeEmpty())
+		})
+
+		It("F3: returns empty list when parent has no properties", func() {
+			got, err := env.worldService.ListPropertiesByParent(context.Background(),
+				"character:"+charID1.String(), "character", charID2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeEmpty())
+		})
+
+		It("F4: infra-failure path is covered by Task 3 unit test", func() {
+			Skip("F4 covered by the Task 3 unit test TestService_ListPropertiesByParent. " +
+				"The integration variant requires mock-injection at the repo layer, " +
+				"which the access-suite real-stack pattern does not support. " +
+				"See spec INV-2b for the unit-test coverage reference.")
+		})
+
+		It("F5: restricted+excluded_from beats visible_to (deny-overrides)", func() {
+			// char1 in BOTH visible_to and excluded_from → forbid wins.
+			// Raw-SQL insertProperty bypasses worldpg.validateVisibilityLists;
+			// this test exercises the filter-loop's deny-override path, not the
+			// production write-path overlap validator.
+			_ = insertProperty("character", charID2, "split", "x", "restricted",
+				nil, []ulid.ULID{charID1}, []ulid.ULID{charID1})
+			// Also insert a public prop so there's something to return.
+			public := insertProperty("character", charID2, "bio", "x", "public", nil, nil, nil)
+
+			got, err := env.worldService.ListPropertiesByParent(context.Background(),
+				"character:"+charID1.String(), "character", charID2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(HaveLen(1))
+			Expect(got[0].ID).To(Equal(public),
+				"the restricted prop with char1 in excluded_from MUST be filtered out (forbid wins)")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Final task of the property-authz redesign epic (`holomush-72ou`, epic `holomush-rmsi`). Closes `holomush-rmsi.5`.

- **27 integration regression tests** for property authz running against the REAL ABAC stack from `setupAccessTestEnv` (NOT the integrationtest harness's `allowAllPolicyEngine` — the testing blind spot per `feedback_privacytest_bypasses_abac`):
  - S1-S13: visibility seed scenarios (public/private/admin/system/restricted incl. `visible_to`/`excluded_from`)
  - R1-R9: `ParentLocationResolver` scenarios (location chains, character-held, object-held, cycle detection at `maxParentChainDepth=20`)
  - F1-F5: `Service.ListPropertiesByParent` filter scenarios (F4 Skip with pointer to `TestService_ListPropertiesByParent` unit test from rmsi.3 + INV-2b)
- **Two latent PropertyProvider bugs fixed** (`internal/access/policy/attribute/property.go`) — `visible_to`/`excluded_from` were never emitted into the attribute bag and never declared in `Schema()`, making `seed:property-restricted-visible-to` + `seed:property-restricted-excluded` dead code post-Task-2 wiring. The bugfix is required for S9, S10, and F5 to be meaningful; without it, those seeds' `principal.id in resource.X` DSL guards would have been permanently false.
- **Audit-contract lock** in S10 — asserts that an explicit FORBID emits an audit entry carrying `EffectDeny` + non-empty PolicyID. Catches the failure mode where the engine silently drops audit emission for property-seed decisions.
- **Spec §6 stale rows corrected** — S8 (admin reading system-visibility) and S10 (excluded_from forbid) expected-effect rows updated to match the implementation per ADR-087 and deny-overrides semantics.

## Pre-push reviews

- `code-reviewer` (sonnet): READY — 3 Low NITs addressed inline (CHECK-constraint citation, S10/F5 raw-SQL bypass commentary)
- `abac-reviewer` (sonnet): READY — audit-emission NIT taken (audit-contract lock added to S10)
- spec-compliance reviewer (sonnet): READY — PropertyProvider bugfix validated as legitimate Task-2 latent defect surfaced by writing the planned tests; not unrelated drift

## Test plan

- [x] `task test:int -- ./test/integration/access/` — 49 passed + 1 skipped (F4)
- [x] `task lint` clean
- [x] `task fmt:check` clean
- [x] `task pr-prep` full lane green (lint, fmt, schema, license, unit, integration, E2E)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed property visibility restrictions to properly enforce `visible_to` and `excluded_from` controls, preventing unintended access to restricted properties.

* **Tests**
  * Extended integration test coverage for property visibility scenarios, including public, private, admin, owner, and restricted visibility modes with deny-override semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->