### PR TITLE
fix(session): reject lease/grace below 2× gateway refresh cadence (holomush-rsoe6.22)

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -1164,6 +1164,21 @@ func parseSessionConfig(cfg *coreConfig) (sessionTTL, reaperInterval, leaseTTL, 
 		return 0, 0, 0, 0, oops.Code("CONFIG_INVALID").With("field", "session_boot_grace").Errorf("boot grace must be positive")
 	}
 
+	// A live gateway connection only refreshes its lease once per
+	// session.DefaultLeaseRefreshInterval (15s). A LeaseTTL/BootGrace below 2× that
+	// cadence lets the reaper sweep a healthy connection between refreshes (lease)
+	// or before a surviving gateway re-asserts after restart (grace, I-LIVE-4), so
+	// reject anything under the floor (holomush-rsoe6.22). Defaults (45s/60s) clear it.
+	minLeaseGrace := 2 * session.DefaultLeaseRefreshInterval
+	if leaseTTL < minLeaseGrace {
+		return 0, 0, 0, 0, oops.Code("CONFIG_INVALID").With("field", "session_lease_ttl").
+			Errorf("lease TTL must be at least %s (2× the %s gateway refresh cadence) so a healthy connection is not reaped between refreshes", minLeaseGrace, session.DefaultLeaseRefreshInterval)
+	}
+	if bootGrace < minLeaseGrace {
+		return 0, 0, 0, 0, oops.Code("CONFIG_INVALID").With("field", "session_boot_grace").
+			Errorf("boot grace must be at least %s (2× the %s gateway refresh cadence) so a surviving gateway can re-assert its leases before the post-restart sweep", minLeaseGrace, session.DefaultLeaseRefreshInterval)
+	}
+
 	if cfg.SessionMaxHistory <= 0 {
 		cfg.SessionMaxHistory = 500
 	}

