### PR TITLE
test(wholesystem): cross-plugin-ABAC permit/deny against real engine (holomush-0f0f4)

### DIFF
--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -124,6 +124,15 @@ type Server struct {
 	// passed; nil otherwise. Stopped via t.Cleanup registered in startPlugins.
 	pluginSub *pluginsetup.PluginSubsystem
 
+	// accessEngine is the ABAC policy engine the stack evaluates against: the
+	// allow-all default, a WithPolicyEngine override, or — under WithRealABAC —
+	// the real seeded engine (abacSub.Engine()). Exposed via AccessEngine() so
+	// whole-system tests can evaluate plugin-installed manifest policies (e.g.
+	// test-abac-widget's widget-read-normal / widget-forbid-restricted) directly
+	// against the same engine the harness wired the plugin attribute resolvers
+	// onto (holomush-0f0f4.9, INV-WS-2).
+	accessEngine types.AccessPolicyEngine
+
 	// guestStartLocationID is the location all guests are placed into.
 	guestStartLocationID ulid.ULID
 }
@@ -258,18 +267,27 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	cmdRegistry := command.NewRegistry()
 	if cfg.withPlugins {
 		res, pp, aud := pluginAttrSources(abacSub)
+		// Under WithRealABAC, route plugin manifest-policy installs through the
+		// engine's own cache-wired installer so they go live on the real engine
+		// (mirrors INV-RA-4's resolver/provider routing). nil → startPlugins uses
+		// a fresh standalone installer for the allow-all default.
+		var policyInst *plugins.PolicyInstaller
+		if abacSub != nil {
+			policyInst = abacSub.PolicyInstaller()
+		}
 		pluginSub = startPlugins(t, ctx, pluginDeps{
-			pool:           pool,
-			connStr:        connStr,
-			engine:         pe,
-			sessionStore:   sessionStoreInst,
-			verbReg:        verbRegistry,
-			playerRepo:     playerRepo,
-			hasher:         hasher,
-			playerSess:     playerSessionStore,
-			resolver:       res,
-			pluginProvider: pp,
-			auditor:        aud,
+			pool:            pool,
+			connStr:         connStr,
+			engine:          pe,
+			sessionStore:    sessionStoreInst,
+			verbReg:         verbRegistry,
+			playerRepo:      playerRepo,
+			hasher:          hasher,
+			playerSess:      playerSessionStore,
+			resolver:        res,
+			pluginProvider:  pp,
+			auditor:         aud,
+			policyInstaller: policyInst,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}
@@ -329,6 +347,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		bus:                  bus,
 		coreServer:           coreServer,
 		pluginSub:            pluginSub,
+		accessEngine:         pe,
 		guestStartLocationID: guestLocID,
 	}
 }
