### PR TITLE
refactor(invariants): migrate INV-ACCESS to canonical ids (holomush-hz0v4.14.10)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -72,6 +72,17 @@ invariants.
 | `INV-PRESENCE-8` | Client presence map keyed by character_id; idempotent add/remove. | `I-PRES-8` | pending |
 | `INV-PRESENCE-9` | Response deduplicates by character_id (defense-in-depth). | `I-PRES-9` | pending |
 
+### `INV-ACCESS`
+
+| ID | Summary | Legacy | Binding |
+|----|---------|--------|---------|
+| `INV-ACCESS-1` | With WithRealABAC(), the CoreServer access engine is the setup.BuildABACStack engine, not allowAllPolicyEngine. | `INV-RA-1` | pending |
+| `INV-ACCESS-2` | Without WithRealABAC(), the harness retains the allow-all default (no regression). | `INV-RA-2` | pending |
+| `INV-ACCESS-3` | With WithRealABAC(), the seed:* policy set is installed before the engine's cache loads; the engine evaluates against a non-empty seeded policy set. | `INV-RA-3` | pending |
+| `INV-ACCESS-4` | With WithRealABAC()+WithInTreePlugins(), the attribute.Resolver and attribute.PluginProvider the plugin subsystem registers on are the SAME instances (pointer identity) the engine evaluates against. | `INV-RA-4` | pending |
+| `INV-ACCESS-5` | Every attribute namespace referenced by an installed seed policy has a registered provider under WithRealABAC (no silent default-deny from an unregistered provider). | `INV-RA-5` | pending |
+| `INV-ACCESS-6` | Option order MUST NOT affect the resulting stack: Start(t,A,B) and Start(t,B,A) produce identical permit/deny behavior. | `INV-RA-6` | pending |
+
 ### `INV-SESSION`
 
 | ID | Summary | Legacy | Binding |

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -268,15 +268,20 @@ scopes:
   - name: INV-ACCESS
     description: "ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions"
     boundary: "Access control evaluation. Does NOT include: stream-access gating at gRPC boundary (→ INV-EVENTBUS)."
-    # Family RA (real-ABAC harness). See redesign spec §2.1.
-    status: pending
+    # Family RA (real-ABAC harness). All INV-RA sites are in the integration
+    # harness (internal/testsupport/integrationtest/), not internal/access/. See .14.10.
+    status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
     owned_paths:
-      - "internal/access/**"
+      # The real-ABAC harness files (where INV-RA-1..6 live). NOT internal/access/**
+      # — that has no RA token and harbors a separate unmigrated bare-INV-N family.
+      - "internal/testsupport/integrationtest/real_abac.go"
+      - "internal/testsupport/integrationtest/real_abac_test.go"
     shared_files:
-      # ACCESS+SCENE+CRYPTO+EVENTBUS+PLUGIN: shared integration harness (RA-4 site).
+      # General integration harness (RA-4 pointer-identity ride-along).
       - "internal/testsupport/integrationtest/harness.go"
+      - "internal/testsupport/integrationtest/plugins.go"
 
   - name: INV-SESSION
     description: "Session status lifecycle, connection attachment, focus membership, idle detection"
@@ -822,4 +827,66 @@ invariants:
     refs:
       - {file: "internal/eventbus/subscriber_consumer_config.go", token: "I-PRIV-8"}
       - {file: "internal/eventbus/subscriber_consumer_config_test.go", token: "I-PRIV-8"}
