### PR TITLE
docs(scenes): Phase 8 board + content-warnings spec, plan, ADRs (holomush-iokti)

### DIFF
--- a/docs/adr/holomush-0blcz-safety-union-content-warning-resolution.md
+++ b/docs/adr/holomush-0blcz-safety-union-content-warning-resolution.md
@@ -1,0 +1,69 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Safety-Union Resolution for Content-Warning Block Settings
+
+**Status:** Accepted
+**Decision:** holomush-0blcz
+**Design bead:** holomush-iokti
+**Date:** 2026-05-30
+
+## Context
+
+Content-warning **block** preferences (the categories a player never wants shown)
+exist at GAME, PLAYER, and CHARACTER scope. The host settings `Chain`
+(`internal/settings/chain.go`) resolves scalar settings **first-match-wins** —
+the most-specific scope that has a value wins and shadows the rest.
+
+For a safety-sensitive block list, first-match-wins is hazardous: a character-scope
+list that omits a category would silently *discard* a player-level boundary,
+exposing the human to content they explicitly blocked. The blocked set must be
+**monotone** — adding a block at any scope may only enlarge it.
+
+## Decision
+
+`core-scenes` resolves `content.cw_block` as the **union** of the GAME, PLAYER,
+and CHARACTER scope lists, read via three explicit single-scope `GetSetting`
+calls and unioned plugin-side. The substrate `Chain`'s first-match-wins semantic
+is deliberately **not** used for this setting. The substrate is unchanged; the
+union is the safety-aware consumer's own composition over single-scope primitives.
+
+A `SETTING_SCOPE_CHAINED` RPC mode (host-side chain merge) is **not** provided.
+
+## Rationale
+
+- Content warnings are a safety feature; the blocked set must be monotone under
+  scope composition (INV-6). Override-by-specificity inverts that property.
+- The chained RPC mode's first-match-wins result is simply *wrong* for this
+  consumer — so it would be dead, misleading surface even if built.
+- Keeping the union in the consumer keeps the substrate generic: a single-scope
+  read primitive serves both first-match (host `Chain`) and union (safety)
+  composition without the substrate privileging either.
+
+## Alternatives Considered
+
+- **First-match-wins (substrate `Chain` semantic).** Rejected: a character-scope
+  block omitting a category discards the player's boundary for it; safety is not
+  monotone under override.
+- **`SETTING_SCOPE_CHAINED` RPC mode.** Rejected: returns first-match-wins (wrong
+  semantic for the only consumer); a single `principal_id` cannot resolve
+  character→player without a host-side join; dead wire surface.
+
+## Consequences
+
+- **Positive:** player-level boundaries are inviolable regardless of
+  character-scope configuration; substrate `Chain` semantics and existing
+  consumers are untouched; no `SETTING_SCOPE_CHAINED` dead surface.
+- **Negative:** three `GetSetting` reads per board query (mitigated — these are
+  cheap local DB reads, not cross-service RPCs); the union pattern is plugin-local,
+  so future safety-setting consumers must apply it deliberately.
+- **Neutral:** the divergence from `Chain` is intentional and recorded in INV-6,
+  not an inconsistency.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md` §3.4, INV-6
+- Related: `holomush-74ib4` (owner-partitioned settings substrate the reads run against)
+- Design bead: `holomush-iokti`

--- a/docs/adr/holomush-74ib4-owner-partitioned-plugin-settings.md
+++ b/docs/adr/holomush-74ib4-owner-partitioned-plugin-settings.md
@@ -1,0 +1,117 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Owner-Partitioned Plugin Settings with Opaque Host Passthrough
+
+**Status:** Accepted
+**Decision:** holomush-74ib4
+**Design bead:** holomush-iokti
+**Date:** 2026-05-30
+
+## Context
+
+Plugins need to persist per-player and per-character preferences (the driving
+case: content-warning block lists for the scene board, `holomush-iokti`). The
+host already owns the `players.preferences` JSONB column through a typed
+`auth.PlayerPreferences` struct that is marshaled **whole** on every write
+(`internal/auth/postgres/player_repo.go:33,169`).
+
+Three forces collide:
+
+1. A generic flat-map writer over `players.preferences` would race the typed
+   whole-struct marshal — the typed write silently drops any key the generic
+   writer added (two writers, one column, data loss).
+2. Typed host fields (the existing `auth.PlayerPreferences.Scenes.FocusReplayTail`
+   is one) walk plugin-domain vocabulary into `internal/auth` and force an
+   `internal/` edit for every new plugin preference — violating the plugin
+   boundary (`holomush-z1e7`: plugins must not require `internal/` changes).
+3. Per-plugin preference tables re-solve generic storage once per plugin,
+   defeating the goal of solving preferences once for channels, forums, and
+   every future plugin.
+
+## Decision
+
+Plugin preferences are stored via an **opaque passthrough partition** on the
+host's typed preferences struct:
+
+```go
+type PlayerPreferences struct {
+    MaxCharacters int
+    Scenes        ScenePlayerPreferences
+    Plugins       map[string]json.RawMessage `json:"plugins,omitempty"` // opaque
+}
+```
+
+The settings substrate exposes owner-narrowed handles. `Settings` (the read
+interface) is unchanged; stores return `Scoped`, which narrows to a partition:
+
+```go
+type Scoped interface {
+    Settings                    // bare reads → host partition
+    Owner(name string) Writable // narrow to a plugin's partition
+    Host() Writable             // explicit host partition
+}
+```
+
+`.Owner("core-scenes")` re-points the underlying `jsonMapSettings.data` at
+`plugins["core-scenes"]`; writes commit via the **single** existing
+`auth.PlayerRepository.Update` path (read-modify-write), so the typed marshal now
+round-trips plugin keys instead of dropping them. The host never interprets the
+contents of `Plugins`.
+
+Namespace validation is **host-partition-only**: the view returned by
+`.Owner(name)` carries `validateNamespace = false`, so the `RegisteredNamespaces`
+allowlist (`internal/settings/namespaces.go`) applies only to the host partition.
+Inside a plugin partition the plugin owns its keyspace, unchecked — adding a key
+like `content.cw_block` requires **zero `internal/` edits**.
+
+## Rationale
+
+- Eliminates the two-writer clobber: the typed repo stays the sole marshal path
+  for the column; `json:"plugins,omitempty"` + read-modify-write preserves other
+  owners' keys.
+- Keeps the host domain-ignorant (INV-10): no plugin vocabulary enters
+  `internal/`; `content` is never added to `RegisteredNamespaces`.
+- Reusable by every future plugin with zero per-key substrate cost (INV-12). The
+  one-time `Plugins` field + owner-narrowing machinery is substrate, paid once.
+- `ValidateNamespace` enforces the *host's* namespace contract, which is
+  meaningless inside a partition the host does not interpret; scoping it by a
+  factory-level flag is structural, not a per-call conditional.
+- Distinct from `holomush-7pdhf` (opaque plugin manifest config): that covers
+  init-time config delivery from the manifest; this covers runtime read/write
+  preferences persisted per principal.
+
+## Alternatives Considered
+
+- **Typed host field** (`auth.PlayerPreferences.Content.CWBlock`). Rejected:
+  embeds plugin vocabulary in `internal/auth` and requires an `internal/` edit
+  per new plugin preference — the same leak as the existing `Scenes.FocusReplayTail`
+  field, debt not to extend.
+- **Generic flat-map over `players.preferences` without owner partitioning.**
+  Rejected: collides with the typed whole-struct marshal — two writers, silent
+  key loss.
+- **Plugin-local table per plugin.** Rejected: re-solders generic preference
+  storage per plugin; defeats "solve preferences once."
+- **Unconditional `ValidateNamespace` on all partitions.** Rejected: would force
+  registering every plugin key in `internal/settings/namespaces.go`, an
+  `internal/` edit per plugin key.
+
+## Consequences
+
+- **Positive:** any plugin adds settings with zero `internal/` edits after the
+  substrate ships; no silent data loss on the preferences column; the substrate
+  is reusable across channels, forums, and future plugins.
+- **Negative:** `auth.PlayerPreferences` gains a `map[string]json.RawMessage`
+  field opaque to static analysis; plugin key typos fail soft (not-found) rather
+  than loud.
+- **Neutral:** existing typed fields are unaffected; game-scope partitioning uses
+  a host-controlled `plugin/<name>/<key>` prefix (flat `holomush_system_info`
+  k/v has no sub-object).
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md` §1.1, §3.1 (A2–A4), INV-10, INV-12
+- Related: `holomush-z1e7` (strict plugin boundary), `holomush-7pdhf` (opaque plugin manifest config — distinct), `holomush-uvbyt` (structural isolation of this substrate)
+- Design bead: `holomush-iokti`

