### PR TITLE
docs(build): retire-lefthook + license-eye — spec, plan, ADR (holomush-gcio6)

### DIFF
--- a/docs/adr/holomush-x14mc-adopt-license-eye-markdown-licensing.md
+++ b/docs/adr/holomush-x14mc-adopt-license-eye-markdown-licensing.md
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Adopt license-eye and Extend SPDX Headers to Functional Markdown
+
+**Date:** 2026-05-25
+**Status:** Accepted
+**Decision:** holomush-x14mc
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH's license tooling was `addlicense`, scoped to code directories
+(`LICENSE_DIRS = api cmd internal pkg plugins scripts`). `addlicense` silently
+exits 0 on `.md` files — it has no comment-style mapping for markdown, so it
+adds no header and reports no gap. Consequently the project's functional
+markdown — design specs, implementation plans, ADRs, and agent-facing rules
+under `.claude/rules/` — carried no license header, even though these are
+infrastructure artifacts (increasingly consumed by automated agents as
+load-bearing input, not human-only prose).
+
+Retiring `lefthook` (`holomush-gcio6`) reworked the license-header automation
+anyway: lefthook's `license-headers` pre-commit hook was being removed, and the
+header-insertion step had to move into `task fmt`. That made it the right moment
+to decide the *tool of record* and the *coverage boundary* for SPDX headers,
+rather than bolt a second markdown-only licenser alongside `addlicense`.
+
+## Decision
+
+Replace `addlicense` with `license-eye` (Apache SkyWalking Eyes), driven by a
+root `.licenserc.yaml`, as the single tool of record for SPDX license headers.
+Extend header coverage to **functional markdown** (`docs/**`, `.claude/rules/**`,
+root `*.md`) using the `AngleBracket` comment style (`<!-- … -->`), while
+explicitly **excluding user-facing rendered content** (`plugins/**/content/**`,
+`site/docs/**` player guides) via `.licenserc.yaml` `paths-ignore`. `task fmt`
+runs `license-eye header fix`; `task license:check` / CI run `license-eye header
+check`.
+
+## Rationale
+
+- `addlicense` cannot process `.md` (silent exit 0, no header) — a different
+  tool was structurally necessary to license markdown at all.
+- `license-eye` produces byte-identical `// SPDX-…` headers for existing code
+  files (INV-5), so the migration introduces no churn on the code surface.
+- The `paths-ignore` set in `.licenserc.yaml` is the canonical, tooling-enforced
+  statement of the content-vs-infrastructure-markdown boundary; future file
+  additions inherit it automatically rather than relying on convention.
+- One declarative config + one `task fmt` / `task license:check` surface
+  eliminates the prior split between automated code headers and absent markdown
+  headers.
+
+## Alternatives Considered
+
+**Option A: Keep `addlicense`; stamp markdown with a bespoke wrapper**
+
+| Aspect     | Assessment                                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| Strengths  | No new tool dependency; familiar invocation                                                         |
+| Weaknesses | Two tools, two configs, no single exclusion boundary; bespoke wrapper needs maintenance; no md check |
+
+**Option B: `license-eye` with `.licenserc.yaml` (chosen)**
+
+| Aspect     | Assessment                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| Strengths  | One tool, one config; check + fix for code and markdown; byte-identical code headers; declarative scope |
+| Weaknesses | New Go tool dependency; `addlicense` removed from `task setup`; one-time large markdown-stamping diff    |
+
+**Option C: License ALL markdown, including `site/docs/**` and plugin content**
+
+| Aspect     | Assessment                                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| Strengths  | Maximum consistency                                                                             |
+| Weaknesses | Stamps machine-readable comments into user-facing/distributed copy (MOTD, player guides); no benefit |
+
+## Consequences
+
+**Positive:**
+
+- Specs, plans, ADRs, and agent rules carry machine-readable authorship/license
+  metadata.
+- `task fmt` and `task license:check` apply uniformly to code and functional
+  markdown.
+- The content-vs-infrastructure boundary is explicit and tooling-enforced, not
+  convention.
+
+**Negative:**
+
+- A new `license-eye` binary must be installed (`task setup`); contributors who
+  skip `task setup` see check failures until they install it.
+- The one-time stamping commit is a large mechanical diff across `docs/**` and
+  `.claude/rules/**`.
+
+**Neutral:**
+
+- `addlicense` is removed from `task setup`; no parallel-install period.
+- The `LICENSE_DIRS` Taskfile variable is superseded by `.licenserc.yaml`
+  `paths`.
+
+## References
+
+- [Retire lefthook + license-eye Migration Design — §4 (Replace addlicense), §5 (Markdown scope)](../superpowers/specs/2026-05-25-retire-lefthook-license-eye-design.md)
+- [Implementation plan — Phase 2 (Tasks 3–5)](../superpowers/plans/2026-05-25-retire-lefthook-license-eye.md)
+- Parent work: bd issue `holomush-gcio6` (lefthook retirement); related pattern ADR `holomush-u2exm`

