### PR TITLE
fix(plugin): thread connection_id through binary-plugin command adapter (holomush-dble7)

### DIFF
--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -267,6 +267,13 @@ func (a *pluginServerAdapter) HandleCommand(ctx context.Context, req *pluginv1.H
 		SessionID:     protoCmd.GetSessionId(),
 		PlayerID:      protoCmd.GetPlayerId(),
 		InvokedAs:     protoCmd.GetRawInput(),
+		// Phase 5 (holomush-dble7): without this, the per-connection id sent
+		// by the host (host.go DeliverCommand, proto field 9) is dropped on
+		// receive, so binary-plugin handlers see an empty ConnectionID and
+		// `scene focus`/`scene grid` reject every web command with "requires a
+		// live connection". Lua plugins pass the struct in-process and never
+		// lose it — omitting it here is a plugin-runtime-symmetry violation.
+		ConnectionID: protoCmd.GetConnectionId(),
 	}
 
 	// Attach an audit hint slice to the handler context so plugin code

--- a/pkg/plugin/sdk_connectionid_internal_test.go
+++ b/pkg/plugin/sdk_connectionid_internal_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"testing"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureCommandHandler records the CommandRequest it receives so a test can
+// assert which proto fields the server adapter mapped through.
+type captureCommandHandler struct {
+	got CommandRequest
+}
+
+func (h *captureCommandHandler) HandleCommand(_ context.Context, req CommandRequest) (*CommandResponse, error) {
+	h.got = req
+	return OK("ok"), nil
+}
+
+// TestPluginServerAdapterHandleCommandMapsConnectionID is the regression test
+// for holomush-dble7: the binary-plugin SDK server adapter MUST copy the proto
+// CommandRequest.connection_id (field 9) into pluginsdk.CommandRequest.ConnectionID.
+// Dropping it (the original bug) made `scene focus`/`scene grid` reject every
+// real web command with "requires a live connection", because the handler's
+// req.ConnectionID was always empty. This is the binary-runtime analogue of the
+// in-process Lua path (which never round-trips through proto), so dropping it
+// here is also a plugin-runtime-symmetry violation.
+func TestPluginServerAdapterHandleCommandMapsConnectionID(t *testing.T) {
+	tests := []struct {
+		name   string
+		connID string
+	}{
+		{"maps a populated connection_id through to the handler", "01KSTEHGQEXR7J0B0VK5GBKG1F"},
+		// Legacy/scripted callers omit connection_id (executeViaDispatcher
+		// allows empty); the adapter must pass the empty value through, not
+		// substitute a sentinel.
+		{"passes an empty connection_id through unchanged", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &captureCommandHandler{}
+			adapter := &pluginServerAdapter{cmdHandler: handler}
+
+			_, err := adapter.HandleCommand(context.Background(), &pluginv1.HandleCommandRequest{
+				Command: &pluginv1.CommandRequest{
+					Command:      "scene",
+					Args:         "focus #01KSTEHGRW53M7Y5RE0XCP74HZ",
+					CharacterId:  "char-1",
+					SessionId:    "01KSTEHGPG40KRF87BB72WNZNM",
+					ConnectionId: tt.connID,
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.connID, handler.got.ConnectionID,
+				"adapter MUST map proto connection_id into CommandRequest.ConnectionID (holomush-dble7)")
+		})
+	}
+}

--- a/web/e2e/scenes.spec.ts
+++ b/web/e2e/scenes.spec.ts
@@ -185,3 +185,52 @@ test.describe('Scene lifecycle (Phase 2)', () => {
     await waitForOutputMatching(page, /State: active/, before);
   });
 });
