### PR TITLE
fix(eventbus/history): short-circuit hot reads on empty subjects (87qu fix)

### DIFF
--- a/internal/eventbus/history/hot_jetstream.go
+++ b/internal/eventbus/history/hot_jetstream.go
@@ -25,6 +25,14 @@ import (
 // query surfaces quickly.
 const hotFetchTimeout = 5 * time.Second
 
+// hotPrecheckTimeout bounds the subject-emptiness precheck. Short
+// because GetLastMsgForSubject is a metadata lookup that returns in
+// milliseconds in the steady state; a missed deadline here falls
+// through to the existing Fetch path so the worst case is no slower
+// than today (we just pay the full hotFetchTimeout if the precheck
+// itself stalls).
+const hotPrecheckTimeout = 1 * time.Second
+
 // HotTierOption tunes jetStreamHotTier construction.
 type HotTierOption func(*jetStreamHotTier)
 
@@ -93,16 +101,54 @@ func newJetStreamHotTier(js jetstream.JetStream, selector codec.KeySelector, now
 	return h
 }
 
-// Read satisfies HotTier. Builds an OrderedConsumer rooted at the earliest
-// start position implied by q, fetches up to pageSize messages, decodes
-// each, and filters in-process for the Before/After/NotAfter bounds the JS
-// consumer cannot express directly.
+// subjectIsEmpty returns true when GetLastMsgForSubject confirms no
+// message has ever matched subj on eventbus.StreamName. Returns false
+// on success (a message exists), on any lookup error (graceful
+// fallthrough — caller proceeds with the existing Fetch path), and on
+// ctx cancellation (caller's Fetch will also short-circuit on the same
+// ctx). Bounded by hotPrecheckTimeout independently of the caller's
+// ctx so a slow precheck cannot consume the caller's full latency
+// budget.
+func (h *jetStreamHotTier) subjectIsEmpty(ctx context.Context, subj eventbus.Subject) bool {
+	preCtx, cancel := context.WithTimeout(ctx, hotPrecheckTimeout)
+	defer cancel()
+	stream, err := h.js.Stream(preCtx, eventbus.StreamName)
+	if err != nil {
+		return false
+	}
+	if _, lastErr := stream.GetLastMsgForSubject(preCtx, string(subj)); errors.Is(lastErr, jetstream.ErrMsgNotFound) {
+		return true
+	}
+	return false
+}
+
 // Read fetches a page of events from JetStream. The *StreamStateSnapshot
 // parameter is intentionally ignored: the hot tier always derives its own
 // stream state from the query parameters and (for tail reads) a fresh
 // stream.Info() call — see the backward uncursored branch below.
 func (h *jetStreamHotTier) Read(ctx context.Context, q eventbus.HistoryQuery, edge time.Time, pageSize int, _ *StreamStateSnapshot) ([]eventbus.Event, error) {
 	if pageSize <= 0 {
+		return nil, nil
+	}
+	// Subject-emptiness precheck (holomush-87qu connect-latency fix):
+	// GetLastMsgForSubject is a cheap metadata lookup that returns
+	// jetstream.ErrMsgNotFound when no message has ever matched the
+	// subject filter. Without this, cons.Fetch below blocks for the
+	// full hotFetchTimeout (5s) on truly-empty subjects — the
+	// dominant component of fresh-guest connect latency (two ambient
+	// streams × 5s wait = ~10s "syncing" window).
+	//
+	// The NATS-recommended primitive for this use case (per
+	// nats-io/nats.go docs + Stream Management wiki) is exactly
+	// GetLastMsgForSubject + ErrMsgNotFound sentinel. Alternatives
+	// (Stream.Info aggregates, ConsumerInfo.NumPending) require
+	// heavier ops; this is the lightest available probe.
+	//
+	// Failure modes are graceful: if the Stream lookup or precheck
+	// itself errors (e.g. transient ctx deadline, NATS connection
+	// hiccup), we fall through to the existing Fetch path and pay
+	// the same worst-case wait as before — no regression.
+	if h.subjectIsEmpty(ctx, q.Subject) {
 		return nil, nil
 	}
 	// Determine the fetch size (how many messages to request from the JS

--- a/internal/eventbus/history/hot_jetstream_test.go
+++ b/internal/eventbus/history/hot_jetstream_test.go
@@ -294,3 +294,50 @@ func TestReaderRejectsInvalidDirection(t *testing.T) {
 	})
 	errutil.AssertErrorCode(t, err, "EVENTBUS_HISTORY_INVALID_DIRECTION")
 }
