### PR TITLE
feat(integrationtest): WithInTreePlugins harness + whole-system suite (holomush-0f0f4)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -143,13 +143,22 @@ Other test engines: `AllowAllEngine()`, `DenyAllEngine()`, `NewErrorEngine(err)`
 | unit | none | `task test` | (none) |
 | bus-integration | embedded NATS (`eventbustest`) | `task test:int` | `//go:build integration` |
 | audit-integration | embedded NATS + Postgres testcontainer | `task test:int` | `//go:build integration` |
-| full-stack integration | embedded NATS + Postgres + `CoreServer` (+ optional in-tree plugins) | `task test:int` | `//go:build integration` |
+| full-stack integration | embedded NATS + Postgres + `CoreServer` (+ optional in-tree plugins via `WithInTreePlugins()`) | `task test:int` | `//go:build integration` |
 | **E2E** | full Docker stack driven through a real client (browser) | `task test:e2e` | (Playwright) |
 
 "E2E" means the Playwright browser suite — a test that crosses the real user
 boundary. The Ginkgo `test:int` suite is **integration** (it calls Go/gRPC APIs
 in-process), regardless of how much of the stack it stands up. Use "E2E" only
 for the Playwright suite; Go Ginkgo suites are "integration".
+
+**Whole-system plugin tier** (top Go-fidelity tier within full-stack integration):
+`integrationtest.Start(t, integrationtest.WithInTreePlugins())` loads ALL in-tree
+plugins via `setup.PluginSubsystem` → `Manager.LoadAll` (INV-5, INV-WS-1). The
+`test/integration/wholesystem/` census suite (`holomush-0f0f4`) asserts the full
+plugin set loads and the `help` command is registered. Requires binary artifacts
+(`task plugin:build-all`; automatic in `task test:int`). See
+`site/docs/contributing/integration-tests.md#whole-system-plugin-tier-withintreeplugins`
+for the full capability doc.
 
 `eventbustest` provides the in-process embedded NATS server (`MemoryStorage`)
 used at every non-unit tier. This matches production, which also runs embedded

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -151,6 +151,8 @@ tasks:
 
   test:int:
     desc: Run integration tests (needs Docker for testcontainers)
+    env:
+      HOLOMUSH_REQUIRE_PLUGINS: "1"
     cmds:
       - task: plugin:build-all
       # No package enumeration: the only //go:build !integration helper

--- a/internal/testsupport/integrationtest/default_plugins_test.go
+++ b/internal/testsupport/integrationtest/default_plugins_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartWithoutPluginsLeavesHarnessPluginFree enforces INV-WS-4: omitting
+// WithInTreePlugins yields a plugin-free harness; the plugin accessors panic.
+func TestStartWithoutPluginsLeavesHarnessPluginFree(t *testing.T) {
+	srv := Start(t)
+	defer srv.Stop()
+	require.Nil(t, srv.pluginSub, "default Start must not start the plugin subsystem")
+	require.Panics(t, func() { _ = srv.PluginManager() },
+		"PluginManager must panic when plugins were not requested")
+}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -74,6 +74,7 @@ import (
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/naming"
 	"github.com/holomush/holomush/internal/pgnanos"
+	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/internal/telnet"
@@ -114,6 +115,10 @@ type Server struct {
 	// coreServer is the in-process CoreServer (no network transport).
 	coreServer *holoGRPC.CoreServer
 
+	// pluginSub is the started plugin subsystem when WithInTreePlugins was
+	// passed; nil otherwise. Stopped via t.Cleanup registered in startPlugins.
+	pluginSub *pluginsetup.PluginSubsystem
+
 	// guestStartLocationID is the location all guests are placed into.
 	guestStartLocationID ulid.ULID
 }
@@ -125,6 +130,7 @@ type StartOption func(*startConfig)
 // startConfig holds resolved Start options.
 type startConfig struct {
 	accessEngine types.AccessPolicyEngine
+	withPlugins  bool
 }
 
 // WithPolicyEngine overrides the harness's default allow-all ABAC engine.
@@ -210,8 +216,35 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	}
 	pe := cfg.accessEngine
 
-	// Command dispatcher (minimal: no commands registered).
-	dispatcher, err := command.NewDispatcher(command.NewRegistry(), pe)
+	// VerbRegistry must exist before plugins load (they register verbs). It is
+	// also required by the locationFollower's synthetic location_state emit path
+	// so RenderingMetadata is stamped on the EventFrame (gateway drops
+	// nil-Rendering events per INV-GW-5, holomush-4wdu). Production wires this in
+	// cmd/holomush/sub_grpc.go.
+	verbRegistry, err := core.BootstrapVerbRegistry("test")
+	require.NoError(t, err, "integrationtest.Start: BootstrapVerbRegistry")
+
+	// Command dispatcher. When WithInTreePlugins is set, the dispatcher is fed
+	// the plugin subsystem's command registry so plugin commands are
+	// dispatchable (mirrors cmd/holomush/sub_grpc.go); otherwise it gets an
+	// empty registry (no commands registered).
+	var pluginSub *pluginsetup.PluginSubsystem
+	cmdRegistry := command.NewRegistry()
+	if cfg.withPlugins {
+		pluginSub = startPlugins(t, ctx, pluginDeps{
+			pool:         pool,
+			connStr:      connStr,
+			engine:       pe,
+			sessionStore: sessionStoreInst,
+			verbReg:      verbRegistry,
+			playerRepo:   playerRepo,
+			hasher:       hasher,
+			playerSess:   playerSessionStore,
+		})
+		cmdRegistry = pluginSub.CommandRegistry()
+	}
+
+	dispatcher, err := command.NewDispatcher(cmdRegistry, pe)
 	require.NoError(t, err, "integrationtest.Start: create command dispatcher")
 	cmdServices := command.NewTestServices(command.ServicesConfig{Engine: pe})
 
