### PR TITLE
docs(session): liveness + gateway-survival spec, plan, ADRs (holomush-rsoe6)

### DIFF
--- a/docs/adr/holomush-0qx5e-boot-grace-not-boot-reconcile.md
+++ b/docs/adr/holomush-0qx5e-boot-grace-not-boot-reconcile.md
@@ -1,0 +1,55 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Boot-Grace Window Replaces Boot-Reconcile for Core-Restart Safety
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-0qx5e
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The naive fix for orphaned `active` sessions is to mark all `active` sessions
+`detached` when core boots — the historical MUSH "everyone goes linkdead on
+reboot" pattern. HoloMUSH's process topology changes the semantics: core and
+the gateway are **separate processes**, and a core restart does not disconnect
+clients whose sockets live in the gateway (`cmd/holomush/gateway.go` hosts both
+the web and telnet servers). Single-core-process is a documented invariant
+(`docs/plans/2026-04-07-cursor-lock-finding-1-closure.md`), but that does not
+imply single *transport* process.
+
+## Decision
+
+On core process start the lease sweep is suppressed for a **boot-grace window**
+of at least `L + margin`; no `active` sessions are forcibly detached at boot.
+Live gateway connections re-assert their leases within one refresh interval,
+after which the sweep resumes normally (invariant **I-LIVE-4**). This is
+orthogonal to the `AddConnection` lease stamp (`last_seen_at = now`), which
+independently protects the legitimate zero-connection window of a
+freshly-created session.
+
+## Rationale
+
+- A core restart is invisible to clients attached through the gateway; treating
+  it as a mass disconnect would force a detach/reattach "reconnect storm" on
+  every deploy.
+- The grace window gives live gateways time to re-assert their leases before the
+  sweep could incorrectly reap them — no special gateway↔core boot coordination
+  is required.
+- It is a time-bounded suppression, not a permanent exemption: pre-restart
+  ghosts are still swept once the window elapses.
+
+## Alternatives Considered
+
+- **Boot reconcile (mark all `active` sessions `detached` on core boot).**
+  Rejected: unsafe under the separate-gateway topology — it would forcibly
+  detach users who are actively connected through the gateway. Immediate
+  clearing of pre-restart ghosts does not justify dropping live sessions.
+
+## Consequences
+
+Pre-restart ghost sessions persist for up to `L` + the grace window (≈60s
+default) after a core restart before being swept. The grace parameter MUST
+exceed the gateway's refresh interval; misconfiguration could cause spurious
+detaches.

--- a/docs/adr/holomush-2w9vh-gateway-is-liveness-authority.md
+++ b/docs/adr/holomush-2w9vh-gateway-is-liveness-authority.md
@@ -1,0 +1,53 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# The Gateway Is the Liveness Authority for Connection Leases
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-2w9vh
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Given a decaying connection-lease model (see holomush-6syxb), the question is
+*which process refreshes the lease*. Core holds the session and connection
+records. The gateway (a separate, long-lived process) holds the actual client
+sockets — web (`internal/web`) and telnet (`internal/telnet`) — and has direct
+visibility into client-death signals (WebSocket close, TCP RST, idle-timeout,
+heartbeat `Send` failure) that core cannot observe from its side of the
+gateway↔core gRPC stream.
+
+## Decision
+
+The gateway process is the **sole authority** that refreshes a connection's
+liveness lease. It calls `RefreshConnection` on each heartbeat tick while the
+client socket is open and ceases refreshing within one tick of detecting
+transport loss (invariant **I-LIVE-1**). The existing 15s client-liveness
+heartbeat in `StreamEvents` is the refresh vehicle on web; the telnet read-loop
+/ idle-timeout is the equivalent on telnet.
+
+## Rationale
+
+- The gateway directly observes client-socket state that core cannot: a
+  half-open client whose gateway↔core stream is still open would fool any
+  core-side timer, but the gateway's heartbeat `Send` failure detects it.
+- The existing 15s heartbeat is a natural refresh hook — no new timer
+  infrastructure is required.
+- The gateway already calls `Disconnect` on client loss; `RefreshConnection` is
+  the symmetric positive liveness assertion.
+
+## Alternatives Considered
+
+- **Core-side timer bump** (no gateway change, no new RPC): core bumps
+  `last_seen_at` on inbound stream activity. Rejected: core's view of the
+  gateway↔core stream cannot detect a dead client whose stream is still open, so
+  it would keep a half-open client's lease alive indefinitely — defeating the
+  entire purpose of the lease.
+
+## Consequences
+
+Steady-state cost: one `RefreshConnection` call per connection per refresh
+interval (~15s). The gateway gains a correctness obligation — a bug that fails
+to stop refreshing on client death would keep a ghost alive — but that surface
+is small and symmetric with the existing `Disconnect`-on-close path.

--- a/docs/adr/holomush-6syxb-liveness-derives-from-connection-lease.md
+++ b/docs/adr/holomush-6syxb-liveness-derives-from-connection-lease.md
@@ -1,0 +1,64 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Session Liveness Derives From a Decaying Connection Lease
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-6syxb
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+Sessions stuck at `status='active'` after a core restart or an unclean
+disconnect are structurally uncollectable: the reaper only sweeps
+`detached`-and-past-TTL rows (`ListExpired`), `active` rows carry
+`expires_at = NULL`, and the cooperative `Disconnect` RPC is the only path
+that transitions `active → detached`. The root cause is that presence trusts
+*stored intent* (the `status` enum) rather than an *observed, self-decaying*
+signal — so any time the cooperative cleanup is skipped (SIGKILL on redeploy,
+browser-tab close with no `Disconnect`, network drop), `status` freezes at
+`active` over a dead transport and the session becomes a permanent
+presence ghost. This also produces a two-reaper deadlock: the guest idle
+reaper excludes any guest with an `active`/`detached` session, so the orphan
+immunizes the guest from cleanup too.
+
+## Decision
+
+Session liveness is determined **solely** by a per-connection
+`session_connections.last_seen_at` lease that MUST be actively refreshed. A
+connection whose lease has lapsed (`last_seen_at < now − L`) is removed by the
+lease sweep without requiring a cooperative `Disconnect`. `active` and
+`grid_present` become **derived** quantities recomputed from the live
+connection set. No read path may treat `status='active'` as evidence of a live
+transport independent of the lease layer (invariant **I-LIVE-5**). The
+cooperative `Disconnect` RPC is retained as the graceful-close fast-path; the
+lease is the backstop for every non-cooperative case.
+
+## Rationale
+
+- The stored `status` enum is intent, not observation; any approach that trusts
+  it directly recreates ghost-presence whenever cooperative cleanup is skipped.
+- A decaying lease is *correct-by-construction*: a dead transport simply stops
+  being refreshed, the lease lapses, and the connection is swept — surviving a
+  core restart (a live gateway re-asserts within one interval) and killing
+  ghosts (nothing refreshes a corpse).
+- The pattern has direct precedent in the codebase: `plugin_repo.last_seen_at` +
+  `SweepInactive` already do exactly this for plugins.
+- It breaks the guest-reaper / session-reaper deadlock by construction.
+
+## Alternatives Considered
+
+- **A — boot reconcile (mark all `active` detached on core boot).** Rejected:
+  unsafe under the gateway topology — a core restart does not disconnect clients
+  whose sockets live in the gateway process, so this would forcibly detach
+  genuinely-live users.
+- **B — sweep `active` sessions with zero `session_connections` rows.**
+  Rejected: subsumed by the lease model, and the existence of a connection row
+  is not evidence of liveness (a SIGKILL leaves dangling rows).
+- **C — extend the reaper to `active` + no-connection + stale `updated_at`.**
+  Rejected: subsumed; `updated_at` is not a liveness signal.
+- **D — presence query joins `session_connections` (EXISTS check).** Rejected:
+  a SIGKILL leaves connection rows dangling too, so `EXISTS(connection)` is
+  satisfied by a corpse. The decaying `last_seen_at` is the correct-by-construction
+  form of this direction.

--- a/docs/adr/holomush-6vl53-active-vs-grid-present-axes.md
+++ b/docs/adr/holomush-6vl53-active-vs-grid-present-axes.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# `active` and `grid_present` Are Distinct Domain Axes; Roster Uses `grid_present`
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-6vl53
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+The existing presence model collapses two distinct questions into one field:
+"does the session have any live transport?" and "is the character visible on the
+grid (a terminal/telnet connection)?". `ListActiveByLocation`
+(`internal/store/session_store.go:620`) filters on `status='active'` only, so a
+character connected via only a non-grid transport would appear in the location
+roster. These axes have different consumers and different semantics.
+
+## Decision
+
+`session.active` means the session has ≥1 live connection of **any** transport
+type; `session.grid_present` means the session has ≥1 live connection of
+`client_type ∈ {terminal, telnet}`. The location presence roster MUST be
+filtered to `grid_present` characters, not raw `active` sessions (invariants
+**I-LIVE-3**, **I-PRES-1**). Both flags are recomputed from the live connection
+set on every connection-set change.
+
+## Rationale
+
+- The location roster represents "who can be seen and interacted with on the
+  grid" — a terminal/telnet semantic, not generic connectivity.
+- Separating the axes is forward-compatible with future non-grid transports
+  (API, webhook callbacks) that create `active` sessions without conferring grid
+  presence.
+- `grid_present` is already a stored `BOOLEAN` column on `sessions`
+  (`migrations/000001_baseline.up.sql:209`); the split reuses existing schema
+  rather than introducing new tables, and keeps presence reads cheap (flag-based,
+  no per-read join into `session_connections`).
+
+## Alternatives Considered
+
+- **Collapse `active` and `grid_present`** (treat `status='active'` as implying
+  grid presence). Rejected: not forward-compatible with non-grid transports;
+  incorrectly surfaces any-transport connections on the location roster; and
+  conflates two orthogonal concerns, making a later decoupling a breaking change.
+
+## Consequences
+
+Any code that currently equates `active` with grid-visible must move to
+`grid_present`. Two boolean flags must be kept in sync on every connection-set
+change (owned by the lease/connection recompute layer).

