### PR TITLE
test: establish test-tier taxonomy and test-only-construct isolation (holomush-1eps2)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -200,6 +200,27 @@ Keep under 200 lines. Curate — don't hoard.
   usual threat); flag the comment if it overclaims. Encountered: INV-L1 guard
   in `internal/logging/import_guard_test.go` (2026-05-23).
 
+- **Command-style Lua plugins MUST be driven via `DeliverCommand`, not `DeliverEvent`.**
+  `on_command` returns plain string (→ `CommandOK`) or `{status, output, events}`
+  table; `DeliverCommand` (`internal/plugin/lua/host.go:310`) routes through
+  `parseCommandResponse` (host.go:656-695) which parses that shape. `DeliverEvent`
+  feeds the wrapper to `parseEmitEvents` (wrong path) → nil emits. A test driving a
+  command plugin via `DeliverEvent` and asserting `[]EmitEvent` is testing the wrong
+  entry point. SDK status: `CommandOK=0, CommandError=1, CommandFailure=2`
+  (`pkg/plugin/command.go:13-19`). Lua `{status=2}` → fail-closed (e.g. core-help
+  logs the engine error + returns "temporarily unavailable", main.lua:24-28/110-114
+  — genuine fail-closed, not error-swallow). Encountered: holomush-gria3 (2026-05-25).
+
+- **Subscriber emit path is NOT the capability gate; `dispatch` filters on qualified
+  event type.** `internal/plugin/subscriber.go:88-102` dispatch → deliverAsync →
+  the *test's own* mock emitter, never `event_emitter.go::Emit`. So an echo-bot
+  "emit-count==0" failure is a SUBSCRIBE-FILTER mismatch, not capability gating:
+  `dispatch` matches `string(event.Type)` against `sub.eventTypes`, and
+  `corecomm.EventTypeSay == "core-communication:say"` (qualified,
+  `plugins/core-communication/events.go:24`) — subscribing with `Manifest.Events`
+  short-form `"say"` never matches. Don't trust a bead's "gated on capability"
+  hypothesis without tracing the actual path. Encountered: holomush-gria3.
+
 ## Invariants worth remembering
 
 - **Top-level oops Code() is the wire-visible code**: client-side error

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -136,15 +136,26 @@ mockAccess.Grant(subject, "emit", "stream")              // Layer 2 / capability
 
 Other test engines: `AllowAllEngine()`, `DenyAllEngine()`, `NewErrorEngine(err)`, `NewInfraFailureEngine(t, reason, policyID)`.
 
-## EventBus Test Harness
+## Test Tiers
 
-`internal/eventbus/eventbustest.New(t)` provides an in-process embedded NATS server with `MemoryStorage` for unit and bus-integration tests.
+| Tier | Dependencies | Runner | Build tag |
+| --- | --- | --- | --- |
+| unit | none | `task test` | (none) |
+| bus-integration | embedded NATS (`eventbustest`) | `task test:int` | `//go:build integration` |
+| audit-integration | embedded NATS + Postgres testcontainer | `task test:int` | `//go:build integration` |
+| full-stack integration | embedded NATS + Postgres + `CoreServer` (+ optional in-tree plugins) | `task test:int` | `//go:build integration` |
+| **E2E** | full Docker stack driven through a real client (browser) | `task test:e2e` | (Playwright) |
 
-| Aspect | Description |
-| ------ | ----------- |
-| **Intended use** | Unit tests and bus-integration tests (tests that exercise the bus itself) |
-| **Scoping mechanism** | The `test:int` target in `Taskfile.yaml` runs an **explicit package list**, not `./...` — it enumerates only the packages that carry `//go:build integration` test files. There is **no** `//go:build !integration` tag on `eventbustest/embedded.go`. The list exists to *exclude* packages whose **unit** tests import `!integration`-tagged helpers (e.g. `internal/grpc/`) so they don't fail to compile under `-tags=integration` — it does not stop the harness itself from running in integration packages that legitimately use it. (The same `//go:build !integration` trick *is* used on `core.NewMemoryEventStore` in `internal/core/store_memory.go`, which works only because nothing integration-tagged imports it — not the case for the bus harness, which bus-integration tests legitimately import.) |
-| **Current E2E reality** | Embedded NATS is also used today by the full-stack E2E harnesses (`internal/testsupport/holomushtest`, `internal/testsupport/integrationtest`), both `//go:build integration`. Whether full-stack E2E *should* be forbidden from embedded NATS — and how to distinguish bus-integration from E2E in the build system — is an open design question tracked in **holomush-1eps2**. Until that lands, this section describes the harness's actual reach rather than asserting an unenforced rule. |
+"E2E" means the Playwright browser suite — a test that crosses the real user
+boundary. The Ginkgo `test:int` suite is **integration** (it calls Go/gRPC APIs
+in-process), regardless of how much of the stack it stands up. Use "E2E" only
+for the Playwright suite; Go Ginkgo suites are "integration".
+
+`eventbustest` provides the in-process embedded NATS server (`MemoryStorage`)
+used at every non-unit tier. This matches production, which also runs embedded
+NATS (`internal/eventbus/subsystem.go`); external/clustered NATS is unimplemented
+(tracked in holomush-s5ts). Production code MUST NOT import `eventbustest` or
+`internal/core/coretest` — enforced by the depguard rule in `.golangci.yaml`.
 
 ## Plugin Tests (`internal/plugin`)
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
     - unparam
     - gocritic
     - nolintlint
+    - depguard
 
     # Logging correctness — enforce trace-context propagation + structured-log
     # discipline (see CLAUDE.md "Structured Logging" + .claude/rules/logging.md,
@@ -132,6 +133,24 @@ linters:
           - forbidigo
 
   settings:
+    depguard:
+      rules:
+        no-test-only-constructs-in-production:
+          # Apply only to production files: not *_test.go, and not the
+          # test-support packages that legitimately wire harnesses in
+          # non-_test.go files. A rule whose `files` are all negations
+          # applies to every file except those excluded.
+          files:
+            - "!$test"
+            - "!**/internal/testsupport/**"
+            - "!**/internal/cluster/clustertest/**"
+            - "!**/test/testutil/**"
+          deny:
+            - pkg: github.com/holomush/holomush/internal/eventbus/eventbustest
+              desc: "embedded NATS test harness; production code MUST NOT import it (holomush-1eps2)"
+            - pkg: github.com/holomush/holomush/internal/core/coretest
+              desc: "in-memory test event store; production code MUST NOT import it (holomush-1eps2)"
+
     errcheck:
       check-type-assertions: true
       check-blank: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,13 +231,14 @@ Directories checked: `api/`, `cmd/`, `internal/`, `pkg/`, `plugins/`, `scripts/`
 
 Detail in `.claude/rules/testing.md` (auto-loads when editing test files): coverage targets, test naming (ACE), table-driven patterns, assertions, mockery, ginkgo/gomega integration tests, EventBus test harness, ABAC test engines.
 
-| Always-on rule                       | Description                                                                  |
-| ------------------------------------ | ---------------------------------------------------------------------------- |
-| **MUST** write tests before impl     | TDD — see `dev-flow:test-driven-development`                              |
-| **MUST** maintain >80% coverage      | Per-package; verify with `task test:cover`                                   |
-| **MUST** use Ginkgo/Gomega for E2E   | Build tag `//go:build integration`; runs via `task test:int`                 |
-| **MUST** run `task test:int` on refactors | `task test` does NOT compile integration files — refactors of shared types break silently otherwise |
-| **MUST NOT** use `eventbustest` in E2E | Embedded NATS harness is unit/bus-integration only; E2E uses full stack    |
+| Always-on rule                                    | Description                                                                                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **MUST** write tests before impl                  | TDD — see `dev-flow:test-driven-development`                                                                          |
+| **MUST** maintain >80% coverage                   | Per-package; verify with `task test:cover`                                                                               |
+| **MUST** use Ginkgo/Gomega for full-stack integration tests | Build tag `//go:build integration`; runs via `task test:int`                                               |
+| **MUST** run `task test:int` on refactors         | `task test` does NOT compile integration files — refactors of shared types break silently otherwise                      |
+| **MUST NOT** import `eventbustest`/`coretest` in production code | Production code MUST NOT import `eventbustest`/`coretest` (depguard-enforced); embedded NATS is correct at every test tier |
+| Canonical tier taxonomy                           | Lives in `.claude/rules/testing.md`.                                                                                     |
 
 ### Session-store testing (Docker required)
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -153,22 +153,13 @@ tasks:
     desc: Run integration tests (needs Docker for testcontainers)
     cmds:
       - task: plugin:build-all
-      # The explicit package list is load-bearing: `./...` under `-tags=integration`
-      # tries to compile packages like `internal/grpc/` whose unit tests depend on
-      # `core.NewMemoryEventStore` (a file with `//go:build !integration`), causing
-      # compilation failures. The list below enumerates the packages that actually
-      # contain `//go:build integration` test files.
-      #
+      # No package enumeration: the only //go:build !integration helper
+      # (the in-memory event store) was extracted to internal/core/coretest
+      # (holomush-1eps2), so ./... compiles cleanly under -tags=integration.
       # -coverpkg=./... makes integration tests contribute coverage to every
-      # production package they exercise, not just the package that contains
-      # the test. Without this, files like internal/audit/postgres.go reported
-      # 0% despite being fully exercised by test/integration/audit/ and the
-      # store migration tests. See .codecov.yml for Codecov's merge behavior.
+      # production package they exercise (see .codecov.yml).
       - "{{.GO_TOOL}} gotestsum --format pkgname -- -race -tags=integration -count=1 -coverprofile=coverage-int.out -covermode=atomic
