### PR TITLE
refactor(invariants): migrate INV-CLUSTER from bare INV-N (holomush-hz0v4.14.11)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -20,3 +20,31 @@
   -tags=integration` surfaces `lostcancel` warnings at `context.WithTimeout` sites
   that already carry `//nolint:govet` — NOT findings (bare vet ignores golangci
   nolint; `task lint` is the real gate). Encountered: hz0v4.14.9 (2026-06-02) — NOT READY.
+
+- **Bare-INV-N (CLUSTER) migration is the same shape as I-<OLD>-N but the
+  per-family test lives in `test/meta/inv_binding_test.go`, not a separate
+  `i_<old>_coverage_test.go` (hz0v4.14.11 READY).** Phase-3c invariants
+  (INV-53..60 + INV-28/29) were tracked by
+  `TestEveryPhase3cInvariantHasAtLeastOneTestBinding` (scanned `// Verifies:
+  INV-<digits>`). On migration this test + its 3 locals
+  (`phase3cInvariants`/`invLintEnforced`/`verifiesRE`) MUST be removed, but the
+  shared `findRepoRoot`/`skipDirs` helpers in the SAME file MUST be KEPT (used by
+  10+ meta files — `liveness_invariants_test.go`, `proto_doc_comments_test.go`,
+  `invariant_registry_test.go`, etc.). Verify file still compiles via `task test
+  -- ./test/meta/`. The lone surviving `TestEveryPhase3c...` mention is fine if
+  it's in the rewritten doc-comment explaining the retirement (not a symbol ref).
+  Review pattern for bare-INV-N: (1) `rg '\bINV-(28|29|53..60)\b' -g '!docs/**'
+  -g '!*.md' -g '!test/meta/**'` → exit 1 (NO matches); (2) closed-world
+  {file,token} rewrite preserves co-located non-set bare tokens — INV-27 in
+  participants_cache.go must read "INV-CLUSTER-9 + INV-27", and CRYPTO tokens
+  (INV-9,12,13,17-21,25,26,30,32,33,34,37,39,49) elsewhere untouched; (3) DENSE
+  renumber: non-contiguous legacy maps ascending-by-position to 1..N — verify each
+  entry's `legacy:` AND every `refs[].token` equals the legacy token (awk
+  block-scan), no dup legacy; (4) gorules is a SEPARATE module — its analyzer
+  user-facing diagnostic message + Doc + testdata `// want` directives rename in
+  lockstep (INV-58→INV-CLUSTER-8); run `task test:gorules` after `go clean
+  -testcache` (else cached `ok` masks the testdata edit); (5) `task
+  lint:invariants` (= `inv-render -check`) must exit 0 for invariants.md sync.
+  Origin SPEC is NOT migrated (spec line still says INV-58) — by design; legacy
+  column in invariants.md/yaml records the link. Encountered: hz0v4.14.11
+  (2026-06-02) — READY.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -72,6 +72,21 @@ invariants.
 | `INV-PRESENCE-8` | Client presence map keyed by character_id; idempotent add/remove. | `I-PRES-8` | pending |
 | `INV-PRESENCE-9` | Response deduplicates by character_id (defense-in-depth). | `I-PRES-9` | pending |
 
+### `INV-CLUSTER`
+
+| ID | Summary | Legacy | Binding |
+|----|---------|--------|---------|
+| `INV-CLUSTER-1` | KEK rotation issues a cluster-prefixed NATS request-reply cache-invalidate ping and MUST receive N-of-N replica acks (30s timeout; rollback on timeout). | `INV-28` | pending |
+| `INV-CLUSTER-2` | Rotate/Rekey(context) issues a cluster-prefixed cache-invalidate ping and MUST receive N-of-N replica acks before returning (5s timeout; N=1 degenerates to local self-ack; rollback on timeout). | `INV-29` | pending |
+| `INV-CLUSTER-3` | Every cluster.Registry member has a unique MemberID; colliding concurrent registration is rejected with CLUSTER_MEMBER_DUPLICATE_ID. | `INV-53` | pending |
+| `INV-CLUSTER-4` | All Phase-3c internal coordination subjects are cluster_id-prefixed; members drop messages whose payload cluster_id disagrees with their configured cluster_id. | `INV-54` | pending |
+| `INV-CLUSTER-5` | A pill on internal.<cluster_id>.member.poison.<self_id> triggers Pill.Trigger after flushing audit telemetry; the production Pill terminates the process with exit code 125. | `INV-55` | pending |
+| `INV-CLUSTER-6` | invalidation.Coordinator attempts at most one probe-and-pill + retry cycle per RequestInvalidation; after the second timeout it returns INVALIDATION_PARTIAL_FAILURE with the missing-member set. | `INV-56` | pending |
+| `INV-CLUSTER-7` | cluster.Registry.ProbeAndPill issues at most one attempt per (member_id, reason) per PillRateLimit window (claim-then-probe, closing the TOCTOU race); over-limit returns ErrPillRateLimited without reaching the wire. | `INV-57` | pending |
+| `INV-CLUSTER-8` | No Phase-3c decision is conditioned on cross-host wall-clock comparison (enforced by the noremoteclockcompare analyzer; observability-only skew/latency metrics are the carved-out exceptions). | `INV-58` | pending |
+| `INV-CLUSTER-9` | A successful RequestInvalidation(participants_changed) leaves every other live member's dek.ParticipantsCache with no entry for (ctxType, ctxId, version) on return (re-fetch from PG). | `INV-59` | pending |
+| `INV-CLUSTER-10` | cluster.Registry.ProbeAndPill refuses id==Self() with ErrCannotPillSelf; the Coordinator filters Self() out of the missing-member set (prevents N=1 self-pill). | `INV-60` | pending |
+
 ### `INV-ACCESS`
 
 | ID | Summary | Legacy | Binding |

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -257,13 +257,25 @@ scopes:
       replicas. Does NOT include single-process DEK operations (→ INV-CRYPTO)."
     # bare INV-28/29/56/59 (cross-replica invalidation) defined in the master crypto spec
     # but scoped to CLUSTER per the boundary note. See redesign spec §2.1.
