### PR TITLE
fix(help): render partial command list on ABAC soft-error instead of hiding all (holomush-869o8)

### DIFF
--- a/internal/plugin/help_integration_test.go
+++ b/internal/plugin/help_integration_test.go
@@ -307,10 +307,15 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 	})
 
 	Describe("error engine handling", func() {
-		It("returns unavailable message when list_commands engine errors", func() {
-			// The Lua plugin calls list_commands; when the policy engine errors,
-			// list_commands returns an error and the Lua code returns a graceful
-			// failure message (status=2) rather than a partial list.
+		It("renders the available partial list when list_commands engine errors", func() {
+			// When the policy engine errors, list_commands returns a populated list
+			// of no-capability commands (always included; here "look") plus
+			// incomplete=true and a non-nil err — the SOFT-failure tier of the host
+			// contract (internal/plugin/hostfunc/commands.go). The Lua handler honors
+			// it: render the usable commands with an incompleteness indicator rather
+			// than hiding everything behind a blanket message (holomush-869o8). The
+			// blanket "temporarily unavailable" message is reserved for a genuinely
+			// nil result (registry/engine nil), which an error engine never produces.
 			errorEngine := policytest.NewErrorEngine(errors.New("policy store unavailable"))
 			fixture, err := setupHelpTestWithEngine(errorEngine)
 			Expect(err).NotTo(HaveOccurred())
@@ -327,10 +332,14 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeNil())
 
-			Expect(resp.Status).To(Equal(pluginsdk.CommandFailure),
-				"engine error should produce CommandFailure status")
-			Expect(resp.Output).To(ContainSubstring("temporarily unavailable"),
-				"should return a graceful unavailability message, not a partial list")
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK),
+				"a populated-but-incomplete list must render, not fail")
+			Expect(resp.Output).NotTo(ContainSubstring("temporarily unavailable"),
+				"the blanket message is reserved for a genuinely nil result")
+			Expect(resp.Output).To(ContainSubstring("look"),
+				"no-capability commands are always available and must be shown")
+			Expect(resp.Output).To(ContainSubstring("incomplete"),
+				"the user must be told the list may be incomplete")
 		})
 
 		It("returns full command list when engine succeeds", func() {
@@ -353,9 +362,11 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			Expect(resp.Output).NotTo(ContainSubstring("unavailable"))
 		})
 
-		It("returns unavailable message when search engine errors", func() {
-			// search_commands also calls list_commands; engine errors produce
-			// a graceful failure message (status=2) rather than partial search results.
+		It("renders partial search results when search engine errors", func() {
+			// search_commands shares list_commands' contract: an engine error yields
+			// a populated list of no-capability commands + incomplete=true, so the
+			// search runs over the usable subset and renders matches with an
+			// incompleteness indicator rather than a blanket failure (holomush-869o8).
 			errorEngine := policytest.NewErrorEngine(errors.New("policy store unavailable"))
 			fixture, err := setupHelpTestWithEngine(errorEngine)
 			Expect(err).NotTo(HaveOccurred())
@@ -372,10 +383,14 @@ var _ = Describe("Help Plugin – list_commands result format", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).NotTo(BeNil())
 
-			Expect(resp.Status).To(Equal(pluginsdk.CommandFailure),
-				"engine error during search should produce CommandFailure status")
-			Expect(resp.Output).To(ContainSubstring("temporarily unavailable"),
-				"should return a graceful unavailability message, not partial search results")
+			Expect(resp.Status).To(Equal(pluginsdk.CommandOK),
+				"a populated-but-incomplete search must render, not fail")
+			Expect(resp.Output).NotTo(ContainSubstring("temporarily unavailable"),
+				"the blanket message is reserved for a genuinely nil result")
+			Expect(resp.Output).To(ContainSubstring("look"),
+				"the matching no-capability command must be shown")
+			Expect(resp.Output).To(ContainSubstring("incomplete"),
+				"the user must be told the search list may be incomplete")
 		})
 	})
 })

