### PR TITLE
refactor(invariants): migrate deferred bare-INV-N clusters → INV-PLUGIN/INV-ACCESS (holomush-hz0v4.14.22)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -145,3 +145,29 @@
   grpc-api.md table-row "non-comment" diffs are doc prose; verify each ± pair
   differs ONLY in the token. No `token:",}` trailing-comma noise this time.
   Encountered: hz0v4.14.15 (2026-06-03) — READY.
+
+- **Final bare-INV-N PER-SITE pass (tri-overloaded namespace: same bare number
+  → DIFFERENT outcomes per file) — all checks held (hz0v4.14.22 READY).** The
+  whole point: bare INV-1 → INV-PLUGIN-22 ONLY in plugin-evaluate files
+  (pluginauthz/evaluate.go, hostfunc/evaluate.go, hostfunc/stdlib_settings.go,
+  goplugin/evaluate_invariants_test.go), while command-visibility INV-1 (commands.go,
+  functions.go, setup/subsystem.go) LEFT bare; settings INV-6 (host_service.go) +
+  fence INV-6/7 (lua/host.go) LEFT. Verify per-file, not per-number. Key checks:
+  (1) `rg '\bINV-[0-9]+\b'` over EVERY owned file → ZERO (residual walk = `bareInvRE
+  \bINV-\d+\b` at invariant_registry_test.go:488); foreign bare tokens survive ONLY
+  in shared_files (residual `continue`s on shared, line ~550). (2) checkProvenance
+  (line 492) greps CANONICAL `e.ID` at each ref site, NOT `r.Token` — so refs
+  recording legacy `token: "INV-15"/"INV-A16"/"INV-4"` is the standing FROM-anchor
+  convention, NOT a finding; the canonical token must ALSO be physically present
+  (it is). (3) Cross-scope ownership is legit: access/setup/subsystem.go +
+  setup_warn_integ_test.go are PLUGIN-owned (INV-4 audit-wiring is plugin-evaluate,
+  not ABAC) — confirm each appears ONCE in owned_paths and carries ONLY the migrated
+  token; no scope owns `internal/access/**` glob so TestOwnedPathsPartition is safe.
+  (4) seed.go/seed_test.go genuinely multi-scope (PRIVACY I-PRIV-6 + now ACCESS) →
+  ACCESS-shared not owned; seed_smoke_test.go/spec_amendments_test.go ACCESS-owned.
+  (5) Bare `A16` prose (no INV- prefix) MUST stay — `\bA16\b` rewrite would corrupt
+  `INV-A16`; `INV-A16` → INV-ACCESS-8 cleanly. (6) Zero `.go` executable-line edits;
+  every .go diff line is a comment or test-assertion string-literal token swap.
+  (7) This diff CLEANED a pre-existing `,}` (INV-RA-6 line 1657) but ADDED a new one
+  (INV-A16 line 1682) — 5th recurrence, Low non-blocking, renderer-inert. PLUGIN dense
+  1..28, ACCESS dense 1..8. Encountered: hz0v4.14.22 (2026-06-03) — READY.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -218,6 +218,13 @@ invariants.
 | `INV-PLUGIN-19` | The whole-system suite MUST assert >=1 cross-plugin-ABAC permit AND >=1 forbid against the real seeded engine. | `INV-WS-2` | pending |
 | `INV-PLUGIN-20` | The whole-system suite MUST NOT be silently skipped in CI: with HOLOMUSH_REQUIRE_PLUGINS set, a missing binary artifact is a hard failure. | `INV-WS-3` | pending |
 | `INV-PLUGIN-21` | WithInTreePlugins() MUST be opt-in: omitting it leaves the harness plugin-free and behaviorally unchanged. | `INV-WS-4` | pending |
+| `INV-PLUGIN-22` | PluginHostService.Evaluate's subject is host-derived from the authenticated actor; there is no subject field on the wire (never sourced from plugin/Lua-supplied data). | `INV-1` | pending |
+| `INV-PLUGIN-23` | No authenticated actor bound to the call → Evaluate returns deny + error (fail-closed). | `INV-2` | pending |
+| `INV-PLUGIN-24` | A resource type the plugin does not own (outside its entitlement, no command carve-out) → rejected. | `INV-3` | pending |
+| `INV-PLUGIN-25` | Each Evaluate emits exactly one host-stamped audit event; the audit logger MUST be wired on both the binary (gRPC) and Lua (hostfunc) surfaces. | `INV-4` | pending |
+| `INV-PLUGIN-26` | The binary (gRPC) and Lua (hostfunc) surfaces reach identical host evaluation logic via a single shared mapping (runtime parity). | `INV-5` | pending |
+| `INV-PLUGIN-27` | Each settings host RPC MUST ship a Go SDK method AND a Lua hostfunc together (runtime parity); the settings access gate is the single shared path for both runtimes. | `INV-8` | pending |
+| `INV-PLUGIN-28` | Cross-plugin settings isolation MUST be structural: the host binds the plugin partition from the authenticated caller identity (stamped at server construction), never from caller-supplied input; a plugin MUST NOT address another plugin's owner partition. | `INV-11` | pending |
 
 ### `INV-EVENTBUS`
 
@@ -276,6 +283,8 @@ invariants.
 | `INV-ACCESS-4` | With WithRealABAC()+WithInTreePlugins(), the attribute.Resolver and attribute.PluginProvider the plugin subsystem registers on are the SAME instances (pointer identity) the engine evaluates against. | `INV-RA-4` | pending |
 | `INV-ACCESS-5` | Every attribute namespace referenced by an installed seed policy has a registered provider under WithRealABAC (no silent default-deny from an unregistered provider). | `INV-RA-5` | pending |
 | `INV-ACCESS-6` | Option order MUST NOT affect the resulting stack: Start(t,A,B) and Start(t,B,A) produce identical permit/deny behavior. | `INV-RA-6` | pending |
