### PR TITLE
fix(web): movement events render actor name once, not twice (holomush-pzen)

### DIFF
--- a/web/src/lib/components/terminal/MovementRenderer.svelte
+++ b/web/src/lib/components/terminal/MovementRenderer.svelte
@@ -20,7 +20,11 @@
 </script>
 
 <div class="event event-{event.type}" data-testid="event">
-  <span class="movement">{#if event.actor}{event.actor}{' '}{/if}{@html linkUrls(event.text)}</span>
+  <!-- Movement `text` is already a full sentence ("<actor> has arrived.")
+       from the server's formatMovementText, so render it verbatim. Prefixing
+       `actor` here (as communication events do, where `text` is a bare body)
+       double-prints the name — holomush-pzen. -->
+  <span class="movement">{@html linkUrls(event.text)}</span>
 </div>
 
 <style>

--- a/web/src/lib/components/terminal/MovementRenderer.svelte.test.ts
+++ b/web/src/lib/components/terminal/MovementRenderer.svelte.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import MovementRenderer from './MovementRenderer.svelte';
+
+// Movement events carry the full sentence in `event.text` (the server's
+// formatMovementText composes "<actor> has arrived."), unlike communication
+// events whose `text` is the bare body. The renderer MUST therefore emit
+// `text` verbatim and MUST NOT prepend `actor` — doing so double-prints the
+// name ("Opal Radon Opal Radon has arrived."). Regression guard for
+// holomush-pzen.
+
+interface MovementEvent {
+  type: string;
+  category: string;
+  format: string;
+  actor: string;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+function render(event: MovementEvent): { text: string; movementSpans: number } {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(MovementRenderer, { target, props: { event } });
+  const text = (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+  const movementSpans = target.querySelectorAll('.movement').length;
+  unmount(component);
+  target.remove();
+  return { text, movementSpans };
+}
+
+// `type` is the bare wire discriminator the server emits ("arrive" / "leave",
+// per internal/web/translate.go), not a namespaced form.
+function movement(type: 'arrive' | 'leave', actor: string, text: string): MovementEvent {
+  return { type, category: 'movement', format: 'notification', actor, text, metadata: {} };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('MovementRenderer', () => {
+  it('renders an arrival with the actor name exactly once', () => {
+    const { text, movementSpans } = render(movement('arrive', 'Opal Radon', 'Opal Radon has arrived.'));
+    expect(text).toBe('Opal Radon has arrived.');
+    expect(text.match(/Opal Radon/g) ?? []).toHaveLength(1);
+    // Exactly one node carries the sentence — no separate actor element that
+    // could reintroduce the name with identical visible text.
+    expect(movementSpans).toBe(1);
+  });
+
+  it('renders a departure with the actor name exactly once', () => {
+    const { text } = render(movement('leave', 'Beryl Cobalt', 'Beryl Cobalt has left.'));
+    expect(text).toBe('Beryl Cobalt has left.');
+    expect(text.match(/Beryl Cobalt/g) ?? []).toHaveLength(1);
+  });
+
+  it('renders a departure-with-reason with the actor name exactly once', () => {
+    const { text } = render(movement('leave', 'Beryl Cobalt', 'Beryl Cobalt has left (disconnected).'));
+    expect(text).toBe('Beryl Cobalt has left (disconnected).');
+    expect(text.match(/Beryl Cobalt/g) ?? []).toHaveLength(1);
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,9 +5,31 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	test: {
-		environment: 'jsdom',
-		include: ['src/**/*.test.ts'],
 		globals: false,
-		setupFiles: ['./src/test-setup.ts']
+		// Shared across both projects (inherited via `extends: true`).
+		environment: 'jsdom',
+		setupFiles: ['./src/test-setup.ts'],
+		// Two projects: server-side logic tests (`*.test.ts`) run as before,
+		// while Svelte component tests (`*.svelte.test.ts`) resolve the
+		// `browser` entry points so `mount` works under jsdom (per the Svelte
+		// testing docs).
+		projects: [
+			{
+				extends: true,
+				test: {
+					name: 'server',
+					include: ['src/**/*.test.ts'],
+					exclude: ['src/**/*.svelte.test.ts']
+				}
+			},
+			{
+				extends: true,
+				resolve: { conditions: ['browser'] },
+				test: {
+					name: 'client',
+					include: ['src/**/*.svelte.test.ts']
+				}
+			}
+		]
 	}
 });


### PR DESCRIPTION
## Summary

Fixes **holomush-pzen** (#2873): web-terminal movement events double-printed the actor name — `Opal Radon Opal Radon has arrived.` instead of `Opal Radon has arrived.` Affected every arrive/leave for every player.

Root cause is a two-layer asymmetry:
- The server's `formatMovementText` (`internal/web/translate.go:157`) already composes the **full sentence** into `event.text` (`"<actor> has arrived."`).
- `MovementRenderer.svelte` *also* prepended `{event.actor}{' '}` — the pattern `CommunicationRenderer` uses correctly, because communication `text` is a **bare body** (`"Hello!"`). For movement, `text` is the whole sentence, so the name printed twice.

`EventRenderer` dispatches `MovementRenderer` only for `category === 'movement'`, so the fix is localized and cannot regress say/pose/ooc.

## Changes

- **`MovementRenderer.svelte`** — render `event.text` verbatim; drop the actor prefix. (Bead option A; rejected option B — stripping actor from the server formatter — because it would diverge the web translate layer from its self-contained-sentence contract for no functional gain. Server/telnet untouched.)
- **`MovementRenderer.svelte.test.ts`** — the repo's first Svelte component test; regression guard for arrive / leave / leave-with-reason, asserting the actor appears exactly once.
- **`vite.config.ts`** — split into `server` + `client` Vitest projects so `*.svelte.test.ts` resolves the `browser` entry points (needed for `mount` under jsdom, per the Svelte testing docs). The pre-existing `*.test.ts` keep their exact prior resolution.

## Test Plan

- [x] New test reproduces the bug (RED: `Beryl Cobalt Beryl Cobalt has left.`) → passes after the fix (GREEN).
- [x] Full web unit suite: 205 pass (202 pre-existing + 3 new), 0 regressions.
- [x] `svelte-check`: 0 errors.
- [x] `task pr-prep` (fast lane): `status=pass`.
- [x] Server `formatMovementText` and telnet gateway untouched → telnet movement output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
