### PR TITLE
feat(pr-prep): machine-readable result file + grep-on-output guidance (holomush-qj5v1)

### DIFF
--- a/.claude/rules/search-tools.md
+++ b/.claude/rules/search-tools.md
@@ -22,6 +22,19 @@ the native Read/Glob tools.
 | **SHOULD** reach for `ast-grep` | For structural matches and codemods — see patterns below. |
 | **MUST** brief sub-agents on this ladder | Sub-agents default to `rg`/full-file `Read` without an explicit reminder. |
 
+## Searching files ≠ deciding whether a command succeeded
+
+The ladder above is for finding text *in files*. Deciding whether a **command
+run** passed, failed, or should be retried is a different question — and
+`grep`/`rg` over its output is the wrong tool for it.
+
+| Requirement | Rule |
+| --- | --- |
+| **MUST** use the exit code | To decide pass/fail of a command, check `$?` — never grep its stdout/stderr for a "success"/"error" string. |
+| **MUST NOT** branch on a matched output string | A command's output can echo test fixtures, expected-value assertions, or your own input, so a status substring may appear on a **passing** run. Real example: `task pr-prep`'s `pr-prep-lock.bats` self-test surfaces `another pr-prep is running` on healthy runs — an agent's retry loop grepped for that string, mistook every pass for lock contention, and re-ran the full lane forever (May 2026). |
+| **MUST** read the exit code, not the log tail, for background runs | With `run_in_background`, get pass/fail from the run's reported exit code (or a result artifact the command writes), not by grepping the captured log. Piping through `tee`/`tail`/a trailing `echo` masks the real exit code unless `set -o pipefail` is on. |
+| **MAY** grep output as a *secondary* confirmation | After the exit code says pass, matching a known terminal line (e.g. `✓ All PR checks passed.`) is fine as a sanity check — never as the primary signal. |
+
 ## ast-grep for HoloMUSH (Go)
 
 `ast-grep` (`sg`) matches parsed syntax (whitespace/var-name independent) and can

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,25 @@ first if you've made edits since the last `jj` command. See
 [pr-prep](site/docs/contributing/pr-prep.md) for collision behavior and
 the docs lane.
 
