### PR TITLE
fix(scenes): bare-ULID scene identity — eliminate scene- prefix (holomush-y5inx)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -11,6 +11,19 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
 
 ## Known invariants to check
 
+- **History-decrypt gate ≠ ABAC engine (y5inx.8, 2026-05-28)**: `authguard.checkCharacter`
+  (`internal/eventbus/authguard/guard.go:67-79`) gates SENSITIVE history decrypt by
+  binding_id membership in the DEK participant set — the ABACEngine is consulted ONLY on
+  the player branch, NEVER character. So an allow-all policy engine in a test harness does
+  NOT make the decrypt gate trivially pass; the gate is the real DEK-participant lookup.
+  Scene `.ic` streams are private (membership-gated via `sessionHasMembership`, I-17,
+  `stream_access.go:85-115`); ABAC never consulted for them. Two distinct layers: I-17
+  membership (can SEE the frame) vs decrypt-gate AuthGuard (can decrypt). A scene member
+  who is NOT a DEK participant correctly gets metadata-only (dispatcher.go:310-314), never
+  plaintext, never error-fallthrough. When reviewing harness/test-support wiring that
+  replicates this, confirm identity is built from session-record data (PlayerID/CharacterID
+  + bindings.Current), gated on `cryptoEnabled && bindings != nil`, not client-supplied.
+
 - `context.Background()` usage in access-critical paths loses auth context — always flag
 - `TODO`/`FIXME` comments deferring security checks are blocking, not informational
 - DSL attribute names must be validated against an allowlist; arbitrary strings are an injection surface

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -363,6 +363,13 @@ Keep under 200 lines. Curate — don't hoard.
   to exercise. `stream_access_test.go:39` explicitly documents the
   rejection: `{"returns false for old colon-style scene stream",
   "scene:01ABC:ic", false}`. Encountered: iwzt.9-11 (2026-05-21).
+  (c) **Harness scene-helper REAL-vs-synthetic distinction**: `Session.CreateScene`
+  (`integrationtest/session.go:465`) drives the REAL `SceneServiceClient().CreateScene`
+  RPC → core-scenes mints a BARE ULID (`service.go:1113`, holomush-y5inx) and persists
+  a backing row; `Server.NewSceneWithoutMember`/`NewScene` (`harness.go:569`) return a
+  SYNTHETIC `idgen.New()` ULID with NO backing row. A "real CreateScene bare-ULID"
+  regression claim is only honored by the `CreateScene` helper. Confirmed: y5inx.4
+  (2026-05-28) — its INV-Y5INX-2 spec correctly uses `CreateScene`.
 
 - **Contributor-guide example YAML/JSON MUST match the validator's regex/schema,
   not just "look plausible."** When a how-to doc shows a copy-paste registry/config

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -286,6 +286,29 @@ Keep under 200 lines. Curate — don't hoard.
   runtime-specific code, but the policy/manifest gate MUST be at the
   shared site.
 
