### PR TITLE
ci(docs): give ci-docs-skip Lint real teeth via task pr-prep:docs (holomush-3zrvh)

### DIFF
--- a/.github/workflows/ci-docs-skip.yaml
+++ b/.github/workflows/ci-docs-skip.yaml
@@ -3,11 +3,16 @@
 
 name: CI
 
-# Same-name skip workflow for docs-only PRs. When ci.yaml is path-skipped,
-# branch-protection required checks (Build, Lint, Test) would otherwise stay
-# in 'Pending' state forever. This workflow provides no-op jobs whose names
-# are byte-identical to ci.yaml's required-check job names, so GitHub treats
-# them as the same required check and reports green.
+# Same-name companion workflow for docs-only PRs. When ci.yaml is path-skipped,
+# branch-protection required checks (Build, Lint, Test, Integration Test, E2E
+# Test) would otherwise stay 'Pending' forever. Job names here are byte-identical
+# to ci.yaml's required-check job names so GitHub treats them as the same check.
+#
+# Lint is NOT a no-op: it runs the real docs lint lane (task pr-prep:docs —
+# markdown, ADR, docs-symmetry, fmt, license, docs-paths-sync) so markdown/ADR
+# violations can no longer land on main unchecked (holomush-3zrvh — the gap that
+# let PR #4281's MD038 + missing-ADR-Rationale through). Test/Build/Integration/
+# E2E stay no-op stand-ins — docs changes don't exercise those.
 #
 # DOCS_ONLY_PATHS — must remain byte-identical with ci.yaml's paths-ignore
 # blocks and Taskfile.yaml's DOCS_ONLY_PATHS var. Enforced by
@@ -45,9 +50,40 @@ permissions:
 jobs:
   Lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # Real docs lint — mirrors ci.yaml's Lint setup (the same steps already run
+    # the full task lint + fmt:check + license:check there), then runs the docs
+    # subset via task pr-prep:docs. holomush-3zrvh.
+    runs-on: namespace-profile-linux-amd64-2x4
     steps:
-      - run: echo "docs-only PR — Lint skipped (no code changes)"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Docs lint reads the repo + public release/proxy downloads only; no
+          # git credentials needed post-checkout. Avoids persisting the token in
+          # .git/config (zizmor artipacked).
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go modules and build
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          cache: go
+
+      - name: Install Task
+        uses: ./.github/actions/install-task
+
+      - name: Install formatters
+        # ripgrep + rumdl + dprint — the doc-lint lane needs rumdl (markdown),
+        # dprint (fmt:check), and rg (lint:adr / lint:no-* scans inside task lint).
+        uses: ./.github/actions/install-formatters
+
+      - name: Lint docs
+        run: task pr-prep:docs
+
   Test:
     name: Test
     runs-on: ubuntu-latest

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -921,12 +921,14 @@ tasks:
       - echo "✓ All PR checks passed."
 
   pr-prep:docs:
-    desc: Docs-only fast lane (auto-selected by pr-prep on docs-only diffs).
+    desc: Docs-only fast lane (auto-selected by pr-prep on docs-only diffs; also run by ci-docs-skip.yaml's Lint job so docs
+      PRs are linted in CI — holomush-3zrvh).
     cmds:
       - echo "▸ Running docs-only fast lane"
       - task: lint:markdown
       - task: lint:yaml
       - task: lint:docs-symmetry
+      - task: lint:adr
       - task: fmt:check
       - task: license:check
       - task: lint:docs-paths-sync

--- a/site/docs/contributing/pr-prep.md
+++ b/site/docs/contributing/pr-prep.md
@@ -206,10 +206,16 @@ read-only jj command) before `task pr-prep` to force a snapshot.
 On the CI side, `.github/workflows/ci.yaml` has `paths-ignore` for the
 same glob list. A separate workflow `.github/workflows/ci-docs-skip.yaml`
 runs on the inverse path filter with workflow name `CI` and jobs named