-        -coverpkg=./... ./cmd/holomush/ ./internal/access/setup/ ./internal/admin/approval/ ./internal/admin/socket/ ./internal/auth/postgres/
-        ./internal/content/ ./internal/eventbus/audit/ ./internal/eventbus/audit/chain/ ./internal/admin/policy/ ./internal/eventbus/crypto/dek/
-        ./internal/admin/readstream/ ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/plugin/ ./internal/store/
-        ./plugins/core-scenes/ ./test/testutil/ ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/..."
+        -coverpkg=./... {{.CLI_ARGS | default \"./...\"}}"
 
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -167,8 +167,8 @@ tasks:
       - "{{.GO_TOOL}} gotestsum --format pkgname -- -race -tags=integration -count=1 -coverprofile=coverage-int.out -covermode=atomic
         -coverpkg=./... ./cmd/holomush/ ./internal/access/setup/ ./internal/admin/approval/ ./internal/admin/socket/ ./internal/auth/postgres/
         ./internal/content/ ./internal/eventbus/audit/ ./internal/eventbus/audit/chain/ ./internal/admin/policy/ ./internal/eventbus/crypto/dek/
-        ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/store/ ./plugins/core-scenes/ ./test/testutil/
-        ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/..."
+        ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/plugin/ ./internal/store/ ./plugins/core-scenes/
+        ./test/testutil/ ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/..."
 
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -167,8 +167,8 @@ tasks:
       - "{{.GO_TOOL}} gotestsum --format pkgname -- -race -tags=integration -count=1 -coverprofile=coverage-int.out -covermode=atomic
         -coverpkg=./... ./cmd/holomush/ ./internal/access/setup/ ./internal/admin/approval/ ./internal/admin/socket/ ./internal/auth/postgres/
         ./internal/content/ ./internal/eventbus/audit/ ./internal/eventbus/audit/chain/ ./internal/admin/policy/ ./internal/eventbus/crypto/dek/
-        ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/plugin/ ./internal/store/ ./plugins/core-scenes/
-        ./test/testutil/ ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/..."
+        ./internal/admin/readstream/ ./internal/eventbus/crypto/kek/ ./internal/eventbus/history/ ./internal/plugin/ ./internal/store/
+        ./plugins/core-scenes/ ./test/testutil/ ./internal/testsupport/integrationtest/ ./internal/world/postgres/ ./test/integration/..."
 
   test:int:focus:
     desc: Run focused integration tests with Ginkgo focus filter (pass -ginkgo.focus="..." after --)

--- a/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
+++ b/docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md
@@ -1059,7 +1059,7 @@ interface boundary; the migration is the work.
 | Unit | Pure logic | None | < 10ms |
 | Bus integration | EventBus contract | Embedded NATS, MemoryStorage | < 100ms |
 | Audit integration | Host + plugin projections | Embedded NATS + PG testcontainer | < 500ms |
-| E2E | Full server, multi-protocol | Embedded NATS + PG + clients | seconds |
+| Full-stack integration | Full server, multi-protocol | Embedded NATS + PG + clients | seconds |
 
 #### Controllable test seams (no hidden waits)
 

--- a/internal/admin/readstream/cold_reader_integration_test.go
+++ b/internal/admin/readstream/cold_reader_integration_test.go
@@ -68,10 +68,10 @@ func insertEncryptedAuditRow(
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
-			envelope, schema_ver, codec, js_seq,
+			envelope, schema_ver, codec, js_seq, rendering,
 			dek_ref, dek_version
 		) VALUES ($1, $2, 'test.encrypted', $3, 'system', NULL,
-		          $4, 1, 'aes256-gcm', $5,
+		          $4, 1, 'aes256-gcm', $5, '{}',
 		          42, 1)
 	`, id[:], string(subject), pgnanos.From(ts), envelopeBytes, int64(seq))
 	Expect(err).NotTo(HaveOccurred())
@@ -100,9 +100,9 @@ func insertIdentityAuditRow(
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
-			envelope, schema_ver, codec, js_seq
+			envelope, schema_ver, codec, js_seq, rendering
 		) VALUES ($1, $2, 'test.cleartext', $3, 'system', NULL,
-		          $4, 1, 'identity', $5)
+		          $4, 1, 'identity', $5, '{}')
 	`, id[:], string(subject), pgnanos.From(ts), envelopeBytes, int64(seq))
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -248,12 +248,12 @@ var _ = Describe("ColdReader", func() {
 			_, err = pool.Exec(context.Background(), `
 				INSERT INTO events_audit (
 					id, subject, type, timestamp, actor_kind, actor_id,
-					envelope, schema_ver, codec, js_seq,
+					envelope, schema_ver, codec, js_seq, rendering,
 					dek_ref, dek_version
 				) VALUES ($1, $2, 'test.encrypted', $3, 'system', NULL,
-				          $4, 1, 'xchacha20poly1305-v1', $5,
+				          $4, 1, 'xchacha20poly1305-v1', $5, '{}',
 				          42, NULL)
-			`, id[:], string(subject), now, envelopeBytes, int64(9001))
+			`, id[:], string(subject), pgnanos.From(now), envelopeBytes, int64(9001))
 			Expect(err).NotTo(HaveOccurred())
 
 			cr := NewColdReader(pool)

--- a/internal/auth/auth_service_test.go
+++ b/internal/auth/auth_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	"github.com/holomush/holomush/internal/auth/mocks"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/internal/session"
 	sessionmocks "github.com/holomush/holomush/internal/session/mocks"
 	"github.com/holomush/holomush/pkg/errutil"
@@ -307,7 +308,7 @@ func TestWithGameSessionFanoutIgnoresNilGameStore(t *testing.T) {
 	playerRepo := mocks.NewMockPlayerRepository(t)
 	playerSessionRepo := mocks.NewMockPlayerSessionRepository(t)
 	hasher := mocks.NewMockPasswordHasher(t)
-	engine := core.NewEngine(core.NewMemoryEventStore())
+	engine := core.NewEngine(coretest.NewMemoryEventStore())
 
 	// nil gameSessions — fanout must be silently ignored.
 	svc, err := auth.NewAuthService(
@@ -331,7 +332,7 @@ func TestConfigureGameSessionFanoutIgnoresNilArgs(t *testing.T) {
 	svc.ConfigureGameSessionFanout(nil, gameStore)
 
 	// nil gameSessions — no-op.
-	engine := core.NewEngine(core.NewMemoryEventStore())
+	engine := core.NewEngine(coretest.NewMemoryEventStore())
 	svc.ConfigureGameSessionFanout(engine, nil)
 
 	// All three calls must be no-ops: the service should work normally.
@@ -348,7 +349,7 @@ func TestAuthenticatePlayerEmitsSessionEndedForEvictedSessionChildren(t *testing
 	const capN = 2
 
 	// --- set up in-memory event store + engine ---
-	eventStore := core.NewMemoryEventStore()
+	eventStore := coretest.NewMemoryEventStore()
 	engine := core.NewEngine(eventStore)
 
 	// --- set up session mock ---
@@ -433,7 +434,7 @@ func TestAuthenticatePlayerSkipsChildSessionsNotInTrimmedSet(t *testing.T) {
 	ctx := context.Background()
 	const capN = 2
 
-	eventStore := core.NewMemoryEventStore()
+	eventStore := coretest.NewMemoryEventStore()
 	engine := core.NewEngine(eventStore)
 	gameStore := sessionmocks.NewMockStore(t)
 

--- a/internal/command/handlers/shutdown_test.go
+++ b/internal/command/handlers/shutdown_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/holomush/holomush/internal/access/policy/policytest"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 )
 
 // Note: Capability checks are performed by the dispatcher, not the handler.
@@ -43,7 +44,7 @@ func newShutdownExec(t *testing.T, args string, store core.EventAppender) (*comm
 
 func TestShutdownHandlerImmediateShutdown(t *testing.T) {
 	ctx := context.Background()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 	exec, buf := newShutdownExec(t, "", store)
 
 	err := ShutdownHandler(ctx, exec)
@@ -62,7 +63,7 @@ func TestShutdownHandlerImmediateShutdown(t *testing.T) {
 
 func TestShutdownHandlerDelayedShutdown(t *testing.T) {
 	ctx := context.Background()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 	exec, buf := newShutdownExec(t, "60", store)
 
 	err := ShutdownHandler(ctx, exec)
@@ -106,7 +107,7 @@ func TestShutdownHandler_InvalidDelay(t *testing.T) {
 
 func TestShutdownHandlerBroadcastsToSystemStream(t *testing.T) {
 	ctx := context.Background()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 	exec, _ := newShutdownExec(t, "", store)
 
 	err := ShutdownHandler(ctx, exec)

--- a/internal/command/types_test.go
+++ b/internal/command/types_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
 	"github.com/holomush/holomush/pkg/errutil"
@@ -754,7 +755,7 @@ func TestNewCommandEntryPluginNameWithCapabilities(t *testing.T) {
 
 func TestServicesBroadcastSystemMessageCreatesCorrectEvent(t *testing.T) {
 	ctx := context.Background()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 	stream := "test-stream"
 	testMessage := "Server is shutting down"
 

--- a/internal/core/coretest/store_memory.go
+++ b/internal/core/coretest/store_memory.go
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-//go:build !integration
-
-package core
+// Package coretest provides test-only implementations of internal/core
+// interfaces. Production code MUST NOT import this package; the prohibition
+// is enforced by the depguard rule in .golangci.yaml (see holomush-1eps2).
+package coretest
 
 import (
 	"context"
@@ -11,30 +12,30 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/core"
 )
 
 // MemoryEventStore is an in-memory event store for unit testing.
-// It implements EventAppender and provides Replay/ReplayTail/LastEventID
-// as test-inspection helpers. Subscribe and SubscribeSession were removed
-// in F7 (those paths now go through the JetStream bus; tests that need
-// live-subscription behavior use integration tests with NATS).
+// It implements core.EventAppender and provides Replay/ReplayTail/LastEventID
+// as test-inspection helpers.
 type MemoryEventStore struct {
 	mu      sync.RWMutex
-	streams map[string][]Event
+	streams map[string][]core.Event
 }
 
 // NewMemoryEventStore creates a new in-memory event store.
 func NewMemoryEventStore() *MemoryEventStore {
 	return &MemoryEventStore{
-		streams: make(map[string][]Event),
+		streams: make(map[string][]core.Event),
 	}
 }
 
-// Compile-time check: MemoryEventStore satisfies EventAppender.
-var _ EventAppender = (*MemoryEventStore)(nil)
+// Compile-time check: MemoryEventStore satisfies core.EventAppender.
+var _ core.EventAppender = (*MemoryEventStore)(nil)
 
 // Append persists an event to the in-memory store.
-func (s *MemoryEventStore) Append(_ context.Context, event Event) error {
+func (s *MemoryEventStore) Append(_ context.Context, event core.Event) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.streams[event.Stream] = append(s.streams[event.Stream], event)
@@ -43,7 +44,7 @@ func (s *MemoryEventStore) Append(_ context.Context, event Event) error {
 
 // Replay returns events from a stream starting after the given ID.
 // Test-inspection helper; not part of any production interface.
-func (s *MemoryEventStore) Replay(_ context.Context, stream string, afterID ulid.ULID, limit int) ([]Event, error) {
+func (s *MemoryEventStore) Replay(_ context.Context, stream string, afterID ulid.ULID, limit int) ([]core.Event, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -52,7 +53,6 @@ func (s *MemoryEventStore) Replay(_ context.Context, stream string, afterID ulid
 		return nil, nil
 	}
 
-	// Find start index
 	startIdx := 0
 	if afterID.Compare(ulid.ULID{}) != 0 {
 		found := false
@@ -68,10 +68,9 @@ func (s *MemoryEventStore) Replay(_ context.Context, stream string, afterID ulid
 		}
 	}
 
-	// Slice with limit
 	endIdx := min(startIdx+limit, len(events))
 
-	result := make([]Event, endIdx-startIdx)
+	result := make([]core.Event, endIdx-startIdx)
 	copy(result, events[startIdx:endIdx])
 	return result, nil
 }
@@ -84,7 +83,7 @@ func (s *MemoryEventStore) LastEventID(_ context.Context, stream string) (ulid.U
 
 	events := s.streams[stream]
 	if len(events) == 0 {
-		return ulid.ULID{}, ErrStreamEmpty
+		return ulid.ULID{}, core.ErrStreamEmpty
 	}
 	return events[len(events)-1].ID, nil
 }
@@ -96,7 +95,7 @@ const maxReplayTailCount = 501
 // Events with timestamps before notBefore are excluded. If beforeID is non-zero,
 // events with ID >= beforeID are excluded. Count is capped at maxReplayTailCount.
 // Test-inspection helper; not part of any production interface.
-func (s *MemoryEventStore) ReplayTail(_ context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]Event, error) {
+func (s *MemoryEventStore) ReplayTail(_ context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]core.Event, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -112,8 +111,7 @@ func (s *MemoryEventStore) ReplayTail(_ context.Context, stream string, count in
 		return nil, nil
 	}
 
-	// Scan from the end, applying both filters, collecting up to count events.
-	var eligible []Event
+	var eligible []core.Event
 	for i := len(events) - 1; i >= 0 && len(eligible) < count; i-- {
 		e := events[i]
 		if !beforeID.IsZero() && e.ID.Compare(beforeID) >= 0 {
@@ -125,7 +123,6 @@ func (s *MemoryEventStore) ReplayTail(_ context.Context, stream string, count in
 		eligible = append(eligible, e)
 	}
 
-	// Reverse eligible to get ascending order.
 	for i, j := 0, len(eligible)-1; i < j; i, j = i+1, j-1 {
 		eligible[i], eligible[j] = eligible[j], eligible[i]
 	}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -39,7 +39,7 @@ type Engine struct {
 // Panics when store is nil so the misconfiguration surfaces at construction
 // time rather than deferring to the first Handle* call (which would panic on
 // a nil-receiver dereference of e.store). Detects both untyped nil and
-// typed-nil interface values (e.g. (*MemoryEventStore)(nil)) so callers
+// typed-nil interface values (e.g. a typed-nil concrete pointer) so callers
 // truly fail fast at construction.
 func NewEngine(store EventAppender) *Engine {
 	if store == nil || isNilEventAppender(store) {

--- a/internal/core/engine_end_session_ctx_test.go
+++ b/internal/core/engine_end_session_ctx_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,24 +14,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// inMemAppender is a minimal in-memory core.EventAppender for the white-box
+// ctx-decoupling tests below. These tests stay in package core to reach the
+// unexported sessionTerminalCommitTimeout, so they cannot import
+// internal/core/coretest (that would create an import cycle: coretest imports
+// core). Only Append + Replay are needed here.
+type inMemAppender struct {
+	mu      sync.Mutex
+	streams map[string][]Event
+}
+
+func newInMemAppender() *inMemAppender {
+	return &inMemAppender{streams: make(map[string][]Event)}
+}
+
+func (s *inMemAppender) Append(_ context.Context, e Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streams[e.Stream] = append(s.streams[e.Stream], e)
+	return nil
+}
+
+func (s *inMemAppender) Replay(_ context.Context, stream string, _ ulid.ULID, _ int) ([]Event, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Event(nil), s.streams[stream]...), nil
+}
+
 // ctxRecordingStore records the context passed to Append so tests can verify
 // the append ctx is decoupled from the caller's ctx.
 type ctxRecordingStore struct {
-	*MemoryEventStore
+	*inMemAppender
 	appendCtx context.Context //nolint:containedctx // test seam
 }
 
 func (s *ctxRecordingStore) Append(ctx context.Context, event Event) error {
 	s.appendCtx = ctx
-	return s.MemoryEventStore.Append(ctx, event)
+	return s.inMemAppender.Append(ctx, event)
 }
 
 // TestEndSessionDecouplesAppendCtxFromCallerCtx verifies the decoupled-ctx
 // discipline: the context passed to store.Append is NOT the caller's ctx,
 // so caller-ctx cancel does not prevent the audit-critical append.
 func TestEndSessionDecouplesAppendCtxFromCallerCtx(t *testing.T) {
-	inner := NewMemoryEventStore()
-	store := &ctxRecordingStore{MemoryEventStore: inner}
+	inner := newInMemAppender()
+	store := &ctxRecordingStore{inMemAppender: inner}
 	engine := NewEngine(store)
 
 	callerCtx, cancel := context.WithCancel(context.Background())
@@ -67,18 +95,18 @@ func TestEndSessionDecouplesAppendCtxFromCallerCtx(t *testing.T) {
 // performs the append. This simulates a client hangup that races with the
 // quit path: if EndSession used caller ctx for Append, the event would drop.
 type cancellingStore struct {
-	*MemoryEventStore
+	*inMemAppender
 	cancel context.CancelFunc
 }
 
 func (s *cancellingStore) Append(ctx context.Context, event Event) error {
 	// Cancel the caller ctx mid-append. If EndSession mistakenly plumbed
 	// callerCtx into Append, this would cause store-side ctx-aware
-	// implementations to drop the write. MemoryEventStore ignores ctx so
+	// implementations to drop the write. inMemAppender ignores ctx so
 	// we additionally check ctx.Err() of the passed-in ctx to confirm
 	// the decoupling regardless of store behavior.
 	s.cancel()
-	return s.MemoryEventStore.Append(ctx, event)
+	return s.inMemAppender.Append(ctx, event)
 }
 
 // TestEndSessionAppendCtxNotCancelledWhenCallerCtxCancelsMidAppend verifies
@@ -88,8 +116,8 @@ func TestEndSessionAppendCtxNotCancelledWhenCallerCtxCancelsMidAppend(t *testing
 	callerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	inner := NewMemoryEventStore()
-	store := &cancellingStore{MemoryEventStore: inner, cancel: cancel}
+	inner := newInMemAppender()
+	store := &cancellingStore{inMemAppender: inner, cancel: cancel}
 	engine := NewEngine(store)
 
 	charID := NewULID()
@@ -110,7 +138,7 @@ func TestEndSessionAppendCtxNotCancelledWhenCallerCtxCancelsMidAppend(t *testing
 // cause the terminal session_ended event to be skipped — the append uses a
 // fresh background context bounded by sessionTerminalCommitTimeout.
 func TestEndSessionPersistsEventEvenWhenCallerCtxAlreadyCancelled(t *testing.T) {
-	store := NewMemoryEventStore()
+	store := newInMemAppender()
 	engine := NewEngine(store)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/core/engine_end_session_test.go
+++ b/internal/core/engine_end_session_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-package core
+package core_test
 
 import (
 	"context"
@@ -13,19 +13,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
 func TestEndSessionEmitsCorrectEventShapeOnCharacterStream(t *testing.T) {
 	ctx := context.Background()
-	store := NewMemoryEventStore()
-	engine := NewEngine(store)
+	store := coretest.NewMemoryEventStore()
+	engine := core.NewEngine(store)
 
-	charID := NewULID()
-	sessionID := NewULID().String()
-	char := CharacterRef{ID: charID, Name: "Testy", LocationID: NewULID()}
+	charID := core.NewULID()
+	sessionID := core.NewULID().String()
+	char := core.CharacterRef{ID: charID, Name: "Testy", LocationID: core.NewULID()}
 
-	err := engine.EndSession(ctx, char, sessionID, SessionEndedCauseQuit, "Goodbye!")
+	err := engine.EndSession(ctx, char, sessionID, core.SessionEndedCauseQuit, "Goodbye!")
 	require.NoError(t, err)
 
 	stream := "character:" + charID.String()
@@ -35,47 +37,47 @@ func TestEndSessionEmitsCorrectEventShapeOnCharacterStream(t *testing.T) {
 
 	ev := events[0]
 	assert.Equal(t, stream, ev.Stream, "stream must be character:{ID}")
-	assert.Equal(t, EventTypeSessionEnded, ev.Type)
-	assert.Equal(t, ActorCharacter, ev.Actor.Kind, "cause=quit uses ActorCharacter")
+	assert.Equal(t, core.EventTypeSessionEnded, ev.Type)
+	assert.Equal(t, core.ActorCharacter, ev.Actor.Kind, "cause=quit uses ActorCharacter")
 	assert.Equal(t, charID.String(), ev.Actor.ID)
 	assert.NotZero(t, ev.ID, "event MUST have a ULID (monotonic per I-16)")
 
-	var payload SessionEndedPayload
+	var payload core.SessionEndedPayload
 	require.NoError(t, json.Unmarshal(ev.Payload, &payload))
 	assert.Equal(t, sessionID, payload.SessionID)
 	assert.Equal(t, charID.String(), payload.CharacterID)
-	assert.Equal(t, SessionEndedCauseQuit, payload.Cause)
+	assert.Equal(t, core.SessionEndedCauseQuit, payload.Cause)
 	assert.Equal(t, "Goodbye!", payload.Reason)
 }
 
 func TestEndSessionUsesActorSystemForNonQuitCauses(t *testing.T) {
 	ctx := context.Background()
 
-	charID := NewULID()
-	char := CharacterRef{ID: charID, Name: "Testy", LocationID: NewULID()}
+	charID := core.NewULID()
+	char := core.CharacterRef{ID: charID, Name: "Testy", LocationID: core.NewULID()}
 
 	cases := []string{
-		SessionEndedCauseLogout,
-		SessionEndedCauseGuestEnd,
-		SessionEndedCauseKicked,
-		SessionEndedCauseReaped,
-		SessionEndedCauseEvicted,
+		core.SessionEndedCauseLogout,
+		core.SessionEndedCauseGuestEnd,
+		core.SessionEndedCauseKicked,
+		core.SessionEndedCauseReaped,
+		core.SessionEndedCauseEvicted,
 	}
 
 	for _, cause := range cases {
 		t.Run("uses ActorSystem actor when cause is "+cause, func(t *testing.T) {
-			store := NewMemoryEventStore()
-			engine := NewEngine(store)
+			store := coretest.NewMemoryEventStore()
+			engine := core.NewEngine(store)
 
-			err := engine.EndSession(ctx, char, NewULID().String(), cause, "reason")
+			err := engine.EndSession(ctx, char, core.NewULID().String(), cause, "reason")
 			require.NoError(t, err)
 
 			stream := "character:" + charID.String()
 			events, err := store.Replay(ctx, stream, ulid.ULID{}, 10)
 			require.NoError(t, err)
 			require.Len(t, events, 1)
-			assert.Equal(t, ActorSystem, events[0].Actor.Kind)
-			assert.Equal(t, ActorSystemID, events[0].Actor.ID)
+			assert.Equal(t, core.ActorSystem, events[0].Actor.Kind)
+			assert.Equal(t, core.ActorSystemID, events[0].Actor.ID)
 		})
 	}
 }
@@ -85,16 +87,16 @@ type appendFailStore struct {
 	err error
 }
 
-func (s *appendFailStore) Append(_ context.Context, _ Event) error { return s.err }
+func (s *appendFailStore) Append(_ context.Context, _ core.Event) error { return s.err }
 
-var _ EventAppender = (*appendFailStore)(nil)
+var _ core.EventAppender = (*appendFailStore)(nil)
 
 func TestEndSessionReturnsErrorWhenStoreFails(t *testing.T) {
 	store := &appendFailStore{err: errors.New("disk full")}
-	engine := NewEngine(store)
+	engine := core.NewEngine(store)
 
-	char := CharacterRef{ID: NewULID(), Name: "Testy", LocationID: NewULID()}
-	err := engine.EndSession(context.Background(), char, NewULID().String(), SessionEndedCauseQuit, "bye")
+	char := core.CharacterRef{ID: core.NewULID(), Name: "Testy", LocationID: core.NewULID()}
+	err := engine.EndSession(context.Background(), char, core.NewULID().String(), core.SessionEndedCauseQuit, "bye")
 
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "SESSION_ENDED_APPEND_FAILED")

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-package core
+package core_test
 
 import (
 	"context"
@@ -11,16 +11,19 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 )
 
 func TestEngineHandleConnectStoresArriveEventWithCharacterPayload(t *testing.T) {
-	store := NewMemoryEventStore()
-	engine := NewEngine(store)
+	store := coretest.NewMemoryEventStore()
+	engine := core.NewEngine(store)
 
 	ctx := context.Background()
-	charID := NewULID()
-	locationID := NewULID()
-	char := CharacterRef{ID: charID, Name: "Alyssa", LocationID: locationID}
+	charID := core.NewULID()
+	locationID := core.NewULID()
+	char := core.CharacterRef{ID: charID, Name: "Alyssa", LocationID: locationID}
 
 	stream := "location:" + locationID.String()
 
@@ -31,25 +34,25 @@ func TestEngineHandleConnectStoresArriveEventWithCharacterPayload(t *testing.T) 
 	events, err := store.Replay(ctx, stream, ulid.ULID{}, 10)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
-	assert.Equal(t, EventTypeArrive, events[0].Type)
+	assert.Equal(t, core.EventTypeArrive, events[0].Type)
 	assert.Equal(t, stream, events[0].Stream)
-	assert.Equal(t, ActorCharacter, events[0].Actor.Kind)
+	assert.Equal(t, core.ActorCharacter, events[0].Actor.Kind)
 	assert.Equal(t, charID.String(), events[0].Actor.ID)
 
 	// Verify payload
-	var payload ArrivePayload
+	var payload core.ArrivePayload
 	require.NoError(t, json.Unmarshal(events[0].Payload, &payload))
 	assert.Equal(t, "Alyssa", payload.CharacterName)
 }
 
 func TestEngineHandleDisconnectStoresLeaveEventWithReasonPayload(t *testing.T) {
-	store := NewMemoryEventStore()
-	engine := NewEngine(store)
+	store := coretest.NewMemoryEventStore()
+	engine := core.NewEngine(store)
 
 	ctx := context.Background()
-	charID := NewULID()
-	locationID := NewULID()
-	char := CharacterRef{ID: charID, Name: "Alyssa", LocationID: locationID}
+	charID := core.NewULID()
+	locationID := core.NewULID()
+	char := core.CharacterRef{ID: charID, Name: "Alyssa", LocationID: locationID}
 
 	stream := "location:" + locationID.String()
 
@@ -60,38 +63,38 @@ func TestEngineHandleDisconnectStoresLeaveEventWithReasonPayload(t *testing.T) {
 	events, err := store.Replay(ctx, stream, ulid.ULID{}, 10)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
-	assert.Equal(t, EventTypeLeave, events[0].Type)
+	assert.Equal(t, core.EventTypeLeave, events[0].Type)
 	assert.Equal(t, stream, events[0].Stream)
-	assert.Equal(t, ActorCharacter, events[0].Actor.Kind)
+	assert.Equal(t, core.ActorCharacter, events[0].Actor.Kind)
 	assert.Equal(t, charID.String(), events[0].Actor.ID)
 
 	// Verify payload
-	var payload LeavePayload
+	var payload core.LeavePayload
 	require.NoError(t, json.Unmarshal(events[0].Payload, &payload))
 	assert.Equal(t, "Alyssa", payload.CharacterName)
 	assert.Equal(t, "quit", payload.Reason)
 }
 
 func TestNewEngineAcceptsMemoryStore(t *testing.T) {
-	store := NewMemoryEventStore()
-	e := NewEngine(store)
+	store := coretest.NewMemoryEventStore()
+	e := core.NewEngine(store)
 	assert.NotNil(t, e)
 }
 
 func TestNewEnginePanicsOnNilAppender(t *testing.T) {
 	assert.Panics(t, func() {
-		NewEngine(nil)
+		core.NewEngine(nil)
 	}, "NewEngine must reject a nil EventAppender so callers fail fast at construction")
 }
 
 func TestNewEnginePanicsOnTypedNilAppender(t *testing.T) {
-	// A typed-nil (*MemoryEventStore)(nil) is NOT caught by a naive
+	// A typed-nil (*coretest.MemoryEventStore)(nil) is NOT caught by a naive
 	// `== nil` guard because the interface wraps a non-nil type
 	// descriptor. The constructor uses reflection (isNilEventAppender)
 	// to detect this so misconfiguration surfaces at construction time
 	// rather than on first Handle* call.
-	var nilStore *MemoryEventStore
+	var nilStore *coretest.MemoryEventStore
 	assert.Panics(t, func() {
-		_ = NewEngine(nilStore)
+		_ = core.NewEngine(nilStore)
 	}, "typed-nil store must panic at construction, not on first use")
 }

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	authmocks "github.com/holomush/holomush/internal/auth/mocks"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/internal/session"
 	sessionmocks "github.com/holomush/holomush/internal/session/mocks"
 	"github.com/holomush/holomush/internal/testsupport/sessiontest"
@@ -86,7 +87,7 @@ func TestAuthenticatePlayer_Success(t *testing.T) {
 	sessionStore := sessiontest.NewStore(t)
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore:      sessionStore,
 		authService:       authSvc,
@@ -160,7 +161,7 @@ func TestAuthenticatePlayer_ErrorPaths(t *testing.T) {
 			ctx := context.Background()
 
 			server := &CoreServer{
-				engine:       core.NewEngine(core.NewMemoryEventStore()),
+				engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 				sessionStore: sessiontest.NewStore(t),
 			}
 
@@ -215,7 +216,7 @@ func TestSelectCharacter_Success(t *testing.T) {
 	sessiontest.SeedPlayerSession(t, pool, ps)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,
@@ -243,7 +244,7 @@ func TestSelectCharacter_InvalidSession(t *testing.T) {
 		Return(nil, auth.ErrNotFound)
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
@@ -275,7 +276,7 @@ func TestSelectCharacter_InvalidCharacter(t *testing.T) {
 		}, nil)
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
@@ -322,7 +323,7 @@ func TestSelectCharacter_Reattach(t *testing.T) {
 	}))
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,
@@ -365,7 +366,7 @@ func TestSelectCharacter_SameTokenTwice(t *testing.T) {
 	sessiontest.SeedPlayerSession(t, pool, ps)
 	callCount := 0
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,
@@ -418,7 +419,7 @@ func TestSelectCharacter_FreshSession_SetsLocationArrivedAt(t *testing.T) {
 
 	before := time.Now()
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,
@@ -477,7 +478,7 @@ func TestSelectCharacter_Reattach_PreservesLocationArrivedAt(t *testing.T) {
 	}))
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,
@@ -523,7 +524,7 @@ func TestCreatePlayer_Success(t *testing.T) {
 	playerSessionRepo.EXPECT().Create(mock.Anything, mock.AnythingOfType("*auth.PlayerSession")).Return(nil)
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore:      sessiontest.NewStore(t),
 		authService:       authSvc,
@@ -560,7 +561,7 @@ func TestCreatePlayer_ErrorPaths(t *testing.T) {
 			name: "service not configured returns success=false with not configured message",
 			setupServer: func(t *testing.T) *CoreServer {
 				return &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 				}
 			},
@@ -574,7 +575,7 @@ func TestCreatePlayer_ErrorPaths(t *testing.T) {
 					return nil, nil, "", auth.ErrNotFound // simulates username taken via oops
 				}
 				return &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 					authService:  authSvc,
 				}
@@ -590,7 +591,7 @@ func TestCreatePlayer_ErrorPaths(t *testing.T) {
 					return nil, nil, "", errors.New("pq: relation \"players_private_v3\" does not exist")
 				}
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					authService:       authSvc,
 					playerSessionRepo: authmocks.NewMockPlayerSessionRepository(t),
@@ -609,7 +610,7 @@ func TestCreatePlayer_ErrorPaths(t *testing.T) {
 						"operation", "check username availability")
 				}
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					authService:       authSvc,
 					playerSessionRepo: authmocks.NewMockPlayerSessionRepository(t),
@@ -666,7 +667,7 @@ func TestCreateCharacter_Success(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 		characterService:  charSvc,
@@ -705,7 +706,7 @@ func TestCreateCharacter_ErrorPaths(t *testing.T) {
 				sessionRepo.EXPECT().GetByTokenHash(mock.Anything, tokenHash).
 					Return(nil, auth.ErrNotFound)
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					playerSessionRepo: sessionRepo,
 					characterService:  newMockCharacterService(t),
 				}
@@ -718,7 +719,7 @@ func TestCreateCharacter_ErrorPaths(t *testing.T) {
 			setupServer: func(_ *testing.T) *CoreServer {
 				// playerSessionRepo is nil — resolvePlayerSession returns error
 				return &CoreServer{
-					engine: core.NewEngine(core.NewMemoryEventStore()),
+					engine: core.NewEngine(coretest.NewMemoryEventStore()),
 				}
 			},
 			wantMsgContains: "invalid or expired",
@@ -737,7 +738,7 @@ func TestCreateCharacter_ErrorPaths(t *testing.T) {
 						"shard", "char_shard_3")
 				}
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 					characterService:  charSvc,
@@ -791,7 +792,7 @@ func TestListCharacters_ErrorPaths(t *testing.T) {
 				sessionRepo.EXPECT().GetByTokenHash(mock.Anything, auth.HashSessionToken("bad-token")).
 					Return(nil, auth.ErrNotFound)
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					playerSessionRepo: sessionRepo,
 				}
 			},
@@ -802,7 +803,7 @@ func TestListCharacters_ErrorPaths(t *testing.T) {
 			setupServer: func(t *testing.T) *CoreServer {
 				t.Helper()
 				return &CoreServer{
-					engine: core.NewEngine(core.NewMemoryEventStore()),
+					engine: core.NewEngine(coretest.NewMemoryEventStore()),
 					// playerSessionRepo is nil
 				}
 			},
@@ -837,7 +838,7 @@ func TestListCharacters_Success(t *testing.T) {
 		}, nil)
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
@@ -904,7 +905,7 @@ func TestListCharacters_LocationDerivation(t *testing.T) {
 				}, nil)
 
 			server := &CoreServer{
-				engine:            core.NewEngine(core.NewMemoryEventStore()),
+				engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 				sessionStore:      sessiontest.NewStore(t),
 				playerSessionRepo: sessionRepo,
 				charRepo:          charRepo,
@@ -937,7 +938,7 @@ func TestRequestPasswordReset_AlwaysSuccess(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore: sessiontest.NewStore(t),
 		resetService: resetSvc,
@@ -955,7 +956,7 @@ func TestRequestPasswordReset_NotConfigured(t *testing.T) {
 	ctx := context.Background()
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore: sessiontest.NewStore(t),
 	}
@@ -982,7 +983,7 @@ func TestConfirmPasswordReset_Success(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore: sessiontest.NewStore(t),
 		resetService: resetSvc,
@@ -1035,7 +1036,7 @@ func TestConfirmPasswordReset_InvalidTokenPaths(t *testing.T) {
 			resetSvc.resetPasswordFunc = tt.resetPasswordFunc
 
 			server := &CoreServer{
-				engine:       core.NewEngine(core.NewMemoryEventStore()),
+				engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 				sessionStore: sessiontest.NewStore(t),
 				resetService: resetSvc,
 			}
@@ -1091,7 +1092,7 @@ func TestLogoutEmitsSessionEndedForEachChildGameSession(t *testing.T) {
 	sess2ID := core.NewULID()
 	locID := ulid.Make()
 
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 	sessStore, pool := sessiontest.NewStoreWithPool(t)
 	sessiontest.SeedPlayerSession(t, pool, ps)
 	require.NoError(t, sessStore.Set(ctx, sess1ID.String(), &session.Info{
@@ -1198,7 +1199,7 @@ func TestLogout_Success(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine: core.NewEngine(core.NewMemoryEventStore()),
+		engine: core.NewEngine(coretest.NewMemoryEventStore()),
 
 		sessionStore: sessiontest.NewStore(t),
 		authService:  authSvc,
@@ -1231,7 +1232,7 @@ func TestLogout_ErrorPaths(t *testing.T) {
 					return ulid.ULID{}, auth.ErrNotFound
 				}
 				return &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 					authService:  authSvc,
 				}
@@ -1243,7 +1244,7 @@ func TestLogout_ErrorPaths(t *testing.T) {
 			setupServer: func(t *testing.T) *CoreServer {
 				t.Helper()
 				return &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 				}
 			},
@@ -1264,7 +1265,7 @@ func TestLogout_ErrorPaths(t *testing.T) {
 
 func TestResolvePlayerSession_RepoNotConfigured(t *testing.T) {
 	server := &CoreServer{
-		engine:       core.NewEngine(core.NewMemoryEventStore()),
+		engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore: sessiontest.NewStore(t),
 		// playerSessionRepo is nil
 	}
@@ -1282,7 +1283,7 @@ func TestResolvePlayerSession_TokenNotFound(t *testing.T) {
 		Return(nil, auth.ErrNotFound)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -1303,7 +1304,7 @@ func TestResolvePlayerSession_RefreshTTLError_StillReturnsSession(t *testing.T) 
 		Return(errors.New("redis timeout"))
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -1334,7 +1335,7 @@ func TestCheckPlayerSession(t *testing.T) {
 				playerRepo.EXPECT().GetByID(mock.Anything, playerID).
 					Return(&auth.Player{ID: playerID, Username: "alice"}, nil)
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 					playerRepo:        playerRepo,
@@ -1351,7 +1352,7 @@ func TestCheckPlayerSession(t *testing.T) {
 				sessionRepo.EXPECT().GetByTokenHash(mock.Anything, tokenHash).
 					Return(nil, auth.ErrNotFound)
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -1363,7 +1364,7 @@ func TestCheckPlayerSession(t *testing.T) {
 			name: "session repo not configured",
 			setup: func(t *testing.T) (*CoreServer, *corev1.CheckPlayerSessionRequest) {
 				server := &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 				}
 				return server, &corev1.CheckPlayerSessionRequest{PlayerSessionToken: validToken}
@@ -1378,7 +1379,7 @@ func TestCheckPlayerSession(t *testing.T) {
 				ps := makePlayerSession(playerID)
 				sessionRepo := setupSessionRepo(t, ps)
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -1424,7 +1425,7 @@ func TestCheckPlayerSessionPopulatesPlayerIDIsGuestAndCharactersOnSuccess(t *tes
 		Return([]*world.Character{{ID: charID, PlayerID: playerID, Name: "Jasper Iodine"}}, nil)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 		playerRepo:        playerRepo,
@@ -1470,7 +1471,7 @@ func TestCheckPlayerSession_ErrorTranslation(t *testing.T) {
 				sessionRepo.EXPECT().GetByTokenHash(mock.Anything, tokenHash).
 					Return(nil, samberOops.Code("PLAYER_SESSION_NOT_FOUND").Errorf("unknown token"))
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -1482,7 +1483,7 @@ func TestCheckPlayerSession_ErrorTranslation(t *testing.T) {
 			setupServer: func(t *testing.T) *CoreServer {
 				// playerSessionRepo unset → resolvePlayerSession returns NOT_CONFIGURED.
 				return &CoreServer{
-					engine:       core.NewEngine(core.NewMemoryEventStore()),
+					engine:       core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore: sessiontest.NewStore(t),
 				}
 			},
@@ -1499,7 +1500,7 @@ func TestCheckPlayerSession_ErrorTranslation(t *testing.T) {
 				playerRepo.EXPECT().GetByID(mock.Anything, playerID).
 					Return(nil, errors.New("connection refused"))
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 					playerRepo:        playerRepo,
@@ -1520,7 +1521,7 @@ func TestCheckPlayerSession_ErrorTranslation(t *testing.T) {
 				charRepo.EXPECT().ListByPlayer(mock.Anything, playerID).
 					Return(nil, errors.New("char repo down"))
 				return &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 					playerRepo:        playerRepo,
@@ -1758,7 +1759,7 @@ func TestListPlayerSessionsReturnsCallersOwnSessionsWithIsCurrentFlag(t *testing
 		Return([]*auth.PlayerSession{ps1, ps2}, nil)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -1829,7 +1830,7 @@ func TestListPlayerSessions_ReturnsEmptyPaths(t *testing.T) {
 			sessionRepo := tt.setupRepo(t)
 
 			server := &CoreServer{
-				engine:            core.NewEngine(core.NewMemoryEventStore()),
+				engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 				sessionStore:      sessiontest.NewStore(t),
 				playerSessionRepo: sessionRepo,
 			}
@@ -1875,7 +1876,7 @@ func TestRevokePlayerSessionRevokesOwnOtherSession(t *testing.T) {
 	sessionRepo.EXPECT().Delete(mock.Anything, targetPS.ID).Return(nil)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -1927,7 +1928,7 @@ func TestRevokePlayerSession_RejectsPaths(t *testing.T) {
 				// Delete MUST NOT be called for a foreign session - the mock would fail the test
 				// if an unexpected call were made.
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -1945,7 +1946,7 @@ func TestRevokePlayerSession_RejectsPaths(t *testing.T) {
 				sessionRepo.EXPECT().GetByTokenHash(mock.Anything, auth.HashSessionToken("invalid")).
 					Return(nil, auth.ErrNotFound)
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -1973,7 +1974,7 @@ func TestRevokePlayerSession_RejectsPaths(t *testing.T) {
 				sessionRepo.EXPECT().RefreshTTL(mock.Anything, callerPS.ID, auth.PlayerSessionTTL).Return(nil)
 				// No GetByID expectation — "not-a-ulid" fails parse first.
 				server := &CoreServer{
-					engine:            core.NewEngine(core.NewMemoryEventStore()),
+					engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 					sessionStore:      sessiontest.NewStore(t),
 					playerSessionRepo: sessionRepo,
 				}
@@ -2039,7 +2040,7 @@ func TestRevokeOtherPlayerSessionsKeepsCallerDeletesRest(t *testing.T) {
 	sessionRepo.EXPECT().Delete(mock.Anything, other2.ID).Return(nil)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -2060,7 +2061,7 @@ func TestRevokeOtherPlayerSessionsRejectsInvalidToken(t *testing.T) {
 		Return(nil, auth.ErrNotFound)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -2092,7 +2093,7 @@ func TestRevokeOtherPlayerSessionsSucceedsWithNoOtherSessions(t *testing.T) {
 		Return([]*auth.PlayerSession{callerPS}, nil)
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
 		playerSessionRepo: sessionRepo,
 	}
@@ -2134,7 +2135,7 @@ func TestSessionManagementRPCsRefreshCallerTTL(t *testing.T) {
 		repo.EXPECT().ListByPlayer(mock.Anything, playerID).Return([]*auth.PlayerSession{caller}, nil)
 
 		server := &CoreServer{
-			engine: core.NewEngine(core.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
+			engine: core.NewEngine(coretest.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
 			playerSessionRepo: repo,
 		}
 		_, err := server.ListPlayerSessions(ctx, &corev1.ListPlayerSessionsRequest{PlayerSessionToken: validToken})
@@ -2151,7 +2152,7 @@ func TestSessionManagementRPCsRefreshCallerTTL(t *testing.T) {
 		repo.EXPECT().Delete(mock.Anything, target.ID).Return(nil)
 
 		server := &CoreServer{
-			engine: core.NewEngine(core.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
+			engine: core.NewEngine(coretest.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
 			playerSessionRepo: repo,
 		}
 		_, err := server.RevokePlayerSession(ctx, &corev1.RevokePlayerSessionRequest{
@@ -2168,7 +2169,7 @@ func TestSessionManagementRPCsRefreshCallerTTL(t *testing.T) {
 		repo.EXPECT().ListByPlayer(mock.Anything, playerID).Return([]*auth.PlayerSession{caller}, nil)
 
 		server := &CoreServer{
-			engine: core.NewEngine(core.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
+			engine: core.NewEngine(coretest.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
 			playerSessionRepo: repo,
 		}
 		_, err := server.RevokeOtherPlayerSessions(ctx, &corev1.RevokeOtherPlayerSessionsRequest{PlayerSessionToken: validToken})
@@ -2184,7 +2185,7 @@ func TestSessionManagementRPCsRefreshCallerTTL(t *testing.T) {
 		repo.EXPECT().ListByPlayer(mock.Anything, playerID).Return([]*auth.PlayerSession{caller}, nil)
 
 		server := &CoreServer{
-			engine: core.NewEngine(core.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
+			engine: core.NewEngine(coretest.NewMemoryEventStore()), sessionStore: sessiontest.NewStore(t),
 			playerSessionRepo: repo,
 		}
 		resp, err := server.ListPlayerSessions(ctx, &corev1.ListPlayerSessionsRequest{PlayerSessionToken: validToken})
@@ -2228,9 +2229,9 @@ func TestLogoutProceedsWithoutFanoutWhenGetByTokenHashFails(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessiontest.NewStore(t),
-		eventStore:        core.NewMemoryEventStore(),
+		eventStore:        coretest.NewMemoryEventStore(),
 		authService:       authSvc,
 		playerSessionRepo: sessionRepo,
 	}
@@ -2276,9 +2277,9 @@ func TestLogoutProceedsWithoutFanoutWhenListByPlayerSessionFails(t *testing.T) {
 	}
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      mockSessStore,
-		eventStore:        core.NewMemoryEventStore(),
+		eventStore:        coretest.NewMemoryEventStore(),
 		authService:       authSvc,
 		playerSessionRepo: sessionRepo,
 	}
@@ -2435,7 +2436,7 @@ func TestGuestSessionCarriesCharacterCreatedAt(t *testing.T) {
 	sessionID := core.NewULID()
 
 	server := &CoreServer{
-		engine:            core.NewEngine(core.NewMemoryEventStore()),
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
 		sessionStore:      sessionStore,
 		playerSessionRepo: sessionRepo,
 		charRepo:          charRepo,

--- a/internal/grpc/dispatcher_test.go
+++ b/internal/grpc/dispatcher_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/testsupport/sessiontest"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
@@ -257,7 +258,7 @@ func TestDispatcher_HandleCommand_UnknownCommand(t *testing.T) {
 	charID := core.NewULID()
 	sessionID := core.NewULID()
 	locationID := core.NewULID()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 
 	server := newDispatcherTestServer(t, store)
 
@@ -293,7 +294,7 @@ func TestDispatcher_HandleCommand_Quit(t *testing.T) {
 	charID := core.NewULID()
 	sessionID := core.NewULID()
 	locationID := core.NewULID()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 
 	var hookCalled bool
 	server := newDispatcherTestServer(
@@ -355,7 +356,7 @@ func TestQuitPathAppendsSessionEndedOnCharacterStream(t *testing.T) {
 	charID := core.NewULID()
 	sessionID := core.NewULID()
 	locationID := core.NewULID()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 
 	server := newDispatcherTestServer(t, store)
 
@@ -414,7 +415,7 @@ func TestGuestDisconnectEmitsSessionEndedOnCharacterStream(t *testing.T) {
 	charID := core.NewULID()
 	sessionID := core.NewULID()
 	locationID := core.NewULID()
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 
 	server := newDispatcherTestServer(t, store)
 
@@ -476,7 +477,7 @@ func TestAdminBootEmitsSessionEndedWithKickedCause(t *testing.T) {
 	targetSessionID := core.NewULID()
 	targetLocationID := core.NewULID()
 
-	store := core.NewMemoryEventStore()
+	store := coretest.NewMemoryEventStore()
 
 	// Build a server with a "testboot" command that records the target
 	// session as booted. Server teardown logic then emits the session_ended

--- a/internal/grpc/pipeline_rendering_test.go
+++ b/internal/grpc/pipeline_rendering_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/core/coretest"
 	"github.com/holomush/holomush/internal/session"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 	corecomm "github.com/holomush/holomush/plugins/core-communication"
@@ -32,7 +33,7 @@ func TestPipelineRendering(t *testing.T) {
 		sessionID := core.NewULID()
 		locationID := core.NewULID()
 
-		store := core.NewMemoryEventStore()
+		store := coretest.NewMemoryEventStore()
 		server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
 			sessionID.String(): {
 				CharacterID:   charID,
@@ -81,7 +82,7 @@ func TestPipelineRendering(t *testing.T) {
 		sessionID := core.NewULID()
 		locationID := core.NewULID()
 
-		store := core.NewMemoryEventStore()
+		store := coretest.NewMemoryEventStore()
 		server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
 			sessionID.String(): {
 				CharacterID:   charID,
@@ -127,7 +128,7 @@ func TestPipelineRendering(t *testing.T) {
 		sessionID := core.NewULID()
 		locationID := core.NewULID()
 
-		store := core.NewMemoryEventStore()
+		store := coretest.NewMemoryEventStore()
 		server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
 			sessionID.String(): {
 				CharacterID:   charID,
@@ -175,7 +176,7 @@ func TestPipelineRendering(t *testing.T) {
 		sessionID := core.NewULID()
 		locationID := core.NewULID()
 
-		store := core.NewMemoryEventStore()
+		store := coretest.NewMemoryEventStore()
 		server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
 			sessionID.String(): {
 				CharacterID:   charID,
@@ -222,7 +223,7 @@ func TestPipelineRendering(t *testing.T) {
 		sessionID := core.NewULID()
 		locationID := core.NewULID()
 
-		store := core.NewMemoryEventStore()
+		store := coretest.NewMemoryEventStore()
 		server := newHandleCommandServer(t, store, newTestSessionStore(t, map[string]*session.Info{
 			sessionID.String(): {
 				CharacterID:   charID,

--- a/internal/plugin/communication_integration_test.go
+++ b/internal/plugin/communication_integration_test.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"slices"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
@@ -108,15 +106,22 @@ var _ = Describe("Communication Plugin Integration", func() {
 			Expect(fixture.Plugin.Manifest.Version).To(Equal("1.0.0"))
 		})
 
-		It("subscribes to command events", func() {
-			Expect(slices.Contains(fixture.Plugin.Manifest.Events, "command")).To(BeTrue())
+		It("handles commands via on_command (no event subscriptions)", func() {
+			// core-communication uses on_command for dispatch; it does not
+			// subscribe to any event stream (events: field is absent in manifest).
+			Expect(fixture.Plugin.Manifest.Events).To(BeEmpty())
 		})
 
-		It("declares no top-level policies by default", func() {
-			Expect(fixture.Plugin.Manifest.Policies).To(BeEmpty())
+		It("declares execute-communication and execute-pemit policies", func() {
+			// The manifest ships two ABAC policies.
+			policyNames := make([]string, len(fixture.Plugin.Manifest.Policies))
+			for i, p := range fixture.Plugin.Manifest.Policies {
+				policyNames[i] = p.Name
+			}
+			Expect(policyNames).To(ContainElements("execute-communication", "execute-pemit"))
 		})
 
-		It("declares say command with comms.say capability", func() {
+		It("declares say command with emit capability", func() {
 			var sayCmd *plugins.CommandSpec
 			for i := range fixture.Plugin.Manifest.Commands {
 				if fixture.Plugin.Manifest.Commands[i].Name == "say" {
@@ -126,11 +131,12 @@ var _ = Describe("Communication Plugin Integration", func() {
 			}
 			Expect(sayCmd).NotTo(BeNil())
 			Expect(sayCmd.Capabilities).To(ContainElement(command.Capability{Action: "emit", Resource: "stream", Scope: command.ScopeLocal}))
-			Expect(sayCmd.Help).To(Equal("Send a message to the room"))
+			// Help text matches plugin.yaml as of current manifest.
+			Expect(sayCmd.Help).To(Equal("Say something to the location"))
 			Expect(sayCmd.Usage).To(Equal("say <message>"))
 		})
 
-		It("declares pose command with comms.pose capability", func() {
+		It("declares pose command with emit capability", func() {
 			var poseCmd *plugins.CommandSpec
 			for i := range fixture.Plugin.Manifest.Commands {
 				if fixture.Plugin.Manifest.Commands[i].Name == "pose" {
@@ -140,10 +146,11 @@ var _ = Describe("Communication Plugin Integration", func() {
 			}
 			Expect(poseCmd).NotTo(BeNil())
 			Expect(poseCmd.Capabilities).To(ContainElement(command.Capability{Action: "emit", Resource: "stream", Scope: command.ScopeLocal}))
-			Expect(poseCmd.Help).To(Equal("Perform an action in the room"))
+			// Help text matches plugin.yaml as of current manifest.
+			Expect(poseCmd.Help).To(Equal("Perform an action"))
 		})
 
-		It("declares emit command with comms.emit capability", func() {
+		It("declares emit command with emit capability", func() {
 			var emitCmd *plugins.CommandSpec
 			for i := range fixture.Plugin.Manifest.Commands {
 				if fixture.Plugin.Manifest.Commands[i].Name == "emit" {
@@ -153,284 +160,244 @@ var _ = Describe("Communication Plugin Integration", func() {
 			}
 			Expect(emitCmd).NotTo(BeNil())
 			Expect(emitCmd.Capabilities).To(ContainElement(command.Capability{Action: "emit", Resource: "stream", Scope: command.ScopeLocal}))
-			Expect(emitCmd.Help).To(Equal("Emit raw text to the room (privileged)"))
+			// Help text matches plugin.yaml as of current manifest.
+			Expect(emitCmd.Help).To(Equal("Emit a message to the location"))
 		})
 	})
 
-	Describe("Say Command Event Handling", func() {
-		Context("when receiving say command event", func() {
-			It("emits say event to location stream with double quotes by default", func() {
-				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01ABC",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"say","args":"Hello everyone!","character_name":"Alice","location_id":"loc456"}`,
-				}
+	// All command tests use DeliverCommand, which correctly parses the
+	// {status, output, events} wrapper table that on_command returns.
+	// DeliverEvent+callOnCommand feeds the wrapper directly to parseEmitEvents
+	// (wrong path); DeliverCommand goes through parseCommandResponse (correct path).
 
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+	Describe("Say Command Handling", func() {
+		Context("when say command is invoked with a message", func() {
+			It("emits say event to location stream", func() {
+				ctx := context.Background()
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "say",
+					Args:          "Hello everyone!",
+					CharacterName: "Alice",
+					LocationID:    "loc456",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("location:loc456"))
-				Expect(emits[0].Type).To(Equal(pluginsdk.EventType(corecomm.EventTypeSay)))
-				Expect(emits[0].Payload).To(ContainSubstring(`Alice says, \"Hello everyone!\"`))
-				Expect(emits[0].Payload).To(ContainSubstring(`"speaker":"Alice"`))
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				Expect(resp.Events[0].Stream).To(Equal("location:loc456"))
+				Expect(resp.Events[0].Type).To(Equal(pluginsdk.EventType(corecomm.EventTypeSay)))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"character_name":"Alice"`))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`Hello everyone!`))
 			})
 		})
 
 		Context("when say command has empty message", func() {
-			It("returns error message to character", func() {
+			It("returns error status with prompt", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01DEF",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"say","args":"","character_name":"Alice","location_id":"loc456","character_id":"char123"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "say",
+					Args:          "",
+					CharacterName: "Alice",
+					LocationID:    "loc456",
+					CharacterID:   "char123",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("character:char123"))
-				Expect(string(emits[0].Type)).To(Equal("error"))
-				Expect(emits[0].Payload).To(ContainSubstring("What do you want to say?"))
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+				Expect(resp.Output).To(ContainSubstring("What do you want to say?"))
 			})
 		})
 	})
 
-	Describe("Pose Command Event Handling", func() {
-		Context("when receiving pose command event", func() {
-			It("emits pose event with character name and space prepended", func() {
+	Describe("Pose Command Handling", func() {
+		Context("when pose command is invoked with an action", func() {
+			It("emits pose event with structured payload", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":"waves hello.","character_name":"Bob","location_id":"loc456"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          "waves hello.",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("location:loc456"))
-				Expect(emits[0].Type).To(Equal(pluginsdk.EventType(corecomm.EventTypePose)))
-				Expect(emits[0].Payload).To(ContainSubstring(`Bob waves hello.`))
-				Expect(emits[0].Payload).To(ContainSubstring(`"actor":"Bob"`))
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				Expect(resp.Events[0].Stream).To(Equal("location:loc456"))
+				Expect(resp.Events[0].Type).To(Equal(pluginsdk.EventType(corecomm.EventTypePose)))
+				// Payload is structured JSON: {character_name, action}; rendering happens at display layer
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"character_name":"Bob"`))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"action":"waves hello."`))
 			})
 		})
 
-		Context("when pose command uses : variant", func() {
-			It("includes space before action (same as regular pose)", func() {
+		Context("when pose command uses : variant in args", func() {
+			It("strips : prefix and emits action without no_space flag", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI1",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":":smiles warmly.","character_name":"Bob","location_id":"loc456"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          ":smiles warmly.",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				// : variant should still include space (same as regular pose)
-				Expect(emits[0].Payload).To(ContainSubstring(`Bob smiles warmly.`))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				// : prefix stripped; action is "smiles warmly." with no no_space flag
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"action":"smiles warmly."`))
+				Expect(resp.Events[0].Payload).NotTo(ContainSubstring(`"no_space"`))
 			})
 		})
 
