### PR TITLE
ci(release): make release workflow dispatch-only — drop on:push:tags re-trigger (holomush-76rsl)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  # Dispatch-only. A v* tag pushed with the release App token would re-fire
+  # this workflow (App-token pushes are exempt from the GITHUB_TOKEN
+  # recursion guard), producing a duplicate run that fails on already-existing
+  # release assets. `task release:cut` always uses this dispatch entry point.
   workflow_dispatch:
     inputs:
       expected_increment:
@@ -35,9 +36,6 @@ jobs:
       packages: write # push container images to GHCR
       id-token: write # Cosign keyless signing (OIDC)
       attestations: write # SLSA provenance attestations
-    # Runs on a manual release dispatch OR a human-pushed v* tag (fallback).
-    # The old release-PR tool is gone; the v* tag is the only contract.
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -48,10 +46,8 @@ jobs:
           # tag and goreleaser creates the remote tag/Release via the App token.
           persist-credentials: false
 
-      # ── Release dispatch path: derive version + create the v* tag inline ──
-      # (skipped on the tag-push fallback path, where the tag already exists)
+      # ── Derive version + create the v* tag inline from the checked-out HEAD ──
       - name: Mint GitHub App token
-        if: github.event_name == 'workflow_dispatch'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -64,17 +60,14 @@ jobs:
           permission-packages: write
 
       - name: Install cog
-        if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/install-cog
 
       - name: Configure git identity for tagging
-        if: github.event_name == 'workflow_dispatch'
         run: |
           git config user.name "holomush-release[bot]"
           git config user.email "holomush-release[bot]@users.noreply.github.com"
 
       - name: Preview + guard version bump
-        if: github.event_name == 'workflow_dispatch'
         env:
           EXPECTED: ${{ inputs.expected_increment }}
         run: |
@@ -106,7 +99,6 @@ jobs:
           fi
 
       - name: Cut tag (cog bump, tag-only)
-        if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
           # Creates a LOCAL v* tag from conventional commits. No bump commit
@@ -119,11 +111,7 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            TAG="$(git describe --tags --abbrev=0)"   # the cog-created local tag
-          else
-            TAG="${GITHUB_REF_NAME}"                  # the human-pushed tag
-          fi
+          TAG="$(git describe --tags --abbrev=0)"   # the cog-created local tag
           if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::resolved tag '${TAG}' is not a v-prefixed semver; refusing to build a malformed release"
             exit 1
@@ -199,10 +187,9 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          # App token on the dispatch path (creates the remote tag via
-          # target_commitish + bypasses any v* tag-protection); GITHUB_TOKEN on
-          # the human-pushed-tag fallback path.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          # App token creates the remote tag via target_commitish and bypasses
+          # any v* tag-protection.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Verify signing artifacts were created (defense-in-depth)
       - name: Verify signing artifacts exist

--- a/docs/adr/holomush-4mmzy-inline-single-run-release.md
+++ b/docs/adr/holomush-4mmzy-inline-single-run-release.md
@@ -4,7 +4,7 @@
 # Cut Releases Inline in One Dispatched Run
 
 **Date:** 2026-05-24
-**Status:** Accepted
+**Status:** Superseded by holomush-76rsl
 **Decision:** holomush-4mmzy
 **Deciders:** HoloMUSH Contributors
 
@@ -76,5 +76,9 @@ fallback for human-pushed local tags.
 
 ## References
 
+- Superseded by: [`holomush-76rsl`](holomush-76rsl-release-workflow-dispatch-only.md) —
+  drops the `on: push: tags` fallback because the App-token tag creation
+  re-triggered this workflow (duplicate `422 already_exists` run). The inline
+  single-run decision below is unchanged; only the fallback sub-clause is reversed.
 - [Cocogitto Release Tooling Design — §Why a single inline dispatched run, §Component 3b, INV-1, INV-8](../superpowers/specs/2026-05-24-cocogitto-release-tooling-design.md)
 - [Tag-only release; GitHub Release notes as canonical history (`holomush-jfb9x`)](holomush-jfb9x-tag-only-release-drop-changelog.md)

