### PR TITLE
docs: web client brand rebrand + AA contrast (spec, plan, ADRs) (holomush-9ektq)

### DIFF
--- a/docs/adr/holomush-lcr84-brand-chrome-vs-game-message-colors.md
+++ b/docs/adr/holomush-lcr84-brand-chrome-vs-game-message-colors.md
@@ -1,0 +1,57 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Software Brand Governs Chrome Tokens Only; Message Colors Are Game-World Content
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Decision:** holomush-lcr84
+**Deciders:** HoloMUSH Contributors
+**Related:** holomush-9ektq
+
+## Context
+
+The web client uses two CSS custom-property namespaces: `--color-*` for UI chrome (background, accents, borders, status) and `--mush-*` for in-game message text (say/pose/system/ooc/…). The 2026-05-28 software brand refresh (`.claude/rules/branding.md`) defined the holographic-terminal identity — cyan accents (`#3dd6f7`/`#1565c0`) on ink, with amber (`#ffb300`) reserved as the cursor only (INV-1). branding.md INV-6 already states the brand is "software/platform only — never the game world / default setting," but the boundary at the *token* level was implicit, and the web client predated the brand entirely (brown/amber, amber-as-accent).
+
+During the web rebrand (holomush-9ektq) the question surfaced concretely: do the 11 `--mush-*` message colors get brand-locked to the cyan palette? The user clarified INV-6's intent — it decouples the software brand from the game/sandbox brand; it is not a ban on a given aesthetic.
+
+## Decision
+
+The software brand palette governs **only** the `--color-*` chrome namespace. The `--mush-*` message-color tokens are game-world content with **no parity obligation** to the software brand: the game/sandbox may adopt any message palette (warm, cyan, custom) independently and copy themes across the boundary without synchronization. INV-1 (amber = cursor only) applies **exclusively** to `--color-*` accent tokens.
+
+This is enforced mechanically: the INV-1 brand-guard test (`themeStore.test.ts`) asserts cyan-dominance and amber-absence on `--color-primary`/`accent`/`ring`/`scrollback.indicator` for the `default-*` themes only — it never inspects `--mush-*`, and it never runs against the `warm-*` themes.
+
+## Alternatives Considered
+
+### A — Decouple `--mush-*` from the brand, no parity obligation (chosen)
+
+Game-message text is authored content, not platform chrome. Decoupling lets warm alternate themes use amber for `--mush-system` without violating the cursor-only rule, and lets game designers/operators define message palettes freely. Cost: the boundary must be documented so future contributors don't re-couple the namespaces.
+
+### B — Brand-lock `--mush-*` to the same cyan palette as chrome
+
+Visual consistency and one palette to maintain, but it forces a parity obligation on game-world presentation, makes the warm-dark theme's amber `--mush-system` a brand violation, and conflates platform identity with authored content. Rejected.
+
+## Rationale
+
+- Brand rules exist so the *platform UI* is recognizable; message text is game content, a different ownership domain.
+- The warm alternate themes (holomush-9ektq D3) require amber in `--mush-system`; decoupling makes that coherent rather than a violation.
+- Aligns with and operationalizes branding.md INV-6 at the token-namespace level.
+- Narrows the INV-1 enforcement surface to a well-defined token subset, making the brand-guard test precise.
+
+## Consequences
+
+**Positive:** operators and game designers define message palettes freely; warm themes are coherent; INV-1 enforcement is a narrow, testable subset.
+
+**Negative:** contributors must learn which namespace governs brand vs content; the boundary lives in docs + the guard test, not in the type system.
+
+**Neutral:** the brand-guard test checks `--color-*` accents only — a direct mechanical reflection of this boundary.
+
+## Implementation
+
+See `docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md` Task 3 (INV-1 brand-guard test scoped to `--color-*` on `default-*` themes) and Tasks 4–5 (message `--mush-*` values chosen as game-world content, not brand-locked).
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md` §Decisions D4, §Invariants INV-1
+- `.claude/rules/branding.md` INV-1, INV-6
+- `web/src/lib/stores/themeStore.ts` `MUSH_TOKENS` (the namespace split)

--- a/docs/adr/holomush-poxub-foreground-input-themed-tokens.md
+++ b/docs/adr/holomush-poxub-foreground-input-themed-tokens.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# `foreground` and `input` Are Themed `ThemeColors` Keys, Not `@theme`-Only Statics
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Decision:** holomush-poxub
+**Deciders:** HoloMUSH Contributors
+**Related:** holomush-9ektq, holomush-lcr84
+
+## Context
+
+The web client's runtime theming works by mapping a theme JSON's keys to `--color-*`/`--mush-*` custom properties (`themeToCssVars()`) applied inline on `.app-root`; the Tailwind v4 `@theme` block in `web/src/app.css` carries build-time static defaults. `--color-foreground` and `--color-input` existed **only** as `@theme` statics — there was no `foreground` or `input` key in the `ThemeColors` type or the theme JSONs, so they could not be overridden per theme at runtime. Body text and input borders therefore rendered the same color regardless of the selected theme — a latent bug exposed once the rebrand added a light brand theme (which needs a dark foreground where the dark theme needs a light one).
+
+## Decision
+
+`foreground` and `input` are promoted to full `ThemeColors` keys, present in every theme JSON and emitted by `themeToCssVars()` as `--color-foreground` / `--color-input`, overriding the `@theme` statics at runtime. This codifies a general rule: **any token whose value differs between themes MUST be a `ThemeColors` key**, not an `@theme`-only static. The `@theme` statics remain as pre-hydration/SSR/unstyled-fallback defaults.
+
+## Alternatives Considered
+
+### A — Promote `foreground` and `input` to `ThemeColors` keys (chosen)
+
+Runtime theme switching correctly overrides body text and input borders; consistent with every other theme-variant token; `themeToCssVars()` already maps any non-MUSH key to `--color-<key>`, so promotion needs only the type + JSON edits, no store-logic change. `pnpm check` enforces completeness — a missing key in any theme JSON is a type error.
+
+### B — Leave them as `@theme` statics only
+
+No type/JSON churn, but light and dark would share one foreground/input color — broken runtime theming for body text and input borders on light themes. Rejected: it is the bug, not a viable option.
+
+## Rationale
+
+- A single build-time static cannot serve both a light and a dark foreground; the value is inherently theme-variant, which is exactly what `ThemeColors` is for.
+- `ThemeColors` is the contract for runtime-themeable tokens; the rule "theme-variant ⇒ `ThemeColors` key" makes that contract complete and gives future contributors a clear test for where a new token belongs.
+- The mapping is automatic in `themeToCssVars()` (`themeStore.ts:83-93`), so the cost is type + data, not logic.
+
+## Consequences
+
+**Positive:** all four themes render correct body-text/input-border colors; `pnpm check` mechanically enforces JSON completeness.
+
+**Negative:** all theme JSONs and the `ThemeColors` type must stay in sync; every new theme must supply these keys (and the other new tokens `cursor`, `scrollback.replayed`).
+
+**Neutral:** the `@theme` statics persist as fallback defaults for non-themed/unhydrated contexts.
+
+## Implementation
+
+See `docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md` Task 1 (add keys to `ThemeColors`) and Tasks 2/4/5 (populate all theme JSONs); INV-6 token-completeness test in Task 3.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md` §Token specification (reconciliation note), §Invariants INV-6
+- `web/src/lib/stores/themeStore.ts:83-93` (`themeToCssVars` non-MUSH auto-map)
+- `web/CLAUDE.md` "Theme System" → "Adding a New Theme Token"

--- a/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
+++ b/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
@@ -83,6 +83,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 - Delete: `web/src/lib/theme/classic-dark.json`, `web/src/lib/theme/classic-light.json`
 - Modify: `web/src/lib/stores/themeStore.ts:6-16,28-54`
 - Modify: `web/src/lib/components/terminal/CommandPalette.svelte:44-47`
+- Modify: `web/src/lib/components/TopBar.svelte:24-35` (duplicate static theme registry)
 - Modify: `web/src/lib/stores/themeStore.test.ts:35-45`
 
 - [ ] **Step 1: Create `warm-dark.json`** (brown palette relocated; `status.text`/`muted.foreground` raised to AA `#9a8f7e`; new tokens added)
