### PR TITLE
fix(deploy): recreate core/gateway (add -T to migrate) + assert deployed version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,14 +96,51 @@ jobs:
             docker compose --profile tunnel --profile backups pull core gateway cloudflared
             docker compose --profile tunnel --profile backups build backup
             docker compose --profile tunnel --profile backups up -d --no-recreate postgres
-            docker compose --profile tunnel --profile backups run --rm core migrate
+            # -T is load-bearing: this script is fed to `ssh ... bash -s <<EOF`, so
+            # stdin IS the heredoc. Without -T, `compose run` attaches stdin and
+            # consumes the remaining heredoc lines (the `up -d` below) as the
+            # container's stdin — so the recreate never runs and core/gateway stay
+            # on the old image while the deploy still "succeeds" (holomush-aocap).
+            docker compose --profile tunnel --profile backups run --rm -T core migrate
             docker compose --profile tunnel --profile backups up -d
           EOF
 
-      - name: Health probe
+      - name: Verify deployed version + health
         env:
           DROPLET_IP: ${{ steps.droplet.outputs.ip }}
+          DISPATCH_TAG: ${{ inputs.tag }}
         run: |-
-          ssh -o StrictHostKeyChecking=yes "holomush@${DROPLET_IP}" \
-            "docker compose -f /opt/holomush/compose.yaml exec -T gateway \
-               wget -q --spider http://localhost:9101/healthz/readiness"
+          VERSION="$DISPATCH_TAG"
+          IMAGE_VERSION="${VERSION#v}"
+          ssh -o StrictHostKeyChecking=yes "holomush@${DROPLET_IP}" bash -s -- "${IMAGE_VERSION}" <<'EOF'
+            set -euo pipefail
+            IMAGE_VERSION="$1"
+            EXPECTED="ghcr.io/holomush/holomush:${IMAGE_VERSION}"
+            cd /opt/holomush
+            # Assert core+gateway actually run the deployed image. A recreate
+            # failure leaves a stale container that still passes readiness, so
+            # readiness alone masks a bad deploy (holomush-aocap). All
+            # `compose run/exec` here use -T (stdin = this heredoc).
+            for svc in core gateway; do
+              running="$(docker compose -f compose.yaml ps --format '{{.Image}}' "$svc")"
+              if [ "$running" != "$EXPECTED" ]; then
+                echo "::error::$svc is running '$running' but expected '$EXPECTED' — deploy did not recreate to the target version"
+                exit 1
+              fi
+            done
+            echo "✓ core + gateway on ${EXPECTED}"
+            # core/gateway are freshly recreated each deploy, so poll readiness
+            # rather than racing the first probe against container startup
+            # (a single immediate probe can hit a still-starting container).
+            for attempt in $(seq 1 30); do
+              if docker compose -f compose.yaml exec -T gateway \
+                   wget -q --spider http://localhost:9101/healthz/readiness; then
+                echo "✓ gateway ready"
+                exit 0
+              fi
+              echo "gateway not ready (attempt ${attempt}/30); retrying in 5s..."
+              sleep 5
+            done
+            echo "::error::gateway did not become ready within ~150s"
+            exit 1
+          EOF


### PR DESCRIPTION
## What

Fixes `holomush-aocap` — deploys silently left `core`/`gateway` on the **stale image** while reporting success. Found live: the sandbox was running `0.1.13` (3 releases behind) after the `v0.2.0` deploy "succeeded".

## Root cause

The restart script runs via `ssh … bash -s <<'EOF'`, so **stdin is the heredoc**. The migrate step was `docker compose … run --rm core migrate` **without `-T`**. Without `-T`, `compose run` attaches stdin and **consumes the remaining heredoc lines** — including the final `docker compose up -d` — as the container's stdin. So the recreate **never executes**; the old containers keep running and pass `/healthz/readiness`, masking the stale version. The snapshot step right above correctly uses `exec -T`; the migrate line just dropped it.

Confirmed: deploy log ends exactly at the migrate output (zero `up -d` lines); `MIGRATE_EXIT=0` (not an abort); running the identical `up -d` manually (no heredoc-stdin) recreated `0.1.13 → 0.2.0` immediately.

## Fix

1. **`-T` on the migrate run** (`run --rm -T core migrate`) so it can't eat the heredoc — matches the snapshot step's `exec -T`.
2. **Version-asserting health check** — the probe now asserts `core` + `gateway` run `ghcr.io/holomush/holomush:${IMAGE_VERSION}` before the readiness wget, so a recreate failure can't pass silently again. Closes the "health probe masks stale version" half + the deferred CodeRabbit health-probe-retry note on the bead.

## Notes

- Live sandbox already remediated to `0.2.0` manually; this prevents recurrence on the next deploy.
- `code-reviewer`: READY. `task lint:actions` + `yamlfmt -lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)