### PR TITLE
fix(web): split CSP so SvelteKit inline bootstrap is hash-allowed (holomush-11ape)

### DIFF
--- a/internal/web/security_headers.go
+++ b/internal/web/security_headers.go
@@ -24,24 +24,35 @@ const (
 	// avoid trapping dev-mode plain-HTTP clients into HTTPS-only for a year.
 	hdrHSTSValue = "max-age=31536000; includeSubDomains"
 
-	// hdrCSPValue — conservative CSP for the SvelteKit SPA in production:
-	//   - default-src 'self'              all fetches default to same-origin
-	//   - connect-src 'self' ws: wss:     allow WebSocket + ConnectRPC to origin
-	//   - img-src 'self' data:            allow inline data-URI images (icons)
-	//   - style-src 'self' 'unsafe-inline' Svelte component styles need inline
-	//   - script-src 'self'               no inline scripts in prod builds
-	//   - frame-ancestors 'none'          modern clickjacking protection
+	// hdrCSPValue — the header half of the SPA's Content-Security-Policy.
 	//
-	// Only emitted when Secure=true because Vite dev-mode injects inline
-	// <script> tags that violate script-src 'self'. If this breaks the SPA
-	// even in production, promote to a Config option (opt-in) rather than
-	// relaxing the policy for all deployments.
-	hdrCSPValue = "default-src 'self'; " +
-		"connect-src 'self' ws: wss:; " +
-		"img-src 'self' data:; " +
-		"style-src 'self' 'unsafe-inline'; " +
-		"script-src 'self'; " +
-		"frame-ancestors 'none'"
+	// CSP for this SPA is deliberately split across two policies:
+	//
+	//   1. This response header carries only the directives that *cannot* be
+	//      expressed in a <meta> tag or that benefit from header-level enforcement:
+	//        - frame-ancestors 'none'  clickjacking protection (browsers IGNORE
+	//                                  frame-ancestors when set via <meta>, so it
+	//                                  MUST live on the header)
+	//        - base-uri 'self'         block <base> tag injection
+	//        - object-src 'none'       no plugins/embeds
+	//
+	//   2. SvelteKit emits a <meta http-equiv="content-security-policy"> tag in the
+	//      prerendered HTML (configured via `csp: { mode: 'hash' }` in
+	//      web/svelte.config.js) carrying default-src/script-src/style-src/img-src/
+	//      connect-src, where script-src includes the per-build sha256 hashes of
+	//      SvelteKit's inline hydration bootstrap.
+	//
+	// The split is load-bearing: two CSPs are enforced independently and a resource
+	// must satisfy ALL of them. If this header also set `script-src 'self'` (or a
+	// `default-src 'self'` that scripts fall back to), it would block SvelteKit's
+	// hashed inline bootstrap — the adapter-static build mounts the app from an
+	// inline <script>, and a static (frozen) document cannot use a per-request
+	// nonce, so the hash in the meta tag is the only way to allow it. Setting the
+	// document's script policy here would re-introduce the blank-page regression
+	// (holomush-11ape).
+	hdrCSPValue = "frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"object-src 'none'"
 )
 
 // SecurityHeadersMiddleware wraps next with a standard set of HTTP security
@@ -54,7 +65,9 @@ const (
 //
 // Secure-only headers (set only when secure=true, which tracks TLS deployment):
 //   - Strict-Transport-Security: max-age=31536000; includeSubDomains
-//   - Content-Security-Policy: conservative SPA policy (see hdrCSPValue)
+//   - Content-Security-Policy: header half of the split SPA policy (see
+//     hdrCSPValue); the script/style/connect half ships as a <meta> tag in the
+//     SvelteKit build
 //
 // Headers are set before delegating to next, so they appear on any response
 // the inner handler emits — including errors, redirects, and streaming frames.

--- a/internal/web/security_headers_test.go
+++ b/internal/web/security_headers_test.go
@@ -53,20 +53,39 @@ func TestSecurityHeadersSetsHSTSInSecureMode(t *testing.T) {
 		rec.Header().Get("Strict-Transport-Security"))
 }
 
