### PR TITLE
fix(sandbox): guest-reaper FK cascade, Secure cookies, OTel opt-in (live-log findings)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -201,6 +201,19 @@ Keep under 200 lines. Curate — don't hoard.
   or snapshot inside RLock. Check this pattern whenever a new late-bound field
   is added to Host.
 
+- **FK cascade fix over-reach contradicts crypto soft-delete spec**: a bug fix
+  that adds `ON DELETE CASCADE` to fix one FK (e.g. guest reaper needs only
+  `player_character_bindings.player_id` cascade) must NOT also cascade
+  `character_id`. The crypto design spec
+  (`docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md:732-734`)
+  mandates character deletion SOFT-deletes bindings (`ended_at`/`ended_reason`)
+  and explicitly "do NOT cascade-delete them" — historical `binding_id` is
+  forensic-retention substrate in `crypto_keys.participants[]`. `Service.DeleteCharacter`
+  (`internal/world/service.go:602` → `character_repo.go:77 DELETE FROM characters`)
+  is a live method (no prod caller yet, Phase-4-deferred). Always scope a cascade
+  fix to the exact FK the bug needs and check the touched table against any
+  soft-delete lifecycle spec before widening. Encountered 2026-05-23 (21bd9).
+
 - **Plan-file markdown breaks lint gate**: `task lint` includes `rumdl` markdown
   lint over `docs/`. A stray bare ` ``` ` fence will fail `lint:markdown` and
   block CI. Run `task lint` after any plan file edit.

--- a/cmd/holomush/gateway.go
+++ b/cmd/holomush/gateway.go
@@ -37,6 +37,7 @@ type gatewayConfig struct {
 	WebAddr              string        `koanf:"web_addr"`
 	WebDir               string        `koanf:"web_dir"`
 	CORSOrigins          []string      `koanf:"cors_origins"`
+	SecureCookies        bool          `koanf:"secure_cookies"`
 	TelnetMaxConns       int           `koanf:"telnet_max_conns"`
 	TelnetIdleTimeout    time.Duration `koanf:"telnet_idle_timeout"`
 	TelnetWriteTimeout   time.Duration `koanf:"telnet_write_timeout"`
@@ -111,6 +112,7 @@ from telnet and web clients, forwarding commands to the core process.`,
 	cmd.Flags().StringVar(&cfg.WebAddr, "web-addr", defaultWebAddr, "web HTTP listen address")
 	cmd.Flags().StringVar(&cfg.WebDir, "web-dir", "", "override embedded static files with directory path")
 	cmd.Flags().StringSliceVar(&cfg.CORSOrigins, "cors-origins", nil, "allowed CORS origins (e.g., http://localhost:5173)")
+	cmd.Flags().BoolVar(&cfg.SecureCookies, "secure-cookies", false, "set the Secure flag + SameSite=Strict on session cookies (MUST be true for any TLS-served deployment; default false for local plain-HTTP dev)")
 	cmd.Flags().IntVar(&cfg.TelnetMaxConns, "telnet-max-conns", defaultTelnetMaxConns, "max concurrent telnet connections")
 	cmd.Flags().DurationVar(&cfg.TelnetIdleTimeout, "telnet-idle-timeout", defaultTelnetIdleTimeout, "per-connection idle read timeout")
 	cmd.Flags().DurationVar(&cfg.TelnetWriteTimeout, "telnet-write-timeout", defaultTelnetWriteTimeout, "per-send write deadline")
@@ -296,6 +298,7 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, cmd *cobra.Comm
 		Handler:     webHandler,
 		WebDir:      cfg.WebDir,
 		CORSOrigins: cfg.CORSOrigins,
+		Secure:      cfg.SecureCookies,
 		// Forward the configured DSN so the web server can register the
 		// /api/sentry-relay tunnel endpoint. Empty = no relay (and no
 		// open-proxy risk).

