### PR TITLE
test(harness): integrationtest publish-driving layer + happy-path E2E (holomush-shcyu)

### DIFF
--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -161,23 +161,65 @@ type EmittedEvent struct{ SubjectStr string }
 // the JetStream message by subject. Panics via requirePluginCrypto if the
 // substrate was not wired.
 func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payloadJSON string, sensitive bool) EmittedEvent {
-	s.requirePluginCrypto("EmitPluginEvent")
+	// WithPluginCrypto's fixed scene is keyed by the BARE sceneID ULID (the
+	// seedScene row at crypto.go uses pc.sceneID.String() with no prefix), so
+	// the subject's scene-id token is that bare form — self-consistent with the
+	// seeded row. Preserves 5iaov's callers byte-for-byte.
+	return s.emitPluginEventForScene(ctx, plugin,
+		s.pluginCrypto.sceneID.String(), s.pluginCrypto.actorID, eventType, payloadJSON, sensitive)
+}
+
+// EmitSceneICContent emits an encrypted (Sensitive=true) scene IC event for an
+// ARBITRARY scene + actor — used to seed content into a CreateScene-created
+// scene (the command emit path can't set Sensitive; INV-7 fence, spec §3.4).
+// Requires WithPluginCrypto + WithInTreePlugins. The scene row MUST already
+// exist (via CreateScene) so core-scenes' InsertScenePose UPDATE … RETURNING
+// resolves.
+//
+// sceneID is the BARE ULID returned by Session.CreateScene; core-scenes
+// PERSISTS scene rows under the "scene-"+ULID form (newSceneID,
+// service.go:1113) and its InsertScenePose keys off that stored id via
+// parseSceneSubject(subject)[3] → UPDATE scenes WHERE id=<token> (audit.go:629,
+// :233). So the subject's scene-id token MUST be "scene-"+sceneID — NOT the
+// plan's literal sceneID.String() — for the UPDATE…RETURNING to find the row.
+// This mirrors production's own subject builder dotStyleSceneSubjectIC, which
+// is fed the stored "scene-"+ULID id (store.go:1479).
+func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
+	return s.emitPluginEventForScene(ctx, plugin,
+		"scene-"+sceneID.String(), actorID, eventType, payloadJSON, true)
+}
+
+// emitPluginEventForScene is the parameterized core extracted from
+// EmitPluginEvent. It drives a real plugin emit through the Manager's
+// EmitPluginEvent boundary (the same path core-scenes commands use), returning
+// the translated NATS subject for wire assertions.
+//
+// sceneSubjectID is the scene-id token placed verbatim into the subject's
+// <sceneID> segment (events.<game_id>.scene.<sceneSubjectID>.ic). It MUST match
+// the id stored in plugin_core_scenes.scenes for that scene, because
+// core-scenes' AuditEvent handler routes scene_pose through InsertScenePose,
+// which calls parseSceneSubject (requires the 5-token <id>.<channel> shape,
+// audit.go:629) and UPDATEs scenes WHERE id=<sceneSubjectID> … RETURNING
+// (requires the matching scene row). Callers own forming that token:
+// EmitPluginEvent passes the bare WithPluginCrypto sceneID (its self-seeded
+// row uses the bare form); EmitSceneICContent passes "scene-"+ULID (matching
+// CreateScene's stored id).
+//
+// Panics via requirePluginCrypto if the substrate was not wired.
+func (s *Server) emitPluginEventForScene(ctx context.Context, plugin, sceneSubjectID string, actorID ulid.ULID, eventType, payloadJSON string, sensitive bool) EmittedEvent {
+	s.requirePluginCrypto("emitPluginEventForScene")
 	s.t.Helper()
 
-	// Legacy colon-style subject: namespace token MUST be a namespace the
-	// plugin declares in its manifest `emits:` (the emitter rejects otherwise).
-	// core-scenes declares `emits: [scene]`, so the namespace is "scene".
+	// Namespace token MUST be a namespace the plugin declares in its manifest
+	// `emits:` (the emitter rejects otherwise). core-scenes declares
+	// `emits: [scene]`, so the namespace is "scene".
 	dp, ok := s.pluginSub.Manager().GetLoadedPlugin(plugin)
-	require.Truef(s.t, ok, "integrationtest.Server.EmitPluginEvent: plugin %q not loaded", plugin)
+	require.Truef(s.t, ok, "integrationtest.Server.emitPluginEventForScene: plugin %q not loaded", plugin)
 	require.NotEmptyf(s.t, dp.Manifest.Emits,
-		"integrationtest.Server.EmitPluginEvent: plugin %q declares no emit namespaces", plugin)
+		"integrationtest.Server.emitPluginEventForScene: plugin %q declares no emit namespaces", plugin)
 