@@ -361,6 +380,16 @@ func (s *Server) CommandRegistry() *command.Registry {
 func (s *Server) ServiceRegistry() *plugins.ServiceRegistry {
 	s.requirePlugins("ServiceRegistry")
 	return s.pluginSub.ServiceRegistry()
+}
+
+// AccessEngine returns the ABAC policy engine the stack evaluates against.
+// Under WithRealABAC it is the real seeded engine (abacSub.Engine()); composed
+// with WithInTreePlugins, plugin-declared attribute resolvers are registered on
+// that engine's resolver, so callers can evaluate plugin-installed manifest
+// policies against it directly (holomush-0f0f4.9, INV-WS-2). Without
+// WithRealABAC it is the allow-all default (or a WithPolicyEngine override).
+func (s *Server) AccessEngine() types.AccessPolicyEngine {
+	return s.accessEngine
 }
 
 func (s *Server) requirePlugins(method string) {

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -176,6 +176,13 @@ type pluginDeps struct {
 	resolver       *attribute.Resolver
 	pluginProvider *attribute.PluginProvider
 	auditor        pluginauthz.Auditor
+	// policyInstaller routes manifest-policy installs through the engine's OWN
+	// cache-wired PolicyInstaller when WithRealABAC is active, so each install
+	// fires the store→cache invalidation (setup.go SetOnMutate) and plugin
+	// policies become live on the engine the harness evaluates against. nil under
+	// the allow-all default → startPlugins builds a fresh standalone installer
+	// (there is no engine cache to invalidate). (holomush-0f0f4.9, INV-WS-2)
+	policyInstaller *plugins.PolicyInstaller
 }
 
 // startPlugins constructs and starts a PluginSubsystem mirroring production
@@ -227,8 +234,18 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 		CharLister:     bootstrapsetup.NewCharRepoAdapter(d.pool, worldpostgres.NewCharacterRepository(d.pool)),
 	}
 
-	// PolicyInstaller over a real policystore so manifest policies install.
-	policyInst := plugins.NewPolicyInstaller(policystore.NewPostgresStore(d.pool))
+	// PolicyInstaller: under WithRealABAC, reuse the engine's OWN installer (over
+	// the cache-wired store) so each manifest-policy install trips the engine's
+	// store→cache invalidation (setup.go SetOnMutate → cache.Invalidate, which
+	// reloads inline unless a reload is already in flight; the engine's poller
+	// backstops). Installs run sequentially during LoadAll, before Start returns,
+	// so plugin policies are live by the time tests evaluate. Otherwise (allow-all
+	// default) a fresh installer over the pool suffices — no engine cache to
+	// invalidate.
+	policyInst := d.policyInstaller
+	if policyInst == nil {
+		policyInst = plugins.NewPolicyInstaller(policystore.NewPostgresStore(d.pool))
+	}
 
 	// Resolver / plugin provider are caller-supplied (pluginAttrSources): with a
 	// real ABAC subsystem they are the engine's OWN instances so plugin-declared

--- a/test/integration/wholesystem/abac_test.go
+++ b/test/integration/wholesystem/abac_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package wholesystem_test
+
+import (
+	"context"
+
+	policytypes "github.com/holomush/holomush/internal/access/policy/types"
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+// INV-WS-2: the whole-system stack — real in-tree plugins (WithInTreePlugins)
+// loaded over the real seeded ABAC engine (WithRealABAC) — MUST evaluate a
+// plugin-installed manifest policy end-to-end. test-abac-widget ships
+// widget-read-normal (permit) and widget-forbid-restricted (forbid)
+// (plugins/test-abac-widget/plugin.yaml:31-36); its AttributeResolver, loaded
+// via WithInTreePlugins, resolves widget:normal-1 → {type:normal} and
+// widget:restricted-1 → {type:restricted}, registered on the same engine
+// AccessEngine() returns. The forbid spec is the real-engine sentinel: allow-all
+// would *permit* widget:restricted-1, so a passing deny proves the plugin
+// resolver and the seeded forbid policy are both live on the real engine.
+var _ = Describe("cross-plugin ABAC (INV-WS-2)", Ordered, func() {
+	var (
+		srv     *integrationtest.Server
+		subject string
+	)
+
+	BeforeAll(func() {
+		srv = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithRealABAC(),
+		)
+		// A real connected character is the principal. The widget policies gate
+		// on resource.widget.type (resolved by test-abac-widget), not on roles,
+		// so a roleless character suffices — using a real one keeps the
+		// principal resolving cleanly through the seeded providers.
+		sess := srv.ConnectAuthed(context.Background(), "Widgeteer")
+		subject = "character:" + sess.CharacterID.String()
+	})
+	AfterAll(func() {
+		if srv != nil {
+			srv.Stop()
+		}
+	})
+
+	It("permits read on a normal widget (plugin-installed widget-read-normal policy)", func() {
+		req, err := policytypes.NewAccessRequest(subject, "read", "widget:normal-1", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		decision, err := srv.AccessEngine().Evaluate(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision.IsAllowed()).To(BeTrue(),
+			"test-abac-widget's widget-read-normal permit MUST allow reading a normal widget through the real engine")
+	})
+
+	It("forbids read on a restricted widget (plugin-installed widget-forbid-restricted policy)", func() {
+		req, err := policytypes.NewAccessRequest(subject, "read", "widget:restricted-1", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		decision, err := srv.AccessEngine().Evaluate(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision.IsAllowed()).To(BeFalse(),
+			"test-abac-widget's widget-forbid-restricted MUST deny reading a restricted widget (allow-all would have permitted it)")
+		Expect(decision.Effect()).To(Equal(policytypes.EffectDeny),
+			"a forbid policy MUST surface EffectDeny, not merely the absence of a permit")
+	})
+})


### PR DESCRIPTION
## Summary

Completes epic `holomush-0f0f4` — the **11th and final bead** (`.9`). The first 10 landed in #4275; `.9` was gated on `holomush-f5t07` (`WithRealABAC()`, shipped in #4276).

**INV-WS-2**: assert ≥1 permit and ≥1 forbid through the **real seeded ABAC engine** against a plugin-installed manifest policy — `test-abac-widget`'s `widget-read-normal` (permit) and `widget-forbid-restricted` (forbid) — composed via `WithInTreePlugins() + WithRealABAC()`.

## A real wiring gap the test caught

Writing the test surfaced that the `WithInTreePlugins()+WithRealABAC()` composition wired the attribute **resolver** and **plugin-provider** to the real engine (f5t07's INV-RA-4) but **not the policy installer**. `startPlugins` was installing plugin manifest policies into a *separate* `policystore` instance — a different object than the one `abacSub`'s cache invalidation watches (`internal/access/setup/setup.go:300`, `ps.SetOnMutate → cache.Invalidate`). So plugin-declared policies were written to a store the engine's cache never watched, never compiled into the engine, and **silently default-denied**.

The fix routes the plugin installer through `abacSub.PolicyInstaller()` (the cache-wired one) under `WithRealABAC`, mirroring how f5t07 routed the resolver/provider. Without it, "cross-plugin ABAC against the real engine" was hollow — exactly what INV-WS-2 exists to prevent.

## Changes

- `test/integration/wholesystem/abac_test.go` (new) — the two INV-WS-2 specs. The **permit** spec cannot pass under default-deny, so its passing proves `widget-read-normal` genuinely fires; the **forbid** spec asserts `EffectDeny` (distinct from `EffectDefaultDeny`), proving the forbid policy is live rather than merely an absent permit.
- `internal/testsupport/integrationtest/harness.go` — `Server.AccessEngine()` accessor (exposes the configured engine); route the plugin installer to `abacSub.PolicyInstaller()` under `WithRealABAC`.
- `internal/testsupport/integrationtest/plugins.go` — `pluginDeps.policyInstaller`; `startPlugins` uses it when set, else a fresh standalone installer (the allow-all path is unchanged).

## Test plan

- `task test:int -- ./test/integration/wholesystem/...` — green (permit + forbid against the real engine).
- `task test:int -- ./internal/testsupport/integrationtest/...` — 14 tests green, incl. f5t07's INV-RA-1..6 (the `WithRealABAC`/plugins paths this change touches) — **no regression**.
- `task pr-prep` (fast lane) green; integration + E2E run as required CI checks.

Closes the epic: `.1`–`.8`, `.10`, `.11` (#4275) + `.9` (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
