### PR TITLE
docs(plugin): binary world-query parity design + plan + ADRs (holomush-q42fh)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Derive world-read subject host-side; no subject field on wire](holomush-nthq6-derive-world-read-subject-host-side-no-subject-field-wire.md) | 2026-05-30 | Accepted | `holomush-nthq6` |
+| [Remove forgeable injectable WorldService; PluginHostService Query is the sole binary world-read path](holomush-c6oo8-remove-forgeable-injectable-worldservice-pluginhostservice-q.md) | 2026-05-30 | Accepted | `holomush-c6oo8` |
 | [Isolate xk6 extensions in a separate Go module](holomush-2344h-isolate-xk6-extensions-separate-go-module.md) | 2026-05-28 | Accepted | `holomush-2344h` |
 | [Use k6 + Custom xk6 Binary for Full-System Load Testing](holomush-evggu-use-k6-custom-xk6-binary-full-system-load-testing.md) | 2026-05-28 | Accepted | `holomush-evggu` |
 | [Use topic-tab navigation over a single grouped sidebar](holomush-q924m-use-topic-tab-navigation-over-a-single-grouped-sidebar.md) | 2026-05-28 | Accepted | `holomush-q924m` |

--- a/docs/adr/holomush-c6oo8-remove-forgeable-injectable-worldservice-pluginhostservice-q.md
+++ b/docs/adr/holomush-c6oo8-remove-forgeable-injectable-worldservice-pluginhostservice-q.md
@@ -1,0 +1,66 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-c6oo8; do not edit manually; use `/adr update holomush-c6oo8` -->
+
+# Remove forgeable injectable WorldService; PluginHostService Query is the sole binary world-read path
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-c6oo8
+**Deciders:** Sean Brandt
+
+## Context
+
+Binary plugins could reach `WorldService` via the plugin service registry (`requires: holomush.world.v1.WorldService`), calling the gRPC server with a caller-supplied subject. This is structurally equivalent to the EmitEvent actor-forgery surface closed by holomush-ec22.1. The path was latent — `core-scenes` declared the `requires` but had zero `worldv1` client usage — but its existence in the registry constitutes an open privilege-escalation surface. The new `PluginHostService` Query* RPCs (see the companion decision) make this injection unnecessary.
+
+## Decision
+
+The `WorldService` gRPC server (`internal/world/grpc_server.go`), its registry registration (`internal/plugin/setup/subsystem.go`), and the in-process conn (`internal/plugin/setup/world_conn.go`) are deleted. `PluginHostService` Query* RPCs become the sole binary-plugin world-read surface, parallel to the Lua hostfunc surface. The core server is unaffected — it reads `world.Service` directly in-process, never through the gRPC server. The `WorldService` proto is retained only if a non-plugin consumer mounts the handler; the implementation plan verifies this before deleting the proto service.
+
+## Rationale
+
+- A single constrained path per runtime (PluginHostService for binary, hostfunc for Lua) matches the plugin-runtime-symmetry invariant; two paths for binary would create a privilege gradient.
+- INV-3 (`WorldService` MUST NOT be resolvable from the plugin service registry) is verifiable by a structural meta-test — a policy-only approach cannot achieve this guarantee.
+- The forgery surface lives in `grpc_server.go`'s `access.CharacterSubject(req.GetSubjectId())` reads; those lines are removed by deleting the file, not by patching it.
+- The new PluginHostService path covers the same functional use cases; no capability is lost, only the unsafe delivery mechanism.
+- `core-scenes` (the only binary plugin) has zero actual `worldv1` client usage — the `requires` entry is vestigial, so no production behavior changes.
+
+## Alternatives Considered
+
+### Delete the registry injection; PluginHostService Query* is the sole path (chosen)
+
+- **Strengths:** Eliminates the forgery surface structurally — no binary plugin can obtain a `WorldService` client with an arbitrary-subject interface; enforces the single-constrained-path invariant matching the Lua runtime; the `WorldService` gRPC server becomes dead code and is removed, reducing attack surface.
+- **Weaknesses:** Requires reworking integration-test fixtures that used the injection as the canonical "binary plugin requires a host service" example; the "missing required service" DAG test must be re-vehicled onto a synthetic absent service.
+
+### Keep the registry injection; add an interceptor that stamps the host-derived subject
+
+- **Strengths:** No test rework; keeps the plugin DAG `requires`/`provides` mechanism exercised for `WorldService`.
+- **Weaknesses:** Two subject-derivation paths exist for binary plugins (interceptor vs token lookup) — runtime-divergence risk; does not match the Lua surface shape (Lua has no WorldService gRPC client path); does not achieve the single-constrained-path invariant; leaves a registry entry future plugins could `requires` and misuse.
+
+### Keep the registry injection as an opt-in advanced surface
+
+- **Strengths:** Maximum flexibility for future binary plugins that need arbitrary-subject world queries.
+- **Weaknesses:** Perpetuates the forgery surface; arbitrary-subject queries warrant their own higher-risk design; Lua plugins have no equivalent surface, violating plugin-runtime-symmetry.
+
+## Consequences
+
+**Positive:**
+
+- The only binary-accessible path that accepted a caller-supplied subject is removed; INV-3 is structurally enforceable.
+- Binary and Lua runtimes have parallel, equally-constrained world-read surfaces.
+- Dead code removed (`grpc_server.go`, `grpc_server_test.go`, `world_conn.go`, `NewGRPCServer`).
+- The plugin DAG is simplified: no plugin `requires` `WorldService`.
+
+**Negative:**
+
+- Integration-test fixtures coupled to the injectable `WorldService` must be reworked; the "missing required service" DAG test must be re-vehicled onto a synthetic absent service.
+- Tutorial documentation (`binary-plugins.md`) must be updated to replace the `requires: holomush.world.v1.WorldService` canonical example.
+
+**Neutral:**
+
+- The `WorldService` proto and generated bindings may be retained if non-plugin consumers mount the handler; the plan gates on a usage audit.
+- The Lua bridge's `hostfunc.WithWorldService` is independent of the registry injection and is untouched.

