### PR TITLE
docs(observability): OTel-native log surfacing — spec, plan, ADRs, slog rule

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "internal/**/*.go"
+  - "cmd/**/*.go"
+  - "pkg/**/*.go"
+  - "plugins/**/*.go"
+---
+
+# Structured Logging Conventions
+
+HoloMUSH logs through `log/slog`. The logger is built in
+`internal/logging/handler.go` (`Setup`/`SetDefault`) and wraps a base
+JSON/text handler with a `traceHandler` that injects `service`, `version`,
+and — when present on the `context.Context` — `trace_id` and `span_id`.
+
+## MUST use context-carrying log variants
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** call `*Context` variants | `slog.InfoContext(ctx, …)`, `WarnContext`, `ErrorContext`, `DebugContext`, and `errutil.LogErrorContext(ctx, msg, err, …)` whenever a `context.Context` is in scope |
+| **MUST NOT** use bare variants when a ctx exists | `slog.Info(…)`, `logger.Warn(…)`, `errutil.LogError(…)` discard trace context and produce orphaned log lines |
+| **MUST** thread the ctx | If a `ctx` is reachable as a parameter, struct field, or derivable value, plumb it into the log call rather than reaching for the bare form |
+| **MAY** use bare variants | Only in the **absolutely-impossible** case: no `ctx` exists and one cannot reasonably be plumbed (init code, `main`, bare goroutines without a request/operation context, pure helpers with no caller context) |
+
+## Why this is a MUST, not a SHOULD
+
+Trace context (`trace_id` / `span_id`) is carried on the
+`context.Context`, not on the logger. Only the `*Context` slog variants
+extract it (via `traceHandler` today, and via the
+`contrib/bridges/otelslog` bridge once application logs flow to the
+OpenTelemetry log pipeline → Loki / Grafana / Sentry).
+
+A bare `slog.Info("scene started", "id", id)` emits a log line with **no
+trace correlation** — in Sentry's Logs view or Loki it cannot be linked
+back to the span/transaction it happened inside. That defeats the entire
+point of surfacing logs into a distributed-tracing backend: the value is
+in *correlation*, and correlation is lost the moment the ctx is dropped.
+
+## Examples
+
+```go
+// WRONG — ctx is right there in the signature, but dropped.
+func (s *CoreServer) handle(ctx context.Context, req *Req) error {
+    slog.Info("handling request", "kind", req.Kind)        // orphaned
+    if err != nil {
+        errutil.LogError(s.logger, "handle failed", err)   // orphaned
+    }
+}
+
+// RIGHT — ctx threaded; the log line carries trace_id/span_id.
+func (s *CoreServer) handle(ctx context.Context, req *Req) error {
+    slog.InfoContext(ctx, "handling request", "kind", req.Kind)
+    if err != nil {
+        errutil.LogErrorContext(ctx, "handle failed", err)
+    }
+}
+
+// ACCEPTABLE — no ctx in scope and none derivable (process bootstrap).
+func main() {
+    slog.Info("starting holomush", "version", buildVersion)
+}
+```
+
+## Enforcement (planned)
+
+This rule will be enforced mechanically by the `sloglint` linter with
+`context: scope` — that setting flags a bare log call **only when a
+`context.Context` is in scope**, which is exactly the "unless absolutely
+impossible" carve-out above. Enabling it is a large mechanical migration
+(~600 call sites today) tracked as `holomush-xrdjw`; until it lands, the
+rule is enforced by review. Do not introduce new bare-variant call sites that
+have a ctx available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,16 @@ Use `oops` for structured errors: `oops.With(k, v).Wrap(err)`, `oops.Errorf(...)
 
 **Method-value gotcha:** when using accessor methods (e.g., `decision.Reason()`), always include `()`. Without parens, Go creates a method value (func pointer) that compiles silently when passed to `...any` parameters (`oops.With`, `slog`).
 
+### Structured Logging
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **MUST** use context-carrying variants | `slog.InfoContext(ctx, …)` / `WarnContext` / `ErrorContext` / `DebugContext` and `errutil.LogErrorContext(ctx, …)` — **never** bare `slog.Info(…)` / `logger.Warn(…)` / `errutil.LogError(…)` — whenever a `context.Context` is in scope |
+| **MUST NOT** drop the context | If a `ctx` is reachable (parameter, struct field, or derivable), it MUST be threaded into the log call |
+| **MAY** use bare variants | Only when no `ctx` exists *and* one cannot reasonably be plumbed (init/`main`, bare goroutines, pure helpers with no caller context) — this is the "absolutely impossible" carve-out |
+
+**Why:** trace context (`trace_id`/`span_id`) lives on the `context.Context`. Only the `*Context` variants propagate it into the OpenTelemetry log pipeline, so bare calls produce orphaned log lines that can't be correlated with the trace/span they belong to in Loki, Grafana, or Sentry. See [logging.md](.claude/rules/logging.md) for the full rationale and the planned `sloglint` enforcement.
+
 ### Database Migrations
 
 `internal/store/migrations/`, embedded at compile time. Sequential numbering, paired `.up.sql` + `.down.sql`, idempotent (`IF NOT EXISTS`), no triggers/functions (all logic in Go). Full guide: [database-migrations.md](site/docs/contributing/database-migrations.md).

--- a/docs/adr/holomush-1wbzn-captureexception-behind-errutil.md
+++ b/docs/adr/holomush-1wbzn-captureexception-behind-errutil.md
@@ -1,0 +1,78 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Confine the sentry-go Error-Event (CaptureException) Touchpoint to pkg/errutil
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-1wbzn
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Sentry distinguishes two products: **Logs** (a searchable, trace-correlated
+structured-log stream) and **Issues** (grouped, alertable error events with
+stacktraces). The OTel-native log pipeline (ADR `holomush-ci829`) places
+ERROR-level records into Sentry **Logs** as ordinary entries. It does **not**
+create grouped Issues — those require `sentry.CaptureException`, a Sentry-SDK
+call.
+
+That call is the one place where error reporting must touch the vendor SDK,
+which is in direct tension with the import-graph perimeter established by
+INV-L1 (no sentry-go outside `internal/telemetry`). The question is a
+trust-ownership decision: *where does the error-event SDK touchpoint live*,
+and is it in scope for the log-surfacing work?
+
+## Alternatives Considered
+
+1. **Include `CaptureException` wiring in this work**, inline in
+   `internal/telemetry` or scattered at error sites. Fewer PRs and ERROR logs
+   immediately become Issues — but it spreads the sentry-go touchpoint and
+   couples the error-reporting path to the log pipeline, making both harder to
+   test and replace.
+2. **Defer behind a future `pkg/errutil` wrapper (chosen).** Keeps the
+   sentry-go error-event touchpoint in exactly one package; the boundary is
+   explicit and testable; the log pipeline ships complete without blocking on
+   the Issues story.
+
+## Decision
+
+Error-event capture (`sentry.CaptureException` → Sentry Issues) is **deferred
+to a separate bead** and, when implemented, MUST live only behind a
+`pkg/errutil` wrapper. `pkg/errutil` already owns the structured-error logging
+seam (`LogError` / `LogErrorContext`); it becomes the single owner of any
+sentry-go error-event API surface. No other package may import sentry-go for
+error capture.
+
+## Rationale
+
+- Prevents the sentry-go import footprint from spreading beyond
+  `internal/telemetry`; the INV-L1 perimeter stays clean and the future
+  wrapper is the only additional permitted importer.
+- `pkg/errutil` is the canonical seam for future SDK replacement or
+  mock injection in tests.
+- This work delivers a complete, shippable log pipeline; the Issues story is
+  independently releasable.
+
+## Consequences
+
+**Positive:**
+
+- The import-graph for error-event capture is defined *before* implementation
+  begins, so the follow-up cannot accidentally scatter the SDK touchpoint.
+- `pkg/errutil` is the single owner of any sentry-go error-event surface.
+
+**Negative:**
+
+- Operators see ERROR logs in the Sentry **Logs** stream but not as grouped
+  **Issues** until the follow-up bead ships.
+
+**Neutral:**
+
+- The follow-up bead must import sentry-go only through `pkg/errutil`, which
+  this decision mandates.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md` §1 (Non-Goals), §12 (INV-L1)
+- Related: holomush-ci829 (OTel-native binding / INV-L1), holomush-0wun (trace dual-export follow-ups)

