### PR TITLE
test(gfo6): deterministic ns fixture + load-bearing JoinedAt round-trip (gfo6.12.{1,2,3})

### DIFF
--- a/cmd/holomush/crypto_operator_validation_test.go
+++ b/cmd/holomush/crypto_operator_validation_test.go
@@ -44,10 +44,13 @@ func seedPlayer(t *testing.T, ctx context.Context, pool *pgxpool.Pool) string {
 	// Username uses the full ULID for uniqueness — ULIDs created in the
 	// same millisecond share their timestamp prefix, so a short prefix
 	// is not collision-safe.
+	// INV-TS-1: players.created_at is BIGINT-ns; deterministic fixture so the
+	// seed value survives the round-trip unambiguously and the test is reproducible.
+	createdAt := time.Date(2026, 5, 22, 12, 0, 0, 123456789, time.UTC).UnixNano()
 	_, err := pool.Exec(ctx,
 		`INSERT INTO players (id, username, password_hash, created_at, updated_at)
 		 VALUES ($1, $2, $3, $4, $4)`,
-		id, "test_player_"+id, "hash", time.Now().UTC().UnixNano())
+		id, "test_player_"+id, "hash", createdAt)
 	require.NoError(t, err)
 	return id
 }

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -249,9 +249,14 @@ var _ = Describe("Manager", func() {
 		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 		Expect(err).NotTo(HaveOccurred())
 
+		// INV-TS-1: deterministic ns-precision fixture so the JoinedAt round-trip
+		// assertion below is load-bearing — sub-microsecond bits are preserved
+		// through pgnanos.Time scan/insert paths.
+		joinedAt1 := time.Date(2026, 5, 22, 12, 0, 0, 123456789, time.UTC)
+		joinedAt2 := time.Date(2026, 5, 22, 12, 0, 0, 987654321, time.UTC)
 		initial := []dek.Participant{
-			{PlayerID: "01ABC", CharacterID: "01XYZ", BindingID: "01DEF", JoinedAt: time.Now().UTC()},
-			{PlayerID: "01GHI", CharacterID: "01JKL", BindingID: "01MNO", JoinedAt: time.Now().UTC()},
+			{PlayerID: "01ABC", CharacterID: "01XYZ", BindingID: "01DEF", JoinedAt: joinedAt1},
+			{PlayerID: "01GHI", CharacterID: "01JKL", BindingID: "01MNO", JoinedAt: joinedAt2},
 		}
 		key, err := mgr.GetOrCreate(ctx, dek.ContextID{Type: "scene", ID: "01HXX"}, initial)
 		Expect(err).NotTo(HaveOccurred())
@@ -262,9 +267,13 @@ var _ = Describe("Manager", func() {
 		Expect(parts[0].PlayerID).To(Equal("01ABC"))
 		Expect(parts[0].CharacterID).To(Equal("01XYZ"))
 		Expect(parts[0].BindingID).To(Equal("01DEF"))
+		Expect(parts[0].JoinedAt.UnixNano()).To(Equal(joinedAt1.UnixNano()),
+			"INV-TS-1: JoinedAt ns precision MUST survive round-trip")
 		Expect(parts[1].PlayerID).To(Equal("01GHI"))
 		Expect(parts[1].CharacterID).To(Equal("01JKL"))
 		Expect(parts[1].BindingID).To(Equal("01MNO"))
+		Expect(parts[1].JoinedAt.UnixNano()).To(Equal(joinedAt2.UnixNano()),
+			"INV-TS-1: JoinedAt ns precision MUST survive round-trip")
 	})
 
 	It("Participants not found returns DEK_NOT_FOUND", func() {

--- a/internal/eventbus/history/cold_postgres_integration_test.go
+++ b/internal/eventbus/history/cold_postgres_integration_test.go
@@ -376,7 +376,9 @@ var _ = Describe("PostgresColdTier", func() {
 
 			// Insert two events: one AT the boundary timestamp (must
 			// be included) and one strictly after (must be excluded).
-			boundary := time.Now().UTC().Truncate(time.Microsecond)
+			// INV-TS-1: events_audit is BIGINT-ns end-to-end, so no µs
+			// truncation needed — the boundary value round-trips bit-exact.
+			boundary := time.Now().UTC()
 			atID := integrationULID(uint64(boundary.UnixMilli()))
 			afterID := integrationULID(uint64(boundary.Add(1 * time.Second).UnixMilli()))
 			insertIntegrationAuditRowAt(pool, atID, subject, 1, boundary)


### PR DESCRIPTION
## Summary

Three small INV-TS-1 spec-compliance fixes that were deferred during the gfo6 drain and surfaced again by the post-PR-#4198 bead-auditor pass, plus one tracking-debt fix surfaced by the existing INV-TS-3 lint guard.

### Bead closures (all 3 verified KEEP by bead-auditor)

- **holomush-gfo6.12.3** — replace `time.Now().UTC()` with deterministic `time.Date(2026, 5, 22, 12, 0, 0, *, time.UTC)` fixtures at the 3 sites the spec called out:
  - `internal/eventbus/crypto/dek/manager_integration_test.go:253-254` (Participants seed)
  - `cmd/holomush/crypto_operator_validation_test.go:50` (seedPlayer)
- **holomush-gfo6.12.1** — add a load-bearing `Expect(parts[N].JoinedAt.UnixNano()).To(Equal(...))` round-trip assertion to the "Participants round-trip persists and retrieves participant list" test. The two participants now use **different** sub-microsecond ns values (`123456789` vs `987654321`) so the assertion meaningfully exercises the bits that would be lost under µs truncation.
- **holomush-gfo6.12.2** — add `// INV-TS-1: ...` forwarding comment at `crypto_operator_validation_test.go:50` where the original `Truncate(time.Microsecond)` call was deleted in the gfo6 sweep. Spec Task 12 Check 7 requires this citation at every discipline-deletion site.

### Tracking-debt fix (surfaced by INV-TS-3 lint)

- `internal/eventbus/history/cold_postgres_integration_test.go:379` — drop `.Truncate(time.Microsecond)` from the NotAfter boundary test. `events_audit` is BIGINT-ns end-to-end (post-PR-#4188); the truncate was dead code from the TIMESTAMPTZ era. The `task lint:no-microsecond-truncate` guard caught it once main got the lint wiring from PR #4198.

## Test plan

- [x] `task pr-prep` passes end-to-end (6m45s, exit=0)
- [x] `task lint:no-microsecond-truncate` passes (was the original failure)
- [x] `go vet ./internal/eventbus/crypto/dek/... ./cmd/holomush/... ./internal/eventbus/history/...` clean
- [x] New JoinedAt round-trip assertion is meaningful — different ns values per participant catch any precision loss

Closes `holomush-gfo6.12.1`, `holomush-gfo6.12.2`, `holomush-gfo6.12.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)