### PR TITLE
test(harness): plugin-crypto round-trip via WithPluginCrypto (holomush-5iaov)

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -46,6 +46,7 @@ import (
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/logging"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	sessionsetup "github.com/holomush/holomush/internal/session/setup"
@@ -520,7 +521,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// (via grpcSubsystemConfig.KeySelector → newHistoryReader →
 	// history.WithCodecSelector). Pointer-identity is asserted by
 	// TestDispatcherAndHotTierShareSelector.
-	pluginCodecKeySelector := buildKeySelector()
+	pluginCodecKeySelector := cryptowiring.KeySelector()
 
 	// F5: wire per-plugin audit plumbing. Both the OwnerMap (drives host-
 	// projection ack-and-skip) and the per-plugin consumer manager (drives

--- a/cmd/holomush/cryptowiring_adapter.go
+++ b/cmd/holomush/cryptowiring_adapter.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
 )
 
 // managerSource adapts *plugins.Manager to cryptowiring.ManifestSource so the
@@ -27,4 +28,18 @@ func (s managerSource) AlwaysSensitiveEmitTypes(name string) []string {
 		}
 	}
 	return out
+}
+
+func (s managerSource) AuditSubjects() []cryptowiring.AuditSubjectDecl {
+	decls := s.mgr.AuditSubjects()
+	out := make([]cryptowiring.AuditSubjectDecl, 0, len(decls))
+	for _, d := range decls {
+		out = append(out, cryptowiring.AuditSubjectDecl{PluginName: d.PluginName, Subject: d.Subject})
+	}
+	return out
+}
+
+func (s managerSource) HasAuditClient(name string) bool {
+	_, ok := s.mgr.PluginAuditClient(name)
+	return ok
 }

--- a/cmd/holomush/cryptowiring_adapter.go
+++ b/cmd/holomush/cryptowiring_adapter.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	plugins "github.com/holomush/holomush/internal/plugin"
+)
+
+// managerSource adapts *plugins.Manager to cryptowiring.ManifestSource so the
+// prod call site in sub_grpc.go can pass a real Manager to
+// cryptowiring.AlwaysSensitiveSet without importing the full plugin package
+// into cryptowiring (which would create a circular dependency).
+type managerSource struct{ mgr *plugins.Manager }
+
+func (s managerSource) ListPlugins() []string { return s.mgr.ListPlugins() }
+
+func (s managerSource) AlwaysSensitiveEmitTypes(name string) []string {
+	dp, ok := s.mgr.GetLoadedPlugin(name)
+	if !ok || dp.Manifest == nil || dp.Manifest.Crypto == nil {
+		return nil
+	}
+	var out []string
+	for _, emit := range dp.Manifest.Crypto.Emits {
+		if emit.Sensitivity == plugins.SensitivityAlways {
+			out = append(out, emit.EventType)
+		}
+	}
+	return out
+}

--- a/cmd/holomush/gateway_imports_test.go
+++ b/cmd/holomush/gateway_imports_test.go
@@ -58,12 +58,18 @@ var coreOnlyFiles = map[string]struct{}{
 	"cmd_admin_totp.go":      {},
 	"cmd_admin_totp_deps.go": {},
 	// Phase 7 INV-P7-9 + INV-P7-7 + INV-P7-15 wiring (holomush-1r0v.5).
-	// Constructs the boot-time codec.KeySelector + PluginDowngradeFence
-	// helpers (always-sensitive set, crypto_keys lookup, violation
-	// emitter). Imports eventbus/codec/history/plugin; core-only by
-	// design (matches crypto_rekey_wiring.go precedent).
+	// Constructs the boot-time PluginDowngradeFence helpers (crypto_keys
+	// lookup, violation emitter). Imports eventbus/history + core; core-only
+	// by design (matches crypto_rekey_wiring.go precedent). The KeySelector
+	// and AlwaysSensitiveSet derivations moved to internal/plugin/cryptowiring
+	// (holomush-5iaov.1/.2), so this file no longer imports codec or plugin.
 	"phase7_fence_wiring.go":      {},
 	"phase7_fence_wiring_test.go": {},
+	// AlwaysSensitiveSet adapter (holomush-5iaov.2). Adapts *plugins.Manager
+	// to cryptowiring.ManifestSource for the boot-time AlwaysSensitiveSet
+	// call. Imports internal/plugin; core-only (matches phase7_fence_wiring.go
+	// precedent).
+	"cryptowiring_adapter.go": {},
 }
 
 var forbidden = []string{

--- a/cmd/holomush/phase7_fence_wiring.go
+++ b/cmd/holomush/phase7_fence_wiring.go
@@ -16,43 +16,10 @@ import (
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/history"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginauditpb "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
-
-// buildKeySelector returns the single codec.KeySelector instance threaded
-// into both audit.PluginConsumerManager (via audit.WithKeySelector) and
-// history.NewReader (via history.WithCodecSelector). INV-P7-9 requires the
-// SAME pointer-identity selector in both places — see the parked test at
-// test/integration/eventbus_e2e/dispatcher_selector_identity_test.go.
-//
-// Phase 7 keeps the production deployment on the identity selector
-// (plugin-owned audit subjects are not yet encrypted at the bus level).
-// When a real KEK-backed selector ships, this constructor takes the
-// configured codec.KeySelector and returns it unchanged. The single
-// pointer is what matters for INV-P7-9.
-func buildKeySelector() codec.KeySelector {
-	return &identityProductionKeySelector{}
-}
-
-// identityProductionKeySelector is the placeholder selector used while
-// no plugin-owned audit subject is encrypted at the bus boundary. It
-// always returns (codec.NameIdentity, "", nil) for encrypt and the
-// no-op codec.NoKey for decrypt — equivalent to the package-private
-// identityKeySelector in internal/eventbus/publisher.go but lifted to
-// the boot wiring layer so the SAME instance can be threaded into both
-// the dispatcher and the reader.
-type identityProductionKeySelector struct{}
-
-func (identityProductionKeySelector) SelectForEncrypt(_ context.Context, _ string) (codec.Name, codec.KeyLabel, error) {
-	return codec.NameIdentity, "", nil
-}
-
-func (identityProductionKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ codec.KeyID) (codec.Key, error) {
-	return codec.NoKey, nil
-}
 
 // buildAlwaysSensitiveSet walks every loaded manifest and produces the
 // qualified `<plugin>:<event_type>` set the PluginDowngradeFence uses for

--- a/cmd/holomush/phase7_fence_wiring.go
+++ b/cmd/holomush/phase7_fence_wiring.go
@@ -6,11 +6,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 
@@ -19,40 +16,6 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/history"
 	pluginauditpb "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
-
-// newCryptoKeysLookup wraps the *pgxpool.Pool with a thin Exists query
-// that satisfies history.CryptoKeysLookup. The query filters
-// `destroyed_at IS NULL` so destroyed DEKs read as Exists=false (the
-// fence then surfaces the row as metadata_only=true per INV-P7-15).
-func newCryptoKeysLookup(pool *pgxpool.Pool) history.CryptoKeysLookup {
-	return &cryptoKeysLookup{pool: pool}
-}
-
-type cryptoKeysLookup struct {
-	pool *pgxpool.Pool
-}
-
-func (l *cryptoKeysLookup) Exists(ctx context.Context, dekRef uint64) (bool, error) {
-	if l.pool == nil {
-		return false, oops.Code("CRYPTO_KEYS_LOOKUP_POOL_NIL").
-			Errorf("crypto_keys lookup invoked with nil pool")
-	}
-	const q = `SELECT 1 FROM crypto_keys WHERE id = $1 AND destroyed_at IS NULL LIMIT 1`
-	var one int
-	err := l.pool.QueryRow(ctx, q, dekRef).Scan(&one)
-	if err != nil {
-		// pgx returns ErrNoRows when the row is absent (or destroyed) —
-		// that's the legitimate Exists=false case, NOT an infrastructure
-		// failure.
-		if errors.Is(err, pgx.ErrNoRows) {
-			return false, nil
-		}
-		return false, oops.Code("CRYPTO_KEYS_LOOKUP_QUERY_FAILED").
-			With("dek_ref", dekRef).
-			Wrap(err)
-	}
-	return true, nil
-}
 
 // newViolationEmitter constructs a ViolationEmitter that publishes
 // `events.<game>.system.plugin_integrity_violation` events on every

--- a/cmd/holomush/phase7_fence_wiring.go
+++ b/cmd/holomush/phase7_fence_wiring.go
@@ -17,49 +17,8 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/history"
-	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginauditpb "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
-
-// buildAlwaysSensitiveSet walks every loaded manifest and produces the
-// qualified `<plugin>:<event_type>` set the PluginDowngradeFence uses for
-// INV-P7-7 (manifest-set heuristic). Built ONCE at boot per INV-P7-8 — the
-// fence copies the input map so callers may not mutate it after
-// construction.
-//
-// Returns an empty (non-nil) map when mgr is nil or no plugin declares
-// `crypto.emits[].sensitivity: always`, mirroring the behaviour of
-// alwaysSensitiveFromManifest in test/integration/eventbus_e2e/.
-func buildAlwaysSensitiveSet(mgr *plugins.Manager) map[string]struct{} {
-	out := map[string]struct{}{}
-	if mgr == nil {
-		return out
-	}
-	for _, name := range mgr.ListPlugins() {
-		dp, ok := mgr.GetLoadedPlugin(name)
-		if !ok || dp.Manifest == nil || dp.Manifest.Crypto == nil {
-			continue
-		}
-		for _, emit := range dp.Manifest.Crypto.Emits {
-			if emit.Sensitivity != plugins.SensitivityAlways {
-				continue
-			}
-			key := emit.EventType
-			prefix := dp.Manifest.Name + ":"
-			if !startsWith(key, prefix) {
-				key = prefix + key
-			}
-			out[key] = struct{}{}
-		}
-	}
-	return out
-}
-
-// startsWith is a tiny stdlib-free helper so this file does not pull
-// the strings package just to check a single prefix.
-func startsWith(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
-}
 
 // newCryptoKeysLookup wraps the *pgxpool.Pool with a thin Exists query
 // that satisfies history.CryptoKeysLookup. The query filters

--- a/cmd/holomush/phase7_fence_wiring_test.go
+++ b/cmd/holomush/phase7_fence_wiring_test.go
@@ -208,15 +208,3 @@ func TestViolationEmitter_BadEventID_StillEmits(t *testing.T) {
 	require.NoError(t, err, "malformed row.Id MUST NOT block the emit; zero ULID is acceptable")
 	require.Len(t, inner.published, 1)
 }
-
-// TestCryptoKeysLookup_NilPool verifies the fail-closed defensive guard
-// against a misconfigured deployment. Production wiring always supplies
-// a non-nil pool; the nil-pool branch is the safety net.
-func TestCryptoKeysLookup_NilPool(t *testing.T) {
-	t.Parallel()
-	lookup := newCryptoKeysLookup(nil)
-	exists, err := lookup.Exists(context.Background(), 42)
-	require.Error(t, err)
-	errutil.AssertErrorCode(t, err, "CRYPTO_KEYS_LOOKUP_POOL_NIL")
-	assert.False(t, exists, "nil pool MUST NOT report existence")
-}

--- a/cmd/holomush/phase7_fence_wiring_test.go
+++ b/cmd/holomush/phase7_fence_wiring_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/pkg/errutil"
 	pluginauditpb "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
@@ -208,31 +207,6 @@ func TestViolationEmitter_BadEventID_StillEmits(t *testing.T) {
 	)
 	require.NoError(t, err, "malformed row.Id MUST NOT block the emit; zero ULID is acceptable")
 	require.Len(t, inner.published, 1)
-}
-
-// TestIdentityProductionKeySelector_SelectForEncrypt verifies the
-// placeholder selector returns the expected (NameIdentity, "", nil)
-// triple for any subject. Trivial branch coverage; pinned in case a
-// future refactor changes the placeholder behaviour without updating
-// the INV-P7-9 substrate test (which only asserts pointer identity, not
-// return values).
-func TestIdentityProductionKeySelector_SelectForEncrypt(t *testing.T) {
-	t.Parallel()
-	sel := &identityProductionKeySelector{}
-	name, label, err := sel.SelectForEncrypt(context.Background(), "events.any.subject")
-	require.NoError(t, err)
-	assert.Equal(t, codec.NameIdentity, name)
-	assert.Equal(t, codec.KeyLabel(""), label)
-}
-
-// TestIdentityProductionKeySelector_SelectForDecrypt mirrors the encrypt
-// test for the decrypt path.
-func TestIdentityProductionKeySelector_SelectForDecrypt(t *testing.T) {
-	t.Parallel()
-	sel := &identityProductionKeySelector{}
-	key, err := sel.SelectForDecrypt(context.Background(), codec.NameIdentity, codec.KeyID(0))
-	require.NoError(t, err)
-	assert.Equal(t, codec.NoKey, key)
 }
 
 // TestStartsWith covers the tiny stdlib-free prefix helper used by

--- a/cmd/holomush/phase7_fence_wiring_test.go
+++ b/cmd/holomush/phase7_fence_wiring_test.go
@@ -209,42 +209,6 @@ func TestViolationEmitter_BadEventID_StillEmits(t *testing.T) {
 	require.Len(t, inner.published, 1)
 }
 
-// TestStartsWith covers the tiny stdlib-free prefix helper used by
-// buildAlwaysSensitiveSet's plugin-name qualification logic.
-func TestStartsWith(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name   string
-		s      string
-		prefix string
-		want   bool
-	}{
-		{"prefix matches", "core-scenes:secret", "core-scenes:", true},
-		{"empty prefix always matches", "anything", "", true},
-		{"empty string and empty prefix matches", "", "", true},
-		{"prefix longer than string is false", "abc", "abcdef", false},
-		{"prefix-with-different-content false", "core-scenes:secret", "core-comms:", false},
-		{"exact-length match", "abc", "abc", true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, startsWith(tc.s, tc.prefix))
-		})
-	}
-}
-
-// TestBuildAlwaysSensitiveSet_NilManager verifies the documented nil-mgr
-// path: returns an empty (non-nil) map. The other branches (manifest
-// walking, sensitivity filtering, prefix qualification) are exercised
-// by the integration test that boots a real plugin manager with a real
-// manifest declaring crypto.emits[].sensitivity:always.
-func TestBuildAlwaysSensitiveSet_NilManager(t *testing.T) {
-	t.Parallel()
-	out := buildAlwaysSensitiveSet(nil)
-	require.NotNil(t, out, "MUST return non-nil map even for nil mgr (caller iterates without nil-check)")
-	assert.Empty(t, out)
-}
-
 // TestCryptoKeysLookup_NilPool verifies the fail-closed defensive guard
 // against a misconfigured deployment. Production wiring always supplies
 // a non-nil pool; the nil-pool branch is the safety net.

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -334,7 +334,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 	// QueryHistory calls for plugin-owned subjects route to the plugin's
 	// PluginAuditService.QueryHistory RPC instead of the host tiers.
 	js := s.cfg.EventBus.JS()
