### PR TITLE
docs: test-tier taxonomy & test-only-construct isolation — spec, plan, ADRs (holomush-1eps2)

### DIFF
--- a/docs/adr/holomush-1r2hp-e2e-reserved-for-playwright.md
+++ b/docs/adr/holomush-1r2hp-e2e-reserved-for-playwright.md
@@ -1,0 +1,72 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Reserve "E2E" for Playwright; Ginkgo `test:int` Is Full-Stack Integration
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-1r2hp
+**Deciders:** HoloMUSH Contributors
+**Related:** holomush-1eps2
+
+## Context
+
+"E2E" had three incompatible meanings in the repo: `CLAUDE.md` called the
+Ginkgo `test:int` suite "E2E", the JetStream design spec (2026-04-18 §8) named
+its top Go tier "E2E", and `pr-prep.md` + CI used "E2E" exclusively for the
+Playwright browser suite. The collision made it impossible to state a tier
+boundary unambiguously in docs, rules, or ADRs.
+
+## Decision
+
+"E2E" is reserved for tests that cross the **real user boundary** (browser or
+telnet) against a running binary — run by `task test:e2e` (Playwright). The
+Ginkgo `task test:int` suite is **integration**, with named tiers:
+unit → bus-integration → audit-integration → full-stack integration (all Go,
+embedded NATS, `//go:build integration`). All repo documentation adopts this
+vocabulary; INV-4 keeps it from regressing (documented convention, optionally a
+CI grep-lint per the plan).
+
+## Alternatives Considered
+
+### A — Reserve "E2E" for the real-user boundary; rename the Go tier (chosen)
+
+Aligns with the standard industry definition (E2E = real client, real binary).
+Makes the tier label informative: a contributor infers the test's dependencies
+from its name. Requires a one-time doc migration.
+
+### B — Retain "E2E" as a synonym for any high-fidelity in-process test
+
+No migration, but perpetuates the three-way collision and makes "E2E" useless
+as a signal — the label no longer tells you whether a browser, a binary, or
+only an in-process `CoreServer` is involved.
+
+## Rationale
+
+- Boundary-crossed, not breadth-of-stack, is the defining property of E2E. The
+  Ginkgo harness stands up a `CoreServer` in-process and calls Go/gRPC APIs
+  directly — integration by any standard definition.
+- The collision actively blocked accurate documentation: `testing.md` could not
+  assert a true invariant without disambiguating which "E2E" it meant.
+- Reserving a word for one meaning shapes every future test file and ADR — a
+  cross-cutting vocabulary decision.
+
+## Consequences
+
+**Positive:** tier name implies dependencies; docs carry consistent vocabulary;
+INV-4 prevents regression.
+
+**Negative:** one-time migration of `CLAUDE.md`, `testing.md`, the JetStream
+spec §8, and `integration-tests.md`; contributors must unlearn "E2E = Ginkgo".
+
+**Neutral:** the Playwright suite and `task test:e2e` are unchanged — only the
+label on the Ginkgo suite changes.
+
+## Implementation
+
+See `docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md` Task 7.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` §4
+- `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` §8 (origin of the 4-tier model)

--- a/docs/adr/holomush-qti5d-depguard-test-only-isolation.md
+++ b/docs/adr/holomush-qti5d-depguard-test-only-isolation.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Enforce Test-Only Import Isolation via depguard, Not Build Tags
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-qti5d
+**Deciders:** HoloMUSH Contributors
+**Related:** holomush-1eps2, holomush-bmtd, holomush-tcf7
+
+## Context
+
+The in-memory event store (`core.NewMemoryEventStore`) carried a
+`//go:build !integration` tag to keep it out of production builds. It was the
+*only* non-test file with that tag, and its side effect forced `task test:int`
+to enumerate an explicit package list — `./...` fails to compile under
+`-tags=integration` whenever a compiled file references the excluded symbol
+(holomush-bmtd). The real safety property is "production packages must not
+import test-only constructs" — a package-import constraint, not a
+compilation-lane constraint. A precursor (holomush-tcf7) had already removed a
+false claim in `testing.md` that a build tag "enforced" this.
+
+## Decision
+
+Test-only construct isolation is enforced by a **depguard** deny rule in
+`.golangci.yaml`, not a build tag. `MemoryEventStore` is extracted into a new
+test-only package `internal/core/coretest` so the rule can operate at package
+granularity; the `//go:build !integration` tag on `store_memory.go` is removed,
+unblocking `task test:int -- ./...` and deleting the explicit package list.
+
+## Alternatives Considered
+
+### A — depguard package-import rule (chosen)
+
+Enforces the real invariant uniformly across every build lane, scoped to
+production files via `files` patterns with a test-support allowlist. Eliminates
+the fragile package list as a side effect. Requires extracting the store to its
+own package (depguard cannot deny a symbol within a package production needs)
+and enabling depguard (disabled today).
+
+### B — Build-tag scheme (`busint` / `!e2e`)
+
+Cannot separate bus-integration from full-stack integration without breaking
+compilation, because both legitimately import `eventbustest`. Adds a tag
+dimension requiring a full-tree migration, and still does not actually prevent
+production imports — it only excludes files from build lanes.
+
+### C — Pure documentation / status quo
+
+Zero code, but leaves production import of test-only constructs silently
+possible and the bmtd drift class (new integration tests silently not run)
+unfixed.
+
+## Rationale
+
+- The safety property is a package boundary rule; depguard is the mechanism that
+  matches it.
+- Removing the sole non-test `!integration` file lets `./...` compile under
+  `-tags=integration`, killing the silent-omission drift class.
+- A meta-test (`TestDepguardTestOnlyConstructRulesPresent`) guards the config
+  against silent deletion — the exact failure mode that produced the original
+  false invariant.
+
+## Consequences
+
+**Positive:** INV-1/INV-2 (no production import of `eventbustest` /
+`core/coretest`) are machine-enforced at `task lint`; `test:int -- ./...` works
+without enumeration; the depguard allowlist self-documents the legitimate
+harness packages.
+
+**Negative:** requires extracting the store and updating 9 test-file imports;
+adds depguard as an active linter contributors must learn.
+
+**Neutral:** the `coretest` package name + doc-comment make the prohibition
+visible without reading `.golangci.yaml`.
+
+## Implementation
+
+See `docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md` Tasks 1, 2, 5, 6.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` §5
+- holomush-1eps2 (design), holomush-bmtd (absorbed), holomush-tcf7 (precursor)

--- a/docs/adr/holomush-vjg7z-plugin-opt-in-harness-capability.md
+++ b/docs/adr/holomush-vjg7z-plugin-opt-in-harness-capability.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Plugin Layer as an Opt-In Harness Capability in Full-Stack Integration
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-vjg7z
+**Deciders:** HoloMUSH Contributors
+**Related:** holomush-1eps2, holomush-f5t07
+
+## Context
+
+The `integrationtest` harness (canonical per `CLAUDE.md`) starts a real
+in-process `CoreServer` with Postgres and embedded NATS, but loads **zero
+plugins**. Production loads 10 in-tree plugins (6 Lua, 2 binary, 2 setting) via
+`plugin.Manager.LoadAll`. Tests exercising scenes, channels, or objects against
+a plugin-free harness exercise a hollow core — the behaviors are plugin-provided.
+
+## Decision
+
+Full-stack integration includes the plugin layer, but plugin-loading is an
+**opt-in harness capability** (`integrationtest.WithInTreePlugins()` driving
+`plugin.Manager.LoadAll`), not mandatory on every test. A single **whole-system
+suite** loads all in-tree plugins (mirroring production) as the top Go-fidelity
+tier; targeted tests (privacy, presence) stay lean. The capability + suite are
+implemented in a follow-up bead (discovered-from holomush-1eps2); this decision
+defines the intent and tier meaning.
+
+## Alternatives Considered
+
+### A — Opt-in capability + dedicated whole-system suite (chosen)
+
+Targeted tests stay lean; one whole-system suite gives manifest-DAG, load-order,
+and cross-plugin-ABAC coverage. Affordable: 6 of 8 functional plugins are
+in-process Lua, so only the 2 binary plugins need an availability gate.
+
+### B — Mandatory plugin loading for all full-stack tests
+
+Maximum default fidelity, but burdens every targeted test with binary-plugin
+build artifacts, subprocess startup latency, and DAG-load failure surface
+unrelated to what it tests.
+
+### C — No plugin loading (status quo)
+
+No change, but plugin-provided behaviors (scenes, channels, communication) stay
+untested at the integration tier; cross-plugin-ABAC / manifest-DAG regressions
+surface only in E2E or production.
+
+## Rationale
+
+- Plugins are not optional in production; a zero-plugin full-stack test does not
+  test the production topology.
+- Opt-in avoids imposing binary-plugin cost on tests that don't need it.
+- One whole-system suite provides the high-fidelity coverage without universal
+  cost; the Lua-vs-binary asymmetry makes it cheap.
+
+## Consequences
+
+**Positive:** manifest-DAG / load-order / cross-plugin-ABAC regressions become
+catchable at `task test:int`; existing targeted tests are unaffected;
+`WithInTreePlugins()` self-documents intent.
+
+**Negative:** the capability + suite are deferred to a follow-up bead — until it
+lands, the plugin-loading fidelity gap remains; the binary-plugin availability
+gate fails at runtime (not compile time) if artifacts are missing.
+
+**Neutral:** INV-5 (whole-system suite uses `Manager.LoadAll`) is declared here,
+enforced in the follow-up.
+
+## Implementation
+
+Deferred to a follow-up bead (discovered-from holomush-1eps2). This design fixes
+only the tier *meaning*; see spec §6/§7.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` §6, §7
+- Sibling harness-fidelity gap: holomush-f5t07 (ABAC bypass)