+| `INV-ACCESS-7` | ABAC denies subscribe to events.*.system.* (and audit.>) streams for kind={plugin\|character} at the gRPC subscribe boundary; the Rekey system audit event lands on a subject those principals cannot read. | `INV-15` | pending |
+| `INV-ACCESS-8` | Two ABAC seed forbid policies MUST deny character and plugin principals from reading events.*.system.crypto_totp.* streams (sub-epic A; A16 extends INV-15's system-namespace deny across crypto audit namespaces). | `INV-A16` | pending |
 
 ### `INV-SESSION`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -223,18 +223,24 @@ scopes:
     description: "Runtime symmetry, manifest validation, hostfunc safety, emit gates, setting isolation, plugin authz"
     boundary: "Plugin-system contracts applicable to both Lua and binary runtimes. Does NOT include: plugin crypto wiring
       (→ INV-CRYPTO)."
-    # Families PC (runtime config), W9ML (plugin identity), WS (whole-system load harness). See redesign spec §2.1.
+    # Families PC (runtime config), W9ML (plugin identity), WS (whole-system load harness),
+    # plugin-host-evaluate INV-1..5 (→22..26), phase-8 settings-authz INV-8/11 (→27/28). See redesign §2.1.
     # P7 split: PLUGIN gets ZERO P7 tokens (§2.1 lines 163-164 — all remaining P7 → CRYPTO .14.15).
-    # The pluginauthz/settings bare INV-1..5/8/11 are DEFERRED to the dedicated bare-INV-N pass
-    # (tri-overloaded shared namespace: plugin-host-evaluate vs command-query vs phase-8-settings;
-    # same class as the INV-15/A16 ABAC tokens flagged on epic .14). pluginauthz/** is NOT owned here.
-    # owned_paths use file-paths (not /** globs) for dirs that hold deferred/foreign bare INV-N
-    # (pluginauthz, wholesystem/census, internal/plugin settings) so the residual walk stays clean.
+    # The pluginauthz/settings bare INV-1..5/8/11 were the tri-overloaded shared namespace
+    # (plugin-host-evaluate vs command-query vs phase-8-settings); migrated PER-SITE in .14.22 — the
+    # plugin-evaluate invariants span pluginauthz/hostfunc/goplugin + audit-wiring setup files, NOT
+    # evaluate.go alone (the earlier .14.14 'evaluate.go ONLY' note undercounted; corrected here).
+    # owned_paths use file-paths (not /** globs) for dirs that hold foreign bare INV-N so the residual
+    # walk stays clean. LEFT untouched (foreign, co-located): command-visibility INV-1 (commands.go/
+    # functions.go/help_integration_test.go/setup/subsystem.go), settings INV-6 (host_service.go),
+    # sensitivity-fence INV-6/7 (lua/host.go — flagged on epic .14 for classification).
     status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-26-plugin-runtime-config-design.md"
       - "docs/superpowers/specs/2026-05-04-legacy-id-elimination-design.md"
       - "docs/superpowers/specs/2026-05-25-wholesystem-plugin-integration-design.md"
+      - "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+      - "docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"
     owned_paths:
       # PC (plugin-runtime-config): config files are PLUGIN-exclusive.
       - "internal/plugin/config.go"
@@ -250,9 +256,32 @@ scopes:
       - "internal/testsupport/integrationtest/invariants_test.go"
       - "internal/testsupport/integrationtest/default_plugins_test.go"
       - "test/integration/wholesystem/abac_test.go"
+      # plugin-host-evaluate INV-1..5 (.14.22): clean, exclusive sites (subject host-derived,
+      # fail-closed, entitlement, single-audit, binary↔Lua parity). evaluate.go itself is shared
+      # (EVENTBUS ROPS-3 co-located); these carry only the migrated plugin-evaluate tokens.
+      - "internal/plugin/pluginauthz/principal.go"
+      - "internal/plugin/hostfunc/evaluate.go"
+      - "internal/plugin/hostfunc/stdlib_settings.go"
+      - "internal/plugin/hostfunc/stdlib_settings_test.go"
+      - "internal/plugin/hostfunc/functions_audit_wiring_test.go"
+      - "internal/plugin/goplugin/host_engine_wiring_test.go"
+      - "internal/plugin/goplugin/host_settings_test.go"
+      - "internal/plugin/goplugin/evaluate_invariants_test.go"
+      - "internal/plugin/lua/settings_ops_adapter.go"
+      - "internal/plugin/lua/settings_ops_adapter_test.go"
+      - "internal/plugin/setup/subsystem_test.go"
+      # INV-4 audit-wiring sites in internal/access/setup/ (plugin-evaluate, not ABAC-scope).
+      - "internal/access/setup/subsystem.go"
+      - "internal/access/setup/setup_warn_integ_test.go"
     shared_files:
       # PLUGIN+STORE: no_delete grep gate (W9ML-9) lives in a STORE-owned file.
       - "internal/store/no_delete_grep_test.go"
+      # .14.22 plugin-evaluate / settings sites carrying co-located FOREIGN bare tokens:
+      # evaluate.go (EVENTBUS ROPS-3), functions.go (command-vis INV-1), host_service.go
+      # (settings INV-6 + SCENE-shared). The foreign tokens stay; residual skips shared files.
+      - "internal/plugin/pluginauthz/evaluate.go"
+      - "internal/plugin/hostfunc/functions.go"
+      - "internal/plugin/goplugin/host_service.go"
       # PLUGIN+(S substrate): goplugin host (PC-8 + foreign INV-S5).
       - "internal/plugin/goplugin/host.go"
       - "internal/plugin/goplugin/host_test.go"
@@ -374,20 +403,34 @@ scopes:
   - name: INV-ACCESS
     description: "ABAC policy evaluation, attribute provider invariants, seed policy shape, authorization decisions"
     boundary: "Access control evaluation. Does NOT include: stream-access gating at gRPC boundary (→ INV-EVENTBUS)."
-    # Family RA (real-ABAC harness). All INV-RA sites are in the integration
-    # harness (internal/testsupport/integrationtest/), not internal/access/. See .14.10.
+    # Family RA (real-ABAC harness, INV-RA-1..6 in the integration harness) + the ABAC
+    # system-stream-deny seed-policy invariants INV-15 (→7) and INV-A16 (→8), migrated in .14.22.
+    # INV-15/A16 are crypto-origin (master crypto §INV-15; phase-5 sub-epic A INV-A16) but their
+    # CODE HOME is the ABAC seed layer (internal/access/policy/), and this scope is "seed policy
+    # shape, authorization decisions" — so they fold here, not into INV-CRYPTO (user-confirmed).
+    # Bare 'A16' prose shorthand (no INV- prefix) is LEFT — \bA16\b would corrupt INV-A16; A16 is
+    # the amendment's human label, INV-ACCESS-8 its canonical id. See .14.10/.14.22.
     status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-26-harness-real-abac-design.md"
+      - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+      - "docs/superpowers/specs/2026-05-07-event-payload-crypto-phase5-totp-substrate-design.md"
     owned_paths:
-      # The real-ABAC harness files (where INV-RA-1..6 live). NOT internal/access/**
-      # — that has no RA token and harbors a separate unmigrated bare-INV-N family.
+      # The real-ABAC harness files (where INV-RA-1..6 live).
       - "internal/testsupport/integrationtest/real_abac.go"
       - "internal/testsupport/integrationtest/real_abac_test.go"
+      # INV-15/A16 ABAC system-stream-deny seed-policy sites (.14.22). seed.go/seed_test.go
+      # are PRIVACY-shared (I-PRIV-6 co-located) so they are SHARED below, not owned; these two
+      # are ACCESS-exclusive for the deny-policy invariants.
+      - "internal/access/policy/seed_smoke_test.go"
+      - "internal/access/spec_amendments_test.go"
     shared_files:
       # General integration harness (RA-4 pointer-identity ride-along).
       - "internal/testsupport/integrationtest/harness.go"
       - "internal/testsupport/integrationtest/plugins.go"
+      # INV-15/A16 sites also carrying PRIVACY I-PRIV-6 (genuinely multi-scope).
+      - "internal/access/policy/seed.go"
+      - "internal/access/policy/seed_test.go"
 
   - name: INV-SESSION
     description: "Session status lifecycle, connection attachment, focus membership, idle detection"
@@ -1614,7 +1657,29 @@ invariants:
       behavior."
     binding: pending
     refs:
-      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-6",}
+      - {file: "internal/testsupport/integrationtest/real_abac_test.go", token: "INV-RA-6"}
+  - id: INV-ACCESS-7
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-15@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "ABAC denies subscribe to events.*.system.* (and audit.>) streams for kind={plugin|character} at the gRPC subscribe
+      boundary; the Rekey system audit event lands on a subject those principals cannot read."
+    binding: pending
+    refs:
+      - {file: "internal/access/policy/seed.go", token: "INV-15"}
+      - {file: "internal/access/policy/seed_test.go", token: "INV-15"}
+      - {file: "internal/access/policy/seed_smoke_test.go", token: "INV-15"}
+      - {file: "internal/access/spec_amendments_test.go", token: "INV-15"}
+  - id: INV-ACCESS-8
+    scope: INV-ACCESS
+    origin_spec: "docs/superpowers/specs/2026-05-07-event-payload-crypto-phase5-totp-substrate-design.md"
+    legacy: ["INV-A16@docs/superpowers/specs/2026-05-07-event-payload-crypto-phase5-totp-substrate-design.md"]
+    summary: "Two ABAC seed forbid policies MUST deny character and plugin principals from reading events.*.system.crypto_totp.*
+      streams (sub-epic A; A16 extends INV-15's system-namespace deny across crypto audit namespaces)."
+    binding: pending
+    refs:
+      - {file: "internal/access/policy/seed.go", token: "INV-A16"}
+      - {file: "internal/access/policy/seed_test.go", token: "INV-A16",}
 
   # -- INV-CLUSTER -- migrated from bare INV-N (cross-replica coordination) (holomush-hz0v4.14.11).
   # Origin: docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md (master crypto spec; these bare invariants are CLUSTER-scoped per the
@@ -2855,3 +2920,85 @@ invariants:
     binding: pending
     refs:
       - {file: "internal/testsupport/integrationtest/default_plugins_test.go", token: "INV-WS-4"}
+  - id: INV-PLUGIN-22
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+    legacy: ["INV-1@docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"]
+    summary: "PluginHostService.Evaluate's subject is host-derived from the authenticated actor; there is no subject field
+      on the wire (never sourced from plugin/Lua-supplied data)."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/pluginauthz/evaluate.go", token: "INV-1"}
+      - {file: "internal/plugin/hostfunc/evaluate.go", token: "INV-1"}
+      - {file: "internal/plugin/hostfunc/stdlib_settings.go", token: "INV-1"}
+      - {file: "internal/plugin/goplugin/evaluate_invariants_test.go", token: "INV-1"}
+  - id: INV-PLUGIN-23
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+    legacy: ["INV-2@docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"]
+    summary: "No authenticated actor bound to the call → Evaluate returns deny + error (fail-closed)."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/pluginauthz/evaluate.go", token: "INV-2"}
+      - {file: "internal/plugin/hostfunc/stdlib_settings.go", token: "INV-2"}
+  - id: INV-PLUGIN-24
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+    legacy: ["INV-3@docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"]
+    summary: "A resource type the plugin does not own (outside its entitlement, no command carve-out) → rejected."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/pluginauthz/evaluate.go", token: "INV-3"}
+  - id: INV-PLUGIN-25
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+    legacy: ["INV-4@docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"]
+    summary: "Each Evaluate emits exactly one host-stamped audit event; the audit logger MUST be wired on both the binary
+      (gRPC) and Lua (hostfunc) surfaces."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/pluginauthz/evaluate.go", token: "INV-4"}
+      - {file: "internal/plugin/goplugin/host_engine_wiring_test.go", token: "INV-4"}
+      - {file: "internal/plugin/hostfunc/functions_audit_wiring_test.go", token: "INV-4"}
+      - {file: "internal/plugin/setup/subsystem.go", token: "INV-4"}
+      - {file: "internal/plugin/setup/subsystem_test.go", token: "INV-4"}
+      - {file: "internal/access/setup/subsystem.go", token: "INV-4"}
+      - {file: "internal/access/setup/setup_warn_integ_test.go", token: "INV-4"}
+  - id: INV-PLUGIN-26
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
+    legacy: ["INV-5@docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"]
+    summary: "The binary (gRPC) and Lua (hostfunc) surfaces reach identical host evaluation logic via a single shared mapping
+      (runtime parity)."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/pluginauthz/evaluate.go", token: "INV-5"}
+      - {file: "internal/plugin/goplugin/evaluate_invariants_test.go", token: "INV-5"}
+  - id: INV-PLUGIN-27
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"
+    legacy: ["INV-8@docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"]
+    summary: "Each settings host RPC MUST ship a Go SDK method AND a Lua hostfunc together (runtime parity); the settings
+      access gate is the single shared path for both runtimes."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/goplugin/host_service.go", token: "INV-8"}
+      - {file: "internal/plugin/hostfunc/functions.go", token: "INV-8"}
+      - {file: "internal/plugin/hostfunc/stdlib_settings.go", token: "INV-8"}
+      - {file: "internal/plugin/hostfunc/stdlib_settings_test.go", token: "INV-8"}
+      - {file: "internal/plugin/lua/host.go", token: "INV-8"}
+      - {file: "internal/plugin/lua/settings_ops_adapter.go", token: "INV-8"}
+      - {file: "internal/plugin/pluginauthz/principal.go", token: "INV-8"}
+  - id: INV-PLUGIN-28
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"
+    legacy: ["INV-11@docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"]
+    summary: "Cross-plugin settings isolation MUST be structural: the host binds the plugin partition from the authenticated
+      caller identity (stamped at server construction), never from caller-supplied input; a plugin MUST NOT address another
+      plugin's owner partition."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/goplugin/host_service.go", token: "INV-11"}
+      - {file: "internal/plugin/goplugin/host_settings_test.go", token: "INV-11"}
+      - {file: "internal/plugin/lua/settings_ops_adapter_test.go", token: "INV-11"}
+      - {file: "internal/plugin/pluginauthz/principal.go", token: "INV-11"}

