### PR TITLE
fix(web): enrich command.roundtrip OTel span + wire browser PUBLIC_OTEL_ENDPOINT (holomush-yak8r)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,10 +166,22 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build web bundle into internal/web/dist/
-        # PUBLIC_SENTRY_* are baked into the SvelteKit static bundle at BUILD
-        # time (no runtime server). When PUBLIC_SENTRY_DSN is unset/empty the
-        # browser SDK init is a no-op, so this is safe before the secret exists.
+        # PUBLIC_* are baked into the SvelteKit static bundle at BUILD time —
+        # adapter-static emits frozen HTML embedded into the Go binary via
+        # go:embed, so there is no runtime server to inject $env/dynamic/public.
+        # Each var below is a no-op when unset/empty (browser SDK/tracer init
+        # returns early), so this is safe before the var/secret is populated.
+        #
+        # PUBLIC_OTEL_ENDPOINT gates the OTel-native browser tracer
+        # (web/src/lib/telemetry.ts) — the project's primary, vendor-neutral
+        # telemetry path. Set it (via the PUBLIC_OTEL_ENDPOINT repo/environment
+        # variable) to a BROWSER-REACHABLE OTLP-HTTP base URL once one exists;
+        # browser spans then flow to the OTel collector, which fans out to
+        # Sentry/Tempo via its own exporters. See holomush-yak8r notes: a
+        # same-origin gateway OTLP relay (mirroring /api/sentry-relay) is the
+        # recommended prod path to dodge ad-blockers/CORS on the ingest origin.
         env:
+          PUBLIC_OTEL_ENDPOINT: ${{ vars.PUBLIC_OTEL_ENDPOINT }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
           PUBLIC_SENTRY_ENVIRONMENT: prod
           PUBLIC_SENTRY_RELEASE: ${{ steps.version.outputs.version }}

--- a/site/src/content/docs/operating/how-to/sentry.md
+++ b/site/src/content/docs/operating/how-to/sentry.md
@@ -16,27 +16,31 @@ Sentry is a one-line config change; no app code needs to be touched.
 
 ## Architecture
 
-```text
-                         ┌──────────────────────┐
-                         │  Existing OTLP gRPC  │
-                  ┌─────►│  → Grafana / Tempo   │
-┌─────────────┐   │      └──────────────────────┘
-│ holomush    │   │
-│ TracerProv  │───┤
-│             │   │      ┌──────────────────────┐
-└─────────────┘   └─────►│  Sentry OTLP HTTP    │
-                         │  → sentry.io         │
-                         └──────────────────────┘
+```mermaid
+flowchart LR
+  subgraph server["Server (Go)"]
+    tp["TracerProvider"]
+  end
+  tp -->|"OTLP gRPC"| tempo["Grafana / Tempo"]
+  tp -->|"Sentry OTLP HTTP"| sentry["sentry.io"]
 
-         (browser)       ┌──────────────────────┐
-         WebTracerProv  ────► OTLP HTTP collector│
-         + @sentry/svelte ──► sentry.io          │
-                         └──────────────────────┘
+  subgraph browser["Browser (SvelteKit)"]
+    web["WebTracerProvider (OTel)"]
+    sdk["@sentry/svelte SDK"]
+  end
+  web -->|"OTLP HTTP"| collector["OTLP collector"]
+  collector -->|"exporters"| tempo
+  collector -->|"exporters"| sentry
+  sdk -->|"via /api/sentry-relay"| sentry
 ```
 
-Both backends receive a copy of every span. Errors and logs (captured via
-`sentry.CaptureException` and `sentry.Logger`) are emitted only over the
-Sentry channel.
+The server `TracerProvider` dual-exports every span (Grafana/Tempo **and**
+Sentry). The browser has **two independent channels**: the OTel
+`WebTracerProvider` reaches Sentry/Tempo only **through the collector's
+exporters** (it never talks to sentry.io directly), while `@sentry/svelte`
+tunnels straight to sentry.io via the same-origin relay. Errors and logs
+(`sentry.CaptureException`, `sentry.Logger`) are emitted only over the Sentry
+channel.
 
 ## Server-side (Go binaries)
 
@@ -69,6 +73,51 @@ Add the following to the web client's environment (SvelteKit reads
 The browser SDK is dynamically imported and tree-shaken out when
 `PUBLIC_SENTRY_DSN` is empty, so deployments without Sentry pay no bundle
 cost.
+
+### Browser traces are OTel-native (`PUBLIC_OTEL_ENDPOINT`)
+
+The browser has **two independent channels** (see the architecture diagram
+above): the OTel `WebTracerProvider` (`web/src/lib/telemetry.ts`) and the
+`@sentry/svelte` SDK (`web/src/lib/sentry.ts`). HoloMUSH keeps **traces
+OpenTelemetry-native** — the Sentry SDK is reserved for the Sentry-specific
+bits with no OTel browser equivalent (unhandled-error capture,
+`console.error`/`console.warn` forwarding). Custom spans
+(`command.roundtrip`, `stream.lifecycle`) are emitted on the OTel tracer, so
+they reach Sentry **only via the collector's Sentry exporter**, never through
+the Sentry browser SDK.
+
+> **Privacy note:** the `command.roundtrip` span records `command.input` — the
+> verbatim text the player typed. Authentication is a separate `/login` RPC
+> (not a terminal command), so credentials do not flow through this span, but
+> in-game commands can still carry private content. Browser spans only leave
+> the page when `PUBLIC_OTEL_ENDPOINT` is set; point it only at a collector you
+> control, and scrub/redact at the collector if your retention policy requires.
+
+| Variable               | Required | Default | Notes                                                                 |
+| ---------------------- | -------- | ------- | --------------------------------------------------------------------- |
+| `PUBLIC_OTEL_ENDPOINT` | no       | (unset) | Browser-reachable OTLP-HTTP **base** URL; `telemetry.ts` appends `/v1/traces`. When unset the web tracer no-ops. Baked at build time (see below). |
+
+Because the web client ships as an `adapter-static` bundle embedded into the
+Go binary via `go:embed`, **every `PUBLIC_*` value is frozen at
+`task web:build` (`pnpm build`) time** — there is no runtime server to inject
+`$env/dynamic/public`. Setting `PUBLIC_OTEL_ENDPOINT` (or `PUBLIC_SENTRY_DSN`)
+in the *deployed* container's runtime environment has **no effect**; the
+release pipeline (`.github/workflows/release.yaml`) injects these at build
+time before `goreleaser` packages the image.
+
+In production the Go binary serves the web bundle, the ConnectRPC gateway, and
+`/api/sentry-relay` on a **single origin** (`web/src/lib/transport.ts` prod
+`baseUrl=""`), so the OTel `FetchInstrumentation` auto-propagates `traceparent`
+to the gateway with no CORS involved — `propagateTraceHeaderCorsUrls`'
+`localhost` matcher only matters for the cross-origin **dev** layout
+(`vite` on `:5173` → gateway on `:8080`).
+
+> **Browser → collector reachability (prod hand-off):** browser OTLP POSTs to
+> an external collector face ad-blockers and CORS on the ingest origin — the
+> same reason the Sentry SDK tunnels through the same-origin
+> `/api/sentry-relay`. The recommended prod path is a **same-origin gateway
+> OTLP relay** that forwards browser OTLP to the collector; until that exists,
+> leave `PUBLIC_OTEL_ENDPOINT` unset in prod. See `holomush-yak8r`.
 
 ## Local dev setup
 

--- a/web/src/lib/commandSpan.test.ts
+++ b/web/src/lib/commandSpan.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { describe, it, expect } from 'vitest';
+import { commandRoundtripAttributes } from './commandSpan';
+
+describe('commandRoundtripAttributes', () => {
+  it('records the full command input verbatim', () => {
+    const attrs = commandRoundtripAttributes('look here', '01HCONN0000000000000000AAA');
+    expect(attrs['command.input']).toBe('look here');
+  });
+
+  it('extracts command name from the first whitespace-delimited token', () => {
+    const attrs = commandRoundtripAttributes('say hello world', '01HCONN0000000000000000AAA');
+    expect(attrs['command.name']).toBe('say');
+  });
+
+  it('trims for the name but stores command.input verbatim', () => {
+    const attrs = commandRoundtripAttributes('   pose waves   ', '01HCONN0000000000000000AAA');
+    expect(attrs['command.name']).toBe('pose');
+    expect(attrs['command.input']).toBe('   pose waves   ');
+  });
+
+  it('records connection_id and a true presence witness when connectionId is set', () => {
+    const attrs = commandRoundtripAttributes('look', '01HCONN0000000000000000AAA');
+    expect(attrs['connection_id']).toBe('01HCONN0000000000000000AAA');
+    expect(attrs['connection_id.present']).toBe(true);
+  });
+
+  it('records a false presence witness when connectionId is empty (the dble7 signal)', () => {
+    const attrs = commandRoundtripAttributes('look', '');
+    expect(attrs['connection_id']).toBe('');
+    expect(attrs['connection_id.present']).toBe(false);
+  });
+
+  it('yields an empty command name for an empty command without throwing', () => {
+    const attrs = commandRoundtripAttributes('', '01HCONN0000000000000000AAA');
+    expect(attrs['command.name']).toBe('');
+    expect(attrs['command.input']).toBe('');
+  });
+});

--- a/web/src/lib/commandSpan.ts
+++ b/web/src/lib/commandSpan.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import type { Attributes } from '@opentelemetry/api';
+
+/**
+ * Build the OpenTelemetry attribute bag for a `command.roundtrip` span.
+ *
+ * Kept pure (no `$env`/SDK imports) so the per-command telemetry can be
+ * asserted in unit tests. `connection_id` is exactly the field that goes
+ * empty in the holomush-dble7 scene-focus bug class; recording it — plus a
+ * boolean `connection_id.present` witness — makes that failure visible on the
+ * span. The witness lets a backend query distinguish "absent" from
+ * "present-but-empty" without string comparison. (Unlike the host-side ABAC
+ * `has_X` convention, which OMITS an absent key to avoid fail-open DSL
+ * semantics, the value is emitted as `''` alongside the witness — span
+ * attributes carry no such fail-open risk.)
+ *
+ * `command.name` is the first whitespace-delimited token (the verb), a
+ * low-cardinality attribute suitable for grouping; `command.input` carries the
+ * full input verbatim, preserving the pre-existing span attribute.
+ */
+export function commandRoundtripAttributes(
+  command: string,
+  connectionId: string,
+): Attributes {
+  // split(/\s+/, 1) on a trimmed string always yields a 1-element array
+  // (`['']` for empty input), so [0] is always a string.
+  const name = command.trim().split(/\s+/, 1)[0];
+  return {
+    'command.input': command,
+    'command.name': name,
+    'connection_id': connectionId,
+    'connection_id.present': connectionId !== '',
+  };
+}

--- a/web/src/lib/telemetry.ts
+++ b/web/src/lib/telemetry.ts
@@ -75,6 +75,13 @@ export async function initTelemetry(): Promise<void> {
     registerInstrumentations({
       instrumentations: [
         new FetchInstrumentation({
+          // DEV-ONLY matcher. FetchInstrumentation always injects `traceparent`
+          // on SAME-ORIGIN requests; this list only governs CROSS-origin ones.
+          // In prod the Go binary serves the web bundle and the ConnectRPC
+          // gateway on one origin (transport.ts prod baseUrl=""), so
+          // propagation is automatic and this matcher is irrelevant. It exists
+          // for the dev layout (vite :5173 → gateway :8080). Do NOT "widen to
+          // the gateway origin" for prod — that's a no-op there. See holomush-yak8r.
           propagateTraceHeaderCorsUrls: [/localhost/],
         }),
       ],

--- a/web/src/routes/(authed)/terminal/+page.svelte
+++ b/web/src/routes/(authed)/terminal/+page.svelte
@@ -31,6 +31,7 @@
   import Sidebar from '$lib/components/sidebar/Sidebar.svelte';
   import { goto } from '$app/navigation';
   import { trace, type Span } from '@opentelemetry/api';
+  import { commandRoundtripAttributes } from '$lib/commandSpan';
   import { backfillStreams } from '$lib/backfill/streamBackfill';
   import { isUnimplementedError } from '$lib/connect/errors';
   import { isStaleSession } from '$lib/util/stale';
@@ -626,18 +627,28 @@
       pendingCommandSpan.setStatus({ code: 2, message: 'timeout' });
       pendingCommandSpan.end();
     }
-    pendingCommandSpan = tracer.startSpan('command.roundtrip', {
+    // Capture a local handle: the module-level pendingCommandSpan can be nulled
+    // or replaced across the awaits below — by a command_response event ending
+    // it, or by a concurrent sendCommand starting a new one. All mutations go
+    // through `span`; the module var is only cleared if it still points here.
+    // command.input is set at span start so it survives a stream-ready timeout.
+    const span = tracer.startSpan('command.roundtrip', {
       attributes: { 'command.input': command },
     });
+    pendingCommandSpan = span;
 
     try {
       await waitForStreamReady();
+      // Attach the connection_id actually sent to the gateway (post stream-ready)
+      // plus command.name. An empty connection_id here is the holomush-dble7
+      // scene-focus signal — recording it makes that bug class visible on the span.
+      span.setAttributes(commandRoundtripAttributes(command, connectionId));
       const resp = await client.sendCommand({ sessionId, text: command, connectionId });
       if (!resp.success) {
         error = resp.errorMessage || 'Command failed';
-        pendingCommandSpan?.setStatus({ code: 2, message: error });
-        pendingCommandSpan?.end();
-        pendingCommandSpan = null;
+        span.setStatus({ code: 2, message: error });
+        span.end();
+        if (pendingCommandSpan === span) pendingCommandSpan = null;
       }
     } catch (e) {
       if (isStaleSession(e)) {
@@ -645,9 +656,9 @@
         return;
       }
       error = e instanceof Error ? e.message : 'Command failed';
-      pendingCommandSpan?.setStatus({ code: 2, message: error });
-      pendingCommandSpan?.end();
-      pendingCommandSpan = null;
+      span.setStatus({ code: 2, message: error });
+      span.end();
+      if (pendingCommandSpan === span) pendingCommandSpan = null;
     }
   }
 


### PR DESCRIPTION
## Summary

Resolves the code-side of **holomush-yak8r** (Web UI OpenTelemetry → Sentry). Root-cause investigation reframed the bead: the browser has **two disjoint telemetry channels** — the OTel `WebTracerProvider` (→ collector) and the `@sentry/svelte` SDK (→ sentry.io). HoloMUSH keeps **traces OpenTelemetry-native**; Sentry is a downstream consumer of the collector, not a span source. So `command.roundtrip` (an OTel span) reaches Sentry only via the collector's exporter — the bead's suggested telemetry.ts "fixes" targeted the wrong pipeline.

- **Enrich the OTel `command.roundtrip` span** — new pure, unit-tested helper `commandRoundtripAttributes` (`web/src/lib/commandSpan.ts`) records `connection_id`, a `connection_id.present` boolean witness, and `command.name`. Wired into `terminal/+page.svelte` at **send time** (post `waitForStreamReady`) so the span captures the `connection_id` actually sent to the gateway — the holomush-dble7 scene-focus signal.
- **Build-time wiring** — `PUBLIC_OTEL_ENDPOINT` is now injectable at release build (`release.yaml` `web:embed`, `vars.PUBLIC_OTEL_ENDPOINT`, empty default = safe no-op), mirroring the `PUBLIC_SENTRY_*` block. `adapter-static` + `go:embed` bakes `$env` at build time; runtime injection has no effect.
- **Docs** — `operating/how-to/sentry.md` documents the two-pipeline model, static-build env-baking, same-origin auto-propagation, and the prod relay hand-off.
- **No-churn clarification** — `propagateTraceHeaderCorsUrls` is dev-only (prod is same-origin via `transport.ts baseUrl=""`); added a comment so it isn't "widened to the gateway origin" per the bead's misdiagnosis.

## Not in this PR (hand-off / follow-up)

- **holomush-2uogn** (filed): same-origin gateway OTLP relay (mirrors `/api/sentry-relay`) — the prod substrate so browser OTLP reaches the collector without ad-blocker/CORS issues.
- **Operator verification (yak8r AC):** the live "zero browser spans in Sentry" symptom is in the `@sentry/svelte` path — verify `PUBLIC_SENTRY_DSN` secret is non-empty and the deployed image post-dates the Sentry wiring. After 2uogn, set `vars.PUBLIC_OTEL_ENDPOINT` and confirm `command.roundtrip` reaches Sentry via the collector.

## Test Plan

- [x] `web pnpm test:unit` — new `commandSpan.test.ts` (6 cases) + full suite green on rebased main (84 tests)
- [x] `web pnpm check` (svelte-check) — 0 errors
- [x] `task pr-prep` (fast lane) — status=pass
- [x] `task lint:actions`, `task lint:markdown`, `task fmt:check` — clean
- [ ] Operator: live-Sentry verification per hand-off above

🤖 Generated with [Claude Code](https://claude.com/claude-code)