### PR TITLE
refactor(plugins): migrate Lua emit-table key from deprecated 'stream' to canonical 'subject' (holomush-fz9h)

### DIFF
--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -75,7 +75,7 @@ function on_event(event)
     if event.type == "say" then
         return {
             {
-                stream = event.stream,
+                subject = event.stream,
                 type = "say",
                 payload = '{"message":"Echo: ' .. event.payload .. '"}'
             }
@@ -143,7 +143,7 @@ func TestLuaHostDeliverEventReadsSensitiveFromReturnedTable(t *testing.T) {
 function on_event(event)
     return {
         {
-            stream = event.stream,
+            subject = event.stream,
             type = "core-test:secret",
             payload = '{"msg":"private"}',
             sensitive = true
@@ -195,7 +195,7 @@ func TestLuaHostDeliverEventDefaultsSensitiveFalseFromReturnedTable(t *testing.T
 function on_event(event)
     return {
         {
-            stream = event.stream,
+            subject = event.stream,
             type = "core-test:public",
             payload = '{"msg":"public"}'
         }
@@ -254,7 +254,7 @@ func TestLuaHostDeliverEventRejectsNonBoolSensitive(t *testing.T) {
 function on_event(event)
     return {
         {
-            stream = event.stream,
+            subject = event.stream,
             type = "core-test:misshapen",
             payload = '{}',
             sensitive = "true"
@@ -502,7 +502,7 @@ func TestLuaHost_DeliverEvent_ActorKinds(t *testing.T) {
 function on_event(event)
     return {
         {
-            stream = "test:1",
+            subject = "test:1",
             type = "echo",
             payload = event.actor_kind
         }
@@ -658,14 +658,14 @@ func TestLuaHostDeliverEventMalformedEmitEvents(t *testing.T) {
 function on_event(event)
     return {
         {
-            stream = "valid:1",
+            subject = "valid:1",
             type = "test",
             payload = "valid"
         },
         "not a table",  -- Should be skipped
         123,            -- Should be skipped
         {
-            stream = "valid:2",
+            subject = "valid:2",
             type = "test",
             payload = "also valid"
         }
@@ -730,7 +730,7 @@ func TestLuaHostDeliverEventAllFields(t *testing.T) {
 function on_event(event)
     return {
         {
-            stream = "test:1",
+            subject = "test:1",
             type = "echo",
             payload = event.id .. "|" .. event.stream .. "|" .. event.type .. "|" ..
                       tostring(event.timestamp) .. "|" .. event.actor_kind .. "|" .. event.actor_id
@@ -778,7 +778,7 @@ function on_event(event)
     local id = holomush.new_request_id()
     holomush.log("info", "Got event: " .. event.type)
     return {{
-        stream = event.stream,
+        subject = event.stream,
         type = "say",
         payload = '{"request_id":"' .. id .. '"}'
     }}
@@ -837,7 +837,7 @@ func TestLuaHostDeliverEventOnCommandCommandEvent(t *testing.T) {
 function on_command(ctx)
     return {
         {
-            stream = "location:" .. ctx.location_id,
+            subject = "location:" .. ctx.location_id,
             type = "echo",
             payload = ctx.command .. "|" .. ctx.args .. "|" .. ctx.invoked_as .. "|" ..
                       ctx.character_name .. "|" .. ctx.character_id .. "|" ..
@@ -890,7 +890,7 @@ function on_event(event)
     if event.type == "command" then
         return {
             {
-                stream = "fallback:1",
+                subject = "fallback:1",
                 type = "echo",
                 payload = "fell_back_to_on_event"
             }
@@ -936,7 +936,7 @@ func TestLuaHostDeliverEventOnCommandNonCommandEventUsesOnEvent(t *testing.T) {
 function on_command(ctx)
     return {
         {
-            stream = "on_command:1",
+            subject = "on_command:1",
             type = "echo",
             payload = "on_command_called"
         }
@@ -946,7 +946,7 @@ end
 function on_event(event)
     return {
         {
-            stream = "on_event:1",
+            subject = "on_event:1",
             type = "echo",
             payload = "on_event_called"
         }
@@ -992,7 +992,7 @@ function on_command(ctx)
     end
     return {
         {
-            stream = "test:1",
+            subject = "test:1",
             type = "echo",
             payload = "args=" .. args_value
         }
@@ -1034,7 +1034,7 @@ function on_command(ctx)
     -- Even with invalid payload, ctx should have empty strings
     return {
         {
-            stream = "test:1",
+            subject = "test:1",
             type = "echo",
             payload = "name=" .. (ctx.command or "nil")
         }
@@ -1079,7 +1079,7 @@ function on_event(event)
         "string entry",
         123,
         {
-            stream = "valid:1",
+            subject = "valid:1",
             type = "test",
             payload = "valid"
         }
@@ -1188,11 +1188,11 @@ func TestLuaHostDeliverEventMalformedEmitEventsWarnsOnMissingType(t *testing.T) 
 function on_event(event)
     return {
         {
-            stream = "test:1",
+            subject = "test:1",
             payload = "missing type"
         },
         {
-            stream = "valid:1",
+            subject = "valid:1",
             type = "test",
             payload = "valid"
         }
@@ -1249,12 +1249,12 @@ function on_event(event)
             payload = "missing stream"
         },
         {
-            stream = "valid:1",
+            subject = "valid:1",
             type = "test",
             payload = "valid"
         },
         {
-            stream = "test:2",
+            subject = "test:2",
             -- missing type
             payload = "missing type"
         }
@@ -1349,7 +1349,7 @@ function on_command(ctx)
         output = "You say: " .. ctx.args,
         events = {
             {
-                stream = "location:" .. ctx.location_id,
+                subject = "location:" .. ctx.location_id,
                 type = "say",
                 payload = ctx.args,
             },

--- a/internal/plugin/lua/plugins_emit_subject_key_test.go
+++ b/internal/plugin/lua/plugins_emit_subject_key_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deprecatedStreamKeyPattern matches a deprecated `stream =` emit-table-key
+// write at the start of a line (possibly indented; any nesting of opening
+// braces). Anchoring to start-of-line ensures `event.stream` field reads
+// (which are still part of the input-side host→Lua event-table contract,
+// out of scope for fz9h) are not falsely flagged.
+var deprecatedStreamKeyPattern = regexp.MustCompile(`^[\s{]*stream\s*=`)
+
+// In-tree Lua plugins MUST emit using the canonical `subject =` key, never
+// the deprecated `stream =` alias accepted by `parseEmitEvents` for backward
+// compatibility. The alias logs WARN on every emit (host.go:548) and is
+// scheduled for removal under holomush-zxmo once this migration ships.
+//
+// Pattern is anchored to start-of-line so it matches table-key writes
+// (`stream = "..."` or `{stream = "..."`) without matching field reads
+// (`x = event.stream`).
+func TestNoInTreeLuaPluginUsesDeprecatedStreamEmitKey(t *testing.T) {
+	root := repoRoot(t)
+	pluginsDir := filepath.Join(root, "plugins")
+
+	var offenders []string
+	err := filepath.WalkDir(pluginsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || filepath.Ext(path) != ".lua" {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path) //nolint:gosec // test-only scan of in-tree plugin sources
+		if readErr != nil {
+			return readErr
+		}
+		rel, _ := filepath.Rel(root, path)
+		for i, line := range strings.Split(string(raw), "\n") {
+			if deprecatedStreamKeyPattern.MatchString(line) {
+				offenders = append(offenders, rel+":"+strconv.Itoa(i+1)+"  "+strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err, "walk plugins/ directory")
+
+	require.Empty(t, offenders,
+		"in-tree Lua plugins must use canonical `subject = ...` key in emit tables, "+
+			"not deprecated `stream = ...` alias (holomush-fz9h). Offenders:\n  %s",
+		strings.Join(offenders, "\n  "))
+}
+
+// TestDeprecatedStreamKeyPatternCatchesKnownOffenderShapesAndIgnoresFieldReads
+// guards the regex itself against silent breakage. If a future cleanup pass
+// loosens the anchor (e.g. drops the `^` or `[\s{]*`) the matcher could miss
+// genuine offenders OR start flagging permitted `event.stream` reads, in
+// either case making the directory-walk assertion above silently useless.
+func TestDeprecatedStreamKeyPatternCatchesKnownOffenderShapesAndIgnoresFieldReads(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"single-brace emit-table write", `        {stream = "location:01ABC", type = "say"}`, true},
+		{"double-brace emit-table write (page/pemit shape)", `        {{stream = "character:01ABC", type = "page"}},`, true},
+		{"bare key (echo-bot pre-migration shape)", `            stream = event.stream,`, true},
+		{"canonical subject= key", `        {subject = "location:01ABC", type = "say"}`, false},
+		{"event.stream field read on right-hand side", `        local s = event.stream`, false},
+		{"comment mentioning stream", `    -- emit to the location stream`, false},
+		{"payload assembly referencing event.stream", `        payload = "id=" .. event.stream`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, deprecatedStreamKeyPattern.MatchString(tt.line))
+		})
+	}
+}
+
+// repoRoot walks up from the test's cwd until it finds a directory containing
+// go.mod, returning that path. Tests run from the package directory by
+// default, so we walk up a few levels.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	dir := cwd
+	for i := 0; i < 10; i++ {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate go.mod above %s", cwd)
+	return ""
+}
+

--- a/plugins/core-communication/main.lua
+++ b/plugins/core-communication/main.lua
@@ -73,7 +73,7 @@ local function handle_say(ctx)
                     ',"message":' .. json_string(msg) .. '}'
 
     return ok_events({
-        {stream = "location:" .. ctx.location_id, type = "core-communication:say", payload = payload}
+        {subject ="location:" .. ctx.location_id, type = "core-communication:say", payload = payload}
     })
 end
 
@@ -118,7 +118,7 @@ local function handle_pose(ctx)
     payload = payload .. '}'
 
     return ok_events({
-        {stream = "location:" .. ctx.location_id, type = "core-communication:pose", payload = payload}
+        {subject ="location:" .. ctx.location_id, type = "core-communication:pose", payload = payload}
     })
 end
 
@@ -153,7 +153,7 @@ local function handle_ooc(ctx)
                     ',"style":' .. json_string(style) .. '}'
 
     return ok_events({
-        {stream = "location:" .. ctx.location_id, type = "core-communication:ooc", payload = payload}
+        {subject ="location:" .. ctx.location_id, type = "core-communication:ooc", payload = payload}
     })
 end
 
@@ -175,7 +175,7 @@ local function handle_emit(ctx)
     local payload = '{"message":' .. json_string(msg) .. '}'
 
     return ok_events({
-        {stream = "location:" .. loc, type = "emit", payload = payload}
+        {subject ="location:" .. loc, type = "emit", payload = payload}
     })
 end
 
@@ -273,7 +273,7 @@ local function handle_page(ctx)
     end
 
     return ok_events(
-        {{stream = "character:" .. target_session.character_id, type = "core-communication:page", payload = payload}},
+        {{subject ="character:" .. target_session.character_id, type = "core-communication:page", payload = payload}},
         formatted_for_sender
     )
 end
@@ -394,8 +394,8 @@ local function handle_whisper(ctx)
 
     return ok_events(
         {
-            {stream = "location:" .. loc, type = "core-communication:whisper_notice", payload = notice_payload},
-            {stream = "character:" .. target.character_id, type = "core-communication:whisper", payload = whisper_payload},
+            {subject ="location:" .. loc, type = "core-communication:whisper_notice", payload = notice_payload},
+            {subject ="character:" .. target.character_id, type = "core-communication:whisper", payload = whisper_payload},
         },
         sender_msg
     )
@@ -440,7 +440,7 @@ local function handle_pemit(ctx)
                     ',"message":' .. json_string(message) .. '}'
 
     return ok_events(
-        {{stream = "character:" .. target_session.character_id, type = "core-communication:pemit", payload = payload}},
+        {{subject ="character:" .. target_session.character_id, type = "core-communication:pemit", payload = payload}},
         "Pemit sent to " .. target_session.character_name .. "."
     )
 end

--- a/plugins/echo-bot/main.lua
+++ b/plugins/echo-bot/main.lua
@@ -36,7 +36,7 @@ function on_event(event)
     -- Return echo event
     return {
         {
-            stream = event.stream,
+            subject = event.stream,
             type = "core-communication:say",
             payload = '{"message":"Echo: ' .. msg .. '"}'
         }


### PR DESCRIPTION
## Summary

Plugin emit tables now use the canonical `subject = ...` key instead of the
deprecated `stream = ...` alias accepted for backward-compat by
`parseEmitEvents` at `internal/plugin/lua/host.go:545-555`. Every Lua emit
was firing `slog.Warn`:

    level=WARN msg="plugin emit uses deprecated 'stream' key; migrate to 'subject'"

Closes holomush-fz9h. Unblocks holomush-zxmo (alias removal — `bd dep` edge already in place).

## Scope

Producer side only.

| Surface | Sites |
| --- | --- |
| `plugins/core-communication/main.lua` | 8 (say, pose, ooc, emit, page, whisper, whisper_notice, pemit) |
| `plugins/echo-bot/main.lua` | 1 (`subject = event.stream` — input-side read unchanged) |
| `internal/plugin/lua/host_test.go` | 21 test fixtures embedded as Lua source (would have blocked zxmo) |
| `internal/plugin/lua/plugins_emit_subject_key_test.go` | **NEW** — directory walk regression + regex-guard table test |

## Out of scope (intentionally deferred)

- Removing the alias from `host.go` — holomush-zxmo (now `bd dep` blocked-by fz9h)
- Input-side rename (`event.stream` field set by `host.go:511`, `hostfunc/stdlib.go:420`, `hostfunc/stdlib_focus.go:390`) — F5 per the comment at `host.go:589-591`. Renaming this field is an API contract change for out-of-tree Lua plugins.
- Subject value migration colon→dot (`location:01ABC` → `events.<game>.location.01ABC`) — holomush-rops.

## Test plan

- [x] `task lint` (EXIT=0)
- [x] `task fmt` (no churn)
- [x] `task test -- ./internal/plugin/...` (1337 tests)
- [x] `task test:int` full integration (1865 tests)
- [x] New `TestNoInTreeLuaPluginUsesDeprecatedStreamEmitKey` walks `plugins/**/*.lua` and asserts no `stream =` line (red→green confirmed)
- [x] New `TestDeprecatedStreamKeyPatternCatchesKnownOffenderShapesAndIgnoresFieldReads` guards the regex itself (3 should-match + 4 should-not subtests)
- [x] `task pr-prep` ✓ All PR checks passed

## CI notes

The full pr-prep lane flaked twice before passing clean:
- Round 1: `cmd/holomush/admin_read_stream_e2e_test.go:2113` (F-E12 chain-verification `Eventually` timeout on the `operator_read_completed` audit row). Filed as **holomush-7b9n**.
- Round 2: 8 unrelated suites failed with uniform Docker startup timeouts (`resource temporarily unavailable`, `wait until ready ... context deadline exceeded`); 53 zombie Postgres testcontainers were left over from concurrent pr-prep activity on the host. Manifestation of **holomush-tmrv** (Docker testcontainer startup timeout under load). After cleanup, round 3 passed cleanly.

Neither flake is caused by this change (lexical key rename in Lua emit tables; no Go logic touched outside the new test file). Integration suite run in isolation against the same code passed 1865/1865 in 137s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated core communication and echo bot plugins to emit events with correct field naming for improved event handling consistency.

* **Tests**
  * Added validation tests to enforce proper event structure across in-tree Lua plugins and prevent deprecated patterns from being reintroduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->