### PR TITLE
fix(web): gate streamReadyGate on both REPLAY_COMPLETE and backfillDone (fujt)

### DIFF
--- a/web/e2e/terminal.spec.ts
+++ b/web/e2e/terminal.spec.ts
@@ -45,6 +45,49 @@ test.describe('Terminal UI', () => {
     await expect(page.locator('[data-testid="event"]').first()).toBeVisible({ timeout: 10000 });
   });
 
+  // holomush-fujt: connect-time race where a command sent in the window
+  // between Subscribe REPLAY_COMPLETE and backfill completion would have
+  // its server-emitted event picked up by the still-running backfill and
+  // rendered as dimmed/replayed scrollback (above the LIVE marker)
+  // instead of live (below it). Fix A gates streamReadyGate on BOTH
+  // REPLAY_COMPLETE AND backfillDone, so the textarea is held until
+  // backfill is done — any post-connect command's event arrives via
+  // Subscribe only and renders live by construction.
+  //
+  // Invariant under test: a command sent immediately after connect MUST
+  // produce a live (non-dimmed) event. Pre-fix this could be dimmed
+  // when the backfill query was slow enough to overlap the command;
+  // post-fix the gate guarantees backfill is done first.
+  test('command sent immediately after connect renders live, not dimmed (holomush-fujt)', async ({
+    page,
+  }) => {
+    await connectAsGuest(page);
+    const token = Date.now();
+    const input = page.locator('textarea');
+
+    // Fire immediately. After Fix A, the textarea may briefly be
+    // disabled while backfill finishes; the fill+press still works
+    // (Playwright auto-waits for actionability), but by the time the
+    // command actually dispatches, backfill is done and the resulting
+    // event flows only through Subscribe — never via backfill.
+    await input.fill(`say live-${token}`);
+    await input.press('Enter');
+
+    const event = page
+      .locator('[data-testid="event"]')
+      .filter({ hasText: `live-${token}` });
+    await expect(event).toBeVisible({ timeout: 10000 });
+
+    // CRITICAL: the event MUST NOT be in the dimmed section. A
+    // regression of fujt (gate resolves at REPLAY_COMPLETE only)
+    // would put this event in the dimmed scrollback under load.
+    const dimmedCount = await page
+      .locator('.dimmed [data-testid="event"]')
+      .filter({ hasText: `live-${token}` })
+      .count();
+    expect(dimmedCount).toBe(0);
+  });
+
   // F5 (holomush-1tvn.12) rewrite: asserts against events_audit instead of
   // the now-empty events table. Say events are published to the host-owned
   // `events.<game>.location.<id>` subject and persist in the host audit

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -249,19 +249,45 @@
     const liveBuffer: GameEvent[] = [];
     const seenEventIds = new Set<string>();
     let backfillDone = false;
+    let replayComplete = false;
 
     // Subscribe runs in parallel with backfill. Subscribe events arriving
     // before backfill completes are buffered and drained afterward.
     // Subscribe's replay-phase events are events the user MISSED while detached,
     // so they render as replayed=false after draining (NOT dimmed).
     //
-    // streamReadyGate resolves on REPLAY_COMPLETE (not backfill). Commands
-    // sent during backfill get a response via Subscribe which is buffered
-    // and drains as live after the dimmed scrollback.
+    // streamReadyGate resolves only when BOTH Subscribe REPLAY_COMPLETE AND
+    // backfill have finished — see maybeMarkReady. This closes the
+    // holomush-fujt race where a command sent post-REPLAY_COMPLETE but
+    // pre-backfill-done would have its server-emitted event picked up by
+    // the still-running backfill query and rendered as dimmed/replayed
+    // scrollback. By gating the gate on both, the command input is held
+    // until backfill is done, so any user-emitted event arrives via
+    // Subscribe only and renders live by construction. The structurally-
+    // correct fix (cursor-bounded backfill — holomush-iu8j) will let
+    // this gate relax back to REPLAY_COMPLETE-only once backfill returns
+    // events strictly older than the Subscribe attach moment.
     //
     // Generation gating: resolveStreamReady / rejectStreamReady are already
     // generation-scoped (they no-op if streamReadyGate.generation !== generation),
     // so a stale Subscribe from a prior invocation cannot poison a fresh gate.