--- a/cmd/holomush/gateway_test.go
+++ b/cmd/holomush/gateway_test.go
@@ -539,6 +539,25 @@ func TestGatewayCommand_WebDefaults(t *testing.T) {
 	corsOrigins, err := cmd.Flags().GetStringSlice("cors-origins")
 	require.NoError(t, err)
 	assert.Empty(t, corsOrigins)
+
+	// secure-cookies defaults false so local plain-HTTP dev keeps working;
+	// TLS deployments (the sandbox) MUST pass --secure-cookies (holomush-w8ywo).
+	secureCookies, err := cmd.Flags().GetBool("secure-cookies")
+	require.NoError(t, err)
+	assert.False(t, secureCookies)
+}
+
+// TestGatewayCommand_SecureCookiesFlag verifies --secure-cookies binds to the
+// gateway config so the gateway can set web.Config.Secure on TLS deployments
+// (holomush-w8ywo regression lock).
+func TestGatewayCommand_SecureCookiesFlag(t *testing.T) {
+	cmd := NewGatewayCmd()
+	err := cmd.Flags().Parse([]string{"--secure-cookies"})
+	require.NoError(t, err)
+
+	secureCookies, err := cmd.Flags().GetBool("secure-cookies")
+	require.NoError(t, err)
+	assert.True(t, secureCookies)
 }
 
 // TestControlServerError_TriggersShutdown verifies that when the control gRPC server

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -61,7 +61,13 @@ services:
       - --log-format=json
     environment:
       DATABASE_URL: postgres://holomush:${POSTGRES_PASSWORD}@postgres:5432/holomush?sslmode=require
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}
+      # Empty by default: with no OTLP endpoint the telemetry SDK no-ops
+      # (internal/telemetry/provider.go). A localhost:4317 default made the
+      # service spam "telemetry SDK error: connection refused" on deployments
+      # without a collector. Operators wanting tracing set this explicitly
+      # (e.g. OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317) and run the
+      # observability profile.
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       # Error/trace reporting. Empty SENTRY_DSN disables Sentry (no-op), so
       # self-hosters without Sentry are unaffected.
       SENTRY_DSN: ${SENTRY_DSN:-}
@@ -91,8 +97,12 @@ services:
       - --core-addr=core:9000
       - --metrics-addr=0.0.0.0:9101
       - --log-format=json
+      # Served over TLS (Cloudflare edge -> tunnel -> gateway), so session
+      # cookies MUST carry the Secure flag + SameSite=Strict.
+      - --secure-cookies
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}
+      # Empty by default — see the core service note above (no-op without a collector).
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       # Gateway reads SENTRY_DSN (cmd/holomush/gateway.go); empty = disabled.
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
@@ -157,8 +167,8 @@ services:
     restart: unless-stopped
     profiles: [observability]
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
     volumes:
       - ${CONFIG_DIR:-/opt/holomush/config}/otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
     networks:

--- a/internal/auth/postgres/player_repo.go
+++ b/internal/auth/postgres/player_repo.go
@@ -311,8 +311,10 @@ func (r *PlayerRepository) ListIdleGuests(ctx context.Context, idleSince time.Ti
 }
 
 // DeleteGuestPlayer removes a guest player. The is_guest=true guard prevents
-// accidental deletion of registered players. FK cascades delete characters
-// and player sessions.
+// accidental deletion of registered players. FK cascades delete characters,
+// player sessions, and player_character_bindings (the bindings cascade was
+// added in migration 000040; without it the reaper failed with a 23503 FK
+// violation for any guest that had a character binding).
 func (r *PlayerRepository) DeleteGuestPlayer(ctx context.Context, playerID ulid.ULID) error {
 	result, err := r.pool.Exec(ctx, `
 		DELETE FROM players WHERE id = $1 AND is_guest = true

--- a/internal/auth/postgres/player_repo_test.go
+++ b/internal/auth/postgres/player_repo_test.go
@@ -517,6 +517,53 @@ func TestPlayerRepository_DefaultCharacterID(t *testing.T) {
 	})
 }
 
+// TestPlayerRepository_DeleteGuestPlayer_CascadesBindings is the regression
+// lock for holomush-21bd9: before migration 000040 the
+// player_character_bindings.player_id FK had no ON DELETE CASCADE, so reaping a
+// guest that had a character binding failed with SQLSTATE 23503 and the
+// GuestReaper logged a WARN every interval forever. This reproduces that exact
+// shape (guest player + character + active binding) and asserts the delete now
+// succeeds and cascades.
+func TestPlayerRepository_DeleteGuestPlayer_CascadesBindings(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewPlayerRepository(testPool)
+
+	guestID := ulid.Make()
+	charID := ulid.Make()
+	bindingID := ulid.Make()
+
+	_, err := testPool.Exec(ctx,
+		`INSERT INTO players (id, username, password_hash, is_guest) VALUES ($1, $2, '', true)`,
+		guestID.String(), "guest_cascade_"+guestID.String())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM players WHERE id = $1`, guestID.String())
+	})
+
+	_, err = testPool.Exec(ctx,
+		`INSERT INTO characters (id, player_id, name) VALUES ($1, $2, $3)`,
+		charID.String(), guestID.String(), "Guest Char")
+	require.NoError(t, err)
+
+	_, err = testPool.Exec(ctx,
+		`INSERT INTO player_character_bindings (id, player_id, character_id) VALUES ($1, $2, $3)`,
+		bindingID.String(), guestID.String(), charID.String())
+	require.NoError(t, err)
+
+	err = repo.DeleteGuestPlayer(ctx, guestID)
+	require.NoError(t, err, "deleting a guest with a character binding must not violate the FK")
+
+	var bindings int
+	require.NoError(t, testPool.QueryRow(ctx,
+		`SELECT count(*) FROM player_character_bindings WHERE player_id = $1`, guestID.String()).Scan(&bindings))
+	assert.Zero(t, bindings, "binding should cascade-delete with the guest player")
+
+	var chars int
+	require.NoError(t, testPool.QueryRow(ctx,
+		`SELECT count(*) FROM characters WHERE id = $1`, charID.String()).Scan(&chars))
+	assert.Zero(t, chars, "character should cascade-delete with the guest player")
+}
+
 // Compile-time interface check.
 var _ auth.PlayerRepository = (*postgres.PlayerRepository)(nil)
 

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Migrator", func() {
 
 			version, dirty, err = migrator.Version()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(uint(39)))
