### PR TITLE
docs(perf): full-system load/perf testing harness — spec, plan, ADRs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Isolate xk6 extensions in a separate Go module](holomush-2344h-isolate-xk6-extensions-separate-go-module.md) | 2026-05-28 | Accepted | `holomush-2344h` |
+| [Use k6 + Custom xk6 Binary for Full-System Load Testing](holomush-evggu-use-k6-custom-xk6-binary-full-system-load-testing.md) | 2026-05-28 | Accepted | `holomush-evggu` |
 | [Use topic-tab navigation over a single grouped sidebar](holomush-q924m-use-topic-tab-navigation-over-a-single-grouped-sidebar.md) | 2026-05-28 | Accepted | `holomush-q924m` |
 | [Organize docs audience-first with Diátaxis modes within](holomush-md3k4-organize-docs-audience-first-di-taxis-modes-within.md) | 2026-05-28 | Accepted | `holomush-md3k4` |
 | [Use autogenerate sidebar over explicit entries](holomush-38kmt-use-autogenerate-sidebar-over-explicit-entries.md) | 2026-05-28 | Accepted | `holomush-38kmt` |

--- a/docs/adr/holomush-2344h-isolate-xk6-extensions-separate-go-module.md
+++ b/docs/adr/holomush-2344h-isolate-xk6-extensions-separate-go-module.md
@@ -1,0 +1,45 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+
+# Isolate xk6 extensions in a separate Go module
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-2344h
+**Deciders:** Sean Brandt
+
+## Context
+
+The load harness (ADR holomush-evggu) adds k6 `xk6` extension code in Go — a raw-TCP telnet driver and (possibly) a forked `xk6-connectrpc`. These depend on k6's internal packages and the xk6 extension API, which carry a large, fast-moving transitive dependency tree. The root module's `go test ./...`, `task lint`, and `go mod tidy` walk every package reachable from the root `go.mod`. Folding the xk6 code into the root module would pull k6's dependency tree into every root-module tool and risk version conflicts with production dependencies.
+
+## Decision
+
+The xk6 Go extensions live in a **separate Go module** at `test/load/go.mod` (module path `github.com/holomush/holomush/test/load`), isolated from the root `go.mod` by Go's module-boundary semantics. Their unit tests run via `task loadtest:test` (which runs the suite under `test/load`), never via the root `./...`.
+
+## Rationale
+
+- Go nested modules are excluded from a parent module's `./...` scans by the toolchain — the isolation is structural and automatic, not convention-enforced or linter-policed.
+- k6's dependency tree is large and churns quickly; keeping it out of the root module prevents conflicts with production dependencies and keeps `task lint` and the root test suite fast.
+- The `test/load` module has no production consumers; sharing type definitions across the boundary would be a design smell, so the lost reuse costs nothing real.
+
+## Alternatives Considered
+
+- **Fold xk6 extensions into the root `go.mod`** — single module, shared types, one `go.sum`, no cross-module `replace` directives. Rejected: k6's transitive dependency tree enters the root module, polluting `task lint`, the root test suite, and `go mod tidy` for every contributor, and risking dependency conflicts with production code.
+- **Separate Go module at `test/load/go.mod`** — root tooling never sees k6 deps; the boundary is enforced by the Go toolchain; `task loadtest:test` is the single explicit entry point. Cost: `replace` directives for in-tree extensions and a second `go.sum`. Chosen.
+
+## Consequences
+
+**Positive:** the root test suite, `task lint`, and `go mod tidy` are unaffected by k6 dependency churn; the module boundary is enforced by the Go toolchain with no linter rule or CI check needed.
+
+**Negative:** in-tree xk6 extensions need `replace` directives in `test/load/go.mod`; contributors must run the extension tests from the `test/load` module (via `task loadtest:test`) rather than relying on the root module; two `go.sum` files to maintain.
+
+**Neutral:** consistent with the conventional Go pattern of isolating tool/codegen modules (e.g., a `tools/go.mod`).
+
+## References
+
+- Plan: docs/superpowers/plans/2026-05-28-load-perf-testing-harness.md (File Structure; Task 2)
+- Design bead: holomush-ql7ef · Tooling ADR: holomush-evggu

--- a/docs/adr/holomush-evggu-use-k6-custom-xk6-binary-full-system-load-testing.md
+++ b/docs/adr/holomush-evggu-use-k6-custom-xk6-binary-full-system-load-testing.md
@@ -1,0 +1,49 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+
+# Use k6 + Custom xk6 Binary for Full-System Load Testing
+
+**Date:** 2026-05-28
+**Status:** Accepted
+**Decision:** holomush-evggu
+**Deciders:** Sean Brandt
+
+## Context
+
+HoloMUSH's full-system load harness must drive two bespoke wire protocols: the **Connect** protocol (HTTP/2-via-TLS-ALPN, the browser SPA's path through `internal/web/server.go`'s `NewWebServiceHandler`) and **raw-TCP telnet** (the gateway telnet listener). A Go-native generator would have exact fidelity and could attach to the in-process `integrationtest` CoreServer, but it would require reimplementing ramp executors, percentile aggregation, threshold-gating, and Grafana output. k6 provides all of those as batteries, but its built-in `k6/net/grpc` module drives the **gRPC** envelope, not the **Connect** envelope the browser actually uses on the same handler. The xk6 extension mechanism lets us bundle a Go module that imports `connectrpc.com/connect` directly — and a community extension (`bumberboy/xk6-connectrpc`, born from grafana/k6#5193) already exists — eliminating the protocol-fidelity gap.
+
+## Decision
+
+Adopt **k6 with a custom `xk6 build` binary** bundling `xk6-connectrpc` (Connect wire protocol, H2/TLS) and an xk6 telnet/raw-TCP module, driving the **full Dockerized `holomush` binary at the network boundary**. A mandatory P1 spike vets `xk6-connectrpc` for server-streaming support (the `Subscribe` event path) before committing to use-as-is vs. fork-and-extend. The in-process core-tier load driver is deferred (component-level coverage stays with Go micro-benchmarks + `task soak:eventbus`).
+
+## Rationale
+
+- **Connect-envelope fidelity:** `xk6-connectrpc` imports `connectrpc.com/connect`, whose client speaks the Connect protocol by default, driving the exact wire path the SvelteKit PWA uses (INV-LOAD-1). k6's built-in gRPC module would exercise a different envelope on the same handler.
+- **Telnet fidelity:** a raw-TCP xk6 module hits the real gateway telnet listener bit-exactly (INV-LOAD-2); no off-the-shelf HTTP tool can drive the bespoke telnet protocol.
+- **Avoid re-inventing k6 batteries:** ramp/arrival-rate executors, p99 metrics, thresholds-as-exit-code pass/fail gates, and Prometheus remote-write are load-bearing for the SLO program and slot into the project's existing OTel/Grafana stack — not worth reimplementing.
+- **Supply-chain discipline:** pinned extension commits + reproducible `xk6 build` + CI cache + license check contain the new-toolchain risk.
+
+## Alternatives Considered
+
+- **Go-native load generator (both tiers)** — zero new toolchain, exact fidelity for both protocols, and could attach to the in-process `integrationtest` CoreServer tier. Rejected: requires reimplementing the ramp/percentile/threshold/dashboard machinery k6 provides for free, and the in-process advantage is deferred (Phase 3) so it is not realized in P1/P2.
+- **k6 with the built-in `k6/net/grpc` module** — no custom extension, simpler build. Rejected: drives the gRPC envelope, not the Connect envelope the browser uses on the same handler (a real fidelity gap), and cannot drive raw-TCP telnet.
+- **Off-the-shelf HTTP tools (vegeta, Gatling)** — mature, no custom builds. Rejected: cannot drive the bespoke telnet protocol, cannot reach the in-process core tier, and fragment into disjoint tools with no shared threshold/dashboard story.
+- **k6 + custom xk6 binary (`xk6-connectrpc` + xk6-telnet)** — exact fidelity on both protocols plus k6 batteries and existing-Grafana reuse; distributed execution available for ceiling experiments. Chosen.
+
+## Consequences
+
+**Positive:** a single scenario script drives both protocols with shared k6 metrics and threshold gates; Grafana/Prometheus output slots into the existing OTel stack with no new dashboarding infrastructure; distributed load generation (Phase 3) becomes a k6 config change, not an architectural rewrite.
+
+**Negative:** a new k6/xk6 toolchain is added to the build surface and the custom binary must be maintained; `xk6-connectrpc` is young, so a streaming gap may force a fork plus an upstream-maintenance obligation; the harness cannot attach to the in-process `integrationtest` CoreServer tier (it needs a running server), deferring the in-process tier to Phase 3.
+
+**Neutral:** the in-process Go core-tier driver is explicitly deferred; the fork-vs-upstream decision is contingent on the P1 spike outcome.
+
+## References
+
+- Spec: docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md §3.1
+- Design bead: holomush-ql7ef
+- grafana/k6#5193 (Connect RPC support); bumberboy/xk6-connectrpc

