### PR TITLE
fix(sandbox): deploy-sandbox v-prefix image tag + repo-level deploy gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -321,9 +321,12 @@ jobs:
     name: Deploy Sandbox
     runs-on: namespace-profile-linux-amd64-2x4
     # Joins the `prod` GitHub Environment: gives deployment tracking/history in
-    # the Environments UI, surfaces the live URL, scopes the SANDBOX_DEPLOY_ENABLED
-    # gate variable, and is the hook for adding a required-reviewer approval rule
-    # later without touching this workflow.
+    # the Environments UI, surfaces the live URL, and is the hook for adding a
+    # required-reviewer approval rule later without touching this workflow.
+    # NOTE: the SANDBOX_DEPLOY_ENABLED gate below is a *repository* variable, not
+    # an environment-scoped one — environment variables are not resolvable in a
+    # job-level `if:` (the environment activates only after the gate is
+    # evaluated, so an env-scoped var reads as empty and the job silently skips).
     environment:
       name: prod
       url: https://game.holomush.dev
@@ -422,7 +425,12 @@ jobs:
             rm -rf /tmp/holomush-release
 
             cd /opt/holomush
-            sed -i "s/^HOLOMUSH_VERSION=.*/HOLOMUSH_VERSION=${VERSION}/" .env
+            # The git tag is v-prefixed (v0.1.9), but goreleaser publishes the
+            # container image as bare {{ .Version }} (0.1.9). git clone above
+            # needs the tag; HOLOMUSH_VERSION / docker pull need the bare
+            # version, so strip a single leading "v" here.
+            IMAGE_VERSION="${VERSION#v}"
+            sed -i "s/^HOLOMUSH_VERSION=.*/HOLOMUSH_VERSION=${IMAGE_VERSION}/" .env
             docker compose --profile tunnel --profile backups pull core gateway cloudflared
             docker compose --profile tunnel --profile backups build backup
             docker compose --profile tunnel --profile backups up -d --no-recreate postgres


### PR DESCRIPTION
## Summary

The `deploy-sandbox` job (auto-deploy to game.holomush.dev) had never run until now — the gate was `false` through v0.1.7/0.1.8/0.1.9. Flipping it on and running a **pre-flight `workflow_dispatch`** surfaced two latent bugs that would have broken the first real auto-deploy, plus confirmed the env branch policy. This PR fixes the v-prefix bug; the gate fix was applied operationally (see below).

### 1. v-prefix image-tag mismatch (the code fix here)

goreleaser publishes the image as bare `{{ .Version }}` — GHCR tags are `0.1.9`, `0.1.9-amd64`, `0.1.9-arm64`, `latest` (no `v*`). But the git **tag** is `v0.1.9`. The "Pull + migrate + restart" step used the same `VERSION` for both `git clone --branch` (needs `v0.1.9`) **and** `HOLOMUSH_VERSION` → `docker compose pull` (needs `0.1.9`), so the pull would 404 on `ghcr.io/holomush/holomush:v0.1.9`.

**Fix:** derive `IMAGE_VERSION="${VERSION#v}"` for the image while keeping `VERSION` (v-prefixed) for `git clone --branch`. Strip verified idempotent: `v0.1.9→0.1.9`, `v0.2.0→0.2.0`, `0.1.9→0.1.9`.

### 2. Gate variable moved to repository scope (operational + comment fix here)

`SANDBOX_DEPLOY_ENABLED` was an **environment(`prod`)-scoped** variable, but environment variables are **not resolvable in a job-level `if:`** (the environment activates only after the gate is evaluated), so `deploy-sandbox` silently **skipped** even with the variable set to `true`. Moved to a **repository** variable (`=true`); removed the `prod`-scoped duplicate. The job still joins `environment: prod` for deployment tracking/URL/history. Workflow comment corrected to document this.

### Also confirmed (no change needed)

`prod` environment deployment-branch policy = `{branch: main, tag: v*}` — dispatch from a feature branch is rejected at setup. Pre-flight must run from `main` or a `v*` tag. (This PR → merge to `main` → dispatch from `main` to complete the pre-flight.)

## Review

`code-reviewer`: **READY** (zero findings; independently confirmed goreleaser `.Version` strips `v` at `.goreleaser.yaml:123,143,159`).

## Test plan

- [ ] Merge to `main`
- [ ] `gh workflow run release.yaml --ref main -f tag=v0.1.9` → `deploy-sandbox` runs to completion (SSH backup + clone v0.1.9 + pull 0.1.9 + migrate + restart + health probe)
- [ ] First real tag-push release auto-deploys without image-pull 404

Refs: holomush-hryj, holomush-hryj.27

🤖 Generated with [Claude Code](https://claude.com/claude-code)