### PR TITLE
fix(scenes): scene subcommands accept '#' prefix and bare scene id interchangeably (holomush-ehbnk)

### DIFF
--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -565,9 +565,9 @@ func (p *scenePlugin) handleCreate(ctx context.Context, req pluginsdk.CommandReq
 // enforced via the host ABAC evaluator (read-scene-as-participant policy)
 // before this handler is called.
 func (p *scenePlugin) handleInfo(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	sceneID := strings.TrimSpace(args)
+	sceneID := normalizeSceneID(args)
 	if sceneID == "" {
-		return pluginsdk.Errorf("Usage: scene info <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene info #<scene id>"), nil
 	}
 
 	resp, err := p.service.GetScene(ctx, &scenev1.GetSceneRequest{
@@ -605,9 +605,9 @@ func (p *scenePlugin) handleInfo(ctx context.Context, req pluginsdk.CommandReque
 // non-owner participants alike. The sweep is best-effort: DB state is
 // authoritative, and focus-side errors are logged, not surfaced to the user.
 func (p *scenePlugin) handleEnd(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	sceneID := strings.TrimSpace(args)
+	sceneID := normalizeSceneID(args)
 	if sceneID == "" {
-		return pluginsdk.Errorf("Usage: scene end <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene end #<scene id>"), nil
 	}
 
 	if _, err := p.service.EndScene(ctx, &scenev1.EndSceneRequest{
@@ -663,9 +663,9 @@ func (p *scenePlugin) handleEnd(ctx context.Context, req pluginsdk.CommandReques
 
 // handlePause transitions an active scene to the paused state. Owner-only.
 func (p *scenePlugin) handlePause(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	sceneID := strings.TrimSpace(args)
+	sceneID := normalizeSceneID(args)
 	if sceneID == "" {
-		return pluginsdk.Errorf("Usage: scene pause <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene pause #<scene id>"), nil
 	}
 
 	_, err := p.service.PauseScene(ctx, &scenev1.PauseSceneRequest{
@@ -685,9 +685,9 @@ func (p *scenePlugin) handlePause(ctx context.Context, req pluginsdk.CommandRequ
 // handleResume transitions a paused scene back to active. Owner-only in
 // Phase 2; Phase 3 widens to any member per spec D6.
 func (p *scenePlugin) handleResume(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	sceneID := strings.TrimSpace(args)
+	sceneID := normalizeSceneID(args)
 	if sceneID == "" {
-		return pluginsdk.Errorf("Usage: scene resume <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene resume #<scene id>"), nil
 	}
 
 	_, err := p.service.ResumeScene(ctx, &scenev1.ResumeSceneRequest{
@@ -717,17 +717,18 @@ func (p *scenePlugin) handleResume(ctx context.Context, req pluginsdk.CommandReq
 func (p *scenePlugin) handleSet(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
 	args = strings.TrimSpace(args)
 	if args == "" {
-		return pluginsdk.Errorf("Usage: scene set <scene id> field=value"), nil
+		return pluginsdk.Errorf("Usage: scene set #<scene id> field=value"), nil
 	}
 
-	sceneID, rest := splitSubcommand(args)
+	sceneRef, rest := splitSubcommand(args)
+	sceneID := normalizeSceneID(sceneRef)
 	if sceneID == "" || rest == "" {
-		return pluginsdk.Errorf("Usage: scene set <scene id> field=value"), nil
+		return pluginsdk.Errorf("Usage: scene set #<scene id> field=value"), nil
 	}
 
 	eqIdx := strings.IndexByte(rest, '=')
 	if eqIdx < 0 {
-		return pluginsdk.Errorf("Usage: scene set <scene id> field=value"), nil
+		return pluginsdk.Errorf("Usage: scene set #<scene id> field=value"), nil
 	}
 	field := strings.TrimSpace(rest[:eqIdx])
 	value := strings.TrimSpace(rest[eqIdx+1:])
@@ -797,9 +798,9 @@ func splitSubcommand(args string) (sub, rest string) {
 func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
 	fields := strings.Fields(args)
 	if len(fields) != 1 {
-		return pluginsdk.Errorf("Usage: scene join <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene join #<scene id>"), nil
 	}
-	sceneID := fields[0]
+	sceneID := normalizeSceneID(fields[0])
 
 	if _, err := p.service.JoinScene(ctx, &scenev1.JoinSceneRequest{
 		CharacterId: req.CharacterID,
@@ -914,9 +915,9 @@ func (p *scenePlugin) handleJoin(ctx context.Context, req pluginsdk.CommandReque
 func (p *scenePlugin) handleLeave(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
 	fields := strings.Fields(args)
 	if len(fields) != 1 {
-		return pluginsdk.Errorf("Usage: scene leave <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene leave #<scene id>"), nil
 	}
-	sceneID := fields[0]
+	sceneID := normalizeSceneID(fields[0])
 
 	if _, err := p.service.LeaveScene(ctx, &scenev1.LeaveSceneRequest{
 		CharacterId: req.CharacterID,
@@ -951,9 +952,9 @@ func (p *scenePlugin) handleInvite(ctx context.Context, req pluginsdk.CommandReq
 	// Strict arity: reject anything other than exactly 2 tokens — see handleJoin.
 	fields := strings.Fields(args)
 	if len(fields) != 2 {
-		return pluginsdk.Errorf("Usage: scene invite <scene id> <character>"), nil
+		return pluginsdk.Errorf("Usage: scene invite #<scene id> <character>"), nil
 	}
-	sceneID, target := fields[0], fields[1]
+	sceneID, target := normalizeSceneID(fields[0]), fields[1]
 
 	_, err := p.service.InviteToScene(ctx, &scenev1.InviteToSceneRequest{
 		CharacterId:       req.CharacterID,
@@ -975,9 +976,9 @@ func (p *scenePlugin) handleKick(ctx context.Context, req pluginsdk.CommandReque
 	// Strict arity: reject anything other than exactly 2 tokens — see handleJoin.
 	fields := strings.Fields(args)
 	if len(fields) != 2 {
-		return pluginsdk.Errorf("Usage: scene kick <scene id> <character>"), nil
+		return pluginsdk.Errorf("Usage: scene kick #<scene id> <character>"), nil
 	}
-	sceneID, target := fields[0], fields[1]
+	sceneID, target := normalizeSceneID(fields[0]), fields[1]
 
 	_, err := p.service.KickFromScene(ctx, &scenev1.KickFromSceneRequest{
 		CharacterId:       req.CharacterID,
@@ -999,9 +1000,9 @@ func (p *scenePlugin) handleTransfer(ctx context.Context, req pluginsdk.CommandR
 	// Strict arity: reject anything other than exactly 2 tokens — see handleJoin.
 	fields := strings.Fields(args)
 	if len(fields) != 2 {
-		return pluginsdk.Errorf("Usage: scene transfer <scene id> <character>"), nil
+		return pluginsdk.Errorf("Usage: scene transfer #<scene id> <character>"), nil
 	}
-	sceneID, target := fields[0], fields[1]
+	sceneID, target := normalizeSceneID(fields[0]), fields[1]
 
 	_, err := p.service.TransferOwnership(ctx, &scenev1.TransferOwnershipRequest{
 		CharacterId:         req.CharacterID,
@@ -1028,9 +1029,9 @@ func (p *scenePlugin) handleTransfer(ctx context.Context, req pluginsdk.CommandR
 func (p *scenePlugin) handleSwitch(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
 	fields := strings.Fields(args)
 	if len(fields) != 1 {
-		return pluginsdk.Errorf("Usage: scene switch <scene id>"), nil
+		return pluginsdk.Errorf("Usage: scene switch #<scene id>"), nil
 	}
-	sceneID := fields[0]
+	sceneID := normalizeSceneID(fields[0])
 
 	if p.focusClient == nil {
 		slog.WarnContext(
@@ -1049,7 +1050,7 @@ func (p *scenePlugin) handleSwitch(ctx context.Context, req pluginsdk.CommandReq
 		var oe oops.OopsError
 		if errors.As(err, &oe) && oe.Code() == "FOCUS_NOT_MEMBER" {
 			return pluginsdk.Errorf(
-				"You are not a member of scene %s. Use `scene join %s` first.", sceneID, sceneID,
+				"You are not a member of scene %s. Use `scene join #%s` first.", sceneID, sceneID,
 			), nil
 		}
 		slog.WarnContext(
@@ -1104,28 +1105,24 @@ func (p *scenePlugin) handleSceneGrid(ctx context.Context, req pluginsdk.Command
 	}, nil
 }
 
-// handleSceneFocus implements `scene focus #<id>`. Parses a scene reference
-// (ULID prefixed with `#`), validates it is syntactically valid, then calls
-// SetConnectionFocus on the current connection. The substrate is the canonical
-// authority for membership (INV-P5-1): FOCUS_WITHOUT_MEMBERSHIP from the
-// substrate produces a user-facing denial; other substrate errors surface as
-// SCENE_FOCUS_FAILED internal errors.
+// handleSceneFocus implements `scene focus #<id>`. Parses a scene reference,
+// then calls SetConnectionFocus on the current connection. The substrate is the
+// canonical authority for membership (INV-P5-1): FOCUS_WITHOUT_MEMBERSHIP from
+// the substrate produces a user-facing denial; other substrate errors surface
+// as SCENE_FOCUS_FAILED internal errors.
+//
+// The scene ref is normalized leniently: the '#'-prefixed display form (as
+// surfaced in the web RECENT panel) and a bare ULID are both accepted, matching
+// every other scene subcommand so a ref that works for `scene join` works here
+// too (holomush-ehbnk).
 //
 // The plugin does NOT pre-check membership; substrate enforcement via T14 is
 // sufficient per plan Task 19 ("let substrate be the authority").
 func (p *scenePlugin) handleSceneFocus(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
-	arg := strings.TrimSpace(args)
-	if arg == "" {
-		return pluginsdk.Errorf("Usage: scene focus #<scene id>"), nil
-	}
-
-	// Require the '#' prefix per the command syntax; strip it to get the
-	// bare scene ID. The substrate validates membership and scene existence;
-	// the plugin's responsibility is parse + dispatch + render only.
-	if !strings.HasPrefix(arg, "#") {
-		return pluginsdk.Errorf("Usage: scene focus #<scene id>"), nil
-	}
-	sceneID := strings.TrimPrefix(arg, "#")
+	// Accept the '#'-prefixed display form or a bare ULID interchangeably; strip
+	// the optional '#' to get the bare scene ID. The substrate validates
+	// membership and scene existence; the plugin parses + dispatches + renders.
+	sceneID := normalizeSceneID(args)
 	if sceneID == "" {
 		return pluginsdk.Errorf("Usage: scene focus #<scene id>"), nil
 	}
@@ -1498,17 +1495,32 @@ func (p *scenePlugin) resolveSingleSceneMembership(ctx context.Context, characte
 	}
 }
 
+// normalizeSceneID strips a single optional leading '#' (and surrounding
+// whitespace) from a scene-reference token, yielding the bare scene ULID used
+// downstream (holomush-y5inx bare-ULID identity). The mandatory-scene-id
+// subcommands (join, focus, switch, info, end, pause, resume, leave, invite,
+// kick, transfer, set) accept the '#'-prefixed display form — as surfaced in
+// the web RECENT panel, prompts, and join's own success hints — and the bare
+// form interchangeably, so a ref that works for one subcommand works for all
+// (holomush-ehbnk). Only the leading '#' is stripped; embedded junk is left for
+// downstream ULID validation in the service layer.
+func normalizeSceneID(token string) string {
+	return strings.TrimPrefix(strings.TrimSpace(token), "#")
+}
+
 // sceneResourceRef derives the ABAC resource string for a scene subcommand
 // from the subcommand args. Returns "scene:<id>" on success, error if args
 // are empty after trimming. Used as the ResourceRef in GatedSubcommand for
 // subcommands where the scene ID is the entire remaining args (end, pause,
-// resume, leave, info — whole remainder is the scene ID).
+// resume, leave, info — whole remainder is the scene ID). The id is normalized
+// (optional '#' stripped) so the evaluated resource ref matches the bare id the
+// handler passes downstream — no "scene:#<id>" skew (holomush-ehbnk).
 func sceneResourceRef(args string) (string, error) {
 	fields := strings.Fields(args)
 	if len(fields) == 0 {
 		return "", fmt.Errorf("scene id is required")
 	}
-	return "scene:" + fields[0], nil // ABAC resource ref (type:id), not a pub/sub subject (INV-P4-1)
+	return "scene:" + normalizeSceneID(fields[0]), nil // ABAC resource ref (type:id), not a pub/sub subject (INV-P4-1)
 }
 
 // sceneResourceRefFirstField derives the ABAC resource string for subcommands
@@ -1520,7 +1532,7 @@ func sceneResourceRefFirstField(args string) (string, error) {
 	if len(fields) == 0 {
 		return "", oops.Errorf("scene id is required")
 	}
-	return "scene:" + fields[0], nil // ABAC resource ref (type:id), not a pub/sub subject (INV-P4-1)
+	return "scene:" + normalizeSceneID(fields[0]), nil // ABAC resource ref (type:id), not a pub/sub subject (INV-P4-1)
 }
 
 // handleVoteExtend implements `scene publish vote extend <count> [#<scene id>]`

--- a/plugins/core-scenes/commands_focus_test.go
+++ b/plugins/core-scenes/commands_focus_test.go
@@ -291,14 +291,17 @@ func TestHandleSceneFocus_OtherSubstrateError(t *testing.T) {
 	assert.Equal(t, "SCENE_FOCUS_FAILED", oe.Code())
 }
 
-// TestHandleSceneFocus_MalformedRef verifies that a scene reference without
-// the required '#' prefix returns a usage error without calling SetConnectionFocus.
-func TestHandleSceneFocus_MalformedRef(t *testing.T) {
+// TestHandleSceneFocus_LoneHashRejected verifies that a ref that normalizes to
+// the empty string (a lone '#') returns a usage error without calling
+// SetConnectionFocus. The '#' prefix is now optional (holomush-ehbnk); a bare
+// ref is accepted (see TestSceneFocusAcceptsBareAndHash), so the only parse
+// rejection left is an empty-after-normalize ref.
+func TestHandleSceneFocus_LoneHashRejected(t *testing.T) {
 	p, fc := newTestPluginWithFocus(t)
 
 	resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
 		Command:      "scene",
-		Args:         "focus scene-01KS93ESFTBJW44QB1RZFC67AN", // missing '#' prefix
+		Args:         "focus #", // normalizes to empty
 		CharacterID:  "char-bob",
 		SessionID:    "sess-bob",
 		ConnectionID: "01JW0000000000000000000013",
@@ -307,7 +310,7 @@ func TestHandleSceneFocus_MalformedRef(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, pluginsdk.CommandError, resp.Status)
 	assert.Contains(t, resp.Output, "Usage:")
-	assert.Empty(t, fc.setConnFocusCalls, "SetConnectionFocus MUST NOT be called on malformed ref")
+	assert.Empty(t, fc.setConnFocusCalls, "SetConnectionFocus MUST NOT be called on empty ref")
 }
 
 // TestHandleSceneFocus_MissingArg verifies that `scene focus` with no argument

--- a/plugins/core-scenes/commands_sceneref_test.go
+++ b/plugins/core-scenes/commands_sceneref_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeSceneID covers the shared scene-ref token normalizer: it strips
+// a single optional leading '#' and surrounding whitespace, yielding the bare
+// scene ULID used downstream (holomush-ehbnk / holomush-y5inx).
+func TestNormalizeSceneID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare id is returned unchanged", "01KSTF08ABCDEF", "01KSTF08ABCDEF"},
+		{"single leading hash is stripped", "#01KSTF08ABCDEF", "01KSTF08ABCDEF"},
+		{"surrounding whitespace is trimmed", "  #01KSTF08ABCDEF  ", "01KSTF08ABCDEF"},
+		{"only the first hash is stripped", "##01KSTF08ABCDEF", "#01KSTF08ABCDEF"},
+		{"bare with whitespace is trimmed", "  01KSTF08ABCDEF ", "01KSTF08ABCDEF"},
+		{"lone hash yields empty", "#", ""},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeSceneID(tt.input))
+		})
+	}
+}
+
+// TestSceneResourceRefStripsHashPrefix verifies the ABAC resource-ref helpers
+// strip an optional '#' so the resource ref evaluated by the host engine uses
+// the same bare scene id the handler passes downstream (no scene:#<id> skew).
+func TestSceneResourceRefStripsHashPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(string) (string, error)
+	}{
+		{"sceneResourceRef", sceneResourceRef},
+		{"sceneResourceRefFirstField", sceneResourceRefFirstField},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+" strips hash", func(t *testing.T) {
+			got, err := tt.fn("#01KSTF08ABCDEF extra")
+			require.NoError(t, err)
+			assert.Equal(t, "scene:01KSTF08ABCDEF", got)
+		})
+		t.Run(tt.name+" accepts bare", func(t *testing.T) {
+			got, err := tt.fn("01KSTF08ABCDEF extra")
+			require.NoError(t, err)
+			assert.Equal(t, "scene:01KSTF08ABCDEF", got)
+		})
+		t.Run(tt.name+" rejects empty", func(t *testing.T) {
+			_, err := tt.fn("   ")
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestSceneFocusAcceptsBareAndHash verifies `scene focus` leniently accepts
+// both the '#'-prefixed display form and a bare scene id, dispatching the bare
+// id to SetConnectionFocus in both cases (holomush-ehbnk direction A).
+func TestSceneFocusAcceptsBareAndHash(t *testing.T) {
+	const bareID = "01KSTF08ABCDEF"
+	for _, form := range []string{bareID, "#" + bareID} {
+		t.Run("focus "+form, func(t *testing.T) {
+			p, fc := newTestPluginWithFocus(t)
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command:      "scene",
+				Args:         "focus " + form,
+				CharacterID:  "char-bob",
+				SessionID:    "sess-bob",
+				ConnectionID: "01JW0000000000000000000013",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+			require.Len(t, fc.setConnFocusCalls, 1, "SetConnectionFocus MUST be called once")
+			require.NotNil(t, fc.setConnFocusCalls[0].focusKey)
+			assert.Equal(t, bareID, fc.setConnFocusCalls[0].focusKey.TargetID,
+				"downstream MUST receive the bare scene id (no '#')")
+		})
+	}
+}
+
+// TestSceneJoinAcceptsBareAndHash verifies `scene join` leniently accepts both
+// the '#'-prefixed display form (as surfaced in the web RECENT panel) and a
+// bare id, passing the bare id to the focus substrate in both cases.
+func TestSceneJoinAcceptsBareAndHash(t *testing.T) {
+	for _, prefix := range []string{"", "#"} {
+		t.Run("join prefix="+prefix, func(t *testing.T) {
+			p, fc := newTestPluginWithFocus(t)
+			createResp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command: "scene", Args: "create The Gate", CharacterID: "char-owner",
+			})
+			require.NoError(t, err)
+			sceneID := extractSceneID(t, createResp.Output)
+
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command:     "scene",
+				Args:        "join " + prefix + sceneID,
+				CharacterID: "char-bob",
+				SessionID:   "sess-bob",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+			require.Len(t, fc.joinCalls, 1, "JoinFocus MUST be called once")
+			assert.Equal(t, sceneID, fc.joinCalls[0].target.TargetID,
+				"JoinFocus MUST receive the bare scene id")
+			require.Len(t, fc.autoFocusOnJoinCalls, 1, "AutoFocusOnJoin MUST be called once")
+			assert.Equal(t, sceneID, fc.autoFocusOnJoinCalls[0].sceneID,
+				"AutoFocusOnJoin MUST receive the bare scene id")
+		})
+	}
+}
+
+// TestSceneSwitchAcceptsBareAndHash verifies `scene switch` leniently accepts
+// both forms, passing the bare id to PresentFocus.
+func TestSceneSwitchAcceptsBareAndHash(t *testing.T) {
+	const bareID = "01KSTF08ABCDEF"
+	for _, form := range []string{bareID, "#" + bareID} {
+		t.Run("switch "+form, func(t *testing.T) {
+			p, fc := newTestPluginWithFocus(t)
+			resp, err := p.HandleCommand(context.Background(), pluginsdk.CommandRequest{
+				Command:     "scene",
+				Args:        "switch " + form,
+				CharacterID: "char-bob",
+				SessionID:   "sess-bob",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, pluginsdk.CommandOK, resp.Status)
+			require.Len(t, fc.presentCalls, 1, "PresentFocus MUST be called once")
+			assert.Equal(t, bareID, fc.presentCalls[0].target.TargetID,
+				"PresentFocus MUST receive the bare scene id")
+		})
+	}
+}

--- a/web/e2e/scenes.spec.ts
+++ b/web/e2e/scenes.spec.ts
@@ -208,10 +208,12 @@ test.describe('Scene focus routing (Phase 5, holomush-dble7)', () => {
 
     // Focus-substrate membership is established by `scene join` (JoinFocus),
     // not by `scene create` (DB row only) — so join before focusing, which is
-    // the real user flow. NB: `scene join` takes a BARE id (no `#`), whereas
-    // `scene focus` REQUIRES the `#` prefix.
+    // the real user flow. Both `scene join` and `scene focus` now accept the
+    // `#`-prefixed display form interchangeably with a bare ULID (holomush-ehbnk);
+    // joining with the `#` form here used to yield "scene not found: #<id>" and
+    // is now a regression guard for that parity fix.
     before = await currentEventCount(page);
-    await sendCommand(page, `scene join ${sceneId}`);
+    await sendCommand(page, `scene join #${sceneId}`);
     await waitForOutputMatching(page, /Joined scene/, before);
 
     before = await currentEventCount(page);


### PR DESCRIPTION
## Problem

Scene subcommands disagreed on the `#` scene-ref prefix (holomush-ehbnk, discovered writing the dble7 e2e):

- `scene focus` **required** `#` (stripped it); a bare ULID was rejected with a usage error.
- `scene join` (and the other mandatory-id subcommands) took `fields[0]` **verbatim** — so a `#`-prefixed ref, the form surfaced in the web RECENT panel and in join's own success hints, flowed into the store as `scene not found: #<id>`.

A ref that worked for one subcommand failed for the other — confusing for users and for AI agents driving the terminal.

## Fix (direction A — lenient accept, canonical bare ULID downstream)

- Add a shared `normalizeSceneID(token)` helper: strips one optional leading `#` + surrounding whitespace, yielding the bare ULID (per holomush-y5inx bare-ULID identity).
- Apply it at **every** mandatory-scene-id extraction site: `join`, `focus`, `switch`, `info`, `end`, `pause`, `resume`, `leave`, `invite`, `kick`, `transfer`, `set`.
- Apply it in the **two ABAC resource-ref helpers** (`sceneResourceRef`, `sceneResourceRefFirstField`) so the evaluated resource ref matches the bare id the handler passes downstream — no `scene:#<id>` skew that would break authorization.
- Unify usage strings to `#<scene id>`.

`#<id>` and bare `<id>` are now interchangeable on every scene subcommand.

## Scope

The publish/log family (`resolveSceneRef`) keeps its spec'd (§6.1) `#`-explicit + single-membership-inference contract: the leading `#` there disambiguates a scene ref from a format token in `scene publish download [<format>] [#<id>]`. `#<id>` already works on the whole publish family, so the reported contradiction is fully resolved.

**Silent-failure "ALSO VERIFY":** the `scene focus` non-member no-output observed in the dble7 e2e was the empty-`connection_id` path (the just-landed dble7 fix), not a handler gap — `TestHandleSceneFocus_NotInScene` proves the handler surfaces "You're not in Scene …" on `FOCUS_WITHOUT_MEMBERSHIP`. No split needed.

## Tests

- New `commands_sceneref_test.go`: table-driven coverage for the helper, both ABAC ref helpers, and focus/join/switch **bare-and-`#` parity** asserting the bare id reaches the substrate (`TargetID`/`sceneID`), not just status OK.
- Repurposed `TestHandleSceneFocus_MalformedRef` → `TestHandleSceneFocus_LoneHashRejected` (the `#`-required contract is gone; only an empty-after-normalize ref is rejected).
- `web/e2e/scenes.spec.ts`: corrected a stale comment and switched `scene join` to the `#` form as a regression guard for the previously-broken path.

## Verification

- `task test -- ./plugins/core-scenes/` → 487 pass
- `task lint:go` → 0 issues
- `task pr-prep` (fast lane) → status=pass, exit=0
- code-reviewer agent → READY (no blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scene commands now accept scene references in both formats: with `#` prefix (e.g., `#scene123`) and without (e.g., `scene123`), providing greater flexibility and consistency across all scene operations.

* **Tests**
  * Added comprehensive test coverage for scene reference handling and command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holomush/holomush/pull/4330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->