### PR TITLE
docs(brand): holomush.dev software brand refresh — spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-05-28-holomush-software-brand-refresh.md
+++ b/docs/superpowers/plans/2026-05-28-holomush-software-brand-refresh.md
@@ -1,0 +1,638 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# HoloMUSH Software Brand Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dated glossy-orb `holomush.dev` brand with the "holographic terminal" system — a cyan app-tile mark (`h` + cutout) and a `>holomush_` monospace command-line wordmark with an amber underscore accent — across favicon, header logo, OG card, GitHub assets, the docs-site palette, and project guidance.
+
+**Architecture:** A single re-runnable Node/bun generator (`site/scripts/build-brand-assets.mjs`) is the source of truth for all raster/vector assets. It uses `opentype.js` to outline JetBrains Mono glyphs to SVG paths (font-independent output, INV-3), composes the master SVGs (tile + light/dark lockups), and uses `sharp` (already a site dep) to rasterize PNG favicons and composite the OG card over a one-time fal.ai-generated backdrop. Site wiring is `astro.config.mjs` (logo/favicon/head) + `custom.css` (cyan-only Starlight accent tokens). Brand rules are codified in `.claude/rules/branding.md` + `site/CLAUDE.md`.
+
+**Tech Stack:** Astro + Starlight, `opentype.js`, `sharp`, JetBrains Mono (OFL), fal.ai (Nano Banana Pro for OG backdrop), CSS custom properties.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md` (8 RFC2119 invariants — INV-1 amber-cursor-only, INV-3 outline-to-paths, INV-5 light/dark, INV-6 game-world-out-of-scope, INV-7 tokens-in-custom.css, INV-8 guidance).
+
+**Palette tokens:** cyan-bright `#3dd6f7` · tile gradient `#34d6f6 → #1565c0` · cyan-deep `#1565c0` · amber `#ffb300` (cursor only) · ink `#0b0c0e`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `site/scripts/build-brand-assets.mjs` | **Create.** Generator: outlines glyphs, writes master SVGs, rasterizes PNGs, composites OG card. Source of truth. |
+| `site/scripts/lib/glyphs.mjs` | **Create.** Loads JetBrains Mono TTF, returns SVG path `d` for a string at a baseline/size via opentype.js. |
+| `site/src/assets/brand/fonts/JetBrainsMono-Medium.ttf` | **Create.** Committed OFL font for outlining (build-time only). |
+| `site/src/assets/brand/og-backdrop.png` | **Create.** One-time fal.ai holographic backdrop (1200×630), committed source. |
+| `site/src/assets/logo-dark.svg` | **Create.** Header lockup, dark mode (cyan-bright wordmark). Generated. |
+| `site/src/assets/logo-light.svg` | **Create.** Header lockup, light mode (cyan-deep wordmark). Generated. |
+| `site/public/favicon.svg` | **Create.** Primary favicon (tile, outlined `h` + amber underscore). Generated. |
+| `site/public/favicon-16.png` / `-32.png` / `-48.png` | **Create.** PNG fallbacks. Generated. |
+| `site/public/apple-touch-icon.png` | **Create.** 180×180 on opaque ink. Generated. |
+| `site/public/og-card.png` | **Create.** 1200×630 social card. Generated. |
+| `site/public/favicon.png` | **Replace** (regenerated 32px) or **delete** (superseded by `.svg`). |
+| `site/src/assets/logo.png`, `site/src/assets/favicon.png` | **Delete.** Superseded. |
+| `site/astro.config.mjs:14-15` | **Modify.** `logo: {light,dark}`, `favicon: '/favicon.svg'`, `head: [...]`. |
+| `site/src/styles/custom.css:4-16` | **Modify.** Cyan-only Starlight accent tokens (light+dark) + `--brand-*` tokens. |
+| `site/package.json` | **Modify.** Add `opentype.js` devDep + `brand:build` script. |
+| `.claude/rules/branding.md` | **Create.** Auto-loading brand rules (paths-scoped). |
+| `site/CLAUDE.md` | **Modify.** Add `## Branding` section. |
+| `CLAUDE.md` (root) | **Modify.** Pointer to branding guidance. |
+| `assets/brand/og-avatar.png`, README banner | **Create.** GitHub org avatar + README banner; embed banner in `README.md`. |
+
+---
+
+## Phase 1: Toolchain
+
+### Task 1: Brand toolchain deps + font
+
+**Files:**
+
+- Modify: `site/package.json`
+- Create: `site/src/assets/brand/fonts/JetBrainsMono-Medium.ttf`
+- Create: `site/scripts/` (directory)
+
+- [ ] **Step 1: Obtain the font**
+
+Download JetBrains Mono from the official source (`https://github.com/JetBrains/JetBrainsMono/releases` — verify the latest release tag first; the family is OFL-licensed and redistributable). Extract `fonts/ttf/JetBrainsMono-Medium.ttf` into `site/src/assets/brand/fonts/`.
+
+Run: `ls -la site/src/assets/brand/fonts/JetBrainsMono-Medium.ttf`
+Expected: file present, ~200KB.
+
+- [ ] **Step 2: Add the outlining dependency**
+
+In `site/`, run: `bun add -d opentype.js`
+Expected: `opentype.js` appears under `devDependencies` in `site/package.json`. (`sharp` is already a dependency — do not re-add.)
+
+- [ ] **Step 3: Add the build script entry**
+
+In `site/package.json` `scripts`, add:
+
+```json
+"brand:build": "node scripts/build-brand-assets.mjs"
+```
+
+- [ ] **Step 4: Verify opentype loads the font**
+
+Run: `cd site && node -e "Promise.all([import('opentype.js'),import('node:fs')]).then(([o,fs])=>{const b=fs.readFileSync('src/assets/brand/fonts/JetBrainsMono-Medium.ttf');const f=o.parse(b.buffer.slice(b.byteOffset,b.byteOffset+b.byteLength));console.log('units/em',f.unitsPerEm,'h-path-ok',!!f.getPath('h',0,0,100).toPathData())})"`
+Expected: prints `units/em 1000 h-path-ok true` (unitsPerEm may differ; the boolean MUST be `true`).
+
+- [ ] **Step 5: Commit**
+
+Commit (this is a jj-colocated repo — `jj describe`/`jj commit`, see the `jj:jujutsu` skill): `feat(brand): add JetBrains Mono + opentype.js for asset outlining (holomush-7daup)`
+
+---
+
+### Task 2: Glyph-outlining helper
+
+**Files:**
+
+- Create: `site/scripts/lib/glyphs.mjs`
+- Test: inline node assertion (Step 2)
+
+- [ ] **Step 1: Write the helper**
+
+```javascript
+// site/scripts/lib/glyphs.mjs
+// opentype.js ESM exposes NAMED exports only (no default export). Use the
+// namespace/named form under Node ESM, and parse() (loadSync is deprecated).
+import { parse } from 'opentype.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FONT = resolve(here, '../../src/assets/brand/fonts/JetBrainsMono-Medium.ttf');
+const _buf = readFileSync(FONT);
+const font = parse(_buf.buffer.slice(_buf.byteOffset, _buf.byteOffset + _buf.byteLength));
+
+// Return { d, width } for `text` rendered with baseline at (x,y), em size `size`.
+export function glyphPath(text, x, y, size) {
+  const path = font.getPath(text, x, y, size);
+  const adv = font.getAdvanceWidth(text, size);
+  return { d: path.toPathData(2), width: adv };
+}
+
+export const EM = font.unitsPerEm;
+```
+
+- [ ] **Step 2: Verify it emits a path and advance width**
+
+Run: `cd site && node -e "import('./scripts/lib/glyphs.mjs').then(m=>{const g=m.glyphPath('h',0,160,160);console.log('hasD', g.d.startsWith('M'), 'w>0', g.width>0)})"`
+Expected: `hasD true w>0 true`
+
+- [ ] **Step 3: Commit**
+
+`feat(brand): glyph-to-path helper via opentype (holomush-7daup)`
+
+---
+
+## Phase 2: Master vector assets
+
+### Task 3: Tile mark → `favicon.svg`
+
+The tile: 256×256 rounded square, cyan gradient, lowercase `h` knocked out as a transparent cutout (via mask), solid amber underscore. The `h` is an outlined path (INV-3), not `<text>`.
+
+**Files:**
+
+- Modify: `site/scripts/build-brand-assets.mjs` (create in this task)
+- Create (generated): `site/public/favicon.svg`
+
+- [ ] **Step 1: Write the generator's tile section**
+
+```javascript
+// site/scripts/build-brand-assets.mjs
+// All imports MUST stay at the top of the file (ESM requirement). `sharp` is
+// imported here for use in later tasks (raster/composite); unused until Task 5.
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import sharp from 'sharp';
+import { glyphPath } from './lib/glyphs.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PUBLIC = resolve(here, '../public');
+const ASSETS = resolve(here, '../src/assets');
+mkdirSync(PUBLIC, { recursive: true });
+
+const CYAN1 = '#34d6f6', CYAN2 = '#1565c0', AMBER = '#ffb300';
+
+// h outlined: baseline y=188, x=60, size 160 (see spec reference geometry)
+const h = glyphPath('h', 60, 188, 160);
+
+const tileSvg = `<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="HoloMUSH">
+<defs>
+<linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="${CYAN1}"/><stop offset="1" stop-color="${CYAN2}"/></linearGradient>
+<mask id="cut"><rect width="256" height="256" rx="58" fill="#fff"/><path d="${h.d}" fill="#000"/></mask>
+</defs>
+<rect width="256" height="256" rx="58" fill="url(#g)" mask="url(#cut)"/>
+<rect x="158" y="170" width="46" height="16" rx="3" fill="${AMBER}"/>
+</svg>
+`;
+writeFileSync(`${PUBLIC}/favicon.svg`, tileSvg);
+console.log('wrote favicon.svg');
+```
+
+- [ ] **Step 2: Run the generator**
+
+Run: `cd site && node scripts/build-brand-assets.mjs`
+Expected: prints `wrote favicon.svg`; `site/public/favicon.svg` exists.
+
+- [ ] **Step 3: Verify it is valid SVG and renders at favicon sizes**
+
+Run: `cd site && for s in 16 32 48; do rsvg-convert -w $s -h $s public/favicon.svg -o /tmp/fav-$s.png && magick identify /tmp/fav-$s.png | head -1; done`
+Expected: three lines, each reporting a `PNG <s>x<s>` image with no parse error. Open `/tmp/fav-16.png` and confirm the `h` is readable and the amber underscore is visible (INV-2: underscore may be faint at 16px — acceptable as long as the `h` reads).
+
+- [ ] **Step 4: Commit**
+
+`feat(brand): generate tile favicon.svg with outlined h + amber cursor (holomush-7daup)`
+
+---
+
+### Task 4: Header lockups (light + dark) → `logo-light.svg` / `logo-dark.svg`
+
+The horizontal lockup: tile (left) + `>holomush_` wordmark (right). Wordmark = dimmed prompt `>`, `holomush` in cyan (bright on dark, deep on light), trailing amber underscore. All glyphs outlined.
+
+**Files:**
+
+- Modify: `site/scripts/build-brand-assets.mjs`
+- Create (generated): `site/src/assets/logo-dark.svg`, `site/src/assets/logo-light.svg`
+
+- [ ] **Step 1: Add the lockup builder to the generator**
+
+Append to `build-brand-assets.mjs` (before any final log):
+
+```javascript
+// --- Header lockups -------------------------------------------------
+// Reusable inner tile (no aria; embedded). 96px tile on a 520x128 canvas.
+function tileGroup(idSuffix) {
+  // The tile is the full 256-unit artwork, scaled to 96px and offset into the
+  // 128px-tall lockup canvas. The h path uses the same full-tile coords as the
+  // standalone favicon (60,188,160).
+  return `<g transform="translate(16,16) scale(0.375)">
+<defs><linearGradient id="g${idSuffix}" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="${CYAN1}"/><stop offset="1" stop-color="${CYAN2}"/></linearGradient>
+<mask id="cut${idSuffix}"><rect width="256" height="256" rx="58" fill="#fff"/><path d="${glyphPath('h',60,188,160).d}" fill="#000"/></mask></defs>
+<rect width="256" height="256" rx="58" fill="url(#g${idSuffix})" mask="url(#cut${idSuffix})"/>
+<rect x="158" y="170" width="46" height="16" rx="3" fill="${AMBER}"/></g>`;
+}
+
+function lockup({ id, wordColor, promptOpacity }) {
+  const baseY = 84, size = 54, wordX = 120;
+  const prompt = glyphPath('>', wordX, baseY, size);
+  const word = glyphPath('holomush', wordX + prompt.width, baseY, size);
+  const cursorX = wordX + prompt.width + word.width + 8;
+  return `<svg viewBox="0 0 ${Math.ceil(cursorX + 44)} 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="HoloMUSH">
+${tileGroup(id)}
+<path d="${prompt.d}" fill="${wordColor}" opacity="${promptOpacity}"/>
+<path d="${word.d}" fill="${wordColor}"/>
+<rect x="${cursorX}" y="${baseY - 8}" width="30" height="8" rx="2" fill="${AMBER}"/>
+</svg>
+`;
+}
+
+writeFileSync(`${ASSETS}/logo-dark.svg`, lockup({ id: 'd', wordColor: '#3dd6f7', promptOpacity: '0.5' }));
+writeFileSync(`${ASSETS}/logo-light.svg`, lockup({ id: 'l', wordColor: '#1565c0', promptOpacity: '0.55' }));
+console.log('wrote logo-dark.svg, logo-light.svg');
+```
+
+- [ ] **Step 2: Run and verify both lockups render**
+
+Run: `cd site && node scripts/build-brand-assets.mjs && rsvg-convert src/assets/logo-dark.svg -o /tmp/logo-dark.png && rsvg-convert src/assets/logo-light.svg -o /tmp/logo-light.png && magick identify /tmp/logo-dark.png /tmp/logo-light.png`
+Expected: two PNGs reported, no parse error. Open both: tile + `>holomush_` reads cleanly; underscore is amber; dark variant uses bright cyan, light variant uses deep cyan. If glyph spacing or vertical centering looks off, adjust `baseY`/`wordX`/`scale` constants and re-run (this is the one expected tuning loop — verify by eye against the brainstorm `board-final` reference).
+
+- [ ] **Step 3: Commit**
+
+`feat(brand): generate light/dark header lockups with outlined wordmark (holomush-7daup)`
+
+---
+
+## Phase 3: Rasterized assets
+
+### Task 5: PNG favicons + apple-touch icon
+
+**Files:**
+
+- Modify: `site/scripts/build-brand-assets.mjs`
+- Create (generated): `site/public/favicon-16.png`, `-32.png`, `-48.png`, `site/public/favicon.png`, `site/public/apple-touch-icon.png`
+
+- [ ] **Step 1: Add sharp rasterization**
+
+Append to `build-brand-assets.mjs` (the `sharp` import is already at the top of the file from Task 3 — do **not** add another import here):
+
+```javascript
+const faviconSvgBuf = Buffer.from(tileSvg);
+for (const s of [16, 32, 48]) {
+  await sharp(faviconSvgBuf, { density: 384 }).resize(s, s).png().toFile(`${PUBLIC}/favicon-${s}.png`);
+}
+// Legacy /favicon.png path (Safari/older) = 32px tile
+await sharp(faviconSvgBuf, { density: 384 }).resize(32, 32).png().toFile(`${PUBLIC}/favicon.png`);
+// apple-touch 180 on opaque ink (no transparency for iOS)
+await sharp(faviconSvgBuf, { density: 720 })
+  .resize(180, 180)
+  .flatten({ background: '#0b0c0e' })
+  .png().toFile(`${PUBLIC}/apple-touch-icon.png`);
+console.log('wrote PNG favicons + apple-touch-icon');
+```
+
+(Note: the file's top-level code must run in an async context — wrap the script body in `async function main(){…}; await main();` or rely on top-level `await`, which Node ESM supports. Use top-level `await`.)
+
+- [ ] **Step 2: Run and verify dimensions**
+
+Run: `cd site && node scripts/build-brand-assets.mjs && for f in favicon-16 favicon-32 favicon-48 favicon apple-touch-icon; do magick identify public/$f.png | head -1; done`
+Expected: `favicon-16` → 16×16, `-32`/`favicon` → 32×32, `-48` → 48×48, `apple-touch-icon` → 180×180, the apple-touch one fully opaque.
+
+- [ ] **Step 3: Commit**
+
+`feat(brand): rasterize PNG favicons + apple-touch icon via sharp (holomush-7daup)`
+
+---
+
+### Task 6: OG / social card (fal.ai backdrop + composite)
+
+**Files:**
+
+- Create: `site/src/assets/brand/og-backdrop.png` (one-time, generated by the implementing agent via fal.ai)
+- Modify: `site/scripts/build-brand-assets.mjs`
+- Create (generated): `site/public/og-card.png`
+
+- [ ] **Step 1: Generate the backdrop (one-time, agent action)**
+
+Using the fal.ai MCP `run_model` with `fal-ai/nano-banana-pro` (~$0.15), generate a 1200×630 atmospheric backdrop. Prompt: *"A subtle dark holographic backdrop, near-black ink ground (#0b0c0e) with faint cyan scanlines and a soft cyan glow gradient in the lower right, generous empty space on the left for a logo, no text, cinematic, 16:9 wide."* Download the result to `site/src/assets/brand/og-backdrop.png` and confirm it is 1200×630 (resize with sharp if the model returns another ratio). Commit it as a source asset.
+
+Run: `magick identify site/src/assets/brand/og-backdrop.png | head -1`
+Expected: `PNG 1200x630`.
+
+- [ ] **Step 2: Composite the lockup over the backdrop**
+
+Append to `build-brand-assets.mjs`:
+
+```javascript
+// OG card: dark lockup composited over the fal.ai backdrop, left-aligned
+const ogLockupPng = await sharp(Buffer.from(lockup({ id: 'og', wordColor: '#3dd6f7', promptOpacity: '0.5' })), { density: 300 })
+  .resize({ width: 760 }).png().toBuffer();
+await sharp(`${ASSETS}/brand/og-backdrop.png`)
+  .resize(1200, 630)
+  .composite([{ input: ogLockupPng, left: 90, top: 250 }])
+  .png().toFile(`${PUBLIC}/og-card.png`);
+console.log('wrote og-card.png');
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `cd site && node scripts/build-brand-assets.mjs && magick identify public/og-card.png | head -1`
+Expected: `PNG 1200x630`. Open it: lockup is legible, left-aligned, not clipped; amber cursor visible against cyan.
+
+- [ ] **Step 4: Commit**
+
+`feat(brand): OG social card via fal.ai backdrop + sharp composite (holomush-7daup)`
+
+---
+
+## Phase 4: Site integration
+
+### Task 7: Recolor palette tokens (`custom.css`)
+
+INV-1: Starlight accent slots are **cyan only**; amber appears nowhere in UI tokens (it lives only inside the logo SVGs). INV-7: all brand colors are `--brand-*` custom properties.
+
+**Files:**
+
+- Modify: `site/src/styles/custom.css`
+
+- [ ] **Step 1: Replace the token block**
+
+Replace `site/src/styles/custom.css` lines 4-16 (the comment + both `:root` blocks) with:
+
+```css
+/* Brand tokens — holographic terminal (INV-1, INV-7). Amber is logo-only. */
+:root {
+  --brand-cyan-bright: #3dd6f7;
+  --brand-cyan-deep: #1565c0;
+  --brand-amber: #ffb300; /* logo cursor only — never a UI accent (INV-1) */
+  --brand-ink: #0b0c0e;
+
+  /* Starlight accent = cyan only (dark mode default) */
+  --sl-color-accent-low: #07303f;
+  --sl-color-accent: #3dd6f7;
+  --sl-color-accent-high: #b3ecfb;
+}
+
+:root[data-theme='light'] {
+  --sl-color-accent-low: #cdeefb;
+  --sl-color-accent: #1565c0;
+  --sl-color-accent-high: #0a3a66;
+}
+```
+
+- [ ] **Step 2: Verify no amber in Starlight tokens**
+
+Run: `cd site && rg -n 'sl-color-accent' src/styles/custom.css && rg -nc 'ffb300' src/styles/custom.css`
+Expected: the three accent vars resolve to cyan hexes only; `ffb300` appears exactly once (the `--brand-amber` definition with its INV-1 comment), never inside an `--sl-color-accent*` value.
+
+- [ ] **Step 3: Commit**
+
+`feat(brand): recolor docs accent to cyan, brand tokens (holomush-7daup)`
+
+---
+
+### Task 8: Wire `astro.config.mjs`
+
+**Files:**
+
+- Modify: `site/astro.config.mjs:14-15`
+
+- [ ] **Step 1: Replace the logo + favicon lines and add head tags**
+
+Replace `logo: { src: './src/assets/logo.png', alt: 'HoloMUSH' },` and `favicon: '/favicon.png',` with:
+
+```javascript
+      logo: {
+        light: './src/assets/logo-light.svg',
+        dark: './src/assets/logo-dark.svg',
+        alt: 'HoloMUSH',
+        replacesTitle: true,
+      },
+      favicon: '/favicon.svg',
+      head: [
+        { tag: 'link', attrs: { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32.png' } },
+        { tag: 'link', attrs: { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16.png' } },
+        { tag: 'link', attrs: { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' } },
+        { tag: 'meta', attrs: { property: 'og:image', content: 'https://holomush.dev/og-card.png' } },
+        { tag: 'meta', attrs: { property: 'og:image:width', content: '1200' } },
+        { tag: 'meta', attrs: { property: 'og:image:height', content: '630' } },
+        { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
+        { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://holomush.dev/og-card.png' } },
+      ],
+```
+
+(`replacesTitle: true` because the lockup contains the wordmark — avoids a duplicate "HoloMUSH" text beside the logo.)
+
+- [ ] **Step 2: Delete superseded source assets**
+
+Run: `cd site && rm src/assets/logo.png src/assets/favicon.png`
+Expected: both removed. (`public/favicon.png` is kept — regenerated in Task 5 as the legacy fallback.)
+
+- [ ] **Step 3: Verify config parses**
+
+Run: `cd site && node --check astro.config.mjs && rg -n "logo:|favicon:|og:image" astro.config.mjs`
+Expected: no syntax error; logo uses `light`/`dark`, favicon is `/favicon.svg`, og:image present.
+
+- [ ] **Step 4: Commit**
+
+`feat(brand): wire new logo/favicon/og tags into Starlight config (holomush-7daup)`
+
+---
+
+### Task 9: Build verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full asset regen + site build**
+
+Run: `cd site && node scripts/build-brand-assets.mjs && task docs:build`
+Expected: generator prints all "wrote …" lines; `task docs:build` exits 0 with the new assets bundled. (`task docs:build` wraps `bunx astro build` per `site/CLAUDE.md`.)
+
+- [ ] **Step 2: Visual smoke test (light + dark)**
+
+Run: `cd site && task docs:serve` and open the local URL. Confirm: header shows the cyan lockup; toggling light/dark swaps `logo-light`/`logo-dark`; favicon tile shows in the browser tab; links/active-nav render cyan (no orange, no amber).
+
+- [ ] **Step 3: Commit (if any tuning landed)**
+
+`chore(brand): regenerate assets, verify docs build (holomush-7daup)`
+
+---
+
+## Phase 5: Project guidance (INV-8)
+
+### Task 10: `.claude/rules/branding.md`
+
+**Files:**
+
+- Create: `.claude/rules/branding.md`
+
+- [ ] **Step 1: Write the rule (auto-loads on brand files)**
+
+```markdown
+---
+paths:
+  - "site/src/assets/**"
+  - "site/src/styles/custom.css"
+  - "site/public/favicon*"
+  - "site/public/og-card.png"
+  - "site/public/apple-touch-icon.png"
+  - "site/astro.config.mjs"
+  - "site/scripts/build-brand-assets.mjs"
+  - "README.md"
+---
+
+# HoloMUSH Software Branding
+
+The `holomush.dev` software brand is the **holographic terminal**: a cyan
+app-tile mark and a `>holomush_` monospace command-line wordmark. Full design:
+`docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md`.
+
+## Palette tokens (defined in `site/src/styles/custom.css`)
+
+| Token | Hex | Role |
+| --- | --- | --- |
+| `--brand-cyan-bright` | `#3dd6f7` | wordmark + dark-mode links/accent |
+| tile gradient | `#34d6f6 → #1565c0` | tile fill |
+| `--brand-cyan-deep` | `#1565c0` | light-mode wordmark/links |
+| `--brand-amber` | `#ffb300` | **cursor only** |
+| `--brand-ink` | `#0b0c0e` | dark ground |
+
+## Rules
+
+| Requirement | Rule |
+| --- | --- |
+| **MUST NOT** use amber as a UI accent | `#ffb300` is the **cursor only** (tile underscore, wordmark cursor). Links, buttons, nav, fills are cyan. Putting amber in `--sl-color-accent*` is a bug (INV-1). |
+| **MUST** keep brand colors in tokens | All brand hex live in `site/src/styles/custom.css` `--brand-*`. No hardcoded brand hex in components (INV-7). |
+| **MUST** outline glyphs in logo SVGs | Logo/favicon SVGs carry the `h`/wordmark as vector `<path>`, not `<text>` — no runtime font dependency (INV-3). Regenerate via `site/scripts/build-brand-assets.mjs`. |
+| **MUST** ship light + dark lockups | `logo-light.svg` / `logo-dark.svg` (INV-5). The tile is palette-stable. |
+| **MUST NOT** touch game-world art | This brand is the **software/platform** only — never the game world / default setting (INV-6). |
+| **MUST** regenerate, not hand-edit | Assets are generated by `build-brand-assets.mjs`. Edit the script + rerun `bun run brand:build`; don't hand-edit generated SVG/PNG. |
+```
+
+- [ ] **Step 2: Verify frontmatter parses (YAML)**
+
+Run: `rg -n '^paths:' .claude/rules/branding.md && head -20 .claude/rules/branding.md`
+Expected: `paths:` frontmatter present with the brand globs.
+
+- [ ] **Step 3: Commit**
+
+`docs(brand): add .claude/rules/branding.md guidance (holomush-7daup)`
+
+---
+
+### Task 11: `site/CLAUDE.md` Branding section + root pointer
+
+**Files:**
+
+- Modify: `site/CLAUDE.md`
+- Modify: `CLAUDE.md` (root)
+
+- [ ] **Step 1: Add `## Branding` to `site/CLAUDE.md`**
+
+Insert after the `## Voice and Tone` section:
+
+```markdown
+## Branding
+
+The site brand is the **holographic terminal**: a cyan app-tile mark (`h` +
+cutout) and a `>holomush_` monospace wordmark with an **amber underscore
+cursor** as the only warm accent. Assets are generated by
+`scripts/build-brand-assets.mjs` (run `bun run brand:build`); never hand-edit
+the generated SVG/PNG.
+
+- **Amber (`#ffb300`) is the cursor only** — links, nav, and buttons are cyan.
+- Brand colors live as `--brand-*` tokens in `src/styles/custom.css`.
+- Logo ships light + dark variants (`src/assets/logo-{light,dark}.svg`).
+- Full rules: `.claude/rules/branding.md`. Design:
+  `docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md`.
+```
+
+- [ ] **Step 2: Add a pointer to root `CLAUDE.md`**
+
+In the root `CLAUDE.md` "Documentation Structure" section, add a row/line after the site-docs entry:
+
+```markdown
+**Branding:** The software brand (logo, favicon, palette) is defined in
+`.claude/rules/branding.md` and `site/CLAUDE.md` — cyan tile + `>holomush_`
+wordmark, amber cursor accent only.
+```
+
+- [ ] **Step 3: Verify markdown lint passes**
+
+Run: `cd site && task lint:docs-symmetry 2>/dev/null; cd .. && bunx rumdl check --config site/.rumdl.toml site/CLAUDE.md .claude/rules/branding.md 2>/dev/null || echo "(run task lint to confirm in CI-pinned rumdl)"`
+Expected: no markdown violations in the new/edited files (verify under `task lint` before PR; rumdl version skew is a known gotcha).
+
+- [ ] **Step 4: Commit**
+
+`docs(brand): branding section in site/CLAUDE.md + root pointer (holomush-7daup)`
+
+---
+
+## Phase 6: GitHub assets
+
+### Task 12: Org avatar + README banner
+
+**Files:**
+
+- Modify: `site/scripts/build-brand-assets.mjs`
+- Create (generated): `assets/brand/og-avatar.png` (460×460), `assets/brand/readme-banner.png`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add avatar + banner outputs to the generator**
+
+Append to `build-brand-assets.mjs`:
+
+```javascript
+// reuse mkdirSync already imported at the top of the file (Task 3)
+const GH = resolve(here, '../../assets/brand');
+mkdirSync(GH, { recursive: true });
+// Org avatar: 460x460 tile on opaque ink
+await sharp(Buffer.from(tileSvg), { density: 920 })
+  .resize(460, 460).flatten({ background: '#0b0c0e' })
+  .png().toFile(`${GH}/og-avatar.png`);
+// README banner: 1280x320, dark lockup centered on ink
+const bannerLockup = await sharp(Buffer.from(lockup({ id: 'bn', wordColor: '#3dd6f7', promptOpacity: '0.5' })), { density: 300 })
+  .resize({ width: 720 }).png().toBuffer();
+await sharp({ create: { width: 1280, height: 320, channels: 4, background: '#0b0c0e' } })
+  .composite([{ input: bannerLockup, gravity: 'centre' }])
+  .png().toFile(`${GH}/readme-banner.png`);
+console.log('wrote og-avatar.png, readme-banner.png');
+```
+
+- [ ] **Step 2: Run and verify dimensions**
+
+Run: `cd site && node scripts/build-brand-assets.mjs && magick identify ../assets/brand/og-avatar.png ../assets/brand/readme-banner.png | cat`
+Expected: `og-avatar` 460×460 opaque, `readme-banner` 1280×320.
+
+- [ ] **Step 3: Embed the banner in README**
+
+`README.md` opens with an SPDX comment block (lines 1-4) then `# HoloMUSH` (line 6). Insert the banner **between the SPDX comment and the `# HoloMUSH` heading** — i.e. replace the blank line 5 region so the result reads:
+
+```markdown
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<p align="center"><img src="assets/brand/readme-banner.png" alt="HoloMUSH" width="640"></p>
+
+# HoloMUSH
+```
+
+Do not place the image above the SPDX header. There is no existing banner to replace.
+
+- [ ] **Step 4: Verify README renders the image path**
+
+Run: `rg -n 'assets/brand/readme-banner.png' README.md && ls assets/brand/readme-banner.png`
+Expected: reference present and file exists.
+
+- [ ] **Step 5: Commit**
+
+`feat(brand): org avatar + README banner (holomush-7daup)`
+
+(The org avatar is uploaded to GitHub org settings manually — outside the repo build.)
+
+---
+
+## Acceptance (maps to spec)
+
+- INV-1: `rg ffb300 site/src/styles/custom.css` shows amber only in `--brand-amber`, never in `--sl-color-accent*` (Task 7).
+- INV-2: favicon `h` readable at 16px (Task 3 Step 3).
+- INV-3: logo/favicon SVGs contain `<path>`, no `<text>` (Tasks 3-4) — `rg '<text' site/public/favicon.svg site/src/assets/logo-*.svg` returns nothing.
+- INV-4: wordmark renders `>holomush_` with dim prompt + amber underscore (Task 4).
+- INV-5: `logo-light.svg` + `logo-dark.svg` both ship, wired via `logo:{light,dark}` (Tasks 4, 8).
+- INV-6: no game-world assets touched anywhere in this plan.
+- INV-7: all brand hex are `--brand-*` tokens in `custom.css` (Task 7).
+- INV-8: `.claude/rules/branding.md` + `site/CLAUDE.md` Branding + root pointer (Tasks 10-11).
+- `task docs:build` green (Task 9); full asset set generated (favicon set, header light/dark, OG card, avatar, banner).
+
+## Out of Scope
+
+Game-world / default-setting branding (INV-6); `web/` PWA theming; body web-font loading (wordmark is outlined).
+<!-- adr-capture: sha256=4139d0149b92f47e; session=cli; ts=2026-05-28T14:02:07Z; adrs= -->

--- a/docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md
+++ b/docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md
@@ -1,0 +1,270 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# HoloMUSH Software Brand Refresh — Design
+
+| | |
+| --- | --- |
+| **Status** | Draft — pending design-reviewer |
+| **Bead** | holomush-7daup |
+| **Date** | 2026-05-28 |
+| **Scope** | Software/platform brand on `holomush.dev` (logo + imagery). **NOT** the game world / default setting. |
+
+## Context & Motivation
+
+The current `holomush.dev` brand is a glossy 3D-orb mark (a reflective sphere
+with an orange→amber flame "h" and a lowercase `holomush` wordmark baked into
+the raster) paired with a deep-orange / amber palette
+(`site/src/assets/logo.png`, `site/src/assets/favicon.png`, accent tokens in
+`site/src/styles/custom.css`).
+
+Four motivations drive the refresh (per `bd show holomush-7daup`):
+
+1. The orb mark reads as a mid-2000s "Web 2.0" aesthetic — dated.
+2. We want a more distinctive, ownable mark that scales cleanly to a favicon.
+3. We need a fuller asset set (wordmark, social cards, org avatar, light/dark).
+4. We want to sharpen what HoloMUSH-the-software *is* and express it visually.
+
+This refresh covers the **software/platform** identity only. The game world and
+default-setting visual language are explicitly out of scope.
+
+## Concept & Positioning
+
+**"HoloMUSH as a holographic terminal."**
+
+The name bridges two ideas, and the brand expresses both:
+
+- **Holo** → a holographic, projected-light reading, carried by a cool **cyan**
+  palette.
+- **MUSH** → the text-game / command-line heritage, carried by a **monospace
+  command-line wordmark** and a **cursor** motif.
+
+The signature detail is a single **amber underscore cursor** — the one warm
+spark against the cool cyan field. It ties the two halves of the concept
+together in one element and becomes the brand's most ownable feature.
+
+This positioning was reached through five visual exploration rounds (see
+*Alternatives Considered*); the convergence trace is recorded as `bd note`s on
+holomush-7daup.
+
+## Brand System
+
+### Primary mark — the tile
+
+A rounded-square tile filled with a cyan gradient, with a bold lowercase
+monospace **`h`** knocked out as transparent negative space, plus a solid
+**amber underscore** cursor. The solid tile shape holds at 16px where a bare
+glyph would thin out; the `h` carries recognition, the amber underscore adds
+the cursor motif at larger sizes.
+
+Reference geometry (the `h` is shown here as `<text>` for clarity; production
+assets MUST outline it to paths — see INV-3):
+
+```svg
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg"><defs>
+<linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#34d6f6"/><stop offset="1" stop-color="#1565c0"/></linearGradient>
+<mask id="m"><rect x="0" y="0" width="256" height="256" rx="58" fill="white"/>
+<text x="60" y="188" font-family="JetBrains Mono, monospace" font-size="160" font-weight="600" fill="black">h</text></mask></defs>
+<rect x="0" y="0" width="256" height="256" rx="58" fill="url(#g)" mask="url(#m)"/>
+<rect x="158" y="170" width="46" height="16" rx="3" fill="#ffb300"/></svg>
+```
+
+Used for: favicon, apple-touch-icon, GitHub org avatar, app/social profile icon.
+
+### Wordmark — the command line
+
+`>holomush_` set in a real monospace typeface:
+
+- a dimmed prompt `>` (≈55% opacity),
+- the lowercase word `holomush` in **cyan-bright**,
+- a trailing **amber underscore** cursor at the baseline.
+
+Used for: documentation site header, README banner, social/OG card, anywhere a
+horizontal brand signature is needed.
+
+### Lockups
+
+- **Horizontal lockup**: tile + wordmark, side by side (header, banner).
+- **Icon-only**: the tile (favicon, avatar).
+- **Wordmark-only**: `>holomush_` (inline text contexts).
+
+### Typography
+
+| Role | Typeface |
+| --- | --- |
+| Wordmark + cursor | **JetBrains Mono** (recommended — OFL-licensed, dev-native, excellent monospace rhythm) |
+
+JetBrains Mono is the production face (OFL-licensed, dev-native, even monospace
+rhythm). It is the typeface used throughout the brainstorm previews and is locked
+for the wordmark. Because the wordmark glyphs are outlined to paths (INV-3), no
+web-font loading is required at runtime — the font is needed only at asset-build
+time.
+
+### Color tokens
+
+| Token | Hex | Role |
+| --- | --- | --- |
+| `--brand-cyan-bright` | `#3dd6f7` | Wordmark letters; dark-mode links/accent |
+| `--brand-cyan` (gradient) | `#34d6f6 → #1565c0` | Tile fill |
+| `--brand-cyan-deep` | `#1565c0` | Light-mode wordmark/links; hover |
+| `--brand-amber` | `#ffb300` | **Signature accent — cursor only** |
+| `--brand-ink` | `#0b0c0e` | Dark ground |
+
+## Invariants (RFC2119)
+
+- **INV-1** — The amber accent (`#ffb300`) **MUST** be used only for the cursor
+  motif (tile underscore, wordmark cursor). It **MUST NOT** be used for body
+  links, large fills, or as a general UI accent. Rationale: the "one warm spark"
+  is the brand's identity; diluting it dissolves the concept.
+- **INV-2** — The icon/tile **MUST** remain legible at 16px. The lowercase `h`
+  carries recognition; the underscore **MAY** be omitted or simplified below
+  ~20px if it harms clarity. Favicon output **MUST** be visually verified at
+  16/32/48px.
+- **INV-3** — Production logo/icon SVGs **MUST** be self-contained with the `h`
+  glyph **outlined to vector paths** (no runtime font dependency). The wordmark
+  **MUST** either outline its glyphs or embed/subset the monospace face.
+- **INV-4** — The wordmark **MUST** render as the command line `>holomush_`: a
+  dimmed prompt, cyan letters, and an amber underscore cursor.
+- **INV-5** — Light- and dark-mode variants **MUST** be provided for the header
+  lockup. The tile is palette-stable and **MUST** render identically in both.
+- **INV-6** — This work **MUST** be limited to the software/platform brand. It
+  **MUST NOT** alter game-world / default-setting assets, imagery, or copy.
+- **INV-7** — All brand colors **MUST** be defined as CSS custom properties in
+  one place (`site/src/styles/custom.css`). Components **MUST NOT** hardcode
+  brand hex values.
+- **INV-8** — Brand guidance **MUST** be codified so it outlives this spec: an
+  auto-loading `.claude/rules/branding.md` (scoped via `paths:` frontmatter to
+  brand-touching files) and a "Branding" section in `site/CLAUDE.md`. Both
+  **MUST** restate the palette tokens, the amber-cursor-only rule (INV-1), the
+  tile/wordmark system, the light/dark requirement (INV-5), and the
+  game-world-out-of-scope boundary (INV-6). Root `CLAUDE.md` **MUST** point to
+  this guidance.
+
+## Asset Inventory
+
+| Asset | Format | Notes |
+| --- | --- | --- |
+| Favicon | `favicon.svg` + PNG `16/32/48` | Tile mark; outlined paths (INV-3) |
+| Apple touch icon | PNG `180×180` | Tile on opaque ink ground |
+| Header logo — dark | SVG | Horizontal lockup, cyan-bright wordmark |
+| Header logo — light | SVG | Horizontal lockup, cyan-deep wordmark |
+| OG / social card | PNG `1200×630` | fal.ai atmospheric cyan backdrop + composited lockup |
+| GitHub org avatar | PNG `≥460²` | Tile mark, opaque ground |
+| README banner | SVG/PNG | Horizontal lockup on ink |
+
+## Production Approach
+
+- **Tile + wordmark**: hand-built SVG (mask cutout for the `h`, solid rect for
+  the amber underscore). The Round-4/5 hand-built tile is the starting geometry.
+  Per the user's decision, a **fal.ai (Recraft Vector) refine pass** MAY be run
+  to polish the tile before the final hand-clean; the glyph is then outlined
+  (INV-3).
+- **Wordmark**: set `>holomush_` in JetBrains Mono, convert to outlines, add the
+  amber underscore rect.
+- **OG card imagery**: generate a subtle holographic / scanline cyan backdrop
+  via **fal.ai Nano Banana Pro** (`fal-ai/nano-banana-pro`, ~$0.15/img), then
+  composite the wordmark lockup on top.
+- **PNG rasterization**: from the master SVGs at required sizes.
+
+## Site Integration
+
+```mermaid
+graph LR
+  T["Color tokens<br/>custom.css"] --> M["Tile mark"]
+  T --> W["Wordmark<br/>&gt;holomush_"]
+  M --> FAV["favicon.svg + PNGs<br/>apple-touch"]
+  M --> AV["org avatar"]
+  M --> HL["header lockup<br/>(light + dark)"]
+  W --> HL
+  W --> OG["OG card<br/>(fal.ai backdrop)"]
+  W --> BAN["README banner"]
+  T --> ACC["Starlight accent<br/>(links/nav) → cyan only"]
+  HL --> SITE["astro.config.mjs<br/>logo + favicon"]
+  FAV --> SITE
+```
+
+Concretely:
+
+1. Replace `site/src/assets/logo.png` with the SVG header lockup(s); set
+   `astro.config.mjs` `logo: { light: '...', dark: '...' }` (Starlight's
+   theme-switching sub-keys) to the two lockup variants, and `favicon: '/favicon.svg'`.
+2. Add `site/public/favicon.svg` (primary) + PNG fallbacks (`16/32/48`) and a
+   `180×180` apple-touch-icon. **Replace** the existing `site/public/favicon.png`
+   and **remove** the now-unused `site/src/assets/favicon.png`. Wire the extra
+   icon link tags (PNG fallbacks, apple-touch) via Starlight's `head:` array in
+   `astro.config.mjs`.
+3. Recolor `site/src/styles/custom.css` Starlight accent tokens to **cyan only** —
+   all three `--sl-color-accent-low` / `--sl-color-accent` / `--sl-color-accent-high`
+   slots take cyan shades, in both the light and dark `:root` blocks. Amber
+   (`--brand-amber`) is **not** assigned to any Starlight UI token; it appears
+   only inside the logo/wordmark SVGs (the cursor). Define the `--brand-*` tokens
+   here (INV-1, INV-7).
+4. Add the OG card asset and a single site-wide `og:image` / `twitter:image` via
+   Starlight's `head:` array in `astro.config.mjs` (one global card; not
+   per-page, so no custom head component is needed).
+5. Org avatar + README banner are repo/GitHub assets (applied outside the site
+   build).
+6. Codify brand guidance (see *Project Guidance & Enforcement*) so the system
+   survives beyond this spec (INV-8).
+
+## Project Guidance & Enforcement
+
+The brand decisions **MUST** be captured as durable project guidance, not left
+only in this spec. Three touchpoints (INV-8):
+
+| File | Action | Content |
+| --- | --- | --- |
+| `.claude/rules/branding.md` | **new** | `paths:` frontmatter scoping to brand files (`site/src/assets/**`, `site/src/styles/custom.css`, `site/public/favicon*`, `site/astro.config.mjs`, `README.md`). Body: concept summary, token table, the tile/wordmark system, and the invariants restated as contributor rules — foregrounding **amber-cursor-only** (INV-1), **tokens-in-custom.css** (INV-7), **light/dark** (INV-5), and **game-world-out-of-scope** (INV-6). Auto-loads when editing brand files. |
+| `site/CLAUDE.md` | **edit** | Add a `## Branding` section: the holographic-terminal concept, the mark + wordmark system, the palette tokens, and pointers to `.claude/rules/branding.md` and this spec. |
+| `CLAUDE.md` (root) | **edit** | One-line pointer (in *Documentation Structure* or *Core Systems*) to the branding rule + `site/CLAUDE.md` Branding section. |
+
+The rules-file body **MUST** include an explicit do/don't for the amber accent
+(the most easily-violated invariant) — e.g. "amber `#ffb300` is the cursor only;
+links, buttons, and fills are cyan."
+
+## Out of Scope
+
+- Game-world / default-setting branding, imagery, or copy (INV-6).
+- Web client (`web/`) PWA theming beyond shared brand tokens (future follow-up
+  if desired).
+- A full typeface/web-font loading strategy for body text (only the wordmark
+  uses JetBrains Mono, and it is outlined).
+
+## Acceptance Criteria
+
+- All eight invariants hold; favicon visually verified at 16/32/48px.
+- Header lockup renders correctly in Starlight light and dark modes.
+- `task docs:build` succeeds with the new assets and recolored accent.
+- No hardcoded brand hex outside `custom.css` (INV-7).
+- OG card produced and referenced via meta tags.
+- Game-world assets untouched (INV-6).
+- Brand guidance codified in `.claude/rules/branding.md` + `site/CLAUDE.md`, with
+  a root `CLAUDE.md` pointer (INV-8); the amber-cursor-only rule is stated
+  explicitly as a do/don't.
+
+## Alternatives Considered
+
+Five visual rounds (all generated via fal.ai Recraft Vector, then hand-built for
+control), recorded on holomush-7daup:
+
+1. **Direction sampler** (8 concepts): holographic, terminal, geometric,
+   synthwave lockups + portal / monogram / node / prism symbol marks. Selected:
+   terminal, geometric, portal, monogram → a clean/restrained/geometric
+   preference, rejecting glowy-effect marks.
+2. **Crossing the winners** (8): `h`-letterform × terminal/cursor × portal.
+   Selected: cursor-`h`, app-tile cutout, prompt-`h` → the *command-line*
+   family.
+3. **Convergence** (8): refined cursor-`h` marks + first wordmark lockups.
+   Selected: `h`+block-cursor mark (#1) + `>holomush_` prompt line (#8); and the
+   tile-cutout (#4) + trailing-cursor wordmark (#7).
+4. **Finalist faceoff**: open-prompt (A) vs app-tile (B) systems, favicon-tested.
+   Selected: **B tile + A lockup**.
+5. **Cursor + palette**: underscore cursor chosen over block; palette explored —
+   cyan ranked first, amber second, monochrome third; **cyan + amber-cursor
+   hybrid** selected as the final palette.
+
+Rejected palettes: warm orange/amber (the old brand — superseded), phosphor
+green, violet/magenta, pure monochrome.
+<!-- adr-capture: sha256=ee19d311a90a8a7a; session=cli; ts=2026-05-28T14:02:07Z; adrs= -->


### PR DESCRIPTION
## Summary

Design **spec** + implementation **plan** for refreshing the `holomush.dev` **software/platform** brand (logo + imagery). Game-world / default-setting branding is explicitly out of scope.

The chosen identity is a **holographic terminal**: a cyan app-tile mark (lowercase `h` cut out) + a `>holomush_` monospace command-line wordmark, with a single **amber underscore cursor** as the signature accent.

This is a **docs-only PR** (spec + plan). Implementation is tracked separately as epic **holomush-7daup** (12 child tasks materialized in bd).

## What's included

- `docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md` — 8 RFC2119 invariants (amber-cursor-only, outline-to-paths, light/dark, tokens-in-custom.css, game-world-out-of-scope, guidance-codified)
- `docs/superpowers/plans/2026-05-28-holomush-software-brand-refresh.md` — 12 tasks across 6 phases (toolchain → master SVGs → raster → site integration → guidance → GitHub assets)

## Process

- Co-designed via five fal.ai-generated visual rounds (Recraft Vector for marks); palette shifted from the old orange/amber to cyan + amber-cursor
- `design-reviewer`: READY (round 2) · `plan-reviewer`: READY (round 2)
- `capture-adrs`: 0 ADRs (brand/tooling/convention decisions, not architecture)

## Test plan

- [ ] Reviewers confirm spec/plan are coherent and scoped to the software brand only
- [ ] Implementation lands under epic holomush-7daup (favicon set, light/dark header logo, OG card, org avatar, README banner, docs accent recolor, `.claude/rules/branding.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)