### PR TITLE
docs(contributing): accurate README links + contributor-facing onboarding surface (holomush-ec22.17, holomush-ec22.21)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Bug report
+description: Report a problem with HoloMUSH
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in the sections
+        below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that trigger the behavior.
+      placeholder: |
+        1. Connect via telnet ...
+        2. Run command ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual behavior
+      description: What you expected to happen, and what actually happened.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Release tag or `git` commit SHA you're running.
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, deployment style (Docker / local), and anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/holomush/holomush/discussions
+    about: Ask questions, share ideas, and discuss HoloMUSH with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Feature request
+description: Suggest an idea or enhancement for HoloMUSH
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Describe the problem first — it helps us evaluate
+        solutions we might not have considered.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about, and why they fall short.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Pull request
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123. Link the issue this PR addresses, if any. -->
+
+## Checklist
+
+- [ ] Tests added or updated, and passing (`task test`)
+- [ ] `task pr-prep` run locally and green
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,88 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@holomush.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,78 +5,81 @@
 
 # Contributing to HoloMUSH
 
-Thank you for your interest in contributing to HoloMUSH!
+Thanks for your interest in contributing! HoloMUSH is open source (Apache-2.0)
+and welcomes contributions of all kinds — code, documentation, bug reports, and
+feature ideas.
 
