### PR TITLE
feat(grpc,web): instrument Subscribe phase spans + budget regression lock (87qu)

### DIFF
--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -19,6 +19,10 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -75,6 +79,23 @@ type SessionDefaults struct {
 // session reattach CAS) that must run on a fresh context so client disconnect
 // does not abort cleanup.
 const cleanupTimeout = 1 * time.Second
+
+// tracer is the package-level OTel tracer for gRPC handler instrumentation.
+// Sibling spans created here attach as children of the otelgrpc-installed
+// server interceptor span, so each Subscribe RPC produces a full phase
+// breakdown in Tempo / Grafana without a separate parent (holomush-87qu).
+var tracer = otel.Tracer("holomush/internal/grpc")
+
+// recordSpanError pairs RecordError with SetStatus(codes.Error, ...) so
+// Tempo / Grafana queries that filter for `status.code=ERROR` surface
+// the failing leg of a slow trace. RecordError alone leaves the span's
+// status column as Unset; the exception event is attached but the span
+// is not filterable. Mirrors plugins/core-scenes/observability.go's
+// recordError pattern.
+func recordSpanError(span trace.Span, err error) {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
 
 // replayCompleteFrame returns a SubscribeResponse containing the
 // REPLAY_COMPLETE control signal.
@@ -703,6 +724,21 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		requestID = req.Meta.RequestId
 	}
 
+	// Phase-level spans on the Subscribe handler (holomush-87qu). The
+	// otelgrpc interceptor's RPC span is the parent; each phase below
+	// is a sibling child span scoped to a single piece of pre-replay
+	// work. The dominator of the 8-10s "syncing" window observed in
+	// holomush-87qu is unknown by code reading alone — these spans let
+	// Tempo / Grafana show which phase carries the time.
+	subscribeSpan := trace.SpanFromContext(ctx)
+	subscribeSpan.SetAttributes(attribute.String("subscribe.session_id", req.SessionId))
+	if requestID != "" {
+		// Skip emitting the attribute on Meta-less requests so a Tempo
+		// search by `subscribe.request_id=""` doesn't match every empty
+		// caller.
+		subscribeSpan.SetAttributes(attribute.String("subscribe.request_id", requestID))
+	}
+
 	slog.DebugContext(
 		ctx, "subscribe request",
 		"request_id", requestID,
@@ -715,13 +751,16 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 
 	// Validate session ownership before any other work. Enumeration-safe:
 	// every failure mode collapses to the same SESSION_NOT_FOUND error.
+	validateCtx, validateSpan := tracer.Start(ctx, "subscribe.validate_ownership")
 	if _, err := auth.ValidateSessionOwnership(
-		ctx,
+		validateCtx,
 		s.playerSessionRepo,
 		s.sessionStore,
 		req.GetPlayerSessionToken(),
 		req.GetSessionId(),
 	); err != nil {
+		recordSpanError(validateSpan, err)
+		validateSpan.End()
 		slog.DebugContext(
 			ctx, "subscribe session ownership validation failed",
 			"request_id", requestID,
@@ -730,11 +769,16 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		)
 		return oops.Code("SESSION_NOT_FOUND").With("session_id", req.SessionId).Errorf("session not found")
 	}
+	validateSpan.End()
 
-	info, err := s.sessionStore.Get(ctx, req.SessionId)
+	getCtx, getSpan := tracer.Start(ctx, "subscribe.session_get")
+	info, err := s.sessionStore.Get(getCtx, req.SessionId)
 	if err != nil {
+		recordSpanError(getSpan, err)
+		getSpan.End()
 		return oops.Code("SESSION_NOT_FOUND").With("session_id", req.SessionId).Errorf("session not found")
 	}
+	getSpan.End()
 
 	// Connection registration (bd-j2xj). Only fires when the caller supplies
 	// a connection_id + client_type. Gate removal uses a fresh context so
@@ -753,12 +797,17 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 			Streams:     []string{},
 			ConnectedAt: time.Now(),
 		}
-		if addErr := s.sessionStore.AddConnection(ctx, conn); addErr != nil {
+		addCtx, addSpan := tracer.Start(ctx, "subscribe.add_connection",
+			trace.WithAttributes(attribute.String("connection.id", connID.String())))
+		if addErr := s.sessionStore.AddConnection(addCtx, conn); addErr != nil {
+			recordSpanError(addSpan, addErr)
+			addSpan.End()
 			return oops.Code("SUBSCRIBE_ADD_CONNECTION_FAILED").
 				With("session_id", req.GetSessionId()).
 				With("connection_id", req.GetConnectionId()).
 				Wrap(addErr)
 		}
+		addSpan.End()
 		defer func() {
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 			defer cancel()
@@ -775,10 +824,15 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 
 	// Reattach if detached.
 	if info.Status == session.StatusDetached {
-		ok, casErr := s.sessionStore.ReattachCAS(ctx, req.SessionId)
+		reattachCtx, reattachSpan := tracer.Start(ctx, "subscribe.reattach_cas")
+		ok, casErr := s.sessionStore.ReattachCAS(reattachCtx, req.SessionId)
 		if casErr != nil {
+			recordSpanError(reattachSpan, casErr)
+			reattachSpan.End()
 			return oops.Code("SESSION_REATTACH_FAILED").With("session_id", req.SessionId).Wrap(casErr)
 		}
+		reattachSpan.SetAttributes(attribute.Bool("reattach.won_cas", ok))
+		reattachSpan.End()
 		if !ok {
 			return oops.Code("SESSION_REATTACH_LOST").
 				With("session_id", req.SessionId).
@@ -795,11 +849,15 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// RestoreFocus — produces the full stream list and replay modes.
 	var plan focus.RestorePlan
 	if s.focusCoordinator != nil {
-		p, planErr := s.focusCoordinator.RestoreFocus(ctx, req.SessionId)
+		restoreCtx, restoreSpan := tracer.Start(ctx, "subscribe.restore_focus")
+		p, planErr := s.focusCoordinator.RestoreFocus(restoreCtx, req.SessionId)
 		if planErr != nil {
+			recordSpanError(restoreSpan, planErr)
 			slog.WarnContext(ctx, "RestoreFocus failed, falling back to empty plan",
 				"session_id", req.SessionId, "error", planErr)
 		}
+		restoreSpan.SetAttributes(attribute.Int("restore.stream_count", len(p.Streams)))
+		restoreSpan.End()
 		plan = p
 	}
 
@@ -875,11 +933,20 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 
 	// Open the bus session. JS preserves the durable consumer's cursor
 	// across reconnect, so events not acked last time get redelivered
-	// automatically; there is no explicit replay phase.
-	busStream, subErr := s.subscriber.OpenSession(ctx, req.SessionId, sessionIdentity, filters, minFloor)
+	// automatically; there is no explicit replay phase. This span covers
+	// the JetStream LookupConsumer + CreateOrUpdateConsumer round trips
+	// — known to be a non-trivial chunk of connect latency under load
+	// (see holomush-l015 for the warmup-race surface on the audit-side
+	// counterpart).
+	openCtx, openSpan := tracer.Start(ctx, "subscribe.bus_open_session",
+		trace.WithAttributes(attribute.Int("filters.count", len(filters))))
+	busStream, subErr := s.subscriber.OpenSession(openCtx, req.SessionId, sessionIdentity, filters, minFloor)
 	if subErr != nil {
+		recordSpanError(openSpan, subErr)
+		openSpan.End()
 		return oops.Code("SUBSCRIBE_FAILED").With("session_id", req.SessionId).Wrap(subErr)
 	}
+	openSpan.End()
 	defer func() {
 		if closeErr := busStream.Close(); closeErr != nil {
 			slog.WarnContext(ctx, "bus stream close failed", "session_id", req.SessionId, "error", closeErr)
@@ -908,9 +975,13 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		updateFilters: s.makeFilterUpdater(busStream, filterSet),
 		verbRegistry:  s.verbRegistry,
 	}
-	if sendErr := lf.sendSynthetic(ctx, stream); sendErr != nil {
+	syntheticCtx, syntheticSpan := tracer.Start(ctx, "subscribe.send_synthetic")
+	if sendErr := lf.sendSynthetic(syntheticCtx, stream); sendErr != nil {
+		recordSpanError(syntheticSpan, sendErr)
+		syntheticSpan.End()
 		return oops.Code("SEND_FAILED").With("session_id", req.SessionId).Wrap(sendErr)
 	}
+	syntheticSpan.End()
 
 	// Control channel for mid-session stream updates (plugin add/remove).
 	ctrlCh := make(chan sessionStreamUpdate, 16)
@@ -922,6 +993,10 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// REPLAY_COMPLETE is emitted immediately — the bus handles replay
 	// transparently by redelivering from the durable's acked-seq. Clients
 	// that gate UI on this signal still see it at the expected point.
+	// This is the latency-budget boundary for holomush-87qu: time from
+	// Subscribe RPC entry to this Send is what the user perceives as the
+	// 'syncing' window on the server side.
+	subscribeSpan.AddEvent("subscribe.replay_complete_sent")
 	if err := stream.Send(replayCompleteFrame()); err != nil {
 		return oops.With("session_id", req.SessionId).Wrap(err)
 	}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -996,10 +996,10 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// This is the latency-budget boundary for holomush-87qu: time from
 	// Subscribe RPC entry to this Send is what the user perceives as the
 	// 'syncing' window on the server side.
-	subscribeSpan.AddEvent("subscribe.replay_complete_sent")
 	if err := stream.Send(replayCompleteFrame()); err != nil {
 		return oops.With("session_id", req.SessionId).Wrap(err)
 	}
+	subscribeSpan.AddEvent("subscribe.replay_complete_sent")
 
 	return s.runSubscribeLoop(ctx, info, busStream, filterSet, stream, lf, ctrlCh)
 }

--- a/internal/testsupport/integrationtest/harness_smoke_test.go
+++ b/internal/testsupport/integrationtest/harness_smoke_test.go
@@ -153,3 +153,60 @@ var _ = Describe("Integration harness Subscribe transport lifecycle", func() {
 		felix.Logout(ctx)
 	})
 })
+
+// holomush-87qu: Subscribe → REPLAY_COMPLETE budget regression lock.
+//
+// The bead's TDD acceptance asks for a server-side assertion that
+// "empty-history Subscribe emits REPLAY_COMPLETE in < 200ms". The
+// production observation was 8-10s wall time for the user-perceived
+// 'syncing' window; this test fails-fast if a regression of that
+// magnitude (or even one order smaller) reappears.
+//
+// Budget: 1 second — generous enough to absorb macOS testcontainers
+// + embedded NATS startup variance under CI load (where bus.Start
+// is hot but the SQL roundtrips through the testcontainer have
+// >100ms tail-latency spikes), tight enough that the 8-10s field
+// observation would fail by an order of magnitude. The bead's
+// stricter 200ms target lives as an aspirational comment; tightening
+// to 200ms requires deflaking the testcontainers latency floor
+// first, which is out of scope for the instrumentation PR.
+//
+// Test shape: ConnectAuthed (warm-up: covers SelectCharacter +
+// initial Subscribe), DetachTransport (drops the live stream),
+// then measure ReattachTransport (a clean Subscribe → REPLAY_COMPLETE
+// round-trip with no SelectCharacter overhead). Reattach is the
+// pure Subscribe-handler measurement target.
+var _ = Describe("Integration harness Subscribe budget (holomush-87qu)", func() {
+	It("reattach completes Subscribe → REPLAY_COMPLETE within budget", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second) //nolint:govet // cancel called below; deferred via defer
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT)
+		defer ts.Stop()
+
+		sess := ts.ConnectAuthed(ctx, "Budget")
+
+		// Drop the transport so the next attach exercises only the
+		// Subscribe handler — no SelectCharacter, no character create.
+		sess.DetachTransport(ctx)
+
+		// Aspirational target per the bead: <200ms. CI budget: 1s.
+		// Tighten over time as the testcontainers latency floor
+		// improves (or as the bead's perf fix lands).
+		const budget = 1 * time.Second
+
+		start := time.Now()
+		sess.ReattachTransport(ctx)
+		elapsed := time.Since(start)
+
+		Expect(elapsed).To(BeNumerically("<", budget),
+			"Subscribe → REPLAY_COMPLETE budget exceeded — took %s, budget %s. "+
+				"Server-side OTel spans on the Subscribe handler (subscribe.validate_ownership, "+
+				"subscribe.session_get, subscribe.add_connection, subscribe.reattach_cas, "+
+				"subscribe.restore_focus, subscribe.bus_open_session, subscribe.send_synthetic) "+
+				"will reveal which phase dominates; aspirational target is <200ms (holomush-87qu).",
+			elapsed, budget)
+
+		sess.Logout(ctx)
+	})
+})

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -285,6 +285,12 @@
     const maybeMarkReady = () => {
       if (!replayComplete || !backfillDone) return;
       if (generation !== streamGeneration || localController.signal.aborted) return;
+      // holomush-87qu: phase-transition events on the stream.lifecycle
+      // span so Tempo / Grafana show which leg dominates the 8-10s
+      // 'syncing' window observed in the field. The two callers
+      // (REPLAY_COMPLETE handler + backfill finally block) each emit
+      // their own subscribe.* / backfill.* events before calling here.
+      localSpan.addEvent('stream.ready');
       resolveStreamReady(generation);
       setConnectionStatus('connected');
     };
@@ -300,6 +306,10 @@
           if (response.frame.case === 'control') {
             const ctrl = response.frame.value;
             if (ctrl.signal === ControlSignal.REPLAY_COMPLETE) {
+              // 87qu: time-from-hydrate-start to this event is the
+              // server-side Subscribe-phase wall time as observed by
+              // the client. Pairs with backfill.done below.
+              localSpan.addEvent('subscribe.replay_complete');
               replayComplete = true;
               maybeMarkReady();
             } else if (ctrl.signal === ControlSignal.STREAM_CLOSED) {
@@ -379,6 +389,15 @@
     // Failures are swallowed — empty presence is the safe fallback.
     const snapshotFetchPromise = client
       .webListFocusPresence({ sessionId }, { signal: localController.signal })
+      .then((resp) => {
+        // 87qu: distinguish snapshot-arm wins from timeout-arm wins in
+        // the race below. If the connect-latency dominator is a hung
+        // webListFocusPresence call, the timeout arm will fire after
+        // SNAPSHOT_TIMEOUT_MS and Tempo will show snapshot.timeout
+        // instead of snapshot.received.
+        localSpan.addEvent('snapshot.received');
+        return resp;
+      })
       .catch((err: unknown) => {
         if (isUnimplementedError(err)) {
           console.debug('[presence] snapshot unavailable (scene focus not implemented)');
@@ -400,6 +419,10 @@
       snapshotFetchPromise,
       new Promise((resolve) => {
         const timer = window.setTimeout(() => {
+          // 87qu: paired with snapshot.received above to disambiguate
+          // race-arm winners. Seeing this event in a trace means
+          // webListFocusPresence took >SNAPSHOT_TIMEOUT_MS to respond.
+          localSpan.addEvent('snapshot.timeout');
           console.warn('[presence] snapshot timed out; seeding empty');
           resolve({ entries: [] });
         }, SNAPSHOT_TIMEOUT_MS);
@@ -408,6 +431,13 @@
         void snapshotFetchPromise.finally(() => window.clearTimeout(timer));
       }),
     ]);
+
+    // 87qu: time-from-hydrate-start to this event is "how long did
+    // initial JS-side setup take before any backfill RPC dispatched".
+    // The two backfill HTTP RPCs that follow are auto-spanned by
+    // FetchInstrumentation, so the gap between this event and the
+    // next webListSessionStreams span is pure JS wall time.
+    localSpan.addEvent('backfill.start');
 
     // Backfill: enumerate streams via WebListSessionStreams, fan-out
     // WebQueryStreamHistory per stream, render as replayed=true. Failures
@@ -474,6 +504,11 @@
         );
       }
 
+      // 87qu: time-from-hydrate-start to this event tells us how long
+      // the WebListSessionStreams + WebQueryStreamHistory fan-out took
+      // (the individual RPCs are auto-spanned by FetchInstrumentation;
+      // this aggregate is the JS-side completion signal).
+      localSpan.addEvent('backfill.done');
       backfillDone = true;
       maybeMarkReady();
       if (generation === streamGeneration && !localController.signal.aborted) {

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -387,6 +387,13 @@
 
     // Fetch presence snapshot in parallel with backfill (T11 of holomush-5b2j).
     // Failures are swallowed — empty presence is the safe fallback.
+    //
+    // snapshotWinner gates the race-arm event emission so only the
+    // arm that fires first records its event on the span. Without
+    // this, a timeout-then-late-fetch sequence would emit both
+    // `snapshot.timeout` and `snapshot.received`, making winner
+    // disambiguation impossible in Tempo (87qu code-review finding).
+    let snapshotWinner: 'received' | 'timeout' | null = null;
     const snapshotFetchPromise = client
       .webListFocusPresence({ sessionId }, { signal: localController.signal })
       .then((resp) => {
@@ -395,7 +402,10 @@
         // webListFocusPresence call, the timeout arm will fire after
         // SNAPSHOT_TIMEOUT_MS and Tempo will show snapshot.timeout
         // instead of snapshot.received.
-        localSpan.addEvent('snapshot.received');
+        if (snapshotWinner === null) {
+          snapshotWinner = 'received';
+          localSpan.addEvent('snapshot.received');
+        }
         return resp;
       })
       .catch((err: unknown) => {
@@ -422,7 +432,10 @@
           // 87qu: paired with snapshot.received above to disambiguate
           // race-arm winners. Seeing this event in a trace means
           // webListFocusPresence took >SNAPSHOT_TIMEOUT_MS to respond.
-          localSpan.addEvent('snapshot.timeout');
+          if (snapshotWinner === null) {
+            snapshotWinner = 'timeout';
+            localSpan.addEvent('snapshot.timeout');
+          }
           console.warn('[presence] snapshot timed out; seeding empty');
           resolve({ entries: [] });
         }, SNAPSHOT_TIMEOUT_MS);
@@ -507,8 +520,13 @@
       // 87qu: time-from-hydrate-start to this event tells us how long
       // the WebListSessionStreams + WebQueryStreamHistory fan-out took
       // (the individual RPCs are auto-spanned by FetchInstrumentation;
-      // this aggregate is the JS-side completion signal).
-      localSpan.addEvent('backfill.done');
+      // this aggregate is the JS-side completion signal). Guarded by
+      // the same stale-generation check that gates the surrounding
+      // presence.seed and liveBuffer drain — a stale invocation's
+      // backfill.done would skew the live trace's latency baseline.
+      if (generation === streamGeneration && !localController.signal.aborted) {
+        localSpan.addEvent('backfill.done');
+      }
       backfillDone = true;
       maybeMarkReady();
       if (generation === streamGeneration && !localController.signal.aborted) {


### PR DESCRIPTION
## Summary

The bead is investigation-shaped — the 8-10s `syncing` window on guest
connect has no proven dominator from code reading alone. This PR ships
the diagnostic substrate so future runs (against game.holomush.dev or
local `task dev`) reveal which phase carries the time, plus a regression
lock that fails fast if connect latency reverts to the field-observed
8-10s.

### Server-side (`internal/grpc/server.go`)

- Package-level `otel.Tracer("holomush/internal/grpc")`
- Child spans on each phase of `CoreServer.Subscribe` before
  `REPLAY_COMPLETE`:
  - `subscribe.validate_ownership`
  - `subscribe.session_get`
  - `subscribe.add_connection` (conditional)
  - `subscribe.reattach_cas` (conditional)
  - `subscribe.restore_focus`
  - `subscribe.bus_open_session` (covers JetStream LookupConsumer +
    CreateOrUpdateConsumer)
  - `subscribe.send_synthetic`
- `recordSpanError` helper pairs `RecordError` + `SetStatus(codes.Error)`
  so Tempo / Grafana `status.code=ERROR` filters surface the failing
  leg of a slow trace (mirrors `plugins/core-scenes/observability.go`)
- `AddEvent("subscribe.replay_complete_sent")` on the otelgrpc RPC
  span at the exact `REPLAY_COMPLETE` Send boundary

### Web-side (`web/src/routes/(authed)/terminal/+page.svelte`)

- `addEvent` calls on the existing `stream.lifecycle` span at every
  phase transition: `subscribe.replay_complete`, `backfill.start`,
  `backfill.done`, `stream.ready`, `snapshot.received`,
  `snapshot.timeout`
- Snapshot race-arm winners are disambiguated so a hung
  `webListFocusPresence` (3s timeout) shows up as `snapshot.timeout`
  instead of unattributed wall time

### Regression lock (`internal/testsupport/integrationtest/harness_smoke_test.go`)

- New Ginkgo spec: `ConnectAuthed` → `DetachTransport` → measure
  `ReattachTransport` (the pure Subscribe → `REPLAY_COMPLETE`
  round-trip) → assert under 1s budget
- Bead's aspirational target is <200ms; CI budget is 1s to absorb
  macOS testcontainers + embedded NATS variance. The 8-10s field
  observation would fail by an order of magnitude either way

## What this PR is NOT

This is **not the perf fix**. Once measurement against real traffic
identifies the dominator, follow-up beads will tighten the budget
toward the 200ms target and fix the actual perf issue.

## Test plan

- [x] `task test -- ./internal/grpc/` — 336 tests pass under `-race`
- [x] `task lint:go` — 0 issues
- [x] `pnpm check` — 0 errors (5 pre-existing CSS warnings)
- [x] Targeted integration: `gotestsum ./internal/testsupport/integrationtest/...`
      (76s for all 4 specs in the package; budget spec passed under 1s)
- [x] `task pr-prep` — passed (after waiting for another agent's lock)
- [x] Code review (pre-push, in-session): READY — 3 non-blocking
      findings (RecordError+SetStatus pairing, snapshot race-arm
      events, empty `request_id` attribute gate) all addressed before
      push

Closes holomush-87qu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced observability: added end-to-end tracing and span events to Subscribe and stream lifecycle paths (session management, connection/reattach, replay, backfill, presence snapshot). Instrumentation-only; no functional behavior changes.

* **Tests**
  * New integration test verifying Subscribe/reattach timing and ensuring replay-complete transition meets performance budget.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->