### PR TITLE
docs(scenes): bare-ULID identity spec, plan + ADR (holomush-y5inx)

### DIFF
--- a/docs/adr/holomush-vy0rt-entity-ids-bare-ulid.md
+++ b/docs/adr/holomush-vy0rt-entity-ids-bare-ulid.md
@@ -1,0 +1,140 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Entity Identifiers Are Bare ULIDs; Type Discrimination Lives in the Subject Domain and ABAC Prefix
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-vy0rt
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Scenes were the only entity in HoloMUSH whose identifier carried an embedded
+type-tag prefix: `newSceneID()` (`plugins/core-scenes/service.go:1113`) minted
+`"scene-" + ulid.String()`. Every other entity — locations, characters, exits,
+objects, bindings (`internal/world/*.go`) — mints a bare ULID via `idgen.New()`,
+and even a sibling table inside the same plugin (scene publish attempts,
+`plugins/core-scenes/publish_store.go:48`) uses bare ULIDs. The prefix was
+introduced in PR #200 with no comment, ADR, or spec; it was undocumented.
+
+The type tag is also redundant: an event's type is already discriminated by the
+subject domain segment (`events.<game>.scene.<id>.ic`) and, for authorization,
+by the ABAC resource-type prefix (`scene:<id>`, a separate colon-style
+mechanism at a different layer). Nothing in the tree parses `scene-` to recover
+a type.
+
+Because the stored id was prefixed but every host parse boundary called
+`ulid.Parse` on the raw subject token, three boundaries rejected real scene
+identifiers:
+
+- `streamToFocusKey` / `extractSceneID` (`internal/grpc/stream_access.go:137`) —
+  `ulid.Parse("scene-<ULID>")` → `ErrDataSize` → `INVALID_ARGUMENT`.
+- `streamScopeFloor` (`internal/grpc/scope_floor.go:44`) — compares the bare
+  `FocusMembership.TargetID.String()` against the prefixed extracted id, so the
+  temporal floor never matches.
+- `protoToFocusKey` (`internal/plugin/goplugin/host_service.go:469`) —
+  `ulid.Parse(TargetID)` rejects the prefixed join key.
+
+This broke `scene log` / `scene log export`, scene join/subscription, and the
+privacy temporal floor for every command-created scene
+(`holomush-y5inx`). A masking `TrimPrefix(…, "scene-")` in the integration test
+harness (`internal/testsupport/integrationtest/session.go:473`) — the only
+strip anywhere in the tree — hid the regression by keeping all scene tests in
+bare-id space. This is the same parse boundary the prior atomic subject
+migration (`holomush-s9nu`) touched without surfacing the prefix mismatch.
+
+## Decision
+
+Entity identifiers in HoloMUSH are bare ULIDs. Type discrimination is carried
+exclusively by the event-subject domain segment
+(`events.<game>.<domain>.<id>`) and the ABAC resource-type prefix
+(`<type>:<id>`) — never by a tag embedded in the identifier string itself.
+
+`newSceneID()` mints a bare ULID identical in form to every other entity. No
+production code path may strip a type-tag prefix from an identifier or subject
+token (INV-Y5INX-5). The bare form makes the stored id, the subject token,
+`FocusKey.TargetID`, and `FocusMembership.TargetID` byte-identical end-to-end,
+so the three host parse boundaries work without any normalization.
+
+The `"ope-"` ops-event prefix (`plugins/core-scenes/ops_events.go:111`) is the
+same anti-pattern but is a pure internal primary key never parsed at a focus
+boundary; it is not a live bug and is flagged P3 for future normalization under
+this same convention.
+
+## Rationale
+
+**A type tag inside the identifier forces every `ulid.Parse` boundary to strip
+it first.** Forgetting the strip fails closed (`INVALID_ARGUMENT`) or, worse,
+fails open silently (a floor comparison that never matches → unfiltered
+history). The prefix recurred independently at three host boundaries, which
+demonstrates it is a systematic bug class, not a one-off oversight.
+
+**Bare identifiers make the invariant self-enforcing.** When the string form
+equals the parsed form, every parsing boundary becomes a no-op pass-through.
+Any future entity that mistakenly embeds a prefix fails `ulid.Parse` at the same
+boundaries immediately, surfacing in tests rather than silently in production.
+
+**Type information is already fully encoded elsewhere** — the subject domain
+segment and the ABAC resource-type prefix. Embedding it in the id is redundant
+and harmful.
+
+**Consistency.** Scenes now match every other entity in the world model;
+there is one identity convention to learn, not a per-entity exception.
+
+## Alternatives Considered
+
+**Option A: Bare ULID mint (chosen).**
+
+| Aspect | Assessment |
+| --- | --- |
+| Strengths | Stored id, subject token, and focus-key fields are byte-identical end-to-end; no per-boundary normalization; the bug class cannot recur; consistent with all other entities; deletes the masking harness strip |
+| Weaknesses | Abandons existing prefixed scene rows (dev/sandbox data; disposable); future contributors must know the convention and resist adding prefixes |
+
+**Option B: Tolerate the prefix — `TrimPrefix` at each parse boundary.**
+
+| Aspect | Assessment |
+| --- | --- |
+| Strengths | Preserves existing stored data without a reset; additive change |
+| Weaknesses | Enshrines a permanent standing requirement — every new boundary must remember to strip; the next boundary added forgets, reintroducing the exact bug; adds code to preserve undocumented cruft |
+
+**Option C: Duplicate the temporal floor inside the plugin `QueryHistory` path.**
+
+| Aspect | Assessment |
+| --- | --- |
+| Strengths | Isolates the fix to the plugin boundary without touching host infrastructure |
+| Weaknesses | The host already computes and forwards `NotBefore`; duplicating the floor risks drift between two implementations of one invariant; does not fix the parse failures at `streamToFocusKey` or `protoToFocusKey` |
+
+## Consequences
+
+**Positive:**
+
+- `scene log`, `scene log export`, scene join/subscription, and the privacy
+  temporal floor all work correctly for real `CreateScene`-minted scenes.
+- The bug class (type-tagged id rejected by `ulid.Parse`) cannot recur: a
+  future prefixed id fails at the same boundaries immediately, in tests.
+- No per-boundary normalization code; boundaries stay simple and uniform.
+- Establishes a system-wide identity convention binding all future entity types.
+
+**Negative:**
+
+- Existing prefixed scene rows (dev/sandbox data) are abandoned — no migration
+  path. Acceptable because the data is disposable; would NOT be acceptable for
+  production data.
+- Future contributors must learn the bare-ULID convention; this ADR is the
+  record that prevents reintroducing a distinguishing prefix for a new entity.
+
+**Neutral:**
+
+- The `"ope-"` ops-event prefix is unchanged (internal PK, never parsed at a
+  focus boundary); a P3 follow-up normalizes it under this convention.
+- The ABAC resource-type prefix convention (`scene:<id>`) is unaffected — it is
+  a distinct, intentional mechanism at the authorization layer.
+
+## References
+
+- [Scene Bare-ULID Identity Design](../superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md) — §Decision, §Rationale, §Alternatives, INV-Y5INX-1 / INV-Y5INX-5
+- [Scene Bare-ULID Identity Plan](../superpowers/plans/2026-05-28-scene-bare-ulid-identity.md)
+- [ADR `holomush-s9nu`](holomush-s9nu-scene-subject-atomic-migration.md) — Atomic scene-subject dot-style migration (touched the same parse boundaries; this ADR completes the identity side)
+- Bead: `holomush-y5inx` (the P1 bug this convention resolves)
+- Out of scope: `"ope-"` ops-event prefix normalization (P3 follow-up under this ADR)

