### PR TITLE
docs(plugin): plugin-crypto round-trip harness spec, plan, and ADR (holomush-5iaov)

### DIFF
--- a/docs/adr/holomush-35ej2-extract-cryptowiring.md
+++ b/docs/adr/holomush-35ej2-extract-cryptowiring.md
@@ -1,0 +1,142 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Extract Manifest-Derived Crypto Helpers to internal/plugin/cryptowiring
+
+**Date:** 2026-05-27
+**Status:** Accepted
+**Decision:** holomush-35ej2
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Four helpers in `cmd/holomush` (package `main`, therefore unimportable) derive
+plugin-crypto/audit wiring from the loaded plugin `Manager`:
+
+- `historyOwnersFromPlugins` (`sub_grpc.go:892-927`) — builds the `audit.OwnerMap`
+  that routes plugin-owned subjects, filtering on `PluginAuditClient` registration.
+- `buildAlwaysSensitiveSet` (`phase7_fence_wiring.go:66-89`) — the
+  `<plugin>:<event_type>` set the PluginDowngradeFence uses (INV-P7-7).
+- `newCryptoKeysLookup` (`phase7_fence_wiring.go:101-129`) — the
+  `history.CryptoKeysLookup` over the DB pool.
+- `buildKeySelector` (`phase7_fence_wiring.go:36`) — the single identity
+  `codec.KeySelector` threaded (pointer-identically, INV-P7-9) into the audit
+  consumer and the history reader.
+
+The `integrationtest` harness (`internal/testsupport/integrationtest`) needs
+these exact derivations to reproduce production crypto routing when completing
+the plugin-crypto round-trip (`holomush-5iaov`). Because they live in package
+`main`, the harness cannot import them — it must either reimplement them or the
+helpers must be extracted to a shared `internal/` package.
+
+A related constraint surfaced during design: there are **two** owner-map
+derivations from the same `Manager` — the read-side one above, and an audit-side
+one in `core.go:574-590` that additionally gates each owner-entry on `pcm.Add`
+success. They are **not** equivalent: the audit-side Add-gate is load-bearing —
+marking a subject owned while no consumer runs drops events from every audit sink
+(`core.go:561-564`).
+
+## Decision
+
+Extract the four **read-side** manifest-derivation helpers from `cmd/holomush`
+into a new shared package `internal/plugin/cryptowiring`, consumed by **both**
+`cmd/holomush` (production boot) and the `integrationtest` harness.
+
+The derivation functions take a narrow `ManifestSource` interface
+(`ListPlugins`, `AlwaysSensitiveEmitTypes`, `AuditSubjects`, `HasAuditClient`)
+rather than `*plugin.Manager` directly; `*plugin.Manager` satisfies it
+structurally via a thin `managerSource` adapter at each call site.
+
+The audit-side owner derivation in `core.go` (gated on `pcm.Add` success) is
+**intentionally NOT collapsed** into the shared `OwnerMapFromManager`. Only the
+read-side derivation is shared; the audit-side stays in place.
+
+## Rationale
+
+- **Single source of truth, compile-time enforced.** Extraction makes divergence
+  between the harness and production structurally impossible. Reimplementing the
+  derivations in the harness risks the worst kind of test — green in test,
+  divergent in prod — with no compile-time guard against drift.
+- **The two owner derivations are not equivalent.** Collapsing the read-side and
+  audit-side derivations would erase the audit-side `pcm.Add`-success gate, a
+  silent correctness regression (owned-but-no-running-consumer ⇒ dropped events).
+  So the extraction is deliberately narrowed to the read-side path.
+- **Narrow interface for testability.** `ManifestSource` decouples the derivation
+  logic from `*plugin.Manager`, so `cryptowiring` unit-tests with fakes (no loaded
+  Manager, no testcontainer) and documents the exact read surface the derivations
+  require. This is the consequence-level decision that makes the extraction's
+  testability goal reachable.
+- **Cycle-free placement.** Locating the package under `internal/plugin/` (not
+  `internal/eventbus/`) avoids any `eventbus → plugin` import cycle;
+  `internal/eventbus/audit` and `internal/eventbus/history` do not import
+  `internal/plugin`.
+- **Pointer-identity invariant stays enforceable.** Exporting the single
+  `KeySelector()` from one package keeps the INV-P7-9 "same instance in audit
+  consumer and history reader" invariant testable.
+
+## Alternatives Considered
+
+### Extract to `internal/plugin/cryptowiring` (chosen)
+
+Move the read-side derivations into a shared `internal/` package consumed by both
+production boot and the harness. **Strengths:** single source of truth; divergence
+between harness and prod is structurally impossible; also makes four previously
+unimportable `main`-package helpers independently testable. **Weaknesses:** requires
+a production refactor (revises the original "zero prod changes" framing); adds a
+package boundary that must stay cycle-free.
+
+### Reimplement the derivations locally in the harness (rejected)
+
+Re-derive owners / always-sensitive / lookup / keyselector inside the harness.
+**Strengths:** zero production changes; the harness stays self-contained.
+**Weaknesses:** recreates the exact failure mode the harness exists to prevent —
+green in test, divergent in prod — with no compile-time guard against drift. Any
+future change to the read-side derivation would have to be applied in two places.
+
+### Pass `*plugin.Manager` directly instead of a `ManifestSource` interface (rejected)
+
+Keep the concrete `*plugin.Manager` parameter the original helpers used.
+**Strengths:** no adapter; simpler call sites. **Weaknesses:** unit-testing the
+derivations would require a fully loaded `Manager` (integration-tier cost), defeating
+the extraction's testability goal and coupling the package to the concrete type. The
+narrow interface (satisfied structurally by `*plugin.Manager`) was chosen instead.
+
+### Collapse the read-side and audit-side owner derivations into one (rejected)
+
+Unify `historyOwnersFromPlugins` and the `core.go` audit-closure derivation.
+**Rejected** because they are not equivalent — the audit side gates each owner-entry
+on `pcm.Add` success, a load-bearing difference (owned-but-no-running-consumer drops
+events, `core.go:561-564`). Only the read-side derivation is shared; the audit-side
+stays in place (D2 narrowed).
+
+## Consequences
+
+**Positive**
+
+- One place to change manifest-to-crypto-routing derivation; updates propagate to
+  both production and the harness automatically.
+- `cryptowiring` is independently unit-testable with fake `ManifestSource`
+  implementations (target ≥90% coverage), with the DB-touching `CryptoKeysLookup`
+  query covered by an in-package integration test.
+- The `ManifestSource` interface is a stable, documented contract for the
+  derivations.
+
+**Negative**
+
+- Requires a production refactor — `cmd/holomush` call sites repointed, the four
+  helpers deleted — revising `holomush-5iaov`'s original "zero prod changes" framing.
+- A `managerSource` adapter must be maintained (in `cmd/holomush` and a harness
+  equivalent) to bridge `*plugin.Manager` to `ManifestSource`.
+
+**Neutral**
+
+- The audit-side owner derivation in `core.go` is intentionally untouched; the
+  read-side/audit-side `OwnerMap` asymmetry MUST be documented on the shared
+  `OwnerMapFromManager` function.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-27-harness-plugin-crypto-roundtrip-design.md` (§5, §1.2, D2)
+- Plan: `docs/superpowers/plans/2026-05-27-harness-plugin-crypto-roundtrip.md` (Tasks 1-4)
+- Epic: `holomush-5iaov`
+- Related: `holomush-edqh1` (two-gate plugin self-decrypt — read-back authz)

--- a/docs/superpowers/plans/2026-05-27-harness-plugin-crypto-roundtrip.md
+++ b/docs/superpowers/plans/2026-05-27-harness-plugin-crypto-roundtrip.md
@@ -1,0 +1,980 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Harness Plugin-Crypto Round-Trip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the full plugin-crypto round-trip (emit fence → publish encrypt → audit projection → read-back decrypt) into the `integrationtest` harness behind an opt-in `WithPluginCrypto()`, extracting prod's manifest-derivation helpers into a shared package so the harness reproduces prod crypto routing faithfully.
+
+**Architecture:** Phase 1 extracts four derivation helpers from `cmd/holomush` (package `main`, unimportable) into a new `internal/plugin/cryptowiring` package consumed by both prod and the harness — the derivations take narrow interfaces so they unit-test with fakes. Phase 2 adds `WithPluginCrypto()` and mirrors prod's `sub_grpc.go:343-484` crypto wiring against the embedded bus. Phase 3 proves the round-trip with a Ginkgo integration suite.
+
+**Tech Stack:** Go, gopher-lua/go-plugin host, NATS JetStream (embedded via `eventbustest`), Postgres testcontainer, `dek`/`kek`/`codec`/`audit`/`authguard` crypto packages, Ginkgo/Gomega.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-harness-plugin-crypto-roundtrip-design.md` (design-reviewer READY). Invariants INV-5IA-1..6 referenced per task.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Phase |
+|------|----------------|-------|
+| `internal/plugin/cryptowiring/cryptowiring.go` (Create) | `KeySelector`, `AlwaysSensitiveSet`, `CryptoKeysLookup`, `OwnerMapFromManager` + the narrow `ManifestSource` interface | 1 |
+| `internal/plugin/cryptowiring/cryptowiring_test.go` (Create) | Unit tests (fakes) for the derivations + nil-guards | 1 |
+| `internal/plugin/cryptowiring/cryptowiring_integration_test.go` (Create) | `//go:build integration` — `CryptoKeysLookup.Exists` against Postgres | 1 |
+| `cmd/holomush/phase7_fence_wiring.go` (Modify) | Remove moved helpers; repoint to `cryptowiring` | 1 |
+| `cmd/holomush/sub_grpc.go` (Modify) | Repoint `historyOwnersFromPlugins` / `buildAlwaysSensitiveSet` / `newCryptoKeysLookup` / `buildKeySelector` call sites | 1 |
+| `cmd/holomush/core.go` (Modify) | Repoint `buildKeySelector` call site only (audit-side owner derivation untouched) | 1 |
+| `internal/testsupport/integrationtest/crypto.go` (Create, `//go:build integration`) | `WithPluginCrypto()` + the 4-link wiring constructor | 2 |
+| `internal/testsupport/integrationtest/harness.go` (Modify) | Thread `withPluginCrypto` through `startConfig` + `Start` | 2 |
+| `internal/testsupport/integrationtest/plugins.go` (Modify) | Accept crypto deps in `startPlugins`; call `ConfigureEventEmitter` / `ConfigureReadbackDecryptor` | 2 |
+| `test/integration/plugincrypto/plugincrypto_suite_test.go` (Create) | Ginkgo suite bootstrap | 3 |
+| `test/integration/plugincrypto/roundtrip_test.go` (Create) | Positive + negative round-trip specs (INV-5IA-4/5/6) | 3 |
+
+---
+
+## Phase 1: Extract shared `cryptowiring` package
+
+### Task 1: Create `cryptowiring` package + move `KeySelector`
+
+**Files:**
+
+- Create: `internal/plugin/cryptowiring/cryptowiring.go`
+- Create: `internal/plugin/cryptowiring/cryptowiring_test.go`
+- Modify: `cmd/holomush/phase7_fence_wiring.go` (remove `buildKeySelector` + `identityProductionKeySelector`)
+- Modify: `cmd/holomush/core.go:523` and `cmd/holomush/sub_grpc.go` (repoint `buildKeySelector()` → `cryptowiring.KeySelector()`)
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/plugin/cryptowiring/cryptowiring_test.go`:
+
+```go
+package cryptowiring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+)
+
+func TestKeySelectorReturnsIdentityCodecForEncrypt(t *testing.T) {
+	sel := cryptowiring.KeySelector()
+	name, label, err := sel.SelectForEncrypt(context.Background(), "events.g1.scene.x.ic")
+	assert.NoError(t, err)
+	assert.Equal(t, codec.NameIdentity, name)
+	assert.Equal(t, codec.KeyLabel(""), label)
+}
+
+func TestKeySelectorReturnsNoKeyForDecrypt(t *testing.T) {
+	sel := cryptowiring.KeySelector()
+	key, err := sel.SelectForDecrypt(context.Background(), codec.NameIdentity, codec.KeyID(0))
+	assert.NoError(t, err)
+	assert.Equal(t, codec.NoKey, key)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/cryptowiring/`
+Expected: FAIL — package `cryptowiring` does not exist.
+
+- [ ] **Step 3: Create the package, move `buildKeySelector` + `identityProductionKeySelector` verbatim**
+
+`internal/plugin/cryptowiring/cryptowiring.go` (move the two declarations from `cmd/holomush/phase7_fence_wiring.go:36-55` verbatim; export `KeySelector`):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package cryptowiring holds the plugin-manifest-derived crypto/audit wiring
+// shared by production boot (cmd/holomush) and the integration harness
+// (internal/testsupport/integrationtest). Extracting these derivations keeps
+// the harness faithful to prod's exact ownership/sensitivity routing.
+package cryptowiring
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+// KeySelector returns the single identity codec.KeySelector instance threaded
+// into audit.PluginConsumerManager (WithKeySelector) and history.NewReader
+// (WithCodecSelector). INV-P7-9 requires SAME pointer-identity in both places.
+func KeySelector() codec.KeySelector { return &identityKeySelector{} }
+
+type identityKeySelector struct{}
+
+func (identityKeySelector) SelectForEncrypt(_ context.Context, _ string) (codec.Name, codec.KeyLabel, error) {
+	return codec.NameIdentity, "", nil
+}
+
+func (identityKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ codec.KeyID) (codec.Key, error) {
+	return codec.NoKey, nil
+}
+```
+
+- [ ] **Step 4: Repoint prod call sites + delete the moved declarations**
+
+In `cmd/holomush/phase7_fence_wiring.go` delete `buildKeySelector` (lines 36-38) and `identityProductionKeySelector` (lines 40-55). In `cmd/holomush/core.go:523` change `pluginCodecKeySelector := buildKeySelector()` → `pluginCodecKeySelector := cryptowiring.KeySelector()` and add the import `"github.com/holomush/holomush/internal/plugin/cryptowiring"`. Grep for any other `buildKeySelector()` caller: `rg -n "buildKeySelector\(" cmd/holomush/` and repoint each.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `task test -- ./internal/plugin/cryptowiring/` → Expected: PASS
+Run: `task build` → Expected: success (prod repointed cleanly)
+
+- [ ] **Step 6: Commit**
+
+`jj describe`/`jj commit` per `references/vcs-preamble.md`: `refactor(crypto): extract codec KeySelector to internal/plugin/cryptowiring (holomush-5iaov)`
+
+---
+
+### Task 2: Move `AlwaysSensitiveSet` (interface-based, unit-tested)
+
+**Files:**
+
+- Modify: `internal/plugin/cryptowiring/cryptowiring.go` (add `ManifestSource` + `AlwaysSensitiveSet`)
+- Modify: `internal/plugin/cryptowiring/cryptowiring_test.go`
+- Modify: `cmd/holomush/phase7_fence_wiring.go` (remove `buildAlwaysSensitiveSet` + `startsWith`)
+- Modify: `cmd/holomush/sub_grpc.go:377` (repoint)
+
+- [ ] **Step 1: Write the failing test (with a fake manifest source)**
+
+Append to `cryptowiring_test.go`:
+
+```go
+type fakeLoadedPlugin struct {
+	name        string
+	alwaysTypes []string // event types declared sensitivity:always
+}
+
+type fakeManifestSource struct{ plugins []fakeLoadedPlugin }
+
+func (f fakeManifestSource) ListPlugins() []string {
+	out := make([]string, len(f.plugins))
+	for i, p := range f.plugins {
+		out[i] = p.name
+	}
+	return out
+}
+
+func (f fakeManifestSource) AlwaysSensitiveEmitTypes(pluginName string) []string {
+	for _, p := range f.plugins {
+		if p.name == pluginName {
+			return p.alwaysTypes
+		}
+	}
+	return nil
+}
+
+func TestAlwaysSensitiveSetQualifiesUnqualifiedTypes(t *testing.T) {
+	src := fakeManifestSource{plugins: []fakeLoadedPlugin{
+		{name: "core-scenes", alwaysTypes: []string{"scene_pose", "core-scenes:scene_say"}},
+	}}
+	got := cryptowiring.AlwaysSensitiveSet(src)
+	assert.Equal(t, map[string]struct{}{
+		"core-scenes:scene_pose": {},
+		"core-scenes:scene_say":  {},
+	}, got)
+}
+
+func TestAlwaysSensitiveSetEmptyForNilSource(t *testing.T) {
+	assert.Empty(t, cryptowiring.AlwaysSensitiveSet(nil))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/cryptowiring/`
+Expected: FAIL — `cryptowiring.AlwaysSensitiveSet` and `ManifestSource` undefined.
+
+- [ ] **Step 3: Add the interface + function**
+
+> Design note: the current `buildAlwaysSensitiveSet` (`phase7_fence_wiring.go:66-89`) reaches into `mgr.ListPlugins()` + `mgr.GetLoadedPlugin(name).Manifest.Crypto.Emits`. To unit-test without a loaded `*plugin.Manager`, the extracted form takes a narrow `ManifestSource` interface that flattens "always-sensitive emit types per plugin" — `*plugin.Manager` satisfies it via a tiny adapter (Step 4). This keeps the derivation logic (prefix-qualification) unit-testable while prod passes the real manager.
+
+Add to `cryptowiring.go` (note `strings.HasPrefix` replaces the cmd-local `startsWith`):
+
+```go
+import "strings" // add to import block
+
+// ManifestSource is the narrow read surface the derivations need from a loaded
+// plugin set. *plugin.Manager satisfies the richer original API; the prod call
+// sites adapt it (see managerSource in cmd/holomush). Defined as an interface
+// so cryptowiring unit tests use fakes instead of a fully-loaded Manager.
+type ManifestSource interface {
+	ListPlugins() []string
+	// AlwaysSensitiveEmitTypes returns the crypto.emits[] event types declared
+	// sensitivity:always for pluginName (qualified or unqualified).
+	AlwaysSensitiveEmitTypes(pluginName string) []string
+}
+
+// AlwaysSensitiveSet produces the qualified `<plugin>:<event_type>` set the
+// PluginDowngradeFence uses for INV-P7-7. Returns a non-nil empty map when src
+// is nil. Mirrors buildAlwaysSensitiveSet (phase7_fence_wiring.go:66-89).
+func AlwaysSensitiveSet(src ManifestSource) map[string]struct{} {
+	out := map[string]struct{}{}
+	if src == nil {
+		return out
+	}
+	for _, name := range src.ListPlugins() {
+		prefix := name + ":"
+		for _, et := range src.AlwaysSensitiveEmitTypes(name) {
+			key := et
+			if !strings.HasPrefix(key, prefix) {
+				key = prefix + key
+			}
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Add the `*plugin.Manager` adapter + repoint prod**
+
+In `cmd/holomush` add a `managerSource` adapter (new small file `cmd/holomush/cryptowiring_adapter.go` or appended near the call site) implementing `cryptowiring.ManifestSource` over `*plugins.Manager` — `ListPlugins()` delegates; `AlwaysSensitiveEmitTypes(name)` reproduces the `GetLoadedPlugin(name).Manifest.Crypto.Emits` walk filtering `SensitivityAlways`:
+
+```go
+type managerSource struct{ mgr *plugins.Manager }
+
+func (s managerSource) ListPlugins() []string { return s.mgr.ListPlugins() }
+
+func (s managerSource) AlwaysSensitiveEmitTypes(name string) []string {
+	dp, ok := s.mgr.GetLoadedPlugin(name)
+	if !ok || dp.Manifest == nil || dp.Manifest.Crypto == nil {
+		return nil
+	}
+	var out []string
+	for _, emit := range dp.Manifest.Crypto.Emits {
+		if emit.Sensitivity == plugins.SensitivityAlways {
+			out = append(out, emit.EventType)
+		}
+	}
+	return out
+}
+```
+
+In `sub_grpc.go:377` change `alwaysSensitive := buildAlwaysSensitiveSet(pluginManager)` → `alwaysSensitive := cryptowiring.AlwaysSensitiveSet(managerSource{mgr: pluginManager})`. Delete `buildAlwaysSensitiveSet` + `startsWith` from `phase7_fence_wiring.go`.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `task test -- ./internal/plugin/cryptowiring/` → PASS
+Run: `task build` → success
+
+- [ ] **Step 6: Commit**
+
+`refactor(crypto): extract AlwaysSensitiveSet to cryptowiring (holomush-5iaov)`
+
+---
+
+### Task 3: Move `CryptoKeysLookup`
+
+**Files:**
+
+- Modify: `internal/plugin/cryptowiring/cryptowiring.go` (add `CryptoKeysLookup`)
+- Modify: `internal/plugin/cryptowiring/cryptowiring_test.go` (nil-guard unit test)
+- Create: `internal/plugin/cryptowiring/cryptowiring_integration_test.go` (Exists-query, `//go:build integration`)
+- Modify: `cmd/holomush/phase7_fence_wiring.go` (remove `newCryptoKeysLookup` + `cryptoKeysLookup`)
+- Modify: `cmd/holomush/sub_grpc.go:378` (repoint)
+
+- [ ] **Step 1: Write the failing unit test (nil-pool guard)**
+
+Append to `cryptowiring_test.go`:
+
+```go
+func TestCryptoKeysLookupNilPoolReturnsError(t *testing.T) {
+	lookup := cryptowiring.CryptoKeysLookup(nil)
+	_, err := lookup.Exists(context.Background(), 42)
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/cryptowiring/`
+Expected: FAIL — `cryptowiring.CryptoKeysLookup` undefined.
+
+- [ ] **Step 3: Move `newCryptoKeysLookup` + `cryptoKeysLookup` verbatim**
+
+Move from `phase7_fence_wiring.go:101-129` into `cryptowiring.go`, exporting the constructor as `CryptoKeysLookup`; body (the `crypto_keys WHERE id=$1 AND destroyed_at IS NULL` query + `pgx.ErrNoRows`→false + nil-pool guard) is unchanged. Add imports `pgx`, `pgxpool`, `oops`, `history`.
+
+```go
+// CryptoKeysLookup wraps the pool with the Exists query satisfying
+// history.CryptoKeysLookup. Filters destroyed_at IS NULL so destroyed DEKs read
+// as Exists=false (INV-P7-15). Moved verbatim from newCryptoKeysLookup.
+func CryptoKeysLookup(pool *pgxpool.Pool) history.CryptoKeysLookup {
+	return &cryptoKeysLookup{pool: pool}
+}
+// ... cryptoKeysLookup struct + Exists method moved verbatim ...
+```
+
+- [ ] **Step 4: Write the Exists-query integration test**
+
+`internal/plugin/cryptowiring/cryptowiring_integration_test.go`:
+
+```go
+//go:build integration
+
+package cryptowiring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+func TestCryptoKeysLookupExistsReportsAbsentDEKAsFalse(t *testing.T) {
+	ctx := context.Background()
+	connStr := testutil.FreshDatabase(t, testutil.SharedPostgres(t))
+	es, err := store.NewPostgresEventStore(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(es.Close)
+
+	lookup := cryptowiring.CryptoKeysLookup(es.Pool())
+	exists, err := lookup.Exists(ctx, 999999)
+	require.NoError(t, err)
+	assert.False(t, exists, "absent DEK id must read as Exists=false, not error")
+}
+```
+
+- [ ] **Step 5: Repoint prod + run**
+
+In `sub_grpc.go:378` change `cryptoKeysLookupForFence := newCryptoKeysLookup(pool)` → `cryptoKeysLookupForFence := cryptowiring.CryptoKeysLookup(pool)`. Delete the moved declarations from `phase7_fence_wiring.go`.
+
+Run: `task test -- ./internal/plugin/cryptowiring/` → PASS (unit)
+Run: `task test:int -- ./internal/plugin/cryptowiring/` → PASS (Exists query)
+Run: `task build` → success
+
+- [ ] **Step 6: Commit**
+
+`refactor(crypto): extract CryptoKeysLookup to cryptowiring (holomush-5iaov)`
+
+---
+
+### Task 4: Add `OwnerMapFromManager` (read-side derivation; D2 narrowed — no collapse)
+
+**Files:**
+
+- Modify: `internal/plugin/cryptowiring/cryptowiring.go` (add `OwnerMapFromManager` + extend `ManifestSource`)
+- Modify: `internal/plugin/cryptowiring/cryptowiring_test.go`
+- Modify: `cmd/holomush/sub_grpc.go:336,892-927` (repoint history owners to the shared fn; delete `historyOwnersFromPlugins`)
+- **DO NOT TOUCH** `cmd/holomush/core.go:574-590` — the audit-side derivation's `pcm.Add`-success gate is load-bearing (spec §1.2 / D2).
+
+- [ ] **Step 1: Write the failing test (fake) + read-side parity intent**
+
+Extend the `fakeManifestSource` with audit-subject + client-registration surface, then:
+
+```go
+func (f fakeManifestSource) AuditSubjects() []cryptowiring.AuditSubjectDecl {
+	var out []cryptowiring.AuditSubjectDecl
+	for _, p := range f.plugins {
+		for _, s := range p.auditSubjects {
+			out = append(out, cryptowiring.AuditSubjectDecl{PluginName: p.name, Subject: s})
+		}
+	}
+	return out
+}
+func (f fakeManifestSource) HasAuditClient(name string) bool {
+	for _, p := range f.plugins {
+		if p.name == name {
+			return p.hasClient
+		}
+	}
+	return false
+}
+
+func TestOwnerMapFromManagerOmitsPluginsWithoutRegisteredClient(t *testing.T) {
+	src := fakeManifestSource{plugins: []fakeLoadedPlugin{
+		{name: "core-scenes", auditSubjects: []string{"scene:*"}, hasClient: true},
+		{name: "ghost", auditSubjects: []string{"ghost:*"}, hasClient: false}, // no client → omitted
+	}}
+	om := cryptowiring.OwnerMapFromManager(src)
+	require.NotNil(t, om)
+	assert.Equal(t, "core-scenes", om.Resolve("scene:abc").PluginName)
+	assert.Empty(t, om.Resolve("ghost:abc").PluginName, "ghost has no client → not owned (host fallback)")
+}
+
+func TestOwnerMapFromManagerNilWhenNoOwners(t *testing.T) {
+	assert.Nil(t, cryptowiring.OwnerMapFromManager(fakeManifestSource{}))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./internal/plugin/cryptowiring/`
+Expected: FAIL — `OwnerMapFromManager` / `AuditSubjectDecl` undefined.
+
+- [ ] **Step 3: Add `OwnerMapFromManager` (port `historyOwnersFromPlugins` logic onto the interface)**
+
+```go
+import "github.com/holomush/holomush/internal/eventbus/audit"
+import "log/slog"
+
+// AuditSubjectDecl mirrors the (PluginName, Subject) pair the manager exposes
+// via AuditSubjects(); redeclared here so ManifestSource stays decoupled.
+type AuditSubjectDecl struct {
+	PluginName string
+	Subject    string
+}
+
+// Extend ManifestSource with the audit surface (Step 1 of Task 4):
+//   AuditSubjects() []AuditSubjectDecl
+//   HasAuditClient(pluginName string) bool
+
+// OwnerMapFromManager builds the read-side audit.OwnerMap: a subject is owned
+// iff its plugin has a registered PluginAuditService client. Returns nil when no
+// plugin qualifies (reader treats nil as "host owns everything"). This is the
+// READ-side derivation (ports historyOwnersFromPlugins, sub_grpc.go:892-927). It
+// is intentionally NOT shared with core.go's audit-side derivation, which adds a
+// load-bearing pcm.Add-success gate (spec §1.2).
+func OwnerMapFromManager(src ManifestSource) *audit.OwnerMap {
+	if src == nil {
+		return nil
+	}
+	decls := src.AuditSubjects()
+	owners := make([]audit.SubjectOwner, 0, len(decls))
+	for _, d := range decls {
+		if !src.HasAuditClient(d.PluginName) {
+			continue
+		}
+		owners = append(owners, audit.SubjectOwner{PluginName: d.PluginName, Pattern: d.Subject})
+	}
+	if len(owners) == 0 {
+		return nil
+	}
+	m, err := audit.NewOwnerMap(owners)
+	if err != nil {
+		slog.Error("cryptowiring: OwnerMap construction failed; plugin-owned subjects route via host fallback", "error", err)
+		return nil
+	}
+	return m
+}
+```
+
+- [ ] **Step 4: Extend `managerSource` adapter + repoint sub_grpc.go**
+
+Add to `managerSource` (cmd/holomush): `AuditSubjects()` maps `s.mgr.AuditSubjects()` → `[]cryptowiring.AuditSubjectDecl`; `HasAuditClient(name)` returns `_, ok := s.mgr.PluginAuditClient(name); ok`. In `sub_grpc.go:336` change `owners := historyOwnersFromPlugins(pluginManager)` → `owners := cryptowiring.OwnerMapFromManager(managerSource{mgr: pluginManager})`. Delete `historyOwnersFromPlugins` (sub_grpc.go:892-927).
+
+- [ ] **Step 5: Read-side parity check + run**
+
+Confirm no behavior change on the prod read path: `rg -n "historyOwnersFromPlugins" cmd/holomush/` returns no hits (fully repointed). The fake-based tests assert the same client-registration filter the deleted function used.
+
+Run: `task test -- ./internal/plugin/cryptowiring/` → PASS
+Run: `task test:int` (full, to catch history-reader integration breakage from the repoint) → PASS
+Run: `task build` → success
+
+- [ ] **Step 6: Commit**
+
+`refactor(crypto): extract read-side OwnerMapFromManager to cryptowiring (holomush-5iaov)`
+
+---
+
+## Phase 2: Harness `WithPluginCrypto` wiring
+
+### Task 5: Add `WithPluginCrypto()` option + panic-without-plugins guard (INV-5IA-1/2)
+
+**Files:**
+
+- Create: `internal/testsupport/integrationtest/crypto.go` (`//go:build integration`)
+- Modify: `internal/testsupport/integrationtest/harness.go` (`startConfig` field + Start guard)
+- Test: `internal/testsupport/integrationtest/crypto_test.go` (`//go:build integration`)
+
+- [ ] **Step 1: Write the failing test (INV-5IA-2 panic)**
+
+`internal/testsupport/integrationtest/crypto_test.go`:
+
+```go
+//go:build integration
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// INV-5IA-2: WithPluginCrypto without WithInTreePlugins must panic.
+func TestWithPluginCryptoWithoutPluginsPanics(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"integrationtest: WithPluginCrypto() requires WithInTreePlugins()",
+		func() { Start(t, WithPluginCrypto()) })
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- ./internal/testsupport/integrationtest/`
+Expected: FAIL — `WithPluginCrypto` undefined.
+
+- [ ] **Step 3: Add the option + startConfig field + guard**
+
+In `harness.go` `startConfig` (line ~145) add `withPluginCrypto bool`. In `crypto.go`:
+
+```go
+//go:build integration
+
+package integrationtest
+
+// WithPluginCrypto wires the full plugin-crypto round-trip (emit fence → publish
+// encrypt → audit projection → read-back) into the harness. REQUIRES
+// WithInTreePlugins (the emitter, per-plugin consumer, and read-back decryptor
+// all need the loaded Manager). Assumes crypto-CORRECT plugins: WithCryptoEnabled
+// is global to the shared emitter, so a loaded plugin that emits
+// sensitivity:always content without claiming Sensitive=true would reject (spec
+// §6.2). Drive only crypto-correct plugins (e.g. core-scenes) under this option.
+func WithPluginCrypto() StartOption {
+	return func(c *startConfig) { c.withPluginCrypto = true }
+}
+```
+
+In `harness.go` `Start`, after options are resolved (line ~243) add the guard:
+
+```go
+if cfg.withPluginCrypto && !cfg.withPlugins {
+	panic("integrationtest: WithPluginCrypto() requires WithInTreePlugins()")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test:int -- -run TestWithPluginCryptoWithoutPluginsPanics ./internal/testsupport/integrationtest/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+`feat(test): add WithPluginCrypto opt-in + plugins-required guard (holomush-5iaov)`
+
+---
+
+### Task 6: Write the round-trip Ginkgo suite (RED — drives the wiring)
+
+> TDD for integration substrate: author the target round-trip suite now. It will FAIL (links unwired) until Tasks 7-8 land. The suite defines the harness API the wiring must satisfy: `Server.EmitPluginEvent`, `Server.QueryPluginAuditRows`, `Server.ReadBackOwnRows`.
+
+**Files:**
+
+- Create: `test/integration/plugincrypto/plugincrypto_suite_test.go`
+- Create: `test/integration/plugincrypto/roundtrip_test.go`
+
+- [ ] **Step 1: Suite bootstrap**
+
+`plugincrypto_suite_test.go`:
+
+```go
+//go:build integration
+
+package plugincrypto_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPluginCrypto(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugin Crypto Round-Trip Suite")
+}
+```
+
+- [ ] **Step 2: Write the positive round-trip spec (INV-5IA-4/6) — expected RED**
+
+`roundtrip_test.go` (positive path; helper signatures defined here are implemented in Tasks 7-8):
+
+```go
+//go:build integration
+
+package plugincrypto_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+var _ = Describe("plugin crypto round-trip", func() {
+	var ts *integrationtest.Server
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		ts = integrationtest.Start(GinkgoT(), integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		DeferCleanup(ts.Stop)
+	})
+
+	It("encrypts sensitivity:always content on the wire and recovers plaintext via read-back", func() {
+		// 1. Emit a sensitivity:always core-scenes IC event (claims Sensitive=true).
+		emitted := ts.EmitPluginEvent(ctx, "core-scenes", "scene_pose", `{"text":"a secret pose"}`, true)
+
+		// INV-5IA-4: encrypted on the wire — non-identity codec + a DEK row.
+		Eventually(func() codec.Name { return ts.WireCodecFor(ctx, emitted.SubjectStr) }).
+			ShouldNot(Equal(codec.NameIdentity))
+		Expect(ts.DEKRowCount(ctx)).To(BeNumerically(">", 0))
+
+		// 2. Event projected to the plugin audit table (scene_log) as an encrypted row.
+		var rows []integrationtest.PluginAuditRow
+		Eventually(func() int {
+			rows = ts.QueryPluginAuditRows(ctx, "core-scenes", emitted.SubjectStr)
+			return len(rows)
+		}).Should(BeNumerically(">", 0))
+
+		// 3. Read-back via host decryptor → plaintext recovered (INV-5IA-6).
+		results := ts.ReadBackOwnRows(ctx, "core-scenes", rows)
+		Expect(results).To(HaveLen(len(rows)))
+		Expect(results[0].Plaintext).To(ContainSubstring("a secret pose"))
+		// INV-5IA-6: read-back audit fired.
+		Expect(ts.ReadBackAuditCount(ctx)).To(BeNumerically(">", 0))
+	})
+})
+```
+
+- [ ] **Step 3: Run to confirm RED (compiles against missing helpers)**
+
+Run: `task test:int -- ./test/integration/plugincrypto/`
+Expected: FAIL/compile-error — `ts.EmitPluginEvent` etc. undefined (these are implemented in Tasks 7-8). This RED state is the target the wiring must turn green.
+
+- [ ] **Step 4: Commit**
+
+`test(plugincrypto): add round-trip suite (red until wiring lands) (holomush-5iaov)`
+
+---
+
+### Task 7: Harness crypto substrate — KEK + DEK manager + crypto publisher (links 1-2)
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/crypto.go`
+- Modify: `internal/testsupport/integrationtest/harness.go` (construct substrate when `withPluginCrypto`; pass crypto publisher into the emitter wiring)
+- Modify: `internal/testsupport/integrationtest/plugins.go` (`startPlugins` accepts the crypto publisher + gameID; calls `ConfigureEventEmitter`)
+- Modify: `harness.go` Server struct (store `dekMgr`, `cryptoSelector`, helper fields)
+
+- [ ] **Step 1: Add the substrate constructor (mirror `holomushtest.newKEKProvider` + `dek.NewManager`)**
+
+In `crypto.go`:
+
+```go
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+	worldpg "github.com/holomush/holomush/internal/world/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+type pluginCrypto struct {
+	dekMgr   dek.Manager
+	selector codec.KeySelector
+	publisher eventbus.Publisher // crypto-enabled (DEK + identity selector), rendering-wrapped
+}
+
+// newPluginCrypto builds the test crypto substrate: ephemeral KEK → DEK manager
+// (pool-backed Store, so DEKs persist to crypto_keys) → a crypto-enabled
+// publisher over the embedded bus. Mirrors holomushtest.newKEKProvider
+// (server.go:492-505) + dek.NewManager (server.go:402-409).
+func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Pool, verbReg *core.VerbRegistry) *pluginCrypto {
+	t.Helper()
+	ctx := context.Background()
+
+	kekBytes := make([]byte, kek.KEKByteLength)
+	_, err := rand.Read(kekBytes)
+	require.NoError(t, err)
+	envName := "HOLOMUSH_TEST_KEK_PLUGINCRYPTO"
+	t.Setenv(envName, hex.EncodeToString(kekBytes))
+	provider, err := kek.NewLocalAEADProviderForUnitTest(ctx, kek.NewEnvSource(envName, false))
+	require.NoError(t, err, "newPluginCrypto: KEK provider")
+
+	cacheCfg := dek.CacheConfig{Capacity: 64, TTL: time.Minute}
+	dekMgr, err := dek.NewManager(
+		provider, dek.NewStore(pool),
+		dek.NewCache(cacheCfg), dek.NewParticipantsCache(cacheCfg),
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil }, // noopInv
+		worldpg.NewBindingRepository(pool),
+	)
+	require.NoError(t, err, "newPluginCrypto: dek.NewManager")
+
+	sel := cryptowiring.KeySelector()
+	raw := bus.Bus.Publisher(eventbus.WithDEKManager(dekMgr), eventbus.WithCodecSelector(sel))
+	return &pluginCrypto{
+		dekMgr:    dekMgr,
+		selector:  sel,
+		publisher: eventbus.NewRenderingPublisher(raw, verbReg),
+	}
+}
+```
+
+- [ ] **Step 2: Thread the crypto publisher into `startPlugins` → `ConfigureEventEmitter` (link 1)**
+
+In `plugins.go`, add `cryptoPublisher eventbus.Publisher` and `gameID string` to `pluginDeps`. After `ps.Start(ctx)` in `startPlugins` (line ~274), when `cryptoPublisher != nil`:
+
+```go
+if d.cryptoPublisher != nil {
+	ps.Manager().ConfigureEventEmitter(
+		d.cryptoPublisher,
+		// WithGameID takes a GameIDProvider (func() string), NOT a string
+		// (event_emitter.go:63-64) — wrap the captured gameID in a closure.
+		plugins.WithGameID(func() string { return d.gameID }),
+		plugins.WithCryptoEnabled(true), // link 1: scene_pose etc. → event.Sensitive=true
+	)
+}
+```
+
+In `harness.go` `Start`, when `cfg.withPluginCrypto`, construct `pc := newPluginCrypto(t, bus, pool, verbRegistry)` BEFORE `startPlugins` and pass `cryptoPublisher: pc.publisher, gameID: bus.Bus.GameID()` into `pluginDeps` (`pluginDeps.gameID` stays `string`; the closure above adapts it to `GameIDProvider`). Store `pc` on the `Server` for Tasks 8 + helpers (`Server.t *testing.T` already exists at `harness.go:101` for the `require.NoError(s.t, …)` calls in Task 8).
+
+- [ ] **Step 3: Add `EmitPluginEvent` + wire-codec/DEK helpers used by the suite**
+
+In `crypto.go`, add `Server` methods (panic via `requirePluginCrypto` if the option was absent):
+
+```go
+type EmittedEvent struct{ SubjectStr string }
+
+// EmitPluginEvent drives a real plugin emit through the Manager's
+// EmitPluginEvent boundary (the same path core-scenes commands use), returning
+// the NATS subject for wire assertions.
+func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payloadJSON string, sensitive bool) EmittedEvent {
+	s.requirePluginCrypto("EmitPluginEvent")
+	// ... call s.pluginSub.Manager().EmitPluginEvent(ctx, plugin, pluginsdk.EmitEvent{
+	//        Subject: plugin+":"+<entity>, Type: eventType, Payload: payloadJSON, Sensitive: sensitive})
+	// EmitPluginEvent returns ONLY error (manager.go:408) — the helper DERIVES the
+	// translated NATS subject from its inputs (subjectxlate.Legacy(plugin+":"+entity, gameID))
+	// and returns it in EmittedEvent.SubjectStr for the wire assertions.
+}
+
+// WireCodecFor reads the JetStream message header codec for the subject.
+func (s *Server) WireCodecFor(ctx context.Context, subject string) codec.Name { /* read via bus.JS */ }
+
+// DEKRowCount counts rows in crypto_keys.
+func (s *Server) DEKRowCount(ctx context.Context) int { /* SELECT count(*) FROM crypto_keys */ }
+```
+
+> Plan note: `EmitPluginEvent`'s exact `pluginsdk.EmitEvent` shape + `Manager.EmitPluginEvent` signature are grounded at `manager.go:424` / `manager_test.go:2001` — the implementer confirms via `mcp__probe__extract_code EmitPluginEvent` before filling the body.
+
+- [ ] **Step 4: Run — partial green (emit + wire-encryption assertions)**
+
+Run: `task test:int -- ./internal/testsupport/integrationtest/` → PASS (panic guard + any substrate unit assertions)
+Run: `task build` and `task test:int -- ./test/integration/plugincrypto/` → still RED on read-back helpers (Task 8), but the emit + `WireCodecFor` ShouldNot(identity) + `DEKRowCount > 0` assertions now pass.
+
+- [ ] **Step 5: Commit**
+
+`feat(test): wire harness plugin-crypto emit+encrypt substrate (holomush-5iaov)`
+
+---
+
+### Task 8: Audit projection (link 3) + read-back decryptor (link 4) → suite GREEN
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/crypto.go`
+- Modify: `internal/testsupport/integrationtest/harness.go` / `plugins.go` (call `ConfigureReadbackDecryptor`; start the PCM)
+
+- [ ] **Step 1: Wire the PluginConsumerManager (link 3)**
+
+In `crypto.go`, add (mirrors `core.go:556-591`, including a local `pluginAuditClientAdapter` mirroring `core.go:1159-1173`):
+
+```go
+func startPluginConsumers(t *testing.T, ctx context.Context, bus *eventbustest.Embedded, mgr *plugins.Manager, sel codec.KeySelector) *audit.PluginConsumerManager {
+	t.Helper()
+	pcm := audit.NewPluginConsumerManager(bus.JS, audit.WithKeySelector(sel))
+	byPlugin := map[string][]string{}
+	for _, d := range mgr.AuditSubjects() {
+		byPlugin[d.PluginName] = append(byPlugin[d.PluginName], d.Subject)
+	}
+	for name, subjects := range byPlugin {
+		client, ok := mgr.PluginAuditClient(name)
+		if !ok {
+			continue
+		}
+		require.NoError(t, pcm.Add(ctx, audit.PluginConsumerConfig{
+			PluginName: name, Subjects: subjects, Client: pluginAuditClientAdapter{client: client},
+		}), "startPluginConsumers: pcm.Add %s", name)
+	}
+	return pcm
+}
+```
+
+Define `pluginAuditClientAdapter` with the single `AuditEvent(ctx, *pluginv1.AuditEventRequest) (*pluginv1.AuditEventResponse, error)` method delegating to the proto client (copy shape from `core.go:1164-1173`).
+
+- [ ] **Step 2: Wire the read-back decryptor (link 4) — real guard + audit emitter**
+
+Add to `crypto.go` (mirrors `sub_grpc.go:347-366,477-484`):
+
+```go
+func (s *Server) configureReadback(ctx context.Context, pc *pluginCrypto) {
+	mgr := s.pluginSub.Manager()
+	auditEm, err := authguardaudit.NewQueuedEmitter(pc.publisher, authguardaudit.WithGameID(s.bus.Bus.GameID()))
+	require.NoError(s.t, err)
+	sessionBridgeEm, err := authguardaudit.NewSessionBridgeEmitter(auditEm)
+	require.NoError(s.t, err)
+
+	guard, err := authguard.New(
+		authguard.NewDEKParticipantLookup(pc.dekMgr),
+		authguard.NewPluginManifestLookup(mgr),
+		s.accessEngine,        // ABACEngine — never invoked on the plugin-readback path
+		auditEm,               // BackpressureChecker — fresh QueuedEmitter ⇒ no throttle (spec §6.1)
+	)
+	require.NoError(s.t, err)
+
+	owners := cryptowiring.OwnerMapFromManager(managerSourceForHarness{mgr: mgr})
+	mgr.ConfigureReadbackDecryptor(history.NewReadbackDecryptor(
+		owners,
+		cryptowiring.AlwaysSensitiveSet(managerSourceForHarness{mgr: mgr}),
+		cryptowiring.CryptoKeysLookup(s.pool),
+		authguard.NewSessionBridgeGuard(guard),
+		pc.dekMgr,
+		sessionBridgeEm,
+	))
+	s.readbackAuditEm = auditEm // for ReadBackAuditCount
+}
+```
+
+> `managerSourceForHarness` is the harness's copy of the `cmd/holomush` `managerSource` adapter (Task 2/4). Both are thin; sharing them is optional (a follow-up could move the adapter into `cryptowiring`, but that pulls `*plugin.Manager` into the package — deferred). Call `startPluginConsumers` + `configureReadback` from `Start` when `cfg.withPluginCrypto`, after `startPlugins`.
+
+- [ ] **Step 3: Add `QueryPluginAuditRows` / `ReadBackOwnRows` / `ReadBackAuditCount` helpers**
+
+```go
+type PluginAuditRow struct{ /* mirrors pluginv1.AuditRow fields needed */ }
+type ReadBackResult struct {
+	Plaintext string
+	Denied    bool // true when the host decryptor refused the row (g1/g2 deny)
+}
+
+func (s *Server) QueryPluginAuditRows(ctx context.Context, plugin, subject string) []PluginAuditRow { /* SELECT from plugin_core_scenes.scene_log */ }
+func (s *Server) ReadBackOwnRows(ctx context.Context, plugin string, rows []PluginAuditRow) []ReadBackResult { /* call mgr.<ReadbackDecryptor>.DecryptOwnRow per row, mapping plaintext */ }
+func (s *Server) ReadBackAuditCount(ctx context.Context) int { /* count read-back audit emissions via readbackAuditEm or events_audit */ }
+```
+
+> Implementer grounds the exact `scene_log` columns via `rg -n "scene_log" plugins/core-scenes/` and the `DecryptOwnRow` call shape via `mcp__probe__extract_code DecryptOwnRow` (readback.go:245).
+
+- [ ] **Step 4: Run — suite GREEN (INV-5IA-4/6)**
+
+Run: `task test:int -- ./test/integration/plugincrypto/`
+Expected: PASS — positive round-trip recovers plaintext + audit fired.
+
+- [ ] **Step 5: Commit**
+
+`feat(test): wire harness plugin audit projection + read-back; round-trip green (holomush-5iaov)`
+
+---
+
+## Phase 3: Negative path + invariants + coverage
+
+### Task 9: Negative read-back (INV-5IA-5), shared-source assertion (INV-5IA-3), coverage
+
+**Files:**
+
+- Modify: `test/integration/plugincrypto/roundtrip_test.go` (negative spec)
+- Modify: `internal/testsupport/integrationtest/crypto.go` (optional `WithReadbackThrottled` seam if needed for negative)
+- Modify: `internal/plugin/cryptowiring/cryptowiring_test.go` (INV-5IA-3 pointer-identity)
+
+- [ ] **Step 1: Write the negative spec (readback:false → denied, no plaintext)**
+
+Append to `roundtrip_test.go`:
+
+```go
+It("denies read-back for an event type whose manifest declares readback:false, without leaking plaintext", func() {
+	// scene_publish_started is sensitivity:never (publish_events.go:61) — emit a
+	// readback:false-class event and assert read-back refuses it.
+	emitted := ts.EmitPluginEvent(ctx, "core-scenes", "scene_publish_started", `{"scene":"x"}`, false)
+	var rows []integrationtest.PluginAuditRow
+	Eventually(func() int { rows = ts.QueryPluginAuditRows(ctx, "core-scenes", emitted.SubjectStr); return len(rows) }).
+		Should(BeNumerically(">", 0))
+	results := ts.ReadBackOwnRows(ctx, "core-scenes", rows)
+	Expect(results[0].Plaintext).To(BeEmpty(), "readback-denied row must not yield plaintext")
+	Expect(results[0].Denied).To(BeTrue())
+	// INV-5IA-4 negative half: a sensitivity:never event stays identity-coded.
+	Expect(ts.WireCodecFor(ctx, emitted.SubjectStr)).To(Equal(codec.NameIdentity))
+})
+```
+
+> Grounding note: confirm a `readback:false` (or `sensitivity:never`) event type the implementer can drive through `EmitPluginEvent`; `plugin.yaml:81,84-117` lists `sensitivity:never` notice types. The assertion targets `DenyReadbackManifestMissing` / a non-OK `RowResult` (guard.go:166-167). `ReadBackResult.Denied` is defined in Task 8.
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test:int -- ./test/integration/plugincrypto/`
+Expected: PASS (both positive and negative).
+
+- [ ] **Step 3: Write the INV-5IA-3 pointer-identity unit test**
+
+In `cryptowiring_test.go`, assert `KeySelector()` returns a usable identity selector and (harness side) that the SAME selector instance feeds the PCM and the publisher. The harness assertion (in `crypto_test.go`):
+
+```go
+// INV-5IA-1: WithInTreePlugins ALONE must NOT wire plugin crypto. A crypto-only
+// helper called without WithPluginCrypto panics via requirePluginCrypto, proving
+// the substrate is unwired (the census suite already runs WithInTreePlugins-only).
+func TestWithInTreePluginsAloneDoesNotWireCrypto(t *testing.T) {
+	ts := Start(t, WithInTreePlugins())
+	defer ts.Stop()
+	assert.Panics(t, func() {
+		ts.EmitPluginEvent(context.Background(), "core-scenes", "scene_pose", `{"text":"x"}`, true)
+	})
+}
+
+// INV-5IA-3: the codec selector is shared (pointer-identity) across links 2-4.
+func TestPluginCryptoSharesSelectorInstance(t *testing.T) {
+	ts := Start(t, WithInTreePlugins(), WithPluginCrypto())
+	defer ts.Stop()
+	assert.Same(t, ts.cryptoSelectorForTest(), ts.cryptoSelectorForTest()) // single instance reused
+}
+```
+
+> Implementer exposes a test-only accessor `cryptoSelectorForTest()` returning `s.pluginCrypto.selector`; the real pointer-identity guarantee comes from constructing `sel` once in `newPluginCrypto` and passing the same value to both `bus.Bus.Publisher(WithCodecSelector(sel))` and `audit.NewPluginConsumerManager(WithKeySelector(sel))`.
+
+- [ ] **Step 4: Coverage verification**
+
+Run unit coverage on the new prod package:
+
+```text
+task test:cover -- ./internal/plugin/cryptowiring/
+```
+
+Expected: ≥80% (derivations + KeySelector + nil-guards). Note the `CryptoKeysLookup.Exists` query lines are integration-covered (Task 3 integration test) — confirm with:
+
+```text
+go test -tags=integration -coverprofile=/tmp/cw.out ./internal/plugin/cryptowiring/ && go tool cover -func=/tmp/cw.out | tail -1
+```
+
+Harness-wiring coverage (integration-only) evidence:
+
+```text
+go test -tags=integration -coverpkg=./internal/testsupport/integrationtest/... ./test/integration/plugincrypto/...
+```
+
+- [ ] **Step 5: Full gate + commit**
+
+Run: `task test:int` (full integration — catches cross-suite breakage)
+Run: `task lint:go` and `task fmt`
+Commit: `test(plugincrypto): negative read-back + INV-5IA-3 selector identity + coverage (holomush-5iaov)`
+
+---
+
+## Out of scope (follow-up beads)
+
+- Stale "no sensitive field" comments at `event_emitter.go:162-168` and `:67-82` (spec §1.3).
+- Scene-specific publish driving (`CreateScene`, publish windows/scheduler) — `holomush-shcyu`.
+- Host-subject audit projection (`audit.NewSubsystem`), cluster invalidation — explicitly excluded (spec §2).
+<!-- adr-capture: sha256=a235c0ac04b4dcd2; session=cli; ts=2026-05-28T00:48:19Z; adrs=holomush-35ej2 -->