-	owners := historyOwnersFromPlugins(pluginManager)
+	owners := cryptowiring.OwnerMapFromManager(managerSource{mgr: pluginManager})
 	router := audit.NewPluginHistoryRouter(pluginAuditClientProvider{mgr: pluginManager})
 
 	// INV-39 wiring: if RekeyManager is set (production shape with KEK wired),
@@ -882,49 +882,6 @@ func newHistoryReader(
 		}
 	}
 	return history.NewReader(js, pool, cfg.StreamMaxAge, time.Now, opts...)
-}
-
-// historyOwnersFromPlugins aggregates plugin-declared audit subjects into an
-// audit.OwnerMap. A nil return means no plugins declared ownership, which
-// the reader treats as "host owns everything" — the Phase A default.
-// Returns nil on construction failure and logs the reason; a broken
-// manifest MUST NOT block gRPC start because plugin-owned subjects will
-// still fall through to host storage (which is the safe degradation).
-func historyOwnersFromPlugins(mgr *plugins.Manager) *audit.OwnerMap {
-	if mgr == nil {
-		return nil
-	}
-	decls := mgr.AuditSubjects()
-	if len(decls) == 0 {
-		return nil
-	}
-	// Only claim ownership for plugins that actually have a registered
-	// PluginAuditService client. If a plugin declares subjects in its
-	// manifest but never brought up a service (e.g. crashed at startup),
-	// the audit subsystem leaves those subjects to the host projection;
-	// routing them to the plugin here anyway would make QueryHistory fail
-	// instead of reading from the host archive. Mirrors the filter in
-	// buildAuditSubsystem (core.go).
-	owners := make([]audit.SubjectOwner, 0, len(decls))
-	for _, d := range decls {
-		if _, ok := mgr.PluginAuditClient(d.PluginName); !ok {
-			continue
-		}
-		owners = append(owners, audit.SubjectOwner{
-			PluginName: d.PluginName,
-			Pattern:    d.Subject,
-		})
-	}
-	if len(owners) == 0 {
-		return nil
-	}
-	m, err := audit.NewOwnerMap(owners)
-	if err != nil {
-		slog.Error("history OwnerMap construction failed; plugin-owned subjects will route via host fallback",
-			"error", err)
-		return nil
-	}
-	return m
 }
 
 // pluginAuditClientProvider adapts the plugin manager to the

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -376,7 +376,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 	// PluginConsumerManager — its manifests are populated by now
 	// (DependsOn enforces plugin Start before gRPC Start).
 	alwaysSensitive := cryptowiring.AlwaysSensitiveSet(managerSource{mgr: pluginManager})
-	cryptoKeysLookupForFence := newCryptoKeysLookup(pool)
+	cryptoKeysLookupForFence := cryptowiring.CryptoKeysLookup(pool)
 	// Pass the RAW publisher + registry; newViolationEmitter wraps
 	// internally so the violation event gets exactly one App-Rendering
 	// stamp. The subsystem's primary `publisher` is already a

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -44,6 +44,7 @@ import (
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/internal/naming"
 	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
 	sessionsetup "github.com/holomush/holomush/internal/session/setup"
@@ -374,7 +375,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 	// pluginSub.Manager() the audit closure used to build the
 	// PluginConsumerManager — its manifests are populated by now
 	// (DependsOn enforces plugin Start before gRPC Start).
-	alwaysSensitive := buildAlwaysSensitiveSet(pluginManager)
+	alwaysSensitive := cryptowiring.AlwaysSensitiveSet(managerSource{mgr: pluginManager})
 	cryptoKeysLookupForFence := newCryptoKeysLookup(pool)
 	// Pass the RAW publisher + registry; newViolationEmitter wraps
 	// internally so the violation event gets exactly one App-Rendering

--- a/internal/plugin/cryptowiring/cryptowiring.go
+++ b/internal/plugin/cryptowiring/cryptowiring.go
@@ -20,6 +20,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/history"
+	"github.com/holomush/holomush/pkg/errutil"
 )
 
 // AuditSubjectDecl mirrors the (PluginName, Subject) pair the manager exposes
@@ -89,7 +90,7 @@ func OwnerMapFromManager(src ManifestSource) *audit.OwnerMap {
 	}
 	m, err := audit.NewOwnerMap(owners)
 	if err != nil {
-		slog.Error("cryptowiring: OwnerMap construction failed; plugin-owned subjects route via host fallback", "error", err)
+		errutil.LogError(slog.Default(), "cryptowiring: OwnerMap construction failed; plugin-owned subjects route via host fallback", err)
 		return nil
 	}
 	return m

--- a/internal/plugin/cryptowiring/cryptowiring.go
+++ b/internal/plugin/cryptowiring/cryptowiring.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package cryptowiring holds the plugin-manifest-derived crypto/audit wiring
+// shared by production boot (cmd/holomush) and the integration harness
+// (internal/testsupport/integrationtest). Extracting these derivations keeps
+// the harness faithful to prod's exact ownership/sensitivity routing.
+package cryptowiring
+
+import (
+	"context"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+)
+
+// KeySelector returns a new identity codec.KeySelector. Callers MUST call this
+// once and thread the SAME instance into both audit.PluginConsumerManager
+// (WithKeySelector) and history.NewReader (WithCodecSelector): INV-P7-9 requires
+// pointer-identity across the two sinks, which is the caller's responsibility,
+// not a guarantee of this constructor (it allocates a fresh value per call).
+func KeySelector() codec.KeySelector { return &identityKeySelector{} }
+
+type identityKeySelector struct{}
+
+func (identityKeySelector) SelectForEncrypt(_ context.Context, _ string) (codec.Name, codec.KeyLabel, error) {
+	return codec.NameIdentity, "", nil
+}
+
+func (identityKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ codec.KeyID) (codec.Key, error) {
+	return codec.NoKey, nil
+}

--- a/internal/plugin/cryptowiring/cryptowiring.go
+++ b/internal/plugin/cryptowiring/cryptowiring.go
@@ -9,9 +9,42 @@ package cryptowiring
 
 import (
 	"context"
+	"strings"
 
 	"github.com/holomush/holomush/internal/eventbus/codec"
 )
