### PR TITLE
feat(invariants): registry migration foundation — schema, map, tool, guard (holomush-hz0v4.14.1-.4)

### DIFF
--- a/cmd/inv-migrate/main.go
+++ b/cmd/inv-migrate/main.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ref struct {
+	File  string `yaml:"file"`
+	Token string `yaml:"token"`
+}
+type entry struct {
+	ID    string `yaml:"id"`
+	Scope string `yaml:"scope"`
+	Refs  []ref  `yaml:"refs"`
+}
+type doc struct {
+	Invariants []entry `yaml:"invariants"`
+}
+
+func main() {
+	scope := flag.String("scope", "", "scope to migrate, e.g. INV-PRESENCE")
+	regPath := flag.String("registry", "docs/architecture/invariants.yaml", "registry path")
+	dry := flag.Bool("dry-run", false, "print planned rewrites without writing")
+	flag.Parse()
+	if *scope == "" {
+		fmt.Fprintln(os.Stderr, "inv-migrate: -scope is required")
+		os.Exit(2)
+	}
+	data, err := os.ReadFile(*regPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var d doc
+	if err = yaml.Unmarshal(data, &d); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var plan []rewrite
+	for _, e := range d.Invariants {
+		if e.Scope != *scope {
+			continue
+		}
+		for _, rf := range e.Refs {
+			plan = append(plan, rewrite{File: rf.File, Token: rf.Token, Canonical: e.ID})
+		}
+	}
+	if *dry {
+		for _, r := range plan {
+			fmt.Printf("%s: %s -> %s\n", r.File, r.Token, r.Canonical)
+		}
+		return
+	}
+	n, err := rewriteAll(plan)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("inv-migrate %s: %d files rewritten\n", *scope, n)
+}

--- a/cmd/inv-migrate/migrate.go
+++ b/cmd/inv-migrate/migrate.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+// Command inv-migrate rewrites in-code invariant annotations from a legacy
+// token to the canonical INV-<SCOPE>-N id, driven entirely by the registry's
+// recorded {file, token} refs. It NEVER matches on bare INV-N across the tree;
+// it only touches sites the registry recorded. See
+// docs/superpowers/specs/2026-06-01-invariant-registry-migration-redesign.md.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// rewrite is one recorded site: replace whole-token Token with Canonical in File.
+type rewrite struct {
+	File      string
+	Token     string
+	Canonical string
+}
+
+// rewriteAll applies each rewrite to its file. Whole-token match only (so INV-3
+// never matches inside INV-31). Idempotent: a file whose Token is already absent
+// is left unchanged. Returns the count of files actually modified. A recorded
+// file that does not exist is an error (the registry is stale — fail loud).
+func rewriteAll(plan []rewrite) (int, error) {
+	changed := 0
+	for _, r := range plan {
+		data, err := os.ReadFile(r.File)
+		if err != nil {
+			return changed, fmt.Errorf("recorded ref unreadable %s: %w", r.File, err)
+		}
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(r.Token) + `\b`)
+		out := re.ReplaceAll(data, []byte(r.Canonical))
+		if bytes.Equal(out, data) {
+			continue
+		}
+		if err := os.WriteFile(r.File, out, 0o644); err != nil { //nolint:gosec // G306: source files are 0644 by repo convention
+			return changed, fmt.Errorf("write %s: %w", r.File, err)
+		}
+		changed++
+	}
+	return changed, nil
+}

--- a/cmd/inv-migrate/migrate.go
+++ b/cmd/inv-migrate/migrate.go
@@ -24,14 +24,15 @@ type rewrite struct {
 
 // rewriteAll applies each rewrite to its file. Whole-token match only (so INV-3
 // never matches inside INV-31). Idempotent: a file whose Token is already absent
-// is left unchanged. Returns the count of files actually modified. A recorded
-// file that does not exist is an error (the registry is stale — fail loud).
+// is left unchanged. Returns the count of DISTINCT files actually modified (a
+// file with multiple recorded token rewrites counts once). A recorded file that
+// does not exist is an error (the registry is stale — fail loud).
 func rewriteAll(plan []rewrite) (int, error) {
-	changed := 0
+	changedFiles := map[string]bool{}
 	for _, r := range plan {
 		data, err := os.ReadFile(r.File)
 		if err != nil {
-			return changed, fmt.Errorf("recorded ref unreadable %s: %w", r.File, err)
+			return len(changedFiles), fmt.Errorf("recorded ref unreadable %s: %w", r.File, err)
 		}
 		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(r.Token) + `\b`)
 		out := re.ReplaceAll(data, []byte(r.Canonical))
@@ -39,9 +40,9 @@ func rewriteAll(plan []rewrite) (int, error) {
 			continue
 		}
 		if err := os.WriteFile(r.File, out, 0o644); err != nil { //nolint:gosec // G306: source files are 0644 by repo convention
-			return changed, fmt.Errorf("write %s: %w", r.File, err)
+			return len(changedFiles), fmt.Errorf("write %s: %w", r.File, err)
 		}
-		changed++
+		changedFiles[r.File] = true
 	}
-	return changed, nil
+	return len(changedFiles), nil
 }

--- a/cmd/inv-migrate/migrate_test.go
+++ b/cmd/inv-migrate/migrate_test.go
@@ -12,7 +12,9 @@ func TestRewriteScopeRewritesOnlyRecordedTokens(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "presence.go")
 	// INV-3 belongs to PRESENCE here; a stray INV-4 is NOT recorded and must be untouched.