-		Context("when pose command uses ; variant (no-space/possessive)", func() {
-			It("omits space before action for possessives", func() {
+		Context("when pose command uses ; variant in args (no-space/possessive)", func() {
+			It("strips ; prefix and sets no_space flag in payload", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI2A",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":";'s eyes widen.","character_name":"Bob","location_id":"loc456"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          ";'s eyes widen.",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				// ; variant should NOT include space (for possessives like 's)
-				Expect(emits[0].Payload).To(ContainSubstring(`Bob's eyes widen.`))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				// ; prefix stripped; action includes the possessive and no_space=true is set
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"action":"'s eyes widen."`))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"no_space":true`))
 			})
 		})
 
 		Context("when pose uses invoked_as field from prefix alias", func() {
-			It("uses invoked_as=; for no-space variant", func() {
+			It("uses invoked_as=; for no-space variant (sets no_space flag)", func() {
 				ctx := context.Background()
-				// Tests primary path: prefix alias sets invoked_as, args has no prefix marker
-				event := pluginsdk.Event{
-					ID:        "01GHI3",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":"'s sword gleams.","character_name":"Conan","location_id":"loc456","invoked_as":";"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          "'s sword gleams.",
+					CharacterName: "Conan",
+					LocationID:    "loc456",
+					InvokedAs:     ";",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				// ; prefix alias means no space between name and action
-				Expect(emits[0].Payload).To(ContainSubstring(`Conan's sword gleams.`))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				// invoked_as=; sets no_space=true in payload
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"action":"'s sword gleams."`))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"no_space":true`))
 			})
 
-			It("uses invoked_as=: for space variant", func() {
+			It("uses invoked_as=: for space variant (no no_space flag)", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI4",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":"draws their blade.","character_name":"Conan","location_id":"loc456","invoked_as":":"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          "draws their blade.",
+					CharacterName: "Conan",
+					LocationID:    "loc456",
+					InvokedAs:     ":",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				// : prefix alias means space between name and action
-				Expect(emits[0].Payload).To(ContainSubstring(`Conan draws their blade.`))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				// invoked_as=: does not set no_space flag
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`"action":"draws their blade."`))
+				Expect(resp.Events[0].Payload).NotTo(ContainSubstring(`"no_space"`))
 			})
 		})
 
 		Context("when pose command has empty action", func() {
-			It("returns error message to character", func() {
+			It("returns error status with pose-specific prompt", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI2",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":"","character_name":"Bob","location_id":"loc456","character_id":"char123"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          "",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+					CharacterID:   "char123",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("character:char123"))
-				Expect(string(emits[0].Type)).To(Equal("error"))
-				Expect(emits[0].Payload).To(ContainSubstring("What do you want to do?"))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+				Expect(resp.Output).To(ContainSubstring("What do you want to pose?"))
 			})
 		})
 
 		Context("when pose uses prefix marker with no action after it", func() {
-			It("returns error message when only : is provided in args", func() {
+			It("returns error when only : is provided in args", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI5",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":":","character_name":"Bob","location_id":"loc456","character_id":"char123"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          ":",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+					CharacterID:   "char123",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("character:char123"))
-				Expect(string(emits[0].Type)).To(Equal("error"))
-				Expect(emits[0].Payload).To(ContainSubstring("What do you want to do?"))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+				Expect(resp.Output).To(ContainSubstring("What do you want to pose?"))
 			})
 
-			It("returns error message when only ; is provided in args", func() {
+			It("returns error when only ; is provided in args", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01GHI6",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"pose","args":";","character_name":"Bob","location_id":"loc456","character_id":"char123"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "pose",
+					Args:          ";",
+					CharacterName: "Bob",
+					LocationID:    "loc456",
+					CharacterID:   "char123",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("character:char123"))
-				Expect(string(emits[0].Type)).To(Equal("error"))
-				Expect(emits[0].Payload).To(ContainSubstring("What do you want to do?"))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+				Expect(resp.Output).To(ContainSubstring("What do you want to pose?"))
 			})
 		})
 	})
 
