### PR TITLE
fix(focus): unify focus-delta coordinator — binary prod fix + Lua parity (holomush-66228)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,12 @@ jobs:
     name: E2E Test
     runs-on: namespace-profile-linux-amd64-4x8
     needs: [test]
+    # web:generate (via docker:build:cover) runs `buf generate`, which pulls
+    # the remote BSR plugins (buf.build/bufbuild/es, buf.build/connectrpc/es).
+    # Authenticate so it uses the token's BSR rate limit, not the anonymous one
+    # that was failing with resource_exhausted (holomush-k1kb).
+    env:
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -234,6 +240,11 @@ jobs:
     name: Build
     runs-on: namespace-profile-linux-amd64-2x4
     needs: [lint, test, integration, e2e]
+    # `task build` embeds the web client (web:generate → `buf generate`), which
+    # pulls remote BSR plugins; authenticate to avoid the anonymous rate limit
+    # (holomush-k1kb).
+    env:
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -441,11 +441,9 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 		holoFocus.WithPlayerPreferences(holoFocus.NewPlayerPrefsAdapter(authPlayerRepo)),
 		holoFocus.WithStreamContributor(&focusStreamContributorAdapter{pm: pluginManager}),
 	}
+	focusCoordOpts = append(focusCoordOpts, holoFocus.WithGameID(s.cfg.EventBus.GameID()))
 	if s.cfg.StreamRegistry != nil {
-		focusCoordOpts = append(
-			focusCoordOpts,
-			holoFocus.WithStreamSender(holoGRPC.NewStreamSenderAdapter(s.cfg.StreamRegistry)),
-		)
+		focusCoordOpts = append(focusCoordOpts, holoGRPC.FocusStreamCoordinatorOptions(s.cfg.StreamRegistry)...)
 	}
 	focusCoord, focusErr := holoFocus.NewCoordinator(focusCoordOpts...)
 	if focusErr != nil {

--- a/internal/grpc/focus/auto_focus_on_join.go
+++ b/internal/grpc/focus/auto_focus_on_join.go
@@ -100,6 +100,12 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 		TotalConnectionCount: uint32(len(conns)), //nolint:gosec // conn count is bounded by active connections per session
 	}
 
+	// Connections transitioning grid→scene this call — the only ones that need
+	// a subscription delta. A connection already focused on this scene re-enters
+	// "focused" but its streams are unchanged, so it is deliberately excluded
+	// (see the driveFocusDeltas call below).
+	var deltaConns []ulid.ULID
+
 	// Step 3 + 4: filter and mutate each terminal/telnet connection.
 	for _, conn := range conns {
 		if !isTerminalLike(conn.ClientType) {
@@ -111,6 +117,10 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 
 		// Track which bucket this connection ends in, set inside the mutator.
 		var outcome string // "focused" | "skipped" | "membership_absent"
+		// Whether this connection was on the grid (no FocusKey) before the
+		// mutation. Only grid→scene transitions need a subscription delta;
+		// a connection already focused on this scene keeps its streams.
+		var wasOnGrid bool
 
 		m := session.NewSessionConnectionMutator(
 			func(info session.Info, conn session.Connection) (session.Info, session.Connection, error) {
@@ -120,6 +130,10 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 					outcome = "skipped"
 					return info, conn, nil // no-op; UpdateSessionConnection commits this unchanged
 				}
+				// Reaching here, conn.FocusKey is either nil (grid) or already
+				// == target (re-focus on the same scene). Capture it before we
+				// overwrite, so the delta step can skip the no-op re-focus.
+				wasOnGrid = conn.FocusKey == nil
 
 				// INV-P5-1: scene focus requires a matching FocusMembership.
 				if !hasMembership(info.FocusMemberships, target.Kind, target.TargetID) {
@@ -172,6 +186,11 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 		switch outcome {
 		case "focused":
 			resp.FocusedConnectionIDs = append(resp.FocusedConnectionIDs, connID)
+			if wasOnGrid {
+				// Only a genuine grid→scene transition needs a delta; a
+				// re-focus on the same scene leaves the stream set unchanged.
+				deltaConns = append(deltaConns, connID)
+			}
 		case "skipped":
 			resp.SkippedConnectionIDs = append(resp.SkippedConnectionIDs, connID)
 		}
@@ -179,16 +198,16 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 	}
 
 	// INV-FS-1: drive per-connection subscription deltas at the common path.
-	// We pass nil as the old FocusKey (grid) for every focused connection.
-	// D8/INV-P5-11 (line ~119) only skips connections focused on a DIFFERENT
-	// target, so a newly-grid→scene connection gets the correct add(scene)+
-	// remove(location) delta. A connection already focused on this SAME scene
-	// also lands in FocusedConnectionIDs (it falls through the skip unchanged);
-	// for it the grid→scene delta is redundant but idempotent — SendToConnection
-	// re-adds streams it already holds and removes a location stream it already
-	// dropped, both no-ops at the registry (best-effort, INV-FS-8).
+	// deltaConns holds only connections that actually moved grid→scene this
+	// call, so passing nil as the old FocusKey (grid) is correct for every one
+	// of them: each gets the add(scene)+remove(location) delta exactly once.
+	// A connection already focused on this SAME scene is excluded — its stream
+	// set is unchanged, and re-driving a grid→scene delta would otherwise issue
+	// a redundant scene re-add (which carries ReplayModeFromCursor and could
+	// replay scene history again) plus a remove of a location stream it no
+	// longer holds (holomush-fqv8z review finding).
 	sceneFk := &session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID}
-	c.driveFocusDeltas(ctx, resp.SessionID, resp.CharLocationID, nil, sceneFk, resp.FocusedConnectionIDs)
+	c.driveFocusDeltas(ctx, resp.SessionID, resp.CharLocationID, nil, sceneFk, deltaConns)
 
 	return resp, nil
 }

--- a/internal/grpc/focus/auto_focus_on_join.go
+++ b/internal/grpc/focus/auto_focus_on_join.go
@@ -14,15 +14,18 @@ import (
 )
 
 // AutoFocusOnJoinResponse carries the fan-out result from AutoFocusOnJoin.
-// T18 translates this to the wire format (PluginHostServiceAutoFocusOnJoinResponse).
+// The binary plugin host translates this to the wire format
+// (PluginHostServiceAutoFocusOnJoinResponse).
 type AutoFocusOnJoinResponse struct {
-	// SessionID is the session that owns the auto-focused connections. Used by
-	// the T18 RPC handler to route SendToConnection calls without a second
-	// store round-trip. Empty when SESSION_NOT_FOUND (no active session).
+	// SessionID is the session that owns the auto-focused connections. Consumed
+	// by focus.Coordinator.driveFocusDeltas to route SendToConnection calls
+	// without a second store round-trip (INV-FS-1). Empty when SESSION_NOT_FOUND
+	// (no active session).
 	SessionID string
-	// CharLocationID is the session's LocationID at mutation time. Used by
-	// the T18 RPC handler to compute grid stream names for subscription
-	// delta routing (location:<charLocationID> for grid-focused connections).
+	// CharLocationID is the session's LocationID at mutation time. Consumed by
+	// focus.Coordinator.driveFocusDeltas to compute grid stream names for
+	// subscription delta routing (location:<charLocationID> for grid-focused
+	// connections).
 	CharLocationID ulid.ULID
 	// FocusedConnectionIDs are connections that were successfully auto-focused.
 	FocusedConnectionIDs []ulid.ULID
@@ -176,8 +179,14 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 	}
 
 	// INV-FS-1: drive per-connection subscription deltas at the common path.
-	// Focused conns were on grid before this call (INV-P5-11 skips already-focused
-	// conns), so the old stream set is the grid/location set (nil FocusKey).
+	// We pass nil as the old FocusKey (grid) for every focused connection.
+	// D8/INV-P5-11 (line ~119) only skips connections focused on a DIFFERENT
+	// target, so a newly-grid→scene connection gets the correct add(scene)+
+	// remove(location) delta. A connection already focused on this SAME scene
+	// also lands in FocusedConnectionIDs (it falls through the skip unchanged);
+	// for it the grid→scene delta is redundant but idempotent — SendToConnection
+	// re-adds streams it already holds and removes a location stream it already
+	// dropped, both no-ops at the registry (best-effort, INV-FS-8).
 	sceneFk := &session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID}
 	c.driveFocusDeltas(ctx, resp.SessionID, resp.CharLocationID, nil, sceneFk, resp.FocusedConnectionIDs)
 

--- a/internal/grpc/focus/auto_focus_on_join.go
+++ b/internal/grpc/focus/auto_focus_on_join.go
@@ -175,5 +175,11 @@ func (c *defaultCoordinator) AutoFocusOnJoin(
 		// outcome == "membership_absent" is handled in the error path above.
 	}
 
+	// INV-FS-1: drive per-connection subscription deltas at the common path.
+	// Focused conns were on grid before this call (INV-P5-11 skips already-focused
+	// conns), so the old stream set is the grid/location set (nil FocusKey).
+	sceneFk := &session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID}
+	c.driveFocusDeltas(ctx, resp.SessionID, resp.CharLocationID, nil, sceneFk, resp.FocusedConnectionIDs)
+
 	return resp, nil
 }

