### PR TITLE
refactor(invariants): migrate INV-STORE to canonical ids (holomush-hz0v4.14.7)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -596,7 +596,7 @@ tasks:
         echo "AGENTS.md → CLAUDE.md symlink intact."
 
   lint:no-unixnano-in-repos:
-    desc: "Reject UnixNano() / time.Unix(0, ...) in repo packages outside pgnanos (INV-TS-2)"
+    desc: "Reject UnixNano() / time.Unix(0, ...) in repo packages outside pgnanos (INV-STORE-2)"
     cmds:
       - |
         set -euo pipefail
@@ -616,7 +616,7 @@ tasks:
         fi
 
   lint:no-microsecond-truncate:
-    desc: "Reject .Truncate(time.Microsecond) in Go code (INV-TS-3)"
+    desc: "Reject .Truncate(time.Microsecond) in Go code (INV-STORE-3)"
     cmds:
       - |
         set -euo pipefail
@@ -642,7 +642,7 @@ tasks:
         fi
 
   lint:no-timestamptz:
-    desc: "Reject new TIMESTAMPTZ/TIMESTAMP columns in post-gfo6 migrations (INV-TS-1)"
+    desc: "Reject new TIMESTAMPTZ/TIMESTAMP columns in post-gfo6 migrations (INV-STORE-1)"
     cmds:
       - |
         set -euo pipefail

