### PR TITLE
feat(web): same-origin gateway OTLP relay for browser traces (holomush-2uogn)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,12 +174,15 @@ jobs:
         #
         # PUBLIC_OTEL_ENDPOINT gates the OTel-native browser tracer
         # (web/src/lib/telemetry.ts) — the project's primary, vendor-neutral
-        # telemetry path. Set it (via the PUBLIC_OTEL_ENDPOINT repo/environment
-        # variable) to a BROWSER-REACHABLE OTLP-HTTP base URL once one exists;
-        # browser spans then flow to the OTel collector, which fans out to
-        # Sentry/Tempo via its own exporters. See holomush-yak8r notes: a
-        # same-origin gateway OTLP relay (mirroring /api/sentry-relay) is the
-        # recommended prod path to dodge ad-blockers/CORS on the ingest origin.
+        # telemetry path. The same-origin gateway OTLP relay now exists
+        # (/api/otlp/v1/traces, internal/web/otlp_relay.go, mirroring
+        # /api/sentry-relay), so set PUBLIC_OTEL_ENDPOINT to "/api/otlp" (the
+        # tracer appends /v1/traces). The relay forwards to the collector,
+        # which fans out to Sentry/Tempo via its own exporters — dodging the
+        # ad-blocker/CORS failures that block direct browser POSTs to an
+        # external ingest origin. The gateway must have OTLP_RELAY_ENDPOINT set
+        # to the collector's OTLP/HTTP base URL (e.g. http://otel-collector:4318)
+        # for the relay to register. See holomush-2uogn / holomush-yak8r.
         env:
           PUBLIC_OTEL_ENDPOINT: ${{ vars.PUBLIC_OTEL_ENDPOINT }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}

--- a/cmd/holomush/gateway.go
+++ b/cmd/holomush/gateway.go
@@ -316,6 +316,11 @@ func runGatewayWithDeps(ctx context.Context, cfg *gatewayConfig, logConfig confi
 		// /api/sentry-relay tunnel endpoint. Empty = no relay (and no
 		// open-proxy risk).
 		SentryDSN: os.Getenv("SENTRY_DSN"),
+		// Collector's OTLP/HTTP base URL for the same-origin browser trace
+		// relay at /api/otlp/v1/traces. Empty = relay disabled. This is the
+		// HTTP receiver (port 4318), distinct from OTEL_EXPORTER_OTLP_ENDPOINT
+		// (the gateway's own gRPC export target, port 4317).
+		OTLPRelayEndpoint: os.Getenv("OTLP_RELAY_ENDPOINT"),
 	})
 	if err != nil {
 		return oops.With("operation", "create web server").Wrap(err)

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -103,6 +103,13 @@ services:
     environment:
       # Empty by default — see the core service note above (no-op without a collector).
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      # Collector's OTLP/HTTP base URL for the same-origin browser trace relay
+      # at /api/otlp/v1/traces (cmd/holomush/gateway.go). Empty = relay
+      # disabled. Recommended value when the observability profile is active:
+      # http://otel-collector:4318 (the HTTP receiver — distinct from the gRPC
+      # 4317 above). Requires the gateway to share a network with the collector
+      # (the collector joins `frontend` below for exactly this).
+      OTLP_RELAY_ENDPOINT: ${OTLP_RELAY_ENDPOINT:-}
       # Gateway reads SENTRY_DSN (cmd/holomush/gateway.go); empty = disabled.
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
@@ -172,7 +179,13 @@ services:
     volumes:
       - ${CONFIG_DIR:-/opt/holomush/config}/otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
     networks:
+      # backend: core/gateway gRPC export (OTEL_EXPORTER_OTLP_ENDPOINT, 4317).
+      # frontend: the gateway's same-origin OTLP/HTTP relay (OTLP_RELAY_ENDPOINT)
+      # forwards browser spans to the collector's 4318 receiver, so the
+      # collector must be reachable from the gateway's network. No ports are
+      # published, so the receiver stays internal to the compose networks.
       - backend
+      - frontend
 
   backup:
     build: ./docker/postgres-backup

--- a/compose.yaml
+++ b/compose.yaml
@@ -60,6 +60,12 @@ services:
     command: ["gateway", "--log-format", "text", "--core-addr", "core:9000", "--metrics-addr", "0.0.0.0:9101"]
     environment:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      # Same-origin browser trace relay (/api/otlp/v1/traces). Empty by
+      # default: the dev observability flow (`task dev` + `task dev:obs`) points
+      # PUBLIC_OTEL_ENDPOINT straight at localhost:4318, so the relay isn't on
+      # the dev path. Set to http://otel-collector:4318 to exercise the relay
+      # in compose (the gateway would also need the `backend` network).
+      OTLP_RELAY_ENDPOINT: ${OTLP_RELAY_ENDPOINT-}
       SENTRY_DSN: ${SENTRY_DSN-}
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT-dev-local}
       SENTRY_RELEASE: ${SENTRY_RELEASE-}

