### PR TITLE
fix(sandbox): cloud-init holomush host user uid 1000 + keep postgres data uid 70 (.21)

### DIFF
--- a/scripts/cloud-init.sh
+++ b/scripts/cloud-init.sh
@@ -110,8 +110,14 @@ fi
 # user (instead of as root) to run docker compose. DO's --ssh-keys flag
 # populates root's authorized_keys, so we clone those keys to the holomush
 # user so the same DigitalOcean SSH key works for both accounts.
+# Create the host user with a FIXED uid/gid 1000 to match the holomush user
+# baked into the container image (ghcr.io/holomush/holomush runs as uid 1000).
+# A --system user lands in the 100-999 range, so bind-mounted dirs under
+# /opt/holomush (e.g. config/certs) would be owned by a uid the containerized
+# core/gateway can't write to → "permission denied" generating mTLS certs.
 if ! id "${HOLOMUSH_USER}" &>/dev/null; then
-  useradd --system --create-home --shell /bin/bash "${HOLOMUSH_USER}"
+  groupadd --gid 1000 "${HOLOMUSH_USER}"
+  useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash "${HOLOMUSH_USER}"
   usermod -aG docker "${HOLOMUSH_USER}"
 fi
 
@@ -214,6 +220,12 @@ chmod 600 "${HOLOMUSH_DIR}/.env"
 
 # --- Set ownership ---
 chown -R "${HOLOMUSH_USER}:${HOLOMUSH_USER}" "${HOLOMUSH_DIR}"
+
+# The postgres container runs as uid/gid 70 (postgres:18-alpine), not the
+# holomush host user. Its data dir is bind-mounted at /var/lib/postgresql, so
+# it must be owned by 70 — otherwise (on volume reuse) the chown -R above would
+# hand postgres' own data to uid 1000 and postgres would fail to read it.
+chown -R 70:70 "${HOLOMUSH_DIR}/data/postgres"
 
 # --- Configure firewall ---
 if command -v ufw &>/dev/null; then


### PR DESCRIPTION
## Summary

The fresh-droplet bootstrap got past Kopia (thanks to `.19`) all the way to `docker compose up`, where it stalled on a **uid mismatch**:

- The container image's \`holomush\` user is **uid 1000**, but cloud-init created the **host** \`holomush\` user with \`useradd --system\` → a 100–999 uid (**999** in practice).
- \`chown -R holomush /opt/holomush\` then made the bind-mounted \`config/certs\` dir 999-owned, so the containerized **core**/**gateway** (uid 1000) hit \`permission denied\` generating their mTLS certs → crash loop.
- Separately, the persistent volume carried **stale uid-999 PGDATA + SSL key** from a months-old debian-postgres attempt, which `postgres:18-alpine` (uid 70) rejected.

## Fixes

- **Host user uid 1000** (per the directive): \`groupadd --gid 1000\` + \`useradd --uid 1000 --gid 1000\` instead of \`--system\`, matching the image → bind-mounted dirs are writable by the container.
- **Protect postgres data**: after the recursive chown, restore \`/opt/holomush/data/postgres\` to **uid 70** (postgres' user) — otherwise volume reuse hands postgres' own data to 1000 and breaks it.

(The stale-volume PGDATA was a one-time artifact of abandoned earlier attempts; a clean volume + these ownership rules initdb's correctly.)

## Validated on a live droplet

On droplet 159.65.255.90 (running v0.1.4), I reproduced the fix manually over SSH: wiped the stale uid-999 PGDATA, chowned `data/postgres`→70 and `config`→1000, then `docker compose up -d`. Result — **full stack healthy**:

```
postgres   Up (healthy)
core       Up (healthy)   "core process ready", 64 ABAC policies loaded
gateway    Up   0.0.0.0:4201->4201
cloudflared / backup  Up
```

Gateway healthz → `ok`; telnet `:4201` →

```
Welcome to HoloMUSH!
Use: connect guest
```

This PR makes cloud-init do those ownership steps automatically so a fresh bootstrap reaches the same state with **no manual intervention**.

## Path to fully-automated live

Merge → v0.1.5 → fresh bootstrap → cloud-init succeeds end-to-end → core stack up → **the workflow's DNS-records + reachability steps (only ever skipped) finally run** → `game.holomush.dev` publicly live.

## Test plan

- [x] `shellcheck scripts/cloud-init.sh` clean (sole SC1091 is a pre-existing os-release note)
- [x] Fix proven on a live droplet — full stack healthy, telnet banner served
- [ ] On v0.1.5 fresh bootstrap: cloud-init completes (status: done); DNS + reachability steps run; `game.holomush.dev/healthz` → 200

Refs: holomush-hryj, holomush-hryj.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)