-	os.WriteFile(src, []byte("// INV-3: snapshot\nx := 1 // INV-4: unrelated\n"), 0o600)
+	if err := os.WriteFile(src, []byte("// INV-3: snapshot\nx := 1 // INV-4: unrelated\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	plan := []rewrite{{File: src, Token: "INV-3", Canonical: "INV-PRESENCE-1"}}
 	changed, err := rewriteAll(plan)
@@ -22,7 +24,10 @@ func TestRewriteScopeRewritesOnlyRecordedTokens(t *testing.T) {
 	if changed != 1 {
 		t.Fatalf("want 1 file changed, got %d", changed)
 	}
-	got, _ := os.ReadFile(src)
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := "// INV-PRESENCE-1: snapshot\nx := 1 // INV-4: unrelated\n"
 	if string(got) != want {
 		t.Errorf("rewrite wrong:\n got %q\nwant %q", got, want)
@@ -32,7 +37,9 @@ func TestRewriteScopeRewritesOnlyRecordedTokens(t *testing.T) {
 func TestRewriteIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "p.go")
-	os.WriteFile(src, []byte("// INV-3: x\n"), 0o600)
+	if err := os.WriteFile(src, []byte("// INV-3: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	plan := []rewrite{{File: src, Token: "INV-3", Canonical: "INV-PRESENCE-1"}}
 	if _, err := rewriteAll(plan); err != nil {
 		t.Fatal(err)

--- a/cmd/inv-migrate/migrate_test.go
+++ b/cmd/inv-migrate/migrate_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRewriteScopeRewritesOnlyRecordedTokens(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "presence.go")
+	// INV-3 belongs to PRESENCE here; a stray INV-4 is NOT recorded and must be untouched.
+	os.WriteFile(src, []byte("// INV-3: snapshot\nx := 1 // INV-4: unrelated\n"), 0o600)
+
+	plan := []rewrite{{File: src, Token: "INV-3", Canonical: "INV-PRESENCE-1"}}
+	changed, err := rewriteAll(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed != 1 {
+		t.Fatalf("want 1 file changed, got %d", changed)
+	}
+	got, _ := os.ReadFile(src)
+	want := "// INV-PRESENCE-1: snapshot\nx := 1 // INV-4: unrelated\n"
+	if string(got) != want {
+		t.Errorf("rewrite wrong:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestRewriteIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "p.go")
+	os.WriteFile(src, []byte("// INV-3: x\n"), 0o600)
+	plan := []rewrite{{File: src, Token: "INV-3", Canonical: "INV-PRESENCE-1"}}
+	if _, err := rewriteAll(plan); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := rewriteAll(plan) // second run: token already gone
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed != 0 {
+		t.Errorf("re-run should change 0 files, changed %d", changed)
+	}
+}
+
+func TestRewriteRefusesMissingFile(t *testing.T) {
+	plan := []rewrite{{File: "/nope/missing.go", Token: "INV-3", Canonical: "INV-PRESENCE-1"}}
+	if _, err := rewriteAll(plan); err == nil {
+		t.Fatal("want error for missing recorded file, got nil")
+	}
+}

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -14,31 +14,201 @@ scopes:
       validation (→ INV-PLUGIN), cluster coordination (→ INV-CLUSTER). Crypto invariants that operate on in-process state
       (DEK cache, key material, envelope codec) belong here; invariants that govern wire-level coordination between replicas
       (invalidation pings, probe-and-pill, N-of-N ack contracts) belong under INV-CLUSTER."
+    # Family→scope evidence: bare INV-N (crypto payload/DEK/KEK/AAD) →
+    # 2026-04-25-event-payload-crypto-design.md; RB → 2026-05-25-plugin-readback-decrypt-design.md;
+    # P7 (crypto half) → 2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md.
+    # See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+      - "docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md"
+      - "docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md"
+    owned_paths:
+      - "internal/eventbus/crypto/**"
+      - "internal/eventbus/history/**"
+      - "internal/admin/readstream/**"
+      - "test/integration/crypto/**"
+      - "pkg/plugin/decrypt_client.go"
+      - "pkg/plugin/audit.go"
+      - "internal/plugin/cryptowiring/**"
+      - "internal/plugin/hostfunc/stdlib_audit.go"
+      - "internal/plugin/hostfunc/stdlib_audit_test.go"
+      - "internal/eventbus/authguard/**"
+      - "internal/eventbus/audit_row_access.go"
+      - "internal/eventbus/audit/**"
+      - "test/integration/privacy/scene_history_readback_test.go"
+    shared_files:
+      # CRYPTO+STORE: history files carrying both P7/RB and TS (nanos) annotations.
+      - "internal/eventbus/history/readback.go"
+      - "internal/eventbus/history/phase7_boundary_meta_test.go"
+      - "internal/eventbus/history/plugin_aad_reconstruction_test.go"
+      - "internal/eventbus/history/cold_postgres.go"
+      - "internal/eventbus/history/cold_postgres_integration_test.go"
+      - "internal/eventbus/history/plugin_aad_adapter.go"
+      # CRYPTO+SCENE: core-scenes files carrying both scene-domain and crypto annotations.
+      - "plugins/core-scenes/audit.go"
+      - "plugins/core-scenes/main.go"
+      - "plugins/core-scenes/main_test.go"
+      - "plugins/core-scenes/service.go"
+      - "plugins/core-scenes/publish_snapshot_integration_test.go"
+      - "plugins/core-scenes/publish_store.go"
+      - "internal/plugin/goplugin/host_service.go"
+      # CRYPTO+EVENTBUS+STORE: publisher carries GW + P7 + TS.
+      - "internal/eventbus/publisher.go"
+      - "internal/eventbus/types.go"
+      - "internal/eventbus/publisher_test.go"
+      # CRYPTO+ACCESS+SCENE+EVENTBUS+PLUGIN: the shared integration harness.
+      - "internal/testsupport/integrationtest/harness.go"
+      - "internal/testsupport/integrationtest/crypto.go"
 
   - name: INV-PRIVACY
     description: "Stream history temporal floors, scope gating, guest-session bounds, reattach/Idle arrival-timestamp semantics"
     boundary: "Privacy-relevant gating on history reads. Does NOT include: ABAC policy evaluation (→ INV-ACCESS), subscribe
       authorization (→ INV-EVENTBUS)."
+    # No legacy family migrates here in this pass; privacy invariants live in
+    # the history-scope spec and are asserted under test/integration/privacy/.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md"
+    owned_paths:
+      - "internal/grpc/scope_floor.go"
+    shared_files: []
 
   - name: INV-PRESENCE
     description: "Presence snapshot correctness, field enumeration, client-side dedup, ownership obscuration"
     boundary: "Current-state presence queries. Does NOT include: session status lifecycle (→ INV-SESSION)."
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-19-presence-snapshot-design.md"
+    owned_paths:
+      - "internal/grpc/focus/presence*.go"
+      - "test/integration/presence/**"
+    shared_files: []
 
   - name: INV-SCENE
     description: "Scene lifecycle, board queries, content warnings, pose ordering, focus model, publish snapshot/state, IC
       isolation, history readability"
     boundary: "All scene-domain behavior. Cross-cuts multiple Phase specs (P4–P8)."
+    # Families P4/P5/P6/FS/FW/Y5INX and the SH publish-driving harness. See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md"
+      - "docs/superpowers/specs/2026-05-21-scenes-phase-5-focus-model-and-multi-connection-visibility-design.md"
+      - "docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md"
+      - "docs/superpowers/specs/2026-05-28-focus-delta-coordinator-unification-design.md"
+      - "docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md"
+      - "docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md"
+    owned_paths:
+      - "plugins/core-scenes/**"
+      - "internal/grpc/focus/**"
+      - "internal/grpc/stream_registry*.go"
+      - "internal/grpc/focus_wiring*.go"
+      - "internal/grpc/scope_floor_test.go"
+      - "internal/plugin/lua/focus_ops_adapter.go"
+      - "internal/plugin/hostfunc/stdlib_focus.go"
+      - "internal/plugin/hostfunc/stdlib_focus_test.go"
+      - "pkg/plugin/focus_client.go"
+      - "test/integration/scenes/**"
+      - "test/meta/focus_delta_gate_test.go"
+      - "test/meta/scenes_phase6_invariants_test.go"
+      - "internal/test/invariants/inv_p5_coverage_meta_test.go"
+      - "internal/test/invariants/scene_no_abac_in_getposeorder_test.go"
+      - "internal/test/invariants/scene_resolver_no_poseorder_leak_test.go"
+    shared_files:
+      # SCENE+CRYPTO: see CRYPTO.shared_files (core-scenes audit/main/service/publish_store).
+      - "plugins/core-scenes/audit.go"
+      - "plugins/core-scenes/main.go"
+      - "plugins/core-scenes/main_test.go"
+      - "plugins/core-scenes/service.go"
+      - "plugins/core-scenes/publish_snapshot_integration_test.go"
+      - "plugins/core-scenes/publish_store.go"
+      # SCENE+SESSION: P5 focus-model annotations on session-domain files.
+      - "internal/session/session.go"
+      - "internal/session/connection_test.go"
+      - "internal/session/session_connection_mutator_test.go"
+      - "internal/store/session_store.go"
+      - "internal/store/session_store_integration_test.go"
+      # SCENE+STORE: server.go carries P5-11 + TS; privacy_test carries P4 + TS.
+      - "internal/grpc/server.go"
+      - "test/integration/privacy/privacy_test.go"
+      # SCENE+EVENTBUS: query_stream_history carries P4 + ROPS; the colon-eradication meta-tests carry P4 + ROPS.
+      - "internal/grpc/query_stream_history.go"
+      - "internal/grpc/stream_access.go"
+      - "internal/test/invariants/colon_eradication_test.go"
+      - "internal/test/invariants/inv_p4_coverage_meta_test.go"
+      # SCENE+EVENTBUS+PLUGIN: plugin subsystem carries FS + GW + PC.
+      - "internal/plugin/setup/subsystem.go"
+      - "internal/plugin/goplugin/host_service.go"
+      # Shared integration harness (see CRYPTO.shared_files).
+      - "internal/testsupport/integrationtest/harness.go"
 
   - name: INV-PLUGIN
     description: "Runtime symmetry, manifest validation, hostfunc safety, emit gates, setting isolation, plugin authz"
     boundary: "Plugin-system contracts applicable to both Lua and binary runtimes. Does NOT include: plugin crypto wiring
       (→ INV-CRYPTO)."
+    # Families PC (runtime config), W9ML (plugin identity), WS (whole-system load harness). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md"
+      - "docs/superpowers/specs/2026-05-04-legacy-id-elimination-design.md"
+      - "docs/superpowers/specs/2026-05-25-wholesystem-plugin-integration-design.md"
+    owned_paths:
+      - "internal/plugin/identity_registry.go"
+      - "internal/plugin/identity_registry_test.go"
+      - "internal/plugin/pluginauthz/**"
+      - "internal/store/plugin_repo.go"
+      - "internal/eventbus/proto_legacy_id_grep_test.go"
+      - "internal/eventbus/no_legacy_id_grep_test.go"
+      - "test/integration/wholesystem/**"
+      - "test/integration/plugin/**"
+    shared_files:
+      # PLUGIN+EVENTBUS: manager carries GW + W9ML.
+      - "internal/plugin/manager.go"
+      - "internal/plugin/manager_test.go"
+      # PLUGIN+SCENE+EVENTBUS: plugin subsystem (see SCENE.shared_files).
+      - "internal/plugin/setup/subsystem.go"
+      # Shared integration harness (see CRYPTO.shared_files).
+      - "internal/testsupport/integrationtest/harness.go"
 
   - name: INV-EVENTBUS
     description: "Subject naming, JetStream consumer config, audit projection, delivery contracts, tier routing, rendering
       completeness, colon eradication"
     boundary: "Event infrastructure. Does NOT include: event payload encryption (→ INV-CRYPTO), history privacy gating (→
       INV-PRIVACY)."
+    # Families GW (rendering completeness), ROPS (colon eradication), P7 (audit-plumbing half). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-04-26-gateway-verb-registry-sourcing.md"
+      - "docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md"
+      - "docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md"
+    owned_paths:
+      - "internal/eventbus/rendering_publisher*.go"
+      - "internal/gateway_invariants/**"
+      - "internal/gatewaymetrics/**"
+      - "internal/telnet/gateway_handler*.go"
+      - "internal/web/translate*.go"
+      - "internal/grpc/location_follow*.go"
+      - "internal/core/registry_test.go"
+      - "internal/core/exports_test.go"
+      - "test/integration/eventbus_e2e/rendering_completeness_test.go"
+      - "test/integration/streams/rops_test.go"
+      - "internal/grpc/stream_access_test.go"
+    shared_files:
+      # EVENTBUS+CRYPTO+STORE: publisher/types (see CRYPTO.shared_files).
+      - "internal/eventbus/publisher.go"
+      - "internal/eventbus/types.go"
+      - "internal/eventbus/publisher_test.go"
+      # EVENTBUS+SCENE: query_stream_history / stream_access / colon-eradication meta-tests (see SCENE.shared_files).
+      - "internal/grpc/query_stream_history.go"
+      - "internal/grpc/stream_access.go"
+      - "internal/test/invariants/colon_eradication_test.go"
+      - "internal/test/invariants/inv_p4_coverage_meta_test.go"
+      # EVENTBUS+PLUGIN: manager / subsystem (see PLUGIN.shared_files).
+      - "internal/plugin/manager.go"
+      - "internal/plugin/manager_test.go"
+      - "internal/plugin/setup/subsystem.go"
+      # Shared integration harness (see CRYPTO.shared_files).
+      - "internal/testsupport/integrationtest/harness.go"
 
   - name: INV-CLUSTER
     description: "Member identity, heartbeats, cache invalidation (cross-replica coordination path), probe-and-pill, clock
@@ -46,29 +216,114 @@ scopes:
     boundary: "Multi-replica coordination. Includes cluster-scoped invalidation contracts (e.g., INV-28/INV-29 N-of-N ack
       pings, INV-56 Coordinator retry limits, INV-59 cache-invalidation correctness) that govern wire-level behavior between
       replicas. Does NOT include single-process DEK operations (→ INV-CRYPTO)."
+    # bare INV-28/29/56/59 (cross-replica invalidation) defined in the master crypto spec
+    # but scoped to CLUSTER per the boundary note. See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    owned_paths:
+      - "internal/cluster/**"
+      - "internal/eventbus/crypto/invalidation/**"
+    shared_files: []
 
   - name: INV-ACCESS
     description: "ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions"
     boundary: "Access control evaluation. Does NOT include: stream-access gating at gRPC boundary (→ INV-EVENTBUS)."
+    # Family RA (real-ABAC harness). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    owned_paths:
+      - "internal/access/**"
+    shared_files:
+      # ACCESS+SCENE+CRYPTO+EVENTBUS+PLUGIN: shared integration harness (RA-4 site).
+      - "internal/testsupport/integrationtest/harness.go"
 
   - name: INV-SESSION
     description: "Session status lifecycle, connection attachment, focus membership, idle detection"
     boundary: "Session state machine. Does NOT include: presence snapshot (→ INV-PRESENCE)."
+    # Family M (remove session memstore). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-23-remove-session-memstore-design.md"
+    owned_paths:
+      - "internal/store/session_store_test.go"
+      - "internal/testsupport/sessiontest/**"
+    shared_files:
+      # SESSION+SCENE: P5 focus-model annotations on session-domain files (see SCENE.shared_files).
+      - "internal/session/session.go"
+      - "internal/session/connection_test.go"
+      - "internal/session/session_connection_mutator_test.go"
+      - "internal/store/session_store.go"
+      - "internal/store/session_store_integration_test.go"
 
   - name: INV-STORE
     description: "Migration discipline, no-DELETE enforcement, spec compliance scanning"
     boundary: "Database invariants."
+    # Family TS (nanosecond-timestamps migration discipline + pgnanos seam). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    owned_paths:
+      - "internal/pgnanos/**"
+      - "internal/store/migrations/**"
+      - "internal/store/migrate_inv_ts_integration_test.go"
+      - "internal/store/migrate_clamp_integration_test.go"
+      - "internal/store/lint_meta_test.go"
+      - "internal/store/spec_meta_test.go"
+      - "internal/store/no_delete_grep_test.go"
+    shared_files:
+      # STORE+CRYPTO: history files carrying TS + P7/RB (see CRYPTO.shared_files).
+      - "internal/eventbus/history/readback.go"
+      - "internal/eventbus/history/phase7_boundary_meta_test.go"
+      - "internal/eventbus/history/plugin_aad_reconstruction_test.go"
+      - "internal/eventbus/history/cold_postgres.go"
+      - "internal/eventbus/history/cold_postgres_integration_test.go"
+      - "internal/eventbus/history/plugin_aad_adapter.go"
+      # STORE+EVENTBUS+CRYPTO: publisher (see CRYPTO.shared_files).
+      - "internal/eventbus/publisher.go"
+      - "internal/eventbus/publisher_test.go"
+      # STORE+SCENE: server.go + privacy_test + core-scenes publish_store (see SCENE.shared_files).
+      - "internal/grpc/server.go"
+      - "test/integration/privacy/privacy_test.go"
+      - "plugins/core-scenes/publish_store.go"
+      # STORE+CRYPTO harness (TS in crypto integration harness).
+      - "internal/testsupport/integrationtest/crypto.go"
 
   - name: INV-TELEMETRY
     description: "Logging discipline, trace context, metric naming, sloglint policy"
     boundary: "Observability contracts."
+    # Family LOAD (load/perf harness latency+verdict). See redesign spec §2.1.
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    owned_paths:
+      - "internal/logging/**"
+      - "internal/telemetry/**"
+      - "test/load/**"
+    shared_files: []
 
   - name: INV-BRANDING
     description: "Asset integrity, palette tokens, logo generation"
     boundary: "Visual identity invariants. Does NOT include: docs quality (separate concern)."
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-28-holomush-software-brand-refresh-design.md"
+    owned_paths:
+      - "site/src/styles/custom.css"
+      - "site/src/assets/brand/**"
+      - "site/scripts/build-brand-assets.mjs"
+    shared_files: []
 
   - name: INV-DOCS
     description: "Proto doc comments, doc IA, contributor onboarding surface"
     boundary: "Documentation quality invariants."
+    status: pending
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-28-proto-doc-comments-design.md"
+    owned_paths:
+      - "test/meta/proto_doc_comments_test.go"
+      - "scripts/check-docs-ia.sh"
+    shared_files: []
 
 invariants: []

--- a/docs/superpowers/specs/2026-06-01-invariant-registry-migration-redesign.md
+++ b/docs/superpowers/specs/2026-06-01-invariant-registry-migration-redesign.md
@@ -144,6 +144,36 @@ NOT trusted): `P4/P5/P6/FS/FW → SCENE`; `RB → CRYPTO`; `GW → EVENTBUS`;
 `ROPS`, `Y5INX`, `W9ML`, `M`, `RA` are unclassified and MUST be resolved during
 classification.
 
+#### 2.1 Derived family→scope map (holomush-hz0v4.14.2)
+
+Re-derived from each family's defining spec (the spec whose prose *states* the
+invariant, not merely a spec that references it). Every row cites a verified
+origin-spec path and a one-line evidence note. Where a family splits across
+scopes, it appears on multiple rows.
+
+| Family | Scope | Origin spec (path) | Evidence (what in the spec establishes it) |
+| --- | --- | --- | --- |
+| P4 | INV-SCENE | `docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md` | §12 numbered-invariant table defines INV-P4-1..13: scene event subjects, pose-order gating, IC isolation — all scene-domain behavior. |
+| P5 | INV-SCENE | `docs/superpowers/specs/2026-05-21-scenes-phase-5-focus-model-and-multi-connection-visibility-design.md` | §10 defines INV-P5-1..14: focus-membership precondition, focus-key atomicity, terminal-only filter — the scene focus model. |
+| P6 | INV-SCENE | `docs/superpowers/specs/2026-05-23-scenes-phase-6-logs-vote-privacy-design.md` | §16 defines INV-P6-1..9: publication-vote roster, IsParticipant publish gate, archive-state transitions — scene logs/vote/privacy. |
+| FS | INV-SCENE | `docs/superpowers/specs/2026-05-28-focus-delta-coordinator-unification-design.md` | Table defines INV-FS-1..7: per-connection focus-delta delivery driven inside `focus.Coordinator` — the scene focus-delivery model (subsumes ex-ymgjs INV-FW-*). |
+| FW | INV-SCENE | `docs/superpowers/specs/2026-05-28-focus-delta-coordinator-unification-design.md` | INV-FW-1/2/4/5 are explicitly re-stated as INV-FS-2/4/5/6 ("ex-ymgjs INV-FW-N"); same focus-delivery domain. |
+| Y5INX | INV-SCENE | `docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md` | INV-Y5INX-1..4: `newSceneID()` bare ULID, scene readable via real RPC, join opens focus subscription, history-scope floor — scene identity/lifecycle. |
+| RB | INV-CRYPTO | `docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md` | INV-RB-1..10: host-side read-back decryption, DEK never reaches plugin, AAD round-trip, `plugin_decrypt` audit, downgrade/DEK-existence reuse — cryptographic operations on payloads. (RB-9 runtime symmetry is a property *of* the crypto primitive, not a plugin-system invariant.) |
+| P7 | INV-CRYPTO | `docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md` | SPLIT — crypto half: INV-P7-1,2,5,6,7,9,11,12,15,16 = ciphertext byte-equality, DEK-existence fence, downgrade refusal, AAD reconstruction, shared KeySelector. These are payload-encryption invariants (carry master INV-25/26/46/48/50 onto the plugin-routed path). |
+| P7 | INV-EVENTBUS | `docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md` | SPLIT — eventbus/audit-plumbing half: INV-P7-3,4,10 = plugin audit-table DEK columns + header parser + standalone migration ordering. These are audit-projection/dispatcher plumbing (host-owned-vs-plugin-owned audit), the INV-EVENTBUS "audit projection" surface. (INV-P7-13/14 plugin-role/sensitivity-gate are corroborating boundary checks that ride with the crypto half.) |
+| GW | INV-EVENTBUS | `docs/superpowers/specs/2026-04-26-gateway-verb-registry-sourcing.md` | INV-GW-1..16: verb-registry sourcing, `EMIT_UNKNOWN_VERB`/`EMIT_VALIDATION_FAILED` paths, rendering-field propagation, `events_audit.rendering` column, enum parity — event rendering-completeness, an INV-EVENTBUS surface. |
+| ROPS | INV-EVENTBUS | `docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md` | INV-ROPS-1..3: colon-style subjects survive only as ABAC policy-DSL identifiers; `QueryStreamHistory`/`Subscribe` qualify to dot-form; repo-wide scan fails CI on surviving colon streams — subject-naming/colon-eradication, INV-EVENTBUS. |
+| PC | INV-PLUGIN | `docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md` | INV-PC-1,8: host MUST NOT interpret plugin config-key meaning; `needsInit` gate includes `len(Config)>0` — plugin-system manifest/runtime contract. |
+| W9ML | INV-PLUGIN | `docs/superpowers/specs/2026-05-04-legacy-id-elimination-design.md` | INV-W9ML-1..8: uniform ULID identity per actor kind, `IdentityRegistry` resolution path, plugin-name uniqueness/stable-ULID across retention — plugin identity contract. (Spans store/eventbus annotation sites, but the invariant *is* plugin identity.) |
+| RA | INV-ACCESS | `docs/superpowers/specs/2026-05-26-harness-real-abac-design.md` | INV-RA-1..4: `WithRealABAC()` wires the real access engine and installs the `seed:*` policy set; allow-all retained without it — ABAC policy-evaluation harness wiring. |
+| TS | INV-STORE | `docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md` | INV-TS-1..7: all persistent time = `BIGINT` epoch-ns, no new `TIMESTAMPTZ` migrations, `pgnanos.Time` canonical scan/insert seam, no `Truncate(µs)` — migration discipline + storage seam. (Annotated widely because every nanos round-trip touches it; the invariant is database/storage.) |
+| M | INV-SESSION | `docs/superpowers/specs/2026-05-23-remove-session-memstore-design.md` | INV-M-1..4: `session.Store` has exactly one production impl (`PostgresSessionStore`), `sessiontest.NewStore` isolation, `client_type` rejection semantics — session-store state machine. |
+| WS | (test-infra) → INV-PLUGIN | `docs/superpowers/specs/2026-05-25-wholesystem-plugin-integration-design.md` | INV-WS-1..4: `WithInTreePlugins()` reuses `setup.PluginSubsystem`, asserts cross-plugin ABAC permit+forbid, not silently skipped, opt-in — whole-system plugin-load harness; owned under INV-PLUGIN (plugin-subsystem load discipline). |
+| LOAD | (test-infra) → INV-TELEMETRY | `docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md` | INV-LOAD-1..4: harness drives web/telnet tiers, latency thresholds, k6-exit-code verdict — load/perf observability harness; owned under INV-TELEMETRY (latency/metric verdicts). |
+| SH | (test-infra) → INV-SCENE | `docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md` | INV-SH-1..5: plugin-config overrides reach core-scenes, `SceneServiceClient` resolves the scene plugin, `CreateScene` returns a real ULID, zero production code, publish lifecycle E2E — scene publish-driving harness; owned under INV-SCENE. |
+| bare `INV-N` | per-origin-spec | `docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md` (master) + `docs/architecture/invariants.md`-tracked | NOT a single scope. INV-1..27/30..55 (crypto payload/DEK/KEK/AAD) → INV-CRYPTO (`internal/eventbus/crypto/**`, `internal/eventbus/history/**`). INV-28/29/56/59 (N-of-N invalidation ack, Coordinator retry, cache-invalidation correctness) → INV-CLUSTER (`internal/cluster/**`) per the existing INV-CLUSTER boundary note. Each bare token is scoped by *its* origin spec, not forced into one family. |
+
 ### 3. Per-ref classification
 
 For each scope, classification proceeds per reference using three signals, in

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -104,6 +104,33 @@ invariants:
 	}
 }
 
+// TestOwnedPathsPartition asserts that no path glob is claimed by two scopes'
+// owned_paths unless it appears in some scope's shared_files allowlist. This is
+// the deterministic F2 defense: owned_paths MUST partition the annotated tree
+// so a mislabeled annotation (e.g. a scene file stamped INV-CRYPTO-*) cannot
+// pass the provenance guard's ownership check.
+func TestOwnedPathsPartition(t *testing.T) {
+	reg := loadRegistry(t)
+	owner := map[string]string{} // path glob -> scope
+	shared := map[string]bool{}
+	for _, sc := range reg.Scopes {
+		for _, f := range sc.SharedFiles {
+			shared[f] = true
+		}
+	}
+	for _, sc := range reg.Scopes {
+		for _, p := range sc.OwnedPaths {
+			if shared[p] {
+				continue // explicitly shared; ownership waived
+			}
+			if prev, dup := owner[p]; dup {
+				t.Errorf("owned_paths overlap: %q owned by both %s and %s", p, prev, sc.Name)
+			}
+			owner[p] = sc.Name
+		}
+	}
+}
+
 // registryVerifiesRE matches `// Verifies: INV-<SCOPE>-<N>` annotations in test files.
 var registryVerifiesRE = regexp.MustCompile(`//\s*Verifies:\s*(INV-[A-Z]+-\d+)`)
 

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -4,6 +4,7 @@
 package meta
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -41,7 +42,7 @@ type scopeRecord struct {
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description"`
 	Boundary    string   `yaml:"boundary"`
-	Status      string   `yaml:"status"`       // pending | migrated
+	Status      string   `yaml:"status"` // pending | migrated
 	OriginSpecs []string `yaml:"origin_specs"`
 	OwnedPaths  []string `yaml:"owned_paths"`  // path globs; MAY target individual files
 	SharedFiles []string `yaml:"shared_files"` // exact paths annotating >1 scope
@@ -138,6 +139,60 @@ var registryVerifiesRE = regexp.MustCompile(`//\s*Verifies:\s*(INV-[A-Z]+-\d+)`)
 // Used for the orphan-detection pass.
 var registryInvRefRE = regexp.MustCompile(`\b(INV-[A-Z]+-\d+)\b`)
 
+// checkRegistryBindings validates registry structural invariants (duplicate IDs,
+// scope membership, binding presence, pending constraints, external path existence)
+// against the provided bindings map (INV-ID → []file paths). Returns findings as
+// strings so callers can either t.Error each finding (real-repo test) or assert
+// the count matches expectations (table-driven subtests).
+// root is used only for external path existence checks.
+func checkRegistryBindings(reg registryDoc, bindings map[string][]string, root string) []string {
+	var findings []string
+
+	// Check for duplicate IDs and build scope-membership index.
+	byID := make(map[string]registryEntry, len(reg.Invariants))
+	seenScopes := make(map[string]bool)
+	for _, e := range reg.Invariants {
+		if _, dup := byID[e.ID]; dup {
+			findings = append(findings, fmt.Sprintf("duplicate ID in registry: %s", e.ID))
+		}
+		byID[e.ID] = e
+		parts := strings.SplitN(e.ID, "-", 3)
+		if len(parts) == 3 {
+			seenScopes[parts[0]+"-"+parts[1]] = true
+		}
+	}
+
+	// Cross-check: every scope declared in the YAML has at least one invariant.
+	for _, sc := range reg.Scopes {
+		if !seenScopes[sc.Name] {
+			findings = append(findings, fmt.Sprintf("scope %s declared in YAML scopes but has no invariants", sc.Name))
+		}
+	}
+
+	// Assert every registry entry has a binding or external path.
+	for _, e := range reg.Invariants {
+		if e.External {
+			for _, p := range e.AssertedBy {
+				absPath := filepath.Join(root, p)
+				if _, statErr := os.Stat(absPath); statErr != nil {
+					findings = append(findings, fmt.Sprintf("%s: external path %q does not exist: %v", e.ID, p, statErr))
+				}
+			}
+			continue
+		}
+		if e.Binding == "pending" {
+			if len(e.AssertedBy) > 0 {
+				findings = append(findings, fmt.Sprintf("%s: binding: pending entries MUST NOT carry asserted_by (no fabricated bindings)", e.ID))
+			}
+			continue
+		}
+		if len(bindings[e.ID]) == 0 {
+			findings = append(findings, fmt.Sprintf("%s: no test binding found (expected at least one `// Verifies: %s` comment in a *_test.go file)", e.ID, e.ID))
+		}
+	}
+	return findings
+}
+
 // TestEveryRegistryInvariantHasBinding asserts that every invariant in
 // docs/architecture/invariants.yaml has at least one test binding, or is
 // explicitly marked binding: pending (tolerated — verification backfill tracked
@@ -163,28 +218,6 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		// tracked by holomush-hz0v4.14.18 (gates final verification .14.17), so a
 		// later regression that empties the registry fails loudly instead of skipping.
 		t.Skip("invariants.yaml has no entries yet — populated per-scope by the holomush-hz0v4.14 migration (skip removed by holomush-hz0v4.14.18)")
-	}
-
-	// Index by ID for fast lookup.
-	byID := make(map[string]registryEntry, len(reg.Invariants))
-	seenScopes := make(map[string]bool)
-	for _, e := range reg.Invariants {
-		if _, dup := byID[e.ID]; dup {
-			t.Errorf("duplicate ID in registry: %s", e.ID)
-		}
-		byID[e.ID] = e
-		// Extract scope from ID for scope-existence check.
-		parts := strings.SplitN(e.ID, "-", 3)
-		if len(parts) == 3 {
-			seenScopes[parts[0]+"-"+parts[1]] = true
-		}
-	}
-
-	// Cross-check: every scope declared in the YAML has at least one invariant.
-	for _, sc := range reg.Scopes {
-		if !seenScopes[sc.Name] {
-			t.Errorf("scope %s declared in YAML scopes but has no invariants", sc.Name)
-		}
 	}
 
 	// 2. Walk the repo for // Verifies: annotations.
@@ -217,7 +250,7 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		if openErr != nil {
 			return openErr
 		}
-		data, readErr := io.ReadAll(f)
+		fileData, readErr := io.ReadAll(f)
 		closeErr := f.Close()
 		if readErr != nil {
 			return readErr
@@ -225,7 +258,7 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		if closeErr != nil {
 			return closeErr
 		}
-		matches := registryVerifiesRE.FindAllSubmatch(data, -1)
+		matches := registryVerifiesRE.FindAllSubmatch(fileData, -1)
 		for _, m := range matches {
 			id := string(m[1])
 			bindings[id] = append(bindings[id], rel)
@@ -237,31 +270,23 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 	}
 
 	// 3. Assert every registry entry has a binding or external path.
+	for _, finding := range checkRegistryBindings(reg, bindings, root) {
+		t.Error(finding)
+	}
+
 	pendingCount := 0
 	for _, e := range reg.Invariants {
-		if e.External {
-			for _, p := range e.AssertedBy {
-				absPath := filepath.Join(root, p)
-				if _, statErr := os.Stat(absPath); statErr != nil {
-					t.Errorf("%s: external path %q does not exist: %v", e.ID, p, statErr)
-				}
-			}
-			continue
-		}
 		if e.Binding == "pending" {
-			if len(e.AssertedBy) > 0 {
-				t.Errorf("%s: binding: pending entries MUST NOT carry asserted_by (no fabricated bindings)", e.ID)
-			}
 			pendingCount++
-			continue
-		}
-		if len(bindings[e.ID]) == 0 {
-			t.Errorf("%s: no test binding found (expected at least one `// Verifies: %s` comment in a *_test.go file)", e.ID, e.ID)
 		}
 	}
 	t.Logf("registry: %d invariant(s) marked binding: pending (verification backfill tracked separately)", pendingCount)
 
 	// 4. Orphan detection: scan specs/ for INV-<SCOPE>-<N> references not in registry.
+	byID := make(map[string]registryEntry, len(reg.Invariants))
+	for _, e := range reg.Invariants {
+		byID[e.ID] = e
+	}
 	orphans := make(map[string]int)
 	err = filepath.WalkDir(filepath.Join(root, "docs", "superpowers", "specs"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -273,11 +298,11 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		if !strings.HasSuffix(d.Name(), ".md") {
 			return nil
 		}
-		data, readErr := os.ReadFile(path) //nolint:gosec // G122: meta-test walker reads in-repo doc files for invariant-ref grep; no symlink concern
+		specData, readErr := os.ReadFile(path) //nolint:gosec // G122: meta-test walker reads in-repo doc files for invariant-ref grep; no symlink concern
 		if readErr != nil {
 			return readErr
 		}
-		matches := registryInvRefRE.FindAllSubmatch(data, -1)
+		matches := registryInvRefRE.FindAllSubmatch(specData, -1)
 		for _, m := range matches {
 			id := string(m[1])
 			if _, known := byID[id]; !known {
@@ -291,5 +316,288 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 	}
 	for id, n := range orphans {
 		t.Errorf("orphan invariant %s referenced %d time(s) in specs/ but not in invariants.yaml", id, n)
+	}
+}
+
+// TestRegistryBindingChecks is a table-driven test of the registry structural
+// validation logic via checkRegistryBindings. Each case exercises one
+// enumerated failure mode using a synthetic registryDoc + bindings map.
+func TestRegistryBindingChecks(t *testing.T) {
+	root := findRepoRoot(t) // used for external path existence checks
+
+	tests := []struct {
+		name         string
+		reg          registryDoc
+		bindings     map[string][]string
+		wantFindings int    // 0 = expect pass, >0 = expect at least this many findings
+		findingLike  string // substring that MUST appear in findings when wantFindings > 0
+	}{
+		{
+			name: "passes on empty invariant list",
+			reg:  registryDoc{},
+			// empty registry → no invariants to check → no findings
+			wantFindings: 0,
+		},
+		{
+			name: "detects duplicate IDs",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO", Binding: "pending"},
+					{ID: "INV-FOO-1", Scope: "INV-FOO", Binding: "pending"},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 1,
+			findingLike:  "duplicate ID",
+		},
+		{
+			name: "detects scope with no invariants",
+			reg: registryDoc{
+				Scopes: []scopeRecord{{Name: "INV-BAR"}},
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO", Binding: "pending"},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 1,
+			findingLike:  "INV-BAR declared in YAML scopes but has no invariants",
+		},
+		{
+			name: "detects missing binding",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO"},
+				},
+			},
+			bindings:     map[string][]string{}, // no Verifies annotations found
+			wantFindings: 1,
+			findingLike:  "INV-FOO-1: no test binding found",
+		},
+		{
+			name: "passes with binding present",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO"},
+				},
+			},
+			bindings:     map[string][]string{"INV-FOO-1": {"some/test_file_test.go"}},
+			wantFindings: 0,
+		},
+		{
+			name: "passes binding: pending without asserted_by",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO", Binding: "pending"},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 0,
+		},
+		{
+			name: "detects binding: pending with asserted_by (fabricated binding)",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO", Binding: "pending", AssertedBy: []string{"some/file_test.go"}},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 1,
+			findingLike:  "MUST NOT carry asserted_by",
+		},
+		{
+			name: "detects external path that does not exist",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					{ID: "INV-FOO-1", Scope: "INV-FOO", External: true, AssertedBy: []string{"nonexistent/path/file.go"}},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 1,
+			findingLike:  "does not exist",
+		},
+		{
+			name: "passes external path that exists",
+			reg: registryDoc{
+				Invariants: []registryEntry{
+					// Use a well-known file in the repo that is guaranteed to exist.
+					{ID: "INV-FOO-1", Scope: "INV-FOO", External: true, AssertedBy: []string{"docs/architecture/invariants.yaml"}},
+				},
+			},
+			bindings:     map[string][]string{},
+			wantFindings: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := checkRegistryBindings(tc.reg, tc.bindings, root)
+			if tc.wantFindings == 0 {
+				if len(findings) != 0 {
+					t.Errorf("expected no findings, got %d: %v", len(findings), findings)
+				}
+				return
+			}
+			if len(findings) == 0 {
+				t.Fatalf("expected at least %d finding(s), got none", tc.wantFindings)
+			}
+			if tc.findingLike != "" {
+				found := false
+				for _, f := range findings {
+					if strings.Contains(f, tc.findingLike) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected a finding containing %q, got: %v", tc.findingLike, findings)
+				}
+			}
+		})
+	}
+}
+
+// bareInvRE matches a residual un-migrated bare INV-N token (no scope prefix).
+var bareInvRE = regexp.MustCompile(`\bINV-\d+\b`)
+
+// checkProvenance is the guard body, factored so the negative test can call it
+// against a synthetic registry+tree and assert it returns findings.
+func checkProvenance(root string, reg registryDoc) []string {
+	var findings []string
+	migrated := map[string]bool{}
+	owned := map[string]string{} // glob -> scope (already partition-checked elsewhere)
+	shared := map[string]map[string]bool{}
+	for _, sc := range reg.Scopes {
+		if sc.Status == "migrated" {
+			migrated[sc.Name] = true
+		}
+		for _, p := range sc.OwnedPaths {
+			owned[p] = sc.Name
+		}
+		shared[sc.Name] = map[string]bool{}
+		for _, f := range sc.SharedFiles {
+			shared[sc.Name][f] = true
+		}
+	}
+	// For each migrated scope's recorded refs, confirm the canonical token is at that site.
+	for _, e := range reg.Invariants {
+		if !migrated[e.Scope] {
+			continue
+		}
+		for _, r := range e.Refs {
+			data, err := os.ReadFile(filepath.Join(root, r.File))
+			if err != nil {
+				findings = append(findings, fmt.Sprintf("%s: recorded ref unreadable (%v)", e.ID, err))
+				continue
+			}
+			if !regexp.MustCompile(`\b` + regexp.QuoteMeta(e.ID) + `\b`).Match(data) {
+				findings = append(findings, fmt.Sprintf("%s: canonical token absent at recorded site %s", e.ID, r.File))
+			}
+			// Ownership: the file must be owned by e.Scope OR explicitly shared to it.
+			if !shared[e.Scope][r.File] && !pathOwnedBy(owned, r.File, e.Scope) {
+				findings = append(findings, fmt.Sprintf("%s: ref %s not in %s owned_paths/shared_files", e.ID, r.File, e.Scope))
+			}
+		}
+	}
+	// Residual check: a migrated scope's owned files MUST NOT still carry a bare
+	// INV-N (un-migrated). Walk each migrated scope's owned dirs, reusing the
+	// package-level skipDirs set (.git/.jj/.worktrees/vendor/node_modules/bin/
+	// build/dist) AND the explicit .claude/worktrees path guard — skipDirs does
+	// NOT contain a plain "worktrees" key, so the bare WalkDir-into-.claude/
+	// worktrees pollution bug (holomush-jb1ec) is only prevented by the path
+	// guard below; keep both.
+	for _, sc := range reg.Scopes {
+		if sc.Status != "migrated" {
+			continue
+		}
+		for _, glob := range sc.OwnedPaths {
+			base := strings.TrimSuffix(glob, "**")
+			base = strings.TrimSuffix(base, "/")
+			_ = filepath.WalkDir(filepath.Join(root, base), func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil //nolint:nilerr // missing/!dir globs (file-specific owned_paths) → skip, not fatal
+				}
+				if d.IsDir() {
+					if _, skip := skipDirs[d.Name()]; skip || strings.Contains(p, "/.claude/worktrees/") {
+						return fs.SkipDir
+					}
+					return nil
+				}
+				rel, _ := filepath.Rel(root, p)
+				if shared[sc.Name][rel] {
+					return nil // shared files carry mixed scopes; checked via refs only
+				}
+				body, rerr := os.ReadFile(p) //nolint:gosec // G304: in-repo walk under owned_paths
+				if rerr == nil && bareInvRE.Match(body) {
+					findings = append(findings, fmt.Sprintf("%s: residual bare INV-N in migrated-scope file %s", sc.Name, rel))
+				}
+				return nil
+			})
+		}
+	}
+	return findings
+}
+
+// pathOwnedBy reports whether file matches any owned-path glob assigned to scope.
+// Uses doublestar-style matching via filepath.Match on each path segment prefix;
+// for simplicity a glob ending in /** matches any file under that prefix.
+func pathOwnedBy(owned map[string]string, file, scope string) bool {
+	for glob, sc := range owned {
+		if sc != scope {
+			continue
+		}
+		if strings.HasSuffix(glob, "/**") {
+			if strings.HasPrefix(file, strings.TrimSuffix(glob, "**")) {
+				return true
+			}
+			continue
+		}
+		if ok, _ := filepath.Match(glob, file); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProvenanceGuard(t *testing.T) {
+	root := findRepoRoot(t)
+	reg := loadRegistry(t)
+	if f := checkProvenance(root, reg); len(f) > 0 {
+		for _, line := range f {
+			t.Error(line)
+		}
+	}
+}
+
+func TestProvenanceGuardFailsOnMislabel(t *testing.T) {
+	dir := t.TempDir()
+	// A scene file mislabeled with a CRYPTO id; CRYPTO owns only crypto paths.
+	if err := os.MkdirAll(filepath.Join(dir, "plugins", "core-scenes"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	scene := filepath.Join("plugins", "core-scenes", "board.go")
+	if err := os.WriteFile(filepath.Join(dir, scene), []byte("// INV-CRYPTO-1: mislabeled\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg := registryDoc{
+		Scopes:     []scopeRecord{{Name: "INV-CRYPTO", Status: "migrated", OwnedPaths: []string{"internal/eventbus/crypto/**"}}},
+		Invariants: []registryEntry{{ID: "INV-CRYPTO-1", Scope: "INV-CRYPTO", Refs: []ref{{File: scene, Token: "INV-CRYPTO-1"}}}},
+	}
+	f := checkProvenance(dir, reg)
+	if len(f) == 0 {
+		t.Fatal("guard must fail on a scene file stamped INV-CRYPTO-1, but passed")
+	}
+	// Assert the OWNERSHIP check fired (not merely "some" finding): the token IS
+	// present in the fixture, so a count-only assertion would still pass if a
+	// future edit dropped the token and surfaced a different finding instead,
+	// silently losing ownership coverage.
+	found := false
+	for _, line := range f {
+		if strings.Contains(line, "not in INV-CRYPTO owned_paths") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected an owned_paths ownership finding, got: %v", f)
 	}
 }

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -15,9 +15,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ref is a path-anchored annotation site: a file plus the ID token to anchor on.
+// Never a line number — line numbers drift between classification and migration.
+type ref struct {
+	File  string `yaml:"file"`
+	Token string `yaml:"token"`
+}
+
 // registryEntry mirrors one invariant in invariants.yaml.
 type registryEntry struct {
 	ID         string   `yaml:"id"`
+	Scope      string   `yaml:"scope"`
+	OriginSpec string   `yaml:"origin_spec"`
 	Legacy     []string `yaml:"legacy"`
 	Summary    string   `yaml:"summary"`
 	Severity   string   `yaml:"severity"`
@@ -25,15 +34,74 @@ type registryEntry struct {
 	AssertedBy []string `yaml:"asserted_by"`
 	External   bool     `yaml:"external"`
 	Binding    string   `yaml:"binding"`
+	Refs       []ref    `yaml:"refs"`
+}
+
+type scopeRecord struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Boundary    string   `yaml:"boundary"`
+	Status      string   `yaml:"status"`       // pending | migrated
+	OriginSpecs []string `yaml:"origin_specs"`
+	OwnedPaths  []string `yaml:"owned_paths"`  // path globs; MAY target individual files
+	SharedFiles []string `yaml:"shared_files"` // exact paths annotating >1 scope
 }
 
 type registryDoc struct {
-	Scopes []struct {
-		Name        string `yaml:"name"`
-		Description string `yaml:"description"`
-		Boundary    string `yaml:"boundary"`
-	} `yaml:"scopes"`
+	Scopes     []scopeRecord   `yaml:"scopes"`
 	Invariants []registryEntry `yaml:"invariants"`
+}
+
+// loadRegistry parses invariants.yaml from the repo root.
+func loadRegistry(t *testing.T) registryDoc {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(findRepoRoot(t), "docs", "architecture", "invariants.yaml"))
+	if err != nil {
+		t.Fatalf("read invariants.yaml: %v", err)
+	}
+	var reg registryDoc
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse invariants.yaml: %v", err)
+	}
+	return reg
+}
+
+func TestRegistrySchemaParsesOwnershipFields(t *testing.T) {
+	const fixture = `
+scopes:
+  - name: INV-PRESENCE
+    status: migrated
+    origin_specs: ["docs/superpowers/specs/x.md"]
+    owned_paths: ["internal/grpc/focus/**"]
+    shared_files: ["test/integration/wholesystem/census_test.go"]
+invariants:
+  - id: INV-PRESENCE-1
+    scope: INV-PRESENCE
+    origin_spec: "docs/superpowers/specs/x.md"
+    legacy: ["INV-3@docs/superpowers/specs/x.md"]
+    summary: "snapshot enumerates all active sessions"
+    binding: pending
+    refs:
+      - {file: "internal/grpc/focus/presence.go", token: "INV-3"}
+`
+	var reg registryDoc
+	if err := yaml.Unmarshal([]byte(fixture), &reg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(reg.Scopes) != 1 {
+		t.Fatalf("want 1 scope, got %d", len(reg.Scopes))
+	}
+	sc := reg.Scopes[0]
+	if sc.Status != "migrated" || len(sc.OwnedPaths) != 1 || len(sc.SharedFiles) != 1 {
+		t.Errorf("scope ownership fields not parsed: %+v", sc)
+	}
+	inv := reg.Invariants[0]
+	if inv.OriginSpec == "" || len(inv.Refs) != 1 {
+		t.Fatalf("invariant origin/refs not parsed: %+v", inv)
+	}
+	if inv.Refs[0].File != "internal/grpc/focus/presence.go" || inv.Refs[0].Token != "INV-3" {
+		t.Errorf("ref not parsed: %+v", inv.Refs[0])
+	}
 }
 
 // registryVerifiesRE matches `// Verifies: INV-<SCOPE>-<N>` annotations in test files.


### PR DESCRIPTION
## Summary

Foundation-only set for the invariant-registry `INV-<SCOPE>-N` rename migration (plan: `docs/superpowers/plans/2026-06-01-invariant-registry-migration.md`). Four dependent tasks, drained as one reviewable PR. **Per-scope data migration (.14.5+) is deliberately out of scope** — those need human classification review per the redesign design.

| Bead | Commit | What |
|------|--------|------|
| holomush-hz0v4.14.1 | `rtmxllxx` | Registry Go structs: `scope`/`origin_spec`/`refs` on `registryEntry`, named `scopeRecord` with ownership fields, `loadRegistry` helper |
| holomush-hz0v4.14.2 | `sxspxuww` | Re-derived family→scope map **from source specs with evidence** (prior assumed map was ~64% wrong); per-scope `status`/`origin_specs`/`owned_paths`/`shared_files` for all 13 scopes; `TestOwnedPathsPartition` |
| holomush-hz0v4.14.3 | `ptxtkzwn` | `cmd/inv-migrate` — closed-world, site-addressed, idempotent rename tool driven by recorded `{file,token}` refs (never value-keyed sed) |
| holomush-hz0v4.14.4 | `oqznurxo` | Deterministic provenance guard (existence + site-match + `owned_paths` ownership on migrated scopes; residual bare-`INV-N` check; negative mislabel test). Also refactors `TestEveryRegistryInvariantHasBinding` into table-driven subtests (deferred CodeRabbit from #4358) |

## Notable evidence finding

The **P7 family splits CRYPTO + EVENTBUS** (not CRYPTO+PLUGIN as the starting hypothesis assumed) — P7-3/4/10 are audit-column/struct-mirror/migration plumbing → EVENTBUS; the payload-encryption invariants → CRYPTO. Verified per-invariant against the phase-7 spec. The exact per-ref allocation (e.g. the shared header parser P7-2) is recorded for Phase-4 per-ref classification human review.

## Verification

`task pr-prep` (fast lane) green: bats, schema-check, license, plugin builds, lint, fmt, unit tests, build. `invariants:` list intentionally remains empty `[]` (Phase 4 populates it per-scope). The empty-registry skip in `TestEveryRegistryInvariantHasBinding` is preserved with its `holomush-hz0v4.14.18` removal-tracking note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)