### PR TITLE
fix(release): verify-release uses v-prefixed tag for gh release download (.20)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -260,12 +260,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.goreleaser.outputs.version }}"
+          # goreleaser's version output is un-prefixed (matches the image tag
+          # ghcr.io/...:0.1.6), but the GitHub release/tag is v-prefixed
+          # (v0.1.6). Use the v-prefixed tag for gh release lookups.
+          RELEASE_TAG="v${VERSION}"
 
-          echo "Verifying release ${VERSION}..."
+          echo "Verifying release ${RELEASE_TAG}..."
 
           # Wait for release to be available (handles propagation delay)
           for i in {1..5}; do
-            if gh release view "${VERSION}" -R holomush/holomush > /dev/null 2>&1; then
+            if gh release view "${RELEASE_TAG}" -R holomush/holomush > /dev/null 2>&1; then
               break
             fi
             echo "Release not yet available, waiting... (attempt $i/5)"
@@ -274,11 +278,11 @@ jobs:
 
           # Download checksums and the cosign v3 sigstore bundle.
           mkdir -p dist
-          if ! gh release download "${VERSION}" -R holomush/holomush -D dist \
+          if ! gh release download "${RELEASE_TAG}" -R holomush/holomush -D dist \
             -p 'checksums.txt' -p 'checksums.txt.sigstore.json'; then
             echo "ERROR: Failed to download release artifacts"
             echo "This may indicate the release was not published or signing failed"
-            gh release view "${VERSION}" -R holomush/holomush --json assets || true
+            gh release view "${RELEASE_TAG}" -R holomush/holomush --json assets || true
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

v0.1.6 got `attest-containers` green (the #4218 digest fix worked ✅) — so **verify-release ran for the first time ever** and immediately failed: `release not found` / "Failed to download release artifacts".

**Root cause:** a v-prefix mismatch. `.17` makes `goreleaser.outputs.version` = `0.1.6` (un-prefixed, correct for the image tag `ghcr.io/holomush/holomush:0.1.6`), but the GitHub release/tag is **`v0.1.6`** (release-please's v-prefixed tag). verify-release ran `gh release view/download "0.1.6"` → no such release.

**Fix:** derive `RELEASE_TAG="v${VERSION}"` and use it for the three `gh release` lookups; keep the un-prefixed `${VERSION}` for the image `cosign verify` (which is correct as-is).

## Impact

Last gap in the auto-deploy chain: `attest-containers` ✅ → **verify-release** (this fix) → `deploy-sandbox`. After v0.1.7, the release pipeline is fully green and `deploy-sandbox` can run (gate permitting).

## Test plan

- [x] `task lint:actions` + `task lint:yaml` pass
- [x] Confirmed release tags are v-prefixed (`gh release list` → `v0.1.6`, `v0.1.5`…) while the image tag is un-prefixed
- [ ] On v0.1.7: verify-release downloads `v0.1.7` artifacts + passes; full release green; `deploy-sandbox` runs

Refs: holomush-hryj, holomush-hryj.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)