--- a/internal/access/policy/seed.go
+++ b/internal/access/policy/seed.go
@@ -234,7 +234,7 @@ func SeedPolicies() []SeedPolicy {
 			SeedVersion: 1,
 		},
 
-		// --- Phase-5 sub-epic A TOTP-substrate audit namespace deny policies (INV-A16) ---
+		// --- Phase-5 sub-epic A TOTP-substrate audit namespace deny policies (INV-ACCESS-8) ---
 		//
 		// Reserved subject namespace events.<game>.system.crypto_totp.<scope>.<event>
 		// (sub-epic D emits; sub-epic A reserves). Parallel to the audit.* denies above.
@@ -272,9 +272,9 @@ func SeedPolicies() []SeedPolicy {
 			SeedVersion: 1,
 		},
 
-		// --- Phase-5 sub-epic E broad events.*.system.* deny policies (A16 / INV-15 extension) ---
+		// --- Phase-5 sub-epic E broad events.*.system.* deny policies (A16 / INV-ACCESS-7 extension) ---
 		//
-		// Amendment A16 extended INV-15 to deny plugin/character subscribes to ALL
+		// Amendment A16 extended INV-ACCESS-7 to deny plugin/character subscribes to ALL
 		// events.*.system.* namespaces, explicitly including the rekey audit chain
 		// (events.<gameID>.system.rekey.<ct>.<cid>) added in sub-epic E.
 		// These broad seeds future-proof subsequent audit chains (future sub-epics
@@ -285,13 +285,13 @@ func SeedPolicies() []SeedPolicy {
 		// filter remains as defense-in-depth.
 		{
 			Name:        "seed:deny-events-system-read-character",
-			Description: "Characters MUST NOT read events.*.system.* streams (Phase 5 sub-epic E; A16 / INV-15 extension — covers rekey and all future system audit namespaces)",
+			Description: "Characters MUST NOT read events.*.system.* streams (Phase 5 sub-epic E; A16 / INV-ACCESS-7 extension — covers rekey and all future system audit namespaces)",
 			DSLText:     `forbid(principal is character, action in ["read"], resource is stream) when { resource.stream.name like "events.*.system.*" };`,
 			SeedVersion: 1,
 		},
 		{
 			Name:        "seed:deny-events-system-read-plugin",
-			Description: "Plugins MUST NOT read events.*.system.* streams (Phase 5 sub-epic E; A16 / INV-15 extension — covers rekey and all future system audit namespaces)",
+			Description: "Plugins MUST NOT read events.*.system.* streams (Phase 5 sub-epic E; A16 / INV-ACCESS-7 extension — covers rekey and all future system audit namespaces)",
 			DSLText:     `forbid(principal is plugin, action in ["read"], resource is stream) when { resource.stream.name like "events.*.system.*" };`,
 			SeedVersion: 1,
 		},

--- a/internal/access/policy/seed_smoke_test.go
+++ b/internal/access/policy/seed_smoke_test.go
@@ -814,7 +814,7 @@ func TestSeedSmokePemitAllowedForAdmin(t *testing.T) {
 	assert.True(t, decision.IsAllowed(), "admin should execute pemit; got: %s — %s", decision.Effect(), decision.Reason())
 }
 
-// Phase-5 sub-epic E ABAC-layer enforcement smoke tests (A16 / INV-15 extension)
+// Phase-5 sub-epic E ABAC-layer enforcement smoke tests (A16 / INV-ACCESS-7 extension)
 //
 // These tests verify that the ABAC engine (with seed policies loaded) denies
 // character and plugin principals from reading events.*.system.rekey.* streams.
@@ -841,7 +841,7 @@ func TestSeedSmokeCharacterDeniedEventsSystemRekeyStream(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, decision.IsAllowed(),
-		"character must NOT read events.*.system.rekey.* stream (ABAC seed gate A16/INV-15); got: %s — %s",
+		"character must NOT read events.*.system.rekey.* stream (ABAC seed gate A16/INV-ACCESS-7); got: %s — %s",
 		decision.Effect(), decision.Reason())
 }
 
