### PR TITLE
feat(sandbox): wire backend Sentry (core+gateway) end-to-end (holomush-hryj)

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -364,6 +364,10 @@ jobs:
             secrets.DO_SPACES_ACCESS_KEY }}
           BACKUP_S3_SECRET_KEY_VAL: ${{ steps.spaces_key.outputs.secret_key != '' && steps.spaces_key.outputs.secret_key ||
             secrets.DO_SPACES_SECRET_KEY }}
+          # Backend Sentry DSN (core + gateway). Optional — empty disables
+          # Sentry. ENVIRONMENT/RELEASE/SAMPLE_RATE default in cloud-init.sh
+          # (prod / image tag / 0.1).
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           set -euo pipefail
 
@@ -371,6 +375,7 @@ jobs:
           echo "::add-mask::${PG_PASSWORD}"
           echo "::add-mask::${KOPIA_PASSWORD}"
           echo "::add-mask::${BACKUP_S3_SECRET_KEY_VAL}"
+          [ -n "${SENTRY_DSN}" ] && echo "::add-mask::${SENTRY_DSN}" || true
 
           # HOLOMUSH_REF and HOLOMUSH_VERSION arrive from the `image` step's
           # outputs, where they were also probed against GHCR before any paid
@@ -387,6 +392,7 @@ jobs:
             "${KOPIA_PASSWORD}" \
             "${BACKUP_S3_ACCESS_KEY_VAL}" \
             "${BACKUP_S3_SECRET_KEY_VAL}" \
+            "${SENTRY_DSN}" \
             <<'PYEOF'
           import sys
 
@@ -400,6 +406,7 @@ jobs:
           kopia_pwd      = sys.argv[8]
           s3_access_key  = sys.argv[9]
           s3_secret_key  = sys.argv[10]
+          sentry_dsn     = sys.argv[11]
 
           cloud_config = """\
           #cloud-config
@@ -435,6 +442,7 @@ jobs:
           export BACKUP_KEEP_DAILY="7"
           export BACKUP_KEEP_WEEKLY="4"
           export BACKUP_KEEP_MONTHLY="6"
+          export SENTRY_DSN="{sentry_dsn}"
 
           """
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -62,6 +62,12 @@ services:
     environment:
       DATABASE_URL: postgres://holomush:${POSTGRES_PASSWORD}@postgres:5432/holomush?sslmode=require
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}
+      # Error/trace reporting. Empty SENTRY_DSN disables Sentry (no-op), so
+      # self-hosters without Sentry are unaffected.
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-}
     volumes:
       - ${CONFIG_DIR:-/opt/holomush/config}/certs:/home/holomush/.config/holomush/certs
     networks:
@@ -87,6 +93,11 @@ services:
       - --log-format=json
     environment:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}
+      # Gateway reads SENTRY_DSN (cmd/holomush/gateway.go); empty = disabled.
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-}
     volumes:
       - ${CONFIG_DIR:-/opt/holomush/config}/certs:/home/holomush/.config/holomush/certs:ro
     networks:

--- a/scripts/cloud-init.sh
+++ b/scripts/cloud-init.sh
@@ -64,6 +64,14 @@ CLOUDFLARE_TUNNEL_TOKEN="${CLOUDFLARE_TUNNEL_TOKEN:-}"
 # Caddy-mode only.
 LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
 
+# Sentry error/trace reporting (backend: core + gateway). Empty DSN disables
+# Sentry entirely. Defaults: environment "prod", release tracks the image tag,
+# 10% trace sampling.
+SENTRY_DSN="${SENTRY_DSN:-}"
+SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-prod}"
+SENTRY_RELEASE="${SENTRY_RELEASE:-${HOLOMUSH_VERSION}}"
+SENTRY_TRACES_SAMPLE_RATE="${SENTRY_TRACES_SAMPLE_RATE:-0.1}"
+
 # When set, the script auto-starts compose after .env is written.
 HOLOMUSH_DOMAIN="${HOLOMUSH_DOMAIN:-}"
 
@@ -206,6 +214,17 @@ elif [ -n "${BACKUP_S3_BUCKET}" ] \
   || [ -n "${BACKUP_S3_ACCESS_KEY}" ] \
   || [ -n "${BACKUP_S3_SECRET_KEY}" ]; then
   echo "WARNING: backups require BACKUP_S3_BUCKET, KOPIA_PASSWORD, BACKUP_S3_ACCESS_KEY, and BACKUP_S3_SECRET_KEY — backups disabled" >&2