--- a/internal/grpc/focus/coordinator.go
+++ b/internal/grpc/focus/coordinator.go
@@ -123,8 +123,10 @@ type SetConnectionFocusResult struct {
 type defaultCoordinator struct {
 	sessionStore      session.Store
 	streamSender      StreamSender
+	connectionSender  ConnectionSender
 	streamContributor StreamContributor
 	policies          map[session.FocusKind]KindPolicy
+	gameID            string
 
 	// Settings stores for preference resolution.
 	gameSettings      settings.Settings
@@ -146,6 +148,20 @@ func WithSessionStore(store session.Store) CoordinatorOption {
 // WithStreamSender sets the stream sender.
 func WithStreamSender(sender StreamSender) CoordinatorOption {
 	return func(c *defaultCoordinator) { c.streamSender = sender }
+}
+
+// WithConnectionSender sets the per-Connection stream sender used to deliver
+// focus-driven subscription deltas (INV-FS-1: the coordinator is the sole
+// driver). A nil sender disables per-connection delta delivery (best-effort).
+func WithConnectionSender(sender ConnectionSender) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.connectionSender = sender }
+}
+
+// WithGameID sets the game ID used to compute focus-managed scene stream
+// names (events.<gameID>.scene.<id>.{ic,ooc}). Empty defaults to "main" at
+// the call site of ComputeFocusManagedStreams' caller.
+func WithGameID(gameID string) CoordinatorOption {
+	return func(c *defaultCoordinator) { c.gameID = gameID }
 }
 
 // WithKindPolicy registers a KindPolicy for its kind.

--- a/internal/grpc/focus/coordinator.go
+++ b/internal/grpc/focus/coordinator.go
@@ -73,9 +73,10 @@ type Coordinator interface {
 	// (D9-gated) Info.PresentingFocus atomically under one Store-lock
 	// acquisition. Pins INV-P5-1 (FocusMemberships gate on scene targets)
 	// and INV-P5-13 (scene grid preserves PresentingFocus). Returns
-	// SetConnectionFocusResult so the RPC handler (T18) can compute
-	// subscription deltas via ComputeFocusManagedStreams + StreamDeltas +
-	// SendToConnection without a second store round-trip.
+	// SetConnectionFocusResult so the coordinator itself can drive
+	// per-connection subscription deltas via ComputeFocusManagedStreams +
+	// StreamDeltas + SendToConnection without a second store round-trip
+	// (INV-FS-1, see driveFocusDeltas).
 	// isSceneGrid=true MUST NOT touch Info.PresentingFocus.
 	SetConnectionFocus(
 		ctx context.Context,
@@ -104,8 +105,8 @@ type RestorePlan struct {
 }
 
 // SetConnectionFocusResult carries the outputs of a SetConnectionFocus call
-// needed by the T18 RPC handler to compute per-Connection subscription deltas
-// without a second store round-trip.
+// consumed by focus.Coordinator.driveFocusDeltas to compute per-Connection
+// subscription deltas without a second store round-trip (INV-FS-1).
 type SetConnectionFocusResult struct {
 	// OldFocusKey is the Connection.FocusKey value captured before the mutation.
 	// Nil means the connection was on the grid (no prior explicit focus).
@@ -158,8 +159,10 @@ func WithConnectionSender(sender ConnectionSender) CoordinatorOption {
 }
 
 // WithGameID sets the game ID used to compute focus-managed scene stream
-// names (events.<gameID>.scene.<id>.{ic,ooc}). Empty defaults to "main" at
-// the call site of ComputeFocusManagedStreams' caller.
+// names (events.<gameID>.scene.<id>.{ic,ooc}). An empty string is treated as
+// the default game "main", applied inside driveFocusDeltas. Production always
+// supplies a concrete game id (cmd/holomush wires s.cfg.EventBus.GameID());
+// the empty default exists for tests that don't set one.
 func WithGameID(gameID string) CoordinatorOption {
 	return func(c *defaultCoordinator) { c.gameID = gameID }
 }

--- a/internal/grpc/focus/focus_delta.go
+++ b/internal/grpc/focus/focus_delta.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// driveFocusDeltas computes the per-connection subscription delta from
+// oldFK→newFK and delivers it to each connection via the coordinator's
+// ConnectionSender. This is the single common-path driver for BOTH plugin
+// runtimes (INV-FS-1): the binary RPC handler and the Lua hostfunc adapter
+// both reach it through AutoFocusOnJoin / SetConnectionFocus.
+//
+// Best-effort and non-fatal (INV-FS-8): a delivery failure is logged but never
+// fails the focus mutation, and one connection's failure does not abort the
+// rest. A nil connectionSender (e.g. tests / deployments without a registry)
+// skips delivery — preserving the holomush-y5inx.9 nil-skip behavior, now
+// uniformly for both runtimes.
+func (c *defaultCoordinator) driveFocusDeltas(
+	ctx context.Context,
+	sessionID string,
+	charLocationID ulid.ULID,
+	oldFK, newFK *session.FocusKey,
+	conns []ulid.ULID,
+) {
+	if c.connectionSender == nil || sessionID == "" || len(conns) == 0 {
+		return
+	}
+	gameID := c.gameID
+	if gameID == "" {
+		gameID = "main"
+	}
+	oldStreams := ComputeFocusManagedStreams(oldFK, charLocationID, gameID)
+	newStreams := ComputeFocusManagedStreams(newFK, charLocationID, gameID)
+	adds, removes := StreamDeltas(oldStreams, newStreams)
+	for _, connID := range conns {
+		for _, stream := range adds {
+			if err := c.connectionSender.SendToConnection(sessionID, connID, stream, true); err != nil {
+				slog.WarnContext(ctx, "focus delta add delivery failed",
+					"session_id", sessionID, "connection_id", connID.String(),
+					"stream", stream, "error", err)
+			}
+		}
+		for _, stream := range removes {
+			if err := c.connectionSender.SendToConnection(sessionID, connID, stream, false); err != nil {
+				slog.WarnContext(ctx, "focus delta remove delivery failed",
+					"session_id", sessionID, "connection_id", connID.String(),
+					"stream", stream, "error", err)
+			}
+		}
+	}
+}

--- a/internal/grpc/focus/focus_delta_test.go
+++ b/internal/grpc/focus/focus_delta_test.go
@@ -60,6 +60,49 @@ func (s *captureConnSender) removes() []string {
 	return out
 }
 
+func TestSetConnectionFocusDrivesPerConnectionDeltas(t *testing.T) {
+	charID := ulid.Make()
+	sceneA := ulid.Make()
+	sceneB := ulid.Make()
+	locID := ulid.Make()
+	connID := ulid.Make()
+
+	fkA := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneA}
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID:          "sess-1",
+			CharacterID: charID,
+			LocationID:  locID,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneA, JoinedAt: time.Now()},
+				{Kind: session.FocusKindScene, TargetID: sceneB, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions)
+	cs := &captureConnSender{}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+
+	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+		ID: connID, SessionID: "sess-1", ClientType: "terminal", FocusKey: &fkA,
+	}))
+
+	// scene A → scene B: remove A's IC/OOC, add B's IC/OOC.
+	fkB := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneB}
+	_, err := coord.SetConnectionFocus(context.Background(), connID, &fkB, false)
+	require.NoError(t, err)
+
+	a := sceneA.String()
+	b := sceneB.String()
+	assert.ElementsMatch(t, []string{
+		"events.main.scene." + b + ".ic", "events.main.scene." + b + ".ooc",
+	}, cs.adds(), "scene→scene MUST add the new scene's streams")
+	assert.ElementsMatch(t, []string{
+		"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc",
+	}, cs.removes(), "scene→scene MUST remove the old scene's streams (from OldFocusKey)")
+}
+
 func TestAutoFocusOnJoinDrivesPerConnectionDeltas(t *testing.T) {
 	charID := ulid.Make()
 	sceneID := ulid.Make()

--- a/internal/grpc/focus/focus_delta_test.go
+++ b/internal/grpc/focus/focus_delta_test.go
@@ -5,6 +5,7 @@ package focus
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -144,4 +145,72 @@ func TestAutoFocusOnJoinDrivesPerConnectionDeltas(t *testing.T) {
 		"events.main.scene." + scene + ".ooc",
 	}, cs.adds(), "grid→scene MUST add scene IC + OOC")
 	assert.ElementsMatch(t, []string{"location:" + loc}, cs.removes(), "grid→scene MUST remove the location stream")
+}
+
+func TestAutoFocusOnJoinNilSenderIsNoOp(t *testing.T) {
+	charID := ulid.Make()
+	sceneID := ulid.Make()
+	locID := ulid.Make()
+	connID := ulid.Make()
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID: "sess-1", CharacterID: charID, LocationID: locID,
+			Status: session.StatusActive,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions) // connectionSender stays nil
+	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+		ID: connID, SessionID: "sess-1", ClientType: "terminal",
+	}))
+	// Must not panic; focus mutation still succeeds.
+	resp, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneID)
+	require.NoError(t, err)
+	assert.Len(t, resp.FocusedConnectionIDs, 1)
+}
+
+func TestDriveFocusDeltasContinuesPastSendError(t *testing.T) {
+	charID := ulid.Make()
+	sceneID := ulid.Make()
+	locID := ulid.Make()
+	connID := ulid.Make()
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID: "sess-1", CharacterID: charID, LocationID: locID,
+			Status: session.StatusActive,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions)
+	scene := sceneID.String()
+	// Fail the IC add; the OOC add and the location remove must still be attempted.
+	cs := &captureConnSender{errOn: map[string]error{
+		"events.main.scene." + scene + ".ic": errors.New("CONNECTION_NOT_REGISTERED"),
+	}}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+		ID: connID, SessionID: "sess-1", ClientType: "terminal",
+	}))
+
+	resp, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneID)
+	require.NoError(t, err, "delivery failure MUST NOT fail the focus mutation")
+	require.Len(t, resp.FocusedConnectionIDs, 1)
+	// All three deltas attempted despite the IC failure.
+	assert.Len(t, cs.calls, 3, "one failing send MUST NOT abort the remaining sends")
+}
+
+func TestAutoFocusOnJoinSessionNotFoundDrivesNoDeltas(t *testing.T) {
+	coord, _ := newTestCoordinator(t, map[string]*session.Info{})
+	cs := &captureConnSender{}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+	resp, err := coord.AutoFocusOnJoin(context.Background(), ulid.Make(), ulid.Make())
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), resp.TotalConnectionCount)
+	assert.Empty(t, cs.calls, "no session → no deltas")
 }

--- a/internal/grpc/focus/focus_delta_test.go
+++ b/internal/grpc/focus/focus_delta_test.go
@@ -214,3 +214,100 @@ func TestAutoFocusOnJoinSessionNotFoundDrivesNoDeltas(t *testing.T) {
 	assert.Equal(t, uint32(0), resp.TotalConnectionCount)
 	assert.Empty(t, cs.calls, "no session → no deltas")
 }
+
+func TestSetConnectionFocusSceneToGridDrivesPerConnectionDeltas(t *testing.T) {
+	charID := ulid.Make()
+	sceneA := ulid.Make()
+	locID := ulid.Make()
+	connID := ulid.Make()
+
+	fkA := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneA}
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID:          "sess-1",
+			CharacterID: charID,
+			LocationID:  locID,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneA, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions)
+	cs := &captureConnSender{}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+
+	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+		ID: connID, SessionID: "sess-1", ClientType: "terminal", FocusKey: &fkA,
+	}))
+
+	// scene A → grid: remove A's IC/OOC, add the location stream. Exercises
+	// driveFocusDeltas with newFK=nil against a LIVE connectionSender (the
+	// removal path that TestSceneGrid_DoesNotClearPresentingFocus leaves nil).
+	_, err := coord.SetConnectionFocus(context.Background(), connID, nil, true)
+	require.NoError(t, err)
+
+	a := sceneA.String()
+	loc := locID.String()
+	assert.ElementsMatch(t, []string{"location:" + loc}, cs.adds(),
+		"scene→grid MUST add the location stream")
+	assert.ElementsMatch(t, []string{
+		"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc",
+	}, cs.removes(), "scene→grid MUST remove the old scene's streams (from OldFocusKey)")
+}
+
+func TestAutoFocusOnJoinFansOutDeltasToAllConnections(t *testing.T) {
+	charID := ulid.Make()
+	sceneID := ulid.Make()
+	locID := ulid.Make()
+	conn1 := ulid.Make()
+	conn2 := ulid.Make()
+
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID: "sess-1", CharacterID: charID, LocationID: locID,
+			Status: session.StatusActive,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions)
+	cs := &captureConnSender{}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+
+	for _, id := range []ulid.ULID{conn1, conn2} {
+		require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+			ID: id, SessionID: "sess-1", ClientType: "terminal",
+		}))
+	}
+
+	resp, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneID)
+	require.NoError(t, err)
+	require.Len(t, resp.FocusedConnectionIDs, 2, "both terminal connections auto-focus")
+
+	scene := sceneID.String()
+	loc := locID.String()
+	// Each connection independently receives the full grid→scene delta — proves
+	// the per-connection fan-out loop in driveFocusDeltas reaches every conn.
+	for _, id := range []ulid.ULID{conn1, conn2} {
+		var adds, removes []string
+		for _, c := range cs.calls {
+			if c.connectionID != id {
+				continue
+			}
+			assert.Equal(t, "sess-1", c.sessionID)
+			if c.add {
+				adds = append(adds, c.stream)
+			} else {
+				removes = append(removes, c.stream)
+			}
+		}
+		assert.ElementsMatch(t, []string{
+			"events.main.scene." + scene + ".ic", "events.main.scene." + scene + ".ooc",
+		}, adds, "each connection MUST get scene IC + OOC")
+		assert.ElementsMatch(t, []string{"location:" + loc}, removes,
+			"each connection MUST drop the location stream")
+	}
+}

--- a/internal/grpc/focus/focus_delta_test.go
+++ b/internal/grpc/focus/focus_delta_test.go
@@ -61,90 +61,108 @@ func (s *captureConnSender) removes() []string {
 	return out
 }
 
-func TestSetConnectionFocusDrivesPerConnectionDeltas(t *testing.T) {
+// TestCoordinatorDrivesPerConnectionDeltas is the table-driven matrix of
+// single-connection focus transitions and the streams each must add/remove.
+// Behavioural edge cases (nil sender, send-error continuation, session-not-
+// found, multi-connection fan-out) keep their own focused tests below, since
+// they assert delivery semantics rather than the add/remove delta itself.
+func TestCoordinatorDrivesPerConnectionDeltas(t *testing.T) {
 	charID := ulid.Make()
 	sceneA := ulid.Make()
 	sceneB := ulid.Make()
 	locID := ulid.Make()
 	connID := ulid.Make()
-
+	a, b, loc := sceneA.String(), sceneB.String(), locID.String()
 	fkA := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneA}
-	sessions := map[string]*session.Info{
-		"sess-1": {
-			ID:          "sess-1",
-			CharacterID: charID,
-			LocationID:  locID,
-			FocusMemberships: []session.FocusMembership{
-				{Kind: session.FocusKindScene, TargetID: sceneA, JoinedAt: time.Now()},
-				{Kind: session.FocusKindScene, TargetID: sceneB, JoinedAt: time.Now()},
+
+	memberships := []session.FocusMembership{
+		{Kind: session.FocusKindScene, TargetID: sceneA, JoinedAt: time.Now()},
+		{Kind: session.FocusKindScene, TargetID: sceneB, JoinedAt: time.Now()},
+	}
+
+	tests := []struct {
+		name        string
+		connFK      *session.FocusKey // connection's focus before the call (nil = grid)
+		invoke      func(coord *defaultCoordinator) error
+		wantAdds    []string
+		wantRemoves []string
+	}{
+		{
+			name:   "SetConnectionFocus scene→scene adds the new scene's streams and removes the old",
+			connFK: &fkA,
+			invoke: func(coord *defaultCoordinator) error {
+				fkB := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneB}
+				_, err := coord.SetConnectionFocus(context.Background(), connID, &fkB, false)
+				return err
 			},
+			wantAdds:    []string{"events.main.scene." + b + ".ic", "events.main.scene." + b + ".ooc"},
+			wantRemoves: []string{"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc"},
+		},
+		{
+			name:   "SetConnectionFocus scene→grid adds the location stream and removes the scene streams",
+			connFK: &fkA,
+			invoke: func(coord *defaultCoordinator) error {
+				_, err := coord.SetConnectionFocus(context.Background(), connID, nil, true)
+				return err
+			},
+			wantAdds:    []string{"location:" + loc},
+			wantRemoves: []string{"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc"},
+		},
+		{
+			name:   "AutoFocusOnJoin grid→scene adds the scene streams and removes the location stream",
+			connFK: nil,
+			invoke: func(coord *defaultCoordinator) error {
+				_, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneA)
+				return err
+			},
+			wantAdds:    []string{"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc"},
+			wantRemoves: []string{"location:" + loc},
+		},
+		{
+			// holomush-fqv8z review finding: a connection already focused on
+			// the target scene re-enters "focused" but its stream set is
+			// unchanged, so it MUST NOT receive a redundant grid→scene delta.
+			name:   "AutoFocusOnJoin re-focus on the same scene drives no delta",
+			connFK: &fkA,
+			invoke: func(coord *defaultCoordinator) error {
+				_, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneA)
+				return err
+			},
+			wantAdds:    nil,
+			wantRemoves: nil,
 		},
 	}
-	coord, _ := newTestCoordinator(t, sessions)
-	cs := &captureConnSender{}
-	coord.connectionSender = cs
-	coord.gameID = "main"
 
-	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
-		ID: connID, SessionID: "sess-1", ClientType: "terminal", FocusKey: &fkA,
-	}))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessions := map[string]*session.Info{
+				"sess-1": {
+					ID:               "sess-1",
+					CharacterID:      charID,
+					LocationID:       locID,
+					Status:           session.StatusActive,
+					FocusMemberships: memberships,
+				},
+			}
+			coord, _ := newTestCoordinator(t, sessions)
+			cs := &captureConnSender{}
+			coord.connectionSender = cs
+			coord.gameID = "main"
 
