### PR TITLE
fix(release): build plugins + add to docker build context (holomush-hryj.16)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,12 @@ project_name: holomush
 before:
   hooks:
     - go mod tidy
+    # Compile the binary plugins (host + linux amd64/arm64) into build/plugins/.
+    # The Dockerfile COPYs build/plugins/ (see dockers.extra_files below); the
+    # plugin loader resolves the right per-arch binary at runtime. Running it as
+    # a goreleaser before-hook means `task release:snapshot` and the real
+    # release both produce the plugins identically.
+    - task plugin:build-all
 
 builds:
   - id: holomush
@@ -125,6 +131,13 @@ dockers:
     dockerfile: Dockerfile
     goos: linux
     goarch: amd64
+    # The Dockerfile COPYs plugins/ (Lua + manifests) and build/plugins/
+    # (compiled binary plugins, all arches). goreleaser's docker build context
+    # is a temp dir containing only the binary + Dockerfile, so these must be
+    # listed as extra_files to land in the context.
+    extra_files:
+      - plugins
+      - build/plugins
 
   - image_templates:
       - "ghcr.io/holomush/holomush:{{ .Version }}-arm64"
@@ -138,6 +151,9 @@ dockers:
     dockerfile: Dockerfile
     goos: linux
     goarch: arm64
+    extra_files:
+      - plugins
+      - build/plugins
 
 docker_manifests:
   - name_template: "ghcr.io/holomush/holomush:{{ .Version }}"


### PR DESCRIPTION
## Summary

The v0.1.2 release run got past cosign v3 signing (\`.15\` ✅) but goreleaser then failed the **docker build**: the Dockerfile \`COPY plugins/\` (:20) and \`COPY build/plugins/\` (:25), but goreleaser's docker build context held only the binary + Dockerfile → \`'/build/plugins': not found\`. Two causes:

1. \`build/plugins/\` (compiled binary plugins) was never built in the release path.
2. The \`dockers:\` blocks had no \`extra_files\`, so the Dockerfile's COPY sources weren't in the temp build context.

## Fix (single file — `.goreleaser.yaml`)

- **`before.hooks`**: add \`task plugin:build-all\` → produces \`build/plugins/\` (host + linux amd64/arm64) before the docker build. Running it as a goreleaser hook means **both** \`goreleaser release\` (CI) and \`task release:snapshot\` (local) build plugins identically.
- **`dockers` (both amd64 + arm64)**: \`extra_files: [plugins, build/plugins]\` so the Dockerfile's \`COPY\` sources land in the build context.

No \`release.yaml\` change needed — the hook covers plugin building in both paths.

## Validated locally (the point of this batch-harden pass)

\`\`\`
goreleaser release --snapshot --clean --skip=publish,sign,validate,announce,sbom
→ building docker image ghcr.io/holomush/holomush:...-arm64
→ building docker image ghcr.io/holomush/holomush:...-amd64
  took: 16s
• release succeeded after 25s
\`\`\`

**Both docker images built cleanly** — the \`COPY plugins/\` + \`COPY build/plugins/\` now resolve. Skipped locally: sbom (syft not installed; CI installs it), sign (cosign needs CI OIDC — already proven in the v0.1.2 run), publish/attestation (post-build, CI-only).

## What this means for the release pipeline

This was the 4th never-exercised gap. With the binary→archive→checksum→**docker** stages now validated end-to-end locally, the only remaining real-CI-only unknowns are: SBOM (syft, low risk — CI provides it), and the post-publish tail (attestation jobs + verify-release image-signature verify). Cutting v0.1.3 after this merges should get through **build → sign → publish** for the first time.

## Test plan

- [x] \`task release:check\` validates
- [x] Local \`goreleaser release --snapshot\` builds both docker images (full pipeline minus CI-only steps)
- [ ] On v0.1.3 release: goreleaser publishes \`ghcr.io/holomush/holomush:0.1.3\` + \`:latest\`; attestation + verify-release exercise for the first time

## Note

Pre-existing (not addressed): \`go mod tidy\` produces a diff (minor go.mod drift on main); goreleaser warns \`dockers\`→\`dockers_v2\`. Both candidates for the \`holomush-dfsvk\` tooling pass.

Refs: holomush-hryj, holomush-hryj.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)