### PR TITLE
docs(eventbus): colon-style subject eradication design + plan + ADRs (holomush-rops)

### DIFF
--- a/docs/adr/holomush-21ahd-dot-form-sole-subject-representation.md
+++ b/docs/adr/holomush-21ahd-dot-form-sole-subject-representation.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Dot-Form as the Sole Pub/Sub Subject Representation; subjectxlate Deleted
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Decision:** holomush-21ahd
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+HoloMUSH carried two representations for every pub/sub stream name: the
+JetStream-native dot form (`events.<gid>.<domain>.<id>`) and a legacy colon form
+(`location:<id>`, `character:<id>`). The `internal/eventbus/subjectxlate/` shim
+translated between them at every publish, every history read, and every client
+delivery. Its own header marked it transitional — to be removed once host/plugin
+code emitted JetStream-native subjects ("F5") — but that removal never shipped
+with the JetStream cutover.
+
+The dual representation was an active source of privacy bugs: a classifier that
+received the form it did not recognize returned "not private," skipped the I-17
+membership gate, and fell through to the ABAC default branch
+(`holomush-pkixe`, `holomush-ofpi`). `holomush-s9nu` migrated the **scene** domain
+atomically to dot form; this decision extends that to the entire stream namespace
+and deletes the shim. It supersedes the `holomush-ec22.3` "subjectxlate endgame"
+decision.
+
+## Decision
+
+Adopt the dot form (`events.<gid>.<domain>.<id>`) as the **single canonical**
+pub/sub subject representation across all producers, classifiers, gRPC wire
+fields, the SvelteKit client, and durable audit. Delete
+`internal/eventbus/subjectxlate/` in the same PR as the producer and classifier
+migrations.
+
+GameID injection moves from `subjectxlate.Legacy` to a single
+`eventbus.Qualify(gid, relativeRef)` helper, called at exactly two boundaries:
+the **emit qualifier** (`internal/plugin/event_emitter.go` and the host core emit
+path) and the **read-entry qualifier** (`QueryStreamHistory` / `Subscribe`,
+before the classifier switch). Producers and the Lua SDK emit **domain-relative
+references** (`location.<id>`, not `events.<gid>.location.<id>`) because they do
+not hold the gameID; the host qualifies at the boundary.
+
+## Rationale
+
+- Any intermediate state between producer migration and classifier migration
+  reproduces the `pkixe`/`ofpi` failure mode — an unrecognized form skips its
+  authorization branch. A single canonical form makes that state unrepresentable.
+- The translation shim was already marked transitional by the project; a single
+  form removes the maintenance surface entirely rather than extending it.
+- A single, named injection point (`eventbus.Qualify`) makes "where gameID enters
+  the subject" explicit and auditable, versus diffuse `subjectxlate` calls.
+- The invariant is enforced mechanically: INV-ROPS-3 (repo-wide CI scan over Go
+  and Lua) forbids any surviving colon stream literal, and INV-ROPS-4
+  (producer↔subscriber round-trip) proves emit-subject equals subscriber-filter.
+
+## Alternatives Considered
+
+1. **Retain subjectxlate; extend it bidirectionally for all domains.** Lets
+   producers migrate independently, but keeps a permanent translation surface and
+   leaves the `pkixe`/`ofpi` half-migrated-classifier failure class open
+   indefinitely (and a latent fail-open if a `stream:*` permit seed is ever
+   added). Rejected.
+2. **Dual-format classifiers during a transition window.** Smaller per-PR blast
+   radius, but multiplies the classifier surface that must be correct and extends
+   the window for the `pkixe` failure class. `holomush-s9nu` showed even a
+   zero-width window (emit dot, gate still colon) silently breaks stream access.
+   Rejected.
+3. **Single-form cutover; delete the shim in the same PR (chosen).** Classifiers
+   see exactly one form; the `pkixe`/`ofpi` root cause is eliminated permanently;
+   INV-ROPS-3 can enforce eradication as a CI gate. Cost: one large coordinated PR
+   across host producers, the Lua SDK and inline Lua, the SvelteKit client,
+   classifiers, ABAC seeds, and the test harness.
+
+## Consequences
+
+**Positive:** classifiers parse one form; the `pkixe`/`ofpi` privacy bug classes
+are eliminated structurally (an unrecognized name is rejected at handler entry per
+INV-ROPS-2); ~300 lines of translation infrastructure removed; a CI gate blocks
+re-introduction.
+
+**Negative:** a large coordinated PR; `abac-reviewer` + `code-reviewer` required
+before push due to classifier and seed changes.
+
+**Neutral:** the colon form survives only as ABAC policy-DSL type-prefixes inside
+`internal/access/` (see [holomush-wia9e](holomush-wia9e-colon-dot-role-split-access-boundary.md));
+`holomush-s9nu` is the direct scene-domain predecessor.

--- a/docs/adr/holomush-wia9e-colon-dot-role-split-access-boundary.md
+++ b/docs/adr/holomush-wia9e-colon-dot-role-split-access-boundary.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Colon/Dot Role Split Enforced as an internal/access Package Boundary
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Decision:** holomush-wia9e
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+After the stream-name migration ([holomush-21ahd](holomush-21ahd-dot-form-sole-subject-representation.md)),
+the string `character:<id>` serves two distinct roles: a pub/sub **stream name**
+(now `character.<id>` dot form) and an ABAC policy-DSL **subject/resource
+identifier** (stays colon). Both were previously constructed as inline
+`"character:" + id` literals scattered across the codebase, making the two roles
+structurally conflatable — and making INV-ROPS-3's eradication scan unable to
+tell a missed stream producer from a legitimate ABAC subject by text alone.
+
+`internal/access/prefix.go` already exports canonical ABAC builders
+(`access.CharacterSubject`, `access.SceneResource`, `access.PluginSubject`, …),
+used across `world/`, `command/`, `grpc/`, and `hostfunc/`. A handful of straggler
+host sites still inlined the literal.
+
+## Decision
+
+Colon-style identifiers are produced **exclusively** by `internal/access`
+builders. No host code outside `internal/access/` may contain an inline
+colon-prefixed entity literal: the `character.<id>` stream form and the
+`character:<id>` ABAC-subject form are built by **different packages**, so the two
+roles are structurally unconflatable. The INV-ROPS-3 CI scan allowlists
+`internal/access/` as the sole sanctioned package; any colon entity-prefix
+literal outside it is an unambiguous stream-producer bug.
+
+Plugin code (`plugins/core-scenes/`) builds ABAC resources but cannot import
+`internal/access` (plugin boundary); its residual colon literals are scan-exempt
+via the `Evaluate(` call-site or a `// ABAC resource ref` marker, and are audited
+as the only sanctioned residual.
+
+## Rationale
+
+- A package boundary makes the role split enforceable **mechanically**
+  (INV-ROPS-3 scan, INV-ROPS-6 unit test) instead of by per-line heuristics.
+- The builders are already the established convention; routing the stragglers
+  through them completes it rather than inventing a new mechanism.
+- It makes a future over-eager sweep that accidentally migrates an ABAC subject
+  to dot form a visible compiler error or scan miss — you cannot conflate the
+  roles if you must use different packages to construct them.
+- The builders panic on empty input, strictly safer than bare concatenation
+  (an empty subject would silently bypass access control).
+
+## Alternatives Considered
+
+1. **Convention only — document the split, rely on review.** No code change
+   beyond the migration, but INV-ROPS-3 then needs per-line heuristics (marker
+   comments, call-site patterns) to classify every colon literal, and any new
+   inline literal is ambiguous at review time. Rejected — the round-3/4 review
+   experience showed this is whack-a-mole.
+2. **Package boundary via the existing `internal/access` builders (chosen).**
+   Any inline colon literal outside `internal/access/` is unambiguously a bug;
+   the role split is enforced at the construction site, never by runtime string
+   sniffing. Cost: a documented plugin escape hatch, and routing seven straggler
+   host sites through the builders in the same PR.
+
+## Consequences
+
+**Positive:** INV-ROPS-3 logic is simple (skip `internal/access/`; any other hit
+is a bug); INV-ROPS-6 guards against an over-eager sweep silently breaking
+character-principal policies; straggler sites gain the builders' empty-input
+safety.
+
+**Negative:** plugin ABAC-resource construction needs a scan escape hatch
+(`Evaluate(` / `// ABAC resource ref`) that must be audited; seven straggler host
+sites are routed through the builders in the migration PR.
+
+**Neutral:** the `stream:` ABAC resource straddles the boundary — the `stream:`
+type-prefix is colon (built in `internal/access`) but the embedded stream name is
+dot, so `StreamProvider.ResolveResource` parses dot-form names even though it
+lives inside `internal/access/`. ABAC seed text embedding a stream name
+(`like "location:*"`) is not exempt — those flip to the `has_location` witness in
+lockstep (INV-ROPS-8).

--- a/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
+++ b/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
@@ -1042,3 +1042,5 @@ Expected: PASS
 - [ ] `holomush-ofpi` verified fixed (Subscribe scope-floor sees qualified subjects); close it.
 - [ ] `holomush-ec22.3` closed as superseded (subjectxlate deleted).
 - [ ] `code-reviewer` + `abac-reviewer` run before push (touches `internal/access/` + I-17 gate).
+
+<!-- adr-capture: sha256=56edd66c42d34847; session=brainstorm-rops; ts=2026-05-29T00:00:00Z; adrs=holomush-21ahd,holomush-wia9e -->

--- a/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
+++ b/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
@@ -156,16 +156,19 @@ Commit using VCS-appropriate commands per `references/vcs-preamble.md`. Message:
 - Modify: `internal/world/events.go:22-40` (builders + delete colon consts)
 - Modify: `internal/core/event.go:14-17` (delete `StreamPrefixCharacter`)
 - Modify: `internal/core/engine.go:73,96` (inline `"location:"` → `"location."`)
+- Modify: `internal/core/engine_end_session.go:62` (inline `"character:"` → `"character."`)
 - Modify: `internal/grpc/focus/subscription_router.go:37,47` (inline `"location:"` → `"location."`)
-- Test: `internal/world/events_test.go`
+- Modify: `internal/grpc/focus/scenepolicy/policy.go:29-30` (`StreamsFor` colon scene filters → dot relative)
+- Test: `internal/world/events_test.go`, `internal/grpc/focus/scenepolicy/policy_test.go`
 
-> **Note:** `auth_handlers.go:876` is **not** in scope — it builds `"character:"+id`
-> as an ABAC *subject* (`GetLocation` call), not a stream name. Leave it colon.
-> `subscription_router.go` deliberately avoids importing `internal/grpc`/`world`
-> to dodge an import cycle (see its `:14` comment), so flip it with an **inline**
-> `"location." + characterLocationID.String()`, not `world.LocationStream`. Also
-> update its stale `:27` doc-comment that names `notifications:<character_id>` as
-> a stream — restate it in dot form (`events.<gid>.notification.<id>`).
+> **Note:** `auth_handlers.go:876` builds `"character:"+id` as an ABAC *subject*
+> (not a stream); it is handled in **Task 5 Step 7** by routing through
+> `access.CharacterSubject(...)`, not here. `subscription_router.go` deliberately
+> avoids importing `internal/grpc`/`world` to dodge an import cycle (see its `:14`
+> comment), so flip it with an **inline** `"location." + characterLocationID.String()`,
+> not `world.LocationStream`. Also update its stale `:27` doc-comment that names
+> `notifications:<character_id>` as a stream — restate it in dot form
+> (`events.<gid>.notification.<id>`).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -238,11 +241,37 @@ In `internal/core/engine.go`, change the two inline literals at lines 73 and 96:
 - [ ] **Step 4: Flip the inline colon producers + fix compile breaks**
 
 First flip the inline literals the compiler will NOT catch (they use no deleted
-constant): `internal/grpc/focus/subscription_router.go:37,47`:
+constant):
+
+- `internal/grpc/focus/subscription_router.go:37,47`:
 
 ```go
 	return []string{"location." + characterLocationID.String()}
 ```
+
+- `internal/core/engine_end_session.go:62` — the `NewEvent` stream argument:
+
+```go
+	event := NewEvent(
+		"character."+char.ID.String(),
+```
+
+- `internal/grpc/focus/scenepolicy/policy.go:29-30` — `StreamsFor` returns the
+  IC/OOC **subscription filters**. `s9nu` migrated the scene emit path and
+  classifiers to dot but missed this filter producer (latent `ofpi`-class bug).
+  Flip to the dot-relative form the host qualifier expects:
+
+```go
+func (p *ScenePolicy) StreamsFor(target session.FocusKey) []string {
+	id := target.TargetID.String()
+	return []string{
+		"scene." + id + ".ic",
+		"scene." + id + ".ooc",
+	}
+}
+```
+
+  Update `policy_test.go` expectations to the dot form.
 
 Then `task build`. Expected: compile errors at every `core.StreamPrefixCharacter`
 / `world.StreamPrefix*` consumer (e.g. `internal/grpc/server.go:1246,1294`). For
@@ -410,15 +439,17 @@ Expected: PASS
 ### Task 5: Dot-only classifiers, read-entry qualifier, and location seeds
 
 This is the privacy-critical core. All four `internal/grpc/` classifiers flip to
-dot-only, `QueryStreamHistory` qualifies `req.Stream` at entry, and the two
-location seeds switch to the `has_location` witness.
+dot-only, `QueryStreamHistory` qualifies `req.Stream` at entry, the location
+seeds switch to the `has_location` witness, and the straggler host ABAC-subject
+sites route through the existing `internal/access` builders (so no inline colon
+literal survives in host code — the INV-ROPS-3 boundary).
 
 **Files:**
 
 - Modify: `internal/grpc/stream_access.go:70-115`
 - Modify: `internal/grpc/scope_floor.go:33-81,93`