+- **Focus per-connection delta delivery is asymmetric BY DESIGN — not a
+  symmetry violation.** Two distinct focus delivery seams: (1) session-level
+  `focus.StreamSender` (`coordinator.go:22`, `JoinFocus → StreamSender.Send →
+  SessionStreamRegistry.Send → r.channels[sessionID]`, `join.go:51`) wired on
+  the COORDINATOR in prod (`sub_grpc.go:447`) — both runtimes use it; (2)
+  per-connection `focus.ConnectionSender` (binary host field, `host_service.go:255,315`
+  AutoFocusOnJoin/SetConnectionFocus → `SendToConnection → r.connections`).
+  ConnectionSender is **nil in production** (`core.go:405-422` PluginSubsystemConfig
+  omits it; `sub_grpc.go` never sets it) — per-connection deltas are SKIPPED in
+  prod today. Lua DELIBERATELY drops per-connection deltas: `focus_ops_adapter.go:46-49`
+  ("Lua plugins react to focus events via JetStream, not via the RPC return
+  value"). So neither runtime drives per-connection deltas in prod; both deliver
+  session-level via the same coordinator StreamSender. A binary-only
+  `ConnectionSender` field/wiring is NOT a privilege gradient — it's
+  runtime-specific delta delivery, not a trust/policy/manifest gate (those stay
+  at `event_emitter.go::Emit`). Both Subscribe registrations (`server.go:822`
+  session-wide Register + `:872` RegisterConnection) write the SAME ctrlCh, so a
+  single-connection joiner gets delivery via session-level StreamSender
+  regardless of ConnectionSender. Trap: a "binary AutoFocusOnJoin delivery never
+  wired in prod" claim is FACTUALLY true (ConnectionSender nil) but does NOT
+  imply a missing capability — session-level delivery covers it. Encountered:
+  holomush-y5inx.9 harness focus wiring (2026-05-28).
+
 - **Plugin emit token store: pluginName binding is the cross-plugin
   defense**: `emitTokenStore.Lookup(pluginName, token)` rejects when the
   stored entry's pluginName != caller pluginName. The caller pluginName

--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -393,6 +393,19 @@ Keep under 200 lines. Curate — don't hoard.
   SYNTHETIC `idgen.New()` ULID with NO backing row. A "real CreateScene bare-ULID"
   regression claim is only honored by the `CreateScene` helper. Confirmed: y5inx.4
   (2026-05-28) — its INV-Y5INX-2 spec correctly uses `CreateScene`.
+  (d) **Sensitivity-fence INV direction** (`internal/plugin/sensitivity_fence.go:17-22`,
+  `EnforceSensitivity`): manifest=never + claim=true → REJECT **INV-6** (`EVENT_SENSITIVITY_NOT_DECLARED`);
+  manifest=always + claim=false → REJECT **INV-7** (`EVENT_SENSITIVITY_REQUIRED`). So a
+  `sensitivity: never` type (e.g. `scene_publish_started`, plugin.yaml:99-100) emitted with
+  `Sensitive=true` (EmitSceneICContent) is an INV-6 rejection — emit it plaintext via
+  `EmitScenePlaintextContent` (Sensitive=false) instead. A scene-crypto test comment citing
+  "INV-7 fence" for a never-type Sensitive=true rejection would be the wrong invariant number.
+  Confirmed correct in y5inx.6 (2026-05-28). DEK participation is orthogonal to the JoinedAt
+  temporal floor: seed ALL decryptors up front in ONE `GetOrCreate` (it only applies `initial`
+  on FIRST mint, `manager.go:204-270`); the floor (JoinScene's returned JoinedAt) is the only
+  per-session differentiator. Plaintext/identity-codec events read back MetadataOnly=false
+  (`hot_jetstream.go:499` AuthGuard NOT invoked); encrypted events decrypt to MetadataOnly=false
+  for DEK participants.
 
 - **Contributor-guide example YAML/JSON MUST match the validator's regex/schema,
   not just "look plausible."** When a how-to doc shows a copy-paste registry/config

--- a/.claude/agent-memory/crypto-reviewer/MEMORY.md
+++ b/.claude/agent-memory/crypto-reviewer/MEMORY.md
@@ -1,3 +1,4 @@
 # Crypto Reviewer Memory Index
 
 - [Read-Back Decrypt Architecture](project_readback_decrypt.md) — host-mediated plugin self-decrypt primitive; AAD canonical set; legacy_id eliminated
+- [Harness Crypto Readback Wiring](project_harness_crypto_readback.md) — integrationtest WithPluginCrypto mirrors prod history-reader+readback-decryptor; verification checklist

--- a/.claude/agent-memory/crypto-reviewer/project_harness_crypto_readback.md
+++ b/.claude/agent-memory/crypto-reviewer/project_harness_crypto_readback.md
@@ -1,0 +1,18 @@
+---
+name: harness-crypto-readback
+description: integrationtest harness WithPluginCrypto wiring mirrors production history-reader + readback-decryptor crypto path; how to verify faithful mirror
+metadata:
+  type: project
+---
+
+The `internal/testsupport/integrationtest` harness gained a `WithPluginCrypto()` StartOption (crypto.go) that wires the full plugin-crypto round-trip: emit fence → encrypt publish → audit projection → host history reader read-back + read-back decryptor. Landed under bead holomush-y5inx.8.
+
+**Why:** to exercise the SENSITIVE plugin-owned scene-event decrypt-on-readback path (authorized DEK participant decrypts; non-participant downgrades to metadata-only, no error) end-to-end in an integration test, matching production semantics.
+
+**How to apply (when reviewing future changes to this harness's crypto wiring):**
+- Production mirror is `cmd/holomush/sub_grpc.go`: `newHistoryReader` (~785-885) for the reader, the readback-decryptor block (~472-485), and the AuthGuard construction (~340-371). Diff the harness against these.
+- Single-guard invariant: `buildHistoryCrypto` (crypto.go) builds `authguard.New(...)`→`NewSessionBridgeGuard` ONCE; both `readerCryptoOptions` (reader) and `configureReadback` (decryptor) must reuse that one `histCrypto.sessionGuard`. A second guard is a finding.
+- INV-P7-9 selector identity: ONE `pc.selector` (`cryptowiring.KeySelector()`) must feed emit publisher, plugin consumer manager, AND history reader.
+- Known ACCEPTABLE divergence: harness wires `WithHistoryAuth` only (no `WithHistoryAuthAndSourceResolver`/FallbackResolver), so INV-39 cold-tier fallback is inactive. Documented as hot-tier-only readback. Verified non-weakening: `WithHistoryAuth` and `WithHistoryAuthAndSourceResolver` wire identical hot-tier authGuard+DEK; only the cold source resolver differs (tier.go).
+- Fail-closed proof: guard-deny → metadata-only frame + `NoPlaintextReasonAuthGuardDeny` + empty payload, no error (`history/dispatcher.go:310-314`). Bare reader (no crypto) returns `EVENTBUS_HISTORY_AUTH_GUARD_NIL` for sensitive reads — never zero-key decrypt (dispatcher.go:287-292).
+- DEK seeding: `GetOrCreate` selects active row first, applies `initial` participants ONLY on first mint (manager.go:207-244). So `SeedSceneDEKParticipant` pre-minting with the session participant survives the emit-path `GetOrCreate(ctx,ctxID,nil)`. ctxID `{Type:"scene",ID:sceneID}` must match between seed and `contextIDFromSubject` (publisher.go:498-520).

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -22,6 +22,7 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/goplugin"
@@ -87,19 +88,37 @@ type AdminDepsProvider interface {
 
 // PluginSubsystemConfig configures the plugin subsystem.
 type PluginSubsystemConfig struct {
-	DataDir            string
-	DatabaseConnStr    string   // PostgreSQL connection string for schema provisioning
-	CertsDir           string   // path to game certs directory (for loading CA)
-	GameID             string   // game ID for cert SANs
-	TrustAllowlist     []string // server-side plugin trust escalation allowlist
-	ABAC               EngineProvider
-	PolicyInst         PolicyInstallerProvider
-	PluginProv         PluginProviderSetter
-	World              WorldServiceProvider
-	Sessions           SessionProvider
-	AdminDeps          AdminDepsProvider
-	Registry           *lifecycle.ReadinessRegistry
-	StreamRegistry     plugins.StreamRegistry
+	DataDir         string
+	DatabaseConnStr string   // PostgreSQL connection string for schema provisioning
+	CertsDir        string   // path to game certs directory (for loading CA)
+	GameID          string   // game ID for cert SANs
+	TrustAllowlist  []string // server-side plugin trust escalation allowlist
+	ABAC            EngineProvider
+	PolicyInst      PolicyInstallerProvider
+	PluginProv      PluginProviderSetter
+	World           WorldServiceProvider
+	Sessions        SessionProvider
+	AdminDeps       AdminDepsProvider
+	Registry        *lifecycle.ReadinessRegistry
+	StreamRegistry  plugins.StreamRegistry
+	// ConnectionSender is the per-connection Phase-5 delta seam for the binary
+	// plugin host. Session-level focus delivery for both runtimes flows through
+	// JoinFocus → focus.StreamSender (coordinator-wired); however, the scene
+	// KindPolicy returns ReplayModeBoundedTail/LiveOnly for OnJoin, and the
+	// StreamSenderAdapter rejects those modes with REPLAY_MODE_NOT_SUPPORTED
+	// (best-effort errcheck: the error is silently dropped). The binary host's
+	// AutoFocusOnJoin RPC handler therefore drives the actual per-connection
+	// subscription deltas via ConnectionSender.SendToConnection → the
+	// connection's control channel, adding the scene IC/OOC streams to the live
+	// Subscribe filter set. The Lua per-connection focus path
+	// (internal/plugin/lua/focus_ops_adapter.go:46-49) deliberately omits
+	// per-connection deltas — Lua plugins react via JetStream, not the RPC
+	// return. nil leaves binary AutoFocusOnJoin delta-delivery silently skipped
+	// (holomush-y5inx.9). NOTE: this field is intentionally landed here as
+	// forward-plumbing; its production wiring in cmd/holomush/sub_grpc.go is
+	// deferred until Phase 5 is fully wired end-to-end (bead holomush-y5inx
+	// scoped production out-of-scope).
+	ConnectionSender   focus.ConnectionSender
 	LuaTimeout         time.Duration // per-invocation CPU deadline for Lua plugins
 	LuaRegistryMaxSize int           // max Lua registry size per plugin state
 	// VerbRegistry is seeded by BootstrapVerbRegistry in core.go and passed
@@ -276,6 +295,16 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// binary host so overrideFor() can look them up at plugin init time.
 		goplugin.WithConfigOverrides(s.cfg.PluginConfigOverrides),
 	)
+
+	// Wire the per-connection delta sender for the binary host's AutoFocusOnJoin
+	// RPC handler. This is the real scene-stream subscription path: JoinFocus →
+	// StreamSender is silently dropped (ReplayModeBoundedTail/LiveOnly rejected);
+	// AutoFocusOnJoin → SendToConnection → ctrlCh is the actual delivery seam.
+	// The Lua per-connection focus path deliberately omits this (focus_ops_adapter.go).
+	// nil → binary AutoFocusOnJoin delta-delivery silently skipped (holomush-y5inx.9).
+	if s.cfg.ConnectionSender != nil {
+		hostOpts = append(hostOpts, goplugin.WithConnectionSender(s.cfg.ConnectionSender))
+	}
 
 	if s.cfg.CertsDir != "" {
 		ca, caErr := tlscerts.LoadCA(s.cfg.CertsDir)

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -559,6 +559,15 @@ func (s *Server) SeedCharacterBinding(ctx context.Context, sess *Session) string
 	if err == nil && bindingID != "" {
 		return bindingID
 	}
+	// Only fall back to Create on the explicit not-found miss; surface any
+	// other repo error (e.g. BINDING_STORE_QUERY_FAILED) instead of masking it
+	// behind a duplicate-row Create.
+	if err != nil {
+		oe, ok := oops.AsOops(err)
+		if !ok || oe.Code() != "BINDING_NOT_FOUND" {
+			require.NoError(s.t, err, "integrationtest.SeedCharacterBinding: Current")
+		}
+	}
 	bindingID, err = repo.Create(ctx, sess.PlayerID.String(), sess.CharacterID.String(),
 		"integrationtest.SeedCharacterBinding")
 	require.NoError(s.t, err, "integrationtest.SeedCharacterBinding: Create binding")

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -176,17 +176,15 @@ func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payload
 // exist (via CreateScene) so core-scenes' InsertScenePose UPDATE … RETURNING
 // resolves.
 //
-// sceneID is the BARE ULID returned by Session.CreateScene; core-scenes
-// PERSISTS scene rows under the "scene-"+ULID form (newSceneID,
-// service.go:1113) and its InsertScenePose keys off that stored id via
-// parseSceneSubject(subject)[3] → UPDATE scenes WHERE id=<token> (audit.go:629,
-// :233). So the subject's scene-id token MUST be "scene-"+sceneID — NOT the
-// plan's literal sceneID.String() — for the UPDATE…RETURNING to find the row.
-// This mirrors production's own subject builder dotStyleSceneSubjectIC, which
-// is fed the stored "scene-"+ULID id (store.go:1479).
+// sceneID is the BARE ULID returned by Session.CreateScene. core-scenes
+// persists scene rows under that bare id (newSceneID, service.go:1113,
+// holomush-y5inx) and its InsertScenePose keys off it via
+// parseSceneSubject(subject)[3] → UPDATE scenes WHERE id=<token>. The subject's
+// scene-id token is the bare sceneID — identical to production's own subject
+// builder dotStyleSceneSubjectIC, which is fed the stored bare id.
 func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
 	return s.emitPluginEventForScene(ctx, plugin,
-		"scene-"+sceneID.String(), actorID, eventType, payloadJSON, true)
+		sceneID.String(), actorID, eventType, payloadJSON, true)
 }
 
 // emitPluginEventForScene is the parameterized core extracted from
@@ -202,7 +200,7 @@ func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID,
 // audit.go:629) and UPDATEs scenes WHERE id=<sceneSubjectID> … RETURNING
 // (requires the matching scene row). Callers own forming that token:
 // EmitPluginEvent passes the bare WithPluginCrypto sceneID (its self-seeded
-// row uses the bare form); EmitSceneICContent passes "scene-"+ULID (matching
+// row uses the bare form); EmitSceneICContent passes the bare ULID (matching
 // CreateScene's stored id).
 //
 // Panics via requirePluginCrypto if the substrate was not wired.

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -359,41 +359,112 @@ func (s *Server) seedScene(ctx context.Context, pc *pluginCrypto) {
 	require.NoError(s.t, err, "integrationtest.seedScene: insert plugin_core_scenes.scenes")
 }
 
-// configureReadback wires the read-back decryptor (link 4): the REAL
-// SessionBridgeGuard (DEK-participant + plugin-manifest lookups + ABAC engine +
-// backpressure) plus the audit-chain emitter, threaded into the Manager so the
-// DecryptOwnAuditRows host RPC (and the harness's ReadBackOwnRows helper)
-// recover plaintext from a plugin's own encrypted audit rows and emit the INV-19
-// read-back audit record. Mirrors cmd/holomush/sub_grpc.go:347-366,478-485.
-// Pure construction — takes no context (all New* calls below are synchronous).
-func (s *Server) configureReadback(pc *pluginCrypto) {
-	mgr := s.pluginSub.Manager()
+// historyCrypto bundles the crypto substrate shared by the host history reader
+// (readerCryptoOptions) and the read-back decryptor (configureReadback).
+// Building these once guarantees the reader's hot-tier AuthGuard and the
+// decryptor's g2 gate are the SAME guard instance over the SAME DEK-participant
+// and plugin-manifest lookups — no divergent guards (holomush-y5inx.8).
+type historyCrypto struct {
+	// sessionGuard is the eventbus.SessionAuthGuard wrapping the real authguard
+	// (DEK-participant + plugin-manifest lookups + ABAC engine + backpressure).
+	// Threaded into history.NewReader (hot/cold tier auth) AND the read-back
+	// decryptor's g2 gate.
+	sessionGuard eventbus.SessionAuthGuard
+	// sessionAuditEm is the eventbus.SessionAuditEmitter (INV-19 plugin-decrypt
+	// audit). Wrapped by countingAuditEmitter for the decryptor; the reader's
+	// hot-tier auth path consumes the same emitter so plugin decrypts on the
+	// reader path also audit.
+	sessionAuditEm eventbus.SessionAuditEmitter
+	// auditEm is the raw QueuedEmitter retained for Shutdown (drain goroutines)
+	// and reused as the guard's BackpressureChecker.
+	auditEm *authguardaudit.Emitter
+}
 
-	auditEm, err := authguardaudit.NewQueuedEmitter(pc.publisher, authguardaudit.WithGameID(s.bus.Bus.GameID()))
-	require.NoError(s.t, err, "integrationtest.configureReadback: NewQueuedEmitter")
-	s.readbackAuditEm = auditEm
+// buildHistoryCrypto constructs the shared AuthGuard + audit-emitter substrate
+// ONCE so both the history reader and the read-back decryptor use the same
+// instances. MUST run after startPlugins (the manifest lookup needs the loaded
+// Manager) and BEFORE the host history reader is constructed (so
+// readerCryptoOptions can thread the guard into history.NewReader). Returns the
+// bundle plus the raw QueuedEmitter (retained by the caller for t.Cleanup
+// Shutdown). Pure construction — all New* calls below are synchronous.
+//
+// Free function (not a *Server method) because it runs before the *Server is
+// assembled in Start: the reader must be built with the guard threaded in, and
+// the reader is constructed before the Server struct literal.
+func buildHistoryCrypto(
+	t *testing.T,
+	pc *pluginCrypto,
+	mgr *plugins.Manager,
+	accessEngine authguard.ABACEngine,
+	gameID string,
+) *historyCrypto {
+	t.Helper()
+
+	auditEm, err := authguardaudit.NewQueuedEmitter(pc.publisher, authguardaudit.WithGameID(gameID))
+	require.NoError(t, err, "integrationtest.buildHistoryCrypto: NewQueuedEmitter")
 	sessionBridgeEm, err := authguardaudit.NewSessionBridgeEmitter(auditEm)
-	require.NoError(s.t, err, "integrationtest.configureReadback: NewSessionBridgeEmitter")
-	// Wrap so ReadBackAuditCount observes the emission synchronously (see
-	// countingAuditEmitter). The guard's BackpressureChecker still uses the raw
-	// auditEm (throttle state lives there); only the read-back audit-emit seam
-	// fed to the decryptor is wrapped.
-	countingEm := countingAuditEmitter{inner: sessionBridgeEm, n: &s.readbackAuditCount}
+	require.NoError(t, err, "integrationtest.buildHistoryCrypto: NewSessionBridgeEmitter")
 
 	guard, err := authguard.New(
 		authguard.NewDEKParticipantLookup(pc.dekMgr),
 		authguard.NewPluginManifestLookup(mgr),
-		s.accessEngine, // ABACEngine — never invoked on the plugin-readback path
-		auditEm,        // BackpressureChecker — fresh QueuedEmitter ⇒ no throttle
+		accessEngine, // ABACEngine — never invoked on the character/plugin-readback paths
+		auditEm,      // BackpressureChecker — fresh QueuedEmitter ⇒ no throttle
 	)
-	require.NoError(s.t, err, "integrationtest.configureReadback: authguard.New")
+	require.NoError(t, err, "integrationtest.buildHistoryCrypto: authguard.New")
+
+	return &historyCrypto{
+		sessionGuard:   authguard.NewSessionBridgeGuard(guard),
+		sessionAuditEm: sessionBridgeEm,
+		auditEm:        auditEm,
+	}
+}
+
+// readerCryptoOptions returns the history.Reader options that wire the shared
+// AuthGuard + DEK manager + audit emitter + codec selector into the host
+// history reader, so a SENSITIVE plugin-owned scene event read back through
+// Session.QueryStreamHistory decrypts for an authorized DEK participant
+// (hot-tier checkCharacter binding_id match) and downgrades to metadata-only
+// for a non-participant. Mirrors the production newHistoryReader shape
+// (cmd/holomush/sub_grpc.go:834-882): WithCodecSelector + WithHistoryAuth.
+//
+// The harness reader reads recent events from the hot JetStream tier, so the
+// minimum is WithHistoryAuth (no source-resolver / cold-tier fallback needed —
+// the readback event is always within JS retention).
+func (h *historyCrypto) readerCryptoOptions(pc *pluginCrypto) []history.Option {
+	return []history.Option{
+		history.WithCodecSelector(pc.selector),
+		history.WithHistoryAuth(h.sessionGuard, pc.dekMgr, h.sessionAuditEm),
+	}
+}
+
+// configureReadback wires the read-back decryptor (link 4) using the SHARED
+// SessionBridgeGuard + audit-chain emitter built once by buildHistoryCrypto,
+// threaded into the Manager so the DecryptOwnAuditRows host RPC (and the
+// harness's ReadBackOwnRows helper) recover plaintext from a plugin's own
+// encrypted audit rows and emit the INV-19 read-back audit record. Mirrors
+// cmd/holomush/sub_grpc.go:347-366,478-485.
+//
+// Reuses the guard + audit emitter built by buildHistoryCrypto (same instances
+// the history reader uses) so there is exactly one guard in the harness. Pure
+// construction — takes no context (all New* calls below are synchronous).
+func (s *Server) configureReadback(pc *pluginCrypto) {
+	s.t.Helper()
+	require.NotNil(s.t, s.histCrypto, "integrationtest.configureReadback: buildHistoryCrypto must run first")
+	mgr := s.pluginSub.Manager()
+
+	// Wrap so ReadBackAuditCount observes the emission synchronously (see
+	// countingAuditEmitter). The guard's BackpressureChecker still uses the raw
+	// auditEm (throttle state lives there); only the read-back audit-emit seam
+	// fed to the decryptor is wrapped.
+	countingEm := countingAuditEmitter{inner: s.histCrypto.sessionAuditEm, n: &s.readbackAuditCount}
 
 	src := managerSourceForHarness{mgr: mgr}
 	decryptor := history.NewReadbackDecryptor(
 		cryptowiring.OwnerMapFromManager(src),
 		cryptowiring.AlwaysSensitiveSet(src),
 		cryptowiring.CryptoKeysLookup(s.pool),
-		authguard.NewSessionBridgeGuard(guard),
+		s.histCrypto.sessionGuard,
 		pc.dekMgr,
 		countingEm,
 	)
@@ -402,6 +473,50 @@ func (s *Server) configureReadback(pc *pluginCrypto) {
 	// harness's ReadBackOwnRows helper can drive it directly without the RPC.
 	mgr.ConfigureReadbackDecryptor(decryptor)
 	s.readbackDecryptor = decryptor
+}
+
+// SeedSceneDEKParticipant mints the scene's DEK with sess as the sole
+// participant (binding_id keyed) BEFORE the sensitive emit, so the hot-tier
+// AuthGuard's checkCharacter branch PERMITS sess on read-back. GetOrCreate only
+// applies `initial` participants on FIRST mint; the publisher's emit-path
+// GetOrCreate(ctx, ctxID, nil) then finds this existing DEK, so the participant
+// set survives. Also establishes sess's player↔character binding so
+// QueryStreamHistory's binding lookup resolves to the same binding_id stamped
+// here. Requires WithPluginCrypto.
+func (s *Server) SeedSceneDEKParticipant(ctx context.Context, sceneID ulid.ULID, sess *Session) {
+	s.requirePluginCrypto("SeedSceneDEKParticipant")
+	s.t.Helper()
+	require.NotZero(s.t, sess.PlayerID, "SeedSceneDEKParticipant: session needs a non-zero PlayerID (use ConnectAuthed*, not ConnectGuest)")
+	bindingID := s.SeedCharacterBinding(ctx, sess)
+	ctxID := dek.ContextID{Type: "scene", ID: sceneID.String()}
+	_, err := s.pluginCrypto.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{{
+		PlayerID:    sess.PlayerID.String(),
+		CharacterID: sess.CharacterID.String(),
+		BindingID:   bindingID,
+		JoinedAt:    time.Now().UTC(),
+		AddedVia:    "integrationtest.SeedSceneDEKParticipant",
+	}})
+	require.NoError(s.t, err, "integrationtest.SeedSceneDEKParticipant: GetOrCreate DEK")
+}
+
+// SeedCharacterBinding ensures sess's character has an active player↔character
+// binding row and returns its binding_id — the value QueryStreamHistory's
+// binding lookup (BindingRepository.Current) resolves and the AuthGuard's
+// checkCharacter compares against the DEK participant set. Idempotent: an
+// existing active binding is reused. Requires WithPluginCrypto.
+func (s *Server) SeedCharacterBinding(ctx context.Context, sess *Session) string {
+	s.requirePluginCrypto("SeedCharacterBinding")
+	s.t.Helper()
+	require.NotZero(s.t, sess.PlayerID, "SeedCharacterBinding: session needs a non-zero PlayerID (use ConnectAuthed*, not ConnectGuest)")
+	repo := worldpg.NewBindingRepository(s.pool)
+	bindingID, err := repo.Current(ctx, sess.CharacterID.String())
+	if err == nil && bindingID != "" {
+		return bindingID
+	}
+	bindingID, err = repo.Create(ctx, sess.PlayerID.String(), sess.CharacterID.String(),
+		"integrationtest.SeedCharacterBinding")
+	require.NoError(s.t, err, "integrationtest.SeedCharacterBinding: Create binding")
+	return bindingID
 }
 
 // managerSourceForHarness adapts *plugins.Manager to

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -187,6 +187,20 @@ func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID,
 		sceneID.String(), actorID, eventType, payloadJSON, true)
 }
 
+// EmitScenePlaintextContent emits a non-sensitive (Sensitive=false) scene IC
+// event for an ARBITRARY scene + actor — used to seed notice-type content
+// (sensitivity: never events such as scene_publish_started, scene_join_ic, etc.)
+// into a CreateScene-created scene. Requires WithPluginCrypto + WithInTreePlugins.
+// The scene row MUST already exist (via CreateScene).
+//
+// Complement of EmitSceneICContent (which always emits Sensitive=true for
+// content events). Use this for event types whose manifest declares
+// sensitivity: never; the INV-6 fence rejects Sensitive=true for those types.
+func (s *Server) EmitScenePlaintextContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
+	return s.emitPluginEventForScene(ctx, plugin,
+		sceneID.String(), actorID, eventType, payloadJSON, false)
+}
+
 // emitPluginEventForScene is the parameterized core extracted from
 // EmitPluginEvent. It drives a real plugin emit through the Manager's
 // EmitPluginEvent boundary (the same path core-scenes commands use), returning
@@ -497,6 +511,38 @@ func (s *Server) SeedSceneDEKParticipant(ctx context.Context, sceneID ulid.ULID,
 		AddedVia:    "integrationtest.SeedSceneDEKParticipant",
 	}})
 	require.NoError(s.t, err, "integrationtest.SeedSceneDEKParticipant: GetOrCreate DEK")
