### PR TITLE
fix(invariants): anchor consistency-lint md-ID extraction to first column (holomush-hz0v4.14.19)

### DIFF
--- a/scripts/check-invariant-registry-consistency.sh
+++ b/scripts/check-invariant-registry-consistency.sh
@@ -9,8 +9,10 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-YAML="$REPO_ROOT/docs/architecture/invariants.yaml"
-MD="$REPO_ROOT/docs/architecture/invariants.md"
+# Paths default to the in-repo registry but are overridable so the consistency
+# logic can be exercised against fixtures (scripts/tests/*.bats).
+YAML="${INV_REGISTRY_YAML:-$REPO_ROOT/docs/architecture/invariants.yaml}"
+MD="${INV_REGISTRY_MD:-$REPO_ROOT/docs/architecture/invariants.md}"
 
 if [[ ! -f "$YAML" ]]; then
   echo "ERROR: invariants.yaml not found at $YAML"
@@ -28,8 +30,12 @@ if [[ -z "$yaml_ids" ]]; then
   exit 0
 fi
 
-# Extract IDs from markdown table rows (lines matching "| `INV-...` |")
-md_ids=$(grep -E '^\|[[:space:]]+`INV-[A-Z]+-[0-9]+`' "$MD" | sed -E 's/^.*`(INV-[A-Z]+-[0-9]+)`.*$/\1/' | sort || true)
+# Extract IDs from markdown table rows (lines matching "| `INV-...` |").
+# Anchor the sed capture to the first column so a row that also references a
+# legacy ID in backticks (e.g. "| `INV-CRYPTO-1` | replaces `INV-RB-5` |")
+# yields the PRIMARY id, not the last backtick-wrapped token. A greedy `^.*`
+# prefix would bind the capture to the trailing legacy ID (holomush-hz0v4.14.19).
+md_ids=$(grep -E '^\|[[:space:]]+`INV-[A-Z]+-[0-9]+`' "$MD" | sed -E 's/^\|[[:space:]]+`(INV-[A-Z]+-[0-9]+)`.*$/\1/' | sort || true)
 
 # Every YAML ID must appear in markdown.
 fail=0

--- a/scripts/tests/invariant-registry-consistency.bats
+++ b/scripts/tests/invariant-registry-consistency.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 HoloMUSH Contributors
+
+# Regression tests for scripts/check-invariant-registry-consistency.sh.
+# Primary guard: the markdown-ID extraction must capture each row's FIRST-column
+# (primary) invariant ID, not a trailing legacy ID also wrapped in backticks
+# (holomush-hz0v4.14.19). A greedy `^.*` sed prefix used to bind the capture to
+# the last backtick token, producing spurious drift once rows reference legacy
+# IDs.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/check-invariant-registry-consistency.sh"
+  TMP="$BATS_TEST_TMPDIR"
+  export INV_REGISTRY_YAML="$TMP/invariants.yaml"
+  export INV_REGISTRY_MD="$TMP/invariants.md"
+}
+
+run_check() {
+  run bash "$SCRIPT"
+}
+
+@test "primary first-column ID is captured even when a row also cites a legacy ID in backticks" {
+  cat >"$INV_REGISTRY_YAML" <<'YAML'
+invariants:
+  - id: INV-CRYPTO-1
+    scope: INV-CRYPTO
+YAML
+  cat >"$INV_REGISTRY_MD" <<'MD'
+| ID | Notes |
+| --- | --- |
+| `INV-CRYPTO-1` | replaces `INV-RB-5` |
+MD
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"consistent"* ]]
+}
+
+@test "drift is reported when the YAML ID is absent from the markdown table" {
+  cat >"$INV_REGISTRY_YAML" <<'YAML'
+invariants:
+  - id: INV-CRYPTO-1
+    scope: INV-CRYPTO
+YAML
+  cat >"$INV_REGISTRY_MD" <<'MD'
+| ID | Notes |
+| --- | --- |
+| `INV-PRESENCE-1` | unrelated |
+MD
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"YAML has INV-CRYPTO-1 but markdown table does not"* ]]
+}
+
+@test "drift is reported when the markdown table has an ID absent from YAML" {
+  cat >"$INV_REGISTRY_YAML" <<'YAML'
+invariants:
+  - id: INV-CRYPTO-1
+    scope: INV-CRYPTO
+YAML
+  cat >"$INV_REGISTRY_MD" <<'MD'
+| ID | Notes |
+| --- | --- |
+| `INV-CRYPTO-1` | ok |
+| `INV-CRYPTO-2` | replaces `INV-RB-6` |
+MD
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"markdown table has INV-CRYPTO-2 but YAML does not"* ]]
+}
+
+@test "empty YAML registry skips the check (scaffolding tolerance)" {
+  printf 'invariants: []\n' >"$INV_REGISTRY_YAML"
+  printf '(no invariants yet)\n' >"$INV_REGISTRY_MD"
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes the greedy markdown-ID extraction in `scripts/check-invariant-registry-consistency.sh` flagged by code-reviewer on PR #4358 (bead `holomush-hz0v4.14.19`).

The `md_ids` extraction used a greedy `^.*` sed prefix, so a markdown table row carrying two backtick-wrapped IDs — a first-column primary id plus a legacy reference (e.g. `` | `INV-CRYPTO-1` | replaces `INV-RB-5` | ``) — captured the **last** token (`INV-RB-5`) instead of the first-column primary id. Harmless today (tables are empty) but bites the moment the per-scope table generator renders rows that cite legacy IDs in backticks — exactly what the `INV-PRESENCE` migration (`.14.5`) onward will produce. This bead **gates `.14.5`**.

## Changes

- **`scripts/check-invariant-registry-consistency.sh`** — anchor the sed capture to the first column (`^\|[[:space:]]+\`(INV-…)\``) so it always binds the primary id. Added `INV_REGISTRY_YAML` / `INV_REGISTRY_MD` env overrides (defaulting to the in-repo registry paths) so the consistency logic is exercisable against fixtures.
- **`scripts/tests/invariant-registry-consistency.bats`** — new 4-test regression suite (auto-discovered by `task test:bats`, in the pr-prep fast lane). Tests confirmed to fail against the greedy form and pass against the anchored form.

## Verification

- `bats scripts/tests/invariant-registry-consistency.bats` → 4/4 pass; confirmed they fail under the greedy sed.
- `task lint:invariants` green (real registry still empty → skip).
- `task pr-prep` (fast lane) → pass.
- code-reviewer → READY, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)