### PR TITLE
fix(release): allow deps commit type so Renovate PRs pass commit-lint

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -11,10 +11,10 @@
 # cog 7.x note: these settings are top-level keys, NOT nested under a
 # [settings] table (cog 7 rejects an unknown `settings` section). The commit
 # type allow-list is cog's built-in default (feat, fix, docs, style, refactor,
-# perf, test, build, ci, chore, revert) — `cog verify` rejects any other type.
-# We do NOT redefine it via [commit_types]: an empty `feat = {}` override makes
-# `cog bump --auto` fail with "Commit type `feat` not allowed", which only
-# surfaces on the bump/release path (latent until cog became the release engine).
+# perf, test, build, ci, chore, revert) PLUS any type ADDED in [commit_types]
+# below. Footgun: an EMPTY entry (`feat = {}`) DISABLES that type — `cog verify`
+# then rejects it and `cog bump --auto` fails with "Commit type `feat` not
+# allowed". So to ADD a type, give it a NON-EMPTY table; never use `{}`.
 
 # v-prefixed tags (v1.2.3) to match GoReleaser and the existing tag history.
 tag_prefix = "v"
@@ -27,3 +27,10 @@ disable_changelog = true
 branch_whitelist = ["main"]
 
 ignore_merge_commits = true
+
+# Add `deps` as an allowed type so Renovate's `deps:` prefix
+# (.github/renovate.json `commitMessagePrefix`) passes the commit-lint PR-title
+# gate. Non-empty table (NOT `{}`) so it ADDS the type without disabling it; no
+# bump_* keys so dependency bumps never trigger a release on their own.
+[commit_types]
+deps = { omit_from_changelog = true }

--- a/docs/superpowers/plans/2026-05-24-cocogitto-release-tooling.md
+++ b/docs/superpowers/plans/2026-05-24-cocogitto-release-tooling.md
@@ -149,6 +149,13 @@ branch_whitelist = ["main"]
 
 ignore_merge_commits = true
 
+# SUPERSEDED DURING IMPLEMENTATION — do NOT copy this block verbatim.
+# In cog 7.x an empty `X = {}` entry DISABLES that type (cog then rejects it in
+# `cog verify` and fails `cog bump` with "Commit type X not allowed"). The block
+# below would therefore disable all of cog's built-in defaults. The shipped
+# cog.toml omits `[commit_types]` entirely and relies on cog's default allow-list
+# (feat/fix/docs/style/refactor/perf/test/build/ci/chore/revert); new types are
+# ADDED only via NON-empty tables (e.g. `deps = { omit_from_changelog = true }`).
 # Allowed commit types for `cog verify` (PR-title gate) and bump inference.
 [commit_types]
 feat = {}

--- a/scripts/tests/cog-release.bats
+++ b/scripts/tests/cog-release.bats
@@ -63,3 +63,22 @@ setup() {
   run cog verify "just some words with no type"
   [ "$status" -ne 0 ]
 }
+
+@test "deps: type is accepted (Renovate commitMessagePrefix, PR #4253 regression)" {
+  run cog verify "deps: Pin dependency @sentry/svelte to 10.53.1"
+  [ "$status" -eq 0 ]
+}
+
+@test "deps commits don't break cog bump and don't bump the version on their own" {
+  git commit -q --allow-empty -m "deps: bump some/dependency to 1.2.3"
+  run cog bump --auto --disable-bump-commit
+  # A lone deps commit is non-bumping: cog reports nothing to bump (non-zero),
+  # but it must NOT fail with a parse/allow-list error, and must leave the tag at v0.1.0.
+  [ "$(git describe --tags --abbrev=0)" = "v0.1.0" ]
+}
+
+@test "adding deps did not disable cog's default commit types" {
+  run cog verify "feat: a feature"; [ "$status" -eq 0 ]
+  run cog verify "fix: a fix"; [ "$status" -eq 0 ]
+  run cog verify "chore: a chore"; [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

The cocogitto switchover (#4252) added a `commit-lint` workflow that runs `cog verify` on PR titles. Renovate is configured with `commitMessagePrefix: "deps:"` (`.github/renovate.json:100`), but `cog`'s commit-type allow-list (built-in defaults) lacks `deps` — so **all 4 open Renovate PRs (#4253–#4256) fail commit-lint** with `Commit type deps not allowed`, blocking their auto-merge.

## Fix

Add `deps` as an allowed cog commit type via a **non-empty** `[commit_types]` entry:

```toml
[commit_types]
deps = { omit_from_changelog = true }
```

- **Non-empty** is required: in cog 7.x an empty `deps = {}` would *disable* the type (the footgun documented in `cog.toml` that the worker hit with `feat = {}`).
- **No `bump_*` keys** — dependency bumps never trigger a release on their own.

## Tests

`scripts/tests/cog-release.bats` gains 3 regression tests: `deps:` accepted, `deps` non-bumping (tag stays `v0.1.0`), and cog's default types (feat/fix/chore) still allowed (guards the disable footgun). All pass.

## After merge

The 4 open Renovate PRs need to rebase onto this fix to pick up the new `cog.toml`; Renovate will auto-rebase (or `@renovatebot rebase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)