--- a/docs/superpowers/plans/2026-05-28-scene-bare-ulid-identity.md
+++ b/docs/superpowers/plans/2026-05-28-scene-bare-ulid-identity.md
@@ -1,0 +1,615 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scene Bare-ULID Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the `scene-` id prefix so scenes mint bare ULIDs like every other entity, restoring `scene log`, scene join/subscription, and the privacy temporal floor for real scenes.
+
+**Architecture:** `newSceneID()` is the single production site that mints the prefix. Changing it to return a bare ULID makes the stored id, the subject token, `FocusKey.TargetID`, and `FocusMembership.TargetID` byte-identical end-to-end, so the three host parse boundaries (`streamToFocusKey`, `streamScopeFloor`, `protoToFocusKey`) work unmodified. The remaining work is realigning test helpers that manually re-added the prefix and adding regression coverage that drives a real `CreateScene` scene through the host paths the test harness previously masked.
+
+**Tech Stack:** Go, `github.com/oklog/ulid/v2`, Ginkgo/Gomega integration tests (`//go:build integration`), the `internal/testsupport/integrationtest` harness (Postgres testcontainer + embedded NATS + real `CoreServer`).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md`
+**Bead:** holomush-y5inx
+
+---
+
+## File map
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `plugins/core-scenes/service.go` | `newSceneID()` minter — the root change | 1 |
+| `plugins/core-scenes/service_test.go` | unit test for `newSceneID`; fix the `HasPrefix` assertion at :602 | 1 |
+| `internal/testsupport/integrationtest/session.go` | `CreateScene` helper — drop the masking `TrimPrefix` | 2 |
+| `internal/testsupport/integrationtest/crypto.go` | `EmitSceneICContent` — drop the `"scene-"+` re-add; update comments | 2 |
+| `test/integration/scenes/publish_e2e_test.go` | drop the `"scene-"+` reconstruction at :70 | 3 |
+| `test/integration/plugin/binary_plugin_test.go` | flip the `HavePrefix("scene-")` assertion at :900 | 3 |
+| `test/integration/scenes/real_scene_history_readable_test.go` | NEW — INV-Y5INX-2 (`scene log` host read) | 4 |
+| `test/integration/scenes/real_scene_join_subscription_test.go` | NEW — INV-Y5INX-3 (join opens subscription) | 5 |
+| `test/integration/scenes/publish_history_scope_e2e_test.go` | NEW — INV-Y5INX-4 / E9 (holomush-5rh.20.42) | 6 |
+| `test/integration/scenes/scene_id_bare_guard_test.go` | NEW — INV-Y5INX-1/5 behavioral guard | 7 |
+
+**Reviewers:** `abac-reviewer` + `crypto-reviewer` MUST gate before push (the change touches the scene access-gate parse path and the AAD subject shape).
+
+---
+
+### Task 1: `newSceneID()` mints a bare ULID
+
+**Files:**
+
+- Modify: `plugins/core-scenes/service.go:1113`
+- Modify: `plugins/core-scenes/service_test.go` (add unit test; fix the `:602` assertion)
+
+Both files are `package main`. `newSceneID` is unexported, so the unit test calls it directly.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to `plugins/core-scenes/service_test.go`:
+
+```go
+func TestNewSceneIDReturnsBareULIDWithoutPrefix(t *testing.T) {
+	id, err := newSceneID()
+	require.NoError(t, err)
+	assert.False(t, strings.HasPrefix(id, "scene-"),
+		"scene id must be a bare ULID, not a scene- prefixed string (holomush-y5inx)")
+	parsed, perr := ulid.Parse(id)
+	require.NoError(t, perr, "scene id must parse as a bare ULID")
+	assert.Equal(t, id, parsed.String(), "round-trip: stored id equals its ULID string form")
+}
+```
+
+If `ulid` is not already imported in `service_test.go`, add `"github.com/oklog/ulid/v2"` to its import block.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `task test -- -run TestNewSceneIDReturnsBareULIDWithoutPrefix ./plugins/core-scenes/`
+Expected: FAIL — `newSceneID()` currently returns `"scene-"+ULID`, so `HasPrefix` is true and `ulid.Parse` errors with `ErrDataSize`.
+
+- [ ] **Step 3: Make the minter return a bare ULID**
+
+In `plugins/core-scenes/service.go`, change the return at line 1113:
+
+```go
+// before
+	return "scene-" + id.String(), nil
+// after
+	return id.String(), nil
+```
+
+Then fix the now-inverted assertion in `plugins/core-scenes/service_test.go:602` (inside `TestSceneServiceCreateScenePersistsTitleAndOwnerWhenRequestIsValid`):
+
+```go
+// before
+	assert.True(t, strings.HasPrefix(resp.GetScene().GetId(), "scene-"))
+// after
+	assert.False(t, strings.HasPrefix(resp.GetScene().GetId(), "scene-"),
+		"scene id is a bare ULID (holomush-y5inx)")
+	_, idErr := ulid.Parse(resp.GetScene().GetId())
+	assert.NoError(t, idErr, "scene id parses as a bare ULID")
+```
+
+- [ ] **Step 4: Run the package unit tests to verify they pass**
+
+Run: `task test -- ./plugins/core-scenes/`
+Expected: PASS (both the new test and the fixed `:602` assertion).
+
+- [ ] **Step 5: Lint**
+
+Run: `task lint:go`
+Expected: clean (no new findings).
+
+- [ ] **Step 6: Commit**
+
+```text
+fix(scenes): mint bare ULID scene ids, drop scene- prefix (holomush-y5inx)
+```
+
+---
+
+### Task 2: Realign the integration harness to bare scene ids
+
+The harness manually compensated for the prefix in two places. After Task 1 both must stop re-adding/stripping it, or the crypto ingest path will mismatch the now-bare stored row.
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/session.go:462-477` (`CreateScene`)
+- Modify: `internal/testsupport/integrationtest/crypto.go:180-190` (`EmitSceneICContent` + doc comment)
+
+Both are `package integrationtest`.
+
+- [ ] **Step 1: Drop the masking strip in `CreateScene`**
+
+In `internal/testsupport/integrationtest/session.go`, replace the body that strips the prefix (lines 470-476):
+
+```go
+// before
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene")
+	// core-scenes stamps scene IDs as "scene-"+ULID (plugins/core-scenes/service.go:1113);
+	// strip the prefix before parsing the underlying ULID.
+	raw := strings.TrimPrefix(resp.GetScene().GetId(), "scene-")
+	id, err := ulid.Parse(raw)
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene: parse scene id")
+	return id
+// after
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene")
+	// core-scenes mints bare ULID scene ids (plugins/core-scenes/service.go:1113,
+	// holomush-y5inx). The returned id parses directly — no prefix to strip.
+	id, err := ulid.Parse(resp.GetScene().GetId())
+	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene: parse scene id")
+	return id
+```
+
+If `strings` becomes unused in `session.go` after this edit, remove it from the import block (let `task lint:go` / the compiler tell you).
+
+- [ ] **Step 2: Drop the `"scene-"+` re-add in `EmitSceneICContent`**
+
+In `internal/testsupport/integrationtest/crypto.go`, the doc comment (lines 178-186) and body (lines 188-190) assume the stored id is prefixed. Replace:
+
+```go
+// before
+// sceneID is the BARE ULID returned by Session.CreateScene; core-scenes
+// PERSISTS scene rows under the "scene-"+ULID form (newSceneID,
+// service.go:1113) and its InsertScenePose keys off that stored id via
+// parseSceneSubject(subject)[3] → UPDATE scenes WHERE id=<token> (audit.go:629,
+// :233). So the subject's scene-id token MUST be "scene-"+sceneID — NOT the
+// plan's literal sceneID.String() — for the UPDATE…RETURNING to find the row.
+// This mirrors production's own subject builder dotStyleSceneSubjectIC, which
+// is fed the stored "scene-"+ULID id (store.go:1479).
+func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
+	return s.emitPluginEventForScene(ctx, plugin,
+		"scene-"+sceneID.String(), actorID, eventType, payloadJSON, true)
+}
+// after
+// sceneID is the BARE ULID returned by Session.CreateScene. core-scenes
+// persists scene rows under that bare id (newSceneID, service.go:1113,
+// holomush-y5inx) and its InsertScenePose keys off it via
+// parseSceneSubject(subject)[3] → UPDATE scenes WHERE id=<token>. The subject's
+// scene-id token is the bare sceneID — identical to production's own subject
+// builder dotStyleSceneSubjectIC, which is fed the stored bare id.
+func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
+	return s.emitPluginEventForScene(ctx, plugin,
+		sceneID.String(), actorID, eventType, payloadJSON, true)
+}
+```
+
+Also update the trailing comment on `emitPluginEventForScene` (around lines 203-205) that reads `EmitSceneICContent passes "scene-"+ULID (matching CreateScene's stored id)` → `EmitSceneICContent passes the bare ULID (matching CreateScene's stored id)`.
+
+- [ ] **Step 3: Run the existing scene + crypto integration suites to verify they still pass on bare ids**
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: PASS. The existing `seed_encrypted_ic_validation_test.go` and `publish_e2e_test.go` exercise `EmitSceneICContent` + ingest; they confirm the bare subject token now matches the bare stored row. (Requires Docker.)
+
+> Note: `publish_e2e_test.go` still reconstructs `"scene-"+sceneID.String()` at line 70 — it is fixed in Task 3. If Task 3 has not run yet, that test may fail at the join/command step; that is expected and resolved by Task 3. Run Task 2 and Task 3 together before relying on a green `scenes` suite.
+
+- [ ] **Step 4: Commit**
+
+```text
+test(scenes): realign integration harness to bare scene ids (holomush-y5inx)
+```
+
+---
+
+### Task 3: Fix the remaining required test fixtures
+
+Two test sites assert or reconstruct the prefix as a contract and break after Task 1.
+
+**Files:**
+
+- Modify: `test/integration/scenes/publish_e2e_test.go:65-83`
+- Modify: `test/integration/plugin/binary_plugin_test.go:900`
+
+- [ ] **Step 1: Drop the prefix reconstruction in `publish_e2e_test.go`**
+
+Replace lines 65-70:
+
+```go
+// before
+		// CreateScene returns the BARE ULID (prefix stripped by the harness),
+		// but core-scenes stores the id as "scene-<ULID>" and the command/RPC
+		// resolvers match the stored full form verbatim (handleEnd/handleJoin/
+		// handleInvite pass the token straight through; resolveSceneRef strips
+		// only the leading '#'). So reconstruct the stored form for refs.
+		sceneID := alice.CreateScene(ctx, loc)
+		fullSceneID := "scene-" + sceneID.String()
+// after
+		// CreateScene returns the bare ULID, which is exactly the stored id
+		// (holomush-y5inx). Command/RPC resolvers match the stored form verbatim
+		// (handleEnd/handleJoin/handleInvite pass the token straight through;
+		// resolveSceneRef strips only the leading '#'), so the bare id is the ref.
+		sceneID := alice.CreateScene(ctx, loc)
+		sceneRef := sceneID.String()
+```
+
+Then replace every later use of `fullSceneID` in this `It` block with `sceneRef` (the `scene invite`, `scene join`, `scene end`, `scene publish #…`, `scene publish vote …`, and the `ListScenePublishAttempts` `SceneId:` field at the call sites around lines 77-110). Also update the comment at lines 80-82 that says `EmitSceneICContent … re-adds the "scene-" prefix internally` → `EmitSceneICContent takes the bare ULID and builds the bare subject`.
+
+- [ ] **Step 2: Flip the `HavePrefix` assertion in `binary_plugin_test.go`**
+
+`makePrivateScene` (lines 886-894) returns `createResp.GetScene().GetId()` — the raw RPC id, now bare. Replace line 900:
+
+```go
+// before
+				Expect(sceneID).To(HavePrefix("scene-"))
+// after
+				Expect(sceneID).NotTo(HavePrefix("scene-"),
+					"scene id is a bare ULID (holomush-y5inx)")
+				_, parseErr := ulid.Parse(sceneID)
+				Expect(parseErr).NotTo(HaveOccurred(), "scene id parses as a bare ULID")
+```
+
+If `github.com/oklog/ulid/v2` is not imported in `binary_plugin_test.go`, add it. The rest of that lifecycle test uses `sceneID` directly in commands and DB queries, which match the bare stored id unchanged.
+
+- [ ] **Step 3: Run both affected suites**
+
+Run: `task test:int -- ./test/integration/scenes/... ./test/integration/plugin/...`
+Expected: PASS. (Requires Docker; `task plugin:build-all` runs automatically under `task test:int`.)
+
+- [ ] **Step 4: Commit**
+
+```text
+test(scenes): drop scene- prefix from publish + binary-plugin fixtures (holomush-y5inx)
+```
+
+---
+
+### Task 4: Regression — `scene log` history is readable on a real scene (INV-Y5INX-2)
+
+Proves the host `QueryStreamHistory` path no longer returns `INVALID_ARGUMENT` for a `CreateScene`-minted scene.
+
+**Files:**
+
+- Create: `test/integration/scenes/real_scene_history_readable_test.go`
+
+- [ ] **Step 1: Write the regression test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-Y5INX-2: a participant can read the IC history of a real CreateScene
+// scene via the host QueryStreamHistory path (the `scene log` route). Before
+// holomush-y5inx the stored "scene-<ULID>" id failed ulid.Parse in
+// streamToFocusKey → INVALID_ARGUMENT, so `scene log` was broken for every
+// real scene.
+var _ = Describe("INV-Y5INX-2: real scene history is readable via the host", func() {
+	It("returns IC content for a CreateScene scene instead of INVALID_ARGUMENT", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+		)
+		defer ts.Stop()
+
+		alice := ts.ConnectAuthed(ctx, "Alice")
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+		sceneStream := "events." + ts.GameID() + ".scene." + sceneID.String() + ".ic"
+
+		// Emit one sensitive IC pose into the scene (sets up a real scene_log row).
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", `{"text":"the manor is quiet tonight"}`)
+
+		// Read it back through the host history path the `scene log` command
+		// uses. The load-bearing assertions are (1) no error — pre-fix this
+		// returned INVALID_ARGUMENT — and (2) the emitted pose is present.
+		Eventually(func(g Gomega) {
+			evs, err := alice.QueryStreamHistory(ctx, sceneStream)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"INV-Y5INX-2: host QueryStreamHistory MUST NOT reject a bare scene subject")
+			g.Expect(evs).NotTo(BeEmpty(), "scene log must contain the emitted pose")
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	})
+})
+```
+
+`QueryStreamHistory` returns `([]*corev1.EventFrame, error)` (`session.go:517`); the slice non-emptiness is the assertion — no element-type shim needed. Mirrors the sibling call at `privacy_test.go:629`.
+
+- [ ] **Step 2: Run it to confirm it passes (post-Task-1)**
+
+Run: `task test:int -- -run TestScenes ./test/integration/scenes/` (Ginkgo entrypoint is `suite_test.go`)
+Expected: PASS. (To see the pre-fix RED, temporarily revert Task 1's one-line change: the read fails with `INVALID_ARGUMENT`.)
+
+- [ ] **Step 3: Commit**
+
+```text
+test(scenes): regression — real scene history readable via host (holomush-y5inx)
+```
+
+---
+
+### Task 5: Regression — real `scene join` opens a focus subscription (INV-Y5INX-3)
+
+The store-shortcut `JoinScene` helper bypasses `protoToFocusKey`, so it cannot prove the bug is fixed. This test drives the real `scene join` command and asserts **delivery** (an emitted pose reaches the joiner's live stream) — independent of the command-success response, which the host may report `Success=true` regardless (bead D4/E8 note).
+
+**Files:**
+
+- Create: `test/integration/scenes/real_scene_join_subscription_test.go`
+
+- [ ] **Step 1: Write the regression test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-Y5INX-3: joining a real scene via the `scene join` command opens a focus
+// subscription, so a subsequently-emitted IC pose is delivered to the joiner's
+// live stream. Before holomush-y5inx the prefixed "scene-<ULID>" join key
+// failed ulid.Parse in protoToFocusKey, the subscription never opened, and the
+// joiner received nothing (WaitForEvent would time out).
+var _ = Describe("INV-Y5INX-3: real scene join opens a subscription", func() {
+	It("delivers a post-join IC pose to a command-joined participant", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+		)
+		defer ts.Stop()
+
+		alice := ts.ConnectAuthed(ctx, "Alice")
+		bob := ts.ConnectAuthed(ctx, "Bob")
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+
+		// Bob joins through the REAL command path (JoinScene helper bypasses
+		// protoToFocusKey; the command does not). The bare id is the stored ref.
+		Expect(bob.SendCommand(ctx, "scene join "+sceneID.String())).To(Succeed())
+
+		// Alice emits an IC pose AFTER bob's join.
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", `{"text":"bob, you made it"}`)
+
+		// If the subscription opened, bob's live stream delivers the pose.
+		// WaitForEvent t.Fatalf's on timeout, so reaching a non-nil return is
+		// the positive assertion.
+		got := bob.WaitForEvent(ctx, "scene_pose")
+		Expect(got).NotTo(BeNil(),
+			"INV-Y5INX-3: command-joined participant MUST receive scene IC events")
+	})
+})
+```
+
+> Verify the `EmitSceneICContent` `eventType` ("scene_pose") matches the `Type` that `WaitForEvent` sees on the delivered frame. If the host translates the wire type (e.g. a `core-scenes:`-namespaced verb), align the `WaitForEvent` argument to the delivered `EventFrame.Type` — check the type a sibling test (`non_participant_ic_isolation_test.go`) asserts on delivered scene poses and use the same string.
+
+- [ ] **Step 2: Run it to confirm it passes (post-Task-1)**
+
+Run: `task test:int -- ./test/integration/scenes/`
+Expected: PASS. (Pre-fix RED: revert Task 1 and `WaitForEvent` times out → `t.Fatalf`.)
+
+- [ ] **Step 3: Commit**
+
+```text
+test(scenes): regression — real scene join opens subscription (holomush-y5inx)
+```
+
+---
+
+### Task 6: E9 — late-joiner temporal floor on publish events (INV-Y5INX-4, unblocks holomush-5rh.20.42)
+
+Mirrors the `privacy_test.go` I-PRIV-2 scene floor, but on a real `CreateScene` scene with a publish-typed IC event. The late joiner must not see a `scene_publish_started` event emitted before their join; the floor is keyed on `FocusMembership.JoinedAt`. Uses the `JoinScene` store-shortcut (which sets a precise `JoinedAt`) — correct here because this test exercises the **floor**, not the subscription wiring.
+
+**Files:**
+
+- Create: `test/integration/scenes/publish_history_scope_e2e_test.go`
+
+- [ ] **Step 1: Write the E9 test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-Y5INX-4 / E9 (holomush-5rh.20.42): the history-scope temporal floor
+// excludes a publish event emitted before a late participant joined a REAL
+// scene. The early participant (joined first) sees it; the late participant
+// does not. Floors at FocusMembership.JoinedAt via streamScopeFloor.
+var _ = Describe("INV-Y5INX-4 / E9: publish-event history-scope floor", func() {
+	It("hides a pre-join scene_publish_started from a late joiner of a real scene", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+		)
+		defer ts.Stop()
+
+		owner := ts.ConnectAuthed(ctx, "Owner")
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		sceneStream := "events." + ts.GameID() + ".scene." + sceneID.String() + ".ic"
+
+		// Early joiner is a member before any event is emitted.
+		early := ts.ConnectAuthed(ctx, "Early")
+		early.JoinScene(ctx, sceneID)
+
+		// Emit the publish-started event BEFORE the late joiner joins.
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_publish_started", `{"attempt":"first"}`)
+
+		// Late joiner joins AFTER the publish-started event.
+		late := ts.ConnectAuthed(ctx, "Late")
+		lateJoinedAt := late.JoinScene(ctx, sceneID)
+
+		// Emit a second event AFTER the late join so the late joiner has at
+		// least one visible event (proves the floor is a floor, not a blanket deny).
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", `{"text":"after late joined"}`)
+
+		// Early joiner sees BOTH events (joined before either).
+		Eventually(func(g Gomega) {
+			evs, err := early.QueryStreamHistory(ctx, sceneStream)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(evs)).To(BeNumerically(">=", 2),
+				"early joiner must see the pre-join publish event and the later pose")
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		// Late joiner sees ONLY post-join events; every returned event's
+		// timestamp is >= their JoinedAt, and the pre-join publish event is gone.
+		Eventually(func(g Gomega) {
+			evs, err := late.QueryStreamHistory(ctx, sceneStream)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(evs).NotTo(BeEmpty(), "late joiner must see the post-join pose")
+			for _, e := range evs {
+				g.Expect(e.GetTimestamp().AsTime()).To(BeTemporally(">=", lateJoinedAt),
+					"INV-Y5INX-4: pre-join publish event leaked past the floor")
+			}
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	})
+})
+```
+
+> The `e.GetTimestamp().AsTime()` accessor mirrors `privacy_test.go:631-633`. If the returned frame type differs, copy the exact timestamp accessor that file uses on its `QueryStreamHistory` results.
+
+- [ ] **Step 2: Run it**
+
+Run: `task test:int -- ./test/integration/scenes/`
+Expected: PASS.
+
+- [ ] **Step 3: Close the E9 blocker linkage**
+
+This test satisfies holomush-5rh.20.42 (E9). Note it in the bead: `bd note holomush-5rh.20.42 "Satisfied by test/integration/scenes/publish_history_scope_e2e_test.go (INV-Y5INX-4); unblocked by holomush-y5inx bare-ULID fix."` Do not close 5rh.20.42 here — leave that to its own review/close flow.
+
+- [ ] **Step 4: Commit**
+
+```text
+test(scenes): E9 publish-event history-scope floor on real scene (holomush-y5inx)
+```
+
+---
+
+### Task 7: Behavioral guard — `CreateScene` RPC returns a bare ULID (INV-Y5INX-1 / INV-Y5INX-5)
+
+A permanent regression guard pinning the production mint output, so a future change cannot silently reintroduce a type-tag prefix.
+
+**Files:**
+
+- Create: `test/integration/scenes/scene_id_bare_guard_test.go`
+
+- [ ] **Step 1: Write the guard test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+)
+
+// INV-Y5INX-1 / INV-Y5INX-5: the production CreateScene RPC mints a bare ULID
+// scene id — no "scene-" (or any) prefix. This guards against reintroducing a
+// type-tag prefix on entity ids (the bare-ULID identity convention).
+var _ = Describe("INV-Y5INX-1/5: CreateScene mints a bare ULID", func() {
+	It("returns an id with no scene- prefix that parses as a ULID", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT, integrationtest.WithInTreePlugins())
+		defer ts.Stop()
+
+		alice := ts.ConnectAuthed(ctx, "Alice")
+		loc := ts.NewLocation(ctx)
+
+		// Call the RPC directly (not the helper) so we assert on the raw id the
+		// server returns, not the harness-parsed value. Mirrors session.go:464.
+		resp, err := ts.SceneServiceClient().CreateScene(ctx, &scenev1.CreateSceneRequest{
+			CharacterId: alice.CharacterID.String(),
+			Title:       "guard scene",
+			LocationId:  loc.String(),
+			Visibility:  "open",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		rawID := resp.GetScene().GetId()
+
+		Expect(strings.HasPrefix(rawID, "scene-")).To(BeFalse(),
+			"INV-Y5INX-1/5: scene id MUST be a bare ULID, not scene- prefixed")
+		_, perr := ulid.Parse(rawID)
+		Expect(perr).NotTo(HaveOccurred(), "scene id MUST parse as a bare ULID")
+	})
+})
+```
+
+The `scenev1` import alias (`pkg/proto/holomush/scene/v1`) matches `session.go:23`; `SceneServiceClient()` is `harness.go:476`.
+
+- [ ] **Step 2: Run it**
+
+Run: `task test:int -- ./test/integration/scenes/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```text
+test(scenes): guard — CreateScene mints bare ULID (holomush-y5inx)
+```
+
+---
+
+## Final verification (before push)
+
+- [ ] `task test -- ./plugins/core-scenes/` — unit tests green.
+- [ ] `task test:int -- ./test/integration/scenes/... ./test/integration/plugin/...` — integration green (Docker).
+- [ ] `task lint:go` — clean.
+- [ ] `task pr-prep` (fast lane) — green. Note: this diff touches integration surface (Ginkgo specs + shared `integrationtest` helpers), so also run `task pr-prep:full` per CLAUDE.md, since `Integration Test` / `E2E Test` are required CI checks.
+- [ ] `abac-reviewer` + `crypto-reviewer` run and return READY before push.
+
+<!-- adr-capture: sha256=296ff30d3fb4b1e8; session=cli; ts=2026-05-28T19:52:10Z; adrs=holomush-vy0rt -->

--- a/docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md
+++ b/docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md
@@ -1,0 +1,253 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scene Bare-ULID Identity — Design
+
+**Status:** Draft (brainstorming → design-reviewer gate)
+**Bead:** holomush-y5inx
+**Date:** 2026-05-28
+**Reviewers required:** `abac-reviewer` (touches the scene access-gate parse path), `crypto-reviewer` (event-payload AAD subject shape)
+
+---
+
+## Problem (grounded)
+
+Scenes are the only entity in HoloMUSH whose identifier carries a type-tag
+prefix. `newSceneID()` mints `"scene-" + ulid.String()`
+(`plugins/core-scenes/service.go:1113`). Every other entity — locations,
+characters, exits, objects, bindings — mints a **bare** ULID via
+`idgen.New()` (`internal/world/location.go:63`, `character.go:27`,
+`exit.go:109`, `object.go:147`, `postgres/binding_repo.go:84`). Even a sibling
+table inside the same plugin, scene publish attempts, mints bare ULIDs
+(`plugins/core-scenes/publish_store.go:48`).
+
+The prefix is **undocumented** — it was introduced in PR #200 (Epic 9
+foundation) with no comment, ADR, or spec — and it is **redundant**: an event's
+type is already discriminated by the subject domain segment
+(`events.<game>.scene.<id>.ic`) and, for authorization, by the ABAC
+resource-type prefix (`scene:<id>`, a separate colon-style mechanism). Nothing
+in the tree parses `scene-` to recover a type; the only `TrimPrefix(…,
+"scene-")` anywhere is the integration-test harness
+(`internal/testsupport/integrationtest/session.go:473`).
+
+Because the stored id is prefixed but the host parses the raw subject token as a
+ULID, three host boundaries reject real scenes:
+
+| Boundary | Location | Failure |
+| --- | --- | --- |
+| `streamToFocusKey` / `extractSceneID` | `internal/grpc/stream_access.go:137` | `ulid.Parse("scene-<ULID>")` → `ErrDataSize` → `INVALID_ARGUMENT` |
+| `streamScopeFloor` | `internal/grpc/scope_floor.go:44` | compares bare `FocusMembership.TargetID.String()` to extracted `scene-<ULID>` → never matches → temporal floor never applies |
+| `protoToFocusKey` | `internal/plugin/goplugin/host_service.go:469` | `ulid.Parse(TargetID)` on prefixed join key → rejected |
+
+Observable impact on real (command-created) scenes:
+
+- **`scene log` / `scene log export` are broken.** `handleLog`
+  (`commands.go:115`) routes through the host `QueryStreamHistory`
+  (`fetchSceneLogEntries`, `commands.go:175`), which fails at
+  `streamToFocusKey`. A participant gets `INVALID_ARGUMENT`.
+- **Scene join cannot subscribe.** `handleJoin` (`commands.go:802`) passes the
+  prefixed id unchanged into `JoinFocus` (`commands.go:828-830`);
+  `protoToFocusKey` rejects it. `JoinScene` has already committed the DB row, so
+  the user receives a non-fatal "Joined scene in database, but your session
+  could not subscribe (…). Please retry" error (`commands.go:844-847`) — where
+  retry never succeeds, because the prefixed id fails `ulid.Parse` every time.
+  The error is correctly *surfaced* (not swallowed); the defect is that the
+  subscription is structurally unreachable for any real scene.
+- **The privacy temporal floor never fires** for real scenes, so a late
+  joiner's history is unfiltered. The existing floor test passes only because
+  the harness strips the prefix (`session.go:473`) and uses bare-id test scenes.
+
+This was latent because no test ever drove a real `CreateScene`-minted scene
+through the host path — the harness strip masked it. Blocks holomush-5rh.20.42
+(E9), transitively holomush-5rh.20.43 (E10).
+
+---
+
+## Decision
+
+**Entity identifiers in HoloMUSH are bare ULIDs. Type discrimination is carried
+exclusively by the event-subject domain segment
+(`events.<game>.<domain>.<id>`) and the ABAC resource-type prefix
+(`<type>:<id>`) — never by a tag embedded in the identifier string itself.**
+
+Concretely: `newSceneID()` mints a bare ULID like every other entity. The
+`scene-` prefix is removed. Existing prefixed scene data is abandoned (it is
+dev/sandbox-only and disposable).
+
+This is the ADR-worthy decision; it is formalized via `capture-adrs` once this
+spec and its plan reach READY. It binds future entity types, not just scenes.
+
+### Rationale
+
+A type tag inside the identifier forces **every** `ulid.Parse` boundary to strip
+it first. Forgetting the strip fails closed (`INVALID_ARGUMENT`) or, worse,
+fails silently (a floor comparison that never matches → fail-open history). That
+is precisely the y5inx bug class, and it recurred independently at three host
+boundaries. A bare identifier makes the stored id, the subject token, the
+`FocusKey.TargetID`, and the `FocusMembership.TargetID` byte-identical
+end-to-end, so boundaries require **no** normalization and the bug class cannot
+recur. It also makes scenes consistent with the rest of the world model.
+
+### Alternatives considered
+
+- **(b) Tolerate the prefix — `TrimPrefix` at each parse boundary.** Rejected.
+  It enshrines a permanent standing requirement ("remember to strip here") that
+  the next new boundary will forget, reintroducing the exact bug. It adds code
+  to preserve cruft.
+- **(c) Apply the temporal floor inside the plugin `QueryHistory` path.**
+  Rejected. The host already computes and forwards `NotBefore`; duplicating the
+  floor in the plugin risks drift between two implementations of one invariant.
+
+---
+
+## Goals
+
+- Scenes mint bare ULIDs; the three host parse boundaries work unmodified.
+- `scene log`, `scene log export`, scene join/subscription, and the privacy
+  temporal floor all function for real `CreateScene`-minted scenes.
+- Joining a real scene opens a working focus subscription (the prefixed-id
+  "could not subscribe, please retry" failure no longer occurs).
+- Regression coverage drives a **real** scene end-to-end through the host path
+  that the harness strip previously masked.
+
+## Non-goals
+
+- No data migration or crypto AAD re-bind (data is disposable; see below).
+- No change to the `ope-` ops-event prefix (`ops_events.go:111`) — same
+  anti-pattern, but the id is a pure internal primary key never parsed at a
+  focus boundary, so it is not a live bug. Filed as a P3 follow-up.
+- No change to the ABAC resource-type prefix convention (`scene:<id>`); that is
+  a distinct, intentional mechanism and is unaffected.
+
+---
+
+## Invariants (RFC2119)
+
+- **INV-Y5INX-1 (MUST).** `newSceneID()` returns a bare 26-character ULID with
+  no `scene-` (or any) prefix.
+- **INV-Y5INX-2 (MUST).** A scene created via `CreateScene` is readable via the
+  host `CoreServer.QueryStreamHistory` by a participant (`scene log` returns the
+  scene's IC content rather than `INVALID_ARGUMENT`).
+- **INV-Y5INX-3 (MUST).** Joining a real scene opens a focus subscription:
+  `protoToFocusKey` parses the bare join key and `JoinFocus` succeeds, so the
+  "could not subscribe, please retry" path (`commands.go:844`) no longer fires
+  for a valid scene id.
+- **INV-Y5INX-4 (MUST).** The history-scope temporal floor
+  (`streamScopeFloor`) excludes pre-join events for a late participant of a
+  real scene (the iwzt scene-join floor applies end-to-end).
+- **INV-Y5INX-5 (MUST NOT).** No production code path strips a `scene-` prefix
+  from an identifier or subject token (the masking strip in the test harness is
+  removed; no replacement is added at any boundary).
+
+Each `INV-Y5INX-*` invariant maps to a named guarding test (see the Test
+strategy matrix). A behavioral guard test pins the production mint output —
+the real `CreateScene` RPC returns a bare ULID — so INV-Y5INX-1 / INV-Y5INX-5
+cannot silently regress.
+
+---
+
+## Architecture
+
+The change is small and predominantly subtractive. Identifier flow before and
+after:
+
+```mermaid
+flowchart LR
+    subgraph before["Before — prefixed (broken)"]
+        mintB["newSceneID()\n'scene-' + ULID"] --> storeB["scenes.id =\nscene-ULID"]
+        storeB --> subjB["subject token\nscene-ULID"]
+        subjB --> parseB["ulid.Parse(scene-ULID)\nstreamToFocusKey /\nscope_floor /\nprotoToFocusKey"]
+        parseB --> failB["ErrDataSize →\nINVALID_ARGUMENT\nor floor never matches"]
+        memB["FocusMembership.TargetID\n(bare ULID)"] -. "never equals" .-> subjB
+    end
+
+    subgraph after["After — bare (works)"]
+        mintA["newSceneID()\nULID"] --> storeA["scenes.id =\nULID"]
+        storeA --> subjA["subject token\nULID"]
+        subjA --> parseA["ulid.Parse(ULID)\n(unchanged boundaries)"]
+        parseA --> okA["FocusKey resolved;\nfloor matches"]
+        memA["FocusMembership.TargetID\n(bare ULID)"] == "equals" ==> subjA
+    end
+```
+
+### Changes
+
+1. **`newSceneID()`** (`plugins/core-scenes/service.go:1113`) →
+   `return id.String(), nil`. Drop the `"scene-" +` concatenation. This is the
+   root fix; the three host parse boundaries then work unmodified.
+2. **Delete the masking strip** in
+   `internal/testsupport/integrationtest/session.go:473` so integration tests
+   run against the production bare-id shape (INV-Y5INX-5).
+3. **Update test fixtures and assertions.**
+   - **Required:** flip the positive prefix assertion at `service_test.go:602`
+     (`assert.True(strings.HasPrefix(id, "scene-"))`) to assert the id is a bare
+     ULID (`ulid.Parse` succeeds, no `scene-` prefix). Update any other fixture
+     that feeds a scene id into a `ulid.Parse` boundary.
+   - **Cosmetic:** resolver tests (`commands_resolve_test.go`) use synthetic
+     fake ids (`"scene-abc"`, `"scene-xyz"`) that exercise only string-equality
+     membership lookup, never `ulid.Parse`; they pass regardless. Updating them
+     is optional polish, not correctness.
+
+There is **no join-handler change**. `handleJoin` already surfaces a
+non-idempotent `JoinFocus` failure (`commands.go:833-847`); once ids are bare,
+`protoToFocusKey` parses the key and that failure path stops firing for valid
+scenes (INV-Y5INX-3). The "surface the swallowed join" item from earlier triage
+is dropped — there was no swallow.
+
+### What deliberately does NOT change
+
+`streamToFocusKey` / `extractSceneID` (`stream_access.go`), `streamScopeFloor`
+(`scope_floor.go`), `protoToFocusKey` (`host_service.go`), and scene_log ingest
+(`InsertScenePose` `UPDATE scenes WHERE id=<subject token>`) all keep working
+untouched — the stored id and the subject token are both bare ULIDs, so the
+`WHERE` match and the `ulid.Parse` calls succeed natively.
+
+### Crypto / ABAC considerations
+
+- **Crypto AAD.** Sensitive poses bind the subject into the AEAD AAD. With bare
+  ids, fresh poses bind the bare subject. No re-bind is required because
+  existing encrypted rows are abandoned (disposable data). `crypto-reviewer`
+  confirms the bare subject is a valid AAD binding and that no code re-derives a
+  prefixed subject for decryption of new rows.
+- **ABAC.** The scene access gate runs through `streamToFocusKey` /
+  `streamScopeFloor`. The change removes a parse failure; it does not alter any
+  policy, default-deny posture, or attribute. `abac-reviewer` confirms the gate
+  still fails closed for non-participants and that the floor now applies to real
+  scenes (previously it silently did not — a fail-open the bare id closes).
+
+### Data reset
+
+Existing prefixed scene rows (`scenes`, `scene_log`, memberships, publish
+tables) are **abandoned**. The data is dev/sandbox-only and disposable; the
+sandbox is reset via fresh-DB redeploy. No migration code and no AAD re-bind are
+shipped — consistent with the project's "no prod-shape discipline for
+undeployed data" posture.
+
+---
+
+## Test strategy
+
+| Test | Tier | Invariant |
+| --- | --- | --- |
+| `newSceneID` returns a bare 26-char ULID (no prefix) | unit | INV-Y5INX-1 |
+| `scene log` on a real `CreateScene` scene returns IC content (not `INVALID_ARGUMENT`) | integration | INV-Y5INX-2 |
+| Real scene join opens a focus subscription and does NOT return the "could not subscribe" error | integration | INV-Y5INX-3 |
+| E9 (holomush-5rh.20.42): history-scope-privacy floor excludes a late joiner's pre-join events on a real scene | integration (E2E) | INV-Y5INX-4 |
+| Behavioral guard: `CreateScene` RPC returns a bare ULID (pins mint output) | integration | INV-Y5INX-1 / INV-Y5INX-5 |
+| Task 2 removes the sole `TrimPrefix(…, "scene-")` in the tree (harness) | (refactor) | INV-Y5INX-5 |
+
+The harness strip removal (change 2) means the existing scene integration suite
+now exercises the production id shape; any latent prefix assumption surfaces
+there.
+
+---
+
+## Out of scope / follow-ups
+
+- **`ope-` ops-event prefix** (`plugins/core-scenes/ops_events.go:111`) — same
+  anti-pattern, not a live bug (internal PK, never `ulid.Parse`d at a focus
+  boundary). File P3 to normalize for consistency with this ADR.
+
+<!-- adr-capture: sha256=ce88ff82a8be4022; session=cli; ts=2026-05-28T19:52:10Z; adrs=holomush-vy0rt -->


### PR DESCRIPTION
## What

Docs-only PR landing the design artifacts for **holomush-y5inx** (P1) before implementation:

- **Spec** — `docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md` (design-reviewer READY)
- **Plan** — `docs/superpowers/plans/2026-05-28-scene-bare-ulid-identity.md` (plan-reviewer READY; 7 tasks materialized as `holomush-y5inx.1`–`.7`)
- **ADR** — `docs/adr/holomush-vy0rt-entity-ids-bare-ulid.md`

## Why

Scenes were the only entity minting a type-tagged id (`scene-<ULID>`). Because the host parses the raw subject token as a ULID at three boundaries (`streamToFocusKey`, `streamScopeFloor`, `protoToFocusKey`), real scenes were rejected — breaking `scene log`, scene join/subscription, and the privacy temporal floor. A test-harness strip masked the regression.

**Decision (ADR holomush-vy0rt):** entity identifiers are bare ULIDs; type discrimination lives in the event-subject domain segment and the ABAC resource prefix, never embedded in the id string. Fix is to eliminate the prefix (data is disposable) rather than strip it at each parse boundary.

## Scope

Docs only — no code changes. Implementation follows in subsequent PR(s) driven by the materialized bead graph (`bd ready` → `holomush-y5inx.1`). Landing docs first so implementer subagents read canonical spec/plan/ADR from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)