--- a/docs/adr/holomush-uvbyt-structural-plugin-settings-isolation.md
+++ b/docs/adr/holomush-uvbyt-structural-plugin-settings-isolation.md
@@ -1,0 +1,70 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Structural Cross-Plugin Isolation via Authenticated Caller Binding
+
+**Status:** Accepted
+**Decision:** holomush-uvbyt
+**Design bead:** holomush-iokti
+**Date:** 2026-05-30
+
+## Context
+
+The `GetSetting`/`SetSetting` host RPCs (`holomush-74ib4`) give plugins access to
+the owner-partitioned settings substrate. The owner dimension selects which
+plugin's partition a call reads or writes. If the owner were a caller-supplied
+field, any plugin could name another plugin's partition — a cross-plugin
+exfiltration and corruption surface. The owner must be an **enforceable trust
+boundary**, not a naming convention.
+
+## Decision
+
+The owner is **never on the wire**. The host RPC server resolves it from
+`pluginHostServiceServer.pluginName`, which is stamped at server construction
+(`internal/plugin/goplugin/host_service.go:28`) from the authenticated calling
+plugin's identity — there is one server instance per loaded plugin. Every call is
+served against `base.Owner(s.pluginName)`. There is no RPC parameter through which
+a plugin can express another owner.
+
+This complements — does not replace — ABAC authorization (`holomush-iokti` INV-7),
+which governs *principal*-scope access (may this subject read/write its own vs.
+another's preferences). Structural isolation governs *plugin*-scope access (which
+plugin partition is addressable at all).
+
+## Rationale
+
+- Isolation-by-construction is strictly stronger than isolation-by-check: there
+  is no code path through which a plugin can supply an owner name, so the
+  guarantee cannot be bypassed by a forgotten authz predicate or a future
+  refactor that adds a field.
+- Consistent with the plugin-boundary posture (`holomush-z1e7`): the host enforces
+  structural constraints, not soft conventions.
+- Eliminates an entire confused-deputy class without a per-call predicate.
+
+## Alternatives Considered
+
+- **Caller-supplied owner parameter on the wire.** Rejected: any plugin can forge
+  any owner; isolation becomes an unenforced convention.
+- **Runtime check comparing a caller-supplied owner to the authenticated plugin
+  name.** Rejected: still a per-call predicate that a bug or refactor can bypass;
+  the enforcement is not evident from the type. A wire field that must always
+  equal the caller's identity is better removed entirely.
+
+## Consequences
+
+- **Positive:** cross-plugin partition reads/writes are structurally impossible;
+  the guarantee survives future RPC field additions because owner is not a field.
+- **Negative:** one `pluginHostServiceServer` instance per loaded plugin (not
+  shared) — minor memory overhead, already the established pattern for the
+  per-plugin emit-token mechanism.
+- **Neutral:** layered with ABAC — structural isolation bounds *which plugin
+  partition*; ABAC bounds *which principal's* data within it.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md` §3.2, INV-11
+- Grounding: `internal/plugin/goplugin/host_service.go:28,31` (`pluginName` stamped at construction)
+- Related: `holomush-74ib4` (owner-partitioned settings substrate), `holomush-z1e7` (strict plugin boundary)
+- Design bead: `holomush-iokti`

