### PR TITLE
feat(integrationtest): WithRealABAC() boots real seeded ABAC engine in harness (holomush-f5t07)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -221,6 +221,26 @@ Keep under 200 lines. Curate — don't hoard.
   short-form `"say"` never matches. Don't trust a bead's "gated on capability"
   hypothesis without tracing the actual path. Encountered: holomush-gria3.
 
+- **`location:<id>` stream reads bypass `engine.Evaluate` — gated by the location
+  hard-gate, not ABAC Layer 3.** `QueryStreamHistory`
+  (`internal/grpc/query_stream_history.go:196-211`) routes `isLocationStream`
+  streams to a hard-gate: `if !staffOverride(...) { if info.LocationID != extractLocationID(stream) { DENY } }`.
+  `staffOverride` (`scope_floor.go:88-103`) is the ONLY ABAC consult for location
+  streams — it evaluates `read_unrestricted_history` on `stream:*`. A **co-located**
+  location read (`info.LocationID == requested`) is permitted by the hard-gate
+  WITHOUT ever consulting ABAC for the `stream:` resource, so
+  `seed:player-location-stream-read` is effectively dead for this handler. Consequence
+  for harness-real-ABAC test review: a "colocated permit succeeds only because the
+  stream provider is registered" sentinel does NOT work through `QueryStreamHistory`
+  (the hard-gate permits regardless of provider registration). The valid g776
+  sentinel is the ADMIN/non-colocated path: admin role → `"admin" in
+  principal.character.roles` (CharacterProvider + RoleResolver, needs RoleStore wired)
+  → `seed:admin-full-access`/`seed:staff-read-unrestricted-history` permits
+  `read_unrestricted_history` → staffOverride true → bypass hard-gate. An unregistered
+  roles provider flips admin to denied. Only ABAC Layer 3 (`global`, `system`, …
+  non-location public streams) hits `engine.Evaluate` directly. Encountered:
+  holomush-f5t07 (2026-05-26).
+
 ## Invariants worth remembering
 
 - **Top-level oops Code() is the wire-visible code**: client-side error

