### PR TITLE
perf(web): bound the reconnect dedup window to a fixed LRU (holomush-rsoe6.21)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/getsentry/sentry-go/otel/otlp v0.46.2
 	github.com/go-viper/mapstructure/v2 v2.4.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-plugin v1.8.0 h1:ie8S6RRY8RvB2usYZv+AAZ/wBvx2AU5p5QeP5j/FORs=
 github.com/hashicorp/go-plugin v1.8.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/internal/web/dedup.go
+++ b/internal/web/dedup.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package web
+
+import (
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// reconnectDedupSize bounds the recent-event-id window used to suppress the
+// JetStream redelivery overlap after a core-stream reconnect. The overlap is
+// only the sent-but-unacked frames — core acks each delivery synchronously
+// after Send (internal/grpc/server.go dispatchDelivery), so the window is
+// single-digit frames in practice. 1024 is a generous bound that keeps
+// per-connection memory fixed regardless of stream lifetime (holomush-rsoe6.21).
+const reconnectDedupSize = 1024
+
+// reconnectDedup is a bounded recent-id set that guards against double-forwarding
+// the redelivery overlap when a core Subscribe stream reconnects. It replaces an
+// unbounded session-lifetime map so a long-lived, high-traffic stream cannot grow
+// per-connection memory without bound on the hot path.
+//
+// Not safe for concurrent use: each streamEvents call owns one instance, consulted
+// only on that call's single frame-forwarding goroutine.
+type reconnectDedup struct {
+	seen *lru.Cache[string, struct{}]
+}
+
+// newReconnectDedup returns a dedup window holding the most recent
+// reconnectDedupSize event ids.
+func newReconnectDedup() *reconnectDedup {
+	// lru.New only errors on size <= 0, and reconnectDedupSize is a positive
+	// constant, so this cannot fail. Panic (the regexp.MustCompile idiom) guards
+	// against a future edit that makes the size non-positive rather than handing
+	// back a nil cache that would nil-panic on first use.
+	seen, err := lru.New[string, struct{}](reconnectDedupSize)
+	if err != nil {
+		panic(fmt.Sprintf("web: reconnect dedup cache size %d invalid: %v", reconnectDedupSize, err))
+	}
+	return &reconnectDedup{seen: seen}
+}
+
+// seenOrRecord reports whether id was already forwarded within the recent window.
+// A new id is recorded (evicting the oldest once the window is full) and reported
+// unseen (false); an id already present is reported seen (true) so the caller skips
+// the redelivery. ContainsOrAdd does the check-then-record atomically and does not
+// refresh recency, so eviction stays insertion-ordered — correct here because the
+// overlap is always the most recent frames. The evicted bool is irrelevant to
+// dedup (the evicted id is, by construction, far older than any redelivery).
+func (d *reconnectDedup) seenOrRecord(id string) bool {
+	contained, _ := d.seen.ContainsOrAdd(id, struct{}{})
+	return contained
+}

--- a/internal/web/dedup_test.go
+++ b/internal/web/dedup_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package web
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReconnectDedupRecordsAndDeduplicates verifies the bounded reconnect-overlap
+// dedup window: a fresh id is reported unseen and recorded, a repeated id within
+// the window is reported seen (so the caller skips the JetStream redelivery), and
+// the window is bounded — ids beyond reconnectDedupSize are evicted rather than
+// retained for the stream's lifetime (holomush-rsoe6.21).
+func TestReconnectDedupRecordsAndDeduplicates(t *testing.T) {
+	// window holds 2× the bound so the eviction cases push the earliest ids out.
+	window := make([]string, 2*reconnectDedupSize)
+	for i := range window {
+		window[i] = fmt.Sprintf("evt-%06d", i)
+	}
+
+	tests := []struct {
+		name    string
+		prefill []string // ids recorded (in order) before the checked call
+		check   string   // id whose seenOrRecord return value is asserted
+		want    bool     // expected return: true == already seen within the window
+		msg     string
+	}{
+		{
+			name: "reports a fresh id as unseen", check: "evt-a", want: false,
+			msg: "first sighting of an id must be reported unseen",
+		},
+		{
+			name:    "reports a repeated id within the window as seen",
+			prefill: []string{"evt-a"}, check: "evt-a", want: true,
+			msg: "a repeated id must be reported seen so the redelivery is skipped",
+		},
+		{
+			// Recording 2× the bound evicts the earliest id; an unbounded map
+			// would still report it seen. seenOrRecord re-records it, but the
+			// asserted return value proves it was not retained.
+			name:    "evicts the earliest id beyond the bounded window",
+			prefill: window, check: "evt-000000", want: false,
+			msg: "an id beyond the bounded window must be evicted, not retained for the stream lifetime",
+		},
+		{
+			name:    "keeps the most-recently-recorded id within the window",
+			prefill: window, check: fmt.Sprintf("evt-%06d", 2*reconnectDedupSize-1), want: true,
+			msg: "the most-recently-recorded id must still be within the window",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newReconnectDedup()
+			for _, id := range tt.prefill {
+				d.seenOrRecord(id)
+			}
+			assert.Equal(t, tt.want, d.seenOrRecord(tt.check), tt.msg)
+		})
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -237,17 +237,16 @@ func (h *Handler) StreamEvents(ctx context.Context, req *connect.Request[webv1.S
 	var outageDeadline time.Time
 	backoff := 100 * time.Millisecond
 
-	// seen is the dedup set for the redelivery overlap after a reconnect. Core
-	// acks JetStream delivery AFTER Send, so only sent-but-unacked frames replay
-	// on resume — a small window. The set is session-lifetime for simplicity; if
-	// a single session ever forwards enough distinct events to make this a
-	// memory concern, bound it to a recent-id ring (follow-up).
-	seen := make(map[string]struct{})
-	var lastForwardedID string
+	// dedup suppresses the redelivery overlap after a reconnect. Core acks
+	// JetStream delivery AFTER Send, so only sent-but-unacked frames replay on
+	// resume — a small window. A bounded recent-id set (not an unbounded
+	// session-lifetime map) keeps per-connection memory fixed regardless of how
+	// many distinct events a long-lived stream forwards (holomush-rsoe6.21).
+	dedup := newReconnectDedup()
 	firstOpen := true
 
 	for {
-		cause, opened := h.runSubscribeOnce(ctx, sessionID, token, connID.String(), stream, firstOpen, seen, &lastForwardedID)
+		cause, opened := h.runSubscribeOnce(ctx, sessionID, token, connID.String(), stream, firstOpen, dedup)
 		if opened {
 			// A successful (re)open ends any outage: reset the per-outage budget
 			// and backoff so a later break gets a fresh ceiling (I-SURV-4 is a
@@ -312,9 +311,9 @@ func subscribeRecvErrIsTerminal(err error) bool {
 // runSubscribeOnce runs a single core Subscribe attempt to completion and
 // classifies why it ended. On a healthy open it sends STREAM_OPENED (first
 // attempt) or RECONNECTED (subsequent attempts), forwards frames (deduping the
-// redelivery overlap via seen), and runs the heartbeat/lease refresh. It owns a
-// per-attempt context so the spawned recv goroutine is always unblocked and
-// reaped when this function returns.
+// redelivery overlap via the bounded dedup window), and runs the heartbeat/lease
+// refresh. It owns a per-attempt context so the spawned recv goroutine is always
+// unblocked and reaped when this function returns.
 //
 // The returned bool (opened) reports whether this attempt successfully opened
 // the subscription AND sent its open frame (STREAM_OPENED or RECONNECTED). The
@@ -325,8 +324,7 @@ func (h *Handler) runSubscribeOnce(
 	sessionID, token, connID string,
 	stream *connect.ServerStream[webv1.StreamEventsResponse],
 	firstOpen bool,
-	seen map[string]struct{},
-	lastForwardedID *string,
+	dedup *reconnectDedup,
 ) (breakCause, bool) {
 	opened := false
 	// Per-attempt context: cancelling it on return unblocks the recv goroutine's
@@ -484,12 +482,8 @@ func (h *Handler) runSubscribeOnce(
 			// Dedup the redelivery overlap before forwarding. Only Event frames
 			// carry ids; Control frames pass straight through.
 			if ef, isEvent := result.resp.GetFrame().(*corev1.SubscribeResponse_Event); isEvent {
-				if id := ef.Event.GetId(); id != "" {
-					if _, dup := seen[id]; dup {
-						continue // already forwarded; skip the redelivery
-					}
-					seen[id] = struct{}{}
-					*lastForwardedID = id
+				if id := ef.Event.GetId(); id != "" && dedup.seenOrRecord(id) {
+					continue // already forwarded within the recent window; skip the redelivery
 				}
 			}
 			if fwdErr := h.forwardFrame(ctx, result.resp, stream, sessionID); fwdErr != nil {


### PR DESCRIPTION
## Summary

`StreamEvents` deduped the JetStream redelivery overlap after a core-stream reconnect using an **unbounded session-lifetime** `seen map[string]struct{}` — every distinct forwarded event id was retained for the stream's whole life, so a long-lived high-traffic web stream grew per-connection memory without bound on the hot path.

The dedup only needs to cover the redelivery overlap, and core acks each JetStream delivery **synchronously after Send** (`internal/grpc/server.go` `dispatchDelivery`), so the overlap is the sent-but-unacked window — single-digit frames. A small bounded window is therefore correct with enormous margin.

## Changes

- **`internal/web/dedup.go`** (new) — `reconnectDedup`, a bounded recent-id set over `hashicorp/golang-lru/v2` (`reconnectDedupSize = 1024`). `seenOrRecord` uses the library's atomic `ContainsOrAdd`; `Contains`-style check doesn't bump recency, so eviction is insertion-ordered (correct — the overlap is always the most recent frames).
- **`internal/web/handler.go`** — replaced the unbounded map with `*reconnectDedup`, threaded through `runSubscribeOnce` (dropped the `seen` map + `lastForwardedID` params). Removed the **dead write-only `lastForwardedID`** (set, never read).
- **`go.mod` / `go.sum`** — `github.com/hashicorp/golang-lru/v2 v2.0.7` (direct).

## Design decisions (operator-confirmed)

- **golang-lru/v2, N=1024** — overlap is single-digit frames, so 1024 is ~100×+ margin (no double-forward risk) while bounding memory to ~tens of KB/connection. `New`'s error is structurally impossible on a positive const size → guarded with the `regexp.MustCompile` panic idiom (errcheck `check-blank` is on).
- **Removed `lastForwardedID`** — confirmed write-only dead state; a future resume feature can reintroduce it with an actual reader.

## Test plan

- TDD: `TestReconnectDedupRecordsAndDeduplicates` — fresh-miss, repeat-hit, and bounded-eviction-past-the-window (red→green).
- `task test ./internal/web/` — 233 tests pass (the `runSubscribeOnce` reconnect paths exercise the dedup).
- `task lint` exit 0; `task pr-prep` (fast lane) green.
- `code-reviewer`: **READY**, no blocking findings (verified the bound is safe against the core ack path; applied the `ContainsOrAdd` atomic-method improvement).

Closes holomush-rsoe6.21 (closes at merge) — the last open child of epic holomush-rsoe6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)