### PR TITLE
fix(deploy): detach stdin (</dev/null) on foreground compose run/exec in ssh heredocs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
             VERSION="$1"
             cd /opt/holomush
             docker compose --profile tunnel --profile backups exec -T backup \
-              /usr/local/bin/backup.sh --tag="pre-deploy:${VERSION}"
+              /usr/local/bin/backup.sh --tag="pre-deploy:${VERSION}" </dev/null
           EOF
 
       - name: Pull + migrate + restart
@@ -96,12 +96,15 @@ jobs:
             docker compose --profile tunnel --profile backups pull core gateway cloudflared
             docker compose --profile tunnel --profile backups build backup
             docker compose --profile tunnel --profile backups up -d --no-recreate postgres
-            # -T is load-bearing: this script is fed to `ssh ... bash -s <<EOF`, so
-            # stdin IS the heredoc. Without -T, `compose run` attaches stdin and
-            # consumes the remaining heredoc lines (the `up -d` below) as the
-            # container's stdin — so the recreate never runs and core/gateway stay
-            # on the old image while the deploy still "succeeds" (holomush-aocap).
-            docker compose --profile tunnel --profile backups run --rm -T core migrate
+            # `</dev/null` is load-bearing: this script is fed to `ssh ... bash -s
+            # <<'EOF'`, so stdin IS the heredoc. A foreground `compose run`/`exec`
+            # attaches stdin by default and drains the remaining heredoc lines
+            # (the `up -d` below) into the container as its stdin — so the recreate
+            # never runs and core/gateway stay on the old image while the deploy
+            # still "succeeds" (holomush-aocap). `-T` only disables the pseudo-TTY;
+            # it does NOT detach stdin, so the `</dev/null` redirect is the actual
+            # guard. Keep both: `-T` documents intent, `</dev/null` enforces it.
+            docker compose --profile tunnel --profile backups run --rm -T core migrate </dev/null
             docker compose --profile tunnel --profile backups up -d
           EOF
 
@@ -119,8 +122,9 @@ jobs:
             cd /opt/holomush
             # Assert core+gateway actually run the deployed image. A recreate
             # failure leaves a stale container that still passes readiness, so
-            # readiness alone masks a bad deploy (holomush-aocap). All
-            # `compose run/exec` here use -T (stdin = this heredoc).
+            # readiness alone masks a bad deploy (holomush-aocap). Foreground
+            # `compose exec` here gets `-T` (no TTY) AND `</dev/null` so it can't
+            # drain the heredoc that is this script's stdin (see deploy step).
             for svc in core gateway; do
               running="$(docker compose -f compose.yaml ps --format '{{.Image}}' "$svc")"
               if [ "$running" != "$EXPECTED" ]; then
@@ -134,7 +138,7 @@ jobs:
             # (a single immediate probe can hit a still-starting container).
             for attempt in $(seq 1 30); do
               if docker compose -f compose.yaml exec -T gateway \
-                   wget -q --spider http://localhost:9101/healthz/readiness; then
+                   wget -q --spider http://localhost:9101/healthz/readiness </dev/null; then
                 echo "✓ gateway ready"
                 exit 0
               fi


### PR DESCRIPTION
## Problem

Deploy Sandbox run [26427034329](https://github.com/holomush/holomush/actions/runs/26427034329/job/77792632653) failed at **Verify deployed version + health**:

```
core is running 'ghcr.io/holomush/holomush:0.2.0' but expected 'ghcr.io/holomush/holomush:0.3.0'
— deploy did not recreate to the target version
```

The verify step (added in #4260) did its job — it caught a deploy that silently left stale containers running.

## Root cause

The remote deploy script is delivered via `ssh … bash -s <<'EOF'`, so the **remote** bash reads its script from a **non-seekable socket**. A foreground `docker compose run --rm -T core migrate` attaches and **drains** that stdin, consuming the next heredoc line — `docker compose … up -d`, the recreate. bash can't `lseek` back over a socket, so the recreate never runs, `core`/`gateway` stay on the old image, and the step still exits `0`.

`-T` only disables the pseudo-TTY; it does **not** detach stdin, so #4260's `-T` addition was incomplete. (A local `<<'EOF'` heredoc is a *seekable temp file*, so bash seeks back and the bug never reproduces locally — only the ssh-socket path triggers it.)

## Fix

Add `</dev/null` to every **foreground** `compose run`/`exec` in the deploy/verify heredocs so they can't drain the script stdin:

- `run --rm -T core migrate` (deploy step — the one that broke)
- `exec -T gateway wget … readiness` (verify step — same bug, latent on the failure path: it would have eaten the post-loop `::error`/`exit 1` and masked a never-ready gateway)
- `exec -T backup backup.sh` (pre-deploy — last line of its heredoc today, hardened for consistency)

Detached `up -d`, `pull`, `build`, `ps` don't attach the shell's stdin and are left unchanged. Comments corrected to explain `-T` (TTY) vs `</dev/null` (stdin).

## Verification

- Reproduced the bug and verified the fix locally with piped (non-seekable) stdin — the dropped `up -d` line returns with `</dev/null`.
- `actionlint` (repo config) + `shellcheck` 0.11.0 on the `run:` blocks: clean.
- `code-reviewer` gate: READY, no blocking findings.

## Follow-up (operational — not in this PR)

The sandbox is **currently on stale `core` 0.2.0**. After this merges, the **Deploy Sandbox** workflow must be re-dispatched for `v0.3.0` to actually recreate the containers.

Closes holomush-ldjmo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)