@@ -934,6 +934,6 @@ func TestSeedSmokePluginDeniedEventsSystemRekeyStream(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, decision.IsAllowed(),
-		"plugin must NOT read events.*.system.rekey.* stream (ABAC seed gate A16/INV-15); got: %s — %s",
+		"plugin must NOT read events.*.system.rekey.* stream (ABAC seed gate A16/INV-ACCESS-7); got: %s — %s",
 		decision.Effect(), decision.Reason())
 }

--- a/internal/access/policy/seed_test.go
+++ b/internal/access/policy/seed_test.go
@@ -111,7 +111,7 @@ func TestSeedPoliciesExpectedNames(t *testing.T) {
 		// Phase-3b audit deny policies
 		"seed:deny-audit-read-character",
 		"seed:deny-audit-read-plugin",
-		// Phase-5 sub-epic A TOTP-substrate audit deny policies (INV-A16)
+		// Phase-5 sub-epic A TOTP-substrate audit deny policies (INV-ACCESS-8)
 		"seed:deny-events-system-crypto-totp-read-character",
 		"seed:deny-events-system-crypto-totp-read-plugin",
 		// Phase-5 sub-epic D crypto-policy audit deny policies
@@ -242,7 +242,7 @@ func TestSeedPoliciesScenePoliciesExist(t *testing.T) {
 
 // Phase-3b audit deny policy tests
 //
-// INV-15 (post-Phase-3d Decision 4 reword): ABAC denies subscribe to
+// INV-ACCESS-7 (post-Phase-3d Decision 4 reword): ABAC denies subscribe to
 // audit.* streams for kind={plugin|character}. Per master spec §7.7
 // (amended via Phase 3d grounding doc Appendix A), ABAC at the gRPC
 // subscribe handler boundary is the authoritative isolation gate. The
@@ -251,7 +251,7 @@ func TestSeedPoliciesScenePoliciesExist(t *testing.T) {
 // apply (game-topic NATS is single-principal by architectural design).
 //
 // The two test cases below verify both seed policies exist with the
-// correct DSL — they are the Phase-3d-touchable coverage of INV-15.
+// correct DSL — they are the Phase-3d-touchable coverage of INV-ACCESS-7.
 //
 // Refs: docs/superpowers/specs/2026-05-03-event-payload-crypto-phase3d-grounding.md (Decision 3 + Decision 4)
 
@@ -285,9 +285,9 @@ func TestSeedPoliciesIncludesAuditSubscribeDenyForPlugin(t *testing.T) {
 	assert.True(t, found, "audit.> deny seed policy for plugin MUST be present")
 }
 
-// Phase-5 sub-epic A TOTP-substrate audit deny policy tests (INV-A16)
+// Phase-5 sub-epic A TOTP-substrate audit deny policy tests (INV-ACCESS-8)
 //
-// INV-A16: ABAC denies subscribe to events.*.system.crypto_totp.* streams
+// INV-ACCESS-8: ABAC denies subscribe to events.*.system.crypto_totp.* streams
 // for kind={plugin|character}. Sub-epic D emits these events; sub-epic A
 // reserves the namespace via these seeds.
 
@@ -303,7 +303,7 @@ func TestSeedPoliciesIncludesEventsSystemCryptoTotpDenyForCharacter(t *testing.T
 			break
 		}
 	}
-	assert.True(t, found, "events.*.system.crypto_totp.* deny seed for character MUST be present (INV-A16)")
+	assert.True(t, found, "events.*.system.crypto_totp.* deny seed for character MUST be present (INV-ACCESS-8)")
 }
 
 func TestSeedPoliciesIncludesEventsSystemCryptoTotpDenyForPlugin(t *testing.T) {
@@ -318,12 +318,12 @@ func TestSeedPoliciesIncludesEventsSystemCryptoTotpDenyForPlugin(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "events.*.system.crypto_totp.* deny seed for plugin MUST be present (INV-A16)")
+	assert.True(t, found, "events.*.system.crypto_totp.* deny seed for plugin MUST be present (INV-ACCESS-8)")
 }
 
 // Phase-5 sub-epic D crypto-policy audit deny policy tests
 //
-// Mirrors INV-A16 for the events.*.system.crypto_policy.* namespace.
+// Mirrors INV-ACCESS-8 for the events.*.system.crypto_policy.* namespace.
 // Sub-epic D emits crypto.policy_set audit events on this subject; these
 // seeds are the ABAC-layer gate parallel to the dispatchDelivery
 // AUDIT_ONLY filter at internal/grpc/server.go (~line 1019).
@@ -358,9 +358,9 @@ func TestSeedPoliciesIncludesEventsSystemCryptoPolicyDenyForPlugin(t *testing.T)
 	assert.True(t, found, "events.*.system.crypto_policy.* deny seed for plugin MUST be present (Phase 5 sub-epic D)")
 }
 
-// Phase-5 sub-epic E broad events.*.system.* deny policy tests (A16 / INV-15 extension)
+// Phase-5 sub-epic E broad events.*.system.* deny policy tests (A16 / INV-ACCESS-7 extension)
 //
-// A16 extended INV-15 to cover all events.*.system.* namespaces, explicitly
+// A16 extended INV-ACCESS-7 to cover all events.*.system.* namespaces, explicitly
 // including the rekey audit chain (events.<gameID>.system.rekey.<ct>.<cid>).
 // The narrow per-namespace seeds (crypto_totp, crypto_policy) are subsumed by
 // these broad seeds, which future-proof against subsequent audit chains.
@@ -380,7 +380,7 @@ func TestSeedPoliciesIncludesEventsSystemRekeyDenyForCharacter(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "events.*.system.* broad deny seed for character MUST be present (A16 / INV-15)")
+	assert.True(t, found, "events.*.system.* broad deny seed for character MUST be present (A16 / INV-ACCESS-7)")
 }
 
 func TestSeedPoliciesIncludesEventsSystemRekeyDenyForPlugin(t *testing.T) {
@@ -397,7 +397,7 @@ func TestSeedPoliciesIncludesEventsSystemRekeyDenyForPlugin(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "events.*.system.* broad deny seed for plugin MUST be present (A16 / INV-15)")
+	assert.True(t, found, "events.*.system.* broad deny seed for plugin MUST be present (A16 / INV-ACCESS-7)")
 }
 
 // Phase-5 iwzt history-scope-privacy policy tests

--- a/internal/access/setup/setup_warn_integ_test.go
+++ b/internal/access/setup/setup_warn_integ_test.go
@@ -39,7 +39,7 @@ func TestBuildABACStack_WarnsWhenPropertyRepoMissing(t *testing.T) {
 		LocationRepo:  worldpostgres.NewLocationRepository(pool),
 		ObjectRepo:    worldpostgres.NewObjectRepository(pool),
 		// PropertyRepo + ParentLocationResolver INTENTIONALLY OMITTED — exercises
-		// the 8d. else-branch WARN path. Per holomush-72ou INV-4.
+		// the 8d. else-branch WARN path. Per holomush-72ou INV-PLUGIN-25.
 	})
 	require.NoError(t, err)
 