--- a/cmd/holomush/crypto_operator_validation_test.go
+++ b/cmd/holomush/crypto_operator_validation_test.go
@@ -44,7 +44,7 @@ func seedPlayer(t *testing.T, ctx context.Context, pool *pgxpool.Pool) string {
 	// Username uses the full ULID for uniqueness — ULIDs created in the
 	// same millisecond share their timestamp prefix, so a short prefix
 	// is not collision-safe.
-	// INV-TS-1: players.created_at is BIGINT-ns; deterministic fixture so the
+	// INV-STORE-1: players.created_at is BIGINT-ns; deterministic fixture so the
 	// seed value survives the round-trip unambiguously and the test is reproducible.
 	createdAt := time.Date(2026, 5, 22, 12, 0, 0, 123456789, time.UTC).UnixNano()
 	_, err := pool.Exec(ctx,

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -68,4 +68,17 @@ invariants.
 | `INV-SESSION-3` | PostgresSessionStore.AddConnection rejects invalid client_type (accept terminal/comms_hub/telnet; reject others). | `INV-M-3` | pending |
 | `INV-SESSION-4` | Memstore-removal preserves behavioral coverage: every pre-consolidation test is named in a surviving test's // replaces: chain. | `INV-M-4` | pending |
 
+### `INV-STORE`
+
+| ID | Summary | Legacy | Binding |
+|----|---------|--------|---------|
+| `INV-STORE-1` | All persistent time values stored as BIGINT epoch-ns (UTC); no new TIMESTAMPTZ/TIMESTAMP columns. | `INV-TS-1` | pending |
+| `INV-STORE-2` | pgnanos.Time is the canonical scan/insert seam between time.Time and BIGINT epoch-ns; no int64<->time.Time arithmetic outside pgnanos. | `INV-TS-2` | pending |
+| `INV-STORE-3` | Application code (production + tests) must not Truncate(time.Microsecond) on any time.Time round-tripping through PG. | `INV-TS-3` | pending |
+| `INV-STORE-4` | publisher.Publish does not truncate event.Timestamp before AAD/envelope; the on-wire timestamp carries full nanosecond precision. | `INV-TS-4` | pending |
+| `INV-STORE-5` | AAD round-trip publish->persist->read->reconstruct is byte-equal at full nanosecond resolution (strengthens former INV-P7-16). | `INV-TS-5` | pending |
+| `INV-STORE-6` | Privacy/scope floor comparisons operate at nanosecond resolution; the dispatchDelivery Truncate(microsecond) is deleted, not stubbed. | `INV-TS-6` | pending |
+| `INV-STORE-7` | Sub-microsecond timestamp ties resolve deterministically; the privacy floor uses >= so an event at the exact floor ns is included. | `INV-TS-7` | pending |
+| `INV-STORE-9` | TIMESTAMPTZ->BIGINT conversion migrations saturate out-of-range / +/-infinity to int64 bounds, pass NULL through, and convert in-range values exactly (numeric arithmetic). | `INV-TS-9` | pending |
+
 <!-- END GENERATED: invariant-tables -->

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -277,7 +277,7 @@ scopes:
     description: "Migration discipline, no-DELETE enforcement, spec compliance scanning"
     boundary: "Database invariants."
     # Family TS (nanosecond-timestamps migration discipline + pgnanos seam). See redesign spec §2.1.
-    status: pending
+    status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
     owned_paths:
@@ -289,22 +289,39 @@ scopes:
       - "internal/store/spec_meta_test.go"
       - "internal/store/no_delete_grep_test.go"
     shared_files:
-      # STORE+CRYPTO: history files carrying TS + P7/RB (see CRYPTO.shared_files).
-      - "internal/eventbus/history/readback.go"
-      - "internal/eventbus/history/phase7_boundary_meta_test.go"
-      - "internal/eventbus/history/plugin_aad_reconstruction_test.go"
+      # All non-STORE-owned files carrying an INV-TS token (renamed to INV-STORE-N
+      # here): .go + plugin migration comments + Taskfile lint descs. They hold TS
+      # alongside other scopes' (CRYPTO/SCENE/EVENTBUS/PRIVACY) annotations. Survey .14.7.
+      - "Taskfile.yaml"
+      - "cmd/holomush/crypto_operator_validation_test.go"
+      - "internal/admin/readstream/cold_reader.go"
+      - "internal/admin/readstream/cold_reader_integration_test.go"
+      - "internal/eventbus/crypto/dek/manager_integration_test.go"
       - "internal/eventbus/history/cold_postgres.go"
       - "internal/eventbus/history/cold_postgres_integration_test.go"
+      - "internal/eventbus/history/phase7_boundary_meta_test.go"
       - "internal/eventbus/history/plugin_aad_adapter.go"
-      # STORE+EVENTBUS+CRYPTO: publisher (see CRYPTO.shared_files).
+      - "internal/eventbus/history/plugin_aad_reconstruction_test.go"
+      - "internal/eventbus/history/readback.go"
       - "internal/eventbus/publisher.go"
       - "internal/eventbus/publisher_test.go"
-      # STORE+SCENE: server.go + privacy_test + core-scenes publish_store (see SCENE.shared_files).
       - "internal/grpc/server.go"
-      - "test/integration/privacy/privacy_test.go"
-      - "plugins/core-scenes/publish_store.go"
-      # STORE+CRYPTO harness (TS in crypto integration harness).
+      - "internal/grpc/subscribe_loop_test.go"
+      - "internal/testsupport/holomushtest/server.go"
       - "internal/testsupport/integrationtest/crypto.go"
+      - "plugins/core-scenes/migrations/000007_timestamps_to_bigint.up.sql"
+      - "plugins/core-scenes/migrations/000008_scene_publication.up.sql"
+      - "plugins/core-scenes/poseorder_integration_test.go"
+      - "plugins/core-scenes/publish_service.go"
+      - "plugins/core-scenes/publish_snapshot.go"
+      - "plugins/core-scenes/publish_store.go"
+      - "plugins/core-scenes/store.go"
+      - "plugins/core-scenes/store_integration_test.go"
+      - "test/integration/crypto/harness_impl_test.go"
+      - "test/integration/crypto/rekey_inv39_test.go"
+      - "test/integration/crypto/rekey_sweep_ttl_test.go"
+      - "test/integration/plugin/binary_plugin_test.go"
+      - "test/integration/privacy/privacy_test.go"
 
   - name: INV-TELEMETRY
     description: "Logging discipline, trace context, metric naming, sloglint policy"
@@ -468,3 +485,140 @@ invariants:
     # Process/review invariant (// replaces: attestation chain); no in-code
     # annotation token to migrate.
     refs: []
+
+  # -- INV-STORE -- migrated from INV-TS-N (family TS, nanosecond-timestamps) (holomush-hz0v4.14.7).
+  # Origin: docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md (Invariants table).
+  # 1:1 number mapping preserved; NO INV-STORE-8 (legacy INV-TS-8 was dropped, spec successor is a P3 task).
+  # Refs span .go + shipped .up.sql migration comments + Taskfile.yaml lint descs (full survey).
+  # binding: pending across the scope -- verification backfill is holomush-hz0v4.11.
+  - id: INV-STORE-1
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-1@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "All persistent time values stored as BIGINT epoch-ns (UTC); no new TIMESTAMPTZ/TIMESTAMP columns."
+    binding: pending
+    refs:
+      - {file: "Taskfile.yaml", token: "INV-TS-1"}
+      - {file: "cmd/holomush/crypto_operator_validation_test.go", token: "INV-TS-1"}
+      - {file: "internal/admin/readstream/cold_reader.go", token: "INV-TS-1"}
+      - {file: "internal/admin/readstream/cold_reader_integration_test.go", token: "INV-TS-1"}
+      - {file: "internal/eventbus/crypto/dek/manager_integration_test.go", token: "INV-TS-1"}
+      - {file: "internal/eventbus/history/cold_postgres_integration_test.go", token: "INV-TS-1"}
+      - {file: "internal/pgnanos/doc.go", token: "INV-TS-1"}
+      - {file: "internal/store/migrate_inv_ts_integration_test.go", token: "INV-TS-1"}
+      - {file: "internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "internal/store/migrations/000041_auth_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "internal/store/migrations/000042_world_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "internal/store/migrations/000043_totp_misc_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "internal/store/migrations/000044_pregfo6_gap_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-1"}
+      - {file: "internal/testsupport/holomushtest/server.go", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/migrations/000007_timestamps_to_bigint.up.sql", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/migrations/000008_scene_publication.up.sql", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/poseorder_integration_test.go", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/publish_store.go", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/store.go", token: "INV-TS-1"}
+      - {file: "plugins/core-scenes/store_integration_test.go", token: "INV-TS-1"}
+      - {file: "test/integration/crypto/harness_impl_test.go", token: "INV-TS-1"}
+      - {file: "test/integration/crypto/rekey_inv39_test.go", token: "INV-TS-1"}
+      - {file: "test/integration/crypto/rekey_sweep_ttl_test.go", token: "INV-TS-1"}
+      - {file: "test/integration/plugin/binary_plugin_test.go", token: "INV-TS-1"}
+      - {file: "test/integration/privacy/privacy_test.go", token: "INV-TS-1"}
+  - id: INV-STORE-2
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-2@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "pgnanos.Time is the canonical scan/insert seam between time.Time and BIGINT epoch-ns; no int64<->time.Time arithmetic
+      outside pgnanos."
+    binding: pending
+    refs:
+      - {file: "Taskfile.yaml", token: "INV-TS-2"}
+      - {file: "internal/pgnanos/pgnanos_test.go", token: "INV-TS-2"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-2"}
+      - {file: "plugins/core-scenes/poseorder_integration_test.go", token: "INV-TS-2"}
+      - {file: "plugins/core-scenes/publish_service.go", token: "INV-TS-2"}
+  - id: INV-STORE-3
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-3@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "Application code (production + tests) must not Truncate(time.Microsecond) on any time.Time round-tripping through
+      PG."
+    binding: pending
+    refs:
+      - {file: "Taskfile.yaml", token: "INV-TS-3"}
+      - {file: "internal/pgnanos/pgnanos.go", token: "INV-TS-3"}
+      - {file: "internal/store/lint_meta_test.go", token: "INV-TS-3"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-3"}
+  - id: INV-STORE-4
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-4@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "publisher.Publish does not truncate event.Timestamp before AAD/envelope; the on-wire timestamp carries full
+      nanosecond precision."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/publisher.go", token: "INV-TS-4"}
+      - {file: "internal/eventbus/publisher_test.go", token: "INV-TS-4"}
+      - {file: "internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql", token: "INV-TS-4"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-4"}
+      - {file: "test/integration/privacy/privacy_test.go", token: "INV-TS-4"}
+  - id: INV-STORE-5
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-5@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "AAD round-trip publish->persist->read->reconstruct is byte-equal at full nanosecond resolution (strengthens
+      former INV-P7-16)."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/history/cold_postgres.go", token: "INV-TS-5"}
+      - {file: "internal/eventbus/history/phase7_boundary_meta_test.go", token: "INV-TS-5"}
+      - {file: "internal/eventbus/history/plugin_aad_adapter.go", token: "INV-TS-5"}
+      - {file: "internal/eventbus/history/plugin_aad_reconstruction_test.go", token: "INV-TS-5"}
+      - {file: "internal/eventbus/history/readback.go", token: "INV-TS-5"}
+      - {file: "internal/eventbus/publisher.go", token: "INV-TS-5"}
+      - {file: "internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql", token: "INV-TS-5"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-5"}
+      - {file: "internal/testsupport/integrationtest/crypto.go", token: "INV-TS-5"}
+      - {file: "plugins/core-scenes/migrations/000007_timestamps_to_bigint.up.sql", token: "INV-TS-5"}
+      - {file: "plugins/core-scenes/publish_snapshot.go", token: "INV-TS-5"}
+      - {file: "plugins/core-scenes/publish_store.go", token: "INV-TS-5"}
+  - id: INV-STORE-6
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-6@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "Privacy/scope floor comparisons operate at nanosecond resolution; the dispatchDelivery Truncate(microsecond)
+      is deleted, not stubbed."
+    binding: pending
+    refs:
+      - {file: "internal/grpc/server.go", token: "INV-TS-6"}
+      - {file: "internal/grpc/subscribe_loop_test.go", token: "INV-TS-6"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-6"}
+      - {file: "test/integration/privacy/privacy_test.go", token: "INV-TS-6"}
+  - id: INV-STORE-7
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-7@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "Sub-microsecond timestamp ties resolve deterministically; the privacy floor uses >= so an event at the exact
+      floor ns is included."
+    binding: pending
+    refs:
+      - {file: "internal/grpc/server.go", token: "INV-TS-7"}
+      - {file: "internal/grpc/subscribe_loop_test.go", token: "INV-TS-7"}
+      - {file: "internal/pgnanos/doc.go", token: "INV-TS-7"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-7"}
+      - {file: "test/integration/privacy/privacy_test.go", token: "INV-TS-7"}
+  - id: INV-STORE-9
+    scope: INV-STORE
+    origin_spec: "docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"
+    legacy: ["INV-TS-9@docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md"]
+    summary: "TIMESTAMPTZ->BIGINT conversion migrations saturate out-of-range / +/-infinity to int64 bounds, pass NULL through,
+      and convert in-range values exactly (numeric arithmetic)."
+    binding: pending
+    refs:
+      - {file: "internal/store/migrate_clamp_integration_test.go", token: "INV-TS-9"}
+      - {file: "internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
+      - {file: "internal/store/migrations/000041_auth_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
+      - {file: "internal/store/migrations/000042_world_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
+      - {file: "internal/store/migrations/000043_totp_misc_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
+      - {file: "internal/store/migrations/000044_pregfo6_gap_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-9"}

--- a/internal/admin/readstream/cold_reader.go
+++ b/internal/admin/readstream/cold_reader.go
@@ -106,7 +106,7 @@ func (c *ColdReader) Read(ctx context.Context, q ColdQuery) ([]ColdRow, error) {
 			idBytes    []byte
 			subjectStr string
 			eventType  string
-			// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-TS-1).
+			// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-STORE-1).
 			ts           pgnanos.Time
 			actorKindStr string
 			actorIDBytes []byte

--- a/internal/admin/readstream/cold_reader_integration_test.go
+++ b/internal/admin/readstream/cold_reader_integration_test.go
@@ -64,7 +64,7 @@ func insertEncryptedAuditRow(
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	// timestamp is BIGINT-ns post-gfo6 (INV-TS-1).
+	// timestamp is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,
@@ -96,7 +96,7 @@ func insertIdentityAuditRow(
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	// timestamp is BIGINT-ns post-gfo6 (INV-TS-1).
+	// timestamp is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, err = pool.Exec(context.Background(), `
 		INSERT INTO events_audit (
 			id, subject, type, timestamp, actor_kind, actor_id,

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Manager", func() {
 		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
 		Expect(err).NotTo(HaveOccurred())
 
-		// INV-TS-1: deterministic ns-precision fixture so the JoinedAt round-trip
+		// INV-STORE-1: deterministic ns-precision fixture so the JoinedAt round-trip
 		// assertion below is load-bearing — sub-microsecond bits are preserved
 		// through pgnanos.Time scan/insert paths.
 		joinedAt1 := time.Date(2026, 5, 22, 12, 0, 0, 123456789, time.UTC)
@@ -268,12 +268,12 @@ var _ = Describe("Manager", func() {
 		Expect(parts[0].CharacterID).To(Equal("01XYZ"))
 		Expect(parts[0].BindingID).To(Equal("01DEF"))
 		Expect(parts[0].JoinedAt.UnixNano()).To(Equal(joinedAt1.UnixNano()),
-			"INV-TS-1: JoinedAt ns precision MUST survive round-trip")
+			"INV-STORE-1: JoinedAt ns precision MUST survive round-trip")
 		Expect(parts[1].PlayerID).To(Equal("01GHI"))
 		Expect(parts[1].CharacterID).To(Equal("01JKL"))
 		Expect(parts[1].BindingID).To(Equal("01MNO"))
 		Expect(parts[1].JoinedAt.UnixNano()).To(Equal(joinedAt2.UnixNano()),
-			"INV-TS-1: JoinedAt ns precision MUST survive round-trip")
+			"INV-STORE-1: JoinedAt ns precision MUST survive round-trip")
 	})
 
 	It("Participants not found returns DEK_NOT_FOUND", func() {

--- a/internal/eventbus/history/cold_postgres.go
+++ b/internal/eventbus/history/cold_postgres.go
@@ -214,7 +214,7 @@ func (c *postgresColdTier) Read(ctx context.Context, q eventbus.HistoryQuery, ed
 			eventType  string
 			// ts is scanned for column-position alignment with the SELECT list
 			// only; Event.Timestamp is recovered from envelopeBytes via
-			// decodeColdRow's proto.Unmarshal (INV-TS-5 AAD byte-equality).
+			// decodeColdRow's proto.Unmarshal (INV-STORE-5 AAD byte-equality).
 			ts             pgnanos.Time
 			actorKindStr   string
 			actorIDBytes   []byte

--- a/internal/eventbus/history/cold_postgres_integration_test.go
+++ b/internal/eventbus/history/cold_postgres_integration_test.go
@@ -376,7 +376,7 @@ var _ = Describe("PostgresColdTier", func() {
 
 			// Insert two events: one AT the boundary timestamp (must
 			// be included) and one strictly after (must be excluded).
-			// INV-TS-1: events_audit is BIGINT-ns end-to-end, so no µs
+			// INV-STORE-1: events_audit is BIGINT-ns end-to-end, so no µs
 			// truncation needed — the boundary value round-trips bit-exact.
 			boundary := time.Now().UTC()
 			atID := integrationULID(uint64(boundary.UnixMilli()))

--- a/internal/eventbus/history/phase7_boundary_meta_test.go
+++ b/internal/eventbus/history/phase7_boundary_meta_test.go
@@ -102,7 +102,7 @@ func TestPhase7InvariantsHaveNamedTests(t *testing.T) {
 		// that file for invariant traceability.
 		{"INV-P7-13", "TestBinaryPlugin"},
 		{"INV-P7-15", "TestFenceRefusesUnknownDekRef"},
-		// INV-P7-16 was superseded by INV-TS-5 (ADR holomush-f5h0); the
+		// INV-P7-16 was superseded by INV-STORE-5 (ADR holomush-f5h0); the
 		// carrier test was renamed from TestRoundTripProducesByteEqualAAD
 		// to TestRoundTripPreservesAADWithSubMicrosecondNanos as part of
 		// gfo6 Phase 1 (ns-precise timestamps).

--- a/internal/eventbus/history/plugin_aad_adapter.go
+++ b/internal/eventbus/history/plugin_aad_adapter.go
@@ -28,7 +28,7 @@ import (
 // plugin-stored event failing AEAD tag-check on decrypt, because the
 // reconstructed AAD would no longer be byte-equal to the encrypt-side
 // AAD computed at publish time. The integration test
-// TestRoundTripPreservesAADWithSubMicrosecondNanos (INV-TS-5, formerly
+// TestRoundTripPreservesAADWithSubMicrosecondNanos (INV-STORE-5, formerly
 // INV-P7-16 per ADR holomush-f5h0) is the load-bearing guard.
 func AuditRowToEvent(row *pluginauditpb.AuditRow) *eventbusv1.Event {
 	if row == nil {

--- a/internal/eventbus/history/plugin_aad_reconstruction_test.go
+++ b/internal/eventbus/history/plugin_aad_reconstruction_test.go
@@ -19,7 +19,7 @@ import (
 	pluginauditpb "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
-// TestRoundTripPreservesAADWithSubMicrosecondNanos asserts INV-TS-5
+// TestRoundTripPreservesAADWithSubMicrosecondNanos asserts INV-STORE-5
 // (formerly INV-P7-16, superseded by ADR holomush-f5h0): byte-equal
 // AAD reconstruction across an ns-precise publisher AAD and an
 // ns-precise PG-BIGINT round-trip. Without this, EVERY sensitive
@@ -89,14 +89,14 @@ func TestRoundTripPreservesAADWithSubMicrosecondNanos(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, encryptSideAAD, reconstructedAAD,
-		"INV-TS-5: AAD reconstruction MUST be byte-equal to encrypt-side; "+
+		"INV-STORE-5: AAD reconstruction MUST be byte-equal to encrypt-side; "+
 			"a mismatch breaks AEAD tag-check on every sensitive plugin-stored event")
 
-	// INV-TS-5 reinforcement: the sub-µs nanosecond component survives the
+	// INV-STORE-5 reinforcement: the sub-µs nanosecond component survives the
 	// publish → DB → read → AAD-reconstruct round-trip at ns column resolution.
 	roundTripTs := reconstructedEvent.GetTimestamp().AsTime()
 	assert.Equal(t, 789, roundTripTs.Nanosecond()%1000,
-		"INV-TS-5: AAD round-trip MUST preserve sub-µs nanoseconds at ns column resolution")
+		"INV-STORE-5: AAD round-trip MUST preserve sub-µs nanoseconds at ns column resolution")
 }
 
 // TestRoundTripProducesByteEqualAAD_NilActor exercises the same
@@ -139,5 +139,5 @@ func TestRoundTripProducesByteEqualAAD_NilActor(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, encryptSideAAD, reconstructedAAD,
-		"INV-TS-5: nil-Actor round trip MUST also produce byte-equal AAD")
+		"INV-STORE-5: nil-Actor round trip MUST also produce byte-equal AAD")
 }

--- a/internal/eventbus/history/readback.go
+++ b/internal/eventbus/history/readback.go
@@ -116,7 +116,7 @@ func decryptPluginRow(
 	}
 
 	// AuditRowToEvent omits Payload (it carries only the AAD-canonical
-	// fields, INV-TS-5). Restore the ciphertext so the dispatcher's Decode
+	// fields, INV-STORE-5). Restore the ciphertext so the dispatcher's Decode
 	// has its AEAD input; aad.Build excludes Payload, so the reconstructed
 	// AAD is unaffected by this assignment.
 	envelope := AuditRowToEvent(row)

--- a/internal/eventbus/publisher.go
+++ b/internal/eventbus/publisher.go
@@ -188,7 +188,7 @@ func (p *JetStreamPublisher) Publish(ctx context.Context, event Event) error {
 		Subject: string(event.Subject),
 		Type:    string(event.Type),
 		// Full ns precision — BIGINT-ns column migration (gfo6) makes µs-truncation
-		// unnecessary; structural AAD byte-equality holds via INV-TS-4 / INV-TS-5
+		// unnecessary; structural AAD byte-equality holds via INV-STORE-4 / INV-STORE-5
 		// (supersedes former INV-P7-16 discipline-dependent guarantee).
 		Timestamp: timestamppb.New(event.Timestamp),
 		Actor:     ActorToProto(event.Actor),

--- a/internal/eventbus/publisher_test.go
+++ b/internal/eventbus/publisher_test.go
@@ -302,7 +302,7 @@ func TestPublisherStampsAllRequiredHeaders(t *testing.T) {
 	require.NoError(t, d.Ack())
 }
 
-// TestPublisherPreservesNanoseconds gates INV-TS-4. The publisher MUST
+// TestPublisherPreservesNanoseconds gates INV-STORE-4. The publisher MUST
 // NOT truncate the event timestamp before AAD construction or envelope
 // marshal. After the BIGINT-ns migration, AAD reconstruction at read
 // time receives the full-precision timestamp from PG, so byte-equal AAD
@@ -338,9 +338,9 @@ func TestPublisherPreservesNanoseconds(t *testing.T) {
 	require.NoError(t, d.Ack())
 
 	assert.Equal(t, 789, got.Timestamp.Nanosecond()%1000,
-		"INV-TS-4: publisher MUST preserve sub-µs nanoseconds; sub-µs digits MUST survive")
+		"INV-STORE-4: publisher MUST preserve sub-µs nanoseconds; sub-µs digits MUST survive")
 	assert.Equal(t, ev.Timestamp, got.Timestamp.UTC(),
-		"INV-TS-4: published timestamp MUST equal source timestamp at full precision")
+		"INV-STORE-4: published timestamp MUST equal source timestamp at full precision")
 }
 
 func TestActorKindStringCoversAllVariants(t *testing.T) {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -1260,7 +1260,7 @@ func (s *CoreServer) dispatchDelivery(
 			"session_id", info.ID, "event_id", event.ID.String(), "error", getErr)
 		currentInfo = info
 	}
-	// Floor uses ns precision and >= semantics (INV-TS-6 / INV-TS-7,
+	// Floor uses ns precision and >= semantics (INV-STORE-6 / INV-STORE-7,
 	// gfo6 epic): publisher no longer truncates timestamps, so the
 	// scope-floor comparison runs at full time.Now() resolution.
 	floor := streamScopeFloor(currentInfo, string(event.Subject))

--- a/internal/grpc/subscribe_loop_test.go
+++ b/internal/grpc/subscribe_loop_test.go
@@ -312,7 +312,7 @@ func (e *erroringSessionStore) Get(_ context.Context, _ string) (*session.Info, 
 }
 
 // TestDispatchDeliveryDropsEventEmittedInSameNanosecondAsArrival gates
-// INV-TS-6. The floor comparison MUST operate at nanosecond resolution.
+// INV-STORE-6. The floor comparison MUST operate at nanosecond resolution.
 // An event whose Timestamp is one nanosecond BELOW the floor
 // (LocationArrivedAt) MUST be filtered out by dispatchDelivery.
 //
@@ -343,12 +343,12 @@ func TestDispatchDeliveryDropsEventEmittedInSameNanosecondAsArrival(t *testing.T
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err)
 	require.Len(t, stream.sent, 0,
-		"INV-TS-6: event one ns below floor MUST be filtered at dispatchDelivery")
+		"INV-STORE-6: event one ns below floor MUST be filtered at dispatchDelivery")
 	assert.Equal(t, 1, d.acks(),
 		"filtered event is ack'd (consumed, not forwarded)")
 }
 
-// TestDispatchDeliveryIncludesEventAtExactFloorNanosecond gates INV-TS-7.
+// TestDispatchDeliveryIncludesEventAtExactFloorNanosecond gates INV-STORE-7.
 // The floor MUST use >= semantics: an event whose Timestamp exactly equals
 // LocationArrivedAt MUST be INCLUDED in the visible window.
 //
@@ -375,7 +375,7 @@ func TestDispatchDeliveryIncludesEventAtExactFloorNanosecond(t *testing.T) {
 	err := s.dispatchDelivery(context.Background(), info, d, stream, nil)
 	require.NoError(t, err)
 	require.Len(t, stream.sent, 1,
-		"INV-TS-7: event at exact floor ns MUST be included (>= semantics)")
+		"INV-STORE-7: event at exact floor ns MUST be included (>= semantics)")
 	assert.Equal(t, 1, d.acks())
 }
 

--- a/internal/pgnanos/doc.go
+++ b/internal/pgnanos/doc.go
@@ -19,5 +19,5 @@
 //	    ..., pgnanos.From(time.Now()))
 //
 // See docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md
-// (INV-TS-1 through INV-TS-7) for the spec this package serves.
+// (INV-STORE-1 through INV-STORE-7) for the spec this package serves.
 package pgnanos

--- a/internal/pgnanos/pgnanos.go
+++ b/internal/pgnanos/pgnanos.go
@@ -15,7 +15,7 @@ type Time time.Time
 
 // From constructs a Time from a time.Time, preserving nanosecond
 // precision and normalizing to UTC. Callers MUST NOT have already
-// truncated t (INV-TS-3).
+// truncated t (INV-STORE-3).
 func From(t time.Time) Time { return Time(t.UTC()) }
 
 // Time returns the underlying time.Time in UTC.

--- a/internal/pgnanos/pgnanos_test.go
+++ b/internal/pgnanos/pgnanos_test.go
@@ -93,7 +93,7 @@ func TestValue(t *testing.T) {
 	}
 }
 
-// TestRoundTripPreservesSubMicrosecondNanoseconds pins INV-TS-2 (see
+// TestRoundTripPreservesSubMicrosecondNanoseconds pins INV-STORE-2 (see
 // internal/store/spec_meta_test.go cases slice). MUST remain a top-level
 // Test* function — the meta-test walks the AST for top-level decls,
 // not for t.Run subtests. Do not collapse into a table.

--- a/internal/store/lint_meta_test.go
+++ b/internal/store/lint_meta_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// TestLintNoMicrosecondTruncatePasses pins INV-TS-3 via the lint task.
+// TestLintNoMicrosecondTruncatePasses pins INV-STORE-3 via the lint task.
 // If anyone reintroduces a microsecond-precision truncate call without a
 // pgnanos-exempt annotation, this test fails along with the lint.
 //
@@ -29,12 +29,12 @@ func TestLintNoMicrosecondTruncatePasses(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "task", "lint:no-microsecond-truncate")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("INV-TS-3 violated: %s\n%s", err, strings.TrimSpace(string(out)))
+		t.Fatalf("INV-STORE-3 violated: %s\n%s", err, strings.TrimSpace(string(out)))
 	}
 }
 
 // TestLintNoMicrosecondTruncateScansAnExplicitPath is the regression guard for
-// holomush-vpvu5. The INV-TS-3 lint MUST hand rg an explicit search path. A
+// holomush-vpvu5. The INV-STORE-3 lint MUST hand rg an explicit search path. A
 // path-less `rg ... --type=go` reads stdin whenever stdin is not a TTY (CI
 // wires every run-step's stdin to /dev/null; background agents attach idle
 // pipes), so it scans empty stdin instead of the repo — passing silently while
@@ -53,7 +53,7 @@ func TestLintNoMicrosecondTruncateScansAnExplicitPath(t *testing.T) {
 		t.Fatalf("read %s: %v", taskfile, err)
 	}
 
-	// The lone rg invocation enforcing INV-TS-3 is the only line carrying all
+	// The lone rg invocation enforcing INV-STORE-3 is the only line carrying all
 	// of "rg -n", "--type=go", and "Microsecond"; the surrounding comment/echo
 	// lines that mention the pattern have neither "rg -n" nor "--type=go".
 	var rgLine string
@@ -65,7 +65,7 @@ func TestLintNoMicrosecondTruncateScansAnExplicitPath(t *testing.T) {
 		}
 	}
 	if rgLine == "" {
-		t.Fatal("could not locate the INV-TS-3 rg invocation in Taskfile.yaml")
+		t.Fatal("could not locate the INV-STORE-3 rg invocation in Taskfile.yaml")
 	}
 
 	// Capture the first token after --type=go. The path-less form leaves only
@@ -73,10 +73,10 @@ func TestLintNoMicrosecondTruncateScansAnExplicitPath(t *testing.T) {
 	// a search path such as {{.ROOT_DIR}}.
 	m := regexp.MustCompile(`--type=go\s+(\S+)`).FindStringSubmatch(rgLine)
 	if m == nil {
-		t.Fatalf("INV-TS-3 rg invocation has nothing after --type=go: %q", rgLine)
+		t.Fatalf("INV-STORE-3 rg invocation has nothing after --type=go: %q", rgLine)
 	}
 	if tok := m[1]; tok == `\` || tok == "|" {
-		t.Fatalf("INV-TS-3 rg invocation is path-less (token %q after --type=go) — under a "+
+		t.Fatalf("INV-STORE-3 rg invocation is path-less (token %q after --type=go) — under a "+
 			"non-TTY stdin rg reads stdin, not the repo: silent no-op in CI / hang on a pipe "+
 			"(holomush-vpvu5). Line: %s", tok, strings.TrimSpace(rgLine))
 	}

--- a/internal/store/migrate_clamp_integration_test.go
+++ b/internal/store/migrate_clamp_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// INV-TS-9: The TIMESTAMPTZ→BIGINT (epoch-nanosecond) conversion migrations
+// INV-STORE-9: The TIMESTAMPTZ→BIGINT (epoch-nanosecond) conversion migrations
 // (000038, 000041, 000042, 000043, 000044) MUST NOT error on pre-existing
 // data outside the int64-nanosecond range or on ±infinity sentinels. Such
 // values saturate to the int64 bounds (max ≈ 2262-04-11, min ≈ 1677-09-21);
@@ -55,7 +55,7 @@ type convCase struct {
 	insertNull func(label string) string
 }
 
-var _ = Describe("INV-TS-9: TIMESTAMPTZ→BIGINT conversion saturates out-of-range and infinity to int64-ns bounds and preserves NULL", func() {
+var _ = Describe("INV-STORE-9: TIMESTAMPTZ→BIGINT conversion saturates out-of-range and infinity to int64-ns bounds and preserves NULL", func() {
 	// boundary rows: SQL literal → expected post-conversion BIGINT.
 	type boundaryRow struct {
 		label string

--- a/internal/store/migrate_inv_ts_integration_test.go
+++ b/internal/store/migrate_inv_ts_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/holomush/holomush/test/testutil"
 )
 
-// INV-TS-1: After all migrations run, no holomush-owned schema may contain
+// INV-STORE-1: After all migrations run, no holomush-owned schema may contain
 // a TIMESTAMPTZ or TIMESTAMP column. All pre-gfo6 gap tables (bootstrap_metadata,
 // crypto_rekey_checkpoints, holomush_system_info, setting_bootstrap_state) were
 // migrated in 000044 (holomush-gfo6.34).
@@ -25,7 +25,7 @@ import (
 // Suite-registered with the store package's Ginkgo runner in
 // store_suite_test.go::TestStore. The Describe string is the literal pinned in
 // spec_meta_test.go cases (INV-TS-META meta-test).
-var _ = Describe("INV-TS-1: no TIMESTAMPTZ columns after migration", func() {
+var _ = Describe("INV-STORE-1: no TIMESTAMPTZ columns after migration", func() {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -68,7 +68,7 @@ var _ = Describe("INV-TS-1: no TIMESTAMPTZ columns after migration", func() {
 		Expect(rows.Err()).NotTo(HaveOccurred())
 
 		Expect(violations).To(BeEmpty(),
-			"INV-TS-1: holomush schemas MUST NOT contain TIMESTAMPTZ/TIMESTAMP columns after migration. Violations: %v",
+			"INV-STORE-1: holomush schemas MUST NOT contain TIMESTAMPTZ/TIMESTAMP columns after migration. Violations: %v",
 			violations)
 	})
 })

--- a/internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql
+++ b/internal/store/migrations/000038_eventbus_crypto_timestamps_to_bigint.up.sql
@@ -4,14 +4,14 @@
 -- Convert events_audit and crypto_keys timestamp columns from TIMESTAMPTZ
 -- to BIGINT (epoch nanoseconds, UTC). See:
 --   docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md
--- INV-TS-1, INV-TS-4, INV-TS-5.
+-- INV-STORE-1, INV-STORE-4, INV-STORE-5.
 --
 -- Idempotent: each ALTER COLUMN ... TYPE step is wrapped in a DO block that
 -- guards on information_schema.columns.data_type, so re-running this migration
 -- (recovery replays, partial-apply retries) is safe. Pattern mirrors
 -- 000017_events_audit_envelope_rename.up.sql.
 --
--- Overflow-safe (INV-TS-9): each TYPE USING clause converts in numeric and
+-- Overflow-safe (INV-STORE-9): each TYPE USING clause converts in numeric and
 -- clamps with GREATEST/LEAST to the int64-ns range, so pre-existing values
 -- beyond ~[1678, 2262] or ±infinity saturate to the int64 bounds instead of
 -- raising "bigint out of range" (SQLSTATE 22003). NULL is guarded explicitly

--- a/internal/store/migrations/000041_auth_timestamps_to_bigint.up.sql
+++ b/internal/store/migrations/000041_auth_timestamps_to_bigint.up.sql
@@ -2,14 +2,14 @@
 -- Copyright 2026 HoloMUSH Contributors
 
 -- Convert auth-domain timestamp columns from TIMESTAMPTZ to BIGINT
--- (epoch nanoseconds, UTC). INV-TS-1.
+-- (epoch nanoseconds, UTC). INV-STORE-1.
 --
 -- Idempotent: each ALTER COLUMN ... TYPE step is wrapped in a DO block that
 -- guards on information_schema.columns.data_type, so re-running this migration
 -- (recovery replays, partial-apply retries) is safe. Pattern mirrors
 -- 000038_eventbus_crypto_timestamps_to_bigint.up.sql.
 --
--- Overflow-safe (INV-TS-9): each TYPE USING clause converts in numeric and
+-- Overflow-safe (INV-STORE-9): each TYPE USING clause converts in numeric and
 -- clamps with GREATEST/LEAST to the int64-ns range, so pre-existing values
 -- beyond ~[1678, 2262] or ±infinity saturate to the int64 bounds instead of
 -- raising "bigint out of range" (SQLSTATE 22003). NULL is guarded explicitly

--- a/internal/store/migrations/000042_world_timestamps_to_bigint.up.sql
+++ b/internal/store/migrations/000042_world_timestamps_to_bigint.up.sql
@@ -2,14 +2,14 @@
 -- Copyright 2026 HoloMUSH Contributors
 
 -- Convert world-domain timestamp columns from TIMESTAMPTZ to BIGINT
--- (epoch nanoseconds, UTC). INV-TS-1.
+-- (epoch nanoseconds, UTC). INV-STORE-1.
 --
 -- Idempotent: each ALTER COLUMN ... TYPE step is wrapped in a DO block that
 -- guards on information_schema.columns.data_type, so re-running this migration
 -- (recovery replays, partial-apply retries) is safe. Pattern mirrors
 -- 000038_eventbus_crypto_timestamps_to_bigint.up.sql.
 --
--- Overflow-safe (INV-TS-9): each TYPE USING clause converts in numeric and
+-- Overflow-safe (INV-STORE-9): each TYPE USING clause converts in numeric and
 -- clamps with GREATEST/LEAST to the int64-ns range, so pre-existing values
 -- beyond ~[1678, 2262] or ±infinity saturate to the int64 bounds instead of
 -- raising "bigint out of range" (SQLSTATE 22003). NULL is guarded explicitly

--- a/internal/store/migrations/000043_totp_misc_timestamps_to_bigint.up.sql
+++ b/internal/store/migrations/000043_totp_misc_timestamps_to_bigint.up.sql
@@ -3,14 +3,14 @@
 
 -- Convert totp, admin_approvals, plugins, content_items, aliases, access
 -- policy, and access_audit_log timestamp columns from TIMESTAMPTZ to BIGINT
--- (epoch nanoseconds, UTC). INV-TS-1.
+-- (epoch nanoseconds, UTC). INV-STORE-1.
 --
 -- Idempotent: each ALTER COLUMN ... TYPE step is wrapped in a DO block that
 -- guards on information_schema.columns.data_type, so re-running this migration
 -- (recovery replays, partial-apply retries) is safe. Pattern mirrors
 -- 000038_eventbus_crypto_timestamps_to_bigint.up.sql.
 --
--- Overflow-safe (INV-TS-9): each TYPE USING clause converts in numeric and
+-- Overflow-safe (INV-STORE-9): each TYPE USING clause converts in numeric and
 -- clamps with GREATEST/LEAST to the int64-ns range, so pre-existing values
 -- beyond ~[1678, 2262] or ±infinity saturate to the int64 bounds instead of
 -- raising "bigint out of range" (SQLSTATE 22003). NULL is guarded explicitly

--- a/internal/store/migrations/000044_pregfo6_gap_timestamps_to_bigint.up.sql
+++ b/internal/store/migrations/000044_pregfo6_gap_timestamps_to_bigint.up.sql
@@ -2,15 +2,15 @@
 -- Copyright 2026 HoloMUSH Contributors
 
 -- Convert pre-gfo6 gap timestamp columns from TIMESTAMPTZ to BIGINT
--- (epoch nanoseconds, UTC). INV-TS-1. These tables were missed in the
--- Phases 1–4 sweep and surfaced by the INV-TS-1 meta-test (holomush-gfo6.22).
+-- (epoch nanoseconds, UTC). INV-STORE-1. These tables were missed in the
+-- Phases 1–4 sweep and surfaced by the INV-STORE-1 meta-test (holomush-gfo6.22).
 --
 -- Idempotent: each ALTER COLUMN ... TYPE step is wrapped in a DO block that
 -- guards on information_schema.columns.data_type, so re-running this migration
 -- (recovery replays, partial-apply retries) is safe. Pattern mirrors
 -- 000038_eventbus_crypto_timestamps_to_bigint.up.sql.
 --
--- Overflow-safe (INV-TS-9): each TYPE USING clause converts in numeric and
+-- Overflow-safe (INV-STORE-9): each TYPE USING clause converts in numeric and
 -- clamps with GREATEST/LEAST to the int64-ns range, so pre-existing values
 -- beyond ~[1678, 2262] or ±infinity saturate to the int64 bounds instead of
 -- raising "bigint out of range" (SQLSTATE 22003). NULL is guarded explicitly

--- a/internal/store/spec_meta_test.go
+++ b/internal/store/spec_meta_test.go
@@ -18,8 +18,8 @@ import (
 // TestNanosecondTimestampsInvariantsHaveNamedTests is the drift detector
 // for the invariants table in
 // docs/superpowers/specs/2026-05-22-nanosecond-timestamps-design.md §5.
-// For each INV-TS-N (1..7 and 9; INV-TS-8 was dropped — see the §7
-// future-work table), the test verifies the named test that pins the
+// For each INV-STORE-N (1..7 and 9; there is no INV-STORE-8 — the legacy
+// INV-TS-8 was dropped, see the §7 future-work table), the test verifies the named test that pins the
 // invariant exists somewhere in the repo's *_test.go corpus.
 //
 // "Named test" matches against two surfaces collected from the source AST:
@@ -49,28 +49,28 @@ func TestNanosecondTimestampsInvariantsHaveNamedTests(t *testing.T) {
 		inv      string
 		testName string
 	}{
-		// INV-TS-1: lint + Ginkgo integration spec (Describe string is
+		// INV-STORE-1: lint + Ginkgo integration spec (Describe string is
 		// the pinned identifier — the test is suite-registered under
 		// store_suite_test.go::TestStore, not a standalone func Test*).
-		{"INV-TS-1", "INV-TS-1: no TIMESTAMPTZ columns after migration"},
-		// INV-TS-2: pgnanos round-trip test
-		{"INV-TS-2", "TestRoundTripPreservesSubMicrosecondNanoseconds"},
-		// INV-TS-3: enforced by lint:no-microsecond-truncate; meta-test asserts the lint passes
-		{"INV-TS-3", "TestLintNoMicrosecondTruncatePasses"},
-		// INV-TS-4: publisher preserves ns
-		{"INV-TS-4", "TestPublisherPreservesNanoseconds"},
-		// INV-TS-5: AAD round-trip preserves ns
-		{"INV-TS-5", "TestRoundTripPreservesAADWithSubMicrosecondNanos"},
-		// INV-TS-6: floor drops sub-floor-ns events
-		{"INV-TS-6", "TestDispatchDeliveryDropsEventEmittedInSameNanosecondAsArrival"},
-		// INV-TS-7: floor includes exact-floor-ns events
-		{"INV-TS-7", "TestDispatchDeliveryIncludesEventAtExactFloorNanosecond"},
-		// INV-TS-9: conversion migrations saturate out-of-range/infinity to
+		{"INV-STORE-1", "INV-STORE-1: no TIMESTAMPTZ columns after migration"},
+		// INV-STORE-2: pgnanos round-trip test
+		{"INV-STORE-2", "TestRoundTripPreservesSubMicrosecondNanoseconds"},
+		// INV-STORE-3: enforced by lint:no-microsecond-truncate; meta-test asserts the lint passes
+		{"INV-STORE-3", "TestLintNoMicrosecondTruncatePasses"},
+		// INV-STORE-4: publisher preserves ns
+		{"INV-STORE-4", "TestPublisherPreservesNanoseconds"},
+		// INV-STORE-5: AAD round-trip preserves ns
+		{"INV-STORE-5", "TestRoundTripPreservesAADWithSubMicrosecondNanos"},
+		// INV-STORE-6: floor drops sub-floor-ns events
+		{"INV-STORE-6", "TestDispatchDeliveryDropsEventEmittedInSameNanosecondAsArrival"},
+		// INV-STORE-7: floor includes exact-floor-ns events
+		{"INV-STORE-7", "TestDispatchDeliveryIncludesEventAtExactFloorNanosecond"},
+		// INV-STORE-9: conversion migrations saturate out-of-range/infinity to
 		// int64-ns bounds, preserve NULL (Describe string is the pinned
-		// identifier — suite-registered under TestStore). INV-TS-8 was dropped
-		// (former wire-format invariant; see §7 future-work table), so the
-		// number is intentionally skipped.
-		{"INV-TS-9", "INV-TS-9: TIMESTAMPTZ→BIGINT conversion saturates out-of-range and infinity to int64-ns bounds and preserves NULL"},
+		// identifier — suite-registered under TestStore). The legacy INV-TS-8
+		// was dropped (former wire-format invariant; see §7 future-work table),
+		// so there is no INV-STORE-8 — the number is intentionally skipped.
+		{"INV-STORE-9", "INV-STORE-9: TIMESTAMPTZ→BIGINT conversion saturates out-of-range and infinity to int64-ns bounds and preserves NULL"},
 	}
 
 	repoRoot := findRepoRoot(t)

--- a/internal/testsupport/holomushtest/server.go
+++ b/internal/testsupport/holomushtest/server.go
@@ -550,7 +550,7 @@ func (p *testAuditPublisher) PublishAudit(
 	payload []byte,
 ) (ulid.ULID, error) {
 	id := ulid.Make()
-	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-TS-1); use the SQL-side
+	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-STORE-1); use the SQL-side
 	// BIGINT-ns expression rather than TIMESTAMPTZ now().
 	_, err := p.pool.Exec(ctx,
 		`INSERT INTO events_audit
@@ -769,7 +769,7 @@ func (p *directSQLPublisher) Publish(ctx context.Context, ev eventbus.Event) err
 	// Store ev.Payload (raw JSON body) directly as the envelope column.
 	// The policy chain verifier's decodePolicyPayloadJSON falls back to raw JSON
 	// when proto.Unmarshal fails, so this path is correct for test usage.
-	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-TS-1); SQL-side
+	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-STORE-1); SQL-side
 	// expression mirrors the migration's DEFAULT.
 	_, err := p.pool.Exec(ctx,
 		`INSERT INTO events_audit

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -709,7 +709,7 @@ func (s *Server) ReadBackAuditCount(_ context.Context) int {
 // auditRowToProto rebuilds the *pluginv1.AuditRow from a scene_log PluginAuditRow
 // field-for-field, mirroring plugins/core-scenes/publish_snapshot.go::
 // logRowToAuditRow so the AAD the host rebuilds (AuditRowToEvent + aad.Build) is
-// byte-equal to the encrypt-side AAD (INV-RB-4 / INV-TS-5).
+// byte-equal to the encrypt-side AAD (INV-RB-4 / INV-STORE-5).
 func auditRowToProto(r *PluginAuditRow) *pluginv1.AuditRow {
 	out := &pluginv1.AuditRow{
 		Id:        r.ID,

--- a/plugins/core-scenes/migrations/000007_timestamps_to_bigint.up.sql
+++ b/plugins/core-scenes/migrations/000007_timestamps_to_bigint.up.sql
@@ -2,8 +2,8 @@
 -- Copyright 2026 HoloMUSH Contributors
 
 -- Convert core-scenes timestamp columns from TIMESTAMPTZ to BIGINT (epoch
--- nanoseconds, UTC). Plugin-side companion to host migration. INV-TS-1,
--- INV-TS-5 (plugin AAD path).
+-- nanoseconds, UTC). Plugin-side companion to host migration. INV-STORE-1,
+-- INV-STORE-5 (plugin AAD path).
 
 -- Drop TIMESTAMPTZ defaults before type conversion; PostgreSQL cannot
 -- auto-cast TIMESTAMPTZ defaults when changing column type to BIGINT.

--- a/plugins/core-scenes/migrations/000008_scene_publication.up.sql
+++ b/plugins/core-scenes/migrations/000008_scene_publication.up.sql
@@ -3,7 +3,7 @@
 
 -- Phase 6 (holomush-5rh.15): publication artifact distinct from the
 -- audit scene_log table. See spec section 3.3.
--- Timestamps are BIGINT epoch-nanoseconds (INV-TS-1).
+-- Timestamps are BIGINT epoch-nanoseconds (INV-STORE-1).
 
 CREATE TABLE IF NOT EXISTS published_scenes (
     id                     TEXT        PRIMARY KEY,

--- a/plugins/core-scenes/poseorder_integration_test.go
+++ b/plugins/core-scenes/poseorder_integration_test.go
@@ -262,7 +262,7 @@ var _ = Describe("INV-P4-8: pose-order metadata is a function of scene_log", fun
 		Expect(*gotChar2.lastPoseSeq).To(Equal(*wantChar2.lastPoseSeq),
 			"INV-P4-8: rebuilt char2.last_pose_seq MUST equal maintained value")
 
-		// last_pose_at is BIGINT-ns; round-trip is bit-exact (INV-TS-1, INV-TS-2).
+		// last_pose_at is BIGINT-ns; round-trip is bit-exact (INV-STORE-1, INV-STORE-2).
 		Expect(gotChar1.lastPoseAt).NotTo(BeNil(),
 			"INV-P4-8: rebuilt char1.last_pose_at MUST be set")
 		Expect(gotChar2.lastPoseAt).NotTo(BeNil(),

--- a/plugins/core-scenes/publish_service.go
+++ b/plugins/core-scenes/publish_service.go
@@ -112,7 +112,7 @@ func assembleParticipantResponse(pub *PublishedScene, entries []PublishedSceneEn
 		AttemptNumber:          int32(pub.AttemptNumber), //nolint:gosec // attempt_number is bounded by max_publish_attempts (single digits); never overflows int32
 		Status:                 string(pub.Status),
 		ParticipantsSnapshot:   pub.ParticipantsSnapshot,
-		InitiatedAtUnixNs:      pub.InitiatedAt.Time().UnixNano(), // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-TS-2 targets the DB seam)
+		InitiatedAtUnixNs:      pub.InitiatedAt.Time().UnixNano(), // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-STORE-2 targets the DB seam)
 		CooloffStartedAtUnixNs: unixNanoOrZero(pub.CoolOffStartedAt),
 		ResolvedAtUnixNs:       unixNanoOrZero(pub.ResolvedAt),
 		PublishedAtUnixNs:      unixNanoOrZero(pub.PublishedAt),
@@ -146,7 +146,7 @@ func unixNanoOrZero(t *pgnanos.Time) int64 {
 	if t == nil {
 		return 0
 	}
-	return t.Time().UnixNano() // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-TS-2 targets the DB seam)
+	return t.Time().UnixNano() // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-STORE-2 targets the DB seam)
 }
 
 // StartScenePublish opens a publication attempt for an ended scene. The
@@ -461,7 +461,7 @@ func assembleAttemptsResponse(attempts []PublishedScene) *scenev1.ListScenePubli
 			Id:                a.ID,
 			AttemptNumber:     int32(a.AttemptNumber), //nolint:gosec // attempt_number bounded by max_publish_attempts; never overflows int32
 			Status:            string(a.Status),
-			InitiatedAtUnixNs: a.InitiatedAt.Time().UnixNano(), // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-TS-2 targets the DB seam)
+			InitiatedAtUnixNs: a.InitiatedAt.Time().UnixNano(), // pgnanos-exempt: proto int64 *_unix_ns wire field; serializing a pgnanos.Time, not a DB scan/insert seam (INV-STORE-2 targets the DB seam)
 			ResolvedAtUnixNs:  unixNanoOrZero(a.ResolvedAt),
 		}
 		if a.FailureReason != nil {

--- a/plugins/core-scenes/publish_snapshot.go
+++ b/plugins/core-scenes/publish_snapshot.go
@@ -319,7 +319,7 @@ func (s *SceneServiceImpl) failSnapshotTx(ctx context.Context, tx pgx.Tx, attemp
 // host read-back primitive consumes. The conversion mirrors the QueryHistory
 // proto build (audit.go) field-for-field so the AAD the host rebuilds via
 // AuditRowToEvent + aad.Build is byte-equal to the encrypt-side AAD
-// (INV-RB-4 / INV-TS-5). Subject is the snapshot's authoritative IC subject
+// (INV-RB-4 / INV-STORE-5). Subject is the snapshot's authoritative IC subject
 // (the store passes the same value to the WHERE clause). DEK ref/version are
 // widened to the proto's unsigned optional fields only when present (identity
 // rows leave them nil).

--- a/plugins/core-scenes/publish_store.go
+++ b/plugins/core-scenes/publish_store.go
@@ -605,10 +605,10 @@ func (s *SceneStore) ExtendMaxPublishAttempts(ctx context.Context, sceneID strin
 // Timestamp and ActorKind are carried because the host read-back decrypt
 // primitive rebuilds the per-event AAD from the row's authoritative fields
 // (id/subject/type/timestamp/actor.kind/actor.id/codec/dek_ref/dek_version) via
-// AuditRowToEvent + aad.Build — the INV-TS-5 byte-equal round-trip. A LogRow
+// AuditRowToEvent + aad.Build — the INV-STORE-5 byte-equal round-trip. A LogRow
 // missing these fields would reconstruct a non-matching AAD and fail AEAD
 // tag-check on every sensitive row (read-back design INV-RB-4). Timestamp is the
-// BIGINT epoch-ns scene_log column (INV-TS-1).
+// BIGINT epoch-ns scene_log column (INV-STORE-1).
 type LogRow struct {
 	ID         []byte
 	Type       string
@@ -760,7 +760,7 @@ func (s *SceneStore) MarkPublished(ctx context.Context, tx pgx.Tx, id string, in
 //
 // nowNs is supplied by the Go-clock caller as epoch nanoseconds
 // rather than using SQL now() so the comparison is always against the same Go
-// clock used to write initiated_at (INV-TS-1, noremoteclockcompare gorule).
+// clock used to write initiated_at (INV-STORE-1, noremoteclockcompare gorule).
 //
 // vote_window is an INTERVAL stored as microseconds; it is converted to
 // nanoseconds inline: EXTRACT(EPOCH FROM vote_window)::BIGINT * 1000000000.

--- a/plugins/core-scenes/store.go
+++ b/plugins/core-scenes/store.go
@@ -363,7 +363,7 @@ func (s *SceneStore) IsMember(ctx context.Context, sceneID, characterID string) 
 // transitions cannot corrupt the state machine.
 //
 // Sets `state = 'ended'` and `ended_at = $2` (app-supplied `pgnanos.From(time.Now())`,
-// per INV-TS-1 BIGINT-ns seam) atomically and returns the resulting row via
+// per INV-STORE-1 BIGINT-ns seam) atomically and returns the resulting row via
 // Postgres RETURNING. Returns SCENE_NOT_FOUND if no row
 // matches the ID at all, or SCENE_TRANSITION_FORBIDDEN if the row exists
 // but is in a state that cannot be ended.

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -1890,7 +1890,7 @@ var _ = Describe("SceneStore", func() {
 			sceneID := "scene-cascade-test-01"
 
 			// Insert a published_scenes row with all NOT NULL columns.
-			// initiated_at is BIGINT epoch-nanoseconds (INV-TS-1).
+			// initiated_at is BIGINT epoch-nanoseconds (INV-STORE-1).
 			_, err := store.pool.Exec(
 				ctx, `
 				INSERT INTO published_scenes
@@ -2401,7 +2401,7 @@ var _ = Describe("Publish store — ReadSceneLogForSnapshot", func() {
 		store := newTestStore()
 		subject := "events.main.scene.scene-snaplog-1.ic"
 
-		// scene_log.timestamp is BIGINT epoch-nanos (INV-TS-1, migration 000007).
+		// scene_log.timestamp is BIGINT epoch-nanos (INV-STORE-1, migration 000007).
 		// Ordering is by id ASC, so make the ids deterministically increasing:
 		// a strictly-monotonic time component with zero entropy guarantees
 		// insertion order == ORDER BY id ASC by construction, without depending

--- a/test/integration/crypto/harness_impl_test.go
+++ b/test/integration/crypto/harness_impl_test.go
@@ -183,7 +183,7 @@ func (h *Harness) seedDEKAndEvents(t *testing.T, cfg HarnessConfig) {
 	// (`{"type":"test","seq":N}`, N starting at 0); E2E specs exercise Phase 3
 	// cold re-encryption which transforms these rows. js_seq is 1-indexed.
 	//
-	// Note: timestamp column is BIGINT-ns post-gfo6 (INV-TS-1); the SQL-side
+	// Note: timestamp column is BIGINT-ns post-gfo6 (INV-STORE-1); the SQL-side
 	// (EXTRACT(EPOCH FROM now()) * 1e9)::BIGINT expression evaluates once per
 	// statement, so all seeded rows share one timestamp. Specs that need a
 	// deterministic order over the seed rows MUST order by js_seq, not timestamp.
@@ -372,7 +372,7 @@ func (h *Harness) SeedCompletedCheckpoint(ctxType, ctxID string) {
 	// Compute a synthetic DEK id that is unlikely to collide: hash the key string
 	// into a large int64 using a stable deterministic formula.
 	dekID := seedDEKID(77770000, ctxType, ctxID)
-	// crypto_keys.created_at is BIGINT-ns post-gfo6 (INV-TS-1).
+	// crypto_keys.created_at is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, _ = h.DB.Exec(ctx,
 		`INSERT INTO crypto_keys
 		   (id, context_type, context_id, version, wrapped_dek, wrap_provider,
@@ -409,7 +409,7 @@ func (h *Harness) SeedActiveCheckpoint(ctxType, ctxID string) {
 	defer cancel()
 
 	dekID := seedDEKID(88890000, ctxType, ctxID)
-	// crypto_keys.created_at is BIGINT-ns post-gfo6 (INV-TS-1).
+	// crypto_keys.created_at is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, _ = h.DB.Exec(ctx,
 		`INSERT INTO crypto_keys
 		   (id, context_type, context_id, version, wrapped_dek, wrap_provider,

--- a/test/integration/crypto/rekey_inv39_test.go
+++ b/test/integration/crypto/rekey_inv39_test.go
@@ -61,7 +61,7 @@ func (d *directColdLookup) LookupByID(ctx context.Context, id eventbus.EventID) 
 		codecName  string
 		dekRef     *int64
 		dekVersion *uint32
-		// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-TS-1);
+		// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-STORE-1);
 		// scan target must be pgnanos.Time. ts is unused downstream
 		// (env is built from envelope bytes), so this is a position
 		// placeholder for Scan's column-count alignment.
@@ -136,7 +136,7 @@ func insertEncryptedAuditRow(
 		return ulid.ULID{}, err
 	}
 
-	// timestamp is BIGINT-ns post-gfo6 (INV-TS-1).
+	// timestamp is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, execErr := pool.Exec(ctx, `
 		INSERT INTO events_audit
 		  (id, subject, type, timestamp, actor_kind, envelope, schema_ver,

--- a/test/integration/crypto/rekey_sweep_ttl_test.go
+++ b/test/integration/crypto/rekey_sweep_ttl_test.go
@@ -51,7 +51,7 @@ func (p *sweepTestAuditPublisher) PublishAudit(
 	payload []byte,
 ) (ulid.ULID, error) {
 	id := ulid.Make()
-	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-TS-1).
+	// events_audit.timestamp is BIGINT-ns post-gfo6 (INV-STORE-1).
 	_, err := p.pool.Exec(ctx,
 		`INSERT INTO events_audit
 		   (id, subject, type, timestamp, actor_kind, envelope, schema_ver, codec, js_seq, rendering)

--- a/test/integration/plugin/binary_plugin_test.go
+++ b/test/integration/plugin/binary_plugin_test.go
@@ -610,7 +610,7 @@ var _ = Describe("Binary Plugin Lifecycle", func() {
 		}
 
 		// Helper for direct DB state read. ended_at is BIGINT-ns post-gfo6
-		// (INV-TS-1); nullable column → *pgnanos.Time pointer pattern.
+		// (INV-STORE-1); nullable column → *pgnanos.Time pointer pattern.
 		readSceneState := func(id string) (state string, endedAt *pgnanos.Time) {
 			err := lifecyclepool.QueryRow(
 				lifecyclectx,

--- a/test/integration/privacy/privacy_test.go
+++ b/test/integration/privacy/privacy_test.go
@@ -359,7 +359,7 @@ var _ = Describe("I-PRIV-3 / I-PRIV-4: detach/reattach preserves session floor a
 		// with the same type at unrelated timestamps).
 		//
 		// Post-holomush-gfo6 the entire pipeline preserves nanosecond precision
-		// end-to-end (INV-TS-1 BIGINT-ns columns + INV-TS-4 publisher does not
+		// end-to-end (INV-STORE-1 BIGINT-ns columns + INV-STORE-4 publisher does not
 		// truncate). The prior defensive microsecond floor-truncate is no
 		// longer needed — wall-clock floors compare against equal-precision
 		// event timestamps.
@@ -420,7 +420,7 @@ var _ = Describe("I-PRIV-1: new guest sees no pre-arrival location history", fun
 			To(Succeed(), "harness emit MUST succeed for the seed event")
 		guestA.Logout(ctx)
 
-		// INV-TS-6/INV-TS-7 (gfo6): ns-resolution timestamps + >= floor semantics
+		// INV-STORE-6/INV-STORE-7 (gfo6): ns-resolution timestamps + >= floor semantics
 		// make the prior µs tie-prevention gap unnecessary.
 
 		// Guest B connects (fresh) into the same location.
@@ -591,7 +591,7 @@ var _ = Describe("I-PRIV-2 (scene): scene events before join are invisible", fun
 		Expect(owner.EmitDirectEvent(ctx, sceneStream, "core-scenes:pose", prePayload)).
 			To(Succeed(), "pre-join seed event MUST publish")
 
-		// INV-TS-6/INV-TS-7 (gfo6): ns-resolution timestamps + >= floor semantics
+		// INV-STORE-6/INV-STORE-7 (gfo6): ns-resolution timestamps + >= floor semantics
 		// make the prior µs tie-prevention gap unnecessary.
 
 		// Joiner connects and joins the scene. JoinScene stamps the


### PR DESCRIPTION
## Summary

Third per-scope migration in the `INV-<SCOPE>-N` registry migration (`holomush-hz0v4.14`) — the **largest, most cross-cutting** scope. Migrates legacy family **INV-TS-N** (nanosecond-timestamps discipline + `pgnanos` seam) to **INV-STORE-N** via `cmd/inv-migrate`: **68 sites across 42 files** renamed, 8 invariants registered (`binding: pending`), scope flipped to `migrated`, `invariants.md` regenerated.

**1:1 number mapping preserved; there is no `INV-STORE-8`** — legacy `INV-TS-8` (a wire-format invariant) was dropped (origin spec §7; successor is a P3 task). Scope = `INV-STORE-1..7, 9`.

## Classification (survey-driven)

The TS family is annotated *widely* (every nanos round-trip touches it), so most sites ride on files owned by other scopes:
- **12 owned** (`pgnanos/**`, `store/migrations/**`, the store meta/migrate tests)
- **30 shared_files** (`.go` + plugin migration comments + Taskfile lint descs) — TS rides alongside CRYPTO/SCENE/EVENTBUS/PRIVACY annotations there.

**Survey covered `.go` + `.sql` + `Taskfile.yaml`** — a `.go`-only sweep would have missed 8 non-Go sites (5 shipped `internal/store/migrations/*.up.sql` [owned], 2 `plugins/core-scenes/migrations/*.up.sql` + 3 `Taskfile.yaml` lint descs [shared]). Per your approval, those were renamed for consistency (comment-only edits to shipped migrations; `golang-migrate` tracks versions not content, so behavior is unchanged).

## Safety

- **No collateral damage:** whole-token rewrite left adjacent other-scope tokens intact (`INV-P7-16`, `INV-RB-4`, `INV-W9ML-9`, `INV-GW-*` all unchanged at their sites).
- **SQL edits are comment-only** — verified no DDL changed; the `internal/store` migrate integration tests *run* these migrations and pass (186 tests).
- **Behavioral meta-tests kept, not retired:** `spec_meta_test.go` (id→pinned-test-name table) and `lint_meta_test.go` are STORE-owned and renamed in lockstep with the test names/Describe strings they pin, so they stay consistent (unlike `.14.5`'s per-family *coverage* test, which scanned for the legacy token and was retired).

## Verification

- code-reviewer → **READY** (no blocking). One forward note: `no_delete_grep_test.go` carries an `INV-W9ML-9` token → recorded on `.14.14` (INV-PLUGIN) for its future shared_files.
- Sweep: zero leftover `INV-TS` except the 2 intentional "INV-TS-8 was dropped" prose mentions. 42 token-files == 42 registry-ref-files (closure verified).
- guard + partition + binding + render-check green; `internal/store`/`pgnanos`/`grpc`/`eventbus` unit (Docker, 900+ tests) green; integration packages compile-verified (`go vet -tags=integration`); `task lint` exit 0; fast lane pass.

> `task pr-prep:full` still blocked locally by the unrelated `check-bead-jxo8-5.sh` (jxo8 closed-epic bd reverse-index quirk; not in CI). CI runs the Integration + E2E gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)