### PR TITLE
chore(claude): soften cat/head/tail/find enforcement hook from block to nudge

### DIFF
--- a/.claude/hooks/enforce-task-runner.sh
+++ b/.claude/hooks/enforce-task-runner.sh
@@ -2,14 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 HoloMUSH Contributors
 #
-# PreToolUse hook: enforce task runner and dedicated tools
-# Blocks direct go/lint commands (go test/build, golangci-lint, gofmt) and
-# the cat/head/tail/find file utilities, suggesting the proper task commands
-# or native Claude Code tools. grep is a soft nudge (not a block) toward the
-# modern search ladder — see the grep case for why.
+# PreToolUse hook: enforce task runner, nudge toward dedicated tools
+# HARD-BLOCKS direct go/lint commands (go test/build, golangci-lint, gofmt):
+# these have a correct `task` alternative and raw use bypasses task-runner
+# setup, so running them is a genuine mistake worth denying.
+# SOFT-NUDGES the cat/head/tail/find/grep file utilities (echo to stderr, no
+# exit 2). They are frequently the right tool (head -c, tail -f, piping into
+# jq, find -exec) and even when Read/Glob would do, a hard block is now a net
+# hazard: recent harnesses dispatch tool calls in parallel batches, and an
+# exit-2 deny on ONE segment cancels every sibling call in the batch — so a
+# `task test … ; tail /tmp/log` verification idiom loses the real test run.
+# grep was softened first (see its case); cat/head/tail/find followed for the
+# same reason.
 # Error strategy: enforcement hook — fails open on jq/parse errors
 # (command proceeds unchecked), but reliably blocks known bad patterns
-# when parsing succeeds.
+# (go/lint/fmt) when parsing succeeds.
 set -uo pipefail
 
 # --- Parse phase: fail open on malformed input ---
@@ -164,16 +171,18 @@ while IFS= read -r segment; do
       echo "Nudge: prefer 'rg' over $word (faster, .gitignore-aware). For Go symbol/AST reads use mcp__probe__search_code; for structural patterns or codemods use ast-grep. ($word still runs.)" >&2
       ;;
     cat)
-      # Allow heredocs (with or without space/flags): cat <<EOF, cat<<EOF, cat -s <<EOF
-      # Allow /dev paths: cat /dev/null
+      # Soft nudge, NOT a block (no exit 2) — see header for the parallel-batch
+      # cascade rationale. Stay silent for heredocs (cat <<EOF, cat<<EOF,
+      # cat -s <<EOF) and /dev paths (cat /dev/null), which have no Read-tool
+      # equivalent at all.
       if ! echo "$before_pipe" | command grep -qE "(<<|/dev/)"; then
-        echo "Use the Read tool instead of cat" >&2
-        exit 2
+        echo "Nudge: prefer the Read tool over cat for file reads (offset/limit for ranges). cat still runs." >&2
       fi
       ;;
     head|tail)
-      echo "Use the Read tool with offset/limit instead of $word" >&2
-      exit 2
+      # Soft nudge, NOT a block (no exit 2) — see header. head -c (byte limit),
+      # tail -f, and piping (cmd | tail -N) have no Read-tool equivalent.
+      echo "Nudge: prefer the Read tool with offset/limit over $word for file reads. $word still runs." >&2
       ;;
     find)
       # Allow find when used with predicates Glob can't express:
@@ -182,10 +191,10 @@ while IFS= read -r segment; do
       # or actions (-exec/-delete/-printf). Block plain "find . -name '*.x'"
       # patterns since Glob handles those.
       if echo "$rest" | command grep -qE -- '(-(m|a|c)(time|min)|-newer|-size|-perm|-user|-group|-uid|-gid|-empty|-exec|-delete|-printf|-fprint|-iname|-iwholename|-i?regex|-maxdepth|-mindepth|-prune|-follow|-xdev)\b'; then
-        :  # allow
+        :  # predicate Glob can't express — stay silent
       else
