### PR TITLE
test(plugin): command connection_id round-trip coverage for both plugin runtimes (holomush-q5czf)

### DIFF
--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -1717,7 +1717,8 @@ function on_command(ctx)
     return ctx.command .. "|" .. ctx.args .. "|" ..
            ctx.character_id .. "|" .. ctx.character_name .. "|" ..
            ctx.location_id .. "|" .. ctx.session_id .. "|" ..
-           ctx.player_id .. "|" .. ctx.invoked_as
+           ctx.player_id .. "|" .. ctx.invoked_as .. "|" ..
+           ctx.connection_id
 end
 `)
 
@@ -1743,10 +1744,15 @@ end
 		SessionID:     "01SESS",
 		PlayerID:      "01PLAYER",
 		InvokedAs:     ";",
+		// connection_id is the per-connection routing id (Phase 5). It MUST
+		// reach the Lua on_command handler — the runtime-symmetric counterpart
+		// of the binary path guarded by connection_id_roundtrip_test.go
+		// (holomush-dble7 was the binary side dropping it).
+		ConnectionID: "01CONN",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "say|Hello!|01CHAR|Alice|01LOC|01SESS|01PLAYER|;", resp.Output)
+	assert.Equal(t, "say|Hello!|01CHAR|Alice|01LOC|01SESS|01PLAYER|;|01CONN", resp.Output)
 }
 
 func TestLuaHostDeliverCommandWithHostFunctions(t *testing.T) {

--- a/test/integration/plugin/connection_id_roundtrip_test.go
+++ b/test/integration/plugin/connection_id_roundtrip_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package plugin_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/goplugin"
+	"github.com/holomush/holomush/internal/plugin/plugintest"
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
+// buildConnIDEchoPlugin compiles the connid_echo_plugin testdata binary into a
+// fresh per-test directory laid out the way goplugin.Host.Load expects
+// (<dir>/plugin.yaml + <dir>/<os>-<arch>/connid-echo-plugin). Mirrors
+// buildForgeryPlugin in actor_authentication_test.go.
+func buildConnIDEchoPlugin() (string, *plugins.Manifest) {
+	GinkgoT().Helper()
+	pluginDir := GinkgoT().TempDir()
+	platformDir := runtime.GOOS + "-" + runtime.GOARCH
+	platformSubDir := filepath.Join(pluginDir, platformDir)
+	Expect(os.MkdirAll(platformSubDir, 0o755)).To(Succeed())
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	srcDir := filepath.Join(filepath.Dir(thisFile), "testdata", "connid_echo_plugin")
+	manifestData, err := os.ReadFile(filepath.Join(srcDir, "plugin.yaml"))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), manifestData, 0o644)).To(Succeed())
+
+	manifest, err := plugins.ParseManifest(manifestData)
+	Expect(err).NotTo(HaveOccurred())
+
+	binaryPath := filepath.Join(platformSubDir, "connid-echo-plugin")
+	cmd := exec.Command("go", "build", "-o", binaryPath, ".") // #nosec G204 -- in-tree test source dir
+	cmd.Dir = srcDir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, buildErr := cmd.CombinedOutput()
+	Expect(buildErr).NotTo(HaveOccurred(), "go build connid_echo_plugin failed: %s", string(out))
+
+	return pluginDir, manifest
+}
+
+// This suite is the Go-tier regression guard for holomush-dble7. The bug was a
+// dropped ConnectionID in the binary-plugin SDK receive adapter
+// (pkg/plugin/sdk.go); it evaded TestDispatcher_PassesConnectionIDToPluginCommand
+// because that test uses a fake deliverer at the struct boundary, never the
+// real proto round-trip. Here a real binary plugin is loaded over go-plugin
+// gRPC and a command is delivered through host.DeliverCommand
+// (host send -> proto -> SDK adapter receive -> handler); the plugin echoes
+// the ConnectionID it observed so we can assert it survived.
+var _ = Describe("Binary plugin command connection_id round-trip (holomush-dble7)", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		host       *goplugin.Host
+		pluginName string
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+		pluginDir, manifest := buildConnIDEchoPlugin()
+		pluginName = manifest.Name
+		// DeliverCommand stamps an actor + issues an emit token, which needs
+		// the plugin name resolvable to a ULID via the identity registry.
+		host = goplugin.NewHost(
+			goplugin.WithIdentityRegistry(plugintest.NewStubRegistry(manifest.Name)),
+		)
+		Expect(host.Load(ctx, manifest, pluginDir)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		if host != nil {
+			_ = host.Close(ctx)
+		}
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	DescribeTable(
+		"delivers connection_id intact across the gRPC proto boundary",
+		func(connID string) {
+			resp, err := host.DeliverCommand(ctx, pluginName, pluginsdk.CommandRequest{
+				Command:      "echo",
+				CharacterID:  "char-1",
+				ConnectionID: connID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+			// The plugin echoes "connid=<ConnectionID it received>". If the SDK
+			// adapter drops connection_id (the dble7 regression), a populated
+			// connID arrives empty at the handler and this assertion fails.
+			Expect(resp.Output).To(Equal("connid=" + connID))
+		},
+		Entry("a populated connection_id reaches the handler", "01KSTEHGQEXR7J0B0VK5GBKG1F"),
+		Entry("an empty connection_id passes through unchanged (legacy/scripted caller)", ""),
+	)
+})

--- a/test/integration/plugin/testdata/connid_echo_plugin/main.go
+++ b/test/integration/plugin/testdata/connid_echo_plugin/main.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Package main implements connid_echo_plugin: a test-only binary plugin whose
+// HandleCommand echoes the ConnectionID it received back in the response
+// output. It is the fixture for connection_id_roundtrip_test.go, which proves
+// that CommandRequest.connection_id survives the full
+// host -> proto -> SDK-adapter -> handler round-trip over real go-plugin gRPC.
+//
+// Regression guard for holomush-dble7: the binary-plugin SDK receive adapter
+// (pkg/plugin/sdk.go pluginServerAdapter.HandleCommand) once dropped
+// ConnectionID when rebuilding pluginsdk.CommandRequest from the proto, which
+// no struct-boundary unit test caught (the dispatcher test used a fake
+// deliverer). This plugin drives the real adapter.
+package main
+
+import (
+	"context"
+
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
+// echoPlugin implements both Handler (required by Serve) and CommandHandler
+// (so the SDK server adapter wires cmdHandler and routes HandleCommand here).
+type echoPlugin struct{}
+
+// HandleEvent is an unused no-op; this plugin only exercises the command path.
+func (p *echoPlugin) HandleEvent(_ context.Context, _ pluginsdk.Event) ([]pluginsdk.EmitEvent, error) {
+	return nil, nil
+}
+
+// HandleCommand echoes the received ConnectionID so the test can assert it
+// survived the gRPC proto round-trip. The "connid=" prefix keeps the assertion
+// unambiguous even when ConnectionID is empty (the legacy/scripted path).
+func (p *echoPlugin) HandleCommand(_ context.Context, req pluginsdk.CommandRequest) (*pluginsdk.CommandResponse, error) {
+	return pluginsdk.OK("connid=" + req.ConnectionID), nil
+}
+
+func main() {
+	pluginsdk.Serve(&pluginsdk.ServeConfig{Handler: &echoPlugin{}})
+}

--- a/test/integration/plugin/testdata/connid_echo_plugin/plugin.yaml
+++ b/test/integration/plugin/testdata/connid_echo_plugin/plugin.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+# connid-echo-plugin is a test-only binary plugin used by
+# connection_id_roundtrip_test.go. Its HandleCommand echoes the received
+# ConnectionID back in the response output, proving that
+# CommandRequest.connection_id survives the host -> proto -> SDK-adapter ->
+# handler round-trip over real go-plugin gRPC (regression guard for
+# holomush-dble7). It needs no services, storage, or events — the command
+# path does not require Init/EventSink wiring.
+name: connid-echo-plugin
+version: 0.0.0
+type: binary
+requires: []
+
+binary-plugin:
+  executable: connid-echo-plugin


### PR DESCRIPTION
## Summary

Adds a Go-tier regression guard for the **holomush-dble7** class (binary-plugin SDK adapter dropping `ConnectionID`; fixed in #4321). Closes **holomush-q5czf**.

dble7 evaded `TestDispatcher_PassesConnectionIDToPluginCommand` because that test uses a **fake deliverer at the struct boundary** — never the real proto round-trip. This adds coverage one layer out.

## What it does
- `testdata/connid_echo_plugin/` — a tiny binary plugin whose `HandleCommand` echoes the `ConnectionID` it received (`connid=<value>`).
- `connection_id_roundtrip_test.go` — a `//go:build integration` Ginkgo `DescribeTable` that loads the plugin over **real go-plugin gRPC** and delivers a command via `host.DeliverCommand`, asserting `connection_id` survives the full path: host send (`host.go:818`) → proto → SDK adapter receive (`pkg/plugin/sdk.go`) → handler. Two cases: populated + empty (legacy/scripted).

## Why it's a real guard (not tautological)
Temporarily reverting the `sdk.go` fix makes the **populated** case fail (`connid=` vs `connid=01KST…`); restoring it passes both. Verified empirically.

## Relationship to the existing unit guard
Complementary, not duplicate: the unit test `TestPluginServerAdapterHandleCommandMapsConnectionID` (shipped with #4321) drives the adapter in isolation; this integration test additionally covers the **host send side** and **real gRPC marshal/unmarshal**. Keep both.

## Verification
- Focused `task test:int:focus` green (fix present); **fails as expected** when the fix is reverted (guard proven).
- Net diff is **test-only** (3 new files; `pkg/plugin/sdk.go` unchanged).
- `code-reviewer`: **READY**, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)