### PR TITLE
fix(lint): exclude CHANGELOG.md from rumdl fmt + fmt:check too (holomush-hryj.11)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -564,7 +564,7 @@ tasks:
   fmt:markdown:
     desc: Format Markdown files
     cmds:
-      - rumdl fmt --exclude 'site,.git,.beads,.serena,.claude' .
+      - rumdl fmt --exclude 'site,.git,.beads,.serena,.claude,CHANGELOG.md' .
       - rumdl fmt --config site/.rumdl.toml site/
 
   fmt:yaml:
@@ -581,7 +581,7 @@ tasks:
     desc: Check formatting without modifying
     cmds:
       - dprint check
-      - rumdl fmt --check --exclude 'site,.git,.beads,.serena,.claude' .
+      - rumdl fmt --check --exclude 'site,.git,.beads,.serena,.claude,CHANGELOG.md' .
       - rumdl fmt --check --config site/.rumdl.toml site/
 
   # ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #4202. That PR excluded the release-please \`CHANGELOG.md\` from \`rumdl check\` (the \`lint:markdown\` target) — but \`rumdl\` is invoked in **three** Taskfile targets, each carrying its own \`--exclude\` flag:

| Target | Command | Patched in |
|---|---|---|
| \`lint:markdown\` | \`rumdl check --exclude ...\` | #4202 ✅ |
| \`fmt:markdown\` | \`rumdl fmt --exclude ...\` | **this PR** |
| \`fmt:check\` | \`rumdl fmt --check --exclude ...\` | **this PR** |

So the release PR's \`Lint\` check kept failing — this time at the \`fmt:check\` step (#4201, CI run 26341028794, exit 201), because \`rumdl fmt --check\` still saw the CHANGELOG. This PR adds \`CHANGELOG.md\` to the two remaining \`--exclude\` flags.

## Why not just rely on .rumdl.toml's exclude?

Each task passes an explicit \`--exclude\` CLI flag that **overrides** the \`.rumdl.toml\` exclude list, so the file-level exclude alone doesn't take effect for these invocations. Patching the flags matches the existing pattern (consistent with how \`site\` is already excluded per-flag).

## dprint?

dprint only formats \`**/*.json\` + \`**/*.toml\` (no markdown plugin — see \`dprint.json\`), so it never touches \`CHANGELOG.md\`. rumdl is the only checker that needed the exclude.

## Verification

\`task fmt:check\` passes with a deliberately-violating \`CHANGELOG.md\` present (MD012/MD050). Confirmed the \`rumdl fmt --check\` invocation skips it with the new flag.

## Context

Completes \`holomush-hryj.11\` (the CHANGELOG-lint blocker for release PRs). After this merges, re-run #4201's Lint → green → v0.1.0 ships. The remaining release-PR-CI item is \`holomush-hryj.10\` (App token so release PRs trigger CI without a manual close+reopen) — separate, deferred.

## Test plan

- [x] \`task fmt:check\` passes with a violating CHANGELOG.md present
- [x] \`task lint:yaml\` clean on the edited Taskfile
- [ ] On merge: re-trigger #4201 Lint → green

Refs: holomush-hryj, holomush-hryj.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)