### PR TITLE
docs: SP1 docs-site migration to Astro Starlight — spec, plan, 3 ADRs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,9 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Adopt Astro Starlight as the docs site platform](holomush-145ko-adopt-astro-starlight-as-docs-site-platform.md) | 2026-05-27 | Accepted | `holomush-145ko` |
+| [Render Mermaid diagrams client-side via Starlight plugin](holomush-xneg2-render-mermaid-diagrams-client-side-via-starlight-plugin.md) | 2026-05-27 | Accepted | `holomush-xneg2` |
+| [Use bun as the docs-site package manager](holomush-qf2oo-use-bun-as-docs-site-package-manager.md) | 2026-05-27 | Accepted | `holomush-qf2oo` |
 | [integration/E2E are CI-authoritative-and-required, local-optional](holomush-5k6au-integration-e2e-are-ci-authoritative-and-required-local-opti.md) | 2026-05-26 | Accepted | `holomush-5k6au` |
 | [quarantine flaky specs via governed registry, not deletion](holomush-5eqiv-quarantine-flaky-specs-via-governed-registry-not-deletion.md) | 2026-05-26 | Accepted | `holomush-5eqiv` |
 | [Separate authorization (WHO) from business-state validity (WHEN) in scene policies](holomush-sqpnv-authz-who-vs-business-state-when-scene-policies.md) | 2026-05-25 | Accepted | `holomush-sqpnv` |

--- a/docs/adr/holomush-145ko-adopt-astro-starlight-as-docs-site-platform.md
+++ b/docs/adr/holomush-145ko-adopt-astro-starlight-as-docs-site-platform.md
@@ -1,0 +1,43 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-145ko; do not edit manually; use `/adr update holomush-145ko` -->
+
+# Adopt Astro Starlight as the docs site platform
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-145ko
+**Deciders:** Sean Brandt
+
+## Context
+
+The HoloMUSH docs site was built on zensical (Python/uv, MkDocs-style). It had accumulated nav drift (~20 markdown files orphaned from the hand-maintained `zensical.toml` nav, including the core `binary-plugins`/`lua-plugins` author guides), had no path to emit `llms.txt`, and was the lone Python/uv toolchain surface in an otherwise Node-toolchain repo (the SvelteKit web client uses Node/pnpm). A decision was needed: stay on zensical, migrate to a Node-based documentation framework, or build a custom solution.
+
+## Decision
+
+Adopt **Astro Starlight** as the documentation platform. SP1 executes a strict **lift-and-shift** (platform swap only — identical content, structure, and navigation; no information-architecture changes) so that follow-on sub-projects can leverage Starlight's `autogenerate` sidebar (SP2 Diátaxis re-bucketing) and the `starlight-llms-txt` plugin on a proven substrate.
+
+## Rationale
+
+- `llms.txt`/`llms-full.txt`/`llms-small.txt` are near-zero cost on Starlight (the maintained `starlight-llms-txt` plugin) and non-trivial custom work on any other platform.
+- Starlight's `autogenerate`-sidebar-from-directory structurally eliminates the nav-drift class of bug; this cannot be realized on zensical's hand-maintained nav.
+- Consolidating on the Node toolchain removes the lone Python/uv surface from CI and contributor environments.
+- Separating the platform swap (SP1) from the IA redesign (SP2) keeps each change diagnosable in isolation — re-platforming and re-architecting simultaneously is the migration anti-pattern that makes failures undiagnosable.
+
+## Alternatives Considered
+
+- **Stay on zensical** — no migration cost and no content-loss risk, but no llms.txt plugin exists, the hand-maintained nav is structurally unable to eliminate drift, and it keeps Python/uv as a toolchain island. Rejected.
+- **Custom SSG or another Node framework** — maximum control over output, but no maintained llms.txt plugin, no autogenerate sidebar, and high build cost with no ecosystem leverage. Rejected.
+- **Astro Starlight** — first-class autogenerate sidebar, drop-in llms.txt plugin, Node toolchain consistent with the web client, strong MDX support, Cloudflare Pages deploy unchanged. Migration cost (codemods for admonitions, content tabs, ~165 internal links) is one-time and bounded. Chosen.
+
+## Consequences
+
+**Positive:** nav drift becomes structurally preventable via autogenerate (SP2); `llms.txt`/`llms-full.txt`/`llms-small.txt` emitted from day one; single Node toolchain across web client and docs; Pagefind search replaces zensical's built-in with no extra config.
+
+**Negative:** one-time migration cost (frontmatter codemods, admonition rewrites, ~165 internal-link rewrites across ~45 files); `plugin-guide.md` is forced to `.mdx` (MDX strictness is a new failure mode for that file); URL slugs may change (accepted — no external link contracts).
+
+**Neutral:** the Cloudflare Pages project (`holomush-site`) and deploy target are unchanged; `rumdl` markdown lint continues unchanged, with `astro check` added for the single `.mdx` file.

--- a/docs/adr/holomush-qf2oo-use-bun-as-docs-site-package-manager.md
+++ b/docs/adr/holomush-qf2oo-use-bun-as-docs-site-package-manager.md
@@ -1,0 +1,42 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-qf2oo; do not edit manually; use `/adr update holomush-qf2oo` -->
+
+# Use bun as the docs-site package manager
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-qf2oo
+**Deciders:** Sean Brandt
+
+## Context
+
+The Astro Starlight migration (see `holomush-145ko`) requires selecting a Node package manager for the docs site. The repo's SvelteKit web client (`web/`) already standardizes on `pnpm@11.1.3`. The project has a stated package-manager preference order — bun → pnpm → npm — but no prior docs-site Node surface existed to enforce repo-wide consistency.
+
+## Decision
+
+Use **bun** as the docs-site package manager, with a mandatory **pnpm → npm fallback** if bun is unavailable in a given environment. The lockfile is `bun.lock`. The divergence from `web/`'s pnpm is a deliberate, documented trade-off; reviewers MAY override to pnpm for uniformity without losing a lockfile.
+
+## Rationale
+
+- The docs site is an independent build with no shared dependency graph with `web/`; single-package-manager uniformity therefore provides limited practical benefit.
+- The project's preference order (bun → pnpm → npm) is explicit; honoring it here is consistent with stated policy.
+- The divergence is recorded and bounded: pnpm is the named fallback, so the decision is reversible to the uniformity-matching option at review time.
+
+## Alternatives Considered
+
+- **bun** — matches the stated bun-first preference, faster installs, `oven-sh/setup-bun` available in CI. Adds a second JS package manager to the repo. Chosen.
+- **pnpm (matching `web/`)** — single package manager repo-wide; contributors already have it. But violates the stated preference, and the docs site shares no dependency graph with `web/`, so uniformity buys little. Rejected (named as the fallback).
+- **npm** — universal, no setup step, but slowest with no advantage over bun/pnpm. Rejected.
+
+## Consequences
+
+**Positive:** faster CI install step for docs builds; consistent with the stated project package-manager preference.
+
+**Negative:** two JS package managers coexist (bun for docs, pnpm for `web/`) — contributors must be aware of both; CI docs jobs must include an `oven-sh/setup-bun` step.
+
+**Neutral:** a reviewer may override to pnpm; the spec explicitly flags this trade-off for that purpose.