+fi
+
+if [ -n "${SENTRY_DSN}" ]; then
+  cat >> "${HOLOMUSH_DIR}/.env" <<EOF
+
+# Sentry error/trace reporting (core + gateway). Empty DSN disables it.
+SENTRY_DSN=${SENTRY_DSN}
+SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}
+SENTRY_RELEASE=${SENTRY_RELEASE}
+SENTRY_TRACES_SAMPLE_RATE=${SENTRY_TRACES_SAMPLE_RATE}
+EOF
 fi
 
 # Data paths (commented defaults for reference)

--- a/scripts/cloud-init.sh
+++ b/scripts/cloud-init.sh
@@ -110,8 +110,14 @@ fi
 # user (instead of as root) to run docker compose. DO's --ssh-keys flag
 # populates root's authorized_keys, so we clone those keys to the holomush
 # user so the same DigitalOcean SSH key works for both accounts.
+# Create the host user with a FIXED uid/gid 1000 to match the holomush user
+# baked into the container image (ghcr.io/holomush/holomush runs as uid 1000).
+# A --system user lands in the 100-999 range, so bind-mounted dirs under
+# /opt/holomush (e.g. config/certs) would be owned by a uid the containerized
+# core/gateway can't write to → "permission denied" generating mTLS certs.
 if ! id "${HOLOMUSH_USER}" &>/dev/null; then
-  useradd --system --create-home --shell /bin/bash "${HOLOMUSH_USER}"
+  groupadd --gid 1000 "${HOLOMUSH_USER}"
+  useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash "${HOLOMUSH_USER}"
   usermod -aG docker "${HOLOMUSH_USER}"
 fi
 
@@ -214,6 +220,12 @@ chmod 600 "${HOLOMUSH_DIR}/.env"
 
 # --- Set ownership ---
 chown -R "${HOLOMUSH_USER}:${HOLOMUSH_USER}" "${HOLOMUSH_DIR}"
+
+# The postgres container runs as uid/gid 70 (postgres:18-alpine), not the
+# holomush host user. Its data dir is bind-mounted at /var/lib/postgresql, so
+# it must be owned by 70 — otherwise (on volume reuse) the chown -R above would
+# hand postgres' own data to uid 1000 and postgres would fail to read it.
+chown -R 70:70 "${HOLOMUSH_DIR}/data/postgres"
 
 # --- Configure firewall ---
 if command -v ufw &>/dev/null; then


### PR DESCRIPTION
## Summary

Backend Sentry flows GH secret → bootstrap render → cloud-init `.env` → compose env → **core + gateway**. Empty `SENTRY_DSN` disables Sentry (no-op), so self-hosters are unaffected.

- **`compose.prod.yaml`** — `SENTRY_DSN`/`SENTRY_ENVIRONMENT`/`SENTRY_RELEASE`/`SENTRY_TRACES_SAMPLE_RATE` on core + gateway (`${SENTRY_*:-}` defaults).
- **`scripts/cloud-init.sh`** — intake `SENTRY_*` (defaults: env `prod`, release = image tag, rate `0.1`) + render into `.env` when `SENTRY_DSN` is set.
- **`.github/workflows/bootstrap-sandbox.yaml`** — pass `SENTRY_DSN` (secret) into the cloud-init user-data (masked); the rest default in cloud-init.sh.

## Stacked PR

⚠️ **Base is `holomush-hryj-21-cloudinit-uid` (#4214), not main** — this PR shares `cloud-init.sh` edits with `.21`. Merge order: **#4214 → this** (retarget to main after #4214 lands), alongside **#4215** (release-pipeline + web Sentry build). All three → v0.1.5.

## Secret values + web Sentry

- `SENTRY_DSN` (backend) + `PUBLIC_SENTRY_DSN` (web) values are set via `gh secret set` — optional, browser-exposed DSNs, no live validation needed. Follow-up will fold them into `bootstrap_seed_secrets.py`.
- Web Sentry (`PUBLIC_SENTRY_*`) is build-time, wired in #4215's goreleaser step.

## Test plan

- [x] `shellcheck scripts/cloud-init.sh` clean; `actionlint` + `yamlfmt` pass
- [x] bootstrap render: argv[11] + `export SENTRY_DSN` present; DSN masked
- [x] compose Sentry entries mirror the working `OTEL_EXPORTER` pattern, `yamlfmt`-clean
- [ ] On clean bootstrap with `SENTRY_DSN` secret set: core logs show `sentry_enabled:true`

Refs: holomush-hryj

🤖 Generated with [Claude Code](https://claude.com/claude-code)