### PR TITLE
build(taskfile): add web:dev:obs to wire web-side OTel tracing in dev

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -52,9 +52,20 @@ tasks:
       - docker compose down -v
 
   dev:obs:
-    desc: Start dev environment with observability stack (Grafana, Tempo, Prometheus, Dozzle)
+    desc: Start dev environment with observability stack (Grafana, Jaeger, Prometheus, Dozzle)
     cmds:
       - task: docker:build
+      # Surface the UIs up front so traces from the server-side spans
+      # (e.g. holomush-87qu's Subscribe phase breakdown) are discoverable.
+      # Web-side traces require `task web:dev:obs` in a separate shell —
+      # the SvelteKit tracer is conditional on PUBLIC_OTEL_ENDPOINT.
+      - |
+        echo "▸ Observability UIs (start after services are up):"
+        echo "    Jaeger    http://localhost:16686"
+        echo "    Grafana   http://localhost:3001"
+        echo "    Dozzle    http://localhost:8888"
+        echo "    Prom      http://localhost:9090  (internal to backend; expose via grafana)"
+        echo "▸ Web-side traces: run 'task web:dev:obs' in another shell"
       - COMPOSE_PROFILES=observability docker compose up --force-recreate --remove-orphans
 
   test:
@@ -412,6 +423,20 @@ tasks:
     deps: ['web:install', 'web:generate']
     cmds:
       - pnpm dev
+
+  web:dev:obs:
+    desc: Run SvelteKit dev server with OTel tracing enabled (pairs with `task dev:obs`)
+    dir: web
+    deps: ['web:install', 'web:generate']
+    cmds:
+      # PUBLIC_OTEL_ENDPOINT is the conditional-init switch for the web
+      # tracer (web/src/lib/telemetry.ts:33) — without it set, the SDK
+      # returns early and no spans are emitted. The browser POSTs to the
+      # OTel collector's HTTP receiver (compose.yaml exposes 4318 on
+      # localhost; collector config allows CORS from http://localhost:*).
+      # Use the HTTP endpoint, NOT 4317 (that's gRPC, browser can't use it).
+      # Pair with `task dev:obs` to start the otel-collector + Jaeger.
+      - PUBLIC_OTEL_ENDPOINT=http://localhost:4318 pnpm dev
 
   # ──────────────────────────────────────────
   # Linters (called by `task lint`)


### PR DESCRIPTION
## Summary

The holomush-87qu spans landed in #4190 added phase events to the
`stream.lifecycle` span (`subscribe.replay_complete`,
`backfill.start/done`, `snapshot.received/timeout`, `stream.ready`)
but those never fire in dev because `web/src/lib/telemetry.ts:33`
short-circuits when `PUBLIC_OTEL_ENDPOINT` is unset — and
`task web:dev` didn't set it.

This closes the half-wired state:

- `task dev:obs` starts the otel-collector + Jaeger + Grafana +
  Dozzle (server-side spans flow to Jaeger at `:16686`)
- `task web:dev:obs` exports `PUBLIC_OTEL_ENDPOINT=http://localhost:4318`
  so the web tracer initializes and emits to the collector's HTTP
  endpoint (4318, not gRPC 4317 which browsers can't use). CORS in
  the collector config already allows `http://localhost:*` so
  cross-origin POST from svelte dev (5173) works.

Also: `dev:obs` description corrected from "Tempo" to "Jaeger" to
match `compose.yaml` (which uses `jaegertracing/all-in-one`), and
now echoes UI URLs + the pairing hint before `docker compose up` so
the workflow is discoverable from `task --list`.

## Why a separate `web:dev:obs`

If `PUBLIC_OTEL_ENDPOINT` were unconditional on `web:dev`, the
browser would spam fetch errors to a missing collector whenever
the observability profile isn't active. Opt-in via a paired task
keeps the zero-dependency default intact.

## Test plan

- [x] `task --list` shows both `dev:obs` (updated desc) and the new
      `web:dev:obs`
- [x] `task pr-prep` — passed (full pipeline including E2E)
- [x] Code review (pre-push, in-session): READY — 3 non-blocking
      findings all acceptable trade-offs (echo timing, CORS LAN-binding
      edge case, separate-task rationale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability development environment to use Jaeger instead of Tempo, with clearer startup messaging for monitoring endpoints.
  * Added new development server task with OpenTelemetry browser tracing enabled, allowing developers to capture client-side traces alongside backend observability data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->