+}
+
+// SeedSceneDEKParticipants mints the scene's DEK with ALL provided sessions as
+// participants in a SINGLE GetOrCreate call. This is the multi-participant
+// variant of SeedSceneDEKParticipant, required when more than one session must
+// decrypt sensitive events on the same scene.
+//
+// GetOrCreate applies the initial participant set ONLY on first mint, so minting
+// with one session and then calling again for another would leave the second
+// session outside the DEK participant set — the AuthGuard would deny their
+// decrypt and return metadata-only. Calling with all sessions at once avoids
+// that. Also establishes each session's player↔character binding so
+// QueryStreamHistory's binding lookup resolves to the same binding_id stamped
+// here. Requires WithPluginCrypto.
+func (s *Server) SeedSceneDEKParticipants(ctx context.Context, sceneID ulid.ULID, sessions ...*Session) {
+	s.requirePluginCrypto("SeedSceneDEKParticipants")
+	s.t.Helper()
+	participants := make([]dek.Participant, 0, len(sessions))
+	for _, sess := range sessions {
+		require.NotZero(s.t, sess.PlayerID, "SeedSceneDEKParticipants: every session needs a non-zero PlayerID (use ConnectAuthed*, not ConnectGuest)")
+		bindingID := s.SeedCharacterBinding(ctx, sess)
+		participants = append(participants, dek.Participant{
+			PlayerID:    sess.PlayerID.String(),
+			CharacterID: sess.CharacterID.String(),
+			BindingID:   bindingID,
+			JoinedAt:    time.Now().UTC(),
+			AddedVia:    "integrationtest.SeedSceneDEKParticipants",
+		})
+	}
+	ctxID := dek.ContextID{Type: "scene", ID: sceneID.String()}
+	_, err := s.pluginCrypto.dekMgr.GetOrCreate(ctx, ctxID, participants)
+	require.NoError(s.t, err, "integrationtest.SeedSceneDEKParticipants: GetOrCreate DEK")
 }
 
 // SeedCharacterBinding ensures sess's character has an active player↔character

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -152,6 +152,15 @@ type Server struct {
 	// goroutines are stopped via t.Cleanup in Start. nil unless WithPluginCrypto.
 	readbackAuditEm *authguardaudit.Emitter
 
+	// histCrypto bundles the shared crypto substrate (AuthGuard + session
+	// bridges + audit emitter) used by BOTH the host history reader
+	// (readerCryptoOptions, threaded into history.NewReader under
+	// WithPluginCrypto) and the read-back decryptor (configureReadback). Built
+	// once by buildHistoryCrypto so the two surfaces share one guard instance
+	// and one audit emitter (DRY — no divergent guards). nil unless
+	// WithPluginCrypto.
+	histCrypto *historyCrypto
+
 	// accessEngine is the ABAC policy engine the stack evaluates against: the
 	// allow-all default, a WithPolicyEngine override, or — under WithRealABAC —
 	// the real seeded engine (abacSub.Engine()). Exposed via AccessEngine() so
@@ -360,18 +369,27 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	engine := core.NewEngine(&noopEventAppender{})
 
 	// HistoryReader: minimal wiring against the embedded bus's JetStream
-	// and the test Postgres pool. All crypto/audit/fence options are
-	// nil-defaulted — the production newHistoryReader in
+	// and the test Postgres pool. Without WithPluginCrypto, all crypto/audit/
+	// fence options are nil-defaulted — the production newHistoryReader in
 	// cmd/holomush/sub_grpc.go layers those on, but for privacy-invariant
-	// tests the bare JS+Postgres tier is sufficient.
-	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now)
+	// tests the bare JS+Postgres tier is sufficient (zero blast radius).
+	//
+	// Under WithPluginCrypto, build the shared AuthGuard + DEK manager + audit
+	// emitter + codec selector and thread them into the reader (holomush-y5inx.8)
+	// so a SENSITIVE plugin-owned scene event read back via QueryStreamHistory
+	// decrypts for an authorized DEK participant. buildHistoryCrypto runs here
+	// (after startPlugins, before the reader) so configureReadback below reuses
+	// the SAME guard instance — no divergent guards.
+	var histCrypto *historyCrypto
+	historyReaderOpts := []history.Option{}
+	if cfg.withPluginCrypto {
+		histCrypto = buildHistoryCrypto(t, pc, pluginSub.Manager(), pe, bus.Bus.GameID())
+		historyReaderOpts = histCrypto.readerCryptoOptions(pc)
+	}
+	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now, historyReaderOpts...)
 
 	// CoreServer wired with all required subsystems.