--- a/plugins/core-help/help_lua_test.go
+++ b/plugins/core-help/help_lua_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package corehelp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// blanketMessage is the user-facing string the handler MUST reserve for a
+// genuinely unavailable result (registry/engine nil → host returns nil result).
+// It MUST NOT appear when the host returns a populated-but-incomplete list.
+const blanketMessage = "Help is temporarily unavailable. Please try again later."
+
+// listCommandsResult configures the stubbed holomush.list_commands return for
+// a single test case, mirroring the host contract in
+// internal/plugin/hostfunc/commands.go:
+//   - hard failure (registry/engine nil): nilResult=true, errString!=""
+//   - soft failure (incomplete): nilResult=false, populated commands,
+//     incomplete=true, errString!=""
+//   - clean: nilResult=false, populated commands, incomplete=false, errString=""
+type listCommandsResult struct {
+	commands   []map[string]string // each row: name, help, usage, source
+	incomplete bool
+	nilResult  bool
+	errString  string // "" => Lua nil (no error)
+}
+
+// runHelp loads the real plugins/core-help/main.lua into a gopher-lua state
+// with stubbed holo.fmt and holomush host tables, then invokes on_command with
+// the given args. It returns the rendered output text regardless of whether the
+// handler returned a bare string (success path) or a {status, output} table
+// (error path).
+func runHelp(t *testing.T, args string, stub listCommandsResult) string {
+	t.Helper()
+
+	L := lua.NewState()
+	defer L.Close()
+
+	registerFmtStub(L)
+	registerHolomushStub(L, stub)
+
+	require.NoError(t, L.DoFile("main.lua"), "load core-help main.lua")
+
+	ctx := L.NewTable()
+	L.SetField(ctx, "args", lua.LString(args))
+	L.SetField(ctx, "character_id", lua.LString("01HZX0000000000000000TURQ"))
+
+	require.NoError(t, L.CallByParam(lua.P{
+		Fn:      L.GetGlobal("on_command"),
+		NRet:    1,
+		Protect: true,
+	}, ctx), "call on_command")
+
+	ret := L.Get(-1)
+	L.Pop(1)
+
+	switch v := ret.(type) {
+	case lua.LString:
+		return string(v)
+	case *lua.LTable:
+		return lua.LVAsString(L.GetField(v, "output"))
+	default:
+		t.Fatalf("on_command returned unexpected type %T", ret)
+		return ""
+	}
+}
+
+// registerFmtStub installs a minimal `holo.fmt` table. The formatters are
+// identity-ish so that command names, the trailing hint, and any incomplete
+// indicator survive into the asserted output.
+func registerFmtStub(L *lua.LState) {
+	identity := func(s *lua.LState) int {
+		s.Push(lua.LString(s.CheckString(1)))
+		return 1
+	}
+	fmtMod := L.NewTable()
+	L.SetField(fmtMod, "header", L.NewFunction(identity))
+	L.SetField(fmtMod, "bold", L.NewFunction(identity))
+	L.SetField(fmtMod, "dim", L.NewFunction(identity))
+	// table stub: flatten rows so cell contents (command names) appear in output.
+	L.SetField(fmtMod, "table", L.NewFunction(func(s *lua.LState) int {
+		arg := s.CheckTable(1)
+		rows, ok := L.GetField(arg, "rows").(*lua.LTable)
+		var b strings.Builder
+		if ok {
+			rows.ForEach(func(_, row lua.LValue) {
+				rt, isTbl := row.(*lua.LTable)
+				if !isTbl {
+					return
+				}
+				rt.ForEach(func(_, cell lua.LValue) {
+					b.WriteString(lua.LVAsString(cell))
+					b.WriteString(" ")
+				})
+				b.WriteString("\n")
+			})
+		}
+		s.Push(lua.LString(b.String()))
+		return 1
+	}))
+	holo := L.NewTable()
+	L.SetField(holo, "fmt", fmtMod)
+	L.SetGlobal("holo", holo)
+}
+
+// registerHolomushStub installs a `holomush` table with a no-op log and a
+// list_commands that returns the configured (result, err) pair.
+func registerHolomushStub(L *lua.LState, stub listCommandsResult) {
+	holomush := L.NewTable()
+	L.SetField(holomush, "log", L.NewFunction(func(_ *lua.LState) int { return 0 }))
+	L.SetField(holomush, "list_commands", L.NewFunction(func(s *lua.LState) int {
+		if stub.nilResult {
+			s.Push(lua.LNil)
+		} else {
+			result := s.NewTable()
+			cmds := s.NewTable()
+			for i, c := range stub.commands {
+				ct := s.NewTable()
+				s.SetField(ct, "name", lua.LString(c["name"]))
+				s.SetField(ct, "help", lua.LString(c["help"]))
+				s.SetField(ct, "usage", lua.LString(c["usage"]))
+				s.SetField(ct, "source", lua.LString(c["source"]))
+				s.RawSetInt(cmds, i+1, ct)
+			}
+			s.SetField(result, "commands", cmds)
+			s.SetField(result, "incomplete", lua.LBool(stub.incomplete))
+			s.Push(result)
+		}
+		if stub.errString != "" {
+			s.Push(lua.LString(stub.errString))
+		} else {
+			s.Push(lua.LNil)
+		}
+		return 2
+	}))
+	L.SetGlobal("holomush", holomush)
+}
+
+func twoCommands() []map[string]string {
+	return []map[string]string{
+		{"name": "help", "help": "Show help", "source": "core-help"},
+		{"name": "look", "help": "Look around", "source": "core-world"},
+	}
+}
+
+// TestHelpHandlerRendersAccordingToListCommandsContract exercises the no-args
+// (list_all_commands) and "search <term>" (search_commands) paths against every
+// tier of the holomush.list_commands contract:
+//   - soft failure (populated result + incomplete=true + err): render the usable
+//     commands with an incompleteness indicator, never the blanket message;
+//   - hard failure (nil result + err): show the blanket message;
+//   - clean (populated result, no err): render the full list, no indicator.
+//
+// The "incomplete" substring is the lowercase token from the dim indicator the
+// handler appends; its presence/absence distinguishes soft from clean/hard.
+func TestHelpHandlerRendersAccordingToListCommandsContract(t *testing.T) {
+	const searchBlanket = "Search is temporarily unavailable"
+
+	tests := []struct {
+		name            string
+		args            string
+		result          listCommandsResult
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "list renders partial list with indicator when incomplete with error",
+			args: "",
+			result: listCommandsResult{
+				commands:   twoCommands(),
+				incomplete: true,
+				errString:  "some commands may be hidden due to a system error; try again or contact an admin if the problem persists",
+			},
+			wantContains:    []string{"help", "look", "incomplete"},
+			wantNotContains: []string{blanketMessage},
+		},
+		{
+			name:         "list shows blanket message when result unavailable",
+			args:         "",
+			result:       listCommandsResult{nilResult: true, errString: "command registry not available"},
+			wantContains: []string{blanketMessage},
+		},
+		{
+			name:            "list renders full list without indicator when complete",
+			args:            "",
+			result:          listCommandsResult{commands: twoCommands()},
+			wantContains:    []string{"help", "look"},
+			wantNotContains: []string{blanketMessage, "incomplete"},
+		},
+		{
+			name: "search renders partial matches with indicator when incomplete with error",
+			args: "search look",
+			result: listCommandsResult{
+				commands:   twoCommands(),
+				incomplete: true,
+				errString:  "some commands may be hidden due to a system error",
+			},
+			wantContains:    []string{"look", "incomplete"},
+			wantNotContains: []string{searchBlanket},
+		},
+		{
+			name:         "search shows blanket message when result unavailable",
+			args:         "search look",
+			result:       listCommandsResult{nilResult: true, errString: "access engine not available"},
+			wantContains: []string{searchBlanket},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := runHelp(t, tt.args, tt.result)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, out, want)
+			}
+			for _, notWant := range tt.wantNotContains {
+				assert.NotContains(t, out, notWant)
+			}
+		})
+	}
+}

