### PR TITLE
fix(plugin): enforce CommandRequest field parity across both plugin runtimes (holomush-peqfu)

### DIFF
--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -805,18 +805,10 @@ func (h *Host) DeliverCommand(ctx context.Context, name string, cmd pluginsdk.Co
 		return nil, oops.In("goplugin").With("plugin", name).With("operation", "deliver_command").Wrap(ErrPluginNotLoaded)
 	}
 
+	// Single cmd->proto mapping site (holomush-peqfu); see
+	// pluginsdk.CommandRequestToProto for the parity contract.
 	protoReq := &pluginv1.HandleCommandRequest{
-		Command: &pluginv1.CommandRequest{
-			Command:       cmd.Command,
-			Args:          cmd.Args,
-			RawInput:      cmd.InvokedAs,
-			CharacterId:   cmd.CharacterID,
-			CharacterName: cmd.CharacterName,
-			LocationId:    cmd.LocationID,
-			SessionId:     cmd.SessionID,
-			PlayerId:      cmd.PlayerID,
-			ConnectionId:  cmd.ConnectionID, // Phase 5 (holomush-5rh.14 T19 follow-up)
-		},
+		Command: pluginsdk.CommandRequestToProto(cmd),
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, DefaultEventTimeout)

--- a/internal/plugin/lua/command_parity_test.go
+++ b/internal/plugin/lua/command_parity_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package lua
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unicode"
+
+	lua "github.com/yuin/gopher-lua"
+
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+)
+
+// goFieldToLuaKey derives the snake_case Lua table key for a Go struct field
+// name, matching the convention buildCommandRequestTable uses (CharacterID ->
+// character_id, InvokedAs -> invoked_as, ConnectionID -> connection_id). A new
+// field whose Lua key does not follow this convention will fail the parity test
+// below, which is the intended tripwire: the author must either conform the key
+// or consciously teach this helper.
+func goFieldToLuaKey(name string) string {
+	var b strings.Builder
+	runes := []rune(name)
+	for i, r := range runes {
+		if unicode.IsUpper(r) {
+			if i > 0 && (unicode.IsLower(runes[i-1]) || unicode.IsDigit(runes[i-1])) {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// TestBuildCommandRequestTableCarriesEveryField is the Lua-runtime half of the
+// CommandRequest parity guard (holomush-peqfu). It fills every exported field
+// with a sentinel and asserts each one reaches the Lua command table under its
+// conventional snake_case key. A field added to CommandRequest without a
+// matching state.SetField in buildCommandRequestTable is invisible to Lua
+// command handlers — the same structural omission as holomush-dble7, but on the
+// in-process runtime. This guard turns that omission into a build failure.
+func TestBuildCommandRequestTableCarriesEveryField(t *testing.T) {
+	var cmd pluginsdk.CommandRequest
+	v := reflect.ValueOf(&cmd).Elem()
+	typ := v.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if f.Type.Kind() != reflect.String {
+			t.Fatalf("CommandRequest.%s has unsupported kind %s — extend this guard AND "+
+				"ensure the new field is set in buildCommandRequestTable (holomush-peqfu)",
+				f.Name, f.Type.Kind())
+		}
+		v.Field(i).SetString("sentinel::" + f.Name)
+	}
+
+	state := lua.NewState()
+	defer state.Close()
+
+	tbl := (&Host{}).buildCommandRequestTable(state, cmd)
+
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		key := goFieldToLuaKey(f.Name)
+		got := tbl.RawGetString(key)
+		if got.String() != "sentinel::"+f.Name {
+			t.Errorf("CommandRequest.%s MUST appear in the Lua command table under key %q, "+
+				"got %q — a missing field means the Lua runtime never receives it "+
+				"(holomush-peqfu)", f.Name, key, got.String())
+		}
+	}
+}

--- a/pkg/plugin/command_marshal.go
+++ b/pkg/plugin/command_marshal.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+
+// CommandRequestToProto converts the canonical CommandRequest into its proto
+// wire form. It is the single host-side site mapping CommandRequest fields onto
+// pluginv1.CommandRequest (used by the binary-plugin host on send); pair every
+// edit here with CommandRequestFromProto so a field added to CommandRequest is
+// carried in both directions. TestCommandRequestProtoRoundTripCarriesEveryField
+// fails if the two drift — this is the structural guard behind holomush-dble7,
+// where the receive side silently dropped connection_id (holomush-peqfu).
+func CommandRequestToProto(cmd CommandRequest) *pluginv1.CommandRequest {
+	return &pluginv1.CommandRequest{
+		Command:       cmd.Command,
+		Args:          cmd.Args,
+		RawInput:      cmd.InvokedAs,
+		CharacterId:   cmd.CharacterID,
+		CharacterName: cmd.CharacterName,
+		LocationId:    cmd.LocationID,
+		SessionId:     cmd.SessionID,
+		PlayerId:      cmd.PlayerID,
+		ConnectionId:  cmd.ConnectionID,
+	}
+}
+
+// CommandRequestFromProto converts a proto CommandRequest back into the
+// canonical CommandRequest (used by the binary-plugin SDK adapter on receive).
+// See CommandRequestToProto for the parity contract.
+func CommandRequestFromProto(p *pluginv1.CommandRequest) CommandRequest {
+	return CommandRequest{
+		Command:       p.GetCommand(),
+		Args:          p.GetArgs(),
+		CharacterID:   p.GetCharacterId(),
+		CharacterName: p.GetCharacterName(),
+		LocationID:    p.GetLocationId(),
+		SessionID:     p.GetSessionId(),
+		PlayerID:      p.GetPlayerId(),
+		InvokedAs:     p.GetRawInput(),
+		ConnectionID:  p.GetConnectionId(),
+	}
+}

--- a/pkg/plugin/command_marshal_test.go
+++ b/pkg/plugin/command_marshal_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fillStringFieldsWithSentinels sets every exported string field of the struct
+// pointed to by ptr to a unique, field-name-derived sentinel, so that a field
+// dropped by a marshaling step is detectable after a round-trip. It fails the
+// test on any exported field whose kind it cannot fill — forcing the author of
+// a new non-string CommandRequest field to teach this helper and, in doing so,
+// confront the parity contract (holomush-peqfu).
+func fillStringFieldsWithSentinels(t *testing.T, ptr any) {
+	t.Helper()
+	v := reflect.ValueOf(ptr).Elem()
+	typ := v.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		switch f.Type.Kind() {
+		case reflect.String:
+			v.Field(i).SetString("sentinel::" + f.Name)
+		default:
+			t.Fatalf("fillStringFieldsWithSentinels: %s.%s has unsupported kind %s — "+
+				"extend this helper AND ensure the new field is marshaled through both "+
+				"plugin runtimes (holomush-peqfu)", typ.Name(), f.Name, f.Type.Kind())
+		}
+	}
+}
+
+// TestCommandRequestProtoRoundTripCarriesEveryField is the binary-runtime half
+// of the CommandRequest parity guard (holomush-peqfu). It fills every exported
+// field with a sentinel and asserts the value survives cmd -> proto -> cmd. A
+// field wired in only one direction — or missing from the proto message
+// entirely — is dropped by the round-trip and fails this test. This is the
+// structural class-killer behind holomush-dble7 (binary plugins silently
+// dropped connection_id on the proto receive side): adding a CommandRequest
+// field without wiring CommandRequestToProto AND CommandRequestFromProto can no
+// longer pass silently.
+func TestCommandRequestProtoRoundTripCarriesEveryField(t *testing.T) {
+	var req CommandRequest
+	fillStringFieldsWithSentinels(t, &req)
+
+	got := CommandRequestFromProto(CommandRequestToProto(req))
+
+	require.Equal(t, req, got,
+		"every exported CommandRequest field MUST survive the cmd->proto->cmd round "+
+			"trip; a mismatch means a field is wired in one direction but not the other, "+
+			"or is missing from the proto message (holomush-peqfu)")
+}

--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -257,24 +257,11 @@ func (a *pluginServerAdapter) HandleCommand(ctx context.Context, req *pluginv1.H
 	}
 	ctx = contextWithIncomingActorMetadata(ctx)
 
-	protoCmd := req.GetCommand()
-	cmd := CommandRequest{
-		Command:       protoCmd.GetCommand(),
-		Args:          protoCmd.GetArgs(),
-		CharacterID:   protoCmd.GetCharacterId(),
-		CharacterName: protoCmd.GetCharacterName(),
-		LocationID:    protoCmd.GetLocationId(),
-		SessionID:     protoCmd.GetSessionId(),
-		PlayerID:      protoCmd.GetPlayerId(),
-		InvokedAs:     protoCmd.GetRawInput(),
-		// Phase 5 (holomush-dble7): without this, the per-connection id sent
-		// by the host (host.go DeliverCommand, proto field 9) is dropped on
-		// receive, so binary-plugin handlers see an empty ConnectionID and
-		// `scene focus`/`scene grid` reject every web command with "requires a
-		// live connection". Lua plugins pass the struct in-process and never
-		// lose it — omitting it here is a plugin-runtime-symmetry violation.
-		ConnectionID: protoCmd.GetConnectionId(),
-	}
+	// Single proto->cmd mapping site (holomush-peqfu). holomush-dble7 was a
+	// hand-copied receive site that silently dropped connection_id; routing
+	// through CommandRequestFromProto, guarded by the proto round-trip parity
+	// test, makes that class of omission a build failure.
+	cmd := CommandRequestFromProto(req.GetCommand())
 
 	// Attach an audit hint slice to the handler context so plugin code
 	// can call pluginsdk.Audit(ctx).Deny(...) and have hints collected


### PR DESCRIPTION
## Summary

- `pluginsdk.CommandRequest` was hand-marshaled at **three independent sites** with no enforced parity — the structural source of the `holomush-dble7` class (binary plugins silently dropped `connection_id` on the proto receive side). A new field reached a runtime only if a human edited all three sites; nothing failed if they forgot.
- **(B) Collapsed the cmd↔proto mapping to single-direction helpers** in `pkg/plugin/command_marshal.go` (`CommandRequestToProto` / `CommandRequestFromProto`); the binary host send (`internal/plugin/goplugin/host.go`) and SDK adapter receive (`pkg/plugin/sdk.go`) now route through them — one edit site per direction.
- **(A) Added two reflection-driven exhaustiveness guards** that enumerate `CommandRequest`'s exported fields, so a new field is covered with **zero per-field maintenance**:
  - `TestCommandRequestProtoRoundTripCarriesEveryField` (`pkg/plugin`) — sentinel-fill + `reflect.DeepEqual` over `cmd→proto→cmd`.
  - `TestBuildCommandRequestTableCarriesEveryField` (`internal/plugin/lua`) — snake_case key presence in the Lua command table.
- Scope is `CommandRequest` only; extension to the other Host-boundary structs (`EmitIntent`/`Event`/`SessionStreamsRequest`) is tracked in **holomush-av954**.

This is the durable structural guard behind the reactive per-field tests landed in holomush-q5czf (#4326): adding a `CommandRequest` field without wiring both runtimes is now a build failure rather than a silent omission.

## Test Plan

- [x] `task test -- ./pkg/plugin/... ./internal/plugin/lua/... ./internal/plugin/goplugin/...` — 481 pass (incl. the dble7 q5czf regression)
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` (fast lane) — `status=pass`
- [x] **Guard demonstrated:** a temporary unwired field on `CommandRequest` made both guards fail with grounded messages, then reverted
- [ ] CI Integration + E2E gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)