### PR TITLE
feat(quality-gates): tier-split — quarantine mechanism + pr-prep fast/full lane split (holomush-b4myw)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -343,3 +343,27 @@ Keep under 200 lines. Curate — don't hoard.
   to exercise. `stream_access_test.go:39` explicitly documents the
   rejection: `{"returns false for old colon-style scene stream",
   "scene:01ABC:ic", false}`. Encountered: iwzt.9-11 (2026-05-21).
+
+- **Contributor-guide example YAML/JSON MUST match the validator's regex/schema,
+  not just "look plausible."** When a how-to doc shows a copy-paste registry/config
+  example that a meta-test validates, run the doc's literal example through the
+  validator's extraction regex before trusting it. Real miss: quarantine.md
+  Step-2 example used `- id: holomush-xxxx` (bead under `id:`) but the bijection
+  meta-test's `registryBeadRE = ^\s*bead:\s*(holomush-...)`
+  (`test/meta/quarantine_registry_test.go:24`) and `test/quarantine.yaml:10`
+  schema `{ id, kind, bead, since, reason }` require a `bead:` key — the example
+  registers ZERO beads, so a contributor copying it breaks INV-2. The doc lint
+  (`task lint:markdown`) passes because the YAML is well-formed; only schema/regex
+  cross-check catches it. Verify: `printf '<example>' | rg '<validator-regex>'`.
+  Encountered: holomush-b4myw.10 (2026-05-25).
+
+- **Tier-split docs intentionally LEAD not-yet-landed tooling — verify the bead
+  graph before flagging "command doesn't exist."** In the tier-split-quality-gates
+  epic (holomush-b4myw), Task 10 docs reference `task quarantine:audit` (Task 5,
+  OPEN) and nightly `HOLOMUSH_RUN_QUARANTINED=1` wiring in nightly-soak.yml (Task 6,
+  OPEN — currently only runs `task soak:eventbus`). The plan explicitly instructs
+  the doc to mention them (plan lines 1085/1089), same lead-the-promotion pattern
+  as the Task 11 ruleset flip. So a doc citing a not-yet-existing `task X` is
+  Medium/non-blocking IF a sibling bead owns it; check `bd list` for the owning
+  task before calling it a blocker. (Distinct from finding #1 above, which is a
+  doc that breaks an ALREADY-LANDED validator.) Encountered: holomush-b4myw.10.

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -357,6 +357,18 @@ Keep under 200 lines. Curate — don't hoard.
   cross-check catches it. Verify: `printf '<example>' | rg '<validator-regex>'`.
   Encountered: holomush-b4myw.10 (2026-05-25).
 
+- **`jq '.[0].status // "unknown"'` fallback fires on `[]`, NOT on empty stdin.**
+  In quarantine-audit.sh (holomush-b4myw.5), `bd show <missing-bead> --json` emits
+  NOTHING; jq over empty input outputs an empty string, so the `// "unknown"`
+  default never fires (verified: `echo "" | jq -r '.[0].status // "unknown"'` →
+  empty; `echo "[]" | jq ...` → `unknown`). Net effect: a registry row citing a
+  renamed/deleted bead fails OPEN (status="" ≠ "closed" → audit passes). Acceptable
+  for INV-3 (contract is "is the cited bead closed", and INV-2 bijection meta-test
+  is the existence guard) — flag non-blocking. Also: `grep -oE 'bead:[[:space:]]*holomush-...'
+  | awk '{print $2}'` returns empty if a row uses no-space `bead:holomush-x` (whole
+  match is one field) — latent, today's registry + bijection RE both use the space
+  form. Encountered: holomush-b4myw.5 (2026-05-25).
+
 - **Tier-split docs intentionally LEAD not-yet-landed tooling — verify the bead
   graph before flagging "command doesn't exist."** In the tier-split-quality-gates
   epic (holomush-b4myw), Task 10 docs reference `task quarantine:audit` (Task 5,

--- a/.claude/agents/branch-readiness-check.md
+++ b/.claude/agents/branch-readiness-check.md
@@ -48,9 +48,11 @@ You are the HoloMUSH branch-readiness checker. Your one job is to inspect the cu
 - For the bead this branch implements (if any): `bd show <id>` — is it open or done? Description's TDD acceptance criteria all met?
 
 ### 4. pr-prep evidence
-- Search recent shell history / scrollback for `task pr-prep` output. If you can't find it, NOT READY — `task pr-prep` MUST run to full completion before push (no subset, no sub-agent delegation, no exceptions).
-- If pr-prep was run and failed, NOT READY.
-- For `.claude/` or doc-only changes, pr-prep is still required AND `task lint:docs-symmetry` MUST also pass when `CLAUDE.md` or `AGENTS.md` were touched.
+
+- Search recent shell history / scrollback for `task pr-prep` (the fast lane) output / result file. If you can't find evidence the fast gate ran green, NOT READY — the fast `task pr-prep` (schema/license/lint/fmt/unit/build) MUST run before push.
+- **Integration / E2E are CI-authoritative, not a local READY gate.** They run as required checks (`Integration Test`, `E2E Test`) in CI, which has not run at pre-push time. So do NOT require local `task test:int`/`task test:e2e` evidence. If the diff touches the int/e2e surface (`test/integration/**`, `web/e2e/**`, integration-tagged packages), targeted `task test:int -- ./<domain>` or `task pr-prep:full` is RECOMMENDED but not blocking.
+- If the fast pr-prep was run and failed, NOT READY.
+- For `.claude/` or doc-only changes, the docs lane runs automatically AND `task lint:docs-symmetry` MUST pass when `CLAUDE.md` or `AGENTS.md` were touched.
 
 ### 5. Code review
 - Has `code-reviewer` (or `pr-review-toolkit:review-pr`) run on this branch? Look in `.claude/agent-memory/code-reviewer/reports/` for a recent report cited against this branch's change IDs.

--- a/.claude/commands/landing-sequence.md
+++ b/.claude/commands/landing-sequence.md
@@ -21,7 +21,7 @@ for push; otherwise infer from the current jj workspace).
    - For each: either `bd close <id>` (if done) or `bd note <id> "<state at end of session>"` (if continuing)
 
 3. **pr-prep gate**
-   - MUST run `task pr-prep` to full completion before push, regardless of what changed. No subset, no approximation, no exceptions. Reason: `task pr-prep` bundles lint + format + schema + license + unit + `task test:int` + `task test:e2e` to mirror CI. Subset checks miss integration-only failures.
+   - MUST run the fast `task pr-prep` (schema + license + lint + fmt + unit + build) green before push. Integration + E2E are required CI checks (`Integration Test`, `E2E Test`) — they gate the PR in CI, not locally. If you touched `test/integration/**`, `web/e2e/**`, or integration-tagged packages, run targeted `task test:int -- ./<domain>` or `task pr-prep:full` first (recommended, not mandatory).
    - If pr-prep fails: STOP, surface the failure, do not push.
    - For `.claude/`-touching changes, additionally verify `task lint:docs-symmetry` passes (the docs-symmetry lint runs as part of `task lint`, which `task pr-prep` invokes — but call it out separately if a CLAUDE.md/AGENTS.md edit was the primary motivation).
 

--- a/.claude/commands/pr-prep.md
+++ b/.claude/commands/pr-prep.md
@@ -1,43 +1,63 @@
 ---
-description: Run task pr-prep to completion and surface the first failure clearly — no shortcuts, no sub-agent delegation
+description: Run the appropriate pr-prep lane (fast by default; full for int+e2e) and surface the first failure clearly
 ---
 
