### PR TITLE
docs(roadmap): mark SP0 landed in theme:docs-platform

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ and machine-readable `llms.txt`.
 
 | Sub-project | Scope | Tracking |
 | ----------- | ----- | -------- |
-| SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | stub `holomush-ay6xm` (P4 backlog — not yet designed) |
+| SP0 | Proto per-field doc comments + buf `COMMENTS` ratchet (platform-independent) | ✅ **landed** (#4303) — epic `holomush-300ad`; all 14 protos documented, buf `COMMENTS` unconditional + name-echo quality gate; 6 grounding-surfaced bugs filed (P1 `holomush-8cxo6` fail-open ABAC sentinel) |
 | SP1 | **Migrate zensical → Astro Starlight (bun) + llms.txt** | ✅ **landed** — epic `holomush-cwnu0`; ADRs `holomush-145ko`, `holomush-qf2oo`, `holomush-xneg2` |
 | SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | ✅ **landed** (#4296 re-org + #4297 mode-purity) — epic `holomush-44nxc`; ADRs `holomush-md3k4`, `holomush-38kmt`; follow-up `holomush-e6kvc` |
 | SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |


### PR DESCRIPTION
## Summary

Marks **SP0** (proto doc-comments + buf `COMMENTS` ratchet) as landed in the `theme:docs-platform` program table, matching the SP1/SP2 rows. SP0 merged via #4303 (epic `holomush-300ad`).

Per CLAUDE.md Strategic Themes — keep `docs/roadmap.md` current when a theme's sub-project completes.

## Test plan

- [x] `task pr-prep` green (fast lane, exit 0)
- [x] `rumdl` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)