-      - {file: "test/integration/privacy/privacy_test.go", token: "I-PRIV-8"}
+      - {file: "test/integration/privacy/privacy_test.go", token: "I-PRIV-8",}
+
+  # -- INV-ACCESS -- migrated from INV-RA-N (family RA, real-ABAC harness) (holomush-hz0v4.14.10).
+  # Origin: docs/superpowers/specs/2026-05-26-harness-real-abac-design.md. binding: pending — backfill .11.
+  # NOTE: all INV-RA sites live in internal/testsupport/integrationtest/ (the real-ABAC
+  # harness), NOT internal/access/. The scaffold's owned_paths=internal/access/** was
+  # corrected (it owns zero RA tokens and harbors a SEPARATE unmigrated bare-INV-N family
+  # INV-15/INV-A16 that a /** residual walk would false-flag).
+  - id: INV-ACCESS-1
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-1@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "With WithRealABAC(), the CoreServer access engine is the setup.BuildABACStack engine, not allowAllPolicyEngine."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-1"}
+  - id: INV-ACCESS-2
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-2@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "Without WithRealABAC(), the harness retains the allow-all default (no regression)."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-2"}
+  - id: INV-ACCESS-3
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-3@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "With WithRealABAC(), the seed:* policy set is installed before the engine's cache loads; the engine evaluates
+      against a non-empty seeded policy set."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-3"}
+  - id: INV-ACCESS-4
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-4@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "With WithRealABAC()+WithInTreePlugins(), the attribute.Resolver and attribute.PluginProvider the plugin subsystem
+      registers on are the SAME instances (pointer identity) the engine evaluates against."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/harness.go", token: "INV-RA-4"}
+      - {file: "internal/testsupport/integrationtest/plugins.go", token: "INV-RA-4"}
+      - {file: "internal/testsupport/integrationtest/real_abac.go", token: "INV-RA-4"}
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-4"}
+  - id: INV-ACCESS-5
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-5@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "Every attribute namespace referenced by an installed seed policy has a registered provider under WithRealABAC
+      (no silent default-deny from an unregistered provider)."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-5"}
+  - id: INV-ACCESS-6
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+    legacy: ["INV-RA-6@docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"]
+    summary: "Option order MUST NOT affect the resulting stack: Start(t,A,B) and Start(t,B,A) produce identical permit/deny
+      behavior."
+    binding: pending
+    refs:
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-6"}

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -362,7 +362,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 		res, pp, aud := pluginAttrSources(abacSub)
 		// Under WithRealABAC, route plugin manifest-policy installs through the
 		// engine's own cache-wired installer so they go live on the real engine
