### PR TITLE
docs(plugin): plugin runtime config — spec, plan, 2 ADRs (holomush-yzt86)

### DIFF
--- a/docs/adr/holomush-7pdhf-plugin-config-opaque-host-passthrough.md
+++ b/docs/adr/holomush-7pdhf-plugin-config-opaque-host-passthrough.md
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Plugin Runtime Config Is Plugin-Owned via Opaque Host Passthrough
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-7pdhf
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH plugins had no sanctioned mechanism for tunable runtime behavior
+config (windows, intervals, limits). The core server already provisions
+resources a plugin declares in its manifest — a Postgres schema for
+`storage: postgres`, host service addresses for `requires:`, crypto-emit
+capture for `crypto.emits`. That raised the question: should the core server
+also *understand* a plugin's behavior config?
+
+The core-scenes plugin made the gap concrete with a real bug ("cfg-zero"):
+`main.go` constructed the service with a raw struct literal `&SceneServiceImpl{}`,
+so the 7d/30m publish-vote window defaults — applied only in the unused
+`NewSceneServiceImpl` constructor — were never set. Production publish windows
+resolved to `0/0`, collapsing a 7-day vote window to the next ≤30s scheduler
+sweep. There was no seam for a test harness to set short windows either.
+
+This decision pairs with [[holomush-ikozq]] (the manifest declares a *typed
+schema*); this ADR covers *who owns the config and how it crosses the
+host↔plugin boundary*.
+
+## Decision
+
+Plugin runtime config is **plugin-owned**, delivered by the host as an **opaque
+passthrough**:
+
+- The plugin **manifest** declares the config schema (keys → type, default,
+  required); see [[holomush-ikozq]].
+- The **host** reads that schema, validates only **generic types**
+  (`duration`/`int`/`bool`/`string`), merges an optional **server-provided
+  override** per key (`manifest default < override`), and delivers the resulting
+  `map<string,string>` to the plugin — for binary plugins via a new
+  `ServiceConfig.plugin_config` field at `Init`; for Lua via the `holomush.config`
+  global. The host **never interprets a key's meaning**.
+- The **plugin** owns all key semantics and decodes the delivered map itself
+  (`pluginsdk.DecodeConfig[T]` for Go; `holomush.config` accessors for Lua).
+
+The host is therefore **semantically opaque but generically type-aware** —
+"this value is a duration" is structural validation the host may do; "`vote_window`
+governs publish voting" is plugin semantics the host must not know.
+
+**Delivery contract:** the binary `needsInit` gate (`internal/plugin/goplugin/host.go`)
+is extended to include `len(manifest.Config) > 0`, so a plugin declaring *only*
+`config:` still receives `Init` and therefore its `plugin_config`. This is
+codified as invariant **INV-PC-8** with a regression test (rather than a separate
+ADR — it is the binary-runtime delivery mechanism for this decision).
+
+## Alternatives Considered
+
+- **Host-semantic config** (the core server registers and interprets known
+  config keys). Rejected: violates the plugin boundary ([[holomush-z1e7]]),
+  couples plugin semantics to the substrate, and requires a host change for
+  every new plugin config key. Directly contrary to the directive that the core
+  server cannot know or care about a plugin's config needs.
+- **Hardcoded Go defaults (status quo).** Rejected: no test tunability, the
+  cfg-zero bug class (constructor bypass silently yields zero values), and no
+  override seam — fundamentally not a config primitive.
+
+## Consequences
+
+**Positive**
+
+- Any plugin can declare runtime config with no substrate change.
+- The cfg-zero bug class is eliminated by construction: config is always loaded
+  from the manifest on every init path; the zero-value struct literal is
+  unreachable in production.
+- The server-provided override channel (`PluginSubsystemConfig.PluginConfigOverrides`)
+  gives a test harness a clean seam to set short windows without production
+  impact — the seam [[holomush-shcyu]] consumes to drive the Phase 6 publish E2E.
+
+**Negative**
+
+- The host cannot enforce cross-key semantic constraints (e.g. `vote_window >
+  cooloff_window`); such checks live in the plugin.
+- Plugin authors must call `DecodeConfig` / the `holomush.config` accessors;
+  forgetting them yields zero values — mitigated by `required: true` +
+  load-time fail-fast.
+
+**Neutral**
+
+- The host understands the four generic types for structural validation only;
+  this is generic-type awareness, not plugin-semantic awareness.

--- a/docs/adr/holomush-ikozq-manifest-typed-config-schema-ssot.md
+++ b/docs/adr/holomush-ikozq-manifest-typed-config-schema-ssot.md
@@ -1,0 +1,70 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Plugin Manifest Typed Config Schema Is the Single Source of Truth for All Runtimes
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-ikozq
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Given that plugin runtime config crosses the host↔plugin boundary as an opaque
+map ([[holomush-7pdhf]]), each runtime still needs to turn those string values
+into typed values. Binary plugins do this naturally via Go struct tags; Lua
+plugins via accessor calls. Left to each runtime, that is **two independent
+declarations** of a key's type and default — e.g. "`vote_window` is a duration
+defaulting to `168h`" written once in a Go struct and again in Lua accessor
+calls. Those declarations can drift, which is a latent violation of the
+**plugin-runtime-symmetry** invariant (`.claude/rules/plugin-runtime-symmetry.md`),
+a project MUST: binary and Lua plugins must be treated identically by the host.
+
+## Decision
+
+The plugin manifest `config:` block is a **typed schema** — each key declares
+`{type, default, required, description}` — and is the **single source of truth**
+driving **both** runtimes:
+
+- Binary plugins decode via `pluginsdk.DecodeConfig[T]` (mapstructure).
+- Lua plugins read via `holomush.config` typed accessors.
+- The host derives type validation and the default/override merge from this one
+  schema, so binary and Lua typing are **identical by construction**, not by
+  discipline.
+
+v1 supports **scalar types only** (`duration`/`int`/`bool`/`string`);
+enum/nested/list types are deferred to a future extension.
+
+## Alternatives Considered
+
+- **Flat string map + read-site typing** (manifest carries only key→string;
+  each runtime declares the type where it reads the value). Rejected: it
+  re-introduces two independent, driftable typing declarations (the symmetry
+  hazard); it has no auto-generated config documentation; and it cannot do
+  load-time type validation, only runtime. It traded a little less manifest
+  machinery for a standing discipline burden — and `koanf`/`mapstructure` were
+  already in the module graph, so the schema path was affordable.
+
+## Consequences
+
+**Positive**
+
+- Binary and Lua typing can never silently diverge for a given key — symmetry by
+  construction.
+- The config surface is self-documenting from the manifest (drives the
+  `site/docs/extending/` config reference).
+- Load-time fail-fast on a misauthored manifest (`PLUGIN_CONFIG_TYPE_INVALID`,
+  `PLUGIN_CONFIG_MISSING_REQUIRED`) is possible only because the host knows each
+  key's declared type from the schema.
+
+**Negative**
+
+- The manifest JSON schema must be regenerated (`task generate:schema` →
+  `schemas/plugin.schema.json`) and committed whenever the `config:` shape
+  changes — enforced by the schema-drift CI check.
+- Scalar-only in v1; richer types require a follow-up.
+
+**Neutral**
+
+- The host's schema awareness is limited to generic types; it does not interpret
+  key semantics (see [[holomush-7pdhf]]).

