### PR TITLE
fix(release+sandbox): version resolution + Kopia cache perms + non-fatal backup init (.17/.19)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,9 +51,19 @@ jobs:
 
       - name: Get version
         id: version
+        env:
+          # On the release-please path the workflow is triggered by a push to
+          # main, so GITHUB_REF_NAME is "main" — the real tag comes from the
+          # release-please job output. On a direct tag push, release-please is
+          # skipped (RP_TAG empty) and GITHUB_REF_NAME is the tag.
+          RP_TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME}"
+          if [ -n "${RP_TAG}" ]; then
+            VERSION="${RP_TAG#v}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version: ${VERSION}"
 

--- a/docker/postgres-backup/Dockerfile
+++ b/docker/postgres-backup/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a50
 # pull it in the build step. Pin the version here and bump deliberately.
 ARG KOPIA_VERSION=0.18.0
 
-RUN apk add --no-cache bash ca-certificates curl supercronic postgresql18-client coreutils tzdata \
+RUN apk add --no-cache bash ca-certificates curl su-exec supercronic postgresql18-client coreutils tzdata \
     && adduser -D -g '' backup \
     && arch="$(uname -m)"; \
        case "${arch}" in \
@@ -50,7 +50,8 @@ RUN printf '%s\n' '0 3 * * * . /etc/backup.env && /usr/local/bin/backup.sh' \
     && touch /etc/backup.env \
     && chown backup:backup /etc/backup.env
 
-USER backup
-
+# NOTE: no `USER backup` here. The entrypoint starts as root so it can fix
+# ownership of the kopia cache (a root-owned Docker named volume) before
+# dropping to the unprivileged `backup` user via su-exec. See entrypoint.sh.
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["cron"]

--- a/docker/postgres-backup/entrypoint.sh
+++ b/docker/postgres-backup/entrypoint.sh
@@ -2,13 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 HoloMUSH Contributors
 #
-# Container entrypoint. If invoked with no args (or the default CMD "cron"),
-# dump relevant env vars to /etc/backup.env so supercronic's minimal shell
-# can source them, then exec supercronic. Any other argv — e.g.,
+# Container entrypoint. Starts as root so it can fix ownership of the kopia
+# cache directory (a root-owned Docker named volume mounted at
+# /home/backup/.cache/kopia), then drops to the unprivileged `backup` user
+# via su-exec. If invoked with no args (or the default CMD "cron"), dump
+# relevant env vars to /etc/backup.env so supercronic's minimal shell can
+# source them, then exec supercronic. Any other argv — e.g.,
 # `docker compose run --rm backup kopia repository connect s3 ...` — is
-# executed directly, bypassing the cron path.
+# executed directly (still dropped to `backup`), bypassing the cron path.
 
 set -eu
+
+# Docker named volumes are created root-owned; the non-root `backup` user
+# cannot write into the mounted cache dir without this. Idempotent.
+mkdir -p /home/backup/.cache/kopia
+chown -R backup:backup /home/backup/.cache
 
 env \
   | grep -E '^(POSTGRES_|PGPASSWORD|KOPIA_PASSWORD|BACKUP_|AWS_)' \
@@ -16,7 +24,7 @@ env \
   > /etc/backup.env
 
 if [ "$#" -eq 0 ] || [ "$1" = "cron" ]; then
-  exec /usr/bin/supercronic /etc/backup.crontab
+  exec su-exec backup /usr/bin/supercronic /etc/backup.crontab
 fi
 
-exec "$@"
+exec su-exec backup "$@"

--- a/scripts/cloud-init.sh
+++ b/scripts/cloud-init.sh
@@ -276,7 +276,10 @@ case "${HOLOMUSH_DOMAIN}" in
       # into the command string. sudo -u with explicit env= args prevents
       # shell metacharacters in secrets from breaking or hijacking the command.
       # shellcheck disable=SC2016
