### PR TITLE
docs: SP5 docs quality & cohesion — spec, plan, ADR

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Use topic-tab navigation over a single grouped sidebar](holomush-q924m-use-topic-tab-navigation-over-a-single-grouped-sidebar.md) | 2026-05-28 | Accepted | `holomush-q924m` |
 | [Organize docs audience-first with Diátaxis modes within](holomush-md3k4-organize-docs-audience-first-di-taxis-modes-within.md) | 2026-05-28 | Accepted | `holomush-md3k4` |
 | [Use autogenerate sidebar over explicit entries](holomush-38kmt-use-autogenerate-sidebar-over-explicit-entries.md) | 2026-05-28 | Accepted | `holomush-38kmt` |
 | [Adopt Astro Starlight as the docs site platform](holomush-145ko-adopt-astro-starlight-as-docs-site-platform.md) | 2026-05-27 | Accepted | `holomush-145ko` |

--- a/docs/adr/holomush-q924m-use-topic-tab-navigation-over-single-grouped-sidebar.md
+++ b/docs/adr/holomush-q924m-use-topic-tab-navigation-over-single-grouped-sidebar.md
@@ -1,0 +1,41 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-q924m; do not edit manually; use `/adr update holomush-q924m` -->
+
+# Use topic-tab navigation over a single grouped sidebar
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-q924m
+**Deciders:** Sean Brandt
+
+## Context
+
+SP2 (`holomush-38kmt`) established an autogenerate sidebar with the 5 audience-section groups in a **single** sidebar. SP5 proposes adopting `starlight-sidebar-topics` to surface those 5 sections as **top-level tabs**, each carrying its own scoped sidebar — matching the navigation model of the peer docs sites used as exemplars (Hermes Agent, OpenClaw, Pi). The SP2 autogenerate ADR governs how the groups are *derived*; it does not cover the tab-vs-single-list *surfacing* model.
+
+## Decision
+
+Adopt `starlight-sidebar-topics` to convert the 5 SP2 autogenerate groups into scoped **topic tabs** — each tab owns its sidebar. The underlying autogenerate groups remain in config, so the single-sidebar model is a fallback if the plugin is ever dropped.
+
+## Rationale
+
+- The audience-first IA (SP2) produces exactly the 5 sections topic-tabs require — no restructuring cost; the plugin consumes the existing directory structure.
+- Scoped sidebars cut cognitive load per persona: a player never scrolls past plugin-dev pages; an operator sees only operating docs.
+- The single long sidebar was explicitly the shortcoming motivating SP5's comparison against peer docs sites.
+- `starlight-sidebar-topics` (HiDeoo, ~17.6K weekly, Starlight ≥0.38; we're 0.39) is the maintained option for this nav shape.
+
+## Alternatives Considered
+
+- **Single grouped sidebar (SP2 autogenerate status quo)** — no new dependency, all sections visible at once, already working; but presents all 5 audience sections as one long list regardless of reader role, and doesn't match the exemplar nav model. Rejected (retained only as fallback).
+
+## Consequences
+
+**Positive:** each reader sees only their section's sidebar; nav model matches the exemplars (perceived cohesion); no IA restructuring needed.
+
+**Negative:** adds the `starlight-sidebar-topics` plugin dependency (abandonment → revert to grouped sidebar); topic-tab root links must resolve, so INV-8 link-check + INV-5 render check become mandatory gates.
+
+**Neutral:** `astro.config.mjs`'s `sidebar` array is replaced by a `topics` array (different config shape); does **not** supersede `holomush-38kmt` (that governs group derivation; this governs surfacing).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,7 @@ and machine-readable `llms.txt`.
 | SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | ✅ **landed** (#4296 re-org + #4297 mode-purity) — epic `holomush-44nxc`; ADRs `holomush-md3k4`, `holomush-38kmt`; follow-up `holomush-e6kvc` |
 | SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |
 | SP4 | Complete gRPC service coverage (all 13 services, field-level) | stub `holomush-okm59` (P4 backlog — not yet designed) |
+| SP5 | Docs quality & cohesion — content/arrangement/communication (rubric+audit editorial pass) + topic-tab nav, page-actions, community | epic `holomush-ivwij` (15 tasks); ADR `holomush-q924m` |
 
 **Program anchor:** decision bead `holomush-rkwyb` carries the SP0–SP4 framing and sequencing rationale; query the full program with `bd list -l theme:docs-platform`.
 

--- a/docs/superpowers/plans/2026-05-28-docs-quality-cohesion.md
+++ b/docs/superpowers/plans/2026-05-28-docs-quality-cohesion.md
@@ -1,0 +1,387 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Docs Quality & Cohesion Implementation Plan (SP5)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the docs genuinely good to read and navigate — clear writing, oriented arrangement, consistent voice/terminology — with a supporting presentation layer (topic-tab nav, page actions, section overviews, community links).
+
+**Architecture:** Two halves. **Presentation** (Phase 1) is mechanical Starlight config + 2 plugins. **Editorial** (Phases 2–4) is the substance: write a quality rubric, audit every page against it, then per-section prioritized prose passes (full-revise sub-threshold pages, light-touch the rest, defer the long tail to beads). Presentation ships first so the visible chrome lands quickly; editorial is the bulk.
+
+**Tech Stack:** Astro Starlight 0.39 / Astro 6.3, bun, `starlight-sidebar-topics`, `starlight-llm-actions`, built-in `editLink`/`social`/`lastUpdated`, `linkinator` (link check), bats, `jj`.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-docs-quality-cohesion-design.md`
+**Design bead:** `holomush-ivwij` · **Program anchor:** `holomush-rkwyb`
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `site/package.json` | Add `starlight-sidebar-topics`, `starlight-llm-actions` | Modify |
+| `site/astro.config.mjs` | Topic tabs, page-actions, `editLink`, `lastUpdated`, `social` | Modify |
+| `site/src/styles/custom.css` | Light visual polish (accent/spacing/code/asides) | Modify |
+| `site/src/content/docs/contributing/reference/docs-style-guide.md` | The editorial **quality rubric** (also the contributor standard) | Create |
+| `docs/superpowers/sp5-docs-quality-audit.md` | Per-page audit (scores + priority + biggest issue) | Create |
+| `site/src/content/docs/{guide,operating,extending,contributing,reference}/index.md` | Section **overview** pages (card grids → sub-sections) | Modify |
+| `site/src/content/docs/**` | Prioritized editorial revisions + dedupe + cross-links | Modify |
+| `scripts/check-docs-quality.sh` + `scripts/tests/docs-quality.bats` | Structural invariants (overviews, social, advisory terminology grep, page count) | Create |
+
+> **Lifecycle:** runs in the `sp5-docs-polish` jj workspace (branched from `main@origin`). Commit per task with `jj commit`/`jj describe`; `task fmt:markdown` before each docs commit. Run `.mjs`/plugin installs with **bun**. The editorial tasks (Phases 3–4) are prose work guided by the rubric (Task 5) + audit (Task 6) — they have no unit tests; verification is build-green + `task docs:linkcheck` + per-section human review.
+>
+> **Plugin caveat:** context7 quota was exhausted at design time. Before wiring `starlight-sidebar-topics` (Task 1) and `starlight-llm-actions` (Task 2), read each plugin's current README for exact config + whether the top-level `sidebar` key is kept or removed under the topics plugin. Pin versions in `package.json`.
+
+---
+
+## Phase 1: Presentation & chrome
+
+### Task 1: Topic-tab navigation (`starlight-sidebar-topics`)
+
+**Files:** `site/package.json`, `site/astro.config.mjs`
+
+- [ ] **Step 1: Install**
+
+```bash
+cd site && bun add starlight-sidebar-topics
+```
+
+- [ ] **Step 2: Configure 5 topics (one per audience section)**
+
+Add the plugin and define a topic per audience, each autogenerating its own sidebar from its directory. Read the plugin README first to confirm whether to remove the top-level `sidebar` key (the plugin renders per-topic sidebars):
+
+```javascript
+import starlightSidebarTopics from 'starlight-sidebar-topics';
+// ⚠️ The existing top-level `sidebar: [...]` key (astro.config.mjs) is very
+// likely REMOVED here — starlight-sidebar-topics renders a per-topic sidebar,
+// so keeping both produces duplicate/competing sidebars. Confirm in the 0.7.x
+// README, then delete the old `sidebar` key as part of this task.
+// inside starlight({ ... }) plugins: [...existing,
+  starlightSidebarTopics([
+    { label: 'Guide',        link: '/guide/',        icon: 'open-book',    items: [{ autogenerate: { directory: 'guide' } }] },
+    { label: 'Operating',    link: '/operating/',    icon: 'setting',      items: [{ autogenerate: { directory: 'operating' } }] },
+    { label: 'Extending',    link: '/extending/',    icon: 'puzzle',       items: [{ autogenerate: { directory: 'extending' } }] },
+    { label: 'Contributing', link: '/contributing/', icon: 'pencil',      items: [{ autogenerate: { directory: 'contributing' } }] },
+    { label: 'Reference',    link: '/reference/',    icon: 'information',  items: [{ autogenerate: { directory: 'reference' } }] },
+  ]),
+// ]
+```
+
+- [ ] **Step 3: Build + verify tabs**
+
+```bash
+cd site && bunx astro build
+```
+
+Then `bunx astro dev` — confirm 5 topic tabs render above the sidebar; selecting one shows only that section's sidebar; the home splash still links into `/guide/`.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs(site): topic-tab navigation via starlight-sidebar-topics (holomush-ivwij)"`
+
+### Task 2: Page-actions dropdown (`starlight-llm-actions`)
+
+**Files:** `site/package.json`, `site/astro.config.mjs`
+
+- [ ] **Step 1: Install + register** (read README for current config shape)
+
+```bash
+cd site && bun add starlight-llm-actions
+```
+
+Add `starlightLlmActions({ ... })` to the `plugins` array (copy/view as Markdown, open-in-LLM). Configure the action set per the README.
+
+- [ ] **Step 2: Build + verify**
+
+```bash
+cd site && bunx astro build
+```
+
+`bunx astro dev` — confirm a page-actions control appears in the page title area on a content page, and "copy as Markdown" yields the page body.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(site): per-page LLM page-actions dropdown (holomush-ivwij)"`
+
+### Task 3: Built-in chrome — editLink, lastUpdated, community
+
+**Files:** `site/astro.config.mjs`
+
+- [ ] **Step 1: Add config keys**
+
+```javascript
+      editLink: { baseUrl: 'https://github.com/holomush/holomush/edit/main/site/' },
+      lastUpdated: true,
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/holomush/holomush' },
+        { icon: 'comment', label: 'Discussions', href: 'https://github.com/holomush/holomush/discussions' },
+        // Discord: add when the invite exists — placeholder, do not ship a dead link:
+        // { icon: 'discord', label: 'Discord', href: '<DISCORD_INVITE_URL>' },
+      ],
+```
+
+> Discord ships only once a real invite URL is supplied (spec ⚑). GitHub Discussions ships now. Confirm GitHub Discussions is enabled on the repo, or drop that entry.
+
+- [ ] **Step 2: Build + verify**
+
+```bash
+cd site && bunx astro build
+```
+
+`bunx astro dev` — confirm "Edit page" link (→ GitHub edit URL), "Last updated" footer, and the social icons.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs(site): editLink + lastUpdated + community social links (holomush-ivwij)"`
+
+### Task 4: Light visual polish (`custom.css`)
+
+**Files:** `site/src/styles/custom.css`
+
+- [ ] **Step 1: Refine without changing fonts**
+
+Tighten code-block, aside, and heading spacing; ensure the deep-orange accent has adequate contrast in both schemes. Keep Starlight's default font stack (no web-font add). Keep edits small and reversible.
+
+- [ ] **Step 2: Build + eyeball; Commit**
+
+```bash
+cd site && bunx astro build
+```
+
+`jj commit -m "docs(site): light CSS polish, default fonts retained (holomush-ivwij)"`
+
+---
+
+## Phase 2: Editorial foundation
+
+### Task 5: Write the quality rubric
+
+**Files:** `site/src/content/docs/contributing/reference/docs-style-guide.md`
+
+- [ ] **Step 1: Author the rubric page**
+
+Write the 8-dimension rubric from the spec (Orientation, Audience-fit, Mode-fit, Clarity & voice, Examples, Terminology, Cross-linking, Conciseness), each scored 0–2, grounded in `site/CLAUDE.md` voice and `.claude/rules/terminology.md`. Include the per-mode page skeletons (how-to: goal→prereqs→steps→verify; reference: structured; tutorial: narrative; explanation: concept-first). Add `title` frontmatter; it will surface under Contributing → Reference and is the standard for new docs.
+
+- [ ] **Step 2: Build + commit**
+
+```bash
+cd site && bunx astro build
+```
+
+`jj commit -m "docs(contributing): documentation quality rubric / style guide (holomush-ivwij)"`
+
+### Task 6: Audit every page against the rubric
+
+**Files:** `docs/superpowers/sp5-docs-quality-audit.md`
+
+- [ ] **Step 1: Generate the page list**
+
+```bash
+fd -e md -e mdx . site/src/content/docs | rg -v 'docs/index.mdx|reference/events/' | sort
+```
+
+(≈76 content pages — excludes the root splash and auto-generated `reference/events/*`.)
+
+- [ ] **Step 2: Score each page**
+
+Read each page against the rubric; record a table row: `slug | Orient | Aud | Mode | Clarity | Ex | Term | Xlink | Concise | Total/16 | biggest issue`. This is editorial judgment, not a script.
+
+- [ ] **Step 3: Assign priority**
+
+Mark **P1 (full revision)** = total < 10 OR any 0 on Mode-fit/Terminology; **P2 (light touch)** = 10–13; **OK** = ≥14. Summarize counts per section at the top.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs: SP5 per-page quality audit + priorities (holomush-ivwij)"`
+
+---
+
+## Phase 3: Arrangement
+
+### Task 7: Section overview pages
+
+**Files:** `site/src/content/docs/{guide,operating,extending,contributing,reference}/index.md`
+
+- [ ] **Step 1: Enrich each section index into an oriented landing**
+
+For each of the 5 indexes: a 1–2 sentence "what's here / who it's for", a `<CardGrid>` of `<LinkCard>`s to the mode sub-sections (and key pages), and an explicit "Start here →" pointer. Mirror the home splash's component use. `extending`/`contributing` already have link lists — upgrade to cards; `guide`/`operating`/`reference` are sparser — build out.
+
+```mdx
+---
+title: Operating HoloMUSH
+---
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Run and maintain a HoloMUSH server — install, deploy, secure, and operate it.
+
+<CardGrid>
+  <LinkCard title="How-to guides" href="/operating/how-to/installation/" description="Install, deploy, rotate keys, back up, monitor." />
+  <LinkCard title="Reference" href="/operating/reference/configuration/" description="Configuration and operational reference." />
+  <LinkCard title="Explanation" href="/operating/explanation/authentication/" description="How auth, lifecycle, and plugin security work." />
+</CardGrid>
+```
+
+- [ ] **Step 2: Build + linkcheck**
+
+```bash
+cd site && bunx astro build && cd .. && task docs:linkcheck
+```
+
+Expected: build green; zero broken links.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs: section overview landing pages with card grids (holomush-ivwij)"`
+
+### Task 8: De-duplication pass
+
+**Files:** overlapping pages (audit-identified), e.g. `*/authentication`, `extending/reference/events` vs `reference/events`
+
+- [ ] **Step 1: Identify overlaps from the audit**
+
+```bash
+rg -l "authentication|password|argon2" site/src/content/docs | sort
+```
+
+For each overlap cluster (auth across operating/contributing/reference; `extending/reference/events` vs generated `reference/events`): pick the **canonical home**, reduce the others to a 1-line cross-link, and verify no content is lost (move unique material into the canonical page first).
+
+- [ ] **Step 2: Fix inbound links (no redirects — SP1 stance)**
+
+For any page reduced/merged, rewrite inbound links to the canonical slug. Verify:
+
+```bash
+cd site && bunx astro build && cd .. && task docs:linkcheck
+```
+
+Expected: zero broken links.
+
+- [ ] **Step 3: Commit**
+
+`jj commit -m "docs: de-duplicate overlapping auth/events coverage, cross-link (holomush-ivwij)"`
+
+---
+
+## Phase 4: Per-section editorial passes
+
+> Tasks 9–13 apply the rubric to one section each, driven by the Task 6 audit. Per section: **full-revise** its P1 pages (clarity, orientation, mode-fit, examples, terminology, voice), **light-touch** P2 pages, leave OK pages, and **file a follow-up bead** for any page whose needed rewrite exceeds editorial scope. Verify build + linkcheck after each. These are prose tasks — no unit tests; the rubric + audit + per-section review are the bar.
+
+### Task 9: Editorial pass — Guide
+
+**Files:** `site/src/content/docs/guide/**`
+
+- [ ] **Step 1:** Apply the rubric to the Guide section's audited pages (player-facing: warm, jargon-light, example-led). Full-revise P1, light-touch P2.
+- [ ] **Step 2:** `cd site && bunx astro build && cd .. && task docs:linkcheck` → green.
+- [ ] **Step 3:** File `theme:docs-platform` follow-up beads for any deferred page; note IDs.
+- [ ] **Step 4:** `task fmt:markdown` then `jj commit -m "docs(guide): editorial pass to rubric (holomush-ivwij)"`
+
+### Task 10: Editorial pass — Operating
+
+**Files:** `site/src/content/docs/operating/**`
+
+- [ ] **Step 1:** Apply the rubric (operator-facing: precise, procedure-first how-tos; clean reference). Full-revise P1, light-touch P2.
+- [ ] **Step 2:** build + linkcheck → green.
+- [ ] **Step 3:** file deferred-page beads.
+- [ ] **Step 4:** `task fmt:markdown` then `jj commit -m "docs(operating): editorial pass to rubric (holomush-ivwij)"`
+
+### Task 11: Editorial pass — Extending
+
+**Files:** `site/src/content/docs/extending/**`
+
+- [ ] **Step 1:** Apply the rubric (plugin-dev-facing: concrete code examples, clear tutorial arcs vs how-tos vs reference). Full-revise P1, light-touch P2.
+- [ ] **Step 2:** build + linkcheck → green.
+- [ ] **Step 3:** file deferred-page beads.
+- [ ] **Step 4:** `task fmt:markdown` then `jj commit -m "docs(extending): editorial pass to rubric (holomush-ivwij)"`
+
+### Task 12: Editorial pass — Contributing
+
+**Files:** `site/src/content/docs/contributing/**`
+
+- [ ] **Step 1:** Apply the rubric (contributor-facing: crisp how-tos, conceptual explanations). Full-revise P1, light-touch P2. (Style-guide page from Task 5 is already to-standard.)
+- [ ] **Step 2:** build + linkcheck → green.
+- [ ] **Step 3:** file deferred-page beads.
+- [ ] **Step 4:** `task fmt:markdown` then `jj commit -m "docs(contributing): editorial pass to rubric (holomush-ivwij)"`
+
+### Task 13: Editorial pass — Reference
+
+**Files:** `site/src/content/docs/reference/**` (hand-written pages only — NOT the generated `grpc-api`/`events`, which are SP0/SP4)
+
+- [ ] **Step 1:** Apply the rubric to hand-written reference pages (`access-control`, `audit-subjects`, `index`): structured, scannable, accurate. Do **not** edit generated `grpc-api.md` or `events/*` (owned by the generators / SP4).
+- [ ] **Step 2:** build + linkcheck → green.
+- [ ] **Step 3:** file deferred-page beads.
+- [ ] **Step 4:** `task fmt:markdown` then `jj commit -m "docs(reference): editorial pass to hand-written reference (holomush-ivwij)"`
+
+---
+
+## Phase 5: Verification
+
+### Task 14: Structural invariant checks (INV-1/2/4/7) + advisory terminology grep
+
+**Files:** `scripts/check-docs-quality.sh`, `scripts/tests/docs-quality.bats`
+
+- [ ] **Step 1: Write `check-docs-quality.sh`** — assert:
+  - **INV-1/2:** the rubric page exists; the audit exists and its row count == the content-page count (`fd … | rg -v 'docs/index.mdx|reference/events/' | wc -l`).
+  - **INV-4:** each of the 5 section `index.md` contains a `<CardGrid>`.
+  - **INV-7:** `astro.config.mjs` `social` includes GitHub + Discussions (+ Discord when present).
+  - **Advisory terminology grep (NOT a gate):** print candidate misuses for human review — `rg -n 'location[^.]{0,30}\broom\b' site/src/content/docs` and similar — exit 0 regardless (triage aid only, per spec INV-3).
+
+- [ ] **Step 2: Write `docs-quality.bats`** wrapping the hard asserts (INV-1/2/4/7) with `assert_success`; the terminology grep is run for output, not asserted.
+
+- [ ] **Step 3: Run**
+
+```bash
+cd site && bunx astro build && cd .. && bats scripts/tests/docs-quality.bats
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "test(docs): SP5 structural invariants + terminology advisory (holomush-ivwij)"`
+
+### Task 15: Final sweep + pr-prep
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+cd site && rm -rf dist && cd .. && task docs:build && task docs:linkcheck && bats scripts/tests/docs-quality.bats
+for f in llms.txt llms-full.txt llms-small.txt; do test -s "site/dist/$f" && echo "OK $f"; done
+```
+
+Expected: all green; llms files non-empty (INV-8). Spot-check topic tabs + page actions in `bunx astro preview`.
+
+- [ ] **Step 2: Branding/IA unchanged (INV-9)**
+
+INV-9 preserves **fonts + brand assets**, not all of `custom.css` (Task 4 deliberately polishes spacing/accent in it). So assert assets are byte-identical and `custom.css` has no *font* changes:
+
+```bash
+# Brand assets (logo/favicon) byte-identical to main@origin:
+jj diff --from main@origin -- site/src/assets site/public/favicon.png   # expect: empty
+# custom.css polish must NOT touch the font stack:
+jj diff --from main@origin -- site/src/styles/custom.css | rg -i 'font-family|--sl-font|@font-face' \
+  && echo "FONT CHANGE — investigate (INV-9 violation)" || echo "no font changes — good"
+```
+
+Expected: assets diff empty; "no font changes — good". Confirm no slug changes beyond approved dedupe merges.
+
+- [ ] **Step 3: `task fmt:markdown` then `task pr-prep`**
+
+Expected: pass marker `✓ Fast PR checks passed`.
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "docs(site): finalize SP5 quality + cohesion pass (holomush-ivwij)"`
+
+---
+
+## Out of scope (follow-on)
+
+- Deferred long-tail prose rewrites (Tasks 9–13 beads).
+- Discord social entry until an invite URL exists.
+- SP0 (proto comments), SP4 (gRPC coverage); generated `reference/grpc-api`/`events` content.
+- Hosted AI-search widget.
+<!-- adr-capture: sha256=2f31e0294c76358d; session=2f5ef07e; ts=2026-05-28T21:14:29Z; adrs=holomush-q924m -->

--- a/docs/superpowers/specs/2026-05-28-docs-quality-cohesion-design.md
+++ b/docs/superpowers/specs/2026-05-28-docs-quality-cohesion-design.md
@@ -1,0 +1,182 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Documentation Quality — Content, Arrangement, Communication (SP5)
+
+| Field         | Value                                                          |
+| ------------- | -------------------------------------------------------------- |
+| Status        | Draft — pending `design-reviewer`                              |
+| Tracking bead | `holomush-ivwij`                                               |
+| Date          | 2026-05-28                                                     |
+| Sub-project   | SP5 of the docs-platform program (anchor `holomush-rkwyb`)    |
+| Depends on    | SP1 (Starlight) + SP2 (Diátaxis IA) — both landed             |
+
+## Summary
+
+Make the documentation genuinely good to **read** and **navigate** — clear
+writing, sound arrangement, consistent voice and terminology, no overlap or
+dead weight — and bring the site's presentation to parity with peer docs
+(topic-tab navigation, per-page actions, section overviews, community
+identity). **This is primarily a content-and-communication effort**, not a
+layout one: the presentation layer is the supporting pillar, not the point.
+
+The editorial work is made tractable with a written **quality rubric**, a
+**per-page audit** that scores and prioritizes, and **prioritized passes** —
+full rewrites for the worst/highest-impact pages in-scope, rubric-guided light
+touches elsewhere, and follow-up beads for the long tail.
+
+## Program context
+
+SP5 is a new sub-project of the `theme:docs-platform` program (anchor
+`holomush-rkwyb`; see `docs/roadmap.md`). SP1 (Astro Starlight migration) and
+SP2 (audience-first Diátaxis IA + autogenerate sidebar) have both landed. SP5
+builds on that substrate: SP2's audience folders become the input to topic-tab
+navigation, and SP2's mode buckets define the per-mode page shapes this pass
+makes consistent. SP0 (proto comments) and SP4 (gRPC coverage) are independent
+and out of scope here.
+
+Motivating comparison: peer docs sites (Hermes Agent, OpenClaw, Pi) read as
+cohesive products — top-level navigation, oriented section overviews, page
+actions, a clear voice. HoloMUSH today has the IA and a home splash, but inner
+pages are plain, the sidebar is one long list, there's no per-page action or
+community link, and prose quality/consistency varies page to page.
+
+## Goals
+
+- **MUST** establish a written editorial **quality rubric** grounded in
+  `site/CLAUDE.md` voice and `.claude/rules/terminology.md`, and apply it.
+- **MUST** audit every doc page (clarity / arrangement / mode-fit /
+  terminology) and prioritize; **MUST** fully revise the high-priority pages
+  and rubric-light-touch the rest, filing follow-up beads for deferred prose work.
+- **MUST** give each of the 5 sections an orienting overview page (card grid →
+  sub-sections, short "what's here / who it's for / where to start").
+- **MUST** make terminology consistent and **checkable** (no `room` / `player`-
+  as-character misuse in prose).
+- **MUST** reduce duplication/overlap and add cross-links / next-steps.
+- **MUST** add topic-tab navigation, a per-page actions dropdown, Edit-on-GitHub,
+  `lastUpdated`, and community links (GitHub Discussions + Discord).
+- **MUST** preserve branding and the SP2 IA; keep build / `llms.txt` / link-check green.
+
+## Non-goals
+
+- **MUST NOT** change the SP2 information architecture (folder structure / slugs)
+  beyond merges that dedupe genuinely duplicated pages (each such merge gets a
+  redirect-free link fix per SP1 stance).
+- **MUST NOT** author net-new conceptual docs or fill SP0/SP4 surface (proto
+  comments, gRPC coverage).
+- **MUST NOT** adopt a hosted AI-search widget — the page-actions "open in LLM"
+  is the lighter substitute.
+- **MUST NOT** change content *meaning* — editorial passes improve clarity and
+  arrangement, not the technical facts.
+
+## Architecture / Approach
+
+Three pillars. Pillar 1 (communication) is the substance; Pillar 3
+(presentation) is the enabling layer.
+
+### Pillar 1 — Communication: the quality rubric
+
+A checked-in rubric (`site/docs-quality-rubric.md` or
+`site/CONTRIBUTING-docs.md`) defines the bar every page is held to. Each page is
+scored 0–2 on each dimension:
+
+| Dimension | What "good" means |
+| --- | --- |
+| **Orientation** | Opens with 1–2 sentences: what this page is + who it's for. No cold starts. |
+| **Audience-fit** | Pitched at the section's reader (player / operator / plugin dev / contributor); jargon either avoided or explained on first use. |
+| **Mode-fit (Diátaxis)** | Matches its bucket: how-to = goal→steps→verify, no lectures; reference = structured/scannable; tutorial = narrative arc; explanation = concept-first, no step lists. |
+| **Clarity & voice** | `site/CLAUDE.md` voice — conversational, direct, grounded; cuts "simply / just / easily / of course"; sentences earn their place. |
+| **Examples** | Concrete example/command where it materially helps comprehension. |
+| **Terminology** | Canonical terms per `.claude/rules/terminology.md` (`location` not room, `character` vs `player`). |
+| **Cross-linking** | Links to prerequisites and logical next steps; not a dead end. |
+| **Conciseness** | No filler, no duplication of content better placed elsewhere. |
+
+The rubric is also the contributor standard going forward (lives in the docs so
+new pages inherit it).
+
+### Pillar 1 — the audit + prioritized passes
+
+1. **Audit:** produce `site/docs-quality-audit.md` — a table of every page with
+   its per-dimension scores, a total, and a one-line "biggest issue." Generated
+   by reading each page against the rubric (this is editorial judgment, not a
+   script).
+2. **Prioritize:** pages below a threshold (e.g. total < 10/16, or any 0 on
+   Mode-fit/Terminology) are **P1 — full revision in-scope**. Pages 10–13 get a
+   **rubric-guided light touch**. Pages ≥14 are left, noted "good."
+3. **Passes, per section:** revise P1 pages section-by-section (Guide →
+   Operating → Extending → Contributing → Reference) so each section is
+   independently reviewable. Deferred prose work → follow-up beads labeled
+   `theme:docs-platform`.
+
+### Pillar 2 — Arrangement
+
+- **Section overview pages:** enrich each section `index.md` into an orienting
+  landing — short intro + `<CardGrid>`/`<LinkCard>` to the mode sub-sections,
+  and an explicit "start here" reading order. (Pattern already used on the home
+  splash.) Note: `extending/index` and `contributing/index` already carry link
+  lists and need less work than the sparser `guide/`, `operating/`, `reference/`
+  indexes — the audit confirms per-section effort.
+- **De-duplication:** reconcile overlapping content — e.g. authentication
+  appears in `operating/`, `contributing/`, and `reference/`; `extending/events`
+  vs the generated `reference/events`. For each: pick the canonical home, reduce
+  the others to a cross-link, fix inbound links (no redirects, SP1 stance).
+- **Per-mode page shape:** apply a consistent skeleton per Diátaxis mode so
+  same-type pages feel cohesive (defined in the rubric; applied during passes).
+- **Cross-links / next-steps:** every page ends pointing somewhere sensible.
+
+### Pillar 3 — Presentation (enabling)
+
+| Change | Mechanism |
+| --- | --- |
+| Top-level **topic tabs** (5 audience sections, each own sidebar) | `starlight-sidebar-topics` (Starlight ≥0.38; we're 0.39) — convert the 5 sidebar groups to topics |
+| Per-page **actions dropdown** (copy/view as Markdown, open-in-LLM) | `starlight-llm-actions` (ties into SP1 llms.txt) |
+| **Edit on GitHub** | built-in `editLink.baseUrl: https://github.com/holomush/holomush/edit/main/site/` |
+| **Last updated** + prev/next pagination | built-in `lastUpdated: true` (pagination is default) |
+| **Community** links | built-in `social`: add GitHub Discussions **and** Discord. ⚑ Discord invite URL is an implementation input — placeholder until supplied; GitHub Discussions ships regardless |
+| **Light visual polish** | `customCss` (accent/spacing/code-block/admonition); keep Starlight default fonts |
+
+## Invariants
+
+| ID | Invariant | Verification |
+| --- | --- | --- |
+| INV-1 | The quality rubric exists in the docs and is referenced by the audit. | File presence + audit cross-reference. |
+| INV-2 | Every page is scored in the audit; no page is unscored. | Meta-check: audit row count == content-page count, where a **content page** is any `.md`/`.mdx` under `site/src/content/docs/` **excluding** the root `index.mdx` splash and the auto-generated `reference/events/*` sub-pages. |
+| INV-3 | Terminology is consistent in prose per the canonical glossary (`location` for the spatial concept; `character` vs `player` used correctly). | **Rubric/audit dimension (human-judged)** — the spatial concept is "location" (generic English "room", e.g. "common room", is allowed; `player` is itself canonical). An **advisory** `rg` helper flags *candidate* misuses (`location.*\broom\b` proximity, etc.) for reviewer attention — it is a triage aid, **not** a hard CI gate (the token-level false-positive rate is too high to gate on). |
+| INV-4 | Each of the 5 sections has an orienting overview `index` with a card grid to its sub-sections. | Per-section check. |
+| INV-5 | Topic tabs render for all 5 sections; each tab scopes its own sidebar. | Build + nav check. |
+| INV-6 | Every doc page has the page-actions dropdown and an Edit-on-GitHub link. | Rendered-page check on a sample + config presence. |
+| INV-7 | Community (GitHub Discussions + Discord) and GitHub repo links present. | `social` config check. |
+| INV-8 | No broken internal links after de-dup/cross-link changes; build + `llms.txt` regenerate. | `task docs:linkcheck` + build. |
+| INV-9 | Branding (logo/favicon/accent/`custom.css` fonts) preserved; SP2 IA (slugs) unchanged except approved merges. | Diff vs `main@origin` (`jj diff`). |
+
+> The subjective core (prose quality / voice) is **not** invariant-checked — it
+> is governed by the rubric and per-section human review. INV-1..9 fence the
+> checkable structure around that judgment; they do not pretend to assert "well
+> written."
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Editorial pass balloons (60 pages) | Audit-prioritized: only sub-threshold pages get full rewrites in-scope; rest are light-touch + follow-up beads. |
+| Subjective quality is unreviewable | Rubric makes the standard explicit; per-section passes keep review chunks small; audit scores make "done" legible. |
+| `starlight-sidebar-topics` reshapes nav / breaks deep links | Topic links target existing section roots (`/guide/` …); link-check (INV-8) backstops. |
+| Discord invite not available | GitHub Discussions ships now; Discord added when the URL exists (placeholder, not a blocker). |
+| De-dup merges change slugs | Treat as the only allowed IA change; fix inbound links; INV-8 guards. |
+
+## Out of scope (follow-on)
+
+- Deferred prose rewrites for the long-tail pages (follow-up beads).
+- Net-new conceptual docs; SP0 (proto comments); SP4 (gRPC coverage).
+- Hosted AI-search widget.
+
+## References
+
+- Current site: `site/astro.config.mjs` (Starlight 0.39 / Astro 6.3; plugins client-mermaid + llms-txt; autogenerate sidebar; social=github), `site/src/content/docs/**`, `site/src/styles/custom.css`, home `index.mdx` (splash hero + CardGrid).
+- Editorial standard: `site/CLAUDE.md` (voice & tone) + `.claude/rules/terminology.md` (canonical glossary, MUST-NOT-mix).
+- Plugins: `starlight-sidebar-topics` (HiDeoo), `starlight-llm-actions` (page actions), built-in `editLink`/`social`/`lastUpdated` (starlight.astro.build). context7 quota was exceeded at design time — plugin shapes grounded via the Starlight plugins registry + exa; re-verify versions/config at plan time.
+- Program anchor `holomush-rkwyb`; roadmap `docs/roadmap.md` § `theme:docs-platform`.
+- Reference sites: Hermes Agent, OpenClaw, Pi (user-provided exemplars).
+<!-- adr-capture: sha256=206ad7cb3cd89e67; session=2f5ef07e; ts=2026-05-28T21:14:29Z; adrs=holomush-q924m -->


### PR DESCRIPTION
Planning artifacts for **SP5** of the `theme:docs-platform` program — making the docs genuinely good to read and navigate. Primarily a **content/communication** effort; presentation is the enabling layer.

**Docs-only PR.** Implementation is the 15-task epic `holomush-ivwij`.

## Contents
- **Spec:** `docs/superpowers/specs/2026-05-28-docs-quality-cohesion-design.md` — `design-reviewer` READY
- **Plan:** `docs/superpowers/plans/2026-05-28-docs-quality-cohesion.md` — `plan-reviewer` READY (2 rounds), 15 tasks
- **ADR:** `holomush-q924m` (topic-tab navigation over a single grouped sidebar)
- **Roadmap:** SP5 row added to `theme:docs-platform`

## Approach
- **Editorial core:** a quality rubric (voice + terminology) → per-page audit → prioritized prose passes (full-revise the worst, light-touch the rest, follow-up beads for the tail).
- **Arrangement:** section overview pages, de-duplication, per-mode page shapes, cross-links.
- **Presentation (enabling):** topic-tab nav (`starlight-sidebar-topics`), LLM page-actions, Edit-on-GitHub, `lastUpdated`, GitHub Discussions + Discord, light CSS.
- Honest boundary: prose quality is rubric-and-review governed, not invariant-faked; 9 invariants fence the checkable structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)