--- a/docs/superpowers/plans/2026-05-27-plugin-runtime-config.md
+++ b/docs/superpowers/plans/2026-05-27-plugin-runtime-config.md
@@ -1,0 +1,1111 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Runtime Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic plugin-runtime-config primitive — a manifest-declared typed config schema delivered to plugins via an opaque host passthrough — and adopt it in core-scenes (fixing the cfg-zero bug).
+
+**Architecture:** A plugin declares a typed `config:` schema in its manifest (keys → type/default/required). The host reads it opaquely, merges an optional server-provided override per key (`manifest default < override`), validates generic types, and delivers the merged `map[string]string` to the plugin at init — binary via a new `ServiceConfig.plugin_config` field, Lua via the `holomush.config` global. The SDK decodes typed config (`DecodeConfig[T]` for Go; `holomush.config` accessors for Lua). The host never interprets a key's meaning.
+
+**Tech Stack:** Go 1.24+, `github.com/go-viper/mapstructure/v2` (struct decode; already in the module graph as a koanf dep, promoted to direct), protobuf via `buf`, gopher-lua, testify (unit), Ginkgo (integration). Spec: `docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md`.
+
+**Invariants:** INV-PC-1..8 (spec §7). Each task notes which it implements.
+
+---
+
+## Task 1: Manifest `ConfigParam` type + `Config` field
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go` (Manifest struct ~`:71`)
+- Test: `internal/plugin/manifest_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/plugin/manifest_test.go`:
+
+```go
+func TestParseManifestConfigBlock(t *testing.T) {
+	data := []byte(`
+name: demo
+version: 1.0.0
+type: binary
+config:
+  vote_window:
+    type: duration
+    default: 168h
+    required: true
+    description: "vote collection window"
+  max_attempts:
+    type: int
+    default: "3"
+`)
+	m, err := ParseManifest(data)
+	require.NoError(t, err)
+	require.Len(t, m.Config, 2)
+	require.Equal(t, "duration", m.Config["vote_window"].Type)
+	require.Equal(t, "168h", m.Config["vote_window"].Default)
+	require.True(t, m.Config["vote_window"].Required)
+	require.Equal(t, "int", m.Config["max_attempts"].Type)
+	require.False(t, m.Config["max_attempts"].Required)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestParseManifestConfigBlock ./internal/plugin/`
+Expected: FAIL — `m.Config` undefined.
+
+- [ ] **Step 3: Add the type + field**
+
+In `internal/plugin/manifest.go`, add near the other config helper types:
+
+```go
+// ConfigParam declares one plugin runtime config key. Opaque to the host:
+// type/default/required are validated generically; the host never interprets
+// what a key controls. See
+// docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md.
+type ConfigParam struct {
+	Type        string `yaml:"type" json:"type"` // duration|int|bool|string
+	Default     string `yaml:"default,omitempty" json:"default,omitempty"`
+	Required    bool   `yaml:"required,omitempty" json:"required,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+```
+
+In the `Manifest` struct (`:71`), add the field:
+
+```go
+	// Config is the plugin's runtime config schema, keyed by config key.
+	// Opaque to host semantics (host validates generic types + merges values;
+	// plugin owns meaning). Empty for plugins with no runtime config.
+	Config map[string]ConfigParam `yaml:"config,omitempty" json:"config,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestParseManifestConfigBlock ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md` — message: `feat(plugin): manifest ConfigParam type + Config schema field (holomush-yzt86)`.
+
+---
+
+## Task 2: Config-schema validation + regenerate manifest JSON schema
+
+**Files:**
+
+- Create: `internal/plugin/config.go`
+- Modify: `internal/plugin/manifest.go` (`Validate()` `:369`)
+- Test: `internal/plugin/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/plugin/config_test.go`:
+
+```go
+func TestValidateConfigSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     map[string]ConfigParam
+		wantErr string // oops code substring; "" = no error
+	}{
+		{"valid duration with default", map[string]ConfigParam{"w": {Type: "duration", Default: "30m"}}, ""},
+		{"valid int", map[string]ConfigParam{"n": {Type: "int", Default: "3"}}, ""},
+		{"unknown type", map[string]ConfigParam{"x": {Type: "float"}}, "PLUGIN_CONFIG_SCHEMA_INVALID"},
+		{"bad default for type", map[string]ConfigParam{"w": {Type: "duration", Default: "banana"}}, "PLUGIN_CONFIG_SCHEMA_INVALID"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfigSchema(tc.cfg)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			errutil.AssertErrorCode(t, err, tc.wantErr)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestValidateConfigSchema ./internal/plugin/`
+Expected: FAIL — `validateConfigSchema` / `parseScalar` undefined.
+
+- [ ] **Step 3: Implement `config.go` type helpers + validation**
+
+Create `internal/plugin/config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package plugins — plugin runtime config: generic-type validation and the
+// host-side merge of manifest defaults with server-provided overrides. The
+// host treats keys/values opaquely w.r.t. plugin semantics; only generic
+// types (duration/int/bool/string) are understood, for structural validation.
+package plugins
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/samber/oops"
+)
+
+// validScalar reports whether value parses to the declared generic type.
+// string always validates. Used by manifest schema validation and the merge.
+func validScalar(typ, value string) error {
+	switch typ {
+	case "duration":
+		if _, err := time.ParseDuration(value); err != nil {
+			return oops.With("value", value).Wrap(err)
+		}
+	case "int":
+		if _, err := strconv.Atoi(value); err != nil {
+			return oops.With("value", value).Wrap(err)
+		}
+	case "bool":
+		if _, err := strconv.ParseBool(value); err != nil {
+			return oops.With("value", value).Wrap(err)
+		}
+	case "string":
+		// any string is valid
+	default:
+		return oops.With("type", typ).Errorf("unknown config type %q", typ)
+	}
+	return nil
+}
+
+// validateConfigSchema checks each declared config param has a known generic
+// type and a parseable default (if any). Semantic meaning is plugin-owned.
+func validateConfigSchema(schema map[string]ConfigParam) error {
+	for key, p := range schema {
+		switch p.Type {
+		case "duration", "int", "bool", "string":
+		default:
+			return oops.Code("PLUGIN_CONFIG_SCHEMA_INVALID").
+				With("key", key).With("type", p.Type).
+				Errorf("config key %q: unknown type %q (want duration|int|bool|string)", key, p.Type)
+		}
+		if p.Default != "" {
+			if err := validScalar(p.Type, p.Default); err != nil {
+				return oops.Code("PLUGIN_CONFIG_SCHEMA_INVALID").
+					With("key", key).Wrapf(err, "config key %q: default does not parse as %s", key, p.Type)
+			}
+		}
+	}
+	return nil
+}
+```
+
+Add the import `"github.com/holomush/holomush/pkg/errutil"` to `config_test.go`.
+
+- [ ] **Step 4: Wire into `Manifest.Validate()`**
+
+In `internal/plugin/manifest.go` `Validate()` (`:369`), before the final `return nil`:
+
+```go
+	if err := validateConfigSchema(m.Config); err != nil {
+		return err
+	}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test -- -run TestValidateConfigSchema ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 6: Regenerate the manifest JSON schema**
+
+The manifest schema is generated from the Go struct. Run: `task generate:schema`
+Then verify nothing else drifted: `task test -- ./internal/plugin/` and confirm the regenerated schema artifact now includes `config`. Stage the regenerated schema file(s) (the `generate:schema` output) — they MUST be committed or CI's schema-drift check fails.
+
+- [ ] **Step 7: Commit**
+
+Message: `feat(plugin): validate config schema + regenerate manifest schema (holomush-yzt86)`.
+
+---
+
+## Task 3: Host-side merge (`MergePluginConfig`) — INV-PC-2/4/5/6
+
+**Files:**
+
+- Modify: `internal/plugin/config.go`
+- Test: `internal/plugin/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/plugin/config_test.go`:
+
+```go
+func TestMergePluginConfig(t *testing.T) {
+	schema := map[string]ConfigParam{
+		"vote_window":    {Type: "duration", Default: "168h", Required: true},
+		"cooloff_window": {Type: "duration", Default: "30m"},
+		"needs_override": {Type: "int", Required: true}, // no default
+	}
+	t.Run("INV-PC-2 override wins; defaults fill", func(t *testing.T) {
+		got, err := MergePluginConfig(schema, map[string]string{"cooloff_window": "5s", "needs_override": "1"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"vote_window": "168h", "cooloff_window": "5s", "needs_override": "1"}, got)
+	})
+	t.Run("INV-PC-4 missing required (no default, no override)", func(t *testing.T) {
+		_, err := MergePluginConfig(schema, map[string]string{})
+		errutil.AssertErrorCode(t, err, "PLUGIN_CONFIG_MISSING_REQUIRED")
+	})
+	t.Run("INV-PC-5 override value wrong type", func(t *testing.T) {
+		_, err := MergePluginConfig(schema, map[string]string{"vote_window": "banana", "needs_override": "1"})
+		errutil.AssertErrorCode(t, err, "PLUGIN_CONFIG_TYPE_INVALID")
+	})
+	t.Run("INV-PC-6 override key not in schema", func(t *testing.T) {
+		_, err := MergePluginConfig(schema, map[string]string{"needs_override": "1", "bogus": "x"})
+		errutil.AssertErrorCode(t, err, "PLUGIN_CONFIG_UNKNOWN_KEY")
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestMergePluginConfig ./internal/plugin/`
+Expected: FAIL — `MergePluginConfig` undefined.
+
+- [ ] **Step 3: Implement the merge**
+
+Append to `internal/plugin/config.go`:
+
+```go
+// MergePluginConfig computes the effective config a plugin receives: manifest
+// defaults overlaid by the server-provided override, per key (override wins).
+// It enforces, opaquely w.r.t. plugin meaning:
+//   - INV-PC-6: an override key not declared in schema → PLUGIN_CONFIG_UNKNOWN_KEY
+//   - INV-PC-5: an effective value not parseable to its declared type → PLUGIN_CONFIG_TYPE_INVALID
+//   - INV-PC-4: a required key with neither default nor override → PLUGIN_CONFIG_MISSING_REQUIRED
+//
+// Returns a flat map[string]string ready for opaque delivery to either runtime.
+func MergePluginConfig(schema map[string]ConfigParam, override map[string]string) (map[string]string, error) {
+	for k := range override {
+		if _, ok := schema[k]; !ok {
+			return nil, oops.Code("PLUGIN_CONFIG_UNKNOWN_KEY").
+				With("key", k).Errorf("override key %q not declared in manifest config schema", k)
+		}
+	}
+	out := make(map[string]string, len(schema))
+	for key, p := range schema {
+		val, has := override[key]
+		if !has {
+			if p.Default == "" {
+				if p.Required {
+					return nil, oops.Code("PLUGIN_CONFIG_MISSING_REQUIRED").
+						With("key", key).Errorf("required config key %q has no default and no override", key)
+				}
+				continue // absent, not required → omit
+			}
+			val = p.Default
+		}
+		if err := validScalar(p.Type, val); err != nil {
+			return nil, oops.Code("PLUGIN_CONFIG_TYPE_INVALID").
+				With("key", key).Wrapf(err, "config key %q: value does not parse as %s", key, p.Type)
+		}
+		out[key] = val
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestMergePluginConfig ./internal/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `task lint:go`. Then commit: `feat(plugin): MergePluginConfig — opaque defaults<override merge (holomush-yzt86)`.
+
+---
+
+## Task 4: Proto — `ServiceConfig.plugin_config`
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/plugin.proto` (`message ServiceConfig` `:118`)
+- Regenerate: `pkg/proto/holomush/plugin/v1/*.pb.go` (via `task proto`)
+
+- [ ] **Step 1: Add the field**
+
+In `api/proto/holomush/plugin/v1/plugin.proto`, inside `message ServiceConfig` (after `required_services = 2;`):
+
+```proto
+  // Opaque plugin-owned runtime config: the effective (manifest-default <
+  // server-override) map the host delivers at init. The host does NOT
+  // interpret keys/values; the plugin decodes them per its own schema.
+  map<string, string> plugin_config = 3;
+```
+
+- [ ] **Step 2: Regenerate proto Go code**
+
+Run: `task proto`
+Expected: `pkg/proto/holomush/plugin/v1/plugin.pb.go` regenerated with a `GetPluginConfig()` accessor on `ServiceConfig`.
+
+- [ ] **Step 3: Verify it compiles + lint**
+
+Run: `task build` then `task lint`.
+Expected: build passes; `ServiceConfig.GetPluginConfig()` exists.
+
+- [ ] **Step 4: Commit**
+
+Message: `feat(proto): ServiceConfig.plugin_config opaque map (holomush-yzt86)`. Include the regenerated `.pb.go`.
+
+---
+
+## Task 5: Thread `PluginConfigOverrides` through the subsystem to the host
+
+**Files:**
+
+- Modify: `internal/plugin/setup/subsystem.go` (`PluginSubsystemConfig` `:89`; wiring to `Manager`)
+- Modify: `internal/plugin/manager.go` (pass overrides to the binary host)
+- Modify: `internal/plugin/goplugin/host.go` (Host gains per-plugin override access)
+- Test: `internal/plugin/goplugin/host_test.go`
+
+- [ ] **Step 1: Add the override field to `PluginSubsystemConfig`**
+
+In `internal/plugin/setup/subsystem.go` `PluginSubsystemConfig` (`:89`), add:
+
+```go
+	// PluginConfigOverrides maps plugin name → (config key → value), merged
+	// over each plugin's manifest config defaults at init (override wins).
+	// Opaque to the host. Empty in production; tests/ops populate it. Keys
+	// MUST be declared in the target plugin's manifest config schema (else
+	// PLUGIN_CONFIG_UNKNOWN_KEY at load).
+	PluginConfigOverrides map[string]map[string]string
+```
+
+- [ ] **Step 2: Write the failing test (host carries the override)**
+
+In `internal/plugin/goplugin/host_test.go`:
+
+```go
+func TestHostConfigOverrideForPlugin(t *testing.T) {
+	h := &Host{configOverrides: map[string]map[string]string{
+		"demo": {"vote_window": "5s"},
+	}}
+	require.Equal(t, map[string]string{"vote_window": "5s"}, h.overrideFor("demo"))
+	require.Nil(t, h.overrideFor("absent")) // no override → nil (defaults apply)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `task test -- -run TestHostConfigOverrideForPlugin ./internal/plugin/goplugin/`
+Expected: FAIL — `Host.configOverrides` / `overrideFor` undefined.
+
+- [ ] **Step 4: Add the field + accessor to `Host`**
+
+In `internal/plugin/goplugin/host.go`, add to the `Host` struct and a helper:
+
+```go
+	// configOverrides is the per-plugin server-provided config override
+	// (plugin name → key → value), threaded from PluginSubsystemConfig.
+	configOverrides map[string]map[string]string
+```
+
+```go
+// overrideFor returns the server-provided config override for a plugin, or nil
+// when none is configured (manifest defaults then apply).
+func (h *Host) overrideFor(pluginName string) map[string]string {
+	return h.configOverrides[pluginName]
+}
+```
+
+Thread `cfg.PluginConfigOverrides` from `subsystem.go` into the `Manager`, and from the `Manager` into the binary `Host` constructor (set `Host.configOverrides`). Follow the existing pattern by which other `PluginSubsystemConfig` fields reach the host (e.g. `schemaProvisioner`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test -- -run TestHostConfigOverrideForPlugin ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 6: Build + commit**
+
+Run: `task build`. Commit: `feat(plugin): thread PluginConfigOverrides subsystem→manager→host (holomush-yzt86)`.
+
+---
+
+## Task 6: Binary delivery + `needsInit` gate — INV-PC-8
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go` (`needsInit` `:595-598`; `initReq.Config` construction)
+- Test: `internal/plugin/goplugin/host_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/plugin/goplugin/host_test.go`:
+
+```go
+func TestNeedsInitIncludesConfig(t *testing.T) {
+	// INV-PC-8: a config-only plugin (no requires/provides/storage/crypto)
+	// MUST still be initialised so its plugin_config is delivered.
+	m := &plugins.Manifest{
+		Name:   "demo",
+		Config: map[string]plugins.ConfigParam{"w": {Type: "duration", Default: "5s"}},
+	}
+	require.True(t, manifestNeedsInit(m), "config-only manifest must need Init")
+
+	bare := &plugins.Manifest{Name: "bare"}
+	require.False(t, manifestNeedsInit(bare), "manifest with nothing needs no Init")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestNeedsInitIncludesConfig ./internal/plugin/goplugin/`
+Expected: FAIL — `manifestNeedsInit` undefined (the gate is currently an inline expression).
+
+- [ ] **Step 3: Extract the gate as a function and extend it**
+
+In `internal/plugin/goplugin/host.go`, replace the inline `needsInit := …` (`:595-598`) with a call to a new package function, and define it:
+
+```go
+// manifestNeedsInit reports whether the host must call Init on a plugin.
+// Init injects services (requires/provides), provisions storage, captures
+// crypto.emits (INV-S5), AND — INV-PC-8 — delivers plugin_config for any
+// plugin declaring a config schema.
+func manifestNeedsInit(m *plugins.Manifest) bool {
+	return len(m.Requires) > 0 ||
+		len(m.Provides) > 0 ||
+		m.Storage == plugins.StoragePostgres ||
+		(m.Crypto != nil && len(m.Crypto.Emits) > 0) ||
+		len(m.Config) > 0
+}
+```
+
+At the call site: `needsInit := manifestNeedsInit(manifest)`.
+
+- [ ] **Step 4: Populate `plugin_config` in the InitRequest**
+
+In the `if needsInit {` block, after the `initReq` is built (and after the `ConnectionString` provisioning block), add:
+
+```go
+		if len(manifest.Config) > 0 {
+			merged, mergeErr := plugins.MergePluginConfig(manifest.Config, h.overrideFor(manifest.Name))
+			if mergeErr != nil {
+				client.Kill()
+				if certDir != "" {
+					_ = os.RemoveAll(certDir) //nolint:errcheck // best-effort cleanup
+				}
+				return oops.In("goplugin").With("plugin", manifest.Name).
+					With("operation", "merge_plugin_config").Wrap(mergeErr)
+			}
+			initReq.Config.PluginConfig = merged
+		}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./internal/plugin/goplugin/`
+Expected: PASS (gate test + existing host tests).
+
+- [ ] **Step 6: Build + commit**
+
+Run: `task build`. Commit: `feat(plugin): deliver plugin_config + needsInit config gate, INV-PC-8 (holomush-yzt86)`.
+
+---
+
+## Task 7: SDK `DecodeConfig[T]` (Go) — typed decode
+
+**Files:**
+
+- Create: `pkg/plugin/config.go`
+- Modify: `go.mod` (promote `go-viper/mapstructure/v2` to direct via `go mod tidy`)
+- Test: `pkg/plugin/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `pkg/plugin/config_test.go` (package `pluginsdk`):
+
+```go
+func TestDecodeConfig(t *testing.T) {
+	type demoCfg struct {
+		VoteWindow time.Duration `mapstructure:"vote_window"`
+		MaxTries   int           `mapstructure:"max_tries"`
+		Enabled    bool          `mapstructure:"enabled"`
+		Label      string        `mapstructure:"label"`
+	}
+	sc := &pluginv1.ServiceConfig{PluginConfig: map[string]string{
+		"vote_window": "168h", "max_tries": "3", "enabled": "true", "label": "x",
+	}}
+	got, err := DecodeConfig[demoCfg](sc)
+	require.NoError(t, err)
+	require.Equal(t, 168*time.Hour, got.VoteWindow)
+	require.Equal(t, 3, got.MaxTries)
+	require.True(t, got.Enabled)
+	require.Equal(t, "x", got.Label)
+}
+
+func TestDecodeConfigNilSafe(t *testing.T) {
+	type demoCfg struct{ VoteWindow time.Duration `mapstructure:"vote_window"` }
+	got, err := DecodeConfig[demoCfg](&pluginv1.ServiceConfig{}) // no plugin_config
+	require.NoError(t, err)
+	require.Zero(t, got.VoteWindow)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestDecodeConfig ./pkg/plugin/`
+Expected: FAIL — `DecodeConfig` undefined.
+
+- [ ] **Step 3: Implement `DecodeConfig`**
+
+Create `pkg/plugin/config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/samber/oops"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// DecodeConfig decodes the host-delivered opaque plugin_config map into T,
+// reading `mapstructure:` struct tags. String values are coerced to the struct
+// field type (durations via StringToTimeDurationHookFunc; ints/bools via weak
+// typing). Defaults and required-key enforcement are applied host-side
+// (MergePluginConfig); DecodeConfig is pure string→typed conversion. koanf is
+// not used — there is no file/provider layering, just one in-memory map.
+func DecodeConfig[T any](config *pluginv1.ServiceConfig) (T, error) {
+	var out T
+	raw := make(map[string]any, len(config.GetPluginConfig()))
+	for k, v := range config.GetPluginConfig() {
+		raw[k] = v
+	}
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		TagName:          "mapstructure",
+		Result:           &out,
+	})
+	if err != nil {
+		return out, oops.Code("PLUGIN_CONFIG_DECODE_FAILED").Wrap(err)
+	}
+	if err := dec.Decode(raw); err != nil {
+		return out, oops.Code("PLUGIN_CONFIG_DECODE_FAILED").Wrap(err)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Promote mapstructure to a direct dependency**
+
+Run: `go mod tidy` (via the repo's module tooling — confirm `task` has no wrapper; if not, run `go mod tidy` directly per repo norms). Confirm `go-viper/mapstructure/v2` moves out of the `// indirect` block in `go.mod`. No new module is added (it was already in the graph as koanf's dep).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test -- -run TestDecodeConfig ./pkg/plugin/`
+Expected: PASS.
+
+- [ ] **Step 6: Build + commit**
+
+Run: `task build`. Commit: `feat(plugin-sdk): DecodeConfig[T] typed config decode (holomush-yzt86)`.
+
+---
+
+## Task 8: Lua delivery — `holomush.config` + typed accessors
+
+**Files:**
+
+- Modify: `internal/plugin/lua/host.go` (thread merged config to the per-delivery `Register` call)
+- Modify: `internal/plugin/hostfunc/functions.go` (`Register` `:162`; expose `holomush.config`)
+- Create: `internal/plugin/hostfunc/config.go` (the accessor builder)
+- Test: `internal/plugin/hostfunc/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/plugin/hostfunc/config_test.go`:
+
+```go
+func TestLuaConfigAccessors(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	mod := L.NewTable()
+	registerConfigTable(L, mod, map[string]string{"vote_window": "168h", "n": "3", "on": "true", "s": "hi"})
+	L.SetGlobal("holomush", mod)
+
+	require.NoError(t, L.DoString(`
+		assert(holomush.config.duration("vote_window") == 168*60*60)  -- seconds
+		assert(holomush.config.int("n") == 3)
+		assert(holomush.config.bool("on") == true)
+		assert(holomush.config.string("s") == "hi")
+		assert(holomush.config.duration("absent") == nil)
+		local ok = pcall(function() holomush.config.require_duration("absent") end)
+		assert(ok == false)  -- require_* errors when absent
+	`))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestLuaConfigAccessors ./internal/plugin/hostfunc/`
+Expected: FAIL — `registerConfigTable` undefined.
+
+- [ ] **Step 3: Implement the accessor builder**
+
+Create `internal/plugin/hostfunc/config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package hostfunc
+
+import (
+	"strconv"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// registerConfigTable installs holomush.config on mod, exposing the host's
+// merged (opaque string) config map with typed accessors that mirror the Go
+// SDK (DecodeConfig). duration returns seconds (Lua number); require_* error
+// when the key is absent. Conversion uses the same fail-loud discipline as the
+// rest of the Lua host.
+func registerConfigTable(L *lua.LState, mod *lua.LTable, cfg map[string]string) {
+	c := L.NewTable()
+	get := func(key string) (string, bool) { v, ok := cfg[key]; return v, ok }
+
+	dur := func(require bool) lua.LGFunction {
+		return func(L *lua.LState) int {
+			key := L.CheckString(1)
+			v, ok := get(key)
+			if !ok {
+				if require {
+					L.RaiseError("holomush.config.require_duration: missing key %q", key)
+				}
+				L.Push(lua.LNil)
+				return 1
+			}
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				L.RaiseError("holomush.config: key %q value %q is not a duration", key, v)
+			}
+			L.Push(lua.LNumber(d.Seconds()))
+			return 1
+		}
+	}
+	intFn := func(require bool) lua.LGFunction {
+		return func(L *lua.LState) int {
+			key := L.CheckString(1)
+			v, ok := get(key)
+			if !ok {
+				if require {
+					L.RaiseError("holomush.config.require_int: missing key %q", key)
+				}
+				L.Push(lua.LNil)
+				return 1
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				L.RaiseError("holomush.config: key %q value %q is not an int", key, v)
+			}
+			L.Push(lua.LNumber(n))
+			return 1
+		}
+	}
+	boolFn := func(L *lua.LState) int {
+		key := L.CheckString(1)
+		v, ok := get(key)
+		if !ok {
+			L.Push(lua.LNil)
+			return 1
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			L.RaiseError("holomush.config: key %q value %q is not a bool", key, v)
+		}
+		L.Push(lua.LBool(b))
+		return 1
+	}
+	strFn := func(L *lua.LState) int {
+		key := L.CheckString(1)
+		if v, ok := get(key); ok {
+			L.Push(lua.LString(v))
+		} else {
+			L.Push(lua.LNil)
+		}
+		return 1
+	}
+
+	L.SetField(c, "duration", L.NewFunction(dur(false)))
+	L.SetField(c, "require_duration", L.NewFunction(dur(true)))
+	L.SetField(c, "int", L.NewFunction(intFn(false)))
+	L.SetField(c, "require_int", L.NewFunction(intFn(true)))
+	L.SetField(c, "bool", L.NewFunction(boolFn))
+	L.SetField(c, "string", L.NewFunction(strFn))
+	L.SetField(mod, "config", c)
+}
+```
+
+- [ ] **Step 4: Thread config into `Register`**
+
+In `internal/plugin/hostfunc/functions.go`, give `Functions` a per-call config map. Add a field `pluginConfig map[string]string` set by a setter, OR add a parameter. Minimal change: add a setter and call `registerConfigTable` inside `Register` just before `ls.SetGlobal("holomush", mod)` (`:230`):
+
+```go
+	registerConfigTable(ls, mod, f.pluginConfigFor(pluginName))
+```
+
+Add to `Functions`:
+
+```go
+	// pluginConfigs holds the merged (opaque) config per plugin, set by the
+	// Lua host before Register. nil/absent → empty holomush.config.
+	pluginConfigs map[string]map[string]string
+```
+
+```go
+func (f *Functions) SetPluginConfigs(c map[string]map[string]string) { f.pluginConfigs = c }
+func (f *Functions) pluginConfigFor(name string) map[string]string    { return f.pluginConfigs[name] }
+```
+
+- [ ] **Step 5: Populate the merged config in the Lua host**
+
+Thread `PluginConfigOverrides` into the Lua host via a functional option mirroring the existing `WithCPUTimeout` (`internal/plugin/lua/host.go:51` `type HostOption func(*Host)`, `:57`). Add to `host.go`:
+
+```go
+// WithPluginConfigOverrides threads the server-provided per-plugin config
+// overrides into the Lua host (mirrors the binary host's configOverrides).
+func WithPluginConfigOverrides(o map[string]map[string]string) HostOption {
+	return func(h *Host) { h.configOverrides = o }
+}
+```
+
+Add `configOverrides map[string]map[string]string` and `mergedConfigs map[string]map[string]string` fields to the Lua `Host` struct. In `Host.Load(ctx, manifest, dir)` (`:137`), once `manifest` is in hand, compute and stash the merge (fail the load on error, mirroring the binary host):
+
+```go
+	merged, err := plugins.MergePluginConfig(manifest.Config, h.configOverrides[manifest.Name])
+	if err != nil {
+		return oops.In("lua").With("plugin", manifest.Name).With("operation", "merge_plugin_config").Wrap(err)
+	}
+	if h.mergedConfigs == nil {
+		h.mergedConfigs = map[string]map[string]string{}
+	}
+	h.mergedConfigs[manifest.Name] = merged
+```
+
+Before each per-delivery `h.hostFuncs.Register(L, name, requires...)` (in `DeliverEvent`/`DeliverCommand`/`QuerySessionStreams`), call `h.hostFuncs.SetPluginConfigs(h.mergedConfigs)` so `registerConfigTable` (Step 3) — invoked inside `Register` via `f.pluginConfigFor(name)` (Step 4) — sees the merged map.
+
+Wire the option where the Lua host is built (`internal/plugin/setup/subsystem.go:182`):
+
+```go
+	luaHost := pluginlua.NewHostWithFunctions(
+		luaFns,
+		// ...existing opts...
+		pluginlua.WithPluginConfigOverrides(cfg.PluginConfigOverrides),
+	)
+```
+
+This is the same functional-option threading the binary host uses for its provider deps (Task 5's `schemaProvisioner` pattern).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `task test -- ./internal/plugin/hostfunc/ ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 7: Build + commit**
+
+Run: `task build`. Commit: `feat(plugin): Lua holomush.config typed accessors (holomush-yzt86)`.
+
+---
+
+## Task 9: core-scenes — declare `config:` in the manifest
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml`
+
+- [ ] **Step 1: Add the config block**
+
+In `plugins/core-scenes/plugin.yaml`, add a top-level `config:` block:
+
+```yaml
+config:
+  vote_window:
+    type: duration
+    default: 168h
+    description: "How long a publish-vote attempt collects votes before timeout."
+  cooloff_window:
+    type: duration
+    default: 30m
+    description: "Delay between unanimous-yes resolution and PUBLISHED."
+  scheduler_interval:
+    type: duration
+    default: 30s
+    description: "How often the publish scheduler sweeps for expired attempts."
+```
+
+- [ ] **Step 2: Verify the manifest still validates**
+
+Run: `task test -- -run TestParseManifest ./internal/plugin/` (and the plugin's own manifest test if present).
+Expected: PASS — the schema parses and validates.
+
+- [ ] **Step 3: Commit**
+
+Message: `feat(scenes): declare publish window/interval config in manifest (holomush-yzt86)`.
+
+---
+
+## Task 10: core-scenes — manifest-source config in `Init` AND tests; fix cfg-zero — INV-PC-7
+
+The manifest is the single config source for **both** production and tests (no
+hardcoded Go window default). Production: `Init` → `applyConfig`. Tests: a
+`newTestService` helper sources from the real manifest via the same `applyConfig`
+path. `DefaultSceneServiceConfig()` is removed; the ~12 test call sites migrate.
+
+**Files:**
+
+- Modify: `plugins/core-scenes/main.go` (`Init` ~`:155`; scheduler construction `:197-203`; add `applyConfig` + `schedInterval`)
+- Modify: `plugins/core-scenes/service.go` (`NewSceneServiceImpl` `:150` — drop the `cfg: DefaultSceneServiceConfig()` seed)
+- Modify: `plugins/core-scenes/publish_helpers.go` (`:114` — delete `DefaultSceneServiceConfig()`)
+- Create: `plugins/core-scenes/testhelpers_test.go` (`//go:embed plugin.yaml` + `manifestServiceConfig` + `newTestService`)
+- Migrate (`NewSceneServiceImpl(` → `newTestService(t, `): `service_test.go`, `publish_service_test.go`, `publish_snapshot_integration_test.go`, `service_publish_gate_test.go`, `service_public_archive_test.go`, `service_privacy_block_test.go`, `commands_test.go`, `commands_publish_test.go`, `commands_log_test.go`, `commands_emit_test.go`, `publish_scheduler_integration_test.go`
+- Modify: `plugins/core-scenes/publish_helpers_test.go` (remove `TestDefaultSceneServiceConfigMatchesSpecDefaults` — the pinned function is gone; manifest is the sole source)
+- Test: `plugins/core-scenes/main_test.go`
+
+- [ ] **Step 1: Write the failing test (INV-PC-7 regression lock)**
+
+In `plugins/core-scenes/main_test.go`:
+
+```go
+func TestInitAppliesManifestConfig(t *testing.T) {
+	p := &scenePlugin{service: &SceneServiceImpl{}}
+	cfg := &pluginv1.ServiceConfig{PluginConfig: map[string]string{
+		"vote_window": "168h", "cooloff_window": "30m", "scheduler_interval": "30s",
+	}}
+	require.NoError(t, p.applyConfig(cfg))
+	require.Equal(t, 168*time.Hour, p.service.cfg.DefaultVoteWindow)
+	require.Equal(t, 30*time.Minute, p.service.cfg.DefaultCoolOffWindow)
+	require.Equal(t, 30*time.Second, p.schedInterval)
+	// cfg-zero regression: never the zero value.
+	require.NotZero(t, p.service.cfg.DefaultVoteWindow)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestInitAppliesManifestConfig ./plugins/core-scenes/`
+Expected: FAIL — `applyConfig` / `schedInterval` undefined.
+
+- [ ] **Step 3: Add `applyConfig` and a scheduler-interval field**
+
+In `plugins/core-scenes/main.go`, add a `schedInterval time.Duration` field to `scenePlugin` and:
+
+```go
+type sceneConfig struct {
+	VoteWindow        time.Duration `mapstructure:"vote_window"`
+	CoolOffWindow     time.Duration `mapstructure:"cooloff_window"`
+	SchedulerInterval time.Duration `mapstructure:"scheduler_interval"`
+}
+
+// applyConfig decodes the host-delivered plugin_config and applies it to the
+// service config + scheduler interval. Defaults come from the manifest
+// (plugin.yaml config:), so the service cfg is never the zero value (fixes the
+// cfg-zero bug where main built &SceneServiceImpl{} with no defaults).
+func (p *scenePlugin) applyConfig(config *pluginv1.ServiceConfig) error {
+	sc, err := pluginsdk.DecodeConfig[sceneConfig](config)
+	if err != nil {
+		return oops.Code("SCENE_INIT_FAILED").Wrap(err)
+	}
+	p.service.cfg = SceneServiceConfig{
+		DefaultVoteWindow:    sc.VoteWindow,
+		DefaultCoolOffWindow: sc.CoolOffWindow,
+	}
+	p.schedInterval = sc.SchedulerInterval
+	return nil
+}
+```
+
+- [ ] **Step 4: Call it from `Init` and wire the scheduler interval**
+
+In `Init` (`main.go:155`), call `p.applyConfig(config)` early (after the nil-conn check), and change the scheduler construction (`:197-203`) to use the configured interval:
+
+```go
+	if err := p.applyConfig(config); err != nil {
+		return err
+	}
+	// ...
+	sched := &publishScheduler{
+		svc:      p.service,
+		store:    store,
+		interval: p.schedInterval, // from manifest config (was hardcoded 30s)
+		now:      time.Now,
+	}
+```
+
+- [ ] **Step 5: Add the manifest-sourced test helper (single config source for tests)**
+
+Create `plugins/core-scenes/testhelpers_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+//go:embed plugin.yaml
+var testManifestYAML []byte
+
+// manifestServiceConfig returns the ServiceConfig the host would deliver for
+// core-scenes with no override — sourced from the real manifest. Tests and
+// production thus share ONE config source (the manifest); there is no Go
+// window default to drift from it.
+func manifestServiceConfig(t *testing.T) *pluginv1.ServiceConfig {
+	t.Helper()
+	m, err := plugins.ParseManifest(testManifestYAML)
+	require.NoError(t, err)
+	merged, err := plugins.MergePluginConfig(m.Config, nil)
+	require.NoError(t, err)
+	return &pluginv1.ServiceConfig{PluginConfig: merged}
+}
+
+// newTestService builds a SceneServiceImpl whose config is applied the same way
+// production applies it (applyConfig over the manifest-sourced ServiceConfig).
+func newTestService(t *testing.T, store sceneStorer) *SceneServiceImpl {
+	t.Helper()
+	p := &scenePlugin{service: NewSceneServiceImpl(store)}
+	require.NoError(t, p.applyConfig(manifestServiceConfig(t)))
+	return p.service
+}
+```
+
+- [ ] **Step 6: Remove the Go default; migrate the test call sites**
+
+In `service.go` `NewSceneServiceImpl` (`:150`), drop the `cfg: DefaultSceneServiceConfig()` field — the constructor no longer seeds windows; `applyConfig` is the sole setter. In `publish_helpers.go`, delete `DefaultSceneServiceConfig()`. In `publish_helpers_test.go`, delete `TestDefaultSceneServiceConfigMatchesSpecDefaults` (the function it pins is gone; the manifest is the single source, so there is nothing to drift). Then migrate every `NewSceneServiceImpl(<store>)` call in the 11 listed test files to `newTestService(t, <store>)` (mechanical; test helper funcs that build a service gain a `t *testing.T` param; `&scenePlugin{service: NewSceneServiceImpl(store)}` → `&scenePlugin{service: newTestService(t, store)}`).
+
+Production (`main.go`) keeps `&SceneServiceImpl{}` in `main()` (the store is injected in `Init`); `applyConfig` (Step 4) sets `cfg` from the manifest. So both prod and tests derive config from the manifest — consistency without forcing the constructor through a store it doesn't have at `main()` time.
+
+- [ ] **Step 7: Run tests**
+
+Run: `task test -- ./plugins/core-scenes/`
+Expected: PASS — the migrated suite (services now manifest-sourced) plus the new `TestInitAppliesManifestConfig`. No package references `DefaultSceneServiceConfig` any more.
+
+- [ ] **Step 8: Build + lint + commit**
+
+Run: `task build` then `task lint:go`. Commit: `fix(scenes): manifest-source publish config in Init + tests; fix cfg-zero, INV-PC-7 (holomush-yzt86)`.
+
+---
+
+## Task 11: Meta-tests — INV-PC-1 host opacity + INV-PC enumeration
+
+**Files:**
+
+- Create: `internal/plugin/config_opacity_test.go`
+- Create/Modify: `test/meta/plugin_config_invariants_test.go`
+
+- [ ] **Step 1: Write the host-opacity test (INV-PC-1)**
+
+In `internal/plugin/config_opacity_test.go`:
+
+```go
+// INV-PC-1: the host treats config opaquely — it MUST NOT contain literals of
+// any plugin's config keys (it understands only generic types). This pins the
+// boundary against a future host edit that special-cases a plugin key.
+func TestHostDoesNotReferencePluginConfigKeys(t *testing.T) {
+	bannedKeys := []string{"vote_window", "cooloff_window", "scheduler_interval"}
+	pkgs := []string{".", "setup", "goplugin", "hostfunc", "lua"} // internal/plugin/...
+	for _, pkg := range pkgs {
+		dir := filepath.Join(".", pkg)
+		matches := grepGoLiterals(t, dir, bannedKeys) // helper: rg-style scan of non-test .go
+		require.Empty(t, matches, "host pkg %s must not reference plugin config key literals: %v", pkg, matches)
+	}
+}
+```
+
+(Implement `grepGoLiterals` as a small filepath.Walk + token scan over non-`_test.go` files, or shell out to `rg`. Keep it test-local.)
+
+- [ ] **Step 2: Run test to verify it passes (it should already hold)**
+
+Run: `task test -- -run TestHostDoesNotReferencePluginConfigKeys ./internal/plugin/`
+Expected: PASS — no host code references those keys (they live only in `plugins/core-scenes/`).
+
+- [ ] **Step 3: Write the INV-PC enumeration meta-test**
+
+In `test/meta/plugin_config_invariants_test.go`:
+
+```go
+// TestPluginConfigInvariantsHaveTestCoverage asserts every INV-PC-N (spec §7)
+// is cited by at least one test in the tree.
+func TestPluginConfigInvariantsHaveTestCoverage(t *testing.T) {
+	want := []string{"INV-PC-1", "INV-PC-2", "INV-PC-3", "INV-PC-4",
+		"INV-PC-5", "INV-PC-6", "INV-PC-7", "INV-PC-8"}
+	cited := scanTreeForInvariantCitations(t, "INV-PC-") // walk *_test.go for the IDs
+	for _, id := range want {
+		require.Contains(t, cited, id, "no test cites %s", id)
+	}
+}
+```
+
+Ensure each test added in Tasks 3/6/10 cites its INV-PC ID in a comment or `t.Run` name (they do per the code above). Add an explicit INV-PC-3 unit test on `MergePluginConfig` output identity (the single merged map is what both delivery paths receive) so INV-PC-3 is cited.
+
+- [ ] **Step 4: Run the meta-test**
+
+Run: `task test -- -run TestPluginConfigInvariants ./test/meta/`
+Expected: PASS once all IDs are cited.
+
+- [ ] **Step 5: Commit**
+
+Message: `test(plugin): INV-PC-1 opacity + INV-PC enumeration meta-tests (holomush-yzt86)`.
+
+---
+
+## Task 12: Docs — plugin config for plugin authors
+
+**Files:**
+
+- Create: `site/docs/extending/plugin-config.md`
+- Modify: the `extending/` nav/index if one exists (follow the existing pattern)
+
+- [ ] **Step 1: Write the doc**
+
+Create `site/docs/extending/plugin-config.md` covering: the manifest `config:` schema (keys, the four types, `default`/`required`/`description`); the merge/precedence (`manifest default < server override`); generic-type validation + the three error codes; the Go `DecodeConfig[T]` helper with the `mapstructure:` struct-tag example; the Lua `holomush.config` accessors (`duration`/`int`/`bool`/`string`/`require_*`). Use a core-scenes example (`vote_window`/`cooloff_window`/`scheduler_interval`). Mirror the structure/tone of an existing `site/docs/extending/` page.
+
+- [ ] **Step 2: Build the docs site**
+
+Run: `task docs:build`
+Expected: builds without broken-link/lint errors.
+
+- [ ] **Step 3: Commit**
+
+Message: `docs(extending): plugin runtime config guide (holomush-yzt86)`.
+
+---
+
+## Final verification
+
+- [ ] Run `task test` — all unit tests pass.
+- [ ] Run `task test:int -- ./internal/plugin/...` — integration tests pass (Docker required).
+- [ ] Run `task lint` and `task fmt` — clean.
+- [ ] Confirm INV-PC-1..8 each have a citing test (`task test -- -run TestPluginConfigInvariants ./test/meta/`).
+- [ ] Confirm `go.mod` shows `go-viper/mapstructure/v2` as a direct dependency and `go mod tidy` is a no-op.
+<!-- adr-capture: sha256=26f468042a1331c5; ts=2026-05-27T13:28:09Z; adrs=holomush-7pdhf,holomush-ikozq -->

--- a/docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md
+++ b/docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md
@@ -1,0 +1,391 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Plugin Runtime Config: Manifest Schema + Opaque Host Passthrough
+
+**Status:** Draft v1 (2026-05-26)
+**Bead:** holomush-yzt86
+**Provenance:** Extracted from the holomush-shcyu (Phase 6 scene-publish E2E harness) brainstorm, 2026-05-26.
+
+## RFC2119 Keywords
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are
+to be interpreted as described in RFC2119.
+
+## 1. Overview
+
+HoloMUSH plugins have no way to carry **runtime behavior config** today. The
+manifest (`plugin.yaml`) declares `requires`/`provides`/`storage`/`crypto`/
+`actions`/`audit`, but nothing for tunable behavior (windows, intervals,
+limits). Plugins that need such values either hardcode them in Go or omit them.
+
+This spec adds a generic, reusable **plugin runtime config primitive**:
+
+1. A plugin declares a **typed config schema** in its manifest (`config:` — each
+   key has a type, optional default, required flag, and description).
+2. The host reads that schema **opaquely** (it understands generic types like
+   `duration`/`int`/`bool`, never what a key *means*), merges an optional
+   **server-provided override** per key (`manifest default < override`), and
+   delivers the merged values to the plugin at init.
+3. The plugin receives **typed** config via SDK helpers — `DecodeConfig[T]` for
+   binary plugins, `holomush.config` accessors for Lua — both deriving their
+   typing from the **same** manifest schema.
+
+The motivating consumer is **core-scenes** (Phase 6 scene-publish), which needs
+test-tunable vote/cool-off windows and a scheduler interval, and which today
+ships a latent bug because those values are zero in production (see §2.2).
+
+### 1.1 Why a host-opaque, plugin-owned model
+
+Plugin behavior config is the **plugin's** concern, not the core server's. The
+host provisions *resources* a plugin requests via its manifest (a Postgres
+schema for `storage: postgres`, host service addresses for `requires:`), but it
+MUST NOT understand the *semantics* of a plugin's behavior knobs. `vote_window`
+is "a duration the core-scenes plugin uses"; the host MUST NOT know it governs
+publish voting. This keeps the plugin boundary clean (`.claude/rules/
+plugin-boundary.md`) and lets plugins evolve their config without host changes.
+
+### 1.2 Why a schema (not a flat map)
+
+A typed schema in the manifest is the **single declaration** both plugin
+runtimes derive typing from. Without it, a binary plugin would type config via
+Go struct tags and a Lua plugin via accessor calls — two independent
+declarations of "`vote_window` is a duration defaulting to 168h" that can
+**drift**, a latent violation of the plugin-runtime-symmetry invariant
+(`.claude/rules/plugin-runtime-symmetry.md`). One manifest schema makes
+binary/Lua typing identical **by construction**. It also auto-documents the
+config surface for plugin authors and operators, and enables **load-time**
+fail-fast on a misauthored manifest.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- A plugin MUST be able to declare a typed config schema in its manifest.
+- The host MUST deliver merged config (manifest defaults overlaid by an optional
+  server-provided override) to the plugin at init, treating keys/values
+  opaquely with respect to plugin semantics.
+- Binary and Lua plugins MUST receive config with **identical merge and typing
+  semantics** (plugin-runtime-symmetry).
+- The SDK MUST provide typed config access for both runtimes (no hand-rolled
+  string parsing in plugin code).
+- core-scenes MUST adopt the primitive, moving its window/interval defaults out
+  of Go and into its manifest, fixing the cfg-zero bug (§2.2).
+- A test harness MUST be able to set the server-provided override (the seam
+  holomush-shcyu consumes for short windows/interval).
+
+### 2.2 Motivating bug (cfg-zero)
+
+`plugins/core-scenes/main.go:218` constructs the service with a raw struct
+literal `&SceneServiceImpl{}`. The 7d/30m window defaults are applied **only**
+in `NewSceneServiceImpl` (`service.go:150` → `DefaultSceneServiceConfig()`,
+`publish_helpers.go`), which `main.go` does not call, and there is no
+config seam anywhere in the package. So in production `s.cfg` is the zero value:
+`StartScenePublish` (`publish_service.go:206-207`) reads
+`DefaultVoteWindow == 0` and `DefaultCoolOffWindow == 0`, and every publish
+attempt times out / cools off on the first scheduler sweep (≤ 30s) instead of
+honoring the spec's 7-day/30-minute windows.
+
+This primitive fixes the bug as a side effect: config (including defaults) is
+loaded from the manifest on every init path, so the zero-value literal is no
+longer reachable.
+
+### 2.3 Non-Goals (deferred to other beads)
+
+- **shcyu harness driving** — the `integrationtest` `StartOption` that sets the
+  server-provided override, the `SceneService` client accessor, `Session.
+  CreateScene` wiring, and the Phase 6 E2E tests. These consume this primitive
+  and live in holomush-shcyu's separate spec.
+- **A host-provided clock/time service** plugins query instead of `time.Now`
+  ("true" injected plugin time). Deferred; a separate architecture bead only if
+  first-class plugin time-control proves necessary. See §10.
+- **A production config source** populating the server-provided override.
+  Production override is empty (manifest defaults apply); HoloMUSH is undeployed,
+  so no operator config surface is built yet.
+- **Enum / nested / list config types.** v1 supports scalar types
+  (`duration`, `int`, `bool`, `string`); richer types are a future extension.
+
+## 3. Manifest Config Schema
+
+A plugin MAY add a `config:` block to its manifest. Each entry declares one
+config key:
+
+```yaml
+config:
+  vote_window:
+    type: duration          # duration | int | bool | string
+    default: 168h           # optional; string form, parsed per type
+    required: true          # optional; default false
+    description: "How long a publish-vote attempt collects votes before timeout."
+  cooloff_window:
+    type: duration
+    default: 30m
+    description: "Delay between unanimous-yes resolution and PUBLISHED."
+  scheduler_interval:
+    type: duration
+    default: 30s
+    description: "How often the publish scheduler sweeps for expired attempts."
+```
+
+### 3.1 Schema field semantics
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `type` | yes | One of `duration`, `int`, `bool`, `string`. The host understands these **generic** types for structural validation only. |
+| `default` | no | Default value in string form (`"168h"`, `"3"`, `"true"`). Parsed per `type`. |
+| `required` | no (default `false`) | The effective value MUST resolve from `default` **or** override; load fails if neither is present. A `required` key WITH a `default` is therefore always satisfied by the default (the flag documents intent and guards against a future default removal); a `required` key WITHOUT a `default` MUST be supplied by an override or load fails (`PLUGIN_CONFIG_MISSING_REQUIRED`). |
+| `description` | SHOULD | Human-readable; drives auto-generated config docs (§8). |
+
+### 3.2 Go manifest type
+
+`internal/plugin/manifest.go` gains a `Config` field on the `Manifest` struct:
+
+```go
+// ConfigParam declares one plugin runtime config key. The host treats type/
+// default/required generically; it never interprets what the key controls.
+type ConfigParam struct {
+    Type        string `yaml:"type" json:"type"`               // duration|int|bool|string
+    Default     string `yaml:"default,omitempty" json:"default,omitempty"`
+    Required    bool   `yaml:"required,omitempty" json:"required,omitempty"`
+    Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
+// Config is the plugin's runtime config schema, keyed by config key. Opaque to
+// host semantics: the host validates generic types and merges values, but never
+// interprets a key's meaning.
+Config map[string]ConfigParam `yaml:"config,omitempty" json:"config,omitempty"`
+```
+
+`schemas/plugin.schema.json` MUST be regenerated (`go generate`) to include the
+`config` object and its `ConfigParam` shape, and the regenerated schema MUST be
+committed (a `go generate` side effect that fails `task lint`/schema checks if
+omitted).
+
+## 4. Host-Side Merge and Delivery
+
+```mermaid
+flowchart TB
+    MAN["manifest config: schema<br/>(types + defaults + required)"]
+    OV["server-provided override<br/>(PluginSubsystemConfig, per-plugin, opaque)<br/>empty in prod · set by harness in tests"]
+    MAN -->|defaults| MERGE
+    OV -->|per-key overlay| MERGE["host merge + generic-type validation<br/>effective = override[key] ?? default[key]<br/>validate parses to declared type · fail-fast on missing-required"]
+    MERGE -->|"binary: map<string,string> on ServiceConfig.plugin_config"| BIN["plugin Init → SDK DecodeConfig[T]"]
+    MERGE -->|"lua: holomush.config (merged values)"| LUA["Lua accessors convert per schema type"]
+    MERGE -->|setting| NA["N/A — bootstrap-only"]
+```
+
+### 4.1 Merge algorithm
+
+For each key `k` declared in the manifest `config:`:
+
+1. `effective[k] = override[k]` if the server-provided override contains `k`,
+   else `default[k]` if the manifest declares a default, else **absent**.
+2. If `k` is `required` and `effective[k]` is absent → the host MUST fail plugin
+   load with a structured error (`PLUGIN_CONFIG_MISSING_REQUIRED`,
+   key + plugin in context).
+3. If `effective[k]` is present, the host MUST validate it parses to the
+   declared generic `type` (e.g. `time.ParseDuration` for `duration`); a parse
+   failure MUST fail plugin load (`PLUGIN_CONFIG_TYPE_INVALID`).
+
+The host MUST NOT inspect or branch on a key's *meaning* — only its declared
+generic type. An override key not declared in the manifest schema MUST be
+rejected at load (`PLUGIN_CONFIG_UNKNOWN_KEY`, INV-PC-6) so typos fail fast
+rather than silently no-op.
+
+### 4.2 Server-provided override channel
+
+`PluginSubsystemConfig` (the production wiring struct, mirrored by the
+`integrationtest` harness at `internal/testsupport/integrationtest/plugins.go`)
+gains a per-plugin override:
+
+```go
+// PluginConfigOverrides maps plugin name → (config key → value). Opaque to the
+// host. Empty in production; the test harness populates it (e.g. short windows/
+// interval). Overrides MUST name a key declared in the target plugin's manifest
+// config schema (else PLUGIN_CONFIG_UNKNOWN_KEY at load).
+PluginConfigOverrides map[string]map[string]string
+```
+
+In production this is empty → manifest defaults apply. holomush-shcyu sets it for
+core-scenes in E2E.
+
+This mirrors the caller-supplied-field-with-nil-default pattern #4277
+(holomush-0f0f4.9) established for `pluginDeps.policyInstaller`
+(`internal/testsupport/integrationtest/plugins.go:185`, `:245-248`): the harness
+supplies the field; the allow-all/production path builds a default when it is
+absent. `PluginConfigOverrides` threads the same way (harness option →
+`pluginDeps` → `PluginSubsystemConfig`).
+
+### 4.3 Per-runtime delivery (symmetry)
+
+The host-side model is uniform (build `effective` per plugin); delivery adapts
+to each runtime's init path:
+
+- **Binary plugins.** `ServiceConfig` (`api/proto/holomush/plugin/v1/
+  plugin.proto:118`) gains `map<string,string> plugin_config = 3;` carrying the
+  merged values. The SDK exposes them to the plugin's `Init(ctx, config)`
+  (`pkg/plugin/service.go:50`, dispatched at `pkg/plugin/sdk.go:153→192`).
+  **The `needsInit` gate MUST be extended.** Today the host calls `Init` only
+  when a plugin declares `requires`/`provides`/`storage: postgres`/
+  `crypto.emits` (`internal/plugin/goplugin/host.go:595-598`); a plugin
+  declaring **only** `config:` would have `Init` skipped and silently receive
+  no config. The gate MUST add `len(manifest.Config) > 0` so any config-bearing
+  plugin is initialised (INV-PC-8). (core-scenes already trips the gate via
+  `storage: postgres`, but the primitive is generic.)
+- **Lua plugins.** Lua has no `Init` RPC; config rides the **per-delivery
+  hostfunc surface**. It MUST be exposed under `holomush.config` in
+  `hostfunc.Functions.Register` (`internal/plugin/hostfunc/functions.go:162`,
+  `ls.SetGlobal("holomush", mod)` at `:230`) — the same place every other
+  per-delivery `holomush.*` hostfunc is installed. **Not** in
+  `internal/plugin/lua/host.go` `Load` (`:201`): that `L.SetGlobal("holomush",
+  …)` runs in the INV-S5 capture pass's throwaway `LState` (`defer L.Close()`)
+  and is discarded after load. `Functions.Register` already receives the
+  plugin name and host context; it gains access to the merged config map.
+- **Setting plugins.** Bootstrap-only; no runtime config delivery (N/A).
+
+The merged value map the host builds per plugin is the single parity point:
+binary `plugin_config` and Lua `holomush.config` carry that same map — typing is
+not re-derived per runtime (INV-PC-3).
+
+## 5. SDK Surface
+
+### 5.1 Binary (Go) — typed decode
+
+The SDK adds a generic decode helper over the delivered `plugin_config` map,
+backed by `github.com/go-viper/mapstructure/v2`. The decode lifts
+`plugin_config` into a `map[string]any` and runs `mapstructure.NewDecoder` with
+`DecoderConfig{DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+WeaklyTypedInput: true, TagName: "mapstructure"}`, then `Decode`. mapstructure
+is already in the module graph as a koanf dependency, so this is a one-line
+promotion from indirect to direct via `go mod tidy` — no new module is
+introduced. (koanf itself is not used here: there is no file/provider layering,
+just a single in-memory map.):
+
+```go
+// DecodeConfig decodes the host-delivered plugin_config map into T using
+// mapstructure with a string→time.Duration hook. Unknown/extra keys and
+// type-mismatched values return a structured error. Defaults and required-key
+// enforcement are already applied host-side (§4.1); DecodeConfig is pure
+// string→typed conversion.
+func DecodeConfig[T any](config *pluginv1.ServiceConfig) (T, error)
+```
+
+Plugin usage (core-scenes):
+
+```go
+type sceneConfig struct {
+    VoteWindow        time.Duration `mapstructure:"vote_window"`
+    CoolOffWindow     time.Duration `mapstructure:"cooloff_window"`
+    SchedulerInterval time.Duration `mapstructure:"scheduler_interval"`
+}
+
+func (p *scenePlugin) Init(ctx context.Context, config *pluginv1.ServiceConfig) error {
+    cfg, err := pluginsdk.DecodeConfig[sceneConfig](config)
+    if err != nil {
+        return oops.Code("SCENE_INIT_FAILED").Wrap(err)
+    }
+    p.service.cfg = SceneServiceConfig{
+        DefaultVoteWindow:    cfg.VoteWindow,
+        DefaultCoolOffWindow: cfg.CoolOffWindow,
+    }
+    p.schedInterval = cfg.SchedulerInterval
+    // ...
+}
+```
+
+### 5.2 Lua — typed accessors
+
+The Lua `holomush.config` table MUST expose typed accessors mirroring the Go
+SDK, using the host's existing fail-loud Lua parsing discipline
+(`internal/plugin/lua/host.go:635`):
+
+```lua
+local vote_window = holomush.config.require_duration("vote_window")  -- errors if absent/unparseable
+local cooloff     = holomush.config.duration("cooloff_window")       -- nil if absent
+local interval    = holomush.config.duration("scheduler_interval")
+-- also: holomush.config.int(key), .bool(key), .string(key), .require_*(key)
+```
+
+Lua plugins MUST NOT hand-roll string→type conversion; the accessors are the
+sanctioned path, keeping conversion semantics identical to the binary SDK.
+
+## 6. core-scenes Adoption (first consumer)
+
+1. **Declare** `vote_window`/`cooloff_window`/`scheduler_interval` (all
+   `duration`, defaults `168h`/`30m`/`30s`) in `plugins/core-scenes/plugin.yaml`
+   `config:`.
+2. **Read** them in `Init` via `DecodeConfig[sceneConfig]` (§5.1); set
+   `p.service.cfg` and the scheduler interval from the decoded values.
+3. **Source config from the manifest in both production and tests** — one
+   source of truth, no hardcoded Go window values. Production: `Init` →
+   `applyConfig` decodes the host-delivered config. Tests: a `newTestService`
+   helper parses the core-scenes manifest (`//go:embed plugin.yaml`), merges with
+   no override, and applies it through the **same** `applyConfig` path, so tests
+   exercise the production config path against the manifest's real defaults.
+   `DefaultSceneServiceConfig()` is **removed** and `NewSceneServiceImpl` no
+   longer seeds `cfg`; the ~12 core-scenes test files that constructed services
+   via `NewSceneServiceImpl` migrate to `newTestService`. This keeps test and
+   prod as consistent as is reasonable — both derive config from the manifest,
+   not a divergent Go default — and removes the manifest/Go duplication entirely.
+4. **Wire** the scheduler interval from config rather than the literal
+   `interval: 30 * time.Second` at `main.go:200`.
+
+This closes the cfg-zero bug (§2.2): production reads `168h`/`30m`/`30s` from the
+manifest via `applyConfig`; the `&SceneServiceImpl{}` zero-value path no longer
+reaches `StartScenePublish`.
+
+## 7. Invariants
+
+| ID | Invariant | Test |
+| --- | --- | --- |
+| INV-PC-1 | The host MUST NOT interpret plugin config key *meaning* — only declared generic types. | Meta-test: host packages (`internal/plugin/`, `internal/plugin/setup/`) contain no plugin-config key literals (e.g. `"vote_window"`). |
+| INV-PC-2 | Effective config = manifest defaults overlaid by server override, per key; override wins. | Unit: merge with/without override; override replaces a defaulted key. |
+| INV-PC-3 | The host builds one merged value map per plugin; both binary (`plugin_config`) and Lua (`holomush.config`) delivery carry that same map — parity is enforced at the host-merge layer, not re-derived per runtime. | Unit: assert the host-merge output is the single map handed to both delivery paths (no per-runtime re-typing). Per-runtime decode (binary `DecodeConfig`, Lua accessors) is tested separately against that map — avoids needing a live dual-runtime fixture. |
+| INV-PC-4 | A `required` key absent from both manifest default and override → fail-fast at plugin load. | Unit: load with missing required → `PLUGIN_CONFIG_MISSING_REQUIRED`. |
+| INV-PC-5 | A value that does not parse to its declared type → fail-fast at load. | Unit: `vote_window: "banana"` (type duration) → `PLUGIN_CONFIG_TYPE_INVALID`. |
+| INV-PC-6 | An override key not declared in the manifest schema → fail-fast at load. | Unit: override unknown key → `PLUGIN_CONFIG_UNKNOWN_KEY`. |
+| INV-PC-7 | With no override (production), core-scenes resolves `vote_window=168h`, `cooloff_window=30m`, `scheduler_interval=30s` (cfg-zero regression lock). | Integration: load core-scenes with empty override; assert decoded config ≠ zero. |
+| INV-PC-8 | A binary plugin declaring `config:` MUST receive `Init` (and its `plugin_config`) even with none of `requires`/`provides`/`storage`/`crypto.emits` — the `needsInit` gate (`goplugin/host.go:595-598`) MUST include `len(manifest.Config) > 0`. | Unit: load a `config:`-only binary manifest → assert `Init` is invoked and the config is delivered (not silently skipped). |
+
+A meta-test `TestPluginConfigInvariantsHaveTestCoverage` MUST enumerate
+INV-PC-1..8 and assert ≥1 test cites each by ID.
+
+## 8. Documentation (PR-blocking)
+
+`site/docs/extending/` MUST gain a plugin-config section documenting: the
+manifest `config:` schema shape and types, the merge/precedence rules, the Go
+`DecodeConfig[T]` helper, and the Lua `holomush.config` accessors. A non-trivial
+plugin-system surface is not complete without author-facing docs.
+
+## 9. Testing Plan
+
+| Tier | Coverage |
+| --- | --- |
+| Unit | Merge algorithm (§4.1), type validation, error codes (INV-PC-2,4,5,6); `DecodeConfig[T]` conversion incl. duration hook; Lua accessor conversion + fail-loud. |
+| Integration | Binary plugin loaded via `PluginSubsystem` reads config from manifest + override (INV-PC-7); Lua plugin reads `holomush.config`; binary/Lua parity (INV-PC-3). |
+| Meta | INV-PC coverage enumeration; INV-PC-1 host-opacity grep. |
+
+Coverage target ≥ 85% for new files (`internal/plugin/` config code, SDK decode).
+
+## 10. Open Questions / Future
+
+- **Host clock/time service (deferred).** A host-provided clock plugins query
+  instead of `time.Now` would give first-class deterministic plugin time without
+  short-window tuning, but is cross-cutting (must honor plugin-runtime-symmetry
+  across all runtimes) and adds a per-read round-trip. Out of scope; file a
+  separate architecture bead only if needed.
+- **Richer config types** (enum, list, nested) — future extension; v1 is scalar
+  only.
+- **Production override source** — when HoloMUSH deploys, an operator config
+  surface may populate `PluginConfigOverrides`. Not built now (undeployed).
+
+## 11. Downstream
+
+holomush-shcyu (Phase 6 scene-publish E2E harness) depends on this primitive: it
+sets `PluginConfigOverrides["core-scenes"]` with short cool-off + scheduler
+interval to drive cool-off→PUBLISHED in bounded test time, then adds the
+`SceneService` client accessor, `Session.CreateScene` wiring, and the E2E specs
+(holomush-5rh.20.39–.43, .30).
+<!-- adr-capture: sha256=a00f88c98d0fe956; ts=2026-05-27T13:28:09Z; adrs=holomush-7pdhf,holomush-ikozq -->


### PR DESCRIPTION
## What

Design spec, implementation plan, and 2 ADRs for the **plugin runtime config primitive** (`holomush-yzt86`): a manifest-declared **typed config schema** delivered to plugins via an **opaque host passthrough**, with symmetric Go (`DecodeConfig[T]`) and Lua (`holomush.config`) decoding. First consumer is **core-scenes**, which fixes a live cfg-zero bug (publish-vote windows currently resolve to `0/0` in production instead of 7d/30m).

**Docs-only** — no code in this PR. Implementation lands in follow-up PRs from the materialized epic.

## Contents

- `docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md` — design spec (design-reviewer: **READY**)
- `docs/superpowers/plans/2026-05-27-plugin-runtime-config.md` — 12-task TDD plan (plan-reviewer: **READY**, round 3 precondition-gated)
- `docs/adr/holomush-7pdhf-plugin-config-opaque-host-passthrough.md` — ADR: config is plugin-owned via opaque host passthrough
- `docs/adr/holomush-ikozq-manifest-typed-config-schema-ssot.md` — ADR: manifest typed schema is the cross-runtime single source of truth

## Tracking

Epic `holomush-yzt86` + 12 task beads (`yzt86.1`–`.12`) materialized with the dependency DAG (`bd ready` → `.1` manifest field + `.4` proto field). `holomush-shcyu` (Phase 6 scene-publish E2E harness) depends on this primitive.

## Why docs-first

Landing the spec/plan/ADRs on `main` so implementer subagents read canonical context from `main` during subagent-driven execution. The primitive targets `main` directly (Phase 6 part-1 landed in #4279, resolving the dependency diamond).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