-    status: pending
+    status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
     owned_paths:
       - "internal/cluster/**"
       - "internal/eventbus/crypto/invalidation/**"
-    shared_files: []
+      - "test/integration/cluster/**"
+    shared_files:
+      # CRYPTO-owned files (crypto/dek/**, test/integration/crypto/**) carrying
+      # cluster invalidation tokens, + the noremoteclockcompare lint analyzer/testdata
+      # that enforces INV-CLUSTER-8 (legacy INV-58). Co-located CRYPTO tokens untouched.
+      - "gorules/analyzers/noremoteclockcompare/noremoteclockcompare.go"
+      - "gorules/analyzers/noremoteclockcompare/testdata/src/example.com/negative/negative.go"
+      - "gorules/analyzers/noremoteclockcompare/testdata/src/example.com/positive/positive.go"
+      - "internal/eventbus/crypto/dek/manager.go"
+      - "internal/eventbus/crypto/dek/manager_integration_test.go"
+      - "internal/eventbus/crypto/dek/participants_cache.go"
+      - "internal/eventbus/crypto/dek/rekey_run.go"
+      - "test/integration/crypto/cache_invalidation_test.go"
 
   - name: INV-ACCESS
     description: "ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions"
@@ -889,4 +901,123 @@ invariants:
       behavior."
     binding: pending
     refs:
-      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-6"}
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-6",}
+
+  # -- INV-CLUSTER -- migrated from bare INV-N (cross-replica coordination) (holomush-hz0v4.14.11).
+  # Origin: docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md (master crypto spec; these bare invariants are CLUSTER-scoped per the
+  # boundary note). FIRST bare-INV-N scope: dense per-scope renumbering (legacy 28,29,53-60
+  # are non-contiguous in the crypto spec's global numbering). binding: pending — backfill .11.
+  # Co-located CRYPTO bare tokens (e.g. INV-27 in participants_cache.go) are NOT touched.
+  - id: INV-CLUSTER-1
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-28@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "KEK rotation issues a cluster-prefixed NATS request-reply cache-invalidate ping and MUST receive N-of-N replica
+      acks (30s timeout; rollback on timeout)."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/invalidation/coordinator.go", token: "INV-28"}
+      - {file: "internal/eventbus/crypto/invalidation/coordinator_internal_test.go", token: "INV-28"}
+  - id: INV-CLUSTER-2
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-29@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "Rotate/Rekey(context) issues a cluster-prefixed cache-invalidate ping and MUST receive N-of-N replica acks before
+      returning (5s timeout; N=1 degenerates to local self-ack; rollback on timeout)."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/manager_integration_test.go", token: "INV-29"}
+      - {file: "internal/eventbus/crypto/invalidation/coordinator.go", token: "INV-29"}
+      - {file: "test/integration/crypto/cache_invalidation_test.go", token: "INV-29"}
+  - id: INV-CLUSTER-3
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-53@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "Every cluster.Registry member has a unique MemberID; colliding concurrent registration is rejected with CLUSTER_MEMBER_DUPLICATE_ID."
+    binding: pending
+    refs:
+      - {file: "gorules/analyzers/noremoteclockcompare/testdata/src/example.com/negative/negative.go", token: "INV-53"}
+      - {file: "internal/cluster/heartbeat.go", token: "INV-53"}
+      - {file: "internal/cluster/metrics.go", token: "INV-53"}
+      - {file: "internal/cluster/registry.go", token: "INV-53"}
+      - {file: "test/integration/cluster/cluster_test.go", token: "INV-53"}
+  - id: INV-CLUSTER-4
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-54@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "All Phase-3c internal coordination subjects are cluster_id-prefixed; members drop messages whose payload cluster_id
+      disagrees with their configured cluster_id."
+    binding: pending
+    refs:
+      - {file: "internal/cluster/heartbeat.go", token: "INV-54"}
+      - {file: "internal/eventbus/crypto/invalidation/coordinator.go", token: "INV-54"}
+      - {file: "internal/eventbus/crypto/invalidation/coordinator_internal_test.go", token: "INV-54"}
+      - {file: "test/integration/cluster/cluster_test.go", token: "INV-54"}
+  - id: INV-CLUSTER-5
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-55@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "A pill on internal.<cluster_id>.member.poison.<self_id> triggers Pill.Trigger after flushing audit telemetry;
+      the production Pill terminates the process with exit code 125."
+    binding: pending
+    refs:
+      - {file: "internal/cluster/probe_pill_test.go", token: "INV-55"}
+      - {file: "test/integration/cluster/cluster_test.go", token: "INV-55"}
+  - id: INV-CLUSTER-6
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-56@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "invalidation.Coordinator attempts at most one probe-and-pill + retry cycle per RequestInvalidation; after the
+      second timeout it returns INVALIDATION_PARTIAL_FAILURE with the missing-member set."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/invalidation/coordinator.go", token: "INV-56"}
+      - {file: "test/integration/crypto/cache_invalidation_test.go", token: "INV-56"}
+  - id: INV-CLUSTER-7
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-57@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "cluster.Registry.ProbeAndPill issues at most one attempt per (member_id, reason) per PillRateLimit window (claim-then-probe,
+      closing the TOCTOU race); over-limit returns ErrPillRateLimited without reaching the wire."
+    binding: pending
+    refs:
+      - {file: "internal/cluster/probe_pill.go", token: "INV-57"}
+      - {file: "internal/cluster/probe_pill_test.go", token: "INV-57"}
+      - {file: "internal/cluster/registry.go", token: "INV-57"}
+      - {file: "test/integration/cluster/cluster_test.go", token: "INV-57"}
+  - id: INV-CLUSTER-8
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-58@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "No Phase-3c decision is conditioned on cross-host wall-clock comparison (enforced by the noremoteclockcompare
+      analyzer; observability-only skew/latency metrics are the carved-out exceptions)."
+    binding: pending
+    refs:
+      - {file: "gorules/analyzers/noremoteclockcompare/noremoteclockcompare.go", token: "INV-58"}
+      - {file: "gorules/analyzers/noremoteclockcompare/testdata/src/example.com/negative/negative.go", token: "INV-58"}
+      - {file: "gorules/analyzers/noremoteclockcompare/testdata/src/example.com/positive/positive.go", token: "INV-58"}
+      - {file: "internal/cluster/heartbeat.go", token: "INV-58"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-58"}
+  - id: INV-CLUSTER-9
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-59@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "A successful RequestInvalidation(participants_changed) leaves every other live member's dek.ParticipantsCache
+      with no entry for (ctxType, ctxId, version) on return (re-fetch from PG)."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-59"}
+      - {file: "internal/eventbus/crypto/dek/participants_cache.go", token: "INV-59"}
+      - {file: "test/integration/crypto/cache_invalidation_test.go", token: "INV-59"}
+  - id: INV-CLUSTER-10
+    scope: INV-CLUSTER
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-60@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "cluster.Registry.ProbeAndPill refuses id==Self() with ErrCannotPillSelf; the Coordinator filters Self() out
+      of the missing-member set (prevents N=1 self-pill)."
+    binding: pending
+    refs:
+      - {file: "internal/cluster/probe_pill.go", token: "INV-60"}
+      - {file: "internal/cluster/probe_pill_test.go", token: "INV-60"}
+      - {file: "internal/eventbus/crypto/invalidation/coordinator.go", token: "INV-60"}
+      - {file: "test/integration/cluster/cluster_test.go", token: "INV-60"}

