### PR TITLE
test(audit): bounded retry + nats_err observability for consumer create (l015)

### DIFF
--- a/internal/eventbus/audit/projection.go
+++ b/internal/eventbus/audit/projection.go
@@ -59,34 +59,105 @@ type projection struct {
 	workerCtx context.Context //nolint:containedctx // lifecycle ctx, not request ctx
 }
 
+// consumerCreateBackoffs is the retry schedule for CreateOrUpdateConsumer.
+// Sized to absorb JetStream's brief warmup window where the meta-leader
+// is elected and the events stream is queryable but the consumer-create
+// RPC can still return "no responders" or context-deadline errors under
+// load (observed flake holomush-l015 — admin/policy_chain BeforeEach
+// surfaced AUDIT_CONSUMER_CREATE_FAILED once across ~3 task test:int
+// runs while the host was at 1.5x normal wall time). Total worst-case
+// wait before giving up: ~350ms — long enough to outlast typical warmup
+// jitter, short enough that a real permanent failure (config mismatch,
+// stream missing) still fails fast within the surrounding test timeout.
+//
+// Declared `var` (not `const`) so projection_unit_test.go's
+// withShortBackoffs(t) can swap it to a microsecond schedule for the
+// retry tests. Tests in this package MUST NOT call t.Parallel() while
+// the retry tests are present — concurrent t.Cleanup restores would
+// race on the shared slice. The race detector would catch a violation,
+// but the failure mode is non-obvious; prefer the comment as a guard.
+var consumerCreateBackoffs = []time.Duration{
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+}
+
 // newProjection creates or updates the durable consumer on the EVENTS
 // stream. Durable consumers resume from the last-acked seq on restart,
 // which is what makes this crash-safe.
