### PR TITLE
test(testsupport): add Session.RefreshFromPersisted helper (q2qt)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -145,7 +145,7 @@ tasks:
         ./cmd/holomush/ ./internal/access/setup/ ./internal/admin/approval/ ./internal/admin/socket/ ./internal/auth/postgres/
         ./internal/content/ ./internal/eventbus/audit/ ./internal/eventbus/audit/chain/ ./internal/admin/policy/ ./internal/eventbus/crypto/dek/
         ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/store/ ./plugins/core-scenes/ ./test/testutil/
-        ./internal/world/postgres/ ./test/integration/...
+        ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/...
 
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)

--- a/internal/testsupport/integrationtest/harness_smoke_test.go
+++ b/internal/testsupport/integrationtest/harness_smoke_test.go
@@ -66,6 +66,45 @@ var _ = Describe("Integration harness basic connect/command/logout", func() {
 	})
 })
 
+// holomush-q2qt: Session.RefreshFromPersisted re-reads the mutable Session
+// fields (LocationID, LocationArrivedAt) from the persisted sessions row.
+//
+// The smoke uses Server.SetLocationArrivedAt to mutate the DB row WITHOUT
+// touching the harness-side struct (Server.MoveTo updates both, so it's
+// tautological as a refresh trigger). After SetLocationArrivedAt the
+// struct is stale; after RefreshFromPersisted it MUST reflect the DB.
+var _ = Describe("Integration harness Session.RefreshFromPersisted", func() {
+	It("re-reads LocationArrivedAt from the persisted sessions row", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel called below; deferred via defer
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT)
+		defer ts.Stop()
+
+		sess := ts.ConnectAuthed(ctx, "Quinn")
+		originalArrivedAt := sess.LocationArrivedAt
+		originalLocation := sess.LocationID
+
+		// Mutate the DB row out-of-band. Direct SQL bypasses the harness's
+		// struct update, so without a refresh the harness-side field stays
+		// stale.
+		futureArrivedAt := originalArrivedAt.Add(42 * time.Second)
+		ts.SetLocationArrivedAt(ctx, sess.SessionID, futureArrivedAt)
+
+		Expect(sess.LocationArrivedAt).To(BeTemporally("==", originalArrivedAt),
+			"precondition: SetLocationArrivedAt MUST NOT touch the harness-side struct")
+
+		sess.RefreshFromPersisted(ctx)
+
+		Expect(sess.LocationArrivedAt).To(BeTemporally("==", futureArrivedAt),
+			"RefreshFromPersisted MUST surface the DB-side LocationArrivedAt")
+		Expect(sess.LocationID).To(Equal(originalLocation),
+			"RefreshFromPersisted MUST NOT mutate LocationID when the DB row's location is unchanged")
+
+		sess.Logout(ctx)
+	})
+})
+
 // holomush-m5nj precursor to iwzt.16: ConnectAuthed auto-attaches a live
 // Subscribe stream; DetachTransport tears it down and transitions the
 // session to Detached; ReattachTransport rebuilds the stream against the

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -214,6 +214,43 @@ func (s *Session) MoveTo(ctx context.Context, newLocationID ulid.ULID) {
 	s.LocationArrivedAt = now
 }
 
+// RefreshFromPersisted re-reads the harness's mutable Session fields
+// (LocationID, LocationArrivedAt) from the persisted sessions row.
+//
+// Connect-time hydration is asymmetric: LocationArrivedAt is sourced
+// from the persisted row by all three connect paths
+// (ConnectAuthedWithRoles, ConnectGuest, AuthedPlayer.OpenWebSession),
+// but LocationID is sourced from the persisted row only by
+// OpenWebSession — ConnectAuthed* and ConnectGuest seed it from
+// Server.guestStartLocationID, which equals persisted.LocationID
+// immediately post-connect but diverges as soon as the DB row's
+// location_id is mutated out-of-band. RefreshFromPersisted surfaces
+// the DB-side value uniformly.
+//
+// Used by tests asserting on harness-side state after any path that
+// may have mutated the session row out-of-band: Server.MoveTo (which
+// does update the struct in-place, so a refresh is a no-op) or the
+// direct-SQL helpers Server.SetLocationArrivedAt / Server.ExpireSession
+// (which do NOT update the struct).
+//
+// Scope: only LocationID and LocationArrivedAt are refreshed.
+// Identity-bound fields — SessionID, CharacterID, CharacterName,
+// OriginalLocationID, SessionCreatedAt, Reattached — are NOT mutated.
+// The transport-state fields under transportMu are out of scope; cycle
+// DetachTransport/ReattachTransport to manage those.
+//
+// On lookup failure (session deleted, store error) the call fails the
+// test via require.NoError — there is no "soft" path. Tests that
+// expect the session row to be gone should assert that condition
+// directly rather than calling RefreshFromPersisted.
+func (s *Session) RefreshFromPersisted(ctx context.Context) {
+	s.server.t.Helper()
+	persisted, err := s.server.sessionStore.Get(ctx, s.SessionID)
+	require.NoError(s.server.t, err, "integrationtest.Session.RefreshFromPersisted: sessionStore.Get(%s)", s.SessionID)
+	s.LocationID = persisted.LocationID
+	s.LocationArrivedAt = persisted.LocationArrivedAt
+}
+
 // DetachTransport simulates a client disconnect: cancels the in-flight
 // Subscribe RPC's stream context (production's Subscribe defer removes the
 // session_connections row), waits for the goroutine to exit, then calls the