--- a/gorules/analyzers/noremoteclockcompare/noremoteclockcompare.go
+++ b/gorules/analyzers/noremoteclockcompare/noremoteclockcompare.go
@@ -2,7 +2,7 @@
 // Copyright 2026 HoloMUSH Contributors
 
 // Package noremoteclockcompare implements the lint rule that enforces
-// INV-58 (Phase 3c grounding doc Decision 8): no cross-host wall-clock
+// INV-CLUSTER-8 (Phase 3c grounding doc Decision 8): no cross-host wall-clock
 // comparisons. The rule flags any subtraction or comparison between a
 // time.Time value and a struct-field selector whose name is on the
 // remote-sourced allowlist (PublishedAt, IssuedAt, StartedAt,
@@ -83,13 +83,13 @@ var timePackageFuncAllowlist = map[string]struct{}{
 	"Until": {},
 }
 
-const message = "INV-58: no cross-host wall-clock comparison; remote-sourced timestamps must not feed protocol decisions. Use sequence numbers (Phase 3c grounding doc Decision 8). Annotate with //nolint:noremoteclockcompare with justification if this is an observability-only carve-out."
+const message = "INV-CLUSTER-8: no cross-host wall-clock comparison; remote-sourced timestamps must not feed protocol decisions. Use sequence numbers (Phase 3c grounding doc Decision 8). Annotate with //nolint:noremoteclockcompare with justification if this is an observability-only carve-out."
 
 // Analyzer is the registered analyzer instance. Wired into golangci-lint
 // via gorules/analyzers/noremoteclockcompare/plugin.go.
 var Analyzer = &analysis.Analyzer{
 	Name:     "noremoteclockcompare",
-	Doc:      "INV-58: forbids wall-clock comparisons against remote-sourced struct fields (PublishedAt, IssuedAt, StartedAt, LastPublishedAt) when the operand resolves to time.Time",
+	Doc:      "INV-CLUSTER-8: forbids wall-clock comparisons against remote-sourced struct fields (PublishedAt, IssuedAt, StartedAt, LastPublishedAt) when the operand resolves to time.Time",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }

--- a/gorules/analyzers/noremoteclockcompare/testdata/src/example.com/negative/negative.go
+++ b/gorules/analyzers/noremoteclockcompare/testdata/src/example.com/negative/negative.go
@@ -24,7 +24,7 @@ func okLocalSelectorSub(s sample) time.Duration {
 }
 
 // IsZero / Equal are not in timeMethodAllowlist; remote-remote identity