--- a/docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md
+++ b/docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md
@@ -1,0 +1,566 @@
+# Test-Tier Taxonomy & Test-Only-Construct Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make test-only constructs (the in-memory event store, the embedded NATS harness) compile/lint-provably absent from production code, delete the fragile `test:int` package list, and reconcile the test-tier taxonomy/terminology across the docs.
+
+**Architecture:** Extract `MemoryEventStore` from `package core` into a new test-only package `internal/core/coretest` and drop its `//go:build !integration` tag (the lone tag forcing package enumeration). Enforce "no production import of test-only constructs" via a new **depguard** rule (package-granular, which is why extraction is required). With the tag gone, `test:int` runs `./...` and the explicit list is deleted. A meta-test guards the depguard rule against silent deletion. Docs adopt the four-tier integration model with "E2E" reserved for Playwright.
+
+**Tech Stack:** Go 1.x, `golangci-lint` v2 (depguard linter), Taskfile, `gotestsum`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md`
+**Design bead:** holomush-1eps2 (absorbs holomush-bmtd)
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `internal/core/coretest/store_memory.go` | The in-memory event store, test-only, no build tag | Create (moved from `internal/core/store_memory.go`) |
+| `internal/core/store_memory.go` | (removed) | Delete |
+| `internal/core/engine_test.go`, `engine_end_session_test.go`, `engine_end_session_ctx_test.go` | white-box core tests | Modify (import + qualify `coretest.NewMemoryEventStore`) |
+| `internal/auth/auth_service_test.go`, `internal/command/handlers/shutdown_test.go`, `internal/command/types_test.go`, `internal/grpc/auth_handlers_test.go`, `internal/grpc/dispatcher_test.go`, `internal/grpc/pipeline_rendering_test.go` | consumers of the store | Modify (qualify import) |
+| `internal/core/engine.go:42`, `internal/plugin/host.go:115` | stale comments referencing `MemoryEventStore` | Modify (comment text) |
+| `.golangci.yaml` | enable + configure depguard | Modify |
+| `Taskfile.yaml` (`test:int`) | drop the explicit package list | Modify |
+| `test/meta/depguard_config_test.go` | meta-tests: assert depguard deny rules present (INV-1/2) + test:int has no package list (INV-3) | Create (in existing `package meta`) |
+| `.claude/rules/testing.md`, `CLAUDE.md`, `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md`, `site/docs/contributing/integration-tests.md` | tier taxonomy + terminology | Modify |
+
+---
+
+### Task 1: Extract `MemoryEventStore` into `internal/core/coretest`
+
+**Files:**
+
+- Create: `internal/core/coretest/store_memory.go`
+- Delete: `internal/core/store_memory.go`
+
+- [ ] **Step 1: Create the new package file**
+
+Create `internal/core/coretest/store_memory.go` with the store moved out of
+`package core`, the `//go:build !integration` tag dropped, and the three
+package-internal references (`Event`, `EventAppender`, `ErrStreamEmpty`)
+qualified with `core.`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package coretest provides test-only implementations of internal/core
+// interfaces. Production code MUST NOT import this package; the prohibition
+// is enforced by the depguard rule in .golangci.yaml (see holomush-1eps2).
+package coretest
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/core"
+)
+
+// MemoryEventStore is an in-memory event store for unit testing.
+// It implements core.EventAppender and provides Replay/ReplayTail/LastEventID
+// as test-inspection helpers.
+type MemoryEventStore struct {
+	mu      sync.RWMutex
+	streams map[string][]core.Event
+}
+
+// NewMemoryEventStore creates a new in-memory event store.
+func NewMemoryEventStore() *MemoryEventStore {
+	return &MemoryEventStore{
+		streams: make(map[string][]core.Event),
+	}
+}
+
+// Compile-time check: MemoryEventStore satisfies core.EventAppender.
+var _ core.EventAppender = (*MemoryEventStore)(nil)
+
+// Append persists an event to the in-memory store.
+func (s *MemoryEventStore) Append(_ context.Context, event core.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streams[event.Stream] = append(s.streams[event.Stream], event)
+	return nil
+}
+
+// Replay returns events from a stream starting after the given ID.
+// Test-inspection helper; not part of any production interface.
+func (s *MemoryEventStore) Replay(_ context.Context, stream string, afterID ulid.ULID, limit int) ([]core.Event, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	events := s.streams[stream]
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	startIdx := 0
+	if afterID.Compare(ulid.ULID{}) != 0 {
+		found := false
+		for i, e := range events {
+			if e.ID == afterID {
+				startIdx = i + 1
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, nil
+		}
+	}
+
+	endIdx := min(startIdx+limit, len(events))
+
+	result := make([]core.Event, endIdx-startIdx)
+	copy(result, events[startIdx:endIdx])
+	return result, nil
+}
+
+// LastEventID returns the most recent event ID for a stream.
+// Test-inspection helper; not part of any production interface.
+func (s *MemoryEventStore) LastEventID(_ context.Context, stream string) (ulid.ULID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	events := s.streams[stream]
+	if len(events) == 0 {
+		return ulid.ULID{}, core.ErrStreamEmpty
+	}
+	return events[len(events)-1].ID, nil
+}
+
+// maxReplayTailCount is the server-side cap for ReplayTail count parameter.
+const maxReplayTailCount = 501
+
+// ReplayTail returns the most recent count events on stream, ascending by ID.
+// Events with timestamps before notBefore are excluded. If beforeID is non-zero,
+// events with ID >= beforeID are excluded. Count is capped at maxReplayTailCount.
+// Test-inspection helper; not part of any production interface.
+func (s *MemoryEventStore) ReplayTail(_ context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]core.Event, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if count > maxReplayTailCount {
+		count = maxReplayTailCount
+	}
+	if count <= 0 {
+		return nil, nil
+	}
+
+	events := s.streams[stream]
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	var eligible []core.Event
+	for i := len(events) - 1; i >= 0 && len(eligible) < count; i-- {
+		e := events[i]
+		if !beforeID.IsZero() && e.ID.Compare(beforeID) >= 0 {
+			continue
+		}
+		if !notBefore.IsZero() && e.Timestamp.Before(notBefore) {
+			continue
+		}
+		eligible = append(eligible, e)
+	}
+
+	for i, j := 0, len(eligible)-1; i < j; i, j = i+1, j-1 {
+		eligible[i], eligible[j] = eligible[j], eligible[i]
+	}
+	return eligible, nil
+}
+```
+
+- [ ] **Step 2: Delete the old file**
+
+Run: `rm internal/core/store_memory.go`
+
+- [ ] **Step 3: Verify the new package compiles**
+
+Run: `task build`
+Expected: PASS (the new package compiles; call sites are still broken — fixed in Task 2, so `task test` will fail until then, but `task build` compiles non-test code).
+
+- [ ] **Step 4: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`.
+Message: `refactor(core): extract MemoryEventStore to internal/core/coretest (holomush-1eps2)`
+
+---
+
+### Task 2: Update the 9 test call sites to use `coretest`
+
+**Files:**
+
+- Modify: `internal/core/engine_test.go`, `internal/core/engine_end_session_test.go`, `internal/core/engine_end_session_ctx_test.go` (package `core`, unqualified calls)
+- Modify: `internal/auth/auth_service_test.go`, `internal/command/handlers/shutdown_test.go`, `internal/command/types_test.go`, `internal/grpc/auth_handlers_test.go`, `internal/grpc/dispatcher_test.go`, `internal/grpc/pipeline_rendering_test.go`
+
+- [ ] **Step 1: Find every call site**
+
+Run: `rg -n 'NewMemoryEventStore|core\.MemoryEventStore|MemoryEventStore' --type go -g '*_test.go'`
+Expected: matches in the 9 files above. Note for each whether the call is
+`NewMemoryEventStore(` (unqualified — the `package core` files) or
+`core.NewMemoryEventStore(` (qualified — the others).
+
+- [ ] **Step 2: Add the import and re-qualify in each file**
+
+In every listed test file, add to the import block:
+
+```go
+"github.com/holomush/holomush/internal/core/coretest"
+```
+
+Then replace references:
+
+- In the `package core` files (`engine_test.go`, `engine_end_session_test.go`, `engine_end_session_ctx_test.go`): `NewMemoryEventStore(` → `coretest.NewMemoryEventStore(`, and any `*MemoryEventStore` type reference → `*coretest.MemoryEventStore`.
+- In the other six files: `core.NewMemoryEventStore(` → `coretest.NewMemoryEventStore(`, and `*core.MemoryEventStore` → `*coretest.MemoryEventStore`.
+
+- [ ] **Step 3: Run goimports/format**
+
+Run: `task fmt`
+Expected: import blocks reordered; no errors.
+
+- [ ] **Step 4: Run the affected unit tests**
+
+Run: `task test -- ./internal/core/ ./internal/auth/ ./internal/command/... ./internal/grpc/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Message: `refactor(tests): point MemoryEventStore call sites at coretest (holomush-1eps2)`
+
+---
+
+### Task 3: Fix the two stale production comments
+
+**Files:**
+
+- Modify: `internal/core/engine.go:42`
+- Modify: `internal/plugin/host.go:115`
+
+- [ ] **Step 1: Update engine.go comment**
+
+Read `internal/core/engine.go:40-44`. The comment references
+`(*MemoryEventStore)(nil)` as an example of a typed-nil interface value. Update
+the example to `(*coretest.MemoryEventStore)(nil)` (or drop the parenthetical
+example if `coretest` would read oddly in a production-file comment — prefer a
+generic phrasing like "a typed-nil concrete pointer").
+
+- [ ] **Step 2: Update host.go comment**
+
+Read `internal/plugin/host.go:113-117`. The comment says the interface is
+"Satisfied by MemoryEventStore in ...". Update to "Satisfied by
+`coretest.MemoryEventStore` in tests" so it no longer implies a production
+dependency on a moved symbol.
+
+- [ ] **Step 3: Verify build**
+
+Run: `task build`
+Expected: PASS (comments only).
+
+- [ ] **Step 4: Commit**
+
+Message: `docs(comments): update MemoryEventStore references after coretest move (holomush-1eps2)`
+
+---
+
+### Task 4: Delete the `test:int` package list
+
+**Files:**
+
+- Modify: `Taskfile.yaml` (the `test:int` target, currently lines ~152-171)
+
+- [ ] **Step 1: Rewrite the recipe**
+
+Read the current `test:int` target. Replace the explicit package-list `cmds`
+entry with `./...` honoring `CLI_ARGS`, and replace the load-bearing comment
+(which explained the enumeration) with a note that the enumeration is no longer
+needed:
+
+```yaml
+  test:int:
+    desc: Run integration tests (needs Docker for testcontainers)
+    cmds:
+      - task: plugin:build-all
+      # No package enumeration: the only //go:build !integration helper
+      # (the in-memory event store) was extracted to internal/core/coretest
+      # (holomush-1eps2), so ./... compiles cleanly under -tags=integration.
+      # -coverpkg=./... makes integration tests contribute coverage to every
+      # production package they exercise (see .codecov.yml).
+      - "{{.GO_TOOL}} gotestsum --format pkgname -- -race -tags=integration -count=1 -coverprofile=coverage-int.out -covermode=atomic -coverpkg=./... {{.CLI_ARGS | default \"./...\"}}"
+```
+
+- [ ] **Step 2: Verify `./...` compiles and runs under the integration tag**
+
+Run: `task test:int`
+Expected: PASS — every integration-tagged package compiles and runs; no
+"undefined: NewMemoryEventStore" errors. (Docker must be running.)
+
+- [ ] **Step 3: Verify CLI_ARGS passthrough (the bmtd ergonomics fix)**
+
+Run: `task test:int -- -run TestSomething ./test/integration/privacy/`
+Expected: runs only the named package/test (no longer silently runs the full
+default list).
+
+- [ ] **Step 4: Commit**
+
+Message: `build(taskfile): drop test:int package list; ./... works post-coretest (holomush-1eps2, absorbs holomush-bmtd)`
+
+---
+
+### Task 5: Enable and configure the depguard rule
+
+**Files:**
+
+- Modify: `.golangci.yaml` (add `depguard` to `linters.enable`; add `linters.settings.depguard`)
+
+- [ ] **Step 1: Add depguard to the enable list**
+
+In `.golangci.yaml`, under `linters.enable`, add (in the "Maintenance" group):
+
+```yaml
+    - depguard
+```
+
+- [ ] **Step 2: Add the depguard settings block**
+
+Under `linters.settings:` add a rule that denies the test-only packages,
+scoped to production files only (test files and the test-support harness
+packages are exempt). Use depguard's `$test` file keyword plus directory
+negations:
+
+```yaml
+    depguard:
+      rules:
+        no-test-only-constructs-in-production:
+          # Apply only to production files: not *_test.go, and not the
+          # test-support packages that legitimately wire harnesses in
+          # non-_test.go files.
+          files:
+            - "!$test"
+            - "!**/internal/testsupport/**"
+            - "!**/internal/cluster/clustertest/**"
+          deny:
+            - pkg: github.com/holomush/holomush/internal/eventbus/eventbustest
+              desc: "embedded NATS test harness; production code MUST NOT import it (holomush-1eps2)"
+            - pkg: github.com/holomush/holomush/internal/core/coretest
+              desc: "in-memory test event store; production code MUST NOT import it (holomush-1eps2)"
+```
+
+- [ ] **Step 3: Verify clean tree passes**
+
+Run: `task lint`
+Expected: PASS (no production package imports either denied package today).
+
+- [ ] **Step 4: Verify the rule actually catches a violation**
+
+Temporarily add `import _ "github.com/holomush/holomush/internal/core/coretest"`
+to a production file (e.g. top of `internal/core/engine.go`).
+Run: `task lint`
+Expected: FAIL with a depguard error naming `coretest` and the `desc` text.
+Then **remove** the temporary import and re-run `task lint` → PASS.
+
+(If Step 4 does not fail as expected, the `files` negation semantics differ in
+the pinned golangci-lint version — check the version in `go.tool.mod` and the
+depguard docs for that version, and adjust the `files`/`$test` patterns until a
+production-file violation is caught while `_test.go` and `testsupport/` imports
+remain allowed.)
+
+- [ ] **Step 5: Commit**
+
+Message: `build(lint): enable depguard to keep test-only constructs out of production (holomush-1eps2)`
+
+---
+
+### Task 6: Add meta-tests guarding the invariants
+
+**Files:**
+
+- Create: `test/meta/depguard_config_test.go` (new file in the existing `package meta` — reuses that package's `findRepoRoot(t)` helper at `test/meta/inv_binding_test.go`)
+
+- [ ] **Step 1: Write the meta-tests**
+
+Create `test/meta/depguard_config_test.go`. It reuses the existing
+`findRepoRoot(t)` helper (same package), reads the repo-root config files, and
+asserts (a) both depguard deny packages are present (INV-1/INV-2) and (b) the
+`test:int` recipe honors `CLI_ARGS` and enumerates no packages (INV-3) — so
+neither guarantee can be silently deleted:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDepguardTestOnlyConstructRulesPresent guards INV-1/INV-2 against silent
+// deletion — the exact failure mode (a config claim silently diverging from
+// reality) this work was created to correct (holomush-1eps2).
+func TestDepguardTestOnlyConstructRulesPresent(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, ".golangci.yaml"))
+	require.NoError(t, err, "read .golangci.yaml")
+	cfg := string(data)
+
+	for _, pkg := range []string{
+		"github.com/holomush/holomush/internal/eventbus/eventbustest",
+		"github.com/holomush/holomush/internal/core/coretest",
+	} {
+		require.Contains(t, cfg, pkg,
+			"depguard deny rule for %q missing from .golangci.yaml (holomush-1eps2 INV-1/INV-2)", pkg)
+	}
+}
+
+// TestTaskfileIntHasNoPackageList guards INV-3: the test:int recipe must run
+// ./... (honoring CLI_ARGS) and must NOT re-introduce an enumerated package
+// list (holomush-1eps2, absorbs holomush-bmtd).
+func TestTaskfileIntHasNoPackageList(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "Taskfile.yaml"))
+	require.NoError(t, err, "read Taskfile.yaml")
+	tf := string(data)
+
+	// Isolate the test:int recipe block: from its key line to the next
+	// 2-space-indented task key.
+	loc := regexp.MustCompile(`(?m)^  test:int:[ \t]*$`).FindStringIndex(tf)
+	require.NotNil(t, loc, "test:int target not found in Taskfile.yaml")
+	after := tf[loc[1]:]
+	block := after
+	if next := regexp.MustCompile(`(?m)^  \S`).FindStringIndex(after); next != nil {
+		block = after[:next[0]]
+	}
+
+	require.Contains(t, block, "CLI_ARGS",
+		"test:int must honor CLI_ARGS (holomush-1eps2 INV-3 / bmtd)")
+	require.NotContains(t, block, "./internal/",
+		"test:int must not enumerate packages; use ./... (holomush-1eps2 INV-3)")
+}
+```
+
+- [ ] **Step 2: Run them to verify they pass**
+
+Run: `task test -- ./test/meta/`
+Expected: PASS (Task 4 removed the package list; Task 5 added both deny entries).
+
+- [ ] **Step 3: Verify each fails when its guarantee regresses**
+
+Temporarily delete the `coretest` deny line from `.golangci.yaml` →
+`task test -- ./test/meta/` FAILs naming `coretest`; restore it.
+Temporarily re-add `./internal/store/` to the `test:int` recipe →
+`task test -- ./test/meta/` FAILs on the package-list assertion; restore it.
+
+- [ ] **Step 4: Commit**
+
+Message: `test(meta): guard depguard deny rules + test:int package-list erasure (holomush-1eps2)`
+
+---
+
+### Task 7: Reconcile the test-tier taxonomy across docs
+
+**Files:**
+
+- Modify: `.claude/rules/testing.md` (the "EventBus Test Harness" section, ~lines 139-147)
+- Modify: `CLAUDE.md` (the Testing always-on table — the "Ginkgo/Gomega for E2E" + "MUST NOT use eventbustest in E2E" rows)
+- Modify: `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` (§8 testing-strategy tier table)
+- Modify: `site/docs/contributing/integration-tests.md`
+
+- [ ] **Step 1: Rewrite the testing.md tier table**
+
+Replace the "EventBus Test Harness" section with the canonical taxonomy (spec
+§4) and the depguard invariant (spec §5). Use this table:
+
+```markdown
+## Test Tiers
+
+| Tier | Dependencies | Runner | Build tag |
+| --- | --- | --- | --- |
+| unit | none | `task test` | (none) |
+| bus-integration | embedded NATS (`eventbustest`) | `task test:int` | `//go:build integration` |
+| audit-integration | embedded NATS + Postgres testcontainer | `task test:int` | `//go:build integration` |
+| full-stack integration | embedded NATS + Postgres + `CoreServer` (+ optional in-tree plugins) | `task test:int` | `//go:build integration` |
+| **E2E** | full Docker stack driven through a real client (browser) | `task test:e2e` | (Playwright) |
+
+"E2E" means the Playwright browser suite — a test that crosses the real user
+boundary. The Ginkgo `test:int` suite is **integration** (it calls Go/gRPC APIs
+in-process), regardless of how much of the stack it stands up.
+
+`eventbustest` provides the in-process embedded NATS server (`MemoryStorage`)
+used at every non-unit tier. This matches production, which also runs embedded
+NATS (`internal/eventbus/subsystem.go`); external/clustered NATS is unimplemented
+(tracked in holomush-s5ts). Production code MUST NOT import `eventbustest` or
+`internal/core/coretest` — enforced by the depguard rule in `.golangci.yaml`.
+```
+
+- [ ] **Step 2: Fix the CLAUDE.md Testing rows**
+
+In `CLAUDE.md`, change "MUST use Ginkgo/Gomega for E2E" → "MUST use Ginkgo/Gomega
+for full-stack integration tests"; change "MUST NOT use `eventbustest` in E2E"
+→ "Production code MUST NOT import `eventbustest`/`coretest` (depguard-enforced);
+embedded NATS is correct at every test tier". Add a one-line pointer: "Canonical
+tier taxonomy lives in `.claude/rules/testing.md`."
+
+- [ ] **Step 3: Reconcile the jetstream spec tier name**
+
+In `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` §8, rename
+the "E2E" Go tier to "full-stack integration" (or add a one-line note: "renamed
+to full-stack integration per holomush-1eps2; E2E now denotes the Playwright
+suite").
+
+- [ ] **Step 4: Update the contributor guide**
+
+In `site/docs/contributing/integration-tests.md`, adopt the tier vocabulary and
+note that full-stack integration may load in-tree plugins (capability;
+whole-system suite is a follow-up). Reserve "E2E" for Playwright.
+
+- [ ] **Step 5: INV-4 decision (documented convention, not a machine check)**
+
+Per spec §8 INV-4 (deferred to this plan): implement INV-4 as a **documented
+convention** — the tier table above is the single source of truth; do NOT add a
+brittle grep-lint over prose. Add one sentence to `.claude/rules/testing.md`:
+"Use 'E2E' only for the Playwright suite; Go Ginkgo suites are 'integration'."
+
+- [ ] **Step 6: Verify docs lane**
+
+Run: `task fmt && task pr-prep:docs`
+Expected: PASS (`task lint:docs-symmetry` green; markdown formatted).
+
+- [ ] **Step 7: Commit**
+
+Message: `docs(testing): canonical test-tier taxonomy; reserve E2E for Playwright (holomush-1eps2)`
+
+---
+
+## Wrap-up (post-implementation, before close)
+
+- [ ] Close holomush-bmtd: `bd close holomush-bmtd --reason "Absorbed into holomush-1eps2 (PR <n>): coretest extraction + depguard + package-list deletion + CLI_ARGS passthrough."`
+- [ ] Confirm the whole-system-plugin follow-up and holomush-f5t07 remain open and linked.
+- [ ] Run the full gate: `task pr-prep` green before push.
+
+## Self-Review Coverage Map (spec → task)
+
+| Spec requirement | Task |
+| --- | --- |
+| §4 canonical taxonomy + E2E=Playwright | Task 7 |
+| §5 depguard invariant (INV-1/INV-2) | Task 5 |
+| §5.1 extract store, drop tag | Task 1, 2, 3 |
+| §5.1 delete package list + CLI_ARGS | Task 4 |
+| §8 meta-test (INV-1/2 + INV-3 guards) | Task 6 |
+| §8 INV-3 (`./...` no enumeration) | Task 4 (recipe) + Task 6 (guard) |
+| §8 INV-4 (documented convention) | Task 7 Step 5 |
+| §9 doc updates | Task 7 |
+| §10 bmtd closed as absorbed | Wrap-up |
+| §6 full-stack plugins / §7 follow-ups | Out of scope (deferred beads; not implemented here) |
+
+<!-- adr-capture: sha256=b4978f2f3553a9c9; session=cli; ts=2026-05-25T16:11:18Z; adrs=holomush-qti5d,holomush-1r2hp,holomush-vjg7z -->

--- a/docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md
+++ b/docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md
@@ -1,0 +1,217 @@
+# Test-Tier Taxonomy & Test-Only-Construct Isolation — Design
+
+- **Status:** Draft (pending design-reviewer)
+- **Design bead:** holomush-1eps2
+- **Precursor:** holomush-tcf7 (closed — removed the false `//go:build !integration` enforcement claim from `.claude/rules/testing.md`)
+- **Absorbs:** holomush-bmtd (`test:int` explicit-package-list fragility) — closed into this bead
+- **Related:** holomush-s5ts (External NATS deploy epic — owns the real-NATS test matrix)
+- **Date:** 2026-05-25
+
+## 1. Context
+
+`holomush-tcf7` removed a documentation invariant that asserted a compile-time
+enforcement which never existed: `.claude/rules/testing.md` claimed
+*"the `//go:build !integration` tag on the harness file enforces"* that the
+embedded NATS harness (`internal/eventbus/eventbustest`) is not used in E2E
+tests. No such tag exists on `eventbustest/embedded.go`, and the harness is in
+fact used by every non-unit test tier.
+
+Triaging that exposed a tangle of three confusions this design resolves:
+
+1. **An overloaded build tag.** The single `integration` tag spans bus-level
+   tests and full-stack tests that all legitimately import `eventbustest`, so no
+   build tag can separate them without breaking compilation.
+2. **An overloaded word.** "E2E" means three different things across the repo:
+   the Ginkgo `test:int` suite (`CLAUDE.md`), the Playwright suite (`pr-prep.md`
+   - CI), and the top Go tier of the JetStream design spec.
+3. **A fragile scoping mechanism.** `Taskfile.yaml`'s `test:int` target
+   enumerates an explicit package list because `internal/core/store_memory.go`
+   carries `//go:build !integration` (it is the **only** non-test file that
+   does). Under `-tags=integration` that file is excluded, so any package whose
+   unit tests reference `core.NewMemoryEventStore` fails to compile under
+   `./...`. New integration tests in unlisted packages silently never run
+   (this is `holomush-bmtd`).
+
+### Grounding that reshaped the design
+
+- **Production runs embedded NATS.** `internal/eventbus/subsystem.go` boots an
+  in-process `nats-server/v2` via `DontListen` + `nats.InProcessServer` — the
+  same path `eventbustest` uses. The only difference is `FileStorage` (prod) vs
+  `MemoryStorage` (test). `ModeCluster`/external NATS is a reserved-but-
+  unimplemented constant (`internal/eventbus/config.go`). **There is no
+  embedded-vs-real fidelity gap today**; it opens only after the external-NATS
+  pivot (`holomush-s5ts`). Building NATS-testcontainer infra now would be
+  prod-shape-for-an-undeployed-system.
+- **`eventbustest` is the only NATS in the entire test suite.** The sole
+  testcontainer in use is Postgres.
+- **A 4-tier model already exists** in `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md`
+  §8 (unit / bus-integration / audit-integration / E2E, embedded NATS at all
+  non-unit tiers) — it just never propagated into `CLAUDE.md`/`testing.md`.
+
+## 2. Goals
+
+- Establish a single canonical test-tier taxonomy and reserve "E2E" for one
+  meaning, propagated into `.claude/rules/testing.md` and `CLAUDE.md`.
+- Replace the never-existent build-tag "enforcement" with a *real*,
+  lint-enforced invariant: test-only constructs never leak into production code.
+- Remove the root cause of the `test:int` package-list fragility so
+  `task test:int -- ./...` works and the enumeration is deleted
+  (absorbs `holomush-bmtd`).
+- Define what "full-stack integration" means with respect to the in-tree
+  plugin layer.
+
+## 3. Non-Goals
+
+- **No real/external NATS in tests.** Deferred to `holomush-s5ts`
+  (its scope-item-5: "external-NATS test matrix; nats-server in test
+  containers"). Embedded NATS stays at every tier because production is
+  embedded NATS today.
+- **No build-tag scheme** (`busint`/`!e2e` etc.). The honest invariant is a
+  package-import rule, not a compilation-lane rule.
+- **Not fixing the `integrationtest` harness ABAC bypass.** The harness wires
+  `allowAllPolicyEngine` by default — a *separate* fidelity gap that masked a P0
+  (`holomush-g776`) for 6+ weeks. Tracked in **holomush-f5t07** (sibling to the
+  harness-loads-no-plugins gap this design addresses in §6/§7); not owned here.
+- **Not building the whole-system plugin suite in this bead.** The *decision*
+  is made here; the harness capability + suite are a discovered-from follow-up
+  (see §7).
+
+## 4. The Canonical Test-Tier Taxonomy
+
+"E2E" is reserved for tests that cross the **real user boundary** (a browser,
+or telnet) against a real running binary. Breadth of stack does not make a test
+E2E — boundary crossed does. The Ginkgo `test:int` suite stands up the full
+server in-process and calls Go/gRPC APIs directly, so it is **integration**, not
+E2E, regardless of how much it wires up.
+
+| Tier | Dependencies | Runner | Build tag |
+| --- | --- | --- | --- |
+| unit | none | `task test` | (none) |
+| bus-integration | embedded NATS (`eventbustest`) | `task test:int` | `//go:build integration` |
+| audit-integration | embedded NATS + Postgres testcontainer | `task test:int` | `//go:build integration` |
+| full-stack integration | embedded NATS + Postgres + `CoreServer` (+ optional in-tree plugins, §6) | `task test:int` | `//go:build integration` |
+| **E2E** | full Docker stack driven through a real client (browser) | `task test:e2e` | (Playwright, no Go tag) |
+
+This adopts the JetStream-spec model as the operational SSOT. The two outliers
+to correct: `CLAUDE.md`'s "MUST use Ginkgo/Gomega for E2E" phrasing and the
+JetStream spec's "E2E" Go-tier name (rename to "full-stack integration").
+
+## 5. The Real Invariant: depguard, Not a Build Tag
+
+The property actually worth proving is **test-only constructs never leak into
+production code** — production (non-test) packages must not import the embedded
+test harness or the in-memory event store. This is a package-import rule,
+enforced uniformly across every build lane by **depguard** (a `golangci-lint`
+linter, not currently enabled).
+
+### 5.1 Mechanical change (absorbs holomush-bmtd)
+
+1. **Extract** `NewMemoryEventStore` (and the `MemoryEventStore` type) out of
+   `internal/core/store_memory.go` into a test-only package
+   `internal/core/coretest/`; **drop** the `//go:build !integration` tag.
+2. **Enable depguard** in `.golangci.yaml` with deny rules forbidding imports of
+   `internal/core/coretest` and `internal/eventbus/eventbustest`, scoped to
+   production files only. **Allowlist:** `_test.go` files, `internal/testsupport/**`,
+   and `internal/cluster/clustertest` (the test-support packages that
+   legitimately wire harnesses in non-`_test.go` files).
+3. **Delete the explicit package list** in `Taskfile.yaml`'s `test:int` target.
+   With no `!integration` symbols remaining, `./...` compiles under
+   `-tags=integration`. The recipe becomes
+   `gotestsum -- -race -tags=integration ... {{.CLI_ARGS | default "./..."}}`,
+   which **also fixes** bmtd's CLI_ARGS-passthrough gap
+   (`task test:int -- -run X ./pkg/`) and kills the "new integration test
+   silently never runs" drift class at the root.
+
+`store_memory.go` is the only non-test `//go:build !integration` file in the
+repo, so removing it is sufficient — no other enumeration cause exists.
+
+## 6. Full-Stack Integration and the Plugin Layer
+
+Plugins are part of the real stack: scenes, channels, objects, aliases, and
+communication are **plugin-provided**. The 10 in-tree plugins break down as
+6 Lua (including the `echo-bot` example), 2 binary (`core-scenes` and the
+`test-abac-widget` fixture), and 2 setting/config-only. A full-stack
+test that loads zero plugins exercises a hollow core. Production loads all of
+them via `plugin.Manager.LoadAll` (DAG-resolved).
+
+**Decision:** plugin-loading is a **harness capability**, not mandatory on every
+full-stack test. Targeted full-stack tests (privacy floor, presence snapshot)
+stay lean; a single **whole-system suite** loads *all* in-tree plugins via
+`Manager.LoadAll`, mirroring production — the highest-fidelity Go-level tier,
+the closest thing to E2E-minus-the-browser, where manifest-DAG / load-order /
+cross-plugin-ABAC regressions surface.
+
+Cost asymmetry that makes this affordable: 6 of 8 functional plugins are
+in-process Lua (no subprocess, no build artifact). Only `core-scenes` and
+`test-abac-widget` are hashicorp/go-plugin subprocesses requiring `build/plugins`
+artifacts (which `task test:int` already builds via `plugin:build-all`). So the
+binary layer is the only part warranting an availability gate.
+
+The harness capability (`integrationtest.WithInTreePlugins()`) and the
+whole-system suite are **implemented in a follow-up** (§7); this design only
+fixes the *meaning* of the tier.
+
+## 7. Follow-Up Work (filed, not done here)
+
+- **Whole-system plugin suite + harness capability** (discovered-from 1eps2):
+  add `integrationtest.WithInTreePlugins()` driving `Manager.LoadAll`, a
+  binary-plugin availability gate, and one whole-system suite loading every
+  in-tree plugin.
+- **`integrationtest` ABAC-bypass fidelity gap** — the harness defaults to
+  `allowAllPolicyEngine`; tracked in **holomush-f5t07** (not owned here).
+- **Real/testcontainer NATS for E2E**: owned by `holomush-s5ts` scope-item-5;
+  linked, not duplicated.
+
+## 8. Invariants (RFC2119)
+
+| # | Invariant | Enforcement / Test |
+| --- | --- | --- |
+| INV-1 | Production (non-test) packages **MUST NOT** import `internal/eventbus/eventbustest`. | depguard deny rule; fails `task lint`. |
+| INV-2 | Production (non-test) packages **MUST NOT** import `internal/core/coretest` (the in-memory event store). | depguard deny rule; fails `task lint`. |
+| INV-3 | `task test:int -- ./...` **MUST** compile and run with **no** explicit package enumeration in `Taskfile.yaml`. | CI integration job runs `./...`; a Taskfile-grep meta-test asserts no hard-coded package list remains. |
+| INV-4 | Repo documentation **MUST** use "E2E" only for the Playwright/browser suite; Go Ginkgo suites **MUST** be called "integration". | A new CI grep-lint step asserting the tier vocabulary (no "Ginkgo … E2E" phrasing) in `.claude/rules/testing.md` + `CLAUDE.md`. NOTE: existing `lint:docs-symmetry` only checks the CLAUDE.md↔AGENTS.md symlink, not vocabulary — this is a *new* check. The plan **MAY** instead implement INV-4 as a documented convention (no machine check) if it judges a grep too brittle; this decision is deferred to the plan. |
+| INV-5 | The whole-system suite (when implemented per §7) **MUST** load all in-tree plugins via `plugin.Manager.LoadAll`. | Asserted in the follow-up bead's tests; declared here. |
+
+### Meta-test
+
+`TestDepguardTestOnlyConstructRulesPresent` reads `.golangci.yaml` and asserts
+the deny entries for `eventbustest` and `core/coretest` exist — guarding the
+guard so INV-1/INV-2 cannot be silently deleted (the failure mode that produced
+this whole saga). This is the meta-test required for non-trivial specs
+(`feedback_invariants_and_docs_as_spec_acceptance`).
+
+## 9. Documentation (PR-blocking)
+
+- `.claude/rules/testing.md` — replace the EventBus-harness section with the §4
+  tier table; document the depguard invariant (§5) and the full-stack/plugin
+  meaning (§6).
+- `CLAUDE.md` — fix "Ginkgo/Gomega for E2E" → "Ginkgo/Gomega for full-stack
+  integration"; add a short pointer to the canonical taxonomy in `testing.md`.
+- `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md` §8 — rename
+  the "E2E" Go tier to "full-stack integration" (or add a note reconciling it).
+- `site/docs/contributing/integration-tests.md` — adopt the tier vocabulary;
+  note that full-stack integration may load in-tree plugins.
+
+## 10. Acceptance Criteria
+
+- `task test:int -- ./...` succeeds; `Taskfile.yaml` `test:int` has no package
+  enumeration and honors `CLI_ARGS`.
+- `task lint` fails if any production package imports `eventbustest` or
+  `core/coretest`; passes on the migrated tree.
+- `NewMemoryEventStore` lives in `internal/core/coretest/`; `store_memory.go`
+  carries no build tag (or is removed).
+- The meta-test (`TestDepguardTestOnlyConstructRulesPresent`) passes.
+- Docs in §9 carry the tiered taxonomy; "E2E" means Playwright everywhere.
+- `holomush-bmtd` closed as "absorbed into holomush-1eps2"; the whole-system
+  plugin suite filed as a discovered-from follow-up.
+
+## 11. ADR-Worthy Decisions
+
+1. **Test-tier taxonomy + "E2E" reserved for Playwright** (a tier-naming /
+   vocabulary decision shaping how all future tests are classified).
+2. **depguard package-import rule replaces build-tag isolation** for keeping
+   test-only constructs out of production (a cross-cutting enforcement-mechanism
+   decision).
+3. **Full-stack integration includes the plugin layer via an opt-in capability +
+   a whole-system suite** (a test-architecture decision about fidelity tiers).
+<!-- adr-capture: sha256=1a54caf4300e2204; session=cli; ts=2026-05-25T16:11:18Z; adrs=holomush-qti5d,holomush-1r2hp,holomush-vjg7z -->


### PR DESCRIPTION
Design docs for **holomush-1eps2** (absorbs holomush-bmtd). Docs-only; no code yet — implementation tracked as the 7 child tasks under the epic.

## What's here
- **Spec** `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` — design-reviewer READY.
- **Plan** `docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md` — plan-reviewer READY; 7 tasks.
- **3 ADRs** `docs/adr/holomush-{qti5d,1r2hp,vjg7z}-*.md`.

## The decisions
1. **Canonical 4-tier taxonomy; E2E reserved for Playwright** (ADR 1r2hp). Ginkgo `test:int` = tiered *integration* (unit → bus-integration → audit-integration → full-stack integration); E2E = the browser suite. Resolves a three-way 'E2E' collision.
2. **depguard, not build tags** (ADR qti5d). Test-only constructs (`eventbustest`, the in-memory store) are kept out of production by a package-import deny rule — extract `MemoryEventStore` → `internal/core/coretest`, drop the lone `!integration` tag, delete the fragile `test:int` package list (absorbs bmtd, fixes CLI_ARGS passthrough).
3. **Full-stack integration includes plugins** (ADR vjg7z) via an opt-in harness capability + a whole-system suite (impl deferred to a follow-up).

## Scope notes
- Embedded NATS stays at every tier — production *is* embedded NATS today; real-NATS-in-E2E is deferred to **holomush-s5ts**.
- The `integrationtest` ABAC-bypass fidelity gap is tracked separately in **holomush-f5t07**.

## Verification
- `task pr-prep:docs` ✓ · design-reviewer READY · plan-reviewer READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)