### PR TITLE
refactor(invariants): register INV-TELEMETRY (spec-only LOAD family) (holomush-hz0v4.14.8)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -81,4 +81,17 @@ invariants.
 | `INV-STORE-7` | Sub-microsecond timestamp ties resolve deterministically; the privacy floor uses >= so an event at the exact floor ns is included. | `INV-TS-7` | pending |
 | `INV-STORE-9` | TIMESTAMPTZ->BIGINT conversion migrations saturate out-of-range / +/-infinity to int64 bounds, pass NULL through, and convert in-range values exactly (numeric arithmetic). | `INV-TS-9` | pending |
 
+### `INV-TELEMETRY`
+
+| ID | Summary | Legacy | Binding |
+|----|---------|--------|---------|
+| `INV-TELEMETRY-1` | Load harness drives the web tier over the Connect protocol (not gRPC/gRPC-Web). | `INV-LOAD-1` | pending |
+| `INV-TELEMETRY-2` | Load harness drives the telnet tier over raw TCP through the real gateway telnet listener. | `INV-LOAD-2` | pending |
+| `INV-TELEMETRY-3` | say->broadcast and page/whisper->delivery latency is computed from an in-payload emit-timestamp recorded by the recipient VU (never cross-VU shared state); generator/SUT clock skew <= 50ms. | `INV-LOAD-3` | pending |
+| `INV-TELEMETRY-4` | Load pass/fail verdict is derived from k6's exit code (thresholds), never a substring match on k6 output. | `INV-LOAD-4` | pending |
+| `INV-TELEMETRY-5` | SLO thresholds gate against .benchmarks/load-baseline.json (relative regression), not hard-coded absolutes, once a baseline exists. | `INV-LOAD-5` | pending |
+| `INV-TELEMETRY-6` | Load scenario must not issue command verbs not registered in the running server (command-availability gating). | `INV-LOAD-6` | pending |
+| `INV-TELEMETRY-7` | Load action selection is seeded deterministically so two runs of the same scenario config produce the same action sequence. | `INV-LOAD-7` | pending |
+| `INV-TELEMETRY-8` | The load harness must not be wired into task pr-prep (fast lane). | `INV-LOAD-8` | pending |
+
 <!-- END GENERATED: invariant-tables -->

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -326,8 +326,9 @@ scopes:
   - name: INV-TELEMETRY
     description: "Logging discipline, trace context, metric naming, sloglint policy"
     boundary: "Observability contracts."
-    # Family LOAD (load/perf harness latency+verdict). See redesign spec §2.1.
-    status: pending
+    # Family LOAD (INV-LOAD-1..8, load/perf harness). Spec-only — harness unbuilt;
+    # see redesign spec §2.1. (Scaffold/map said 1..4; the spec defines 8.)
+    status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
     owned_paths:
@@ -621,4 +622,69 @@ invariants:
       - {file: "internal/store/migrations/000042_world_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
       - {file: "internal/store/migrations/000043_totp_misc_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
       - {file: "internal/store/migrations/000044_pregfo6_gap_timestamps_to_bigint.up.sql", token: "INV-TS-9"}
-      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-9"}
+      - {file: "internal/store/spec_meta_test.go", token: "INV-TS-9",}
+
+  # -- INV-TELEMETRY -- migrated from INV-LOAD-N (family LOAD, load-perf harness) (holomush-hz0v4.14.8).
+  # Origin: docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md.
+  # Spec-only family: the load-perf harness is not yet built (test/load/ absent, no
+  # k6/baseline, zero in-code annotations), so all 8 are refs: [] / binding: pending.
+  # When the harness lands it annotates with INV-TELEMETRY-N directly (backfill .11).
+  - id: INV-TELEMETRY-1
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-1@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "Load harness drives the web tier over the Connect protocol (not gRPC/gRPC-Web)."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-2
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-2@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "Load harness drives the telnet tier over raw TCP through the real gateway telnet listener."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-3
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-3@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "say->broadcast and page/whisper->delivery latency is computed from an in-payload emit-timestamp recorded by
+      the recipient VU (never cross-VU shared state); generator/SUT clock skew <= 50ms."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-4
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-4@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "Load pass/fail verdict is derived from k6's exit code (thresholds), never a substring match on k6 output."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-5
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-5@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "SLO thresholds gate against .benchmarks/load-baseline.json (relative regression), not hard-coded absolutes,
+      once a baseline exists."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-6
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-6@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "Load scenario must not issue command verbs not registered in the running server (command-availability gating)."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-7
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-7@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "Load action selection is seeded deterministically so two runs of the same scenario config produce the same action
+      sequence."
+    binding: pending
+    refs: []
+  - id: INV-TELEMETRY-8
+    scope: INV-TELEMETRY
+    origin_spec: "docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"
+    legacy: ["INV-LOAD-8@docs/superpowers/specs/2026-05-28-load-perf-testing-harness-design.md"]
+    summary: "The load harness must not be wired into task pr-prep (fast lane)."
+    binding: pending
+    refs: []


### PR DESCRIPTION
## Summary

Fourth per-scope migration. INV-TELEMETRY's legacy family is **LOAD** (`INV-LOAD-1..8`, the load-perf testing harness). The family is **spec-only**: the harness is unbuilt (`test/load/` absent, no k6/`load-baseline.json`, zero `INV-LOAD` tokens anywhere in code across `.go`/`.sql`/`.yaml`). So this is a **registry-only** change — no `cmd/inv-migrate` rewrites.

Registers `INV-TELEMETRY-1..8` (legacy `INV-LOAD-1..8`), all `binding: pending` / `refs: []`, flips the scope to `status: migrated`, regenerates `invariants.md`. When the harness lands it annotates with `INV-TELEMETRY-N` directly (binding backfill is `.11`).

## Notes

- **Corrected the scaffold/family-map undercount:** they said `INV-LOAD-1..4`; the origin spec defines **8** (verified `INV-LOAD-1..8`).
- `owned_paths` (`internal/logging/**`, `internal/telemetry/**`, `test/load/**`) and `shared_files: []` unchanged — residual-safe (no bare `INV-N` in the owned dirs; `test/load/**` is absent so the residual walk skips it).
- The trailing comma on the final flow-mapping ref (`invariants.yaml`) is **dprint-canonical** (the formatter puts it on the file's last flow-map); `fmt:check` is green with it.

## Verification

- code-reviewer → **READY** (no blocking; the one nit — a trailing comma — is fmt-canonical, confirmed `task fmt` re-adds it).
- Zero `INV-LOAD` tokens in code (all 8 `refs: []` correct, not missed). 8 summaries spot-checked against the spec.
- guard + partition + binding + render-check green; `task lint` exit 0; fast lane pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)