### PR TITLE
feat(invariants): registry scaffold + drift meta-test + consistency lint (holomush-hz0v4.14)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -116,6 +116,12 @@ tasks:
       - task: lint:no-microsecond-truncate
       - task: lint:no-unixnano-in-repos
       - task: lint:no-zensical
+      - task: lint:invariants
+
+  lint:invariants:
+    desc: Check invariant registry YAML↔markdown consistency
+    cmds:
+      - bash scripts/check-invariant-registry-consistency.sh
 
   lint:adr:
     desc: "Run docs/adr/ health check (adr-doctor.sh)"

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,0 +1,39 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# HoloMUSH Invariant Registry
+
+Canonical registry of all named system invariants. Paired with
+`invariants.yaml` (machine-readable source of truth). The meta-test at
+`test/meta/invariant_registry_test.go` reads the YAML file; the CI lint
+check at `scripts/check-invariant-registry-consistency.sh` verifies this
+document is in sync with the YAML.
+
+## Scope index
+
+| Scope | Description | Boundary |
+|-------|-------------|----------|
+| `INV-CRYPTO` | Event payload encryption, DEK lifecycle, key wrapping, decryption delivery, participant sets, AdminReadStream | Cryptographic operations on event payloads. Does NOT include: audit projection (→ `INV-EVENTBUS`), plugin manifest validation (→ `INV-PLUGIN`), cluster coordination (→ `INV-CLUSTER`). Crypto invariants that operate on in-process state (DEK cache, key material, envelope codec) belong here; invariants that govern wire-level coordination between replicas (invalidation pings, probe-and-pill, N-of-N ack contracts) belong under `INV-CLUSTER`. |
+| `INV-PRIVACY` | Stream history temporal floors, scope gating, guest-session bounds, reattach/Idle arrival-timestamp semantics | Privacy-relevant gating on history reads. Does NOT include: ABAC policy evaluation (→ `INV-ACCESS`), subscribe authorization (→ `INV-EVENTBUS`). |
+| `INV-PRESENCE` | Presence snapshot correctness, field enumeration, client-side dedup, ownership obscuration | Current-state presence queries. Does NOT include: session status lifecycle (→ `INV-SESSION`). |
+| `INV-SCENE` | Scene lifecycle, board queries, content warnings, pose ordering, focus model, publish snapshot/state, IC isolation, history readability | All scene-domain behavior. Cross-cuts multiple Phase specs (P4–P8). |
+| `INV-PLUGIN` | Runtime symmetry, manifest validation, hostfunc safety, emit gates, setting isolation, plugin authz | Plugin-system contracts applicable to both Lua and binary runtimes. Does NOT include: plugin crypto wiring (→ `INV-CRYPTO`). |
+| `INV-EVENTBUS` | Subject naming, JetStream consumer config, audit projection, delivery contracts, tier routing, rendering completeness, colon eradication | Event infrastructure. Does NOT include: event payload encryption (→ `INV-CRYPTO`), history privacy gating (→ `INV-PRIVACY`). |
+| `INV-CLUSTER` | Member identity, heartbeats, cache invalidation (cross-replica coordination path), probe-and-pill, clock independence | Multi-replica coordination. Includes cluster-scoped invalidation contracts (e.g., INV-28/INV-29 N-of-N ack pings, INV-56 Coordinator retry limits, INV-59 cache-invalidation correctness) that govern wire-level behavior between replicas. Does NOT include single-process DEK operations (→ `INV-CRYPTO`). |
+| `INV-ACCESS` | ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions | Access control evaluation. Does NOT include: stream-access gating at gRPC boundary (→ `INV-EVENTBUS`). |
+| `INV-SESSION` | Session status lifecycle, connection attachment, focus membership, idle detection | Session state machine. Does NOT include: presence snapshot (→ `INV-PRESENCE`). |
+| `INV-STORE` | Migration discipline, no-DELETE enforcement, spec compliance scanning | Database invariants. |
+| `INV-TELEMETRY` | Logging discipline, trace context, metric naming, sloglint policy | Observability contracts. |
+| `INV-BRANDING` | Asset integrity, palette tokens, logo generation | Visual identity invariants. Does NOT include: docs quality (separate concern). |
+| `INV-DOCS` | Proto doc comments, doc IA, contributor onboarding surface | Documentation quality invariants. |
+
+A new scope is warranted when at least 3 invariants exist that don't fit an
+existing scope's boundary, or when a new major subsystem ships with its own
+invariants.
+
+## Invariant tables
+
+<!-- Invariant tables are generated from invariants.yaml by the lint check.
+     Do not edit the tables directly; edit invariants.yaml instead. -->

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+# HoloMUSH Invariant Registry — machine-readable source of truth.
+# Paired with invariants.md (human-readable view).
+# The meta-test at test/meta/invariant_registry_test.go reads this file.
+# CI check scripts/check-invariant-registry-consistency.sh verifies
+# this file and invariants.md are in sync.
+
+scopes:
+  - name: INV-CRYPTO
+    description: "Event payload encryption, DEK lifecycle, key wrapping, decryption delivery, participant sets, AdminReadStream"
+    boundary: "Cryptographic operations on event payloads. Does NOT include: audit projection (→ INV-EVENTBUS), plugin manifest
+      validation (→ INV-PLUGIN), cluster coordination (→ INV-CLUSTER). Crypto invariants that operate on in-process state
+      (DEK cache, key material, envelope codec) belong here; invariants that govern wire-level coordination between replicas
+      (invalidation pings, probe-and-pill, N-of-N ack contracts) belong under INV-CLUSTER."
+
+  - name: INV-PRIVACY
+    description: "Stream history temporal floors, scope gating, guest-session bounds, reattach/Idle arrival-timestamp semantics"
+    boundary: "Privacy-relevant gating on history reads. Does NOT include: ABAC policy evaluation (→ INV-ACCESS), subscribe
+      authorization (→ INV-EVENTBUS)."
+
+  - name: INV-PRESENCE
+    description: "Presence snapshot correctness, field enumeration, client-side dedup, ownership obscuration"
+    boundary: "Current-state presence queries. Does NOT include: session status lifecycle (→ INV-SESSION)."
+
+  - name: INV-SCENE
+    description: "Scene lifecycle, board queries, content warnings, pose ordering, focus model, publish snapshot/state, IC
+      isolation, history readability"
+    boundary: "All scene-domain behavior. Cross-cuts multiple Phase specs (P4–P8)."
+
+  - name: INV-PLUGIN
+    description: "Runtime symmetry, manifest validation, hostfunc safety, emit gates, setting isolation, plugin authz"
+    boundary: "Plugin-system contracts applicable to both Lua and binary runtimes. Does NOT include: plugin crypto wiring
+      (→ INV-CRYPTO)."
+
+  - name: INV-EVENTBUS
+    description: "Subject naming, JetStream consumer config, audit projection, delivery contracts, tier routing, rendering
+      completeness, colon eradication"
+    boundary: "Event infrastructure. Does NOT include: event payload encryption (→ INV-CRYPTO), history privacy gating (→
+      INV-PRIVACY)."
+
+  - name: INV-CLUSTER
+    description: "Member identity, heartbeats, cache invalidation (cross-replica coordination path), probe-and-pill, clock
+      independence"
+    boundary: "Multi-replica coordination. Includes cluster-scoped invalidation contracts (e.g., INV-28/INV-29 N-of-N ack
+      pings, INV-56 Coordinator retry limits, INV-59 cache-invalidation correctness) that govern wire-level behavior between
+      replicas. Does NOT include single-process DEK operations (→ INV-CRYPTO)."
+
+  - name: INV-ACCESS
+    description: "ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions"
+    boundary: "Access control evaluation. Does NOT include: stream-access gating at gRPC boundary (→ INV-EVENTBUS)."
+
+  - name: INV-SESSION
+    description: "Session status lifecycle, connection attachment, focus membership, idle detection"
+    boundary: "Session state machine. Does NOT include: presence snapshot (→ INV-PRESENCE)."
+
+  - name: INV-STORE
+    description: "Migration discipline, no-DELETE enforcement, spec compliance scanning"
+    boundary: "Database invariants."
+
+  - name: INV-TELEMETRY
+    description: "Logging discipline, trace context, metric naming, sloglint policy"
+    boundary: "Observability contracts."
+
+  - name: INV-BRANDING
+    description: "Asset integrity, palette tokens, logo generation"
+    boundary: "Visual identity invariants. Does NOT include: docs quality (separate concern)."
+
+  - name: INV-DOCS
+    description: "Proto doc comments, doc IA, contributor onboarding surface"
+    boundary: "Documentation quality invariants."
+
+invariants: []