@@ -144,7 +145,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 {
   "name": "warm-light",
   "colors": {
-    "say.speaker": "#0277bd",
+    "say.speaker": "#0268a8",
     "say.speech": "#1a1a1a",
     "pose.actor": "#2e7d32",
     "pose.action": "#666666",
@@ -256,6 +257,23 @@ Replace lines 46-47 of `web/src/lib/components/terminal/CommandPalette.svelte`:
 ```svelte
     { id: 'theme.warm-dark',      label: 'Switch theme: Warm Dark',      run: () => setTheme('warm-dark') },
     { id: 'theme.warm-light',     label: 'Switch theme: Warm Light',     run: () => setTheme('warm-light') },
+```
+
+- [ ] **Step 5b: Update `TopBar.svelte`'s duplicate theme registry** — it statically imports the JSON files deleted in Step 3, so this MUST change or `pnpm check`/`pnpm build` fails with module-not-found. Replace lines 24-35 of `web/src/lib/components/TopBar.svelte`:
+
+```svelte
+  import defaultDark from '$lib/theme/default-dark.json';
+  import defaultLight from '$lib/theme/default-light.json';
+  import warmDark from '$lib/theme/warm-dark.json';
+  import warmLight from '$lib/theme/warm-light.json';
+  import type { Theme } from '$lib/theme/types';
+
+  const themeData: Record<string, Theme> = {
+    'default-dark': defaultDark as Theme,
+    'default-light': defaultLight as Theme,
+    'warm-dark': warmDark as Theme,
+    'warm-light': warmLight as Theme,
+  };
 ```
 
 - [ ] **Step 6: Update the test fixture imports**
@@ -556,7 +574,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 - [ ] **Step 1: Run the entire theme test file**
 
 Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts`
-Expected: PASS — all four themes clear contrast (INV-2/3/7), brand guards hold (INV-1), tokens exposed (INV-6), migration works (D9). If a `warm-dark`/`warm-light` contrast case fails, raise that theme's `status.text`/`muted.foreground`/`scrollback.replayed` until ≥4.5:1 (warm-dark muted is `#9a8f7e`; bump toward `#a89c8a` if needed).
+Expected: PASS — all four themes clear contrast (INV-2/3/7), brand guards hold (INV-1), tokens exposed (INV-6), migration works (D9). If any contrast case fails, darken the offending token until ≥4.5:1: for chrome, `status.text`/`muted.foreground`/`scrollback.replayed` (warm-dark muted is `#9a8f7e`; bump toward `#a89c8a`); for messages, the dimmest hues — note `warm-light say.speaker` was pre-darkened `#0277bd`→`#0268a8` (4.43→5.46:1) in Task 2 for exactly this reason, so any *other* warm-light message token that fails gets the same one-step darkening treatment.
 
 - [ ] **Step 2: Commit (only if a warm token was adjusted; otherwise skip)**
 

--- a/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
+++ b/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
@@ -860,3 +860,5 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ## Out of scope (per spec)
 
 Game/sandbox warm-theme adoption; operator custom themes (holomush-nmr8); `terminalBlackBackground` semantics; non-theme component restructuring.
+
+<!-- adr-capture: sha256=63b1ae52b335c618; session=brainstorm-9ektq; ts=2026-05-29T00:00:00Z; adrs=holomush-lcr84,holomush-poxub -->

--- a/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
+++ b/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 # Web Client Brand Rebrand + AA Contrast Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -38,6 +43,7 @@
 ### Task 1: Promote/add the four new theme token keys to the type contract
 
 **Files:**
+
 - Modify: `web/src/lib/theme/types.ts:18-30`
 
 - [ ] **Step 1: Add the keys to `ThemeColors`**
@@ -78,6 +84,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 2: Relocate warm themes + rename theme ids + localStorage migration (D3, D9)
 
 **Files:**
+
 - Create: `web/src/lib/theme/warm-dark.json` (content = current `default-dark.json` brown palette + new tokens)
 - Create: `web/src/lib/theme/warm-light.json` (content = current `default-light.json` cream palette + new tokens)
 - Delete: `web/src/lib/theme/classic-dark.json`, `web/src/lib/theme/classic-light.json`
@@ -325,6 +332,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 3: Add the WCAG contrast + brand-guard test harness (INV-1, INV-2, INV-3, INV-6)
 
 **Files:**
+
 - Modify: `web/src/lib/stores/themeStore.test.ts` (append new describe blocks + helpers)
 
 - [ ] **Step 1: Add the luminance + contrast helpers** (append near the `rgb()` helper, after line 53)
@@ -432,6 +440,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 4: Rewrite `default-dark.json` to the brand palette
 
 **Files:**
+
 - Modify: `web/src/lib/theme/default-dark.json` (full rewrite)
 
 - [ ] **Step 1: Replace the entire file**
@@ -501,6 +510,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 5: Rewrite `default-light.json` to the brand palette
 
 **Files:**
+
 - Modify: `web/src/lib/theme/default-light.json` (full rewrite)
 
 - [ ] **Step 1: Replace the entire file**
@@ -585,6 +595,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 7: Update `app.css` `@theme` statics + wire the amber caret (D7, D8, INV-1)
 
 **Files:**
+
 - Modify: `web/src/app.css:9-48`
 - Modify: `web/src/lib/components/terminal/CommandInput.svelte:214-222`
 
@@ -664,6 +675,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 8: holomush-1hgk — replace scrollback compounding opacity with a colour token (INV-4)
 
 **Files:**
+
 - Modify: `web/src/lib/components/terminal/EventRenderer.svelte:27,44`
 - Modify: `web/src/lib/components/terminal/TerminalView.svelte:53-55,74,109`
 - Modify: `web/src/lib/stores/themeStore.test.ts` (consuming-site guard)
@@ -751,6 +763,7 @@ Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj co
 ### Task 9: holomush-vhsz — enlarge the shortcut hint bar (INV-5)
 
 **Files:**
+
 - Modify: `web/src/lib/components/terminal/CommandInput.svelte:233-247`
 - Modify: `web/src/lib/stores/themeStore.test.ts` (consuming-site guard)
 

--- a/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
+++ b/docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md
@@ -1,0 +1,844 @@
+# Web Client Brand Rebrand + AA Contrast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-skin the web client's two default themes to the holographic-terminal brand palette (cyan/ink), relocate the brown/warm palettes to `warm-*` themes, and meet WCAG AA 4.5:1 on all four themes — closing holomush-6siys, holomush-1hgk, and holomush-vhsz.
+
+**Architecture:** Theme colors live in `web/src/lib/theme/*.json`, mapped to `--color-*`/`--mush-*` CSS custom properties by `themeToCssVars()` and applied as inline style on `.app-root`. `web/src/app.css` `@theme` carries build-time statics (default-dark). The rebrand is driven from the JSON token tables; a new pure-vitest contrast test enforces AA across all themes. Two coordinated fixes are CSS-mechanism changes in terminal components.
+
+**Tech Stack:** SvelteKit 2 / Svelte 5, Tailwind CSS v4 (`@theme`), vitest, TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md` (design bead holomush-9ektq).
+
+**Working dir:** jj workspace `/Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand`. All `pnpm`/test commands run from `web/`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `web/src/lib/theme/types.ts` | `ThemeColors` contract | add `foreground`, `input`, `cursor`, `scrollback.replayed` keys |
+| `web/src/lib/theme/default-dark.json` | brand dark | rewrite → cyan/ink |
+| `web/src/lib/theme/default-light.json` | brand light | rewrite → cyan-on-light |
+| `web/src/lib/theme/warm-dark.json` | warm dark alternate | new file (relocated brown), replaces `classic-dark.json` |
+| `web/src/lib/theme/warm-light.json` | warm light alternate | new file (relocated cream), replaces `classic-light.json` |
+| `web/src/lib/stores/themeStore.ts` | theme registry + prefs | rename ids, add `classic-*`→`warm-*` migration |
+| `web/src/lib/components/terminal/CommandPalette.svelte` | theme-switch palette commands | rename ids/labels `:44-47` |
+| `web/src/app.css` | `@theme` build-time statics | brand-dark values + new tokens |
+| `web/src/lib/components/terminal/CommandInput.svelte` | command input + hint bar | caret-color amber; vhsz font-size |
+| `web/src/lib/components/terminal/TerminalView.svelte` | scrollback rendering | 1hgk: opacity → `--color-scrollback-replayed` |
+| `web/src/lib/components/terminal/EventRenderer.svelte` | per-event renderer | 1hgk: remove `.dimmed` opacity |
+| `web/src/lib/stores/themeStore.test.ts` | theme tests | add contrast + brand-guard + migration tests |
+
+**Token-vs-type decision (resolves spec reconciliation note):** `foreground` and `input` are promoted to themed `ThemeColors` keys (light and dark need different foregrounds; a single `@theme` static cannot serve both). `themeToCssVars()` already maps any non-MUSH key to `--color-<key>`, so no store-logic change is needed for them — only the type, the JSONs, and the `@theme` defaults.
+
+---
+
+### Task 1: Promote/add the four new theme token keys to the type contract
+
+**Files:**
+- Modify: `web/src/lib/theme/types.ts:18-30`
+
+- [ ] **Step 1: Add the keys to `ThemeColors`**
+
+In `web/src/lib/theme/types.ts`, replace the "Chrome tokens (structural UI)" block (lines 18-30) with:
+
+```typescript
+  // Chrome tokens (structural UI)
+  background: string;
+  foreground: string;
+  input: string;
+  surface: string;
+  border: string;
+  cursor: string;
+  'input.prompt': string;
+  'input.text': string;
+  'input.background': string;
+  'status.text': string;
+  'status.background': string;
+  'status.online': string;
+  'status.offline': string;
+  'sidebar.background': string;
+  'scrollback.indicator': string;
+  'scrollback.replayed': string;
+```
+
+- [ ] **Step 2: Run the type check to verify it now fails (JSONs missing keys)**
+
+Run: `cd web && pnpm check`
+Expected: FAIL — the four `*.json` files cast `as Theme` are now missing `foreground`, `input`, `cursor`, `scrollback.replayed`. (Svelte-check surfaces the missing-property errors on the JSON imports.) This failure is expected and is fixed by Tasks 2-6.
+
+- [ ] **Step 3: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "feat(web): add foreground/input/cursor/scrollback.replayed theme tokens (holomush-9ektq)"`
+
+---
+
+### Task 2: Relocate warm themes + rename theme ids + localStorage migration (D3, D9)
+
+**Files:**
+- Create: `web/src/lib/theme/warm-dark.json` (content = current `default-dark.json` brown palette + new tokens)
+- Create: `web/src/lib/theme/warm-light.json` (content = current `default-light.json` cream palette + new tokens)
+- Delete: `web/src/lib/theme/classic-dark.json`, `web/src/lib/theme/classic-light.json`
+- Modify: `web/src/lib/stores/themeStore.ts:6-16,28-54`
+- Modify: `web/src/lib/components/terminal/CommandPalette.svelte:44-47`
+- Modify: `web/src/lib/stores/themeStore.test.ts:35-45`
+
+- [ ] **Step 1: Create `warm-dark.json`** (brown palette relocated; `status.text`/`muted.foreground` raised to AA `#9a8f7e`; new tokens added)
+
+```json
+{
+  "name": "warm-dark",
+  "colors": {
+    "say.speaker": "#4fc3f7",
+    "say.speech": "#ffffff",
+    "pose.actor": "#81c784",
+    "pose.action": "#aaaaaa",
+    "system": "#ffb74d",
+    "arrive": "#888888",
+    "leave": "#888888",
+    "command.output": "#e0e0e0",
+    "command.error": "#e57373",
+    "ooc": "#9575cd",
+    "pemit": "#80cbc4",
+    "background": "#1a1210",
+    "foreground": "#e0d6cf",
+    "input": "#3e2a1a",
+    "surface": "#1e1612",
+    "border": "#3e2a1a",
+    "cursor": "#ffb74d",
+    "input.prompt": "#ff7043",
+    "input.text": "#e0d6cf",
+    "input.background": "#16100c",
+    "status.text": "#9a8f7e",
+    "status.background": "#1e1612",
+    "status.online": "#66bb6a",
+    "status.offline": "#e57373",
+    "sidebar.background": "#1e1612",
+    "scrollback.indicator": "#ffb74d",
+    "scrollback.replayed": "#9a8f7e",
+    "primary": "#ff7043",
+    "primary.foreground": "#ffffff",
+    "secondary": "#2a1e16",
+    "secondary.foreground": "#e0d6cf",
+    "muted": "#2a1e16",
+    "muted.foreground": "#9a8f7e",
+    "accent": "#ffb74d",
+    "accent.foreground": "#1a1210",
+    "destructive": "#e57373",
+    "destructive.foreground": "#ffffff",
+    "card": "#1e1612",
+    "card.foreground": "#e0d6cf",
+    "popover": "#1e1612",
+    "popover.foreground": "#e0d6cf",
+    "ring": "#ff7043",
+    "radius": "0.5rem"
+  }
+}
+```
+
+- [ ] **Step 2: Create `warm-light.json`** (cream palette relocated; `muted.foreground #6b6055` already AA; new tokens added)
+
+```json
+{
+  "name": "warm-light",
+  "colors": {
+    "say.speaker": "#0277bd",
+    "say.speech": "#1a1a1a",
+    "pose.actor": "#2e7d32",
+    "pose.action": "#666666",
+    "system": "#b34700",
+    "arrive": "#616161",
+    "leave": "#616161",
+    "command.output": "#1a1a1a",
+    "command.error": "#c62828",
+    "ooc": "#6a1b9a",
+    "pemit": "#00695c",
+    "background": "#faf5f0",
+    "foreground": "#1a1510",
+    "input": "#d4c4b0",
+    "surface": "#f0ebe5",
+    "border": "#d4c4b0",
+    "cursor": "#c75c00",
+    "input.prompt": "#e64a19",
+    "input.text": "#1a1510",
+    "input.background": "#fffcf8",
+    "status.text": "#6b6055",
+    "status.background": "#f0ebe5",
+    "status.online": "#2e7d32",
+    "status.offline": "#c62828",
+    "sidebar.background": "#f5f0ea",
+    "scrollback.indicator": "#e65100",
+    "scrollback.replayed": "#6b6055",
+    "primary": "#e64a19",
+    "primary.foreground": "#ffffff",
+    "secondary": "#d4c4b0",
+    "secondary.foreground": "#1a1510",
+    "muted": "#d4c4b0",
+    "muted.foreground": "#6b6055",
+    "accent": "#f57c00",
+    "accent.foreground": "#ffffff",
+    "destructive": "#c62828",
+    "destructive.foreground": "#ffffff",
+    "card": "#f0ebe5",
+    "card.foreground": "#1a1510",
+    "popover": "#f0ebe5",
+    "popover.foreground": "#1a1510",
+    "ring": "#e64a19",
+    "radius": "0.5rem"
+  }
+}
+```
+
+- [ ] **Step 3: Delete the old classic files**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && rm web/src/lib/theme/classic-dark.json web/src/lib/theme/classic-light.json`
+
+- [ ] **Step 4: Update `themeStore.ts` imports, registry, and add migration**
+
+Replace lines 6-16 of `web/src/lib/stores/themeStore.ts`:
+
+```typescript
+import defaultDark from '$lib/theme/default-dark.json';
+import defaultLight from '$lib/theme/default-light.json';
+import warmDark from '$lib/theme/warm-dark.json';
+import warmLight from '$lib/theme/warm-light.json';
+
+const themes: Record<string, Theme> = {
+  'default-dark': defaultDark as Theme,
+  'default-light': defaultLight as Theme,
+  'warm-dark': warmDark as Theme,
+  'warm-light': warmLight as Theme,
+};
+
+// Renamed theme ids (holomush-9ektq D3): classic-* → warm-*.
+const RENAMED_THEME_IDS: Record<string, string> = {
+  'classic-dark': 'warm-dark',
+  'classic-light': 'warm-light',
+};
+```
+
+Then in `loadPreferences()` (lines 32-41), apply the rename when reading saved prefs. Replace the `if (saved) { ... }` block with:
+
+```typescript
+    if (saved) {
+      const parsed = JSON.parse(saved) as Partial<ThemePreferences>;
+      const requested = parsed.themeId ?? '';
+      const migrated = RENAMED_THEME_IDS[requested] ?? requested;
+      return {
+        themeId: themes[migrated] ? migrated : 'default-dark',
+        terminalBlackBackground: parsed.terminalBlackBackground ?? false,
+      };
+    }
+```
+
+And in the legacy-key branch (lines 44-50), map the legacy id too. Replace:
+
+```typescript
+  // Migrate from old key
+  const legacyTheme = localStorage.getItem('holomush-theme');
+  if (legacyTheme) {
+    const migrated = RENAMED_THEME_IDS[legacyTheme] ?? legacyTheme;
+    if (themes[migrated]) {
+      const prefs = { themeId: migrated, terminalBlackBackground: false };
+      localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+      localStorage.removeItem('holomush-theme');
+      return prefs;
+    }
+  }
+```
+
+- [ ] **Step 5: Update `CommandPalette.svelte` theme-switch commands**
+
+Replace lines 46-47 of `web/src/lib/components/terminal/CommandPalette.svelte`:
+
+```svelte
+    { id: 'theme.warm-dark',      label: 'Switch theme: Warm Dark',      run: () => setTheme('warm-dark') },
+    { id: 'theme.warm-light',     label: 'Switch theme: Warm Light',     run: () => setTheme('warm-light') },
+```
+
+- [ ] **Step 6: Update the test fixture imports**
+
+Replace lines 37-45 of `web/src/lib/stores/themeStore.test.ts`:
+
+```typescript
+import defaultDark from '$lib/theme/default-dark.json';
+import defaultLight from '$lib/theme/default-light.json';
+import warmDark from '$lib/theme/warm-dark.json';
+import warmLight from '$lib/theme/warm-light.json';
+
+const builtInThemes = [
+  ['default-dark', defaultDark],
+  ['default-light', defaultLight],
+  ['warm-dark', warmDark],
+  ['warm-light', warmLight],
+] as const;
+```
+
+- [ ] **Step 7: Add a migration test**
+
+Append to `web/src/lib/stores/themeStore.test.ts` (before the final closing):
+
+```typescript
+describe('classic-* → warm-* id migration (holomush-9ektq D9)', () => {
+  it('maps a saved classic-dark pref to warm-dark', async () => {
+    localStorage.setItem('holomush-theme-prefs', JSON.stringify({ themeId: 'classic-dark', terminalBlackBackground: false }));
+    vi.resetModules();
+    const mod = await import('./themeStore');
+    let id = '';
+    mod.themePreferences.subscribe((p) => { id = p.themeId; })();
+    expect(id).toBe('warm-dark');
+  });
+});
+```
+
+- [ ] **Step 8: Run the migration test**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "migration"`
+Expected: PASS (the new describe block). Other suites in the file may still fail on missing tokens until Tasks 4-6 — that's expected.
+
+- [ ] **Step 9: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "feat(web): relocate classic→warm themes + id migration (holomush-9ektq)"`
+
+---
+
+### Task 3: Add the WCAG contrast + brand-guard test harness (INV-1, INV-2, INV-3, INV-6)
+
+**Files:**
+- Modify: `web/src/lib/stores/themeStore.test.ts` (append new describe blocks + helpers)
+
+- [ ] **Step 1: Add the luminance + contrast helpers** (append near the `rgb()` helper, after line 53)
+
+```typescript
+function relLuminance(hex: string): number {
+  const { r, g, b } = rgb(hex);
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const a = relLuminance(fg);
+  const b = relLuminance(bg);
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Chrome text tokens that render type and must clear AA against a background.
+const CHROME_TEXT_TOKENS = [
+  'foreground', 'status.text', 'muted.foreground', 'scrollback.replayed',
+  'card.foreground', 'popover.foreground', 'secondary.foreground',
+] as const;
+
+// All 11 message tokens render against the theme background.
+const MESSAGE_TOKENS = [
+  'say.speaker', 'say.speech', 'pose.actor', 'pose.action', 'system',
+  'arrive', 'leave', 'command.output', 'command.error', 'ooc', 'pemit',
+] as const;
+
+const AA = 4.5;
+```
+
+- [ ] **Step 2: Add the contrast test (INV-2, INV-3)**
+
+```typescript
+describe('WCAG AA contrast (holomush-6siys, holomush-9ektq INV-2/INV-3)', () => {
+  for (const [id, theme] of builtInThemes) {
+    const c = theme.colors as Record<string, string>;
+    for (const tok of CHROME_TEXT_TOKENS) {
+      it(`${id}: chrome ${tok} ≥ ${AA}:1 on background`, () => {
+        expect(contrastRatio(c[tok], c.background)).toBeGreaterThanOrEqual(AA);
+      });
+    }
+    for (const tok of MESSAGE_TOKENS) {
+      it(`${id}: message ${tok} ≥ ${AA}:1 on background`, () => {
+        expect(contrastRatio(c[tok], c.background)).toBeGreaterThanOrEqual(AA);
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 3: Add the brand/amber guard (INV-1) and token-completeness (INV-6)**
+
+```typescript
+describe('brand alignment (holomush-9ektq INV-1)', () => {
+  const brandDefaults = [['default-dark', defaultDark], ['default-light', defaultLight]] as const;
+  for (const [id, theme] of brandDefaults) {
+    const c = theme.colors as Record<string, string>;
+    for (const tok of ['primary', 'accent', 'ring', 'scrollback.indicator'] as const) {
+      it(`${id}: ${tok} is cyan-dominant (blue ≥ red), never amber`, () => {
+        const { r, b } = rgb(c[tok]);
+        expect(b, `${tok}=${c[tok]} must be cyan-family`).toBeGreaterThanOrEqual(r);
+      });
+    }
+    it(`${id}: amber appears only on cursor`, () => {
+      // amber = red-dominant warm hue; the cursor is allowed to be amber, nothing else.
+      const amberish = (hex: string) => { const { r, g, b } = rgb(hex); return r > b && g > b && r > 150; };
+      for (const [k, v] of Object.entries(c)) {
+        if (k === 'cursor' || k === 'radius') continue;
+        expect(amberish(v), `${k}=${v} must not be amber`).toBe(false);
+      }
+    });
+  }
+});
+
+describe('new tokens exposed as --color-* (holomush-9ektq INV-6)', () => {
+  for (const [id, theme] of builtInThemes) {
+    const css = themeToCssVars(theme.colors as ThemeColors);
+    for (const cssKey of ['--color-cursor', '--color-scrollback-replayed', '--color-foreground', '--color-input']) {
+      it(`${id}: themeToCssVars emits ${cssKey}`, () => {
+        expect(css).toContain(`${cssKey}: `);
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 4: Run the new suites to verify they FAIL on current themes**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "contrast"`
+Expected: FAIL — `default-dark`/`default-light` still hold brown values (e.g. `status.text` brown fails AA on the not-yet-rebranded background), and `default-dark.json` doesn't yet have the brand cyan accents. This is the TDD red state; Tasks 4-6 turn it green.
+
+- [ ] **Step 5: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "test(web): WCAG AA contrast + brand-guard harness for themes (holomush-9ektq)"`
+
+---
+
+### Task 4: Rewrite `default-dark.json` to the brand palette
+
+**Files:**
+- Modify: `web/src/lib/theme/default-dark.json` (full rewrite)
+
+- [ ] **Step 1: Replace the entire file**
+
+```json
+{
+  "name": "default-dark",
+  "colors": {
+    "say.speaker": "#43ebff",
+    "say.speech": "#f2f5f8",
+    "pose.actor": "#69ddb9",
+    "pose.action": "#99a7b4",
+    "system": "#7acaeb",
+    "arrive": "#758a96",
+    "leave": "#758a96",
+    "command.output": "#dbe3e9",
+    "command.error": "#fc7f7f",
+    "ooc": "#98b0f6",
+    "pemit": "#65ddd3",
+    "background": "#0b0c0e",
+    "foreground": "#e8edf2",
+    "input": "#1d2a33",
+    "surface": "#101418",
+    "border": "#1d2a33",
+    "cursor": "#ffb300",
+    "input.prompt": "#3dd6f7",
+    "input.text": "#e8edf2",
+    "input.background": "#07080a",
+    "status.text": "#9aa7b2",
+    "status.background": "#101418",
+    "status.online": "#7fd98f",
+    "status.offline": "#fc7f7f",
+    "sidebar.background": "#101418",
+    "scrollback.indicator": "#3dd6f7",
+    "scrollback.replayed": "#8b98a4",
+    "primary": "#3dd6f7",
+    "primary.foreground": "#04222e",
+    "secondary": "#18202a",
+    "secondary.foreground": "#e8edf2",
+    "muted": "#1a2128",
+    "muted.foreground": "#9aa7b2",
+    "accent": "#3dd6f7",
+    "accent.foreground": "#04222e",
+    "destructive": "#fc7f7f",
+    "destructive.foreground": "#04222e",
+    "card": "#101418",
+    "card.foreground": "#e8edf2",
+    "popover": "#101418",
+    "popover.foreground": "#e8edf2",
+    "ring": "#3dd6f7",
+    "radius": "0.5rem"
+  }
+}
+```
+
+- [ ] **Step 2: Run the default-dark contrast + brand suites**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "default-dark"`
+Expected: PASS for all `default-dark:` contrast, brand-alignment, amber-only-cursor, and token-exposure cases.
+
+- [ ] **Step 3: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "feat(web): rebrand default-dark to holographic cyan/ink (holomush-9ektq, holomush-6siys)"`
+
+---
+
+### Task 5: Rewrite `default-light.json` to the brand palette
+
+**Files:**
+- Modify: `web/src/lib/theme/default-light.json` (full rewrite)
+
+- [ ] **Step 1: Replace the entire file**
+
+```json
+{
+  "name": "default-light",
+  "colors": {
+    "say.speaker": "#0277bd",
+    "say.speech": "#1a2026",
+    "pose.actor": "#1b7a5e",
+    "pose.action": "#5a6b76",
+    "system": "#1565c0",
+    "arrive": "#62717c",
+    "leave": "#62717c",
+    "command.output": "#1a2026",
+    "command.error": "#c62828",
+    "ooc": "#5e35b1",
+    "pemit": "#00796b",
+    "background": "#f6f8fa",
+    "foreground": "#1a2026",
+    "input": "#d3dde4",
+    "surface": "#eef2f5",
+    "border": "#d3dde4",
+    "cursor": "#e09000",
+    "input.prompt": "#1565c0",
+    "input.text": "#1a2026",
+    "input.background": "#ffffff",
+    "status.text": "#5a6b76",
+    "status.background": "#eef2f5",
+    "status.online": "#2e7d32",
+    "status.offline": "#c62828",
+    "sidebar.background": "#eef2f5",
+    "scrollback.indicator": "#1565c0",
+    "scrollback.replayed": "#62717c",
+    "primary": "#1565c0",
+    "primary.foreground": "#ffffff",
+    "secondary": "#d3dde4",
+    "secondary.foreground": "#1a2026",
+    "muted": "#d3dde4",
+    "muted.foreground": "#5a6b76",
+    "accent": "#1565c0",
+    "accent.foreground": "#ffffff",
+    "destructive": "#c62828",
+    "destructive.foreground": "#ffffff",
+    "card": "#eef2f5",
+    "card.foreground": "#1a2026",
+    "popover": "#eef2f5",
+    "popover.foreground": "#1a2026",
+    "ring": "#1565c0",
+    "radius": "0.5rem"
+  }
+}
+```
+
+- [ ] **Step 2: Run the default-light suites**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "default-light"`
+Expected: PASS. If any `scrollback.replayed`/`muted.foreground` case fails (light-mode dim text reduces contrast), darken the offending token one step (e.g. `#62717c`→`#5a6770`) and re-run until ≥4.5:1.
+
+- [ ] **Step 3: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "feat(web): rebrand default-light to cyan-on-light (holomush-9ektq)"`
+
+---
+
+### Task 6: Run the full theme test suite (all four green — INV-7)
+
+**Files:** none (verification task; warm themes were authored AA-compliant in Task 2)
+
+- [ ] **Step 1: Run the entire theme test file**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts`
+Expected: PASS — all four themes clear contrast (INV-2/3/7), brand guards hold (INV-1), tokens exposed (INV-6), migration works (D9). If a `warm-dark`/`warm-light` contrast case fails, raise that theme's `status.text`/`muted.foreground`/`scrollback.replayed` until ≥4.5:1 (warm-dark muted is `#9a8f7e`; bump toward `#a89c8a` if needed).
+
+- [ ] **Step 2: Commit (only if a warm token was adjusted; otherwise skip)**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "fix(web): tune warm-theme muted tokens to AA (holomush-9ektq INV-7)"`
+
+---
+
+### Task 7: Update `app.css` `@theme` statics + wire the amber caret (D7, D8, INV-1)
+
+**Files:**
+- Modify: `web/src/app.css:9-48`
+- Modify: `web/src/lib/components/terminal/CommandInput.svelte:214-222`
+
+- [ ] **Step 1: Replace the `@theme` block** in `web/src/app.css` (lines 9-48) with brand-dark statics + the new tokens:
+
+```css
+@theme {
+  --color-primary: #3dd6f7;
+  --color-primary-foreground: #04222e;
+  --color-secondary: #18202a;
+  --color-secondary-foreground: #e8edf2;
+  --color-muted: #1a2128;
+  --color-muted-foreground: #9aa7b2;
+  --color-accent: #3dd6f7;
+  --color-accent-foreground: #04222e;
+  --color-destructive: #fc7f7f;
+  --color-destructive-foreground: #04222e;
+  --color-card: #101418;
+  --color-card-foreground: #e8edf2;
+  --color-popover: #101418;
+  --color-popover-foreground: #e8edf2;
+  --color-border: #1d2a33;
+  --color-input: #1d2a33;
+  --color-ring: #3dd6f7;
+  --color-background: #0b0c0e;
+  --color-foreground: #e8edf2;
+  --color-sidebar: #101418;
+  --color-sidebar-foreground: #e8edf2;
+  --color-sidebar-primary: #3dd6f7;
+  --color-sidebar-primary-foreground: #04222e;
+  --color-sidebar-accent: #18202a;
+  --color-sidebar-accent-foreground: #e8edf2;
+  --color-sidebar-border: #1d2a33;
+  --color-sidebar-ring: #3dd6f7;
+  --color-input-text: #e8edf2;
+  --color-input-background: #07080a;
+  --color-input-prompt: #3dd6f7;
+  --color-cursor: #ffb300;
+  --color-surface: #101418;
+  --color-status-text: #9aa7b2;
+  --color-status-background: #101418;
+  --color-status-online: #7fd98f;
+  --color-status-offline: #fc7f7f;
+  --color-sidebar-background: #101418;
+  --color-scrollback-indicator: #3dd6f7;
+  --color-scrollback-replayed: #8b98a4;
+  --radius: 0.5rem;
+}
+```
+
+- [ ] **Step 2: Wire the caret to amber** — in `web/src/lib/components/terminal/CommandInput.svelte`, add `caret-color` to the `textarea` rule (lines 214-222):
+
+```css
+  textarea {
+    flex: 1;
+    background: transparent;
+    border: none; outline: none;
+    color: var(--color-input-text);
+    caret-color: var(--color-cursor);
+    font-family: inherit; font-size: inherit;
+    resize: none; line-height: 20px;
+    overflow-y: auto;
+  }
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd web && pnpm check`
+Expected: PASS (no type errors; all theme JSONs now carry the four new keys).
+
+- [ ] **Step 4: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "feat(web): brand @theme statics + amber caret-color (holomush-9ektq)"`
+
+---
+
+### Task 8: holomush-1hgk — replace scrollback compounding opacity with a colour token (INV-4)
+
+**Files:**
+- Modify: `web/src/lib/components/terminal/EventRenderer.svelte:27,44`
+- Modify: `web/src/lib/components/terminal/TerminalView.svelte:53-55,74,109`
+- Modify: `web/src/lib/stores/themeStore.test.ts` (consuming-site guard)
+
+- [ ] **Step 1: Write the consuming-site guard test first**
+
+Append to `web/src/lib/stores/themeStore.test.ts` inside a new describe:
+
+```typescript
+describe('scrollback de-emphasis uses colour, not opacity (holomush-1hgk INV-4)', () => {
+  const src = (rel: string) => readFileSync(`${process.cwd()}/src/lib/components/terminal/${rel}`, 'utf8');
+  it('TerminalView replay lines use --color-scrollback-replayed', () => {
+    expect(src('TerminalView.svelte')).toContain('var(--color-scrollback-replayed)');
+  });
+  it('TerminalView no longer dims replay lines with opacity', () => {
+    expect(src('TerminalView.svelte')).not.toMatch(/\.line\.replay\s*\{[^}]*opacity/);
+  });
+  it('EventRenderer no longer has a .dimmed opacity rule', () => {
+    expect(src('EventRenderer.svelte')).not.toMatch(/\.dimmed\s*\{[^}]*opacity/);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "scrollback de-emphasis"`
+Expected: FAIL (current `.line.replay { opacity: 0.45 }` and `.dimmed { opacity: 0.5 }` still present).
+
+- [ ] **Step 3: Remove the inner dim in `EventRenderer.svelte`** — delete the `dimmed` prop usage and the opacity rule. Replace line 27 (`<div class:dimmed>`) with:
+
+```svelte
+<div>
+```
+
+Delete line 44 entirely:
+
+```css
+  .dimmed { opacity: 0.5; }
+```
+
+Remove the now-unused `dimmed` prop from the `Props` type (line 21) and the `let { ... dimmed = false }` destructure (line 24) — change line 24 to:
+
+```typescript
+  let { event }: Props = $props();
+```
+
+and delete the `dimmed?: boolean;` line from `Props`.
+
+- [ ] **Step 4: Update `TerminalView.svelte`** — stop passing the removed `dimmed` prop at BOTH call sites and switch the replay line to a colour. Replace line 55 (`<EventRenderer event={line.event} dimmed={true} />`) with:
+
+```svelte
+            <EventRenderer event={line.event} />
+```
+
+And replace line 74 (`<EventRenderer event={line.event} dimmed={false} />`, the live-line call) with:
+
+```svelte
+            <EventRenderer event={line.event} />
+```
+
+(Both are required — `dimmed` no longer exists on `EventRenderer` after Step 3, so a stale `dimmed={false}` would be an unknown-prop error under `pnpm check`.)
+
+Replace line 109 (`.line.replay { opacity: 0.45; }`) with:
+
+```css
+  .line.replay { color: var(--color-scrollback-replayed); }
+  .line.replay :global(*) { color: var(--color-scrollback-replayed); }
+```
+
+(The `:global(*)` override ensures replayed message text takes the dim colour instead of its per-message `--mush-*` hue — the intended monochrome-dim scrollback treatment per spec D6.)
+
+- [ ] **Step 5: Run the guard test + visual smoke**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "scrollback de-emphasis"`
+Expected: PASS.
+
+Then manual: `cd web && pnpm dev`, connect as guest, scroll back — replayed lines render in the dim slate colour, comfortably readable on both default themes (no near-invisible text).
+
+- [ ] **Step 6: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "fix(web): scrollback de-emphasis via colour token, drop compounding opacity (holomush-1hgk)"`
+
+---
+
+### Task 9: holomush-vhsz — enlarge the shortcut hint bar (INV-5)
+
+**Files:**
+- Modify: `web/src/lib/components/terminal/CommandInput.svelte:233-247`
+- Modify: `web/src/lib/stores/themeStore.test.ts` (consuming-site guard)
+
+- [ ] **Step 1: Write the guard test first**
+
+Append a describe to `web/src/lib/stores/themeStore.test.ts`:
+
+```typescript
+describe('shortcut hint bar legibility (holomush-vhsz INV-5)', () => {
+  const src = readFileSync(`${process.cwd()}/src/lib/components/terminal/CommandInput.svelte`, 'utf8');
+  it('.cmd-hints font-size ≥ 14px', () => {
+    const m = /\.cmd-hints\s*\{[^}]*font-size:\s*(\d+)px/.exec(src);
+    expect(m && Number(m[1])).toBeGreaterThanOrEqual(14);
+  });
+  it('.cmd-hints kbd font-size ≥ 13px', () => {
+    const m = /\.cmd-hints kbd\s*\{[^}]*font-size:\s*(\d+)px/.exec(src);
+    expect(m && Number(m[1])).toBeGreaterThanOrEqual(13);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "hint bar legibility"`
+Expected: FAIL (current 10px / 9px).
+
+- [ ] **Step 3: Bump the sizes** — replace `.cmd-hints` and `.cmd-hints kbd` (lines 233-247) of `CommandInput.svelte`:
+
+```css
+  .cmd-hints {
+    padding: 3px 12px;
+    font-size: 14px;
+    color: var(--color-status-text);
+    background: var(--color-background);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+  }
+  .cmd-hints kbd {
+    font-family: inherit; padding: 1px 5px;
+    border: 1px solid var(--color-border); border-radius: 3px;
+    font-size: 13px;
+  }
+```
+
+- [ ] **Step 4: Run the guard test**
+
+Run: `cd web && pnpm vitest run src/lib/stores/themeStore.test.ts -t "hint bar legibility"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "fix(web): enlarge shortcut hint bar to 14/13px (holomush-vhsz)"`
+
+---
+
+### Task 10: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Type check**
+
+Run: `cd web && pnpm check`
+Expected: PASS, zero errors.
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `cd web && pnpm vitest run`
+Expected: PASS — all theme contrast/brand/migration/consuming-site tests green.
+
+- [ ] **Step 3: Visual smoke across all four themes**
+
+Run: `cd web && pnpm dev`. In the browser: open the command palette (`⌘K`), switch through Default Dark / Default Light / Warm Dark / Warm Light. Confirm per theme: footer hint row legible; amber caret in the input; cyan accents (default themes) / amber accents (warm themes); scrollback lines readable. Confirm a saved `classic-dark` pref (set `localStorage['holomush-theme-prefs'] = '{"themeId":"classic-dark"}'` then reload) lands on Warm Dark.
+
+- [ ] **Step 4: Lint/format** (per repo task runner)
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && task fmt && task lint`
+Expected: PASS (or fix surfaced issues).
+
+- [ ] **Step 5: Final commit (if fmt/lint changed anything)**
+
+Run: `cd /Volumes/Code/github.com/holomush/.worktrees/web-brand-rebrand && jj commit -m "chore(web): fmt/lint after theme rebrand (holomush-9ektq)"`
+
+---
+
+## Coverage check (plan ↔ spec)
+
+| Spec item | Task |
+|-----------|------|
+| D1 default-dark in-place brand | Task 4 |
+| D2 default-light brand | Task 5 |
+| D3 classic→warm relocation/rename | Task 2 |
+| D4 +10% cyan message palette | Tasks 4, 5 (values) |
+| D5 AA 4.5:1 target | Task 3 (test) |
+| D6 scrollback colour token (option C) | Task 8 |
+| D7 dark/light cursor amber | Tasks 4, 5, 7 |
+| D8 prompt cyan vs amber caret | Task 7 |
+| D9 localStorage migration | Task 2 |
+| INV-1 brand/amber guard | Task 3 |
+| INV-2/3 AA contrast | Task 3 |
+| INV-4 no-opacity scrollback | Task 8 |
+| INV-5 hint legibility | Task 9 |
+| INV-6 token completeness | Tasks 1, 3 |
+| INV-7 warm aesthetic preserved | Tasks 2, 6 |
+
+## Out of scope (per spec)
+
+Game/sandbox warm-theme adoption; operator custom themes (holomush-nmr8); `terminalBlackBackground` semantics; non-theme component restructuring.

--- a/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
+++ b/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
 # Web Client Brand Rebrand + AA Contrast — Design
 
 **Status:** Draft (brainstorming output, pending design-reviewer)
@@ -65,7 +70,7 @@ New `--color-*` tokens introduced (per `web/CLAUDE.md` "Adding a New Theme Token
 
 Chrome (`--color-*`):
 
-```
+```text
 background          #0b0c0e   foreground          #e8edf2
 surface             #101418   border / input      #1d2a33
 card                #101418   card.foreground     #e8edf2
@@ -86,7 +91,7 @@ radius              0.5rem
 
 Message colours (`--mush-*`, D4 +10%):
 
-```
+```text
 say.speaker #43ebff   say.speech #f2f5f8   pose.actor #69ddb9
 pose.action #99a7b4   system #7acaeb       arrive #758a96   leave #758a96
 command.output #dbe3e9  command.error #fc7f7f  ooc #98b0f6  pemit #65ddd3
@@ -94,7 +99,7 @@ command.output #dbe3e9  command.error #fc7f7f  ooc #98b0f6  pemit #65ddd3
 
 ### `default-light` (brand) — target values
 
-```
+```text
 background          #f6f8fa   foreground          #1a2026
 surface             #eef2f5   border / input      #d3dde4
 primary / accent / ring  #1565c0     primary.foreground  #ffffff
@@ -107,7 +112,7 @@ scrollback.indicator #1565c0  scrollback.replayed #62717c   (NEW; ≥AA, dim —
 
 Message colours (dark-on-light, AA on `#f6f8fa`):
 
-```
+```text
 say.speaker #0277bd   say.speech #1a2026   pose.actor #1b7a5e
 pose.action #5a6b76   system #1565c0       arrive #62717c   leave #62717c
 command.output #1a2026  command.error #c62828  ooc #5e35b1  pemit #00796b

--- a/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
+++ b/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
@@ -180,3 +180,5 @@ Mirrors `themeStore.test.ts` (pure vitest, no browser):
 ## Out of scope
 
 Game/sandbox warm-theme adoption; operator custom themes (holomush-nmr8); `terminalBlackBackground` semantics; any non-theme component restructuring.
+
+<!-- adr-capture: sha256=6970e6f9145cd747; session=brainstorm-9ektq; ts=2026-05-29T00:00:00Z; adrs=holomush-lcr84,holomush-poxub -->

--- a/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
+++ b/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
@@ -1,0 +1,182 @@
+# Web Client Brand Rebrand + AA Contrast — Design
+
+**Status:** Draft (brainstorming output, pending design-reviewer)
+**Design bead:** holomush-9ektq
+**Coordinated bugs:** holomush-6siys (subsumed), holomush-1hgk (P1, mechanism fix), holomush-vhsz (folded)
+**Date:** 2026-05-29
+**Author:** Sean Brandt (with Claude)
+
+## Context
+
+The HoloMUSH web client (`web/`) ships four themes via `web/src/lib/stores/themeStore.ts`. The dark default — `default-dark.json` — is an off-brand brown/amber palette (`background #1a1210`, `primary/ring/prompt #ff7043` orange, `accent/system/scrollback-indicator #ffb74d` amber). Meanwhile the *software* brand (`.claude/rules/branding.md`, `site/src/styles/custom.css`) is the **holographic terminal**: cyan accents (`--brand-cyan-bright #3dd6f7`, `--brand-cyan-deep #1565c0`) on ink (`--brand-ink #0b0c0e`), with amber (`#ffb300`) reserved as the **cursor only** (INV-1). The web client references **zero** `--brand-*` tokens — it predates the 2026-05-28 brand refresh and uses amber exactly where the brand forbids it as a UI accent.
+
+Three grounded contrast/legibility defects exist on this surface:
+
+- **holomush-6siys** — muted-chrome text token `status.text`/`muted.foreground` = `#666055` on `#1a1210` measures **2.96:1** (classic-dark `#555555` on `#0d0d1a` = 2.46:1), below WCAG AA (4.5:1) and even the 3:1 floor. Consumed by 10 components (footer hint bar `↑↓ history`, line-count, breadcrumbs, sidebar counts, room desc, presence, and the scrollback timestamp via `--mush-timestamp` fallback at `TerminalView.svelte:113`).
+- **holomush-1hgk** (P1) — replayed scrollback lines render at compounding opacity `0.45 × 0.5 = 0.225` (`TerminalView.svelte:55,109` + `EventRenderer.svelte:44`), crushing otherwise-bright `--mush-*` tokens (e.g. `system #ffb74d`) to near-invisible on both dark themes.
+- **holomush-vhsz** — footer shortcut hint bar font-size is 10px (hints) / 9px (`kbd`), far below the 15px terminal body (`CommandInput.svelte:233-247`).
+
+> Note: a prior triage claim that a non-themed hardcoded `--n` token existed was a `rg -r` (`--replace`) artifact and is false; the real token is `--color-status-text`, fully themed (corrected on holomush-6siys 2026-05-29).
+
+### Grounding traces
+
+- **probe/test precedent:** `web/src/lib/stores/themeStore.test.ts` (beads holomush-wnilg, holomush-qs31c) iterates all four themes, parses hex per-channel, asserts `themeToCssVars()` exposes each `--color-*`, and guards the consuming `.svelte` sites. This design's tests mirror that shape.
+- **Tailwind v4 theming:** `web/CLAUDE.md` "Theme System" documents that `@theme` compiles `var()` at **build time**; runtime theming overrides `--color-*` via inline style on `.app-root`. `web/src/app.css` confirms the `@theme` static-default block. (context7 was unavailable — monthly quota — so this claim rests on in-repo documentation, flagged for review.)
+- **Brand source:** `.claude/rules/branding.md` INV-1 (amber = cursor only), INV-6 (brand is software/platform, never the game world).
+
+## Goals
+
+1. Re-skin the two **default** web themes to the holographic-terminal brand palette (cyan/ink dark; cyan-deep-on-light light).
+2. Meet **WCAG AA 4.5:1** for every chrome text token and message token against its theme background, on all four themes — closing holomush-6siys by construction.
+3. Coordinate the two palette-agnostic fixes (holomush-1hgk scrollback opacity; holomush-vhsz hint font-size) in the same change.
+4. Preserve the brown/amber aesthetic as a decoupled, selectable "warm" alternate (the user values it; INV-6 reframe permits copying it, with no software↔game parity obligation).
+
+## Non-goals
+
+- Game/sandbox-side adoption of the warm palette (copied separately; no parity).
+- Operator-defined custom themes (holomush-nmr8).
+- Changing `terminalBlackBackground` behavior (it already overrides bg to pure black; unaffected).
+- Re-architecting the theme store, `themeToCssVars`, or the `--color-*`/`--mush-*` split.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Re-skin `default-dark` **in place** to brand cyan/ink | Makes the *default* on-brand; no new id; `default-*` localStorage prefs keep working (renamed `classic-*` ids handled by D9). |
+| D2 | Re-skin `default-light` to brand cyan-deep-on-light | Brand coverage on both modes. |
+| D3 | Rename `classic-*` → `warm-*`; populate with the relocated brown (`warm-dark`) and warm-cream (`warm-light`) palettes | The old "classic" was the cyan one — confusing once cyan is the brand. The current cyan `classic-dark` is redundant with the new brand `default-dark` and is retired; current `classic-light` is replaced by the relocated warm-cream palette. |
+| D9 | Add a `classic-dark`→`warm-dark` / `classic-light`→`warm-light` localStorage migration in `loadPreferences()` | The id rename (D3) would otherwise silently drop saved prefs for `classic-*` users to `default-dark` via the `themes[parsed.themeId]` guard. The existing `holomush-theme`→`holomush-theme-prefs` legacy path is the precedent. (Low stakes — undeployed — but D1's "prefs keep working" must hold for all ids, not just `default-*`.) |
+| D4 | `--mush-*` message colours = cyan-harmonized, **+10% brightness** | Messages are game-world content (INV-6), not brand-locked; the cyan family unifies the look while errors stay red. +10% chosen over baseline/+15% for legibility without neon. |
+| D5 | Contrast target = **WCAG AA 4.5:1** | Matches the cited beads; AAA would flatten the holographic look. |
+| D6 | holomush-1hgk fix = dedicated per-theme `scrollback.replayed` colour token (option C), applied as `color`; **remove** both compounding opacity layers | Opacity is the wrong tool ("older text"); a colour token gives a tunable, AA-guaranteed knob and composes with the contrast test. |
+| D7 | Dark cursor = brand amber `#ffb300`; **light** cursor = darkened amber `#e09000` | Brand amber fails contrast on light (~1.9:1); the darkened variant keeps the amber identity while staying visible. |
+| D8 | Prompt glyph (`>`) is cyan; the **caret** is amber (via `caret-color` / dedicated cursor token) | Keeps amber strictly the cursor per INV-1; the prompt is chrome. |
+
+## Token specification
+
+> **Token-vs-type reconciliation (plan-phase):** the value blocks below name some tokens loosely (`foreground`, `input`). `ThemeColors` (`types.ts`) has **no** bare `foreground` or `input` key — it carries `*.foreground` variants (`card.foreground`, …) and `input.text`/`input.background`/`input.prompt`. The `@theme` block in `app.css` additionally defines `--color-foreground` and `--color-input` as build-time statics with **no** `ThemeColors` counterpart, so they are NOT runtime-themed today. Since light and dark need different body foregrounds, the plan MUST either (a) promote `foreground` (and `input`) to themed `ThemeColors` keys, or (b) confirm no themed surface consumes `var(--color-foreground)`/`var(--color-input)` and update only the `@theme` statics. Resolve this mapping in the plan; the values below are the intended *visual* targets regardless of which token carries them.
+
+New `--color-*` tokens introduced (per `web/CLAUDE.md` "Adding a New Theme Token": add to `ThemeColors` in `types.ts`, all theme JSONs, and the `@theme` default in `app.css`):
+
+- `cursor` → `--color-cursor` (the caret colour; amber per D7).
+- `scrollback.replayed` → `--color-scrollback-replayed` (replayed-line foreground per D6).
+
+### `default-dark` (brand) — target values
+
+Chrome (`--color-*`):
+
+```
+background          #0b0c0e   foreground          #e8edf2
+surface             #101418   border / input      #1d2a33
+card                #101418   card.foreground     #e8edf2
+popover             #101418   popover.foreground  #e8edf2
+sidebar.background  #101418   secondary           #18202a
+primary             #3dd6f7   primary.foreground  #04222e
+accent              #3dd6f7   accent.foreground   #04222e
+ring                #3dd6f7   secondary.foreground #e8edf2
+muted               #1a2128   muted.foreground    #9aa7b2   (≥AA; closes 6siys)
+status.text         #9aa7b2   status.background   #101418
+status.online       #7fd98f   status.offline      #fc7f7f
+input.text          #e8edf2   input.background    #07080a
+input.prompt        #3dd6f7   cursor              #ffb300   (NEW; caret only)
+scrollback.indicator #3dd6f7  scrollback.replayed #8b98a4   (NEW; ≥AA, dim)
+destructive         #fc7f7f   destructive.foreground #04222e
+radius              0.5rem
+```
+
+Message colours (`--mush-*`, D4 +10%):
+
+```
+say.speaker #43ebff   say.speech #f2f5f8   pose.actor #69ddb9
+pose.action #99a7b4   system #7acaeb       arrive #758a96   leave #758a96
+command.output #dbe3e9  command.error #fc7f7f  ooc #98b0f6  pemit #65ddd3
+```
+
+### `default-light` (brand) — target values
+
+```
+background          #f6f8fa   foreground          #1a2026
+surface             #eef2f5   border / input      #d3dde4
+primary / accent / ring  #1565c0     primary.foreground  #ffffff
+muted               #d3dde4   muted.foreground    #5a6b76   (≥AA)
+status.text         #5a6b76   status.online       #2e7d32   status.offline #c62828
+input.text          #1a2026   input.background    #ffffff
+input.prompt        #1565c0   cursor              #e09000   (NEW; darkened amber)
+scrollback.indicator #1565c0  scrollback.replayed #6b7a85   (NEW; ≥AA, dim)
+```
+
+Message colours (dark-on-light, AA on `#f6f8fa`):
+
+```
+say.speaker #0277bd   say.speech #1a2026   pose.actor #1b7a5e
+pose.action #5a6b76   system #1565c0       arrive #62717c   leave #62717c
+command.output #1a2026  command.error #c62828  ooc #5e35b1  pemit #00796b
+```
+
+### `warm-dark` / `warm-light`
+
+`warm-dark.json` = the **current** `default-dark.json` palette verbatim (brown/amber). `warm-light.json` = the **current** `default-light.json` palette verbatim (warm cream). Both gain the two new tokens (`cursor`, `scrollback.replayed`) tuned to their grounds. These are the decoupled "warm" keepers (D3); the current cyan `classic-dark.json` / `classic-light.json` contents are retired.
+
+> The warm themes MUST also satisfy the AA contrast test (INV-3). The relocated brown palette's `status.text #666055` (the original 6siys value) MUST be raised to an AA-compliant warm muted (e.g. `#9a8f7e`) — the warm theme is not exempt from contrast.
+
+### app.css `@theme`
+
+The `@theme` block in `web/src/app.css` registers the build-time statics and MUST be updated to the new `default-dark` brand values, plus the two new tokens (`--color-cursor`, `--color-scrollback-replayed`).
+
+## The three coordinated fixes
+
+```mermaid
+flowchart TD
+    R[Brand rebrand: token values] -->|chosen ≥AA by construction| S6[6siys: muted chrome contrast — SUBSUMED]
+    M[1hgk: scrollback] -->|D6: replace 0.45×0.5 opacity with --color-scrollback-replayed color| F1[Controlled AA-compliant replayed lines]
+    V[vhsz: hint size] -->|.cmd-hints 10→14px, kbd 9→13px| F2[Legible footer]
+    R --> AA[Per-theme AA contrast vitest]
+    M --> AA
+    V --> VIS[Visual / axe smoke]
+```
+
+- **holomush-6siys** — no separate code beyond the token values; the contrast test (INV-2) is its regression guard.
+- **holomush-1hgk** — `EventRenderer.svelte:44` `.dimmed { opacity: 0.5 }` removed; `TerminalView.svelte:109` `.line.replay { opacity: 0.45 }` replaced with `color: var(--color-scrollback-replayed)`; `TerminalView.svelte:55` stops passing `dimmed={true}` (or `dimmed` becomes a no-op and is removed). Replayed lines render in the single dim colour.
+- **holomush-vhsz** — `CommandInput.svelte:233-247`: `.cmd-hints` font-size 10→14px, `kbd` 9→13px, `kbd` padding `0 3px`→`1px 5px`, gap 10→12px.
+
+## Invariants (RFC2119)
+
+- **INV-1 (brand alignment):** `default-dark` and `default-light` MUST derive every chrome accent from the brand palette (`#3dd6f7`/`#1565c0`/`#0b0c0e`). Amber (`#ffb300` dark / `#e09000` light) MUST appear **only** as `--color-cursor`; it MUST NOT be assigned to `primary`, `accent`, `ring`, `scrollback.indicator`, or any link/button/nav chrome token.
+- **INV-2 (AA contrast — chrome):** For all four themes, every chrome **text** token (`foreground`, `status.text`, `muted.foreground`, `primary.foreground`, `accent.foreground`, `card.foreground`, `popover.foreground`, `secondary.foreground`, `scrollback.replayed`) MUST measure ≥4.5:1 against its applicable background token.
+- **INV-3 (AA contrast — messages):** For all four themes, every `--mush-*` message token MUST measure ≥4.5:1 against the theme `background`.
+- **INV-4 (no opacity dimming of scrollback):** Replayed scrollback lines MUST be de-emphasized via `--color-scrollback-replayed` colour, NOT via compounding `opacity`. The `0.45 × 0.5` layers MUST be removed.
+- **INV-5 (hint legibility):** `.cmd-hints` font-size MUST be ≥14px and `.cmd-hints kbd` ≥13px.
+- **INV-6 (token completeness):** `cursor` and `scrollback.replayed` MUST be present in `ThemeColors`, all four theme JSONs, and the `app.css` `@theme` block; `themeToCssVars()` MUST emit `--color-cursor` and `--color-scrollback-replayed`.
+- **INV-7 (warm aesthetic preserved):** A selectable `warm-dark` theme MUST retain a brown/amber palette (the relocated default-dark), subject to INV-2/INV-3.
+
+## Testing
+
+Mirrors `themeStore.test.ts` (pure vitest, no browser):
+
+1. **Contrast test (INV-2, INV-3):** a relative-luminance helper (`L = 0.2126R + 0.7152G + 0.0722B` on linearized sRGB) and `contrastRatio(fg,bg)`; iterate all four theme JSONs, assert every chrome-text and message token ≥4.5:1 against its background. This is the regression guard for holomush-6siys and the rebrand.
+2. **Brand/amber guard (INV-1):** assert `default-*` `primary`/`accent`/`ring`/`scrollback.indicator` are cyan-dominant (b≥r) and that amber hue appears only in `cursor`.
+3. **Token completeness (INV-6):** assert `themeToCssVars()` output contains `--color-cursor` and `--color-scrollback-replayed` for every theme.
+4. **Consuming-site guards (INV-4, INV-5):** read `TerminalView.svelte` / `EventRenderer.svelte` and assert no `opacity: 0.45`/`0.5` dimming on replay lines and that `.line.replay` uses `var(--color-scrollback-replayed)`; read `CommandInput.svelte` and assert `.cmd-hints` font-size ≥14px.
+5. **Visual/axe smoke (holomush-1hgk):** Playwright + axe-core scan of one replayed + one live line per dark theme, asserting AA.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `web/src/lib/theme/default-dark.json` | rewrite → brand cyan/ink + 2 new tokens |
+| `web/src/lib/theme/default-light.json` | rewrite → brand cyan-on-light + 2 new tokens |
+| `web/src/lib/theme/warm-dark.json` | new (relocated brown) — replaces `classic-dark.json` |
+| `web/src/lib/theme/warm-light.json` | new (relocated warm cream) — replaces `classic-light.json` |
+| `web/src/lib/theme/types.ts` | add `cursor`, `scrollback.replayed` to `ThemeColors` |
+| `web/src/lib/stores/themeStore.ts` | rename theme ids `classic-*`→`warm-*`; imports; **add D9 `classic-*`→`warm-*` migration in `loadPreferences()`**; `MUSH_TOKENS` unchanged |
+| `web/src/lib/components/terminal/CommandPalette.svelte` | theme-switch palette commands hardcode the ids/labels at `:44-47` (`setTheme('classic-dark')` etc.) — update to `warm-*` |
+| `web/src/app.css` | `@theme` → brand default-dark statics + 2 new tokens |
+| `web/src/lib/components/terminal/CommandInput.svelte` | vhsz font-size; cursor/caret colour wiring |
+| `web/src/lib/components/terminal/TerminalView.svelte` | 1hgk: replace opacity with `--color-scrollback-replayed` |
+| `web/src/lib/components/terminal/EventRenderer.svelte` | 1hgk: remove `.dimmed` opacity |
+| `web/src/lib/components/TopBar.svelte` (+ any theme-picker UI) | theme id rename |
+| `web/src/lib/stores/themeStore.test.ts` | extend with contrast + brand-guard tests |
+
+## Out of scope
+
+Game/sandbox warm-theme adoption; operator custom themes (holomush-nmr8); `terminalBlackBackground` semantics; any non-theme component restructuring.

--- a/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
+++ b/docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md
@@ -102,7 +102,7 @@ muted               #d3dde4   muted.foreground    #5a6b76   (≥AA)
 status.text         #5a6b76   status.online       #2e7d32   status.offline #c62828
 input.text          #1a2026   input.background    #ffffff
 input.prompt        #1565c0   cursor              #e09000   (NEW; darkened amber)
-scrollback.indicator #1565c0  scrollback.replayed #6b7a85   (NEW; ≥AA, dim)
+scrollback.indicator #1565c0  scrollback.replayed #62717c   (NEW; ≥AA, dim — #6b7a85 measured 4.15:1, below AA)
 ```
 
 Message colours (dark-on-light, AA on `#f6f8fa`):


### PR DESCRIPTION
Design docs for the web-client holographic-terminal rebrand + WCAG AA contrast work. **Docs only — no code.** Implementation tracked under epic `holomush-9ektq` (`.1`–`.8` + adopted `holomush-1hgk`/`holomush-vhsz`/`holomush-6siys`), to land in a follow-up PR.

## What's here
- **Spec** `docs/superpowers/specs/2026-05-29-web-client-brand-rebrand-contrast-design.md` — 9 decisions, 7 RFC2119 invariants, full token tables (design-reviewer: READY).
- **Plan** `docs/superpowers/plans/2026-05-29-web-client-brand-rebrand-contrast.md` — 10 TDD tasks; contrast test mirrors `themeStore.test.ts` (plan-reviewer: READY, round 2).
- **ADRs** `holomush-lcr84` (software brand governs `--color-*` chrome only; `--mush-*` are decoupled game-world content) and `holomush-poxub` (`foreground`/`input` are themed `ThemeColors` keys).

## Why docs-first
Lands canonical spec/plan/ADRs on `main` so the implementation subagents read them from `main` rather than via inlined prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)