+
+// ManifestSource is the narrow read surface the derivations need from a loaded
+// plugin set. *plugin.Manager satisfies the richer original API; the prod call
+// sites adapt it (see managerSource in cmd/holomush). Defined as an interface
+// so cryptowiring unit tests use fakes instead of a fully-loaded Manager.
+type ManifestSource interface {
+	ListPlugins() []string
+	// AlwaysSensitiveEmitTypes returns the crypto.emits[] event types declared
+	// sensitivity:always for pluginName (qualified or unqualified).
+	AlwaysSensitiveEmitTypes(pluginName string) []string
+}
+
+// AlwaysSensitiveSet produces the qualified `<plugin>:<event_type>` set the
+// PluginDowngradeFence uses for INV-P7-7. Returns a non-nil empty map when src
+// is nil. Each unqualified event type is prefixed with `<pluginName>:`.
+func AlwaysSensitiveSet(src ManifestSource) map[string]struct{} {
+	out := map[string]struct{}{}
+	if src == nil {
+		return out
+	}
+	for _, name := range src.ListPlugins() {
+		prefix := name + ":"
+		for _, et := range src.AlwaysSensitiveEmitTypes(name) {
+			key := et
+			if !strings.HasPrefix(key, prefix) {
+				key = prefix + key
+			}
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
 
 // KeySelector returns a new identity codec.KeySelector. Callers MUST call this
 // once and thread the SAME instance into both audit.PluginConsumerManager

--- a/internal/plugin/cryptowiring/cryptowiring.go
+++ b/internal/plugin/cryptowiring/cryptowiring.go
@@ -10,15 +10,24 @@ package cryptowiring
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/oops"
 
+	"github.com/holomush/holomush/internal/eventbus/audit"
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/history"
 )
+
+// AuditSubjectDecl mirrors the (PluginName, Subject) pair the manager exposes
+// via AuditSubjects(); redeclared here so ManifestSource stays decoupled.
+type AuditSubjectDecl struct {
+	PluginName string
+	Subject    string
+}
 
 // ManifestSource is the narrow read surface the derivations need from a loaded
 // plugin set. *plugin.Manager satisfies the richer original API; the prod call
@@ -29,6 +38,11 @@ type ManifestSource interface {
 	// AlwaysSensitiveEmitTypes returns the crypto.emits[] event types declared
 	// sensitivity:always for pluginName (qualified or unqualified).
 	AlwaysSensitiveEmitTypes(pluginName string) []string
+	// AuditSubjects returns the plugin-declared audit subject declarations.
+	AuditSubjects() []AuditSubjectDecl
+	// HasAuditClient reports whether the named plugin has a registered
+	// PluginAuditService client.
+	HasAuditClient(pluginName string) bool
 }
 
 // AlwaysSensitiveSet produces the qualified `<plugin>:<event_type>` set the
@@ -50,6 +64,35 @@ func AlwaysSensitiveSet(src ManifestSource) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+// OwnerMapFromManager builds the read-side audit.OwnerMap: a subject is owned
+// iff its plugin has a registered PluginAuditService client. Returns nil when no
+// plugin qualifies (reader treats nil as "host owns everything"). This is the
+// READ-side derivation (ports historyOwnersFromPlugins, sub_grpc.go:892-927). It
+// is intentionally NOT shared with core.go's audit-side derivation, which adds a
+// load-bearing pcm.Add-success gate (spec §1.2).
+func OwnerMapFromManager(src ManifestSource) *audit.OwnerMap {
+	if src == nil {
+		return nil
+	}
+	decls := src.AuditSubjects()
+	owners := make([]audit.SubjectOwner, 0, len(decls))
+	for _, d := range decls {
+		if !src.HasAuditClient(d.PluginName) {
+			continue
+		}
+		owners = append(owners, audit.SubjectOwner{PluginName: d.PluginName, Pattern: d.Subject})
+	}
+	if len(owners) == 0 {
+		return nil
+	}
+	m, err := audit.NewOwnerMap(owners)
+	if err != nil {
+		slog.Error("cryptowiring: OwnerMap construction failed; plugin-owned subjects route via host fallback", "error", err)
+		return nil
+	}
+	return m
 }
 
 // KeySelector returns a new identity codec.KeySelector. Callers MUST call this

--- a/internal/plugin/cryptowiring/cryptowiring.go
+++ b/internal/plugin/cryptowiring/cryptowiring.go
@@ -9,9 +9,15 @@ package cryptowiring
 
 import (
 	"context"
+	"errors"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/samber/oops"
+
 	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/history"
 )
 
 // ManifestSource is the narrow read surface the derivations need from a loaded
@@ -61,4 +67,37 @@ func (identityKeySelector) SelectForEncrypt(_ context.Context, _ string) (codec.
 
 func (identityKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ codec.KeyID) (codec.Key, error) {
 	return codec.NoKey, nil
+}
+
+// CryptoKeysLookup wraps the pool with the Exists query satisfying
+// history.CryptoKeysLookup. Filters destroyed_at IS NULL so destroyed DEKs read
+// as Exists=false (INV-P7-15).
+func CryptoKeysLookup(pool *pgxpool.Pool) history.CryptoKeysLookup {
+	return &cryptoKeysLookup{pool: pool}
+}
+
+type cryptoKeysLookup struct {
+	pool *pgxpool.Pool
+}
+
+func (l *cryptoKeysLookup) Exists(ctx context.Context, dekRef uint64) (bool, error) {
+	if l.pool == nil {
+		return false, oops.Code("CRYPTO_KEYS_LOOKUP_POOL_NIL").
+			Errorf("crypto_keys lookup invoked with nil pool")
+	}
+	const q = `SELECT 1 FROM crypto_keys WHERE id = $1 AND destroyed_at IS NULL LIMIT 1`
+	var one int
+	err := l.pool.QueryRow(ctx, q, dekRef).Scan(&one)
+	if err != nil {
+		// pgx returns ErrNoRows when the row is absent (or destroyed) —
+		// that's the legitimate Exists=false case, NOT an infrastructure
+		// failure.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, oops.Code("CRYPTO_KEYS_LOOKUP_QUERY_FAILED").
+			With("dek_ref", dekRef).
+			Wrap(err)
+	}
+	return true, nil
 }

--- a/internal/plugin/cryptowiring/cryptowiring_integration_test.go
+++ b/internal/plugin/cryptowiring/cryptowiring_integration_test.go
@@ -1,0 +1,31 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package cryptowiring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+	"github.com/holomush/holomush/internal/store"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+func TestCryptoKeysLookupExistsReportsAbsentDEKAsFalse(t *testing.T) {
+	ctx := context.Background()
+	connStr := testutil.FreshDatabase(t, testutil.SharedPostgres(t))
+	es, err := store.NewPostgresEventStore(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(es.Close)
+
+	lookup := cryptowiring.CryptoKeysLookup(es.Pool())
+	exists, err := lookup.Exists(ctx, 999999)
+	require.NoError(t, err)
+	assert.False(t, exists, "absent DEK id must read as Exists=false, not error")
+}

--- a/internal/plugin/cryptowiring/cryptowiring_test.go
+++ b/internal/plugin/cryptowiring/cryptowiring_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package cryptowiring_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+)
+
+func TestKeySelectorReturnsIdentityCodecForEncrypt(t *testing.T) {
+	t.Parallel()
+	sel := cryptowiring.KeySelector()
+	name, label, err := sel.SelectForEncrypt(context.Background(), "events.g1.scene.x.ic")
+	assert.NoError(t, err)
+	assert.Equal(t, codec.NameIdentity, name)
+	assert.Equal(t, codec.KeyLabel(""), label)
+}
+
+func TestKeySelectorReturnsNoKeyForDecrypt(t *testing.T) {
+	t.Parallel()
+	sel := cryptowiring.KeySelector()
+	key, err := sel.SelectForDecrypt(context.Background(), codec.NameIdentity, codec.KeyID(0))
+	assert.NoError(t, err)
+	assert.Equal(t, codec.NoKey, key)
+}

--- a/internal/plugin/cryptowiring/cryptowiring_test.go
+++ b/internal/plugin/cryptowiring/cryptowiring_test.go
@@ -29,3 +29,44 @@ func TestKeySelectorReturnsNoKeyForDecrypt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, codec.NoKey, key)
 }
+
+type fakeLoadedPlugin struct {
+	name        string
+	alwaysTypes []string // event types declared sensitivity:always
+}
+
+type fakeManifestSource struct{ plugins []fakeLoadedPlugin }
+
+func (f fakeManifestSource) ListPlugins() []string {
+	out := make([]string, len(f.plugins))
+	for i, p := range f.plugins {
+		out[i] = p.name
+	}
+	return out
+}
+
+func (f fakeManifestSource) AlwaysSensitiveEmitTypes(pluginName string) []string {
+	for _, p := range f.plugins {
+		if p.name == pluginName {
+			return p.alwaysTypes
+		}
+	}
+	return nil
+}
+
+func TestAlwaysSensitiveSetQualifiesUnqualifiedTypes(t *testing.T) {
+	t.Parallel()
+	src := fakeManifestSource{plugins: []fakeLoadedPlugin{
+		{name: "core-scenes", alwaysTypes: []string{"scene_pose", "core-scenes:scene_say"}},
+	}}
+	got := cryptowiring.AlwaysSensitiveSet(src)
+	assert.Equal(t, map[string]struct{}{
+		"core-scenes:scene_pose": {},
+		"core-scenes:scene_say":  {},
+	}, got)
+}
+
+func TestAlwaysSensitiveSetEmptyForNilSource(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, cryptowiring.AlwaysSensitiveSet(nil))
+}