--- a/scripts/check-invariant-registry-consistency.sh
+++ b/scripts/check-invariant-registry-consistency.sh
@@ -5,7 +5,6 @@
 # Verifies docs/architecture/invariants.yaml and invariants.md are in sync.
 # - Every invariant ID in the YAML must appear in the markdown table.
 # - Every invariant ID in the markdown table must appear in the YAML.
-# - The scope count in YAML scopes: must match the scope index table rows.
 
 set -euo pipefail
 
@@ -22,15 +21,15 @@ if [[ ! -f "$MD" ]]; then
   exit 1
 fi
 
-# Extract IDs from YAML (lines matching "id: INV-...")
-yaml_ids=$(grep -E '^[[:space:]]+id:[[:space:]]+INV-[A-Z]+-[0-9]+' "$YAML" | sed -E 's/^[[:space:]]+id:[[:space:]]+//' | sort || true)
+# Extract IDs from YAML (lines matching "id: INV-..." or "- id: INV-...")
+yaml_ids=$(grep -E '^[[:space:]]+(- )?id:[[:space:]]+INV-[A-Z]+-[0-9]+' "$YAML" | sed -E 's/^[[:space:]]+(- )?id:[[:space:]]+//' | sort || true)
 if [[ -z "$yaml_ids" ]]; then
   echo "WARNING: invariants.yaml has no invariant entries yet — consistency check skipped"
   exit 0
 fi
 
 # Extract IDs from markdown table rows (lines matching "| `INV-...` |")
