### PR TITLE
docs(roadmap): mark SP1 + SP2 landed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,8 +36,8 @@ and machine-readable `llms.txt`.
 | Sub-project | Scope | Tracking |
 | ----------- | ----- | -------- |
 | SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | stub `holomush-ay6xm` (P4 backlog — not yet designed) |
-| SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | epic `holomush-cwnu0` (20 tasks); ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
-| SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | stub `holomush-44nxc` (P4 backlog — not yet designed) |
+| SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | ✅ **landed** — epic `holomush-cwnu0`; ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
+| SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | ✅ **landed** (#4296 re-org + #4297 mode-purity) — epic `holomush-44nxc`; ADRs `holomush-md3k4`, `holomush-38kmt`; follow-up `holomush-e6kvc` |
 | SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |
 | SP4 | Complete gRPC service coverage (all 13 services, field-level) | stub `holomush-okm59` (P4 backlog — not yet designed) |
 


### PR DESCRIPTION
Updates the `docs/roadmap.md` `theme:docs-platform` table to reflect reality after SP2 landed (#4296 + #4297):

- **SP1** → ✅ landed (epic `holomush-cwnu0`).
- **SP2** → ✅ landed (epic `holomush-44nxc`; ADRs `holomush-md3k4`, `holomush-38kmt`; follow-up `holomush-e6kvc`).

Theme stays Active — SP0 (proto comments) and SP4 (gRPC coverage) remain. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)