### PR TITLE
feat(telemetry): default Sentry log sink to WARN

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -174,7 +174,7 @@ func registerLogSinkFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("log-otel", true, "enable OTLP-collector log sink")
 	cmd.Flags().String("log-otel-level", "", "collector log level override (default: global)")
 	cmd.Flags().Bool("log-sentry", true, "enable Sentry log sink")
-	cmd.Flags().String("log-sentry-level", "", "Sentry log level override (default: global)")
+	cmd.Flags().String("log-sentry-level", "", "Sentry log level override (default: warn)")
 }
 
 // applyLogSinkFlags overlays explicitly-set --log-* flags onto lc, giving CLI

--- a/docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md
+++ b/docs/superpowers/specs/2026-05-23-otel-native-log-surfacing-design.md
@@ -131,15 +131,17 @@ Two surfaces, by nature of the value:
 | `logging.otel.enabled` | `--log-otel` | `true` | Toggle collector sink |
 | `logging.otel.level` | `--log-otel-level` | global | Per-sink floor |
 | `logging.sentry.enabled` | `--log-sentry` | `true` | Toggle Sentry sink |
-| `logging.sentry.level` | `--log-sentry-level` | global | Per-sink floor |
+| `logging.sentry.level` | `--log-sentry-level` | `warn` | Per-sink floor (cost control; Sentry Logs is volume-priced) |
 
 - **Effective enablement** of a sink = `config.enabled` **AND** its
   endpoint is present (stderr has no endpoint, so it depends only on the
   toggle). This lets an operator with `SENTRY_DSN` set send traces to
   Sentry while keeping `logging.sentry.enabled: false`.
 - **Level precedence** per sink: explicit per-sink level > global
-  `LOG_LEVEL` / `--log-level`. Per-sink level defaults to the global
-  level when unset.
+  `LOG_LEVEL` / `--log-level`. The stderr and collector sinks default to the
+  global level when unset; the Sentry sink defaults to `warn`
+  (`config.SentryLogLevelDefault`) so info/debug never reach the volume-priced
+  Sentry Logs view regardless of the global level.
 - Flag/config/env precedence follows the existing `config.Load` order
   (CLI flag > config file > built-in default), matching `log_format`.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,12 +212,21 @@ type LoggingConfig struct {
 	Sentry LoggingSink `koanf:"sentry"`
 }
 
-// DefaultLoggingConfig enables all three sinks with global-inherited levels.
+// SentryLogLevelDefault is the built-in floor for the Sentry log sink. Sentry's
+// Logs view is for actionable signal, not a debug firehose: info/debug records
+// carry no incident value there and would dominate the project's log quota, so
+// the Sentry sink defaults to WARN independent of the (typically lower) global
+// level. Stderr and the collector still inherit the global level. Operators can
+// override via logging.sentry.level / --log-sentry-level.
+const SentryLogLevelDefault = "warn"
+
+// DefaultLoggingConfig enables all three sinks. Stderr and the collector inherit
+// the global level; the Sentry sink defaults to SentryLogLevelDefault (WARN).
 func DefaultLoggingConfig() LoggingConfig {
 	return LoggingConfig{
 		Stderr: LoggingSink{Enabled: true},
 		OTel:   LoggingSink{Enabled: true},
-		Sentry: LoggingSink{Enabled: true},
+		Sentry: LoggingSink{Enabled: true, Level: SentryLogLevelDefault},
 	}
 }
 

