### PR TITLE
test(plugin): harden CommandRequest parity guard — acronym-safe keys + accurate wording (holomush-peqfu follow-up)

### DIFF
--- a/internal/plugin/lua/command_parity_test.go
+++ b/internal/plugin/lua/command_parity_test.go
@@ -16,16 +16,23 @@ import (
 
 // goFieldToLuaKey derives the snake_case Lua table key for a Go struct field
 // name, matching the convention buildCommandRequestTable uses (CharacterID ->
-// character_id, InvokedAs -> invoked_as, ConnectionID -> connection_id). A new
-// field whose Lua key does not follow this convention will fail the parity test
-// below, which is the intended tripwire: the author must either conform the key
-// or consciously teach this helper.
+// character_id, InvokedAs -> invoked_as, ConnectionID -> connection_id). It
+// handles acronym→word boundaries (HTTPMethod -> http_method, URLPath ->
+// url_path) so that a future field does not silently derive a malformed key.
+// A field whose actual Lua key still diverges from this derivation fails the
+// parity test below — the intended tripwire: conform the key or teach this
+// helper.
 func goFieldToLuaKey(name string) string {
 	var b strings.Builder
 	runes := []rune(name)
 	for i, r := range runes {
 		if unicode.IsUpper(r) {
-			if i > 0 && (unicode.IsLower(runes[i-1]) || unicode.IsDigit(runes[i-1])) {
+			prevIsLowerOrDigit := i > 0 && (unicode.IsLower(runes[i-1]) || unicode.IsDigit(runes[i-1]))
+			// Acronym→word boundary: an uppercase run ending where the next
+			// rune is lowercase (the M in HTTPMethod, the P in URLPath).
+			acronymBoundary := i > 0 && unicode.IsUpper(runes[i-1]) &&
+				i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if prevIsLowerOrDigit || acronymBoundary {
 				b.WriteByte('_')
 			}
 			b.WriteRune(unicode.ToLower(r))
@@ -36,16 +43,15 @@ func goFieldToLuaKey(name string) string {
 	return b.String()
 }
 
-// TestBuildCommandRequestTableCarriesEveryField is the Lua-runtime half of the
-// CommandRequest parity guard (holomush-peqfu). It fills every exported field
-// with a sentinel and asserts each one reaches the Lua command table under its
-// conventional snake_case key. A field added to CommandRequest without a
-// matching state.SetField in buildCommandRequestTable is invisible to Lua
-// command handlers — the same structural omission as holomush-dble7, but on the
-// in-process runtime. This guard turns that omission into a build failure.
-func TestBuildCommandRequestTableCarriesEveryField(t *testing.T) {
-	var cmd pluginsdk.CommandRequest
-	v := reflect.ValueOf(&cmd).Elem()
+// fillStringSentinels sets every exported string field of the struct pointed to
+// by ptr to a unique, field-name-derived sentinel, and fails the test on any
+// exported field whose kind it cannot fill — forcing the author of a new
+// non-string CommandRequest field to teach this guard and confront the parity
+// contract (holomush-peqfu). It mirrors fillStringFieldsWithSentinels in
+// pkg/plugin; the duplication is unavoidable across the package boundary.
+func fillStringSentinels(t *testing.T, ptr any) {
+	t.Helper()
+	v := reflect.ValueOf(ptr).Elem()
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
@@ -59,12 +65,50 @@ func TestBuildCommandRequestTableCarriesEveryField(t *testing.T) {
 		}
 		v.Field(i).SetString("sentinel::" + f.Name)
 	}
+}
+
+// TestGoFieldToLuaKeyDerivesSnakeCaseKeys locks the snake_case derivation,
+// including the acronym→word boundary handling that keeps the parity guard's
+// key inference correct for plausible future field names.
+func TestGoFieldToLuaKeyDerivesSnakeCaseKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{"single word lowercases", "Command", "command"},
+		{"trailing acronym splits", "CharacterID", "character_id"},
+		{"two words split", "CharacterName", "character_name"},
+		{"verb-preposition splits", "InvokedAs", "invoked_as"},
+		{"leading acronym then word", "HTTPMethod", "http_method"},
+		{"leading acronym then word URL", "URLPath", "url_path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := goFieldToLuaKey(tt.field); got != tt.want {
+				t.Errorf("goFieldToLuaKey(%q) = %q, want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildCommandRequestTableCarriesEveryField is the Lua-runtime half of the
+// CommandRequest parity guard (holomush-peqfu). It fills every exported field
+// with a sentinel and asserts each one reaches the Lua command table under its
+// conventional snake_case key. A field added to CommandRequest without a
+// matching state.SetField in buildCommandRequestTable is invisible to Lua
+// command handlers — the same structural omission as holomush-dble7, but on the
+// in-process runtime. This guard turns that omission into a test failure.
+func TestBuildCommandRequestTableCarriesEveryField(t *testing.T) {
+	var cmd pluginsdk.CommandRequest
+	fillStringSentinels(t, &cmd)
 
 	state := lua.NewState()
 	defer state.Close()
 
 	tbl := (&Host{}).buildCommandRequestTable(state, cmd)
 
+	typ := reflect.TypeOf(cmd)
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		if !f.IsExported() {

--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -260,7 +260,7 @@ func (a *pluginServerAdapter) HandleCommand(ctx context.Context, req *pluginv1.H
 	// Single proto->cmd mapping site (holomush-peqfu). holomush-dble7 was a
 	// hand-copied receive site that silently dropped connection_id; routing
 	// through CommandRequestFromProto, guarded by the proto round-trip parity
-	// test, makes that class of omission a build failure.
+	// test, makes that class of omission a test failure.
 	cmd := CommandRequestFromProto(req.GetCommand())
 
 	// Attach an audit hint slice to the handler context so plugin code


### PR DESCRIPTION
## Summary

Follow-up to #4332 (merged), landing the three review suggestions from review epic `holomush-7oziv` that arrived just after the squash-merge of the core change:

- **`goFieldToLuaKey` now handles acronym→word boundaries** (`HTTPMethod`→`http_method`, `URLPath`→`url_path`) so the Lua parity guard infers correct snake_case keys for plausible future fields. Locked by a new `TestGoFieldToLuaKeyDerivesSnakeCaseKeys`. (`7oziv.1`)
- **Extracted `fillStringSentinels` helper** in the Lua parity test, mirroring `fillStringFieldsWithSentinels` in `pkg/plugin`. (`7oziv.3`)
- **Corrected "build failure" → "test failure"** in the guard comments (`pkg/plugin/sdk.go`, `internal/plugin/lua/command_parity_test.go`) — the guards are test-time; the code compiles. (`7oziv.2`)

No production behavior change — comment wording + test-only hardening, rebased onto current main (which already contains #4332's mappers/guards and #4333's Lua refactor).

## Test Plan

- [x] `task test -- ./pkg/plugin/... ./internal/plugin/lua/...` — 283 pass
- [x] `task lint:go` — 0 issues
- [x] `task pr-prep` (fast lane) — `status=pass`
- [ ] CI Integration + E2E gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)