--- a/docs/adr/holomush-85exr-gateway-survival-durable-consumer-resume.md
+++ b/docs/adr/holomush-85exr-gateway-survival-durable-consumer-resume.md
@@ -1,0 +1,58 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 HoloMUSH Contributors -->
+
+# Gateway-Survival Resume Uses JetStream Durable-Consumer Re-Subscribe + Client-Side Dedup
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-85exr
+**Deciders:** HoloMUSH Contributors
+
+## Context
+
+When the core `Subscribe` stream breaks while a client socket is still open, the
+gateway must resume event delivery gap-free instead of tearing the client down.
+A prior design carried a caller-supplied replay cursor on `SubscribeRequest`
+(`replay_from_cursor`); that field was **removed** and reserved
+(`api/proto/holomush/core/v1/core.proto:228`) when the focus substrate landed.
+The JetStream durable per-session consumer already tracks its own acked sequence
+server-side (`internal/grpc/server.go:753-756/994/1065`, `internal/eventbus/bus.go:69-74`).
+
+## Decision
+
+On gateway-survival reconnect the gateway re-`Subscribe`s the **same**
+`session_id` with **no** cursor input; core re-opens the durable per-session
+JetStream consumer, which resumes from its acked sequence server-side. Because
+core acks *after* sending (`server.go:1274`), at most the in-flight frame is
+redelivered; the gateway tracks the last forwarded `EventFrame.cursor`/`id` and
+dedups that overlap so the client sees no duplicate or missing events (invariant
+**I-SURV-2**). If the session detached during the core-down gap, the gateway
+reattaches via `SelectCharacter` (`reattached=true`). New web `ControlSignal`
+values `RECONNECTING=4` / `RECONNECTED=5` surface the state to the client.
+
+## Rationale
+
+- `replay_from_cursor` was deliberately removed; the server-side durable consumer
+  is the canonical resume mechanism and owns the replay policy.
+- The consumer's acked-seq is the authoritative gap-free resume point; a
+  gateway-supplied cursor would be redundant at best and incorrect at worst (the
+  gateway may not know the server's exact acked position).
+- Client-side dedup of the bounded overlap (at most one in-flight frame) is
+  predictable, not a full replay scan.
+
+## Alternatives Considered
+
+- **Cursor-in-request resume** (re-add `replay_from_cursor`). Rejected: removed
+  from the proto; caller-supplied cursors permit arbitrary rewinds (backpressure
+  / abuse surface); the durable consumer already tracks the correct point.
+- **Client-driven reconnect only** (no gateway survival; the browser reconnects).
+  Rejected: exposes core restarts as user-visible disconnects and does not
+  prevent ghost sessions (the client re-`SelectCharacter`s into a new session) —
+  fails the "core restart doesn't interrupt activity" goal (G2).
+
+## Consequences
+
+The gateway must maintain per-connection last-forwarded event-id state for
+dedup. Survival depends on the JetStream durable consumer surviving the core
+restart; a lost consumer surfaces as `SESSION_NOT_FOUND` and routes to the
+reattach path. Two new `ControlSignal` enum values are added to `web.proto`.

--- a/docs/superpowers/plans/2026-05-30-session-liveness-and-gateway-survival.md
+++ b/docs/superpowers/plans/2026-05-30-session-liveness-and-gateway-survival.md
@@ -1,0 +1,1279 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Session Liveness & Gateway Survival Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `active`/`grid_present` derive from a gateway-refreshed connection lease that decays on its own, so a disconnected session (e.g. across a core redeploy) stops appearing in presence, and hold client transports across a core restart via durable-consumer reconnect.
+
+**Architecture:** A per-connection lease (`session_connections.last_seen_at`) refreshed by the gateway while the client socket is open; a reaper sweep reaps lapsed connections and recomputes session liveness; the web/telnet gateways refresh the lease and survive core-stream breaks by re-`Subscribe`-ing the durable per-session JetStream consumer (server-side acked-seq resume) and deduping the un-acked overlap. Presence reads the now-honest `grid_present` flag.
+
+**Tech Stack:** Go, PostgreSQL (pgx + `pgnanos` ns-epoch bigints), embedded NATS JetStream (durable consumers), ConnectRPC/gRPC (`corev1`/`webv1`), testify + Ginkgo (integration) + Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md` (invariants I-LIVE-1..5, I-PRES-1, I-SURV-1..5, I-SEC-1).
+
+**Sequencing constraint (from the spec):** P1's lease *sweep* MUST NOT be enabled in production before P2's *refresher* exists, or live sessions get reaped. This plan orders refresh (Phase 2) before the sweep is wired into the running reaper (the sweep store/reaper code lands in Phase 1 but its `Run`-loop activation is the last step of Phase 2). Within one epic landing as a coordinated set this is just task ordering.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `internal/store/migrations/000045_session_connection_last_seen.{up,down}.sql` | add `last_seen_at` + index | T1 |
+| `internal/session/session.go` | `Store` interface: add `RefreshConnection`, `ListLapsedConnections`; `LapsedConnection` type | T2 |
+| `internal/store/session_store.go` | implement the two methods; stamp `last_seen_at` in `AddConnection`; `grid_present` predicate on `ListActiveByLocation` | T2, T12 |
+| `internal/session/mocks/mock_Store.go` | regenerated mock | T2 |
+| `api/proto/holomush/core/v1/core.proto` | `RefreshConnection` RPC + messages | T3 |
+| `api/proto/holomush/web/v1/web.proto` | `CONTROL_SIGNAL_RECONNECTING`/`RECONNECTED` enum values | T9 |
+| `internal/grpc/refresh_connection.go` | `RefreshConnection` handler (ownership-validated) | T3 |
+| `internal/grpc/server.go` | `recomputeSessionLiveness` extracted from `Disconnect` lifecycle; call on `AddConnection` | T4 |
+| `internal/session/reaper.go` | lease sweep + boot-grace; `ReaperConfig` callbacks | T5 |
+| `cmd/holomush/sub_grpc.go` | wire lease-sweep config + callbacks (engine in scope) | T6 |
+| `internal/web/handler.go` | refresh on heartbeat (T7); survival reconnect loop (T10) | T7, T10 |
+| `internal/telnet/gateway_handler.go` | refresh ticker (T8); survival reconnect (T11) | T8, T11 |
+| `test/integration/presence/*_test.go`, `web/e2e/*.spec.ts`, `test/meta/*_test.go` | integration + E2E + invariant-bijection meta-test | T13–T16 |
+
+> **Test-fixture convention:** integration tests construct an `*auth.PlayerSession`
+> and `*session.Info` and seed them via `sessiontest.SeedPlayerSession(t, pool, ps)`
+> + `store.Set(ctx, sess.ID, sess)`, following
+> `test/integration/session/session_persistence_suite_test.go`. The
+> `sessiontest.NewPlayerSession()` / `NewActiveSession(ps)` calls in the snippets
+> below are **shorthand** for that construction — add them as local test helpers
+> (they are not yet in `sessiontest`). `sessiontest.NewStoreWithPool(t)` returns
+> `(store, pool)` in that order. Proto/codegen regeneration is `task proto`.
+> Gateway test helpers in the web/telnet snippets (`runStreamEventsBriefly`,
+> `captureClientFrames`, `newReconnectingCoreClient`, `newAuthedHandler`,
+> `fake.refreshCalls()`, `fake.subscribeCalls()`, etc.) are likewise
+> implementer-supplied scaffolding mirroring the fakes already in
+> `internal/web/handler_test.go` / `internal/telnet/gateway_handler_test.go`.
+>
+> **Model intent (Rule 5):** default `model:sonnet` for every task (the sub-agent
+> floor is sonnet — never haiku, per `.claude/rules/subagent-briefing.md`). Tasks
+> **5** (lease sweep + reaper concurrency), **10** and **11** (gateway reconnect
+> state machine) warrant `model:opus`. `plan-to-beads` applies these as `model:*`
+> labels on the materialized beads.
+
+---
+
+## Phase 1 — Core connection lease
+
+### Task 1: Migration — add `last_seen_at` lease column
+
+**Files:**
+
+- Create: `internal/store/migrations/000045_session_connection_last_seen.up.sql`
+- Create: `internal/store/migrations/000045_session_connection_last_seen.down.sql`
+
+- [ ] **Step 1: Write the up migration**
+
+`000045_session_connection_last_seen.up.sql`:
+
+```sql
+-- Connection lease: last_seen_at is refreshed by the gateway while the client
+-- socket is open (holomush-rsoe6). A connection whose last_seen_at is older
+-- than the lease TTL is reaped, decoupling liveness from the stored status enum.
+ALTER TABLE session_connections
+  ADD COLUMN IF NOT EXISTS last_seen_at BIGINT NOT NULL DEFAULT 0;
+
+-- Backfill existing rows: treat their connect time as their last-seen time.
+UPDATE session_connections SET last_seen_at = connected_at WHERE last_seen_at = 0;
+
+CREATE INDEX IF NOT EXISTS idx_session_connections_last_seen
+  ON session_connections (last_seen_at);
+```
+
+- [ ] **Step 2: Write the down migration**
+
+`000045_session_connection_last_seen.down.sql`:
+
+```sql
+DROP INDEX IF EXISTS idx_session_connections_last_seen;
+ALTER TABLE session_connections DROP COLUMN IF EXISTS last_seen_at;
+```
+
+- [ ] **Step 3: Verify migration round-trips on a scratch DB**
+
+Run: `task test:int -- -run TestMigrations ./internal/store/...`
+Expected: PASS (migrations apply up then down cleanly; integration tests run against a fresh DB).
+
+- [ ] **Step 4: Commit**
+
+Commit per `references/vcs-preamble.md`: `feat(store): add session_connections.last_seen_at lease column (holomush-rsoe6)`
+
+---
+
+### Task 2: Store — `RefreshConnection`, `ListLapsedConnections`, stamp lease on `AddConnection`
+
+**Files:**
+
+- Modify: `internal/session/session.go` (Store interface ~343-357)
+- Modify: `internal/store/session_store.go` (`AddConnection` ~557-560; add two methods after `RemoveConnection` ~577)
+- Test: `test/integration/session/session_lease_test.go` (new; SharedPostgres → `//go:build integration`)
+- Regenerate: `internal/session/mocks/mock_Store.go`
+
+- [ ] **Step 1: Write the failing integration test**
+
+`test/integration/session/session_lease_test.go`:
+
+```go
+//go:build integration
+
+package session_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/testsupport/sessiontest"
+)
+
+func TestRefreshConnectionBumpsLastSeenAndListLapsedExcludesIt(t *testing.T) {
+	ctx := context.Background()
+	store, pool := sessiontest.NewStoreWithPool(t)
+
+	ps := sessiontest.NewPlayerSession()
+	sessiontest.SeedPlayerSession(t, pool, ps)
+	sess := sessiontest.NewActiveSession(ps) // status=active, future ExpiresAt
+	require.NoError(t, store.Set(ctx, sess.ID, sess))
+
+	connID := ulid.Make()
+	require.NoError(t, store.AddConnection(ctx, &session.Connection{
+		ID: connID, SessionID: sess.ID, ClientType: "terminal",
+		ConnectedAt: time.Now().Add(-time.Hour), // stale connect time
+	}))
+
+	// AddConnection stamps last_seen_at = connected_at (stale here), so the
+	// connection is initially lapsed relative to a 45s TTL.
+	lapsed, err := store.ListLapsedConnections(ctx, time.Now().Add(-45*time.Second))
+	require.NoError(t, err)
+	assert.Len(t, lapsed, 1, "stale-connect connection is lapsed before refresh")
+
+	// Refresh bumps last_seen_at to now.
+	require.NoError(t, store.RefreshConnection(ctx, connID))
+
+	lapsed, err = store.ListLapsedConnections(ctx, time.Now().Add(-45*time.Second))
+	require.NoError(t, err)
+	assert.Empty(t, lapsed, "refreshed connection is no longer lapsed")
+}
+
+func TestRefreshConnectionReturnsNotFoundForMissingConnection(t *testing.T) {
+	ctx := context.Background()
+	store, _ := sessiontest.NewStoreWithPool(t)
+	err := store.RefreshConnection(ctx, ulid.Make())
+	require.Error(t, err)
+	assert.Equal(t, "CONNECTION_NOT_FOUND", oopsCode(t, err))
+}
+```
+
+(Helper `oopsCode` asserts the top-level oops code per `.claude/rules/grpc-errors.md`; reuse the package's existing helper or add `func oopsCode(t *testing.T, err error) string { t.Helper(); o, ok := oops.AsOops(err); require.True(t, ok); return o.Code() }`.)
+
+- [ ] **Step 2: Run it — expect compile failure**
+
+Run: `task test:int -- -run TestRefreshConnection ./test/integration/session/...`
+Expected: FAIL — `store.ListLapsedConnections` / `store.RefreshConnection` undefined.
+
+- [ ] **Step 3: Add interface methods + `LapsedConnection` type**
+
+In `internal/session/session.go`, inside the `Store` interface (after `RemoveConnection`, ~347):
+
+```go
+	// RefreshConnection bumps a connection's lease (last_seen_at = now).
+	// Returns CONNECTION_NOT_FOUND if no row matches connectionID.
+	RefreshConnection(ctx context.Context, connectionID ulid.ULID) error
+
+	// ListLapsedConnections returns connections whose lease is older than
+	// olderThan — i.e. last_seen_at < olderThan. Used by the lease sweep.
+	ListLapsedConnections(ctx context.Context, olderThan time.Time) ([]LapsedConnection, error)
+```
+
+And the type (near `Connection`):
+
+```go
+// LapsedConnection is the projection the lease sweep needs: enough to remove
+// the row and recompute the owning session's derived liveness.
+type LapsedConnection struct {
+	ID         ulid.ULID
+	SessionID  string
+	ClientType string
+}
+```
+
+- [ ] **Step 4: Implement in `session_store.go`**
+
+Stamp the lease in `AddConnection` — extend the INSERT (line ~558-560):
+
+```go
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO session_connections (id, session_id, client_type, streams, focus_key, connected_at, last_seen_at)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $6)`,
+		conn.ID.String(), conn.SessionID, conn.ClientType, streams, focusKeyJSON, pgnanos.From(conn.ConnectedAt))
+```
+
+Add after `RemoveConnection` (~577):
+
+```go
+// RefreshConnection bumps a connection's lease to now.
+func (s *PostgresSessionStore) RefreshConnection(ctx context.Context, connectionID ulid.ULID) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE session_connections SET last_seen_at = (EXTRACT(EPOCH FROM now()) * 1e9)::BIGINT WHERE id = $1`,
+		connectionID.String())
+	if err != nil {
+		return oops.With("operation", "refresh connection").
+			With("connection_id", connectionID.String()).Wrap(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return oops.Code("CONNECTION_NOT_FOUND").
+			With("connection_id", connectionID.String()).
+			Errorf("connection not found")
+	}
+	return nil
+}
+
+// ListLapsedConnections returns connections whose lease is older than olderThan.
+func (s *PostgresSessionStore) ListLapsedConnections(ctx context.Context, olderThan time.Time) ([]session.LapsedConnection, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, session_id, client_type FROM session_connections WHERE last_seen_at < $1`,
+		pgnanos.From(olderThan))
+	if err != nil {
+		return nil, oops.With("operation", "list lapsed connections").Wrap(err)
+	}
+	defer rows.Close()
+	var out []session.LapsedConnection
+	for rows.Next() {
+		var idStr string
+		var lc session.LapsedConnection
+		if scanErr := rows.Scan(&idStr, &lc.SessionID, &lc.ClientType); scanErr != nil {
+			return nil, oops.With("operation", "scan lapsed connection").Wrap(scanErr)
+		}
+		id, parseErr := ulid.Parse(idStr)
+		if parseErr != nil {
+			return nil, oops.With("operation", "parse lapsed connection id").With("id", idStr).Wrap(parseErr)
+		}
+		lc.ID = id
+		out = append(out, lc)
+	}
+	return out, oops.Wrap(rows.Err())
+}
+```
+
+- [ ] **Step 5: Regenerate the mock + run**
+
+Run: `mockery` then `task test:int -- -run TestRefreshConnection ./test/integration/session/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+`feat(session): RefreshConnection + ListLapsedConnections lease store methods (holomush-rsoe6)`
+
+---
+
+### Task 3: `RefreshConnection` RPC (ownership-validated, enumeration-safe)
+
+**Files:**
+
+- Modify: `api/proto/holomush/core/v1/core.proto` (add RPC + messages near `Disconnect`)
+- Create: `internal/grpc/refresh_connection.go`
+- Test: `internal/grpc/refresh_connection_test.go`
+- Regenerate protos (`task` proto-generate target)
+
+- [ ] **Step 1: Add proto RPC + messages**
+
+In `core.proto`, add to `service CoreService` (next to `Disconnect`):
+
+```protobuf
+  // RefreshConnection bumps a connection's liveness lease. Called periodically
+  // by the gateway while the client socket is open (holomush-rsoe6). SERVED by
+  // CoreServer.RefreshConnection; ownership-validated and enumeration-safe.
+  rpc RefreshConnection(RefreshConnectionRequest) returns (RefreshConnectionResponse);
+```
+
+And the messages:
+
+```protobuf
+// RefreshConnectionRequest asks core to bump the lease for one connection.
+message RefreshConnectionRequest {
+  // meta carries request correlation data.
+  RequestMeta meta = 1;
+  // session_id names the game session owning the connection.
+  string session_id = 2;
+  // connection_id is the connection whose lease to refresh.
+  string connection_id = 3;
+  // player_session_token proves the caller owns session_id.
+  string player_session_token = 4;
+}
+
+// RefreshConnectionResponse is empty on success; failures are gRPC status codes.
+message RefreshConnectionResponse {
+  // meta carries response correlation data.
+  ResponseMeta meta = 1;
+}
+```
+
+- [ ] **Step 2: Write the failing handler test**
+
+`internal/grpc/refresh_connection_test.go`:
+
+```go
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+	"github.com/holomush/holomush/internal/oops"
+)
+
+func TestRefreshConnectionRefreshesOwnedConnection(t *testing.T) {
+	char := ulid.Make()
+	loc := ulid.Make()
+	sess := mkActiveAt("sess-1", char, loc)
+	store := newTestSessionStore(t, map[string]*session.Info{"sess-1": sess})
+	s := &CoreServer{
+		sessionStore:      store,
+		playerSessionRepo: newFakePlayerSessionRepo(ownedPlayerID),
+	}
+	_, err := s.RefreshConnection(context.Background(), &corev1.RefreshConnectionRequest{
+		SessionId: "sess-1", ConnectionId: ulid.Make().String(),
+		PlayerSessionToken: testPlayerSessionToken,
+	})
+	// Connection not present in the fake store → CONNECTION_NOT_FOUND surfaces
+	// as a successful-ownership but missing-connection path (see Step 3).
+	require.Error(t, err)
+	assert.Equal(t, "CONNECTION_NOT_FOUND", oops.AsOops(err).Code())
+}
+
+func TestRefreshConnectionCollapsesOwnershipFailureToSessionNotFound(t *testing.T) {
+	s := &CoreServer{
+		sessionStore:      newTestSessionStore(t, nil),
+		playerSessionRepo: newFakePlayerSessionRepo(ulid.ULID{}),
+	}
+	_, err := s.RefreshConnection(context.Background(), &corev1.RefreshConnectionRequest{
+		SessionId: "missing", ConnectionId: ulid.Make().String(),
+		PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.Error(t, err)
+	assert.Equal(t, "SESSION_NOT_FOUND", oops.AsOops(err).Code())
+}
+```
+
+- [ ] **Step 3: Implement the handler**
+
+`internal/grpc/refresh_connection.go` (mirrors the ownership pattern at `list_focus_presence.go:44-66`):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/holomush/holomush/internal/grpc/auth"
+	"github.com/holomush/holomush/internal/oops"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+)
+
+// RefreshConnection bumps a connection's liveness lease (holomush-rsoe6).
+// Ownership failures collapse to SESSION_NOT_FOUND (enumeration-safe, I-SEC-1).
+func (s *CoreServer) RefreshConnection(ctx context.Context, req *corev1.RefreshConnectionRequest) (*corev1.RefreshConnectionResponse, error) {
+	if req.GetSessionId() == "" || req.GetConnectionId() == "" {
+		return nil, oops.Code("INVALID_ARGUMENT").Errorf("session_id and connection_id are required")
+	}
+	if _, err := auth.ValidateSessionOwnership(
+		ctx, s.playerSessionRepo, s.sessionStore,
+		req.GetPlayerSessionToken(), req.GetSessionId(),
+	); err != nil {
+		slog.DebugContext(ctx, "refresh connection ownership validation failed",
+			"session_id", req.GetSessionId(), "error", err)
+		return nil, oops.Code("SESSION_NOT_FOUND").
+			With("session_id", req.GetSessionId()).Errorf("session not found")
+	}
+	connID, err := ulid.Parse(req.GetConnectionId())
+	if err != nil {
+		return nil, oops.Code("INVALID_ARGUMENT").With("connection_id", req.GetConnectionId()).
+			Errorf("connection_id is not a valid ULID")
+	}
+	if refreshErr := s.sessionStore.RefreshConnection(ctx, connID); refreshErr != nil {
+		return nil, refreshErr //nolint:wrapcheck // store returns canonical CONNECTION_NOT_FOUND oops code
+	}
+	return &corev1.RefreshConnectionResponse{Meta: responseMeta(req.GetMeta().GetRequestId())}, nil
+}
+```
+
+- [ ] **Step 4: Regenerate protos + run**
+
+Run: `task proto` (regenerate), then `task test -- -run TestRefreshConnection ./internal/grpc/`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+`feat(grpc): RefreshConnection RPC (ownership-validated lease refresh) (holomush-rsoe6)`
+
+---
+
+### Task 4: `recomputeSessionLiveness` — derive `active`/`grid_present` from connections
+
+**Files:**
+
+- Modify: `internal/grpc/server.go` (extract from the `Disconnect` lifecycle at ~1473-1545; call from `AddConnection` path ~854)
+- Test: `internal/grpc/server_liveness_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/grpc/server_liveness_test.go`:
+
+```go
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	sessionmocks "github.com/holomush/holomush/internal/session/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRecomputeSessionLivenessDetachesWhenNoLiveConnections(t *testing.T) {
+	store := sessionmocks.NewMockStore(t)
+	store.EXPECT().CountConnections(mock.Anything, "sess-1").Return(0, nil).Once()
+	store.EXPECT().UpdateStatus(mock.Anything, "sess-1", session.StatusDetached,
+		mock.Anything, mock.Anything).Return(nil).Once()
+	s := &CoreServer{sessionStore: store, sessionDefaults: SessionDefaults{TTL: 30 * time.Minute}}
+
+	got, err := s.recomputeSessionLiveness(context.Background(), &session.Info{ID: "sess-1", GridPresent: false})
+	require.NoError(t, err)
+	assert.Equal(t, session.StatusDetached, got.status)
+}
+
+func TestRecomputeSessionLivenessClearsGridPresentWhenNoGridConnections(t *testing.T) {
+	store := sessionmocks.NewMockStore(t)
+	store.EXPECT().CountConnections(mock.Anything, "sess-1").Return(1, nil).Once() // comms_hub only
+	store.EXPECT().CountConnectionsByType(mock.Anything, "sess-1", "terminal").Return(0, nil).Once()
+	store.EXPECT().CountConnectionsByType(mock.Anything, "sess-1", "telnet").Return(0, nil).Once()
+	store.EXPECT().UpdateGridPresent(mock.Anything, "sess-1", false).Return(nil).Once()
+	s := &CoreServer{sessionStore: store}
+
+	got, err := s.recomputeSessionLiveness(context.Background(), &session.Info{ID: "sess-1", GridPresent: true})
+	require.NoError(t, err)
+	assert.True(t, got.active)
+	assert.False(t, got.gridPresent)
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure**
+
+Run: `task test -- -run TestRecomputeSessionLiveness ./internal/grpc/`
+Expected: FAIL — `recomputeSessionLiveness` undefined.
+
+- [ ] **Step 3: Implement `recomputeSessionLiveness`**
+
+In `server.go`, add (factoring the count/transition logic currently inline in `Disconnect` at 1473-1545):
+
+```go
+// livenessResult is the derived state after recomputing a session's connections.
+type livenessResult struct {
+	active      bool
+	gridPresent bool
+	status      session.Status
+}
+
+// recomputeSessionLiveness derives active/grid_present from the session's live
+// connection set and applies the transitions (detach on zero connections; clear
+// grid_present when no terminal/telnet connection remains). Shared by the
+// Disconnect RPC, the AddConnection path, and the lease sweep (I-LIVE-3).
+func (s *CoreServer) recomputeSessionLiveness(ctx context.Context, info *session.Info) (livenessResult, error) {
+	total, err := s.sessionStore.CountConnections(ctx, info.ID)
+	if err != nil {
+		return livenessResult{}, oops.With("session_id", info.ID).Wrap(err)
+	}
+	res := livenessResult{active: total > 0, status: info.Status}
+	if total == 0 {
+		ttl := time.Duration(info.TTLSeconds) * time.Second
+		if ttl <= 0 {
+			ttl = s.sessionDefaults.TTL
+		}
+		now := time.Now()
+		expiresAt := now.Add(ttl)
+		if updErr := s.sessionStore.UpdateStatus(ctx, info.ID, session.StatusDetached, &now, &expiresAt); updErr != nil {
+			return livenessResult{}, oops.With("session_id", info.ID).Wrap(updErr)
+		}
+		res.status = session.StatusDetached
+		res.gridPresent = false
+		return res, nil
+	}
+	term, err := s.sessionStore.CountConnectionsByType(ctx, info.ID, "terminal")
+	if err != nil {
+		return livenessResult{}, oops.With("session_id", info.ID).Wrap(err)
+	}
+	tel, err := s.sessionStore.CountConnectionsByType(ctx, info.ID, "telnet")
+	if err != nil {
+		return livenessResult{}, oops.With("session_id", info.ID).Wrap(err)
+	}
+	res.gridPresent = term+tel > 0
+	if res.gridPresent != info.GridPresent {
+		if updErr := s.sessionStore.UpdateGridPresent(ctx, info.ID, res.gridPresent); updErr != nil {
+			return livenessResult{}, oops.With("session_id", info.ID).Wrap(updErr)
+		}
+	}
+	return res, nil
+}
+```
+
+- [ ] **Step 4: Call it from the `AddConnection` path**
+
+In `server.go` after the `AddConnection` call (~854-866), recompute so a newly grid-attached session flips `grid_present` true:
+
+```go
+	if _, recErr := s.recomputeSessionLiveness(addCtx, info); recErr != nil {
+		slog.WarnContext(addCtx, "recompute liveness after add connection failed",
+			"session_id", info.ID, "error", recErr)
+	}
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+Run: `task test -- -run TestRecomputeSessionLiveness ./internal/grpc/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+`refactor(grpc): extract recomputeSessionLiveness for derived active/grid_present (holomush-rsoe6)`
+
+---
+
+### Task 5: Lease sweep + boot-grace in the reaper
+
+**Files:**
+
+- Modify: `internal/session/reaper.go` (`ReaperConfig`, `Run`, new `reapLapsedConnections`)
+- Test: `internal/session/reaper_lease_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/session/reaper_lease_test.go`:
+
+```go
+package session_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/session"
+	"github.com/holomush/holomush/internal/testsupport/sessiontest"
+)
+
+func TestReaperSweepsLapsedConnectionAndDetachesSession(t *testing.T) {
+	ctx := context.Background()
+	store, pool := sessiontest.NewStoreWithPool(t)
+	ps := sessiontest.NewPlayerSession()
+	sessiontest.SeedPlayerSession(t, pool, ps)
+	sess := sessiontest.NewActiveSession(ps)
+	require.NoError(t, store.Set(ctx, sess.ID, sess))
+	connID := ulid.Make()
+	require.NoError(t, store.AddConnection(ctx, &session.Connection{
+		ID: connID, SessionID: sess.ID, ClientType: "terminal",
+		ConnectedAt: time.Now().Add(-time.Hour), // lapsed
+	}))
+
+	now := time.Now()
+	var detached []string
+	r := session.NewReaper(store, session.ReaperConfig{
+		Interval:  50 * time.Millisecond,
+		LeaseTTL:  45 * time.Second,
+		BootGrace: 0, // disable boot-grace for this test
+		Now:       func() time.Time { return now },
+		OnSessionDetached: func(info *session.Info) { detached = append(detached, info.ID) },
+	})
+	rctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	r.Run(rctx)
+
+	count, err := store.CountConnections(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "lapsed connection was swept")
+	assert.Contains(t, detached, sess.ID, "session detached after last connection swept")
+}
+
+func TestReaperSuppressesLeaseSweepDuringBootGrace(t *testing.T) {
+	ctx := context.Background()
+	store, pool := sessiontest.NewStoreWithPool(t)
+	ps := sessiontest.NewPlayerSession()
+	sessiontest.SeedPlayerSession(t, pool, ps)
+	sess := sessiontest.NewActiveSession(ps)
+	require.NoError(t, store.Set(ctx, sess.ID, sess))
+	connID := ulid.Make()
+	require.NoError(t, store.AddConnection(ctx, &session.Connection{
+		ID: connID, SessionID: sess.ID, ClientType: "terminal",
+		ConnectedAt: time.Now().Add(-time.Hour),
+	}))
+
+	start := time.Now()
+	r := session.NewReaper(store, session.ReaperConfig{
+		Interval:  50 * time.Millisecond,
+		LeaseTTL:  45 * time.Second,
+		BootGrace: time.Hour, // still inside grace window during the test
+		Now:       func() time.Time { return start.Add(time.Minute) }, // < BootGrace
+	})
+	rctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	r.Run(rctx)
+
+	count, err := store.CountConnections(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "boot-grace suppresses the lease sweep (I-LIVE-4)")
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure**
+
+Run: `task test:int -- -run TestReaper.*Lapsed ./internal/session/...` (uses `sessiontest`, needs Docker)
+Expected: FAIL — `ReaperConfig.LeaseTTL`/`BootGrace`/`Now`/`OnSessionDetached` undefined.
+
+- [ ] **Step 3: Extend `ReaperConfig` + `Run` + add `reapLapsedConnections`**
+
+In `reaper.go`:
+
+```go
+type ReaperConfig struct {
+	Interval  time.Duration
+	OnExpired func(info *Info)
+
+	// LeaseTTL: a connection whose last_seen_at is older than now-LeaseTTL is
+	// swept (holomush-rsoe6, I-LIVE-2). Zero disables the lease sweep.
+	LeaseTTL time.Duration
+	// BootGrace suppresses the lease sweep for this long after Run starts, so a
+	// surviving gateway re-asserts its leases before any reaping (I-LIVE-4).
+	BootGrace time.Duration
+	// Now is injectable for tests; defaults to time.Now.
+	Now func() time.Time
+	// OnSessionDetached fires when the sweep detaches a session (last live
+	// connection removed). Leave events stay deferred to OnExpired at TTL.
+	OnSessionDetached func(info *Info)
+	// OnGridPhaseOut fires when grid_present falls true→false but the session
+	// stays active (a non-grid connection remains).
+	OnGridPhaseOut func(info *Info)
+}
+```
+
+In `NewReaper`, default the clock:
+
+```go
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	r := &Reaper{store: store, config: config}
+	r.bootAt = config.Now()
+	return r
+```
+
+Add `bootAt time.Time` to the `Reaper` struct. Extend `Run`'s tick:
+
+```go
+		case <-ticker.C:
+			r.reapExpired(ctx)
+			if r.config.LeaseTTL > 0 && r.config.Now().Sub(r.bootAt) >= r.config.BootGrace {
+				r.reapLapsedConnections(ctx)
+			}
+```
+
+Add the sweep:
+
+```go
+func (r *Reaper) reapLapsedConnections(ctx context.Context) {
+	cutoff := r.config.Now().Add(-r.config.LeaseTTL)
+	lapsed, err := r.store.ListLapsedConnections(ctx, cutoff)
+	if err != nil {
+		slog.WarnContext(ctx, "reaper: list lapsed connections failed", "error", err)
+		return
+	}
+	affected := make(map[string]struct{})
+	for _, lc := range lapsed {
+		if rmErr := r.store.RemoveConnection(ctx, lc.ID); rmErr != nil {
+			slog.WarnContext(ctx, "reaper: remove lapsed connection failed",
+				"connection_id", lc.ID.String(), "error", rmErr)
+			continue
+		}
+		affected[lc.SessionID] = struct{}{}
+	}
+	for sessionID := range affected {
+		r.recomputeAfterSweep(ctx, sessionID)
+	}
+}
+
+func (r *Reaper) recomputeAfterSweep(ctx context.Context, sessionID string) {
+	info, err := r.store.Get(ctx, sessionID)
+	if err != nil {
+		return // session already gone; nothing to recompute
+	}
+	if info.Status != StatusActive {
+		return
+	}
+	total, err := r.store.CountConnections(ctx, sessionID)
+	if err != nil {
+		slog.WarnContext(ctx, "reaper: count connections failed", "session_id", sessionID, "error", err)
+		return
+	}
+	if total == 0 {
+		ttl := time.Duration(info.TTLSeconds) * time.Second
+		now := r.config.Now()
+		expiresAt := now.Add(ttl)
+		if updErr := r.store.UpdateStatus(ctx, sessionID, StatusDetached, &now, &expiresAt); updErr != nil {
+			slog.WarnContext(ctx, "reaper: detach after sweep failed", "session_id", sessionID, "error", updErr)
+			return
+		}
+		if r.config.OnSessionDetached != nil {
+			r.config.OnSessionDetached(info)
+		}
+		return
+	}
+	term, _ := r.store.CountConnectionsByType(ctx, sessionID, "terminal")
+	tel, _ := r.store.CountConnectionsByType(ctx, sessionID, "telnet")
+	gridPresent := term+tel > 0
+	if !gridPresent && info.GridPresent {
+		if updErr := r.store.UpdateGridPresent(ctx, sessionID, false); updErr != nil {
+			slog.WarnContext(ctx, "reaper: clear grid_present after sweep failed", "session_id", sessionID, "error", updErr)
+			return
+		}
+		if r.config.OnGridPhaseOut != nil {
+			r.config.OnGridPhaseOut(info)
+		}
+	}
+}
+```
+
+> Note: the reaper recomputes via store calls only (no engine dependency); event emission is delegated to the injected callbacks wired in `sub_grpc.go` (Task 6), preserving the package boundary.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `task test:int -- -run TestReaper.*Lapsed ./internal/session/...`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+`feat(session): lease sweep + boot-grace in reaper (holomush-rsoe6)`
+
+---
+
+### Task 6: Wire lease-sweep config + detach/phase-out callbacks
+
+**Files:**
+
+- Modify: `cmd/holomush/sub_grpc.go` (the `session.NewReaper(...)` block, step 10)
+- Modify: `cmd/holomush/core.go` (config: `SessionLeaseTTL`, `SessionBootGrace`)
+- Test: `cmd/holomush/sub_grpc_test.go` (extend reaper-wiring test)
+
+- [ ] **Step 1: Add config fields + flags**
+
+In `core.go`, alongside `SessionReaperInterval` (~75, ~159):
+
+```go
+	SessionLeaseTTL   string `koanf:"session_lease_ttl"`
+	SessionBootGrace  string `koanf:"session_boot_grace"`
+```
+
+```go
+	cmd.Flags().StringVar(&cfg.SessionLeaseTTL, "session-lease-ttl", "45s", "connection lease TTL")
+	cmd.Flags().StringVar(&cfg.SessionBootGrace, "session-boot-grace", "60s", "lease-sweep suppression window after core start")
+```
+
+Extend `parseSessionConfig` (`core.go:~1115`, currently returns `(sessionTTL, reaperInterval time.Duration, err error)`) to parse and return the two new durations — new signature `(sessionTTL, reaperInterval, leaseTTL, bootGrace time.Duration, err error)` — defaulting `45s`/`60s` and erroring on malformed/zero exactly like the existing `SessionReaperInterval` checks. Update its single call site to assign the two new return values into the cfg struct (Step 2).
+
+- [ ] **Step 2: Wire the callbacks into `NewReaper`**
+
+In `sub_grpc.go` step 10, extend the `ReaperConfig`:
+
+```go
+	s.sessionReaper = session.NewReaper(sessionStore, session.ReaperConfig{
+		Interval:  s.cfg.ReaperInterval,
+		LeaseTTL:  s.cfg.LeaseTTL,
+		BootGrace: s.cfg.BootGrace,
+		OnExpired: func(info *session.Info) { /* unchanged: leave + session_ended + guest release */ },
+		OnSessionDetached: func(info *session.Info) {
+			slog.InfoContext(reaperCtx, "lease sweep detached session", "session_id", info.ID)
+			// Leave is deferred to OnExpired at TTL (matches the cooperative detach path).
+		},
+		OnGridPhaseOut: func(info *session.Info) {
+			char := core.CharacterRef{ID: info.CharacterID, Name: info.CharacterName, LocationID: info.LocationID}
+			if dcErr := engine.HandleDisconnect(reaperCtx, char, "phased out"); dcErr != nil {
+				slog.WarnContext(reaperCtx, "lease sweep grid phase-out leave failed",
+					"session_id", info.ID, "error", dcErr)
+			}
+		},
+	})
+```
+
+Add `LeaseTTL`/`BootGrace time.Duration` to the `grpcSubsystemConfig` struct (`sub_grpc.go:~62`, alongside `ReaperInterval` at `:78`) and populate them at the call site from `parseSessionConfig`'s new return values.
+
+- [ ] **Step 3: Extend the wiring test**
+
+In `sub_grpc_test.go`, assert `parseSessionConfig` rejects a malformed `SessionLeaseTTL`/`SessionBootGrace` and accepts valid durations (mirror `TestParseSessionConfigRejectsInvalidReaperInterval`). **Also update the 8 existing `parseSessionConfig` call sites in `cmd/holomush/core_test.go` (~lines 1047,1064,1080,1093,1106,1120,1135,1150)** — their `_, _, err :=` / `ttl, reaper, err :=` destructuring breaks when the signature grows to 5 returns; extend each to the new arity.
+
+- [ ] **Step 4: Run**
+
+Run: `task test -- -run TestParseSessionConfig ./cmd/holomush/` then `task build`
+Expected: PASS; binary builds.
+
+- [ ] **Step 5: Commit**
+
+`feat(core): wire lease sweep TTL + boot-grace + detach/phase-out callbacks (holomush-rsoe6)`
+
+---
+
+## Phase 2 — Gateway lease refresh
+
+### Task 7: Web — refresh lease on the heartbeat tick
+
+**Files:**
+
+- Modify: `internal/web/handler.go` (`StreamEvents` heartbeat case ~249-257)
+- Test: `internal/web/handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `handler_test.go`, drive a fake `CoreServiceClient` whose `Subscribe` stays open, advance one heartbeat, and assert `RefreshConnection` was called with the stream's `connID`:
+
+```go
+func TestStreamEventsRefreshesLeaseOnHeartbeat(t *testing.T) {
+	fake := &fakeCoreClient{ /* Subscribe returns a stream that blocks on Recv */ }
+	h := newTestHandler(t, fake)
+	// run StreamEvents with a 1ms heartbeat override; cancel after 2 ticks
+	// (inject heartbeat interval via a handler field for the test)
+	runStreamEventsBriefly(t, h)
+	assert.GreaterOrEqual(t, fake.refreshCalls(), 1, "heartbeat refreshes the connection lease")
+	assert.Equal(t, h.lastConnID(), fake.lastRefreshConnID())
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `task test -- -run TestStreamEventsRefreshesLease ./internal/web/`
+Expected: FAIL — no `RefreshConnection` call.
+
+- [ ] **Step 3: Implement — refresh in the heartbeat case**
+
+In `handler.go`, after the successful heartbeat `stream.Send` (line ~257), add:
+
+```go
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, rpcTimeout)
+				if _, refreshErr := h.client.RefreshConnection(refreshCtx, &corev1.RefreshConnectionRequest{
+					SessionId:          sessionID,
+					ConnectionId:       connID.String(),
+					PlayerSessionToken: token,
+				}); refreshErr != nil {
+					slog.DebugContext(ctx, "web: lease refresh failed (transient)", "session_id", sessionID, "error", refreshErr)
+				}
+				refreshCancel()
+```
+
+To make the heartbeat interval injectable for the test, add a `heartbeatInterval time.Duration` field on `Handler` defaulting to `15 * time.Second`, and use it at line 241.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `task test -- -run TestStreamEventsRefreshesLease ./internal/web/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`feat(web): refresh connection lease on StreamEvents heartbeat (holomush-rsoe6)`
+
+---
+
+### Task 8: Telnet — refresh lease on a ticker
+
+**Files:**
+
+- Modify: `internal/telnet/gateway_handler.go` (add `CoreClient.RefreshConnection`; add ticker in `Handle` loop ~177)
+- Test: `internal/telnet/gateway_handler_test.go`
+
+- [ ] **Step 1: Add `RefreshConnection` to the telnet `CoreClient` interface**
+
+In `gateway_handler.go` (the `CoreClient` interface ~52-64):
+
+```go
+	RefreshConnection(ctx context.Context, req *corev1.RefreshConnectionRequest) (*corev1.RefreshConnectionResponse, error)
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`gateway_handler_test.go`: drive a handler into the authed/subscribed state, fire the refresh ticker once, assert the fake client saw a `RefreshConnection` for `h.connectionID`.
+
+```go
+func TestGatewayHandlerRefreshesLeaseWhileAuthed(t *testing.T) {
+	fake := newFakeCoreClient(t)
+	h := newAuthedHandler(t, fake) // sessionID + connectionID + token set, authed=true
+	h.refreshOnce(context.Background()) // test hook calling the same path the ticker uses
+	assert.Equal(t, h.connectionID, fake.lastRefreshConnID())
+}
+```
+
+- [ ] **Step 3: Implement — refresh ticker in `Handle`**
+
+Add a `refreshTicker := time.NewTicker(h.limits.LeaseRefreshInterval)` (add `LeaseRefreshInterval` to `Limits`, default 15s) and `defer refreshTicker.Stop()` before the `for` loop (~176), and a select case:
+
+```go
+		case <-refreshTicker.C:
+			if h.authed && h.sessionID != "" {
+				rCtx, rCancel := context.WithTimeout(childCtx, rpcTimeout)
+				if _, err := h.client.RefreshConnection(rCtx, &corev1.RefreshConnectionRequest{
+					SessionId:          h.sessionID,
+					ConnectionId:       h.connectionID,
+					PlayerSessionToken: h.playerSessionToken,
+				}); err != nil {
+					slog.DebugContext(childCtx, "telnet: lease refresh failed (transient)", "session_id", h.sessionID, "error", err)
+				}
+				rCancel()
+			}
+```
+
+Factor the refresh body into `func (h *GatewayHandler) refreshOnce(ctx context.Context)` so the test and the ticker share one path.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `task test -- -run TestGatewayHandlerRefreshesLease ./internal/telnet/`
+Expected: PASS.
+
+- [ ] **Step 5: Activate the sweep (sequencing gate) + commit**
+
+With both refreshers now landed, the lease sweep from Task 5/6 is safe to run. Confirm the default config (`LeaseTTL=45s`) is active. Commit: `feat(telnet): refresh connection lease on a ticker (holomush-rsoe6)`
+
+---
+
+## Phase 3 — Gateway survival
+
+### Task 9: Add `RECONNECTING`/`RECONNECTED` web control signals
+
+**Files:**
+
+- Modify: `api/proto/holomush/web/v1/web.proto` (`ControlSignal` enum ~44-63)
+- Regenerate protos + TS client (`web/src/lib/connect/...`)
+
+- [ ] **Step 1: Add enum values**
+
+```protobuf
+  // CONTROL_SIGNAL_RECONNECTING: the gateway lost its core stream but is holding
+  // the client and reconnecting; the UI shows a reconnecting indicator (holomush-rsoe6).
+  CONTROL_SIGNAL_RECONNECTING = 4;
+  // CONTROL_SIGNAL_RECONNECTED: the gateway re-established the core stream; the
+  // client may clear the reconnecting indicator.
+  CONTROL_SIGNAL_RECONNECTED = 5;
+```
+
+- [ ] **Step 2: Regenerate + verify it compiles**
+
+Run: `task proto`, then `task build` and `cd web && bun run check` (TS types regenerated).
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+`feat(proto): web ControlSignal RECONNECTING/RECONNECTED (holomush-rsoe6)`
+
+---
+
+### Task 10: Web — survive a core-stream break
+
+**Files:**
+
+- Modify: `internal/web/handler.go` (`StreamEvents` recv-error path ~263-280; track last event id)
+- Test: `internal/web/handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Drive `StreamEvents` with a fake core client whose first `Subscribe` stream errors `CodeUnavailable` after one event, then a second `Subscribe` succeeds and replays. Assert: (a) the client stream was NOT closed on the first error, (b) a `RECONNECTING` then `RECONNECTED` control frame reached the client, (c) the duplicate (redelivered) event was deduped.
+
+```go
+func TestStreamEventsReconnectsOnCoreStreamBreakWithoutClosingClient(t *testing.T) {
+	fake := newReconnectingCoreClient(t) // stream #1: 1 event (id "E1") then Unavailable; stream #2: replays E1 then E2
+	h := newTestHandler(t, fake)
+	frames := captureClientFrames(t, h) // collects webv1 frames sent to the client
+	assert.Contains(t, controlSignals(frames), webv1.ControlSignal_CONTROL_SIGNAL_RECONNECTING)
+	assert.Contains(t, controlSignals(frames), webv1.ControlSignal_CONTROL_SIGNAL_RECONNECTED)
+	assert.Equal(t, []string{"E1", "E2"}, eventIDs(frames), "redelivered E1 deduped; no client close")
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`task test -- -run TestStreamEventsReconnects ./internal/web/`) — current code returns `CodeUnavailable` and ends the client stream.
+
+- [ ] **Step 3: Implement — outer reconnect loop**
+
+First define the break classification (package scope in `handler.go`):
+
+```go
+// breakCause classifies why a single Subscribe attempt ended.
+type breakCause int
+
+const (
+	breakDone       breakCause = iota // ctx cancelled / clean end → return nil
+	breakClientGone                   // client transport lost → return (defer Disconnect)
+	breakCoreGone                     // core stream errored, client still alive → reconnect
+)
+```
+
+Restructure `StreamEvents`: move the `Subscribe` + pump + forward into an inner `func (h *Handler) runSubscribeOnce(...) breakCause` and wrap it:
+
+```go
+	var lastForwardedID string
+	seen := make(map[string]struct{})
+	reconnectDeadline := time.Now().Add(h.reconnectCeiling) // ceiling ≤ session reattach TTL
+	backoff := 100 * time.Millisecond
+	for {
+		cause := h.runSubscribeOnce(ctx, sessionID, token, connID, stream, &lastForwardedID, seen)
+		switch cause {
+		case breakClientGone:
+			return nil // defer Disconnect fires
+		case breakCoreGone:
+			if time.Now().After(reconnectDeadline) {
+				return connect.NewError(connect.CodeUnavailable, oops.Errorf("core unreachable past ceiling"))
+			}
+			_ = stream.Send(reconnectingControlFrame())
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			if backoff < 5*time.Second {
+				backoff *= 2
+			}
+			// loop: re-Subscribe (durable consumer resumes server-side)
+		case breakDone:
+			return nil
+		}
+	}
+```
+
+`runSubscribeOnce` opens `h.client.Subscribe`, sends `RECONNECTED` after a successful (re)open (skip on the first open — gate on a `reconnected bool`), then runs the existing heartbeat/recv/forward select. In the event-forward path, capture the id and dedup:
+
+```go
+	case *corev1.SubscribeResponse_Event:
+		id := frame.Event.GetId()
+		if _, dup := seen[id]; dup {
+			return // already forwarded (redelivery overlap)
+		}
+		seen[id] = struct{}{}
+		lastForwardedID = id
+		// ... existing translate + Send ...
+```
+
+Classify the break: client-gone when `stream.Send` fails or `ctx.Done()`; core-gone when `sub.Recv()` returns a non-EOF transport error. If `Subscribe` itself returns `SESSION_NOT_FOUND`, re-`SelectCharacter` (reattach) before the next `runSubscribeOnce`.
+
+Add `reconnectCeiling time.Duration` to `Handler` (default from config; capped at the session reattach TTL).
+
+- [ ] **Step 4: Run — expect PASS** (`task test -- -run TestStreamEventsReconnects ./internal/web/`).
+
+- [ ] **Step 5: Commit**
+
+`feat(web): survive core-stream break — hold client, reconnect, dedup resume (holomush-rsoe6)`
+
+---
+
+### Task 11: Telnet — survive a core-stream break
+
+**Files:**
+
+- Modify: `internal/telnet/gateway_handler.go` (the `eventRecv` closed path ~223-229)
+- Test: `internal/telnet/gateway_handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Drive the handler so its first subscription stream closes (core-gone) while the telnet conn stays open; assert it re-subscribes (calls `Subscribe` again) and emits a reconnecting status line rather than terminating.
+
+```go
+func TestGatewayHandlerReconnectsOnCoreStreamClose(t *testing.T) {
+	fake := newReconnectingCoreClient(t)
+	h := newAuthedHandler(t, fake)
+	out := runHandleBriefly(t, h, fake)
+	assert.GreaterOrEqual(t, fake.subscribeCalls(), 2, "re-subscribed after core stream closed")
+	assert.Contains(t, out, "Reconnecting")
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** — current code sends "Connection to server lost." and continues without re-subscribing.
+
+- [ ] **Step 3: Implement — reconnect on `eventRecv` close**
+
+Replace the `eventRecv` closed branch (~223-229). When the stream closes and the client is still connected and not quitting, re-establish the subscription (the durable consumer resumes), deduping by last event id:
+
+```go
+		case resp, ok := <-eventRecv:
+			if !ok {
+				eventRecv = nil
+				if h.quitting || !h.authed || h.sessionID == "" {
+					continue
+				}
+				h.send("[Reconnecting to server…]")
+				if ch := h.resubscribe(childCtx); ch != nil { // re-Subscribe; reattach on SESSION_NOT_FOUND
+					eventRecv = ch
+					h.send("[Reconnected.]")
+				} else {
+					h.send("Connection to server lost.")
+				}
+				continue
+			}
+			switch frame := resp.GetFrame().(type) {
+			case *corev1.SubscribeResponse_Event:
+				if id := frame.Event.GetId(); id == h.lastEventID {
+					continue // redelivery overlap
+				} else {
+					h.lastEventID = id
+				}
+				h.sendProtoEvent(frame.Event)
+			// ... existing control-frame handling ...
+			}
+```
+
+Add `lastEventID string` to the struct and a `resubscribe(ctx) <-chan *corev1.SubscribeResponse` helper (re-uses `subscribeAndEnter`'s Subscribe call with the existing `sessionID`/`connectionID`; on `SESSION_NOT_FOUND` calls `SelectCharacter` first). Bound retries by a deadline as in the web handler.
+
+- [ ] **Step 4: Run — expect PASS** (`task test -- -run TestGatewayHandlerReconnects ./internal/telnet/`).
+
+- [ ] **Step 5: Commit**
+
+`feat(telnet): survive core-stream break — reconnect + dedup resume (holomush-rsoe6)`
+
+---
+
+## Phase 4 — Presence / `grid_present` split
+
+### Task 12: Roster reads `grid_present`, not raw `active`
+
+**Files:**
+
+- Modify: `internal/store/session_store.go` (`ListActiveByLocation` predicate ~620)
+- Test: `internal/grpc/list_focus_presence_test.go` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `list_focus_presence_test.go`: a session at the location with `GridPresent=false` MUST NOT appear in the roster even though it is `active`.
+
+```go
+func TestListFocusPresenceExcludesActiveButNotGridPresent(t *testing.T) {
+	char1, char2 := ulid.Make(), ulid.Make()
+	loc := ulid.MustParse("01HYXLOCATION0000000000001")
+	caller := mkActiveAt("sess-1", char1, loc)         // grid-present caller
+	offgrid := mkActiveAt("sess-2", char2, loc)
+	offgrid.GridPresent = false                         // active but not on the grid
+	grant := policytest.NewGrantEngine()
+	grant.Grant(access.CharacterSubject(char1.String()), "list_presence", access.LocationResource(loc.String()))
+	s := &CoreServer{
+		sessionStore:          newTestSessionStore(t, map[string]*session.Info{"sess-1": caller, "sess-2": offgrid}),
+		playerSessionRepo:     newFakePlayerSessionRepo(ownedPlayerID),
+		accessEngine:          grant,
+		characterNameResolver: stubResolver(char1, char2),
+	}
+	resp, err := s.ListFocusPresence(context.Background(), &corev1.ListFocusPresenceRequest{
+		SessionId: "sess-1", PlayerSessionToken: testPlayerSessionToken,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Entries, 1, "only grid-present characters appear in the roster (I-PRES-1)")
+}
+```
+
+(Ensure `mkActiveAt` sets `GridPresent=true` by default; if not, set `caller.GridPresent = true`. The in-memory test store's `ListActiveByLocation` must apply the same `grid_present` filter as Postgres — update it too.)
+
+- [ ] **Step 2: Run — expect FAIL** (`task test -- -run TestListFocusPresenceExcludesActiveButNotGridPresent ./internal/grpc/`).
+
+- [ ] **Step 3: Implement — add the predicate**
+
+In `session_store.go:620`, change the query:
+
+```go
+		`SELECT `+sessionSelectColumns+` FROM sessions WHERE location_id = $1 AND status = 'active' AND grid_present = true`,
+```
+
+Apply the same `grid_present` filter to the test session store's `ListActiveByLocation` (`internal/grpc/*_test.go` fake, or `sessiontest`). `location_follow.go:223` shares the method, so its presence list inherits the filter automatically.
+
+- [ ] **Step 4: Run — expect PASS** + regression-check the existing presence tests still pass (`task test -- -run TestListFocusPresence ./internal/grpc/`).
+
+- [ ] **Step 5: Commit**
+
+`feat(store): presence roster filters grid_present (holomush-rsoe6)`
+
+---
+
+## Phase 5 — Cross-cutting tests & docs
+
+### Task 13: Integration — end-to-end deadlock resolution
+
+**Files:**
+
+- Create: `test/integration/presence/lease_reaper_test.go` (`//go:build integration`)
+
+- [ ] **Step 1: Write the spec** (Ginkgo): a guest session whose connection lease lapses → swept → detached → expired by the reaper → the guest player becomes eligible for `ListIdleGuests` (no active/detached session) and is collected. Use `integrationtest.Start(t)`, drive a connection, stop refreshing, advance the reaper.
+
+```go
+//go:build integration
+
+var _ = Describe("Lease-driven liveness", func() {
+	It("clears presence and unblocks the guest reaper when a lease lapses", func() {
+		// Given a connected guest visible in presence …
+		// When its lease lapses and the reaper sweeps …
+		Eventually(presenceAt(loc)).Should(BeEmpty())
+		// And the guest session is detached then expired …
+		Eventually(guestSessionStatus(sessID)).Should(Equal("expired"))
+	})
+})
+```
+
+- [ ] **Step 2: Run** `task test:int -- ./test/integration/presence/...` → PASS.
+- [ ] **Step 3: Commit** `test(integration): lease-driven presence + guest-reaper unblock (holomush-rsoe6)`
+
+### Task 14: Integration — core restart does not detach a live session
+
+**Files:** Create: `test/integration/presence/boot_grace_test.go`
+
+- [ ] **Step 1:** Spec: a lease-refreshed session is NOT detached within the boot-grace window after a simulated reaper restart (construct a fresh `Reaper` with `bootAt=now`); assert no spurious `leave`.
+- [ ] **Step 2:** `task test:int -- ./test/integration/presence/...` → PASS.
+- [ ] **Step 3:** Commit `test(integration): boot-grace protects live sessions on restart (holomush-rsoe6)`
+
+### Task 15: E2E — presence happy path + reconnect
+
+**Files:** Create: `web/e2e/presence-liveness.spec.ts`
+
+- [ ] **Step 1:** Specs (Playwright): (a) two browsers at one location each see the other in PRESENT; one closes → the other sees it drop (no ghost); (b) reload within reattach TTL keeps the character present exactly once; (c) kill transport → ghost clears within `L`+sweep; (d) restart core mid-session → RECONNECTING then resume with no dup/missing events.
+- [ ] **Step 2:** `task test:e2e -- presence-liveness` → PASS.
+- [ ] **Step 3:** Commit `test(e2e): presence liveness happy path + reconnect (holomush-rsoe6)`
+
+### Task 16: Invariant bijection meta-test
+
+**Files:** Create/extend: `test/meta/liveness_invariants_test.go`
+
+- [ ] **Step 1:** Enumerate I-LIVE-1..5, I-PRES-1, I-SURV-1..5, I-SEC-1; map each to ≥1 named covering test (from Tasks 2–15); assert the bijection (every invariant has a test; every registered test names a real invariant). Pattern: mirror an existing meta-test (e.g. `test/meta/quarantine_registry_test.go`).
+- [ ] **Step 2:** `task test -- ./test/meta/...` → PASS.
+- [ ] **Step 3:** `task test:cover` → confirm >80% per touched package (≥90% for `internal/session`).
+- [ ] **Step 4:** Commit `test(meta): invariant↔test bijection for liveness (holomush-rsoe6)`
+
+---
+
+## Final verification (before PR)
+
+- [ ] `task pr-prep` green (fast lane).
+- [ ] `task pr-prep:full` (touches int + E2E surface — Ginkgo presence suites + Playwright spec).
+- [ ] Spec invariants I-LIVE-1..5 / I-PRES-1 / I-SURV-1..5 / I-SEC-1 each map to a passing test (Task 16).
+- [ ] Update the session-lifecycle contributor doc + diagram (holomush-bgxg) with the connection-lease layer.

--- a/docs/superpowers/plans/2026-05-30-session-liveness-and-gateway-survival.md
+++ b/docs/superpowers/plans/2026-05-30-session-liveness-and-gateway-survival.md
@@ -39,7 +39,7 @@ Copyright 2026 HoloMUSH Contributors
 
 > **Test-fixture convention:** integration tests construct an `*auth.PlayerSession`
 > and `*session.Info` and seed them via `sessiontest.SeedPlayerSession(t, pool, ps)`
-> + `store.Set(ctx, sess.ID, sess)`, following
+> plus `store.Set(ctx, sess.ID, sess)`, following
 > `test/integration/session/session_persistence_suite_test.go`. The
 > `sessiontest.NewPlayerSession()` / `NewActiveSession(ps)` calls in the snippets
 > below are **shorthand** for that construction — add them as local test helpers
@@ -1277,3 +1277,4 @@ var _ = Describe("Lease-driven liveness", func() {
 - [ ] `task pr-prep:full` (touches int + E2E surface — Ginkgo presence suites + Playwright spec).
 - [ ] Spec invariants I-LIVE-1..5 / I-PRES-1 / I-SURV-1..5 / I-SEC-1 each map to a passing test (Task 16).
 - [ ] Update the session-lifecycle contributor doc + diagram (holomush-bgxg) with the connection-lease layer.
+<!-- adr-capture: sha256=a664895cce8ad863; session=brainstorm-rsoe6; ts=2026-05-30T15:40:32Z; adrs=holomush-6syxb,holomush-2w9vh,holomush-0qx5e,holomush-6vl53,holomush-85exr -->

--- a/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
+++ b/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
@@ -477,3 +477,4 @@ Reattach TTL continues to come from `sessionDefaults.TTL` (guest TTL per hfvc).
   strategy; clients reconnect to a fresh gateway and re-assert leases.
 - Guest reattach-TTL tuning: holomush-hfvc.
 - Disconnect count-race atomicity: holomush-cizj.
+<!-- adr-capture: sha256=45cf080700a029d7; session=brainstorm-rsoe6; ts=2026-05-30T15:25:47Z; adrs=holomush-6syxb,holomush-2w9vh,holomush-0qx5e,holomush-6vl53,holomush-85exr -->

--- a/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
+++ b/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
@@ -1,0 +1,479 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright 2026 HoloMUSH Contributors
+-->
+
+# Session Liveness & Gateway Survival — Connection Leases, Derived Presence, Resilient Reconnect
+
+| Field | Value |
+| --- | --- |
+| **Bead** | holomush-rsoe6 |
+| **Status** | Draft (brainstorming output, 2026-05-30) |
+| **Related** | holomush-2iyrf (gateway-survival deploy strategy), holomush-hfvc (guest reattach TTL), holomush-cizj (disconnect count race), holomush-r20h (consumer GC on quit), holomush-bgxg (session-lifecycle diagram + doc) |
+| **Supersedes triage directions** | The triage candidate directions A/B/C/D recorded on holomush-rsoe6 are superseded by this design (see §11). |
+
+## 1. Problem
+
+After a core redeploy, a guest character ("Turquoise Argon") that is certainly
+not connected continues to appear in a location's PRESENT roster. The session
+is stuck `status='active'` indefinitely and is never collected.
+
+Root cause, grounded:
+
+- **Presence reads stored intent, not liveness.** The presence roster derives
+  solely from `sessions.status = 'active'` (`internal/store/session_store.go:620`,
+  `ListActiveByLocation`; consumed by `internal/grpc/list_focus_presence.go:140`
+  and `internal/grpc/location_follow.go:223`).
+- **`status` is mutated only by cooperative transitions.** It is set `active`
+  once at `SelectCharacter` (`internal/grpc/auth_handlers.go`), and leaves
+  `active` only via the client-initiated `Disconnect` RPC (`internal/grpc/server.go:1377`)
+  when the connection count hits zero (the `totalCount == 0` branch at
+  `server.go:1473`) or via the reaper. Nothing
+  recomputes it from transport reality.
+- **The reaper cannot collect an `active` orphan.** `ListExpired`
+  (`internal/store/session_store.go:447`) returns only
+  `status='detached' AND expires_at < now`. `active` rows carry
+  `expires_at = NULL` (`session_store.go:480`), so they are structurally
+  invisible to the reaper forever (`internal/session/reaper.go:50`).
+- **A two-reaper deadlock keeps the guest alive too.** The guest idle reaper
+  (`internal/auth/guest_reaper.go`, `IdleTTL` default 10m) excludes any guest
+  with a live session: `ListIdleGuests` filters
+  `NOT EXISTS (… sessions s … WHERE s.status IN ('active','detached'))`
+  (`internal/auth/postgres/player_repo.go:299-304`). The stuck-`active` session
+  therefore immunizes the guest from the guest reaper as well.
+
+The conceptual gap underneath all of this: **`active` is *stored intent*, not
+*observed liveness*.** A core restart, a browser-tab close with no `Disconnect`,
+or a gateway↔core `Disconnect` RPC failure all leave `status='active'` frozen
+over a dead transport, and nothing reconciles it.
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- **G1.** Liveness becomes *correct-by-construction*: `active` and `grid_present`
+  derive from a signal that **decays unless actively refreshed**, so a dead
+  transport ages out automatically with no cooperative cleanup required.
+- **G2.** A **core restart does not interrupt a live client.** The gateway holds
+  the client socket across a core blip, reconnects, resumes gap-free, and
+  re-asserts liveness — so it neither drops live users nor leaves ghosts.
+- **G3.** `active` (session has *any* live transport) and `grid_present`
+  (character is visible on the grid via a `terminal`/`telnet` transport) are
+  modeled as distinct axes; the location roster reflects `grid_present`.
+- **G4.** The fix is symmetric across the **web** and **telnet** transports.
+
+### Non-goals
+
+- Multi-core-process / horizontally-scaled core. Single-core-process is a
+  documented invariant (`docs/plans/2026-04-07-cursor-lock-finding-1-closure.md`);
+  this design assumes it and does not add an instance-ownership column.
+- Guest-specific reattach-TTL tuning — owned by holomush-hfvc. This design uses
+  the existing per-session TTL and is compatible with a shorter guest TTL.
+- Client-originated end-to-end heartbeats (detecting a wedged-but-socket-open
+  client). The gateway's transport-level liveness is the signal here; an
+  app-level client ping is a possible future tightening (§11).
+
+## 3. Background — current transport topology (grounded)
+
+```mermaid
+flowchart LR
+  subgraph Gateway process [Gateway process — long-lived]
+    WEB[internal/web<br/>StreamEvents]
+    TEL[internal/telnet<br/>GatewayHandler]
+  end
+  subgraph Core process [Core process — restartable]
+    SUB[CoreService.Subscribe]
+    STORE[(sessions /<br/>session_connections)]
+  end
+  Browser <-->|WS / HTTP2| WEB
+  TelnetClient <-->|TCP| TEL
+  WEB -->|Subscribe / Disconnect / Refresh| SUB
+  TEL -->|Subscribe / Disconnect / Refresh| SUB
+  SUB --> STORE
+```
+
+- Both client transports live in the **gateway** process (`cmd/holomush/gateway.go`
+  starts `internal/telnet` and `internal/web`); core is a separate, restartable
+  process. The gateway's core client is a single shared `CoreServiceClient`
+  (its ClientConn auto-redials; individual server-streams do not auto-resume).
+- Web (`internal/web/handler.go:194-281`) and telnet
+  (`internal/telnet/gateway_handler.go`) both: `SelectCharacter` → open
+  `Subscribe` stream → core-side `AddConnection` (`server.go:854`) → on stream
+  exit, `defer Disconnect` (web `handler.go:173-188`, telnet `gateway_handler.go:124`).
+- **Today a core-stream break tears down the client.** When core's Subscribe
+  stream errors, `StreamEvents` returns `CodeUnavailable` (`handler.go:272`),
+  ending the client stream; the browser then reconnects (client-driven).
+  Gateway-survival is therefore not implemented yet.
+- **Reuse already present:** a 15s client-liveness heartbeat in `StreamEvents`
+  (`handler.go:241-258`, probes the client via `stream.Send`). **Resume is
+  server-side and JetStream-native:** `Subscribe` opens a *durable per-session
+  consumer* and resumes from its acked-seq on every re-open (`server.go:753-756`,
+  `:994`, `:1065`; `bus.go:69-74`). `SubscribeRequest` has **no** cursor/resume
+  input — `replay_from_cursor` was removed (`core.proto:228`, reserved); the
+  server determines replay policy itself. So the gateway resumes by simply
+  re-`Subscribe`-ing the same `session_id`; the `EventFrame.cursor`
+  (`core.proto:276`, `bytes cursor = 8`) is used by the gateway only to **dedup**
+  the small un-acked redelivery overlap (core acks *after* send, `server.go:1274`,
+  so at most the in-flight frame is redelivered). A `reattached` signal on
+  `SelectCharacterResponse` (`core.proto:731`, field 4) + the `SelectCharacter`
+  reattach path; gRPC server keepalive config (`cmd/holomush/sub_grpc.go:239`).
+- **No session liveness lease exists today.** `session_connections` has
+  `connected_at` but no `last_seen_at` (`internal/store/migrations/000001_baseline.up.sql:226-234`).
+  Precedent for the pattern: `internal/store/plugin_repo.go` already does
+  `last_seen_at` + `SweepInactive` for plugins.
+
+## 4. Design overview
+
+Three composed mechanisms:
+
+1. **Connection lease (core).** Each connection carries a `last_seen_at` lease.
+   The owning gateway refreshes it while the client socket is open; a lease
+   sweep reaps connections whose lease has lapsed. `active` and `grid_present`
+   are recomputed from the set of live connections.
+2. **Gateway lease refresh (web + telnet).** The gateway refreshes the lease on
+   its existing client-liveness tick and stops the moment the client socket is
+   lost.
+3. **Gateway survival (web + telnet).** The client socket is decoupled from any
+   single core Subscribe stream; a core-stream break with a live client triggers
+   reconnect + cursor-resume + reattach, not a client teardown.
+
+The cooperative `Disconnect` RPC is retained as the immediate fast-path on
+graceful close; the lease is the backstop for every non-cooperative case.
+
+### 4.1 State model
+
+```mermaid
+stateDiagram-v2
+  [*] --> active: SelectCharacter (first live conn)
+  active --> active: RefreshConnection (lease stays fresh)
+  active --> detached: last live conn lost (lease lapse OR Disconnect); expires_at = now + reattachTTL
+  detached --> active: reattach (SelectCharacter / re-Subscribe)
+  detached --> expired: reattach TTL elapsed (session reaper emits leave)
+  expired --> [*]: deleted
+```
+
+Connection-level: a connection is **live** while `last_seen_at > now − L`;
+once it lapses, the lease sweep removes it. Removing the last live connection
+of a session drives the `active → detached` transition above (reusing the exact
+logic at `server.go:1473-1545`). `grid_present` is recomputed independently:
+true iff ≥1 live connection of `client_type ∈ {terminal, telnet}`.
+
+### 4.2 Gateway survival sequence
+
+```mermaid
+sequenceDiagram
+  participant C as Client (browser/telnet)
+  participant G as Gateway
+  participant K as Core
+  C->>G: open transport
+  G->>K: Subscribe(session, conn)
+  loop while client alive
+    G-->>C: heartbeat (15s) + forward events (track last EventFrame.cursor)
+    G->>K: RefreshConnection(session, conn)  %% lease fresh
+  end
+  Note over K: core restarts
+  K--xG: Subscribe stream breaks (CodeUnavailable)
+  Note over G: client still alive → DO NOT close client
+  G-->>C: ControlSignal RECONNECTING
+  loop bounded backoff (≤ ceiling)
+    G->>K: Subscribe(session, conn)  %% durable consumer resumes from acked-seq
+  end
+  alt session detached during gap (SESSION_NOT_FOUND)
+    G->>K: SelectCharacter (reattach, reattached=true)
+  end
+  G-->>C: ControlSignal RECONNECTED
+  Note over G,K: server-side durable resume; gateway dedups un-acked overlap by event id; lease re-asserted
+```
+
+## 5. Detailed design (phased)
+
+### Phase 1 — Core connection lease (closes the reported bug on its own)
+
+- **Migration:** add `session_connections.last_seen_at BIGINT NOT NULL` (ns
+  epoch, per the `pgnanos` convention). Note `connected_at` is already `BIGINT`
+  post-migration `000041` (the baseline declared it `TIMESTAMPTZ`), so the new
+  column is type-consistent with it. Backfill existing rows' `last_seen_at` to
+  their `connected_at`. Add an index supporting the sweep predicate
+  (`last_seen_at`).
+- **RPC `RefreshConnection(session_id, connection_id, player_session_token)`**
+  on `CoreService`. Ownership-validated and enumeration-safe (collapse failures
+  to `SESSION_NOT_FOUND`), mirroring `ListFocusPresence`
+  (`internal/grpc/list_focus_presence.go:44-66`). Effect: set `last_seen_at = now`
+  for that connection. (Per-connection rather than batched: each connection has
+  its own session/player token, so batching across tokens is not possible.)
+- **Lease sweep** (extends `internal/session/reaper.go`): on each reaper tick,
+  remove connections with `last_seen_at < now − L`. For each affected session,
+  recompute derived state using the existing transition logic
+  (the `totalCount == 0` branch at `server.go:1473`): zero live connections →
+  `detached(detached_at=now, expires_at=now+reattachTTL)`; recompute
+  `grid_present`, emitting the grid phase-out (`UpdateGridPresent(false)` at
+  `server.go:1545`) when it falls true→false.
+- **`active`/`grid_present` recompute** also fires inline on `AddConnection`
+  (`server.go:854`) and the cooperative `Disconnect`, so the flags are correct
+  between sweeps.
+- **Fresh-connection liveness:** `AddConnection` (`server.go:854`) stamps
+  `last_seen_at = now`, so a newly-created connection is live for a full `L`
+  before its first refresh. This closes the per-session create→first-connect
+  zero-connection window (a legitimate transient that exists at any time, not
+  just at boot) **independently** of the boot-grace window — boot-grace covers
+  core restart; the `AddConnection` stamp covers steady-state connection setup.
+  The sweep predicate (`last_seen_at < now − L`) therefore never reaps a
+  just-created connection, and there is no code path that leaves `last_seen_at`
+  unset.
+- **Boot-grace window:** the lease sweep MUST NOT reap any connection within
+  `L + margin` of core start (records the process start time; skips sweeping
+  until the window elapses). This replaces the unsafe "mark all active detached
+  on boot" reconcile — live gateways re-assert leases within one refresh
+  interval, so a restart never detaches a genuinely-live session.
+
+Phase 1 alone fixes the reported ghost: once Turquoise Argon's gateway stops
+refreshing, the lease lapses within `L`, the connection is swept, the session
+detaches, the session reaper expires it after the reattach TTL, and the guest
+reaper then collects the guest (the deadlock is gone because liveness now
+decays on its own).
+
+### Phase 2 — Gateway lease refresh (web + telnet)
+
+- **Web:** the existing 15s heartbeat tick (`handler.go:247`) additionally calls
+  `RefreshConnection` for its connection when the client probe succeeds; on
+  probe failure it returns (today's behavior) without refreshing.
+- **Telnet:** the read loop / `TelnetIdleTimeout` (`cmd/holomush/gateway.go`)
+  provides the equivalent liveness tick that drives `RefreshConnection`.
+- Lease parameters: refresh interval `R` = 15s (reuse the heartbeat); lease TTL
+  `L` = 45s (tolerate ~3 missed refreshes), configurable. The sweep runs on the
+  session-reaper interval (default 30s), giving a worst-case detection latency
+  of `L + sweep_interval`.
+
+### Phase 3 — Gateway survival reconnect (web + telnet)
+
+- **Decouple** the client socket from any single core Subscribe stream: the
+  client transport lives in an outer loop; the core `Subscribe` is an inner,
+  replaceable resource.
+- **Distinguish the break cause** (the crux the gateway currently conflates):
+
+  | Cause | Detected by | Behavior |
+  | --- | --- | --- |
+  | Client gone | heartbeat `Send` fails / client ctx cancel | tear down + `Disconnect` (today) |
+  | Core gone | core `Recv` error, client still alive | hold client, reconnect, resume |
+
+- **Resume** by re-`Subscribe`-ing the same `session_id`: core re-opens the
+  durable per-session JS consumer, which resumes from its acked-seq server-side
+  (`server.go:753-756`/`:994`/`:1065`). No cursor is passed in
+  (`SubscribeRequest.replay_from_cursor` was removed, `core.proto:228`). Because
+  core acks *after* sending (`server.go:1274`), at most the in-flight frame is
+  redelivered; the gateway tracks the last `EventFrame.cursor` / event ID it
+  forwarded and **dedups** that overlap so the client sees no duplicate. Emit
+  `RECONNECTING`/`RECONNECTED` control frames so the UI shows an indicator rather
+  than a disconnect — these are **new** values added to the web `ControlSignal`
+  enum (`api/proto/holomush/web/v1/web.proto:44`, currently UNSPECIFIED=0,
+  REPLAY_COMPLETE=1, STREAM_CLOSED=2, STREAM_OPENED=3 → add `=4`/`=5`); telnet
+  surfaces them as a status line.
+- **Reattach** via `SelectCharacter` if the session detached during the gap
+  (`reattached=true`), preserving session continuity.
+- **Bounded retry:** if core stays unreachable past a ceiling (≈ reattach TTL or
+  a configured max), give up — close the client transport and issue `Disconnect`
+  (genuine outage).
+
+### Phase 4 — Presence / `grid_present` split
+
+- **Mechanism:** `grid_present` is a stored `BOOLEAN` column on `sessions`
+  (already present, `migrations/000001_baseline.up.sql:209`), recomputed by the
+  lease/connection layer (P1) on every connection-set change. The roster query
+  predicate is extended from `status = 'active'` to
+  `status = 'active' AND grid_present = true` — applied to the query backing both
+  `list_focus_presence.go` and the `location_follow.go` presence list
+  (`session_store.go:620`, `ListActiveByLocation`). Whether this is an added
+  predicate on `ListActiveByLocation` or a dedicated `ListGridPresentByLocation`
+  sibling is a plan-level implementation choice; the **semantics** (roster =
+  `grid_present`) is fixed by I-PRES-1.
+- Presence reads remain flag-based (cheap, no per-read join into
+  `session_connections`) — the P1 lease layer is what keeps `active`/`grid_present`
+  honest, so the roster read trusts the columns.
+- The green "online" dot reflects connection liveness (which, for any
+  grid-present character, is implied).
+
+## 6. Invariants (RFC2119)
+
+- **I-LIVE-1 (refresh).** While a client transport is open, its owning gateway
+  MUST refresh that connection's lease at interval ≤ `R`, and MUST cease
+  refreshing within one tick of detecting transport loss.
+- **I-LIVE-2 (expiry).** A connection whose `last_seen_at` is older than the
+  lease TTL `L` MUST be reaped by the lease sweep without requiring a
+  cooperative `Disconnect`.
+- **I-LIVE-3 (derivation).** `session.active` ⇔ ≥1 live connection;
+  `session.grid_present` ⇔ ≥1 live connection of `client_type ∈ {terminal,
+  telnet}`. Both MUST be recomputed on every connection-set change
+  (add, lease-reap, Disconnect).
+- **I-LIVE-4 (boot grace).** The lease sweep MUST NOT reap any connection within
+  the boot-grace window (≥ `L` + margin) after core process start.
+- **I-LIVE-5 (single source of liveness).** The only writers that transition a
+  session `active ↔ detached` on liveness grounds are the lease layer and the
+  cooperative `Disconnect` RPC. No read path may treat `status='active'` as
+  evidence of a live transport independent of the lease layer.
+- **I-PRES-1 (grid roster).** The location presence roster MUST be filtered to
+  `grid_present` characters, not raw `active` sessions.
+- **I-SURV-1 (cause distinction).** The gateway MUST NOT terminate a live client
+  transport solely because the core Subscribe stream broke; client-gone →
+  `Disconnect`, core-gone-with-live-client → reconnect-and-resume.
+- **I-SURV-2 (gap-free resume).** On reconnect the gateway MUST re-`Subscribe`
+  the same `session_id` so core's durable JS consumer resumes from its acked-seq
+  server-side (no cursor is passed in; `server.go:756`/`:994`/`:1065`), and MUST
+  dedup the un-acked redelivery overlap by event ID (`EventFrame.cursor` /
+  `EventFrame.id`) so no event is dropped or duplicated.
+- **I-SURV-3 (reattach continuity).** If the session detached during the gap,
+  the gateway MUST reattach the same session (`reattached=true`).
+- **I-SURV-4 (bounded retry).** Reconnect MUST be bounded; exceeding the ceiling
+  MUST close the client transport and issue `Disconnect`.
+- **I-SURV-5 (transport symmetry).** Web and telnet MUST implement identical
+  lease-refresh and survival semantics.
+- **I-SEC-1 (ownership).** `RefreshConnection` MUST validate the
+  `player_session_token` + session ownership and collapse any failure to
+  `SESSION_NOT_FOUND` (enumeration-safe).
+
+A meta-test MUST assert a bijection between these numbered invariants and their
+covering tests.
+
+## 7. Error handling
+
+- `RefreshConnection` follows the gRPC-error rules (`.claude/rules/grpc-errors.md`):
+  no inner-error leakage; ownership failures collapse to `SESSION_NOT_FOUND`.
+- **Error contract (load-bearing for I-SURV-1 / I-SURV-3):** the gateway MUST
+  distinguish two failure modes of `RefreshConnection` (and of the re-`Subscribe`
+  during reconnect):
+  - **Transport-level gRPC error** (e.g. `Unavailable` / `DeadlineExceeded` —
+    core is restarting or unreachable): the gateway keeps holding the client
+    socket and retries within the reconnect ceiling. It MUST NOT reattach or
+    tear down the client on a transient error alone.
+  - **Structured `SESSION_NOT_FOUND`** (the session/connection was genuinely
+    reaped — e.g. core was down longer than the reattach TTL): the gateway
+    reattaches via `SelectCharacter` (`reattached` may be false → a fresh
+    session) and resumes.
+  This split is what makes "core restart doesn't kill activity" hold: a brief
+  core outage is transient (retry, no user-visible disconnect), while a genuine
+  reap is a structured signal to reattach.
+- Lease sweep failures are per-connection isolated (mirroring the existing
+  reaper's panic/error isolation, `reaper.go:57-71`) — one bad row cannot abort
+  the sweep.
+- Gateway reconnect uses bounded exponential backoff; structured logs use the
+  `*Context` slog variants (`.claude/rules/logging.md`).
+
+## 8. Testing strategy & quality gates
+
+### 8.1 Discipline (project mandates, restated as acceptance)
+
+- **TDD is required** (`dev-flow:test-driven-development`, CLAUDE.md): tests MUST
+  be written before implementation; each phase lands red → green.
+- **Coverage MUST exceed 80% per package** (`task test:cover`), targeting ≥90%
+  for the core packages touched (`internal/session`, the session paths of
+  `internal/store`, the lease/disconnect paths of `internal/grpc`) per
+  `.claude/rules/testing.md`.
+- **Every numbered invariant (§6) MUST have ≥1 covering test**, and a meta-test
+  MUST assert the invariant ↔ test bijection.
+- Test names follow ACE; `task test`, `task test:int`, and `task test:cover`
+  MUST be green before each phase is complete.
+
+### 8.2 Test taxonomy (each category is required)
+
+**Happy path** (unit + integration + E2E):
+
+- connect → periodic `RefreshConnection` → session stays `active`/`grid_present`
+  → graceful `Disconnect` → `detached` → reattach within TTL → `active` again.
+- The same flow exercised symmetrically for **web** and **telnet** (I-SURV-5).
+- End-to-end (E2E): see the E2E block below — the normal-case presence contract
+  through a real browser, not only failure modes.
+
+**Boundary** (unit):
+
+- Lease threshold: a connection refreshed at `L − ε` is live; at `L + ε` it is
+  swept (I-LIVE-2 off-by-one at the `L` edge).
+- Boot-grace edge: a lapsed connection is NOT reaped at `boot + (graceWindow − ε)`
+  and IS reaped just after (I-LIVE-4).
+- Create→first-connect window: a session with `SelectCharacter` done but no
+  `AddConnection` yet is NOT detached during the grace window (the legitimate
+  zero-connection transient).
+- Connection-count transitions: `N → 0` live connections detaches exactly once;
+  `N → N−1` (still ≥1) does not (I-LIVE-3).
+- Grid boundary: last `terminal`/`telnet` connection removed while a comms_hub
+  connection remains → `grid_present` false, `active` true (I-LIVE-3 / I-PRES-1).
+- Reattach-TTL edge: reattach at `TTL − ε` resumes the session; at `TTL + ε` the
+  session has expired and a fresh one is created.
+- Reconnect ceiling edge: core-down just under the ceiling keeps holding the
+  client; just over closes it and issues `Disconnect` (I-SURV-4).
+
+**Invariant** (unit, one named test per `I-*`, enumerated by the §6 bijection
+meta-test): I-LIVE-1..5, I-PRES-1, I-SURV-1..5, I-SEC-1.
+
+**Integration** (`internal/testsupport/integrationtest`, `//go:build integration`,
+`task test:int`):
+
+- End-to-end deadlock resolution: lease lapse → `detached` → reaped → guest
+  reaper then collects the guest player.
+- Simulated core restart: a lease-refreshed session is NOT detached (no spurious
+  `leave`) within the boot-grace window (G2 / I-LIVE-4).
+- Reconnect resumes gap-free from the cursor and reattaches the same session
+  (I-SURV-2 / I-SURV-3).
+- Presence roster reflects `grid_present`, not raw `active` (I-PRES-1).
+
+**E2E** (Playwright, `task test:e2e`):
+
+- **Happy path:** two browser clients at the same location each see the other in
+  the PRESENT roster with a live indicator; while both stay connected the roster
+  is stable; one logs out / closes its tab → the other sees it drop from PRESENT
+  (no ghost). This is the user-visible presence-correctness contract in the
+  normal case — the steady-state counterpart to the failure cases below.
+- **Happy path (reattach):** a page reload within the reattach TTL keeps the
+  character present *exactly once* (no duplicate roster entry), confirming
+  reattach continuity through a real browser (I-SURV-3).
+- Kill the client transport → ghost clears from PRESENT within `L` + sweep.
+- Restart core mid-session → client sees a `RECONNECTING` indicator then resumes
+  with no duplicate or missing events.
+
+## 9. Configuration
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `session_connection_refresh_interval` | 15s | gateway lease-refresh tick (`R`) |
+| `session_connection_lease_ttl` | 45s | lease TTL (`L`); connection dead past this |
+| `session_boot_grace` | `L` + 15s | lease-sweep suppression after core start |
+| `gateway_reconnect_ceiling` | min(configured, session reattach TTL) | max core-down hold before closing the client; MUST NOT exceed the session's own reattach TTL, so a shorter guest TTL (holomush-hfvc) is honored — there is no point holding a client past the point its session would have been reaped |
+
+Reattach TTL continues to come from `sessionDefaults.TTL` (guest TTL per hfvc).
+
+## 10. Docs deliverables (PR-blocking)
+
+- Update the session-lifecycle contributor doc + diagram (holomush-bgxg) to
+  include the connection-lease layer and the survival reconnect flow.
+- Document the `active` vs `grid_present` distinction in
+  `.claude/rules/terminology.md`-adjacent site docs.
+
+## 11. Alternatives considered
+
+- **A — boot reconcile (mark all `active` detached on core boot).** Rejected:
+  unsafe under the gateway model — a core restart does not disconnect clients,
+  so this would detach genuinely-live, gateway-attached sessions. Replaced by
+  the boot-*grace* window (I-LIVE-4).
+- **B — steady-state sweep of `active` + zero `session_connections`.** Subsumed:
+  the lease sweep is a strictly stronger version (it makes the connection rows
+  themselves decay, rather than trusting their presence).
+- **C — extend the reaper to active+no-connection+stale `updated_at`.** Subsumed
+  by the lease model.
+- **D — presence query joins `session_connections`.** Insufficient alone: a
+  SIGKILL leaves connection rows dangling too, so `EXISTS(connection)` is
+  satisfied by a corpse. The lease (decaying `last_seen_at`) is the
+  correct-by-construction form of D.
+- **Core-side timer-bump of the lease (no gateway change, no new RPC).**
+  Rejected in favor of gateway-refresh: the gateway's client-facing signals
+  (WS close, TCP RST, idle timeout, heartbeat `Send` failure) detect client
+  death that core's view of the gateway↔core stream cannot (a half-open client
+  with a still-open gateway↔core stream).
+- **Client-originated heartbeat (web + telnet).** Higher fidelity (catches a
+  wedged-but-socket-open client) but requires client changes on both transports
+  and awkward telnet pinging. Deferred as a future tightening of I-LIVE-1.
+
+## 12. Out of scope / follow-ups
+
+- Holding client sockets across a **gateway** restart (vs a core restart) is
+  bounded by holomush-2iyrf's "don't restart the gateway unless it changed"
+  strategy; clients reconnect to a fresh gateway and re-assert leases.
+- Guest reattach-TTL tuning: holomush-hfvc.
+- Disconnect count-race atomicity: holomush-cizj.

--- a/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
+++ b/docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md
@@ -77,13 +77,13 @@ over a dead transport, and nothing reconciles it.
 
 ```mermaid
 flowchart LR
-  subgraph Gateway process [Gateway process — long-lived]
-    WEB[internal/web<br/>StreamEvents]
-    TEL[internal/telnet<br/>GatewayHandler]
+  subgraph gw["Gateway process — long-lived"]
+    WEB["internal/web<br/>StreamEvents"]
+    TEL["internal/telnet<br/>GatewayHandler"]
   end
-  subgraph Core process [Core process — restartable]
-    SUB[CoreService.Subscribe]
-    STORE[(sessions /<br/>session_connections)]
+  subgraph core["Core process — restartable"]
+    SUB["CoreService.Subscribe"]
+    STORE[("sessions /<br/>session_connections")]
   end
   Browser <-->|WS / HTTP2| WEB
   TelnetClient <-->|TCP| TEL
@@ -169,20 +169,20 @@ sequenceDiagram
   G->>K: Subscribe(session, conn)
   loop while client alive
     G-->>C: heartbeat (15s) + forward events (track last EventFrame.cursor)
-    G->>K: RefreshConnection(session, conn)  %% lease fresh
+    G->>K: RefreshConnection(session, conn) — keep lease fresh
   end
   Note over K: core restarts
   K--xG: Subscribe stream breaks (CodeUnavailable)
-  Note over G: client still alive → DO NOT close client
+  Note over G: client still alive, DO NOT close client
   G-->>C: ControlSignal RECONNECTING
-  loop bounded backoff (≤ ceiling)
-    G->>K: Subscribe(session, conn)  %% durable consumer resumes from acked-seq
+  loop bounded backoff (<= ceiling)
+    G->>K: Subscribe(session, conn) — durable consumer resumes from acked-seq
   end
   alt session detached during gap (SESSION_NOT_FOUND)
     G->>K: SelectCharacter (reattach, reattached=true)
   end
   G-->>C: ControlSignal RECONNECTED
-  Note over G,K: server-side durable resume; gateway dedups un-acked overlap by event id; lease re-asserted
+  Note over G,K: server-side durable resume, gateway dedups un-acked overlap by event id, lease re-asserted
 ```
 
 ## 5. Detailed design (phased)
@@ -477,4 +477,4 @@ Reattach TTL continues to come from `sessionDefaults.TTL` (guest TTL per hfvc).
   strategy; clients reconnect to a fresh gateway and re-assert leases.
 - Guest reattach-TTL tuning: holomush-hfvc.
 - Disconnect count-race atomicity: holomush-cizj.
-<!-- adr-capture: sha256=45cf080700a029d7; session=brainstorm-rsoe6; ts=2026-05-30T15:25:47Z; adrs=holomush-6syxb,holomush-2w9vh,holomush-0qx5e,holomush-6vl53,holomush-85exr -->
+<!-- adr-capture: sha256=9b852d61bb362969; session=brainstorm-rsoe6; ts=2026-05-30T15:54:05Z; adrs=holomush-6syxb,holomush-2w9vh,holomush-0qx5e,holomush-6vl53,holomush-85exr -->


### PR DESCRIPTION
## Summary

Docs-only PR: the design **spec**, implementation **plan**, and **5 ADRs** for **holomush-rsoe6 — Session Liveness & Gateway Survival**. No code changes; implementation is tracked in the epic's 16 child beads.

### Problem
After a core redeploy a disconnected guest stays in a location's PRESENT roster indefinitely. Root cause: `active` is *stored intent*, not observed liveness — the reaper can't collect an `active` orphan (`active` rows carry `expires_at = NULL`), and a two-reaper deadlock keeps the guest player alive too.

### Design (correct-by-construction liveness)
- Per-connection **lease** (`session_connections.last_seen_at`) that decays unless the gateway refreshes it; a lease sweep reaps lapsed connections and recomputes `active`/`grid_present`.
- **Gateway survival**: hold the client socket across a core restart; re-`Subscribe` resumes the durable per-session JetStream consumer server-side (no cursor input — `replay_from_cursor` was removed); dedup the un-acked overlap.
- **`active` vs `grid_present`** modeled as distinct axes; the location roster derives from `grid_present`.
- **Boot-grace** window, not boot-reconcile (core restart ≠ client disconnect — the gateway holds the sockets).

### Contents
- `docs/superpowers/specs/2026-05-30-session-liveness-and-gateway-survival-design.md` — 12 RFC2119 invariants (I-LIVE-1..5, I-PRES-1, I-SURV-1..5, I-SEC-1).
- `docs/superpowers/plans/2026-05-30-session-liveness-and-gateway-survival.md` — 16 TDD tasks across 5 phases.
- `docs/adr/holomush-{6syxb,2w9vh,0qx5e,6vl53,85exr}-*.md` — 5 ADRs.

### Process
- Both adversarial reviewer gates returned READY (design round 2, plan round 2); `adr-doctor` + docs-lane `pr-prep` green.
- Epic `holomush-rsoe6` materialized: 16 child tasks + 27 dependency edges + 5 decision beads.

> Note: docs-only PRs no-op CI Lint (`ci-docs-skip`), so markdown was gated locally via `task pr-prep:docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