-	Describe("Emit Command Event Handling", func() {
-		Context("when receiving emit command event", func() {
-			It("emits raw text without prefix", func() {
+	Describe("Emit Command Handling", func() {
+		Context("when emit command is invoked with text", func() {
+			It("emits raw text to the location stream", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01JKL",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"emit","args":"The room shakes!","character_name":"Admin","location_id":"loc456"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "emit",
+					Args:          "The room shakes!",
+					CharacterName: "Admin",
+					LocationID:    "loc456",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("location:loc456"))
-				Expect(string(emits[0].Type)).To(Equal("emit"))
-				Expect(emits[0].Payload).To(ContainSubstring(`The room shakes!`))
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+				Expect(resp.Events).To(HaveLen(1))
+				Expect(resp.Events[0].Stream).To(Equal("location:loc456"))
+				// The Lua emit handler returns type = "emit" (unqualified); the host
+				// namespace-qualifies emitted types only when going through PluginEventEmitter.Emit,
+				// not on the direct DeliverCommand path.
+				Expect(string(resp.Events[0].Type)).To(Equal("emit"))
+				Expect(resp.Events[0].Payload).To(ContainSubstring(`The room shakes!`))
 			})
 		})
 
 		Context("when emit command has empty text", func() {
-			It("returns error message to character", func() {
+			It("returns error status with prompt", func() {
 				ctx := context.Background()
-				event := pluginsdk.Event{
-					ID:        "01JKL2",
-					Stream:    "character:char123",
-					Type:      pluginsdk.EventType("command"),
-					Timestamp: time.Now().UnixMilli(),
-					ActorKind: pluginsdk.ActorCharacter,
-					ActorID:   "char123",
-					Payload:   `{"name":"emit","args":"","character_name":"Admin","location_id":"loc456","character_id":"char123"}`,
-				}
-
-				emits, err := fixture.LuaHost.DeliverEvent(ctx, "core-communication", event)
+				resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-communication", pluginsdk.CommandRequest{
+					Command:       "emit",
+					Args:          "",
+					CharacterName: "Admin",
+					LocationID:    "loc456",
+					CharacterID:   "char123",
+				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(emits).To(HaveLen(1))
-				Expect(emits[0].Stream).To(Equal("character:char123"))
-				Expect(string(emits[0].Type)).To(Equal("error"))
-				Expect(emits[0].Payload).To(ContainSubstring("What do you want to emit?"))
+				Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+				Expect(resp.Output).To(ContainSubstring("What do you want to emit?"))
 			})
 		})
 	})
 
 	Describe("Non-Command Event Handling", func() {
 		Context("when receiving non-command events", func() {
-			It("ignores them", func() {
+			It("ignores them (no on_event handler)", func() {
 				ctx := context.Background()
 				event := pluginsdk.Event{
 					ID:        "01MNO",
 					Stream:    "location:123",
 					Type:      pluginsdk.EventType(corecomm.EventTypeSay),
-					Timestamp: time.Now().UnixMilli(),
 					ActorKind: pluginsdk.ActorCharacter,
 					ActorID:   "char_1",
 					Payload:   `{"message":"Hello"}`,

--- a/internal/plugin/help_integration_test.go
+++ b/internal/plugin/help_integration_test.go
@@ -7,7 +7,6 @@ package plugins_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -80,26 +79,6 @@ func setupHelpTest() (*helpFixture, error) {
 	return setupHelpTestWithEngine(policytest.AllowAllEngine())
 }
 
-// makeCommandPayload creates a JSON payload for a command event.
-func makeCommandPayload(name, args string) string {
-	payload := map[string]any{
-		"name":           name,
-		"args":           args,
-		"character_id":   "01HTEST000000000000000CHAR",
-		"location_id":    "01HTEST000000000000000ROOM",
-		"character_name": "TestPlayer",
-	}
-	data, _ := json.Marshal(payload)
-	return string(data)
-}
-
-// parsePayload parses a JSON payload string into a map.
-func parsePayload(payload string) map[string]any {
-	var result map[string]any
-	_ = json.Unmarshal([]byte(payload), &result)
-	return result
-}
-
 var _ = Describe("Help Plugin Integration", func() {
 	var fixture *helpFixture
 
@@ -115,155 +94,104 @@ var _ = Describe("Help Plugin Integration", func() {
 		}
 	})
 
+	// All help tests use DeliverCommand. The help plugin's on_command returns
+	// plain strings or {status, output} tables — no emit events. DeliverCommand
+	// parses these correctly via parseCommandResponse; DeliverEvent feeds the
+	// wrapped result to parseEmitEvents (wrong path) returning nil.
+
 	Describe("help command", func() {
 		It("lists all available commands when called without args", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", ""),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
 
-			// Verify events were emitted
-			outputEvent := result[0]
-			Expect(outputEvent.Type).To(Equal(pluginsdk.EventType("help")))
-
-			// Check that the output contains command names
-			payload := parsePayload(outputEvent.Payload)
-			message, hasMessage := payload["message"].(string)
-			Expect(hasMessage).To(BeTrue())
-
-			// Verify key content is present
-			Expect(message).To(ContainSubstring("say"))
-			Expect(message).To(ContainSubstring("look"))
-			Expect(message).To(ContainSubstring("dig"))
+			// Verify key content is present in the output text
+			Expect(resp.Output).To(ContainSubstring("say"))
+			Expect(resp.Output).To(ContainSubstring("look"))
+			Expect(resp.Output).To(ContainSubstring("dig"))
 		})
 
 		It("shows detailed help for a specific command", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "say"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "say",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
-
-			outputEvent := result[0]
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
 
 			// Verify detailed help content
-			Expect(message).To(ContainSubstring("say"))
-			Expect(message).To(ContainSubstring("say <message>"))
-			Expect(message).To(ContainSubstring("communication"))
+			Expect(resp.Output).To(ContainSubstring("say"))
+			Expect(resp.Output).To(ContainSubstring("say <message>"))
+			Expect(resp.Output).To(ContainSubstring("communication"))
 		})
 
 		It("returns error for unknown command", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "nonexistent"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "nonexistent",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
-
-			outputEvent := result[0]
-			Expect(outputEvent.Type).To(Equal(pluginsdk.EventType("error")))
-
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
-			Expect(message).To(ContainSubstring("Unknown command"))
-			Expect(message).To(ContainSubstring("nonexistent"))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandError))
+			Expect(resp.Output).To(ContainSubstring("Unknown command"))
+			Expect(resp.Output).To(ContainSubstring("nonexistent"))
 		})
 
 		It("searches commands by keyword", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "search room"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "search room",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
-
-			outputEvent := result[0]
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
 
 			// Should find commands mentioning "room"
-			Expect(message).To(ContainSubstring("say")) // "Say something to the room"
-			Expect(message).To(ContainSubstring("dig")) // "Create a new room"
+			Expect(resp.Output).To(ContainSubstring("say")) // "Say something to the room"
+			Expect(resp.Output).To(ContainSubstring("dig")) // "Create a new room"
 		})
 
-		It("searches commands by usage field", func() {
+		It("searches commands by help field", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			// Search for "message" which only appears in usage: "say <message>"
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "search message"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			// "room" appears in the help text of "say" ("Say something to the room")
+			// and "dig" ("Create a new room or exit"), but not "look". The help
+			// plugin searches the name and help fields (not usage), so this exercises
+			// help-field matching with selectivity.
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "search room",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
 
-			outputEvent := result[0]
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
-
-			// Should find "say" command via usage field "say <message>"
-			Expect(message).To(ContainSubstring("say"))
-			// Should NOT find "look" or "dig" (they don't have "message" in any field)
-			Expect(message).NotTo(ContainSubstring("look"))
-			Expect(message).NotTo(ContainSubstring("dig"))
+			Expect(resp.Output).To(ContainSubstring("say"))
+			Expect(resp.Output).To(ContainSubstring("dig"))
+			Expect(resp.Output).NotTo(ContainSubstring("look"))
 		})
 	})
 })
@@ -331,8 +259,9 @@ func setupHelpTestWithEngine(engine accesstypes.AccessPolicyEngine) (*helpFixtur
 var _ = Describe("Help Plugin – list_commands result format", func() {
 	Describe("extracting commands from wrapper table", func() {
 		It("extracts .commands field and iterates correctly", func() {
-			// This test verifies the Lua plugin correctly unwraps
-			// the {commands: [...], incomplete: bool} result table.
+			// This test verifies the Lua plugin correctly unwraps the
+			// {commands: [...], incomplete: bool} result from list_commands.
+			// Uses DeliverCommand which correctly parses the on_command return shape.
 			fixture, err := setupHelpTest()
 			Expect(err).NotTo(HaveOccurred())
 			defer fixture.Cleanup()
@@ -340,32 +269,19 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", ""),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK),
+				"help list should return CommandOK, not error (CommandOK==0 bug would mean #commands==0)")
 
-			// The event type MUST be "help" not "info" —
-			// "info" means the plugin hit #commands == 0 (wrapper table has no integer keys)
-			outputEvent := result[0]
-			Expect(outputEvent.Type).To(Equal(pluginsdk.EventType("help")),
-				"event type should be 'help', not 'info' (which indicates #commands==0 bug)")
-
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
-			Expect(message).To(ContainSubstring("say"))
-			Expect(message).To(ContainSubstring("look"))
-			Expect(message).To(ContainSubstring("dig"))
+			Expect(resp.Output).To(ContainSubstring("say"))
+			Expect(resp.Output).To(ContainSubstring("look"))
+			Expect(resp.Output).To(ContainSubstring("dig"))
 		})
 
 		It("search_commands extracts .commands field correctly", func() {
@@ -376,35 +292,25 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "search room"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "search room",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(len(result)).To(BeNumerically(">=", 1))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK),
+				"search should find commands and return CommandOK")
 
-			// Must be "help" type, meaning search found results
-			outputEvent := result[0]
-			Expect(outputEvent.Type).To(Equal(pluginsdk.EventType("help")),
-				"search should find commands and emit 'help' event")
-
-			payload := parsePayload(outputEvent.Payload)
-			message := payload["message"].(string)
-			Expect(message).To(ContainSubstring("say"))
+			Expect(resp.Output).To(ContainSubstring("say"))
 		})
 	})
 
-	Describe("incomplete flag handling", func() {
-		It("shows warning when incomplete is true", func() {
-			// Use an error engine so some commands are hidden and incomplete=true
+	Describe("error engine handling", func() {
+		It("returns unavailable message when list_commands engine errors", func() {
+			// The Lua plugin calls list_commands; when the policy engine errors,
+			// list_commands returns an error and the Lua code returns a graceful
+			// failure message (status=2) rather than a partial list.
 			errorEngine := policytest.NewErrorEngine(errors.New("policy store unavailable"))
 			fixture, err := setupHelpTestWithEngine(errorEngine)
 			Expect(err).NotTo(HaveOccurred())
@@ -413,48 +319,21 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", ""),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
+			Expect(resp).NotTo(BeNil())
 
-			// Should still show available commands (those with no capabilities: "look")
-			// plus an incomplete warning
-			var messages []string
-			for _, ev := range result {
-				p := parsePayload(ev.Payload)
-				if msg, ok := p["message"].(string); ok {
-					messages = append(messages, msg)
-				}
-			}
-
-			combined := ""
-			for _, m := range messages {
-				combined += m + "\n"
-			}
-
-			// "look" has no capabilities, so it should still appear
-			Expect(combined).To(ContainSubstring("look"),
-				"commands without capabilities should still appear when engine errors")
-
-			// There should be some indication that the list is incomplete
-			Expect(combined).To(SatisfyAny(
-				ContainSubstring("incomplete"),
-				ContainSubstring("hidden"),
-				ContainSubstring("some commands"),
-			), "should warn user that command list may be incomplete")
+			Expect(resp.Status).To(Equal(pluginsdk.CommandFailure),
+				"engine error should produce CommandFailure status")
+			Expect(resp.Output).To(ContainSubstring("temporarily unavailable"),
+				"should return a graceful unavailability message, not a partial list")
 		})
 
-		It("does not show warning when incomplete is false", func() {
+		It("returns full command list when engine succeeds", func() {
 			fixture, err := setupHelpTest() // AllowAll engine, no errors
 			Expect(err).NotTo(HaveOccurred())
 			defer fixture.Cleanup()
@@ -462,33 +341,21 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", ""),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
+			Expect(resp).NotTo(BeNil())
 
-			var combined string
-			for _, ev := range result {
-				p := parsePayload(ev.Payload)
-				if msg, ok := p["message"].(string); ok {
-					combined += msg + "\n"
-				}
-			}
-
-			Expect(combined).NotTo(ContainSubstring("incomplete"))
-			Expect(combined).NotTo(ContainSubstring("hidden"))
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
+			Expect(resp.Output).NotTo(ContainSubstring("unavailable"))
 		})
 
-		It("shows warning when search_commands returns incomplete results", func() {
+		It("returns unavailable message when search engine errors", func() {
+			// search_commands also calls list_commands; engine errors produce
+			// a graceful failure message (status=2) rather than partial search results.
 			errorEngine := policytest.NewErrorEngine(errors.New("policy store unavailable"))
 			fixture, err := setupHelpTestWithEngine(errorEngine)
 			Expect(err).NotTo(HaveOccurred())
@@ -497,39 +364,18 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			// Use "help search <term>" to exercise the search_commands path
-			event := pluginsdk.Event{
-				ID:        "01HTEST",
-				Stream:    "character:01HTEST000000000000000CHAR",
-				Type:      pluginsdk.EventType("command"),
-				Timestamp: time.Now().UnixMilli(),
-				ActorKind: pluginsdk.ActorCharacter,
-				ActorID:   "01HTEST000000000000000CHAR",
-				Payload:   makeCommandPayload("help", "search look"),
-			}
-
-			result, err := fixture.LuaHost.DeliverEvent(ctx, "core-help", event)
+			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
+				Command:     "help",
+				Args:        "search look",
+				CharacterID: "01HTEST000000000000000CHAR",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
+			Expect(resp).NotTo(BeNil())
 
-			var combined string
-			for _, ev := range result {
-				p := parsePayload(ev.Payload)
-				if msg, ok := p["message"].(string); ok {
-					combined += msg + "\n"
-				}
-			}
-
-			// "look" has no capabilities, so it should match the search term
-			Expect(combined).To(ContainSubstring("look"),
-				"commands without capabilities should still appear in search results when engine errors")
-
-			// There should be some indication that search results may be incomplete
-			Expect(combined).To(SatisfyAny(
-				ContainSubstring("incomplete"),
-				ContainSubstring("hidden"),
-				ContainSubstring("some commands"),
-			), "should warn user that search results may be incomplete due to engine errors")
+			Expect(resp.Status).To(Equal(pluginsdk.CommandFailure),
+				"engine error during search should produce CommandFailure status")
+			Expect(resp.Output).To(ContainSubstring("temporarily unavailable"),
+				"should return a graceful unavailability message, not partial search results")
 		})
 	})
 })

--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -112,8 +112,8 @@ type EventEmitterConfigurer interface {
 }
 
 // HistoryReader provides read-only replay access for host functions (e.g.
-// query_stream_history in Lua plugins). Satisfied by MemoryEventStore in
-// unit tests and by a JetStream-backed reader in production.
+// query_stream_history in Lua plugins). Satisfied by coretest.MemoryEventStore
+// in tests and by a JetStream-backed reader in production.
 type HistoryReader interface {
 	ReplayTail(ctx context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]core.Event, error)
 }

--- a/internal/plugin/integration_test.go
+++ b/internal/plugin/integration_test.go
@@ -145,8 +145,9 @@ var _ = Describe("Echo Bot Integration", func() {
 			Expect(slices.Contains(fixture.Plugin.Manifest.Events, "say")).To(BeTrue())
 		})
 
-		It("declares no top-level policies by default", func() {
-			Expect(fixture.Plugin.Manifest.Policies).To(BeEmpty())
+		It("declares emit-events policy", func() {
+			Expect(fixture.Plugin.Manifest.Policies).To(HaveLen(1))
+			Expect(fixture.Plugin.Manifest.Policies[0].Name).To(Equal("emit-events"))
 		})
 	})
 
@@ -292,9 +293,12 @@ var _ = Describe("Echo Bot Integration", func() {
 				},
 			)
 
-			// Create subscriber
+			// Create subscriber. The manifest declares events: [say] (short form) but
+			// dispatched events use the fully qualified type "core-communication:say".
+			// Subscribe with the qualified type so the Subscriber's exact-match filter
+			// routes the event to echo-bot.
 			subscriber := plugins.NewSubscriber(fixture.LuaHost, emitter)
-			subscriber.Subscribe("echo-bot", "location:123", fixture.Plugin.Manifest.Events)
+			subscriber.Subscribe("echo-bot", "location:123", []string{string(corecomm.EventTypeSay)})
 
 			// Start subscriber with event channel
 			ctx, cancel := context.WithCancel(context.Background())

--- a/site/docs/contributing/integration-tests.md
+++ b/site/docs/contributing/integration-tests.md
@@ -1,9 +1,14 @@
 # Integration Test Harness
 
 This page describes the `internal/testsupport/integrationtest` package — the
-canonical harness for HoloMUSH integration tests that need a real in-process
-holomush stack (Postgres + embedded NATS JetStream + production CoreServer)
-rather than a mocked surface.
+canonical harness for HoloMUSH **full-stack integration** tests that need a real
+in-process holomush stack (Postgres + embedded NATS JetStream + production
+CoreServer) rather than a mocked surface.
+
+> **Tier vocabulary:** "E2E" is reserved for the Playwright browser suite
+> (`task test:e2e`). Ginkgo suites run via `task test:int` are **integration**
+> tests — including this harness, which is "full-stack integration". See the
+> canonical tier table in `.claude/rules/testing.md`.
 
 **Package**: `github.com/holomush/holomush/internal/testsupport/integrationtest`
 

--- a/test/meta/depguard_config_test.go
+++ b/test/meta/depguard_config_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDepguardTestOnlyConstructRulesPresent guards INV-1/INV-2 against silent
+// deletion — the exact failure mode (a config claim silently diverging from
+// reality) this work was created to correct (holomush-1eps2).
+func TestDepguardTestOnlyConstructRulesPresent(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, ".golangci.yaml"))
+	require.NoError(t, err, "read .golangci.yaml")
+	cfg := string(data)
+
+	for _, pkg := range []string{
+		"github.com/holomush/holomush/internal/eventbus/eventbustest",
+		"github.com/holomush/holomush/internal/core/coretest",
+	} {
+		require.Contains(t, cfg, pkg,
+			"depguard deny rule for %q missing from .golangci.yaml (holomush-1eps2 INV-1/INV-2)", pkg)
+	}
+}
+
+// TestTaskfileIntHasNoPackageList guards INV-3: the test:int recipe must run
+// ./... (honoring CLI_ARGS) and must NOT re-introduce an enumerated package
+// list (holomush-1eps2, absorbs holomush-bmtd).
+func TestTaskfileIntHasNoPackageList(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "Taskfile.yaml"))
+	require.NoError(t, err, "read Taskfile.yaml")
+	tf := string(data)
+
+	// Isolate the test:int recipe block: from its key line to the next
+	// 2-space-indented task key.
+	loc := regexp.MustCompile(`(?m)^  test:int:[ \t]*$`).FindStringIndex(tf)
+	require.NotNil(t, loc, "test:int target not found in Taskfile.yaml")
+	after := tf[loc[1]:]
+	block := after
+	if next := regexp.MustCompile(`(?m)^  \S`).FindStringIndex(after); next != nil {
+		block = after[:next[0]]
+	}
+
+	require.Contains(t, block, "CLI_ARGS",
+		"test:int must honor CLI_ARGS (holomush-1eps2 INV-3 / bmtd)")
+	require.NotContains(t, block, "./internal/",
+		"test:int must not enumerate packages; use ./... (holomush-1eps2 INV-3)")
+}


### PR DESCRIPTION
## Summary

Resolves the overloaded `integration` build tag and erases the fragile `test:int`
package enumeration that had been silently excluding (and letting rot) integration
packages from CI. Epic **holomush-1eps2**.

- **Extract** `core.MemoryEventStore` (the lone `//go:build !integration` helper)
  into a new `internal/core/coretest` package, repointing 9 test call sites + 2
  production comments. This removes the compile barrier that forced the enumeration.
- **depguard**: enable a deny rule barring production code from importing either
  `internal/eventbus/eventbustest` or `internal/core/coretest` (test-only constructs).
- **Taskfile**: delete the explicit `test:int` package list; run `{{.CLI_ARGS | default "./..."}}`
  under `-tags=integration`, restoring `CLI_ARGS` passthrough (absorbs holomush-bmtd).
- **Repair rotted specs** the `./...` switch surfaced (both silently excluded from the
  old list): `internal/plugin/{communication,help,integration}_integration_test.go`
  (holomush-gria3 — stale pre-opt-in-capability assertions) and
  `internal/admin/readstream/cold_reader_integration_test.go` (holomush-d1582 —
  missing NOT-NULL rendering column + a raw `time.Time` bind to a BIGINT-ns column).
  Both were test-only fixes; no production behavior change.
- **Guard meta-tests** (`test/meta/depguard_config_test.go`): assert the depguard deny
  rules and the no-enumeration invariant cannot silently regress (RED-verified).
- **Docs**: reconcile the test-tier taxonomy across `.claude/rules/testing.md`,
  `CLAUDE.md`, the jetstream design spec §8, and `site/docs/contributing/integration-tests.md`
  — "E2E" now means the Playwright suite; Ginkgo `test:int` is "integration".

ADRs: holomush-qti5d (depguard-not-build-tags), holomush-1r2hp (E2E=Playwright taxonomy),
holomush-vjg7z (plugin opt-in capability). Design/plan in
`docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` and
`docs/superpowers/plans/2026-05-25-test-tier-taxonomy.md`.

## Test Plan

- [x] `task test:int -- ./...` — full repo under `-tags=integration`: 8497 tests, 2 deliberate skips, 0 failures
- [x] `task test -- ./test/meta/` green; both guard meta-tests RED-verified on regression
- [x] `task lint` clean
- [x] `task pr-prep` full lane (lint, format, schema, license, unit, integration, E2E) — All checks passed
- [x] Integrated-branch code review — READY, 0 blocking findings; production guardrail confirmed (engine.go/host.go comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)