### PR TITLE
docs(ci): Claude PR-review GitHub Action design + plan (holomush-3f5s9)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-claude-pr-review-action.md
+++ b/docs/superpowers/plans/2026-05-30-claude-pr-review-action.md
@@ -1,0 +1,866 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Claude PR-Review GitHub Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an internal-first GitHub Action that runs the fzymgc-house `dev-flow:review-pr` skill on HoloMUSH PRs via the official `anthropics/claude-code-action`, with a swappable model-provider profile (Anthropic / DeepSeek / homelab LiteLLM).
+
+**Architecture:** A composite action (`.github/actions/claude-pr-review/`) wraps the official action: it installs the toolchain, bootstraps `bd` against the shared Dolt store, resolves a named profile into the Claude Code env bag (passed via the official action's `settings.env`), runs `/review-pr <PR>` headlessly, then `bd dolt push`es findings and gates the check. A thin workflow (`.github/workflows/claude-review.yml`) owns triggers and runner selection via a two-job `resolve → review` structure (profile→runner must be known before the job starts). Findings live in `bd`; v1 posts the skill's summary comment only.
+
+**Tech Stack:** GitHub Actions (composite action + workflow YAML), Bash, `yq`, `bats` (resolver tests), `actionlint`, the `bd`/Dolt CLI (`brew install steveyegge/beads/bd`), `anthropics/claude-code-action@v1`, Claude Code CLI.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md`
+**Design bead:** `holomush-3f5s9`
+
+**Note on TDD shape:** This plan produces YAML + Bash artifacts. Only the profile
+resolver (`resolve-profile.sh`) is a unit testable with `bats` — it gets a true
+red→green TDD cycle (Task 2). The action/workflow YAML is verified by `yq` parse,
+`yamlfmt`, `actionlint` (workflow only), and a documented manual smoke test
+(Task 10). Commit after every task.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+| --- | --- |
+| `.github/actions/claude-pr-review/profiles.yml` | Named provider profiles → `base_url` / `auth_secret` / `runs_on` / model env bag |
+| `.github/actions/claude-pr-review/resolve-profile.sh` | Read `profiles.yml` + profile name → emit `runs_on`, `base_url`, and the `settings.env` JSON for the official action |
+| `.github/actions/claude-pr-review/action.yml` | Composite action: install → bd bootstrap → resolve env → run official action → bd push → verdict gate |
+| `.github/workflows/claude-review.yml` | Triggers, same-repo guard, concurrency, `resolve`→`review` jobs |
+| `.github/actionlint.yaml` | Register the homelab self-hosted runner label (`§3.4` prereq) |
+| `scripts/tests/resolve-profile.bats` | Unit tests for the resolver |
+| `site/src/content/docs/contributing/how-to/claude-pr-review.md` | Operator docs: required secrets, runner setup, triggering, smoke test |
+
+---
+
+## Phase 1: Profile foundation
+
+### Task 1: Profile registry (`profiles.yml`)
+
+**Files:**
+
+- Create: `.github/actions/claude-pr-review/profiles.yml`
+
+- [ ] **Step 1: Create the profiles file**
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Model-provider profiles for the claude-pr-review action.
+# Secret VALUES live in GitHub secrets and are referenced by name via
+# `auth_secret`; only names appear here. See the design spec §3.
+#
+# Model IDs below are illustrative and current as of 2026-05-30; re-verify
+# against each provider's live API before relying on them (spec §3.2).
+profiles:
+  anthropic:                       # default; GitHub-hosted runner
+    base_url: ""                   # empty → api.anthropic.com
+    auth_secret: ANTHROPIC_API_KEY
+    runs_on: ubuntu-latest
+    env:
+      ANTHROPIC_MODEL: claude-opus-4-8
+      CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-6
+      CLAUDE_CODE_EFFORT_LEVEL: high
+
+  deepseek:                        # Anthropic-shaped endpoint, no proxy
+    base_url: https://api.deepseek.com/anthropic
+    auth_secret: DEEPSEEK_API_KEY
+    runs_on: ubuntu-latest
+    env:
+      ANTHROPIC_MODEL: deepseek-v4-pro
+      ANTHROPIC_DEFAULT_OPUS_MODEL: deepseek-v4-pro
+      ANTHROPIC_DEFAULT_SONNET_MODEL: deepseek-v4-flash
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: deepseek-v4-flash
+      CLAUDE_CODE_SUBAGENT_MODEL: deepseek-v4-flash
+      CLAUDE_CODE_EFFORT_LEVEL: max
+
+  litellm:                         # homelab router; self-hosted runner
+    base_url: ${HOMELAB_LITELLM_URL}
+    auth_secret: LITELLM_API_KEY
+    runs_on: homelab-claude
+    env:
+      ANTHROPIC_MODEL: PLACEHOLDER-fill-from-litellm-registry
+      ANTHROPIC_DEFAULT_OPUS_MODEL: PLACEHOLDER-strong-tier
+      ANTHROPIC_DEFAULT_SONNET_MODEL: PLACEHOLDER-default-tier
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: PLACEHOLDER-cheap-tier
+      CLAUDE_CODE_SUBAGENT_MODEL: PLACEHOLDER-cheap-tier
+      CLAUDE_CODE_EFFORT_LEVEL: max
+```
+
+> The `litellm` `PLACEHOLDER-*` model names and `${HOMELAB_LITELLM_URL}` are
+> intentional operator-config slots, NOT plan placeholders — they are filled
+> from the homelab LiteLLM model registry at deploy time (documented in Task 10).
+> The `anthropic` and `deepseek` profiles are complete and usable as written
+> (pending the §3.2 model-ID re-verification).
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `yq '.profiles | keys' .github/actions/claude-pr-review/profiles.yml`
+Expected: `["anthropic", "deepseek", "litellm"]`
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "feat(ci): claude-pr-review provider profile registry (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 2: Profile resolver (`resolve-profile.sh`) — TDD with bats
+
+**Files:**
+
+- Create: `.github/actions/claude-pr-review/resolve-profile.sh`
+- Test: `scripts/tests/resolve-profile.bats`
+
+The resolver reads `profiles.yml` and a profile name, then writes three
+`name=value` lines to the file named by `$GITHUB_OUTPUT` (GitHub Actions step
+output convention): `runs_on`, `base_url`, and `settings_env` (a compact JSON
+object for the official action's `settings.env`). The auth token is injected by
+the caller (the action), not the resolver, so the resolver never touches secrets.
+
+- [ ] **Step 1: Write the failing bats test**
+
+```bash
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+
+setup() {
+  RESOLVER="$BATS_TEST_DIRNAME/../../.github/actions/claude-pr-review/resolve-profile.sh"
+  PROFILES="$BATS_TEST_DIRNAME/../../.github/actions/claude-pr-review/profiles.yml"
+  GITHUB_OUTPUT="$(mktemp)"
+  export GITHUB_OUTPUT
+}
+
+teardown() { rm -f "$GITHUB_OUTPUT"; }
+
+@test "resolves anthropic profile to ubuntu-latest with empty base_url" {
+  run bash "$RESOLVER" anthropic "$PROFILES"
+  [ "$status" -eq 0 ]
+  grep -q '^runs_on=ubuntu-latest$' "$GITHUB_OUTPUT"
+  grep -q '^base_url=$' "$GITHUB_OUTPUT"
+  grep -q 'ANTHROPIC_MODEL' "$GITHUB_OUTPUT"
+}
+
+@test "resolves deepseek profile with the deepseek anthropic base_url" {
+  run bash "$RESOLVER" deepseek "$PROFILES"
+  [ "$status" -eq 0 ]
+  grep -q '^base_url=https://api.deepseek.com/anthropic$' "$GITHUB_OUTPUT"
+}
+
+@test "emits settings_env as a single-line JSON object" {
+  run bash "$RESOLVER" deepseek "$PROFILES"
+  [ "$status" -eq 0 ]
+  line="$(grep '^settings_env=' "$GITHUB_OUTPUT" | head -1)"
+  json="${line#settings_env=}"
+  echo "$json" | yq -p=json '.ANTHROPIC_DEFAULT_SONNET_MODEL' | grep -q 'deepseek-v4-flash'
+}
+
+@test "exits non-zero with a message for an unknown profile" {
+  run bash "$RESOLVER" no-such-profile "$PROFILES"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown profile"* ]]
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bats scripts/tests/resolve-profile.bats`
+Expected: FAIL — resolver script does not exist yet.
+
+- [ ] **Step 3: Write the resolver**
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Resolve a claude-pr-review provider profile into GitHub Actions step outputs.
+# Usage: resolve-profile.sh <profile-name> [profiles.yml path]
+# Writes runs_on, base_url, settings_env (JSON) to $GITHUB_OUTPUT.
+# Does NOT handle secrets — the auth token is injected by the caller.
+set -euo pipefail
+
+profile="${1:?usage: resolve-profile.sh <profile-name> [profiles.yml]}"
+profiles_file="${2:-"$(dirname "$0")/profiles.yml"}"
+
+if [[ -z "$(yq ".profiles.\"$profile\"" "$profiles_file")" || \
+      "$(yq ".profiles.\"$profile\"" "$profiles_file")" == "null" ]]; then
+  echo "resolve-profile: unknown profile '$profile'" >&2
+  exit 1
+fi
+
+# Plain yq (NOT -o=json) for scalar fields — -o=json double-quotes the string
+# (`"ubuntu-latest"`), which breaks `runs-on` and the bats assertions.
+runs_on="$(yq ".profiles.\"$profile\".runs_on" "$profiles_file")"
+base_url="$(yq ".profiles.\"$profile\".base_url" "$profiles_file")"
+# base_url may carry a ${HOMELAB_LITELLM_URL}-style ref; expand from env.
+base_url="$(eval "echo \"$base_url\"")"
+settings_env="$(yq -o=json -I=0 ".profiles.\"$profile\".env" "$profiles_file")"
+
+{
+  echo "runs_on=$runs_on"
+  echo "base_url=$base_url"
+  echo "settings_env=$settings_env"
+} >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 4: Make the resolver executable**
+
+Run: `chmod +x .github/actions/claude-pr-review/resolve-profile.sh`
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bats scripts/tests/resolve-profile.bats`
+Expected: PASS (4 tests). The resolver uses plain `yq` for `runs_on`/`base_url`
+(unquoted scalars) and `yq -o=json -I=0` only for the `env` object, so the
+`^runs_on=ubuntu-latest$` assertion matches the bare value.
+
+> Requires `yq` (mikefarah) on PATH. If `task test:bats` is run via the repo's
+> environment it is present; if running this single suite ad hoc, install per
+> the pattern in Task 4 Step 1b first.
+
+- [ ] **Step 6: Run the repo bats gate**
+
+Run: `task test:bats`
+Expected: PASS — all bats suites including the new one.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "feat(ci): profile resolver for claude-pr-review action (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 3: Register the homelab runner label (spec §3.4 prereq)
+
+**Files:**
+
+- Modify: `.github/actionlint.yaml`
+
+- [ ] **Step 1: Add the homelab label**
+
+Edit `.github/actionlint.yaml` so `self-hosted-runner.labels` includes the
+homelab runner label used by the `litellm` profile:
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+self-hosted-runner:
+  labels:
+    - namespace-profile-linux-amd64-2x4
+    - namespace-profile-linux-amd64-4x8
+    - namespace-profile-linux-amd64-8x16
+    - homelab-claude
+```
+
+- [ ] **Step 2: Verify actionlint config is valid**
+
+`actionlint` is pinned in `go.tool-lint.mod` (not the main module), so invoke it
+through the repo's wiring. Either run the full lint gate:
+
+Run: `task lint`
+
+…or invoke actionlint directly with the correct modfile (the form `task lint`
+uses via `GO_TOOL_LINT`):
+
+Run: `GOWORK=off go tool -modfile=go.tool-lint.mod actionlint -config-file .github/actionlint.yaml .github/workflows/*`
+Expected: exit 0 (no workflow references `homelab-claude` yet, so findings are
+unchanged — this step just confirms the config still parses).
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "ci(actionlint): register homelab-claude self-hosted runner label (holomush-3f5s9)"
+jj new
+```
+
+---
+
+## Phase 2: Composite action
+
+### Task 4: Composite action skeleton — metadata, inputs, toolchain install
+
+**Files:**
+
+- Create: `.github/actions/claude-pr-review/action.yml`
+
+- [ ] **Step 1: Write the action metadata + inputs + install steps**
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+name: Claude PR Review
+description: >-
+  Run the fzymgc-house dev-flow:review-pr skill on a pull request via Claude
+  Code, with a swappable model-provider profile. Bootstraps bd against the
+  shared Dolt store and posts a summary review comment.
+
+inputs:
+  pr_number:
+    description: PR number to review.
+    required: true
+  model_profile:
+    description: Profile name from profiles.yml (anthropic | deepseek | litellm).
+    required: false
+    default: anthropic
+  auth_token:
+    description: >-
+      Provider auth token (the secret named by the profile's auth_secret).
+      Used as ANTHROPIC_AUTH_TOKEN and as the official action's anthropic_api_key.
+    required: true
+  aspects:
+    description: Aspects forwarded to /review-pr (all | code | security | ...).
+    required: false
+    default: all
+  post_comment:
+    description: Auto-post the summary comment headlessly.
+    required: false
+    default: "true"
+  fail_on:
+    description: none | changes_requested — whether the verdict fails the check.
+    required: false
+    default: none
+  dolt_remote_url:
+    description: Dolt remote URL (with credentials) for bd bootstrap/push.
+    required: true
+  github_token:
+    description: Token used by the skill's gh calls (pr comment / api).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go (for yq build)
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - name: Install yq (mikefarah)
+      # The resolver and the verdict step parse YAML/JSON with mikefarah yq.
+      # Built from go.tool.mod (pinned) via the module proxy — mirrors
+      # .github/workflows/scripts-tests.yaml; avoids the GitHub Releases CDN
+      # flake class and Ubuntu's incompatible python `yq`.
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$HOME/.local/bin"
+        GOWORK=off go build -modfile=go.tool.mod \
+          -o "$HOME/.local/bin/yq" github.com/mikefarah/yq/v4
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/yq" --version
+
+    - name: Install Node and Claude Code CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install -g @anthropic-ai/claude-code
+        claude --version
+
+    - name: Install bd (beads)
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install steveyegge/beads/bd
+        bd version
+```
+
+> **Step 1b (above):** the Go+yq install block is the canonical way to get
+> `yq` on PATH in this repo (grounded against `scripts-tests.yaml`). The
+> resolver (Task 6) and verdict step (Task 8) both depend on it, so it MUST
+> precede them. `actions/checkout` is run by the calling workflow (Task 9), so
+> `go.mod`/`go.tool.mod` are present when this step runs.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run: `yq '.inputs | keys' .github/actions/claude-pr-review/action.yml`
+Expected: a list including `pr_number`, `model_profile`, `auth_token`,
+`aspects`, `post_comment`, `fail_on`, `dolt_remote_url`, `github_token`.
+
+- [ ] **Step 3: Format**
+
+Run: `task fmt`
+Expected: no diff (or an applied yamlfmt normalization that you then include).
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(ci): claude-pr-review composite action skeleton + toolchain install (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 5: Composite action — bd bootstrap step
+
+**Files:**
+
+- Modify: `.github/actions/claude-pr-review/action.yml` (append a step after "Install bd")
+
+- [ ] **Step 1: Add the bd bootstrap step**
+
+Insert after the "Install bd (beads)" step, before any review step:
+
+```yaml
+    - name: Bootstrap beads from shared Dolt
+      shell: bash
+      env:
+        DOLT_REMOTE_URL: ${{ inputs.dolt_remote_url }}
+      run: |
+        set -euo pipefail
+        # CI=true makes bd bootstrap non-interactive automatically.
+        bd dolt remote add origin "$DOLT_REMOTE_URL"
+        bd bootstrap --yes
+        bd where        # diagnostic: confirm the active DB location
+```
+
+- [ ] **Step 2: Verify the YAML still parses**
+
+Run: `yq '.runs.steps[].name' .github/actions/claude-pr-review/action.yml`
+Expected: the step list now includes `Bootstrap beads from shared Dolt`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "feat(ci): bd bootstrap step in claude-pr-review action (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 6: Composite action — resolve profile into env
+
+**Files:**
+
+- Modify: `.github/actions/claude-pr-review/action.yml` (append a resolve step)
+
+- [ ] **Step 1: Add the resolve step**
+
+Insert after the bootstrap step:
+
+```yaml
+    - name: Resolve model profile
+      id: profile
+      shell: bash
+      env:
+        HOMELAB_LITELLM_URL: ${{ vars.HOMELAB_LITELLM_URL }}
+      run: |
+        set -euo pipefail
+        "${{ github.action_path }}/resolve-profile.sh" \
+          "${{ inputs.model_profile }}" \
+          "${{ github.action_path }}/profiles.yml"
+```
+
+This populates `steps.profile.outputs.runs_on`, `.base_url`, `.settings_env`
+(the resolver writes to `$GITHUB_OUTPUT`).
+
+- [ ] **Step 2: Verify YAML parses and the step id is wired**
+
+Run: `yq '.runs.steps[] | select(.id == "profile") | .name' .github/actions/claude-pr-review/action.yml`
+Expected: `Resolve model profile`
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "feat(ci): resolve model profile into env in claude-pr-review action (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 7: Composite action — run the official action (headless review)
+
+**Files:**
+
+- Modify: `.github/actions/claude-pr-review/action.yml` (append the official-action step)
+
+- [ ] **Step 1: Pin the official action SHA**
+
+Resolve and record the current `v1` commit SHA (repo convention is SHA-pinning
+with a version comment):
+
+```bash
+gh api repos/anthropics/claude-code-action/git/refs/tags/v1 \
+  --jq '.object.sha'
+```
+
+Note the SHA for the next step's `uses:` line (replace `PINNED_SHA`).
+
+- [ ] **Step 2: Add the official-action step**
+
+Insert after the resolve step. The whole profile env bag goes through
+`settings.env`; `ANTHROPIC_AUTH_TOKEN` is merged in from the `auth_token` input
+(the resolver intentionally never sees the secret). The prompt carries the
+headless post override (v1 bridge for upstream issue #128).
+
+```yaml
+    - name: Run review via claude-code-action
+      uses: anthropics/claude-code-action@PINNED_SHA # v1
+      with:
+        anthropic_api_key: ${{ inputs.auth_token }}
+        # plugin_marketplaces takes Git URLs (newline-separated); plugins takes
+        # bare plugin names (newline-separated). NOT owner/repo and NOT
+        # name@marketplace (grounded against the action source, bead note round3).
+        plugin_marketplaces: https://github.com/fzymgc-house/fzymgc-house-skills.git
+        plugins: dev-flow
+        settings: |
+          {
+            "env": ${{ steps.profile.outputs.settings_env }}
+          }
+        prompt: |
+          /review-pr ${{ inputs.pr_number }} ${{ inputs.aspects }}
+
+          You are running headless in CI. There is no human to confirm.
+          When review-pr reaches its "offer to post" step, post the summary
+          comment without asking (post_comment=${{ inputs.post_comment }}).
+          Do not wait for any interactive input.
+      env:
+        ANTHROPIC_BASE_URL: ${{ steps.profile.outputs.base_url }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth_token }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+```
+
+> **Implementer note (spec §3.3):** `settings.env` is the channel that survives
+> composite-action env shadowing. The job-level `env:` here sets
+> `ANTHROPIC_BASE_URL` (which the action explicitly forwards) and the `GH_TOKEN`
+> the skill's `gh` calls need. If a future action version stops forwarding
+> `ANTHROPIC_BASE_URL`, move it into the `settings.env` JSON (it is already there
+> for the model vars). The `auth_token` is set both as `anthropic_api_key`
+> (satisfies `validateEnvironmentVariables`) and `ANTHROPIC_AUTH_TOKEN` (bearer
+> path for LiteLLM); DeepSeek accepts the x-api-key path too.
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run: `yq '.runs.steps[] | select(.uses) | .uses' .github/actions/claude-pr-review/action.yml`
+Expected: the pinned `anthropics/claude-code-action@<sha>` reference.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "feat(ci): invoke claude-code-action for headless review (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 8: Composite action — persist findings + verdict gate
+
+**Files:**
+
+- Modify: `.github/actions/claude-pr-review/action.yml` (append push + gate steps)
+
+The verdict reproduces review-pr's own logic (spec §5.3): count open findings on
+the PR's review epic labelled `severity:critical` or `severity:important`.
+
+- [ ] **Step 1: Add the push + gate steps**
+
+Insert after the review step:
+
+```yaml
+    - name: Persist findings to shared Dolt
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Pull immediately before push to minimise the concurrent-writer window;
+        # retry once on conflict (spec §5.3).
+        bd dolt pull || true
+        bd dolt push || { bd dolt pull && bd dolt push; }
+
+    - name: Compute verdict and gate
+      id: verdict
+      shell: bash
+      run: |
+        set -euo pipefail
+        epic="$(bd list --label "pr-review,pr:${{ inputs.pr_number }}" --json \
+          | yq -p=json '.[0].id')"
+        if [[ -z "$epic" || "$epic" == "null" ]]; then
+          echo "verdict=unknown" >> "$GITHUB_OUTPUT"
+          echo "No review epic found for PR ${{ inputs.pr_number }}." >&2
+          exit 0
+        fi
+        must_fix="$(bd list --parent "$epic" --status open --json \
+          | yq -p=json '[.[] | select(.labels[] == "severity:critical" or .labels[] == "severity:important")] | length')"
+        echo "verdict_count=$must_fix" >> "$GITHUB_OUTPUT"
+        if [[ "$must_fix" -gt 0 ]]; then
+          echo "verdict=changes_requested" >> "$GITHUB_OUTPUT"
+          if [[ "${{ inputs.fail_on }}" == "changes_requested" ]]; then
+            echo "::error::Review verdict CHANGES REQUESTED ($must_fix must-fix finding(s))."
+            exit 1
+          fi
+        else
+          echo "verdict=pass" >> "$GITHUB_OUTPUT"
+        fi
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run: `yq '.runs.steps[].name' .github/actions/claude-pr-review/action.yml`
+Expected: list now ends with `Persist findings to shared Dolt` and
+`Compute verdict and gate`.
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+task fmt
+jj describe -m "feat(ci): persist findings + verdict gate in claude-pr-review action (holomush-3f5s9)"
+jj new
+```
+
+---
+
+## Phase 3: Workflow and operator docs
+
+### Task 9: The workflow (`claude-review.yml`)
+
+**Files:**
+
+- Create: `.github/workflows/claude-review.yml`
+
+Two jobs: `resolve` (always `ubuntu-latest`) outputs the runner label + the
+auth-secret name; `review` runs on that label and calls the composite action.
+The same-repo guard (spec §5.1) lives on the auto trigger; fork PRs run only via
+the `claude-review` label.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+name: Claude Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+      model_profile:
+        description: Profile (anthropic | deepseek | litellm)
+        required: false
+        default: anthropic
+      aspects:
+        description: Aspects for /review-pr
+        required: false
+        default: all
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    # Run unless this is a fork PR push without the claude-review label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.action != 'labeled') ||
+      (github.event.action == 'labeled' &&
+       github.event.label.name == 'claude-review')
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on: ${{ steps.r.outputs.runs_on }}
+      profile: ${{ steps.r.outputs.profile }}
+      auth_secret: ${{ steps.r.outputs.auth_secret }}
+      pr_number: ${{ steps.r.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Install yq (mikefarah)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          GOWORK=off go build -modfile=go.tool.mod \
+            -o "$HOME/.local/bin/yq" github.com/mikefarah/yq/v4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - id: r
+        env:
+          HOMELAB_LITELLM_URL: ${{ vars.HOMELAB_LITELLM_URL }}
+        run: |
+          set -euo pipefail
+          profile="${{ github.event.inputs.model_profile || 'anthropic' }}"
+          pr="${{ github.event.inputs.pr_number || github.event.pull_request.number }}"
+          dir=.github/actions/claude-pr-review
+          # Resolve runs_on for the chosen profile.
+          "$dir/resolve-profile.sh" "$profile" "$dir/profiles.yml"
+          # resolve-profile.sh already appended runs_on/base_url/settings_env;
+          # add the auth-secret name and pr_number for the review job.
+          auth_secret="$(yq ".profiles.\"$profile\".auth_secret" "$dir/profiles.yml")"
+          echo "profile=$profile" >> "$GITHUB_OUTPUT"
+          echo "auth_secret=$auth_secret" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
+
+  review:
+    needs: resolve
+    runs-on: ${{ needs.resolve.outputs.runs_on }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/claude-pr-review
+        with:
+          pr_number: ${{ needs.resolve.outputs.pr_number }}
+          model_profile: ${{ needs.resolve.outputs.profile }}
+          aspects: ${{ github.event.inputs.aspects || 'all' }}
+          auth_token: ${{ secrets[needs.resolve.outputs.auth_secret] }}
+          dolt_remote_url: ${{ secrets.DOLT_REMOTE_URL }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on: none
+```
+
+> **Implementer notes:**
+> - `actions/checkout` and `actions/setup-go` are SHA-pinned above to the same
+>   SHAs every other repo workflow uses (`de0fac2…` / `4a3601…`). Confirm they
+>   still match (`rg 'actions/checkout@' .github/workflows`) before committing.
+> - `secrets[needs.resolve.outputs.auth_secret]` uses dynamic secret indexing —
+>   GitHub evaluates `secrets[<expr>]` in the `with:` context. Confirm during the
+>   smoke test (Task 10) that the resolved name maps to a configured secret.
+> - The `resolve` job's `runs_on` output comes from the resolver's
+>   `$GITHUB_OUTPUT` write; the explicit `echo` lines add the secret name + PR.
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `GOWORK=off go tool -modfile=go.tool-lint.mod actionlint -config-file .github/actionlint.yaml .github/workflows/claude-review.yml`
+Expected: exit 0. (`GOWORK=off -modfile=go.tool-lint.mod` is required — `actionlint`
+lives in `go.tool-lint.mod`, not the main module, and `go.work` mode breaks
+`-modfile`.) If actionlint flags `secrets[...]` dynamic indexing, prefer a static
+`fromJSON` map over a disable directive.
+
+- [ ] **Step 3: Run the repo lint gate**
+
+Run: `task lint`
+Expected: PASS (actionlint + yamlfmt clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+task fmt
+jj describe -m "feat(ci): claude-review workflow (resolve+review jobs, triggers, guards) (holomush-3f5s9)"
+jj new
+```
+
+---
+
+### Task 10: Operator docs + manual smoke test
+
+**Files:**
+
+- Create: `site/src/content/docs/contributing/how-to/claude-pr-review.md`
+  (the `contributing/` dir holds only `index.mdx` + `how-to/`/`explanation/`/`reference/` subdirs; the doc goes under `how-to/`)
+
+- [ ] **Step 1: Write the operator doc**
+
+````markdown
+---
+title: Claude PR Review action
+description: Running the automated Claude PR-review GitHub Action.
+---
+
+The `claude-review` workflow runs the `dev-flow:review-pr` skill on a PR via
+Claude Code and posts a summary review comment.
+
+## Required secrets
+
+| Secret | Used for |
+| --- | --- |
+| `ANTHROPIC_API_KEY` | `anthropic` profile auth |
+| `DEEPSEEK_API_KEY` | `deepseek` profile auth |
+| `LITELLM_API_KEY` | `litellm` profile auth |
+| `DOLT_REMOTE_URL` | `bd` bootstrap/push against the shared Dolt store |
+
+## Required variables
+
+| Variable | Used for |
+| --- | --- |
+| `HOMELAB_LITELLM_URL` | base URL of the homelab LiteLLM Anthropic endpoint |
+
+## Runners
+
+- `anthropic` / `deepseek` profiles run on `ubuntu-latest` (GitHub-hosted).
+- `litellm` runs on a self-hosted runner labelled `homelab-claude` that can reach
+  the homelab LiteLLM and Dolt server. Register that label in
+  `.github/actionlint.yaml` (already done) and bring up a runner with it.
+
+## Triggering
+
+- **Manual:** Actions → Claude Review → Run workflow → enter PR number + profile.
+- **Auto (same-repo PRs):** runs on PR open/synchronize.
+- **Fork PRs:** apply the `claude-review` label to opt a fork PR in.
+
+## Cost control
+
+The `deepseek` profile (and any `litellm` profile pointing at a cheap tier) keeps
+routine reviews inexpensive; `CLAUDE_CODE_SUBAGENT_MODEL` puts the ~8 review-pr
+aspect agents on the cheap tier. Rate-limit fallback (Anthropic → LiteLLM) is
+planned for v2.
+````
+
+- [ ] **Step 2: Fill the litellm profile model names**
+
+Edit `.github/actions/claude-pr-review/profiles.yml`: replace the `litellm`
+`PLACEHOLDER-*` model values with real model identifiers from the homelab
+LiteLLM model registry (e.g. the names LiteLLM exposes for the chosen
+OpenRouter/Ollama backends). Leave `${HOMELAB_LITELLM_URL}` as-is (resolved from
+the repo variable at runtime).
+
+- [ ] **Step 3: Verify the §3.2 model IDs against live APIs**
+
+Re-confirm the `anthropic` and `deepseek` profile model identifiers against each
+provider's current model list before the first real run (spec §3.2). Fix any
+that have changed.
+
+- [ ] **Step 4: Manual smoke test (cheap profile, throwaway PR)**
+
+1. Configure `DEEPSEEK_API_KEY` + `DOLT_REMOTE_URL` secrets in the repo.
+2. Open a tiny throwaway PR.
+3. Actions → Claude Review → Run workflow → PR number + `model_profile: deepseek`.
+4. Confirm: the `resolve` job picks `ubuntu-latest`; the `review` job bootstraps
+   `bd`, runs `/review-pr`, and a summary comment appears on the PR carrying the
+   `<!-- pr-review:<bead-id> -->` marker.
+5. Re-run on the same PR; confirm the comment updates in place (idempotency,
+   spec §5.4) rather than duplicating.
+6. `bd show <epic-id>` against the shared store; confirm findings persisted via
+   `bd dolt push`.
+
+Record the smoke-test outcome in a `bd note holomush-3f5s9`.
+
+- [ ] **Step 5: Lint docs and commit**
+
+```bash
+task lint
+task fmt
+jj describe -m "docs(ci): claude-pr-review operator guide + litellm profile fill (holomush-3f5s9)"
+jj new
+```
+
+---
+
+## Out of scope (v1 — per spec §1.2)
+
+- Inline per-line review comments (upstream issue #129; v2).
+- Rate-limit fallback orchestration (Anthropic → LiteLLM on 429; v2).
+- `pull_request_target` privileged fork review with secrets.
+- Multi-PR batch review.
+- The raw Claude Code CLI invocation path (spec §7; documented fallback only).
+<!-- adr-capture: sha256=15220a6f7a8c5382; session=cli; ts=2026-05-30T21:23:26Z; adrs= -->

--- a/docs/superpowers/plans/2026-05-30-claude-pr-review-action.md
+++ b/docs/superpowers/plans/2026-05-30-claude-pr-review-action.md
@@ -730,6 +730,7 @@ jobs:
 ```
 
 > **Implementer notes:**
+>
 > - `actions/checkout` and `actions/setup-go` are SHA-pinned above to the same
 >   SHAs every other repo workflow uses (`de0fac2…` / `4a3601…`). Confirm they
 >   still match (`rg 'actions/checkout@' .github/workflows`) before committing.
@@ -863,4 +864,4 @@ jj new
 - `pull_request_target` privileged fork review with secrets.
 - Multi-PR batch review.
 - The raw Claude Code CLI invocation path (spec §7; documented fallback only).
-<!-- adr-capture: sha256=15220a6f7a8c5382; session=cli; ts=2026-05-30T21:23:26Z; adrs= -->
+<!-- adr-capture: sha256=12024e7a22aa178b; session=cli; ts=2026-05-30T21:57:05Z; adrs= -->

--- a/docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md
+++ b/docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md
@@ -398,7 +398,7 @@ These are filed upstream as **requirements** (not solutions), as three issues on
   no precise anchor.
 - **Issue 3 (documentation) — model-tier env-var contract** (requirement D):
   document that the skill relies on `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`
-  + `CLAUDE_CODE_SUBAGENT_MODEL` and runs unmodified against non-Anthropic
+  and `CLAUDE_CODE_SUBAGENT_MODEL`; runs unmodified against non-Anthropic
   providers when they are mapped; list the logical tiers it uses.
 
 ## 9. Grounding traces
@@ -438,4 +438,4 @@ Recorded on bead holomush-3f5s9 (`bd show holomush-3f5s9`):
 input syntax for the official action (the `dev-flow@fzymgc-house-skills`
 marketplace-qualifier form, §4.1), and the live model identifiers for each
 provider (§3.2 note).
-<!-- adr-capture: sha256=e5fbcfb46f0f52e0; session=cli; ts=2026-05-30T21:21:55Z; adrs= -->
+<!-- adr-capture: sha256=33f1a7f09e559925; session=cli; ts=2026-05-30T21:57:05Z; adrs= -->

--- a/docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md
+++ b/docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md
@@ -1,0 +1,441 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Claude PR Review GitHub Action — Design
+
+- **Bead:** holomush-3f5s9
+- **Status:** Draft (pending design-reviewer gate)
+- **Date:** 2026-05-30
+- **Author:** Sean Brandt (with Claude Opus 4.8)
+
+## 1. Summary
+
+A GitHub Action that runs automated code review on HoloMUSH pull requests by
+driving the fzymgc-house **`dev-flow:review-pr`** skill through Claude Code in a
+runner, with a **configurable model-provider profile** so reviews can run on
+Anthropic directly, on DeepSeek's Anthropic-compatible endpoint, or through a
+homelab **LiteLLM** router (which fans out to OpenRouter / Ollama / cost-tiered
+models).
+
+The action is **internal-first** — built inside the HoloMUSH repo cleanly enough
+to be extracted into a standalone reusable action later. Its motivations are
+**cost control** (cheap models on routine PRs) and **rate-limit resilience**
+(fall back to another provider when Anthropic is throttled), leveraging existing
+homelab infrastructure (LiteLLM + a shared Dolt server) reached via a
+self-hosted runner.
+
+### 1.1 Goals
+
+- Run `dev-flow:review-pr` end-to-end in CI: gather PR context, dispatch the
+  aspect agents, file findings, compute the verdict, post a summary comment.
+- Make the model provider a single, named, swappable **profile**.
+- Persist review findings to the shared `bd`/Dolt store (`bd dolt pull/push`).
+- Keep the GitHub-plumbing surface (auth, comment posting, plugin loading) on
+  the official `anthropics/claude-code-action`, not hand-rolled.
+
+### 1.2 Non-goals (v1)
+
+YAGNI — explicitly deferred:
+
+- Inline per-line review comments (summary comment only in v1; inline is v2).
+- Rate-limit fallback orchestration (single profile per run in v1).
+- `pull_request_target` / privileged fork-PR review with secrets.
+- Multi-PR batch review.
+- The raw-CLI invocation path (documented as a fallback, not built).
+
+## 2. Architecture
+
+Two units with a clean seam: a **workflow** owns *when/where*, a **composite
+action** owns *how* and is the extractable artifact.
+
+```text
+.github/
+├── workflows/
+│   └── claude-review.yml          # triggers, runner selection, profile resolution
+└── actions/
+    └── claude-pr-review/
+        ├── action.yml             # composite: bootstrap → official action → push
+        └── profiles.yml           # model-provider profile registry
+```
+
+### 2.1 Workflow — `claude-review.yml`
+
+Owns *when* a review runs and *where* (which runner):
+
+- **Triggers:**
+  - `workflow_dispatch` — manual, inputs `pr_number`, `model_profile`, `aspects`.
+  - `pull_request: [opened, synchronize]` — auto-review, **same-repo branches
+    only** (see §5.1).
+  - `pull_request` label event — review fork PRs only when a maintainer applies
+    the `claude-review` label.
+- **Concurrency:** `group: claude-review-${{ pr_number }}`,
+  `cancel-in-progress: true` — a new push supersedes an in-flight review.
+- **Runner selection:** `runs-on` is taken from the resolved profile
+  (self-hosted homelab label for homelab profiles; `ubuntu-latest` for direct
+  Anthropic/DeepSeek).
+- Passes `pr_number`, resolved `model_profile`, and `aspects` to the composite
+  action.
+
+The workflow knows nothing about LiteLLM, Dolt, or the official action's
+internals — it names a profile and a PR. That ignorance is what keeps the
+composite action extractable.
+
+### 2.2 Composite action — `claude-pr-review/action.yml`
+
+Owns *how*. Public input contract:
+
+| Input | Default | Purpose |
+|---|---|---|
+| `pr_number` | — | PR to review |
+| `model_profile` | `anthropic` | profile name → resolves base_url / model env / secret / runner |
+| `aspects` | `all` | forwarded to `/review-pr` |
+| `post_comment` | `true` | headless auto-post the summary comment |
+| `fail_on` | `none` | `none` \| `changes_requested` — gate the check on the verdict |
+| `beads_remote` | (secret ref) | Dolt remote for `bd dolt pull/push` |
+
+## 3. Model-provider profiles
+
+The "configurable model" surface reduces to a **profile registry**. A profile is
+not a single model — it is the full Claude Code **tiering env bag** plus a base
+URL, an auth-secret name, and a runner hint.
+
+### 3.1 Why the full env bag
+
+`dev-flow:review-pr` dispatches its aspect agents by **logical tier name**: its
+Step 5 defaults agents to `sonnet` and escalates specific agents (security,
+crypto, large diffs) to `opus`, passing `model: sonnet` / `model: opus` to each
+`Task`. Against a non-Anthropic backend those literal names are meaningless
+unless Claude Code's tier env vars map them. Those env vars are therefore the
+**translation layer** that lets the skill run **unmodified** on any provider:
+
+| Env var | Role | review-pr consumer |
+|---|---|---|
+| `ANTHROPIC_MODEL` | main / orchestrator model | the `/review-pr` driver |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | resolves logical "sonnet" | default aspect agents |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | resolves logical "opus" | escalated agents |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | resolves logical "haiku" | background / cheap calls |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | subagent model override | the fanned-out aspect agents |
+| `CLAUDE_CODE_EFFORT_LEVEL` | reasoning effort | whole run |
+
+`CLAUDE_CODE_SUBAGENT_MODEL` is the primary **cost lever**: review-pr fans out
+~8 aspect agents; pointing them at a cheaper tier while the orchestrator runs a
+stronger model directly serves the cost-control motivation.
+
+### 3.2 Storage — checked-in `profiles.yml`
+
+Because a profile carries six-plus env vars, a checked-in `profiles.yml` is the
+natural home (a `case` statement or per-call workflow inputs would be unwieldy).
+Secret **values** live in GitHub secrets and are referenced by name; only names
+appear in the file.
+
+```yaml
+profiles:
+  anthropic:                       # default; GitHub-hosted runner OK
+    base_url: ""                   # unset → api.anthropic.com
+    auth_secret: ANTHROPIC_API_KEY
+    runs_on: ubuntu-latest
+    env:
+      ANTHROPIC_MODEL: claude-opus-4-8
+      CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-6
+      CLAUDE_CODE_EFFORT_LEVEL: high
+
+  deepseek:                        # Anthropic-shaped endpoint, no proxy, hosted OK
+    base_url: https://api.deepseek.com/anthropic
+    auth_secret: DEEPSEEK_API_KEY
+    runs_on: ubuntu-latest
+    env:
+      ANTHROPIC_MODEL: deepseek-v4-pro
+      ANTHROPIC_DEFAULT_OPUS_MODEL: deepseek-v4-pro
+      ANTHROPIC_DEFAULT_SONNET_MODEL: deepseek-v4-flash
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: deepseek-v4-flash
+      CLAUDE_CODE_SUBAGENT_MODEL: deepseek-v4-flash
+      CLAUDE_CODE_EFFORT_LEVEL: max
+
+  litellm:                         # homelab router → OpenRouter / Ollama / cost tiers
+    base_url: ${{ vars.HOMELAB_LITELLM_URL }}
+    auth_secret: LITELLM_API_KEY
+    runs_on: [self-hosted, homelab-claude]   # MUST be registered (see §3.4)
+    env:
+      ANTHROPIC_MODEL: <litellm model name>          # fill from homelab LiteLLM model registry
+      ANTHROPIC_DEFAULT_OPUS_MODEL: <strong tier>
+      ANTHROPIC_DEFAULT_SONNET_MODEL: <default tier>
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: <cheap tier>
+      CLAUDE_CODE_SUBAGENT_MODEL: <cheap tier>
+      CLAUDE_CODE_EFFORT_LEVEL: max
+```
+
+> **Model IDs above are illustrative** and current as of 2026-05-30
+> (`claude-opus-4-8`/`claude-sonnet-4-6` are the repo's current models per
+> CLAUDE.md; DeepSeek's Anthropic-endpoint mapping is `claude-opus*` →
+> `deepseek-v4-pro`, `claude-sonnet*`/`claude-haiku*` → `deepseek-v4-flash` per
+> grounding §9). The plan MUST re-verify the exact model identifiers against each
+> provider's live API before pinning them, and fill the `litellm` placeholders
+> from the homelab LiteLLM model registry.
+
+### 3.4 Runner-label prerequisite (homelab profiles)
+
+The repo's `.github/actionlint.yaml` registers **only**
+`namespace-profile-linux-amd64-{2x4,4x8,8x16}` as valid self-hosted runner
+labels; `task lint` runs `actionlint`, which fails on any unregistered label.
+The homelab self-hosted runner is the user's own infrastructure (not a Namespace
+runner), so the `litellm` profile's label (`homelab-claude` above) is **not**
+currently valid.
+
+**Prerequisite (a plan task):** register the homelab runner's label in
+`.github/actionlint.yaml` under `self-hosted-runner.labels` **before** the
+`litellm` profile workflow can pass lint. The `anthropic` and `deepseek`
+profiles run on `ubuntu-latest` (GitHub-hosted) and need no registration.
+
+### 3.3 How the profile reaches the CLI through the official action
+
+The base-URL override works **through** the official action — verified against
+its source (grounding, §9). Two facts make this clean:
+
+1. `validateEnvironmentVariables()` on the **default Anthropic provider** (no
+   `use_bedrock`/`use_vertex`/`use_foundry`) only requires that
+   `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` is present. It does **not**
+   reject `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, or the
+   `ANTHROPIC_DEFAULT_*_MODEL` vars.
+2. The action explicitly forwards `ANTHROPIC_BASE_URL` and the default-model env
+   vars to the CLI subprocess, and exposes a **`settings` input** accepting a
+   JSON `"env"` object — the recommended way to pass arbitrary env to the CLI.
+
+**Therefore the composite action passes the whole profile env bag via the
+action's `settings.env`** (not a step-level `env:` block — composite-action env
+shadowing would hide a step block from the CLI; `settings.env`, job-level
+`env:`, or a prior `$GITHUB_ENV` write are the working channels):
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    anthropic_api_key: ${{ secrets[profile.auth_secret] }}   # satisfies validation
+    settings: |
+      { "env": {
+          "ANTHROPIC_BASE_URL": "<profile.base_url>",
+          "ANTHROPIC_AUTH_TOKEN": "<profile.auth_secret value>",
+          "ANTHROPIC_MODEL": "...", "ANTHROPIC_DEFAULT_SONNET_MODEL": "...",
+          "ANTHROPIC_DEFAULT_OPUS_MODEL": "...", "CLAUDE_CODE_SUBAGENT_MODEL": "...",
+          "CLAUDE_CODE_EFFORT_LEVEL": "max"
+      } }
+```
+
+**Auth nuance (per-endpoint config, not architectural):** Claude Code sends
+`ANTHROPIC_API_KEY` as `x-api-key` and `ANTHROPIC_AUTH_TOKEN` as
+`Authorization: Bearer`. DeepSeek's endpoint accepts `x-api-key` (its compat
+table lists it "Fully Supported"), so `anthropic_api_key` alone may suffice
+there; LiteLLM commonly expects a bearer token, so set `ANTHROPIC_AUTH_TOKEN`
+via `settings.env`. Setting both (API key to satisfy validation, AUTH_TOKEN for
+the bearer path) is the safe default the plan should adopt unless an endpoint
+proves otherwise.
+
+The raw-CLI path (§7) is now a true last resort, retained only against a future
+action version tightening provider validation.
+
+## 4. Data flow
+
+```text
+trigger (dispatch | same-repo PR push | claude-review label)
+        │
+        ▼
+workflow resolves profile → selects runner → calls composite action
+        │
+        ▼
+[1] install toolchain        node + @anthropic-ai/claude-code, gh, task,
+                             bd (brew install steveyegge/beads/bd)
+[2] bd bootstrap             bd dolt remote add <name> <DOLT_REMOTE_URL secret>
+                             bd bootstrap --yes   (CI=true → non-interactive;
+                                                   clones from the Dolt remote)
+[3] official action env      profile env bag passed via settings.env (§3.3)
+[4] run official action      anthropics/claude-code-action@v1:
+                               plugin_marketplaces: fzymgc-house/fzymgc-house-skills
+                               plugins: dev-flow@fzymgc-house-skills
+                               prompt: "/review-pr <PR> <aspects>" + headless post override
+                             (inside: review-pr creates epic + finding beads,
+                              aggregates, computes verdict, posts summary comment)
+        │
+        ▼
+[5] bd dolt push             persist epic + findings to shared Dolt
+[6] read verdict             from bd severity counts → exit 0 / fail per fail_on
+```
+
+### 4.1 Plugin loading
+
+The official action's `plugin_marketplaces` + `plugins` inputs load the
+fzymgc-house marketplace and the `dev-flow` plugin, which bundles **both** the
+`/review-pr` orchestrator skill and its aspect agents (`code-reviewer`,
+`security-auditor`, `silent-failure-hunter`, `pr-test-analyzer`,
+`type-design-analyzer`, `comment-analyzer`, `api-contract-checker`,
+`spec-compliance`, `code-simplifier`, `slop-hunter`). No agent definitions are
+hand-copied into the action.
+
+## 5. Security & failure modes
+
+### 5.1 Trigger safety (fork PRs)
+
+- `pull_request: [opened, synchronize]` runs **only** for same-repo branches:
+  guard `if github.event.pull_request.head.repo.full_name == github.repository`.
+- Fork PRs are reviewed only when a maintainer applies the `claude-review`
+  label, on a privileged path that **does not check out or execute fork code**
+  with secrets in scope — the review reads the diff; it never runs the PR's
+  build/test.
+- No `pull_request_target` in v1.
+
+### 5.2 Secret hygiene
+
+All provider tokens and Dolt credentials are GitHub secrets, referenced by name
+in `profiles.yml`, never echoed. Credential export avoids `set -x`. The summary
+comment is the only outward artifact.
+
+### 5.3 Failure-mode matrix
+
+| Failure | Behavior |
+|---|---|
+| `bd dolt pull` fails (Dolt unreachable) | Fail fast, clear message; no review attempted (don't run with a broken findings store) |
+| Model endpoint 429 / quota | v1: fail the job with a labeled message (`profile=<name> rate-limited`); v2: trigger fallback profile |
+| Provider auth fails | Fail fast; hint "check `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`) for profile X" |
+| Claude run exits non-zero | Surface the CLI exit; do **not** `bd dolt push` partial state |
+| `bd dolt push` conflict | pull-then-retry once; if still conflicting, leave local + emit a warning artifact (never lose findings) |
+| review-pr finds PR merged/closed | skill self-reconciles (its Step 3/12); action exits 0 |
+| Verdict = CHANGES_REQUESTED | exit 0 unless `fail_on: changes_requested`, then exit 1 to gate merge |
+
+### 5.4 Idempotency
+
+Re-running on the same PR is safe: review-pr keys off the existing
+`pr-review,pr:<n>` epic and increments a `turn:N` label; the summary comment
+carries the `<!-- pr-review:<bead-id> -->` marker so it updates in place rather
+than duplicating.
+
+### 5.5 bd-in-CI bootstrap
+
+The bootstrap is a solved sequence, grounded against the `bd` CLI (§9):
+
+```bash
+brew install steveyegge/beads/bd          # public homebrew tap
+bd dolt remote add origin "$DOLT_REMOTE_URL"   # creds from secret
+bd bootstrap --yes                         # CI=true ⇒ non-interactive;
+                                           # clones DB from the configured Dolt remote
+# … review runs (review-pr writes epic + findings) …
+bd dolt push                               # persist
+```
+
+Why the previously-flagged risks are handled:
+
+1. **`.beads/redirect` absolute-path (reviewer finding 3)** — **non-issue**.
+   The redirect file is **gitignored** (per `.beads/.gitignore`), so it is
+   absent on a fresh CI clone; `bd` resolves to the repo's own `.beads/`. There
+   is no stale macOS path to override. `bd where` confirms the active location
+   for debugging.
+2. **`bd` install** — `brew install steveyegge/beads/bd` (the repo's
+   `Taskfile.yaml` uses the same tap). `bd bootstrap` is purpose-built for
+   "setting up beads on a fresh clone" and auto-detects non-interactive mode when
+   `CI=true`.
+3. **Dolt auth from CI** — a `DOLT_REMOTE_URL` secret (with embedded
+   credentials, or paired with a token secret) wired via `bd dolt remote add`.
+   The plan confirms the exact credential form `bd dolt` expects non-interactively.
+4. **Concurrent-writer / merge risk** — a human session and the CI run could
+   both push; the `pr-review` epic is run-local so conflict risk is low. Pull
+   immediately before push; tolerant retry (§5.3).
+5. **Headless confirmation override** — review-pr Step 10 says "do NOT post
+   without confirmation." v1 overrides via the prompt ("you are headless in CI;
+   post the summary without asking"); the durable fix is upstream Issue 1 (§8).
+6. **`gh` auth inside the skill** — review-pr shells out to `gh pr comment` /
+   `gh api`. Confirm `GH_TOKEN` is exported into the CLI's shell, not only the
+   action's own steps.
+
+## 6. Testing strategy
+
+GitHub Actions is awkward to unit-test, so the strategy is layered:
+
+- **`act` / local dry-run** of the composite action with a stub profile against a
+  throwaway PR, asserting step ordering and env export (no real model spend).
+- **`profiles.yml` schema test** — a validator (consistent with the repo's
+  `task lint` schema checks) asserting every profile has
+  `base_url`/`auth_secret`/`runs_on`/`env`, and that referenced secrets are
+  wired in the workflow.
+- **One live smoke PR** against the cheap `deepseek` profile exercising the full
+  pull → review → comment → push loop before wiring the Anthropic profile.
+- **bd push/pull integration** verified against a **scratch Dolt branch** first
+  (not main) to de-risk the concurrent-writer path.
+
+## 7. Alternatives considered
+
+- **Raw Claude Code CLI in the composite action** — provider-agnostic by
+  construction and full control over flags/env/exit handling, but reimplements
+  GitHub plumbing the official action provides (token wiring, the inline-comment
+  MCP tool for v2). **Kept as a documented fallback** if the official action's
+  provider validation rejects the LiteLLM/DeepSeek base-URL override (§3.3).
+- **Workflow-only, no composite action** — fewest files, but not extractable;
+  rejected against the "extractable later" goal.
+- **Ephemeral throwaway `bd` DB per run** — avoids Dolt-in-CI auth, but loses
+  findings and breaks cross-run `/address-findings`; rejected in favor of
+  `bd dolt pull/push` against the shared store.
+- **Bundling `claude-code-router` as a per-job proxy** — unnecessary once a
+  central LiteLLM router is available; DeepSeek needs no proxy at all (native
+  Anthropic-shaped endpoint). Rejected as redundant complexity.
+
+## 8. Upstream requirements (fzymgc-house/fzymgc-house-skills)
+
+`dev-flow:review-pr` has gaps that make headless CI use require workarounds.
+These are filed upstream as **requirements** (not solutions), as three issues on
+`fzymgc-house/fzymgc-house-skills`:
+
+- **[#128](https://github.com/fzymgc-house/fzymgc-house-skills/issues/128)** — Issue 1 below
+- **[#129](https://github.com/fzymgc-house/fzymgc-house-skills/issues/129)** — Issue 2 below
+- **[#130](https://github.com/fzymgc-house/fzymgc-house-skills/issues/130)** — Issue 3 below
+
+- **Issue 1 (enhancement) — headless/CI mode + machine-readable verdict**
+  (combines requirements A + B; they ship together):
+  - Non-interactive mode that auto-posts the summary without the Step 10
+    confirmation prompt and never blocks on stdin (opt-in; default unchanged).
+  - Machine-readable verdict: non-zero exit on CHANGES REQUESTED and/or a JSON
+    summary (`{verdict, critical, important, suggestions, epic}`) matching the
+    prose verdict exactly.
+- **Issue 2 (enhancement) — optional inline per-line review comments**
+  (requirement C; v2 enabler): opt-in inline review comments anchored to
+  file+line, in addition to the summary, degrading gracefully when a finding has
+  no precise anchor.
+- **Issue 3 (documentation) — model-tier env-var contract** (requirement D):
+  document that the skill relies on `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`
+  + `CLAUDE_CODE_SUBAGENT_MODEL` and runs unmodified against non-Anthropic
+  providers when they are mapped; list the logical tiers it uses.
+
+## 9. Grounding traces
+
+Recorded on bead holomush-3f5s9 (`bd show holomush-3f5s9`):
+
+- `.github` survey — no existing Claude action; local composite actions are
+  `install-cog`/`install-formatters`/`install-task` only.
+- deepwiki `anthropics/claude-code-action` — Agent Mode via `prompt` runs on
+  `pull_request` without `@claude`; model via `claude_args --model`; skills via
+  `plugin_marketplaces` + `plugins`; tools via `--allowedTools`; providers limited
+  to Anthropic/Bedrock/Vertex/Foundry (no native OpenRouter/Ollama).
+- exa — DeepSeek ships a native Anthropic-compatible endpoint
+  (`https://api.deepseek.com/anthropic`); `ANTHROPIC_AUTH_TOKEN` + tier env vars;
+  `claude-opus*` → `deepseek-v4-pro`, `claude-sonnet*`/`claude-haiku*` →
+  `deepseek-v4-flash`.
+- deepwiki `musistudio/claude-code-router` — translation-proxy approach for
+  OpenAI-shaped backends; unnecessary here given central LiteLLM.
+- read — `dev-flow:review-pr` SKILL.md: bead-native, summary-only post,
+  confirmation-gated, aspect agents bundled in the `dev-flow` plugin.
+- deepwiki `anthropics/claude-code-action` (round 2, §3.3) —
+  `validateEnvironmentVariables()` on the default Anthropic provider only
+  requires `ANTHROPIC_API_KEY`|`CLAUDE_CODE_OAUTH_TOKEN`; does **not** reject
+  `ANTHROPIC_BASE_URL`/`AUTH_TOKEN`/`DEFAULT_*`. Action forwards
+  `ANTHROPIC_BASE_URL` + default-model env to the CLI; `settings.env` JSON is the
+  recommended channel for the full env bag (composite-action env shadowing means
+  a step-level `env:` block is hidden from the CLI).
+- `bd` CLI (§5.5) — install `brew install steveyegge/beads/bd`; `bd bootstrap`
+  is the fresh-clone primitive (auto non-interactive under `CI=true`; clones from
+  the configured Dolt remote / `refs/dolt/data`). `.beads/redirect` is gitignored,
+  so absent on a fresh CI clone — the absolute-path concern does not arise.
+- `.github/actionlint.yaml` — registers only
+  `namespace-profile-linux-amd64-{2x4,4x8,8x16}` self-hosted labels; the homelab
+  runner label must be added there before the `litellm` profile passes lint (§3.4).
+
+**Verify at plan time (not yet grounded):** the exact `plugins:`
+input syntax for the official action (the `dev-flow@fzymgc-house-skills`
+marketplace-qualifier form, §4.1), and the live model identifiers for each
+provider (§3.2 note).
+<!-- adr-capture: sha256=e5fbcfb46f0f52e0; session=cli; ts=2026-05-30T21:21:55Z; adrs= -->


### PR DESCRIPTION
## Summary

Design spec + implementation plan for an internal-first GitHub Action that runs the fzymgc-house `dev-flow:review-pr` skill on HoloMUSH PRs via the official `anthropics/claude-code-action`, with swappable model-provider profiles (Anthropic / DeepSeek / homelab LiteLLM) for cost control and rate-limit resilience. Findings persist through `bd dolt pull/push`; v1 posts the summary comment only.

**Docs-only** — no code. Lands the canonical spec/plan on `main` so subagent-driven implementation of epic `holomush-3f5s9` (10 child beads) can read them from the worktree.

## Contents

- `docs/superpowers/specs/2026-05-30-claude-pr-review-action-design.md` — design (READY via design-reviewer, 2 rounds)
- `docs/superpowers/plans/2026-05-30-claude-pr-review-action.md` — 10-task plan in 3 phases (READY via plan-reviewer, 2 rounds)

## Pipeline

brainstorming → design-reviewer (READY) → writing-plans → plan-reviewer (READY) → capture-adrs (0 ADRs) → plan-to-beads (epic `holomush-3f5s9` + 10 children). Upstream requirements filed: fzymgc-house/fzymgc-house-skills #128/#129/#130.

## Verification

`task pr-prep:docs` green (markdown/yaml lint, docs-symmetry, ADR doctor, fmt:check, license:check, docs-paths-sync). Auto docs-detection in `task pr-prep` was skipped because secondary jj workspaces have no `.git/`; diff confirmed docs-only via `jj diff --name-only -r main@origin..@`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)