### PR TITLE
docs: plugin host Evaluate — spec, plan, and ADRs (holomush-8kkv5)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,10 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Add host Evaluate RPC for per-action plugin authorization](holomush-dttdj-host-evaluate-rpc-per-action-plugin-authz.md) | 2026-05-25 | Accepted | `holomush-dttdj` |
+| [Derive Evaluate subject host-side; no subject field on wire](holomush-qeypl-host-derived-evaluate-subject.md) | 2026-05-25 | Accepted | `holomush-qeypl` |
+| [Scope plugin Evaluate entitlement to owned resource types](holomush-61rdl-evaluate-entitlement-owned-resource-types.md) | 2026-05-25 | Accepted | `holomush-61rdl` |
+| [Make plugin authorization gates structural via gated subcommand dispatcher](holomush-9l9pu-structural-gated-subcommand-dispatcher.md) | 2026-05-25 | Accepted | `holomush-9l9pu` |
 | [Drop in-memory session.Store fake; test against real Postgres](holomush-bozv-drop-session-memstore-test-against-postgres.md) | 2026-05-23 | Accepted | `holomush-bozv` |
 | [Denormalize Pose-Order Metadata Against scene_log Source of Truth](holomush-r4th-denormalize-pose-order-metadata.md) | 2026-05-19 | Accepted | `holomush-r4th` |
 | [Migrate Scene Subjects to NATS Dot-Style Atomically With Plugin Emit Code](holomush-s9nu-scene-subject-atomic-migration.md) | 2026-05-19 | Accepted | `holomush-s9nu` |

--- a/docs/adr/holomush-61rdl-evaluate-entitlement-owned-resource-types.md
+++ b/docs/adr/holomush-61rdl-evaluate-entitlement-owned-resource-types.md
@@ -1,0 +1,36 @@
+# Scope plugin Evaluate entitlement to owned resource types
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-61rdl
+**Deciders:** Sean Brandt
+
+## Context
+
+A plugin that can call `Evaluate` with an arbitrary resource type could use the host ABAC engine as a cross-domain policy oracle — probing decisions for resources outside its concern (e.g., a scene plugin asking about server-admin resources), leaking policy shape and attribute existence across domain boundaries. The 2026-04-06 trust-boundary work enforced resource-type ownership for policy *installation* but not for *evaluation* calls.
+
+## Decision
+
+The host rejects any `Evaluate` call whose resource type is not declared in the requesting plugin's manifest `resource_types`, with a `command` carve-out for the plugin's own commands. The check runs before the engine. The rule is one line of host code applied **identically** to both runtimes; the behavioral difference between binary and Lua plugins is purely an artifact of manifest data (Lua plugins structurally cannot declare `resource_types` or implement `AttributeResolver`, so their effective entitlement degrades to the `command` carve-out).
+
+## Rationale
+
+- The same trust boundary already governs policy installation; extending it to evaluation is the consistent move (contributors reason about one model).
+- A plugin with full data access to its own resources gains no new information from "can actor X do Y on *my* resource" — that answer is exactly what it needs to gate. Cross-domain probing is what leaks.
+- Lua degradation falls out of the existing architecture without a runtime-specific trust rule, preserving the plugin-runtime-symmetry invariant ("runtime-specific code is acceptable for runtime-specific concerns … but MUST NOT differ in policy / trust / manifest-gate dimensions").
+
+## Alternatives Considered
+
+- **Free-form resource type (no entitlement check on Evaluate).** Rejected — turns the plugin into a policy oracle for any resource type, enabling cross-domain information leakage. The legitimate cross-domain-query use case is deferred to a future higher-risk design.
+
+## Consequences
+
+- **Positive:** cross-domain oracle attacks are structurally blocked before the engine runs; one entitlement rule spans both runtimes; consistent with the 2026-04-06 installation boundary.
+- **Negative:** instance-level `Evaluate` is effectively binary-plugin-only in v1; a plugin cannot evaluate against a sibling plugin's resource even when legitimate.
+- **Neutral:** action strings stay free-form; an unmatched action default-denies via the engine.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md` §3
+- Design bead: holomush-8kkv5
+- Related: `docs/superpowers/specs/2026-04-06-plugin-abac-trust-boundary-design.md` §2.1; `.claude/rules/plugin-runtime-symmetry.md`

--- a/docs/adr/holomush-9l9pu-structural-gated-subcommand-dispatcher.md
+++ b/docs/adr/holomush-9l9pu-structural-gated-subcommand-dispatcher.md
@@ -1,0 +1,37 @@
+# Make plugin authorization gates structural via gated subcommand dispatcher
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-9l9pu
+**Deciders:** Sean Brandt
+
+## Context
+
+The host `Evaluate` RPC (see [holomush-dttdj](holomush-dttdj-host-evaluate-rpc-per-action-plugin-authz.md)) leaves enforcement cooperative: a plugin author who forgets to call `Evaluate` ships an ungated subcommand. The host cannot verify call-sites because it never sees subcommands. The risk is bounded to plugin-owned resources by the entitlement check, but "core plugin author forgets" is a realistic failure mode — `core-scenes`' existing ad-hoc Go authorization checks demonstrate the pattern.
+
+## Decision
+
+The plugin SDK provides a **gated subcommand dispatcher**. Each subcommand is registered as `{name, action, resourceRef func(args) (string, error), handler}`. The SDK calls `Evaluate(action, resourceRef(args))` before the handler and short-circuits to a denial response on deny (or a service-failure response on engine error). `core-scenes` adopts the dispatcher and removes its ad-hoc Go authorization checks. A table-driven backstop test (INV-7) asserts every gated subcommand denies when its policy denies.
+
+## Rationale
+
+- A structural gate eliminates the "forgot to call Evaluate" failure mode for subcommands registered through the dispatcher — authorization is no longer a remembered call.
+- The `resourceRef` extractor keeps arg-grammar in the plugin, so no host layering violation is introduced.
+- INV-7 gives a table-driven, automatically-checked regression guard.
+- `core-scenes` is the N=1 concrete consumer that validates the API before it becomes a shared primitive.
+
+## Alternatives Considered
+
+- **Document the Evaluate call pattern; rely on code review.** Rejected — authorization gates remain a remembered call; review cannot exhaustively prove every subcommand is gated, and the failure is silent (ungated action, no runtime error).
+
+## Consequences
+
+- **Positive:** the gate is structural for dispatcher-registered subcommands; INV-7 catches regressions automatically; existing non-gated subcommands remain backward-compatible (opt-in).
+- **Negative:** adoption is opt-in — a plugin that bypasses the dispatcher still faces the cooperative-enforcement problem; adds one SDK abstraction for authors to learn.
+- **Neutral:** the host never verifies call-sites; the dispatcher's guarantee is scoped to subcommands registered through it.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md` §6
+- Plan: `docs/superpowers/plans/2026-05-25-plugin-host-evaluate.md` Task 6, Task 8 (INV-7)
+- Design bead: holomush-8kkv5