-	// scene A → scene B: remove A's IC/OOC, add B's IC/OOC.
-	fkB := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneB}
-	_, err := coord.SetConnectionFocus(context.Background(), connID, &fkB, false)
-	require.NoError(t, err)
+			require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+				ID: connID, SessionID: "sess-1", ClientType: "terminal", FocusKey: tt.connFK,
+			}))
 
-	a := sceneA.String()
-	b := sceneB.String()
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + b + ".ic", "events.main.scene." + b + ".ooc",
-	}, cs.adds(), "scene→scene MUST add the new scene's streams")
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc",
-	}, cs.removes(), "scene→scene MUST remove the old scene's streams (from OldFocusKey)")
-}
+			require.NoError(t, tt.invoke(coord))
 
-func TestAutoFocusOnJoinDrivesPerConnectionDeltas(t *testing.T) {
-	charID := ulid.Make()
-	sceneID := ulid.Make()
-	locID := ulid.Make()
-	termConnID := ulid.Make()
-
-	sessions := map[string]*session.Info{
-		"sess-1": {
-			ID:          "sess-1",
-			CharacterID: charID,
-			LocationID:  locID,
-			Status:      session.StatusActive,
-			FocusMemberships: []session.FocusMembership{
-				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: time.Now()},
-			},
-		},
+			for _, c := range cs.calls {
+				assert.Equal(t, "sess-1", c.sessionID, "every delta targets the connection's session")
+				assert.Equal(t, connID, c.connectionID, "every delta targets the one connection")
+			}
+			assert.ElementsMatch(t, tt.wantAdds, cs.adds(), "delta adds")
+			assert.ElementsMatch(t, tt.wantRemoves, cs.removes(), "delta removes")
+		})
 	}
-	coord, _ := newTestCoordinator(t, sessions)
-	cs := &captureConnSender{}
-	coord.connectionSender = cs
-	coord.gameID = "main"
-
-	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
-		ID: termConnID, SessionID: "sess-1", ClientType: "terminal",
-	}))
-
-	resp, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneID)
-	require.NoError(t, err)
-	require.Len(t, resp.FocusedConnectionIDs, 1)
-
-	scene := sceneID.String()
-	loc := locID.String()
-	for _, c := range cs.calls {
-		assert.Equal(t, "sess-1", c.sessionID)
-		assert.Equal(t, termConnID, c.connectionID)
-	}
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + scene + ".ic",
-		"events.main.scene." + scene + ".ooc",
-	}, cs.adds(), "grid→scene MUST add scene IC + OOC")
-	assert.ElementsMatch(t, []string{"location:" + loc}, cs.removes(), "grid→scene MUST remove the location stream")
 }
 
 func TestAutoFocusOnJoinNilSenderIsNoOp(t *testing.T) {
@@ -213,47 +231,6 @@ func TestAutoFocusOnJoinSessionNotFoundDrivesNoDeltas(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), resp.TotalConnectionCount)
 	assert.Empty(t, cs.calls, "no session → no deltas")
-}
-
-func TestSetConnectionFocusSceneToGridDrivesPerConnectionDeltas(t *testing.T) {
-	charID := ulid.Make()
-	sceneA := ulid.Make()
-	locID := ulid.Make()
-	connID := ulid.Make()
-
-	fkA := session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneA}
-	sessions := map[string]*session.Info{
-		"sess-1": {
-			ID:          "sess-1",
-			CharacterID: charID,
-			LocationID:  locID,
-			FocusMemberships: []session.FocusMembership{
-				{Kind: session.FocusKindScene, TargetID: sceneA, JoinedAt: time.Now()},
-			},
-		},
-	}
-	coord, _ := newTestCoordinator(t, sessions)
-	cs := &captureConnSender{}
-	coord.connectionSender = cs
-	coord.gameID = "main"
-
-	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
-		ID: connID, SessionID: "sess-1", ClientType: "terminal", FocusKey: &fkA,
-	}))
-
-	// scene A → grid: remove A's IC/OOC, add the location stream. Exercises
-	// driveFocusDeltas with newFK=nil against a LIVE connectionSender (the
-	// removal path that TestSceneGrid_DoesNotClearPresentingFocus leaves nil).
-	_, err := coord.SetConnectionFocus(context.Background(), connID, nil, true)
-	require.NoError(t, err)
-
-	a := sceneA.String()
-	loc := locID.String()
-	assert.ElementsMatch(t, []string{"location:" + loc}, cs.adds(),
-		"scene→grid MUST add the location stream")
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + a + ".ic", "events.main.scene." + a + ".ooc",
-	}, cs.removes(), "scene→grid MUST remove the old scene's streams (from OldFocusKey)")
 }
 
 func TestAutoFocusOnJoinFansOutDeltasToAllConnections(t *testing.T) {

--- a/internal/grpc/focus/focus_delta_test.go
+++ b/internal/grpc/focus/focus_delta_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package focus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+)
+
+// connDelta is one captured SendToConnection call.
+type connDelta struct {
+	sessionID    string
+	connectionID ulid.ULID
+	stream       string
+	add          bool
+}
+
+// captureConnSender is a focus.ConnectionSender test double. errOn maps a
+// stream name to an error the sender returns for that stream (boundary tests).
+type captureConnSender struct {
+	calls []connDelta
+	errOn map[string]error
+}
+
+func (s *captureConnSender) SendToConnection(sessionID string, connectionID ulid.ULID, stream string, add bool) error {
+	s.calls = append(s.calls, connDelta{sessionID, connectionID, stream, add})
+	if s.errOn != nil {
+		if err, ok := s.errOn[stream]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *captureConnSender) adds() []string {
+	var out []string
+	for _, c := range s.calls {
+		if c.add {
+			out = append(out, c.stream)
+		}
+	}
+	return out
+}
+
+func (s *captureConnSender) removes() []string {
+	var out []string
+	for _, c := range s.calls {
+		if !c.add {
+			out = append(out, c.stream)
+		}
+	}
+	return out
+}
+
+func TestAutoFocusOnJoinDrivesPerConnectionDeltas(t *testing.T) {
+	charID := ulid.Make()
+	sceneID := ulid.Make()
+	locID := ulid.Make()
+	termConnID := ulid.Make()
+
+	sessions := map[string]*session.Info{
+		"sess-1": {
+			ID:          "sess-1",
+			CharacterID: charID,
+			LocationID:  locID,
+			Status:      session.StatusActive,
+			FocusMemberships: []session.FocusMembership{
+				{Kind: session.FocusKindScene, TargetID: sceneID, JoinedAt: time.Now()},
+			},
+		},
+	}
+	coord, _ := newTestCoordinator(t, sessions)
+	cs := &captureConnSender{}
+	coord.connectionSender = cs
+	coord.gameID = "main"
+
+	require.NoError(t, coord.sessionStore.AddConnection(context.Background(), &session.Connection{
+		ID: termConnID, SessionID: "sess-1", ClientType: "terminal",
+	}))
+
+	resp, err := coord.AutoFocusOnJoin(context.Background(), charID, sceneID)
+	require.NoError(t, err)
+	require.Len(t, resp.FocusedConnectionIDs, 1)
+
+	scene := sceneID.String()
+	loc := locID.String()
+	for _, c := range cs.calls {
+		assert.Equal(t, "sess-1", c.sessionID)
+		assert.Equal(t, termConnID, c.connectionID)
+	}
+	assert.ElementsMatch(t, []string{
+		"events.main.scene." + scene + ".ic",
+		"events.main.scene." + scene + ".ooc",
+	}, cs.adds(), "grid→scene MUST add scene IC + OOC")
+	assert.ElementsMatch(t, []string{"location:" + loc}, cs.removes(), "grid→scene MUST remove the location stream")
+}

--- a/internal/grpc/focus/set_connection_focus.go
+++ b/internal/grpc/focus/set_connection_focus.go
@@ -108,5 +108,10 @@ func (c *defaultCoordinator) SetConnectionFocus(
 		// even if a future mutator reorders captures above the error return.
 		return SetConnectionFocusResult{}, uerr //nolint:wrapcheck // store errors are already oops-coded
 	}
+	// INV-FS-1: drive the per-connection subscription delta at the common path.
+	// Old streams derive from the pre-mutation FocusKey (result.OldFocusKey;
+	// nil = grid), new streams from focusKey (the requested target; nil = grid).
+	c.driveFocusDeltas(ctx, result.SessionID, result.CharLocationID, result.OldFocusKey, focusKey, []ulid.ULID{connectionID})
+
 	return result, nil
 }

