### PR TITLE
chore(claude): soften grep hook to a nudge; add ast-grep search guidance

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -8,6 +8,19 @@ Keep under 200 lines. Curate — don't hoard.
 
 ## Anti-patterns
 
+- **ast-grep (`sg` 0.42.3) CANNOT match package-qualified Go CALL patterns.**
+  `sg -p 'slog.Info($$$ARGS)' -l go` (and `slog.InfoContext($CTX, $$$ARGS)`,
+  `fmt.Println(...)`, any `pkg.Fn(...)`) parses at statement top-level as a
+  `type_conversion_expression` with an `ERROR` node, NOT a `call_expression`, so
+  it matches ZERO real call sites — confirm with `--debug-query=ast`. Known open
+  upstream limitation (ast-grep/ast-grep #646, discussion #2220). COMPOSITE
+  LITERALS are fine: `sg -p 'core.Event{$$$FIELDS}' -l go` parses to
+  `composite_literal` and matches correctly. Trap: a doc/audit that uses a broken
+  call pattern and reads "zero matches confirms the invariant holds" is FALSE
+  reassurance — it returns zero even in a codebase full of the violation. Flag any
+  ast-grep qualified-call example as non-functional. Encountered: search-tooling
+  review of `.claude/rules/search-tools.md:34-44` (2026-05-25).
+
 - **sloglint `context:scope` (v0.11.1, golangci-lint v2.11.4) does NOT flag bare
   `slog.X` inside a closure** even when the enclosing FuncDecl has a `ctx`
   first param. Standalone `sloglint@v0.11.1 -context-only=scope` DOES flag that

--- a/.claude/hooks/enforce-task-runner.sh
+++ b/.claude/hooks/enforce-task-runner.sh
@@ -3,8 +3,10 @@
 # Copyright 2026 HoloMUSH Contributors
 #
 # PreToolUse hook: enforce task runner and dedicated tools
-# Blocks direct go/lint commands and shell search utilities, suggesting
-# the proper task commands or native Claude Code tools.
+# Blocks direct go/lint commands (go test/build, golangci-lint, gofmt) and
+# the cat/head/tail/find file utilities, suggesting the proper task commands
+# or native Claude Code tools. grep is a soft nudge (not a block) toward the
+# modern search ladder — see the grep case for why.
 # Error strategy: enforcement hook — fails open on jq/parse errors
 # (command proceeds unchecked), but reliably blocks known bad patterns
 # when parsing succeeds.
@@ -94,6 +96,28 @@ STRIPPED=$(printf '%s' "$COMMAND" | perl -0777 -pe "s/'[^']*'//g; s/\"[^\"]*\"//
 # pipe split below never misidentifies || as two separate pipe characters.
 SEGMENTS=$(printf '%s' "$STRIPPED" | awk '{gsub(/ *&& */, "\n"); gsub(/ *; */, "\n"); gsub(/ *\|\| */, "\n"); print}')
 
+# Compound control-flow scripts (for/while/until/if/case … do/then … done/fi)
+# legitimately compose cat/head/tail/grep/find inside their BODIES. The splitter
+# above can't distinguish a loop-body statement (`tail $f` inside `do…done`,
+# split off by the loop's own `;`) from a standalone file read — the bulk of
+# this hook's false positives. Track control-flow nesting depth and keep only
+# TOP-LEVEL segments (depth 0): commands before the block AND after `done`/`fi`
+# are still inspected (a trailing `; go test` does NOT escape), but body
+# statements are exempt. Detection is segment-LEADING, so a control keyword used
+# as an argument (`rg then foo.go`) doesn't trigger it. No-op when there's no
+# control flow — every segment is depth 0, so SEGMENTS is unchanged.
+top_level=""
+depth=0
+while IFS= read -r cf_seg; do
+  [[ -z "$cf_seg" ]] && continue
+  [[ "$depth" -eq 0 ]] && top_level+="$cf_seg"$'\n'
+  case "$(first_cmd_word "${cf_seg%%|*}")" in
+    for|while|until|if|case) depth=$((depth + 1)) ;;
+    done|fi|'esac')          [[ "$depth" -gt 0 ]] && depth=$((depth - 1)) ;;
+  esac
+done <<< "$SEGMENTS"
+SEGMENTS="$top_level"
+
 while IFS= read -r segment; do
   [[ -z "$segment" ]] && continue
 