--- a/internal/plugin/cryptowiring/cryptowiring_test.go
+++ b/internal/plugin/cryptowiring/cryptowiring_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+	"github.com/holomush/holomush/pkg/errutil"
 )
 
 func TestKeySelectorReturnsIdentityCodecForEncrypt(t *testing.T) {
@@ -69,4 +71,13 @@ func TestAlwaysSensitiveSetQualifiesUnqualifiedTypes(t *testing.T) {
 func TestAlwaysSensitiveSetEmptyForNilSource(t *testing.T) {
 	t.Parallel()
 	assert.Empty(t, cryptowiring.AlwaysSensitiveSet(nil))
+}
+
+func TestCryptoKeysLookupNilPoolReturnsError(t *testing.T) {
+	t.Parallel()
+	lookup := cryptowiring.CryptoKeysLookup(nil)
+	exists, err := lookup.Exists(context.Background(), 42)
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "CRYPTO_KEYS_LOOKUP_POOL_NIL")
+	assert.False(t, exists, "nil pool MUST NOT report existence")
 }

--- a/internal/plugin/cryptowiring/cryptowiring_test.go
+++ b/internal/plugin/cryptowiring/cryptowiring_test.go
@@ -33,8 +33,10 @@ func TestKeySelectorReturnsNoKeyForDecrypt(t *testing.T) {
 }
 
 type fakeLoadedPlugin struct {
-	name        string
-	alwaysTypes []string // event types declared sensitivity:always
+	name          string
+	alwaysTypes   []string // event types declared sensitivity:always
+	auditSubjects []string
+	hasClient     bool
 }
 
 type fakeManifestSource struct{ plugins []fakeLoadedPlugin }
@@ -80,4 +82,45 @@ func TestCryptoKeysLookupNilPoolReturnsError(t *testing.T) {
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "CRYPTO_KEYS_LOOKUP_POOL_NIL")
 	assert.False(t, exists, "nil pool MUST NOT report existence")
+}
+
+func (f fakeManifestSource) AuditSubjects() []cryptowiring.AuditSubjectDecl {
+	var out []cryptowiring.AuditSubjectDecl
+	for _, p := range f.plugins {
+		for _, s := range p.auditSubjects {
+			out = append(out, cryptowiring.AuditSubjectDecl{PluginName: p.name, Subject: s})
+		}
+	}
+	return out
+}
+
+func (f fakeManifestSource) HasAuditClient(name string) bool {
+	for _, p := range f.plugins {
+		if p.name == name {
+			return p.hasClient
+		}
+	}
+	return false
+}
+
+func TestOwnerMapFromManagerOmitsPluginsWithoutRegisteredClient(t *testing.T) {
+	t.Parallel()
+	src := fakeManifestSource{plugins: []fakeLoadedPlugin{
+		{name: "core-scenes", auditSubjects: []string{"events.*.scene.>"}, hasClient: true},
+		{name: "ghost", auditSubjects: []string{"events.*.ghost.>"}, hasClient: false}, // no client → omitted
+	}}
+	om := cryptowiring.OwnerMapFromManager(src)
+	require.NotNil(t, om)
+	assert.Equal(t, "core-scenes", om.Resolve("events.g1.scene.abc").PluginName)
+	assert.Empty(t, om.Resolve("events.g1.ghost.abc").PluginName, "ghost has no client → not owned (host fallback)")
+}
+
+func TestOwnerMapFromManagerNilWhenNoOwners(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, cryptowiring.OwnerMapFromManager(fakeManifestSource{}))
+}
+
+func TestOwnerMapFromManagerNilSourceReturnsNil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, cryptowiring.OwnerMapFromManager(nil))
 }

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -9,22 +9,35 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/audit"
+	"github.com/holomush/holomush/internal/eventbus/authguard"
+	authguardaudit "github.com/holomush/holomush/internal/eventbus/authguard/audit"
 	"github.com/holomush/holomush/internal/eventbus/codec"
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
-	"github.com/holomush/holomush/internal/eventbus/subjectxlate"
+	"github.com/holomush/holomush/internal/eventbus/history"
+	"github.com/holomush/holomush/internal/idgen"
+	"github.com/holomush/holomush/internal/pgnanos"
+	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/cryptowiring"
 	worldpg "github.com/holomush/holomush/internal/world/postgres"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
 // WithPluginCrypto wires the full plugin-crypto round-trip (emit fence → publish
@@ -45,6 +58,15 @@ type pluginCrypto struct {
 	dekMgr    dek.Manager
 	selector  codec.KeySelector
 	publisher eventbus.Publisher // crypto-enabled (DEK + identity selector), rendering-wrapped
+	// actorID is the stable character actor stamped on emits (EmitPluginEvent).
+	// Fixed per Server so the actor persisted to scene_log round-trips byte-equal
+	// into the read-back AAD.
+	actorID ulid.ULID
+	// sceneID is the stable scene the emitted scene_* events belong to. The
+	// subject is events.<game_id>.scene.<sceneID>.ic; a row is seeded in
+	// plugin_core_scenes.scenes so core-scenes' InsertScenePose FK/UPDATE
+	// (scenes.total_pose_count … RETURNING) finds the scene.
+	sceneID ulid.ULID
 }
 
 // newPluginCrypto builds the test crypto substrate: ephemeral KEK → DEK manager
@@ -79,12 +101,48 @@ func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Poo
 	)
 	require.NoError(t, err, "newPluginCrypto: dek.NewManager")
 
+	// The RenderingPublisher (wrapped below) looks up a verb for every emitted
+	// event type. core-scenes registers its scene event types as crypto.emits
+	// (not manifest verbs:), so the bootstrap registry has no entry — register
+	// them here so plugin emits resolve. Mirrors the reference round-trip test
+	// (test/integration/crypto/readback_test.go:141) which registers the scene
+	// emit type as a verb before emitting.
+	registerSceneEmitVerbs(t, verbReg)
+
 	sel := cryptowiring.KeySelector()
 	raw := bus.Bus.Publisher(eventbus.WithDEKManager(dekMgr), eventbus.WithCodecSelector(sel))
 	return &pluginCrypto{
 		dekMgr:    dekMgr,
 		selector:  sel,
 		publisher: eventbus.NewRenderingPublisher(raw, verbReg),
+		actorID:   idgen.New(),
+		sceneID:   idgen.New(),
+	}
+}
+
+// registerSceneEmitVerbs registers core-scenes' plugin-owned scene event types
+// as rendering verbs so the RenderingPublisher resolves them on the plugin emit
+// path. The list mirrors core-scenes' phase4EmitTypes (sensitive IC content) +
+// phase6EmitTypes (publication notices); the harness can't import the
+// `package main` plugin, so the set is duplicated here. RegisterWithSource is
+// idempotent-safe for fresh per-test registries.
+func registerSceneEmitVerbs(t *testing.T, verbReg *core.VerbRegistry) {
+	t.Helper()
+	sceneEmitTypes := []string{
+		"scene_pose", "scene_say", "scene_emit", "scene_ooc",
+		"scene_join_ic", "scene_leave_ic", "scene_pose_order_changed_ic", "scene_idle_nudge",
+		"scene_publish_started", "scene_publish_vote_cast", "scene_publish_cooloff_started",
+		"scene_publish_resolved", "scene_publish_withdrawn", "scene_publish_vote_attempts_extended",
+	}
+	for _, et := range sceneEmitTypes {
+		require.NoErrorf(t, verbReg.RegisterWithSource(core.VerbRegistration{
+			Type:          et,
+			Category:      "communication",
+			Format:        "speech",
+			Label:         et,
+			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+			Source:        "core-scenes",
+		}, "1.0.0"), "registerSceneEmitVerbs: register %q", et)
 	}
 }
 
@@ -113,18 +171,30 @@ func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payload
 	require.Truef(s.t, ok, "integrationtest.Server.EmitPluginEvent: plugin %q not loaded", plugin)
 	require.NotEmptyf(s.t, dp.Manifest.Emits,
 		"integrationtest.Server.EmitPluginEvent: plugin %q declares no emit namespaces", plugin)
-	legacySubject := dp.Manifest.Emits[0] + ":" + eventType
+
+	// Build a well-formed scene IC subject: events.<game_id>.scene.<sceneID>.ic.
+	// core-scenes' AuditEvent handler routes scene_pose through InsertScenePose,
+	// which calls parseSceneSubject (requires the 5-token <id>.<channel> shape,
+	// audit.go:629) and UPDATEs scenes WHERE id=<sceneID> … RETURNING (requires
+	// the seeded scene row). A bare "scene:scene_pose" subject would fail both.
+	natsSubject := "events." + s.bus.Bus.GameID() + ".scene." + s.pluginCrypto.sceneID.String() + ".ic"
+
+	// Stamp the host event actor the emitter requires (event_emitter.go::Emit →
+	// actorFromContext). Production stamps it at the command-dispatch / host-RPC
+	// boundary; this helper bypasses dispatch, so it stamps directly. A character
+	// actor is in core-scenes' actor_kinds_claimable list ([plugin, character])
+	// and is what scene_pose ingest requires. The actor's (kind, id) is persisted
+	// to scene_log and rebuilt verbatim into the read-back AAD, so it MUST be
+	// stable per emit — s.pluginCrypto.actorID is allocated once per Server.
+	ctx = core.WithActor(ctx, core.Actor{Kind: core.ActorCharacter, ID: s.pluginCrypto.actorID.String()})
 
 	err := s.pluginSub.Manager().EmitPluginEvent(ctx, plugin, pluginsdk.EmitEvent{
-		Stream:    legacySubject,
+		Stream:    natsSubject, // already a dot-style events.<gid>.scene.<id>.ic subject; passed through unchanged
 		Type:      pluginsdk.EventType(eventType),
 		Payload:   payloadJSON,
 		Sensitive: sensitive,
 	})
 	require.NoError(s.t, err, "integrationtest.Server.EmitPluginEvent: Manager.EmitPluginEvent")
-
-	natsSubject, err := subjectxlate.Legacy(legacySubject, s.bus.Bus.GameID())
-	require.NoError(s.t, err, "integrationtest.Server.EmitPluginEvent: subjectxlate.Legacy")
 
 	return EmittedEvent{SubjectStr: natsSubject}
 }
