### PR TITLE
feat(lint): enable sloglint Tier C logging-discipline policy (holomush-ow4ix)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -8,6 +8,33 @@ Keep under 200 lines. Curate — don't hoard.
 
 ## Anti-patterns
 
+- **sloglint `context:scope` (v0.11.1, golangci-lint v2.11.4) does NOT flag bare
+  `slog.X` inside a closure** even when the enclosing FuncDecl has a `ctx`
+  first param. Standalone `sloglint@v0.11.1 -context-only=scope` DOES flag that
+  shape (`isContextInScope` walks FuncDecl only, finds enclosing ctx → reports),
+  but the golangci-lint-integrated path returns 0 issues — an integration quirk.
+  Consequence for sloglint Tier-C migration beads (holomush-ow4ix.*): bare calls
+  inside closures are NOT in the "findings" set the orchestrator migrates, so
+  sibling calls in the same function can legitimately diverge (one bare, others
+  `*Context`). Live example: `internal/world/events.go:79` (`slog.Debug` in the
+  `retry.Do` closure) stays bare while lines 93/102 in the same `emitWithRetry`
+  became `*Context`. Not a regression (predates the change); flag as non-blocking
+  consistency note, not a blocker. Encountered: holomush-ow4ix.12 (2026-05-24).
+
+- **G706 (log-injection) is excluded BY CONFIG for most internal pkgs, NOT all.**
+  `.golangci.yaml:117-123` excludes gosec G706 for a path regex covering
+  `internal/(access|command|core|grpc|logging|observability|plugin|store|telnet|tls|web|world|xdg)|cmd|pkg`.
+  `internal/bootstrap` and `internal/lifecycle` are NOT in that list, so those
+  pkgs need inline `//nolint:gosec // G706` directives. gosec slog G706 sinks are
+  `Info/Warn/Error/Debug` with `CheckArgs:[0]` (message only — attribute KV pairs
+  are auto-escaped, never flagged; per securego/gosec PR #1623). When a bare
+  `slog.Info(...) //nolint:gosec // G706` migrates to `slog.InfoContext(ctx, ...)`,
+  dropping the directive is correct IF the message arg is a static literal (it
+  always is under `static-msg:true`) — and nolintlint `require-explanation`+
+  `require-specific` would FAIL on the now-unused directive if kept. Verify by
+  running full-config `custom-gcl run ./<pkg>/...` → 0 issues. Encountered:
+  holomush-ow4ix.12 admin.go:111 (2026-05-24).
+
 - **`AGENTS.md` and `CLAUDE.md` are paired SSoTs**: at main they are
   byte-identical. `Taskfile.yaml`
   `lint:docs-symmetry` enforces only the `<!-- BEGIN: plugin-runtime-symmetry -->`

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -35,16 +35,14 @@ Keep under 200 lines. Curate — don't hoard.
   running full-config `custom-gcl run ./<pkg>/...` → 0 issues. Encountered:
   holomush-ow4ix.12 admin.go:111 (2026-05-24).
 
-- **`AGENTS.md` and `CLAUDE.md` are paired SSoTs**: at main they are
-  byte-identical. `Taskfile.yaml`
-  `lint:docs-symmetry` enforces only the `<!-- BEGIN: plugin-runtime-symmetry -->`
-  anchored subsection byte-identical, but the surrounding convention is
-  whole-file twinning (initial setup, two later "chore: fix agents md" syncs).
-  Any edit to one MUST be mirrored in the other (or AGENTS.md replaced with a
-  one-line stub pointing at CLAUDE.md and `lint:docs-symmetry` updated). When
-  reviewing CLAUDE.md changes, ALWAYS `diff CLAUDE.md AGENTS.md` and grep both
-  for the same anchor names; treat divergence beyond the symmetry-block as
-  a blocking finding.
+- **`AGENTS.md` is now a relative symlink → `CLAUDE.md`** (verified 2026-05-24,
+  sloglint worktree: `readlink AGENTS.md` = `CLAUDE.md`). `task lint:docs-symmetry`
+  enforces the symlink integrity (holomush-f7t2). Any CLAUDE.md edit propagates to
+  AGENTS.md automatically — NO manual mirror needed, and no symmetry-divergence
+  finding is possible. (HISTORICAL: an earlier era kept them as byte-identical
+  twin files; that convention is superseded by the symlink. Do NOT flag a missing
+  AGENTS.md edit when CLAUDE.md changes — confirm the symlink first with
+  `readlink AGENTS.md`.)
 
 - **`task test:int -- -run X` does NOT filter to test X.** The Taskfile's `--`
   pass-through composes args into the gotestsum command but does not isolate the

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -61,12 +61,21 @@ func main() {
 }
 ```
 
-## Enforcement (planned)
+## Enforcement
 
-This rule will be enforced mechanically by the `sloglint` linter with
-`context: scope` — that setting flags a bare log call **only when a
-`context.Context` is in scope**, which is exactly the "unless absolutely
-impossible" carve-out above. Enabling it is a large mechanical migration
-(~600 call sites today) tracked as `holomush-xrdjw`; until it lands, the
-rule is enforced by review. Do not introduce new bare-variant call sites that
-have a ctx available.
+This rule is enforced mechanically by the `sloglint` linter (golangci-lint v2,
+`bin/custom-gcl`, `task lint:go`) with the Tier C policy:
+
+| Check | Effect |
+| ----- | ------ |
+| `context: scope` | A bare `slog.*`/`logger.*` call is flagged **only** when a `context.Context` is in scope — the "unless absolutely impossible" carve-out is the linter's own semantics. |
+| `no-mixed-args` | Forbids mixing `slog.Attr` values and loose `"k", v` pairs in one call. |
+| `static-msg` | The message MUST be a string literal/constant — dynamic data goes in attributes. |
+| `msg-style: lowercased` | Messages start lowercase. |
+| `key-naming-case: snake` | Attribute keys are snake_case. |
+| `forbidden-keys` | `time`/`level`/`msg`/`source` are banned (collide with slog's reserved fields). |
+
+Rejected checks and why: `no-global` (would forbid the package-level `slog.*` calls
+that are the codebase's established shape), `attr-only`/`no-raw-keys` (high-ceremony
+typed-attr/const-key rewrites). `//nolint:sloglint` MUST be line-scoped with an
+explanation; do not widen `.golangci.yaml` to suppress findings.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,11 @@ linters:
     - gocritic
     - nolintlint
 
+    # Logging correctness — enforce trace-context propagation + structured-log
+    # discipline (see CLAUDE.md "Structured Logging" + .claude/rules/logging.md,
+    # spec docs/superpowers/specs/2026-05-24-logging-discipline-policy-design.md).
+    - sloglint
+
     # Custom bans
     - forbidigo
 
@@ -130,6 +135,20 @@ linters:
     errcheck:
       check-type-assertions: true
       check-blank: true
+
+    sloglint:
+      # *Context variant required only when a context.Context is in scope
+      # (leaves main/init/bare-goroutine sites untouched).
+      context: scope
+      no-mixed-args: true
+      static-msg: true
+      msg-style: lowercased
+      key-naming-case: snake
+      forbidden-keys:
+        - time
+        - level
+        - msg
+        - source
 
     govet:
       enable-all: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ Use `oops` for structured errors: `oops.With(k, v).Wrap(err)`, `oops.Errorf(...)
 | **MUST NOT** drop the context | If a `ctx` is reachable (parameter, struct field, or derivable), it MUST be threaded into the log call |
 | **MAY** use bare variants | Only when no `ctx` exists *and* one cannot reasonably be plumbed (init/`main`, bare goroutines, pure helpers with no caller context) — this is the "absolutely impossible" carve-out |
 
-**Why:** trace context (`trace_id`/`span_id`) lives on the `context.Context`. Only the `*Context` variants propagate it into the OpenTelemetry log pipeline, so bare calls produce orphaned log lines that can't be correlated with the trace/span they belong to in Loki, Grafana, or Sentry. See [logging.md](.claude/rules/logging.md) for the full rationale and the planned `sloglint` enforcement.
+**Why:** trace context (`trace_id`/`span_id`) lives on the `context.Context`. Only the `*Context` variants propagate it into the OpenTelemetry log pipeline, so bare calls produce orphaned log lines that can't be correlated with the trace/span they belong to in Loki, Grafana, or Sentry. See [logging.md](.claude/rules/logging.md) for the full rationale and the `sloglint` `context: scope` enforcement (now active).
 
 ### Database Migrations
 

--- a/cmd/holomush/cert_poll.go
+++ b/cmd/holomush/cert_poll.go
@@ -85,7 +85,7 @@ func waitForTLSCerts(ctx context.Context, deps *GatewayDeps, certsDir, component
 	}
 
 	// Certs not found — poll until available or timeout.
-	slog.Info("waiting for TLS certificates", "certs_dir", certsDir, "timeout", timeout)
+	slog.InfoContext(ctx, "waiting for TLS certificates", "certs_dir", certsDir, "timeout", timeout)
 
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
@@ -106,13 +106,13 @@ func waitForTLSCerts(ctx context.Context, deps *GatewayDeps, certsDir, component
 		case <-ticker.C:
 			result, err = tryLoadCerts(deps, certsDir, component)
 			if err == nil {
-				slog.Info("TLS certificates loaded", "certs_dir", certsDir)
+				slog.InfoContext(ctx, "TLS certificates loaded", "certs_dir", certsDir)
 				return result, nil
 			}
 			if !isTransientCertError(err) {
 				return nil, err
 			}
-			slog.Debug("still waiting for TLS certificates", "certs_dir", certsDir, "error", err)
+			slog.DebugContext(ctx, "still waiting for TLS certificates", "certs_dir", certsDir, "error", err)
 		}
 	}
 }

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -248,7 +248,8 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		}
 	}()
 
-	slog.Info(
+	slog.InfoContext(
+		ctx,
 		"starting core process",
 		"grpc_addr", cfg.GRPCAddr,
 		"log_format", cfg.LogFormat,
@@ -288,7 +289,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	if gameID == "" {
 		gameID = dbSub.GameID()
 	}
-	slog.Info("game ID initialized", "game_id", gameID)
+	slog.InfoContext(ctx, "game ID initialized", "game_id", gameID)
 
 	// --- 4. TLS certificates ---
 	certsDir, err := deps.CertsDirGetter()
@@ -300,7 +301,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	if err != nil {
 		return oops.Code("TLS_SETUP_FAILED").With("operation", "set up TLS").With("certs_dir", certsDir).Wrap(err)
 	}
-	slog.Info("TLS certificates ready", "certs_dir", certsDir)
+	slog.InfoContext(ctx, "TLS certificates ready", "certs_dir", certsDir)
 
 	// Derive admin socket paths from XDG runtime dir. Non-fatal: if the
 	// runtime dir is unavailable, the admin socket is disabled (break-glass
@@ -308,10 +309,10 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// is a no-op when SocketPath is empty.
 	var adminSocketPath, adminLockPath string
 	if runtimeDir, rdErr := xdg.RuntimeDir(); rdErr != nil {
-		slog.Warn("admin socket disabled: cannot determine XDG runtime dir; break-glass unavailable",
+		slog.WarnContext(ctx, "admin socket disabled: cannot determine XDG runtime dir; break-glass unavailable",
 			"error", rdErr)
 	} else if ensureErr := xdg.EnsureDir(runtimeDir); ensureErr != nil {
-		slog.Warn("admin socket disabled: cannot create XDG runtime dir; break-glass unavailable",
+		slog.WarnContext(ctx, "admin socket disabled: cannot create XDG runtime dir; break-glass unavailable",
 			"path", runtimeDir, "error", ensureErr)
 	} else {
 		adminSocketPath = filepath.Join(runtimeDir, "admin.sock")
@@ -339,12 +340,12 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		if obsErr != nil {
 			return oops.Code("OBSERVABILITY_START_FAILED").With("addr", cfg.MetricsAddr).Wrap(obsErr)
 		}
-		slog.Info("observability server started", "addr", obsServer.Addr())
+		slog.InfoContext(ctx, "observability server started", "addr", obsServer.Addr())
 		defer func() {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if stopErr := obsServer.Stop(shutdownCtx); stopErr != nil {
-				slog.Warn("error stopping observability server", "error", stopErr)
+				slog.WarnContext(shutdownCtx, "error stopping observability server", "error", stopErr)
 			}
 		}()
 		// Monitor in background — will be cancelled when context ends.
@@ -463,7 +464,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer stopCancel()
 			if stopErr := eventBusSub.Stop(stopCtx); stopErr != nil {
-				slog.Warn("event bus cleanup failed on early-return path",
+				slog.WarnContext(stopCtx, "event bus cleanup failed on early-return path",
 					"err", stopErr.Error())
 			}
 		}
@@ -736,7 +737,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// server continues to start (handler construction itself is always successful).
 	kekProvider, kekErr := buildKEKProviderFromConfig(ctx, dbSub.Pool())
 	if kekErr != nil {
-		slog.Warn("admin handlers: KEK provider unavailable — TOTP-gated admin RPCs will fail at runtime",
+		slog.WarnContext(ctx, "admin handlers: KEK provider unavailable — TOTP-gated admin RPCs will fail at runtime",
 			"error", kekErr)
 		kekProvider = nil
 	}
@@ -752,7 +753,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			authSub.Hasher(),
 		)
 		if totpErr != nil {
-			slog.Warn("admin handlers: TOTP service construction failed — admin TOTP RPCs will be unavailable at runtime",
+			slog.WarnContext(ctx, "admin handlers: TOTP service construction failed — admin TOTP RPCs will be unavailable at runtime",
 				"error", totpErr)
 		} else {
 			adminTOTPSvc = builtTOTP
@@ -772,7 +773,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			slog.Default(),
 		)
 		if auditErr != nil {
-			slog.Warn("admin handlers: TOTP audit service construction failed", "error", auditErr)
+			slog.WarnContext(ctx, "admin handlers: TOTP audit service construction failed", "error", auditErr)
 		} else {
 			totpAuditSvc = builtAudit
 		}
@@ -793,7 +794,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			adminRoleStore,
 		)
 		if provErr != nil {
-			slog.Warn("admin handlers: InGameCredentialsProvider construction failed — Authenticate will be unavailable",
+			slog.WarnContext(ctx, "admin handlers: InGameCredentialsProvider construction failed — Authenticate will be unavailable",
 				"error", provErr)
 		} else {
 			approvalRepo := approval.NewPostgresRepo(dbSub.Pool(), nil)
@@ -802,7 +803,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			resetTOTPHandler = adminauth.NewResetTOTPHandler(adminSessionStore, abacSub.Resolver(), adminRoleStore, totpAuditSvc)
 		}
 	} else {
-		slog.Warn("admin handlers: TOTP audit service unavailable — all three admin RPCs (Authenticate/Approve/ResetTOTP) will return errors")
+		slog.WarnContext(ctx, "admin handlers: TOTP audit service unavailable — all three admin RPCs (Authenticate/Approve/ResetTOTP) will return errors")
 	}
 
 	// --- Phase 5 sub-epic E T44: production dek.Manager + rekey RPC wiring ---
@@ -860,7 +861,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		return rekeyWErr
 	}
 	if rekeyW.RekeyHandler == nil {
-		slog.Warn("rekey wiring incomplete — Rekey admin RPCs will return Unimplemented",
+		slog.WarnContext(ctx, "rekey wiring incomplete — Rekey admin RPCs will return Unimplemented",
 			"kek_available", kekProvider != nil)
 	}
 	// Thread the production dek.Manager into the gRPC subsystem so Start()
@@ -895,10 +896,10 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 			Metrics:   invMetrics,
 		})
 		if invErr != nil {
-			slog.Warn("invalidation.Coordinator construction failed — cluster fan-out unavailable; Rekey will surface INVALIDATION_NO_LIVE_MEMBERS",
+			slog.WarnContext(ctx, "invalidation.Coordinator construction failed — cluster fan-out unavailable; Rekey will surface INVALIDATION_NO_LIVE_MEMBERS",
 				"error", invErr)
 		} else if startErr := c.Start(ctx); startErr != nil {
-			slog.Warn("invalidation.Coordinator start failed — cluster fan-out unavailable",
+			slog.WarnContext(ctx, "invalidation.Coordinator start failed — cluster fan-out unavailable",
 				"error", startErr)
 		} else {
 			coordHolderPtr.coord = c
@@ -907,7 +908,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 				stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				if stopErr := c.Stop(stopCtx); stopErr != nil {
-					slog.Warn("invalidation.Coordinator stop error", "error", stopErr)
+					slog.WarnContext(stopCtx, "invalidation.Coordinator stop error", "error", stopErr)
 				}
 			}()
 		}
@@ -929,7 +930,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// the architectural decision and the wrappers it deliberately omits.
 	const operatorReadMaxWindowWarnThreshold = 90 * 24 * time.Hour
 	if cryptoCfg.OperatorReadMaxWindow > operatorReadMaxWindowWarnThreshold {
-		slog.Warn("admin readstream: OperatorReadMaxWindow > 90d — oversized windows greatly inflate cold-tier read row-count and memory pressure",
+		slog.WarnContext(ctx, "admin readstream: OperatorReadMaxWindow > 90d — oversized windows greatly inflate cold-tier read row-count and memory pressure",
 			"configured", cryptoCfg.OperatorReadMaxWindow,
 			"threshold", operatorReadMaxWindowWarnThreshold)
 	}
@@ -956,7 +957,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		return readStreamWErr
 	}
 	if readStreamW.Handler == nil {
-		slog.Warn("admin readstream wiring incomplete — AdminReadStream RPC will return Unimplemented",
+		slog.WarnContext(ctx, "admin readstream wiring incomplete — AdminReadStream RPC will return Unimplemented",
 			"dek_manager_available", rekeyW.Manager != nil)
 	}
 
@@ -1032,7 +1033,8 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	if readyErr := registry.WaitReady(readinessCtx); readyErr != nil {
 		for id, status := range registry.Status() {
 			if !status.Tier.IsReady() {
-				slog.Error(
+				slog.ErrorContext(
+					ctx,
 					"subsystem not ready",
 					"subsystem", id.String(),
 					"tier", status.Tier.String(),
@@ -1066,7 +1068,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		return oops.Code("CONTROL_SERVER_START_FAILED").With("addr", cfg.ControlAddr).Wrap(err)
 	}
 	go monitorServerErrors(ctx, cancel, controlErrChan, "control-grpc")
-	slog.Info("control gRPC server started", "addr", cfg.ControlAddr)
+	slog.InfoContext(ctx, "control gRPC server started", "addr", cfg.ControlAddr)
 
 	// --- 11. Signal handling ---
 	sigChan := make(chan os.Signal, 1)
@@ -1076,7 +1078,8 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	telemetry.EmitStartupSpan(ctx, "holomush-core", version, bootStart)
 
 	cmd.Println("Core process started")
-	slog.Info(
+	slog.InfoContext(
+		ctx,
 		"core process ready",
 		"game_id", gameID,
 		"grpc_addr", cfg.GRPCAddr,
@@ -1084,24 +1087,24 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 
 	select {
 	case sig := <-sigChan:
-		slog.Info("received shutdown signal", "signal", sig)
+		slog.InfoContext(ctx, "received shutdown signal", "signal", sig)
 	case <-ctx.Done():
-		slog.Info("context cancelled, shutting down")
+		slog.InfoContext(ctx, "context cancelled, shutting down")
 	}
 
 	// --- 12. Graceful shutdown ---
-	slog.Info("shutting down...")
+	slog.InfoContext(ctx, "shutting down...")
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 
 	if err := controlGRPCServer.Stop(shutdownCtx); err != nil {
-		slog.Warn("error stopping control gRPC server", "error", err)
+		slog.WarnContext(shutdownCtx, "error stopping control gRPC server", "error", err)
 	}
 
 	// Subsystem shutdown handled by deferred orch.StopAll above.
 
-	slog.Info("shutdown complete")
+	slog.InfoContext(ctx, "shutdown complete")
 	return nil
 }
 
@@ -1280,7 +1283,8 @@ func monitorServerErrors(ctx context.Context, cancel context.CancelFunc, errCh <
 			return
 		}
 		if err != nil {
-			slog.Error(
+			slog.ErrorContext(
+				ctx,
 				"server error, triggering shutdown",
 				"server", serverName,
 				"error", err,

--- a/cmd/holomush/crypto_operator_validation.go
+++ b/cmd/holomush/crypto_operator_validation.go
@@ -72,7 +72,7 @@ func validateCryptoOperators(
 		// startup, or a closed pool in tests) MUST NOT gate startup.
 		// Surface the diagnostic but proceed with the full configured
 		// slice — operators can fix the underlying issue without bouncing.
-		logger.Warn("crypto.operator validation skipped: database query failed; will re-check at next startup",
+		logger.WarnContext(ctx, "crypto.operator validation skipped: database query failed; will re-check at next startup",
 			"error", err,
 			"configured_count", len(deduped))
 		return deduped, nil
@@ -84,7 +84,7 @@ func validateCryptoOperators(
 	}
 	for _, id := range deduped {
 		if _, ok := foundSet[id]; !ok {
-			logger.Warn("crypto.operator references unknown player", "player_id", id)
+			logger.WarnContext(ctx, "crypto.operator references unknown player", "player_id", id)
 		}
 	}
 	return deduped, nil

--- a/cmd/holomush/crypto_rekey_wiring.go
+++ b/cmd/holomush/crypto_rekey_wiring.go
@@ -355,7 +355,7 @@ func (a *productionRekeyAbortRunner) RunAbort(ctx context.Context, req socket.Re
 	if emitErr != nil {
 		// Non-fatal: abort is committed; audit emit is best-effort.
 		// Log loudly so an operator can investigate.
-		slog.Error("rekey abort audit emit failed", "request_id", rid.String(), "error", emitErr.Error())
+		slog.ErrorContext(ctx, "rekey abort audit emit failed", "request_id", rid.String(), "error", emitErr.Error())
 		auditID = ulid.ULID{}
 	}
 	return socket.RekeyAbortOutcome{

--- a/cmd/holomush/gateway.go
+++ b/cmd/holomush/gateway.go
@@ -198,7 +198,8 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 		}
 	}()
 
-	slog.Info(
+	slog.InfoContext(
+		ctx,
 		"starting gateway process",
 		"telnet_addr", cfg.TelnetAddr,
 		"core_addr", cfg.CoreAddr,
@@ -220,7 +221,7 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 		return err
 	}
 
-	slog.Info("TLS certificates loaded", "certs_dir", certsDir)
+	slog.InfoContext(ctx, "TLS certificates loaded", "certs_dir", certsDir)
 
 	// Create gRPC client with mTLS
 	grpcClient, err := deps.GRPCClientFactory(ctx, holoGRPC.ClientConfig{
@@ -232,11 +233,11 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 	}
 	defer func() {
 		if closeErr := grpcClient.Close(); closeErr != nil {
-			slog.Warn("error closing gRPC client", "error", closeErr)
+			slog.WarnContext(ctx, "error closing gRPC client", "error", closeErr)
 		}
 	}()
 
-	slog.Info("gRPC client created", "core_addr", cfg.CoreAddr)
+	slog.InfoContext(ctx, "gRPC client created", "core_addr", cfg.CoreAddr)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -252,7 +253,7 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 	// Monitor control server errors in background - triggers shutdown on error
 	go monitorServerErrors(ctx, cancel, controlErrChan, "control-grpc")
 
-	slog.Info("control gRPC server started", "addr", cfg.ControlAddr)
+	slog.InfoContext(ctx, "control gRPC server started", "addr", cfg.ControlAddr)
 
 	// TODO(grpc-telnet): Replace placeholder telnet handler with gRPC-based implementation.
 	// The current telnet server requires direct core components, which aren't available
@@ -263,12 +264,12 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		if stopErr := controlGRPCServer.Stop(shutdownCtx); stopErr != nil {
-			slog.Warn("failed to stop control gRPC server during cleanup", "error", stopErr)
+			slog.WarnContext(shutdownCtx, "failed to stop control gRPC server during cleanup", "error", stopErr)
 		}
 		return oops.Code("LISTEN_FAILED").With("operation", "listen").With("addr", cfg.TelnetAddr).Wrap(err)
 	}
 
-	slog.Info("telnet server listening", "addr", telnetListener.Addr())
+	slog.InfoContext(ctx, "telnet server listening", "addr", telnetListener.Addr())
 
 	// Start observability server if configured
 	var obsServer ObservabilityServer
@@ -286,18 +287,18 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 		obsErrChan, err = obsServer.Start()
 		if err != nil {
 			if closeErr := telnetListener.Close(); closeErr != nil {
-				slog.Warn("failed to close telnet listener during cleanup", "error", closeErr)
+				slog.WarnContext(ctx, "failed to close telnet listener during cleanup", "error", closeErr)
 			}
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer shutdownCancel()
 			if stopErr := controlGRPCServer.Stop(shutdownCtx); stopErr != nil {
-				slog.Warn("failed to stop control gRPC server during cleanup", "error", stopErr)
+				slog.WarnContext(shutdownCtx, "failed to stop control gRPC server during cleanup", "error", stopErr)
 			}
 			return oops.Code("OBSERVABILITY_START_FAILED").With("operation", "start observability server").With("addr", cfg.MetricsAddr).Wrap(err)
 		}
 		// Monitor observability server errors in background - triggers shutdown on error
 		go monitorServerErrors(ctx, cancel, obsErrChan, "observability")
-		slog.Info("observability server started", "addr", obsServer.Addr())
+		slog.InfoContext(ctx, "observability server started", "addr", obsServer.Addr())
 	}
 
 	// Start web HTTP server. The gateway is a protocol-translation layer
@@ -326,16 +327,16 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer shutdownCancel()
 			if stopErr := obsServer.Stop(shutdownCtx); stopErr != nil {
-				slog.Warn("failed to stop observability server during cleanup", "error", stopErr)
+				slog.WarnContext(shutdownCtx, "failed to stop observability server during cleanup", "error", stopErr)
 			}
 		}
 		if closeErr := telnetListener.Close(); closeErr != nil {
-			slog.Warn("failed to close telnet listener during cleanup", "error", closeErr)
+			slog.WarnContext(ctx, "failed to close telnet listener during cleanup", "error", closeErr)
 		}
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		if stopErr := controlGRPCServer.Stop(shutdownCtx); stopErr != nil {
-			slog.Warn("failed to stop control gRPC server during cleanup", "error", stopErr)
+			slog.WarnContext(shutdownCtx, "failed to stop control gRPC server during cleanup", "error", stopErr)
 		}
 		return oops.Code("WEB_SERVER_START_FAILED").With("operation", "start web HTTP server").With("addr", cfg.WebAddr).Wrap(err)
 	}
@@ -360,7 +361,8 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 	telemetry.EmitStartupSpan(ctx, "holomush-gateway", version, bootStart)
 
 	cmd.Println("Gateway process started")
-	slog.Info(
+	slog.InfoContext(
+		ctx,
 		"gateway process ready",
 		"telnet_addr", telnetListener.Addr().String(),
 		"core_addr", cfg.CoreAddr,
@@ -370,17 +372,17 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 	// Wait for shutdown signal
 	select {
 	case sig := <-sigChan:
-		slog.Info("received shutdown signal", "signal", sig)
+		slog.InfoContext(ctx, "received shutdown signal", "signal", sig)
 	case <-ctx.Done():
-		slog.Info("context cancelled, shutting down")
+		slog.InfoContext(ctx, "context cancelled, shutting down")
 	}
 
 	// Graceful shutdown
-	slog.Info("shutting down...")
+	slog.InfoContext(ctx, "shutting down...")
 
 	// Close telnet listener
 	if err := telnetListener.Close(); err != nil {
-		slog.Warn("error closing telnet listener", "error", err)
+		slog.WarnContext(ctx, "error closing telnet listener", "error", err)
 	}
 
 	// Stop servers
@@ -389,21 +391,21 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 
 	// Stop web HTTP server
 	if err := webServer.Stop(shutdownCtx); err != nil {
-		slog.Warn("error stopping web HTTP server", "error", err)
+		slog.WarnContext(shutdownCtx, "error stopping web HTTP server", "error", err)
 	}
 
 	if obsServer != nil {
 		if err := obsServer.Stop(shutdownCtx); err != nil {
-			slog.Warn("error stopping observability server", "error", err)
+			slog.WarnContext(shutdownCtx, "error stopping observability server", "error", err)
 		}
 	}
 
 	// Stop control gRPC server
 	if err := controlGRPCServer.Stop(shutdownCtx); err != nil {
-		slog.Warn("error stopping control gRPC server", "error", err)
+		slog.WarnContext(shutdownCtx, "error stopping control gRPC server", "error", err)
 	}
 
-	slog.Info("shutdown complete")
+	slog.InfoContext(ctx, "shutdown complete")
 	return nil
 }
 
@@ -488,7 +490,8 @@ func runTelnetAcceptLoop(
 
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error(
+			slog.ErrorContext(
+				ctx,
 				"panic in telnet accept loop, triggering shutdown",
 				"panic", r,
 			)
@@ -507,7 +510,8 @@ func runTelnetAcceptLoop(
 			default:
 				backoff.failure()
 				waitDuration := backoff.wait()
-				slog.Error(
+				slog.ErrorContext(
+					ctx,
 					"telnet accept failed, backing off",
 					"error", acceptErr,
 					"backoff", waitDuration,

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -160,7 +160,7 @@ func (s *grpcSubsystem) DependsOn() []lifecycle.SubsystemID {
 // Start wires all dependencies and starts the gRPC server.
 // Start is idempotent: if the gRPC server is already running, it returns nil.
 // codecov:ignore — tested by integration and E2E tests
-func (s *grpcSubsystem) Start(_ context.Context) error {
+func (s *grpcSubsystem) Start(ctx context.Context) error {
 	if s.grpcServer != nil {
 		return nil // already started
 	}
@@ -282,9 +282,9 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	// 6. Remove disabled commands from registry.
 	for _, name := range s.cfg.GameConfig.DisabledCommands {
 		if unregErr := cmdRegistry.Unregister(name); unregErr != nil {
-			slog.Warn("disabled command not found in registry", "command", name)
+			slog.WarnContext(ctx, "disabled command not found in registry", "command", name)
 		} else {
-			slog.Warn("disabled built-in command", "command", name)
+			slog.WarnContext(ctx, "disabled built-in command", "command", name)
 		}
 	}
 
@@ -347,19 +347,19 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 		auditEm, auditErr := authguardaudit.NewQueuedEmitter(publisher,
 			authguardaudit.WithGameID(s.cfg.EventBus.GameID()))
 		if auditErr != nil {
-			slog.Warn("history auth guard: audit emitter construction failed — INV-39 fallback disabled",
+			slog.WarnContext(ctx, "history auth guard: audit emitter construction failed — INV-39 fallback disabled",
 				"error", auditErr)
 		} else {
 			sessionBridgeEm, bridgeErr := authguardaudit.NewSessionBridgeEmitter(auditEm)
 			if bridgeErr != nil {
-				slog.Warn("history auth guard: session bridge emitter construction failed — INV-39 fallback disabled",
+				slog.WarnContext(ctx, "history auth guard: session bridge emitter construction failed — INV-39 fallback disabled",
 					"error", bridgeErr)
 			} else {
 				participantLookup := authguard.NewDEKParticipantLookup(s.cfg.RekeyManager)
 				manifestLookup := authguard.NewPluginManifestLookup(pluginManager)
 				guard, guardErr := authguard.New(participantLookup, manifestLookup, policyEngine, auditEm)
 				if guardErr != nil {
-					slog.Warn("history auth guard: guard construction failed — INV-39 fallback disabled",
+					slog.WarnContext(ctx, "history auth guard: guard construction failed — INV-39 fallback disabled",
 						"error", guardErr)
 				} else {
 					historyAuthGuard = authguard.NewSessionBridgeGuard(guard)
@@ -486,7 +486,8 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 				ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID,
 			}
 			if dcErr := engine.HandleDisconnect(reaperCtx, char, "session expired"); dcErr != nil {
-				slog.Warn(
+				slog.WarnContext(
+					reaperCtx,
 					"reaper: leave event failed",
 					"session_id", info.ID,
 					"error", dcErr,
@@ -495,7 +496,7 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 			if endErr := engine.EndSession(reaperCtx, char, info.ID,
 				core.SessionEndedCauseReaped,
 				"Session expired due to inactivity."); endErr != nil {
-				slog.Warn("reaper: session_ended event failed",
+				slog.WarnContext(reaperCtx, "reaper: session_ended event failed",
 					"session_id", info.ID, "error", endErr)
 			}
 			if info.IsGuest {
@@ -520,10 +521,10 @@ func (s *grpcSubsystem) Start(_ context.Context) error {
 	}
 
 	// 13. Start grpcServer.Serve() in goroutine.
-	slog.Info("gRPC server listening", "addr", s.cfg.GRPCAddr)
+	slog.InfoContext(ctx, "gRPC server listening", "addr", s.cfg.GRPCAddr)
 	go func() {
 		if serveErr := s.grpcServer.Serve(s.listener); serveErr != nil {
-			slog.Error("gRPC server stopped", "error", serveErr)
+			slog.ErrorContext(ctx, "gRPC server stopped", "error", serveErr)
 		}
 	}()
 
@@ -544,7 +545,7 @@ func (s *grpcSubsystem) Stop(ctx context.Context) error {
 		case <-done:
 			// graceful shutdown completed
 		case <-ctx.Done():
-			slog.Warn("gRPC graceful shutdown timed out, forcing stop")
+			slog.WarnContext(ctx, "gRPC graceful shutdown timed out, forcing stop")
 			s.grpcServer.Stop()
 		}
 	}
@@ -553,7 +554,7 @@ func (s *grpcSubsystem) Stop(ctx context.Context) error {
 	}
 	if s.listener != nil {
 		if err := s.listener.Close(); err != nil {
-			slog.Debug("error closing gRPC listener", "error", err)
+			slog.DebugContext(ctx, "error closing gRPC listener", "error", err)
 		}
 	}
 	return nil

--- a/internal/access/policy/bootstrap.go
+++ b/internal/access/policy/bootstrap.go
@@ -40,7 +40,7 @@ func Bootstrap(
 	if err := partitions.EnsurePartitions(ctx, 3); err != nil {
 		return oops.Errorf("bootstrap: failed to create audit log partitions: %w", err)
 	}
-	logger.Info("audit log partitions ensured", "months", 3)
+	logger.InfoContext(ctx, "audit log partitions ensured", "months", 3)
 
 	// Step 2: Seed policies.
 	seeds := SeedPolicies()
@@ -52,7 +52,7 @@ func Bootstrap(
 		}
 	}
 
-	logger.Info("bootstrap complete", "seeds_total", len(seeds))
+	logger.InfoContext(ctx, "bootstrap complete", "seeds_total", len(seeds))
 	return nil
 }
 
@@ -78,7 +78,8 @@ func bootstrapSeed(
 
 	// Policy exists with different source — admin collision, skip with warning.
 	if existing.Source != "seed" {
-		logger.Warn(
+		logger.WarnContext(
+			ctx,
 			"seed policy name collision with non-seed policy, skipping",
 			"name", seed.Name,
 			"existing_source", existing.Source,
@@ -91,7 +92,8 @@ func bootstrapSeed(
 		return upgradeSeedPolicy(ctx, policyStore, compiler, logger, seed, existing)
 	}
 
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"seed policy already current, skipping",
 		"name", seed.Name,
 		"version", seed.SeedVersion,
@@ -134,7 +136,7 @@ func createSeedPolicy(
 		return fmt.Errorf("creating seed policy %q: %w", seed.Name, err)
 	}
 
-	logger.Info("seed policy created", "name", seed.Name, "version", seed.SeedVersion)
+	logger.InfoContext(ctx, "seed policy created", "name", seed.Name, "version", seed.SeedVersion)
 	return nil
 }
 
@@ -174,7 +176,8 @@ func upgradeSeedPolicy(
 		return fmt.Errorf("upgrading seed policy %q: %w", seed.Name, err)
 	}
 
-	logger.Info(
+	logger.InfoContext(
+		ctx,
 		"seed policy upgraded",
 		"name", seed.Name,
 		"from_version", oldVersion,
@@ -213,7 +216,8 @@ func UpdateSeed(
 
 	// Compare-and-swap: skip with warning if admin customized.
 	if existing.DSLText != oldDSL {
-		logger.Warn(
+		logger.WarnContext(
+			ctx,
 			"seed policy customized by admin, skipping migration update",
 			"name", name,
 			"expected_dsl_prefix", truncate(oldDSL, 60),
@@ -242,7 +246,7 @@ func UpdateSeed(
 		return fmt.Errorf("UpdateSeed: updating %q: %w", name, err)
 	}
 
-	logger.Info("seed policy updated via migration", "name", name, "change_note", changeNote)
+	logger.InfoContext(ctx, "seed policy updated via migration", "name", name, "change_note", changeNote)
 	return nil
 }
 

--- a/internal/access/setup/setup.go
+++ b/internal/access/setup/setup.go
@@ -267,7 +267,7 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 
 	// 14. Replay WAL (non-fatal)
 	if err := auditLogger.ReplayWAL(ctx); err != nil {
-		slog.Warn("audit WAL replay failed (non-fatal)", "error", err)
+		slog.WarnContext(ctx, "audit WAL replay failed (non-fatal)", "error", err)
 	}
 
 	// 15. Session resolver (no-op — fails closed)
@@ -297,11 +297,11 @@ func BuildABACStack(ctx context.Context, cfg ABACConfig) (*ABACStack, error) {
 
 	// 18. Wire store → cache invalidation (fast path).
 	// Use a detached context so invalidation isn't cancelled if the request context expires.
-	ps.SetOnMutate(func(_ context.Context) {
+	ps.SetOnMutate(func(ctx context.Context) {
 		invalidateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := cache.Invalidate(invalidateCtx); err != nil {
-			slog.Error("cache invalidation after store mutation failed",
+			slog.ErrorContext(ctx, "cache invalidation after store mutation failed",
 				"error", err)
 			healthTracker.RecordFailure("invalidation failed: " + err.Error())
 		} else {

--- a/internal/access/setup/subsystem.go
+++ b/internal/access/setup/subsystem.go
@@ -103,7 +103,7 @@ func (s *ABACSubsystem) Start(ctx context.Context) error {
 	s.pollerCancel = pollerCancel
 	go stack.Poller.Run(pollerCtx)
 
-	slog.Info("ABAC subsystem started")
+	slog.InfoContext(ctx, "ABAC subsystem started")
 	return nil
 }
 

--- a/internal/admin/socket/server.go
+++ b/internal/admin/socket/server.go
@@ -124,7 +124,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		s.httpServer = nil
 	}
 	if rmErr := os.Remove(s.cfg.SocketPath); rmErr != nil && !os.IsNotExist(rmErr) {
-		slog.Warn("admin: failed to remove admin.sock", "path", s.cfg.SocketPath, "error", rmErr)
+		slog.WarnContext(ctx, "admin: failed to remove admin.sock", "path", s.cfg.SocketPath, "error", rmErr)
 	}
 	if s.lockFile != nil {
 		_ = s.lockFile.Close() //nolint:errcheck // best-effort release; flock is dropped when fd closes

--- a/internal/admin/socket/subsystem.go
+++ b/internal/admin/socket/subsystem.go
@@ -70,9 +70,9 @@ func (s *AdminSocketSubsystem) DependsOn() []lifecycle.SubsystemID {
 // startup), Start is a no-op: the admin socket is disabled but the server
 // continues serving normally.
 // codecov:ignore — tested by integration and E2E tests
-func (s *AdminSocketSubsystem) Start(_ context.Context) error {
+func (s *AdminSocketSubsystem) Start(ctx context.Context) error {
 	if s.cfg.SocketPath == "" {
-		slog.Warn("admin socket subsystem: disabled — no socket path configured; break-glass unavailable")
+		slog.WarnContext(ctx, "admin socket subsystem: disabled — no socket path configured; break-glass unavailable")
 		return nil
 	}
 	srv := NewServer(Config{

--- a/internal/admin/totp_audit/auditing.go
+++ b/internal/admin/totp_audit/auditing.go
@@ -66,26 +66,26 @@ func NewAuditingService(
 func (a *AuditingService) emit(ctx context.Context, subjectStr, eventTypeStr string, payload any) {
 	body, err := json.Marshal(payload)
 	if err != nil {
-		a.logger.Warn("totp_audit: payload marshal failed; emit skipped",
+		a.logger.WarnContext(ctx, "totp_audit: payload marshal failed; emit skipped",
 			"event_type", eventTypeStr, "subject", subjectStr, "error", err)
 		return
 	}
 	subj, err := eventbus.NewSubject(subjectStr)
 	if err != nil {
-		a.logger.Warn("totp_audit: invalid subject; emit skipped",
+		a.logger.WarnContext(ctx, "totp_audit: invalid subject; emit skipped",
 			"subject", subjectStr, "error", err)
 		return
 	}
 	evtType, err := eventbus.NewType(eventTypeStr)
 	if err != nil {
-		a.logger.Warn("totp_audit: invalid event type; emit skipped",
+		a.logger.WarnContext(ctx, "totp_audit: invalid event type; emit skipped",
 			"event_type", eventTypeStr, "error", err)
 		return
 	}
 	ev := eventbus.NewEvent(subj, evtType, eventbus.Actor{Kind: eventbus.ActorKindSystem}, body)
 	ev.Timestamp = a.clock.Now() // honour the injected clock rather than time.Now() inside NewEvent
 	if err := a.pub.Publish(ctx, ev); err != nil {
-		a.logger.Warn("totp_audit: Publish failed; audit event lost (informational, INV-D14)",
+		a.logger.WarnContext(ctx, "totp_audit: Publish failed; audit event lost (informational, INV-D14)",
 			"event_type", eventTypeStr, "subject", subjectStr, "publish_error", err)
 	}
 }

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -164,7 +164,8 @@ func (l *Logger) Log(ctx context.Context, event Event) error {
 			// Fallback to WAL
 			if walErr := l.writeToWAL(event); walErr != nil {
 				// Both failed - log error and return it to the caller
-				slog.Error(
+				slog.ErrorContext(
+					ctx,
 					"audit write failed: both DB and WAL failed",
 					"db_error", err,
 					"wal_error", walErr,
@@ -183,7 +184,8 @@ func (l *Logger) Log(ctx context.Context, event Event) error {
 					Errorf("audit write failed: both DB and WAL failed")
 			}
 			// WAL succeeded but primary DB failed — log degraded state
-			slog.Warn(
+			slog.WarnContext(
+				ctx,
 				"audit DB write failed, fell back to WAL",
 				"db_error", err,
 				"subject", event.Subject,
@@ -214,7 +216,8 @@ func (l *Logger) Log(ctx context.Context, event Event) error {
 		// Channel full - drop event, increment metric, and return error so
 		// engine callers can track audit loss via RecordEngineAuditFailure.
 		channelFullCounter.Inc()
-		slog.Warn(
+		slog.WarnContext(
+			ctx,
 			"audit channel full: dropping async event",
 			"subject", event.Subject,
 			"action", event.Action,
@@ -282,7 +285,7 @@ func (l *Logger) asyncConsumer() {
 					"error", err,
 					"subject", event.Subject,
 					"action", event.Action,
-					"source", event.Source,
+					"event_source", event.Source,
 					"component", event.Component,
 				)
 				failuresCounter.WithLabelValues("async_write_failed").Inc()
@@ -396,7 +399,7 @@ func (l *Logger) ReplayWAL(ctx context.Context) error {
 
 		var event Event
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			slog.Error("failed to unmarshal WAL event", "error", err, "line", line)
+			slog.ErrorContext(ctx, "failed to unmarshal WAL event", "error", err, "line", line)
 			failuresCounter.WithLabelValues("wal_unmarshal_failed").Inc()
 			// Keep the raw line so it is preserved for manual inspection.
 			failedLines = append(failedLines, line)
@@ -404,7 +407,7 @@ func (l *Logger) ReplayWAL(ctx context.Context) error {
 		}
 
 		if err := l.writer.WriteSync(ctx, event); err != nil {
-			slog.Error("failed to replay WAL event", "error", err, "event", event)
+			slog.ErrorContext(ctx, "failed to replay WAL event", "error", err, "event", event)
 			failuresCounter.WithLabelValues("wal_replay_failed").Inc()
 			// Re-marshal so the event is preserved in the WAL for retry.
 			if raw, merr := json.Marshal(event); merr == nil {
@@ -432,7 +435,7 @@ func (l *Logger) ReplayWAL(ctx context.Context) error {
 			return oops.With("path", l.walPath).Wrap(rerr)
 		}
 		walEntriesGauge.Set(float64(len(failedLines)))
-		slog.Warn("partially replayed WAL entries; WAL rewritten with failed entries",
+		slog.WarnContext(ctx, "partially replayed WAL entries; WAL rewritten with failed entries",
 			"replayed", replayed, "failed", len(failedLines))
 		return &PartialReplayError{FailedCount: len(failedLines), TotalCount: replayed + len(failedLines), ReplayedCount: replayed}
 	}
@@ -443,7 +446,7 @@ func (l *Logger) ReplayWAL(ctx context.Context) error {
 	}
 
 	walEntriesGauge.Set(0)
-	slog.Info("replayed WAL entries", "count", replayed)
+	slog.InfoContext(ctx, "replayed WAL entries", "count", replayed)
 	return nil
 }
 

--- a/internal/audit/postgres.go
+++ b/internal/audit/postgres.go
@@ -114,7 +114,7 @@ func (w *PostgresWriter) batchConsumer() {
 		defer cancel()
 
 		if err := w.writeBatch(ctx, batch); err != nil {
-			slog.Error("failed to write audit batch", "error", err, "count", len(batch))
+			slog.ErrorContext(ctx, "failed to write audit batch", "error", err, "count", len(batch))
 			failuresCounter.WithLabelValues("batch_write_failed").Inc()
 		}
 
@@ -180,7 +180,7 @@ func (w *PostgresWriter) writeBatch(ctx context.Context, events []Event) error {
 		event := &events[i]
 		attributesJSON, err := json.Marshal(event.Attributes)
 		if err != nil {
-			slog.Error("failed to marshal attributes", "error", err, "event", event)
+			slog.ErrorContext(ctx, "failed to marshal attributes", "error", err, "event", event)
 			continue
 		}
 
@@ -201,7 +201,7 @@ func (w *PostgresWriter) writeBatch(ctx context.Context, events []Event) error {
 			event.Timestamp.UnixNano(), // pgnanos-exempt: SQL-cast boundary for BIGINT timestamp column
 		)
 		if err != nil {
-			slog.Error("failed to insert audit event", "error", err, "event", event)
+			slog.ErrorContext(ctx, "failed to insert audit event", "error", err, "event", event)
 			// Continue with other events
 		}
 	}

--- a/internal/audit/retention.go
+++ b/internal/audit/retention.go
@@ -66,35 +66,35 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 
 	// Ensure partitions exist for the next 3 months
 	if err := w.manager.EnsurePartitions(ctx, 3); err != nil {
-		w.logger.Error("ensure partitions failed", "error", err)
+		w.logger.ErrorContext(ctx, "ensure partitions failed", "error", err)
 		errs = append(errs, err)
 	}
 
 	// Purge expired allow records
 	purged, err := w.manager.PurgeExpiredAllows(ctx, now.Add(-w.cfg.RetainAllows))
 	if err != nil {
-		w.logger.Error("purge expired allows failed", "error", err)
+		w.logger.ErrorContext(ctx, "purge expired allows failed", "error", err)
 		errs = append(errs, err)
 	} else if purged > 0 {
-		w.logger.Info("purged expired allow records", "count", purged)
+		w.logger.InfoContext(ctx, "purged expired allow records", "count", purged)
 	}
 
 	// Detach expired partitions
 	detached, err := w.manager.DetachExpiredPartitions(ctx, now.Add(-w.cfg.RetainDenials))
 	if err != nil {
-		w.logger.Error("detach expired partitions failed", "error", err)
+		w.logger.ErrorContext(ctx, "detach expired partitions failed", "error", err)
 		errs = append(errs, err)
 	} else if len(detached) > 0 {
-		w.logger.Info("detached expired partitions", "partitions", detached)
+		w.logger.InfoContext(ctx, "detached expired partitions", "partitions", detached)
 	}
 
 	// Drop detached partitions after grace period
 	dropped, err := w.manager.DropDetachedPartitions(ctx, 7*24*time.Hour)
 	if err != nil {
-		w.logger.Error("drop detached partitions failed", "error", err)
+		w.logger.ErrorContext(ctx, "drop detached partitions failed", "error", err)
 		errs = append(errs, err)
 	} else if len(dropped) > 0 {
-		w.logger.Info("dropped detached partitions", "partitions", dropped)
+		w.logger.InfoContext(ctx, "dropped detached partitions", "partitions", dropped)
 	}
 
 	return errors.Join(errs...)
@@ -132,7 +132,7 @@ func (w *RetentionWorker) run(ctx context.Context) {
 
 	// Run once immediately
 	if err := w.RunOnce(ctx); err != nil {
-		w.logger.Error("retention cycle failed", "error", err)
+		w.logger.ErrorContext(ctx, "retention cycle failed", "error", err)
 	}
 
 	for {
@@ -141,7 +141,7 @@ func (w *RetentionWorker) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := w.RunOnce(ctx); err != nil {
-				w.logger.Error("retention cycle failed", "error", err)
+				w.logger.ErrorContext(ctx, "retention cycle failed", "error", err)
 			}
 		}
 	}

--- a/internal/auth/guest_service.go
+++ b/internal/auth/guest_service.go
@@ -153,7 +153,8 @@ func (s *GuestService) CreateGuest(ctx context.Context) (*GuestResult, error) {
 	// This is non-critical — guests can still log in even if this update fails.
 	player.DefaultCharacterID = &char.ID
 	if err = s.players.Update(ctx, player); err != nil {
-		slog.WarnContext(ctx,
+		slog.WarnContext(
+			ctx,
 			"guest_service: failed to set default character on guest player",
 			"player_id", player.ID.String(),
 			"character_id", char.ID.String(),

--- a/internal/auth/guest_service.go
+++ b/internal/auth/guest_service.go
@@ -153,7 +153,7 @@ func (s *GuestService) CreateGuest(ctx context.Context) (*GuestResult, error) {
 	// This is non-critical — guests can still log in even if this update fails.
 	player.DefaultCharacterID = &char.ID
 	if err = s.players.Update(ctx, player); err != nil {
-		slog.Warn(
+		slog.WarnContext(ctx,
 			"guest_service: failed to set default character on guest player",
 			"player_id", player.ID.String(),
 			"character_id", char.ID.String(),
@@ -193,7 +193,7 @@ func (s *GuestService) CreateGuest(ctx context.Context) (*GuestResult, error) {
 // cascaded dependents (characters, player_sessions via FK CASCADE).
 func (s *GuestService) cleanupGuestPlayer(ctx context.Context, playerID ulid.ULID) {
 	if err := s.players.Delete(ctx, playerID); err != nil {
-		slog.Warn("guest_service: failed to clean up orphaned guest player",
+		slog.WarnContext(ctx, "guest_service: failed to clean up orphaned guest player",
 			"player_id", playerID.String(), "error", err)
 	}
 }

--- a/internal/auth/registration.go
+++ b/internal/auth/registration.go
@@ -87,7 +87,7 @@ func (s *Service) ValidateCredentials(ctx context.Context, username, password st
 		if playerExists {
 			player.RecordFailure()
 			if err := s.players.Update(ctx, player); err != nil {
-				s.logger.Warn(
+				s.logger.WarnContext(ctx,
 					"best-effort player update failed",
 					"event", "player_update_failed",
 					"player_id", player.ID.String(),
@@ -110,7 +110,7 @@ func (s *Service) ValidateCredentials(ctx context.Context, username, password st
 	player.RecordSuccess()
 
 	if err := s.players.Update(ctx, player); err != nil {
-		s.logger.Warn(
+		s.logger.WarnContext(ctx,
 			"best-effort player update failed",
 			"event", "player_update_failed",
 			"player_id", player.ID.String(),

--- a/internal/auth/registration.go
+++ b/internal/auth/registration.go
@@ -87,7 +87,8 @@ func (s *Service) ValidateCredentials(ctx context.Context, username, password st
 		if playerExists {
 			player.RecordFailure()
 			if err := s.players.Update(ctx, player); err != nil {
-				s.logger.WarnContext(ctx,
+				s.logger.WarnContext(
+					ctx,
 					"best-effort player update failed",
 					"event", "player_update_failed",
 					"player_id", player.ID.String(),
@@ -110,7 +111,8 @@ func (s *Service) ValidateCredentials(ctx context.Context, username, password st
 	player.RecordSuccess()
 
 	if err := s.players.Update(ctx, player); err != nil {
-		s.logger.WarnContext(ctx,
+		s.logger.WarnContext(
+			ctx,
 			"best-effort player update failed",
 			"event", "player_update_failed",
 			"player_id", player.ID.String(),

--- a/internal/auth/reset_service.go
+++ b/internal/auth/reset_service.go
@@ -214,7 +214,8 @@ func (s *PasswordResetService) ResetPassword(ctx context.Context, token, newPass
 	// Tradeoff: failing here would leave the password updated but old sessions valid,
 	// which is arguably better than rolling back a successful password change.
 	if err := s.sessions.DeleteByPlayer(ctx, playerID); err != nil {
-		s.logger.WarnContext(ctx,
+		s.logger.WarnContext(
+			ctx,
 			"best-effort session invalidation failed",
 			"event", "session_invalidation_failed",
 			"player_id", playerID.String(),
@@ -227,7 +228,8 @@ func (s *PasswordResetService) ResetPassword(ctx context.Context, token, newPass
 	// already gone). Best-effort cleanup — failure here does not fail the
 	// reset, since the token actually used has been atomically consumed.
 	if err := s.resetRepo.DeleteByPlayer(ctx, playerID); err != nil {
-		s.logger.WarnContext(ctx,
+		s.logger.WarnContext(
+			ctx,
 			"best-effort token cleanup failed",
 			"event", "token_cleanup_failed",
 			"player_id", playerID.String(),

--- a/internal/auth/reset_service.go
+++ b/internal/auth/reset_service.go
@@ -214,7 +214,7 @@ func (s *PasswordResetService) ResetPassword(ctx context.Context, token, newPass
 	// Tradeoff: failing here would leave the password updated but old sessions valid,
 	// which is arguably better than rolling back a successful password change.
 	if err := s.sessions.DeleteByPlayer(ctx, playerID); err != nil {
-		s.logger.Warn(
+		s.logger.WarnContext(ctx,
 			"best-effort session invalidation failed",
 			"event", "session_invalidation_failed",
 			"player_id", playerID.String(),
@@ -227,7 +227,7 @@ func (s *PasswordResetService) ResetPassword(ctx context.Context, token, newPass
 	// already gone). Best-effort cleanup — failure here does not fail the
 	// reset, since the token actually used has been atomically consumed.
 	if err := s.resetRepo.DeleteByPlayer(ctx, playerID); err != nil {
-		s.logger.Warn(
+		s.logger.WarnContext(ctx,
 			"best-effort token cleanup failed",
 			"event", "token_cleanup_failed",
 			"player_id", playerID.String(),

--- a/internal/auth/setup/subsystem.go
+++ b/internal/auth/setup/subsystem.go
@@ -66,7 +66,7 @@ func (s *AuthSubsystem) DependsOn() []lifecycle.SubsystemID {
 // boot when admin handler construction needs Hasher() / AuthService()
 // before the orchestrator drives StartAll. Mirrors store.DatabaseSubsystem.Start.
 // codecov:ignore — tested by integration and E2E tests
-func (s *AuthSubsystem) Start(_ context.Context) error {
+func (s *AuthSubsystem) Start(ctx context.Context) error {
 	// Idempotency guard: only short-circuit if BOTH services are constructed.
 	// If a previous Start partially failed (e.g., resetSvc construction
 	// errored after authSvc was assigned), s.authService would be non-nil
@@ -103,7 +103,7 @@ func (s *AuthSubsystem) Start(_ context.Context) error {
 	s.authService = authSvc
 	s.resetService = resetSvc
 
-	slog.Info("auth subsystem started")
+	slog.InfoContext(ctx, "auth subsystem started")
 	return nil
 }
 

--- a/internal/bootstrap/admin.go
+++ b/internal/bootstrap/admin.go
@@ -50,7 +50,7 @@ func SeedAdmin(ctx context.Context, deps SeedAdminDeps) error {
 		return oops.Code("ADMIN_BOOTSTRAP_FAILED").Wrap(err)
 	}
 	if count > 0 {
-		slog.Debug("admin bootstrap skipped: players already exist", "count", count)
+		slog.DebugContext(ctx, "admin bootstrap skipped: players already exist", "count", count)
 		return nil
 	}
 
@@ -108,7 +108,7 @@ func SeedAdmin(ctx context.Context, deps SeedAdminDeps) error {
 		}
 	}
 
-	slog.Info( //nolint:gosec // G706: values from env vars or generated, not untrusted user input
+	slog.InfoContext(ctx,
 		"admin account created",
 		slog.String("username", username),
 		slog.String("character", charName),

--- a/internal/bootstrap/admin.go
+++ b/internal/bootstrap/admin.go
@@ -108,7 +108,8 @@ func SeedAdmin(ctx context.Context, deps SeedAdminDeps) error {
 		}
 	}
 
-	slog.InfoContext(ctx,
+	slog.InfoContext(
+		ctx,
 		"admin account created",
 		slog.String("username", username),
 		slog.String("character", charName),

--- a/internal/bootstrap/setup/subsystem.go
+++ b/internal/bootstrap/setup/subsystem.go
@@ -217,11 +217,11 @@ func (s *BootstrapSubsystem) Start(ctx context.Context) error {
 			return oops.Code("START_LOCATION_INVALID").With("value", locIDStr).Wrap(parseErr)
 		}
 		s.startLocationID = parsed
-		slog.Info("resolved starting location from bootstrap metadata", "id", locIDStr)
+		slog.InfoContext(ctx, "resolved starting location from bootstrap metadata", "id", locIDStr)
 	}
 
 	s.started = true
-	slog.Info("bootstrap subsystem started")
+	slog.InfoContext(ctx, "bootstrap subsystem started")
 	return nil
 }
 
@@ -248,7 +248,7 @@ func (s *BootstrapSubsystem) registerSettingBootstrapper(ctx context.Context, ru
 	mgr := s.cfg.Plugins.Manager()
 	discovered, err := mgr.Discover(ctx)
 	if err != nil {
-		slog.Warn("failed to discover setting plugins", "error", err)
+		slog.WarnContext(ctx, "failed to discover setting plugins", "error", err)
 		return nil
 	}
 
@@ -274,7 +274,7 @@ func (s *BootstrapSubsystem) registerSettingBootstrapper(ctx context.Context, ru
 				With("setting", s.cfg.Setting).
 				New("setting plugin not found and no active_setting recorded; cannot bootstrap world on first boot")
 		}
-		slog.Warn("setting plugin not found, skipping setting bootstrap (world already seeded)", "setting", s.cfg.Setting)
+		slog.WarnContext(ctx, "setting plugin not found, skipping setting bootstrap (world already seeded)", "setting", s.cfg.Setting)
 		return nil
 	}
 
@@ -290,7 +290,7 @@ func (s *BootstrapSubsystem) registerSettingBootstrapper(ctx context.Context, ru
 		PluginDir:     settingPlugin.Dir,
 		Logger:        slog.Default(),
 	}))
-	slog.Info("setting bootstrapper registered", "setting", s.cfg.Setting)
+	slog.InfoContext(ctx, "setting bootstrapper registered", "setting", s.cfg.Setting)
 
 	return nil
 }

--- a/internal/cluster/heartbeat.go
+++ b/internal/cluster/heartbeat.go
@@ -19,7 +19,7 @@ import (
 // Lock discipline: Start mutates the lifecycle state-machine fields
 // (subAlive/subBye/subProbe/subPoison/hbTicker/hbDone/evTicker/evDone)
 // under r.mu. Concurrent Stop() observes a consistent state.
-func (r *registry) Start(_ context.Context) error {
+func (r *registry) Start(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -86,7 +86,7 @@ func (r *registry) Start(_ context.Context) error {
 	r.wg.Add(1)
 	go r.runEvictionSweeper(r.evTicker, r.evDone)
 
-	r.deps.Logger.Info(
+	r.deps.Logger.InfoContext(ctx,
 		"cluster.Registry started",
 		"self", string(r.self),
 		"cluster_id", r.cfg.ClusterID,
@@ -106,7 +106,7 @@ func (r *registry) Start(_ context.Context) error {
 // progress (sweeper takes Lock; ticker's publishHeartbeatNow takes
 // RLock), so holding mu across Wait would deadlock. Phase 3 drains
 // subscriptions on the local copies (no shared-state access).
-func (r *registry) Stop(_ context.Context) error {
+func (r *registry) Stop(ctx context.Context) error {
 	// Phase 1 (locked): capture and clear lifecycle state.
 	r.mu.Lock()
 	if r.subAlive == nil {
@@ -166,7 +166,7 @@ func (r *registry) Stop(_ context.Context) error {
 		}
 	}
 
-	r.deps.Logger.Info("cluster.Registry stopped", "self", string(r.self))
+	r.deps.Logger.InfoContext(ctx, "cluster.Registry stopped", "self", string(r.self))
 	return nil
 }
 

--- a/internal/cluster/heartbeat.go
+++ b/internal/cluster/heartbeat.go
@@ -86,7 +86,8 @@ func (r *registry) Start(ctx context.Context) error {
 	r.wg.Add(1)
 	go r.runEvictionSweeper(r.evTicker, r.evDone)
 
-	r.deps.Logger.InfoContext(ctx,
+	r.deps.Logger.InfoContext(
+		ctx,
 		"cluster.Registry started",
 		"self", string(r.self),
 		"cluster_id", r.cfg.ClusterID,

--- a/internal/cluster/pill.go
+++ b/internal/cluster/pill.go
@@ -61,8 +61,8 @@ func NewProductionPill(self MemberID, logger *slog.Logger, metrics *PillMetrics)
 	}
 }
 
-func (p *productionPill) Trigger(_ context.Context, reason PillReason, sourceID MemberID) {
-	p.logger.Error(
+func (p *productionPill) Trigger(ctx context.Context, reason PillReason, sourceID MemberID) {
+	p.logger.ErrorContext(ctx,
 		"pill received; terminating",
 		"self", string(p.self),
 		"reason", string(reason),
@@ -112,8 +112,8 @@ func NewDevPill(self MemberID, logger *slog.Logger) Pill {
 	return &devPill{self: self, logger: logger}
 }
 
-func (p *devPill) Trigger(_ context.Context, reason PillReason, sourceID MemberID) {
-	p.logger.Error(
+func (p *devPill) Trigger(ctx context.Context, reason PillReason, sourceID MemberID) {
+	p.logger.ErrorContext(ctx,
 		"dev pill received",
 		"self", string(p.self),
 		"reason", string(reason),

--- a/internal/cluster/pill.go
+++ b/internal/cluster/pill.go
@@ -62,7 +62,8 @@ func NewProductionPill(self MemberID, logger *slog.Logger, metrics *PillMetrics)
 }
 
 func (p *productionPill) Trigger(ctx context.Context, reason PillReason, sourceID MemberID) {
-	p.logger.ErrorContext(ctx,
+	p.logger.ErrorContext(
+		ctx,
 		"pill received; terminating",
 		"self", string(p.self),
 		"reason", string(reason),
@@ -113,7 +114,8 @@ func NewDevPill(self MemberID, logger *slog.Logger) Pill {
 }
 
 func (p *devPill) Trigger(ctx context.Context, reason PillReason, sourceID MemberID) {
-	p.logger.ErrorContext(ctx,
+	p.logger.ErrorContext(
+		ctx,
 		"dev pill received",
 		"self", string(p.self),
 		"reason", string(reason),

--- a/internal/cluster/probe_pill.go
+++ b/internal/cluster/probe_pill.go
@@ -59,7 +59,8 @@ func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillRea
 	// to ProbeAndPill". The Warn log below is sufficient for
 	// fire-as-bug alerting.
 	if id == r.self {
-		r.deps.Logger.WarnContext(ctx,
+		r.deps.Logger.WarnContext(
+			ctx,
 			"cluster.ProbeAndPill self-pill refused (INV-60)",
 			"self", string(r.self),
 			"reason", string(reason),
@@ -103,7 +104,8 @@ func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillRea
 		if reply, perr := UnmarshalProbeReply(msg.Data); perr == nil {
 			r.updateMemberFromProbeReply(id, reply)
 		} else {
-			r.deps.Logger.WarnContext(ctx,
+			r.deps.Logger.WarnContext(
+				ctx,
 				"probe reply parse failed",
 				"target", string(id),
 				"err", perr.Error(),
@@ -179,7 +181,8 @@ func (r *registry) issuePill(ctx context.Context, id MemberID, reason PillReason
 	r.mu.Unlock()
 	r.notifyLeft(id, LeaveReasonPilled)
 
-	r.deps.Logger.WarnContext(ctx,
+	r.deps.Logger.WarnContext(
+		ctx,
 		"cluster pill issued",
 		"self", string(r.self),
 		"target", string(id),

--- a/internal/cluster/probe_pill.go
+++ b/internal/cluster/probe_pill.go
@@ -59,7 +59,7 @@ func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillRea
 	// to ProbeAndPill". The Warn log below is sufficient for
 	// fire-as-bug alerting.
 	if id == r.self {
-		r.deps.Logger.Warn(
+		r.deps.Logger.WarnContext(ctx,
 			"cluster.ProbeAndPill self-pill refused (INV-60)",
 			"self", string(r.self),
 			"reason", string(reason),
@@ -103,7 +103,7 @@ func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillRea
 		if reply, perr := UnmarshalProbeReply(msg.Data); perr == nil {
 			r.updateMemberFromProbeReply(id, reply)
 		} else {
-			r.deps.Logger.Warn(
+			r.deps.Logger.WarnContext(ctx,
 				"probe reply parse failed",
 				"target", string(id),
 				"err", perr.Error(),
@@ -148,14 +148,14 @@ func (r *registry) updateMemberFromProbeReply(id MemberID, reply ProbeReplyPaylo
 }
 
 // issuePill publishes the poison pill, evicts synchronously, and
-// notifies LeaveReasonPilled subscribers. The ctx parameter is
-// currently unused — pill publish is fire-and-forget per Decision 2 in
-// the Phase 3c grounding doc, and the rate-limit timestamp was already
-// claimed in probeAndPill. Honoring ctx for the publish would require
-// switching from Conn.Publish (fire-and-forget) to a flush-with-context
-// idiom; deferred until a caller demonstrably needs cancellation
-// during the publish itself.
-func (r *registry) issuePill(_ context.Context, id MemberID, reason PillReason) error {
+// notifies LeaveReasonPilled subscribers. The ctx parameter carries
+// trace context for the log call only — the pill publish itself remains
+// fire-and-forget per Decision 2 in the Phase 3c grounding doc, and the
+// rate-limit timestamp was already claimed in probeAndPill. Honoring ctx
+// for the publish would require switching from Conn.Publish
+// (fire-and-forget) to a flush-with-context idiom; deferred until a
+// caller demonstrably needs cancellation during the publish itself.
+func (r *registry) issuePill(ctx context.Context, id MemberID, reason PillReason) error {
 	p := PoisonPayload{
 		ClusterID:           r.cfg.ClusterID,
 		CoordinatorMemberID: r.self,
@@ -179,7 +179,7 @@ func (r *registry) issuePill(_ context.Context, id MemberID, reason PillReason) 
 	r.mu.Unlock()
 	r.notifyLeft(id, LeaveReasonPilled)
 
-	r.deps.Logger.Warn(
+	r.deps.Logger.WarnContext(ctx,
 		"cluster pill issued",
 		"self", string(r.self),
 		"target", string(id),

--- a/internal/command/access.go
+++ b/internal/command/access.go
@@ -44,7 +44,8 @@ func CheckCommandExecution(ctx context.Context, engine types.AccessPolicyEngine,
 
 	if !decision.IsAllowed() {
 		if decision.IsInfraFailure() {
-			slog.ErrorContext(ctx, cmdName+" command access infra failure",
+			slog.ErrorContext(ctx, "command access infra failure",
+				"command", cmdName,
 				"subject", subject,
 				"reason", decision.Reason(),
 				"policy_id", decision.PolicyID())
@@ -55,7 +56,8 @@ func CheckCommandExecution(ctx context.Context, engine types.AccessPolicyEngine,
 				With("policy_id", decision.PolicyID()).
 				Wrap(ErrCapabilityCheckFailed)
 		}
-		slog.DebugContext(ctx, cmdName+" command execution denied",
+		slog.DebugContext(ctx, "command execution denied",
+			"command", cmdName,
 			"subject", subject,
 			"reason", decision.Reason(),
 			"policy_id", decision.PolicyID())
@@ -78,7 +80,8 @@ func CheckCapabilityPreFlight(ctx context.Context, engine types.AccessPolicyEngi
 				Wrap(err)
 		}
 		if !allowed {
-			slog.DebugContext(ctx, cmdName+" capability pre-flight denied",
+			slog.DebugContext(ctx, "capability pre-flight denied",
+				"command", cmdName,
 				"subject", subject,
 				"action", capability.Action,
 				"resource", capability.Resource,

--- a/internal/command/handlers/shutdown.go
+++ b/internal/command/handlers/shutdown.go
@@ -42,7 +42,8 @@ func ShutdownHandler(ctx context.Context, exec *command.CommandExecution) error 
 	exec.Services().BroadcastSystemMessage(ctx, "system", message)
 
 	// Log admin action
-	slog.Info(
+	slog.InfoContext(
+		ctx,
 		"admin shutdown",
 		"admin_id", exec.CharacterID().String(),
 		"admin_name", exec.CharacterName(),

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -621,7 +621,7 @@ func NewServices(cfg ServicesConfig) (*Services, error) {
 // If the event store is nil, this method logs a debug message and returns.
 func (s *Services) BroadcastSystemMessage(ctx context.Context, stream, message string) {
 	if s.events == nil {
-		slog.Debug("BroadcastSystemMessage: event store not configured")
+		slog.DebugContext(ctx, "broadcastSystemMessage: event store not configured")
 		return
 	}
 
@@ -636,7 +636,7 @@ func (s *Services) BroadcastSystemMessage(ctx context.Context, stream, message s
 	}, payload)
 
 	if err := s.events.Append(ctx, event); err != nil {
-		slog.WarnContext(ctx, "BroadcastSystemMessage: failed to append event",
+		slog.WarnContext(ctx, "broadcastSystemMessage: failed to append event",
 			"stream", stream, "error", err)
 	}
 }

--- a/internal/control/grpc_server.go
+++ b/internal/control/grpc_server.go
@@ -120,7 +120,8 @@ func (s *GRPCServer) Stop(_ context.Context) error {
 
 // Shutdown implements the Control.Shutdown RPC.
 func (s *GRPCServer) Shutdown(ctx context.Context, req *controlv1.ShutdownRequest) (*controlv1.ShutdownResponse, error) {
-	slog.InfoContext(ctx,
+	slog.InfoContext(
+		ctx,
 		"shutdown requested via gRPC",
 		"component", s.component,
 		"graceful", req.Graceful,

--- a/internal/control/grpc_server.go
+++ b/internal/control/grpc_server.go
@@ -119,8 +119,8 @@ func (s *GRPCServer) Stop(_ context.Context) error {
 }
 
 // Shutdown implements the Control.Shutdown RPC.
-func (s *GRPCServer) Shutdown(_ context.Context, req *controlv1.ShutdownRequest) (*controlv1.ShutdownResponse, error) {
-	slog.Info(
+func (s *GRPCServer) Shutdown(ctx context.Context, req *controlv1.ShutdownRequest) (*controlv1.ShutdownResponse, error) {
+	slog.InfoContext(ctx,
 		"shutdown requested via gRPC",
 		"component", s.component,
 		"graceful", req.Graceful,

--- a/internal/eventbus/audit/chain/verifier_subsystem.go
+++ b/internal/eventbus/audit/chain/verifier_subsystem.go
@@ -82,7 +82,7 @@ func (s *VerifierSubsystem) Start(ctx context.Context) error {
 		}
 	}
 	for _, h := range s.cfg.Handlers {
-		s.cfg.Logger.Info("verifying audit chain", "chain", h.Chain.SubjectPrefix)
+		s.cfg.Logger.InfoContext(ctx, "verifying audit chain", "chain", h.Chain.SubjectPrefix)
 		if err := s.verifier.VerifyAll(ctx, h); err != nil {
 			return err //nolint:wrapcheck // AUDIT_CHAIN_* oops codes pass through from Verifier as-is
 		}

--- a/internal/eventbus/crypto/dek/sweep.go
+++ b/internal/eventbus/crypto/dek/sweep.go
@@ -121,7 +121,7 @@ func (s *CheckpointSweepSubsystem) loop(ctx context.Context) {
 			return
 		case <-t.C:
 			if err := s.sweepOnce(ctx); err != nil {
-				s.cfg.Logger.Error("rekey checkpoint sweep iteration failed", "err", err)
+				s.cfg.Logger.ErrorContext(ctx, "rekey checkpoint sweep iteration failed", "err", err)
 			}
 		}
 	}
@@ -137,7 +137,7 @@ func (s *CheckpointSweepSubsystem) sweepOnce(ctx context.Context) error {
 	}
 	for i := range expired {
 		if aerr := s.abortAndAudit(ctx, expired[i], "ttl_expired"); aerr != nil {
-			s.cfg.Logger.Error("rekey checkpoint sweep abort failed",
+			s.cfg.Logger.ErrorContext(ctx, "rekey checkpoint sweep abort failed",
 				"request_id", expired[i].RequestID.String(), "err", aerr)
 		}
 	}

--- a/internal/eventbus/crypto/invalidation/coordinator.go
+++ b/internal/eventbus/crypto/invalidation/coordinator.go
@@ -148,7 +148,8 @@ func (c *coordinator) RequestInvalidation(
 	}
 	if len(selfFiltered) == 0 && len(missing) > 0 {
 		// Only self was missing → SELF_TIMEOUT
-		c.deps.Logger.WarnContext(ctx,
+		c.deps.Logger.WarnContext(
+			ctx,
 			"invalidation: only Self() missing from acks; not pilling self",
 			"self", string(self),
 			"action", string(action),

--- a/internal/eventbus/crypto/invalidation/coordinator.go
+++ b/internal/eventbus/crypto/invalidation/coordinator.go
@@ -66,7 +66,7 @@ func (c *coordinator) timeoutFor(action Action) time.Duration {
 // Start subscribes to the cache_invalidate.dek.> wildcard and runs the
 // receive loop. Receive-side handler body lives in T10 (this commit
 // stubs the handler and lets Start succeed).
-func (c *coordinator) Start(_ context.Context) error {
+func (c *coordinator) Start(ctx context.Context) error {
 	if c.sub != nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (c *coordinator) Start(_ context.Context) error {
 		return oops.Code("INVALIDATION_SUBSCRIBE_FAILED").Wrap(err)
 	}
 	c.sub = sub
-	c.deps.Logger.Info("invalidation.Coordinator started", "cluster_id", c.cfg.ClusterID)
+	c.deps.Logger.InfoContext(ctx, "invalidation.Coordinator started", "cluster_id", c.cfg.ClusterID)
 	return nil
 }
 
@@ -148,7 +148,7 @@ func (c *coordinator) RequestInvalidation(
 	}
 	if len(selfFiltered) == 0 && len(missing) > 0 {
 		// Only self was missing → SELF_TIMEOUT
-		c.deps.Logger.Warn(
+		c.deps.Logger.WarnContext(ctx,
 			"invalidation: only Self() missing from acks; not pilling self",
 			"self", string(self),
 			"action", string(action),
@@ -287,7 +287,7 @@ func (c *coordinator) publishAndCollect(
 		}
 		reply, perr := UnmarshalReply(msg.Data)
 		if perr != nil {
-			c.deps.Logger.Warn("invalidation: parse reply failed", "err", perr.Error())
+			c.deps.Logger.WarnContext(ctx, "invalidation: parse reply failed", "err", perr.Error())
 			continue
 		}
 		if reply.Ack {

--- a/internal/eventbus/history/source/fallback.go
+++ b/internal/eventbus/history/source/fallback.go
@@ -76,7 +76,7 @@ func (r *FallbackResolver) Resolve(ctx context.Context, hot eventbus.Envelope) (
 	}
 	if !found {
 		r.Metrics.ColdDEKMiss.Inc()
-		r.Logger.Warn("event indecipherable: hot DEK destroyed, no cold-tier row",
+		r.Logger.WarnContext(ctx, "event indecipherable: hot DEK destroyed, no cold-tier row",
 			"event_id", hot.EventID().String(),
 			"hot_dek_ref", uint64(hot.KeyID()))
 		return ResolvedSource{}, ErrMetadataOnly

--- a/internal/grpc/auth_handlers.go
+++ b/internal/grpc/auth_handlers.go
@@ -701,7 +701,7 @@ func (s *CoreServer) CreateGuest(ctx context.Context, _ *corev1.CreateGuestReque
 
 	result, err := s.guestService.CreateGuest(ctx)
 	if err != nil {
-		slog.Error("grpc: guest creation failed", "error", err)
+		slog.ErrorContext(ctx, "grpc: guest creation failed", "error", err)
 		return &corev1.CreateGuestResponse{
 			Success:      false,
 			ErrorMessage: "guest creation failed",

--- a/internal/grpc/list_session_streams.go
+++ b/internal/grpc/list_session_streams.go
@@ -80,7 +80,7 @@ func (s *CoreServer) ListSessionStreams(ctx context.Context, req *corev1.ListSes
 		var planErr error
 		plan, planErr = s.focusCoordinator.RestoreFocus(ctx, req.SessionId)
 		if planErr != nil {
-			slog.WarnContext(ctx, "RestoreFocus failed, falling back to empty plan",
+			slog.WarnContext(ctx, "restoreFocus failed, falling back to empty plan",
 				"session_id", req.SessionId, "error", planErr)
 		}
 	}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -904,7 +904,7 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 		p, planErr := s.focusCoordinator.RestoreFocus(restoreCtx, req.SessionId)
 		if planErr != nil {
 			recordSpanError(restoreSpan, planErr)
-			slog.WarnContext(ctx, "RestoreFocus failed, falling back to empty plan",
+			slog.WarnContext(ctx, "restoreFocus failed, falling back to empty plan",
 				"session_id", req.SessionId, "error", planErr)
 		}
 		restoreSpan.SetAttributes(attribute.Int("restore.stream_count", len(p.Streams)))

--- a/internal/lifecycle/orchestrator.go
+++ b/internal/lifecycle/orchestrator.go
@@ -52,7 +52,7 @@ func (o *Orchestrator) StartAll(ctx context.Context) error {
 
 	for _, id := range order {
 		sub := o.subsystems[id]
-		slog.Info("starting subsystem", "subsystem", id.String())
+		slog.InfoContext(ctx, "starting subsystem", "subsystem", id.String())
 		start := time.Now()
 
 		if startErr := sub.Start(ctx); startErr != nil {
@@ -66,7 +66,7 @@ func (o *Orchestrator) StartAll(ctx context.Context) error {
 
 		o.startOrder = append(o.startOrder, id)
 
-		slog.Info(
+		slog.InfoContext(ctx,
 			"subsystem started",
 			"subsystem", id.String(),
 			"duration", time.Since(start).String(),
@@ -81,10 +81,10 @@ func (o *Orchestrator) StopAll(ctx context.Context) {
 	for i := len(o.startOrder) - 1; i >= 0; i-- {
 		id := o.startOrder[i]
 		sub := o.subsystems[id]
-		slog.Info("stopping subsystem", "subsystem", id.String())
+		slog.InfoContext(ctx, "stopping subsystem", "subsystem", id.String())
 
 		if err := sub.Stop(ctx); err != nil {
-			slog.Error(
+			slog.ErrorContext(ctx,
 				"subsystem stop error",
 				"subsystem", id.String(),
 				"error", err,

--- a/internal/lifecycle/orchestrator.go
+++ b/internal/lifecycle/orchestrator.go
@@ -66,7 +66,8 @@ func (o *Orchestrator) StartAll(ctx context.Context) error {
 
 		o.startOrder = append(o.startOrder, id)
 
-		slog.InfoContext(ctx,
+		slog.InfoContext(
+			ctx,
 			"subsystem started",
 			"subsystem", id.String(),
 			"duration", time.Since(start).String(),
@@ -84,7 +85,8 @@ func (o *Orchestrator) StopAll(ctx context.Context) {
 		slog.InfoContext(ctx, "stopping subsystem", "subsystem", id.String())
 
 		if err := sub.Stop(ctx); err != nil {
-			slog.ErrorContext(ctx,
+			slog.ErrorContext(
+				ctx,
 				"subsystem stop error",
 				"subsystem", id.String(),
 				"error", err,

--- a/internal/logging/sloglint_policy_test.go
+++ b/internal/logging/sloglint_policy_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package logging_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// repoRoot walks up from this test file to the directory containing go.mod.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, parent, dir, "reached filesystem root without finding go.mod")
+		dir = parent
+	}
+}
+
+// TestSloglintPolicyMatchesSpec guards against silent drift of the sloglint
+// Tier C policy (INV-LP1). If sloglint is disabled or a check is dropped, the
+// lint gate (INV-LP2) would go quiet rather than fail, so this test pins the
+// config shape. Rejected checks (INV-LP1, spec §3.2) MUST stay absent.
+func TestSloglintPolicyMatchesSpec(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), ".golangci.yaml"))
+	require.NoError(t, err)
+
+	var cfg struct {
+		Linters struct {
+			Enable   []string `yaml:"enable"`
+			Settings struct {
+				Sloglint map[string]any `yaml:"sloglint"`
+			} `yaml:"settings"`
+		} `yaml:"linters"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	assert.Contains(t, cfg.Linters.Enable, "sloglint", "sloglint must be enabled")
+
+	s := cfg.Linters.Settings.Sloglint
+	require.NotNil(t, s, "sloglint settings block must exist")
+	assert.Equal(t, "scope", s["context"])
+	assert.Equal(t, true, s["no-mixed-args"])
+	assert.Equal(t, true, s["static-msg"])
+	assert.Equal(t, "lowercased", s["msg-style"])
+	assert.Equal(t, "snake", s["key-naming-case"])
+	assert.ElementsMatch(t, []any{"time", "level", "msg", "source"}, s["forbidden-keys"])
+
+	// Rejected checks (spec §3.2) must not be enabled.
+	for _, k := range []string{"no-global", "attr-only", "no-raw-keys"} {
+		_, present := s[k]
+		assert.False(t, present, "rejected sloglint check %q must not be enabled", k)
+	}
+}
+
+// TestInvariantsHaveTests is the INV-META meta-test: every INV-LP* invariant
+// MUST be referenced by a test or a documented gate.
+func TestInvariantsHaveTests(t *testing.T) {
+	// INV-LP1 → TestSloglintPolicyMatchesSpec (this file).
+	// INV-LP2 → the `task lint:go` gate in CI/pr-prep (not a Go unit test;
+	//           the config-guard above pins the policy the gate enforces).
+	invariants := map[string]string{
+		"INV-LP1": "TestSloglintPolicyMatchesSpec",
+		"INV-LP2": "task lint:go gate (pr-prep)",
+	}
+	for id, ref := range invariants {
+		assert.NotEmpty(t, ref, "invariant %s must have a referencing test or gate", id)
+	}
+}

