### PR TITLE
ci(release): multi-arch attest digest + prod GH environment + web Sentry build (.20)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build web bundle into internal/web/dist/
+        # PUBLIC_SENTRY_* are baked into the SvelteKit static bundle at BUILD
+        # time (no runtime server). When PUBLIC_SENTRY_DSN is unset/empty the
+        # browser SDK init is a no-op, so this is safe before the secret exists.
+        env:
+          PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+          PUBLIC_SENTRY_ENVIRONMENT: prod
+          PUBLIC_SENTRY_RELEASE: ${{ steps.version.outputs.version }}
+          PUBLIC_SENTRY_TRACES_SAMPLE_RATE: "0.1"
         run: task web:embed
 
       # GoReleaser handles building, signing, and releasing atomically.
@@ -211,21 +219,17 @@ jobs:
           VERSION="${{ needs.goreleaser.outputs.version }}"
           IMAGE="ghcr.io/holomush/holomush:${VERSION}"
 
-          echo "Fetching digest for ${IMAGE}"
-          MANIFEST_STDERR=$(mktemp)
-          if ! docker manifest inspect "${IMAGE}" --verbose > /tmp/manifest.json 2> "${MANIFEST_STDERR}"; then
-            echo "ERROR: Failed to inspect manifest for ${IMAGE}"
-            echo "Docker manifest inspect stderr:"
-            cat "${MANIFEST_STDERR}"
-            exit 1
-          fi
+          # Resolve the multi-arch image INDEX digest. `docker manifest
+          # inspect --verbose` returns a JSON *array* for a manifest list
+          # (one entry per platform), which broke the old `.Descriptor.digest`
+          # jq. `buildx imagetools inspect --format '{{.Manifest.Digest}}'`
+          # returns the index digest directly and is the correct attestation
+          # subject for a multi-arch image (works for single-arch too).
+          echo "Fetching index digest for ${IMAGE}"
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}')
 
-          DIGEST=$(jq -r '.Descriptor.digest // .digest' /tmp/manifest.json | head -1)
-
-          if [[ -z "${DIGEST}" || "${DIGEST}" == "null" ]]; then
-            echo "ERROR: Could not extract digest from manifest"
-            echo "Manifest output:"
-            cat /tmp/manifest.json
+          if [[ "${DIGEST}" != sha256:* ]]; then
+            echo "ERROR: Could not resolve index digest for ${IMAGE} (got: '${DIGEST}')"
             exit 1
           fi
 
@@ -312,6 +316,13 @@ jobs:
   deploy-sandbox:
     name: Deploy Sandbox
     runs-on: namespace-profile-linux-amd64-2x4
+    # Joins the `prod` GitHub Environment: gives deployment tracking/history in
+    # the Environments UI, surfaces the live URL, scopes the SANDBOX_DEPLOY_ENABLED
+    # gate variable, and is the hook for adding a required-reviewer approval rule
+    # later without touching this workflow.
+    environment:
+      name: prod
+      url: https://game.holomush.dev
     needs: [verify-release]
     # On tag push: wait for verify-release to succeed. On workflow_dispatch
     # (redeploy an existing release): run independently since goreleaser +


### PR DESCRIPTION
## Summary

Release-pipeline portion of the v0.1.5 round (all `release.yaml`):

1. **`.20` attest-containers digest** — `docker manifest inspect --verbose` returns a JSON **array** for a multi-arch manifest list, which broke the old `.Descriptor.digest` jq (v0.1.4 `attest-containers` failed → `verify-release` skipped → `deploy-sandbox` would skip). Now uses `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` to resolve the **image-index digest** directly — the correct multi-arch attestation subject (works single-arch too). **This unblocks the auto-update path** (`verify-release` → `deploy-sandbox`).

2. **`prod` GitHub Environment** on `deploy-sandbox` (`environment: { name: prod, url: https://game.holomush.dev }`) — deployment tracking/history, the live URL on commits/PRs, scopes the `SANDBOX_DEPLOY_ENABLED` gate to `prod`, and is the hook for a future required-reviewer approval rule with no further code change. (Env created + gate var moved into it, `=false` for now.)

3. **Web Sentry build env** — `PUBLIC_SENTRY_DSN`/`ENVIRONMENT`/`RELEASE`/`TRACES_SAMPLE_RATE` on the `task web:embed` step. SvelteKit's static build bakes these into the embedded bundle; unset DSN → no-op, so it's safe before the secret exists.

## Companion PRs (same v0.1.5 round)

- **#4214** — `.21` cloud-init host uid 1000 (clean-slate bootstrap fix)
- **PR B (next)** — backend Sentry wiring (compose + cloud-init + bootstrap-sandbox + seed-secrets), stacked on #4214 to avoid a `cloud-init.sh` conflict

## Test plan

- [x] `task lint:actions` + `task lint:yaml` pass
- [x] `prod` environment created; `SANDBOX_DEPLOY_ENABLED` scoped to it
- [ ] On v0.1.5 release: `attest-containers` resolves the index digest, `verify-release` runs green, and (gate on) `deploy-sandbox` shows under the `prod` environment

Refs: holomush-hryj, holomush-hryj.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)