### PR TITLE
fix(release): buf in goreleaser + plain vX.Y.Z tags + drop release-as (holomush-hryj.12/.13/.8)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,14 @@ jobs:
       - name: Install Task
         uses: ./.github/actions/install-task
 
+      # web:embed → web:build → web:generate runs `buf generate` to produce
+      # the ConnectRPC TS clients before the SvelteKit build. buf is not a
+      # `go tool` binary, so it needs its own install here (mirrors ci.yaml).
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build web bundle into internal/web/dist/
         run: task web:embed
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-as": "0.1.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

The first-ever release run (v0.1.0 PR #4201) exposed two latent release-pipeline blockers. This PR fixes both plus a required config cleanup, so the re-release (v0.1.1) publishes cleanly.

### 1. (\`holomush-hryj.12\`, **P0**) goreleaser job missing \`buf\`

The goreleaser job runs \`task web:embed\` → \`web:build\` → \`web:generate\` → \`buf generate\`, but never installed \`buf\` → exit 127 (\`"buf": executable file not found\`). First release ever, so this never ran before. **Blocks all releases.** Fix: add \`bufbuild/buf-setup-action@v1\` before the web-bundle build, mirroring \`ci.yaml\` (which installs buf the same way at lines 219/268).

### 2. (\`holomush-hryj.13\`) component-prefixed tag

Manifest mode + \`package-name: holomush\` produced the tag \`holomush-v0.1.0\` instead of \`v0.1.0\`. That doesn't match \`release.yaml\`'s \`on.push.tags: ['v*']\` and is non-standard for goreleaser version detection. Fix: \`"include-component-in-tag": false\` → plain \`vX.Y.Z\` tags. (Key verified via context7.)

### 3. (\`holomush-hryj.8\`) remove the one-shot \`release-as\`

\`release-as: 0.1.0\` was a one-time override to supersede PR #7. With \`0.1.0\` now recorded in \`.release-please-manifest.json\`, leaving it in would re-pin 0.1.0 (already released) and block the next version proposal. Removing it (this is what task \`.8\` always called for) lets release-please propose the next version from conventional-commit signal.

## What happens on merge

These are \`fix:\` commits, so release-please proposes **v0.1.1** (with \`bump-patch-for-minor-pre-major\`, a plain \`v0.1.1\` tag). Merging that release PR runs goreleaser **with buf present + a valid tag** → publishes \`ghcr.io/holomush/holomush:0.1.1\` + \`:latest\`. The sandbox bootstrap auto-resolves the latest release, so v0.1.1 is fine.

The phantom \`holomush-v0.1.0\` release+tag (goreleaser had failed; no artifacts) was already deleted.

## Test plan

- [x] \`task lint:actions\` (actionlint) + \`task lint:yaml\` pass
- [x] \`release-please-config.json\` parses; \`dprint check\` clean
- [x] \`include-component-in-tag\` confirmed as a valid top-level key (context7)
- [ ] On merge: release-please proposes \`v0.1.1\` with a plain tag
- [ ] On v0.1.1 merge: goreleaser gets past \`web:embed\` and publishes the GHCR image

## Remaining release-PR-CI item

\`holomush-hryj.10\` (GitHub App token so release PRs trigger CI without manual close+reopen) stays deferred — close+reopen remains the stopgap for the v0.1.1 PR.

Refs: holomush-hryj, holomush-hryj.12, holomush-hryj.13, holomush-hryj.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)