### PR TITLE
fix(release): migrate cosign signing to v3 bundle format (holomush-hryj.15)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,21 +125,16 @@ jobs:
           set -euo pipefail
           echo "Verifying signing artifacts..."
 
-          # Check that checksums signature and certificate exist
-          if [[ ! -f dist/checksums.txt.sig ]]; then
-            echo "ERROR: checksums.txt.sig not found - signing may have failed"
-            ls -la dist/
-            exit 1
-          fi
-
-          if [[ ! -f dist/checksums.txt.sig.cert ]]; then
-            echo "ERROR: checksums.txt.sig.cert not found - signing may have failed"
+          # cosign v3 emits a single sigstore bundle (.sigstore.json) instead of
+          # the separate .sig + .sig.cert files. See https://goreleaser.com/blog/cosign-v3.
+          if [[ ! -f dist/checksums.txt.sigstore.json ]]; then
+            echo "ERROR: checksums.txt.sigstore.json not found - signing may have failed"
             ls -la dist/
             exit 1
           fi
 
           echo "✓ Signing artifacts verified:"
-          ls -la dist/checksums.txt.sig*
+          ls -la dist/checksums.txt.sigstore.json
 
       # Upload artifacts for provenance attestation
       - name: Upload release artifacts
@@ -263,20 +258,21 @@ jobs:
             sleep 10
           done
 
-          # Download checksums and signature
+          # Download checksums and the cosign v3 sigstore bundle.
           mkdir -p dist
           if ! gh release download "${VERSION}" -R holomush/holomush -D dist \
-            -p 'checksums.txt' -p 'checksums.txt.sig' -p 'checksums.txt.sig.cert'; then
+            -p 'checksums.txt' -p 'checksums.txt.sigstore.json'; then
             echo "ERROR: Failed to download release artifacts"
             echo "This may indicate the release was not published or signing failed"
             gh release view "${VERSION}" -R holomush/holomush --json assets || true
             exit 1
           fi
 
-          # Verify signature
+          # Verify signature against the bundle (cosign v3). The bundle carries
+          # both the signature and the signing certificate, so no separate
+          # --certificate / --signature flags are needed.
           cosign verify-blob \
-            --certificate dist/checksums.txt.sig.cert \
-            --signature dist/checksums.txt.sig \
+            --bundle dist/checksums.txt.sigstore.json \
             --certificate-identity-regexp "https://github.com/holomush/holomush/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,10 +81,14 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
+    # cosign v3 consolidates the separate signature + certificate files into a
+    # single sigstore bundle (.sigstore.json) via --bundle. See
+    # https://goreleaser.com/blog/cosign-v3. The verify-release job consumes
+    # this bundle with `cosign verify-blob --bundle`.
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${signature}.cert"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
 


### PR DESCRIPTION
## Summary

The v0.1.1 release (run 26342092196) got past the buf fix (#4205) but goreleaser then failed at **cosign signing**:

\`\`\`
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
⨯ release failed: could not sign artifact cmd=cosign artifact=checksums.txt
\`\`\`

**Root cause:** \`sigstore/cosign-installer@v4.1.2\` installs **cosign v3.0.6**, but \`.goreleaser.yaml\`'s signs block used cosign-2.x flags (\`--output-signature\` / \`--output-certificate\`). cosign v3 consolidates those two files into a single \`.sigstore.json\` **bundle** via \`--bundle\`; with no bundle path it tried to write to an empty path.

This goes **forward** to cosign v3's bundle format (goreleaser's documented migration: https://goreleaser.com/blog/cosign-v3), not backward by pinning cosign v2.

## Changes (3 coordinated edits — the pipeline both produces and verifies the signature)

1. **\`.goreleaser.yaml\` signs** — \`--output-signature\`/\`--output-certificate\` → \`--bundle=\${signature}\`, with \`signature: \${artifact}.sigstore.json\`. Emits a single \`checksums.txt.sigstore.json\`.
2. **\`release.yaml\` "Verify signing artifacts exist"** — checks for \`checksums.txt.sigstore.json\` instead of \`.sig\` + \`.sig.cert\`.
3. **\`release.yaml\` verify-release "Verify checksums signature"** — downloads the \`.sigstore.json\` bundle and runs \`cosign verify-blob --bundle ...\` (the bundle carries both the signature and the certificate, so no separate flags).

Image signing (\`docker_signs\` → \`cosign sign <image>\`) and image verify are **registry-attached, not blob-based**, so they're unchanged by the v3 blob change — left as-is and watched in the run.

## What happens on merge

\`fix:\` commit → release-please proposes **v0.1.2** → close+reopen → merge → goreleaser signs with cosign v3 bundles → publishes \`ghcr.io/holomush/holomush:0.1.2\` + \`:latest\`, and verify-release validates the bundle.

## Test plan

- [x] \`task release:check\` (goreleaser config) validates
- [x] \`task lint:actions\` + \`task lint:yaml\` pass
- [ ] On v0.1.2 release run: goreleaser signs + publishes the image; verify-release \`verify-blob --bundle\` passes; image signature verify passes

## Notes

- Pre-existing (not addressed): goreleaser warns \`dockers\`/\`docker_manifests\` are being phased out for \`dockers_v2\`.
- This is the 3rd never-exercised release-pipeline gap (after CHANGELOG-lint \`.11\`, buf-missing \`.12\`). Broader tooling revisit tracked in \`holomush-dfsvk\`.

Refs: holomush-hryj, holomush-hryj.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)