@@ -224,13 +257,6 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	// cmd/holomush/sub_grpc.go layers those on, but for privacy-invariant
 	// tests the bare JS+Postgres tier is sufficient.
 	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now)
-
-	// VerbRegistry — required by the locationFollower's synthetic
-	// location_state emit path so RenderingMetadata is stamped on the
-	// EventFrame (gateway drops nil-Rendering events per INV-GW-5,
-	// holomush-4wdu). Production also wires this in cmd/holomush/sub_grpc.go.
-	verbRegistry, err := core.BootstrapVerbRegistry("test")
-	require.NoError(t, err, "integrationtest.Start: BootstrapVerbRegistry")
 
 	// CoreServer wired with all required subsystems.
 	coreServer := holoGRPC.NewCoreServer(
@@ -272,6 +298,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		guestSvc:             guestSvc,
 		bus:                  bus,
 		coreServer:           coreServer,
+		pluginSub:            pluginSub,
 		guestStartLocationID: guestLocID,
 	}
 }

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -74,6 +74,7 @@ import (
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/naming"
 	"github.com/holomush/holomush/internal/pgnanos"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/store"
@@ -303,10 +304,40 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	}
 }
 
-// Stop tears down the in-process stack. Idempotent.
-// Postgres and NATS cleanup are handled by t.Cleanup() registered in Start.
+// Stop tears down the in-process stack. Idempotent. Postgres and NATS cleanup
+// are handled by t.Cleanup handlers registered in Start; the plugin subsystem
+// (if started) is stopped here and is also t.Cleanup-registered as a safety net.
 func (s *Server) Stop() {
-	// Resources cleaned up by t.Cleanup handlers registered in Start.
+	if s.pluginSub != nil {
+		_ = s.pluginSub.Stop(context.Background())
+	}
+}
+
+// PluginManager returns the loaded plugin Manager. Panics if WithInTreePlugins
+// was not passed to Start.
+func (s *Server) PluginManager() *plugins.Manager {
+	s.requirePlugins("PluginManager")
+	return s.pluginSub.Manager()
+}
+
+// CommandRegistry returns the plugin-populated command registry (builtins +
+// admin + plugin commands). Panics if WithInTreePlugins was not passed.
+func (s *Server) CommandRegistry() *command.Registry {
+	s.requirePlugins("CommandRegistry")
+	return s.pluginSub.CommandRegistry()
+}
+
+// ServiceRegistry returns the plugin service registry. Panics if
+// WithInTreePlugins was not passed.
+func (s *Server) ServiceRegistry() *plugins.ServiceRegistry {
+	s.requirePlugins("ServiceRegistry")
+	return s.pluginSub.ServiceRegistry()
+}
+
+func (s *Server) requirePlugins(method string) {
+	if s.pluginSub == nil {
+		panic("integrationtest: " + method + "() requires Start(t, WithInTreePlugins())")
+	}
 }
 
 // NewLocation creates a fresh persistent location in the world and returns

--- a/internal/testsupport/integrationtest/invariants_test.go
+++ b/internal/testsupport/integrationtest/invariants_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// This file is intentionally NOT build-tagged `//go:build integration`, unlike
+// the rest of this package. It is a source-scanning meta-test that only reads
+// plugins.go as a file (no integration symbols, no DB/bus/Docker), so it runs in
+// the fast `task test` lane to guard INV-WS-1 on every build.
+
+package integrationtest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithInTreePluginsReusesSubsystem enforces INV-WS-1: the capability MUST
+// reuse setup.PluginSubsystem and MUST NOT construct plugins.NewManager directly
+// in this package. Guards against a future refactor that silently forks the
+// production wiring.
+func TestWithInTreePluginsReusesSubsystem(t *testing.T) {
+	src, err := os.ReadFile("plugins.go")
+	require.NoError(t, err)
+	body := string(src)
+	require.Contains(t, body, "pluginsetup.NewPluginSubsystem(",
+		"INV-WS-1: capability must construct the PluginSubsystem")
+	require.NotContains(t, body, "plugins.NewManager(",
+		"INV-WS-1: capability must not construct plugins.NewManager directly — reuse PluginSubsystem")
+}

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -14,6 +14,14 @@ import (
 	"runtime"
 
 	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	policytypes "github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/command/handlers"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/world"
 )
 
 // assemblePluginsDir builds a unified plugins directory under dst by copying
@@ -91,6 +99,36 @@ func binaryArtifactsPresent(buildDir string) bool {
 	info, err := os.Stat(exe)
 	return err == nil && !info.IsDir()
 }