--- a/internal/web/otlp_relay.go
+++ b/internal/web/otlp_relay.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package web
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/pkg/errutil"
+)
+
+// otlpRelayMaxBody bounds the inbound OTLP trace export size. The browser
+// tracer batches spans on a 1s timer (web/src/lib/telemetry.ts), so a single
+// POST carries a small burst of spans — typically tens of KB. 4 MiB is
+// generous headroom for legitimate batches while still bounding the relay as
+// an amplification vector into the collector.
+//
+// Note: the cap is on the ENCODED bytes. The relay forwards Content-Encoding
+// without decompressing, so a non-SDK client could POST a small gzip body that
+// expands past 4 MiB at the collector. The configured browser path never hits
+// this — the OTel-JS http exporter sends uncompressed JSON (gzip unimplemented
+// upstream) — and the collector enforces its own limits, so we accept the
+// residual surface rather than buffer-and-inflate on every request.
+const otlpRelayMaxBody = 4 << 20
+
+// otlpRelayTimeout caps the outbound POST to the collector. The collector is
+// in-cluster and responds promptly; 10s tolerates a slow/contended collector
+// without leaving relay goroutines hung on a wedged upstream.
+const otlpRelayTimeout = 10 * time.Second
+
+// parseOTLPCollectorEndpoint validates the configured collector base URL and
+// derives the OTLP/HTTP traces ingest URL (<base>/v1/traces). The collector's
+// HTTP receiver listens on its own port (4318 by default) — distinct from the
+// gRPC receiver (4317) the Go SDK exports to via OTEL_EXPORTER_OTLP_ENDPOINT —
+// so the relay target is configured independently.
+func parseOTLPCollectorEndpoint(endpoint string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", oops.Code("OTLP_RELAY_ENDPOINT_INVALID").Wrap(err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", oops.Code("OTLP_RELAY_ENDPOINT_INVALID").Errorf("endpoint scheme must be http or https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", oops.Code("OTLP_RELAY_ENDPOINT_INVALID").Errorf("endpoint missing host")
+	}
+	base := strings.TrimRight(endpoint, "/")
+	return base + "/v1/traces", nil
+}
+
+// NewOTLPRelayHandler returns an http.Handler that accepts browser OTLP/HTTP
+// trace exports and forwards them to the configured collector's /v1/traces
+// receiver. It is the OpenTelemetry analogue of the Sentry envelope relay
+// (sentry_relay.go): the browser sees a same-origin POST instead of one to an
+// external ingest origin, which ad-blockers and CORS would otherwise block.
+//
+// Unlike the Sentry relay, the forward target is fixed by server config rather
+// than derived from the request, so the relay cannot be turned into an open
+// forwarder. It is, however, an unauthenticated ingest into the collector;
+// the body size is bounded to limit amplification abuse.
+//
+// Returns an error if the configured endpoint cannot be parsed; callers MUST
+// leave the route unregistered in that case rather than installing a
+// non-functional endpoint.
+func NewOTLPRelayHandler(collectorEndpoint string) (http.Handler, error) {
+	forwardURL, err := parseOTLPCollectorEndpoint(collectorEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: otlpRelayTimeout}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Bound the inbound size to prevent the relay being used as an
+		// amplification vector. MaxBytesReader closes the body and returns
+		// http.MaxBytesError on overflow, which we surface as 413.
+		body, readErr := io.ReadAll(http.MaxBytesReader(w, r.Body, otlpRelayMaxBody))
+		if readErr != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(readErr, &maxErr) {
+				http.Error(w, "trace export too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "could not read trace export", http.StatusBadRequest)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), otlpRelayTimeout)
+		defer cancel()
+
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, forwardURL, bytes.NewReader(body))
+		if reqErr != nil {
+			http.Error(w, "could not build upstream request", http.StatusInternalServerError)
+			return
+		}
+		// Forward the encoding-relevant headers so the collector can decode
+		// the payload. The browser OTLP/HTTP exporter sends JSON or protobuf
+		// (Content-Type) and MAY compress (Content-Encoding); both must reach
+		// the collector unchanged.
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			req.Header.Set("Content-Type", ct)
+		}
+		if ce := r.Header.Get("Content-Encoding"); ce != "" {
+			req.Header.Set("Content-Encoding", ce)
+		}
+
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			errutil.LogErrorContext(r.Context(), "otlp relay: upstream POST failed", respErr)
+			http.Error(w, "upstream collector POST failed", http.StatusBadGateway)
+			return
+		}
+		defer func() {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				slog.DebugContext(r.Context(), "otlp relay: close upstream body", "error", closeErr.Error())
+			}
+		}()
+
+		// Mirror the collector's response (status + headers + body) back to
+		// the browser exporter so it can drive its own retry/back-off on 429s
+		// and surface partial-success bodies.
+		for k, values := range resp.Header {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		if _, copyErr := io.Copy(w, resp.Body); copyErr != nil {
+			errutil.LogErrorContext(r.Context(), "otlp relay: failed to copy upstream body", copyErr)
+		}
+	}), nil
+}

