### PR TITLE
refactor(plugin/lua): remove deprecated 'stream' key alias from emit-table parser (holomush-zxmo)

### DIFF
--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -549,20 +549,7 @@ func (h *Host) parseEmitEvents(ret lua.LValue) (emits []pluginsdk.EmitEvent, val
 			return
 		}
 
-		// F1: `subject` is the canonical key; `stream` is accepted for one
-		// release as a deprecation alias so existing Lua plugins keep working
-		// during the cutover. When both are set, subject wins.
 		subject := emitTableString(eventTable, "subject")
-		if subject == "" {
-			if legacy := emitTableString(eventTable, "stream"); legacy != "" {
-				slog.Warn(
-					"plugin emit uses deprecated 'stream' key; migrate to 'subject'",
-					"key", "stream",
-					"index", index,
-				)
-				subject = legacy
-			}
-		}
 		eventType := emitTableString(eventTable, "type")
 		payload := emitTableString(eventTable, "payload")
 

--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -1181,6 +1181,76 @@ end
 	assert.Contains(t, logOutput, "warn-missing-subject", "expected plugin name in warning")
 }
 
+// After holomush-zxmo removes the F1 deprecation alias, an emit table that
+// supplies only the legacy `stream =` key (and no `subject =`) MUST be
+// rejected by parseEmitEvents with the same "missing required 'subject'
+// field" validation error that an entry with neither key gets. The clean
+// break removes any silent rewriting that might let stale out-of-tree code
+// limp along; rejection is the correct loud failure mode after the
+// in-tree producer migration in holomush-fz9h closed all in-tree consumers
+// of the alias.
+func TestLuaHostDeliverEventRejectsLegacyStreamKeyEntryAsMissingSubject(t *testing.T) {
+	dir := t.TempDir()
+
+	// Plugin returns an entry with only the legacy `stream =` key (no
+	// `subject =`) and a control entry using canonical `subject =`. The
+	// legacy entry MUST be rejected; the canonical entry MUST pass through.
+	mainLua := `
+function on_event(event)
+    return {
+        {
+            stream = "legacy:1",
+            type = "test",
+            payload = "legacy-stream-key-only"
+        },
+        {
+            subject = "valid:1",
+            type = "test",
+            payload = "canonical"
+        }
+    }
+end
+`
+	writeMainLua(t, dir, mainLua)
+
+	var logBuf bytes.Buffer
+	handler := slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(oldLogger)
+
+	host := pluginlua.NewHost()
+	defer closeHost(t, host)
+
+	manifest := &plugins.Manifest{
+		Name:      "reject-legacy-stream",
+		Version:   "1.0.0",
+		Type:      plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+	}
+
+	err := host.Load(context.Background(), manifest, dir)
+	require.NoError(t, err)
+
+	event := pluginsdk.Event{ID: "01ABC", Type: "say"}
+	emits, err := host.DeliverEvent(context.Background(), "reject-legacy-stream", event)
+	require.NoError(t, err)
+
+	// Only the canonical entry MUST pass; the legacy entry MUST be dropped.
+	require.Len(t, emits, 1,
+		"legacy `stream =` key alone MUST be rejected once the F1 deprecation alias is removed (holomush-zxmo)")
+	assert.Equal(t, "valid:1", emits[0].Stream,
+		"surviving entry MUST be the one that used canonical `subject =`")
+
+	// Validation error MUST surface via slog as a missing-subject error,
+	// matching the shape produced when neither key is set.
+	logOutput := logBuf.String()
+	assert.Contains(t, logOutput, "missing required 'subject' field",
+		"validation log MUST cite the missing-subject error code for the legacy-stream-key entry")
+	assert.Contains(t, logOutput, "reject-legacy-stream",
+		"validation log MUST include the plugin name")
+}
+
 func TestLuaHostDeliverEventMalformedEmitEventsWarnsOnMissingType(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Drops the F1 deprecation fallback at `internal/plugin/lua/host.go` (formerly
lines 552-565) that consulted the legacy `stream` key when canonical
`subject` was absent and logged

    level=WARN msg="plugin emit uses deprecated 'stream' key; migrate to 'subject'"

on every legacy-shape emit. The producer-side migration in holomush-fz9h
(PR #4189) removed every in-tree consumer of the alias, so this clean break
has no in-tree blast radius — and the new TDD-failing acceptance test
confirms a legacy-only emit now fails missing-subject validation loudly
instead of silently rewriting.

Closes holomush-zxmo. Closes original ext issue #2874.

## Diff

| File | Δ |
| --- | --- |
| `internal/plugin/lua/host.go` | −13 lines (alias fallback + slog.Warn + deprecation comment) |
| `internal/plugin/lua/host_test.go` | +70 lines (new acceptance test) |

Before:

```go
// F1: `subject` is the canonical key; `stream` is accepted for one
// release as a deprecation alias so existing Lua plugins keep working
// during the cutover. When both are set, subject wins.
subject := emitTableString(eventTable, "subject")
if subject == "" {
    if legacy := emitTableString(eventTable, "stream"); legacy != "" {
        slog.Warn(
            "plugin emit uses deprecated 'stream' key; migrate to 'subject'",
            "key", "stream",
            "index", index,
        )
        subject = legacy
    }
}
```

After:

```go
subject := emitTableString(eventTable, "subject")
```

Downstream missing-subject validation at the next block is unchanged and
already produces the right error message — verified by the new test.

## New test

`internal/plugin/lua/host_test.go::TestLuaHostDeliverEventRejectsLegacyStreamKeyEntryAsMissingSubject`
asserts: an emit table with only `stream = "..."` (no `subject =`) is
rejected with the same `missing required 'subject' field` validation
error a table with neither key gets, and that an adjacent canonical
entry passes through.

**Red→green confirmed:** test fails before the host.go change (entry passes
via alias, returning 2 emits) and passes after (1 emit, legacy entry
rejected with the canonical error code in the log).

## Out of scope

- `pluginsdk.EmitEvent.Stream` Go field rename to `Subject` — still F5
- Proto field name rename in `hostfunc.proto` / `plugin.proto` — still F5
  (wire-contract change for out-of-tree plugins)
- Host→Lua input-side rename from `event.stream` to `event.subject` — still F5
- Subject value migration colon→dot — holomush-rops
- Repo-wide gofumpt drift in 16 unrelated files surfaced when `task fmt`
  runs in a fresh workspace — already tracked by holomush-mpb7d (meta:
  fmt:check doesn't enforce gofumpt) and holomush-0ce01 / iusi / dkpb
  (cleanup sweeps). Restored from parent during pre-push hygiene to
  keep this PR scope-clean.

## Test plan

- [x] New test red before change, green after
- [x] `task test -- ./internal/plugin/lua/...` (108 tests, +1 from fz9h baseline)
- [x] `task test -- ./internal/plugin/... ./plugins/...` (1610 tests)
- [x] `task lint` EXIT=0
- [x] `task pr-prep` ✓ All PR checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)