--- a/docs/superpowers/specs/2026-05-27-harness-plugin-crypto-roundtrip-design.md
+++ b/docs/superpowers/specs/2026-05-27-harness-plugin-crypto-roundtrip-design.md
@@ -1,0 +1,328 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Design: complete the plugin-crypto round-trip in the integration harness
+
+| | |
+|---|---|
+| **Bead** | holomush-5iaov |
+| **Date** | 2026-05-27 |
+| **Status** | Draft (pre design-reviewer) |
+| **Labels** | crypto, plugin, test-harness |
+| **First consumer** | holomush-shcyu (Phase 6 publish E2E) — depends on this |
+| **Reviewers** | `crypto-reviewer` (MUST, before `code-reviewer`), `code-reviewer` |
+
+## 1. Problem
+
+The `internal/testsupport/integrationtest` harness boots a real in-process stack
+(Postgres testcontainer + embedded NATS JetStream + production `CoreServer`) and,
+under `WithInTreePlugins()`, loads the full in-tree plugin set. But two crypto/event
+seams were deliberately left unwired when `WithInTreePlugins` landed (#4275):
+
+- The plugin **event emitter** is never configured — `startPlugins`
+  (`internal/testsupport/integrationtest/plugins.go:154-160`) documents that
+  `Manager.ConfigureEventEmitter` is not called and the `WorldService` is built
+  without an `EventEmitter` (`plugins.go:215-224`). Any plugin-emitted event fails
+  with "plugin event emitter is not configured".
+- The **read-back decryptor** is never configured — the harness builds a *minimal*
+  `HistoryReader` (`harness.go:302-307`, `history.NewReader(bus.JS, pool, 30d, Now)`,
+  all crypto/audit/fence options omitted) and never calls
+  `Manager.ConfigureReadbackDecryptor` (`manager.go:374`). Any plugin read-back of
+  `sensitivity: always` content fails ("read-back decryptor not configured").
+
+The originating bead framed this as "two `ConfigureX` calls." Grounding the
+`event.Sensitive` data-flow end-to-end (see §9) shows the gap is an **indivisible
+four-link crypto round-trip**, because the links are fail-closed coupled: a plugin
+emit of `sensitivity: always` content is only useful for read-back if it was
+*encrypted* on publish and *projected* to the plugin's audit table — and enabling
+the emit-side sensitivity fence *without* a publish-side DEK manager makes every
+sensitive emit hard-error.
+
+### 1.1 The four-link chain (grounded)
+
+```mermaid
+flowchart LR
+    P[core-scenes plugin<br/>emits sensitivity:always IC event] -->|1. emit fence| E["PluginEventEmitter.Emit<br/>cryptoEnabled ⇒ event.Sensitive=true<br/>(event_emitter.go:169-180)"]
+    E -->|2. publish encrypt| PUB["Publisher.Publish<br/>Sensitive && dekMgr ⇒ XChaCha20v1 + DEK row<br/>Sensitive && nil dekMgr ⇒ HARD ERROR<br/>(publisher.go:208-229)"]
+    PUB -->|3. audit projection| PCM["PluginConsumerManager<br/>encrypted event → plugin_core_scenes.scene_log<br/>(core.go:556)"]
+    PCM -->|4. read-back decrypt| RB["ReadbackDecryptor.DecryptOwnRow<br/>g1 OwnerMap + g2 AuthGuard + INV-RB audit<br/>(readback.go:245)"]
+    RB --> OUT[plaintext IC snapshot<br/>for publish]
+```
+
+| # | Link | Today in harness | Production reference |
+|---|------|------------------|----------------------|
+| 1 | **Emit fence** — `ConfigureEventEmitter(pub, WithGameID, WithCryptoEnabled(true))` so `sensitivity: always` events get `event.Sensitive=true` | ❌ never called; `WorldService` has no emitter | `sub_grpc.go:210-213` (prod omits `WithCryptoEnabled` — see §1.3) |
+| 2 | **Publish encrypt** — the EventBus publisher MUST hold a `DEKManager` or `event.Sensitive=true` hard-errors (`EVENTBUS_SENSITIVE_EVENT_NO_DEK_MANAGER`) | ❌ `eventbustest.New` builds `NewSubsystemWithStorage` with no crypto (`embedded.go:63-80`) | `holomushtest.newKEKProvider` / `readstreamDEKManager` |
+| 3 | **Audit projection** — `audit.NewPluginConsumerManager(js, WithKeySelector(sel))` + `pcm.Add` per plugin projects the encrypted event → `plugin_core_scenes.scene_log` | ❌ harness wires no audit consumer | `core.go:531-598` |
+| 4 | **Read-back decrypt** — `ConfigureReadbackDecryptor(NewReadbackDecryptor(owners, alwaysSensitive, cryptoKeysLookup, guard, dekMgr, auditEm))` | ❌ never called | `sub_grpc.go:477-484` |
+
+### 1.2 Two structural frictions (grounded)
+
+- **Dep sourcing.** All read-back deps and the link-3 wiring are sourced from
+  **unexported** helpers in `cmd/holomush` (package `main`, unimportable):
+  `historyOwnersFromPlugins` (`sub_grpc.go:336`), `buildAlwaysSensitiveSet` /
+  `newCryptoKeysLookup` (`sub_grpc.go:377-378`), `buildKeySelector` (`core.go:523`).
+  There are **two** owner-derivations from the same plugin manager — the history/read
+  side (`historyOwnersFromPlugins`, `sub_grpc.go:892-927`, filters on client
+  registration) and the audit side (`core.go:574-590`, additionally gates each
+  owner-entry on `pcm.Add` success). They are **not equivalent**: the audit side's
+  Add-gate is load-bearing — marking a subject owned with no running consumer drops
+  events from every sink (`core.go:561-564`). Only the **read-side** derivation is
+  shared (§5); the audit-side derivation stays as-is.
+- **Manual CoreServer assembly.** The harness hand-builds its `CoreServer`
+  (`harness.go:310`), bypassing the production subsystem lifecycle
+  (`grpcSubsystem.Start` + `core.go` audit closure) that normally wires every link.
+  So each link is a manual reconstruction in the harness.
+
+### 1.3 Why the emit fence is off in prod, and why the harness turns it on
+
+Production never passes `WithCryptoEnabled` (`sub_grpc.go:210-213`), so the plugin
+emit fence is off and every plugin event currently emits `Sensitive=false`. An older
+`event_emitter.go:162-168` comment attributes this to the binary-plugin proto lacking
+a `sensitive` field — **that comment is stale**: `EmitEventRequest` now carries
+`bool sensitive = 4` with INV-6/INV-7 semantics (`plugin.proto:312-320`), the Manager
+copies it into `EmitIntent.Sensitive` (`manager.go:424`), and core-scenes already
+claims it on IC content (`commands.go:1324-1328`; asserted by
+`commands_emit_test.go:54-117`). The same stale "no sensitive field" claim is repeated
+in the `WithCryptoEnabled` docstring at `event_emitter.go:67-82` (the binary path sets
+it at `goplugin/host_service.go:100`). Correcting both stale spots is a small side-issue,
+out of scope here; noted for a follow-up bead.
+
+The live reason the fence stays off in prod is **cross-plugin rollout conservatism**:
+`ConfigureEventEmitter` installs **one shared emitter** for all plugins, so
+`WithCryptoEnabled(true)` is global. The fence's `always + claim=false → reject`
+(`EVENT_SENSITIVITY_REQUIRED`) and `never + claim=true → reject`
+(`EVENT_SENSITIVITY_NOT_DECLARED`) rules (`sensitivity_fence.go:23-43`) mean turning
+the fence on game-wide would break any loaded plugin that is not yet crypto-correct.
+
+The harness's `WithPluginCrypto` deliberately turns the fence **on** (co-wired with the
+DEK manager — they MUST be enabled together, since `Sensitive=true` without a DEK
+manager hard-errors at the publisher). This models the **intended crypto-enabled
+deployment** and lets the round-trip be tested ahead of the game-wide prod activation
+that `holomush-shcyu` depends on. The global-flag sharp edge is handled by **scoping
+the round-trip test to a crypto-correct plugin (core-scenes)** — see §6.2.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Wire the full emit → encrypt → project → read-back round-trip into the harness as a
+  single opt-in `StartOption`, with **production-faithful** crypto routing, ownership
+  derivation, and read-back authorization.
+- Unblock `holomush-shcyu` (its Phase 6 publish E2E reads back the encrypted IC
+  snapshot via the plugin read-back path — grounded in `publish_snapshot.go`).
+- Ship the substrate **self-validating**: it proves the round-trip independently of
+  any consumer.
+
+**Non-goals**
+
+- Scene-specific driving (`CreateScene`, publish windows / scheduler interval,
+  `SceneServiceClient` accessor, the publish E2E itself) — stays in `holomush-shcyu`.
+- Host-subject audit projection to `events_audit` (`audit.NewSubsystem`) — not needed
+  for the plugin round-trip; only the per-plugin consumer is in scope.
+- Cluster invalidation / rekey orchestration — single-process `noopInv`; the rekey
+  `Orchestrator`/`CheckpointRepo`/admin-socket machinery is rekey-only and irrelevant.
+
+## 3. Decisions
+
+These were resolved during brainstorming (see the bead's grounding notes):
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Absorb the full round-trip** into 5iaov (all 4 links + dep sourcing), not split into a narrow bead + sibling | The fail-closed coupling (link 1 without link 2 ⇒ hard error) means no link is independently testable; a narrower bead would produce untestable substrate. |
+| D2 | **Extract** the manifest-derivation helpers to a shared internal package consumed by **both** prod and the harness — **revising the bead's "zero prod changes" claim** | The point of an integration harness is fidelity. Reimplementing the derivations risks the worst kind of test: green in test, divergent in prod. Extraction is small and mechanical. |
+| D3 | **Real `SessionBridgeGuard(Guard)`** for read-back authz + real audit-chain emitter (not permissive stubs) | The plugin read-back path (`checkPluginReadback`, `guard.go:162-170`) is **not** session-state-dependent — it's a manifest-flag check + backpressure check with the ABAC gate deliberately dropped (§7.5). So the real guard is cheap here and catches the regressions worth catching (`readback:false` should deny). Stubbing would mask them. |
+| D4 | **Self-validating** round-trip test (positive + negative), TDD-first | Substrate that can't be validated in isolation couples its debugging to consumers. The extraction itself is the drift defense, so a separate prod-parity meta-test is deferred unless review requests it. |
+
+## 4. Surface — opt-in `StartOption`
+
+A new `WithPluginCrypto()` option, composed with `WithInTreePlugins()`:
+
+```go
+ts := integrationtest.Start(t, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+```
+
+- **MUST require** `WithInTreePlugins()` — the emitter, the per-plugin consumer, and
+  the read-back decryptor all need the loaded `Manager`. Used without it ⇒ `panic`
+  (mirrors the existing `requirePlugins` guard, `harness.go:395-399`).
+- **MUST NOT** be folded into `WithInTreePlugins` — the whole-system census suite
+  (`holomush-0f0f4.8`) reads load-state only and MUST NOT pay KEK/DEK/consumer cost.
+- The deterministic backpressure seam (§6) MAY be tuned by a further option
+  (e.g. `WithReadbackThrottled()`) for the negative path; default is no-throttle.
+
+## 5. Extraction unit (shared-for-fidelity)
+
+Extract the manifest-derivation helpers from `cmd/holomush` (package `main`) into a
+new shared package — **proposed `internal/plugin/cryptowiring`** (these functions
+fundamentally *derive crypto/audit wiring from the plugin `Manager`*; placing them
+under `internal/plugin/` rather than `internal/eventbus/` avoids any appearance of an
+`eventbus → plugin` import cycle — exact home is import-graph-verified at plan time):
+
+- `OwnerMapFromManager(*plugin.Manager) *audit.OwnerMap` — extracts the **history/read-side**
+  derivation (`historyOwnersFromPlugins`, `sub_grpc.go:892-927`; client-registration
+  filter), consumed by the prod history reader (`sub_grpc.go:336`) **and** the harness
+  read-back. It is **not** collapsed with `core.go`'s audit-side derivation
+  (`core.go:574-590`): that path additionally gates each owner-entry on `pcm.Add` success
+  (`core.go:561-564`), a load-bearing difference. **Gated** by a unit test asserting the
+  shared function reproduces the current `historyOwnersFromPlugins` output before
+  `sub_grpc.go` is repointed (read-side parity; the audit-side derivation is untouched).
+- `AlwaysSensitiveSet(*plugin.Manager) map[string]struct{}` — from `buildAlwaysSensitiveSet`.
+- `CryptoKeysLookup(*pgxpool.Pool) history.CryptoKeysLookup` — from `newCryptoKeysLookup`.
+- `KeySelector(...) codec.KeySelector` — from `buildKeySelector`; the **same instance**
+  is threaded into links 2, 3, and 4 (production's pointer-identity requirement,
+  `core.go:516-523`).
+
+Both prod (`sub_grpc.go` / `core.go`) and the harness call these. The DEK-manager and
+KEK construction are **not** extracted — they use already-exported primitives
+(`dek.NewManager`, `dek.NewStore`, `kek.NewLocalAEADProviderForUnitTest`) and live as
+a small test-tier constructor in the harness (mirror `holomushtest.newKEKProvider`,
+`server.go:492-502`).
+
+## 6. Link-by-link wiring (inside `WithPluginCrypto`)
+
+All construction happens in the harness's `Start`/`startPlugins` path, guarded by the
+option. Ordering mirrors prod: emitter + publisher before plugin command dispatch;
+read-back decryptor after the manager has loaded manifests.
+
+| Link | Wiring | Dep source |
+|------|--------|-----------|
+| 1 — emit fence | `mgr.ConfigureEventEmitter(cryptoPublisher, plugins.WithGameID(gid), plugins.WithCryptoEnabled(true))` | harness has `Manager` + `bus.Bus.GameID()` |
+| 2 — publish encrypt | a crypto-enabled `Publisher` over the embedded bus's JetStream — `eventbus` publish options `WithDEKManager(dekMgr)` + `WithCodecSelector(sel)` — passed as the emitter's publisher | `dekMgr := dek.NewManager(kekProvider, dek.NewStore(pool), caches, noopInv, bindings)`; `kekProvider := kek.NewLocalAEADProviderForUnitTest(...)` |
+| 3 — audit projection | `pcm := audit.NewPluginConsumerManager(bus.JS, audit.WithKeySelector(sel))`; `pcm.Add(ctx, PluginConsumerConfig{PluginName, Subjects, Client})` per declared plugin (harness defines a small `pluginAuditClientAdapter`, mirroring `core.go:1159-1173`) | `mgr.AuditSubjects()`, `mgr.PluginAuditClient(name)` |
+| 4 — read-back | `owners := cryptowiring.OwnerMapFromManager(mgr)` (read-side derivation, §5; independent of the link-3 Add-pass); `mgr.ConfigureReadbackDecryptor(history.NewReadbackDecryptor(owners, alwaysSensitive, cryptoKeysLookup, guard, dekMgr, auditEm))` | link-2 `dekMgr` + the real guard (§6.1) + shared `cryptowiring` |
+
+> **Resolved seam:** the crypto-enabled publisher comes from
+> `bus.Bus.Publisher(eventbus.WithDEKManager(dekMgr), eventbus.WithCodecSelector(sel))`
+> — `(*Subsystem).Publisher` already accepts `...PublishOption` (`publisher.go:394`), so
+> **no `eventbustest` change is needed**. The harness wraps it with
+> `eventbus.NewRenderingPublisher(raw, verbRegistry)` to mirror prod's `wrapPublisher`.
+> All reach the same JetStream stream the
+> harness's subscriber already reads.
+
+### 6.1 Read-back authorization (D3)
+
+```go
+guard := authguard.NewSessionBridgeGuard(
+    authguard.New(participantLookup, manifestLookup, abacEngine, backpressure),
+)
+```
+
+- `manifestLookup` **MUST** be the real loaded `Manager` (so a `readback:false` event
+  type genuinely denies via `DenyReadbackManifestMissing`, `guard.go:166-167`).
+- `participantLookup` and `abacEngine` satisfy the constructor but are **never invoked**
+  on the plugin-readback path (`checkPluginReadback` reaches neither — `guard.go:162-170`);
+  they MAY be the harness's existing minimal/allow-all instances.
+- `backpressure` **MUST** be a deterministic test seam, default **no-throttle**, with an
+  opt-in force-throttle for the negative path (a real checker keyed to live audit-queue
+  depth would make the round-trip nondeterministic).
+- `auditEm` **MUST** be a real audit-chain `SessionAuditEmitter` (INV-RB-3 exercised for
+  real, non-nil — read-back fails closed otherwise).
+
+### 6.2 Global emit fence — test scoping
+
+`WithCryptoEnabled` is global to the shared emitter (§1.3), so under `WithPluginCrypto`
+every loaded plugin's emits run through the fence. The round-trip suite **MUST** drive
+only a crypto-correct plugin (**core-scenes** — it claims `Sensitive=true` on
+`sensitivity: always` content and `false` on `sensitivity: never` notices,
+`commands.go:1324-1328` / `publish_events.go:61`). A future in-tree plugin that emits
+`sensitivity: always` content without claiming would reject under `WithPluginCrypto`;
+that is the same constraint prod carries and is **out of scope** here. Per-plugin fence
+enablement is not supported by the single shared emitter and is **not** introduced by
+this work. This constraint is documented on `WithPluginCrypto` so consumers know the
+option assumes crypto-correct plugins.
+
+## 7. Invariants (RFC2119)
+
+Each invariant ships with at least one test (unit or integration as noted).
+
+- **INV-5IA-1** — Plugin crypto wiring MUST be reachable only via `WithPluginCrypto`;
+  `WithInTreePlugins` alone MUST NOT wire the emitter, the DEK manager, the per-plugin
+  consumer, or the read-back decryptor. *(harness-level test)*
+- **INV-5IA-2** — `WithPluginCrypto` used without `WithInTreePlugins` MUST panic with a
+  clear message. *(unit/harness test)*
+- **INV-5IA-3** — The harness MUST source `owners` / `alwaysSensitive` /
+  `cryptoKeysLookup` / `keySelector` from the **shared `cryptowiring` package**, not from
+  harness-local reimplementations; the `keySelector` instance MUST be shared by links 2,
+  3, and 4. *(unit test on cryptowiring + a harness assertion of pointer-identity)*
+- **INV-5IA-4** — A `sensitivity: always` plugin emit under `WithPluginCrypto` MUST be
+  encrypted on the wire (non-identity codec header + a `crypto_keys` DEK row), never
+  plaintext; a `sensitivity: never` emit MUST remain identity-coded. *(integration)*
+- **INV-5IA-5** — The read-back guard's `ManifestLookup` MUST be the real loaded
+  `Manager`: a `crypto.emits[].readback=true` event MUST permit read-back, a
+  `readback:false` event MUST deny it without leaking plaintext. *(integration)*
+- **INV-5IA-6** — The round-trip test MUST assert, on the positive path, **plaintext
+  recovery** of the emitted IC content **and** that the INV-RB-3 read-back audit fired;
+  and on the negative path, denial **without** plaintext. *(integration)*
+
+## 8. Test strategy & acceptance
+
+### 8.1 TDD order (`dev-flow:test-driven-development`)
+
+1. **Unit** tests for `cryptowiring` helpers (owner-map collapse parity, alwaysSensitive
+   set, cryptoKeysLookup, keyselector) — red, then extract.
+2. **Harness** assertions for INV-5IA-1/2/3 (opt-in gating, panic-without-plugins,
+   shared-source + pointer-identity) — red, then wire `WithPluginCrypto`.
+3. **Ginkgo** round-trip suite for INV-5IA-4/5/6 — red, then wire links 1–4 until green.
+
+### 8.2 Coverage targets (split by tier)
+
+| Package | Tier | How ≥80% is met | Verified by |
+|---|---|---|---|
+| `internal/plugin/cryptowiring` (**new, prod code**) | unit | table-driven tests over manifest fixtures; target 90%+ (crypto-adjacent) | `task test:cover` |
+| `internal/testsupport/integrationtest` (`//go:build integration`) | integration-only | exercised by the round-trip suite — invisible to `task test:cover` because `task test` does not compile integration files | `go test -tags=integration -coverpkg=./internal/testsupport/integrationtest/... ./test/integration/plugincrypto/...` |
+
+The ≥80% bar is a **hard gate on the new `cryptowiring` prod package**. The
+integration-tagged harness wiring's coverage proof is the Ginkgo suite plus the
+explicit `-tags=integration -coverpkg` run (the default unit `test:cover` cannot see it
+by construction).
+
+### 8.3 Full integration (`testing.md`)
+
+The round-trip is a Ginkgo/Gomega suite — **proposed `test/integration/plugincrypto/`** —
+`//go:build integration`, run via `task test:int`, standing up the real stack
+(`integrationtest.Start(t, WithInTreePlugins(), WithPluginCrypto())`). The async
+projection → `scene_log` step uses `Eventually(...)` (no `time.Sleep`). Requires the
+binary plugin artifacts (`task plugin:build-all`; automatic under `task test:int`).
+
+No pre-quarantining: a flaky step is investigated and fixed (a `test/quarantine.yaml`
+row is added only with an open bead, never for a real failure).
+
+## 9. Grounding references
+
+Verified during brainstorming (see also the bead's `grounding/*` notes):
+
+- Emit fence gate: `internal/plugin/event_emitter.go:169-180` (`cryptoEnabled` ⇒
+  `event.Sensitive`), `:221-229` (event built with `Sensitive`).
+- Fence rules (`always+claim=false → EVENT_SENSITIVITY_REQUIRED`,
+  `never+claim=true → EVENT_SENSITIVITY_NOT_DECLARED`):
+  `internal/plugin/sensitivity_fence.go:23-43`, `sensitivity_fence_test.go:24-29`.
+- Sensitive claim exists + is propagated: proto `bool sensitive = 4`
+  `api/proto/holomush/plugin/v1/plugin.proto:312-320`; `internal/plugin/manager.go:424`
+  (copies into `EmitIntent`); core-scenes claims it `plugins/core-scenes/commands.go:1324-1328`
+  (always) / `publish_events.go:61` (never), asserted `commands_emit_test.go:54-117`.
+  (The `event_emitter.go:162-168` "no sensitive field" comment is stale.)
+- Publish encrypt / fail-closed: `internal/eventbus/publisher.go:208-229`
+  (`Sensitive && dekMgr` ⇒ encrypt; `Sensitive && nil` ⇒
+  `EVENTBUS_SENSITIVE_EVENT_NO_DEK_MANAGER`).
+- Prod emitter wiring (no `WithCryptoEnabled`): `cmd/holomush/sub_grpc.go:210-213`.
+- Read-back deps + real guard: `cmd/holomush/sub_grpc.go:336,343-366,377-378,477-484`;
+  constructor `internal/eventbus/history/readback.go:204-230`.
+- Read-back authz is manifest+backpressure, ABAC dropped:
+  `internal/eventbus/authguard/guard.go:41-65,162-170`; `adapter_manifest.go:24-28`;
+  `adapter_session.go:30`.
+- Audit consumer + owner-map convergence: `cmd/holomush/core.go:514,516-523,531-598`
+  (`audit.NewPluginConsumerManager` at `:556`).
+- Manager configure seams: `internal/plugin/manager.go:332,374`.
+- core-scenes intent: `plugins/core-scenes/plugin.yaml:59-117`
+  (`crypto.emits`, `sensitivity: always`/`never`, `readback`); publish uses the
+  read-back path: `plugins/core-scenes/publish_snapshot.go` (decryptor interface
+  `[]*pluginv1.AuditRow → []*pluginv1.RowResult`).
+- Test crypto prior art: `internal/testsupport/holomushtest/server.go:401-410,492-502`
+  (`dek.NewManager`, `kek.NewLocalAEADProviderForUnitTest`);
+  `cmd/holomush/admin_read_stream_e2e_test.go:375-385`.
+- Harness state: `internal/testsupport/integrationtest/harness.go:302-307` (minimal
+  reader), `:310` (manual CoreServer); `plugins.go:154-160` (emitter deliberately
+  unwired), `:215-224`; `internal/eventbus/eventbustest/embedded.go:63-80` (no crypto).
+<!-- adr-capture: sha256=b6b5e867718f0cac; session=cli; ts=2026-05-28T00:48:19Z; adrs=holomush-35ej2 -->


### PR DESCRIPTION
## Summary

Docs-only PR landing the **design spec, implementation plan, and ADR** for the
plugin-crypto round-trip harness work (`holomush-5iaov`). No code changes — this
lands the canonical docs on `main` so implementer sessions read them from there.

- `docs/superpowers/specs/2026-05-27-harness-plugin-crypto-roundtrip-design.md` — design spec
- `docs/superpowers/plans/2026-05-27-harness-plugin-crypto-roundtrip.md` — 9-task TDD plan
- `docs/adr/holomush-35ej2-extract-cryptowiring.md` — ADR for the `cryptowiring` extraction

## What it designs

Completes the 4-link plugin-crypto round-trip (emit fence → publish encrypt →
audit projection → read-back decrypt) in the `integrationtest` harness behind an
opt-in `WithPluginCrypto()`, extracting prod's manifest-derivation helpers into a
shared `internal/plugin/cryptowiring` package so the harness reproduces production
crypto routing faithfully. First consumer: `holomush-shcyu` (Phase 6 publish E2E).

## Tracking (bd)

- Epic `holomush-5iaov` (promoted) + 9 child tasks `.1`–`.9` in a linear TDD chain.
- Decision bead `holomush-35ej2` (cryptowiring extraction ADR).

## Review status

- `design-reviewer`: **READY** (round 1) — all 31 `path:line` citations verified.
- `plan-reviewer`: **READY** (round 2).
- `code-reviewer`: N/A — docs-only diff (no code); the two doc-appropriate
  adversarial gates above are the satisfying review.
- `task pr-prep` (fast lane): **pass**.

Implementation lands in follow-up PRs per the 9 plan tasks (crypto-reviewer gate
applies to the crypto-touching tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
