### PR TITLE
fix(scripts): seed-secrets SSH key — strip bracketed-paste escapes (holomush-9s4wv)

### DIFF
--- a/scripts/bootstrap_seed_secrets.py
+++ b/scripts/bootstrap_seed_secrets.py
@@ -38,6 +38,7 @@ import argparse  # noqa: E402 — imports below require Python 3.12
 import getpass  # noqa: E402
 import json  # noqa: E402
 import os  # noqa: E402
+import re  # noqa: E402
 import subprocess  # noqa: E402
 import tempfile  # noqa: E402
 import urllib.error  # noqa: E402
@@ -146,6 +147,13 @@ def prompt_yes_no(prompt: str) -> bool:
     return ans == "y"
 
 
+# Matches ANSI CSI escape sequences, including the bracketed-paste markers
+# (ESC[200~ / ESC[201~) that terminals inject around pasted text. input()
+# captures these into the first/last pasted lines and corrupts multi-line
+# secrets such as a pasted private key, so strip them defensively.
+_ANSI_CSI = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
 def collect_with_confirm(
     prompt: str,
     *,
@@ -166,6 +174,10 @@ def collect_with_confirm(
                     line = input()
                 except EOFError:
                     break
+                # Strip bracketed-paste / CSI escapes the terminal injects
+                # around pasted text before the sentinel check, so the closing
+                # ESC[201~ doesn't hide the terminating ".".
+                line = _ANSI_CSI.sub("", line)
                 if line == ".":
                     break
                 lines.append(line)
@@ -370,7 +382,10 @@ def validate_do_ssh_key_id(token: str, key_id: str) -> tuple[ValidationResult, s
 def validate_do_ssh_private_key(private_key: str, expected_fingerprint: str) -> ValidationResult:
     name = "DIGITALOCEAN_SSH_PRIVATE_KEY"
     with tempfile.NamedTemporaryFile(mode="w", suffix=".key", delete=False, encoding="utf-8") as tf:
-        tf.write(private_key)
+        # OpenSSH/PEM private keys must end with exactly one trailing newline;
+        # the collected value may have it stripped (file read .strip() or paste
+        # join). Normalize so ssh-keygen always sees a well-formed key file.
+        tf.write(private_key.rstrip("\n") + "\n")
         keyfile = tf.name
     try:
         os.chmod(keyfile, 0o600)

--- a/scripts/tests/test_bootstrap_seed_secrets.py
+++ b/scripts/tests/test_bootstrap_seed_secrets.py
@@ -407,3 +407,34 @@ def test_main_exits_1_when_validation_fails(monkeypatch):
     rc = bss.main([])
     assert rc == 1
     assert write_called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _ANSI_CSI — bracketed-paste / CSI escape stripping (holomush-9s4wv)
+# ---------------------------------------------------------------------------
+
+
+def test_ansi_csi_strips_bracketed_paste_start_marker():
+    # Terminals prefix the first pasted line with ESC[200~.
+    assert (
+        bss._ANSI_CSI.sub("", "\x1b[200~-----BEGIN OPENSSH PRIVATE KEY-----")
+        == "-----BEGIN OPENSSH PRIVATE KEY-----"
+    )
+
+
+def test_ansi_csi_strips_bracketed_paste_end_marker():
+    # Terminals suffix the last pasted line with ESC[201~.
+    assert (
+        bss._ANSI_CSI.sub("", "-----END OPENSSH PRIVATE KEY-----\x1b[201~")
+        == "-----END OPENSSH PRIVATE KEY-----"
+    )
+
+
+def test_ansi_csi_leaves_clean_sentinel_intact():
+    # A "." terminator wrapped in paste markers must reduce to "." so the
+    # multi-line reader still detects end-of-input.
+    assert bss._ANSI_CSI.sub("", "\x1b[200~.\x1b[201~") == "."
+
+
+def test_ansi_csi_leaves_plain_text_untouched():
+    assert bss._ANSI_CSI.sub("", "ssh-ed25519 AAAAC3Nz") == "ssh-ed25519 AAAAC3Nz"


### PR DESCRIPTION
## Summary

Pasting the SSH private key into \`scripts/bootstrap_seed_secrets.py\`'s multi-line prompt failed validation with \`ssh-keygen -y failed: error in libcrypto: unsupported\` — even though the same key validates fine via \`ssh-keygen -y -f <file>\`.

**Root cause:** modern terminals in **bracketed-paste mode** wrap pasted text in \`ESC[200~\` … \`ESC[201~\` escape sequences. The script's \`input()\`-based multi-line reader captured those into the first/last lines, corrupting the key's armor. The escapes are non-printing, so the key "looked fine." Confirmed 2026-05-23: operator's DO key (from 1Password) failed pasted, passed standalone.

## Fixes

1. **Strip CSI/bracketed-paste escapes** (`_ANSI_CSI` regex) from each line in the multi-line reader, *before* the `.` sentinel check (so a paste-wrapped `.` still terminates input).
2. **Normalize trailing newline** in \`validate_do_ssh_private_key\` — write \`private_key.rstrip("\n") + "\n"\` so ssh-keygen always sees a well-formed key file (the collected value may have it stripped by \`.strip()\` or a file read).
3. The **file-path input option already existed** (line 256) — entering a path avoids the paste path entirely. That's the recommended route and is the immediate workaround (no need to wait for this PR to merge to proceed).

## Tests

+4 regression tests for `_ANSI_CSI` stripping (start/end markers, paste-wrapped sentinel, plain text untouched). **All 25 script tests pass**; \`ruff check\` + \`ruff format --check\` clean (verified via \`uv run --group dev\`, matching CI).

## Context

Surfaced while running the sandbox-activation operator step \`holomush-hryj.4\` (seed-secrets dry-run). Standalone tooling bug — not under the activation epic. The operator can proceed *now* by entering the key **file path** at the prompt instead of pasting.

Refs: holomush-9s4wv

🤖 Generated with [Claude Code](https://claude.com/claude-code)