+**Reading the pr-prep result — exit code first, then disambiguate; never
+grep the lock string.** Run it as the SOLE command (`task pr-prep` — no
+`| tee` / `| tail` / trailing `echo`, which mask `$?`). Exit `0` = pass.
+Non-zero = something stopped it, but **go-task collapses every non-zero exit
+to `201`**, so the exit code alone canNOT tell lock contention apart from a
+real gate failure. Distinguish them by behavior, not by a status substring:
+**contention** returns in ~2s, runs no lane steps, and prints `ERROR: another
+pr-prep is running` to stderr (retry-able — wait, then re-run); a **real
+failure** runs lane steps (minutes) and fails a named check (`fmt:check`,
+`lint:*`, a test) — do NOT retry, fix it. **MUST NOT** drive a retry loop off
+the string `another pr-prep is running`: pr-prep's own `pr-prep-lock.bats`
+self-test surfaces that exact string on **healthy** runs, so matching it loops
+forever re-running the full serialized lane (May 2026 incident). The
+final-line `✓ All PR checks passed.` confirms a pass; it is not a substitute
+for the exit code. Each run also prints a line `▸ pr-prep result: <path>` and
+writes that file with a `status=` line (`pass`/`fail`/`contention`) — match the
+`▸ pr-prep result:` prefix (don't assume a line number) and read the file for
+the authoritative verdict; the behavioral cues above are the fallback.
+
 ### Session isolation
 
 This repo is developed primarily by concurrent AI agent sessions. Because jj snapshots the working copy on every command, two sessions sharing the same jj workspace will collide on uncommitted edits.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -726,9 +726,27 @@ tasks:
           set -euo pipefail
 
           # ─────────────────────────────────────────────────────────────
+          # Result artifact (spec I-11). go-task collapses every non-zero
+          # exit to 201, so callers cannot tell lock-contention from a real
+          # gate failure by exit code — each run writes a machine-readable
+          # result file and prints its path; automation reads that instead
+          # of grepping stdout (which trips on pr-prep-lock.bats' own
+          # "another pr-prep is running" assertion string).
+          # ─────────────────────────────────────────────────────────────
+          LOCK_DIR="${TMPDIR:-/tmp}/holomush-pr-prep"
+          RUN_DIR="$LOCK_DIR/runs"
+          mkdir -p "$RUN_DIR"
+          RESULT="$RUN_DIR/$(date -u +%Y%m%dT%H%M%SZ)-$$.result"
+          printf '▸ pr-prep result: %s\n' "$RESULT"
+          write_result() {
+            printf 'status=%s\nlane=%s\nexit=%s\nfinished_at=%s\n' \
+              "$1" "$2" "$3" "$(date -u +%FT%TZ)" > "$RESULT"
+          }
+
+          # ─────────────────────────────────────────────────────────────
           # Docs-only detection. MUST live in this same `- cmd:` block as
           # the flock body below — go-task spawns each `- cmd:` in its own
-          # subshell, so `exec` only short-circuits within the same shell.
+          # subshell, so the `exit` short-circuit only works within this shell.
           # Spec §4.3.1.
           # ─────────────────────────────────────────────────────────────
           if [ "${HOLOMUSH_PR_PREP_FORCE_FULL:-}" != "1" ]; then
@@ -738,13 +756,14 @@ tasks:
               DOCS_REGEX=$(bash scripts/docs-paths-regex.sh)
               if ! printf '%s\n' "$CHANGED" | grep -vE "$DOCS_REGEX" >/dev/null; then
                 echo "▸ docs-only diff detected; running pr-prep:docs"
-                exec task pr-prep:docs
+                drc=0
+                task pr-prep:docs || drc=$?
+                if [ "$drc" -eq 0 ]; then write_result pass docs 0; else write_result fail docs "$drc"; fi
+                exit "$drc"
               fi
             fi
           fi
 
-          LOCK_DIR="${TMPDIR:-/tmp}/holomush-pr-prep"
-          mkdir -p "$LOCK_DIR"
           LOCK="$LOCK_DIR/lock"
           INFO="$LOCK_DIR/info"
           rc=0
@@ -765,12 +784,19 @@ tasks:
               echo "  Lock file: $LOCK"
               echo "  Wait for it to finish, or kill the holder PID if wedged."
             } >&2
+            write_result contention full 75
             exit 1
           fi
           if [ "$rc" -ne 0 ]; then
-            echo "ERROR: lock acquire failed unexpectedly (rc=$rc); see flock(1) output above." >&2
+            # rc is non-zero and not 75: on a successful lock acquire flock
+            # returns the inner lane's exit code, so this is usually a real
+            # gate failure (go-task wraps it to 201); it can also be a flock
+            # error such as EACCES on the lockfile. Either way: status=fail.
+            write_result fail full "$rc"
+            echo "ERROR: pr-prep failed (rc=$rc) — a check failed (see output above) or the lock could not be acquired (e.g. flock EACCES)." >&2
             exit "$rc"
           fi
+          write_result pass full 0
 
   pr-prep:run:
     cmds:

--- a/docs/superpowers/specs/2026-04-26-pr-prep-concurrency-safety-design.md
+++ b/docs/superpowers/specs/2026-04-26-pr-prep-concurrency-safety-design.md
@@ -196,6 +196,28 @@ The exit-code wrapping in scenarios 2 and 5 is go-task's documented behavior (ev
 
 The POC is preserved at `/tmp/flock-poc-v3/Taskfile.yaml` for the duration of design review. The earlier rev-1 and rev-2 POCs (`/tmp/flock-poc/`, `/tmp/flock-poc-rev2/`) are kept for regression reference but **do not exercise the production layout** and MUST NOT be used as evidence for any future revision. The implementation plan MUST include equivalent automated tests using the bats fixture described in §"Test Plan".
 