--- a/docs/adr/holomush-dttdj-host-evaluate-rpc-per-action-plugin-authz.md
+++ b/docs/adr/holomush-dttdj-host-evaluate-rpc-per-action-plugin-authz.md
@@ -1,0 +1,38 @@
+# Add host Evaluate RPC for per-action plugin authorization
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-dttdj
+**Deciders:** Sean Brandt
+
+## Context
+
+Plugin commands share a single command-level ABAC gate: Layer 1 (`execute command:<name>`) plus Layer 2 (type-level capability pre-flight, which by the 2026-04-07 C1 hardening resolves only subject/environment/action attributes — never a resource instance). Per-subcommand authorization is therefore impossible: a subcommand cannot map to a distinct command-level capability without breaking its siblings, and the per-operation policies plugins already declare in `plugin.yaml` are never evaluated because no call-site combines a real resource instance with a specific action. The first concrete blocker is the E2 admin-only gate on `scene extend` (`extend_publish_attempts`), but the gap is general across plugin runtimes.
+
+## Decision
+
+Introduce a single `Evaluate(action, resource) -> Decision` RPC on both `PluginHostService` (binary gRPC) and the Lua `holomush.evaluate` hostfunc, both delegating to one shared host-side implementation that runs the full ABAC engine. This is a **third enforcement tier** layered above Layer 1 (command execute) and Layer 2 (type-level capability pre-flight): the plugin supplies an action and a real resource instance, and the host returns the decision. All per-action plugin authorization unifies on the engine — `core-scenes`' ad-hoc Go authorization checks migrate to DSL policies + `Evaluate` calls.
+
+## Rationale
+
+- The engine, the per-operation policies, and attribute resolution already exist; the only missing piece is an evaluation entry point that carries a real resource instance and a specific action.
+- Unifying on the engine eliminates two-sources-of-truth: the DSL policy becomes the single authoritative decision rather than being shadowed by hardcoded Go checks.
+- The plugin owns its arg-grammar (it extracts the resource instance); the host owns the decision. Neither leaks into the other.
+- A new gated subcommand needs only a new policy in `plugin.yaml` — no new RPC, no host change.
+
+## Alternatives Considered
+
+- **A: Host parses subcommands and evaluates at dispatch.** Rejected — a layering violation: the host sees `cmd.Args` as an opaque string and would have to learn every plugin's subcommand grammar and resource-ID extraction, coupling the host to plugin internals.
+- **B: Expose character roles to plugins for Go self-gating.** Rejected — moves enforcement out of the host engine, makes the admin DSL policy decorative, and creates two parallel enforcement engines (engine DSL + plugin Go). Contradicts the unify-on-engine goal.
+
+## Consequences
+
+- **Positive:** the ABAC engine becomes the single authoritative per-action decision point for plugin authorization; every decision gets a host-stamped audit trail (closing a current gap); new gates are policy-only.
+- **Negative:** enforcement is cooperative at the plugin boundary — a plugin that bypasses the SDK dispatcher can still ship an ungated action (bounded to plugin-owned resources by the entitlement check; mitigated by the gated subcommand dispatcher). Instance-level evaluation is effectively binary-plugin-only (Lua plugins own no resource types).
+- **Neutral:** Layer 1 and Layer 2 are unchanged; decision caching is out of scope (the engine's attribute-resolution caching applies).
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md` §Decisions, §1, §6
+- Plan: `docs/superpowers/plans/2026-05-25-plugin-host-evaluate.md`
+- Design bead: holomush-8kkv5

--- a/docs/adr/holomush-qeypl-host-derived-evaluate-subject.md
+++ b/docs/adr/holomush-qeypl-host-derived-evaluate-subject.md
@@ -1,0 +1,37 @@
+# Derive Evaluate subject host-side; no subject field on wire
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-qeypl
+**Deciders:** Sean Brandt
+
+## Context
+
+An authorization-evaluation RPC exposed to plugin code is a subject-spoofing surface: a plugin could claim to evaluate as an arbitrary character rather than the authenticated actor, escalating privilege or probing other actors' permissions. The host already overwrites plugin-supplied identity fields in `dispatcher.go::extractAuditHints` ("the plugin cannot spoof these fields"), but that stance had not yet been extended to a plugin-callable evaluation surface.
+
+## Decision
+
+`EvaluateRequest` carries **no subject field** by construction. The host derives the subject from the authenticated actor already bound to the call: for binary plugins from the per-dispatch token (the same mechanism `EmitEvent` uses — `tokenStore.Lookup`, not plugin-supplied actor metadata); for Lua plugins from the dispatch `context.Context` (`core.ActorFromContext`). If no authenticated actor is bound, `Evaluate` fails closed (deny + error). Evaluating on behalf of a subject other than the current actor is out of scope for v1.
+
+## Rationale
+
+- A proto-level omission is a structural guarantee — a future refactor cannot accidentally thread a subject through without changing the proto and triggering review (INV-1 is a meta-test over the proto descriptor, not a runtime assertion).
+- Mirrors the existing host-side anti-spoof posture (`EmitEvent` token authentication, `extractAuditHints` field overwrite).
+- Fail-closed on missing actor prevents unauthenticated evaluation, which would be a silent hole.
+- "Evaluate as another subject" is a meaningfully higher-risk capability that warrants its own design.
+
+## Alternatives Considered
+
+- **Subject field on `EvaluateRequest` (plugin supplies subject).** Rejected — a plugin can forge any subject over the RPC; the host cannot distinguish legitimate from forged values. Enables privilege escalation and cross-actor probing. The (legitimate) "can character X do Y?" use case is deferred to a future higher-risk design.
+
+## Consequences
+
+- **Positive:** subject spoofing is structurally impossible at the proto level; INV-1 is verifiable by a descriptor scan; consistent with existing anti-spoof posture.
+- **Negative:** plugins cannot evaluate hypothetical/other subjects in v1.
+- **Neutral:** both runtimes reach the same host derivation logic; only the actor-recovery mechanism differs (token vs ctx) — a runtime-specific concern, not a policy/trust difference.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md` §2
+- Design bead: holomush-8kkv5
+- Related: `internal/plugin/goplugin/host_service.go::EmitEvent` (token→actor pattern)

--- a/docs/superpowers/plans/2026-05-25-plugin-host-evaluate.md
+++ b/docs/superpowers/plans/2026-05-25-plugin-host-evaluate.md
@@ -1,0 +1,1498 @@
+# Plugin Host `Evaluate` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a host `Evaluate(action, resource)` RPC + Lua hostfunc so plugin command handlers can authorize a specific action against a specific resource instance through the real ABAC engine, and migrate `core-scenes` per-action authorization onto it (unblocking E2's admin-gated `scene extend`).
+
+**Architecture:** A runtime-neutral shared evaluation core (`internal/plugin/pluginauthz`) performs entitlement + `engine.Evaluate` + audit, given a **host-trusted subject**. Two thin surfaces feed it: the binary `PluginHostService.Evaluate` gRPC (subject recovered from the dispatch token, mirroring `EmitEvent`) and the Lua `holomush.evaluate` global (subject from `core.ActorFromContext(L.Context())`). The SDK adds a `host.Evaluate` client helper and a gated subcommand dispatcher that makes the gate structural. `core-scenes` migrates its ad-hoc Go authz checks to `Evaluate` calls against policies that already exist in its `plugin.yaml`.
+
+**Tech Stack:** Go, ConnectRPC/gRPC (`buf generate` via `task proto`), gopher-lua, the existing ABAC engine (`internal/access/policy`), `internal/audit`, Ginkgo/Gomega for E2E.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md`
+**Design bead:** holomush-8kkv5
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+| ---- | -------------- |
+| `internal/plugin/pluginauthz/evaluate.go` (Create) | Runtime-neutral shared core: entitlement check, `engine.Evaluate`, audit emission. The single function both surfaces delegate to (INV-5). |
+| `internal/plugin/pluginauthz/evaluate_test.go` (Create) | Unit tests for the shared core. |
+| `api/proto/holomush/plugin/v1/plugin.proto` (Modify) | Add `Evaluate` RPC + `EvaluateRequest`/`EvaluateResponse` to `PluginHostService`. |
+| `internal/plugin/goplugin/host.go` (Modify) | `WithEngine` / `WithAuditLogger` host options + fields; per-plugin owned-type lookup. |
+| `internal/plugin/goplugin/host_service.go` (Modify) | Implement `pluginHostServiceServer.Evaluate` (token→actor→subject→pluginauthz). |
+| `internal/plugin/hostfunc/evaluate.go` (Create) | `holomush.evaluate` Lua global (ctx→subject→pluginauthz). |
+| `internal/plugin/hostfunc/functions.go` (Modify) | Register `evaluate`; add `WithAuditLogger` option. |
+| `pkg/plugin/evaluate_client.go` (Create) | SDK `host.Evaluate(ctx, action, resource)` binary client helper. |
+| `pkg/plugin/gated_dispatch.go` (Create) | SDK gated subcommand dispatcher. |
+| `plugins/core-scenes/plugin.yaml` (Modify) | Declare `extend_publish_attempts` action; add admin policy. |
+| `plugins/core-scenes/commands.go` (Modify) | Wire subcommands through the gated dispatcher; remove ad-hoc Go authz checks. |
+| `site/docs/extending/plugin-host-evaluate.md` (Create) | Plugin-author guide (PR-blocking). |
+| `internal/access/policy/plugin_evaluate_gate_test.go` (Create) | Real-engine integration test of the admin gate via `pluginauthz.Evaluate` (Tier 1). Full-stack Ginkgo/Gomega command-path E2E is a deferred follow-up (Tier 2, depends on iwzt-9). |
+
+---
+
+## Phase 1: Shared evaluation core + proto
+
+### Task 1: `pluginauthz` shared evaluation core
+
+**Files:**
+
+- Create: `internal/plugin/pluginauthz/evaluate.go`
+- Test: `internal/plugin/pluginauthz/evaluate_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginauthz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/internal/access/policy/types"
+)
+
+// stubEngine returns a fixed decision/error and records the request.
+type stubEngine struct {
+	decision types.Decision
+	err      error
+	gotReq   types.AccessRequest
+	called   bool
+}
+
+func (s *stubEngine) Evaluate(_ context.Context, req types.AccessRequest) (types.Decision, error) {
+	s.called = true
+	s.gotReq = req
+	return s.decision, s.err
+}
+
+func (s *stubEngine) CanPerformAction(context.Context, string, string, string, string) (bool, error) {
+	return false, nil
+}
+
+// recordingAuditor captures audit events.
+type recordingAuditor struct{ events []audit.Event }
+
+func (r *recordingAuditor) Log(_ context.Context, e audit.Event) error {
+	r.events = append(r.events, e)
+	return nil
+}
+
+func TestEvaluate_AllowEmitsAuditAndReturnsDecision(t *testing.T) {
+	eng := &stubEngine{decision: types.NewDecision(types.EffectAllow, "permitted by p", "p")}
+	aud := &recordingAuditor{}
+
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine:     eng,
+		Auditor:    aud,
+		PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "character:01ABC",
+		Action:     "extend_publish_attempts",
+		Resource:   "scene:01SCENE",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+	assert.Equal(t, "p", dec.MatchedPolicy)
+	assert.Equal(t, "character:01ABC", eng.gotReq.Subject)
+	assert.Equal(t, "extend_publish_attempts", eng.gotReq.Action)
+	assert.Equal(t, "scene:01SCENE", eng.gotReq.Resource)
+	require.Len(t, aud.events, 1)
+	assert.Equal(t, "character:01ABC", aud.events[0].Subject)
+	assert.Equal(t, audit.SourcePlugin, aud.events[0].Source)
+	assert.Equal(t, "core-scenes", aud.events[0].Component)
+	assert.Equal(t, types.EffectAllow, aud.events[0].Effect)
+}
+
+func TestEvaluate_EntitlementRejectsForeignType(t *testing.T) {
+	eng := &stubEngine{decision: types.NewDecision(types.EffectAllow, "", "p")}
+	aud := &recordingAuditor{}
+
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: eng, Auditor: aud, PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "character:01ABC", Action: "read", Resource: "server:global",
+	})
+
+	require.Error(t, err)
+	assert.False(t, dec.Allowed)
+	assert.False(t, eng.called, "engine MUST NOT be consulted for an unentitled resource type")
+}
+
+func TestEvaluate_CommandCarveOutAllowed(t *testing.T) {
+	eng := &stubEngine{decision: types.NewDecision(types.EffectAllow, "", "p")}
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: eng, Auditor: &recordingAuditor{}, PluginName: "lua-plug",
+		OwnedTypes: map[string]bool{}, // Lua: empty
+		Subject:    "character:01ABC", Action: "execute", Resource: "command:foo",
+	})
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+	assert.True(t, eng.called)
+}
+
+func TestEvaluate_EmptyActionRejected(t *testing.T) {
+	_, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: &stubEngine{}, Auditor: &recordingAuditor{}, PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "character:01ABC", Action: "", Resource: "scene:01SCENE",
+	})
+	require.Error(t, err)
+}
+
+func TestEvaluate_MalformedResourceRejected(t *testing.T) {
+	for _, res := range []string{"noseparator", ":noid", "notype:", ""} {
+		_, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+			Engine: &stubEngine{}, Auditor: &recordingAuditor{}, PluginName: "core-scenes",
+			OwnedTypes: map[string]bool{"scene": true},
+			Subject:    "character:01ABC", Action: "read", Resource: res,
+		})
+		require.Errorf(t, err, "resource %q must be rejected", res)
+	}
+}
+
+func TestEvaluate_EmptySubjectFailsClosed(t *testing.T) {
+	eng := &stubEngine{}
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: eng, Auditor: &recordingAuditor{}, PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "", Action: "read", Resource: "scene:01SCENE",
+	})
+	require.Error(t, err)
+	assert.False(t, dec.Allowed)
+	assert.False(t, eng.called, "no authenticated subject MUST fail closed before the engine")
+}
+
+func TestEvaluate_EngineErrorFailsClosed(t *testing.T) {
+	eng := &stubEngine{err: assertAnErr()}
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: eng, Auditor: &recordingAuditor{}, PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "character:01ABC", Action: "read", Resource: "scene:01SCENE",
+	})
+	require.Error(t, err)
+	assert.False(t, dec.Allowed, "engine error MUST NOT fail open")
+}
+
+func TestEvaluate_DefaultDenyOnUnmatchedPolicy(t *testing.T) {
+	eng := &stubEngine{decision: types.NewDecision(types.EffectDefaultDeny, "no match", "")}
+	dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+		Engine: eng, Auditor: &recordingAuditor{}, PluginName: "core-scenes",
+		OwnedTypes: map[string]bool{"scene": true},
+		Subject:    "character:01ABC", Action: "read", Resource: "scene:01SCENE",
+	})
+	require.NoError(t, err)
+	assert.False(t, dec.Allowed)
+}
+
+func assertAnErr() error { return context.DeadlineExceeded }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/pluginauthz/`
+Expected: FAIL — package `pluginauthz` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package pluginauthz holds the runtime-neutral per-action authorization
+// core shared by the binary (PluginHostService.Evaluate) and Lua
+// (holomush.evaluate) surfaces. Both delegate here so policy/trust
+// behavior cannot diverge between runtimes (INV-5).
+package pluginauthz
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/errutil"
+)
+
+// ActorSubject maps a host-stamped Actor to its ABAC subject string. It is
+// the single mapping shared by the binary and Lua surfaces (INV-5) so the
+// two cannot derive divergent subjects. Returns "" for an unknown/zero
+// actor kind, which Evaluate treats as fail-closed.
+func ActorSubject(a core.Actor) string {
+	switch a.Kind {
+	case core.ActorCharacter:
+		return "character:" + a.ID
+	case core.ActorPlugin:
+		return "plugin:" + a.ID
+	case core.ActorSystem:
+		return "system"
+	default:
+		return ""
+	}
+}
+
+// Auditor is the minimal audit sink pluginauthz needs. *audit.Logger
+// satisfies it.
+type Auditor interface {
+	Log(ctx context.Context, event audit.Event) error
+}
+
+// Input carries everything the shared core needs. Subject is HOST-DERIVED
+// and MUST NOT originate from plugin-supplied data (INV-1).
+type Input struct {
+	Engine     types.AccessPolicyEngine
+	Auditor    Auditor
+	PluginName string
+	OwnedTypes map[string]bool // plugin's resource_types; empty for Lua
+	Subject    string
+	Action     string
+	Resource   string // "type:id"
+}
+
+// Decision is the runtime-neutral result returned to both surfaces.
+type Decision struct {
+	Allowed       bool
+	Reason        string
+	MatchedPolicy string
+}
+
+// commandResourceType is the carve-out type any plugin may evaluate for its
+// own commands (see spec §3).
+const commandResourceType = "command"
+
+// Evaluate runs entitlement → engine → audit and returns a runtime-neutral
+// Decision. It fails closed on every error path: a non-nil error always
+// accompanies a non-allowing Decision.
+func Evaluate(ctx context.Context, in Input) (Decision, error) {
+	if in.Subject == "" {
+		// No authenticated actor bound to the call (INV-2).
+		return Decision{}, oops.Code("EVALUATE_NO_SUBJECT").
+			With("plugin", in.PluginName).
+			Errorf("evaluate called without an authenticated subject")
+	}
+	if in.Action == "" {
+		return Decision{}, oops.Code("EVALUATE_EMPTY_ACTION").
+			With("plugin", in.PluginName).Errorf("action must not be empty")
+	}
+
+	resType, resID, ok := splitResourceRef(in.Resource)
+	if !ok {
+		return Decision{}, oops.Code("EVALUATE_BAD_RESOURCE").
+			With("plugin", in.PluginName).With("resource", in.Resource).
+			Errorf("resource must be of the form type:id")
+	}
+
+	// Entitlement (INV-3): plugin-owned type or the command carve-out.
+	if resType != commandResourceType && !in.OwnedTypes[resType] {
+		return Decision{}, oops.Code("EVALUATE_UNENTITLED_TYPE").
+			With("plugin", in.PluginName).With("resource_type", resType).
+			Errorf("plugin may not evaluate resource type %q", resType)
+	}
+	_ = resID // present-and-non-empty already validated by splitResourceRef
+
+	req, reqErr := types.NewAccessRequest(in.Subject, in.Action, in.Resource, nil)
+	if reqErr != nil {
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(reqErr)
+	}
+
+	dec, evalErr := in.Engine.Evaluate(ctx, req)
+	if evalErr != nil {
+		errutil.LogErrorContext(ctx, "plugin evaluate engine error", evalErr,
+			"plugin", in.PluginName, "action", in.Action, "resource", in.Resource)
+		// Fail closed: error accompanies a non-allowing decision.
+		return Decision{}, oops.With("plugin", in.PluginName).Wrap(evalErr)
+	}
+
+	result := Decision{
+		Allowed:       dec.IsAllowed(),
+		Reason:        dec.Reason(),
+		MatchedPolicy: dec.PolicyID(),
+	}
+
+	// Audit (INV-4): exactly one host-stamped event per evaluation.
+	if in.Auditor != nil {
+		effect := types.EffectDeny
+		if dec.IsAllowed() {
+			effect = types.EffectAllow
+		}
+		if logErr := in.Auditor.Log(ctx, audit.Event{
+			Name:      "plugin.evaluate",
+			Source:    audit.SourcePlugin,
+			Component: in.PluginName,
+			Subject:   in.Subject,
+			Action:    in.Action,
+			Resource:  in.Resource,
+			Effect:    effect,
+			Timestamp: time.Now(),
+		}); logErr != nil {
+			errutil.LogErrorContext(ctx, "plugin evaluate audit log failed", logErr,
+				"plugin", in.PluginName, "action", in.Action)
+			// Audit failure does not change the authorization outcome.
+		}
+	}
+
+	return result, nil
+}
+
+// splitResourceRef parses "type:id" and requires both halves non-empty.
+func splitResourceRef(ref string) (resType, resID string, ok bool) {
+	i := strings.IndexByte(ref, ':')
+	if i <= 0 || i >= len(ref)-1 {
+		return "", "", false
+	}
+	return ref[:i], ref[i+1:], true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- ./internal/plugin/pluginauthz/`
+Expected: PASS (all 9 tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `task lint:go`
+Expected: no findings. (If `errutil` import is unused in a variant, remove it — do not add a blanket nolint.)
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "feat(pluginauthz): shared per-action plugin authz core (holomush-8kkv5)"`
+
+---
+
+### Task 2: Add `Evaluate` to the `PluginHostService` proto
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/plugin.proto` (service `PluginHostService`, after `IsAnyConnFocused` at line ~98)
+
+- [ ] **Step 1: Add the RPC and messages**
+
+In `service PluginHostService { ... }` add:
+
+```protobuf
+  // Evaluate runs the host ABAC engine for a single action against a single
+  // resource instance owned by the calling plugin. The subject is derived
+  // host-side from the dispatch token (see EmitEvent) — there is no subject
+  // field on the wire (spec §2, INV-1).
+  rpc Evaluate(PluginHostServiceEvaluateRequest) returns (PluginHostServiceEvaluateResponse);
+```
+
+At the bottom of the file, add the messages:
+
+```protobuf
+message PluginHostServiceEvaluateRequest {
+  string action = 1 [(buf.validate.field).string.min_len = 1];
+  // resource is a typed instance ref: "scene:01ABC...".
+  string resource = 2 [(buf.validate.field).string.min_len = 3];
+}
+
+message PluginHostServiceEvaluateResponse {
+  bool allowed = 1;
+  string reason = 2;
+  string matched_policy = 3;
+}
+```
+
+- [ ] **Step 2: Regenerate proto code**
+
+Run: `task proto`
+Expected: `pkg/proto/holomush/plugin/v1/plugin.pb.go` and `plugin_grpc.pb.go` regenerate with `PluginHostServiceEvaluateRequest/Response` and a `PluginHostServiceClient.Evaluate` method. `UnimplementedPluginHostServiceServer.Evaluate` returns `codes.Unimplemented`.
+
+- [ ] **Step 3: Verify generated symbols exist**
+
+Run: `rg -n "func.*PluginHostServiceClient.*Evaluate|PluginHostServiceEvaluateResponse" pkg/proto/holomush/plugin/v1/`
+Expected: matches in `plugin_grpc.pb.go` and `plugin.pb.go`.
+
+- [ ] **Step 4: Build**
+
+Run: `task build`
+Expected: PASS (the `UnimplementedPluginHostServiceServer` embedding keeps the host service compiling before Task 3 implements the method).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(proto): add Evaluate RPC to PluginHostService (holomush-8kkv5)"`
+
+---
+
+## Phase 2: Binary surface
+
+### Task 3: Implement `PluginHostService.Evaluate` (binary)
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go` (add `engine`, `auditor` fields + `WithEngine`/`WithAuditLogger` options near the other `HostOption`s at line ~147)
+- Modify: `internal/plugin/goplugin/host_service.go` (add `Evaluate` method modeled on `EmitEvent` at line 42)
+- Test: `internal/plugin/goplugin/host_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestEvaluateDerivesSubjectFromTokenAndDelegates asserts the binary
+// Evaluate recovers the actor from the dispatch token (NOT plugin-supplied
+// metadata), builds a character: subject, and returns the engine decision.
+func TestEvaluateDerivesSubjectFromToken(t *testing.T) {
+	eng := policytest.AllowAllEngine()
+	manifest := &plugins.Manifest{
+		Name: "core-scenes", Type: plugins.TypeBinary,
+		ResourceTypes: []string{"scene"},
+	}
+	h := newTestHostWithEngine(t, "core-scenes", manifest, eng)
+	srv := &pluginHostServiceServer{host: h, pluginName: "core-scenes"}
+
+	charID := core.NewULID()
+	ctx, _ := contextWithValidToken(t, srv, core.Actor{Kind: core.ActorCharacter, ID: charID.String()})
+
+	resp, err := srv.Evaluate(ctx, &pluginv1.PluginHostServiceEvaluateRequest{
+		Action:   "extend_publish_attempts",
+		Resource: "scene:01SCENE0000000000000000000",
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetAllowed())
+}
+
+func TestEvaluateMissingTokenFailsClosed(t *testing.T) {
+	h := newTestHostWithEngine(t, "core-scenes",
+		&plugins.Manifest{Name: "core-scenes", Type: plugins.TypeBinary, ResourceTypes: []string{"scene"}},
+		policytest.AllowAllEngine())
+	srv := &pluginHostServiceServer{host: h, pluginName: "core-scenes"}
+
+	_, err := srv.Evaluate(context.Background(), &pluginv1.PluginHostServiceEvaluateRequest{
+		Action: "read", Resource: "scene:01SCENE0000000000000000000",
+	})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "EMIT_TOKEN_MISSING")
+}
+
+func TestEvaluateForeignResourceTypeRejected(t *testing.T) {
+	h := newTestHostWithEngine(t, "core-scenes",
+		&plugins.Manifest{Name: "core-scenes", Type: plugins.TypeBinary, ResourceTypes: []string{"scene"}},
+		policytest.AllowAllEngine())
+	srv := &pluginHostServiceServer{host: h, pluginName: "core-scenes"}
+	ctx, _ := contextWithValidToken(t, srv, core.Actor{Kind: core.ActorCharacter, ID: core.NewULID().String()})
+
+	_, err := srv.Evaluate(ctx, &pluginv1.PluginHostServiceEvaluateRequest{
+		Action: "read", Resource: "server:global",
+	})
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "EVALUATE_UNENTITLED_TYPE")
+}
+```
+
+Add the test helper (after `newTestServer`):
+
+```go
+func newTestHostWithEngine(t *testing.T, name string, m *plugins.Manifest, eng types.AccessPolicyEngine) *Host {
+	t.Helper()
+	h := NewHost(WithEngine(eng))
+	h.plugins[name] = &loadedPlugin{manifest: m}
+	return h
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/goplugin/ -run TestEvaluate`
+Expected: FAIL — `WithEngine` undefined, `srv.Evaluate` undefined.
+
+- [ ] **Step 3: Add host fields + options in `host.go`**
+
+Add fields to the `Host` struct (near `eventEmitter`/`tokenStore`, line ~171):
+
+```go
+	engine  types.AccessPolicyEngine // optional; nil = Evaluate fails closed
+	auditor pluginauthz.Auditor      // optional; nil = no audit emission
+```
+
+Add options near the other `HostOption`s:
+
+```go
+// WithEngine configures the host with the ABAC engine used by the
+// PluginHostService.Evaluate RPC.
+func WithEngine(e types.AccessPolicyEngine) HostOption {
+	return func(h *Host) { h.engine = e }
+}
+
+// WithAuditLogger configures the host with the audit sink used to record
+// per-action Evaluate decisions.
+func WithAuditLogger(a pluginauthz.Auditor) HostOption {
+	return func(h *Host) { h.auditor = a }
+}
+```
+
+Add a helper to read a plugin's owned resource types:
+
+```go
+// ownedResourceTypes returns the set of resource type names declared by the
+// named plugin's manifest. Returns an empty (non-nil) set if unknown.
+func (h *Host) ownedResourceTypes(pluginName string) map[string]bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make(map[string]bool)
+	if lp, ok := h.plugins[pluginName]; ok && lp.manifest != nil {
+		for _, rt := range lp.manifest.ResourceTypes {
+			out[rt] = true
+		}
+	}
+	return out
+}
+```
+
+Add imports: `"github.com/holomush/holomush/internal/access/policy/types"` and `"github.com/holomush/holomush/internal/plugin/pluginauthz"`.
+
+- [ ] **Step 4: Implement `Evaluate` in `host_service.go`**
+
+```go
+// Evaluate runs the host ABAC engine for one action against one resource
+// instance owned by the calling plugin. The subject is recovered from the
+// dispatch token (identical anti-spoof posture to EmitEvent, spec §2); the
+// plugin's actor metadata is NOT trusted as an identity claim.
+func (s *pluginHostServiceServer) Evaluate(ctx context.Context, req *pluginv1.PluginHostServiceEvaluateRequest) (*pluginv1.PluginHostServiceEvaluateResponse, error) {
+	if s.host == nil {
+		return nil, oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	s.host.mu.RLock()
+	engine := s.host.engine
+	auditor := s.host.auditor
+	tokenStore := s.host.tokenStore
+	s.host.mu.RUnlock()
+	if engine == nil {
+		return nil, oops.Code("EVALUATE_ENGINE_UNCONFIGURED").
+			With("plugin", s.pluginName).Errorf("plugin host engine is not configured")
+	}
+	if tokenStore == nil {
+		return nil, oops.Code("EMIT_TOKEN_STORE_UNCONFIGURED").
+			With("plugin", s.pluginName).Errorf("plugin token store is not configured")
+	}
+
+	md, _ := metadata.FromIncomingContext(ctx)
+	tokens := md.Get("x-holomush-emit-token")
+	if len(tokens) == 0 || tokens[0] == "" {
+		return nil, oops.Code("EMIT_TOKEN_MISSING").
+			With("plugin", s.pluginName).Errorf("evaluate without a host-issued dispatch token")
+	}
+	storedActor, ok := tokenStore.Lookup(s.pluginName, tokens[0])
+	if !ok {
+		return nil, oops.Code("EMIT_TOKEN_REJECTED").
+			With("plugin", s.pluginName).Errorf("dispatch token is not valid for this plugin")
+	}
+
+	dec, err := pluginauthz.Evaluate(ctx, pluginauthz.Input{
+		Engine:     engine,
+		Auditor:    auditor,
+		PluginName: s.pluginName,
+		OwnedTypes: s.host.ownedResourceTypes(s.pluginName),
+		Subject:    pluginauthz.ActorSubject(storedActor), // shared mapping (INV-5)
+		Action:     req.GetAction(),
+		Resource:   req.GetResource(),
+	})
+	if err != nil {
+		return nil, oops.With("plugin", s.pluginName).Wrap(err)
+	}
+	return &pluginv1.PluginHostServiceEvaluateResponse{
+		Allowed:       dec.Allowed,
+		Reason:        dec.Reason,
+		MatchedPolicy: dec.MatchedPolicy,
+	}, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./internal/plugin/goplugin/ -run TestEvaluate`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "feat(plugin): binary PluginHostService.Evaluate via dispatch-token subject (holomush-8kkv5)"`
+
+---
+
+## Phase 3: Lua surface
+
+### Task 4: `holomush.evaluate` Lua hostfunc
+
+**Files:**
+
+- Create: `internal/plugin/hostfunc/evaluate.go`
+- Modify: `internal/plugin/hostfunc/functions.go` (register `evaluate` in `Register`; add `WithAuditLogger` option + `auditor` field)
+- Test: `internal/plugin/hostfunc/evaluate_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc_test
+
+import (
+	"context"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/policytest"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/hostfunc"
+)
+
+func TestEvaluateAllowedByEngine(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	charID := core.NewULID()
+	L.SetContext(core.WithActor(context.Background(),
+		core.Actor{Kind: core.ActorCharacter, ID: charID.String()}))
+
+	hf := hostfunc.New(nil, hostfunc.WithEngine(policytest.AllowAllEngine()))
+	hf.Register(L, "lua-plug")
+
+	require.NoError(t, L.DoString(`allowed, reason = holomush.evaluate("execute", "command:greet")`))
+	assert.True(t, bool(L.GetGlobal("allowed").(lua.LBool)))
+}
+
+func TestEvaluateDeniedByEngine(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	L.SetContext(core.WithActor(context.Background(),
+		core.Actor{Kind: core.ActorCharacter, ID: core.NewULID().String()}))
+
+	hf := hostfunc.New(nil, hostfunc.WithEngine(policytest.DenyAllEngine()))
+	hf.Register(L, "lua-plug")
+
+	require.NoError(t, L.DoString(`allowed, reason = holomush.evaluate("execute", "command:greet")`))
+	assert.False(t, bool(L.GetGlobal("allowed").(lua.LBool)))
+}
+
+func TestEvaluateNoActorFailsClosed(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	// No actor on the context.
+	L.SetContext(context.Background())
+	hf := hostfunc.New(nil, hostfunc.WithEngine(policytest.AllowAllEngine()))
+	hf.Register(L, "lua-plug")
+
+	require.NoError(t, L.DoString(`allowed, err = holomush.evaluate("execute", "command:greet")`))
+	assert.False(t, bool(L.GetGlobal("allowed").(lua.LBool)))
+	assert.NotEqual(t, lua.LNil, L.GetGlobal("err"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/hostfunc/ -run TestEvaluate`
+Expected: FAIL — `holomush.evaluate` is not registered (Lua attempt-to-call-nil).
+
+- [ ] **Step 3: Implement the hostfunc**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// evaluateFn returns the holomush.evaluate(action, resource) implementation
+// for the named plugin. Lua plugins own no resource_types, so entitlement
+// degrades to the command carve-out (spec §3). Subject is read from the
+// dispatch context (in-process, not forgeable) — never from Lua args.
+func (f *Functions) evaluateFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		action := L.CheckString(1)
+		resource := L.CheckString(2)
+		ctx := luaContext(L)
+
+		if f.engine == nil {
+			L.Push(lua.LFalse)
+			L.Push(lua.LString("access engine not available"))
+			return 2
+		}
+
+		var subject string
+		if actor, ok := core.ActorFromContext(ctx); ok {
+			subject = pluginauthz.ActorSubject(actor) // shared mapping (INV-5)
+		}
+
+		dec, err := pluginauthz.Evaluate(ctx, pluginauthz.Input{
+			Engine:     f.engine,
+			Auditor:    f.auditor,
+			PluginName: pluginName,
+			OwnedTypes: map[string]bool{}, // Lua plugins own no resource types
+			Subject:    subject,
+			Action:     action,
+			Resource:   resource,
+		})
+		if err != nil {
+			L.Push(lua.LFalse)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		L.Push(lua.LBool(dec.Allowed))
+		if dec.Reason != "" {
+			L.Push(lua.LString(dec.Reason))
+		} else {
+			L.Push(lua.LNil)
+		}
+		return 2
+	}
+}
+```
+
+The subject mapping is the shared `pluginauthz.ActorSubject` (Task 1) — do
+NOT redefine it here; both surfaces MUST use the one mapper (INV-5).
+
+> `luaContext(L)` is the existing helper used by other hostfuncs to read `L.Context()` with a background fallback — confirm its name with `rg -n "func luaContext|L.Context\(\)" internal/plugin/hostfunc/` and reuse it. If the helper is named differently, match the existing call sites.
+
+- [ ] **Step 4: Register it + add the auditor field/option in `functions.go`**
+
+In the `Functions` struct add: `auditor pluginauthz.Auditor`.
+Add the option:
+
+```go
+// WithAuditLogger sets the audit sink used by holomush.evaluate.
+func WithAuditLogger(a pluginauthz.Auditor) Option {
+	return func(f *Functions) { f.auditor = a }
+}
+```
+
+In `Register`, alongside the other `holomush.*` registrations, add:
+
+```go
+	L.SetField(holo, "evaluate", L.NewFunction(f.evaluateFn(pluginName)))
+```
+
+(Use whatever local variable the existing code uses for the `holomush` table — confirm with `rg -n "SetField\(.*new_request_id|holomush" internal/plugin/hostfunc/functions.go`.)
+
+If an audit/context meta-test enumerates registered hostfuncs (e.g.
+`RegisteredFunctionsForAudit` exercised by `context_audit_test.go`), add
+`evaluate` to that inventory so the per-hostfunc context-cancellation meta-test
+covers it. Confirm with `rg -n "RegisteredFunctionsForAudit|context_audit" internal/plugin/hostfunc/`; if the inventory is derived automatically from the registered globals, no change is needed.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./internal/plugin/hostfunc/ -run TestEvaluate`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "feat(hostfunc): holomush.evaluate Lua global delegating to pluginauthz (holomush-8kkv5)"`
+
+---
+
+## Phase 4: SDK ergonomics
+
+### Task 5: SDK `host.Evaluate` client helper (binary)
+
+**Files:**
+
+- Create: `pkg/plugin/evaluate_client.go`
+- Test: `pkg/plugin/evaluate_client_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// evalTestServer is a minimal PluginHostService returning a fixed decision.
+type evalTestServer struct {
+	pluginv1.UnimplementedPluginHostServiceServer
+	gotAction, gotResource string
+	allow                  bool
+}
+
+func (s *evalTestServer) Evaluate(_ context.Context, req *pluginv1.PluginHostServiceEvaluateRequest) (*pluginv1.PluginHostServiceEvaluateResponse, error) {
+	s.gotAction = req.GetAction()
+	s.gotResource = req.GetResource()
+	return &pluginv1.PluginHostServiceEvaluateResponse{Allowed: s.allow, Reason: "ok"}, nil
+}
+
+func TestHostEvaluateForwardsAndReturnsDecision(t *testing.T) {
+	srv := &evalTestServer{allow: true}
+	conn := startPluginHostServiceTestServer(t, srv)
+	client := &hostEvaluateClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+
+	dec, err := client.Evaluate(context.Background(), "extend_publish_attempts", "scene:01SCENE")
+	require.NoError(t, err)
+	assert.True(t, dec.Allowed)
+	assert.Equal(t, "extend_publish_attempts", srv.gotAction)
+	assert.Equal(t, "scene:01SCENE", srv.gotResource)
+}
+
+func TestHostEvaluateNilClientFailsClosed(t *testing.T) {
+	client := &hostEvaluateClient{}
+	dec, err := client.Evaluate(context.Background(), "read", "scene:01SCENE")
+	require.Error(t, err)
+	assert.False(t, dec.Allowed)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./pkg/plugin/ -run TestHostEvaluate`
+Expected: FAIL — `hostEvaluateClient` undefined.
+
+- [ ] **Step 3: Implement the client helper**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// EvaluateDecision is the SDK-facing result of a host Evaluate call.
+type EvaluateDecision struct {
+	Allowed       bool
+	Reason        string
+	MatchedPolicy string
+}
+
+// HostEvaluator lets a binary plugin authorize one action against one
+// resource instance through the host ABAC engine. The host derives the
+// subject from the dispatch context — the plugin does not (and cannot)
+// supply it.
+type HostEvaluator interface {
+	Evaluate(ctx context.Context, action, resource string) (EvaluateDecision, error)
+}
+
+type hostEvaluateClient struct {
+	client pluginv1.PluginHostServiceClient
+}
+
+func (c *hostEvaluateClient) Evaluate(ctx context.Context, action, resource string) (EvaluateDecision, error) {
+	if c.client == nil {
+		return EvaluateDecision{}, oops.New("host evaluate client is not configured")
+	}
+	resp, err := c.client.Evaluate(ctx, &pluginv1.PluginHostServiceEvaluateRequest{
+		Action:   action,
+		Resource: resource,
+	})
+	if err != nil {
+		return EvaluateDecision{}, oops.With("action", action).With("resource", resource).Wrap(err)
+	}
+	return EvaluateDecision{
+		Allowed:       resp.GetAllowed(),
+		Reason:        resp.GetReason(),
+		MatchedPolicy: resp.GetMatchedPolicy(),
+	}, nil
+}
+```
+
+> Wire `hostEvaluateClient` into the plugin's host-service injection path the same way `pluginHostFocusClient` is injected during `Init` (see `pkg/plugin/service.go` / `focus_client.go`). Add that injection step here only if Task 7's `core-scenes` wiring needs it; otherwise the constructor is enough for the unit test and a follow-up step wires it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- ./pkg/plugin/ -run TestHostEvaluate`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "feat(pluginsdk): host.Evaluate client helper (holomush-8kkv5)"`
+
+---
+
+### Task 6: SDK gated subcommand dispatcher
+
+**Files:**
+
+- Create: `pkg/plugin/gated_dispatch.go`
+- Test: `pkg/plugin/gated_dispatch_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEvaluator struct {
+	allow     bool
+	gotAction string
+	gotResrc  string
+	calls     int
+}
+
+func (f *fakeEvaluator) Evaluate(_ context.Context, action, resource string) (EvaluateDecision, error) {
+	f.calls++
+	f.gotAction, f.gotResrc = action, resource
+	return EvaluateDecision{Allowed: f.allow, Reason: "nope"}, nil
+}
+
+func TestGatedSubcommand_DenyShortCircuitsBeforeHandler(t *testing.T) {
+	ev := &fakeEvaluator{allow: false}
+	handlerRan := false
+	gs := GatedSubcommand{
+		Name:        "extend",
+		Action:      "extend_publish_attempts",
+		ResourceRef: func(args string) (string, error) { return "scene:" + args, nil },
+		Handler: func(context.Context, CommandRequest, string) (*CommandResponse, error) {
+			handlerRan = true
+			return OK(""), nil
+		},
+	}
+
+	resp, err := gs.Run(context.Background(), ev, CommandRequest{Command: "scene", Args: "extend 01SCENE"}, "01SCENE")
+	require.NoError(t, err)
+	assert.False(t, handlerRan, "handler MUST NOT run when the gate denies")
+	assert.Equal(t, CommandError, resp.Status)
+	assert.Equal(t, "extend_publish_attempts", ev.gotAction)
+	assert.Equal(t, "scene:01SCENE", ev.gotResrc)
+}
+
+func TestGatedSubcommand_AllowRunsHandler(t *testing.T) {
+	ev := &fakeEvaluator{allow: true}
+	gs := GatedSubcommand{
+		Name: "extend", Action: "extend_publish_attempts",
+		ResourceRef: func(args string) (string, error) { return "scene:" + args, nil },
+		Handler: func(context.Context, CommandRequest, string) (*CommandResponse, error) {
+			return OK("extended"), nil
+		},
+	}
+	resp, err := gs.Run(context.Background(), ev, CommandRequest{Command: "scene", Args: "extend 01SCENE"}, "01SCENE")
+	require.NoError(t, err)
+	assert.Equal(t, CommandOK, resp.Status)
+	assert.Equal(t, "extended", resp.Output)
+}
+
+func TestGatedSubcommand_ResourceRefErrorSkipsGateAndHandler(t *testing.T) {
+	ev := &fakeEvaluator{allow: true}
+	handlerRan := false
+	gs := GatedSubcommand{
+		Name: "extend", Action: "extend_publish_attempts",
+		ResourceRef: func(string) (string, error) { return "", assertRefErr() },
+		Handler: func(context.Context, CommandRequest, string) (*CommandResponse, error) {
+			handlerRan = true
+			return OK(""), nil
+		},
+	}
+	resp, err := gs.Run(context.Background(), ev, CommandRequest{Command: "scene", Args: "extend"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, CommandError, resp.Status)
+	assert.False(t, handlerRan)
+	assert.Equal(t, 0, ev.calls, "gate MUST NOT be consulted when the resource ref can't be derived")
+}
+
+func assertRefErr() error { return context.Canceled }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./pkg/plugin/ -run TestGatedSubcommand`
+Expected: FAIL — `GatedSubcommand` undefined.
+
+- [ ] **Step 3: Implement the gated dispatcher**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import "context"
+
+// GatedSubcommand binds a subcommand to an ABAC action + a resource-ref
+// extractor so the host Evaluate gate is structural, not a remembered call.
+// ResourceRef parses the resource instance from the already-split arg
+// remainder (the plugin owns arg-grammar); Handler runs only if Evaluate
+// allows. Signatures match the existing core-scenes subcommand handlers
+// (ctx, req, args) -> (*CommandResponse, error).
+type GatedSubcommand struct {
+	Name        string
+	Action      string
+	ResourceRef func(args string) (string, error)
+	Handler     func(ctx context.Context, req CommandRequest, args string) (*CommandResponse, error)
+}
+
+// Run resolves the resource ref, evaluates the gate, and runs the handler
+// only on allow. A resource-ref error or a denial both short-circuit to a
+// CommandError response; the handler does not run. An engine error returns
+// a CommandFailure (service-degraded) response.
+func (g GatedSubcommand) Run(ctx context.Context, ev HostEvaluator, req CommandRequest, args string) (*CommandResponse, error) {
+	resource, refErr := g.ResourceRef(args)
+	if refErr != nil {
+		return Errorf("%s: %v", g.Name, refErr), nil
+	}
+	dec, err := ev.Evaluate(ctx, g.Action, resource)
+	if err != nil {
+		return Failuref("permission check failed: %v", err), nil
+	}
+	if !dec.Allowed {
+		reason := dec.Reason
+		if reason == "" {
+			reason = "you are not permitted to do that"
+		}
+		return Errorf("%s", reason), nil
+	}
+	return g.Handler(ctx, req, args)
+}
+```
+
+> Constructors confirmed in `pkg/plugin/command.go`: `OK(output) *CommandResponse`, `Errorf(format, ...) *CommandResponse` (returns `Status: CommandError`), and `Failuref(format, ...) *CommandResponse` (returns `Status: CommandFailure`). The engine-error path here wants `CommandFailure`, so it MAY call `Failuref("permission check failed: %v", err)` instead of the inline literal shown — either is fine; prefer `Failuref` for consistency with the rest of the SDK.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- ./pkg/plugin/ -run TestGatedSubcommand`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "feat(pluginsdk): structural gated subcommand dispatcher (holomush-8kkv5)"`
+
+---
+
+## Phase 5: core-scenes migration
+
+### Task 7: Declare the extend action + admin policy; wire `scene extend`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml` (add `actions:` entry + admin policy)
+- Modify: `plugins/core-scenes/commands.go` (wire `extend` via `GatedSubcommand`)
+- Test: `plugins/core-scenes/commands_test.go`
+
+- [ ] **Step 1: Add the action + policy to `plugin.yaml`**
+
+Add an `actions:` block (top-level, sibling to `policies:`):
+
+```yaml
+actions:
+  - extend_publish_attempts
+```
+
+Add to the `policies:` list:
+
+```yaml
+  - name: admin-extend-publish-attempts
+    dsl: >-
+      permit(principal is character, action in ["extend_publish_attempts"],
+      resource is scene) when { "admin" in principal.character.roles };
+```
+
+- [ ] **Step 2: Verify manifest still parses**
+
+Run: `task test -- ./internal/plugin/ -run TestParseManifest`
+Expected: PASS — the new `actions:` entry and policy validate (free-form action name is allowed; admin DSL references the core `principal.character.roles` attribute).
+
+- [ ] **Step 3: Write the failing handler test**
+
+```go
+func TestSceneExtendDeniedForNonAdmin(t *testing.T) {
+	p := newScenePluginWithEvaluator(t, denyEvaluator{}) // Evaluate → not allowed
+	sceneID := createSceneInTest(t, p, "char-alice", "Extendable")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "extend " + sceneID, CharacterID: "char-alice",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandError, resp.Status)
+	assert.Contains(t, resp.Output, "permitted")
+}
+
+func TestSceneExtendAllowedForAdmin(t *testing.T) {
+	p := newScenePluginWithEvaluator(t, allowEvaluator{}) // Evaluate → allowed
+	sceneID := createSceneInTest(t, p, "char-admin", "Extendable")
+
+	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+		Command: "scene", Args: "extend " + sceneID, CharacterID: "char-admin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+}
+```
+
+Add the fakes (`allowEvaluator`/`denyEvaluator` implement `pluginsdk.HostEvaluator`) and a `newScenePluginWithEvaluator` constructor that injects the evaluator into the plugin's command router. Match the existing scene test harness in `commands_test.go`.
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneExtend`
+Expected: FAIL — `extend` subcommand unknown / not gated.
+
+- [ ] **Step 5: Wire the `extend` subcommand through `GatedSubcommand`**
+
+In the subcommand router (`dispatchCommand`), register `extend`:
+
+```go
+pluginsdk.GatedSubcommand{
+	Name:        "extend",
+	Action:      "extend_publish_attempts",
+	ResourceRef: sceneResourceRef, // shared helper added in Task 8 (or inline here if Task 7 lands first)
+	Handler:     p.handleExtend,   // (ctx, req, args) (*pluginsdk.CommandResponse, error)
+}
+```
+
+where the shared resource-ref helper mirrors how existing handlers parse the id
+(`sceneID := strings.TrimSpace(args)`):
+
+```go
+func sceneResourceRef(args string) (string, error) {
+	id := strings.TrimSpace(args)
+	if id == "" {
+		return "", oops.Errorf("scene id is required")
+	}
+	return "scene:" + id, nil
+}
+```
+
+Dispatch it from `dispatchCommand` after the subcommand split, passing the
+plugin's injected `pluginsdk.HostEvaluator` and the arg remainder:
+
+```go
+case "extend":
+	return extendGate.Run(ctx, p.evaluator, req, args)
+```
+
+(If `handleExtend` does not yet exist, add the minimal handler that performs the
+bump via the scene store/service — its body is E2 work tracked under
+holomush-5rh.20.35; this task only proves the gate denies/permits. `p.evaluator`
+is a new `pluginsdk.HostEvaluator` field on `scenePlugin`, injected from the
+`hostEvaluateClient` during `Init` in production and from a fake in tests.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneExtend`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "feat(core-scenes): admin-gated scene extend via host Evaluate (holomush-8kkv5)"`
+
+---
+
+### Task 8: Migrate existing subcommands onto the engine; remove ad-hoc Go authz
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go` (replace Go authz decisions with `GatedSubcommand` gates)
+- Test: `plugins/core-scenes/commands_test.go`
+
+- [ ] **Step 1: Write the failing table-driven test (INV-7 backstop)**
+
+```go
+// TestSceneGatedSubcommands_DenyWhenPolicyDenies asserts every gated
+// subcommand short-circuits to a denial when the engine denies.
+func TestSceneGatedSubcommands_DenyWhenPolicyDenies(t *testing.T) {
+	cases := []struct{ sub, action string }{
+		{"end", "end"},
+		{"pause", "pause"},
+		{"resume", "resume"},
+		{"set", "update"},
+		{"invite", "invite"},
+		{"kick", "kick"},
+		{"transfer", "transfer-ownership"},
+		{"leave", "leave"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sub, func(t *testing.T) {
+			p := newScenePluginWithEvaluator(t, denyEvaluator{})
+			sceneID := createSceneInTest(t, p, "char-alice", "T")
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command: "scene", Args: tc.sub + " " + sceneID, CharacterID: "char-bob",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, pluginsdk.CommandError, resp.Status, "subcommand %q must deny via engine", tc.sub)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./plugins/core-scenes/ -run TestSceneGatedSubcommands`
+Expected: FAIL — subcommands still gate via Go `IsParticipant`, not the injected evaluator.
+
+- [ ] **Step 3: Convert each subcommand to a `GatedSubcommand`**
+
+For each row in the migration table (spec §7), register a `GatedSubcommand` with the verbatim action string and a `ResourceRef` of `"scene:" + <parsed id>`. Then delete the now-redundant Go authorization-decision checks — specifically the `store.IsParticipant` gate in `handleEmit` (`commands.go::handleEmit`, ~L844) and the owner checks in the end/pause/transfer/kick handlers. Keep cheap structural guards (arity, scene-id present/parseable).
+
+Example for `end`:
+
+```go
+endGate := pluginsdk.GatedSubcommand{
+	Name: "end", Action: "end",
+	ResourceRef: sceneResourceRef, // shared helper: "scene:" + TrimSpace(args)
+	Handler:     p.handleEnd,      // existing (ctx, req, args) (*CommandResponse, error)
+}
+// in dispatchCommand: case "end": return endGate.Run(ctx, p.evaluator, req, args)
+```
+
+Add the shared `ResourceRef` helper once (introduced in Task 7 if that lands
+first; otherwise here). For subcommands whose id is not the whole remainder
+(e.g. `invite <scene> <char>`, which uses `strings.Fields(args)[0]`), give that
+subcommand its own `ResourceRef` that mirrors its existing parser:
+
+```go
+func sceneResourceRef(args string) (string, error) {
+	id := strings.TrimSpace(args)
+	if id == "" {
+		return "", oops.Errorf("scene id is required")
+	}
+	return "scene:" + id, nil
+}
+
+func sceneResourceRefFirstField(args string) (string, error) {
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		return "", oops.Errorf("scene id is required")
+	}
+	return "scene:" + fields[0], nil
+}
+```
+
+- [ ] **Step 4: Run the full core-scenes suite**
+
+Run: `task test -- ./plugins/core-scenes/`
+Expected: PASS. Pre-existing participant/owner tests now pass through the engine gate; the `IsParticipant`-specific unit tests that asserted the Go path are updated or removed (the behavior is now asserted through the evaluator).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `task lint:go`
+`jj commit -m "refactor(core-scenes): migrate per-action authz from Go checks to host Evaluate (holomush-8kkv5)"`
+
+---
+
+## Phase 6: Meta-tests, E2E, docs
+
+### Task 9: Structural invariant meta-tests (INV-1, INV-5)
+
+**Files:**
+
+- Test: `internal/plugin/goplugin/evaluate_invariants_test.go` (Create)
+
+- [ ] **Step 1: Write INV-1 — no subject field on the wire**
+
+```go
+func TestINV1_EvaluateRequestHasNoSubjectField(t *testing.T) {
+	md := (&pluginv1.PluginHostServiceEvaluateRequest{}).ProtoReflect().Descriptor()
+	for i := 0; i < md.Fields().Len(); i++ {
+		name := string(md.Fields().Get(i).Name())
+		assert.NotEqual(t, "subject", name, "EvaluateRequest MUST NOT carry a subject field (INV-1)")
+	}
+}
+```
+
+- [ ] **Step 2: Write INV-5 — both surfaces delegate to pluginauthz.Evaluate**
+
+```go
+// TestINV5_BothSurfacesDelegateToPluginauthz asserts the binary and Lua
+// surfaces produce identical decisions for the same engine + inputs, which
+// holds because both call pluginauthz.Evaluate. A divergence (e.g. one
+// surface skipping entitlement) breaks this.
+func TestINV5_BinaryAndLuaAgreeOnEntitlementReject(t *testing.T) {
+	// Binary: foreign type rejected.
+	// (reuse TestEvaluateForeignResourceTypeRejected harness)
+	// Lua: foreign type rejected.
+	L := lua.NewState(); defer L.Close()
+	L.SetContext(core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: core.NewULID().String()}))
+	hf := hostfunc.New(nil, hostfunc.WithEngine(policytest.AllowAllEngine()))
+	hf.Register(L, "lua-plug")
+	require.NoError(t, L.DoString(`allowed, err = holomush.evaluate("read", "scene:01X")`)) // lua owns no types
+	assert.False(t, bool(L.GetGlobal("allowed").(lua.LBool)), "lua must reject unowned type via shared entitlement")
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `task test -- ./internal/plugin/goplugin/ -run TestINV`
+Expected: PASS.
+`jj commit -m "test(plugin): INV-1 no-subject-field + INV-5 surface-parity meta-tests (holomush-8kkv5)"`
+
+---
+
+### Task 10: Real-engine integration test of the admin gate
+
+**Harness reality (why this is not a full-stack Ginkgo E2E):** the
+`integrationtest` harness wires an **empty** command registry
+(`internal/testsupport/integrationtest/harness.go:214` —
+`command.NewDispatcher(command.NewRegistry(), pe)`), loads **no plugins**, and
+uses **fake** engines by design (the privacy suite passes
+`WithPolicyEngine(policytest.DenyAllEngine())`); `Session.CreateScene` is a
+`t.Fatalf` stub (`session.go:461`, TODO iwzt-9). So a `scene extend`
+command-path E2E and any participant/owner assertion (which need the
+core-scenes `AttributeResolver` loaded) are **blocked on harness extension** and
+are deferred to a follow-up (Step 3). The `extend_publish_attempts` admin gate
+is **principal-attribute-only** (`"admin" in principal.character.roles`), so it
+needs no scene attribute resolution and is provable **now** against a real
+engine using the policy package's existing engine-builder
+(`createTestEngineWithPolicies` + `characterProvider` in `seed_smoke_test.go`).
+`pluginauthz` imports only `policy/types` + `audit` + `core`, so a `package
+policy` test may import it with no cycle.
+
+**Files:**
+
+- Create: `internal/access/policy/plugin_evaluate_gate_test.go` (package `policy`)
+
+- [ ] **Step 1: Write the real-engine table test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+)
+
+// adminExtendDSL mirrors the admin-extend-publish-attempts policy declared in
+// plugins/core-scenes/plugin.yaml (Task 7). The test installs it into a real
+// Engine so the gate is exercised through real DSL parsing + condition
+// evaluation against principal.character.roles, via pluginauthz.Evaluate.
+const adminExtendDSL = `permit(principal is character, action in ["extend_publish_attempts"], resource is scene) when { "admin" in principal.character.roles };`
+
+func TestPluginEvaluate_AdminExtendGate_RealEngine(t *testing.T) {
+	cases := []struct {
+		name      string
+		roles     []string
+		wantAllow bool
+	}{
+		{"admin allowed", []string{"admin"}, true},
+		{"plain player denied", []string{"player"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := characterProvider(map[string]any{
+				"id":    "01CHAR",
+				"roles": tc.roles,
+			}, nil)
+			eng := createTestEngineWithPolicies(t, []string{adminExtendDSL},
+				[]attribute.AttributeProvider{prov})
+
+			dec, err := pluginauthz.Evaluate(context.Background(), pluginauthz.Input{
+				Engine:     eng,
+				PluginName: "core-scenes",
+				OwnedTypes: map[string]bool{"scene": true},
+				Subject:    "character:01CHAR",
+				Action:     "extend_publish_attempts",
+				Resource:   "scene:01SCENE0000000000000000000",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAllow, dec.Allowed)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `task test -- ./internal/access/policy/ -run TestPluginEvaluate_AdminExtendGate`
+Expected: PASS — admin allowed, player denied, through the real engine + real
+DSL condition evaluation. (No Docker; mock providers + in-memory engine.)
+Commit: `jj commit -m "test(policy): real-engine admin-extend gate via pluginauthz.Evaluate (holomush-8kkv5)"`
+
+- [ ] **Step 3: File the deferred full-stack E2E follow-up**
+
+The full `scene extend` command-path E2E (telnet → loaded core-scenes plugin →
+gated dispatcher → host Evaluate) and participant/owner-via-`AttributeResolver`
+assertions require the `integrationtest` harness to (a) load the core-scenes
+binary plugin + its command registry and (b) implement the scene-creation RPC
+(`Session.CreateScene`, TODO iwzt-9). That is harness infrastructure, out of
+scope for this feature. File it:
+
+Run:
+
+```bash
+bd create --type=task --priority=2 --labels="abac,plugin,test,e2e" \
+  --title="E2E: scene extend command-path via integrationtest (Ginkgo/Gomega)" \
+  --description="Full-stack E2E for the host Evaluate gate: load core-scenes into the integrationtest harness + scene-creation RPC, then drive 'scene extend' (admin allow / player deny) and 'scene end' non-participant deny THROUGH the real engine + AttributeResolver. MUST use Ginkgo/Gomega, //go:build integration, task test:int. Deferred from holomush-8kkv5 because the harness currently wires an empty command registry and Session.CreateScene is a stub (iwzt-9)."
+bd dep add <new-id> iwzt-9   # blocked-by the harness scene-creation work
+```
+
+(Use the real iwzt-9 bead id; confirm with `bd list --json | rg iwzt`.) This
+follow-up carries the Ginkgo/Gomega full-stack E2E the project standard expects;
+the admin-gate security property itself is proven now by Step 1.
+
+---
+
+### Task 11: Plugin-author documentation (PR-blocking)
+
+**Files:**
+
+- Create: `site/docs/extending/plugin-host-evaluate.md`
+
+- [ ] **Step 1: Write the guide**
+
+Document, with runnable snippets: the `host.Evaluate(ctx, action, resource)` Go SDK call and the `holomush.evaluate(action, resource)` Lua global; the `GatedSubcommand` pattern (action + `ResourceRef` + handler); the entitlement rule (resource type must be plugin-owned, or `command` for own commands); and that the subject is **host-derived** (never plugin-supplied). Cross-link `site/docs/extending/abac-attribute-resolver.md`.
+
+- [ ] **Step 2: Lint the markdown**
+
+Run: `rumdl check site/docs/extending/plugin-host-evaluate.md`
+Expected: no issues. (If `site/.rumdl.toml` applies, run from repo root so the right config is picked up.)
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(extending): plugin host Evaluate + gated-subcommand guide (holomush-8kkv5)"`
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green (full lane).
+- [ ] All seven invariants (INV-1…7) have a passing test (INV-1/5 meta-tests Task 9; INV-2/3/6 + audit/INV-4 unit Task 1; INV-7 Task 8; admin gate against the real engine Task 10).
+- [ ] Tier-2 full-stack command-path E2E follow-up bead filed and blocked on iwzt-9 (Task 10 Step 3).
+- [ ] `bd` children all closed; epic ready to close.
+- [ ] Spec, plan, ADRs, and code on `main` (docs-first PR or single PR per the writing-plans handoff).
+<!-- adr-capture: sha256=9e279a280a56d971; session=cli; ts=2026-05-25T14:26:23Z; adrs=holomush-dttdj,holomush-qeypl,holomush-61rdl,holomush-9l9pu -->

--- a/docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md
+++ b/docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md
@@ -1,0 +1,411 @@
+# Plugin Host `Evaluate` — per-action ABAC for plugin commands
+
+**Date:** 2026-05-25
+**Status:** Draft
+**Design bead:** holomush-8kkv5
+**Unblocks:** holomush-5rh.20.35 (E2: scene publish vote extend)
+
+## Problem Statement
+
+Plugin commands cannot enforce per-subcommand / per-action authorization. A
+plugin command (e.g. `scene`) declares **command-level** capabilities in
+`plugin.yaml` (`scene → {action: write, resource: scene}`). At dispatch the host
+evaluates two coarse gates:
+
+1. **Layer 1** — `engine.Evaluate(subject, "execute", "command:scene")` (may this
+   character run `scene` at all).
+2. **Layer 2** — capability pre-flight `engine.CanPerformAction(subject, "write",
+   "scene", scope)`. Per the 2026-04-07 C1 hardening this resolves **only**
+   subject / environment / action attributes — never a resource instance — so it
+   passes *optimistically* with no instance to evaluate against.
+
+The per-operation policies that `core-scenes` already declares in `plugin.yaml`
+(`end-own-scene`, `pause-own-scene`, `write-scene-as-participant`,
+`transfer-ownership`, …) are **never evaluated**: there is no call-site that has
+both a real resource instance *and* a specific action. A subcommand cannot map to
+a distinct command-level capability without breaking sibling subcommands (they
+share one command entry).
+
+The plugin also cannot self-gate **principal-attribute** policies (admin):
+
+- No `roles` field on `pluginsdk.CommandRequest` (verified: only
+  `Command/Args/CharacterID/CharacterName/LocationID/SessionID/PlayerID/InvokedAs/ConnectionID`).
+- No roles on `QueryCharacter`'s `CharacterInfo` (verified: only `id` + `name`).
+- No ABAC-evaluate host RPC on any surface (verified: `plugin.proto`
+  `PluginHostService`, `hostfunc.proto` `HostFunctionsService`, `audit.proto`,
+  `attribute.proto` — the last is the inverse host→plugin direction).
+
+Resource-relative policies (owner / participant) *are* self-gatable today —
+`core-scenes` does ad-hoc `store.IsParticipant` checks in Go
+(`commands.go::handleEmit`, ~L844) — but admin is not.
+
+**Impact:** E2 (`scene publish vote extend`) must be admin-only. Wiring it ungated
+is a security regression (exposes `max_publish_attempts` bumping to every player).
+
+## What already exists (and is reused unchanged)
+
+The 2026-04-06 plugin-ABAC-trust-boundary work built most of the machinery:
+
+- `core-scenes` **owns** the `scene` resource type (`scene` is **not** in
+  `ProtectedResourceTypes`; `plugin.yaml` declares `resource_types: [scene]`).
+- All per-operation `scene` policies are already declared in
+  `plugins/core-scenes/plugin.yaml`.
+- `core-scenes` implements the `AttributeResolver` gRPC service
+  (`resolver.go`) exposing `participants`, `owner`, etc.
+- The host resolves **principal** attributes (`principal.character.roles`,
+  defaulting to `["player"]` — `attribute/character.go`).
+
+The engine, the policies, and attribute resolution are all in place. The single
+missing primitive is an **evaluation entry point** the plugin can call with a
+real resource instance and a specific action.
+
+## RFC 2119 Keywords
+
+| Keyword        | Meaning                                    |
+| -------------- | ------------------------------------------ |
+| **MUST**       | Absolute requirement                       |
+| **MUST NOT**   | Absolute prohibition                       |
+| **SHOULD**     | Recommended, may ignore with justification |
+| **SHOULD NOT** | Not recommended                            |
+| **MAY**        | Optional                                   |
+
+## Decisions (brainstorm 2026-05-25)
+
+- **Scope:** general, reusable entry point. E2 is the first consumer; B8 and
+  future plugins reuse it.
+- **Blast radius:** *unify on engine.* All per-action plugin authorization flows
+  through the host engine via `Evaluate`; `core-scenes`' ad-hoc Go decision
+  checks migrate to DSL + `Evaluate` calls. The engine becomes the single
+  source of truth for per-action plugin authorization.
+- **Architecture:** Option C (host `Evaluate` RPC), rejecting:
+  - **A** (host parses subcommands and evaluates at dispatch) — a layering
+    violation: the host only sees `cmd.Args` as an opaque string and would have
+    to learn every plugin's subcommand grammar *and* extract resource IDs from
+    free-form args.
+  - **B** (expose `roles` to plugins so handlers self-gate admin) — moves
+    enforcement *out* of the host engine (the admin DSL policy becomes
+    decorative), contradicting "unify on engine" and creating two enforcement
+    engines.
+
+## Design
+
+### 1. The `Evaluate` entry point
+
+A single new host RPC, mirrored on both plugin surfaces:
+
+```protobuf
+rpc Evaluate(EvaluateRequest) returns (EvaluateResponse);
+
+message EvaluateRequest {
+  string action   = 1;  // "extend_publish_attempts", "write", "end", "invite"
+  string resource = 2;  // typed *instance* ref: "scene:01ABC..."
+  // NB: no `subject` field — see §2.
+}
+
+message EvaluateResponse {
+  bool   allowed        = 1;
+  string reason         = 2;  // human-facing denial text for the user message
+  string matched_policy = 3;  // for the audit trail / debugging
+}
+```
+
+The plugin supplies **action + resource instance**; the host runs the full ABAC
+pipeline (principal attributes it owns, resource attributes via the plugin's own
+`AttributeResolver`, environment attributes) and returns the decision. Nothing
+else about the engine changes.
+
+This is a **third enforcement tier**, not a replacement. Layer 1 (`execute
+command:<name>`) and Layer 2 (type-level capability pre-flight) stay at dispatch.
+`Evaluate` adds Layer 3 *inside the handler*: "may this actor do *this
+subcommand* on *this resource instance*."
+
+### 2. Subject authenticity (anti-spoofing)
+
+`EvaluateRequest` has **no subject field by construction.** The host derives the
+subject from the authenticated actor already bound to the call.
+
+- **MUST** derive subject host-side:
+  - **Binary:** from the actor-metadata + token mechanism the host already uses
+    to authenticate `EmitEvent`. The dispatcher stamps `core.WithActor` before
+    `DeliverCommand` (`dispatcher.go::dispatchToPlugin`); the host service
+    recovers the actor on the inbound `Evaluate` call.
+  - **Lua:** from the dispatch `ctx` threaded into the hostfunc (the path
+    `list_commands` already uses).
+- **MUST** fail closed: if no authenticated actor is bound to the call,
+  `Evaluate` returns `allowed=false` and an error. A plugin can never evaluate
+  as an empty or chosen subject.
+- v1 is locked to *"the current actor."* Evaluating on behalf of **another**
+  character is out of scope (§ Out of Scope).
+
+This mirrors the existing anti-spoof stance in `dispatcher.go::extractAuditHints`
+("the plugin cannot spoof these fields — the dispatcher overwrites them").
+
+### 3. Entitlement (oracle / probe containment)
+
+To stop a plugin using `Evaluate` as a policy oracle against unrelated domains:
+
+- The `resource` type **MUST** be one the plugin owns (declared in
+  `resource_types`) or `command` for its own commands — the same trust boundary
+  the policy installer already enforces (2026-04-06 §2.1). `core-scenes` asking
+  about `scene` is allowed; asking about `server` or another plugin's resource is
+  **rejected** (deny + error).
+- `action` stays free-form (like capabilities); an unmatched action default-
+  denies. No extra entitlement check on action beyond non-empty.
+- Rationale: a plugin already has full data access to its own resources, so "can
+  this actor do X on *my* resource" leaks nothing new — and that answer is
+  precisely what it needs to gate. Cross-domain probing is what is forbidden.
+
+**Entitlement anchor (binary and Lua).** The ownership signal the host checks is
+**identical for both runtimes**: the requesting plugin's manifest. A plugin may
+evaluate resource type `R` iff `R ∈ manifest.resource_types`, plus the `command`
+carve-out for its own commands. Because `resource_types` is binary-only
+(`internal/plugin/manifest.go:570-572` — Lua and setting plugins MUST NOT declare
+it), a Lua plugin's `resource_types` is structurally empty, so its effective
+entitlement degrades to the `command` carve-out only. This is **not** a
+runtime-asymmetric trust rule — the *rule* is one line of host code applied to
+both surfaces; only the manifest *data* differs. It also falls out correctly from
+the existing architecture: resource-instance evaluation needs an
+`AttributeResolver`, which is binary-only (2026-04-06 §3), so instance-level
+`Evaluate` is inherently a binary-plugin capability. The Lua surface exists for
+parity (§4) and the `command` carve-out, and fails closed for resource types the
+Lua plugin does not (cannot) own. This data-vs-policy distinction is exactly what
+the plugin-runtime-symmetry invariant permits ("runtime-specific code is
+acceptable for runtime-specific concerns … but MUST NOT differ in policy / trust /
+manifest-gate dimensions").
+
+### 4. Runtime symmetry (binary + Lua, shipped together)
+
+Per the plugin-runtime-symmetry invariant and the `host_rpc_lua_parity` rule,
+`Evaluate` **MUST** land on both surfaces in one change:
+
+- **Binary:** `PluginHostService.Evaluate` (gRPC) + Go SDK helper
+  `host.Evaluate(ctx, action, resource) (Decision, error)`.
+- **Lua:** `HostFunctionsService.Evaluate` + hostfunc
+  `holomush.evaluate(action, resource) -> allowed, reason`.
+- Both **MUST** dispatch into one host-side implementation that calls the ABAC
+  engine — the gate lives at the common path, so policy / trust behavior cannot
+  diverge between runtimes. Runtime-specific code is limited to runtime-specific
+  concerns (binary token auth vs. Lua ctx threading), never the decision logic.
+
+### 5. Audit (host-owned, automatic)
+
+Every `Evaluate` is an authorization decision, so the **host MUST** emit exactly
+one audit event per call: subject host-stamped, plus action / resource / effect /
+matched-policy / `component=<plugin>`. The plugin **MUST NOT** hand-roll authz
+audit hints for these decisions — the host owns the stamping, so a plugin can
+neither forge nor forget the authz trail. This also closes a current gap:
+operators have no decision trail for plugin per-action gates today.
+
+### 6. Making the gate hard to forget (cooperative-enforcement risk)
+
+C's one weakness: enforcement is cooperative — a plugin author who forgets to
+call `Evaluate` ships the action ungated. The mitigation is SDK ergonomics that
+make the gate **structural**, not a remembered call.
+
+- The SDK **SHOULD** provide a **gated subcommand dispatcher**. A subcommand is
+  registered as `{name, action, resourceRef func(req) (string, error), handler}`.
+  The SDK calls `Evaluate(action, resourceRef(req))` *before* `handler` and
+  short-circuits to a denial response on deny.
+- The plugin supplies the `resourceRef` extractor (e.g. "parse the scene id from
+  arg 1", or "the scene I'm focused on") — so arg-grammar stays in the plugin (no
+  layering violation), but the gate is automatic for every subcommand registered
+  through the helper.
+- `core-scenes` already has an internal subcommand router (`dispatchCommand`); it
+  adopts the gated variant.
+- Backstop: a table-driven test asserting every gated subcommand denies when its
+  policy denies (INV-7).
+
+The host **MUST NOT** attempt to verify call-sites — it never sees subcommands.
+For untrusted third-party plugins, the residual "didn't gate" risk is bounded by
+§2–§3 (they can only evaluate / gate their own resources). The threat model here
+is "core plugin author forgets," which a structural SDK gate addresses.
+
+### 7. `core-scenes` migration + E2's admin gate
+
+**New action + policy (E2, unblocks holomush-5rh.20.35):**
+
+- Declare `extend_publish_attempts` in the `core-scenes` manifest `actions:`.
+- Add to `plugins/core-scenes/plugin.yaml`:
+
+  ```text
+  permit(principal is character, action in ["extend_publish_attempts"], resource is scene)
+    when { "admin" in principal.character.roles };
+  ```
+
+- Wire `scene extend …` through the gated subcommand dispatcher →
+  `Evaluate("extend_publish_attempts", "scene:<id>")`. Non-admins are denied by
+  the engine; the command ships gated.
+
+**Migrate existing subcommands onto the engine (unify):** each handler's ad-hoc
+Go authorization decision is replaced by an `Evaluate` call against the policy
+that **already exists** in `plugin.yaml`:
+
+The **Action** column below is the exact action string the policy DSL matches
+(verified against `plugins/core-scenes/plugin.yaml`); the `Evaluate` call MUST
+pass that string verbatim or the policy will not match and the engine will
+default-deny.
+
+| Subcommand         | Existing policy (already declared)                  | Action (verbatim)    |
+| ------------------ | --------------------------------------------------- | -------------------- |
+| `end`              | `end-own-scene`                                     | `end`                |
+| `pause` / `resume` | `pause-own-scene` / `resume-scene-as-participant`   | `pause` / `resume`   |
+| `set`              | `update-own-scene`                                  | `update`             |
+| `pose` / write     | `write-scene-as-participant`                        | `write`              |
+| `invite` / `kick`  | `invite-to-scene` / `kick-from-scene`               | `invite` / `kick`    |
+| `transfer`         | `transfer-ownership`                                | `transfer-ownership` |
+| `join`             | `join-open-scene` / `join-private-scene-as-invitee` | `join`               |
+| `leave` / `info`   | `leave-scene` / `read-scene-as-participant`         | `leave` / `read`     |
+
+The engine becomes the single authoritative per-action decision. Cheap
+structural guards (arity, scene-id present/parseable) stay in Go; the
+authorization-decision Go checks (`store.IsParticipant` at `commands.go::handleEmit`, ~L844, the
+owner checks) are **removed** — keeping them re-introduces the two-sources-of-
+truth problem unification exists to eliminate. The `commands.go:844`
+"defense-in-depth" comment becomes the `Evaluate` call itself.
+
+### 8. Invariants
+
+| ID    | Invariant |
+| ----- | --------- |
+| INV-1 | `Evaluate`'s subject is host-derived from the authenticated actor; there is no `subject` field on the wire. *(meta-test: proto descriptor has no subject field)* |
+| INV-2 | No authenticated actor bound to the call → `Evaluate` returns deny + error (fail-closed). |
+| INV-3 | A `resource` type the plugin does not own → rejected (entitlement). |
+| INV-4 | Each `Evaluate` emits exactly one host-stamped audit event. |
+| INV-5 | Binary and Lua surfaces reach identical host evaluation logic. *(parity meta-test)* |
+| INV-6 | Unmatched action / resource → deny (default-deny preserved). |
+| INV-7 | Every subcommand registered as "gated" denies when its policy denies (no ungated gated-subcommand). |
+
+### 9. Files changed (anticipated)
+
+| File | Change |
+| ---- | ------ |
+| `api/proto/holomush/plugin/v1/plugin.proto` | Add `Evaluate` to `PluginHostService` + messages |
+| `api/proto/holomush/plugin/v1/hostfunc.proto` | Add `Evaluate` to `HostFunctionsService` + messages |
+| `internal/plugin/goplugin/host_service.go` | Implement binary `Evaluate` (subject from actor/token; entitlement; engine call; audit) |
+| `internal/plugin/hostfunc/*.go` | Implement Lua `Evaluate` hostfunc + `holomush.evaluate` |
+| `pkg/plugin/*.go` | Go SDK `host.Evaluate` helper; gated subcommand dispatcher |
+| `plugins/core-scenes/plugin.yaml` | Declare `extend_publish_attempts` under `actions:`; add admin policy under `policies:` |
+| `plugins/core-scenes/commands.go` | Migrate subcommands to gated dispatcher; remove ad-hoc Go authz checks |
+| `site/docs/extending/` | Plugin author guide: `Evaluate` + gated-subcommand pattern |
+| `test/integration/...` | E2E coverage (§10) |
+
+### 10. Testing
+
+This work is **TDD** (`dev-flow:test-driven-development`): every test below is
+written **before** the implementation it covers, and **MUST** fail for the right
+reason before the implementation lands. Per-package coverage **MUST** be **≥ 80%**
+(`task test:cover`) for each new surface on its own merits — the host `Evaluate`
+implementation, the SDK gated dispatcher, and the Lua hostfunc each meet the bar
+independently; they MUST NOT be diluted by the repo aggregate. Tests are
+table-driven wherever the input space is enumerable. Unit-layer dependencies (the
+engine, the actor source) use `mockery`-generated mocks; no real DB at the unit
+layer.
+
+#### 10.1 Unit — host `Evaluate` (the shared binary + Lua implementation)
+
+**Happy path**
+
+- Allow returned when policy permits the action on the instance (participant +
+  `write`; admin + `extend_publish_attempts`).
+- `allowed`, `reason`, and `matched_policy` populated correctly on both allow and
+  deny.
+- Exactly one host-stamped audit event emitted per call (INV-4).
+
+**Boundaries / edges**
+
+- Empty `action` → reject (non-empty rule).
+- Malformed `resource` ref (no colon, empty type, empty id) → reject.
+- Entitlement boundary (INV-3): plugin-owned resource type passes through to the
+  engine; foreign or core-protected type rejected **before** the engine.
+- Lua plugin (structurally empty `resource_types`) evaluating an instance type →
+  rejected at entitlement; the `command` carve-out for its own command → allowed
+  through (INV-3 across runtimes).
+- Action matching no policy → deny (INV-6 default-deny).
+
+**Error / fail-closed**
+
+- No authenticated actor bound to the call → deny + error (INV-2).
+- Engine returns an error → deny + error surfaced (fail-closed; assert it does
+  **not** fail open).
+- `AttributeResolver` unavailable / erroring → engine's existing circuit-breaker
+  path → deny.
+
+#### 10.2 Unit — SDK gated subcommand dispatcher
+
+- A gated subcommand calls `Evaluate(action, resourceRef(req))` before the
+  handler; the handler is **not** invoked on deny (INV-7).
+- Deny short-circuits to a user-facing `CommandError` denial, not a fatal.
+- `resourceRef` extractor error → usage/denial error, handler not invoked.
+- Ungated subcommand path still works (back-compat).
+- Table-driven over the full `core-scenes` subcommand set asserting
+  deny-when-policy-denies for every gated subcommand (INV-7 backstop).
+
+#### 10.3 Meta-tests (structural invariants)
+
+- **INV-1:** reflect over the generated `EvaluateRequest` — assert it has **no**
+  `subject` field.
+- **INV-5:** assert both `PluginHostService.Evaluate` (binary) and
+  `HostFunctionsService.Evaluate` (Lua) delegate to the one shared host
+  evaluation function (single call-through via a shared seam / counting fake) —
+  the runtime-symmetry guarantee.
+
+#### 10.4 Real-engine + full-stack E2E
+
+Two tiers, split by what the test infrastructure currently supports.
+
+**Tier 1 — real-engine gate test (in scope, feasible now).** The
+`extend_publish_attempts` admin gate is principal-attribute-only
+(`"admin" in principal.character.roles`), so it needs no scene
+`AttributeResolver`. It **MUST** be proven against a **real** `Engine` built
+from the policy package's engine-builder (`createTestEngineWithPolicies` +
+`characterProvider`, `internal/access/policy/seed_smoke_test.go`): install the
+`admin-extend-publish-attempts` DSL, then drive `pluginauthz.Evaluate` with an
+admin subject (→ allow) and a plain-player subject (→ deny). This exercises real
+DSL parsing + condition evaluation + the `pluginauthz` core (entitlement, audit)
+— not an allow-all stub.
+
+**Tier 2 — full-stack command-path E2E (deferred to a follow-up, depends on
+iwzt-9).** A `scene extend` E2E driven through the real stack
+(telnet → loaded core-scenes plugin → gated dispatcher → host Evaluate), plus
+participant/owner regression locks (`scene end`/`pause`/`transfer`/`kick` denied
+for non-participants **through the engine + AttributeResolver**), **MUST** use
+**Ginkgo/Gomega** (project E2E standard), build tag `//go:build integration`,
+`task test:int`. These are **not feasible today**: the `integrationtest` harness
+wires an **empty command registry** (`harness.go:214`), loads **no plugins**, and
+uses **fake** engines by design (the privacy suite passes
+`WithPolicyEngine(policytest.DenyAllEngine())`); `Session.CreateScene` is a
+stub (`session.go:461`, TODO iwzt-9). They are filed as a follow-up bead blocked
+on the harness extension (load core-scenes + scene-creation RPC). `eventbustest`
+**MUST NOT** be used for E2E.
+
+Coverage of the invariants does **not** depend on Tier 2: INV-4 (audit) and
+INV-2/3/6 are covered by Tier-1 + the §10.1 unit suite; INV-5 (runtime parity)
+by the §10.3 meta-test. Tier 2 adds command-path UX coverage and
+resource-attribute regression locks once the harness supports them.
+
+#### 10.5 Docs
+
+The `site/docs/extending/` guide is **PR-blocking**: it documents the `Evaluate`
+SDK helper, the gated-subcommand pattern, the entitlement rule, and that the
+subject is host-derived (never plugin-supplied).
+
+## Out of Scope
+
+- Evaluating on behalf of a subject **other than** the current actor (future,
+  higher-risk; needs its own design).
+- Decision caching (the engine already caches attribute resolution).
+- Changes to the Layer-1 / Layer-2 dispatch gates.
+- Wiring B8's `publish` / `withdraw_publish` actions specifically — the mechanism
+  supports them, but those ride on B8's own bead.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Plugin forgets to gate a subcommand → ungated action | Structural SDK gated dispatcher (§6) + INV-7 backstop; untrusted plugins bounded by §2–§3 |
+| Plugin uses `Evaluate` as a cross-domain policy oracle | Entitlement check (§3) — resource type must be plugin-owned |
+| Subject spoofing | No subject on the wire; host-derived + fail-closed (§2) |
+| Runtime privilege gradient | Parity requirement (§4) + INV-5 meta-test |
+| Removing Go checks regresses behavior | Existing `plugin.yaml` policies already encode the same rules; E2E asserts engine-path equivalence |
+
+<!-- adr-capture: sha256=7f2b311436e3cf10; session=cli; ts=2026-05-25T14:26:23Z; adrs=holomush-dttdj,holomush-qeypl,holomush-61rdl,holomush-9l9pu -->


### PR DESCRIPTION
Design docs for the **plugin host `Evaluate`** feature — a host RPC that closes the per-subcommand/per-action plugin authorization gap (unblocks E2 `scene extend`, `holomush-5rh.20.35`).

## What's here (docs only)

- **Spec** — `docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md` (3 design-review rounds → READY)
- **Plan** — `docs/superpowers/plans/2026-05-25-plugin-host-evaluate.md` (11 tasks, TDD; 2 plan-review rounds → READY)
- **4 ADRs** — `docs/adr/holomush-{dttdj,qeypl,61rdl,9l9pu}-*.md` + README index

## Decisions captured

| ADR | Decision |
|-----|----------|
| `holomush-dttdj` | Host `Evaluate(action, resource)` RPC (Option C) — third enforcement tier; rejects host-side subcommand parsing (A) and exposing roles (B) |
| `holomush-qeypl` | Subject derived host-side; no subject field on the wire (anti-spoof, fail-closed) |
| `holomush-61rdl` | Entitlement scoped to plugin-owned resource types (+ command carve-out); one rule both runtimes |
| `holomush-9l9pu` | Structural gated subcommand dispatcher so the gate can't be forgotten |

## Tracking

Epic `holomush-8kkv5` + 11 child tasks (`.1`–`.11`) materialized in bd with dependency graph + decision linkages. Implementation lands in follow-up PRs per the plan.

Docs-only change: passed `task pr-prep:docs`. `code-reviewer` not applicable (no code diff); the spec and plan went through `design-reviewer` (×3) and `plan-reviewer` (×2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)