-Run `task pr-prep` to full completion. This mirrors all CI jobs (lint, format,
-schema, license, unit, integration, E2E). MUST run as a single command — never
-approximate by running individual steps and claiming pr-prep passed.
+Run the **fast** `task pr-prep` before push — it's the mandatory gate (schema,
+license, lint, fmt, unit, build, bats; no Docker, no flock). Run
+`task pr-prep:full` when your diff touches the integration / E2E surface; it runs
+the full pipeline (everything fast does, plus integration + E2E) behind a
+machine-global flock. Integration + E2E also run in CI as required checks
+(`Integration Test`, `E2E Test`), so they gate the PR there regardless.
 
-Reason for the no-shortcut rule: in April 2026 a partial check (lint + unit
-tests only) was misrepresented as "pr-prep green" and pushed broken code.
-The integration tests caught a compilation error in
-`test/integration/access/concurrent_engine_test.go` that unit tests couldn't
-see (integration tests use `//go:build integration`). This wasted user time
-and money; that's why this rule is non-negotiable.
+Whichever lane you run, run it as a single command end-to-end — never approximate
+by running individual steps and claiming pr-prep passed.
+
+Reason for the no-shortcut rule: in April 2026 a partial check (lint + unit tests
+only) was misrepresented as "pr-prep green" and pushed broken code. The
+integration tests caught a compilation error in
+`test/integration/access/concurrent_engine_test.go` that unit tests couldn't see
+(integration tests use `//go:build integration`). This wasted user time and
+money; that's why running the chosen lane end-to-end is non-negotiable.
 
 ## Procedure
 
-1. **Run** — single invocation, foreground:
+1. **Pick the lane:**
+   - Default: `task pr-prep` (fast — mandatory before every push).
+   - `task pr-prep:full` if the diff touches `test/integration/**`, `web/e2e/**`, or integration-tagged packages (recommended; the full gate is flock-serialized).
+   - Docs-only diffs auto-route to the docs lane.
+
+2. **Run** — single invocation, foreground:
+
    ```bash
-   task pr-prep
+   task pr-prep          # fast lane (mandatory)
+   # or, when you touched int/e2e:
+   task pr-prep:full     # full int+e2e gate (flock-serialized)
    ```
-   Output is large; if running interactively, prefer running it in the
-   background and tailing the result. The Bash tool can run with
-   `run_in_background: true` and check the result file when notified.
 
-2. **On success** — report green with the run summary line.
+   Output is large; if running interactively, prefer the background and read the
+   result file. Each run prints `▸ pr-prep result: <path>` and writes a file with
+   `status=`/`lane=`/`exit=` lines — read that file (match the `▸ pr-prep result:`
+   prefix) for the authoritative verdict rather than grepping stdout. Exit code
+   first: `0` = pass. go-task collapses every non-zero exit to `201`, so on the
+   full lane distinguish lock contention (`lane=full`, `status=contention`,
+   returns in ~2s) from a real gate failure via the result file — never by a
+   status substring.
 
-3. **On failure** — report:
+3. **On success** — report green with the run summary line and the `lane=` value.
+
+4. **On failure** — report:
    - **Which job failed first** (often the earliest red is the root cause)
    - **The actual error text** from that job
    - **A short suggested next step** — e.g.,
-     - lint failure → `task lint` to reproduce, then fix per `.claude/rules/grpc-errors.md` if it's a wrapcheck issue, line-scoped `//nolint:<rule>` only
+     - lint failure → `task lint` to reproduce, then fix; line-scoped `//nolint:<rule>` only
      - fmt failure → `task fmt` and re-run
      - schema regen failure → run the cited `go generate`, commit the regenerated file, retry
      - test failure → reproduce with `task test -- ./<package>` (or `task test:int -- ./<package>`)
 
-4. **Anti-patterns** — never do these:
+5. **Anti-patterns** — never do these:
    - Run `task lint && task test` and call that "pr-prep passed"
    - Trust a sub-agent's report that pr-prep is green — verify yourself. Sub-agents can't catch schema-regeneration side-effects (e.g., `go generate` updating `schemas/plugin.schema.json`) that must be committed before the PR is current.
-   - Skip pr-prep because "only docs changed". The `feedback_pr_prep` rule is "no exceptions, no shortcuts" — always run `task pr-prep` end-to-end before push.
+   - Drive a retry loop off the string `another pr-prep is running` — pr-prep's own `pr-prep-lock.bats` self-test surfaces that exact string on healthy runs; read the exit code + result file instead.
 
 ## Scope hint
 

--- a/.claude/hooks/enforce-task-runner.sh
+++ b/.claude/hooks/enforce-task-runner.sh
@@ -135,7 +135,7 @@ while IFS= read -r segment; do
       case "$second_word" in
         test)
           if echo "$rest" | command grep -qE '(^|\s)-tags[= ]'; then
-            echo "Use 'task test:integration' instead of 'go test -tags=...'" >&2
+            echo "Use 'task test:int' instead of 'go test -tags=...'" >&2
           else
             echo "Use 'task test' instead of 'go test'" >&2
           fi

