### PR TITLE
docs(testing): correct EventBus harness section — no !integration enforcement exists (holomush-tcf7)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -140,10 +140,11 @@ Other test engines: `AllowAllEngine()`, `DenyAllEngine()`, `NewErrorEngine(err)`
 
 `internal/eventbus/eventbustest.New(t)` provides an in-process embedded NATS server with `MemoryStorage` for unit and bus-integration tests.
 
-| Requirement | Description |
-| ----------- | ----------- |
-| **MUST NOT** use in E2E tests | E2E tests use the full server stack with a real PG testcontainer |
-| **Compile-time enforcement** | The `//go:build !integration` tag on the harness file enforces this |
+| Aspect | Description |
+| ------ | ----------- |
+| **Intended use** | Unit tests and bus-integration tests (tests that exercise the bus itself) |
+| **Scoping mechanism** | The `test:int` target in `Taskfile.yaml` runs an **explicit package list**, not `./...` — it enumerates only the packages that carry `//go:build integration` test files. There is **no** `//go:build !integration` tag on `eventbustest/embedded.go`. The list exists to *exclude* packages whose **unit** tests import `!integration`-tagged helpers (e.g. `internal/grpc/`) so they don't fail to compile under `-tags=integration` — it does not stop the harness itself from running in integration packages that legitimately use it. (The same `//go:build !integration` trick *is* used on `core.NewMemoryEventStore` in `internal/core/store_memory.go`, which works only because nothing integration-tagged imports it — not the case for the bus harness, which bus-integration tests legitimately import.) |
+| **Current E2E reality** | Embedded NATS is also used today by the full-stack E2E harnesses (`internal/testsupport/holomushtest`, `internal/testsupport/integrationtest`), both `//go:build integration`. Whether full-stack E2E *should* be forbidden from embedded NATS — and how to distinguish bus-integration from E2E in the build system — is an open design question tracked in **holomush-1eps2**. Until that lands, this section describes the harness's actual reach rather than asserting an unenforced rule. |
 
 ## Plugin Tests (`internal/plugin`)
 


### PR DESCRIPTION
Closes holomush-tcf7.

## What
`.claude/rules/testing.md` claimed: *"The `//go:build !integration` tag on the harness file enforces this."* That tag has **never** existed on `internal/eventbus/eventbustest/embedded.go` (`git log --follow` confirms; the claim was introduced aspirationally in #3528). The section asserted a compile-time guarantee that does not exist.

## Fix (doc accuracy only)
Replaced the false-enforcement table with an accurate one:
- **Intended use** — unit + bus-integration tests.
- **Scoping mechanism** — the real mechanism is the explicit `test:int` package list in `Taskfile.yaml` (not `./...`), which exists to exclude packages whose *unit* tests import `!integration` helpers; there is no build tag on the bus harness. Contrasts with `core.NewMemoryEventStore` (which *can* carry `!integration` only because nothing integration-tagged imports it).
- **Current E2E reality** — embedded NATS is also used today by the full-stack E2E harnesses (`holomushtest`, `integrationtest`), both `//go:build integration`.

## Out of scope
Whether full-stack E2E *should* be forbidden from embedded NATS — and how to distinguish bus-integration from E2E in the build system — is an open design question tracked in **holomush-1eps2** (discovered-from this bead). The doc now describes reality rather than re-asserting an unenforced rule.

## Verification
- `task fmt:check` ✓ `task pr-prep:docs` ✓ (`.claude/rules/**` is in DOCS_ONLY_PATHS)
- code-reviewer: READY (all 6 factual claims grounded at path:line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)