--- a/internal/config/logging_config_test.go
+++ b/internal/config/logging_config_test.go
@@ -15,6 +15,17 @@ func TestLoggingConfig_Defaults(t *testing.T) {
 	require.True(t, c.Stderr.Enabled)
 	require.True(t, c.OTel.Enabled)
 	require.True(t, c.Sentry.Enabled)
+
+	// Stderr and the collector inherit the global level (empty per-sink
+	// level); the Sentry sink defaults to WARN so info/debug never reach
+	// the Sentry Logs view regardless of the global level.
+	require.Empty(t, c.Stderr.Level)
+	require.Empty(t, c.OTel.Level)
+	require.Equal(t, SentryLogLevelDefault, c.Sentry.Level)
+
+	// The default Sentry level must actually resolve to WARN, and must hold
+	// that floor even when the global level is lower (debug).
+	require.Equal(t, slog.LevelWarn, c.Sentry.EffectiveLevel(slog.LevelDebug))
 }
 
 func TestLoggingSink_EffectiveLevel(t *testing.T) { // INV-L4

--- a/site/docs/operating/sentry.md
+++ b/site/docs/operating/sentry.md
@@ -149,7 +149,7 @@ configurable sinks.
 | `logging.otel.enabled`   | `--log-otel`          | `true`      | Toggle OTLP collector sink           |
 | `logging.otel.level`     | `--log-otel-level`    | (global)    | Per-sink level override              |
 | `logging.sentry.enabled` | `--log-sentry`        | `true`      | Toggle Sentry sink                   |
-| `logging.sentry.level`   | `--log-sentry-level`  | (global)    | Per-sink level override              |
+| `logging.sentry.level`   | `--log-sentry-level`  | `warn`      | Per-sink level override              |
 
 **Toggle + endpoint rule:** a non-stderr sink is active only when its toggle
 is on *and* its endpoint is configured — `OTEL_EXPORTER_OTLP_ENDPOINT` for
@@ -157,10 +157,12 @@ the collector, `SENTRY_DSN` for Sentry. If the endpoint is absent the sink
 is skipped regardless of the toggle.
 
 **Per-sink level overrides:** each sink can filter independently of the
-global `LOG_LEVEL` / `--log-level`. The most common reason to set
-`--log-sentry-level warn` is cost control: Sentry Logs is volume-priced, so
-routing only WARN+ to Sentry while keeping stderr at DEBUG avoids paying for
-every debug trace.
+global `LOG_LEVEL` / `--log-level`. The Sentry sink defaults to `warn`
+(unlike stderr and the collector, which inherit the global level) as cost
+control: Sentry Logs is volume-priced, so routing only WARN+ to Sentry while
+keeping stderr at DEBUG avoids paying for every debug trace. Lower it with
+`--log-sentry-level info` (or `debug`) if you need richer logs in Sentry
+temporarily.
 
 ### Trace correlation
 


### PR DESCRIPTION
## What

Default the **Sentry log sink** to `WARN` so info/debug application logs are no longer forwarded to Sentry's volume-priced Logs view. stderr and the OTLP collector sinks still inherit the global `LOG_LEVEL`.

## Why

Application logs reach Sentry via the OTel-native pipeline (`log/slog` → `otelslog` bridge → `LoggerProvider` → per-sink `levelFilter` → `otlploghttp` → Sentry), which landed on main in 0.1.13. The Sentry sink previously inherited the global level (default `info`), so info/debug noise was billed against Sentry Logs quota with no incident value.

This is configured at the correct layer — the existing per-sink `levelFilter` consumes `cfg.Sentry.EffectiveLevel(global)` — not a sentry-go `BeforeSendLog` SDK hook, which would be dead code (nothing calls `sentry.NewLogger`).

## Changes

- `internal/config/config.go`: new `SentryLogLevelDefault = "warn"`; `DefaultLoggingConfig()` sets the Sentry sink to it.
- `cmd/holomush/core.go`: `--log-sentry-level` help text default `global` → `warn`.
- `internal/config/logging_config_test.go`: assert the Sentry default resolves to `slog.LevelWarn` and holds the floor even when global is `debug`.
- Docs: otel-native-log spec (defaults table + level-precedence bullet) and `site/docs/operating/sentry.md` (defaults table + cost-control note).

Operators can still lower it per-deployment via `logging.sentry.level` / `--log-sentry-level info`.

## Verification

- `task pr-prep` — full lane green (`✓ All PR checks passed.`).
- `code-reviewer` agent — **READY**, no blocking findings; verified the full config → `buildLogProcessors` → `levelFilter` → `slogToOTel` wiring and confirmed the collector floor is not accidentally raised.

Closes holomush-v1yvj

🤖 Generated with [Claude Code](https://claude.com/claude-code)