-	coreServer := holoGRPC.NewCoreServer(
-		engine,
-		sessionStoreInst,
-		dispatcher,
-		cmdServices,
+	coreServerOpts := []holoGRPC.CoreServerOption{
 		holoGRPC.WithAuthService(authService),
 		holoGRPC.WithPlayerSessionRepo(playerSessionStore),
 		holoGRPC.WithPlayerRepo(playerRepo),
@@ -392,6 +410,26 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		// without the operational complexity of seeded ABAC policies.
 		holoGRPC.WithAccessEngine(pe),
 		holoGRPC.WithVerbRegistry(verbRegistry),
+	}
+	// Under WithPluginCrypto, enable the Phase 3b crypto identity path so
+	// QueryStreamHistory builds a typed CHARACTER SessionIdentity (binding_id
+	// resolved via the BindingRepo) and hands it to the hot-tier AuthGuard.
+	// Without these the identity is the zero value and the guard cannot match a
+	// DEK participant. Gated to crypto so non-crypto suites keep the current
+	// (binding-lookup-skipped) behavior — zero blast radius (holomush-y5inx.8).
+	if cfg.withPluginCrypto {
+		coreServerOpts = append(
+			coreServerOpts,
+			holoGRPC.WithCryptoEnabled(true),
+			holoGRPC.WithBindingRepository(worldpg.NewBindingRepository(pool)),
+		)
+	}
+	coreServer := holoGRPC.NewCoreServer(
+		engine,
+		sessionStoreInst,
+		dispatcher,
+		cmdServices,
+		coreServerOpts...,
 	)
 
 	srv := &Server{
@@ -408,6 +446,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		coreServer:           coreServer,
 		pluginSub:            pluginSub,
 		pluginCrypto:         pc,
+		histCrypto:           histCrypto,
 		accessEngine:         pe,
 		guestStartLocationID: guestLocID,
 	}
@@ -417,8 +456,10 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	// (host-side DEK decrypt + INV-19 audit). Wired after startPlugins so the
 	// Manager's audit clients are resolvable. INV-P7-9: the SAME pc.selector
 	// instance feeds the consumer manager that the crypto-enabled publisher used
-	// on the emit side.
+	// on the emit side. The read-back decryptor reuses the guard + audit emitter
+	// built by buildHistoryCrypto above (also used by the host history reader).
 	if cfg.withPluginCrypto {
+		srv.readbackAuditEm = histCrypto.auditEm
 		srv.seedScene(ctx, pc)
 		srv.pluginConsumers = startPluginConsumers(t, ctx, bus, pluginSub.Manager(), pc.selector)
 		t.Cleanup(func() { _ = srv.pluginConsumers.Stop(context.Background()) })
@@ -696,6 +737,17 @@ func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, ro
 	require.NoError(s.t, s.charRepo.Create(ctx, char),
 		"integrationtest.ConnectAuthedWithRoles: persist character")
 
+	// Under WithPluginCrypto the CoreServer runs with WithCryptoEnabled(true), so
+	// Subscribe / QueryStreamHistory perform a binding lookup
+	// (BindingRepository.Current) to build the typed CHARACTER identity. Create
+	// the binding row here — production characters always have one; the harness's
+	// direct charRepo.Create bypasses that path (holomush-y5inx.8).
+	if s.pluginCrypto != nil {
+		_, bindErr := worldpg.NewBindingRepository(s.pool).Create(ctx,
+			player.ID.String(), char.ID.String(), "integrationtest.ConnectAuthedWithRoles")
+		require.NoError(s.t, bindErr, "integrationtest.ConnectAuthedWithRoles: create binding")
+	}
+
 	// Stamp roles into character_roles.
 	for _, role := range roles {
 		_, roleErr := s.pool.Exec(ctx,
@@ -723,6 +775,7 @@ func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, ro
 	sess := &Session{
 		server:             s,
 		SessionID:          selResp.GetSessionId(),
+		PlayerID:           player.ID,
 		CharacterID:        char.ID,
 		CharacterName:      selResp.GetCharacterName(),
 		LocationID:         s.guestStartLocationID,

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -58,6 +58,8 @@ package integrationtest
 
 import (
 	"context"
+	"errors"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -78,13 +80,17 @@ import (
 	authguardaudit "github.com/holomush/holomush/internal/eventbus/authguard/audit"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/eventbus/history"
+	"github.com/holomush/holomush/internal/eventbus/subjectxlate"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
+	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/grpc/focus/scenepolicy"
 	"github.com/holomush/holomush/internal/idgen"
 	"github.com/holomush/holomush/internal/naming"
 	"github.com/holomush/holomush/internal/pgnanos"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	pluginsetup "github.com/holomush/holomush/internal/plugin/setup"
 	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/settings"
 	"github.com/holomush/holomush/internal/store"
 	"github.com/holomush/holomush/internal/telnet"
 	"github.com/holomush/holomush/internal/world"
@@ -180,10 +186,11 @@ type StartOption func(*startConfig)
 
 // startConfig holds resolved Start options.
 type startConfig struct {
-	accessEngine     types.AccessPolicyEngine
-	withPlugins      bool
-	withRealABAC     bool
-	withPluginCrypto bool
+	accessEngine      types.AccessPolicyEngine
+	withPlugins       bool
+	withRealABAC      bool
+	withPluginCrypto  bool
+	withFocusDelivery bool
 	// pluginConfigOverrides is the per-plugin opaque config override
 	// (plugin name → key → value) threaded into PluginSubsystemConfig.
 	pluginConfigOverrides map[string]map[string]string
@@ -208,6 +215,23 @@ func WithPolicyEngine(eng types.AccessPolicyEngine) StartOption {
 // seed:* grants a roleless character.
 func WithRealABAC() StartOption {
 	return func(c *startConfig) { c.withRealABAC = true }
+}
+
+// WithFocusDelivery wires a real focus.Coordinator + SessionStreamRegistry into
+// the harness (mirroring production cmd/holomush/sub_grpc.go:428-470) so the
+// REAL `scene join` command path reaches JoinFocus → AutoFocusOnJoin →
+// per-connection subscription delivery. Without it, the plugin host-service
+// JoinFocus RPC short-circuits with "focus coordinator not configured"
+// (internal/plugin/goplugin/host_service.go:113) and no scene-stream
+// subscription is ever added, so a post-join IC pose is never delivered to the
+// joiner's live Subscribe stream.
+//
+// REQUIRES WithInTreePlugins (the coordinator is injected into the loaded
+// plugin hosts via Manager.ConfigureFocusDeps). Gated exactly like
+// WithPluginCrypto so non-focus suites keep the current WithSubscriber-only
+// wiring — zero blast radius (holomush-y5inx.9).
+func WithFocusDelivery() StartOption {
+	return func(c *startConfig) { c.withFocusDelivery = true }
 }
 
 // Start bootstraps a full in-process holomush stack and returns a Server.
@@ -285,6 +309,9 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	if cfg.withPluginCrypto && !cfg.withPlugins {
 		panic("integrationtest: WithPluginCrypto() requires WithInTreePlugins()")
 	}
+	if cfg.withFocusDelivery && !cfg.withPlugins {
+		panic("integrationtest: WithFocusDelivery() requires WithInTreePlugins()")
+	}
 	pe := cfg.accessEngine
 
 	// Real seeded ABAC engine (opt-in). Overrides the allow-all default and is
@@ -317,6 +344,19 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		pc = newPluginCrypto(t, bus, pool, verbRegistry)
 	}
 
+	// Focus-delivery: the SessionStreamRegistry MUST exist BEFORE startPlugins so
+	// its ConnectionSenderAdapter can be wired into the binary plugin host at
+	// construction (mirrors production core.go, which creates the registry before
+	// the plugin subsystem). The CoreServer is also given this same registry so
+	// the Subscribe handler registers each connection's control channel on it.
+	// nil under non-focus suites — zero blast radius (holomush-y5inx.9).
+	var streamRegistry *holoGRPC.SessionStreamRegistry
+	var connectionSender focus.ConnectionSender
+	if cfg.withFocusDelivery {
+		streamRegistry = holoGRPC.NewSessionStreamRegistry()
+		connectionSender = holoGRPC.NewConnectionSenderAdapter(streamRegistry)
+	}
+
 	var pluginSub *pluginsetup.PluginSubsystem
 	cmdRegistry := command.NewRegistry()
 	if cfg.withPlugins {
@@ -345,6 +385,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			cryptoPublisher:       cryptoPublisherOf(pc),
 			gameID:                bus.Bus.GameID(),
 			pluginConfigOverrides: cfg.pluginConfigOverrides,
+			connectionSender:      connectionSender,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}
@@ -388,6 +429,59 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	}
 	historyReader := history.NewReader(bus.JS, pool, 30*24*time.Hour, time.Now, historyReaderOpts...)
 
+	// Focus-delivery coordinator (opt-in via WithFocusDelivery; the
+	// SessionStreamRegistry was created above, before startPlugins). Mirrors
+	// production cmd/holomush/sub_grpc.go:428-470: a real focus.Coordinator wired
+	// with the scene KindPolicy, game settings, player-preference reader, and the
+	// plugin StreamContributor. The scene `join` command reaches JoinFocus →
+	// AutoFocusOnJoin; the binary host's AutoFocusOnJoin RPC handler then drives
+	// per-Connection subscription deltas via the ConnectionSenderAdapter (wired at
+	// host construction above) → the connection's control channel, adding the
+	// scene IC/OOC streams to the live Subscribe filter set. The coordinator is
+	// injected into the loaded plugin hosts via Manager.ConfigureFocusDeps below.
+	// Gated so non-focus suites keep the WithSubscriber-only wiring — zero blast
+	// radius (holomush-y5inx.9).
+	var focusCoord focus.Coordinator
+	if cfg.withFocusDelivery {
+		gameSettings := settings.NewGameSettings(&settings.SystemInfoAdapter{
+			Store:       evStore,
+			NotFoundErr: store.ErrSystemInfoNotFound,
+		})
+		var focusErr error
+		focusCoord, focusErr = focus.NewCoordinator(
+			focus.WithSessionStore(sessionStoreInst),
+			focus.WithKindPolicy(scenepolicy.New()),
+			focus.WithGameSettings(gameSettings),
+			focus.WithPlayerPreferences(focus.NewPlayerPrefsAdapter(playerRepo)),
+			focus.WithStreamContributor(&focusStreamContributorAdapter{pm: pluginSub.Manager()}),
+			focus.WithStreamSender(holoGRPC.NewStreamSenderAdapter(streamRegistry)),
+		)
+		require.NoError(t, focusErr, "integrationtest.Start: build focus coordinator")
+	}
+
+	// Subscriber: the embedded bus subscriber powers Subscribe → WaitForEvent /
+	// DrainEvents. Under WithFocusDelivery + WithPluginCrypto, the live Subscribe
+	// loop must decode SENSITIVE scene IC events (delivered after a `scene join`).
+	// A bare identity-codec subscriber hits the zero-key AEAD decode path and
+	// errors ("bad key length"), tearing down the transport. Threading the same
+	// AuthGuard + DEK manager + codec selector + decrypt-audit emitter that the
+	// history reader uses (buildHistoryCrypto) gives the live path Decision-5
+	// semantics: a non-DEK-participant receives a metadata-only frame (Type still
+	// stamped) rather than an error, and a participant receives plaintext. Gated
+	// to crypto so non-crypto suites keep the bare subscriber — zero blast radius
+	// (holomush-y5inx.9).
+	var subscriber eventbus.Subscriber
+	if cfg.withFocusDelivery && histCrypto != nil {
+		subscriber = bus.Bus.Subscriber(
+			eventbus.WithSubscriberCodecSelector(pc.selector),
+			eventbus.WithSubscriberAuthGuard(histCrypto.sessionGuard),
+			eventbus.WithSubscriberDEKManager(pc.dekMgr),
+			eventbus.WithSubscriberDecryptAuditEmitter(histCrypto.sessionAuditEm),
+		)
+	} else {
+		subscriber = bus.Bus.Subscriber()
+	}
+
 	// CoreServer wired with all required subsystems.
 	coreServerOpts := []holoGRPC.CoreServerOption{
 		holoGRPC.WithAuthService(authService),
@@ -399,7 +493,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		holoGRPC.WithGuestService(guestSvc),
 		// Wire embedded bus subscriber so Subscribe calls succeed for
 		// WaitForEvent / DrainEvents paths.
-		holoGRPC.WithSubscriber(bus.Bus.Subscriber()),
+		holoGRPC.WithSubscriber(subscriber),
 		// HistoryReader powers QueryStreamHistory end-to-end so privacy
 		// integration tests can exercise the full RPC path.
 		holoGRPC.WithHistoryReader(historyReader),
@@ -424,6 +518,18 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			holoGRPC.WithBindingRepository(worldpg.NewBindingRepository(pool)),
 		)
 	}
+	// Under WithFocusDelivery, hand the CoreServer the stream registry and focus
+	// coordinator. WithStreamRegistry makes Subscribe register each connection's
+	// control channel (server.go:821/871); WithFocusCoordinator makes Subscribe
+	// run RestoreFocus and lets AutoFocusOnJoin's filter updates reach the live
+	// loop (holomush-y5inx.9).
+	if cfg.withFocusDelivery {
+		coreServerOpts = append(
+			coreServerOpts,
+			holoGRPC.WithStreamRegistry(streamRegistry),
+			holoGRPC.WithFocusCoordinator(focusCoord),
+		)
+	}
 	coreServer := holoGRPC.NewCoreServer(
 		engine,
 		sessionStoreInst,
@@ -431,6 +537,18 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		cmdServices,
 		coreServerOpts...,
 	)
+
+	// Inject the focus coordinator + history reader into the loaded plugin hosts
+	// (late-binding: plugins started before this wiring existed). Without this,
+	// the plugin host-service JoinFocus RPC short-circuits with "focus
+	// coordinator not configured" (host_service.go:113) and the real `scene join`
+	// command never registers a scene-stream subscription (holomush-y5inx.9).
+	if cfg.withFocusDelivery {
+		pluginSub.Manager().ConfigureFocusDeps(focusCoord, &focusHistoryReaderAdapter{
+			reader: historyReader,
+			gameID: bus.Bus.GameID,
+		})
+	}
 
 	srv := &Server{
 		t:                    t,
@@ -990,3 +1108,125 @@ func (*allowAllPolicyEngine) CanPerformAction(_ context.Context, _, _, _, _ stri
 }
 
 var _ types.AccessPolicyEngine = (*allowAllPolicyEngine)(nil)
+
+// focusStreamContributorAdapter bridges plugins.Manager.QuerySessionStreams to
+// focus.StreamContributor by converting the request type. Mirrors the
+// production adapter at cmd/holomush/sub_grpc.go:770. Wired only under
+// WithFocusDelivery so RestoreFocus can include ambient plugin streams.
+type focusStreamContributorAdapter struct {
+	pm *plugins.Manager
+}
+
+// QuerySessionStreams implements focus.StreamContributor.
+func (a *focusStreamContributorAdapter) QuerySessionStreams(ctx context.Context, req focus.StreamContributorRequest) []string {
+	return a.pm.QuerySessionStreams(ctx, plugins.SessionStreamsRequest{
+		CharacterID: req.CharacterID,
+		PlayerID:    req.PlayerID,
+		SessionID:   req.SessionID,
+	})
+}
+
+var _ focus.StreamContributor = (*focusStreamContributorAdapter)(nil)
+
+// focusHistoryReaderAdapter bridges eventbus.HistoryReader (QueryHistory) to
+// plugins.HistoryReader (ReplayTail), so the focus coordinator's
+// QueryStreamHistory replay path resolves under WithFocusDelivery. Mirrors the
+// production busHistoryReaderAdapter at cmd/holomush/sub_grpc.go:670.
+type focusHistoryReaderAdapter struct {
+	reader eventbus.HistoryReader
+	gameID func() string
+}
+
+var _ plugins.HistoryReader = (*focusHistoryReaderAdapter)(nil)
+
+// ReplayTail satisfies plugins.HistoryReader. Fetches up to count most-recent
+// events on stream (optionally filtered by notBefore and exclusive beforeID),
+// returning them in ascending ULID order (oldest→newest).
+func (a *focusHistoryReaderAdapter) ReplayTail(ctx context.Context, stream string, count int, notBefore time.Time, beforeID ulid.ULID) ([]core.Event, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+	gameID := a.gameID()
+	if gameID == "" {
+		gameID = "main"
+	}
+	natsSubject, err := subjectxlate.Legacy(stream, gameID)
+	if err != nil {
+		return nil, oops.With("stream", stream).Wrap(err)
+	}
+	sub, err := eventbus.NewSubject(natsSubject)
+	if err != nil {
+		return nil, oops.With("stream", stream).Wrap(err)
+	}
+	q := eventbus.HistoryQuery{
+		Subject:   sub,
+		Direction: eventbus.DirectionBackward,
+		PageSize:  count,
+		NotBefore: notBefore,
+	}
+	if !beforeID.IsZero() {
+		q.BeforeID = beforeID
+	}
+	hs, err := a.reader.QueryHistory(ctx, q)
+	if err != nil {
+		return nil, oops.With("stream", stream).Wrap(err)
+	}
+	defer hs.Close() //nolint:errcheck // best-effort iterator close
+
+	collected := make([]eventbus.Event, 0, count)
+	for {
+		e, nextErr := hs.Next(ctx)
+		if nextErr != nil {
+			if errors.Is(nextErr, io.EOF) {
+				break
+			}
+			return nil, oops.With("stream", stream).Wrap(nextErr)
+		}
+		collected = append(collected, e)
+		if len(collected) >= count {
+			break
+		}
+	}
+	// Backward direction yields newest-first; reverse to ascending order
+	// (oldest→newest) and translate eventbus.Event → core.Event.
+	result := make([]core.Event, len(collected))
+	for i := range collected {
+		j := len(collected) - 1 - i
+		streamName := subjectxlate.ToLegacy(string(collected[i].Subject), gameID)
+		result[j] = busEventToCoreEvent(collected[i], streamName)
+	}
+	return result, nil
+}
+
+// busEventToCoreEvent translates an eventbus.Event to a core.Event for plugin
+// consumption. Mirrors cmd/holomush/sub_grpc.go:739.
+func busEventToCoreEvent(e eventbus.Event, stream string) core.Event {
+	actorID := ""
+	if e.Actor.ID != (ulid.ULID{}) {
+		actorID = e.Actor.ID.String()
+	}
+	return core.Event{
+		ID:        e.ID,
+		Stream:    stream,
+		Type:      core.EventType(e.Type),
+		Timestamp: e.Timestamp,
+		Actor: core.Actor{
+			Kind: busActorKindToCore(e.Actor.Kind),
+			ID:   actorID,
+		},
+		Payload: e.Payload,
+	}
+}
+
+func busActorKindToCore(k eventbus.ActorKind) core.ActorKind {
+	switch k {
+	case eventbus.ActorKindCharacter:
+		return core.ActorCharacter
+	case eventbus.ActorKindSystem:
+		return core.ActorSystem
+	case eventbus.ActorKindPlugin:
+		return core.ActorPlugin
+	default:
+		return core.ActorSystem
+	}
+}

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -30,6 +30,7 @@ import (
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
@@ -203,6 +204,12 @@ type pluginDeps struct {
 	// GameIDProvider closure so plugin emits translate legacy colon-style
 	// subjects to events.<game_id>.<ns>.<id> consistently.
 	gameID string
+	// connectionSender delivers per-Connection stream subscription deltas to the
+	// binary plugin host (focus.ConnectionSender). Wired only under
+	// WithFocusDelivery so the binary core-scenes AutoFocusOnJoin RPC handler can
+	// route the scene IC/OOC stream subscription onto the joiner's live Subscribe
+	// loop. nil leaves binary delta-delivery best-effort skipped (holomush-y5inx.9).
+	connectionSender focus.ConnectionSender
 	// pluginConfigOverrides is the per-plugin opaque config override
 	// (plugin name → key → value) threaded into PluginSubsystemConfig.
 	pluginConfigOverrides map[string]map[string]string
@@ -291,6 +298,7 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 		LuaTimeout:            5 * time.Second,
 		LuaRegistryMaxSize:    1024 * 1024,
 		PluginConfigOverrides: d.pluginConfigOverrides,
+		ConnectionSender:      d.connectionSender,
 	}
 
 	ps := pluginsetup.NewPluginSubsystem(cfg)

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -40,6 +40,10 @@ type Session struct {
 
 	// SessionID is the game session identifier returned by SelectCharacter.
 	SessionID string
+	// PlayerID is the ULID of the player account that owns CharacterID. Set at
+	// connect time; used by crypto helpers that need the player_id for DEK
+	// participant rows / bindings (e.g. SeedSceneDEKParticipant).
+	PlayerID ulid.ULID
 	// CharacterID is the ULID of the in-game character for this session.
 	CharacterID ulid.ULID
 	// CharacterName is the display name of the character.

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -7,7 +7,6 @@ package integrationtest
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -468,10 +467,9 @@ func (s *Session) CreateScene(ctx context.Context, locationID ulid.ULID) ulid.UL
 		Visibility:  "open",
 	})
 	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene")
-	// core-scenes stamps scene IDs as "scene-"+ULID (plugins/core-scenes/service.go:1113);
-	// strip the prefix before parsing the underlying ULID.
-	raw := strings.TrimPrefix(resp.GetScene().GetId(), "scene-")
-	id, err := ulid.Parse(raw)
+	// core-scenes mints bare ULID scene ids (plugins/core-scenes/service.go:1113,
+	// holomush-y5inx). The returned id parses directly — no prefix to strip.
+	id, err := ulid.Parse(resp.GetScene().GetId())
 	require.NoError(s.server.t, err, "integrationtest.Session.CreateScene: parse scene id")
 	return id
 }

--- a/internal/testsupport/integrationtest/session.go
+++ b/internal/testsupport/integrationtest/session.go
@@ -663,6 +663,7 @@ func (p *AuthedPlayer) OpenWebSession(ctx context.Context) *Session {
 	sess := &Session{
 		server:             p.server,
 		SessionID:          selResp.GetSessionId(),
+		PlayerID:           p.PlayerID,
 		CharacterID:        p.CharacterID,
 		CharacterName:      selResp.GetCharacterName(),
 		LocationID:         persisted.LocationID,

--- a/plugins/core-scenes/commands_test.go
+++ b/plugins/core-scenes/commands_test.go
@@ -66,7 +66,9 @@ func TestHandleCommandCreateInvokesSceneServiceCreateScene(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "Scene created")
-	assert.True(t, strings.Contains(resp.Output, "scene-"), "output should include the scene id")
+	assert.False(t, strings.Contains(resp.Output, "scene-"),
+		"scene id in output must be a bare ULID, not scene- prefixed (holomush-y5inx)")
+	assert.Contains(t, resp.Output, "Scene created: ", "output should include the scene id")
 }
 
 func TestHandleCommandInfoShowsCreatedScene(t *testing.T) {

--- a/plugins/core-scenes/service.go
+++ b/plugins/core-scenes/service.go
@@ -1110,7 +1110,7 @@ func newSceneID() (string, error) {
 	if err != nil {
 		return "", oops.Code("SCENE_ID_GEN_FAILED").Wrap(err)
 	}
-	return "scene-" + id.String(), nil
+	return id.String(), nil
 }
 
 // Phase 6 publication RPC stubs — present per plan A3 Step 5 so the Phase 6

--- a/plugins/core-scenes/service_test.go
+++ b/plugins/core-scenes/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -599,7 +600,10 @@ func TestSceneServiceCreateScenePersistsTitleAndOwnerWhenRequestIsValid(t *testi
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.GetScene())
-	assert.True(t, strings.HasPrefix(resp.GetScene().GetId(), "scene-"))
+	assert.False(t, strings.HasPrefix(resp.GetScene().GetId(), "scene-"),
+		"scene id is a bare ULID (holomush-y5inx)")
+	_, idErr := ulid.Parse(resp.GetScene().GetId())
+	assert.NoError(t, idErr, "scene id parses as a bare ULID")
 	assert.Equal(t, "Tea at the Manor", resp.GetScene().GetTitle(), "title should be trimmed")
 	assert.Equal(t, "char-alice", resp.GetScene().GetOwnerId())
 	assert.Equal(t, string(SceneStateActive), resp.GetScene().GetState())
@@ -1735,4 +1739,14 @@ type erroringIsParticipantStore struct {
 
 func (e *erroringIsParticipantStore) IsParticipant(_ context.Context, _, _ string) (bool, error) {
 	return false, e.err
+}
+
+func TestNewSceneIDReturnsBareULIDWithoutPrefix(t *testing.T) {
+	id, err := newSceneID()
+	require.NoError(t, err)
+	assert.False(t, strings.HasPrefix(id, "scene-"),
+		"scene id must be a bare ULID, not a scene- prefixed string (holomush-y5inx)")
+	parsed, perr := ulid.Parse(id)
+	require.NoError(t, perr, "scene id must parse as a bare ULID")
+	assert.Equal(t, id, parsed.String(), "round-trip: stored id equals its ULID string form")
 }

--- a/test/integration/plugin/binary_plugin_test.go
+++ b/test/integration/plugin/binary_plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+	"github.com/oklog/ulid/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -897,7 +898,10 @@ var _ = Describe("Binary Plugin Lifecycle", func() {
 			It("supports create→invite→join→kick→reinvite→join→transfer→leave", func() {
 				// 1. Create a private scene as char-alice.
 				sceneID := makePrivateScene("char-alice", "E2E Test Scene")
-				Expect(sceneID).To(HavePrefix("scene-"))
+				Expect(sceneID).NotTo(HavePrefix("scene-"),
+					"scene id is a bare ULID (holomush-y5inx)")
+				_, parseErr := ulid.Parse(sceneID)
+				Expect(parseErr).NotTo(HaveOccurred(), "scene id parses as a bare ULID")
 
 				// DB validation: owner participant row inserted by CreateWithOwner.
 				var ownerRole string

--- a/test/integration/plugin/binary_plugin_test.go
+++ b/test/integration/plugin/binary_plugin_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/oklog/ulid/v2"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
 	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
-	"github.com/oklog/ulid/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/test/integration/scenes/publish_e2e_test.go
+++ b/test/integration/scenes/publish_e2e_test.go
@@ -61,48 +61,47 @@ var _ = Describe("happy-path scene publish lifecycle reaches PUBLISHED with decr
 	It("Alice ends, publishes, both vote yes, cool-off sweeps → PUBLISHED, both read RPCs return decrypted content", func() {
 		loc := ts.NewLocation(ctx)
 
-		// CreateScene returns the BARE ULID (prefix stripped by the harness),
-		// but core-scenes stores the id as "scene-<ULID>" and the command/RPC
-		// resolvers match the stored full form verbatim (handleEnd/handleJoin/
-		// handleInvite pass the token straight through; resolveSceneRef strips
-		// only the leading '#'). So reconstruct the stored form for refs.
+		// CreateScene returns the bare ULID, which is exactly the stored id
+		// (holomush-y5inx). Command/RPC resolvers match the stored form verbatim
+		// (handleEnd/handleJoin/handleInvite pass the token straight through;
+		// resolveSceneRef strips only the leading '#'), so the bare id is the ref.
 		sceneID := alice.CreateScene(ctx, loc)
-		fullSceneID := "scene-" + sceneID.String()
+		sceneRef := sceneID.String()
 
 		// Bob must JOIN, not merely be invited — the vote roster seeds from
 		// role IN ('owner','member') (INV-P6-1); an 'invited' row is excluded.
 		// scene invite / scene join pass fields[0] directly to the RPC (no '#'
 		// stripping), and the invite target is a character ID, not a name.
-		Expect(alice.SendCommand(ctx, "scene invite "+fullSceneID+" "+bob.CharacterID.String())).To(Succeed())
-		Expect(bob.SendCommand(ctx, "scene join "+fullSceneID)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene invite "+sceneRef+" "+bob.CharacterID.String())).To(Succeed())
+		Expect(bob.SendCommand(ctx, "scene join "+sceneRef)).To(Succeed())
 
 		// Seed encrypted IC content into the created scene (command emit path
 		// can't set Sensitive → INV-7 fence, §3.4). EmitSceneICContent takes the
-		// BARE ULID and re-adds the "scene-" prefix internally.
+		// bare ULID and builds the bare subject.
 		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
 			alice.CharacterID, "scene_pose", `{"text":"the scene happens"}`)
 
 		// Command-driven lifecycle. scene end takes the bare stored id; scene
 		// publish / scene publish vote route through resolveSceneRef so they need
 		// the '#'-prefixed stored form.
-		Expect(alice.SendCommand(ctx, "scene end "+fullSceneID)).To(Succeed())
-		Expect(alice.SendCommand(ctx, "scene publish #"+fullSceneID)).To(Succeed())
-		Expect(alice.SendCommand(ctx, "scene publish vote yes #"+fullSceneID)).To(Succeed())
-		Expect(bob.SendCommand(ctx, "scene publish vote yes #"+fullSceneID)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene end "+sceneRef)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene publish #"+sceneRef)).To(Succeed())
+		Expect(alice.SendCommand(ctx, "scene publish vote yes #"+sceneRef)).To(Succeed())
+		Expect(bob.SendCommand(ctx, "scene publish vote yes #"+sceneRef)).To(Succeed())
 
 		// Scheduler (~20ms interval, ~1ms cool-off) sweeps COOLOFF → PUBLISHED.
 		// The read RPCs key off the ATTEMPT ulid (published_scene_id), recovered
 		// via ListScenePublishAttempts → the PUBLISHED summary's Id. Poll until a
 		// PUBLISHED attempt appears — that's the grounded PUBLISHED signal
 		// (status string "PUBLISHED", publish_types.go:19) regardless of event
-		// name. SceneId keys off the stored full form (IsParticipant /
-		// ListSceneAttempts), so pass fullSceneID.
+		// name. SceneId keys off the stored bare ULID (IsParticipant /
+		// ListSceneAttempts), so pass sceneRef.
 		var publishedSceneID string
 		Eventually(func(g Gomega) {
 			listResp, err := ts.SceneServiceClient().ListScenePublishAttempts(ctx,
 				&scenev1.ListScenePublishAttemptsRequest{
 					CallerCharacterId: alice.CharacterID.String(),
-					SceneId:           fullSceneID,
+					SceneId:           sceneRef,
 				})
 			g.Expect(err).NotTo(HaveOccurred())
 			publishedSceneID = ""

--- a/test/integration/scenes/publish_history_scope_e2e_test.go
+++ b/test/integration/scenes/publish_history_scope_e2e_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-Y5INX-4 / E9 (holomush-5rh.20.42): the history-scope temporal floor
+// excludes a publish event emitted BEFORE a late participant joined a REAL
+// scene. The early participant (joined first) sees it; the late participant
+// does not. Floors at FocusMembership.JoinedAt via streamScopeFloor.
+//
+// Two orthogonal mechanisms are exercised simultaneously:
+//
+//  1. FLOOR — keyed on FocusMembership.JoinedAt, set by the JoinScene
+//     store-shortcut helper. The JoinScene path is correct here: this test
+//     exercises the floor, not the subscription wiring.
+//
+//  2. DECRYPTION — keyed on DEK participation, set by SeedSceneDEKParticipants.
+//     Both early and late are seeded together in one GetOrCreate call BEFORE any
+//     event is emitted, so both receive a decrypted (non-metadata-only) frame.
+//     GetOrCreate only applies initial participants on first mint; seeding with
+//     both sessions up front is the correct way to grant both decrypt access
+//     while keeping the floor (JoinedAt) as the only differentiator.
+//
+// Spec: docs/superpowers/plans/2026-05-28-scene-bare-ulid-identity.md §Task 6.
+// Bead: holomush-y5inx.6, unblocks holomush-5rh.20.42.
+var _ = Describe("INV-Y5INX-4 / E9: publish-event history-scope floor", func() {
+	It("hides a pre-join scene_publish_started from a late joiner of a real scene", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+
+		ts := integrationtest.Start(suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+		)
+		DeferCleanup(ts.Stop)
+
+		// Create owner + scene.
+		owner := ts.ConnectAuthed(ctx, "Owner")
+		DeferCleanup(func() { owner.Logout(ctx) })
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		sceneStream := "events." + ts.GameID() + ".scene." + sceneID.String() + ".ic"
+
+		// Connect early and late joiners.
+		early := ts.ConnectAuthed(ctx, "Early")
+		DeferCleanup(func() { early.Logout(ctx) })
+		late := ts.ConnectAuthed(ctx, "Late")
+		DeferCleanup(func() { late.Logout(ctx) })
+
+		// Seed DEK with BOTH participants in a single GetOrCreate call BEFORE
+		// any emit. GetOrCreate only applies initial participants on first mint,
+		// so both early and late must be present now to decrypt later.
+		// DEK participation is orthogonal to the floor: seeding up front is
+		// correct; only JoinedAt controls which events each session sees.
+		ts.SeedSceneDEKParticipants(ctx, sceneID, early, late)
+
+		// Early joins BEFORE the publish-started event; her JoinedAt predates it.
+		early.JoinScene(ctx, sceneID)
+
+		// Emit the publish-started event BEFORE the late joiner joins.
+		// scene_publish_started has sensitivity: never in the manifest, so it
+		// must be emitted as Sensitive=false (EmitScenePlaintextContent).
+		// EmitSceneICContent would be rejected by the INV-6 fence for this type.
+		ts.EmitScenePlaintextContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_publish_started", `{"attempt":"first"}`)
+
+		// Late joins AFTER the publish-started event; her JoinedAt becomes the floor.
+		lateJoinedAt := late.JoinScene(ctx, sceneID)
+
+		// Emit a second event AFTER the late join so the late joiner has at
+		// least one visible event — proves the floor is a floor, not a blanket deny.
+		ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", `{"text":"after late joined"}`)
+
+		// ASSERTION 1 — early joiner sees BOTH events (joined before either).
+		// The early participant sees the pre-join publish event AND the later pose,
+		// and both are DECRYPTED (MetadataOnly == false) because early is a DEK
+		// participant.
+		Eventually(func(g Gomega) {
+			evs, err := early.QueryStreamHistory(ctx, sceneStream)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"early joiner QueryStreamHistory must not error")
+			g.Expect(len(evs)).To(BeNumerically(">=", 2),
+				"early joiner must see the pre-join publish event and the later pose")
+			for _, e := range evs {
+				g.Expect(e.GetMetadataOnly()).To(BeFalse(),
+					"INV-Y5INX-4: early participant (DEK member) must receive DECRYPTED frames")
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+
+		// ASSERTION 2 — late joiner sees ONLY post-join events; every returned
+		// event's timestamp is >= her JoinedAt. The pre-join scene_publish_started
+		// is absent. Visible events are DECRYPTED (MetadataOnly == false) because
+		// late is also a DEK participant.
+		Eventually(func(g Gomega) {
+			evs, err := late.QueryStreamHistory(ctx, sceneStream)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"late joiner QueryStreamHistory must not error")
+			g.Expect(evs).NotTo(BeEmpty(),
+				"late joiner must see the post-join pose (vacuous-pass guard)")
+			for _, e := range evs {
+				g.Expect(e.GetTimestamp().AsTime()).To(BeTemporally(">=", lateJoinedAt),
+					"INV-Y5INX-4: event %q at %s leaked before late joiner's JoinedAt %s",
+					e.GetType(), e.GetTimestamp().AsTime(), lateJoinedAt)
+				g.Expect(e.GetMetadataOnly()).To(BeFalse(),
+					"INV-Y5INX-4: late participant (DEK member) must receive DECRYPTED frames")
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+	})
+})

--- a/test/integration/scenes/publish_history_scope_e2e_test.go
+++ b/test/integration/scenes/publish_history_scope_e2e_test.go
@@ -40,7 +40,8 @@ var _ = Describe("INV-Y5INX-4 / E9: publish-event history-scope floor", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		DeferCleanup(cancel)
 
-		ts := integrationtest.Start(suiteT,
+		ts := integrationtest.Start(
+			suiteT,
 			integrationtest.WithInTreePlugins(),
 			integrationtest.WithPluginCrypto(),
 		)

--- a/test/integration/scenes/real_scene_history_readable_test.go
+++ b/test/integration/scenes/real_scene_history_readable_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-Y5INX-2: a participant can read the IC history of a REAL CreateScene-minted
+// (bare-ULID) scene via the host QueryStreamHistory path (the "scene log" route),
+// receiving the REAL DECRYPTED sensitive pose — with no INVALID_ARGUMENT and no
+// EVENTBUS_HISTORY_DECODE_FAILED.
+//
+// PRE-FIX FAILURE CHAIN (holomush-y5inx):
+//   - Task 1 fix: core-scenes started minting bare-ULID scene IDs (e.g.
+//     "01JVWXYZ…") instead of the legacy "scene-<ULID>" prefix form. Before
+//     that fix, QueryStreamHistory's streamToFocusKey path could not ulid.Parse
+//     the prefixed id and errored with INVALID_ARGUMENT. The bare-ULID id parses
+//     cleanly, so the membership gate (I-17) and scope floor pass through.
+//   - Task 8 fix: the harness history reader was wired with WithPluginCrypto's
+//     AuthGuard + DEK manager + codec selector (holomush-y5inx.8). Before that
+//     wiring the bare reader hit the zero-key decrypt path and returned
+//     EVENTBUS_HISTORY_DECODE_FAILED for any encrypted event.
+//
+// This regression spec proves BOTH fixes hold end-to-end: CreateScene (mints bare
+// ULID), JoinScene (I-17 membership), SeedSceneDEKParticipant (DEK participant
+// set), EmitSceneICContent (real encrypted scene_pose), QueryStreamHistory → clean
+// decrypt, payload == plaintext.
+var _ = Describe("INV-Y5INX-2: real scene history readable and decrypted via host", func() {
+	const plaintext = `{"text":"a real scene pose for regression INV-Y5INX-2"}`
+
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		alice *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		alice = ts.ConnectAuthed(ctx, "Alice")
+	})
+
+	AfterEach(func() {
+		if alice != nil {
+			alice.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("decrypts a sensitive scene_pose for a participant reading via the scene log route (bare-ULID scene)", func() {
+		// CreateScene mints a bare-ULID scene ID (no "scene-" prefix) as of
+		// holomush-y5inx Task 1. The old prefix form caused INVALID_ARGUMENT from
+		// streamToFocusKey's ulid.Parse; this confirms the bare form parses cleanly.
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+		Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero bare ULID")
+
+		// Alice joins the scene (I-17 membership gate). Join BEFORE the emit so
+		// the scope floor (her JoinedAt) does not filter the event out.
+		alice.JoinScene(ctx, sceneID)
+
+		// Mint the scene DEK with Alice as a participant BEFORE the emit. The
+		// publisher's GetOrCreate(ctx, ctxID, nil) on the emit path finds this
+		// existing DEK, so Alice's binding_id is in the participant set the
+		// hot-tier AuthGuard checks on QueryStreamHistory. Without this, the
+		// AuthGuard would downgrade to metadata-only (no error, but no plaintext).
+		ts.SeedSceneDEKParticipant(ctx, sceneID, alice)
+
+		// Emit a REAL sensitive scene_pose into the CreateScene-minted scene.
+		// EmitSceneICContent passes Sensitive=true, taking the XChaCha20v1 encrypt
+		// branch; the ciphertext is published to JetStream and projected to
+		// plugin_core_scenes.scene_log by the audit consumer.
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", plaintext)
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()),
+			"emitted subject must carry the bare scene ULID")
+
+		// Poll until the event is readable (JetStream ack may be slightly ahead of
+		// the durable consumer's projection). This also provides an early signal
+		// that the INVALID_ARGUMENT regression (Task 1) and the
+		// EVENTBUS_HISTORY_DECODE_FAILED regression (Task 8) do not fire.
+		Eventually(func(g Gomega) {
+			got, err := alice.QueryStreamHistory(ctx, emitted.SubjectStr)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"QueryStreamHistory must not error — pre-Task-1: INVALID_ARGUMENT, pre-Task-8: EVENTBUS_HISTORY_DECODE_FAILED")
+			g.Expect(got).NotTo(BeEmpty(), "the encrypted scene_pose must be readable back")
+		}).Should(Succeed())
+
+		// Final authoritative assertion: the last frame is fully decrypted.
+		got, err := alice.QueryStreamHistory(ctx, emitted.SubjectStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeEmpty())
+		ev := got[len(got)-1]
+		Expect(ev.GetMetadataOnly()).To(BeFalse(),
+			"INV-Y5INX-2: participant must receive a DECRYPTED (non-metadata-only) frame via the scene log route")
+		Expect(string(ev.GetPayload())).To(Equal(plaintext),
+			"INV-Y5INX-2: decrypted payload must equal the original plaintext JSON")
+	})
+})

--- a/test/integration/scenes/real_scene_join_subscription_test.go
+++ b/test/integration/scenes/real_scene_join_subscription_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// Regression spec (holomush-y5inx.5): INV-Y5INX-3 — joining a scene via the
+// REAL `scene join` command with a BARE-ULID scene ID opens a focus
+// subscription, so an IC pose emitted into the scene AFTER the join is
+// DELIVERED to the joiner's live Subscribe stream.
+//
+// ROOT CAUSE (pre-fix): protoToFocusKey in
+// internal/plugin/goplugin/host_service.go received the join key as the
+// PREFIXED string "scene-<ULID>" — the scene's stored primary key, which
+// newSceneID() minted pre-fix as "scene-" + ULID. ulid.Parse rejects that
+// prefix, so the parse failed, the subscription was never registered, and
+// WaitForEvent timed out — no pose ever arrived on the joiner's stream.
+//
+// FIX (holomush-y5inx Task 1 / ADR holomush-vy0rt): scene IDs are now minted
+// BARE — newSceneID() returns a bare ULID (`return id.String()`), so the stored
+// scene id is bare and `scene join` passes a bare ULID that protoToFocusKey's
+// ulid.Parse accepts UNMODIFIED. NO boundary-stripping is involved: ADR
+// holomush-vy0rt explicitly REJECTED the per-boundary TrimPrefix/strip approach
+// (Option B). With the bare id parsing cleanly, AutoFocusOnJoin registers the
+// scene IC stream on the joiner's live Subscribe loop.
+//
+// This is a DELIVERY assertion: a metadata-only frame whose Type == "scene_pose"
+// proves the subscription opened and the live loop received the event.
+// toProtoSubscribeResponse stamps Type regardless of metadata_only
+// (internal/grpc/server.go:664), so Type and MetadataOnly are independent.
+var _ = Describe("INV-Y5INX-3: bare-ULID scene join opens a live subscription", func() {
+	var (
+		ts     *integrationtest.Server
+		ctx    context.Context
+		owner  *integrationtest.Session
+		joiner *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+			integrationtest.WithFocusDelivery(),
+		)
+		owner = ts.ConnectAuthed(ctx, "Owner")
+		joiner = ts.ConnectAuthed(ctx, "Joiner")
+	})
+
+	AfterEach(func() {
+		if joiner != nil {
+			joiner.Logout(ctx)
+		}
+		if owner != nil {
+			owner.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("delivers a post-join scene_pose to the joiner after running `scene join <bare-ULID>` (INV-Y5INX-3)", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero bare ULID")
+
+		// REAL command path (NOT the JoinScene store-shortcut, which bypasses
+		// protoToFocusKey entirely). The regression being pinned is specifically
+		// that `scene join <bare-ULID>` reaches protoToFocusKey with the
+		// prefixed key "scene-<ULID>", which ulid.Parse rejects pre-fix.
+		// Post-fix the prefix is stripped before parsing, so the subscription
+		// is registered and AutoFocusOnJoin wires the scene IC stream into the
+		// joiner's live Subscribe filter set.
+		err := joiner.SendCommand(ctx, "scene join "+sceneID.String())
+		Expect(err).NotTo(HaveOccurred(),
+			"INV-Y5INX-3: `scene join <bare-ULID>` must succeed — pre-fix: "+
+				"ulid.Parse of the prefixed key failed, returning COMMAND_REJECTED")
+
+		// Emit a real IC pose AFTER the join so the only delivery path is the
+		// subscription AutoFocusOnJoin opened. If protoToFocusKey still fails
+		// to parse, no subscription exists and WaitForEvent times out.
+		const poseJSON = `{"text":"regression pose for INV-Y5INX-3: bare-ULID parse fix"}`
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", poseJSON)
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()),
+			"emitted subject must carry the bare scene ULID")
+
+		// Authoritative delivery assertion (INV-Y5INX-3): the joiner's live
+		// Subscribe stream receives a scene_pose frame. Pre-fix this always
+		// timed out because the subscription was never registered. Post-fix
+		// the frame arrives once AutoFocusOnJoin succeeds.
+		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		Expect(frame).NotTo(BeNil(),
+			"INV-Y5INX-3: post-join pose MUST be delivered — pre-fix: "+
+				"protoToFocusKey could not parse the prefixed join key, "+
+				"so AutoFocusOnJoin never registered the subscription")
+		Expect(frame.GetType()).To(Equal("scene_pose"))
+		// The joiner is not a DEK participant, so the frame MUST be
+		// metadata-only — no plaintext payload leak (fail-closed).
+		Expect(frame.GetMetadataOnly()).To(BeTrue(),
+			"INV-Y5INX-3: non-DEK-participant joiner MUST receive a "+
+				"metadata-only frame (fail-closed: no plaintext leak)")
+	})
+})

--- a/test/integration/scenes/scene_command_join_delivery_test.go
+++ b/test/integration/scenes/scene_command_join_delivery_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// Keystone (holomush-y5inx.9): a REAL `scene join` command, dispatched through
+// the harness's CoreServer, must reach JoinFocus → AutoFocusOnJoin →
+// per-connection subscription delivery, so an IC pose emitted into the scene
+// AFTER the join is delivered on the joiner's live Subscribe stream.
+//
+// PRE-FIX GAP: the integrationtest harness wired only WithSubscriber and NO
+// focus.Coordinator / StreamRegistry. The plugin host-service JoinFocus RPC
+// (internal/plugin/goplugin/host_service.go:113) short-circuits with "focus
+// coordinator not configured" BEFORE protoToFocusKey, so the real `scene join`
+// path could never register the scene-stream subscription. WaitForEvent then
+// times out — the joiner never receives the post-join pose.
+//
+// POST-FIX: WithFocusDelivery() wires a real focus.Coordinator + SessionStreamRegistry
+// (+ ConfigureFocusDeps) into the harness, gated exactly like WithPluginCrypto
+// (.8) so non-focus suites keep current wiring. The `scene join` command then
+// drives AutoFocusOnJoin → StreamSenderAdapter → the connection's control
+// channel, adding the scene IC stream to the live Subscribe filter set; the
+// next EmitSceneICContent pose is delivered.
+//
+// This is a DELIVERY (subscription-open) assertion: a metadata-only frame whose
+// Type == "scene_pose" is sufficient — the joiner need not be a DEK participant
+// to prove the subscription reached the live loop (toProtoSubscribeResponse
+// stamps Type from the event regardless of metadata_only,
+// internal/grpc/server.go:664).
+var _ = Describe("holomush-y5inx.9: real scene join command delivers post-join IC pose", func() {
+	var (
+		ts     *integrationtest.Server
+		ctx    context.Context
+		owner  *integrationtest.Session
+		joiner *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+			integrationtest.WithFocusDelivery(),
+		)
+		owner = ts.ConnectAuthed(ctx, "Owner")
+		joiner = ts.ConnectAuthed(ctx, "Joiner")
+	})
+
+	AfterEach(func() {
+		if joiner != nil {
+			joiner.Logout(ctx)
+		}
+		if owner != nil {
+			owner.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("delivers a post-join scene_pose to a joiner who ran the real `scene join` command", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero bare ULID")
+
+		// REAL command path (NOT the JoinScene store-shortcut): this is the
+		// surface the keystone exists to exercise. Pre-fix this either fails
+		// (focus coordinator not configured surfaced as a CommandError) or
+		// succeeds without wiring the subscription; post-fix it wires the
+		// scene IC stream onto the joiner's live Subscribe loop.
+		err := joiner.SendCommand(ctx, "scene join "+sceneID.String())
+		Expect(err).NotTo(HaveOccurred(),
+			"real `scene join` must succeed once the focus coordinator is wired "+
+				"(pre-fix: COMMAND_REJECTED — focus coordinator not configured)")
+
+		// Emit a real sensitive scene_pose into the scene AFTER the join, so the
+		// only way the joiner can receive it is via the subscription
+		// AutoFocusOnJoin added. The owner is the actor (a scene participant).
+		const poseJSON = `{"text":"a post-join pose for the y5inx.9 delivery keystone"}`
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", poseJSON)
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()),
+			"emitted subject must carry the bare scene ULID")
+
+		// The authoritative delivery assertion: the joiner's live Subscribe
+		// stream receives a scene_pose frame. Pre-fix this times out (no
+		// subscription was ever added). A frame whose Type == "scene_pose"
+		// proves the scene IC stream reached the live loop.
+		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		Expect(frame).NotTo(BeNil(),
+			"holomush-y5inx.9: the post-join pose MUST be delivered to the joiner's "+
+				"live Subscribe stream once the focus coordinator + stream registry are wired")
+		Expect(frame.GetType()).To(Equal("scene_pose"))
+		// The joiner is a non-DEK-participant, so the delivered frame MUST be
+		// metadata-only (no plaintext payload). This pins the live-path fail-closed
+		// (no-plaintext-leak) invariant — defense-in-depth per abac-reviewer.
+		// toProtoSubscribeResponse stamps Type regardless of metadata_only
+		// (internal/grpc/server.go:664), so Type and MetadataOnly are independent
+		// assertions.
+		Expect(frame.GetMetadataOnly()).To(BeTrue(),
+			"holomush-y5inx.9: non-DEK-participant joiner MUST receive metadata-only frame "+
+				"(fail-closed: no plaintext payload leak)")
+	})
+})

--- a/test/integration/scenes/scene_history_decrypt_readback_test.go
+++ b/test/integration/scenes/scene_history_decrypt_readback_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// holomush-y5inx.8: the integrationtest harness host history reader is wired
+// with the crypto substrate (AuthGuard + DEK manager + codec selector) under
+// WithPluginCrypto, so a SENSITIVE scene pose read back through
+// Session.QueryStreamHistory is DECRYPTED for an authorized DEK participant and
+// downgraded to metadata-only (no error) for a non-participant.
+//
+// BEFORE the wiring (bare reader at harness.go:367) the participant readback
+// errored with EVENTBUS_HISTORY_DECODE_FAILED — the guard-nil default path
+// tried to decrypt the XChaCha20v1 payload with a zero key.
+//
+// The character-identity decrypt path runs through the hot-tier AuthGuard
+// (decodeAndAuthorizeHistory → decodeAuthorizeAndDispatch::checkCharacter):
+// a binding_id match against the DEK's participant set permits the decrypt;
+// a miss denies it and surfaces a metadata-only row (dispatcher.go:310-314).
+var _ = Describe("encrypted scene IC content read back through QueryStreamHistory", func() {
+	const plaintext = `{"text":"a secret pose"}`
+
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		alice *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		ts = integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		alice = ts.ConnectAuthed(ctx, "Alice")
+	})
+
+	AfterEach(func() {
+		if alice != nil {
+			alice.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("decrypts the sensitive pose for a scene participant (DEK member)", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+
+		// Alice joins the scene (I-17 membership gate) BEFORE the emit so the
+		// scope floor (her JoinedAt) does not filter the event out.
+		alice.JoinScene(ctx, sceneID)
+
+		// Mint the scene DEK with Alice as a participant BEFORE the emit. The
+		// publisher's GetOrCreate(ctx, ctxID, nil) on the emit path then finds
+		// the existing DEK (initial participants are only set on first mint),
+		// so Alice's binding_id is in the participant set the AuthGuard checks.
+		ts.SeedSceneDEKParticipant(ctx, sceneID, alice)
+
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", plaintext)
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()))
+
+		Eventually(func(g Gomega) {
+			got, err := alice.QueryStreamHistory(ctx, emitted.SubjectStr)
+			g.Expect(err).NotTo(HaveOccurred(),
+				"participant QueryStreamHistory must not error (was EVENTBUS_HISTORY_DECODE_FAILED before wiring)")
+			g.Expect(got).NotTo(BeEmpty(), "the encrypted scene_pose must be readable back")
+		}).Should(Succeed())
+
+		got, err := alice.QueryStreamHistory(ctx, emitted.SubjectStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeEmpty())
+		ev := got[len(got)-1]
+		Expect(ev.GetMetadataOnly()).To(BeFalse(),
+			"participant must receive a DECRYPTED (non-metadata-only) frame")
+		Expect(string(ev.GetPayload())).To(Equal(plaintext),
+			"the decrypted payload must equal the original plaintext JSON")
+	})
+
+	It("downgrades to metadata-only (no error) for a non-participant scene member", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := alice.CreateScene(ctx, loc)
+		alice.JoinScene(ctx, sceneID)
+		ts.SeedSceneDEKParticipant(ctx, sceneID, alice)
+
+		// Bob is a scene member (passes the I-17 membership gate) and joins
+		// BEFORE the emit so the I-PRIV-6 temporal scope floor (his JoinedAt)
+		// does not filter the event out — he can SEE the frame. But he is NOT a
+		// DEK participant, so the decrypt-layer AuthGuard denies, yielding a
+		// metadata-only frame WITHOUT an error (dispatcher.go:310-314).
+		bob := ts.ConnectAuthed(ctx, "Bob")
+		defer bob.Logout(ctx)
+		bob.JoinScene(ctx, sceneID) // binding already created at connect (crypto enabled)
+
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			alice.CharacterID, "scene_pose", plaintext)
+
+		// Wait until the event is readable by the participant (Alice decrypts it),
+		// proving the row landed; then read as the non-participant Bob.
+		Eventually(func(g Gomega) {
+			got, err := alice.QueryStreamHistory(ctx, emitted.SubjectStr)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).NotTo(BeEmpty())
+		}).Should(Succeed())
+
+		got, err := bob.QueryStreamHistory(ctx, emitted.SubjectStr)
+		Expect(err).NotTo(HaveOccurred(),
+			"non-participant decrypt denial must surface as metadata-only, not an error")
+		Expect(got).NotTo(BeEmpty(),
+			"a metadata-only frame is still returned to a scene member")
+		ev := got[len(got)-1]
+		Expect(ev.GetMetadataOnly()).To(BeTrue(),
+			"non-participant must receive a metadata-only frame")
+		Expect(ev.GetPayload()).To(BeEmpty(),
+			"non-participant must not receive plaintext")
+	})
+})

--- a/test/integration/scenes/scene_id_bare_guard_test.go
+++ b/test/integration/scenes/scene_id_bare_guard_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
+)
+
+// INV-Y5INX-1 / INV-Y5INX-5: the production CreateScene RPC mints a bare ULID
+// scene id — no "scene-" (or any) prefix. This guards against reintroducing a
+// type-tag prefix on entity ids (the bare-ULID identity convention).
+var _ = Describe("INV-Y5INX-1/5: CreateScene mints a bare ULID", func() {
+	It("returns an id with no scene- prefix that parses as a ULID", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ts := integrationtest.Start(suiteT, integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		defer ts.Stop()
+
+		alice := ts.ConnectAuthed(ctx, "Alice")
+		loc := ts.NewLocation(ctx)
+
+		// Call the RPC directly (not the helper) so we assert on the raw id the
+		// server returns, not the harness-parsed value. Mirrors session.go:464.
+		resp, err := ts.SceneServiceClient().CreateScene(ctx, &scenev1.CreateSceneRequest{
+			CharacterId: alice.CharacterID.String(),
+			Title:       "guard scene",
+			LocationId:  loc.String(),
+			Visibility:  "open",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		rawID := resp.GetScene().GetId()
+
+		Expect(strings.HasPrefix(rawID, "scene-")).To(BeFalse(),
+			"INV-Y5INX-1/5: scene id MUST be a bare ULID, not scene- prefixed")
+		_, perr := ulid.Parse(rawID)
+		Expect(perr).NotTo(HaveOccurred(), "scene id MUST parse as a bare ULID")
+	})
+})

--- a/web/e2e/scenes.spec.ts
+++ b/web/e2e/scenes.spec.ts
@@ -81,11 +81,13 @@ async function waitForOutputMatching(
 }
 
 /**
- * Extract the scene ID from a "Scene created: scene-XXXXX" terminal event.
- * Scene IDs are `scene-` plus a 26-char Crockford base32 ULID.
+ * Extract the scene ID from a "Scene created: <ULID>" terminal event.
+ * Scene IDs are bare 26-char Crockford base32 ULIDs — holomush-y5inx eliminated
+ * the legacy `scene-` prefix. The output line is `Scene created: <ULID>`; the
+ * ULID is the first 26-char uppercase-alnum token in events after the command.
  */
 async function extractSceneIdFromOutput(page: Page, sinceIndex: number): Promise<string> {
-  return waitForOutputMatching(page, /scene-[A-Z0-9]+/, sinceIndex);
+  return waitForOutputMatching(page, /[0-9A-Z]{26}/, sinceIndex);
 }
 
 test.describe('Scene lifecycle (Phase 2)', () => {
@@ -101,7 +103,7 @@ test.describe('Scene lifecycle (Phase 2)', () => {
     let before = await currentEventCount(page);
     await sendCommand(page, 'scene create Phase 2 Lifecycle Test');
     const sceneId = await extractSceneIdFromOutput(page, before);
-    expect(sceneId).toMatch(/^scene-[A-Z0-9]+$/);
+    expect(sceneId).toMatch(/^[0-9A-Z]{26}$/);
 
     // DB: scene exists with state='active', owner = current character
     let scene = await db.getSceneById(sceneId);


### PR DESCRIPTION
## Summary

Implements the **scene bare-ULID identity** epic (`holomush-y5inx`, ADR `holomush-vy0rt`): scene IDs are now minted as **bare ULIDs** like every other entity, eliminating the `scene-<ULID>` prefix anti-pattern. The prefix broke `scene log` history reads, scene-join subscriptions, and the privacy floor for real (command-created) scenes because every `ulid.Parse` boundary rejected the prefixed id.

- **Core fix:** `newSceneID()` mints a bare ULID (no `scene-`); no per-boundary `TrimPrefix` (ADR `holomush-vy0rt` rejected the strip-at-boundary approach).
- **Two harness keystones** (test-support only, gated so non-using suites are untouched): the host `QueryStreamHistory` reader wired with AuthGuard + DEK + codec selector (`WithPluginCrypto`), and a focus coordinator + stream registry (`WithFocusDelivery`) so a real `scene join` command opens a live subscription. The latter required one additive, nil-default production field (`PluginSubsystemConfig.ConnectionSender`) — production behavior unchanged.
- **Regression suite:** INV-Y5INX-1..5 — bare-ULID mint guard, real-scene history readback (decrypted), real scene-join delivery, and the publish-event history-scope floor; plus realigning the integration harness and the `publish_e2e`/binary-plugin fixtures off the prefix (greens the long-red `publish_e2e`).

9 commits, each independently reviewed (code-reviewer; crypto-reviewer + abac-reviewer on the crypto/access-touching keystones). Unblocks `holomush-5rh.20.42` (E9).

## Test Plan

- [x] `task pr-prep` (fast lane) — green
- [x] `task test -- ./plugins/core-scenes/` — green
- [x] `task test:int -- ./test/integration/scenes/... ./test/integration/plugin/...` — green (incl. previously-red `publish_e2e`)
- [x] `task test:int -- ./test/integration/privacy/...` — green (blast-radius: non-crypto/non-focus suites keep prior harness wiring)
- [ ] CI required checks: `Integration Test` + `E2E Test` (run on Namespace runners)

## Follow-up (not in this PR)

A production gap surfaced during the focus-coordinator keystone: `cmd/holomush` does not set `ConnectionSender`, and `StreamSenderAdapter` rejects scene replay modes (`bounded_tail`/`live_only`), so binary scene-plugin `AutoFocusOnJoin` per-connection live delivery may be unwired in production. Recorded for separate triage — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)