### PR TITLE
docs(plugins): fix manifest.yaml→plugin.yaml filename drift (holomush-vcvw)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,7 @@ Three plugin types:
 | `binary`    | hashicorp/go-plugin subprocess | Complex services with proto contracts  |
 | `setting`   | Bootstrap only           | Configuration-only plugins (no runtime)     |
 
-**Manifest schema** (`manifest.yaml`): Each plugin declares `requires` (proto
+**Manifest schema** (`plugin.yaml`): Each plugin declares `requires` (proto
 services it depends on), `provides` (proto services it implements), and
 `storage` (database tables it needs). The plugin loader performs DAG dependency
 resolution to determine load order and validates that all `requires` are

--- a/site/src/content/docs/contributing/explanation/event-store.md
+++ b/site/src/content/docs/contributing/explanation/event-store.md
@@ -135,13 +135,13 @@ directly.
 
 ---
 
-## Declaring audit subjects in `manifest.yaml`
+## Declaring audit subjects in `plugin.yaml`
 
 Plugins that own a subject namespace declare it in their manifest so the host
 can route audit projection to the plugin's own consumer (spec §1c, §6):
 
 ```yaml
-# plugins/core-scenes/manifest.yaml
+# plugins/core-scenes/plugin.yaml
 name: core-scenes
 type: binary
 version: "0.1.0"

--- a/site/src/content/docs/extending/how-to/verb-registration.md
+++ b/site/src/content/docs/extending/how-to/verb-registration.md
@@ -11,7 +11,7 @@ rest at load time.
 
 ## Declaring verbs in your manifest
 
-In `manifest.yaml`, add a `verbs:` block:
+In `plugin.yaml`, add a `verbs:` block:
 
 ```yaml
 verbs:
@@ -43,7 +43,7 @@ verbs:
 ## How verb metadata flows
 
 ```text
-manifest.yaml verbs:
+plugin.yaml verbs:
     ↓ plugin loader reads at LoadAll
 VerbRegistry.RegisterWithSource(reg, manifest.Version)
     ↓ RenderingPublisher wraps every Publisher call
@@ -63,7 +63,7 @@ Emitting an event whose type is not in the registry returns
 
 ## Version tracking
 
-The plugin version from `manifest.yaml` is recorded as
+The plugin version from `plugin.yaml` is recorded as
 `source_plugin_version` in the rendering metadata. After a plugin reload,
 new events carry the new version. Old events in `events_audit` keep their
 original version, enabling drift detection.


### PR DESCRIPTION
## What

The plugin loader reads **`plugin.yaml`** (`internal/plugin/manager.go:452,798`) and all ten in-tree plugins use `plugin.yaml`, but several authoritative docs still named the file `manifest.yaml`. This drift previously caused CodeRabbit to flag a correct script as broken (PR #2779 thread). Fixes `holomush-vcvw`.

## Changes (filename only — the *concept* is still "manifest")

| File | Refs |
|------|------|
| `CLAUDE.md:402` | `**Manifest schema** (plugin.yaml)` — also fixes `AGENTS.md` via its symlink |
| `site/.../extending/how-to/verb-registration.md` | 3 refs |
| `site/.../contributing/explanation/event-store.md` | 2 refs |

## Deliberately untouched
- `docs/superpowers/specs/` + `docs/superpowers/plans/` — dated point-in-time artifacts (two already note the `plugin.yaml`-not-`manifest.yaml` distinction); rewriting history is wrong.
- `internal/plugin/identity_registry_test.go:152` — a *test-code* comment, out of scope for a docs bead.
- The Go struct field `manifest.Version` (parsed-object reference, not the filename) was preserved.

## Verification
- `task pr-prep` → `status=pass lane=fast exit=0` (full fast lane: bats + lint + fmt + unit + build).
- `rg "manifest\.yaml" CLAUDE.md site/src/content/docs/` → 0 matches.

## Review chain
Skipped the full review chain per the CLAUDE.md small-fix carve-out: docs-only filename correction, no code or access-control surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)