+
+    // maybeMarkReady resolves the gate and flips connection status to
+    // 'connected' once both flags are set. Idempotent: resolveStreamReady
+    // no-ops if the gate is already resolved (or stale-generation). The
+    // explicit generation check mirrors the symmetry of other gating
+    // sites in this function (see backfill drain block) and prevents a
+    // stale invocation from clobbering a newer generation's connection
+    // status — the flags themselves are closure-local so a stale
+    // generation cannot reach this helper today, but the guard makes
+    // the invariant local to the helper rather than relying on the
+    // caller's closure scope.
+    const maybeMarkReady = () => {
+      if (!replayComplete || !backfillDone) return;
+      if (generation !== streamGeneration || localController.signal.aborted) return;
+      resolveStreamReady(generation);
+      setConnectionStatus('connected');
+    };
     const subscribePromise = (async () => {
       try {
         // NOTE: replayFromCursor field was removed from SubscribeRequest
@@ -274,8 +300,8 @@
           if (response.frame.case === 'control') {
             const ctrl = response.frame.value;
             if (ctrl.signal === ControlSignal.REPLAY_COMPLETE) {
-              resolveStreamReady(generation);
-              setConnectionStatus('connected');
+              replayComplete = true;
+              maybeMarkReady();
             } else if (ctrl.signal === ControlSignal.STREAM_CLOSED) {
               // Stale-generation guard: if a later hydrate has started,
               // skip mutating shared state (connected, sessionId) and just
@@ -449,6 +475,7 @@
       }
 
       backfillDone = true;
+      maybeMarkReady();
       if (generation === streamGeneration && !localController.signal.aborted) {
         replayActive.set(false);
         // Drain Subscribe events that arrived during backfill, deduping.


### PR DESCRIPTION
## Summary

Closes the connect-time race where a user command sent in the window
between Subscribe `REPLAY_COMPLETE` and `backfillDone` would have its
server-emitted event picked up by the still-running
`WebQueryStreamHistory` backfill query and rendered as dimmed/replayed
scrollback above the `LIVE` marker.

**Pre-fix sequence (the bug):**
1. `REPLAY_COMPLETE` → `resolveStreamReady` → `sendCommand` unblocked
2. User emits `pose foo` → server → `events_audit`
3. Backfill is still in flight; its query picks up the just-emitted row
4. Backfill drains first with `replayed=true` → dimmed
5. Subscribe also delivers the event into `liveBuffer`; dedup at
   `seenEventIds.has()` suppresses the live copy
6. Net: user's own event appears dimmed in pre-LIVE scrollback

User-captured reproduction in the bead: Emerald Radium + Pearl Radium
guests both saw their first pose render dimmed even though it was
emitted post-connect.

## Fix shape

Fix A from the bead — the ship-now one-line gate change. A local
`maybeMarkReady` helper inside `hydrateAndStream` resolves the gate
AND flips status to `'connected'` only when both `replayComplete` and
`backfillDone` are true. Generation + abort guards mirror the symmetry
of the surrounding `hydrateAndStream` gating sites.

**Trade-off:** command input stays disabled until backfill finishes,
extending the perceived `syncing` window.

## Follow-ups

- `holomush-87qu` (P0, separate bead) — connect-to-ready latency: makes
  the now-honest `syncing` window shorter
- `holomush-iu8j` (P2, **filed in this PR**) — cursor-bounded backfill
  (the bead's Fix B), which removes the race by construction and lets
  the gate relax back to `REPLAY_COMPLETE`-only

## Test plan

- [x] `pnpm check` — 0 errors (5 pre-existing CSS warnings unrelated to
      this change)
- [x] `pnpm test:unit` — 60 unit tests pass
- [x] `task pr-prep` — passed (after waiting for another agent's
      pr-prep lock; full pipeline including E2E green)
- [x] New Playwright assertion: connect → send `say live-{token}` →
      assert event is visible AND its `.dimmed` count is 0. Note: this
      is a probabilistic regression catcher (race window is small in
      local CI without artificial latency); the deterministic regression
      test will land with `iu8j` once a backfill-stall hook exists.
- [x] Code review (pre-push, in-session): READY — 2 non-blocking
      findings (generation guard in `maybeMarkReady`, filing of Fix B
      follow-up bead) both addressed before push

Closes holomush-fujt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal stream synchronization to ensure proper state initialization before processing post-connection commands.

* **Tests**
  * Added E2E test for terminal UI to verify command handling during connection initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->