### PR TITLE
docs(gates): tier-split quality gates — spec + plan + 2 ADRs (holomush-b4myw)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [integration/E2E are CI-authoritative-and-required, local-optional](holomush-5k6au-integration-e2e-are-ci-authoritative-and-required-local-opti.md) | 2026-05-26 | Accepted | `holomush-5k6au` |
+| [quarantine flaky specs via governed registry, not deletion](holomush-5eqiv-quarantine-flaky-specs-via-governed-registry-not-deletion.md) | 2026-05-26 | Accepted | `holomush-5eqiv` |
 | [Separate authorization (WHO) from business-state validity (WHEN) in scene policies](holomush-sqpnv-authz-who-vs-business-state-when-scene-policies.md) | 2026-05-25 | Accepted | `holomush-sqpnv` |
 | [Add host Evaluate RPC for per-action plugin authorization](holomush-dttdj-host-evaluate-rpc-per-action-plugin-authz.md) | 2026-05-25 | Accepted | `holomush-dttdj` |
 | [Derive Evaluate subject host-side; no subject field on wire](holomush-qeypl-host-derived-evaluate-subject.md) | 2026-05-25 | Accepted | `holomush-qeypl` |

--- a/docs/adr/holomush-5eqiv-quarantine-flaky-specs-via-governed-registry-not-deletion.md
+++ b/docs/adr/holomush-5eqiv-quarantine-flaky-specs-via-governed-registry-not-deletion.md
@@ -1,0 +1,38 @@
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-5eqiv; do not edit manually; use `/adr update holomush-5eqiv` -->
+
+# quarantine flaky specs via governed registry, not deletion
+
+**Date:** 2026-05-26
+**Status:** Accepted
+**Decision:** holomush-5eqiv
+**Deciders:** Sean Brandt
+
+## Context
+
+Promoting integration/E2E to required CI checks would immediately block merges on ~8 known-flaky specs. The project's "no rerun — investigate" policy means these cannot be re-run past; deleting them loses coverage; silently skipping them (comment-out or bare `.Skip()` without a registry) risks a roach-motel where specs check in and never leave. A mechanism was needed that (a) excludes flaky specs from gating CI, (b) still runs them somewhere, and (c) creates a forcing-function toward eventual removal.
+
+## Decision
+
+Quarantined specs carry an in-code marker plus a `test/quarantine.yaml` registry row. The gating exclusion for all Go integration specs is a single environment variable, `HOLOMUSH_RUN_QUARANTINED`, checked by a `quarantinetest` helper (`Skip(t, bead)` for plain-`testing.T`; `if !quarantinetest.Enabled() { Skip(...) }` for Ginkgo). Playwright uses its native `{ tag: ['@quarantine', '@<bead>'] }` + `--grep-invert`. A bijection meta-test (runs in `task test`) enforces marker↔registry-row↔bead correspondence. The nightly lane runs the quarantined set and emits a health report; `task quarantine:audit` checks bead liveness where `bd` is reachable.
+
+## Rationale
+
+- The env-gate is the only mechanism that works uniformly across plain-`testing.T` and Ginkgo integration packages: `task test:int` runs `go test ./...` across both, and a Ginkgo `--ginkgo.label-filter` passed to `go test ./...` fails with "flag provided but not defined" on non-Ginkgo packages.
+- The bijection meta-test is the hard, always-on forcing-function — a marker without a registry row (or vice versa) breaks the build on every PR.
+- The nightly run surfaces "passing N consecutive nights" un-quarantine candidates without blocking PRs.
+- A bead id in every marker makes each quarantined spec self-documenting and traceable to a fix bead.
+
+## Alternatives Considered
+
+- **Delete flaky specs until fixed.** Rejected: coverage lost, no audit trail, may never be re-added, violates "investigate, don't skip."
+- **Ginkgo `--label-filter` to exclude flakes from gating runs.** Rejected: cannot be the single mechanism because `go test ./...` spans non-Ginkgo packages that don't register the flag.
+- **Env-var gate + registry + bijection meta-test + nightly lane (chosen).** Uniform across Go stacks; Playwright uses native tag+grep-invert; registry + meta-test make the set auditable and self-limiting.
+
+## Consequences
+
+**Positive:** flaky specs are excluded from gating CI without deletion or silent skip; the registry + meta-test create an auditable, self-documenting set that cannot silently grow or shrink; the nightly health report drives burn-down signal without requiring it.
+
+**Negative:** a new `internal/testsupport/quarantinetest` package must be depguard-denied from production; bead-liveness (INV-3) cannot be a CI hard-gate because the Dolt shared-server is not on ephemeral runners — it is an advisory local/pre-`bd close` audit; three marker idioms (plain-Go, Ginkgo, Playwright) must be documented and kept in sync.
+
+**Neutral:** Ginkgo `Label("quarantine", ...)` is optional reporting metadata, not the gate; the quarantine seed list is re-derived from open flake beads at execution time, not frozen in the spec.

--- a/docs/adr/holomush-5k6au-integration-e2e-are-ci-authoritative-and-required-local-opti.md
+++ b/docs/adr/holomush-5k6au-integration-e2e-are-ci-authoritative-and-required-local-opti.md
@@ -1,0 +1,38 @@
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-5k6au; do not edit manually; use `/adr update holomush-5k6au` -->
+
+# integration/E2E are CI-authoritative-and-required, local-optional
+
+**Date:** 2026-05-26
+**Status:** Accepted
+**Decision:** holomush-5k6au
+**Deciders:** Sean Brandt
+
+## Context
+
+The mandatory pre-push gate `task pr-prep` ran all CI tiers serially — including Docker-bound integration and E2E tests — behind a machine-global `flock`, taking 5–15 min per run and serializing N concurrent agent sessions at the finish line. The `protect-main` ruleset did not require `Integration Test` or `E2E Test`, so the local gate was strictly more expensive than the merge gate while being lower-fidelity (rumdl version skew, macOS vs linux/amd64, local Docker vs Testcontainers Cloud). The project owner decided `main` MUST be protected by these tiers. The open question was *where* the gate should live.
+
+## Decision
+
+`Integration Test` and `E2E Test` become required CI status checks on `protect-main`. The mandatory local `task pr-prep` shrinks to the cheap, deterministic, high-local-fidelity tier (schema, license, lint, fmt, unit, build, bats) with no Docker and no `flock`. Integration/E2E become CI-authoritative and local-optional (targeted `task test:int -- ./<domain>` or opt-in `task pr-prep:full`).
+
+## Rationale
+
+- The authoritative merge signal is CI regardless; "pr-prep green locally" was never a guarantee of "CI green" given version/OS/Docker-backend skew.
+- A check should block at the cheapest point where its signal is trustworthy and restarting is cheap: cheap/deterministic checks block everywhere; slow/Docker-bound/lower-fidelity checks are CI-authoritative.
+- The serial-flock contention cost scales with agent parallelism — the exact property the project optimizes for — making the status quo architecturally self-defeating.
+- The `nightly-soak.yml` precedent already established shift-right for slow tiers ("`task pr-prep` stays fast").
+
+## Alternatives Considered
+
+- **Keep integration/E2E in the mandatory local gate (status quo).** Rejected: serial flock contention grows O(N) with agent count; local fidelity lower than CI; `protect-main` never required these tiers, so the cost was borne without proportionate safety gain.
+- **Drop integration/E2E from both the local gate and required checks.** Rejected: regressions undetected until nightly; violates the owner's explicit requirement that `main` MUST be protected by these checks.
+- **Move integration/E2E to CI-authoritative-and-required, local-optional (chosen).** Fast local lane (~2–3 min, no Docker/flock); CI fans work across five parallel runners (~6–8 min); authoritative, higher-fidelity merge signal.
+
+## Consequences
+
+**Positive:** mandatory local gate drops to ~2–3 min with no flock contention; `main` is protected by integration + E2E at the merge gate; CI signal is authoritative and higher-fidelity.
+
+**Negative:** developers touching integration surfaces must run targeted local `test:int` proactively or wait for CI feedback; process-tooling (`branch-readiness-check`, `CLAUDE.md`, `landing-the-plane`, pr-prep/landing commands, the review-reminder hook) must be rewritten or it will actively fight the new policy.
+
+**Neutral:** `task pr-prep:full` retains the flock and the full 9-step body as an opt-in path; the `holomush-qj5v1` result-file contract is extended with `lane=fast`, not bypassed.