--- a/internal/grpc/focus/set_connection_focus.go
+++ b/internal/grpc/focus/set_connection_focus.go
@@ -38,9 +38,9 @@ import (
 //     Connection.FocusKey but leave PresentingFocus alone (D9 split-brain
 //     guard).
 //
-// Returns SetConnectionFocusResult so the RPC handler (T18) can compute
-// stream deltas via ComputeFocusManagedStreams + StreamDeltas + SendToConnection
-// without a second store round-trip. The pre-mutation FocusKey is captured
+// Returns SetConnectionFocusResult so the coordinator can drive stream deltas
+// via ComputeFocusManagedStreams + StreamDeltas + SendToConnection without a
+// second store round-trip (INV-FS-1, see driveFocusDeltas). The pre-mutation FocusKey is captured
 // inside the mutator closure via an outer-variable binding; on any error
 // path OldFocusKey returns nil so partial state cannot leak.
 func (c *defaultCoordinator) SetConnectionFocus(
@@ -80,8 +80,8 @@ func (c *defaultCoordinator) SetConnectionFocus(
 			}
 
 			// Capture pre-mutation conn.FocusKey for the post-commit
-			// subscription delta (T18). Copy by value to break aliasing
-			// with the (about-to-be-replaced) per-conn pointer.
+			// subscription delta (driveFocusDeltas). Copy by value to break
+			// aliasing with the (about-to-be-replaced) per-conn pointer.
 			if sc.FocusKey != nil {
 				cpy := *sc.FocusKey
 				result.OldFocusKey = &cpy

--- a/internal/grpc/focus/set_connection_focus_test.go
+++ b/internal/grpc/focus/set_connection_focus_test.go
@@ -73,8 +73,8 @@ func TestSetConnectionFocus_HappyPath(t *testing.T) {
 
 // TestSetConnectionFocus_HappyPath_ReturnsOldFocusKey verifies the
 // OldFocusKey-capture closure: when switching focus from scene A → B, the
-// returned old key matches A (T18 needs this to drive subscription_router
-// stream deltas).
+// returned old key matches A (the coordinator's driveFocusDeltas needs this to
+// drive subscription_router stream deltas).
 func TestSetConnectionFocus_HappyPath_ReturnsOldFocusKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/grpc/focus_wiring.go
+++ b/internal/grpc/focus_wiring.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import "github.com/holomush/holomush/internal/grpc/focus"
+
+// FocusStreamCoordinatorOptions is the SINGLE assembly point for the two
+// registry-derived focus.Coordinator senders (INV-FS-4): the session-wide
+// StreamSender and the per-Connection ConnectionSender, both backed by the
+// same SessionStreamRegistry. Production (cmd/holomush) and the integration
+// harness MUST build their coordinator stream wiring through this helper rather
+// than hand-rolling NewStreamSenderAdapter + NewConnectionSenderAdapter, so the
+// harness is a faithful production mirror by construction.
+func FocusStreamCoordinatorOptions(reg *SessionStreamRegistry) []focus.CoordinatorOption {
+	return []focus.CoordinatorOption{
+		focus.WithStreamSender(NewStreamSenderAdapter(reg)),
+		focus.WithConnectionSender(NewConnectionSenderAdapter(reg)),
+	}
+}

--- a/internal/grpc/focus_wiring_test.go
+++ b/internal/grpc/focus_wiring_test.go
@@ -15,24 +15,42 @@ import (
 
 // INV-FS-5: the StreamSender and ConnectionSender produced for one coordinator
 // MUST target the same SessionStreamRegistry. We prove it by routing through
-// both registry-derived adapters and asserting both reach the one registry.
+// each registry-derived adapter and asserting it reaches the one registry.
 func TestFocusStreamCoordinatorOptionsShareOneRegistry(t *testing.T) {
 	reg := NewSessionStreamRegistry()
-	opts := FocusStreamCoordinatorOptions(reg)
-	require.Len(t, opts, 2, "helper yields exactly StreamSender + ConnectionSender options")
+	require.Len(t, FocusStreamCoordinatorOptions(reg), 2,
+		"helper yields exactly StreamSender + ConnectionSender options")
 
 	sessionID := "sess-x"
 	connID := ulid.Make()
 
-	// Verify ConnectionSenderAdapter reaches the registry.
-	connCh := make(chan sessionStreamUpdate, 1)
-	reg.RegisterConnection(sessionID, connID, connCh)
-	require.NoError(t, NewConnectionSenderAdapter(reg).SendToConnection(sessionID, connID, "events.main.scene.s.ic", true))
-	assert.Len(t, connCh, 1, "ConnectionSender adapter MUST reach the same registry")
+	tests := []struct {
+		name     string
+		register func(ch chan sessionStreamUpdate) // wire a buffered channel into the registry
+		send     func() error                      // route one update through the adapter under test
+	}{
+		{
+			name:     "ConnectionSender adapter reaches the registry",
+			register: func(ch chan sessionStreamUpdate) { reg.RegisterConnection(sessionID, connID, ch) },
+			send: func() error {
+				return NewConnectionSenderAdapter(reg).SendToConnection(sessionID, connID, "events.main.scene.s.ic", true)
+			},
+		},
+		{
+			name:     "StreamSender adapter reaches the registry",
+			register: func(ch chan sessionStreamUpdate) { reg.Register(sessionID, ch) },
+			send: func() error {
+				return NewStreamSenderAdapter(reg).Send(sessionID, "location:x", true, focus.ReplayModeFromCursor)
+			},
+		},
+	}
 
-	// Verify StreamSenderAdapter reaches the registry.
-	sessCh := make(chan sessionStreamUpdate, 1)
-	reg.Register(sessionID, sessCh)
-	require.NoError(t, NewStreamSenderAdapter(reg).Send(sessionID, "location:x", true, focus.ReplayModeFromCursor))
-	assert.Len(t, sessCh, 1, "StreamSender adapter MUST reach the same registry")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan sessionStreamUpdate, 1)
+			tt.register(ch)
+			require.NoError(t, tt.send())
+			assert.Len(t, ch, 1, "adapter MUST reach the same registry")
+		})
+	}
 }

--- a/internal/grpc/focus_wiring_test.go
+++ b/internal/grpc/focus_wiring_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/grpc/focus"
+)
+
+// INV-FS-5: the StreamSender and ConnectionSender produced for one coordinator
+// MUST target the same SessionStreamRegistry. We prove it by routing through
+// both registry-derived adapters and asserting both reach the one registry.
+func TestFocusStreamCoordinatorOptionsShareOneRegistry(t *testing.T) {
+	reg := NewSessionStreamRegistry()
+	opts := FocusStreamCoordinatorOptions(reg)
+	require.Len(t, opts, 2, "helper yields exactly StreamSender + ConnectionSender options")
+
+	sessionID := "sess-x"
+	connID := ulid.Make()
+
+	// Verify ConnectionSenderAdapter reaches the registry.
+	connCh := make(chan sessionStreamUpdate, 1)
+	reg.RegisterConnection(sessionID, connID, connCh)
+	require.NoError(t, NewConnectionSenderAdapter(reg).SendToConnection(sessionID, connID, "events.main.scene.s.ic", true))
+	assert.Len(t, connCh, 1, "ConnectionSender adapter MUST reach the same registry")
+
+	// Verify StreamSenderAdapter reaches the registry.
+	sessCh := make(chan sessionStreamUpdate, 1)
+	reg.Register(sessionID, sessCh)
+	require.NoError(t, NewStreamSenderAdapter(reg).Send(sessionID, "location:x", true, focus.ReplayModeFromCursor))
+	assert.Len(t, sessCh, 1, "StreamSender adapter MUST reach the same registry")
+}

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -141,12 +141,6 @@ func WithFocusCoordinator(fc focus.Coordinator) HostOption {
 	return func(h *Host) { h.focusCoordinator = fc }
 }
 
-// WithConnectionSender configures the host with a per-Connection stream sender
-// for Phase 5 SetConnectionFocus / AutoFocusOnJoin subscription delta delivery.
-func WithConnectionSender(cs focus.ConnectionSender) HostOption {
-	return func(h *Host) { h.connectionSender = cs }
-}
-
 // WithHistoryReader configures the host with a history reader for
 // QueryStreamHistory RPCs.
 func WithHistoryReader(hr plugins.HistoryReader) HostOption {
@@ -208,7 +202,6 @@ type Host struct {
 	hostClientCert    *tlscerts.ClientCert
 	eventEmitter      plugins.PluginIntentEmitter
 	focusCoordinator  focus.Coordinator
-	connectionSender  focus.ConnectionSender
 	historyReader     plugins.HistoryReader
 	readbackDecryptor plugins.ReadbackDecryptor
 	identityRegistry  plugins.IdentityRegistry
@@ -337,22 +330,6 @@ func (h *Host) FocusCoordinator() focus.Coordinator {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.focusCoordinator
-}
-
-// SetConnectionSender injects the per-Connection stream sender after construction.
-// Same late-binding rationale as SetFocusCoordinator. Used for Phase 5
-// SetConnectionFocus / AutoFocusOnJoin subscription delta delivery.
-func (h *Host) SetConnectionSender(cs focus.ConnectionSender) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.connectionSender = cs
-}
-
-// ConnectionSender returns the current per-Connection stream sender, or nil if not set.
-func (h *Host) ConnectionSender() focus.ConnectionSender {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.connectionSender
 }
 
 // SetHistoryReader injects the history reader after construction.

--- a/internal/plugin/goplugin/host_service.go
+++ b/internal/plugin/goplugin/host_service.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus/cursor"
-	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
 	"github.com/holomush/holomush/internal/session"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
@@ -243,30 +242,11 @@ func (s *pluginHostServiceServer) SetConnectionFocus(ctx context.Context, req *p
 			Errorf("is_scene_grid=true is incompatible with a non-nil focus_key; supply one or the other")
 	}
 
-	result, err := fc.SetConnectionFocus(ctx, connID, focusKey, req.GetIsSceneGrid())
+	_, err = fc.SetConnectionFocus(ctx, connID, focusKey, req.GetIsSceneGrid())
 	if err != nil {
 		return nil, oops.With("plugin", s.pluginName).
 			With("connection_id", connID.String()).
 			Wrap(err)
-	}
-
-	// Drive subscription deltas via ConnectionSender if wired (T18, INV-P5-10).
-	// Best-effort: CONNECTION_NOT_REGISTERED means no live Subscribe goroutine.
-	cs := s.host.ConnectionSender()
-	if cs != nil {
-		gameID := s.host.gameID
-		if gameID == "" {
-			gameID = "main"
-		}
-		oldStreams := focus.ComputeFocusManagedStreams(result.OldFocusKey, result.CharLocationID, gameID)
-		newStreams := focus.ComputeFocusManagedStreams(focusKey, result.CharLocationID, gameID)
-		adds, removes := focus.StreamDeltas(oldStreams, newStreams)
-		for _, stream := range adds {
-			_ = cs.SendToConnection(result.SessionID, connID, stream, true) //nolint:errcheck // best-effort
-		}
-		for _, stream := range removes {
-			_ = cs.SendToConnection(result.SessionID, connID, stream, false) //nolint:errcheck // best-effort
-		}
 	}
 
 	// Echo back the new FocusKey (nil = grid).
@@ -307,31 +287,6 @@ func (s *pluginHostServiceServer) AutoFocusOnJoin(ctx context.Context, req *plug
 			With("character_id", charID.String()).
 			With("scene_id", sceneID.String()).
 			Wrap(err)
-	}
-
-	// Drive subscription deltas for each successfully focused connection.
-	// Focused connections were previously on grid (nil FocusKey — D8 ensures
-	// already-focused conns are skipped), so old streams = grid streams.
-	cs := s.host.ConnectionSender()
-	if cs != nil && len(r.FocusedConnectionIDs) > 0 && r.SessionID != "" {
-		gameID := s.host.gameID
-		if gameID == "" {
-			gameID = "main"
-		}
-		sceneFk := &session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID}
-		// Old streams for grid-focused connections are location streams.
-		oldStreams := focus.ComputeFocusManagedStreams(nil, r.CharLocationID, gameID)
-		newStreams := focus.ComputeFocusManagedStreams(sceneFk, r.CharLocationID, gameID)
-		adds, removes := focus.StreamDeltas(oldStreams, newStreams)
-		for _, cid := range r.FocusedConnectionIDs {
-			connIDCopy := cid // loop var safety
-			for _, stream := range adds {
-				_ = cs.SendToConnection(r.SessionID, connIDCopy, stream, true) //nolint:errcheck // best-effort
-			}
-			for _, stream := range removes {
-				_ = cs.SendToConnection(r.SessionID, connIDCopy, stream, false) //nolint:errcheck // best-effort
-			}
-		}
 	}
 
 	resp := &pluginv1.PluginHostServiceAutoFocusOnJoinResponse{

--- a/internal/plugin/goplugin/host_service_test.go
+++ b/internal/plugin/goplugin/host_service_test.go
@@ -1170,7 +1170,7 @@ func TestAutoFocusOnJoin_ReturnsResponseShape(t *testing.T) {
 			},
 		},
 	}
-	srv := newTestServer(fc, nil) // no ConnectionSender — best-effort skip
+	srv := newTestServer(fc, nil) // nil coordinator extras — best-effort skip
 
 	charIDBuf := charID.Bytes()
 	sceneIDBuf := sceneID.Bytes()

