### PR TITLE
fix(release): attest digest via imagetools json dump (.20 redux)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,14 +219,14 @@ jobs:
           VERSION="${{ needs.goreleaser.outputs.version }}"
           IMAGE="ghcr.io/holomush/holomush:${VERSION}"
 
-          # Resolve the multi-arch image INDEX digest. `docker manifest
-          # inspect --verbose` returns a JSON *array* for a manifest list
-          # (one entry per platform), which broke the old `.Descriptor.digest`
-          # jq. `buildx imagetools inspect --format '{{.Manifest.Digest}}'`
-          # returns the index digest directly and is the correct attestation
-          # subject for a multi-arch image (works for single-arch too).
+          # Resolve the multi-arch image INDEX digest — the correct attestation
+          # subject for a manifest list. The Go-template form
+          # (`--format '{{.Manifest.Digest}}'`) silently prints the default
+          # human output in this buildx version, so use the structured JSON
+          # dump (`--format '{{json .}}'`) and pull `.manifest.digest` with jq.
+          # Validated against ghcr.io/holomush/holomush:0.1.5.
           echo "Fetching index digest for ${IMAGE}"
-          DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}')
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{json .}}' | jq -r '.manifest.digest')
 
           if [[ "${DIGEST}" != sha256:* ]]; then
             echo "ERROR: Could not resolve index digest for ${IMAGE} (got: '${DIGEST}')"


### PR DESCRIPTION
## Summary

The `.20` fix in #4215 used `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`, but that Go-template form **silently prints the default human output** in this buildx version (it doesn't error), so the v0.1.5 `attest-containers` job got `Name: ... Digest: ... Manifests:` as the "digest" and failed the `sha256:*` check.

**Fix:** use the structured JSON dump and extract with jq:
```bash
DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{json .}}' | jq -r '.manifest.digest')
```

## Validated against the real published image

```
$ docker buildx imagetools inspect ghcr.io/holomush/holomush:0.1.5 --format '{{json .}}' | jq -r '.manifest.digest'
sha256:ff6e5f8ca68277d0ebd65c58046b76a80e9769a736328953bfed8271adf097ea   # ✓ matches the index digest
```

(Also cross-checked the awk-on-default-output approach returns the same digest; chose the structured JSON form as more version-stable.)

## Impact

Unblocks `attest-containers` → `verify-release` → `deploy-sandbox` (the auto-update path). The v0.1.5 image is already published and usable; this makes the **next** release (v0.1.6) fully green so auto-deploy can run.

## Test plan

- [x] Digest extraction validated against `ghcr.io/holomush/holomush:0.1.5` (correct index digest)
- [x] `task lint:actions` + `task lint:yaml` pass
- [ ] On v0.1.6: `attest-containers` + `verify-release` pass; `deploy-sandbox` runs (gate permitting)

Refs: holomush-hryj, holomush-hryj.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)