### PR TITLE
docs(crypto): plugin read-back decryption design — spec, plan, 4 ADRs (holomush-m7pxs)

### DIFF
--- a/docs/adr/holomush-c3kyv-detect-not-prevent-bulk-self-decrypt.md
+++ b/docs/adr/holomush-c3kyv-detect-not-prevent-bulk-self-decrypt.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Detect-Not-Prevent Posture for Plugin Bulk Historical Self-Decrypt
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-c3kyv
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+A plugin with the `readback` capability can, in principle, decrypt **all** of its own historical sensitive events — not just those relevant to the current operation. The only property encryption-at-rest buys *against the owning plugin itself* is temporal: a plugin compromised at time T cannot retroactively recover plaintext for events emitted before T. A broad read-back capability erodes that forward-secrecy-under-compromise property. Genuine prevention would require conditioning the decrypt on domain state (e.g. "only when the scene is COOLOFF with all-yes votes"), coupling scene-domain state into the trusted authorization layer.
+
+## Decision
+
+The security posture for plugin bulk historical self-decrypt is **detect, not prevent**. Bulk access is **bounded** (OwnerMap subject-scope confines it to data the plugin authored; a 500-row `maxDecryptBatch` cap per call; the operator's rekey/DEK-destruction lever revokes unconditionally via INV-P7-15) and **made loud** (a mandatory INV-19 `plugin_decrypt` audit event per decrypt, on a subject the plugin cannot subscribe to; the primitive fails closed if the audit emitter is absent). It is **not prevented** via contextual domain-state conditioning.
+
+## Options Considered
+
+- **Prevent — contextual/consent-gated ABAC** (decrypt permitted only under publish-state attributes). *Rejected:* forces scene-domain state (publish state, vote state) into the trusted ABAC gate — disproportionate complexity for a low-probability concern, given the plugin already sees plaintext at emit time.
+- **Detect — subject-scoping + mandatory INV-19 audit + batch cap + DEK-destroy lever — chosen.** Loud, scoped, reversible.
+
+## Consequences
+
+- **Positive:** no coupling of scene-domain state into the crypto authorization layer; the operator retains DEK destruction as a hard revocation; the per-decrypt INV-19 audit trail is load-bearing for forensic detection.
+- **Negative:** a compromised plugin can bulk-read its own historical content (bounded to its subjects, audited, but not prevented); realizing the detection value requires operators to monitor audit streams.
+- **Neutral:** the 500-row `maxDecryptBatch` cap (distinct from `QueryStreamHistory`'s silent clamp) makes bulk reads multi-hop and auditable at each hop.
+
+See spec §7.1, §7.2. Pairs with the two-gate authz model (holomush-edqh1).

--- a/docs/adr/holomush-edqh1-two-gate-plugin-self-decrypt-no-abac.md
+++ b/docs/adr/holomush-edqh1-two-gate-plugin-self-decrypt-no-abac.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Two-Gate Plugin Self-Decrypt Authorization Without an ABAC Decrypt Action
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-edqh1
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Authorizing a plugin to decrypt its **own** historical events on read-back needed a principal model. The cross-plugin decrypt capability (`crypto.consumes.requests_decryption`, INV-45) is live-delivery-only and structurally inapplicable: a self-reference fails the validator (`crypto_validator.go`), and it conflates live-delivery consume with read-back. The ABAC `decrypt` action exists in `checkPlugin` (`guard.go:129`) but **no production policy and no `dek` resource type satisfy it** — it always-denies in production today (the only grant is a test helper). The snapshot principal is fixed by architecture: it runs in the plugin's lifecycle ticker, and there is no System `IdentityKind`.
+
+## Decision
+
+Plugin self-decrypt is authorized by **exactly two gates**, each evaluated once (default-deny):
+
+1. **g1 — OwnerMap subject-ownership**, enforced host-side at primitive entry (`OwnerMap.Resolve(subject).PluginName == principal.PluginName`). The sole subject-scope check.
+2. **g2 — manifest `crypto.emits[].readback: true`** via a new `ManifestLookup.PluginCanReadBack`, distinct from the consumes-side `PluginRequestsDecryption`. Loader-validated; default `false` (the explicit opt-in).
+
+There is **no ABAC `decrypt`-action gate**. Wiring one is deferred to a follow-up bead (it would also fix the latent live-delivery always-deny).
+
+## Options Considered
+
+- **Reuse `requests_decryption` / relax the self-ref validator.** *Rejected:* conflates live-delivery with read-back; stretches INV-45 dependency semantics.
+- **ABAC-only seeded grant, or a 3-gate model (manifest + ABAC + ownership).** *Rejected:* both depend on production ABAC plumbing — a `dek` resource type + a `decrypt` permit policy — that does not exist; coupling this work to absent infrastructure for no security gain over gates 1–2 + INV-19 audit.
+- **Two gates (OwnerMap + manifest flag), ABAC deferred — chosen.** Concrete, verifiable, default-deny, runtime-symmetric.
+
+## Consequences
+
+- **Positive:** C7 is unblocked without waiting for `dek`-ABAC plumbing; default-deny preserved (a plugin without `readback: true` is denied even on its own subjects); the `ManifestLookup` extension is narrow (existing fakes gain a default-`false` method).
+- **Negative:** the ABAC `decrypt` action remains unbuilt; the live-delivery `checkPlugin` ABAC call always-denies in production today — that latent gap is now documented but not fixed.
+- **Neutral:** the deferral is filed as a follow-up (spec §7.5); the crypto-reviewer must evaluate it as a deliberate scope decision.
+
+See spec §4, §7.5. Pairs with the detect-not-prevent posture (holomush-c3kyv).

--- a/docs/adr/holomush-g3d4l-host-mediated-plugin-readback-decryption.md
+++ b/docs/adr/holomush-g3d4l-host-mediated-plugin-readback-decryption.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Host-Mediated Plugin Read-Back Decryption (Plugins Never Hold DEKs)
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-g3d4l
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Plugin-owned `sensitivity:always` events (scene IC `scene_pose`/`scene_say`/`scene_emit`; comms `whisper`/`page`/`pemit`) are encrypted by the host at emit time; plugins never hold a DEK. No path existed to decrypt these payloads on a history read-back, which made the C7 scene-publish snapshot unbuildable as written (its premise "the plugin already holds DEK access" was false). Two consumers need plaintext on read-back — the snapshot (plugin-initiated, already holds its `scene_log` rows from an in-tx read) and participant web reconnect-backfill — but via structurally different read paths.
+
+## Decision
+
+All plugin read-back decryption is **host-mediated** via a single shared primitive (`fenceCheckRow` → `AuditRowToEvent` → `decodeAuthorizeAndDispatch`). The plugin passes ciphertext rows and receives only plaintext (or typed refusals); a DEK never crosses the plugin boundary. The **snapshot** uses a direct `PluginHostService.DecryptOwnAuditRows` RPC (it already holds its rows); **participant routed reads** use the same primitive wired into the `PluginDowngradeFence` clean-row path.
+
+## Options Considered
+
+- **Route the snapshot through host `QueryHistory` (bead Option A).** Reuses the existing read path, no new RPC. *Rejected:* creates a `plugin→host→plugin→host→plugin` self-loop — the plugin already holds its rows from the in-tx read, making the round-trip incoherent.
+- **Grant the plugin DEK access for its own events (bead Option C).** Plugin decrypts locally. *Rejected:* violates the role-isolation invariant that defines the plugin trust boundary (plugins never hold DEKs); conflicts with INV-P7-7/INV-P7-15.
+- **Host-side decrypt primitive consumed via a direct entry (bead Option B — chosen).** Host rebuilds AAD, resolves the DEK, decrypts, returns plaintext. One hop for the snapshot, no self-loop; the same primitive serves both consumers.
+
+## Consequences
+
+- **Positive:** plugin DEK isolation (a core security invariant, INV-RB-1) is preserved unconditionally; both consumers reuse identical decrypt logic, so a fix or crypto upgrade applies to both by construction (AAD parity INV-RB-4, fence parity INV-RB-5).
+- **Negative:** a new host RPC (`DecryptOwnAuditRows`) plus its Lua hostfunc must ship together (Go+Lua parity); the fence contract changes (see holomush-wfh42).
+- **Neutral:** the primitive is subject-agnostic — core-communication and core-scenes share it with no per-plugin special-casing (INV-RB-11).
+
+See spec `docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md` §1, §3.

--- a/docs/adr/holomush-wfh42-fence-decrypts-clean-rows.md
+++ b/docs/adr/holomush-wfh42-fence-decrypts-clean-rows.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# PluginDowngradeFence Decrypts Clean Rows for Authorized Routed Readers
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-wfh42
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The Phase-7 `PluginDowngradeFence` gated plugin-owned history reads (INV-P7-7 downgrade refusal + INV-P7-15 DEK-existence) and passed **clean rows through as ciphertext**. This was a half-built contract: the fence enforced the structural invariants but delivered no usable plaintext to authorized readers, so participant scene-IC scrollback and comms `whisper`/`page` history were silently broken. The gap was masked by tests running against a `fakeHistoryReader` (`query_stream_history_test.go`), which never exercises the codec/DEK/fence stack. Scene-IC is *armed*: it enters the backfill set via the focus substrate (`subscription_router.go`), so the first scene participant who reconnects gets ciphertext/refused.
+
+## Decision
+
+The fence's clean-row path now **decrypts** via the shared `decryptPluginRow` primitive instead of passing ciphertext through. The reading principal is the character, authorized by the existing **DEK participant-set membership** check (`guard.go:64`). INV-P7-7/INV-P7-15 gate behavior is preserved by extracting the per-row check into a shared `fenceCheckRow` function used by both the fence and the snapshot direct entry.
+
+## Options Considered
+
+- **Keep the fence gate-only; add a separate decrypt tier.** *Rejected:* duplicates routing logic and still fails to deliver plaintext on the path participants already use.
+- **Complete the fence — clean rows decrypt via the shared primitive — chosen.** A single primitive serves both the snapshot direct entry and the routed fence, so decrypt logic cannot diverge; fence parity (INV-RB-5) holds by construction.
+
+## Consequences
+
+- **Positive:** participant scene-IC scrollback and comms `whisper`/`page`/`pemit` read-back are fixed with no per-plugin special-casing (INV-RB-11); the fake-reader coverage gap is closed by real-stack integration tests (INV-RB-7).
+- **Negative:** all existing fence tests asserting ciphertext-passthrough must migrate to plaintext/refusal assertions (a deliberate migration, not a regression); the fence now requires the read-back deps + the caller identity threaded from `HistoryQuery.Caller`.
+- **Neutral:** the fence-contract change is PR-blocking documentation for contributors (spec §11).
+
+See spec §3.2, §3.4. Realizes INV-RB-5, INV-RB-7, INV-RB-11.

--- a/docs/superpowers/plans/2026-05-25-plugin-readback-decrypt.md
+++ b/docs/superpowers/plans/2026-05-25-plugin-readback-decrypt.md
@@ -1,0 +1,879 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Plugin Read-Back Decryption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give plugins a host-mediated path to decrypt their own `sensitivity:always` events on read-back (snapshot direct entry) and complete the routed fence so scene participants can read decrypted history.
+
+**Architecture:** A reusable host-side `decryptPluginRow` (per-row: fence check → `AuditRowToEvent` → `decodeAuthorizeAndDispatch`) is consumed by two entries — a new `PluginHostService.DecryptOwnAuditRows` RPC (snapshot, plugin-self-decrypt principal, gated by host-side `OwnerMap` ownership + a new `readback` manifest capability; **no ABAC `decrypt` grant** — that plumbing is unbuilt, deferred per spec §7.5) and the existing `PluginDowngradeFence` clean-row path (participant, DEK-participant-set principal). The host always holds DEKs; the plugin only ever receives plaintext. Authorization is routed by a new `ReadBack` discriminator on the AuthGuard `CheckRequest` so `decodeAuthorizeAndDispatch` is reused wholesale.
+
+**Tech Stack:** Go, `gopher-lua` (hostfunc), `hashicorp/go-plugin` + Connect/gRPC (`buf generate`), PostgreSQL, `crypto/rand`. Tests: `task test` (unit, Docker for session/`sessiontest`), Ginkgo/Gomega for E2E (`//go:build integration`, `task test:int`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md`](../specs/2026-05-25-plugin-readback-decrypt-design.md) (design-reviewer READY, round 3). Invariants INV-RB-1..12 referenced per task.
+
+**Out of scope (downstream beads):** the C7 snapshot *pipeline* that calls `DecryptOwnAuditRows` (`holomush-5rh.20.26`); scene-log review/export (`holomush-cb4x`); focus-substrate backfill completeness (`oy6e`).
+
+---
+
+## File Structure
+
+| File | New/Modify | Responsibility |
+| --- | --- | --- |
+| `internal/plugin/crypto_manifest.go` | Modify | `CryptoEmit.Readback bool` field |
+| `internal/plugin/crypto_validator.go` | Modify | reject `readback:true` on non-emitted / `never` types |
+| `internal/plugin/manager.go` | Modify | `Manager.PluginCanReadBack(plugin, eventType) bool` |
+| `internal/eventbus/authguard/authguard.go` | Modify | extend `ManifestLookup` interface; `ReadBack` on `CheckRequest`; `PermitPluginReadbackGrant`/`DenyReadbackManifestMissing` codes |
+| `internal/eventbus/authguard/adapter_manifest.go` | Modify | `manifestAdapter.PluginCanReadBack` delegates to `Manager` |
+| `internal/eventbus/authguard/guard.go` | Modify | `Guard.checkPluginReadback`; route `Plugin+ReadBack` in `Check` |
+| `internal/eventbus/bus.go` | Modify | `ReadBack bool` on `SessionCheckRequest` |
+| `internal/eventbus/authguard/adapter_session.go` | Modify | map `ReadBack` across the eventbus↔authguard bridge |
+| `internal/eventbus/history/plugin_downgrade_fence.go` | Modify | extract `fenceCheckRow`; clean-row path calls `decryptPluginRow` |
+| `internal/eventbus/history/dispatcher.go` | Modify | thread `readBack` into `decodeAuthorizeAndDispatch` |
+| `internal/eventbus/history/readback.go` | Create | `decryptPluginRow` + `RowResult` |
+| `api/proto/holomush/plugin/v1/audit.proto` | Modify | `DecryptOwnAuditRows` RPC + request/response + `RowResult` message |
+| `internal/plugin/goplugin/host_service.go` | Modify | `DecryptOwnAuditRows` host handler (OwnerMap gate + chunked decrypt) |
+| `pkg/plugin/audit.go` | Modify | Go SDK `DecryptOwnAuditRows` helper |
+| `internal/plugin/hostfunc/*` + `internal/plugin/lua/*` | Modify | Lua hostfunc wrapper (Go+Lua parity) |
+| `plugins/core-scenes/plugin.yaml` | Modify | `readback: true` on `scene_pose`/`scene_say`/`scene_emit` |
+| `schemas/plugin.schema.json` | Modify (generated) | regen for `readback` field |
+| `site/docs/extending/plugin-crypto-readback.md` | Create | author-facing capability docs |
+| `test/integration/crypto/readback_test.go` | Create | real-stack integration + meta-test |
+| `test/integration/privacy/scene_history_readback_test.go` | Create | participant E2E |
+
+Dependency order: **T1 → T2** (manifest); **T1 → T3** (authguard); **T4** (fence extract, independent); **T3 + T4 → T5** (primitive); **T5 → T6 → T7** (RPC, SDK/Lua); **T5 + T4 → T8** (fence completion); **all → T9**; **T10** (docs) parallel.
+
+---
+
+## Task 1: Manifest `readback` capability
+
+**Files:**
+
+- Modify: `internal/plugin/crypto_manifest.go:33`
+- Modify: `internal/plugin/crypto_validator.go`
+- Modify: `internal/plugin/manager.go:1504` (add sibling method)
+- Modify: `internal/eventbus/authguard/authguard.go` (`ManifestLookup`)
+- Modify: `internal/eventbus/authguard/adapter_manifest.go`
+- Test: `internal/plugin/crypto_manifest_test.go`, `internal/plugin/crypto_validator_test.go`, `internal/plugin/manager_test.go`, `internal/eventbus/authguard/adapter_manifest_test.go`
+
+- [ ] **Step 1: Write the failing test for the field + lookup**
+
+In `internal/plugin/manager_test.go`:
+
+```go
+func TestPluginCanReadBack(t *testing.T) {
+	t.Parallel()
+	m := newTestManagerWithManifest(t, &Manifest{
+		Name: "core-scenes",
+		Crypto: &CryptoSection{Emits: []CryptoEmit{
+			{EventType: "scene_pose", Sensitivity: SensitivityAlways, Readback: true},
+			{EventType: "scene_join_ic", Sensitivity: SensitivityNever},
+		}},
+	})
+	assert.True(t, m.PluginCanReadBack("core-scenes", "scene_pose"))
+	assert.False(t, m.PluginCanReadBack("core-scenes", "scene_join_ic"), "readback not set")
+	assert.False(t, m.PluginCanReadBack("core-scenes", "unknown"), "type not emitted")
+	assert.False(t, m.PluginCanReadBack("other", "scene_pose"), "wrong plugin")
+}
+```
+
+(`newTestManagerWithManifest` is the existing helper in `internal/plugin/crypto_manifest_lookup_test.go`, used by `TestManagerPluginRequestsDecryptionMatchesQualifiedRef`; reuse it.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `task test -- -run TestPluginCanReadBack ./internal/plugin/`
+Expected: FAIL — `Readback` undefined and `PluginCanReadBack` undefined.
+
+- [ ] **Step 3: Add the field**
+
+`internal/plugin/crypto_manifest.go` — extend `CryptoEmit`:
+
+```go
+type CryptoEmit struct {
+	EventType   string      `yaml:"event_type" json:"event_type"`
+	Sensitivity Sensitivity `yaml:"sensitivity" json:"sensitivity"`
+	Description string      `yaml:"description,omitempty" json:"description,omitempty"`
+	// Readback declares that this plugin may read back and decrypt its own
+	// historical events of this type via the host (the plugin never holds a
+	// DEK). Default false (default-deny). MUST NOT be true for a
+	// SensitivityNever type. See plugin-readback-decrypt-design INV-RB-2.
+	Readback bool `yaml:"readback,omitempty" json:"readback,omitempty"`
+}
+```
+
+- [ ] **Step 4: Add `Manager.PluginCanReadBack`**
+
+`internal/plugin/manager.go` — mirror `PluginRequestsDecryption` (`:1504`) but scan `Emits`:
+
+```go
+// PluginCanReadBack returns true iff pluginName's manifest declares
+// crypto.emits[].readback=true for eventType. Read-back authorization
+// gate g2 (plugin-readback-decrypt-design §4). Distinct from
+// PluginRequestsDecryption, which reads crypto.consumes.
+func (m *Manager) PluginCanReadBack(pluginName, eventType string) bool {
+	manifest := m.lookupManifest(pluginName)
+	if manifest == nil || manifest.Crypto == nil {
+		return false
+	}
+	for _, e := range manifest.Crypto.Emits {
+		if e.EventType == eventType {
+			return e.Readback
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 5: Extend the `ManifestLookup` interface + adapter**
+
+`internal/eventbus/authguard/authguard.go` — add to the existing interface:
+
+```go
+type ManifestLookup interface {
+	PluginRequestsDecryption(pluginName, eventType string) bool
+	PluginCanReadBack(pluginName, eventType string) bool
+}
+```
+
+`internal/eventbus/authguard/adapter_manifest.go` — add:
+
+```go
+func (a *manifestAdapter) PluginCanReadBack(pluginName, eventType string) bool {
+	if a == nil || a.mgr == nil {
+		return false
+	}
+	return a.mgr.PluginCanReadBack(pluginName, eventType)
+}
+```
+
+Update every other `ManifestLookup` implementor to satisfy the wider interface: `fakeManifest` (`internal/eventbus/authguard/guard_test.go`), the lookups in `test/integration/crypto/metadata_only_test.go` and `test/integration/crypto/plugin_decrypt_test.go`. Each gains a method returning `false` by default (or a configurable field mirroring its existing `PluginRequestsDecryption` fake).
+
+- [ ] **Step 6: Run the lookup tests**
+
+Run: `task test -- -run 'TestPluginCanReadBack|TestPluginRequestsDecryption' ./internal/plugin/ ./internal/eventbus/authguard/`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing validator test**
+
+`internal/plugin/crypto_validator_test.go`:
+
+```go
+func TestCryptoValidatorRejectsReadbackOnNeverType(t *testing.T) {
+	t.Parallel()
+	err := ValidateCrypto(&Manifest{
+		Name: "core-scenes",
+		Crypto: &CryptoSection{Emits: []CryptoEmit{
+			{EventType: "scene_join_ic", Sensitivity: SensitivityNever, Readback: true},
+		}},
+	})
+	errutil.AssertErrorCode(t, err, "PLUGIN_CRYPTO_READBACK_ON_NEVER")
+}
+
+func TestCryptoValidatorAllowsReadbackOnAlwaysType(t *testing.T) {
+	t.Parallel()
+	err := ValidateCrypto(&Manifest{
+		Name: "core-scenes",
+		Crypto: &CryptoSection{Emits: []CryptoEmit{
+			{EventType: "scene_pose", Sensitivity: SensitivityAlways, Readback: true},
+		}},
+	})
+	require.NoError(t, err)
+}
+```
+
+(The entrypoint is `ValidateCrypto(m *Manifest)` at `crypto_validator.go:17`; the new code `PLUGIN_CRYPTO_READBACK_ON_NEVER` follows the existing `PLUGIN_CRYPTO_*` naming, e.g. `PLUGIN_CRYPTO_INVALID_SENSITIVITY`.)
+
+- [ ] **Step 8: Run to verify it fails, then add the rule**
+
+Run: `task test -- -run TestCryptoValidatorRejectsReadbackOnNeverType ./internal/plugin/` → FAIL.
+
+In `crypto_validator.go`, in the per-`CryptoEmit` loop add:
+
+```go
+if e.Readback && e.Sensitivity == SensitivityNever {
+	return oops.Code("PLUGIN_CRYPTO_READBACK_ON_NEVER").
+		With("event_type", e.EventType).
+		Errorf("readback:true is invalid on a sensitivity:never type")
+}
+```
+
+- [ ] **Step 9: Run the validator + lint, then commit**
+
+Run: `task test -- ./internal/plugin/ ./internal/eventbus/authguard/` then `task lint:go`
+Expected: PASS, no lint findings.
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`: `feat(plugin): add crypto.emits[].readback manifest capability (holomush-m7pxs INV-RB-2)`.
+
+---
+
+## Task 2: core-scenes declares `readback`
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml:40-55`
+- Modify (generated): `schemas/plugin.schema.json`
+- Test: `plugins/core-scenes/plugin_manifest_test.go` (or the existing manifest-parse test)
+
+- [ ] **Step 1: Write the failing test**
+
+In the core-scenes manifest test (mirror an existing `crypto.emits` assertion):
+
+```go
+func TestCoreScenesManifestDeclaresReadback(t *testing.T) {
+	t.Parallel()
+	m := loadCoreScenesManifest(t) // existing helper
+	for _, et := range []string{"scene_pose", "scene_say", "scene_emit"} {
+		e := findEmit(t, m, et)
+		assert.True(t, e.Readback, "%s MUST declare readback:true for snapshot decrypt", et)
+		assert.Equal(t, plugin.SensitivityAlways, e.Sensitivity)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestCoreScenesManifestDeclaresReadback ./plugins/core-scenes/` → FAIL.
+
+- [ ] **Step 3: Add `readback: true` to the three content emits**
+
+`plugins/core-scenes/plugin.yaml` — for `scene_pose`, `scene_say`, `scene_emit` add `readback: true`:
+
+```yaml
+    - event_type: scene_pose
+      sensitivity: always
+      readback: true
+      description: "IC pose by a scene participant; visible to all participants in the scene's IC stream."
+```
+
+(Leave `scene_ooc` without `readback` — OOC is never archived into the published log, so the snapshot does not read it.)
+
+- [ ] **Step 4: Regenerate the schema**
+
+Run: `task generate` to update `schemas/plugin.schema.json` for the new `readback` field. Confirm the field appears in the generated schema (`rg readback schemas/plugin.schema.json`).
+
+- [ ] **Step 5: Run tests + lint, then commit**
+
+Run: `task test -- ./plugins/core-scenes/` → PASS.
+Commit: `feat(core-scenes): declare crypto readback on scene content events (holomush-m7pxs)`.
+
+---
+
+## Task 3: AuthGuard read-back branch
+
+**Files:**
+
+- Modify: `internal/eventbus/authguard/authguard.go` (`CheckRequest`, decision codes)
+- Modify: `internal/eventbus/authguard/guard.go:119` (add `checkPluginReadback`; route in `Check`)
+- Modify: `internal/eventbus/bus.go` (`SessionCheckRequest.ReadBack`)
+- Modify: `internal/eventbus/authguard/adapter_session.go` (bridge mapping)
+- Test: `internal/eventbus/authguard/guard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/eventbus/authguard/guard_test.go`:
+
+```go
+func TestCheckPluginReadbackPermitsWithManifestFlag(t *testing.T) {
+	t.Parallel()
+	// 2-gate model: permit rests on the manifest readback flag (g2);
+	// OwnerMap (g1) is enforced upstream at the primitive. NO ABAC gate —
+	// denyABAC proves readback does not depend on an ABAC grant (spec §7.5).
+	g := NewGuard(noParts{}, fakeManifest{readback: true}, denyABAC{}, noBP{})
+	dec, err := g.Check(context.Background(), CheckRequest{
+		Identity:  Identity{Kind: IdentityKindPlugin, PluginName: "core-scenes"},
+		EventType: "scene_pose",
+		ReadBack:  true,
+		KeyID:     7, KeyVersion: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, dec.Permit, "permit on manifest flag alone — no ABAC dependency")
+	assert.Equal(t, PermitPluginReadbackGrant, dec.Code)
+}
+
+func TestCheckPluginReadbackDeniedWithoutManifestFlag(t *testing.T) {
+	t.Parallel()
+	g := NewGuard(noParts{}, fakeManifest{readback: false}, denyABAC{}, noBP{})
+	dec, err := g.Check(context.Background(), CheckRequest{
+		Identity: Identity{Kind: IdentityKindPlugin, PluginName: "core-scenes"},
+		EventType: "scene_pose", ReadBack: true, KeyID: 7, KeyVersion: 1,
+	})
+	require.NoError(t, err)
+	assert.False(t, dec.Permit)
+	assert.Equal(t, DenyReadbackManifestMissing, dec.Code)
+}
+
+func TestCheckPluginReadbackFalseUsesLiveDeliveryGate(t *testing.T) {
+	t.Parallel()
+	// ReadBack=false MUST route to the existing checkPlugin (requests_decryption).
+	g := NewGuard(noParts{}, fakeManifest{readback: true, requests: false}, allowABAC{}, noBP{})
+	dec, _ := g.Check(context.Background(), CheckRequest{
+		Identity: Identity{Kind: IdentityKindPlugin, PluginName: "core-scenes"},
+		EventType: "scene_pose", ReadBack: false, KeyID: 7, KeyVersion: 1,
+	})
+	assert.False(t, dec.Permit, "live-delivery gate denies without requests_decryption")
+	assert.Equal(t, DenyManifestDeclarationMissing, dec.Code)
+}
+```
+
+Extend `fakeManifest` with a `readback bool` field and a `PluginCanReadBack` method returning it.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestCheckPluginReadback ./internal/eventbus/authguard/` → FAIL (`ReadBack`, `PermitPluginReadbackGrant`, `DenyReadbackManifestMissing` undefined).
+
+- [ ] **Step 3: Add the discriminator + decision codes**
+
+`internal/eventbus/authguard/authguard.go`:
+
+```go
+type CheckRequest struct {
+	Identity   Identity
+	KeyID      codec.KeyID
+	KeyVersion uint32
+	EventType  string
+	EventID    ulid.ULID
+	// ReadBack selects the read-back authorization path (manifest
+	// crypto.emits[].readback) over the live-delivery path
+	// (crypto.consumes.requests_decryption). Only meaningful for
+	// IdentityKindPlugin. See plugin-readback-decrypt-design §4.
+	ReadBack bool
+}
+```
+
+Add to the `DecisionCode` block: `PermitPluginReadbackGrant` and `DenyReadbackManifestMissing`.
+
+- [ ] **Step 4: Add `checkPluginReadback` + route in `Check`**
+
+`internal/eventbus/authguard/guard.go` — new method mirroring `checkPlugin` but using `PluginCanReadBack`:
+
+```go
+// checkPluginReadback — read-back path: backpressure pre-check → readback
+// manifest declaration → permit. INV-RB-2 gate g2 (manifest); gate g1
+// (OwnerMap subject ownership) is enforced upstream at the primitive entry.
+// NO ABAC gate — gate 3 was dropped (that plumbing is unbuilt; spec §7.5).
+// ctx is unused (kept for signature parity with checkPlugin / future ABAC).
+func (g *Guard) checkPluginReadback(_ context.Context, req CheckRequest) (Decision, error) {
+	if g.bp.ShouldThrottle(req.Identity.PluginName) {
+		return Decision{Permit: false, Code: DenyAuditBackpressure, Reason: "audit-emit queue throttled"}, nil
+	}
+	if !g.manifest.PluginCanReadBack(req.Identity.PluginName, req.EventType) {
+		return Decision{Permit: false, Code: DenyReadbackManifestMissing, Reason: "manifest does not declare crypto.emits[].readback"}, nil
+	}
+	return Decision{Permit: true, Code: PermitPluginReadbackGrant}, nil
+}
+```
+
+In `Guard.Check`, where it dispatches on `Identity.Kind`, route the plugin case:
+
+```go
+case IdentityKindPlugin:
+	if req.ReadBack {
+		return g.checkPluginReadback(ctx, req)
+	}
+	return g.checkPlugin(ctx, req)
+```
+
+- [ ] **Step 5: Thread `ReadBack` across the eventbus↔authguard bridge**
+
+`internal/eventbus/bus.go` — add `ReadBack bool` to `SessionCheckRequest`. `internal/eventbus/authguard/adapter_session.go` — in the `SessionCheckRequest → authguard.CheckRequest` mapping, copy `ReadBack: req.ReadBack`.
+
+- [ ] **Step 6: Run + lint, then commit**
+
+Run: `task test -- ./internal/eventbus/authguard/ ./internal/eventbus/` then `task lint:go` → PASS.
+Commit: `feat(authguard): read-back authz branch (checkPluginReadback, ReadBack discriminator) (holomush-m7pxs INV-RB-2)`.
+
+---
+
+## Task 4: Extract the shared per-row fence check
+
+**Files:**
+
+- Modify: `internal/eventbus/history/plugin_downgrade_fence.go:160-233`
+- Test: `internal/eventbus/history/plugin_downgrade_fence_test.go`
+
+- [ ] **Step 1: Write the failing test for the extracted function**
+
+`internal/eventbus/history/plugin_downgrade_fence_test.go`:
+
+```go
+func TestFenceCheckRow(t *testing.T) {
+	t.Parallel()
+	always := map[string]struct{}{"scene_pose": {}}
+	lookup := fakeCryptoKeysLookup{exists: true}
+
+	// identity codec on always-sensitive → downgrade refusal.
+	r, err := fenceCheckRow(context.Background(), rowOf("scene_pose", "identity", nil), always, lookup)
+	require.NoError(t, err)
+	assert.Equal(t, fenceRefuseDowngrade, r)
+
+	// non-identity, dek present → clean.
+	dek := uint64(7)
+	r, err = fenceCheckRow(context.Background(), rowOf("scene_pose", "xchacha20poly1305-v1", &dek), always, lookup)
+	require.NoError(t, err)
+	assert.Equal(t, fenceClean, r)
+
+	// non-identity, dek absent → DEK-missing refusal.
+	r, err = fenceCheckRow(context.Background(), rowOf("scene_pose", "xchacha20poly1305-v1", nil), always, lookup)
+	require.NoError(t, err)
+	assert.Equal(t, fenceRefuseDEKMissing, r)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestFenceCheckRow ./internal/eventbus/history/` → FAIL.
+
+- [ ] **Step 3: Extract `fenceCheckRow`**
+
+`internal/eventbus/history/plugin_downgrade_fence.go` — introduce a result enum and a pure function, then call it from `fencedStream.Next`:
+
+```go
+type fenceVerdict int
+
+const (
+	fenceClean fenceVerdict = iota
+	fenceRefuseDowngrade   // INV-P7-7
+	fenceRefuseDEKMissing  // INV-P7-15
+	fenceRefuseInternal
+)
+
+// fenceCheckRow applies INV-P7-7 (downgrade) + INV-P7-15 (DEK existence)
+// to one plugin audit row. Pure except for the cryptoKeys existence
+// lookup. Shared by fencedStream.Next (routed reads) and the snapshot
+// direct entry (DecryptOwnAuditRows) so INV-RB-5 holds on both paths.
+func fenceCheckRow(ctx context.Context, row *pluginauditpb.AuditRow, alwaysSensitive map[string]struct{}, lookup CryptoKeysLookup) (fenceVerdict, error) {
+	if row.GetCodec() == "identity" {
+		if _, sensitive := alwaysSensitive[row.GetType()]; sensitive {
+			return fenceRefuseDowngrade, nil
+		}
+		return fenceClean, nil
+	}
+	if row.DekRef == nil {
+		return fenceRefuseDEKMissing, nil
+	}
+	if lookup == nil {
+		return fenceRefuseInternal, nil
+	}
+	exists, err := lookup.Exists(ctx, *row.DekRef)
+	if err != nil {
+		return fenceClean, oops.Code("AUDIT_ROW_DEK_LOOKUP_FAILED").With("dek_ref", *row.DekRef).Wrap(err)
+	}
+	if !exists {
+		return fenceRefuseDEKMissing, nil
+	}
+	return fenceClean, nil
+}
+```
+
+Rewrite `fencedStream.Next`'s INV-P7-7/INV-P7-15 block to call `fenceCheckRow` and map verdicts to the existing `refuseEvent(...)` reasons + `emitViolationBounded` on downgrade. Behavior MUST be identical to today (this step is a pure refactor — the clean-row path still `return ev, nil` until Task 9).
+
+- [ ] **Step 4: Run the full fence suite**
+
+Run: `task test -- ./internal/eventbus/history/` → PASS (all pre-existing fence tests green; refactor is behavior-preserving).
+
+- [ ] **Step 5: Commit**
+
+Commit: `refactor(history): extract fenceCheckRow for reuse by read-back paths (holomush-m7pxs INV-RB-5)`.
+
+---
+
+## Task 5: The `decryptPluginRow` primitive
+
+**Files:**
+
+- Create: `internal/eventbus/history/readback.go`
+- Modify: `internal/eventbus/history/dispatcher.go:252` (thread `readBack`)
+- Test: `internal/eventbus/history/readback_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/eventbus/history/readback_test.go`:
+
+```go
+func TestDecryptPluginRowPlaintextOnCleanRow(t *testing.T) {
+	t.Parallel()
+	deps := newReadbackDeps(t) // wires fakeGuard(permit), fakeDEK, fakeAuditEmitter, always-set, exists-lookup
+	row := encryptedRow(t, deps, "scene_pose", []byte("Alice poses."))
+	res := decryptPluginRow(context.Background(), pluginPrincipal("core-scenes", "inst-1"), row, deps)
+	require.True(t, res.OK())
+	assert.Equal(t, []byte("Alice poses."), res.Plaintext)
+	assert.Len(t, deps.audit.records, 1, "INV-19 audit emitted (INV-RB-3)")
+}
+
+func TestDecryptPluginRowRefusesDowngrade(t *testing.T) {
+	t.Parallel()
+	deps := newReadbackDeps(t)
+	row := rowOf("scene_pose", "identity", nil) // identity on always-sensitive
+	res := decryptPluginRow(context.Background(), pluginPrincipal("core-scenes", "inst-1"), row, deps)
+	require.False(t, res.OK())
+	assert.Equal(t, eventbus.NoPlaintextReasonDowngradeRefused, res.Reason)
+	assert.Empty(t, deps.audit.records, "no decrypt → no audit")
+}
+
+func TestDecryptPluginRowFailClosedWithoutAuditEmitter(t *testing.T) {
+	t.Parallel()
+	deps := newReadbackDeps(t)
+	deps.audit = nil // INV-RB-3 fail-closed
+	row := encryptedRow(t, deps, "scene_pose", []byte("x"))
+	res := decryptPluginRow(context.Background(), pluginPrincipal("core-scenes", "inst-1"), row, deps)
+	assert.False(t, res.OK())
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run TestDecryptPluginRow ./internal/eventbus/history/` → FAIL.
+
+- [ ] **Step 3: Thread `readBack` into the decode path**
+
+`internal/eventbus/history/dispatcher.go` — add a `readBack bool` parameter to `decodeAuthorizeAndDispatch` and set it on the built request:
+
+```go
+req := eventbus.SessionCheckRequest{
+	Identity:   identity,
+	KeyID:      keyID,
+	KeyVersion: keyVersion,
+	EventType:  envelope.GetType(),
+	EventID:    eventID,
+	ReadBack:   readBack,
+}
+```
+
+Update existing callers (hot/cold tier) to pass `false`.
+
+- [ ] **Step 4: Write the primitive + `RowResult`**
+
+`internal/eventbus/history/readback.go`:
+
+```go
+// RowResult is the per-row outcome of read-back decryption: either
+// Plaintext (OK) or a typed refusal Reason. INV-RB-12.
+type RowResult struct {
+	Plaintext []byte
+	Reason    eventbus.NoPlaintextReason // zero == none (OK)
+	Err       error                      // non-nil for terminal errors (e.g. DEK lookup)
+}
+
+func (r RowResult) OK() bool { return r.Err == nil && r.Reason == eventbus.NoPlaintextReasonUnspecified }
+
+// readbackDeps bundles the host-held machinery the primitive needs.
+type readbackDeps struct {
+	alwaysSensitive map[string]struct{}
+	cryptoKeys      CryptoKeysLookup
+	guard           eventbus.SessionAuthGuard
+	dek             eventbus.SessionDEKManager
+	audit           eventbus.SessionAuditEmitter
+}
+
+// decryptPluginRow runs the shared read-back per-row pipeline: fence
+// (INV-P7-7/P7-15, INV-RB-5) → AuditRowToEvent → decodeAuthorizeAndDispatch
+// (AAD INV-E20 + DEK resolve + codec.Decode + INV-19 audit, INV-RB-1/3/4).
+// The host always holds the DEK; the principal (plugin self-decrypt or
+// participant character) is authorized inside decodeAuthorizeAndDispatch.
+func decryptPluginRow(ctx context.Context, identity eventbus.SessionIdentity, row *pluginauditpb.AuditRow, d readbackDeps) RowResult {
+	verdict, err := fenceCheckRow(ctx, row, d.alwaysSensitive, d.cryptoKeys)
+	if err != nil {
+		return RowResult{Err: err}
+	}
+	switch verdict {
+	case fenceRefuseDowngrade:
+		return RowResult{Reason: eventbus.NoPlaintextReasonDowngradeRefused}
+	case fenceRefuseDEKMissing:
+		return RowResult{Reason: eventbus.NoPlaintextReasonDEKMissing}
+	case fenceRefuseInternal:
+		return RowResult{Reason: eventbus.NoPlaintextReasonInternal}
+	}
+
+	envelope := AuditRowToEvent(row)
+	// AuditRowToEvent omits Payload (it is AAD-only, INV-TS-5). Restore the
+	// ciphertext for c.Decode — aad.Build excludes Payload, so AAD is
+	// unaffected; this matches how the hot/cold tiers feed a full envelope.
+	envelope.Payload = row.GetPayload()
+	codecName := codec.Name(row.GetCodec())
+	keyID := codec.KeyID(row.GetDekRef())
+	readBack := identity.Kind == eventbus.IdentityKindPlugin
+	ev, metaOnly, err := decodeAuthorizeAndDispatch(
+		ctx, envelope, codecName, keyID, row.GetDekVersion(),
+		identity, d.guard, d.dek, d.audit, readBack,
+	)
+	if err != nil {
+		return RowResult{Err: err}
+	}
+	if metaOnly {
+		return RowResult{Reason: ev.NoPlaintextReason}
+	}
+	return RowResult{Plaintext: ev.Payload}
+}
+```
+
+(`NoPlaintextReasonUnspecified` is the zero value at `eventbus/types.go:34` — do NOT add a new reason constant; `TestNoPlaintextReasonEnumParity` pins the count at 8. Confirm `row.GetDekRef()` / `row.GetDekVersion()` accessors on the generated `pluginauditpb.AuditRow`.)
+
+- [ ] **Step 5: Run + lint, commit**
+
+Run: `task test -- ./internal/eventbus/history/` then `task lint:go` → PASS.
+Commit: `feat(history): decryptPluginRow read-back primitive (holomush-m7pxs INV-RB-1/3/4/5/12)`.
+
+---
+
+## Task 6: `DecryptOwnAuditRows` RPC + host handler
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/audit.proto`
+- Modify: `internal/plugin/goplugin/host_service.go:495` (pattern)
+- Test: `internal/plugin/goplugin/host_service_test.go`
+
+- [ ] **Step 1: Add the proto + regenerate**
+
+`api/proto/holomush/plugin/v1/audit.proto` — add to `PluginAuditService` (or `PluginHostService` if the plugin→host audit calls live there; match where `AuditEvent`/`QueryHistory` are defined for the host-implemented side):
+
+```protobuf
+// DecryptOwnAuditRows decrypts a batch of the calling plugin's OWN audit
+// rows host-side. The plugin never holds a DEK. Per-row result envelope
+// (INV-RB-12). Batch capped at 500 server-side. Authorization: OwnerMap
+// subject ownership (g1) + crypto.emits[].readback manifest flag (g2) (INV-RB-2).
+rpc DecryptOwnAuditRows(DecryptOwnAuditRowsRequest) returns (DecryptOwnAuditRowsResponse);
+```
+
+```protobuf
+message DecryptOwnAuditRowsRequest {
+  repeated AuditRow rows = 1;
+}
+message DecryptOwnAuditRowsResponse {
+  repeated RowResult results = 1; // 1:1 with request rows, same order (INV-RB-12)
+}
+message RowResult {
+  bytes id = 1;            // echoes AuditRow.id for correlation
+  bytes plaintext = 2;     // set iff decrypted
+  string no_plaintext_reason = 3; // set iff refused (e.g. "downgrade_refused", "dek_missing")
+}
+```
+
+Run: `task generate` (buf). Confirm generated Go in `pkg/proto/holomush/plugin/v1/`.
+
+- [ ] **Step 2: Write the failing handler test**
+
+`internal/plugin/goplugin/host_service_test.go`:
+
+```go
+func TestDecryptOwnAuditRowsRejectsForeignSubject(t *testing.T) {
+	t.Parallel()
+	s := newHostServiceForPlugin(t, "core-scenes", withOwnerMap(ownerOf("events.main.scene.X.ic", "core-scenes")))
+	resp, err := s.DecryptOwnAuditRows(ctx, &pluginv1.DecryptOwnAuditRowsRequest{
+		Rows: []*pluginv1.AuditRow{rowWithSubject("events.main.comm.whisper", "scene_pose")},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "not_owner", resp.Results[0].NoPlaintextReason, "INV-RB-2 g1: not the owner")
+}
+
+func TestDecryptOwnAuditRowsCapsBatchAt500(t *testing.T) {
+	t.Parallel()
+	s := newHostServiceForPlugin(t, "core-scenes", withOwnerMap(...))
+	_, err := s.DecryptOwnAuditRows(ctx, &pluginv1.DecryptOwnAuditRowsRequest{Rows: make([]*pluginv1.AuditRow, 501)})
+	errutil.AssertErrorCode(t, err, "DECRYPT_BATCH_TOO_LARGE")
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `task test -- -run TestDecryptOwnAuditRows ./internal/plugin/goplugin/` → FAIL.
+
+- [ ] **Step 4: Implement the handler**
+
+`internal/plugin/goplugin/host_service.go` — mirror `QueryStreamHistory`'s structure, but note this handler **rejects** an over-cap batch (vs `QueryStreamHistory`, which silently *clamps* `count` to `maxQueryStreamHistoryCount` at `:512`). Use a dedicated `const maxDecryptBatch = 500` rather than reusing the clamp constant, to keep the reject-vs-clamp distinction explicit:
+
+```go
+const maxDecryptBatch = 500
+
+func (s *pluginHostServiceServer) DecryptOwnAuditRows(ctx context.Context, req *pluginv1.DecryptOwnAuditRowsRequest) (*pluginv1.DecryptOwnAuditRowsResponse, error) {
+	if len(req.GetRows()) > maxDecryptBatch {
+		return nil, oops.Code("DECRYPT_BATCH_TOO_LARGE").
+			With("plugin", s.pluginName).With("count", len(req.GetRows())).
+			Errorf("batch exceeds cap %d", maxDecryptBatch)
+	}
+	dec := s.host.ReadbackDecryptor() // host wiring exposes the primitive's deps + OwnerMap
+	results := make([]*pluginv1.RowResult, 0, len(req.GetRows()))
+	for _, row := range req.GetRows() {
+		results = append(results, dec.DecryptOwnRow(ctx, s.pluginName, s.instanceID, row))
+	}
+	return &pluginv1.DecryptOwnAuditRowsResponse{Results: results}, nil
+}
+```
+
+Add a host-side `ReadbackDecryptor` (a thin type in `internal/eventbus/history` or `internal/plugin`) whose `DecryptOwnRow` does the **OwnerMap gate 1** then calls `decryptPluginRow` with a plugin `SessionIdentity`, mapping `RowResult` → proto `RowResult`. Owner mismatch → `no_plaintext_reason="not_owner"` (no `decryptPluginRow` call).
+
+- [ ] **Step 5: Run + lint, commit**
+
+Run: `task test -- ./internal/plugin/goplugin/ ./internal/eventbus/history/` then `task lint:go` → PASS.
+Commit: `feat(plugin): DecryptOwnAuditRows host RPC (OwnerMap gate + chunked decrypt) (holomush-m7pxs INV-RB-2/6/12)`.
+
+---
+
+## Task 7: Go SDK + Lua hostfunc parity
+
+**Files:**
+
+- Modify: `pkg/plugin/audit.go`
+- Modify: `internal/plugin/hostfunc/*` + `internal/plugin/lua/*` (mirror an existing host RPC)
+- Test: `pkg/plugin/audit_test.go`, `internal/plugin/hostfunc/*_test.go`
+
+- [ ] **Step 1: Write failing Go SDK test**
+
+`pkg/plugin/audit_test.go` — assert the SDK method calls the client and returns per-row plaintext/refusal:
+
+```go
+func TestDecryptOwnAuditRowsSDK(t *testing.T) {
+	t.Parallel()
+	c := &fakeHostClient{decrypt: func(rows []*pluginv1.AuditRow) []*pluginv1.RowResult {
+		return []*pluginv1.RowResult{{Id: rows[0].Id, Plaintext: []byte("hi")}}
+	}}
+	got, err := DecryptOwnAuditRows(ctx, c, []*pluginv1.AuditRow{{Id: idBytes}})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hi"), got[0].Plaintext)
+}
+```
+
+- [ ] **Step 2: Run → fail; implement the SDK helper**
+
+Add `DecryptOwnAuditRows` to `pkg/plugin/audit.go` wrapping the generated client method (mirror the existing `LoadForQuery`/`QueryStreamHistory` SDK shape).
+
+- [ ] **Step 3: Write the failing Lua hostfunc test, then implement**
+
+Mirror the existing `query_stream_history` Lua wrapper: register `holomush.host:decrypt_own_audit_rows(rows)` in the Lua VM, marshalling rows in and `{plaintext|reason}` out. Assert via the hostfunc test harness that a Lua call reaches the host client.
+
+Per the host-RPC Go+Lua parity invariant, this MUST ship in the same change as the Go SDK method.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `task test -- ./pkg/plugin/ ./internal/plugin/hostfunc/ ./internal/plugin/lua/` → PASS.
+Commit: `feat(plugin): DecryptOwnAuditRows Go SDK + Lua hostfunc (parity) (holomush-m7pxs)`.
+
+---
+
+## Task 8: Complete the fence — routed reads decrypt
+
+**Files:**
+
+- Modify: `internal/eventbus/history/plugin_downgrade_fence.go` (`fencedStream.Next` clean-row path; thread caller identity)
+- Modify: `internal/eventbus/history/tier.go:420` (pass `q.Caller`/`q.Identity` into the fence)
+- Test: `internal/eventbus/history/plugin_downgrade_fence_test.go` (migrate ciphertext→plaintext assertions)
+
+- [ ] **Step 1: Update the fence test from passthrough to plaintext**
+
+Migrate the existing "clean row passes through as ciphertext" assertions to expect **plaintext** for an authorized member, and a refusal for a non-member:
+
+```go
+func TestFenceDecryptsCleanRowForMember(t *testing.T) {
+	t.Parallel()
+	f := newFenceWithReadback(t, memberCharacter("char-1")) // wires decryptPluginRow deps + character identity
+	ev, err := fencedNext(t, f, encryptedRow(t, "scene_pose", []byte("Alice poses.")))
+	require.NoError(t, err)
+	assert.False(t, ev.MetadataOnly)
+	assert.Equal(t, []byte("Alice poses."), ev.Payload)
+}
+
+func TestFenceRefusesCleanRowForNonMember(t *testing.T) {
+	t.Parallel()
+	f := newFenceWithReadback(t, nonMemberCharacter("char-2"))
+	ev, err := fencedNext(t, f, encryptedRow(t, "scene_pose", []byte("secret")))
+	require.NoError(t, err)
+	assert.True(t, ev.MetadataOnly, "non-member MUST NOT get plaintext (INV-RB-7)")
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `task test -- -run 'TestFenceDecrypts|TestFenceRefusesCleanRow' ./internal/eventbus/history/` → FAIL.
+
+- [ ] **Step 3: Wire the clean-row path to `decryptPluginRow`**
+
+In `fencedStream.Next`, replace the final `// Clean row — pass through` `return ev, nil` with a call to `decryptPluginRow` using a **character** `SessionIdentity` derived from the query caller. The fence gains the readback deps + the caller identity at construction. Map the `RowResult`: plaintext → set `ev.Payload`; refusal → `refuseEvent(ev, res.Reason)`; `Err` → return the error.
+
+`internal/eventbus/history/tier.go:420` — thread the caller into the fenced router so the fence can build the identity:
+
+```go
+return r.fencedRouter().QueryHistory(ctx, owner.PluginName, q) // q.Caller / q.Identity already carry the principal (bus.go:117)
+```
+
+(If the `PluginHistoryRouter` interface does not currently forward identity to the fence, extend the fence constructor/`QueryHistory` to accept it from `q`. Convert `q.Caller` (Actor) → `authguard.Identity` via the existing `ToSessionIdentity`/Actor mapping; `ReadBack=false` so `Check` routes to `checkCharacter` DEK-membership.)
+
+- [ ] **Step 4: Run the full history + privacy unit suites**
+
+Run: `task test -- ./internal/eventbus/history/ ./internal/grpc/` → PASS. Confirm no other fence test regressed.
+
+- [ ] **Step 5: Commit**
+
+Commit: `feat(history): fence decrypts clean rows for authorized routed readers (holomush-m7pxs INV-RB-7)`.
+
+---
+
+## Task 9: Integration + E2E (real stack)
+
+**Files:**
+
+- Create: `test/integration/crypto/readback_test.go` (real-stack integration + INV-RB meta-test)
+- Create: `test/integration/privacy/scene_history_readback_test.go` (participant E2E, Ginkgo)
+
+- [ ] **Step 1: Real-stack integration — authorized vs unauthorized**
+
+`test/integration/crypto/readback_test.go` (`//go:build integration`) using the real codec + DEK manager + fence + primitive (NOT `fakeHistoryReader` — closes the fake-bus coverage gap). Snapshot direct-entry path: authorized → plaintext (INV-RB-1/2/3/4/12), unauthorized → refused (INV-RB-2):
+
+```go
+func TestReadbackAuthorizedReturnsPlaintext(t *testing.T) {
+	h := integrationtest.New(t) // real Postgres + NATS + CoreServer
+	// emit an encrypted scene_pose as core-scenes; read it back via DecryptOwnAuditRows.
+	row := h.EmitSceneIC(t, "scene_pose", "Alice poses.")
+	res := h.DecryptOwnAuditRows(t, "core-scenes", []*pluginv1.AuditRow{row})
+	require.Equal(t, []byte("Alice poses."), res[0].Plaintext)
+	h.AssertPluginDecryptAudit(t, "core-scenes", 1) // INV-RB-3
+}
+
+func TestReadbackForeignSubjectRefused(t *testing.T) { /* core-comm row via core-scenes → not_owner */ }
+func TestReadbackWithoutReadbackFlagDenied(t *testing.T) { /* plugin w/o readback manifest → deny */ }
+```
+
+- [ ] **Step 2: Meta-test — every INV-RB-* referenced**
+
+Enumerate the INV-RB-* that **this plan implements** — **1, 2, 3, 4, 5, 7, 9, 11, 12** plus the direct-entry side of **6** — and assert each is named in ≥1 test (`rg`-style registry test mirroring the master crypto spec's invariant-coverage discipline). **INV-RB-8** (snapshot atomicity), **INV-RB-10** (`SNAPSHOT_DECRYPT_FAILED`), and the *consumer* side of **INV-RB-6** (the snapshot reads via the direct entry, not `QueryHistory`) are asserted by the C7 snapshot-pipeline bead (`holomush-5rh.20.26`), which consumes `DecryptOwnAuditRows` — out of scope here (see plan header). Run: `task test:int -- ./test/integration/crypto/` → PASS.
+
+- [ ] **Step 3: Participant E2E — scene-IC scrollback**
+
+`test/integration/privacy/scene_history_readback_test.go` (Ginkgo): a scene member reconnects, backfills the scene-IC stream via `WebQueryStreamHistory`, and receives **decrypted** poses; a non-member receives refused/metadata-only (INV-RB-7). Use the `integrationtest` harness with `WithPolicyEngine` seeded to permit.
+
+- [ ] **Step 4: Run E2E, commit**
+
+Run: `task test:int -- ./test/integration/crypto/ ./test/integration/privacy/` → PASS.
+Commit: `test(crypto): real-stack read-back integration + participant E2E (holomush-m7pxs INV-RB-3/7/11/12)`.
+
+---
+
+## Task 10: Documentation (PR-blocking)
+
+**Files:**
+
+- Create: `site/docs/extending/plugin-crypto-readback.md`
+- Modify: `site/docs/contributing/` (a sentence in the relevant crypto/eventbus contributor page)
+
+- [ ] **Step 1: Write the author-facing capability doc**
+
+`site/docs/extending/plugin-crypto-readback.md`: what `crypto.emits[].readback` means, that decrypt is host-mediated (plugin never holds a DEK), the three authz gates (OwnerMap ownership / `readback` flag / ABAC `decrypt`), the INV-19 audit, and that the host caps batches at 500. Link the design spec.
+
+- [ ] **Step 2: Note the fence-contract change for contributors**
+
+Add a short note to `site/docs/contributing/event-emit-pipeline.md` (the closest existing crypto/eventbus contributor page; if it lacks a read-back section, add one): routed plugin-owned reads now decrypt clean rows for authorized readers (was ciphertext-passthrough); `fenceCheckRow` is shared with the snapshot read-back path.
+
+- [ ] **Step 3: Build docs + commit**
+
+Run: `task docs:build` → success (no broken links).
+Commit: `docs(extending): plugin read-back decrypt capability (holomush-m7pxs)`.
+
+---
+
+## Verification (whole plan)
+
+- [ ] `task lint` — zero findings
+- [ ] `task test` — all unit packages green, ≥80% per-package coverage on touched packages (`task test:cover`)
+- [ ] `task test:int` — integration + E2E green (Docker)
+- [ ] `task pr-prep` — full lane green before any push
+<!-- adr-capture: sha256=35b67f992e0afa6a; ts=2026-05-25T16:15:06Z; adrs=holomush-g3d4l,holomush-edqh1,holomush-c3kyv,holomush-wfh42 -->

--- a/docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md
+++ b/docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md
@@ -1,0 +1,277 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Host-Mediated Read-Back Decryption for Plugin-Owned Sensitive Subjects
+
+| | |
+| --- | --- |
+| **Design bead** | `holomush-m7pxs` |
+| **Date** | 2026-05-25 |
+| **Status** | READY (design-reviewer, round 4 — 2-gate model) |
+| **Driving consumer** | `holomush-5rh.20.26` (C7 scene publish snapshot) — blocked by this design |
+| **Relates to** | Master crypto spec [`2026-04-25-event-payload-crypto-design.md`](2026-04-25-event-payload-crypto-design.md); scenes phase 6 [`2026-05-23-scenes-phase-6-logs-vote-privacy-design.md`](2026-05-23-scenes-phase-6-logs-vote-privacy-design.md) §11; ADR `holomush-sb3n` (scene content `sensitivity:always`) |
+| **Revises** | scenes phase 6 spec §11.1, §11.2, §11.4 (see [§10](#10-revisions-to-the-scenes-phase-6-spec)) |
+
+---
+
+## 1. Problem
+
+Plugin-owned event subjects classified `sensitivity:always` (scene IC content: `scene_pose`/`scene_say`/`scene_emit`; comms `whisper`/`page`/`pemit`) are encrypted at rest in the owning plugin's audit table (`scene_log` for core-scenes). **No path anywhere decrypts these payloads on a history read-back.** Verified against current code (`main`):
+
+- The plugin emits **plaintext** (`plugins/core-scenes/commands.go:892`, `Sensitive: true`); the **host** encrypts at `internal/plugin/event_emitter.go` (`EnforceSensitivity`). The plugin imports no `eventbus/codec`, `eventbus/crypto`, or `crypto/dek` — it never holds a DEK.
+- `Reader.QueryHistory` short-circuits plugin-owned subjects to `fencedRouter()` and returns that stream directly (`internal/eventbus/history/tier.go:410-422`). The `codec.KeySelector` decrypt is only wired into the host-owned hot/cold tiers.
+- The `PluginDowngradeFence` only **gates** — INV-P7-7 downgrade refusal + INV-P7-15 DEK-existence — and passes **ciphertext through for clean rows** (`internal/eventbus/history/plugin_downgrade_fence.go:232`). It never decrypts.
+- Consequently the scenes-phase-6 snapshot (§11.2) is unbuildable as written: its premise "the plugin already holds DEK access for its own events" is **false**, and the only decrypt machinery (`decodeAuthorizeAndDispatch`, `internal/eventbus/history/dispatcher.go:~180-210`) is unreachable from the plugin-routed path.
+
+The gap is **general**, not snapshot-specific: any authorized read-back of plugin-owned sensitive content returns ciphertext or a refused metadata-only row. It is currently masked because the read-back tests run against a `fakeHistoryReader` (`internal/grpc/query_stream_history_test.go:264`) that bypasses the codec/DEK/fence/decrypt stack, asserting authorization only — never payload.
+
+### 1.1 Two armed consumers
+
+1. **Scene publish snapshot (C7):** the publish state machine, on cool-off elapse, must read the scene's IC events and render them into the immutable `published_scenes.content_entries`. It needs plaintext. System-initiated, runs in the plugin's lifecycle ticker (scenes-phase-6 §225).
+2. **Participant history read-back:** a scene participant's web client backfills stream history on reconnect (`web/src/lib/backfill/streamBackfill.ts`). Scene-IC reaches the backfill set via the focus substrate (`internal/grpc/focus/subscription_router.go:42` emits `events.<game>.scene.<id>.ic` on scene focus; `auto_focus_on_join.go` wires it). The first scene participant who reconnects gets ciphertext/refused. Comms `whisper`/`page` share the identical gap.
+
+These consumers share a **decrypt primitive** but **not a read path**: the snapshot reads its own table directly and must not route through the host (a self-loop, §3.1); participants have no DB access and must be served via the host-routed read.
+
+## 2. Goals / Non-goals
+
+**Goals:**
+
+- A single reusable host-side decrypt primitive for plugin-owned sensitive audit rows: rebuild AAD, resolve DEK host-side, apply the downgrade fence, authorize, decrypt, audit.
+- A first-class capability for a plugin to read back and decrypt **its own** sensitive events, host-mediated (plugin never holds a DEK).
+- Unblock C7 (snapshot) and complete the participant routed read-back, in one coherent change.
+- Preserve role isolation, default-deny ABAC, INV-P7-7/INV-P7-15 fence semantics, and INV-19 decrypt auditing.
+
+**Non-goals:**
+
+- Granting plugins DEK access. The host always holds keys; the plugin only ever receives plaintext.
+- Cryptographic prevention of a compromised plugin bulk-reading its own historical content (see [§7](#7-security-analysis) — the chosen posture is *detect*, not *prevent*).
+- Contextual/consent-gated decrypt (publish-state-conditioned ABAC) — rejected as disproportionate ([§7.2](#72-rejected-prevent)).
+- Changing the cross-plugin `requests_decryption` capability (INV-45) or live-delivery decrypt (INV-17).
+
+## 3. Design overview
+
+### 3.1 The self-loop, avoided
+
+The plugin-routed read path exists so the host can serve readers with **no DB access** (participants): reader → host `Reader.QueryHistory` → `PluginHistoryRouter` → plugin's `PluginAuditService.QueryHistory` → plugin reads its table → ciphertext to host → (decrypt) → reader. For the **snapshot**, the reader *is* the plugin, which already holds the rows from its in-tx SQL read (C6, `ReadSceneLogForSnapshot`). Routing the snapshot through that path is a `plugin→host→plugin→host→plugin` loop. The snapshot therefore uses a **direct** decrypt entry: it passes the rows it already read to the host primitive and gets plaintext back (one hop).
+
+### 3.2 Components
+
+| Component | Location (new/extend) | Role |
+| --- | --- | --- |
+| **Decrypt primitive** | extend `internal/eventbus/history` | `Decrypt(ctx, principal, []*pluginauditpb.AuditRow) → []RowResult`, each `RowResult` plaintext **or** a typed refusal (per-row, never all-or-nothing). For each row it adapts via the existing `AuditRowToEvent` (`plugin_aad_adapter.go:33`, INV-TS-5 byte-equal round-trip) then **delegates to `decodeAuthorizeAndDispatch`** (`dispatcher.go:252`) — MUST NOT reimplement AAD/decode, to guarantee encrypt-path parity. |
+| **Subject-ownership gate** | `internal/eventbus/audit` `OwnerMap` | Host-side structural check at primitive entry: `OwnerMap.Resolve(row.subject).PluginName == principal.PluginName`. The **single** place subject-scope is enforced (INV-RB-2 gate 1). |
+| **Manifest capability** | extend `internal/plugin/crypto_manifest.go` `CryptoEmit` | `readback bool` flag (default `false`) is the backing field; `Manager.PluginCanReadBack(plugin, eventType)` implements the lookup (parallel to `Manager.PluginRequestsDecryption`, `manager.go:1504`). The method is **added to the existing `authguard.ManifestLookup` interface** (not a new interface): `manifestAdapter` delegates to `Manager`; the ~3 test fakes (`fakeManifest`, and the `metadata_only_test`/`plugin_decrypt_test` lookups) gain a default-`false` method. Distinct from `PluginRequestsDecryption` (which reads `consumes`). Loader rejects `readback: true` on a type the plugin does not emit. Runtime-symmetric. |
+| **AuthGuard readback branch** | extend `internal/eventbus/authguard/guard.go` | New `Guard.CheckPluginReadback` (parallel to live-delivery `checkPlugin`), reusing `Guard`'s existing `manifest ManifestLookup` field (no new injection point): backpressure pre-check → gate on `PluginCanReadBack` → permit. **No ABAC `decrypt` grant** — that production plumbing (a `dek` resource type + a `decrypt` permit policy) does not exist; the manifest `readback` flag (default-deny) + the OwnerMap gate are the authorization. See [§4](#4-authorization-model) + [§7.5](#75-deferred-abac-decrypt-action). |
+| **Snapshot direct entry** | new host RPC on `PluginHostService` | `DecryptOwnAuditRows([]AuditRow) → []RowResult` (per-row envelope). Per-call batch cap of 500 (a dedicated `maxDecryptBatch` const that **rejects** over-cap, distinct from `QueryStreamHistory`'s silent clamp at `host_service.go:495`); the snapshot **chunks** its decrypt over the row set to support scenes of any length, bounding per-call memory + blast radius. Plugin-self-decrypt principal. Go SDK method + Lua hostfunc ship together (host-RPC Go+Lua parity). |
+| **Fence completion** | `internal/eventbus/history/plugin_downgrade_fence.go` | Clean rows are **decrypted** via the primitive instead of passed through as ciphertext. The reader principal is taken from `HistoryQuery.Caller` (`bus.go:117`, already populated by the host gRPC layer) mapped to an `authguard.Identity`; AuthGuard authorizes via DEK-participant-set membership (`guard.go:64`). Subject-agnostic — core-communication `whisper`/`page`/`pemit` get read-back decrypt with no comms-specific logic. |
+
+The primitive's per-row decision is identical for both consumers (only the principal differs):
+
+```mermaid
+flowchart TD
+    A[AuditRow in] --> O{OwnerMap · principal<br/>owns subject? · INV-RB-2 g1}
+    O -- no --> R0[refuse · not owner]
+    O -- yes --> B{manifest readback<br/>flag? · INV-RB-2 g2}
+    B -- no --> R1[refuse · not authorized]
+    B -- yes --> C{INV-P7-7 downgrade?}
+    C -- yes --> R2[refuse · DowngradeRefused]
+    C -- no --> D{INV-P7-15 DEK exists?}
+    D -- no --> R3[refuse · DEKMissing]
+    D -- yes --> E[AuditRowToEvent + aad.Build · INV-RB-4]
+    E --> F[host resolves DEK · codec.Decode · INV-RB-1]
+    F --> G{decode ok?}
+    G -- no --> R4[refuse · decrypt failed]
+    G -- yes --> H[emit INV-19 audit · fail-closed · INV-RB-3]
+    H --> I[plaintext RowResult out]
+```
+
+### 3.3 Data flow — snapshot (plugin-self-decrypt principal)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as publishService (plugin ticker)
+    participant DB as scene_log (in-tx)
+    participant H as Host DecryptOwnAuditRows
+    participant K as DEK + codec (host-held)
+    participant AU as DecryptAuditEmitter
+
+    T->>DB: ReadSceneLogForSnapshot(tx, subject) · C6 · ciphertext
+    DB-->>T: AuditRows (ciphertext, dek_ref, codec)
+    T->>H: DecryptOwnAuditRows(rows)
+    loop each row (see §3.2 decision)
+        H->>H: subject-scope + readback grant · INV-RB-2
+        H->>H: INV-P7-7 / INV-P7-15 fence · INV-RB-5
+        H->>K: aad.Build + resolve DEK + codec.Decode · INV-RB-1, INV-RB-4
+        H->>AU: emit plugin_decrypt audit · fail-closed · INV-RB-3
+    end
+    H-->>T: plaintext rows
+    T->>T: render content entries
+    rect rgb(235, 240, 255)
+        note over T,DB: single write transaction · INV-RB-8
+        T->>DB: SELECT FOR UPDATE, re-validate COOLOFF + all-yes
+        T->>DB: MarkPublished(content_entries), then SetSceneState(archived)
+    end
+    T->>T: post-tx emit scene_publish_resolved (outcome=PUBLISHED)
+```
+
+### 3.4 Data flow — participant (routed, DEK-membership principal)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as web client (reconnect)
+    participant C as CoreServer.QueryStreamHistory
+    participant R as Reader.QueryHistory
+    participant PR as PluginHistoryRouter
+    participant P as plugin PluginAuditService
+    participant F as fencedStream + primitive
+
+    W->>C: WebQueryStreamHistory(scene.ic)
+    C->>C: membership gate · I-17
+    C->>R: QueryHistory(subject = scene.ic)
+    R->>PR: plugin-owned, route via fencedRouter()
+    PR->>P: QueryHistory(subject)
+    P-->>PR: ciphertext rows
+    PR-->>F: ciphertext rows
+    loop each row in fencedStream.Next
+        F->>F: INV-P7-7 / INV-P7-15 gate (unchanged)
+        F->>F: clean row → decrypt via §3.2 primitive · INV-RB-7
+        note over F: principal = character ·<br/>AuthGuard DEK participant-set membership (guard.go:64) ·<br/>then codec.Decode + INV-19 audit
+    end
+    F-->>W: plaintext frames
+```
+
+## 4. Authorization model
+
+The principal is **fixed by the architecture**: there is no System `IdentityKind` (`internal/eventbus/authguard/authguard.go` enumerates Unknown/Character/Player/Plugin/Operator), and the snapshot runs in the plugin's lifecycle ticker. So:
+
+- **Snapshot:** principal = the plugin (`IdentityKindPlugin`, core-scenes), decrypting **its own** events.
+- **Participant:** principal = the reading character (`IdentityKindCharacter`), authorized by existing **DEK participant-set membership** (`internal/eventbus/authguard/guard.go:64`) — no new authz design.
+
+For the plugin-self-decrypt case, authorization is **two single-purpose gates**, each evaluated exactly once and in order; failing either denies (default-deny):
+
+1. **Subject ownership (structural, host-side).** At primitive entry the host checks `OwnerMap.Resolve(row.subject).PluginName == principal.PluginName`. A plugin can only submit rows on subjects it owns — the *only* place subject-scope is enforced.
+2. **Manifest intent.** `crypto.emits[].readback: true` for the row's event type, checked via the new `ManifestLookup.PluginCanReadBack(plugin, eventType)` — distinct from the live-delivery `PluginRequestsDecryption` (which reads `consumes`). Loader rejects `readback: true` on a type the plugin does not emit; default `false`. This is the explicit, default-deny opt-in.
+
+Every successful decrypt then emits the INV-19 `audit.<game>.plugin_decrypt.<plugin>` event on a subject the plugin cannot subscribe to; the primitive fails closed if the emitter is absent.
+
+**No ABAC `decrypt`-action gate.** The cross-plugin live-delivery path (`checkPlugin`) issues an ABAC `decrypt` request on a `dek:<keyID>:<keyVer>` resource, but **no production policy satisfies it and no `dek` resource type exists** — that plumbing is unbuilt (it always-denies in prod today; only test helpers grant it). Adding it for read-back would couple this work to an absent subsystem for no security gain over gates 1–2 + audit: gate 1 confines the plugin to data it authored, gate 2 is the explicit opt-in, and every decrypt is audited. Wiring a real ABAC `decrypt` action (for live-delivery **and** read-back) is deferred — see [§7.5](#75-deferred-abac-decrypt-action).
+
+The **participant (routed) path** reuses gate 1's structural machinery but replaces gate 2 with the existing **DEK participant-set membership** check (`guard.go:64`) keyed on the reading character — no manifest flag.
+
+This is *not* implicit ownership — a plugin lacking the manifest `readback` flag is denied even on its own subjects.
+
+## 5. Why self-decrypt is not a new information class
+
+core-scenes constructs the plaintext at emit time (`commands.go:892`); it already sees every pose/say/emit as it happens. The only property encryption-at-rest buys *against the plugin itself* is **temporal**: a plugin cannot retroactively recover plaintext for events emitted before it had decrypt access. Read-back self-decrypt grants no content the plugin did not author. The residual concern is bulk retroactive access after compromise — addressed in [§7](#7-security-analysis).
+
+## 6. Atomicity (snapshot)
+
+scenes-phase-6 §11.3 atomicity is about the **state write** (status → PUBLISHED, `content_entries` set, scene archived), not the read. The snapshot therefore reads + decrypts + renders **before** opening the write transaction. C6 reads the full IC row set in one read-tx (a consistent snapshot of `scene_log`); the snapshot then chunks the decrypt into ≤500-row `DecryptOwnAuditRows` calls (a pure transform over the already-read rows), all completing before the write-tx opens. The `SELECT FOR UPDATE` on `published_scenes` inside the write-tx re-validates COOLOFF + all-yes and is the serialization point. There remains no observable intermediate state where a publication is PUBLISHED without content. A vote-flip between the read and the write is caught by the in-tx re-check (no-op commit).
+
+## 7. Security analysis
+
+### 7.1 Chosen posture: detect, not prevent
+
+A `readback`-capable plugin can, in principle, decrypt **all** of its own historical sensitive events (subject-scoping limits it to data it already owns, but not to a single scene or time window). Genuine prevention requires conditioning the decrypt on domain state (e.g. "only when the scene is COOLOFF + all-yes"), which forces scene-domain state up into the trusted gate (ABAC attributes or a publish-scoped host entry) — a coupling cost disproportionate to a low-probability concern, given the plugin already sees plaintext at emit. **Decision (m7pxs): detect.** Bulk historical access is (a) bounded to data the plugin authored, (b) made loud via mandatory INV-19 audit on an unsuppressable subject, (c) bounded per call by the 500-row batch cap (§3.2), and (d) ultimately revocable by the operator's rekey/DEK-destruction lever (a destroyed DEK fails the read-back at INV-P7-15, unchanged).
+
+### 7.2 Rejected: prevent
+
+Contextual/consent-gated ABAC (decrypt permitted only under publish-state attributes) is explicitly out of scope. It is recorded here so a future reviewer understands the omission is deliberate, not an oversight.
+
+### 7.3 AAD rebuild safety
+
+The direct entry accepts rows from the plugin. The host **rebuilds AAD from the row's own authoritative fields** (`id`/`subject`/`type`/`timestamp`/`actor`/`codec`/`dek_ref`/`dek_version`, all carried on `pluginauditpb.AuditRow`) by routing through the existing `AuditRowToEvent` adapter (`plugin_aad_adapter.go`) + `aad.Build` — the same path whose byte-equality is pinned by INV-TS-5. A row whose fields are inconsistent with the ciphertext's bound AAD fails `codec.Decode`. Combined with the subject-ownership gate ([§4](#4-authorization-model) gate 1 — the plugin cannot even submit another plugin's subjects), a malicious plugin cannot decrypt anything it did not author.
+
+### 7.4 Plugin-runtime symmetry
+
+The capability, fence, and audit are runtime-agnostic and apply identically to binary and Lua plugins (per the project plugin-runtime-symmetry invariant). No host-side trust check distinguishes the runtimes.
+
+### 7.5 Deferred: ABAC decrypt action
+
+The host has no `dek` resource type and no `decrypt` permit policy in production: `seed.go` carries only plugin-stream `forbid` policies, no plugin manifest declares a `decrypt` policy, and the sole grant is a test helper (`policytest`). The AuthGuard's `checkPlugin` ABAC call (`guard.go:129`) therefore always-denies in production — live-delivery plugin decrypt is itself ungranted, latent only because no shipped plugin uses `requests_decryption`. Building that plumbing (a `dek` resource type + attribute provider + a plugin-decrypt policy mechanism) is **out of scope here** and filed as a follow-up bead; when it lands, both live-delivery and read-back can adopt the ABAC `decrypt` action as an additional gate. Until then, read-back authorization is gates 1–2 + INV-19 audit (the detect posture, §7.1) — complete and default-deny. This is a deliberate scope decision, not an oversight; the crypto-reviewer should evaluate it as such.
+
+## 8. Invariants
+
+All MUST have a test at the stated level. A meta-test MUST assert every `INV-RB-*` is referenced by at least one test (mirroring the master crypto spec's invariant-coverage discipline).
+
+| ID | Invariant | Test |
+| --- | --- | --- |
+| **INV-RB-1** | Read-back decryption MUST occur host-side; the plugin MUST NOT receive or hold a DEK. The plugin receives only plaintext (or a refusal). | Unit + Integration |
+| **INV-RB-2** | A plugin read-back decrypt MUST pass two gates, each evaluated once (default-deny — failing either denies): **(g1)** host-side `OwnerMap` subject-ownership at primitive entry, the *sole* subject-scope check; **(g2)** manifest `crypto.emits[].readback: true` via `PluginCanReadBack` (the explicit default-deny opt-in). No ABAC `decrypt` gate (deferred, §7.5). | Unit + Integration |
+| **INV-RB-3** | Every read-back decrypt MUST emit an INV-19 `plugin_decrypt` audit event on a subject the plugin cannot subscribe to. The primitive MUST fail closed if the audit emitter is absent. | Unit + Integration |
+| **INV-RB-4** | AAD for read-back decrypt MUST be built by routing the row through `AuditRowToEvent` + `aad.Build` (the INV-TS-5 round-trip path); the primitive MUST delegate to `decodeAuthorizeAndDispatch`, not reimplement decode. A row whose fields do not match its ciphertext's bound AAD MUST fail decrypt. | Unit |
+| **INV-RB-5** | INV-P7-7 (downgrade refusal) and INV-P7-15 (DEK-existence) MUST apply on every read-back path — snapshot direct entry and routed fence — identically to the pre-existing fence behavior. | Unit |
+| **INV-RB-6** | The snapshot MUST read its IC events via the plugin's in-tx SQL read + the direct decrypt entry; it MUST NOT route through `PluginAuditService.QueryHistory` (no self-loop). | Unit |
+| **INV-RB-7** | The fence's clean-row path MUST return decrypted plaintext to a routed reader authorized by AuthGuard DEK-participant-set membership; a non-member MUST receive a refused/metadata-only row (membership gate unchanged). | Integration |
+| **INV-RB-8** | Snapshot read + decrypt + render MUST complete before the write-tx; the in-tx `SELECT FOR UPDATE` re-validation of COOLOFF + all-yes MUST be the serialization point. A vote-flip between read and write MUST yield a no-op commit. | Integration |
+| **INV-RB-9** | The capability, fence, and audit MUST apply identically to binary and Lua plugins (runtime symmetry). | Unit |
+| **INV-RB-10** | A snapshot decrypt failure MUST transition the attempt to ATTEMPT_FAILED with `failure_reason = SNAPSHOT_DECRYPT_FAILED` (scenes-phase-6 §11.4 preserved). | Integration |
+| **INV-RB-11** | The decrypt primitive and fence completion MUST be subject-agnostic: any plugin-owned `sensitivity:always` subject (scene IC AND core-communication `whisper`/`page`/`pemit`) MUST flow through the identical primitive with no per-plugin special-casing. | Unit + Integration |
+| **INV-RB-12** | `DecryptOwnAuditRows` MUST return a per-row result (plaintext or typed refusal), never all-or-nothing; ordering MUST match the input. The snapshot consumer MUST treat any refusal/error as a publish failure (→ INV-RB-10). | Unit + Integration |
+
+## 9. Testing strategy
+
+**TDD is mandatory** (project CLAUDE.md / `dev-flow:test-driven-development`): every behavior below is written test-first — a failing test before the implementing code. **Target ≥ 80% per-package coverage** (verified with `task test:cover`) for every package this design touches: `internal/eventbus/history`, `internal/eventbus/authguard`, `internal/plugin` (manifest + hostfunc), `internal/access` (policy seed), `plugins/core-scenes` (snapshot consumer). The suite is layered as a pyramid:
+
+### 9.1 Unit — happy path
+
+- Primitive decrypts a well-formed encrypted row → plaintext `RowResult` (INV-RB-1).
+- `AuditRowToEvent` + `aad.Build` reproduces the encrypt-path AAD byte-for-byte (reuse/extend the INV-TS-5 round-trip) (INV-RB-4).
+- `PluginCanReadBack` true for a declared `readback: true` emit type, false otherwise (INV-RB-2 g2).
+- `DecryptOwnAuditRows` returns one `RowResult` per input row, order-preserving (INV-RB-12).
+
+### 9.2 Unit — invariants (≥1 test per INV-RB-*, enforced by the meta-test)
+
+- One named test per invariant ID. **Meta-test:** enumerate `INV-RB-*` and assert each is referenced by ≥1 test (mirrors the master-spec invariant-coverage discipline). Covers the host-side/no-DEK-leak (1), two-gate default-deny (2), INV-19 audit + fail-closed (3), AAD parity (4), fence parity (5), no-self-loop (6), routed membership gate (7), atomicity (8), runtime symmetry (9), snapshot-fail mapping (10), subject-agnostic (11), per-row envelope (12).
+
+### 9.3 Unit — boundaries & negatives
+
+- Empty `[]AuditRow`; single row; batch at the 500-row cap; over-cap rejection; snapshot chunking across a row set larger than the cap.
+- Identity-codec row mixed with encrypted rows in one batch (identity passes through; encrypted decrypts).
+- Gate denials, each isolated: foreign (non-owned) subject → deny at g1; `readback:false`/absent → deny at g2 (INV-RB-2).
+- Downgrade row (identity codec on always-sensitive) → DowngradeRefused; absent/destroyed DEK → DEKMissing (INV-RB-5).
+- Audit emitter nil → fail-closed refusal, no plaintext (INV-RB-3).
+- Loader rejects `readback: true` on a non-emitted type.
+
+### 9.4 Integration — real stack (Docker; closes the fake-bus gap)
+
+- Via `internal/testsupport/integrationtest` (real codec + DEK manager + fence + primitive): **authorized** read-back returns plaintext; **unauthorized** (non-owner / no flag) returns refusal. This is the coverage the current `fakeHistoryReader` suite structurally cannot provide (INV-RB-7).
+- Routed participant read: scene member gets decrypted frames; non-member gets refused/metadata-only (membership gate unchanged) (INV-RB-7).
+- Fence parity on the routed path after the contract change: downgrade + DEK-missing still refuse; existing fence tests migrated from ciphertext-passthrough to plaintext assertions (INV-RB-5).
+- core-communication `whisper`/`page` read-back through the identical primitive (INV-RB-11).
+
+### 9.5 E2E (Ginkgo/Gomega, `//go:build integration`, `task test:int`)
+
+- Full publish lifecycle: encrypted `scene_log` → COOLOFF elapse → snapshot → `published_scenes.content_entries` holds rendered **plaintext**, scene archived, `scene_publish_resolved{PUBLISHED}` emitted (INV-RB-8).
+- Snapshot decrypt failure (e.g. DEK destroyed mid-flight) → ATTEMPT_FAILED + `SNAPSHOT_DECRYPT_FAILED`, no partial publish (INV-RB-10, INV-RB-12).
+- Vote-flip between the read and the write-tx → no-op commit, no publication (INV-RB-8).
+- Participant reconnect-backfill of a scene-IC stream returns decrypted scrollback to a member end-to-end through `WebQueryStreamHistory` (INV-RB-7).
+
+## 10. Revisions to the scenes-phase-6 spec
+
+- **§11.1** — unchanged in intent (direct in-tx read via C6 `ReadSceneLogForSnapshot`), with a forward-reference to the direct decrypt entry defined here.
+- **§11.2** — replace the false premise ("the plugin already holds DEK access for its own events") with: the snapshot passes its rows to the host `DecryptOwnAuditRows` entry; the host decrypts (the plugin holds no DEK). Cross-reference INV-RB-1..5.
+- **§11.4** — `SNAPSHOT_DECRYPT_FAILED` semantics unchanged; now produced by the host primitive returning a decrypt error (INV-RB-10).
+- The C7 bead's "no new crypto surface" constraint is **void** — no read-back decrypt exists anywhere, so new surface (the primitive + capability + grant + RPC) is unavoidable. crypto-reviewer MUST gate it.
+
+## 11. Documentation (PR-blocking)
+
+- `site/docs/extending/` — document the `crypto.emits[].readback` capability and the host-mediated self-decrypt model for plugin authors.
+- `site/docs/contributing/` — note the read-back decrypt primitive and the fence-contract change (clean rows now decrypt) for contributors.
+- Update any plugin manifest schema reference (`schemas/plugin.schema.json` via `go generate`) for the new `readback` field.
+
+## 12. Reviewer focus (crypto-reviewer)
+
+- AAD reconstruction is byte-identical to the encrypt path (INV-RB-4 / INV-E20).
+- The fence-contract change (ciphertext-passthrough → plaintext) does not weaken INV-P7-7 / INV-P7-15 for any plugin-routed read, including core-communication.
+- Subject-scoping (`OwnerMap`) cannot be bypassed by plugin-supplied row fields.
+- The Detect posture ([§7.1](#71-chosen-posture-detect-not-prevent)) is an accepted residual risk, not an oversight.
+
+## 13. Out of scope / follow-ups
+
+- Wiring scene-IC into the participant backfill end-to-end beyond decrypt (focus-substrate completeness) — tracked under `oy6e`.
+- A scene-log review/export consumer — `holomush-cb4x` (will reuse the routed read-back path completed here).
+- **Production ABAC `decrypt`-action plumbing** (§7.5): a `dek` resource type + attribute provider + a plugin-decrypt policy mechanism. Fixes the latent always-deny on live-delivery `checkPlugin` AND lets read-back adopt the ABAC action as a third gate. File as a separate bead; not required for this design's detect posture.
+<!-- adr-capture: sha256=f217d0abaf28b70b; ts=2026-05-25T16:15:06Z; adrs=holomush-g3d4l,holomush-edqh1,holomush-c3kyv,holomush-wfh42 -->


### PR DESCRIPTION
## Summary

Design docs for **host-mediated plugin read-back decryption** — unblocks the C7 scene-publish snapshot (`holomush-5rh.20.26`), which `holomush-m7pxs` blocked (the snapshot's "plugin already holds DEK access" premise was false). **Docs-only**; implementation is tracked as epic `holomush-m7pxs` (10 task beads, materialized).

### Contents
- **Spec** `docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md` — design-reviewer READY (4 rounds; 2-gate model)
- **Plan** `docs/superpowers/plans/2026-05-25-plugin-readback-decrypt.md` — plan-reviewer READY (2 rounds; 10 TDD tasks)
- **4 ADRs** (`docs/adr/`): `g3d4l` host-mediated decrypt (plugins never hold DEKs) · `edqh1` two-gate self-decrypt authz (OwnerMap + manifest `readback`; no ABAC) · `c3kyv` detect-not-prevent posture · `wfh42` fence-contract change (clean rows decrypt for authorized routed readers)

### Design in one line
A reusable host-side decrypt primitive (host holds DEKs; plugin receives only plaintext) consumed by a direct snapshot RPC and the completed `PluginDowngradeFence` routed path. Authorization = host-side OwnerMap subject-ownership + a new `crypto.emits[].readback` manifest flag; the ABAC `decrypt` action is deferred (its production plumbing — a `dek` resource type + permit policy — does not exist and always-denies today).

### Notable
- Grounding caught that the spec's original gate-3 (ABAC decrypt) rested on nonexistent production plumbing → dropped to a 2-gate model (deferred follow-up filed in §7.5).
- The fence-contract change (ciphertext-passthrough → decrypt) also fixes the latent, armed break in participant scene-IC scrollback + comms whisper/page read-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)