--- a/plugins/core-help/main.lua
+++ b/plugins/core-help/main.lua
@@ -20,14 +20,33 @@ local function table_sort_by_key(t, key)
 end
 
 -- list_all_commands handles "help" with no arguments.
+--
+-- holomush.list_commands has a two-tier failure contract (see
+-- internal/plugin/hostfunc/commands.go): a HARD failure (command registry or
+-- access engine unavailable) returns a nil result plus an error; a SOFT failure
+-- returns a fully-populated command list with result.incomplete=true plus an
+-- error, because an ABAC engine error hid some capability-gated commands.
+-- No-capability commands (help itself included) are always present, so the soft
+-- list is usable. We therefore branch on result, not on err: only a nil result
+-- warrants the blanket "unavailable" message; an incomplete list is rendered
+-- with a warning so the user still gets the commands they can run.
 local function list_all_commands(ctx)
     local result, err = holomush.list_commands(ctx.character_id)
-    if err then
-        holomush.log("error", "help: failed to list commands for " .. ctx.character_id .. ": " .. err)
+
+    if result == nil then
+        if err then
+            holomush.log("error", "help: failed to list commands for " .. ctx.character_id .. ": " .. err)
+        end
         return {status = 2, output = "Help is temporarily unavailable. Please try again later."}
     end
 
