### PR TITLE
test(audit): apply consumer-create retry+observability to PluginConsumerManager.Add (ghg1)

### DIFF
--- a/internal/eventbus/audit/plugin_consumer.go
+++ b/internal/eventbus/audit/plugin_consumer.go
@@ -116,6 +116,27 @@ func NewPluginConsumerManager(js jetstream.JetStream, opts ...PluginConsumerMana
 	return m
 }
 
+// wrapPluginConsumerCreateError applies the canonical
+// AUDIT_PLUGIN_CONSUMER_CREATE_FAILED wrap. Mirrors
+// wrapConsumerCreateError (host-projection variant in projection.go),
+// surfacing the underlying NATS error as a structured `nats_err`
+// field so oops Code() / field readers (Gomega's Succeed() matcher,
+// Ginkgo failure summary, errutil.AssertErrorContext) see the root
+// cause and not just the holomush error code.
+//
+// Includes the implicit `stream` field for symmetry with the host
+// wrap — both surfaces target eventbus.StreamName ("EVENTS") on the
+// same JetStream, so log-search and dashboard panels can filter by a
+// single `stream` field across both audit-consumer-create call sites.
+func wrapPluginConsumerCreateError(err error, pluginName, consumer string) error {
+	return oops.Code("AUDIT_PLUGIN_CONSUMER_CREATE_FAILED").
+		With("stream", eventbus.StreamName).
+		With("plugin", pluginName).
+		With("consumer", consumer).
+		With("nats_err", err.Error()).
+		Wrap(err)
+}
+
 // Add creates (or updates) a durable consumer for the given plugin block
 // and registers its dispatcher. MUST be called before Start.
 func (m *PluginConsumerManager) Add(ctx context.Context, cfg PluginConsumerConfig) error {
@@ -160,20 +181,29 @@ func (m *PluginConsumerManager) Add(ctx context.Context, cfg PluginConsumerConfi
 	}
 
 	name := pluginDurableName(cfg.PluginName)
-	cons, err := m.js.CreateOrUpdateConsumer(ctx, eventbus.StreamName, jetstream.ConsumerConfig{
-		Durable:        name,
-		Name:           name,
-		FilterSubjects: cfg.Subjects,
-		AckPolicy:      jetstream.AckExplicitPolicy,
-		AckWait:        ackWait,
-		MaxAckPending:  maxAckPending,
-		MaxDeliver:     maxDeliver,
+	// Route through createConsumerWithRetry so plugin Add() shares the
+	// JetStream-warmup retry behavior newProjection guards against —
+	// same RPC, same js, same EVENTS stream. Prophylactic: no flake has
+	// been observed on the plugin path (l015's empirical observation
+	// was on the host projection), but the failure surface is
+	// structurally identical, so the retry preserves symmetry rather
+	// than papering over a tracked regression. Plugin Add() runs after
+	// the host projection's consumer create in production wiring, so
+	// warmup is typically already absorbed by the time we get here
+	// (holomush-ghg1 follow-up to l015).
+	cons, err := createConsumerWithRetry(ctx, func(ctx context.Context) (jetstream.Consumer, error) {
+		return m.js.CreateOrUpdateConsumer(ctx, eventbus.StreamName, jetstream.ConsumerConfig{
+			Durable:        name,
+			Name:           name,
+			FilterSubjects: cfg.Subjects,
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			AckWait:        ackWait,
+			MaxAckPending:  maxAckPending,
+			MaxDeliver:     maxDeliver,
+		})
 	})
 	if err != nil {
-		return oops.Code("AUDIT_PLUGIN_CONSUMER_CREATE_FAILED").
-			With("plugin", cfg.PluginName).
-			With("consumer", name).
-			Wrap(err)
+		return wrapPluginConsumerCreateError(err, cfg.PluginName, name)
 	}
 
 	pc := &pluginConsumer{cfg: cfg, consumer: cons}

--- a/internal/eventbus/audit/plugin_consumer_unit_test.go
+++ b/internal/eventbus/audit/plugin_consumer_unit_test.go
@@ -331,3 +331,28 @@ func TestAddRejectsNilClient(t *testing.T) {
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "AUDIT_PLUGIN_CONSUMER_INVALID_CONFIG")
 }
+
+// TestWrapPluginConsumerCreateErrorSurfacesUnderlyingNATSError pins the
+// observability contract for plugin Add(): when CreateOrUpdateConsumer
+// ultimately fails, the wrapped error MUST surface the underlying NATS
+// error message via a structured `nats_err` field. Without this, oops
+// Code() / structured-field consumers (Ginkgo's failure summary,
+// errutil.AssertErrorContext) see only AUDIT_PLUGIN_CONSUMER_CREATE_FAILED
+// and cannot diagnose root cause — the same defect that blocked l015
+// diagnosis on the host-projection side, now closed on the plugin side
+// (holomush-ghg1 follow-up).
+func TestWrapPluginConsumerCreateErrorSurfacesUnderlyingNATSError(t *testing.T) {
+	t.Parallel()
+	natsErr := errors.New("nats: no stream matches subject")
+	wrapped := wrapPluginConsumerCreateError(natsErr, "core-scenes", "plugin_audit_core-scenes")
+
+	errutil.AssertErrorCode(t, wrapped, "AUDIT_PLUGIN_CONSUMER_CREATE_FAILED")
+	require.ErrorIs(t, wrapped, natsErr,
+		"chain MUST preserve the underlying NATS error for errors.Is/As consumers")
+	require.ErrorContains(t, wrapped, "no stream matches subject",
+		"wrapped error chain MUST contain the underlying NATS message")
+	errutil.AssertErrorContext(t, wrapped, "stream", eventbus.StreamName)
+	errutil.AssertErrorContext(t, wrapped, "plugin", "core-scenes")
+	errutil.AssertErrorContext(t, wrapped, "consumer", "plugin_audit_core-scenes")
+	errutil.AssertErrorContext(t, wrapped, "nats_err", natsErr.Error())
+}

--- a/internal/eventbus/audit/projection.go
+++ b/internal/eventbus/audit/projection.go
@@ -70,6 +70,10 @@ type projection struct {
 // jitter, short enough that a real permanent failure (config mismatch,
 // stream missing) still fails fast within the surrounding test timeout.
 //
+// Shared by newProjection (host audit) and PluginConsumerManager.Add
+// (per-plugin consumers) — both invoke the same RPC against the same
+// stream and so face the same warmup race.
+//
 // Declared `var` (not `const`) so projection_unit_test.go's
 // withShortBackoffs(t) can swap it to a microsecond schedule for the
 // retry tests. Tests in this package MUST NOT call t.Parallel() while
@@ -137,6 +141,12 @@ func wrapConsumerCreateError(err error, stream, consumer string) error {
 // truly permanent error (config mismatch, missing stream) is bounded by
 // the total backoff (~350ms) and the diagnostic cost of differentiating
 // transient vs permanent error classes exceeds the savings.
+//
+// Shared by newProjection and PluginConsumerManager.Add. Both callers
+// wrap the returned error with their own oops Code (the host wraps with
+// AUDIT_CONSUMER_CREATE_FAILED via wrapConsumerCreateError; the plugin
+// path wraps with AUDIT_PLUGIN_CONSUMER_CREATE_FAILED via
+// wrapPluginConsumerCreateError in plugin_consumer.go).
 func createConsumerWithRetry(ctx context.Context, create func(context.Context) (jetstream.Consumer, error)) (jetstream.Consumer, error) {
 	var lastErr error
 	for attempt := 0; attempt <= len(consumerCreateBackoffs); attempt++ {


### PR DESCRIPTION
## Summary

Follow-up to l015 / #4185. `PluginConsumerManager.Add` now routes its
`CreateOrUpdateConsumer` call through the package-private
`createConsumerWithRetry` helper introduced in l015 — same RPC against
the same `js` against the same `EVENTS` stream as the host projection,
so the JetStream-warmup race surface is structurally identical and the
retry preserves symmetry.

- `AUDIT_PLUGIN_CONSUMER_CREATE_FAILED` now wraps via new
  `wrapPluginConsumerCreateError`, surfacing the underlying NATS error
  as a structured `nats_err` field (mirrors `wrapConsumerCreateError`).
  Field set: `stream` + `plugin` + `consumer` + `nats_err` — log-search
  and dashboard panels can filter by a single `stream` field across
  both audit-consumer-create call sites.
- One new unit test
  (`TestWrapPluginConsumerCreateErrorSurfacesUnderlyingNATSError`)
  pins the wrap-shape observability contract.
- Retry behavior on this path is implicitly covered by the 5
  retry-helper unit tests landed in l015 since both call sites now
  share the helper.

## Why prophylactic, not reactive

No flake has been observed on the plugin path. l015's empirical
observation was on the host projection. The plugin path runs after the
host projection's consumer create has typically absorbed JS warmup by
the time `Add()` runs. The retry preserves structural symmetry rather
than papering over a tracked regression.

## Test plan

- [x] `task test -- ./internal/eventbus/audit/` — 96 tests pass under
      `-race` (+1 new wrap-shape test)
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` — passed (after waiting for another agent's
      pr-prep lock to clear; full pipeline including E2E green)
- [x] Code review (pre-push, in-session): READY — two non-blocking
      findings (symmetric `stream` field on plugin wrap,
      prophylactic-vs-reactive comment phrasing) both addressed
      before push

Closes holomush-ghg1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for plugin consumer creation failures with enhanced diagnostic information and standardized error messages.

* **Tests**
  * Added unit test to verify underlying error details are preserved and properly surfaced in error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->