--- a/test/integration/access/seed_policies_test.go
+++ b/test/integration/access/seed_policies_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	. "github.com/onsi/ginkgo/v2"         //nolint:revive // ginkgo convention
-	. "github.com/onsi/gomega"            //nolint:revive // gomega convention
-	. "github.com/onsi/gomega/gstruct"    //nolint:revive // gstruct matchers convention
+	. "github.com/onsi/ginkgo/v2"      //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"         //nolint:revive // gomega convention
+	. "github.com/onsi/gomega/gstruct" //nolint:revive // gstruct matchers convention
 
 	"github.com/holomush/holomush/internal/access"
 	"github.com/holomush/holomush/internal/access/policy/types"
@@ -469,7 +469,7 @@ var _ = Describe("Seed Policy Behavior", func() {
 			// slug — name-level binding would require an extra store lookup.
 			Eventually(func() []audit.Event {
 				return env.auditWriter.Entries()
-			}).WithTimeout(2 * time.Second).WithPolling(10 * time.Millisecond).
+			}).WithTimeout(2*time.Second).WithPolling(10*time.Millisecond).
 				ShouldNot(BeEmpty(), "deny audit entry MUST be recorded")
 			Expect(env.auditWriter.Entries()).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Effect": Equal(types.EffectDeny),


### PR DESCRIPTION
## Summary

- Adds `Session.RefreshFromPersisted(ctx)` to the integration test harness —
  a seam for tests asserting on harness-side `Session` state after the
  persisted `sessions` row was mutated out-of-band (`Server.SetLocationArrivedAt`,
  `Server.ExpireSession`, future direct-SQL helpers). Refreshes `LocationID`
  + `LocationArrivedAt`; identity-bound fields (`SessionID`/`CharacterID`/
  `CharacterName`/`OriginalLocationID`/`SessionCreatedAt`/`Reattached`) and
  `transportMu`-protected fields are deliberately out of scope.
- Adds a Ginkgo smoke spec exercising the helper via `Server.SetLocationArrivedAt`
  (the DB-only mutator) — `MoveTo` would update both sides and make the
  assertion tautological.
- Wires `./internal/testsupport/integrationtest/` into `task test:int`'s
  explicit package list. The harness's own smoke test (`TestIntegrationHarness`)
  landed in m5nj/#4178 but was never connected to CI; the new
  `Session.RefreshFromPersisted` spec is now exercised on every CI run
  alongside the existing connect/command/logout and Subscribe-transport-lifecycle
  specs.

## Background

`holomush-q2qt` was filed during PR #4181 (iwzt.16) — the I-PRIV-3
floor-preservation test today asserts `delivered.Timestamp >= preDetachFloor`,
which relies on `dispatchDelivery`'s filter behavior. With this helper, that
test can tighten to a direct re-read of `sessions.location_arrived_at`
post-reattach (a non-tautological direct invariant check).

## Test plan

- [x] `task test:int` — 1858 tests pass, includes the new
      `Session.RefreshFromPersisted` smoke spec (one direct-SQL mutation
      via `SetLocationArrivedAt`, refresh, assert harness-side surfaces
      DB value)
- [x] `task lint:go` — 0 issues
- [x] `task fmt:go` clean
- [x] `task pr-prep` — passed (after retry; observed one transient flake
      `AUDIT_CONSUMER_CREATE_FAILED` in admin/policy_chain E2E
      BeforeEach, filed as `holomush-l015`, unrelated to this PR)
- [x] Code review (pre-push, in-session): READY — two non-blocking
      findings (docstring accuracy for LocationID hydration asymmetry,
      cosmetic `.UTC()` removal) addressed before push

Closes holomush-q2qt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating session refresh functionality with persisted storage to ensure data consistency across updates.
  * Extended integration test configuration for improved test coverage.
  * Added test helper for refreshing session state from persistent storage.

* **Style**
  * Minor formatting improvements in test code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->