-    if result == nil or #result.commands == 0 then
+    local incomplete = err ~= nil or result.incomplete == true
+    if incomplete then
+        holomush.log("warn", "help: command list incomplete for " .. ctx.character_id ..
+            (err and (": " .. err) or ""))
+    end
+
+    if #result.commands == 0 then
         return "No commands available."
     end
 
@@ -65,6 +84,10 @@ local function list_all_commands(ctx)
     end
 
     out = out .. holo.fmt.dim("Type 'help <command>' for detailed help.")
+    if incomplete then
+        out = out .. "\n" .. holo.fmt.dim(
+            "⚠ This command list may be incomplete due to a temporary system error. Try 'help' again shortly.")
+    end
     return out
 end
 
@@ -106,11 +129,25 @@ local function show_command_help(ctx, name)
 end
 
 -- search_commands handles "help search <term>".
+--
+-- Shares list_commands' two-tier failure contract with list_all_commands: a nil
+-- result is a hard failure (blanket message), while a populated result with a
+-- non-nil err / incomplete=true is a soft failure whose usable subset we still
+-- search and render, appending an incompleteness indicator.
 local function search_commands(ctx, term)
     local result, err = holomush.list_commands(ctx.character_id)
-    if err then
-        holomush.log("error", "help: failed to search commands for " .. term .. ": " .. err)
+
+    if result == nil then
+        if err then
+            holomush.log("error", "help: failed to search commands for " .. term .. ": " .. err)
+        end
         return {status = 2, output = "Search is temporarily unavailable. Please try again later."}
+    end
+
+    local incomplete = err ~= nil or result.incomplete == true
+    if incomplete then
+        holomush.log("warn", "help: search command list incomplete for " .. term ..
+            (err and (": " .. err) or ""))
     end
 
     local lower_term = term:lower()
@@ -137,6 +174,10 @@ local function search_commands(ctx, term)
     end
     out = out .. holo.fmt.table({headers = {"Command", "Description"}, rows = rows}) .. "\n\n"
     out = out .. holo.fmt.dim("Found " .. #matches .. " command(s).")
+    if incomplete then
+        out = out .. "\n" .. holo.fmt.dim(
+            "⚠ Searchable commands may be incomplete due to a temporary system error. Try again shortly.")
+    end
 
     return out
 end


### PR DESCRIPTION
## Problem

P1 prod bug (`holomush-869o8`). Typing `help` rendered a blanket "Help is temporarily unavailable. Please try again later." and hid **every** command whenever a single capability-gated command's ABAC eval errored — 100% reproducing in prod for guests. The rest of the game was healthy, so the plugin host, registry, and engine were all up; help just discarded a usable list.

## Root cause

`holomush.list_commands` has a deliberate **two-tier failure contract** (`internal/plugin/hostfunc/commands.go:50-55`):

- **Hard failure** (command registry or access engine nil) → `nil` result + error string.
- **Soft failure** (≥1 ABAC engine error; circuit breaker trips at 3) → a **fully-populated** commands list with `incomplete=true` + a non-nil error string.

No-capability commands — including `help` itself (`plugin.yaml` `capabilities: []`) — are *always* included even when the breaker trips, so the soft list is always usable. But `plugins/core-help/main.lua` branched on `if err` and threw the populated list away, collapsing both tiers into the blanket message.

## Fix

`plugins/core-help/main.lua` only (the host func was already correct and well-covered):

- Branch on `result == nil` instead of `err`. Hard failure → blanket message; soft failure → render the available commands plus a dim "⚠ may be incomplete" indicator and a `warn` log.
- Applied to **both** `list_all_commands` (the bead's scoped no-args path) **and** `search_commands`, which carried the identical contract violation in the same file.

## Tests

New `plugins/core-help/help_lua_test.go` — a test-only Go package that loads the **real** `main.lua` in a gopher-lua harness with stubbed `holo.fmt`/`holomush`. 5 cases: list partial-on-incomplete, list blanket-on-nil, search partial-on-incomplete, search blanket-on-nil, clean-no-indicator. The partial-render cases fail against the original code and pass after the fix.

## Verification

- `task test -- ./plugins/core-help/ ./internal/plugin/hostfunc/` → 442 pass
- `task lint:go` → 0 issues
- `task pr-prep` (fast lane) → status=pass
- Pre-push `code-reviewer` gate → READY (no blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)