+
+type engineProvider struct {
+	eng      policytypes.AccessPolicyEngine
+	resolver *attribute.Resolver
+	auditor  pluginauthz.Auditor
+}
+
+func (p engineProvider) Engine() policytypes.AccessPolicyEngine { return p.eng }
+func (p engineProvider) AttributeResolver() *attribute.Resolver { return p.resolver }
+func (p engineProvider) AuditLogger() pluginauthz.Auditor       { return p.auditor }
+
+type sessionProvider struct{ store session.Access }
+
+func (p sessionProvider) SessionStore() session.Access { return p.store }
+
+type worldProvider struct{ svc *world.Service }
+
+func (p worldProvider) Service() *world.Service { return p.svc }
+
+type adminDepsProvider struct{ deps handlers.AdminDeps }
+
+func (p adminDepsProvider) AdminDeps() handlers.AdminDeps { return p.deps }
+
+type policyInstallerProvider struct{ inst *plugins.PolicyInstaller }
+
+func (p policyInstallerProvider) PolicyInstaller() *plugins.PolicyInstaller { return p.inst }
+
+type pluginProviderSetter struct{ pp *attribute.PluginProvider }
+
+func (p pluginProviderSetter) PluginProvider() *attribute.PluginProvider { return p.pp }
 
 func copyFile(src, dst string, mode os.FileMode) error {
 	in, err := os.Open(src)

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/samber/oops"
 )
@@ -52,6 +53,43 @@ func copyTree(src, dst string) error {
 		}
 		return copyFile(path, target, info.Mode())
 	})