--- a/internal/web/otlp_relay_test.go
+++ b/internal/web/otlp_relay_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package web
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOTLPCollectorEndpointBuildsTracesURL(t *testing.T) {
+	got, err := parseOTLPCollectorEndpoint("http://otel-collector:4318")
+	require.NoError(t, err)
+	assert.Equal(t, "http://otel-collector:4318/v1/traces", got)
+}
+
+func TestParseOTLPCollectorEndpointTrimsTrailingSlash(t *testing.T) {
+	got, err := parseOTLPCollectorEndpoint("http://otel-collector:4318/")
+	require.NoError(t, err)
+	assert.Equal(t, "http://otel-collector:4318/v1/traces", got)
+}
+
+func TestParseOTLPCollectorEndpointRejectsMissingScheme(t *testing.T) {
+	_, err := parseOTLPCollectorEndpoint("otel-collector:4318")
+	require.Error(t, err)
+}
+
+func TestParseOTLPCollectorEndpointRejectsMissingHost(t *testing.T) {
+	_, err := parseOTLPCollectorEndpoint("http:///v1/traces")
+	require.Error(t, err)
+}
+
+func TestNewOTLPRelayHandlerRejectsInvalidEndpoint(t *testing.T) {
+	_, err := NewOTLPRelayHandler("not a url with spaces")
+	require.Error(t, err)
+}
+
+func TestOTLPRelayHandlerRejectsNonPost(t *testing.T) {
+	handler, err := NewOTLPRelayHandler("http://otel-collector:4318")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/otlp/v1/traces", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}
+
+func TestOTLPRelayHandlerRejectsOversizeBody(t *testing.T) {
+	handler, err := NewOTLPRelayHandler("http://otel-collector:4318")
+	require.NoError(t, err)
+
+	body := bytes.Repeat([]byte("a"), otlpRelayMaxBody+1)
+	req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestOTLPRelayHandlerForwardsToCollectorTracesPath(t *testing.T) {
+	var (
+		receivedPath     string
+		receivedBody     []byte
+		receivedType     string
+		receivedEncoding string
+	)
+	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedBody, _ = io.ReadAll(r.Body)
+		receivedType = r.Header.Get("Content-Type")
+		receivedEncoding = r.Header.Get("Content-Encoding")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"partialSuccess":{}}`))
+	}))
+	defer collector.Close()
+
+	handler, err := NewOTLPRelayHandler(collector.URL)
+	require.NoError(t, err)
+
+	payload := `{"resourceSpans":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/v1/traces", receivedPath)
+	assert.Equal(t, payload, string(receivedBody))
+	assert.Equal(t, "application/json", receivedType)
+	assert.Equal(t, "gzip", receivedEncoding, "Content-Encoding must be forwarded so the collector can decode")
+	assert.Equal(t, `{"partialSuccess":{}}`, rec.Body.String(), "upstream response body is mirrored back")
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"), "upstream response headers are mirrored back")
+}
+
+func TestOTLPRelayHandlerReturnsBadGatewayWhenCollectorUnreachable(t *testing.T) {
+	// Point at a closed server so the forward POST fails at dial time.
+	collector := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	unreachableURL := collector.URL
+	collector.Close()
+
+	handler, err := NewOTLPRelayHandler(unreachableURL)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/otlp/v1/traces", strings.NewReader(`{"resourceSpans":[]}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -31,6 +31,14 @@ type Config struct {
 	// DSN value is used to validate inbound envelopes — the relay only
 	// forwards traffic destined for the configured project.
 	SentryDSN string
+	// OTLPRelayEndpoint, when non-empty, enables the /api/otlp/v1/traces
+	// endpoint that the browser OTel tracer (web/src/lib/telemetry.ts) POSTs
+	// spans to as a same-origin, ad-blocker-safe ingest. The value is the
+	// collector's OTLP/HTTP base URL (e.g. http://otel-collector:4318); the
+	// relay forwards to <base>/v1/traces. Distinct from
+	// OTEL_EXPORTER_OTLP_ENDPOINT, which is the gateway's own gRPC export
+	// target (port 4317).
+	OTLPRelayEndpoint string
 }
 
 // Server is the web HTTP server hosting ConnectRPC and static files.
@@ -76,6 +84,24 @@ func NewServer(cfg Config) (*Server, error) {
 		} else {
 			mux.Handle("/api/sentry-relay", relayHandler)
 			slog.Info("web: sentry relay registered at /api/sentry-relay")
+		}
+	}
+
+	// Register the browser OTLP trace relay if a collector endpoint is
+	// configured. The relay accepts same-origin OTLP/HTTP trace POSTs at
+	// /api/otlp/v1/traces and forwards them to the collector, bypassing the
+	// ad-blocker/CORS failures that block direct browser POSTs to an external
+	// ingest origin. A failed parse of the configured endpoint leaves the
+	// route unregistered (so a non-functional endpoint never ships) and is
+	// logged so operators notice.
+	if cfg.OTLPRelayEndpoint != "" {
+		otlpHandler, otlpErr := NewOTLPRelayHandler(cfg.OTLPRelayEndpoint)
+		if otlpErr != nil {
+			errutil.LogError(slog.Default(),
+				"web: OTLP trace relay not registered due to endpoint parse error", otlpErr)
+		} else {
+			mux.Handle("/api/otlp/v1/traces", otlpHandler)
+			slog.Info("web: OTLP trace relay registered at /api/otlp/v1/traces")
 		}
 	}
 

--- a/site/src/content/docs/operating/how-to/sentry.md
+++ b/site/src/content/docs/operating/how-to/sentry.md
@@ -115,9 +115,14 @@ to the gateway with no CORS involved — `propagateTraceHeaderCorsUrls`'
 > **Browser → collector reachability (prod hand-off):** browser OTLP POSTs to
 > an external collector face ad-blockers and CORS on the ingest origin — the
 > same reason the Sentry SDK tunnels through the same-origin
-> `/api/sentry-relay`. The recommended prod path is a **same-origin gateway
-> OTLP relay** that forwards browser OTLP to the collector; until that exists,
-> leave `PUBLIC_OTEL_ENDPOINT` unset in prod. See `holomush-yak8r`.
+> `/api/sentry-relay`. The prod path is the **same-origin gateway OTLP relay**
+> at `/api/otlp/v1/traces` (`internal/web/otlp_relay.go`), which forwards
+> browser spans to the collector. To enable it: set the gateway's
+> `OTLP_RELAY_ENDPOINT` to the collector's OTLP/HTTP base URL (e.g.
+> `http://otel-collector:4318`) and set `PUBLIC_OTEL_ENDPOINT=/api/otlp` at
+> build time (the tracer appends `/v1/traces`). See the
+> [Browser OTLP relay](#browser-otlp-relay-apiotlpv1traces) section below and
+> `holomush-2uogn` / `holomush-yak8r`.
 
 ## Local dev setup
 
@@ -257,6 +262,36 @@ Implementation: `internal/web/sentry_relay.go` + registration in
 `internal/web/server.go`. Unit tests cover DSN validation, oversize
 rejection, method/method-not-allowed, and the forward path
 (`internal/web/sentry_relay_test.go`).
+
+## Browser OTLP relay (`/api/otlp/v1/traces`)
+
+The OTel-native browser tracer faces the **same** ad-blocker/CORS problem as
+the Sentry SDK: a direct browser POST to an external OTLP collector origin is
+blocked. The gateway therefore exposes a same-origin OTLP/HTTP relay that the
+`WebTracerProvider`'s `OTLPTraceExporter` targets, mirroring the Sentry tunnel.
+
+| Behaviour | Detail |
+| --- | --- |
+| **Endpoint** | `POST /api/otlp/v1/traces` on the gateway web HTTP listener (the tracer's `PUBLIC_OTEL_ENDPOINT=/api/otlp` base + the exporter's `/v1/traces` suffix). |
+| **Registration gate** | Only registered when `OTLP_RELAY_ENDPOINT` is set on the gateway. Unset = no endpoint. |
+| **Forward target** | Fixed by server config (`OTLP_RELAY_ENDPOINT` + `/v1/traces`), not derived from the request — so the relay cannot be turned into an open forwarder. Recommended value: `http://otel-collector:4318`. |
+| **Header passthrough** | `Content-Type` and `Content-Encoding` are forwarded so the collector decodes JSON/protobuf and any compression. |
+| **Size limit** | Inbound bodies capped at 4 MiB; oversize returns `413`. |
+| **Upstream timeout** | 10 s (the in-cluster collector responds promptly). |
+| **Method** | `POST` only; other methods get `405`. |
+
+Unlike the Sentry relay there is no per-request validation — the target is
+fixed — but the endpoint is an **unauthenticated ingest** into the collector,
+so the body size is bounded to limit amplification abuse. The collector must be
+reachable from the gateway's network (in `compose.prod.yaml` the collector
+joins the `frontend` network for exactly this; no ports are published, so the
+receiver stays internal).
+
+Implementation: `internal/web/otlp_relay.go` + registration in
+`internal/web/server.go`. Unit tests cover endpoint parsing, oversize
+rejection, method-not-allowed, the forward path (path, body, header
+passthrough, response mirroring), and the upstream-failure (`502`) path
+(`internal/web/otlp_relay_test.go`).
 
 ## DSN handling
 


