### PR TITLE
test(scenes): deterministic ULID ordering in ReadSceneLogForSnapshot (holomush-ag0b0)

### DIFF
--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -2402,9 +2402,15 @@ var _ = Describe("Publish store — ReadSceneLogForSnapshot", func() {
 		subject := "events.main.scene.scene-snaplog-1.ic"
 
 		// scene_log.timestamp is BIGINT epoch-nanos (INV-TS-1, migration 000007).
-		// ulid.Make() is monotonic, so insertion order == ORDER BY id ASC.
+		// Ordering is by id ASC, so make the ids deterministically increasing:
+		// a strictly-monotonic time component with zero entropy guarantees
+		// insertion order == ORDER BY id ASC by construction, without depending
+		// on ulid.Make()'s wall-clock + global monotonic entropy source.
+		var seq uint64
 		insertLog := func(subj, eventType string) {
-			id := ulid.Make()
+			seq++
+			var id ulid.ULID
+			Expect(id.SetTime(seq)).NotTo(HaveOccurred())
 			_, err := store.pool.Exec(ctx, `
 				INSERT INTO scene_log (id, subject, type, timestamp, actor_kind, payload, schema_ver, codec)
 				VALUES ($1, $2, $3, (EXTRACT(EPOCH FROM now()) * 1e9)::BIGINT, 'character', $4, 1, 'identity')`,


### PR DESCRIPTION
## Summary

Makes the `ReadSceneLogForSnapshot` integration test's ULID ordering deterministic. Previously the test seeded `scene_log` rows with `ulid.Make()`, whose ordering relied on the wall clock plus a process-global monotonic entropy source — an implementation detail that made the `ORDER BY id ASC` assertion fragile (CodeRabbit finding #7 on PR #4279, deferred as out-of-scope polish).

The inserts now build ids via `ULID.SetTime(seq)` with a strictly-increasing counter and zero entropy, so insertion order == `ORDER BY id ASC` by construction — no RNG, no wall clock.

## Scope

- Test-only change; no production impact.
- Single file: `plugins/core-scenes/store_integration_test.go`.

## Verification

- `task test:int -- -run TestCoreScenesIntegration ./plugins/core-scenes/` — green (focused spec + full package suite).
- `task pr-prep` (fast lane) — `status=pass`.

Closes holomush-ag0b0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)