-## Development Process
+Find work to do, or report a bug or idea, via
+[GitHub Issues](https://github.com/holomush/holomush/issues).
 
-### Prerequisites
+## Prerequisites
 
-- Go 1.22+
-- Task (task runner)
-- PostgreSQL 18+
+- Go — the required version is pinned in [`go.mod`](go.mod)
+- [Task](https://taskfile.dev/) (the task runner this project uses)
+- PostgreSQL
+- Docker (only needed to run the integration tests locally)
 
-### Setup
+## Your first pull request
+
+HoloMUSH uses a standard GitHub fork-and-pull-request workflow:
 
 ```bash
-# Clone the repository
-git clone https://github.com/holomush/holomush.git
+# 1. Fork the repo on GitHub, then clone YOUR fork
+git clone https://github.com/<your-username>/holomush.git
 cd holomush
 
-# Install tools and git hooks
+# 2. Install tools and git hooks
 task setup
 
-# Run tests
+# 3. Create a branch
+git checkout -b my-change
+
+# 4. Make your change test-first, then run the local checks
+task lint
 task test
+task pr-prep        # the local pre-PR gate; CI also runs integration + E2E
+
+# 5. Push to your fork and open a pull request
+git push -u origin my-change
 ```
 
-### Workflow
+That's the whole flow — plain `git`, your own fork, a PR. CI runs the full
+suite (including integration and E2E tests) on every pull request.
 
-We use [beads](https://github.com/steveyegge/beads) for task tracking:
+## What we expect
 
-1. Check `bd ready` for available tasks
-2. Write failing tests first (TDD)
-3. Implement until tests pass
-4. Update documentation
-5. Submit PR
+A few conventions keep the codebase coherent. Rather than restating them here
+(where they'd drift), see the canonical docs:
 
-### Commit Messages
+- **[Pull Request Guide](https://holomush.dev/contributing/how-to/pr-guide/)** —
+  PR workflow, review, and merge process; conventional-commit titles.
+- **[Coding standards](https://holomush.dev/contributing/reference/coding-standards/)** —
+  style, error handling, test naming, the >80% coverage expectation.
+- **[Integration tests](https://holomush.dev/contributing/how-to/integration-tests/)** —
+  how the Docker-backed integration suite works.
+- **[System architecture](https://holomush.dev/contributing/explanation/architecture/)** —
+  how the pieces fit together.
+- **[Plugin guide](https://holomush.dev/extending/tutorials/plugin-guide/)** —
+  writing Lua and binary plugins.
 
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
+The `task pr-prep` gate covers most of this automatically before you open a PR.
 
-```text
-type(scope): description
+## How we develop (optional — not required for contributors)
 
-Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-```
-
-Examples:
-
-- `feat(events): add event replay on reconnection`
-- `fix(telnet): handle connection timeout gracefully`
-- `docs(readme): update quick start instructions`
-
-### Code Style
-
-- Go code follows `gofumpt` formatting
-- Run `task lint` before committing
-- Pre-commit hooks enforce style automatically
-
-### Pull Requests
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run `task lint` and `task test`
-5. Submit a PR with clear description
-
-### Questions?
-
-Open an issue for discussion before starting major work.
+HoloMUSH is developed heavily with AI coding agents, using
+[Jujutsu (jj)](https://jj-vcs.github.io/) for version control and an internal
+issue tracker. **You need none of that.** Standard `git`, GitHub Issues, and
+GitHub pull requests are fully supported and are the only thing we ask of
+contributors. (This is why you'll see a `CLAUDE.md`, a `.jj/` directory, and
+agent-authored commits — they're part of the maintainer workflow, not
+requirements for you.)
 
 ## Code of Conduct
 
-Be respectful and constructive. We're all here to build something great.
+This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold it.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.
+By contributing, you agree that your contributions will be licensed under the
+[Apache 2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A modern MUSH platform combining classic text-based multiplayer gameplay with co
 
 ### Prerequisites
 
-- Go 1.23+
+- Go (version pinned in [`go.mod`](go.mod))
 - [Task](https://taskfile.dev/) (task runner)
 - PostgreSQL (for data storage)
 - Docker (for integration tests)
@@ -86,7 +86,7 @@ telnet localhost 4201
 - **ABAC engine** with Cedar-inspired DSL, in-memory policy cache with push-based invalidation
 - **SvelteKit web client** with terminal UI, ANSI rendering, and session persistence
 
-See [Architecture](site/docs/contributors/architecture.md) for details.
+See [Architecture](https://holomush.dev/contributing/explanation/architecture/) for details.
 
 ## Development
 
@@ -141,12 +141,12 @@ cosign verify \
   ghcr.io/holomush/holomush:v1.0.0
 ```
 
-See [Verifying Releases](docs/reference/verifying-releases.md) for complete instructions.
+See [Verifying Releases](https://holomush.dev/operating/how-to/deploy/verifying-releases/) for complete instructions.
 
 ## Documentation
 
-- [Architecture](site/docs/contributors/architecture.md) - System design overview
-- [Plugin Guide](site/docs/developers/plugin-guide.md) - Writing plugins with ABAC policies
+- [Architecture](https://holomush.dev/contributing/explanation/architecture/) - System design overview
+- [Plugin Guide](https://holomush.dev/extending/tutorials/plugin-guide/) - Writing plugins with ABAC policies
 - [Contributing](CONTRIBUTING.md) - Contribution guidelines
 
 ## License

--- a/docs/superpowers/specs/2026-05-29-contributor-onboarding-surface-design.md
+++ b/docs/superpowers/specs/2026-05-29-contributor-onboarding-surface-design.md
@@ -1,0 +1,211 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Contributor Onboarding Surface — Design
+
+**Status:** Draft
+**Beads:** holomush-ec22.17 (anchor), holomush-ec22.21 (folded in)
+**Date:** 2026-05-29
+**Supersedes / relates:** follow-ups holomush-zao2 (testing guide), site `contributing/` IA restructure (to be filed)
+
+## 1. Problem
+
+The first three artifacts an external contributor encounters are broken or
+misleading:
+
+- **README.md** — 4 documentation-link occurrences (lines 89, 144, 148, 149,
+  pointing at 3 unique targets) reference the pre-migration `site/docs/` tree
+  (and a non-existent `contributors/` folder); the Go prerequisite says `1.23+`
+  while `go.mod` is `1.26.2` and CONTRIBUTING says `1.22+` — a three-way drift
+  that proves **any hardcoded version number rots after commit**.
+- **CONTRIBUTING.md** — 78 lines of generic boilerplate that actively
+  misdescribes the project: a `git clone` + feature-branch flow with no mention
+  of the real local gate (`task pr-prep`), wrong Go version (`1.22+`), and no
+  coverage / test-naming / integration-test guidance.
+- **CODE_OF_CONDUCT.md and `.github/` templates** — absent. A contributor
+  filing an issue or PR gets no scaffolding.
+
+This reads as unmaintained on first contact — directly opposed to the project's
+open-source goal.
+
+## 2. Audience principle (the spine)
+
+HoloMUSH is developed primarily by its maintainer and AI agents using an
+internal toolchain: **jujutsu (jj)** workspaces, a **Dolt-backed `bd` (beads)**
+tracker, and a stage-gated spec→plan→bead workflow. **External contributors
+have none of this** — no `bd` server access, no jj requirement (the repo is
+git-colocated, so plain `git` works end-to-end).
+
+> **Invariant of this design:** the maintainer/agent workflow MUST NOT be
+> conflated with the external-contributor workflow. CONTRIBUTING.md and the
+> `.github/` surface address the **external contributor only**: standard GitHub
+> fork → `git` branch → PR, GitHub **Issues** for finding/reporting work, and
+> `task` targets for local checks. Maintainer/agent tooling is acknowledged
+> exactly once, as explicitly **not required**.
+
+This principle also governs *what CONTRIBUTING links to*: it MUST route
+contributors only to audience-appropriate (tool-agnostic) docs, never to
+jj/beads-specific maintainer pages.
+
+## 3. Scope
+
+**In scope (one coherent "external-contributor onboarding surface" change):**
+
+- README.md — repoint 4 doc-link occurrences to published `holomush.dev` URLs; remove hardcoded tool versions (reference `go.mod`).
+- CONTRIBUTING.md — rewrite as a thin, accurate front-door **router**.
+- CODE_OF_CONDUCT.md — add (Contributor Covenant 2.1).
+- `.github/` — add issue templates (bug, feature), `config.yml`, and `PULL_REQUEST_TEMPLATE.md`.
+- Audience banners on `site/src/content/docs/contributing/how-to/pr-prep.md` and
+  `…/sessions.md` marking them maintainer-workflow (jj+beads) pages.
+
+**Out of scope (follow-ups, do not do here):**
+
+- Authoring the testify-vs-ginkgo testing guide → holomush-zao2.
+- Full audience-based IA restructure of the site `contributing/` section
+  (separating maintainer vs contributor docs throughout) → new bead to be filed.
+- README status-section accuracy beyond the Go version (e.g., "planned"
+  features that have shipped) — not a link/onboarding defect.
+
+## 4. Design
+
+### 4a. README.md (surgical, in place)
+
+Repoint the broken links to published URLs (all verified `200` on 2026-05-29):
+
+| README line(s) | Old (broken) | New (published URL) |
+| --- | --- | --- |
+| 89, 148 | `site/docs/contributors/architecture.md` | `https://holomush.dev/contributing/explanation/architecture/` |
+| 144 | `docs/reference/verifying-releases.md` | `https://holomush.dev/operating/how-to/deploy/verifying-releases/` |
+| 149 | `site/docs/developers/plugin-guide.md` | `https://holomush.dev/extending/tutorials/plugin-guide/` |
+
+(Source note: the plugin-guide page is `…/extending/tutorials/plugin-guide.mdx`
+— MDX, not `.md`; Starlight renders both to the same slug. An implementer
+verifying file existence MUST search for `.mdx`.)
+
+**Remove hardcoded tool versions** rather than updating them — they are
+guaranteed stale once committed (the three-way drift in §1 is the proof).
+Replace `Go 1.23+` with `Go` linking to the source of truth
+(`[`go.mod`](go.mod)`); drop any pinned PostgreSQL major. Leave the rest of
+README's structure and prose intact.
+
+### 4b. CONTRIBUTING.md (thin front-door router, ~50–70 lines)
+
+A contributor must be able to go from zero to an open PR using only this file +
+the published docs it links. Sections:
+
+1. **Welcome** — Apache-2.0; contributions of all kinds welcome; find and report
+   work via **GitHub Issues** (link to the issues page), not an internal tracker.
+2. **Prerequisites** — Go (version pinned in [`go.mod`](go.mod)), [Task],
+   PostgreSQL, Docker (for integration tests). **No hardcoded version numbers** —
+   reference `go.mod` as the single source of truth so the doc cannot drift.
+3. **Your first PR** — standard git: fork → `git clone` your fork → `task setup`
+   → `git checkout -b` → make changes (TDD) → `task lint && task test` →
+   `task pr-prep` (note: "CI runs the full suite including integration and E2E")
+   → push to your fork → open a PR.
+4. **What we expect** — conventional-commit PR titles, tests-first, >80%
+   coverage, ACE test names — each **linked** to the canonical page rather than
+   restated:
+   - Pull Request Guide → `https://holomush.dev/contributing/how-to/pr-guide/`
+   - Coding standards → `https://holomush.dev/contributing/reference/coding-standards/`
+   - Integration tests → `https://holomush.dev/contributing/how-to/integration-tests/`
+   - System architecture → `https://holomush.dev/contributing/explanation/architecture/`
+   - Plugin authoring → `https://holomush.dev/extending/tutorials/plugin-guide/`
+5. **How we develop (optional — not required for contributors)** — one short
+   paragraph: HoloMUSH is developed heavily with AI agents using jj and an
+   internal issue tracker; **you need none of it** — standard git, GitHub
+   Issues, and GitHub PRs are fully supported and all we ask. (Explains the
+   otherwise-confusing `CLAUDE.md`, `.jj/`, and agent-authored commits.)
+6. **Code of Conduct** — link to `CODE_OF_CONDUCT.md`.
+7. **License** — inbound=outbound Apache-2.0 (retain).
+
+`task pr-prep` is named as the local gate but the jj/beads-flavored
+`pr-prep.md` page is **not** linked raw; a one-line caveat notes its examples
+use the maintainer jj flow while the `task` itself works identically under git.
+`sessions.md` (jj workspaces) is **never** linked from CONTRIBUTING.
+
+### 4c. CODE_OF_CONDUCT.md
+
+Adopt **Contributor Covenant 2.1** verbatim (the de-facto OSS standard), with
+the enforcement/reporting contact set to the dedicated role alias
+**`conduct@holomush.dev`** (decoupled from any individual; the user confirms the
+address is provisionable on the domain).
+
+### 4d. `.github/` templates
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml` — GitHub issue **form**: summary,
+  reproduction, expected vs actual, version/commit, environment.
+- `.github/ISSUE_TEMPLATE/feature_request.yml` — issue form: problem, proposed
+  solution, alternatives.
+- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: true` (stay
+  low-friction). Contact links: **no Security link** (`SECURITY.md` confirmed
+  absent, 2026-05-29); add a **Discussions** contact link only if Discussions is
+  enabled on the repo (verify with `gh repo view --json hasDiscussionsEnabled`
+  run from the main repo dir at implementation; if disabled or unverifiable,
+  omit `contact_links` entirely — a bare `blank_issues_enabled: true` is valid).
+- `.github/PULL_REQUEST_TEMPLATE.md` — audience-neutral (used by contributors
+  *and* maintainers): summary, linked issue, and a short checklist (tests pass,
+  `task pr-prep` run, conventional-commit title). No jj/beads specifics.
+
+### 4e. Audience banners (site docs)
+
+Prepend a short admonition to `pr-prep.md` and `sessions.md` (Starlight `:::note`
+or equivalent) identifying them as **maintainer workflow** pages assuming jj +
+the internal tracker, and pointing external contributors to CONTRIBUTING.md.
+This keeps the CONTRIBUTING router honest without restructuring the site IA.
+
+## 5. Invariants (RFC2119, verifiable)
+
+- **INV-1** — README MUST NOT contain any link to the legacy `site/docs/` tree
+  or `docs/reference/` paths. Every documentation link in README MUST be a
+  published `holomush.dev` URL that resolves `200`. *(check: the "no legacy
+  path" clause is `rg`-verifiable and CI-enforceable; the "resolves `200`"
+  clause is a **manual pre-merge gate** — `task pr-prep:docs` (markdownlint/
+  rumdl) does NOT perform HTTP resolution on external URLs, and no
+  `lychee`/link-checker is wired in. **Accepted tradeoff:** published-URL links
+  can rot silently post-merge with no automated detector; this is the cost of
+  reader-facing URLs over repo-relative paths. Mitigation: verify each URL by
+  `curl -I` before merge.)*
+- **INV-2** — README and CONTRIBUTING MUST NOT hardcode a Go (or other tool)
+  version number; the Go prerequisite MUST reference `go.mod` as the source of
+  truth. *(check: `rg -n "[Gg]o 1\.[0-9]+|PostgreSQL [0-9]" README.md
+  CONTRIBUTING.md` → 0 hits)*
+- **INV-3** — CONTRIBUTING.md MUST NOT present `jj`, `bd`/beads, or `jj
+  workspace` commands as contributor steps. Any mention of them MUST appear
+  only within the "How we develop" section, framed as not-required.
+  *(check: `rg` for `^\s*(jj|bd)` command lines = 0)*
+- **INV-4** — `CODE_OF_CONDUCT.md` MUST exist at repo root and CONTRIBUTING's
+  Code of Conduct section MUST link to it. *(check: file exists + `rg` link)*
+- **INV-5** — `.github/ISSUE_TEMPLATE/` MUST contain a bug and a feature
+  template, and `.github/PULL_REQUEST_TEMPLATE.md` MUST exist. *(check: `fd`)*
+- **INV-6** — CONTRIBUTING MUST NOT link `sessions.md`; `pr-prep.md` MUST be
+  referenced only as the `task pr-prep` gate with the maintainer-flow caveat.
+  *(check: `rg`)*
+- **INV-7** — `pr-prep.md` and `sessions.md` MUST each carry an audience banner
+  identifying them as maintainer (jj+beads) workflow pages. *(check: `rg`)*
+
+## 6. Verification
+
+- `task pr-prep` (docs lane: markdown lint, link checks, fmt, license headers) green.
+- Manual `curl -I` (or browser) confirms every new README/CONTRIBUTING URL resolves `200`.
+- `rg "site/docs/|docs/reference/" README.md` → 0 hits (INV-1).
+- `rg -n "[Gg]o 1\.[0-9]+|PostgreSQL [0-9]" README.md CONTRIBUTING.md` → 0 hits
+  (INV-2: no hardcoded tool versions).
+- License headers present on new `.md`/`.yml` files where applicable (`task license:check`).
+
+## 7. Resolved / confirmed-at-implementation decisions
+
+1. **CoC enforcement contact** — RESOLVED: dedicated alias
+   `conduct@holomush.dev` (see §4c).
+2. **`config.yml` contact links** — Security link: NO (`SECURITY.md` absent,
+   confirmed 2026-05-29). Discussions link: verify `hasDiscussionsEnabled` at
+   implementation; omit if disabled/unverifiable (see §4d).
+
+## 8. Follow-ups (file as separate beads)
+
+- **holomush-zao2** — author the testify-vs-ginkgo contributor testing guide;
+  once it exists, add it to the CONTRIBUTING router.
+- **(new)** — audience-based IA restructure of the site `contributing/` section:
+  cleanly separate maintainer-workflow docs (jj, beads, pr-prep, sessions) from
+  contributor-facing docs throughout, rather than relying on per-page banners.

--- a/site/src/content/docs/contributing/how-to/pr-prep.md
+++ b/site/src/content/docs/contributing/how-to/pr-prep.md
@@ -2,6 +2,15 @@
 title: "Pre-Push Quality Gate (`task pr-prep`)"
 ---
 
+:::note[Maintainer workflow]
+This page documents the maintainer/agent workflow; its examples assume
+[Jujutsu (jj)](https://jj-vcs.github.io/) and the project's internal tooling.
+**External contributors don't need jj** — `task pr-prep` works identically under
+standard `git`. See
+[CONTRIBUTING.md](https://github.com/holomush/holomush/blob/main/CONTRIBUTING.md)
+for the contributor workflow.
+:::
+
 `task pr-prep` is the project's mandatory pre-push gate. It MUST pass before pushing to a PR branch. HoloMUSH uses a two-lane design so the gate is always fast locally while the heavyweight integration and E2E checks run in CI.
 
 ## Lanes

--- a/site/src/content/docs/contributing/how-to/sessions.md
+++ b/site/src/content/docs/contributing/how-to/sessions.md
@@ -2,6 +2,14 @@
 title: "Session Isolation"
 ---
 
+:::note[Maintainer workflow]
+This page documents the maintainer/agent session-isolation workflow using
+[Jujutsu (jj)](https://jj-vcs.github.io/) workspaces. **External contributors
+don't need jj or workspaces** — a standard `git` fork-and-branch workflow is all
+that's required. See
+[CONTRIBUTING.md](https://github.com/holomush/holomush/blob/main/CONTRIBUTING.md).
+:::
+
 HoloMUSH is developed primarily by concurrent AI agent sessions (Claude Code) and human contributors working in parallel. Because `jj` snapshots the working copy on every command, two sessions sharing the same `jj` workspace will collide on uncommitted edits.
 
 To prevent this, every Claude Code session runs in its own `jj` workspace under `<repo-parent>/.worktrees/<name>`.


### PR DESCRIPTION
## What

Fixes the **external-contributor first-impression surface** — the README links, CONTRIBUTING.md, CODE_OF_CONDUCT, and `.github/` templates. Closes **holomush-ec22.17** and **holomush-ec22.21** (folded together; same surface).

Brainstormed via `dev-flow:brainstorming`; design-reviewer **READY**. Spec: `docs/superpowers/specs/2026-05-29-contributor-onboarding-surface-design.md`.

## Audience principle (the spine)

The maintainer/agent workflow (jj, internal `bd` tracker, stage-gated flow) is **never conflated** with the external-contributor workflow. CONTRIBUTING and `.github/` address external contributors only — standard GitHub fork → `git` branch → PR, GitHub **Issues** for work — and acknowledge the internal tooling exactly once, as explicitly *not required*.

## Changes

- **README.md** — repoint 4 broken doc links (lines 89/144/148/149) to published `holomush.dev` URLs (all verified `200`); **remove the hardcoded Go version**, linking `go.mod` as the source of truth. (There was a three-way drift: `go.mod` 1.26.2 / README 1.23+ / CONTRIBUTING 1.22+ — any pinned number rots after commit.)
- **CONTRIBUTING.md** — rewritten as a thin front-door **router**: standard git/GitHub flow, GitHub Issues, `task pr-prep`; links only contributor-safe published docs (pr-guide, coding-standards, integration-tests, architecture, plugin-guide); a "How we develop" note frames jj/beads/`CLAUDE.md` as not-required.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, contact `conduct@holomush.dev`.
- **`.github/`** — bug + feature issue forms, `config.yml` (Discussions contact link; no Security link — no `SECURITY.md`), `PULL_REQUEST_TEMPLATE.md`.
- **Audience banners** on `contributing/how-to/pr-prep.md` and `sessions.md` marking them maintainer (jj) workflow pages.

## Invariants

7 RFC2119 invariants in the spec, all verified (no legacy doc paths in README; no hardcoded tool versions; no jj/bd command-steps in CONTRIBUTING; CoC exists+linked; templates exist; sessions.md not linked; banners present).

## Verification

`task pr-prep` → `status=pass lane=fast exit=0` (bats + license + lint + markdown + build). All 6 published URLs return `200`.

## Out of scope (follow-ups)

- holomush-zao2 — testify-vs-ginkgo testing guide.
- New bead (to file) — full audience-based IA restructure of the site `contributing/` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)