-	// Build a well-formed scene IC subject: events.<game_id>.scene.<sceneID>.ic.
-	// core-scenes' AuditEvent handler routes scene_pose through InsertScenePose,
-	// which calls parseSceneSubject (requires the 5-token <id>.<channel> shape,
-	// audit.go:629) and UPDATEs scenes WHERE id=<sceneID> … RETURNING (requires
-	// the seeded scene row). A bare "scene:scene_pose" subject would fail both.
-	natsSubject := "events." + s.bus.Bus.GameID() + ".scene." + s.pluginCrypto.sceneID.String() + ".ic"
+	// Build a well-formed scene IC subject: events.<game_id>.scene.<sceneSubjectID>.ic.
+	natsSubject := "events." + s.bus.Bus.GameID() + ".scene." + sceneSubjectID + ".ic"
 
 	// Stamp the host event actor the emitter requires (event_emitter.go::Emit →
 	// actorFromContext). Production stamps it at the command-dispatch / host-RPC
@@ -185,8 +227,8 @@ func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payload
 	// actor is in core-scenes' actor_kinds_claimable list ([plugin, character])
 	// and is what scene_pose ingest requires. The actor's (kind, id) is persisted
 	// to scene_log and rebuilt verbatim into the read-back AAD, so it MUST be
-	// stable per emit — s.pluginCrypto.actorID is allocated once per Server.
-	ctx = core.WithActor(ctx, core.Actor{Kind: core.ActorCharacter, ID: s.pluginCrypto.actorID.String()})
+	// stable per emit.
+	ctx = core.WithActor(ctx, core.Actor{Kind: core.ActorCharacter, ID: actorID.String()})
 
 	err := s.pluginSub.Manager().EmitPluginEvent(ctx, plugin, pluginsdk.EmitEvent{
 		Stream:    natsSubject, // already a dot-style events.<gid>.scene.<id>.ic subject; passed through unchanged
@@ -194,7 +236,7 @@ func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payload
 		Payload:   payloadJSON,
 		Sensitive: sensitive,
 	})
-	require.NoError(s.t, err, "integrationtest.Server.EmitPluginEvent: Manager.EmitPluginEvent")
+	require.NoError(s.t, err, "integrationtest.Server.emitPluginEventForScene: Manager.EmitPluginEvent")
 
 	return EmittedEvent{SubjectStr: natsSubject}
 }

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -174,6 +174,9 @@ type startConfig struct {
 	withPlugins      bool
 	withRealABAC     bool
 	withPluginCrypto bool
+	// pluginConfigOverrides is the per-plugin opaque config override
+	// (plugin name → key → value) threaded into PluginSubsystemConfig.
+	pluginConfigOverrides map[string]map[string]string
 }
 
 // WithPolicyEngine overrides the harness's default allow-all ABAC engine.
