### PR TITLE
fix(web): render disconnected conn-dot red via dedicated status.offline token (holomush-qs31c)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -41,6 +41,7 @@
   --color-status-text: #666055;
   --color-status-background: #1e1612;
   --color-status-online: #66bb6a;
+  --color-status-offline: #e57373;
   --color-sidebar-background: #1e1612;
   --color-scrollback-indicator: #ffb74d;
   --radius: 0.5rem;

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -210,7 +210,7 @@
   .conn-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-text); }
   .conn-pill[data-status="connected"] .conn-dot { background: var(--color-status-online); }
   .conn-pill[data-status="syncing"] .conn-dot { background: var(--color-accent); animation: dot-pulse 1200ms ease-in-out infinite; }
-  .conn-pill[data-status="disconnected"] .conn-dot { background: var(--mush-system, #e57373); }
+  .conn-pill[data-status="disconnected"] .conn-dot { background: var(--color-status-offline); }
   .nav-link {
     color: var(--color-input-text); text-decoration: none;
     padding: 2px 8px; border-radius: 4px; border: 1px solid var(--color-border);

--- a/web/src/lib/stores/themeStore.test.ts
+++ b/web/src/lib/stores/themeStore.test.ts
@@ -80,7 +80,35 @@ describe('status.online token (holomush-wnilg)', () => {
   }
 });
 
-describe('status dot CSS wiring (holomush-wnilg)', () => {
+describe('status.offline token (holomush-qs31c)', () => {
+  for (const [id, theme] of builtInThemes) {
+    const colors = theme.colors as Record<string, string>;
+
+    it(`${id} defines a red-dominant status.offline color`, () => {
+      const offline = colors['status.offline'];
+      expect(offline, `${id} must define a status.offline color`).toBeDefined();
+      const { r, g, b } = rgb(offline);
+      // Red channel dominates → the dot reads as red (dead connection), not orange.
+      expect(r, `${id} status.offline (${offline}) red channel must exceed green`).toBeGreaterThan(g);
+      expect(r, `${id} status.offline (${offline}) red channel must exceed blue`).toBeGreaterThan(b);
+    });
+
+    it(`${id} decouples status.offline from the orange system message token`, () => {
+      // The original bug coupled the disconnected dot to --mush-system, which
+      // every theme defines orange. The status indicator must NOT reuse it.
+      expect(colors['status.offline']).not.toBe(colors['system']);
+    });
+
+    it(`${id} exposes status.offline as the chrome --color-status-offline custom property`, () => {
+      // The CSS references var(--color-status-offline); themeToCssVars must
+      // actually define it (killing the dead var(--x, fallback) footgun).
+      const css = themeToCssVars(theme.colors as ThemeColors);
+      expect(css).toContain(`--color-status-offline: ${colors['status.offline']}`);
+    });
+  }
+});
+
+describe('status dot CSS wiring (holomush-wnilg, holomush-qs31c)', () => {
   // Guard the consuming sites, not just the token table: the original bug
   // lived in the .svelte CSS (var(--mush-arrive, …)). Reverting these lines
   // while keeping the token would otherwise pass every token-table assertion.
@@ -104,4 +132,12 @@ describe('status dot CSS wiring (holomush-wnilg)', () => {
       expect(componentSrc(rel)).not.toContain('var(--mush-arrive');
     });
   }
+
+  it('TopBar disconnected dot consumes --color-status-offline', () => {
+    expect(componentSrc('TopBar.svelte')).toContain('var(--color-status-offline)');
+  });
+
+  it('TopBar disconnected dot no longer reuses the orange --mush-system message token', () => {
+    expect(componentSrc('TopBar.svelte')).not.toContain('var(--mush-system');
+  });
 });

--- a/web/src/lib/theme/classic-dark.json
+++ b/web/src/lib/theme/classic-dark.json
@@ -21,6 +21,7 @@
     "status.text": "#555555",
     "status.background": "#12122a",
     "status.online": "#66bb6a",
+    "status.offline": "#e57373",
     "sidebar.background": "#12122a",
     "scrollback.indicator": "#ffb74d",
     "primary": "#4fc3f7",

--- a/web/src/lib/theme/classic-light.json
+++ b/web/src/lib/theme/classic-light.json
@@ -21,6 +21,7 @@
     "status.text": "#616161",
     "status.background": "#f0f0f0",
     "status.online": "#2e7d32",
+    "status.offline": "#c62828",
     "sidebar.background": "#f5f5f5",
     "scrollback.indicator": "#e65100",
     "primary": "#0277bd",

--- a/web/src/lib/theme/default-dark.json
+++ b/web/src/lib/theme/default-dark.json
@@ -21,6 +21,7 @@
     "status.text": "#666055",
     "status.background": "#1e1612",
     "status.online": "#66bb6a",
+    "status.offline": "#e57373",
     "sidebar.background": "#1e1612",
     "scrollback.indicator": "#ffb74d",
     "primary": "#ff7043",

--- a/web/src/lib/theme/default-light.json
+++ b/web/src/lib/theme/default-light.json
@@ -21,6 +21,7 @@
     "status.text": "#6b6055",
     "status.background": "#f0ebe5",
     "status.online": "#2e7d32",
+    "status.offline": "#c62828",
     "sidebar.background": "#f5f0ea",
     "scrollback.indicator": "#e65100",
     "primary": "#e64a19",

--- a/web/src/lib/theme/types.ts
+++ b/web/src/lib/theme/types.ts
@@ -25,6 +25,7 @@ export interface ThemeColors {
   'status.text': string;
   'status.background': string;
   'status.online': string;
+  'status.offline': string;
   'sidebar.background': string;
   'scrollback.indicator': string;
 


### PR DESCRIPTION
## Summary

The **disconnected** status dot in TopBar rendered **orange, not red**, in every theme. `TopBar.svelte:213` used `var(--mush-system, #e57373)` — but `--mush-system` is the MUSH system-*message* color, injected **orange** by every theme (`themeStore.ts`; `default-dark`/`classic-dark` `#ffb74d`, `default-light` `#b34700`). Because the custom property is always theme-defined, the red `#e57373` CSS fallback was **unreachable dead code**.

Same bug class as **holomush-wnilg** (status indicator coupled to a message-category token + dead `var(--x, fallback)`). This PR completes the decoupling of the connection-status indicator from the message palette that wnilg began (it added `status.online` green).

Fix (mirrors wnilg's `status.online` resolution — decouple the status indicator from the message palette):

- Add a dedicated chrome token `status.offline` (→ `--color-status-offline`) to `ThemeColors` and all four theme JSONs, defined **red**: `#e57373` (dark) / `#c62828` (light), matching each theme's existing `destructive` red for legibility.
- Add the `--color-status-offline` baseline to `app.css` `:root`.
- Point `TopBar:213` at `var(--color-status-offline)` with **no fallback** — the referenced property is now always defined, so there is no dead fallback to mislead future readers.

Out of scope: the *syncing* dot (`TopBar:212`) correctly uses chrome `--color-accent`.

## Test Plan

- [x] New tests in `web/src/lib/stores/themeStore.test.ts` (10 cases): every theme defines a red-dominant `status.offline` distinct from the orange `system` token; `themeToCssVars` emits `--color-status-offline`; **and** the consuming TopBar disconnected dot references `var(--color-status-offline)` and no longer references `var(--mush-system`.
- [x] Full web unit suite — 92 passed
- [x] `svelte-check` — 0 errors
- [x] `task pr-prep` (fast lane) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)