--- a/internal/plugin/goplugin/host_service_test.go
+++ b/internal/plugin/goplugin/host_service_test.go
@@ -1012,61 +1012,27 @@ func (failingReader) Read(_ []byte) (int, error) {
 
 var errFailingReader = oops.Errorf("simulated rand exhaustion")
 
-// stubConnectionSender records SendToConnection calls for assertion.
-type stubConnectionSender struct {
-	calls []connSendCall
-}
-
-type connSendCall struct {
-	sessionID    string
-	connectionID ulid.ULID
-	stream       string
-	add          bool
-}
-
-func (s *stubConnectionSender) SendToConnection(sessionID string, connectionID ulid.ULID, stream string, add bool) error {
-	s.calls = append(s.calls, connSendCall{sessionID, connectionID, stream, add})
-	return nil
-}
-
-// newTestServerWithConnSender creates a server with a ConnectionSender wired.
-func newTestServerWithConnSender(fc focus.Coordinator, cs *stubConnectionSender) *pluginHostServiceServer {
-	h := &Host{
-		plugins:          make(map[string]*loadedPlugin),
-		focusCoordinator: fc,
-		connectionSender: cs,
-		gameID:           "main",
-	}
-	return &pluginHostServiceServer{
-		host:       h,
-		pluginName: "test-plugin",
-	}
-}
-
-// TestSetConnectionFocus_DrivesSubscriptionDeltas verifies that a successful
-// SetConnectionFocus RPC call drives SendToConnection with the correct stream
-// adds and removes. Focus change from grid (nil) → scene → subscription_router
-// must remove the grid location stream and add the two scene IC/OOC streams.
-func TestSetConnectionFocus_DrivesSubscriptionDeltas(t *testing.T) {
+// TestSetConnectionFocus_DelegatesToCoordinator verifies that a successful
+// SetConnectionFocus RPC delegates to the focus coordinator and returns the
+// expected wire response. Delta driving is now owned by the coordinator.
+func TestSetConnectionFocus_DelegatesToCoordinator(t *testing.T) {
 	t.Parallel()
 
 	connID := ulid.Make()
 	sceneID := ulid.Make()
 	locID := ulid.Make()
-	sessionID := "sess-delta"
 
 	fc := &stubCoordinator{
 		setConnFocusResult: focus.SetConnectionFocusResult{
 			OldFocusKey:    nil, // grid → scene transition
-			SessionID:      sessionID,
+			SessionID:      "sess-delta",
 			CharLocationID: locID,
 		},
 	}
-	cs := &stubConnectionSender{}
-	srv := newTestServerWithConnSender(fc, cs)
+	srv := newTestServer(fc, nil)
 
 	connIDBuf := connID.Bytes()
-	_, err := srv.SetConnectionFocus(context.Background(), &pluginv1.PluginHostServiceSetConnectionFocusRequest{
+	resp, err := srv.SetConnectionFocus(context.Background(), &pluginv1.PluginHostServiceSetConnectionFocusRequest{
 		ConnectionId: connIDBuf[:],
 		FocusKey: &pluginv1.FocusKey{
 			Kind:     pluginv1.FocusKind_FOCUS_KIND_SCENE,
@@ -1075,84 +1041,39 @@ func TestSetConnectionFocus_DrivesSubscriptionDeltas(t *testing.T) {
 		IsSceneGrid: false,
 	})
 	require.NoError(t, err)
-
-	// Grid → scene: location stream removed, scene IC+OOC added.
-	require.NotEmpty(t, cs.calls, "SendToConnection MUST be called on focus change")
-
-	// Collect adds and removes.
-	var adds, removes []string
-	for _, c := range cs.calls {
-		assert.Equal(t, sessionID, c.sessionID)
-		assert.Equal(t, connID, c.connectionID)
-		if c.add {
-			adds = append(adds, c.stream)
-		} else {
-			removes = append(removes, c.stream)
-		}
-	}
-
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + sceneID.String() + ".ic",
-		"events.main.scene." + sceneID.String() + ".ooc",
-	}, adds, "scene IC+OOC streams MUST be added")
-	assert.ElementsMatch(t, []string{
-		"location:" + locID.String(),
-	}, removes, "grid location stream MUST be removed")
+	require.NotNil(t, resp)
+	// The response echoes the new focus key back.
+	require.NotNil(t, resp.GetFocusKey())
+	assert.Equal(t, pluginv1.FocusKind_FOCUS_KIND_SCENE, resp.GetFocusKey().GetKind())
+	assert.Equal(t, sceneID.String(), resp.GetFocusKey().GetTargetId())
 }
 
-// TestAutoFocusOnJoin_DrivesSubscriptionDeltas verifies that a successful
-// AutoFocusOnJoin RPC drives SendToConnection for each focused connection.
-// The delta is grid → scene: location removed, scene IC+OOC added.
-func TestAutoFocusOnJoin_DrivesSubscriptionDeltas(t *testing.T) {
+// TestAutoFocusOnJoin_DelegatesToCoordinator verifies that a successful
+// AutoFocusOnJoin RPC delegates to the focus coordinator and returns the
+// expected connection count and IDs. Delta driving is now owned by the coordinator.
+func TestAutoFocusOnJoin_DelegatesToCoordinator(t *testing.T) {
 	t.Parallel()
 
 	connID := ulid.Make()
-	sceneID := ulid.Make()
-	locID := ulid.Make()
-	sessionID := "sess-autofocus"
 
 	fc := &stubCoordinator{
 		autoFocusResult: focus.AutoFocusOnJoinResponse{
-			SessionID:            sessionID,
-			CharLocationID:       locID,
+			SessionID:            "sess-1",
 			FocusedConnectionIDs: []ulid.ULID{connID},
 			TotalConnectionCount: 1,
 		},
 	}
-	cs := &stubConnectionSender{}
-	srv := newTestServerWithConnSender(fc, cs)
+	srv := newTestServer(fc, nil)
 
 	charID := ulid.Make()
 	charIDBuf := charID.Bytes()
-	sceneIDBuf := sceneID.Bytes()
 	resp, err := srv.AutoFocusOnJoin(context.Background(), &pluginv1.PluginHostServiceAutoFocusOnJoinRequest{
 		CharacterId: charIDBuf[:],
-		SceneId:     sceneIDBuf[:],
+		SceneId:     ulid.Make().Bytes(),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), resp.GetTotalConnectionCount())
 	require.Len(t, resp.GetFocusedConnectionIds(), 1)
-
-	// Verify subscription deltas.
-	require.NotEmpty(t, cs.calls, "SendToConnection MUST be called for focused connections")
-
-	var adds, removes []string
-	for _, c := range cs.calls {
-		assert.Equal(t, sessionID, c.sessionID)
-		assert.Equal(t, connID, c.connectionID)
-		if c.add {
-			adds = append(adds, c.stream)
-		} else {
-			removes = append(removes, c.stream)
-		}
-	}
-	assert.ElementsMatch(t, []string{
-		"events.main.scene." + sceneID.String() + ".ic",
-		"events.main.scene." + sceneID.String() + ".ooc",
-	}, adds, "scene IC+OOC streams MUST be added")
-	assert.ElementsMatch(t, []string{
-		"location:" + locID.String(),
-	}, removes, "grid location stream MUST be removed on grid→scene transition")
 }
 
 // TestIsAnyConnFocused_PassthroughBool verifies the simple bool passthrough

--- a/internal/plugin/lua/focus_ops_adapter.go
+++ b/internal/plugin/lua/focus_ops_adapter.go
@@ -18,7 +18,9 @@ import (
 // delegate to the wrapped coordinator. AutoFocusOnJoin translates the
 // AutoFocusOnJoinResponse struct to the FocusOps tuple shape
 // (focused, skipped []ulid.ULID, failed []FocusFailure, totalConnCount uint32, err error).
-// T18 will remove this adapter.
+// This adapter is the permanent Lua delegation seam: it lets the gopher-lua
+// hostfunc layer reach the same focus.Coordinator the binary host uses, so both
+// runtimes drive focus deltas through one common path (INV-FS-1).
 type coordinatorFocusOpsAdapter struct {
 	c focus.Coordinator
 }
@@ -42,8 +44,8 @@ func (a *coordinatorFocusOpsAdapter) PresentFocus(ctx context.Context, sessionID
 }
 
 // SetConnectionFocus delegates to the coordinator. The FocusOps surface
-// returns only error; the coordinator's oldFocusKey return is consumed at
-// the T18 RPC-handler layer (which holds the Coordinator directly), so
+// returns only error; the coordinator's oldFocusKey return is consumed inside
+// focus.Coordinator.driveFocusDeltas (which the coordinator calls itself), so
 // dropping it here is safe. Per-connection subscription deltas are driven
 // inside focus.Coordinator (INV-FS-1), so the adapter needs only to
 // delegate; the dropped oldFocusKey return value is not needed here.
@@ -55,7 +57,8 @@ func (a *coordinatorFocusOpsAdapter) SetConnectionFocus(ctx context.Context, con
 // AutoFocusOnJoin delegates to the coordinator and translates the
 // AutoFocusOnJoinResponse struct to the FocusOps tuple shape — the
 // individual slices and total count — discarding fields (SessionID,
-// CharLocationID) that are only needed by the T18 RPC handler.
+// CharLocationID) that the coordinator consumes internally in
+// driveFocusDeltas and the Lua tuple surface does not need.
 func (a *coordinatorFocusOpsAdapter) AutoFocusOnJoin(ctx context.Context, characterID, sceneID ulid.ULID) (focused, skipped []ulid.ULID, failed []hostfunc.FocusFailure, totalConnCount uint32, err error) {
 	resp, err := a.c.AutoFocusOnJoin(ctx, characterID, sceneID)
 	if err != nil {

--- a/internal/plugin/lua/focus_ops_adapter.go
+++ b/internal/plugin/lua/focus_ops_adapter.go
@@ -44,18 +44,18 @@ func (a *coordinatorFocusOpsAdapter) PresentFocus(ctx context.Context, sessionID
 // SetConnectionFocus delegates to the coordinator. The FocusOps surface
 // returns only error; the coordinator's oldFocusKey return is consumed at
 // the T18 RPC-handler layer (which holds the Coordinator directly), so
-// dropping it here is safe — the Lua hostfunc path does not need stream
-// deltas (Lua plugins react to focus events via JetStream, not via the
-// RPC return value).
+// dropping it here is safe. Per-connection subscription deltas are driven
+// inside focus.Coordinator (INV-FS-1), so the adapter needs only to
+// delegate; the dropped oldFocusKey return value is not needed here.
 func (a *coordinatorFocusOpsAdapter) SetConnectionFocus(ctx context.Context, connectionID ulid.ULID, focusKey *session.FocusKey, isSceneGrid bool) error {
 	_, err := a.c.SetConnectionFocus(ctx, connectionID, focusKey, isSceneGrid)
 	return err //nolint:wrapcheck // coordinator errors are already oops-coded
 }
 
 // AutoFocusOnJoin delegates to the coordinator and translates the
-// AutoFocusOnJoinResponse struct to the FocusOps tuple shape. The Lua
-// hostfunc path does not need the full struct — it consumes the individual
-// slices and total count directly.
+// AutoFocusOnJoinResponse struct to the FocusOps tuple shape — the
+// individual slices and total count — discarding fields (SessionID,
+// CharLocationID) that are only needed by the T18 RPC handler.
 func (a *coordinatorFocusOpsAdapter) AutoFocusOnJoin(ctx context.Context, characterID, sceneID ulid.ULID) (focused, skipped []ulid.ULID, failed []hostfunc.FocusFailure, totalConnCount uint32, err error) {
 	resp, err := a.c.AutoFocusOnJoin(ctx, characterID, sceneID)
 	if err != nil {

--- a/internal/plugin/lua/focus_ops_adapter_test.go
+++ b/internal/plugin/lua/focus_ops_adapter_test.go
@@ -5,6 +5,7 @@ package lua
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -12,19 +13,31 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/holomush/holomush/internal/grpc/focus"
+	"github.com/holomush/holomush/internal/session"
 )
 
-// stubCoordinator embeds the interface and overrides only AutoFocusOnJoin, so
-// it satisfies focus.Coordinator without implementing all methods.
+// stubCoordinator embeds the interface and overrides only the methods under
+// test, so it satisfies focus.Coordinator without implementing all methods.
 type stubCoordinator struct {
 	focus.Coordinator
 	gotChar, gotScene ulid.ULID
 	resp              focus.AutoFocusOnJoinResponse
+
+	// SetConnectionFocus capture.
+	gotConnID      ulid.ULID
+	gotFocusKey    *session.FocusKey
+	gotIsSceneGrid bool
+	setConnErr     error
 }
 
 func (s *stubCoordinator) AutoFocusOnJoin(_ context.Context, charID, sceneID ulid.ULID) (focus.AutoFocusOnJoinResponse, error) {
 	s.gotChar, s.gotScene = charID, sceneID
 	return s.resp, nil
+}
+
+func (s *stubCoordinator) SetConnectionFocus(_ context.Context, connectionID ulid.ULID, focusKey *session.FocusKey, isSceneGrid bool) (focus.SetConnectionFocusResult, error) {
+	s.gotConnID, s.gotFocusKey, s.gotIsSceneGrid = connectionID, focusKey, isSceneGrid
+	return focus.SetConnectionFocusResult{}, s.setConnErr
 }
 
 func TestLuaAdapterAutoFocusOnJoinDelegatesAndTranslates(t *testing.T) {
@@ -45,4 +58,29 @@ func TestLuaAdapterAutoFocusOnJoinDelegatesAndTranslates(t *testing.T) {
 	assert.Empty(t, skipped)
 	assert.Empty(t, failed)
 	assert.Equal(t, uint32(1), total)
+}
+
+func TestLuaAdapterSetConnectionFocusDelegates(t *testing.T) {
+	connID := ulid.Make()
+	sceneID := ulid.Make()
+	fk := &session.FocusKey{Kind: session.FocusKindScene, TargetID: sceneID}
+	stub := &stubCoordinator{}
+	adapter := &coordinatorFocusOpsAdapter{c: stub}
+
+	err := adapter.SetConnectionFocus(context.Background(), connID, fk, false)
+	require.NoError(t, err)
+	assert.Equal(t, connID, stub.gotConnID, "adapter MUST forward connectionID to the coordinator")
+	assert.Equal(t, fk, stub.gotFocusKey, "adapter MUST forward focusKey to the coordinator")
+	assert.False(t, stub.gotIsSceneGrid, "adapter MUST forward isSceneGrid to the coordinator")
+}
+
+func TestLuaAdapterSetConnectionFocusPropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	stub := &stubCoordinator{setConnErr: wantErr}
+	adapter := &coordinatorFocusOpsAdapter{c: stub}
+
+	err := adapter.SetConnectionFocus(context.Background(), ulid.Make(), nil, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr, "adapter MUST propagate the coordinator's error")
+	assert.True(t, stub.gotIsSceneGrid, "adapter MUST forward isSceneGrid=true (scene→grid)")
 }

--- a/internal/plugin/lua/focus_ops_adapter_test.go
+++ b/internal/plugin/lua/focus_ops_adapter_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/grpc/focus"
+)
+
+// stubCoordinator embeds the interface and overrides only AutoFocusOnJoin, so
+// it satisfies focus.Coordinator without implementing all methods.
+type stubCoordinator struct {
+	focus.Coordinator
+	gotChar, gotScene ulid.ULID
+	resp              focus.AutoFocusOnJoinResponse
+}
+
+func (s *stubCoordinator) AutoFocusOnJoin(_ context.Context, charID, sceneID ulid.ULID) (focus.AutoFocusOnJoinResponse, error) {
+	s.gotChar, s.gotScene = charID, sceneID
+	return s.resp, nil
+}
+
+func TestLuaAdapterAutoFocusOnJoinDelegatesAndTranslates(t *testing.T) {
+	charID := ulid.Make()
+	sceneID := ulid.Make()
+	focusedConn := ulid.Make()
+	stub := &stubCoordinator{resp: focus.AutoFocusOnJoinResponse{
+		FocusedConnectionIDs: []ulid.ULID{focusedConn},
+		TotalConnectionCount: 1,
+	}}
+	adapter := &coordinatorFocusOpsAdapter{c: stub}
+
+	focused, skipped, failed, total, err := adapter.AutoFocusOnJoin(context.Background(), charID, sceneID)
+	require.NoError(t, err)
+	assert.Equal(t, charID, stub.gotChar, "adapter MUST forward characterID to the coordinator")
+	assert.Equal(t, sceneID, stub.gotScene, "adapter MUST forward sceneID to the coordinator")
+	assert.Equal(t, []ulid.ULID{focusedConn}, focused)
+	assert.Empty(t, skipped)
+	assert.Empty(t, failed)
+	assert.Equal(t, uint32(1), total)
+}

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -86,6 +86,14 @@ type AdminDepsProvider interface {
 }
 
 // PluginSubsystemConfig configures the plugin subsystem.
+//
+// Focus-delta delivery note: per-connection focus deltas are driven inside
+// focus.Coordinator for BOTH binary and Lua plugin runtimes (INV-FS-1). The
+// plugin host itself no longer carries a ConnectionSender — that field was
+// removed as part of the focus-delta coordinator unification (holomush-66228).
+// The host still receives StreamRegistry so the Lua hostfunc session-stream
+// contribution path (auto_focus_on_join → hostfunc.StreamRegistry call) can
+// look up a character's active session streams.
 type PluginSubsystemConfig struct {
 	DataDir            string
 	DatabaseConnStr    string   // PostgreSQL connection string for schema provisioning

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -22,7 +22,6 @@ import (
 	"github.com/holomush/holomush/internal/command"
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
-	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/goplugin"
@@ -101,24 +100,6 @@ type PluginSubsystemConfig struct {
 	AdminDeps       AdminDepsProvider
 	Registry        *lifecycle.ReadinessRegistry
 	StreamRegistry  plugins.StreamRegistry
-	// ConnectionSender is the per-connection Phase-5 delta seam for the binary
-	// plugin host. Session-level focus delivery for both runtimes flows through
-	// JoinFocus → focus.StreamSender (coordinator-wired); however, the scene
-	// KindPolicy returns ReplayModeBoundedTail/LiveOnly for OnJoin, and the
-	// StreamSenderAdapter rejects those modes with REPLAY_MODE_NOT_SUPPORTED
-	// (best-effort errcheck: the error is silently dropped). The binary host's
-	// AutoFocusOnJoin RPC handler therefore drives the actual per-connection
-	// subscription deltas via ConnectionSender.SendToConnection → the
-	// connection's control channel, adding the scene IC/OOC streams to the live
-	// Subscribe filter set. The Lua per-connection focus path
-	// (internal/plugin/lua/focus_ops_adapter.go:46-49) deliberately omits
-	// per-connection deltas — Lua plugins react via JetStream, not the RPC
-	// return. nil leaves binary AutoFocusOnJoin delta-delivery silently skipped
-	// (holomush-y5inx.9). NOTE: this field is intentionally landed here as
-	// forward-plumbing; its production wiring in cmd/holomush/sub_grpc.go is
-	// deferred until Phase 5 is fully wired end-to-end (bead holomush-y5inx
-	// scoped production out-of-scope).
-	ConnectionSender   focus.ConnectionSender
 	LuaTimeout         time.Duration // per-invocation CPU deadline for Lua plugins
 	LuaRegistryMaxSize int           // max Lua registry size per plugin state
 	// VerbRegistry is seeded by BootstrapVerbRegistry in core.go and passed
@@ -295,16 +276,6 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// binary host so overrideFor() can look them up at plugin init time.
 		goplugin.WithConfigOverrides(s.cfg.PluginConfigOverrides),
 	)
-
-	// Wire the per-connection delta sender for the binary host's AutoFocusOnJoin
-	// RPC handler. This is the real scene-stream subscription path: JoinFocus →
-	// StreamSender is silently dropped (ReplayModeBoundedTail/LiveOnly rejected);
-	// AutoFocusOnJoin → SendToConnection → ctrlCh is the actual delivery seam.
-	// The Lua per-connection focus path deliberately omits this (focus_ops_adapter.go).
-	// nil → binary AutoFocusOnJoin delta-delivery silently skipped (holomush-y5inx.9).
-	if s.cfg.ConnectionSender != nil {
-		hostOpts = append(hostOpts, goplugin.WithConnectionSender(s.cfg.ConnectionSender))
-	}
 
 	if s.cfg.CertsDir != "" {
 		ca, caErr := tlscerts.LoadCA(s.cfg.CertsDir)

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -87,19 +87,19 @@ type AdminDepsProvider interface {
 
 // PluginSubsystemConfig configures the plugin subsystem.
 type PluginSubsystemConfig struct {
-	DataDir         string
-	DatabaseConnStr string   // PostgreSQL connection string for schema provisioning
-	CertsDir        string   // path to game certs directory (for loading CA)
-	GameID          string   // game ID for cert SANs
-	TrustAllowlist  []string // server-side plugin trust escalation allowlist
-	ABAC            EngineProvider
-	PolicyInst      PolicyInstallerProvider
-	PluginProv      PluginProviderSetter
-	World           WorldServiceProvider
-	Sessions        SessionProvider
-	AdminDeps       AdminDepsProvider
-	Registry        *lifecycle.ReadinessRegistry
-	StreamRegistry  plugins.StreamRegistry
+	DataDir            string
+	DatabaseConnStr    string   // PostgreSQL connection string for schema provisioning
+	CertsDir           string   // path to game certs directory (for loading CA)
+	GameID             string   // game ID for cert SANs
+	TrustAllowlist     []string // server-side plugin trust escalation allowlist
+	ABAC               EngineProvider
+	PolicyInst         PolicyInstallerProvider
+	PluginProv         PluginProviderSetter
+	World              WorldServiceProvider
+	Sessions           SessionProvider
+	AdminDeps          AdminDepsProvider
+	Registry           *lifecycle.ReadinessRegistry
+	StreamRegistry     plugins.StreamRegistry
 	LuaTimeout         time.Duration // per-invocation CPU deadline for Lua plugins
 	LuaRegistryMaxSize int           // max Lua registry size per plugin state
 	// VerbRegistry is seeded by BootstrapVerbRegistry in core.go and passed

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -345,16 +345,12 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	}
 
 	// Focus-delivery: the SessionStreamRegistry MUST exist BEFORE startPlugins so
-	// its ConnectionSenderAdapter can be wired into the binary plugin host at
-	// construction (mirrors production core.go, which creates the registry before
-	// the plugin subsystem). The CoreServer is also given this same registry so
-	// the Subscribe handler registers each connection's control channel on it.
+	// it can be wired into the CoreServer (the Subscribe handler registers each
+	// connection's control channel on it).
 	// nil under non-focus suites — zero blast radius (holomush-y5inx.9).
 	var streamRegistry *holoGRPC.SessionStreamRegistry
-	var connectionSender focus.ConnectionSender
 	if cfg.withFocusDelivery {
 		streamRegistry = holoGRPC.NewSessionStreamRegistry()
-		connectionSender = holoGRPC.NewConnectionSenderAdapter(streamRegistry)
 	}
 
 	var pluginSub *pluginsetup.PluginSubsystem
@@ -385,7 +381,6 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			cryptoPublisher:       cryptoPublisherOf(pc),
 			gameID:                bus.Bus.GameID(),
 			pluginConfigOverrides: cfg.pluginConfigOverrides,
-			connectionSender:      connectionSender,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -194,6 +194,9 @@ type startConfig struct {
 	// pluginConfigOverrides is the per-plugin opaque config override
 	// (plugin name → key → value) threaded into PluginSubsystemConfig.
 	pluginConfigOverrides map[string]map[string]string
+	// extraPluginDirs holds additional plugin directories (e.g. test-only Lua
+	// fixtures) staged into the plugin load path alongside the in-tree plugins.
+	extraPluginDirs []string
 }
 
 // WithPolicyEngine overrides the harness's default allow-all ABAC engine.
@@ -381,6 +384,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			cryptoPublisher:       cryptoPublisherOf(pc),
 			gameID:                bus.Bus.GameID(),
 			pluginConfigOverrides: cfg.pluginConfigOverrides,
+			extraPluginDirs:       cfg.extraPluginDirs,
 		})
 		cmdRegistry = pluginSub.CommandRegistry()
 	}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -432,10 +432,11 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	// SessionStreamRegistry was created above, before startPlugins). Mirrors
 	// production cmd/holomush/sub_grpc.go:428-470: a real focus.Coordinator wired
 	// with the scene KindPolicy, game settings, player-preference reader, and the
-	// plugin StreamContributor. The scene `join` command reaches JoinFocus →
-	// AutoFocusOnJoin; the binary host's AutoFocusOnJoin RPC handler then drives
-	// per-Connection subscription deltas via the ConnectionSenderAdapter (wired at
-	// host construction above) → the connection's control channel, adding the
+	// plugin StreamContributor plus the ConnectionSender (both wired from one
+	// SessionStreamRegistry via FocusStreamCoordinatorOptions, mirroring prod).
+	// The scene `join` command reaches JoinFocus → AutoFocusOnJoin; the
+	// coordinator itself then drives per-Connection subscription deltas
+	// (driveFocusDeltas, INV-FS-1) → the connection's control channel, adding the
 	// scene IC/OOC streams to the live Subscribe filter set. The coordinator is
 	// injected into the loaded plugin hosts via Manager.ConfigureFocusDeps below.
 	// Gated so non-focus suites keep the WithSubscriber-only wiring — zero blast

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -442,15 +442,17 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 			Store:       evStore,
 			NotFoundErr: store.ErrSystemInfoNotFound,
 		})
-		var focusErr error
-		focusCoord, focusErr = focus.NewCoordinator(
+		coordOpts := []focus.CoordinatorOption{
 			focus.WithSessionStore(sessionStoreInst),
 			focus.WithKindPolicy(scenepolicy.New()),
 			focus.WithGameSettings(gameSettings),
 			focus.WithPlayerPreferences(focus.NewPlayerPrefsAdapter(playerRepo)),
 			focus.WithStreamContributor(&focusStreamContributorAdapter{pm: pluginSub.Manager()}),
-			focus.WithStreamSender(holoGRPC.NewStreamSenderAdapter(streamRegistry)),
-		)
+			focus.WithGameID(bus.Bus.GameID()),
+		}
+		coordOpts = append(coordOpts, holoGRPC.FocusStreamCoordinatorOptions(streamRegistry)...)
+		var focusErr error
+		focusCoord, focusErr = focus.NewCoordinator(coordOpts...)
 		require.NoError(t, focusErr, "integrationtest.Start: build focus coordinator")
 	}
 

--- a/internal/testsupport/integrationtest/options.go
+++ b/internal/testsupport/integrationtest/options.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package integrationtest
+
+// WithExtraPluginDir stages an additional plugin directory (e.g. a test-only
+// Lua fixture under test/integration/.../testdata/lua/<name>) into the plugin
+// load path so the real plugin subsystem loads it alongside the in-tree
+// plugins. Used by focus runtime-symmetry tests that need a Lua plugin which
+// calls the auto_focus_on_join hostfunc. dir is resolved relative to the test's
+// package directory (Go runs tests with CWD = package dir).
+func WithExtraPluginDir(dir string) StartOption {
+	return func(c *startConfig) { c.extraPluginDirs = append(c.extraPluginDirs, dir) }
+}

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -235,6 +235,9 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 		"startPlugins: assemble plugins dir")
 
 	for _, extra := range d.extraPluginDirs {
+		// Reject a blank entry: filepath.Abs("") resolves to the current working
+		// directory, which would stage the entire repo as a bogus "plugin".
+		require.NotEmpty(t, extra, "startPlugins: extra plugin dir must not be empty")
 		abs, err := filepath.Abs(extra)
 		require.NoError(t, err, "startPlugins: resolve extra plugin dir")
 		base := filepath.Base(abs)

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -30,7 +30,6 @@ import (
 	"github.com/holomush/holomush/internal/command/handlers"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/lifecycle"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/plugin/pluginauthz"
@@ -204,12 +203,6 @@ type pluginDeps struct {
 	// GameIDProvider closure so plugin emits translate legacy colon-style
 	// subjects to events.<game_id>.<ns>.<id> consistently.
 	gameID string
-	// connectionSender delivers per-Connection stream subscription deltas to the
-	// binary plugin host (focus.ConnectionSender). Wired only under
-	// WithFocusDelivery so the binary core-scenes AutoFocusOnJoin RPC handler can
-	// route the scene IC/OOC stream subscription onto the joiner's live Subscribe
-	// loop. nil leaves binary delta-delivery best-effort skipped (holomush-y5inx.9).
-	connectionSender focus.ConnectionSender
 	// pluginConfigOverrides is the per-plugin opaque config override
 	// (plugin name → key → value) threaded into PluginSubsystemConfig.
 	pluginConfigOverrides map[string]map[string]string
@@ -298,7 +291,6 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 		LuaTimeout:            5 * time.Second,
 		LuaRegistryMaxSize:    1024 * 1024,
 		PluginConfigOverrides: d.pluginConfigOverrides,
-		ConnectionSender:      d.connectionSender,
 	}
 
 	ps := pluginsetup.NewPluginSubsystem(cfg)

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -206,6 +206,9 @@ type pluginDeps struct {
 	// pluginConfigOverrides is the per-plugin opaque config override
 	// (plugin name → key → value) threaded into PluginSubsystemConfig.
 	pluginConfigOverrides map[string]map[string]string
+	// extraPluginDirs holds additional plugin directories (e.g. test-only Lua
+	// fixtures) staged into the plugin load path after the in-tree plugins.
+	extraPluginDirs []string
 }
 
 // startPlugins constructs and starts a PluginSubsystem mirroring production
@@ -230,6 +233,13 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	require.NoError(t,
 		assemblePluginsDir(pluginsDst, repoPluginsSrcDir(), buildDir),
 		"startPlugins: assemble plugins dir")
+
+	for _, extra := range d.extraPluginDirs {
+		abs, err := filepath.Abs(extra)
+		require.NoError(t, err, "startPlugins: resolve extra plugin dir")
+		dstSub := filepath.Join(pluginsDst, filepath.Base(abs))
+		require.NoError(t, copyTree(abs, dstSub), "startPlugins: stage extra plugin dir")
+	}
 
 	// WorldService — mirror internal/world/setup/subsystem.go. EventEmitter is
 	// intentionally omitted (production world/setup omits it too); world.NewService

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -237,7 +237,15 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	for _, extra := range d.extraPluginDirs {
 		abs, err := filepath.Abs(extra)
 		require.NoError(t, err, "startPlugins: resolve extra plugin dir")
-		dstSub := filepath.Join(pluginsDst, filepath.Base(abs))
+		base := filepath.Base(abs)
+		dstSub := filepath.Join(pluginsDst, base)
+		// Fail loudly on a basename collision rather than silently overwriting:
+		// the staging dest is keyed only by filepath.Base, so two extra dirs (or
+		// an extra dir clashing with an in-tree plugin) sharing a final component
+		// would otherwise clobber each other.
+		_, statErr := os.Stat(dstSub)
+		require.Truef(t, os.IsNotExist(statErr),
+			"startPlugins: extra plugin dir basename %q collides with an already-staged plugin at %s", base, dstSub)
 		require.NoError(t, copyTree(abs, dstSub), "startPlugins: stage extra plugin dir")
 	}
 

--- a/site/src/content/docs/contributing/how-to/integration-tests.md
+++ b/site/src/content/docs/contributing/how-to/integration-tests.md
@@ -112,7 +112,7 @@ ts := integrationtest.Start(
 The fixture at `test/integration/scenes/testdata/lua/focus_join/` is a minimal
 Lua plugin that exposes the `luafocusjoin` command, which calls
 `holomush.auto_focus_on_join` (the hostfunc registered at
-`internal/plugin/lua/stdlib_focus.go`). The integration test at
+`internal/plugin/hostfunc/stdlib_focus.go`). The integration test at
 `test/integration/scenes/lua_focus_parity_test.go` (INV-FS-3) loads this
 fixture and asserts that the Lua path delivers a live scene IC event to the
 joiner's Subscribe stream — the same end-to-end assertion used by the binary

--- a/site/src/content/docs/contributing/how-to/integration-tests.md
+++ b/site/src/content/docs/contributing/how-to/integration-tests.md
@@ -61,6 +61,66 @@ Do NOT use it when:
    - Why production code can't reasonably reach that state.
    - FK / cascade side effects (when applicable).
 
+## Opt into focus delivery
+
+`WithFocusDelivery` wires a real `focus.Coordinator` + `SessionStreamRegistry`
+so the plugin host's `JoinFocus` / `AutoFocusOnJoin` path reaches the live
+Subscribe filter set. Without it, those RPCs short-circuit with "focus
+coordinator not configured" and no scene-stream subscription is ever added.
+
+```go
+ts := integrationtest.Start(
+    t,
+    integrationtest.WithInTreePlugins(),
+    integrationtest.WithFocusDelivery(),
+)
+```
+
+**Requires `WithInTreePlugins()`** — the coordinator is injected into the
+loaded plugin hosts via `Manager.ConfigureFocusDeps`.
+
+### How the harness builds the coordinator senders
+
+Both production (`cmd/holomush`) and the integration harness build the
+coordinator's focus-delivery senders through the same helper:
+
+```go
+holoGRPC.FocusStreamCoordinatorOptions(streamRegistry)
+```
+
+`FocusStreamCoordinatorOptions` bundles a `StreamSender` and a
+`ConnectionSender`, both backed by the same `SessionStreamRegistry`. Because
+the harness calls this helper rather than hand-rolling the adapters, it is a
+faithful production mirror by construction (INV-FS-4).
+
+### Testing Lua runtime symmetry with `WithExtraPluginDir`
+
+`WithExtraPluginDir(dir)` stages an additional plugin directory into the load
+path alongside the in-tree plugins. This is the mechanism for the Lua
+runtime-symmetry test:
+
+```go
+ts := integrationtest.Start(
+    suiteT,
+    integrationtest.WithInTreePlugins(),
+    integrationtest.WithPluginCrypto(),
+    integrationtest.WithFocusDelivery(),
+    integrationtest.WithExtraPluginDir("testdata/lua/focus_join"),
+)
+```
+
+The fixture at `test/integration/scenes/testdata/lua/focus_join/` is a minimal
+Lua plugin that exposes the `luafocusjoin` command, which calls
+`holomush.auto_focus_on_join` (the hostfunc registered at
+`internal/plugin/lua/stdlib_focus.go`). The integration test at
+`test/integration/scenes/lua_focus_parity_test.go` (INV-FS-3) loads this
+fixture and asserts that the Lua path delivers a live scene IC event to the
+joiner's Subscribe stream — the same end-to-end assertion used by the binary
+`scene join` keystone, proving plugin-runtime symmetry.
+
+`dir` is resolved relative to the test package directory (Go runs tests with
+CWD equal to the package directory).
+
 ## Opt into the whole-system plugin tier
 
 The harness supports an opt-in **whole-system** mode that loads all in-tree

--- a/test/integration/scenes/lua_focus_parity_test.go
+++ b/test/integration/scenes/lua_focus_parity_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// INV-FS-3: Lua-runtime focus-delta parity.
+//
+// Proves that the gopher-lua VM path into holomush.auto_focus_on_join (the
+// Lua hostfunc registered at internal/plugin/lua/stdlib_focus.go) delivers
+// a live scene IC event to the joiner's Subscribe stream, end-to-end. This
+// is the full-fidelity lock for plugin-runtime symmetry: the SAME
+// subscribe/emit/await assertion used by the binary `scene join` keystone
+// (scene_command_join_delivery_test.go, holomush-y5inx.9) fires here, but
+// with the focus delta triggered by the Lua `luafocusjoin` command rather
+// than the binary scene-join gRPC path.
+//
+// Bead: holomush-66228
+// Spec: docs/superpowers/plans/2026-05-28-focus-delta-coordinator-unification.md §Task 13
+var _ = Describe("INV-FS-3: Lua-runtime auto_focus_on_join parity — live IC delivery", func() {
+	var (
+		ts     *integrationtest.Server
+		ctx    context.Context
+		owner  *integrationtest.Session
+		joiner *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		// WithExtraPluginDir stages testdata/lua/focus_join (the Lua fixture
+		// that calls holomush.auto_focus_on_join) into the plugin load path
+		// alongside the in-tree plugins. WithFocusDelivery wires the real
+		// focus.Coordinator + SessionStreamRegistry so the Lua hostfunc's
+		// auto_focus_on_join call reaches the live Subscribe filter set.
+		// WithPluginCrypto is required for EmitSceneICContent + the live
+		// crypto-decode path that delivers scene IC frames to the joiner.
+		ts = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+			integrationtest.WithFocusDelivery(),
+			integrationtest.WithExtraPluginDir("testdata/lua/focus_join"),
+		)
+		owner = ts.ConnectAuthed(ctx, "Owner")
+		joiner = ts.ConnectAuthed(ctx, "Joiner")
+	})
+
+	AfterEach(func() {
+		if joiner != nil {
+			joiner.Logout(ctx)
+		}
+		if owner != nil {
+			owner.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("delivers a post-join scene_pose to the joiner after the Lua luafocusjoin command fires auto_focus_on_join (INV-FS-3)", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero bare ULID")
+
+		// Seed a FocusMembership for the joiner so AutoFocusOnJoin does not
+		// fail with FOCUS_FAILURE_REASON_MEMBERSHIP_ABSENT. The `scene join`
+		// binary command does both join+auto-focus internally; the Lua fixture
+		// only calls auto_focus_on_join, so the membership must pre-exist.
+		// JoinScene adds a FocusMembership{Kind: Scene, TargetID: sceneID}
+		// directly to the session store — observationally equivalent to the
+		// production JoinFocus path for the membership gate.
+		joiner.JoinScene(ctx, sceneID)
+
+		// Run the Lua `luafocusjoin <charID> <sceneID>` command. This fires
+		// the test-focus-join plugin's on_command(ctx) handler which calls
+		// holomush.auto_focus_on_join(char_id, scene_id) — the Lua hostfunc
+		// exercising the gopher-lua VM path into the real focus.Coordinator.
+		// On success the coordinator updates the joiner's live Subscribe
+		// filter set to include the scene IC stream (mirroring the binary
+		// `scene join` path tested in scene_command_join_delivery_test.go).
+		err := joiner.SendCommand(ctx, "luafocusjoin "+joiner.CharacterID.String()+" "+sceneID.String())
+		Expect(err).NotTo(HaveOccurred(),
+			"INV-FS-3: `luafocusjoin` must succeed — the Lua hostfunc should "+
+				"reach the focus coordinator and open the scene IC subscription")
+
+		// Emit a real sensitive scene_pose into the scene AFTER the focus join
+		// so the only delivery path is the subscription auto_focus_on_join
+		// opened via the Lua VM. If the Lua runtime path does not wire the
+		// subscription, WaitForEvent will time out.
+		const poseJSON = `{"text":"lua focus parity pose for INV-FS-3"}`
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", poseJSON)
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()),
+			"emitted subject must carry the bare scene ULID")
+
+		// Authoritative delivery assertion (INV-FS-3): the joiner's live
+		// Subscribe stream receives a scene_pose frame. Pre-fix (without the
+		// Lua hostfunc or coordinator wiring) this would time out because no
+		// subscription was ever added. Post-fix the frame arrives once the
+		// Lua auto_focus_on_join call succeeds and registers the subscription.
+		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		Expect(frame).NotTo(BeNil(),
+			"INV-FS-3: post-join pose MUST be delivered via the Lua-runtime "+
+				"auto_focus_on_join path — the scene IC subscription must be "+
+				"wired into the joiner's live Subscribe filter set")
+		Expect(frame.GetType()).To(Equal("scene_pose"))
+		// The joiner is a non-DEK-participant, so the delivered frame MUST be
+		// metadata-only (no plaintext payload). Mirrors the binary assertion in
+		// scene_command_join_delivery_test.go: fail-closed, no plaintext leak.
+		Expect(frame.GetMetadataOnly()).To(BeTrue(),
+			"INV-FS-3: non-DEK-participant joiner MUST receive a metadata-only "+
+				"frame (fail-closed: no plaintext payload leak)")
+	})
+})

--- a/test/integration/scenes/lua_focus_parity_test.go
+++ b/test/integration/scenes/lua_focus_parity_test.go
@@ -65,7 +65,11 @@ var _ = Describe("INV-FS-3: Lua-runtime auto_focus_on_join parity — live IC de
 		if owner != nil {
 			owner.Logout(ctx)
 		}
-		ts.Stop()
+		// Nil-safe: if integrationtest.Start failed before ts was assigned,
+		// ts.Stop() would nil-panic and mask the real setup failure.
+		if ts != nil {
+			ts.Stop()
+		}
 	})
 
 	It("delivers a post-join scene_pose to the joiner after the Lua luafocusjoin command fires auto_focus_on_join (INV-FS-3)", func() {

--- a/test/integration/scenes/testdata/lua/focus_join/plugin.lua
+++ b/test/integration/scenes/testdata/lua/focus_join/plugin.lua
@@ -22,15 +22,21 @@
 --     { focused_connection_ids, skipped_connection_ids,
 --       failed_connection_ids, total_connection_count }
 --   Returns (nil, error_string) on failure.
---   Registered at stdlib_focus.go:70 via ls.SetField(mod, "auto_focus_on_join", ...).
+--   Registered at internal/plugin/hostfunc/stdlib_focus.go:70 via
+--   ls.SetField(mod, "auto_focus_on_join", ...).
 
 function on_command(ctx)
-    local char_id, scene_id = ctx.args:match("(%S+)%s+(%S+)")
-    if not char_id or not scene_id then
+    -- The command keeps its 2-arg form (luafocusjoin <character_id> <scene_id>)
+    -- for caller compatibility, but the args-supplied character id is IGNORED:
+    -- we always focus the ISSUING character (ctx.character_id), never an
+    -- arbitrary one. This enforces own-character-only focus — a character cannot
+    -- focus another character's connections through this fixture command.
+    local _, scene_id = ctx.args:match("(%S+)%s+(%S+)")
+    if not scene_id then
         return {status = 1, output = "usage: luafocusjoin <character_id> <scene_id>"}
     end
 
-    local result, err = holomush.auto_focus_on_join(char_id, scene_id)
+    local result, err = holomush.auto_focus_on_join(ctx.character_id, scene_id)
     if err then
         return {status = 2, output = "auto_focus_on_join failed: " .. err}
     end

--- a/test/integration/scenes/testdata/lua/focus_join/plugin.lua
+++ b/test/integration/scenes/testdata/lua/focus_join/plugin.lua
@@ -1,0 +1,44 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- test-focus-join: registers a command that auto-focuses the issuing
+-- character's connections onto a scene, exercising the real gopher-lua VM
+-- path into holomush.auto_focus_on_join (focus runtime-symmetry test).
+--
+-- Command form: luafocusjoin <character_id_ulid> <scene_id_ulid>
+--
+-- on_command(ctx) receives a Lua table with fields:
+--   ctx.command      (string) command name
+--   ctx.args         (string) raw argument string
+--   ctx.character_id (string) ULID of the issuing character
+--   ctx.location_id  (string) ULID of the issuing character's location
+--   ctx.session_id   (string) session ULID
+--   ctx.player_id    (string) player ULID
+--   ctx.connection_id (string) connection ULID (empty for non-connection paths)
+--
+-- holomush.auto_focus_on_join(char_id_str, scene_id_str):
+--   Both arguments are ULID strings.
+--   Returns a result table on success:
+--     { focused_connection_ids, skipped_connection_ids,
+--       failed_connection_ids, total_connection_count }
+--   Returns (nil, error_string) on failure.
+--   Registered at stdlib_focus.go:70 via ls.SetField(mod, "auto_focus_on_join", ...).
+
+function on_command(ctx)
+    local char_id, scene_id = ctx.args:match("(%S+)%s+(%S+)")
+    if not char_id or not scene_id then
+        return {status = 1, output = "usage: luafocusjoin <character_id> <scene_id>"}
+    end
+
+    local result, err = holomush.auto_focus_on_join(char_id, scene_id)
+    if err then
+        return {status = 2, output = "auto_focus_on_join failed: " .. err}
+    end
+
+    local focused_count = 0
+    if result and result.focused_connection_ids then
+        focused_count = #result.focused_connection_ids
+    end
+
+    return "focused:" .. tostring(focused_count)
+end

--- a/test/integration/scenes/testdata/lua/focus_join/plugin.yaml
+++ b/test/integration/scenes/testdata/lua/focus_join/plugin.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+name: test-focus-join
+version: 1.0.0
+type: lua
+resource_types: []
+requires: []
+provides: []
+
+lua-plugin:
+  entry: plugin.lua
+
+commands:
+  - name: luafocusjoin
+    capabilities:
+      - action: write
+        resource: scene
+        scope: local
+    help: "Test command: auto-focuses the issuing character's connections onto a scene (Lua runtime symmetry fixture)"
+    usage: "luafocusjoin <character_id_ulid> <scene_id_ulid>"
+
+policies:
+  - name: execute-luafocusjoin
+    dsl: >-
+      permit(principal is character, action in ["execute"], resource is command) when { resource.command.name == "luafocusjoin"
+      };

--- a/test/meta/focus_delta_gate_test.go
+++ b/test/meta/focus_delta_gate_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot walks up from the test's CWD to the module root (go.mod).
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func nonTestGoFilesContaining(t *testing.T, root, needle string) []string {
+	t.Helper()
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		b, rerr := os.ReadFile(path) //nolint:gosec // G122: meta-test walker reads source files for invariant grep; no symlink concern
+		if rerr != nil {
+			return rerr
+		}
+		if strings.Contains(string(b), needle) {
+			rel, _ := filepath.Rel(root, path)
+			hits = append(hits, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hits
+}
+
+// INV-FS-1: per-connection focus-delta delivery is driven ONLY inside
+// internal/grpc/focus. The interface decl + the registry impl/adapter in
+// internal/grpc are the only other legitimate occurrences.
+func TestSendToConnectionConfinedToFocusAndRegistry(t *testing.T) {
+	root := repoRoot(t)
+	allowed := map[string]bool{
+		"internal/grpc/stream_registry.go":           true, // impl + ConnectionSenderAdapter
+		"internal/grpc/focus/subscription_router.go": true, // ConnectionSender interface decl
+		"internal/grpc/focus/focus_delta.go":         true, // the sole driver (the gate)
+	}
+	for _, f := range nonTestGoFilesContaining(t, root, "SendToConnection(") {
+		if !allowed[f] {
+			t.Errorf("INV-FS-1 violation: SendToConnection( used outside the focus gate: %s", f)
+		}
+	}
+}
+
+// INV-FS-4: the registry-derived adapter pair is assembled ONLY in the
+// FocusStreamCoordinatorOptions helper (constructors are defined in
+// stream_registry.go).
+func TestFocusAdapterPairAssembledOnlyInHelper(t *testing.T) {
+	root := repoRoot(t)
+	allowed := map[string]bool{
+		"internal/grpc/stream_registry.go": true, // constructor definitions
+		"internal/grpc/focus_wiring.go":    true, // the single assembly point
+	}
+	for _, needle := range []string{"NewConnectionSenderAdapter(", "NewStreamSenderAdapter("} {
+		for _, f := range nonTestGoFilesContaining(t, root, needle) {
+			if !allowed[f] {
+				t.Errorf("INV-FS-4 violation: %s used outside FocusStreamCoordinatorOptions: %s", needle, f)
+			}
+		}
+	}
+}

--- a/test/meta/focus_delta_gate_test.go
+++ b/test/meta/focus_delta_gate_test.go
@@ -10,24 +10,7 @@ import (
 	"testing"
 )
 
-// repoRoot walks up from the test's CWD to the module root (go.mod).
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found")
-		}
-		dir = parent
-	}
-}
+// repoRoot is provided by findRepoRoot in inv_binding_test.go (same package).
 
 func nonTestGoFilesContaining(t *testing.T, root, needle string) []string {
 	t.Helper()
@@ -62,7 +45,7 @@ func nonTestGoFilesContaining(t *testing.T, root, needle string) []string {
 // internal/grpc/focus. The interface decl + the registry impl/adapter in
 // internal/grpc are the only other legitimate occurrences.
 func TestSendToConnectionConfinedToFocusAndRegistry(t *testing.T) {
-	root := repoRoot(t)
+	root := findRepoRoot(t)
 	allowed := map[string]bool{
 		"internal/grpc/stream_registry.go":           true, // impl + ConnectionSenderAdapter
 		"internal/grpc/focus/subscription_router.go": true, // ConnectionSender interface decl
@@ -79,7 +62,7 @@ func TestSendToConnectionConfinedToFocusAndRegistry(t *testing.T) {
 // FocusStreamCoordinatorOptions helper (constructors are defined in
 // stream_registry.go).
 func TestFocusAdapterPairAssembledOnlyInHelper(t *testing.T) {
-	root := repoRoot(t)
+	root := findRepoRoot(t)
 	allowed := map[string]bool{
 		"internal/grpc/stream_registry.go": true, // constructor definitions
 		"internal/grpc/focus_wiring.go":    true, // the single assembly point


### PR DESCRIPTION
## Summary

Relocates per-connection focus-delta driving **into `focus.Coordinator`** so it is the single common-path driver for **both** binary and Lua plugin runtimes (INV-FS-1). This fixes a **P0 production bug** and closes a plugin-runtime-symmetry gap (a MUST invariant per `.claude/rules/plugin-runtime-symmetry.md`).

- **P0 fix:** the production coordinator was assembled with only a session-wide `StreamSender`, so binary scene-joins never delivered per-connection focus deltas to live connections. `cmd/holomush/sub_grpc.go` now wires the `ConnectionSender` via the shared `FocusStreamCoordinatorOptions` helper (Task 7).
- **Lua parity:** previously the Lua adapter "deliberately omitted" delta-driving (a stale comment conflating plugin reaction via JetStream with the joiner's live stream switch). Because driving now lives in the coordinator, Lua plugins gain identical per-connection delivery for free — proven end-to-end by a full gopher-lua integration test (INV-FS-3).
- **Structural lock:** the binary host's `ConnectionSender` seam is deleted; meta-tests forbid any out-of-gate `SendToConnection(`/adapter-constructor usage (INV-FS-1/INV-FS-4); prod + harness build the coordinator's senders through one helper so they cannot drift.

Supersedes `holomush-ymgjs`. Implements ADR `holomush-jfw0k`. 14 tasks, drained autonomously via `holomush-2gk70`.

## Changes by phase

- **Coordinator drives deltas** — `driveFocusDeltas` helper + `WithConnectionSender`/`WithGameID` options; called from `AutoFocusOnJoin` + `SetConnectionFocus` (Tasks 1-2); boundary/error coverage (Task 3).
- **Remove binary seam** — delete the binary handler delta loops + the host `ConnectionSender` API/wiring/harness chain (Tasks 4-5).
- **Unify wiring** — `FocusStreamCoordinatorOptions` single-assembly helper; prod + harness call it (Tasks 6-8).
- **Lua parity + invariants** — Lua adapter delegation unit test + comment fix; INV-FS-1/4 meta-tests; `WithExtraPluginDir` + Lua fixture + full gopher-lua parity integration test (Tasks 9-13).
- **Docs** — integration-tests guide + subsystem doc-comment (Task 14).

## Test Plan

- [x] `task pr-prep` (fast lane) — pass
- [x] `task test -- ./internal/grpc/focus/` — 90.8% self-coverage; nil-sender no-op, error-continuation, session-not-found boundary cases
- [x] `task test:int -- ./test/integration/scenes/...` — green, incl. binary regression net (`real_scene_join_subscription`, `auto_focus_on_join_terminal_only`, `multi_connection_visibility`) + new Lua parity spec (INV-FS-3)
- [x] `task test -- ./test/meta/` — INV-FS-1 + INV-FS-4 gate pass
- [x] `task lint:go` clean; `rumdl` + `lint:docs-symmetry` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)