--- a/.claude/hooks/remind-pre-action-review.sh
+++ b/.claude/hooks/remind-pre-action-review.sh
@@ -70,6 +70,13 @@ if [ "$handoff_intent" = "1" ] && {
   reminders+=("**Pre-hand-off ABAC gate:** Changes touch the access-control surface. \`abac-reviewer\` MUST run alongside \`code-reviewer\`. Invoke \`/review-abac\` (or \`Agent\` with \`subagent_type: abac-reviewer\`) before pushing. To skip, the user must explicitly say so (e.g. \"skip ABAC review\").")
 fi
 
+# int/e2e surface nudge: handoff intent AND the diff touches integration/E2E
+# paths. Integration+E2E are CI-required (not a local mandatory gate), but a
+# targeted local run before push catches breakage a CI round-trip slower.
+if [ "$handoff_intent" = "1" ] && printf '%s' "$changed_paths" | grep -qE '(test/integration/|web/e2e/|_integration_test\.go|\.spec\.ts)'; then
+  reminders+=("**int/e2e surface touched:** \`Integration Test\` / \`E2E Test\` are CI-required checks. A targeted local run before push (\`task test:int -- ./<domain>\` or \`task pr-prep:full\`) catches failures a CI round-trip sooner — recommended, not mandatory (CI is authoritative).")
+fi
+
 # plan-reviewer triggers: anything that implies a plan is about to be executed.
 if printf '%s' "$lower" | grep -qE '(execute[[:space:]]+(the[[:space:]]+)?plan|run[[:space:]]+(the[[:space:]]+)?plan|start[[:space:]]+implementing|begin[[:space:]]+(the[[:space:]]+)?plan|plan[[:space:]]+is[[:space:]]+ready|approve[[:space:]]+(the[[:space:]]+)?plan|\bapproved\b)'; then
   reminders+=("**Pre-execute gate:** Before \`superpowers:executing-plans\` or \`superpowers:subagent-driven-development\` consumes a plan, the \`plan-reviewer\` adversarial sub-agent MUST run on it. Invoke \`/review-plan\` now if it has not already run for the latest revision of the plan.")

--- a/.claude/rules/landing-the-plane.md
+++ b/.claude/rules/landing-the-plane.md
@@ -5,7 +5,7 @@ When ending a work session, work is **NOT complete until changes are pushed**. T
 ## Mandatory checklist
 
 1. **File beads for remaining work** — anything not finished gets a `bd create` so it survives the session
-2. **Run `task pr-prep`** (mirrors CI) if code changed — MUST be green before push. Run as a single command to full completion; never approximate by running individual steps. Reason: April 2026 incident where a partial check claimed pr-prep passed and pushed broken integration tests.
+2. **Run `task pr-prep`** (the **fast lane**: schema/license/lint/fmt/unit/build/bats; no Docker, no flock) if code changed — MUST be green before push. Run the chosen lane as a single command to full completion; never approximate by running individual steps. Reason: April 2026 incident where a partial check claimed pr-prep passed and pushed broken integration tests. The integration and E2E gate runs in CI as required checks (`Integration Test` + `E2E Test`); run `task pr-prep:full` locally when your diff touches int/E2E surface.
 3. **Update issue status** — `bd close` what's done; `bd update` what's still in flight
 4. **Push:**
    - `jj git fetch`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -157,6 +157,26 @@ NATS (`internal/eventbus/subsystem.go`); external/clustered NATS is unimplemente
 (tracked in holomush-s5ts). Production code MUST NOT import `eventbustest` or
 `internal/core/coretest` — enforced by the depguard rule in `.golangci.yaml`.
 
+### Quarantine
+
+Known-flaky integration and E2E specs are quarantined so they self-skip in gating CI and in `task pr-prep:full`, running only nightly or locally with `HOLOMUSH_RUN_QUARANTINED=1`. Quarantine is for **flakiness with an open bead** — never for a real failure.
+
+**Three marker idioms:**
+
+| Stack | Marker |
+| --- | --- |
+| Go unit/integration | `quarantinetest.Skip(t, "holomush-xxxx")` (helper at `internal/testsupport/quarantinetest`) |
+| Ginkgo | `if !quarantinetest.Enabled() { Skip("quarantined: holomush-xxxx") }` |
+| Playwright | `{ tag: ['@quarantine', '@holomush-xxxx'] }` |
+
+Every marker MUST have a corresponding row in `test/quarantine.yaml` citing an open bead (enforced by the bijection meta-test INV-2 at `test/meta/quarantine_registry_test.go`). `task quarantine:audit` flags rows whose cited bead is closed.
+
+Production code MUST NOT import `quarantinetest` — enforced by depguard.
+
+To un-quarantine: fix the flake, remove the marker and the `test/quarantine.yaml` row, then verify `task quarantine:audit` is clean.
+
+See [site/docs/contributing/quarantine.md](../../site/docs/contributing/quarantine.md) for the full contributor guide.
+
 ## Plugin Tests (`internal/plugin`)
 
 Lua plugins use gopher-lua which creates fresh VM state per event delivery. Binary plugins use hashicorp/go-plugin and communicate via gRPC.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,7 +232,7 @@ jobs:
         uses: ./.github/actions/install-task
 
       - name: Run E2E tests with coverage
-        run: task test:e2e:cover
+        run: task test:e2e:cover -- --grep-invert @quarantine
 
       - name: Upload E2E coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -47,3 +47,36 @@ jobs:
 
       - name: Run eventbus soak suite
         run: task soak:eventbus
+
+  quarantine:
+    name: Quarantine Health
+    runs-on: namespace-profile-linux-amd64-4x8
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Cache Go modules and build
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          cache: go
+      - name: Install Task
+        uses: ./.github/actions/install-task
+      # Run the quarantined Go specs (health signal only; never gates merge).
+      # continue-on-error: known-flaky by definition — a red here is expected
+      # and must not fail the nightly workflow.
+      - name: Run quarantined integration specs
+        continue-on-error: true
+        env:
+          HOLOMUSH_RUN_QUARANTINED: "1"
+        run: task test:int
+      - name: Run quarantined E2E specs
+        continue-on-error: true
+        run: task test:e2e:cover -- --grep @quarantine

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -54,6 +54,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup Testcontainers Cloud Client
         uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -150,6 +150,8 @@ linters:
               desc: "embedded NATS test harness; production code MUST NOT import it (holomush-1eps2)"
             - pkg: github.com/holomush/holomush/internal/core/coretest
               desc: "in-memory test event store; production code MUST NOT import it (holomush-1eps2)"
+            - pkg: github.com/holomush/holomush/internal/testsupport/quarantinetest
+              desc: "quarantine skip helper; production code MUST NOT import it (holomush-b4myw)"
 
     errcheck:
       check-type-assertions: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,18 +297,26 @@ task test:int                                    # Integration tests (needs Dock
 | **MUST NOT** disable lint/format rules | Without explicit user confirmation                 |
 | **SHOULD** run `task fmt`              | Before committing to ensure consistent formatting  |
 
-**MUST** run `task pr-prep` before creating a PR or pushing to a PR branch.
-It auto-detects docs-only diffs (per `Taskfile.yaml` `vars.DOCS_ONLY_PATHS`)
-and runs the `pr-prep:docs` fast lane in that case; for any non-docs path,
-it runs the full pipeline mirroring all CI jobs (lint, format, schema,
-license, unit, integration, E2E) and MUST pass with zero failures. Use
-`HOLOMUSH_PR_PREP_FORCE_FULL=1 task pr-prep` to force the full lane.
-Docker is always available — never skip E2E tests on the full lane. The
-full lane is serialized per user — only one runs at a time on a given
-machine. Note: docs detection relies on jj's snapshot of `@`; run `jj st`
-first if you've made edits since the last `jj` command. See
-[pr-prep](site/docs/contributing/pr-prep.md) for collision behavior and
-the docs lane.
+**MUST** run `task pr-prep` (the **fast lane**) before creating a PR or
+pushing to a PR branch. The fast lane runs bats → schema-check →
+license:check → plugin:build-all → lint → fmt:check → unit tests → build.
+It requires no Docker and holds no flock, so it is always safe to run
+without coordination. On docs-only diffs it auto-delegates to
+`task pr-prep:docs` (markdown lint, YAML lint, docs-symmetry check, fmt,
+license). Note: docs detection relies on jj's snapshot of `@`; run `jj st`
+first if you've made edits since the last `jj` command.
+
+`task pr-prep:full` runs the flock-serialized **full lane** (everything
+fast does, plus integration tests and E2E in Docker). It is opt-in —
+recommended when your diff touches int/E2E surface (Ginkgo suites, Playwright
+specs, or their shared helpers). The full lane is serialized machine-globally
+per user. Use `HOLOMUSH_PR_PREP_FORCE_FULL=1 task pr-prep` to trigger it
+from the auto-detecting entry point.
+
+**`Integration Test` and `E2E Test` are required CI checks protecting `main`.**
+They run on Namespace runners with Testcontainers Cloud in CI — not in the
+mandatory local fast lane. See [pr-prep](site/docs/contributing/pr-prep.md)
+for the full lanes reference and lock/contention behavior.
 
 **Reading the pr-prep result — exit code first, then disambiguate; never
 grep the lock string.** Run it as the SOLE command (`task pr-prep` — no

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -726,6 +726,12 @@ tasks:
     cmds:
       - cmd: |
           set -euo pipefail
+          # Delegate to the full lane BEFORE any fast-lane result-path setup,
+          # so a force-full run never prints a stale 'pr-prep result:' path
+          # that the fast lane won't write (the full lane emits its own).
+          if [ "${HOLOMUSH_PR_PREP_FORCE_FULL:-}" = "1" ]; then
+            exec task pr-prep:full
+          fi
           LOCK_DIR="${TMPDIR:-/tmp}/holomush-pr-prep"
           RUN_DIR="$LOCK_DIR/runs"
           mkdir -p "$RUN_DIR"
@@ -735,10 +741,6 @@ tasks:
             printf 'status=%s\nlane=%s\nexit=%s\nfinished_at=%s\n' \
               "$1" "$2" "$3" "$(date -u +%FT%TZ)" > "$RESULT"
           }
-          # Docs-only diffs still delegate to the docs lane.
-          if [ "${HOLOMUSH_PR_PREP_FORCE_FULL:-}" = "1" ]; then
-            exec task pr-prep:full
-          fi
           timeout 5 git fetch -q origin main 2>/dev/null || true
           CHANGED=$(timeout 5 git diff --name-only origin/main...HEAD 2>/dev/null || true)
           if [ -n "$CHANGED" ]; then

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -219,6 +219,11 @@ tasks:
           ./scripts/e2e-summary.sh
           exit $E2E_EXIT
 
+  quarantine:audit:
+    desc: Fail if any quarantined spec's bead is closed (needs bd; run locally / pre-bd-close). INV-3.
+    cmds:
+      - bash scripts/quarantine-audit.sh
+
   test:bats:
     desc: Run bats shell tests under scripts/tests/
     cmds:
@@ -716,7 +721,8 @@ tasks:
   # ──────────────────────────────────────────
 
   pr-prep:
-    desc: Fast pre-push gate (schema/license/lint/fmt/unit/build/bats; no Docker, no concurrency lock). Mandatory before push. Use 'pr-prep:full' for int+e2e.
+    desc: Fast pre-push gate (schema/license/lint/fmt/unit/build/bats; no Docker, no concurrency lock). Mandatory before push.
+      Use 'pr-prep:full' for int+e2e.
     cmds:
       - cmd: |
           set -euo pipefail

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -716,6 +716,68 @@ tasks:
   # ──────────────────────────────────────────
 
   pr-prep:
+    desc: Fast pre-push gate (schema/license/lint/fmt/unit/build/bats; no Docker, no concurrency lock). Mandatory before push. Use 'pr-prep:full' for int+e2e.
+    cmds:
+      - cmd: |
+          set -euo pipefail
+          LOCK_DIR="${TMPDIR:-/tmp}/holomush-pr-prep"
+          RUN_DIR="$LOCK_DIR/runs"
+          mkdir -p "$RUN_DIR"
+          RESULT="$RUN_DIR/$(date -u +%Y%m%dT%H%M%SZ)-$$.result"
+          printf '▸ pr-prep result: %s\n' "$RESULT"
+          write_result() {
+            printf 'status=%s\nlane=%s\nexit=%s\nfinished_at=%s\n' \
+              "$1" "$2" "$3" "$(date -u +%FT%TZ)" > "$RESULT"
+          }
+          # Docs-only diffs still delegate to the docs lane.
+          if [ "${HOLOMUSH_PR_PREP_FORCE_FULL:-}" = "1" ]; then
+            exec task pr-prep:full
+          fi
+          timeout 5 git fetch -q origin main 2>/dev/null || true
+          CHANGED=$(timeout 5 git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          if [ -n "$CHANGED" ]; then
+            DOCS_REGEX=$(bash scripts/docs-paths-regex.sh)
+            if ! printf '%s\n' "$CHANGED" | grep -vE "$DOCS_REGEX" >/dev/null; then
+              echo "▸ docs-only diff detected; running pr-prep:docs"
+              drc=0; task pr-prep:docs || drc=$?
+              if [ "$drc" -eq 0 ]; then write_result pass docs 0; else write_result fail docs "$drc"; fi
+              exit "$drc"
+            fi
+          fi
+          rc=0; task pr-prep:fast:run || rc=$?
+          if [ "$rc" -eq 0 ]; then write_result pass fast 0; else write_result fail fast "$rc"; fi
+          exit "$rc"
+
+  pr-prep:fast:run:
+    desc: Inner body of the fast lane (no result file; called by pr-prep).
+    cmds:
+      - echo "▸ Running bats shell tests..."
+      - task: test:bats
+      - echo "▸ Verifying schema is current..."
+      - cmd: |
+          SCHEMA=schemas/plugin.schema.json
+          BEFORE=$(sha256sum "$SCHEMA" | cut -d' ' -f1)
+          go generate ./internal/plugin/
+          AFTER=$(sha256sum "$SCHEMA" | cut -d' ' -f1)
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "ERROR: Schema out of sync with Go types. Run 'task generate:schema' and commit."
+            exit 1
+          fi
+      - echo "▸ Checking license headers..."
+      - task: license:check
+      - echo "▸ Building binary plugins..."
+      - task: plugin:build-all
+      - echo "▸ Running linters..."
+      - task: lint
+      - echo "▸ Checking formatting..."
+      - task: fmt:check
+      - echo "▸ Running unit tests..."
+      - task: test
+      - echo "▸ Building..."
+      - task: build
+      - echo "✓ Fast PR checks passed (run 'task pr-prep:full' for integration + E2E)."
+
+  pr-prep:full:
     desc: Run all CI checks locally before pushing (mirrors ALL CI jobs) [serialized via flock; auto-selects docs lane on
       docs-only diffs]
     preconditions:

--- a/cmd/holomush/admin_read_stream_e2e_test.go
+++ b/cmd/holomush/admin_read_stream_e2e_test.go
@@ -140,6 +140,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/pgnanos"
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
 	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
 	adminv1 "github.com/holomush/holomush/pkg/proto/holomush/admin/v1"
 	"github.com/holomush/holomush/pkg/proto/holomush/admin/v1/adminv1connect"
@@ -827,8 +828,11 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E10 (INV-F14): per-frame write deadline — slow sender trips ErrWriteDeadlineExceeded → DEADLINE_EXCEEDED")
 	scenarioFE10WriteDeadline(env)
 
-	By("F-E12 (INV-F9): chain verification — VerifyScope on a happy-path request_id succeeds")
-	scenarioFE12ChainVerification(env)
+	// quarantined: holomush-7b9n — F-E12 audit-row projection flakes under load; skip only this step in gating runs (runs nightly).
+	if quarantinetest.Enabled() {
+		By("F-E12 (INV-F9): chain verification — VerifyScope on a happy-path request_id succeeds")
+		scenarioFE12ChainVerification(env)
+	}
 
 	By("F-E16 (INV-F11): idempotent dual-control reuse — second invocation by different requester finds approved row, no PendingApproval")
 	scenarioFE16IdempotentDualControlReuse(env)

--- a/internal/eventbus/audit/projection_test.go
+++ b/internal/eventbus/audit/projection_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/pgnanos"
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
 	"github.com/holomush/holomush/test/testutil"
 )
 
@@ -130,6 +131,7 @@ func countAuditRows(t *testing.T, pool *pgxpool.Pool) int {
 // waits for the projection to drain, then asserts the row fields match
 // the headers and metadata we published.
 func TestProjectionDrainsPublishedMessageToAuditTable(t *testing.T) {
+	quarantinetest.Skip(t, "holomush-1nl7")
 	shared := testutil.SharedPostgres(t)
 	connStr := testutil.FreshDatabase(t, shared)
 	pool := openPool(t, connStr)
@@ -205,6 +207,7 @@ func TestProjectionIsIdempotentOnDuplicate(t *testing.T) {
 //   - Even if the same message were redelivered, ON CONFLICT DO NOTHING
 //     is the safety net.
 func TestProjectionResumesAfterRestart(t *testing.T) {
+	quarantinetest.Skip(t, "holomush-q55b")
 	shared := testutil.SharedPostgres(t)
 	connStr := testutil.FreshDatabase(t, shared)
 	pool := openPool(t, connStr)

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
 )
 
 // expectedTables lists every table present after all migrations have been applied.
@@ -256,6 +257,9 @@ var _ = Describe("Migrator", func() {
 
 	Describe("ConcurrentUp", func() {
 		It("allows at least one concurrent Up() to succeed with consistent final state", func() {
+			if !quarantinetest.Enabled() {
+				Skip("quarantined: holomush-pqzv")
+			}
 			ctx := context.Background()
 
 			// Start PostgreSQL container

--- a/internal/testsupport/quarantinetest/quarantinetest.go
+++ b/internal/testsupport/quarantinetest/quarantinetest.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package quarantinetest gates known-flaky integration/E2E specs. A spec
+// marked with Skip self-skips in gating runs (env unset) and runs in the
+// nightly lane (HOLOMUSH_RUN_QUARANTINED=1). Every Skip MUST cite an open
+// bead and have a matching row in test/quarantine.yaml (enforced by the
+// bijection meta-test in test/meta). Production code MUST NOT import this
+// package (depguard-enforced). See
+// docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md.
+package quarantinetest
+
+import (
+	"os"
+	"testing"
+)
+
+// EnvVar toggles whether quarantined specs run. Set to "1" in the nightly
+// lane; unset everywhere else (so quarantined specs self-skip in gating CI).
+const EnvVar = "HOLOMUSH_RUN_QUARANTINED"
+
+// Enabled reports whether quarantined specs should run.
+func Enabled() bool { return os.Getenv(EnvVar) == "1" }
+
+// Skip skips the test as quarantined unless Enabled(). bead MUST be the
+// tracking bead id (e.g. "holomush-q55b") and MUST appear in
+// test/quarantine.yaml.
+func Skip(t *testing.T, bead string) {
+	t.Helper()
+	if !Enabled() {
+		t.Skipf("quarantined: %s (set %s=1 to run)", bead, EnvVar)
+	}
+}

--- a/internal/testsupport/quarantinetest/quarantinetest_test.go
+++ b/internal/testsupport/quarantinetest/quarantinetest_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package quarantinetest_test
+
+import (
+	"testing"
+
+	"github.com/holomush/holomush/internal/testsupport/quarantinetest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnabledReflectsEnvVar(t *testing.T) {
+	t.Run("false when env unset", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "")
+		assert.False(t, quarantinetest.Enabled())
+	})
+	t.Run("true when env is 1", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "1")
+		assert.True(t, quarantinetest.Enabled())
+	})
+	t.Run("false for any other value", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_RUN_QUARANTINED", "true")
+		assert.False(t, quarantinetest.Enabled())
+	})
+}
+
+func TestSkipSkipsWhenDisabled(t *testing.T) {
+	t.Setenv("HOLOMUSH_RUN_QUARANTINED", "")
+	ranPast := false
+	t.Run("subject", func(t *testing.T) {
+		quarantinetest.Skip(t, "holomush-q55b")
+		ranPast = true // unreachable when Skip fires
+	})
+	assert.False(t, ranPast, "code after Skip must not run when quarantine disabled")
+}
+
+func TestSkipRunsWhenEnabled(t *testing.T) {
+	t.Setenv("HOLOMUSH_RUN_QUARANTINED", "1")
+	ranPast := false
+	t.Run("subject", func(t *testing.T) {
+		quarantinetest.Skip(t, "holomush-q55b")
+		ranPast = true
+	})
+	assert.True(t, ranPast, "code after Skip must run when quarantine enabled")
+}

--- a/scripts/quarantine-audit.sh
+++ b/scripts/quarantine-audit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Fails if any bead referenced by test/quarantine.yaml is closed (fix landed
+# but the spec was never un-quarantined). Run locally / before `bd close`;
+# requires `bd` on PATH with a reachable beads DB. INV-3.
+set -euo pipefail
+
+REG="test/quarantine.yaml"
+[ -f "$REG" ] || { echo "no $REG; nothing to audit"; exit 0; }
+
+if ! command -v bd >/dev/null 2>&1; then
+  echo "quarantine:audit: bd not on PATH — skipping (run where bd is reachable)" >&2
+  exit 0
+fi
+
+rc=0
+# Process substitution (not a pipe) keeps the loop in the MAIN shell so that
+# rc mutations survive — a `... | while read` loop runs in a subshell and
+# `exit "$rc"` would always be 0 (the audit would be a silent no-op).
+while read -r bead; do
+  [ -n "$bead" ] || continue
+  status=$(bd show "$bead" --json 2>/dev/null | jq -r '.[0].status // "unknown"')
+  if [ "$status" = "closed" ]; then
+    echo "QUARANTINE AUDIT: $bead is closed but still quarantined — un-quarantine it." >&2
+    rc=1
+  fi
+done < <(grep -oE 'bead:[[:space:]]*holomush-[a-z0-9.]+' "$REG" | awk '{print $2}' | sort -u)
+exit "$rc"

--- a/site/docs/contributing/pr-prep.md
+++ b/site/docs/contributing/pr-prep.md
@@ -1,10 +1,12 @@
 # Pre-Push Quality Gate (`task pr-prep`)
 
-`task pr-prep` is the project's mandatory pre-push gate. It mirrors every CI job (schema check, license check, plugin builds, lint, format, unit tests, integration tests, E2E in Docker) and MUST pass before pushing to a PR branch.
+`task pr-prep` is the project's mandatory pre-push gate. It MUST pass before pushing to a PR branch. HoloMUSH uses a two-lane design so the gate is always fast locally while the heavyweight integration and E2E checks run in CI.
 
-A full run takes 5–15 minutes and is CPU- and Docker-heavy.
+## Lanes
 
-## What it does
+### Fast lane (default, mandatory)
+
+`task pr-prep` runs the fast lane by default:
 
 1. Bats shell tests (concurrency-lock harness regression check)
 2. Schema regeneration check
@@ -13,12 +15,40 @@ A full run takes 5–15 minutes and is CPU- and Docker-heavy.
 5. Lint
 6. Format check
 7. Unit tests (Go)
+8. Build
+
+The fast lane requires no Docker and holds no flock. A typical run takes 2–5 minutes. It is always safe to run concurrently across multiple agent sessions.
+
+On docs-only diffs, `task pr-prep` auto-delegates to `task pr-prep:docs` instead (see [Docs-only fast lane](#docs-only-fast-lane) below).
+
+### Full lane (opt-in)
+
+`task pr-prep:full` adds the integration and E2E gate on top of everything the fast lane runs:
+
 8. Integration tests (Go, with PostgreSQL testcontainer)
 9. E2E tests (Playwright in Docker)
 
-## Concurrent runs
+The full lane is **flock-serialized machine-globally per user** — only one runs at a time. A typical full run takes 5–15 minutes and is CPU- and Docker-heavy.
 
-`task pr-prep` is serialized machine-globally per user. If you run `task pr-prep` on a machine where another `task pr-prep` is already in flight (typically: another agent session, or another terminal you forgot about), the second invocation exits non-zero immediately with a message like:
+Use the full lane when your diff touches integration test surface (Ginkgo suites, Playwright specs, or their shared helpers). You can also trigger it from the auto-detecting entry point:
+
+```bash
+HOLOMUSH_PR_PREP_FORCE_FULL=1 task pr-prep
+```
+
+### CI-required checks: Integration Test and E2E Test
+
+`Integration Test` and `E2E Test` are **required CI checks protecting `main`**. They run in CI on Namespace runners with Testcontainers Cloud — not in the mandatory local fast lane. A PR cannot merge until both are green in CI.
+
+Quarantined specs are excluded from both gating CI runs and from the full lane's Docker-backed suite. They run only nightly and locally with `HOLOMUSH_RUN_QUARANTINED=1`. See [quarantine.md](quarantine.md) for details.
+
+### Docs lane
+
+`task pr-prep:docs` runs automatically when every changed path is docs-only (see [Docs-only fast lane](#docs-only-fast-lane) below). It has no Docker dependency and does not acquire the flock.
+
+## Concurrent runs (full lane)
+
+`task pr-prep:full` is serialized machine-globally per user via `flock(1)`. The fast lane (`task pr-prep`) has no such restriction — concurrent fast-lane runs across agent sessions are safe. If you run `task pr-prep:full` on a machine where another full-lane run is already in flight, the second invocation exits non-zero immediately with a message like:
 
 ```text
 ERROR: another pr-prep is running on this machine.
@@ -79,10 +109,12 @@ The file holds `key=value` lines:
 
 ```text
 status=pass
-lane=full
+lane=fast
 exit=0
 finished_at=2026-05-25T12:14:03Z
 ```
+
+(A full-lane run writes `lane=full`. A contention exit writes `lane=full` with `status=contention`.)
 
 Branch on `status`, which is `pass`, `fail`, or `contention`:
 

--- a/site/docs/contributing/quarantine.md
+++ b/site/docs/contributing/quarantine.md
@@ -1,0 +1,109 @@
+# Quarantining Flaky Tests
+
+Sometimes an integration or E2E test becomes intermittently unreliable — a timing sensitivity, a port-conflict race, a testcontainer startup hiccup. When that happens you have two choices: fix it immediately, or quarantine it so CI stays green while you track the flake in a bead.
+
+Quarantine is for **flakiness only**. Never quarantine a test that is failing because the code is broken. If a test is reliably failing, the code needs fixing, not the test.
+
+## When to quarantine
+
+Quarantine a test when all of the following are true:
+
+- It fails intermittently (not every run, not in a reproducible pattern).
+- You have an open bead tracking the root cause.
+- Blocking CI on it would slow down other contributors.
+
+If the flake is rare and the fix is imminent, it may be faster to just fix it. Use your judgment.
+
+## How to quarantine
+
+### Step 1: Add a marker
+
+Add the appropriate marker for your test stack. Every marker must cite the open bead ID.
+
+**Go unit or integration test:**
+
+```go
+import "github.com/holomush/holomush/internal/testsupport/quarantinetest"
+
+func TestSomethingFlaky(t *testing.T) {
+    quarantinetest.Skip(t, "holomush-xxxx")
+    // rest of test
+}
+```
+
+**Ginkgo integration spec:**
+
+```go
+import "github.com/holomush/holomush/internal/testsupport/quarantinetest"
+
+It("does the flaky thing", func() {
+    if !quarantinetest.Enabled() {
+        Skip("quarantined: holomush-xxxx")
+    }
+    // rest of spec
+})
+```
+
+**Playwright E2E spec:**
+
+```ts
+test("does the flaky thing", { tag: ["@quarantine", "@holomush-xxxx"] }, async ({ page }) => {
+    // rest of test
+});
+```
+
+### Step 2: Add a registry row
+
+Add a row to `test/quarantine.yaml` for every marker you added:
+
+```yaml
+entries:
+  - id: TestSomethingFlaky
+    kind: go        # go | ginkgo | playwright
+    bead: holomush-xxxx
+    since: 2026-05-25
+    reason: brief description of the flake
+```
+
+Where: `id` = the test identifier (Go func name, Ginkgo spec phrase, or Playwright test title); `kind` = the stack (`go`|`ginkgo`|`playwright`); `bead` = the tracking bead id — **required**, this is the key the bijection reads; `since` = ISO date; `reason` = short flake description.
+
+The bijection meta-test (INV-2) at `test/meta/quarantine_registry_test.go` checks that every marker has a registry row and every registry row cites an open bead. It runs as part of `task test`, so CI will catch a mismatch immediately.
+
+### Step 3: Verify
+
+```bash
+task test -- ./test/meta/ -run TestQuarantineRegistryBijection
+task quarantine:audit
+```
+
+Both should be clean. `task quarantine:audit` is the standalone check that flags registry rows whose cited bead is already closed. _(the `quarantine:audit` task and the nightly quarantined-run wiring land in follow-up work; see beads holomush-b4myw.5 / .6)_
+
+## How quarantined specs run
+
+Quarantined specs are **excluded from gating CI** and from `task pr-prep:full`. They run in two circumstances:
+
+- **Nightly**: the nightly soak workflow (`.github/workflows/nightly-soak.yml`) runs with `HOLOMUSH_RUN_QUARANTINED=1`. _(nightly quarantined-run wiring lands in follow-up work; see bead holomush-b4myw.6)_
+- **Locally**: set `HOLOMUSH_RUN_QUARANTINED=1` before running any test command to include quarantined specs.
+
+```bash
+HOLOMUSH_RUN_QUARANTINED=1 task test:int
+HOLOMUSH_RUN_QUARANTINED=1 task test:e2e
+```
+
+This lets you reproduce and debug the flake without affecting CI.
+
+## How to un-quarantine
+
+When you fix the root cause:
+
+1. Remove the marker from the test file.
+2. Remove the row from `test/quarantine.yaml`.
+3. Run `task quarantine:audit` — expect clean output. _(lands in follow-up work; see bead holomush-b4myw.5)_
+4. Run the test with and without `HOLOMUSH_RUN_QUARANTINED=1` to confirm it passes reliably.
+5. Close the tracking bead.
+
+## Notes
+
+- Production code MUST NOT import `quarantinetest`. This is enforced by the depguard rule in `.golangci.yaml`.
+- Every `test/quarantine.yaml` row must cite an open bead. `task quarantine:audit` _(coming in bead holomush-b4myw.5)_ flags stale rows (closed bead); remove those rows when you close the bead.
+- The `test/quarantine.yaml` registry and its meta-test (INV-2) are the authoritative list of quarantined specs. Comments in test files are informational only.

--- a/test/meta/ci_required_jobs_test.go
+++ b/test/meta/ci_required_jobs_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCIRequiredJobNamesPresent enforces INV-5: both the real CI workflow and
+// the docs-skip workflow must define jobs named "Integration Test" and
+// "E2E Test" so the required checks resolve (incl. on docs-only PRs).
+func TestCIRequiredJobNamesPresent(t *testing.T) {
+	root := findRepoRoot(t)
+	for _, wf := range []string{
+		filepath.Join(".github", "workflows", "ci.yaml"),
+		filepath.Join(".github", "workflows", "ci-docs-skip.yaml"),
+	} {
+		data, err := os.ReadFile(filepath.Join(root, wf))
+		require.NoError(t, err, "read %s", wf)
+		body := string(data)
+		require.Contains(t, body, "name: Integration Test", "%s missing 'Integration Test' job (INV-5)", wf)
+		require.Contains(t, body, "name: E2E Test", "%s missing 'E2E Test' job (INV-5)", wf)
+	}
+}

--- a/test/meta/depguard_config_test.go
+++ b/test/meta/depguard_config_test.go
@@ -24,6 +24,7 @@ func TestDepguardTestOnlyConstructRulesPresent(t *testing.T) {
 	for _, pkg := range []string{
 		"github.com/holomush/holomush/internal/eventbus/eventbustest",
 		"github.com/holomush/holomush/internal/core/coretest",
+		"github.com/holomush/holomush/internal/testsupport/quarantinetest",
 	} {
 		require.Contains(t, cfg, pkg,
 			"depguard deny rule for %q missing from .golangci.yaml (holomush-1eps2 INV-1/INV-2)", pkg)

--- a/test/meta/pr_prep_fast_lane_test.go
+++ b/test/meta/pr_prep_fast_lane_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// taskBlock returns the Taskfile body of `<name>:` up to the next 2-space task key.
+func taskBlock(t *testing.T, tf, name string) string {
+	t.Helper()
+	loc := regexp.MustCompile(`(?m)^  ` + regexp.QuoteMeta(name) + `:[ \t]*$`).FindStringIndex(tf)
+	require.NotNil(t, loc, "%s target not found in Taskfile.yaml", name)
+	after := tf[loc[1]:]
+	if next := regexp.MustCompile(`(?m)^  \S`).FindStringIndex(after); next != nil {
+		return after[:next[0]]
+	}
+	return after
+}
+
+// TestPrPrepFastLaneExcludesHeavyTiers enforces INV-4: the mandatory pr-prep
+// (non-full) lane must not run test:int/test:e2e and must not flock; the
+// heavy tiers live only in pr-prep:full.
+func TestPrPrepFastLaneExcludesHeavyTiers(t *testing.T) {
+	root := findRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "Taskfile.yaml"))
+	require.NoError(t, err, "read Taskfile.yaml")
+	tf := string(data)
+
+	fast := taskBlock(t, tf, "pr-prep")
+	require.NotContains(t, fast, "test:int", "pr-prep (fast) must not run integration tests (INV-4)")
+	require.NotContains(t, fast, "test:e2e", "pr-prep (fast) must not run E2E tests (INV-4)")
+	require.NotContains(t, fast, "flock", "pr-prep (fast) must not acquire the flock (INV-4)")
+
+	full := taskBlock(t, tf, "pr-prep:full")
+	require.Contains(t, full, "flock", "pr-prep:full must keep the flock")
+}

--- a/test/meta/quarantine_registry_test.go
+++ b/test/meta/quarantine_registry_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// beadRE matches a holomush bead id wherever it appears (registry rows or
+// in-code markers).
+var beadRE = regexp.MustCompile(`holomush-[a-z0-9.]+`)
+
+// registryBeadRE pulls the bead id from a `bead:` key line in the registry.
+var registryBeadRE = regexp.MustCompile(`(?m)^\s*bead:\s*(holomush-[a-z0-9.]+)`)
+
+// markerLineRE matches an in-code quarantine marker line and is used to scope
+// bead extraction to lines that actually mark a spec quarantined:
+//   - Go:        quarantinetest.Skip(t, "holomush-xxxx")
+//   - Ginkgo:    Skip("quarantined: holomush-xxxx")  (or Label("quarantine", "holomush-xxxx"))
+//   - Playwright '@quarantine' tag line carries an adjacent '@holomush-xxxx' tag
+var markerLineRE = regexp.MustCompile(`quarantinetest\.Skip\(|quarantined:|@quarantine|Label\("quarantine"`)
+
+// TestQuarantineRegistryBijection enforces INV-2: every in-code quarantine
+// marker maps to exactly one test/quarantine.yaml row and vice versa.
+func TestQuarantineRegistryBijection(t *testing.T) {
+	root := findRepoRoot(t)
+
+	registry := registryBeads(t, root)
+	markers := markerBeads(t, root)
+
+	sort.Strings(registry)
+	sort.Strings(markers)
+
+	require.Equal(t, registry, markers,
+		"quarantine marker set and test/quarantine.yaml must be identical "+
+			"(registry=%v markers=%v)", registry, markers)
+}
+
+func registryBeads(t *testing.T, root string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "test", "quarantine.yaml"))
+	require.NoError(t, err, "read test/quarantine.yaml")
+	out := newQuarantineBeadSet()
+	for _, m := range registryBeadRE.FindAllStringSubmatch(string(data), -1) {
+		out.add(m[1])
+	}
+	return out.slice()
+}
+
+func markerBeads(t *testing.T, root string) []string {
+	t.Helper()
+	out := newQuarantineBeadSet()
+	rootFS, err := os.OpenRoot(root)
+	require.NoError(t, err, "open repo root")
+	defer func() { _ = rootFS.Close() }()
+
+	// Files that contain marker-shaped lines that are NOT real quarantine
+	// markers and MUST be excluded from the walk:
+	//   - this meta-test's own regex literals; and
+	//   - the quarantinetest helper package's self-tests, which exercise
+	//     Skip with a sample bead id but quarantine no real spec.
+	// Real quarantine markers live in actual integration/E2E specs.
+	metaSelf := filepath.Join("test", "meta", "quarantine_registry_test.go")
+	helperPkg := filepath.Join("internal", "testsupport", "quarantinetest") + string(filepath.Separator)
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		// Scan Go test files and Playwright specs only.
+		isGoTest := strings.HasSuffix(name, "_test.go")
+		isSpec := strings.HasSuffix(name, ".spec.ts")
+		if !isGoTest && !isSpec {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		// Skip files whose marker-shaped lines are not real markers.
+		if rel == metaSelf || strings.HasPrefix(rel, helperPkg) {
+			return nil
+		}
+		f, openErr := rootFS.Open(rel)
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		_ = f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !markerLineRE.MatchString(line) {
+				continue
+			}
+			for _, b := range beadRE.FindAllString(line, -1) {
+				out.add(b)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err, "walk repo for markers")
+	return out.slice()
+}
+
+// quarantineBeadSet is a tiny string set used to collect bead ids without duplicates.
+type quarantineBeadSet struct{ m map[string]struct{} }
+
+func newQuarantineBeadSet() *quarantineBeadSet { return &quarantineBeadSet{m: map[string]struct{}{}} }
+func (s *quarantineBeadSet) add(v string)      { s.m[v] = struct{}{} }
+func (s *quarantineBeadSet) slice() []string {
+	out := make([]string, 0, len(s.m))
+	for k := range s.m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/test/meta/tooling_no_mandatory_int_test.go
+++ b/test/meta/tooling_no_mandatory_int_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolingDoesNotMandateLocalIntE2E enforces INV-6: no .claude/ tooling
+// artifact may assert that local int/e2e is mandatory before push. The old
+// "to full completion before push" phrasing encoded exactly that rule.
+func TestToolingDoesNotMandateLocalIntE2E(t *testing.T) {
+	root := findRepoRoot(t)
+	const banned = "to full completion before push"
+	claudeDir := filepath.Join(root, ".claude")
+
+	var offenders []string
+	err := filepath.WalkDir(claudeDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// agent-memory holds review logs/learnings that legitimately QUOTE
+			// the banned phrase descriptively (and reports/ is gitignored, so
+			// this filesystem walk would otherwise read ephemeral session
+			// artifacts). It is not a tooling artifact that asserts the rule.
+			if d.Name() == "agent-memory" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Skip this guard's own source so its literal doesn't self-trip.
+		if strings.HasSuffix(path, "tooling_no_mandatory_int_test.go") {
+			return nil
+		}
+		f, openErr := os.Open(path) //nolint:gosec // path from controlled WalkDir under .claude/
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		_ = f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(data), banned) {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	require.NoError(t, err, "walk .claude/")
+	require.Empty(t, offenders,
+		"these .claude/ artifacts still assert the old full-gate-before-push rule (INV-6): %v", offenders)
+}

--- a/test/quarantine.yaml
+++ b/test/quarantine.yaml
@@ -8,4 +8,29 @@
 # is closed. See docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md.
 #
 # entries: list of { id, kind (go|ginkgo|playwright), bead, since, reason }
-entries: []
+entries:
+  - id: TestProjectionResumesAfterRestart
+    kind: go
+    bead: holomush-q55b
+    since: 2026-05-25
+    reason: consumer-info eventual-consistency race on restart (5zpf closed as dup)
+  - id: TestProjectionDrainsPublishedMessageToAuditTable
+    kind: go
+    bead: holomush-1nl7
+    since: 2026-05-25
+    reason: AwaitDrained cold-start race
+  - id: ConcurrentUp allows at least one concurrent Up to succeed
+    kind: ginkgo
+    bead: holomush-pqzv
+    since: 2026-05-25
+    reason: testcontainers docker port-map timeout under load
+  - id: admin_read_stream F-E12 chain verification (surgical step skip)
+    kind: ginkgo
+    bead: holomush-7b9n
+    since: 2026-05-25
+    reason: operator_read_completed audit row times out under load; only the F-E12 step is gated
+  - id: terminal.spec.ts reconnect/session (4 tests)
+    kind: playwright
+    bead: holomush-0jzs
+    since: 2026-05-25
+    reason: WebSocket reconnect timing flakes in CI (reconnect/replay/history/draft)

--- a/test/quarantine.yaml
+++ b/test/quarantine.yaml
@@ -1,0 +1,11 @@
+# Quarantine registry — known-flaky integration/E2E specs.
+#
+# Each entry MUST reference an open/in-progress bead and have a matching
+# in-code marker (quarantinetest.Skip / Ginkgo Skip / Playwright @quarantine
+# tag). The bijection meta-test (test/meta/quarantine_registry_test.go)
+# fails the build if a marker lacks a row or a row lacks a marker.
+# `task quarantine:audit` (run where bd is reachable) flags rows whose bead
+# is closed. See docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md.
+#
+# entries: list of { id, kind (go|ginkgo|playwright), bead, since, reason }
+entries: []

--- a/web/e2e/terminal.spec.ts
+++ b/web/e2e/terminal.spec.ts
@@ -357,7 +357,7 @@ test.describe('Terminal UI', () => {
     await expect(input).toHaveValue('look');
   });
 
-  test('reconnect receives live events after replay', async ({ page }) => {
+  test('reconnect receives live events after replay', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ page }) => {
     await connectAsGuest(page);
 
     // Reload — session persists, stream reconnects
@@ -428,7 +428,7 @@ test.describe('Terminal UI', () => {
     expect(matched, `expected event with "${token}" in history response`).toBe(true);
   });
 
-  test('page reload replays prior events from multiple guests', async ({ browser }) => {
+  test('page reload replays prior events from multiple guests', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ browser }) => {
     // Two independent browser contexts (separate sessions, same starting location)
     const ctx1 = await browser.newContext();
     const ctx2 = await browser.newContext();
@@ -604,7 +604,7 @@ test.describe('Terminal UI', () => {
     await ctx2.close();
   });
 
-  test('command history persists across reconnect', async ({ page }) => {
+  test('command history persists across reconnect', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ page }) => {
     await connectAsGuest(page);
 
     // Send commands with unique tokens to avoid collision with other tests
@@ -657,7 +657,7 @@ test.describe('Terminal UI', () => {
     await expect(inputAfter).toHaveValue('say this is a long pose that I do not want to lose');
   });
 
-  test('draft does not leak across sessions', async ({ page }) => {
+  test('draft does not leak across sessions', { tag: ['@quarantine', '@holomush-0jzs'] }, async ({ page }) => {
     await connectAsGuest(page);
 
     // Type a draft and wait for debounced save


### PR DESCRIPTION
Implements Phases 1–3 of the **tier-split quality gates** epic (`holomush-b4myw`): reshape the merge-gate contract so Integration + E2E become CI-authoritative (promotion is Phase 4), the mandatory local `task pr-prep` shrinks to a fast deterministic lane, and known flakes are governed by a quarantine registry instead of blocking PRs.

Spec: `docs/superpowers/specs/2026-05-25-tier-split-quality-gates-design.md` · Plan: `docs/superpowers/plans/2026-05-25-tier-split-quality-gates.md` · ADRs: `holomush-5k6au`, `holomush-5eqiv`.

## What landed (10 beads, drained via `holomush-t1eba`)

| Bead | Change |
| --- | --- |
| `.1` | `internal/testsupport/quarantinetest` env-gate helper (`Enabled`/`Skip`, `HOLOMUSH_RUN_QUARANTINED`) |
| `.2` | depguard deny: production MUST NOT import `quarantinetest` (+ meta-test guard) |
| `.3` | `test/quarantine.yaml` registry + **INV-2** marker↔registry bijection meta-test |
| `.4` | Quarantined **5** known flakes across 3 stacks (re-derived from the repo — see below) |
| `.5` | E2E gating exclusion (`--grep-invert @quarantine`) + `quarantine:audit` task/script (**INV-3**) |
| `.6` | Nightly `Quarantine Health` job (`continue-on-error`, runs the quarantined set) |
| `.7` | `pr-prep` **fast** mandatory lane + opt-in `pr-prep:full` (**INV-4**), result-file contract preserved |
| `.8` | Rewrote readiness agent + pr-prep commands: int/E2E are CI-authoritative, not a local gate |
| `.9` | int/e2e hook nudge + `test:integration`→`test:int` fix + **INV-6** banned-phrase guard |
| `.10` | Docs (CLAUDE.md, landing-the-plane, pr-prep, testing, new `quarantine.md`) + **INV-5** CI-job-name guard |

## Quarantine set (re-derived — plan's registry was stale)

The plan's seed list was authored from old bd reports; re-derived against the repo with operator triage:

- **Quarantined (5):** `q55b`, `1nl7` (Go `Skip`), `pqzv` (Ginkgo), `7b9n` (**surgical** — only the flaky F-E12 step is gated; the rest of the chain runs), `0jzs` (4 `@quarantine` Playwright tags).
- **Excluded:** `tmrv` (testcontainer-startup infra flake → stays open as a fix bead; **`.11` blocks on it**), `h9fp` (telnet spec was removed → closed obsolete), `5zpf` (dup of `q55b`).

## Validation
- Fast `task pr-prep` green on the rebased branch (lint/fmt/unit/build/schema/license/plugins/bats; all 56 bats pass).
- All meta-tests pass (INV-2/4/5/6); `task test:int` confirmed the audit specs self-skip in gating runs.
- Every commit reviewed by an independent `code-reviewer` pass.

## Not in this PR (Phase 4 — owner follow-ups)
- `holomush-tmrv`: fix the crypto-suite testcontainer startup.
- `holomush-b4myw.11`: flip the `protect-main` ruleset to make `Integration Test` + `E2E Test` required (repo-admin action; gated on the above and on this PR merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)