### PR TITLE
fix(ci): point Deploy Site at rotated CLOUDFLARE_* secrets (holomush-rclq3)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -31,6 +31,6 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site/build --project-name=holomush-site


### PR DESCRIPTION
## Problem

The **Deploy Site** workflow has failed on every `main` push since **2026-04-27**, each time with Cloudflare:

```
A request to the Cloudflare API (/accounts/***/pages/projects/holomush-site) failed.
Authentication error [code: 10000]
```

(PR builds pass because the deploy step is gated to `github.ref == 'refs/heads/main'`.)

## Root cause

`site.yml` was the **only** workflow still referencing the old secret names `CF_API_TOKEN` / `CF_ACCOUNT_ID` (last touched 2026-04-24). Every other Cloudflare workflow (`bootstrap-sandbox.yaml`) uses the rotated `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` set, refreshed **2026-05-23**. The `CF_*` set was abandoned during a token rotation, leaving the site deploy pointed at a dead token.

Timeline:
- Last successful deploy: **2026-04-21**
- `CF_API_TOKEN` secret last updated: **2026-04-24**
- First failure (identical error): **2026-04-27** — constant since.

## Fix

Migrate `site.yml` to the canonical, rotated `CLOUDFLARE_*` secret names.

```diff
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
```

## Caveat (follow-up if needed)

This assumes `CLOUDFLARE_API_TOKEN` carries the **Account → Cloudflare Pages → Edit** scope. If the post-merge deploy still throws `code: 10000`, the workflow is correct but that scope must be added to the token in the Cloudflare dashboard.

## Verification

- `task lint:actions` (actionlint) clean
- `task pr-prep` fast lane green (workflow-only diff)

Closes holomush-rclq3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)