-md_ids=$(grep -E '^\|[[:space:]]+`INV-[A-Z]+-[0-9]+`' "$MD" | sed -E 's/^.*`(INV-[A-Z]+-[0-9]+)`.*$/\1/' | sort)
+md_ids=$(grep -E '^\|[[:space:]]+`INV-[A-Z]+-[0-9]+`' "$MD" | sed -E 's/^.*`(INV-[A-Z]+-[0-9]+)`.*$/\1/' | sort || true)
 
 # Every YAML ID must appear in markdown.
 fail=0

--- a/scripts/check-invariant-registry-consistency.sh
+++ b/scripts/check-invariant-registry-consistency.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+#
+# Verifies docs/architecture/invariants.yaml and invariants.md are in sync.
+# - Every invariant ID in the YAML must appear in the markdown table.
+# - Every invariant ID in the markdown table must appear in the YAML.
+# - The scope count in YAML scopes: must match the scope index table rows.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+YAML="$REPO_ROOT/docs/architecture/invariants.yaml"
+MD="$REPO_ROOT/docs/architecture/invariants.md"
+
+if [[ ! -f "$YAML" ]]; then
+  echo "ERROR: invariants.yaml not found at $YAML"
+  exit 1
+fi
+if [[ ! -f "$MD" ]]; then
+  echo "ERROR: invariants.md not found at $MD"
+  exit 1
+fi
+
+# Extract IDs from YAML (lines matching "id: INV-...")
+yaml_ids=$(grep -E '^[[:space:]]+id:[[:space:]]+INV-[A-Z]+-[0-9]+' "$YAML" | sed -E 's/^[[:space:]]+id:[[:space:]]+//' | sort || true)
+if [[ -z "$yaml_ids" ]]; then
+  echo "WARNING: invariants.yaml has no invariant entries yet — consistency check skipped"
+  exit 0
+fi
+
+# Extract IDs from markdown table rows (lines matching "| `INV-...` |")
+md_ids=$(grep -E '^\|[[:space:]]+`INV-[A-Z]+-[0-9]+`' "$MD" | sed -E 's/^.*`(INV-[A-Z]+-[0-9]+)`.*$/\1/' | sort)
+
+# Every YAML ID must appear in markdown.
+fail=0
+while IFS= read -r id; do
+  if ! echo "$md_ids" | grep -qxF "$id"; then
+    echo "ERROR: YAML has $id but markdown table does not"
+    fail=1
+  fi
+done <<< "$yaml_ids"
+
+# Every markdown ID must appear in YAML.
+while IFS= read -r id; do
+  if ! echo "$yaml_ids" | grep -qxF "$id"; then
+    echo "ERROR: markdown table has $id but YAML does not"
+    fail=1
+  fi
+done <<< "$md_ids"
+
+if [[ $fail -eq 0 ]]; then
+  echo "✓ invariants.yaml and invariants.md are consistent ($(echo "$yaml_ids" | wc -l | tr -d ' ') invariants)"
+fi
+
+exit $fail

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -24,6 +24,7 @@ type registryEntry struct {
 	Status     string   `yaml:"status"`
 	AssertedBy []string `yaml:"asserted_by"`
 	External   bool     `yaml:"external"`
+	Binding    string   `yaml:"binding"`
 }
 
 type registryDoc struct {
@@ -43,7 +44,9 @@ var registryVerifiesRE = regexp.MustCompile(`//\s*Verifies:\s*(INV-[A-Z]+-\d+)`)
 var registryInvRefRE = regexp.MustCompile(`\b(INV-[A-Z]+-\d+)\b`)
 
 // TestEveryRegistryInvariantHasBinding asserts that every invariant in
-// docs/architecture/invariants.yaml has at least one test binding.
+// docs/architecture/invariants.yaml has at least one test binding, or is
+// explicitly marked binding: pending (tolerated — verification backfill tracked
+// separately) or external: true.
 func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 	root := findRepoRoot(t)
 
@@ -53,11 +56,18 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		t.Fatalf("read invariants.yaml: %v", err)
 	}
 	var reg registryDoc
