### PR TITLE
docs(roadmap): file docs-platform program stubs + anchor

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,11 +35,13 @@ and machine-readable `llms.txt`.
 
 | Sub-project | Scope | Tracking |
 | ----------- | ----- | -------- |
-| SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | not yet filed |
+| SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | stub `holomush-ay6xm` (P4 backlog — not yet designed) |
 | SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | epic `holomush-cwnu0` (20 tasks); ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
-| SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | not yet filed |
+| SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | stub `holomush-44nxc` (P4 backlog — not yet designed) |
 | SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |
-| SP4 | Complete gRPC service coverage (all 13 services, field-level) | not yet filed |
+| SP4 | Complete gRPC service coverage (all 13 services, field-level) | stub `holomush-okm59` (P4 backlog — not yet designed) |
+
+**Program anchor:** decision bead `holomush-rkwyb` carries the SP0–SP4 framing and sequencing rationale; query the full program with `bd list -l theme:docs-platform`.
 
 **Why now:** the live site had drifted — ~20 docs orphaned from a hand-maintained
 nav, a gRPC reference covering only 5 of 13 services with empty field


### PR DESCRIPTION
Syncs the `docs/roadmap.md` `theme:docs-platform` section to the bd state materialized after PR #4286.

- SP0/SP2/SP4 rows: `not yet filed` → their backlog tracking stubs (`holomush-ay6xm`, `holomush-44nxc`, `holomush-okm59`, all P4, not yet designed).
- Adds the **program anchor** reference: decision bead `holomush-rkwyb` (carries SP0–SP4 framing + sequencing).

Keeps the roadmap current per CLAUDE.md "Strategic Themes". Docs-only; no code/site changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)