@@ -317,20 +320,21 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			policyInst = abacSub.PolicyInstaller()
 		}
 		pluginSub = startPlugins(t, ctx, pluginDeps{
-			pool:            pool,
-			connStr:         connStr,
-			engine:          pe,
-			sessionStore:    sessionStoreInst,
-			verbReg:         verbRegistry,
-			playerRepo:      playerRepo,
-			hasher:          hasher,
-			playerSess:      playerSessionStore,
-			resolver:        res,
-			pluginProvider:  pp,
-			auditor:         aud,
-			policyInstaller: policyInst,
-			cryptoPublisher: cryptoPublisherOf(pc),
-			gameID:          bus.Bus.GameID(),
+			pool:                  pool,
+			connStr:               connStr,
+			engine:                pe,
+			sessionStore:          sessionStoreInst,
+			verbReg:               verbRegistry,
+			playerRepo:            playerRepo,
+			hasher:                hasher,
+			playerSess:            playerSessionStore,
+			resolver:              res,
+			pluginProvider:        pp,
+			auditor:               aud,
+			policyInstaller:       policyInst,
+			cryptoPublisher:       cryptoPublisherOf(pc),
+			gameID:                bus.Bus.GameID(),
+			pluginConfigOverrides: cfg.pluginConfigOverrides,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -90,6 +90,7 @@ import (
 	"github.com/holomush/holomush/internal/world"
 	worldpg "github.com/holomush/holomush/internal/world/postgres"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
 	"github.com/holomush/holomush/test/testutil"
 )
 
@@ -455,6 +456,17 @@ func (s *Server) CommandRegistry() *command.Registry {
 func (s *Server) ServiceRegistry() *plugins.ServiceRegistry {
 	s.requirePlugins("ServiceRegistry")
 	return s.pluginSub.ServiceRegistry()
+}
+
+// SceneServiceClient returns a SceneService client backed by the loaded
+// core-scenes plugin, resolved from the existing plugin ServiceRegistry.
+// Test-only; requires WithInTreePlugins (panics otherwise via requirePlugins).
+func (s *Server) SceneServiceClient() scenev1.SceneServiceClient {
+	s.requirePlugins("SceneServiceClient")
+	svc, err := s.ServiceRegistry().Resolve("holomush.scene.v1.SceneService")
+	require.NoError(s.t, err, "integrationtest.Server.SceneServiceClient: resolve SceneService")
+	require.NotNil(s.t, svc.Conn, "integrationtest.Server.SceneServiceClient: nil conn")
+	return scenev1.NewSceneServiceClient(svc.Conn)
 }
 
 // AccessEngine returns the ABAC policy engine the stack evaluates against.

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -340,9 +340,21 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		cmdRegistry = pluginSub.CommandRegistry()
 	}
 
-	dispatcher, err := command.NewDispatcher(cmdRegistry, pe)
+	// When plugins are loaded, route plugin-backed commands through the
+	// PluginManager deliverer (mirrors cmd/holomush/sub_grpc.go:310). Without
+	// this, SendCommand of any plugin command (e.g. "scene …") is rejected with
+	// NO_PLUGIN_DELIVERER, so command-driven plugin E2Es cannot run.
+	var dispatcherOpts []command.DispatcherOption
+	if pluginSub != nil {
+		dispatcherOpts = append(dispatcherOpts, command.WithPluginDeliverer(pluginSub.Manager()))
+	}
+	dispatcher, err := command.NewDispatcher(cmdRegistry, pe, dispatcherOpts...)
 	require.NoError(t, err, "integrationtest.Start: create command dispatcher")
-	cmdServices := command.NewTestServices(command.ServicesConfig{Engine: pe})
+	// Session service wired so plugin commands that succeed can bump session
+	// activity (dispatchToPlugin → exec.Services().Session().UpdateActivity).
+	// session.Store satisfies session.Access (mirrors cmd/holomush/sub_grpc.go:295);
+	// without it, command-driven plugin E2Es panic on the nil Session getter.
+	cmdServices := command.NewTestServices(command.ServicesConfig{Engine: pe, Session: sessionStoreInst})
 
 	// Core engine with a no-op event appender.
 	engine := core.NewEngine(&noopEventAppender{})

--- a/internal/testsupport/integrationtest/harness_test.go
+++ b/internal/testsupport/integrationtest/harness_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// TestSceneServiceClientResolves verifies that Server.SceneServiceClient()
+// resolves the loaded core-scenes SceneService from the plugin registry and
+// returns a non-nil gRPC client.
+func TestSceneServiceClientResolves(t *testing.T) {
+	ts := integrationtest.Start(t, integrationtest.WithInTreePlugins())
+	defer ts.Stop()
+	require.NotNil(t, ts.SceneServiceClient())
+}

--- a/internal/testsupport/integrationtest/harness_test.go
+++ b/internal/testsupport/integrationtest/harness_test.go
@@ -6,8 +6,10 @@
 package integrationtest_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/testsupport/integrationtest"
@@ -20,4 +22,18 @@ func TestSceneServiceClientResolves(t *testing.T) {
 	ts := integrationtest.Start(t, integrationtest.WithInTreePlugins())
 	defer ts.Stop()
 	require.NotNil(t, ts.SceneServiceClient())
+}
+
+// TestSessionCreateSceneReturnsULID verifies that Session.CreateScene drives a
+// real SceneService.CreateScene RPC and returns the created scene's ULID.
+func TestSessionCreateSceneReturnsULID(t *testing.T) {
+	// WithPluginCrypto wires the plugin event emitter (required for
+	// SceneService.CreateScene, which emits a scene_created event);
+	// WithInTreePlugins alone leaves the emitter unconfigured (plugins.go:155-161).
+	ts := integrationtest.Start(t, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+	defer ts.Stop()
+	loc := ts.NewLocation(context.Background())
+	alice := ts.ConnectAuthed(context.Background(), "Alice")
+	sceneID := alice.CreateScene(context.Background(), loc)
+	require.NotEqual(t, ulid.ULID{}, sceneID)
 }

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -163,6 +163,14 @@ func WithInTreePlugins() StartOption {
 	return func(c *startConfig) { c.withPlugins = true }
 }
 
+// WithPluginConfigOverrides sets per-plugin config overrides (plugin name →
+// key → value) the harness threads into PluginSubsystemConfig.PluginConfigOverrides
+// — the same opaque channel production uses (yzt86). Reusable by any plugin's
+// harness tests. Empty/absent → manifest defaults.
+func WithPluginConfigOverrides(overrides map[string]map[string]string) StartOption {
+	return func(c *startConfig) { c.pluginConfigOverrides = overrides }
+}
+
 // pluginDeps is the minimal set of already-built harness objects startPlugins
 // needs. Start passes these in so this helper stays decoupled from the Server.
 type pluginDeps struct {
@@ -195,6 +203,9 @@ type pluginDeps struct {
 	// GameIDProvider closure so plugin emits translate legacy colon-style
 	// subjects to events.<game_id>.<ns>.<id> consistently.
 	gameID string
+	// pluginConfigOverrides is the per-plugin opaque config override
+	// (plugin name → key → value) threaded into PluginSubsystemConfig.
+	pluginConfigOverrides map[string]map[string]string
 }
 
 // startPlugins constructs and starts a PluginSubsystem mirroring production
@@ -267,18 +278,19 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	// resolver.RegisterProvider per plugin that declares resource_types and panics
 	// on a nil resolver (subsystem.go:319).
 	cfg := pluginsetup.PluginSubsystemConfig{
-		DataDir:            dataDir,
-		DatabaseConnStr:    d.connStr,
-		ABAC:               engineProvider{eng: d.engine, resolver: d.resolver, auditor: d.auditor},
-		PolicyInst:         policyInstallerProvider{inst: policyInst},
-		PluginProv:         pluginProviderSetter{pp: d.pluginProvider},
-		World:              worldProvider{svc: worldSvc},
-		Sessions:           sessionProvider{store: d.sessionStore},
-		AdminDeps:          adminDepsProvider{deps: adminDeps},
-		Registry:           lifecycle.NewReadinessRegistry(),
-		VerbRegistry:       d.verbReg,
-		LuaTimeout:         5 * time.Second,
-		LuaRegistryMaxSize: 1024 * 1024,
+		DataDir:               dataDir,
+		DatabaseConnStr:       d.connStr,
+		ABAC:                  engineProvider{eng: d.engine, resolver: d.resolver, auditor: d.auditor},
+		PolicyInst:            policyInstallerProvider{inst: policyInst},
+		PluginProv:            pluginProviderSetter{pp: d.pluginProvider},
+		World:                 worldProvider{svc: worldSvc},
+		Sessions:              sessionProvider{store: d.sessionStore},
+		AdminDeps:             adminDepsProvider{deps: adminDeps},
+		Registry:              lifecycle.NewReadinessRegistry(),
+		VerbRegistry:          d.verbReg,
+		LuaTimeout:            5 * time.Second,
+		LuaRegistryMaxSize:    1024 * 1024,
+		PluginConfigOverrides: d.pluginConfigOverrides,
 	}
 
 	ps := pluginsetup.NewPluginSubsystem(cfg)

--- a/internal/testsupport/integrationtest/plugins_test.go
+++ b/internal/testsupport/integrationtest/plugins_test.go
@@ -56,6 +56,15 @@ func TestBinaryArtifactsPresentDetectsCoreScenes(t *testing.T) {
 	require.True(t, binaryArtifactsPresent(build))
 }
 
+func TestWithPluginConfigOverridesThreads(t *testing.T) {
+	var c startConfig
+	WithPluginConfigOverrides(map[string]map[string]string{
+		"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"},
+	})(&c)
+	require.Equal(t, "1ms", c.pluginConfigOverrides["core-scenes"]["cooloff_window"])
+	require.Equal(t, "20ms", c.pluginConfigOverrides["core-scenes"]["scheduler_interval"])
+}
+
 func TestPluginProvidersSatisfyInterfaces(t *testing.T) {
 	// Compile-time interface satisfaction is the real assertion; this test
 	// exists so the file fails to build if an adapter drifts from its iface.

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -7,6 +7,7 @@ package integrationtest
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/session"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
 )
 
 // Tunable timeouts for the Subscribe-stream transport lifecycle. Set high
@@ -455,12 +457,23 @@ func (s *Session) transportActive() bool {
 	return s.transportCancel != nil
 }
 
-// CreateScene creates a new scene (focus session) and returns its ULID.
-//
-// TODO(iwzt-9): invoke FocusCoordinator.CreateScene once wired.
-func (s *Session) CreateScene(_ context.Context) ulid.ULID {
-	s.server.t.Fatalf("integrationtest.Session.CreateScene: TODO iwzt-9 — scene creation RPC not yet wired")
-	return ulid.ULID{}
+// CreateScene creates a scene owned by this session's character via the
+// loaded core-scenes SceneService and returns its ULID.
+func (s *Session) CreateScene(ctx context.Context, locationID ulid.ULID) ulid.ULID {
+	s.server.t.Helper()
+	resp, err := s.server.SceneServiceClient().CreateScene(ctx, &scenev1.CreateSceneRequest{
+		CharacterId: s.CharacterID.String(),
+		Title:       "test scene",
+		LocationId:  locationID.String(),
+		Visibility:  "open",
+	})
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene")
+	// core-scenes stamps scene IDs as "scene-"+ULID (plugins/core-scenes/service.go:1113);
+	// strip the prefix before parsing the underlying ULID.
+	raw := strings.TrimPrefix(resp.GetScene().GetId(), "scene-")
+	id, err := ulid.Parse(raw)
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene: parse scene id")
+	return id
 }
 
 // JoinScene adds a FocusMembership{Kind: Scene, TargetID: sceneID} to the

--- a/test/integration/scenes/publish_e2e_test.go
+++ b/test/integration/scenes/publish_e2e_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+)
+
+// holomush-shcyu (Task 5, folds holomush-5rh.20.39/E6): the happy-path publish
+// E2E. Alice creates a scene, Bob joins (so the vote roster seeds him — an
+// invited-only row is excluded by role IN ('owner','member'), INV-P6-1),
+// encrypted IC content is seeded (the command emit path is fence-rejected under
+// crypto, spec §3.4), the lifecycle is driven entirely by commands (end →
+// publish → unanimous vote), the scheduler sweeps COOLOFF → PUBLISHED (short
+// cooloff_window + scheduler_interval via WithPluginConfigOverrides), and both
+// read RPCs return decrypted content keyed by the ATTEMPT ulid.
+var _ = Describe("happy-path scene publish lifecycle reaches PUBLISHED with decrypted content", func() {
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		alice *integrationtest.Session
+		bob   *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 120*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+			integrationtest.WithPluginConfigOverrides(map[string]map[string]string{
+				"core-scenes": {"cooloff_window": "1ms", "scheduler_interval": "20ms"},
+			}),
+		)
+		alice = ts.ConnectAuthed(ctx, "Alice")
+		bob = ts.ConnectAuthed(ctx, "Bob")
+	})
+
+	AfterEach(func() {
+		if bob != nil {
+			bob.Logout(ctx)
+		}
+		if alice != nil {
+			alice.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("Alice ends, publishes, both vote yes, cool-off sweeps → PUBLISHED, both read RPCs return decrypted content", func() {
+		loc := ts.NewLocation(ctx)
+
+		// CreateScene returns the BARE ULID (prefix stripped by the harness),
+		// but core-scenes stores the id as "scene-<ULID>" and the command/RPC
+		// resolvers match the stored full form verbatim (handleEnd/handleJoin/
+		// handleInvite pass the token straight through; resolveSceneRef strips
+		// only the leading '#'). So reconstruct the stored form for refs.
+		sceneID := alice.CreateScene(ctx, loc)
+		fullSceneID := "scene-" + sceneID.String()
+
+		// Bob must JOIN, not merely be invited — the vote roster seeds from
+		// role IN ('owner','member') (INV-P6-1); an 'invited' row is excluded.
+		// scene invite / scene join pass fields[0] directly to the RPC (no '#'
+		// stripping), and the invite target is a character ID, not a name.
+		Expect(alice.SendCommand(ctx, "scene invite "+fullSceneID+" "+bob.CharacterID.String())).To(Succeed())
+		Expect(bob.SendCommand(ctx, "scene join "+fullSceneID)).To(Succeed())
+
+		// Seed encrypted IC content into the created scene (command emit path
+		// can't set Sensitive → INV-7 fence, §3.4). EmitSceneICContent takes the
+		// BARE ULID and re-adds the "scene-" prefix internally.
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", `{"text":"the scene happens"}`)
+
+		// Command-driven lifecycle. scene end takes the bare stored id; scene
+		// publish / scene publish vote route through resolveSceneRef so they need
+		// the '#'-prefixed stored form.
+		Expect(alice.SendCommand(ctx, "scene end "+fullSceneID)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene publish #"+fullSceneID)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene publish vote yes #"+fullSceneID)).To(Succeed())
+		Expect(bob.SendCommand(ctx, "scene publish vote yes #"+fullSceneID)).To(Succeed())
+
+		// Scheduler (~20ms interval, ~1ms cool-off) sweeps COOLOFF → PUBLISHED.
+		// The read RPCs key off the ATTEMPT ulid (published_scene_id), recovered
+		// via ListScenePublishAttempts → the PUBLISHED summary's Id. Poll until a
+		// PUBLISHED attempt appears — that's the grounded PUBLISHED signal
+		// (status string "PUBLISHED", publish_types.go:19) regardless of event
+		// name. SceneId keys off the stored full form (IsParticipant /
+		// ListSceneAttempts), so pass fullSceneID.
+		var publishedSceneID string
+		Eventually(func(g Gomega) {
+			listResp, err := ts.SceneServiceClient().ListScenePublishAttempts(ctx,
+				&scenev1.ListScenePublishAttemptsRequest{
+					CallerCharacterId: alice.CharacterID.String(),
+					SceneId:           fullSceneID,
+				})
+			g.Expect(err).NotTo(HaveOccurred())
+			publishedSceneID = ""
+			for _, a := range listResp.GetAttempts() {
+				if a.GetStatus() == "PUBLISHED" {
+					publishedSceneID = a.GetId()
+				}
+			}
+			g.Expect(publishedSceneID).NotTo(BeEmpty(), "no PUBLISHED attempt yet")
+		}).WithTimeout(5 * time.Second).WithPolling(20 * time.Millisecond).Should(Succeed())
+
+		// Participant read returns decrypted content. content_entries is
+		// "populated only when PUBLISHED" (scene.pb.go:2270), so non-empty
+		// content is the grounded PUBLISHED + decryption-succeeded signal.
+		pub, err := ts.SceneServiceClient().GetPublishedScene(ctx, &scenev1.GetPublishedSceneRequest{
+			CallerCharacterId: alice.CharacterID.String(),
+			PublishedSceneId:  publishedSceneID,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pub.GetStatus()).To(Equal("PUBLISHED"))
+		Expect(pub.GetContentEntries()).NotTo(BeEmpty())
+
+		// Public archive (no caller gate; keyed by the attempt ulid) returns
+		// content once PUBLISHED.
+		arch, err := ts.SceneServiceClient().GetPublicSceneArchive(ctx, &scenev1.GetPublicSceneArchiveRequest{
+			PublishedSceneId: publishedSceneID,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arch.GetContentEntries()).NotTo(BeEmpty())
+	})
+})

--- a/test/integration/scenes/seed_encrypted_ic_validation_test.go
+++ b/test/integration/scenes/seed_encrypted_ic_validation_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// holomush-shcyu (Task 4 validation): proves the parameterized crypto
+// round-trip — encrypted IC content seeded into a CreateScene-created scene
+// reads back on the wire as XChaCha20v1 — BEFORE the full publish E2E. The
+// command emit path can't set Sensitive (INV-7 fence, spec §3.4), so the
+// harness seeds encrypted content via EmitSceneICContent for an arbitrary
+// scene + actor.
+var _ = Describe("encrypted IC content seeded into a CreateScene'd scene", func() {
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		alice *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		alice = ts.ConnectAuthed(ctx, "Alice")
+	})
+
+	AfterEach(func() {
+		if alice != nil {
+			alice.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("encrypted scene_pose seeded into a CreateScene'd scene reads back", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", `{"text":"a secret pose"}`)
+
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()))
+		Eventually(func() codec.Name { return ts.WireCodecFor(ctx, emitted.SubjectStr) }).
+			Should(Equal(codec.NameXChaCha20v1)) // encrypted on the wire
+	})
+})


### PR DESCRIPTION
## Summary

Adds the test-tier harness driving layer so a full-stack Ginkgo E2E can drive the core-scenes Phase 6 publish lifecycle to `PUBLISHED` and read it back — then ships that happy-path E2E (folds in `holomush-5rh.20.39`/E6). Closes epic **holomush-shcyu**.

**All changes are behind `//go:build integration` — zero production code changes.** Composes the two landed prerequisites: `WithPluginConfigOverrides` (yzt86 #4284, short cool-off/scheduler windows) and `WithPluginCrypto` (5iaov #4290, the encrypt + read-back round-trip).

## Commits (5, TDD red→green, each code-reviewer READY)

1. **`WithPluginConfigOverrides` StartOption** — threads per-plugin opaque config into `PluginSubsystemConfig.PluginConfigOverrides`.
2. **`Server.SceneServiceClient()` accessor** — resolves `holomush.scene.v1.SceneService` via the existing plugin `ServiceRegistry()`.
3. **Wire `Session.CreateScene`** — replaces the `t.Fatalf` stub with a real `SceneService.CreateScene` RPC.
4. **`EmitSceneICContent`** — refactors `EmitPluginEvent` to a parameterized core; adds a scene/actor-parameterized variant to seed encrypted IC content into a created scene (the command emit path is fence-rejected under crypto, INV-7 / §3.4).
5. **Happy-path publish E2E** (`test/integration/scenes/publish_e2e_test.go`) — Alice creates → Bob joins → encrypted IC seeded → command-driven end/publish/unanimous-vote → real scheduler sweep → `PUBLISHED` → `GetPublishedScene` + `GetPublicSceneArchive` return decrypted content. Also wires the harness command dispatcher (`WithPluginDeliverer` + `Session`) so command-driven plugin E2Es run (mirrors `cmd/holomush/sub_grpc.go:295,310`).

## Test plan

- [x] `task pr-prep` fast lane green (lint/fmt/build/unit/license/schema)
- [x] Full integration tree green: `task test:int -- ./test/integration/... ./internal/testsupport/integrationtest/...` (47 tests, no blast-radius regression from the harness wiring)
- [x] Scene reaches `PUBLISHED`; both read RPCs return non-empty decrypted `ContentEntries`
- [ ] CI required checks (Integration Test + E2E Test) on Namespace runners

Unblocks the variant/denial beads `5rh.20.40/.41/.42/.30`.

Spec: `docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md` · Plan: `docs/superpowers/plans/2026-05-28-shcyu-harness-publish-driving.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating scene creation and publishing workflows.
  * Added encrypted content handling validation tests.

* **Refactor**
  * Enhanced test infrastructure for scene service integration.
  * Improved plugin configuration support in test harness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->