-		// (mirrors INV-RA-4's resolver/provider routing). nil → startPlugins uses
+		// (mirrors INV-ACCESS-4's resolver/provider routing). nil → startPlugins uses
 		// a fresh standalone installer for the allow-all default.
 		var policyInst *plugins.PolicyInstaller
 		if abacSub != nil {

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -294,7 +294,7 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	// Resolver / plugin provider are caller-supplied (pluginAttrSources): with a
 	// real ABAC subsystem they are the engine's OWN instances so plugin-declared
 	// providers (e.g. core-scenes' "scene" namespace) register on the resolver the
-	// engine evaluates against (INV-RA-4); with allow-all they are fresh standalone
+	// engine evaluates against (INV-ACCESS-4); with allow-all they are fresh standalone
 	// instances. Both are non-nil — PluginSubsystem.Start calls
 	// resolver.RegisterProvider per plugin that declares resource_types and panics
 	// on a nil resolver (subsystem.go:319).

--- a/internal/testsupport/integrationtest/real_abac.go
+++ b/internal/testsupport/integrationtest/real_abac.go
@@ -66,7 +66,7 @@ func startRealABAC(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *abacs
 // the plugin subsystem should register against. With a real ABAC subsystem, these
 // are the subsystem's OWN instances so plugin-declared providers (e.g. core-scenes'
 // "scene" namespace) register on the resolver the engine evaluates against
-// (INV-RA-4). With no real engine (allow-all default), fresh standalone instances
+// (INV-ACCESS-4). With no real engine (allow-all default), fresh standalone instances
 // are correct — allow-all ignores attributes, so the #4275 behavior is preserved.
 func pluginAttrSources(abacSub *abacsetup.ABACSubsystem) (*attribute.Resolver, *attribute.PluginProvider, pluginauthz.Auditor) {
 	if abacSub != nil {

--- a/internal/testsupport/integrationtest/real_abac_test.go
+++ b/internal/testsupport/integrationtest/real_abac_test.go
@@ -32,7 +32,7 @@ func movedAwayPlayer(t *testing.T, ctx context.Context, ts *Server, charName str
 	return sess, priorStream
 }
 
-// INV-RA-1: under WithRealABAC, a regular (non-staff) character is DENIED a
+// INV-ACCESS-1: under WithRealABAC, a regular (non-staff) character is DENIED a
 // read against a location it has left. Allow-all would permit this via the
 // staffOverride bypass — so a passing assertion here proves the engine is the
 // real seeded engine, not allowAllPolicyEngine.
@@ -43,14 +43,14 @@ func TestRealABAC_RegularPlayerDeniedNonColocatedRead(t *testing.T) {
 	mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
 
 	_, err := mover.QueryStreamHistory(ctx, priorStream)
-	require.Error(t, err, "INV-RA-1: real engine MUST deny a regular player's non-colocated read")
+	require.Error(t, err, "INV-ACCESS-1: real engine MUST deny a regular player's non-colocated read")
 	oopsErr, ok := oops.AsOops(err)
 	require.True(t, ok, "denial must surface as an oops error")
 	require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code(),
-		"INV-RA-1: denial MUST collapse to STREAM_ACCESS_DENIED")
+		"INV-ACCESS-1: denial MUST collapse to STREAM_ACCESS_DENIED")
 }
 
-// INV-RA-2: without WithRealABAC, the harness retains the allow-all default —
+// INV-ACCESS-2: without WithRealABAC, the harness retains the allow-all default —
 // the same non-colocated read SUCCEEDS (staff bypass). Guards against an
 // accidental flip of the default.
 func TestRealABAC_DefaultEngineStillAllowAll(t *testing.T) {
@@ -61,10 +61,10 @@ func TestRealABAC_DefaultEngineStillAllowAll(t *testing.T) {
 
 	_, err := mover.QueryStreamHistory(ctx, priorStream)
 	require.NoError(t, err,
-		"INV-RA-2: allow-all default MUST permit the non-colocated read via staff bypass")
+		"INV-ACCESS-2: allow-all default MUST permit the non-colocated read via staff bypass")
 }
 
-// INV-RA-3 + INV-RA-5: under WithRealABAC, an admin-role character is PERMITTED
+// INV-ACCESS-3 + INV-ACCESS-5: under WithRealABAC, an admin-role character is PERMITTED
 // the non-colocated read via seed:admin-full-access (read_unrestricted_history).
 // This proves (a) the seed:* set is installed and a seeded permit works, and
 // (b) the provider populating principal.character.roles is registered — an
@@ -78,11 +78,11 @@ func TestRealABAC_AdminPermittedNonColocatedRead_g776Sentinel(t *testing.T) {
 
 	_, err := boss.QueryStreamHistory(ctx, priorStream)
 	require.NoError(t, err,
-		"INV-RA-3/RA-5: seed:admin-full-access MUST permit an admin's non-colocated read; "+
+		"INV-ACCESS-3/INV-ACCESS-5: seed:admin-full-access MUST permit an admin's non-colocated read; "+
 			"a failure here means seeds weren't installed or the roles provider is unregistered")
 }
 
-// INV-RA-4: when a real ABAC subsystem is present, pluginAttrSources MUST route
+// INV-ACCESS-4: when a real ABAC subsystem is present, pluginAttrSources MUST route
 // the plugin layer to the subsystem's OWN resolver and plugin provider (pointer
 // identity) — not freshly-allocated standalone instances — so plugin-declared
 // attribute providers register on the resolver the engine evaluates against.
@@ -99,11 +99,11 @@ func TestRealABAC_PluginAttrSourcesUsesEngineInstances(t *testing.T) {
 	res, pp, aud := pluginAttrSources(abacSub)
 
 	require.Same(t, abacSub.AttributeResolver(), res,
-		"INV-RA-4: plugin resolver MUST be the engine's resolver instance")
+		"INV-ACCESS-4: plugin resolver MUST be the engine's resolver instance")
 	require.Same(t, abacSub.PluginProvider(), pp,
-		"INV-RA-4: plugin provider MUST be the engine's plugin-provider instance")
+		"INV-ACCESS-4: plugin provider MUST be the engine's plugin-provider instance")
 	require.Equal(t, abacSub.AuditLogger(), aud,
-		"INV-RA-4: plugin auditor MUST be the engine's auditor")
+		"INV-ACCESS-4: plugin auditor MUST be the engine's auditor")
 
 	// nil subsystem → fresh standalone instances (the allow-all default path).
 	resStd, ppStd, audStd := pluginAttrSources(nil)