-- Modify: `internal/grpc/query_stream_history.go:45-110,170-250`
-- Modify: `internal/grpc/auth_handlers.go:876`, `internal/plugin/pluginauthz/evaluate.go:65` (ABAC-subject exemption markers)
+- Modify: `internal/grpc/query_stream_history.go:45-110,170-250` (incl. `:220` ABAC subject)
+- Modify: `internal/grpc/auth_handlers.go:876`, `internal/plugin/pluginauthz/evaluate.go:65`, `internal/eventbus/authguard/guard.go:130`, `internal/command/handlers/resetpassword.go:107`, `internal/store/role_resolver.go:30` (route ABAC subjects through `access.*` builders)
 - Modify: `internal/access/policy/seed.go:59-70`
 - Test: `internal/grpc/stream_access_test.go`, `internal/grpc/scope_floor_test.go`
 
@@ -561,26 +592,32 @@ the co-location clause untouched and bump `SeedVersion`:
 		},
 ```
 
-- [ ] **Step 7: Mark the sanctioned ABAC-subject literals (INV-ROPS-3 exemption)**
+- [ ] **Step 7: Route straggler host ABAC subjects through the `access.*` builders**
 
-Three production files outside `internal/access/` build `"character:"+id` as an
-ABAC **subject** (not a stream) and MUST keep the colon. Add the explicit
-exemption marker `// rops:abac-subject` to each so the Task 8 INV-ROPS-3 scan
-skips them (the scan keys on that exact substring):
+The colon ABAC-subject form is built by the **existing** `internal/access`
+builders (`access.CharacterSubject`, `access.PluginSubject`, …), already the
+convention across `world/`, `command/`, `hostfunc/`, `grpc/`. A few host sites
+still inline the literal; route them through the builders so no inline colon
+literal survives in host code (the INV-ROPS-3 boundary, and a cleanup
+`prefix.go`'s doc-comment explicitly calls for). Each builder panics on empty
+input, which is strictly safer than the bare concatenation:
 
-- `internal/grpc/scope_floor.go:93` — the `"character:"+info.CharacterID.String()`
-  argument to `NewAccessRequest` in `staffOverride`.
-- `internal/grpc/auth_handlers.go:876` — `subj := "character:" + c.ID.String()`.
-- `internal/plugin/pluginauthz/evaluate.go:65` — `return "character:" + a.ID`.
+- `internal/grpc/scope_floor.go:93` → `access.CharacterSubject(info.CharacterID.String())`
+- `internal/grpc/query_stream_history.go:220` → `access.CharacterSubject(info.CharacterID.String())`
+- `internal/grpc/auth_handlers.go:876` → `access.CharacterSubject(c.ID.String())`
+- `internal/plugin/pluginauthz/evaluate.go:65` → `access.CharacterSubject(a.ID)`
+- `internal/eventbus/authguard/guard.go:130` → `access.PluginSubject(req.Identity.PluginName)`
+- `internal/command/handlers/resetpassword.go:107` → `access.CharacterSubject(<id>)` (replaces the `fmt.Sprintf("character:%s", …)`)
+- `internal/store/role_resolver.go:30` → parse via `access.ParseEntityRef(subject)` (or `strings.TrimPrefix(subject, access.SubjectCharacter)`) instead of the bare `"character:"` literal
 
-Example (the marker must be on the same line as the literal):
+Add the `"github.com/holomush/holomush/internal/access"` import where missing.
+After this, `task build` then `task test`.
 
-```go
-		subj := "character:" + c.ID.String() // rops:abac-subject (ABAC principal, not a stream)
-```
-
-(`scope_floor.go:49`'s `HasPrefix(stream, "character:")` is NOT marked — it is a
-stream classifier that Step 4 already flipped to dot, so the literal is gone.)
+> **Plugin residual (NOT host):** `plugins/core-scenes/commands.go` builds
+> `"scene:"+id` as an ABAC resource and **cannot** import `internal/access`
+> (plugin boundary). Those lines already call `evaluator.Evaluate(` or carry the
+> `// ABAC resource ref` comment, which the Task 8 INV-ROPS-3 scan skips — they
+> are left as-is. This is the only sanctioned inline colon residual.
 
 - [ ] **Step 8: Run tests to verify they pass**
 
@@ -715,21 +752,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestINV_ROPS_3_NoColonStreamLiterals asserts no production Go/TS source
-// contains a colon-style pub/sub STREAM literal outside the ABAC layer.
-// Supersedes INV-P4-1 with a repo-wide scan. Roots MUST exist (fail, not skip).
+// TestINV_ROPS_3_NoColonStreamLiterals asserts no production Go source contains
+// a colon-style entity-prefix literal as a pub/sub STREAM name. Supersedes
+// INV-P4-1 with a repo-wide scan. Roots MUST exist (fail, not skip).
 //
-// Colon type-prefixes legitimately appear as ABAC SUBJECT literals
-// ("character:"+id for NewAccessRequest) in production files OUTSIDE
-// internal/access/ (scope_floor.go:93, auth_handlers.go:876,
-// pluginauthz/evaluate.go:65). Content alone cannot distinguish an ABAC subject
-// from a missed stream producer, so the scan skips: (a) comment lines, and
-// (b) any line bearing the explicit exemption marker "rops:abac-subject" — which
-// those three sites carry (added in Task 5). This mirrors INV-P4-1's
-// abacContextMarkers approach, made explicit per-line.
+// The stream-vs-ABAC ambiguity is solved structurally: ABAC subjects/resources
+// are built ONLY via internal/access builders (access.CharacterSubject,
+// SceneResource, …), which live in the allowlisted internal/access package.
+// Host code therefore has NO inline colon literal (Task 5 Step 7 routed the
+// stragglers through the builders). The scan skips: (a) internal/access/;
+// (b) comment lines; (c) lines that call an ABAC evaluation API or carry the
+// "ABAC resource ref" marker — the only residual, in plugins/core-scenes/ which
+// cannot import internal/access. Any other hit is unambiguously a stream-producer
+// bug. (mirrors INV-P4-1's proven abacContextMarkers approach.)
 func TestINV_ROPS_3_NoColonStreamLiterals(t *testing.T) {
 	roots := []string{"../../../internal", "../../../pkg", "../../../plugins", "../../../cmd"}
-	pattern := regexp.MustCompile(`"(location|character|notifications|scene):`)
+	pattern := regexp.MustCompile(`"(location|character|notifications|scene|plugin):`)
+	abacMarkers := []string{"Evaluate(", "CanPerformAction(", "NewAccessRequest(", ".Grant(", "ABAC resource ref"}
 	for _, root := range roots {
 		info, err := os.Stat(root)
 		require.NoErrorf(t, err, "scan root missing: %s", root) // fail, never skip
@@ -741,9 +780,8 @@ func TestINV_ROPS_3_NoColonStreamLiterals(t *testing.T) {
 				return err
 			}
 			if d.IsDir() {
-				// allowlist: ABAC policy-DSL layer keeps colon type-prefixes.
 				if strings.Contains(path, "internal/access") {
-					return filepath.SkipDir
+					return filepath.SkipDir // sole sanctioned home of colon prefixes
 				}
 				return nil
 			}
@@ -760,8 +798,15 @@ func TestINV_ROPS_3_NoColonStreamLiterals(t *testing.T) {
 				if strings.HasPrefix(line, "//") || strings.HasPrefix(line, "*") {
 					continue // doc/comment line, not a producer
 				}
-				if strings.Contains(raw, "rops:abac-subject") {
-					continue // sanctioned ABAC-subject literal (Task 5 marker)
+				skip := false
+				for _, m := range abacMarkers {
+					if strings.Contains(raw, m) {
+						skip = true // ABAC subject/resource construction, not a stream
+						break
+					}
+				}
+				if skip {
+					continue
 				}
 				t.Errorf("INV-ROPS-3: colon-style stream literal in %s:%d:\n  %s", path, i+1, line)
 			}
@@ -877,11 +922,10 @@ empty `policy_id` + "by ABAC" log line).
 
 - [ ] **Step 4: Write INV-ROPS-6 role-split unit test**
 
-There is **no** `access.CharacterSubject` builder (verified: `internal/access`
-exports only `ParseSubject`). The canonical colon ABAC-subject construction site
-is `internal/grpc/scope_floor.go:93` (`"character:"+info.CharacterID.String()`).
-Assert both forms directly — the stream builder is dot, the ABAC subject literal
-stays colon — without introducing a builder:
+The role split is now a real package boundary: the **stream** builder
+(`world.CharacterStream`, dot) vs the **ABAC subject** builder
+(`access.CharacterSubject`, colon, in `internal/access/prefix.go`). Assert both
+against the real builders:
 
 ```go
 // internal/grpc/stream_access_test.go — add
@@ -889,9 +933,8 @@ func TestRoleSplitCharacterStreamDotABACSubjectColon(t *testing.T) {
 	id := ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
 	// Stream form: dot-relative (this migration).
 	require.Equal(t, "character."+id.String(), world.CharacterStream(id))
-	// ABAC subject form: colon — unchanged, as built at scope_floor.go:93.
-	abacSubject := "character:" + id.String()
-	require.True(t, strings.HasPrefix(abacSubject, "character:"))
+	// ABAC subject form: colon — the existing access builder, unchanged.
+	require.Equal(t, "character:"+id.String(), access.CharacterSubject(id.String()))
 }
 ```
 
@@ -960,7 +1003,7 @@ Expected: PASS
 
 - [ ] `task pr-prep` green (fast lane).
 - [ ] `task pr-prep:full` green (this diff touches int + E2E surface — Subscribe/QueryStreamHistory + scene/privacy integration suites).
-- [ ] `rg -n '"(location|character|notifications|scene):' internal pkg plugins cmd | rg -v internal/access` returns nothing (INV-ROPS-3 holds manually).
+- [ ] `rg -n '"(location|character|notifications|scene|plugin):' internal pkg plugins cmd | rg -v 'internal/access|Evaluate\(|CanPerformAction\(|NewAccessRequest\(|\.Grant\(|ABAC resource ref|^\s*//'` returns nothing (INV-ROPS-3 holds manually — host code routes ABAC subjects through `access.*` builders; the only colon residual is plugin `Evaluate(` lines).
 - [ ] `holomush-pkixe` verified fixed by this work (scene members read their own history via the I-17 gate); close it with evidence.
 - [ ] `holomush-ofpi` verified fixed (Subscribe scope-floor sees qualified subjects); close it.
 - [ ] `holomush-ec22.3` closed as superseded (subjectxlate deleted).

--- a/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
+++ b/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
@@ -1,0 +1,967 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Colon-Style Subject Eradication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate every pub/sub stream name from legacy colon form (`location:<id>`, `character:<id>`) to JetStream-native dot form (`events.<gid>.location.<id>`) end to end, and delete `internal/eventbus/subjectxlate/`.
+
+**Architecture:** Producers and clients emit a **domain-relative dot reference** (`location.<id>`, `character.<id>`, `global`); a single host-side qualifier (`eventbus.Qualify`) prepends `events.<gid>.` at exactly two boundaries (emit + read-entry), replacing the two `subjectxlate` call sites. Classifiers, the bus, and the durable audit see only fully-qualified dot subjects. The colon form survives **only** as an ABAC policy-DSL type-prefix (`character:`, `stream:`), never as a stream name.
+
+**Tech Stack:** Go (`internal/`, `pkg/holo`, `cmd/holomush`), gRPC/protobuf (`api/proto`), SvelteKit/TypeScript (`web/src`), PostgreSQL (no migration — streams are not persisted as colon strings; audit stores the qualified subject).
+
+**Spec:** [docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md](../specs/2026-05-29-colon-style-subject-eradication-design.md) — invariants INV-ROPS-1 … INV-ROPS-8.
+
+**Bead:** `holomush-rops`. Subsumes `holomush-ec22.3`, `holomush-pkixe`, `holomush-ofpi`.
+
+---
+
+## Safety property that makes the ordering green
+
+`subjectxlate.Legacy` only prepends `events.<gid>.` and replaces `:`→`.`. A
+dot-relative reference has no colon, so `Legacy("location.<id>", gid)` and
+`Legacy("location:<id>", gid)` produce the **identical** subject
+`events.<gid>.location.<id>`. Therefore Tasks 1–3 (constructors, qualifier,
+producers→dot, witness) can land while the shim is still present — the wire stays
+correct. Tasks 4–6 flip the classifiers, read-entry, wire, and client; Task 7
+deletes the shim. The full integration suite is green at the end of Task 7; unit
+tests are green at every task.
+
+---
+
+## File structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `internal/eventbus/qualify.go` (new) | `Qualify(gid, relativeRef)` — the single gameID-injection helper | 1 |
+| `internal/world/events.go` | relative stream builders (`:`→`.`); delete `StreamPrefix*` colon consts | 2 |
+| `internal/core/event.go` | delete `StreamPrefixCharacter` colon const | 2 |
+| `internal/core/engine.go` | producers emit dot-relative refs | 2 |
+| `pkg/holo/emit.go` | Lua SDK emitter emits dot-relative refs | 3 |
+| `internal/access/policy/attribute/stream.go` | dot-aware `location` parse + `has_location` witness | 4 |
+| `internal/grpc/stream_access.go` | dot-only private/membership classifiers | 5 |
+| `internal/grpc/scope_floor.go` | dot-only location/character scope-floor branches | 5 |
+| `internal/grpc/query_stream_history.go` | read-entry qualifier; dot classifiers | 5 |
+| `internal/grpc/server.go` | Subscribe read-entry qualifier; `dispatchDelivery` dot | 6 |
+| `cmd/holomush/sub_grpc.go` | `busEventAppender`/`busHistoryReaderAdapter` use `Qualify` | 6 |
+| `api/proto/holomush/core/v1/*.proto`, `web/src/lib/backfill/*` | wire + client carry dot refs | 6 |
+| `internal/access/policy/seed.go` | location seeds use `has_location` witness | 5 |
+| `internal/eventbus/subjectxlate/` | **deleted** | 7 |
+| `internal/test/invariants/colon_eradication_test.go` (new) | INV-ROPS-3 repo-wide scan + bijection | 8 |
+| `test/integration/streams/rops_test.go` (new) | INV-ROPS-4/7/8 round-trip, floor, seed auth | 8 |
+| docs + ADR | iwzt, scenes-v2, event-conventions, architecture.md, s9nu amendment | 9 |
+
+---
+
+### Task 1: `eventbus.Qualify` — the single gameID-injection helper
+
+**Files:**
+
+- Create: `internal/eventbus/qualify.go`
+- Test: `internal/eventbus/qualify_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/eventbus/qualify_test.go
+package eventbus
+
+import "testing"
+
+func TestQualifyPrependsEventsAndGameID(t *testing.T) {
+	got, err := Qualify("main", "location.01ABC")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "events.main.location.01ABC"; string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestQualifyRejectsEmptyGameID(t *testing.T) {
+	if _, err := Qualify("", "location.01ABC"); err == nil {
+		t.Fatal("expected error for empty game id")
+	}
+}
+
+func TestQualifyPassesThroughAlreadyQualified(t *testing.T) {
+	got, err := Qualify("main", "events.main.scene.01S.ic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "events.main.scene.01S.ic"; string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestQualify ./internal/eventbus/`
+Expected: FAIL — `undefined: Qualify`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/eventbus/qualify.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package eventbus
+
+import "github.com/samber/oops"
+
+// Qualify turns a domain-relative stream reference (e.g. "location.01ABC",
+// "character.01XYZ", "global") into a fully-qualified JetStream subject by
+// prepending "events.<gameID>.". References already starting with "events."
+// are returned unchanged (idempotent). gameID MUST be non-empty.
+//
+// This is the single host-side gameID-injection point introduced by
+// holomush-rops; it replaces subjectxlate.Legacy. Producers and clients, which
+// lack the gameID, emit relative references; Qualify is applied at the emit and
+// read-entry boundaries (spec §1 "where gameID enters").
+func Qualify(gameID, relativeRef string) (Subject, error) {
+	if relativeRef == "" {
+		return "", oops.Errorf("empty stream reference")
+	}
+	if len(relativeRef) >= 7 && relativeRef[:7] == "events." {
+		return NewSubject(relativeRef)
+	}
+	if gameID == "" {
+		return "", oops.With("ref", relativeRef).Errorf("game id required to qualify stream reference")
+	}
+	return NewSubject("events." + gameID + "." + relativeRef)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestQualify ./internal/eventbus/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Commit using VCS-appropriate commands per `references/vcs-preamble.md`. Message:
+`feat(eventbus): add Qualify gameID-injection helper (holomush-rops)`
+
+---
+
+### Task 2: Host producers emit dot-relative references
+
+**Files:**
+
+- Modify: `internal/world/events.go:22-40` (builders + delete colon consts)
+- Modify: `internal/core/event.go:14-17` (delete `StreamPrefixCharacter`)
+- Modify: `internal/core/engine.go:73,96` (inline `"location:"` → `"location."`)
+- Modify: `internal/grpc/focus/subscription_router.go:37,47` (inline `"location:"` → `"location."`)
+- Test: `internal/world/events_test.go`
+
+> **Note:** `auth_handlers.go:876` is **not** in scope — it builds `"character:"+id`
+> as an ABAC *subject* (`GetLocation` call), not a stream name. Leave it colon.
+> `subscription_router.go` deliberately avoids importing `internal/grpc`/`world`
+> to dodge an import cycle (see its `:14` comment), so flip it with an **inline**
+> `"location." + characterLocationID.String()`, not `world.LocationStream`. Also
+> update its stale `:27` doc-comment that names `notifications:<character_id>` as
+> a stream — restate it in dot form (`events.<gid>.notification.<id>`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/world/events_test.go — add
+func TestLocationStreamUsesDotRelativeForm(t *testing.T) {
+	id := ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if got := LocationStream(id); got != "location."+id.String() {
+		t.Fatalf("got %q, want dot-relative location.<id>", got)
+	}
+}
+
+func TestCharacterStreamUsesDotRelativeForm(t *testing.T) {
+	id := ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if got := CharacterStream(id); got != "character."+id.String() {
+		t.Fatalf("got %q, want dot-relative character.<id>", got)
+	}
+}
+
+func TestBroadcastLocationStreamUsesDotWildcard(t *testing.T) {
+	if got := BroadcastLocationStream(); got != "location.*" {
+		t.Fatalf("got %q, want location.*", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run 'TestLocationStreamUsesDot|TestCharacterStreamUsesDot|TestBroadcastLocationStreamUsesDot' ./internal/world/`
+Expected: FAIL — still returns `location:<id>`
+
+- [ ] **Step 3: Flip the builders and delete the colon constants**
+
+In `internal/world/events.go`, replace lines 22-40:
+
+```go
+// Stream domain tokens for domain-relative stream references. The host
+// qualifier (eventbus.Qualify) prepends "events.<gameID>." to produce the
+// fully-qualified subject; these builders return the relative reference only.
+const (
+	streamDomainLocation  = "location."
+	streamDomainCharacter = "character."
+)
+
+// LocationStream returns the domain-relative stream reference for a location.
+func LocationStream(id ulid.ULID) string {
+	return streamDomainLocation + id.String()
+}
+
+// CharacterStream returns the domain-relative stream reference for a character.
+func CharacterStream(id ulid.ULID) string {
+	return streamDomainCharacter + id.String()
+}
+
+// BroadcastLocationStream returns the relative reference matching all locations.
+func BroadcastLocationStream() string {
+	return streamDomainLocation + "*"
+}
+```
+
+In `internal/core/event.go`, delete lines 14-17 (the `StreamPrefixCharacter`
+const and its doc comment).
+
+In `internal/core/engine.go`, change the two inline literals at lines 73 and 96:
+
+```go
+		Stream:    "location." + char.LocationID.String(),
+```
+
+- [ ] **Step 4: Flip the inline colon producers + fix compile breaks**
+
+First flip the inline literals the compiler will NOT catch (they use no deleted
+constant): `internal/grpc/focus/subscription_router.go:37,47`:
+
+```go
+	return []string{"location." + characterLocationID.String()}
+```
+
+Then `task build`. Expected: compile errors at every `core.StreamPrefixCharacter`
+/ `world.StreamPrefix*` consumer (e.g. `internal/grpc/server.go:1246,1294`). For
+each, replace the prefix-constant reference with the dot domain token. At
+`server.go:1246`: `strings.HasPrefix(legacyStream, "character.")`; at `:1294`:
+`strings.HasPrefix(ctrl.stream, "location.")`. Re-run `task build` until green.
+
+> Why both: the constant deletions are surfaced by the compiler, but
+> `subscription_router.go`'s inline `"location:"+id` is not — only INV-ROPS-3
+> (Task 8) would flag it. Flip it here so the eradication scan is green when it
+> lands.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./internal/world/ ./internal/core/`
+Expected: PASS. (Wire stays correct: `subjectxlate.Legacy("location.<id>")` ==
+`Legacy("location:<id>")` — the separator-agnostic property above.)
+
+- [ ] **Step 6: Commit**
+
+`refactor(world,core): emit dot-relative stream references (holomush-rops)`
+
+---
+
+### Task 3: Lua SDK emitter emits dot-relative references
+
+**Files:**
+
+- Modify: `pkg/holo/emit.go:18-22` (constants), `:54-88` (methods unchanged in shape)
+- Test: `pkg/holo/emit_test.go`
+
+- [ ] **Step 1: Update the failing test**
+
+In `pkg/holo/emit_test.go`, change the hardcoded colon expectations to dot. Find
+each `"location:01ABC"` / `"character:01CHAR..."` expectation and rewrite the
+stream assertion, e.g.:
+
+```go
+	// was: want stream "location:" + locationID
+	if ev.Stream != "location."+locationID {
+		t.Fatalf("got %q, want dot-relative location.<id>", ev.Stream)
+	}
+```
+
+(Repeat for the `Character`, `Global`, and `*Sensitive` cases — `global` is
+unchanged, it is already a bare token.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- ./pkg/holo/`
+Expected: FAIL — emitter still produces `location:<id>`
+
+- [ ] **Step 3: Flip the SDK constants**
+
+In `pkg/holo/emit.go`, replace lines 18-22:
+
+```go
+// Domain-relative stream tokens. The host qualifier (eventbus.Qualify) prepends
+// "events.<gameID>." — the SDK lacks the gameID, so it emits the relative ref.
+const (
+	streamPrefixCharacter = "character."
+	streamPrefixLocation  = "location."
+	streamPrefixGlobal    = "global"
+)
+```
+
+(The `Location`/`Character`/`Global` method bodies are unchanged — they already
+concatenate the prefix; only the prefix value changes. Update their doc-comments
+that say `"location:<id>"` to `"location.<id>"`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- ./pkg/holo/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+`refactor(holo): Lua SDK emits dot-relative stream references (holomush-rops)`
+
+---
+
+### Task 4: `StreamProvider` — dot-aware location parse + `has_location` witness
+
+**Files:**
+
+- Modify: `internal/access/policy/attribute/stream.go:34-62`
+- Test: `internal/access/policy/attribute/stream_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/access/policy/attribute/stream_test.go — add
+func TestStreamProviderExtractsLocationFromQualifiedDotSubject(t *testing.T) {
+	p := NewStreamProvider()
+	attrs, err := p.ResolveResource(context.Background(), "stream:events.main.location.01LOC")
+	require.NoError(t, err)
+	require.Equal(t, "01LOC", attrs["location"])
+	require.Equal(t, true, attrs["has_location"])
+}
+
+func TestStreamProviderOmitsLocationForNonLocationStream(t *testing.T) {
+	p := NewStreamProvider()
+	attrs, err := p.ResolveResource(context.Background(), "stream:events.main.character.01CHR")
+	require.NoError(t, err)
+	_, present := attrs["location"]
+	require.False(t, present, "location key MUST be absent (not empty-sentinel) for non-location streams")
+	require.Equal(t, false, attrs["has_location"])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestStreamProvider ./internal/access/policy/attribute/`
+Expected: FAIL — current parse keys on `"location:"` prefix; dot name yields no `location`, and `has_location` is undefined.
+
+- [ ] **Step 3: Make the parse dot-aware and emit the witness**
+
+In `internal/access/policy/attribute/stream.go`, replace `ResolveResource`
+(lines 34-51) and add `has_location` to `Schema()`:
+
+```go
+// ResolveResource resolves stream attributes for a resource. The resource ID is
+// "stream:<name>" where <name> is a fully-qualified dot subject
+// (e.g. "events.<gid>.location.<ULID>"). The location attribute is emitted ONLY
+// for location subjects; the has_location witness is always present (true/false)
+// per .claude/rules/abac-providers.md (omit value, never sentinel).
+func (p *StreamProvider) ResolveResource(_ context.Context, resourceID string) (map[string]any, error) {
+	id, ok := parseEntityID(resourceID, "stream")
+	if !ok {
+		return nil, nil
+	}
+
+	attrs := map[string]any{
+		"type": "stream",
+		"name": id,
+	}
+
+	// Location subjects are "events.<gid>.location.<ULID>": parts[2]=="location".
+	parts := strings.Split(id, ".")
+	if len(parts) == 4 && parts[0] == "events" && parts[2] == "location" && parts[3] != "" {
+		attrs["location"] = parts[3]
+		attrs["has_location"] = true
+	} else {
+		attrs["has_location"] = false
+		// location key INTENTIONALLY ABSENT (ADR holomush-9gtl fail-safe).
+	}
+
+	return attrs, nil
+}
+```
+
+Add to the `Schema()` `Attributes` map: `"has_location": types.AttrTypeBool,`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestStreamProvider ./internal/access/policy/attribute/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+`feat(access): StreamProvider dot-aware location parse + has_location witness (holomush-rops)`
+
+---
+
+### Task 5: Dot-only classifiers, read-entry qualifier, and location seeds
+
+This is the privacy-critical core. All four `internal/grpc/` classifiers flip to
+dot-only, `QueryStreamHistory` qualifies `req.Stream` at entry, and the two
+location seeds switch to the `has_location` witness.
+
+**Files:**
+
+- Modify: `internal/grpc/stream_access.go:70-115`
+- Modify: `internal/grpc/scope_floor.go:33-81,93`
+- Modify: `internal/grpc/query_stream_history.go:45-110,170-250`
+- Modify: `internal/grpc/auth_handlers.go:876`, `internal/plugin/pluginauthz/evaluate.go:65` (ABAC-subject exemption markers)
+- Modify: `internal/access/policy/seed.go:59-70`
+- Test: `internal/grpc/stream_access_test.go`, `internal/grpc/scope_floor_test.go`
+
+- [ ] **Step 1: Write the failing classifier non-collision test (INV-ROPS-5)**
+
+```go
+// internal/grpc/stream_access_test.go — add
+func TestStreamClassifiersNonCollision(t *testing.T) {
+	cases := []struct {
+		name              string
+		stream            string
+		wantPrivate       bool
+		wantScene         bool
+		wantLocation      bool
+	}{
+		{"qualified location is public-not-scene", "events.main.location.01LOC", false, false, true},
+		{"qualified character is private-not-scene", "events.main.character.01CHR", true, false, false},
+		{"qualified scene ic is private-and-scene", "events.main.scene.01SCN.ic", true, true, false},
+		{"colon character is rejected (no longer private)", "character:01CHR", false, false, false},
+		{"colon location is rejected (not location)", "location:01LOC", false, false, false},
+		{"garbage is none", "nonsense", false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.wantPrivate, isPrivateStream(tc.stream))
+			require.Equal(t, tc.wantScene, isSceneStream(tc.stream))
+			require.Equal(t, tc.wantLocation, isLocationStream(tc.stream))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestStreamClassifiersNonCollision ./internal/grpc/`
+Expected: FAIL — colon character still classified private; qualified character not yet recognized.
+
+- [ ] **Step 3: Flip the character classifiers to dot-only**
+
+In `internal/grpc/stream_access.go`, add a dot character helper and update the
+two character branches (replace the `HasPrefix("character:")` /
+`TrimPrefix("character:")` logic at lines 70-115):
+
+```go
+// isCharacterStream reports whether a stream is a qualified personal character
+// subject: events.<gameID>.character.<ULID> (exactly 4 segments).
+func isCharacterStream(stream string) bool {
+	parts := strings.Split(stream, ".")
+	return len(parts) == 4 && parts[0] == "events" && parts[1] != "" &&
+		parts[2] == "character" && parts[3] != ""
+}
+
+func extractCharacterID(stream string) (string, bool) {
+	parts := strings.Split(stream, ".")
+	if len(parts) == 4 && parts[0] == "events" && parts[1] != "" &&
+		parts[2] == "character" && parts[3] != "" {
+		return parts[3], true
+	}
+	return "", false
+}
+
+func isPrivateStream(stream string) bool {
+	return isCharacterStream(stream) || isSceneStream(stream)
+}
+```
+
+In `sessionHasMembership` (lines 85-115), replace the `character:` branch:
+
+```go
+	if charID, ok := extractCharacterID(stream); ok {
+		if info.CharacterID == (ulid.ULID{}) {
+			return false
+		}
+		return info.CharacterID.String() == charID
+	}
+```
+
+- [ ] **Step 4: Flip the location/character scope-floor branches**
+
+In `internal/grpc/scope_floor.go`, replace `isLocationStream` (lines 69-81) and
+the character branch of `streamScopeFloor` (line 49):
+
+```go
+// isLocationStream reports whether a stream is a qualified location subject:
+// events.<gameID>.location.<ULID> (exactly 4 segments).
+func isLocationStream(stream string) bool {
+	parts := strings.Split(stream, ".")
+	return len(parts) == 4 && parts[0] == "events" && parts[1] != "" &&
+		parts[2] == "location" && parts[3] != ""
+}
+
+func extractLocationID(stream string) string {
+	parts := strings.Split(stream, ".")
+	if len(parts) == 4 {
+		return parts[3]
+	}
+	return ""
+}
+```
+
+In `streamScopeFloor`, change `case strings.HasPrefix(stream, "character:"):`
+to `case isCharacterStream(stream):`.
+
+- [ ] **Step 5: Add the read-entry qualifier (INV-ROPS-2)**
+
+In `internal/grpc/query_stream_history.go`, immediately after the `req.Stream ==
+""` guard (line ~96) and after `info` is loaded, qualify the stream and reject
+the unqualifiable, then run the existing classifier switch on the qualified value:
+
+```go
+	qualified, qErr := eventbus.Qualify(s.currentGameID(), req.Stream)
+	if qErr != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid stream")
+	}
+	stream := string(qualified) // classify on the qualified subject below
+```
+
+Replace the `req.Stream` references in the auth switch (lines 173-231) with
+`stream`. Delete the downstream `subjectxlate.Legacy(legacyStream, gameID)` at
+`:425,494` — `stream` is already qualified; pass it directly to the bus fetch.
+
+- [ ] **Step 6: Switch the location seeds to the has_location witness (INV-ROPS-8 fix)**
+
+In `internal/access/policy/seed.go`, edit the two seeds at lines 60 and 66.
+Replace `resource.stream.name like "location:*"` with the witness check; leave
+the co-location clause untouched and bump `SeedVersion`:
+
+```go
+		{
+			Name:        "seed:player-stream-emit",
+			Description: "Characters can emit to co-located location streams",
+			DSLText:     `permit(principal is character, action in ["emit"], resource is stream) when { resource.stream.has_location == true && resource.stream.location == principal.character.location };`,
+			SeedVersion: 3,
+		},
+		{
+			Name:        "seed:player-location-stream-read",
+			Description: "Characters can read history of their current location stream",
+			DSLText:     `permit(principal is character, action in ["read"], resource is stream) when { resource.stream.has_location == true && resource.stream.location == principal.character.location };`,
+			SeedVersion: 2,
+		},
+```
+
+- [ ] **Step 7: Mark the sanctioned ABAC-subject literals (INV-ROPS-3 exemption)**
+
+Three production files outside `internal/access/` build `"character:"+id` as an
+ABAC **subject** (not a stream) and MUST keep the colon. Add the explicit
+exemption marker `// rops:abac-subject` to each so the Task 8 INV-ROPS-3 scan
+skips them (the scan keys on that exact substring):
+
+- `internal/grpc/scope_floor.go:93` — the `"character:"+info.CharacterID.String()`
+  argument to `NewAccessRequest` in `staffOverride`.
+- `internal/grpc/auth_handlers.go:876` — `subj := "character:" + c.ID.String()`.
+- `internal/plugin/pluginauthz/evaluate.go:65` — `return "character:" + a.ID`.
+
+Example (the marker must be on the same line as the literal):
+
+```go
+		subj := "character:" + c.ID.String() // rops:abac-subject (ABAC principal, not a stream)
+```
+
+(`scope_floor.go:49`'s `HasPrefix(stream, "character:")` is NOT marked — it is a
+stream classifier that Step 4 already flipped to dot, so the literal is gone.)
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `task test -- ./internal/grpc/ ./internal/access/... ./internal/plugin/...`
+Expected: PASS (unit). Integration round-trip is verified in Task 8.
+
+- [ ] **Step 9: Commit**
+
+`refactor(grpc,access): dot-only stream classifiers + read-entry qualifier + witness seeds (holomush-rops)`
+
+---
+
+### Task 6: Wire contract, Subscribe path, dispatch, and SvelteKit client
+
+**Files:**
+
+- Modify: `internal/grpc/server.go` (Subscribe read-entry qualify; `dispatchDelivery:1177,1246,1252,1294`)
+- Modify: `cmd/holomush/sub_grpc.go` (`busEventAppender.Append`, `busHistoryReaderAdapter.ReplayTail`)
+- Modify: `api/proto/holomush/core/v1/*.proto` doc-comments for `stream`/`streams` fields (note dot form; no field-shape change)
+- Modify: `web/src/lib/backfill/*` (construct/consume dot refs)
+- Test: existing `internal/grpc` + `web` unit tests
+
+- [ ] **Step 1: Qualify Subscribe filters at entry**
+
+In `internal/grpc/server.go` `Subscribe`, replace the `computeInitialFilters` →
+`toSubject` → `subjectxlate.Legacy` chain so each requested filter is qualified
+via `eventbus.Qualify(s.currentGameID(), filter)`. Filters that fail to qualify
+return `codes.InvalidArgument`.
+
+- [ ] **Step 2: Make `dispatchDelivery` operate on the qualified subject**
+
+In `internal/grpc/server.go` `dispatchDelivery` (~1168-1252): delete the
+`legacyStream := subjectxlate.ToLegacy(...)` at `:1177`. Feed the already-dot
+`event.Subject` directly to `streamScopeFloor` (`:1228`), to the character check
+at `:1246` (now `isCharacterStream(string(event.Subject))`), and set the
+delivered frame's stream field to the qualified subject (the client now expects
+dot — Step 5).
+
+- [ ] **Step 3: Update `sub_grpc.go` appender/replay**
+
+In `cmd/holomush/sub_grpc.go`: `busEventAppender.Append` receives a dot-relative
+`core.Event.Stream` from `engine.go` (Task 2); qualify it with
+`eventbus.Qualify(gameID, ev.Stream)` instead of `subjectxlate.Legacy`. In
+`busHistoryReaderAdapter.ReplayTail`, qualify the requested stream the same way
+and stop calling `subjectxlate.ToLegacy` on results — return the qualified
+subject as the frame stream.
+
+- [ ] **Step 4: Update proto doc-comments**
+
+In `api/proto/holomush/core/v1` the `string stream` (QueryStreamHistory),
+`repeated string streams` (Subscribe filters), and delivered-frame `stream`
+fields are unchanged in shape; update their leading doc-comments to state the
+value is a domain-relative dot reference (`location.<id>`) that the server
+qualifies. Run `task lint:proto`. Expected: PASS (COMMENTS gate satisfied).
+
+- [ ] **Step 5: Flip the SvelteKit client to dot refs**
+
+In `web/src/lib/backfill/*` change the stream references the client sends and
+matches from colon to dot-relative (`location.<id>`, `character.<id>`). Update
+the corresponding `*.test.ts` fixtures.
+
+Run: `cd web && bun run test` (or the repo's web test task)
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+`refactor(grpc,web): dot stream refs on the wire + Subscribe/dispatch qualify (holomush-rops)`
+
+---
+
+### Task 7: Delete `subjectxlate` and its harness callers
+
+**Files:**
+
+- Delete: `internal/eventbus/subjectxlate/subjectxlate.go`, `subjectxlate_test.go`
+- Modify: `internal/grpc/server.go:663`, `cmd/holomush/sub_grpc.go`, `internal/admin/readstream/`, `internal/testsupport/integrationtest/session.go:585`, `harness.go:1155,1197`, `crypto.go:160` (stale comment), `internal/testsupport/integrationtest/real_abac_test.go:30` (builds `"location:"+id` — flip to `world.LocationStream`; breaks silently post-migration otherwise)
+
+- [ ] **Step 1: Replace the remaining callers**
+
+Replace each remaining `subjectxlate.Legacy(x, gid)` with
+`eventbus.Qualify(gid, x)` and each `subjectxlate.ToLegacy(sub, gid)` with a
+direct use of the already-dot subject (drop the call). The test harness
+`session.go:585` and `harness.go:1155,1197` use `Qualify`; update the
+`crypto.go:160` doc-comment to drop the `subjectxlate` reference.
+
+- [ ] **Step 2: Delete the package**
+
+```bash
+rm internal/eventbus/subjectxlate/subjectxlate.go internal/eventbus/subjectxlate/subjectxlate_test.go
+```
+
+- [ ] **Step 3: Verify the build and full unit suite**
+
+Run: `task build && task test`
+Expected: PASS — no remaining importers of `subjectxlate`.
+
+- [ ] **Step 4: Commit**
+
+`refactor(eventbus): delete subjectxlate shim — dot subjects are canonical (holomush-rops)`
+
+---
+
+### Task 8: Invariant tests — INV-ROPS-3 (eradication), INV-ROPS-4/6/7/8
+
+**Files:**
+
+- Create: `internal/test/invariants/colon_eradication_test.go` (INV-ROPS-3 + bijection)
+- Delete: `internal/test/invariants/scene_subjects_test.go` (INV-P4-1, subsumed); remove its entry from `inv_p4_coverage_meta_test.go`
+- Create: `test/integration/streams/rops_test.go` (INV-ROPS-4/7/8; `//go:build integration`)
+- Test: the above
+
+- [ ] **Step 1: Write the eradication meta-test (INV-ROPS-3)**
+
+Model on the deleted `scene_subjects_test.go`, but **walk the tree** (do not use a
+fixed file list) and **fail on a missing root** (no `t.Skipf`):
+
+```go
+// internal/test/invariants/colon_eradication_test.go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package invariants
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestINV_ROPS_3_NoColonStreamLiterals asserts no production Go/TS source
+// contains a colon-style pub/sub STREAM literal outside the ABAC layer.
+// Supersedes INV-P4-1 with a repo-wide scan. Roots MUST exist (fail, not skip).
+//
+// Colon type-prefixes legitimately appear as ABAC SUBJECT literals
+// ("character:"+id for NewAccessRequest) in production files OUTSIDE
+// internal/access/ (scope_floor.go:93, auth_handlers.go:876,
+// pluginauthz/evaluate.go:65). Content alone cannot distinguish an ABAC subject
+// from a missed stream producer, so the scan skips: (a) comment lines, and
+// (b) any line bearing the explicit exemption marker "rops:abac-subject" — which
+// those three sites carry (added in Task 5). This mirrors INV-P4-1's
+// abacContextMarkers approach, made explicit per-line.
+func TestINV_ROPS_3_NoColonStreamLiterals(t *testing.T) {
+	roots := []string{"../../../internal", "../../../pkg", "../../../plugins", "../../../cmd"}
+	pattern := regexp.MustCompile(`"(location|character|notifications|scene):`)
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		require.NoErrorf(t, err, "scan root missing: %s", root) // fail, never skip
+		require.True(t, info.IsDir())
+	}
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				// allowlist: ABAC policy-DSL layer keeps colon type-prefixes.
+				if strings.Contains(path, "internal/access") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			require.NoError(t, rerr)
+			for i, raw := range strings.Split(string(data), "\n") {
+				if !pattern.MatchString(raw) {
+					continue
+				}
+				line := strings.TrimSpace(raw)
+				if strings.HasPrefix(line, "//") || strings.HasPrefix(line, "*") {
+					continue // doc/comment line, not a producer
+				}
+				if strings.Contains(raw, "rops:abac-subject") {
+					continue // sanctioned ABAC-subject literal (Task 5 marker)
+				}
+				t.Errorf("INV-ROPS-3: colon-style stream literal in %s:%d:\n  %s", path, i+1, line)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
+}
+```
+
+- [ ] **Step 2: Remove INV-P4-1 and its bijection entry**
+
+```bash
+rm internal/test/invariants/scene_subjects_test.go
+```
+
+In `internal/test/invariants/inv_p4_coverage_meta_test.go`, delete the
+`TestINV_P4_1_NoColonStyleSceneSubjects` entry from the coverage map so
+`TestINV_P4_Coverage_Meta` stays green.
+
+- [ ] **Step 3: Write the integration invariants (INV-ROPS-4/7/8)**
+
+Write these as **plain-Go `func Test…(t *testing.T)`** tests (build-tag
+`//go:build integration`) using `integrationtest.Start(t)` + `testify` — the
+repo convention for harness-based integration tests (no Ginkgo suite bootstrap;
+unlike `test/integration/privacy/` which uses a Ginkgo suite, a new leaf dir does
+not need one, and testify-in-integration is established convention).
+
+The real harness API (verified in `internal/testsupport/integrationtest/`):
+`Start(t, opts...) *Server`; `Server.NewLocation(ctx) ulid.ULID`,
+`Server.GameID() string`, `Server.ConnectAuthed(ctx, charName) *Session`,
+`WithRealABAC()` (loads the actual seeds — use this for INV-ROPS-8, NOT a
+placeholder), `WithPolicyEngine(eng)`; `Session.EmitDirectEvent(ctx, stream,
+evType, payload []byte) error`, `Session.QueryStreamHistory(ctx, stream)
+([]*corev1.EventFrame, error)`, `Session.WaitForEvent(ctx, eventType)
+*corev1.EventFrame`. There is no `Subscribe`/`Received`/`EmitLocationEvent`
+shortcut — use emit-then-`WaitForEvent`/`QueryStreamHistory`. `EmitDirectEvent`
+and `QueryStreamHistory` take the **relative** stream ref (`world.LocationStream(id)`);
+the harness qualifies via the same `eventbus.Qualify` path the production server
+uses (after Task 7 updates `session.go:585`).
+
+```go
+// test/integration/streams/rops_test.go
+//go:build integration
+
+package streams
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+	"github.com/holomush/holomush/internal/world"
+)
+
+// INV-ROPS-4: an event emitted to a location's dot stream is delivered to a
+// session present at that location — proving producer subject (world.LocationStream
+// → Qualify) equals the subscriber filter the harness derives the same way.
+func TestINV_ROPS_4_ProducerSubscriberSymmetry(t *testing.T) {
+	ctx := context.Background()
+	s := integrationtest.Start(t)
+	locID := s.NewLocation(ctx)
+	sess := s.ConnectAuthed(ctx, "alice")
+	// Place alice at locID and focus the location stream (use the harness move/
+	// focus helpers — confirm exact names in harness.go at implementation time).
+	require.NoError(t, sess.EmitDirectEvent(ctx, world.LocationStream(locID), "say", []byte(`{"text":"hi"}`)))
+	frame := sess.WaitForEvent(ctx, "say")
+	require.NotNil(t, frame, "event emitted to dot location stream must be delivered")
+}
+
+// INV-ROPS-7: a late joiner cannot read pre-join history (scope floor applied),
+// and the read is authorized by the I-17 membership gate, not ABAC fall-through.
+func TestINV_ROPS_7_LateJoinerFloorAndMembershipGate(t *testing.T) {
+	ctx := context.Background()
+	s := integrationtest.Start(t)
+	locID := s.NewLocation(ctx)
+	emitter := s.ConnectAuthed(ctx, "early")
+	require.NoError(t, emitter.EmitDirectEvent(ctx, world.LocationStream(locID), "say", []byte(`{"text":"pre"}`)))
+	// late joiner connects AFTER the pre-join event; assert QueryStreamHistory
+	// for the location stream omits the pre-join frame (LocationArrivedAt floor).
+	late := s.ConnectAuthed(ctx, "late")
+	frames, err := late.QueryStreamHistory(ctx, world.LocationStream(locID))
+	require.NoError(t, err)
+	// assert no frame predates late's arrival; and (per the pkixe tell) that the
+	// authorization path was the I-17 membership gate, not ABAC default-deny —
+	// assert via the harness's decision/log capture, not just the allow outcome.
+	_ = frames
+}
+
+// INV-ROPS-8: with the real seeded engine, a co-located character can emit+read
+// its dot location stream; a non-co-located character is denied.
+func TestINV_ROPS_8_LocationSeedAuthorization(t *testing.T) {
+	ctx := context.Background()
+	s := integrationtest.Start(t, integrationtest.WithRealABAC())
+	locID := s.NewLocation(ctx)
+	resident := s.ConnectAuthed(ctx, "resident") // place at locID
+	require.NoError(t, resident.EmitDirectEvent(ctx, world.LocationStream(locID), "say", []byte(`{"text":"hi"}`)))
+	// outsider at a DIFFERENT location must be denied emit/read on locID's stream.
+	otherLoc := s.NewLocation(ctx)
+	outsider := s.ConnectAuthed(ctx, "outsider") // place at otherLoc
+	err := outsider.EmitDirectEvent(ctx, world.LocationStream(locID), "say", []byte(`{"text":"no"}`))
+	require.Error(t, err, "non-co-located emit must be denied by seed:player-stream-emit")
+}
+```
+
+The `// place at …` / decision-capture bodies are wired against the harness's
+character-placement and focus helpers at implementation time; the method calls
+shown above are all real. The INV-ROPS-7 test MUST assert the read was authorized
+**by the membership gate**, not ABAC fall-through (per the `pkixe` tell — the
+empty `policy_id` + "by ABAC" log line).
+
+- [ ] **Step 4: Write INV-ROPS-6 role-split unit test**
+
+There is **no** `access.CharacterSubject` builder (verified: `internal/access`
+exports only `ParseSubject`). The canonical colon ABAC-subject construction site
+is `internal/grpc/scope_floor.go:93` (`"character:"+info.CharacterID.String()`).
+Assert both forms directly — the stream builder is dot, the ABAC subject literal
+stays colon — without introducing a builder:
+
+```go
+// internal/grpc/stream_access_test.go — add
+func TestRoleSplitCharacterStreamDotABACSubjectColon(t *testing.T) {
+	id := ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	// Stream form: dot-relative (this migration).
+	require.Equal(t, "character."+id.String(), world.CharacterStream(id))
+	// ABAC subject form: colon — unchanged, as built at scope_floor.go:93.
+	abacSubject := "character:" + id.String()
+	require.True(t, strings.HasPrefix(abacSubject, "character:"))
+}
+```
+
+- [ ] **Step 5: Run the invariant tests**
+
+Run: `task test -- ./internal/test/invariants/ ./internal/grpc/` then `task test:int -- ./test/integration/streams/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+`test(rops): INV-ROPS-3/4/6/7/8 + retire INV-P4-1 (holomush-rops)`
+
+---
+
+### Task 9: Docs, ADR amendment, stale comments
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md` §3 (iwzt stream-type table → dot)
+- Modify: `docs/superpowers/specs/2026-04-06-scenes-and-rp-design-v2.md` §3.1 (stream-naming table; notifications row)
+- Modify: `.claude/rules/event-conventions.md` (dot-only subject naming)
+- Modify: `site/src/content/docs/contributing/explanation/architecture.md` (stale pre-cutover model, `ec22.18`)
+- Modify: `docs/adr/holomush-s9nu-scene-subject-atomic-migration.md` (amend Consequences: INV-P4-1 superseded by INV-ROPS-3)
+- Modify: `internal/grpc/query_stream_history.go:576-578` (stale doc-comment)
+
+- [ ] **Step 1: Update the spec/rules/docs tables**
+
+Rewrite each stream-naming table cell from colon to dot form. In
+`event-conventions.md`, state that domain-relative dot references are the only
+form producers emit and the host qualifies with `events.<gid>.`.
+
+- [ ] **Step 2: Amend ADR `holomush-s9nu`**
+
+Add an addendum to the Consequences section: "INV-P4-1's 3-file scene scan is
+superseded by INV-ROPS-3 (repo-wide colon-stream-literal gate, `holomush-rops`).
+The dot-style scene migration this ADR recorded is now the universal stream
+form." Update the bd decision record per the `dev-flow:evolve-adr` flow.
+
+- [ ] **Step 3: Fix the stale Go doc-comments**
+
+Rewrite the comments that describe colon-delimited streams / `subjectxlate`
+translation (now gone) to the dot form:
+
+- `internal/grpc/query_stream_history.go:576-578` ("colon-delimited ... the web
+  client expects").
+- `internal/grpc/server.go:211` and `:655` (e.g. `"character:01ABC"` translation
+  examples — `:655` mentions "F5 migrates", which this work completes).
+- `internal/plugin/pluginauthz/evaluate.go:247` (the `"character:01ABC" →
+  "character"` parse example — clarify it is an ABAC subject, not a stream).
+
+(These comment lines are skipped by INV-ROPS-3's comment-skip rule, so they are
+hygiene, not a CI blocker — but leaving them stale misleads future readers.)
+
+- [ ] **Step 4: Verify docs lint**
+
+Run: `task lint:markdown` and `task lint:proto`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+`docs(rops): dot-style stream docs + s9nu ADR amendment (holomush-rops)`
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green (fast lane).
+- [ ] `task pr-prep:full` green (this diff touches int + E2E surface — Subscribe/QueryStreamHistory + scene/privacy integration suites).
+- [ ] `rg -n '"(location|character|notifications|scene):' internal pkg plugins cmd | rg -v internal/access` returns nothing (INV-ROPS-3 holds manually).
+- [ ] `holomush-pkixe` verified fixed by this work (scene members read their own history via the I-17 gate); close it with evidence.
+- [ ] `holomush-ofpi` verified fixed (Subscribe scope-floor sees qualified subjects); close it.
+- [ ] `holomush-ec22.3` closed as superseded (subjectxlate deleted).
+- [ ] `code-reviewer` + `abac-reviewer` run before push (touches `internal/access/` + I-17 gate).

--- a/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
+++ b/docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md
@@ -296,12 +296,18 @@ Expected: PASS. (Wire stays correct: `subjectxlate.Legacy("location.<id>")` ==
 
 ---
 
-### Task 3: Lua SDK emitter emits dot-relative references
+### Task 3: Lua emit layer emits dot-relative references
+
+Covers both Lua emit paths: the `pkg/holo` SDK constants AND the in-tree
+`core-communication` plugin, which builds subjects **inline in Lua** (it does not
+use the SDK constants). Both reach `event_emitter.go:207`, which qualifies with
+the gameID — so both must emit the relative dot form, not colon.
 
 **Files:**
 
 - Modify: `pkg/holo/emit.go:18-22` (constants), `:54-88` (methods unchanged in shape)
-- Test: `pkg/holo/emit_test.go`
+- Modify: `plugins/core-communication/main.lua:76,121,156,178,276,397,398,443` (inline `subject =` colon → dot)
+- Test: `pkg/holo/emit_test.go`, plus the `core-communication` integration/behavior coverage (say/pose/ooc/page/whisper/pemit/emit)
 
 - [ ] **Step 1: Update the failing test**
 
@@ -342,14 +348,38 @@ const (
 concatenate the prefix; only the prefix value changes. Update their doc-comments
 that say `"location:<id>"` to `"location.<id>"`.)
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Flip the inline Lua subjects in `core-communication/main.lua`**
 
-Run: `task test -- ./pkg/holo/`
-Expected: PASS
+The plugin returns events with inline-built `subject =` strings. Flip the colon
+to dot at all 8 sites (the `type = "core-communication:say"` colons are
+event-type names — `plugin:verb` form — and stay):
 
-- [ ] **Step 5: Commit**
+```lua
+        {subject = "location." .. ctx.location_id, type = "core-communication:say", payload = payload}
+        {subject = "location." .. ctx.location_id, type = "core-communication:pose", payload = payload}
+        {subject = "location." .. ctx.location_id, type = "core-communication:ooc", payload = payload}
+        {subject = "location." .. loc, type = "emit", payload = payload}
+        {subject = "character." .. target_session.character_id, type = "core-communication:page", payload = payload}
+        {subject = "location." .. loc, type = "core-communication:whisper_notice", payload = notice_payload}
+        {subject = "character." .. target.character_id, type = "core-communication:whisper", payload = whisper_payload}
+        {subject = "character." .. target_session.character_id, type = "core-communication:pemit", payload = payload}
+```
 
-`refactor(holo): Lua SDK emits dot-relative stream references (holomush-rops)`
+Why it matters: these bypass `pkg/holo` and reach `event_emitter.go:207`. After
+Task 7 replaces `subjectxlate.Legacy` with `eventbus.Qualify`, a colon subject
+(`"location:01ABC"`) qualifies to `"events.main.location:01ABC"`, which fails
+`NewSubject` token validation (the colon is not in `[A-Za-z0-9_-]`) — breaking
+every say/pose/ooc/page/whisper/pemit/emit command. The dot form qualifies cleanly.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `task test -- ./pkg/holo/` and the `core-communication` plugin tests
+(`task test -- ./plugins/core-communication/...` and the comms integration suite).
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+`refactor(holo,core-communication): Lua emit layer emits dot-relative stream references (holomush-rops)`
 
 ---
 
@@ -693,7 +723,7 @@ Expected: PASS
 **Files:**
 
 - Delete: `internal/eventbus/subjectxlate/subjectxlate.go`, `subjectxlate_test.go`
-- Modify: `internal/grpc/server.go:663`, `cmd/holomush/sub_grpc.go`, `internal/admin/readstream/`, `internal/testsupport/integrationtest/session.go:585`, `harness.go:1155,1197`, `crypto.go:160` (stale comment), `internal/testsupport/integrationtest/real_abac_test.go:30` (builds `"location:"+id` — flip to `world.LocationStream`; breaks silently post-migration otherwise)
+- Modify: `internal/grpc/server.go:663`, `cmd/holomush/sub_grpc.go`, `internal/admin/readstream/`, `internal/testsupport/integrationtest/session.go:585`, `harness.go:1155,1197`, `crypto.go:160` (stale comment), `internal/testsupport/integrationtest/real_abac_test.go:30` and `harness_smoke_test.go:135` (both build `"location:"+id` for `EmitDirectEvent` — flip to `world.LocationStream`; break at `pr-prep:full` post-migration otherwise — `_test.go` so INV-ROPS-3 won't catch them)
 
 - [ ] **Step 1: Replace the remaining callers**
 
@@ -785,7 +815,11 @@ func TestINV_ROPS_3_NoColonStreamLiterals(t *testing.T) {
 				}
 				return nil
 			}
-			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			// Scan Go AND Lua: core-communication/main.lua builds stream
+			// subjects inline (bypasses pkg/holo), so .lua must be covered.
+			isGo := strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go")
+			isLua := strings.HasSuffix(path, ".lua")
+			if !isGo && !isLua {
 				return nil
 			}
 			data, rerr := os.ReadFile(path)

--- a/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
+++ b/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
@@ -78,9 +78,9 @@ A producer/classifier survey narrows the bead's 2026-05-20 discovered scope:
 | Stream | Colon (today) | Dot (canonical) | Live code? |
 | --- | --- | --- | --- |
 | Location | `location:<ULID>` | `events.<gid>.location.<ULID>` | **Yes** — `internal/core/engine.go:73,96`, `internal/world/events.go`, `internal/grpc/server.go:1294`, grid focus routing, scope floor, ABAC `StreamProvider`, **Lua SDK `pkg/holo/emit.go` `Emitter.Location()`** |
-| Character (personal) | `character:<ULID>` | `events.<gid>.character.<ULID>` | **Yes** — `internal/grpc/auth_handlers.go:876`, `stream_access.go`, `scope_floor.go`, `internal/grpc/server.go:1246`, `internal/core/event.go:17`, **Lua SDK `pkg/holo/emit.go` `Emitter.Character()`** |
+| Character (personal) | `character:<ULID>` | `events.<gid>.character.<ULID>` | **Yes** — `stream_access.go`, `scope_floor.go`, `internal/grpc/server.go:1246`, `internal/core/event.go:17`, `internal/core/engine_end_session.go:62` (`NewEvent` producer), **Lua SDK `pkg/holo/emit.go` `Emitter.Character()`** |
 | Global (ambient) | `global` | `events.<gid>.global` | **Yes** — **Lua SDK `pkg/holo/emit.go:21` `Emitter.Global()`** emits to stream name `"global"`. This is a live pub/sub stream, not merely an ABAC scope. |
-| Scene IC/OOC | *(already dot, `s9nu`)* | `events.<gid>.scene.<ULID>.{ic,ooc}` | Done — this design only extends its meta-test |
+| Scene IC/OOC | partly dot (`s9nu`) | `events.<gid>.scene.<ULID>.{ic,ooc}` | **Mostly done** — emit path + classifiers are dot (`s9nu`). BUT `internal/grpc/focus/scenepolicy/policy.go:29-30` `StreamsFor` still builds colon `scene:<id>:ic/:ooc` **subscription filters** — a producer `s9nu` missed (latent `ofpi`-class bug). This design flips it + extends the meta-test. |
 | Notifications | `notifications:<charID>` | `events.<gid>.notification.<charID>` | **No live producer** — design-reference only (scenes v2 §3.1, future Phase 10). Spec-text update; no code to flip. |
 | `system` | — | — | **Not a pub/sub stream** — ABAC actor-kind / audit source only. No emitter targets it as a stream. Out of scope. |
 
@@ -140,8 +140,17 @@ distinct, and the stream builders emit the **domain-relative dot reference**
   `world.StreamPrefixLocation/Character` (`events.go:23-24`) and
   `core.StreamPrefixCharacter` (`event.go:17`) are deleted; callers route through
   the builders or emit relative dot refs inline.
-- ABAC subjects continue through the existing `internal/access` builders
-  (`character:<id>`), **untouched** — they are not stream names.
+- ABAC subjects/resources are constructed through the **existing**
+  `internal/access` builders — `access.CharacterSubject(id)`,
+  `access.SceneResource(id)`, `access.PluginSubject(name)`, etc.
+  (`internal/access/prefix.go`), already the established convention across
+  `world/`, `command/`, `grpc/`, `hostfunc/`. These return the colon form
+  (`character:<id>`) and live inside the scan-allowlisted `internal/access/`
+  package. A handful of straggler host sites still inline `"character:"+id`;
+  routing them through the builders (a cleanup `prefix.go` explicitly calls for)
+  means **no inline colon literal survives in host code outside
+  `internal/access/`** — making the role split a real package boundary, not a
+  convention.
 - `global` (`pkg/holo/emit.go:21`) is already a bare token with no separator; its
   relative reference is unchanged. Only the host qualifier must keep producing
   `events.<gid>.global` after the shim is gone.
@@ -361,14 +370,23 @@ boundary test as noted. RFC2119 keywords are normative.
 - **INV-ROPS-2** — Unclassifiable stream names are rejected at handler entry
   with `INVALID_ARGUMENT`, never routed to a default authorization branch.
 - **INV-ROPS-3 (eradication gate)** — A CI meta-test asserts no production Go or
-  TypeScript source contains a colon-style pub/sub stream literal (`location:`,
-  `character:`, `notifications:`, `scene:` as a stream name) outside the ABAC
-  layer (`internal/access/` + the policy DSL, the sole allowlist). This
-  **subsumes** INV-P4-1's 3-file scene scope with a strictly stronger repo-wide
-  gate; INV-P4-1 is removed in favor of it. The scan MUST **fail** (not
-  `t.Skipf`) if a target file or directory is missing — the old INV-P4-1
-  skip-on-missing logic (`scene_subjects_test.go:62-73`) is a false-pass trap a
-  repo-wide scan cannot inherit.
+  TypeScript source contains a colon-style entity-prefix literal (`location:`,
+  `character:`, `notifications:`, `scene:`, `plugin:`, …) as a **stream name**.
+  Distinguishing a stream-name literal from a legitimate ABAC subject/resource
+  literal is solved structurally, not heuristically: **ABAC subjects/resources
+  are built only via `internal/access` builders** (`access.CharacterSubject`,
+  `SceneResource`, …), which live in the scan's sole allowlisted package. The
+  scan therefore: (a) skips `internal/access/`; (b) skips comment lines; (c)
+  skips lines that call an ABAC evaluation API (`Evaluate(`, `CanPerformAction(`,
+  `NewAccessRequest(`, `.Grant(`) or carry the `// ABAC resource ref` marker —
+  the residual for plugin code (`plugins/core-scenes/`), which cannot import
+  `internal/access`. Host code has **zero** inline colon literals (all route
+  through the builders), so any host hit is unambiguously a stream-producer bug.
+  This **subsumes** INV-P4-1's 3-file scene scope with a strictly stronger
+  repo-wide gate; INV-P4-1 is removed in favor of it. The scan MUST **fail** (not
+  `t.Skipf`) on a missing root — the old INV-P4-1 skip-on-missing logic
+  (`scene_subjects_test.go:62-73`) is a false-pass trap a repo-wide scan cannot
+  inherit.
 - **INV-ROPS-4 (producer↔subscriber symmetry)** — An integration test (real
   embedded NATS via `eventbustest`) emits through the production producer path
   for each migrated stream type and asserts a subscriber built from the

--- a/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
+++ b/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
@@ -1,0 +1,460 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Colon-Style Pub/Sub Subject Eradication — Design
+
+**Bead:** `holomush-rops`
+**Status:** design (brainstormed 2026-05-29)
+**Supersedes / subsumes:** `holomush-ec22.3` (subjectxlate endgame decision), `holomush-pkixe` (scene history denial), `holomush-ofpi` (Subscribe-path scope-floor mismatch)
+
+## Overview
+
+HoloMUSH carries two representations for every pub/sub stream name. The
+JetStream-native **dot form** (`events.<gid>.<domain>.<id>[.<facet>]`) is what
+travels on the wire and into the durable audit; the legacy **colon form**
+(`location:<id>`, `character:<id>`) is what internal Go code, the ABAC stream
+classifiers, the gRPC `Stream` wire fields, and the SvelteKit client all speak.
+The `internal/eventbus/subjectxlate/` package bridges the two at every publish,
+every history read, and every translate-back-for-client.
+
+`subjectxlate`'s own header names the migration that retires it — "F5 will
+migrate plugin/host code to JetStream-native subjects, at which point the
+translation becomes a no-op." That migration never shipped with the JetStream
+cutover. The shim documented as transitional became permanent infrastructure,
+and the dual representation is an active source of privacy-relevant bugs: a
+stream-name classifier that recognizes one form but receives the other skips
+its authorization branch (`holomush-pkixe`, `holomush-ofpi`).
+
+This design eradicates the colon form as a **pub/sub stream name**, end to end,
+in a single coordinated change, and deletes `subjectxlate`.
+
+### Scenes already migrated; this finishes the job
+
+Scenes Phase 4 (`holomush-5rh.13`, ADR `holomush-s9nu`) migrated **scene** IC/OOC
+subjects to dot form and narrowed the scene classifiers to dot-only. It did so
+on a premise that was not yet true — that read-path callers pass dot form — while
+`ToLegacy` (`internal/grpc/server.go:663`) still hands clients colon-style scene
+names. That gap is `holomush-pkixe`. This design makes the premise true for every
+stream type, so the scene work and the `pkixe`/`ofpi` symptoms resolve together.
+
+## Goals
+
+- Every pub/sub stream name has exactly one representation — the dot form —
+  in producers, classifiers, gRPC wire fields, the SvelteKit client, the admin
+  break-glass read path, durable audit, specs, and docs.
+- `internal/eventbus/subjectxlate/` is deleted.
+- The colon form survives **only** as an ABAC policy-DSL resource/subject
+  identifier (`character:<id>`, `scene:<id>`, `stream:<name>`, `plugin:<id>`),
+  which is policy serialization, not a pub/sub subject.
+- The privacy gate behavior that the dual representation broke or endangered
+  (I-17 membership gate, temporal scope floor) is proven correct by test, not
+  merely incidentally fixed.
+
+## Non-goals
+
+- **ABAC resource/subject TYPE-PREFIXES are not touched.** `character:`,
+  `scene:`, `stream:`, `plugin:`, `system` as policy-DSL *type-prefixes*
+  (`internal/access/`) keep their colon convention. This is the explicit
+  boundary of `holomush-rops` and a hard constraint of this design (INV-ROPS-1,
+  INV-ROPS-6). **However, DSL policy text that embeds a pub/sub stream *name* is
+  not exempt** — the two location seeds (`seed.go:60,66`) match
+  `resource.stream.name like "location:*"`, where `location:` is an embedded
+  stream name, not a type-prefix. Those embedded names flip and the seeds are
+  updated in lockstep (§1 seed clause, INV-ROPS-8). The "ABAC layer is the
+  allowlist" framing applies only to the INV-ROPS-3 string scan, not to runtime
+  policy semantics.
+- **No backward-compatibility window.** The client and server ship in one
+  deploy; there are no externally-pinned clients. No dual-format transition,
+  no reserved-field deprecation, no migration shim.
+- **No new stream domains.** This renames existing streams; it does not add
+  notification or ambient stream infrastructure.
+
+## Live migration surface (grounded 2026-05-29)
+
+A producer/classifier survey narrows the bead's 2026-05-20 discovered scope:
+
+| Stream | Colon (today) | Dot (canonical) | Live code? |
+| --- | --- | --- | --- |
+| Location | `location:<ULID>` | `events.<gid>.location.<ULID>` | **Yes** — `internal/core/engine.go:73,96`, `internal/world/events.go`, `internal/grpc/server.go:1294`, grid focus routing, scope floor, ABAC `StreamProvider`, **Lua SDK `pkg/holo/emit.go` `Emitter.Location()`** |
+| Character (personal) | `character:<ULID>` | `events.<gid>.character.<ULID>` | **Yes** — `internal/grpc/auth_handlers.go:876`, `stream_access.go`, `scope_floor.go`, `internal/grpc/server.go:1246`, `internal/core/event.go:17`, **Lua SDK `pkg/holo/emit.go` `Emitter.Character()`** |
+| Global (ambient) | `global` | `events.<gid>.global` | **Yes** — **Lua SDK `pkg/holo/emit.go:21` `Emitter.Global()`** emits to stream name `"global"`. This is a live pub/sub stream, not merely an ABAC scope. |
+| Scene IC/OOC | *(already dot, `s9nu`)* | `events.<gid>.scene.<ULID>.{ic,ooc}` | Done — this design only extends its meta-test |
+| Notifications | `notifications:<charID>` | `events.<gid>.notification.<charID>` | **No live producer** — design-reference only (scenes v2 §3.1, future Phase 10). Spec-text update; no code to flip. |
+| `system` | — | — | **Not a pub/sub stream** — ABAC actor-kind / audit source only. No emitter targets it as a stream. Out of scope. |
+
+The live code migration is **location + character + global**, spanning host
+producers (`internal/core`, `internal/world`, `internal/grpc`), the ABAC layer
+(§1 seed clause), and the **Lua plugin SDK** (`pkg/holo/emit.go`). Notifications
+is a documentation correction; scene is a meta-test extension. This refines the
+bead's broader 2026-05-20 guess; `global` and the `pkg/holo` SDK surface were
+surfaced during design review and correct an earlier under-count.
+
+### Completeness mechanism (not an exhaustive manifest)
+
+The per-step file lists below are **representative anchors**, not a complete
+call-site manifest. Producing the exhaustive inventory is the `writing-plans`
+job. Completeness is *guaranteed mechanically*, not by this prose:
+
+- **INV-ROPS-3** (repo-wide string scan) fails CI on any surviving colon stream
+  literal in non-`internal/access/` source — including test files with inline
+  literals (e.g. `dispatcher_test.go`, `pkg/holo/emit_test.go`).
+- **The compiler** forces every consumer of a deleted `StreamPrefix*` constant
+  (e.g. `server.go:1246,1294`) to surface as a build error.
+
+A file missed in the prose below is therefore caught at build or CI time, never
+shipped. The plan enumerates; these two gates enforce.
+
+## Architecture
+
+### §1 Canonical model and the role split
+
+After this work, a pub/sub stream name is **only** the dot form. There is no
+second representation to translate to or from, so `subjectxlate` is deleted
+rather than narrowed.
+
+The central hazard is the string `character:<id>`, which serves two unrelated
+roles today, both built as `"character:" + id`:
+
+1. a **pub/sub stream name** (the character's personal event stream) — flips to
+   `events.<gid>.character.<id>`;
+2. an **ABAC subject/resource ID** in the policy DSL (e.g.
+   `NewAccessRequest("character:"+id, …)` at `scope_floor.go:93`) — stays colon.
+
+> **INV-ROPS-1.** Colon-style survives only as an ABAC policy-DSL
+> resource/subject identifier. It MUST NOT appear as a pub/sub stream name in
+> any producer, classifier, wire field, or client. The two roles are
+> disambiguated **by role at the construction site**, never by sniffing the
+> string at runtime.
+
+**Mechanism.** The stream builders and the ABAC subject builders are kept
+distinct, and the stream builders emit the **domain-relative dot reference**
+(no gameID — see the next subsection on where gameID enters):
+
+- The existing relative builders change their separator only:
+  `world.LocationStream(id) → "location.<id>"` (was `"location:" + id`),
+  `world.CharacterStream(id) → "character.<id>"`,
+  `world.BroadcastLocationStream() → "location.*"`. Signatures are unchanged
+  (id only); just the `:`→`.` in the returned reference. The colon constants
+  `world.StreamPrefixLocation/Character` (`events.go:23-24`) and
+  `core.StreamPrefixCharacter` (`event.go:17`) are deleted; callers route through
+  the builders or emit relative dot refs inline.
+- ABAC subjects continue through the existing `internal/access` builders
+  (`character:<id>`), **untouched** — they are not stream names.
+- `global` (`pkg/holo/emit.go:21`) is already a bare token with no separator; its
+  relative reference is unchanged. Only the host qualifier must keep producing
+  `events.<gid>.global` after the shim is gone.
+
+Today the stream form and the ABAC-subject form are both an inline
+`"character:" + id`; routing stream construction through the relative builders
+(which emit `character.<id>`) while ABAC subjects keep `character:<id>` makes the
+two roles structurally unconflatable. Note `world.CharacterStream(id)` returns a
+relative reference, **not** a valid `eventbus.Subject` — `NewSubject` requires the
+`events.` prefix (`types.go:257`), which only the host qualifier adds.
+
+### The `stream:` ABAC resource straddle
+
+The ABAC *resource* for a stream is `stream:<name>`. The `stream:` type-prefix
+is policy serialization and stays colon; the embedded `<name>` is a pub/sub
+stream name and flips to dot. So the resource string becomes
+`stream:events.<gid>.location.<ULID>`.
+
+This forces a lockstep change in `StreamProvider.ResolveResource`
+(`internal/access/policy/attribute/stream.go:46`), which today extracts the
+`resource.location` DSL attribute via `strings.HasPrefix(id, "location:")`. If
+the embedded name flips to dot while this parser still matches `location:`, the
+`location` attribute is silently omitted and every `resource.location ==
+principal.location` policy fails closed. The parser MUST become dot-aware in the
+same change. This file is the `abac-providers.md` canonical fail-safe example,
+so its fix follows the "omit, do not sentinel" rule (INV-ROPS-7's provider test).
+
+### The two location seed policies and the `has_location` witness
+
+`seed:player-stream-emit` (`internal/access/policy/seed.go:60`) and
+`seed:player-location-stream-read` (`:66`) each match:
+
+```text
+resource.stream.name like "location:*" && resource.stream.location == principal.character.location
+```
+
+The *access control* is the second clause — co-location, attribute-based,
+**unchanged** by the flip. The `like "location:*"` clause is a **stream-type
+guard** ("is this a location stream at all?"). Its job is to stop a non-location
+stream that happens to carry a matching `location` attribute from satisfying the
+co-location clause alone (a fail-open it prevents). Under the flip, the name is
+`events.<gid>.location.<id>` and `like "location:*"` matches nothing, silently
+revoking location emit/read for every non-staff character — a fail-closed
+regression no classifier or string-scan invariant catches (the INV-ROPS-3 scan
+excludes `internal/access/`).
+
+The fix is to replace the name-pattern type-guard with the **`has_location`
+witness**: `StreamProvider` MUST emit a `has_location` boolean alongside the
+optional `location` attribute (per the `abac-providers.md` witness convention,
+which the current provider omits), and the seeds test that witness instead of
+the name. This decouples the seeds from the subject-string format entirely — a
+future format change cannot re-break them. The co-location clause is untouched.
+Pinned by INV-ROPS-8.
+
+### Relative reference vs qualified subject — where gameID enters
+
+The fully-qualified dot subject embeds the gameID (`events.<gid>.location.<id>`),
+but the producers and clients that name streams **do not hold the gameID**.
+Today `subjectxlate.Legacy` injects it host-side at two boundaries:
+
+- **Emit:** a plugin emits `subjectRaw = "location:<id>"` (no gameID); the host
+  prepends `events.<gid>.` at `internal/plugin/event_emitter.go:201-207`. Host
+  producers (`engine.go:73`) likewise set a colon `Stream` field qualified
+  downstream.
+- **Read:** the client sends a colon `req.Stream`; the classifiers at
+  `query_stream_history.go:173,177` run on that raw field, while
+  `fetchHistoryFromBus` (`:425`) qualifies it with the session gameID for the
+  bus fetch.
+
+So deleting `subjectxlate` does not just swap `:`→`.` — it relocates **where
+gameID enters the subject**. This design fixes that explicitly:
+
+> **Canonical forms.** A *domain-relative reference* (`location.<id>`,
+> `character.<id>`, `scene.<id>.ic`, `global`) is what producers and clients —
+> which lack the gameID — emit. A *qualified subject*
+> (`events.<gid>.<relative>`) is what the bus, durable audit, and **all
+> classifiers** see. gameID is host/server-owned and is prepended at exactly two
+> boundaries, each replacing a `subjectxlate` call:
+>
+> - **Emit qualifier** — `event_emitter.go:207` (plugins) and the host core emit
+>   path prepend `events.<gid>.` to the producer's relative reference.
+> - **Read-entry qualifier** — `QueryStreamHistory` / `Subscribe` qualify
+>   `req.Stream` to the fully-qualified dot form from the **session** gameID
+>   **before** the classifier switch. Classifiers therefore only ever see the
+>   qualified form (matching `isSceneStream`'s existing `events.<gid>.…`
+>   expectation), and this is the single point where INV-ROPS-2 entry-rejection
+>   lives. This also subsumes the `pkixe`-era "normalize at entry" idea.
+
+This is why the §1 stream builders stay relative (`world.LocationStream(id) →
+"location.<id>"`, id only, no gameID): they produce the relative reference, and
+a single host-side **qualifier** prepends `events.<gid>.` before the result is
+turned into an `eventbus.Subject` (which `NewSubject` requires to start with
+`events.`). The qualifier is a small new helper — `eventbus.Qualify(gid,
+relativeRef) → events.<gid>.<relativeRef>` — that replaces the two
+`subjectxlate.Legacy` call sites (emit + read-entry). INV-ROPS-4 asserts the
+producer's relative reference, once qualified, equals the subject the classifier
+expects.
+
+### §2 I-17 classifiers and the fail-closed discipline
+
+The I-17 gate (`internal/grpc/stream_access.go`) decides whether a stream is
+private (membership-only, no ABAC override). `holomush-pkixe` proved that a
+classifier which receives a form it does not recognize returns "not private,"
+skips the membership gate, and falls through to the ABAC default branch — today
+a default-deny (fail-closed, broken reads), but a latent fail-**open** the moment
+any `stream:*` permit seed exists.
+
+Because the cutover is big-bang (below), the classifiers become **dot-only and
+reject colon outright**. There is no dual-format window, so there is no
+half-recognized state to fall through.
+
+Classifiers that flip (all `internal/grpc/`):
+
+| Classifier | Today | After |
+| --- | --- | --- |
+| `isPrivateStream` (`stream_access.go:70`) | `HasPrefix("character:")` ∨ `isSceneStream` | dot character ∨ `isSceneStream` |
+| `sessionHasMembership` (`stream_access.go:90`) | `TrimPrefix("character:")` | parse dot character subject |
+| `isLocationStream` (`scope_floor.go:69`) | `HasPrefix("location:")` | dot location shape-check |
+| `streamScopeFloor` character branch (`scope_floor.go:49`) | `HasPrefix("character:")` | dot character branch |
+
+Each classifier uses the exact-segment-count discipline `isSceneStream` already
+models (`len(parts) != N → false`; empty gid/id → false). A location stream is
+4 segments (`events.<gid>.location.<id>`); a scene stream is 5
+(`events.<gid>.scene.<id>.<facet>`); the segment count plus the domain token at
+`parts[2]` distinguishes them with no overlap.
+
+> **INV-ROPS-2.** `QueryStreamHistory` / `Subscribe` qualify `req.Stream` to the
+> fully-qualified dot form (from the session gameID) at handler entry, **before**
+> the classifier switch. A stream that does not qualify to a valid dot-style
+> private or public subject MUST be rejected there with `INVALID_ARGUMENT`, never
+> allowed to fall through the classifier chain to a default authorization branch.
+> Classifiers see only qualified subjects. This closes the `pkixe`/`ofpi`
+> fall-through class permanently and is the read-entry qualifier from §1.
+
+### §3 Cutover: one coordinated change
+
+There is no compatibility window to respect, and the chosen strategy is
+**big-bang**: flip the canonical form everywhere in a single PR and delete the
+shim in the same PR. Rationale: any intermediate state is a half-migrated
+classifier — exactly the `pkixe` failure mode. A zero-width dual-format window
+is the smallest possible fail-open surface.
+
+Within the single PR, edit in dependency order:
+
+1. **Constructors** — add the dot-style stream constructors (§1); add nothing to
+   the ABAC subject path. Establishes the role split before call sites move.
+2. **Producers** — emit dot directly:
+   - **Host:** `internal/core/engine.go:73,96`; `internal/world/events.go`
+     AND `internal/core/event.go:17` (delete the `StreamPrefix*` colon constants
+     in **both** files); `internal/grpc/auth_handlers.go:876`; the
+     `world.StreamPrefix*` consumers the compiler surfaces on deletion, including
+     `internal/grpc/server.go:1246,1294` (`dispatchDelivery` follower checks);
+     `core-communication` emit paths.
+   - **Lua plugin SDK:** `pkg/holo/emit.go` — `streamPrefixCharacter`,
+     `streamPrefixLocation`, `streamPrefixGlobal` constants and the
+     `Emitter.Character()` / `Location()` / `Global()` methods → emit a
+     **domain-relative dot reference** (`location.<id>`, `character.<id>`,
+     `global`); the SDK lacks the gameID, so it does NOT prepend `events.<gid>.`
+     (per §1, the host qualifier does). The change here is the separator
+     (`:`→`.`) and dropping the colon. Its tests (`pkg/holo/emit_test.go`)
+     hardcode colon expectations that update with it.
+   - **Test assertions** with inline colon literals (e.g.
+     `internal/grpc/dispatcher_test.go` `core.StreamPrefixCharacter` usages at
+     lines ~444/455/552/563 plus inline `"location:"`/`"character:"` literals) —
+     the plan enumerates these; INV-ROPS-3 backstops any miss.
+3. **Classifiers + ABAC provider** — flip the four `internal/grpc/` classifiers
+   (§2) and `StreamProvider.ResolveResource` (§1) in lockstep; `StreamProvider`
+   additionally emits the `has_location` witness (§1 seed clause / INV-ROPS-8).
+4. **ABAC seeds** — rewrite the `like "location:*"` type-guard in
+   `seed:player-stream-emit` (`seed.go:60`) and `seed:player-location-stream-read`
+   (`seed.go:66`) to test the `has_location` witness; leave the co-location
+   clause untouched. Bump each seed's `SeedVersion`.
+5. **Qualifiers + wire + shim deletion** — proto `Stream`/`streams` fields and
+   the SvelteKit client now carry domain-relative dot references (§1). **Replace**
+   (not merely delete) the two gameID qualifiers `subjectxlate` performed:
+   - **Emit qualifier** — `event_emitter.go:207` and the host core emit path
+     prepend `events.<gid>.` to the producer's relative reference directly.
+   - **Read-entry qualifier** — `QueryStreamHistory` / `Subscribe` qualify
+     `req.Stream` from the session gameID at entry (INV-ROPS-2), replacing the
+     downstream `subjectxlate.Legacy` at `query_stream_history.go:425,494`.
+
+   Then delete the remaining `subjectxlate.Legacy`/`ToLegacy` callers
+   (`server.go:663`, `sub_grpc.go`, `internal/admin/readstream/`, **and the test
+   harness `internal/testsupport/integrationtest/session.go:585` +
+   `harness.go:1155,1197`** — these fail compilation otherwise, taking
+   INV-ROPS-4's harness down with them; the stale doc-comment at `crypto.go:160`
+   also updates) and delete the `subjectxlate` package.
+6. **SvelteKit client** — `web/src/lib/backfill/*` constructs/consumes dot; its
+   tests update.
+7. **Invariant-test cleanup + specs / docs / rules** — remove INV-P4-1
+   (`internal/test/invariants/scene_subjects_test.go`) AND its entry in the
+   coverage bijection (`inv_p4_coverage_meta_test.go`) in the same change, or
+   `TestINV_P4_Coverage_Meta` fails on the dangling reference; iwzt §3
+   stream-type table; scenes-v2 §3.1 stream-naming table (incl. the notifications
+   row); `.claude/rules/event-conventions.md`; the stale
+   `site/docs/contributing/architecture.md` (`ec22.18`); and an **amendment to
+   ADR `holomush-s9nu`** recording that INV-P4-1 is superseded by INV-ROPS-3 (its
+   Consequences section otherwise misdescribes the codebase).
+
+### Sequencing relative to `pkixe`
+
+`holomush-pkixe`'s tactical "sniff both forms" fix was aborted (2026-05-29): it
+is blocked by INV-P4-1 (a CI meta-test forbidding colon `scene:` literals in the
+read-path files) and would manufacture the very half-migrated state this cutover
+eliminates. `pkixe` and `ofpi` are now blocked-by `rops`; this design is their
+fix. `pkixe`'s root-cause analysis — including the INV-P4-1 false-premise
+finding and the invariant-n temporal-floor leak — is direct input here.
+
+## Invariants
+
+All invariants are numbered, asserted by a test, and covered by a meta-test or
+boundary test as noted. RFC2119 keywords are normative.
+
+- **INV-ROPS-1** — Colon-style appears only as an ABAC policy-DSL identifier;
+  never as a pub/sub stream name. *(Enforced executably by INV-ROPS-3 +
+  INV-ROPS-6.)*
+- **INV-ROPS-2** — Unclassifiable stream names are rejected at handler entry
+  with `INVALID_ARGUMENT`, never routed to a default authorization branch.
+- **INV-ROPS-3 (eradication gate)** — A CI meta-test asserts no production Go or
+  TypeScript source contains a colon-style pub/sub stream literal (`location:`,
+  `character:`, `notifications:`, `scene:` as a stream name) outside the ABAC
+  layer (`internal/access/` + the policy DSL, the sole allowlist). This
+  **subsumes** INV-P4-1's 3-file scene scope with a strictly stronger repo-wide
+  gate; INV-P4-1 is removed in favor of it. The scan MUST **fail** (not
+  `t.Skipf`) if a target file or directory is missing — the old INV-P4-1
+  skip-on-missing logic (`scene_subjects_test.go:62-73`) is a false-pass trap a
+  repo-wide scan cannot inherit.
+- **INV-ROPS-4 (producer↔subscriber symmetry)** — An integration test (real
+  embedded NATS via `eventbustest`) emits through the production producer path
+  for each migrated stream type and asserts a subscriber built from the
+  production filter constructor receives it. Proves emit-subject == filter-string
+  end to end; the only guard against silent non-delivery, which neither the
+  string scan nor unit classifier tests can catch.
+- **INV-ROPS-5 (classifier non-collision)** — A table-driven unit test over the
+  four `internal/grpc/` classifiers asserts: a location stream is
+  public-not-scene; a character stream is private-not-scene; a scene stream is
+  private-and-scene; an unknown/malformed name is none. Guards against
+  segment-count confusion (4-segment location vs 5-segment scene) granting or
+  dropping the membership gate.
+- **INV-ROPS-6 (role split, both directions)** — For the same character ULID, a
+  test asserts the **stream** is dot (`events.<gid>.character.<id>`) and the
+  **ABAC subject** is colon (`character:<id>`). Makes INV-ROPS-1 executable and
+  guards against an over-eager sweep migrating the ABAC subject and silently
+  breaking character-principal policies.
+- **INV-ROPS-7 (temporal floor on every private stream)** — A test asserts a
+  late joiner cannot read pre-join history on each private stream type — the
+  scope floor (`JoinedAt` / `LocationArrivedAt`) is applied, not the zero-floor
+  default. Directly from `pkixe`'s invariant-n finding (colon scene streams leaked
+  pre-join history). Paired with a `StreamProvider` test asserting that, for a dot
+  location stream, `resource.location` is **populated** and the `has_location`
+  witness is `true`; and for non-location streams `location` is **absent** (not
+  empty-sentinel, per `abac-providers.md`) while `has_location` is **present and
+  false**.
+- **INV-ROPS-8 (location-seed authorization survives the flip)** — An integration
+  test seeds the engine and asserts: a co-located character can `emit` to and
+  `read` its own dot-form location stream, and a non-co-located character cannot.
+  Catches the silent fail-closed regression in `seed:player-stream-emit` /
+  `seed:player-location-stream-read` (the `like "location:*"` type-guard) that
+  the INV-ROPS-3 string scan cannot see because it excludes `internal/access/`.
+  Depends on the `has_location` witness (§1 seed clause).
+
+A meta-test (INV-2-style bijection) asserts every `INV-ROPS-*` number above maps
+to at least one test, so the set cannot silently shrink.
+
+## Testing strategy
+
+| Tier | Tests |
+| --- | --- |
+| Unit | INV-ROPS-5 classifier matrix; INV-ROPS-6 role split; `StreamProvider` dot-parse + `has_location` witness (INV-ROPS-7 pair); every constructor output parses as a valid `eventbus.NewSubject` (token-rule regression guard, plain test, not an INV) |
+| Integration (`//go:build integration`, `eventbustest`) | INV-ROPS-4 producer↔subscriber round-trip per stream type; INV-ROPS-2 handler-entry rejection; INV-ROPS-7 late-joiner temporal-floor and I-17-membership-gate-identity assertions on `QueryStreamHistory` + `Subscribe`; INV-ROPS-8 seeded location emit/read authorization (co-located permit, non-co-located deny) |
+| Meta | INV-ROPS-3 repo-wide colon-stream-literal scan, fail-on-missing-target (replaces INV-P4-1); INV-ROPS bijection registry test |
+
+I-17 identity assertions (INV-ROPS-7) check that a private read is authorized **by
+the membership gate**, not merely that it is allowed — per the `pkixe` tell (the
+empty `policy_id` + "by ABAC" log line). A regression that re-routes private
+reads through ABAC fails even when ABAC happens to permit.
+
+## Scope ledger
+
+**Explicitly NOT touched:**
+
+- ABAC policy-DSL resource/subject **type-prefixes** (`character:`, `scene:`,
+  `stream:`, `plugin:`, `system`) — `internal/access/`. INV-ROPS-1 / INV-ROPS-6.
+- Scene IC/OOC subjects — already dot (`s9nu`); only the meta-test scope changes.
+- `system` — ABAC actor-kind / audit source, not a pub/sub stream. No emitter
+  targets it; no stream is invented for it. *(`global`, by contrast, IS a live
+  stream via the Lua SDK and is in scope — see the surface table.)*
+- Notification stream infrastructure — no live producer; spec-text correction only.
+
+**Touched inside `internal/access/` despite the type-prefix exemption** (the
+boundary correction from design-review round 1):
+
+- `StreamProvider.ResolveResource` (`stream.go:46`) — dot-aware parse + new
+  `has_location` witness.
+- The two location seeds (`seed.go:60,66`) — `like "location:*"` type-guard →
+  `has_location` witness; co-location clause unchanged; `SeedVersion` bumped.
+
+These are the places where a pub/sub stream *name* is embedded in policy code;
+they flip even though the surrounding type-prefixes do not.
+
+## Open questions
+
+None blocking. The notification stream name (`events.<gid>.notification.<charID>`)
+is provisional spec text only; it binds nothing until a producer is built.
+
+## References
+
+- `internal/eventbus/subjectxlate/subjectxlate.go` — the shim this design deletes
+  (its header names this migration "F5")
+- `internal/grpc/stream_access.go`, `scope_floor.go`, `query_stream_history.go` —
+  the I-17 classifiers and read-path auth switch
+- `internal/access/policy/attribute/stream.go` — the ABAC `StreamProvider` straddle
+- `docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md` §1.1 —
+  mandates dot-style for new code; this closes the gap on legacy code
+- `holomush-pkixe`, `holomush-ofpi`, `holomush-ec22.3` — subsumed beads
+- `.claude/rules/abac-providers.md` — the omit-don't-sentinel fail-safe rule

--- a/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
+++ b/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
@@ -77,8 +77,8 @@ A producer/classifier survey narrows the bead's 2026-05-20 discovered scope:
 
 | Stream | Colon (today) | Dot (canonical) | Live code? |
 | --- | --- | --- | --- |
-| Location | `location:<ULID>` | `events.<gid>.location.<ULID>` | **Yes** — `internal/core/engine.go:73,96`, `internal/world/events.go`, `internal/grpc/server.go:1294`, grid focus routing, scope floor, ABAC `StreamProvider`, **Lua SDK `pkg/holo/emit.go` `Emitter.Location()`** |
-| Character (personal) | `character:<ULID>` | `events.<gid>.character.<ULID>` | **Yes** — `stream_access.go`, `scope_floor.go`, `internal/grpc/server.go:1246`, `internal/core/event.go:17`, `internal/core/engine_end_session.go:62` (`NewEvent` producer), **Lua SDK `pkg/holo/emit.go` `Emitter.Character()`** |
+| Location | `location:<ULID>` | `events.<gid>.location.<ULID>` | **Yes** — `internal/core/engine.go:73,96`, `internal/world/events.go`, `internal/grpc/server.go:1294`, grid focus routing, scope floor, ABAC `StreamProvider`, **Lua SDK `pkg/holo/emit.go` `Emitter.Location()`**, **inline Lua `plugins/core-communication/main.lua`** (say/pose/ooc/emit/whisper_notice) |
+| Character (personal) | `character:<ULID>` | `events.<gid>.character.<ULID>` | **Yes** — `stream_access.go`, `scope_floor.go`, `internal/grpc/server.go:1246`, `internal/core/event.go:17`, `internal/core/engine_end_session.go:62` (`NewEvent` producer), **Lua SDK `pkg/holo/emit.go` `Emitter.Character()`**, **inline Lua `plugins/core-communication/main.lua`** (page/whisper/pemit) |
 | Global (ambient) | `global` | `events.<gid>.global` | **Yes** — **Lua SDK `pkg/holo/emit.go:21` `Emitter.Global()`** emits to stream name `"global"`. This is a live pub/sub stream, not merely an ABAC scope. |
 | Scene IC/OOC | partly dot (`s9nu`) | `events.<gid>.scene.<ULID>.{ic,ooc}` | **Mostly done** — emit path + classifiers are dot (`s9nu`). BUT `internal/grpc/focus/scenepolicy/policy.go:29-30` `StreamsFor` still builds colon `scene:<id>:ic/:ooc` **subscription filters** — a producer `s9nu` missed (latent `ofpi`-class bug). This design flips it + extends the meta-test. |
 | Notifications | `notifications:<charID>` | `events.<gid>.notification.<charID>` | **No live producer** — design-reference only (scenes v2 §3.1, future Phase 10). Spec-text update; no code to flip. |
@@ -370,7 +370,9 @@ boundary test as noted. RFC2119 keywords are normative.
 - **INV-ROPS-2** — Unclassifiable stream names are rejected at handler entry
   with `INVALID_ARGUMENT`, never routed to a default authorization branch.
 - **INV-ROPS-3 (eradication gate)** — A CI meta-test asserts no production Go or
-  TypeScript source contains a colon-style entity-prefix literal (`location:`,
+  Lua source (`.go` + `.lua` — `core-communication/main.lua` builds subjects
+  inline, bypassing `pkg/holo`; the SvelteKit client is covered by its own Task-6
+  flip + web tests) contains a colon-style entity-prefix literal (`location:`,
   `character:`, `notifications:`, `scene:`, `plugin:`, …) as a **stream name**.
   Distinguishing a stream-name literal from a legitimate ABAC subject/resource
   literal is solved structurally, not heuristically: **ABAC subjects/resources

--- a/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
+++ b/docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md
@@ -478,3 +478,5 @@ is provisional spec text only; it binds nothing until a producer is built.
   mandates dot-style for new code; this closes the gap on legacy code
 - `holomush-pkixe`, `holomush-ofpi`, `holomush-ec22.3` — subsumed beads
 - `.claude/rules/abac-providers.md` — the omit-don't-sentinel fail-safe rule
+
+<!-- adr-capture: sha256=2d647005fecc29f6; session=brainstorm-rops; ts=2026-05-29T00:00:00Z; adrs=holomush-21ahd,holomush-wia9e -->


### PR DESCRIPTION
## Docs-only: colon-style subject eradication design + plan + ADRs

Design artifacts for **`holomush-rops`** — eradicating legacy colon-style pub/sub
stream names (`location:<id>`, `character:<id>`) in favor of the JetStream-native
dot form, end to end, and deleting `internal/eventbus/subjectxlate/`. No code
changes; spec/plan/ADRs only.

### What's here
- **Spec** `docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md` — 8 INV-ROPS invariants; passed `design-reviewer` (3 rounds).
- **Plan** `docs/superpowers/plans/2026-05-29-colon-style-subject-eradication.md` — 9 TDD tasks; passed `plan-reviewer` (6 rounds).
- **ADRs** `holomush-21ahd` (dot-form as the sole subject representation; subjectxlate deleted — subsumes `ec22.3`, extends `s9nu`) and `holomush-wia9e` (colon/dot role split enforced as an `internal/access` package boundary).

### Why
The colon↔dot translation shim (`subjectxlate`) was documented as transitional
since the JetStream cutover but became permanent. The dual representation is an
active source of privacy bugs: a classifier that receives the unrecognized form
skips the I-17 membership gate (`holomush-pkixe`, `holomush-ofpi`). A single
canonical form eliminates that class.

### Approach
Producers/clients emit a domain-relative reference (`location.<id>`); the host
injects gameID via a single `eventbus.Qualify` helper at two boundaries (emit +
read-entry), replacing the shim. Colon survives only as ABAC policy-DSL
identifiers, built exclusively by `internal/access` builders — so any inline
colon literal outside `internal/access/` is unambiguously a stream-producer bug
(the INV-ROPS-3 CI scan, covering `.go` + `.lua`).

### Tracking
Epic `holomush-rops` materialized with 9 child tasks (`holomush-rops.1`–`.9`);
`pkixe`/`ofpi`/`ec22.3` blocked-by the epic. Implementation lands in a separate
PR (the big-bang migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