--- a/docs/adr/holomush-nthq6-derive-world-read-subject-host-side-no-subject-field-wire.md
+++ b/docs/adr/holomush-nthq6-derive-world-read-subject-host-side-no-subject-field-wire.md
@@ -1,0 +1,66 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-nthq6; do not edit manually; use `/adr update holomush-nthq6` -->
+
+# Derive world-read subject host-side; no subject field on wire
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Decision:** holomush-nthq6
+**Deciders:** Sean Brandt
+
+## Context
+
+Plugin world-read RPCs on `WorldService` accepted a caller-supplied `subject_id`, allowing binary plugins to name any character as the acting subject — a confused-deputy / privilege-escalation surface identical to the EmitEvent actor-forgery class. ADR holomush-qeypl established the host-derived, forgery-free subject pattern for `Evaluate`; the same structural fix is needed for all four world-read host functions (`QueryLocation`, `QueryCharacter`, `QueryLocationCharacters`, `QueryObject`). The new `PluginHostService` Query* RPCs carry only the target entity id, with no subject field; the host recovers the actor from the dispatch token (binary) or the VM context (Lua) and maps it through `pluginauthz.ActorSubject`.
+
+## Decision
+
+Every `PluginHostServiceQuery*Request` message carries no subject field. The host derives the ABAC subject from the authenticated actor bound to the dispatch context, via the single shared `pluginauthz.ActorSubject`, applying on-behalf-of (OBO) semantics: a character actor resolves to `character:<id>` (the acting character's authority), a plugin actor resolves to `plugin:<name>` (the self-fallback for plugin-initiated reads). This extends ADR holomush-qeypl from the `Evaluate` surface to all four world-read RPCs, for both the binary and Lua runtimes.
+
+## Rationale
+
+- A proto-level omission is a structural guarantee — INV-1 is a descriptor scan, not a runtime assertion; a future refactor cannot thread a subject through without changing the proto and triggering review.
+- Mirrors the established anti-spoof posture: holomush-qeypl (Evaluate), holomush-ec22.1 (EmitEvent token auth).
+- OBO semantics (the acting character's authority, not the plugin's broad authority) prevent confused-deputy reads where a plugin serving character A could read character B's world view.
+- Fail-closed on a missing/zero actor (yields `""` subject → world read denied) prevents unauthenticated reads.
+- Both runtimes converge on the same `ActorSubject` call and the same `world.Service.checkAccess` chokepoint, so INV-2 (shared derivation) and INV-5 (cross-runtime parity) are verifiable.
+
+## Alternatives Considered
+
+### Host-derived subject via dispatch context (chosen)
+
+- **Strengths:** Structurally forgery-free at the proto level (INV-1 is a descriptor scan, not a runtime check); OBO semantics fall out naturally from the actor-stamping already done at dispatch; consistent with holomush-qeypl and EmitEvent; a single shared `ActorSubject` function prevents runtime divergence.
+- **Weaknesses:** Plugins cannot query world state on behalf of an arbitrary subject in v1; plugin-initiated reads (no acting character) resolve to `plugin:<name>`, which may be broader than the minimal-privilege ideal.
+
+### Subject field on request (plugin supplies subject)
+
+- **Strengths:** Allows "what can character X see?" queries from a plugin acting in a broader context.
+- **Weaknesses:** The host cannot distinguish forged from legitimate values over the RPC; enables privilege escalation and cross-actor probing. Rejected for the same reason as in holomush-qeypl.
+
+### Interceptor that overwrites a plugin-supplied subject
+
+- **Strengths:** Keeps the existing `WorldService` gRPC server; less proto churn.
+- **Weaknesses:** An interceptor still requires the proto field to exist, making the forgery-free guarantee a runtime policy rather than a structural one; does not close the registry-injection surface (see the companion decision).
+
+## Consequences
+
+**Positive:**
+
+- Subject spoofing is structurally impossible at the proto level for all world reads.
+- OBO scoping: a plugin serving a command reads only what the acting character may read.
+- Consistent host-side anti-spoof posture across Evaluate, EmitEvent, and world reads.
+- A single shared subject-derivation path (`pluginauthz.ActorSubject`) cannot diverge between runtimes.
+
+**Negative:**
+
+- Plugins cannot query world state on behalf of a hypothetical/other subject in v1.
+- Plugin-initiated world reads (no acting character) resolve to `plugin:<name>`, which may be broader than the minimal-privilege ideal.
+
+**Neutral:**
+
+- The actor-recovery mechanism differs by runtime (dispatch token vs VM context) — a runtime-specific concern, not a policy difference.
+- The `WorldQuerierAdapter` hard-coded subject is retired for reads; its type may be removed or reduced.

--- a/docs/superpowers/plans/2026-05-30-binary-world-query-parity.md
+++ b/docs/superpowers/plans/2026-05-30-binary-world-query-parity.md
@@ -1,0 +1,1217 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Binary World-Query Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give binary plugins host-stamped `QueryLocation/QueryCharacter/QueryLocationCharacters/QueryObject` RPCs on `PluginHostService`, unify both plugin runtimes on a host-derived on-behalf-of (OBO) read subject, and delete the forgeable injectable `WorldService` gRPC path.
+
+**Architecture:** Extend the accepted ADR holomush-qeypl pattern (host-derived `Evaluate` subject, no subject on the wire) to world reads. The acting subject is recovered host-side from the dispatch token (binary) or the VM-context actor (Lua), mapped through the single shared `pluginauthz.ActorSubject`, and passed to the existing `world.Service` ABAC chokepoint. The `WorldService` gRPC server existed only for plugin injection and is removed; `world.Service` (the in-process Go type) stays.
+
+**Tech Stack:** Go, buf/protobuf (`task proto:generate`), gopher-lua, hashicorp/go-plugin, testify + Ginkgo (`//go:build integration`), `task` runner.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-binary-world-query-parity-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `api/proto/holomush/plugin/v1/plugin.proto` | 4 RPCs + request/response messages (no subject field) | Modify |
+| `pkg/proto/holomush/plugin/v1/*.pb.go` | Generated bindings | Regenerate |
+| `internal/plugin/goplugin/host.go` | `WorldReader` dep + `WithWorldService` option | Modify |
+| `internal/plugin/goplugin/host_service.go` | 4 Query handlers + `readSubject` helper + proto mappers | Modify |
+| `internal/plugin/goplugin/world_query_test.go` | Handler unit tests | Create |
+| `internal/plugin/goplugin/world_query_invariants_test.go` | INV-1/INV-3/INV-4 meta-tests | Create |
+| `internal/plugin/setup/subsystem.go` | Wire `WithWorldService`; remove registry injection | Modify |
+| `internal/plugin/setup/world_conn.go` | The injection conn builder | Delete |
+| `internal/world/grpc_server.go` + `grpc_server_test.go` | Dead WorldService gRPC server (forgery surface) | Delete (pending proto check) |
+| `internal/plugin/hostfunc/helpers.go` | OBO read-subject helper | Modify |
+| `internal/plugin/hostfunc/world.go` | 4 query fns → OBO subject | Modify |
+| `internal/plugin/hostfunc/world_test.go` | Lua OBO tests | Modify |
+| `pkg/plugin/world_client.go` + `world_client_test.go` | `WorldQuerier` facade + `WorldQuerierAware` | Create |
+| `plugins/core-scenes/plugin.yaml` | Drop unused `requires` | Modify |
+| `test/integration/plugin/binary_plugin_test.go` | Re-vehicle WorldService-coupled tests | Modify |
+| `site/src/content/docs/extending/tutorials/binary-plugins.md` | Replace WorldService `requires` example | Modify |
+| `site/src/content/docs/reference/grpc-api.md` | Regenerated reference | Regenerate |
+
+---
+
+## Phase 1: Proto surface
+
+### Task 1: Add the four Query RPCs to PluginHostService
+
+**Files:**
+
+- Modify: `api/proto/holomush/plugin/v1/plugin.proto`
+- Regenerate: `pkg/proto/holomush/plugin/v1/`
+
+- [ ] **Step 1: Add the RPCs to `service PluginHostService`**
+
+After the `Evaluate` RPC (`plugin.proto:190`), add:
+
+```protobuf
+  // QueryLocation returns one location's identity snapshot. The host resolves
+  // it through world.Service.GetLocation under the acting subject derived from
+  // the dispatch token (the invoking character for command/event dispatch, the
+  // plugin itself for plugin-initiated reads). No subject is accepted on the
+  // wire; ABAC is enforced at the world-service layer.
+  rpc QueryLocation(PluginHostServiceQueryLocationRequest) returns (PluginHostServiceQueryLocationResponse);
+
+  // QueryCharacter returns one character's identity snapshot via
+  // world.Service.GetCharacter under the host-derived acting subject. location_id
+  // is empty when the character is not in the world. No subject on the wire.
+  rpc QueryCharacter(PluginHostServiceQueryCharacterRequest) returns (PluginHostServiceQueryCharacterResponse);
+
+  // QueryLocationCharacters returns the {id, name} roster of characters at a
+  // location via world.Service.GetCharactersByLocation under the host-derived
+  // acting subject. The roster is empty when none are present. No subject on the wire.
+  rpc QueryLocationCharacters(PluginHostServiceQueryLocationCharactersRequest) returns (PluginHostServiceQueryLocationCharactersResponse);
+
+  // QueryObject returns one object's identity snapshot via world.Service.GetObject
+  // under the host-derived acting subject. location_id is empty when the object
+  // is not placed in the world. No subject on the wire.
+  rpc QueryObject(PluginHostServiceQueryObjectRequest) returns (PluginHostServiceQueryObjectResponse);
+```
+
+- [ ] **Step 2: Add the request/response messages**
+
+At the end of `plugin.proto` (before the closing of the file's message block — match surrounding style):
+
+```protobuf
+// PluginHostServiceQueryLocationRequest names the location to snapshot. It
+// carries no subject: the host derives the acting subject from the dispatch
+// token (INV-1).
+message PluginHostServiceQueryLocationRequest {
+  // location_id is the ULID of the location to read.
+  string location_id = 1;
+}
+
+// PluginHostServiceQueryLocationResponse returns the requested location's
+// identity fields.
+message PluginHostServiceQueryLocationResponse {
+  // id is the location ULID.
+  string id = 1;
+  // name is the location's display name.
+  string name = 2;
+  // description is the location's prose description.
+  string description = 3;
+}
+
+// PluginHostServiceQueryCharacterRequest names the character to snapshot;
+// carries no subject (INV-1).
+message PluginHostServiceQueryCharacterRequest {
+  // character_id is the ULID of the character to read.
+  string character_id = 1;
+}
+
+// PluginHostServiceQueryCharacterResponse returns the requested character's
+// identity fields. location_id is empty when the character is not in the world.
+message PluginHostServiceQueryCharacterResponse {
+  // id is the character ULID.
+  string id = 1;
+  // player_id is the owning player's ULID.
+  string player_id = 2;
+  // name is the character's display name.
+  string name = 3;
+  // description is the character's prose description.
+  string description = 4;
+  // location_id is the character's current location ULID, empty if none.
+  string location_id = 5;
+}
+
+// PluginHostServiceQueryLocationCharactersRequest names the location whose
+// occupant roster to return; carries no subject (INV-1).
+message PluginHostServiceQueryLocationCharactersRequest {
+  // location_id is the ULID of the location whose roster to read.
+  string location_id = 1;
+}
+
+// PluginHostServiceCharacterRef is one entry in a character roster: id + name
+// only. Use QueryCharacter to fetch full detail.
+message PluginHostServiceCharacterRef {
+  // id is the character ULID.
+  string id = 1;
+  // name is the character's display name.
+  string name = 2;
+}
+
+// PluginHostServiceQueryLocationCharactersResponse returns the location's
+// occupant roster; empty when the location holds no characters.
+message PluginHostServiceQueryLocationCharactersResponse {
+  // characters is the {id, name} roster at the location.
+  repeated PluginHostServiceCharacterRef characters = 1;
+}
+
+// PluginHostServiceQueryObjectRequest names the object to snapshot; carries no
+// subject (INV-1).
+message PluginHostServiceQueryObjectRequest {
+  // object_id is the ULID of the object to read.
+  string object_id = 1;
+}
+
+// PluginHostServiceQueryObjectResponse returns the requested object's identity
+// fields. location_id is empty when the object is not placed.
+message PluginHostServiceQueryObjectResponse {
+  // id is the object ULID.
+  string id = 1;
+  // name is the object's display name.
+  string name = 2;
+  // description is the object's prose description.
+  string description = 3;
+  // location_id is the object's current location ULID, empty if none.
+  string location_id = 4;
+}
+```
+
+- [ ] **Step 3: Regenerate bindings**
+
+Run: `task proto:generate`
+Expected: `pkg/proto/holomush/plugin/v1/plugin.pb.go` + `plugin_grpc.pb.go` updated with the new types; no error.
+
+- [ ] **Step 4: Verify proto lint (doc-comment + name-echo gates)**
+
+Run: `task lint:proto`
+Expected: PASS (every new element has a non-name-echo doc comment).
+
+- [ ] **Step 5: Verify build**
+
+Run: `task build`
+Expected: PASS (generated server interface now declares the 4 methods; `pluginHostServiceServer` will fail to satisfy it until Task 5 — if `task build` fails here on the unimplemented methods, that is expected and resolved in Task 5; commit the proto first).
+
+- [ ] **Step 6: Commit**
+
+`jj describe -m "feat(plugin): add world-query RPCs to PluginHostService proto (holomush-q42fh)"` then `jj new`.
+
+### Task 2: INV-1 meta-test — no subject field on Query requests
+
+**Files:**
+
+- Create: `internal/plugin/goplugin/world_query_invariants_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package goplugin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// TestINV1WorldQueryRequestsHaveNoSubjectField asserts none of the four
+// world-query request messages carry a subject field — the acting subject is
+// host-derived from the dispatch token, never plugin-supplied (INV-1).
+func TestINV1WorldQueryRequestsHaveNoSubjectField(t *testing.T) {
+	descs := []protoreflect.MessageDescriptor{
+		(&pluginv1.PluginHostServiceQueryLocationRequest{}).ProtoReflect().Descriptor(),
+		(&pluginv1.PluginHostServiceQueryCharacterRequest{}).ProtoReflect().Descriptor(),
+		(&pluginv1.PluginHostServiceQueryLocationCharactersRequest{}).ProtoReflect().Descriptor(),
+		(&pluginv1.PluginHostServiceQueryObjectRequest{}).ProtoReflect().Descriptor(),
+	}
+	for _, d := range descs {
+		fields := d.Fields()
+		for i := range fields.Len() {
+			assert.NotEqual(t, "subject", string(fields.Get(i).Name()),
+				"%s MUST NOT carry a subject field (INV-1)", d.Name())
+		}
+		assert.Equal(t, 1, fields.Len(),
+			"%s MUST carry exactly one field (the entity id) (INV-1)", d.Name())
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it passes** (the proto from Task 1 already satisfies it)
+
+Run: `task test -- -run TestINV1WorldQuery ./internal/plugin/goplugin/`
+Expected: PASS. (This is a lock, not a red-first test — it guards against a future subject-field addition.)
+
+- [ ] **Step 3: Commit**
+
+`jj describe -m "test(plugin): INV-1 lock — world-query requests carry no subject (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 2: Binary handlers
+
+### Task 3: Thread a world reader into the plugin Host
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host.go`
+- Modify: `internal/plugin/setup/subsystem.go`
+
+- [ ] **Step 1: Define the `WorldReader` interface and `worldQuerier` field**
+
+In `host.go`, near the other option funcs (`WithCommandQuerier` at `:201`), add:
+
+```go
+// WorldReader is the read-only slice of world.Service the plugin host needs to
+// serve world-query RPCs. *world.Service satisfies it.
+type WorldReader interface {
+	GetLocation(ctx context.Context, subjectID string, id ulid.ULID) (*world.Location, error)
+	GetCharacter(ctx context.Context, subjectID string, id ulid.ULID) (*world.Character, error)
+	GetCharactersByLocation(ctx context.Context, subjectID string, locationID ulid.ULID, opts world.ListOptions) ([]*world.Character, error)
+	GetObject(ctx context.Context, subjectID string, id ulid.ULID) (*world.Object, error)
+}
+
+// WithWorldService injects the world reader used by the world-query host RPCs.
+func WithWorldService(w WorldReader) HostOption {
+	return func(h *Host) { h.worldQuerier = w }
+}
+```
+
+Add the field to `type Host struct` (alongside `commandQuerier` at `:221`):
+
+```go
+	worldQuerier      WorldReader
+```
+
+(Add the imports `"github.com/holomush/holomush/internal/world"` and `"github.com/oklog/ulid/v2"` to `host.go` if not already present.)
+
+- [ ] **Step 2: Wire it in subsystem.go**
+
+In `internal/plugin/setup/subsystem.go`, where the goplugin host is constructed (the block with `goplugin.WithServiceRegistry(s.registry)` at `:274`), add the option:
+
+```go
+		goplugin.WithWorldService(s.cfg.World.Service()),
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `task build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`jj describe -m "feat(plugin): inject WorldReader into plugin Host (holomush-q42fh)"` then `jj new`.
+
+### Task 4: `readSubject` helper — host-derived OBO subject from the dispatch token
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host_service.go`
+- Create: `internal/plugin/goplugin/world_query_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package goplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/errutil"
+)
+
+// ctxWithToken issues a dispatch token for the given actor and returns an
+// incoming-metadata context carrying it (mirrors how DeliverCommand wires the
+// plugin call).
+func ctxWithToken(t *testing.T, h *Host, plugin string, actor core.Actor) context.Context {
+	t.Helper()
+	tok, err := h.tokenStore.Issue(plugin, actor)
+	require.NoError(t, err)
+	md := metadata.New(map[string]string{"x-holomush-emit-token": tok})
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func TestReadSubjectDerivesCharacterSubjectFromToken(t *testing.T) {
+	h := newTestHostWithTokenStore(t) // helper defined in Step 3
+	s := &pluginHostServiceServer{host: h, pluginName: "p"}
+	charID := core.NewULID().String()
+	ctx := ctxWithToken(t, h, "p", core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	subject, err := s.readSubject(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "character:"+charID, subject)
+}
+
+func TestReadSubjectFailsClosedWithoutToken(t *testing.T) {
+	h := newTestHostWithTokenStore(t)
+	s := &pluginHostServiceServer{host: h, pluginName: "p"}
+
+	_, err := s.readSubject(context.Background())
+
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "EMIT_TOKEN_MISSING")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestReadSubject ./internal/plugin/goplugin/`
+Expected: FAIL — `s.readSubject` undefined and `newTestHostWithTokenStore` undefined.
+
+- [ ] **Step 3: Implement `readSubject` and the test host helper**
+
+In `host_service.go` add (reusing the exact token-recovery shape from `Evaluate` at `:543-570`):
+
+```go
+// readSubject recovers the host-vouched ABAC subject for a read-only host RPC
+// from the dispatch token, mirroring Evaluate's token→actor recovery. The
+// subject is NEVER taken from the request (INV-1/INV-2). Fails closed.
+func (s *pluginHostServiceServer) readSubject(ctx context.Context) (string, error) {
+	if s.host == nil {
+		return "", oops.With("plugin", s.pluginName).New("plugin host service is not configured")
+	}
+	s.host.mu.RLock()
+	tokenStore := s.host.tokenStore
+	s.host.mu.RUnlock()
+
+	md, _ := metadata.FromIncomingContext(ctx)
+	tokens := md.Get("x-holomush-emit-token")
+	if len(tokens) == 0 || tokens[0] == "" {
+		return "", oops.Code("EMIT_TOKEN_MISSING").
+			With("plugin", s.pluginName).
+			Errorf("plugin read without a host-issued dispatch token")
+	}
+	if tokenStore == nil {
+		return "", oops.Code("EMIT_TOKEN_STORE_UNCONFIGURED").
+			With("plugin", s.pluginName).
+			Errorf("plugin token store is not configured")
+	}
+	storedActor, ok := tokenStore.Lookup(s.pluginName, tokens[0])
+	if !ok {
+		return "", oops.Code("EMIT_TOKEN_REJECTED").
+			With("plugin", s.pluginName).
+			Errorf("dispatch token is not valid for this plugin")
+	}
+	subject := pluginauthz.ActorSubject(storedActor)
+	if subject == "" {
+		return "", oops.Code("WORLD_QUERY_NO_SUBJECT").
+			With("plugin", s.pluginName).
+			Errorf("no acting subject for world read")
+	}
+	return subject, nil
+}
+```
+
+In `world_query_test.go` add the host helper (construct a Host with a real token store; mirror the existing test-host construction in `host_service_test.go`):
+
+```go
+func newTestHostWithTokenStore(t *testing.T) *Host {
+	t.Helper()
+	h := NewHost() // token store is initialized by NewHost; confirm against host.go
+	t.Cleanup(func() { _ = h.Close() })
+	return h
+}
+```
+
+(If `NewHost()` does not initialize `tokenStore`, follow the construction used by the existing `TestEmitEvent*`/`TestEvaluate*` tests in `host_service_test.go` — match that exact setup.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestReadSubject ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj describe -m "feat(plugin): readSubject helper derives OBO subject from dispatch token (holomush-q42fh)"` then `jj new`.
+
+### Task 5: Implement the four Query handlers + proto mappers
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/host_service.go`
+- Modify: `internal/plugin/goplugin/world_query_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `world_query_test.go`:
+
+```go
+func TestQueryLocationReturnsLocationWhenAuthorized(t *testing.T) {
+	h, eng, repo := newTestHostWithWorld(t) // helper in Step 3
+	locID := core.NewULID()
+	charID := core.NewULID().String()
+	eng.Grant("character:"+charID, "read", "location:"+locID.String())
+	repo.EXPECT().Get(mock.Anything, locID).Return(&world.Location{ID: locID, Name: "Square", Description: "A square."}, nil)
+	s := &pluginHostServiceServer{host: h, pluginName: "p"}
+	ctx := ctxWithToken(t, h, "p", core.Actor{Kind: core.ActorCharacter, ID: charID})
+
+	resp, err := s.QueryLocation(ctx, &pluginv1.PluginHostServiceQueryLocationRequest{LocationId: locID.String()})
+
+	require.NoError(t, err)
+	assert.Equal(t, locID.String(), resp.GetId())
+	assert.Equal(t, "Square", resp.GetName())
+	assert.Equal(t, "A square.", resp.GetDescription())
+}
+
+func TestQueryLocationDeniedForUnauthorizedSubject(t *testing.T) {
+	h, _, _ := newTestHostWithWorld(t) // no grant
+	locID := core.NewULID()
+	s := &pluginHostServiceServer{host: h, pluginName: "p"}
+	ctx := ctxWithToken(t, h, "p", core.Actor{Kind: core.ActorCharacter, ID: core.NewULID().String()})
+
+	_, err := s.QueryLocation(ctx, &pluginv1.PluginHostServiceQueryLocationRequest{LocationId: locID.String()})
+
+	require.Error(t, err)
+}
+
+func TestQueryLocationInvalidIDRejected(t *testing.T) {
+	h, _, _ := newTestHostWithWorld(t)
+	s := &pluginHostServiceServer{host: h, pluginName: "p"}
+	ctx := ctxWithToken(t, h, "p", core.Actor{Kind: core.ActorCharacter, ID: core.NewULID().String()})
+
+	_, err := s.QueryLocation(ctx, &pluginv1.PluginHostServiceQueryLocationRequest{LocationId: "not-a-ulid"})
+
+	require.Error(t, err)
+	errutil.AssertErrorCode(t, err, "INVALID_ARGUMENT")
+}
+```
+
+(Add equivalent happy-path + denial tests for `QueryCharacter`, `QueryLocationCharacters` — including an empty-roster case — and `QueryObject`, following the same shape. For `QueryCharacter`, assert the nullable `location_id` is empty when `Character.LocationID == nil`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestQuery ./internal/plugin/goplugin/`
+Expected: FAIL — handlers + `newTestHostWithWorld` undefined.
+
+- [ ] **Step 3: Implement the handlers + mappers**
+
+In `host_service.go`:
+
+```go
+// worldQuerier returns the host's world reader under the read lock.
+func (s *pluginHostServiceServer) worldQuerier() WorldReader {
+	s.host.mu.RLock()
+	defer s.host.mu.RUnlock()
+	return s.host.worldQuerier
+}
+
+func (s *pluginHostServiceServer) QueryLocation(ctx context.Context, req *pluginv1.PluginHostServiceQueryLocationRequest) (*pluginv1.PluginHostServiceQueryLocationResponse, error) {
+	subject, err := s.readSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wq := s.worldQuerier()
+	if wq == nil {
+		return nil, oops.Code("WORLD_READER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("world reader not configured")
+	}
+	id, err := ulid.Parse(req.GetLocationId())
+	if err != nil {
+		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid location_id")
+	}
+	loc, err := wq.GetLocation(ctx, subject, id)
+	if err != nil {
+		return nil, mapWorldQueryError(s.pluginName, err)
+	}
+	return &pluginv1.PluginHostServiceQueryLocationResponse{
+		Id: loc.ID.String(), Name: loc.Name, Description: loc.Description,
+	}, nil
+}
+
+func (s *pluginHostServiceServer) QueryCharacter(ctx context.Context, req *pluginv1.PluginHostServiceQueryCharacterRequest) (*pluginv1.PluginHostServiceQueryCharacterResponse, error) {
+	subject, err := s.readSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wq := s.worldQuerier()
+	if wq == nil {
+		return nil, oops.Code("WORLD_READER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("world reader not configured")
+	}
+	id, err := ulid.Parse(req.GetCharacterId())
+	if err != nil {
+		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid character_id")
+	}
+	c, err := wq.GetCharacter(ctx, subject, id)
+	if err != nil {
+		return nil, mapWorldQueryError(s.pluginName, err)
+	}
+	resp := &pluginv1.PluginHostServiceQueryCharacterResponse{
+		Id: c.ID.String(), PlayerId: c.PlayerID.String(), Name: c.Name, Description: c.Description,
+	}
+	if c.LocationID != nil {
+		resp.LocationId = c.LocationID.String()
+	}
+	return resp, nil
+}
+
+func (s *pluginHostServiceServer) QueryLocationCharacters(ctx context.Context, req *pluginv1.PluginHostServiceQueryLocationCharactersRequest) (*pluginv1.PluginHostServiceQueryLocationCharactersResponse, error) {
+	subject, err := s.readSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wq := s.worldQuerier()
+	if wq == nil {
+		return nil, oops.Code("WORLD_READER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("world reader not configured")
+	}
+	id, err := ulid.Parse(req.GetLocationId())
+	if err != nil {
+		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid location_id")
+	}
+	chars, err := wq.GetCharactersByLocation(ctx, subject, id, world.ListOptions{})
+	if err != nil {
+		return nil, mapWorldQueryError(s.pluginName, err)
+	}
+	refs := make([]*pluginv1.PluginHostServiceCharacterRef, len(chars))
+	for i, c := range chars {
+		refs[i] = &pluginv1.PluginHostServiceCharacterRef{Id: c.ID.String(), Name: c.Name}
+	}
+	return &pluginv1.PluginHostServiceQueryLocationCharactersResponse{Characters: refs}, nil
+}
+
+func (s *pluginHostServiceServer) QueryObject(ctx context.Context, req *pluginv1.PluginHostServiceQueryObjectRequest) (*pluginv1.PluginHostServiceQueryObjectResponse, error) {
+	subject, err := s.readSubject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wq := s.worldQuerier()
+	if wq == nil {
+		return nil, oops.Code("WORLD_READER_UNCONFIGURED").With("plugin", s.pluginName).Errorf("world reader not configured")
+	}
+	id, err := ulid.Parse(req.GetObjectId())
+	if err != nil {
+		return nil, oops.Code("INVALID_ARGUMENT").With("plugin", s.pluginName).Errorf("invalid object_id")
+	}
+	o, err := wq.GetObject(ctx, subject, id)
+	if err != nil {
+		return nil, mapWorldQueryError(s.pluginName, err)
+	}
+	resp := &pluginv1.PluginHostServiceQueryObjectResponse{
+		Id: o.ID.String(), Name: o.Name, Description: o.Description,
+	}
+	// NB: world.Object exposes locationID via the LocationID() accessor
+	// (object.go:135), unlike Location/Character which use public fields.
+	if lid := o.LocationID(); lid != nil {
+		resp.LocationId = lid.String()
+	}
+	return resp, nil
+}
+
+// mapWorldQueryError sanitizes a world.Service error for the plugin wire
+// boundary: it logs nothing here (callers log) and wraps with a generic code,
+// never leaking internal detail (.claude/rules/grpc-errors.md).
+func mapWorldQueryError(plugin string, err error) error {
+	return oops.Code("WORLD_QUERY_FAILED").With("plugin", plugin).Wrap(err)
+}
+```
+
+Add the `newTestHostWithWorld` helper to `world_query_test.go`, constructing a `Host` with `WithWorldService(world.NewService(...))` backed by a `policytest` engine and `worldtest` mock repos (mirror `internal/world/service_test.go` setup). Confirm `world.Object` has a `LocationID *ulid.ULID` field via `mcp__probe__extract_code world.Object`; if the field name differs, adjust the mapper.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestQuery ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the server now satisfies the generated interface**
+
+Run: `task build`
+Expected: PASS (`pluginHostServiceServer` implements all 4 methods).
+
+- [ ] **Step 6: Commit**
+
+`jj describe -m "feat(plugin): serve world-query RPCs with host-derived OBO subject (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 3: Lua OBO refactor
+
+### Task 6: Switch the Lua query fns to a host-derived OBO subject
+
+**Files:**
+
+- Modify: `internal/plugin/hostfunc/helpers.go`
+- Modify: `internal/plugin/hostfunc/world.go`
+- Modify: `internal/plugin/hostfunc/world_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `world_test.go` (mirror `evaluate_test.go`'s context-actor setup):
+
+```go
+func TestQueryLocationUsesActingCharacterSubject(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	charID := core.NewULID()
+	locID := core.NewULID()
+	eng := policytest.NewGrantEngine()
+	eng.Grant("character:"+charID.String(), "read", "location:"+locID.String())
+	repo := worldtest.NewMockLocationRepository(t)
+	repo.EXPECT().Get(mock.Anything, locID).Return(&world.Location{ID: locID, Name: "Square"}, nil)
+	svc := world.NewService(world.ServiceConfig{LocationRepo: repo, Engine: eng})
+	hf := hostfunc.New(nil, hostfunc.WithWorldService(svc))
+	L.SetContext(core.WithActor(context.Background(), core.Actor{Kind: core.ActorCharacter, ID: charID.String()}))
+	hf.Register(L, "lua-plug")
+
+	require.NoError(t, L.DoString(`loc = holomush.query_location("`+locID.String()+`")`))
+	// Assert the read succeeded under character:<id>, not plugin:lua-plug.
+	tbl := L.GetGlobal("loc").(*lua.LTable)
+	assert.Equal(t, "Square", tbl.RawGetString("name").String())
+}
+
+func TestQueryLocationFailsClosedWithoutActor(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+	svc := world.NewService(world.ServiceConfig{
+		LocationRepo: worldtest.NewMockLocationRepository(t),
+		Engine: policytest.NewGrantEngine(),
+	})
+	hf := hostfunc.New(nil, hostfunc.WithWorldService(svc))
+	L.SetContext(context.Background()) // no actor
+	hf.Register(L, "lua-plug")
+
+	require.NoError(t, L.DoString(`loc, err = holomush.query_location("`+core.NewULID().String()+`")`))
+	assert.Equal(t, lua.LNil, L.GetGlobal("loc"))
+	assert.NotEqual(t, lua.LNil, L.GetGlobal("err"))
+}
+```
+
+(If the existing `world_test.go` asserts `plugin:<name>` subject for queries, those assertions encode the OLD behavior and MUST be updated to the OBO subject — this is the latent-gap fix, not a regression.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestQueryLocation ./internal/plugin/hostfunc/`
+Expected: FAIL — `query_location` still reads under `plugin:lua-plug`, so the `character:<id>` grant doesn't authorize it (permission denied) and `loc` is nil.
+
+- [ ] **Step 3: Add an OBO read-subject helper**
+
+In `helpers.go`, add alongside `withQueryContext` (`:84`):
+
+```go
+// withReadSubject derives the host-stamped acting subject from the VM context
+// actor (OBO: the invoking character during dispatch; the plugin itself for
+// plugin-initiated reads) and invokes fn with it. Fails closed (pushes a Lua
+// error and returns) when no actor is on the context — the subject is NEVER
+// the hard-coded plugin identity (INV-2). Mirrors evaluateFn's derivation.
+func (f *Functions) withReadSubject(
+	L *lua.LState,
+	funcName string,
+	fn func(ctx context.Context, subjectID string) int,
+) int {
+	parentCtx := L.Context()
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, defaultPluginQueryTimeout)
+	defer cancel()
+
+	actor, ok := core.ActorFromContext(ctx)
+	if !ok {
+		return pushError(L, funcName+": no acting subject for world read")
+	}
+	subject := pluginauthz.ActorSubject(actor)
+	if subject == "" {
+		return pushError(L, funcName+": no acting subject for world read")
+	}
+	return fn(ctx, subject)
+}
+```
+
+The error helper is `pushError(L *lua.LState, errMsg string) int` (`helpers.go:23`) —
+the only error-push idiom in the package; there is no `pushQueryError`. Add
+imports `core` (`internal/core`) and `pluginauthz` (`internal/plugin/pluginauthz`)
+if absent. `defaultPluginQueryTimeout` already exists (used by `withQueryContext`).
+
+- [ ] **Step 4: Rewrite the four query fns to use it**
+
+This is a **minimal diff per fn**, not a rewrite: swap the `withQueryContext`
+(adapter, `plugin:<name>`) wrapper for `withReadSubject` (OBO subject), and
+change the data-source call from `adapter.GetX(ctx, id)` to
+`f.worldMutator.GetX(ctx, subject, id)`. **Keep each fn's existing Lua-table
+marshalling block verbatim** — only the wrapper and the call line change.
+`queryLocationFn` becomes:
+
+```go
+func (f *Functions) queryLocationFn(pluginName string) lua.LGFunction {
+	return func(L *lua.LState) int {
+		id, perr := ulid.Parse(L.CheckString(1))
+		if perr != nil {
+			return pushError(L, "query_location: invalid location id")
+		}
+		return f.withReadSubject(L, "query_location", func(ctx context.Context, subject string) int {
+			loc, err := f.worldMutator.GetLocation(ctx, subject, id)
+			if err != nil {
+				return pushError(L, "query_location: "+err.Error())
+			}
+			// <-- keep the EXISTING loc→Lua-table marshalling that currently
+			//     follows `adapter.GetLocation(ctx, id)` in this fn, verbatim.
+			return /* existing marshalled push */ 0
+		})
+	}
+}
+```
+
+Apply the same minimal diff to `queryCharacterFn`, `queryLocationCharactersFn`,
+`queryObjectFn`: change their inner call to `f.worldMutator.GetCharacter(ctx,
+subject, id)` / `GetCharactersByLocation(ctx, subject, id, opts)` /
+`GetObject(ctx, subject, id)` respectively, wrap in `f.withReadSubject(L,
+"<fn-name>", …)`, and keep each fn's current marshalling block unchanged. Remove
+the `withQueryContext` calls from these four fns. The `pluginName` parameter
+stays in each fn's signature (registration-fixed) even if now unused in the OBO
+path — unused function parameters are legal in Go. Leave `withMutatorContext`
+and the write fns untouched (mutations are out of scope and remain
+`plugin:<name>`).
+
+- [ ] **Step 5: Remove now-dead read code from the adapter**
+
+**`withQueryContext` MUST NOT be deleted** — it has non-query callers
+`findLocationFn` (`world_write.go:207`) and `getPropertyFn` (`world_write.go:366`).
+Only stop the four query fns from using it. For `WorldQuerierAdapter`: if its read
+methods (`GetLocation`/`GetCharacter`/`GetCharactersByLocation`/`GetObject` in
+`adapter.go`) have no remaining callers after Step 4, delete those read methods;
+keep the adapter type itself if `withMutatorContext`/write paths still construct
+it. Confirm caller sets with `mcp__probe__search_code "WorldQuerierAdapter"` and
+run `task lint` to surface any unused-symbol errors.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `task test -- -run TestQuery ./internal/plugin/hostfunc/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+`jj describe -m "fix(plugin): Lua world queries read under acting subject, not plugin identity (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 4: SDK facade
+
+### Task 7: `WorldQuerier` plugin-facing facade
+
+**Files:**
+
+- Create: `pkg/plugin/world_client.go`
+- Create: `pkg/plugin/world_client_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the real `evaluate_client_test.go` pattern exactly — a server type
+embedding `UnimplementedPluginHostServiceServer`, started via the existing
+`startPluginHostServiceTestServer(t, srv)` helper, with the token captured from
+incoming metadata (the package-private `emitTokenHeader` const,
+`event_sink.go:23`). There is no client stub type in this package.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+type worldTestServer struct {
+	pluginv1.UnimplementedPluginHostServiceServer
+	gotToken string
+}
+
+func (s *worldTestServer) QueryLocation(ctx context.Context, req *pluginv1.PluginHostServiceQueryLocationRequest) (*pluginv1.PluginHostServiceQueryLocationResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if tokens := md.Get(emitTokenHeader); len(tokens) > 0 {
+			s.gotToken = tokens[0]
+		}
+	}
+	return &pluginv1.PluginHostServiceQueryLocationResponse{Id: req.GetLocationId(), Name: "Square", Description: "A square."}, nil
+}
+
+func TestWorldQuerierGetLocationForwardsTokenAndMaps(t *testing.T) {
+	srv := &worldTestServer{}
+	conn := startPluginHostServiceTestServer(t, srv)
+	c := &hostWorldClient{client: pluginv1.NewPluginHostServiceClient(conn)}
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(emitTokenHeader, "dispatch-token-abc"))
+
+	loc, err := c.GetLocation(ctx, "01LOC")
+
+	require.NoError(t, err)
+	assert.Equal(t, "01LOC", loc.ID)
+	assert.Equal(t, "Square", loc.Name)
+	assert.Equal(t, "dispatch-token-abc", srv.gotToken) // token ferried incoming→outgoing
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `task test -- -run TestWorldQuerier ./pkg/plugin/`
+Expected: FAIL — `hostWorldClient` / `WorldQuerier` undefined.
+
+- [ ] **Step 3: Implement the facade**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package pluginsdk
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+	"google.golang.org/grpc/metadata"
+
+	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
+)
+
+// Location/Character/Object/CharacterRef are the plugin-facing world snapshots
+// returned by WorldQuerier. They are decoupled from the wire types.
+type Location struct{ ID, Name, Description string }
+type Character struct{ ID, PlayerID, Name, Description, LocationID string }
+type Object struct{ ID, Name, Description, LocationID string }
+type CharacterRef struct{ ID, Name string }
+
+// WorldQuerier is the read-only world surface exposed to binary plugins. The
+// host derives the acting subject from the dispatch context; the plugin passes
+// only the entity id (never a subject).
+type WorldQuerier interface {
+	GetLocation(ctx context.Context, locationID string) (Location, error)
+	GetCharacter(ctx context.Context, characterID string) (Character, error)
+	GetLocationCharacters(ctx context.Context, locationID string) ([]CharacterRef, error)
+	GetObject(ctx context.Context, objectID string) (Object, error)
+}
+
+// WorldQuerierAware is implemented by service providers to receive a
+// WorldQuerier during Init, parallel to HostEvaluatorAware.
+type WorldQuerierAware interface{ SetWorldQuerier(WorldQuerier) }
+
+type hostWorldClient struct{ client pluginv1.PluginHostServiceClient }
+
+func (c *hostWorldClient) GetLocation(ctx context.Context, locationID string) (Location, error) {
+	if c.client == nil {
+		return Location{}, oops.New("host world client is not configured")
+	}
+	resp, err := c.client.QueryLocation(ferryToken(ctx), &pluginv1.PluginHostServiceQueryLocationRequest{LocationId: locationID})
+	if err != nil {
+		return Location{}, oops.With("location_id", locationID).Wrap(err)
+	}
+	return Location{ID: resp.GetId(), Name: resp.GetName(), Description: resp.GetDescription()}, nil
+}
+
+// (GetCharacter, GetLocationCharacters, GetObject follow the same shape:
+// ferryToken(ctx), call the matching RPC, map the response struct.)
+```
+
+Add a `ferryToken(ctx)` helper that copies the incoming `x-holomush-emit-token` onto the outgoing context (extract the exact logic from `evaluate_client.go:64-75` into a shared helper and have both call it — DRY).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `task test -- -run TestWorldQuerier ./pkg/plugin/`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `WorldQuerierAware` injection**
+
+Find where `HostEvaluatorAware` / `FocusClientAware` are injected during plugin Init (`mcp__probe__search_code "SetHostEvaluator"`), and inject `SetWorldQuerier(&hostWorldClient{client: ...})` at the same site. Add a test asserting a provider implementing `WorldQuerierAware` receives a non-nil querier.
+
+- [ ] **Step 6: Commit**
+
+`jj describe -m "feat(plugin-sdk): WorldQuerier facade for binary plugins (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 5: Remove the forgery surface
+
+### Task 8: Delete the injectable WorldService and its dead gRPC server
+
+**Files:**
+
+- Modify: `internal/plugin/setup/subsystem.go`
+- Delete: `internal/plugin/setup/world_conn.go`
+- Delete: `internal/world/grpc_server.go`, `internal/world/grpc_server_test.go` (pending proto check)
+- Modify: `plugins/core-scenes/plugin.yaml`
+
+- [ ] **Step 1: Check for any other consumer of the WorldService gRPC/Connect surface**
+
+Run: `mcp__probe__search_code "NewWorldServiceHandler"` and `rg -rn 'worldv1connect|RegisterWorldServiceServer|WorldServiceClient' --type go`
+Expected: the only references are `world_conn.go`, `grpc_server.go`, and their tests. Record the result. If a real consumer exists (e.g., a mounted Connect handler), STOP and keep the proto + server, deleting only the registry injection; otherwise proceed to delete the server too.
+
+- [ ] **Step 2: Remove the registry injection in subsystem.go**
+
+Delete, in `subsystem.go`: the `worldConn` struct field (`:134`); the
+`newWorldInProcessConn` construction + error handling (`:214-218`); the
+deferred/teardown `s.worldConn.Close()` handling (`:234-235`); the
+`s.registry.Register(plugins.RegisteredService{Name: "holomush.world.v1.WorldService", Conn: worldConn})`
+block (`:238-244`); and the final `s.worldConn.Close()` in the subsystem's
+`Close`/shutdown (`:432-434`). Keep `hostfunc.WithWorldService(s.cfg.World.Service())`
+(`:188`) and the new `goplugin.WithWorldService(...)` (Task 3) — both read
+`s.cfg.World.Service()` directly and are independent of the registry injection.
+
+- [ ] **Step 3: Delete the dead files**
+
+```text
+rm internal/plugin/setup/world_conn.go
+rm internal/world/grpc_server.go internal/world/grpc_server_test.go
+```
+
+(Only delete `grpc_server.go`/`_test.go` if Step 1 found no other consumer.)
+
+- [ ] **Step 4: Drop the unused requires from core-scenes**
+
+In `plugins/core-scenes/plugin.yaml`, remove the line `- holomush.world.v1.WorldService` under `requires:`. If `requires:` becomes empty, set it to `requires: []` or remove the key per the schema (`task lint` validates `schemas/plugin.schema.json`).
+
+- [ ] **Step 5: Verify build + lint**
+
+Run: `task build && task lint`
+Expected: PASS. No unused-symbol or dangling-import errors.
+
+- [ ] **Step 6: Commit**
+
+`jj describe -m "refactor(plugin): remove forgeable injectable WorldService gRPC path (holomush-q42fh)"` then `jj new`.
+
+### Task 9: Re-vehicle the WorldService-coupled integration tests
+
+**Files:**
+
+- Modify: `test/integration/plugin/binary_plugin_test.go`
+
+- [ ] **Step 1: Remove the WorldService fixtures**
+
+Delete the five WorldService registry registrations (around `:188, 275, 396, 552, 845`) and the manifest assertion at `:131` (`Requires` contains `holomush.world.v1.WorldService`). These existed only to satisfy core-scenes' now-removed `requires`.
+
+- [ ] **Step 2: Re-vehicle the "fails to load" test**
+
+Rewrite the test at `:330-357` so the unmet-requires DAG path is still covered: load a binary whose in-test manifest declares `requires: [holomush.nonexistent.v1.FakeService]` (use the existing core-scenes binary with an in-test manifest override, or a `testdata/` fixture binary). Assert the load error contains `holomush.nonexistent.v1.FakeService`. The registry-resolve check fires after the go-plugin handshake, so a launchable binary is required.
+
+- [ ] **Step 3: Run the integration suite for this file**
+
+Run: `task test:int -- ./test/integration/plugin/...` (Ginkgo suites filter via `--focus`/`--label-filter`, not `go test -run`; run the whole package here)
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+`jj describe -m "test(plugin): re-vehicle WorldService-coupled binary-plugin integration tests (holomush-q42fh)"` then `jj new`.
+
+### Task 10: INV-3 meta-test — WorldService not registry-resolvable
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/world_query_invariants_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Build the plugin subsystem the way an existing setup test does (`mcp__probe__search_code "NewServiceRegistry"` / find the subsystem `Start` test) and assert the registry has no `holomush.world.v1.WorldService` entry:
+
+```go
+func TestINV3WorldServiceNotPluginResolvable(t *testing.T) {
+	reg := buildTestPluginRegistry(t) // mirror the existing subsystem-start test setup
+	// ServiceRegistry.Resolve returns (*RegisteredService, error) (registry.go:39);
+	// an unregistered name returns a non-nil error.
+	_, err := reg.Resolve("holomush.world.v1.WorldService")
+	assert.Error(t, err, "WorldService MUST NOT be resolvable from the plugin registry (INV-3)")
+}
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test -- -run TestINV3 ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+`jj describe -m "test(plugin): INV-3 lock — WorldService not plugin-resolvable (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 6: Parity invariants + integration
+
+### Task 11: INV-4 parity meta-test (4 Lua query fns ↔ 4 RPCs)
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/world_query_invariants_test.go`
+
+- [ ] **Step 1: Write the test**
+
+```go
+func TestINV4WorldQuerySurfaceParity(t *testing.T) {
+	luaQueries := []string{
+		"holomush.query_location",
+		"holomush.query_character",
+		"holomush.query_location_characters",
+		"holomush.query_object",
+	}
+	sd := pluginv1.File_holomush_plugin_v1_plugin_proto.Services().ByName("PluginHostService")
+	rpcs := map[string]bool{}
+	for i := range sd.Methods().Len() {
+		if n := string(sd.Methods().Get(i).Name()); strings.HasPrefix(n, "Query") {
+			rpcs[n] = true
+		}
+	}
+	assert.Len(t, rpcs, len(luaQueries),
+		"each Lua query_* fn MUST have a matching PluginHostService Query RPC (INV-4)")
+	for _, want := range []string{"QueryLocation", "QueryCharacter", "QueryLocationCharacters", "QueryObject"} {
+		assert.True(t, rpcs[want], "missing RPC %s (INV-4)", want)
+	}
+}
+```
+
+(Confirm the generated proto file var name via `mcp__probe__grep "File_holomush_plugin_v1_plugin_proto"`.)
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test -- -run TestINV4 ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+`jj describe -m "test(plugin): INV-4 lock — Lua/RPC world-query surface parity (holomush-q42fh)"` then `jj new`.
+
+### Task 12: Integration — cross-runtime OBO scoping + confused-deputy regression
+
+**Files:**
+
+- Create: `test/integration/plugin/world_query_obo_test.go` (or extend an existing suite)
+
+- [ ] **Step 1: Write the integration specs (Ginkgo, `//go:build integration`)**
+
+Using the `integrationtest` harness (`WithInTreePlugins()` where a real plugin is needed, `WithPolicyEngine(policytest.DenyAllEngine())` for denial paths), specify:
+
+```go
+//go:build integration
+
+var _ = Describe("Plugin world-query OBO", func() {
+	It("scopes a binary plugin's world read to the acting character (INV-5)", func() {
+		// character A (authorized for location L) triggers a command handled by a
+		// binary plugin that calls QueryLocation(L); expect success returning L.
+	})
+	It("denies a read the acting character is not authorized for (confused-deputy guard)", func() {
+		// character A NOT authorized for character B's record; A triggers the plugin
+		// to QueryCharacter(B); expect PermissionDenied — proves OBO, not plugin-broad.
+	})
+	It("yields identical results via the Lua runtime for the same actor (INV-5)", func() {
+		// same scenario through a Lua plugin; assert equal outcome.
+	})
+	It("uses plugin identity for a plugin-initiated read (no acting character)", func() {
+		// plugin-initiated read resolves to plugin:<name>.
+	})
+})
+```
+
+Fill each `It` with concrete harness calls (seed location/character via the harness helpers; drive the command path; assert the response or the gRPC code).
+
+- [ ] **Step 2: Run**
+
+Run: `task test:int -- ./test/integration/plugin/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+`jj describe -m "test(plugin): integration — OBO world-read scoping + confused-deputy guard (holomush-q42fh)"` then `jj new`.
+
+### Task 13: INV-2 structural meta-test + coverage gate
+
+**Files:**
+
+- Modify: `internal/plugin/goplugin/world_query_invariants_test.go`
+
+- [ ] **Step 1: Write the INV-2 structural assertion**
+
+INV-2 (both surfaces derive the subject via `pluginauthz.ActorSubject`, never request-sourced or hard-coded) is enforced behaviorally by Task 5/6 tests plus a structural guard. Add a guard that the binary handlers and Lua query fns do not reference `req.GetSubjectId`-style accessors and do not call `access.PluginSubject` at the query sites:
+
+```go
+func TestINV2NoRequestSubjectOnQueryHandlers(t *testing.T) {
+	// The Query*Request messages have no subject field (INV-1 covers this); this
+	// asserts the SDK request constructors expose no subject setter either.
+	// Reflect over the request structs: assert no exported field name contains "Subject".
+	for _, msg := range []any{
+		&pluginv1.PluginHostServiceQueryLocationRequest{},
+		&pluginv1.PluginHostServiceQueryCharacterRequest{},
+		&pluginv1.PluginHostServiceQueryLocationCharactersRequest{},
+		&pluginv1.PluginHostServiceQueryObjectRequest{},
+	} {
+		ty := reflect.TypeOf(msg).Elem()
+		for i := range ty.NumField() {
+			assert.NotContains(t, ty.Field(i).Name, "Subject",
+				"%s exposes a Subject field (INV-2)", ty.Name())
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test -- -run TestINV2 ./internal/plugin/goplugin/`
+Expected: PASS.
+
+- [ ] **Step 3: Verify per-package coverage**
+
+Run: `task test:cover -- ./internal/plugin/... ./pkg/plugin/... ./internal/world/...`
+Expected: each touched package > 80%. Add tests for any uncovered handler branch (nil reader, world error mapping) until the gate passes.
+
+- [ ] **Step 4: Commit**
+
+`jj describe -m "test(plugin): INV-2 structural guard + coverage for world-query surface (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Phase 7: Docs + final gates
+
+### Task 14: Update docs and run the full pre-push gate
+
+**Files:**
+
+- Modify: `site/src/content/docs/extending/tutorials/binary-plugins.md`
+- Regenerate: `site/src/content/docs/reference/grpc-api.md`
+- Verify: `site/src/content/docs/extending/tutorials/lua-plugins.md`
+
+- [ ] **Step 1: Replace the WorldService `requires` example**
+
+In `binary-plugins.md` (the `requires: [holomush.world.v1.WorldService]` example, ~line 47), replace it with the new pattern: binary plugins reach world reads via the injected `WorldQuerier` host facade (implement `WorldQuerierAware`), not a `requires` entry. Add a short snippet showing `SetWorldQuerier` + a `GetLocation` call. Note the read is host-scoped to the acting character (OBO).
+
+- [ ] **Step 2: Regenerate the gRPC reference**
+
+Run: `task docs:build` (or the proto→md generator the repo uses; confirm via `rg -n 'grpc-api' Taskfile.yml`).
+Expected: `grpc-api.md` reflects the removed WorldService server (if deleted) and the new PluginHostService RPCs. Verify the `lua-plugins.md` `world_ext.*` section still reads correctly (the `query_*` globals remain, now OBO).
+
+- [ ] **Step 3: Markdown + docs lint**
+
+Run: `task fmt && task lint:docs-symmetry`
+Expected: PASS (escape `|` in any tables; mermaid for any diagrams).
+
+- [ ] **Step 4: Full pre-push gate**
+
+Run: `task pr-prep:full` (this change touches integration surface — Ginkgo suites — so the full lane is appropriate).
+Expected: `✓ All PR checks passed.` (exit 0). If it fails, read the named failing check and fix; do not retry on a real failure.
+
+- [ ] **Step 5: Commit**
+
+`jj describe -m "docs(plugin): document binary world-query facade; regen gRPC reference (holomush-q42fh)"` then `jj new`.
+
+---
+
+## Spec coverage check
+
+| Spec element | Task(s) |
+|---|---|
+| 4 RPCs, no subject field (Component 1) | 1 |
+| Binary handlers, OBO subject (Component 2) | 3, 4, 5 |
+| Lua OBO refactor (Component 3) | 6 |
+| SDK facade (Component 4) | 7 |
+| Remove forgery surface incl. dead gRPC server (Component 5) | 8 |
+| Integration-test rework (Component 5) | 9 |
+| Docs (Component 5) | 14 |
+| INV-1 | 2 |
+| INV-2 | 13 |
+| INV-3 | 10 |
+| INV-4 | 11 |
+| INV-5, INV-6 | 12 (+ 5/6 unit) |
+| Coverage / TDD / verification commands | every task; gate in 13, 14 |
+| A1/A2 ADRs | captured by `capture-adrs` after plan READY |

--- a/docs/superpowers/specs/2026-05-30-binary-world-query-parity-design.md
+++ b/docs/superpowers/specs/2026-05-30-binary-world-query-parity-design.md
@@ -1,0 +1,508 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Binary World-Query Parity via Host-Derived Subject — Design
+
+**Date:** 2026-05-30
+**Status:** Draft
+**Bead:** holomush-q42fh
+**Author:** Sean Brandt
+**Reviewers:** abac-reviewer, code-reviewer (pre-push gates)
+
+## Summary
+
+Give binary plugins first-class world-read host functions
+(`QueryLocation`, `QueryCharacter`, `QueryLocationCharacters`, `QueryObject`)
+on the live `PluginHostService`, and unify both plugin runtimes on a
+**host-derived, on-behalf-of (OBO) subject** model that is forgery-free by
+construction. This extends the accepted pattern from
+[ADR holomush-qeypl](../../adr/holomush-qeypl-host-derived-evaluate-subject.md)
+("Derive Evaluate subject host-side; no subject field on wire") from the
+`Evaluate` surface to the world-read surface.
+
+As part of the same change, remove the **forgeable** injectable
+`holomush.world.v1.WorldService` path that binary plugins could (latently) use
+to assert an arbitrary caller subject.
+
+## Context
+
+### The bead's original premise is false
+
+`holomush-q42fh` was filed asserting that *binary plugins cannot query
+locations or characters* — a plugin-runtime-symmetry violation. Grounding
+against `main` (workspace `design-q42fh`, off `#4347`) disproved this:
+
+- `WorldService` (`api/proto/holomush/world/v1/world.proto:21-44`) already
+  exposes `GetLocation`, `GetCharacter`, `ListCharactersAtLocation`,
+  `ListExits`, all ABAC-gated.
+- The host registers an in-process `WorldService` conn in the plugin service
+  registry (`internal/plugin/setup/subsystem.go:213-240`,
+  `internal/plugin/setup/world_conn.go`), reachable by any plugin via a
+  manifest `requires` entry. `core-scenes` (the only binary plugin) already
+  declares `requires: holomush.world.v1.WorldService`.
+
+So binary plugins *can* read world state today. The bead's `hostfunc.proto`
+name-collision concern is also moot: `holomush-4hhh0` (PR #4346, merged
+2026-05-30) deleted that file entirely.
+
+### The real defects
+
+Two genuine problems remain, and they are the opposite of "cannot read":
+
+1. **Surface gap.** Binary plugins have no host-trusted, identity-scoped
+   world-read surface equivalent to Lua's `holomush.query_*` globals. The only
+   path available to them is the general `WorldService` gRPC client — different
+   ergonomics, and (see below) a broken trust model.
+
+2. **Forgery surface.** The `WorldService` gRPC server trusts a
+   *caller-supplied* subject on every read:
+
+   ```go
+   // internal/world/grpc_server.go:43,61,79,100
+   subjectID := access.CharacterSubject(req.GetSubjectId())
+   ```
+
+   No interceptor overrides `req.SubjectId`. This is correct when the caller is
+   the core server (which authenticated the acting character upstream). It is
+   **not** safe when the caller is a *plugin*: a binary plugin can name any
+   character ID as the subject and read that character's world view — a
+   confused-deputy / privilege-escalation surface, the same class as the
+   EmitEvent actor-forgery surface closed by `holomush-ec22.1`. It is *latent*
+   today: `core-scenes` declares the `requires` but has zero `worldv1` client
+   usage — it never calls it.
+
+3. **Latent Lua OBO gap.** The Lua `query_*` path reads under a hard-coded
+   `plugin:<name>` subject (`WorldQuerierAdapter.SubjectID()`,
+   `internal/plugin/hostfunc/adapter.go:67`). It *ignores* the acting character
+   even when a command dispatch made one available. So a Lua plugin servicing
+   character A's command reads world state under the plugin's broad authority,
+   not A's — inconsistent with how `Evaluate` already behaves (see precedent).
+
+### The accepted precedent this design copies
+
+[ADR holomush-qeypl](../../adr/holomush-qeypl-host-derived-evaluate-subject.md)
+established, for the `Evaluate` host call, that the acting subject is **derived
+host-side from the trusted dispatch context, never carried on the wire**:
+
+- Binary: the per-dispatch token (`x-holomush-emit-token`) is looked up in the
+  host token store to recover the vouched-for actor
+  (`internal/plugin/goplugin/host_service.go:516-578`).
+- Lua: the actor is read from the VM call context via
+  `core.ActorFromContext` (`internal/plugin/hostfunc/evaluate.go:46-49`).
+- Both map the actor to an ABAC subject through the single shared function
+  `pluginauthz.ActorSubject` (`internal/plugin/pluginauthz/evaluate.go:59-89`),
+  which cannot diverge between runtimes (INV-5 of that surface).
+
+This design applies the identical mechanism to world reads.
+
+## Goals
+
+- Binary plugins gain `QueryLocation`, `QueryCharacter`,
+  `QueryLocationCharacters`, `QueryObject` on `PluginHostService`.
+- Both runtimes derive the world-read subject host-side via
+  `pluginauthz.ActorSubject`, yielding correct OBO behavior:
+  - **acting character** (`character:<id>`) when reached inside a command /
+    event dispatch (the host vouched for that character);
+  - **plugin self** (`plugin:<name>`) when plugin-initiated (no acting
+    character — host vouched for the plugin).
+- No world-read surface accepts a request-supplied subject (forgery-free).
+- The forgeable injectable `WorldService` registry path is removed (the
+  `WorldService` proto and the core-server gRPC server are unaffected).
+
+## Non-goals
+
+- Changing `ListCommands` / `GetCommandHelp`, which derive their subject from a
+  caller-supplied `character_id` (`host_service.go:733,765`). By this design's
+  logic that is *also* forgeable, but it is a sibling concern tracked
+  separately (see [Out of scope](#out-of-scope)).
+- Re-introducing any plugin-to-plugin or plugin-to-host world *mutation* path.
+  This design covers reads only.
+- Production-shape compatibility (backfill, deprecation windows, reserved proto
+  fields). HoloMUSH is undeployed; removals are straight deletions.
+
+## Design
+
+### Subject derivation (the core of the change)
+
+Every world read on every runtime resolves its ABAC subject through one
+expression:
+
+```text
+subject = pluginauthz.ActorSubject(actor)
+```
+
+where `actor` is the **host-stamped** actor for the current call, obtained from
+the trusted dispatch context — never from request fields:
+
+| Runtime | Actor source | File reference |
+|---|---|---|
+| Binary | `tokenStore.Lookup(pluginName, token)` where `token` is the `x-holomush-emit-token` metadata header | mirrors `host_service.go:516-578` (`Evaluate`) |
+| Lua    | `core.ActorFromContext(L.Context())` | mirrors `evaluate.go:46-49` (`evaluateFn`) |
+
+`pluginauthz.ActorSubject` (`evaluate.go:59-89`) already encodes the OBO /
+self-fallback split:
+
+- `core.ActorCharacter` → `access.CharacterSubject(id)` = `character:<id>` (OBO)
+- `core.ActorPlugin` → `access.PluginSubject(id)` = `plugin:<name>` (self)
+- `core.ActorSystem` → `system`
+- zero / unknown / empty-id → `""`, which downstream treats as fail-closed
+
+No per-call branching is introduced: the actor the host vouched for *is* the
+authority. The resolved subject is passed to the existing world-read chokepoint
+`world.Service.Get{Location,Character,CharactersByLocation,Object}
+(ctx, subject, id)` (`internal/world/service.go:184,637,686,424`), which
+performs the ABAC `checkAccess`.
+
+This design **depends on, but does not change**, the existing actor-stamping at
+delivery: the dispatch path already decides which actor to vouch for (the acting
+character for a command/event dispatch; the plugin self for plugin-initiated
+work) and stamps it onto the binary dispatch token / Lua VM context. This is the
+same upstream mechanism `evaluateFn` and `EmitEvent` already consume; world
+reads consume it identically. OBO-vs-self is therefore settled upstream, not by
+this surface.
+
+### Component 1 — proto (`api/proto/holomush/plugin/v1/plugin.proto`)
+
+Add four RPCs to `service PluginHostService`, following the existing
+`PluginHostServiceXxxRequest/Response` naming convention:
+
+```protobuf
+rpc QueryLocation(PluginHostServiceQueryLocationRequest)
+    returns (PluginHostServiceQueryLocationResponse);
+rpc QueryCharacter(PluginHostServiceQueryCharacterRequest)
+    returns (PluginHostServiceQueryCharacterResponse);
+rpc QueryLocationCharacters(PluginHostServiceQueryLocationCharactersRequest)
+    returns (PluginHostServiceQueryLocationCharactersResponse);
+rpc QueryObject(PluginHostServiceQueryObjectRequest)
+    returns (PluginHostServiceQueryObjectResponse);
+```
+
+Request messages carry **only the target entity id** — `location_id`,
+`character_id`, or `object_id`. **No `subject_id` field exists** on any of them;
+that absence is INV-1, the forgery fix encoded in the schema (exactly as
+`PluginHostServiceEvaluateRequest` carries only `action` + `resource`).
+
+Response messages mirror the field shapes the Lua marshalling already exposes
+(`internal/plugin/hostfunc/world.go`): location → id/name/description; character
+→ id/player_id/name/description/location_id (location_id nullable); location
+characters → roster of {id, name}; object → id/name/description/location_id.
+Every proto element carries a Go-grounded doc comment (enforced by
+`task lint:proto`). No name collision exists — `hostfunc.proto` is deleted.
+
+### Component 2 — binary handler (`internal/plugin/goplugin/`)
+
+- Thread a world reader into `Host`: add a `WithWorldService(*world.Service)`
+  option setting a `worldQuerier` field, parallel to the existing
+  `WithCommandQuerier`/`commandQuerier` (`host.go:202,221`). It is fed
+  `s.cfg.World.Service()` at construction in `subsystem.go` (the same value the
+  Lua bridge already receives via `hostfunc.WithWorldService`).
+- Implement the four handlers on `pluginHostServiceServer`
+  (`host_service.go`). Each: recover the actor from the dispatch token (reuse
+  the `Evaluate` token-recovery code path), derive `subject` via
+  `pluginauthz.ActorSubject`, fail closed on empty subject, then call the
+  corresponding `world.Service` read. Read-only: no dispatch-token *mutation*,
+  no actor stamping onto a context — but the token is still **required** to
+  recover the acting subject (the self-token fallback covers plugin-initiated
+  reads, identical to `EmitEvent`).
+- Inner world errors are mapped to sanitized gRPC status (per
+  `.claude/rules/grpc-errors.md`); internal detail is logged, not returned.
+
+### Component 3 — Lua path (`internal/plugin/hostfunc/`)
+
+`queryLocationFn`, `queryCharacterFn`, `queryLocationCharactersFn`,
+`queryObjectFn` (`world.go`) currently delegate to `WorldQuerierAdapter`, which
+hard-codes `plugin:<name>`. Change them to derive the subject from
+`core.ActorFromContext(L.Context())` → `pluginauthz.ActorSubject` (the
+`evaluateFn` shape), then call `world.Service` with that subject. This fixes the
+latent Lua OBO gap and makes the Lua surface use the same subject source as the
+binary surface.
+
+`WorldQuerierAdapter`'s hard-coded-subject behavior is retired for reads. The
+adapter type may be removed or reduced to a subject-parameterized thin wrapper;
+the implementation plan decides, provided INV-2 holds.
+
+### Component 4 — SDK facade (`pkg/plugin/world_client.go`)
+
+A plugin-facing `WorldQuerier` interface plus a `WorldQuerierAware`
+injection hook (`SetWorldQuerier`), parallel to `HostEvaluator` /
+`HostEvaluatorAware` (`pkg/plugin/evaluate_client.go`). The concrete client
+wraps `pluginv1.PluginHostServiceClient` and ferries the incoming dispatch
+token onto the outgoing RPC (verbatim from `evaluate_client.go:51-75`). It
+exposes only the entity id — never a subject — matching the wire contract.
+
+### Component 5 — remove the forgery surface
+
+**Scope precision.** The core server does **not** read world state through the
+`WorldService` gRPC server — it calls `world.Service` directly in-process
+(`internal/grpc/auth_handlers.go`, `internal/grpc/location_follow.go` →
+`GetLocation`/`GetExitsByLocation`). The `WorldService` gRPC server
+(`internal/world/grpc_server.go`, constructed by `world.NewGRPCServer`) exists
+**only** for the plugin-injectable path: its sole non-test caller is
+`internal/plugin/setup/world_conn.go:21`, which this component deletes.
+Therefore `grpc_server.go` (and `grpc_server_test.go`, and `NewGRPCServer`)
+becomes dead code and MUST be removed as part of this component — that deletion
+*is* the forgery-surface removal (the `access.CharacterSubject(req.GetSubjectId())`
+reads live there).
+
+The `WorldService` *proto* (`api/proto/holomush/world/v1/world.proto`) and its
+generated bindings are a separate question: the plan MUST verify whether any
+other consumer mounts the WorldService gRPC/Connect handler
+(`worldv1connect`); if none exists, removing the proto service is in scope
+(with `grpc-api.md` regen); if a consumer exists, the proto stays and only the
+server impl is deleted. (`world.Service` — the in-process Go type — is retained
+unconditionally; it is the chokepoint both runtimes read through.)
+
+Code removal:
+
+- Delete the `WorldService` registry registration and its in-process conn:
+  `subsystem.go:213-240` (the `s.registry.Register({Name:
+  "holomush.world.v1.WorldService", Conn: worldConn})` block), the `worldConn`
+  field and its `Close` handling, and the file
+  `internal/plugin/setup/world_conn.go`.
+- Drop the now-unused `requires: holomush.world.v1.WorldService` from
+  `plugins/core-scenes/plugin.yaml`.
+- The Lua bridge's `hostfunc.WithWorldService(s.cfg.World.Service())`
+  (`subsystem.go:188`) is **independent** of the registry injection and is
+  untouched; the new binary handler reads through the same
+  `s.cfg.World.Service()` value.
+
+Test rework (`test/integration/plugin/binary_plugin_test.go`) — this file uses
+the injectable `WorldService` as its canonical "binary plugin requires a host
+service" example and MUST be reworked:
+
+- Five fixtures construct + register `WorldService` in the registry (lines
+  ~188, 275, 396, 552, 845) purely to satisfy core-scenes' (now-dropped)
+  `requires`. These registrations and the corresponding manifest assertion
+  (`:131` `Requires` contains `holomush.world.v1.WorldService`) MUST be removed.
+- The "fails to load when a required service is not in the registry" test
+  (`:330-357`) currently uses `WorldService` as the missing-required-service
+  vehicle. It MUST be re-vehicled onto a synthetic absent service name (e.g. a
+  manifest requiring `holomush.nonexistent.v1.FakeService`) so the DAG
+  unmet-requires path stays covered after `WorldService` is no longer
+  required by any real plugin. Note the registry-resolve check fires *after*
+  the go-plugin handshake (`host.go` `Load`, post-`broker` init), so the
+  re-vehicled test still needs a launchable binary — use the existing
+  core-scenes binary with an in-test manifest override, or a `testdata/`
+  fixture binary; the plan picks one.
+- The whole-system load census (`test/integration/wholesystem/`) MUST stay
+  green — core-scenes loads cleanly without the dropped `requires`.
+
+Docs:
+
+- `site/src/content/docs/extending/tutorials/binary-plugins.md` documents
+  `requires: [holomush.world.v1.WorldService]` as the canonical binary-plugin
+  manifest example; replace it (binary plugins now reach world reads via the
+  `WorldQuerier` host facade, not a `requires` entry).
+- `site/src/content/docs/reference/grpc-api.md` is generated; regenerate so any
+  "registered in the service registry as holomush.world.v1.WorldService" note
+  drops. Verify `lua-plugins.md`'s `world_ext.*` section still reads correctly
+  (it documents the Lua `query_*` globals, which remain).
+
+### Component 6 — audit registry (verified already correct; no action)
+
+The earlier draft claimed `holomush.query_object` was missing from
+`RegisteredFunctionsForAudit`. **This was a stale-workspace grounding error.**
+On `main`, `query_object` is present at
+`internal/plugin/hostfunc/functions.go:340` (registration at `:240`, audit list
+`:330-360`), so the `context_audit_test.go` meta-test already exercises it. No
+change is required; this section is retained only to record the retraction.
+
+### Data flow
+
+```mermaid
+flowchart TD
+  CMD[character runs command] --> SRV[core server: dispatch<br/>vouches actor = character]
+  SRV -->|deliver + dispatch token| BP[binary plugin]
+  SRV -->|deliver, actor on Lua ctx| LP[lua plugin]
+  BP -->|QueryCharacter id + token| BH[host_service handler:<br/>tokenStore.Lookup → actor]
+  LP -->|holomush.query_character id| LH[queryCharacterFn:<br/>core.ActorFromContext → actor]
+  BH --> AS[pluginauthz.ActorSubject actor]
+  LH --> AS
+  AS -->|character:id OBO / plugin:name self| WS[world.Service read + checkAccess]
+  WS --> REPO[(repositories)]
+  PLG[plugin-initiated read<br/>no acting character] -->|self-token → ActorPlugin| AS
+```
+
+## Security and ABAC posture
+
+This change touches the access-control trust boundary and MUST clear the
+`abac-reviewer` gate before `code-reviewer`.
+
+- **Single chokepoint.** Both runtimes converge on `world.Service.checkAccess`.
+  No read bypasses ABAC.
+- **No wire subject.** Subjects are host-derived only; INV-1 makes a
+  request-supplied subject structurally impossible.
+- **Forgery removed.** The only path that accepted a caller subject (the
+  injectable `WorldService`) is deleted for plugin reachability.
+- **Fail-closed.** An empty/zero actor yields `""` subject; `world.Service`
+  treats an unauthorized/empty subject as deny (consistent with
+  `pluginauthz.Evaluate`'s `EVALUATE_NO_SUBJECT`).
+- **OBO confused-deputy protection.** Because the subject is the host-vouched
+  acting character, a plugin servicing character A's command can read only what
+  A may read — it cannot escalate by naming another subject.
+
+## Invariants (RFC2119)
+
+Each invariant is backed by a behavioral test; INV-1..INV-5 additionally get a
+structural meta-test modeled on
+`internal/plugin/goplugin/evaluate_invariants_test.go`.
+
+- **INV-1** — Every `PluginHostServiceQuery*Request` message MUST NOT contain a
+  field named `subject` (or any subject alias). *Meta-test:* proto-reflection
+  over each request descriptor asserts no such field and asserts the exact
+  field count.
+- **INV-2** — Both the binary handler and the Lua hostfunc MUST derive the
+  read subject via `pluginauthz.ActorSubject` applied to a host-stamped actor.
+  Neither MAY read a subject from request data nor hard-code a constant subject.
+- **INV-3** — After this change, `holomush.world.v1.WorldService` MUST NOT be
+  resolvable from the plugin service registry. *Meta-test:* assert the registry
+  built by the plugin subsystem has no such entry.
+- **INV-4** — The set of Lua `holomush.query_*` world functions and the set of
+  `PluginHostService` world-query RPCs MUST be in 1:1 correspondence
+  (4 ↔ 4). *Meta-test:* enumerate both and assert equality.
+- **INV-5** — For identical inputs and identical host-vouched actor, the binary
+  and Lua surfaces MUST produce identical authorization outcomes (shared
+  `world.Service` + shared `ActorSubject`).
+- **INV-6** — A world read with no recoverable acting actor (no valid dispatch
+  token on the binary surface; no actor on the Lua context) MUST fail closed
+  (deny / error), never default to a broad subject.
+
+## Testing and verification (RFC2119)
+
+### Process requirements
+
+- The implementation MUST be test-driven (`dev-flow:test-driven-development`):
+  for every behavior below, a failing test is written first, watched fail, then
+  made to pass. This is the project mandate (CLAUDE.md "Test-Driven
+  Development"); it is restated here as an acceptance gate, not an aspiration.
+- Per-package coverage MUST exceed 80% for every touched package, verified with
+  `task test:cover`. The subject-derivation and ABAC-adjacent paths
+  (`internal/plugin/goplugin`, `internal/plugin/hostfunc`,
+  `internal/plugin/pluginauthz`) SHOULD reach 90%+.
+- Every new exported function MUST have at least one positive and one negative
+  test (`.claude/rules/testing.md`). Test names MUST follow ACE; tables are used
+  where the case axis is data.
+- Each invariant INV-1..INV-6 MUST be traceable to a named test (the
+  meta-tests for INV-1..INV-5, a behavioral test for INV-6).
+
+### Happy-path tests (per RPC × per runtime — binary and Lua)
+
+- `QueryLocation` authorized → returns id, name, description for the location.
+- `QueryCharacter` authorized → returns id, player_id, name, description, and
+  `location_id`; **and** the nullable-`location_id` case (character not in
+  world) returns the absent/empty form, not an error.
+- `QueryLocationCharacters` authorized → returns the `{id, name}` roster; **and**
+  the empty-roster case (location with no occupants) returns an empty list, not
+  an error or nil-deref.
+- `QueryObject` authorized → returns id, name, description, location_id.
+- Cross-runtime equality: identical actor + input yields identical marshalled
+  output on both surfaces (the behavioral half of INV-5).
+
+### OBO subject-behavior tests
+
+- Character actor (dispatch context) → subject `character:<id>`; the read is
+  authorized as that character.
+- Plugin actor (self-token / plugin-initiated) → subject `plugin:<name>`.
+- Confused-deputy guard: with actor A vouched, a read of an entity that only
+  actor B may see MUST be denied — proving OBO scoping, not plugin-broad
+  authority. This is the regression test for the bug class this design fixes.
+
+### Boundary and error-path tests
+
+- Malformed or empty entity id → `InvalidArgument` (binary) / Lua error return.
+- Entity not found → `NotFound`, with the inner error sanitized
+  (`.claude/rules/grpc-errors.md`: no internal detail on the wire).
+- Unauthorized subject → `PermissionDenied`, sanitized.
+- No recoverable acting actor — missing/invalid dispatch token (binary), no
+  actor on the VM context (Lua) — MUST fail closed (INV-6), never default to a
+  broad subject.
+- Zero/empty actor → `ActorSubject` returns `""` → world read denied.
+- Nil world service / nil access engine → fail closed (mirrors
+  `evaluate_test.go` nil-engine cases).
+- Context deadline exceeded / cancelled → surfaces as a denial/error, proving
+  the context is threaded into the world call.
+
+### Invariant meta-tests (mirror `evaluate_invariants_test.go`)
+
+- **INV-1** — proto reflection over each of the four `Query*Request`
+  descriptors: no `subject` field; exact expected field count per message.
+- **INV-2** — structural: the Lua `query_*` call sites and the binary handlers
+  resolve their subject through `pluginauthz.ActorSubject`; no hard-coded
+  `access.PluginSubject`/`CharacterSubject` and no request-sourced subject at
+  those sites.
+- **INV-3** — the service registry built by the plugin subsystem has no
+  `holomush.world.v1.WorldService` entry.
+- **INV-4** — enumerate the Lua `holomush.query_*` world-function set and the
+  `PluginHostService` world-query RPC set; assert 1:1 (4 ↔ 4).
+- **INV-5** — behavioral parity test across runtimes (see happy-path).
+
+### Integration tests (Ginkgo, `//go:build integration`, `integrationtest` harness)
+
+- End-to-end OBO: character A runs a command handled by a **binary** plugin
+  that reads a location/character; A observes only A-authorized data, and an
+  entity A may not see is denied through the full stack.
+- Cross-runtime parity: the same scenario via a **Lua** plugin yields the same
+  outcome (`WithInTreePlugins()` to load the real plugin set).
+- Plugin-initiated read (no acting character) resolves to `plugin:<name>`.
+- Removal verification: with the injection gone, no plugin can resolve/inject
+  `holomush.world.v1.WorldService`, and `core-scenes` loads cleanly without the
+  dropped `requires` (whole-system load census stays green).
+- Denial-path coverage uses `WithPolicyEngine(policytest.DenyAllEngine())` per
+  the harness convention.
+
+### Verification commands (per stage)
+
+`task test -- ./<pkg>` during TDD; `task lint:proto` after proto/codegen;
+`task test:cover` for the coverage gate; `task test:int` for the Ginkgo
+suites; `task pr-prep` (fast lane) before push, `task pr-prep:full` given the
+int-surface this touches.
+
+## ADRs to capture
+
+- **A1 — Host-derived subject for plugin world reads (OBO via dispatch
+  context); no subject on wire.** Extends holomush-qeypl from `Evaluate` to the
+  world-read surface; records the OBO-vs-self-fallback semantics and the
+  forgery-free wire contract.
+- **A2 — Remove the forgeable injectable `WorldService`; `PluginHostService`
+  Query* is the sole binary world-read path.** Records why the registry
+  injection is deleted rather than secured with a stamping interceptor (single
+  constrained path per runtime, matching Lua).
+
+## Out of scope
+
+- **`ListCommands` / `GetCommandHelp` subject forgeability.** These derive the
+  subject from a caller-supplied `character_id` (`host_service.go:733,765`),
+  which is the same forgery shape this design removes for world reads. Fixing
+  them is a separate, sibling change; file a follow-up bead referencing A1/A2 as
+  precedent. Not addressed here to keep this change cohesive.
+- **World mutations from plugins.** Reads only.
+- **External / clustered NATS, production migration shaping.** Not applicable.
+
+## Grounding references
+
+- ADR holomush-qeypl — host-derived Evaluate subject (precedent).
+- `internal/plugin/goplugin/host_service.go:516-578` — Evaluate token→actor
+  recovery (binary template).
+- `internal/plugin/hostfunc/evaluate.go:46-49` — Lua actor-from-context
+  derivation (Lua template).
+- `internal/plugin/pluginauthz/evaluate.go:59-89` — `ActorSubject` shared map.
+- `internal/world/service.go:184,424,637,686` — world-read ABAC chokepoint.
+- `internal/world/grpc_server.go:43,61,79,100` — the forgeable
+  caller-subject reads being removed from plugin reachability.
+- `internal/plugin/setup/subsystem.go:188,213-240`,
+  `internal/plugin/setup/world_conn.go` — injection removal surface.
+- `internal/plugin/hostfunc/functions.go:240` — `query_object` Lua
+  registration; `:330-360` — `RegisteredFunctionsForAudit` (query_object at
+  `:340`, already present).
+- `test/integration/plugin/binary_plugin_test.go:131,188,275,330-357,396,552,845`
+  — integration coverage coupled to the injectable `WorldService` (rework
+  surface for Component 5).
+- `site/src/content/docs/extending/tutorials/binary-plugins.md` — tutorial
+  documenting the `requires: holomush.world.v1.WorldService` example (doc
+  update surface for Component 5).
+- `internal/plugin/goplugin/evaluate_invariants_test.go` — meta-test template.
+- No new external dependencies are introduced; context7/deepwiki grounding is
+  not applicable (internal Go/proto only).
+<!-- adr-capture: sha256=bef637b5093c8611; session=cli; ts=2026-05-30T17:01:59Z; adrs=holomush-nthq6,holomush-c6oo8 -->


### PR DESCRIPTION
## What

Docs-only PR landing the design artifacts for **holomush-q42fh** (binary world-query parity) so implementation subagents read canonical context from `main`:

- **Spec** — `docs/superpowers/specs/2026-05-30-binary-world-query-parity-design.md`
- **Plan** — `docs/superpowers/plans/2026-05-30-binary-world-query-parity.md` (14 TDD tasks)
- **ADRs** — `holomush-nthq6` (derive world-read subject host-side; no subject on wire) and `holomush-c6oo8` (remove forgeable injectable WorldService)

## Why

The bead's original premise — *binary plugins cannot query world state* — was disproven during grounding (they can, via the injectable `WorldService`). The real defects: a **surface gap** (no host-trusted world-read surface for binary plugins) and a **forgery surface** (the injectable `WorldService` gRPC server trusts a caller-supplied `subject_id`). This design extends the accepted **ADR holomush-qeypl** pattern (host-derived `Evaluate` subject, no subject on the wire) to world reads — `QueryLocation/QueryCharacter/QueryLocationCharacters/QueryObject` on `PluginHostService` with **on-behalf-of** subject derivation for *both* runtimes (fixing a latent Lua OBO gap), and deletes the forgeable injection.

## Review trail

- `design-reviewer`: **READY** (round 2)
- `plan-reviewer`: **READY** (round 2)
- bd: epic `holomush-q42fh` promoted + children `.1`–`.14` materialized with dependency graph

Implementation (the 14 beads) follows in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