--- a/docs/adr/holomush-ci829-otel-native-log-binding.md
+++ b/docs/adr/holomush-ci829-otel-native-log-binding.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Bind Application Logs to OpenTelemetry; Sentry as a Config-Only OTLP Consumer
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-ci829
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH already exports traces to Sentry through an OpenTelemetry-native
+dual-export (`holomush-0wun`): one `TracerProvider`, a collector batcher,
+and a second batcher pointing at Sentry's OTLP-HTTP endpoint. The governing
+invariant from that work, stated in `site/docs/operating/sentry.md`, is that
+"removing Sentry is a one-line config change; no app code needs to be
+touched."
+
+Surfacing `log/slog` application logs into Sentry presented a fork. sentry-go
+(`v0.46.2`, already a dependency) ships first-party logging integrations —
+the `sentryslog` handler and `sentry.NewLogger` — that route logs directly to
+Sentry. Alternatively, logs can flow through the OpenTelemetry log pipeline
+with Sentry as a generic OTLP logs consumer. Sentry ingests OTLP logs at
+`…/integration/otlp/v1/logs` (auth via the `x-sentry-auth` header); notably,
+sentry-go provides **no** OTLP log exporter (only `NewTraceExporter`), so the
+OTel path uses the generic `otlploghttp` exporter.
+
+## Alternatives Considered
+
+1. **`sentryslog` / `sentry.NewLogger` (vendor-SDK path).** Fewer new
+   modules; sentry-go already imported; simplest wiring. But it couples
+   application logging code to Sentry's API surface, breaks the
+   vendor-neutral invariant established for traces, cannot share a single
+   provider with the collector sink, and would require a second
+   vendor-specific handler to add any future destination.
+2. **OTel log pipeline; Sentry as OTLP consumer (chosen).** Application code
+   stays vendor-neutral; mirrors the existing trace dual-export shape; a
+   single bridge conversion pass feeds all sinks; collector and Sentry sinks
+   are symmetric; swapping or removing Sentry needs no app-code change. Cost:
+   the OTel log SDK and exporters are experimental `v0.x`, and DSN→endpoint
+   derivation must be maintained.
+
+## Decision
+
+Application logs are routed through the OpenTelemetry `LoggerProvider` via a
+`contrib/bridges/otelslog` bridge; Sentry receives logs as a plain OTLP-HTTP
+consumer. **No sentry-go import is permitted outside `internal/telemetry`**
+— in particular `internal/logging` and general application code must never
+import it. This is enforced statically by INV-L1 (an import-guard test).
+
+## Rationale
+
+- Preserves the vendor-neutral invariant already established for traces.
+- A single provider + bridge means the `slog`→OTel conversion runs once,
+  regardless of how many sinks are active.
+- Sentry can be replaced or disabled by changing configuration, not code.
+- INV-L1 makes the boundary a grep-able static check, not a review hope.
+
+## Consequences
+
+**Positive:**
+
+- Application code has no observable coupling to Sentry.
+- Adding future sinks (Loki direct, CloudWatch, …) requires only a new
+  processor, not new handler code.
+- Trace correlation is automatic via OTel context propagation.
+
+**Negative:**
+
+- The OTel log SDK modules are `v0.x`; minor-version bumps may require
+  coordinated updates (mitigated by pinning + a Task-1 API smoke test).
+- DSN→OTLP-endpoint derivation must be maintained in `internal/telemetry`.
+
+**Neutral:**
+
+- `sentry.Flush` at shutdown now drains only the SDK's error buffers, not log
+  buffers; the shutdown order changes accordingly (logs drain via
+  `LoggerProvider.Shutdown`).
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md` §1, §6, §12 (INV-L1)
+- Plan: `docs/superpowers/plans/2026-05-23-otel-native-log-surfacing.md`
+- Prior art: `holomush-0wun` (trace dual-export), `site/docs/operating/sentry.md`
+- Related: holomush-stow5 (provider topology), holomush-1wbzn (errutil error-event seam)

--- a/docs/adr/holomush-stow5-single-loggerprovider-levelfilter.md
+++ b/docs/adr/holomush-stow5-single-loggerprovider-levelfilter.md
@@ -1,0 +1,78 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Single LoggerProvider With Per-Sink LevelFilter Processors
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Decision:** holomush-stow5
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The application-log pipeline (see ADR `holomush-ci829`) must fan records out
+to up to three sinks — stderr, the OTLP collector (→ Loki/Grafana), and
+Sentry — each with an **independent severity floor** (e.g. stderr at
+`debug` locally while Sentry only takes `warn`). Two structural shapes were
+evaluated for the OTel side.
+
+The stderr sink is special: it is served by the existing `traceHandler`
+(`internal/logging/handler.go`), which is a plain `slog.Handler` and is not
+OTel-aware. So regardless of the OTel topology, a `slog`-layer fan-out is
+needed to tee the stderr handler and the OTel bridge.
+
+## Alternatives Considered
+
+1. **One `LoggerProvider` per sink.** Each provider handles its own level
+   natively, needing no custom processor. But the `slog`→OTel bridge
+   conversion then runs once per provider, it is inconsistent with the
+   `TracerProvider`-with-two-batchers shape already shipped, and it
+   multiplies provider lifecycles to construct and shut down.
+2. **Single `LoggerProvider` + per-sink `LevelFilter` processor (chosen).**
+   The bridge conversion runs once; maximal symmetry with the existing
+   `TracerProvider`; a single shutdown chain; a ~20-line custom
+   `sdklog.Processor` (`LevelFilter`) delivers per-sink levels by dropping
+   records below a threshold before each batch processor.
+
+## Decision
+
+A single `sdk/log.LoggerProvider` holds up to two batch-processor pipelines
+— the collector via `otlploggrpc`, Sentry via `otlploghttp` — and each is
+wrapped in a `LevelFilter` processor that drops records below the configured
+per-sink severity floor. At the `slog` layer a `FanoutHandler` tees every
+record to the stderr `traceHandler` (gated by its own `LevelGate`) and to
+the `otelslog` bridge that feeds the provider.
+
+## Rationale
+
+- Mirrors the `TracerProvider`-with-two-batchers shape shipped in
+  `holomush-0wun`, keeping the telemetry subsystem internally consistent.
+- A single bridge pass avoids redundant `slog`→OTel record conversion.
+- `LevelFilter` is a self-contained, testable type with no external
+  dependencies; per-sink levels are the one thing a single provider cannot do
+  natively, and this is the minimal mechanism that supplies them.
+
+## Consequences
+
+**Positive:**
+
+- `telemetry.Init` manages one provider lifecycle instead of N.
+- Adding a fourth sink is appending another processor, not constructing a
+  new provider.
+
+**Negative:**
+
+- The custom `LevelFilter` must track the `sdklog.Processor` interface if it
+  changes across future `v0.x` releases (caught by the Task-1 API smoke
+  test).
+
+**Neutral:**
+
+- A `FanoutHandler` at the `slog` layer is still required to decouple the
+  non-OTel stderr `traceHandler` from the bridge path.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md` §3
+- Plan: Tasks 3 (`LevelFilter`), 4 (`FanoutHandler`/`LevelGate`), 7 (provider build)
+- Related: holomush-ci829 (OTel-native binding)

