### PR TITLE
ci: drop arduino/setup-task@v2 — direct install.sh (holomush-06vz)

### DIFF
--- a/.github/workflows/benchmark-check.yml
+++ b/.github/workflows/benchmark-check.yml
@@ -43,10 +43,12 @@ jobs:
           cache: go
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; sha256-verified
+        # tarball download, no GITHUB_TOKEN required. Replaces
+        # arduino/setup-task@v2 (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Run benchmark regression check
         run: bash scripts/check-benchmark-regression.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,14 @@ jobs:
           cache: go
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; the script downloads
+        # the official release tarball + its sha256 checksum from GitHub and
+        # verifies before installing. No GITHUB_TOKEN required — replaces
+        # arduino/setup-task@v2 which hit recurring 401 "Bad credentials"
+        # against the Namespace runner token proxy (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Install golangci-lint v2
         run: |
@@ -142,10 +146,14 @@ jobs:
           cache: go
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; the script downloads
+        # the official release tarball + its sha256 checksum from GitHub and
+        # verifies before installing. No GITHUB_TOKEN required — replaces
+        # arduino/setup-task@v2 which hit recurring 401 "Bad credentials"
+        # against the Namespace runner token proxy (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0
@@ -186,10 +194,14 @@ jobs:
           cache: go
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; the script downloads
+        # the official release tarball + its sha256 checksum from GitHub and
+        # verifies before installing. No GITHUB_TOKEN required — replaces
+        # arduino/setup-task@v2 which hit recurring 401 "Bad credentials"
+        # against the Namespace runner token proxy (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0
@@ -242,10 +254,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; the script downloads
+        # the official release tarball + its sha256 checksum from GitHub and
+        # verifies before installing. No GITHUB_TOKEN required — replaces
+        # arduino/setup-task@v2 which hit recurring 401 "Bad credentials"
+        # against the Namespace runner token proxy (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Run E2E tests with coverage
         run: task test:e2e:cover
@@ -294,10 +310,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; the script downloads
+        # the official release tarball + its sha256 checksum from GitHub and
+        # verifies before installing. No GITHUB_TOKEN required — replaces
+        # arduino/setup-task@v2 which hit recurring 401 "Bad credentials"
+        # against the Namespace runner token proxy (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Build
         run: task build

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -43,10 +43,12 @@ jobs:
           cache: go
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; sha256-verified
+        # tarball download, no GITHUB_TOKEN required. Replaces
+        # arduino/setup-task@v2 (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,10 +92,12 @@ jobs:
         run: corepack enable && corepack prepare pnpm@11.0.3 --activate
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; sha256-verified
+        # tarball download, no GITHUB_TOKEN required. Replaces
+        # arduino/setup-task@v2 (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Build web bundle into internal/web/dist/
         run: task web:embed

--- a/.github/workflows/scripts-tests.yaml
+++ b/.github/workflows/scripts-tests.yaml
@@ -63,10 +63,12 @@ jobs:
           yq --version
 
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Direct install via taskfile.dev's install.sh; sha256-verified
+        # tarball download, no GITHUB_TOKEN required. Replaces
+        # arduino/setup-task@v2 (holomush-06vz).
+        run: |
+          curl -fsSL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+          task --version
 
       - name: Run bats
         # Plumb the bats-action install path into BATS_LIB_PATH so


### PR DESCRIPTION
## Summary

`arduino/setup-task@v2` has been failing with `##[error]Bad credentials` (HTTP 401 from `api.github.com`) at a rate of ~1/hr across Lint, Test, and E2E jobs on both PRs and `main`. The action authenticates a release-fetch API call with the workflow's `GITHUB_TOKEN`, and that token has been getting rejected through Namespace's runner token proxy. Most-recent hit: run [26335233292](https://github.com/holomush/holomush/actions/runs/26335233292) (main, 14:28 UTC today).

The action also pins Node.js 20, which GitHub Actions force-upgrades to Node 24 on **2026-06-02** — a hard expiry 10 days out. So even setting the credentials issue aside, the action needs to go.

This swap replaces all 9 invocations across 5 workflow files with a direct `curl | sudo sh` install via `taskfile.dev/install.sh`. That script downloads the official release tarball + its sha256 checksum from GitHub releases and verifies before installing — no GitHub API authentication required. Same trust model as the existing `golangci-lint`/`yq` installs in this repo.

Closes `holomush-06vz`.

## Files touched

- `.github/workflows/ci.yaml` (5 invocations)
- `.github/workflows/nightly-soak.yml`
- `.github/workflows/release.yaml`
- `.github/workflows/benchmark-check.yml`
- `.github/workflows/scripts-tests.yaml`

## Test plan

- [x] `task lint:actions` clean
- [x] `yq eval` parses all 5 modified workflows
- [ ] CI green on this PR (the test is "the Lint/Test/E2E jobs themselves no longer fail at the Install Task step")
- [ ] No regression in nightly-soak (verified once the next nightly fires) or release.yaml (verified next tagged release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)