--- a/docs/superpowers/plans/2026-05-29-scenes-phase-8-board-content-warnings.md
+++ b/docs/superpowers/plans/2026-05-29-scenes-phase-8-board-content-warnings.md
@@ -1,0 +1,621 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scenes Phase 8 — Scene Board + Content Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the scene board + a game-overridable content-warning model, on an **owner-partitioned** settings substrate that exposes typed, structurally-isolated per-plugin settings to plugins without the host learning any plugin's vocabulary.
+
+**Architecture:** Substrate-first. Phase 1 adds a list type and the owner-partitioning model to `internal/settings` (host stays domain-ignorant via an opaque `Plugins` passthrough). Phase 2 exposes it over a `PluginHostService` RPC whose owner is **bound from the authenticated plugin name** (`pluginHostServiceServer.pluginName`), with Go+Lua parity. Phases 3–5 are core-scenes consumers: the CW taxonomy/vocabulary (read-time default fallback), the `ListScenes` board query (server-side filtering, union CW block), and the `scenes` command.
+
+**Tech Stack:** Go, gRPC/buf, PostgreSQL (host `internal/store/migrations`), gopher-lua hostfuncs (`internal/plugin/lua`), hashicorp/go-plugin host service (`internal/plugin/goplugin`), testify + Ginkgo (`internal/testsupport/integrationtest`).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md`
+**Design bead:** `holomush-iokti`
+
+**Model labels (for plan-to-beads, Rule 5):** Phases 1–2 substrate tasks → `model:opus` (interface design, boundary-sensitive, ABAC). Phases 3–5 → `model:sonnet` (pattern-mirroring against grounded examples).
+
+---
+
+## Conventions for every task
+
+- Tests: `task test -- ./<package>/`; integration `task test:int`. Never bare `go test`.
+- Commit: `jj commit -m "type(scope): desc (holomush-iokti)"`.
+- SPDX headers on new `.go`/`.sql` (via `task fmt`); `slog.*Context(ctx,…)`; `oops` for errors.
+- After each task: `task lint && task test -- ./<touched-package>/`.
+
+---
+
+## Phase 1: Settings substrate — list type + owner partitioning
+
+### Task 1: `StringSliceN` read accessor across all backings
+
+**Files:**
+
+- Modify: `internal/settings/settings.go` (add to `Settings` interface)
+- Modify: `internal/settings/player.go:76` (`jsonMapSettings`), `:168` (`emptySettings`)
+- Modify: `internal/settings/game.go:56` (`postgresGameSettings`)
+- Modify: `internal/settings/chain.go:23` (`Chain`)
+- Test: `internal/settings/player_test.go`, `game_test.go`, `chain_test.go`
+
+- [ ] **Step 1: Write failing tests** (one per backing)
+
+```go
+// player_test.go
+func TestJSONMapSettingsStringSliceNReturnsNativeArray(t *testing.T) {
+	s := settings.NewJSONMapSettingsForTest(map[string]json.RawMessage{
+		"core.cw_block": json.RawMessage(`["violence","death"]`)}, true) // (data, validateNamespace)
+	got, ok := s.StringSliceN(context.Background(), "core.cw_block")
+	require.True(t, ok)
+	assert.Equal(t, []string{"violence", "death"}, got)
+}
+func TestJSONMapSettingsStringSliceNScalarReturnsFalse(t *testing.T) {
+	s := settings.NewJSONMapSettingsForTest(map[string]json.RawMessage{
+		"core.cw_block": json.RawMessage(`"violence"`)}, true)
+	_, ok := s.StringSliceN(context.Background(), "core.cw_block")
+	assert.False(t, ok)
+}
+// game_test.go
+func TestGameSettingsStringSliceNDecodesJSONArrayString(t *testing.T) {
+	store := newMockSystemInfoStore()
+	require.NoError(t, store.SetSystemInfo(context.Background(), "core.x", `["a","b"]`))
+	got, ok := settings.NewGameSettings(store).StringSliceN(context.Background(), "core.x")
+	require.True(t, ok)
+	assert.Equal(t, []string{"a", "b"}, got)
+}
+```
+
+(Use `core.*` keys — `core` is already in `RegisteredNamespaces`, so host-partition validation passes.)
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./internal/settings/` → `StringSliceN undefined`.
+
+- [ ] **Step 3: Add to interface + backings**
+
+`settings.go` — add to `Settings`:
+
+```go
+	// StringSliceN returns a string-list setting; unset or non-list → (nil,false).
+	StringSliceN(ctx context.Context, key string) ([]string, bool)
+```
+
+`player.go` `jsonMapSettings` (note `validateNamespace` gate — see Task 2; for Task 1 keep the existing unconditional `ValidateNamespace`, Task 2 adds the flag):
+
+```go
+func (j *jsonMapSettings) StringSliceN(ctx context.Context, key string) ([]string, bool) {
+	if j.validateNamespace { // field added in Task 2; until then call ValidateNamespace directly
+		if err := ValidateNamespace(key); err != nil {
+			slog.DebugContext(ctx, "settings read: invalid namespace", "key", key, "error", err)
+			return nil, false
+		}
+	}
+	raw, ok := j.data[key]
+	if !ok {
+		return nil, false
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, false // not a JSON array — never coerce a scalar
+	}
+	return out, true
+}
+```
+
+> NB: Tasks 1 and 2 touch `jsonMapSettings` together. If implementing strictly serially, in Task 1 write `StringSliceN` with the existing unconditional `ValidateNamespace(key)` call, then Task 2 introduces the `validateNamespace` field and threads it through all five accessors. Prefer implementing Task 1 + Task 2 as one branch.
+
+`game.go` `postgresGameSettings`:
+
+```go
+func (g *postgresGameSettings) StringSliceN(ctx context.Context, key string) ([]string, bool) {
+	s, ok := g.StringN(ctx, key)
+	if !ok { return nil, false }
+	var out []string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		slog.DebugContext(ctx, "game settings slice decode failed", "key", key, "error", err)
+		return nil, false
+	}
+	return out, true
+}
+```
+
+`player.go` `emptySettings`: `func (e *emptySettings) StringSliceN(context.Context, string) ([]string, bool) { return nil, false }`
+
+`chain.go` `Chain`:
+
+```go
+func (c *Chain) StringSliceN(ctx context.Context, key string) ([]string, bool) {
+	for _, s := range c.scopes {
+		if v, ok := s.StringSliceN(ctx, key); ok { return v, true }
+	}
+	return nil, false
+}
+```
+
+Add `slices`/`StringSliceN` to the `stubSettings` test double in `chain_test.go`.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./internal/settings/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(settings): StringSliceN list accessor across backings (holomush-iokti)"`
+
+---
+
+### Task 2: Owner-partitioning — `Scoped`/`Writable` + `Owner()`/`Host()` + validation flag
+
+**Files:**
+
+- Modify: `internal/settings/settings.go` (add `Scoped`, `Writable`; change store `For` returns)
+- Modify: `internal/settings/player.go` (`jsonMapSettings` gains `validateNamespace bool`; `PlayerSettings.For` returns `Scoped`; add `Owner`/`Host`)
+- Create: `internal/settings/scoped.go` (the `scopedView` implementing `Scoped`)
+- Test: `internal/settings/scoped_test.go`
+
+**Design:** `Settings` (read) unchanged. A `scopedView` wraps a player's/character's/game's preference data and implements `Scoped`. `.Owner(name)` returns a `Writable` over the `plugins[name]` sub-map with `validateNamespace=false`. `.Host()` returns a `Writable` over the host keyspace with `validateNamespace=true`. For player/character scope, `.Host()` is a **deferred no-op** view (reads unset; writes error) — host player/character settings remain the typed `auth.PlayerPreferences` struct's job; no consumer needs the generic host partition at those scopes (spec §3.1). For game scope, `.Host()` is the real `system_info` keyspace.
+
+- [ ] **Step 1: Write failing isolation tests**
+
+```go
+// scoped_test.go
+func TestOwnerPartitionsAreIsolated(t *testing.T) {
+	sc := settings.NewScopedForTest(map[string]json.RawMessage{}) // empty player prefs
+	require.NoError(t, sc.Owner("core-scenes").SetStringSlice(ctx, "content.cw_block", []string{"violence"}))
+	// other owner sees nothing:
+	_, ok := sc.Owner("core-channels").StringSliceN(ctx, "content.cw_block")
+	assert.False(t, ok)
+	// same owner round-trips, WITHOUT a RegisteredNamespaces entry for "content":
+	got, ok := sc.Owner("core-scenes").StringSliceN(ctx, "content.cw_block")
+	require.True(t, ok)
+	assert.Equal(t, []string{"violence"}, got)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./internal/settings/`
+
+- [ ] **Step 3: Implement**
+
+In `settings.go`:
+
+```go
+type Scoped interface {
+	Settings                    // bare reads → host partition
+	Owner(name string) Writable
+	Host() Writable
+}
+type Writable interface {
+	Settings
+	SetString(ctx context.Context, key, value string) error
+	SetStringSlice(ctx context.Context, key string, values []string) error
+}
+// store factories now return Scoped:
+type PlayerSettingsStore    interface { For(ctx context.Context, playerID    ulid.ULID) Scoped }
+type CharacterSettingsStore interface { For(ctx context.Context, characterID ulid.ULID) Scoped }
+type GameSettings           interface { Scoped }
+```
+
+Add `validateNamespace bool` to `jsonMapSettings`; gate every accessor's `ValidateNamespace` call on it. Provide `NewJSONMapSettingsForTest(data, validateNamespace)`.
+
+`scoped.go` — a `scopedView` holding the loaded prefs + a commit func (read-modify-write back through the owning repo, Task 3). `.Owner(name)` returns a `Writable` whose `jsonMapSettings.data` is `prefs.Plugins[name]` (created if absent) and `validateNamespace=false`; writes mutate that sub-map and call commit. `.Host()` for player/character returns a `noopWritable` (reads `(zero,false)`, writes `oops.Errorf("host player/character settings are typed; use auth.PlayerPreferences")`). `Chain.Owner(name)` returns a new `Chain` whose scopes are each `.Owner(name)`.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./internal/settings/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(settings): owner-partitioned Scoped/Writable with structural isolation (holomush-iokti)"`
+
+---
+
+### Task 3: `SetStringSlice` writer + opaque `Plugins` passthrough (one writer, no clobber)
+
+**Files:**
+
+- Modify: `internal/auth/player.go` (add `Plugins map[string]json.RawMessage` to `PlayerPreferences`)
+- Create: `internal/settings/player_store.go` (real `PlayerSettings` backed by `auth.PlayerRepository`, reading/writing `Preferences.Plugins`)
+- Modify: bootstrap wiring (`cmd/holomush/sub_grpc.go` near `NewGameSettings:433`) to construct `NewPlayerSettingsStore`
+- Test: `internal/auth/player_test.go`, `internal/settings/player_store_integration_test.go`
+
+- [ ] **Step 1: Write failing clobber-resistance test**
+
+```go
+// player_test.go — typed marshal must round-trip the opaque Plugins bag.
+func TestPlayerPreferencesPluginsBagRoundTrips(t *testing.T) {
+	p := auth.PlayerPreferences{MaxCharacters: 3,
+		Plugins: map[string]json.RawMessage{"core-scenes": json.RawMessage(`{"content.cw_block":["violence"]}`)}}
+	b, err := json.Marshal(p); require.NoError(t, err)
+	var got auth.PlayerPreferences
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.JSONEq(t, `{"content.cw_block":["violence"]}`, string(got.Plugins["core-scenes"]))
+}
+```
+
+- [ ] **Step 2: Run, verify fail** (`Plugins` field undefined).
+
+- [ ] **Step 3: Implement**
+
+`auth/player.go` — add to `PlayerPreferences`:
+
+```go
+	// Plugins is an OPAQUE per-plugin settings passthrough (owner partition).
+	// The host never interprets its contents (INV-10). Keyed by plugin name.
+	Plugins map[string]json.RawMessage `json:"plugins,omitempty"`
+```
+
+`player_store.go` — `PlayerSettings.For(ctx, playerID) Scoped` loads `repo.GetByID` → builds a `scopedView` over `player.Preferences.Plugins`, with a commit func that does `repo.GetByID` → set `Preferences.Plugins[owner][key]=raw` → `repo.Update` (the **single** existing writer; whole-struct marshal now includes `Plugins`, so no clobber). `SetStringSlice` marshals `[]string`→`json.RawMessage` and stores it natively (so `StringSliceN`'s `json.Unmarshal(raw,&out)` works).
+
+Wire `NewPlayerSettingsStore(playerRepo)` in bootstrap and inject into the host (Task 7) + focus coordinator.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./internal/auth/` + `task test:int -- ./internal/settings/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(settings): player owner-store via opaque Plugins passthrough (holomush-iokti)"`
+
+---
+
+### Task 4: Game-scope owner partitioning (`plugin/<name>/<key>` prefix)
+
+**Files:**
+
+- Modify: `internal/settings/game.go` (`postgresGameSettings` implements `Scoped`: `Owner`/`Host`)
+- Modify: `internal/settings/namespaces.go` (reserve `plugin` as a forbidden host top-level namespace)
+- Test: `internal/settings/game_test.go`
+
+- [ ] **Step 1: Failing test** — `game.Owner("core-scenes").SetStringSlice(ctx,"content.cw_taxonomy",…)` stores under `plugin/core-scenes/content.cw_taxonomy` and is readable back via `Owner("core-scenes")`, invisible to `Host()`.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** — `postgresGameSettings.Owner(name)` returns a `Writable` that prefixes every key with `"plugin/"+name+"/"` before hitting `SystemInfoStore`, with `validateNamespace=false`. `Host()` returns the bare `postgresGameSettings` (validated). Add a guard so host keys beginning `plugin/` are rejected by `ValidateNamespace` (reserve the segment). The prefix is built from the host-bound owner only (Task 7), so isolation (INV-11) holds.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./internal/settings/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(settings): game-scope owner partitioning via reserved plugin/ prefix (holomush-iokti)"`
+
+---
+
+### Task 5: `characters.preferences` migration + real `CharacterSettingsStore`
+
+**Files:**
+
+- Create: `internal/store/migrations/000045_character_preferences.up.sql` / `.down.sql` (re-verify the number — current max is `000044`)
+- Modify: `internal/settings/character.go` (replace null store with a real owner-partitioned one; keep `NewNullCharacterSettingsStore` for tests)
+- Create: `internal/settings/character_store.go`
+- Modify: bootstrap wiring to construct the real store
+- Test: `internal/settings/character_store_integration_test.go`
+
+- [ ] **Step 1: Migration**
+
+`000045_character_preferences.up.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 HoloMUSH Contributors
+
+-- Phase 8: per-character preferences (owner-partitioned settings scope).
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}';
+```
+
+`.down.sql`: `ALTER TABLE characters DROP COLUMN IF EXISTS preferences;`
+
+- [ ] **Step 2: Failing test** — character-scope `.Owner("core-scenes")` round-trip against a Postgres testcontainer.
+
+- [ ] **Step 3: Run, verify fail.** `task test:int -- ./internal/settings/`
+
+- [ ] **Step 4: Implement** — `CharacterSettings` mirroring `PlayerSettings` (Task 3): a `CharacterPrefs` reader over the `characters` row, `For` returns a `scopedView` over `preferences.plugins`, commit via a `characters.preferences` read-modify-write. (A typed `CharacterPreferences{Plugins map[string]json.RawMessage}` struct or a raw JSONB map — match the player approach.)
+
+- [ ] **Step 5: Run, verify pass + roll migration up/down on a scratch DB.**
+
+- [ ] **Step 6: Commit.** `jj commit -m "feat(settings): real character-scope owner store + characters.preferences (holomush-iokti)"`
+
+---
+
+## Phase 2: Plugin settings access — host RPC + parity + authz
+
+### Task 6: Proto — `GetSetting`/`SetSetting` (single-scope)
+
+**Files:** Modify `api/proto/holomush/plugin/v1/plugin.proto`; regenerate.
+
+- [ ] **Step 1: Add RPCs + messages** (every element doc-commented per `.claude/rules/proto-doc-comments.md`). After the focus RPCs (~:181):
+
+```protobuf
+  // GetSetting reads a single-scope setting in the calling plugin's owner
+  // partition (owner bound host-side from the authenticated plugin). Phase 8.
+  rpc GetSetting(PluginHostServiceGetSettingRequest) returns (PluginHostServiceGetSettingResponse);
+  // SetSetting writes a single-scope setting in the calling plugin's partition;
+  // GAME scope requires operator authz.
+  rpc SetSetting(PluginHostServiceSetSettingRequest) returns (PluginHostServiceSetSettingResponse);
+```
+
+```protobuf
+// SettingScope selects the scope a setting Get/Set targets. No chained mode:
+// callers compose scopes themselves (e.g. CW-block union).
+enum SettingScope {
+  // Unspecified — rejected (fail closed).
+  SETTING_SCOPE_UNSPECIFIED = 0;
+  // Server-wide (holomush_system_info).
+  SETTING_SCOPE_GAME = 1;
+  // Per-player (players.preferences).
+  SETTING_SCOPE_PLAYER = 2;
+  // Per-character (characters.preferences).
+  SETTING_SCOPE_CHARACTER = 3;
+}
+// PluginHostServiceGetSettingRequest reads one key. Owner is NOT on the wire —
+// it is bound host-side from the authenticated plugin (INV-11).
+message PluginHostServiceGetSettingRequest {
+  // Scope to read.
+  SettingScope scope = 1;
+  // Principal ULID: player ID (PLAYER), character ID (CHARACTER), empty (GAME).
+  string principal_id = 2;
+  // Plugin-owned dot-key (e.g. "content.cw_block").
+  string key = 3 [(buf.validate.field).string.min_len = 1];
+}
+// PluginHostServiceGetSettingResponse returns a typed list-or-string value.
+message PluginHostServiceGetSettingResponse {
+  // Whether the key resolved.
+  bool found = 1;
+  // String-list value (Phase 8 uses list-valued settings).
+  repeated string string_list = 2;
+  // Scalar string value (for non-list keys).
+  string string_value = 3;
+}
+// PluginHostServiceSetSettingRequest writes one key in the caller's partition.
+message PluginHostServiceSetSettingRequest {
+  // Target scope.
+  SettingScope scope = 1;
+  // Principal ULID (empty for GAME).
+  string principal_id = 2;
+  // Plugin-owned dot-key.
+  string key = 3 [(buf.validate.field).string.min_len = 1];
+  // String-list value to store.
+  repeated string string_list = 4;
+}
+// PluginHostServiceSetSettingResponse is the empty ack.
+message PluginHostServiceSetSettingResponse {}
+```
+
+- [ ] **Step 2: Regenerate + lint.** `task lint:proto && task build` — clean.
+
+- [ ] **Step 3: Commit.** `jj commit -m "feat(plugin): GetSetting/SetSetting single-scope RPCs (holomush-iokti)"`
+
+---
+
+### Task 7: Host handler — owner bound from `pluginName` + ABAC authz
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host_service.go` (add methods on `pluginHostServiceServer`, ~after `Evaluate:521`)
+- Modify: `internal/plugin/goplugin/host.go:195` (`Host` struct gains settings stores) + add `WithPlayerSettings`/`WithCharacterSettings`/`WithGameSettings` options (mirror `WithEngine:169`/`WithFocusCoordinator:140`) + `SetXxx` late-binders (mirror `SetFocusCoordinator:322`)
+- Modify: bootstrap (`internal/plugin/setup/` + `cmd/holomush`) to inject the stores
+- Test: `internal/plugin/goplugin/host_service_test.go`
+
+- [ ] **Step 1: Failing tests — owner binding + authz denial**
+
+```go
+func TestGetSettingBindsOwnerToCallingPlugin(t *testing.T) {
+	h := newTestHostWithEngine(t, "core-scenes", manifest, allowEngine())
+	seedPlayerPluginSetting(t, h, "p1", "core-scenes", "content.cw_block", []string{"violence"})
+	// Construct the server struct directly (mirror host_service_test.go:1235) —
+	// newPluginHostServiceServer returns a *grpc.Server factory, not the server.
+	s := &pluginHostServiceServer{host: h, pluginName: "core-scenes"}
+	resp, err := s.GetSetting(ctx, &pluginv1.PluginHostServiceGetSettingRequest{
+		Scope: pluginv1.SettingScope_SETTING_SCOPE_PLAYER, PrincipalId: "p1", Key: "content.cw_block"})
+	require.NoError(t, err); require.True(t, resp.GetFound())
+	assert.Equal(t, []string{"violence"}, resp.GetStringList())
+}
+func TestSetSettingGameScopeDeniedForNonOperator(t *testing.T) {
+	s := &pluginHostServiceServer{host: newTestHostWithEngine(t,"core-scenes",manifest,denyEngine()), pluginName: "core-scenes"}
+	_, err := s.SetSetting(ctx, &pluginv1.PluginHostServiceSetSettingRequest{
+		Scope: pluginv1.SettingScope_SETTING_SCOPE_GAME, Key:"content.cw_taxonomy", StringList:[]string{"x"}})
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./internal/plugin/goplugin/`
+
+- [ ] **Step 3: Implement** — mirror `Evaluate:521` (snapshot deps under lock). Resolve `base Scoped` from `scope` (`game` / `players.For(principalID)` / `characters.For(principalID)`); **bind owner via `base.Owner(s.pluginName)`** — `s.pluginName` is stamped at construction (`host_service.go:28`), never from the request. Authz through `s.host.engine`: PLAYER/CHARACTER require `principal_id == acting subject` (own settings); GAME writes require an operator `write`/`setting` decision; deny → `codes.PermissionDenied`. Then `StringSliceN` / `SetStringSlice`. Never leak inner errors (`grpc-errors.md`): log + `status.Error(codes.Internal,"internal error")`.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./internal/plugin/goplugin/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(plugin): host GetSetting/SetSetting — owner-bound + ABAC authz (holomush-iokti)"`
+
+---
+
+### Task 8: Go SDK client method
+
+**Files:** Create `pkg/plugin/settings_client.go` (mirror `pkg/plugin/focus_client.go:296`); add `GetSetting`/`SetSetting` to the host-client interface plugins consume; test `settings_client_test.go`.
+
+- [ ] **Step 1–2: Failing test** for `GetSetting(ctx, scope, principalID, key) ([]string, bool, error)` marshaling the request and mapping the response (mirror `focus_client_test.go`). Run → fail.
+- [ ] **Step 3: Implement** mirroring `pluginHostFocusClient.SetConnectionFocus:296` — build `pluginv1.PluginHostServiceGetSettingRequest`, call `c.client.GetSetting`, map `found`/`string_list`. (No owner param — the host binds it.)
+- [ ] **Step 4–5:** Run pass; `jj commit -m "feat(plugin): SDK settings client (holomush-iokti)"`
+
+---
+
+### Task 9: Lua hostfunc parity (INV-8)
+
+**Files:** Create `internal/plugin/lua/settings_ops_adapter.go` (mirror `focus_ops_adapter.go`); modify `internal/plugin/lua/host.go` (add `SetSettingsOps`, mirror `SetFocusCoordinator:121`) + the `hostfunc.Functions` surface to register `host.get_setting`/`host.set_setting`; test a Lua read.
+
+- [ ] **Step 1–2: Failing test** — a Lua script calling `host.get_setting("player", principal, "content.cw_block")` returns the list. Run → fail.
+- [ ] **Step 3: Implement** the adapter (delegating to the same stores the host handler uses, owner-bound to the Lua plugin's name) + register the Lua functions mirroring the focus ops. **INV-8 gate:** ship in the same change-set as Task 8.
+- [ ] **Step 4–5:** Run pass (`task test -- ./internal/plugin/lua/` + `task test:int`); `jj commit -m "feat(plugin): Lua get_setting/set_setting hostfunc parity (holomush-iokti)"`
+
+---
+
+## Phase 3: Content-warning model (owned by core-scenes)
+
+### Task 10: `DefaultCWTaxonomy` + read-time fallback + Create/Update validation
+
+**Files:**
+
+- Create: `plugins/core-scenes/content_warnings.go` (`DefaultCWTaxonomy` const + `effectiveTaxonomy(ctx) []string`)
+- Modify: `plugins/core-scenes/service.go` (`CreateScene`, `UpdateScene` validation)
+- Test: `plugins/core-scenes/service_test.go`
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestEffectiveTaxonomyFallsBackToDefaultWhenGameUnset(t *testing.T) {
+	p := newScenePluginWithSettings(t, /* game content.cw_taxonomy unset */)
+	assert.Subset(t, p.effectiveTaxonomy(ctx), []string{"violence", "death"})
+}
+func TestCreateSceneRejectsUnknownContentWarning(t *testing.T) {
+	svc := newSceneServiceWithTaxonomy(t, []string{"violence"})
+	_, err := svc.CreateScene(ctx, &scenev1.CreateSceneRequest{
+		CharacterId: char, Title: "X", ContentWarnings: []string{"not-a-cat"}})
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./plugins/core-scenes/`
+
+- [ ] **Step 3: Implement**
+
+```go
+// content_warnings.go
+var DefaultCWTaxonomy = []string{"violence", "sexual-content", "death",
+	"substance-use", "self-harm", "body-horror", "abuse"}
+
+// effectiveTaxonomy reads game-scope content.cw_taxonomy via the settings
+// client; falls back to DefaultCWTaxonomy when unset (INV-5).
+func (p *scenePlugin) effectiveTaxonomy(ctx context.Context) []string {
+	if tax, ok, err := p.settings.GetSetting(ctx, GAME, "", "content.cw_taxonomy"); err == nil && ok && len(tax) > 0 {
+		return tax
+	}
+	return DefaultCWTaxonomy
+}
+```
+
+In `CreateScene`/`UpdateScene`, reject any `content_warnings` value not in `effectiveTaxonomy(ctx)` with `status.Error(codes.InvalidArgument, "unknown content warning")`. Inject the settings client like `p.evaluator`.
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./plugins/core-scenes/`
+
+- [ ] **Step 5: Commit.** `jj commit -m "feat(scenes): DefaultCWTaxonomy fallback + content_warnings validation (holomush-iokti)"`
+
+---
+
+## Phase 4: Scene board query
+
+### Task 11: `ListScenesRequest` proto fields
+
+**Files:** Modify `api/proto/holomush/scene/v1/scene.proto:245`.
+
+- [ ] **Step 1: Add fields** (doc-commented):
+
+```protobuf
+  // Per-query CW exclude filter (hide), layered on the caller's resolved block;
+  // applied server-side so pagination stays correct.
+  repeated string exclude_content_warnings = 4;
+  // Requesting character ULID — resolves character-scope CW block.
+  string character_id = 5 [(buf.validate.field).string.min_len = 1];
+  // Requesting player ULID — resolves player-scope CW block.
+  string player_id = 6 [(buf.validate.field).string.min_len = 1];
+```
+
+- [ ] **Step 2: Regenerate + lint.** `task lint:proto && task build`
+- [ ] **Step 3: Commit.** `jj commit -m "feat(scenes): ListScenesRequest CW-exclude + identity fields (holomush-iokti)"`
+
+---
+
+### Task 12: `ListScenes` store query + service handler (visibility, pagination, tag filter)
+
+**Files:** Modify `plugins/core-scenes/store.go` (add `ListBoard` after `ListScenesForCharacter:1281`), `plugins/core-scenes/service.go` (add `ListScenes`, mirror `GetScene:322`); test `store_integration_test.go`, `service_test.go`.
+
+- [ ] **Step 1: Failing store test (INV-1 + pagination + tag)**
+
+```go
+//go:build integration
+func TestListBoardReturnsOnlyOpenActivePaginated(t *testing.T) {
+	st := newSceneStore(t)
+	seedScene(t, st, "open", "active", []string{"plot"}, nil)
+	seedScene(t, st, "private", "active", nil, nil)  // excluded
+	seedScene(t, st, "open", "ended", nil, nil)       // excluded
+	rows, err := st.ListBoard(ctx, BoardQuery{Limit: 50, Tags: []string{"plot"}})
+	require.NoError(t, err); require.Len(t, rows, 1)
+	assert.Equal(t, "open", rows[0].Visibility)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test:int -- ./plugins/core-scenes/`
+
+- [ ] **Step 3: Implement `ListBoard`** mirroring `ListScenesForCharacter` (span, `oops.Code`, row scan). SQL:
+
+```sql
+SELECT id, title, description, location_id, owner_id, state, pose_order_mode,
+       content_warnings, tags, visibility, created_at
+FROM scenes
+WHERE visibility = 'open' AND state IN ('active','paused')
+  AND ($1::text[] IS NULL OR tags @> $1)
+ORDER BY created_at DESC, id ASC
+LIMIT $2 OFFSET $3
+```
+
+`BoardQuery{Limit, Offset int; Tags []string}` (cap Limit ≤200, default when 0). `ListScenes` maps request→`BoardQuery`, calls `ListBoard`, maps rows→`[]*scenev1.SceneInfo` via existing `rowToProto`. CW filtering deferred to Task 13.
+
+- [ ] **Step 4: Run, verify pass.** `task test:int -- ./plugins/core-scenes/`
+- [ ] **Step 5: Commit.** `jj commit -m "feat(scenes): ListScenes board query (holomush-iokti)"`
+
+---
+
+### Task 13: CW filtering — union block across scopes + per-query exclude (INV-3, INV-6)
+
+**Files:** Modify `plugins/core-scenes/service.go` (`ListScenes`), `plugins/core-scenes/store.go` (`ListBoard` excludes a CW set); test `service_test.go`.
+
+- [ ] **Step 1: Failing union test**
+
+```go
+func TestListScenesExcludesUnionOfBlockedCWs(t *testing.T) {
+	// player blocks {death}; a scene tagged death is excluded; CW labels still present.
+	svc := newSceneServiceWithBlocks(t, playerBlock("p1", []string{"death"}))
+	seedScene(t, svc, "open","active", nil, []string{"death"})   // excluded
+	seedScene(t, svc, "open","active", nil, []string{"romance"}) // kept
+	resp, err := svc.ListScenes(ctx, &scenev1.ListScenesRequest{Limit:50, PlayerId:"p1", CharacterId:"c1"})
+	require.NoError(t, err); require.Len(t, resp.GetScenes(), 1)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./plugins/core-scenes/`
+
+- [ ] **Step 3: Implement union + filter** — excluded set = per-query `exclude_content_warnings` ∪ resolved block. Resolve the block as the **union** of three single-scope `GetSetting` calls (GAME `""`, PLAYER `req.player_id`, CHARACTER `req.character_id`) for `content.cw_block` (INV-6 — single-scope reads, owner-bound to core-scenes host-side). Pass the union to `ListBoard`, which adds `AND NOT (content_warnings && $4)` (array overlap). Never strip `content_warnings` from the projection (INV-2).
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./plugins/core-scenes/` + `task test:int`
+- [ ] **Step 5: Commit.** `jj commit -m "feat(scenes): board CW filtering — union block + per-query exclude (holomush-iokti)"`
+
+---
+
+## Phase 5: `scenes` board command
+
+### Task 14: `scenes` board command handler
+
+**Files:** Modify `plugins/core-scenes/commands.go` (board command; the existing per-character listing stays `scene list`, `handleSceneList:1171`), `plugins/core-scenes/plugin.yaml` (register `scenes` + capabilities); test `commands_test.go`.
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestScenesBoardRendersOpenScenesWithCWLabels(t *testing.T) {
+	p := newScenePluginWithBoard(t /* one scene cw=violence */)
+	resp, err := p.handleScenesBoard(ctx, cmdReq("c1","p1",""))
+	require.NoError(t, err); assert.Contains(t, resp.Text, "violence")
+}
+func TestScenesBoardParsesHideArg(t *testing.T) {
+	p := newScenePluginWithBoard(t /* cw=violence + cw=romance */)
+	resp, _ := p.handleScenesBoard(ctx, cmdReq("c1","p1","hide:violence"))
+	assert.NotContains(t, resp.Text, "violence")
+}
+```
+
+- [ ] **Step 2: Run, verify fail.** `task test -- ./plugins/core-scenes/`
+
+- [ ] **Step 3: Implement** — parse `hide:<cw>`/`tag:<t>` into `ListScenesRequest{ExcludeContentWarnings, Tags, PlayerId:req.PlayerID, CharacterId:req.CharacterID, Limit}`, call `p.service.ListScenes`, render rows (title, id, owner, participant count, tags, CW labels, `[paused]`) via `strings.Builder` like `handleInfo:567`. Register `scenes` in `plugin.yaml` with read capabilities; route it (top-level command, distinct from `scene list`).
+
+- [ ] **Step 4: Run, verify pass.** `task test -- ./plugins/core-scenes/` + `task test:int`
+- [ ] **Step 5: Commit.** `jj commit -m "feat(scenes): scenes board command (holomush-iokti)"`
+
+---
+
+## Post-implementation checklist
+
+- [ ] `task pr-prep` green; `task pr-prep:full` (this plan adds integration tests — Tasks 3, 5, 7, 12, 13).
+- [ ] All 12 invariants (INV-1…INV-12) have a backing test; meta-test asserts catalog completeness.
+- [ ] Migration `000045_character_preferences` rolls up AND down on a scratch DB.
+- [ ] `task lint:proto` clean (new RPCs/messages/enum fully documented; name-echo passes).
+- [ ] **INV-8 parity** verified — Go SDK + Lua both `get_setting`/`set_setting`.
+- [ ] **INV-11 isolation** test — a plugin cannot reach another owner's partition (owner is server-stamped, not request-supplied).
+- [ ] **INV-12** — adding `content.cw_block` required NO `RegisteredNamespaces`/`internal/` edit (only the one-time `Plugins` field + owner machinery).
+- [ ] `abac-reviewer` (settings-write authz, Task 7) + `code-reviewer` before push.
+- [ ] Site docs: `site/src/content/docs/extending/` host settings RPC; player-guide scene board entry.
+- [ ] Supersede `holomush-5rh.17` when these beads close.
+
+<!-- adr-capture: sha256=ca96f4bfe7c8b892; session=iokti; ts=2026-05-30T09:22:25Z; adrs=holomush-74ib4,holomush-uvbyt,holomush-0blcz -->

--- a/docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md
+++ b/docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md
@@ -1,0 +1,400 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Scenes Phase 8 — Scene Board + Content Warnings
+
+**Design bead:** `holomush-iokti`
+**Phase bead (superseded on ship):** `holomush-5rh.17`
+**Sequencing decision:** `holomush-ztiqj` (Phase 8 → Web Portal arc)
+**Status:** Draft (revised — pre design-review round 2)
+**Date:** 2026-05-29
+
+## 1. Overview
+
+Scenes Phase 8 builds the **scene board** — a browsable, filterable directory
+of open scenes — and the **content-warning** experience that lets players
+discover scenes with informed consent and filter out material outside their
+boundaries.
+
+This phase is **not greenfield**. The proto contract and storage columns for
+the board already exist; the gap is implementation, plus one cross-cutting
+substrate investment:
+
+- `ListScenes` RPC is **declared** at `api/proto/holomush/scene/v1/scene.proto:40`
+  but **unimplemented** in `plugins/core-scenes` (no handler, no command wiring;
+  proto comment: "DECLARED BUT NOT SERVED").
+- `content_warnings`, `tags`, and `visibility` already exist on the `SceneInfo`
+  message and are **settable** via `CreateScene`/`UpdateScene`, but are
+  **write-only metadata today** — nothing queries or filters on them.
+- `content_warnings` is currently unvalidated free-form (`repeated string`).
+- The `scenes`/`scene list` command renders only the per-character sidebar
+  (`ListScenesForCharacter`); it is not a board (`commands.go:709` notes
+  tags/content_warnings are unexposed).
+
+Persistent content-warning preferences are **player/character boundaries**, not
+scene domain state. Rather than solve preference storage per-plugin, Phase 8
+exposes the host settings substrate (`internal/settings`) to plugins — following
+the Phase 5 precedent, where a scenes phase folded new `PluginHostService` RPCs
+into itself because scenes was the driving consumer.
+
+### 1.1 The settings substrate must stay domain-ignorant at the host boundary
+
+The host **MUST NOT** know what a "content warning" is. The plugin/host boundary
+forbids the host depending on plugin-domain concepts (`event-conventions.md`:
+*"plugin authors don't need to modify `internal/` to add new event types or
+verbs"*). Two rejected designs and why:
+
+- **A typed host field** (`auth.PlayerPreferences.Content.CWBlock []string`) would
+  walk a content/scenes concept into `internal/auth` and force an `internal/`
+  edit to add any plugin preference. (`auth.PlayerPreferences.Scenes.FocusReplayTail`
+  is the existing instance of this leak — debt to *not* extend.)
+- **A generic flat-map view** over `players.preferences` collides with the typed
+  `auth.PlayerPreferences` struct that owns that column: the typed whole-struct
+  marshal (`player_repo.go:33,169`) silently drops any key the generic writer
+  added. Two writers, one column, data loss.
+
+The resolution is an **owner-partitioned** settings model. The host provides
+generic, typed-value settings storage partitioned by an **owner** dimension; the
+host stores each plugin's keys opaquely and never interprets them. "Content
+warning" exists only inside core-scenes. This keeps the substrate reusable by
+every future plugin (channels, forums, …) — solving preference storage once —
+*without* the host learning any plugin's vocabulary. Preferences are horizontal
+infrastructure; the N=2-before-extraction discipline (INV-S7 / `holomush-lrt3`)
+governs domain-shaped primitives, not generic settings, so exposing this at N=1
+is correct.
+
+## 2. Goals / Non-goals
+
+### 2.1 Goals
+
+- Implement the scene board: `ListScenes` + a `scenes` board command, listing
+  active open scenes with metadata, paginated and filterable by tag and content
+  warning.
+- Ship a game-overridable content-warning taxonomy with a **built-in default**
+  so a fresh game filters correctly with zero operator setup.
+- Display every scene's content-warning labels on the board regardless of active
+  filters (informed consent).
+- Support persistent per-player and per-character content-warning *block*
+  preferences that auto-apply, plus per-query ad-hoc filtering.
+- Expose the settings substrate to plugins via a runtime-symmetric host RPC, with
+  **owner-partitioned, structurally-isolated** access.
+- Add first-class list support (`StringSliceN`) and the owner-narrowing model to
+  the settings substrate.
+
+### 2.2 Non-goals
+
+- **Web rendering of the board** — deferred to `holomush-5rh.8` (web Scenes
+  Portal), the next slice in the arc per `ztiqj`.
+- **Published-log presentation / public URLs** — Epic 8 surface.
+- **A general plugin preferences UI / admin console** — operators configure via
+  existing game-settings tooling.
+- **Notification preferences, idle-nudge, forum scheduling** — later scenes
+  phases (`5rh.19`, `5rh.9`).
+
+## 3. Architecture
+
+Substrate workstreams (A–B) are sequenced first; the content-warning model and
+board uses (C–E) consume them. Mirrors Phase 5's substrate-then-use shape.
+
+```mermaid
+flowchart TD
+    subgraph host["Host (internal/) — domain-ignorant"]
+        SET["internal/settings<br/>Scoped/Writable + Owner() narrowing<br/>+ StringSliceN"]
+        STORE["players/characters.preferences JSONB<br/>opaque 'plugins' passthrough partition"]
+        RPC["PluginHostService GetSetting/SetSetting<br/>(owner BOUND to authenticated caller)"]
+        ABAC["ABAC Evaluate<br/>scope/principal authz"]
+    end
+    subgraph plugin["core-scenes — owns the CW vocabulary"]
+        CMD["scenes board command"]
+        LIST["ListScenes impl<br/>active open scenes, paginated"]
+        TAX["DefaultCWTaxonomy constant<br/>+ read-time fallback"]
+        VALID["Create/UpdateScene<br/>validate content_warnings vs taxonomy"]
+    end
+
+    CMD --> LIST
+    LIST -->|"GetSetting PLAYER/CHARACTER content.cw_block<br/>(owner=core-scenes, bound host-side)"| RPC
+    VALID -->|"GetSetting GAME content.cw_taxonomy<br/>(fallback: DefaultCWTaxonomy)"| RPC
+    RPC --> ABAC
+    RPC --> SET
+    SET --> STORE
+    TAX -.-> VALID
+    LIST -->|"exclude scenes carrying any blocked CW;<br/>always attach CW labels"| CMD
+```
+
+### 3.1 Workstream A — Settings substrate: list type + owner partitioning
+
+**A1. First-class list type.** Add `StringSliceN(ctx, key) ([]string, bool)` to
+the `Settings` read interface, implemented across all backings (`jsonMapSettings`,
+`postgresGameSettings`, `emptySettings`, `Chain`). List values are a first-class
+type, never a JSON blob smuggled through `StringN` (INV-9). JSONB scopes store a
+native JSON array; the game scope (`holomush_system_info`, string k/v) stores a
+JSON-array string and decodes on read.
+
+**A2. Owner-partitioned access.** The `Settings` read interface stays unchanged
+(2-arg accessors). Stores upgrade their factory return type from `Settings` to
+`Scoped`, which adds owner-narrowing:
+
+```go
+// Read view — UNCHANGED.
+type Settings interface {
+    StringN(ctx, key) (string, bool)
+    IntN(ctx, key) (int, bool)
+    BoolN(ctx, key) (bool, bool)
+    DurationN(ctx, key) (time.Duration, bool)
+    StringSliceN(ctx, key) ([]string, bool)
+}
+
+// A Settings that can be narrowed to an owner partition.
+type Scoped interface {
+    Settings                    // bare reads → HOST partition (owner "")
+    Owner(name string) Writable // narrow+bind to a plugin's partition
+    Host() Writable             // explicit host partition (writable)
+}
+
+// A handle bound to (scope-principal, owner). Read + write.
+type Writable interface {
+    Settings
+    SetString(ctx, key, value string) error
+    SetStringSlice(ctx, key string, values []string) error
+}
+
+// Stores return Scoped:
+type PlayerSettingsStore    interface { For(ctx, playerID    ulid.ULID) Scoped }
+type CharacterSettingsStore interface { For(ctx, characterID ulid.ULID) Scoped }
+type GameSettings           interface { Scoped }
+```
+
+`Chain.Owner(name)` narrows every scope in the chain, so scope-chaining and owner
+partitioning compose orthogonally.
+
+**A3. Storage — one column, partitioned by owner.** The host typed preferences
+struct gains a single **opaque passthrough** field; it never interprets its
+contents:
+
+```jsonc
+// players.preferences
+{
+  "max_characters": 5,
+  "scenes": { "focus": { "replay_tail": 3 } },           // owner "" (host)
+  "plugins": { "core-scenes": { "content.cw_block": ["violence"] } } // owner "core-scenes"
+}
+```
+
+```go
+// internal/auth
+type PlayerPreferences struct {
+    MaxCharacters int
+    Scenes        ScenePlayerPreferences
+    Plugins       map[string]json.RawMessage `json:"plugins,omitempty"` // opaque
+}
+```
+
+`.Owner("core-scenes")` re-points the underlying `jsonMapSettings.data` at
+`plugins["core-scenes"]`; `.Host()` reads the top level. Because `Plugins` is a
+real struct field, the typed marshal round-trips plugin keys instead of dropping
+them — **one writer, no clobber**, host stays ignorant of the contents.
+
+**Game scope partitioning.** The game scope is `holomush_system_info`, flat
+string k/v (`internal/settings/game.go`), with no sub-object. Its `.Owner(name)`
+view partitions by a **host-controlled key prefix**: `plugin/<name>/<key>` (the
+`plugin/` segment is reserved and rejected as a host-partition namespace, so host
+and plugin keyspaces can't collide). The narrowed view prepends the prefix
+internally — accessors still take the bare key (`content.cw_taxonomy`). The
+prefix is derived from the host-bound owner (§3.2), never caller-supplied, so the
+same structural-isolation guarantee (INV-11) holds as for the JSONB scopes; and
+the narrowed view skips `ValidateNamespace` per A4.
+
+**A4. Namespace validation is host-partition-only — by construction.**
+Today `jsonMapSettings.StringN`/`StringSliceN` call `ValidateNamespace(key)`
+**unconditionally** on every read (`internal/settings/player.go:81`). A
+naive owner-narrowed read of `content.cw_block` would therefore be rejected
+("content" is not in `RegisteredNamespaces`) and the feature would silently
+return unset — so the bypass must be explicit, not assumed.
+
+**Mechanism:** the view returned by `.Owner(name)` (and `.Host()`'s non-host
+counterpart) carries a `validateNamespace bool` that is **false** for plugin
+partitions and **true** for the host partition. The accessors call
+`ValidateNamespace` only when the flag is set. Equivalently: `ValidateNamespace`
+enforces the *host's* namespace allowlist, which is meaningless inside a plugin
+partition — so the narrowed view simply does not apply it. The host partition
+keeps full validation.
+
+Consequence: once the substrate ships, adding `content.cw_block` requires **zero
+`internal/` edits** — `content` is NOT added to `RegisteredNamespaces`; the
+plugin owns its keyspace.
+
+**A5. Character scope.** Add a `characters.preferences` JSONB migration (host
+migration, next number after the current max) and a real `CharacterSettingsStore`
+implementation mirroring `PlayerSettings`. Player + game scopes already function;
+character scope completes the set. (The `Owner`/`Plugins` partitioning applies
+identically.)
+
+### 3.2 Workstream B — Plugin settings access (host RPC + parity)
+
+Add a `PluginHostService` RPC pair (`api/proto/holomush/plugin/v1/plugin.proto`),
+**single-scope only** (no chained mode — plugins compose scopes themselves):
+
+- `GetSetting(scope, principal_id, key)` → typed value (`string` / `int` / `bool`
+  / `duration` / **`string_list`**) + a `found` witness. `scope ∈ {GAME, PLAYER,
+  CHARACTER}`; `principal_id` is the player ID (PLAYER), character ID (CHARACTER),
+  or empty (GAME).
+- `SetSetting(scope, principal_id, key, values)` → ack.
+
+**Owner binding (structural isolation, INV-11).** The host resolves the
+**authenticated calling plugin's name** at the RPC boundary and serves the call
+against `base.Owner(callerName)`. The plugin **does not** pass an owner — there is
+no parameter through which it could name another plugin's partition. Isolation is
+by construction, not a per-call runtime check.
+
+**Runtime symmetry (INV-8).** The Go SDK method *and* the Lua hostfunc MUST ship
+together (`.claude/rules/plugin-runtime-symmetry.md`).
+
+**Authorization (INV-7).** Through the existing ABAC `Evaluate` path, as a new
+action on a `setting` resource:
+
+- A principal MAY read/write its **own** PLAYER-scope (`principal_id` == acting
+  `player_id`) and CHARACTER-scope (owned character) settings.
+- **GAME-scope writes** require an operator action; GAME-scope reads are permitted
+  (settings are not secret).
+- Cross-principal access is denied. Default-deny.
+
+### 3.3 Workstream C — Content-warning model (owned by core-scenes)
+
+The content-warning vocabulary lives **entirely in core-scenes**; `internal/`
+never names it.
+
+- **Keys** (in core-scenes' own partition): `content.cw_taxonomy` (GAME scope —
+  allowed category keys) and `content.cw_block` (PLAYER/CHARACTER scope — blocked
+  categories). Both string-lists.
+- **Default taxonomy via read-time fallback** (not bootstrap seeding). core-scenes
+  ships a `DefaultCWTaxonomy` constant. The effective taxonomy is the GAME-scope
+  `content.cw_taxonomy` if set, else the constant. A fresh game filters correctly
+  with zero config (INV-5); an operator overrides by writing the GAME-scope value
+  (operator-gated per INV-7). No seed migration, no bootstrap-order dependency, no
+  seed-write authz wrinkle.
+- **Validation.** `CreateScene` / `UpdateScene` reject any `content_warnings`
+  value not in the effective taxonomy (`INVALID_ARGUMENT`, INV-4). Replaces
+  today's unvalidated free-form. No retroactive validation (no deployed data).
+
+Proposed `DefaultCWTaxonomy`: `violence`, `sexual-content`, `death`,
+`substance-use`, `self-harm`, `body-horror`, `abuse`. Contents are a plugin
+constant, not a contract.
+
+### 3.4 Workstream D — Scene board query
+
+Implement `ListScenes` in `core-scenes`:
+
+- **Visibility (INV-1).** Active `open` scenes only; `private` scenes never
+  appear — this is why v2 dropped `unlisted` (the board *is* discovery).
+- **State.** Active scenes; `paused` included and flagged. Ended/archived/
+  published excluded (published logs are an Epic-8 surface).
+- **Pagination + tag filter.** Honors `ListScenesRequest` `limit`/`offset` and
+  `tags` (all already in proto).
+- **CW filter (INV-3, server-side).** Excludes scenes carrying any CW in the
+  caller's resolved `content.cw_block` (see resolution below), plus any per-query
+  exclude args. **All filtering is in the query** — client-side post-filtering is
+  forbidden because it breaks pagination. The per-query args ride the wire via a
+  new `exclude_content_warnings` field on `ListScenesRequest`; identity rides via
+  new `player_id`/`character_id` fields (the request currently carries only
+  `limit`/`offset`/`tags`, `scene.proto:245-261`).
+- **CW display (INV-2).** Every returned row carries its CW labels — display is
+  never suppressed by a filter.
+
+**CW block resolution — union across scopes (INV-6).** core-scenes reads
+`content.cw_block` from its own partition at **GAME, PLAYER, and CHARACTER** scope
+via three single-scope `GetSetting` calls and **unions** them. Union — not
+first-match-wins — because content warnings are a **safety** feature: a
+player-level "never show me X" boundary MUST NOT be discarded by a character-scope
+list that omits X. The host settings `Chain` (used by host code) remains
+first-match-wins for scalars; the union is the plugin consumer's own composition
+over single-scope primitives, so no substrate semantics change.
+
+### 3.5 Workstream E — `scenes` board command
+
+Terminal command rendering board rows: title, id, owner, participant count, tags,
+content-warning labels, and a paused flag. CW labels always shown. Parses
+per-query `hide:<cw>` / `tag:<t>` args into the request. Web rendering is out of
+scope (`5rh.8`). The board is the top-level `scenes` command (browse all open);
+the existing per-character listing stays as `scene list` (overlap resolved in
+planning).
+
+## 4. Invariants (RFC2119)
+
+| ID | Invariant |
+| -- | --------- |
+| **INV-1** | The board MUST return only active `open` scenes; `private` scenes MUST never appear. Default-deny on unknown visibility. |
+| **INV-2** | Every board row MUST display its content-warning labels regardless of active filters. Display MUST NOT be suppressible by a filter. |
+| **INV-3** | A scene carrying any content warning in the caller's resolved `content.cw_block` MUST be excluded from board results, server-side. |
+| **INV-4** | `CreateScene`/`UpdateScene` MUST reject `content_warnings` values not in the effective taxonomy. |
+| **INV-5** | With no game-configured taxonomy, core-scenes' `DefaultCWTaxonomy` MUST apply; a fresh game MUST validate/filter correctly with zero operator configuration. |
+| **INV-6** | `content.cw_block` resolution MUST be the **union** of GAME, PLAYER, and CHARACTER scope lists (safety-accumulating), not first-match-wins. |
+| **INV-7** | Settings access MUST be ABAC-authorized: a principal MAY read/write its own PLAYER/CHARACTER settings; GAME-scope writes MUST require an operator action. Default-deny. |
+| **INV-8** | The settings host RPC MUST ship a Go SDK method AND a Lua hostfunc together (runtime parity). |
+| **INV-9** | List-valued settings MUST use the first-class `StringSliceN` accessor; they MUST NOT be JSON blobs through `StringN`. |
+| **INV-10** | The host MUST remain domain-ignorant: it MUST NOT contain a typed field naming a plugin-domain concept; plugin settings live in an opaque `plugins` passthrough partition the host never interprets. |
+| **INV-11** | Cross-plugin isolation MUST be structural: the host binds the owner partition from the authenticated caller identity (`pluginHostServiceServer.pluginName`, stamped at server construction, `host_service.go:28`), never from caller-supplied input; a plugin MUST NOT be able to address another owner's partition. |
+| **INV-12** | `RegisteredNamespaces` validation MUST apply only to the host partition (owner `""`); plugin partitions own their keyspace unchecked. Once the substrate ships, adding a new plugin setting key MUST require zero `internal/` edits (the one-time `Plugins` passthrough field and the owner-narrowing machinery are substrate, not per-key cost). |
+
+Each invariant is backed by a test; a meta-test asserts the catalog is complete.
+
+## 5. Testing strategy
+
+- **Settings substrate (unit):** `StringSliceN` across all backings (game-scope
+  encode/decode round-trip, `emptySettings` unset contract). `Owner()`/`Host()`
+  narrowing: a write under `.Owner("x")` is invisible to `.Owner("y")` and to
+  `.Host()`, and survives a host-partition typed-struct round-trip (no clobber).
+- **Owner isolation (unit, INV-11):** the host-bound view rejects/has-no-path to
+  another owner's keys; a plugin partition write does not require a
+  `RegisteredNamespaces` entry (INV-12).
+- **Character scope (integration):** real `characters.preferences` CRUD against a
+  Postgres testcontainer; migration up/down reversibility.
+- **Host RPC (integration):** `GetSetting`/`SetSetting` over the real
+  `PluginHostService`, both Go and Lua paths (INV-8 parity), with ABAC denial
+  paths (`policytest.DenyAllEngine`) for cross-principal and GAME-scope writes
+  (INV-7), and a test that a plugin cannot reach another owner's partition (INV-11).
+- **Content-warning model (unit + integration):** INV-4 reject path; INV-5
+  default-taxonomy fallback with no game config; INV-6 union across the three
+  scopes.
+- **Board query (integration):** `integrationtest` full-stack — INV-1 (private
+  invisible), INV-2 (labels always present), INV-3 (block excludes), pagination,
+  tag + CW filter composition.
+
+## 6. Considered alternatives
+
+- **Typed host field** (`auth.PlayerPreferences.Content.CWBlock`). Rejected
+  (INV-10): walks a plugin-domain concept into `internal/auth` and forces an
+  `internal/` edit per plugin preference — the existing `Scenes.FocusReplayTail`
+  field is this same leak, debt not to extend.
+- **Generic flat-map over `players.preferences` without owner partitioning.**
+  Rejected: collides with the typed `auth.PlayerPreferences` whole-struct marshal
+  (`player_repo.go:33,169`) — two writers of one column, the typed write silently
+  drops generic keys.
+- **Plugin-local CW table** (`plugin_core_scenes.player_cw_prefs`). Rejected:
+  re-solders generic preference storage per plugin; defeats "solve prefs once."
+- **Host KV store** (`KVGet`/`KVSet`, itself unserved). Rejected: opaque blob
+  storage with no typed accessors, no scope chaining, no owner isolation.
+- **`SETTING_SCOPE_CHAINED` RPC mode.** Rejected primarily because the only
+  consumer (CW block) needs a *union* across scopes (INV-6), not the chain's
+  first-match-wins — so the plugin makes three explicit single-scope calls
+  regardless, and a chained mode would be dead surface. (Secondarily, a chained
+  read from a single `principal_id` would force the host to do a character→player
+  lookup the single-scope design never needs.) Host code that wants first-match
+  chaining still uses the in-process `settings.Chain` directly.
+- **Bootstrap taxonomy seeding.** Rejected in favor of read-time default fallback:
+  avoids a seed migration, bootstrap-order dependency, and the seed-write authz
+  question (who may write GAME scope at init).
+
+## 7. Open questions (for design-review)
+
+- **`scenes` command overlap.** Board (`scenes`) vs the existing per-character
+  listing (`scene list`): confirm distinct verbs vs one command with modes.
+- **`DefaultCWTaxonomy` contents.** §3.3's list is a plugin constant; confirm the
+  starting category set.
+- **Per-query "peek" override.** Whether a per-query arg may *show* a normally
+  blocked CW for a single board view (`scenes show:violence`), or whether blocks
+  are absolute. Leaning: allow an explicit per-query show (informed in-the-moment
+  choice).
+
+<!-- adr-capture: sha256=da25fec1098b8e69; session=iokti; ts=2026-05-30T09:22:25Z; adrs=holomush-74ib4,holomush-uvbyt,holomush-0blcz -->


### PR DESCRIPTION
## Summary

Design docs for **Scenes Phase 8** — the scene board + content-warning model, built on a new **owner-partitioned settings substrate** that exposes typed, structurally-isolated per-plugin settings without the host learning any plugin's vocabulary.

Materialized as epic `holomush-iokti` (14 tasks). This PR lands the docs only; implementation follows per-bead.

## Contents

- **Spec** — `docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md` (design-reviewer READY, round 3)
- **Plan** — `docs/superpowers/plans/2026-05-29-scenes-phase-8-board-content-warnings.md` (plan-reviewer READY, round 2; 14 tasks / 5 phases)
- **3 ADRs:**
  - `holomush-74ib4` — owner-partitioned plugin settings + opaque host passthrough
  - `holomush-uvbyt` — structural cross-plugin isolation via authenticated caller binding
  - `holomush-0blcz` — safety-union resolution for content-warning block settings

## Key design decisions (the short version)

- The host stays **domain-ignorant**: plugin preferences live in an opaque `Plugins map[string]json.RawMessage` passthrough on `auth.PlayerPreferences`; "content warning" exists only in core-scenes. Adding a plugin setting key needs **zero `internal/` edits**.
- Cross-plugin isolation is **structural** — the settings host RPC binds the owner from the authenticated `pluginHostServiceServer.pluginName`, never from a wire field.
- Content-warning blocks resolve as the **union** across game/player/character scope (safety-accumulating), deliberately diverging from the substrate's first-match-wins.

## Reviewers in scope for implementation (not this docs PR)

`abac-reviewer` (settings-write authz), `code-reviewer`, plugin-runtime-symmetry (Go+Lua parity for the settings RPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)