+### Result artifact (rev-5)
+
+The original design accepted that "the literal exit code is informational only"
+(see I-6) because go-task collapses every non-zero exit to 201. In practice this
+left **automation** with no machine-readable way to tell lock-contention from a
+real gate failure, so a retry loop resorted to grepping stdout for the collision
+string `another pr-prep is running` — which this very suite's `error_includes_metadata`
+test surfaces on **healthy** runs. The result: every passing run looked like a
+collision and the loop re-ran the full serialized lane indefinitely (May 2026
+incident, `holomush-qj5v1`).
+
+rev-5 closes the gap with invariant **I-11**: every invocation writes a
+machine-readable result file under `${LOCK_DIR}/runs/<utc-ts>-<pid>.result` and
+prints its path. Callers branch on `status=` (`pass`/`fail`/`contention`) read
+from that file — never on a substring of stdout. The artifact is the only signal
+that survives go-task's exit-code collapse. Both lanes write it: the docs lane
+records `lane=docs` (the harness now captures `pr-prep:docs`'s exit instead of
+`exec`-ing into it, so it can write the result before exiting); the full lane
+records `lane=full` at all three terminal points (contention, lock-error, pass).
+The contention path's user-facing behavior (stderr message, ~2s non-blocking
+exit, exit non-zero) is unchanged — I-2, I-3, and I-8 still hold.
+
 ### Setup Change
 
 The `setup` task's `brew install` line gains `flock`:
@@ -218,7 +240,7 @@ These updates are PR-blocking acceptance criteria. The implementation plan MUST 
 
 ## Numbered Invariants
 
-Each invariant is enforced by a named test in the bats suite (see "Test Plan" below). The meta-test `all_invariants_have_tests` (a named `@test` block inside `scripts/tests/pr-prep-lock.bats`) MUST verify that every invariant ID (`I-1` … `I-10`) appears in a test name in `pr-prep-lock.bats`.
+Each invariant is enforced by a named test in the bats suite (see "Test Plan" below). The meta-test `all_invariants_have_tests` (a named `@test` block inside `scripts/tests/pr-prep-lock.bats`) MUST verify that every invariant ID (`I-1` … `I-11`) appears in a test name in `pr-prep-lock.bats`.
 
 | #    | Invariant                                                                                                                                                        | Enforcing test            |
 | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