+}
+
+// requirePluginsEnv, when truthy, turns a missing binary-plugin artifact into a
+// hard failure instead of a skip (INV-WS-3). The CI integration job sets it.
+const requirePluginsEnv = "HOLOMUSH_REQUIRE_PLUGINS" //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+
+// goPlatformDir is the per-platform subdir name build-plugins.sh emits
+// (e.g. "darwin-arm64", "linux-amd64").
+func goPlatformDir() string { return runtime.GOOS + "-" + runtime.GOARCH }
+
+// repoBuildPluginsDir resolves the build/plugins directory the same way
+// test/integration/plugin/binary_plugin_test.go does: PLUGIN_BINARY_DIR if set,
+// else <repoRoot>/build/plugins resolved from this source file's location.
+func repoBuildPluginsDir() string { //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+	if dir := os.Getenv("PLUGIN_BINARY_DIR"); dir != "" {
+		return dir
+	}
+	_, thisFile, _, _ := runtime.Caller(0)
+	// internal/testsupport/integrationtest/plugins.go → repo root is 3 dirs up.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	return filepath.Join(repoRoot, "build", "plugins")
+}
+
+// repoPluginsSrcDir resolves the source plugins/ tree from this file's location.
+func repoPluginsSrcDir() string { //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	return filepath.Join(repoRoot, "plugins")
+}
+
+// binaryArtifactsPresent reports whether the core-scenes binary for the current
+// platform exists under buildDir. core-scenes is the canonical production binary
+// plugin; if it built, the rest did too (single build-plugins.sh pass).
+func binaryArtifactsPresent(buildDir string) bool {
+	exe := filepath.Join(buildDir, "core-scenes", goPlatformDir(), "core-scenes")
+	info, err := os.Stat(exe)
+	return err == nil && !info.IsDir()
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -227,10 +227,18 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	// PolicyInstaller over a real policystore so manifest policies install.
 	policyInst := plugins.NewPolicyInstaller(policystore.NewPostgresStore(d.pool))
 
+	// Resolver must be non-nil: PluginSubsystem.Start calls
+	// resolver.RegisterProvider per plugin that declares resource_types
+	// (e.g. core-scenes' "scene" namespace). A nil resolver panics at
+	// subsystem.go:319. A fresh SchemaRegistry + Resolver is sufficient for
+	// the census suite, which reads load state and the command registry only.
+	schemaReg := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(schemaReg)
+
 	cfg := pluginsetup.PluginSubsystemConfig{
 		DataDir:            dataDir,
 		DatabaseConnStr:    d.connStr,
-		ABAC:               engineProvider{eng: d.engine},
+		ABAC:               engineProvider{eng: d.engine, resolver: resolver},
 		PolicyInst:         policyInstallerProvider{inst: policyInst},
 		PluginProv:         pluginProviderSetter{pp: attribute.NewPluginProvider(nil)},
 		World:              worldProvider{svc: worldSvc},

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -8,20 +8,34 @@
 package integrationtest
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/oops"
+	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/access/policy/attribute"
+	policystore "github.com/holomush/holomush/internal/access/policy/store"
 	policytypes "github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/auth"
+	authpostgres "github.com/holomush/holomush/internal/auth/postgres"
+	bootstrapsetup "github.com/holomush/holomush/internal/bootstrap/setup"
 	"github.com/holomush/holomush/internal/command/handlers"
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
+	worldpostgres "github.com/holomush/holomush/internal/world/postgres"
 )
 
 // assemblePluginsDir builds a unified plugins directory under dst by copying
@@ -65,7 +79,7 @@ func copyTree(src, dst string) error {
 
 // requirePluginsEnv, when truthy, turns a missing binary-plugin artifact into a
 // hard failure instead of a skip (INV-WS-3). The CI integration job sets it.
-const requirePluginsEnv = "HOLOMUSH_REQUIRE_PLUGINS" //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+const requirePluginsEnv = "HOLOMUSH_REQUIRE_PLUGINS"
 
 // goPlatformDir is the per-platform subdir name build-plugins.sh emits
 // (e.g. "darwin-arm64", "linux-amd64").
@@ -74,7 +88,7 @@ func goPlatformDir() string { return runtime.GOOS + "-" + runtime.GOARCH }
 // repoBuildPluginsDir resolves the build/plugins directory the same way
 // test/integration/plugin/binary_plugin_test.go does: PLUGIN_BINARY_DIR if set,
 // else <repoRoot>/build/plugins resolved from this source file's location.
-func repoBuildPluginsDir() string { //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+func repoBuildPluginsDir() string {
 	if dir := os.Getenv("PLUGIN_BINARY_DIR"); dir != "" {
 		return dir
 	}
@@ -85,7 +99,7 @@ func repoBuildPluginsDir() string { //nolint:unused // wired by WithInTreePlugin
 }
 
 // repoPluginsSrcDir resolves the source plugins/ tree from this file's location.
-func repoPluginsSrcDir() string { //nolint:unused // wired by WithInTreePlugins in Task 4 (holomush-0f0f4.4)
+func repoPluginsSrcDir() string {
 	_, thisFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
 	return filepath.Join(repoRoot, "plugins")
@@ -129,6 +143,119 @@ func (p policyInstallerProvider) PolicyInstaller() *plugins.PolicyInstaller { re
 type pluginProviderSetter struct{ pp *attribute.PluginProvider }
 
 func (p pluginProviderSetter) PluginProvider() *attribute.PluginProvider { return p.pp }
+
+// WithInTreePlugins boots the real in-tree plugin layer inside the harness
+// CoreServer by reusing production's setup.PluginSubsystem (which calls
+// Manager.LoadAll). It is engine-agnostic — compose it with WithPolicyEngine
+// for cross-plugin-ABAC coverage. If the binary-plugin artifacts are missing,
+// the harness skips the test (run `task plugin:build-all`), unless
+// HOLOMUSH_REQUIRE_PLUGINS is set, in which case it fails (INV-WS-3).
+//
+// Event EMISSION is deliberately NOT wired: startPlugins does not call
+// Manager.ConfigureEventEmitter, and the WorldService is built without an
+// EventEmitter. The whole-system census suite (holomush-0f0f4.8) reads plugin
+// load state and the command registry only, so emit paths are out of scope —
+// a test that drives a plugin command/handler which emits events will fail with
+// "plugin event emitter is not configured". Wiring the emitter is deferred until
+// a suite needs it.
+func WithInTreePlugins() StartOption {
+	return func(c *startConfig) { c.withPlugins = true }
+}
+
+// pluginDeps is the minimal set of already-built harness objects startPlugins
+// needs. Start passes these in so this helper stays decoupled from the Server.
+type pluginDeps struct {
+	pool         *pgxpool.Pool
+	connStr      string
+	engine       policytypes.AccessPolicyEngine
+	sessionStore session.Access
+	verbReg      *core.VerbRegistry
+	playerRepo   auth.PlayerRepository
+	hasher       auth.PasswordHasher
+	playerSess   auth.PlayerSessionRepository // *store.PostgresPlayerSessionStore satisfies this (player_session_store.go:30)
+}
+
+// startPlugins constructs and starts a PluginSubsystem mirroring production
+// (cmd/holomush/sub_grpc.go + internal/plugin/setup). It returns the started
+// subsystem; callers register Stop via t.Cleanup and read CommandRegistry()
+// for the dispatcher. It calls t.Skip/t.Fatal on a missing binary gate.
+func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.PluginSubsystem {
+	t.Helper()
+
+	buildDir := repoBuildPluginsDir()
+	if !binaryArtifactsPresent(buildDir) {
+		msg := "in-tree binary plugins not built; run `task plugin:build-all`"
+		if isTruthy(os.Getenv(requirePluginsEnv)) {
+			t.Fatalf("%s (HOLOMUSH_REQUIRE_PLUGINS set)", msg)
+		}
+		t.Skip(msg)
+	}
+
+	// Assemble the unified plugins dir under a per-test temp DataDir.
+	dataDir := t.TempDir()
+	pluginsDst := filepath.Join(dataDir, "plugins")
+	require.NoError(t,
+		assemblePluginsDir(pluginsDst, repoPluginsSrcDir(), buildDir),
+		"startPlugins: assemble plugins dir")
+
+	// WorldService — mirror internal/world/setup/subsystem.go. EventEmitter is
+	// intentionally omitted (production world/setup omits it too); world.NewService
+	// logs a benign slog.Warn. The census suite reads load state + registry only,
+	// so emit paths aren't exercised.
+	worldSvc := world.NewService(world.ServiceConfig{
+		LocationRepo:  worldpostgres.NewLocationRepository(d.pool),
+		ExitRepo:      worldpostgres.NewExitRepository(d.pool),
+		ObjectRepo:    worldpostgres.NewObjectRepository(d.pool),
+		SceneRepo:     worldpostgres.NewSceneRepository(d.pool),
+		CharacterRepo: worldpostgres.NewCharacterRepository(d.pool),
+		PropertyRepo:  worldpostgres.NewPropertyRepository(d.pool),
+		Engine:        d.engine,
+		Transactor:    worldpostgres.NewTransactor(d.pool),
+	})
+
+	// AdminDeps — all 5 caller-supplied fields required (handlers.RegisterAdmin
+	// panics on nil; subsystem.go calls it unconditionally). PluginLister is set
+	// by the subsystem itself.
+	adminDeps := handlers.AdminDeps{
+		PlayerRepo:     d.playerRepo,
+		Hasher:         d.hasher,
+		PlayerSessions: d.playerSess,
+		ResetRepo:      authpostgres.NewPasswordResetRepository(d.pool),
+		CharLister:     bootstrapsetup.NewCharRepoAdapter(d.pool, worldpostgres.NewCharacterRepository(d.pool)),
+	}
+
+	// PolicyInstaller over a real policystore so manifest policies install.
+	policyInst := plugins.NewPolicyInstaller(policystore.NewPostgresStore(d.pool))
+
+	cfg := pluginsetup.PluginSubsystemConfig{
+		DataDir:            dataDir,
+		DatabaseConnStr:    d.connStr,
+		ABAC:               engineProvider{eng: d.engine},
+		PolicyInst:         policyInstallerProvider{inst: policyInst},
+		PluginProv:         pluginProviderSetter{pp: attribute.NewPluginProvider(nil)},
+		World:              worldProvider{svc: worldSvc},
+		Sessions:           sessionProvider{store: d.sessionStore},
+		AdminDeps:          adminDepsProvider{deps: adminDeps},
+		Registry:           lifecycle.NewReadinessRegistry(),
+		VerbRegistry:       d.verbReg,
+		LuaTimeout:         5 * time.Second,
+		LuaRegistryMaxSize: 1024 * 1024,
+	}
+
+	ps := pluginsetup.NewPluginSubsystem(cfg)
+	t.Cleanup(func() { _ = ps.Stop(context.Background()) })
+	require.NoError(t, ps.Start(ctx), "startPlugins: PluginSubsystem.Start (LoadAll)")
+	return ps
+}
+
+// isTruthy treats "1", "true", "yes" (case-insensitive) as true.
+func isTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
 
 func copyFile(src, dst string, mode os.FileMode) error {
 	in, err := os.Open(src)

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+// assemblePluginsDir and related helpers implement the WithInTreePlugins
+// capability; see harness.go for the Server lifecycle they plug into.
+package integrationtest
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/samber/oops"
+)
+
+// assemblePluginsDir builds a unified plugins directory under dst by copying
+// the source plugins tree (Lua/setting manifests + Lua source) then overlaying
+// the compiled binary artifacts, mirroring the production image overlay
+// (Dockerfile COPY plugins/ then COPY build/plugins/). All copies are real
+// files: Manager.Discover skips symlinked dirs and goplugin.Host rejects
+// symlinked binaries.
+func assemblePluginsDir(dst, srcPlugins, buildPlugins string) error {
+	if err := copyTree(srcPlugins, dst); err != nil {
+		return oops.Code("PLUGINS_DIR_COPY_SOURCE").Wrap(err)
+	}
+	// build/plugins may be absent when binaries are not built; the binary gate
+	// (Task 2) handles that case. Overlay only if present.
+	if _, err := os.Stat(buildPlugins); err == nil {
+		if err := copyTree(buildPlugins, dst); err != nil {
+			return oops.Code("PLUGINS_DIR_OVERLAY_BUILD").Wrap(err)
+		}
+	}
+	return nil
+}
+
+// copyTree recursively copies src into dst, creating dst dirs as needed.
+// Existing dst files are overwritten (overlay semantics).
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error { //nolint:wrapcheck // test helper: walk errors are filesystem errors from t.TempDir paths
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err //nolint:wrapcheck // test helper: Rel only errors on unrooted paths, not possible here
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755) //nolint:gosec // test-only: 0o755 matches plugin dir permissions in the real tree
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err //nolint:wrapcheck // test helper: OS errors pass through directly
+	}
+	defer in.Close() //nolint:errcheck // read-only; close error inconsequential
+	dstDir := filepath.Dir(dst)
+	if mkErr := os.MkdirAll(dstDir, 0o755); mkErr != nil { //nolint:gosec // test-only: 0o755 matches plugin dir permissions
+		return mkErr //nolint:wrapcheck // test helper: OS errors pass through directly
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err //nolint:wrapcheck // test helper: OS errors pass through directly
+	}
+	defer out.Close() //nolint:errcheck // final close below is the authoritative error check
+	if _, cpErr := io.Copy(out, in); cpErr != nil {
+		return cpErr //nolint:wrapcheck // test helper: IO errors pass through directly
+	}
+	return out.Close() //nolint:wrapcheck // test helper: final flush/close error is surfaced directly
+}

--- a/internal/testsupport/integrationtest/plugins_test.go
+++ b/internal/testsupport/integrationtest/plugins_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 )
 
 func TestAssemblePluginsDirOverlaysSourceAndBuild(t *testing.T) {
@@ -52,4 +54,18 @@ func TestBinaryArtifactsPresentDetectsCoreScenes(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(build, "core-scenes", platform), 0o755))                                //nolint:gosec // test-only
 	require.NoError(t, os.WriteFile(filepath.Join(build, "core-scenes", platform, "core-scenes"), []byte("ELF"), 0o755)) //nolint:gosec // test-only
 	require.True(t, binaryArtifactsPresent(build))
+}
+
+func TestPluginProvidersSatisfyInterfaces(t *testing.T) {
+	// Compile-time interface satisfaction is the real assertion; this test
+	// exists so the file fails to build if an adapter drifts from its iface.
+	var (
+		_ pluginsetup.EngineProvider          = engineProvider{}
+		_ pluginsetup.SessionProvider         = sessionProvider{}
+		_ pluginsetup.WorldServiceProvider    = worldProvider{}
+		_ pluginsetup.AdminDepsProvider       = adminDepsProvider{}
+		_ pluginsetup.PolicyInstallerProvider = policyInstallerProvider{}
+		_ pluginsetup.PluginProviderSetter    = pluginProviderSetter{}
+	)
+	require.NotNil(t, &engineProvider{})
 }

--- a/internal/testsupport/integrationtest/plugins_test.go
+++ b/internal/testsupport/integrationtest/plugins_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssemblePluginsDirOverlaysSourceAndBuild(t *testing.T) {
+	root := t.TempDir()
+	// Fake source tree: two plugin dirs with manifests.
+	srcPlugins := filepath.Join(root, "plugins")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcPlugins, "core-help"), 0o755))                                                  //nolint:gosec // test-only: mirroring real plugin dir permissions
+	require.NoError(t, os.MkdirAll(filepath.Join(srcPlugins, "core-scenes"), 0o755))                                                //nolint:gosec // test-only: mirroring real plugin dir permissions
+	require.NoError(t, os.WriteFile(filepath.Join(srcPlugins, "core-help", "plugin.yaml"), []byte("name: core-help\n"), 0o644))     //nolint:gosec // test-only: yaml manifests are not sensitive
+	require.NoError(t, os.WriteFile(filepath.Join(srcPlugins, "core-scenes", "plugin.yaml"), []byte("name: core-scenes\n"), 0o644)) //nolint:gosec // test-only: yaml manifests are not sensitive
+	// Fake build tree: core-scenes binary overlay.
+	buildPlugins := filepath.Join(root, "build", "plugins")
+	require.NoError(t, os.MkdirAll(filepath.Join(buildPlugins, "core-scenes", "linux-amd64"), 0o755))                                //nolint:gosec // test-only: mirroring real plugin dir permissions
+	require.NoError(t, os.WriteFile(filepath.Join(buildPlugins, "core-scenes", "linux-amd64", "core-scenes"), []byte("ELF"), 0o755)) //nolint:gosec // test-only: executable bit required for plugin binary simulation
+
+	dst := t.TempDir()
+	err := assemblePluginsDir(dst, srcPlugins, buildPlugins)
+	require.NoError(t, err)
+
+	// Both source manifests present.
+	require.FileExists(t, filepath.Join(dst, "core-help", "plugin.yaml"))
+	require.FileExists(t, filepath.Join(dst, "core-scenes", "plugin.yaml"))
+	// Binary overlay present in the same plugin dir.
+	require.FileExists(t, filepath.Join(dst, "core-scenes", "linux-amd64", "core-scenes"))
+	// No symlinks (Discover skips them).
+	info, err := os.Lstat(filepath.Join(dst, "core-scenes"))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Zero(t, info.Mode()&os.ModeSymlink, "plugin dir must be a real dir, not a symlink")
+}

