### PR TITLE
fix(web): render connection + presence status dots green via dedicated status.online token (holomush-wnilg)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -40,6 +40,7 @@
   --color-surface: #1e1612;
   --color-status-text: #666055;
   --color-status-background: #1e1612;
+  --color-status-online: #66bb6a;
   --color-sidebar-background: #1e1612;
   --color-scrollback-indicator: #ffb74d;
   --radius: 0.5rem;

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -208,7 +208,7 @@
     color: var(--color-muted-foreground);
   }
   .conn-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-text); }
-  .conn-pill[data-status="connected"] .conn-dot { background: var(--mush-arrive, #66bb6a); }
+  .conn-pill[data-status="connected"] .conn-dot { background: var(--color-status-online); }
   .conn-pill[data-status="syncing"] .conn-dot { background: var(--color-accent); animation: dot-pulse 1200ms ease-in-out infinite; }
   .conn-pill[data-status="disconnected"] .conn-dot { background: var(--mush-system, #e57373); }
   .nav-link {

--- a/web/src/lib/components/sidebar/PresenceList.svelte
+++ b/web/src/lib/components/sidebar/PresenceList.svelte
@@ -66,7 +66,7 @@
   .name { flex: 1; color: var(--color-input-text); }
   .status-dot {
     width: 6px; height: 6px; border-radius: 50%;
-    background: var(--mush-arrive, #66bb6a);
+    background: var(--color-status-online);
   }
   .pres-row.is-idle .status-dot { background: var(--color-status-text); }
 </style>

--- a/web/src/lib/stores/themeStore.test.ts
+++ b/web/src/lib/stores/themeStore.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, vi } from 'vitest';
+
+// themeStore.ts calls loadPreferences() at module load (touches localStorage),
+// which runs before the beforeEach polyfill in test-setup.ts. Stub it before
+// the import so the module evaluates cleanly.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  } as Storage;
+  // jsdom does not implement matchMedia; loadPreferences() calls it at module load.
+  globalThis.matchMedia ??= ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof globalThis.matchMedia;
+});
+
+import { themeToCssVars } from './themeStore';
+import type { ThemeColors } from '$lib/theme/types';
+import defaultDark from '$lib/theme/default-dark.json';
+import defaultLight from '$lib/theme/default-light.json';
+import classicDark from '$lib/theme/classic-dark.json';
+import classicLight from '$lib/theme/classic-light.json';
+
+const builtInThemes = [
+  ['default-dark', defaultDark],
+  ['default-light', defaultLight],
+  ['classic-dark', classicDark],
+  ['classic-light', classicLight],
+] as const;
+
+// Parse #rrggbb into channels so "is it green?" is asserted on the value,
+// not pinned to one exact hex.
+function rgb(hex: string): { r: number; g: number; b: number } {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) throw new Error(`not a #rrggbb hex: ${hex}`);
+  return { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) };
+}
+
+describe('status.online token (holomush-wnilg)', () => {
+  for (const [id, theme] of builtInThemes) {
+    const colors = theme.colors as Record<string, string>;
+
+    it(`${id} defines a green-dominant status.online color`, () => {
+      const online = colors['status.online'];
+      expect(online, `${id} must define a status.online color`).toBeDefined();
+      const { r, g, b } = rgb(online);
+      // Green channel dominates → the dot reads as green, not grey.
+      expect(g, `${id} status.online (${online}) green channel must exceed red`).toBeGreaterThan(r);
+      expect(g, `${id} status.online (${online}) green channel must exceed blue`).toBeGreaterThan(b);
+    });
+
+    it(`${id} decouples status.online from the muted arrive message token`, () => {
+      // The original bug coupled the connection dot to --mush-arrive, which
+      // every theme defines grey. The status indicator must NOT reuse it.
+      expect(colors['status.online']).not.toBe(colors['arrive']);
+    });
+
+    it(`${id} exposes status.online as the chrome --color-status-online custom property`, () => {
+      // The CSS references var(--color-status-online); themeToCssVars must
+      // actually define it (killing the dead var(--x, fallback) footgun).
+      const css = themeToCssVars(theme.colors as ThemeColors);
+      expect(css).toContain(`--color-status-online: ${colors['status.online']}`);
+    });
+  }
+});
+
+describe('status dot CSS wiring (holomush-wnilg)', () => {
+  // Guard the consuming sites, not just the token table: the original bug
+  // lived in the .svelte CSS (var(--mush-arrive, …)). Reverting these lines
+  // while keeping the token would otherwise pass every token-table assertion.
+  // cwd is the web/ package dir because vitest is launched from there.
+  const componentSrc = (rel: string) =>
+    readFileSync(`${process.cwd()}/src/lib/components/${rel}`, 'utf8');
+
+  const sites = [
+    ['TopBar connected dot', 'TopBar.svelte'],
+    ['PresenceList online dot', 'sidebar/PresenceList.svelte'],
+  ] as const;
+
+  for (const [label, rel] of sites) {
+    it(`${label} consumes --color-status-online`, () => {
+      expect(componentSrc(rel)).toContain('var(--color-status-online)');
+    });
+
+    it(`${label} no longer reuses the muted --mush-arrive message token`, () => {
+      // Match the var() usage, not the bare token name, so a future prose
+      // mention of --mush-arrive in a comment can't false-fail the guard.
+      expect(componentSrc(rel)).not.toContain('var(--mush-arrive');
+    });
+  }
+});

--- a/web/src/lib/theme/classic-dark.json
+++ b/web/src/lib/theme/classic-dark.json
@@ -20,6 +20,7 @@
     "input.background": "#0a0a16",
     "status.text": "#555555",
     "status.background": "#12122a",
+    "status.online": "#66bb6a",
     "sidebar.background": "#12122a",
     "scrollback.indicator": "#ffb74d",
     "primary": "#4fc3f7",

--- a/web/src/lib/theme/classic-light.json
+++ b/web/src/lib/theme/classic-light.json
@@ -20,6 +20,7 @@
     "input.background": "#ffffff",
     "status.text": "#616161",
     "status.background": "#f0f0f0",
+    "status.online": "#2e7d32",
     "sidebar.background": "#f5f5f5",
     "scrollback.indicator": "#e65100",
     "primary": "#0277bd",

--- a/web/src/lib/theme/default-dark.json
+++ b/web/src/lib/theme/default-dark.json
@@ -20,6 +20,7 @@
     "input.background": "#16100c",
     "status.text": "#666055",
     "status.background": "#1e1612",
+    "status.online": "#66bb6a",
     "sidebar.background": "#1e1612",
     "scrollback.indicator": "#ffb74d",
     "primary": "#ff7043",

--- a/web/src/lib/theme/default-light.json
+++ b/web/src/lib/theme/default-light.json
@@ -20,6 +20,7 @@
     "input.background": "#fffcf8",
     "status.text": "#6b6055",
     "status.background": "#f0ebe5",
+    "status.online": "#2e7d32",
     "sidebar.background": "#f5f0ea",
     "scrollback.indicator": "#e65100",
     "primary": "#e64a19",

--- a/web/src/lib/theme/types.ts
+++ b/web/src/lib/theme/types.ts
@@ -24,6 +24,7 @@ export interface ThemeColors {
   'input.background': string;
   'status.text': string;
   'status.background': string;
+  'status.online': string;
   'sidebar.background': string;
   'scrollback.indicator': string;
 


### PR DESCRIPTION
## Summary

The "connected" status dot (TopBar) and presence "online" dots (PresenceList) rendered **grey, not green**, in every theme. Both sites used `var(--mush-arrive, #66bb6a)` — but `--mush-arrive` is the MUSH *arrive-message* color, unconditionally injected by every theme as grey (`#888888` dark / `#616161` light). Because the custom property is always defined, the green `#66bb6a` CSS fallback was **unreachable dead code**.

Fix (direction A from the bead — decouple the status indicator from the message palette):

- Add a dedicated chrome token `status.online` (→ `--color-status-online`) to `ThemeColors` and all four theme JSONs: `#66bb6a` (dark), `#2e7d32` (light, matching each light theme's existing `pose.actor` green for legibility).
- Point both dots at `var(--color-status-online)` with **no fallback**, matching the established sibling convention (`--color-status-text` on `TopBar:210` / `PresenceList:71`). The referenced custom property is now always defined, so there is no dead fallback to mislead future readers.

Found while fixing this: the *disconnected* dot (`TopBar:213`, `var(--mush-system, …)` → renders orange) is the same bug class but out of this bead's scope — filed as **holomush-qs31c**.

## Test Plan

- [x] New `web/src/lib/stores/themeStore.test.ts` (16 cases): every theme defines a green-dominant `status.online` distinct from the grey `arrive` token; `themeToCssVars` emits `--color-status-online`; **and** the consuming `.svelte` sites reference `var(--color-status-online)` and no longer reference `--mush-arrive` (guards against a wiring-only revert).
- [x] `npx vitest run` — 78/78 web unit tests pass
- [x] `svelte-check` — 0 errors
- [x] `task pr-prep` (fast lane) — pass
- [x] code-reviewer gate — READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)