+			Expect(version).To(Equal(uint(40)))
 			Expect(dirty).To(BeFalse())
 
 			tables = queryTableNames(suiteT, ctx, connStr)
@@ -174,7 +174,7 @@ var _ = Describe("Migrator", func() {
 
 			version, dirty, err = migrator.Version()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(version).To(Equal(uint(39)))
+			Expect(version).To(Equal(uint(40)))
 			Expect(dirty).To(BeFalse())
 
 			tables = queryTableNames(suiteT, ctx, connStr)

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -278,7 +278,7 @@ func TestMigratorCloseIsIdempotent(t *testing.T) {
 }
 
 func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testing.T) {
-	// At version 0, migrations 1-20, 30, 31, 32, 33, 34, 35, 36, 37, 38, and 39 should be pending
+	// At version 0, migrations 1-20, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, and 40 should be pending
 	// (baseline + is_guest + alias_source + session_player_id + audit_source_component +
 	// session_focus + seed_scene_defaults + session_player_fk + create_events_audit +
 	// drop_events_and_cursors + events_audit_js_seq_index + events_audit_rendering +
@@ -289,16 +289,16 @@ func TestMigratorPendingMigrationsReturnsMigrationsAboveCurrentVersion(t *testin
 	// add_justification_to_checkpoints + add_phase3_count_to_checkpoints +
 	// drop_checkpoint_dek_fks + admin_approvals_op_args_hash_idx +
 	// add_session_history_floor_columns + eventbus_crypto_timestamps_to_bigint +
-	// connection_focus_key)
+	// connection_focus_key + player_character_bindings_cascade)
 	m := &Migrator{m: &mockMigrate{versionVal: 0, versionErr: migrate.ErrNilVersion}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
-	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39}, pending)
+	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40}, pending)
 }
 
 func TestMigratorPendingMigrationsReturnsEmptyAtLatestVersion(t *testing.T) {
-	// At version 39 (latest), no migrations should be pending
-	m := &Migrator{m: &mockMigrate{versionVal: 39}}
+	// At version 40 (latest), no migrations should be pending
+	m := &Migrator{m: &mockMigrate{versionVal: 40}}
 	pending, err := m.PendingMigrations()
 	require.NoError(t, err)
 	assert.Empty(t, pending)

--- a/internal/store/migrations/000040_player_character_bindings_cascade.down.sql
+++ b/internal/store/migrations/000040_player_character_bindings_cascade.down.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Revert the player_id FK to the original no-cascade (RESTRICT) form created
+-- by 000015. (character_id was never altered by the up migration.)
+
+ALTER TABLE player_character_bindings
+    DROP CONSTRAINT IF EXISTS player_character_bindings_player_id_fkey;
+ALTER TABLE player_character_bindings
+    ADD CONSTRAINT player_character_bindings_player_id_fkey
+    FOREIGN KEY (player_id) REFERENCES players(id);

--- a/internal/store/migrations/000040_player_character_bindings_cascade.up.sql
+++ b/internal/store/migrations/000040_player_character_bindings_cascade.up.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- player_character_bindings (000015) created its player_id FK WITHOUT ON DELETE
+-- CASCADE, unlike every other player-referencing FK (e.g. characters.player_id
+-- in 000002, player_totp in 000019). This blocked PlayerRepository.
+-- DeleteGuestPlayer (called by GuestReaper): deleting a guest player that had a
+-- binding failed with
+--   "violates foreign key constraint player_character_bindings_player_id_fkey"
+-- (SQLSTATE 23503), so guests with characters were never reaped and the reaper
+-- logged a WARN every interval. Re-create the player_id FK with ON DELETE
+-- CASCADE so deleting a player removes its bindings (and characters.player_id's
+-- existing cascade removes the character).
+--
+-- The character_id FK is intentionally LEFT as RESTRICT (no cascade): the
+-- crypto forensic-retention design (docs/superpowers/specs/
+-- 2026-04-25-event-payload-crypto-design.md §"Character deletion") requires
+-- character deletion to SOFT-end the binding (ended_at/ended_reason) and keep
+-- historical bindings queryable for forensic decryption — they MUST NOT be
+-- cascade-deleted. The guest-reaper path does not need it: deleting the player
+-- cascade-deletes the binding via player_id before the character is removed.
+
+ALTER TABLE player_character_bindings
+    DROP CONSTRAINT IF EXISTS player_character_bindings_player_id_fkey;
+ALTER TABLE player_character_bindings
+    ADD CONSTRAINT player_character_bindings_player_id_fkey
+    FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary

Three fixes for real errors/warnings found by reviewing the **live game.holomush.dev** container logs after go-live (v0.1.9). Bundled per request.

### 1. Guest reaper blocked by FK (holomush-21bd9) — recurring WARN+ERROR every 60s

`core` logged `guest_reaper: failed to delete guest player` and `postgres` logged `violates foreign key constraint player_character_bindings_player_id_fkey (SQLSTATE 23503)` every minute. Root cause: migration `000015` created `player_character_bindings.player_id` **without** `ON DELETE CASCADE` (unlike every other player-referencing FK), so `DeleteGuestPlayer` could never reap a guest that had a character binding — they accumulated unbounded.

**Fix:** new migration `000040` adds `ON DELETE CASCADE` to **only** `player_id`. The `character_id` FK is deliberately left `NO ACTION`: the crypto forensic-retention design (`docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md` §"Character deletion") requires character deletion to *soft-end* bindings and keep them queryable for forensic decryption — they MUST NOT cascade-delete. Deleting a guest player cascades the binding via `player_id` and the character via the existing `characters.player_id` cascade; the `character_id` NO-ACTION check defers to end-of-statement and passes. Regression test added.

### 2. Session cookies missing `Secure` flag over TLS (holomush-w8ywo)

Gateway logged `session cookies will be issued WITHOUT Secure flag` despite being TLS-fronted (Cloudflare → tunnel). Added a `--secure-cookies` gateway flag (default `false` to preserve local plain-HTTP dev) wired to `web.Config.Secure`, and set it in `compose.prod.yaml`.

### 3. OTel exporter error spam (holomush-ggz0i)

Gateway logged `telemetry SDK error ... dial tcp 127.0.0.1:4317: connect: connection refused` every ~10-30s. `compose.prod.yaml` defaulted `OTEL_EXPORTER_OTLP_ENDPOINT` to `http://localhost:4317`, but no collector runs in the sandbox; `internal/telemetry/provider.go` already no-ops on an empty endpoint. **Fix:** compose now defaults the endpoint to empty for core+gateway (and silences the otel-collector parse warnings). Operators wanting tracing set it explicitly (`otel-collector:4317`) + run the observability profile.

## Review

`code-reviewer`: **READY**. The first pass (NOT READY) caught that the `character_id` cascade would violate the crypto forensic-retention invariant; corrected to `player_id`-only (above), re-reviewed READY.

## Test plan

- [x] `task pr-prep` — ✓ All PR checks passed (lint, fmt, license, unit, integration, e2e)
- [x] New `TestPlayerRepository_DeleteGuestPlayer_CascadesBindings` integration test (guest + character + binding → reap → cascade) passes
- [x] `TestGatewayCommand_SecureCookiesFlag` + WebDefaults flag tests pass
- [x] `internal/store` migrator tests updated to version 40 (unit + FullCycle integration)

## Notes

- Filed follow-ups: `SceneStore ListParticipants` ordering flake (P1, pre-existing, observed once during the full suite) and `license:check` not ignoring `scripts/.venv` (P3, local-tooling gap).

Refs: holomush-hryj, holomush-21bd9, holomush-w8ywo, holomush-ggz0i

🤖 Generated with [Claude Code](https://claude.com/claude-code)