--- a/internal/testsupport/integrationtest/plugins_test.go
+++ b/internal/testsupport/integrationtest/plugins_test.go
@@ -41,3 +41,15 @@ func TestAssemblePluginsDirOverlaysSourceAndBuild(t *testing.T) {
 	require.True(t, info.IsDir())
 	require.Zero(t, info.Mode()&os.ModeSymlink, "plugin dir must be a real dir, not a symlink")
 }
+
+func TestBinaryArtifactsPresentDetectsCoreScenes(t *testing.T) {
+	root := t.TempDir()
+	build := filepath.Join(root, "build", "plugins")
+	// Absent → false.
+	require.False(t, binaryArtifactsPresent(build))
+	// Present (core-scenes for the current platform) → true.
+	platform := goPlatformDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(build, "core-scenes", platform), 0o755))                                //nolint:gosec // test-only
+	require.NoError(t, os.WriteFile(filepath.Join(build, "core-scenes", platform, "core-scenes"), []byte("ELF"), 0o755)) //nolint:gosec // test-only
+	require.True(t, binaryArtifactsPresent(build))
+}

--- a/site/docs/contributing/integration-tests.md
+++ b/site/docs/contributing/integration-tests.md
@@ -202,6 +202,107 @@ so JetStream ack + audit semantics match.
 
 ---
 