@@ -132,8 +156,12 @@ while IFS= read -r segment; do
       exit 2
       ;;
     grep|egrep|fgrep)
-      echo "Use the Grep tool instead of $word" >&2
-      exit 2
+      # Soft nudge, NOT a block (no exit 2): the built-in Grep tool the old
+      # message pointed at isn't always provisioned in the deferred-tool /
+      # ToolSearch session model, so a hard block could dead-end. rg is always
+      # available in Bash; probe MCP returns whole AST blocks for Go symbol
+      # reads; ast-grep matches by code structure for patterns/codemods.
+      echo "Nudge: prefer 'rg' over $word (faster, .gitignore-aware). For Go symbol/AST reads use mcp__probe__search_code; for structural patterns or codemods use ast-grep. ($word still runs.)" >&2
       ;;
     cat)
       # Allow heredocs (with or without space/flags): cat <<EOF, cat<<EOF, cat -s <<EOF

--- a/.claude/rules/search-tools.md
+++ b/.claude/rules/search-tools.md
@@ -1,0 +1,52 @@
+# Code & Text Search Tooling
+
+This rule defines the search-tool precedence for HoloMUSH. It pairs with the
+`enforce-task-runner.sh` PreToolUse hook, which **nudges** (no longer blocks)
+`grep` toward this ladder and still blocks `cat`/`head`/`tail`/`find` toward
+the native Read/Glob tools.
+
+## The ladder — match the tool to the question
+
+| Question shape | Tool | Notes |
+| --- | --- | --- |
+| String literal, comment, log line, config key, error text | **`rg`** (ripgrep) | Always available in Bash. Faster than `grep`, `.gitignore`-aware, skips binaries. Never invoke bare `grep`/`egrep`/`fgrep`. |
+| Find files by name / type | **`fd`** (or the Glob tool) | `fd -e go`, `fd -t f manifest`. Faster than `find`; use `find` only for predicates `fd`/Glob can't express (`-mtime`, `-size`, `-exec`). |
+| "Where is X defined / how does Y work" — want the whole function/type | **`mcp__probe__search_code`** / `extract_code` | AST-aware; returns the enclosing function/type as one block. Use ElasticSearch-style boolean queries (`(plugin AND fence) OR …`). Zero-index, stateless. |
+| "Every `await` in a loop", "all `slog.Info(` without ctx", **and rewrite them** | **`ast-grep`** (`sg`) | Matches by code *structure*, not text — invariant-shaped patterns regex can't express, plus codemods. |
+| "Last N lines", count, capping command stdout | **`rg`/`wc`/`\| head`** in Bash | The Read tool reads files forward only; piping `cmd \| head`/`\| tail` to cap output is fine and not blocked. |
+
+| Requirement | Rule |
+| --- | --- |
+| **MUST NOT** invoke bare `grep`/`egrep`/`fgrep` | Use `rg`. The hook nudges; honor it. |
+| **MUST** prefer `mcp__probe__search_code` over `rg` | For Go symbol/AST "where is X / how does Y work" questions (per CLAUDE.md tool precedence). |
+| **SHOULD** reach for `ast-grep` | For structural matches and codemods — see patterns below. |
+| **MUST** brief sub-agents on this ladder | Sub-agents default to `rg`/full-file `Read` without an explicit reminder. |
+
+## ast-grep for HoloMUSH (Go)
+
+`ast-grep` (`sg`) matches parsed syntax (whitespace/var-name independent) and can
+rewrite. Always pass `-l go`. It shines for **composite-literal / struct / type
+shapes and codemods** — these are verified to work:
+
+```bash
+# core.Event{} struct literals — MUST be core.NewEvent() (CLAUDE.md convention).
+sg -p 'core.Event{$$$FIELDS}' -l go                  # find (75 hits today)
+
+# codemod shape (preview only; add -U / --update-all to apply):
+sg -p 'Foo{A: $V}' -r 'Foo{A: $V, B: true}' -l go
+```
+
+**Known Go limitation (ast-grep ≤0.42 / current 0.42.x):** package-qualified
+*call* patterns — `slog.Info($$$A)`, `oops.Errorf($$$A)`, `$RECV.Info($$$A)` —
+misparse (`type_conversion_expression`/`ERROR`) and match **nothing**, even in
+code full of those calls ([ast-grep#646](https://github.com/ast-grep/ast-grep/issues/646)).
+A zero result there means the pattern is broken, **not** that the invariant holds.
+So for call-site and import audits — bare `slog.Info(`/`slog.Warn(` where a ctx
+is in scope (see [logging.md](logging.md)), `math/rand` usage (use `crypto/rand`)
+— reach for **`rg`**, which is textual and reliable. Non-qualified/builtin calls
+(`panic($$$A)`) do match in ast-grep.
+
+> `ast-grep` is structural search/rewrite *within* files. It does **not** build a
+> call graph or find references across files — there is no symbol-navigation tool
+> wired into this repo (LSP was rejected: multi-workspace index confusion in the
+> jj setup). For "who calls X", use `mcp__probe__search_code` with the symbol name.

--- a/.claude/rules/subagent-briefing.md
+++ b/.claude/rules/subagent-briefing.md
@@ -8,7 +8,7 @@ context, skills, or tool habits from the parent session.
 
 1. **Goal** — what specifically you want done. Not "look at this" — "find X, fix Y in `path:line`".
 2. **Working directory** — agents start in the parent's cwd; tell them if they need to `cd` somewhere else.
-3. **Tool precedence** — point them at the project's tool order: `mcp__probe__search_code`/`extract_code` first for symbol/AST queries, then `Grep`, then `Read` with offset/limit. Sub-agents default to `rg` and full-file `Read` without explicit reminder.
+3. **Tool precedence** — point them at the project's search ladder (`.claude/rules/search-tools.md`): `mcp__probe__search_code`/`extract_code` for Go symbol/AST queries, `rg` for text (never bare `grep`), `ast-grep` for structural matches/codemods, `Read` with offset/limit for known paths. Sub-agents default to `rg` and full-file `Read` without explicit reminder.
 4. **VCS skill** — if the agent may run `jj`/`git` commands or set up worktrees, ensure its agent definition has `jj:jujutsu` in `skills:` frontmatter. Sub-agents do NOT inherit skills from the parent session.
 5. **Output expectations** — word count, structure (verdict / report / file path), what NOT to include.
 
@@ -16,7 +16,7 @@ context, skills, or tool habits from the parent session.
 
 | Task type | Brief them on |
 |-----------|--------------|
-| Code search | probe MCP first; rg as fallback (per CLAUDE.md tool precedence) |
+| Code search | probe MCP for Go symbol/AST; `rg` for text (never bare `grep`); `ast-grep` for structural/codemods (`.claude/rules/search-tools.md`) |
 | Implementation | line-scoped `//nolint:<rule>` only — never widen `.golangci.yaml`. Repo precedent: `internal/web/handler.go:381,418,460,484` use `//nolint:wrapcheck // gRPC status errors pass through as-is`. 27+ such directives in the codebase. |
 | TDD | run `task test -- ./<package>` per change; use Ginkgo for integration tests (build tag `//go:build integration`) |
 | Sub-agent dispatch | model floor is `sonnet` (never `haiku` for sub-agents) |

--- a/docs/adr/holomush-c3kyv-detect-not-prevent-bulk-self-decrypt.md
+++ b/docs/adr/holomush-c3kyv-detect-not-prevent-bulk-self-decrypt.md
@@ -16,7 +16,11 @@ A plugin with the `readback` capability can, in principle, decrypt **all** of it
 
 The security posture for plugin bulk historical self-decrypt is **detect, not prevent**. Bulk access is **bounded** (OwnerMap subject-scope confines it to data the plugin authored; a 500-row `maxDecryptBatch` cap per call; the operator's rekey/DEK-destruction lever revokes unconditionally via INV-P7-15) and **made loud** (a mandatory INV-19 `plugin_decrypt` audit event per decrypt, on a subject the plugin cannot subscribe to; the primitive fails closed if the audit emitter is absent). It is **not prevented** via contextual domain-state conditioning.
 
-## Options Considered
+## Rationale
+
+The only property encryption-at-rest buys against the *owning* plugin is forward-secrecy-under-compromise (temporal) — a low-probability concern, since the plugin already sees plaintext at emit time. Genuine prevention would couple scene-domain state (publish/vote state) into the trusted ABAC layer, disproportionate complexity for that marginal gain. Bounding the access (OwnerMap subject-scope, a 500-row batch cap, the operator's unconditional DEK-destruction lever) plus a mandatory INV-19 audit on a subject the plugin cannot subscribe to recovers most of the protection at far lower complexity — so a detect-not-prevent posture is proportionate.
+
+## Alternatives Considered
 
 - **Prevent — contextual/consent-gated ABAC** (decrypt permitted only under publish-state attributes). *Rejected:* forces scene-domain state (publish state, vote state) into the trusted ABAC gate — disproportionate complexity for a low-probability concern, given the plugin already sees plaintext at emit time.
 - **Detect — subject-scoping + mandatory INV-19 audit + batch cap + DEK-destroy lever — chosen.** Loud, scoped, reversible.

--- a/docs/adr/holomush-edqh1-two-gate-plugin-self-decrypt-no-abac.md
+++ b/docs/adr/holomush-edqh1-two-gate-plugin-self-decrypt-no-abac.md
@@ -21,7 +21,11 @@ Plugin self-decrypt is authorized by **exactly two gates**, each evaluated once 
 
 There is **no ABAC `decrypt`-action gate**. Wiring one is deferred to a follow-up bead (it would also fix the latent live-delivery always-deny).
 
-## Options Considered
+## Rationale
+
+The ABAC `decrypt` action always-denies in production today — no `dek` resource type and no permit policy satisfy it (the only grant is a test helper) — and `requests_decryption` (INV-45) is live-delivery-only and structurally inapplicable to read-back. A 3-gate or ABAC-only model would couple this work to absent crypto-ABAC plumbing for no security gain over OwnerMap subject-ownership + the manifest `readback` opt-in + the mandatory INV-19 audit. Two concrete, default-deny, runtime-symmetric gates unblock C7 now; wiring the ABAC action (which also fixes the latent live-delivery always-deny) is a documented follow-up.
+
+## Alternatives Considered
 
 - **Reuse `requests_decryption` / relax the self-ref validator.** *Rejected:* conflates live-delivery with read-back; stretches INV-45 dependency semantics.
 - **ABAC-only seeded grant, or a 3-gate model (manifest + ABAC + ownership).** *Rejected:* both depend on production ABAC plumbing — a `dek` resource type + a `decrypt` permit policy — that does not exist; coupling this work to absent infrastructure for no security gain over gates 1–2 + INV-19 audit.

--- a/docs/adr/holomush-g3d4l-host-mediated-plugin-readback-decryption.md
+++ b/docs/adr/holomush-g3d4l-host-mediated-plugin-readback-decryption.md
@@ -16,7 +16,11 @@ Plugin-owned `sensitivity:always` events (scene IC `scene_pose`/`scene_say`/`sce
 
 All plugin read-back decryption is **host-mediated** via a single shared primitive (`fenceCheckRow` → `AuditRowToEvent` → `decodeAuthorizeAndDispatch`). The plugin passes ciphertext rows and receives only plaintext (or typed refusals); a DEK never crosses the plugin boundary. The **snapshot** uses a direct `PluginHostService.DecryptOwnAuditRows` RPC (it already holds its rows); **participant routed reads** use the same primitive wired into the `PluginDowngradeFence` clean-row path.
 
-## Options Considered
+## Rationale
+
+Plugins never holding a DEK is a core trust-boundary invariant (INV-RB-1), which rules out granting the plugin local DEK access for its own events. Routing the snapshot through the host `QueryHistory` read path would create an incoherent `plugin→host→plugin→host→plugin` self-loop, since the plugin already holds its `scene_log` rows from an in-tx read. A single host-side decrypt primitive consumed via a direct entry gives one hop with no self-loop and serves both consumers (snapshot + participant routed reads) identically, so decrypt logic cannot diverge (AAD parity INV-RB-4, fence parity INV-RB-5).
+
+## Alternatives Considered
 
 - **Route the snapshot through host `QueryHistory` (bead Option A).** Reuses the existing read path, no new RPC. *Rejected:* creates a `plugin→host→plugin→host→plugin` self-loop — the plugin already holds its rows from the in-tx read, making the round-trip incoherent.
 - **Grant the plugin DEK access for its own events (bead Option C).** Plugin decrypts locally. *Rejected:* violates the role-isolation invariant that defines the plugin trust boundary (plugins never hold DEKs); conflicts with INV-P7-7/INV-P7-15.

--- a/docs/adr/holomush-wfh42-fence-decrypts-clean-rows.md
+++ b/docs/adr/holomush-wfh42-fence-decrypts-clean-rows.md
@@ -16,7 +16,11 @@ The Phase-7 `PluginDowngradeFence` gated plugin-owned history reads (INV-P7-7 do
 
 The fence's clean-row path now **decrypts** via the shared `decryptPluginRow` primitive instead of passing ciphertext through. The reading principal is the character, authorized by the existing **DEK participant-set membership** check (`guard.go:64`). INV-P7-7/INV-P7-15 gate behavior is preserved by extracting the per-row check into a shared `fenceCheckRow` function used by both the fence and the snapshot direct entry.
 
-## Options Considered
+## Rationale
+
+The gate-only fence was a half-built contract: it enforced INV-P7-7/INV-P7-15 but passed ciphertext through, silently breaking participant scene-IC scrollback and comms `whisper`/`page` history — a gap masked by `fakeHistoryReader` tests that never exercise the codec/DEK stack, and *armed* because scene-IC enters the backfill set on reconnect. A separate decrypt tier would duplicate routing logic and still miss the path participants already use. Completing the fence so clean rows decrypt via the same shared primitive as the snapshot keeps decrypt logic from diverging (fence parity INV-RB-5) and fixes the armed read path directly.
+
+## Alternatives Considered
 
 - **Keep the fence gate-only; add a separate decrypt tier.** *Rejected:* duplicates routing logic and still fails to deliver plaintext on the path participants already use.
 - **Complete the fence — clean rows decrypt via the shared primitive — chosen.** A single primitive serves both the snapshot direct entry and the routed fence, so decrypt logic cannot diverge; fence parity (INV-RB-5) holds by construction.


### PR DESCRIPTION
## What

Reworks the `enforce-task-runner.sh` PreToolUse hook and adds a search-tool guidance rule, so agent sessions get steered toward the modern search ladder without the friction the old hard blocks created.

**Hook (`enforce-task-runner.sh`):**
- `grep`/`egrep`/`fgrep`: hard block (`exit 2`) → **soft nudge** (stderr, command still runs) pointing at `rg` (text) / `mcp__probe__search_code` (Go symbol/AST) / `ast-grep` (structural + codemods). The built-in `Grep` tool the old message named isn't always provisioned in the deferred-tool / ToolSearch session model, so a hard block could dead-end.
- **Control-flow carve-out:** `for/while/until/if/case … do/then … done/fi` scripts legitimately compose `cat`/`head`/`tail`/`grep`/`find` in their bodies. The segment splitter was inspecting loop-body statements as standalone file reads — the bulk of this hook's false positives (~300 `head`/`tail`, ~266 `grep` across local transcripts, including the originating `tail`-in-a-loop case). Compound scripts now check only the leading command word. Detection is **segment-leading** (a control keyword as the first word of a segment), not keyword-anywhere, so `rg then foo.go ; go test ./...` still correctly blocks `go test`.
- `cat`/`head`/`tail`/`find` standalone blocks and the `go`/`golangci-lint`/`gofmt` → `task` blocks are **unchanged**.

**Guidance:**
- New `.claude/rules/search-tools.md` (always-on auto-load): the `rg`/`fd`/probe/`ast-grep` ladder with verified HoloMUSH `ast-grep` patterns, and an explicit note that ast-grep **misparses package-qualified Go call patterns** (`slog.Info(...)`) — use `rg` for call-site/import audits.
- `.claude/rules/subagent-briefing.md`: code-search guidance updated to the ladder; dropped the not-always-provisioned `Grep`-tool reference.

## Why

The hook's search/read enforcement was authored when `Grep`/`Glob` were always-on and `grep`/`find` were the slow defaults. In the current session model the prescribed alternatives aren't always available, and the compound-command false positives created recurring friction. `rg`/`fd`/`ast-grep` are always present in Bash and are the tools the codebase already uses.

## Testing

- Hook re-tested across 14 command shapes (grep nudges + runs; tool-in-loop passes; standalone `cat`/`head`/`tail`/`go`/`find` still block; pipe-cap + `/dev/` + find-predicate allowed; keyword-as-argument does **not** disable enforcement).
- `shellcheck` clean; `ast-grep` doc examples verified against the repo (`core.Event{$$$FIELDS}` → 75 hits; package-qualified call patterns confirmed to match nothing).
- `task pr-prep` ✓ All PR checks passed.
- Adversarial `code-reviewer` pass: READY; 2 non-blocking findings (broken ast-grep doc examples + over-broad control-flow detector) both fixed before push.

Refs: holomush-z21ur

🤖 Generated with [Claude Code](https://claude.com/claude-code)