-      sudo -u "${HOLOMUSH_USER}" \
+      # Backups are an OPTIONAL profile — a repo-init failure here MUST NOT
+      # abort the core stack bringup. Wrap the whole init so a non-zero exit
+      # only logs a warning; the script (set -e) continues to `compose up`.
+      if ! sudo -u "${HOLOMUSH_USER}" \
         env \
           HOLOMUSH_DIR="${HOLOMUSH_DIR}" \
           PROFILES="${profiles}" \
@@ -302,7 +305,10 @@ case "${HOLOMUSH_DOMAIN}" in
               $ENDPOINT_ARGS \
               --access-key="$BACKUP_S3_ACCESS_KEY" \
               --secret-access-key="$BACKUP_S3_SECRET_KEY"
-        '
+        '; then
+        echo "WARNING: Kopia repository init failed — nightly backups will be" \
+             "unavailable until fixed. Continuing with the core stack bringup." >&2
+      fi
     fi
 
     su - "${HOLOMUSH_USER}" -s /bin/sh -c "


### PR DESCRIPTION
## Summary

Bundles the last release-pipeline gap (`.17`) and the bootstrap blocker (`.19`) so the next release (v0.1.4) both **releases green** and **brings the sandbox up**.

### `.17` — release version resolved to `main`

\`release.yaml\`'s "Get version" did \`VERSION="${GITHUB_REF_NAME}"\`, which is \`main\` on the release-please path (push to main) → \`attest-containers\` tried \`ghcr.io/holomush/holomush:main\` and failed; \`verify-release\` then skipped. The image always published correctly (goreleaser derives the version from the git tag) — this only fixes the *workflow's* version output. Now uses \`needs.release-please.outputs.tag_name\` (v-stripped), falling back to \`GITHUB_REF_NAME\` (also v-stripped) for direct tag pushes.

### `.19` — Kopia cache perms + cloud-init resilience

Fresh-droplet bootstrap (run 26343634960) failed cloud-init at the Kopia repo init: \`mkdir /home/backup/.cache/kopia/<hash>: permission denied\`. The \`backup-kopia-cache\` named volume is root-owned (Docker default) but the container ran as \`USER backup\`. And cloud-init's \`set -e\` made this optional-backup failure abort the whole sandbox.

- **`docker/postgres-backup/`**: add \`su-exec\`; drop \`USER backup\`; the entrypoint now starts as root, \`chown\`s \`/home/backup/.cache\` to \`backup\`, then drops to \`backup\` via \`su-exec\` (covers both the supercronic cron path and \`docker compose run --rm backup kopia ...\`). Keeps the persistent cache volume the spec wanted.
- **`scripts/cloud-init.sh`**: the Kopia repo-init is now **non-fatal** — backups are an optional profile and must not abort the core stack. A failure logs a warning and continues to \`compose up\`.

Both `.19` fixes ride this release because cloud-init pulls compose/docker/scripts from \`raw.githubusercontent/.../<HOLOMUSH_REF>\` (the release ref).

## Validation

- **`.19` perms fix validated locally**: built the backup image, mounted a fresh (root-owned) named volume, ran the container — entrypoint chowned + dropped to \`backup\`, and \`backup\` wrote the cache: \`running as: backup\` → \`WROTE_CACHE_OK\`, dirs owned \`backup:backup\`. (Baseline confirmed the fresh volume is \`root:root\`.)
- \`shellcheck\` clean on \`entrypoint.sh\` + \`cloud-init.sh\` (sole SC1091 info is a pre-existing note on the Docker-apt line).
- \`task lint:actions\` + \`task lint:yaml\` pass.

## Path to live

Merge → release-please folds these into the v0.1.4 PR → merge v0.1.4 (now fully green: attest-containers + verify-release pass via `.17`) → re-bootstrap (auto-resolves v0.1.4, pulls fixed cloud-init + backup image) → **core stack comes up → game.holomush.dev live**.

Refs: holomush-hryj, holomush-hryj.17, holomush-hryj.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)