-// checks (e.g., INV-53 duplicate-MemberID detection) MUST NOT fire.
+// checks (e.g., INV-CLUSTER-3 duplicate-MemberID detection) MUST NOT fire.
 func okRemoteEqual(a, b sample) bool {
 	if a.StartedAt.IsZero() {
 		return false
@@ -45,7 +45,7 @@ type fakeMember struct {
 
 // Custom type with same-named methods (Before/After/Sub) on a
 // non-time.Time receiver. The analyzer's isTimeMethod check MUST
-// filter these out — they are not the time.Time methods INV-58
+// filter these out — they are not the time.Time methods INV-CLUSTER-8
 // guards against.
 type customOrdered struct {
 	IssuedAt int64

--- a/gorules/analyzers/noremoteclockcompare/testdata/src/example.com/positive/positive.go
+++ b/gorules/analyzers/noremoteclockcompare/testdata/src/example.com/positive/positive.go
@@ -14,64 +14,64 @@ type sample struct {
 }
 
 func badTimeSincePublished(s sample) time.Duration {
-	return time.Since(s.PublishedAt) // want `INV-58:`
+	return time.Since(s.PublishedAt) // want `INV-CLUSTER-8:`
 }
 
 func badTimeSinceIssued(s sample) time.Duration {
-	return time.Since(s.IssuedAt) // want `INV-58:`
+	return time.Since(s.IssuedAt) // want `INV-CLUSTER-8:`
 }
 
 func badNowSubStarted(s sample) time.Duration {
 	now := time.Now()
-	return now.Sub(s.StartedAt) // want `INV-58:`
+	return now.Sub(s.StartedAt) // want `INV-CLUSTER-8:`
 }
 
 func badRemoteSubLocal(s sample) time.Duration {
 	now := time.Now()
-	return s.LastPublishedAt.Sub(now) // want `INV-58:`
+	return s.LastPublishedAt.Sub(now) // want `INV-CLUSTER-8:`
 }
 
 func badNowBefore(s sample) bool {
 	now := time.Now()
-	return now.Before(s.PublishedAt) // want `INV-58:`
+	return now.Before(s.PublishedAt) // want `INV-CLUSTER-8:`
 }
 
 func badRemoteAfter(s sample) bool {
 	now := time.Now()
-	return s.IssuedAt.After(now) // want `INV-58:`
+	return s.IssuedAt.After(now) // want `INV-CLUSTER-8:`
 }
 
 // Transformed-operand cases: the remote selector is hidden inside a
 // time.Time-returning method call (.UTC(), .Add(...), etc.) but still
 // feeds a forbidden comparison.
 func badTimeSincePublishedUTC(s sample) time.Duration {
-	return time.Since(s.PublishedAt.UTC()) // want `INV-58:`
+	return time.Since(s.PublishedAt.UTC()) // want `INV-CLUSTER-8:`
 }
 
 func badNowSubStartedAdd(s sample) time.Duration {
 	now := time.Now()
-	return now.Sub(s.StartedAt.Add(time.Second)) // want `INV-58:`
+	return now.Sub(s.StartedAt.Add(time.Second)) // want `INV-CLUSTER-8:`
 }
 
 func badParenWrapped(s sample) time.Duration {
 	now := time.Now()
-	return now.Sub((s.IssuedAt)) // want `INV-58:`
+	return now.Sub((s.IssuedAt)) // want `INV-CLUSTER-8:`
 }
 
 // time.Until is symmetric to time.Since (now-t vs t-now); also forbidden
 // when the argument is a remote-sourced time.Time selector.
 func badTimeUntilPublished(s sample) time.Duration {
-	return time.Until(s.PublishedAt) // want `INV-58:`
+	return time.Until(s.PublishedAt) // want `INV-CLUSTER-8:`
 }
 
 // Go 1.20+ time.Time.Compare returns -1/0/+1 — same protocol-decision
 // hazard as Before/After when one operand is remote-sourced.
 func badNowCompareIssued(s sample) int {
 	now := time.Now()
-	return now.Compare(s.IssuedAt) // want `INV-58:`
+	return now.Compare(s.IssuedAt) // want `INV-CLUSTER-8:`
 }
 
 func badRemoteCompareNow(s sample) int {
 	now := time.Now()
-	return s.LastPublishedAt.Compare(now) // want `INV-58:`
+	return s.LastPublishedAt.Compare(now) // want `INV-CLUSTER-8:`
 }

--- a/internal/cluster/heartbeat.go
+++ b/internal/cluster/heartbeat.go
@@ -266,7 +266,7 @@ func (r *registry) handleAlive(msg *nats.Msg) {
 		return
 	}
 	if p.ClusterID != r.cfg.ClusterID {
-		// INV-54: drop messages from other clusters.
+		// INV-CLUSTER-4: drop messages from other clusters.
 		r.deps.Logger.Warn("heartbeat cluster_id mismatch; dropping",
 			"got", p.ClusterID, "want", r.cfg.ClusterID, "from", string(p.MemberID))
 		return
@@ -280,7 +280,7 @@ func (r *registry) handleAlive(msg *nats.Msg) {
 
 	r.mu.Lock()
 	existing, present := r.members[p.MemberID]
-	// INV-53: duplicate-MemberID detection. ULID collision is birthday-
+	// INV-CLUSTER-3: duplicate-MemberID detection. ULID collision is birthday-
 	// bound astronomical, but defense-in-depth: if we've already seen a
 	// heartbeat from this MemberID with a different StartedAt, a
 	// different process is re-using the ULID. Reject the new heartbeat
@@ -348,7 +348,7 @@ func (r *registry) handleBye(msg *nats.Msg) {
 		return
 	}
 	if p.ClusterID != r.cfg.ClusterID {
-		return // INV-54
+		return // INV-CLUSTER-4
 	}
 	if p.MemberID == r.self {
 		return
@@ -394,7 +394,7 @@ func (r *registry) handlePoison(msg *nats.Msg) {
 		return
 	}
 	if p.ClusterID != r.cfg.ClusterID {
-		return // INV-54
+		return // INV-CLUSTER-4
 	}
 	// Pill accepted; trigger termination via injected Pill (Decision 7).
 	r.deps.Pill.Trigger(context.Background(), p.Reason, p.CoordinatorMemberID)
@@ -457,7 +457,7 @@ func (r *registry) recordSkew(source MemberID, skew float64) {
 }
 
 // computeSkew returns absolute drift in seconds between local clock and
-// the remote-sourced published_at timestamp. INV-58 carve-out: this
+// the remote-sourced published_at timestamp. INV-CLUSTER-8 carve-out: this
 // computation is the single allowed cross-host clock comparison; the
 // result feeds an observability gauge only and never gates protocol
 // decisions (Phase 3c grounding doc Decision 8).

--- a/internal/cluster/metrics.go
+++ b/internal/cluster/metrics.go
@@ -84,7 +84,7 @@ func NewHeartbeatMetrics(reg prometheus.Registerer) *HeartbeatMetrics {
 	return m
 }
 
-// DuplicateMemberIDMetrics tracks INV-53 enforcement events: heartbeat
+// DuplicateMemberIDMetrics tracks INV-CLUSTER-3 enforcement events: heartbeat
 // receive observed a colliding MemberID with a different StartedAt
 // (indicating a different process re-using the ULID — birthday-bound
 // astronomical, defense-in-depth detection).
@@ -98,7 +98,7 @@ func NewDuplicateMemberIDMetrics(reg prometheus.Registerer) *DuplicateMemberIDMe
 	m := &DuplicateMemberIDMetrics{
 		DuplicateMemberIDTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "cluster_duplicate_member_id_total",
-			Help: "INV-53 enforcement: heartbeat receive observed a colliding MemberID with a mismatched StartedAt; the duplicate heartbeat was rejected.",
+			Help: "INV-CLUSTER-3 enforcement: heartbeat receive observed a colliding MemberID with a mismatched StartedAt; the duplicate heartbeat was rejected.",
 		}, []string{"member_id"}),
 	}
 	reg.MustRegister(m.DuplicateMemberIDTotal)

--- a/internal/cluster/probe_pill.go
+++ b/internal/cluster/probe_pill.go
@@ -51,7 +51,7 @@ var ErrPillProbeSucceeded = oops.Code("CLUSTER_PILL_PROBE_SUCCEEDED").
 // file rather than registry.go so the rate-limit + self-refusal logic
 // stays close to the probe/pill semantics.
 func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillReason) error {
-	// INV-60: refuse self-targeted pills. We do NOT increment
+	// INV-CLUSTER-10: refuse self-targeted pills. We do NOT increment
 	// SelfTimeoutMetrics here — that counter's contract (see
 	// metrics.go cluster_self_timeout_total Help text) is "Coordinator
 	// missed-ack set after probe-and-pill phase contains only Self()",
@@ -61,14 +61,14 @@ func (r *registry) probeAndPill(ctx context.Context, id MemberID, reason PillRea
 	if id == r.self {
 		r.deps.Logger.WarnContext(
 			ctx,
-			"cluster.ProbeAndPill self-pill refused (INV-60)",
+			"cluster.ProbeAndPill self-pill refused (INV-CLUSTER-10)",
 			"self", string(r.self),
 			"reason", string(reason),
 		)
 		return ErrCannotPillSelf
 	}
 
-	// INV-57: rate limit per (member_id, reason). Single-acquisition
+	// INV-CLUSTER-7: rate limit per (member_id, reason). Single-acquisition
 	// "claim" pattern: check the window AND write the timestamp under
 	// one lock acquisition so two concurrent ProbeAndPill calls cannot
 	// both pass the gate. The check governs *attempts*, not

--- a/internal/cluster/probe_pill_test.go
+++ b/internal/cluster/probe_pill_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/holomush/holomush/pkg/errutil"
 )
 
-// Verifies: INV-60
+// Verifies: INV-CLUSTER-10
 func TestProbeAndPillRefusesSelfPerINV60(t *testing.T) {
 	h := clustertest.New(t, "test-game", 1)
 	r := h.Members[0].Registry
@@ -74,7 +74,7 @@ func TestProbeAndPillTriggersPillOnUnresponsivePeer(t *testing.T) {
 	}
 }
 
-// Verifies: INV-57
+// Verifies: INV-CLUSTER-7
 func TestPillRateLimitBlocksSecondPillWithinWindow(t *testing.T) {
 	h := clustertest.New(t, "test-game", 1)
 	r := h.Members[0].Registry
@@ -98,7 +98,7 @@ func TestPillRateLimitBlocksSecondPillWithinWindow(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "CLUSTER_PILL_RATE_LIMITED")
 }
 
-// Verifies: INV-55
+// Verifies: INV-CLUSTER-5
 func TestPillReceivedOnPoisonSubjectInvokesPillTrigger(t *testing.T) {
 	h := clustertest.New(t, "test-game", 1)
 

--- a/internal/cluster/registry.go
+++ b/internal/cluster/registry.go
@@ -65,7 +65,7 @@ type Deps struct {
 	PillMetrics       *PillMetrics
 	SkewMetrics       *SkewMetrics
 	SelfTimeout       *SelfTimeoutMetrics
-	DuplicateMemberID *DuplicateMemberIDMetrics // INV-53 detection metric
+	DuplicateMemberID *DuplicateMemberIDMetrics // INV-CLUSTER-3 detection metric
 	HeartbeatMetrics  *HeartbeatMetrics         // heartbeat-publish failures (ticker path)
 	Pill              Pill                      // production / test / dev
 	SelfIDForTest     MemberID                  // tests inject; production uses ulid.Make()
@@ -158,7 +158,7 @@ type registry struct {
 	// outgoing heartbeats. Updated by external setters in T9.
 	lastInvSeq uint64
 
-	// Pill rate-limit machinery (INV-57). Tracks the timestamp of the
+	// Pill rate-limit machinery (INV-CLUSTER-7). Tracks the timestamp of the
 	// most-recent pill issued for each (member_id, reason) tuple. Lazy
 	// map init in probeAndPill / issuePill — zero-value sync.Mutex and
 	// nil map are safe.

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -292,7 +292,7 @@ func (m *manager) Resolve(ctx context.Context, keyID codec.KeyID, version uint32
 
 // Participants returns the participant set for the (keyID, version)
 // DEK. Reads from ParticipantsCache on hit; on miss, falls through to
-// PG and seeds the cache. Phase 3c grounding doc Decision 3 + INV-59.
+// PG and seeds the cache. Phase 3c grounding doc Decision 3 + INV-CLUSTER-9.
 //
 // PG-before-cache note: this body reads PG first (selectByID) to derive
 // the cache key (ContextType, ContextID, Version), then checks the

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -638,8 +638,8 @@ var _ = Describe("Manager", func() {
 		Expect(parts[0].PlayerID).To(Equal("p2"))
 	})
 
-	// TestManager_Rotate_RollsBackOnInvalidationFailure is INV-29.
-	It("Rotate rolls back on invalidation failure (INV-29)", func() {
+	// TestManager_Rotate_RollsBackOnInvalidationFailure is INV-CLUSTER-2.
+	It("Rotate rolls back on invalidation failure (INV-CLUSTER-2)", func() {
 		pool := testIntegrationPool(suiteT)
 		st := dek.NewStore(pool)
 		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})

--- a/internal/eventbus/crypto/dek/participants_cache.go
+++ b/internal/eventbus/crypto/dek/participants_cache.go
@@ -26,7 +26,7 @@ type ParticipantsCacheKey struct {
 // (participants invalidate per-version on Add via participants_changed
 // action; DEK material invalidates per-context on Rekey).
 //
-// Phase 3c grounding doc Decision 3 + INV-59 + INV-27.
+// Phase 3c grounding doc Decision 3 + INV-CLUSTER-9 + INV-27.
 type ParticipantsCache struct {
 	cap   int
 	ttl   time.Duration

--- a/internal/eventbus/crypto/dek/rekey_run.go
+++ b/internal/eventbus/crypto/dek/rekey_run.go
@@ -227,7 +227,7 @@ func (o *Orchestrator) driveToCompletion(ctx context.Context, rid RequestID, req
 			// observability-only duration: both timestamps originate on this
 			// host's clock (StartedAt at Phase 1 INSERT, CompletedAt at Phase 7
 			// MarkComplete), so the cross-host clock-skew concern that
-			// INV-58 guards against does not apply. The value is for CLI
+			// INV-CLUSTER-8 guards against does not apply. The value is for CLI
 			// display, never for protocol decisions.
 			out.DurationMs = ckpt.CompletedAt.Sub(ckpt.StartedAt).Milliseconds() //nolint:noremoteclockcompare // observability-only; both timestamps are local host wall-clock writes.
 		}

--- a/internal/eventbus/crypto/invalidation/coordinator.go
+++ b/internal/eventbus/crypto/invalidation/coordinator.go
@@ -55,7 +55,7 @@ type coordinator struct {
 }
 
 // timeoutFor returns the action-specific timeout. KEK rotation uses
-// 30s per INV-28; everything else uses cfg.InvalidateTimeout (default 5s).
+// 30s per INV-CLUSTER-1; everything else uses cfg.InvalidateTimeout (default 5s).
 func (c *coordinator) timeoutFor(action Action) time.Duration {
 	if action == ActionKEKRotation {
 		return 30 * time.Second
@@ -93,7 +93,7 @@ func (c *coordinator) Stop(_ context.Context) error {
 
 // RequestInvalidation publishes an invalidation request and waits for
 // N-of-N replica acks; on partial timeout, runs probe-and-pill on
-// missing members and retries once. INV-28, INV-29, INV-56, INV-60.
+// missing members and retries once. INV-CLUSTER-1, INV-CLUSTER-2, INV-CLUSTER-6, INV-CLUSTER-10.
 func (c *coordinator) RequestInvalidation(
 	ctx context.Context,
 	ctxID dek.ContextID,
@@ -137,7 +137,7 @@ func (c *coordinator) RequestInvalidation(
 	// Probe-and-pill phase. Compute missing against the SAME snapshot
 	// used to derive the expected ack count.
 	missing := computeMissingFromSnapshot(snapshot1, acks)
-	// INV-60: filter Self() from missing set.
+	// INV-CLUSTER-10: filter Self() from missing set.
 	self := c.deps.Registry.Self()
 	selfFiltered := make([]cluster.MemberID, 0, len(missing))
 	for _, m := range missing {
@@ -327,7 +327,7 @@ func (c *coordinator) recordSuccess(action Action, outcome string, issuedAt time
 
 // handleInvalidate is the receive-side handler. Parses payload,
 // dispatches on action enum, evicts caches per Phase 3c grounding doc
-// Decision 5/6, and acks via msg.Respond. INV-54: cluster_id-mismatch
+// Decision 5/6, and acks via msg.Respond. INV-CLUSTER-4: cluster_id-mismatch
 // messages dropped without ack.
 //
 // Note on time.Since(payload.IssuedAt): in single-process tests the

--- a/internal/eventbus/crypto/invalidation/coordinator_internal_test.go
+++ b/internal/eventbus/crypto/invalidation/coordinator_internal_test.go
@@ -46,7 +46,7 @@ func TestHandleInvalidateDropsCrossClusterMessage(t *testing.T) {
 	c := newTestCoordinator(t, logBuf)
 
 	// Subscribe to a real reply subject so we can assert that
-	// handleInvalidate's INV-54 cross-cluster drop path did NOT publish
+	// handleInvalidate's INV-CLUSTER-4 cross-cluster drop path did NOT publish
 	// an ack. (Setting msg.Reply = "" wouldn't catch a bug where the
 	// drop path forgot the early-return: the empty-Reply branch's
 	// "msg.Reply empty" warn-log would mask the regression.)
@@ -68,7 +68,7 @@ func TestHandleInvalidateDropsCrossClusterMessage(t *testing.T) {
 	})
 
 	// Build a payload with a mismatched cluster_id; cluster_id-mismatch
-	// must be dropped without ack (INV-54).
+	// must be dropped without ack (INV-CLUSTER-4).
 	payload := Payload{
 		Seq:                 1,
 		CoordinatorMemberID: "01HSENDERAAAAAAAAAAAAAAA",
@@ -91,11 +91,11 @@ func TestHandleInvalidateDropsCrossClusterMessage(t *testing.T) {
 		t.Errorf("expected 'cross-cluster message dropped' warning in log; got: %s", logBuf.String())
 	}
 
-	// INV-54 requires the message be dropped WITHOUT ack. Wait briefly
+	// INV-CLUSTER-4 requires the message be dropped WITHOUT ack. Wait briefly
 	// for any wrongly-published reply to land; assert nothing arrives.
 	select {
 	case stray := <-ackCh:
-		t.Errorf("INV-54 violation: handleInvalidate sent ack on cross-cluster drop path; got reply with data %q", string(stray.Data))
+		t.Errorf("INV-CLUSTER-4 violation: handleInvalidate sent ack on cross-cluster drop path; got reply with data %q", string(stray.Data))
 	case <-time.After(100 * time.Millisecond):
 		// Expected: silence on the reply subject.
 	}
@@ -214,10 +214,10 @@ func TestConfigDefaultsPreservesPositiveInvalidateTimeout(t *testing.T) {
 
 func TestTimeoutForActionKEKRotationReturnsThirtySeconds(t *testing.T) {
 	c := &coordinator{cfg: Config{InvalidateTimeout: 5 * time.Second}}
-	// KEK rotation has its own 30s budget per INV-28; the configured
+	// KEK rotation has its own 30s budget per INV-CLUSTER-1; the configured
 	// InvalidateTimeout (default 5s) MUST NOT apply.
 	if got := c.timeoutFor(ActionKEKRotation); got != 30*time.Second {
-		t.Errorf("timeoutFor(KEKRotation) = %v; want 30s (INV-28 budget)", got)
+		t.Errorf("timeoutFor(KEKRotation) = %v; want 30s (INV-CLUSTER-1 budget)", got)
 	}
 }
 

--- a/test/integration/cluster/cluster_test.go
+++ b/test/integration/cluster/cluster_test.go
@@ -10,7 +10,7 @@
 // `// Verifies: INV-N` so T14's meta-test can bind invariant numbers to
 // test names.
 //
-// INV-55 (production Pill os.Exit(125)) is exercised by a TestPill
+// INV-CLUSTER-5 (production Pill os.Exit(125)) is exercised by a TestPill
 // substitute in internal/cluster/probe_pill_test.go; a real subprocess
 // harness for the production-Pill path is deferred to a follow-up.
 package cluster_test
@@ -28,7 +28,7 @@ import (
 )
 
 var _ = Describe("Cluster Registry", func() {
-	// Verifies: INV-53
+	// Verifies: INV-CLUSTER-3
 	Describe("first-seen StartedAt preservation under duplicate MemberID", func() {
 		It("rejects a duplicate heartbeat carrying a different StartedAt and HolomushVersion", func(ctx SpecContext) {
 			h := clustertest.New(GinkgoT(), "test-game", 1)
@@ -88,7 +88,7 @@ var _ = Describe("Cluster Registry", func() {
 		})
 	})
 
-	// Verifies: INV-54
+	// Verifies: INV-CLUSTER-4
 	Describe("cluster_id namespace isolation", func() {
 		It("never observes a foreign-cluster heartbeat in the local registry", func(ctx SpecContext) {
 			h := clustertest.New(GinkgoT(), "test-game", 1)
@@ -107,7 +107,7 @@ var _ = Describe("Cluster Registry", func() {
 		})
 	})
 
-	// Verifies: INV-57
+	// Verifies: INV-CLUSTER-7
 	Describe("pill rate-limiting", func() {
 		It("blocks a duplicate pill within the rate-limit window", func() {
 			h := clustertest.New(GinkgoT(), "test-game", 1)
@@ -133,8 +133,8 @@ var _ = Describe("Cluster Registry", func() {
 		})
 	})
 
-	// Verifies: INV-60
-	Describe("INV-60 self-pill refusal", func() {
+	// Verifies: INV-CLUSTER-10
+	Describe("INV-CLUSTER-10 self-pill refusal", func() {
 		It("returns CLUSTER_CANNOT_PILL_SELF when target is Self()", func() {
 			h := clustertest.New(GinkgoT(), "test-game", 1)
 			err := h.Members[0].Registry.ProbeAndPill(

--- a/test/integration/crypto/cache_invalidation_test.go
+++ b/test/integration/crypto/cache_invalidation_test.go
@@ -63,7 +63,7 @@ func newCoordOnMember(
 }
 
 var _ = Describe("Invalidation Coordinator", func() {
-	// Verifies: INV-29
+	// Verifies: INV-CLUSTER-2
 	Describe("rekey requires all live members to ack within timeout", func() {
 		It("evicts every replica's DEK cache for the context after a 3-member rekey", func() {
 			h := clustertest.New(GinkgoT(), "test-game", 3)
@@ -102,7 +102,7 @@ var _ = Describe("Invalidation Coordinator", func() {
 		})
 	})
 
-	// Verifies: INV-29 (single-replica degeneration)
+	// Verifies: INV-CLUSTER-2 (single-replica degeneration)
 	Describe("single-member cluster degenerates to self-ack", func() {
 		It("returns nil after a Rekey publishes via NATS loopback to its own subscription", func() {
 			h := clustertest.New(GinkgoT(), "test-game", 1)
@@ -117,7 +117,7 @@ var _ = Describe("Invalidation Coordinator", func() {
 		})
 	})
 
-	// Verifies: INV-59
+	// Verifies: INV-CLUSTER-9
 	// Verifies: INV-12 (read-immediacy substrate)
 	Describe("participants_changed propagates within timeout", func() {
 		It("evicts every replica's ParticipantsCache for (ctxType, ctxID, version) on Add", func() {
@@ -145,7 +145,7 @@ var _ = Describe("Invalidation Coordinator", func() {
 				context.Background(), ctxID, invalidation.ActionParticipantsChanged, 1, 0,
 			)).To(Succeed(), "RequestInvalidation participants_changed")
 
-			// INV-59: every replica's ParticipantsCache for this version
+			// INV-CLUSTER-9: every replica's ParticipantsCache for this version
 			// MUST have no entry upon return.
 			_, ok0 := partCaches[0].Get(pck)
 			Expect(ok0).To(BeFalse(), "member 0 still has cached participants after RequestInvalidation")
@@ -154,7 +154,7 @@ var _ = Describe("Invalidation Coordinator", func() {
 		})
 	})
 
-	// Verifies: INV-56 (single retry)
+	// Verifies: INV-CLUSTER-6 (single retry)
 	Describe("Coordinator attempts at most one probe-and-pill retry cycle", func() {
 		It("returns nil OR a typed timeout error (SELF_TIMEOUT|PARTIAL_FAILURE) when a synthetic peer never acks", func() {
 			h := clustertest.New(GinkgoT(), "test-game", 1)

--- a/test/meta/inv_binding_test.go
+++ b/test/meta/inv_binding_test.go
@@ -2,43 +2,26 @@
 // Copyright 2026 HoloMUSH Contributors
 
 // Package meta contains repository-wide meta-tests that enforce structural
-// invariants — for example, that every Phase 3c invariant declared in the
-// crypto master spec has at least one concrete test binding via a
-// `// Verifies: INV-N` annotation, or (for INV-58, the no-remote-clock-compare
-// rule) an enforcing static analyzer.
+// invariants.
+//
+// This file hosts shared helpers (findRepoRoot, skipDirs) used by many
+// meta-tests in the package. The former Phase-3c per-family coverage test
+// (TestEveryPhase3cInvariantHasAtLeastOneTestBinding) was retired when its
+// INV-53..60 invariants migrated to the registry as INV-CLUSTER-1..10
+// (holomush-hz0v4.14.11); the registry meta-test
+// (TestEveryRegistryInvariantHasBinding) now owns that coverage. The helpers
+// remain here pending relocation by holomush-hz0v4.14.16.
 package meta
 
 import (
-	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
 	"testing"
 )
 
-// phase3cInvariants enumerates the Phase 3c invariants (INV-53..60) that
-// MUST each have at least one test binding (or, for INV-58, an enforcing
-// lint analyzer). Update this list when a new Phase 3c invariant is added
-// to docs/superpowers/specs/2026-04-26-crypto-master-spec.md.
-var phase3cInvariants = []int{53, 54, 55, 56, 57, 58, 59, 60}
-
-// invLintEnforced lists invariants whose binding is the existence of an
-// enforcing static analyzer rather than a runtime test annotation. INV-58
-// (no remote-clock comparisons) is enforced by the noremoteclockcompare
-// analyzer in gorules/analyzers/noremoteclockcompare/.
-var invLintEnforced = map[int]string{
-	58: filepath.Join("gorules", "analyzers", "noremoteclockcompare", "noremoteclockcompare.go"),
-}
-
-// verifiesRE matches `// Verifies: INV-<digits>` annotations in test files.
-var verifiesRE = regexp.MustCompile(`//\s*Verifies:\s*INV-(\d+)`)
-
-// skipDirs are directories that the meta-test MUST NOT descend into when
-// scanning for test bindings. Keeping this in sync with project layout
-// avoids false positives from vendored or generated trees.
+// skipDirs are directories that meta-tests MUST NOT descend into when scanning
+// the repo tree. Keeping this in sync with project layout avoids false
+// positives from vendored or generated trees.
 var skipDirs = map[string]struct{}{
 	".git":         {},
 	".jj":          {},
@@ -48,76 +31,6 @@ var skipDirs = map[string]struct{}{
 	"bin":          {},
 	"build":        {},
 	"dist":         {},
-}
-
-func TestEveryPhase3cInvariantHasAtLeastOneTestBinding(t *testing.T) {
-	root := findRepoRoot(t)
-
-	// Use os.Root for race-free, symlink-safe file reads inside the repo
-	// tree (gosec G122). All paths produced by WalkDir below are converted
-	// to root-relative form before being opened via Root.Open.
-	rootFS, err := os.OpenRoot(root)
-	if err != nil {
-		t.Fatalf("open repo root %q: %v", root, err)
-	}
-	defer func() { _ = rootFS.Close() }()
-
-	bindings := make(map[int][]string) // INV-N -> list of file paths
-
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if _, skip := skipDirs[d.Name()]; skip {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(d.Name(), "_test.go") {
-			return nil
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
-		}
-		f, openErr := rootFS.Open(rel)
-		if openErr != nil {
-			return openErr
-		}
-		data, readErr := io.ReadAll(f)
-		closeErr := f.Close()
-		if readErr != nil {
-			return readErr
-		}
-		if closeErr != nil {
-			return closeErr
-		}
-		matches := verifiesRE.FindAllSubmatch(data, -1)
-		for _, m := range matches {
-			n, convErr := strconv.Atoi(string(m[1]))
-			if convErr != nil {
-				continue
-			}
-			bindings[n] = append(bindings[n], rel)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk repo: %v", err)
-	}
-
-	for _, inv := range phase3cInvariants {
-		if rel, lintEnforced := invLintEnforced[inv]; lintEnforced {
-			if _, statErr := os.Stat(filepath.Join(root, rel)); statErr != nil {
-				t.Errorf("INV-%d: lint-enforced invariant missing analyzer at %s: %v", inv, rel, statErr)
-			}
-			continue
-		}
-		if len(bindings[inv]) == 0 {
-			t.Errorf("INV-%d: no test binding found (expected at least one `// Verifies: INV-%d` comment in a *_test.go file)", inv, inv)
-		}
-	}
 }
 
 // findRepoRoot walks upward from the test's working directory until it finds


### PR DESCRIPTION
## Summary

Seventh per-scope migration, and the **first bare-INV-N scope**. Migrates the cross-replica-coordination invariants — bare `INV-28,29,53,54,55,56,57,58,59,60` (defined in the event-payload-crypto master spec, but CLUSTER-scoped per the boundary note) — to `INV-CLUSTER-1..10`: 34 sites across 16 files, scope flipped to `migrated`, `invariants.md` regenerated.

## Bare-INV-N specifics (precedent for the CRYPTO split, `.14.15`)

- **Dense per-scope renumbering**: legacy `28,29,53-60` are non-contiguous in the crypto spec's global numbering → mapped ascending-by-position to `INV-CLUSTER-1..10` (1=INV-28 … 10=INV-60). `legacy:` records the original token.
- **Complete set is 10, not the scaffold's illustrative 4** (`e.g. 28/29/56/59`): member-ID(53), cluster-subjects(54), pill(55), coordinator-retry(56), probe-rate-limit(57), no-clock-compare(58), cache-invalidation(59), probe-self-refusal(60), N-of-N acks(28,29).
- **Co-located CRYPTO tokens preserved** by the closed-world `{file,token}` rewrite — e.g. `participants_cache.go` now reads `INV-CLUSTER-9 + INV-27` (INV-27 is CRYPTO, untouched).

## Ownership & retirements

- **owned_paths** = `internal/cluster/**`, `crypto/invalidation/**`, `test/integration/cluster/**` (residual-safe — every bare INV-N there is in-set).
- **shared_files** = `crypto/dek/**` files + `test/integration/crypto/cache_invalidation_test.go` (CRYPTO-owned, carry cluster tokens) + the `gorules/noremoteclockcompare` analyzer/testdata (enforces `INV-CLUSTER-8`; its diagnostic message + `// want` directives renamed **in lockstep**).
- Retired the per-family `TestEveryPhase3cInvariantHasAtLeastOneTestBinding` (`inv_binding_test.go`); **kept** the shared `findRepoRoot`/`skipDirs` helpers it hosts (used by 10+ meta-tests; relocation deferred to `.14.16`).

## Verification

- **crypto-reviewer → READY** (pure comment/string rename, no crypto-semantic drift, INV-27 preserved, analyzer message↔testdata in lockstep).
- **code-reviewer → READY** (classification complete, dense map internally consistent, no collateral damage, retirement helper-safe).
- Zero leftover bare cluster tokens; full `./test/meta/` (42) + `task test:gorules` (noremoteclockcompare) + `internal/cluster`/crypto (185) green; render-check green; `task lint` exit 0; fast lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)