-`Lint`, `Test`, `Build` (no-op `echo`s). GitHub's check-identity rule
-treats `(workflow_name, job_name)` as the same required check across
-files, so branch-protection required checks stay green on docs-only PRs
-without invoking the full pipeline.
+`Lint`, `Test`, `Build`, `Integration Test`, `E2E Test`. GitHub's
+check-identity rule treats `(workflow_name, job_name)` as the same required
+check across files, so branch-protection required checks stay green on
+docs-only PRs without invoking the full pipeline.
+
+The `Lint` job there is **not** a no-op: it runs the real docs lane
+(`task pr-prep:docs`) so markdown and ADR violations are caught on
+docs-only PRs instead of landing on `main` unchecked (holomush-3zrvh).
+`Test`, `Build`, `Integration Test`, and `E2E Test` remain no-op `echo`
+stand-ins — docs changes don't exercise those.
 
 If you ever edit `DOCS_ONLY_PATHS`, edit all three locations
 (Taskfile.yaml + ci.yaml + ci-docs-skip.yaml) and run


### PR DESCRIPTION
## Summary

Closes the gate gap found while landing #4282: `.github/workflows/ci-docs-skip.yaml`'s `Lint` job was a **no-op `echo`**, so docs-only PRs (which `ci.yaml` path-skips) ran **no lint at all**. Markdown and ADR violations landed on `main` unchecked — e.g. docs-only PR #4281 shipped an MD038 + two ADRs missing `## Rationale`, surfaced only when the next non-docs PR (#4282) ran the real whole-repo lint and failed.

## Fix (bead's preferred option a, reusing the canonical docs lane)

- **`ci-docs-skip.yaml`** — replace the no-op `Lint` job with a real one that mirrors `ci.yaml`'s Lint setup (`setup-go` + nscloud cache + `install-task` + `install-formatters`) and runs **`task pr-prep:docs`**. `Test`/`Build`/`Integration Test`/`E2E Test` stay no-op stand-ins — docs changes don't exercise those.
- **`Taskfile.yaml`** — add `lint:adr` to `pr-prep:docs`. It was missing, so ADR-structure violations slipped even the **local** docs gate (the second half of the gap). Now both local and CI docs lanes catch them.
- **`site/docs/contributing/pr-prep.md`** — the docs-skip `Lint` is no longer a no-op.

## Why this is guaranteed to work

Every step `pr-prep:docs` runs (`lint:markdown`, `lint:yaml`, `lint:docs-symmetry`, `lint:adr`, `fmt:check`, `license:check`, `lint:docs-paths-sync`) is already a member of `ci.yaml`'s real Lint job (`task lint` + `fmt:check` + `license:check`) on the **identical** runner profile with the **identical** setup steps. So `yq`, the adr-doctor prereqs, and the `license-eye` `go install` path are all proven-present — the new job inherits the same guarantee. `pr-prep:docs` is now the single source of truth driving both the local docs fast lane and the CI docs Lint, so they can't drift.

The bead's noted **rumdl version-skew bypass** is killed here too: `install-formatters` pins rumdl to CI's exact `v0.1.62`.

## Verification

- `task pr-prep:docs` passes end-to-end (incl. new `lint:adr`); verified under CI-pinned **rumdl v0.1.62** + dprint on both repo and `site/`.
- Full `task pr-prep` fast lane green; `lint:actions` / `lint:yaml` / `lint:docs-paths-sync` (INV-1 byte-identity) clean.
- `code-reviewer`: **READY**, no blocking findings.

**Note:** this PR is intentionally *mixed* (touches `site/docs/` plus the workflow/Taskfile) so `ci-docs-skip.yaml` fires alongside `ci.yaml` — that's how the new docs `Lint` job gets exercised in CI on its own PR (a pure-CI change wouldn't trigger the docs-skip workflow).

Closes holomush-3zrvh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)