--- a/docs/adr/holomush-jvrq3-harness-plugin-resolver-pointer-identity.md
+++ b/docs/adr/holomush-jvrq3-harness-plugin-resolver-pointer-identity.md
@@ -1,0 +1,75 @@
+# Harness Threads the Engine's ABAC Resolver/PluginProvider Into the Plugin Layer
+
+**Status:** Accepted
+**Decision:** holomush-jvrq3
+**Related:** holomush-vjg7z (plugin layer as opt-in harness capability — not superseded), holomush-f5t07 (WithRealABAC), holomush-0f0f4.9 (consumer)
+
+## Context
+
+The `internal/testsupport/integrationtest` harness loads in-tree plugins via
+`startPlugins` (PR #4275, `WithInTreePlugins`). That code allocates **standalone**
+`attribute.NewResolver(...)` and `attribute.NewPluginProvider(nil)` instances,
+independent of whichever access engine the harness wires. `PluginSubsystem.Start`
+calls `resolver.RegisterProvider` per plugin that declares resource types (e.g.
+core-scenes' `scene` namespace) onto that standalone resolver.
+
+Under the harness default (`allowAllPolicyEngine`) this is harmless — the engine
+ignores attributes. But when a **real seeded ABAC engine** is present
+(`WithRealABAC`, holomush-f5t07), the engine evaluates against the
+`*attribute.Resolver` it was *built* with. If the plugin subsystem registered its
+providers on a *different* (standalone) resolver, every policy gating a
+plugin-declared namespace (`resource.scene.*`) resolves against an empty
+attribute set and **silently default-denies** — no error, no log. This is the
+exact failure fingerprint of holomush-g776 (LocationProvider unregistered) and
+holomush-xxel (PropertyProvider), and it is the blocking defect for
+holomush-0f0f4.9 (cross-plugin ABAC permit/deny).
+
+## Decision
+
+When the harness boots a real ABAC engine alongside plugins, `startPlugins` MUST
+receive the engine subsystem's **own** `*attribute.Resolver`,
+`*attribute.PluginProvider`, and `pluginauthz.Auditor` instances (pointer
+identity), obtained from `abacsetup.ABACSubsystem.AttributeResolver()` /
+`PluginProvider()` / `AuditLogger()`. When no real engine is present (allow-all
+default), freshly-allocated standalone instances remain correct.
+
+The selection is centralized in a `pluginAttrSources(abacSub)` helper: it returns
+the subsystem's instances when `abacSub != nil`, else fresh standalone ones. The
+contract is enforced by INV-RA-4 (`require.Same` on the resolver and plugin
+provider).
+
+## Rationale
+
+- Plugin attribute providers register on a resolver instance at load time; the
+  engine evaluates against the resolver it was built with. Mismatched instances
+  produce silent default-deny — the hardest failure mode to diagnose, and the
+  documented root cause of two prior multi-week regressions.
+- `abacsetup.ABACSubsystem` exposes all three concrete handles precisely because
+  the plugin layer and the engine must share instances; using them is "doing what
+  production does."
+- The invariant is cross-cutting: any future harness capability that combines an
+  attribute-providing subsystem with a real evaluating engine must honor it.
+  Recording it as an ADR makes the contract discoverable before a contributor
+  introduces a third subsystem that re-breaks it.
+
+## Alternatives Considered
+
+- **Keep the standalone resolver; post-construction swap the engine's resolver
+  reference.** Rejected: requires a mutable resolver-swap API that does not (and
+  should not) exist; introduces an ordering hazard between plugin registration
+  and engine use; no clean pointer-identity test.
+- **Status quo (standalone resolver, allow-all only).** Rejected: makes
+  real-ABAC + plugins a permanently broken combination in the harness;
+  holomush-0f0f4.9 could never pass; the `WithInTreePlugins` path would silently
+  misevaluate `resource.scene.*` the moment a real engine is introduced.
+
+## Consequences
+
+- **Positive:** cross-plugin ABAC permit/deny becomes testable at integration
+  tier; the wiring rule is regression-detected by `require.Same`; future
+  harness opt-ins have a documented contract.
+- **Negative:** `startPlugins` accepts caller-supplied resolver/provider/auditor
+  via `pluginDeps` instead of self-allocating; its code path branches on whether
+  a real subsystem is present.
+- **Neutral:** the `pluginAttrSources` helper makes the branch explicit and
+  unit-testable.

--- a/docs/superpowers/plans/2026-05-26-harness-real-abac.md
+++ b/docs/superpowers/plans/2026-05-26-harness-real-abac.md
@@ -259,7 +259,7 @@ Expected: no findings. (Use line-scoped `//nolint:<rule> // reason` only if a sp
 
 - [ ] **Step 7: Commit**
 
-```
+```text
 jj commit -m "feat(integrationtest): WithRealABAC() boots real seeded ABAC engine (holomush-f5t07)
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
@@ -461,7 +461,7 @@ Expected: PASS. `TestRealABAC_OptionOrderIndependent` runs (not skipped) once bi
 
 Run: `task lint:go` (expect clean), then:
 
-```
+```text
 jj commit -m "feat(integrationtest): thread real resolver/provider/auditor into plugin layer (holomush-f5t07)
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
@@ -520,7 +520,7 @@ Expected: PASS (markdown formatting clean).
 
 - [ ] **Step 4: Commit**
 
-```
+```text
 jj commit -m "docs(integrationtest): document WithRealABAC opt-in and role semantics (holomush-f5t07)
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"

--- a/docs/superpowers/plans/2026-05-26-harness-real-abac.md
+++ b/docs/superpowers/plans/2026-05-26-harness-real-abac.md
@@ -1,0 +1,544 @@
+# WithRealABAC() Harness Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `WithRealABAC()` StartOption to the integration harness that boots the real seeded ABAC engine via production's `abacsetup.NewABACSubsystem`, so full-stack integration tests can catch g776-class default-deny regressions.
+
+**Architecture:** Mirror PR #4275's `WithInTreePlugins()` pattern. A new `startConfig.withRealABAC` flag drives `Start()` to seed the `seed:*` policy set (`policy.Bootstrap`), boot `abacsetup.NewABACSubsystem`, use its `Engine()` as the harness access engine, and thread its concrete `AttributeResolver()`/`PluginProvider()`/`AuditLogger()` into the plugin layer (fixing the standalone-resolver bug). Default stays allow-all; opt-in only.
+
+**Tech Stack:** Go, `//go:build integration`, testify (`require`), Postgres testcontainer (`testutil.SharedPostgres`), embedded NATS (`eventbustest`).
+
+**Spec:** `docs/superpowers/specs/2026-05-26-harness-real-abac-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `internal/testsupport/integrationtest/real_abac.go` | `WithRealABAC` wiring helpers: `poolProvider` adapter, `startRealABAC` (seed + subsystem boot), `pluginAttrSources` (resolver/provider/auditor selection) | Create |
+| `internal/testsupport/integrationtest/harness.go` | `startConfig.withRealABAC` field, `WithRealABAC()` option, `Start()` real-engine branch + plugin threading | Modify |
+| `internal/testsupport/integrationtest/plugins.go` | `pluginDeps` gains `resolver`/`pluginProvider`/`auditor`; `startPlugins` uses them instead of standalone instances | Modify |
+| `internal/testsupport/integrationtest/real_abac_test.go` | All INV-RA-* tests (in-package; white-box helper tests + RPC-driven behavioral tests) | Create |
+| `site/docs/contributing/integration-tests.md` | Document `WithRealABAC` (composition, seed step, live role semantics) | Modify |
+
+**Note on test placement:** Tests live in-package (`package integrationtest`) because INV-RA-4 exercises unexported `pluginAttrSources`/`startRealABAC`. The harness package is `//go:build integration` and is already run under `task test:int` (see existing `harness_smoke_test.go`).
+
+---
+
+### Task 1: `WithRealABAC()` option + real-engine boot
+
+**Files:**
+
+- Create: `internal/testsupport/integrationtest/real_abac.go`
+- Modify: `internal/testsupport/integrationtest/harness.go` (`startConfig` at `:132`, add option near `WithPolicyEngine` at `:142`, `Start()` after `pe := cfg.accessEngine` at `:218`)
+- Test: `internal/testsupport/integrationtest/real_abac_test.go`
+
+**Grounding (verified against current main):**
+
+- Seed policies are runtime-installed via `policy.Bootstrap(ctx, partitions, policyStore, compiler, logger, opts)` (`internal/access/policy/bootstrap.go:30`); `BootstrapOptions{SkipSeedMigrations bool}` (`bootstrap.go:23`).
+- `abacsetup.NewABACSubsystem(ABACSubsystemConfig{DB PoolProvider, Registry *lifecycle.ReadinessRegistry, AuditMode, CryptoOperators})` (`internal/access/setup/subsystem.go:31,51`); `PoolProvider = { Pool() *pgxpool.Pool }` (`subsystem.go`). `Start()` builds all repos from the pool internally (`subsystem.go:79-90`) and starts a poller goroutine (`subsystem.go:105`). `Engine()` (`:124`).
+- `audit.NewPostgresPartitionCreator(pool)` (`internal/audit/partition_creator.go:22`); `policystore.NewPostgresStore(pool)`; `policy.NewCompiler(types.NewAttributeSchema())` (`compiler.go:31`, `types/types.go:368`).
+- Under real ABAC, a regular character reading a **different** location's stream is denied (`staffOverride` returns false — no `read_unrestricted_history`; `internal/grpc/scope_floor.go:88`). Under the allow-all default that same read **succeeds** (staff bypass). A **same-location** read succeeds under either engine (session/colocation floor, ABAC-independent).
+- Helpers: `Server.ConnectAuthed(ctx, name) *Session` (`harness.go:510`), `Server.NewLocation(ctx) ulid.ULID` (`harness.go:345`), `Session.MoveTo(ctx, locID)` (`session.go:203`), `Session.QueryStreamHistory(ctx, stream) ([]*corev1.EventFrame, error)` (`session.go:504`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/testsupport/integrationtest/real_abac_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package integrationtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/require"
+)
+
+// movedAwayPlayer connects charName, records its start location, then moves it
+// to a fresh location. Querying the START location afterward is the ABAC-gated
+// (different-location) path: permitted only for staff via read_unrestricted_history.
+func movedAwayPlayer(t *testing.T, ctx context.Context, ts *Server, charName string, roles []string) (sess *Session, priorStream string) {
+	t.Helper()
+	if roles == nil {
+		sess = ts.ConnectAuthed(ctx, charName)
+	} else {
+		sess = ts.ConnectAuthedWithRoles(ctx, charName, roles)
+	}
+	priorStream = "location:" + sess.LocationID.String()
+	sess.MoveTo(ctx, ts.NewLocation(ctx))
+	return sess, priorStream
+}
+
+// INV-RA-1: under WithRealABAC, a regular (non-staff) character is DENIED a
+// read against a location it has left. Allow-all would permit this via the
+// staffOverride bypass — so a passing assertion here proves the engine is the
+// real seeded engine, not allowAllPolicyEngine.
+func TestRealABAC_RegularPlayerDeniedNonColocatedRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t, WithRealABAC())
+	mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+	_, err := mover.QueryStreamHistory(ctx, priorStream)
+	require.Error(t, err, "INV-RA-1: real engine MUST deny a regular player's non-colocated read")
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "denial must surface as an oops error")
+	require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
+		"INV-RA-1: denial MUST collapse to STREAM_ACCESS_DENIED")
+}
+
+// INV-RA-2: without WithRealABAC, the harness retains the allow-all default —
+// the same non-colocated read SUCCEEDS (staff bypass). Guards against an
+// accidental flip of the default.
+func TestRealABAC_DefaultEngineStillAllowAll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t) // no WithRealABAC
+	mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+	_, err := mover.QueryStreamHistory(ctx, priorStream)
+	require.NoError(t, err,
+		"INV-RA-2: allow-all default MUST permit the non-colocated read via staff bypass")
+}
+
+// INV-RA-3 + INV-RA-5: under WithRealABAC, an admin-role character is PERMITTED
+// the non-colocated read via seed:admin-full-access (read_unrestricted_history).
+// This proves (a) the seed:* set is installed and a seeded permit works, and
+// (b) the provider populating principal.character.roles is registered — an
+// unregistered provider (the g776/xxel fingerprint) would silently default-deny
+// and flip this to STREAM_ACCESS_DENIED, which allow-all would have masked.
+func TestRealABAC_AdminPermittedNonColocatedRead_g776Sentinel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t, WithRealABAC())
+	boss, priorStream := movedAwayPlayer(t, ctx, ts, "Boss", []string{"admin"})
+
+	_, err := boss.QueryStreamHistory(ctx, priorStream)
+	require.NoError(t, err,
+		"INV-RA-3/RA-5: seed:admin-full-access MUST permit an admin's non-colocated read; "+
+			"a failure here means seeds weren't installed or the roles provider is unregistered")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `task test:int -- -run TestRealABAC ./internal/testsupport/integrationtest/`
+Expected: FAIL — `undefined: WithRealABAC`.
+
+- [ ] **Step 3: Create the wiring helper**
+
+Create `internal/testsupport/integrationtest/real_abac.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package integrationtest
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy"
+	policystore "github.com/holomush/holomush/internal/access/policy/store"
+	policytypes "github.com/holomush/holomush/internal/access/policy/types"
+	abacsetup "github.com/holomush/holomush/internal/access/setup"
+	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/internal/lifecycle"
+)
+
+// poolProvider adapts a *pgxpool.Pool to abacsetup.PoolProvider so the harness
+// can hand the test pool to the production ABAC subsystem.
+type poolProvider struct{ pool *pgxpool.Pool }
+
+func (p poolProvider) Pool() *pgxpool.Pool { return p.pool }
+
+// startRealABAC seeds the production seed:* policy set and boots the real ABAC
+// subsystem (production's abacsetup.NewABACSubsystem path, the same constructor
+// cmd/holomush/core.go:380 uses). It returns the started subsystem; callers read
+// Engine()/AttributeResolver()/PluginProvider()/AuditLogger() and the poller is
+// stopped via t.Cleanup.
+func startRealABAC(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *abacsetup.ABACSubsystem {
+	t.Helper()
+
+	// Seed first: the subsystem's Start → BuildABACStack → cache.Reload reads
+	// the policy store at construction. An unseeded store has zero policies and
+	// default-denies everything.
+	require.NoError(t,
+		policy.Bootstrap(
+			ctx,
+			audit.NewPostgresPartitionCreator(pool),
+			policystore.NewPostgresStore(pool),
+			policy.NewCompiler(policytypes.NewAttributeSchema()),
+			slog.Default(),
+			policy.BootstrapOptions{},
+		),
+		"startRealABAC: seed policies",
+	)
+
+	abacSub := abacsetup.NewABACSubsystem(abacsetup.ABACSubsystemConfig{
+		DB:       poolProvider{pool: pool},
+		Registry: lifecycle.NewReadinessRegistry(),
+	})
+	require.NoError(t, abacSub.Start(ctx), "startRealABAC: ABAC subsystem start")
+	t.Cleanup(func() { _ = abacSub.Stop(context.Background()) })
+	return abacSub
+}
+```
+
+- [ ] **Step 4: Wire the option into harness.go**
+
+In `internal/testsupport/integrationtest/harness.go`, add the field to `startConfig` (currently `:132`):
+
+```go
+type startConfig struct {
+	accessEngine types.AccessPolicyEngine
+	withPlugins  bool
+	withRealABAC bool
+}
+```
+
+Add the option next to `WithPolicyEngine` (`:142`):
+
+```go
+// WithRealABAC boots the real seeded ABAC engine inside the harness via
+// production's abacsetup.NewABACSubsystem (which calls setup.BuildABACStack),
+// seeding the seed:* policy set first. Opt-in; the default stays allow-all.
+// Compose with WithInTreePlugins for cross-plugin ABAC coverage.
+//
+// Under WithRealABAC, character_roles become load-bearing: ConnectAuthedWithRoles
+// grants role-based permits, while a roleless ConnectAuthed receives only what
+// seed:* grants a roleless character.
+func WithRealABAC() StartOption {
+	return func(c *startConfig) { c.withRealABAC = true }
+}
+```
+
+In `Start()`, immediately after `pe := cfg.accessEngine` (`:218`), add:
+
+```go
+	// Real seeded ABAC engine (opt-in). Overrides the allow-all default and is
+	// retained for the plugin layer's resolver/pluginProvider threading below.
+	var abacSub *abacsetup.ABACSubsystem
+	if cfg.withRealABAC {
+		abacSub = startRealABAC(t, ctx, pool)
+		pe = abacSub.Engine()
+	}
+```
+
+Add the import to harness.go's import block:
+
+```go
+	abacsetup "github.com/holomush/holomush/internal/access/setup"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test:int -- -run TestRealABAC ./internal/testsupport/integrationtest/`
+Expected: PASS (all three). Requires Docker (Postgres testcontainer).
+
+- [ ] **Step 6: Lint**
+
+Run: `task lint:go`
+Expected: no findings. (Use line-scoped `//nolint:<rule> // reason` only if a specific finding is unavoidable; never widen `.golangci.yaml`.)
+
+- [ ] **Step 7: Commit**
+
+```
+jj commit -m "feat(integrationtest): WithRealABAC() boots real seeded ABAC engine (holomush-f5t07)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Thread real resolver/pluginProvider/auditor into the plugin layer
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/real_abac.go` (add `pluginAttrSources`)
+- Modify: `internal/testsupport/integrationtest/plugins.go` (`pluginDeps` at `:167`, standalone-resolver block at `:235-236,:243`, `cfg.ABAC` at `:242`)
+- Modify: `internal/testsupport/integrationtest/harness.go` (plugin call site at `:234`)
+- Test: `internal/testsupport/integrationtest/real_abac_test.go`
+
+**Grounding (verified):**
+
+- `startPlugins` builds a standalone `attribute.NewResolver(attribute.NewSchemaRegistry())` (`plugins.go:235-236`) and `attribute.NewPluginProvider(nil)` (`plugins.go:243`), passing `engineProvider{eng: d.engine, resolver: resolver}` as `cfg.ABAC` (`plugins.go:242`). `engineProvider` has fields `eng`, `resolver`, `auditor` (`plugins.go`).
+- `abacsetup.ABACSubsystem` exposes `AttributeResolver() *attribute.Resolver` (`subsystem.go:182`), `PluginProvider() *attribute.PluginProvider` (`:149`), `AuditLogger() pluginauthz.Auditor` (`:196`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/testsupport/integrationtest/real_abac_test.go`:
+
+```go
+// INV-RA-4: when a real ABAC subsystem is present, pluginAttrSources MUST route
+// the plugin layer to the subsystem's OWN resolver and plugin provider (pointer
+// identity) — not freshly-allocated standalone instances — so plugin-declared
+// attribute providers register on the resolver the engine evaluates against.
+func TestRealABAC_PluginAttrSourcesUsesEngineInstances(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
+	evStore, err := store.NewPostgresEventStore(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(evStore.Close)
+
+	abacSub := startRealABAC(t, ctx, evStore.Pool())
+	res, pp, aud := pluginAttrSources(abacSub)
+
+	require.Same(t, abacSub.AttributeResolver(), res,
+		"INV-RA-4: plugin resolver MUST be the engine's resolver instance")
+	require.Same(t, abacSub.PluginProvider(), pp,
+		"INV-RA-4: plugin provider MUST be the engine's plugin-provider instance")
+	require.Equal(t, abacSub.AuditLogger(), aud,
+		"INV-RA-4: plugin auditor MUST be the engine's auditor")
+
+	// nil subsystem → fresh standalone instances (the allow-all default path).
+	resStd, ppStd, audStd := pluginAttrSources(nil)
+	require.NotNil(t, resStd, "standalone resolver must be non-nil")
+	require.NotNil(t, ppStd, "standalone plugin provider must be non-nil")
+	require.Nil(t, audStd, "standalone auditor is nil")
+	require.NotSame(t, abacSub.AttributeResolver(), resStd,
+		"standalone resolver must differ from the engine's")
+}
+```
+
+Add the imports used above to the test file's import block:
+
+```go
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/test/testutil"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- -run TestRealABAC_PluginAttrSourcesUsesEngineInstances ./internal/testsupport/integrationtest/`
+Expected: FAIL — `undefined: pluginAttrSources`.
+
+- [ ] **Step 3: Add `pluginAttrSources`**
+
+Append to `internal/testsupport/integrationtest/real_abac.go` (add `attribute`, `pluginauthz` imports):
+
+```go
+// pluginAttrSources returns the attribute resolver, plugin provider, and auditor
+// the plugin subsystem should register against. With a real ABAC subsystem, these
+// are the subsystem's OWN instances so plugin-declared providers (e.g. core-scenes'
+// "scene" namespace) register on the resolver the engine evaluates against
+// (INV-RA-4). With no real engine (allow-all default), fresh standalone instances
+// are correct — allow-all ignores attributes, so the #4275 behavior is preserved.
+func pluginAttrSources(abacSub *abacsetup.ABACSubsystem) (*attribute.Resolver, *attribute.PluginProvider, pluginauthz.Auditor) {
+	if abacSub != nil {
+		return abacSub.AttributeResolver(), abacSub.PluginProvider(), abacSub.AuditLogger()
+	}
+	return attribute.NewResolver(attribute.NewSchemaRegistry()), attribute.NewPluginProvider(nil), nil
+}
+```
+
+Imports to add to `real_abac.go`:
+
+```go
+	"github.com/holomush/holomush/internal/access/policy/attribute"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
+```
+
+- [ ] **Step 4: Extend `pluginDeps` and use the threaded instances in `startPlugins`**
+
+In `internal/testsupport/integrationtest/plugins.go`, extend `pluginDeps` (`:167`):
+
+```go
+type pluginDeps struct {
+	pool           *pgxpool.Pool
+	connStr        string
+	engine         policytypes.AccessPolicyEngine
+	sessionStore   session.Access
+	verbReg        *core.VerbRegistry
+	playerRepo     auth.PlayerRepository
+	hasher         auth.PasswordHasher
+	playerSess     auth.PlayerSessionRepository
+	resolver       *attribute.Resolver
+	pluginProvider *attribute.PluginProvider
+	auditor        pluginauthz.Auditor
+}
+```
+
+Replace the standalone-resolver construction (`plugins.go:235-236`) and the `cfg.ABAC`/`PluginProv` fields (`:242-243`). Delete:
+
+```go
+	schemaReg := attribute.NewSchemaRegistry()
+	resolver := attribute.NewResolver(schemaReg)
+```
+
+and change the `PluginSubsystemConfig` to use the caller-supplied instances:
+
+```go
+		ABAC:               engineProvider{eng: d.engine, resolver: d.resolver, auditor: d.auditor},
+		PolicyInst:         policyInstallerProvider{inst: policyInst},
+		PluginProv:         pluginProviderSetter{pp: d.pluginProvider},
+```
+
+(The `pluginauthz` import already exists in `plugins.go`.)
+
+- [ ] **Step 5: Pass the threaded instances from `Start()`**
+
+In `internal/testsupport/integrationtest/harness.go`, replace the `if cfg.withPlugins { ... }` block (`:234`):
+
+```go
+	if cfg.withPlugins {
+		res, pp, aud := pluginAttrSources(abacSub)
+		pluginSub = startPlugins(t, ctx, pluginDeps{
+			pool:           pool,
+			connStr:        connStr,
+			engine:         pe,
+			sessionStore:   sessionStoreInst,
+			verbReg:        verbRegistry,
+			playerRepo:     playerRepo,
+			hasher:         hasher,
+			playerSess:     playerSessionStore,
+			resolver:       res,
+			pluginProvider: pp,
+			auditor:        aud,
+		})
+		cmdRegistry = pluginSub.CommandRegistry()
+	}
+```
+
+- [ ] **Step 6: Write the composition + option-order tests (INV-RA-6)**
+
+Append to `internal/testsupport/integrationtest/real_abac_test.go`:
+
+```go
+// INV-RA-6: option order MUST NOT affect the resulting stack. Both orderings
+// must produce the same real-ABAC deny for a regular non-colocated read.
+// Plugin-gated: skipped when binary plugins are unbuilt (HOLOMUSH_REQUIRE_PLUGINS
+// forces failure instead — see plugins.go).
+func TestRealABAC_OptionOrderIndependent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []StartOption
+	}{
+		{"plugins-then-abac", []StartOption{WithInTreePlugins(), WithRealABAC()}},
+		{"abac-then-plugins", []StartOption{WithRealABAC(), WithInTreePlugins()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+			ts := Start(t, tc.opts...) // skips here if binary plugins unbuilt
+			mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+			_, err := mover.QueryStreamHistory(ctx, priorStream)
+			require.Error(t, err, "INV-RA-6: composed real engine MUST deny regardless of option order")
+			oopsErr, ok := oops.AsOops(err)
+			require.True(t, ok)
+			require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code())
+		})
+	}
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `task plugin:build-all` (so the composition test runs instead of skipping), then
+`task test:int -- -run TestRealABAC ./internal/testsupport/integrationtest/`
+Expected: PASS. `TestRealABAC_OptionOrderIndependent` runs (not skipped) once binaries are built.
+
+- [ ] **Step 8: Lint + commit**
+
+Run: `task lint:go` (expect clean), then:
+
+```
+jj commit -m "feat(integrationtest): thread real resolver/provider/auditor into plugin layer (holomush-f5t07)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Documentation (PR-blocking)
+
+**Files:**
+
+- Modify: `site/docs/contributing/integration-tests.md`
+- Modify: `internal/testsupport/integrationtest/harness.go` (package doc-comment)
+
+- [ ] **Step 1: Add a `WithRealABAC` section to the contributor guide**
+
+In `site/docs/contributing/integration-tests.md`, add this section after the `WithInTreePlugins` documentation:
+
+````markdown
+## Real ABAC (`WithRealABAC`)
+
+By default the harness wires an allow-all ABAC engine — most integration tests
+assert session/history floors, which are ABAC-independent. To exercise the
+**real seeded ABAC engine** (production's `abacsetup.NewABACSubsystem` path),
+opt in:
+
+```go
+ts := integrationtest.Start(t, integrationtest.WithRealABAC())
+```
+
+This seeds the production `seed:*` policy set (`policy.Bootstrap`) and boots the
+real engine. Compose with `WithInTreePlugins()` for cross-plugin ABAC coverage —
+the plugin subsystem registers its attribute providers on the engine's own
+resolver:
+
+```go
+ts := integrationtest.Start(t, integrationtest.WithInTreePlugins(), integrationtest.WithRealABAC())
+```
+
+**Live role semantics.** Under `WithRealABAC`, `character_roles` are evaluated by
+the engine. `ConnectAuthedWithRoles(ctx, name, []string{"admin"})` grants
+role-based permits (e.g. `seed:admin-full-access`); a roleless `ConnectAuthed`
+receives only what `seed:*` grants a roleless character. Tests that pass under
+allow-all may see denials under `WithRealABAC` until they seed the roles their
+actions require.
+````
+
+- [ ] **Step 2: Update the harness package doc-comment**
+
+In `internal/testsupport/integrationtest/harness.go`, add a sentence to the package doc-comment noting the `WithRealABAC` opt-in and the live role semantics (mirroring the `WithInTreePlugins` note already present).
+
+- [ ] **Step 3: Verify docs build / lint**
+
+Run: `task fmt:check`
+Expected: PASS (markdown formatting clean).
+
+- [ ] **Step 4: Commit**
+
+```
+jj commit -m "docs(integrationtest): document WithRealABAC opt-in and role semantics (holomush-f5t07)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Acceptance verification (after all tasks)
+
+- [ ] `task test:int -- -run TestRealABAC ./internal/testsupport/integrationtest/` — all INV-RA-* green (with `task plugin:build-all` run first so the composition test executes).
+- [ ] INV-RA-1…6 each have a passing test (RA-3 and RA-5 share the admin sentinel).
+- [ ] `task pr-prep` green.
+- [ ] Spec acceptance criteria satisfied: full-stack tests can opt into the real seeded engine; the admin sentinel demonstrates a g776-class default-deny that allow-all masks; docs updated.
+
+## Out of scope (per spec §3)
+
+- Flipping the harness default to production-shape (follow-up bead).
+- `holomush-0f0f4.9`'s `wholesystem/abac_test.go` (consumes this substrate; adds the scene-namespace cross-plugin permit/forbid that fully exercises INV-RA-4 end-to-end).
+- Plugin event emission.
+
+<!-- adr-capture: sha256=c5dcbafac498bfe6; session=brainstorm-holomush-f5t07; ts=2026-05-26T19:04:01Z; adrs=holomush-jvrq3 -->

--- a/docs/superpowers/specs/2026-05-26-harness-real-abac-design.md
+++ b/docs/superpowers/specs/2026-05-26-harness-real-abac-design.md
@@ -1,0 +1,210 @@
+# Design: `WithRealABAC()` — real seeded ABAC engine in the integration harness
+
+- **Bead:** holomush-f5t07
+- **Status:** Accepted (design-review READY, plan-review READY)
+- **Date:** 2026-05-26
+- **Related:** holomush-shcyu (sibling harness-fidelity gap, plugin axis), holomush-0f0f4.9 (consumer), PR #4275 (`WithInTreePlugins`, the precedent this mirrors)
+
+## 1. Problem
+
+The `internal/testsupport/integrationtest` harness wires `allowAllPolicyEngine{}`
+as its access engine by default (`harness.go:214`). Every full-stack integration
+test built on it therefore exercises the snapshot/handler paths **without** the
+real seeded ABAC engine. This is a fidelity gap: a production-side wiring bug in
+the ABAC stack is invisible to integration tests.
+
+This gap has bitten before. `holomush-g776` (`LocationProvider` never registered
+in `BuildABACStack`) silently default-denied 3 location seeds for 6+ weeks because
+no integration test ran the real engine; the same fingerprint recurred in
+`holomush-xxel` (`PropertyProvider`). The production-side seed-coverage validator
+(PR #4161) catches the provider-**registration** class, but no full-stack handler
+test runs against the real engine, so handler/snapshot denial paths stay
+unexercised.
+
+## 2. Goal
+
+Provide an **opt-in** capability — `WithRealABAC()` — that boots the **real
+seeded ABAC engine** inside the harness `CoreServer` by reusing production's ABAC
+subsystem (`abacsetup.NewABACSubsystem`, which calls `setup.BuildABACStack`), so
+default-deny regressions are caught at integration time. This mirrors the pattern
+PR #4275 established for plugins (`WithInTreePlugins()` boots the real
+`pluginsetup.PluginSubsystem`).
+
+The harness default remains allow-all (no churn to existing tests). A **follow-up
+bead** will consider flipping the default to production-shape once adoption and
+the seed/churn cost are understood; that decision is **out of scope here**.
+
+## 3. Non-Goals
+
+- **Flipping the harness default** to production-shape (separate follow-up bead).
+- **Plugins-by-default** — `WithInTreePlugins` stays opt-in (it skips when binary
+  artifacts are unbuilt; making it default would force `task plugin:build-all`
+  or a skip on every integration test).
+- **Plugin event emission** — unwired per PR #4275; not this bead's concern.
+- **`holomush-0f0f4.9`'s `abac_test.go`** — f5t07 provides the substrate + the
+  resolver-threading fix; the cross-plugin permit/forbid assertions are 0f0f4.9's.
+- **Production provider wiring** (`g776`/`xxel`, closed).
+
+## 4. Design
+
+### 4.1 Approach: reuse production's ABAC subsystem
+
+Production reaches the ABAC engine via `abacsetup.NewABACSubsystem`
+(`cmd/holomush/core.go:380`) — a `lifecycle.Subsystem` whose `Start()` calls
+`setup.BuildABACStack`, **not** a raw `BuildABACStack` call. `WithRealABAC()`
+uses `NewABACSubsystem` directly, mirroring how `WithInTreePlugins()` uses
+`pluginsetup.NewPluginSubsystem` (the subsystem wrapper, not the raw `Manager`).
+This keeps the two opt-ins at the same level of abstraction and is literally
+"what production does."
+
+The subsystem exposes every concrete handle the harness needs
+(`internal/access/setup/subsystem.go`): `Engine()` (`:124`),
+`AttributeResolver() *attribute.Resolver` (`:182`),
+`PluginProvider() *attribute.PluginProvider` (`:149`), and `AuditLogger()`
+(`:196`) — the exact trio the plugin layer's `engineProvider`
+(`plugins.go`) needs (`eng`, `resolver`, `auditor`), all as the concrete types
+required by INV-RA-4.
+
+The one cost is lifecycle: `Start()` launches a background policy poller
+(`subsystem.go:105`, `go stack.Poller.Run`). The harness stops it via
+`t.Cleanup(func() { abacSub.Stop(ctx) })`, exactly as `startPlugins` already
+registers `t.Cleanup` for the plugin subsystem's `Stop`. The subsystem's
+accessors panic if called before `Start()`, so the harness MUST `Start()` it
+before wiring the `CoreServer`.
+
+### 4.2 Start() flow
+
+```mermaid
+flowchart TD
+    start["Start(t, opts...)"] --> cfg{startConfig}
+    cfg -->|"withRealABAC"| seed["1. policy.Bootstrap(ctx)<br/>install seed:* policies + audit partitions"]
+    seed --> build["2. abacsetup.NewABACSubsystem(...).Start()<br/>(calls BuildABACStack; cache.Reload now sees seeds)<br/>t.Cleanup(abacSub.Stop)"]
+    build --> eng["3. accessEngine = abacSub.Engine()"]
+    cfg -->|"!withRealABAC"| allow["accessEngine = allowAllPolicyEngine{} (unchanged)"]
+    eng --> plug{"withPlugins?"}
+    allow --> plug
+    plug -->|"yes + withRealABAC"| threadReal["4a. startPlugins receives<br/>abacSub.AttributeResolver() + abacSub.PluginProvider()"]
+    plug -->|"yes, allow-all"| threadStd["4b. startPlugins builds standalone resolver<br/>(unchanged #4275 path)"]
+    plug -->|"no"| done["CoreServer wired with accessEngine"]
+    threadReal --> done
+    threadStd --> done
+```
+
+### 4.3 Changes
+
+1. **`startConfig`** (`harness.go:132`) gains `withRealABAC bool`.
+2. **`WithRealABAC() StartOption`** sets `c.withRealABAC = true` — structurally
+   identical to `WithInTreePlugins()`.
+3. **`Start()`** (`harness.go:157`): when `cfg.withRealABAC`, before constructing
+   the `CoreServer`:
+   - **Seed** — call `policy.Bootstrap(ctx, partitions, policyStore, compiler,
+     logger, opts)` to install the seed policy set (`policy.SeedPolicies()`) and
+     ensure audit-log partitions. Required because the engine's `cache.Reload(ctx)`
+     (inside `BuildABACStack`, called by the subsystem's `Start()`) reads the
+     policy store at construction — an empty store means zero policies means
+     everything default-denies. Inputs: `audit.NewPostgresPartitionCreator(pool)`,
+     `policystore.NewPostgresStore(pool)`, `policy.NewCompiler(types.NewAttributeSchema())`.
+   - **Build + Start** — `abacSub := abacsetup.NewABACSubsystem(ABACSubsystemConfig{
+     DB: <poolProvider>, Registry: <throwaway registry>})`; `abacSub.Start(ctx)`;
+     `t.Cleanup(func() { _ = abacSub.Stop(context.Background()) })`. The subsystem
+     builds all repos from the pool internally (`subsystem.go:79-90`).
+   - **Wire** — `accessEngine = abacSub.Engine()`, overriding the allow-all
+     default. Retain `abacSub.AttributeResolver()`, `abacSub.PluginProvider()`,
+     and `abacSub.AuditLogger()` for the plugin path.
+4. **`startPlugins`** (`plugins.go`): accept a caller-supplied `resolver`,
+   `pluginProvider`, and `auditor` via `pluginDeps`. When `withRealABAC &&
+   withPlugins`, the harness passes `abacSub.AttributeResolver()` +
+   `abacSub.PluginProvider()` + `abacSub.AuditLogger()` (the engine's own
+   instances) instead of the standalone `attribute.NewResolver(schemaReg)`
+   (`plugins.go:236`) / `attribute.NewPluginProvider(nil)` (`plugins.go:243`) it
+   builds today. The allow-all+plugins path (PR #4275) is unchanged — allow-all
+   ignores attributes, so a standalone resolver is correct there.
+
+### 4.4 Live role semantics
+
+Under `WithRealABAC`, `character_roles` become **load-bearing**: the engine
+evaluates them. `ConnectAuthedWithRoles(roles)` grants role-based permits;
+roleless `ConnectAuthed` receives only what `seed:*` grants a roleless character.
+This is documented in the harness package doc-comment so test authors expect
+denials they would not see under allow-all.
+
+### 4.5 Composition (the holomush-0f0f4.9 substrate)
+
+`Start(t, WithInTreePlugins(), WithRealABAC())` yields real plugins + real seeded
+engine + correctly-threaded resolver/pluginProvider → cross-plugin ABAC
+permit/forbid against `widget-*` manifest policies. Each option also works alone.
+
+## 5. Invariants (RFC2119)
+
+- **INV-RA-1** — With `WithRealABAC()`, the `CoreServer` access engine MUST be the
+  `setup.BuildABACStack` engine, NOT `allowAllPolicyEngine`.
+- **INV-RA-2** — Without `WithRealABAC()`, the harness MUST retain the allow-all
+  default (no regression to PR #4275 or existing tests).
+- **INV-RA-3** — With `WithRealABAC()`, the `seed:*` policy set MUST be installed
+  in the policy store before the engine's policy cache is loaded; the engine MUST
+  evaluate against a non-empty seeded policy set.
+- **INV-RA-4** — With `WithRealABAC() + WithInTreePlugins()`, the
+  `*attribute.Resolver` and `*attribute.PluginProvider` the plugin subsystem
+  registers providers on MUST be the **same instances** (pointer identity) the
+  engine evaluates against.
+- **INV-RA-5** — Every attribute namespace referenced by an installed seed policy
+  MUST have a registered provider under `WithRealABAC` (no silent default-deny
+  from an unregistered provider).
+- **INV-RA-6** — Option order MUST NOT affect the resulting stack:
+  `Start(t, A, B)` and `Start(t, B, A)` MUST produce identical permit/deny
+  behavior for `{WithRealABAC, WithInTreePlugins}`.
+
+## 6. Testing strategy
+
+TDD: tests are written before the wiring. The harness package is
+`//go:build integration`. The new wiring MUST reach ≥80% coverage, exercised by
+the invariant tests, the composed integration test, and the denial-path tests
+below (the plan defines how coverage is measured for the integration-tagged
+package).
+
+| Layer | Tests |
+|---|---|
+| **Happy path** | `WithRealABAC` alone → a `seed:*` permit succeeds through a real handler. Composed with `WithInTreePlugins` → cross-plugin permit. |
+| **Boundary** | roleless `ConnectAuthed` (seed-grants only) vs `ConnectAuthedWithRoles`; permit↔deny edge of one seed policy; `WithRealABAC` without plugins; option-order independence (INV-RA-6). |
+| **Invariants** | one test per INV-RA-1…6. |
+| **Integration** | `task test:int` green; ≥1 real privacy/presence-style test under `WithRealABAC`. |
+
+**Meta-test (INV-RA-5, the regression demonstration).** Realized as a
+**colocated-permit sentinel**: under `WithRealABAC`, a `resource.*` seed permit
+(e.g. `seed:player-location-stream-read` — a co-located stream read) succeeds
+**only because** the namespace's attribute provider is registered. An
+unregistered provider — the exact g776/xxel fingerprint — would silently
+default-deny and flip this permit to `STREAM_ACCESS_DENIED`, failing the test;
+under the allow-all default the same permit passes regardless, masking the
+regression. This is the acceptance criterion's "regression that allow-all would
+have passed," and it stays in f5t07 (it *is* the acceptance gate). INV-RA-3 and
+INV-RA-5 share this sentinel test. (A synthetic provider-withholding variant is
+not used: the harness option always wires the full repo set via
+`NewABACSubsystem`, so withholding is reachable only by bypassing the public
+API.)
+
+## 7. Documentation (PR-blocking)
+
+- `site/docs/contributing/integration-tests.md` — document `WithRealABAC`:
+  when to use, composition with `WithInTreePlugins`, the seed step, and the live
+  role semantics (§4.4).
+- Harness package doc-comment — same, at the source.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Seed step (`policy.Bootstrap`) needs a `BootstrapPartitionCreator` + compiler the harness must assemble | Trivial constructors from the pool (`audit.NewPostgresPartitionCreator`, `policy.NewCompiler(types.NewAttributeSchema())`); production assembles the same inputs. Contained to opt-in tests. |
+| `NewABACSubsystem` needs a `PoolProvider` + `*lifecycle.ReadinessRegistry` the harness must supply | A small pool-adapter satisfies `PoolProvider`; a throwaway `lifecycle.NewReadinessRegistry()` suffices (`startPlugins` already constructs one). |
+| Subsystem `Start()` launches a background poller goroutine | Stopped via `t.Cleanup(abacSub.Stop)`, mirroring the plugin subsystem's existing cleanup. Reloads are idempotent and harmless mid-test. |
+| Concrete handle threading into `startPlugins` | `abacSub.AttributeResolver()`/`PluginProvider()`/`AuditLogger()` return the concrete types; `pluginDeps` gains those fields. |
+| Seeded engine denies baseline ops existing tests assumed (role semantics) | Opt-in only — no existing test is affected until it adds `WithRealABAC`; §4.4 documents the semantics. |
+| Divergence from production wiring over time | Reusing `abacsetup.NewABACSubsystem` + `policy.Bootstrap` (production's own composition) keeps the harness on the production path; the seed-coverage validator (PR #4161) backstops provider registration. |
+
+## 9. Follow-ups
+
+- **Flip-default bead** (the "flip later" half): make production-shape the harness
+  default with `WithAllowAllABAC()` opt-out, once enough tests adopt `WithRealABAC`.
+- **holomush-0f0f4.9** consumes this substrate to add `wholesystem/abac_test.go`.
+
+<!-- adr-capture: sha256=7c9fdca8964a81a3; session=brainstorm-holomush-f5t07; ts=2026-05-26T19:04:01Z; adrs=holomush-jvrq3 -->

--- a/docs/superpowers/specs/2026-05-26-harness-real-abac-design.md
+++ b/docs/superpowers/specs/2026-05-26-harness-real-abac-design.md
@@ -169,19 +169,29 @@ package).
 | **Invariants** | one test per INV-RA-1…6. |
 | **Integration** | `task test:int` green; ≥1 real privacy/presence-style test under `WithRealABAC`. |
 
-**Meta-test (INV-RA-5, the regression demonstration).** Realized as a
-**colocated-permit sentinel**: under `WithRealABAC`, a `resource.*` seed permit
-(e.g. `seed:player-location-stream-read` — a co-located stream read) succeeds
-**only because** the namespace's attribute provider is registered. An
-unregistered provider — the exact g776/xxel fingerprint — would silently
-default-deny and flip this permit to `STREAM_ACCESS_DENIED`, failing the test;
-under the allow-all default the same permit passes regardless, masking the
-regression. This is the acceptance criterion's "regression that allow-all would
-have passed," and it stays in f5t07 (it *is* the acceptance gate). INV-RA-3 and
-INV-RA-5 share this sentinel test. (A synthetic provider-withholding variant is
-not used: the harness option always wires the full repo set via
-`NewABACSubsystem`, so withholding is reachable only by bypassing the public
-API.)
+**Meta-test (INV-RA-5, the regression demonstration).** Realized as an
+**admin-role permit sentinel** (`TestRealABAC_AdminPermittedNonColocatedRead_g776Sentinel`):
+under `WithRealABAC`, an admin-role character is permitted a *different-location*
+stream read via `seed:admin-full-access`, which the `staffOverride` path
+(`internal/grpc/scope_floor.go`) resolves through
+`engine.Evaluate("read_unrestricted_history", …)`. This permit succeeds **only
+because** the provider populating `principal.character.roles` is registered — an
+unregistered provider (the exact g776/xxel fingerprint) silently default-denies,
+flipping the permit to `STREAM_ACCESS_DENIED` and failing the test. Under the
+allow-all default the same read passes via the staff bypass regardless
+(INV-RA-2), masking the regression. This is the acceptance criterion's
+"regression that allow-all would have passed," and it stays in f5t07 (it *is* the
+acceptance gate). INV-RA-3 and INV-RA-5 share this sentinel test.
+
+A *co-located* location-stream read is **not** a usable engine sentinel: it is
+permitted by the location hard-gate (`internal/grpc/query_stream_history.go`,
+`info.LocationID == extractLocationID(stream)`), which never reaches
+`engine.Evaluate` for the `stream:` resource — so `seed:player-location-stream-read`
+is dead for that case in this handler. The ABAC-gated path is the
+different-location read via `staffOverride`, hence the admin-role mechanism above.
+(A synthetic provider-withholding variant is not used: the harness option always
+wires the full repo set via `NewABACSubsystem`, so withholding is reachable only
+by bypassing the public API.)
 
 ## 7. Documentation (PR-blocking)
 

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -64,6 +64,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/access/policy/types"
+	abacsetup "github.com/holomush/holomush/internal/access/setup"
 	"github.com/holomush/holomush/internal/auth"
 	authpg "github.com/holomush/holomush/internal/auth/postgres"
 	"github.com/holomush/holomush/internal/command"
@@ -132,6 +133,7 @@ type StartOption func(*startConfig)
 type startConfig struct {
 	accessEngine types.AccessPolicyEngine
 	withPlugins  bool
+	withRealABAC bool
 }
 
 // WithPolicyEngine overrides the harness's default allow-all ABAC engine.
@@ -141,6 +143,18 @@ type startConfig struct {
 // returns false and the hard-gate is exercised end-to-end.
 func WithPolicyEngine(eng types.AccessPolicyEngine) StartOption {
 	return func(c *startConfig) { c.accessEngine = eng }
+}
+
+// WithRealABAC boots the real seeded ABAC engine inside the harness via
+// production's abacsetup.NewABACSubsystem (which calls setup.BuildABACStack),
+// seeding the seed:* policy set first. Opt-in; the default stays allow-all.
+// Compose with WithInTreePlugins for cross-plugin ABAC coverage.
+//
+// Under WithRealABAC, character_roles become load-bearing: ConnectAuthedWithRoles
+// grants role-based permits, while a roleless ConnectAuthed receives only what
+// seed:* grants a roleless character.
+func WithRealABAC() StartOption {
+	return func(c *startConfig) { c.withRealABAC = true }
 }
 
 // Start bootstraps a full in-process holomush stack and returns a Server.
@@ -216,6 +230,14 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		opt(cfg)
 	}
 	pe := cfg.accessEngine
+
+	// Real seeded ABAC engine (opt-in). Overrides the allow-all default and is
+	// retained for the plugin layer's resolver/pluginProvider threading below.
+	var abacSub *abacsetup.ABACSubsystem
+	if cfg.withRealABAC {
+		abacSub = startRealABAC(t, ctx, pool)
+		pe = abacSub.Engine()
+	}
 
 	// VerbRegistry must exist before plugins load (they register verbs). It is
 	// also required by the locationFollower's synthetic location_state emit path

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -254,15 +254,19 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	var pluginSub *pluginsetup.PluginSubsystem
 	cmdRegistry := command.NewRegistry()
 	if cfg.withPlugins {
+		res, pp, aud := pluginAttrSources(abacSub)
 		pluginSub = startPlugins(t, ctx, pluginDeps{
-			pool:         pool,
-			connStr:      connStr,
-			engine:       pe,
-			sessionStore: sessionStoreInst,
-			verbReg:      verbRegistry,
-			playerRepo:   playerRepo,
-			hasher:       hasher,
-			playerSess:   playerSessionStore,
+			pool:           pool,
+			connStr:        connStr,
+			engine:         pe,
+			sessionStore:   sessionStoreInst,
+			verbReg:        verbRegistry,
+			playerRepo:     playerRepo,
+			hasher:         hasher,
+			playerSess:     playerSessionStore,
+			resolver:       res,
+			pluginProvider: pp,
+			auditor:        aud,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -29,7 +29,10 @@
 // Default ABAC engine is allow-all (privacy tests focus on session/history
 // gates, not role enforcement). Tests that need denial-path coverage pass
 // WithPolicyEngine(policytest.DenyAllEngine()) — see iwzt.10 / iwzt.11 for
-// usage.
+// usage. WithRealABAC opts into the real seeded ABAC engine (production's
+// abacsetup.NewABACSubsystem path), making character_roles load-bearing:
+// ConnectAuthedWithRoles grants role-based seed:* permits while a roleless
+// ConnectAuthed receives only what seed:* grants a roleless character.
 //
 // Helper categories:
 //

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -165,14 +165,17 @@ func WithInTreePlugins() StartOption {
 // pluginDeps is the minimal set of already-built harness objects startPlugins
 // needs. Start passes these in so this helper stays decoupled from the Server.
 type pluginDeps struct {
-	pool         *pgxpool.Pool
-	connStr      string
-	engine       policytypes.AccessPolicyEngine
-	sessionStore session.Access
-	verbReg      *core.VerbRegistry
-	playerRepo   auth.PlayerRepository
-	hasher       auth.PasswordHasher
-	playerSess   auth.PlayerSessionRepository // *store.PostgresPlayerSessionStore satisfies this (player_session_store.go:30)
+	pool           *pgxpool.Pool
+	connStr        string
+	engine         policytypes.AccessPolicyEngine
+	sessionStore   session.Access
+	verbReg        *core.VerbRegistry
+	playerRepo     auth.PlayerRepository
+	hasher         auth.PasswordHasher
+	playerSess     auth.PlayerSessionRepository // *store.PostgresPlayerSessionStore satisfies this (player_session_store.go:30)
+	resolver       *attribute.Resolver
+	pluginProvider *attribute.PluginProvider
+	auditor        pluginauthz.Auditor
 }
 
 // startPlugins constructs and starts a PluginSubsystem mirroring production
@@ -227,20 +230,19 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	// PolicyInstaller over a real policystore so manifest policies install.
 	policyInst := plugins.NewPolicyInstaller(policystore.NewPostgresStore(d.pool))
 
-	// Resolver must be non-nil: PluginSubsystem.Start calls
-	// resolver.RegisterProvider per plugin that declares resource_types
-	// (e.g. core-scenes' "scene" namespace). A nil resolver panics at
-	// subsystem.go:319. A fresh SchemaRegistry + Resolver is sufficient for
-	// the census suite, which reads load state and the command registry only.
-	schemaReg := attribute.NewSchemaRegistry()
-	resolver := attribute.NewResolver(schemaReg)
-
+	// Resolver / plugin provider are caller-supplied (pluginAttrSources): with a
+	// real ABAC subsystem they are the engine's OWN instances so plugin-declared
+	// providers (e.g. core-scenes' "scene" namespace) register on the resolver the
+	// engine evaluates against (INV-RA-4); with allow-all they are fresh standalone
+	// instances. Both are non-nil — PluginSubsystem.Start calls
+	// resolver.RegisterProvider per plugin that declares resource_types and panics
+	// on a nil resolver (subsystem.go:319).
 	cfg := pluginsetup.PluginSubsystemConfig{
 		DataDir:            dataDir,
 		DatabaseConnStr:    d.connStr,
-		ABAC:               engineProvider{eng: d.engine, resolver: resolver},
+		ABAC:               engineProvider{eng: d.engine, resolver: d.resolver, auditor: d.auditor},
 		PolicyInst:         policyInstallerProvider{inst: policyInst},
-		PluginProv:         pluginProviderSetter{pp: attribute.NewPluginProvider(nil)},
+		PluginProv:         pluginProviderSetter{pp: d.pluginProvider},
 		World:              worldProvider{svc: worldSvc},
 		Sessions:           sessionProvider{store: d.sessionStore},
 		AdminDeps:          adminDepsProvider{deps: adminDeps},

--- a/internal/testsupport/integrationtest/real_abac.go
+++ b/internal/testsupport/integrationtest/real_abac.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package integrationtest
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/access/policy"
+	policystore "github.com/holomush/holomush/internal/access/policy/store"
+	policytypes "github.com/holomush/holomush/internal/access/policy/types"
+	abacsetup "github.com/holomush/holomush/internal/access/setup"
+	"github.com/holomush/holomush/internal/audit"
+	"github.com/holomush/holomush/internal/lifecycle"
+)
+
+// poolProvider adapts a *pgxpool.Pool to abacsetup.PoolProvider so the harness
+// can hand the test pool to the production ABAC subsystem.
+type poolProvider struct{ pool *pgxpool.Pool }
+
+func (p poolProvider) Pool() *pgxpool.Pool { return p.pool }
+
+// startRealABAC seeds the production seed:* policy set and boots the real ABAC
+// subsystem (production's abacsetup.NewABACSubsystem path, the same constructor
+// cmd/holomush/core.go:380 uses). It returns the started subsystem; callers read
+// Engine()/AttributeResolver()/PluginProvider()/AuditLogger() and the poller is
+// stopped via t.Cleanup.
+func startRealABAC(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *abacsetup.ABACSubsystem {
+	t.Helper()
+
+	// Seed first: the subsystem's Start → BuildABACStack → cache.Reload reads
+	// the policy store at construction. An unseeded store has zero policies and
+	// default-denies everything.
+	require.NoError(
+		t,
+		policy.Bootstrap(
+			ctx,
+			audit.NewPostgresPartitionCreator(pool),
+			policystore.NewPostgresStore(pool),
+			policy.NewCompiler(policytypes.NewAttributeSchema()),
+			slog.Default(),
+			policy.BootstrapOptions{},
+		),
+		"startRealABAC: seed policies",
+	)
+
+	abacSub := abacsetup.NewABACSubsystem(abacsetup.ABACSubsystemConfig{
+		DB:       poolProvider{pool: pool},
+		Registry: lifecycle.NewReadinessRegistry(),
+	})
+	require.NoError(t, abacSub.Start(ctx), "startRealABAC: ABAC subsystem start")
+	t.Cleanup(func() { _ = abacSub.Stop(context.Background()) })
+	return abacSub
+}

--- a/internal/testsupport/integrationtest/real_abac.go
+++ b/internal/testsupport/integrationtest/real_abac.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/access/policy"
+	"github.com/holomush/holomush/internal/access/policy/attribute"
 	policystore "github.com/holomush/holomush/internal/access/policy/store"
 	policytypes "github.com/holomush/holomush/internal/access/policy/types"
 	abacsetup "github.com/holomush/holomush/internal/access/setup"
 	"github.com/holomush/holomush/internal/audit"
 	"github.com/holomush/holomush/internal/lifecycle"
+	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 )
 
 // poolProvider adapts a *pgxpool.Pool to abacsetup.PoolProvider so the harness
@@ -58,4 +60,17 @@ func startRealABAC(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *abacs
 	require.NoError(t, abacSub.Start(ctx), "startRealABAC: ABAC subsystem start")
 	t.Cleanup(func() { _ = abacSub.Stop(context.Background()) })
 	return abacSub
+}
+
+// pluginAttrSources returns the attribute resolver, plugin provider, and auditor
+// the plugin subsystem should register against. With a real ABAC subsystem, these
+// are the subsystem's OWN instances so plugin-declared providers (e.g. core-scenes'
+// "scene" namespace) register on the resolver the engine evaluates against
+// (INV-RA-4). With no real engine (allow-all default), fresh standalone instances
+// are correct — allow-all ignores attributes, so the #4275 behavior is preserved.
+func pluginAttrSources(abacSub *abacsetup.ABACSubsystem) (*attribute.Resolver, *attribute.PluginProvider, pluginauthz.Auditor) {
+	if abacSub != nil {
+		return abacSub.AttributeResolver(), abacSub.PluginProvider(), abacSub.AuditLogger()
+	}
+	return attribute.NewResolver(attribute.NewSchemaRegistry()), attribute.NewPluginProvider(nil), nil
 }

--- a/internal/testsupport/integrationtest/real_abac_test.go
+++ b/internal/testsupport/integrationtest/real_abac_test.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/samber/oops"
 	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/test/testutil"
 )
 
 // movedAwayPlayer connects charName, records its start location, then moves it
@@ -77,4 +80,63 @@ func TestRealABAC_AdminPermittedNonColocatedRead_g776Sentinel(t *testing.T) {
 	require.NoError(t, err,
 		"INV-RA-3/RA-5: seed:admin-full-access MUST permit an admin's non-colocated read; "+
 			"a failure here means seeds weren't installed or the roles provider is unregistered")
+}
+
+// INV-RA-4: when a real ABAC subsystem is present, pluginAttrSources MUST route
+// the plugin layer to the subsystem's OWN resolver and plugin provider (pointer
+// identity) — not freshly-allocated standalone instances — so plugin-declared
+// attribute providers register on the resolver the engine evaluates against.
+func TestRealABAC_PluginAttrSourcesUsesEngineInstances(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	shared := testutil.SharedPostgres(t)
+	connStr := testutil.FreshDatabase(t, shared)
+	evStore, err := store.NewPostgresEventStore(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(evStore.Close)
+
+	abacSub := startRealABAC(t, ctx, evStore.Pool())
+	res, pp, aud := pluginAttrSources(abacSub)
+
+	require.Same(t, abacSub.AttributeResolver(), res,
+		"INV-RA-4: plugin resolver MUST be the engine's resolver instance")
+	require.Same(t, abacSub.PluginProvider(), pp,
+		"INV-RA-4: plugin provider MUST be the engine's plugin-provider instance")
+	require.Equal(t, abacSub.AuditLogger(), aud,
+		"INV-RA-4: plugin auditor MUST be the engine's auditor")
+
+	// nil subsystem → fresh standalone instances (the allow-all default path).
+	resStd, ppStd, audStd := pluginAttrSources(nil)
+	require.NotNil(t, resStd, "standalone resolver must be non-nil")
+	require.NotNil(t, ppStd, "standalone plugin provider must be non-nil")
+	require.Nil(t, audStd, "standalone auditor is nil")
+	require.NotSame(t, abacSub.AttributeResolver(), resStd,
+		"standalone resolver must differ from the engine's")
+}
+
+// INV-RA-6: option order MUST NOT affect the resulting stack. Both orderings
+// must produce the same real-ABAC deny for a regular non-colocated read.
+// Plugin-gated: skipped when binary plugins are unbuilt (HOLOMUSH_REQUIRE_PLUGINS
+// forces failure instead — see plugins.go).
+func TestRealABAC_OptionOrderIndependent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []StartOption
+	}{
+		{"plugins-then-abac", []StartOption{WithInTreePlugins(), WithRealABAC()}},
+		{"abac-then-plugins", []StartOption{WithRealABAC(), WithInTreePlugins()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+			ts := Start(t, tc.opts...) // skips here if binary plugins unbuilt
+			mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+			_, err := mover.QueryStreamHistory(ctx, priorStream)
+			require.Error(t, err, "INV-RA-6: composed real engine MUST deny regardless of option order")
+			oopsErr, ok := oops.AsOops(err)
+			require.True(t, ok)
+			require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code())
+		})
+	}
 }

--- a/internal/testsupport/integrationtest/real_abac_test.go
+++ b/internal/testsupport/integrationtest/real_abac_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package integrationtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samber/oops"
+	"github.com/stretchr/testify/require"
+)
+
+// movedAwayPlayer connects charName, records its start location, then moves it
+// to a fresh location. Querying the START location afterward is the ABAC-gated
+// (different-location) path: permitted only for staff via read_unrestricted_history.
+func movedAwayPlayer(t *testing.T, ctx context.Context, ts *Server, charName string, roles []string) (sess *Session, priorStream string) {
+	t.Helper()
+	if roles == nil {
+		sess = ts.ConnectAuthed(ctx, charName)
+	} else {
+		sess = ts.ConnectAuthedWithRoles(ctx, charName, roles)
+	}
+	priorStream = "location:" + sess.LocationID.String()
+	sess.MoveTo(ctx, ts.NewLocation(ctx))
+	return sess, priorStream
+}
+
+// INV-RA-1: under WithRealABAC, a regular (non-staff) character is DENIED a
+// read against a location it has left. Allow-all would permit this via the
+// staffOverride bypass — so a passing assertion here proves the engine is the
+// real seeded engine, not allowAllPolicyEngine.
+func TestRealABAC_RegularPlayerDeniedNonColocatedRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t, WithRealABAC())
+	mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+	_, err := mover.QueryStreamHistory(ctx, priorStream)
+	require.Error(t, err, "INV-RA-1: real engine MUST deny a regular player's non-colocated read")
+	oopsErr, ok := oops.AsOops(err)
+	require.True(t, ok, "denial must surface as an oops error")
+	require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
+		"INV-RA-1: denial MUST collapse to STREAM_ACCESS_DENIED")
+}
+
+// INV-RA-2: without WithRealABAC, the harness retains the allow-all default —
+// the same non-colocated read SUCCEEDS (staff bypass). Guards against an
+// accidental flip of the default.
+func TestRealABAC_DefaultEngineStillAllowAll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t) // no WithRealABAC
+	mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
+
+	_, err := mover.QueryStreamHistory(ctx, priorStream)
+	require.NoError(t, err,
+		"INV-RA-2: allow-all default MUST permit the non-colocated read via staff bypass")
+}
+
+// INV-RA-3 + INV-RA-5: under WithRealABAC, an admin-role character is PERMITTED
+// the non-colocated read via seed:admin-full-access (read_unrestricted_history).
+// This proves (a) the seed:* set is installed and a seeded permit works, and
+// (b) the provider populating principal.character.roles is registered — an
+// unregistered provider (the g776/xxel fingerprint) would silently default-deny
+// and flip this to STREAM_ACCESS_DENIED, which allow-all would have masked.
+func TestRealABAC_AdminPermittedNonColocatedRead_g776Sentinel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	ts := Start(t, WithRealABAC())
+	boss, priorStream := movedAwayPlayer(t, ctx, ts, "Boss", []string{"admin"})
+
+	_, err := boss.QueryStreamHistory(ctx, priorStream)
+	require.NoError(t, err,
+		"INV-RA-3/RA-5: seed:admin-full-access MUST permit an admin's non-colocated read; "+
+			"a failure here means seeds weren't installed or the roles provider is unregistered")
+}