-        echo "Use the Glob tool instead of find (or add -mtime/-newer/-size/-exec/etc. if you need a predicate Glob can't express)" >&2
-        exit 2
+        # Soft nudge, NOT a block (no exit 2) — see header.
+        echo "Nudge: prefer the Glob tool over find for plain name/path matches (find still runs; add -mtime/-newer/-size/-exec/etc. for predicates Glob can't express)." >&2
       fi
       ;;
   esac

--- a/.claude/rules/search-tools.md
+++ b/.claude/rules/search-tools.md
@@ -7,8 +7,14 @@
 
 This rule defines the search-tool precedence for HoloMUSH. It pairs with the
 `enforce-task-runner.sh` PreToolUse hook, which **nudges** (no longer blocks)
-`grep` toward this ladder and still blocks `cat`/`head`/`tail`/`find` toward
-the native Read/Glob tools.
+the `grep`/`cat`/`head`/`tail`/`find` file utilities toward this ladder — it
+prints a reminder but lets the command run. It still **hard-blocks**
+`go test`/`go build`/`golangci-lint`/`gofmt` (use the `task` runner instead).
+The file utilities were softened from hard blocks because an `exit 2` deny now
+cascades badly: recent harnesses dispatch tool calls in parallel batches, so
+denying one segment (e.g. the `tail /tmp/log` in a `task test … ; tail` run)
+cancels every sibling call in the batch. Honor the nudges, but they won't
+dead-end you.
 
 ## The ladder — match the tool to the question
 


### PR DESCRIPTION
## Problem

`.claude/hooks/enforce-task-runner.sh` hard-blocked (`exit 2`) the `cat` / `head` / `tail` / `find` file utilities. That was a reasonable style nudge under older single-call harnesses, but recent model/harness behavior turned it into a cascade-failure hazard:

1. **Parallel batches.** Tool calls are now dispatched in parallel batches. An `exit 2` deny on *one* call cancels **every sibling call in the batch** — so a style nudge on a `tail` segment nukes the legitimate `task test`/`task build`/`task lint` runs sharing that batch.
2. **Richer shell idioms.** Models compose `task X >/tmp/log 2>&1; echo "EXIT=$?"; tail -N /tmp/log` as one verification command; the standalone `tail` segment trips the block and takes the whole thing down. Some uses have *no* Read-tool equivalent at all (`head -c` byte reads, `tail -f`, piping into `jq`, `find -exec`).

Grounding: across local transcripts the file-utility blocks fired thousands of times; the dominant patterns were the verification idiom above, `head -c` byte reads, and multi-segment diagnostics blocked because one segment used `cat`.

## Change

- Convert `cat` / `head` / `tail` / `find` from hard blocks to **soft nudges** (echo to stderr, fall through to `exit 0`), matching the pre-existing `grep` nudge in the same hook.
- `go test` / `go build` / `golangci-lint` / `gofmt` stay **hard-blocked**: those have a correct `task` alternative and raw use bypasses task-runner setup, so denying them — even inside a batch — remains correct.
- The cat heredoc / `/dev/` silent-skip and the `find` predicate allow-list are unchanged.
- `.claude/rules/search-tools.md` updated to document the block-vs-nudge split and the parallel-batch rationale.

## Verification

- 15-case behavioral harness: file utilities → `rc=0` (nudge); heredoc / `/dev/` / `find -mtime` / post-pipe `tail` → `rc=0` silent; `go`/`golangci-lint`/`gofmt` → `rc=2` (still blocked).
- `shellcheck` clean; SPDX headers intact.
- `task pr-prep` (fast lane) — `status=pass`.
- `code-reviewer` agent — **VERDICT: READY**, no blocking findings.

## Follow-up (out of scope)

`docs/plans/2026-02-05-claude-code-hooks-design.md` still describes these utilities (and `grep`) as "blocked" — pre-existing drift from the earlier grep softening. Tracked separately, not fixed here to keep this diff to the hook + authoritative rule doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
