### PR TITLE
docs: SP2 Diátaxis IA — spec, plan, 2 ADRs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Organize docs audience-first with Diátaxis modes within](holomush-md3k4-organize-docs-audience-first-di-taxis-modes-within.md) | 2026-05-28 | Accepted | `holomush-md3k4` |
+| [Use autogenerate sidebar over explicit entries](holomush-38kmt-use-autogenerate-sidebar-over-explicit-entries.md) | 2026-05-28 | Accepted | `holomush-38kmt` |
 | [Adopt Astro Starlight as the docs site platform](holomush-145ko-adopt-astro-starlight-as-docs-site-platform.md) | 2026-05-27 | Accepted | `holomush-145ko` |
 | [Render Mermaid diagrams client-side via Starlight plugin](holomush-xneg2-render-mermaid-diagrams-client-side-via-starlight-plugin.md) | 2026-05-27 | Accepted | `holomush-xneg2` |
 | [Use bun as the docs-site package manager](holomush-qf2oo-use-bun-as-docs-site-package-manager.md) | 2026-05-27 | Accepted | `holomush-qf2oo` |

--- a/docs/adr/holomush-38kmt-use-autogenerate-sidebar-over-explicit-entries.md
+++ b/docs/adr/holomush-38kmt-use-autogenerate-sidebar-over-explicit-entries.md
@@ -1,0 +1,42 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-38kmt; do not edit manually; use `/adr update holomush-38kmt` -->
+
+# Use autogenerate sidebar over explicit entries
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-38kmt
+**Deciders:** Sean Brandt
+
+## Context
+
+Starlight supports two sidebar modes: an explicit list of entries (the SP1-inherited 43-entry list in `astro.config.mjs`) and `autogenerate`, which derives the nav from the directory tree. SP1 kept the explicit sidebar to preserve parity during the platform swap. Nav drift — hand-maintained sidebar entries falling out of sync with content — was the root cause of ~21 docs being orphaned from the nav.
+
+## Decision
+
+Replace the explicit sidebar with one `autogenerate: { directory }` group per audience section. Use per-page `sidebar.order` / `sidebar.label` frontmatter for ordering and label overrides where alphabetical/title-cased defaults are wrong.
+
+## Rationale
+
+- `autogenerate` makes nav drift **structurally impossible** rather than lint-guarded: any file placed in a configured directory is in the nav by construction.
+- The 43-entry explicit list was a contributing cause of the ~21 orphaned docs; keeping it would require a new lint invariant to prevent recurrence.
+- Label/ordering gaps are addressable via Starlight frontmatter — a maintenance cost, not an architectural limitation.
+- SP1's reason for the explicit sidebar (parity during migration) no longer applies in SP2, the IA-restructuring pass.
+- Flipping to `autogenerate` first (before retire/move) also keeps `astro build` green throughout the re-org: an explicit `{slug}` entry throws `AstroUserError` on a missing target, whereas `autogenerate` re-derives from whatever files exist.
+
+## Alternatives Considered
+
+- **Explicit sidebar (status quo)** — full label/order/grouping control without frontmatter, already in place; but every new doc must be manually added or it is silently orphaned (the exact root cause of the hidden docs), and drift is a recurring bug class needing a CI guard. Rejected.
+
+## Consequences
+
+**Positive:** INV-1 (every non-retired doc reachable) holds by construction, not by test; adding a doc requires only placing it in the right directory; the ~21 orphans surface automatically once placed.
+
+**Negative:** per-page `sidebar.order` frontmatter must be maintained where alphabetical is wrong; multi-word folder labels (e.g. `how-to`) need `sidebar.label`/group-label config to render well.
+
+**Neutral:** the `astro.config.mjs` sidebar field shrinks from 43 entries to 5 autogenerate directives; behavior verified via context7 `/withastro/starlight`.

--- a/docs/adr/holomush-md3k4-organize-docs-audience-first-di-taxis-modes-within.md
+++ b/docs/adr/holomush-md3k4-organize-docs-audience-first-di-taxis-modes-within.md
@@ -1,0 +1,42 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-md3k4; do not edit manually; use `/adr update holomush-md3k4` -->
+
+# Organize docs audience-first with Diátaxis modes within
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-md3k4
+**Deciders:** Sean Brandt
+
+## Context
+
+After the Astro Starlight migration (SP1), the docs site needed a new information architecture. Diátaxis recognizes both **mode-first** (tutorials/how-to/reference/explanation at the top level) and **audience-first** (role sections at the top level, modes nested within) as valid, and says user-perception of the product should drive the primary axis. The site was audience-only with no mode differentiation; ~21 docs were orphaned from the hand-maintained sidebar.
+
+## Decision
+
+Organize docs **audience-first** (`guide` / `operating` / `extending` / `contributing` / `reference`) with **Diátaxis modes** (`tutorials` / `how-to` / `reference` / `explanation`) as subfolders within each audience section. The top-level cross-cutting `reference/` section (generated gRPC/events/access-control) stays flat.
+
+## Rationale
+
+- Diátaxis's complex-hierarchies guidance says the primary axis should match how users perceive their role; HoloMUSH readers identify as player / operator / plugin developer / contributor before they identify by task type.
+- Audience-first scopes each mode list to a single audience, keeping nav groups ≤7 per Diátaxis's nav-length guidance.
+- Audience assignment is unambiguous for virtually every doc; mode-purity within an audience can be improved incrementally (follow-up content-surgery beads) without blocking the IA.
+- Mode-first would mix operators and plugin developers inside the same `how-to` group, degrading findability for the site's primary personas.
+
+## Alternatives Considered
+
+- **Mode-first (Diátaxis at root)** — pure Diátaxis, single primary axis; but conflates distinct audiences into shared buckets and contradicts the user-perception guidance for this product. Rejected.
+- **Audience-only (status quo)** — no structural change, but no learning/procedure/reference differentiation and no answer to nav drift or the ~21 orphans. Rejected.
+
+## Consequences
+
+**Positive:** every doc lives in exactly one audience/mode bucket (unambiguous placement for new docs); Diátaxis adoption is iterative (structure now, mode-purity later); nav lists stay ≤7 at both levels.
+
+**Negative:** "reference" appears at two levels (top-level cross-cutting section + in-audience mode) — contributors must understand the distinction; path depth +1 for non-index docs (longer slugs).
+
+**Neutral:** the root splash `index.mdx` sits outside all audience dirs (unaffected); mode subfolders are created only where content exists.

