### PR TITLE
fix(sandbox): DNS payload via printf — Python dict NameError on proxied:true (.25)

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -665,11 +665,14 @@ jobs:
           print(res[0]['id'] if res else '')
           " 2>/dev/null || echo "")
 
+            # Build the JSON payload directly: proxied is already a valid JSON
+            # boolean (true/false), so emit it unquoted via %s. The previous
+            # python dict-literal form tripped on `'proxied':true` —
+            # Python has True/False, not true/false (NameError). type/name/
+            # content are CF-controlled hostnames/IDs with no JSON-special chars.
             local payload
-            payload=$(python3 -c "
-          import json,sys
-          print(json.dumps({'type':'${type}','name':'${name}','content':'${content}','proxied':${proxied},'ttl':1}))
-          ")
+            payload=$(printf '{"type":"%s","name":"%s","content":"%s","proxied":%s,"ttl":1}' \
+              "${type}" "${name}" "${content}" "${proxied}")
 
             if [ -n "${RECORD_ID}" ]; then
               curl -fsSL \


### PR DESCRIPTION
## Summary

With #4222 merged, the bootstrap finally reached the **"Create Cloudflare DNS records"** step (first execution ever) — and it crashed:

```
NameError: name 'true' is not defined. Did you mean: 'True'?
```

The step built the CF API payload with a Python dict literal interpolating `${proxied}` (a shell `true`/`false`): `{'proxied':${proxied}}` → `'proxied':true` → Python has `True`/`False`, not `true`/`false`.

**Fix:** build the JSON with `printf` instead — `proxied` is already a valid JSON boolean, so emit it unquoted (`%s`). No Python, no NameError.

## Validation

```
proxied=true  → {"...","proxied":true,"ttl":1}   → json.load → bool True  ✓
proxied=false → {"...","proxied":false,"ttl":1}  → json.load → bool False ✓
```
shellcheck clean on the snippet; `actionlint` + `yamlfmt` pass. (Shellcheck-checked the run-block directly this time, per the actionlint/CI skew lesson.)

## Impact

`bootstrap-sandbox.yaml` workflow fix — no release needed. After merge, re-dispatch: cloud-init passes (#4222), DNS records create (this fix), then **Verify reachable** → `game.holomush.dev` publicly live. The DNS step was the last never-run piece before reachability.

Refs: holomush-hryj, holomush-hryj.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)