@@ -161,5 +231,320 @@ func (s *Server) DEKRowCount(ctx context.Context) int {
 func (s *Server) requirePluginCrypto(method string) {
 	if s.pluginCrypto == nil {
 		panic("integrationtest: " + method + "() requires Start(t, WithInTreePlugins(), WithPluginCrypto())")
+	}
+}
+
+// --- Task 8: audit projection (link 3) + read-back decryptor (link 4) ---
+
+// pluginAuditClientAdapter bridges the proto-generated
+// pluginv1.PluginAuditServiceClient to the narrow audit.PluginAuditClient
+// interface the PluginConsumerManager dispatch path consumes. Mirrors the
+// production adapter at cmd/holomush/core.go:1165-1180.
+type pluginAuditClientAdapter struct {
+	client pluginv1.PluginAuditServiceClient
+}
+
+func (a pluginAuditClientAdapter) AuditEvent(ctx context.Context, req *pluginv1.AuditEventRequest) (*pluginv1.AuditEventResponse, error) {
+	resp, err := a.client.AuditEvent(ctx, req)
+	if err != nil {
+		return nil, oops.Code("AUDIT_PLUGIN_RPC_FAILED").Wrap(err)
+	}
+	return resp, nil
+}
+
+// startPluginConsumers wires the per-plugin audit projection (link 3): a
+// PluginConsumerManager whose consumers ack-and-forward each plugin-owned
+// subject's deliveries to that plugin's PluginAuditService.AuditEvent RPC,
+// which projects the (encrypted) event into the plugin's audit table (e.g.
+// plugin_core_scenes.scene_log). Mirrors cmd/holomush/core.go:556-591.
+//
+// INV-P7-9: the SAME codec.KeySelector instance threaded here MUST also feed
+// the read-side history reader; the caller (Start) owns that pointer identity
+// by passing pc.selector to both sinks.
+func startPluginConsumers(t *testing.T, ctx context.Context, bus *eventbustest.Embedded, mgr *plugins.Manager, sel codec.KeySelector) *audit.PluginConsumerManager {
+	t.Helper()
+	pcm := audit.NewPluginConsumerManager(bus.JS, audit.WithKeySelector(sel))
+	byPlugin := map[string][]string{}
+	for _, d := range mgr.AuditSubjects() {
+		byPlugin[d.PluginName] = append(byPlugin[d.PluginName], d.Subject)
+	}
+	for name, subjects := range byPlugin {
+		client, ok := mgr.PluginAuditClient(name)
+		if !ok {
+			continue
+		}
+		require.NoErrorf(t, pcm.Add(ctx, audit.PluginConsumerConfig{
+			PluginName: name,
+			Subjects:   subjects,
+			Client:     pluginAuditClientAdapter{client: client},
+		}), "startPluginConsumers: pcm.Add %s", name)
+	}
+	// Start begins the Consume loops; without it the registered consumers never
+	// dispatch deliveries (plugin_consumer.go:235 gates consumption on started).
+	require.NoError(t, pcm.Start(ctx), "startPluginConsumers: pcm.Start")
+	return pcm
+}
+
+// countingAuditEmitter wraps a SessionAuditEmitter, incrementing an atomic
+// counter SYNCHRONOUSLY on every EmitPluginDecrypt call. The read-back path
+// (history.decryptPluginRow) calls EmitPluginDecrypt inline during
+// DecryptOwnRow, so the count is observable the instant ReadBackOwnRows returns
+// — unlike the underlying authguardaudit.Emitter, which enqueues and PUBLISHES
+// the audit event on a drain goroutine (async). Counting at the publish seam
+// would race the suite's synchronous ReadBackAuditCount read. The audit record
+// is ALSO published to audit.<game_id>.plugin_decrypt.<plugin>, which the EVENTS
+// stream (subject filter events.>) does not capture, so reading the count off
+// the stream is not an option either.
+type countingAuditEmitter struct {
+	inner eventbus.SessionAuditEmitter
+	n     *atomic.Int64
+}
+
+func (c countingAuditEmitter) EmitPluginDecrypt(ctx context.Context, rec eventbus.PluginDecryptRecord) error {
+	c.n.Add(1)
+	return c.inner.EmitPluginDecrypt(ctx, rec)
+}
+
+// seedScene inserts the scene row the scene_pose projection path requires.
+// MUST run after plugins load (the plugin_core_scenes schema + migrations are
+// created during core-scenes Init). created_at is BIGINT epoch-ns (migration
+// 000007); owner_id is the emit actor.
+func (s *Server) seedScene(ctx context.Context, pc *pluginCrypto) {
+	s.t.Helper()
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO plugin_core_scenes.scenes (id, title, owner_id, created_at)
+		 VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING`,
+		pc.sceneID.String(), "plugincrypto round-trip scene", pc.actorID.String(),
+		time.Now().UTC().UnixNano())
+	require.NoError(s.t, err, "integrationtest.seedScene: insert plugin_core_scenes.scenes")
+}
+
+// configureReadback wires the read-back decryptor (link 4): the REAL
+// SessionBridgeGuard (DEK-participant + plugin-manifest lookups + ABAC engine +
+// backpressure) plus the audit-chain emitter, threaded into the Manager so the
+// DecryptOwnAuditRows host RPC (and the harness's ReadBackOwnRows helper)
+// recover plaintext from a plugin's own encrypted audit rows and emit the INV-19
+// read-back audit record. Mirrors cmd/holomush/sub_grpc.go:347-366,478-485.
+// Pure construction — takes no context (all New* calls below are synchronous).
+func (s *Server) configureReadback(pc *pluginCrypto) {
+	mgr := s.pluginSub.Manager()
+
+	auditEm, err := authguardaudit.NewQueuedEmitter(pc.publisher, authguardaudit.WithGameID(s.bus.Bus.GameID()))
+	require.NoError(s.t, err, "integrationtest.configureReadback: NewQueuedEmitter")
+	s.readbackAuditEm = auditEm
+	sessionBridgeEm, err := authguardaudit.NewSessionBridgeEmitter(auditEm)
+	require.NoError(s.t, err, "integrationtest.configureReadback: NewSessionBridgeEmitter")
+	// Wrap so ReadBackAuditCount observes the emission synchronously (see
+	// countingAuditEmitter). The guard's BackpressureChecker still uses the raw
+	// auditEm (throttle state lives there); only the read-back audit-emit seam
+	// fed to the decryptor is wrapped.
+	countingEm := countingAuditEmitter{inner: sessionBridgeEm, n: &s.readbackAuditCount}
+
+	guard, err := authguard.New(
+		authguard.NewDEKParticipantLookup(pc.dekMgr),
+		authguard.NewPluginManifestLookup(mgr),
+		s.accessEngine, // ABACEngine — never invoked on the plugin-readback path
+		auditEm,        // BackpressureChecker — fresh QueuedEmitter ⇒ no throttle
+	)
+	require.NoError(s.t, err, "integrationtest.configureReadback: authguard.New")
+
+	src := managerSourceForHarness{mgr: mgr}
+	decryptor := history.NewReadbackDecryptor(
+		cryptowiring.OwnerMapFromManager(src),
+		cryptowiring.AlwaysSensitiveSet(src),
+		cryptowiring.CryptoKeysLookup(s.pool),
+		authguard.NewSessionBridgeGuard(guard),
+		pc.dekMgr,
+		countingEm,
+	)
+	// Wire into the Manager so the binary plugin's DecryptOwnAuditRows host RPC
+	// uses it (production parity), AND retain the concrete decryptor so the
+	// harness's ReadBackOwnRows helper can drive it directly without the RPC.
+	mgr.ConfigureReadbackDecryptor(decryptor)
+	s.readbackDecryptor = decryptor
+}
+
+// managerSourceForHarness adapts *plugins.Manager to
+// cryptowiring.ManifestSource — the harness copy of cmd/holomush's
+// managerSource (cryptowiring_adapter.go). It supplies the read surface the
+// OwnerMap (g1 gate) and always-sensitive fence set derivations need.
+type managerSourceForHarness struct{ mgr *plugins.Manager }
+
+func (s managerSourceForHarness) ListPlugins() []string { return s.mgr.ListPlugins() }
+
+func (s managerSourceForHarness) AlwaysSensitiveEmitTypes(name string) []string {
+	dp, ok := s.mgr.GetLoadedPlugin(name)
+	if !ok || dp.Manifest == nil || dp.Manifest.Crypto == nil {
+		return nil
+	}
+	var out []string
+	for _, emit := range dp.Manifest.Crypto.Emits {
+		if emit.Sensitivity == plugins.SensitivityAlways {
+			out = append(out, emit.EventType)
+		}
+	}
+	return out
+}
+
+func (s managerSourceForHarness) AuditSubjects() []cryptowiring.AuditSubjectDecl {
+	decls := s.mgr.AuditSubjects()
+	out := make([]cryptowiring.AuditSubjectDecl, 0, len(decls))
+	for _, d := range decls {
+		out = append(out, cryptowiring.AuditSubjectDecl{PluginName: d.PluginName, Subject: d.Subject})
+	}
+	return out
+}
+
+func (s managerSourceForHarness) HasAuditClient(name string) bool {
+	_, ok := s.mgr.PluginAuditClient(name)
+	return ok
+}
+
+var _ cryptowiring.ManifestSource = managerSourceForHarness{}
+
+// PluginAuditRow mirrors the scene_log columns the host read-back decrypt
+// primitive needs to rebuild a *pluginv1.AuditRow with byte-equal AAD
+// (id/subject/type/timestamp/actor.kind/actor.id/codec/dek_ref/dek_version) —
+// see plugins/core-scenes/publish_snapshot.go::logRowToAuditRow.
+type PluginAuditRow struct {
+	ID         []byte
+	Subject    string
+	Type       string
+	Timestamp  pgnanos.Time
+	ActorKind  string
+	ActorID    []byte
+	Payload    []byte
+	SchemaVer  int16
+	Codec      string
+	DEKRef     *int64
+	DEKVersion *int32
+}
+
+// ReadBackResult is one decrypted read-back outcome. Exactly one of Plaintext
+// (clean decrypt) or Denied (the host decryptor refused the row via the g1
+// ownership gate or g2 manifest/AuthGuard gate) is meaningful.
+type ReadBackResult struct {
+	Plaintext string
+	Denied    bool
+}
+
+// QueryPluginAuditRows reads the projected rows for (plugin, subject) from the
+// plugin's audit table. Only "core-scenes" is wired today (it projects to
+// plugin_core_scenes.scene_log; the read mirrors ReadSceneLogForSnapshot's
+// column set) — any other plugin name fails the test via require. Panics via
+// requirePluginCrypto if the substrate was not wired.
+func (s *Server) QueryPluginAuditRows(ctx context.Context, plugin, subject string) []PluginAuditRow {
+	s.requirePluginCrypto("QueryPluginAuditRows")
+	s.t.Helper()
+	require.Equalf(s.t, "core-scenes", plugin,
+		"integrationtest.QueryPluginAuditRows: only core-scenes (plugin_core_scenes.scene_log) is wired, got %q", plugin)
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, subject, type, timestamp, actor_kind, actor_id, payload, schema_ver, codec, dek_ref, dek_version
+		FROM plugin_core_scenes.scene_log
+		WHERE subject = $1
+		ORDER BY id ASC
+	`, subject)
+	require.NoError(s.t, err, "integrationtest.QueryPluginAuditRows: query scene_log")
+	defer rows.Close()
+
+	var out []PluginAuditRow
+	for rows.Next() {
+		var r PluginAuditRow
+		require.NoError(s.t, rows.Scan(
+			&r.ID, &r.Subject, &r.Type, &r.Timestamp, &r.ActorKind, &r.ActorID,
+			&r.Payload, &r.SchemaVer, &r.Codec, &r.DEKRef, &r.DEKVersion,
+		), "integrationtest.QueryPluginAuditRows: scan scene_log row")
+		out = append(out, r)
+	}
+	require.NoError(s.t, rows.Err(), "integrationtest.QueryPluginAuditRows: iterate scene_log rows")
+	return out
+}
+
+// ReadBackOwnRows decrypts each row as plugin's own via the read-back decryptor
+// (link 4): real SessionBridgeGuard authorization + DEK decrypt + INV-19 audit
+// emission. Results are 1:1 with rows in request order. A refused row
+// (g1 not_owner / g2 manifest-or-AuthGuard deny / fail-closed) maps to
+// Denied=true with empty Plaintext. Panics via requirePluginCrypto if the
+// substrate was not wired.
+func (s *Server) ReadBackOwnRows(ctx context.Context, plugin string, rows []PluginAuditRow) []ReadBackResult {
+	s.requirePluginCrypto("ReadBackOwnRows")
+	s.t.Helper()
+	require.NotNil(s.t, s.readbackDecryptor, "integrationtest.ReadBackOwnRows: read-back decryptor not configured")
+
+	out := make([]ReadBackResult, 0, len(rows))
+	for i := range rows {
+		// instanceID "" mirrors the realDecryptorAdapter test seam
+		// (plugins/core-scenes/publish_snapshot_integration_test.go:156).
+		res := s.readbackDecryptor.DecryptOwnRow(ctx, plugin, "", auditRowToProto(&rows[i]))
+		if reason := res.GetNoPlaintextReason(); reason != "" {
+			out = append(out, ReadBackResult{Denied: true})
+			continue
+		}
+		out = append(out, ReadBackResult{Plaintext: string(res.GetPlaintext())})
+	}
+	return out
+}
+
+// ReadBackAuditCount returns the number of read-back audit emissions the
+// read-back path has produced so far. The count is incremented SYNCHRONOUSLY by
+// countingAuditEmitter on each EmitPluginDecrypt (called inline during
+// DecryptOwnRow), so it is observable the instant ReadBackOwnRows returns — no
+// Eventually polling needed. Panics via requirePluginCrypto if the substrate
+// was not wired.
+func (s *Server) ReadBackAuditCount(_ context.Context) int {
+	s.requirePluginCrypto("ReadBackAuditCount")
+	s.t.Helper()
+	return int(s.readbackAuditCount.Load())
+}
+
+// auditRowToProto rebuilds the *pluginv1.AuditRow from a scene_log PluginAuditRow
+// field-for-field, mirroring plugins/core-scenes/publish_snapshot.go::
+// logRowToAuditRow so the AAD the host rebuilds (AuditRowToEvent + aad.Build) is
+// byte-equal to the encrypt-side AAD (INV-RB-4 / INV-TS-5).
+func auditRowToProto(r *PluginAuditRow) *pluginv1.AuditRow {
+	out := &pluginv1.AuditRow{
+		Id:        r.ID,
+		Subject:   r.Subject,
+		Type:      r.Type,
+		Timestamp: timestamppb.New(r.Timestamp.Time()),
+		Actor:     actorProtoFromHarnessRow(r.ActorKind, r.ActorID),
+		Codec:     r.Codec,
+		Payload:   r.Payload,
+		SchemaVer: int32(r.SchemaVer),
+	}
+	if r.DEKRef != nil {
+		v := uint64(*r.DEKRef) //nolint:gosec // scene_log.dek_ref is BIGINT from crypto_keys.id (>= 0); int64→uint64 widening is safe
+		out.DekRef = &v
+	}
+	if r.DEKVersion != nil {
+		v := uint32(*r.DEKVersion) //nolint:gosec // scene_log.dek_version is a 1-based counter (>= 0); int32→uint32 widening is safe
+		out.DekVersion = &v
+	}
+	return out
+}
+
+// actorProtoFromHarnessRow mirrors plugins/core-scenes/audit.go::
+// actorProtoFromRow + actorKindFromString so the rebuilt Actor matches the
+// projected row's stored actor exactly (AAD round-trip).
+func actorProtoFromHarnessRow(kind string, id []byte) *eventbusv1.Actor {
+	if kind == "" && len(id) == 0 {
+		return nil
+	}
+	return &eventbusv1.Actor{Kind: harnessActorKindFromString(kind), Id: id}
+}
+
+func harnessActorKindFromString(s string) eventbusv1.ActorKind {
+	switch s {
+	case "ACTOR_KIND_CHARACTER", "character":
+		return eventbusv1.ActorKind_ACTOR_KIND_CHARACTER
+	case "ACTOR_KIND_SYSTEM", "system":
+		return eventbusv1.ActorKind_ACTOR_KIND_SYSTEM
+	case "ACTOR_KIND_PLUGIN", "plugin":
+		return eventbusv1.ActorKind_ACTOR_KIND_PLUGIN
+	case "ACTOR_KIND_PLAYER", "player":
+		return eventbusv1.ActorKind_ACTOR_KIND_PLAYER
+	default:
+		return eventbusv1.ActorKind_ACTOR_KIND_UNSPECIFIED
 	}
 }

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -5,6 +5,28 @@
 
 package integrationtest
 
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
+	"github.com/holomush/holomush/internal/eventbus/eventbustest"
+	"github.com/holomush/holomush/internal/eventbus/subjectxlate"
+	"github.com/holomush/holomush/internal/plugin/cryptowiring"
+	worldpg "github.com/holomush/holomush/internal/world/postgres"
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
 // WithPluginCrypto wires the full plugin-crypto round-trip (emit fence → publish
 // encrypt → audit projection → read-back) into the harness. REQUIRES
 // WithInTreePlugins (the emitter, per-plugin consumer, and read-back decryptor