--- a/docs/superpowers/plans/2026-05-28-docs-diataxis-ia.md
+++ b/docs/superpowers/plans/2026-05-28-docs-diataxis-ia.md
@@ -27,7 +27,7 @@
 | `scripts/migration/sp2-rewrite-links.mjs` | Rewrites root-absolute internal links via the map | Create |
 | `site/astro.config.mjs` | `sidebar` → `autogenerate` per section (branding fields untouched) | Modify |
 | `site/src/content/docs/**` | Docs relocated into `<audience>/<mode>/` buckets | Move |
-| `site/src/content/docs/contributing/event-delivery.md`, `operating/legacy-id-cutover.md` | Superseded | Delete |
+| `site/src/content/docs/contributing/event-delivery.md`, `site/src/content/docs/operating/legacy-id-cutover.md` | Superseded | Delete |
 | `site/tsconfig.json` | Add `~/*` → `src/*` path alias (preserve `include`/`exclude`) | Modify |
 | `scripts/check-docs-ia.sh` + `scripts/tests/docs-ia.bats` | Parity (INV-1), one-bucket (INV-2), retired-gone (INV-3), branding (INV-5), nav≤7 (INV-6) | Create |
 | `scripts/tests/fixtures/sp2-slug-map.tsv` | Slug-map retained as fixture after move (Task 10) | Move |