--- a/docs/superpowers/plans/2026-05-23-otel-native-log-surfacing.md
+++ b/docs/superpowers/plans/2026-05-23-otel-native-log-surfacing.md
@@ -1,0 +1,962 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# OTel-Native Application-Log Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface `log/slog` application logs into the OpenTelemetry log pipeline so they reach Sentry (Logs) and the OTel collector (→ Loki/Grafana), with trace correlation, while app code stays vendor-neutral (binds to OTel only).
+
+**Architecture:** A `FanoutHandler` tees every slog record to the existing stderr `traceHandler` and to an `otelslog` bridge feeding one `sdk/log.LoggerProvider`. The provider holds up to two batch-processor pipelines (collector via `otlploggrpc`, Sentry via `otlploghttp`), each wrapped in a per-sink `LevelFilter` processor. Sinks are independently toggled by koanf config; endpoints/secrets stay env-driven. Mirrors the shipped trace dual-export (`holomush-0wun`).
+
+**Tech Stack:** Go 1.26, `log/slog`, `go.opentelemetry.io/otel/{log,sdk/log}` (v0.x experimental), `exporters/otlp/otlplog/{otlploghttp,otlploggrpc}`, `contrib/bridges/otelslog`, koanf, cobra, samber/oops, testify.
+
+> **v0.x API note (Rule 7 degraded-mode):** The OTel log SDK, OTLP log exporters, and `otelslog` bridge are experimental `v0.x` modules. context7 was consulted and returned design-level docs but not exact symbol signatures. **Task 1 pins exact versions and confirms the live API surface by compiling a smoke test.** If any later task's code block disagrees with the pinned version's signatures (e.g., a `Processor` method name or an exporter option), treat Task 1's confirmed surface as authoritative and adjust the call — the TDD compile step in each task surfaces drift immediately.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md`
+**Design bead:** `holomush-zgtqo`
+
+---
+
+## Phase 1: Dependencies & log exporters
+
+### Task 1: Add OTel log modules and confirm the API surface
+
+**Files:**
+
+- Modify: `go.mod`
+- Test: `internal/telemetry/logsmoke_test.go`
+
+- [ ] **Step 1: Add the dependencies**
+
+Run (from repo root):
+
+```bash
+go get go.opentelemetry.io/otel/log@latest \
+       go.opentelemetry.io/otel/sdk/log@latest \
+       go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@latest \
+       go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc@latest \
+       go.opentelemetry.io/contrib/bridges/otelslog@latest
+```
+
+Then record the resolved versions: `go list -m go.opentelemetry.io/otel/sdk/log go.opentelemetry.io/contrib/bridges/otelslog`. These are the authoritative signatures for all later tasks.
+
+- [ ] **Step 2: Write a smoke test that exercises the real API surface**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+)
+
+// TestLogSDKSurface pins the experimental v0.x API shapes this plan relies
+// on. If an OTel log-module bump changes any of these, this test breaks
+// first and the implementer reconciles the rest of the package against it.
+func TestLogSDKSurface(t *testing.T) {
+	lp := sdklog.NewLoggerProvider() // no processors → no-op
+	t.Cleanup(func() { _ = lp.Shutdown(context.Background()) })
+
+	// otelslog bridge produces a slog.Handler bound to a provider.
+	h := otelslog.NewHandler("holomush-test", otelslog.WithLoggerProvider(lp))
+	require.NotNil(t, h)
+
+	// Severity type used by the LevelFilter (Task 3).
+	require.Equal(t, otellog.SeverityWarn, otellog.SeverityWarn)
+}
+```
+
+- [ ] **Step 3: Run the smoke test**
+
+Run: `task test -- -run TestLogSDKSurface ./internal/telemetry/`
+Expected: PASS. If it fails to compile, the resolved API differs from this plan — fix the symbol names here and propagate to later tasks before continuing.
+
+- [ ] **Step 4: Commit**
+
+Commit per `references/vcs-preamble.md`: `feat(telemetry): add OTel log SDK deps + API smoke test`.
+
+### Task 2: Sentry logs-endpoint derivation + log exporters
+
+**Files:**
+
+- Create: `internal/telemetry/logexport.go`
+- Test: `internal/telemetry/logexport_test.go`
+
+- [ ] **Step 1: Write the failing test for DSN→endpoint derivation**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSentryLogsTarget(t *testing.T) {
+	dsn := "https://abc123@o4509.ingest.us.sentry.io/4510"
+	url, header, err := sentryLogsTarget(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "https://o4509.ingest.us.sentry.io/api/4510/integration/otlp/v1/logs", url)
+	require.Equal(t, "sentry sentry_key=abc123", header)
+}
+
+func TestSentryLogsTarget_Invalid(t *testing.T) {
+	_, _, err := sentryLogsTarget("not a dsn")
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run TestSentryLogsTarget ./internal/telemetry/`
+Expected: FAIL — `undefined: sentryLogsTarget`.
+
+- [ ] **Step 3: Implement the derivation + exporter constructors**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/samber/oops"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// sentryLogsTarget derives Sentry's OTLP logs endpoint URL and the
+// x-sentry-auth header value from a DSN. DSN parsing stays inside
+// internal/telemetry (the only package permitted to import sentry-go);
+// internal/logging never imports sentry-go (INV-L1).
+func sentryLogsTarget(dsn string) (url, authHeader string, err error) {
+	d, perr := sentry.NewDsn(dsn)
+	if perr != nil {
+		return "", "", oops.Code("SENTRY_DSN_INVALID").Wrap(perr)
+	}
+	host := d.GetHost()
+	projectID := d.GetProjectID()
+	publicKey := d.GetPublicKey()
+	url = fmt.Sprintf("https://%s/api/%s/integration/otlp/v1/logs", host, projectID)
+	authHeader = fmt.Sprintf("sentry sentry_key=%s", publicKey)
+	return url, authHeader, nil
+}
+
+// newCollectorLogExporter builds the OTLP-gRPC log exporter targeting the
+// shared collector endpoint (OTEL_EXPORTER_OTLP_ENDPOINT, env-driven).
+func newCollectorLogExporter(ctx context.Context) (sdklog.Exporter, error) {
+	exp, err := otlploggrpc.New(ctx)
+	if err != nil {
+		return nil, oops.Code("OTEL_LOG_EXPORTER_FAILED").Wrap(err)
+	}
+	return exp, nil
+}
+
+// newSentryLogExporter builds the OTLP-HTTP log exporter targeting Sentry.
+// It reuses the OTEL_EXPORTER_OTLP_ENDPOINT unset guard from initSentry so
+// the otlploghttp transport stays on HTTPS (INV-L8): the SDK forces
+// Insecure=true when that env var carries an http:// scheme.
+func newSentryLogExporter(ctx context.Context, dsn string) (sdklog.Exporter, error) {
+	url, authHeader, err := sentryLogsTarget(dsn)
+	if err != nil {
+		return nil, err
+	}
+	prev, had := os.LookupEnv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if had {
+		if uerr := os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT"); uerr != nil {
+			return nil, oops.Wrap(uerr)
+		}
+		defer func() { _ = os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", prev) }()
+	}
+	exp, err := otlploghttp.New(ctx,
+		otlploghttp.WithEndpointURL(url),
+		otlploghttp.WithHeaders(map[string]string{"x-sentry-auth": authHeader}),
+		otlploghttp.WithCompression(otlploghttp.GzipCompression),
+	)
+	if err != nil {
+		return nil, oops.Code("SENTRY_LOG_EXPORTER_FAILED").Wrap(err)
+	}
+	return exp, nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `task test -- -run TestSentryLogsTarget ./internal/telemetry/`
+Expected: PASS. (Confirm `sentry.NewDsn` accessor names — `GetHost`/`GetProjectID`/`GetPublicKey` — against the pinned sentry-go v0.46.2; adjust if the smoke test in Task 1 revealed different names.)
+
+- [ ] **Step 5: Commit**
+
+`feat(telemetry): Sentry OTLP-logs endpoint derivation + log exporters`.
+
+---
+
+## Phase 2: Per-sink level filter
+
+### Task 3: `LevelFilter` log processor
+
+**Files:**
+
+- Create: `internal/telemetry/logfilter.go`
+- Test: `internal/telemetry/logfilter_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// recordingProcessor captures emitted records for assertions.
+type recordingProcessor struct{ severities []otellog.Severity }
+
+func (r *recordingProcessor) OnEmit(_ context.Context, rec *sdklog.Record) error {
+	r.severities = append(r.severities, rec.Severity())
+	return nil
+}
+func (r *recordingProcessor) Shutdown(context.Context) error   { return nil }
+func (r *recordingProcessor) ForceFlush(context.Context) error { return nil }
+
+func TestLevelFilter_DropsBelowThreshold(t *testing.T) {
+	sink := &recordingProcessor{}
+	f := newLevelFilter(sink, otellog.SeverityWarn)
+
+	for _, sev := range []otellog.Severity{
+		otellog.SeverityInfo, otellog.SeverityWarn, otellog.SeverityError,
+	} {
+		var rec sdklog.Record
+		rec.SetSeverity(sev)
+		require.NoError(t, f.OnEmit(context.Background(), &rec))
+	}
+
+	require.Equal(t, []otellog.Severity{otellog.SeverityWarn, otellog.SeverityError}, sink.severities)
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run TestLevelFilter ./internal/telemetry/`
+Expected: FAIL — `undefined: newLevelFilter`.
+
+- [ ] **Step 3: Implement the filter**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry
+
+import (
+	"context"
+
+	otellog "go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// levelFilter is a log.Processor that forwards only records at or above a
+// minimum severity to the wrapped downstream processor. It is the mechanism
+// that lets a single LoggerProvider give the collector and Sentry sinks
+// independent severity floors (spec INV-L4).
+type levelFilter struct {
+	next sdklog.Processor
+	min  otellog.Severity
+}
+
+func newLevelFilter(next sdklog.Processor, min otellog.Severity) *levelFilter {
+	return &levelFilter{next: next, min: min}
+}
+
+func (f *levelFilter) OnEmit(ctx context.Context, rec *sdklog.Record) error {
+	if rec.Severity() < f.min {
+		return nil
+	}
+	return f.next.OnEmit(ctx, rec)
+}
+
+func (f *levelFilter) Shutdown(ctx context.Context) error   { return f.next.Shutdown(ctx) }
+func (f *levelFilter) ForceFlush(ctx context.Context) error { return f.next.ForceFlush(ctx) }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `task test -- -run TestLevelFilter ./internal/telemetry/`
+Expected: PASS. If `sdklog.Processor` declares additional methods in the pinned version (e.g., an `Enabled`), add delegating implementations — Task 1's smoke confirms the interface.
+
+- [ ] **Step 5: Commit**
+
+`feat(telemetry): per-sink level filter log processor`.
+
+---
+
+## Phase 3: slog fanout + bridge wiring
+
+### Task 4: `FanoutHandler` and `levelGate`
+
+**Files:**
+
+- Modify: `internal/logging/handler.go`
+- Test: `internal/logging/fanout_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFanout_TeesToAllChildren(t *testing.T) {
+	var a, b bytes.Buffer
+	h := NewFanout(
+		slog.NewJSONHandler(&a, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		slog.NewJSONHandler(&b, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	)
+	logger := slog.New(h)
+	logger.Info("hello")
+
+	require.Contains(t, a.String(), "hello")
+	require.Contains(t, b.String(), "hello")
+}
+
+func TestLevelGate_FiltersBelowMin(t *testing.T) {
+	var buf bytes.Buffer
+	gated := NewLevelGate(slog.LevelWarn, slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(gated)
+	logger.Info("dropped")
+	logger.Warn("kept")
+
+	out := buf.String()
+	require.False(t, strings.Contains(out, "dropped"))
+	require.True(t, strings.Contains(out, "kept"))
+}
+
+func TestFanout_SingleChildIsTransparent(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, nil)
+	h := NewFanout(base) // single child
+	require.True(t, h.Enabled(context.Background(), slog.LevelError))
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run 'TestFanout|TestLevelGate' ./internal/logging/`
+Expected: FAIL — `undefined: NewFanout`, `NewLevelGate`.
+
+- [ ] **Step 3: Implement Fanout + LevelGate**
+
+Append to `internal/logging/handler.go`:
+
+```go
+// fanoutHandler dispatches each record to every child handler. Enabled is
+// the OR of children, so a record is processed if any sink wants it; each
+// child then applies its own level/filtering. Used to tee stderr logging
+// and the OTel bridge from one slog.Logger (spec §3, INV-L2).
+type fanoutHandler struct{ children []slog.Handler }
+
+// NewFanout returns a handler that tees to all children. With a single
+// child it is transparent (degenerate case, spec §11 / INV-L7): no panic,
+// behaviour identical to using that child directly.
+func NewFanout(children ...slog.Handler) slog.Handler {
+	return &fanoutHandler{children: children}
+}
+
+func (h *fanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, c := range h.children {
+		if c.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *fanoutHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, c := range h.children {
+		if !c.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := c.Handle(ctx, r.Clone()); err != nil {
+			return err //nolint:wrapcheck // slog.Handler contract: pass child error through
+		}
+	}
+	return nil
+}
+
+func (h *fanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, len(h.children))
+	for i, c := range h.children {
+		next[i] = c.WithAttrs(attrs)
+	}
+	return &fanoutHandler{children: next}
+}
+
+func (h *fanoutHandler) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, len(h.children))
+	for i, c := range h.children {
+		next[i] = c.WithGroup(name)
+	}
+	return &fanoutHandler{children: next}
+}
+
+// levelGate wraps a handler with a minimum level, giving a per-sink floor
+// (spec INV-L4) independent of the global logger level.
+type levelGate struct {
+	min     slog.Level
+	handler slog.Handler
+}
+
+func NewLevelGate(min slog.Level, h slog.Handler) slog.Handler {
+	return &levelGate{min: min, handler: h}
+}
+
+func (g *levelGate) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= g.min && g.handler.Enabled(ctx, level)
+}
+
+func (g *levelGate) Handle(ctx context.Context, r slog.Record) error {
+	//nolint:wrapcheck // slog.Handler contract: pass child error through
+	return g.handler.Handle(ctx, r)
+}
+
+func (g *levelGate) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &levelGate{min: g.min, handler: g.handler.WithAttrs(attrs)}
+}
+
+func (g *levelGate) WithGroup(name string) slog.Handler {
+	return &levelGate{min: g.min, handler: g.handler.WithGroup(name)}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `task test -- -run 'TestFanout|TestLevelGate' ./internal/logging/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`feat(logging): fanout handler + per-sink level gate`.
+
+### Task 5: Extend `logging.Setup` to attach an OTel bridge
+
+**Files:**
+
+- Modify: `internal/logging/handler.go:70-97`
+- Test: `internal/logging/handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSetupWithBridge_TeesToBridge(t *testing.T) {
+	var stderr bytes.Buffer
+	var bridged []string
+	bridge := captureHandler{onHandle: func(r slog.Record) { bridged = append(bridged, r.Message) }}
+
+	logger := SetupWithBridge("svc", "v1", "json", &stderr, slog.LevelInfo, bridge, slog.LevelInfo)
+	logger.Info("both")
+
+	require.Contains(t, stderr.String(), "both")
+	require.Equal(t, []string{"both"}, bridged)
+}
+```
+
+(Define `captureHandler` as a minimal `slog.Handler` test double in the test file: `Enabled` returns true, `Handle` calls `onHandle`, `WithAttrs`/`WithGroup` return self.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run TestSetupWithBridge ./internal/logging/`
+Expected: FAIL — `undefined: SetupWithBridge`.
+
+- [ ] **Step 3: Implement SetupWithBridge and refactor Setup to call it**
+
+Replace the body of `Setup` (`handler.go:70-91`) so the existing function delegates, and add the bridge-aware variant:
+
+```go
+// Setup creates a stderr-only logger (unchanged public behaviour).
+func Setup(service, version, format string, w io.Writer, level slog.Level) *slog.Logger {
+	return SetupWithBridge(service, version, format, w, level, nil, level)
+}
+
+// SetupWithBridge creates a logger that tees stderr (gated at stderrLevel)
+// and, when bridge != nil, an OTel bridge handler (gated at bridgeLevel).
+// When bridge is nil the result is the stderr-only logger (INV-L7).
+func SetupWithBridge(
+	service, version, format string, w io.Writer, stderrLevel slog.Level,
+	bridge slog.Handler, bridgeLevel slog.Level,
+) *slog.Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	var base slog.Handler
+	opts := &slog.HandlerOptions{Level: stderrLevel}
+	if format == "text" {
+		base = slog.NewTextHandler(w, opts)
+	} else {
+		base = slog.NewJSONHandler(w, opts)
+	}
+	stderrHandler := &traceHandler{handler: base, service: service, version: version}
+
+	if bridge == nil {
+		return slog.New(stderrHandler)
+	}
+	gatedBridge := NewLevelGate(bridgeLevel, bridge)
+	return slog.New(NewFanout(stderrHandler, gatedBridge))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `task test -- ./internal/logging/`
+Expected: PASS (existing `handler_test.go` tests still green — `Setup` behaviour unchanged).
+
+- [ ] **Step 5: Commit**
+
+`feat(logging): SetupWithBridge to tee stderr + OTel bridge`.
+
+---
+
+## Phase 4: Logging config
+
+### Task 6: `LoggingConfig` koanf struct
+
+**Files:**
+
+- Modify: `internal/config/config.go`
+- Test: `internal/config/logging_config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestLoggingConfig_Defaults(t *testing.T) {
+	c := DefaultLoggingConfig()
+	require.True(t, c.Stderr.Enabled)
+	require.True(t, c.OTel.Enabled)
+	require.True(t, c.Sentry.Enabled)
+}
+
+func TestLoggingSink_EffectiveLevel(t *testing.T) {
+	global := slog.LevelInfo
+	require.Equal(t, slog.LevelWarn, LoggingSink{Level: "warn"}.EffectiveLevel(global))
+	require.Equal(t, global, LoggingSink{}.EffectiveLevel(global)) // unset → global
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run 'TestLoggingConfig|TestLoggingSink' ./internal/config/`
+Expected: FAIL — `undefined: DefaultLoggingConfig`.
+
+- [ ] **Step 3: Implement the struct**
+
+Add to `internal/config/config.go`:
+
+```go
+// LoggingSink configures one log destination. Level is a slog level name
+// ("debug"|"info"|"warn"|"error"); empty inherits the global level.
+type LoggingSink struct {
+	Enabled bool   `koanf:"enabled"`
+	Level   string `koanf:"level"`
+}
+
+// EffectiveLevel returns the sink's level, falling back to global when the
+// per-sink level is unset or unparseable (spec INV-L4).
+func (s LoggingSink) EffectiveLevel(global slog.Level) slog.Level {
+	if s.Level == "" {
+		return global
+	}
+	var l slog.Level
+	if err := l.UnmarshalText([]byte(s.Level)); err != nil {
+		return global
+	}
+	return l
+}
+
+// LoggingConfig configures the three log sinks. Endpoints/secrets remain
+// env-driven (SENTRY_DSN, OTEL_EXPORTER_OTLP_ENDPOINT); these toggles gate
+// behaviour. Effective enablement of a non-stderr sink = Enabled AND its
+// endpoint present (spec INV-L3), enforced at telemetry.Init.
+type LoggingConfig struct {
+	Stderr LoggingSink `koanf:"stderr"`
+	OTel   LoggingSink `koanf:"otel"`
+	Sentry LoggingSink `koanf:"sentry"`
+}
+
+// DefaultLoggingConfig enables all three sinks with global-inherited levels.
+func DefaultLoggingConfig() LoggingConfig {
+	return LoggingConfig{
+		Stderr: LoggingSink{Enabled: true},
+		OTel:   LoggingSink{Enabled: true},
+		Sentry: LoggingSink{Enabled: true},
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `task test -- -run 'TestLoggingConfig|TestLoggingSink' ./internal/config/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`feat(config): LoggingConfig with per-sink toggles and levels`.
+
+---
+
+## Phase 5: telemetry.Init wiring + CLI
+
+### Task 7: Build the LoggerProvider in `telemetry.Init`
+
+**Files:**
+
+- Modify: `internal/telemetry/provider.go`
+- Test: `internal/telemetry/provider_log_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Use `package telemetry_test` (external) to match the existing
+`provider_test.go`, and write the test against the **target** 5-arg
+signature so no rewrite is needed after Step 3:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package telemetry_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/config"
+	"github.com/holomush/holomush/internal/telemetry"
+)
+
+func TestINV_L7_NoLogSinks_NilHandler(t *testing.T) {
+	// No OTEL endpoint, no SENTRY_DSN, default config → LogHandler nil (INV-L7).
+	res, err := telemetry.Init(context.Background(), "svc", "v1",
+		config.DefaultLoggingConfig(), slog.LevelInfo)
+	require.NoError(t, err)
+	require.Nil(t, res.LogHandler)
+	require.NoError(t, res.Shutdown(context.Background()))
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run TestINV_L7 ./internal/telemetry/`
+Expected: FAIL to compile — current `Init` is 3-arg and returns
+`(func(context.Context) error, error)`, not `(Result, error)`. This is the
+expected red state; Step 3 makes it pass.
+
+- [ ] **Step 3: Change the signature to return `Result` and build the LoggerProvider**
+
+Add the `Result` type and a `buildLogProcessors` helper, and rewrite `Init`'s tail. Key changes to `provider.go`:
+
+```go
+// Result carries the shutdown closure and the optional OTel log bridge
+// handler back to the caller (spec §7). LogHandler is nil when no OTel log
+// sink is enabled, in which case the caller keeps the stderr-only logger.
+type Result struct {
+	Shutdown   func(context.Context) error
+	LogHandler slog.Handler
+}
+
+// buildLogProcessors returns the gated processors for the enabled OTel log
+// sinks. Returns nil when none are enabled. global is the global slog level
+// floor used to translate per-sink levels.
+func buildLogProcessors(
+	ctx context.Context, cfg config.LoggingConfig, global slog.Level,
+	endpoint, sentryDSN string, sentryEnabled bool,
+) []sdklog.Processor {
+	var procs []sdklog.Processor
+	if endpoint != "" && cfg.OTel.Enabled {
+		if exp, err := newCollectorLogExporter(ctx); err != nil {
+			errutil.LogError(slog.Default(), "collector log exporter init failed; skipping", err)
+		} else {
+			procs = append(procs, newLevelFilter(
+				sdklog.NewBatchProcessor(exp), slogToOTel(cfg.OTel.EffectiveLevel(global))))
+		}
+	}
+	if sentryEnabled && cfg.Sentry.Enabled {
+		if exp, err := newSentryLogExporter(ctx, sentryDSN); err != nil {
+			errutil.LogError(slog.Default(), "sentry log exporter init failed; skipping", err)
+		} else {
+			procs = append(procs, newLevelFilter(
+				sdklog.NewBatchProcessor(exp), slogToOTel(cfg.Sentry.EffectiveLevel(global))))
+		}
+	}
+	return procs
+}
+```
+
+Then, after the `TracerProvider` is built and before `return`, construct the `LoggerProvider` from those processors, register it globally via `global.SetLoggerProvider(lp)` (`go.opentelemetry.io/otel/log/global`), build the bridge handler with `otelslog.NewHandler(serviceName, otelslog.WithLoggerProvider(lp))`, and return it on `Result.LogHandler`. Update the shutdown closure to the spec §8 order: `lp.Shutdown` → `tp.Shutdown` → `sentry.Flush`. Update the no-op fast-path (`provider.go:54`) and the doc-comment (`provider.go:33-47`, including the stale "Flush Sentry's own buffers … first" line) to describe `Result`.
+
+`Init` must also accept the `config.LoggingConfig` and global level — change the signature to `Init(ctx, serviceName, serviceVersion string, logCfg config.LoggingConfig, global slog.Level) (Result, error)`. Add a `slogToOTel(slog.Level) otellog.Severity` helper (Debug→SeverityDebug, Info→SeverityInfo, Warn→SeverityWarn, Error→SeverityError).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `task test -- ./internal/telemetry/`
+Expected: PASS. As part of Step 3, also update the **existing**
+`provider_test.go` `Init` call sites (`:20,:28`) to the 5-arg form
+(`config.DefaultLoggingConfig(), slog.LevelInfo`) and switch their result
+handling from the old `shutdown, err :=` to `res, err :=` /
+`res.Shutdown(...)`.
+
+- [ ] **Step 5: Commit**
+
+`feat(telemetry): build LoggerProvider with gated log sinks; Init returns Result`.
+
+### Task 8: Two-phase init + CLI flags in core/gateway
+
+**Files:**
+
+- Modify: `cmd/holomush/core.go:144-201`, `cmd/holomush/gateway.go:155-187`
+- Test: `cmd/holomush/core_test.go`
+
+- [ ] **Step 1: Write the failing test (flag presence)**
+
+```go
+func TestCoreCommand_LogSinkFlags(t *testing.T) {
+	cmd := NewCoreCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--help"})
+	require.NoError(t, cmd.Execute())
+	for _, f := range []string{"--log-sentry", "--log-sentry-level", "--log-otel", "--log-otel-level", "--log-stderr-level"} {
+		require.Contains(t, buf.String(), f)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `task test -- -run TestCoreCommand_LogSinkFlags ./cmd/holomush/`
+Expected: FAIL — flags absent from help.
+
+- [ ] **Step 3: Register flags, load the `logging` config section, and re-seat the logger**
+
+In `NewCoreCmd` flag registration (`core.go:144-157`) add:
+
+```go
+cmd.Flags().Bool("log-stderr", true, "enable stderr log sink")
+cmd.Flags().String("log-stderr-level", "", "stderr log level override (default: global)")
+cmd.Flags().Bool("log-otel", true, "enable OTLP-collector log sink")
+cmd.Flags().String("log-otel-level", "", "collector log level override (default: global)")
+cmd.Flags().Bool("log-sentry", true, "enable Sentry log sink")
+cmd.Flags().String("log-sentry-level", "", "Sentry log level override (default: global)")
+```
+
+In the RunE config-load block (`core.go:120-140`), add `var logConfig = config.DefaultLoggingConfig()` and `config.Load(configFile, cmd, &logConfig, "logging")`, then pass `logConfig` to `runCoreWithDeps` at the call site (`core.go:140`). This requires:
+
+- Adding a `logConfig config.LoggingConfig` parameter to the `runCoreWithDeps` signature (`core.go:167`) — append it after the existing config params.
+- Updating the `runCoreWithDeps(...)` call in `RunE` (`core.go:140`) to pass `logConfig`.
+- Updating any test that calls `runCoreWithDeps` directly to pass `config.DefaultLoggingConfig()`.
+
+In `runCoreWithDeps` replace the `core.go:184-201` block with the two-phase sequence:
+
+```go
+// --- 1. Logging (phase 1: stderr-only) + telemetry ---
+level, err := resolveLogLevel(cmd)
+if err != nil {
+	return err
+}
+stderrLevel := logConfig.Stderr.EffectiveLevel(level)
+logging.SetDefaultWithBridge("holomush-core", version, cfg.LogFormat, stderrLevel, nil, level)
+
+res, telErr := telemetry.Init(ctx, "holomush-core", version, logConfig, level)
+if telErr != nil {
+	return oops.Code("TELEMETRY_INIT_FAILED").Wrap(telErr)
+}
+// Phase 2: re-seat the default logger with the OTel bridge when present.
+if res.LogHandler != nil && logConfig.Stderr.Enabled {
+	logging.SetDefaultWithBridge("holomush-core", version, cfg.LogFormat, stderrLevel, res.LogHandler, level)
+}
+defer func() {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if shutdownErr := res.Shutdown(shutdownCtx); shutdownErr != nil {
+		slog.Warn("telemetry shutdown error", "error", shutdownErr)
+	}
+}()
+```
+
+Add `logging.SetDefaultWithBridge` to `internal/logging/handler.go` mirroring `SetDefault` but delegating to `SetupWithBridge`. Apply the identical change to `gateway.go:171-187` with `"holomush-gateway"`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `task test -- ./cmd/holomush/ ./internal/logging/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`feat(cmd): two-phase logger init + per-sink log flags`.
+
+---
+
+## Phase 6: Collector pipeline, invariants, docs
+
+### Task 9: Add a logs pipeline to the dev collector
+
+**Files:**
+
+- Modify: `docker/otel-collector/config.yaml`
+
+- [ ] **Step 1: Add a logs-capable exporter and pipeline**
+
+The dev collector (`docker/otel-collector/config.yaml`) currently has only
+`otlp/jaeger` (traces-only — Jaeger does not ingest logs) and a single
+`traces` pipeline. Add a `debug` exporter (logs render to the collector's
+own stdout, visible via `docker logs` / Dozzle) and a `logs` pipeline.
+Under `exporters:` add:
+
+```yaml
+  debug:
+    verbosity: detailed
+```
+
+Under `service.pipelines:` add, beside the existing `traces` block:
+
+```yaml
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+```
+
+(Dev only — a production deployment routes logs to a real backend; the
+production collector config in the operator-deployment plan already
+defines a `logs` pipeline.)
+
+- [ ] **Step 2: Validate the collector config**
+
+Run: `docker compose --profile obs config` (or the project's compose-validate task) and confirm no schema error.
+Expected: config parses; collector starts and logs "Everything is ready".
+
+- [ ] **Step 3: Commit**
+
+`feat(obs): accept OTLP logs in the dev collector`.
+
+### Task 10: Invariant guard + meta-test
+
+**Files:**
+
+- Test: `internal/logging/import_guard_test.go`
+- Test: `internal/telemetry/invariants_test.go`
+
+- [ ] **Step 1: Write INV-L1 import-guard test**
+
+```go
+// In internal/logging/import_guard_test.go — INV-L1: logging never imports sentry-go.
+func TestINV_L1_NoSentryImport(t *testing.T) {
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedImports | packages.NeedDeps},
+		"github.com/holomush/holomush/internal/logging")
+	require.NoError(t, err)
+	for _, p := range pkgs {
+		for imp := range p.Imports {
+			require.NotContains(t, imp, "getsentry/sentry-go",
+				"internal/logging must not import sentry-go (INV-L1)")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Write the meta-test enumerating invariants**
+
+```go
+// internal/telemetry/invariants_test.go — INV-META: every INV-L* is referenced by a test.
+func TestINV_Meta_AllInvariantsReferenced(t *testing.T) {
+	want := []string{"INV_L1", "INV_L2", "INV_L3", "INV_L4", "INV_L5", "INV_L6", "INV_L7", "INV_L8"}
+	// grep the test sources under internal/logging + internal/telemetry for each ID;
+	// fail if any ID has zero references. (Use os.ReadDir + os.ReadFile + strings.Contains.)
+	for _, id := range want {
+		require.True(t, invariantReferenced(id), "no test references %s", id)
+	}
+}
+```
+
+(Implement `invariantReferenced` to walk `*_test.go` in both packages and match the ID; map remaining INV-L2/L3/L5/L6/L8 onto the tests written in Tasks 3–8, renaming test funcs to embed the IDs, e.g. `TestINV_L4_PerSinkLevel`.)
+
+- [ ] **Step 3: Run the invariant tests**
+
+Run: `task test -- -run 'TestINV' ./internal/logging/ ./internal/telemetry/`
+Expected: PASS. Add `golang.org/x/tools/go/packages` to go.mod if not present (it is, indirectly).
+
+- [ ] **Step 4: Commit**
+
+`test(telemetry): INV-L1 import guard + invariant meta-test`.
+
+### Task 11: Operator docs
+
+**Files:**
+
+- Modify: `site/docs/operating/sentry.md:126-134,175-183`
+
+- [ ] **Step 1: Rewrite the "Application logs" row and follow-ups**
+
+Replace the "Application logs" row (`sentry.md:132`) so it reads that Go logs flow OTel-natively via the `LoggerProvider` → `otlploghttp` to Sentry's OTLP logs endpoint (no `sentry.Logger` calls), gated by `logging.sentry.enabled`. Add a short "Application logs (OTel-native)" subsection documenting the three sinks, the `logging.*` config keys + CLI flags from Task 8, and that ERROR logs appear in Sentry **Logs** (grouped Issues remain a separate follow-up). Update the "Open follow-ups" list (`sentry.md:175-183`): the slog-bridge follow-up is now **done**; the `CaptureException`→Issues item moves behind a `pkg/errutil` wrapper.
+
+- [ ] **Step 2: Verify docs lint**
+
+Run: `task fmt && task lint:docs-symmetry`
+Expected: no diff after fmt; symmetry check passes.
+
+- [ ] **Step 3: Commit**
+
+`docs(operating): OTel-native application-log surfacing`.
+
+---
+
+## Verification (whole-plan)
+
+- [ ] `task test` — all unit tests green.
+- [ ] `task lint` — clean (line-scoped `//nolint:wrapcheck` only on the handler pass-throughs shown above).
+- [ ] `task test:int` — integration build compiles (shared-type refactor safety).
+- [ ] `task pr-prep` — full lane green before any push.
+- [ ] Manual smoke: run `holomush core` with a real `SENTRY_DSN` + `OTEL_EXPORTER_OTLP_ENDPOINT`, emit a `slog.WarnContext` inside a span, and confirm the log line appears in Sentry Logs correlated to the trace, and in the collector pipeline.
+
+## Carried review findings (from spec round-1/2)
+
+- Update the `telemetry.Init` doc-comment block (`provider.go:33-47`) when the signature changes — covered in Task 7 Step 3.
+- `FanoutHandler` single-child transparency is implemented (Task 4), not just advisory.
+<!-- adr-capture: sha256=31a7856e8ec29609 adrs=holomush-ci829,holomush-stow5,holomush-1wbzn -->

--- a/docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md
+++ b/docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md
@@ -1,0 +1,294 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# OTel-Native Application-Log Surfacing — Design
+
+**Design bead:** `holomush-zgtqo`
+**Status:** Draft (pending design-reviewer)
+**Date:** 2026-05-23
+
+## 1. Scope
+
+### Goals
+
+- Surface HoloMUSH's `log/slog` application logs into the OpenTelemetry
+  log pipeline so they reach **Sentry** (Logs product) and the existing
+  **OTel collector** (→ Grafana / Loki), with trace correlation.
+- Mirror the trace dual-export pattern already shipped (`holomush-0wun`):
+  one provider, multiple gated exporters, Sentry as a swappable OTLP
+  consumer.
+- Keep application code **vendor-neutral**: app code binds to
+  OpenTelemetry only. Sentry remains a config-only OTLP consumer — no
+  `sentryslog` / `sentry.NewLogger` in app or logging code.
+- Three independently toggleable log sinks (stderr, collector, Sentry),
+  each with an optional per-sink severity floor.
+
+### Non-Goals (out of scope)
+
+- **Error events as Sentry Issues** (grouped, alertable, stacktraces).
+  That requires `sentry.CaptureException` and is deferred to a separate
+  bead, to be implemented behind a `pkg/errutil` wrapper so the Sentry
+  SDK touchpoint stays in exactly one package. ERROR-level records still
+  appear in the Sentry **Logs** stream via this work; they just do not
+  become grouped Issues.
+- **Metrics** — Sentry does not ingest OTLP metrics; no OTel metrics
+  pipeline exists today.
+- **Browser-side OTLP logs** — already covered by the browser SDK's
+  `consoleLoggingIntegration` (`web/src/lib/sentry.ts`).
+- **The bare→`*Context` log-call migration** — codified as a MUST in
+  `CLAUDE.md` / `.claude/rules/logging.md` and enforced mechanically by
+  `sloglint` under bead `holomush-xrdjw`.
+
+## 2. Background — current state (grounded)
+
+- Logging: `internal/logging/handler.go` — `Setup`/`SetDefault` build a
+  `slog.Logger` wrapping a JSON/text base handler in a `traceHandler`
+  that injects `service`, `version`, and (when on the ctx) `trace_id` /
+  `span_id` (`handler.go:24-65,70-91`). Logs go **only to stderr** today;
+  no OTel `LoggerProvider` exists.
+- Telemetry: `internal/telemetry/provider.go::Init` builds a
+  `TracerProvider`, conditionally appends an OTLP-gRPC collector batcher
+  (`provider.go:85-91`) and, when `SENTRY_DSN` is set, a Sentry OTLP-HTTP
+  trace batcher (`provider.go:99-108`), then registers globals and
+  returns a shutdown closure (`provider.go:125-132`).
+- Sentry: `internal/telemetry/sentry.go::initSentry` calls `sentry.Init`
+  with `EnableLogs: true` (`sentry.go:74-82`) — but **nothing emits Sentry
+  logs**; `EnableLogs` is a dormant kill-switch. It builds the trace
+  exporter via `sentryotlp.NewTraceExporter` (`sentry.go:111-113`), with
+  an `OTEL_EXPORTER_OTLP_ENDPOINT` unset-during-construction guard to keep
+  the Sentry POSTs on HTTPS (`sentry.go:86-106`).
+- Config: observability secrets/endpoints are env-only (`SENTRY_DSN`,
+  `OTEL_EXPORTER_OTLP_ENDPOINT`, `SENTRY_*`); there is **no** `SentryConfig`
+  struct. Log *format* is a per-subcommand koanf field + CLI flag
+  (`cmd/holomush/core.go:70,149`); log *level* is parsed in
+  `cmd/holomush/root.go` from `LOG_LEVEL` / `--log-level`.
+- Collector config is in-repo: `docker/otel-collector/config.yaml` (dev,
+  traces-only today); the production collector plan already defines a
+  `logs` pipeline.
+- External facts: Sentry ingests OTLP **traces + logs** (not metrics).
+  Logs endpoint: `https://<host>/api/<project>/integration/otlp/v1/logs`,
+  auth header `x-sentry-auth: sentry sentry_key=<public-key>`. sentry-go
+  (`v0.46.2`) ships **no** OTLP log exporter — only `NewTraceExporter` —
+  so logs use the generic `otlploghttp`/`otlploggrpc` exporters.
+
+## 3. Architecture
+
+One `LoggerProvider` fed by a `log/slog`→OTel bridge, fanned out beside
+the existing stderr handler. The collector/Sentry split happens inside
+the provider via per-sink level-filtering processors:
+
+```text
+slog.Default()
+  └─ FanoutHandler                          (Enabled = OR of children)
+       ├─ traceHandler → JSON/text → stderr           [level: stderr]
+       └─ otelslog.Handler → LoggerProvider           [floor: min(enabled OTel sinks)]
+                               ├─ LevelFilter(collector) → BatchProcessor → otlploggrpc → collector → Loki/Grafana
+                               └─ LevelFilter(sentry)    → BatchProcessor → otlploghttp → …/integration/otlp/v1/logs
+```
+
+Rationale for **one** `LoggerProvider` + `LevelFilter` (vs. one provider
+per sink): maximal symmetry with the `TracerProvider`-with-two-batchers
+shape, and a single bridge pass (the slog→OTel conversion runs once).
+Per-sink levels — the one thing a single provider can't do natively — are
+delivered by a ~20-line `sdklog.Processor` that drops records below a
+threshold before its exporter's batch processor.
+
+## 4. Components & files
+
+| Action | Path | Responsibility |
+| ------ | ---- | -------------- |
+| Modify | `internal/telemetry/provider.go` | Build `LoggerProvider` with collector + Sentry log processors (gated like the trace batchers); return it + an `otelslog`-backed `slog.Handler`; add `lp.Shutdown` to the shutdown chain |
+| New | `internal/telemetry/logexport.go` | Construct `otlploggrpc` (collector) and `otlploghttp` (Sentry) log exporters; derive the Sentry logs URL + `x-sentry-auth` header from the DSN; reuse the insecure-scheme unset guard |
+| New | `internal/telemetry/logfilter.go` | `LevelFilter` — an `sdklog.Processor` that forwards only records ≥ a configured `log.Severity` |
+| Modify | `internal/logging/handler.go` | Add `FanoutHandler` + `LevelGate`; extend `Setup` to accept an optional OTel bridge handler and per-sink levels; keep `traceHandler` as the stderr path |
+| Modify | `cmd/holomush/core.go`, `cmd/holomush/gateway.go` | Two-phase init (§7); add `logging` koanf section + CLI flags (§6) |
+| New | `internal/config/config.go` | `LoggingConfig` koanf struct for the per-sink toggles + levels, alongside the existing `GameConfig` / `AuthConfig` / `CryptoConfig` |
+| Modify | `docker/otel-collector/config.yaml` | Add a `logs` pipeline (`receivers: [otlp]`, `exporters: [...]`) |
+| Modify | `site/docs/operating/sentry.md` | Replace the "call `sentry.Logger.Info`" guidance with the OTel-native story; update the "Application logs" row |
+| Modify | `go.mod` | Add `go.opentelemetry.io/otel/log`, `otel/sdk/log`, `exporters/otlp/otlplog/otlploghttp`, `exporters/otlp/otlplog/otlploggrpc`, `contrib/bridges/otelslog` |
+
+(Already drafted in this branch, companion deliverables: `CLAUDE.md`
+"Structured Logging" convention + `.claude/rules/logging.md`.)
+
+## 5. Configuration
+
+Two surfaces, by nature of the value:
+
+**env (secrets / SDK integration / endpoints) — unchanged:**
+
+| Var | Role |
+| --- | ---- |
+| `SENTRY_DSN` | Enables the Sentry sink (logs endpoint + auth derived from it) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables the collector sink (shared with traces) |
+| `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` | Resource tags (existing) |
+
+**koanf config + CLI flags (logging behavior) — new, `logging` section:**
+
+| Key (`koanf`) | CLI flag | Default | Meaning |
+| ------------- | -------- | ------- | ------- |
+| `logging.stderr.enabled` | `--log-stderr` | `true` | Toggle stderr sink |
+| `logging.stderr.level` | `--log-stderr-level` | global | Per-sink floor |
+| `logging.otel.enabled` | `--log-otel` | `true` | Toggle collector sink |
+| `logging.otel.level` | `--log-otel-level` | global | Per-sink floor |
+| `logging.sentry.enabled` | `--log-sentry` | `true` | Toggle Sentry sink |
+| `logging.sentry.level` | `--log-sentry-level` | global | Per-sink floor |
+
+- **Effective enablement** of a sink = `config.enabled` **AND** its
+  endpoint is present (stderr has no endpoint, so it depends only on the
+  toggle). This lets an operator with `SENTRY_DSN` set send traces to
+  Sentry while keeping `logging.sentry.enabled: false`.
+- **Level precedence** per sink: explicit per-sink level > global
+  `LOG_LEVEL` / `--log-level`. Per-sink level defaults to the global
+  level when unset.
+- Flag/config/env precedence follows the existing `config.Load` order
+  (CLI flag > config file > built-in default), matching `log_format`.
+
+## 6. Sentry logs-endpoint derivation
+
+Parse the DSN to build the logs URL and auth header. The DSN
+(`https://<public-key>@<host>/<project-id>`) yields:
+
+- URL: `https://<host>/api/<project-id>/integration/otlp/v1/logs`
+- Header: `x-sentry-auth: sentry sentry_key=<public-key>`
+
+DSN parsing MAY reuse the already-imported `sentry.Dsn` type **within
+`internal/telemetry` only** (that package already depends on sentry-go for
+traces). `internal/logging` MUST remain free of any sentry-go import. The
+`otlploghttp` exporter MUST be constructed under the same
+`OTEL_EXPORTER_OTLP_ENDPOINT` unset guard used for the trace exporter
+(`sentry.go:86-106`) to avoid the insecure-scheme transport switch.
+
+## 7. Init sequencing (two-phase)
+
+Today `logging.SetDefault` runs before `telemetry.Init` so Init can log.
+The bridge now originates *from* `telemetry.Init`, creating a cycle.
+Resolution:
+
+1. **Phase 1:** `logging.Setup` builds a stderr-only logger; set as
+   default so `telemetry.Init` can log during startup.
+2. **Phase 2:** `telemetry.Init` builds the providers including the
+   `LoggerProvider`, and returns the `otelslog` bridge handler.
+3. Re-seat the default logger via `logging.Setup` with the bridge
+   attached and per-sink levels applied.
+
+Init's own startup log lines land on stderr regardless, so nothing is
+lost in the brief pre-bridge window.
+
+### `telemetry.Init` return contract
+
+The current signature is
+`Init(ctx, serviceName, serviceVersion) (func(context.Context) error, error)`
+(`internal/telemetry/provider.go:48`). To carry the bridge to the caller
+without a positional-return sprawl, `Init` MUST return a small result
+struct:
+
+```go
+type Result struct {
+    // Shutdown flushes and stops all providers (logs, traces, Sentry).
+    Shutdown func(context.Context) error
+    // LogHandler is the otelslog-backed slog.Handler for the OTel log
+    // pipeline. It is nil when no OTel log sink is enabled (INV-L7), in
+    // which case the caller keeps the stderr-only logger from Phase 1.
+    LogHandler slog.Handler
+}
+
+// Init also gains logCfg + global so it can build the gated log sinks and
+// translate per-sink levels (§5). The collector/Sentry endpoints stay
+// env-driven; logCfg only carries the toggles + per-sink level overrides.
+func Init(
+    ctx context.Context, serviceName, serviceVersion string,
+    logCfg config.LoggingConfig, global slog.Level,
+) (Result, error)
+```
+
+Callers MUST update accordingly: `cmd/holomush/core.go:191`,
+`cmd/holomush/gateway.go:177`, and `internal/telemetry/provider_test.go`
+(`:20,:28`). When `Result.LogHandler != nil`, the caller re-seats the
+default logger (Phase 3) by composing it with the stderr handler via
+`FanoutHandler`; when nil, no re-seat occurs.
+
+## 8. Error handling & shutdown
+
+- Log-exporter construction failure MUST NOT abort startup: log a warning
+  and continue without that sink — the exact pattern at
+  `provider.go:99-108` ("sentry init failed; continuing without Sentry").
+- Shutdown order MUST be: `lp.Shutdown` (drains log batches incl. the
+  Sentry OTLP-logs batch) → `tp.Shutdown` (spans) → `sentry.Flush` (SDK
+  error buffers). This **changes** the current order
+  (`provider.go:125-132` does `sentry.Flush` first): log batches must be
+  flushed over their own HTTP/gRPC transports before those transports are
+  torn down, and `sentry.Flush` now drains only the SDK's error buffers
+  (logs no longer route through it). The existing "Flush Sentry's own
+  buffers … first" comment MUST be updated, not preserved.
+- When all OTel sinks are disabled, no `LoggerProvider` is created and no
+  bridge is attached — behavior is identical to today (stderr only), zero
+  added overhead.
+
+## 9. Trace correlation & the context-logging rule
+
+Trace context flows into OTel logs only from `slog.*Context` calls (the
+bridge reads `trace_id`/`span_id` from the ctx). Bare `slog.Info(…)`
+produce uncorrelated log lines. This is codified as a MUST in `CLAUDE.md`
+("Structured Logging") and `.claude/rules/logging.md`, with mechanical
+`sloglint` (`context: scope`) enforcement tracked under `holomush-xrdjw`.
+
+## 10. PII consideration (follow-up, not in scope)
+
+Application logs can contain player data. OTel-native redaction is a
+`sdklog.Processor` that scrubs attributes before export. Flagged as a
+follow-up; this design does not add redaction, and operators SHOULD set
+conservative per-sink levels for the Sentry sink until it exists.
+
+## 11. Testing strategy
+
+- Unit (`internal/telemetry`): DSN→logs-endpoint derivation; `LevelFilter`
+  forwards ≥ threshold and drops below; exporter-construction-failure path
+  warns and continues; no-op when sinks disabled. Mirror
+  `sentry_test.go`.
+- Unit (`internal/logging`): `FanoutHandler.Enabled` is the OR of
+  children; records reach both stderr and the bridge; `LevelGate` filters.
+  When the OTel bridge child is `nil` (all OTel sinks disabled, INV-L7),
+  `FanoutHandler` MUST degenerate to the stderr handler — `Enabled`
+  delegates to the base handler, `Handle` writes only to stderr, and no
+  panic occurs (the caller SHOULD simply not wrap in a `FanoutHandler`
+  when there is a single child).
+- Pipeline assertion: use `go.opentelemetry.io/otel/sdk/log/logtest` (or
+  an in-memory exporter) to assert records emitted at the correct
+  severities reach the provider.
+- `task pr-prep` (full lane) green before push.
+
+## 12. Invariants (RFC2119)
+
+| # | Invariant | Test |
+| - | --------- | ---- |
+| INV-L1 | App code and `internal/logging` MUST NOT import sentry-go; the only sentry-go importer for logs is `internal/telemetry`, and only for DSN parsing + exporter wiring | Static: grep/`forbidigo`-style guard in test |
+| INV-L2 | Each sink MUST be independently enable/disable-able; disabling one MUST NOT affect the others | Unit (toggle matrix) |
+| INV-L3 | A sink's effective enablement MUST be `config.enabled AND endpoint-present` | Unit |
+| INV-L4 | Per-sink level MUST override the global level for that sink only; unset per-sink level MUST inherit the global level | Unit |
+| INV-L5 | Exporter construction failure MUST NOT abort process startup | Unit |
+| INV-L6 | Shutdown MUST flush log batches before process exit (`lp.Shutdown` precedes return) | Unit |
+| INV-L7 | With all OTel sinks disabled, no `LoggerProvider` is constructed (stderr-only parity with pre-change behavior) | Unit |
+| INV-L8 | The Sentry logs `otlploghttp` exporter MUST target an `https://` endpoint regardless of `OTEL_EXPORTER_OTLP_ENDPOINT` scheme | Unit |
+| INV-META | Every INV-L* above MUST have at least one referencing test | Meta-test enumerating invariant IDs |
+
+## 13. Dependencies
+
+- go.mod additions (§4). These are official OpenTelemetry modules but,
+  unlike the `v1.43.0` trace/metric modules already in `go.mod`, the log
+  SDK (`otel/sdk/log`), both OTLP log exporters, and the `otelslog`
+  bridge are still **experimental `v0.x`** (no API-stability guarantee;
+  minor versions may break). Accepting them is a deliberate trade-off —
+  there is no `v1` log path yet. The plan MUST pin exact versions and
+  treat OTel log-module bumps as review-gated.
+- `docker/otel-collector/config.yaml` gains a `logs` pipeline so the
+  collector accepts OTLP logs in the dev stack.
+- Production collector config (deploy guide) already has a `logs`
+  pipeline — verify it routes to the intended backend.
+
+## 14. Documentation deliverables (PR-blocking)
+
+- `site/docs/operating/sentry.md` — rewrite the "Application logs" row and
+  add an OTel-native logs section (sinks, toggles, levels, endpoint).
+- `CLAUDE.md` "Structured Logging" + `.claude/rules/logging.md` — already
+  drafted in this branch.
+<!-- adr-capture: sha256=137bf3efec54e21b adrs=holomush-ci829,holomush-stow5,holomush-1wbzn -->


### PR DESCRIPTION
## Summary

Design + planning artifacts (no production code) for **surfacing `log/slog` application logs into the OpenTelemetry log pipeline** — reaching Sentry (Logs) and the OTel collector (→ Loki/Grafana) with trace correlation — mirroring the shipped trace dual-export (`holomush-0wun`). App code binds to OpenTelemetry only; Sentry stays a **config-only OTLP consumer** (INV-L1).

This is the **docs-first PR** of the workflow: spec + plan + ADRs land on `main` so implementation subagents read canonical context from there.

## Contents

- **Spec** — `docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md` (passed `design-reviewer`, 2 rounds; 8 numbered invariants + meta-test)
- **Plan** — `docs/superpowers/plans/2026-05-23-otel-native-log-surfacing.md` (11 TDD tasks; passed `plan-reviewer`, 2 rounds)
- **ADRs** —
  - `holomush-ci829` — bind logs to OTel, not the Sentry SDK (INV-L1 import boundary)
  - `holomush-stow5` — single `LoggerProvider` + per-sink `LevelFilter`
  - `holomush-1wbzn` — confine `CaptureException` to a future `pkg/errutil` wrapper
- **Convention** — `CLAUDE.md` "Structured Logging" + `.claude/rules/logging.md`: **MUST** use context-carrying slog variants (`*Context`) whenever a `ctx` is in scope; `sloglint` enforcement tracked in `holomush-xrdjw`.

## Tracking

- Epic: **`holomush-zgtqo`** — "OTel-native application-log surfacing" (11 children materialized, dependency graph wired)
- Follow-ups: `holomush-xrdjw` (sloglint migration), `holomush-1wbzn` (CaptureException→Issues)

## Verification

- `task pr-prep:docs` — green (markdown lint, fmt, license, docs-symmetry, docs-paths-sync)
- `scripts/adr-doctor.sh` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