--- a/docs/superpowers/plans/2026-05-25-retire-lefthook-license-eye.md
+++ b/docs/superpowers/plans/2026-05-25-retire-lefthook-license-eye.md
@@ -1,0 +1,651 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Retire lefthook + license-eye Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete `lefthook.yaml`; make `task pr-prep` + CI the authoritative quality gate, close the silently-no-op EBNF gate, and replace `addlicense` with `license-eye` (licensing code and functional markdown under one configurable tool).
+
+**Architecture:** No `jj fix` (it is manual-only, no edge over `task fmt`). Every gate lefthook performed already lives in CI/`pr-prep` except EBNF, which gets a new `generate:ebnf:check` task wired into both. `license-eye` (Apache SkyWalking Eyes) replaces `addlicense` via a root `.licenserc.yaml`; `task fmt` becomes the one-command local fixer.
+
+**Tech Stack:** Taskfile (go-task), GitHub Actions, bats (`scripts/tests/`), `license-eye` (`github.com/apache/skywalking-eyes/cmd/license-eye`), Go `go generate`.
+
+**Design spec:** [`docs/superpowers/specs/2026-05-25-retire-lefthook-license-eye-design.md`](../specs/2026-05-25-retire-lefthook-license-eye-design.md)
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+| --- | --- | --- |
+| `Taskfile.yaml` | Modify | `generate:ebnf:check` (new), `license:*` rewire, `fmt` += `license:add`, `setup` install swaps, `pr-prep:run` EBNF step |
+| `.github/workflows/ci.yaml` | Modify | EBNF verify step in the Lint job |
+| `.licenserc.yaml` | Create | license-eye config (license content, paths, paths-ignore, markdown language) |
+| `lefthook.yaml` | Delete | Retired |
+| `cog.toml` | Modify | Drop the lefthook commit-msg-hook comment |
+| `docs/CLAUDE.md` | Modify | Replace "Pre-commit Validation" with "Local quality checks" |
+| `CLAUDE.md` | Modify | License Headers row; remove lefthook mention |
+| `docs/specs/decisions/epic7/general/102-lefthook-markdown-autofix-intentional.md` | Modify | Mark Superseded |
+| `scripts/tests/generate-ebnf-check.bats` | Create | INV-2 (EBNF drift caught) |
+| `scripts/tests/license-eye.bats` | Create | INV-4 (fmt→check roundtrip), INV-6 (content excluded) |
+| `scripts/tests/no-lefthook-refs.bats` | Create | INV-3 (no live lefthook references) |
+| functional markdown (`docs/**`, `.claude/rules/**`, root `*.md`) | Modify | One-time SPDX stamping |
+
+---
+
+## Phase 1: Close the EBNF gate
+
+### Task 1: Add `generate:ebnf:check` task + drift test
+
+**Files:**
+
+- Modify: `Taskfile.yaml` (after `generate:ebnf:` block, `Taskfile.yaml:358-367`)
+- Create: `scripts/tests/generate-ebnf-check.bats`
+
+- [ ] **Step 1: Write the failing bats test**
+
+Create `scripts/tests/generate-ebnf-check.bats`:
+
+```bash
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+# INV-2: the EBNF gate MUST catch drift between the DSL parser and the
+# generated grammar/railroad artifacts. Regenerates for real (needs network
+# for the railroad tool), so this is a slow case by design.
+
+setup_file() {
+  if [ ! -f "scripts/tests/Taskfile.test.yaml" ]; then
+    echo "ERROR: bats must be invoked from the repo root (try 'task test:bats')." >&2
+    exit 1
+  fi
+}
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  EBNF=site/docs/reference/policy-dsl.ebnf
+  cp "$EBNF" "${BATS_TEST_TMPDIR}/orig.ebnf"
+}
+
+teardown() {
+  # generate:ebnf:check regenerates the artifact, so the tree is left clean;
+  # restore is belt-and-suspenders in case the generator was skipped.
+  cp "${BATS_TEST_TMPDIR}/orig.ebnf" "$EBNF"
+}
+
+@test "generate:ebnf:check passes when artifacts are current" {
+  run task generate:ebnf:check
+  assert_success
+}
+
+@test "generate:ebnf:check fails when the EBNF artifact has drifted" {
+  printf '\nDRIFT-MARKER\n' >> "$EBNF"
+  run task generate:ebnf:check
+  assert_failure
+  assert_output --partial "out of sync"
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test:bats 2>&1 | rg -A2 generate-ebnf-check` (or `bats scripts/tests/generate-ebnf-check.bats` from repo root)
+Expected: FAIL — `task generate:ebnf:check` does not exist yet ("task: Task 'generate:ebnf:check' does not exist").
+
+- [ ] **Step 3: Add the `generate:ebnf:check` task**
+
+In `Taskfile.yaml`, immediately after the `generate:ebnf:` block (ends at `Taskfile.yaml:367`), add:
+
+```yaml
+  generate:ebnf:check:
+    desc: Verify generated EBNF grammar + railroad diagram are current
+    cmds:
+      - |
+        set -euo pipefail
+        EBNF=site/docs/reference/policy-dsl.ebnf
+        RAIL=site/docs/reference/policy-dsl-railroad.html
+        BEFORE=$(sha256sum "$EBNF" "$RAIL" | sha256sum)
+        task generate:ebnf
+        AFTER=$(sha256sum "$EBNF" "$RAIL" | sha256sum)
+        if [ "$BEFORE" != "$AFTER" ]; then
+          echo "EBNF/railroad out of sync. Run 'task generate:ebnf' and commit." >&2
+          exit 1
+        fi
+```
+
+(Mirrors the schema-verify pattern at `Taskfile.yaml:789-798`, but sourced as a reusable task because it is called from two places — `pr-prep:run` and CI — in Task 2.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bats scripts/tests/generate-ebnf-check.bats` (from repo root)
+Expected: PASS (both cases). Note: the first run fetches `railroad@latest` via `go run`; ensure network is available.
+
+- [ ] **Step 5: Lint the Taskfile change**
+
+Run: `task lint:yaml`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "build(ebnf): add generate:ebnf:check task + drift test (INV-2) (holomush-gcio6)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 2: Wire `generate:ebnf:check` into pr-prep and CI
+
+**Files:**
+
+- Modify: `Taskfile.yaml:789-798` region (`pr-prep:run`, after the schema-verify block)
+- Modify: `.github/workflows/ci.yaml:90-98` region (Lint job, after "Verify schema is current")
+
+- [ ] **Step 1: Add the EBNF step to `pr-prep:run`**
+
+In `Taskfile.yaml`, in `pr-prep:run`, immediately after the schema-verify `cmd:` block (ends `Taskfile.yaml:798`) and before `- echo "▸ Verifying jxo8.5 bead description..."`, add:
+
+```yaml
+      - echo "▸ Verifying EBNF + railroad are current..."
+      - task: generate:ebnf:check
+```
+
+- [ ] **Step 2: Add the EBNF step to the CI Lint job**
+
+In `.github/workflows/ci.yaml`, in the Lint job, immediately after the "Verify schema is current" step (ends `ci.yaml:98`) and before "Check license headers" (`ci.yaml:100`), add:
+
+```yaml
+      - name: Verify EBNF is current
+        run: task generate:ebnf:check
+```
+
+- [ ] **Step 3: Verify pr-prep includes the gate**
+
+Run: `rg -n 'generate:ebnf:check' Taskfile.yaml .github/workflows/ci.yaml`
+Expected: three hits — the task definition, the `pr-prep:run` call, the CI step.
+
+- [ ] **Step 4: Smoke-test the gate locally**
+
+Run: `task generate:ebnf:check`
+Expected: PASS (exit 0; tree clean — `jj st` shows no changes to the EBNF artifacts).
+
+- [ ] **Step 5: Lint workflow + Taskfile**
+
+Run: `task lint:yaml && task lint:actions`
+Expected: PASS. (Note: actionlint shellcheck on `run:` blocks is CI-only; the `run:` here is a single `task` call with no shell logic, so it is safe.)
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "ci(ebnf): gate generate:ebnf:check in pr-prep + CI Lint (holomush-gcio6)
+
+Repairs the silently-no-op lefthook ebnf-sync hook (it diffed dead
+site/docs/developers/* paths; generator writes site/docs/reference/*).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Phase 2: License tooling migration (addlicense → license-eye)
+
+### Task 3: Adopt license-eye — config, task rewire, install swap
+
+**Files:**
+
+- Create: `.licenserc.yaml`
+- Modify: `Taskfile.yaml` — `license:check` (`:688-692`), `license:add` (`:694-697`), `license:run` (`:699-712`), `setup` addlicense install (`:842`)
+
+- [ ] **Step 1: Create `.licenserc.yaml`**
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# license-eye (Apache SkyWalking Eyes) config — replaces addlicense.
+# Licenses code AND functional markdown (specs/plans/ADRs/rules). User-facing
+# rendered content (plugin landing/MOTD, player-facing site docs) is excluded.
+header:
+  license:
+    content: |
+      SPDX-License-Identifier: Apache-2.0
+      Copyright 2026 HoloMUSH Contributors
+  paths:
+    - "api/**"
+    - "cmd/**"
+    - "internal/**"
+    - "pkg/**"
+    - "plugins/**"
+    - "scripts/**"
+    - "docs/**"
+    - ".claude/rules/**"
+    - "*.md"
+  paths-ignore:
+    - "**/*.pb.go"
+    - "vendor/**"
+    - "internal/web/dist/**"
+    - "plugins/**/content/**"
+    - "site/docs/**"
+    - "AGENTS.md"
+  language:
+    Markdown:
+      extensions: [".md"]
+      comment_style_id: AngleBracket
+  comment: on-failure   # inert under `task`-based invocation; honored only if the GH Action is ever wired
+```
+
+- [ ] **Step 2: Rewire the `license:*` tasks**
+
+In `Taskfile.yaml`, replace the `license:check` / `license:add` / `license:run` blocks (`:688-712`) with:
+
+```yaml
+  license:check:
+    desc: Check SPDX license headers (code + functional markdown)
+    cmds:
+      - license-eye header check
+
+  license:add:
+    desc: Add missing SPDX license headers (code + functional markdown)
+    cmds:
+      - license-eye header fix
+```
+
+(`license:run` and the `LICENSE_DIRS` indirection are removed — `.licenserc.yaml` `paths` supersedes them. Leave the top-level `LICENSE_DIRS` var only if another task references it; verify with `rg -n 'LICENSE_DIRS' Taskfile.yaml` and delete the var if `license:run` was its sole consumer.)
+
+- [ ] **Step 3: Swap the install in `setup`**
+
+In `Taskfile.yaml:842`, replace:
+
+```yaml
+      - go install github.com/google/addlicense@latest
+```
+
+with:
+
+```yaml
+      - go install github.com/apache/skywalking-eyes/cmd/license-eye@latest
+```
+
+- [ ] **Step 4: Install the tool locally**
+
+Run: `go install github.com/apache/skywalking-eyes/cmd/license-eye@latest`
+Expected: `license-eye` on `PATH` (`command -v license-eye`).
+
+- [ ] **Step 5: Verify code-header parity (INV-5)**
+
+Run: `task license:add` then `jj diff --stat`
+Expected: the diff touches ONLY markdown files (newly stamped) and any genuinely-header-less code files — **no existing `// SPDX-License-Identifier` line in a `.go`/`.sh`/`.proto` file is modified**. Confirm with: `jj diff --git | rg '^[+-].*SPDX-License-Identifier' | rg '\.go|\.sh|\.proto'` → expect no changed code-header lines (additions to previously-headerless files are acceptable; modifications to existing ones are not).
+
+**Contingency:** if `license:add` rewrites existing code headers (license-eye's matcher didn't recognize the existing form), add a `pattern:` regex under `header.license` in `.licenserc.yaml` matching the existing header, e.g.:
+
+```yaml
+  license:
+    content: |
+      SPDX-License-Identifier: Apache-2.0
+      Copyright 2026 HoloMUSH Contributors
+    pattern: |
+      SPDX-License-Identifier: Apache-2\.0
+      Copyright \d{4} HoloMUSH Contributors
+```
+
+Re-run Step 5 until existing code headers are untouched.
+
+- [ ] **Step 6: Discard the markdown stamping for now**
+
+The `license:add` in Step 5 also stamped markdown — that is Task 4's deliverable as a separate commit. Discard it from this change so this commit is tooling-only:
+
+Run: `jj diff --name-only | rg '\.md$'` to list the stamped markdown, then restore ONLY those changed files: `jj diff --name-only | rg '\.md$' | xargs -r jj restore --` (do NOT use a broad `glob:**/*.md` — it would also touch unrelated in-progress markdown). Re-run `jj diff --stat` and confirm only `.licenserc.yaml` + `Taskfile.yaml` (+ any code files that were genuinely missing headers) remain.
+
+- [ ] **Step 7: Commit (tooling only)**
+
+```text
+jj describe -m "build(license): replace addlicense with license-eye (holomush-gcio6)
+
+.licenserc.yaml drives license-eye for code + functional markdown.
+Code-file headers unchanged (INV-5). Markdown stamping lands separately.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 4: Stamp functional markdown + content-exclusion test
+
+**Files:**
+
+- Modify: functional markdown across `docs/**`, `.claude/rules/**`, root `*.md` (mechanical)
+- Create: `scripts/tests/license-eye.bats` (INV-6 case)
+
+- [ ] **Step 1: Write the INV-6 failing test**
+
+Create `scripts/tests/license-eye.bats`:
+
+```bash
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+setup_file() {
+  if [ ! -f "scripts/tests/Taskfile.test.yaml" ]; then
+    echo "ERROR: bats must be invoked from the repo root (try 'task test:bats')." >&2
+    exit 1
+  fi
+}
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+}
+
+# INV-6: license-eye MUST NOT stamp user-facing rendered content.
+@test "plugin content markdown stays header-free after license-eye" {
+  run rg -l 'SPDX-License-Identifier' plugins --glob 'plugins/**/content/**/*.md'
+  assert_failure   # rg exits 1 when no file matches → no content md carries a header
+}
+
+# INV-6: site player-facing docs stay header-free.
+@test "site player docs stay header-free" {
+  run rg -l 'SPDX-License-Identifier' site/docs --glob '*.md'
+  assert_failure
+}
+```
+
+- [ ] **Step 2: Run to verify it passes pre-stamp (guards the exclusion before and after)**
+
+Run: `bats scripts/tests/license-eye.bats`
+Expected: PASS (content md is header-free today). This case is a standing guard; it must remain PASS after Step 3 stamps functional markdown.
+
+- [ ] **Step 3: Stamp functional markdown**
+
+Run: `task license:add`
+Expected: `<!-- SPDX-License-Identifier: Apache-2.0 -->` / `<!-- Copyright 2026 HoloMUSH Contributors -->` added to in-scope markdown lacking it (root `CLAUDE.md`, `README.md`, `docs/roadmap.md`, and unheadered files under `docs/**` and `.claude/rules/**`).
+
+- [ ] **Step 4: Verify exclusion held + scope correct**
+
+Run: `bats scripts/tests/license-eye.bats` (INV-6 still PASS) and `rg -L 'SPDX-License-Identifier' --glob 'docs/**/*.md' | head`
+Expected: INV-6 PASS; spot-check that `docs/**` markdown now carries headers and `plugins/**/content/**` does not.
+
+- [ ] **Step 5: Verify the check now passes repo-wide**
+
+Run: `task license:check`
+Expected: PASS (exit 0) — code + functional markdown all headered.
+
+- [ ] **Step 6: Lint the newly-stamped markdown**
+
+Run: `task lint:markdown && task fmt:check`
+Expected: PASS. (If rumdl flags a blank-line rule around the new header, run `task fmt:markdown` and re-check.)
+
+- [ ] **Step 7: Commit the stamping as its own commit**
+
+```text
+jj describe -m "docs(license): stamp SPDX headers on functional markdown (holomush-gcio6)
+
+One-time mechanical license-eye fix over docs/**, .claude/rules/**, root *.md.
+User-facing content excluded (INV-6).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 5: `task fmt` becomes the one-command local fixer
+
+**Files:**
+
+- Modify: `Taskfile.yaml` — `fmt` task list (`:127-131` region)
+- Modify: `scripts/tests/license-eye.bats` (add INV-4 case)
+
+- [ ] **Step 1: Add the INV-4 failing test**
+
+Append to `scripts/tests/license-eye.bats`:
+
+```bash
+# INV-4: after `task fmt`, a freshly-added unheadered in-scope file passes check.
+@test "task fmt adds license headers so license:check passes" {
+  local gof="internal/zzz_invtest_$$.go"
+  local mdf="docs/zzz_invtest_$$.md"
+  printf 'package internal\n\nfunc invtest() {}\n' > "$gof"
+  printf '# inv test\n\nbody\n' > "$mdf"
+
+  run task fmt
+  assert_success
+
+  run grep -q 'SPDX-License-Identifier' "$gof"
+  assert_success
+  run grep -q 'SPDX-License-Identifier' "$mdf"
+  assert_success
+
+  rm -f "$gof" "$mdf"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats scripts/tests/license-eye.bats -f "task fmt adds license"`
+Expected: FAIL — `task fmt` does not yet run `license:add`, so the temp files have no header.
+
+- [ ] **Step 3: Add `license:add` to `task fmt`**
+
+In `Taskfile.yaml`, the `fmt:` task (`:125-131`) currently runs `fmt:go`, `fmt:yaml`, `fmt:markdown`, `fmt:dprint`. Add a `license:add` step **last** (so formatting settles before headers are applied), preserving all existing entries:
+
+```yaml
+  fmt:
+    desc: Format all files and apply license headers
+    cmds:
+      - task: fmt:go
+      - task: fmt:yaml
+      - task: fmt:markdown
+      - task: fmt:dprint
+      - task: license:add
+```
+
+(Confirm the exact current shape first with `rg -n -A6 '^  fmt:' Taskfile.yaml` — do NOT drop `fmt:yaml`; only append `license:add`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bats scripts/tests/license-eye.bats -f "task fmt adds license"`
+Expected: PASS.
+
+- [ ] **Step 5: Full bats + lint**
+
+Run: `task test:bats && task lint:yaml`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "build(fmt): task fmt applies license headers (one-command fixer, INV-4) (holomush-gcio6)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Phase 3: Retire lefthook + documentation
+
+### Task 6: Delete `lefthook.yaml` + setup cleanup + cog.toml
+
+**Files:**
+
+- Delete: `lefthook.yaml`
+- Modify: `Taskfile.yaml` — `setup` brew line (`:839`) + `lefthook install` line; `setup` desc (`:834`)
+- Modify: `cog.toml:7-9`
+
+- [ ] **Step 1: Delete the lefthook config**
+
+Run: `jj file untrack lefthook.yaml 2>/dev/null; rm -f lefthook.yaml` (or simply `rm lefthook.yaml` — jj snapshots the deletion).
+Expected: `lefthook.yaml` gone; `jj st` shows it removed.
+
+- [ ] **Step 2: Remove lefthook from `setup`**
+
+In `Taskfile.yaml`:
+
+- Line `:839` brew install — remove the `lefthook` token from:
+  `- brew install go-task lefthook goreleaser dprint cocogitto rumdl binaryen flock bats-core yq`
+  → `- brew install go-task goreleaser dprint cocogitto rumdl binaryen flock bats-core yq`
+- Remove the `- lefthook install` line entirely.
+- Update `setup` `desc` (`:834`) from "Install all dev tools and git hooks" → "Install all dev tools".
+
+- [ ] **Step 3: Update the cog.toml comment**
+
+In `cog.toml:7-9`, replace:
+
+```toml
+# Conventional-commit validation is enforced in CI on PR titles
+# (.github/workflows/commit-lint.yaml); the lefthook commit-msg hook is
+# best-effort only (jj does not fire it reliably).
+```
+
+with:
+
+```toml
+# Conventional-commit validation is enforced in CI on PR titles
+# (.github/workflows/commit-lint.yaml). There is no local commit-msg hook
+# (jj does not fire git hooks reliably; CI is authoritative).
+```
+
+- [ ] **Step 4: Verify nothing else references the deleted file**
+
+Run: `rg -n 'lefthook install|lefthook\.yaml' Taskfile.yaml; test -f lefthook.yaml && echo PRESENT || echo GONE`
+Expected: no Taskfile hits; `GONE`.
+
+- [ ] **Step 5: Lint**
+
+Run: `task lint:yaml`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "build: retire lefthook.yaml; CI + pr-prep are authoritative (holomush-gcio6)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+### Task 7: Documentation sweep + ADR supersession + no-lefthook meta-test
+
+**Files:**
+
+- Modify: `docs/CLAUDE.md` (Pre-commit Validation section)
+- Modify: `CLAUDE.md` (License Headers row, `:226`)
+- Modify: `docs/specs/decisions/epic7/general/102-lefthook-markdown-autofix-intentional.md` (Status)
+- Create: `scripts/tests/no-lefthook-refs.bats` (INV-3)
+- ADR `holomush-u2exm` supersession note (via `dev-flow:evolve-adr`)
+
+- [ ] **Step 1: Write the INV-3 failing meta-test**
+
+Create `scripts/tests/no-lefthook-refs.bats`:
+
+```bash
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+setup_file() {
+  if [ ! -f "scripts/tests/Taskfile.test.yaml" ]; then
+    echo "ERROR: bats must be invoked from the repo root (try 'task test:bats')." >&2
+    exit 1
+  fi
+}
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+}
+
+# INV-3: no reference to lefthook in live config/docs. Archived plans/specs
+# and the gcio6 spec/plan/ADR (which legitimately discuss the retirement) are
+# out of scope — the guard is a fixed allowlist of LIVE files.
+@test "lefthook.yaml does not exist" {
+  run test -f lefthook.yaml
+  assert_failure
+}
+
+@test "no lefthook references in live config/docs" {
+  run rg -i -n lefthook Taskfile.yaml cog.toml docs/CLAUDE.md CLAUDE.md
+  assert_failure   # rg exits 1 when there are no matches
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats scripts/tests/no-lefthook-refs.bats`
+Expected: the second case FAILS — `docs/CLAUDE.md` and `CLAUDE.md` still mention lefthook.
+
+- [ ] **Step 3: Rewrite the `docs/CLAUDE.md` pre-commit section**
+
+In `docs/CLAUDE.md`, replace the "## Pre-commit Validation" section (the one that reads "The project uses lefthook for pre-commit checks. Documentation changes MUST pass: `task lint:markdown`") with:
+
+```markdown
+## Local quality checks
+
+There is no git pre-commit hook (the repo is `jj`-primary; `jj` does not fire
+git hooks reliably). Run `task fmt` to format and apply license headers, and
+`task pr-prep` to mirror the full CI gate before pushing. Documentation changes
+MUST pass `task lint:markdown`.
+```
+
+- [ ] **Step 4: Update the root `CLAUDE.md` License Headers row**
+
+In `CLAUDE.md` (License Headers table, `:226`), replace the row:
+
+```markdown
+| **Auto-applied** by lefthook        | `task license:add` runs on commit; `task license:check` verifies |
+```
+
+with:
+
+```markdown
+| **Applied** by `task fmt`            | `task fmt` adds headers via `license-eye`; `task license:check` / CI verify |
+```
+
+If any other lefthook mention exists in `CLAUDE.md`, remove or reword it (verify with `rg -n -i lefthook CLAUDE.md`).
+
+- [ ] **Step 5: Mark decision-102 superseded**
+
+In `docs/specs/decisions/epic7/general/102-lefthook-markdown-autofix-intentional.md`, change the `**Status:** Accepted` line (`:10`) to:
+
+```markdown
+**Status:** Superseded by holomush-gcio6 (lefthook retired; markdown formatting now via `task fmt` → rumdl, license headers via `license-eye`)
+```
+
+- [ ] **Step 6: Run the meta-test to verify it passes**
+
+Run: `bats scripts/tests/no-lefthook-refs.bats`
+Expected: PASS (both cases).
+
+- [ ] **Step 7: Supersede ADR holomush-u2exm**
+
+Use the `dev-flow:evolve-adr` skill to add a supersession/amendment note to `holomush-u2exm` recording that the best-effort local commit-msg hook no longer exists (lefthook retired by `holomush-gcio6`); `commit-lint.yaml` remains the sole authoritative conventional-commit gate. Then:
+
+Run: `bd note holomush-u2exm "Amended by holomush-gcio6: lefthook retired; no local commit-msg hook remains; commit-lint.yaml is the sole gate."`
+
+- [ ] **Step 8: Full local gate**
+
+Run: `task test:bats && task lint && task fmt:check`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```text
+jj describe -m "docs: sweep lefthook references; supersede decision-102 + ADR u2exm (holomush-gcio6)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+jj new
+```
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green end-to-end (single command; confirm `✓ All PR checks passed`).
+- [ ] All six invariants exercised: INV-1 (coverage table), INV-2 (`generate-ebnf-check.bats`), INV-3 (`no-lefthook-refs.bats`), INV-4 (`license-eye.bats` fmt case), INV-5 (Task 3 Step 5 diff check), INV-6 (`license-eye.bats` content cases).
+- [ ] `lefthook.yaml` deleted; `rg -i lefthook` over the INV-3 allowlist is empty.
+- [ ] `license-eye` installed in `setup`; `addlicense` removed.
+- [ ] EBNF gate present in both `pr-prep:run` and `ci.yaml`.
+- [ ] Branch landed via PR (squash merge), per the protected-branch policy.
+
+<!-- adr-capture: sha256=1ce7f75236d255bf; ts=2026-05-26T01:21:39Z; adrs=holomush-x14mc -->

--- a/docs/superpowers/specs/2026-05-25-retire-lefthook-license-eye-design.md
+++ b/docs/superpowers/specs/2026-05-25-retire-lefthook-license-eye-design.md
@@ -1,0 +1,252 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Retire lefthook; CI + `task pr-prep` as the authoritative quality surface
+
+**Bead:** `holomush-gcio6`
+**Status:** Design
+**Supersedes (pattern):** generalizes `holomush-u2exm` / `holomush-dfsvk` ("validation
+moves to CI because local hooks are unreliable under `jj`")
+
+## Overview
+
+HoloMUSH is developed primarily through `jj` (colocated repo). `jj` does not fire
+lefthook git hooks reliably, so the repo's `lefthook.yaml` pre-commit automation —
+license-header insertion, formatting, lint gates, schema/EBNF generation gates, and
+conventional-commit validation — runs only sporadically (for git-based commits, never
+for `jj`-driven ones). The original bead framed the fix as "migrate lefthook → `jj fix`
+
+- CI gates." Grounding (recorded on `holomush-gcio6`) overturned that framing:
+
+1. **`jj fix` is manual.** It never runs on commit/snapshot — it must be invoked as
+   `jj fix` (deepwiki `jj-vcs/jj`). So it offers no automation advantage over the
+   `task fmt` / `task pr-prep` developers already run.
+2. **CI already gates ~everything.** `ci.yaml`'s Lint job runs `task license:check`,
+   `task lint` (go/markdown/yaml/actions), `task fmt:check`, and schema verification;
+   `commit-lint.yaml` gates conventional commits. The only gate that exists *solely*
+   in lefthook is `ebnf-sync` — and it diffs dead paths, so it is silently no-op
+   today (see [§ EBNF gap](#3-close-the-ebnf-gate-mandatory)).
+
+This spec therefore **retires lefthook entirely**, proves the existing `task` + CI
+surface is a superset of what lefthook did, closes the one real gap (EBNF), and
+**modernizes license tooling**: replacing `addlicense` (code-only) with
+`license-eye` (Apache SkyWalking Eyes), which licenses code *and* the project's
+functional markdown (specs, plans, ADRs, agent-facing rules) under one configurable
+tool. There is no `jj fix` in the final design.
+
+## Background and grounding
+
+| Source | Finding | Evidence |
+| --- | --- | --- |
+| lefthook config | 9 pre-commit commands + 1 commit-msg | `lefthook.yaml:10-115` |
+| CI Lint job | Already runs license:check, lint, fmt:check, schema verify | `.github/workflows/ci.yaml:90-107` |
+| pr-prep | Regenerates+diffs schema; runs lint, fmt:check, license:check | `Taskfile.yaml:789-815` |
+| EBNF generator | Writes `site/docs/reference/policy-dsl.ebnf` + `policy-dsl-railroad.html` | `internal/access/policy/dsl/gen-ebnf/main.go:33,39` |
+| EBNF lefthook gate | Diffs `site/docs/developers/policy-dsl.*` — **dead paths** | `lefthook.yaml:101` |
+| `jj fix` semantics | Manual only; stdin→stdout filters; never auto on commit | deepwiki `jj-vcs/jj` |
+| `addlicense` | In-place only; **does not process `.md`** (exit 0, no header added) | `addlicense -check plugins scripts` → exit 0 with unheadered `.md` |
+| `license-eye` | check + fix; markdown via `comment_style_id: AngleBracket` (`<!-- -->`) | deepwiki `apache/skywalking-eyes` |
+| lefthook install sites | Only `task setup`; `workspace:new` does not install it | `Taskfile.yaml:834-839`; `rg lefthook` |
+| LICENSE_HEADER | 2 lines: SPDX-License-Identifier + Copyright | `LICENSE_HEADER` |
+
+## Goals
+
+- **G1.** Remove `lefthook.yaml` and all live references to lefthook.
+- **G2.** Guarantee every rewrite/gate lefthook performed remains reachable via
+  `task fmt` (rewrite) or `task pr-prep` + CI (gate).
+- **G3.** Close the EBNF gate in both `pr-prep` and CI, targeting the real artifact
+  paths.
+- **G4.** Replace `addlicense` with `license-eye` as the single license tool for
+  code and functional markdown.
+- **G5.** Make `task fmt` a one-command local fixer (formatting + license headers).
+
+## Non-goals
+
+- **NG1.** `jj fix`. Rejected: manual-only, no advantage over `task fmt`.
+- **NG2.** Local git hooks for git-based contributors. CI is the gate; a best-effort
+  local hook under `jj` is false assurance.
+- **NG3.** Licensing user-facing rendered content markdown (`plugins/**/content/**`,
+  `site/docs/**` player guides).
+- **NG4.** Rewriting archived plans/specs that mention lefthook historically.
+
+## Coverage proof
+
+Every lefthook command maps to an existing `task`/CI home except EBNF:
+
+| lefthook command (`lefthook.yaml`) | Type | Post-removal home | Gap? |
+| --- | --- | --- | --- |
+| `license-headers` (`:15`) | rewrite + gate | `task license:add` (fix, via `fmt`) + `license:check` (pr-prep/CI) | none |
+| `lint-go` (`:41`) | gate | `task lint:go` ∈ `task lint` (pr-prep + CI) | none |
+| `lint-markdown` + `-site` (`:50,57`) | gate | `task lint:markdown` (covers root + `site/`, `Taskfile.yaml:479-483`) | none |
+| `fmt-markdown` + `-site` (`:61,69`) | rewrite | `task fmt:markdown` + `fmt:check` gate | none |
+| `lint-yaml` (`:74`) | gate | `task lint:yaml` | none |
+| `lint-actions` (`:78`) | gate | `task lint:actions` (CI also runs shellcheck) | none |
+| `format-check` (`:82`) | gate | `task fmt:check` (dprint) | none |
+| `schema-sync` (`:85`) | rewrite + gate | pr-prep regenerates+diffs (`Taskfile.yaml:789-798`); CI verifies | none |
+| `ebnf-sync` (`:96`) | rewrite + gate | **nothing — and current hook is no-op** | **must fix (§ below)** |
+| `conventional-commit` (`:111`) | gate | `commit-lint.yaml` (PR title) | none |
+
+## Design
+
+### 1. Retire lefthook
+
+Delete `lefthook.yaml`. Update `Taskfile.yaml` `setup`:
+
+- Drop `lefthook` from the `brew install` line (`Taskfile.yaml:839`).
+- Remove `lefthook install`.
+- Swap `go install .../addlicense` → `go install github.com/apache/skywalking-eyes/cmd/license-eye@latest`.
+- Update `desc` ("dev tools and git hooks" → "dev tools").
+
+The commit-msg `cog verify` hook is removed with the file; `commit-lint.yaml` remains
+the authoritative conventional-commit gate.
+
+### 2. `task fmt` becomes the one-command local fixer
+
+Add `license:add` to `task fmt`'s task list. End-state contract:
+
+- **`task fmt`** = make the tree correct (gofumpt + rumdl fmt + dprint fmt + license
+  headers).
+- **`task pr-prep` / CI** = verify (the existing `:check` gates).
+
+Generators (`task generate:schema` / `generate:ebnf`) stay explicit and source-triggered;
+pr-prep + CI regenerate-and-verify them, so they need not run inside `task fmt`.
+
+### 3. Close the EBNF gate (mandatory)
+
+The lefthook `ebnf-sync` hook diffs `site/docs/developers/policy-dsl.*`, but the
+generator writes `site/docs/reference/policy-dsl.ebnf` + `policy-dsl-railroad.html`
+(`gen-ebnf/main.go:33,39`). `git diff` on non-existent paths exits 0, so the gate is
+**silently no-op today**. The migration repairs it:
+
+- Add an EBNF regenerate-and-verify block to `pr-prep:run`, mirroring the schema block
+  (`Taskfile.yaml:789-798`), diffing the real artifacts:
+  `site/docs/reference/policy-dsl.ebnf` + `policy-dsl-railroad.html`.
+- Add the equivalent step to the `ci.yaml` Lint job.
+
+`generate:ebnf` already declares both artifacts in `generates:` (`Taskfile.yaml:366-367`),
+so no generator-task fix is required — only the regenerate-and-verify *gate* is missing.
+
+### 4. Replace addlicense with license-eye
+
+New `.licenserc.yaml` at repo root:
+
+```yaml
+header:
+  license:
+    content: |
+      SPDX-License-Identifier: Apache-2.0
+      Copyright 2026 HoloMUSH Contributors
+  paths:
+    - "api/**"
+    - "cmd/**"
+    - "internal/**"
+    - "pkg/**"
+    - "plugins/**"
+    - "scripts/**"
+    - "docs/**"
+    - ".claude/rules/**"
+    - "*.md"            # root CLAUDE.md, README.md, roadmap.md
+  paths-ignore:
+    - "**/*.pb.go"
+    - "vendor/**"
+    - "internal/web/dist/**"
+    - "plugins/**/content/**"   # user-facing landing/MOTD copy (NG3)
+    - "site/docs/**"            # player-facing site docs (NG3)
+    - "AGENTS.md"               # symlink to CLAUDE.md (same inode)
+  language:
+    Markdown:
+      extensions: [".md"]
+      comment_style_id: AngleBracket   # <!-- ... -->
+  comment: on-failure
+```
+
+`task license:run` switches from `addlicense {{.MODE}}` to `license-eye header fix`
+(add) / `license-eye header check` (verify). `LICENSE_DIRS` is superseded by the
+`.licenserc.yaml` `paths`.
+
+Because `license-eye` wraps the same `content` per-language, **code-file headers are
+byte-identical** to today's `addlicense` output (`// SPDX-License-Identifier: Apache-2.0`
+…) — verified by INV-5.
+
+### 5. Markdown scope and the one-time stamping commit
+
+The first `license-eye header fix` stamps `<!-- SPDX … -->` into all newly-in-scope
+functional markdown that lacks a header — root `CLAUDE.md`, `README.md`,
+`docs/roadmap.md`, and the unheadered files under `docs/**` and `.claude/rules/**`.
+This is a large but mechanical diff and SHOULD land as its own logical commit, separate
+from the tooling change, to keep review tractable.
+
+### 6. Documentation sweep
+
+Update live docs (leave archived plans):
+
+- `docs/CLAUDE.md` — replace the "Pre-commit Validation / lefthook" section with a
+  "Local quality checks" section (run `task fmt` to fix; `task pr-prep` mirrors CI).
+- root `CLAUDE.md` — License Headers row: "Auto-applied by lefthook" → "`task fmt` adds
+  headers (license-eye); `task license:check` / CI verify". Remove any other lefthook
+  mention.
+- `cog.toml` — drop the comment referencing the lefthook commit-msg hook.
+- `docs/specs/decisions/epic7/general/102-lefthook-markdown-autofix-intentional.md` —
+  mark superseded (the decision is moot once lefthook is gone).
+- ADR `holomush-u2exm` — add a "superseded by `holomush-gcio6`" note (lefthook removed;
+  the best-effort local hook no longer exists). Use `dev-flow:evolve-adr`.
+
+## Flow
+
+```mermaid
+flowchart TD
+    dev["Developer (jj)"] -->|task fmt| fix["gofumpt + rumdl fmt + dprint fmt + license-eye fix"]
+    fix --> tree["Correct working tree"]
+    tree -->|task pr-prep| gate["lint + fmt:check + license:check + schema verify + EBNF verify + tests"]
+    gate -->|push / PR| ci["CI Lint job (same gates) + commit-lint.yaml (PR title)"]
+    ci --> main["main"]
+```
+
+## Invariants (RFC2119)
+
+- **INV-1.** Every rewrite/gate the retired lefthook performed MUST remain reachable
+  via `task fmt` (rewrite) or `task pr-prep` + CI (gate). *Test:* the coverage table is
+  asserted by a checklist; the gates' presence is exercised by INV-2/INV-4.
+- **INV-2.** The EBNF artifacts (`site/docs/reference/policy-dsl.ebnf` and
+  `policy-dsl-railroad.html`) MUST be regenerated-and-verified in **both** `pr-prep:run`
+  and the CI Lint job against `go generate ./internal/access/policy/dsl/`. *Test:* a
+  bats case introduces drift in a generated EBNF artifact, runs `task generate:ebnf:check`,
+  and asserts non-zero exit; the CI step is present.
+- **INV-3.** No reference to `lefthook` MUST remain in live config or docs
+  (`lefthook.yaml`, `Taskfile.yaml`, `cog.toml`, `docs/CLAUDE.md`, root `CLAUDE.md`).
+  Archived plans/specs are exempt. *Test:* `rg` meta-test scoped to the live set.
+- **INV-4.** After `task fmt` on a tree containing a freshly-added in-scope `.go` and
+  `.md` file lacking headers, `task license:check` MUST pass. *Test:* bats.
+- **INV-5.** The `addlicense → license-eye` migration MUST NOT alter any existing
+  code-file license header (no churn beyond markdown additions and genuinely-missing
+  headers). *Test:* the migration commit's diff touches no existing `// SPDX` line.
+- **INV-6.** `license-eye` MUST NOT stamp user-facing rendered content
+  (`plugins/**/content/**`, `site/docs/**`). *Test:* bats — a content `.md` stays
+  header-free after `license-eye header fix`.
+
+## Testing
+
+- **bats** (`task test:bats`, already in pr-prep): INV-2 (EBNF drift), INV-4 (fmt makes
+  check pass), INV-6 (content stays header-free).
+- **meta-test** (`rg` guard, wired as a `lint:` task or bats case): INV-3.
+- **CI itself** exercises INV-2's CI half on every PR.
+
+## Rollout
+
+1. Tooling change: `.licenserc.yaml`, `Taskfile.yaml` (`license:*`, `fmt`, `setup`,
+   `pr-prep:run` EBNF block, `generate:ebnf` fix), `ci.yaml` EBNF step, delete
+   `lefthook.yaml`, `cog.toml` comment.
+2. One-time license stamping commit (markdown headers).
+3. Documentation sweep + ADR/decision-doc supersession.
+4. `task pr-prep` green; PR.
+
+## Out of scope
+
+`jj fix` (NG1); git-contributor local hooks (NG2); licensing user-facing content
+markdown (NG3); rewriting archived plans (NG4).
+
+## Open questions
+
+None blocking.
+
+<!-- adr-capture: sha256=98bfa215af4cc701; ts=2026-05-26T01:21:39Z; adrs=holomush-x14mc -->


### PR DESCRIPTION
## What

Design docs for **holomush-gcio6** — retire `lefthook` and modernize license tooling. Docs-only (spec + plan + ADR); implementation lands in follow-up PRs from the materialized bead chain.

- **Spec:** `docs/superpowers/specs/2026-05-25-retire-lefthook-license-eye-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-25-retire-lefthook-license-eye.md`
- **ADR:** `docs/adr/holomush-x14mc-adopt-license-eye-markdown-licensing.md`

## Decisions

- **Retire `lefthook.yaml` entirely.** `jj` doesn't fire git hooks reliably; CI + `task pr-prep` are already a superset of every lefthook gate. **No `jj fix`** (it's manual-only — no edge over `task fmt`).
- **Close the EBNF gate.** The lefthook `ebnf-sync` hook diffs dead `site/docs/developers/*` paths while the generator writes `site/docs/reference/*` — silently no-op today. New `generate:ebnf:check` task wired into `pr-prep` + CI.
- **Replace `addlicense` with `license-eye`** (ADR `holomush-x14mc`) — one configurable tool licensing code *and* functional markdown (specs/plans/ADRs/rules), excluding user-facing content.
- **`task fmt` becomes the one-command local fixer** (format + license headers).

## Review trail

design-reviewer READY · plan-reviewer READY (round 2) · 6 numbered RFC2119 invariants each with a test. Epic `holomush-gcio6` + 7 child beads materialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)