+
+test.describe('Scene focus routing (Phase 5, holomush-dble7)', () => {
+  // Reproduction for holomush-dble7: `scene focus`/`scene grid` are the only
+  // commands that hard-require req.ConnectionID (the per-stream connection_id
+  // the web client captures from the STREAM_OPENED ControlFrame and echoes on
+  // SendCommand). If the live stream is up but the command carries an empty
+  // connection_id, the plugin rejects with "requires a live connection"
+  // (plugins/core-scenes/commands.go:1146 for focus, :1092 for grid). A guest
+  // is auto-joined as the owner of the scene it creates, so membership is
+  // satisfied and the ONLY thing that can produce that message is an empty
+  // connection_id reaching the handler.
+  test('scene focus on a joined scene succeeds (does not report no live connection)', async ({
+    page,
+  }) => {
+    await connectAsGuest(page);
+
+    let before = await currentEventCount(page);
+    await sendCommand(page, 'scene create Focus Routing Test');
+    const sceneId = await extractSceneIdFromOutput(page, before);
+    expect(sceneId).toMatch(/^[0-9A-Z]{26}$/);
+
+    // Focus-substrate membership is established by `scene join` (JoinFocus),
+    // not by `scene create` (DB row only) — so join before focusing, which is
+    // the real user flow. NB: `scene join` takes a BARE id (no `#`), whereas
+    // `scene focus` REQUIRES the `#` prefix.
+    before = await currentEventCount(page);
+    await sendCommand(page, `scene join ${sceneId}`);
+    await waitForOutputMatching(page, /Joined scene/, before);
+
+    before = await currentEventCount(page);
+    await sendCommand(page, `scene focus #${sceneId}`);
+    // The dble7 bug surfaced here: an empty connection_id yielded
+    // "`scene focus` requires a live connection." instead of the success line.
+    await waitForOutputMatching(
+      page,
+      new RegExp(`now focused on Scene ${sceneId}`),
+      before,
+    );
+  });
+
+  test('scene grid succeeds (does not report no live connection)', async ({ page }) => {
+    await connectAsGuest(page);
+
+    // No scene needed — `scene grid` only requires a live per-connection id.
+    const before = await currentEventCount(page);
+    await sendCommand(page, 'scene grid');
+    await waitForOutputMatching(page, /Focused on the grid\./, before);
+  });
+});


### PR DESCRIPTION
## Summary

`scene focus` / `scene grid` from the web terminal returned ```scene focus` requires a live connection.`` despite a live, connected session (bead **holomush-dble7**, P1).

**Root cause:** the binary-plugin SDK *receive* adapter `pluginServerAdapter.HandleCommand` (`pkg/plugin/sdk.go`) rebuilt `pluginsdk.CommandRequest` from the inbound proto but **omitted `ConnectionID`** — so binary-plugin command handlers always saw an empty connection id. `scene focus`/`scene grid` are the only commands that gate on a per-connection id, so they rejected every web command.

The host **sends** `connection_id` correctly (`internal/plugin/goplugin/host.go`, proto field 9) and the in-process Lua delivery path carries it — so this was a **binary-runtime-only** gap, i.e. a `plugin-runtime-symmetry` violation. It evaded `TestDispatcher_PassesConnectionIDToPluginCommand`, which uses a fake deliverer at the struct boundary rather than the proto adapter.

**Fix:** one line — map proto `connection_id` into `CommandRequest` in the SDK adapter.

## Verification
- New internal regression unit test `TestPluginServerAdapterHandleCommandMapsConnectionID` (red → green) — exercises the real adapter, not a mock.
- New `web/e2e/scenes.spec.ts` **Scene focus routing** suite: `scene focus` (create → join → focus) and `scene grid` — **both pass** end-to-end on the Docker stack; the "requires a live connection" message is gone.
- Unit suites `pkg/plugin` + `internal/command` + `internal/plugin` green (2123 tests); fast `pr-prep` pass.
- `code-reviewer`: **READY** (no blocking findings).

## Reproduction (before)
Live web session, `scene create` + `scene list` work, but `scene focus #<id>` → ```scene focus` requires a live connection.`` Reproduced on current main via the new e2e (not deployment skew).

## Follow-ups filed (not in this PR)
- **holomush-yak8r** (P1) — web UI OpenTelemetry traces never reach Sentry (export gated off + no traceparent propagation to the gateway + `command.roundtrip` span omits `connection_id`). *This is why the bug was hard to diagnose.*
- **holomush-ehbnk** (P3) — `scene focus` requires the `#` prefix while `scene join` rejects it; + a possible silent `scene focus`-on-non-member to verify.
- **holomush-…** (P3) — add a Go-tier host↔binary-plugin gRPC command round-trip test (per code-reviewer defense-in-depth finding).

Resolves holomush-dble7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)