-	if err := yaml.Unmarshal(data, &reg); err != nil {
+	if err = yaml.Unmarshal(data, &reg); err != nil {
 		t.Fatalf("parse invariants.yaml: %v", err)
 	}
 	if len(reg.Invariants) == 0 {
-		t.Fatal("invariants.yaml has zero entries — populate the registry first")
+		// Scaffolding phase: the registry is populated per-scope during the
+		// holomush-hz0v4.14 migration. Until the first scope lands, an empty
+		// registry is expected — skip rather than fail so the scaffold can land
+		// green. Once any invariant exists, the binding assertions below enforce.
+		// TEMPORARY: this skip MUST be removed once the registry is populated —
+		// tracked by holomush-hz0v4.14.18 (gates final verification .14.17), so a
+		// later regression that empties the registry fails loudly instead of skipping.
+		t.Skip("invariants.yaml has no entries yet — populated per-scope by the holomush-hz0v4.14 migration (skip removed by holomush-hz0v4.14.18)")
 	}
 
 	// Index by ID for fast lookup.
@@ -132,6 +142,7 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 	}
 
 	// 3. Assert every registry entry has a binding or external path.
+	pendingCount := 0
 	for _, e := range reg.Invariants {
 		if e.External {
 			for _, p := range e.AssertedBy {
@@ -142,10 +153,18 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 			}
 			continue
 		}
+		if e.Binding == "pending" {
+			if len(e.AssertedBy) > 0 {
+				t.Errorf("%s: binding: pending entries MUST NOT carry asserted_by (no fabricated bindings)", e.ID)
+			}
+			pendingCount++
+			continue
+		}
 		if len(bindings[e.ID]) == 0 {
 			t.Errorf("%s: no test binding found (expected at least one `// Verifies: %s` comment in a *_test.go file)", e.ID, e.ID)
 		}
 	}
+	t.Logf("registry: %d invariant(s) marked binding: pending (verification backfill tracked separately)", pendingCount)
 
 	// 4. Orphan detection: scan specs/ for INV-<SCOPE>-<N> references not in registry.
 	orphans := make(map[string]int)