--- a/docs/superpowers/plans/2026-05-28-load-perf-testing-harness.md
+++ b/docs/superpowers/plans/2026-05-28-load-perf-testing-harness.md
@@ -1,0 +1,1204 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Full-System Load & Performance Testing Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a repeatable k6-based harness that drives the real telnet + Connect wire protocols against the full Dockerized `holomush` binary at N≈1,000 concurrent sessions, measuring comms-path SLOs and gating them in nightly CI.
+
+**Architecture:** A custom `xk6 build` binary bundles two Go extensions — `xk6-connectrpc` (exact Connect protocol for the web tier) and an in-tree xk6 telnet module (raw TCP) — and runs a shared JS scenario that models a comms-heavy workload. say→broadcast and page/whisper→delivery latency are measured client-side via an emit-timestamp carried in the message payload (custom k6 `Trend`s). Thresholds are the pass/fail gate; results stream to the existing Prometheus/Grafana stack. The xk6 Go extensions live in a **separate Go module** rooted at `test/load/` (`test/load/go.mod`; extension packages under `test/load/xk6/`) so k6's dependency tree never enters the root `go.mod`.
+
+**Tech Stack:** k6 + xk6 (Go extension toolchain), `connectrpc.com/connect` (Connect client inside the extension), Docker Compose (SUT stand-up, reusing `compose.yaml`), GitHub Actions (nightly), Taskfile, Go (xk6 modules + `test/meta` invariant tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md`
+**Design bead:** holomush-ql7ef · **ADR:** holomush-evggu (k6 + xk6 tooling)
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+| --- | --- |
+| `test/load/go.mod` | Separate Go module for xk6 extensions — isolates k6 deps from root `go.mod` |
+| `test/load/xk6/telnet/telnet.go` | xk6 raw-TCP telnet driver (dial, two-phase login, send command, read line) |
+| `test/load/xk6/telnet/telnet_test.go` | Go unit tests for the telnet driver's framing/parse helpers |
+| `test/load/xk6/connectrpc/` | Vendored or forked `xk6-connectrpc` (decided by Task 1) |
+| `test/load/build/manifest.txt` | Pinned extension list + commits consumed by `xk6 build` |
+| `test/load/build/Dockerfile.k6` | Reproducible custom-k6 build image (CI cache layer) |
+| `test/load/lib/config.js` | Scenario knobs; env-driven N/duration/seed; verb-availability validation |
+| `test/load/lib/workload.js` | Seeded action-mix selection (comms-heavy) |
+| `test/load/lib/latency.js` | Emit-timestamp encode/decode + custom `Trend` recording |
+| `test/load/lib/session.js` | Session lifecycle (connect/auth/join/loop/churn) per transport |
+| `test/load/scenarios/comms.js` | Top-level scenario wiring lib/* into k6 executors + thresholds |
+| `test/load/README.md` | How to build, run smoke/full, read dashboards, update baseline |
+| `.benchmarks/load-baseline.json` | Tracked SLO baseline for relative regression gating |
+| `.github/workflows/nightly-load.yml` | Nightly heavy run + threshold gate |
+| `test/meta/load_harness_invariants_test.go` | Meta-tests for INV-LOAD-4 (exit-masking) + INV-LOAD-8 (not in pr-prep) |
+| `Taskfile.yaml` | New `loadtest:build` / `loadtest` / `loadtest:full` / `loadtest:test` targets |
+| `site/src/content/docs/contributing/` | How-to + SLO/scenario reference (PR-blocking docs) |
+
+The xk6 modules form their own Go module, so the root module's `go test ./...` and `task lint` never see k6's dependency tree. Their Go unit tests run via `task loadtest:test`.
+
+---
+
+## Phase 1: MVP — de-risk + minimal vertical slice
+
+### Task 1: De-risk spike — vet `xk6-connectrpc` for `StreamEvents` server-streaming
+
+**Files:**
+
+- Create: `test/load/build/manifest.txt`
+- Note: record verdict on bead `holomush-evggu`
+
+This is a **spike**, not TDD. The whole tooling choice (ADR holomush-evggu) hinges on whether `xk6-connectrpc` can consume a Connect **server-stream** (`WebService.StreamEvents`, `api/proto/holomush/web/v1/web.proto:64`). A unary-only extension forces a fork.
+
+> **API caveat:** the `xk6-connectrpc` JS surface used in later tasks (`client.loadProtos`, `client.invoke`, `client.serverStream`, `stream.on('data')`) is **illustrative** — modeled on k6's built-in `k6/net/grpc`. This spike establishes the extension's *actual* exported API; if it differs, update the JS in Tasks 5–6/9/12 to match what the spike confirms.
+
+- [ ] **Step 1: Build a throwaway custom k6 with the extension**
+
+```bash
+go install go.k6.io/xk6/cmd/xk6@latest
+mkdir -p /tmp/k6spike && cd /tmp/k6spike
+xk6 build --with github.com/bumberboy/xk6-connectrpc@latest
+```
+
+Expected: a `k6` binary in `/tmp/k6spike`. If `xk6 build` fails, record the failure and proceed to Step 4 (fork path).
+
+- [ ] **Step 2: Stand up the SUT locally**
+
+Run: `task dev` (or `docker compose -f compose.yaml up -d`) so the gateway serves the Connect `WebService` on its configured port.
+
+- [ ] **Step 3: Probe server-streaming with a minimal script**
+
+```javascript
+// /tmp/k6spike/probe.js
+import connectrpc from 'k6/x/connectrpc';
+
+const client = new connectrpc.Client();
+client.loadProtos(['proto'], 'holomush/web/v1/web.proto');
+
+export default function () {
+  client.connect('https://localhost:8443', { plaintext: false, timeout: '5s' });
+  // The capability under test: a Connect SERVER STREAM.
+  const stream = client.serverStream('holomush.web.v1.WebService/StreamEvents', { /* req */ });
+  stream.on('data', (msg) => console.log('stream data', JSON.stringify(msg)));
+  stream.on('error', (e) => console.error('stream error', e));
+  stream.on('end', () => console.log('stream end'));
+}
+```
+
+Run: `/tmp/k6spike/k6 run /tmp/k6spike/probe.js`
+Expected (success): `stream data ...` lines, proving server-streaming works. Expected (failure): an API error that `serverStream` / `.on('data')` is unsupported.
+
+- [ ] **Step 4: Record the verdict and pin the source**
+
+If streaming works: write `test/load/build/manifest.txt`. **Each line is a complete `xk6 build --with` argument** (the build command in Task 2 just prefixes `--with`): remote modules pin with `@<sha>`, local in-tree modules use xk6's `module=./path` local-replace form.
+
+```text
+# xk6 extension build manifest — one `xk6 build --with` argument per line.
+# Remote: module@version  |  Local in-tree: module=./relative/path
+github.com/bumberboy/xk6-connectrpc@<RESOLVED-COMMIT-SHA>
+```
+
+If streaming is absent: fork to `test/load/xk6/connectrpc/` (Connect server-stream support added by mirroring connect-go's `ServerStreamForClient` loop) and add a local line `github.com/holomush/holomush/test/load/xk6/connectrpc=./xk6/connectrpc` (xk6 resolves `=./path` as the module replacement — no separate `--replace` flag needed). Record either outcome:
+
+```bash
+bd note holomush-evggu "P1 spike verdict: xk6-connectrpc server-streaming = <WORKS @<sha> | ABSENT → forked to test/load/xk6/connectrpc>. StreamEvents drivable: <yes/after-fork>."
+```
+
+- [ ] **Step 5: Commit**
+
+Commit `test/load/build/manifest.txt` per `references/vcs-preamble.md` with message `test(load): pin xk6-connectrpc after streaming spike (holomush-evggu)`.
+
+---
+
+### Task 2: Custom-k6 build pipeline (separate Go module + reproducible build)
+
+**Files:**
+
+- Create: `test/load/go.mod`, `test/load/build/Dockerfile.k6`
+- Modify: `Taskfile.yaml` (add `loadtest:build`)
+- Test: build succeeds and emits a versioned binary
+
+- [ ] **Step 1: Initialize the isolated Go module**
+
+```bash
+cd test/load && go mod init github.com/holomush/holomush/test/load && cd -
+```
+
+Expected: `test/load/go.mod` exists. The root module is unaffected (nested module is excluded from root `./...`).
+
+- [ ] **Step 2: Write the reproducible build image**
+
+```dockerfile
+# test/load/build/Dockerfile.k6  (build context = repo root)
+FROM grafana/xk6:latest AS build
+WORKDIR /src
+# Copy the whole test/load module so local `=./xk6/<ext>` paths in the manifest
+# resolve (the in-tree telnet/connectrpc extensions live under /src/xk6/).
+COPY test/load/ /src/
+# Each manifest line is already a full `--with` argument (module@version OR
+# module=./local/path); we only prefix `--with`. Comments/blanks skipped.
+RUN xk6 build $(grep -vE '^\s*#|^\s*$' build/manifest.txt | sed 's/^/--with /' | tr '\n' ' ') \
+    --output /out/k6
+FROM debian:bookworm-slim
+COPY --from=build /out/k6 /usr/local/bin/k6
+ENTRYPOINT ["k6"]
+```
+
+- [ ] **Step 3: Add the `loadtest:build` task**
+
+```yaml
+  loadtest:build:
+    desc: Build the custom k6 binary (xk6 extensions pinned in test/load/build/manifest.txt)
+    cmds:
+      - docker build -f test/load/build/Dockerfile.k6 -t holomush-k6:local .
+```
+
+- [ ] **Step 4: Verify the build**
+
+Run: `task loadtest:build`
+Expected: image `holomush-k6:local` built; `docker run --rm holomush-k6:local version` prints a k6 version with the bundled extensions listed.
+
+- [ ] **Step 5: Commit**
+
+`test(load): custom k6 build pipeline (isolated go module + pinned xk6)`
+
+---
+
+### Task 3: xk6 telnet module (raw TCP driver)
+
+**Files:**
+
+- Create: `test/load/xk6/telnet/telnet.go`, `test/load/xk6/telnet/telnet_test.go`
+- Modify: `test/load/build/manifest.txt` (add the local telnet module)
+- Reference: `internal/telnet/gateway_handler.go` (two-phase login), `internal/telnet/guest_auth.go` (guest flow)
+
+The gateway telnet listener speaks a line protocol with a two-phase login (guest or registered). The module exposes `dial`, `login`, `send`, and `readLine` to JS.
+
+- [ ] **Step 1: Write the failing Go test for the line framer**
+
+```go
+// test/load/xk6/telnet/telnet_test.go
+package telnet
+
+import "testing"
+
+func TestSplitLinesHandlesCRLFAndLF(t *testing.T) {
+	got := splitLines("hello\r\nworld\nfin")
+	want := []string{"hello", "world", "fin"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run it, verify failure**
+
+Run: `cd test/load && go test ./xk6/telnet/ -run TestSplitLines`
+Expected: FAIL — `undefined: splitLines`.
+
+- [ ] **Step 3: Implement the module + framer**
+
+```go
+// test/load/xk6/telnet/telnet.go
+// Package telnet is an xk6 extension exposing a raw-TCP telnet driver to k6 JS
+// as module "k6/x/telnet". It drives the holomush gateway telnet listener
+// (see internal/telnet/gateway_handler.go) for load testing.
+package telnet
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"time"
+
+	"go.k6.io/k6/js/modules"
+)
+
+func init() { modules.Register("k6/x/telnet", new(RootModule)) }
+
+type RootModule struct{}
+type ModuleInstance struct{ vu modules.VU }
+
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	return &ModuleInstance{vu: vu}
+}
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{Named: map[string]any{"dial": mi.Dial}}
+}
+
+// Conn is the JS-facing handle for one telnet connection.
+type Conn struct {
+	c  net.Conn
+	br *bufio.Reader
+}
+
+// Dial opens a telnet connection with a write/read deadline budget.
+func (mi *ModuleInstance) Dial(addr string, timeoutMs int) (*Conn, error) {
+	c, err := net.DialTimeout("tcp", addr, time.Duration(timeoutMs)*time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+	return &Conn{c: c, br: bufio.NewReader(c)}, nil
+}
+
+// Send writes a command line (CRLF-terminated).
+func (cn *Conn) Send(line string) error {
+	_, err := cn.c.Write([]byte(line + "\r\n"))
+	return err
+}
+
+// ReadLine reads one line up to the deadline; returns "" on timeout.
+func (cn *Conn) ReadLine(timeoutMs int) (string, error) {
+	_ = cn.c.SetReadDeadline(time.Now().Add(time.Duration(timeoutMs) * time.Millisecond))
+	s, err := cn.br.ReadString('\n')
+	return strings.TrimRight(s, "\r\n"), err
+}
+
+func (cn *Conn) Close() error { return cn.c.Close() }
+
+// splitLines normalizes CRLF/LF framing for tests and buffered reads.
+func splitLines(s string) []string {
+	return strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+}
+```
+
+- [ ] **Step 4: Run the test, verify pass**
+
+Run: `cd test/load && go test ./xk6/telnet/ -run TestSplitLines`
+Expected: PASS.
+
+- [ ] **Step 5: Add the local module to the build manifest**
+
+Append the local-module line to `test/load/build/manifest.txt`, using xk6's `module=./path` local-replace form (path relative to the module root `/src` in the build image — see the Task 2 Dockerfile, which copies `test/load/` to `/src/`):
+
+```text
+github.com/holomush/holomush/test/load/xk6/telnet=./xk6/telnet
+```
+
+(No separate `--replace` flag is needed — `=./xk6/telnet` is how `xk6 build --with` resolves a local module. Document the manifest format in `test/load/README.md`.)
+
+- [ ] **Step 6: Rebuild + commit**
+
+Run: `task loadtest:build` (Expected: PASS, telnet module bundled). Commit `test(load): xk6 telnet raw-TCP driver`.
+
+---
+
+### Task 4: Scenario config + canonical verb set (INV-LOAD-7; INV-LOAD-6 enforced in Task 8)
+
+**Files:**
+
+- Create: `test/load/verbs.json`, `test/load/lib/config.js`, `test/load/lib/workload.js`
+- Reference: `plugins/core-communication/plugin.yaml` (registered verbs)
+
+The canonical verb set lives in **`test/load/verbs.json`** so it has exactly one source consumed by both the JS scenario and the Go meta-test (Task 8) that enforces INV-LOAD-6. There is no list-commands RPC — verbs are validated against plugin manifests at build time rather than discovered at runtime (`help` is the only runtime listing surface and its output arrives via the event stream, which is fragile to parse in `setup()`).
+
+- [ ] **Step 1: Write the canonical verb set**
+
+```json
+{
+  "roomBroadcast": ["say", "pose", "emit", "ooc"],
+  "directed": ["page", "whisper"],
+  "read": ["examine"]
+}
+```
+
+Every verb here is a **registered player command** (verified: `say`/`pose`/`emit`/`ooc`/`page`/`whisper` in `plugins/core-communication/plugin.yaml`; `examine` in `plugins/core-objects/plugin.yaml`). There is **no `look`/`move`/`recall` command** in the codebase — reads use `examine`, occupancy/grouping uses **scenes** (Task 10), and history is the `WebQueryStreamHistory` **RPC** (not a verb; Task 9). Channel verbs are absent (no `core-channels` plugin; future per spec §5.1).
+
+- [ ] **Step 2: Write the config module (env-driven, seeded; reads verbs.json)**
+
+```javascript
+// test/load/lib/config.js
+// Central scenario knobs. N and duration are env-driven; the RNG seed is fixed
+// so two runs of the same config produce the same action sequence (INV-LOAD-7).
+// open() reads the canonical verb set at init time (path relative to this file).
+export const VERBS = JSON.parse(open('../verbs.json'));
+
+export const cfg = {
+  webBase: __ENV.HOLOMUSH_WEB || 'https://localhost:8443',
+  telnetAddr: __ENV.HOLOMUSH_TELNET || 'localhost:4000',
+  vus: parseInt(__ENV.LOAD_VUS || '50', 10),       // smoke default; nightly overrides to 1000
+  duration: __ENV.LOAD_DURATION || '30s',
+  seed: parseInt(__ENV.LOAD_SEED || '1337', 10),
+  transport: __ENV.LOAD_TRANSPORT || 'connect',     // 'connect' | 'telnet'
+};
+```
+
+- [ ] **Step 3: Write the seeded action-mix selector**
+
+```javascript
+// test/load/lib/workload.js
+import { cfg, VERBS } from './config.js';
+
+// Deterministic LCG so action selection is reproducible per seed (INV-LOAD-7).
+function lcg(seed) {
+  let s = seed >>> 0;
+  return () => (s = (1103515245 * s + 12345) >>> 0) / 0xffffffff;
+}
+
+// Comms-heavy mix (spec §5), using only real surfaces:
+//   say/pose/emit/ooc 45% · page/whisper 35% · examine 12% · history-RPC 8%.
+// '__history__' is a sentinel routed to the WebQueryStreamHistory RPC (not a verb).
+const MIX = [
+  { p: 0.45, pick: (r) => VERBS.roomBroadcast[Math.floor(r * VERBS.roomBroadcast.length)] },
+  { p: 0.35, pick: (r) => VERBS.directed[Math.floor(r * VERBS.directed.length)] },
+  { p: 0.12, pick: () => 'examine' },
+  { p: 0.08, pick: () => '__history__' },
+];
+
+export function makeActionStream(vuSeed) {
+  const rng = lcg(cfg.seed + vuSeed);
+  return function nextAction() {
+    let roll = rng(), acc = 0;
+    for (const bucket of MIX) {
+      acc += bucket.p;
+      if (roll <= acc) return bucket.pick(rng());
+    }
+    return 'say';
+  };
+}
+```
+
+- [ ] **Step 4: Verify determinism with a tiny k6 check**
+
+```javascript
+// test/load/lib/workload.smoke.js
+import { makeActionStream } from './workload.js';
+export default function () {
+  const a = makeActionStream(7), b = makeActionStream(7);
+  for (let i = 0; i < 100; i++) {
+    if (a() !== b()) throw new Error('non-deterministic action stream');
+  }
+}
+```
+
+Run: `docker run --rm -v "$PWD/test/load:/load" holomush-k6:local run /load/lib/workload.smoke.js`
+Expected: PASS (no throw) — proves INV-LOAD-7.
+
+- [ ] **Step 5: Commit**
+
+`test(load): seeded comms-heavy action mix + canonical verb set`
+
+---
+
+### Task 5: Session lifecycle + minimal action set over the Connect transport
+
+**Files:**
+
+- Create: `test/load/lib/session.js`
+- Reference: `api/proto/holomush/web/v1/web.proto` (`WebCreateGuest`, `StreamEvents`, `SendCommand`)
+
+- [ ] **Step 1: Write the Connect session lifecycle**
+
+```javascript
+// test/load/lib/session.js
+import connectrpc from 'k6/x/connectrpc';
+import { cfg } from './config.js';
+
+const SVC = 'holomush.web.v1.WebService';
+
+// connectSession opens a guest session and its event stream. Returns a handle
+// the scenario loop drives. One persistent connection per VU (spec §6 VU model).
+import { connectAuthMs } from './latency.js';
+
+export function connectSession() {
+  const t0 = Date.now();
+  const client = new connectrpc.Client();
+  client.loadProtos(['proto'], 'holomush/web/v1/web.proto');
+  client.connect(cfg.webBase, { plaintext: cfg.webBase.startsWith('http://'), timeout: '5s' });
+
+  // Two-step guest auth: WebCreateGuest returns default_character_id (no
+  // session_id, proto web.proto:244-252); WebSelectCharacter binds that
+  // character and returns the session_id (proto web.proto:213-223).
+  const guest = client.invoke(`${SVC}/WebCreateGuest`, {});
+  const characterId = guest.message.default_character_id;
+  const sel = client.invoke(`${SVC}/WebSelectCharacter`, { character_id: characterId });
+  const sessionId = sel.message.session_id;
+  // StreamEvents opens the per-connection event stream; the first ControlFrame
+  // (STREAM_OPENED) carries connection_id, which SendCommand needs for routing.
+  const stream = client.serverStream(`${SVC}/StreamEvents`, { session_id: sessionId });
+  const sess = { client, stream, sessionId, connectionId: '', kind: 'connect' };
+  stream.on('data', (evt) => {
+    if (evt.control && evt.control.kind === 'STREAM_OPENED') sess.connectionId = evt.control.connection_id;
+  });
+  connectAuthMs.add(Date.now() - t0); // SLO 5: connect+auth latency
+  return sess;
+}
+
+// sendCommand issues a verb via SendCommandRequest. Field is `text` (proto
+// web.proto:115); session_id + connection_id bind the command to this session.
+export function sendCommand(sess, verb, args, measured) {
+  const text = `${verb} ${args}`.trim();
+  return sess.client.invoke(`${SVC}/SendCommand`, {
+    session_id: sess.sessionId, connection_id: sess.connectionId, text,
+  });
+}
+
+export function closeSession(sess) {
+  try { sess.stream.end(); } finally { sess.client.close(); }
+}
+```
+
+> **Note:** `WebCreateGuest`/`StreamEvents`/`SendCommand` field names are grounded in `api/proto/holomush/web/v1/web.proto`. Confirm the exact JSON field casing (`session_id` vs `sessionId`) the xk6-connectrpc codec emits against the Task 1 spike — connect-go JSON uses the proto field name (`session_id`).
+
+- [ ] **Step 2: Write the scenario skeleton wiring setup + loop**
+
+```javascript
+// test/load/scenarios/comms.js
+import { sleep } from 'k6';
+import connectrpc from 'k6/x/connectrpc';
+import { cfg } from '../lib/config.js';
+import { makeActionStream } from '../lib/workload.js';
+import { connectSession, sendCommand, closeSession } from '../lib/session.js';
+
+export const options = {
+  scenarios: {
+    comms: { executor: 'constant-vus', vus: cfg.vus, duration: cfg.duration },
+  },
+  // Thresholds filled in Task 6/8 (these ARE the SLO gate).
+  thresholds: {},
+};
+
+export function setup() {
+  // Connectivity preflight only. Verb-availability (INV-LOAD-6) is enforced
+  // statically by the Task 8 meta-test against verbs.json + plugin manifests —
+  // not at runtime (there is no list-commands RPC).
+  const c = new connectrpc.Client();
+  c.loadProtos(['proto'], 'holomush/web/v1/web.proto');
+  c.connect(cfg.webBase, { plaintext: cfg.webBase.startsWith('http://'), timeout: '5s' });
+  c.close();
+  return {};
+}
+
+export default function () {
+  let sess = connectSession();
+  const next = makeActionStream(__VU);
+  const end = Date.now() + 20_000; // per-iteration session lifetime; churn added in Task 11
+  while (Date.now() < end) {
+    const verb = next();
+    // Directed (page/whisper) + history RPC are wired in Task 9; until then,
+    // those slots exercise a room broadcast so the smoke stays representative.
+    if (verb === 'examine') sendCommand(sess, 'examine', 'me');
+    else if (verb === '__history__' || verb === 'page' || verb === 'whisper') sendCommand(sess, 'say', 'hello', true);
+    else sendCommand(sess, verb, 'hello', true);
+    sleep(exp(10)); // think-time ~exp(mean 10s), spec §5
+  }
+  closeSession(sess);
+}
+
+function exp(meanSec) { return -Math.log(1 - Math.random()) * meanSec; }
+```
+
+- [ ] **Step 3: Smoke-run against a local SUT**
+
+Run: `task dev` then `task loadtest` (defined in Task 7).
+Expected: VUs connect, issue commands, no connection errors in the k6 summary.
+
+- [ ] **Step 4: Verify INV-LOAD-1 (Connect protocol, not gRPC)**
+
+The harness MUST drive the web tier over the Connect protocol. Inspect the SUT's request telemetry for the smoke run (OTel span attribute on the `holomush-gateway` server span, or the access log): `WebService` requests MUST carry `Content-Type: application/connect+proto` — never `application/grpc`. Record the observed content-type.
+
+Run: `docker compose logs gateway | rg -o 'application/(connect\+proto|grpc[^ ]*)' | sort -u`
+Expected: only `application/connect+proto` appears (proves INV-LOAD-1; gRPC would mean the extension defaulted wrong).
+
+- [ ] **Step 5: Commit**
+
+`test(load): Connect-transport session lifecycle + scenario skeleton`
+
+---
+
+### Task 6: say→broadcast latency via emit-timestamp-in-payload (INV-LOAD-3)
+
+**Files:**
+
+- Create: `test/load/lib/latency.js`
+- Modify: `test/load/lib/session.js`, `test/load/scenarios/comms.js`
+
+- [ ] **Step 1: Write the latency helper (encode/decode + Trend)**
+
+```javascript
+// test/load/lib/latency.js
+import { Trend } from 'k6/metrics';
+
+export const sayBroadcast = new Trend('say_broadcast_ms', true);
+export const directedDelivery = new Trend('directed_delivery_ms', true);
+export const connectAuthMs = new Trend('connect_auth_ms', true); // SLO 5
+
+const MARK = 'LT:'; // sentinel so recipients can find the emit stamp
+
+// stamp embeds a high-res emit timestamp into the outgoing message body.
+export function stamp(body) { return `${body} ${MARK}${Date.now()}`; }
+
+// observe parses the stamp from a received broadcast and records the delta.
+export function observe(trend, receivedBody) {
+  const i = receivedBody.lastIndexOf(MARK);
+  if (i < 0) return;
+  const emit = parseInt(receivedBody.slice(i + MARK.length), 10);
+  if (!Number.isNaN(emit)) trend.add(Date.now() - emit);
+}
+
+// assertClockSkewBound enforces the ≤50ms generator/SUT skew assumption (§12).
+export function assertClockSkewBound(serverNowMs) {
+  const skew = Math.abs(Date.now() - serverNowMs);
+  if (skew > 50) throw new Error(`clock skew ${skew}ms exceeds 50ms bound (INV-LOAD-3)`);
+}
+```
+
+- [ ] **Step 2: Wire stamp into sends and observe into the stream handler**
+
+In `session.js`, stamp room-broadcast + directed sends; in `comms.js` attach a stream `on('data')` handler that routes to `observe(sayBroadcast, ...)` or `observe(directedDelivery, ...)` by event type.
+
+```javascript
+// session.js — sendCommand gains the `measured` stamp (field is `text`, with
+// session_id/connection_id binding — see Task 5).
+import { stamp } from './latency.js';
+export function sendCommand(sess, verb, args, measured) {
+  const body = measured ? stamp(args) : args;
+  return sess.client.invoke(`${SVC}/SendCommand`, {
+    session_id: sess.sessionId, connection_id: sess.connectionId,
+    text: `${verb} ${body}`.trim(),
+  });
+}
+```
+
+```javascript
+// comms.js — inside connectSession wiring:
+import { sayBroadcast, directedDelivery, observe } from '../lib/latency.js';
+sess.stream.on('data', (evt) => {
+  if (evt.type === 'say' || evt.type === 'pose') observe(sayBroadcast, evt.body);
+  else if (evt.type === 'page' || evt.type === 'whisper') observe(directedDelivery, evt.body);
+});
+```
+
+- [ ] **Step 3: Add the SLO thresholds (provisional until baseline calibration)**
+
+```javascript
+// comms.js options.thresholds:
+thresholds: {
+  say_broadcast_ms: ['p(99)<250'],
+  directed_delivery_ms: ['p(99)<150'],
+  connect_auth_ms: ['p(99)<1000'], // SLO 5
+  checks: ['rate>0.999'],          // SLO 4 (error rate < 0.1%)
+},
+```
+
+- [ ] **Step 4: Smoke-run and confirm the Trends populate**
+
+Run: `task loadtest`
+Expected: summary shows `say_broadcast_ms` with a p99 value (co-located VUs receive each other's stamped broadcasts).
+
+- [ ] **Step 5: Commit**
+
+`test(load): client-side say/directed latency via payload timestamp (INV-LOAD-3)`
+
+---
+
+### Task 7: `task loadtest` smoke target + first green run
+
+**Files:**
+
+- Modify: `Taskfile.yaml`
+
+- [ ] **Step 1: Add the smoke + full + module-test targets**
+
+```yaml
+  loadtest:
+    desc: "Load run against a running SUT. Override via vars: LOAD_VUS/LOAD_DURATION/LOAD_SCENARIO."
+    deps: ['loadtest:build']
+    vars:
+      LOAD_VUS: '{{.LOAD_VUS | default "50"}}'
+      LOAD_DURATION: '{{.LOAD_DURATION | default "30s"}}'
+      LOAD_SCENARIO: '{{.LOAD_SCENARIO | default "comms.js"}}'
+      LOAD_TRANSPORT: '{{.LOAD_TRANSPORT | default "connect"}}'
+    cmds:
+      - >-
+        docker run --rm --network host -v "{{.ROOT_DIR}}/test/load:/load"
+        -v "{{.ROOT_DIR}}/api/proto:/load/proto"
+        -e LOAD_VUS={{.LOAD_VUS}} -e LOAD_DURATION={{.LOAD_DURATION}}
+        -e LOAD_TRANSPORT={{.LOAD_TRANSPORT}}
+        holomush-k6:local run /load/scenarios/{{.LOAD_SCENARIO}}
+
+  loadtest:full:
+    desc: "Heavy local load run (N=1000); requires a Dockerized SUT"
+    cmds:
+      - task: loadtest
+        vars: { LOAD_VUS: '1000', LOAD_DURATION: '10m' }
+
+  loadtest:test:
+    desc: "Unit-test the xk6 Go modules (separate go module)"
+    cmds:
+      - cd test/load && go test ./...
+```
+
+(go-task does NOT propagate a `VAR=x task ...` shell prefix into another task's `{{.VAR}}` context — call sub-tasks with the `task:`/`vars:` form, as `loadtest:full` does.)
+
+- [ ] **Step 2: Run the smoke end-to-end**
+
+Run: `task dev` (SUT up) then `task loadtest`
+Expected: exit 0; thresholds reported; `say_broadcast_ms` p99 printed.
+
+- [ ] **Step 3: Run the module tests**
+
+Run: `task loadtest:test`
+Expected: PASS (telnet framer test from Task 3).
+
+- [ ] **Step 4: Commit**
+
+`test(load): loadtest smoke/full/test task targets`
+
+---
+
+### Task 8: Nightly workflow, baseline, and exit-discipline meta-tests (INV-LOAD-4, INV-LOAD-5, INV-LOAD-8)
+
+**Files:**
+
+- Create: `.github/workflows/nightly-load.yml`, `.benchmarks/load-baseline.json`, `test/meta/load_harness_invariants_test.go`
+- Reference: `.github/workflows/nightly-soak.yml`, `test/meta/pr_prep_fast_lane_test.go`, `test/meta/tooling_no_mandatory_int_test.go`
+
+- [ ] **Step 1: Write the nightly workflow**
+
+```yaml
+# .github/workflows/nightly-load.yml
+name: Nightly Load
+on:
+  schedule:
+    - cron: "0 7 * * *"   # 07:00 UTC — after nightly-soak's 06:00 + 30m budget
+  workflow_dispatch: {}
+jobs:
+  load:
+    runs-on: namespace-profile-default
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stand up SUT
+        run: docker compose -f compose.yaml up -d --wait
+      - name: Build custom k6
+        run: task loadtest:build
+      - name: Prepare output dir
+        run: mkdir -p test/load/out
+      - name: Run heavy load (gate on thresholds)
+        run: |
+          docker run --rm --network host \
+            -v "$PWD/test/load:/load" -v "$PWD/api/proto:/load/proto" \
+            -e LOAD_VUS=1000 -e LOAD_DURATION=10m \
+            --out json=/load/out/summary.json \
+            holomush-k6:local run /load/scenarios/comms.js
+      - name: Regression gate vs baseline
+        run: ./scripts/check-load-regression.sh test/load/out/summary.json .benchmarks/load-baseline.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: load-summary, path: test/load/out/summary.json }
+```
+
+The k6 step is a **standalone command whose non-zero exit fails the job** — no `| tee`/`| tail`/trailing `echo` (INV-LOAD-4).
+
+- [ ] **Step 2: Seed the baseline file (calibrated after first run)**
+
+```json
+{
+  "_comment": "Provisional. Replace with observed p99 × headroom after the first nightly run. Gate factor 1.10.",
+  "say_broadcast_ms_p99": 250,
+  "directed_delivery_ms_p99": 150,
+  "command_ack_ms_p99": 200,
+  "history_ms_p99": 500,
+  "connect_auth_ms_p99": 1000
+}
+```
+
+- [ ] **Step 3: Write the regression gate script (INV-LOAD-5)**
+
+Create `scripts/check-load-regression.sh`. It reads each `*_p99` from the baseline JSON, extracts the matching metric's p99 from the k6 end-of-test summary JSON, and exits non-zero if any observed value exceeds `baseline × 1.10` (mirrors `scripts/check-benchmark-regression.sh`).
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# check-load-regression.sh <k6-summary.json> <baseline.json>
+# Exits non-zero if any metric p99 exceeds baseline × FACTOR.
+set -euo pipefail
+SUMMARY="$1"; BASELINE="$2"; FACTOR="${LOAD_GATE_FACTOR:-1.10}"
+fail=0
+# Map baseline keys (e.g. say_broadcast_ms_p99) → k6 metric name (say_broadcast_ms).
+for key in $(jq -r 'keys[] | select(endswith("_p99"))' "$BASELINE"); do
+  metric="${key%_p99}"
+  base=$(jq -r --arg k "$key" '.[$k]' "$BASELINE")
+  # k6 JSON summary stores trends under .metrics.<name>.values["p(99)"].
+  obs=$(jq -r --arg m "$metric" '.metrics[$m].values["p(99)"] // empty' "$SUMMARY")
+  if [ -z "$obs" ]; then echo "WARN: metric $metric absent from summary"; continue; fi
+  limit=$(awk -v b="$base" -v f="$FACTOR" 'BEGIN{printf "%.3f", b*f}')
+  if awk -v o="$obs" -v l="$limit" 'BEGIN{exit !(o>l)}'; then
+    echo "FAIL: $metric p99=$obs > limit=$limit (baseline=$base × $FACTOR)"; fail=1
+  else
+    echo "ok:   $metric p99=$obs <= $limit"
+  fi
+done
+exit "$fail"
+```
+
+- [ ] **Step 4: Write the failing meta-tests (INV-LOAD-4, INV-LOAD-6, INV-LOAD-8)**
+
+Reuse the existing `test/meta` helpers `findRepoRoot(t)` and `taskBlock(t, tf, name)` (defined in `test/meta/pr_prep_fast_lane_test.go`) — do NOT invent new root/parse helpers.
+
+```go
+// test/meta/load_harness_invariants_test.go
+package meta
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// INV-LOAD-8: the load harness MUST NOT be wired into the pr-prep fast lane.
+func TestLoadHarnessNotInPrPrep(t *testing.T) {
+	root := findRepoRoot(t)
+	tf, err := os.ReadFile(filepath.Join(root, "Taskfile.yaml"))
+	require.NoError(t, err)
+	require.NotContains(t, taskBlock(t, string(tf), "pr-prep"), "loadtest",
+		"INV-LOAD-8: pr-prep MUST NOT depend on any loadtest target")
+}
+
+// INV-LOAD-4: the nightly-load gate MUST derive pass/fail from the k6 exit
+// code — no tee/tail/trailing-echo masking on the gating "Run heavy load" step.
+func TestNightlyLoadNoExitMasking(t *testing.T) {
+	root := findRepoRoot(t)
+	wf, err := os.ReadFile(filepath.Join(root, ".github/workflows/nightly-load.yml"))
+	require.NoError(t, err)
+	body := string(wf)
+	// Isolate the gating step: from its name to the next "- name:".
+	i := strings.Index(body, "Run heavy load")
+	require.GreaterOrEqual(t, i, 0, "gating step 'Run heavy load' not found")
+	gate := body[i:]
+	if j := strings.Index(gate, "- name:"); j > 0 {
+		gate = gate[:j]
+	}
+	for _, bad := range []string{"| tee", "| tail", "&& echo", "; echo $?"} {
+		require.NotContains(t, gate, bad,
+			"INV-LOAD-4: gating step masks exit code via %q", bad)
+	}
+}
+
+// INV-LOAD-6: every verb in test/load/verbs.json MUST be a registered command —
+// present in some plugins/*/plugin.yaml commands[].name, or a known built-in.
+func TestLoadScenarioVerbsRegistered(t *testing.T) {
+	root := findRepoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "test/load/verbs.json"))
+	require.NoError(t, err)
+	var groups map[string][]string
+	require.NoError(t, json.Unmarshal(raw, &groups))
+
+	// Every scenario verb must be a plugin-declared command. (verbs.json holds
+	// only real commands — say/pose/emit/ooc/page/whisper + examine — so no
+	// built-in allowlist is needed; reads use examine, history is an RPC.)
+	registered := map[string]bool{}
+	manifests, _ := filepath.Glob(filepath.Join(root, "plugins/*/plugin.yaml"))
+	for _, m := range manifests {
+		b, err := os.ReadFile(m)
+		require.NoError(t, err)
+		var doc struct {
+			Commands []struct {
+				Name string `yaml:"name"`
+			} `yaml:"commands"`
+		}
+		require.NoError(t, yaml.Unmarshal(b, &doc))
+		for _, c := range doc.Commands {
+			registered[c.Name] = true
+		}
+	}
+	for _, verbs := range groups {
+		for _, v := range verbs {
+			require.True(t, registered[v],
+				"INV-LOAD-6: verbs.json verb %q is not a registered command", v)
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Run meta-tests, verify they pass against the new files**
+
+Run: `task test -- -run 'TestLoadHarness|TestNightlyLoad|TestLoadScenarioVerbs' ./test/meta/`
+Expected: PASS (every verb in `verbs.json` resolves to a `commands[].name` in a plugin manifest — comms via `core-communication`, `examine` via `core-objects`).
+
+- [ ] **Step 6: Commit**
+
+`test(load): nightly-load workflow + baseline + exit-discipline meta-tests`
+
+---
+
+## Phase 2: Full — complete mix, both transports, dashboards, docs
+
+### Task 9: Complete comms mix — directed (page/whisper) + emit/ooc + history (SLO 1b)
+
+**Files:**
+
+- Modify: `test/load/lib/session.js`, `test/load/scenarios/comms.js`
+
+- [ ] **Step 1: Implement directed sends with targeting**
+
+`page <name>=<msg>` and `whisper <name>=<msg>` require a target. Pick a random other-VU character name from a `SharedArray` of session identities built in `setup()`.
+
+```javascript
+// session.js — directed send. SendCommandRequest.text carries the verb;
+// session_id + connection_id bind it to this session (proto web.proto:113).
+export function sendDirected(sess, verb, targetName, msg) {
+  return sess.client.invoke(`${SVC}/SendCommand`, {
+    session_id: sess.sessionId, connection_id: sess.connectionId,
+    text: `${verb} ${targetName}=${stamp(msg)}`,
+  });
+}
+```
+
+- [ ] **Step 2: Implement history queries**
+
+```javascript
+// WebQueryStreamHistoryRequest: session_id + stream + count (proto web.proto:333).
+// `count` is the page size — NOT `limit`. `stream` is the subject to page
+// (the session's scene/location IC stream from Task 10's occupancy assignment).
+export function queryHistory(sess, stream) {
+  return sess.client.invoke(`${SVC}/WebQueryStreamHistory`, {
+    session_id: sess.sessionId, stream, count: 20,
+  });
+}
+```
+
+- [ ] **Step 3: Route the action stream to the right sender**
+
+Update the `comms.js` loop to dispatch `page`/`whisper` → `sendDirected(sess, verb, target, 'hi')` (target = a random peer name from the scene roster `SharedArray`), `__history__` → `queryHistory(sess, sess.stream_subject)`, `examine` → `sendCommand(sess, 'examine', target)`, room verbs → `sendCommand(sess, verb, 'hello', true)`.
+
+- [ ] **Step 4: Add command-ack + history Trends and thresholds**
+
+```javascript
+// latency.js
+export const commandAck = new Trend('command_ack_ms', true);
+export const historyMs = new Trend('history_ms', true);
+```
+
+```javascript
+// comms.js thresholds += { command_ack_ms: ['p(99)<200'], history_ms: ['p(99)<500'] }
+```
+
+- [ ] **Step 5: Smoke-run, confirm all four Trends populate**
+
+Run: `task loadtest`
+Expected: `say_broadcast_ms`, `directed_delivery_ms`, `command_ack_ms`, `history_ms` all present.
+
+- [ ] **Step 6: Commit**
+
+`test(load): full comms mix (directed delivery + history) with SLO 1b`
+
+---
+
+### Task 10: Scene-based occupancy/concentration model (Zipf skew + hot scenes)
+
+**Files:**
+
+- Modify: `test/load/lib/session.js`, `test/load/lib/config.js`, `test/load/scenarios/comms.js`
+- Reference: `plugins/core-scenes/plugin.yaml` (`scene <subcommand>` command; `seed:player-scene-participant` grants join/leave)
+
+There is **no `move` command** — co-location/fanout in HoloMUSH happens via **scenes** (the RP container). VUs are assigned to scenes (Zipf-skewed sizes, a few hot scenes); `say`/`pose` inside a scene broadcast to scene participants (`scene_say_ic`/`scene_pose_ic`). This is the faithful concentration model (spec §5 "a few larger scenes").
+
+- [ ] **Step 1: Add the scene-occupancy knob**
+
+```javascript
+// config.js
+export const occupancy = {
+  scenes: parseInt(__ENV.LOAD_SCENES || '150', 10),
+  hotScenes: parseInt(__ENV.LOAD_HOT_SCENES || '4', 10),
+  hotSceneSize: parseInt(__ENV.LOAD_HOT_SIZE || '30', 10),
+};
+```
+
+- [ ] **Step 2: Create scenes in setup() and assign VUs (Zipf skew)**
+
+In `setup()` a small pool of owner VUs run `scene create` to mint scene IDs; setup returns the scene-ID list (k6 passes the `setup()` return value to every VU). `assignScene(vu)` maps a VU to a scene: hot scenes fill first to `hotSceneSize`, the remainder spread across the cold tail. Each VU `scene join <id>`s its assigned scene at session start.
+
+```javascript
+// session.js — deterministic scene assignment (no RNG; depends only on vu).
+export function assignScene(vu, sceneIds) {
+  const { hotScenes, hotSceneSize } = occupancy;
+  const hotCap = hotScenes * hotSceneSize;
+  if (vu <= hotCap) return sceneIds[Math.floor((vu - 1) / hotSceneSize)];
+  return sceneIds[hotScenes + ((vu - hotCap) % (sceneIds.length - hotScenes))];
+}
+
+export function joinScene(sess, sceneId) {
+  sess.sceneId = sceneId;
+  return sendCommand(sess, 'scene', `join ${sceneId}`);
+}
+```
+
+The VU's `stream_subject` for history queries (Task 9) is its scene's IC stream (e.g., `scene:<id>`); set it when joining.
+
+- [ ] **Step 3: Smoke-run, verify hot scenes amplify say_broadcast fanout**
+
+Run: `LOAD_HOT_SIZE=40 task loadtest`
+Expected: `say_broadcast_ms` sample count scales with hot-scene size (each emit in a 40-participant scene records ~39 recipient observations).
+
+- [ ] **Step 4: Commit**
+
+`test(load): scene-based Zipf occupancy + hot-scene concentration`
+
+---
+
+### Task 11: Churn lifecycle (disconnect/reattach) — exercises holomush-hfvc
+
+**Files:**
+
+- Modify: `test/load/scenarios/comms.js`, `test/load/lib/session.js`
+
+- [ ] **Step 1: Add a churn probability knob + reattach path**
+
+```javascript
+// config.js
+export const churnP = parseFloat(__ENV.LOAD_CHURN || '0.02'); // per-iteration disconnect chance
+```
+
+- [ ] **Step 2: Implement disconnect/reconnect in the loop**
+
+On a churn roll, `closeSession` then `connectSession` (guest reattach). Record a `reattach_ok` check.
+
+```javascript
+// comms.js loop:
+if (Math.random() < churnP) { closeSession(sess); sess = connectSession(); check(sess, { 'reattach ok': (s) => !!s.stream }); }
+```
+
+- [ ] **Step 3: Smoke-run with elevated churn**
+
+Run: `LOAD_CHURN=0.2 task loadtest`
+Expected: `reattach ok` check rate high; if it fails, that reproduces holomush-hfvc — file/annotate.
+
+- [ ] **Step 4: Commit**
+
+`test(load): session churn + reattach (repro surface for holomush-hfvc)`
+
+---
+
+### Task 12: Telnet-transport parity
+
+**Files:**
+
+- Modify: `test/load/lib/session.js`, `test/load/scenarios/comms.js`
+
+- [ ] **Step 1: Implement the telnet session lifecycle**
+
+```javascript
+// session.js
+import telnet from 'k6/x/telnet';
+import { cfg } from './config.js';
+export function connectTelnetSession() {
+  const cn = telnet.dial(cfg.telnetAddr, 5000);
+  // Two-phase login: read prompts, choose guest (see internal/telnet/gateway_handler.go).
+  cn.readLine(2000);            // banner
+  cn.send('guest');            // guest login path
+  cn.readLine(2000);            // welcome
+  return { cn, kind: 'telnet' };
+}
+```
+
+- [ ] **Step 2: Branch transport in the scenario**
+
+```javascript
+// comms.js: const sess = cfg.transport === 'telnet' ? connectTelnetSession() : connectSession();
+```
+
+Telnet `say` latency is read from the inbound line stream (a reader loop parses lines and routes stamped broadcasts to `observe`).
+
+- [ ] **Step 3: Verify INV-LOAD-2 (telnet login + say round-trip)**
+
+The telnet smoke MUST complete a guest login and one `say` round-trip (the emitting VU sees its own broadcast echoed on the inbound line stream). Add a `check` in the telnet path asserting a stamped `say` is received within the deadline.
+
+Run: `task loadtest LOAD_TRANSPORT=telnet` (small N)
+Expected: the `telnet say round-trip` check passes — proves INV-LOAD-2.
+
+- [ ] **Step 4: Smoke-run both transports**
+
+Run: `task loadtest LOAD_TRANSPORT=telnet` and `task loadtest LOAD_TRANSPORT=connect`
+Expected: both populate `say_broadcast_ms`. (Pass `LOAD_TRANSPORT` as a go-task var — see Task 7's `-e LOAD_TRANSPORT` forwarding — not a shell prefix.)
+
+- [ ] **Step 5: Commit**
+
+`test(load): telnet-transport scenario parity (INV-LOAD-2)`
+
+---
+
+### Task 13: Grafana/Prometheus output + baseline calibration
+
+**Files:**
+
+- Modify: `.github/workflows/nightly-load.yml`, `.benchmarks/load-baseline.json`
+- Create: `test/load/dashboards/load-overview.json` (Grafana dashboard)
+
+- [ ] **Step 1: Add Prometheus remote-write output to the nightly run**
+
+Add `-o experimental-prometheus-rw` + `K6_PROMETHEUS_RW_SERVER_URL` env to the k6 docker run, pointing at the existing collector.
+
+- [ ] **Step 2: Author the Grafana dashboard JSON** (panels: say/directed/ack/history p99 trend, throughput, error rate, VU count).
+
+- [ ] **Step 3: Calibrate the baseline from the first real run**
+
+After one nightly run, set each `*_p99` in `.benchmarks/load-baseline.json` to observed p99 × 1.2 headroom.
+
+```bash
+bd note holomush-ql7ef "Load baseline calibrated from first nightly run: <metric=value...>"
+```
+
+- [ ] **Step 4: Commit**
+
+`test(load): Grafana/Prometheus output + calibrated baseline`
+
+---
+
+### Task 14: Contributor docs (PR-blocking)
+
+**Files:**
+
+- Create: `site/src/content/docs/contributing/how-to/load-testing.md`, `site/src/content/docs/contributing/reference/load-slos.md`
+
+- [ ] **Step 1: Write the how-to** (build custom k6, run smoke/full, read dashboards, update baseline).
+
+- [ ] **Step 2: Write the SLO/scenario reference** (the 9 SLOs, the scenario knobs/env vars, the invariants).
+
+- [ ] **Step 3: Lint**
+
+Run: `task lint:markdown`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`docs(load): contributor how-to + SLO/scenario reference`
+
+---
+
+## Phase 3: Secondary — capacity ceiling + endurance soak
+
+> These are the secondary uses (the user picked "SLOs + harness" as primary). The steady-state SLOs 1–6 are gated in Phases 1–2; the stability SLOs 7–9 are validated by the endurance soak here. Both build on the P1/P2 harness with no new transport code.
+
+### Task 15: Ceiling-finding mode
+
+**Files:**
+
+- Create: `test/load/scenarios/ceiling.js`
+- Modify: `Taskfile.yaml` (`loadtest:ceiling`)
+
+- [ ] **Step 1: Write a ramping scenario that climbs past N until SLO breach**
+
+```javascript
+// ceiling.js — ramping-vus executor stepping N upward; abort on threshold breach,
+// report the last passing N as the ceiling.
+export const options = {
+  scenarios: { ceiling: { executor: 'ramping-vus', stages: [
+    { duration: '2m', target: 1000 }, { duration: '2m', target: 2000 },
+    { duration: '2m', target: 4000 }, { duration: '2m', target: 8000 },
+  ] } },
+  thresholds: { say_broadcast_ms: [{ threshold: 'p(99)<250', abortOnFail: true }] },
+};
+```
+
+- [ ] **Step 2: Add the task target + a manual-dispatch note** (ceiling runs are opt-in, not nightly — they're exploratory and infra-heavy).
+
+- [ ] **Step 3: Run once, record the ceiling**
+
+```bash
+bd note holomush-ql7ef "Observed single-node ceiling: ~<N> sessions before say_broadcast p99 breach; first bottleneck: <gateway|gRPC|JetStream|Postgres> per OTel spans."
+```
+
+- [ ] **Step 4: Commit**
+
+`test(load): capacity ceiling-finding scenario`
+
+---
+
+### Task 16: Endurance soak variant + stability SLOs (7–9)
+
+**Files:**
+
+- Create: `test/load/scenarios/soak.js`
+- Modify: `Taskfile.yaml` (`loadtest:soak`), `.github/workflows/nightly-load.yml` (optional weekly soak job)
+- Reference: `test/integration/eventbus_e2e/soak_test.go` (leak/RSS assertion shape)
+
+The steady-state SLOs (1–6) are gated nightly. SLOs 7–9 — goroutine-leak (≈ baseline), bounded RSS growth, audit/JetStream consumer lag p99 ≤ 5s — need a multi-hour hold the 10-minute nightly run does not provide.
+
+- [ ] **Step 1: Write the soak scenario (long hold at N, env-overridable)**
+
+```javascript
+// test/load/scenarios/soak.js — reuses the comms scenario default function;
+// only the executor differs (a long constant-vus hold).
+export { default, setup } from './comms.js';
+import { cfg } from '../lib/config.js';
+export const options = {
+  scenarios: { soak: { executor: 'constant-vus', vus: cfg.vus,
+    duration: __ENV.LOAD_DURATION || '4h' } },
+  thresholds: { say_broadcast_ms: ['p(99)<250'], directed_delivery_ms: ['p(99)<150'] },
+};
+```
+
+- [ ] **Step 2: Capture server-side stability metrics (SLOs 7–9)**
+
+These are **server-observed**, not client-measured. A sidecar step samples the SUT's `/metrics` (goroutine count, RSS) at start and end, and computes audit lag from `events_audit` (the same projection the eventbus soak asserts on). `scripts/check-soak-stability.sh` fails if: end-goroutines > start × 1.2 (SLO 7), RSS growth > 50 MB/hour (SLO 8), or audit-lag p99 > 5s (SLO 9).
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# check-soak-stability.sh <metrics-start.txt> <metrics-end.txt> <hours> <pg-dsn>
+set -euo pipefail
+g0=$(rg -o 'go_goroutines (\d+)' -r '$1' "$1"); g1=$(rg -o 'go_goroutines (\d+)' -r '$1' "$2")
+r0=$(rg -o 'process_resident_memory_bytes (\d+)' -r '$1' "$1")
+r1=$(rg -o 'process_resident_memory_bytes (\d+)' -r '$1' "$2")
+hours="$3"; dsn="$4"; fail=0
+awk -v a="$g0" -v b="$g1" 'BEGIN{exit !(b > a*1.2)}' && { echo "FAIL: goroutine leak $g0→$g1 (SLO 7)"; fail=1; }
+awk -v a="$r0" -v b="$r1" -v h="$hours" 'BEGIN{exit !((b-a)/1048576/h > 50)}' && { echo "FAIL: RSS growth >50MB/h (SLO 8)"; fail=1; }
+# SLO 9: audit-lag p99 = persisted_at − event emit time, over the soak window.
+# events_audit carries the event's ULID-derived emit time and the projection's
+# persisted_at; p99 of the delta must be ≤ 5s. (Adjust column names to the
+# events_audit schema — see internal/eventbus/audit/.)
+lag_p99=$(psql "$dsn" -tAc "select coalesce(percentile_disc(0.99) within group (order by extract(epoch from (persisted_at - emitted_at))), 0) from events_audit where persisted_at > now() - interval '${hours} hours';")
+awk -v l="$lag_p99" 'BEGIN{exit !(l > 5)}' && { echo "FAIL: audit lag p99=${lag_p99}s > 5s (SLO 9)"; fail=1; }
+exit "$fail"
+```
+
+(Audit-lag p99 ≤ 5s is asserted by reusing the eventbus soak's lag query against `events_audit`; INV/SLO-9.)
+
+- [ ] **Step 3: Add the soak task target**
+
+```yaml
+  loadtest:soak:
+    desc: "Multi-hour endurance soak (stability SLOs 7-9); opt-in, not nightly-gating"
+    cmds:
+      - task: loadtest
+        vars: { LOAD_VUS: '1000', LOAD_SCENARIO: 'soak.js', LOAD_DURATION: '{{.LOAD_DURATION | default "4h"}}' }
+```
+
+- [ ] **Step 4: Run a shortened soak locally to validate the assertions**
+
+Run: `task loadtest:soak LOAD_DURATION=10m`
+Expected: completes; `check-soak-stability.sh` reports no leak / bounded RSS.
+
+- [ ] **Step 5: Commit**
+
+`test(load): endurance soak variant + stability SLOs 7-9`
+
+> **Out of scope (spec NG3/NG4):** the in-process Go core-tier load driver and distributed multi-node load generation are non-goals for this plan. File a follow-up bead only if CI-deterministic in-process load or >8k single-origin load becomes a real need.
+
+---
+
+## Post-Implementation Checklist
+
+- [ ] `task loadtest:test` green (xk6 module unit tests)
+- [ ] `task test -- ./test/meta/` green (INV-LOAD-4/8 meta-tests)
+- [ ] `task lint` + `task lint:markdown` green
+- [ ] First `nightly-load.yml` run green; baseline calibrated and committed
+- [ ] `site/` docs merged; reference lists all 9 SLOs + INV-LOAD-1..8
+- [ ] Spec invariants INV-LOAD-1..8 each have a verifying test or smoke assertion
+- [ ] Bead `holomush-ql7ef` notes capture: spike verdict, baseline calibration, observed ceiling
+<!-- adr-capture: sha256=66c909a317bb2608; session=cli; ts=2026-05-29T02:30:39Z; adrs=holomush-2344h -->

--- a/docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md
+++ b/docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md
@@ -1,0 +1,337 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Full-System Load & Performance Testing Harness + SLOs — Design
+
+**Design bead:** holomush-ql7ef
+**Status:** Draft (pending design-reviewer gate)
+**Date:** 2026-05-28
+**Participants:** Sean, Claude
+
+## 1. Overview
+
+HoloMUSH has component-level performance coverage (Go micro-benchmarks for the
+policy engine; the `task soak:eventbus` chaos+soak matrix for the EventBus) but
+**no full-system load test**: nothing drives concurrent telnet + web clients
+through the gateway → core (gRPC) → EventBus (JetStream) → Postgres and measures
+end-to-end, player-perceived latency under sustained load.
+
+This design specifies a repeatable full-system load/performance harness and a
+set of end-to-end Service Level Objectives (SLOs) the harness validates. The
+**primary driver is the SLO program** — a reusable harness plus gateable SLOs;
+capacity-ceiling discovery, CI regression detection, and endurance soak are
+secondary uses that build on the same harness.
+
+### 1.1 Goals
+
+- **G1.** Establish end-to-end SLOs measured at a realistic anchor load
+  (N = 1,000 concurrent sessions per node), centred on the comms paths a MUSH
+  actually exercises.
+- **G2.** Build a repeatable harness that drives the **real wire protocols**
+  (Connect for web, raw TCP for telnet) against the full Dockerized binary and
+  validates the SLOs via pass/fail thresholds.
+- **G3.** Surface results as Grafana trend dashboards (reusing the existing
+  OTel/Prometheus stack) and a CI-gated regression check against a tracked
+  baseline.
+
+### 1.2 Non-goals
+
+- **NG1.** Replacing the existing Go micro-benchmarks or `task soak:eventbus` —
+  this harness complements them at the full-system tier; it does not absorb
+  component-level coverage.
+- **NG2.** A bespoke Go load generator that re-implements ramp executors,
+  percentile aggregation, thresholds, and dashboards (k6 provides these).
+- **NG3.** An in-process core-tier concurrent load driver — explicitly deferred
+  to Phase 3, added only if CI-deterministic component load proves worthwhile.
+- **NG4.** Distributed (multi-node) load generation — deferred to Phase 3,
+  relevant only for the ≥5,000-session ceiling experiments.
+- **NG5.** Production / sandbox (`game.holomush.dev`) load testing — the target
+  is a controlled Dockerized instance; running load against shared sandbox infra
+  is out of scope.
+
+## 2. Grounding summary
+
+| Source | Finding |
+| --- | --- |
+| `internal/testsupport/integrationtest/harness.go` | In-process harness boots real CoreServer + embedded NATS JetStream + Postgres testcontainer via in-process gRPC clients; stops at the core — **no** gateway/telnet/web layer. |
+| `scripts/check-benchmark-regression.sh`, `Taskfile.yaml` (`test:bench`) | Existing regression model: run benchmarks, fail at 110% of `.benchmarks/baseline.txt`. Reused conceptually for the load baseline. |
+| `test/integration/eventbus_e2e/soak_test.go`, `.github/workflows/nightly-soak.yml` | Soak pattern: `//go:build integration && soak`, nightly cron, `SOAK_DURATION` override, asserts row-parity + goroutine-leak + RSS-growth (spec §8: 1k ev/s, 5 min, audit lag p99 ≤ 5s). Mirrored for `nightly-load.yml`. |
+| `internal/web/server.go:61` | Web tier served by connect-go `NewWebServiceHandler` — exposes gRPC, gRPC-Web, **and** Connect protocols on one handler. The PWA (connect-es) uses the **Connect** protocol over HTTP/2-via-TLS-ALPN. |
+| `internal/eventbus/telemetry/`, `internal/observability/`, `internal/gatewaymetrics/`, `docker/otel-collector/` | Request paths emit OTel **traces** but no server-side latency **histograms** on say/broadcast paths. Harness measures client-perceived latency; server spans give attribution. |
+| `connectrpc.com/connect v1.19.2`; `bumberboy/xk6-connectrpc` (Jan 2026); grafana/k6#5193 | connect-go client speaks Connect by default; an existing community xk6 extension drives Connect from k6. Must be vetted for server-streaming. |
+| Verbs (`plugins/*/plugin.yaml`, `internal/command/handlers/register.go`, `internal/admin/readstream/filter.go`) | Real player commands: `say`/`pose`/`emit`/`ooc`/`page`/`whisper`/`pemit`/`wall` (`core-communication` Lua plugin, `main.lua:186,285`); `examine`/`describe`/`create`/`set` (`core-objects`); `scene`/`scenes` (`core-scenes`); `dig`/`link` (`core-building`); compiled-in `quit`/`shutdown`/`plugin`/`resetpassword`. **No `look`/`move`/`recall` command exists** — those names are event-verb registrations (`internal/core/builtins.go`) + ABAC seeds (`internal/access/policy/seed.go`), NOT command handlers. `dm` is an event **facet** (`internal/admin/readstream/filter.go`), not a command. **No `channel` command** (no `core-channels` plugin — future per `theme:social-spaces`). |
+
+Full grounding trace is recorded as `bd note` entries on holomush-ql7ef.
+
+## 3. Architecture
+
+The load generator is a custom-built k6 binary (`xk6 build`) bundling two
+extensions, each driving the system's real wire protocol. The target is the
+full Dockerized `holomush` binary.
+
+```mermaid
+flowchart LR
+    subgraph gen["k6 load generator (custom binary)"]
+        scen["shared JS scenario\ncomms-heavy mix\nparametric on N VUs\nfixed RNG seed"]
+        xconn["xk6-connectrpc\n(exact Connect proto, H2/TLS)"]
+        xteln["xk6-telnet\n(raw TCP)"]
+        scen --> xconn
+        scen --> xteln
+    end
+
+    subgraph sut["holomush binary (Dockerized, full stack)"]
+        gw["gateway\ninternal/web + telnet listener"]
+        core["CoreServer (gRPC)"]
+        bus["EventBus\nembedded NATS JetStream"]
+        pg[("Postgres")]
+        gw -->|gRPC| core
+        core --> bus
+        core --> pg
+    end
+
+    xconn -->|"Connect streaming"| gw
+    xteln -->|"TCP telnet"| gw
+
+    subgraph obs["measurement"]
+        k6m["k6 metrics + thresholds\n(SLO gates → exit code)"]
+        trend["custom Trends:\nsay→broadcast,\npage/whisper→delivery\n(emit-ts in payload)"]
+        graf["Grafana\n(k6 metrics + server OTel spans)"]
+    end
+    gen --> k6m
+    xconn -.->|receive ts| trend
+    core -.->|OTel spans| graf
+    k6m --> graf
+```
+
+### 3.1 Tooling decision
+
+**Chosen:** k6 + a custom binary bundling `xk6-connectrpc` (web tier, exact
+Connect protocol) and an xk6 telnet/raw-TCP module (telnet tier, exact TCP).
+
+**Rationale:** k6 provides ramp/arrival-rate executors, percentile metrics,
+**thresholds-as-pass/fail-gates**, native Prometheus/Grafana output, and
+distributed execution — i.e., an SLO program in a box, atop the Grafana/OTel
+stack the project already runs. Because an xk6 extension is a Go module that can
+import `connectrpc.com/connect`, it drives the **exact** Connect wire path the
+PWA uses (it is `WithGRPC()` that opts *into* gRPC; the default is Connect), so
+there is no protocol-fidelity gap. Telnet is raw TCP, so an xk6 module drives it
+bit-exactly.
+
+**Rejected alternatives:**
+
+- **Go-native load generator (both tiers).** Exact fidelity and zero new
+  toolchain, but re-implements ramp/percentile/threshold/dashboard machinery k6
+  provides for free (NG2). The in-process tier it would unlock is deferred (NG3).
+- **k6 with its built-in `k6/net/grpc` for the web tier.** Avoids a custom
+  Connect extension but load-tests the **gRPC** envelope, not the browser's
+  **Connect** envelope on the same handler — a real (if minor) fidelity gap.
+  Superseded by the xk6-connectrpc approach, which removes the gap entirely.
+- **Off-the-shelf HTTP tools (vegeta, Gatling).** Cannot drive the bespoke
+  telnet protocol and cannot reach the in-process tier; would fragment into
+  disjoint tools.
+
+## 4. Service Level Objectives
+
+Measured at the anchor (N = 1,000 concurrent sessions, comms-heavy mix). SLOs
+1–6 are evaluated in the **steady-state** window; SLOs 7–9 are evaluated during
+the **soak variant** (§6). **Targets are PROVISIONAL.** The first nightly
+baseline run sets real numbers (observed p99 × headroom), recorded in
+`.benchmarks/load-baseline.json`; thresholds then gate against the baseline —
+the same model as `check-benchmark-regression.sh` (110% of baseline).
+
+| # | SLO | Provisional target | Fanout class / notes |
+| --- | --- | --- | --- |
+| 1a | say→broadcast p99 | < 250ms (p50 < 50ms) | room broadcast — fanout = co-located sessions; hot scenes amplify |
+| 1b | page/whisper→delivery p99 | < 150ms | directed (`page` cross-location/offline → storage write; `whisper` in-location private) |
+| 2 | command ack p99 (examine, scene) | < 200ms | non-broadcast command → response |
+| 3 | history query p99 | < 500ms | DB-backed; `QueryHistory` |
+| 4 | error rate | < 0.1% | excludes intentional ABAC denials |
+| 5 | connect+auth p99 | < 1s | session establishment under concurrent join |
+| 6 | sustained throughput | report-only | actions/s held at N=1k without SLO breach |
+| 7 | goroutine leak (soak) | ≈ baseline | mirrors eventbus soak assertion |
+| 8 | RSS growth (soak) | bounded / hr | leak detection over hours |
+| 9 | audit / JS consumer lag p99 | ≤ 5s | reuses eventbus spec §8 ceiling |
+
+### 4.1 Latency measurement
+
+say→broadcast (1a) and page/whisper→delivery (1b) are measured client-side **without**
+cross-VU shared state: the emitting VU stamps a high-resolution timestamp into
+the message payload; every recipient VU reads it off the stream on receipt and
+records `now − emit_ts` to a k6 custom `Trend`. Thresholds gate on the Trend's
+`p(99)`. Same-host (or NTP-synced) clocks make the subtraction valid. Server
+OTel spans (gateway / core / JS-publish / delivery) provide bottleneck
+attribution in Grafana but are not the latency-SLO source.
+
+SLOs 1–6 are **client-measured** (latency, error rate, throughput observed by
+the generator). SLOs 7–9 are **server-observed** during the soak variant
+(process goroutine count and RSS via the SUT's metrics; audit / JetStream
+consumer lag via the same `events_audit` projection the eventbus soak asserts on).
+
+## 5. Scenario model
+
+Default scenario: **comms-heavy (~80%), moderate concentration.**
+
+| Action | Share | Fanout class |
+| --- | --- | --- |
+| say / pose / emit / ooc | 45% | scene/room broadcast (wide; hot-scene amplified) |
+| page / whisper | 35% | directed (`page` cross-location, offline-capable → storage write; `whisper` in-location private) |
+| examine | 12% | current-state read (`examine <target>`) |
+| history | 8% | `WebQueryStreamHistory` RPC (not a verb) |
+
+> **Grounded verb set.** Only registered player commands are used: `say`/`pose`/`emit`/`ooc`/`page`/`whisper` (`plugins/core-communication`), `examine` (`plugins/core-objects`). There is **no `look`/`move`/`recall` command** in the codebase — reads use `examine`, history is the `WebQueryStreamHistory` RPC, and co-location/fanout is **scene-based** (no `move`: occupancy comes from joining scenes, the RP container). `channel` is future (no `core-channels` plugin).
+
+| Knob | Value |
+| --- | --- |
+| Per-session pacing | think-time ~ exp(mean 10s) → ~100 actions/s aggregate at N=1k (idle-heavy; connection-count-driven) |
+| Occupancy | 1k sessions across ~150 **scenes** (`scene join`), Zipf-skewed: most 2–5, **3–5 hot scenes at 20–40** participants |
+| Channels (future variant) | when `core-channels` lands: 1 broad channel (~60% subscribed) + several small topic channels. Excluded from the default mix today (§5.1). |
+| Lifecycle | connect → auth (guest + registered mix) → join → loop(think, act) → periodic disconnect/reattach (churn) |
+| Determinism | fixed RNG seed for action selection so baseline comparisons are apples-to-apples |
+
+The concentration knobs are parametric: the **scene-heavy** shape (and a
+**channel-heavy** shape once channels exist — see §5.1) is a config variant of
+this one scenario, not a separate script. **Burst mode** (shorter think-time in
+hot scenes) is intentionally out of scope for now (YAGNI).
+
+### 5.1 Command-availability gating
+
+The default scenario uses only commands that exist today: `say`/`pose`/`emit`/`ooc`/`page`/`whisper`
+(`core-communication`), `examine` (`core-objects`), and `scene` (`core-scenes`,
+for occupancy). There is **no `look`/`move`/`recall` command** — reads use
+`examine`, co-location/fanout is scene-based (`scene join`), and history is the
+`WebQueryStreamHistory` RPC. **`channel` does not exist** (future work under
+`theme:social-spaces`); channel posts are excluded from the default mix and
+treated as a **future variant**, gated on a `core-channels` plugin. INV-LOAD-6
+(no unregistered verb) is enforced by a **build-time meta-test** that validates
+the scenario's verb set (`test/load/verbs.json`) against the plugin manifests —
+not at runtime (there is no list-commands RPC). Enabling the channel variant
+when the plugin lands is a config change.
+
+## 6. Run phases
+
+```mermaid
+flowchart LR
+    w["warm-up\nconnect+auth N,\njoin locations\n(ramp ~60s)"] --> r["ramp\naction rate → target\n(k6 ramping stages)"]
+    r --> s["steady-state\nhold N for D\n(SLO window)"]
+    s --> t["teardown\ndisconnect + drain"]
+    s -. soak variant .-> soak["hold hours\n→ leak / RSS / lag\n(SLO 7–9)"]
+    s -. ceiling variant .-> ceil["ramp past N\nuntil SLO breach\n→ report ceiling"]
+```
+
+**VU model:** N persistent VUs = N long-lived sessions; each opens its
+Connect/telnet stream once, holds it across iterations, and loops with
+think-time. Connection count = VU count — the idle-heavy, connection-count
+shape a MUSH actually has.
+
+## 7. Output & gating
+
+Decision discipline is **exit-code-first** (per `.claude/rules/search-tools.md`):
+the pass/fail verdict is k6's process exit code, never a grep of its log.
+
+| Signal | Path | Role |
+| --- | --- | --- |
+| k6 thresholds | → process exit code | pass/fail gate (primary) |
+| k6 metrics | → Prometheus remote-write / OTLP → Grafana | trend dashboards |
+| k6 JSON summary | → parsed vs `.benchmarks/load-baseline.json` | regression gate (110%-of-baseline) |
+| server OTel spans | → Grafana | bottleneck attribution |
+
+## 8. CI & local integration
+
+| Target | Behaviour |
+| --- | --- |
+| `.github/workflows/nightly-load.yml` | cron **07:00 UTC** — starts after `nightly-soak`'s 06:00 run exhausts its 30-min budget (`.github/workflows/nightly-soak.yml` `timeout-minutes: 30`), avoiding Namespace-runner contention. (Separate `schedule:` triggers cannot express a cross-workflow `needs:`; the time gap is the mechanism, not a hard ordering.) Docker compose stands up the binary; cached custom-k6; heavy run; publish to Grafana + upload JSON; gate on thresholds |
+| `task loadtest` | local smoke (N≈50, D≈30s) against `task dev` / local compose — dev iteration |
+| `task loadtest:full` | heavy run locally |
+| `task loadtest:build` | reproducible `xk6 build` (pinned extension commits) |
+| `task pr-prep` | **excluded** — heavy and requires Docker + a running stack, same rationale as soak/E2E being CI-only |
+
+The load gate is a **nightly/required-CI** concern, not part of the mandatory
+fast-lane `pr-prep`.
+
+## 9. Supply chain — custom k6 binary
+
+The custom k6 binary pins `xk6-connectrpc` (upstream release **or** project
+fork — decided by the P1 spike, §11.1) and the telnet module at fixed commits
+in a build manifest. `xk6 build` MUST be reproducible and the
+resulting binary cached in CI. License/SPDX checks apply to vendored/forked
+extension code.
+
+## 10. Invariants (RFC2119)
+
+Each invariant carries a test obligation; a meta-test asserts the registry of
+invariants is complete (per project spec-acceptance convention).
+
+- **INV-LOAD-1.** The harness MUST drive the web tier over the **Connect**
+  protocol (not gRPC/gRPC-Web). *Test:* assert the xk6-connectrpc client
+  negotiates `application/connect+proto` against a recording handler.
+- **INV-LOAD-2.** The harness MUST drive the telnet tier over raw TCP through
+  the real gateway telnet listener. *Test:* a telnet smoke session completes
+  login + one `say` round-trip.
+- **INV-LOAD-3.** say→broadcast and page/whisper→delivery latency MUST be
+  computed from an emit-timestamp carried **in the message payload**, recorded
+  by the recipient VU — never from cross-VU shared mutable state. The generator
+  and SUT MUST share a clock source with skew ≤ 50ms (§12). *Test:* unit-test
+  the timestamp encode/decode + Trend recording helper; assert the skew bound in
+  setup.
+- **INV-LOAD-4.** The pass/fail verdict MUST be derived from k6's **exit code**
+  (thresholds), never from a substring match on k6 output. *Test:* a meta-test
+  asserts `nightly-load.yml` invokes the k6 gate as a standalone step (the job
+  fails on its non-zero exit) with no `| tee` / `| tail` / trailing `echo` that
+  would mask `$?` — the same exit-masking failure mode documented for `pr-prep`.
+- **INV-LOAD-5.** SLO thresholds MUST gate against `.benchmarks/load-baseline.json`
+  (relative regression), not hard-coded absolute numbers, once a baseline
+  exists. *Test:* the gate script fails when a metric exceeds baseline×factor;
+  passes within it.
+- **INV-LOAD-6.** The scenario MUST NOT issue command verbs that are not
+  registered in the running server (command-availability gating, §5.1).
+  *Test:* scenario config validation rejects unknown verbs against a verb
+  manifest.
+- **INV-LOAD-7.** Action selection MUST be seeded deterministically so two runs
+  of the same scenario config produce the same action sequence. *Test:* two
+  seeded runs produce identical action-count histograms.
+- **INV-LOAD-8.** The load harness MUST NOT be wired into `task pr-prep`
+  (fast lane). *Test:* meta-test greps the pr-prep task graph for any loadtest
+  dependency and fails if present.
+
+## 11. Implementation rollout
+
+| Phase | Scope |
+| --- | --- |
+| **P1 — MVP** | **De-risk gate first:** vet `xk6-connectrpc` for server-streaming (our `Subscribe` path); if absent, P1 forks and adds streaming. Then: `xk6 build` pipeline; telnet module; minimal scenario (say/pose + examine) vs Dockerized binary; client-side say→broadcast Trend; `task loadtest` smoke + `nightly-load.yml`; **first baseline**. |
+| **P2 — Full** | complete comms mix (`page`/`whisper`, `emit`/`ooc`, history) + occupancy/concentration skew + churn lifecycle; both SLO paths (1a/1b); Grafana dashboards; regression gate vs baseline; site/ docs. (Channel variant is conditional on `core-channels` landing — §5.1.) |
+| **P3 — Optional/secondary** | ceiling-finding mode; in-process Go core tier (NG3, deferred); distributed load-gen for ≥5k (NG4). |
+
+### 11.1 P1 de-risk gate
+
+The first P1 task is a **spike**, not a build: confirm `xk6-connectrpc`
+supports the server-streaming `Subscribe` path. A 4-month-old extension may be
+unary-only. The outcome decides whether P1 *uses* the extension or *forks and
+extends* it — a materially different estimate. The spike MUST complete (and any
+fork decision be recorded) before the rest of P1 proceeds.
+
+## 12. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `xk6-connectrpc` lacks streaming | P1 de-risk spike up front (§11.1); fork-and-extend fallback scoped. |
+| Custom k6 binary supply-chain drift | Pin extension commits; reproducible `xk6 build`; cache + license check (§9). |
+| Load-generator host is the bottleneck (not the SUT) | Watch generator-side CPU/saturation; at ≥5k, move to distributed gen (P3). |
+| Clock skew invalidates payload-timestamp latency | Co-locate generator + SUT (same host) or NTP-sync to ≤ 50ms skew; assert the bound in setup. 50ms is < 20% of the 250ms p99 target. |
+| Baseline captured on noisy infra | Baseline on the dedicated nightly runner; require N stable runs before freezing. |
+
+## 13. Documentation deliverables
+
+Per project convention, `site/` docs are PR-blocking for this work:
+
+- `site/src/content/docs/contributing/` — how to run `task loadtest`, read the
+  Grafana dashboards, and update the baseline.
+- A reference page describing the SLOs and the scenario knobs.
+
+## 14. Open questions
+
+- **OQ1.** Baseline-refresh cadence and approval flow (manual reviewed job vs.
+  automatic on green nightly). Default: manual, reviewed — resolve in the plan.
+- **OQ2.** Whether to publish the forked `xk6-connectrpc` (and a telnet module)
+  as standalone repos or vendor them in-tree. Default: in-tree under
+  `test/load/xk6/` for P1; extract if they mature.
+<!-- adr-capture: sha256=6a5c35d269b4ad6b; session=cli; ts=2026-05-29T02:08:48Z; adrs=holomush-evggu -->


### PR DESCRIPTION
## Summary

Design-phase docs for a **full-system load/performance testing harness + SLOs** (design bead `holomush-ql7ef`). Docs-only; no implementation code in this PR.

Lands the spec, the implementation plan, and two ADRs so that subagents/sessions implementing the plan read canonical context from `main`.

## What's here

| Artifact | Path |
| --- | --- |
| Design spec | `docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md` |
| Implementation plan (16 tasks / 3 phases) | `docs/superpowers/plans/2026-05-28-load-perf-testing-harness.md` |
| ADR — k6 + custom xk6 binary tooling | `docs/adr/holomush-evggu-use-k6-custom-xk6-binary-full-system-load-testing.md` |
| ADR — isolate xk6 extensions in a separate Go module | `docs/adr/holomush-2344h-isolate-xk6-extensions-separate-go-module.md` |

## Design highlights

- **Tooling:** k6 + a custom `xk6 build` binary bundling `xk6-connectrpc` (exact Connect-protocol web tier) and an in-tree xk6 telnet module (raw TCP). Drives the real wire protocols against the full Dockerized binary; thresholds are the SLO gate; results stream to the existing Prometheus/Grafana stack.
- **SLOs:** comms-split headline (1a say→broadcast, 1b page/whisper→delivery) + command-ack, history, error-rate, connect+auth, throughput, and soak-stability (goroutine/RSS/audit-lag). Provisional targets calibrate from the first nightly baseline (110%-of-baseline regression gate, mirroring `check-benchmark-regression.sh`).
- **Scenario:** comms-heavy (~80%) using only real registered commands (`say`/`pose`/`emit`/`ooc`/`page`/`whisper` + `examine`); scene-based occupancy (no `move` command); history via the `WebQueryStreamHistory` RPC. Idle-heavy pacing; fixed RNG seed for determinism.
- **Invariants:** 8 numbered RFC2119 invariants (INV-LOAD-1..8), each with a test obligation; build-time meta-tests for exit-discipline, pr-prep exclusion, and verb-registration.
- **Rollout:** P1 MVP (gated on a de-risk spike vetting `xk6-connectrpc` server-streaming), P2 full mix + dashboards + docs, P3 ceiling + endurance soak.

## Review trail

- `design-reviewer`: READY (2 rounds)
- `plan-reviewer`: READY (3 rounds) — caught the real command-set grounding (look/move/recall aren't commands; directed = page/whisper; scene-based occupancy; guest-auth via `WebSelectCharacter`)

Full grounding + reviewer audit trail on `holomush-ql7ef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