### PR DESCRIPTION
## Summary

Adds `/api/otlp/v1/traces` on the gateway web listener — a same-origin relay that accepts browser OTLP/HTTP trace exports and forwards them to the configured collector, mirroring the existing `/api/sentry-relay` (`internal/web/sentry_relay.go`).

This unblocks the OTel-native browser tracer (`web/src/lib/telemetry.ts`) in production: direct browser POSTs to an external collector origin are blocked by ad-blockers + CORS (root-caused in holomush-yak8r), the exact reason the Sentry browser SDK already tunnels through a same-origin relay.

### Why it differs from the Sentry relay
The forward target is **fixed by server config** (`OTLP_RELAY_ENDPOINT` + `/v1/traces`), not derived from the request — so the relay structurally cannot be abused as an open forwarder and needs no per-request validation. It is, however, an unauthenticated collector ingest, so the body is size-bounded (4 MiB) and the request times out (10s). `Content-Type` / `Content-Encoding` are forwarded; the upstream response is mirrored back so the exporter drives its own retry/back-off.

## Changes
- **`internal/web/otlp_relay.go`** (new) — `NewOTLPRelayHandler` + `parseOTLPCollectorEndpoint`.
- **`internal/web/otlp_relay_test.go`** (new) — endpoint parsing, oversize (413), method (405), forward path (path/body/header passthrough/response mirroring), upstream-failure (502).
- **`internal/web/server.go`** — `Config.OTLPRelayEndpoint` + mux registration gated on a successful endpoint parse (parse failure leaves the route unregistered, like the Sentry DSN gate).
- **`cmd/holomush/gateway.go`** — reads `OTLP_RELAY_ENDPOINT` into `Config`.
- **`compose.prod.yaml` / `compose.yaml`** — env wiring; prod collector joins the `frontend` network so the gateway can reach its `4318` receiver (no published ports).
- **`.github/workflows/release.yaml`** — build comment now directs setting `PUBLIC_OTEL_ENDPOINT=/api/otlp`.
- **`site/.../operating/how-to/sentry.md`** — documents the relay alongside the Sentry tunnel.

## Test plan
- `task test -- ./internal/web/` — 222 pass (9 new).
- `task lint:go` — 0 issues.
- `task pr-prep` (fast lane) — `status=pass`.
- Pre-push `code-reviewer` — **READY**, no blocking findings.

## Out of scope / residual
The bead's second acceptance criterion is a **live, post-deploy verification** (a browser session producing `command.roundtrip` spans that reach the collector → Sentry with `connection_id` present). That requires an operator to set `OTLP_RELAY_ENDPOINT` + `PUBLIC_OTEL_ENDPOINT=/api/otlp` and deploy; it cannot be satisfied in CI. holomush-2uogn stays open for that operator step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)