+//
+// The CreateOrUpdateConsumer call is wrapped in a bounded retry to absorb
+// transient JetStream warmup races (see consumerCreateBackoffs). On
+// terminal failure the wrap surfaces the underlying NATS error as a
+// structured `nats_err` field so callers (oops.Code() consumers,
+// Gomega's Succeed() matcher) see the root cause and not just the
+// AUDIT_CONSUMER_CREATE_FAILED code.
 func newProjection(ctx context.Context, js jetstream.JetStream, pool *pgxpool.Pool, cfg Config) (*projection, error) {
-	cons, err := js.CreateOrUpdateConsumer(ctx, eventbus.StreamName, jetstream.ConsumerConfig{
-		Durable:       cfg.ConsumerName,
-		Name:          cfg.ConsumerName,
-		FilterSubject: eventbus.SubjectFilter,
-		AckPolicy:     jetstream.AckExplicitPolicy,
-		AckWait:       cfg.AckWait,
-		MaxAckPending: cfg.MaxAckPending,
-		// MaxDeliver caps redelivery attempts. Without it, a permanent
-		// persist failure (AUDIT_MISSING_HEADER, AUDIT_BAD_SCHEMA_VERSION,
-		// AUDIT_BAD_MSG_ID, BYTEA-incompatible DB row) would redeliver
-		// forever and permanently consume a MaxAckPending slot — a
-		// handful of poison messages could stall the projection.
-		// Phase A TODO: wire a DLQ (e.g., stream 'EVENTS_AUDIT_DLQ') so
-		// messages that exhaust MaxDeliver are preserved for operator
-		// inspection rather than dropped on max-deliver expiry.
-		MaxDeliver: cfg.MaxDeliver,
+	cons, err := createConsumerWithRetry(ctx, func(ctx context.Context) (jetstream.Consumer, error) {
+		return js.CreateOrUpdateConsumer(ctx, eventbus.StreamName, jetstream.ConsumerConfig{
+			Durable:       cfg.ConsumerName,
+			Name:          cfg.ConsumerName,
+			FilterSubject: eventbus.SubjectFilter,
+			AckPolicy:     jetstream.AckExplicitPolicy,
+			AckWait:       cfg.AckWait,
+			MaxAckPending: cfg.MaxAckPending,
+			// MaxDeliver caps redelivery attempts. Without it, a permanent
+			// persist failure (AUDIT_MISSING_HEADER, AUDIT_BAD_SCHEMA_VERSION,
+			// AUDIT_BAD_MSG_ID, BYTEA-incompatible DB row) would redeliver
+			// forever and permanently consume a MaxAckPending slot — a
+			// handful of poison messages could stall the projection.
+			// Phase A TODO: wire a DLQ (e.g., stream 'EVENTS_AUDIT_DLQ') so
+			// messages that exhaust MaxDeliver are preserved for operator
+			// inspection rather than dropped on max-deliver expiry.
+			MaxDeliver: cfg.MaxDeliver,
+		})
 	})
 	if err != nil {
-		return nil, oops.Code("AUDIT_CONSUMER_CREATE_FAILED").
-			With("stream", eventbus.StreamName).
-			With("consumer", cfg.ConsumerName).
-			Wrap(err)
+		return nil, wrapConsumerCreateError(err, eventbus.StreamName, cfg.ConsumerName)
 	}
 	return &projection{consumer: cons, js: js, pool: pool, cfg: cfg, owners: cfg.Owners}, nil
+}
+
+// wrapConsumerCreateError applies the canonical AUDIT_CONSUMER_CREATE_FAILED
+// wrap. Surfaces the underlying NATS error as a structured `nats_err`
+// field so callers that read oops Code() / fields (Gomega's Succeed()
+// matcher, the Ginkgo failure summary, errutil.AssertErrorContext) see
+// the root cause and not just the holomush error code.
+func wrapConsumerCreateError(err error, stream, consumer string) error {
+	return oops.Code("AUDIT_CONSUMER_CREATE_FAILED").
+		With("stream", stream).
+		With("consumer", consumer).
+		With("nats_err", err.Error()).
+		Wrap(err)
+}
+
+// createConsumerWithRetry invokes create with bounded retries from
+// consumerCreateBackoffs. Returns the first success, the last error
+// after the budget is exhausted, or the last error if ctx is cancelled
+// mid-backoff. Retries on any non-nil error — the cost of retrying a
+// truly permanent error (config mismatch, missing stream) is bounded by
+// the total backoff (~350ms) and the diagnostic cost of differentiating
+// transient vs permanent error classes exceeds the savings.
+func createConsumerWithRetry(ctx context.Context, create func(context.Context) (jetstream.Consumer, error)) (jetstream.Consumer, error) {
+	var lastErr error
+	for attempt := 0; attempt <= len(consumerCreateBackoffs); attempt++ {
+		cons, err := create(ctx)
+		if err == nil {
+			return cons, nil
+		}
+		lastErr = err
+		if attempt == len(consumerCreateBackoffs) {
+			break
+		}
+		if ctx.Err() != nil {
+			return nil, lastErr
+		}
+		select {
+		case <-time.After(consumerCreateBackoffs[attempt]):
+		case <-ctx.Done():
+			return nil, lastErr
+		}
+	}
+	return nil, lastErr
 }
 
 // start attaches the Consume callback synchronously so Subsystem.Start

--- a/internal/eventbus/audit/projection_unit_test.go
+++ b/internal/eventbus/audit/projection_unit_test.go
@@ -179,3 +179,114 @@ func TestDecodeULIDStringRejectsInvalid(t *testing.T) {
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "AUDIT_BAD_ULID")
 }
+
+// withShortBackoffs swaps consumerCreateBackoffs for the duration of t
+// so retry tests don't pay the production schedule's wall time. The
+// schedule shape (number of retries) is preserved so attempt counts
+// match the production path; only the per-step sleep shrinks.
+func withShortBackoffs(t *testing.T) {
+	t.Helper()
+	orig := consumerCreateBackoffs
+	consumerCreateBackoffs = []time.Duration{1 * time.Millisecond, 2 * time.Millisecond}
+	t.Cleanup(func() { consumerCreateBackoffs = orig })
+}
+
+func TestCreateConsumerWithRetrySucceedsOnFirstAttempt(t *testing.T) {
+	withShortBackoffs(t)
+	var attempts int
+	cons, err := createConsumerWithRetry(context.Background(), func(_ context.Context) (jetstream.Consumer, error) {
+		attempts++
+		return nil, nil //nolint:nilnil // test stub
+	})
+	require.NoError(t, err)
+	require.Nil(t, cons, "test stub returns nil consumer; production returns a real one")
+	require.Equal(t, 1, attempts, "no retries when first attempt succeeds")
+}
+
+func TestCreateConsumerWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	withShortBackoffs(t)
+	transient := errors.New("nats: no responders")
+	var attempts int
+	cons, err := createConsumerWithRetry(context.Background(), func(_ context.Context) (jetstream.Consumer, error) {
+		attempts++
+		if attempts <= 2 {
+			return nil, transient
+		}
+		return nil, nil //nolint:nilnil // test stub: success after 2 transient errors
+	})
+	require.NoError(t, err)
+	require.Nil(t, cons)
+	require.Equal(t, 3, attempts, "should retry through the two-step backoff schedule")
+}
+
+func TestCreateConsumerWithRetryGivesUpAfterBudgetExhausted(t *testing.T) {
+	withShortBackoffs(t)
+	permanent := errors.New("nats: stream not found")
+	var attempts int
+	_, err := createConsumerWithRetry(context.Background(), func(_ context.Context) (jetstream.Consumer, error) {
+		attempts++
+		return nil, permanent
+	})
+	require.ErrorIs(t, err, permanent, "final error MUST be the underlying NATS error so the caller can surface it")
+	require.Equal(t, 1+len(consumerCreateBackoffs), attempts, "should attempt initial call + one per backoff entry")
+}
+
+func TestCreateConsumerWithRetryRespectsCancelledContext(t *testing.T) {
+	withShortBackoffs(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+	transient := errors.New("transient")
+	var attempts int
+	_, err := createConsumerWithRetry(ctx, func(_ context.Context) (jetstream.Consumer, error) {
+		attempts++
+		return nil, transient
+	})
+	require.ErrorIs(t, err, transient)
+	require.Equal(t, 1, attempts,
+		"ctx.Err() check between attempts MUST short-circuit further retries; only the initial attempt should run")
+}
+
+func TestCreateConsumerWithRetryHonorsCtxDeadlineDuringBackoff(t *testing.T) {
+	// Production backoffs (100ms, 250ms) outlast a 1ms ctx deadline, so
+	// the retry loop should exit via the ctx.Done() select arm rather
+	// than waiting out the full backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	transient := errors.New("transient")
+	start := time.Now()
+	_, err := createConsumerWithRetry(ctx, func(_ context.Context) (jetstream.Consumer, error) {
+		return nil, transient
+	})
+	elapsed := time.Since(start)
+	require.ErrorIs(t, err, transient)
+	require.Less(t, elapsed, 50*time.Millisecond,
+		"ctx deadline MUST short-circuit the backoff sleep; production 100ms backoff would otherwise dominate")
+}
+
+// TestNewProjectionWrapSurfacesUnderlyingNATSError pins the observability
+// contract: when CreateOrUpdateConsumer ultimately fails, the wrapped
+// error MUST surface the underlying NATS error message via a structured
+// `nats_err` field, not just the AUDIT_CONSUMER_CREATE_FAILED code.
+// Without this, Ginkgo's Succeed() matcher and oops.Code() consumers
+// see only the code and cannot diagnose the root cause (the original
+// holomush-l015 failure observation lost the underlying error here).
+func TestNewProjectionWrapSurfacesUnderlyingNATSError(t *testing.T) {
+	withShortBackoffs(t)
+	// Use the retry helper directly with a permanent error to exercise
+	// the wrap path. newProjection itself can't be reached without a
+	// real jetstream.JetStream impl; the wrap shape is the only thing
+	// under test here.
+	permanent := errors.New("nats: no stream matches subject")
+	_, retryErr := createConsumerWithRetry(context.Background(), func(_ context.Context) (jetstream.Consumer, error) {
+		return nil, permanent
+	})
+	require.Error(t, retryErr)
+
+	// Apply the same wrap newProjection applies.
+	wrapped := wrapConsumerCreateError(retryErr, "EVENTS", "host_audit_projection")
+
+	errutil.AssertErrorCode(t, wrapped, "AUDIT_CONSUMER_CREATE_FAILED")
+	require.ErrorContains(t, wrapped, "no stream matches subject",
+		"wrapped error chain MUST contain the underlying NATS message")
+	errutil.AssertErrorContext(t, wrapped, "nats_err", permanent.Error())
+}


### PR DESCRIPTION
## Summary

- Wraps `internal/eventbus/audit/projection.go`'s `CreateOrUpdateConsumer`
  call in a bounded retry (two retries, ~350ms total worst case) to absorb
  JetStream's brief warmup window where the meta-leader is elected and
  the events stream is queryable but the consumer-create RPC can still
  return "no responders" or context-deadline errors under load.
- `AUDIT_CONSUMER_CREATE_FAILED` now surfaces the underlying NATS error as
  a structured `nats_err` field so callers (Gomega's `Succeed()` matcher,
  `oops.AsOops().Code()` consumers, `errutil.AssertErrorContext`,
  Ginkgo's failure summary) see the root cause instead of just the
  holomush error code. The original l015 flake observation lost the NATS
  error here, which is what blocked diagnosis.
- Six new unit tests cover the retry helper: first-attempt success,
  recovery after transient failures, budget exhaustion, pre-cancelled-ctx
  short-circuit, ctx-deadline preemption during backoff sleep, and the
  wrap-shape observability contract.

## Background

`holomush-l015` was filed during PR #4184 (q2qt) after a single
`AUDIT_CONSUMER_CREATE_FAILED` flake hit `admin/policy_chain` BeforeEach
during one of three local `task test:int` runs (failure run took 1m28s
vs 88s for the clean runs — correlates with system load, not code).
The bead's "rerun 20 times" investigation step was explicitly rejected
per the project's no-flakes rule; the fix shape was chosen by user vote
(observability + bounded retry).

## Companion bead

[`holomush-ghg1`](https://github.com/holomush/holomush/issues) (P2)
tracks applying the same retry+observability to
`internal/eventbus/audit/plugin_consumer.go:163`
(`PluginConsumerManager.Add`), which has the same RPC against the same
`js`+stream. Plugin `Add()` typically runs after the host projection's
consumer creation has already absorbed JS warmup, so the risk is
indirect — filed as P2 follow-up rather than folded into this PR.

## Test plan

- [x] `task test -- ./internal/eventbus/audit/` — 95 tests pass under
      `-race`, including 6 new retry-helper tests
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` — passed on first attempt
- [x] Code review (pre-push, in-session): READY — two non-blocking
      findings (plugin_consumer mirror issue, `var` parallel-test
      footgun) both addressed before push (ghg1 bead + inline doc
      comment respectively)

Closes holomush-l015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit system resilience by implementing automatic retry and backoff mechanisms for event consumer initialization, reducing failures from transient issues
  * Enhanced error diagnostics with structured error context for audit-related failures to aid troubleshooting

* **Tests**
  * Added comprehensive test coverage for audit consumer retry behavior and error handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->