@@ -232,6 +254,7 @@ Each invariant is enforced by a named test in the bats suite (see "Test Plan" be
 | I-8  | The lock acquire MUST be non-blocking (`flock -n`); the colliding invocation MUST exit within 2 seconds regardless of how long the holder still has to run.     | `non_blocking_acquire`    |
 | I-9  | `task pr-prep:run` invoked directly without `HOLOMUSH_PR_PREP_BYPASS_LOCK=1` MUST refuse to run, exit non-zero, and print a message naming the bypass env var.  | `bypass_guard_blocks`     |
 | I-10 | `pr-prep:run` MUST NOT appear in `task --list` (default operator view). It MAY appear in `task --list-all`. The Taskfile MUST NOT mark it `internal: true` (which would break the harness's `exec task pr-prep:run`). The contract is enforced primarily at the YAML level via `yq` (robust against go-task version drift); the `task --list` check is a supplementary observed-behavior assertion. | `pr_prep_run_hidden_from_list` |
+| I-11 | Every invocation that reaches the harness body (i.e., past the `flock(1)` precondition of I-7) MUST write a machine-readable result file under `${LOCK_DIR}/runs/<utc-ts>-<pid>.result` (key=value lines: `status=pass\|fail\|contention`, `lane=full\|docs`, `exit=<internal rc>`, `finished_at=<utc>`) and MUST print its path to stdout (`▸ pr-prep result: <path>`). Because go-task collapses every non-zero exit to 201 (I-6), the exit code alone cannot distinguish lock-contention from a real gate failure; the result file is the machine-readable disambiguation so automation never has to grep stdout (where this suite's own `another pr-prep is running` assertion string would cause false positives). | `result_file_records_status` |
 
 ## Test Plan
 
@@ -314,7 +337,7 @@ The 2s budget is empirically generous; the actual kernel cleanup is sub-millisec
 
 The implementation PR is mergeable when:
 
-1. All 10 invariant tests pass under the bats runner integrated by the implementation plan.
+1. All 11 invariant tests pass under the bats runner integrated by the implementation plan.
 2. The meta-test `all_invariants_have_tests` (in `scripts/tests/pr-prep-lock.bats`) passes.
 3. The implementer smoke-tests `task pr-prep` end-to-end on the maintainer's macOS workstation: (a) one full successful run; (b) one deliberate collision run — start a holder in another terminal, invoke `task pr-prep` in this terminal while the holder is still running, verify the COLLIDED stderr message and non-zero exit; (c) one post-success retry — after the holder from (a) completes, invoke `task pr-prep` again in the same workspace and verify it acquires the lock without error. This is operator attestation, not a CI gate; the bats suite enforces all numbered invariants.
 4. CI passes. The CI workflow MUST set `HOLOMUSH_PR_PREP_BYPASS_LOCK=1` if it invokes `pr-prep:run` directly (or invoke `task pr-prep` and rely on the lock being uncontended on a fresh runner). Either form is acceptable; the implementation plan picks one.

--- a/scripts/tests/Taskfile.test.yaml
+++ b/scripts/tests/Taskfile.test.yaml
@@ -24,6 +24,17 @@ tasks:
       - cmd: |
           set -euo pipefail
 
+          # Result artifact (mirrors production pr-prep; spec I-11).
+          LOCK_DIR="{{.LOCK_DIR}}"
+          RUN_DIR="$LOCK_DIR/runs"
+          mkdir -p "$RUN_DIR"
+          RESULT="$RUN_DIR/$(date -u +%Y%m%dT%H%M%SZ)-$$.result"
+          printf '▸ pr-prep result: %s\n' "$RESULT"
+          write_result() {
+            printf 'status=%s\nlane=%s\nexit=%s\nfinished_at=%s\n' \
+              "$1" "$2" "$3" "$(date -u +%FT%TZ)" > "$RESULT"
+          }
+
           # ─────────────────────────────────────────────────────────────
           # Docs-only detection (mirrors production pr-prep at
           # Taskfile.yaml:534-563). Same subshell as flock body below.
@@ -36,13 +47,14 @@ tasks:
               DOCS_REGEX=$(bash "$(dirname "{{.TASKFILE}}")/../../scripts/docs-paths-regex.sh")
               if ! printf '%s\n' "$CHANGED" | grep -vE "$DOCS_REGEX" >/dev/null; then
                 echo "▸ docs-only diff detected; running pr-prep:docs"
-                exec task -t "{{.TASKFILE}}" pr-prep:docs
+                drc=0
+                task -t "{{.TASKFILE}}" pr-prep:docs || drc=$?
+                if [ "$drc" -eq 0 ]; then write_result pass docs 0; else write_result fail docs "$drc"; fi
+                exit "$drc"
               fi
             fi
           fi
 
-          LOCK_DIR="{{.LOCK_DIR}}"
-          mkdir -p "$LOCK_DIR"
           LOCK="$LOCK_DIR/lock"
           INFO="$LOCK_DIR/info"
           rc=0
@@ -70,12 +82,15 @@ tasks:
               echo "  Lock file: $LOCK"
               echo "  Wait for it to finish, or kill the holder PID if wedged."
             } >&2
+            write_result contention full 75
             exit 1
           fi
           if [ "$rc" -ne 0 ]; then
-            echo "ERROR: lock acquire failed unexpectedly (rc=$rc); see flock(1) output above." >&2
+            write_result fail full "$rc"
+            echo "ERROR: pr-prep failed (rc=$rc) — a check failed (see output above) or the lock could not be acquired (e.g. flock EACCES)." >&2
             exit "$rc"
           fi
+          write_result pass full 0
 
   pr-prep:run:
     cmds:

--- a/scripts/tests/pr-prep-lock-helpers.bash
+++ b/scripts/tests/pr-prep-lock-helpers.bash
@@ -56,6 +56,13 @@ holder_pid_from_info() {
   awk -F= '/^pid=/{print $2}' "$INFO_FILE" 2>/dev/null
 }
 
+# Path to the most-recently-written result file in this test's run dir, or
+# empty string if none exist. Each pr-prep invocation writes one result file
+# under $LOCK_DIR/runs/ (I-11); a single-invocation test has exactly one.
+latest_result_file() {
+  ls -t "${LOCK_DIR_OVERRIDE}/runs"/*.result 2>/dev/null | head -1
+}
+
 # Run the fixture pr-prep in the foreground, capturing exit status, stdout,
 # stderr in $status, $output (combined). Mirrors bats run behavior.
 fixture_pr_prep() {

--- a/scripts/tests/pr-prep-lock.bats
+++ b/scripts/tests/pr-prep-lock.bats
@@ -215,9 +215,49 @@ setup() {
   # (the harness's flock -E 75), not propagated to the user.
 }
 
+# I-11: every invocation writes a machine-readable result file under
+# $LOCK_DIR/runs/ recording status=pass|fail|contention. go-task collapses
+# every non-zero exit to 201 (see I-6), so contention and a real gate failure
+# are indistinguishable by exit code; the result file is the machine-readable
+# signal that lets automation disambiguate WITHOUT grepping stdout (which
+# trips on this suite's own "another pr-prep is running" assertion string).
+@test "result_file_records_status: idle pass records status=pass" {
+  STUB_SLEEP=0 STUB_MARKER="${BATS_TEST_TMPDIR}/marker" \
+    run task -t "$(fixture_taskfile)" pr-prep
+  [ "$status" -eq 0 ]
+  local rf
+  rf="$(latest_result_file)"
+  [ -n "$rf" ]
+  grep -q '^status=pass$' "$rf"
+  grep -q '^lane=full$' "$rf"
+  # The path is announced on stdout so callers can find it.
+  [[ "$output" == *"pr-prep result:"* ]]
+}
+
+@test "result_file_records_status (failure): inner failure records status=fail" {
+  STUB_EXIT=42 STUB_SLEEP=0 STUB_MARKER="${BATS_TEST_TMPDIR}/marker" \
+    run task -t "$(fixture_taskfile)" pr-prep
+  [ "$status" -ne 0 ]
+  local rf
+  rf="$(latest_result_file)"
+  [ -n "$rf" ]
+  grep -q '^status=fail$' "$rf"
+}
+
+@test "result_file_records_status (contention): collision records status=contention" {
+  start_collision
+  run fixture_pr_prep
+  [ "$status" -ne 0 ]
+  # The colliding invocation writes status=contention; the holder is still
+  # sleeping and has not written its own result yet.
+  run grep -rl '^status=contention$' "${LOCK_DIR_OVERRIDE}/runs"
+  [ "$status" -eq 0 ]
+  end_collision
+}
+
 # Meta-test: every numbered invariant in the spec MUST have a named bats
 # test. Catches drift between the spec and the suite.
-@test "all_invariants_have_tests: I-1 through I-10 each map to a named test" {
+@test "all_invariants_have_tests: I-1 through I-11 each map to a named test" {
   local spec="docs/superpowers/specs/2026-04-26-pr-prep-concurrency-safety-design.md"
   local bats_file="scripts/tests/pr-prep-lock.bats"
 
@@ -236,6 +276,7 @@ setup() {
     [I-8]="non_blocking_acquire"
     [I-9]="bypass_guard_blocks"
     [I-10]="pr_prep_run_hidden_from_list"
+    [I-11]="result_file_records_status"
   )
 
   # Each invariant ID must appear in the spec's invariant table.

--- a/site/docs/contributing/pr-prep.md
+++ b/site/docs/contributing/pr-prep.md
@@ -62,6 +62,34 @@ killall task
 
 After all fd holders die, the kernel releases the lock within microseconds. Run `task pr-prep` again — it should acquire cleanly.
 
+## Reading the result (for automation)
+
+If you script around `task pr-prep` — a retry loop, a babysitter, an agent — read the **exit code** and the **result file**, not the terminal text. Two things make stdout the wrong signal:
+
+- go-task collapses every non-zero exit to `201`, so the exit code alone can't tell a lock collision apart from a real gate failure.
+- pr-prep's own `pr-prep-lock.bats` self-test prints the string `another pr-prep is running` on healthy runs. A loop that greps for that string to detect contention treats every passing run as a collision and re-runs forever. This happened in May 2026.
+
+Every run writes a result file and prints a line prefixed with `▸ pr-prep result:` (match this prefix to find the path — don't assume a fixed line number, since wrappers may prepend output):
+
+```text
+▸ pr-prep result: /var/folders/.../T/holomush-pr-prep/runs/20260525T120000Z-12345.result
+```
+
+The file holds `key=value` lines:
+
+```text
+status=pass
+lane=full
+exit=0
+finished_at=2026-05-25T12:14:03Z
+```
+
+Branch on `status`, which is `pass`, `fail`, or `contention`:
+
+- `contention` — another run holds the lock. Wait, then retry. (It also returned in ~2s having run nothing.)
+- `fail` — a real check failed. Read the log and fix it; do not retry.
+- `pass` — you are clear to push.
+
 ## How the lock works
 
 `flock(1)` opens a file under `${TMPDIR:-/tmp}/holomush-pr-prep/lock` and holds it for the duration of the inner CI body. The kernel automatically releases the lock when the holding processes' file descriptors close — including when they die for any reason. There is no stale-lock-cleanup procedure to worry about, BUT note (per "Killing a wedged holder" above) that descriptor inheritance through child processes means the holder process tree must die for the lock to release.


### PR DESCRIPTION
## Why

A retry loop around `task pr-prep` re-ran the full serialized lane forever (May 2026). Root cause: an agent grepped pr-prep's stdout for the lock string `another pr-prep is running` to detect contention — but pr-prep's own `pr-prep-lock.bats` self-test emits that exact string on **healthy** runs, so every passing run looked like a collision.

The deeper problem: **go-task collapses every non-zero exit to 201** (verified empirically; the spec already noted this at I-6). So lock-contention and a real gate failure are indistinguishable by exit code at the `task pr-prep` boundary — which is *why* automation was forced to scrape stdout in the first place.

## What changed

**Build (the fix):** every `pr-prep` invocation now writes a machine-readable result file under `${LOCK_DIR}/runs/<utc-ts>-<pid>.result` and prints its path:

```text
status=pass        # pass | fail | contention
lane=full          # full | docs
exit=0
finished_at=2026-05-25T22:30:58Z
```

Automation branches on `status=`, never on stdout. New spec invariant **I-11** (rev-5 of the concurrency-safety design) with three enforcing bats tests; the test fixture is mirrored and the meta-test extended (I-1…I-11).

**Guidance (the gap this exposed):**
- `CLAUDE.md` — pr-prep result-reading discipline (exit code first, then the result file; never grep the lock string).
- `.claude/rules/search-tools.md` — "searching files ≠ deciding a command succeeded": use exit codes / result artifacts, not output grep.
- `site/docs/contributing/pr-prep.md` — "Reading the result (for automation)".

**Drive-by:** reworded a pre-existing misleading stderr message — `flock` returns the inner lane's exit code on a successful acquire, so a real lint/test failure was printing "lock acquire failed unexpectedly".

## Testing

- `task test:bats`: 56/56, 0 failures (the three `result_file_records_status` tests cover pass / fail / contention).
- Full `task pr-prep`: green end-to-end on the final state — verified by exit code **and** the new result file (`status=pass`, dogfooded).
- Adversarial code review: READY, no blocking findings (two Low findings addressed in this PR).

ADR capture intentionally skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>