### PR TITLE
design(scenes-phase-6): logs + publish vote + hard privacy boundary spec + plan

### DIFF
--- a/docs/adr/holomush-39a5f-frozen-voter-roster-in-separate-table.md
+++ b/docs/adr/holomush-39a5f-frozen-voter-roster-in-separate-table.md
@@ -1,0 +1,81 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Publish-Vote Roster Frozen at Attempt Start into `published_scene_votes`, Not on `scene_participants`
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-39a5f
+**Deciders:** HoloMUSH Contributors
+**Related:** [`holomush-jrefa`](holomush-jrefa-published-scenes-table-distinct-from-scene-log.md)
+
+## Context
+
+Phase 6 introduces a publish-vote mechanism. The Scenes v2 design (§1.3) declared a `PublishVote *bool` field on the Participant entity. Implementation surfaced two questions:
+
+1. **Where does vote state live?** On the existing `scene_participants` row, or in a separate table?
+2. **Who is eligible to vote, and when is the eligibility set?** The brainstorm question Q3 surfaced three options: roster frozen at scene-end into a dedicated table; roster = current participants at end time with vote state on participant rows; roster = anyone-ever-participated via soft-deletion of `scene_participants`.
+
+Roster semantics depend on the data model: a frozen roster requires snapshotting at attempt-creation time and cannot be expressed naturally as a column on a live membership table.
+
+Three approaches were considered:
+
+- **Column on `scene_participants`** — add `publish_vote *bool` + `publish_vote_cast_at *time` columns. Vote state lives where membership lives. No snapshot — eligible voters are whoever has a row at scene-end time; leavers-after-end lose their vote when their row is deleted.
+- **Soft-delete `scene_participants`** — add `left_at` column. Eligible voters at scene-end = all non-kicked owner/member participants, including those who voluntarily left. Heaviest change: alters the meaning of `scene_participants` for every existing reader.
+- **Dedicated `published_scene_votes` table** — snapshot eligible voters at attempt creation. One row per (attempt × voter), carrying `vote *bool`, `voted_at`, `last_changed_at`. `scene_participants` untouched.
+
+## Decision
+
+A new `published_scene_votes` table holds vote state, one row per (attempt × voter). The roster is populated at attempt creation by snapshotting `scene_participants` rows with `role IN ('owner', 'member')` (NOT `'invited'`). After insertion, the roster is immutable for the attempt's lifetime: participants joining the scene later do not become voters for this attempt; participants leaving the scene later retain their vote eligibility.
+
+`scene_participants` is not modified by Phase 6. Its existing schema, its membership semantics, and its access patterns are preserved.
+
+Phase 6 also adds a per-scene `max_publish_attempts` column to `scenes` (migration 000009) — this is unrelated to roster but co-located in the same Phase 6 schema work.
+
+## Rationale
+
+**Roster immutability is the load-bearing requirement.** INV-P6-1 mandates that the eligible-voter set is frozen at attempt creation. A leaver-after-end retains their vote (a publication they contributed to should not be derailed by their later departure); a leaver-before-end is excluded (they weren't there when the vote roster was decided). This semantic is impossible to express naturally as a column on a live `scene_participants` table — the row either exists (member) or it doesn't (left), and there's no per-attempt history.
+
+**Coupling vote state with membership lifetime conflates unrelated concerns.** `scene_participants` rows track scene-level membership: who's in the scene right now, when did they join, what's their role. Vote state tracks per-attempt opinion: did this voter cast yes/no for THIS attempt, when, and is it sticky. The two lifecycles are independent: one voter might participate in multiple consecutive publication attempts on the same scene; the roster for each attempt is a separate snapshot. Cramming this into participant rows would require either (a) overwriting vote state per attempt (lose history), or (b) repeated columns per attempt (combinatorial explosion).
+
+**Per-attempt isolation enables clean audit.** With separate vote rows per attempt, the system can answer "who voted yes on attempt 2 but no on attempt 3?" via simple SQL JOIN. With vote state on participant rows, that query is impossible without versioning the participant table.
+
+**`scene_participants` stability matters.** Phase 4 (`5rh.13`) introduced maintained pose-order metadata on `scene_participants`. Phase 5 (`5rh.14`) introduced focus-membership relationships. ABAC attribute resolution (`principal.id in resource.scene.participants`) reads this table. Adding vote-state columns would increase row size for every membership row across every scene, and add the vote-state field to every reader's mental model. The Phase 6 work stays scoped: new table, new rows, no impact on existing participant readers.
+
+## Alternatives Considered
+
+**Option A: Dedicated `published_scene_votes` table, roster frozen at attempt creation (chosen).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Roster immutability is structural (insert-then-update-only); per-attempt isolation; voter lifecycle decoupled from membership lifecycle; `scene_participants` unmodified; vote history preserved across multiple attempts |
+| Weaknesses | One additional table; the snapshot at attempt-creation time requires a transaction-coordinated INSERT (already needed for the publish-attempt row itself) |
+
+**Option B: `publish_vote` + `publish_vote_cast_at` columns on `scene_participants`.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | No new table; vote state lives where membership lives; SQL JOIN unnecessary for "who voted what" queries |
+| Weaknesses | Cannot enforce roster immutability (leavers-after-end lose vote when their row is deleted); cannot support multiple attempts per scene without overwriting vote state; couples scene-membership lifetime with vote-window state; every reader of `scene_participants` carries the publish_vote field in their mental model |
+
+**Option C: Soft-delete `scene_participants` (add `left_at` column).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Eligible voters at scene-end = all non-kicked owner/member rows; supports "anyone who ever participated" semantic; vote-state column on participant row still works |
+| Weaknesses | Changes the meaning of `scene_participants` for every existing reader; every Phase 4/5 query that JOINs against participants must add `WHERE left_at IS NULL`; missed query is a security regression (leaked content to a left participant); biggest blast radius of the three options |
+
+## Consequences
+
+- **Roster immutability is structural.** INV-P6-1 ("rosters frozen at attempt creation and immutable for the attempt's lifetime") is enforced by the table's insert-only-then-update-only semantics: rows are inserted once at attempt creation, then only their `vote`/`voted_at`/`last_changed_at` fields change. No application-layer check is needed to prevent roster mutation.
+- **Per-attempt isolation.** Multiple publication attempts on the same scene have independent roster rows. Each retry gets a fresh tally; vote history of prior attempts persists for audit.
+- **Voter lifecycle decoupled from scene-membership lifecycle.** A voter can leave the scene (deleting their `scene_participants` row) without losing their vote eligibility on an in-flight publication attempt. This matches the user expectation that a vote, once cast, persists.
+- **No `scene_participants` migration.** Phase 6 does not touch `scene_participants` schema. Every existing reader (focus model, Phase 5 multi-connection visibility, audit gates, ABAC `principal.id in resource.scene.participants` attribute resolution) continues to operate against the unchanged shape.
+- **Invited rows excluded by predicate, not by table structure.** The roster snapshot at attempt creation filters `role IN ('owner', 'member')`. An invited character who later accepts (becoming `member`) does NOT retroactively become a voter for an attempt that started before their acceptance. This is correct under the spec's roster-immutability rule but is worth flagging — the contributing-vs-voting distinction lives in the snapshot filter.
+
+## References
+
+- [Scenes Phase 6 design spec](../superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §3.2, §3.3 (DDL), §4.1 (transitions), INV-P6-1
+- [Scenes Phase 6 implementation plan](../superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md) Task A1 (DDL), Task A5 (CreatePublishAttempt seeds roster), Task A6 (CastVote)
+- [Scenes v2 design](../superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md) §1.3 (superseded — `PublishVote *bool` field moved off Participant)
+- Design bead `holomush-5rh.20` (brainstorm Q3 — voter eligibility and state location)

--- a/docs/adr/holomush-c4jee-inv-p6-6-structural-enforcement.md
+++ b/docs/adr/holomush-c4jee-inv-p6-6-structural-enforcement.md
@@ -1,0 +1,111 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# INV-P6-6 (No ABAC Engine in Participant Publication RPCs) Enforced by AST Import Scan and Reflect Field Check
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-c4jee
+**Deciders:** HoloMUSH Contributors
+**Related:** [`holomush-qd3r5`](holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md), [`holomush-c8a9`](holomush-c8a9-scene-privacy-plugin-code-enforcement.md), [`holomush-nt2d`](holomush-nt2d-participant-gate-pattern-generalized.md)
+
+## Context
+
+INV-S9 (substrate-contract §4.1) requires that the hard privacy boundary for scenes be plugin-code-enforced, not ABAC-engine-enforced. Phase 6 inherits this invariant for the new publication RPCs and codifies it as INV-P6-5 (gate runs before content read) and INV-P6-6 (ABAC engine MUST NOT be called during participant-gated publication RPC handlers).
+
+INV-P6-5 is verifiable via a call-stack tripwire test: a mock store with a content-read counter; the handler under test must deny non-participants before the counter increments. This pattern is established at `audit_test.go:229` (`TestQueryHistoryDeniesNonMemberWithoutHittingLogStore`) and is straightforward to extend to the new RPCs.
+
+INV-P6-6 is harder to test. Two approaches were considered:
+
+1. **Runtime injection via functional option.** Add `WithABACEngine(recordingEngine)` to `NewSceneServiceImpl`; tests inject a recording engine and assert `engine.EvaluateCalls() == 0` after the handler returns. Mirrors the pattern used in some other parts of the codebase for ABAC-dependent code.
+
+2. **Structural enforcement.** Two static tests: a `go/parser` AST import scan asserts that `publish_service.go` imports no ABAC policy package; a `reflect` field-type enumeration asserts that `SceneServiceImpl` has no field whose type is (or contains) an ABAC engine interface. No production API change.
+
+The functional-option approach changes production code to accommodate a test concern. Worse, it introduces a code path — `s.abacEngine` (or equivalent) — that a future contributor could mistakenly wire to a real engine, breaking the invariant. A subtle change to the test mock would not catch this; the test asserts on the recorder's behavior, not on the absence of the field.
+
+The structural approach is purely additive: the tests read production code without modifying it. The production API surface stays narrow; there is no field on `SceneServiceImpl` capable of holding an ABAC engine, so the invariant is enforced by absence rather than by behavioral assertion.
+
+## Decision
+
+INV-P6-6 is verified by two tests in `plugins/core-scenes/service_publish_gate_test.go`:
+
+### Test 1: AST import scan
+
+```go
+func TestPublicationServiceFileImportsNoABACPolicyPackage(t *testing.T) {
+    src, err := os.ReadFile("publish_service.go")
+    require.NoError(t, err)
+    fset := token.NewFileSet()
+    f, err := parser.ParseFile(fset, "publish_service.go", src, parser.ImportsOnly)
+    require.NoError(t, err)
+    for _, imp := range f.Imports {
+        path := strings.Trim(imp.Path.Value, `"`)
+        require.False(t, strings.HasPrefix(path, "github.com/holomush/holomush/internal/access/policy"),
+            "INV-P6-6 violation: publish_service.go imports ABAC policy package %s", path)
+    }
+}
+```
+
+### Test 2: Reflect field-type check
+
+```go
+func TestPublicationServiceTypeHasNoABACEngineField(t *testing.T) {
+    typ := reflect.TypeOf(SceneServiceImpl{})
+    for i := 0; i < typ.NumField(); i++ {
+        f := typ.Field(i)
+        require.NotContains(t, strings.ToLower(f.Type.String()), "policy.engine",
+            "INV-P6-6 violation: field %s carries ABAC engine type %s", f.Name, f.Type.String())
+    }
+}
+```
+
+Neither test requires a constructor seam, a functional option, or any production-code change to enable verification. The production constructor signature `NewSceneServiceImpl(store sceneStorer)` is preserved (matches the existing one-parameter shape at `service.go:88`).
+
+## Rationale
+
+**Absence-of-capability is structurally stronger than absence-of-call.** A behavioral test (recording engine + zero-calls assertion) verifies that at the moment the test runs, the handler did not call the engine. A structural test (no import, no field) verifies that at the moment the test runs, the handler **cannot** call the engine — there is no code path that could reach it. The latter survives refactors that introduce a new call site; the former does not.
+
+**Constructor seams introduce production risk.** A functional option `WithABACEngine(engine policy.Engine)` exists in production code even when only tests use it. A future contributor reading `service.go` sees the option, infers "this service can optionally consult ABAC," and adds a real engine. The test that catches this depends on someone re-running it — but the failure mode is "engine consulted, leaked content" before anyone notices the test regression. The structural approach has no such code path.
+
+**The tests are purely additive.** `service_publish_gate_test.go` reads production code via `os.ReadFile` and `reflect.TypeOf`. Production code knows nothing about the tests. Removing the tests is the only way to weaken the invariant — and removal is a visible PR edit that a reviewer can catch.
+
+**Parallels the existing INV-S9 test pattern.** `audit_test.go:229` (`TestQueryHistoryDeniesNonMemberWithoutHittingLogStore`) uses a tripwire mock store to assert call-stack ordering. This ADR's tests extend the pattern from runtime call-stack assertion to compile-time structural assertion. Both are CI-time regression locks; the structural variant runs faster (no test substrate) and catches a strictly larger class of violations.
+
+## Alternatives Considered
+
+**Option A: AST import scan + reflect field-type check (chosen).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Invariant verified by structural absence (no code path can violate); production API unchanged; tests are purely additive; fast (no runtime substrate); regression-locks at CI time |
+| Weaknesses | Doesn't cover dynamically-obtained engines (e.g., via `ctx.Value`, global registry, or reflection) — but such patterns would be unusual in this codebase and would themselves require explicit code addition |
+
+**Option B: `WithABACEngine(engine)` functional option + recording engine in tests.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Familiar functional-options pattern; tests have explicit injection point; runtime-call-count is directly assertable |
+| Weaknesses | Changes production API surface to accommodate test concern; introduces a code path (`s.abacEngine`) that exists even when unused; a future contributor could mistakenly wire a real engine through the option; test failure surface is "ran but called the engine" which requires the test to run on every PR (versus structural check that fails at build time) |
+
+**Option C: Build-tag-gated test seam.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Test-only seam invisible to production builds |
+| Weaknesses | Build-tag complexity for one invariant; debugging seam-related test failures is harder than debugging straightforward structural assertions; introduces a precedent that test-only build tags are acceptable, which complicates the build-tag policy |
+
+## Consequences
+
+- **Regression locked at CI time.** Any future PR that adds an `internal/access/policy` import to `publish_service.go` or adds an `policy.Engine`-typed field to `SceneServiceImpl` triggers an immediate test failure. The intent of the violator must be made explicit by removing the test — a visible, reviewable act.
+- **No production API surface change.** The constructor signature is untouched. Phase 6 does not add a `policy.Engine` parameter or option to any constructor.
+- **Tests are pure code-level checks.** They run as plain `go test`, no integration harness, no runtime substrate. Fast and reproducible.
+- **Limitation: dynamic engines not covered.** If a future implementation obtained an ABAC engine through a different mechanism (e.g., loaded from `ctx.Value(...)`, or via a global registry), the structural tests would not catch it. Contributors must understand the scope: structural absence-of-field is the invariant being verified, not runtime call-site absence.
+- **Combines with [`holomush-qd3r5`](holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md).** The no-shared-code-path decision (qd3r5) plus structural enforcement (this ADR) together make INV-S9 regression resistance a multi-layer property: even if one layer is compromised by a future refactor, the other catches it.
+
+## References
+
+- [Scenes Phase 6 design spec](../superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §9, §9.4, INV-P6-5, INV-P6-6
+- [Scenes Phase 6 implementation plan](../superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md) Task B5 (INV-S9 tripwire + structural tests)
+- [Substrate-contract spec](../superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) INV-S9
+- Existing INV-S9 test pattern: `plugins/core-scenes/audit_test.go:229` (`TestQueryHistoryDeniesNonMemberWithoutHittingLogStore`)
+- Design bead `holomush-5rh.20` (plan-review rounds 1-2 fix log — WithABACEngine option rejected in favor of structural approach)

--- a/docs/adr/holomush-e3xlx-publication-content-as-structured-jsonb.md
+++ b/docs/adr/holomush-e3xlx-publication-content-as-structured-jsonb.md
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Scene Publication Content Stored as Structured JSONB Entry Array, Rendered on Demand
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-e3xlx
+**Deciders:** HoloMUSH Contributors
+**Related:** [`holomush-jrefa`](holomush-jrefa-published-scenes-table-distinct-from-scene-log.md)
+
+## Context
+
+The Phase 6 publication artifact (per `holomush-jrefa`) must serve multiple consumers:
+
+- The participant `scene publish download` command (terminal output)
+- The future Phase 9 web client (HTML/Markdown rendering)
+- Public archive URLs (anonymous reads)
+- The `scene log export` command from `holomush-cb4x` (participant-only audit-history export, same renderer surface)
+- Potential future formats: PDF, RSS, syndicated feed entries
+
+The Scenes v2 design (§1.5) named the field "Content" with no specified shape. The brainstorm question Q7 asked: store content as a rendered markdown blob, or as a structured representation?
+
+Three approaches were considered:
+
+- **Markdown blob.** Single TEXT column holds rendered markdown, written once at PUBLISHED transition. Cheap render at read time (it's already markdown); fixed format.
+- **Multi-format pre-rendered.** Separate columns or rows for each format (markdown + plain_text + jsonl). No render at read time; storage cost multiplied per format; adding new formats requires backfill.
+- **Structured JSONB.** Array of `{speaker, kind, content}` entries where `kind ∈ {pose, say, emit}`. Renderers derive their output from the structure at request time.
+
+## Decision
+
+`published_scenes.content_entries` is a JSONB array of structured entry objects. Each entry has three fields:
+
+- `speaker` (string) — character name as of publish time, taken from `participants_snapshot`
+- `kind` (string enum: `pose | say | emit`) — discriminates the original IC event kind; OOC and ops events are excluded per ADR `holomush-sb3n` and v2 spec §3.1
+- `content` (string) — the decrypted IC payload
+
+The renderer interface lives in `plugins/core-scenes/publish_render.go` and exposes three functions:
+
+- `renderMarkdown(entries []Entry) string`
+- `renderPlainText(entries []Entry) string`
+- `renderJSONL(entries []Entry) ([]byte, error)`
+
+All three are pure functions over the structured representation. `DownloadPublishedScene` and `DownloadPublicSceneArchive` pick a renderer based on the request's `format` field at request time. The snapshot pipeline (COOLOFF → PUBLISHED transition; spec §11) reads decrypted IC events from `scene_log`, filters to the three IC content kinds, and writes the structured entries to `content_entries` atomically with the status change.
+
+## Rationale
+
+**Format extensibility is the load-bearing requirement.** Phase 6 ships markdown + plain_text + jsonl, but the publication artifact's lifetime is years (immutable post-publish). HTML (Phase 9 web view), PDF (export), RSS (syndication), Atom — each is a plausible future format. Pre-rendered storage forces a re-snapshot of every archived scene whenever a new format ships, which is operationally prohibitive once thousands of publications exist. Structured storage makes format addition a pure-Go change.
+
+**Decoupling storage and presentation is good architecture.** The structured entry shape (`speaker`, `kind`, `content`) captures everything semantically interesting about a pose/say/emit: who spoke, what kind of utterance, what they said. The renderer interface is a stable extension point; renderers are pure functions; the storage layer is unaware of formatting. This mirrors the broader holomush pattern of "store structured data, render at the boundary."
+
+**Future per-entry operations become tractable.** Content flagging (a user-reports-this-line surface), per-entry attribution updates (if a character's display name changes post-publish — though current design freezes via `participants_snapshot`), partial redaction (admin-mediated content moderation, future) — all become possible without schema migration once the granularity exists at storage time.
+
+**Render cost at request time is acceptable.** Most scenes have hundreds to low-thousands of entries; rendering N entries is O(N) string concatenation, microseconds in practice. Phase 6 spec §15.5 sets coverage targets that include renderer paths (100% on `publish_render.go`). If a future scene is so large that render cost becomes load-bearing, caching pre-rendered formats in a separate table is an additive change that requires no migration of the canonical `content_entries`.
+
+## Alternatives Considered
+
+**Option A: Structured JSONB entry array, render on demand (chosen).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Format-agnostic; renderer interface is a stable extension point; new formats are additive; future per-entry operations tractable; storage decoupled from presentation |
+| Weaknesses | O(N) render cost on every download; opaque to ad-hoc SQL (requires `jq` or renderer); JSON marshaling at storage time |
+
+**Option B: Pre-rendered markdown blob.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Zero render cost at download; cheap to inspect via SQL; single-column storage |
+| Weaknesses | Locks the publication to one format for its lifetime; adding plain_text/jsonl/HTML requires re-snapshot of all archived scenes (operationally prohibitive); per-entry operations require regex-based markdown parsing; renderer logic changes don't retroactively apply to old publications (which is correct, but the path to add new formats is blocked) |
+
+**Option C: Multiple pre-rendered columns, one per format.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Zero render cost; multiple formats served immediately |
+| Weaknesses | Storage cost multiplied per format (3 formats = 3× row size); adding a new format requires both schema migration AND backfill of every archived row; per-entry operations same blockers as Option B |
+
+## Consequences
+
+- **Format extensibility.** Adding HTML, PDF, RSS, etc. requires only a new renderer function; no schema change, no backfill of archived data.
+- **Decoupled storage and presentation.** The renderer interface is a stable extension point. Storage is unaware of formatting; formatting is unaware of storage.
+- **Render cost at read time, not write time.** Every `Download*` call pays a rendering cost (O(N entries) for N pose/say/emit events). For scenes with thousands of poses, this matters; large-scene optimization (e.g., caching the most-popular renders in a separate table) becomes a follow-up question, not a backfill emergency.
+- **Future per-entry operations are tractable.** Content flagging, per-entry attribution updates, partial redaction — all become possible without schema migration once the granularity exists.
+- **Opaque to ad-hoc SQL.** Direct DB inspection (`SELECT content_entries FROM published_scenes ...`) requires `jq` or the renderer for human readability. Acceptable trade-off; ad-hoc inspection of publication content is not a primary access path.
+- **Renderer test coverage matters.** The structured representation is "correct"; the renderer functions are where format-specific bugs would live. Phase 6 ships ≥90% coverage on `publish_render.go` (plan §15.5 coverage targets).
+
+## References
+
+- [Scenes Phase 6 design spec](../superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §3.1, §12, §11 (snapshot pipeline)
+- [Scenes Phase 6 implementation plan](../superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md) Task C1 (Markdown), C2 (plain-text), C3 (JSONL), C6/C7 (snapshot pipeline)
+- Design bead `holomush-5rh.20` (brainstorm Q7 — storage shape and renderer formats)
+- [ADR holomush-sb3n](holomush-sb3n-scene-content-sensitivity-always.md) — content kind classification (drives the kind enum values)

--- a/docs/adr/holomush-jrefa-published-scenes-table-distinct-from-scene-log.md
+++ b/docs/adr/holomush-jrefa-published-scenes-table-distinct-from-scene-log.md
@@ -1,0 +1,83 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Publication Artifact Stored in `published_scenes`, Not Reusing the `scene_log` Audit Table
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-jrefa
+**Deciders:** HoloMUSH Contributors
+**Related:** [`holomush-qd3r5`](holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md), [`holomush-e3xlx`](holomush-e3xlx-publication-content-as-structured-jsonb.md)
+
+## Context
+
+The Scenes v2 design spec (§1.5) named the publication artifact "Scene Log (Published)" — the same human-readable label used in the `scene log` command surface. Implementation work on Phase 6 surfaced a collision: the `scene_log` table already exists at `plugins/core-scenes/migrations/000004_create_scene_log.up.sql` and `000005_add_scene_log_dek_columns.up.sql` (shipped in PR #267). That table is the per-plugin audit-history mirror: it stores raw event rows with BYTEA-encrypted payloads, DEK references for sensitivity:always events, and mirrors the host `events_audit` schema. Its access surface is the membership-gated `PluginAuditService.QueryHistory` (audit.go:493-555).
+
+The publication artifact has a fundamentally different shape: an immutable, public-when-PUBLISHED snapshot derived from the IC event stream, carrying a rendered structured representation (per ADR `holomush-e3xlx`), frozen `participants_snapshot`, `title_snapshot`, vote-roster summary, retry-attempt tracking. It is one row per publication attempt per scene, not one row per event.
+
+Two approaches were considered:
+
+- **Reuse `scene_log` by extending its schema** to carry publication metadata via additional columns (publication status enum, content_entries JSONB, etc.).
+- **New table `published_scenes`** with publication-specific schema and indices; `scene_log` left unchanged.
+
+## Decision
+
+The publication artifact lives in a new `published_scenes` table (and a companion `published_scene_votes` roster table per ADR `holomush-39a5f`). The `scene_log` table remains the per-plugin audit-history mirror, unmodified by Phase 6.
+
+The two tables occupy distinct conceptual roles:
+
+| Concern | `scene_log` (audit) | `published_scenes` (publication) |
+| ------- | ------------------- | -------------------------------- |
+| Cardinality | One row per scene IC event | One row per publication attempt |
+| Payload | BYTEA, encrypted per event | JSONB content_entries, plaintext (frozen at PUBLISHED) |
+| Mutability | Append-only event stream | Status transitions per attempt; content_entries set once on PUBLISHED |
+| Access surface | `PluginAuditService.QueryHistory` (membership-gated) | `SceneService.GetPublishedScene` / `GetPublicSceneArchive` |
+| Privacy model | Participant-only forever (INV-S9) | Participant-only while non-PUBLISHED; public when PUBLISHED |
+| Schema lineage | Mirrors host `events_audit` | Phase 6 native |
+
+The `scene log` command (participant audit-history replay) continues to read `scene_log` via `QueryHistory`. The `scene publish download` command (publication artifact) reads `published_scenes` via the participant-gated RPC. Neither surface implies the other.
+
+## Rationale
+
+**The two entities serve fundamentally different roles.** `scene_log` is the per-plugin mirror of the host's `events_audit` table — an append-only event stream with BYTEA-encrypted payloads, DEK references, and a schema driven by the event-bus codec. `published_scenes` is the immutable result of a participant-controlled vote: a structured snapshot frozen at the PUBLISHED transition. Conflating them would force every reader to discriminate between event rows and publication rows via a status column, and would couple two unrelated schema-evolution paths.
+
+**Schema shape diverges.** `scene_log` rows carry BYTEA payloads (encrypted per the crypto manifest), `dek_ref`/`dek_version` (FK-ish references to the DEK registry), and event-bus metadata (subject, type, timestamp, codec, schema_ver). `published_scenes` rows carry JSONB `content_entries` (plaintext, structured), `participants_snapshot` (JSONB frozen names), `title_snapshot`, `vote_window`/`cooloff_window` configuration, retry-attempt tracking, status enum, failure-reason enum. Adding the publication columns to `scene_log` would bloat a hot append-only table with cold reference data; adding event-bus columns to `published_scenes` would carry crypto liability onto the public surface.
+
+**Naming clarity for the command surface.** With distinct tables, `scene log` unambiguously means "the participant audit-history replay" (reads `scene_log`), and `scene publish` / `scene publish download` unambiguously means "the publication artifact" (reads `published_scenes`). The v2 spec's "Scene Log (Published)" naming was a load-bearing source of confusion — every reviewer asked "is that the same `scene_log` table?" and the answer is now unambiguously no.
+
+## Alternatives Considered
+
+**Option A: New `published_scenes` table (chosen).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Independent schema lifecycle; clean naming distinction; each table's access patterns and indices are tuned for its role; no crypto liability on the public surface |
+| Weaknesses | One additional table to maintain; one cross-table flow (the snapshot pipeline reads `scene_log`, writes `published_scenes.content_entries`) — but this happens once per attempt at a well-defined point |
+
+**Option B: Extend `scene_log` schema with publication columns + status discriminator.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | One table; the snapshot pipeline becomes a single UPDATE; SQL JOINs simpler |
+| Weaknesses | Two distinct concerns share schema; readers must discriminate by status; bloats a hot append-only table with cold publication metadata; entangles crypto-encrypted event rows with plaintext publication rows; future evolution of either concern is blocked by the other's constraints |
+
+**Option C: Same `scene_log` table, separate row type via JSON envelope.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | No schema change at all; everything is a JSON-payload row |
+| Weaknesses | Loses all type-safety on publication-specific fields (status enum, content_entries shape); SQL filters on publication state become JSON path traversals; query performance degrades; the existing crypto contract on `scene_log` (encrypted payloads) doesn't apply naturally to plaintext publication content |
+
+## Consequences
+
+- **Independent schema lifecycle.** Future schema changes to `scene_log` (e.g., AAD reshape, new DEK column for a crypto upgrade) do not affect `published_scenes`, and vice versa.
+- **Clearer naming.** "Publication" and "publish" reference `published_scenes`; "scene log" and "audit history" reference `scene_log`. The previously-ambiguous "Scene Log" (Published)" naming (v2 spec §1.5) is replaced by `PublishedScene` everywhere in Phase 6.
+- **Cost of duplication.** A read of "everything ever recorded for scene X" hits two tables — `scene_log` for raw events plus `published_scenes` for any publication artifact. This is conceptually correct: those are two different things. The snapshot pipeline at COOLOFF → PUBLISHED transition does cross the boundary (reads `scene_log`, writes `published_scenes.content_entries`) but only in one direction and only at one well-defined point.
+- **Tests do not share fixtures.** Audit-history tests use one schema and one access path; publication tests use another. Tests cannot accidentally cross-contaminate.
+
+## References
+
+- [Scenes Phase 6 design spec](../superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §2 (divergence table — v2 §1.5 renaming), §3.1, §3.3, §11.1 (snapshot reads from scene_log into published_scenes)
+- [Scenes Phase 6 implementation plan](../superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md) Task A1 (000008 migration)
+- [Scenes v2 design](../superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md) §1.5 (superseded naming)
+- Design bead `holomush-5rh.20` (brainstorm Q2 — publication-artifact rename)

--- a/docs/adr/holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md
+++ b/docs/adr/holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Participant-Gated and Public Scene Publication RPCs Use No Shared Code Path
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-qd3r5
+**Deciders:** HoloMUSH Contributors
+**Related:** [`holomush-c8a9`](holomush-c8a9-scene-privacy-plugin-code-enforcement.md), [`holomush-nt2d`](holomush-nt2d-participant-gate-pattern-generalized.md), [`holomush-c4jee`](holomush-c4jee-inv-p6-6-structural-enforcement.md)
+
+## Context
+
+Phase 6 introduces two read surfaces for the scene publication artifact:
+
+1. **Participant-gated reads** — `GetPublishedScene`, `DownloadPublishedScene`, `ListScenePublishAttempts` — return full state (metadata, vote progress, content if PUBLISHED) only to scene participants. INV-S9 (substrate-contract §4.1) requires plugin-code enforcement of the participant check; ABAC engine MUST NOT be in the read path. Pattern established by ADR `holomush-c8a9` and generalized by `holomush-nt2d`.
+
+2. **Public reads** — `GetPublicSceneArchive`, `DownloadPublicSceneArchive` — return the publication artifact (content + frozen participants snapshot + title) to anyone, but ONLY when `published_scenes.status == PUBLISHED`. Non-PUBLISHED rows return opaque `NOT_FOUND` to prevent leaking attempt-in-progress state to non-participants (INV-P6-8).
+
+The two surfaces share the same backing table (`published_scenes`) and serve content from the same JSONB `content_entries` column. The implementation question: should they share helper code?
+
+Two approaches were considered:
+
+- **Shared core helper** — `getPublishedSceneCore(ctx, id, gatePolicy)` with `gatePolicy ∈ {participant, public}`, called by both handler pairs. Single read path, minimal duplication.
+- **Structurally separate handlers** — `GetPublishedScene` and `GetPublicSceneArchive` are independent functions with no shared helpers beyond read-only store methods. Distinct response assemblers, distinct proto request/response messages, distinct error code surfaces.
+
+## Decision
+
+The participant-gated and public RPC pairs are implemented as **structurally separate handlers with no shared gate helper, no shared response assembler, and no flag-driven routing**. Each handler reads the store directly via `GetPublishedSceneHeader` and (conditionally) `GetPublishedSceneContent`, but the call graph from RPC entry point to response assembly is distinct between the two pairs.
+
+The proto contract reinforces the separation:
+
+- Distinct RPC names (`GetPublishedScene` vs `GetPublicSceneArchive`).
+- Distinct request types (the participant request carries `caller_character_id`; the public request does not).
+- Distinct response types (the participant response includes vote progress + per-attempt metadata; the public response includes only the publication artifact's frozen fields).
+
+The implementation is constrained:
+
+- There is no `getPublishedSceneCore(ctx, id, gatePolicy)` helper.
+- There is no shared `assembleResponse(...)` that branches on policy.
+- The two read paths may evolve independently (e.g., the public path may add caching; the participant path may add per-vote-state filtering) without coupling.
+
+Acceptable duplication: both handlers call `GetPublishedSceneHeader` and `GetPublishedSceneContent` (read-only store methods), and both encode their respective response proto messages. The duplication is at the assembly layer, not the read layer.
+
+## Rationale
+
+**The gate must be structural, not behavioral.** INV-S9 enforces that no ABAC override exists for scene reads. A shared helper with a `gatePolicy` flag turns the participant/public boundary into a runtime choice — a flag flip during refactor (or a subtle bug in flag derivation) silently leaks private content. Separate handlers make the access tier visible at the call site: anyone reading `GetPublicSceneArchive` can see immediately that no participant check fires; anyone reading `GetPublishedScene` can see the `IsParticipant` call inline.
+
+**The cost of duplication is paid where it surfaces correctly.** Adding a new access tier (guild-gated reads, time-windowed reads) is design-time work that should require new handler code — not a runtime parameter passed through an existing helper. Code review can verify the gate inline without tracing through a shared helper's branches. The two handlers grow independently: one may add per-vote-state filtering for participants; the other may add anonymous read caching. Coupling would block each from evolving.
+
+**Combines with structural INV-P6-6 enforcement.** Per ADR `holomush-c4jee`, the no-ABAC-engine invariant is verified by AST + reflect structural checks. Together with this ADR's no-shared-path rule, INV-S9 regression resistance becomes a multi-layer property: even if one layer is compromised by a future refactor, the other catches it.
+
+## Alternatives Considered
+
+**Option A: Structurally separate handlers with no shared gate helper (chosen).**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Gate is a structural property of each handler; flag-flip refactor cannot leak content; access tier is visible at the call site; each handler may evolve independently |
+| Weaknesses | Visible code duplication at the response-assembly layer; new access tier requires a new handler (paid at design time, not runtime) |
+
+**Option B: Shared `getPublishedSceneCore(ctx, id, gatePolicy)` helper called with policy flag.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Minimal duplication; single read path; new access tier is a new flag value |
+| Weaknesses | A flag flip during refactor silently turns a participant-only RPC public; the gate becomes a runtime parameter rather than a structural property; INV-S9 enforcement depends on every caller passing the correct flag |
+
+**Option C: Middleware-style decorator wrapping a single core read.**
+
+| Aspect | Assessment |
+| ------ | ---------- |
+| Strengths | Common in HTTP frameworks; familiar to web developers; gate logic is one composable layer |
+| Weaknesses | The core read remains a single function — same flag-driven-gate risk as Option B once any decorator is bypassed; the proto contract still needs distinct request/response messages; complexity added for negligible reuse |
+
+## Consequences
+
+- **Regression resistance.** A future contributor cannot accidentally publish private content by refactoring a shared helper. The gate is a structural property of the handler, not a runtime parameter.
+- **Independent evolution.** Adding a third access tier (e.g., guild-gated reads) requires a new handler pair, not a new flag value. The cost is felt at design time, where it surfaces correctly; not at runtime, where flag-routing bugs would surface.
+- **Explicit code duplication.** The two assembler functions and response message types are visibly distinct, accepted as the cost of regression resistance. Code review can verify the gate is present in each participant handler without tracing through a shared helper's branches.
+- **Structural INV-P6-6 enforcement.** Combined with ADR `holomush-c4jee` (AST import scan + reflect field check), this decision makes "no ABAC engine in the participant read path" enforceable at CI time without runtime injection seams.
+
+## References
+
+- [Scenes Phase 6 design spec](../superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §5.1, §9.1, §9.2
+- [Scenes Phase 6 implementation plan](../superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md) Task B5 (GetPublishedScene), Task C4 (GetPublicSceneArchive)
+- [Substrate-contract spec](../superpowers/specs/2026-05-16-social-spaces-substrate-contract.md) INV-S9
+- Design bead `holomush-5rh.20` (brainstorm Q8 — read access by status)

--- a/docs/superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md
+++ b/docs/superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md
@@ -1,0 +1,3390 @@
+# Scenes Phase 6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `dev-flow:subagent-driven-development` (recommended) or `dev-flow:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 6 of the scenes rework — publish vote state machine, publication artifact distinct from the existing audit scene_log, two-pair RPC surface (participant INV-S9-gated and public status-gated), snapshot pipeline, three renderer formats, and the `scene log` / `scene log export` commands folded in from `holomush-cb4x`.
+
+**Architecture:** New `published_scenes` table + `published_scene_votes` roster table; nine new RPCs split across two structurally separate handler groups so INV-S9 cannot regress via refactor; package-level metric stubs matching the existing Phase 2 pattern; vote events emitted as `sensitivity:never` IC stream notices joining the `scene_join_ic` family.
+
+**Tech Stack:** Go 1.24+, PostgreSQL via pgx/v5, JetStream via NATS, gRPC via hashicorp/go-plugin, Ginkgo/Gomega for integration + E2E, testify for unit, testcontainers-go for PG, mockery for unit mocks.
+
+**Spec:** [`docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md`](../specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md)
+
+**Beads:** Implementation tracker `holomush-5rh.15`; design tracker `holomush-5rh.20`; folds in `holomush-cb4x`.
+
+---
+
+## File Structure
+
+### New files (`plugins/core-scenes/`)
+
+| Path | Purpose |
+| ---- | ------- |
+| `migrations/000008_scene_publication.up.sql` + `.down.sql` | `published_scenes` + `published_scene_votes` tables + indexes |
+| `migrations/000009_scene_max_publish_attempts.up.sql` + `.down.sql` | `scenes.max_publish_attempts` column |
+| `publish_types.go` | Domain types (`PublishedScene`, `PublishedSceneStatus`, `PublishFailureReason`, `PublishedSceneVote`, `Entry`, `EntryKind`) |
+| `publish_store.go` | Store methods for `published_scenes` + `published_scene_votes` + `ReadSceneLogForSnapshot` |
+| `publish_state.go` | State machine helpers (transition guards, vote tally, resolution check) |
+| `publish_service.go` | RPC handlers for the 9 new RPCs |
+| `publish_snapshot.go` | Snapshot pipeline (COOLOFF → PUBLISHED) |
+| `publish_render.go` | Markdown / plain-text / jsonl renderers + entry shape |
+| `publish_events.go` | Event emission helpers for the 6 new IC notice types |
+| `publish_scheduler.go` | Vote-window timeout + cool-off expiry ticker integration |
+| `publish_types_test.go` | Unit tests for types |
+| `publish_state_test.go` | State machine unit tests |
+| `publish_vote_tally_test.go` | Tally unit tests |
+| `publish_roster_test.go` | Roster freeze unit tests |
+| `publish_render_test.go` | Renderer unit tests |
+| `publish_state_integration_test.go` | Lifecycle integration tests |
+| `publish_snapshot_integration_test.go` | Snapshot atomicity + decrypt tests |
+| `publish_resolver_integration_test.go` | INV-P6-7 resolver no-leak meta test |
+| `publish_event_emission_integration_test.go` | Event emission integration tests |
+| `service_publish_gate_test.go` | INV-S9 call-stack tripwire tests |
+| `service_public_archive_test.go` | INV-P6-8 opacity tests |
+| `service_privacy_block_test.go` | INV-P6-9 triple-signal tests |
+| `commands_resolve_test.go` | resolveSceneRef unit tests |
+
+### Modified files
+
+| Path | Change |
+| ---- | ------ |
+| `api/proto/holomush/scene/v1/scene.proto` | Add 9 RPC methods + new request/response messages |
+| `pkg/proto/holomush/scene/v1/*.pb.go` | Regenerated from `task proto` |
+| `plugins/core-scenes/plugin.yaml` | Add 6 `crypto.emits` entries (sensitivity:never) + 3 ABAC policies + new command help blocks |
+| `plugins/core-scenes/commands.go` | Add `scene publish *` + `scene log *` subcommand handlers + `resolveSceneRef` helper |
+| `plugins/core-scenes/metrics.go` | Add 7 package-level no-op stub functions per spec §13.1 |
+| `plugins/core-scenes/main.go` | Wire `publish_scheduler` into plugin lifecycle |
+| `plugins/core-scenes/service.go` | Add public RPCs to `SceneServiceImpl` (delegating to `publish_service.go`) |
+| `plugins/core-scenes/resolver.go` | UNCHANGED (INV-P6-7 forbids adding content attrs); resolver_test.go gets regression-lock meta test |
+
+### Cross-package new test files
+
+| Path | Purpose |
+| ---- | ------- |
+| `test/integration/scenes/publish_e2e_test.go` | Full-stack E2E happy + sad paths |
+| `test/integration/scenes/publish_history_scope_e2e_test.go` | iwzt floor interaction with publish events |
+| `test/meta/scenes_phase6_invariants_test.go` | INV-P6-1..10 coverage enumeration |
+
+---
+
+## Phase A — Schema, Types, Store, State Machine
+
+Phase A produces the foundational substrate. By end of Phase A, the migrations apply cleanly, domain types compile, the store can CRUD `published_scenes` + `published_scene_votes`, and the state machine helpers exist with unit-test coverage. No RPCs or commands yet.
+
+**Spec coverage:** §3 Domain Model, §4 State Machine, §3.3 Migration, §3.4 Configuration.
+
+### Task A1: Migration 000008 — `published_scenes` + `published_scene_votes` tables
+
+**Files:**
+
+- Create: `plugins/core-scenes/migrations/000008_scene_publication.up.sql`
+- Create: `plugins/core-scenes/migrations/000008_scene_publication.down.sql`
+
+**Spec ref:** §3.3
+
+- [ ] **Step 1: Write the up migration**
+
+Content of `000008_scene_publication.up.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Phase 6 (holomush-5rh.15): publication artifact distinct from the
+-- audit scene_log table. See spec section 3.3.
+
+CREATE TABLE IF NOT EXISTS published_scenes (
+    id                     TEXT        PRIMARY KEY,
+    scene_id               TEXT        NOT NULL,
+    attempt_number         INTEGER     NOT NULL,
+    status                 TEXT        NOT NULL CHECK (status IN
+                              ('COLLECTING','COOLOFF','PUBLISHED','ATTEMPT_FAILED')),
+    initiated_by           TEXT        NOT NULL,
+    initiated_at           TIMESTAMPTZ NOT NULL,
+    cooloff_started_at     TIMESTAMPTZ,
+    resolved_at            TIMESTAMPTZ,
+    vote_window            INTERVAL    NOT NULL,
+    cooloff_window         INTERVAL    NOT NULL,
+    max_attempts_snapshot  INTEGER     NOT NULL,
+    content_entries        JSONB,
+    title_snapshot         TEXT,
+    participants_snapshot  JSONB,
+    published_at           TIMESTAMPTZ,
+    failure_reason         TEXT        CHECK (failure_reason IS NULL OR failure_reason IN
+                              ('ANY_NO','TIMEOUT','WITHDRAWN',
+                               'SNAPSHOT_DECRYPT_FAILED','SNAPSHOT_RENDER_FAILED',
+                               'COOLOFF_INVARIANT_BROKEN'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_one_active_per_scene
+    ON published_scenes(scene_id) WHERE status IN ('COLLECTING','COOLOFF');
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_one_published_per_scene
+    ON published_scenes(scene_id) WHERE status = 'PUBLISHED';
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_attempt_unique
+    ON published_scenes(scene_id, attempt_number);
+CREATE INDEX IF NOT EXISTS published_scenes_scene_status
+    ON published_scenes(scene_id, status);
+
+CREATE TABLE IF NOT EXISTS published_scene_votes (
+    published_scene_id  TEXT        NOT NULL,
+    character_id        TEXT        NOT NULL,
+    vote                BOOLEAN,
+    voted_at            TIMESTAMPTZ,
+    last_changed_at     TIMESTAMPTZ,
+    PRIMARY KEY (published_scene_id, character_id)
+);
+
+CREATE INDEX IF NOT EXISTS published_scene_votes_pending
+    ON published_scene_votes(published_scene_id) WHERE vote IS NULL;
+```
+
+- [ ] **Step 2: Write the down migration**
+
+Content of `000008_scene_publication.down.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+DROP INDEX IF EXISTS published_scene_votes_pending;
+DROP TABLE IF EXISTS published_scene_votes;
+
+DROP INDEX IF EXISTS published_scenes_scene_status;
+DROP INDEX IF EXISTS published_scenes_attempt_unique;
+DROP INDEX IF EXISTS published_scenes_one_published_per_scene;
+DROP INDEX IF EXISTS published_scenes_one_active_per_scene;
+DROP TABLE IF EXISTS published_scenes;
+```
+
+- [ ] **Step 3: Run migration lint**
+
+Run: `task lint:migrations`
+Expected: PASS (logic-free SQL only; idempotent IF NOT EXISTS).
+
+- [ ] **Step 4: Run plugin migration smoke test**
+
+Run: `task test:int -- ./plugins/core-scenes/ -run TestStoreOpensWithMigrations`
+Expected: PASS — `NewSceneStore` opens against a fresh DB and applies all migrations including 000008. (This test pre-exists in `store_integration_test.go`; it will pick up the new migration automatically.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-migrations): add 000008 published_scenes + published_scene_votes
+
+Phase 6 schema for publication artifact distinct from audit scene_log
+(holomush-5rh.15). See spec section 3.3."
+```
+
+### Task A2: Migration 000009 — `scenes.max_publish_attempts` column
+
+**Files:**
+
+- Create: `plugins/core-scenes/migrations/000009_scene_max_publish_attempts.up.sql`
+- Create: `plugins/core-scenes/migrations/000009_scene_max_publish_attempts.down.sql`
+
+**Spec ref:** §3.4
+
+- [ ] **Step 1: Write the up migration**
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Phase 6: per-scene configurable max publish attempts. Default 3;
+-- admin can bump via ExtendScenePublishVoteAttempts RPC. See spec §3.4.
+
+ALTER TABLE scenes
+    ADD COLUMN IF NOT EXISTS max_publish_attempts INTEGER NOT NULL DEFAULT 3;
+```
+
+- [ ] **Step 2: Write the down migration**
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+ALTER TABLE scenes DROP COLUMN IF EXISTS max_publish_attempts;
+```
+
+- [ ] **Step 3: Verify migration applies**
+
+Run: `task test:int -- ./plugins/core-scenes/ -run TestStoreOpensWithMigrations`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-migrations): add 000009 scenes.max_publish_attempts
+
+Per-scene retry budget for publish vote attempts (holomush-5rh.15)."
+```
+
+### Task A3: Proto contract — extend `holomush.scene.v1.SceneService`
+
+**Files:**
+
+- Modify: `api/proto/holomush/scene/v1/scene.proto`
+
+**Spec ref:** §5
+
+- [ ] **Step 1: Add the 9 new RPC declarations**
+
+Append to the `service SceneService` block in `scene.proto`:
+
+```protobuf
+  // Phase 6 publication RPCs. See spec section 5.
+  rpc StartScenePublish(StartScenePublishRequest) returns (StartScenePublishResponse);
+  rpc CastPublishSceneVote(CastPublishSceneVoteRequest) returns (CastPublishSceneVoteResponse);
+  rpc WithdrawScenePublish(WithdrawScenePublishRequest) returns (WithdrawScenePublishResponse);
+  rpc GetPublishedScene(GetPublishedSceneRequest) returns (GetPublishedSceneResponse);
+  rpc DownloadPublishedScene(DownloadPublishedSceneRequest) returns (DownloadPublishedSceneResponse);
+  rpc ListScenePublishAttempts(ListScenePublishAttemptsRequest) returns (ListScenePublishAttemptsResponse);
+  rpc GetPublicSceneArchive(GetPublicSceneArchiveRequest) returns (GetPublicSceneArchiveResponse);
+  rpc DownloadPublicSceneArchive(DownloadPublicSceneArchiveRequest) returns (DownloadPublicSceneArchiveResponse);
+  rpc ExtendScenePublishVoteAttempts(ExtendScenePublishVoteAttemptsRequest) returns (ExtendScenePublishVoteAttemptsResponse);
+```
+
+- [ ] **Step 2: Add request/response messages**
+
+Append new messages to `scene.proto` (full message definitions; spec §5 enumerates field requirements):
+
+```protobuf
+message StartScenePublishRequest {
+  string scene_id = 1;
+}
+message StartScenePublishResponse {
+  string published_scene_id = 1;
+  int32 attempt_number = 2;
+}
+
+message CastPublishSceneVoteRequest {
+  string published_scene_id = 1;
+  bool vote = 2;
+}
+message CastPublishSceneVoteResponse {
+  bool is_change = 1;
+}
+
+message WithdrawScenePublishRequest {
+  string published_scene_id = 1;
+}
+message WithdrawScenePublishResponse {}
+
+message PublishedSceneEntry {
+  string speaker = 1;
+  string kind = 2;     // "pose" | "say" | "emit"
+  string content = 3;
+}
+
+message PublishedSceneVoteSummary {
+  int32 yes = 1;
+  int32 no = 2;
+  int32 pending = 3;
+}
+
+message GetPublishedSceneRequest {
+  string published_scene_id = 1;
+}
+message GetPublishedSceneResponse {
+  string id = 1;
+  string scene_id = 2;
+  int32 attempt_number = 3;
+  string status = 4;
+  string failure_reason = 5;       // empty unless ATTEMPT_FAILED
+  PublishedSceneVoteSummary tally = 6;
+  repeated PublishedSceneEntry content_entries = 7;  // populated only when PUBLISHED
+  string title_snapshot = 8;
+  repeated string participants_snapshot = 9;
+  int64 initiated_at_unix_ns = 10;
+  int64 cooloff_started_at_unix_ns = 11;
+  int64 resolved_at_unix_ns = 12;
+  int64 published_at_unix_ns = 13;
+}
+
+message DownloadPublishedSceneRequest {
+  string published_scene_id = 1;
+  string format = 2;   // "markdown" | "plain_text" | "jsonl"
+}
+message DownloadPublishedSceneResponse {
+  bytes content = 1;
+  string mime_type = 2;
+}
+
+message ListScenePublishAttemptsRequest {
+  string scene_id = 1;
+}
+message ListScenePublishAttemptsResponse {
+  repeated PublishedSceneSummary attempts = 1;
+}
+message PublishedSceneSummary {
+  string id = 1;
+  int32 attempt_number = 2;
+  string status = 3;
+  string failure_reason = 4;
+  int64 initiated_at_unix_ns = 5;
+  int64 resolved_at_unix_ns = 6;
+}
+
+message GetPublicSceneArchiveRequest {
+  string published_scene_id = 1;
+}
+message GetPublicSceneArchiveResponse {
+  string id = 1;
+  string title_snapshot = 2;
+  repeated string participants_snapshot = 3;
+  repeated PublishedSceneEntry content_entries = 4;
+  int64 published_at_unix_ns = 5;
+}
+
+message DownloadPublicSceneArchiveRequest {
+  string published_scene_id = 1;
+  string format = 2;
+}
+message DownloadPublicSceneArchiveResponse {
+  bytes content = 1;
+  string mime_type = 2;
+}
+
+message ExtendScenePublishVoteAttemptsRequest {
+  string scene_id = 1;
+  int32 additional = 2;
+}
+message ExtendScenePublishVoteAttemptsResponse {
+  int32 new_max = 1;
+}
+```
+
+- [ ] **Step 3: Regenerate Go bindings**
+
+Run: `task proto`
+Expected: `pkg/proto/holomush/scene/v1/scene.pb.go` + `scene_grpc.pb.go` regenerated cleanly.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `task build`
+Expected: PASS — generated bindings compile; existing handlers may need stub implementations to satisfy the interface (added in Phase B; for now add `panic("not implemented in phase A")` stubs to `service.go` per Step 5).
+
+- [ ] **Step 5: Add not-yet-implemented stubs to `SceneServiceImpl`**
+
+In `plugins/core-scenes/service.go`, append after the existing handlers (line 273 region):
+
+```go
+// Phase 6 RPC stubs — implemented in Phase B (publish_service.go).
+// Present here only so the generated server interface compiles.
+
+func (s *SceneServiceImpl) StartScenePublish(ctx context.Context, req *scenev1.StartScenePublishRequest) (*scenev1.StartScenePublishResponse, error) {
+    return nil, status.Error(codes.Unimplemented, "not yet implemented")
+}
+// Repeat for each of the other 8 RPCs — same shape.
+```
+
+- [ ] **Step 6: Run vet**
+
+Run: `task lint`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(scene-proto): add 9 Phase 6 publication RPCs + messages
+
+Proto contract for StartScenePublish, CastPublishSceneVote,
+WithdrawScenePublish, GetPublishedScene, DownloadPublishedScene,
+ListScenePublishAttempts, GetPublicSceneArchive,
+DownloadPublicSceneArchive, ExtendScenePublishVoteAttempts.
+Stub implementations panic with Unimplemented; real handlers land in
+Phase B (holomush-5rh.15 spec section 5)."
+```
+
+### Task A4: Domain types (`publish_types.go`)
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_types.go`
+- Create: `plugins/core-scenes/publish_types_test.go`
+
+**Spec ref:** §3.1, §3.2
+
+- [ ] **Step 1: Write failing tests in `publish_types_test.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestPublishedSceneStatusIsValid(t *testing.T) {
+    t.Parallel()
+    cases := []struct {
+        name  string
+        s     PublishedSceneStatus
+        valid bool
+    }{
+        {"COLLECTING valid", StatusCollecting, true},
+        {"COOLOFF valid", StatusCoolOff, true},
+        {"PUBLISHED valid", StatusPublished, true},
+        {"ATTEMPT_FAILED valid", StatusAttemptFailed, true},
+        {"empty invalid", PublishedSceneStatus(""), false},
+        {"junk invalid", PublishedSceneStatus("WAT"), false},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            assert.Equal(t, tc.valid, tc.s.IsValid())
+        })
+    }
+}
+
+func TestPublishFailureReasonIsValid(t *testing.T) {
+    t.Parallel()
+    cases := []struct {
+        name  string
+        r     PublishFailureReason
+        valid bool
+    }{
+        {"ANY_NO valid", FailureAnyNo, true},
+        {"TIMEOUT valid", FailureTimeout, true},
+        {"WITHDRAWN valid", FailureWithdrawn, true},
+        {"SNAPSHOT_DECRYPT_FAILED valid", FailureSnapshotDecryptFailed, true},
+        {"SNAPSHOT_RENDER_FAILED valid", FailureSnapshotRenderFailed, true},
+        {"COOLOFF_INVARIANT_BROKEN valid", FailureCoolOffInvariantBroken, true},
+        {"empty invalid", PublishFailureReason(""), false},
+        {"junk invalid", PublishFailureReason("WAT"), false},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            assert.Equal(t, tc.valid, tc.r.IsValid())
+        })
+    }
+}
+
+func TestEntryKindIsValid(t *testing.T) {
+    t.Parallel()
+    assert.True(t, EntryKindPose.IsValid())
+    assert.True(t, EntryKindSay.IsValid())
+    assert.True(t, EntryKindEmit.IsValid())
+    assert.False(t, EntryKind("ooc").IsValid(), "ooc MUST be excluded from publication content per spec §12")
+    assert.False(t, EntryKind("").IsValid())
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `task test -- -run "TestPublishedSceneStatusIsValid|TestPublishFailureReasonIsValid|TestEntryKindIsValid" ./plugins/core-scenes/`
+Expected: FAIL (`undefined: PublishedSceneStatus`, etc.).
+
+- [ ] **Step 3: Implement `publish_types.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "time"
+
+    "github.com/holomush/holomush/internal/pgnanos"
+)
+
+// PublishedSceneStatus is the publish-attempt state machine status per
+// spec §4. See the transition table at §4.1 for legal transitions.
+type PublishedSceneStatus string
+
+const (
+    StatusCollecting    PublishedSceneStatus = "COLLECTING"
+    StatusCoolOff       PublishedSceneStatus = "COOLOFF"
+    StatusPublished     PublishedSceneStatus = "PUBLISHED"
+    StatusAttemptFailed PublishedSceneStatus = "ATTEMPT_FAILED"
+)
+
+func (s PublishedSceneStatus) IsValid() bool {
+    switch s {
+    case StatusCollecting, StatusCoolOff, StatusPublished, StatusAttemptFailed:
+        return true
+    }
+    return false
+}
+
+func (s PublishedSceneStatus) IsTerminal() bool {
+    return s == StatusPublished || s == StatusAttemptFailed
+}
+
+// PublishFailureReason explains why an attempt reached ATTEMPT_FAILED.
+// Set ONLY on terminal ATTEMPT_FAILED rows. See spec §4.1 and §11.4.
+type PublishFailureReason string
+
+const (
+    FailureAnyNo                  PublishFailureReason = "ANY_NO"
+    FailureTimeout                PublishFailureReason = "TIMEOUT"
+    FailureWithdrawn              PublishFailureReason = "WITHDRAWN"
+    FailureSnapshotDecryptFailed  PublishFailureReason = "SNAPSHOT_DECRYPT_FAILED"
+    FailureSnapshotRenderFailed   PublishFailureReason = "SNAPSHOT_RENDER_FAILED"
+    FailureCoolOffInvariantBroken PublishFailureReason = "COOLOFF_INVARIANT_BROKEN"
+)
+
+func (r PublishFailureReason) IsValid() bool {
+    switch r {
+    case FailureAnyNo, FailureTimeout, FailureWithdrawn,
+        FailureSnapshotDecryptFailed, FailureSnapshotRenderFailed,
+        FailureCoolOffInvariantBroken:
+        return true
+    }
+    return false
+}
+
+// EntryKind discriminates the three IC content kinds that survive into
+// a published scene. OOC and ops events are EXCLUDED — see spec §12 and
+// ADR holomush-sb3n.
+type EntryKind string
+
+const (
+    EntryKindPose EntryKind = "pose"
+    EntryKindSay  EntryKind = "say"
+    EntryKindEmit EntryKind = "emit"
+)
+
+func (k EntryKind) IsValid() bool {
+    switch k {
+    case EntryKindPose, EntryKindSay, EntryKindEmit:
+        return true
+    }
+    return false
+}
+
+// Entry is one row in the published_scenes.content_entries JSONB array.
+// Frozen at PUBLISHED transition; immutable thereafter.
+type Entry struct {
+    Speaker string    `json:"speaker"`
+    Kind    EntryKind `json:"kind"`
+    Content string    `json:"content"`
+}
+
+// PublishedScene is the in-memory representation of a published_scenes row.
+type PublishedScene struct {
+    ID                  string
+    SceneID             string
+    AttemptNumber       int
+    Status              PublishedSceneStatus
+    InitiatedBy         string
+    InitiatedAt         pgnanos.Time
+    CoolOffStartedAt    *pgnanos.Time
+    ResolvedAt          *pgnanos.Time
+    VoteWindow          time.Duration
+    CoolOffWindow       time.Duration
+    MaxAttemptsSnapshot int
+    ContentEntries      []Entry        // nil unless PUBLISHED
+    TitleSnapshot       *string
+    ParticipantsSnapshot []string
+    PublishedAt         *pgnanos.Time
+    FailureReason       *PublishFailureReason
+}
+
+// PublishedSceneVote is one row in published_scene_votes — one voter's
+// state on one attempt. Roster is frozen at attempt creation.
+type PublishedSceneVote struct {
+    PublishedSceneID string
+    CharacterID      string
+    Vote             *bool          // nil = pending; *true / *false = cast
+    VotedAt          *pgnanos.Time  // first-cast timestamp
+    LastChangedAt    *pgnanos.Time  // updated on every cast
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `task test -- -run "TestPublishedSceneStatusIsValid|TestPublishFailureReasonIsValid|TestEntryKindIsValid" ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-types): add Phase 6 publish domain types
+
+PublishedSceneStatus + IsValid/IsTerminal, PublishFailureReason +
+IsValid, EntryKind + IsValid, Entry, PublishedScene, PublishedSceneVote.
+Spec section 3.1, 3.2 (holomush-5rh.15)."
+```
+
+### Task A5: Store layer — attempt + roster lifecycle
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_store.go`
+- Test: `plugins/core-scenes/store_integration_test.go` (extend existing file)
+
+**Spec ref:** §3.3, §4
+
+- [ ] **Step 1: Write failing integration tests**
+
+Append to `plugins/core-scenes/store_integration_test.go`:
+
+```go
+var _ = Describe("Publish store — attempt + roster lifecycle", func() {
+    It("creates a published_scenes row with COLLECTING status and frozen roster", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        sceneID := newULID()
+        ownerID := newULID()
+        memberID := newULID()
+        invitedID := newULID()
+        mustCreateScene(store, sceneID, ownerID, string(SceneVisibilityOpen))
+        mustAddParticipant(store, sceneID, memberID, "member")
+        mustAddParticipant(store, sceneID, invitedID, "invited")
+
+        pub, err := store.CreatePublishAttempt(ctx, CreatePublishAttemptInput{
+            SceneID:        sceneID,
+            AttemptNumber:  1,
+            InitiatedBy:    ownerID,
+            VoteWindow:     7 * 24 * time.Hour,
+            CoolOffWindow:  30 * time.Minute,
+            MaxAttempts:    3,
+        })
+        Expect(err).NotTo(HaveOccurred())
+        Expect(pub.Status).To(Equal(StatusCollecting))
+        Expect(pub.AttemptNumber).To(Equal(1))
+
+        voters, err := store.ListPublishVoters(ctx, pub.ID)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(voters).To(HaveLen(2), "roster must include owner+member, NOT invited (INV-P6-1)")
+        voterIDs := make(map[string]bool, len(voters))
+        for _, v := range voters {
+            voterIDs[v.CharacterID] = true
+            Expect(v.Vote).To(BeNil(), "fresh roster row MUST start with vote=nil (pending)")
+        }
+        Expect(voterIDs[ownerID]).To(BeTrue())
+        Expect(voterIDs[memberID]).To(BeTrue())
+        Expect(voterIDs[invitedID]).To(BeFalse(), "invited role MUST be excluded — INV-P6-1")
+    })
+
+    It("rejects a duplicate active attempt for the same scene", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        sceneID := newULID()
+        ownerID := newULID()
+        mustCreateScene(store, sceneID, ownerID, string(SceneVisibilityOpen))
+
+        _, err := store.CreatePublishAttempt(ctx, CreatePublishAttemptInput{
+            SceneID: sceneID, AttemptNumber: 1, InitiatedBy: ownerID,
+            VoteWindow: 7 * 24 * time.Hour, CoolOffWindow: 30 * time.Minute, MaxAttempts: 3,
+        })
+        Expect(err).NotTo(HaveOccurred())
+
+        _, err = store.CreatePublishAttempt(ctx, CreatePublishAttemptInput{
+            SceneID: sceneID, AttemptNumber: 2, InitiatedBy: ownerID,
+            VoteWindow: 7 * 24 * time.Hour, CoolOffWindow: 30 * time.Minute, MaxAttempts: 3,
+        })
+        Expect(err).To(HaveOccurred())
+        Expect(errutil.MatchCode(err, "SCENE_PUBLISH_ALREADY_ACTIVE")).To(BeTrue())
+    })
+})
+```
+
+(`mustAddParticipant` is a helper similar to existing `mustCreateScene`; if not present, add a small helper inline in the test file.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test:int -- -ginkgo.focus="Publish store" ./plugins/core-scenes/`
+Expected: FAIL (`undefined: CreatePublishAttempt`, etc.).
+
+- [ ] **Step 3: Implement `publish_store.go` — `CreatePublishAttempt` + `ListPublishVoters`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "context"
+    "errors"
+    "time"
+
+    "github.com/holomush/holomush/internal/pgnanos"
+    "github.com/holomush/holomush/pkg/errutil"
+    "github.com/holomush/holomush/pkg/oops"
+    "github.com/jackc/pgx/v5"
+)
+
+type CreatePublishAttemptInput struct {
+    SceneID       string
+    AttemptNumber int
+    InitiatedBy   string
+    VoteWindow    time.Duration
+    CoolOffWindow time.Duration
+    MaxAttempts   int
+}
+
+// CreatePublishAttempt creates a published_scenes row in COLLECTING
+// status and seeds published_scene_votes from the scene's owner+member
+// participants in a single transaction. The unique partial index
+// published_scenes_one_active_per_scene enforces "at most one active
+// attempt per scene". See spec §3.3, §4.1.
+func (s *SceneStore) CreatePublishAttempt(ctx context.Context, in CreatePublishAttemptInput) (*PublishedScene, error) {
+    ctx, span := startSpan(ctx, "scene.store.create_publish_attempt",
+        attribute.String("scene_id", in.SceneID))
+    defer span.End()
+
+    id := newULID()
+    initiatedAt := time.Now()
+
+    tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+    if err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_TX_BEGIN_FAILED").Wrap(err)
+    }
+    defer func() { _ = tx.Rollback(ctx) }()
+
+    // Insert the attempt; unique index catches concurrent / duplicate active.
+    _, err = tx.Exec(ctx, `
+        INSERT INTO published_scenes (
+            id, scene_id, attempt_number, status, initiated_by, initiated_at,
+            vote_window, cooloff_window, max_attempts_snapshot
+        ) VALUES ($1, $2, $3, 'COLLECTING', $4, $5, $6, $7, $8)
+    `, id, in.SceneID, in.AttemptNumber, in.InitiatedBy, initiatedAt,
+        in.VoteWindow, in.CoolOffWindow, in.MaxAttempts)
+    if err != nil {
+        if isUniqueViolation(err, "published_scenes_one_active_per_scene") {
+            return nil, oops.Code("SCENE_PUBLISH_ALREADY_ACTIVE").
+                With("scene_id", in.SceneID).Wrap(err)
+        }
+        if isUniqueViolation(err, "published_scenes_one_published_per_scene") {
+            return nil, oops.Code("SCENE_PUBLISH_ALREADY_PUBLISHED").
+                With("scene_id", in.SceneID).Wrap(err)
+        }
+        if isUniqueViolation(err, "published_scenes_attempt_unique") {
+            return nil, oops.Code("SCENE_PUBLISH_ATTEMPT_NUMBER_TAKEN").
+                With("scene_id", in.SceneID).
+                With("attempt_number", in.AttemptNumber).Wrap(err)
+        }
+        return nil, oops.Code("SCENE_PUBLISH_CREATE_FAILED").Wrap(err)
+    }
+
+    // Seed roster from owner+member participants (NOT invited — INV-P6-1).
+    _, err = tx.Exec(ctx, `
+        INSERT INTO published_scene_votes (published_scene_id, character_id)
+        SELECT $1, character_id FROM scene_participants
+        WHERE scene_id = $2 AND role IN ('owner', 'member')
+    `, id, in.SceneID)
+    if err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_SEED_ROSTER_FAILED").Wrap(err)
+    }
+
+    // Verify roster non-empty — fail closed.
+    var rosterSize int
+    if err := tx.QueryRow(ctx,
+        `SELECT count(*) FROM published_scene_votes WHERE published_scene_id = $1`,
+        id).Scan(&rosterSize); err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_ROSTER_CHECK_FAILED").Wrap(err)
+    }
+    if rosterSize == 0 {
+        return nil, oops.Code("SCENE_PUBLISH_NO_ELIGIBLE_VOTERS").
+            With("scene_id", in.SceneID).
+            Errorf("scene has no owner/member participants")
+    }
+
+    if err := tx.Commit(ctx); err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_COMMIT_FAILED").Wrap(err)
+    }
+
+    return &PublishedScene{
+        ID:                  id,
+        SceneID:             in.SceneID,
+        AttemptNumber:       in.AttemptNumber,
+        Status:              StatusCollecting,
+        InitiatedBy:         in.InitiatedBy,
+        InitiatedAt:         pgnanos.From(initiatedAt),
+        VoteWindow:          in.VoteWindow,
+        CoolOffWindow:       in.CoolOffWindow,
+        MaxAttemptsSnapshot: in.MaxAttempts,
+    }, nil
+}
+
+// ListPublishVoters returns all voter rows for an attempt, including
+// pending (vote=nil) rows. Used by the resolution check and observability.
+func (s *SceneStore) ListPublishVoters(ctx context.Context, publishedSceneID string) ([]PublishedSceneVote, error) {
+    rows, err := s.pool.Query(ctx, `
+        SELECT published_scene_id, character_id, vote, voted_at, last_changed_at
+        FROM published_scene_votes
+        WHERE published_scene_id = $1
+        ORDER BY character_id
+    `, publishedSceneID)
+    if err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_LIST_VOTERS_FAILED").Wrap(err)
+    }
+    defer rows.Close()
+    var out []PublishedSceneVote
+    for rows.Next() {
+        var v PublishedSceneVote
+        var votedAt, lastChangedAt *time.Time
+        if err := rows.Scan(&v.PublishedSceneID, &v.CharacterID, &v.Vote, &votedAt, &lastChangedAt); err != nil {
+            return nil, oops.Code("SCENE_PUBLISH_LIST_VOTERS_SCAN_FAILED").Wrap(err)
+        }
+        if votedAt != nil { t := pgnanos.From(*votedAt); v.VotedAt = &t }
+        if lastChangedAt != nil { t := pgnanos.From(*lastChangedAt); v.LastChangedAt = &t }
+        out = append(out, v)
+    }
+    if err := rows.Err(); err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_LIST_VOTERS_ITER_FAILED").Wrap(err)
+    }
+    return out, nil
+}
+
+// isUniqueViolation detects pgx unique-constraint errors on a named index.
+// Helper; refactor into shared store_helpers.go if used elsewhere later.
+func isUniqueViolation(err error, indexName string) bool {
+    var pgErr *pgconn.PgError
+    if !errors.As(err, &pgErr) {
+        return false
+    }
+    return pgErr.Code == "23505" && pgErr.ConstraintName == indexName
+}
+```
+
+(Import additions: `"github.com/jackc/pgx/v5/pgconn"` for `PgError`.)
+
+- [ ] **Step 4: Run integration tests, verify PASS**
+
+Run: `task test:int -- -ginkgo.focus="Publish store" ./plugins/core-scenes/`
+Expected: PASS (both `It` blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-store): CreatePublishAttempt + ListPublishVoters
+
+Phase 6 store primitive for attempt creation + roster freeze in a single
+transaction. Roster excludes invited rows per INV-P6-1 (spec section 3.3,
+4.1). Fails closed on empty roster with SCENE_PUBLISH_NO_ELIGIBLE_VOTERS."
+```
+
+### Task A6: Store layer — vote upsert + tally
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_store.go`
+- Test: `plugins/core-scenes/store_integration_test.go` (extend)
+
+**Spec ref:** §4.2, §4.3
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `store_integration_test.go`:
+
+```go
+var _ = Describe("Publish store — vote operations", func() {
+    It("upserts a vote and returns is_change=false on first cast", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        pub, voter := setupAttemptWithOneVoter(ctx, store)
+
+        result, err := store.CastVote(ctx, pub.ID, voter, true)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(result.IsChange).To(BeFalse(), "first cast is not a change")
+        Expect(result.Vote).To(Equal(true))
+    })
+
+    It("flips a vote and returns is_change=true on change", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        pub, voter := setupAttemptWithOneVoter(ctx, store)
+        _, err := store.CastVote(ctx, pub.ID, voter, true)
+        Expect(err).NotTo(HaveOccurred())
+        result, err := store.CastVote(ctx, pub.ID, voter, false)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(result.IsChange).To(BeTrue())
+        Expect(result.Vote).To(Equal(false))
+    })
+
+    It("re-affirms same value with is_change=false", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        pub, voter := setupAttemptWithOneVoter(ctx, store)
+        _, err := store.CastVote(ctx, pub.ID, voter, true)
+        Expect(err).NotTo(HaveOccurred())
+        result, err := store.CastVote(ctx, pub.ID, voter, true)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(result.IsChange).To(BeFalse())
+    })
+
+    It("rejects vote from non-roster member", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        pub, _ := setupAttemptWithOneVoter(ctx, store)
+
+        nonRosterID := newULID()
+        _, err := store.CastVote(ctx, pub.ID, nonRosterID, true)
+        Expect(errutil.MatchCode(err, "SCENE_PUBLISH_NOT_A_VOTER")).To(BeTrue())
+    })
+
+    It("TallyVotes returns correct yes/no/pending counts", func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+        defer cancel()
+        store := newTestStore()
+        pub := setupAttemptWith3Voters(ctx, store)
+        voters, _ := store.ListPublishVoters(ctx, pub.ID)
+        _, _ = store.CastVote(ctx, pub.ID, voters[0].CharacterID, true)
+        _, _ = store.CastVote(ctx, pub.ID, voters[1].CharacterID, false)
+        // voters[2] pending
+
+        tally, err := store.TallyVotes(ctx, pub.ID)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(tally.Yes).To(Equal(1))
+        Expect(tally.No).To(Equal(1))
+        Expect(tally.Pending).To(Equal(1))
+    })
+})
+```
+
+(Helpers `setupAttemptWithOneVoter` and `setupAttemptWith3Voters` go in the same file, near other helpers.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test:int -- -ginkgo.focus="Publish store — vote operations" ./plugins/core-scenes/`
+Expected: FAIL (`undefined: CastVote`, `undefined: TallyVotes`).
+
+- [ ] **Step 3: Implement `CastVote` + `TallyVotes`**
+
+Append to `publish_store.go`:
+
+```go
+type CastVoteResult struct {
+    Vote     bool
+    IsChange bool
+}
+
+// CastVote upserts a vote. The voter MUST already be on the roster
+// (published_scene_votes row exists with the character_id). Returns
+// IsChange=true if the value differs from a prior cast on the same row.
+func (s *SceneStore) CastVote(ctx context.Context, publishedSceneID, characterID string, vote bool) (*CastVoteResult, error) {
+    ctx, span := startSpan(ctx, "scene.store.cast_vote",
+        attribute.String("published_scene_id", publishedSceneID),
+        attribute.String("character_id", characterID))
+    defer span.End()
+
+    var prior *bool
+    row := s.pool.QueryRow(ctx,
+        `SELECT vote FROM published_scene_votes
+         WHERE published_scene_id = $1 AND character_id = $2`,
+        publishedSceneID, characterID)
+    if err := row.Scan(&prior); err != nil {
+        if errors.Is(err, pgx.ErrNoRows) {
+            return nil, oops.Code("SCENE_PUBLISH_NOT_A_VOTER").
+                With("published_scene_id", publishedSceneID).
+                With("character_id", characterID).Wrap(err)
+        }
+        return nil, oops.Code("SCENE_PUBLISH_CAST_LOOKUP_FAILED").Wrap(err)
+    }
+
+    now := time.Now()
+    isChange := prior == nil || *prior != vote
+
+    _, err := s.pool.Exec(ctx, `
+        UPDATE published_scene_votes
+        SET vote = $1,
+            voted_at = COALESCE(voted_at, $2),
+            last_changed_at = $2
+        WHERE published_scene_id = $3 AND character_id = $4
+    `, vote, now, publishedSceneID, characterID)
+    if err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_CAST_UPDATE_FAILED").Wrap(err)
+    }
+    return &CastVoteResult{Vote: vote, IsChange: isChange}, nil
+}
+
+type VoteTally struct {
+    Yes     int
+    No      int
+    Pending int
+}
+
+// TallyVotes counts yes/no/pending across all voters for an attempt.
+func (s *SceneStore) TallyVotes(ctx context.Context, publishedSceneID string) (*VoteTally, error) {
+    var t VoteTally
+    row := s.pool.QueryRow(ctx, `
+        SELECT
+            count(*) FILTER (WHERE vote = true)  AS yes,
+            count(*) FILTER (WHERE vote = false) AS no,
+            count(*) FILTER (WHERE vote IS NULL) AS pending
+        FROM published_scene_votes WHERE published_scene_id = $1
+    `, publishedSceneID)
+    if err := row.Scan(&t.Yes, &t.No, &t.Pending); err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_TALLY_FAILED").Wrap(err)
+    }
+    return &t, nil
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test:int -- -ginkgo.focus="Publish store — vote operations" ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-store): CastVote + TallyVotes for Phase 6 publish
+
+CastVote upserts onto roster row (SCENE_PUBLISH_NOT_A_VOTER if absent),
+preserves voted_at on first cast, advances last_changed_at on every cast.
+TallyVotes returns yes/no/pending counts in a single query."
+```
+
+### Task A7: Store layer — status read/transitions + SELECT FOR UPDATE
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_store.go`
+- Test: `plugins/core-scenes/store_integration_test.go` (extend)
+
+**Spec ref:** §4.1 (transitions), §11 (SELECT FOR UPDATE for snapshot)
+
+- [ ] **Step 1: Write failing tests covering: GetPublishedSceneHeader, GetPublishedSceneContent, TransitionStatus, LockForSnapshot, CountAttempts**
+
+```go
+var _ = Describe("Publish store — status + transitions", func() {
+    It("GetPublishedSceneHeader returns row without content_entries", func() { ... })
+    It("GetPublishedSceneHeader returns nil for nonexistent id", func() { ... })
+    It("GetPublishedSceneContent returns nil entries for non-PUBLISHED row", func() { ... })
+    It("TransitionStatus(COLLECTING → COOLOFF) sets cooloff_started_at", func() { ... })
+    It("TransitionStatus(COOLOFF → COLLECTING) clears cooloff_started_at", func() { ... })
+    It("TransitionStatus to ATTEMPT_FAILED sets resolved_at + failure_reason", func() { ... })
+    It("TransitionStatus rejects illegal transitions with SCENE_PUBLISH_INVALID_TRANSITION", func() { ... })
+    It("LockForSnapshot blocks concurrent calls (idempotent on second call)", func() { ... })
+    It("CountAttempts returns total + active + published counts per scene", func() { ... })
+})
+```
+
+(Full test bodies follow the patterns in Tasks A5 + A6 — use `Eventually` for the concurrency test.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test:int -- -ginkgo.focus="Publish store — status" ./plugins/core-scenes/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the methods**
+
+```go
+// GetPublishedSceneHeader returns the row WITHOUT content_entries —
+// callers that need content call GetPublishedSceneContent separately.
+// This split is load-bearing for INV-P6-5 (the participant gate runs
+// between the header read and the content read).
+func (s *SceneStore) GetPublishedSceneHeader(ctx context.Context, id string) (*PublishedScene, error) {
+    row := s.pool.QueryRow(ctx, `
+        SELECT id, scene_id, attempt_number, status, initiated_by, initiated_at,
+               cooloff_started_at, resolved_at, vote_window, cooloff_window,
+               max_attempts_snapshot, title_snapshot, participants_snapshot,
+               published_at, failure_reason
+        FROM published_scenes WHERE id = $1
+    `, id)
+    // Scan into PublishedScene; return nil if pgx.ErrNoRows. Pattern follows
+    // existing SceneStore.Get at store.go (e.g., the SELECT pattern at line ~500).
+    var pub PublishedScene
+    // ... (full scan — fill in nullable fields with pointer-to-types)
+    return &pub, nil
+}
+
+// GetPublishedSceneContent returns content_entries + frozen participants.
+// MUST only be called AFTER the participant gate has approved the caller
+// for participant-gated RPCs.
+func (s *SceneStore) GetPublishedSceneContent(ctx context.Context, id string) ([]Entry, error) {
+    var raw []byte
+    if err := s.pool.QueryRow(ctx,
+        `SELECT content_entries FROM published_scenes WHERE id = $1`, id,
+    ).Scan(&raw); err != nil {
+        if errors.Is(err, pgx.ErrNoRows) {
+            return nil, nil
+        }
+        return nil, oops.Code("SCENE_PUBLISH_CONTENT_READ_FAILED").Wrap(err)
+    }
+    if len(raw) == 0 { return nil, nil }
+    var entries []Entry
+    if err := json.Unmarshal(raw, &entries); err != nil {
+        return nil, oops.Code("SCENE_PUBLISH_CONTENT_DECODE_FAILED").Wrap(err)
+    }
+    return entries, nil
+}
+
+// TransitionStatus mutates status with side effects per spec §4.1.
+type TransitionInput struct {
+    To            PublishedSceneStatus
+    FailureReason *PublishFailureReason  // required when To == ATTEMPT_FAILED
+    SetCoolOffAt  *time.Time             // set when entering COOLOFF
+    ClearCoolOff  bool                   // true when leaving COOLOFF (flip-back)
+    Resolved      bool                   // sets resolved_at
+}
+func (s *SceneStore) TransitionStatus(ctx context.Context, id string, in TransitionInput) error {
+    // Single UPDATE with CASE/COALESCE to mutate just the relevant fields.
+    // Validate legality via a precondition CHECK in the WHERE clause
+    // (e.g., only COLLECTING→COOLOFF when current status='COLLECTING').
+    // Return SCENE_PUBLISH_INVALID_TRANSITION on zero rows updated.
+    // Full impl follows the pattern from store.go's MoveCharacter at line ~700.
+    return nil // placeholder; see Step 3 final impl
+}
+
+// LockForSnapshot does SELECT FOR UPDATE on the published_scenes row and
+// re-validates status == COOLOFF. Used by the snapshot pipeline (spec §11.3).
+func (s *SceneStore) LockForSnapshot(ctx context.Context, tx pgx.Tx, id string) (*PublishedScene, error) {
+    var pub PublishedScene
+    // SELECT ... FOR UPDATE; scan; verify status; return.
+    return &pub, nil // placeholder
+}
+
+// CountAttempts returns (total, active, published) counts for a scene.
+// Used by StartScenePublish preconditions (attempt_count < max_attempts).
+func (s *SceneStore) CountAttempts(ctx context.Context, sceneID string) (AttemptCounts, error) {
+    var c AttemptCounts
+    // Single query with FILTER aggregates.
+    return c, nil // placeholder
+}
+type AttemptCounts struct {
+    Total     int
+    Active    int  // status IN (COLLECTING, COOLOFF)
+    Published int  // status == PUBLISHED
+}
+```
+
+Flesh out each placeholder with full SQL bodies following the patterns at `store.go:325-354` (`IsMember`) and `store.go:759-825` (`MoveCharacter` — for transition validation with WHERE clause).
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test:int -- -ginkgo.focus="Publish store — status" ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-store): publish status + transitions + lock
+
+GetPublishedSceneHeader / GetPublishedSceneContent split is load-bearing
+for INV-P6-5: the participant gate runs between these two store calls.
+TransitionStatus uses precondition WHERE clauses for legal-transition
+validation. LockForSnapshot wraps SELECT FOR UPDATE for the snapshot
+pipeline (spec section 11.3)."
+```
+
+### Task A8: State machine + vote tally + roster freeze unit tests
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_state.go`
+- Create: `plugins/core-scenes/publish_state_test.go`
+- Create: `plugins/core-scenes/publish_vote_tally_test.go`
+- Create: `plugins/core-scenes/publish_roster_test.go`
+
+**Spec ref:** §4, §15.1 unit tier
+
+- [ ] **Step 1: Write `publish_state_test.go` failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestPublishStateMachine_TransitionTable(t *testing.T) {
+    t.Parallel()
+    cases := []struct {
+        name        string
+        from        PublishedSceneStatus
+        trigger     PublishTrigger
+        wantTo      PublishedSceneStatus
+        wantReject  bool
+    }{
+        {"COLLECTING + all-yes → COOLOFF", StatusCollecting, TriggerAllYes, StatusCoolOff, false},
+        {"COLLECTING + any-no-after-voted → ATTEMPT_FAILED", StatusCollecting, TriggerAllVotedAnyNo, StatusAttemptFailed, false},
+        {"COLLECTING + timeout → ATTEMPT_FAILED", StatusCollecting, TriggerTimeout, StatusAttemptFailed, false},
+        {"COLLECTING + withdraw → ATTEMPT_FAILED", StatusCollecting, TriggerWithdraw, StatusAttemptFailed, false},
+        {"COOLOFF + window-elapsed → PUBLISHED", StatusCoolOff, TriggerCoolOffElapsed, StatusPublished, false},
+        {"COOLOFF + flip-no → COLLECTING", StatusCoolOff, TriggerFlipNo, StatusCollecting, false},
+        {"COOLOFF + withdraw → ATTEMPT_FAILED", StatusCoolOff, TriggerWithdraw, StatusAttemptFailed, false},
+        {"PUBLISHED + anything rejects", StatusPublished, TriggerAllYes, "", true},
+        {"ATTEMPT_FAILED + anything rejects", StatusAttemptFailed, TriggerAllYes, "", true},
+        {"COLLECTING + cool-off-elapsed rejects (illegal)", StatusCollecting, TriggerCoolOffElapsed, "", true},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            to, ok := NextStatus(tc.from, tc.trigger)
+            if tc.wantReject {
+                assert.False(t, ok)
+            } else {
+                assert.True(t, ok)
+                assert.Equal(t, tc.wantTo, to)
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run TestPublishStateMachine ./plugins/core-scenes/`
+Expected: FAIL (`undefined: PublishTrigger`, `undefined: NextStatus`).
+
+- [ ] **Step 3: Implement `publish_state.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+// PublishTrigger names a state-machine event. The legal transition is
+// (from, trigger) → to per spec §4.1.
+type PublishTrigger string
+
+const (
+    TriggerAllYes         PublishTrigger = "all_yes"
+    TriggerAllVotedAnyNo  PublishTrigger = "all_voted_any_no"
+    TriggerTimeout        PublishTrigger = "timeout"
+    TriggerWithdraw       PublishTrigger = "withdraw"
+    TriggerCoolOffElapsed PublishTrigger = "cooloff_elapsed"
+    TriggerFlipNo         PublishTrigger = "flip_no"
+    TriggerSnapshotFailed PublishTrigger = "snapshot_failed"
+)
+
+// NextStatus returns the next status for (from, trigger) per spec §4.1,
+// or (_, false) if the transition is illegal. Pure function for unit
+// testability; the database layer applies the transition via
+// SceneStore.TransitionStatus.
+func NextStatus(from PublishedSceneStatus, t PublishTrigger) (PublishedSceneStatus, bool) {
+    switch from {
+    case StatusCollecting:
+        switch t {
+        case TriggerAllYes: return StatusCoolOff, true
+        case TriggerAllVotedAnyNo, TriggerTimeout, TriggerWithdraw:
+            return StatusAttemptFailed, true
+        }
+    case StatusCoolOff:
+        switch t {
+        case TriggerCoolOffElapsed: return StatusPublished, true
+        case TriggerFlipNo:         return StatusCollecting, true
+        case TriggerWithdraw, TriggerSnapshotFailed:
+            return StatusAttemptFailed, true
+        }
+    }
+    return "", false
+}
+
+// FailureReasonForTrigger maps a terminal-causing trigger to its failure_reason.
+func FailureReasonForTrigger(t PublishTrigger) (PublishFailureReason, bool) {
+    switch t {
+    case TriggerAllVotedAnyNo: return FailureAnyNo, true
+    case TriggerTimeout:       return FailureTimeout, true
+    case TriggerWithdraw:      return FailureWithdrawn, true
+    }
+    return "", false
+}
+
+// ResolveFromTally returns the trigger to apply based on a tally tally
+// during COLLECTING. Returns ("", false) if no resolution applies yet.
+func ResolveFromTally(t VoteTally) (PublishTrigger, bool) {
+    if t.Pending > 0 {
+        return "", false
+    }
+    if t.No > 0 {
+        return TriggerAllVotedAnyNo, true
+    }
+    return TriggerAllYes, true
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test -- -run TestPublishStateMachine ./plugins/core-scenes/`
+Expected: PASS (10 subtests).
+
+- [ ] **Step 5: Write `publish_vote_tally_test.go`**
+
+```go
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestResolveFromTally(t *testing.T) {
+    t.Parallel()
+    cases := []struct {
+        name    string
+        tally   VoteTally
+        wantT   PublishTrigger
+        wantOK  bool
+    }{
+        {"all yes unanimous", VoteTally{Yes: 3, No: 0, Pending: 0}, TriggerAllYes, true},
+        {"any no after all voted", VoteTally{Yes: 2, No: 1, Pending: 0}, TriggerAllVotedAnyNo, true},
+        {"still pending", VoteTally{Yes: 2, No: 0, Pending: 1}, "", false},
+        {"mixed with pending", VoteTally{Yes: 1, No: 1, Pending: 1}, "", false},
+        {"single yes single voter", VoteTally{Yes: 1, No: 0, Pending: 0}, TriggerAllYes, true},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got, ok := ResolveFromTally(tc.tally)
+            assert.Equal(t, tc.wantOK, ok)
+            if ok {
+                assert.Equal(t, tc.wantT, got)
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 6: Run vote-tally tests, verify PASS**
+
+Run: `task test -- -run TestResolveFromTally ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 7: Write `publish_roster_test.go` — pure logic for roster eligibility**
+
+This tests the in-Go predicate `IsEligibleRole`, used by the store + handler layers:
+
+```go
+package main
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestIsEligibleVoterRole(t *testing.T) {
+    t.Parallel()
+    assert.True(t, IsEligibleVoterRole("owner"))
+    assert.True(t, IsEligibleVoterRole("member"))
+    assert.False(t, IsEligibleVoterRole("invited"))
+    assert.False(t, IsEligibleVoterRole(""))
+    assert.False(t, IsEligibleVoterRole("admin"))
+}
+```
+
+Add to `publish_state.go`:
+
+```go
+// IsEligibleVoterRole returns true for roles that may be on a publish
+// roster per INV-P6-1: owner and member only, NOT invited.
+func IsEligibleVoterRole(role string) bool {
+    return role == "owner" || role == "member"
+}
+```
+
+- [ ] **Step 8: Run, verify PASS**
+
+Run: `task test -- -run TestIsEligibleVoterRole ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj describe -m "feat(scene-state): Phase 6 state machine + tally + roster predicates
+
+Pure-Go state machine helpers (NextStatus, FailureReasonForTrigger,
+ResolveFromTally) and roster eligibility predicate (IsEligibleVoterRole).
+Unit-tested without DB. Spec section 4 (holomush-5rh.15)."
+```
+
+---
+
+## Phase B — Participant RPCs + INV-S9 Gate + Commands
+
+Phase B implements the participant-gated RPC surface, the resolveSceneRef helper, the `scene publish *` commands, and the INV-S9 plugin-code gate with its load-bearing tripwire test. ABAC policies in `plugin.yaml` updated and verified. By end of Phase B, a participant can run `scene publish` / `scene publish vote yes/no` / `scene publish withdraw` against the focused scene; non-participants are denied via the plugin-code gate with the triple-signal observability.
+
+**Spec coverage:** §5 (participant RPCs only — public surface in C), §6 (commands), §8 (ABAC), §9 (INV-S9 contract), §10 (privacy block triple signal).
+
+### Task B1: `resolveSceneRef` helper + tests
+
+**Files:**
+
+- Create: `plugins/core-scenes/commands_resolve_test.go`
+- Modify: `plugins/core-scenes/commands.go` (add helper near top of file)
+
+**Spec ref:** §6.1
+
+**Design note:** The plugin SDK does NOT expose a per-connection "currently focused scene" query — `pluginsdk.FocusClient` (at `pkg/plugin/focus_client.go:27`) has `SetConnectionFocus`, `IsAnyConnFocused`, `JoinFocus`/`LeaveFocus`, but no `GetConnectionFocus`. The existing codebase pattern for "which scene does this command target?" is **single-membership inference** via `p.resolveSingleSceneMembership(ctx, characterID)` (at `commands.go:828` in `handleEmit`, also `commands.go:911` in `handleOrder`): if the character is in exactly one active scene, return its ID; otherwise return an error message that prompts the player to pass `#<scene_id>` explicitly. Phase 6 reuses this pattern instead of inventing a new `FocusedSceneID()` abstraction.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "context"
+    "testing"
+
+    "github.com/holomush/holomush/pkg/errutil"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// fakeMembershipLookup returns a fixed slice of scenes the caller is in.
+type fakeMembershipLookup struct{ scenes []string }
+
+func (f *fakeMembershipLookup) ListScenesForCharacter(_ context.Context, _ string) ([]string, error) {
+    return f.scenes, nil
+}
+
+func TestResolveSceneRef_SingleMembershipNoArg(t *testing.T) {
+    t.Parallel()
+    look := &fakeMembershipLookup{scenes: []string{"scene-abc"}}
+    sceneID, err := resolveSceneRef(context.Background(), look, "char-1", "")
+    require.NoError(t, err)
+    assert.Equal(t, "scene-abc", sceneID)
+}
+
+func TestResolveSceneRef_ExplicitHashArg(t *testing.T) {
+    t.Parallel()
+    look := &fakeMembershipLookup{scenes: []string{"scene-default"}}
+    sceneID, err := resolveSceneRef(context.Background(), look, "char-1", "#scene-xyz")
+    require.NoError(t, err)
+    assert.Equal(t, "scene-xyz", sceneID, "explicit arg overrides single-membership")
+}
+
+func TestResolveSceneRef_NoMembershipNoArg(t *testing.T) {
+    t.Parallel()
+    look := &fakeMembershipLookup{scenes: nil}
+    _, err := resolveSceneRef(context.Background(), look, "char-1", "")
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_NO_FOCUSED_SCENE"))
+}
+
+func TestResolveSceneRef_MultiMembershipNoArgRequiresExplicit(t *testing.T) {
+    t.Parallel()
+    look := &fakeMembershipLookup{scenes: []string{"scene-a", "scene-b"}}
+    _, err := resolveSceneRef(context.Background(), look, "char-1", "")
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_NO_FOCUSED_SCENE"),
+        "ambiguous membership requires explicit '#<id>' arg")
+}
+
+func TestResolveSceneRef_ExplicitMalformed(t *testing.T) {
+    t.Parallel()
+    look := &fakeMembershipLookup{scenes: []string{"scene-default"}}
+    cases := []string{"notahash", "#", "##abc", "  ", "# scene-with-space"}
+    for _, c := range cases {
+        t.Run(c, func(t *testing.T) {
+            _, err := resolveSceneRef(context.Background(), look, "char-1", c)
+            require.Error(t, err)
+            assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_REF_INVALID"))
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run TestResolveSceneRef ./plugins/core-scenes/`
+Expected: FAIL (`undefined: resolveSceneRef`).
+
+- [ ] **Step 3: Implement `resolveSceneRef` in `commands.go`**
+
+```go
+// membershipLookup is the minimal interface resolveSceneRef needs from
+// the store. The real *SceneStore satisfies it via ListScenesForCharacter
+// (store.go:1284). Tests use fakeMembershipLookup.
+type membershipLookup interface {
+    ListScenesForCharacter(ctx context.Context, characterID string) ([]string, error)
+}
+
+// resolveSceneRef returns the scene ID this command targets. If args
+// starts with '#', the rest is treated as an explicit scene ID. Otherwise
+// the helper uses single-membership inference: if the caller is in exactly
+// one active scene, return its ID; ambiguous (zero or multiple) returns
+// SCENE_PUBLISH_NO_FOCUSED_SCENE prompting the player to pass '#<id>'.
+//
+// This mirrors the existing handleEmit / handleOrder pattern at
+// commands.go:828 (resolveSingleSceneMembership). See spec §6.1.
+func resolveSceneRef(ctx context.Context, look membershipLookup, characterID, args string) (string, error) {
+    args = strings.TrimSpace(args)
+    if strings.HasPrefix(args, "#") {
+        id := strings.TrimSpace(args[1:])
+        if id == "" || strings.ContainsAny(id, " \t\n#") {
+            return "", oops.Code("SCENE_PUBLISH_REF_INVALID").
+                With("arg", args).Errorf("malformed scene reference")
+        }
+        return id, nil
+    }
+    if args != "" {
+        return "", oops.Code("SCENE_PUBLISH_REF_INVALID").
+            With("arg", args).Errorf("non-hash arg requires '#' prefix")
+    }
+    scenes, err := look.ListScenesForCharacter(ctx, characterID)
+    if err != nil {
+        return "", oops.Code("SCENE_PUBLISH_REF_LOOKUP_FAILED").Wrap(err)
+    }
+    if len(scenes) != 1 {
+        return "", oops.Code("SCENE_PUBLISH_NO_FOCUSED_SCENE").
+            With("matching_scenes", len(scenes)).
+            Errorf("command requires '#<scene_id>' arg (caller is in %d scenes)", len(scenes))
+    }
+    return scenes[0], nil
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test -- -run TestResolveSceneRef ./plugins/core-scenes/`
+Expected: PASS (5 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-commands): resolveSceneRef with single-membership inference
+
+Single dispatch point for 'scene publish *' and 'scene log *' commands.
+Implicit-no-arg form uses ListScenesForCharacter for single-membership
+inference (mirrors handleEmit/handleOrder at commands.go:828); explicit
+'#<id>' form bypasses inference. Errors: SCENE_PUBLISH_NO_FOCUSED_SCENE,
+SCENE_PUBLISH_REF_INVALID, SCENE_PUBLISH_REF_LOOKUP_FAILED.
+Spec section 6.1 (holomush-5rh.15)."
+```
+
+### Task B1.5: Caller validation + error-mapping helpers (`publish_helpers.go`)
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_helpers.go`
+- Create: `plugins/core-scenes/publish_helpers_test.go`
+
+**Spec ref:** §5 (caller validation pattern), §5.2 (error code surface)
+
+**Design note:** Existing scene handlers do caller validation inline (`audit.go:499-524` checks Kind == CHARACTER, 16-byte ID length, non-zero ULID). Phase 6 handlers need the same predicate at the top of every RPC, so we extract it to a helper to keep the INV-S9 gate ordering legible. The Phase 6 request messages (added in Task A3) MUST include a `caller_character_id` string field — amend the Task A3 proto messages to add `string caller_character_id = N` to `StartScenePublishRequest`, `CastPublishSceneVoteRequest`, `WithdrawScenePublishRequest`, `GetPublishedSceneRequest`, `DownloadPublishedSceneRequest`, `ListScenePublishAttemptsRequest`, `ExtendScenePublishVoteAttemptsRequest`. (The public RPCs `GetPublicSceneArchive` / `DownloadPublicSceneArchive` do NOT carry a caller field — they're unauthenticated.) The plugin command handlers populate `caller_character_id` from `pluginsdk.CommandRequest.CharacterID`.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "context"
+    "testing"
+
+    "github.com/holomush/holomush/pkg/errutil"
+    "github.com/holomush/holomush/pkg/oops"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
+)
+
+func TestParseCallerCharacterID_HappyPath(t *testing.T) {
+    t.Parallel()
+    id, err := parseCallerCharacterID("01HK0000000000000000000001")
+    require.NoError(t, err)
+    assert.Equal(t, "01HK0000000000000000000001", id)
+}
+
+func TestParseCallerCharacterID_Empty(t *testing.T) {
+    t.Parallel()
+    _, err := parseCallerCharacterID("")
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_CALLER_REQUIRED"))
+}
+
+func TestParseCallerCharacterID_Malformed(t *testing.T) {
+    t.Parallel()
+    _, err := parseCallerCharacterID("not-a-ulid")
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_CALLER_MALFORMED"))
+}
+
+func TestMapStoreErr_OopsCodePropagates(t *testing.T) {
+    t.Parallel()
+    err := oops.Code("SCENE_PUBLISH_ALREADY_ACTIVE").Errorf("active")
+    mapped := mapStoreErr(err)
+    assert.True(t, errutil.MatchCode(mapped, "SCENE_PUBLISH_ALREADY_ACTIVE"))
+    assert.Equal(t, codes.FailedPrecondition, status.Code(mapped))
+}
+
+func TestMapStoreErr_BareErrorBecomesInternal(t *testing.T) {
+    t.Parallel()
+    mapped := mapStoreErr(context.Canceled)
+    assert.Equal(t, codes.Internal, status.Code(mapped))
+    // Wire-level message MUST be generic per .claude/rules/grpc-errors.md.
+    assert.Equal(t, "internal error", status.Convert(mapped).Message())
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run "TestParseCallerCharacterID|TestMapStoreErr" ./plugins/core-scenes/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `publish_helpers.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "log/slog"
+
+    "github.com/holomush/holomush/pkg/oops"
+    "github.com/oklog/ulid/v2"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
+)
+
+// parseCallerCharacterID validates a string ULID from a Phase 6 request's
+// caller_character_id field. Mirrors the inline pattern at audit.go:511-524
+// (Kind=CHARACTER check is enforced upstream at the host plugin gateway;
+// service handlers receive the ULID-string in the request body).
+func parseCallerCharacterID(s string) (string, error) {
+    if s == "" {
+        return "", oops.Code("SCENE_PUBLISH_CALLER_REQUIRED").
+            Errorf("caller_character_id is required")
+    }
+    parsed, err := ulid.ParseStrict(s)
+    if err != nil {
+        return "", oops.Code("SCENE_PUBLISH_CALLER_MALFORMED").
+            With("caller_character_id", s).Wrap(err)
+    }
+    if parsed == (ulid.ULID{}) {
+        return "", oops.Code("SCENE_PUBLISH_CALLER_MALFORMED").
+            Errorf("caller_character_id is zero ULID")
+    }
+    return parsed.String(), nil
+}
+
+// mapStoreErr translates store-layer errors into gRPC status codes,
+// preserving oops codes for the application-error category and mapping
+// bare errors to Internal with a generic wire-level message (per
+// .claude/rules/grpc-errors.md "Never leak inner errors past trust
+// boundaries"). The full error is logged at the call site via
+// internalErr; this function only shapes the wire-visible response.
+func mapStoreErr(err error) error {
+    if err == nil {
+        return nil
+    }
+    code := oops.AsOops(err).Code()
+    switch code {
+    case "SCENE_PUBLISH_ALREADY_ACTIVE",
+        "SCENE_PUBLISH_ALREADY_PUBLISHED",
+        "SCENE_PUBLISH_ATTEMPTS_EXHAUSTED",
+        "SCENE_PUBLISH_NO_ELIGIBLE_VOTERS",
+        "SCENE_PUBLISH_INVALID_STATE",
+        "SCENE_PUBLISH_INVALID_TRANSITION":
+        return status.Error(codes.FailedPrecondition, code)
+    case "SCENE_PUBLISH_NOT_A_VOTER",
+        "SCENE_PUBLISH_NOT_OWNER",
+        "SCENE_PRIVACY_BOUNDARY_BLOCK":
+        return status.Error(codes.PermissionDenied, code)
+    case "SCENE_PUBLISH_CALLER_REQUIRED",
+        "SCENE_PUBLISH_CALLER_MALFORMED",
+        "SCENE_PUBLISH_FORMAT_UNSUPPORTED",
+        "SCENE_PUBLISH_REF_INVALID",
+        "SCENE_PUBLISH_NO_FOCUSED_SCENE":
+        return status.Error(codes.InvalidArgument, code)
+    }
+    return status.Error(codes.Internal, "internal error")
+}
+
+// internalErr returns a generic Internal status for the wire and logs
+// the inner error to slog via the package-level logger. Wire-level
+// opacity per .claude/rules/grpc-errors.md "Never leak inner errors
+// past trust boundaries". Single-arg signature keeps handler call
+// sites terse: `return nil, internalErr(err)`.
+func internalErr(err error) error {
+    slog.Error("scene publish internal error", "err", err.Error())
+    return status.Error(codes.Internal, "internal error")
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test -- -run "TestParseCallerCharacterID|TestMapStoreErr" ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 5: Add `SceneServiceImpl` fields `cfg` + `events` + their defaults**
+
+Phase B handlers reference `s.cfg.DefaultVoteWindow`, `s.cfg.DefaultCoolOffWindow`, and `s.events.emit*`. Introduce both here so Phase B compiles. The cfg struct lives in `publish_helpers.go`; the events interface and no-op default live there too (the real emitter ships in Phase D Task D2).
+
+In `plugins/core-scenes/publish_helpers.go`, add:
+
+```go
+import "time"
+
+// SceneServiceConfig carries Phase 6 defaults. Game-wide values set at
+// plugin init time (main.go); per-scene overrides are picked up at
+// StartScenePublish time from the scene row's per-scene columns.
+type SceneServiceConfig struct {
+    DefaultVoteWindow    time.Duration
+    DefaultCoolOffWindow time.Duration
+}
+
+// DefaultSceneServiceConfig matches the spec §6/§4 defaults: 7-day vote
+// window, 30-minute cool-off window.
+func DefaultSceneServiceConfig() SceneServiceConfig {
+    return SceneServiceConfig{
+        DefaultVoteWindow:    7 * 24 * time.Hour,
+        DefaultCoolOffWindow: 30 * time.Minute,
+    }
+}
+
+// publishEventer is the interface SceneServiceImpl uses to fire Phase 6
+// scene_publish_* IC notice events. Phase B handlers call its methods on
+// every state transition; the real implementation (publishEventEmitter)
+// lands in Phase D Task D2. The noopPublishEventer default below absorbs
+// every call during Phase B so handler tests pass without touching the
+// event substrate.
+type publishEventer interface {
+    emitPublishStarted(ctx context.Context, pub *PublishedScene) error
+    emitVoteCast(ctx context.Context, attemptID, characterID string, result *CastVoteResult) error
+    emitCoolOffStarted(ctx context.Context, attemptID string, window time.Duration) error
+    emitResolved(ctx context.Context, attemptID string, finalStatus PublishedSceneStatus, reason *PublishFailureReason, tally *VoteTally) error
+    emitWithdrawn(ctx context.Context, attemptID, withdrawnBy string) error
+    emitAttemptsExtended(ctx context.Context, sceneID, adminID string, additional, newMax int) error
+}
+
+// noopPublishEventer absorbs every emit. Used as the SceneServiceImpl
+// default until Phase D wires the real emitter via SetEventSink-equivalent.
+type noopPublishEventer struct{}
+
+func (noopPublishEventer) emitPublishStarted(context.Context, *PublishedScene) error { return nil }
+func (noopPublishEventer) emitVoteCast(context.Context, string, string, *CastVoteResult) error { return nil }
+func (noopPublishEventer) emitCoolOffStarted(context.Context, string, time.Duration) error { return nil }
+func (noopPublishEventer) emitResolved(context.Context, string, PublishedSceneStatus, *PublishFailureReason, *VoteTally) error { return nil }
+func (noopPublishEventer) emitWithdrawn(context.Context, string, string) error { return nil }
+func (noopPublishEventer) emitAttemptsExtended(context.Context, string, string, int, int) error { return nil }
+```
+
+In `plugins/core-scenes/service.go`, extend the `SceneServiceImpl` struct (add lines after the existing fields) and the constructor:
+
+```go
+type SceneServiceImpl struct {
+    store      sceneStorer
+    // ... existing fields (eventSink, focusClient, gameID, etc.) ...
+    cfg        SceneServiceConfig   // NEW (Phase 6)
+    events     publishEventer       // NEW (Phase 6)
+}
+
+func NewSceneServiceImpl(store sceneStorer) *SceneServiceImpl {
+    return &SceneServiceImpl{
+        store:  store,
+        cfg:    DefaultSceneServiceConfig(),
+        events: noopPublishEventer{},  // Phase D's SetPublishEventer replaces this
+    }
+}
+```
+
+(If existing `NewSceneServiceImpl` already takes more params, preserve them; just add the two-field default-init at the end of the struct literal.)
+
+- [ ] **Step 6: Run, verify PASS (compile-only)**
+
+Run: `task build`
+Expected: PASS — `SceneServiceImpl` now has `cfg` + `events` with sensible defaults so Phase B handlers compile.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): caller validation + error mapping + service config
+
+publish_helpers.go:
+- parseCallerCharacterID validates ULID-string from caller_character_id
+  field (mirrors audit.go:511-524 inline pattern)
+- mapStoreErr translates oops codes to gRPC status per grpc-errors.md
+- internalErr (single-arg) logs + returns generic Internal for wire opacity
+- SceneServiceConfig + DefaultSceneServiceConfig hold Phase 6 defaults
+  (7-day vote window, 30-min cool-off)
+- publishEventer interface + noopPublishEventer default; Phase D wires
+  the real publishEventEmitter
+
+service.go: SceneServiceImpl gains cfg + events fields; NewSceneServiceImpl
+seeds DefaultSceneServiceConfig and noopPublishEventer.
+
+NOTE for Phase 6 readers: Task A3 proto messages MUST include 'string
+caller_character_id = N' in each authenticated request."
+```
+
+### Task B2: `StartScenePublish` handler + ABAC policy
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/service.go` (replace the Phase A stub)
+- Modify: `plugins/core-scenes/plugin.yaml` (add `start-publish-as-participant` policy)
+- Create: `plugins/core-scenes/publish_service_test.go`
+
+**Spec ref:** §5 StartScenePublish, §8 ABAC
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestStartScenePublish_HappyPath(t *testing.T) {
+    t.Parallel()
+    store := newFakeStoreWithEndedScene("scene-1", "owner-1", []string{"owner-1", "member-1"}, []string{"invited-1"})
+    svc := NewSceneServiceImpl(store)
+
+    ctx := callerContext("owner-1")
+    resp, err := svc.StartScenePublish(ctx, &scenev1.StartScenePublishRequest{SceneId: "scene-1"})
+
+    require.NoError(t, err)
+    assert.NotEmpty(t, resp.PublishedSceneId)
+    assert.Equal(t, int32(1), resp.AttemptNumber)
+    // Fake store should have one COLLECTING attempt with a 2-voter roster (NOT 3).
+    pubs := store.publishAttempts()
+    require.Len(t, pubs, 1)
+    assert.Equal(t, StatusCollecting, pubs[0].Status)
+    assert.Len(t, store.publishVoters(pubs[0].ID), 2, "invited excluded — INV-P6-1")
+}
+
+func TestStartScenePublish_RejectsActiveScene(t *testing.T) {
+    t.Parallel()
+    store := newFakeStoreWithActiveScene("scene-1", "owner-1")
+    svc := NewSceneServiceImpl(store)
+    _, err := svc.StartScenePublish(callerContext("owner-1"), &scenev1.StartScenePublishRequest{SceneId: "scene-1"})
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_INVALID_STATE"))
+}
+
+func TestStartScenePublish_RejectsAttemptsExhausted(t *testing.T) {
+    t.Parallel()
+    store := newFakeStoreWithExhaustedAttempts("scene-1", "owner-1", 3)
+    svc := NewSceneServiceImpl(store)
+    _, err := svc.StartScenePublish(callerContext("owner-1"), &scenev1.StartScenePublishRequest{SceneId: "scene-1"})
+    require.Error(t, err)
+    assert.True(t, errutil.MatchCode(err, "SCENE_PUBLISH_ATTEMPTS_EXHAUSTED"))
+}
+```
+
+(Fake store factories `newFakeStoreWithEndedScene` etc. live in `publish_service_test.go`; pattern follows existing `service_test.go::fakeStore`.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run TestStartScenePublish ./plugins/core-scenes/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement handler in `publish_service.go`**
+
+```go
+package main
+
+import (
+    "context"
+
+    scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+    "github.com/holomush/holomush/pkg/oops"
+    "go.opentelemetry.io/otel/attribute"
+    "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/status"
+)
+
+func (s *SceneServiceImpl) StartScenePublish(ctx context.Context, req *scenev1.StartScenePublishRequest) (*scenev1.StartScenePublishResponse, error) {
+    ctx, span := startSpan(ctx, "scene.service.start_scene_publish",
+        attribute.String("scene_id", req.GetSceneId()))
+    defer span.End()
+
+    callerID, err := parseCallerCharacterID(req.GetCallerCharacterId())
+    if err != nil {
+        return nil, err
+    }
+
+    scene, err := s.store.GetScene(ctx, req.GetSceneId())
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+    if scene == nil {
+        return nil, status.Error(codes.NotFound, "scene not found")
+    }
+    if scene.State != string(SceneStateEnded) {
+        return nil, oops.Code("SCENE_PUBLISH_INVALID_STATE").
+            With("scene_id", req.GetSceneId()).
+            With("current_state", scene.State).
+            Errorf("scene must be in 'ended' state to publish")
+    }
+
+    counts, err := s.store.CountAttempts(ctx, req.GetSceneId())
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+    if counts.Published > 0 {
+        return nil, oops.Code("SCENE_PUBLISH_ALREADY_PUBLISHED").
+            With("scene_id", req.GetSceneId()).Errorf("scene already has a published archive")
+    }
+    if counts.Active > 0 {
+        return nil, oops.Code("SCENE_PUBLISH_ALREADY_ACTIVE").
+            With("scene_id", req.GetSceneId()).Errorf("scene already has an active attempt")
+    }
+    if counts.Total >= scene.MaxPublishAttempts {
+        return nil, oops.Code("SCENE_PUBLISH_ATTEMPTS_EXHAUSTED").
+            With("scene_id", req.GetSceneId()).
+            With("max_attempts", scene.MaxPublishAttempts).
+            Errorf("scene has exhausted its publish-attempt budget")
+    }
+
+    pub, err := s.store.CreatePublishAttempt(ctx, CreatePublishAttemptInput{
+        SceneID:       req.GetSceneId(),
+        AttemptNumber: counts.Total + 1,
+        InitiatedBy:   callerID,
+        VoteWindow:    s.cfg.DefaultVoteWindow,
+        CoolOffWindow: s.cfg.DefaultCoolOffWindow,
+        MaxAttempts:   scene.MaxPublishAttempts,
+    })
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+
+    metricScenePublishAttemptResolved("started", "")
+    if emitErr := s.events.emitPublishStarted(ctx, pub); emitErr != nil {
+        slog.WarnContext(ctx, "publish-started emit failed", "err", emitErr)
+    }
+
+    return &scenev1.StartScenePublishResponse{
+        PublishedSceneId: pub.ID,
+        AttemptNumber:    int32(pub.AttemptNumber),
+    }, nil
+}
+```
+
+(`s.cfg` and `s.events` are declared on `SceneServiceImpl` and wired in Task B1.5 Step 5 — `cfg` gets `DefaultSceneServiceConfig()` (7d/30m defaults); `events` gets `noopPublishEventer{}`. Phase D Task D2 replaces the noop emitter with the real `publishEventEmitter` via `SetPublishEventer`.)
+
+- [ ] **Step 4: Add ABAC policy to `plugin.yaml`**
+
+In `plugins/core-scenes/plugin.yaml` under `policies:` (append):
+
+```yaml
+- name: start-publish-as-participant
+  dsl: >-
+    permit(principal is character, action in ["publish"], resource is scene)
+    when { principal.id in resource.scene.participants
+           && resource.scene.state == "ended" };
+```
+
+- [ ] **Step 5: Run, verify PASS**
+
+Run: `task test -- -run TestStartScenePublish ./plugins/core-scenes/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): StartScenePublish RPC + ABAC policy
+
+Creates a new publish-vote attempt with frozen roster (owner+member,
+INV-P6-1). Pre-conditions check scene state, prior publication,
+active attempt, and max-attempts budget. Emits scene_publish_started
+via the event emitter (Phase D wires the real emit). Spec section 5,
+8 (holomush-5rh.15)."
+```
+
+### Task B3: `CastPublishSceneVote` handler + resolution check
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/publish_service_test.go`
+
+**Spec ref:** §5 CastPublishSceneVote, §4.3 resolution check
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestCastPublishSceneVote_FirstYesIsNotAChange(t *testing.T) { ... }
+func TestCastPublishSceneVote_FlipYesToNoIsAChange(t *testing.T) { ... }
+func TestCastPublishSceneVote_NonRosterMemberRejected(t *testing.T) { ... }
+func TestCastPublishSceneVote_TriggersCoolOffOnAllYes(t *testing.T) {
+    // 2-voter roster; vote 1 yes; vote 2 yes; assert store transitions to COOLOFF
+    ...
+}
+func TestCastPublishSceneVote_TriggersAttemptFailedOnAnyNoAfterAllVoted(t *testing.T) { ... }
+func TestCastPublishSceneVote_FlipFromYesToNoDuringCoolOffReturnsToCollecting(t *testing.T) { ... }
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+- [ ] **Step 3: Implement**
+
+```go
+func (s *SceneServiceImpl) CastPublishSceneVote(ctx context.Context, req *scenev1.CastPublishSceneVoteRequest) (*scenev1.CastPublishSceneVoteResponse, error) {
+    ctx, span := startSpan(ctx, "scene.service.cast_publish_scene_vote",
+        attribute.String("published_scene_id", req.GetPublishedSceneId()))
+    defer span.End()
+
+    callerID, err := parseCallerCharacterID(req.GetCallerCharacterId())
+    if err != nil { return nil, err }
+
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetPublishedSceneId())
+    if err != nil { return nil, mapStoreErr(err) }
+    if pub == nil {
+        return nil, status.Error(codes.NotFound, "publication attempt not found")
+    }
+    if pub.Status.IsTerminal() {
+        return nil, oops.Code("SCENE_PUBLISH_INVALID_STATE").
+            With("status", string(pub.Status)).
+            Errorf("vote on terminal attempt rejected")
+    }
+
+    result, err := s.store.CastVote(ctx, pub.ID, callerID, req.GetVote())
+    if err != nil { return nil, mapStoreErr(err) }
+
+    // Run resolution check; transition status if appropriate.
+    if err := s.applyResolution(ctx, pub); err != nil {
+        slog.WarnContext(ctx, "resolution check failed", "err", err, "attempt_id", pub.ID)
+        // Resolution failures don't fail the vote — the next cast/tick retries.
+    }
+
+    metricScenePublishVoteCast(boolLabel(result.Vote), boolLabel(result.IsChange))
+    if emitErr := s.events.emitVoteCast(ctx, pub.ID, callerID, result); emitErr != nil {
+        slog.WarnContext(ctx, "vote-cast emit failed", "err", emitErr)
+    }
+
+    return &scenev1.CastPublishSceneVoteResponse{IsChange: result.IsChange}, nil
+}
+
+// applyResolution checks vote tally and transitions status if applicable.
+// See spec §4.3.
+func (s *SceneServiceImpl) applyResolution(ctx context.Context, pub *PublishedScene) error {
+    tally, err := s.store.TallyVotes(ctx, pub.ID)
+    if err != nil { return err }
+    switch pub.Status {
+    case StatusCollecting:
+        trig, ok := ResolveFromTally(*tally)
+        if !ok { return nil }
+        return s.applyTrigger(ctx, pub.ID, trig)
+    case StatusCoolOff:
+        if tally.No > 0 {
+            return s.applyTrigger(ctx, pub.ID, TriggerFlipNo)
+        }
+    }
+    return nil
+}
+
+// applyTrigger drives the DB state transition for a publish-vote attempt.
+// Reads the current row, computes the next status via the pure NextStatus
+// helper (publish_state.go), and applies the side effects (TransitionStatus
+// store call, metric counter, event emit). Event emission is best-effort
+// in Phase B — Phase D's publishEventEmitter wires the real Emit; Phase B
+// uses a no-op emitter so the state-machine tests pass without depending
+// on Phase D's event substrate.
+func (s *SceneServiceImpl) applyTrigger(ctx context.Context, attemptID string, t PublishTrigger) error {
+    pub, err := s.store.GetPublishedSceneHeader(ctx, attemptID)
+    if err != nil {
+        return err
+    }
+    if pub == nil {
+        return oops.Code("SCENE_PUBLISH_ATTEMPT_NOT_FOUND").
+            With("attempt_id", attemptID).Errorf("attempt vanished")
+    }
+    next, ok := NextStatus(pub.Status, t)
+    if !ok {
+        return oops.Code("SCENE_PUBLISH_INVALID_TRANSITION").
+            With("from", string(pub.Status)).
+            With("trigger", string(t)).
+            Errorf("illegal transition")
+    }
+
+    in := TransitionInput{To: next, Resolved: next.IsTerminal()}
+    if next == StatusAttemptFailed {
+        reason, hasReason := FailureReasonForTrigger(t)
+        if !hasReason {
+            // Snapshot/cooloff-invariant triggers are not in FailureReasonForTrigger;
+            // they're applied via failAttempt from publish_snapshot.go directly.
+            return oops.Code("SCENE_PUBLISH_INVALID_TRANSITION").
+                With("trigger", string(t)).Errorf("no failure_reason mapping")
+        }
+        in.FailureReason = &reason
+    }
+    if next == StatusCoolOff {
+        now := time.Now()
+        in.SetCoolOffAt = &now
+    }
+    if next == StatusCollecting && pub.Status == StatusCoolOff {
+        in.ClearCoolOff = true
+    }
+
+    if err := s.store.TransitionStatus(ctx, attemptID, in); err != nil {
+        return err
+    }
+
+    // Metrics + observability — emit is best-effort; failure logs but does
+    // not roll back the transition (DB state is the source of truth).
+    if next.IsTerminal() {
+        reasonLabel := ""
+        if in.FailureReason != nil {
+            reasonLabel = string(*in.FailureReason)
+        } else if next == StatusPublished {
+            reasonLabel = "all_yes"
+        }
+        metricScenePublishAttemptResolved(string(next), reasonLabel)
+    }
+    if next == StatusCoolOff {
+        if emitErr := s.events.emitCoolOffStarted(ctx, attemptID, pub.CoolOffWindow); emitErr != nil {
+            slog.WarnContext(ctx, "cooloff-started emit failed", "err", emitErr, "attempt_id", attemptID)
+        }
+    }
+    if next.IsTerminal() {
+        tally, _ := s.store.TallyVotes(ctx, attemptID)
+        if emitErr := s.events.emitResolved(ctx, attemptID, next, in.FailureReason, tally); emitErr != nil {
+            slog.WarnContext(ctx, "resolved emit failed", "err", emitErr, "attempt_id", attemptID)
+        }
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test -- -run TestCastPublishSceneVote ./plugins/core-scenes/`
+Expected: PASS — state-machine transitions exercise `applyTrigger` against a fake store; the no-op `publishEventEmitter` (set in `NewSceneServiceImpl` default) absorbs every emit call so tests pass before Phase D.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): CastPublishSceneVote + applyTrigger state machine
+
+Vote upsert with is_change tracking, triggers resolution check that
+transitions COLLECTING→COOLOFF on all-yes or COLLECTING→ATTEMPT_FAILED
+on any-no-after-all-voted. COOLOFF→COLLECTING flip-back on any post-
+cooloff no. applyTrigger reads current status, computes next via
+NextStatus (pure helper), applies TransitionInput to store, fires
+metric stub + emit (no-op in Phase B; Phase D wires real emitter).
+Spec section 4.3, 5 (holomush-5rh.15)."
+```
+
+### Task B4: `WithdrawScenePublish` handler + ABAC policy
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/plugin.yaml` (add `withdraw-publish-as-owner` policy)
+- Modify: `plugins/core-scenes/publish_service_test.go`
+
+**Spec ref:** §5 WithdrawScenePublish, §8
+
+- [ ] **Step 1: Write failing tests** — happy path (owner), rejection (non-owner), rejection (terminal).
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement**
+
+```go
+func (s *SceneServiceImpl) WithdrawScenePublish(ctx context.Context, req *scenev1.WithdrawScenePublishRequest) (*scenev1.WithdrawScenePublishResponse, error) {
+    callerID, err := parseCallerCharacterID(req.GetCallerCharacterId())
+    if err != nil { return nil, err }
+
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetPublishedSceneId())
+    if err != nil { return nil, mapStoreErr(err) }
+    if pub == nil { return nil, status.Error(codes.NotFound, "attempt not found") }
+    if pub.Status.IsTerminal() {
+        return nil, oops.Code("SCENE_PUBLISH_INVALID_STATE").Errorf("attempt already terminal")
+    }
+    scene, err := s.store.GetScene(ctx, pub.SceneID)
+    if err != nil { return nil, mapStoreErr(err) }
+    if scene.OwnerID != callerID {
+        return nil, oops.Code("SCENE_PUBLISH_NOT_OWNER").
+            With("scene_id", pub.SceneID).Errorf("only the scene owner may withdraw")
+    }
+
+    if err := s.applyTrigger(ctx, pub.ID, TriggerWithdraw); err != nil {
+        return nil, mapStoreErr(err)
+    }
+    return &scenev1.WithdrawScenePublishResponse{}, nil
+}
+```
+
+Add policy to `plugin.yaml`:
+
+```yaml
+- name: withdraw-publish-as-owner
+  dsl: >-
+    permit(principal is character, action in ["withdraw_publish"], resource is scene)
+    when { resource.scene.owner == principal.id };
+```
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task B5: `GetPublishedScene` + **INV-S9 tripwire test (CRITICAL)**
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Create: `plugins/core-scenes/service_publish_gate_test.go`
+
+**Spec ref:** §9.1, §9.4, INV-P6-5, INV-P6-6
+
+- [ ] **Step 1: Write the **load-bearing** tripwire test FIRST**
+
+This is the test that pins INV-S9 ordering for Phase 6. It MUST exist before the handler.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "context"
+    "sync/atomic"
+    "testing"
+
+    "github.com/holomush/holomush/pkg/errutil"
+    scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+    "github.com/stretchr/testify/require"
+)
+
+// contentTripwireStore embeds a fake header store and tracks any call
+// into GetPublishedSceneContent. The test asserts the tripwire is NOT
+// hit when a non-participant is denied at the gate — INV-P6-5 ordering.
+type contentTripwireStore struct {
+    *fakeStore
+    contentReadCalls atomic.Int32
+}
+
+func (s *contentTripwireStore) GetPublishedSceneContent(_ context.Context, _ string) ([]Entry, error) {
+    s.contentReadCalls.Add(1)
+    return nil, nil
+}
+
+func TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore(t *testing.T) {
+    t.Parallel()
+    base := newFakeStore()
+    base.installPublishedAttempt("pub-1", "scene-1", StatusPublished)
+    base.installSceneWithRoster("scene-1", "owner-1", []string{"owner-1", "member-1"})
+    // Caller "alice" is NOT in scene-1's roster.
+    store := &contentTripwireStore{fakeStore: base}
+    svc := NewSceneServiceImpl(store)
+
+    _, err := svc.GetPublishedScene(callerContext("alice"), &scenev1.GetPublishedSceneRequest{Id: "pub-1"})
+
+    require.Error(t, err)
+    require.True(t, errutil.MatchCode(err, "SCENE_PRIVACY_BOUNDARY_BLOCK"),
+        "non-participant must receive SCENE_PRIVACY_BOUNDARY_BLOCK")
+    require.Equal(t, int32(0), store.contentReadCalls.Load(),
+        "INV-P6-5 violation: content store hit before the participant gate denied")
+}
+
+// INV-P6-6 is enforced structurally, not via runtime injection: the
+// SceneServiceImpl has no ABAC-engine field, so participant-gated
+// handlers physically cannot call the engine. This test is an AST-
+// level assertion that publish_service.go imports no policy package
+// and references no policy.* symbol. If a future PR adds an engine
+// field or import, this test fires immediately.
+func TestPublicationServiceFileImportsNoABACPolicyPackage(t *testing.T) {
+    t.Parallel()
+    src, err := os.ReadFile("publish_service.go")
+    require.NoError(t, err)
+    fset := token.NewFileSet()
+    f, err := parser.ParseFile(fset, "publish_service.go", src, parser.ImportsOnly)
+    require.NoError(t, err)
+    for _, imp := range f.Imports {
+        path := strings.Trim(imp.Path.Value, `"`)
+        require.False(t, strings.HasPrefix(path, "github.com/holomush/holomush/internal/access/policy"),
+            "INV-P6-6 violation: publish_service.go imports ABAC policy package %s", path)
+    }
+}
+
+func TestPublicationServiceTypeHasNoABACEngineField(t *testing.T) {
+    t.Parallel()
+    // Reflection-based field enumeration; fails if any field's type name
+    // contains "policy" or "Engine" — those are the ABAC engine signals.
+    typ := reflect.TypeOf(SceneServiceImpl{})
+    for i := 0; i < typ.NumField(); i++ {
+        f := typ.Field(i)
+        require.NotContains(t, strings.ToLower(f.Type.String()), "policy.engine",
+            "INV-P6-6 violation: field %s carries ABAC engine type %s", f.Name, f.Type.String())
+    }
+}
+```
+
+(Imports needed in the test file: `"go/parser"`, `"go/token"`, `"os"`, `"reflect"`, `"strings"`.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run "TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore|TestPublicationServiceFileImportsNoABACPolicyPackage|TestPublicationServiceTypeHasNoABACEngineField" ./plugins/core-scenes/`
+Expected: FAIL on `TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore` (handler not implemented yet); the two structural tests should PASS immediately because `publish_service.go` doesn't exist yet (the file-read test errors on missing file, which is its own pre-condition — handle by creating an empty `publish_service.go` first OR by gating the file-read test to require the file to exist, and rely on the reflection test as the live INV-P6-6 lock).
+
+- [ ] **Step 3: Implement `GetPublishedScene` per spec §9.1**
+
+```go
+func (s *SceneServiceImpl) GetPublishedScene(ctx context.Context, req *scenev1.GetPublishedSceneRequest) (*scenev1.GetPublishedSceneResponse, error) {
+    ctx, span := startSpan(ctx, "scene.service.get_published_scene",
+        attribute.String("published_scene_id", req.GetId()))
+    defer span.End()
+
+    callerID, err := parseCallerCharacterID(req.GetCallerCharacterId())
+    if err != nil { return nil, err }
+
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetId())
+    if err != nil { return nil, mapStoreErr(err) }
+    if pub == nil { return nil, status.Error(codes.NotFound, "publication not found") }
+
+    // INV-S9 plugin-code gate. NO ABAC engine consultation.
+    ok, err := s.store.IsParticipant(ctx, pub.SceneID, callerID)
+    if err != nil { return nil, internalErr(err) }
+    if !ok {
+        s.emitPrivacyBoundaryBlock(ctx, "GetPublishedScene", pub.SceneID, callerID, "not_participant")
+        return nil, oops.Code("SCENE_PRIVACY_BOUNDARY_BLOCK").
+            Errorf("scene not accessible")
+    }
+
+    var entries []Entry
+    if pub.Status == StatusPublished {
+        entries, err = s.store.GetPublishedSceneContent(ctx, req.GetId())
+        if err != nil { return nil, internalErr(err) }
+    }
+    tally, err := s.store.TallyVotes(ctx, pub.ID)
+    if err != nil { return nil, mapStoreErr(err) }
+
+    return assembleParticipantResponse(pub, entries, tally), nil
+}
+
+// emitPrivacyBoundaryBlock is the triple-signal helper. See spec §10.
+func (s *SceneServiceImpl) emitPrivacyBoundaryBlock(ctx context.Context, op, sceneID, callerID, reason string) {
+    slog.WarnContext(ctx, "scene privacy boundary block",
+        "operation", op,
+        "scene_id", sceneID,
+        "caller_id", callerID,
+        "denial_reason", reason,
+        "code", "SCENE_PRIVACY_BOUNDARY_BLOCK")
+    metricScenePublishPrivacyBlock(op, reason)
+    span := trace.SpanFromContext(ctx)
+    span.SetStatus(otelcodes.Error, "denied")
+    span.SetAttributes(attribute.String("deny.reason", reason))
+}
+```
+
+(`assembleParticipantResponse` is a small pure function that maps `(*PublishedScene, []Entry, *VoteTally)` → `*scenev1.GetPublishedSceneResponse`.)
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `task test -- -run "TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore|TestPublicationServiceFileImportsNoABACPolicyPackage|TestPublicationServiceTypeHasNoABACEngineField" ./plugins/core-scenes/`
+Expected: PASS — tripwire never fires; no ABAC package imported by publish_service.go; SceneServiceImpl has no field carrying a `policy.Engine` type.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): GetPublishedScene + INV-S9 plugin-code gate
+
+Participant-gated read with the load-bearing INV-P6-5 ordering: caller
+validation → header read → IsParticipant check → content read only on
+gate pass. Tripwire test asserts content store NOT hit when gate denies.
+emitPrivacyBoundaryBlock implements the triple-signal (slog WARN, metric
+stub, span error). Spec section 9, 10 (holomush-5rh.15)."
+```
+
+### Task B6: `DownloadPublishedScene` + INV-S9 gate
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/service_publish_gate_test.go`
+
+Same pattern as B5 — write tripwire test for download path; implement handler that runs `IsParticipant` before any content read.
+
+- [ ] **Step 1: Write tripwire test for download**
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement** (calls into `publish_render` from Phase C; for now stub the render call)
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task B7: `ListScenePublishAttempts` + INV-S9 gate
+
+Same pattern as B5.
+
+- [ ] Steps 1–5: as above
+
+### Task B8: `scene publish` command handler
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+**Spec ref:** §6.1
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestSceneCommand_Publish_DispatchesToService(t *testing.T) {
+    plugin := newTestPluginWithEndedScene("scene-1", "owner-1")
+    resp, err := plugin.handlePublish(callerContext("owner-1"), commandReq("scene-1", ""), "")
+    require.NoError(t, err)
+    require.NotNil(t, resp)
+    // Assert response contains attempt_number and id.
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement `handlePublish` in `commands.go`**
+
+```go
+func (p *scenePlugin) handlePublish(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+    sceneID, err := resolveSceneRef(ctx, p.service.store, req.CharacterID, args)
+    if err != nil {
+        return pluginsdk.Errorf("%s", err.Error()), nil
+    }
+    resp, err := p.service.StartScenePublish(ctx, &scenev1.StartScenePublishRequest{SceneId: sceneID})
+    if err != nil {
+        return pluginsdk.Errorf("%s", err.Error()), nil
+    }
+    return pluginsdk.OK(fmt.Sprintf(
+        "Publish-vote attempt #%d started for scene %s. Participants will be notified.",
+        resp.AttemptNumber, sceneID,
+    )), nil
+}
+```
+
+Wire into the dispatcher (the existing subcommand switch in `commands.go`).
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task B9: `scene publish vote yes|no` commands
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+Same shape as B8. Dispatch routes `scene publish vote yes` to `CastPublishSceneVote(vote=true)`, `scene publish vote no` to `vote=false`.
+
+- [ ] Steps 1–5: as above
+
+### Task B10: `scene publish withdraw` + `scene publish status` + `scene publish download` commands
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+Three small handlers wiring `WithdrawScenePublish`, `GetPublishedScene`, `DownloadPublishedScene` to the SDK.
+
+- [ ] Steps 1–5: as above for each
+
+---
+
+## Phase C — Public Surface + Snapshot Pipeline + Renderers
+
+Phase C ships the public RPC pair (`GetPublicSceneArchive`, `DownloadPublicSceneArchive`), the three renderers (markdown / plain text / jsonl), and the COOLOFF → PUBLISHED snapshot pipeline. By end of Phase C, a successfully resolved vote can transition to PUBLISHED with content_entries populated from the decrypted IC event stream, and public consumers can read the artifact via the public RPC pair.
+
+**Spec coverage:** §5 (public RPCs), §11 (snapshot pipeline), §12 (renderers), INV-P6-8, INV-P6-10.
+
+### Task C1: Markdown renderer + escape tests
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_render.go`
+- Create: `plugins/core-scenes/publish_render_test.go`
+
+**Spec ref:** §12
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestRenderMarkdown_FromEntries(t *testing.T) { ... }
+func TestRenderMarkdown_EmptyEntries(t *testing.T) { ... }
+func TestRenderMarkdown_EscapesMarkdownSyntax(t *testing.T) { ... }
+func TestRenderMarkdown_PreservesUnicodeAndEmoji(t *testing.T) { ... }
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement `renderMarkdown([]Entry) string`**
+
+```go
+func renderMarkdown(entries []Entry) string {
+    if len(entries) == 0 {
+        return "_No content was recorded for this scene._\n"
+    }
+    var b strings.Builder
+    for _, e := range entries {
+        switch e.Kind {
+        case EntryKindPose:
+            fmt.Fprintf(&b, "**%s** %s\n\n", escapeMarkdown(e.Speaker), escapeMarkdown(e.Content))
+        case EntryKindSay:
+            fmt.Fprintf(&b, "**%s** says, \"%s\"\n\n", escapeMarkdown(e.Speaker), escapeMarkdown(e.Content))
+        case EntryKindEmit:
+            fmt.Fprintf(&b, "_%s_\n\n", escapeMarkdown(e.Content))
+        }
+    }
+    return b.String()
+}
+
+func escapeMarkdown(s string) string {
+    var b strings.Builder
+    for _, r := range s {
+        switch r {
+        case '*', '_', '[', ']', '`', '\\':
+            b.WriteByte('\\')
+        }
+        b.WriteRune(r)
+    }
+    return b.String()
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task C2: Plain-text renderer + golden file
+
+Same shape; `renderPlainText([]Entry) string` strips bolding to produce `Alice smiles. Alice says, "Hi." ...`. Golden file in `plugins/core-scenes/testdata/publish_render_plain_text.golden`.
+
+- [ ] Steps 1–5
+
+### Task C3: JSONL renderer + round-trip test
+
+`renderJSONL([]Entry) ([]byte, error)` — emits one JSON object per line. Round-trip test: marshal then split-and-unmarshal should yield equal slice.
+
+- [ ] Steps 1–5
+
+### Task C4: `GetPublicSceneArchive` + opacity tests
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Create: `plugins/core-scenes/service_public_archive_test.go`
+
+**Spec ref:** §5.1, §9.2, INV-P6-8
+
+- [ ] **Step 1: Write failing opacity tests**
+
+```go
+func TestGetPublicSceneArchive_OpacityTable(t *testing.T) {
+    t.Parallel()
+    cases := []struct {
+        name   string
+        setup  func(*fakeStore)
+        argID  string
+    }{
+        {"nonexistent id", func(*fakeStore) {}, "missing-id"},
+        {"COLLECTING attempt", installAttempt("pub-1", StatusCollecting), "pub-1"},
+        {"COOLOFF attempt", installAttempt("pub-2", StatusCoolOff), "pub-2"},
+        {"ATTEMPT_FAILED attempt", installAttempt("pub-3", StatusAttemptFailed), "pub-3"},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            store := newFakeStore()
+            tc.setup(store)
+            svc := NewSceneServiceImpl(store)
+            _, err := svc.GetPublicSceneArchive(context.Background(), &scenev1.GetPublicSceneArchiveRequest{PublishedSceneId: tc.argID})
+            require.Error(t, err)
+            assert.Equal(t, codes.NotFound, status.Code(err),
+                "INV-P6-8: opaque NOT_FOUND for all non-PUBLISHED states")
+            assert.Equal(t, "scene archive not found", status.Convert(err).Message(),
+                "INV-P6-8: identical wire message across non-PUBLISHED states")
+        })
+    }
+}
+
+func TestGetPublicSceneArchive_PublishedReturnsContent(t *testing.T) {
+    store := newFakeStoreWithPublishedScene("pub-1", "scene-1", []Entry{
+        {Speaker: "Alice", Kind: EntryKindSay, Content: "Hello."},
+    })
+    svc := NewSceneServiceImpl(store)
+    resp, err := svc.GetPublicSceneArchive(context.Background(), &scenev1.GetPublicSceneArchiveRequest{PublishedSceneId: "pub-1"})
+    require.NoError(t, err)
+    require.Len(t, resp.ContentEntries, 1)
+    assert.Equal(t, "Alice", resp.ContentEntries[0].Speaker)
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement** per spec §9.2:
+
+```go
+func (s *SceneServiceImpl) GetPublicSceneArchive(ctx context.Context, req *scenev1.GetPublicSceneArchiveRequest) (*scenev1.GetPublicSceneArchiveResponse, error) {
+    ctx, span := startSpan(ctx, "scene.service.get_public_scene_archive",
+        attribute.String("published_scene_id", req.GetPublishedSceneId()))
+    defer span.End()
+
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetPublishedSceneId())
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+    if pub == nil || pub.Status != StatusPublished {
+        return nil, status.Error(codes.NotFound, "scene archive not found")
+    }
+    entries, err := s.store.GetPublishedSceneContent(ctx, req.GetPublishedSceneId())
+    if err != nil { return nil, internalErr(err) }
+    return assemblePublicResponse(pub, entries), nil
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task C5: `DownloadPublicSceneArchive` + opacity tests
+
+Same shape as C4, but routes to a renderer based on the `format` field. Add to `service_public_archive_test.go`.
+
+- [ ] Steps 1–5
+
+### Task C6: Snapshot pipeline scaffolding — `ReadSceneLogForSnapshot`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_store.go`
+- Modify: `plugins/core-scenes/store_integration_test.go`
+
+**Spec ref:** §11.1
+
+- [ ] **Step 1: Write failing integration test** — insert mixed events (poses + says + emits + OOC + ops) into scene_log; assert `ReadSceneLogForSnapshot` returns only pose/say/emit in chronological order.
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement**
+
+```go
+func (s *SceneStore) ReadSceneLogForSnapshot(ctx context.Context, tx pgx.Tx, sceneID string) ([]LogRow, error) {
+    subject := fmt.Sprintf("events.%s.scene.%s.ic", s.gameID, sceneID)
+    rows, err := tx.Query(ctx, `
+        SELECT id, type, payload, schema_ver, codec, dek_ref, dek_version
+        FROM scene_log
+        WHERE subject = $1 AND type IN ('scene_pose','scene_say','scene_emit')
+        ORDER BY id ASC
+    `, subject)
+    // ... scan into []LogRow ...
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task C7: Snapshot pipeline — decrypt + render + atomic transition
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_snapshot.go`
+- Create: `plugins/core-scenes/publish_snapshot_integration_test.go`
+
+**Spec ref:** §11.2, §11.3, INV-P6-10
+
+- [ ] **Step 1: Write failing integration test for happy path: PUBLISHED transition with content_entries populated**
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement `runSnapshot`** per spec §11 pseudocode (in design doc lines 487-553)
+- [ ] **Step 4: Write additional failing tests for failure modes** (decrypt fail, render fail, idempotent re-run)
+- [ ] **Step 5: Implement failure-mode handling**
+- [ ] **Step 6: Run, verify all PASS**
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): snapshot pipeline COOLOFF → PUBLISHED
+
+Atomic transaction: SELECT FOR UPDATE → re-validate all-yes → read
+scene_log rows for pose/say/emit → decrypt sensitive payloads → render
+to JSONB entries → UPDATE status PUBLISHED + content + participants
+snapshot → archive parent scene. Failure modes transition to ATTEMPT_
+FAILED with specific reason. INV-P6-10 atomicity asserted by idempotent
+re-fire test. Crypto-reviewer must pass before push."
+```
+
+---
+
+## Phase D — Events, Crypto Manifest, Observability
+
+Phase D adds the 6 new IC stream event types (sensitivity:never), wires emission into every state transition, adds the 7 metric stubs, and creates the resolver meta-test enforcing INV-P6-7.
+
+**Spec coverage:** §7 event emission, §10 privacy block triple signal, §13 observability, INV-P6-7, INV-P6-9.
+
+### Task D1: Update `plugin.yaml` crypto.emits with 6 new types
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml`
+
+**Spec ref:** §7
+
+- [ ] **Step 1: Append the 6 new entries under `crypto.emits` in the existing list (after `scene_idle_nudge`)**
+
+```yaml
+    - event_type: scene_publish_started
+      sensitivity: never
+      description: "Notice that a scene publish-vote attempt has started; emit time + roster, no content."
+    - event_type: scene_publish_vote_cast
+      sensitivity: never
+      description: "Notice that a roster member cast or changed a vote; character + vote + is_change, no content."
+    - event_type: scene_publish_cooloff_started
+      sensitivity: never
+      description: "Notice that all roster members have voted yes and the cool-off window has begun; ends_at timestamp, no content."
+    - event_type: scene_publish_resolved
+      sensitivity: never
+      description: "Notice of terminal transition (PUBLISHED or ATTEMPT_FAILED) with outcome + reason + tally summary, no IC content."
+    - event_type: scene_publish_withdrawn
+      sensitivity: never
+      description: "Notice that the scene owner withdrew the active publish attempt; emitted alongside scene_publish_resolved."
+    - event_type: scene_publish_vote_attempts_extended
+      sensitivity: never
+      description: "Notice that an admin extended the per-scene publish-attempts budget; new_max + admin_id, no content."
+```
+
+- [ ] **Step 2: Run plugin schema lint**
+
+Run: `task lint` (rumdl + schema validation)
+Expected: PASS — manifest schema accepts the additive entries.
+
+- [ ] **Step 3: Run crypto-reviewer (the agent gate)**
+
+This step requires the user to run `/review-crypto` against the manifest diff. The crypto-reviewer agent verifies the additive declarations match repo invariants. Note in the commit body that the gate fired.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(scene-manifest): declare 6 Phase 6 publish notice events
+
+crypto.emits additions: scene_publish_started, scene_publish_vote_cast,
+scene_publish_cooloff_started, scene_publish_resolved,
+scene_publish_withdrawn, scene_publish_vote_attempts_extended. All
+sensitivity:never — operational metadata, no IC content. Crypto-
+reviewer: READY (additive never declarations; no payload-encryption
+rule changes)."
+```
+
+### Task D2: Event emission helpers (`publish_events.go`)
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_events.go`
+- Modify: `plugins/core-scenes/publish_service.go` (wire `s.events` field)
+
+**Spec ref:** §7
+
+**Design note:** Real emit shape from `commands.go:888-894` in `handleEmit`:
+
+```go
+intent := pluginsdk.EmitIntent{
+    Subject: subject,
+    Type:    pluginsdk.EventType(eventType),
+    Payload: payloadBytes,
+    // Headers, ActorKind, ActorID etc. set per emit context
+}
+if err := p.service.eventSink.Emit(ctx, intent); err != nil { ... }
+```
+
+Phase 6 emitter follows this same shape. The `SceneServiceImpl` already has an `eventSink pluginsdk.EventSink` field (set via `SetEventSink`, mirroring the focusClient wiring from Phase 5 / `commands.go:879`). Phase 6 adds a thin wrapper `publishEventEmitter` that holds an `EventSink` reference and exposes one method per event type with typed signatures so handler call-sites stay readable.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// publish_events_test.go (unit, against a fake EventSink that records intents)
+
+type recordingEventSink struct {
+    intents []pluginsdk.EmitIntent
+    err     error
+}
+
+func (r *recordingEventSink) Emit(_ context.Context, intent pluginsdk.EmitIntent) error {
+    r.intents = append(r.intents, intent)
+    return r.err
+}
+
+func TestEmitPublishStarted_SetsSubjectTypeAndPayload(t *testing.T) {
+    t.Parallel()
+    sink := &recordingEventSink{}
+    // newPublishEventEmitter needs a store reference to fetch the roster
+    // on emitPublishStarted (the handler doesn't pass roster explicitly).
+    fakeStore := newFakeStoreWithRoster("pub-1", []string{"char-1", "char-2"})
+    em := newPublishEventEmitter(sink, fakeStore, "test-game")
+    pub := &PublishedScene{
+        ID: "pub-1", SceneID: "scene-1", AttemptNumber: 1,
+        InitiatedBy: "char-1",
+        VoteWindow: 7 * 24 * time.Hour, CoolOffWindow: 30 * time.Minute,
+    }
+    err := em.emitPublishStarted(context.Background(), pub)
+    require.NoError(t, err)
+    require.Len(t, sink.intents, 1)
+    intent := sink.intents[0]
+    assert.Equal(t, "events.test-game.scene.scene-1.ic", intent.Subject)
+    assert.Equal(t, pluginsdk.EventType("scene_publish_started"), intent.Type)
+    // Decode payload and assert fields match.
+    var ev scenev1.ScenePublishStartedEvent
+    require.NoError(t, proto.Unmarshal(intent.Payload, &ev))
+    assert.Equal(t, "pub-1", ev.AttemptId)
+    assert.Equal(t, int32(1), ev.AttemptNumber)
+    assert.Equal(t, "char-1", ev.InitiatedBy)
+    assert.ElementsMatch(t, []string{"char-1", "char-2"}, ev.RosterCharacterIds)
+}
+
+// Repeat for emitVoteCast, emitCoolOffStarted, emitResolved, emitWithdrawn, emitAttemptsExtended.
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `task test -- -run "TestEmitPublish" ./plugins/core-scenes/`
+Expected: FAIL — `undefined: newPublishEventEmitter`, missing event proto types.
+
+- [ ] **Step 3: Add event proto messages to `scene.proto` + regenerate**
+
+Append to `scene.proto` (one message per IC notice event):
+
+```protobuf
+message ScenePublishStartedEvent {
+  string attempt_id = 1;
+  int32 attempt_number = 2;
+  string initiated_by = 3;
+  int64 vote_window_seconds = 4;
+  int64 cooloff_window_seconds = 5;
+  repeated string roster_character_ids = 6;
+}
+
+message ScenePublishVoteCastEvent {
+  string attempt_id = 1;
+  string character_id = 2;
+  bool vote = 3;
+  bool is_change = 4;
+}
+
+message ScenePublishCoolOffStartedEvent {
+  string attempt_id = 1;
+  int64 cooloff_ends_at_unix_ns = 2;
+}
+
+message ScenePublishResolvedEvent {
+  string attempt_id = 1;
+  string outcome = 2;        // "PUBLISHED" | "ATTEMPT_FAILED"
+  string failure_reason = 3; // empty unless ATTEMPT_FAILED
+  int32 tally_yes = 4;
+  int32 tally_no = 5;
+  int32 tally_pending = 6;
+}
+
+message ScenePublishWithdrawnEvent {
+  string attempt_id = 1;
+  string withdrawn_by = 2;
+}
+
+message ScenePublishVoteAttemptsExtendedEvent {
+  string scene_id = 1;
+  int32 additional = 2;
+  int32 new_max = 3;
+  string admin_id = 4;
+}
+```
+
+Run: `task proto`
+Expected: regenerated `*.pb.go` files.
+
+- [ ] **Step 4: Implement `publish_events.go`**
+
+The struct must satisfy the `publishEventer` interface declared in Task B1.5 `publish_helpers.go`. All six methods take their inputs verbatim from the handler call sites; the emitter is responsible for fetching auxiliary data (roster) and computing the subject string. It needs a `sceneStorer` reference to load the roster on `emitPublishStarted`.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    pluginsdk "github.com/holomush/holomush/pkg/plugin"
+    scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+    "google.golang.org/protobuf/proto"
+)
+
+// publishEventEmitter is the production publishEventer (interface defined
+// in publish_helpers.go). Wraps EventSink + sceneStorer; the latter so
+// emitPublishStarted can load the roster without the handler needing to
+// pass it explicitly.
+//
+// Every event emits on the scene IC subject events.<game_id>.scene.<scene_id>.ic
+// with sensitivity:never per crypto.emits manifest entries.
+type publishEventEmitter struct {
+    sink   pluginsdk.EventSink
+    store  sceneStorer
+    gameID string
+}
+
+func newPublishEventEmitter(sink pluginsdk.EventSink, store sceneStorer, gameID string) *publishEventEmitter {
+    return &publishEventEmitter{sink: sink, store: store, gameID: gameID}
+}
+
+func (e *publishEventEmitter) emitPublishStarted(ctx context.Context, pub *PublishedScene) error {
+    voters, err := e.store.ListPublishVoters(ctx, pub.ID)
+    if err != nil {
+        return err
+    }
+    roster := make([]string, 0, len(voters))
+    for _, v := range voters {
+        roster = append(roster, v.CharacterID)
+    }
+    payload, err := proto.Marshal(&scenev1.ScenePublishStartedEvent{
+        AttemptId:            pub.ID,
+        AttemptNumber:        int32(pub.AttemptNumber),
+        InitiatedBy:          pub.InitiatedBy,
+        VoteWindowSeconds:    int64(pub.VoteWindow.Seconds()),
+        CoolOffWindowSeconds: int64(pub.CoolOffWindow.Seconds()),
+        RosterCharacterIds:   roster,
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(pub.SceneID),
+        Type:    pluginsdk.EventType("scene_publish_started"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) emitVoteCast(ctx context.Context, attemptID, characterID string, result *CastVoteResult) error {
+    // We need the scene_id for the subject. Fetch from the header (cheap;
+    // one row by primary key). Alternative: pass scene_id through the
+    // handler call chain — rejected because it bloats every call site.
+    pub, err := e.store.GetPublishedSceneHeader(ctx, attemptID)
+    if err != nil {
+        return err
+    }
+    payload, err := proto.Marshal(&scenev1.ScenePublishVoteCastEvent{
+        AttemptId: attemptID, CharacterId: characterID,
+        Vote: result.Vote, IsChange: result.IsChange,
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(pub.SceneID),
+        Type:    pluginsdk.EventType("scene_publish_vote_cast"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) emitCoolOffStarted(ctx context.Context, attemptID string, window time.Duration) error {
+    pub, err := e.store.GetPublishedSceneHeader(ctx, attemptID)
+    if err != nil {
+        return err
+    }
+    payload, err := proto.Marshal(&scenev1.ScenePublishCoolOffStartedEvent{
+        AttemptId:           attemptID,
+        CoolOffEndsAtUnixNs: time.Now().Add(window).UnixNano(),
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(pub.SceneID),
+        Type:    pluginsdk.EventType("scene_publish_cooloff_started"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) emitResolved(ctx context.Context, attemptID string, finalStatus PublishedSceneStatus, reason *PublishFailureReason, tally *VoteTally) error {
+    pub, err := e.store.GetPublishedSceneHeader(ctx, attemptID)
+    if err != nil {
+        return err
+    }
+    reasonStr := ""
+    if reason != nil {
+        reasonStr = string(*reason)
+    }
+    var y, n, p int32
+    if tally != nil {
+        y, n, p = int32(tally.Yes), int32(tally.No), int32(tally.Pending)
+    }
+    payload, err := proto.Marshal(&scenev1.ScenePublishResolvedEvent{
+        AttemptId:     attemptID,
+        Outcome:       string(finalStatus),
+        FailureReason: reasonStr,
+        TallyYes:      y,
+        TallyNo:       n,
+        TallyPending:  p,
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(pub.SceneID),
+        Type:    pluginsdk.EventType("scene_publish_resolved"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) emitWithdrawn(ctx context.Context, attemptID, withdrawnBy string) error {
+    pub, err := e.store.GetPublishedSceneHeader(ctx, attemptID)
+    if err != nil {
+        return err
+    }
+    payload, err := proto.Marshal(&scenev1.ScenePublishWithdrawnEvent{
+        AttemptId: attemptID, WithdrawnBy: withdrawnBy,
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(pub.SceneID),
+        Type:    pluginsdk.EventType("scene_publish_withdrawn"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) emitAttemptsExtended(ctx context.Context, sceneID, adminID string, additional, newMax int) error {
+    payload, err := proto.Marshal(&scenev1.ScenePublishVoteAttemptsExtendedEvent{
+        SceneId: sceneID, AdminId: adminID,
+        Additional: int32(additional), NewMax: int32(newMax),
+    })
+    if err != nil {
+        return err
+    }
+    return e.sink.Emit(ctx, pluginsdk.EmitIntent{
+        Subject: e.icSubject(sceneID),
+        Type:    pluginsdk.EventType("scene_publish_vote_attempts_extended"),
+        Payload: string(payload),  // EmitIntent.Payload is string per pkg/plugin/event.go:120
+    })
+}
+
+func (e *publishEventEmitter) icSubject(sceneID string) string {
+    return fmt.Sprintf("events.%s.scene.%s.ic", e.gameID, sceneID)
+}
+```
+
+Also add a wiring method on `SceneServiceImpl` (in `service.go`) so the plugin's `main.go` lifecycle can replace the noop default with the real emitter once the event sink is available:
+
+```go
+// SetPublishEventer replaces the default no-op publish eventer with the
+// supplied implementation. Called from main.go after SetEventSink so the
+// real publishEventEmitter (which needs an EventSink + store) is wired
+// before any RPC handler fires.
+func (s *SceneServiceImpl) SetPublishEventer(e publishEventer) {
+    s.events = e
+}
+```
+
+And in `main.go`, wire the real emitter after `SetEventSink`:
+
+```go
+plugin.service.SetEventSink(sink)
+plugin.service.SetPublishEventer(newPublishEventEmitter(sink, plugin.service.store, plugin.service.gameID))
+```
+
+- [ ] **Step 5: Run, verify PASS**
+
+Run: `task test -- -run "TestEmitPublish" ./plugins/core-scenes/`
+Expected: PASS (one subtest per emit method).
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "feat(scene-publish): event emitter for 6 IC notice events
+
+publish_events.go: typed Emit wrappers per IC notice event type
+(started/vote_cast/cooloff_started/resolved/withdrawn/extended).
+Real impl marshals proto + emits via pluginsdk.EventSink.Emit with
+EmitIntent matching commands.go:888-894 shape. noopPublishEventEmitter
+is the Phase-B default for tests that don't exercise event substrate.
+Proto messages added to scene.proto and regenerated.
+Spec section 7 (holomush-5rh.15)."
+```
+
+### Task D3: Wire emission into state-machine transitions
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/publish_snapshot.go`
+
+Connect `s.events.emit*` calls at every state transition site identified in Phase A `applyTrigger`.
+
+- [ ] Steps 1–5
+
+### Task D4: Event emission integration tests
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_event_emission_integration_test.go`
+
+Ginkgo specs running against a real eventbus harness (NOT eventbustest — use the integrationtest harness's NATS embed).
+
+- [ ] Steps 1–5
+
+### Task D5: Resolver meta-test — INV-P6-7
+
+**Files:**
+
+- Modify: `plugins/core-scenes/resolver_test.go`
+
+**Spec ref:** §9.3, INV-P6-7
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestResolverNeverExposesContentByForbiddenAttributeName(t *testing.T) {
+    t.Parallel()
+    r := newTestResolver()
+    schema, err := r.GetSchema(context.Background(), &pluginv1.GetSchemaRequest{})
+    require.NoError(t, err)
+
+    sceneType, ok := schemaTypeByName(schema, "scene")
+    require.True(t, ok)
+
+    forbidden := regexp.MustCompile(`^(content|content_entries|poses?|says?|emits?|ooc|log|entries|publication)$`)
+    for _, attr := range sceneType.Attributes {
+        assert.False(t, forbidden.MatchString(attr.Name),
+            "INV-P6-7 violation: resolver exposes attribute %q matching forbidden pattern", attr.Name)
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify PASS immediately** (since `resolver.go` is unchanged — this test is a regression lock for future PRs).
+- [ ] **Step 3: Commit**
+
+### Task D6: Metric stubs in `metrics.go`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/metrics.go`
+
+**Spec ref:** §13.1
+
+- [ ] **Step 1: Append 7 stubs** matching the existing pattern at `metrics.go:24-121`:
+
+```go
+//nolint:unused // stub for the future binary plugin metrics infrastructure (spec section 13); intentionally retained so call sites can be wired in cheaply once that infrastructure lands
+func metricScenePublishAttemptResolved(outcome, reason string) {
+    _ = outcome
+    _ = reason
+}
+
+//nolint:unused // stub for the future binary plugin metrics infrastructure (spec section 13)
+func metricScenePublishVoteCast(vote, isChange string) {
+    _ = vote
+    _ = isChange
+}
+
+// ... 5 more stubs: VoteWindowDuration, CoolOffWindowDuration, SnapshotDuration, PrivacyBlock, ActiveAttempts
+```
+
+- [ ] **Step 2: Run `task lint`** — verify no unused-function lint failures (the `//nolint:unused` directives prevent them).
+- [ ] **Step 3: Commit**
+
+### Task D7: Privacy boundary block tests
+
+**Files:**
+
+- Create: `plugins/core-scenes/service_privacy_block_test.go`
+
+Four tests — WARN log emit, metric increment, NO IC event emit (side-channel prevention), span error attribute set. Use a slog test handler + the metric-call shim from D6 + a recording event emitter + an OTel test span recorder.
+
+- [ ] Steps 1–5
+
+---
+
+## Phase E — Admin Extend, cb4x Absorption, Scheduler, E2E
+
+Phase E completes the publication surface: admin `ExtendScenePublishVoteAttempts`, the `scene log` / `scene log export` commands folded from `holomush-cb4x`, the scheduler that drives vote-window timeouts and cool-off expiry, and the cross-package E2E tests in `test/integration/scenes/` and the meta-test in `test/meta/`.
+
+**Spec coverage:** §5 (Extend), §6 (`scene log` commands), §15.3 + §15.4 (E2E + meta).
+
+### Task E1: `ExtendScenePublishVoteAttempts` RPC + ABAC
+
+**Files:**
+
+- Modify: `plugins/core-scenes/publish_service.go`
+- Modify: `plugins/core-scenes/plugin.yaml` (add `admin-extend-publish-attempts` policy)
+- Modify: `plugins/core-scenes/publish_service_test.go`
+
+**Spec ref:** §5, §8
+
+- [ ] **Step 1: Write failing tests** (admin success, non-admin rejection)
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement** + add policy
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task E2: `scene publish vote extend <count>` command
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+Routes to `ExtendScenePublishVoteAttempts`. ABAC gates non-admins; the command name itself is identical for everyone.
+
+- [ ] Steps 1–5
+
+### Task E3: `scene log` command (cb4x absorption)
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+Calls the existing `PluginAuditService.QueryHistory` (membership-gated; INV-S9 enforced by `audit.go:493-555`). Paginate output for terminal display.
+
+- [ ] **Step 1: Write failing test** — happy path (participant), denial (non-participant).
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement `handleLog`**
+
+```go
+func (p *scenePlugin) handleLog(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
+    sceneID, err := resolveSceneRef(ctx, p.service.store, req.CharacterID, args)
+    if err != nil {
+        return pluginsdk.Errorf("%s", err.Error()), nil
+    }
+    rows, err := p.queryHistoryForScene(ctx, sceneID, /* limit */ 50)
+    if err != nil {
+        return pluginsdk.Errorf("%s", err.Error()), nil
+    }
+    entries, err := decodeEntriesForReplay(rows)
+    if err != nil {
+        return pluginsdk.Errorf("%s", err.Error()), nil
+    }
+    return pluginsdk.OK(renderPlainText(entries)), nil
+}
+```
+
+(`queryHistoryForScene` calls the plugin's own audit service via the in-process gRPC handle; same auth surface as the audit RPC.)
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task E4: `scene log export <format>` command
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go`
+- Modify: `plugins/core-scenes/commands_test.go`
+
+Routes to a separate handler that runs the renderer for the chosen format on the same audit-history payload that `scene log` uses.
+
+- [ ] Steps 1–5
+
+### Task E5: Scheduler — vote-window timeout + cool-off expiry tickers
+
+**Files:**
+
+- Create: `plugins/core-scenes/publish_scheduler.go`
+- Modify: `plugins/core-scenes/main.go` (wire into lifecycle)
+- Create: `plugins/core-scenes/publish_scheduler_integration_test.go`
+
+**Spec ref:** §4.3
+
+- [ ] **Step 1: Write failing integration test** — start an attempt with `vote_window=2s`, leave one voter pending, advance 2s of mock time, assert `ATTEMPT_FAILED` with `reason=TIMEOUT`.
+- [ ] **Step 2: Run, verify FAIL**
+- [ ] **Step 3: Implement scheduler**
+
+```go
+type publishScheduler struct {
+    store sceneStorer
+    svc   *SceneServiceImpl
+    tick  *time.Ticker
+}
+
+func (s *publishScheduler) Run(ctx context.Context) {
+    defer s.tick.Stop()
+    for {
+        select {
+        case <-ctx.Done(): return
+        case <-s.tick.C:
+            if err := s.sweep(ctx); err != nil {
+                slog.WarnContext(ctx, "publish scheduler sweep failed", "err", err)
+            }
+        }
+    }
+}
+
+func (s *publishScheduler) sweep(ctx context.Context) error {
+    // 1. SELECT id FROM published_scenes WHERE status='COLLECTING' AND initiated_at + vote_window <= now()
+    //    → apply TriggerTimeout
+    // 2. SELECT id FROM published_scenes WHERE status='COOLOFF' AND cooloff_started_at + cooloff_window <= now()
+    //    → run snapshot pipeline
+    return nil // full impl
+}
+```
+
+Wire `publishScheduler.Run(ctx)` into the plugin's `main()` startup via a goroutine launched alongside the existing focus consumer.
+
+- [ ] **Step 4: Run, verify PASS**
+- [ ] **Step 5: Commit**
+
+### Task E6: E2E happy-path test
+
+**Files:**
+
+- Create: `test/integration/scenes/publish_e2e_test.go`
+
+Ginkgo spec using `internal/testsupport/integrationtest`. Alice creates scene, joins, ends, runs `scene publish`, votes yes, Bob votes yes, cool-off expires, scene transitions to PUBLISHED. Public RPC returns content; participant RPC also returns content.
+
+- [ ] Steps 1–5
+
+### Task E7: E2E privacy gate test
+
+**Files:**
+
+- Modify: `test/integration/scenes/publish_e2e_test.go`
+
+Non-participant Charlie calls `GetPublishedScene` → PermissionDenied with WARN log + metric stub call. Charlie calls `GetPublicSceneArchive` on COLLECTING attempt → NOT_FOUND. Charlie calls same RPC after PUBLISHED → success.
+
+- [ ] Steps 1–5
+
+### Task E8: E2E retry + admin extend test
+
+Same file, new `Context` block. 3 failed attempts; 4th rejected; admin extends; 4th succeeds.
+
+- [ ] Steps 1–5
+
+### Task E9: E2E history-scope-privacy floor test
+
+**Files:**
+
+- Create: `test/integration/scenes/publish_history_scope_e2e_test.go`
+
+Per spec §15.3: a participant who joined the scene AFTER an attempt's `scene_publish_started` cannot see that started event in their history-scope-floor view.
+
+- [ ] Steps 1–5
+
+### Task E10: Meta-test for INV-P6-1..10
+
+**Files:**
+
+- Create: `test/meta/scenes_phase6_invariants_test.go`
+
+Enumerates each invariant ID and asserts at least one test cites it. Pattern: parse all `*_test.go` files for `INV-P6-N` substrings in test bodies / comments; require non-zero for each of 1..10.
+
+- [ ] Steps 1–5
+
+---
+
+## Post-Implementation Checklist
+
+After Task E10 lands:
+
+- [ ] Run `task test` — all unit tests pass with no warnings
+- [ ] Run `task test:int` — all integration + E2E tests pass
+- [ ] Run `task test:cover` — verify ≥85% coverage on `plugins/core-scenes/` overall; ≥90% on new `publish_*.go` files
+- [ ] Run `task lint` — clean (no `//nolint` additions that bypass real issues)
+- [ ] Run `task pr-prep` — full pipeline green
+- [ ] Run `/review-crypto` final pass — ensures the snapshot decrypt path didn't introduce AAD or fence violations
+- [ ] Run `/review-abac` — ensures the 3 new ABAC policies are sound and don't shadow existing rules
+- [ ] Run `/review-code` — adversarial code review
+- [ ] Update `docs/roadmap.md` — move Phase 6 work from "frontier" to shipped in the social-spaces theme section
+- [ ] Close `holomush-5rh.15` with `--reason="Phase 6 shipped in PR #<n>"`
+- [ ] Close `holomush-cb4x` with `--reason="Folded into Phase 6 (5rh.15)"`
+- [ ] Squash-merge PR
+- [ ] Clean up isolated workspace per `.claude/rules/landing-the-plane.md` step 5
+
+## Risk Items
+
+- **Crypto decryption at snapshot time** — Phase 6 introduces a new caller of the per-event-DEK decrypt path. The crypto-reviewer agent MUST pass before push.
+- **Scheduler concurrency vs. RPC handlers** — both can fire `applyTrigger` on the same attempt; SELECT FOR UPDATE in `LockForSnapshot` and precondition WHERE clauses in `TransitionStatus` provide serialization, but the race test in §15.3 must be green.
+- **JSONB indexing growth** — `content_entries` is unindexed JSONB. Long scenes (10k+ poses) produce large rows; if queries against `content_entries` ever surface as a need, a separate audit follow-up bead is required.
+
+## Out of Scope (Future Work)
+
+- Phase 8 (`5rh.17`) — scene board + content warnings (public discovery surface for `GetPublicSceneArchive`)
+- Phase 9 (`5rh.18`) — web chat view + pending-vote dashboard
+- "Resume from ended" scene capability — the §4 state-machine choice preserves the option without committing to it
+- Multi-format publication storage (HTML, PDF) — derive at request time from JSONB content_entries
+- Per-participant publication revocation — once PUBLISHED, immutable
+
+<!-- adr-capture: sha256=35c26bc314cd05a3; session=cli; ts=2026-05-23T23:20:33Z; adrs=qd3r5,jrefa,e3xlx,39a5f,c4jee -->

--- a/docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md
+++ b/docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md
@@ -1,0 +1,946 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Scenes Phase 6: Logs, Publish Vote, and Hard Privacy Boundary
+
+**Status:** Draft v1 (2026-05-23)
+**Bead (impl):** `holomush-5rh.15`
+**Bead (design):** `holomush-5rh.20`
+**Folds in:** `holomush-cb4x` (scene log replay + export commands + renderers)
+**Predecessors:** `holomush-5rh.14` Phase 5 (focus model), shipped 2026-05-21 (PR #4191)
+**Parent design (v2):** [scenes-and-rp-design-v2.md](2026-04-06-scenes-and-rp-design-v2.md) §1.5, §5.5–§5.8, §6.4, §6.6
+**Substrate contract:** [substrate-contract](2026-05-16-social-spaces-substrate-contract.md) — INV-S9 (privacy boundary is participant list, plugin-code enforced)
+**History scope privacy:** [history-scope-privacy-design.md](2026-05-17-history-scope-privacy-design.md) — §3 "scene privacy is absolute"
+
+## RFC2119 Keywords
+
+The keywords MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are used per RFC2119.
+
+## 1. Overview
+
+Phase 6 ships the publication artifact for scenes — a player-controlled mechanism for turning a participant-only roleplay scene into a public, immutable archive. The substrate that gates participant-only reads of the audit history (`scene_log` table, INV-S9 plugin-code participant gate) already shipped in PR #267 (`audit.go:493-555`). Phase 6 adds:
+
+1. A separate **publication artifact** (`published_scenes` table) distinct from the audit `scene_log` table.
+2. A **vote state machine** with three terminal-or-transient states (`COLLECTING`, `COOLOFF`, `PUBLISHED`, `ATTEMPT_FAILED`) and a retry surface up to a configurable per-scene max.
+3. New **gRPC RPCs** split across two surfaces — participant-gated (INV-S9 plugin-code check) and public (status-gated; no participant check).
+4. New **telnet/web commands** under `scene publish` and `scene log` parents, with focus-implicit and explicit `#<scene_id>` argument resolution.
+5. **IC-stream event emission** for publish-vote lifecycle, declared at `sensitivity: never` in the plugin manifest crypto.emits.
+6. A **COOLOFF → PUBLISHED snapshot pipeline** that reads, decrypts, filters, and renders IC events into a structured JSONB content column atomically.
+7. **Observability triple-signal** for hard-privacy-boundary blocks (WARN log + metric + span error; no IC event side channel).
+8. **`scene log` replay + `scene log export`** commands and three-format renderers (markdown, plain text, jsonl) — folded in from `holomush-cb4x`.
+
+## 2. Divergences from the v2 Design and Bead Acceptance Criteria
+
+Phase 6 intentionally departs from several specifics in the v2 design and the `holomush-5rh.15` bead acceptance criteria. Each divergence is listed with its rationale; the design-reviewer is expected to evaluate the divergence as intentional, not a defect.
+
+| Source text | Phase 6 spec | Rationale |
+| ----------- | ------------ | --------- |
+| v2 §5.6 "no mechanism to re-vote or change a vote after casting" | Votes are changeable until attempt resolution | Q4 (2026-05-23 brainstorm). Forgiving UX; resolution remains binary; voted_at + last_changed_at preserve auditability |
+| v2 §5.6 "scene end triggers publish vote" automatically | Explicit `scene publish` command starts every attempt including the first | Q5. Separates ending from publication intent; symmetric retry handling |
+| v2 §5.6 "IF any vote no OR vote timeout: log stays participant-only permanently" | Per-attempt failure, not per-scene. Default 3 attempts per scene; configurable; admin-extendable | Q5. Real-world async play benefits from a retry surface; admin extend adjusts retry budget but does NOT bypass the unanimous-yes requirement |
+| v2 §1.2 "ended → archived after publish vote resolves or times out" | Scene transitions to `archived` ONLY on PUBLISHED. Attempts-exhausted scenes stay `ended` indefinitely | Q5. Preserves a future "resume from ended" capability without committing to it in Phase 6 |
+| Bead "Re-voting and admin overrides are structurally impossible" | Re-voting allowed within attempt. Admin overrides for attempt count allowed; NOT for vote outcome | Q4 + Q5. Privacy contract is "admin cannot bypass unanimous-yes"; admin can adjust retry budget |
+| v2 §1.3 `OriginLocationID` on Participant | Dropped | Q6. `Character.LocationID` is canonical; no operational consumer |
+| v2 §1.3 `PublishVote *bool` on Participant | Moved to `published_scene_votes` table | Q3. Clean roster snapshot at attempt start; doesn't pollute participant rows with vote-window state |
+| v2 §1.5 "Scene Log (Published)" naming | Renamed to `PublishedScene` / `published_scenes` everywhere | Q2. `scene_log` is taken by the audit history table (PR #267); the publication artifact needs an unambiguous name |
+| Bead "scene_logs table (migration 000003)" | Migration `000008_scene_publication.up.sql` (next available number; `scene_log` already exists at 000004) | Plan reflects shipped state; the audit table predates this design |
+
+## 3. Domain Model
+
+### 3.1 PublishedScene
+
+A `PublishedScene` represents one publication attempt for a scene. Multiple `PublishedScene` rows per scene are allowed up to `max_attempts`; at most one PUBLISHED row is allowed per scene (one-and-done).
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| ID | ULID | Yes | Primary identifier |
+| SceneID | ULID | Yes | Logical reference to `scenes(id)` (enforced in code, not via DB FK) |
+| AttemptNumber | int | Yes | 1-indexed; unique within a scene |
+| Status | PublishedSceneStatus | Yes | One of: `COLLECTING`, `COOLOFF`, `PUBLISHED`, `ATTEMPT_FAILED` |
+| InitiatedBy | ULID | Yes | Character ID who ran `scene publish` |
+| InitiatedAt | time.Time | Yes | Attempt-creation timestamp |
+| CoolOffStartedAt | \*time.Time | No | Set on `COLLECTING → COOLOFF` transition; cleared on flip-back |
+| ResolvedAt | \*time.Time | No | Set on terminal status only |
+| VoteWindow | time.Duration | Yes | Frozen at attempt start; default 7 days, configurable |
+| CoolOffWindow | time.Duration | Yes | Frozen at attempt start; default 30 minutes, configurable |
+| MaxAttemptsSnapshot | int | Yes | Frozen at attempt start for audit clarity |
+| ContentEntries | \*\[\]Entry | No | Set ONLY on PUBLISHED transition. Each entry: `{speaker, kind, content}` where `kind ∈ {pose, say, emit}` |
+| TitleSnapshot | \*string | No | Set on PUBLISHED; snapshot of `scenes.title` at publish time |
+| ParticipantsSnapshot | \*\[\]Participant | No | Set on PUBLISHED; frozen list of character names visible to public |
+| PublishedAt | \*time.Time | No | Set on PUBLISHED only |
+| FailureReason | \*PublishFailureReason | No | Set on ATTEMPT_FAILED only. One of: `ANY_NO`, `TIMEOUT`, `WITHDRAWN`, `SNAPSHOT_DECRYPT_FAILED`, `SNAPSHOT_RENDER_FAILED`, `COOLOFF_INVARIANT_BROKEN` |
+
+### 3.2 PublishedSceneVote
+
+One row per eligible voter, per attempt. Roster is frozen at attempt creation.
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| PublishedSceneID | ULID | Yes | Logical reference to `published_scenes(id)` |
+| CharacterID | ULID | Yes | The voter |
+| Vote | \*bool | No | `nil` = pending; `true` = yes; `false` = no |
+| VotedAt | \*time.Time | No | First-cast timestamp |
+| LastChangedAt | \*time.Time | No | Updated on every cast (including no-op same-value re-cast) |
+
+Composite primary key `(PublishedSceneID, CharacterID)`.
+
+### 3.3 Migration
+
+New migration `000008_scene_publication.up.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+CREATE TABLE IF NOT EXISTS published_scenes (
+    id                     TEXT        PRIMARY KEY,
+    scene_id               TEXT        NOT NULL,
+    attempt_number         INTEGER     NOT NULL,
+    status                 TEXT        NOT NULL CHECK (status IN
+                              ('COLLECTING','COOLOFF','PUBLISHED','ATTEMPT_FAILED')),
+    initiated_by           TEXT        NOT NULL,
+    initiated_at           TIMESTAMPTZ NOT NULL,
+    cooloff_started_at     TIMESTAMPTZ,
+    resolved_at            TIMESTAMPTZ,
+    vote_window            INTERVAL    NOT NULL,
+    cooloff_window         INTERVAL    NOT NULL,
+    max_attempts_snapshot  INTEGER     NOT NULL,
+    content_entries        JSONB,
+    title_snapshot         TEXT,
+    participants_snapshot  JSONB,
+    published_at           TIMESTAMPTZ,
+    failure_reason         TEXT        CHECK (failure_reason IS NULL OR failure_reason IN
+                              ('ANY_NO','TIMEOUT','WITHDRAWN',
+                               'SNAPSHOT_DECRYPT_FAILED','SNAPSHOT_RENDER_FAILED',
+                               'COOLOFF_INVARIANT_BROKEN'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_one_active_per_scene
+    ON published_scenes(scene_id) WHERE status IN ('COLLECTING','COOLOFF');
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_one_published_per_scene
+    ON published_scenes(scene_id) WHERE status = 'PUBLISHED';
+CREATE UNIQUE INDEX IF NOT EXISTS published_scenes_attempt_unique
+    ON published_scenes(scene_id, attempt_number);
+CREATE INDEX IF NOT EXISTS published_scenes_scene_status
+    ON published_scenes(scene_id, status);
+
+CREATE TABLE IF NOT EXISTS published_scene_votes (
+    published_scene_id  TEXT        NOT NULL,
+    character_id        TEXT        NOT NULL,
+    vote                BOOLEAN,
+    voted_at            TIMESTAMPTZ,
+    last_changed_at     TIMESTAMPTZ,
+    PRIMARY KEY (published_scene_id, character_id)
+);
+
+CREATE INDEX IF NOT EXISTS published_scene_votes_pending
+    ON published_scene_votes(published_scene_id) WHERE vote IS NULL;
+```
+
+No foreign-key constraints. Referential integrity for `scene_id`, `initiated_by`, `published_scene_id`, and `character_id` is enforced in the Go service layer. This matches the project convention for new tables (per user direction 2026-05-23); the existing `scene_participants → scenes` FK is an outlier.
+
+A paired `000008_scene_publication.down.sql` drops both tables and their indexes. Migrations follow the discipline at `site/docs/contributing/database-migrations.md` (idempotent, logic-free, plain SQL).
+
+### 3.4 Configuration: max_attempts per scene
+
+`scenes.max_publish_attempts` is an INTEGER column that defaults to a game-wide value (default 3). Added in a paired migration `000009_scene_max_publish_attempts.up.sql`:
+
+```sql
+ALTER TABLE scenes
+    ADD COLUMN IF NOT EXISTS max_publish_attempts INTEGER NOT NULL DEFAULT 3;
+```
+
+`ExtendScenePublishVoteAttempts` mutates this column.
+
+## 4. State Machine
+
+The authoritative transition specification is the table at §4.1. The diagram below is a navigational aid.
+
+```text
+       StartScenePublish
+              │
+              ▼
+       ┌─────────────┐  all roster voted yes  ┌─────────┐
+       │ COLLECTING  │ ─────────────────────► │ COOLOFF │
+       │             │ ◄───── vote flip ───── │         │
+       │             │     yes → no (COOLOFF) │         │
+       └─────────────┘                        └────┬────┘
+              │                                    │
+              │ all voted, any no                  │ cooloff window
+              │ OR vote_window timeout             │ elapsed (all-yes)
+              │ OR owner withdraw                  │
+              │                                    ▼
+              │                              ┌───────────┐
+              │                              │ PUBLISHED │  (terminal)
+              │                              └───────────┘
+              ▼
+       ┌────────────────┐
+       │ ATTEMPT_FAILED │  (terminal for this attempt)
+       └────────────────┘
+              ▲
+              │
+              │ owner withdraw from COOLOFF
+              │ OR snapshot transaction failure during COOLOFF→PUBLISHED
+              │
+       (also reached from COOLOFF, see arrows above)
+```
+
+A scene MAY enter a new COLLECTING attempt after ATTEMPT_FAILED (up to `max_publish_attempts`). PUBLISHED is terminal for the scene — no further attempts allowed (unique index `published_scenes_one_published_per_scene`).
+
+### 4.1 Transitions
+
+| From | Trigger | To | Side effects |
+| ---- | ------- | -- | ------------ |
+| (none) | StartScenePublish (scene.state=ended, no active attempt, attempt_count < max, no PUBLISHED row) | COLLECTING | Insert published_scenes row; insert published_scene_votes rows for roster; emit `scene_publish_started` |
+| COLLECTING | All roster votes yes | COOLOFF | Set `cooloff_started_at`; emit `scene_publish_cooloff_started` |
+| COLLECTING | All roster voted, any no | ATTEMPT_FAILED | Set `resolved_at`, `failure_reason = ANY_NO`; emit `scene_publish_resolved` |
+| COLLECTING | `vote_window` elapsed with any pending voter | ATTEMPT_FAILED | Set `resolved_at`, `failure_reason = TIMEOUT`; emit `scene_publish_resolved` |
+| COLLECTING | Owner withdraws | ATTEMPT_FAILED | Set `resolved_at`, `failure_reason = WITHDRAWN`; emit `scene_publish_withdrawn` AND `scene_publish_resolved` |
+| COOLOFF | `cooloff_window` elapsed with all-yes intact | PUBLISHED | Run snapshot pipeline (§7); set `content_entries`, `title_snapshot`, `participants_snapshot`, `published_at`, `resolved_at`; update `scenes.state = 'archived'`; emit `scene_publish_resolved{outcome=PUBLISHED}` |
+| COOLOFF | Any voter changes vote to no | COLLECTING | Clear `cooloff_started_at`; emit `scene_publish_vote_cast{is_change=true, vote=false}`. NO `scene_publish_resolved`. |
+| COOLOFF | Owner withdraws | ATTEMPT_FAILED | Same as COLLECTING-owner-withdraw |
+| COOLOFF | Snapshot transaction fails | ATTEMPT_FAILED | Set `failure_reason` to `SNAPSHOT_DECRYPT_FAILED` or `SNAPSHOT_RENDER_FAILED`; emit `scene_publish_resolved{outcome=ATTEMPT_FAILED, reason=<failure>}` |
+
+### 4.2 Voting semantics
+
+Votes are CHANGEABLE during COLLECTING. A second cast updates `vote` and `last_changed_at`; if the value changes, `scene_publish_vote_cast{is_change=true}` fires. If the value is the same, the event still fires with `is_change=false` for audit clarity (and so renderers can show "re-affirmed").
+
+During COOLOFF, a `yes → no` change demotes the attempt back to COLLECTING. A `no → yes` change is a no-op in COOLOFF because there are no `no` voters by precondition — but the predicate is asserted defensively (state machine rejects no-yes transitions during COOLOFF as `SCENE_PUBLISH_INVALID_STATE`).
+
+### 4.3 Resolution check
+
+Every `CastPublishSceneVote` triggers the resolution check at the end of the same transaction:
+
+```text
+votes := tally(published_scene_id)
+if votes.pending == 0:
+    if votes.no == 0:
+        transition to COOLOFF (if currently COLLECTING)
+    else:
+        transition to ATTEMPT_FAILED with reason=ANY_NO
+elif current_status == COOLOFF and votes.no > 0:
+    transition to COLLECTING (clear cooloff_started_at)
+```
+
+The timeout and cool-off-elapsed transitions are driven by a separate scheduler (the existing plugin's lifecycle ticker, extended to scan `published_scenes` for `vote_window`/`cooloff_window` boundaries).
+
+## 5. gRPC RPC Surface
+
+Proto contract: `holomush.scene.v1.SceneService` (extended). New methods:
+
+| RPC | Caller | Gate | Description |
+| --- | ------ | ---- | ----------- |
+| `StartScenePublish(scene_id)` | owner+member | ABAC `publish` + plugin-code preconditions | Creates a new attempt → COLLECTING |
+| `CastPublishSceneVote(published_scene_id, vote bool)` | roster voter | Plugin-code: caller in `published_scene_votes` for this attempt | Upserts vote; triggers resolution check |
+| `WithdrawScenePublish(published_scene_id)` | scene owner | ABAC `withdraw_publish` (owner only) | Transitions COLLECTING/COOLOFF → ATTEMPT_FAILED |
+| `GetPublishedScene(published_scene_id)` | participant | Plugin-code `IsParticipant` (INV-S9) | Returns full state including content if PUBLISHED |
+| `DownloadPublishedScene(published_scene_id, format)` | participant | Plugin-code `IsParticipant` (INV-S9) | Returns rendered bytes; only when status==PUBLISHED |
+| `ListScenePublishAttempts(scene_id)` | participant | Plugin-code `IsParticipant` (INV-S9) | Audit list of all attempts for this scene |
+| `GetPublicSceneArchive(published_scene_id)` | anyone | Code: status == PUBLISHED OR opaque NOT_FOUND | Public-safe view |
+| `DownloadPublicSceneArchive(published_scene_id, format)` | anyone | Code: same status gate | Rendered bytes; PUBLISHED only |
+| `ExtendScenePublishVoteAttempts(scene_id, additional int)` | admin role | ABAC `extend_publish_attempts` (admin only) | Bumps `scenes.max_publish_attempts` |
+
+### 5.1 Two-pair RPC architecture
+
+The participant-gated pair (`GetPublishedScene`, `DownloadPublishedScene`, `ListScenePublishAttempts`) and the public pair (`GetPublicSceneArchive`, `DownloadPublicSceneArchive`) are deliberately separate handlers that do NOT share a code path beyond the underlying store reads. This separation is the structural guarantee that:
+
+- The participant-gated path cannot accidentally become public via a future refactor.
+- The public path cannot accidentally read private content because it only loads content_entries when status == PUBLISHED.
+
+The proto contract reflects this: separate RPC names, separate request/response messages with different field sets (the public response omits per-voter information and the active vote-progress state).
+
+### 5.2 Error code surface
+
+All new errors use the `oops.Code(...)` convention. Codes prefixed `SCENE_PUBLISH_`:
+
+| Code | Wire status | When |
+| ---- | ----------- | ---- |
+| `SCENE_PUBLISH_INVALID_STATE` | FailedPrecondition | StartScenePublish when scene.state != ended; CastVote when attempt is terminal; etc. |
+| `SCENE_PUBLISH_ALREADY_ACTIVE` | FailedPrecondition | StartScenePublish when an active attempt exists for the scene |
+| `SCENE_PUBLISH_ALREADY_PUBLISHED` | FailedPrecondition | StartScenePublish when a PUBLISHED row exists for the scene |
+| `SCENE_PUBLISH_ATTEMPTS_EXHAUSTED` | FailedPrecondition | StartScenePublish when attempt_count == max_attempts |
+| `SCENE_PUBLISH_NO_ELIGIBLE_VOTERS` | FailedPrecondition | StartScenePublish when roster would be empty (only invited rows on the scene) |
+| `SCENE_PUBLISH_NOT_A_VOTER` | PermissionDenied | CastVote when caller is not in `published_scene_votes` |
+| `SCENE_PUBLISH_INVALID_TRANSITION` | Internal | Defensive: state machine rejects an impossible transition |
+| `SCENE_PUBLISH_NOT_OWNER` | PermissionDenied | WithdrawScenePublish from non-owner |
+| `SCENE_PRIVACY_BOUNDARY_BLOCK` | PermissionDenied | INV-S9 gate denies participant-only read (also emits the triple-signal per §10) |
+| `SCENE_PUBLISH_FORMAT_UNSUPPORTED` | InvalidArgument | Download with format outside {markdown, plain_text, jsonl} |
+| `SCENE_PUBLISH_NO_FOCUSED_SCENE` | InvalidArgument | Telnet command with no arg and no focused scene |
+| `SCENE_PUBLISH_REF_INVALID` | InvalidArgument | Telnet command with malformed `#<id>` |
+| `SCENE_PUBLISH_NOT_PARTICIPANT` | PermissionDenied | Explicit `#<id>` references a scene the caller is not in |
+
+The public RPC pair (`GetPublicSceneArchive`, `DownloadPublicSceneArchive`) returns a single uniform `NOT_FOUND` for all of: nonexistent ID, COLLECTING, COOLOFF, ATTEMPT_FAILED. The error wire shape is identical to "this archive does not exist" — non-participants MUST NOT be able to infer that an attempt is in progress or has failed (INV-P6-8).
+
+Error opacity discipline follows `.claude/rules/grpc-errors.md`. The wire-level `Status.message` is generic; structured `denial_reason` is an internal slog attribute only.
+
+## 6. Commands and Focus Resolution
+
+### 6.1 Command surface
+
+| Command | RPC | Description |
+| ------- | --- | ----------- |
+| `scene publish` | StartScenePublish | Start a new publish-vote attempt on the focused scene |
+| `scene publish #<id>` | StartScenePublish | Same, explicit scene ID |
+| `scene publish withdraw` | WithdrawScenePublish | Owner withdraws active attempt on focused scene |
+| `scene publish status` | GetPublishedScene | Show vote progress for focused scene's active attempt |
+| `scene publish download <format>` | DownloadPublishedScene | Download PUBLISHED artifact in chosen format |
+| `scene publish vote yes` | CastPublishSceneVote(true) | Cast/change vote on focused scene's active attempt |
+| `scene publish vote no` | CastPublishSceneVote(false) | Cast/change vote |
+| `scene publish vote extend <count>` | ExtendScenePublishVoteAttempts | Admin extends max_publish_attempts (ABAC-gated, not name-gated) |
+| `scene log` | (existing audit `QueryHistory`) | Replay IC audit history for focused scene |
+| `scene log #<id>` | (same) | Same, explicit scene ID |
+| `scene log export <format>` | (new local renderer) | Render audit history to chosen format |
+
+All commands accept an optional `#<scene_id>` argument that overrides the connection's focused scene. Resolution rule:
+
+```text
+no arg            → use connection.focused_scene
+                    error SCENE_PUBLISH_NO_FOCUSED_SCENE if connection has no scene focus
+#<scene_id>       → explicit scene reference
+                    error SCENE_PUBLISH_REF_INVALID for malformed input
+                    error SCENE_PUBLISH_NOT_PARTICIPANT if caller is not a member
+```
+
+A `resolveSceneRef(ctx, conn, args) (sceneID, error)` helper in `plugins/core-scenes/commands.go` is the single dispatch point. All `scene publish *` and `scene log *` subcommands route through it.
+
+### 6.2 Cross-scene vote ergonomics
+
+A roster voter MAY be a member of multiple scenes simultaneously. The `scene_publish_started` event emits on the scene IC stream; non-focused roster members receive it as a notification on `notifications:<character_id>` (per v2 §3.3). The notification body includes the `scene_id` and `attempt_id` so the player can fire `scene publish vote yes #<scene_id>` without first switching focus.
+
+A pending-vote dashboard view (showing all scenes with open attempts where the caller is a roster member) is OUT OF SCOPE for Phase 6 — that surface is a Phase 9 (web chat view) concern.
+
+## 7. Event Emission
+
+Six new event types are added to `plugins/core-scenes/plugin.yaml` under `crypto.emits`. All are `sensitivity: never` (operational metadata, no IC content):
+
+| Event type | When | Payload fields |
+| ---------- | ---- | -------------- |
+| `scene_publish_started` | StartScenePublish success | `attempt_id`, `attempt_number`, `initiated_by`, `vote_window_seconds`, `cooloff_window_seconds`, `roster_character_ids` |
+| `scene_publish_vote_cast` | CastPublishSceneVote success | `attempt_id`, `character_id`, `vote`, `is_change` |
+| `scene_publish_cooloff_started` | COLLECTING → COOLOFF | `attempt_id`, `cooloff_ends_at` |
+| `scene_publish_resolved` | Any terminal transition (PUBLISHED OR ATTEMPT_FAILED) | `attempt_id`, `outcome`, `reason`, `tally_yes`, `tally_no`, `tally_pending` |
+| `scene_publish_withdrawn` | WithdrawScenePublish success | `attempt_id`, `withdrawn_by`. Fires AND `scene_publish_resolved` fires so renderers can distinguish |
+| `scene_publish_vote_attempts_extended` | ExtendScenePublishVoteAttempts success | `scene_id`, `additional`, `new_max`, `admin_id` |
+
+All events are emitted on the scene IC stream (`events.<game_id>.scene.<scene_id>.ic`) using the existing plugin emit path (`internal/plugin/event_emitter.go::Emit`). The crypto-reviewer gate fires when the manifest changes; these are additive `never` declarations and do not change payload encryption rules. Visible to focused participants inline; surfaces to non-focused members via the per-character notification stream.
+
+The manifest update will join the existing `scene_join_ic` / `scene_leave_ic` / `scene_pose_order_changed_ic` / `scene_idle_nudge` family of notice events.
+
+## 8. ABAC Policies
+
+Three new policies added to `plugins/core-scenes/plugin.yaml` under `policies`:
+
+```yaml
+- name: start-publish-as-participant
+  dsl: >-
+    permit(principal is character, action in ["publish"], resource is scene)
+    when { principal.id in resource.scene.participants
+           && resource.scene.state == "ended" };
+
+- name: withdraw-publish-as-owner
+  dsl: >-
+    permit(principal is character, action in ["withdraw_publish"], resource is scene)
+    when { resource.scene.owner == principal.id };
+
+- name: admin-extend-publish-attempts
+  dsl: >-
+    permit(principal is character, action in ["extend_publish_attempts"], resource is scene)
+    when { "admin" in principal.character.roles };
+```
+
+Notably absent: there is no `read-publication-as-participant` ABAC policy. `GetPublishedScene` / `DownloadPublishedScene` / `ListScenePublishAttempts` are gated **in plugin code** via `IsParticipant`, not ABAC, per INV-S9. The reviewer for this spec MUST verify no future PR adds such a policy.
+
+The plugin's resolver schema is unchanged. The `scene.participants` attribute (per the existing Phase 3 work) is what the `start-publish-as-participant` policy reads. No new resolver attributes are required.
+
+## 9. INV-S9 Enforcement Contract
+
+This section is the load-bearing privacy work for Phase 6. INV-S9 (substrate-contract §4.1) requires the scene-log hard privacy boundary to be plugin-code enforced, NOT ABAC-engine enforced. Phase 6 extends the same pattern to the publication artifact participant-gated RPCs.
+
+### 9.1 Gate placement
+
+The participant gate is the third step of every participant-gated handler, before any read of `published_scenes.content_entries` or `published_scene_votes`:
+
+```go
+// service_publish.go (sketch)
+func (s *SceneServiceImpl) GetPublishedScene(ctx context.Context, req *scenev1.GetPublishedSceneRequest) (*scenev1.GetPublishedSceneResponse, error) {
+    // Step 1: caller validation.
+    callerID, err := validateCharacterCaller(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    // Step 2: load attempt header (status, scene_id, etc. — NOT content_entries).
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetId())
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+    if pub == nil {
+        return nil, status.Error(codes.NotFound, "publication not found")
+    }
+
+    // Step 3: INV-S9 plugin-code gate. NO ABAC engine consultation.
+    ok, err := s.store.IsParticipant(ctx, pub.SceneID, callerID)
+    if err != nil {
+        return nil, internalErr(err)
+    }
+    if !ok {
+        s.emitPrivacyBoundaryBlock(ctx, "GetPublishedScene", pub.SceneID, callerID, "not_participant")
+        return nil, oops.Code("SCENE_PRIVACY_BOUNDARY_BLOCK").
+            Errorf("scene not accessible")
+    }
+
+    // Step 4: load content if PUBLISHED.
+    var entries []Entry
+    if pub.Status == StatusPublished {
+        entries, err = s.store.GetPublishedSceneContent(ctx, req.GetId())
+        if err != nil {
+            return nil, internalErr(err)
+        }
+    }
+    return assembleParticipantResponse(pub, entries), nil
+}
+```
+
+`GetPublishedSceneHeader` and `GetPublishedSceneContent` are deliberately separate store methods. The header read is needed to know the `scene_id` for the participant check; the content read is gated by `IsParticipant` returning true. This split is what makes the call-stack assertion meaningful (§9.4).
+
+The same pattern applies to `DownloadPublishedScene` and `ListScenePublishAttempts`.
+
+### 9.2 Public surface separation
+
+`GetPublicSceneArchive` is a structurally separate handler:
+
+```go
+func (s *SceneServiceImpl) GetPublicSceneArchive(ctx context.Context, req *scenev1.GetPublicSceneArchiveRequest) (*scenev1.GetPublicSceneArchiveResponse, error) {
+    // No participant check. No ABAC. Status-gated only.
+    pub, err := s.store.GetPublishedSceneHeader(ctx, req.GetId())
+    if err != nil {
+        return nil, mapStoreErr(err)
+    }
+    if pub == nil || pub.Status != StatusPublished {
+        return nil, status.Error(codes.NotFound, "scene archive not found")
+    }
+    entries, err := s.store.GetPublishedSceneContent(ctx, req.GetId())
+    if err != nil {
+        return nil, internalErr(err)
+    }
+    return assemblePublicResponse(pub, entries), nil
+}
+```
+
+The two handlers MUST NOT share helpers beyond the read-only store methods. Specifically:
+
+- There is no `getPublishedSceneCore(ctx, id, gatePolicy)` that both call with different gate flags. A flag-driven gate is a regression risk; flag flips during refactor turn a participant-only RPC public.
+- The response assemblers (`assembleParticipantResponse` vs `assemblePublicResponse`) are distinct functions returning different proto messages.
+
+### 9.2.1 INV-S9 predicate equivalence: `IsMember` and `IsParticipant`
+
+The existing audit-history path (`audit.go::QueryHistory`, lines 493–555) uses `s.memberLookup.IsMember(ctx, sceneID, characterID)`. The new publication-RPC handlers use `s.store.IsParticipant(ctx, sceneID, characterID)` (introduced for `GetPoseOrder` per ADR `holomush-nt2d`). Both predicates implement the same INV-S9 rule: return `true` only for `scene_participants` rows with `role = 'owner'` or `role = 'member'`; rows with `role = 'invited'` return `false`. The difference is naming only — both are valid gate primitives for INV-S9 paths. A future cleanup MAY consolidate to a single name; the spec does not mandate the consolidation in Phase 6.
+
+### 9.3 AttributeResolverService
+
+`plugins/core-scenes/resolver.go` currently returns these attributes for the `scene` type: `id`, `owner`, `state`, `visibility`, `location_id`, `tags`, `warnings`, `participants`, `invitees`. Phase 6 makes no additions and MUST NOT add any of: `content`, `content_entries`, `poses`, `says`, `emits`, `ooc`, `log`, `entries`, `publication`. A meta-test (§11) regression-locks this.
+
+### 9.4 Test contract for INV-S9 (call-stack assertion)
+
+The plugin-code gate ordering is asserted by a tripwire mock store:
+
+```go
+// service_publish_gate_test.go
+type contentTripwireStore struct {
+    headerStore
+    contentReadCalls atomic.Int32
+}
+
+func (s *contentTripwireStore) GetPublishedSceneContent(_ context.Context, _ string) ([]Entry, error) {
+    s.contentReadCalls.Add(1)
+    return nil, nil
+}
+
+func TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore(t *testing.T) {
+    store := &contentTripwireStore{...}
+    // Configure: pub exists, status=PUBLISHED. Caller is NOT a participant.
+    srv := &SceneServiceImpl{store: store, /* no ABAC engine */}
+    _, err := srv.GetPublishedScene(ctx, req)
+    require.Error(t, err)
+    require.Equal(t, "SCENE_PRIVACY_BOUNDARY_BLOCK", oops.AsOops(err).Code())
+    require.Equal(t, int32(0), store.contentReadCalls.Load(),
+        "INV-S9 violation: content store hit before participant gate denied")
+}
+```
+
+This test parallels `audit_test.go:229 TestQueryHistoryDeniesNonMemberWithoutHittingLogStore`, which pins the same ordering for the audit-table read path.
+
+## 10. Hard Privacy Boundary Block — Triple Signal
+
+When the INV-S9 gate denies a non-participant access to a participant-gated RPC, the handler MUST emit a triple-signal observability artifact:
+
+```go
+func (s *SceneServiceImpl) emitPrivacyBoundaryBlock(ctx context.Context, op, sceneID, callerID, reason string) {
+    // 1. WARN structured log.
+    slog.WarnContext(ctx, "scene privacy boundary block",
+        "operation", op,
+        "scene_id", sceneID,
+        "caller_id", callerID,
+        "denial_reason", reason,
+        "code", "SCENE_PRIVACY_BOUNDARY_BLOCK")
+
+    // 2. Counter metric (no-op stub — see §13.1).
+    metricScenePublishPrivacyBlock(op, reason)
+
+    // 3. Span error attribute.
+    span := trace.SpanFromContext(ctx)
+    span.SetStatus(otelcodes.Error, "denied")
+    span.SetAttributes(attribute.String("deny.reason", reason))
+}
+```
+
+The metric call follows the existing package-level no-op stub pattern in `plugins/core-scenes/metrics.go` (see §13.1). Binary-plugin Prometheus infrastructure does not exist yet (per v2 spec §11, recorded as the substrate gap); Phase 6 adds stub functions named per §13.1, each accepting the labeled arguments and discarding them. Every privacy block call-site is wired now; when the host's binary-plugin metrics path lands, only `metrics.go` changes.
+
+The handler MUST NOT emit an IC stream event for the block. Doing so creates a side channel — non-participants who attempt access leave a visible trace on the scene's own stream. Internal observability only (INV-P6-9).
+
+## 11. Snapshot Pipeline (COOLOFF → PUBLISHED)
+
+When the cool-off timer fires for an attempt where COOLOFF status holds, the snapshot pipeline runs:
+
+```go
+// publish_snapshot.go (sketch)
+func (s *publishService) runSnapshot(ctx context.Context, publishedSceneID string) error {
+    ctx, span := tracer.Start(ctx, "scene.publish.snapshot")
+    defer span.End()
+
+    return s.txRunner.RunInTx(ctx, func(tx pgx.Tx) error {
+        // Step 1: SELECT FOR UPDATE; re-validate invariants.
+        pub, err := s.store.LockPublishedSceneForSnapshot(ctx, tx, publishedSceneID)
+        if err != nil {
+            return err
+        }
+        if pub.Status != StatusCoolOff {
+            return nil // idempotent no-op
+        }
+        if !allYesVotes(pub.Votes) {
+            return s.failAttempt(ctx, tx, pub, FailureCoolOffInvariantBroken)
+        }
+
+        // Step 2: read IC events from scene_log, filtered to content kinds.
+        rows, err := s.store.ReadSceneLogForSnapshot(ctx, tx, pub.SceneID)
+        if err != nil {
+            return err
+        }
+
+        // Step 3: decrypt sensitive payloads via the plugin's existing DEK access.
+        decoded, err := s.codec.DecodeBatch(ctx, rows)
+        if err != nil {
+            return s.failAttempt(ctx, tx, pub, FailureSnapshotDecryptFailed)
+        }
+
+        // Step 4: render to structured entries.
+        entries, err := renderEntries(decoded)
+        if err != nil {
+            return s.failAttempt(ctx, tx, pub, FailureSnapshotRenderFailed)
+        }
+
+        // Step 5: read scene metadata for snapshots.
+        scene, err := s.store.GetScene(ctx, tx, pub.SceneID)
+        if err != nil {
+            return err
+        }
+        participants := frozenParticipantsAtPublishTime(scene)
+
+        // Step 6: atomic UPDATE.
+        if err := s.store.MarkPublished(ctx, tx, pub.ID, MarkPublishedInput{
+            ContentEntries:       entries,
+            TitleSnapshot:        scene.Title,
+            ParticipantsSnapshot: participants,
+            PublishedAt:          time.Now(),
+        }); err != nil {
+            return err
+        }
+
+        // Step 7: archive the scene.
+        if err := s.store.SetSceneState(ctx, tx, pub.SceneID, SceneStateArchived); err != nil {
+            return err
+        }
+        return nil
+    })
+    // Step 8 (post-tx): emit scene_publish_resolved{outcome=PUBLISHED}.
+}
+```
+
+### 11.1 Source of truth for IC events
+
+The snapshot reads directly from `plugin_core_scenes.scene_log` (the per-plugin audit table). It does NOT call `PluginAuditService.QueryHistory` — that's a gRPC streaming RPC intended for participant reads. The snapshot is an internal plugin operation that benefits from a direct SQL read.
+
+The filter is `WHERE subject = events.<game_id>.scene.<scene_id>.ic AND type IN ('scene_pose','scene_say','scene_emit')`. OOC, ops events (join/leave/kick), pose-order-changed, idle-nudge, and the new publish-lifecycle events are all excluded. Order is `ORDER BY id ASC` (ULID time-ordered).
+
+### 11.2 Decryption
+
+`scene_pose`, `scene_say`, `scene_emit` are `sensitivity: always` per ADR `holomush-sb3n`. Payloads are per-event-DEK encrypted with AAD bound to event ID + subject. The plugin already holds DEK access for its own events (Phase 7 crypto work). The snapshot reuses the existing decrypt path (no new crypto surface).
+
+The crypto-reviewer MUST evaluate this section for any inadvertent AAD or fence violation. Specifically, bulk-decrypt-at-snapshot reuses existing primitives but is a new caller; the reviewer should confirm:
+
+- AAD is constructed identically to the runtime decrypt path.
+- The downgrade fence (INV-P7-7) is unchanged — no payload-encrypted event is rendered without successful decrypt.
+- DEK access does not cross plugin boundaries (per the role-isolation invariants).
+
+### 11.3 Atomicity
+
+Steps 1–7 happen in a single Postgres transaction. The `SELECT FOR UPDATE` row lock on `published_scenes` ensures concurrent timer fires are serialized; the status re-check in Step 1 makes subsequent fires a no-op. The atomic state change covers: status → PUBLISHED, content_entries set, scenes.state → archived. There is no observable intermediate state where the publication exists in PUBLISHED status without content.
+
+### 11.4 Failure modes
+
+| Failure | Action |
+| ------- | ------ |
+| Status changed under us (vote-flip during cool-off) | No-op; SELECT-FOR-UPDATE found COLLECTING; transaction commits without further mutation |
+| All-yes invariant violated (votes count mismatch) | Transition to ATTEMPT_FAILED with `failure_reason = COOLOFF_INVARIANT_BROKEN` |
+| Decrypt error | Transition to ATTEMPT_FAILED with `failure_reason = SNAPSHOT_DECRYPT_FAILED` |
+| Render error (encoding, panic-recovery) | Transition to ATTEMPT_FAILED with `failure_reason = SNAPSHOT_RENDER_FAILED` |
+| DB error | Bubble up; timer retries on next tick |
+
+All failure transitions emit `scene_publish_resolved` with the appropriate `outcome` and `reason`.
+
+## 12. Renderers
+
+Three formats ship in Phase 6:
+
+| Format | Description |
+| ------ | ----------- |
+| `markdown` | Canonical human-readable form. Each entry rendered as `**<speaker>** <verb-form>` where verb-form is `<content>` (pose), `says, "<content>"` (say), or `<content>` (emit). Pose-order is implicit in document order. Markdown special characters in user content are escaped. |
+| `plain_text` | No markdown syntax. Each entry rendered as `<speaker> <verb-form>`. Suitable for terminal output, copy-paste, email |
+| `jsonl` | One entry per line, each line a JSON object `{"speaker":...,"kind":...,"content":...}`. Stable key ordering for diff-friendliness |
+
+All three are derived at request time from the JSONB `content_entries` column. The same renderer code path serves both `DownloadPublishedScene` (participant) and `DownloadPublicSceneArchive` (public).
+
+For `scene log export` (audit history, NOT publication), the same three renderers operate on the live IC event stream rather than the snapshotted entries. The entry shape is identical (`{speaker, kind, content}`); the source differs.
+
+## 13. Observability
+
+### 13.1 Metrics
+
+Added to `plugins/core-scenes/metrics.go` as **package-level no-op stub functions**, following the established Phase 2 pattern (see `metricSceneCreated`, `metricSceneStateTransition`, etc., at `metrics.go:24-121`). Each stub accepts its labeled arguments and discards them. The file's header comment already documents the wire-up plan: when the binary-plugin metrics infrastructure lands (separate effort, tracked as the v2 spec §11 substrate gap), only this file changes — every call-site is already in place.
+
+| Stub function | Spec metric (when infra lands) | Type | Labels |
+| ------------- | ------------------------------ | ---- | ------ |
+| `metricScenePublishAttemptResolved(outcome, reason string)` | `scene_publish_attempts_total` | counter | `outcome`, `reason` |
+| `metricScenePublishVoteCast(vote, isChange string)` | `scene_publish_votes_cast_total` | counter | `vote`, `is_change` |
+| `metricScenePublishVoteWindowDuration(outcome string, durationSeconds float64)` | `scene_publish_vote_window_duration_seconds` | histogram | `outcome` |
+| `metricScenePublishCoolOffWindowDuration(outcome string, durationSeconds float64)` | `scene_publish_cooloff_window_duration_seconds` | histogram | `outcome` |
+| `metricScenePublishSnapshotDuration(result string, durationSeconds float64)` | `scene_publish_snapshot_duration_seconds` | histogram | `result` |
+| `metricScenePublishPrivacyBlock(operation, denialReason string)` | `scene_publish_privacy_blocks_total` | counter | `operation`, `denial_reason` |
+| `metricScenePublishActiveAttempts(delta int)` | `scene_publish_active_attempts` | gauge | (none) |
+
+Unit tests at this stage assert call-count via a thin shim (interface-typed function variable swappable in tests) — see §15.1 `TestPrivacyBoundaryBlock_IncrementsMetric`. When the real metrics infrastructure lands, the shim is replaced with the Prometheus registration; the call-count assertions transition to Prometheus testutil assertions in the same test names.
+
+### 13.2 Spans
+
+OpenTelemetry spans at every boundary, following the v2 spec §10.1 convention:
+
+- `scene.service.start_scene_publish`
+- `scene.service.cast_publish_scene_vote`
+- `scene.service.withdraw_scene_publish`
+- `scene.service.get_published_scene`
+- `scene.service.download_published_scene`
+- `scene.service.get_public_scene_archive`
+- `scene.publish.resolve`
+- `scene.publish.snapshot`
+- `scene.publish.privacy_block`
+
+All spans carry `scene_id` and `attempt_id` where applicable. Parent context propagates from the host's plugin gRPC client (per v2 §10.1).
+
+### 13.3 Structured logs
+
+Every state-machine transition logs at INFO with `attempt_id`, `scene_id`, `from_status`, `to_status`, `reason`. Every privacy boundary block logs at WARN per §10. Every snapshot result logs at INFO (success) or ERROR (failure) with `attempt_id`, `failure_reason`, wrapped pgx error code.
+
+## 14. Invariants (RFC2119)
+
+- **INV-P6-1 (MUST):** Publication-vote rosters SHALL be frozen at attempt creation and immutable for the attempt's lifetime. Owner+member roles only; invited rows SHALL be excluded.
+- **INV-P6-2 (MUST):** A vote MAY be cast or changed any number of times during COLLECTING. Once an attempt enters COOLOFF, votes MAY be changed only by voting no (which SHALL transition the attempt back to COLLECTING).
+- **INV-P6-3 (MUST):** Only the scene owner SHALL withdraw an active attempt. Participants opposed to publication MUST express their position via voting no, not via withdraw.
+- **INV-P6-4 (MUST):** A scene SHALL transition to `archived` ONLY on PUBLISHED. ATTEMPT_FAILED transitions SHALL NOT advance scene state. Attempts-exhausted scenes SHALL stay `ended` indefinitely.
+- **INV-P6-5 (MUST):** The IsParticipant gate at `GetPublishedScene`, `DownloadPublishedScene`, and `ListScenePublishAttempts` SHALL execute before any database query against `published_scenes.content_entries` or `published_scene_votes`. Verified by call-stack tripwire test.
+- **INV-P6-6 (MUST NOT):** The ABAC engine SHALL NOT be called during participant-gated publication RPC handlers. INV-S9 forbids ABAC from the participant-only read path.
+- **INV-P6-7 (MUST NOT):** `AttributeResolverService.ResolveResource` SHALL NOT return scene content (poses, says, emits, OOC, publication content_entries) under any attribute name. Verified by a regression-lock meta-test.
+- **INV-P6-8 (MUST):** `GetPublicSceneArchive` and `DownloadPublicSceneArchive` SHALL return opaque `NOT_FOUND` for any non-PUBLISHED publication. The error wire shape SHALL be identical for nonexistent, COLLECTING, COOLOFF, and ATTEMPT_FAILED states.
+- **INV-P6-9 (MUST):** Hard-privacy-boundary blocks SHALL emit a WARN-level structured log AND increment `scene_publish_privacy_blocks_total` AND mark the OTel span error with `deny.reason`. NO IC stream event SHALL be emitted (side-channel prevention).
+- **INV-P6-10 (MUST):** Snapshot at COOLOFF → PUBLISHED SHALL be atomic. The SELECT FOR UPDATE + content build + UPDATE + scene state change SHALL happen in one transaction. Snapshot failures SHALL transition to ATTEMPT_FAILED with a specific `failure_reason` and SHALL NOT leave the publication in a partial state.
+
+## 15. Test Plan
+
+The Phase 6 surface is privacy-critical. Coverage discipline applies across four tiers; every invariant in §14 SHALL have at least one test asserting it by ID.
+
+### 15.1 Tier 1: Unit tests
+
+Located in `plugins/core-scenes/*_test.go`. Standard Go testing with testify; ACE naming per `.claude/rules/testing.md`; table-driven where natural. Mocks via mockery; ABAC stubs from `policytest.GrantEngine` / `AllowAllEngine` / `DenyAllEngine`.
+
+**State machine** (`publish_state_test.go`):
+
+- `TestPublishStateMachine_TransitionTable` — every legal transition AND every illegal transition rejects with `SCENE_PUBLISH_INVALID_TRANSITION`
+- `TestPublishStateMachine_RejectsBackwardFromTerminal` — PUBLISHED and ATTEMPT_FAILED reject any outbound transition
+- `TestPublishStateMachine_ResolutionTriggers` — all-yes → COOLOFF; any-no-after-all-voted → ATTEMPT_FAILED; timeout-with-pending → ATTEMPT_FAILED; owner-withdraw from either active state → ATTEMPT_FAILED
+- `TestPublishStateMachine_CoolOffFlipBack` — flip yes → no during COOLOFF returns to COLLECTING; previous yes votes preserved
+
+**Vote tally** (`publish_vote_tally_test.go`):
+
+- `TestVoteTally_CountsYesNoPending` — correct counts for mixed roster
+- `TestVoteTally_UnanimousYesRequiresZeroPendingZeroNo` — unanimous only when `(yes=N, no=0, pending=0)`
+- `TestVoteTally_AllVotedNotUnanimous` — `pending=0 AND no>0` triggers ATTEMPT_FAILED
+
+**Roster freezing** (`publish_roster_test.go`):
+
+- `TestFreezeRoster_OwnerAndMembersOnly` — invited rows excluded
+- `TestFreezeRoster_EmptyExcludedRoles` — invited-only scene produces empty roster → `SCENE_PUBLISH_NO_ELIGIBLE_VOTERS`
+- `TestFreezeRoster_SingleParticipantScene` — owner-alone scene: roster = [owner]; single yes → COOLOFF
+- `TestFreezeRoster_PostFreezeImmutable` — adding members AFTER attempt start does NOT change in-flight roster
+
+**Renderers** (`publish_render_test.go`):
+
+- `TestRenderMarkdown_FromEntries` — well-formed output, speaker bolded, kind-appropriate verb form
+- `TestRenderMarkdown_EmptyEntries` — sentinel "no content" markdown, not empty string
+- `TestRenderMarkdown_EscapesMarkdownSyntax` — user content with `*_[]` escaped
+- `TestRenderMarkdown_PreservesUnicodeAndEmoji` — UTF-8 safe including supplementary plane
+- `TestRenderPlainText_StripsAllSyntax` — output matches expected golden file
+- `TestRenderJSONL_OneEntryPerLine` — each line valid JSON; round-trips byte-equal
+- `TestRenderJSONL_StableKeyOrder` — speaker/kind/content key order deterministic
+
+**Focus resolution** (`commands_resolve_test.go`):
+
+- `TestResolveSceneRef_FocusedNoArg` — uses connection.focused_scene; no DB call
+- `TestResolveSceneRef_ExplicitHashArg` — parses `#<ulid>`, validates membership
+- `TestResolveSceneRef_NoFocusNoArg` — returns `SCENE_PUBLISH_NO_FOCUSED_SCENE`
+- `TestResolveSceneRef_ExplicitMalformed` — returns `SCENE_PUBLISH_REF_INVALID`
+- `TestResolveSceneRef_ExplicitNonMember` — returns `SCENE_PUBLISH_NOT_PARTICIPANT`
+
+**INV-S9 gate ordering** (`service_publish_gate_test.go`) — INV-P6-5/6:
+
+- `TestGetPublishedSceneDeniesNonParticipantWithoutHittingContentStore` — content-read tripwire NOT hit on deny
+- `TestDownloadPublishedSceneDeniesNonParticipantWithoutHittingContentStore`
+- `TestListScenePublishAttemptsDeniesNonParticipantWithoutHittingStore`
+- `TestParticipantRPCsDoNotConsultABACEngine` — recording ABAC engine has zero calls (INV-P6-6)
+- `TestPublicArchiveRPCsDoNotConsultParticipantStore` — separate code path verified
+
+**Public RPC opacity** (`service_public_archive_test.go`) — INV-P6-8:
+
+- `TestGetPublicSceneArchive_OpacityTable` — subtests for nonexistent, COLLECTING, COOLOFF, ATTEMPT_FAILED all return identical wire-shape NOT_FOUND
+- `TestGetPublicSceneArchive_PublishedReturnsContent` — PUBLISHED returns full content + frozen participants + title + published_at
+- `TestDownloadPublicSceneArchive_OpacityTable` — same multi-status opacity check
+
+**Resolver no-leak** (`resolver_test.go`, extended) — INV-P6-7:
+
+- `TestResolverNeverExposesContentByForbiddenAttributeName` — enumerate ResolveResource attrs; assert no key matches `^(content|content_entries|poses?|says?|emits?|ooc|log|entries|publication)$`
+- `TestResolverNeverExposesPublicationStatus` — no publish-attempt status returned in the ABAC attribute surface
+
+**Privacy block triple-signal** (`service_privacy_block_test.go`) — INV-P6-9:
+
+- `TestPrivacyBoundaryBlock_EmitsWARNLog` — slog capture: WARN level with full attribute set
+- `TestPrivacyBoundaryBlock_IncrementsMetric` — `scene_publish_privacy_blocks_total{operation, denial_reason}` increments by 1
+- `TestPrivacyBoundaryBlock_DoesNotEmitICEvent` — mock event emitter; ZERO publish events fire on deny path
+- `TestPrivacyBoundaryBlock_SpanMarkedError` — OTel test exporter: span has `Status.Code == codes.Error`, attribute `deny.reason` set
+
+### 15.2 Tier 2: Plugin-local integration tests
+
+Located in `plugins/core-scenes/*_integration_test.go`. Ginkgo/Gomega with `//go:build integration`. Uses `sharedPG` from `core_scenes_suite_test.go`.
+
+`publish_state_integration_test.go`:
+
+```go
+var _ = Describe("Scene publication lifecycle", func() {
+    Context("Happy path: unanimous yes → PUBLISHED", func() {
+        It("transitions COLLECTING → COOLOFF when all roster votes yes", ...)
+        It("transitions COOLOFF → PUBLISHED when cool-off window elapses", ...)
+        It("writes content_entries atomically with status change", ...)
+        It("updates parent scene.state to archived in same transaction", ...)
+        It("emits scene_publish_resolved with outcome=PUBLISHED", ...)
+    })
+
+    Context("Sad path: any-no after all-voted → ATTEMPT_FAILED", func() {
+        It("transitions to ATTEMPT_FAILED with reason=ANY_NO", ...)
+        It("leaves parent scene in state=ended (NOT archived)", ...)
+        It("allows starting a new attempt with attempt_number+1", ...)
+    })
+
+    Context("Sad path: timeout with pending → ATTEMPT_FAILED", func() {
+        It("transitions to ATTEMPT_FAILED with reason=TIMEOUT", ...)
+        It("counts pending voters as effective no", ...)
+    })
+
+    Context("Sad path: owner withdraw → ATTEMPT_FAILED", func() {
+        It("from COLLECTING: transitions with reason=WITHDRAWN", ...)
+        It("from COOLOFF: transitions with reason=WITHDRAWN", ...)
+        It("rejects withdraw from non-owner participant", ...)
+    })
+
+    Context("Cool-off flip back", func() {
+        It("returns to COLLECTING when a voter flips yes → no", ...)
+        It("preserves other voters' yes votes across the flip", ...)
+        It("can re-enter COOLOFF if the flipped voter changes back to yes", ...)
+    })
+
+    Context("Retry semantics", func() {
+        It("allows up to max_publish_attempts (default 3) attempts per scene", ...)
+        It("rejects StartScenePublish on attempt_count == max", ...)
+        It("admin extend bumps max_publish_attempts; subsequent StartScenePublish succeeds", ...)
+        It("rejects non-admin extend with permission_denied", ...)
+        It("rejects new attempt while a non-terminal attempt exists", ...)
+        It("rejects new attempt after a PUBLISHED row exists", ...)
+    })
+
+    Context("DB constraint enforcement", func() {
+        It("unique index published_scenes_one_active_per_scene rejects duplicate", ...)
+        It("unique index published_scenes_one_published_per_scene rejects duplicate", ...)
+        It("CHECK constraint rejects invalid status enum values", ...)
+    })
+})
+```
+
+`publish_snapshot_integration_test.go` — INV-P6-10 atomicity:
+
+- `It("snapshots pose/say/emit events only, excluding OOC and ops")` — mixed insert; only three content kinds appear in entries
+- `It("decrypts sensitive payloads via plugin's DEK access")` — sensitivity:always payloads → plaintext entries
+- `It("transitions to ATTEMPT_FAILED with SNAPSHOT_DECRYPT_FAILED on key miss")` — corrupted DEK; failure path
+- `It("is idempotent — second snapshot call on same attempt is a no-op")` — concurrent fire; second SELECT-FOR-UPDATE blocked
+- `It("preserves chronological order via ULID id ASC")` — out-of-order insert; ordered output
+- `It("freezes participants_snapshot at PUBLISHED time")` — late-join member appears in participants_snapshot
+
+`publish_resolver_integration_test.go` — INV-P6-7:
+
+- `It("resolver returns identical attribute key set for any scene state")` — Resolve scene at active/paused/ended/archived plus with PUBLISHED row; key set unchanged
+
+`publish_event_emission_integration_test.go`:
+
+- `It("emits scene_publish_started on attempt start")`
+- `It("emits scene_publish_vote_cast with is_change=true on re-vote")`
+- `It("emits scene_publish_cooloff_started on COLLECTING → COOLOFF")`
+- `It("emits scene_publish_resolved with appropriate reason")`
+- `It("emits scene_publish_withdrawn alongside scene_publish_resolved on owner withdraw")`
+- `It("emits scene_publish_vote_attempts_extended on admin extend")`
+
+### 15.3 Tier 3: End-to-end / cross-plugin integration
+
+Located in `test/integration/scenes/`. Ginkgo/Gomega using `internal/testsupport/integrationtest` — real CoreServer, testcontainer Postgres, embedded NATS, full ABAC engine, plugin process. MUST NOT use `eventbustest` (full stack required).
+
+`publish_e2e_test.go`:
+
+```go
+var _ = Describe("Scene publication E2E", func() {
+    Context("Telnet command flow", func() {
+        It("Alice ends scene; runs 'scene publish'; first attempt created", ...)
+        It("each roster member receives notification on per-character stream", ...)
+        It("non-focused roster member can 'scene publish vote yes #id' and vote registers", ...)
+        It("'scene publish status' shows tally without revealing individual votes pre-resolution", ...)
+        It("after all yes + cool-off elapse, scene transitions to PUBLISHED and archived", ...)
+    })
+
+    Context("Privacy gate end-to-end", func() {
+        It("non-participant Charlie's GetPublishedScene returns PermissionDenied", ...)
+        It("Charlie's denial emits WARN log + metric + error span (observable)", ...)
+        It("Charlie's GetPublicSceneArchive while COLLECTING returns NOT_FOUND", ...)
+        It("Charlie's GetPublicSceneArchive after PUBLISHED returns content", ...)
+        It("Charlie cannot use AttributeResolverService to read content", ...)
+    })
+
+    Context("Notifications", func() {
+        It("members not focused on the scene receive scene_publish_started notification", ...)
+        It("notification carries scene_id + attempt_id for explicit voting", ...)
+    })
+
+    Context("Retry and admin extend", func() {
+        It("3 failed attempts blocks a 4th unless admin extends", ...)
+        It("admin extend on a scene with 3 failed allows StartScenePublish to succeed", ...)
+        It("non-admin extend returns PermissionDenied at ABAC gate", ...)
+    })
+
+    Context("Concurrency", func() {
+        It("two voters casting simultaneously each succeed; tally is correct", ...)
+        It("two simultaneous StartScenePublish: exactly one succeeds", ...)
+        It("vote-flip race with cool-off-timer has a well-defined outcome", ...)
+    })
+
+    Context("cb4x: scene log replay + export", func() {
+        It("'scene log' replays IC history paginated, participant-only", ...)
+        It("'scene log export markdown' produces well-formed markdown", ...)
+        It("'scene log export jsonl' produces newline-delimited JSON", ...)
+        It("non-participant 'scene log #id' returns access-denied", ...)
+    })
+})
+```
+
+`publish_history_scope_e2e_test.go` — interaction with the history-scope-privacy floor:
+
+- `It("a participant who joined the scene AFTER an attempt's scene_publish_started cannot see that started event")` — per iwzt §3 scene-join-floor: focus membership joined_at floor blocks pre-membership events
+- `It("a participant who joined before sees all attempt events")` — positive control
+
+### 15.4 Tier 4: Meta-tests
+
+Located in `test/meta/`:
+
+- `TestPhase6InvariantsHaveTestCoverage` — enumerate INV-P6-1..10; assert ≥1 test in tiers 1-3 cites each by ID
+- `TestSceneResolverAttributeAllowlist` — live introspection of `AttributeResolverService.GetSchema` for the `scene` type; assert key set ⊆ allowlist (regression lock for any future attribute addition)
+
+### 15.5 Coverage targets
+
+| Package | Target |
+| ------- | ------ |
+| `plugins/core-scenes/` (Phase 6 additions) | ≥ 85% (privacy-critical surface) |
+| `plugins/core-scenes/publish_*.go` (new files) | ≥ 90% |
+| Renderer functions | 100% |
+
+### 15.6 Test runners
+
+```bash
+task test                                          # All unit tests (Tier 1)
+task test -- ./plugins/core-scenes/...             # Plugin-scoped unit
+task test:int                                      # Integration (Tier 2 + 3)
+task test:int -- ./plugins/core-scenes/...         # Plugin-scoped integration
+task test:int -- ./test/integration/scenes/...     # E2E
+task test:cover                                    # Coverage report
+task pr-prep                                       # Mirrors CI before push
+```
+
+## 16. Phasing (Informative)
+
+The implementation plan (produced by `writing-plans` as the next stage) is expected to slice Phase 6 into roughly five sub-deliverables. This section is informative; `plan-reviewer` and `plan-to-beads` are the authoritative slicing pass.
+
+| Slice | Surface |
+| ----- | ------- |
+| 6a | Schema (migration 000008 + 000009) + domain types + store layer + unit tests for state machine |
+| 6b | Participant RPCs + telnet commands (`scene publish [withdraw\|status]`, `scene publish vote yes/no`) + ABAC policies + INV-S9 gate + unit & integration tests |
+| 6c | Public RPCs + snapshot pipeline + renderers + opacity tests + crypto-reviewer pass |
+| 6d | Event emission (crypto.emits update; crypto-reviewer gate) + observability + privacy-block triple-signal + remaining integration tests |
+| 6e | `scene publish vote extend` admin RPC + `scene log` / `scene log export` (cb4x absorption) + meta-tests + final E2E |
+
+Each slice ships as a discrete bead under the parent epic `holomush-5rh`, with `bd dep add` edges expressing the sequencing. The slice topology is provisional pending `plan-reviewer`.
+
+## 17. Out of Scope
+
+- **Scene board with content warnings** (Phase 8, `holomush-5rh.17`) — public discovery surface for published scenes is deferred to the board work.
+- **Web chat view** (Phase 9, `holomush-5rh.18`) — including a pending-vote dashboard for cross-scene voters.
+- **"Resume from ended"** capability — preserved by the §4 state-machine choice (archive only on PUBLISHED) but not built in Phase 6.
+- **Forum view** of published scenes — out of scope per v2 spec; covered by the future Forum epic.
+- **Per-participant publication revocation** — once PUBLISHED, the artifact is immutable and cannot be withdrawn. Future revocation surface is not designed.
+- **AttributeResolverService schema for publication attributes** — INV-P6-7 forbids; resolver is intentionally not extended.
+- **Multi-format publication storage** (HTML pre-rendering, PDF) — Phase 6 derives all formats from the single JSONB content_entries column; pre-rendered formats are out of scope.
+
+## 18. Open Questions
+
+None at design-doc finalization. All three brainstorm items identified in the `holomush-5rh.15` bead notes were resolved during the 2026-05-23 brainstorm session (see `holomush-5rh.20` notes):
+
+1. **Publication-artifact rename** → `PublishedScene` / `published_scenes` everywhere
+2. **OriginLocationID / PublishVote reinstate** → both removed from the participant model (OriginLocationID dropped; PublishVote lives in dedicated `published_scene_votes` table)
+3. **INV-S9 hard privacy boundary preservation** → resolved as the implementation contract specified in §9-§10
+
+## 19. Related Work
+
+- [Substrate-contract design](2026-05-16-social-spaces-substrate-contract.md) — INV-S9 boundary contract for scene reads
+- [Scenes v2 design](2026-04-06-scenes-and-rp-design-v2.md) — Phase 6 binds to §1.5, §5.5–§5.8, §6.4, §6.6 with the divergences in §2 above
+- [History scope privacy design](2026-05-17-history-scope-privacy-design.md) — §3 "scene privacy is absolute" applies to scene IC stream events including publish-vote lifecycle events
+- [Scenes Phase 4 design](2026-05-19-scenes-phase-4-streams-and-pose-order-design.md) — IsParticipant predicate (§7.3) is the primitive used by §9 gates
+- [Scenes Phase 5 design](2026-05-21-scenes-phase-5-focus-model-and-multi-connection-visibility-design.md) — connection focus + multi-connection visibility; non-focused-member notifications path
+- ADR [holomush-c8a9](../../adr/holomush-c8a9-scene-privacy-plugin-code-enforcement.md) — plugin-code enforcement of scene-log reads
+- ADR [holomush-nt2d](../../adr/holomush-nt2d-participant-gate-pattern-generalized.md) — generalizing the participant-gate pattern across scene RPCs
+- ADR [holomush-sb3n](../../adr/holomush-sb3n-scene-content-sensitivity-always.md) — scene content events classified as sensitivity:always (drives §11.2 decrypt path)
+- `.claude/rules/event-conventions.md` — subject naming, event identity vs ordering
+- `.claude/rules/grpc-errors.md` — error opacity and code-translation discipline
+- `.claude/rules/plugin-manifest.md` — manifest update conventions
+- `.claude/rules/plugin-runtime-symmetry.md` — host RPC parity (informative; Phase 6 does not add host RPCs)
+- `.claude/rules/testing.md` — testing posture and Ginkgo discipline
+
+<!-- adr-capture: sha256=4b723875810e0492; session=cli; ts=2026-05-23T23:20:33Z; adrs=qd3r5,jrefa,e3xlx,39a5f,c4jee -->


### PR DESCRIPTION
## Summary

Design phase for **Scenes Phase 6** (`holomush-5rh.15`): publish vote state machine, publication artifact distinct from audit `scene_log`, two-pair RPC surface (participant INV-S9-gated + public status-gated), snapshot pipeline, three renderer formats. Folds in `holomush-cb4x` (`scene log` replay + export commands).

- **Spec:** `docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md` (945 lines, `design-reviewer` READY after 2 rounds)
- **Plan:** `docs/superpowers/plans/2026-05-23-scenes-phase-6-logs-vote-privacy.md` (3388 lines, `plan-reviewer` READY after 3 rounds — covers 43 tasks across 5 phases)
- **ADRs:** 5 new architecture decisions captured

## ADRs

| ID | Decision |
|----|----------|
| [\`holomush-qd3r5\`](docs/adr/holomush-qd3r5-two-pair-rpc-no-shared-gate-path.md) | Participant-gated and public publication RPCs use no shared code path |
| [\`holomush-jrefa\`](docs/adr/holomush-jrefa-published-scenes-table-distinct-from-scene-log.md) | Publication artifact stored in published_scenes, not reusing scene_log audit |
| [\`holomush-e3xlx\`](docs/adr/holomush-e3xlx-publication-content-as-structured-jsonb.md) | Publication content stored as structured JSONB entry array, rendered on demand |
| [\`holomush-39a5f\`](docs/adr/holomush-39a5f-frozen-voter-roster-in-separate-table.md) | Vote roster frozen at attempt start into published_scene_votes, not on scene_participants |
| [\`holomush-c4jee\`](docs/adr/holomush-c4jee-inv-p6-6-structural-enforcement.md) | INV-P6-6 enforced via AST import scan + reflect field check (no constructor seam) |

## Brainstorm decisions (8 questions resolved on bead holomush-5rh.20)

- **Scope:** vote + read-replay + renderers (cb4x folded); board+CW deferred to Phase 8
- **Naming:** PublishedScene / published_scenes everywhere (resolves v2 spec §1.5 'Scene Log' collision)
- **Voter model:** frozen roster at scene-end; owner+member only; vote in dedicated table
- **Vote semantics:** changeable until resolution, owner withdraw, 30m cool-off, 7d vote window, all positions in for resolution (no short-circuit)
- **Retry:** 3 attempts default per scene (configurable); admin-extend RPC; failed attempts non-terminal for scene
- **OriginLocationID/PublishVote:** both dropped from Participant
- **Vote events:** scene IC stream notices, sensitivity:never (6 new event types added to crypto.emits)
- **Read access:** structurally separate participant + public RPC pairs

## Divergences from v2 spec / bead acceptance criteria

Spec §2 carries the full divergence table with rationale. Key items: votes changeable (not v2's no-re-vote); explicit \`scene publish\` command (not auto-on-scene-end); per-attempt failure with retry (not v2's 'permanent participant-only'); archived ONLY on PUBLISHED (not on attempts-exhausted); admin-extend allowed (bumps counter, NOT vote outcome).

## INV-P6 invariants

10 RFC2119 invariants (INV-P6-1..10) in spec §14, each with at least one test in spec §15 across 4 tiers: unit, plugin-local integration (Ginkgo), E2E, meta.

## bd epic materialized

\`holomush-5rh.20\` promoted task → epic; 43 child task beads filed (.1 – .43). 5 ADR decision beads closed and linked to natural-beneficiary child tasks. First ready: .1 (A1 migration), .2 (A2), .3 (A3 proto), .4 (A4 types), .9 (B1), .27 (D1 crypto manifest), .31 (D5 resolver lock). Critical path P0s: .14 (B5 INV-S9 tripwire), .26 (C7 snapshot pipeline with crypto-reviewer gate).

## Test plan

This PR is **design-only**. Implementation lands per the 43-task plan starting with .1 (migration 000008).

- [x] \`task pr-prep\` green (full pipeline incl. E2E containers)
- [x] design-reviewer READY × 2 rounds
- [x] plan-reviewer READY × 3 rounds (round 1: 7 findings; round 2: 4 cascade mismatches; round 3: 1 critical + 1 minor — all addressed inline)
- [x] adr-extractor returned 5 accepted / 3 rejected (rejections sound — behavioral policy lives in spec text)
- [x] 5 ADR files pass adr-doctor

🤖 Generated with [Claude Code](https://claude.com/claude-code)