+
+// TestHotTierEmptySubjectShortCircuitsInsteadOfWaitingFetchTimeout pins
+// the holomush-87qu fix: querying a subject with zero matching messages
+// MUST return immediately via GetLastMsgForSubject's ErrMsgNotFound
+// short-circuit, NOT pay the full hotFetchTimeout (5s). The connect-
+// latency dominator on fresh-guest sessions was 2 ambient stream
+// backfills each waiting 5s; this regression lock asserts the
+// per-subject wait is now ~10ms typical, definitely <500ms.
+//
+// Budget: 500ms (well below hotFetchTimeout = 5s but generous enough
+// to absorb embedded-NATS startup variance + GetLastMsgForSubject
+// round-trip on CI testcontainers). A regression that reverted to the
+// pre-fix Fetch-on-empty path would fail by an order of magnitude.
+func TestHotTierEmptySubjectShortCircuitsInsteadOfWaitingFetchTimeout(t *testing.T) {
+	embedded := eventbustest.New(t)
+	reader := history.NewReader(
+		embedded.JS, nil,
+		24*time.Hour, func() time.Time { return time.Now() },
+	)
+
+	// A subject that has never been published to — GetLastMsgForSubject
+	// must return ErrMsgNotFound and Read must short-circuit.
+	emptySubject := eventbus.Subject("events.main.never-published.subject")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	stream, err := reader.QueryHistory(ctx, eventbus.HistoryQuery{
+		Subject:   emptySubject,
+		Direction: eventbus.DirectionForward,
+		PageSize:  10,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stream.Close() })
+
+	nextCtx, nextCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer nextCancel()
+	_, nextErr := stream.Next(nextCtx)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, nextErr, io.EOF, "empty subject query must reach EOF, not error or block indefinitely")
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"empty-subject hot read MUST short-circuit via GetLastMsgForSubject (~10ms typical); "+
+			"took %s. Regression of holomush-87qu — the pre-fix path would have waited the "+
+			"full hotFetchTimeout (5s) on cons.Fetch.", elapsed)
+}


### PR DESCRIPTION
## Summary

Eliminates the dominant component of fresh-guest connect latency: two
ambient stream backfills each waiting the full `hotFetchTimeout` (5s)
on empty subjects, observed as 2 × ~5s `WebQueryStreamHistory` calls
in the network panel (~10s "syncing" window). User-reported repro on
game.holomush.dev/terminal.

## Root cause

`cons.Fetch(N, FetchMaxWait(5s))` in
`internal/eventbus/history/hot_jetstream.go` blocks the full
`FetchMaxWait` when no message matches the subject filter. A brand-new
guest's character stream and (for low-traffic locations) location
stream both hit this — wall time = 2 × 5s.

The instrumentation that landed in #4190 made this visible: the
user's network-panel screenshot showed exactly 2 × ~5s
WebQueryStreamHistory calls back-to-back on connect.

## Fix

Subject-emptiness precheck via `Stream.GetLastMsgForSubject` before
`cons.Fetch`. Returns `jetstream.ErrMsgNotFound` when no message has
ever matched the subject → short-circuit and return empty immediately,
skipping the blocking Fetch.

Per nats-io/nats.go docs (verified via DeepWiki Stream Management
wiki page), this is the canonical primitive for empty-subject
detection. Alternatives (`Stream.Info` aggregates,
`ConsumerInfo.NumPending`) are heavier and ill-suited.

**Failure modes are graceful:** ANY error other than `ErrMsgNotFound`
(Stream lookup failure, ctx deadline on precheck, transport hiccup)
falls through to the existing Fetch path — worst case is the pre-fix
wall time, no regression. Precheck is bounded by
`hotPrecheckTimeout=1s` independently of the caller's ctx so a slow
precheck cannot consume the caller's full latency budget.

## Latency impact

| Path | Pre-fix | Post-fix |
|---|---|---|
| Empty-subject hot read | ~5s | ~ms |
| Fresh-guest connect-to-ready | 8-10s (2 × 5s) | ~ms (2 × ~ms) |
| Active-subject hot read | unchanged | +1 metadata RPC (~10ms) |

## Out of scope (acceptable for the P0 fix)

- Time-bounded query whose window excludes all messages still pays
  the full Fetch wait (subject IS non-empty, but window is empty).
  Targets the dominant truly-empty case.
- Wildcard subjects are NATS-spec-supported by `GetLastMsgForSubject`
  but unexercised in production callers.

## Test plan

- [x] `task test -- ./internal/eventbus/history/` — 181 tests pass
      under `-race` (+1 new regression lock)
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` — passed (full pipeline including E2E)
- [x] New regression test
      (`TestHotTierEmptySubjectShortCircuitsInsteadOfWaitingFetchTimeout`)
      asserts query of a never-published subject returns `io.EOF`
      within 500ms (pre-fix would have waited 5s)
- [x] 87qu's existing 1s budget regression lock in the
      integrationtest harness continues to pass
- [x] Code review (pre-push, in-session): READY — 3 non-blocking
      findings all addressed inline or noted as acceptable scope limits

Closes holomush-g2s1z (follow-up perf fix for holomush-87qu, which
shipped instrumentation-only in #4190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)