### PR TITLE
docs(testing): shcyu publish-driving layer — design v2 + implementation plan (holomush-shcyu)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-shcyu-harness-publish-driving.md
+++ b/docs/superpowers/plans/2026-05-28-shcyu-harness-publish-driving.md
@@ -1,0 +1,377 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# shcyu — integrationtest Publish Driving Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the test-tier harness driving layer so a full-stack Ginkgo E2E can drive the core-scenes Phase 6 publish lifecycle to PUBLISHED and read it back, and ship that happy-path E2E (folds in `holomush-5rh.20.39`/E6).
+
+**Architecture:** All additions are behind `//go:build integration` in `internal/testsupport/integrationtest` + `test/integration/scenes` — **zero production code changes**. shcyu composes the two landed prerequisites: `WithPluginConfigOverrides` (sets yzt86's per-plugin config so cool-off + scheduler interval are short) and `WithPluginCrypto` (5iaov; the encrypt + read-back round-trip so the publish snapshot decrypts the IC stream and reaches PUBLISHED). It adds a `SceneService` client accessor, wires `Session.CreateScene`, parameterizes the existing `EmitPluginEvent` by scene/actor (to seed encrypted IC content into a created scene — the command emit path is fence-rejected under crypto, per spec §3.4), and the E2E.
+
+**Tech Stack:** Go 1.24+, gopher-lua/go-plugin substrate, generated `scenev1` gRPC client, Ginkgo/Gomega (the existing `test/integration/scenes` suite), testcontainers Postgres + embedded NATS. Spec: `docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md`.
+
+---
+
+## Phase 1: Harness driving layer + happy-path E2E
+
+### Task 1: `WithPluginConfigOverrides` StartOption
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/plugins.go` (add the option + thread into `startPlugins`' `PluginSubsystemConfig`)
+- Modify: `internal/testsupport/integrationtest/harness.go` (`startConfig` struct — add the field)
+- Test: `internal/testsupport/integrationtest/plugins_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/testsupport/integrationtest/plugins_test.go`:
+
+```go
+//go:build integration
+
+func TestWithPluginConfigOverridesThreads(t *testing.T) {
+	var c startConfig
+	WithPluginConfigOverrides(map[string]map[string]string{
+		"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"},
+	})(&c)
+	require.Equal(t, "1ms", c.pluginConfigOverrides["core-scenes"]["cooloff_window"])
+	require.Equal(t, "20ms", c.pluginConfigOverrides["core-scenes"]["scheduler_interval"])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- -run TestWithPluginConfigOverridesThreads ./internal/testsupport/integrationtest/`
+Expected: FAIL — `WithPluginConfigOverrides` / `startConfig.pluginConfigOverrides` undefined.
+
+- [ ] **Step 3: Add the field + option**
+
+In `harness.go`, add to `startConfig`:
+
+```go
+	// pluginConfigOverrides is the per-plugin opaque config override
+	// (plugin name → key → value) threaded into PluginSubsystemConfig.
+	pluginConfigOverrides map[string]map[string]string
+```
+
+In `plugins.go`, add (next to `WithInTreePlugins`):
+
+```go
+// WithPluginConfigOverrides sets per-plugin config overrides (plugin name →
+// key → value) the harness threads into PluginSubsystemConfig.PluginConfigOverrides
+// — the same opaque channel production uses (yzt86). Reusable by any plugin's
+// harness tests. Empty/absent → manifest defaults.
+func WithPluginConfigOverrides(overrides map[string]map[string]string) StartOption {
+	return func(c *startConfig) { c.pluginConfigOverrides = overrides }
+}
+```
+
+- [ ] **Step 4: Thread it into `startPlugins`**
+
+In `plugins.go` `startPlugins`, where `pluginsetup.PluginSubsystemConfig{...}` is built, add the field:
+
+```go
+		PluginConfigOverrides: d.pluginConfigOverrides,
+```
+
+and add `pluginConfigOverrides map[string]map[string]string` to the `pluginDeps` struct, populated from `startConfig.pluginConfigOverrides` where `Start` builds `pluginDeps` (mirror how other `startConfig`→`pluginDeps` fields flow).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `task test:int -- -run TestWithPluginConfigOverridesThreads ./internal/testsupport/integrationtest/`
+Expected: PASS.
+
+- [ ] **Step 6: Build + commit**
+
+Run: `task build`. Commit: `test(harness): WithPluginConfigOverrides StartOption (holomush-shcyu)`.
+
+---
+
+### Task 2: `Server.SceneServiceClient()` accessor
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/harness.go` (add the method near `ServiceRegistry()` at `:451`)
+- Test: `test/integration/scenes/publish_e2e_test.go` exercises it (Task 5); a focused smoke check here
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/testsupport/integrationtest/harness_test.go` (or a scenes integration test):
+
+```go
+//go:build integration
+
+func TestSceneServiceClientResolves(t *testing.T) {
+	ts := Start(t, WithInTreePlugins())
+	require.NotNil(t, ts.SceneServiceClient())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- -run TestSceneServiceClientResolves ./internal/testsupport/integrationtest/`
+Expected: FAIL — `Server.SceneServiceClient` undefined.
+
+- [ ] **Step 3: Implement the accessor**
+
+In `harness.go`:
+
+```go
+// SceneServiceClient returns a SceneService client backed by the loaded
+// core-scenes plugin, resolved from the existing plugin ServiceRegistry.
+// Test-only; requires WithInTreePlugins (panics otherwise via requirePlugins).
+func (s *Server) SceneServiceClient() scenev1.SceneServiceClient {
+	s.requirePlugins("SceneServiceClient")
+	svc, err := s.ServiceRegistry().Resolve("holomush.scene.v1.SceneService")
+	require.NoError(s.t, err, "integrationtest.Server.SceneServiceClient: resolve SceneService")
+	require.NotNil(s.t, svc.Conn, "integrationtest.Server.SceneServiceClient: nil conn")
+	return scenev1.NewSceneServiceClient(svc.Conn)
+}
+```
+
+Add the import `scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"` if absent.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test:int -- -run TestSceneServiceClientResolves ./internal/testsupport/integrationtest/`
+Expected: PASS (core-scenes registers `holomush.scene.v1.SceneService` via `WithInTreePlugins`).
+
+- [ ] **Step 5: Build + commit**
+
+Run: `task build`. Commit: `test(harness): Server.SceneServiceClient() accessor (holomush-shcyu)`.
+
+---
+
+### Task 3: Wire `Session.CreateScene`
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/session.go` (`:460-462` stub)
+- Test: `test/integration/scenes/publish_e2e_test.go` (Task 5); a focused check here
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build integration
+
+func TestSessionCreateSceneReturnsULID(t *testing.T) {
+	ts := Start(t, WithInTreePlugins())
+	loc := ts.NewLocation(context.Background())
+	alice := ts.ConnectAuthed(context.Background(), "Alice") // creates player+character, returns *Session
+	sceneID := alice.CreateScene(context.Background(), loc)
+	require.NotEqual(t, ulid.ULID{}, sceneID)
+}
+```
+
+Grounded: `Server.ConnectAuthed(ctx, charName)` (`harness.go:639`) creates the player + character via `world.NewCharacter` and returns a `*Session` whose `CharacterID` is a `ulid.ULID` (`session.go:42`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test:int -- -run TestSessionCreateSceneReturnsULID ./internal/testsupport/integrationtest/`
+Expected: FAIL — current stub calls `t.Fatalf` (`session.go:462`).
+
+- [ ] **Step 3: Replace the stub**
+
+Replace `session.go:460-462`:
+
+```go
+// CreateScene creates a scene owned by this session's character via the
+// loaded core-scenes SceneService and returns its ULID.
+func (s *Session) CreateScene(ctx context.Context, locationID ulid.ULID) ulid.ULID {
+	s.server.t.Helper()
+	resp, err := s.server.SceneServiceClient().CreateScene(ctx, &scenev1.CreateSceneRequest{
+		CharacterId: s.CharacterID.String(), // CharacterID is a ulid.ULID (session.go:42)
+		Title:       "test scene",
+		LocationId:  locationID.String(),
+		Visibility:  "open", // string literal — the SceneVisibility consts live in package main (plugins/core-scenes); confirm core-scenes' accepted value
+	})
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene")
+	// CreateSceneResponse wraps *SceneInfo (scene.pb.go:540) — id is resp.GetScene().GetId().
+	id, err := ulid.Parse(resp.GetScene().GetId())
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene: parse scene id")
+	return id
+}
+```
+
+Notes for the implementer: the signature gains `locationID ulid.ULID` (the stub took only `ctx`); update the stub's callers if any (grep `\.CreateScene(`). `s.CharacterID` is grounded (`session.go:42`, a `ulid.ULID`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test:int -- -run TestSessionCreateSceneReturnsULID ./internal/testsupport/integrationtest/`
+Expected: PASS.
+
+- [ ] **Step 5: Build + commit**
+
+Run: `task build`. Commit: `test(harness): wire Session.CreateScene to SceneService (holomush-shcyu)`.
+
+---
+
+### Task 4: Scene-parameterized `EmitSceneICContent` (seed encrypted content into a created scene)
+
+**Why:** The existing `EmitPluginEvent` (`crypto.go:163`) hard-codes `WithPluginCrypto`'s fixed `sceneID`/`actorID` (`crypto.go:180,189`). shcyu's E2E creates its **own** scene and needs encrypted `scene_pose` content in it. The command emit path can't (SDK can't set `Sensitive` → INV-7 fence, spec §3.4), so we add a scene/actor-parameterized variant. A focused validation test proves the parameterized crypto round-trip **before** the full E2E (spec mandate).
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/crypto.go` (extract core; add the variant)
+- Test: `test/integration/plugincrypto/roundtrip_test.go` or a scenes test (validation)
+
+- [ ] **Step 1: Write the failing validation test**
+
+In `test/integration/scenes/publish_e2e_test.go` (or a focused crypto test):
+
+```go
+// Validates encrypted IC content can be seeded into a CreateScene-created scene
+// and read back (the parameterized crypto round-trip) — de-risks Task 5.
+It("seeds encrypted scene_pose into a created scene and reads it back", func() {
+	loc := ts.NewLocation(ctx)
+	alice := ts.ConnectAuthed(ctx, "Alice")
+	sceneID := alice.CreateScene(ctx, loc)
+	emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+		alice.CharacterID, "scene_pose", `{"text":"a secret pose"}`) // CharacterID is a ulid.ULID
+	Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()))
+	Expect(ts.WireCodecFor(emitted.SubjectStr)).To(Equal(codec.NameXChaCha20v1)) // encrypted
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: FAIL — `EmitSceneICContent` undefined.
+
+- [ ] **Step 3: Refactor `EmitPluginEvent` + add the variant**
+
+In `crypto.go`, extract the body of `EmitPluginEvent` into an unexported helper taking explicit `sceneID, actorID ulid.ULID`, and have both the existing method (fixed ids — preserves 5iaov's callers) and a new exported variant call it:
+
+```go
+// EmitSceneICContent emits an encrypted (Sensitive=true) scene IC event for an
+// ARBITRARY scene + actor — used to seed content into a CreateScene-created
+// scene (the command emit path can't set Sensitive; see spec §3.4). Requires
+// WithPluginCrypto + WithInTreePlugins. The scene row MUST already exist
+// (CreateScene) so core-scenes' InsertScenePose UPDATE … RETURNING resolves.
+func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
+	return s.emitPluginEventForScene(ctx, plugin, sceneID, actorID, eventType, payloadJSON, true)
+}
+
+// emitPluginEventForScene is the parameterized core (extracted from
+// EmitPluginEvent). EmitPluginEvent calls it with s.pluginCrypto.sceneID /
+// .actorID; EmitSceneICContent passes caller-supplied ids.
+func (s *Server) emitPluginEventForScene(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string, sensitive bool) EmittedEvent {
+	// ... body of the current EmitPluginEvent, with sceneID/actorID substituted
+	// for s.pluginCrypto.sceneID / s.pluginCrypto.actorID at crypto.go:180,189 ...
+}
+```
+
+Update the existing `EmitPluginEvent` to delegate: `return s.emitPluginEventForScene(ctx, plugin, s.pluginCrypto.sceneID, s.pluginCrypto.actorID, eventType, payloadJSON, sensitive)`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test:int -- ./test/integration/scenes/...` (the validation It) and `task test:int -- ./test/integration/plugincrypto/...` (5iaov's suite still green — the refactor preserved its path).
+Expected: PASS both.
+
+- [ ] **Step 5: Build + lint + commit**
+
+Run: `task build` then `task lint:go`. Commit: `test(harness): EmitSceneICContent — seed encrypted IC content into an arbitrary scene (holomush-shcyu)`.
+
+---
+
+### Task 5: Happy-path publish E2E (folds E6 / `holomush-5rh.20.39`)
+
+**Files:**
+
+- Create/extend: `test/integration/scenes/publish_e2e_test.go` (Ginkgo, in the existing scenes suite)
+
+- [ ] **Step 1: Write the E2E spec**
+
+Follow the existing `test/integration/scenes/*_test.go` Ginkgo conventions (shared `suiteT`, `BeforeEach` Start, `ts` handle). The happy-path spec:
+
+```go
+It("Alice ends scene, publishes, votes pass, cool-off elapses → PUBLISHED with content", func() {
+	loc := ts.NewLocation(ctx)
+	alice := ts.ConnectAuthed(ctx, "Alice")
+	bob := ts.ConnectAuthed(ctx, "Bob")
+
+	sceneID := alice.CreateScene(ctx, loc)
+	// Bob must JOIN, not merely be invited — the vote roster seeds from
+	// role IN ('owner','member') (publish_store.go:86); an 'invited' row is
+	// excluded (INV-P6-1). Without the join, Bob's vote command errors (not a voter).
+	Expect(alice.SendCommand(ctx, "scene invite #"+sceneID.String()+" "+bob.CharacterName)).To(Succeed())
+	Expect(bob.SendCommand(ctx, "scene join #"+sceneID.String())).To(Succeed())
+	// (confirm the exact invite/join command surface in plugins/core-scenes/commands.go
+	// + spec §6.1; handleInvite expects "scene invite <sceneRef> <character>", commands.go:950.)
+
+	// seed encrypted IC content (command path is fence-rejected under crypto, §3.4)
+	ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+		alice.CharacterID, "scene_pose", `{"text":"the scene happens"}`) // CharacterID is a ulid.ULID
+
+	// lifecycle stays command-driven (E6's intent): end → start publish → unanimous vote
+	Expect(alice.SendCommand(ctx, "scene end #"+sceneID.String())).To(Succeed())
+	Expect(alice.SendCommand(ctx, "scene publish #"+sceneID.String())).To(Succeed())
+	Expect(alice.SendCommand(ctx, "scene publish vote yes #"+sceneID.String())).To(Succeed())
+	Expect(bob.SendCommand(ctx, "scene publish vote yes #"+sceneID.String())).To(Succeed())
+
+	// scheduler (~20ms interval, ~1ms cool-off via WithPluginConfigOverrides) sweeps → PUBLISHED.
+	// Await the resolved notice (emitter wired by WithPluginCrypto), bounded.
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	alice.WaitForEvent(waitCtx, "scene_publish_resolved")
+
+	// The read RPCs key off published_scene_id — the ATTEMPT ulid, NOT the scene
+	// ulid (scene.pb.go:2213,2697). The lifecycle was command-driven, so recover
+	// the attempt id via ListScenePublishAttempts → the PUBLISHED summary's Id
+	// (mirrors the plugin's own publishedAttemptID, commands.go:223-225).
+	listResp, err := ts.SceneServiceClient().ListScenePublishAttempts(ctx, &scenev1.ListScenePublishAttemptsRequest{
+		CallerCharacterId: alice.CharacterID.String(), SceneId: sceneID.String(),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	var publishedSceneID string
+	for _, a := range listResp.GetAttempts() { // []*PublishedSceneSummary{Id,AttemptNumber,Status} (scene.pb.go:2610)
+		if a.GetStatus() == "PUBLISHED" { // confirm the canonical published status string
+			publishedSceneID = a.GetId()
+		}
+	}
+	Expect(publishedSceneID).NotTo(BeEmpty(), "no PUBLISHED attempt found for the scene")
+
+	// participant read returns decrypted content
+	pub, err := ts.SceneServiceClient().GetPublishedScene(ctx, &scenev1.GetPublishedSceneRequest{
+		CallerCharacterId: alice.CharacterID.String(), PublishedSceneId: publishedSceneID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	// content_entries is "populated only when PUBLISHED" (scene.pb.go:2270), so
+	// non-empty content is the grounded PUBLISHED + decryption-succeeded signal.
+	Expect(pub.GetContentEntries()).NotTo(BeEmpty())
+
+	// public archive returns content once PUBLISHED
+	arch, err := ts.SceneServiceClient().GetPublicSceneArchive(ctx, &scenev1.GetPublicSceneArchiveRequest{
+		PublishedSceneId: publishedSceneID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(arch.GetContentEntries()).NotTo(BeEmpty())
+})
+```
+
+The `BeforeEach` MUST `Start(suiteT, WithInTreePlugins(), WithPluginCrypto(), WithPluginConfigOverrides(map[string]map[string]string{"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"}}))`.
+
+Implementer notes (grounded shapes — confirm only the flagged unknowns): read RPCs take `PublishedSceneId` (attempt ulid), recovered via `ListScenePublishAttempts` → `PublishedSceneSummary{Id,Status}` (`scene.pb.go:2610`); `ConnectAuthed(ctx, charName)` creates the char and returns `*Session` (`harness.go:639`). Still to confirm at impl: the exact `scene join` command token + whether `handleInvite` strips the `#` ref prefix (it does NOT route through `resolveSceneRef`, `commands.go:950`); the canonical published-status string (`"PUBLISHED"`). Use `#<sceneID>` ref form (spec §6.1).
+
+- [ ] **Step 2: Run the E2E**
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: PASS — the scene reaches PUBLISHED and both RPCs return decrypted content.
+
+- [ ] **Step 3: Run the full suite + commit**
+
+Run: `task test:int -- ./test/integration/scenes/... ./test/integration/plugincrypto/...` (no regressions).
+Commit: `test(scenes): E2E happy-path publish flow (holomush-shcyu, closes 5rh.20.39)`.
+
+---
+
+## Final verification
+
+- [ ] `task test:int -- ./internal/testsupport/integrationtest/... ./test/integration/scenes/... ./test/integration/plugincrypto/...` — all green (Docker required).
+- [ ] `task lint` + `task fmt` clean.
+- [ ] Confirm **zero production code changes** — `jj diff --stat` shows only `internal/testsupport/integrationtest/` + `test/integration/` paths (all `//go:build integration`).
+- [ ] `bd close holomush-5rh.20.39` (E6, folded in) with a reference to the E2E; note the now-unblocked variant beads (`.40`/`.41`/`.42`/`.30`).
+<!-- adr-capture: sha256=e2dbd127464278ee; ts=2026-05-28T12:43:47Z; adrs= -->

--- a/docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md
+++ b/docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md
@@ -1,0 +1,206 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# integrationtest Harness: core-scenes Publish Driving Layer
+
+**Status:** Draft v2 (2026-05-28) — re-grounded against main #4290 after **both** prerequisites landed: `holomush-yzt86` (#4284, plugin runtime config) and `holomush-5iaov` (#4288/#4290, the `WithPluginCrypto` plugin-crypto round-trip). Round-1 NOT READY (the harness lacked the event-emitter + crypto read-back needed to reach PUBLISHED) is **resolved** — that wiring now lives in `WithPluginCrypto`, which shcyu composes.
+**Bead:** holomush-shcyu (deps holomush-yzt86 ✓ + holomush-5iaov ✓, both closed)
+**Provenance:** Re-brainstorm of holomush-shcyu (2026-05-27→28); the two prerequisites were extracted from successive design-review rounds and have since landed.
+
+## RFC2119 Keywords
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are
+to be interpreted as described in RFC2119.
+
+## 1. Overview
+
+The `internal/testsupport/integrationtest` harness can load the core-scenes
+binary plugin (via `WithInTreePlugins`, #4275) but cannot yet **drive** the
+Phase 6 publish lifecycle end-to-end. This spec adds the thin driving layer so a
+full-stack E2E can run Alice → `scene publish` → votes → cool-off → `PUBLISHED`
+→ participant + public RPC reads, and ships the happy-path E2E as the proof.
+
+Everything here is **test-tier**: every new symbol lives behind
+`//go:build integration` in `internal/testsupport/integrationtest` or
+`test/integration/scenes/`. **No production code changes.**
+
+### 1.1 What already landed (the substrate this builds on)
+
+- **`WithInTreePlugins()`** (`internal/testsupport/integrationtest/plugins.go:162`)
+  boots the real `PluginSubsystem` (`LoadAll`), spawning core-scenes as a
+  subprocess.
+- **`WithPluginCrypto()`** (`internal/testsupport/integrationtest/crypto.go:50`,
+  landed via 5iaov #4290) wires the full plugin-crypto round-trip — emit fence →
+  publish **encrypt** → audit projection → **read-back decrypt** — onto the
+  Manager (`ConfigureEventEmitter` at `plugins.go:296`, gated by
+  `cfg.withPluginCrypto` at `harness.go:303`; `ConfigureReadbackDecryptor` at
+  `crypto.go:363`). REQUIRES `WithInTreePlugins`.
+  This is what lets the publish snapshot decrypt the `sensitivity:always` IC
+  stream so a scene can reach `PUBLISHED`, and lets plugin notice-events flow so
+  `WaitForEvent` works. It assumes crypto-correct plugins (core-scenes qualifies).
+- **yzt86 (#4284) — the config channel.** `PluginSubsystemConfig.PluginConfigOverrides`
+  (`map[string]map[string]string`) is threaded to both runtimes; core-scenes
+  reads `vote_window`/`cooloff_window`/`scheduler_interval` from its manifest
+  `config:` via `applyConfig` (`plugins/core-scenes/main.go:56`). yzt86 added
+  **only the prod field** — no harness `StartOption` — so exposing it to tests is
+  shcyu's §3.1.
+- **`Server.ServiceRegistry()`** (`harness.go:451`) — existing harness accessor
+  returning the loaded plugins' `ServiceRegistry`; shcyu's client accessor
+  resolves `SceneService` from it (no new prod or harness-registry plumbing).
+- **`Session.SendCommand`** (`session.go:83`) dispatches telnet commands through
+  `HandleCommand` → the verb registry → the loaded plugin's command handlers.
+- **`Session.CreateScene`** (`session.go:461`) is still a `t.Fatalf` stub.
+- **`Server.EmitPluginEvent`** (used by 5iaov's round-trip test,
+  `test/integration/plugincrypto/roundtrip_test.go:29`) directly emits an
+  encrypted plugin event and is the **proven** crypto-content path (see §3.4).
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- A harness `StartOption` MUST let a test set `PluginConfigOverrides` so core-scenes
+  runs with short `cooloff_window` + `scheduler_interval` (bounded cool-off).
+- The harness MUST expose a `SceneService` client so a test can read back
+  published scenes — including the **public-archive** RPC, which has no command.
+- `Session.CreateScene` MUST create a real scene via the plugin's `SceneService`
+  and return its ULID.
+- A happy-path publish E2E MUST drive the full lifecycle to `PUBLISHED` through
+  the harness and assert participant + public RPC reads — proving the driving
+  layer composes. This is the bead's acceptance and closes holomush-5rh.20.39 (E6).
+- All additions MUST be test-tier (`//go:build integration`); **zero production
+  code changes** (honors the test-only-construct isolation invariant, holomush-1eps2).
+
+### 2.2 Non-Goals (downstream / out of scope)
+
+- **Variant E2E tests** — privacy gate (5rh.20.40 / E7), retry + admin extend
+  (.41 / E8), history-scope floor (.42 / E9), event-emission integration
+  (.30 / D4), the INV-P6 meta-test (.43). These reuse this driving layer and
+  remain separate beads under epic 5rh.20.
+- **`AuthedPlayer.OpenTelnetSession`** (iwzt-16) — the existing
+  `WaitForEvent`/transport-attach machinery suffices for event observation; no
+  telnet-transport differentiation is needed for the happy path.
+- **Any production code change.** The override channel and the registry getter
+  already exist on main.
+
+## 3. Design
+
+```mermaid
+flowchart TB
+    E2E["publish_e2e_test.go (Ginkgo)"]
+    E2E -->|"Start(WithInTreePlugins(), WithPluginCrypto(),<br/>WithPluginConfigOverrides{core-scenes: cooloff~1ms, interval~20ms})"| H["Server (integrationtest)"]
+    E2E -->|"Session.CreateScene(ctx) ⟵ wire stub"| H
+    E2E -->|"EmitPluginEvent(scene_pose, sensitive=true) — encrypted IC content"| H
+    E2E -->|"SendCommand('scene publish', '…vote yes')"| H
+    E2E -->|"Server.SceneServiceClient() ⟵ NEW (test-only)"| REG["Server.ServiceRegistry().Resolve(...)<br/>(existing harness accessor, harness.go:451)"]
+    H --> SUB
+    REG --> SUB
+    subgraph SUB ["core-scenes SUBPROCESS"]
+        CH["command handlers"] --> SVC["SceneServiceImpl"]
+        SCHED["publishScheduler<br/>interval=20ms (from override)"] --> SVC
+        SVC --> ST[("published_scenes")]
+    end
+    SVC -->|"GetPublishedScene / GetPublicSceneArchive"| E2E
+```
+
+### 3.1 `WithPluginConfigOverrides` StartOption
+
+A generic option mirroring the production field:
+
+```go
+// WithPluginConfigOverrides sets per-plugin config overrides (plugin name →
+// key → value) that the harness threads into PluginSubsystemConfig.
+// PluginConfigOverrides — the same opaque channel production uses (yzt86).
+// Reusable by any plugin's harness tests, not scene-specific.
+func WithPluginConfigOverrides(overrides map[string]map[string]string) StartOption
+```
+
+`startPlugins` (`plugins.go`) sets `PluginSubsystemConfig.PluginConfigOverrides`
+from it. Empty/absent → manifest defaults (production behavior). The E2E passes
+`{"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"}}`.
+`vote_window` is left at its manifest default — the happy path resolves on a
+full-roster yes vote (no vote-window timeout needed).
+
+### 3.2 `Server.SceneServiceClient()` accessor (test-only)
+
+```go
+// SceneServiceClient returns a SceneService client backed by the loaded
+// core-scenes plugin, resolved from the (production) PluginSubsystem service
+// registry. Test-only; requires WithInTreePlugins.
+func (s *Server) SceneServiceClient() scenev1.SceneServiceClient
+```
+
+Implementation: `s.ServiceRegistry().Resolve("holomush.scene.v1.SceneService")`
+(the existing harness accessor, `harness.go:451`) → wrap the registered service's
+client conn in the generated `scenev1` client. Panics (test helper) if plugins
+aren't loaded — consistent with the existing `requirePlugins` guard on
+`Server.CommandRegistry()`.
+
+### 3.3 `Session.CreateScene` wiring
+
+Replace the `t.Fatalf` stub (`session.go:461`) with a real call:
+`s.server.SceneServiceClient().CreateScene(ctx, &scenev1.CreateSceneRequest{...})`,
+returning the created scene's ULID. The current stub signature discards the
+context (`func (s *Session) CreateScene(_ context.Context) ulid.ULID`) — the
+wiring MUST thread it (`ctx context.Context`) into the RPC call. The stale
+`iwzt-9` TODO comment is removed.
+
+### 3.4 Happy-path E2E (`test/integration/scenes/publish_e2e_test.go`)
+
+A new Ginkgo spec in the existing `test/integration/scenes/` suite. Flow:
+
+1. `Start(WithInTreePlugins(), WithPluginCrypto(), WithPluginConfigOverrides({"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"}}))`. `WithPluginCrypto` supplies the encrypt + read-back round-trip so the publish snapshot can decrypt the IC stream and reach `PUBLISHED`; the override shortens cool-off + the scheduler interval.
+2. Alice (authed, with a character) `CreateScene(ctx)`, focuses it, adds Bob.
+3. **Seed encrypted IC content** via `Server.EmitPluginEvent(core-scenes, "scene_pose", …, sensitive=true)` — the only path that sets `Sensitive=true`, which the `WithPluginCrypto` fence requires for `sensitivity:always` content (see "Content path"). A command-driven pose would be **rejected** here.
+4. Alice ends the scene; `SendCommand(alice, "scene publish")` → attempt created (COLLECTING).
+5. `SendCommand(alice, "scene publish vote yes")` + `SendCommand(bob, "scene publish vote yes")` → unanimous → COOLOFF.
+6. The subprocess scheduler (~20ms interval, ~1ms cool-off) sweeps → snapshot decrypts (via `WithPluginCrypto`) → `PUBLISHED`. Await the `scene_publish_resolved` notice via `WaitForEvent` (the emitter is wired by `WithPluginCrypto`) under a bounded `context.WithTimeout(ctx, ~2s)`; fall back to bounded polling of the participant RPC if event ordering is awkward.
+7. Assert `GetPublishedScene` (participant) returns content **and** `GetPublicSceneArchive` returns content (`status == PUBLISHED`), via `SceneServiceClient()`.
+
+**Driving split:** publish lifecycle (`scene publish`/vote) via `SendCommand`; encrypted IC content via `EmitPluginEvent(…, sensitive=true)`; read-back + public-archive opacity via `SceneServiceClient()` (the public RPC has no command surface).
+
+**Content path (resolved during design-review round 2).** The IC content the published snapshot decrypts MUST be encrypted, which under `WithPluginCrypto` requires `Sensitive=true`. The binary plugin SDK **cannot yet set `Sensitive` over the wire** (`pkg/plugin/event_sink.go`; `internal/plugin/event_emitter.go:70,164-167`; tracked as P0 fossil `holomush-dj95.3`), so the plugin **command** emit path stamps `Sensitive=false`, and the INV-7 fence (`internal/plugin/sensitivity_fence.go:41`, `EVENT_SENSITIVITY_REQUIRED`) **rejects** a `sensitivity:always` `scene_pose` whenever `WithPluginCrypto` is active. (Production runs cryptoEnabled=off, so this only bites under the test option.) Therefore the E2E MUST seed IC content via `Server.EmitPluginEvent(core-scenes, "scene_pose", …, sensitive=true)` — the helper sets `Sensitive` explicitly (`crypto.go:163`) — **not** via a pose command. The DEK is subject-derived per scene (`internal/eventbus/history/publisher.go:498-519`), so the crypto substrate works for any scene `CreateScene` makes. **Open sub-decision for the plan:** `EmitPluginEvent` as landed targets `WithPluginCrypto`'s fixed seeded scene; to seed content for shcyu's *created* scene the plan either (a) parameterizes `EmitPluginEvent` by scene id (small harness extension), or (b) drives the E2E against the fixed seeded scene (foregoing fresh-content via `CreateScene`). The publish *lifecycle* notices are `sensitivity:never`, so they are not fenced and remain command-driven.
+
+## 4. Test-tier property
+
+Every new symbol is behind `//go:build integration`:
+`WithPluginConfigOverrides` + `SceneServiceClient` (`integrationtest`),
+`Session.CreateScene` body (`integrationtest`), and `publish_e2e_test.go`
+(`test/integration/scenes`). The accessor consumes the **existing** prod
+`PluginSubsystem.ServiceRegistry()` — no production symbol is added or modified.
+This keeps the test-only construct isolated from core/prod (holomush-1eps2) and
+means no crypto/abac/prod-surface review gates apply.
+
+## 5. Invariants
+
+| ID | Invariant | Test |
+| --- | --- | --- |
+| INV-SH-1 | `WithPluginConfigOverrides` reaches `PluginSubsystemConfig.PluginConfigOverrides`, so core-scenes runs with the test's `cooloff_window`/`scheduler_interval`. | E2E: cool-off→PUBLISHED completes within a bounded wait (would hang at 30m/30s defaults). |
+| INV-SH-2 | `Server.SceneServiceClient()` resolves the loaded plugin's `SceneService` (read-back works). | E2E: `GetPublishedScene` + `GetPublicSceneArchive` return content post-PUBLISHED. |
+| INV-SH-3 | `Session.CreateScene` returns a valid scene ULID via the real RPC (no `t.Fatalf`). | Integration: `CreateScene` returns a parseable, non-zero ULID. |
+| INV-SH-4 | The driving layer adds **zero production code**: `SceneServiceClient` uses the existing `ServiceRegistry()` getter; all new symbols are `//go:build integration`. | Meta-test: the new accessor/option/E2E files all carry the `integration` build tag; no new exported symbol appears in a non-test prod package for this change. |
+| INV-SH-5 | The happy-path lifecycle drives to `PUBLISHED` through `SendCommand` + reads back via the client (E6 acceptance). | The `publish_e2e_test.go` spec itself (5rh.20.39). |
+
+A meta-test (`test/meta`) SHOULD assert INV-SH-4's build-tag isolation for the
+new files — the load-bearing property (test-only). The remaining invariants are
+proven by the E2E + the `CreateScene` integration assertion; given this is
+harness infrastructure with one acceptance E2E, a full INV enumeration meta-test
+is not warranted (YAGNI).
+
+## 6. Files Touched (all test-tier)
+
+- Modify: `internal/testsupport/integrationtest/plugins.go` — `WithPluginConfigOverrides` + thread into `startPlugins`.
+- Modify: `internal/testsupport/integrationtest/harness.go` — `Server.SceneServiceClient()`.
+- Modify: `internal/testsupport/integrationtest/session.go` — wire `CreateScene` (`:461`).
+- Create: `test/integration/scenes/publish_e2e_test.go` — happy-path E2E.
+- Create (optional): `test/meta/shcyu_test_tier_test.go` — INV-SH-4 build-tag isolation meta-test.
+
+## 7. Relationship to the Phase 6 E2E cluster
+
+shcyu **folds in** holomush-5rh.20.39 (E6 happy-path) as its acceptance proof.
+On completion, it **unblocks** the variant E2E beads that reuse this driving
+layer: 5rh.20.40 (E7 privacy gate), .41 (E8 retry + admin extend), .42 (E9
+history-scope floor), .30 (D4 event-emission integration), and transitively .43
+(INV-P6 meta-test). Those remain separate beads under epic 5rh.20.
+<!-- adr-capture: sha256=89b8f88cfcfb3982; ts=2026-05-28T12:41:11Z; adrs= -->


### PR DESCRIPTION
## Summary

Lands the **spec + implementation plan** for `holomush-shcyu` — the test-tier integrationtest harness driving layer that lets a full-stack Ginkgo E2E drive the core-scenes Phase 6 publish lifecycle to PUBLISHED and read it back.

Docs-only PR (zero code). The implementation is **entirely `//go:build integration`** — no production changes — and composes the two landed prerequisites: `WithPluginConfigOverrides` (yzt86 plugin-config passthrough, #4284) and `WithPluginCrypto` (5iaov plugin-crypto round-trip, #4290).

## What's in this PR

- `docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md` — design v2 (design-reviewer **READY**, round 2)
- `docs/superpowers/plans/2026-05-28-shcyu-harness-publish-driving.md` — 5-task TDD plan (plan-reviewer **READY**, round 1; 5 Minor findings folded in)

## Materialized work (bd)

`holomush-shcyu` promoted to epic with 5 child tasks + dependency DAG:

| Bead | Task | Deps |
|------|------|------|
| `.1` | WithPluginConfigOverrides StartOption | — |
| `.2` | Server.SceneServiceClient() accessor | — |
| `.3` | Wire Session.CreateScene | `.2` |
| `.4` | Scene-parameterized EmitSceneICContent | `.3` |
| `.5` | Happy-path publish E2E (folds `5rh.20.39`/E6) | `.1`, `.4` |

## Gates

- design-reviewer: READY · plan-reviewer: READY · capture-adrs: 0 candidates (test-tier; architecture already captured by yzt86 ADRs 7pdhf/ikozq + 5iaov)
- `task pr-prep:docs`: ✓ passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)