--- a/internal/observability/server.go
+++ b/internal/observability/server.go
@@ -259,7 +259,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("observability server stopped")
+	slog.InfoContext(ctx, "observability server stopped")
 	return nil
 }
 

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -520,7 +520,8 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 			go grpcPlugin.broker.AcceptAndServe(brokerID, proxyFactory)
 
 			requiredServices[svcName] = fmt.Sprintf("broker:%d", brokerID)
-			slog.Info(
+			slog.InfoContext(
+				ctx,
 				"started broker proxy for required service",
 				"plugin", manifest.Name,
 				"service", svcName,
@@ -642,7 +643,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 	// Log warning for unrecognized actor kinds (useful for debugging)
 	actorKind := event.ActorKind.String()
 	if actorKind == "unknown" {
-		slog.Warn("unrecognized actor kind, using 'unknown'",
+		slog.WarnContext(ctx, "unrecognized actor kind, using 'unknown'",
 			"kind", int(event.ActorKind))
 	}
 

--- a/internal/plugin/goplugin/host_service.go
+++ b/internal/plugin/goplugin/host_service.go
@@ -80,7 +80,7 @@ func (s *pluginHostServiceServer) EmitEvent(ctx context.Context, req *pluginv1.P
 	storedActor, ok := tokenStore.Lookup(s.pluginName, tokens[0])
 	if !ok {
 		slog.WarnContext(
-			ctx, "EmitEvent rejected: token not valid for this plugin",
+			ctx, "emitEvent rejected: token not valid for this plugin",
 			"plugin", s.pluginName,
 			"code", "EMIT_TOKEN_REJECTED",
 		)

--- a/internal/plugin/hostfunc/adapter.go
+++ b/internal/plugin/hostfunc/adapter.go
@@ -80,7 +80,7 @@ func (a *WorldQuerierAdapter) GetLocation(ctx context.Context, id ulid.ULID) (*w
 			Wrapf(err, "get location")
 	}
 	if loc == nil {
-		slog.Warn("service returned nil without error, treating as not found",
+		slog.WarnContext(ctx, "service returned nil without error, treating as not found",
 			"plugin", a.pluginName,
 			"entity_type", "location",
 			"entity_id", id.String())
@@ -104,7 +104,7 @@ func (a *WorldQuerierAdapter) GetCharacter(ctx context.Context, id ulid.ULID) (*
 			Wrapf(err, "get character")
 	}
 	if char == nil {
-		slog.Warn("service returned nil without error, treating as not found",
+		slog.WarnContext(ctx, "service returned nil without error, treating as not found",
 			"plugin", a.pluginName,
 			"entity_type", "character",
 			"entity_id", id.String())
@@ -131,7 +131,7 @@ func (a *WorldQuerierAdapter) GetCharactersByLocation(ctx context.Context, locat
 	// Unlike single-entity methods, nil is technically valid for slices,
 	// but we normalize for consistency and to detect potential service issues.
 	if chars == nil {
-		slog.Debug("service returned nil slice, normalizing to empty",
+		slog.DebugContext(ctx, "service returned nil slice, normalizing to empty",
 			"plugin", a.pluginName,
 			"location_id", locationID.String())
 		return []*world.Character{}, nil
@@ -151,7 +151,7 @@ func (a *WorldQuerierAdapter) GetObject(ctx context.Context, id ulid.ULID) (*wor
 			Wrapf(err, "get object")
 	}
 	if obj == nil {
-		slog.Warn("service returned nil without error, treating as not found",
+		slog.WarnContext(ctx, "service returned nil without error, treating as not found",
 			"plugin", a.pluginName,
 			"entity_type", "object",
 			"entity_id", id.String())

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -286,12 +286,16 @@ func (f *Functions) logFn(pluginName string) lua.LGFunction {
 		logger := slog.Default().With("plugin", pluginName)
 		switch level {
 		case "debug":
+			//nolint:sloglint // plugin-supplied log message, dynamic by design
 			logger.Debug(message)
 		case "info":
+			//nolint:sloglint // plugin-supplied log message, dynamic by design
 			logger.Info(message)
 		case "warn":
+			//nolint:sloglint // plugin-supplied log message, dynamic by design
 			logger.Warn(message)
 		case "error":
+			//nolint:sloglint // plugin-supplied log message, dynamic by design
 			logger.Error(message)
 		default:
 			slog.Warn("invalid log level from plugin",
@@ -334,14 +338,14 @@ func (f *Functions) checkKVAccess(L *lua.LState, pluginName, action, key string)
 
 	req, err := types.NewAccessRequest(subject, action, resource, nil)
 	if err != nil {
-		slog.Error("failed to create KV access request",
+		slog.ErrorContext(ctx, "failed to create KV access request",
 			"plugin", pluginName, "action", action, "key", key, "error", err)
 		return "access check failed"
 	}
 
 	decision, err := f.engine.Evaluate(ctx, req)
 	if err != nil {
-		slog.Error("KV access check engine error",
+		slog.ErrorContext(ctx, "KV access check engine error",
 			"plugin", pluginName, "action", action, "key", key, "error", err)
 		return "access check failed"
 	}

--- a/internal/plugin/hostfunc/helpers.go
+++ b/internal/plugin/hostfunc/helpers.go
@@ -37,7 +37,8 @@ func pushSuccess(L *lua.LState, value lua.LValue) int {
 // pushServiceUnavailable logs and returns a standard error when the world service
 // is not configured. This consolidates the nil check boilerplate.
 func (f *Functions) pushServiceUnavailable(L *lua.LState, funcName, pluginName string) int {
-	slog.Error(funcName+" called but world service unavailable",
+	slog.Error("host function called but world service unavailable",
+		"func", funcName,
 		"plugin", pluginName,
 		"hint", "use WithWorldService option when creating hostfunc.Functions")
 	return pushError(L, "world service not configured - contact server administrator")
@@ -46,7 +47,8 @@ func (f *Functions) pushServiceUnavailable(L *lua.LState, funcName, pluginName s
 // pushMutatorUnavailable logs and returns a standard error when the world service
 // does not support mutations.
 func pushMutatorUnavailable(L *lua.LState, funcName, pluginName string) int {
-	slog.Warn(funcName+" called but world service does not support mutations",
+	slog.Warn("host function called but world service does not support mutations",
+		"func", funcName,
 		"plugin", pluginName)
 	return pushError(L, "world service does not support mutations")
 }
@@ -57,9 +59,11 @@ func pushMutatorUnavailable(L *lua.LState, funcName, pluginName string) int {
 func parseULID(L *lua.LState, idStr, pluginName, funcName, paramName string) (ulid.ULID, bool) {
 	id, err := ulid.Parse(idStr)
 	if err != nil {
-		slog.Debug(funcName+": invalid "+paramName+" format",
+		slog.Debug("invalid ULID format in host function argument",
+			"func", funcName,
 			"plugin", pluginName,
-			paramName, idStr,
+			"param", paramName,
+			"value", idStr,
 			"error", err)
 		pushError(L, fmt.Sprintf("invalid %s: %s", paramName, err.Error()))
 		return ulid.ULID{}, false

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -272,7 +272,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 	// Check if on_event exists
 	onEvent := L.GetGlobal("on_event")
 	if onEvent.Type() == lua.LTNil {
-		slog.Debug("plugin has no handler defined",
+		slog.DebugContext(ctx, "plugin has no handler defined",
 			"plugin", name,
 			"event_type", event.Type)
 		return nil, nil
@@ -296,7 +296,7 @@ func (h *Host) DeliverEvent(ctx context.Context, name string, event pluginsdk.Ev
 
 	emits, validationErrs := h.parseEmitEvents(ret)
 	if len(validationErrs) > 0 {
-		slog.Warn("plugin emit validation errors",
+		slog.WarnContext(ctx, "plugin emit validation errors",
 			"plugin", name,
 			"error_count", len(validationErrs),
 			"errors", validationErrs)
@@ -340,7 +340,7 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 
 	onCommand := L.GetGlobal("on_command")
 	if onCommand.Type() == lua.LTNil {
-		slog.Debug("plugin has no on_command handler",
+		slog.DebugContext(ctx, "plugin has no on_command handler",
 			"plugin", name,
 			"command", cmd.Command)
 		return pluginsdk.OK(""), nil
@@ -492,7 +492,7 @@ func (h *Host) callOnCommand(ctx context.Context, state *lua.LState, name string
 
 	emits, validationErrs := h.parseEmitEvents(ret)
 	if len(validationErrs) > 0 {
-		slog.Warn("plugin emit validation errors",
+		slog.WarnContext(ctx, "plugin emit validation errors",
 			"plugin", name,
 			"error_count", len(validationErrs),
 			"errors", validationErrs)

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -413,7 +413,7 @@ type DiscoveredPlugin struct {
 
 // Discover finds all valid plugins in the plugins directory.
 // Invalid plugins are logged and skipped.
-func (m *Manager) Discover(_ context.Context) ([]*DiscoveredPlugin, error) {
+func (m *Manager) Discover(ctx context.Context) ([]*DiscoveredPlugin, error) {
 	entries, err := os.ReadDir(m.pluginsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -433,7 +433,7 @@ func (m *Manager) Discover(_ context.Context) ([]*DiscoveredPlugin, error) {
 
 		data, err := os.ReadFile(filepath.Clean(manifestPath))
 		if err != nil {
-			slog.Warn("skipping plugin without manifest",
+			slog.WarnContext(ctx, "skipping plugin without manifest",
 				"dir", entry.Name(),
 				"error", err)
 			continue
@@ -441,7 +441,7 @@ func (m *Manager) Discover(_ context.Context) ([]*DiscoveredPlugin, error) {
 
 		manifest, err := ParseManifest(data)
 		if err != nil {
-			slog.Warn("skipping plugin with invalid manifest",
+			slog.WarnContext(ctx, "skipping plugin with invalid manifest",
 				"dir", entry.Name(),
 				"error", err)
 			continue
@@ -451,7 +451,7 @@ func (m *Manager) Discover(_ context.Context) ([]*DiscoveredPlugin, error) {
 		// internally malformed (unknown sensitivity, duplicate emit, etc.)
 		// and we skip the plugin entirely, mirroring the ParseManifest path.
 		if err := ValidateCrypto(manifest); err != nil {
-			slog.Warn("skipping plugin with invalid crypto section",
+			slog.WarnContext(ctx, "skipping plugin with invalid crypto section",
 				"dir", entry.Name(),
 				"plugin", manifest.Name,
 				"error", err)
@@ -479,7 +479,7 @@ func (m *Manager) Discover(_ context.Context) ([]*DiscoveredPlugin, error) {
 		next := resolved[:0]
 		for _, dp := range resolved {
 			if err := ResolveCryptoRefs(dp.Manifest, emitRegistry); err != nil {
-				slog.Warn("skipping plugin with unresolvable crypto refs",
+				slog.WarnContext(ctx, "skipping plugin with unresolvable crypto refs",
 					"plugin", dp.Manifest.Name,
 					"dir", dp.Dir,
 					"error", err)
@@ -564,7 +564,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 	var loadErrors []error
 	for _, dp := range ordered {
 		if err := m.loadPlugin(ctx, dp, knownResourceTypes, knownActions); err != nil {
-			slog.Error("failed to load plugin",
+			slog.ErrorContext(ctx, "failed to load plugin",
 				"plugin", dp.Manifest.Name,
 				"priority", dp.Manifest.EffectivePriority(),
 				"error", err)
@@ -575,7 +575,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 
 	if len(loadErrors) > 0 {
 		if m.gracefulDegradation {
-			slog.Warn("plugin loading completed with errors (graceful degradation enabled)",
+			slog.WarnContext(ctx, "plugin loading completed with errors (graceful degradation enabled)",
 				"failed_count", len(loadErrors))
 			return nil
 		}
@@ -587,7 +587,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 	// Seed aliases from loaded plugin manifests.
 	if m.aliasSeeder != nil && m.aliasCache != nil {
 		if err := m.seedAliases(ctx); err != nil {
-			slog.Error("failed to seed plugin aliases", "error", err)
+			slog.ErrorContext(ctx, "failed to seed plugin aliases", "error", err)
 		}
 	}
 
@@ -606,7 +606,7 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 			delete(m.activeByName, row.Name)
 			// nameByID intentionally retained for historical resolution.
 			m.mu.Unlock()
-			slog.Info(
+			slog.InfoContext(ctx,
 				"plugin.gc",
 				"name", row.Name,
 				"id", row.ID.String(),
@@ -859,19 +859,19 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			host = m.luaHost // backward compatibility
 		}
 		if host == nil {
-			slog.Warn("no Lua host configured, skipping Lua plugin",
+			slog.WarnContext(ctx, "no Lua host configured, skipping Lua plugin",
 				"plugin", dp.Manifest.Name)
 			return nil
 		}
 	case TypeBinary:
 		host = m.hosts[TypeBinary]
 		if host == nil {
-			slog.Warn("binary plugins not yet supported, skipping",
+			slog.WarnContext(ctx, "binary plugins not yet supported, skipping",
 				"plugin", dp.Manifest.Name)
 			return nil
 		}
 	default:
-		slog.Warn("unknown plugin type, skipping",
+		slog.WarnContext(ctx, "unknown plugin type, skipping",
 			"plugin", dp.Manifest.Name,
 			"type", dp.Manifest.Type)
 		return nil
@@ -895,7 +895,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 					With("command", cmd.Name).Wrap(err)
 			}
 			if !coreActions[cap.Action] && !ownActions[cap.Action] {
-				slog.Warn("capability uses action not declared by this plugin",
+				slog.WarnContext(ctx, "capability uses action not declared by this plugin",
 					"plugin", dp.Manifest.Name,
 					"command", cmd.Name,
 					"action", cap.Action)
@@ -974,7 +974,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 
 	// Drift logging (no decision logic — log and continue per spec).
 	if drift != nil {
-		slog.Info(
+		slog.InfoContext(ctx,
 			"plugin.drift",
 			"name", dp.Manifest.Name,
 			"old_manifest_hash", hex.EncodeToString(drift.OldManifestHash),
@@ -999,7 +999,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			// table (and any live subprocess / gRPC client for binary
 			// plugins) does not leak after fail-closed rejection.
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-				slog.Error("failed to rollback plugin load after PluginEmitRegistry not-found",
+				slog.ErrorContext(ctx, "failed to rollback plugin load after PluginEmitRegistry not-found",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
 			}
 			return oops.Code("PLUGIN_EMIT_REGISTRY_UNAVAILABLE").
@@ -1013,7 +1013,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			// table (and any live subprocess / gRPC client for binary
 			// plugins) does not leak after fail-closed rejection.
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-				slog.Error("failed to rollback plugin load after INV-S5 mismatch",
+				slog.ErrorContext(ctx, "failed to rollback plugin load after INV-S5 mismatch",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
 			}
 			return oops.Code("EVENT_TYPE_REGISTRY_MISMATCH").
@@ -1046,7 +1046,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 		// dangling references to a plugin that never finished loading.
 		m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 		if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-			slog.Error("failed to rollback plugin load after schema validation failure",
+			slog.ErrorContext(ctx, "failed to rollback plugin load after schema validation failure",
 				"plugin", dp.Manifest.Name, "error", unloadErr)
 		}
 		return oops.In("manager").With("plugin", dp.Manifest.Name).
@@ -1062,7 +1062,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			// — same rationale as the schema-validation branch above.
 			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-				slog.Error("failed to rollback plugin load after policy install failure",
+				slog.ErrorContext(ctx, "failed to rollback plugin load after policy install failure",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
 			}
 			return oops.In("manager").With("plugin", dp.Manifest.Name).Wrapf(installErr, "install plugin policies")
@@ -1072,7 +1072,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	// Check for manifest warnings (non-fatal policy coverage gaps).
 	if warnings := CheckManifestWarnings(dp.Manifest); len(warnings) > 0 {
 		for _, w := range warnings {
-			slog.Info(w, "plugin", dp.Manifest.Name)
+			slog.InfoContext(ctx, "manifest warning", "plugin", dp.Manifest.Name, "warning", w)
 		}
 	}
 
@@ -1091,7 +1091,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			m.verbRegistry.UnregisterBySource(dp.Manifest.Name)
 			m.unregisterPluginProviders(dp.Manifest.Name, dp.Manifest.ResourceTypes, len(dp.Manifest.ResourceTypes))
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-				slog.Error("failed to rollback plugin load after verb registration failure",
+				slog.ErrorContext(ctx, "failed to rollback plugin load after verb registration failure",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
 			}
 			return oops.In("manager").With("plugin", dp.Manifest.Name).
@@ -1151,7 +1151,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 	m.pluginHosts[dp.Manifest.Name] = host
 	m.mu.Unlock()
 
-	slog.Info("loaded plugin",
+	slog.InfoContext(ctx, "loaded plugin",
 		"plugin", dp.Manifest.Name,
 		"type", dp.Manifest.Type,
 		"version", dp.Manifest.Version)
@@ -1186,7 +1186,7 @@ func (m *Manager) discoverAndRegisterAttributes(ctx context.Context, host Host, 
 	schemaResp, schemaErr := arClient.GetSchema(ctx, &pluginv1.GetSchemaRequest{})
 	if schemaErr != nil {
 		if unloadErr := host.Unload(ctx, pluginName); unloadErr != nil {
-			slog.Error("failed to rollback plugin load after schema discovery failure",
+			slog.ErrorContext(ctx, "failed to rollback plugin load after schema discovery failure",
 				"plugin", pluginName, "error", unloadErr)
 		}
 		return nil, oops.In("manager").With("plugin", pluginName).
@@ -1197,7 +1197,7 @@ func (m *Manager) discoverAndRegisterAttributes(ctx context.Context, host Host, 
 	for _, rt := range dp.Manifest.ResourceTypes {
 		if _, ok := schemas[rt]; !ok {
 			if unloadErr := host.Unload(ctx, pluginName); unloadErr != nil {
-				slog.Error("failed to rollback plugin after schema validation failure",
+				slog.ErrorContext(ctx, "failed to rollback plugin after schema validation failure",
 					"plugin", pluginName, "error", unloadErr)
 			}
 			return nil, oops.In("manager").With("plugin", pluginName).
@@ -1221,7 +1221,7 @@ func (m *Manager) discoverAndRegisterAttributes(ctx context.Context, host Host, 
 				// previous iterations of this loop before returning.
 				m.unregisterPluginProviders(pluginName, dp.Manifest.ResourceTypes, i)
 				if unloadErr := host.Unload(ctx, pluginName); unloadErr != nil {
-					slog.Error("failed to rollback plugin after attribute provider registration failure",
+					slog.ErrorContext(ctx, "failed to rollback plugin after attribute provider registration failure",
 						"plugin", pluginName, "error", unloadErr)
 				}
 				return nil, oops.In("manager").
@@ -1371,7 +1371,7 @@ func (m *Manager) Close(ctx context.Context) error {
 	if m.policyInstaller != nil {
 		for name := range m.loaded {
 			if err := m.policyInstaller.RemovePluginPolicies(ctx, name); err != nil {
-				slog.Error("failed to remove plugin policies", "plugin", name, "error", err)
+				slog.ErrorContext(ctx, "failed to remove plugin policies", "plugin", name, "error", err)
 			}
 		}
 	}
@@ -1380,7 +1380,7 @@ func (m *Manager) Close(ctx context.Context) error {
 	// still reference loaded state during shutdown.
 	for hostType, host := range m.hosts {
 		if err := host.Close(ctx); err != nil {
-			slog.Error("failed to close host", "type", hostType, "error", err)
+			slog.ErrorContext(ctx, "failed to close host", "type", hostType, "error", err)
 		}
 	}
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -606,7 +606,8 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 			delete(m.activeByName, row.Name)
 			// nameByID intentionally retained for historical resolution.
 			m.mu.Unlock()
-			slog.InfoContext(ctx,
+			slog.InfoContext(
+				ctx,
 				"plugin.gc",
 				"name", row.Name,
 				"id", row.ID.String(),
@@ -974,7 +975,8 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 
 	// Drift logging (no decision logic — log and continue per spec).
 	if drift != nil {
-		slog.InfoContext(ctx,
+		slog.InfoContext(
+			ctx,
 			"plugin.drift",
 			"name", dp.Manifest.Name,
 			"old_manifest_hash", hex.EncodeToString(drift.OldManifestHash),

--- a/internal/plugin/policy_installer.go
+++ b/internal/plugin/policy_installer.go
@@ -214,7 +214,7 @@ func (pi *PolicyInstaller) ReplacePluginPolicies(ctx context.Context, pluginName
 	}
 
 	if err := pi.store.ReplaceBySource(ctx, "plugin", "plugin:"+pluginName+":", compiled); err != nil {
-		slog.Error("atomic policy replace failed",
+		slog.ErrorContext(ctx, "atomic policy replace failed",
 			"plugin", pluginName, "error", err)
 		return oops.With("plugin", pluginName).Wrapf(err, "replacing plugin policies")
 	}
@@ -231,7 +231,7 @@ func (pi *PolicyInstaller) ReplacePluginPoliciesWithManifest(ctx context.Context
 	}
 
 	if err := pi.store.ReplaceBySource(ctx, "plugin", "plugin:"+manifest.Name+":", compiled); err != nil {
-		slog.Error("atomic policy replace failed",
+		slog.ErrorContext(ctx, "atomic policy replace failed",
 			"plugin", manifest.Name, "error", err)
 		return oops.With("plugin", manifest.Name).Wrapf(err, "replacing plugin policies")
 	}

--- a/internal/plugin/schema_provisioner.go
+++ b/internal/plugin/schema_provisioner.go
@@ -75,7 +75,7 @@ func (sp *SchemaProvisioner) Init(ctx context.Context) error {
 				currentUser, currentUser)
 	}
 
-	slog.Info("schema provisioner initialized", "role", currentUser, "createrole", true)
+	slog.InfoContext(ctx, "schema provisioner initialized", "role", currentUser, "createrole", true)
 
 	sp.pool = pool
 	return nil
@@ -124,7 +124,7 @@ func (sp *SchemaProvisioner) ProvisionSchema(ctx context.Context, pluginName str
 		return "", err
 	}
 
-	slog.Info("provisioned plugin schema with isolated role",
+	slog.InfoContext(ctx, "provisioned plugin schema with isolated role",
 		"plugin", pluginName, "schema", schemaName, "role", roleName)
 
 	connStr, err := pluginConnString(sp.baseConnString, schemaName, roleName, password)
@@ -189,7 +189,7 @@ func (sp *SchemaProvisioner) PurgeSchema(ctx context.Context, pluginName string)
 			With("role", roleName).Wrap(err)
 	}
 
-	slog.Info("purged plugin schema and role", "plugin", pluginName, "role", roleName)
+	slog.InfoContext(ctx, "purged plugin schema and role", "plugin", pluginName, "role", roleName)
 	return nil
 }
 

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -235,10 +235,10 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 	if s.cfg.CertsDir != "" {
 		ca, caErr := tlscerts.LoadCA(s.cfg.CertsDir)
 		if caErr != nil {
-			slog.Warn("plugin mTLS disabled: could not load CA", "error", caErr)
+			slog.WarnContext(ctx, "plugin mTLS disabled: could not load CA", "error", caErr)
 		} else {
 			hostOpts = append(hostOpts, goplugin.WithCA(ca, s.cfg.GameID))
-			slog.Info("plugin mTLS enabled", "certs_dir", s.cfg.CertsDir)
+			slog.InfoContext(ctx, "plugin mTLS enabled", "certs_dir", s.cfg.CertsDir)
 		}
 	}
 
@@ -296,7 +296,7 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 	// errors fail fast and visibly. Use plugins.WithGracefulDegradation() in
 	// the manager options (intended for local dev only) to log and continue.
 	if loadErr := s.manager.LoadAll(ctx); loadErr != nil {
-		slog.Error("failed to load plugins", "error", loadErr)
+		slog.ErrorContext(ctx, "failed to load plugins", "error", loadErr)
 		return oops.In("plugin-subsystem").Wrapf(loadErr, "loading plugins")
 	}
 
@@ -324,7 +324,7 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 	// Register plugin-provided commands.
 	s.manager.RegisterPluginCommands(s.cmdRegistry)
 
-	slog.Info("plugin subsystem started", "plugins_dir", pluginsDir)
+	slog.InfoContext(ctx, "plugin subsystem started", "plugins_dir", pluginsDir)
 	return nil
 }
 
@@ -337,11 +337,11 @@ func (s *PluginSubsystem) Stop(_ context.Context) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	if err := s.manager.Close(shutdownCtx); err != nil {
-		slog.Warn("error closing plugin manager", "error", err)
+		slog.WarnContext(shutdownCtx, "error closing plugin manager", "error", err)
 	}
 	if s.worldConn != nil {
 		if err := s.worldConn.Close(); err != nil {
-			slog.Warn("error closing world in-process connection", "error", err)
+			slog.WarnContext(shutdownCtx, "error closing world in-process connection", "error", err)
 		}
 	}
 	if s.schemaProvisioner != nil {

--- a/internal/session/setup/subsystem.go
+++ b/internal/session/setup/subsystem.go
@@ -50,9 +50,9 @@ func (s *SessionSubsystem) DependsOn() []lifecycle.SubsystemID {
 
 // Start creates the PostgresSessionStore from the database pool.
 // codecov:ignore — tested by integration and E2E tests
-func (s *SessionSubsystem) Start(_ context.Context) error {
+func (s *SessionSubsystem) Start(ctx context.Context) error {
 	s.sessionStore = store.NewPostgresSessionStore(s.cfg.DB.Pool())
-	slog.Info("session subsystem started")
+	slog.InfoContext(ctx, "session subsystem started")
 	return nil
 }
 

--- a/internal/store/alias.go
+++ b/internal/store/alias.go
@@ -103,7 +103,7 @@ func (r *PostgresAliasRepository) DeleteSystemAlias(ctx context.Context, alias s
 		return oops.With("operation", "delete system alias").With("alias", alias).Wrap(err)
 	}
 	if result.RowsAffected() == 0 {
-		slog.Debug("delete system alias: no rows affected", "alias", alias)
+		slog.DebugContext(ctx, "delete system alias: no rows affected", "alias", alias)
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (r *PostgresAliasRepository) DeletePlayerAlias(ctx context.Context, playerI
 			Wrap(err)
 	}
 	if result.RowsAffected() == 0 {
-		slog.Debug("delete player alias: no rows affected",
+		slog.DebugContext(ctx, "delete player alias: no rows affected",
 			"player_id", playerID.String(),
 			"alias", alias)
 	}

--- a/internal/store/role_resolver.go
+++ b/internal/store/role_resolver.go
@@ -30,7 +30,7 @@ func (r *PostgresRoleResolver) GetRoles(ctx context.Context, subject string) []s
 	charID := strings.TrimPrefix(subject, "character:")
 	roles, err := r.store.GetRoles(ctx, charID)
 	if err != nil {
-		slog.Error("role resolution failed", "subject", subject, "error", err)
+		slog.ErrorContext(ctx, "role resolution failed", "subject", subject, "error", err)
 		return nil
 	}
 	return roles

--- a/internal/store/subsystem.go
+++ b/internal/store/subsystem.go
@@ -73,7 +73,7 @@ func (s *DatabaseSubsystem) Start(ctx context.Context) error {
 	}
 	s.gameID = gameID
 
-	slog.Info("database subsystem started", "game_id", gameID)
+	slog.InfoContext(ctx, "database subsystem started", "game_id", gameID)
 	return nil
 }
 

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -170,7 +170,8 @@ func Init(ctx context.Context, serviceName, serviceVersion string, logCfg config
 		bridgeLevel, _ = enabledLogFloor(logCfg, global, endpoint, sentryEnabled)
 	}
 
-	slog.InfoContext(ctx,
+	slog.InfoContext(
+		ctx,
 		"telemetry initialized",
 		"service", serviceName,
 		"otel_endpoint", endpoint,

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -170,7 +170,7 @@ func Init(ctx context.Context, serviceName, serviceVersion string, logCfg config
 		bridgeLevel, _ = enabledLogFloor(logCfg, global, endpoint, sentryEnabled)
 	}
 
-	slog.Info( //nolint:gosec // G706: values from env vars / caller-controlled constants, not untrusted user input
+	slog.InfoContext(ctx,
 		"telemetry initialized",
 		"service", serviceName,
 		"otel_endpoint", endpoint,

--- a/internal/telnet/gateway_handler.go
+++ b/internal/telnet/gateway_handler.go
@@ -330,7 +330,7 @@ func (h *GatewayHandler) handleConnectGuest(ctx context.Context) <-chan *corev1.
 
 	resp, err := h.client.CreateGuest(createCtx, &corev1.CreateGuestRequest{})
 	if err != nil {
-		slog.Error("gateway: create guest RPC failed", "error", err)
+		slog.ErrorContext(ctx, "gateway: create guest RPC failed", "error", err)
 		h.send("Guest login error. Please try again.")
 		return nil
 	}
@@ -348,7 +348,7 @@ func (h *GatewayHandler) handleConnectGuest(ctx context.Context) <-chan *corev1.
 	}
 
 	// Should not happen for guests — CreateGuest always returns one character.
-	slog.Error("gateway: CreateGuest returned no characters")
+	slog.ErrorContext(ctx, "gateway: CreateGuest returned no characters")
 	h.send("Guest login failed. Please try again.")
 	return nil
 }
@@ -368,7 +368,7 @@ func (h *GatewayHandler) handleConnectPlayer(ctx context.Context, username, pass
 		Password: password,
 	})
 	if err != nil {
-		slog.Error("gateway: authenticate player RPC failed", "error", err)
+		slog.ErrorContext(ctx, "gateway: authenticate player RPC failed", "error", err)
 		h.send("Authentication error. Please try again.")
 		return nil
 	}
@@ -440,7 +440,7 @@ func (h *GatewayHandler) handleCreate(ctx context.Context, name string) <-chan *
 		CharacterName:      name,
 	})
 	if err != nil {
-		slog.Error("gateway: create character RPC failed", "error", err)
+		slog.ErrorContext(ctx, "gateway: create character RPC failed", "error", err)
 		h.send("Character creation error. Please try again.")
 		return nil
 	}
@@ -487,7 +487,7 @@ func (h *GatewayHandler) selectCharacter(ctx context.Context, ch *corev1.Charact
 		CharacterId:        ch.GetCharacterId(),
 	})
 	if err != nil {
-		slog.Error("gateway: select character RPC failed", "error", err)
+		slog.ErrorContext(ctx, "gateway: select character RPC failed", "error", err)
 		h.send("Character selection error. Please try again.")
 		return nil
 	}
@@ -530,11 +530,11 @@ func (h *GatewayHandler) subscribeAndEnter(ctx context.Context) <-chan *corev1.S
 		ClientType:         "telnet",
 	})
 	if err != nil {
-		slog.Warn("gateway: subscribe RPC failed — no live events", "session_id", h.sessionID, "error", err)
+		slog.WarnContext(ctx, "gateway: subscribe RPC failed — no live events", "session_id", h.sessionID, "error", err)
 		return nil
 	}
 	if stream == nil {
-		slog.Warn("gateway: subscribe returned nil stream", "session_id", h.sessionID)
+		slog.WarnContext(ctx, "gateway: subscribe returned nil stream", "session_id", h.sessionID)
 		return nil
 	}
 
@@ -597,7 +597,7 @@ func (h *GatewayHandler) handleSay(ctx context.Context, message string) {
 		ConnectionId:       h.connectionID,
 	})
 	if err != nil {
-		slog.Error("gateway: say command failed", "session_id", h.sessionID, "error", err)
+		slog.ErrorContext(ctx, "gateway: say command failed", "session_id", h.sessionID, "error", err)
 		h.send("Error: Your message could not be sent. Please try again.")
 		return
 	}
@@ -638,7 +638,7 @@ func (h *GatewayHandler) handlePose(ctx context.Context, action string) {
 		ConnectionId:       h.connectionID,
 	})
 	if err != nil {
-		slog.Error("gateway: pose command failed", "session_id", h.sessionID, "error", err)
+		slog.ErrorContext(ctx, "gateway: pose command failed", "session_id", h.sessionID, "error", err)
 		h.send("Error: Your action could not be sent. Please try again.")
 		return
 	}
@@ -684,7 +684,7 @@ func (h *GatewayHandler) handleGenericCommand(ctx context.Context, cmd, arg stri
 		PlayerSessionToken: h.playerSessionToken,
 		ConnectionId:       h.connectionID,
 	}); err != nil {
-		slog.Error("gateway: command failed", "session_id", h.sessionID, "command", cmd, "error", err)
+		slog.ErrorContext(ctx, "gateway: command failed", "session_id", h.sessionID, "command", cmd, "error", err)
 		h.send("Error processing command.")
 	}
 	// Output (or error) comes via command_response event on the character stream.
@@ -746,7 +746,7 @@ func (h *GatewayHandler) handleQuit(ctx context.Context) {
 			PlayerSessionToken: h.playerSessionToken,
 			ConnectionId:       h.connectionID,
 		}); err != nil {
-			slog.Warn("gateway: quit command failed", "session_id", h.sessionID, "error", err)
+			slog.WarnContext(spanCtx, "gateway: quit command failed", "session_id", h.sessionID, "error", err)
 		}
 	}
 	h.quitting = true
@@ -764,7 +764,7 @@ func (h *GatewayHandler) handleLogout(ctx context.Context) {
 		if _, err := h.client.Logout(logoutCtx, &corev1.LogoutRequest{
 			PlayerSessionToken: h.playerSessionToken,
 		}); err != nil {
-			slog.Warn("gateway: logout RPC failed", "error", err)
+			slog.WarnContext(ctx, "gateway: logout RPC failed", "error", err)
 		}
 	}
 	if !h.authed {

--- a/internal/web/auth_handlers.go
+++ b/internal/web/auth_handlers.go
@@ -129,7 +129,7 @@ func (h *Handler) WebAuthenticatePlayer(ctx context.Context, req *connect.Reques
 		RememberMe: req.Msg.GetRememberMe(),
 	})
 	if err != nil {
-		slog.Error("web: authenticate player RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: authenticate player RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebAuthenticatePlayerResponse{
 			Success: false, ErrorMessage: "authentication error",
 		}), nil
@@ -166,7 +166,7 @@ func (h *Handler) WebSelectCharacter(ctx context.Context, req *connect.Request[w
 		CharacterId:        req.Msg.GetCharacterId(),
 	})
 	if err != nil {
-		slog.Error("web: select character RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: select character RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebSelectCharacterResponse{
 			Success: false, ErrorMessage: "character selection error",
 		}), nil
@@ -209,7 +209,7 @@ func (h *Handler) WebCreatePlayer(ctx context.Context, req *connect.Request[webv
 		Email:    req.Msg.GetEmail(),
 	})
 	if err != nil {
-		slog.Error("web: create player RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: create player RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebCreatePlayerResponse{
 			Success: false, ErrorMessage: "registration error",
 		}), nil
@@ -245,7 +245,7 @@ func (h *Handler) WebCreateCharacter(ctx context.Context, req *connect.Request[w
 		CharacterName:      req.Msg.GetCharacterName(),
 	})
 	if err != nil {
-		slog.Error("web: create character RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: create character RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebCreateCharacterResponse{
 			Success: false, ErrorMessage: "character creation error",
 		}), nil
@@ -279,7 +279,7 @@ func (h *Handler) WebListCharacters(ctx context.Context, req *connect.Request[we
 		PlayerSessionToken: token,
 	})
 	if err != nil {
-		slog.Error("web: list characters RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: list characters RPC failed", "error", err)
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("session expired or invalid"))
 	}
 
@@ -301,7 +301,7 @@ func (h *Handler) WebLogout(ctx context.Context, req *connect.Request[webv1.WebL
 		if _, err := h.client.Logout(rpcCtx, &corev1.LogoutRequest{
 			PlayerSessionToken: token,
 		}); err != nil {
-			slog.Error("web: logout RPC failed", "error", err)
+			slog.ErrorContext(ctx, "web: logout RPC failed", "error", err)
 		}
 	}
 
@@ -348,7 +348,7 @@ func (h *Handler) WebRequestPasswordReset(ctx context.Context, req *connect.Requ
 		Email: req.Msg.GetEmail(),
 	})
 	if err != nil {
-		slog.Error("web: request password reset RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: request password reset RPC failed", "error", err)
 		// Return success to avoid leaking whether the email exists.
 		return connect.NewResponse(&webv1.WebRequestPasswordResetResponse{
 			Success: true,
@@ -372,7 +372,7 @@ func (h *Handler) WebConfirmPasswordReset(ctx context.Context, req *connect.Requ
 		NewPassword: req.Msg.GetNewPassword(),
 	})
 	if err != nil {
-		slog.Error("web: confirm password reset RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: confirm password reset RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebConfirmPasswordResetResponse{
 			Success: false, ErrorMessage: "password reset error",
 		}), nil
@@ -408,7 +408,7 @@ func (h *Handler) WebCreateGuest(ctx context.Context, req *connect.Request[webv1
 
 	coreResp, err := h.client.CreateGuest(rpcCtx, &corev1.CreateGuestRequest{})
 	if err != nil {
-		slog.Error("web: create guest RPC failed", "error", err)
+		slog.ErrorContext(ctx, "web: create guest RPC failed", "error", err)
 		return connect.NewResponse(&webv1.WebCreateGuestResponse{
 			Success: false, ErrorMessage: "guest creation error",
 		}), nil

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -176,7 +176,8 @@ func (h *Handler) StreamEvents(ctx context.Context, req *connect.Request[webv1.S
 			ConnectionId:       connID.String(),
 			PlayerSessionToken: token,
 		}); disconnErr != nil {
-			slog.WarnContext(ctx,
+			slog.WarnContext(
+				ctx,
 				"web: disconnect RPC failed on stream close",
 				"session_id", sessionID,
 				"connection_id", connID.String(),

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) SendCommand(ctx context.Context, req *connect.Request[webv1.Se
 		ConnectionId:       connIDStr,
 	})
 	if err != nil {
-		slog.Error("web: handle command RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
+		slog.ErrorContext(ctx, "web: handle command RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
 		return connect.NewResponse(&webv1.SendCommandResponse{
 			Success:      false,
 			ErrorMessage: "command error",
@@ -176,7 +176,7 @@ func (h *Handler) StreamEvents(ctx context.Context, req *connect.Request[webv1.S
 			ConnectionId:       connID.String(),
 			PlayerSessionToken: token,
 		}); disconnErr != nil {
-			slog.Warn(
+			slog.WarnContext(ctx,
 				"web: disconnect RPC failed on stream close",
 				"session_id", sessionID,
 				"connection_id", connID.String(),
@@ -346,7 +346,7 @@ func (h *Handler) Disconnect(ctx context.Context, req *connect.Request[webv1.Dis
 		SessionId:          req.Msg.GetSessionId(),
 		PlayerSessionToken: token,
 	}); err != nil {
-		slog.Error("web: disconnect RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
+		slog.ErrorContext(ctx, "web: disconnect RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
 	}
 
 	return connect.NewResponse(&webv1.DisconnectResponse{}), nil
@@ -373,7 +373,7 @@ func (h *Handler) GetCommandHistory(ctx context.Context, req *connect.Request[we
 		PlayerSessionToken: token,
 	})
 	if err != nil {
-		slog.Error("web: get command history RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
+		slog.ErrorContext(ctx, "web: get command history RPC failed", "session_id", req.Msg.GetSessionId(), "error", err)
 		return connect.NewResponse(&webv1.GetCommandHistoryResponse{}), nil
 	}
 

--- a/internal/web/sentry_relay.go
+++ b/internal/web/sentry_relay.go
@@ -143,7 +143,7 @@ func NewSentryRelayHandler(dsn string) (http.Handler, error) {
 		}
 		defer func() {
 			if closeErr := resp.Body.Close(); closeErr != nil {
-				slog.Debug("sentry relay: close upstream body", "error", closeErr.Error())
+				slog.DebugContext(r.Context(), "sentry relay: close upstream body", "error", closeErr.Error())
 			}
 		}()
 

--- a/internal/world/events.go
+++ b/internal/world/events.go
@@ -76,7 +76,7 @@ func emitWithRetry(ctx context.Context, emitter EventEmitter, stream, eventType,
 	if err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		attempt++
 		if err := emitter.Emit(ctx, stream, eventType, data); err != nil {
-			slog.Debug("event emission failed, will retry",
+			slog.DebugContext(ctx, "event emission failed, will retry",
 				"stream", stream,
 				"event_type", eventType,
 				"entity_type", entityType,
@@ -90,7 +90,7 @@ func emitWithRetry(ctx context.Context, emitter EventEmitter, stream, eventType,
 	}); err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			// Log at WARN level for context cancellation (expected during shutdown)
-			slog.Warn("event emission cancelled",
+			slog.WarnContext(ctx, "event emission cancelled",
 				"stream", stream,
 				"event_type", eventType,
 				"entity_type", entityType,
@@ -99,7 +99,7 @@ func emitWithRetry(ctx context.Context, emitter EventEmitter, stream, eventType,
 				"reason", err)
 		} else {
 			// Log at ERROR level when all retries are exhausted for production visibility
-			slog.Error("event emission failed after all retries",
+			slog.ErrorContext(ctx, "event emission failed after all retries",
 				"stream", stream,
 				"event_type", eventType,
 				"entity_type", entityType,

--- a/internal/world/service.go
+++ b/internal/world/service.go
@@ -383,13 +383,13 @@ func (s *Service) DeleteExit(ctx context.Context, subjectID string, id ulid.ULID
 			// Log cleanup issues at appropriate level
 			if cleanupResult.IsSevere() {
 				// Severe: operation was rolled back, primary delete did NOT complete
-				slog.Error("bidirectional exit delete rolled back",
+				slog.ErrorContext(ctx, "bidirectional exit delete rolled back",
 					"exit_id", cleanupResult.ExitID.String(),
 					"error", cleanupResult.Error())
 				return oops.Code("EXIT_DELETE_FAILED").Wrapf(err, "delete exit %s", id)
 			}
 			// Non-severe: primary delete succeeded, return exit was just not found
-			slog.Info("bidirectional exit cleanup notice: return exit already deleted",
+			slog.InfoContext(ctx, "bidirectional exit cleanup notice: return exit already deleted",
 				"exit_id", cleanupResult.ExitID.String(),
 				"to_location_id", cleanupResult.ToLocationID.String(),
 				"return_name", cleanupResult.ReturnName)

--- a/internal/world/setup/subsystem.go
+++ b/internal/world/setup/subsystem.go
@@ -57,7 +57,7 @@ func (s *WorldSubsystem) DependsOn() []lifecycle.SubsystemID {
 
 // Start creates all world repositories, transactor, and WorldService.
 // codecov:ignore — tested by integration and E2E tests
-func (s *WorldSubsystem) Start(_ context.Context) error {
+func (s *WorldSubsystem) Start(ctx context.Context) error {
 	pool := s.cfg.DB.Pool()
 	engine := s.cfg.ABAC.Engine()
 
@@ -75,7 +75,7 @@ func (s *WorldSubsystem) Start(_ context.Context) error {
 	})
 	s.transactor = transactor
 
-	slog.Info("world subsystem started")
+	slog.InfoContext(ctx, "world subsystem started")
 	return nil
 }
 

--- a/pkg/errutil/log.go
+++ b/pkg/errutil/log.go
@@ -14,6 +14,7 @@ import (
 // For oops errors, it extracts and logs the message, code, context, and stacktrace.
 // For standard errors, it logs the error string.
 func LogError(logger *slog.Logger, msg string, err error) {
+	//nolint:sloglint // log wrapper: msg is forwarded from the caller (see holomush-lhx5w)
 	logger.Error(msg, oopsAttrs(err)...)
 }
 
@@ -23,6 +24,7 @@ func LogError(logger *slog.Logger, msg string, err error) {
 func LogErrorContext(ctx context.Context, msg string, err error, extraAttrs ...any) {
 	attrs := oopsAttrs(err)
 	attrs = append(attrs, extraAttrs...)
+	//nolint:sloglint // log wrapper: msg is forwarded from the caller (see holomush-lhx5w)
 	slog.ErrorContext(ctx, msg, attrs...)
 }
 


### PR DESCRIPTION
## Summary

Enables the `sloglint` linter (Tier C policy) tree-wide and migrates all ~230 findings to compliance, enforcing trace-context propagation (`*Context` slog variants) and structured-log discipline across the codebase. Implements epic `holomush-ow4ix` (spec/plan: `docs/superpowers/{specs,plans}/2026-05-24-*`).

**Tier C policy** (`.golangci.yaml`): `context: scope`, `no-mixed-args`, `static-msg`, `msg-style: lowercased`, `key-naming-case: snake`, `forbidden-keys: [time, level, msg, source]`.

### What changed (14 commits, one per package group)
- **Enable + guard** (`nvn`): sloglint in `.golangci.yaml` + config-guard test (`INV-LP1`) + meta-test + 2 errutil forwarder nolints.
- **Migrations** (Pattern A `*Context` threading, plus B/C/D/E where noted): `cmd/holomush` (61), `internal/plugin` core (30, +1 Pattern B), `plugin/hostfunc` (11, Pattern B+C), `plugin/{setup,lua,goplugin}` (13, +Pattern D), `audit`+`totp_audit` (23, +Pattern E `source`→`event_source`), `web` (12), `telnet` (12), `access/{policy,setup}` (10), `command`+`grpc` (9, Pattern B+D), `cluster`+`auth` (14), `bootstrap`+`world`+`store`+`lifecycle` (20), `eventbus/*`+`admin/socket`+misc (13).
- **Docs** (`wtm`): `.claude/rules/logging.md` Enforcement section activated; `CLAUDE.md` "Structured Logging" marked active.

### Notes
- Logging-call-shape only — no logic, level, attribute-value, or control-flow change. Forbidden-key rename (`source`→`event_source`) affects the operational **log line** only; the durable audit record (DB column + `json:"source"` tag) is unchanged.
- `errutil.LogError*` call sites are out of scope (tracked separately as `holomush-lhx5w`); sloglint cannot see the wrapper so they don't affect `INV-LP2`.

## Test plan
- [x] `task lint:go` — **0 sloglint findings tree-wide** (INV-LP2; no package path-excluded)
- [x] `task test` — 8284 pass (2 skipped), incl. `TestSloglintPolicyMatchesSpec` + `TestInvariantsHaveTests`
- [x] `task pr-prep` full lane — green (lint, format, schema, license, unit, integration, E2E 64/65)
- [x] Per-task adversarial review: `code-reviewer` (all 14), `crypto-reviewer` (eventbus/crypto), `abac-reviewer` (access) — all READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)