--- a/docs/superpowers/plans/2026-05-28-docs-diataxis-ia.md
+++ b/docs/superpowers/plans/2026-05-28-docs-diataxis-ia.md
@@ -1,0 +1,471 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Docs Diátaxis IA Implementation Plan (SP2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-organize the Starlight docs into an audience-first / Diátaxis-within folder structure, flip the sidebar to `autogenerate`, retire two superseded docs, and rewrite internal links — preserving branding byte-identical.
+
+**Architecture:** A single checked-in **slug map** (`scripts/migration/sp2-slug-map.tsv`) drives everything: a move script relocates each doc into its audience/mode folder, a link codemod rewrites root-absolute links via the same map, and a parity check verifies coverage. **The sidebar is flipped to `autogenerate` first** — once the nav has no per-slug references, subsequent deletes/moves can't break the build (an explicit `{slug}` sidebar throws `AstroUserError` on a missing target). Content is **not** rewritten for mode-purity (follow-up beads). No redirects (SP1 stance).
+
+**Tech Stack:** Astro Starlight, bun, `linkinator` (link check), bats (invariant tests), `jj` (VCS). Codemods are bun-run `.mjs` (Node 22+/Bun `fs.globSync`).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-docs-diataxis-ia-design.md`
+**Design bead:** `holomush-44nxc` · **Program anchor:** `holomush-rkwyb`
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `scripts/migration/sp2-slug-map.tsv` | Old→new slug map (52 moves) — DRY driver for moves, links, parity | Create |
+| `scripts/migration/sp2-move.mjs` | Reads map; creates mode dirs + moves files | Create |
+| `scripts/migration/sp2-rewrite-links.mjs` | Rewrites root-absolute internal links via the map | Create |
+| `site/astro.config.mjs` | `sidebar` → `autogenerate` per section (branding fields untouched) | Modify |
+| `site/src/content/docs/**` | Docs relocated into `<audience>/<mode>/` buckets | Move |
+| `site/src/content/docs/contributing/event-delivery.md`, `operating/legacy-id-cutover.md` | Superseded | Delete |
+| `site/tsconfig.json` | Add `~/*` → `src/*` path alias (preserve `include`/`exclude`) | Modify |
+| `scripts/check-docs-ia.sh` + `scripts/tests/docs-ia.bats` | Parity (INV-1), one-bucket (INV-2), retired-gone (INV-3), branding (INV-5), nav≤7 (INV-6) | Create |
+| `scripts/tests/fixtures/sp2-slug-map.tsv` | Slug-map retained as fixture after move (Task 10) | Move |
+
+> **Lifecycle:** runs in the `sp2-diataxis` jj workspace (branched from `main@origin`). Commit per task with `jj commit`/`jj describe`; run `task fmt:markdown` before each docs commit. Codemods under `scripts/migration/` are deleted in Task 10 (the map is kept as a fixture). Run `.mjs` codemods with **bun**, not pre-22 `node` (`fs.globSync`).
+>
+> **Ordering rationale:** sidebar→autogenerate (Task 2) precedes retire (Task 3) and move (Task 4) precisely so the build never references a moved/deleted slug. `autogenerate:{directory}` re-derives the nav from whatever files exist, so it tolerates the retire and the re-bucketing transparently (orphans simply surface as soon as autogenerate is on — that is the goal).
+
+---
+
+## Phase 1: Foundation
+
+### Task 1: Author the slug-map fixture
+
+The single source of truth for the re-org. Format: `old-slug<TAB>new-slug`, one move per line; retires and unchanged pages are NOT listed (they don't move).
+
+**Files:**
+
+- Create: `scripts/migration/sp2-slug-map.tsv`
+
+- [ ] **Step 1: Write the map** (verbatim — mirrors the spec's bucketing tables)
+
+```tsv
+guide/the-world	guide/explanation/the-world
+guide/connecting	guide/how-to/connecting
+guide/building	guide/how-to/building
+guide/commands	guide/reference/commands
+operating/installation	operating/how-to/deploy/installation
+operating/deployment	operating/how-to/deploy/deployment
+operating/verifying-releases	operating/how-to/deploy/verifying-releases
+operating/database	operating/how-to/database
+operating/ca-rotation	operating/how-to/ca-rotation
+operating/crypto-setup	operating/how-to/crypto/crypto-setup
+operating/crypto-runbook	operating/how-to/crypto/crypto-runbook
+operating/crypto-monitoring	operating/how-to/crypto/crypto-monitoring
+operating/telnet-security	operating/how-to/telnet-security
+operating/sentry	operating/how-to/sentry
+operating/plugin-reloads	operating/how-to/plugin-reloads
+operating/sandbox-operations	operating/how-to/sandbox/sandbox-operations
+operating/sandbox-restore	operating/how-to/sandbox/sandbox-restore
+operating/operations	operating/how-to/operations
+operating/configuration	operating/reference/configuration
+operating/authentication	operating/explanation/authentication
+operating/plugin-security	operating/explanation/plugin-security
+extending/getting-started	extending/tutorials/getting-started
+extending/lua-plugins	extending/tutorials/lua-plugins
+extending/binary-plugins	extending/tutorials/binary-plugins
+extending/plugin-guide	extending/tutorials/plugin-guide
+extending/verb-registration	extending/how-to/verb-registration
+extending/audit-events	extending/how-to/audit-events
+extending/event-sensitivity	extending/how-to/event-sensitivity
+extending/plugin-config	extending/how-to/plugin-config
+extending/plugin-crypto-readback	extending/how-to/plugin-crypto-readback
+extending/plugin-host-evaluate	extending/how-to/plugin-host-evaluate
+extending/access-control	extending/how-to/access-control
+extending/abac-attribute-resolver	extending/how-to/abac-attribute-resolver
+extending/api-guide	extending/reference/api-guide
+extending/substrate-contract	extending/reference/substrate-contract
+extending/actor-kinds-claimable	extending/reference/actor-kinds-claimable
+extending/events	extending/reference/events
+extending/audit-chain	extending/explanation/audit-chain
+contributing/database-migrations	contributing/how-to/database-migrations
+contributing/pr-guide	contributing/how-to/pr-guide
+contributing/pr-prep	contributing/how-to/pr-prep
+contributing/quarantine	contributing/how-to/quarantine
+contributing/integration-tests	contributing/how-to/integration-tests
+contributing/sessions	contributing/how-to/sessions
+contributing/coding-standards	contributing/reference/coding-standards
+contributing/architecture	contributing/explanation/architecture
+contributing/authentication	contributing/explanation/authentication
+contributing/event-store	contributing/explanation/event-store
+contributing/event-emit-pipeline	contributing/explanation/event-emit-pipeline
+contributing/gateway-boundary	contributing/explanation/gateway-boundary
+contributing/hostfunc-context-audit	contributing/explanation/hostfunc-context-audit
+contributing/lifecycle-and-health	contributing/explanation/lifecycle-and-health
+```
+
+> `extending/events` (⚑) overlaps `reference/events` (generated). Before committing, open both: if `extending/events` duplicates the generated reference, drop that row from the map and instead **retire it + cross-link to `/reference/events/`** (add to Task 3's retire list). Decide per content.
+
+- [ ] **Step 2: Validate the map**
+
+```bash
+cd /Volumes/Code/github.com/holomush/.worktrees/sp2-diataxis
+awk -F'\t' 'NF!=2{print "BAD ROW: "$0; bad=1} END{if(bad)exit 1; print NR" rows"}' scripts/migration/sp2-slug-map.tsv
+cut -f1 scripts/migration/sp2-slug-map.tsv | while read s; do test -f "site/src/content/docs/$s.md" -o -f "site/src/content/docs/$s.mdx" || echo "MISSING SOURCE: $s"; done
+cut -f2 scripts/migration/sp2-slug-map.tsv | sort | uniq -d | sed 's/^/DUP TARGET: /'
+```
+
+Expected: `52 rows`, no `MISSING SOURCE`, no `DUP TARGET`.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(ia): add SP2 slug map fixture (holomush-44nxc)"`
+
+### Task 2: Flip the sidebar to autogenerate (BEFORE any move/delete)
+
+Doing this first removes every per-slug reference from the nav, so the build survives the retire (Task 3) and move (Task 4). `autogenerate` re-derives the nav from whatever files exist — orphans surface immediately (intended).
+
+**Files:**
+
+- Modify: `site/astro.config.mjs` (`sidebar` field only)
+
+- [ ] **Step 1: Replace the explicit `sidebar` array**
+
+Replace the entire `sidebar: [ … ]` (currently 43 explicit `{ slug }` entries) with autogenerate per audience section. Touch **nothing else** in the file (branding fields stay byte-identical — INV-5):
+
+```javascript
+      sidebar: [
+        { label: 'Guide', autogenerate: { directory: 'guide' } },
+        { label: 'Operating', autogenerate: { directory: 'operating' } },
+        { label: 'Extending', autogenerate: { directory: 'extending' } },
+        { label: 'Contributing', autogenerate: { directory: 'contributing' } },
+        { label: 'Reference', autogenerate: { directory: 'reference' } },
+      ],
+```
+
+- [ ] **Step 2: Build — now green and stays green**
+
+```bash
+cd site && bunx astro build
+```
+
+Expected: PASS. The sidebar now lists current files (including the ~21 orphans, flat for now) with no broken references.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(ia): autogenerate sidebar (pre-move, unbreakable nav) (holomush-44nxc)"`
+
+---
+
+## Phase 2: Retire superseded docs
+
+### Task 3: Delete the two superseded docs + scrub inbound links
+
+**Files:**
+
+- Delete: `site/src/content/docs/contributing/event-delivery.md`, `site/src/content/docs/operating/legacy-id-cutover.md`
+
+- [ ] **Step 1: Confirm they're still superseded**
+
+```bash
+rg -n "Superseded" site/src/content/docs/contributing/event-delivery.md
+rg -q "legacy_id" internal/eventbus/no_legacy_id_grep_test.go && echo "legacy_id elimination still enforced"
+```
+
+Expected: superseded banner present; grep-test still enforces elimination.
+
+- [ ] **Step 2: Find inbound links to either doc**
+
+```bash
+rg -n '\]\((/[^)]*event-delivery|/[^)]*legacy-id-cutover)' site/src/content/docs
+```
+
+- [ ] **Step 3: Remove/repoint those links**
+
+For each hit: if incidental, delete the link (keep prose); if it points to replacement material, repoint (event-delivery → `/contributing/explanation/event-store/`; legacy-id-cutover → drop). No link may resolve to a retired slug.
+
+- [ ] **Step 4: Delete the files**
+
+```bash
+rm -f site/src/content/docs/contributing/event-delivery.md site/src/content/docs/operating/legacy-id-cutover.md
+```
+
+- [ ] **Step 5: Build + verify zero inbound links (INV-3)**
+
+```bash
+cd site && bunx astro build && cd ..
+rg -c '\](/[^)]*(event-delivery|legacy-id-cutover))' site/src/content/docs || echo "0 inbound links — good"
+```
+
+Expected: build PASS (autogenerate already dropped the deleted pages); no inbound-link matches.
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "docs(ia): retire superseded event-delivery + legacy-id-cutover (holomush-44nxc)"`
+
+---
+
+## Phase 3: Move docs into buckets
+
+### Task 4: Move every doc per the slug map
+
+**Files:**
+
+- Create: `scripts/migration/sp2-move.mjs`
+- Move: all 52 mapped docs under `site/src/content/docs/`
+
+- [ ] **Step 1: Write the move script**
+
+```javascript
+// scripts/migration/sp2-move.mjs — read the slug map; for each old→new,
+// create the new parent dir and move the file (preserving .md/.mdx ext).
+import { readFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
+import { dirname } from 'node:path';
+const base = 'site/src/content/docs';
+const rows = readFileSync('scripts/migration/sp2-slug-map.tsv', 'utf8')
+  .trim().split('\n').map(l => l.split('\t'));
+for (const [oldSlug, newSlug] of rows) {
+  const ext = existsSync(`${base}/${oldSlug}.mdx`) ? '.mdx' : '.md';
+  const src = `${base}/${oldSlug}${ext}`;
+  const dst = `${base}/${newSlug}${ext}`;
+  if (!existsSync(src)) { console.error('MISSING', src); process.exit(1); }
+  mkdirSync(dirname(dst), { recursive: true });
+  renameSync(src, dst);
+}
+console.log(`moved ${rows.length} files`);
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+bun scripts/migration/sp2-move.mjs
+```
+
+Expected: `moved 52 files`.
+
+- [ ] **Step 3: Verify sources gone, targets present**
+
+```bash
+cut -f1 scripts/migration/sp2-slug-map.tsv | while read s; do test -e "site/src/content/docs/$s.md" -o -e "site/src/content/docs/$s.mdx" && echo "STILL THERE: $s"; done
+cut -f2 scripts/migration/sp2-slug-map.tsv | while read s; do test -e "site/src/content/docs/$s.md" -o -e "site/src/content/docs/$s.mdx" || echo "MISSING TARGET: $s"; done
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Build (green; content links are stale until Task 5)**
+
+```bash
+cd site && bunx astro build
+```
+
+Expected: `astro build` SUCCEEDS — the autogenerated sidebar (Task 2) re-derives from the new tree, and stale **content** `](/old/)` links are hrefs that don't fail `astro build` (caught by `linkinator` in Task 8, fixed in Task 5).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "docs(ia): move docs into audience/mode buckets (holomush-44nxc)"`
+
+---
+
+## Phase 4: Links + alias
+
+### Task 5: Rewrite internal links via the slug map
+
+**Files:**
+
+- Create: `scripts/migration/sp2-rewrite-links.mjs`
+- Modify: all docs containing links to moved slugs
+
+- [ ] **Step 1: Write the link codemod**
+
+```javascript
+// scripts/migration/sp2-rewrite-links.mjs — rewrite root-absolute internal
+// links ](/old/) → ](/new/) for every moved slug. The slug is terminated by
+// `/?(#…)?)` so a longer slug (/operating/operations-foo) is NOT matched by a
+// shorter one (/operating/operations). Operates on all .md/.mdx in the collection.
+import { readFileSync, writeFileSync, globSync } from 'node:fs';
+const map = new Map(readFileSync('scripts/migration/sp2-slug-map.tsv', 'utf8')
+  .trim().split('\n').map(l => l.split('\t')));
+const files = globSync('site/src/content/docs/**/*.{md,mdx}');
+for (const f of files) {
+  let s = readFileSync(f, 'utf8'); let changed = false;
+  for (const [oldSlug, newSlug] of map) {
+    const re = new RegExp(`\\]\\(/${oldSlug}/?(#[^)]*)?\\)`, 'g');
+    s = s.replace(re, (_m, anchor = '') => { changed = true; return `](/${newSlug}/${anchor})`; });
+  }
+  if (changed) writeFileSync(f, s);
+}
+console.log('links rewritten');
+```
+
+- [ ] **Step 2: Run it + verify no stale links**
+
+```bash
+bun scripts/migration/sp2-rewrite-links.mjs
+cut -f1 scripts/migration/sp2-slug-map.tsv | while read s; do rg -q "\]\(/$s/?[)#]" site/src/content/docs && echo "STALE LINK to $s"; done
+```
+
+Expected: `links rewritten`, no `STALE LINK`.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(ia): rewrite internal links to new slugs (holomush-44nxc)"`
+
+### Task 6: Intra-group sidebar order + `~/*` tsconfig alias
+
+**Files:**
+
+- Modify: section/ordered pages' frontmatter; `site/tsconfig.json`
+
+- [ ] **Step 1: Set intra-group order where alphabetical is wrong**
+
+`autogenerate` orders alphabetically by default. For pages whose order matters (e.g. `getting-started` before `lua-plugins`; `installation` before `deployment`; section `index` first), add `sidebar:` frontmatter:
+
+```yaml
+---
+title: "Getting Started with Plugins"
+sidebar:
+  order: 1
+---
+```
+
+Apply `order: 0` to each section `index`; ordered sequences get ascending `order`; leave the rest alphabetical.
+
+- [ ] **Step 2: Add the `~/*` alias (preserve existing `include`/`exclude`)**
+
+The current `site/tsconfig.json` is `{ "extends": "astro/tsconfigs/strict", "include": [".astro/types.d.ts", "**/*"], "exclude": ["dist"] }`. Add `compilerOptions` **without dropping** the other keys:
+
+```jsonc
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": { "baseUrl": ".", "paths": { "~/*": ["src/*"] } },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}
+```
+
+- [ ] **Step 3: Build + eyeball nav**
+
+```bash
+cd site && bunx astro build
+```
+
+Then `bunx astro dev` — confirm all 5 sections render with mode subgroups, every previously-orphaned doc appears, ordering is right, and the accent color/logo are unchanged.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs(ia): sidebar order frontmatter + ~/* tsconfig alias (holomush-44nxc)"`
+
+---
+
+## Phase 5: Verification + follow-ups
+
+### Task 7: Invariant check scripts (INV-1/2/3/5/6)
+
+**Files:**
+
+- Create: `scripts/check-docs-ia.sh`, `scripts/tests/docs-ia.bats`
+
+- [ ] **Step 1: Write `check-docs-ia.sh`** — it MUST assert:
+
+- **INV-1 parity:** every content slug (all `.md`/`.mdx` under `site/src/content/docs` except root `index.mdx`) resolves to a built page `site/dist/<slug>/index.html` after `task docs:build`.
+- **INV-2 one-bucket:** no `.md`/`.mdx` sits directly under an audience dir except `index.*` — every non-index doc is under `<audience>/<mode>/…` (`reference/` is exempt; it's flat by design).
+- **INV-3 retired-gone:** `contributing/event-delivery.*` and `operating/legacy-id-cutover.*` are absent and no link resolves to their slugs (`rg` over the collection).
+- **INV-5 branding:** compare the working copy against **`main@origin`** (the SP2 branch base) using the **jj-native** `jj diff --from main@origin -- <paths>` (the worktree has no `.git`, so bare `git diff` fails): assert `site/src/styles/custom.css`, `site/src/assets/logo.png`, `site/public/favicon.png` are **unchanged** (empty diff); `site/astro.config.mjs` differs **only** within the `sidebar` field; `site/tsconfig.json` differs **only** by the added `compilerOptions.paths` alias.
+- **INV-6 nav≤7:** ≤7 top-level sidebar sections; flag any single mode folder with >7 direct children (operators' `how-to` is sub-grouped per the spec).
+
+- [ ] **Step 2: Write `docs-ia.bats`** wrapping the script with `assert_success`, plus a meta-test asserting `scripts/tests/fixtures/sp2-slug-map.tsv` (relocated in Task 10) has 52 rows. (Until Task 10 relocates it, point the meta-test at `scripts/migration/sp2-slug-map.tsv`; update the path in Task 10 Step 1.)
+
+- [ ] **Step 3: Run**
+
+```bash
+cd site && bunx astro build && cd .. && bats scripts/tests/docs-ia.bats
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "test(ia): IA parity/bucket/retire/branding/nav invariants (holomush-44nxc)"`
+
+### Task 8: Link-check + llms.txt (INV-4, INV-7)
+
+**Files:** none (uses `task docs:linkcheck` from SP1; verification only)
+
+- [ ] **Step 1: Build + link-check**
+
+```bash
+task docs:linkcheck
+```
+
+Expected: zero broken internal links (INV-4).
+
+- [ ] **Step 2: Verify llms outputs regenerated (INV-7)**
+
+```bash
+for f in llms.txt llms-full.txt llms-small.txt; do test -s "site/dist/$f" && echo "OK $f" || echo "MISSING $f"; done
+```
+
+Expected: all OK.
+
+### Task 9: File follow-up content-surgery beads
+
+**Files:** none (bd only)
+
+- [ ] **Step 1: For each ⚑ doc that mixes modes, file a follow-up**
+
+For each of `operating/operations`, `operating/authentication`, `operating/plugin-security`, `extending/plugin-guide`, `extending/plugin-config`, `extending/access-control`, `extending/substrate-contract`, `extending/events`, `contributing/integration-tests`, `contributing/hostfunc-context-audit` — open it; if it mixes Diátaxis modes, file:
+
+```bash
+bd create --type=task --priority=3 -l theme:docs-platform \
+  --title="Mode-purity rewrite: <new-slug>" \
+  --description="<new-slug> mixes Diátaxis modes; split/rewrite to one pure mode. Follow-up from SP2 (holomush-44nxc). See docs/superpowers/specs/2026-05-28-docs-diataxis-ia-design.md."
+```
+
+If a doc is already single-mode, note it and skip. Record the filed IDs: `bd note holomush-44nxc "SP2 follow-ups: <ids>"`.
+
+### Task 10: Final sweep + cleanup + pr-prep
+
+**Files:**
+
+- Move: `scripts/migration/sp2-slug-map.tsv` → `scripts/tests/fixtures/sp2-slug-map.tsv`
+- Delete: `scripts/migration/` (one-shot codemods)
+
+- [ ] **Step 1: Keep the map as a fixture; delete the codemods**
+
+```bash
+mkdir -p scripts/tests/fixtures
+mv scripts/migration/sp2-slug-map.tsv scripts/tests/fixtures/sp2-slug-map.tsv
+rm -rf scripts/migration
+```
+
+Update the `docs-ia.bats` 52-row meta-test path (Task 7 Step 2) to `scripts/tests/fixtures/sp2-slug-map.tsv`. `check-docs-ia.sh` derives the retired list inline (does not depend on the map at steady state).
+
+- [ ] **Step 2: Full sweep**
+
+```bash
+cd site && rm -rf dist && cd .. && task docs:build && task docs:linkcheck && bats scripts/tests/docs-ia.bats
+```
+
+Expected: all green.
+
+- [ ] **Step 3: `task fmt:markdown` then `task pr-prep`**
+
+```bash
+task fmt:markdown && task pr-prep
+```
+
+Expected: pass marker `✓ Fast PR checks passed`.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs(ia): finalize Diátaxis re-org; retain slug-map fixture, drop codemods (holomush-44nxc)"`
+
+---
+
+## Out of scope (follow-on)
+
+- Mode-purity content rewrites (Task 9 beads).
+- Net-new tutorials (player getting-started, etc.).
+- SP0 (proto comments), SP4 (gRPC coverage).
+<!-- adr-capture: sha256=3a25324db37e82b1; session=2f5ef07e; ts=2026-05-28T13:14:26Z; adrs=holomush-md3k4,holomush-38kmt -->

--- a/docs/superpowers/specs/2026-05-28-docs-diataxis-ia-design.md
+++ b/docs/superpowers/specs/2026-05-28-docs-diataxis-ia-design.md
@@ -1,0 +1,306 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Docs Site Diátaxis Information Architecture — Design (SP2)
+
+| Field         | Value                                                          |
+| ------------- | -------------------------------------------------------------- |
+| Status        | Draft — pending `design-reviewer`                              |
+| Tracking bead | `holomush-44nxc`                                               |
+| Date          | 2026-05-28                                                     |
+| Sub-project   | SP2 of the docs-platform program (anchor `holomush-rkwyb`)    |
+| Depends on    | SP1 (Astro Starlight migration) — landed `holomush-cwnu0`     |
+
+## Summary
+
+Re-organize the (now-Starlight) documentation into an **audience-first,
+Diátaxis-within** information architecture, flip the Starlight sidebar to
+**`autogenerate`** (so the folder tree *is* the navigation — structurally
+eliminating nav drift and surfacing every orphaned doc), and **retire** the
+two superseded docs. This is a **re-file-and-renavigate** pass: docs move into
+audience/mode buckets and links are rewritten, but content is **not** rewritten
+for mode-purity — docs that mix Diátaxis modes are flagged as follow-up beads.
+Site **branding is preserved byte-identical**.
+
+## Program context
+
+SP2 is the third sub-project of the `theme:docs-platform` program (see
+`docs/roadmap.md` and anchor `holomush-rkwyb`). SP1 (platform migration) landed;
+the site is Astro Starlight with content at `site/src/content/docs/`, an explicit
+43-entry sidebar, and ~21 docs orphaned from that sidebar (carried over by SP1's
+lift-and-shift but left hidden by design). SP2 fixes the IA that SP1 deliberately
+left untouched. SP0 (proto comments) and SP4 (gRPC coverage) are independent.
+
+## Motivation
+
+- **~21 orphaned docs.** SP1 moved every doc into the collection but ported the
+  nav 1:1, so core guides (`binary-plugins`, `lua-plugins`, `crypto-runbook`,
+  `integration-tests`, `audit-subjects`, …) are built but unreachable.
+- **No purpose-based organization.** The current structure is audience-only;
+  within each audience, learning material, procedures, reference, and concepts
+  are undifferentiated. Diátaxis gives readers a mode-shaped path to what they
+  need.
+- **Two superseded docs still shipping.** `contributing/event-delivery.md`
+  (self-titled "Superseded", replaced by JetStream) and
+  `operating/legacy-id-cutover.md` (a one-time migration whose end-state is
+  enforced by `internal/eventbus/no_legacy_id_grep_test.go`).
+- **Nav drift is a recurring class of bug.** Autogenerate removes the
+  hand-maintained sidebar entirely, making drift impossible rather than
+  lint-guarded.
+
+## Goals
+
+- **MUST** organize docs audience-first with Diátaxis modes
+  (tutorials / how-to / reference / explanation) within each audience.
+- **MUST** switch the sidebar to `autogenerate`, so every non-retired doc is
+  reachable (no orphans by construction).
+- **MUST** retire `contributing/event-delivery.md` and
+  `operating/legacy-id-cutover.md`, removing all inbound links.
+- **MUST** rewrite internal links to the new slugs via an old→new slug map,
+  keeping links **root-absolute** (never relative `../`).
+- **MUST** preserve site branding (title, description, logo, favicon, accent
+  palette, brand assets) byte-identical.
+- **MUST** keep the build green and regenerate `llms.txt`.
+- **MUST** file follow-up beads for docs that mix Diátaxis modes (content
+  surgery deferred).
+
+## Non-goals
+
+- **MUST NOT** rewrite doc *content* for mode-purity (splitting mixed docs) —
+  that is follow-up work.
+- **MUST NOT** author net-new docs (e.g. missing tutorials) beyond placement —
+  gaps are filed as beads.
+- **MUST NOT** alter the generated-artifact pipelines (`docs:proto`,
+  `docs:gen-events`, `generate:ebnf`) beyond any slug/link updates the move
+  requires.
+- **MUST NOT** touch SP0 (proto comments) or SP4 (gRPC coverage).
+
+## Architecture
+
+### Target structure (audience-first, Diátaxis-within)
+
+The folder tree under `site/src/content/docs/` becomes the navigation:
+
+```mermaid
+graph TD
+    R["site/src/content/docs/"]
+    R --> G["guide/ (players & designers)"]
+    R --> O["operating/ (operators)"]
+    R --> E["extending/ (plugin developers)"]
+    R --> C["contributing/ (contributors)"]
+    R --> F["reference/ (generated, cross-cutting — stays flat)"]
+    G --> Gh["how-to/ · explanation/ · reference/"]
+    O --> Oh["how-to/ · reference/ · explanation/"]
+    E --> Eh["tutorials/ · how-to/ · reference/ · explanation/"]
+    C --> Ch["how-to/ · explanation/ · reference/"]
+```
+
+Rules:
+
+- The root splash page `site/src/content/docs/index.mdx` stays at the root,
+  **untouched** — it is outside every audience directory, so `autogenerate` on
+  those directories never surfaces it and it is excluded from the bucketing
+  tables by design.
+- A section `index.md` stays at the audience root as that section's landing page.
+- Mode subfolders are created **only where content exists** — no empty modes.
+- `reference/` (top level) holds **generated, cross-cutting** reference
+  (`grpc-api`, `events`, `access-control`, `audit-subjects`) and stays flat.
+  "Reference" thus appears both as this top-level section *and* as a Diátaxis
+  mode inside audiences (e.g. `operating/reference/configuration`); this is
+  intentional, not muddled — the top-level one is generated/cross-audience, the
+  in-audience ones are audience-specific.
+- **Nav-length guideline (Diátaxis):** landing/contents lists SHOULD stay ≤7
+  items. Where a mode bucket exceeds that (notably `operating/how-to`), it
+  SHOULD be topically sub-grouped (e.g. `operating/how-to/crypto/`) at plan
+  time.
+
+### Proposed bucketing
+
+Per-doc placement (`current slug` → `new slug`, mode, action). **Proposed** —
+each doc's mode is confirmed when opened at plan/implementation time; ambiguous
+ones (marked ⚑) and any found to mix modes get a follow-up content-surgery bead.
+
+#### guide/ (players & designers)
+
+| Current | New | Mode |
+| --- | --- | --- |
+| `guide/index` | `guide/index` | landing |
+| `guide/the-world` | `guide/explanation/the-world` | explanation |
+| `guide/connecting` | `guide/how-to/connecting` | how-to |
+| `guide/building` | `guide/how-to/building` | how-to |
+| `guide/commands` | `guide/reference/commands` | reference |
+
+#### operating/ (operators)
+
+| Current | New | Mode |
+| --- | --- | --- |
+| `operating/index` | `operating/index` | landing |
+| `operating/installation` | `operating/how-to/installation` | how-to |
+| `operating/deployment` | `operating/how-to/deployment` | how-to |
+| `operating/database` | `operating/how-to/database` | how-to |
+| `operating/ca-rotation` | `operating/how-to/ca-rotation` | how-to |
+| `operating/crypto-setup` | `operating/how-to/crypto-setup` | how-to |
+| `operating/crypto-runbook` | `operating/how-to/crypto-runbook` | how-to |
+| `operating/crypto-monitoring` | `operating/how-to/crypto-monitoring` | how-to |
+| `operating/telnet-security` | `operating/how-to/telnet-security` | how-to |
+| `operating/sentry` | `operating/how-to/sentry` | how-to |
+| `operating/verifying-releases` | `operating/how-to/verifying-releases` | how-to |
+| `operating/plugin-reloads` | `operating/how-to/plugin-reloads` | how-to |
+| `operating/sandbox-operations` | `operating/how-to/sandbox-operations` | how-to |
+| `operating/sandbox-restore` | `operating/how-to/sandbox-restore` | how-to |
+| `operating/operations` | `operating/how-to/operations` | how-to ⚑ |
+| `operating/configuration` | `operating/reference/configuration` | reference |
+| `operating/authentication` | `operating/explanation/authentication` | explanation ⚑ |
+| `operating/plugin-security` | `operating/explanation/plugin-security` | explanation ⚑ |
+| `operating/legacy-id-cutover` | — | **RETIRE** |
+
+> `operating/how-to` has ~14 entries (> the ≤7 guideline) → topically
+> sub-group. **Criterion:** any mode bucket with >7 entries is split by shared
+> topic prefix. Proposed split (confirm at plan time): `crypto/` (crypto-setup,
+> crypto-runbook, crypto-monitoring), `sandbox/` (sandbox-operations,
+> sandbox-restore), `deploy/` (installation, deployment, verifying-releases);
+> the remainder stay flat under `operating/how-to/`.
+
+#### extending/ (plugin developers)
+
+| Current | New | Mode |
+| --- | --- | --- |
+| `extending/index` | `extending/index` | landing |
+| `extending/getting-started` | `extending/tutorials/getting-started` | tutorial |
+| `extending/lua-plugins` | `extending/tutorials/lua-plugins` | tutorial |
+| `extending/binary-plugins` | `extending/tutorials/binary-plugins` | tutorial |
+| `extending/plugin-guide` | `extending/tutorials/plugin-guide` (`.mdx`) | tutorial ⚑ |
+| `extending/verb-registration` | `extending/how-to/verb-registration` | how-to |
+| `extending/audit-events` | `extending/how-to/audit-events` | how-to |
+| `extending/event-sensitivity` | `extending/how-to/event-sensitivity` | how-to |
+| `extending/plugin-config` | `extending/how-to/plugin-config` | how-to ⚑ |
+| `extending/plugin-crypto-readback` | `extending/how-to/plugin-crypto-readback` | how-to |
+| `extending/plugin-host-evaluate` | `extending/how-to/plugin-host-evaluate` | how-to |
+| `extending/access-control` | `extending/how-to/access-control` | how-to ⚑ |
+| `extending/abac-attribute-resolver` | `extending/how-to/abac-attribute-resolver` | how-to |
+| `extending/api-guide` | `extending/reference/api-guide` | reference |
+| `extending/substrate-contract` | `extending/reference/substrate-contract` | reference ⚑ |
+| `extending/actor-kinds-claimable` | `extending/reference/actor-kinds-claimable` | reference |
+| `extending/events` | `extending/reference/events` | reference ⚑ (overlaps `reference/events` — reconcile/merge at plan time) |
+| `extending/audit-chain` | `extending/explanation/audit-chain` | explanation |
+
+#### contributing/ (contributors)
+
+| Current | New | Mode |
+| --- | --- | --- |
+| `contributing/index` | `contributing/index` | landing |
+| `contributing/database-migrations` | `contributing/how-to/database-migrations` | how-to |
+| `contributing/pr-guide` | `contributing/how-to/pr-guide` | how-to |
+| `contributing/pr-prep` | `contributing/how-to/pr-prep` | how-to |
+| `contributing/quarantine` | `contributing/how-to/quarantine` | how-to |
+| `contributing/integration-tests` | `contributing/how-to/integration-tests` | how-to ⚑ |
+| `contributing/sessions` | `contributing/how-to/sessions` | how-to |
+| `contributing/coding-standards` | `contributing/reference/coding-standards` | reference |
+| `contributing/architecture` | `contributing/explanation/architecture` | explanation |
+| `contributing/authentication` | `contributing/explanation/authentication` | explanation |
+| `contributing/event-store` | `contributing/explanation/event-store` | explanation |
+| `contributing/event-emit-pipeline` | `contributing/explanation/event-emit-pipeline` | explanation |
+| `contributing/gateway-boundary` | `contributing/explanation/gateway-boundary` | explanation |
+| `contributing/hostfunc-context-audit` | `contributing/explanation/hostfunc-context-audit` | explanation ⚑ |
+| `contributing/lifecycle-and-health` | `contributing/explanation/lifecycle-and-health` | explanation |
+| `contributing/event-delivery` | — | **RETIRE** (superseded) |
+
+#### reference/ (generated, cross-cutting — flat)
+
+| Current | New | Mode |
+| --- | --- | --- |
+| `reference/index` | `reference/index` | landing |
+| `reference/grpc-api` | `reference/grpc-api` | reference (generated) |
+| `reference/events` | `reference/events` | reference (generated) |
+| `reference/access-control` | `reference/access-control` | reference |
+| `reference/audit-subjects` | `reference/audit-subjects` | reference (was orphan → surfaced) |
+
+### Sidebar (autogenerate)
+
+`astro.config.mjs`'s explicit 43-entry `sidebar` is replaced with one
+`autogenerate` group per audience section, e.g.:
+
+```javascript
+sidebar: [
+  { label: 'Guide',        autogenerate: { directory: 'guide' } },
+  { label: 'Operating',    autogenerate: { directory: 'operating' } },
+  { label: 'Extending',    autogenerate: { directory: 'extending' } },
+  { label: 'Contributing', autogenerate: { directory: 'contributing' } },
+  { label: 'Reference',    autogenerate: { directory: 'reference' } },
+],
+```
+
+Mode subfolders become nested collapsible groups (labels title-cased from folder
+names; refine "How To" → "How-to guides" via per-page/group config at plan time).
+Per-page `sidebar.order` / `sidebar.label` frontmatter sets intra-group order
+where alphabetical is wrong.
+
+### Link rewriting
+
+Moving ~50 docs changes their slugs. The implementation builds an explicit
+**old-slug → new-slug map** and rewrites every internal link via codemod.
+Internal links MUST be **root-absolute slugs** (`/extending/tutorials/lua-plugins/`),
+never relative `../` — root-absolute is the SP1-established convention (128 such
+links today vs 3 relative) and survives the *source* moving. A link checker
+(INV-4) backstops the codemod. Inbound links to the two retired docs are removed
+(not rewritten).
+
+### Branding preservation
+
+The re-org touches only content files and the `sidebar` field. It MUST leave
+unchanged: `astro.config.mjs` `title`/`description`/`logo`/`favicon`/`customCss`;
+`site/src/styles/custom.css` (deep-orange `#ff5722` accent + amber `#ffcc80`);
+and brand assets `site/src/assets/logo.png`, `site/public/favicon.png`.
+
+### Import aliasing
+
+Add a `tsconfig.json` path alias `~/*` → `src/*` (absent from
+`astro/tsconfigs/strict`) as forward-hygiene for future MDX/`.astro` component
+and asset imports, so deeper nesting never forces `../../../` import paths. (Doc
+*links* need no alias — they use root-absolute slugs.)
+
+### Follow-up beads
+
+Docs marked ⚑ (mode ambiguous) and any found to mix modes when opened get a
+content-surgery follow-up bead (`bead-create-smart`, labeled
+`theme:docs-platform`), so mode-purity is iterative per Diátaxis's own adoption
+guidance.
+
+## Invariants
+
+| ID | Invariant | Verification |
+| --- | --- | --- |
+| INV-1 | Every non-retired doc is reachable via the autogenerated sidebar. | Structural via `autogenerate` (any file in a configured directory is in the nav by construction). Verified concretely by a script that asserts every content slug (minus retired) resolves to a built page under `site/dist/<slug>/index.html` after `task docs:build`, backstopped by INV-4. |
+| INV-2 | Each page lives in exactly one audience/mode bucket (or an audience root `index`); no page sits directly under an audience dir except `index`. | Path-shape lint over `site/src/content/docs`. |
+| INV-3 | The two superseded docs are deleted and have zero inbound links. | `rg` guard: files absent; no link resolves to their old slugs. |
+| INV-4 | Zero broken internal links after the move. | `linkinator` over `site/dist` in CI. |
+| INV-5 | Branding unchanged: `title`/`description`/`logo`/`favicon`/`customCss` fields, `custom.css`, and brand assets are byte-identical to pre-SP2. | Diff assertion on those paths/fields. The **only** permitted config changes in SP2 are: the `sidebar` field of `astro.config.mjs`, and the added `paths` alias in `tsconfig.json` — any other diff to `astro.config.mjs` / `tsconfig.json` / `custom.css` / brand assets fails the check. |
+| INV-6 | Top-level nav is ≤7 sections; any mode group >7 is topically sub-grouped. | Nav-shape check. |
+| INV-7 | Build green and `llms.txt`/`llms-full.txt`/`llms-small.txt` regenerate non-empty. | `task docs:build` + post-build assertion. |
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| URL slugs change site-wide (every moved doc) | Accepted — no external link contracts (SP1 stance). The old→new map + link-check keep internal links intact. |
+| Autogenerate group labels read poorly ("How To") | Set group labels / `sidebar.label` at plan time; verify in preview. |
+| `operating/how-to` over-long | Topical sub-grouping (INV-6). |
+| `extending/events` duplicates `reference/events` | Reconcile (merge or cross-link) at plan time; flagged ⚑. |
+| A retired doc has inbound links elsewhere | INV-3 `rg` guard catches them before merge. |
+
+## Out of scope (follow-on)
+
+- Mode-purity content rewrites for ⚑/mixed docs (follow-up beads).
+- Net-new tutorials (e.g. a player "getting started", a guide tutorial).
+- SP0 (proto comments), SP4 (gRPC coverage).
+
+## References
+
+- SP1 result: `site/astro.config.mjs`, `site/src/content/docs/**`, `site/src/styles/custom.css`.
+- Diátaxis: <https://diataxis.fr> and <https://diataxis.fr/complex-hierarchies/> (both mode-first and audience-first valid; user-perception drives; nav lists ≤7; never muddle purposes).
+- Starlight sidebar `autogenerate`: context7 `/withastro/starlight`.
+- Program anchor `holomush-rkwyb`; roadmap `docs/roadmap.md` § `theme:docs-platform`.
+- Retire evidence: `internal/eventbus/no_legacy_id_grep_test.go` (legacy_id eliminated); `contributing/event-delivery.md` "Superseded" banner.
+<!-- adr-capture: sha256=ae56ff05d9f7864d; session=2f5ef07e; ts=2026-05-28T13:14:26Z; adrs=holomush-md3k4,holomush-38kmt -->


### PR DESCRIPTION
Planning artifacts for **SP2** of the `theme:docs-platform` program — re-organizing the docs into an **audience-first / Diátaxis-within** structure, flipping the sidebar to `autogenerate`, surfacing the ~21 orphaned docs, and retiring 2 superseded docs.

**Docs-only PR** (no site/code changes). Implementation is the 10-task epic `holomush-44nxc`; this lands the spec/plan/ADRs on `main` for implementer subagents.

## Contents
- **Spec:** `docs/superpowers/specs/2026-05-28-docs-diataxis-ia-design.md` — `design-reviewer` READY
- **Plan:** `docs/superpowers/plans/2026-05-28-docs-diataxis-ia.md` — `plan-reviewer` READY (2 rounds), 10 tasks
- **ADRs:** `holomush-md3k4` (audience-first Diátaxis-within IA), `holomush-38kmt` (autogenerate sidebar over explicit)

## Key decisions
- **Audience-first, Diátaxis-within** (rejected mode-first/hybrid; grounded in Diátaxis complex-hierarchies guidance).
- **Autogenerate sidebar** makes nav-drift structurally impossible (the root cause of the ~21 orphans); flipped *before* the move so the build never references a moved/deleted slug.
- **Branding preserved byte-identical** (INV-5); root-absolute slug links via old→new map; 2 superseded docs retired.

## Scope discipline
Re-file + renavigate only. Mode-purity content rewrites → follow-up beads (Task 9). SP0 (proto comments) / SP4 (gRPC coverage) out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)