--- a/docs/adr/holomush-76rsl-release-workflow-dispatch-only.md
+++ b/docs/adr/holomush-76rsl-release-workflow-dispatch-only.md
@@ -1,0 +1,105 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Release Workflow is Dispatch-Only
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Decision:** holomush-76rsl
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+`holomush-4mmzy` decided to cut releases inline in one `workflow_dispatch` run
+and **retained `on: push: tags: 'v*'` only as a fallback for human-pushed local
+tags**. Its Context reasoned that this fallback was harmless because a tag pushed
+by a workflow authenticated with the default `GITHUB_TOKEN` does not re-trigger
+`on: push: tags` — GitHub suppresses workflow-to-workflow triggering to prevent
+recursion.
+
+That analysis missed the credential the dispatch path actually uses. On the
+dispatch path GoReleaser creates the remote tag with a **GitHub App token**
+(`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`), needed to bypass `v*`
+tag-protection. App-token (and PAT) pushes are **not** subject to the
+`GITHUB_TOKEN` recursion guard — they re-trigger workflows normally.
+
+The result, observed on the `v0.5.0` cut (2026-05-29):
+
+| Run | Trigger | Actor | Outcome |
+| --- | --- | --- | --- |
+| [26648759017](https://github.com/holomush/holomush/actions/runs/26648759017) | `workflow_dispatch` | `seanb4t` | success — the real release |
+| [26648915779](https://github.com/holomush/holomush/actions/runs/26648915779) | `push` (tag `v0.5.0`) | `holomush-release-bot[bot]` | failure |
+
+The duplicate `push` run re-ran GoReleaser against the tag the dispatch run had
+already published, failing with `422 Validation Failed … Code:already_exists` on
+the release assets. Every dispatched release produced a spurious red run.
+
+## Decision
+
+The release workflow runs on `workflow_dispatch` **only**. The
+`on: push: tags: 'v*'` trigger is removed. The now-unconditional dispatch path
+also sheds its dual-path scaffolding (the per-step
+`if: github.event_name == 'workflow_dispatch'` guards, the `GITHUB_REF_NAME`
+branch in version resolution, and the `|| secrets.GITHUB_TOKEN` GoReleaser token
+fallback).
+
+The inline single-run decision of `holomush-4mmzy` (INV-1, INV-8) is **unchanged
+and reinforced** — this ADR reverses only that ADR's fallback-trigger sub-clause.
+
+## Rationale
+
+- The fallback was not harmless: the App-token tag creation it relied on
+  re-triggers the very workflow it was meant to back up, turning a "fallback"
+  into a guaranteed duplicate failing run on every release.
+- Building from `main` at dispatch time is as correct and repeatable as building
+  "on the tag": the job pins one immutable checkout, `cog bump` mints the local
+  tag at that exact SHA, and GoReleaser builds that same tree and points the
+  remote tag at it via `release.target_commitish`. Tag and build commit are
+  identical and created atomically in one job — there is no drift window that a
+  tag-checkout would close.
+- `task release:cut` already invokes `gh workflow run release.yaml`
+  (`workflow_dispatch`), so the canonical release entry point is unaffected.
+- A failed or partial release can still be rebuilt by re-running the recorded
+  workflow run (`gh run rerun`), which replays the same SHA — so dropping the
+  hand-pushed-tag entry point loses no rebuild capability.
+
+## Alternatives Considered
+
+**Option A: Keep `on: push: tags` and guard the job against the release bot**
+
+Add `&& github.actor != 'holomush-release-bot[bot]'` to the job `if:` so the
+self-triggered run no-ops while a genuine human-pushed tag still builds.
+
+| Aspect | Assessment |
+| --- | --- |
+| Strengths | Preserves the human-pushed-tag entry point |
+| Weaknesses | Keeps the dual-path conditional complexity `4mmzy` already flagged as a negative; couples the workflow to a specific bot login; the entry point is unused in practice (`task release:cut` always dispatches) |
+
+**Option B: Dispatch-only (chosen)**
+
+| Aspect | Assessment |
+| --- | --- |
+| Strengths | Eliminates the duplicate run at the source; removes all dual-path conditionals, simplifying the workflow; matches actual usage |
+| Weaknesses | A hand-pushed `v*` tag no longer starts a release — mitigated by `gh run rerun` and by always cutting via `task release:cut` |
+
+## Consequences
+
+**Positive:**
+
+- No more spurious failing `push`-triggered run per release; the dispatch run is
+  the single source of truth for a cut.
+- The workflow loses its dual-path branches and reads as a straight-line
+  dispatch pipeline.
+
+**Negative:**
+
+- Pushing a `v*` tag by hand no longer triggers a release. Cuts go through
+  `task release:cut`; ad-hoc rebuilds go through re-running the workflow run.
+
+## References
+
+- Supersedes: [`holomush-4mmzy`](holomush-4mmzy-inline-single-run-release.md) —
+  inline single-run release; this ADR reverses only its `on: push: tags`
+  fallback sub-clause.
+- [Cocogitto Release Tooling Design — INV-1, INV-8, Component 3b](../superpowers/specs/2026-05-24-cocogitto-release-tooling-design.md)
+- [GitHub Actions: events that trigger workflows — token-based recursion suppression](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)


### PR DESCRIPTION
## Problem

`task release:cut` cuts a release, then a **second** `Release` workflow run fires and fails. Observed on the `v0.5.0` cut:

| Run | Trigger | Actor | Outcome |
| --- | --- | --- | --- |
| [26648759017](https://github.com/holomush/holomush/actions/runs/26648759017) | `workflow_dispatch` | `seanb4t` | ✅ the real release |
| [26648915779](https://github.com/holomush/holomush/actions/runs/26648915779) | `push` (tag `v0.5.0`) | `holomush-release-bot[bot]` | ❌ `422 already_exists` |

### Root cause

The workflow had both `workflow_dispatch` and `on: push: tags: 'v*'`. On the dispatch path GoReleaser creates the remote `v*` tag using a **GitHub App token** (to bypass tag-protection). App-token pushes are **not** subject to GitHub's `GITHUB_TOKEN` workflow-recursion guard, so the tag push re-fires the workflow. The duplicate run re-runs GoReleaser against the already-published release → `422 Validation Failed … Code:already_exists`.

ADR `holomush-4mmzy` retained the `on: push: tags` trigger as a "human-pushed-tag fallback" but its analysis only accounted for `GITHUB_TOKEN`-pushed tags (which *are* suppressed). It missed the App-token case.

## Change

- **Drop `on: push: tags`** → the workflow is dispatch-only. `task release:cut` already uses `gh workflow run` (dispatch), so no caller change.
- Remove the now-dead dual-path scaffolding: the per-step `if: github.event_name == 'workflow_dispatch'` guards, the `GITHUB_REF_NAME` branch in version resolution, and the `|| secrets.GITHUB_TOKEN` GoReleaser token fallback.

### Is building from `main` (not the tag) correct?

Yes. The job pins one immutable checkout; `cog bump` mints the local tag at that exact SHA; GoReleaser builds that same tree and points the remote tag at it via `release.target_commitish`. Tag and build commit are identical, created atomically in one job — there is no drift window a tag-checkout would close. Re-running a workflow run (`gh run rerun`) still rebuilds the recorded SHA, so no rebuild capability is lost.

## ADR governance

This reverses only the fallback sub-clause of `holomush-4mmzy`; its inline single-run decision (INV-1, INV-8) stands and is reinforced. Per the immutability rule, adds superseding ADR **`holomush-76rsl`** and flips `4mmzy` to `Superseded by holomush-76rsl`. `task lint:adr` green.

## Verification

- `task lint:actions` ✓
- `task lint:adr` ✓ (supersession edge + status consistent)
- `task pr-prep` (fast lane) ✓ `status=pass`
- `code-reviewer` pass run (READY on all technical checks; the ADR-governance finding is addressed by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)