### PR TITLE
fix(workflows): silence false-positive shellcheck SC2015 in bootstrap-sandbox

### DIFF
--- a/.github/workflows/bootstrap-sandbox.yaml
+++ b/.github/workflows/bootstrap-sandbox.yaml
@@ -369,6 +369,14 @@ jobs:
           # (prod / image tag / 0.1).
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          # shellcheck disable=SC2015
+          # BACKUP_S3_ACCESS_KEY_VAL and BACKUP_S3_SECRET_KEY_VAL env values
+          # use the GitHub Actions ternary pattern (a != empty AND a OR b).
+          # When actionlint inlines those values for shellcheck analysis, the
+          # pattern triggers SC2015 (A && B || C is not if-then-else). The GH
+          # Actions expression has correct short-circuit semantics (b equals
+          # a when truthy, so the c-fallback only fires when a is empty);
+          # SC2015 is a cross-language false positive here.
           set -euo pipefail
 
           echo "::add-mask::${TUNNEL_TOKEN}"


### PR DESCRIPTION
## Summary

actionlint's shellcheck integration triggers SC2015 ("A && B || C is not if-then-else") on the bootstrap-sandbox.yaml run: block because it inlines the `BACKUP_S3_ACCESS_KEY_VAL` and `BACKUP_S3_SECRET_KEY_VAL` env values into the script. Those env values use the GitHub Actions ternary pattern (which has correct short-circuit semantics that don't apply to the SC2015 anti-pattern).

The GH Actions expression evaluates correctly (the C-fallback only fires when A is empty), so SC2015 is a cross-language false positive. Fix: add `# shellcheck disable=SC2015` at the top of the run: block with explanatory comment.

## Impact

Unblocks CI lint for PR #4198 (gfo6 nanosecond timestamps Phase 2-5), which was failing on this pre-existing main lint issue. Other PRs reading the same actionlint check should also benefit.

## Test plan

- [x] `task lint:actions` passes locally
- [x] No logic change — only adds shellcheck directive + comment
- [x] No untrusted-input handling introduced

Closes: bd holomush-9agj9

🤖 Generated with [Claude Code](https://claude.com/claude-code)