### PR TITLE
fix(test): reclaim half-started Postgres testcontainer on retry (holomush-tmrv)

### DIFF
--- a/test/testutil/postgres.go
+++ b/test/testutil/postgres.go
@@ -96,6 +96,15 @@ func startPostgresOnce(ctx context.Context) (*PostgresEnv, error) {
 		),
 	)
 	if err != nil {
+		// testcontainers-go returns a non-nil container handle when the
+		// wait-until-ready strategy fails (generic.go: `return c, err`).
+		// Reclaim it before returning so StartPostgres's retry does not pile
+		// a fresh container on top of a leaked half-started one — the
+		// resource pressure that causes the mapped-port timeout in the first
+		// place (holomush-tmrv).
+		if container != nil {
+			_ = container.Terminate(ctx) //nolint:errcheck // best-effort cleanup
+		}
 		return nil, fmt.Errorf("run postgres: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

`holomush-tmrv`: the crypto integration suite intermittently panics during Postgres testcontainer startup under Docker resource pressure:

```
run postgres: generic container: start container: started hook: wait until ready: mapped port: check target: retries: 9, port: "", last err: ... context deadline exceeded
```

## Root cause

testcontainers-go v0.42.0 returns a **non-nil** container handle when the wait-until-ready strategy fails (`generic.go:94` `return c, fmt.Errorf("start container: %w", err)`, propagated through `Run` at `:145` and `postgres.Run` at `:168`). `startPostgresOnce` discarded that handle without terminating it, so each failed attempt **leaked a half-started container**. `StartPostgres`'s 3× retry-with-backoff then spun up a fresh container on top of the leaked one — compounding the exact Docker resource pressure that caused the mapped-port timeout in the first place (a retry storm at the daemon level).

## Fix

Terminate the failed attempt's container (best-effort) before returning, so the retry starts from a clean slate instead of piling on.

The bead's three originally-suggested fixes were **already implemented** since it was filed (PR #3674-era): shared process-scope container (#217), a 2-minute wait deadline, and the 3× retry loop. This leak-on-retry was the remaining gap.

## Verification

- `task test:int -- ./test/integration/crypto/` → 6 tests green.
- `task pr-prep` full lane (lint, schema, license, unit, integration, E2E) → `status=pass exit=0`.
- `ctx` validity confirmed safe: all `StartPostgres` callers pass `context.Background()`, and the wait deadline is a derived child ctx (`wait/all.go:82`), so the caller ctx is live at terminate time.

## Notes

- Independent of PR #4273 (tier-split quality gates); branched off `main`.
- `holomush-b4myw.11` (protect-main ruleset flip) blocks-on `holomush-tmrv`. This is one of two gates on `.11`; the other is PR #4273 merging. I am **not** closing `tmrv` — flake fixes warrant loop-verification under load before closing, which is an operator call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)