@@ -14,4 +36,130 @@ package integrationtest
 // §6.2). Drive only crypto-correct plugins (e.g. core-scenes) under this option.
 func WithPluginCrypto() StartOption {
 	return func(c *startConfig) { c.withPluginCrypto = true }
+}
+
+// pluginCrypto bundles the test crypto substrate: an ephemeral KEK, a
+// pool-backed DEK manager (so DEKs persist to crypto_keys), and a
+// crypto-enabled publisher over the embedded bus.
+type pluginCrypto struct {
+	dekMgr    dek.Manager
+	selector  codec.KeySelector
+	publisher eventbus.Publisher // crypto-enabled (DEK + identity selector), rendering-wrapped
+}
+
+// newPluginCrypto builds the test crypto substrate: ephemeral KEK → DEK manager
+// (pool-backed Store, so DEKs persist to crypto_keys) → a crypto-enabled
+// publisher over the embedded bus. Mirrors holomushtest.newKEKProvider
+// (server.go:492-505) + dek.NewManager (server.go:404-409).
+//
+// The publisher is wired WithDEKManager so that sensitive events
+// (event.Sensitive=true) take the encrypt branch in JetStreamPublisher.Publish
+// (publisher.go:208-225): that branch ignores the codec selector and uses
+// codec.NameXChaCha20v1 with a DEK from GetOrCreate, persisting a crypto_keys
+// row and stamping App-Dek-Ref. The identity KeySelector wired via
+// WithCodecSelector only governs the non-sensitive (default) path.
+func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Pool, verbReg *core.VerbRegistry) *pluginCrypto {
+	t.Helper()
+	ctx := context.Background()
+
+	kekBytes := make([]byte, kek.KEKByteLength)
+	_, err := rand.Read(kekBytes)
+	require.NoError(t, err, "newPluginCrypto: read KEK bytes")
+	const envName = "HOLOMUSH_TEST_KEK_PLUGINCRYPTO"
+	t.Setenv(envName, hex.EncodeToString(kekBytes))
+	provider, err := kek.NewLocalAEADProviderForUnitTest(ctx, kek.NewEnvSource(envName, false))
+	require.NoError(t, err, "newPluginCrypto: KEK provider")
+
+	cacheCfg := dek.CacheConfig{Capacity: 64, TTL: time.Minute}
+	dekMgr, err := dek.NewManager(
+		provider, dek.NewStore(pool),
+		dek.NewCache(cacheCfg), dek.NewParticipantsCache(cacheCfg),
+		func(_ context.Context, _ dek.ContextID, _ string, _, _ uint32) error { return nil }, // noop invalidator
+		worldpg.NewBindingRepository(pool),                                                   // satisfies dek.BindingResolver via Current
+	)
+	require.NoError(t, err, "newPluginCrypto: dek.NewManager")
+
+	sel := cryptowiring.KeySelector()
+	raw := bus.Bus.Publisher(eventbus.WithDEKManager(dekMgr), eventbus.WithCodecSelector(sel))
+	return &pluginCrypto{
+		dekMgr:    dekMgr,
+		selector:  sel,
+		publisher: eventbus.NewRenderingPublisher(raw, verbReg),
+	}
+}
+
+// EmittedEvent is the result of EmitPluginEvent, carrying the translated NATS
+// subject for wire assertions.
+type EmittedEvent struct{ SubjectStr string }
+
+// EmitPluginEvent drives a real plugin emit through the Manager's
+// EmitPluginEvent boundary (the same path core-scenes commands use), returning
+// the translated NATS subject for wire assertions.
+//
+// The legacy colon-style subject is derived as "<plugin>:<eventType>" — a
+// well-formed legacy subject whose namespace token matches the plugin's
+// declared emit namespace. The NATS subject returned mirrors the translation
+// the emitter itself performs (subjectxlate.Legacy), so WireCodecFor can read
+// the JetStream message by subject. Panics via requirePluginCrypto if the
+// substrate was not wired.
+func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payloadJSON string, sensitive bool) EmittedEvent {
+	s.requirePluginCrypto("EmitPluginEvent")
+	s.t.Helper()
+
+	// Legacy colon-style subject: namespace token MUST be a namespace the
+	// plugin declares in its manifest `emits:` (the emitter rejects otherwise).
+	// core-scenes declares `emits: [scene]`, so the namespace is "scene".
+	dp, ok := s.pluginSub.Manager().GetLoadedPlugin(plugin)
+	require.Truef(s.t, ok, "integrationtest.Server.EmitPluginEvent: plugin %q not loaded", plugin)
+	require.NotEmptyf(s.t, dp.Manifest.Emits,
+		"integrationtest.Server.EmitPluginEvent: plugin %q declares no emit namespaces", plugin)
+	legacySubject := dp.Manifest.Emits[0] + ":" + eventType
+
+	err := s.pluginSub.Manager().EmitPluginEvent(ctx, plugin, pluginsdk.EmitEvent{
+		Stream:    legacySubject,
+		Type:      pluginsdk.EventType(eventType),
+		Payload:   payloadJSON,
+		Sensitive: sensitive,
+	})
+	require.NoError(s.t, err, "integrationtest.Server.EmitPluginEvent: Manager.EmitPluginEvent")
+
+	natsSubject, err := subjectxlate.Legacy(legacySubject, s.bus.Bus.GameID())
+	require.NoError(s.t, err, "integrationtest.Server.EmitPluginEvent: subjectxlate.Legacy")
+
+	return EmittedEvent{SubjectStr: natsSubject}
+}
+
+// WireCodecFor reads the App-Codec header on the most recent JetStream message
+// for the subject. Returns codec.NameIdentity if no message is present yet (so
+// the suite's Eventually(...).ShouldNot(Equal(NameIdentity)) polls until the
+// encrypted message lands). Panics via requirePluginCrypto if the substrate was
+// not wired.
+func (s *Server) WireCodecFor(_ context.Context, subject string) codec.Name {
+	s.requirePluginCrypto("WireCodecFor")
+	s.t.Helper()
+
+	msgs := s.bus.RawMessagesOnSubject(s.t, subject, 1, eventbustest.DefaultAwaitTimeout)
+	if len(msgs) == 0 {
+		return codec.NameIdentity
+	}
+	return codec.Name(msgs[len(msgs)-1].Header.Get(eventbus.HeaderCodec))
+}
+
+// DEKRowCount counts rows in crypto_keys. Panics via requirePluginCrypto if the
+// substrate was not wired.
+func (s *Server) DEKRowCount(ctx context.Context) int {
+	s.requirePluginCrypto("DEKRowCount")
+	s.t.Helper()
+
+	var n int
+	err := s.pool.QueryRow(ctx, `SELECT count(*) FROM crypto_keys`).Scan(&n)
+	require.NoError(s.t, err, "integrationtest.Server.DEKRowCount: count crypto_keys")
+	return n
+}
+
+// requirePluginCrypto panics if WithPluginCrypto was not passed to Start.
+func (s *Server) requirePluginCrypto(method string) {
+	if s.pluginCrypto == nil {
+		panic("integrationtest: " + method + "() requires Start(t, WithInTreePlugins(), WithPluginCrypto())")
+	}
 }

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest
+
+// WithPluginCrypto wires the full plugin-crypto round-trip (emit fence → publish
+// encrypt → audit projection → read-back) into the harness. REQUIRES
+// WithInTreePlugins (the emitter, per-plugin consumer, and read-back decryptor
+// all need the loaded Manager). Assumes crypto-CORRECT plugins: WithCryptoEnabled
+// is global to the shared emitter, so a loaded plugin that emits
+// sensitivity:always content without claiming Sensitive=true would reject (spec
+// §6.2). Drive only crypto-correct plugins (e.g. core-scenes) under this option.
+func WithPluginCrypto() StartOption {
+	return func(c *startConfig) { c.withPluginCrypto = true }
+}