--- a/site/docs/contributing/integration-tests.md
+++ b/site/docs/contributing/integration-tests.md
@@ -303,6 +303,35 @@ table and to the main "Test packages currently using the harness" table above.
 
 ---
 
+## Real ABAC (`WithRealABAC`)
+
+By default the harness wires an allow-all ABAC engine — most integration tests
+assert session/history floors, which are ABAC-independent. To exercise the
+**real seeded ABAC engine** (production's `abacsetup.NewABACSubsystem` path),
+opt in:
+
+```go
+ts := integrationtest.Start(t, integrationtest.WithRealABAC())
+```
+
+This seeds the production `seed:*` policy set (`policy.Bootstrap`) and boots the
+real engine. Compose with `WithInTreePlugins()` for cross-plugin ABAC coverage —
+the plugin subsystem registers its attribute providers on the engine's own
+resolver:
+
+```go
+ts := integrationtest.Start(t, integrationtest.WithInTreePlugins(), integrationtest.WithRealABAC())
+```
+
+**Live role semantics.** Under `WithRealABAC`, `character_roles` are evaluated by
+the engine. `ConnectAuthedWithRoles(ctx, name, []string{"admin"})` grants
+role-based permits (e.g. `seed:admin-full-access`); a roleless `ConnectAuthed`
+receives only what `seed:*` grants a roleless character. Tests that pass under
+allow-all may see denials under `WithRealABAC` until they seed the roles their
+actions require.
+
+---
+
 ## Related
 
 - `internal/eventbus/eventbustest/` — bus-only harness for unit tests that


### PR DESCRIPTION
## What

Adds an opt-in `WithRealABAC()` StartOption to the `internal/testsupport/integrationtest` harness that boots the **real seeded ABAC engine** via production's `abacsetup.NewABACSubsystem` (the same constructor `cmd/holomush/core.go` uses), so full-stack integration tests can catch **g776-class default-deny regressions** instead of leaking them to e2e.

Mirrors PR #4275's `WithInTreePlugins()` pattern. The harness default stays allow-all (zero churn to existing tests); flipping the default to production-shape is a deferred follow-up.

Closes **holomush-f5t07**. Provides the substrate **holomush-0f0f4.9** depends on; sibling to **holomush-shcyu** (plugin axis).

## How

- `startRealABAC` seeds the `seed:*` policy set (`policy.Bootstrap`) **before** building the subsystem (the engine's `cache.Reload` reads the store at construction), then boots `NewABACSubsystem` and stops its poller via `t.Cleanup`.
- `pluginAttrSources` threads the engine's **own** `*attribute.Resolver` / `*attribute.PluginProvider` / `Auditor` into the plugin layer when a real engine is present — fixing the standalone-resolver bug (`plugins.go`) so plugin-declared providers (e.g. core-scenes' `scene` namespace) register on the resolver the engine evaluates against. The allow-all + plugins path (#4275) is behaviorally unchanged.

## Invariants (INV-RA-1..6)

Six numbered invariants, each with a test (`real_abac_test.go`): real engine boots (RA-1), allow-all default preserved (RA-2), seeds installed + admin sentinel (RA-3/RA-5, the g776 regression demonstration via `staffOverride` → `engine.Evaluate`), resolver/provider pointer identity (RA-4, `require.Same`), option-order independence (RA-6).

## Testing

- `task test:int -- -run TestRealABAC ./internal/testsupport/integrationtest/` → 7 tests green (RA-6 composition test runs, not skipped, with binary plugins built).
- `task pr-prep` (fast lane) green; integration runs as the required CI check.

## Docs & decisions

- Spec: `docs/superpowers/specs/2026-05-26-harness-real-abac-design.md`
- Plan: `docs/superpowers/plans/2026-05-26-harness-real-abac.md`
- ADR **holomush-jvrq3**: `docs/adr/holomush-jvrq3-harness-plugin-resolver-pointer-identity.md` (the resolver/pluginProvider pointer-identity contract)
- Contributor guide: `site/docs/contributing/integration-tests.md` (WithRealABAC section + live role semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)