--- a/docs/superpowers/plans/2026-05-25-tier-split-quality-gates.md
+++ b/docs/superpowers/plans/2026-05-25-tier-split-quality-gates.md
@@ -1,0 +1,1167 @@
+# Tier-Split Quality Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Integration Test` + `E2E Test` required CI checks via a quarantine-then-promote mechanism, and shrink the mandatory local `task pr-prep` gate to the fast deterministic tier.
+
+**Architecture:** A `quarantinetest` env-gate helper + a Playwright tag let known-flaky specs self-exclude from gating CI runs; a `test/quarantine.yaml` registry plus a bijection meta-test keep the set governed and shrinking. CI's existing `Integration Test`/`E2E Test` jobs run the quarantine-excluded set (names unchanged → check identity preserved); `nightly-soak` runs the quarantined set for a health signal. `task pr-prep` splits into a fast mandatory lane (no Docker/flock) and an opt-in `pr-prep:full`. The `protect-main` ruleset gains the two required contexts **last**, after all mechanism + tooling lands.
+
+**Tech Stack:** Go (`testing`, table-driven + `test/meta` regex meta-tests), Ginkgo (`Skip`), Playwright (`tag` + `--grep-invert`), go-task `Taskfile.yaml`, GitHub Actions, `golangci-lint` depguard, `bd`, jj.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md` · **Design bead:** `holomush-b4myw`
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `internal/testsupport/quarantinetest/quarantinetest.go` | env-gate helper: `Enabled()`, `Skip(t, bead)` | 1 |
+| `internal/testsupport/quarantinetest/quarantinetest_test.go` | unit test for the helper (INV-1 Go proof) | 1 |
+| `.golangci.yaml` | new depguard deny entry for `quarantinetest` | 2 |
+| `test/meta/depguard_config_test.go` | extend to assert the new deny entry (INV-2-adjacent) | 2 |
+| `test/quarantine.yaml` | the quarantine registry (ledger) | 3 |
+| `test/meta/quarantine_registry_test.go` | bijection meta-test: marker set == registry set (INV-2) | 3 |
+| (seed flake test files) | apply markers; register each (INV-1) | 4 |
+| `.github/workflows/ci.yaml` | `E2E Test` job excludes `@quarantine` | 5 |
+| `Taskfile.yaml` | `quarantine:audit` task; `pr-prep` fast lane + new `pr-prep:full` | 5, 7 |
+| `scripts/quarantine-audit.sh` | local/pre-`bd close` bead-liveness audit (INV-3) | 5 |
+| `.github/workflows/nightly-soak.yml` | nightly quarantine-set run + health report | 6 |
+| `test/meta/pr_prep_fast_lane_test.go` | INV-4 meta-test | 7 |
+| `.claude/agents/branch-readiness-check.md` | rewrite pr-prep-evidence criterion | 8 |
+| `.claude/commands/pr-prep.md`, `.claude/commands/landing-sequence.md` | reword for fast/full lanes | 8 |
+| `.claude/hooks/remind-pre-action-review.sh` | path-triggered int/e2e nudge | 9 |
+| `.claude/hooks/enforce-task-runner.sh` | `test:integration`→`test:int` string fix | 9 |
+| `test/meta/tooling_no_mandatory_int_test.go` | INV-6 grep-lint over `.claude/` | 9 |
+| `test/meta/ci_required_jobs_test.go` | INV-5 meta-test | 10 |
+| `CLAUDE.md`, `.claude/rules/landing-the-plane.md`, `site/docs/contributing/pr-prep.md`, `.claude/rules/testing.md`, `site/docs/contributing/quarantine.md` | docs | 10 |
+| `protect-main` ruleset (GitHub) | add 2 required contexts | 11 |
+
+---
+
+## Phase 1: Quarantine mechanism (nothing gates yet)
+
+### Task 1: `quarantinetest` env-gate helper
+
+**Files:**
+
+- Create: `internal/testsupport/quarantinetest/quarantinetest.go`
+- Test: `internal/testsupport/quarantinetest/quarantinetest_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/testsupport/quarantinetest/quarantinetest_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package quarantinetest_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnabledReflectsEnvVar(t *testing.T) {
+	t.Run("false when env unset", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "")
+		assert.False(t, quarantinetest.Enabled())
+	})
+	t.Run("true when env is 1", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "1")
+		assert.True(t, quarantinetest.Enabled())
+	})
+	t.Run("false for any other value", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "true")
+		assert.False(t, quarantinetest.Enabled())
+	})
+}
+
+func TestSkipSkipsWhenDisabled(t *testing.T) {
+	t.Setenv("HOLOMUSH_RUN_QUARANTINED", "")
+	ranPast := false
+	t.Run("subject", func(t *testing.T) {
+		quarantinetest.Skip(t, "holomush-q55b")
+		ranPast = true // unreachable when Skip fires
+	})
+	assert.False(t, ranPast, "code after Skip must not run when quarantine disabled")
+}
+
+func TestSkipRunsWhenEnabled(t *testing.T) {
+	t.Setenv("HOLOMUSH_RUN_QUARANTINED", "1")
+	ranPast := false
+	t.Run("subject", func(t *testing.T) {
+		quarantinetest.Skip(t, "holomush-q55b")
+		ranPast = true
+	})
+	assert.True(t, ranPast, "code after Skip must run when quarantine enabled")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test -- ./internal/testsupport/quarantinetest/`
+Expected: FAIL — `package quarantinetest is not in std` / undefined `quarantinetest.Enabled`.
+
+- [ ] **Step 3: Write the helper**
+
+Create `internal/testsupport/quarantinetest/quarantinetest.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package quarantinetest gates known-flaky integration/E2E specs. A spec
+// marked with Skip self-skips in gating runs (env unset) and runs in the
+// nightly lane (HOLOMUSH_RUN_QUARANTINED=1). Every Skip MUST cite an open
+// bead and have a matching row in test/quarantine.yaml (enforced by the
+// bijection meta-test in test/meta). Production code MUST NOT import this
+// package (depguard-enforced). See
+// docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md.
+package quarantinetest
+
+import (
+	"os"
+	"testing"
+)
+
+// EnvVar toggles whether quarantined specs run. Set to "1" in the nightly
+// lane; unset everywhere else (so quarantined specs self-skip in gating CI).
+const EnvVar = "HOLOMUSH_RUN_QUARANTINED"
+
+// Enabled reports whether quarantined specs should run.
+func Enabled() bool { return os.Getenv(EnvVar) == "1" }
+
+// Skip skips the test as quarantined unless Enabled(). bead MUST be the
+// tracking bead id (e.g. "holomush-q55b") and MUST appear in
+// test/quarantine.yaml.
+func Skip(t *testing.T, bead string) {
+	t.Helper()
+	if !Enabled() {
+		t.Skipf("quarantined: %s (set %s=1 to run)", bead, EnvVar)
+	}
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `task test -- ./internal/testsupport/quarantinetest/`
+Expected: PASS (all three functions).
+
+- [ ] **Step 5: Lint**
+
+Run: `task lint:go`
+Expected: clean (no wrapcheck/sloglint issues; pure helper).
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "test(quarantine): add quarantinetest env-gate helper (holomush-b4myw)"
+```
+
+---
+
+### Task 2: depguard deny entry for `quarantinetest`
+
+**Files:**
+
+- Modify: `.golangci.yaml` (depguard `deny` list, currently `.golangci.yaml:148-152`)
+- Test: `test/meta/depguard_config_test.go:24-30` (extend the package loop)
+
+- [ ] **Step 1: Extend the meta-test (failing first)**
+
+In `test/meta/depguard_config_test.go`, add the new package to the loop in `TestDepguardTestOnlyConstructRulesPresent`:
+
+```go
+	for _, pkg := range []string{
+		"github.com/holomush/holomush/internal/eventbus/eventbustest",
+		"github.com/holomush/holomush/internal/core/coretest",
+		"github.com/holomush/holomush/internal/testsupport/quarantinetest",
+	} {
+		require.Contains(t, cfg, pkg,
+			"depguard deny rule for %q missing from .golangci.yaml", pkg)
+	}
+```
+
+- [ ] **Step 2: Run the meta-test to verify it fails**
+
+Run: `task test -- ./test/meta/ -run TestDepguardTestOnlyConstructRulesPresent`
+Expected: FAIL — config does not contain `.../quarantinetest`.
+
+- [ ] **Step 3: Add the deny entry**
+
+In `.golangci.yaml`, append to the `deny:` list under `no-test-only-constructs-in-production` (after the `coretest` entry at line 152):
+
+```yaml
+            - pkg: github.com/holomush/holomush/internal/testsupport/quarantinetest
+              desc: "quarantine skip helper; production code MUST NOT import it (holomush-b4myw)"
+```
+
+(The `files:` exclusion already lists `!**/internal/testsupport/**`, so the helper package itself is exempt from the rule — only production importers are denied.)
+
+- [ ] **Step 4: Run the meta-test to verify it passes**
+
+Run: `task test -- ./test/meta/ -run TestDepguardTestOnlyConstructRulesPresent`
+Expected: PASS.
+
+- [ ] **Step 5: Verify depguard actually fires (manual probe, then revert)**
+
+Add a temporary USED import to a production file (NOT a blank import — `revive`'s blank-imports rule fires first and masks depguard; per `holomush-1eps2` lesson). In `internal/core/engine.go` add at package scope: `var _ = quarantinetest.Enabled` with the import, then:
+
+Run: `task lint:go`
+Expected: FAIL — depguard reports `quarantinetest` import denied in production.
+Then **revert** the probe edit and re-run `task lint:go` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "lint(quarantine): deny quarantinetest import from production via depguard (holomush-b4myw)"
+```
+
+---
+
+### Task 3: registry + bijection meta-test
+
+**Files:**
+
+- Create: `test/quarantine.yaml`
+- Create: `test/meta/quarantine_registry_test.go`
+
+- [ ] **Step 1: Create an empty-but-valid registry**
+
+Create `test/quarantine.yaml`:
+
+```yaml
+# Quarantine registry — known-flaky integration/E2E specs.
+#
+# Each entry MUST reference an open/in-progress bead and have a matching
+# in-code marker (quarantinetest.Skip / Ginkgo Skip / Playwright @quarantine
+# tag). The bijection meta-test (test/meta/quarantine_registry_test.go)
+# fails the build if a marker lacks a row or a row lacks a marker.
+# `task quarantine:audit` (run where bd is reachable) flags rows whose bead
+# is closed. See docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md.
+#
+# entries: list of { id, kind (go|ginkgo|playwright), bead, since, reason }
+entries: []
+```
+
+- [ ] **Step 2: Write the bijection meta-test (failing)**
+
+Create `test/meta/quarantine_registry_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// beadRE matches a holomush bead id wherever it appears (registry rows or
+// in-code markers).
+var beadRE = regexp.MustCompile(`holomush-[a-z0-9.]+`)
+
+// registryBeadRE pulls the bead id from a `bead:` key line in the registry.
+var registryBeadRE = regexp.MustCompile(`(?m)^\s*bead:\s*(holomush-[a-z0-9.]+)`)
+
+// markerLineRE matches an in-code quarantine marker line and is used to scope
+// bead extraction to lines that actually mark a spec quarantined:
+//   - Go:        quarantinetest.Skip(t, "holomush-xxxx")
+//   - Ginkgo:    Skip("quarantined: holomush-xxxx")  (or Label("quarantine", "holomush-xxxx"))
+//   - Playwright '@quarantine' tag line carries an adjacent '@holomush-xxxx' tag
+var markerLineRE = regexp.MustCompile(`quarantinetest\.Skip\(|quarantined:|@quarantine|Label\("quarantine"`)
+
+// TestQuarantineRegistryBijection enforces INV-2: every in-code quarantine
+// marker maps to exactly one test/quarantine.yaml row and vice versa.
+func TestQuarantineRegistryBijection(t *testing.T) {
+	root := findRepoRoot(t)
+
+	registry := registryBeads(t, root)
+	markers := markerBeads(t, root)
+
+	sort.Strings(registry)
+	sort.Strings(markers)
+
+	require.Equal(t, registry, markers,
+		"quarantine marker set and test/quarantine.yaml must be identical "+
+			"(registry=%v markers=%v)", registry, markers)
+}
+
+func registryBeads(t *testing.T, root string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "test", "quarantine.yaml"))
+	require.NoError(t, err, "read test/quarantine.yaml")
+	out := newQuarantineBeadSet()
+	for _, m := range registryBeadRE.FindAllStringSubmatch(string(data), -1) {
+		out.add(m[1])
+	}
+	return out.slice()
+}
+
+func markerBeads(t *testing.T, root string) []string {
+	t.Helper()
+	out := newQuarantineBeadSet()
+	rootFS, err := os.OpenRoot(root)
+	require.NoError(t, err, "open repo root")
+	defer func() { _ = rootFS.Close() }()
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		// Scan Go test files and Playwright specs only.
+		isGoTest := strings.HasSuffix(name, "_test.go")
+		isSpec := strings.HasSuffix(name, ".spec.ts")
+		if !isGoTest && !isSpec {
+			return nil
+		}
+		// Never count this meta-test's own regex literals as markers.
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == filepath.Join("test", "meta", "quarantine_registry_test.go") {
+			return nil
+		}
+		f, openErr := rootFS.Open(rel)
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		_ = f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !markerLineRE.MatchString(line) {
+				continue
+			}
+			for _, b := range beadRE.FindAllString(line, -1) {
+				out.add(b)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err, "walk repo for markers")
+	return out.slice()
+}
+
+// quarantineBeadSet is a tiny string set used to collect bead ids without duplicates.
+type quarantineBeadSet struct{ m map[string]struct{} }
+
+func newQuarantineBeadSet() *quarantineBeadSet { return &quarantineBeadSet{m: map[string]struct{}{}} }
+func (s *quarantineBeadSet) add(v string)      { s.m[v] = struct{}{} }
+func (s *quarantineBeadSet) slice() []string {
+	out := make([]string, 0, len(s.m))
+	for k := range s.m {
+		out = append(out, k)
+	}
+	return out
+}
+```
+
+- [ ] **Step 3: Run the meta-test to verify it passes on the empty registry**
+
+Run: `task test -- ./test/meta/ -run TestQuarantineRegistryBijection`
+Expected: PASS (empty registry, zero markers — both sets empty and equal).
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "test(quarantine): registry + bijection meta-test (INV-2) (holomush-b4myw)"
+```
+
+---
+
+### Task 4: apply quarantine markers to the seed flakes
+
+**Files (verified):**
+
+- Modify: `internal/eventbus/audit/projection_test.go:207` (`TestProjectionResumesAfterRestart` — `q55b`/`5zpf`), `:132` (`TestProjectionDrainsPublishedMessageToAuditTable` — `1nl7`)
+- Modify: `web/e2e/terminal.spec.ts` (`0jzs` reconnect/session)
+- Modify: `test/quarantine.yaml`
+
+**Files (re-derive at execution — `rg`/`bd show` did not pin these by their bead-title strings; per spec §9 the set is re-derived from `bd`):** `holomush-7b9n` (`eventbus_e2e` Ginkgo, gates in `Integration Test`), `holomush-tmrv` (`test/integration/crypto/` Ginkgo/Go), `holomush-pqzv` (`TestMigrator_ConcurrentUp`), `holomush-h9fp` (telnet disconnect E2E).
+
+- [ ] **Step 1: Mark the audit flakes (Go env-gate — concrete example)**
+
+In `internal/eventbus/audit/projection_test.go`, add the import (the file is `package audit_test`, `//go:build integration`):
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
+)
+```
+
+As the first statement inside `TestProjectionResumesAfterRestart` (line 207) and `TestProjectionDrainsPublishedMessageToAuditTable` (line 132):
+
+```go
+func TestProjectionResumesAfterRestart(t *testing.T) {
+	quarantinetest.Skip(t, "holomush-q55b")
+	// ... existing body ...
+}
+```
+
+`holomush-5zpf` is a duplicate report of `q55b` (same spec, same race). Close it as a dup rather than registering a second row for one marker:
+
+```bash
+bd close holomush-5zpf --reason "duplicate of holomush-q55b (same spec TestProjectionResumesAfterRestart); tracked there"
+```
+
+The seed-list is therefore **7** registry rows, not 8.
+
+```go
+func TestProjectionDrainsPublishedMessageToAuditTable(t *testing.T) {
+	quarantinetest.Skip(t, "holomush-1nl7")
+	// ... existing body ...
+}
+```
+
+- [ ] **Step 2: Mark the remaining Go integration flakes**
+
+For `holomush-7b9n`, `holomush-tmrv`, `holomush-pqzv`: run `bd show <bead>` to read the spec identity, then locate it:
+
+```bash
+bd show holomush-pqzv   # confirms TestMigrator_ConcurrentUp
+rg -n "func TestMigrator_ConcurrentUp" --type go
+```
+
+Apply the matching marker:
+
+- **Plain-`testing.T`** (e.g. `pqzv`, `tmrv` if Go test funcs): `quarantinetest.Skip(t, "holomush-pqzv")` as the first statement (add the import).
+- **Ginkgo** (e.g. `7b9n` in `test/integration/eventbus_e2e/`): inside the `It(...)` block, first line:
+
+```go
+It("...", func() {
+	if !quarantinetest.Enabled() {
+		Skip("quarantined: holomush-7b9n")
+	}
+	// ... existing body ...
+})
+```
+
+- [ ] **Step 3: Mark the Playwright flakes (tag — concrete example)**
+
+In `web/e2e/terminal.spec.ts`, add the `@quarantine` tag plus the bead tag to the flaky test's options (locate the specific `test(...)` from `bd show holomush-0jzs`):
+
+```ts
+test('reconnects after a dropped session', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ page }) => {
+	// ... existing body ...
+});
+```
+
+Repeat for `holomush-h9fp` once its spec file is located (`bd show holomush-h9fp` → `rg` in `web/e2e`).
+
+- [ ] **Step 4: Populate the registry**
+
+In `test/quarantine.yaml`, replace `entries: []` with one row per marked spec:
+
+```yaml
+entries:
+  - id: TestProjectionResumesAfterRestart
+    kind: go
+    bead: holomush-q55b
+    since: 2026-05-25
+    reason: consumer-info eventual-consistency race on restart (5zpf closed as dup)
+  - id: TestProjectionDrainsPublishedMessageToAuditTable
+    kind: go
+    bead: holomush-1nl7
+    since: 2026-05-25
+    reason: AwaitDrained cold-start race
+  - id: eventbus_e2e F-E12 chain verification
+    kind: ginkgo
+    bead: holomush-7b9n
+    since: 2026-05-25
+    reason: operator_read_completed audit row times out under load
+  - id: crypto integration suite startup
+    kind: go
+    bead: holomush-tmrv
+    since: 2026-05-25
+    reason: Docker testcontainer startup timeout under load
+  - id: TestMigrator_ConcurrentUp
+    kind: go
+    bead: holomush-pqzv
+    since: 2026-05-25
+    reason: docker port-map timeout
+  - id: telnet disconnect via quit
+    kind: playwright
+    bead: holomush-h9fp
+    since: 2026-05-25
+    reason: flaky telnet disconnect E2E
+  - id: terminal reconnect/session
+    kind: playwright
+    bead: holomush-0jzs
+    since: 2026-05-25
+    reason: flaky terminal.spec.ts reconnect/session
+```
+
+> `holomush-5zpf` was closed as a duplicate of `q55b` in Step 1, so it has **no** marker and **no** registry row. The bijection set is exactly the 7 beads marked in the test files = the 7 `bead:` rows here. Do **not** add a `5zpf` marker or a `5zpf` comment to the q55b marker line — `markerBeads` scans every `holomush-*` token on a marker line, so a stray `holomush-5zpf` in a comment would break the bijection (markers=8 vs registry=7).
+
+- [ ] **Step 5: Verify bijection + gating-skip behavior**
+
+```bash
+task test -- ./test/meta/ -run TestQuarantineRegistryBijection
+```
+
+Expected: PASS (marker bead set == registry bead set).
+
+```bash
+task test:int -- ./internal/eventbus/audit/
+```
+
+Expected: PASS, with `TestProjectionResumesAfterRestart` and `TestProjectionDrainsPublishedMessageToAuditTable` reported **SKIP** (quarantined).
+
+```bash
+HOLOMUSH_RUN_QUARANTINED=1 task test:int -- ./internal/eventbus/audit/
+```
+
+Expected: the two specs now RUN (may flake — that's expected, this is the nightly behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "test(quarantine): quarantine 7 known int/e2e flakes + register (holomush-b4myw)"
+```
+
+---
+
+## Phase 2: CI wiring
+
+### Task 5: E2E gating exclusion + `quarantine:audit` task + audit script
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yaml:235` (E2E Test job run step)
+- Create: `scripts/quarantine-audit.sh`
+- Modify: `Taskfile.yaml` (add `quarantine:audit` task)
+
+- [ ] **Step 1: Exclude `@quarantine` from the gating E2E job**
+
+In `.github/workflows/ci.yaml`, change the E2E Test job's run step (line 235) from:
+
+```yaml
+        run: task test:e2e:cover
+```
+
+to:
+
+```yaml
+        run: task test:e2e:cover -- --grep-invert @quarantine
+```
+
+(The `Integration Test` job at line 185 needs **no change** — `HOLOMUSH_RUN_QUARANTINED` is unset there, so quarantined Go specs self-skip via the helper.)
+
+- [ ] **Step 2: Write the audit script**
+
+Create `scripts/quarantine-audit.sh`:
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Fails if any bead referenced by test/quarantine.yaml is closed (fix landed
+# but the spec was never un-quarantined). Run locally / before `bd close`;
+# requires `bd` on PATH with a reachable beads DB. INV-3.
+set -euo pipefail
+
+REG="test/quarantine.yaml"
+[ -f "$REG" ] || { echo "no $REG; nothing to audit"; exit 0; }
+
+if ! command -v bd >/dev/null 2>&1; then
+  echo "quarantine:audit: bd not on PATH — skipping (run where bd is reachable)" >&2
+  exit 0
+fi
+
+rc=0
+# Process substitution (not a pipe) keeps the loop in the MAIN shell so that
+# rc mutations survive — a `... | while read` loop runs in a subshell and
+# `exit "$rc"` would always be 0 (the audit would be a silent no-op).
+while read -r bead; do
+  [ -n "$bead" ] || continue
+  status=$(bd show "$bead" --json 2>/dev/null | jq -r '.[0].status // "unknown"')
+  if [ "$status" = "closed" ]; then
+    echo "QUARANTINE AUDIT: $bead is closed but still quarantined — un-quarantine it." >&2
+    rc=1
+  fi
+done < <(grep -oE 'bead:[[:space:]]*holomush-[a-z0-9.]+' "$REG" | awk '{print $2}' | sort -u)
+exit "$rc"
+```
+
+Make it executable: `chmod +x scripts/quarantine-audit.sh`.
+
+- [ ] **Step 3: Add the `quarantine:audit` task**
+
+In `Taskfile.yaml`, add (near the other `test:*` tasks):
+
+```yaml
+  quarantine:audit:
+    desc: Fail if any quarantined spec's bead is closed (needs bd; run locally / pre-bd-close). INV-3.
+    cmds:
+      - bash scripts/quarantine-audit.sh
+```
+
+- [ ] **Step 4: Verify the audit passes (all seed beads open)**
+
+Run: `task quarantine:audit`
+Expected: exit 0 (all 7 beads open). Temporarily edit `test/quarantine.yaml` to reference a known-closed bead (e.g. `holomush-1eps2`) → expect a non-zero "is closed but still quarantined" error; then revert.
+
+- [ ] **Step 5: Lint the workflow + script**
+
+Run: `task lint:actions` and `task lint` (shellcheck runs on scripts via lint).
+Expected: clean. (Note: actionlint+shellcheck on workflow `run:` blocks is CI-only for some rules — keep the run-step change a single token.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "ci(quarantine): exclude @quarantine from gating E2E; add quarantine:audit (holomush-b4myw)"
+```
+
+---
+
+### Task 6: nightly quarantine run + health report
+
+**Files:**
+
+- Modify: `.github/workflows/nightly-soak.yml` (add a `quarantine` job)
+
+- [ ] **Step 1: Add the quarantine job**
+
+In `.github/workflows/nightly-soak.yml`, add a second job after `soak` (mirror its setup steps):
+
+```yaml
+  quarantine:
+    name: Quarantine Health
+    runs-on: namespace-profile-linux-amd64-4x8
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Cache Go modules and build
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          cache: go
+      - name: Install Task
+        uses: ./.github/actions/install-task
+      # Run the quarantined Go specs (health signal only; never gates merge).
+      # continue-on-error: known-flaky by definition — a red here is expected
+      # and must not fail the nightly workflow.
+      - name: Run quarantined integration specs
+        continue-on-error: true
+        env:
+          HOLOMUSH_RUN_QUARANTINED: "1"
+        run: task test:int
+      - name: Run quarantined E2E specs
+        continue-on-error: true
+        run: task test:e2e:cover -- --grep @quarantine
+```
+
+> Rationale for `continue-on-error`: per the §3.3 design the nightly run is a **health report**, not a gate. A quarantined spec that now passes N consecutive nights is an un-quarantine candidate (read from the job's logs/annotations). The bead-closure audit (`task quarantine:audit`, Task 5) runs locally where `bd` is reachable — the spec's open-item is resolved in favor of **not** provisioning `bd` on the ephemeral runner (the Dolt shared-server isn't reachable from CI; the health signal needs no `bd`).
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `task lint:actions`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "ci(quarantine): nightly quarantine-set health run (holomush-b4myw)"
+```
+
+---
+
+## Phase 3: Local gate shrink + tooling + docs
+
+### Task 7: split `pr-prep` into fast lane + `pr-prep:full`
+
+**Files:**
+
+- Modify: `Taskfile.yaml:718-799` (`pr-prep`), and add `pr-prep:full`
+- Create: `test/meta/pr_prep_fast_lane_test.go`
+
+- [ ] **Step 1: Write the INV-4 meta-test (failing)**
+
+Create `test/meta/pr_prep_fast_lane_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// taskBlock returns the Taskfile body of `<name>:` up to the next 2-space task key.
+func taskBlock(t *testing.T, tf, name string) string {
+	t.Helper()
+	loc := regexp.MustCompile(`(?m)^  ` + regexp.QuoteMeta(name) + `:[ \t]*$`).FindStringIndex(tf)
+	require.NotNil(t, loc, "%s target not found in Taskfile.yaml", name)
+	after := tf[loc[1]:]
+	if next := regexp.MustCompile(`(?m)^  \S`).FindStringIndex(after); next != nil {
+		return after[:next[0]]
+	}
+	return after
+}
+
+// TestPrPrepFastLaneExcludesHeavyTiers enforces INV-4: the mandatory pr-prep
+// (non-full) lane must not run test:int/test:e2e and must not flock; the
+// heavy tiers live only in pr-prep:full.
+func TestPrPrepFastLaneExcludesHeavyTiers(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "Taskfile.yaml"))
+	require.NoError(t, err, "read Taskfile.yaml")
+	tf := string(data)
+
+	fast := taskBlock(t, tf, "pr-prep")
+	require.NotContains(t, fast, "test:int", "pr-prep (fast) must not run integration tests (INV-4)")
+	require.NotContains(t, fast, "test:e2e", "pr-prep (fast) must not run E2E tests (INV-4)")
+	require.NotContains(t, fast, "flock", "pr-prep (fast) must not acquire the flock (INV-4)")
+
+	full := taskBlock(t, tf, "pr-prep:full")
+	require.Contains(t, full, "flock", "pr-prep:full must keep the flock")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- ./test/meta/ -run TestPrPrepFastLaneExcludesHeavyTiers`
+Expected: FAIL — current `pr-prep` contains `flock`; `pr-prep:full` not found.
+
+- [ ] **Step 3: Restructure the Taskfile**
+
+Rename the current `pr-prep:run` body's heavy tail into `pr-prep:full`, and make `pr-prep` the fast lane. Concretely:
+
+(a) Rename the existing `pr-prep:` task (the flock wrapper, `:718-799`) to `pr-prep:full:` — keep its body verbatim (docs detection, result-file `lane=full`/`docs`, flock, `pr-prep:run`). It remains the opt-in full gate.
+
+(b) Add a new `pr-prep:` fast lane that writes a `lane=fast` result file and runs only the deterministic tier:
+
+```yaml
+  pr-prep:
+    desc: Fast pre-push gate (schema/license/lint/fmt/unit/build/bats; no Docker, no flock). Mandatory before push. Use 'pr-prep:full' for int+e2e.
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          LOCK_DIR="${TMPDIR:-/tmp}/holomush-pr-prep"
+          RUN_DIR="$LOCK_DIR/runs"
+          mkdir -p "$RUN_DIR"
+          RESULT="$RUN_DIR/$(date -u +%Y%m%dT%H%M%SZ)-$$.result"
+          printf '▸ pr-prep result: %s\n' "$RESULT"
+          write_result() {
+            printf 'status=%s\nlane=%s\nexit=%s\nfinished_at=%s\n' \
+              "$1" "$2" "$3" "$(date -u +%FT%TZ)" > "$RESULT"
+          }
+          # Docs-only diffs still delegate to the docs lane.
+          if [ "${HOLOMUSH_PR_PREP_FORCE_FULL:-}" = "1" ]; then
+            exec task pr-prep:full
+          fi
+          timeout 5 git fetch -q origin main 2>/dev/null || true
+          CHANGED=$(timeout 5 git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          if [ -n "$CHANGED" ]; then
+            DOCS_REGEX=$(bash scripts/docs-paths-regex.sh)
+            if ! printf '%s\n' "$CHANGED" | grep -vE "$DOCS_REGEX" >/dev/null; then
+              echo "▸ docs-only diff detected; running pr-prep:docs"
+              drc=0; task pr-prep:docs || drc=$?
+              if [ "$drc" -eq 0 ]; then write_result pass docs 0; else write_result fail docs "$drc"; fi
+              exit "$drc"
+            fi
+          fi
+          rc=0; task pr-prep:fast:run || rc=$?
+          if [ "$rc" -eq 0 ]; then write_result pass fast 0; else write_result fail fast "$rc"; fi
+          exit "$rc"
+
+  pr-prep:fast:run:
+    desc: Inner body of the fast lane (no result file; called by pr-prep).
+    cmds:
+      - echo "▸ Running bats shell tests..."
+      - task: test:bats
+      - echo "▸ Verifying schema is current..."
+      - cmd: |
+          SCHEMA=schemas/plugin.schema.json
+          BEFORE=$(sha256sum "$SCHEMA" | cut -d' ' -f1)
+          go generate ./internal/plugin/
+          AFTER=$(sha256sum "$SCHEMA" | cut -d' ' -f1)
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "ERROR: Schema out of sync with Go types. Run 'task generate:schema' and commit."
+            exit 1
+          fi
+      - echo "▸ Checking license headers..."
+      - task: license:check
+      - echo "▸ Building binary plugins..."
+      - task: plugin:build-all
+      - echo "▸ Running linters..."
+      - task: lint
+      - echo "▸ Checking formatting..."
+      - task: fmt:check
+      - echo "▸ Running unit tests..."
+      - task: test
+      - echo "▸ Building..."
+      - task: build
+      - echo "✓ Fast PR checks passed (run 'task pr-prep:full' for integration + E2E)."
+```
+
+(The `HOLOMUSH_PR_PREP_FORCE_FULL=1` env var now routes fast→full, preserving the existing escape hatch.)
+
+- [ ] **Step 4: Run the meta-test + a real fast run**
+
+Run: `task test -- ./test/meta/ -run TestPrPrepFastLaneExcludesHeavyTiers`
+Expected: PASS.
+
+Run: `task pr-prep`
+Expected: runs bats→schema→license→plugins→lint→fmt→unit→build, prints `✓ Fast PR checks passed`, writes a `lane=fast` result file. No Docker, no flock-contention message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "build(pr-prep): fast mandatory lane + opt-in pr-prep:full (INV-4) (holomush-b4myw)"
+```
+
+---
+
+### Task 8: rewrite the readiness agent + pr-prep commands
+
+**Files:**
+
+- Modify: `.claude/agents/branch-readiness-check.md` (`### 4. pr-prep evidence` + `### 5`/`Do NOT run` mentions)
+- Modify: `.claude/commands/pr-prep.md`
+- Modify: `.claude/commands/landing-sequence.md:24`
+
+- [ ] **Step 1: Rewrite `### 4. pr-prep evidence`**
+
+Replace the `### 4. pr-prep evidence` section in `.claude/agents/branch-readiness-check.md` with:
+
+```markdown
+### 4. pr-prep evidence
+
+- Search recent shell history / scrollback for `task pr-prep` (the fast lane) output / result file. If you can't find evidence the fast gate ran green, NOT READY — the fast `task pr-prep` (schema/license/lint/fmt/unit/build) MUST run before push.
+- **Integration / E2E are CI-authoritative, not a local READY gate.** They run as required checks (`Integration Test`, `E2E Test`) in CI, which has not run at pre-push time. So do NOT require local `task test:int`/`task test:e2e` evidence. If the diff touches the int/e2e surface (`test/integration/**`, `web/e2e/**`, integration-tagged packages), targeted `task test:int -- ./<domain>` or `task pr-prep:full` is RECOMMENDED but not blocking.
+- If the fast pr-prep was run and failed, NOT READY.
+- For `.claude/` or doc-only changes, the docs lane runs automatically AND `task lint:docs-symmetry` MUST pass when `CLAUDE.md` or `AGENTS.md` were touched.
+```
+
+- [ ] **Step 2: Rewrite `.claude/commands/pr-prep.md`**
+
+Replace the body to describe the lane split: the fast mandatory lane (schema/license/lint/fmt/unit/build) is the default `task pr-prep`; `task pr-prep:full` runs the full int+E2E gate behind the flock; int/E2E are CI-required. Keep the April-2026 "no partial-and-claim-green" lesson but scope it to whichever lane is run. (Full replacement text — write the whole file, no placeholders: front-matter `description:` updated to "Run the appropriate pr-prep lane (fast by default; full for int+e2e) and surface the first failure clearly"; Procedure section documents `task pr-prep` fast + `task pr-prep:full` + reading the `lane=` result file.)
+
+- [ ] **Step 3: Fix `landing-sequence.md:24`**
+
+In `.claude/commands/landing-sequence.md`, replace the pr-prep gate bullet (line 24) with:
+
+```markdown
+   - MUST run the fast `task pr-prep` (schema + license + lint + fmt + unit + build) green before push. Integration + E2E are required CI checks (`Integration Test`, `E2E Test`) — they gate the PR in CI, not locally. If you touched `test/integration/**`, `web/e2e/**`, or integration-tagged packages, run targeted `task test:int -- ./<domain>` or `task pr-prep:full` first (recommended, not mandatory).
+```
+
+- [ ] **Step 4: Verify no broken references**
+
+Run: `rg -n "to full completion before push" .claude/`
+Expected: zero matches (the banned phrase — INV-6, Task 9 enforces this).
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "docs(tooling): readiness agent + pr-prep commands for lane split (holomush-b4myw)"
+```
+
+---
+
+### Task 9: hook nudge + string fix + INV-6 meta-test
+
+**Files:**
+
+- Modify: `.claude/hooks/remind-pre-action-review.sh` (add path-triggered int/e2e nudge)
+- Modify: `.claude/hooks/enforce-task-runner.sh:138` (`test:integration`→`test:int`)
+- Create: `test/meta/tooling_no_mandatory_int_test.go`
+
+- [ ] **Step 1: Fix the stale task name**
+
+In `.claude/hooks/enforce-task-runner.sh` line 138, change:
+
+```bash
+            echo "Use 'task test:integration' instead of 'go test -tags=...'" >&2
+```
+
+to:
+
+```bash
+            echo "Use 'task test:int' instead of 'go test -tags=...'" >&2
+```
+
+- [ ] **Step 2: Add the path-triggered nudge**
+
+In `.claude/hooks/remind-pre-action-review.sh`, after the `abac-reviewer` block (line 71), add:
+
+```bash
+# int/e2e surface nudge: handoff intent AND the diff touches integration/E2E
+# paths. Integration+E2E are CI-required (not a local mandatory gate), but a
+# targeted local run before push catches breakage a CI round-trip slower.
+if [ "$handoff_intent" = "1" ] && printf '%s' "$changed_paths" | grep -qE '(test/integration/|web/e2e/|_integration_test\.go|\.spec\.ts)'; then
+  reminders+=("**int/e2e surface touched:** \`Integration Test\` / \`E2E Test\` are CI-required checks. A targeted local run before push (\`task test:int -- ./<domain>\` or \`task pr-prep:full\`) catches failures a CI round-trip sooner — recommended, not mandatory (CI is authoritative).")
+fi
+```
+
+- [ ] **Step 3: Write the INV-6 meta-test (failing if banned phrase present)**
+
+Create `test/meta/tooling_no_mandatory_int_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolingDoesNotMandateLocalIntE2E enforces INV-6: no .claude/ tooling
+// artifact may assert that local int/e2e is mandatory before push. The old
+// "to full completion before push" phrasing encoded exactly that rule.
+func TestToolingDoesNotMandateLocalIntE2E(t *testing.T) {
+	root := findRepoRoot(t)
+	const banned = "to full completion before push"
+	claudeDir := filepath.Join(root, ".claude")
+
+	var offenders []string
+	err := filepath.WalkDir(claudeDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip this guard's own source so its literal doesn't self-trip.
+		if strings.HasSuffix(path, "tooling_no_mandatory_int_test.go") {
+			return nil
+		}
+		f, openErr := os.Open(path) //nolint:gosec // path from controlled WalkDir under .claude/
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		_ = f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(data), banned) {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	require.NoError(t, err, "walk .claude/")
+	require.Empty(t, offenders,
+		"these .claude/ artifacts still assert the old full-gate-before-push rule (INV-6): %v", offenders)
+}
+```
+
+- [ ] **Step 4: Run the meta-test**
+
+Run: `task test -- ./test/meta/ -run TestToolingDoesNotMandateLocalIntE2E`
+Expected: PASS (Task 8 already removed the banned phrase). If FAIL, the offenders list shows which file still has it — fix it.
+
+- [ ] **Step 5: Smoke-test the hooks**
+
+```bash
+echo '{"prompt":"push this branch","cwd":"'"$PWD"'"}' | .claude/hooks/remind-pre-action-review.sh
+```
+
+Expected: emits the code-reviewer reminder (and, if the workspace diff touches int/e2e paths, the new surface nudge).
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "hooks(gates): int/e2e surface nudge + test:int string fix + INV-6 guard (holomush-b4myw)"
+```
+
+---
+
+### Task 10: docs + INV-5 meta-test
+
+**Files:**
+
+- Modify: `CLAUDE.md` (pr-prep MUST rule + Commands section), `.claude/rules/landing-the-plane.md` (step 2), `site/docs/contributing/pr-prep.md` (lane split), `.claude/rules/testing.md` (tier table + quarantine concept)
+- Create: `site/docs/contributing/quarantine.md`
+- Create: `test/meta/ci_required_jobs_test.go`
+
+- [ ] **Step 1: Write the INV-5 meta-test (failing if a job name is missing)**
+
+Create `test/meta/ci_required_jobs_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCIRequiredJobNamesPresent enforces INV-5: both the real CI workflow and
+// the docs-skip workflow must define jobs named "Integration Test" and
+// "E2E Test" so the required checks resolve (incl. on docs-only PRs).
+func TestCIRequiredJobNamesPresent(t *testing.T) {
+	root := findRepoRoot(t)
+	for _, wf := range []string{
+		filepath.Join(".github", "workflows", "ci.yaml"),
+		filepath.Join(".github", "workflows", "ci-docs-skip.yaml"),
+	} {
+		data, err := os.ReadFile(filepath.Join(root, wf))
+		require.NoError(t, err, "read %s", wf)
+		body := string(data)
+		require.Contains(t, body, "name: Integration Test", "%s missing 'Integration Test' job (INV-5)", wf)
+		require.Contains(t, body, "name: E2E Test", "%s missing 'E2E Test' job (INV-5)", wf)
+	}
+}
+```
+
+- [ ] **Step 2: Run it (passes against current files)**
+
+Run: `task test -- ./test/meta/ -run TestCIRequiredJobNamesPresent`
+Expected: PASS (both workflows already define both names).
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+In the `## Commands` section, replace the `MUST run task pr-prep before creating a PR` paragraph with the lane-split rule: the **fast** `task pr-prep` (schema/license/lint/fmt/unit/build, no Docker/flock) is mandatory before push; `task pr-prep:full` runs the full int+E2E gate (flock-serialized) and is opt-in / for when you touched that surface; **`Integration Test` + `E2E Test` are required CI checks** that protect `main`. Keep the docs-lane note.
+
+- [ ] **Step 4: Update `.claude/rules/landing-the-plane.md`**
+
+In step 2 ("Run `task pr-prep`"), change to: run the fast `task pr-prep` green before push; int+E2E gate in CI as required checks; `task pr-prep:full` recommended when the diff touches int/e2e. Preserve the April-2026 "single command, no subset" warning scoped to whichever lane runs.
+
+- [ ] **Step 5: Update `site/docs/contributing/pr-prep.md`**
+
+Add a "Lanes" section: fast (default, mandatory), full (`pr-prep:full`, flock), docs (auto). Document that int/E2E are CI-required and quarantine-excluded; cross-link `quarantine.md`. Keep the existing lock/contention content under the full lane.
+
+- [ ] **Step 6: Update `.claude/rules/testing.md`**
+
+In the Test Tiers section, add a "Quarantine" subsection: the three marker idioms (`quarantinetest.Skip` / Ginkgo `Skip` under `quarantinetest.Enabled()` / Playwright `@quarantine` tag), the `test/quarantine.yaml` registry, the bijection meta-test, `task quarantine:audit`, and that quarantined specs run only nightly + `HOLOMUSH_RUN_QUARANTINED=1`.
+
+- [ ] **Step 7: Create `site/docs/contributing/quarantine.md`**
+
+Write the contributor guide: when to quarantine (a flake with an open bead, never a real failure), how (per-stack marker + registry row), how it runs (excluded from gating CI, runs nightly + local with the env var), and how to un-quarantine (fix → remove marker + row → `task quarantine:audit` green). Follow the site voice (see `site/CLAUDE.md`).
+
+- [ ] **Step 8: Verify docs lint + symmetry**
+
+Run: `task lint:markdown` and `task lint:docs-symmetry`
+Expected: clean (CLAUDE.md/AGENTS.md symlink symmetry intact).
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj describe -m "docs(gates): lane split + quarantine guide + INV-5 guard (holomush-b4myw)"
+```
+
+---
+
+## Phase 4: Promotion (gated on Phases 1-3 merged to main)
+
+### Task 11: flip the `protect-main` ruleset
+
+**Files:** none in-repo — GitHub ruleset change via `gh api`. **Do this only after Phases 1-3 are merged to `main`.**
+
+- [ ] **Step 1: Confirm the gating jobs are green on `main`**
+
+```bash
+gh run list --workflow=ci.yaml --branch main --limit 3 --json conclusion,displayTitle
+```
+
+Expected: recent `main` runs `success`, with `Integration Test`/`E2E Test` green (quarantine-excluded).
+
+- [ ] **Step 2: Read current required contexts**
+
+```bash
+gh api repos/holomush/holomush/rulesets/11923801 \
+  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+Expected: `Build`, `Lint`, `Test`, `CodeRabbit`.
+
+- [ ] **Step 3: Add `Integration Test` + `E2E Test`**
+
+Fetch the ruleset JSON, add the two contexts to the `required_status_checks` array (each `{"context":"Integration Test"}` / `{"context":"E2E Test"}`), and PUT it back:
+
+```bash
+gh api repos/holomush/holomush/rulesets/11923801 > /tmp/ruleset.json
+# Edit /tmp/ruleset.json: append the two contexts to the required_status_checks
+# rule's parameters.required_status_checks array (keep strict_required_status_checks_policy=false).
+gh api -X PUT repos/holomush/holomush/rulesets/11923801 --input /tmp/ruleset.json
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+gh api repos/holomush/holomush/rulesets/11923801 \
+  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+Expected: now includes `Integration Test` and `E2E Test`.
+
+- [ ] **Step 5: End-to-end gate check**
+
+Open a trivial **docs-only** PR → confirm it becomes mergeable (the `ci-docs-skip` no-op `Integration Test`/`E2E Test` satisfy the required checks). Open a trivial **code** PR → confirm `Integration Test`/`E2E Test` run the quarantine-excluded suite and gate merge. Close both.
+
+- [ ] **Step 6: Close the epic**
+
+```bash
+bd close holomush-b4myw --reason "Tier-split gates shipped: int/e2e CI-required (quarantine-excluded), local pr-prep shrunk to fast lane, quarantine mechanism + governance live."
+```
+
+---
+
+## Post-implementation checklist
+
+- [ ] All meta-tests pass: `task test -- ./test/meta/`
+- [ ] Fast `task pr-prep` runs green with no Docker/flock; `task pr-prep:full` still runs the full gate.
+- [ ] `task quarantine:audit` green (all quarantined beads open).
+- [ ] `rg "to full completion before push" .claude/` → zero hits (INV-6).
+- [ ] Ruleset shows `Integration Test` + `E2E Test` required (Phase 4).
+- [ ] Quarantine burn-down tracked: each of the 7 seed beads, when fixed, removes its marker + registry row (bijection test enforces).
+<!-- adr-capture: sha256=57ee3a8e11afda1e; session=a5d87bb9; ts=2026-05-26T00:36:25Z; adrs=holomush-5k6au,holomush-5eqiv -->

--- a/docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md
+++ b/docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md
@@ -1,0 +1,225 @@
+# Tier-Split Quality Gates
+
+**Date:** 2026-05-25
+**Status:** Design — READY (design-review round 2, 2026-05-25)
+**Tracking bead:** `holomush-b4myw`
+**Related:** `Taskfile.yaml` (`pr-prep`, `pr-prep:run`, `pr-prep:docs`, `test:int`, `test:e2e`); `.github/workflows/ci.yaml`, `.github/workflows/ci-docs-skip.yaml`, `.github/workflows/nightly-soak.yml`; `protect-main` branch ruleset; `docs/superpowers/specs/2026-04-26-pr-prep-concurrency-safety-design.md` (the flock harness this reshapes the role of); `docs/superpowers/specs/2026-05-25-test-tier-taxonomy-design.md` (the tier taxonomy this builds on); `.claude/agents/branch-readiness-check.md`, `.claude/commands/pr-prep.md`, `.claude/commands/landing-sequence.md`, `.claude/hooks/remind-pre-action-review.sh`, `.claude/hooks/enforce-task-runner.sh`; `CLAUDE.md` + `.claude/rules/landing-the-plane.md` (the MUST-run-pr-prep rule); `holomush-qj5v1` (pr-prep machine-readable result — orthogonal, noted)
+
+## Problem
+
+The mandatory pre-push gate `task pr-prep` mirrors **all** CI jobs serially — schema, license, plugin builds, lint, format, unit, integration, and E2E-in-Docker — behind a machine-global `flock` that serializes every invocation on a developer machine. A full run takes 5–15 minutes.
+
+HoloMUSH is developed primarily by concurrent autonomous agent sessions, each in its own jj workspace. The pre-push gate is therefore the one place the architecture's concurrency collapses to a single lane: when N agents reach "ready to push," they contend on one lock, paying up to N × (5–15 min) serialized at the finish line. The contention tax grows with the exact thing the project optimizes for (agent parallelism). `holomush-qj5v1` exists because contention is routine enough that agents cannot distinguish "someone else holds the lock" from "my code is broken" (go-task collapses every non-zero exit to 201).
+
+Three grounded facts reframe the gate:
+
+1. **The local gate is stricter than the merge gate.** The `protect-main` ruleset requires `Build`, `Lint`, `Test`, `CodeRabbit` — **not** `Integration Test` or `E2E Test`. Those two jobs run in CI but gate nothing. So `pr-prep` enforces integration/E2E as blocking locally while the authoritative merge gate treats them as advisory. `main` is not actually protected by the tier the local gate spends the most time on.
+2. **Local is slower than CI for identical coverage, and lower-fidelity.** CI fans the same work across five parallel runners (~6–8 min wall-clock); `pr-prep` runs it serially on one contended machine (5–15 min). Local fidelity is also lower (rumdl version skew, macOS vs `linux-amd64`, local Docker vs Testcontainers Cloud), so "pr-prep green locally" was never a guarantee of "CI green." The authoritative signal is CI regardless.
+3. **The shift-right precedent already exists.** `nightly-soak.yml` was created so "`task pr-prep` stays fast" — the eventbus soak suite was already moved out of the pre-push gate onto a schedule.
+
+The decision (made by the project owner): **`main` MUST be protected by integration and E2E checks.** This spec resolves *how* to deliver that protection without (a) leaving the contention tax on every push, or (b) wedging merges on the ~8 known integration/E2E flakes that collide with the "no rerun — investigate" policy.
+
+## Goals
+
+1. **`main` MUST be protected by integration and E2E checks** — `Integration Test` and `E2E Test` become required status checks on `protect-main`.
+2. **The mandatory pre-push gate MUST shrink** to the fast, deterministic, high-local-fidelity tier (schema, license, lint, format, unit, build, bats) — no Docker, no `flock`, no integration/E2E.
+3. **Known-flaky integration/E2E specs MUST NOT block merge** while they remain unfixed — they are quarantined into a non-gating lane, not deleted or silently skipped.
+4. **Quarantine MUST burn down, not accrete** — a governed registry plus an enforced forcing-function makes the set shrink toward empty.
+5. **Process-tooling (agents, commands, hooks) MUST NOT assert the old "full pr-prep before push" rule** — the readiness agent in particular must stop demanding local integration/E2E evidence.
+6. **The promotion to required checks MUST be sequenced last**, after the quarantine mechanism, CI wiring, local-gate shrink, and tooling rewrites land — so no interval exists where required checks reference an unquarantined flake or a docs-only PR hangs on a missing check.
+
+## Non-goals
+
+1. **Fixing the flakes themselves.** Each flake has (or gets) its own bead; this spec quarantines and sequences them. Burn-down is tracked work, out of scope here.
+2. **Enabling `strict` required-status-checks** (force-rebase-to-main before merge). The ruleset stays non-strict.
+3. **Parallelizing `pr-prep:full`.** The `flock` harness stays on the opt-in full lane; collisions there are rare by construction. YAGNI.
+4. **Reworking the `holomush-qj5v1` result-file mechanism** (merged in #4270). The lane split preserves and extends its contract (see §5 "Result-file contract") by adding a `lane=fast` value; it does not redesign the result file, the lock harness, or the contention semantics.
+5. **Touching the reviewer gates** (`code-reviewer` / `crypto-reviewer` / `abac-reviewer`). They are orthogonal to the test-gate tier-split and stand unchanged.
+6. **Cross-stack quarantine of unit-tier flakes.** Unit races (e.g. `cizj`, `tnxo`, `tvvp`) live under the already-required `Test` job and are out of scope; this spec governs the integration/E2E tier only.
+
+## Design
+
+### 1. The model — gate by (tier × authority)
+
+The governing principle: **a check blocks at the cheapest point where its signal is trustworthy and restarting is cheap.** Cheap + deterministic + high-local-fidelity checks block everywhere (local and CI). Slow + Docker-bound + contended + lower-local-fidelity checks are CI-authoritative and opt-in locally.
+
+| Tier | Mandatory local (`pr-prep`) | Opt-in / targeted local | CI authority |
+| --- | --- | --- | --- |
+| schema, license, lint, fmt, unit, build, bats | runs (~2–3 min, no Docker, no `flock`) | — | required (`Lint` / `Test` / `Build`) |
+| integration (Go + Ginkgo) | not run | `task test:int -- ./<pkg>` or `task pr-prep:full` | **required** (`Integration Test`, quarantine-excluded) |
+| E2E (Playwright + `eventbus_e2e`) | not run | targeted or `task pr-prep:full` | **required** (`E2E Test`, quarantine-excluded) |
+| quarantined integration/E2E specs | not run | `HOLOMUSH_RUN_QUARANTINED=1 task …` | non-gating; runs in `nightly-soak` |
+
+The mandatory local gate becomes **exactly the set of required CI checks that are cheap and faithful locally**. Integration/E2E are the deliberate exception: required in CI (where they scale and run on faithful infrastructure), opt-in locally.
+
+### 2. Quarantine mechanism — one concept, three idiom bindings
+
+A spec is *quarantined* when it is known-flaky and tracked by an open bead. The quarantine marker is in-code and carries the bead id, so a quarantined spec is self-documenting. The concept is identical across stacks; the binding differs.
+
+**Why the Go gating mechanism is an env-gate, not a Ginkgo label-filter.** `task test:int` runs `gotestsum -- go test -tags=integration … ./...` (`Taskfile.yaml:152–162`) across both plain-`testing.T` packages (e.g. `internal/eventbus/audit`) and Ginkgo packages (`test/integration/**`). A Ginkgo `--ginkgo.label-filter` flag passed to `go test ./...` is only registered by packages that import Ginkgo — the non-Ginkgo integration packages would fail with "flag provided but not defined." So the gating exclusion for **all Go integration specs** is a single environment variable, `HOLOMUSH_RUN_QUARANTINED`, checked by the `quarantinetest` helper. No per-package test-flag plumbing; gating runs leave it unset (quarantined specs self-skip), the nightly lane sets it (they run).
+
+**2.1 Plain-Go integration** (`testing.T` under `internal/**` with `//go:build integration` — the audit/migrator flakes):
+
+```go
+func TestProjectionResumesAfterRestart(t *testing.T) {
+    quarantinetest.Skip(t, "holomush-q55b") // t.Skip unless HOLOMUSH_RUN_QUARANTINED=1
+    // ...
+}
+```
+
+**2.2 Ginkgo** (`test/integration/**`, including `test/integration/eventbus_e2e/`) — same env-gate, Ginkgo's own `Skip`:
+
+```go
+It("verifies the chain end to end", func() {
+    if !quarantinetest.Enabled() { Skip("quarantined: holomush-7b9n") }
+    // ...
+})
+```
+
+A spec **MAY** additionally carry `Label("quarantine", "holomush-7b9n")` for ginkgo-CLI reporting/filtering in nightly, but the **gating exclusion is the env-gate** above — the Label is reporting metadata, not the gate.
+
+**The `quarantinetest` helper** (`internal/testsupport/quarantinetest`) exposes `Enabled() bool` (reads `HOLOMUSH_RUN_QUARANTINED`) and `Skip(t, bead)` (wraps `t.Skip`). It is a new test-only package and **MUST be added to the depguard `deny` list** in `.golangci.yaml` alongside the existing `eventbustest` / `coretest` entries (`.golangci.yaml:148–152`) — the current rule excludes `internal/testsupport/**` files from the check but does **not** deny importing `quarantinetest` from production, so a new explicit deny entry is required.
+
+**2.3 Playwright** (`web/e2e/*.spec.ts`) — separate Node runner, no `go test` flag constraint:
+
+```ts
+test('reconnects after a dropped session', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ page }) => { /* ... */ });
+```
+
+Gating runs use `playwright test --grep-invert @quarantine`; the nightly lane uses `--grep @quarantine`. (Verified — Playwright `tag` option + `--grep` / `--grep-invert`.)
+
+### 3. Quarantine governance — registry + meta-test + nightly liveness
+
+The marker alone risks a roach-motel: specs check in and never leave. Governance has three layers.
+
+**3.1 Registry** — a tracked ledger `test/quarantine.yaml`, one row per quarantined spec:
+
+```yaml
+# Each entry MUST reference an open/in-progress bead. The meta-test (INV-2) enforces
+# marker<->row bijection; the nightly liveness check (INV-3) enforces
+# the bead is still open.
+- id: TestProjectionResumesAfterRestart   # Go test name / Ginkgo spec text / Playwright title
+  kind: go                                # go | ginkgo | playwright
+  bead: holomush-q55b
+  since: 2026-05-25
+  reason: consumer-info eventual-consistency race on restart
+```
+
+**3.2 Bijection meta-test** (`test/meta/`, alongside the existing INV-TS meta-tests from `holomush-1eps2`) — a pure Go test, no `bd` dependency, runs in `task test`. It scans the three marker idioms (file-scans `web/e2e/**` for `@quarantine` tags, `test/integration/**` for `Label("quarantine", …)`, and `internal/**` integration files for `quarantinetest.Skip`) and asserts a **bijection** with `test/quarantine.yaml`: every marker maps to exactly one row, every row maps to exactly one marker, and the row's `bead` matches the marker's bead label.
+
+**3.3 Burn-down forcing-functions.** Two layers, ordered by how hard they bind:
+
+1. **Bijection meta-test (hard, every PR).** §3.2 runs in `task test` — it fails the build if a marker lacks a registry row or vice versa. This is the always-on gate and needs no `bd`.
+2. **Nightly health report (advisory).** The nightly lane (§4) runs the quarantined set and emits a per-spec pass/fail report. A spec passing N consecutive nights is flagged an **un-quarantine candidate**.
+
+A third check — "bead closed but spec still quarantined" — requires bead status, which lives in the Dolt shared-server, **not** in the repo or on ephemeral CI runners. So it is delivered as a `task quarantine:audit` target that queries `bd` and is run **where `bd` is reachable** (developer machines; the nightly runner *iff* `bd` is provisioned there). **Open item for the plan:** whether to provision `bd` + a `.beads/redirect` on the nightly runner, or leave `quarantine:audit` as a local/pre-`bd close` convention. The spec does not assume `bd`-in-CI works; INV-3 is scoped accordingly.
+
+This keeps unit tests deterministic and network-free while still giving quarantine a forcing-function toward empty via layer 1 (hard) and layer 2 (signal).
+
+### 4. CI changes
+
+```mermaid
+flowchart TD
+    PR["PR push / code paths"] --> Gate
+    subgraph Gate["Gating CI jobs (required)"]
+        IT["Integration Test\nHOLOMUSH_RUN_QUARANTINED unset\n→ quarantined Go specs self-skip"]
+        ET["E2E Test\nplaywright --grep-invert @quarantine"]
+        Other["Lint · Test · Build · CodeRabbit"]
+    end
+    Gate -->|all green| Mergeable
+    Docs["PR push / docs-only paths"] --> Skip["ci-docs-skip.yaml\n(already emits) Lint · Test · Build · Integration Test · E2E Test no-ops"]
+    Skip -->|same check identity| Mergeable
+    Nightly["nightly-soak 06:00 UTC"] --> Q["Quarantined set\nHOLOMUSH_RUN_QUARANTINED=1 / --grep @quarantine"]
+    Q --> Rep["per-spec health report\n+ optional task quarantine:audit (where bd reachable)"]
+```
+
+- **`ci.yaml`**: the existing `Integration Test` and `E2E Test` jobs now run the **quarantine-excluded** set. For the Go `Integration Test` job, exclusion is automatic — `HOLOMUSH_RUN_QUARANTINED` is unset, so quarantined Go specs self-skip via the helper (no Taskfile/flag change to `test:int`). The `E2E Test` (Playwright) job adds `--grep-invert @quarantine`. Job names are unchanged, so the required-check identity is preserved — no rename, no ruleset churn beyond adding the two contexts.
+- **`ci-docs-skip.yaml`**: **already emits** no-op jobs named `Integration Test` (`:62`) and `E2E Test` (`:67`) alongside `Lint`/`Test`/`Build`. So the docs-only-PR hang is **already mitigated** — no change needed here; the promotion just needs these names to remain. GitHub's `(workflow_name, job_name)` check-identity rule makes the no-op satisfy the required check. The `DOCS_ONLY_PATHS` three-location sync rule (`lint:docs-paths-sync`) is unaffected.
+- **`nightly-soak.yml`**: add a job that runs the quarantined set (`HOLOMUSH_RUN_QUARANTINED=1` for Go; `--grep @quarantine` for Playwright), emits the §3.3 per-spec health report, and runs `task quarantine:audit` if `bd` is provisioned (the §3.3 open item).
+- **`protect-main` ruleset**: add `Integration Test` and `E2E Test` to the required status-check contexts. `strict` stays `false`.
+
+### 5. Local gate changes (`Taskfile.yaml`)
+
+- **`task pr-prep`** (default, mandatory) → fast tier only: schema check, license, lint, fmt, unit, build, bats. **No `test:int`, no `test:e2e`, no `flock`.** The docs-only fast lane (`pr-prep:docs`) detection is retained and unchanged.
+- **`task pr-prep:full`** → today's full 9-step body, **keeping the `flock`**. This is a **new named task** (the Taskfile today has only `pr-prep`, `pr-prep:run`, `pr-prep:docs`; `HOLOMUSH_PR_PREP_FORCE_FULL=1` merely bypasses docs-lane detection and falls through to the same locked body — it is not a task). The env var continues to work; `pr-prep:full` is the discoverable alias. The concurrency-safety harness (and its `qj5v1` result file, written with `lane=full`) remains correct and unchanged for this lane.
+- **Targeted integration/E2E** — `task test:int -- ./test/integration/<domain>` is the documented "you touched this surface" path; an equivalent targeted E2E invocation is documented for `web/e2e`.
+
+Because the fast lane runs no Docker steps, the cross-workspace E2E-compose collision the `flock` was built to prevent cannot occur on the common path — so the lock is correctly absent there and survives only where it is still needed (`pr-prep:full`).
+
+**Result-file contract (preserve `holomush-qj5v1`, merged in #4270).** `pr-prep` now writes a machine-readable result file (`status` / `lane` / `exit` / `finished_at`) at each terminal point, with `lane` ∈ {`docs`, `full`} today. The lane split **MUST extend, not bypass, this contract**: the new fast lane writes `lane=fast` with the correct `status`/`exit`, so automation (and `branch-readiness-check`) keeps a uniform signal across all three lanes. The fast lane writes its result file but acquires no `flock` (INV-4); only `full` and the contention path interact with the lock.
+
+### 6. Process-tooling surface (agents, commands, hooks)
+
+The old rule is encoded in tooling beyond `CLAUDE.md`. Each artifact is classified by required action.
+
+| Artifact | Type | Change |
+| --- | --- | --- |
+| `.claude/agents/branch-readiness-check.md` | agent | **MUST rewrite** the `### 4. pr-prep evidence` section and its mention under "Do NOT run `task pr-prep` yourself" (anchor by heading, not line number — refs drift). Mandatory evidence = **fast** `pr-prep`; integration/E2E downgraded to **SHOULD-when-you-touched-that-surface** (CI is authoritative and has not run at pre-push time, so it cannot be a local READY gate). Semantic change to a READY/NOT-READY criterion. |
+| `.claude/commands/pr-prep.md` | command | **MUST reword** for the fast (default) / `pr-prep:full` (opt-in) / docs lanes. |
+| `.claude/commands/landing-sequence.md` | command | **MUST reword** the landing flow to the fast-gate framing. |
+| `.claude/hooks/remind-pre-action-review.sh` | UserPromptSubmit hook | **SHOULD enhance**: add a path-triggered nudge — when the diff touches `test/integration/**`, `web/e2e/**`, or integration-tagged packages, remind the agent to run targeted `task test:int -- ./<domain>` or `task pr-prep:full` before push (CI now gates these as required). Mirrors the existing crypto/ABAC path-trigger pattern. |
+| `.claude/hooks/enforce-task-runner.sh` | PreToolUse hook | **Audit-only**: new shapes (`task test:int -- ./pkg`, `HOLOMUSH_RUN_QUARANTINED=1 task …`) route through `task` and are not blocked. Fix the stale `task test:integration` → `task test:int` string while there. |
+| `.claude/hooks/session-reminder.sh`, `.claude/hooks/post-push-cleanup-nudge.sh` | hooks | **No change** — orthogonal (uncommitted/unpushed/cleanup nudges). |
+| reviewer gates (code / crypto / abac) in `remind-pre-action-review.sh` | hook | **No change** — orthogonal; reviewer gates stand. |
+
+`branch-readiness-check` is the linchpin: if the local gate shrinks without rewriting this agent, every push would be flagged NOT READY for "missing pr-prep evidence" even when the new process is followed correctly — the agent would actively fight the new policy.
+
+`CLAUDE.md` and `.claude/rules/landing-the-plane.md` (the human-readable MUST-run-pr-prep rule) are also reworded; `site/docs/contributing/pr-prep.md` and `.claude/rules/testing.md` (tier table + quarantine concept) are updated, and a new `site/docs/contributing/quarantine.md` documents the marker idioms, registry, and burn-down flow.
+
+### 7. Invariants (RFC2119)
+
+Each invariant has a test; INV-1/2/4/5/6 are statically enforceable, INV-3 is nightly.
+
+- **INV-1** A spec carrying a quarantine marker in any stack **MUST NOT** execute in a gating CI job.
+- **INV-2** Every in-code quarantine marker **MUST** correspond to exactly one `test/quarantine.yaml` row whose `bead` matches the marker's bead id, and vice versa (bijection — meta-test).
+- **INV-3** Every `test/quarantine.yaml` row **MUST** reference a bead; `task quarantine:audit` (run where `bd` is reachable) **MUST** report a row whose bead is `closed` as a failure (fix-but-still-quarantined). This is a `bd`-reachable audit, not a CI-hard gate (the Dolt store is not on CI runners — see §3.3).
+- **INV-4** The mandatory `task pr-prep` (non-`full`) **MUST NOT** invoke `test:int` or `test:e2e` and **MUST NOT** acquire the `pr-prep` `flock`.
+- **INV-5** The required CI contexts **MUST** include `Integration Test` and `E2E Test`, and `ci-docs-skip.yaml` **MUST** emit jobs of those exact names so docs-only PRs satisfy them.
+- **INV-6** Process-tooling artifacts under `.claude/` (agents, commands, hooks) **MUST NOT** assert that local `test:int` / `test:e2e` is mandatory before push (grep-lint meta-test over `.claude/`).
+
+### 8. Promotion sequencing
+
+The order exists to guarantee no interval where required checks reference an unquarantined flake or a docs-only PR hangs.
+
+1. **Mechanism lands.** `quarantinetest` helper (`Enabled()` + `Skip(t, bead)`) + its depguard `deny` entry; `test/quarantine.yaml`; the §3.2 bijection meta-test; the §3.1 markers on the ~8 seed flakes. Required checks unchanged — nothing gates yet, but quarantined Go specs now self-skip in the (still-advisory) `Integration Test` job and the Playwright tag is excluded in `E2E Test`.
+2. **CI wiring lands.** The `E2E Test` job adds `--grep-invert @quarantine` (the Go `Integration Test` job needs no change — env-gate is automatic). `nightly-soak.yml` gains the quarantined-set run + health report (+ `quarantine:audit` per the §3.3 open item). `ci-docs-skip.yaml` needs **no change** — it already emits `Integration Test`/`E2E Test` no-ops.
+3. **Local-gate shrink + docs + tooling land.** `pr-prep` fast lane + new `pr-prep:full` task; `CLAUDE.md` / `landing-the-plane` rewrites; `branch-readiness-check` and the two commands rewritten; the path-triggered hook nudge; `enforce-task-runner` `test:integration`→`test:int` string fix.
+4. **Flip the ruleset.** Add `Integration Test` + `E2E Test` to required contexts. Verify a docs-only PR and a code PR both behave (docs-only satisfies via the existing no-op; code PR gates on the quarantine-excluded suite).
+
+Steps 1–3 are ordinary PR work; step 4 is a one-time ruleset edit gated on 1–3 being merged.
+
+### 9. Quarantine seed-list
+
+The integration/E2E-tier open flakes to quarantine in step 1 (each re-verified still-open and still-tier-correct at execution time):
+
+The **CI job** column is the load-bearing classifier — it dictates the marker idiom (Go env-gate vs Playwright tag) and which gating job excludes the spec. Note that `eventbus_e2e` despite its name runs under `Integration Test` (`task test:int`), **not** the Playwright `E2E Test` job.
+
+| Bead | Marker stack | CI job (gating) | Spec |
+| --- | --- | --- | --- |
+| `holomush-q55b` | Go env-gate | Integration Test | `TestProjectionResumesAfterRestart` (consumer-info race) |
+| `holomush-5zpf` | Go env-gate | Integration Test | `TestProjectionResumesAfterRestart` (duplicate report) |
+| `holomush-1nl7` | Go env-gate | Integration Test | `TestProjectionDrainsPublishedMessageToAuditTable` (AwaitDrained cold-start) |
+| `holomush-7b9n` | Go env-gate (Ginkgo) | Integration Test | `eventbus_e2e` F-E12 chain-verification `operator_read_completed` timeout |
+| `holomush-tmrv` | Go env-gate | Integration Test | crypto suite Docker testcontainer startup timeout under load |
+| `holomush-pqzv` | Go env-gate | Integration Test | `TestMigrator_ConcurrentUp` docker port-map timeout |
+| `holomush-h9fp` | Playwright tag | E2E Test | telnet disconnect/quit |
+| `holomush-0jzs` | Playwright tag | E2E Test | `terminal.spec.ts` reconnect/session |
+
+`q55b` and `5zpf` are the same underlying spec; quarantining it satisfies both. Six of the eight gate in `Integration Test`, two in `E2E Test`. The list is a starting point — execution re-derives the set from `bd` (open flake/race beads scoped to integration/E2E packages) and confirms each spec's actual CI job before tagging.
+
+### 10. Testing
+
+- **Unit / meta:** the §3.2 bijection meta-test (INV-2); an INV-4 meta-test asserting `pr-prep` (non-full) invokes neither `test:int`/`test:e2e` nor `flock` (Taskfile scan, in the spirit of `1eps2`'s `TestTaskfileIntHasNoPackageList`); an INV-6 grep-lint over `.claude/`; an INV-5 assertion that `ci.yaml` and `ci-docs-skip.yaml` both define `Integration Test` and `E2E Test` jobs.
+- **Behavioral:** a quarantined Go sample (plain + Ginkgo) proves it self-skips with `HOLOMUSH_RUN_QUARANTINED` unset and runs when set; a Playwright sample proves `--grep-invert @quarantine` excludes it and `--grep @quarantine` selects it (INV-1).
+- **Audit:** `task quarantine:audit` is exercised against a fixture registry pointing at a closed bead (expects failure) and an open bead (expects pass) — INV-3.
+- **Manual gate verification (step 4):** one docs-only PR and one code PR confirm the required-check behavior end-to-end.
+
+### 11. ADRs
+
+`capture-adrs` will extract two architecture-shaping decisions:
+
+1. **Integration/E2E are CI-authoritative-and-required, local-optional** — reshapes the merge-gate contract (what protects `main`, and what the mandatory local gate is).
+2. **Quarantine as a governed bucket** — a registry + bijection meta-test + nightly `bd`-liveness forcing-function, with three per-stack marker idioms — reshapes the test-taxonomy contract.
+
+Scheduling choices (quarantine-then-promote over fix-first; nightly lane over per-PR) are sequencing decisions and live in this spec's text, not in ADRs.
+<!-- adr-capture: sha256=a7059a2da8c14954; session=a5d87bb9; ts=2026-05-26T00:28:32Z; adrs=holomush-5k6au,holomush-5eqiv -->


### PR DESCRIPTION
Design docs for **tier-splitting the quality gates**: make `Integration Test` + `E2E Test` required CI checks via a quarantine-then-promote mechanism, and shrink the mandatory local `task pr-prep` gate to the fast deterministic tier.

Docs-only PR (no code). Implementation is tracked in bd epic `holomush-b4myw` (11 child tasks, 4 phases); this lands the canonical context so implementer subagents read spec/plan/ADRs from `main`.

## Contents

- **Spec** `docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md` — design-review READY (round 2)
- **Plan** `docs/superpowers/plans/2026-05-25-tier-split-quality-gates.md` — plan-review READY (round 2), 11 tasks
- **ADRs** — `holomush-5k6au` (integration/E2E are CI-authoritative-and-required, local-optional) and `holomush-5eqiv` (quarantine flaky specs via governed registry, not deletion), rendered under `docs/adr/` + indexed

## Key decisions

- Gate by (tier × authority): fast/deterministic checks block everywhere; slow/Docker/contended int+E2E are CI-authoritative and opt-in locally.
- Uniform `HOLOMUSH_RUN_QUARANTINED` env-gate for Go (plain + Ginkgo) + Playwright `@quarantine` tag; `test/quarantine.yaml` registry + bijection meta-test + nightly health run.
- Promotion sequenced last (ruleset flip after mechanism + CI wiring + tooling land), so no interval wedges merges or hangs docs-only PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)