-func TestSecurityHeadersSetsCSPInSecureMode(t *testing.T) {
+func TestSecurityHeadersSetsHeaderHalfOfSplitCSPInSecureMode(t *testing.T) {
 	handler := SecurityHeadersMiddleware(true, okHandler())
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
 
+	// The header carries only the directives that cannot live in a <meta> tag.
+	// frame-ancestors in particular is ignored by browsers when set via <meta>,
+	// so it MUST be enforced here.
 	csp := rec.Header().Get("Content-Security-Policy")
-	assert.Contains(t, csp, "default-src 'self'")
-	assert.Contains(t, csp, "connect-src 'self' ws: wss:")
-	assert.Contains(t, csp, "img-src 'self' data:")
-	assert.Contains(t, csp, "style-src 'self' 'unsafe-inline'")
-	assert.Contains(t, csp, "script-src 'self'")
 	assert.Contains(t, csp, "frame-ancestors 'none'")
+	assert.Contains(t, csp, "base-uri 'self'")
+	assert.Contains(t, csp, "object-src 'none'")
+}
+
+func TestSecurityHeadersOmitsDocumentScriptPolicyFromHeaderInSecureMode(t *testing.T) {
+	handler := SecurityHeadersMiddleware(true, okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// script-src/default-src MUST NOT appear on the header: they are owned by the
+	// SvelteKit <meta> CSP (hash mode), which carries the sha256 of the inline
+	// hydration bootstrap. A same-origin script-src here would be enforced
+	// alongside the meta policy and block that bootstrap — the blank-page
+	// regression (holomush-11ape).
+	csp := rec.Header().Get("Content-Security-Policy")
+	assert.NotContains(t, csp, "script-src",
+		"document script policy must come from the SvelteKit meta CSP, not the header")
+	assert.NotContains(t, csp, "default-src",
+		"a default-src here would act as a script-src fallback and block the inline bootstrap")
 }
 
 func TestSecurityHeadersSetsAlwaysOnHeadersInSecureMode(t *testing.T) {

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -7,7 +7,33 @@ const config = {
 			pages: 'build',
 			assets: 'build',
 			fallback: 'index.html'
-		})
+		}),
+		// Content-Security-Policy for the prerendered SPA.
+		//
+		// adapter-static emits frozen HTML at build time, so a per-request nonce
+		// is impossible — that leaves hashes. In `hash` mode SvelteKit computes the
+		// sha256 of its own inline hydration bootstrap <script> during prerender and
+		// injects a <meta http-equiv="content-security-policy"> tag carrying those
+		// hashes. This meta tag is the authoritative script-src/style-src/connect-src
+		// policy for the document.
+		//
+		// Header-only directives (frame-ancestors, base-uri, object-src) stay on the
+		// Go SecurityHeadersMiddleware — browsers ignore frame-ancestors in a <meta>
+		// tag, so it can only be enforced via the response header. The Go header is
+		// deliberately split to NOT set default-src/script-src; otherwise both
+		// policies would enforce and the header's same-origin script-src would block
+		// the hashed inline bootstrap (two CSPs intersect — a script must satisfy
+		// every active policy). See internal/web/security_headers.go.
+		csp: {
+			mode: 'hash',
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self'],
+				'style-src': ['self', 'unsafe-inline'],
+				'img-src': ['self', 'data:'],
+				'connect-src': ['self', 'ws:', 'wss:']
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
## Problem

Production web at `game.holomush.dev` rendered a **blank page** (telnet unaffected).

Two layers, surfaced in order:

1. **Cloudflare Bot Fight Mode** was issuing a managed challenge on every request to the zone, walling the SPA at the edge. Resolved out-of-band (dashboard); confirmed via `firewallEventsAdaptive` (`source: botFight`).
2. **Exposed once the edge cleared:** the gateway's CSP set `script-src 'self'`, which forbids inline scripts. SvelteKit's `adapter-static` build mounts the SPA from an **inline `<script>`** in the prerendered `index.html` (`__sveltekit_…; import(...).then(([kit,app]) => kit.start(app, element))`). The browser blocked it → no hydration → blank page.

This is exactly the case the existing `internal/web/security_headers.go` comment predicted: *"If this breaks the SPA even in production…"*. The assumption that only Vite dev-mode emits inline scripts was wrong — SvelteKit's **production** build does too.

## Fix

A static (frozen) document can't use a per-request nonce, so the inline bootstrap is allowed **by hash**, with CSP split across two policies (each enforced independently — a resource must satisfy both):

- **`web/svelte.config.js`** — enable SvelteKit `csp: { mode: 'hash' }`. SvelteKit injects a `<meta http-equiv="content-security-policy">` carrying the per-build `sha256` of its inline scripts, plus `default-src`/`script-src`/`style-src`/`img-src`/`connect-src` for the document.
- **`internal/web/security_headers.go`** — the header CSP now sets only `frame-ancestors 'none'; base-uri 'self'; object-src 'none'` — the directives that must (or should) be enforced via the response header. Browsers **ignore `frame-ancestors` in a `<meta>` tag**, so it has to stay header-side. It no longer sets `default-src`/`script-src`, which would be enforced alongside the meta policy and re-block the hashed bootstrap.
- **`internal/web/security_headers_test.go`** — assertions updated (positive on the header half, negative on `script-src`/`default-src`).

## Verification

- Built `index.html` carries `script-src 'self' 'sha256-…'`; recomputed the bootstrap's sha256 → **matches the meta hash exactly**.
- No inline `<style>` in the build, so SvelteKit adds no style hashes → `style-src 'self' 'unsafe-inline'` stays effective (a hash would void `'unsafe-inline'` per CSP3) and the `style="display: contents"` attribute is still permitted.
- Cloudflare **Rocket Loader off**, **HTML/JS minify off** → the inline script reaches the browser byte-for-byte, so the hash holds at the edge.
- `code-reviewer`: **READY**, no blocking findings.
- `task pr-prep`: full lane green (unit + integration + E2E 64 passed).

## Deploy note

The CSP is compiled into the gateway binary and baked into the SvelteKit build, so production won't render until this merges and a new release is cut/deployed.

Closes holomush-11ape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)