--- a/internal/access/setup/subsystem.go
+++ b/internal/access/setup/subsystem.go
@@ -189,7 +189,7 @@ func (s *ABACSubsystem) AttributeResolver() *attribute.Resolver {
 // AuditLogger returns the audit logger from the ABAC stack as a
 // pluginauthz.Auditor. The concrete type is *audit.Logger; callers may pass
 // the return value directly to goplugin.WithAuditLogger or
-// hostfunc.WithAuditLogger to satisfy spec §5 / INV-4. Returns nil when
+// hostfunc.WithAuditLogger to satisfy spec §5 / INV-PLUGIN-25. Returns nil when
 // AuditLogger is nil (audit logging disabled), giving callers a clean nil
 // interface value rather than an interface wrapping a nil pointer.
 // Panics if called before Start().

--- a/internal/access/spec_amendments_test.go
+++ b/internal/access/spec_amendments_test.go
@@ -155,7 +155,7 @@ func TestSpecAmendmentsLandedSubEpicE(t *testing.T) {
 		"E_A14_phase5_rekey_checkpoints": "crypto_rekey_checkpoints",
 		// A15: §12 open questions — holomush-ojw1.6 permanent reference
 		"E_A15_ojw1_6_ref": "holomush-ojw1.6",
-		// A16: §10 line 900-901 INV-15 ABAC denial extended to events.*.system.*
+		// A16: §10 line 900-901 INV-ACCESS-7 ABAC denial extended to events.*.system.*
 		"E_A16_abac_events_system_denial": "events.*.system.*",
 	}
 

--- a/internal/plugin/goplugin/evaluate_invariants_test.go
+++ b/internal/plugin/goplugin/evaluate_invariants_test.go
@@ -9,9 +9,9 @@ package goplugin
 // as TestEvaluateForeignResourceTypeRejected etc.) — they are structural locks
 // that break loudly if a future change violates the spec invariants:
 //
-//   INV-1: EvaluateRequest carries NO subject field (subject is host-derived,
+//   INV-PLUGIN-22: EvaluateRequest carries NO subject field (subject is host-derived,
 //          never on the wire).
-//   INV-5: Both the binary (gRPC) surface AND the Lua (hostfunc) surface reject
+//   INV-PLUGIN-26: Both the binary (gRPC) surface AND the Lua (hostfunc) surface reject
 //          a resource type the plugin does not own, proving they both reach the
 //          shared pluginauthz.Evaluate entitlement gate and cannot diverge.
 
@@ -34,14 +34,14 @@ import (
 // TestINV1EvaluateRequestHasNoSubjectField reflects over the proto descriptor of
 // PluginHostServiceEvaluateRequest and asserts no field named "subject" exists.
 // The subject is always host-derived from the dispatch token; placing it on
-// the wire would allow plugins to forge authorization subjects (INV-1).
+// the wire would allow plugins to forge authorization subjects (INV-PLUGIN-22).
 func TestINV1EvaluateRequestHasNoSubjectField(t *testing.T) {
 	md := (&pluginv1.PluginHostServiceEvaluateRequest{}).ProtoReflect().Descriptor()
 	fields := md.Fields()
 	for i := range fields.Len() {
 		name := string(fields.Get(i).Name())
 		assert.NotEqual(t, "subject", name,
-			"EvaluateRequest MUST NOT carry a subject field (INV-1): "+
+			"EvaluateRequest MUST NOT carry a subject field (INV-PLUGIN-22): "+
 				"subject is host-derived from the dispatch token, never plugin-supplied")
 	}
 	// Positive assertion: only the expected fields are present.
@@ -49,7 +49,7 @@ func TestINV1EvaluateRequestHasNoSubjectField(t *testing.T) {
 	// breaks this test even if the name check above is somehow weakened.
 	assert.Equal(t, 2, fields.Len(),
 		"EvaluateRequest MUST have exactly 2 fields (action + resource); "+
-			"adding a subject field violates INV-1")
+			"adding a subject field violates INV-PLUGIN-22")
 }
 
 // TestINV5BothSurfacesRejectForeignResourceTypeViaSharedEntitlementGate asserts

--- a/internal/plugin/goplugin/host_engine_wiring_test.go
+++ b/internal/plugin/goplugin/host_engine_wiring_test.go
@@ -47,7 +47,7 @@ func (s *stubAuditorForGoplugin) Log(_ context.Context, _ audit.Event) error { r
 var _ pluginauthz.Auditor = (*stubAuditorForGoplugin)(nil)
 
 // TestWithAuditLoggerStoresAuditorInHost is a behavioral wiring-guard for
-// holomush-p1tq2.5 / INV-4. It verifies that goplugin.WithAuditLogger
+// holomush-p1tq2.5 / INV-PLUGIN-25. It verifies that goplugin.WithAuditLogger
 // correctly propagates the given Auditor into the host's internal auditor
 // field, confirming the PluginHostService.Evaluate path will emit audit
 // events.
@@ -58,7 +58,7 @@ var _ pluginauthz.Auditor = (*stubAuditorForGoplugin)(nil)
 //
 // to goplugin.NewHost. Without this propagation, PluginHostService.Evaluate
 // silently drops all audit events regardless of the decision, violating
-// spec §5 / INV-4.
+// spec §5 / INV-PLUGIN-25.
 //
 // This test confirms:
 //  1. WithAuditLogger is a valid HostOption (compile-time guard).
@@ -74,7 +74,7 @@ func TestWithAuditLoggerStoresAuditorInHost(t *testing.T) {
 	got := host.AuditorForTest()
 	assert.NotNil(t, got,
 		"binary host MUST have a non-nil auditor after WithAuditLogger option is applied; "+
-			"nil means PluginHostService.Evaluate never emits audit events (INV-4 regression)")
+			"nil means PluginHostService.Evaluate never emits audit events (INV-PLUGIN-25 regression)")
 	assert.Same(t, aud, got,
 		"host must store the identical auditor instance passed to WithAuditLogger; "+
 			"a different instance would break audit-log correlation across subsystems")

--- a/internal/plugin/goplugin/host_service.go
+++ b/internal/plugin/goplugin/host_service.go
@@ -601,7 +601,7 @@ func (s *pluginHostServiceServer) Evaluate(ctx context.Context, req *pluginv1.Pl
 // Security invariants (holomush-iokti.7):
 //   - The plugin partition is bound host-side from s.pluginName (stamped at
 //     construction, never from the request) via base.Plugin(s.pluginName). Two
-//     plugins with different names address disjoint partitions (INV-11).
+//     plugins with different names address disjoint partitions (INV-PLUGIN-28).
 //   - Scope must be specified; SETTING_SCOPE_UNSPECIFIED fails closed
 //     (InvalidArgument).
 //   - CHARACTER: req.principal_id must equal the acting character's ID (correct
@@ -628,7 +628,7 @@ func (s *pluginHostServiceServer) GetSetting(ctx context.Context, req *pluginv1.
 	// method-level invariants above): it fails closed on a bad token/subject and
 	// enforces principal ownership for PLAYER / CHARACTER. GAME reads are open to
 	// any plugin (no engine check); base.Plugin(s.pluginName) below confines the
-	// read to the caller's own keyspace (INV-11).
+	// read to the caller's own keyspace (INV-PLUGIN-28).
 	base, _, err := s.resolveSettingScope(ctx, req.GetScope(), req.GetPrincipalId())
 	if err != nil {
 		return nil, err
@@ -783,7 +783,7 @@ func (s *pluginHostServiceServer) principalScopedStore(
 // host-vouched expectedOwnerID by delegating to the runtime-neutral shared gate
 // pluginauthz.CheckPrincipalOwnership — the SAME helper the Lua
 // get_setting/set_setting hostfuncs use, so the binary and Lua ownership trust
-// checks cannot diverge (plugin-runtime-symmetry, INV-8). The oops codes the
+// checks cannot diverge (plugin-runtime-symmetry, INV-PLUGIN-27). The oops codes the
 // helper returns are mapped to the gRPC statuses this RPC has always returned:
 // INVALID_PRINCIPAL_ID → InvalidArgument ("invalid principal_id"),
 // PRINCIPAL_NOT_OWNED → PermissionDenied ("permission denied").
@@ -813,7 +813,7 @@ func (s *pluginHostServiceServer) requirePrincipalOwnership(principalID, expecte
 // a GAME-scope write. The subject (token-recovered) must be permitted to "write"
 // the per-plugin resource pluginauthz.SettingsGameWriteResource(s.pluginName).
 // Using the per-plugin resource lets operator policies scope GAME-write per
-// plugin (plugin-runtime-symmetry, INV-8; holomush-iokti.15 Item 2).
+// plugin (plugin-runtime-symmetry, INV-PLUGIN-27; holomush-iokti.15 Item 2).
 // A deny → PermissionDenied; an engine/build failure is logged and surfaced as
 // a generic Internal (no inner-error leak).
 func (s *pluginHostServiceServer) authorizeGameWrite(ctx context.Context, subject string) error {

--- a/internal/plugin/goplugin/host_settings_test.go
+++ b/internal/plugin/goplugin/host_settings_test.go
@@ -461,7 +461,7 @@ func TestPlayerSettingDeniedWhenPrincipalNotOwningPlayer(t *testing.T) {
 		"PLAYER principal_id MUST equal the token's owning player")
 }
 
-// TestGameSettingOwnerPartitionIsolatedAcrossPlugins is the INV-11 security test:
+// TestGameSettingOwnerPartitionIsolatedAcrossPlugins is the INV-PLUGIN-28 security test:
 // a value written by plug-A under its owner partition is invisible to plug-B,
 // because the owner is bound host-side from the authenticated plugin name.
 func TestGameSettingOwnerPartitionIsolatedAcrossPlugins(t *testing.T) {
@@ -498,5 +498,5 @@ func TestGameSettingOwnerPartitionIsolatedAcrossPlugins(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, respB.GetFound(),
-		"INV-11: plug-B MUST NOT read plug-A's owner partition")
+		"INV-PLUGIN-28: plug-B MUST NOT read plug-A's owner partition")
 }

--- a/internal/plugin/hostfunc/evaluate.go
+++ b/internal/plugin/hostfunc/evaluate.go
@@ -16,7 +16,7 @@ import (
 // evaluateFn returns the holomush.evaluate(action, resource) Lua host function.
 //
 // Subject is derived from the host-stamped actor on the Lua VM's context
-// (INV-1: NEVER from Lua arguments). Delegates to pluginauthz.Evaluate with
+// (INV-PLUGIN-22: NEVER from Lua arguments). Delegates to pluginauthz.Evaluate with
 // empty OwnedTypes — Lua plugins own no resource types, so entitlement
 // degrades to the command: carve-out (spec §3).
 //

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -123,7 +123,7 @@ func WithFocusOps(fo FocusOps) Option {
 
 // WithSettingsOps sets the plugin-partitioned settings store seam for the
 // holomush.get_setting / set_setting host functions (plugin-runtime-symmetry
-// with the binary GetSetting / SetSetting RPCs; INV-8).
+// with the binary GetSetting / SetSetting RPCs; INV-PLUGIN-27).
 func WithSettingsOps(so SettingsOps) Option {
 	return func(f *Functions) { f.settingsOps = so }
 }

--- a/internal/plugin/hostfunc/functions_audit_wiring_test.go
+++ b/internal/plugin/hostfunc/functions_audit_wiring_test.go
@@ -26,7 +26,7 @@ func (s *stubAuditorForHostfunc) Log(_ context.Context, _ audit.Event) error { r
 var _ pluginauthz.Auditor = (*stubAuditorForHostfunc)(nil)
 
 // TestWithAuditLoggerStoresAuditorInFunctions is a behavioral wiring-guard for
-// holomush-p1tq2.5 / INV-4 on the Lua surface. It verifies that
+// holomush-p1tq2.5 / INV-PLUGIN-25 on the Lua surface. It verifies that
 // hostfunc.WithAuditLogger correctly propagates the given Auditor into the
 // Functions' internal auditor field, confirming that holomush.evaluate Lua
 // calls will emit audit events.
@@ -36,7 +36,7 @@ var _ pluginauthz.Auditor = (*stubAuditorForHostfunc)(nil)
 //	hostfunc.WithAuditLogger(s.cfg.ABAC.AuditLogger())
 //
 // to hostfunc.New. Without this propagation, holomush.evaluate silently drops
-// all audit events regardless of the decision, violating spec §5 / INV-4.
+// all audit events regardless of the decision, violating spec §5 / INV-PLUGIN-25.
 //
 // This test confirms:
 //  1. WithAuditLogger is a valid Option (compile-time guard).
@@ -52,7 +52,7 @@ func TestWithAuditLoggerStoresAuditorInFunctions(t *testing.T) {
 	got := funcs.AuditorForTest()
 	assert.NotNil(t, got,
 		"hostfunc.Functions MUST have a non-nil auditor after WithAuditLogger option is applied; "+
-			"nil means holomush.evaluate never emits audit events (INV-4 regression)")
+			"nil means holomush.evaluate never emits audit events (INV-PLUGIN-25 regression)")
 	assert.Same(t, aud, got,
 		"Functions must store the identical auditor instance passed to WithAuditLogger; "+
 			"a different instance would break audit-log correlation across subsystems")

--- a/internal/plugin/hostfunc/stdlib_settings.go
+++ b/internal/plugin/hostfunc/stdlib_settings.go
@@ -49,7 +49,7 @@ func settingScopeFromString(s string) pluginv1.SettingScope {
 }
 
 // resolveSettingsAccess recovers the acting actor and (for PLAYER scope) the
-// host-vouched owning player from the Lua VM context (INV-1: NEVER from Lua
+// host-vouched owning player from the Lua VM context (INV-PLUGIN-22: NEVER from Lua
 // args), maps the scope string, enforces principal ownership for PLAYER /
 // CHARACTER via the SHARED pluginauthz.CheckPrincipalOwnership gate (the SAME
 // helper the binary host uses, with the SAME expected-owner semantics), and —
@@ -75,7 +75,7 @@ func (f *Functions) resolveSettingsAccess(
 
 	actor, ok := core.ActorFromContext(ctx)
 	if !ok || pluginauthz.ActorSubject(actor) == "" {
-		// No authenticated actor on the call → fail closed (INV-1 / INV-2).
+		// No authenticated actor on the call → fail closed (INV-PLUGIN-22 / INV-PLUGIN-23).
 		return scope, "", "permission denied"
 	}
 
@@ -114,7 +114,7 @@ func (f *Functions) resolveSettingsAccess(
 // the recovered subject must be permitted to "write" the per-plugin resource
 // pluginauthz.SettingsGameWriteResource(pluginName) via the ABAC engine. Using
 // the per-plugin resource keeps binary and Lua identical (plugin-runtime-symmetry,
-// INV-8; holomush-iokti.15 Item 2). A nil engine or a deny → permission denied;
+// INV-PLUGIN-27; holomush-iokti.15 Item 2). A nil engine or a deny → permission denied;
 // engine build errors are logged and surfaced as a generic message (no
 // inner-error leak).
 func (f *Functions) authorizeGameWrite(ctx context.Context, pluginName, subject string) string {

--- a/internal/plugin/hostfunc/stdlib_settings_test.go
+++ b/internal/plugin/hostfunc/stdlib_settings_test.go
@@ -258,7 +258,7 @@ func TestPlayerSettingDeniedWhenPrincipalNotOwningPlayer(t *testing.T) {
 // Lua GET-path TestGetSettingPlayerScopeDeniedWhenNoOwningPlayerOnContext: a
 // PLAYER-scope WRITE with no owning player stamped on the ctx fails closed, and
 // the denied write never reaches the store. Closes the runtime-symmetry test gap
-// (INV-8, holomush-sl0ir.13): the gate is shared (set_setting → resolveSettingsAccess
+// (INV-PLUGIN-27, holomush-sl0ir.13): the gate is shared (set_setting → resolveSettingsAccess
 // → CheckPrincipalOwnership), but the write path lacked an explicit Lua mirror.
 func TestSetSettingPlayerScopeDeniedWhenNoOwningPlayerOnContext(t *testing.T) {
 	L := lua.NewState()
@@ -290,7 +290,7 @@ func TestSetSettingPlayerScopeDeniedWhenNoOwningPlayerOnContext(t *testing.T) {
 // mirror of the binary TestSetSettingPlayerForeignPrincipalDenied: even with an
 // owning player on the ctx, a PLAYER-scope WRITE whose principal_id does NOT
 // equal the vouched owner is denied and never reaches the store
-// (holomush-sl0ir.13 / INV-8).
+// (holomush-sl0ir.13 / INV-PLUGIN-27).
 func TestSetSettingPlayerScopeDeniedWhenPrincipalNotOwningPlayer(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -135,7 +135,7 @@ func (h *Host) SetFocusCoordinator(fc focus.Coordinator) {
 // underlying hostfunc bridge via a settingsStoresOpsAdapter that satisfies
 // hostfunc.SettingsOps, so the Lua get_setting / set_setting hostfuncs reach the
 // SAME stores the binary GetSetting / SetSetting RPCs use (plugin-runtime-
-// symmetry, INV-8). Implements plugins.SettingsDepsConfigurer; invoked by
+// symmetry, INV-PLUGIN-27). Implements plugins.SettingsDepsConfigurer; invoked by
 // Manager.ConfigureSettingsDeps via findOptional during gRPC subsystem Start.
 //
 // If any store is nil the binding is cleared rather than wrapping a partial set

--- a/internal/plugin/lua/settings_ops_adapter.go
+++ b/internal/plugin/lua/settings_ops_adapter.go
@@ -17,7 +17,7 @@ import (
 // to the hostfunc.SettingsOps store seam. It is the permanent Lua delegation
 // seam: it lets the gopher-lua hostfunc layer reach the SAME settings stores the
 // binary PluginHostService uses, so both runtimes drive plugin-partitioned
-// settings through one common store path (plugin-runtime-symmetry, INV-8).
+// settings through one common store path (plugin-runtime-symmetry, INV-PLUGIN-27).
 //
 // All trust checks (actor recovery, principal ownership, GAME-write operator
 // authorization) are performed by the hostfunc layer BEFORE these methods run —

--- a/internal/plugin/lua/settings_ops_adapter_test.go
+++ b/internal/plugin/lua/settings_ops_adapter_test.go
@@ -77,7 +77,7 @@ func TestSettingsAdapterIsolatesByOwnerPartition(t *testing.T) {
 		pluginv1.SettingScope_SETTING_SCOPE_CHARACTER, "plug-A", charID,
 		"content.cw_block", []string{"gore"}))
 
-	// A different plugin owner addresses a disjoint partition (INV-11).
+	// A different plugin owner addresses a disjoint partition (INV-PLUGIN-28).
 	_, found, err := adapter.GetSetting(ctx,
 		pluginv1.SettingScope_SETTING_SCOPE_CHARACTER, "plug-B", charID, "content.cw_block")
 	require.NoError(t, err)

--- a/internal/plugin/pluginauthz/evaluate.go
+++ b/internal/plugin/pluginauthz/evaluate.go
@@ -4,7 +4,7 @@
 // Package pluginauthz holds the runtime-neutral per-action authorization
 // core shared by the binary (PluginHostService.Evaluate) and Lua
 // (holomush.evaluate) surfaces. Both delegate here so policy/trust
-// behavior cannot diverge between runtimes (INV-5).
+// behavior cannot diverge between runtimes (INV-PLUGIN-26).
 package pluginauthz
 
 import (
@@ -57,7 +57,7 @@ func initCounter() {
 }
 
 // ActorSubject maps a host-stamped Actor to its ABAC subject string. It is
-// the single mapping shared by the binary and Lua surfaces (INV-5) so the
+// the single mapping shared by the binary and Lua surfaces (INV-PLUGIN-26) so the
 // two cannot derive divergent subjects. Returns "" for an unknown/zero
 // actor kind, which Evaluate treats as fail-closed.
 func ActorSubject(a core.Actor) string {
@@ -95,7 +95,7 @@ type Auditor interface {
 }
 
 // Input carries everything the shared core needs. Subject is HOST-DERIVED
-// and MUST NOT originate from plugin-supplied data (INV-1).
+// and MUST NOT originate from plugin-supplied data (INV-PLUGIN-22).
 type Input struct {
 	Engine     types.AccessPolicyEngine
 	Auditor    Auditor
@@ -169,7 +169,7 @@ func Evaluate(ctx context.Context, in Input) (Decision, error) {
 		return Decision{}, err
 	}
 	if in.Subject == "" {
-		// No authenticated actor bound to the call (INV-2).
+		// No authenticated actor bound to the call (INV-PLUGIN-23).
 		err := oops.Code("EVALUATE_NO_SUBJECT").
 			With("plugin", in.PluginName).
 			Errorf("evaluate called without an authenticated subject")
@@ -192,7 +192,7 @@ func Evaluate(ctx context.Context, in Input) (Decision, error) {
 		return Decision{}, err
 	}
 
-	// Entitlement (INV-3): plugin-owned type or the command carve-out.
+	// Entitlement (INV-PLUGIN-24): plugin-owned type or the command carve-out.
 	if resType != commandResourceType && !in.OwnedTypes[resType] {
 		err := oops.Code("EVALUATE_UNENTITLED_TYPE").
 			With("plugin", in.PluginName).With("resource_type", resType).
@@ -232,7 +232,7 @@ func Evaluate(ctx context.Context, in Input) (Decision, error) {
 	}
 	recordEffect(effect)
 
-	// Audit (INV-4): exactly one host-stamped event per evaluation.
+	// Audit (INV-PLUGIN-25): exactly one host-stamped event per evaluation.
 	if in.Auditor != nil {
 		auditEffect := types.EffectDeny
 		if dec.IsAllowed() {

--- a/internal/plugin/pluginauthz/principal.go
+++ b/internal/plugin/pluginauthz/principal.go
@@ -12,11 +12,11 @@ import (
 // writes to for the given plugin. It is the single source of truth shared by
 // the binary (PluginHostService.SetSetting) and Lua (holomush.set_setting)
 // surfaces so the two runtimes cannot drift onto different operator-permission
-// resources (plugin-runtime-symmetry, INV-8). The resource is per-plugin so
+// resources (plugin-runtime-symmetry, INV-PLUGIN-27). The resource is per-plugin so
 // operator policies can scope GAME-write permission per plugin: a grant on
 // "setting:game:core-scenes" authorises only that plugin's GAME writes, not
 // all plugins'. The owner partition already confines the DATA to the plugin's
-// keyspace (INV-11); this scopes the operator POLICY to match.
+// keyspace (INV-PLUGIN-28); this scopes the operator POLICY to match.
 // Only operator subjects are granted "write" on it; a non-operator
 // plugin/character is denied.
 func SettingsGameWriteResource(pluginName string) string {
@@ -28,7 +28,7 @@ func SettingsGameWriteResource(pluginName string) string {
 // act on behalf of. It is the single runtime-neutral ownership gate shared by
 // the binary (PluginHostService.GetSetting/SetSetting) and Lua
 // (holomush.get_setting/set_setting) settings surfaces, so the trust check
-// cannot diverge between runtimes (plugin-runtime-symmetry, INV-8).
+// cannot diverge between runtimes (plugin-runtime-symmetry, INV-PLUGIN-27).
 //
 // Identity recovery legitimately differs per runtime — the binary path recovers
 // the expected owner from the dispatch token (emit_token_store), the Lua path

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -45,7 +45,7 @@ const shutdownTimeout = 10 * time.Second
 // plugin-declared attribute providers so that per-action resource policies
 // (e.g. resource.scene.*) resolve at evaluation time. AuditLogger satisfies
 // pluginauthz.Auditor and is wired to both Evaluate surfaces (binary and Lua)
-// so that spec §5 / INV-4 ("exactly one host-stamped audit event per
+// so that spec §5 / INV-PLUGIN-25 ("exactly one host-stamped audit event per
 // plugin per-action decision") is satisfied in production.
 type EngineProvider interface {
 	Engine() types.AccessPolicyEngine
@@ -56,7 +56,7 @@ type EngineProvider interface {
 	// AuditLogger returns the audit.Logger from the ABAC stack. It satisfies
 	// pluginauthz.Auditor and is passed to goplugin.WithAuditLogger and
 	// hostfunc.WithAuditLogger so both Evaluate surfaces emit audit events
-	// (INV-4). May return nil when audit logging is disabled.
+	// (INV-PLUGIN-25). May return nil when audit logging is disabled.
 	AuditLogger() pluginauthz.Auditor
 }
 
@@ -178,7 +178,7 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 	capRegistry.Register("holomush.plugin.v1.AuditService", hostfunc.NewAuditCapability())
 
 	// Create hostfunc bridge.
-	// Wire the audit logger so holomush.evaluate Lua calls emit INV-4 host-stamped
+	// Wire the audit logger so holomush.evaluate Lua calls emit INV-PLUGIN-25 host-stamped
 	// audit events. The logger satisfies pluginauthz.Auditor; nil is safe (audit
 	// is skipped) but should not occur in production since ABACSubsystem always
 	// constructs an audit.Logger during Start().
@@ -278,9 +278,9 @@ func (s *PluginSubsystem) Start(ctx context.Context) error {
 		// attribute resolver registered on it is the same one returned by
 		// s.cfg.ABAC.AttributeResolver() below. One engine+resolver pair for both surfaces.
 		goplugin.WithEngine(s.cfg.ABAC.Engine()),
-		// Wire the audit logger so PluginHostService.Evaluate emits INV-4 host-stamped
+		// Wire the audit logger so PluginHostService.Evaluate emits INV-PLUGIN-25 host-stamped
 		// audit events for binary plugins. Same logger instance as the Lua surface above
-		// (both call s.cfg.ABAC.AuditLogger()), satisfying spec §5 / INV-4.
+		// (both call s.cfg.ABAC.AuditLogger()), satisfying spec §5 / INV-PLUGIN-25.
 		goplugin.WithAuditLogger(s.cfg.ABAC.AuditLogger()),
 		// Thread per-plugin config overrides from PluginSubsystemConfig into the
 		// binary host so overrideFor() can look them up at plugin init time.

--- a/internal/plugin/setup/subsystem_test.go
+++ b/internal/plugin/setup/subsystem_test.go
@@ -87,7 +87,7 @@ func TestPluginSubsystemHealthStatusReportsDeadBeforeStart(t *testing.T) {
 
 // TestEngineProviderInterfaceRequiresAttributeResolverAndAuditLogger is a
 // compile-time guard. The EngineProvider interface used by PluginSubsystem MUST
-// include AttributeResolver() (holomush-8kkv5.18) and AuditLogger() (INV-4 /
+// include AttributeResolver() (holomush-8kkv5.18) and AuditLogger() (INV-PLUGIN-25 /
 // holomush-p1tq2.5) so that Start() can wire both surfaces. If either method is
 // removed from the interface this line fails to compile — catching the regression
 // before it reaches E2E.
@@ -209,7 +209,7 @@ func (r *recordingAuditor) Log(_ context.Context, event audit.Event) error {
 }
 
 // TestAuditWiringFromEngineProvider is a table-driven wiring-guard for
-// holomush-p1tq2.5 / INV-4. Each row asserts that:
+// holomush-p1tq2.5 / INV-PLUGIN-25. Each row asserts that:
 //  1. fakeEngineProvider.AuditLogger() returns a non-nil auditor (so the
 //     guard is meaningful).
 //  2. The corresponding host/functions constructor accepts the
@@ -220,7 +220,7 @@ func (r *recordingAuditor) Log(_ context.Context, event audit.Event) error {
 // package-level access to host internals via export_test.go.
 //
 // Without this wiring PluginHostService.Evaluate (binary) and holomush.evaluate
-// (Lua) never emit audit events regardless of the decision, violating spec §5 / INV-4.
+// (Lua) never emit audit events regardless of the decision, violating spec §5 / INV-PLUGIN-25.
 func TestAuditWiringFromEngineProvider(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## What

The dedicated **bare-INV-N pass** (epic **holomush-hz0v4.14**, bead **holomush-hz0v4.14.22**) — cleans up the tri-overloaded shared bare namespace that the per-scope migrations deferred because the *same bare number means different invariants across origin specs within the same files*. Per-site semantic classification → closed-world `{file,token}` migration via `cmd/inv-migrate`. Doc-comment/annotation rename only; no behavior change.

### Migrated (9 entries)
| Cluster | Origin spec | Legacy → canonical |
|---|---|---|
| plugin-host-evaluate | `2026-05-25-plugin-host-evaluate` | `INV-1..5` → `INV-PLUGIN-22..26` |
| phase-8 settings-authz | `2026-05-29-scenes-phase-8-board-content-warnings` | `INV-8/11` → `INV-PLUGIN-27/28` |
| ABAC system-stream-deny | `2026-04-25` master crypto | `INV-15` → `INV-ACCESS-7` |
| ABAC crypto_totp deny | `2026-05-07` phase-5 totp-substrate | `INV-A16` → `INV-ACCESS-8` |

**INV-15/A16 fold to INV-ACCESS** (not INV-CRYPTO): their code home is the ABAC seed layer (`internal/access/policy/`) and INV-ACCESS's scope is "seed policy shape, authorization decisions." User-confirmed.

The plugin-host-evaluate invariants span `pluginauthz/` + `hostfunc/` + `goplugin/` + the audit-wiring `setup/` files — **not `evaluate.go` alone** (the `.14.14` "evaluate.go ONLY" note undercounted; corrected per-site with annotation-text evidence).

### Left untouched (closed-world — the tri-overload disambiguation)
The same bare numbers mean *other* invariants in co-located files; all preserved:
- **command-visibility `INV-1`** (`commands.go`, `functions.go`, `help_integration_test.go`, `setup/subsystem.go`)
- **settings `INV-6`** (`host_service.go`), **sensitivity-fence `INV-6/7`** (`lua/host.go` — flagged on epic .14)
- **bare `A16`** prose shorthand (`\bA16\b` would corrupt the `A16` inside `INV-A16`; A16 is the amendment's human label, `INV-ACCESS-8` its canonical id)

## Verification
- `inv-migrate` applied (PLUGIN 18 + ACCESS 4 files), **idempotent**; leftover bare `INV-N` confined to `shared_files` only (residual-walk-skipped); all OWNED files clean.
- Provenance guard + partition + binding + full `./test/meta/` green; touched unit packages (2706 tests) + integration-compile green; `task lint` / `fmt:check` / `license:check` / `build` green.
- **abac-reviewer: READY** (no ABAC behavior change, default-deny integrity preserved, faithful rename). **code-reviewer: READY** (zero `.go` executable changes, tri-overload disambiguation verified, dense numbering, no foreign collateral).

> **Local pr-prep note:** the fast-lane `generate:ebnf:check` bats self-test could not run offline (fetches `railroad@latest`; `dial tcp: bad file descriptor`). This PR touches **zero** DSL/EBNF/railroad files; CI (with network) validates it.

After this, epic `.14` remaining: `.14.16/.18/.20/.21` (meta-test/guard hardening) and `.14.17` (final verification — must first classify the flagged INV-F*, master-fence INV-6/7, and INV-S* families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)