--- a/cmd/holomush/core_test.go
+++ b/cmd/holomush/core_test.go
@@ -1155,7 +1155,9 @@ func TestParseSessionConfigPreservesPositiveMaxHistory(t *testing.T) {
 
 // TestParseSessionConfigLeaseTTLAndBootGrace covers parsing/validation of
 // session_lease_ttl and session_boot_grace: malformed and zero values are
-// rejected, empty values default to 45s/60s, and explicit values are preserved.
+// rejected, empty values default to 45s/60s, explicit values are preserved, and
+// values below 2× the gateway refresh cadence (the 30s floor, holomush-rsoe6.22)
+// are rejected to prevent the reaper sweeping a healthy connection between refreshes.
 func TestParseSessionConfigLeaseTTLAndBootGrace(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1172,6 +1174,14 @@ func TestParseSessionConfigLeaseTTLAndBootGrace(t *testing.T) {
 		{name: "rejects zero boot_grace", bootGrace: "0s", wantErrSubstr: "positive"},
 		{name: "empty values default to 45s/60s", wantLease: 45 * time.Second, wantBoot: 60 * time.Second},
 		{name: "explicit values preserved", leaseTTL: "2m", bootGrace: "3m", wantLease: 2 * time.Minute, wantBoot: 3 * time.Minute},
+		// holomush-rsoe6.22: lease/grace below 2× the gateway refresh cadence
+		// (session.DefaultLeaseRefreshInterval = 15s) let the reaper sweep a
+		// healthy connection between refreshes. Reject anything under the 30s floor.
+		{name: "rejects lease_ttl below 2x refresh cadence", leaseTTL: "20s", wantErrCode: "CONFIG_INVALID", wantErrSubstr: "cadence"},
+		{name: "rejects boot_grace below 2x refresh cadence", bootGrace: "20s", wantErrCode: "CONFIG_INVALID", wantErrSubstr: "cadence"},
+		// Both below floor: the lease check runs first, so its error wins.
+		{name: "rejects when both below floor — lease error wins", leaseTTL: "20s", bootGrace: "20s", wantErrCode: "CONFIG_INVALID", wantErrSubstr: "lease TTL"},
+		{name: "accepts lease_ttl and boot_grace at the 2x cadence floor", leaseTTL: "30s", bootGrace: "30s", wantLease: 30 * time.Second, wantBoot: 30 * time.Second},
 	}
 
 	for _, tt := range tests {

--- a/internal/session/reaper.go
+++ b/internal/session/reaper.go
@@ -11,6 +11,19 @@ import (
 	"github.com/samber/oops"
 )
 
+// DefaultLeaseRefreshInterval is the cadence at which a live gateway connection
+// refreshes its server-side lease (CoreService.RefreshConnection → last_seen_at).
+// Both the web StreamEvents heartbeat (internal/web) and the telnet lease-refresh
+// ticker (internal/telnet) default to this value — this constant is their single
+// source of truth.
+//
+// It is the floor the session reaper's LeaseTTL and BootGrace must clear: a
+// healthy connection only touches last_seen_at once per interval, so a LeaseTTL
+// at or below it can lapse between refreshes, and a BootGrace below it lets the
+// post-restart sweep fire before any surviving gateway re-asserts (I-LIVE-4).
+// parseSessionConfig (cmd/holomush) rejects lease/grace below 2× this value.
+const DefaultLeaseRefreshInterval = 15 * time.Second
+
 // ReaperConfig configures the session reaper.
 type ReaperConfig struct {
 	Interval  time.Duration    // how often to check for expired sessions

--- a/internal/telnet/limits.go
+++ b/internal/telnet/limits.go
@@ -3,7 +3,11 @@
 
 package telnet
 
-import "time"
+import (
+	"time"
+
+	"github.com/holomush/holomush/internal/session"
+)
 
 // Limits bounds per-connection resource use. Zero values in a Limits value
 // are NOT interpreted as "unlimited" — callers MUST populate the struct
@@ -28,8 +32,9 @@ type Limits struct {
 	// RPCs while the connection is authenticated (holomush-rsoe6, I-LIVE-1).
 	// A live client refreshes the server-side lease at this interval, keeping
 	// the connection visible to the liveness sweep. MUST be well under the
-	// sweep's LeaseTTL (default 45 s) so at least one refresh fires per
-	// window. Defaults to 15 s in DefaultLimits.
+	// sweep's LeaseTTL so at least one refresh fires per window; parseSessionConfig
+	// (cmd/holomush) enforces LeaseTTL/BootGrace ≥ 2× this interval. Defaults to
+	// session.DefaultLeaseRefreshInterval (15 s) in DefaultLimits.
 	LeaseRefreshInterval time.Duration
 }
 
@@ -39,5 +44,5 @@ var DefaultLimits = Limits{
 	IdleReadTimeout:      5 * time.Minute,
 	WriteTimeout:         30 * time.Second,
 	PreAuthTimeout:       2 * time.Minute,
-	LeaseRefreshInterval: 15 * time.Second,
+	LeaseRefreshInterval: session.DefaultLeaseRefreshInterval,
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/session"
 	contentv1 "github.com/holomush/holomush/pkg/proto/holomush/content/v1"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 	webv1 "github.com/holomush/holomush/pkg/proto/holomush/web/v1"
@@ -414,7 +415,7 @@ func (h *Handler) runSubscribeOnce(
 
 	hbInterval := h.heartbeatInterval
 	if hbInterval <= 0 {
-		hbInterval = 15 * time.Second
+		hbInterval = session.DefaultLeaseRefreshInterval
 	}
 	heartbeat := time.NewTicker(hbInterval)
 	defer heartbeat.Stop()


### PR DESCRIPTION
## Summary

`parseSessionConfig` only rejected *non-positive* `session_lease_ttl` / `session_boot_grace`. An operator could set either **below the 15s gateway refresh cadence**, so the session reaper's lease sweep (`reaper.go` — cutoff `now − LeaseTTL`) could remove a **healthy** connection between refreshes, or a `BootGrace` below the cadence let the post-restart sweep fire before a surviving gateway re-asserts its leases (the I-LIVE-4 guarantee). This is a self-inflicted liveness failure from misconfiguration.

This PR adds config validation and removes the duplicated cadence literal.

## Changes

- **`internal/session/reaper.go`** — new `DefaultLeaseRefreshInterval = 15 * time.Second`, the single source of truth for the gateway lease-refresh cadence (documents the reaper↔gateway contract).
- **`internal/web/handler.go`** — StreamEvents heartbeat fallback now references the const (was inline `15 * time.Second`).
- **`internal/telnet/limits.go`** — `DefaultLimits.LeaseRefreshInterval` now references the const; doc comment refreshed.
- **`cmd/holomush/core.go`** — `parseSessionConfig` rejects `lease_ttl`/`boot_grace` below **2× the cadence** (30s floor) with `oops.Code("CONFIG_INVALID")` and field metadata. Defaults (45s/60s) clear it comfortably.

## Design decisions (operator-confirmed)

- **Shared constant in `internal/session`** (the leaf package owning `LeaseTTL`/`BootGrace`) — eliminates the two duplicated `15s` magic numbers without crossing a service boundary (a const, not a service; gateway-boundary invariant intact, no import cycle).
- **2× cadence floor** (not just ≥ cadence) — gives a full refresh-cycle of jitter/latency margin so a healthy client is never reaped on a single late refresh.

## Test plan

- TDD: `TestParseSessionConfigLeaseTTLAndBootGrace` extended to 11 cases — below-floor rejection for each field, both-below ordering, and the exact 30s boundary accepted (red→green).
- `task test` across `cmd/holomush`, `internal/web`, `internal/telnet`, `internal/session` — all pass (const swap keeps web/telnet behavior identical at 15s).
- `task lint` exit 0; `task pr-prep` (fast lane) green.
- `code-reviewer`: **READY**, no blocking findings.

Closes holomush-rsoe6.22 (closes at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)