--- a/internal/testsupport/integrationtest/crypto_test.go
+++ b/internal/testsupport/integrationtest/crypto_test.go
@@ -6,9 +6,12 @@
 package integrationtest
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
 )
 
 // INV-5IA-2: WithPluginCrypto without WithInTreePlugins must panic.
@@ -16,4 +19,33 @@ func TestWithPluginCryptoWithoutPluginsPanics(t *testing.T) {
 	assert.PanicsWithValue(t,
 		"integrationtest: WithPluginCrypto() requires WithInTreePlugins()",
 		func() { Start(t, WithPluginCrypto()) })
+}
+
+// INV-5IA-1: WithInTreePlugins ALONE must NOT wire plugin crypto. A crypto-only
+// helper called without WithPluginCrypto panics via requirePluginCrypto, proving
+// the substrate is unwired (the census suite already runs WithInTreePlugins-only).
+func TestWithInTreePluginsAloneDoesNotWireCrypto(t *testing.T) {
+	ts := Start(t, WithInTreePlugins())
+	defer ts.Stop()
+	assert.Panics(t, func() {
+		ts.EmitPluginEvent(context.Background(), "core-scenes", "scene_pose", `{"text":"x"}`, true)
+	})
+}
+
+// INV-5IA-3: the codec selector is shared (pointer-identity) across links 2-4.
+// The substrate's source selector (pc.selector, also threaded into the crypto
+// publisher at link 2) MUST be the SAME instance the PluginConsumerManager
+// (link 3) holds — asserting source-vs-sink, not the source against itself.
+func TestPluginCryptoSharesSelectorInstance(t *testing.T) {
+	ts := Start(t, WithInTreePlugins(), WithPluginCrypto())
+	defer ts.Stop()
+	assert.Same(t, ts.cryptoSelectorForTest(), ts.pluginConsumers.KeySelectorForTest())
+}
+
+// cryptoSelectorForTest is a test-only accessor exposing the substrate's source
+// codec.KeySelector (pc.selector) — the instance wired into the crypto publisher
+// (WithCodecSelector, link 2). INV-5IA-3 asserts it is the same pointer the
+// PluginConsumerManager (link 3) holds via KeySelectorForTest().
+func (s *Server) cryptoSelectorForTest() codec.KeySelector {
+	return s.pluginCrypto.selector
 }

--- a/internal/testsupport/integrationtest/crypto_test.go
+++ b/internal/testsupport/integrationtest/crypto_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// INV-5IA-2: WithPluginCrypto without WithInTreePlugins must panic.
+func TestWithPluginCryptoWithoutPluginsPanics(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"integrationtest: WithPluginCrypto() requires WithInTreePlugins()",
+		func() { Start(t, WithPluginCrypto()) })
+}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -58,6 +58,7 @@ package integrationtest
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,6 +74,8 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/audit"
+	authguardaudit "github.com/holomush/holomush/internal/eventbus/authguard/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/eventbus/history"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
@@ -131,6 +134,22 @@ type Server struct {
 	// crypto.go require it (requirePluginCrypto panics when absent). Retained on
 	// the Server for Task 8's audit/read-back helpers.
 	pluginCrypto *pluginCrypto
+
+	// pluginConsumers is the per-plugin audit projection (link 3), wired when
+	// WithPluginCrypto was passed; nil otherwise. Stopped via t.Cleanup in Start.
+	pluginConsumers *audit.PluginConsumerManager
+
+	// readbackDecryptor is the host read-back decryptor (link 4), wired when
+	// WithPluginCrypto was passed; nil otherwise. ReadBackOwnRows drives it.
+	readbackDecryptor *history.ReadbackDecryptor
+
+	// readbackAuditCount counts read-back audit emissions on the
+	// audit.<game_id>.plugin_decrypt.<plugin> subjects (read by ReadBackAuditCount).
+	readbackAuditCount atomic.Int64
+
+	// readbackAuditEm is the read-back audit emitter (link 4); its drain
+	// goroutines are stopped via t.Cleanup in Start. nil unless WithPluginCrypto.
+	readbackAuditEm *authguardaudit.Emitter
 
 	// accessEngine is the ABAC policy engine the stack evaluates against: the
 	// allow-all default, a WithPolicyEngine override, or — under WithRealABAC —
@@ -358,7 +377,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		holoGRPC.WithVerbRegistry(verbRegistry),
 	)
 
-	return &Server{
+	srv := &Server{
 		t:                    t,
 		pool:                 pool,
 		playerSessionStore:   playerSessionStore,
@@ -375,6 +394,22 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		accessEngine:         pe,
 		guestStartLocationID: guestLocID,
 	}
+
+	// Plugin-crypto links 3+4 (Task 8): the audit projection (PluginConsumerManager
+	// forwarding plugin-owned subjects to scene_log) and the read-back decryptor
+	// (host-side DEK decrypt + INV-19 audit). Wired after startPlugins so the
+	// Manager's audit clients are resolvable. INV-P7-9: the SAME pc.selector
+	// instance feeds the consumer manager that the crypto-enabled publisher used
+	// on the emit side.
+	if cfg.withPluginCrypto {
+		srv.seedScene(ctx, pc)
+		srv.pluginConsumers = startPluginConsumers(t, ctx, bus, pluginSub.Manager(), pc.selector)
+		t.Cleanup(func() { _ = srv.pluginConsumers.Stop(context.Background()) })
+		srv.configureReadback(pc)
+		t.Cleanup(func() { _ = srv.readbackAuditEm.Shutdown(context.Background()) })
+	}
+
+	return srv
 }
 
 // cryptoPublisherOf returns pc's crypto-enabled publisher, or nil when pc is

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -72,6 +72,7 @@ import (
 	authpg "github.com/holomush/holomush/internal/auth/postgres"
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/eventbus/history"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
@@ -123,6 +124,13 @@ type Server struct {
 	// pluginSub is the started plugin subsystem when WithInTreePlugins was
 	// passed; nil otherwise. Stopped via t.Cleanup registered in startPlugins.
 	pluginSub *pluginsetup.PluginSubsystem
+
+	// pluginCrypto is the plugin-crypto substrate (ephemeral KEK + pool-backed
+	// DEK manager + crypto-enabled publisher) wired when WithPluginCrypto was
+	// passed; nil otherwise. The emit + wire-codec + DEK-count helpers in
+	// crypto.go require it (requirePluginCrypto panics when absent). Retained on
+	// the Server for Task 8's audit/read-back helpers.
+	pluginCrypto *pluginCrypto
 
 	// accessEngine is the ABAC policy engine the stack evaluates against: the
 	// allow-all default, a WithPolicyEngine override, or — under WithRealABAC —
@@ -267,6 +275,16 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	// the plugin subsystem's command registry so plugin commands are
 	// dispatchable (mirrors cmd/holomush/sub_grpc.go); otherwise it gets an
 	// empty registry (no commands registered).
+	// Plugin-crypto substrate (opt-in via WithPluginCrypto, gated to require
+	// WithInTreePlugins above). Constructed BEFORE startPlugins so its
+	// crypto-enabled publisher can be threaded into the plugin event emitter
+	// via ConfigureEventEmitter (link 1: sensitive plugin emits encrypt on the
+	// wire with persisted DEKs).
+	var pc *pluginCrypto
+	if cfg.withPluginCrypto {
+		pc = newPluginCrypto(t, bus, pool, verbRegistry)
+	}
+
 	var pluginSub *pluginsetup.PluginSubsystem
 	cmdRegistry := command.NewRegistry()
 	if cfg.withPlugins {
@@ -292,6 +310,8 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			pluginProvider:  pp,
 			auditor:         aud,
 			policyInstaller: policyInst,
+			cryptoPublisher: cryptoPublisherOf(pc),
+			gameID:          bus.Bus.GameID(),
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}
@@ -351,9 +371,21 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		bus:                  bus,
 		coreServer:           coreServer,
 		pluginSub:            pluginSub,
+		pluginCrypto:         pc,
 		accessEngine:         pe,
 		guestStartLocationID: guestLocID,
 	}
+}
+
+// cryptoPublisherOf returns pc's crypto-enabled publisher, or nil when pc is
+// nil (no WithPluginCrypto). A nil cryptoPublisher leaves the plugin event
+// emitter unwired, preserving the WithInTreePlugins-only behavior the
+// whole-system census suite relies on.
+func cryptoPublisherOf(pc *pluginCrypto) eventbus.Publisher {
+	if pc == nil {
+		return nil
+	}
+	return pc.publisher
 }
 
 // Stop tears down the in-process stack. Idempotent. Postgres and NATS cleanup

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -143,9 +143,10 @@ type StartOption func(*startConfig)
 
 // startConfig holds resolved Start options.
 type startConfig struct {
-	accessEngine types.AccessPolicyEngine
-	withPlugins  bool
-	withRealABAC bool
+	accessEngine     types.AccessPolicyEngine
+	withPlugins      bool
+	withRealABAC     bool
+	withPluginCrypto bool
 }
 
 // WithPolicyEngine overrides the harness's default allow-all ABAC engine.
