### PR TITLE
docs(roadmap): mark SP5 landed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ and machine-readable `llms.txt`.
 | SP2 | Diátaxis IA redesign, `autogenerate` sidebar, orphan triage + superseded retirement | ✅ **landed** (#4296 re-org + #4297 mode-purity) — epic `holomush-44nxc`; ADRs `holomush-md3k4`, `holomush-38kmt`; follow-up `holomush-e6kvc` |
 | SP3 | `llms.txt` / `llms-full.txt` / `llms-small.txt` generation | **folded into SP1** (`starlight-llms-txt` plugin) |
 | SP4 | Complete gRPC service coverage (all 13 services, field-level) | stub `holomush-okm59` (P4 backlog — not yet designed) |
-| SP5 | Docs quality & cohesion — content/arrangement/communication (rubric+audit editorial pass) + topic-tab nav, page-actions, community | epic `holomush-ivwij` (15 tasks); ADR `holomush-q924m` |
+| SP5 | Docs quality & cohesion — content/arrangement/communication (rubric+audit editorial pass) + topic-tab nav, page-actions, community | ✅ **landed** (#4304) — epic `holomush-ivwij`; ADR `holomush-q924m`; deferred content tail tracked (`holomush-3skv5`, `fvxlv`, `x8v4i`, `ton17`, `e6kvc`) |
 
 **Program anchor:** decision bead `holomush-rkwyb` carries the SP0–SP4 framing and sequencing rationale; query the full program with `bd list -l theme:docs-platform`.
 


### PR DESCRIPTION
Marks SP5 (docs quality & cohesion) ✅ landed in the `theme:docs-platform` roadmap after #4304 (epic `holomush-ivwij`, ADR `holomush-q924m`), with the deferred content-tail beads noted. Docs-only.

Program status: SP0/SP1/SP2/SP5 landed; SP4 (gRPC coverage) is the remaining sub-project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)