@@ -114,7 +114,7 @@ func TestRealABAC_PluginAttrSourcesUsesEngineInstances(t *testing.T) {
 		"standalone resolver must differ from the engine's")
 }
 
-// INV-RA-6: option order MUST NOT affect the resulting stack. Both orderings
+// INV-ACCESS-6: option order MUST NOT affect the resulting stack. Both orderings
 // must produce the same real-ABAC deny for a regular non-colocated read.
 // Plugin-gated: skipped when binary plugins are unbuilt (HOLOMUSH_REQUIRE_PLUGINS
 // forces failure instead — see plugins.go).
@@ -133,7 +133,7 @@ func TestRealABAC_OptionOrderIndependent(t *testing.T) {
 			mover, priorStream := movedAwayPlayer(t, ctx, ts, "Mover", nil)
 
 			_, err := mover.QueryStreamHistory(ctx, priorStream)
-			require.Error(t, err, "INV-RA-6: composed real engine MUST deny regardless of option order")
+			require.Error(t, err, "INV-ACCESS-6: composed real engine MUST deny regardless of option order")
 			oopsErr, ok := oops.AsOops(err)
 			require.True(t, ok)
 			require.Equal(t, "STREAM_ACCESS_DENIED", oopsErr.Code())


### PR DESCRIPTION
## Summary

Sixth per-scope migration. Migrates legacy family **INV-RA-N** (real-ABAC harness, INV-RA-1..6) to **INV-ACCESS-N**: 9 sites across 4 files renamed, 6 invariants registered (`binding: pending`), scope flipped to `migrated`, `invariants.md` regenerated.

## Scaffold correction (the crux)

All INV-RA sites live in `internal/testsupport/integrationtest/` (the real-ABAC harness: `real_abac.go`, `real_abac_test.go`, `harness.go`, `plugins.go`) — **none** in `internal/access/`. The scaffold's `owned_paths: internal/access/**` was wrong twice over: it owns zero RA tokens, **and** `internal/access/` harbors a separate unmigrated bare-INV-N family (`INV-15`/`INV-A16`, ABAC system-stream denies) that a `/**` residual walk would false-flag once ACCESS is `migrated`. Corrected:
- **owned_paths** = `real_abac.go` + `real_abac_test.go` (residual-safe; only INV-RA→INV-ACCESS tokens).
- **shared_files** = `harness.go` + `plugins.go` (general harness; RA-4 pointer-identity ride-along).

The `internal/access/` `INV-15`/`INV-A16` bare family is out of scope (flagged on the epic for the bare-INV-N pass). This change touches only `internal/testsupport/integrationtest/` (not `internal/access/`), so the abac-reviewer path trigger correctly doesn't fire.

## Verification

- code-reviewer → **READY** (no blocking; fixed the one nit — a `RA-5` shorthand inv-migrate couldn't catch). No collateral damage; residual-safe.
- Zero `INV-RA` left; 6 summaries spot-checked vs spec §lines 144-159.
- **Full** `./test/meta/` suite green (43), guard + render-check green, `task lint` exit 0.
- Fast lane: green. **Note:** the bats step initially failed because `cog-release.bats` fixtures do real `git commit`s and the local 1Password commit-signing agent (`op-ssh-sign`) was erroring — unrelated to this change; re-ran the fast lane with `commit.gpgsign=false` scoped to the throwaway test commits (all 9 cog-release tests then pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)