@@ -240,6 +241,9 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	cfg := &startConfig{accessEngine: &allowAllPolicyEngine{}}
 	for _, opt := range opts {
 		opt(cfg)
+	}
+	if cfg.withPluginCrypto && !cfg.withPlugins {
+		panic("integrationtest: WithPluginCrypto() requires WithInTreePlugins()")
 	}
 	pe := cfg.accessEngine
 

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -29,6 +29,7 @@ import (
 	bootstrapsetup "github.com/holomush/holomush/internal/bootstrap/setup"
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
@@ -183,6 +184,17 @@ type pluginDeps struct {
 	// the allow-all default → startPlugins builds a fresh standalone installer
 	// (there is no engine cache to invalidate). (holomush-0f0f4.9, INV-WS-2)
 	policyInstaller *plugins.PolicyInstaller
+	// cryptoPublisher is the crypto-enabled publisher (DEK manager + identity
+	// codec selector, rendering-wrapped) wired by WithPluginCrypto. When
+	// non-nil, startPlugins calls Manager.ConfigureEventEmitter so plugin emits
+	// publish through it (link 1: sensitive emits encrypt on the wire). nil
+	// leaves the emitter unwired, matching the WithInTreePlugins-only behavior
+	// the whole-system census suite relies on.
+	cryptoPublisher eventbus.Publisher
+	// gameID is the embedded bus game id, threaded into the emitter as a
+	// GameIDProvider closure so plugin emits translate legacy colon-style
+	// subjects to events.<game_id>.<ns>.<id> consistently.
+	gameID string
 }
 
 // startPlugins constructs and starts a PluginSubsystem mirroring production
@@ -272,6 +284,21 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	ps := pluginsetup.NewPluginSubsystem(cfg)
 	t.Cleanup(func() { _ = ps.Stop(context.Background()) })
 	require.NoError(t, ps.Start(ctx), "startPlugins: PluginSubsystem.Start (LoadAll)")
+
+	// Wire the plugin event emitter to the crypto-enabled publisher when
+	// WithPluginCrypto supplied one. WithGameID takes a GameIDProvider
+	// (func() string), NOT a string (event_emitter.go:63-64) — wrap the
+	// captured gameID in a closure. WithCryptoEnabled(true) turns on the Phase
+	// 3a sensitivity fence so sensitivity:always emits (e.g. scene_pose) that
+	// claim Sensitive=true publish encrypted.
+	if d.cryptoPublisher != nil {
+		gameID := d.gameID
+		ps.Manager().ConfigureEventEmitter(
+			d.cryptoPublisher,
+			plugins.WithGameID(func() string { return gameID }),
+			plugins.WithCryptoEnabled(true),
+		)
+	}
 	return ps
 }
 

--- a/test/integration/plugincrypto/plugincrypto_suite_test.go
+++ b/test/integration/plugincrypto/plugincrypto_suite_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugincrypto_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+)
+
+// suiteT exposes the *testing.T from TestPluginCrypto so Ginkgo Describe blocks
+// can pass it to integrationtest.Start (which requires *testing.T — Ginkgo's
+// GinkgoT() does not satisfy that interface directly).
+var suiteT *testing.T
+
+func TestPluginCrypto(t *testing.T) {
+	suiteT = t
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugin Crypto Round-Trip Suite")
+}

--- a/test/integration/plugincrypto/roundtrip_test.go
+++ b/test/integration/plugincrypto/roundtrip_test.go
@@ -47,4 +47,38 @@ var _ = Describe("plugin crypto round-trip", func() {
 		// INV-5IA-6: read-back audit fired.
 		Expect(ts.ReadBackAuditCount(ctx)).To(BeNumerically(">", 0))
 	})
+
+	It("denies read-back for an event type whose manifest declares readback:false, without leaking plaintext", func() {
+		// scene_ooc is sensitivity:always but has NO readback declaration — it is
+		// encrypted on the wire but the g2 AuthGuard check
+		// (checkPluginReadback → PluginCanReadBack → false) refuses it on the
+		// read-back path, so plaintext is never returned. This exercises the real
+		// denial path: decodeAuthorizeAndDispatch skips identity-codec rows before
+		// the AuthGuard, so we need a sensitivity:always event to reach the guard.
+		ctx := context.Background()
+		emitted := ts.EmitPluginEvent(ctx, "core-scenes", "scene_ooc", `{"ooc":"x"}`, true)
+		var rows []integrationtest.PluginAuditRow
+		Eventually(func() int { rows = ts.QueryPluginAuditRows(ctx, "core-scenes", emitted.SubjectStr); return len(rows) }).
+			Should(BeNumerically(">", 0))
+		results := ts.ReadBackOwnRows(ctx, "core-scenes", rows)
+		Expect(results[0].Plaintext).To(BeEmpty(), "readback-denied row must not yield plaintext")
+		Expect(results[0].Denied).To(BeTrue())
+		// INV-5IA-4: a sensitivity:always event without readback is still encrypted
+		// on the wire (non-identity codec), confirming the deny is from the AuthGuard
+		// gate, not from a missing encryption step.
+		Expect(ts.WireCodecFor(ctx, emitted.SubjectStr)).NotTo(Equal(codec.NameIdentity))
+	})
+
+	It("leaves a sensitivity:never event identity-coded on the wire (no over-encryption)", func() {
+		// INV-5IA-4 negative half: scene_join_ic is sensitivity:never, so the
+		// publisher MUST NOT encrypt it — the wire codec stays identity. Gating on
+		// the projected audit row first guarantees the JetStream message landed, so
+		// the WireCodecFor read sees a real message (not the no-message sentinel).
+		ctx := context.Background()
+		emitted := ts.EmitPluginEvent(ctx, "core-scenes", "scene_join_ic", `{"who":"x"}`, false)
+		Eventually(func() int {
+			return len(ts.QueryPluginAuditRows(ctx, "core-scenes", emitted.SubjectStr))
+		}).Should(BeNumerically(">", 0))
+		Expect(ts.WireCodecFor(ctx, emitted.SubjectStr)).To(Equal(codec.NameIdentity))
+	})
 })

--- a/test/integration/plugincrypto/roundtrip_test.go
+++ b/test/integration/plugincrypto/roundtrip_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugincrypto_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+var _ = Describe("plugin crypto round-trip", func() {
+	var ts *integrationtest.Server
+
+	BeforeEach(func() {
+		ts = integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		DeferCleanup(ts.Stop)
+	})
+
+	It("encrypts sensitivity:always content on the wire and recovers plaintext via read-back", func() {
+		ctx := context.Background()
+		// 1. Emit a sensitivity:always core-scenes IC event (claims Sensitive=true).
+		emitted := ts.EmitPluginEvent(ctx, "core-scenes", "scene_pose", `{"text":"a secret pose"}`, true)
+
+		// INV-5IA-4: encrypted on the wire — non-identity codec + a DEK row.
+		Eventually(func() codec.Name { return ts.WireCodecFor(ctx, emitted.SubjectStr) }).
+			ShouldNot(Equal(codec.NameIdentity))
+		Expect(ts.DEKRowCount(ctx)).To(BeNumerically(">", 0))
+
+		// 2. Event projected to the plugin audit table (scene_log) as an encrypted row.
+		var rows []integrationtest.PluginAuditRow
+		Eventually(func() int {
+			rows = ts.QueryPluginAuditRows(ctx, "core-scenes", emitted.SubjectStr)
+			return len(rows)
+		}).Should(BeNumerically(">", 0))
+
+		// 3. Read-back via host decryptor → plaintext recovered (INV-5IA-6).
+		results := ts.ReadBackOwnRows(ctx, "core-scenes", rows)
+		Expect(results).To(HaveLen(len(rows)))
+		Expect(results[0].Plaintext).To(ContainSubstring("a secret pose"))
+		// INV-5IA-6: read-back audit fired.
+		Expect(ts.ReadBackAuditCount(ctx)).To(BeNumerically(">", 0))
+	})
+})


### PR DESCRIPTION
## Summary

Completes the `integrationtest` harness's plugin-runtime crypto wiring (the gap `WithInTreePlugins` (#4275) left), so plugin E2E tests can **observe plugin-emitted events** and **read back encrypted plugin content**. Implements the full plugin-crypto round-trip behind an opt-in `WithPluginCrypto()`:

```
emit fence (link 1) → publish encrypt (link 2) → audit projection (link 3) → read-back decrypt (link 4)
```

Epic **holomush-5iaov** (9 tasks). Spec/plan/ADR landed in #4288. First consumer: holomush-shcyu (Phase 6 publish E2E).

## What changed

**Phase 1 — extract shared `cryptowiring` package** (prod's manifest-derivation helpers lived in unimportable `package main`):
- `.1` codec `KeySelector` → `internal/plugin/cryptowiring`
- `.2` `AlwaysSensitiveSet` behind a narrow `ManifestSource` interface (fake-testable) + `managerSource` adapter
- `.3` `CryptoKeysLookup` (+ Postgres integration test)
- `.4` read-side `OwnerMapFromManager` (D2: kept separate from `core.go`'s `pcm.Add`-gated audit-side derivation)

**Phase 2 — harness `WithPluginCrypto` wiring:**
- `.5` `WithPluginCrypto()` opt-in + fail-fast guard (panics without `WithInTreePlugins`, INV-5IA-2)
- `.6` round-trip Ginkgo suite (RED — defines the harness API contract)
- `.7` crypto substrate: ephemeral KEK + pool-backed `dek.Manager` + crypto-enabled publisher; `ConfigureEventEmitter(WithCryptoEnabled)` (links 1–2)
- `.8` audit `PluginConsumerManager` projection + read-back decryptor with the real `SessionBridgeGuard` + audit-chain emitter (links 3–4) → **suite GREEN**

**Phase 3 — negative path + invariants + coverage:**
- `.9` negative read-back denial (`scene_ooc`: encrypted on wire, g2 manifest gate denies, no plaintext leak), INV-5IA-4 negative half (sensitivity:never stays identity), INV-5IA-1 (unwired-by-default), INV-5IA-3 (cross-link selector pointer-identity)

All test-tier (`//go:build integration`); production code paths are the existing `Manager`/crypto constructors. One read-side derivation helper (`OwnerMapFromManager`) extracted to a shared `internal/plugin/cryptowiring` package consumed by both prod boot and the harness.

## Test evidence

- Full `task test:int` — **8882 tests, 5 quarantine-skipped, 0 failures**
- `task pr-prep` (fast lane) — **pass** (build, lint, fmt, unit, bats, schema, license)
- plugincrypto round-trip suite: positive (recovers plaintext + read-back audit fires) + 2 negative/invariant specs — green

## Review

Every commit reviewed by `code-reviewer` + spec-compliance; the crypto-domain tasks (`.7`/`.8`/`.9`) additionally passed the `crypto-reviewer` gate (verified: no fail-open, encrypt-branch ignores the identity selector, AAD byte-equality on read-back, single-selector pointer identity, real g1/g2 readback gates — genuine permit, not a bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)