--- a/docs/adr/holomush-xneg2-render-mermaid-diagrams-client-side-via-starlight-plugin.md
+++ b/docs/adr/holomush-xneg2-render-mermaid-diagrams-client-side-via-starlight-plugin.md
@@ -1,0 +1,42 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-xneg2; do not edit manually; use `/adr update holomush-xneg2` -->
+
+# Render Mermaid diagrams client-side via Starlight plugin
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-xneg2
+**Deciders:** Sean Brandt
+
+## Context
+
+The HoloMUSH docs site migrates from zensical to Astro Starlight (SP1). Seven content pages use Mermaid fenced code blocks that must render on the new platform. Starlight ships `astro-expressive-code` as its built-in syntax highlighter, which intercepts the Astro/remark pipeline in a way that conflicts with build-time Mermaid renderers. CI build containers do not include a browser runtime.
+
+## Decision
+
+Render Mermaid diagrams **client-side** via the `@pasqal-io/starlight-client-mermaid` Starlight plugin, rather than any build-time renderer.
+
+## Rationale
+
+- Build-time renderers (`astro-mermaid`, `rehype-mermaid`) conflict with Starlight's `astro-expressive-code` syntax highlighter, breaking code-block highlighting site-wide.
+- `rehype-mermaid` additionally requires a headless Playwright browser in the CI build container, which is not available and would add significant image weight.
+- The client-side Starlight plugin is a first-class plugin-API integration that sidesteps the Astro pipeline entirely, so expressive-code highlighting is unaffected and no browser runtime is needed in CI.
+
+## Alternatives Considered
+
+- **`astro-mermaid` (build-time Astro integration)** — static SVG at build time, no runtime JS, but conflicts with `astro-expressive-code` and breaks all syntax-highlighted code blocks. Rejected.
+- **`rehype-mermaid` (build-time rehype plugin)** — well-maintained, hooks the rehype pipeline, but needs a Playwright browser in the CI build container and triggers the same expressive-code conflict. Rejected.
+- **`@pasqal-io/starlight-client-mermaid` (client-side Starlight plugin)** — avoids both constraints; single `bun add`; diagrams render in the browser at runtime. Chosen.
+
+## Consequences
+
+**Positive:** site-wide code-block syntax highlighting is unaffected; the CI build container needs no browser runtime; new Mermaid pages need no build-infrastructure change.
+
+**Negative:** Mermaid diagrams require JavaScript to render — invisible to JS-disabled clients and to static-HTML scrapers; rendering is deferred to page load rather than pre-built into HTML.
+
+**Neutral:** the seven affected pages (`operating/crypto-runbook.md` plus six `contributing/` files) keep standard fenced Mermaid blocks — no authoring changes required.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,7 @@ and machine-readable `llms.txt`.
 | SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | not yet filed |
 | SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | epic `holomush-cwnu0` (20 tasks); ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
 | SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | not yet filed |
+| SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |
 | SP4 | Complete gRPC service coverage (all 13 services, field-level) | not yet filed |
 
 **Why now:** the live site had drifted — ~20 docs orphaned from a hand-maintained

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,28 @@ sequencing.
 
 ## Active themes
 
+### `theme:docs-platform` — Docs site migration, IA, and gRPC reference
+
+A five-sub-project program to make the documentation site reflect reality and
+serve both humans and LLMs. The substrate is the doc platform itself; the uses
+are an accurate gRPC reference, a purpose-organized information architecture,
+and machine-readable `llms.txt`.
+
+| Sub-project | Scope | Tracking |
+| ----------- | ----- | -------- |
+| SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | not yet filed |
+| SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | epic `holomush-cwnu0` (20 tasks); ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
+| SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | not yet filed |
+| SP4 | Complete gRPC service coverage (all 13 services, field-level) | not yet filed |
+
+**Why now:** the live site had drifted — ~20 docs orphaned from a hand-maintained
+nav, a gRPC reference covering only 5 of 13 services with empty field
+descriptions, and no `llms.txt` path. SP1 swaps the platform (the prerequisite
+substrate) as a strict lift-and-shift so SP2/SP4 can land cleanly on it; SP0 runs
+in parallel since its source of truth is the `.proto` files. Sequencing rationale
+and the lift-and-shift discipline are in
+`docs/superpowers/specs/2026-05-27-docs-starlight-migration-design.md`.
+
 ### `theme:social-spaces` — Scenes, Channels, Forums, Discord
 
 The largest in-flight thread. Four product surfaces sharing one substrate:

--- a/docs/superpowers/plans/2026-05-27-docs-starlight-migration.md
+++ b/docs/superpowers/plans/2026-05-27-docs-starlight-migration.md
@@ -1,0 +1,744 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Docs Site Migration to Astro Starlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the HoloMUSH docs site from zensical (Python/uv) to Astro Starlight (Node/bun) as a strict lift-and-shift — identical content, structure, and navigation — and emit `llms.txt`.
+
+**Architecture:** Astro + `@astrojs/starlight` at `site/`, content as an Astro collection at `site/src/content/docs/`, built with bun, deployed to the same Cloudflare Pages project. The explicit sidebar reproduces today's `zensical.toml` nav 1:1 (no IA change). All three doc generators (`docs:proto`, `docs:gen-events`, `generate:ebnf`) are re-pointed at the new tree. Mermaid renders client-side via a Starlight plugin to avoid the build-time conflict with Starlight's syntax highlighter.
+
+**Tech Stack:** Astro 5, `@astrojs/starlight`, bun (pnpm/npm fallback), `starlight-llms-txt`, `@pasqal-io/starlight-client-mermaid`, Pagefind (built-in), Cloudflare Pages, `linkinator` (link check).
+
+**Spec:** `docs/superpowers/specs/2026-05-27-docs-starlight-migration-design.md`
+**ADRs:** `holomush-145ko` (adopt Astro Starlight), `holomush-qf2oo` (bun package manager), `holomush-xneg2` (client-side mermaid)
+
+---
+
+## File Structure
+
+Files created / modified, grouped by responsibility:
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `site/package.json` | Node project manifest (bun) — deps, scripts | Create |
+| `site/astro.config.mjs` | Astro+Starlight config: title, logo, social, palette, sidebar, plugins | Create |
+| `site/src/content.config.ts` | Astro content-collection definition (Starlight `docsLoader`/`docsSchema`) | Create |
+| `site/src/content/docs/**` | Migrated markdown content (moved from `site/docs/**`) | Move + transform |
+| `site/src/assets/**` | Logo, favicon, guide images | Move |
+| `site/public/reference/policy-dsl.ebnf`, `…-railroad.html` | Static (non-markdown) generated artifacts | New generator destination |
+| `site/src/styles/custom.css` | Brand palette (slate/deep-orange/amber) as Starlight CSS vars | Create |
+| `site/.gitignore` | Ignore `node_modules`, `dist`, `.astro` | Create |
+| `Taskfile.yaml` (`docs:*`, `docs:proto`, `docs:gen-events`, `generate:ebnf`) | Re-point build/setup/serve + generators | Modify |
+| `scripts/gen-event-docs.sh` | Event-doc generator output path + frontmatter | Modify |
+| `.github/workflows/site.yml` | bun setup + `astro build` + deploy `site/dist` | Modify |
+| `scripts/tests/license-eye.bats`, `generate-ebnf-check.bats`, `pr-prep-docs-detection.bats`, `docs-paths-regex.bats` | Re-path stale `site/docs/` references | Modify |
+| `site/zensical.toml`, `site/.python-version`, `site/pyproject.toml`/`uv.lock` | zensical/uv surface | Delete |
+| `scripts/check-docs-parity.sh` + `scripts/tests/docs-parity.bats` | Parity manifest + meta-test (INV-1/INV-5) | Create |
+
+> **Lifecycle reminder:** This plan runs in the `docs-starlight` jj workspace. Per the VCS preamble, commit with `jj commit -m "..."`/`jj describe`; never `jj new` before committing in-flight work. Run `task fmt:markdown` before each commit touching docs.
+>
+> **Codemod discipline:** The transform tasks (frontmatter, admonitions, links) are one-shot codemods over ~65 files. Each writes a small script under `scripts/migration/` (deleted in Task 19), runs it, and the verification is `astro build` + targeted `rg` checks. Do NOT hand-edit 65 files.
+
+---
+
+## Phase 1: Scaffold
+
+### Task 1: Scaffold Astro + Starlight at `site/` (alongside zensical)
+
+Bring up a buildable Starlight project in a temporary subdir, then move its scaffolding into `site/` next to the existing zensical files (which stay until Task 19). This keeps each commit buildable.
+
+**Files:**
+
+- Create: `site/package.json`, `site/astro.config.mjs`, `site/src/content.config.ts`, `site/.gitignore`, `site/tsconfig.json`
+- Create: `site/src/content/docs/index.md` (temporary placeholder; replaced in Task 3)
+
+- [ ] **Step 1: Scaffold into a scratch dir**
+
+Run (from repo root):
+
+```bash
+cd /tmp && rm -rf hm-starlight && bun create astro@latest hm-starlight -- --template starlight --no-install --no-git --yes
+```
+
+Expected: `/tmp/hm-starlight/` with `astro.config.mjs`, `package.json`, `src/content.config.ts`, `src/content/docs/index.mdx`.
+
+- [ ] **Step 2: Copy scaffold files into `site/`**
+
+Copy `package.json`, `astro.config.mjs`, `src/content.config.ts`, `tsconfig.json`, and a `.gitignore` into `site/`. Add SPDX headers where the repo requires them (`*.mjs`, `*.ts` — see `task license:check`). Do not copy the scratch `src/content/docs/` yet (Task 3 moves the real content).
+
+- [ ] **Step 3: Pin bun + install**
+
+Run:
+
+```bash
+cd site && bun install
+```
+
+Expected: `site/bun.lock` created, `site/node_modules/` populated. Commit `bun.lock`.
+
+- [ ] **Step 4: Add a placeholder home page and build**
+
+Create `site/src/content/docs/index.md`:
+
+```markdown
+---
+title: HoloMUSH
+description: Modern MUSH platform with Lua & Go plugins
+---
+
+Placeholder — replaced during content migration.
+```
+
+- [ ] **Step 5: Verify the scaffold builds**
+
+Run:
+
+```bash
+cd site && bunx astro build
+```
+
+Expected: build succeeds; `site/dist/index.html` exists.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "build(site): scaffold Astro Starlight alongside zensical (holomush-cwnu0)"`
+
+### Task 2: Base Starlight config (branding parity)
+
+**Files:**
+
+- Modify: `site/astro.config.mjs`
+- Create: `site/src/styles/custom.css`
+- Move: `site/docs/assets/logo.png`, `favicon.png` → `site/src/assets/` (copy now; the old paths are removed in Task 19)
+
+- [ ] **Step 1: Write `astro.config.mjs` base config**
+
+Reproduce the zensical metadata (`site/zensical.toml`: `site_name`, `site_description`, repo link, slate/deep-orange/amber palette):
+
+```javascript
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  site: 'https://holomush.dev',
+  integrations: [
+    starlight({
+      title: 'HoloMUSH',
+      description: 'Modern MUSH platform with Lua & Go plugins',
+      logo: { src: './src/assets/logo.png', alt: 'HoloMUSH' },
+      favicon: '/favicon.png',
+      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/holomush/holomush' }],
+      customCss: ['./src/styles/custom.css'],
+      // sidebar added in Task 12; plugins (mermaid, llms-txt) added in Tasks 8 & 13
+    }),
+  ],
+});
+```
+
+- [ ] **Step 2: Brand palette in `custom.css`**
+
+Map the zensical deep-orange/amber accents onto Starlight's CSS custom properties (`--sl-color-accent*`). Use the deep-orange hue family for `--sl-color-accent` and amber for hover. (Reference: Starlight "CSS & styling" — accent color tokens.)
+
+- [ ] **Step 3: Build and eyeball**
+
+Run: `cd site && bunx astro build` → PASS. Run `bunx astro dev` and confirm logo, title, and accent color render. (Manual visual check.)
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "build(site): base Starlight branding config (holomush-cwnu0)"`
+
+---
+
+## Phase 2: Content migration
+
+### Task 3: Move content tree into the collection
+
+**Files:**
+
+- Move: `site/docs/**/*.md` → `site/src/content/docs/**/*.md`
+- Move: `site/docs/guide/images/**`, `site/docs/assets/**` → `site/src/assets/**`
+- Delete: temporary `site/src/content/docs/index.md` from Task 1 (real `index.md` arrives in the move)
+
+- [ ] **Step 1: Move markdown**
+
+```bash
+mkdir -p site/src/content/docs
+git -C . mv site/docs/* site/src/content/docs/ 2>/dev/null || (cp -R site/docs/. site/src/content/docs/ && echo "copied")
+```
+
+Then relocate assets to `site/src/assets/` and fix in-page image paths in a later codemod (Task 7 handles links; images are covered there too).
+
+- [ ] **Step 2: Build (expect frontmatter errors)**
+
+Run: `cd site && bunx astro build`
+Expected: FAIL — pages without a `title` frontmatter error. This is expected and fixed in Task 4.
+
+- [ ] **Step 3: Commit the move (build-red is acceptable mid-phase)**
+
+`jj commit -m "refactor(site): move docs into Astro content collection (holomush-cwnu0)"`
+
+### Task 4: Frontmatter codemod (title from H1)
+
+**Files:**
+
+- Create: `scripts/migration/add-frontmatter.mjs`
+- Modify: all `site/src/content/docs/**/*.md`
+
+- [ ] **Step 1: Write the codemod**
+
+```javascript
+// scripts/migration/add-frontmatter.mjs — for each .md/.mdx under the docs
+// collection: if no YAML frontmatter, take the first `# H1` as title, remove
+// that H1 line, and prepend `---\ntitle: <h1>\n---`. Idempotent: skip files
+// that already start with `---`.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+const files = globSync('site/src/content/docs/**/*.{md,mdx}');
+for (const f of files) {
+  let s = readFileSync(f, 'utf8');
+  if (s.startsWith('---')) continue;
+  const m = s.match(/^#\s+(.+)$/m);
+  const title = (m ? m[1] : f.split('/').pop().replace(/\.mdx?$/, '')).replace(/"/g, '\\"');
+  if (m) s = s.replace(m[0] + '\n', '');
+  writeFileSync(f, `---\ntitle: "${title}"\n---\n\n${s.replace(/^\n+/, '')}`);
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun scripts/migration/add-frontmatter.mjs`
+
+> Run via **bun** (not `node` on a pre-22 runtime) — the codemod uses `fs.globSync`, which exists only in Node 22+ / Bun 1.x. Same applies to the Task 5/7 codemods.
+
+- [ ] **Step 3: Build**
+
+Run: `cd site && bunx astro build`
+Expected: PASS (or remaining failures are admonition/tab/link issues handled in Tasks 5-7, not frontmatter). Confirm `rg -L '^---' site/src/content/docs -g '*.md' -g '*.mdx'` returns nothing missing frontmatter (every file starts with `---`).
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "refactor(site): add Starlight title frontmatter to all pages (holomush-cwnu0)"`
+
+### Task 5: Admonitions → Starlight asides
+
+**Files:**
+
+- Create: `scripts/migration/admonitions.mjs`
+- Modify: the 5 files containing `!!!`/`???` (`operating/authentication.md`, `operating/configuration.md`, `index.md`, `guide/building.md`, `extending/plugin-guide.md` — verify with `rg -l '^\s*(!!!|\?\?\?)' site/src/content/docs`)
+
+- [ ] **Step 1: Write the codemod**
+
+Map MkDocs admonition syntax to Starlight asides. MkDocs:
+
+```text
+!!! note "Title"
+    body line
+```
+
+→ Starlight:
+
+```text
+:::note[Title]
+body line
+:::
+```
+
+Handle types `note|tip|info→note`, `warning|caution→caution`, `danger|error→danger`. Dedent the 4-space admonition body. Write `scripts/migration/admonitions.mjs` to transform all matches.
+
+- [ ] **Step 2: Run + build**
+
+Run: `bun scripts/migration/admonitions.mjs && cd site && bunx astro build`
+Expected: PASS for the admonition files. Verify `rg -c '^\s*!!!' site/src/content/docs` returns 0.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "refactor(site): convert MkDocs admonitions to Starlight asides (holomush-cwnu0)"`
+
+### Task 6: Content tabs → MDX (`plugin-guide`)
+
+**Files:**
+
+- Modify → rename: `site/src/content/docs/extending/plugin-guide.md` → `plugin-guide.mdx`
+
+- [ ] **Step 1: Convert the 10 `=== "Tab"` blocks**
+
+Rename the file to `.mdx`, add the import, and convert each pymdownx tab group:
+
+```mdx
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="Lua">…</TabItem>
+  <TabItem label="Go">…</TabItem>
+</Tabs>
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd site && bunx astro build`
+Expected: PASS. Verify no other file still uses `=== "`: `rg -l '^\s*=== "' site/src/content/docs` → empty.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "refactor(site): convert plugin-guide content tabs to MDX Tabs (holomush-cwnu0)"`
+
+### Task 7: Internal link + image path codemod
+
+**Files:**
+
+- Create: `scripts/migration/links.mjs`
+- Modify: the ~45 files containing `](…​.md)` links and any moved-image references
+
+- [ ] **Step 1: Write the codemod**
+
+Rewrite `](path/to/page.md)` and `](page.md#anchor)` to Starlight slug links: strip `.md`/`.mdx`, make root-relative under the docs base (e.g. `](../operating/configuration.md)` → `](/operating/configuration/)`). Resolve relative paths against the file's own location. Rewrite moved image refs (`assets/…`, `images/…`) to the new `~/assets/` or `/` static path. Leave external `http(s)://` links untouched.
+
+- [ ] **Step 2: Run + build**
+
+Run: `bun scripts/migration/links.mjs && cd site && bunx astro build`
+Expected: PASS. Spot-check: `rg -c '\]\([^)]*\.md[)#]' site/src/content/docs` → 0 internal `.md` links remain.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "refactor(site): rewrite internal links to Starlight slugs (holomush-cwnu0)"`
+
+### Task 8: Mermaid (client-side Starlight plugin)
+
+**Files:**
+
+- Modify: `site/astro.config.mjs`, `site/package.json`
+
+- [ ] **Step 1: Install the plugin**
+
+Run: `cd site && bun add @pasqal-io/starlight-client-mermaid`
+
+> **Why this one:** build-time renderers (`astro-mermaid`, `rehype-mermaid`) conflict with Starlight's `astro-expressive-code` syntax highlighter (breaks all code-block highlighting) and `rehype-mermaid` needs Playwright in the build container. The client-side Starlight plugin avoids both (grounded: spec § References; `holomush-cwnu0` mermaid grounding note).
+
+- [ ] **Step 2: Register it in the Starlight `plugins` array**
+
+```javascript
+import starlightClientMermaid from '@pasqal-io/starlight-client-mermaid';
+// inside starlight({ ... }):
+plugins: [starlightClientMermaid()],
+```
+
+- [ ] **Step 3: Build + verify code highlighting intact**
+
+Run: `cd site && bunx astro build` → PASS. In `bunx astro dev`, open one of the 7 mermaid pages (e.g. `/operating/crypto-runbook/`) and confirm the diagram renders AND a nearby fenced code block still has syntax highlighting (the expressive-code regression check).
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "build(site): client-side mermaid via Starlight plugin (holomush-cwnu0)"`
+
+---
+
+## Phase 3: Generators
+
+### Task 9: Re-point `docs:proto` into the collection
+
+**Files:**
+
+- Modify: `Taskfile.yaml` `docs:proto` (currently emits `site/docs/reference/grpc-api.md` at ~L1110-1127)
+
+- [ ] **Step 1: Change output path + add frontmatter**
+
+Point `--doc_opt`/output to `site/src/content/docs/reference/grpc-api.md`. Add a post-generation step (mirroring the existing `perl` link-fixup) that prepends Starlight frontmatter:
+
+```bash
+printf -- '---\ntitle: "gRPC API Reference"\n---\n\n%s' "$(cat site/src/content/docs/reference/grpc-api.md)" > site/src/content/docs/reference/grpc-api.md.tmp && mv site/src/content/docs/reference/grpc-api.md.tmp site/src/content/docs/reference/grpc-api.md
+```
+
+Update the task's `generates:` to the new path. Keep the proto input list unchanged (coverage is SP4).
+
+- [ ] **Step 2: Regenerate + build + reproducibility**
+
+Run: `task docs:proto && cd site && bunx astro build` → PASS. Run `task docs:proto` again, then `jj diff site/src/content/docs/reference/grpc-api.md` → empty (INV-4).
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "build(docs): emit gRPC reference into Starlight collection (holomush-cwnu0)"`
+
+### Task 10: Re-point `docs:gen-events`
+
+**Files:**
+
+- Modify: `Taskfile.yaml` `docs:gen-events` (L1086-1095) `generates:` paths
+- Modify: `scripts/gen-event-docs.sh` (output dir + per-file `title` frontmatter)
+
+- [ ] **Step 1: Update the script output path**
+
+In `scripts/gen-event-docs.sh`, change the output base from `site/docs/reference/events` to `site/src/content/docs/reference/events` and ensure each emitted `.md` (including `events.md`) begins with `---\ntitle: "<name>"\n---`.
+
+- [ ] **Step 2: Update the Taskfile `generates:` list**
+
+Point `docs:gen-events` `generates:` at `site/src/content/docs/reference/events/*.md` and `…/events.md`.
+
+- [ ] **Step 3: Regenerate + build + reproducibility**
+
+Run: `task docs:gen-events && cd site && bunx astro build` → PASS. Re-run and `jj diff` the events dir → empty (INV-4). Confirm `task docs:build` (which deps `docs:gen-events`) succeeds end-to-end.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "build(docs): emit event reference into Starlight collection (holomush-cwnu0)"`
+
+### Task 11: Re-point `generate:ebnf` to static assets
+
+**Files:**
+
+- Modify: `Taskfile.yaml` `generate:ebnf` + `generate:ebnf:check` (L~370-394)
+
+- [ ] **Step 1: Change EBNF/HTML output to `site/public/reference/`**
+
+The `.ebnf` and `.html` are not content pages — emit them to `site/public/reference/policy-dsl.ebnf` and `…-railroad.html` (served at `/reference/policy-dsl.ebnf`). Update `EBNF=`/`RAIL=` vars, the `sources:`/`generates:` lists, and the `generate:ebnf:check` paths.
+
+- [ ] **Step 2: Fix the link from `access-control.md`**
+
+The page that links the DSL artifacts (`reference/access-control.md`) must point at `/reference/policy-dsl.ebnf` and `/reference/policy-dsl-railroad.html` (root static paths). Update via Task 7's link codemod re-run or a targeted edit.
+
+- [ ] **Step 3: Regenerate + build + check**
+
+Run: `task generate:ebnf && task generate:ebnf:check && cd site && bunx astro build` → PASS. Confirm `site/dist/reference/policy-dsl.ebnf` exists in the build output.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "build(docs): emit policy-DSL EBNF/railroad as static assets (holomush-cwnu0)"`
+
+---
+
+## Phase 4: Navigation + llms.txt
+
+### Task 12: Explicit sidebar 1:1 from `zensical.toml`
+
+**Files:**
+
+- Modify: `site/astro.config.mjs` (add `sidebar`)
+
+- [ ] **Step 1: Translate the nav**
+
+Reproduce `site/zensical.toml`'s five sections and exact page order as a Starlight `sidebar` array. Each zensical entry `"operating/deployment.md"` becomes `{ slug: 'operating/deployment' }`. **Do not** use `autogenerate` (that surfaces orphans + superseded — deferred to SP2). Keep the same orphan-hidden set.
+
+```javascript
+sidebar: [
+  { label: 'Guide', items: [
+    { slug: 'guide' }, { slug: 'guide/the-world' }, { slug: 'guide/connecting' },
+    { slug: 'guide/commands' }, { slug: 'guide/building' },
+  ] },
+  { label: 'Operating', items: [
+    { slug: 'operating' }, { slug: 'operating/deployment' }, { slug: 'operating/installation' },
+    { slug: 'operating/configuration' }, { slug: 'operating/database' },
+    { slug: 'operating/authentication' }, { slug: 'operating/telnet-security' },
+    { slug: 'operating/ca-rotation' }, { slug: 'operating/crypto-setup' },
+    { slug: 'operating/operations' }, { slug: 'operating/sentry' },
+    { slug: 'operating/verifying-releases' },
+  ] },
+  { label: 'Extending', items: [
+    { slug: 'extending' }, { slug: 'extending/getting-started' },
+    { slug: 'extending/plugin-guide' }, { slug: 'extending/plugin-config' },
+    { slug: 'extending/access-control' }, { slug: 'extending/abac-attribute-resolver' },
+    { slug: 'extending/event-sensitivity' }, { slug: 'extending/plugin-crypto-readback' },
+    { slug: 'extending/api-guide' }, { slug: 'extending/events' },
+  ] },
+  { label: 'Contributing', items: [
+    { slug: 'contributing' }, { slug: 'contributing/architecture' },
+    { slug: 'contributing/coding-standards' }, { slug: 'contributing/authentication' },
+    { slug: 'contributing/database-migrations' }, { slug: 'contributing/event-store' },
+    { slug: 'contributing/event-delivery' }, { slug: 'contributing/event-emit-pipeline' },
+    { slug: 'contributing/hostfunc-context-audit' }, { slug: 'contributing/lifecycle-and-health' },
+    { slug: 'contributing/pr-guide' }, { slug: 'contributing/sessions' },
+  ] },
+  { label: 'Reference', items: [
+    { slug: 'reference' }, { slug: 'reference/access-control' },
+    { slug: 'reference/grpc-api' }, { slug: 'reference/events' },
+  ] },
+],
+```
+
+> This list mirrors `site/zensical.toml` (the five `[[project.nav]]` sections) exactly as of this workspace's `main`: **Guide 5, Operating 12, Extending 10, Contributing 12, Reference 4** entries. It includes the still-linked `contributing/event-delivery` (retirement is SP2). `extending/plugin-guide` keeps the `plugin-guide` slug even though the file becomes `.mdx` (slugs are extension-independent).
+>
+> **MANDATORY before committing:** re-read `site/zensical.toml` *in your working copy* (not a cached value) and diff the section entry-counts against the numbers above. The nav grows as features land — this exact list was already once stale by 4 pages. If the counts differ, reconcile before proceeding, or Task 18's parity check (INV-1) fails.
+
+- [ ] **Step 2: Build + parity eyeball**
+
+Run: `cd site && bunx astro build` → PASS. In `bunx astro dev`, confirm the sidebar shows the same five sections in the same order as the live zensical site, and that `index.md` (home) plus the orphans remain absent.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "build(site): explicit sidebar reproducing zensical nav 1:1 (holomush-cwnu0)"`
+
+### Task 13: `llms.txt` generation
+
+**Files:**
+
+- Modify: `site/astro.config.mjs`, `site/package.json`
+
+- [ ] **Step 1: Install + register**
+
+Run: `cd site && bun add starlight-llms-txt`. Add to the Starlight `plugins` array:
+
+```javascript
+import starlightLlmsTxt from 'starlight-llms-txt';
+// inside plugins: [ … , starlightLlmsTxt({ projectName: 'HoloMUSH' }) ]
+```
+
+- [ ] **Step 2: Build + verify outputs**
+
+Run: `cd site && bunx astro build`
+Expected: `site/dist/llms.txt`, `site/dist/llms-full.txt`, `site/dist/llms-small.txt` all exist and are non-empty (INV-6).
+
+```bash
+for f in llms.txt llms-full.txt llms-small.txt; do test -s "site/dist/$f" && echo "OK $f" || echo "MISSING $f"; done
+```
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "build(site): generate llms.txt via starlight-llms-txt (holomush-cwnu0)"`
+
+---
+
+## Phase 5: CI / tooling / lint
+
+### Task 14: Re-point Taskfile `docs:*`
+
+**Files:**
+
+- Modify: `Taskfile.yaml` `docs:setup` (L1080), `docs:build` (L1097), `docs:serve` (L1104)
+
+- [ ] **Step 1: Rewrite the three tasks**
+
+```yaml
+docs:setup:
+  desc: Set up documentation dev environment
+  dir: site
+  cmds:
+    - bun install   # fallback order bun → pnpm → npm per ADR holomush-qf2oo
+
+docs:build:
+  desc: Build documentation site
+  deps: ['docs:gen-events']
+  dir: site
+  cmds:
+    - bunx astro build
+
+docs:serve:
+  desc: Start documentation dev server
+  dir: site
+  cmds:
+    - bunx astro dev
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `task docs:setup && task docs:build`
+Expected: PASS; `site/dist/` populated (build deps `docs:gen-events`, which now writes into the collection).
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "build(docs): point Taskfile docs tasks at bun/astro (holomush-cwnu0)"`
+
+### Task 15: CI deploy workflow
+
+**Files:**
+
+- Modify: `.github/workflows/site.yml`
+
+- [ ] **Step 1: Replace uv/zensical with bun/astro**
+
+Swap the `Install uv` + `Build site` steps for bun setup + astro build, and deploy `site/dist`:
+
+```yaml
+      - name: Install bun
+        uses: oven-sh/setup-bun@<pinned-sha> # vN — verify latest on marketplace
+        with:
+          bun-version: latest
+      - name: Build site
+        working-directory: site
+        run: bun install --frozen-lockfile && bunx astro build
+      - name: Deploy to Cloudflare Pages
+        if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site/dist --project-name=holomush-site
+```
+
+> Pin `oven-sh/setup-bun` to a release SHA verified on the GitHub marketplace at implementation time (per the project's action-version rule). The workflow-file edit triggers the security hook — apply the verbatim retry, don't rewrite to appease it.
+
+- [ ] **Step 2: Verify locally what CI will run**
+
+Run: `cd site && bun install --frozen-lockfile && bunx astro build` → PASS.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "ci(site): build with bun/astro, deploy site/dist (holomush-cwnu0)"`
+
+### Task 16: bats path fixes + docs-skip verification
+
+**Files:**
+
+- Modify: `scripts/tests/license-eye.bats:35`, `scripts/tests/generate-ebnf-check.bats:19`, `scripts/tests/pr-prep-docs-detection.bats`, `scripts/tests/docs-paths-regex.bats`
+
+- [ ] **Step 1: Re-path `license-eye.bats`**
+
+Change `site/docs/guide site/docs/operating site/docs/reference` → `site/src/content/docs/guide site/src/content/docs/operating site/src/content/docs/reference`. (Without this the `rg` runs on nonexistent paths, exits 1, and the test passes spuriously — masking the check.)
+
+- [ ] **Step 2: Re-path `generate-ebnf-check.bats:19`**
+
+Update `EBNF=site/docs/reference/policy-dsl.ebnf` to the new static path `site/public/reference/policy-dsl.ebnf` (matching Task 11).
+
+- [ ] **Step 3: Refresh docs-detection example paths**
+
+In `pr-prep-docs-detection.bats` and `docs-paths-regex.bats`, change `site/docs/index.md` examples to `site/src/content/docs/index.md`. (`DOCS_ONLY_PATHS` is already `site/**` so detection still works; this only keeps the fixtures honest. Confirm with `task docs-paths-sync`.)
+
+- [ ] **Step 4: Run the bats suites**
+
+Run: `bats scripts/tests/license-eye.bats scripts/tests/generate-ebnf-check.bats scripts/tests/pr-prep-docs-detection.bats scripts/tests/docs-paths-regex.bats`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "test: re-path docs bats fixtures to content collection (holomush-cwnu0)"`
+
+### Task 17: rumdl flavor + link-check + mdx check
+
+**Files:**
+
+- Modify: `site/.rumdl.toml` (L8 `flavor`, L17 `MD046`)
+- Modify: `Taskfile.yaml` (add a `docs:linkcheck` task) and `.github/workflows/site.yml` (run it)
+
+- [ ] **Step 1: Resolve `flavor = "mkdocs"`**
+
+Starlight is not MkDocs. Change `flavor` to the rumdl default (or `commonmark`) and remove the `MD046` "for tabs" carve-out (tabs are now MDX). Run `task fmt:markdown` and fix any newly-surfaced violations in the migrated content.
+
+- [ ] **Step 2: Add a link checker (INV-2)**
+
+Add `docs:linkcheck` that builds then runs `linkinator` against `site/dist` (internal links only):
+
+```yaml
+docs:linkcheck:
+  dir: site
+  deps: ['docs:build']
+  cmds:
+    - bunx linkinator dist --recurse --silent
+```
+
+Add a CI step running `task docs:linkcheck`. (`astro check` is NOT a link checker — it only type-checks; add it separately for the `.mdx` file if desired.)
+
+- [ ] **Step 3: Verify**
+
+Run: `task docs:linkcheck`
+Expected: PASS, zero broken internal links (INV-2).
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "ci(docs): rumdl flavor fix + linkinator link check (holomush-cwnu0)"`
+
+---
+
+## Phase 6: Parity, decommission, invariants
+
+### Task 18: Parity manifest + meta-test (INV-1, INV-5)
+
+**Files:**
+
+- Create: `scripts/tests/fixtures/zensical-nav.txt`, `scripts/check-docs-parity.sh`, `scripts/tests/docs-parity.bats`
+
+- [ ] **Step 1: Capture the zensical nav as a fixture (before Task 19 deletes `zensical.toml`)**
+
+Extract every `"<path>.md"` entry from the five `[[project.nav]]` sections into a slug-per-line fixture:
+
+```bash
+mkdir -p scripts/tests/fixtures
+rg -o '"([a-z0-9/-]+)\.md"' -r '$1' site/zensical.toml > scripts/tests/fixtures/zensical-nav.txt
+wc -l scripts/tests/fixtures/zensical-nav.txt   # sanity: 43 entries (5+12+10+12+4)
+```
+
+This must run while `site/zensical.toml` still exists (this task precedes Task 19). Commit the fixture so the parity check survives decommission.
+
+- [ ] **Step 2: Write the parity check**
+
+`check-docs-parity.sh` reads `scripts/tests/fixtures/zensical-nav.txt` and asserts each slug has a corresponding built page under `site/dist/<slug>/index.html` (treating `<dir>/index` → `<dir>/index.html`). Also assert migrated page count == source markdown count under `site/src/content/docs` (INV-5).
+
+- [ ] **Step 3: Write the meta-test**
+
+`docs-parity.bats`: assert the fixture's entry count equals 43 (so the fixture can't silently shrink), then run `check-docs-parity.sh` and assert success.
+
+- [ ] **Step 4: Run**
+
+Run: `cd site && bunx astro build && bats scripts/tests/docs-parity.bats`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "test(docs): nav parity manifest + meta-test (holomush-cwnu0)"`
+
+### Task 19: Decommission zensical (INV-7)
+
+**Files:**
+
+- Delete: `site/zensical.toml`, `site/docs/` (old tree), `site/pyproject.toml`, `site/uv.lock`, `site/.python-version` (whichever exist), `scripts/migration/`
+- Modify: `.github/workflows/ci-docs-skip.yaml` if it names zensical-specific paths
+
+- [ ] **Step 1: Remove the zensical/uv surface + migration scripts**
+
+```bash
+git rm -r site/zensical.toml site/docs 2>/dev/null; rm -rf scripts/migration
+# remove site/pyproject.toml site/uv.lock site/.python-version if present
+```
+
+- [ ] **Step 2: Add the INV-7 guard**
+
+Add a CI/`pr-prep` `rg` guard asserting no `zensical` or `uv run` remains in `Taskfile.yaml`, `.github/workflows/`, or `site/` config:
+
+```bash
+! rg -n 'zensical|uv run' Taskfile.yaml .github/workflows site --glob '!site/dist/**' --glob '!**/node_modules/**'
+```
+
+- [ ] **Step 3: Full build from clean**
+
+Run: `rm -rf site/dist && task docs:build && task docs:linkcheck && bats scripts/tests/docs-parity.bats`
+Expected: all PASS with the old tree gone.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "build(site): decommission zensical/uv docs surface (holomush-cwnu0)"`
+
+### Task 20: Final invariant sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+task docs:build              # INV-3 build green (deps gen-events)
+task docs:proto && jj diff site/src/content/docs/reference/grpc-api.md   # INV-4 reproducible (empty)
+task docs:linkcheck          # INV-2 no broken links
+bats scripts/tests/docs-parity.bats        # INV-1 + INV-5
+for f in llms.txt llms-full.txt llms-small.txt; do test -s site/dist/$f; done   # INV-6
+rg -n 'zensical|uv run' Taskfile.yaml .github/workflows site --glob '!site/dist/**' --glob '!**/node_modules/**'   # INV-7 (expect 0)
+```
+
+Expected: every check passes / returns empty.
+
+- [ ] **Step 2: Run `task pr-prep`**
+
+Run: `task pr-prep` (docs-affecting; confirm it runs the right lane and is green).
+
+- [ ] **Step 3: Commit (if pr-prep produced regenerated artifacts)**
+
+`jj commit -m "build(site): finalize Starlight migration; all invariants green (holomush-cwnu0)"`
+
+---
+
+## Out of scope (follow-on sub-projects)
+
+- **SP2** — Diátaxis re-bucketing, flip sidebar to `autogenerate`, orphan triage + superseded retirement (`event-delivery.md`, `legacy-id-cutover.md`).
+- **SP0** — proto per-field doc comments + buf `COMMENTS` ratchet.
+- **SP4** — complete gRPC service coverage (migrate `docs:proto` to buf; all 13 services with field descriptions).
+<!-- adr-capture: sha256=642c0cc5552d09ea; session=2f5ef07e; ts=2026-05-27T20:08:58Z; adrs=holomush-xneg2 -->

--- a/docs/superpowers/specs/2026-05-27-docs-starlight-migration-design.md
+++ b/docs/superpowers/specs/2026-05-27-docs-starlight-migration-design.md
@@ -1,0 +1,312 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Docs Site Migration to Astro Starlight — Design (SP1)
+
+| Field            | Value                                                       |
+| ---------------- | ----------------------------------------------------------- |
+| Status           | Draft — pending `design-reviewer`                           |
+| Tracking bead    | `holomush-cwnu0`                                            |
+| Date             | 2026-05-27                                                  |
+| Sub-project      | SP1 of the docs-platform program (see [Program context](#program-context)) |
+| Supersedes       | the zensical-based site build (`site/zensical.toml`)        |
+
+## Summary
+
+Migrate the HoloMUSH documentation site from **zensical** (Python/uv,
+MkDocs-style) to **Astro Starlight** (Node), as a strict **lift-and-shift
+platform swap**: identical content, identical structure, identical navigation
+semantics — different engine. The cutover additionally lands `llms.txt`
+generation (a drop-in Starlight plugin) because it is near-zero-risk and
+additive.
+
+Information-architecture changes (Diátaxis), orphan triage, superseded-doc
+retirement, and per-field gRPC proto comments are **explicitly deferred** to
+follow-on sub-projects. The governing principle: re-platforming and
+re-architecting in the same change makes failures undiagnosable and reviews
+unreviewable. Change one variable at a time.
+
+## Program context
+
+This spec is one sub-project of a larger documentation program tracked under
+`holomush-cwnu0`. The full decomposition:
+
+```mermaid
+graph TD
+    SP0["SP0 · Proto contract docs<br/>per-field comments + buf COMMENTS ratchet<br/>PLATFORM-INDEPENDENT (parallel)"]
+    SP1["SP1 · Starlight migration + llms.txt<br/>THIS SPEC"]
+    SP2["SP2 · Diátaxis IA redesign<br/>re-bucket + autogenerate sidebar + triage"]
+    SP4["SP4 · gRPC reference completeness<br/>all 13 services, fully field-commented"]
+
+    SP1 --> SP2
+    SP0 --> SP4
+    SP1 --> SP4
+```
+
+- **SP0** (parallel, independent): author per-message/RPC/field doc comments
+  across all 14 protos, grounded in the Go handler implementations; enable
+  buf's `COMMENTS` lint category as a per-package ratchet; file beads for any
+  implementation mismatches found. The source of truth is the `.proto` files,
+  so this work is valuable under any doc platform.
+- **SP2** (gated on SP1): re-bucket content into Diátaxis quadrants
+  (tutorials / how-to / reference / explanation), flip the Starlight sidebar
+  from explicit to directory `autogenerate`, and perform orphan triage +
+  superseded-doc retirement (e.g. `contributing/event-delivery.md`,
+  `operating/legacy-id-cutover.md`) deliberately rather than in transit.
+- **SP4** (gated on SP0 + SP1): complete the generated gRPC reference so every
+  service renders with fully populated field descriptions.
+
+SP3 (llms.txt) was folded into SP1.
+
+## Motivation
+
+The current zensical site has accumulated structural debt that the platform
+makes hard to fix:
+
+- **Nav drift.** `site/zensical.toml` carries a hand-maintained explicit nav
+  that has drifted from disk: ~20 markdown files are orphaned from it
+  (built but unreachable), including core author guides
+  `extending/binary-plugins.md` (659 lines) and `extending/lua-plugins.md`.
+  Starlight's `autogenerate`-sidebar-from-directory feature eliminates this
+  class of bug structurally — but adopting it is an IA change (SP2), and it
+  first requires the platform (SP1).
+- **No llms.txt path.** There is no zensical mechanism for emitting
+  `llms.txt` / `llms-full.txt`; on Starlight it is a maintained plugin.
+- **Toolchain fragmentation.** The repo's web client already uses the Node
+  toolchain; the docs site is the lone Python/uv surface. Consolidating on
+  Node reduces the number of language runtimes contributors and CI must
+  carry.
+
+This spec does **not** itself fix nav drift or write new content — it moves the
+substrate so the follow-on sub-projects can.
+
+## Goals
+
+- **MUST** render every page currently reachable in the zensical nav on
+  Starlight at an equivalent slug, with no content loss.
+- **MUST** produce a green `astro build` and a successful Cloudflare Pages
+  deploy from the existing `holomush-site` project.
+- **MUST** convert all non-portable MkDocs/zensical markdown constructs to
+  their Starlight equivalents without losing rendered meaning.
+- **MUST** keep all three generated artifacts (`docs:proto` → `grpc-api.md`,
+  `docs:gen-events` → `events/`, `generate:ebnf` → policy-DSL EBNF/railroad)
+  rendering/serving, with reproducible generation.
+- **MUST** emit `llms.txt` and `llms-full.txt` in the build output.
+- **MUST** update all CI, task-runner, and lint touchpoints to the new paths
+  and toolchain, and remove the zensical/uv docs surface.
+
+## Non-goals
+
+- **MUST NOT** reorganize content taxonomy (no Diátaxis re-bucketing) — SP2.
+- **MUST NOT** switch the sidebar to `autogenerate` — SP2 (it would surface
+  orphans and superseded docs uncontrolled; see [Sidebar](#sidebar-explicit-11-port)).
+- **MUST NOT** retire, merge, or triage orphaned/superseded docs — SP2.
+- **MUST NOT** add per-field proto comments or complete missing gRPC services
+  — SP0 / SP4.
+- **MUST NOT** add a `_redirects` URL-compatibility map. URL slugs MAY change;
+  the site has no external consumers whose links must be preserved (consistent
+  with the project's "no prod-shape for undeployed surfaces" stance).
+
+## Architecture
+
+### Toolchain & layout
+
+```mermaid
+graph LR
+    subgraph before["Before (zensical)"]
+        Z1["site/docs/**/*.md"] --> Z2["uv run zensical build"]
+        Z2 --> Z3["site/build/"]
+        Z3 --> Z4["Cloudflare Pages<br/>holomush-site"]
+    end
+    subgraph after["After (Starlight)"]
+        A1["site/src/content/docs/**/*.md(x)"] --> A2["astro build"]
+        A2 --> A3["site/dist/"]
+        A3 --> A4["Cloudflare Pages<br/>holomush-site"]
+    end
+```
+
+| Concern        | Before (zensical)             | After (Starlight)                         |
+| -------------- | ----------------------------- | ----------------------------------------- |
+| Runtime        | Python / uv                   | Node                                      |
+| Package manager | uv (Python)                  | **bun** (preferred); pnpm → npm fallback  |
+| Framework      | zensical                      | Astro + `@astrojs/starlight`              |
+| Config         | `site/zensical.toml`          | `site/astro.config.mjs`                   |
+| Content root   | `site/docs/`                  | `site/src/content/docs/`                  |
+| Build output   | `site/build/`                 | `site/dist/`                              |
+| Build command  | `uv run zensical build`       | `bunx astro build` (via `task docs:build`) |
+| Search         | zensical built-in             | Pagefind (Starlight built-in)             |
+| Deploy target  | Cloudflare Pages `holomush-site` | unchanged                              |
+
+**Package-manager choice.** The docs site uses **bun** per the
+preference order bun → pnpm → npm; the implementation MUST fall back to pnpm,
+then npm, only if bun is unavailable in a given environment. Dependencies are
+locked with `bun.lock`. This is a deliberate, recorded divergence from the
+web client (`web/`), which standardizes on `pnpm@11.1.3`: the docs site is an
+independent build with no shared dependency graph, and the preference takes
+precedence over single-PM uniformity. CI installs bun via
+`oven-sh/setup-bun`. (If a reviewer judges repo-wide PM uniformity more
+valuable than the bun preference, pnpm is the fallback that also matches
+`web/` — flagged here so the tradeoff is explicit.)
+
+Starlight content lives in an Astro content collection at
+`site/src/content/docs/`. Audience subdirectories (`guide/`, `operating/`,
+`extending/`, `contributing/`, `reference/`) are preserved **unchanged** under
+that root.
+
+### Content migration
+
+Every `.md` file is moved `site/docs/<path>` → `site/src/content/docs/<path>`
+and adjusted:
+
+1. **Frontmatter.** Starlight requires a `title` in each page's frontmatter.
+   Derive it from the existing top-level H1; the H1 MAY then be removed
+   (Starlight renders the title as the page heading) to avoid a duplicate
+   heading. A codemod performs this; pages already carrying frontmatter are
+   merged, not overwritten.
+2. **Admonitions.** MkDocs `!!! note` / `??? warning` blocks (~8 across 5
+   files) convert to Starlight asides (`:::note`, `:::caution`, `:::tip`,
+   `:::danger`). Mapping table maintained in the implementation plan.
+3. **Content tabs.** `=== "Tab"` pymdownx tabs (10 occurrences, all in
+   `extending/plugin-guide.md`) convert to Starlight's MDX `<Tabs>` /
+   `<TabItem>`. This is the **only** file forced to `.mdx`; all others remain
+   `.md`.
+4. **Internal links.** ~165 `](path.md)`-style links across ~45 files rewrite to
+   Starlight slug links (extension-less, root-relative). A codemod performs the
+   rewrite; the link-check gate (INV-2) catches misses. (Counts are indicative,
+   not contractual — the codemod operates on all matches, and INV-2 is the
+   backstop.)
+5. **Mermaid.** 7 files use ` ```mermaid ` fences (`operating/crypto-runbook.md`,
+   `contributing/{architecture,authentication,index,integration-tests,event-delivery,lifecycle-and-health}.md`).
+   A Starlight-compatible mermaid rehype integration is added so they render
+   (zensical rendered these via its superfences equivalent; Starlight needs an
+   explicit integration). The integration MUST be verified against all 7, not a
+   subset.
+6. **Assets.** `site/docs/assets/` and `guide/images/` move under the content
+   collection (or `site/src/assets/` per Starlight asset conventions); image
+   references update accordingly.
+
+### Sidebar (explicit 1:1 port)
+
+The Starlight `sidebar` config in `astro.config.mjs` reproduces the
+`zensical.toml` nav **exactly**: same five top-level sections, same page order,
+same set of pages. Crucially, the 20 currently-orphaned files stay orphaned and
+the superseded `event-delivery.md` stays linked — **parity demands we change
+nothing about what is or isn't navigable.** SP2 is where the sidebar flips to
+`autogenerate` and orphans/superseded docs are resolved deliberately.
+
+> Rationale: turning on `autogenerate` here would silently surface 20 hidden
+> pages *and* known-stale pages in the same change as the engine swap,
+> entangling an IA decision with a platform decision. Deferring keeps SP1
+> diffable against the old site page-for-page.
+
+### Generated artifacts (three generators, not one)
+
+The reference section is **partly generated**, by three separate task pipelines
+that all write into the old content root. SP1 MUST re-point **all three**;
+missing any one breaks `task docs:build` or silently drops a page that
+[INV-1](#invariants) requires.
+
+| Generator                  | Source                          | Current output                                                                 | New destination |
+| -------------------------- | ------------------------------- | ------------------------------------------------------------------------------ | --------------- |
+| `docs:proto` (Taskfile:~1117) | `protoc` + `protoc-gen-doc`   | `site/docs/reference/grpc-api.md`                                              | `site/src/content/docs/reference/grpc-api.md` (+ `title` frontmatter) |
+| `docs:gen-events` (Taskfile:1086) — a **`dep` of `docs:build`** (Taskfile:1099) | `scripts/gen-event-docs.sh` from plugin manifests | `site/docs/reference/events/*.md` + `site/docs/reference/events.md` | `site/src/content/docs/reference/events/*.md` + `events.md` (+ `title` frontmatter) |
+| `generate:ebnf` (Taskfile:~370) — wired into `pr-prep` via `generate:ebnf:check` | policy-DSL grammar | `site/docs/reference/policy-dsl.ebnf` + `policy-dsl-railroad.html` (**non-markdown**) | `site/public/reference/` (Astro static assets, served at `/reference/...`) — these are downloadable/linked artifacts, not content-collection pages |
+
+Markdown generators (`docs:proto`, `docs:gen-events`) need a frontmatter-prepend
+step (a `title`) mirroring the existing well-known-type link-fixup `perl` step
+in `docs:proto`. The `.ebnf`/`.html` artifacts are **not** content pages —
+they go to Astro's `public/` directory so the links from
+`reference/access-control.md` continue to resolve. Each generator MUST remain
+reproducible (INV-4): regenerating yields no diff.
+
+For `docs:proto` specifically, the proto input set is **unchanged** from today
+(the existing file list) — completing service coverage and migrating generation
+to buf is SP4, not SP1. SP1 only guarantees the *current* generated output
+renders on the new engine.
+
+### llms.txt
+
+The `starlight-llms-txt` plugin is added to the Starlight config with
+`projectName: "HoloMUSH"`. It emits `llms.txt`, `llms-full.txt`, and
+`llms-small.txt` into the build output. Promote ordering MAY surface
+`guide/index.md` and the gRPC reference near the top; this is cosmetic and not
+an invariant beyond the files existing and being non-empty (INV-6).
+
+### CI / tooling / lint touchpoints
+
+| Touchpoint                          | Change                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `.github/workflows/site.yml`        | Replace `uv run zensical build` with `oven-sh/setup-bun` + `bunx astro build`; deploy `site/dist`. |
+| `.github/workflows/ci-docs-skip.yaml` | Docs-only detection globs — see `DOCS_ONLY_PATHS` note below.         |
+| `Taskfile.yaml` `docs:setup/build/serve` | `bun install` + `bunx astro` commands (pnpm/npm fallback); drop `uv sync`. |
+| `Taskfile.yaml` `docs:proto`        | Output path → content collection; add `title` frontmatter step.        |
+| `Taskfile.yaml` `docs:gen-events` (a `dep` of `docs:build`) | Output path → content collection; add `title` frontmatter step. **Missing this breaks `docs:build`.** See [Generated artifacts](#generated-artifacts-three-generators-not-one). |
+| `Taskfile.yaml` `generate:ebnf` / `generate:ebnf:check` | Output path → `site/public/reference/` (static assets). Update the `generates:` list and the `:check` paths. |
+| `scripts/tests/generate-ebnf-check.bats:19` | Re-path `EBNF=site/docs/reference/...` to the new static-asset path.  |
+| `scripts/tests/license-eye.bats:35` | Re-path `site/docs/guide site/docs/operating site/docs/reference` → new content root. **Currently passes spuriously post-move** (`rg` on a nonexistent path exits 1 = the test's "good" code), masking the check — must re-path, not just leave. |
+| `scripts/tests/pr-prep-docs-detection.bats`, `docs-paths-regex.bats` | Refresh stale `site/docs/index.md` example paths to `site/src/content/docs/...`. (They still match `site/**`, so non-breaking, but stale.) |
+| `lint:docs-symmetry` / `docs-paths-sync` | Update path expectations; `AGENTS.md`↔`CLAUDE.md` symlink unaffected. `docs-paths-sync` keeps `DOCS_ONLY_PATHS` byte-identical across `Taskfile.yaml`/`ci.yaml`/`ci-docs-skip.yaml` — any glob change MUST be applied to all three. |
+| `rumdl` (`site/.rumdl.toml`)        | Continues to lint `.md`. **Revisit `flavor = "mkdocs"` (line 8)** — Starlight is not MkDocs; the `MD046` carve-out "for tabs" (line 17) is moot once `plugin-guide.md` tabs become MDX. Decision: switch flavor or record why it stays. Add `astro check` (type/MDX validation) for the `.mdx` file — **not** as a link checker (see INV-2). |
+
+**`DOCS_ONLY_PATHS` is already correct** (`Taskfile.yaml:30` = `site/**`),
+so it covers `site/src/content/docs/**` with no change. The earlier-draft claim
+that it needed re-pathing was wrong. `ci-docs-skip.yaml` mirrors the same broad
+`site/**` glob and likewise needs no re-path — only the bats *example paths*
+above are stale.
+
+### Decommission zensical
+
+Once parity (INV-1..6) is green: remove `site/zensical.toml`, the Python/uv
+docs dependencies, and the old `site/docs/` tree. The `site/.rumdl.toml`
+remains (markdown lint is platform-independent).
+
+## Invariants
+
+All invariants are CI-enforceable and MUST have a test; INV-1 additionally has
+a meta-test asserting the parity manifest itself stays honest.
+
+| ID    | Invariant                                                                                      | Verification |
+| ----- | ---------------------------------------------------------------------------------------------- | ------------ |
+| INV-1 | Every page reachable in the zensical nav is reachable on Starlight at an equivalent slug.       | Parity manifest checked in CI; **meta-test**: manifest entry count equals migrated page count. (Manifest format — generated JSON vs checked-in fixture — defined at plan time.) |
+| INV-2 | Zero broken internal links after conversion.                                                    | A dedicated link checker (e.g. `linkinator`/`astro-broken-links`) in CI — **not** `astro check`, which only type-checks components/MDX and does not validate links. |
+| INV-3 | `astro build` succeeds and Cloudflare Pages preview deploys.                                     | `site.yml` build+deploy job. |
+| INV-4 | All three generators (`docs:proto`, `docs:gen-events`, `generate:ebnf`) emit into the new tree and regeneration yields no diff; their outputs build with no frontmatter/MDX error. | `task docs:proto` + `docs:gen-events` + `generate:ebnf` then `git diff --exit-code`; `astro build`. |
+| INV-5 | No content loss: migrated page count equals source page count (no unapproved drops).            | Count assertion in the migration check. |
+| INV-6 | `llms.txt`, `llms-full.txt`, and `llms-small.txt` exist and are non-empty in `site/dist/`.       | Post-build assertion (the plugin emits all three; assert all three so a regression in any is caught). |
+| INV-7 | No residual zensical/uv references remain in CI, Taskfile, or repo config after cutover.         | `rg` guard in CI (no `zensical`, no `uv run` in docs paths). |
+
+## Risks & mitigations
+
+| Risk                                                        | Mitigation                                                            |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| URL slugs change, breaking any external links               | Accepted (non-goal: no redirects). Site has no external link contracts. |
+| MDX strictness breaks on stray `<`/`{` in prose             | Only `plugin-guide.md` becomes `.mdx`; all others stay `.md` (lenient). |
+| docs-only-skip mechanism mis-paths and re-introduces the known lint-debt footgun | Re-path carefully; verify a docs-only PR still skips and a code PR still runs Lint. |
+| Mermaid integration renders differently than zensical       | Visual spot-check of the 7 mermaid pages in the preview deploy.       |
+| Cloudflare Pages build env lacks bun / a compatible Node version | Use `oven-sh/setup-bun` in `site.yml` and build there (or set the Pages build command to bun); pin the bun/Node version. |
+| Second JS package manager (bun for docs, pnpm for `web/`) adds toolchain surface | Accepted per the stated bun→pnpm→npm preference; documented divergence. Reviewer MAY override to pnpm for uniformity. |
+
+## Out of scope (follow-on sub-projects)
+
+- **SP2** — Diátaxis re-bucketing, `autogenerate` sidebar, orphan triage,
+  superseded retirement (`event-delivery.md` self-titled "Superseded";
+  `legacy-id-cutover.md` pending a completed-migration check).
+- **SP0** — proto per-message/RPC/field doc comments + buf `COMMENTS` ratchet.
+- **SP4** — complete gRPC service coverage (migrate `docs:proto` to buf;
+  all 13 public services rendered with field descriptions).
+
+## References
+
+- Current site config: `site/zensical.toml`; build/deploy: `.github/workflows/site.yml`.
+- Current doc-gen: `Taskfile.yaml` `docs:proto` (raw `protoc` + `protoc-gen-doc`).
+- Starlight sidebar / content collections / plugins:
+  context7 `/withastro/starlight` (autogenerate sidebar, MDX, plugin API).
+- llms.txt: `starlight-llms-txt` (delucis) — its docs site
+  (<https://delucis.github.io/starlight-llms-txt/>) confirms it "generates the
+  following files": `llms.txt`, `llms-full.txt`, `llms-small.txt` (grounds INV-6).
+- Diátaxis (SP2): <https://diataxis.fr> — four modes on two axes.
+- EventBus/JetStream context for the superseded `event-delivery.md`:
+  `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md`.
+<!-- adr-capture: sha256=c4fc65bf7c999baf; session=2f5ef07e; ts=2026-05-27T19:07:13Z; adrs=holomush-145ko,holomush-qf2oo -->


### PR DESCRIPTION
Planning artifacts for **SP1** of the `theme:docs-platform` program — migrating the documentation site from zensical (Python/uv) to **Astro Starlight** (Node/bun) as a strict lift-and-shift, plus `llms.txt` generation.

**Docs-only PR** (no code or site changes yet). Implementation is tracked as the 20-task epic `holomush-cwnu0`; this lands the spec/plan/ADRs on `main` so implementer subagents can read them.

## Contents
- **Spec:** `docs/superpowers/specs/2026-05-27-docs-starlight-migration-design.md` — `design-reviewer` READY (2 rounds)
- **Plan:** `docs/superpowers/plans/2026-05-27-docs-starlight-migration.md` — `plan-reviewer` READY (2 rounds), 20 tasks
- **ADRs:** `holomush-145ko` (adopt Astro Starlight), `holomush-qf2oo` (bun package manager), `holomush-xneg2` (client-side mermaid)
- **Roadmap:** new `theme:docs-platform` section framing SP0–SP4

## Scope discipline
SP1 is platform-swap only. Deferred: Diátaxis IA + orphan triage + superseded-doc retirement (SP2), proto per-field comments (SP0), full gRPC service coverage (SP4).

## Key decisions
- **bun** package manager (pnpm/npm fallback) — documented divergence from `web/`'s pnpm.
- **Client-side mermaid** via `@pasqal-io/starlight-client-mermaid` — build-time renderers conflict with Starlight's `astro-expressive-code` highlighter and `rehype-mermaid` needs Playwright in CI.
- All three doc generators (`docs:proto`, `docs:gen-events`, `generate:ebnf`) re-pointed; 7 invariants (parity meta-test, link-check, reproducible generation, llms.txt presence, no zensical residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)