### PR TITLE
test(plugin): drop subsumed help search-by-keyword spec (holomush-nn408)

### DIFF
--- a/internal/plugin/help_integration_test.go
+++ b/internal/plugin/help_integration_test.go
@@ -156,24 +156,6 @@ var _ = Describe("Help Plugin Integration", func() {
 			Expect(resp.Output).To(ContainSubstring("nonexistent"))
 		})
 
-		It("searches commands by keyword", func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			resp, err := fixture.LuaHost.DeliverCommand(ctx, "core-help", pluginsdk.CommandRequest{
-				Command:     "help",
-				Args:        "search room",
-				CharacterID: "01HTEST000000000000000CHAR",
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp).NotTo(BeNil())
-			Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
-
-			// Should find commands mentioning "room"
-			Expect(resp.Output).To(ContainSubstring("say")) // "Say something to the room"
-			Expect(resp.Output).To(ContainSubstring("dig")) // "Create a new room"
-		})
-
 		It("searches commands by help field", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()


### PR DESCRIPTION
## What

Removes the `searches commands by keyword` spec from
`internal/plugin/help_integration_test.go`. It sent a byte-identical request
(`Args: "search room"`, same fixture, same `CharacterID`) to the adjacent
`searches commands by help field` spec, which adds a discriminating
`NotTo(ContainSubstring("look"))` assertion and fully subsumes it.

Keeping both meant one spec could never fail without the other also failing —
pure redundancy. The negative assertion is what proves search is *selective*,
so the help-field spec is the strict superset worth keeping.

## Why

Pre-existing test-hygiene debt (not introduced by PR #4328); surfaced by
`pr-test-analyzer` during PR #4328 review. Tracked as holomush-nn408
(was holomush-ktdji.1).

## Verification

Focused integration run confirms the kept spec passes and the suite count
dropped by exactly one (85 → 84):

```
Will run 1 of 84 specs
Help Plugin Integration help command searches commands by help field
Ran 1 of 84 Specs — SUCCESS! 1 Passed | 0 Failed | 83 Skipped
```

`task pr-prep` (fast lane) green.

Closes holomush-nn408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)