+## Whole-system plugin tier (`WithInTreePlugins`)
+
+The harness supports an opt-in **whole-system** mode that loads all in-tree
+plugins, exercising the same production plugin wiring path. This is the top
+Go-fidelity integration tier (see canonical tier table in
+`.claude/rules/testing.md`).
+
+### Opt-in
+
+```go
+srv := integrationtest.Start(t, integrationtest.WithInTreePlugins())
+```
+
+Omitting `WithInTreePlugins` leaves the plugin subsystem nil — existing
+targeted suites (`privacy`, `presence`) are unaffected (INV-WS-4).
+
+### How it works
+
+`WithInTreePlugins()` reuses production's `setup.PluginSubsystem` (which calls
+`Manager.LoadAll`) — it does NOT construct `plugins.NewManager` directly in the
+harness (INV-WS-1). The harness assembles a temporary `plugins/` overlay (the
+source tree's `plugins/` directory + compiled artifacts from `build/plugins/`),
+then calls `PluginSubsystem.Start(ctx)`, which DAG-resolves and loads all
+in-tree plugins.
+
+**What loads:** discover-all finds 8 runtime plugins — 5 core Lua plugins
+(`core-aliases`, `core-building`, `core-communication`, `core-help`,
+`core-objects`), 1 additional Lua plugin (`echo-bot`), and 2 binary plugins
+(`core-scenes`, `test-abac-widget`). The 2 setting plugins
+(`setting-crossroads` / `setting-skeleton`, manifest names `crossroads` /
+`skeleton`) are configuration-only: they fall through to `loadPlugin`'s
+`default` branch, which logs a warning and skips them, so they are not
+registered in the Manager's loaded set.
+
+**Event emission is NOT wired.** `WithInTreePlugins` does not call
+`Manager.ConfigureEventEmitter`. The whole-system census reads plugin load
+state and the command registry only. A plugin command that emits events will
+fail with "plugin event emitter is not configured" until a future suite wires
+it explicitly.
+
+**Accessors panic without the option.** `PluginManager()`,
+`CommandRegistry()`, and `ServiceRegistry()` are only valid when
+`WithInTreePlugins` was passed; calling them otherwise panics with a clear
+message.
+
+### Prerequisite: build the binary plugins
+
+Binary plugins (`core-scenes`, `test-abac-widget`) must be compiled before
+running the whole-system suite:
+
+```bash
+task plugin:build-all   # compile all binary plugins for linux/amd64
+```
+
+`task test:int` runs `plugin:build-all` automatically, so CI always has fresh
+artifacts. If you run integration tests outside `task test:int` without prior
+builds, the harness skips (INV-WS-3): locally it calls `t.Skip`; when
+`HOLOMUSH_REQUIRE_PLUGINS=1` is set (as in CI), it calls `t.Fatalf` so CI
+never silently green-skips past missing binaries.
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as Suite (Ginkgo)
+    participant H as integrationtest.Start
+    participant PS as PluginSubsystem
+    participant M as plugin.Manager
+    participant SRV as integrationtest.Server
+    S->>H: Start(t, WithInTreePlugins())
+    H->>H: binary-gate check (skip or fatal if artifacts absent)
+    H->>H: assemblePluginsDir (overlay plugins/ + build/plugins/)
+    H->>PS: setup.NewPluginSubsystem(cfg).Start(ctx)
+    PS->>M: LoadAll(ctx) [strict, DAG-resolved]
+    M-->>PS: 8 runtime plugins loaded; commands/verbs/aliases registered
+    PS-->>H: Manager, CommandRegistry, ServiceRegistry
+    H-->>S: *Server (srv)
+    S->>SRV: PluginManager().ListPlugins() — census assertion
+    S->>SRV: CommandRegistry().Get("help") — command registration assertion
+```
+
+### Suite and test packages
+
+| Package                                 | Bead epic | What it asserts                                              |
+| --------------------------------------- | --------- | ------------------------------------------------------------ |
+| `test/integration/wholesystem/`         | 0f0f4     | INV-5: all in-tree plugins load; `help` command registered   |
+
+When you add a test package that uses `WithInTreePlugins`, append it to this
+table and to the main "Test packages currently using the harness" table above.
+
+### Invariants
+
+| # | Invariant | Enforcement |
+| --- | --- | --- |
+| INV-5 | The whole-system suite MUST load all in-tree plugins via `Manager.LoadAll` | Routing through `PluginSubsystem.Start`; census asserts full plugin set |
+| INV-WS-1 | `WithInTreePlugins` MUST reuse `setup.PluginSubsystem`, not fork `plugins.NewManager` directly | Meta-test `TestWithInTreePluginsReusesSubsystem` source-scans `integrationtest/` |
+| INV-WS-3 | Whole-system suite MUST NOT be silently skipped in CI | `HOLOMUSH_REQUIRE_PLUGINS=1` converts the missing-artifact skip to `t.Fatalf`; CI's `task test:int` runs `plugin:build-all` first and globs `./...`, so the suite always runs |
+| INV-WS-4 | `WithInTreePlugins` MUST be opt-in; omitting it leaves harness plugin-free | Existing targeted suites pass with no edits; harness test asserts no plugin subsystem starts by default |
+
+---
+
 ## Related
 
 - `internal/eventbus/eventbustest/` — bus-only harness for unit tests that

--- a/test/integration/wholesystem/census_test.go
+++ b/test/integration/wholesystem/census_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package wholesystem_test
+
+import (
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+// expectedPlugins is the in-tree set discover-all loads. NOTE: these are plugin
+// MANIFEST names (ListPlugins returns manifest names, not dir names): the
+// setting-crossroads/setting-skeleton dirs have manifest names crossroads/skeleton,
+// but TypeSetting is not handled by loadPlugin (falls through to default/skip with
+// warning), so setting plugins do NOT appear in ListPlugins(). Only Lua and Binary
+// plugins are registered in Manager.loaded.
+var expectedPlugins = []string{
+	"core-aliases", "core-building", "core-communication", "core-help",
+	"core-objects", "core-scenes", "echo-bot",
+	"test-abac-widget",
+}
+
+var _ = Describe("whole-system plugin load (INV-5)", Ordered, func() {
+	var srv *integrationtest.Server
+
+	BeforeAll(func() {
+		srv = integrationtest.Start(suiteT, integrationtest.WithInTreePlugins())
+	})
+	AfterAll(func() {
+		if srv != nil {
+			srv.Stop()
+		}
+	})
+
+	It("loads every in-tree plugin via Manager.LoadAll", func() {
+		loaded := srv.PluginManager().ListPlugins()
+		for _, name := range expectedPlugins {
+			Expect(loaded).To(ContainElement(name), "plugin %q must load", name)
+		}
+	})
+
+	It("registers plugin commands in the dispatcher registry", func() {
+		reg := srv.CommandRegistry()
+		_, ok := reg.Get("help")
+		Expect(ok).To(BeTrue(), "core-help command must be registered")
+	})
+})

--- a/test/integration/wholesystem/wholesystem_suite_test.go
+++ b/test/integration/wholesystem/wholesystem_suite_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package wholesystem_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+// suiteT exposes the *testing.T from TestWholeSystem so Ginkgo Describe blocks
+// can pass it to integrationtest.Start (which requires *testing.T — Ginkgo's
+// GinkgoT() does not satisfy that interface directly).
+var suiteT *testing.T
+
+func TestWholeSystem(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Whole-System Plugin Integration Suite")
+}


### PR DESCRIPTION
## Summary

Implements **10 of 11 beads** under epic `holomush-0f0f4`. Adds `integrationtest.WithInTreePlugins()` — an opt-in harness `StartOption` that boots the real in-tree plugin layer by reusing production's `setup.PluginSubsystem` (`Manager.LoadAll`) — plus a `test/integration/wholesystem/` Ginkgo census suite, the `HOLOMUSH_REQUIRE_PLUGINS` CI guard, and PR-blocking docs.

- **Spec:** `docs/superpowers/specs/2026-05-25-wholesystem-plugin-integration-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-25-wholesystem-plugin-integration.md`

Landed autonomously via `/drain epic holomush-0f0f4`.

## What's included (10 beads)

| Bead | Change |
|---|---|
| `.1` | Plugins-dir overlay assembly helper |
| `.2` | Binary-plugin availability gate detection |
| `.3` | Plugin-subsystem provider adapters |
| `.4` | `WithInTreePlugins` option + subsystem startup wiring |
| `.5` | Plugin subsystem teardown + accessors |
| `.6` | INV-WS-1 reuse-`PluginSubsystem` meta-test |
| `.7` | INV-WS-4 default-plugin-free guarantee (integration) |
| `.8` | Whole-system suite bootstrap + structural census |
| `.10` | CI guard: `HOLOMUSH_REQUIRE_PLUGINS` in integration job |
| `.11` | Docs: whole-system tier + `WithInTreePlugins` |

## Invariants

- **INV-5** — whole-system suite loads all in-tree plugins via `Manager.LoadAll`
- **INV-WS-1** — `WithInTreePlugins` reuses production `setup.PluginSubsystem`, not a raw `Manager`
- **INV-WS-3** — whole-system suite MUST NOT be silently skipped in CI (`HOLOMUSH_REQUIRE_PLUGINS=1` converts the missing-artifact skip to `t.Fatalf`)
- **INV-WS-4** — `WithInTreePlugins` is opt-in; omitting it leaves the harness plugin-free

`WithInTreePlugins()` is engine-agnostic — it composes with `WithPolicyEngine`.

## Deferred

- **`.9` Cross-plugin-ABAC permit/deny (INV-WS-2)** — blocked on `holomush-f5t07` (the harness `WithRealABAC` path). The epic stays open; `.9` lands in a follow-up once f5t07 closes (`/drain resume holomush-siciv`).

## Review notes

- Pre-push `code-reviewer`: **READY**, no blocking findings (reviewer ran the suites + lint independently).
- **Finding #1** (a doc line claimed an INV-WS-3 "guard spec asserts suite ran" mechanism that does not exist) — **fixed** in this PR.
- **Finding #2** (census asserts set-containment, not exact name + count) — **accepted as designed**: strict `LoadAll` aborts on any load failure and each expected plugin is asserted present, so the headline regression class (a plugin failing to load) is caught; an exact-count assertion would be brittle as plugins are added.

## Test plan

- `HOLOMUSH_PR_PREP_FORCE_FULL=1 task pr-prep` — **full lane green** (lint, build, unit, integration, E2E) on this stack rebased onto current `main` (#4273).
- Whole-system integration suite loads all in-tree plugins (6 Lua / 2 binary / 2 setting — setting plugins do not appear in `ListPlugins`) with no `SERVICE_ALREADY_REGISTERED` collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