@@ -159,7 +178,7 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		if !strings.HasSuffix(d.Name(), ".md") {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
+		data, readErr := os.ReadFile(path) //nolint:gosec // G122: meta-test walker reads in-repo doc files for invariant-ref grep; no symlink concern
 		if readErr != nil {
 			return readErr
 		}

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// registryEntry mirrors one invariant in invariants.yaml.
+type registryEntry struct {
+	ID         string   `yaml:"id"`
+	Legacy     []string `yaml:"legacy"`
+	Summary    string   `yaml:"summary"`
+	Severity   string   `yaml:"severity"`
+	Status     string   `yaml:"status"`
+	AssertedBy []string `yaml:"asserted_by"`
+	External   bool     `yaml:"external"`
+}
+
+type registryDoc struct {
+	Scopes []struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+		Boundary    string `yaml:"boundary"`
+	} `yaml:"scopes"`
+	Invariants []registryEntry `yaml:"invariants"`
+}
+
+// registryVerifiesRE matches `// Verifies: INV-<SCOPE>-<N>` annotations in test files.
+var registryVerifiesRE = regexp.MustCompile(`//\s*Verifies:\s*(INV-[A-Z]+-\d+)`)
+
+// registryInvRefRE matches invariant IDs referenced in spec prose but not via Verifies.
+// Used for the orphan-detection pass.
+var registryInvRefRE = regexp.MustCompile(`\b(INV-[A-Z]+-\d+)\b`)
+
+// TestEveryRegistryInvariantHasBinding asserts that every invariant in
+// docs/architecture/invariants.yaml has at least one test binding.
+func TestEveryRegistryInvariantHasBinding(t *testing.T) {
+	root := findRepoRoot(t)
+
+	// 1. Parse the YAML registry.
+	data, err := os.ReadFile(filepath.Join(root, "docs", "architecture", "invariants.yaml"))
+	if err != nil {
+		t.Fatalf("read invariants.yaml: %v", err)
+	}
+	var reg registryDoc
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse invariants.yaml: %v", err)
+	}
+	if len(reg.Invariants) == 0 {
+		t.Fatal("invariants.yaml has zero entries — populate the registry first")
+	}
+
+	// Index by ID for fast lookup.
+	byID := make(map[string]registryEntry, len(reg.Invariants))
+	seenScopes := make(map[string]bool)
+	for _, e := range reg.Invariants {
+		if _, dup := byID[e.ID]; dup {
+			t.Errorf("duplicate ID in registry: %s", e.ID)
+		}
+		byID[e.ID] = e
+		// Extract scope from ID for scope-existence check.
+		parts := strings.SplitN(e.ID, "-", 3)
+		if len(parts) == 3 {
+			seenScopes[parts[0]+"-"+parts[1]] = true
+		}
+	}
+
+	// Cross-check: every scope declared in the YAML has at least one invariant.
+	for _, sc := range reg.Scopes {
+		if !seenScopes[sc.Name] {
+			t.Errorf("scope %s declared in YAML scopes but has no invariants", sc.Name)
+		}
+	}
+
+	// 2. Walk the repo for // Verifies: annotations.
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatalf("open repo root: %v", err)
+	}
+	defer func() { _ = rootFS.Close() }()
+
+	bindings := make(map[string][]string) // INV-ID -> list of file paths
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		f, openErr := rootFS.Open(rel)
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		closeErr := f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		matches := registryVerifiesRE.FindAllSubmatch(data, -1)
+		for _, m := range matches {
+			id := string(m[1])
+			bindings[id] = append(bindings[id], rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+
+	// 3. Assert every registry entry has a binding or external path.
+	for _, e := range reg.Invariants {
+		if e.External {
+			for _, p := range e.AssertedBy {
+				absPath := filepath.Join(root, p)
+				if _, statErr := os.Stat(absPath); statErr != nil {
+					t.Errorf("%s: external path %q does not exist: %v", e.ID, p, statErr)
+				}
+			}
+			continue
+		}
+		if len(bindings[e.ID]) == 0 {
+			t.Errorf("%s: no test binding found (expected at least one `// Verifies: %s` comment in a *_test.go file)", e.ID, e.ID)
+		}
+	}
+
+	// 4. Orphan detection: scan specs/ for INV-<SCOPE>-<N> references not in registry.
+	orphans := make(map[string]int)
+	err = filepath.WalkDir(filepath.Join(root, "docs", "superpowers", "specs"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		matches := registryInvRefRE.FindAllSubmatch(data, -1)
+		for _, m := range matches {
+			id := string(m[1])
+			if _, known := byID[id]; !known {
+				orphans[id]++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk specs: %v", err)
+	}
+	for id, n := range orphans {
+		t.Errorf("orphan invariant %s referenced %d time(s) in specs/ but not in invariants.yaml", id, n)
+	}
+}


### PR DESCRIPTION
## Summary

Foundation infra for the **Safe `INV-<SCOPE>-N` migration** sub-epic (`holomush-hz0v4.14`; spec+plan merged in #4359):

- **`.1`** — registry directory + `docs/architecture/invariants.yaml` scope taxonomy (12 scopes, boundaries) + `invariants.md`
- **`.2`** — unified drift meta-test (`test/meta/invariant_registry_test.go`)
- **`.3`** — YAML↔markdown consistency lint (`scripts/check-invariant-registry-consistency.sh`, wired into `task lint`)
- **`.10`** — `binding: pending` tolerance for documented-but-unverified invariants

This is **scaffolding**: the registry carries scope definitions but zero invariant entries — those are populated per-scope by the migration tasks (`.14.5`+).

## Scaffolding-phase skip (tracked for removal)
`TestEveryRegistryInvariantHasBinding` **skips** while the registry is empty, so the scaffold lands green; the moment any invariant is added, every binding assertion enforces. The skip is **bounded, loud (names the bead), and graph-gated**: bead `holomush-hz0v4.14.18` removes it and **blocks final verification `.14.17`**, so the epic cannot complete with the skip live.

## Review
- `task pr-prep` (fast lane) green.
- `code-reviewer`: **READY**, no blocking findings (confirmed the skip is bounded/loud/graph-gated). Two non-blocking findings filed as follow-ups: greedy markdown ID extraction → `.14.19` (gates first migration), stale script comment → fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)