### PR TITLE
refactor(invariants): migrate INV-F (sub-epic-F AdminReadStream) → INV-CRYPTO (holomush-hz0v4.14.23)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -1,5 +1,3 @@
-  Encountered: holomush-hz0v4.14.5 (2026-06-01) — READY.
-
 - **Per-family coverage meta-test MUST be DELETED on registry migration — not
   optional (hz0v4.14.9 NOT-READY).** When a scope migrates I-<OLD>-N →
   INV-<SCOPE>-N, the legacy `test/meta/i_<old>_coverage_test.go` greps for
@@ -171,3 +169,32 @@
   (7) This diff CLEANED a pre-existing `,}` (INV-RA-6 line 1657) but ADDED a new one
   (INV-A16 line 1682) — 5th recurrence, Low non-blocking, renderer-inert. PLUGIN dense
   1..28, ACCESS dense 1..8. Encountered: hz0v4.14.22 (2026-06-03) — READY.
+
+- **First NOT-READY in the .14.x classification series: registry guards are
+  BLIND to unregistered files, so a green meta-test run does NOT prove a family
+  migration is complete (hz0v4.14.23 INV-F NOT READY).** Two defects survived a
+  fully-green run (lint:invariants, provenance, partition, binding, 617 unit tests,
+  int-compile): (A) **51 residual bare `INV-F*` token refs** (INV-F1/2/3/6/9/10/11/
+  12/14/15/17) in THREE cmd/holomush files NOT in the diff: admin_read_stream_e2e_test.go
+  (45), readstream_wiring_test.go (4), admin_authenticate_e2e_test.go (2). These are
+  the SAME family the bead migrates, but the files are neither owned_paths nor
+  shared_files nor in any registry `refs[]`, so the residual walk + provenance guard
+  never look at them → green despite incomplete migration. 4 of those are STALE
+  cross-file func-name cites (`TestINV_F2/F6/F3/F17_...` at lines 1124/1159/1245/2137)
+  pointing at funcs THIS diff RENAMED to TestINV_CRYPTO_54/56/55/67 — now dangling.
+  (B) **Range-rewrite corruption**: phase7_boundary_meta_test.go:25 prose
+  `INV-P7-1..16` → `INV-CRYPTO-38..16` (tool rewrote left side of a `..N` range,
+  left suffix). `INV-P7-1` is a P7 token (handled in .14.15), OUT OF SCOPE for the
+  F pass — tool should not have touched it. Substring `INV-CRYPTO-38` keeps
+  provenance green (real anchor is the table row at line 54), so CI is blind.
+  Redesign spec (2026-06-01-...-redesign.md:42) DOCUMENTS this exact class:
+  "INV-CRYPTO-1..5 — nonsensical as crypto. Every CI gate passed." Same bug the
+  crypto-reviewer caught on F-compound-refs (INV-CRYPTO-56/F7), recurred on a
+  `..N` range. **Review pattern for family migrations: do NOT trust green guards
+  as proof of completeness. ALWAYS run `rg -c '\bINV-<OLD>[0-9]' --glob '!docs/**'`
+  over the WHOLE tree (not just diffed files) — residual hits in unregistered files
+  = incomplete migration. Also `rg 'INV-<SCOPE>-[0-9]+\.\.[0-9]+'` for range
+  corruption, and `rg 'TestINV_<OLD>[0-9]'` for dangling renamed-func cites.**
+  Mechanical search-replace correct part: 35 diffed files all comment/string/test-func
+  swaps, dense 53..67, no executable edits, generated artifacts in sync. The DEFECT
+  is what was MISSED, not what was changed. Encountered: hz0v4.14.23 (2026-06-03) — NOT READY.

--- a/api/proto/holomush/admin/v1/admin.proto
+++ b/api/proto/holomush/admin/v1/admin.proto
@@ -100,7 +100,7 @@ service AdminService {
   // typed metadata_only and no_plaintext_reason redaction fields for
   // destroyed-DEK and plaintext-suppressed events. When dual_control is set
   // in the request, the handler blocks until a second operator approves via
-  // the admin_approvals table before emitting any event frames (INV-F11/F17).
+  // the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
   // Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
   rpc AdminReadStream(AdminReadStreamRequest) returns (stream AdminReadStreamResponse);
 }

--- a/api/proto/holomush/admin/v1/read_stream.proto
+++ b/api/proto/holomush/admin/v1/read_stream.proto
@@ -23,7 +23,7 @@ message AdminReadStreamRequest {
   // session_token is the bearer token identifying the operator. The handler
   // resolves it to an OperatorSession via SessionStore.GetOperatorSession and
   // then checks that the resolved player holds the crypto.operator ABAC grant
-  // (INV-F3) before any data read or audit publish occurs.
+  // (INV-CRYPTO-55) before any data read or audit publish occurs.
   string session_token = 1;
   // subject_pattern is an optional additional NATS subject filter applied
   // server-side on top of the context-derived subjects. An empty string means
@@ -40,11 +40,11 @@ message AdminReadStreamRequest {
   // ResolveBounds validates type, arity, and ID format per sensitiveTypes.
   repeated ContextRef context = 4;
   // since is the inclusive lower bound of the query window. When absent (nil),
-  // the server defaults to now minus the configured DefaultWindow (INV-F6).
+  // the server defaults to now minus the configured DefaultWindow (INV-CRYPTO-56).
   // ResolveBounds rejects since >= until with DENY_OPERATOR_READ_TIME_INVERTED.
   google.protobuf.Timestamp since = 5;
   // until is the exclusive upper bound of the query window. When absent (nil),
-  // the server defaults to now (INV-F6). ResolveBounds rejects until more than
+  // the server defaults to now (INV-CRYPTO-56). ResolveBounds rejects until more than
   // 5 seconds in the future with DENY_OPERATOR_READ_FUTURE_BOUND.
   google.protobuf.Timestamp until = 6;
   // limit caps the maximum number of EventFrame responses the client wants to
@@ -54,7 +54,7 @@ message AdminReadStreamRequest {
   // dual_control requires a second operator to approve the request before the
   // stream begins. When true, the server sends a PendingApproval frame and
   // blocks until approval.Repo.WaitForApproval resolves or the ApprovalTTL
-  // elapses (INV-F11/F17). When false, the fast single-control path runs
+  // elapses (INV-CRYPTO-61/INV-CRYPTO-67). When false, the fast single-control path runs
   // immediately after the capability check.
   bool dual_control = 8;
   // dual_control_timeout_seconds overrides the server's configured ApprovalTTL
@@ -63,7 +63,7 @@ message AdminReadStreamRequest {
   // justification is the operator's plain-text reason for the read. REQUIRED:
   // ResolveBounds rejects empty or whitespace-only values with
   // DENY_OPERATOR_READ_JUSTIFICATION_EMPTY. Maximum 4096 UTF-8 bytes.
-  // Captured verbatim in the pre-data audit payload (INV-F1/F7).
+  // Captured verbatim in the pre-data audit payload (INV-CRYPTO-53/INV-CRYPTO-57).
   string justification = 10;
 }
 
@@ -96,8 +96,8 @@ message ContextRef {
 // zero or more EventFrame frames, and exactly one ReadFinished frame as the
 // terminal message. The handler (internal/admin/readstream/handler.go
 // handleInternal) enforces the audit invariants: the pre-data audit is emitted
-// before the first frame (INV-F1/F2) and the post-data audit is emitted after
-// the final frame (INV-F10).
+// before the first frame (INV-CRYPTO-53/INV-CRYPTO-54) and the post-data audit is emitted after
+// the final frame (INV-CRYPTO-60).
 message AdminReadStreamResponse {
   // payload carries the frame for this response message. Exactly one variant
   // is set per AdminReadStreamResponse.
@@ -212,19 +212,19 @@ message ReadFinished {
     TERMINATED_BY_CLIENT_DISCONNECT = 2;
     // TERMINATED_BY_DEADLINE_EXCEEDED indicates either the request context
     // deadline was exceeded (context.DeadlineExceeded) or a per-frame write
-    // deadline fired (ErrWriteDeadlineExceeded, INV-F14) during streaming.
+    // deadline fired (ErrWriteDeadlineExceeded, INV-CRYPTO-64) during streaming.
     TERMINATED_BY_DEADLINE_EXCEEDED = 3;
     // TERMINATED_BY_SERVER_ERROR indicates an unexpected server-side failure
     // (cold-reader error, codec failure, or other unclassified error). Mapped
     // by the classifyTerminator catch-all branch.
     TERMINATED_BY_SERVER_ERROR = 4;
     // TERMINATED_BY_DUAL_CONTROL_TIMEOUT indicates the ApprovalTTL elapsed
-    // before a second operator approved the request (INV-F11/F17). Mapped
+    // before a second operator approved the request (INV-CRYPTO-61/INV-CRYPTO-67). Mapped
     // from READSTREAM_DUAL_CONTROL_TIMEOUT oops code.
     TERMINATED_BY_DUAL_CONTROL_TIMEOUT = 5;
     // TERMINATED_BY_AUDIT_EMIT_FAILURE indicates the pre-data audit publish
     // (EmitStart) failed before any event data was read or sent. Mapped from
-    // DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-F2). No event data was
+    // DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-CRYPTO-54). No event data was
     // delivered when this value appears.
     TERMINATED_BY_AUDIT_EMIT_FAILURE = 6;
   }

--- a/api/proto/holomush/core/v1/core.proto
+++ b/api/proto/holomush/core/v1/core.proto
@@ -335,7 +335,7 @@ enum NoPlaintextReason {
 
   // NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref
   // (DEK reference column missing or NULL). Stamped exclusively by sub-epic F's
-  // operator-read classifier (INV-F16).
+  // operator-read classifier (INV-CRYPTO-66).
   NO_PLAINTEXT_REASON_DEK_MISSING = 4;
 
   // NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS means a cold-tier audit row references a

--- a/cmd/holomush/admin_authenticate_e2e_test.go
+++ b/cmd/holomush/admin_authenticate_e2e_test.go
@@ -742,8 +742,8 @@ var _ = Describe("Admin Authenticate Lifecycle (full-stack E2E)", func() {
 		//   - F-E1:  happy path single context
 		//   - F-E2:  whole-game wildcard with defaulted bounds
 		//   - F-E13: multi-context k-way merge (global timestamp order)
-		//   - F-E14: sensitive-content filter (INV-F15)
-		//   - F-E17: classifier surface (INV-F12 producers)
+		//   - F-E14: sensitive-content filter (INV-CRYPTO-65)
+		//   - F-E17: classifier surface (INV-CRYPTO-62 producers)
 		// =========================================================================
 		runAdminReadStreamScenarios(env)
 	})

--- a/cmd/holomush/admin_read_stream_e2e_test.go
+++ b/cmd/holomush/admin_read_stream_e2e_test.go
@@ -45,7 +45,7 @@ package main
 // which the classifier maps to STALE_DEK (not DEKMissing / DEKBadColumns).
 // F-E17 therefore exercises the realistic STALE_DEK path: 5 rows whose
 // dek_ref points to nonexistent crypto_keys IDs (orphans). All 5 frames
-// arrive metadata-only with NoPlaintextReason=STALE_DEK. INV-F12's
+// arrive metadata-only with NoPlaintextReason=STALE_DEK. INV-CRYPTO-62's
 // "metadata-only on missing DEK" contract is enforced; the specific reason
 // enum is whichever the production classifier emits.
 //
@@ -60,7 +60,7 @@ package main
 // Note on F-E4 approach: the live server's handler was constructed at boot
 // with the production emitter. R.18 constructs an in-process handler
 // directly (not through the live UDS) so it can inject a failing emitter.
-// This is consistent with how handler_test.go exercises INV-F2 at the unit
+// This is consistent with how handler_test.go exercises INV-CRYPTO-54 at the unit
 // level.
 //
 // R.19 lifecycle scenarios:
@@ -100,7 +100,7 @@ package main
 //     PendingApproval frames, both invocations' audit payloads share
 //     the SAME approval_id. Two-requester setup required because
 //     GetByOpArgsHash excludes the requester's own primary_player_id
-//     per R.2's INV-F17 contract — carol cannot reuse her own row.
+//     per R.2's INV-CRYPTO-67 contract — carol cannot reuse her own row.
 
 import (
 	"context"
@@ -181,7 +181,7 @@ type adminReadStreamView struct {
 func (v *adminReadStreamView) EventCount() int { return len(v.events) }
 
 // DecryptFailCount returns the number of metadata-only frames received.
-// Mirrors the server-side decrypt_fail_count counter for INV-F12.
+// Mirrors the server-side decrypt_fail_count counter for INV-CRYPTO-62.
 func (v *adminReadStreamView) DecryptFailCount() int {
 	var n int
 	for _, e := range v.events {
@@ -505,7 +505,7 @@ func (e *adminAuthEnv) seedAdminReadStreamData(
 // seedPlainAuditRow inserts a single identity-codec (cleartext) row into
 // events_audit. dek_ref is NULL — the row MUST NOT be returned by the
 // cold-tier filter (R.10's WHERE dek_ref IS NOT NULL clause excludes it).
-// Used by F-E14 to assert the sensitive-content filter (INV-F15).
+// Used by F-E14 to assert the sensitive-content filter (INV-CRYPTO-65).
 func (e *adminAuthEnv) seedPlainAuditRow(subject string, ts time.Time) ulid.ULID {
 	ctx, cancel := context.WithTimeout(e.ctx, 5*time.Second)
 	defer cancel()
@@ -537,7 +537,7 @@ func (e *adminAuthEnv) seedPlainAuditRow(subject string, ts time.Time) ulid.ULID
 // a nonexistent crypto_keys row. The envelope payload is a random byte
 // string (cannot be decrypted; DEK lookup fails first anyway). DecryptRow's
 // DEK-resolve step returns DEK_NOT_FOUND, which classifyDecryptErr maps to
-// NoPlaintextReason_STALE_DEK (INV-F12 branch 3/4).
+// NoPlaintextReason_STALE_DEK (INV-CRYPTO-62 branch 3/4).
 //
 // orphanDEKRef is the synthetic dek_ref value (caller-chosen, MUST be
 // unused; e.g., 0x7FFF_FFFF_FFFF_FFF0 + offset).
@@ -782,10 +782,10 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E13: multi-context — 20 events in global timestamp order")
 	scenarioFE13MultiContext(env)
 
-	By("F-E14: sensitive-content filter — 5 encrypted received, 3 plain filtered (INV-F15)")
+	By("F-E14: sensitive-content filter — 5 encrypted received, 3 plain filtered (INV-CRYPTO-65)")
 	scenarioFE14SensitiveFilter(env)
 
-	By("F-E17: classifier surface — 5 metadata-only frames with STALE_DEK reason (INV-F12 producers)")
+	By("F-E17: classifier surface — 5 metadata-only frames with STALE_DEK reason (INV-CRYPTO-62 producers)")
 	scenarioFE17ClassifierSurface(env)
 
 	// R.18 validation / denial scenarios.
@@ -793,7 +793,7 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E4 (INV-42): audit-emit failure → DENY_AUDIT_PRE_DATA_PUBLISH, zero data frames")
 	scenarioFE4AuditEmitFailure(env)
 
-	By("F-E8 (INV-F6): window > MaxWindow → DENY_OPERATOR_READ_WINDOW_TOO_LARGE, zero audit rows")
+	By("F-E8 (INV-CRYPTO-56): window > MaxWindow → DENY_OPERATOR_READ_WINDOW_TOO_LARGE, zero audit rows")
 	scenarioFE8WindowTooLarge(env)
 
 	By("F-E9a: whitespace-only justification → DENY_OPERATOR_READ_JUSTIFICATION_EMPTY, zero audit rows")
@@ -802,7 +802,7 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E9b: 4097-byte justification → DENY_OPERATOR_READ_JUSTIFICATION_TOO_LONG, zero audit rows")
 	scenarioFE9bJustificationTooLong(env)
 
-	By("F-E11 (INV-F3): missing crypto.operator capability → DENY_OPERATOR_CAPABILITY, zero audit rows")
+	By("F-E11 (INV-CRYPTO-55): missing crypto.operator capability → DENY_OPERATOR_CAPABILITY, zero audit rows")
 	scenarioFE11MissingCapability(env)
 
 	By("F-E15a: dm with 1 id → DENY_OPERATOR_READ_ARITY_MISMATCH")
@@ -816,7 +816,7 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E3: mixed decrypt — 80 plaintext + 20 STALE_DEK metadata-only frames after DEK destroy")
 	scenarioFE3MixedDecrypt(env)
 
-	By("F-E5 (INV-F11): dual-control happy — carol initiates, MarkApproved by playerD, stream resumes")
+	By("F-E5 (INV-CRYPTO-61): dual-control happy — carol initiates, MarkApproved by playerD, stream resumes")
 	scenarioFE5DualControlHappy(env)
 
 	By("F-E6: dual-control timeout — no approver; TerminatedBy=DUAL_CONTROL_TIMEOUT; zero audit rows")
@@ -825,16 +825,16 @@ func runAdminReadStreamScenarios(env *adminAuthEnv) {
 	By("F-E7: client disconnect — context cancel mid-stream; TerminatedBy=CLIENT_DISCONNECT")
 	scenarioFE7ClientDisconnect(env)
 
-	By("F-E10 (INV-F14): per-frame write deadline — slow sender trips ErrWriteDeadlineExceeded → DEADLINE_EXCEEDED")
+	By("F-E10 (INV-CRYPTO-64): per-frame write deadline — slow sender trips ErrWriteDeadlineExceeded → DEADLINE_EXCEEDED")
 	scenarioFE10WriteDeadline(env)
 
 	// quarantined: holomush-7b9n — F-E12 audit-row projection flakes under load; skip only this step in gating runs (runs nightly).
 	if quarantinetest.Enabled() {
-		By("F-E12 (INV-F9): chain verification — VerifyScope on a happy-path request_id succeeds")
+		By("F-E12 (INV-CRYPTO-59): chain verification — VerifyScope on a happy-path request_id succeeds")
 		scenarioFE12ChainVerification(env)
 	}
 
-	By("F-E16 (INV-F11): idempotent dual-control reuse — second invocation by different requester finds approved row, no PendingApproval")
+	By("F-E16 (INV-CRYPTO-61): idempotent dual-control reuse — second invocation by different requester finds approved row, no PendingApproval")
 	scenarioFE16IdempotentDualControlReuse(env)
 }
 
@@ -876,11 +876,11 @@ func scenarioFE1HappyPath(env *adminAuthEnv) {
 	Eventually(func() int {
 		return env.operatorReadAuditCount("crypto.system.operator_read", requestID)
 	}, "10s", "200ms").Should(Equal(1),
-		"F-E1: exactly one crypto.system.operator_read audit row (INV-F1)")
+		"F-E1: exactly one crypto.system.operator_read audit row (INV-CRYPTO-53)")
 	Eventually(func() int {
 		return env.operatorReadAuditCount("crypto.system.operator_read_completed", requestID)
 	}, "10s", "200ms").Should(Equal(1),
-		"F-E1: exactly one crypto.system.operator_read_completed audit row (INV-F10)")
+		"F-E1: exactly one crypto.system.operator_read_completed audit row (INV-CRYPTO-60)")
 }
 
 // ---- F-E2 ----
@@ -971,7 +971,7 @@ func scenarioFE14SensitiveFilter(env *adminAuthEnv) {
 	Expect(seededIDs).To(HaveLen(encryptedCount), "F-E14 encrypted seed count")
 
 	// Plain rows under the SAME subject pattern — these MUST be filtered by
-	// R.10's `dek_ref IS NOT NULL` clause (INV-F15).
+	// R.10's `dek_ref IS NOT NULL` clause (INV-CRYPTO-65).
 	plainSubject := env.readstreamSubjectForContext("scene", sceneID, "test.cleartext")
 	plainTimestamps := make([]time.Time, plainCount)
 	plainIDs := make([]ulid.ULID, plainCount)
@@ -993,7 +993,7 @@ func scenarioFE14SensitiveFilter(env *adminAuthEnv) {
 	Expect(view.TerminatedBy()).To(Equal(adminv1.ReadFinished_TERMINATED_BY_CLIENT_EOF),
 		"F-E14: clean-EOF terminator")
 	Expect(view.EventCount()).To(Equal(encryptedCount),
-		"F-E14: exactly 5 encrypted events (plain rows MUST be filtered, INV-F15)")
+		"F-E14: exactly 5 encrypted events (plain rows MUST be filtered, INV-CRYPTO-65)")
 	Expect(view.DecryptFailCount()).To(Equal(0),
 		"F-E14: no decrypt failures expected")
 	Expect(view.finished.GetEventsScanned()).To(Equal(int64(encryptedCount)),
@@ -1007,7 +1007,7 @@ func scenarioFE14SensitiveFilter(env *adminAuthEnv) {
 	for _, ev := range view.events {
 		_, leaked := plainIDSet[ev.GetId()]
 		Expect(leaked).To(BeFalse(),
-			"F-E14: plain (identity-codec) row %s MUST NEVER appear (INV-F15)", ev.GetId())
+			"F-E14: plain (identity-codec) row %s MUST NEVER appear (INV-CRYPTO-65)", ev.GetId())
 	}
 }
 
@@ -1020,7 +1020,7 @@ func scenarioFE17ClassifierSurface(env *adminAuthEnv) {
 
 	// Seed 5 rows whose dek_ref points to nonexistent crypto_keys IDs.
 	// dek.Manager.Resolve returns DEK_NOT_FOUND for each — classifyDecryptErr
-	// maps that to STALE_DEK (INV-F12 branch 3/4). The brief's originally-
+	// maps that to STALE_DEK (INV-CRYPTO-62 branch 3/4). The brief's originally-
 	// planned DEK_MISSING / DEK_BAD_COLUMNS shape is unreachable in r8
 	// (see file header for rationale).
 	baseTime := time.Now().UTC().Add(-45 * time.Second)
@@ -1054,7 +1054,7 @@ func scenarioFE17ClassifierSurface(env *adminAuthEnv) {
 
 	// Plaintext MUST NEVER leak — metadata-only payloads are empty.
 	Expect(view.PayloadsAllEmpty()).To(BeTrue(),
-		"F-E17: metadata-only frames MUST carry empty Payload (no plaintext leak, INV-F12)")
+		"F-E17: metadata-only frames MUST carry empty Payload (no plaintext leak, INV-CRYPTO-62)")
 
 	// Classifier verdict: every row's reason is STALE_DEK in r8.
 	// (See file header note — DEK_MISSING / DEK_BAD_COLUMNS branches are
@@ -1064,7 +1064,7 @@ func scenarioFE17ClassifierSurface(env *adminAuthEnv) {
 		"F-E17: one reason per metadata-only frame")
 	for i, r := range reasons {
 		Expect(r).To(Equal(corev1.NoPlaintextReason_NO_PLAINTEXT_REASON_STALE_DEK),
-			"F-E17: row %d must classify as STALE_DEK (orphan dek_ref → DEK_NOT_FOUND → STALE_DEK per INV-F12)", i)
+			"F-E17: row %d must classify as STALE_DEK (orphan dek_ref → DEK_NOT_FOUND → STALE_DEK per INV-CRYPTO-62)", i)
 	}
 
 	// The dek_ref classifier branches DEK_MISSING and DEK_BAD_COLUMNS are
@@ -1088,7 +1088,7 @@ func scenarioFE17ClassifierSurface(env *adminAuthEnv) {
 
 // scenarioFE4AuditEmitFailure asserts that when EmitStart fails, the handler
 // returns DENY_AUDIT_PRE_DATA_PUBLISH and emits ZERO data frames (INV-42 /
-// INV-F2). Because the live server's handler was constructed at boot with
+// INV-CRYPTO-54). Because the live server's handler was constructed at boot with
 // the production emitter, this scenario constructs an in-process handler
 // (via buildInProcessReadStreamClient) with a failing audit emitter injected.
 //
@@ -1120,12 +1120,12 @@ func scenarioFE4AuditEmitFailure(env *adminAuthEnv) {
 	Expect(streamErr).To(HaveOccurred(), "F-E4: stream.Err() must be non-nil when EmitStart fails")
 	// ConnectRPC deviation (documented in file header): oops codes are NOT
 	// transmitted over the wire — only CodeUnknown + the Errorf message text.
-	// The substantive invariant is zero data frames (INV-42 / INV-F2), asserted
-	// below. Oops code coverage lives in handler_test.go::TestINV_F2_AuditPublishFailRefuses.
+	// The substantive invariant is zero data frames (INV-42 / INV-CRYPTO-54), asserted
+	// below. Oops code coverage lives in handler_test.go::TestINV_CRYPTO_54_AuditPublishFailRefuses.
 	Expect(streamErr.Error()).To(ContainSubstring("audit emit failed"),
 		"F-E4: error message MUST contain the audit-emit-failure text")
 
-	// ZERO data frames: no EventFrame, no ReadStarted (INV-42 / INV-F2).
+	// ZERO data frames: no EventFrame, no ReadStarted (INV-42 / INV-CRYPTO-54).
 	for _, f := range frames {
 		Expect(f.GetEvent()).To(BeNil(),
 			"F-E4: ZERO EventFrame frames MUST arrive when EmitStart fails (INV-42)")
@@ -1134,10 +1134,10 @@ func scenarioFE4AuditEmitFailure(env *adminAuthEnv) {
 	}
 }
 
-// ---- F-E8 (INV-F6) ----
+// ---- F-E8 (INV-CRYPTO-56) ----
 
 // scenarioFE8WindowTooLarge asserts that requesting a window > MaxWindow (30d)
-// returns DENY_OPERATOR_READ_WINDOW_TOO_LARGE. Per INV-F3 ordering the
+// returns DENY_OPERATOR_READ_WINDOW_TOO_LARGE. Per INV-CRYPTO-55 ordering the
 // rejection fires BEFORE EmitStart, so zero audit rows should exist for
 // a request_id that never got one. We assert no new audit rows of any
 // operator_read type appear for a fresh pseudo-requestID probe.
@@ -1156,11 +1156,11 @@ func scenarioFE8WindowTooLarge(env *adminAuthEnv) {
 	Expect(streamErr).To(HaveOccurred(), "F-E8: stream must error when window exceeds MaxWindow")
 	// ConnectRPC deviation: oops code DENY_OPERATOR_READ_WINDOW_TOO_LARGE is NOT
 	// transmitted over the wire. Assert on the Errorf message text instead.
-	// Oops code coverage lives in filter_test.go::TestINV_F6_WindowTooLargeRejected.
+	// Oops code coverage lives in filter_test.go::TestINV_CRYPTO_56_WindowTooLargeRejected.
 	Expect(streamErr.Error()).To(ContainSubstring("exceeds maximum"),
 		"F-E8: error message MUST contain the window-too-large text")
 
-	// INV-F3: rejection precedes pre-data audit — zero operator_read audit rows.
+	// INV-CRYPTO-55: rejection precedes pre-data audit — zero operator_read audit rows.
 	// Because we have no request_id (rejection fired before EmitStart stamped one),
 	// we assert the total count of new operator_read rows is zero at this instant.
 	// We don't assert a specific request_id because there isn't one.
@@ -1207,10 +1207,10 @@ func scenarioFE9bJustificationTooLong(env *adminAuthEnv) {
 		"F-E9b: error message MUST reference justification validation failure")
 }
 
-// ---- F-E11 (INV-F3) ----
+// ---- F-E11 (INV-CRYPTO-55) ----
 
 // scenarioFE11MissingCapability asserts that a player without crypto.operator
-// receives DENY_OPERATOR_CAPABILITY. Per INV-F3, the capability check runs
+// receives DENY_OPERATOR_CAPABILITY. Per INV-CRYPTO-55, the capability check runs
 // BEFORE EmitStart — zero audit rows may be created for this request.
 //
 // Because PlayerAttributeProvider is read-only post-construction (INV-B6),
@@ -1242,19 +1242,19 @@ func scenarioFE11MissingCapability(env *adminAuthEnv) {
 	Expect(streamErr).To(HaveOccurred(), "F-E11: stream must error when crypto.operator is absent")
 	// ConnectRPC deviation: oops code DENY_OPERATOR_CAPABILITY not transmitted.
 	// Assert Errorf text instead. Oops code coverage in
-	// handler_test.go::TestINV_F3_CapabilityCheckPrecedesAudit.
+	// handler_test.go::TestINV_CRYPTO_55_CapabilityCheckPrecedesAudit.
 	Expect(streamErr.Error()).To(ContainSubstring("crypto.operator"),
 		"F-E11: error message MUST reference the missing crypto.operator capability")
 
-	// INV-F3: capability check precedes EmitStart — ZERO data frames.
+	// INV-CRYPTO-55: capability check precedes EmitStart — ZERO data frames.
 	for _, f := range frames {
 		Expect(f.GetEvent()).To(BeNil(),
-			"F-E11: ZERO EventFrame frames MUST arrive when capability is denied (INV-F3)")
+			"F-E11: ZERO EventFrame frames MUST arrive when capability is denied (INV-CRYPTO-55)")
 		Expect(f.GetStarted()).To(BeNil(),
 			"F-E11: ReadStarted MUST NOT be sent when capability is denied")
 	}
 
-	// INV-F3: EmitStart MUST NOT have been called, so zero operator_read rows.
+	// INV-CRYPTO-55: EmitStart MUST NOT have been called, so zero operator_read rows.
 	// Use the live env's queryPool — the in-process handler uses the same pool.
 	// A unique marker in the justification would let us filter by payload, but
 	// since the audit emitter is failingAuditEmitter (never succeeds even if
@@ -1510,7 +1510,7 @@ func (s *slowStreamSender) Send(resp *adminv1.AdminReadStreamResponse) error {
 //   - Every metadata-only frame has empty Payload (no plaintext leak).
 //
 // The classifier maps DEK_NOT_FOUND (returned by Resolve on a destroyed
-// key) → STALE_DEK per INV-F12 branch 3/4 (decrypt.go::classifyDecryptErr).
+// key) → STALE_DEK per INV-CRYPTO-62 branch 3/4 (decrypt.go::classifyDecryptErr).
 func scenarioFE3MixedDecrypt(env *adminAuthEnv) {
 	const plaintextCount = 80
 	const destroyedCount = 20
@@ -1555,7 +1555,7 @@ func scenarioFE3MixedDecrypt(env *adminAuthEnv) {
 	Expect(view.finished.GetDecryptFailCount()).To(Equal(int64(destroyedCount)),
 		"F-E3: finished.decrypt_fail_count = 20")
 
-	// Plaintext MUST NEVER leak on metadata-only frames (INV-F12 contract).
+	// Plaintext MUST NEVER leak on metadata-only frames (INV-CRYPTO-62 contract).
 	Expect(view.PayloadsAllEmpty()).To(BeTrue(),
 		"F-E3: every metadata-only frame MUST have empty Payload")
 
@@ -1659,7 +1659,7 @@ func scenarioFE5DualControlHappy(env *adminAuthEnv) {
 	pl := env.operatorReadStartPayloadFor(requestID)
 	Expect(pl.ApproverPlayerID).NotTo(BeNil())
 	Expect(pl.ApproverPlayerID.String()).To(Equal(env.playerD.String()),
-		"F-E5: audit approver_player_id MUST equal playerD (not carol — INV-F11 no self-approve)")
+		"F-E5: audit approver_player_id MUST equal playerD (not carol — INV-CRYPTO-61 no self-approve)")
 	Expect(pl.ApprovalID).NotTo(BeNil(),
 		"F-E5: audit approval_id MUST be set")
 	Expect(*pl.ApprovalID).To(Equal(ulid.ULID(approvalRID)),
@@ -1886,12 +1886,12 @@ func pendingApprovalCount(env *adminAuthEnv, primaryPlayer ulid.ULID, opKind str
 // context.Canceled (deadline_writer.go:54), which classifyTerminator
 // maps to CLIENT_DISCONNECT inside the handler.
 //
-// PRODUCTION CAVEAT (INV-F10): EmitCompleted uses the same ctx as the
+// PRODUCTION CAVEAT (INV-CRYPTO-60): EmitCompleted uses the same ctx as the
 // request — once that ctx is cancelled, the chain emitter's SQL load
 // fails with AUDIT_CHAIN_LOAD_FAILED + context.Canceled. The handler
 // logs WARN and continues (handler.go:297). The completed audit row
 // MAY therefore be absent for CLIENT_DISCONNECT. This is acceptable
-// per INV-F10 ("completion audit failure does NOT raise"); the start
+// per INV-CRYPTO-60 ("completion audit failure does NOT raise"); the start
 // row is the durable record. Asserting the completed row's
 // terminated_by here would be racy: it depends on whether the cancel
 // arrived before or after the audit emitter's first DB roundtrip.
@@ -1946,7 +1946,7 @@ func scenarioFE7ClientDisconnect(env *adminAuthEnv) {
 //   - Driving the production handler with a custom StreamSenderForTest
 //     gives us deterministic per-frame timing. SendWithDeadline runs
 //     inside the same handler that the UDS exercises, so this still
-//     covers the INV-F14 production path.
+//     covers the INV-CRYPTO-64 production path.
 //
 // Sanity case follow-up: with WriteDeadline=500ms and sleep=10ms, the
 // scan completes cleanly (CLIENT_EOF, all events delivered).
@@ -2085,7 +2085,7 @@ func (nopEventbusPublisherForTest) Publish(_ context.Context, _ eventbus.Event) 
 // then verifies the resulting chain on disk via chain.NewVerifier +
 // VerifyScope. The chain MUST link: start payload (prev_hash=nil at
 // genesis OR prev_hash=previous chain entry) → completed payload
-// (prev_hash=start's self_hash). INV-F9.
+// (prev_hash=start's self_hash). INV-CRYPTO-59.
 //
 // VerifyScope walks the chain for the given scope (request_id) and
 // recomputes each entry's self_hash from the canonical-form payload,
@@ -2125,7 +2125,7 @@ func scenarioFE12ChainVerification(env *adminAuthEnv) {
 	handler := readstream.OperatorReadHandlerFor(env.gameID)
 	verifyErr := verifier.VerifyScope(env.ctx, handler, requestID)
 	Expect(verifyErr).NotTo(HaveOccurred(),
-		"F-E12: chain.VerifyScope MUST succeed (INV-F9): start.self_hash → completed.prev_hash linkage holds")
+		"F-E12: chain.VerifyScope MUST succeed (INV-CRYPTO-59): start.self_hash → completed.prev_hash linkage holds")
 }
 
 // ---- F-E16 (idempotent dual-control reuse) ----
@@ -2134,7 +2134,7 @@ func scenarioFE12ChainVerification(env *adminAuthEnv) {
 // path. Carol opens an approval (request 1); we MarkApproved it with
 // playerD. Then a SECOND requester invokes AdminReadStream with
 // IDENTICAL args + DualControl=true. GetByOpArgsHash filters out the
-// requester's own author (INV-F17 per R.2's TestINV_F17_GetByOpArgsHashFiltersOwnAuthor),
+// requester's own author (INV-CRYPTO-67 per R.2's TestINV_CRYPTO_67_GetByOpArgsHashFiltersOwnAuthor),
 // so the second invocation MUST be made by a DIFFERENT requester from
 // the original. We use playerA (alice) — even though alice is locked
 // out for Authenticate, the in-process handler bypasses session-store
@@ -2161,7 +2161,7 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 	contexts := []*adminv1.ContextRef{
 		{Type: "scene", Ids: []string{sceneID}},
 	}
-	// INV-F11 idempotent reuse requires that invocation 2's opArgsHash equal
+	// INV-CRYPTO-61 idempotent reuse requires that invocation 2's opArgsHash equal
 	// invocation 1's. ResolveBounds defaults missing Since/Until from
 	// time.Now() at the resolve site, so two invocations submitted seconds
 	// apart resolve to DIFFERENT bounds → different hashes → reuse miss →
@@ -2273,7 +2273,7 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 	// Practical check: invocation 1's audit start payload's approval_id
 	// MUST equal approval1RID. That single check, combined with "invocation
 	// 2 emitted zero PendingApproval and Open was therefore never called",
-	// proves the reuse contract (INV-F11 idempotent reuse) at E2E level.
+	// proves the reuse contract (INV-CRYPTO-61 idempotent reuse) at E2E level.
 	Eventually(func() *ulid.ULID {
 		pl := env.operatorReadStartPayloadFor(requestID1)
 		return pl.ApprovalID
@@ -2295,7 +2295,7 @@ func scenarioFE16IdempotentDualControlReuse(env *adminAuthEnv) {
 // envSessionStoreFE16Adapter wraps the base envSessionStoreAdapter with
 // an extra (token, playerID) pair. F-E16 uses this to add a synthetic
 // alice token so the second invocation can run under a DIFFERENT
-// requester than carol (INV-F17 requires the requester to differ from
+// requester than carol (INV-CRYPTO-67 requires the requester to differ from
 // the approval row's primary_player_id for GetByOpArgsHash to find the
 // row).
 type envSessionStoreFE16Adapter struct {

--- a/cmd/holomush/readstream_wiring_test.go
+++ b/cmd/holomush/readstream_wiring_test.go
@@ -71,13 +71,13 @@ func TestCryptoConfigDefaultsPopulatesOperatorReadFields(t *testing.T) {
 	cfg := config.CryptoConfig{}.Defaults()
 
 	assert.Equal(t, 1*time.Hour, cfg.OperatorReadDefaultWindow,
-		"OperatorReadDefaultWindow MUST default to 1h (INV-F6)")
+		"OperatorReadDefaultWindow MUST default to 1h (INV-CRYPTO-56)")
 	assert.Equal(t, 30*24*time.Hour, cfg.OperatorReadMaxWindow,
-		"OperatorReadMaxWindow MUST default to 30d (INV-F6)")
+		"OperatorReadMaxWindow MUST default to 30d (INV-CRYPTO-56)")
 	assert.Equal(t, 30*time.Second, cfg.OperatorReadWriteDeadline,
-		"OperatorReadWriteDeadline MUST default to 30s (INV-F14)")
+		"OperatorReadWriteDeadline MUST default to 30s (INV-CRYPTO-64)")
 	assert.Equal(t, 5*time.Minute, cfg.OperatorReadApprovalTTL,
-		"OperatorReadApprovalTTL MUST default to 5m (INV-F11)")
+		"OperatorReadApprovalTTL MUST default to 5m (INV-CRYPTO-61)")
 }
 
 // TestCryptoConfigDefaultsPreservesExplicitOperatorReadFields verifies that

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -101,6 +101,21 @@ invariants.
 | `INV-CRYPTO-50` | The host QueryStreamHistory plugin path MUST refuse any plugin-returned row where codec!=identity AND dek_ref is absent or not present in crypto_keys (destroyed_at IS NULL filter); refusal surfaces as metadata_only=true (carries master INV-48). | `INV-P7-15` | pending |
 | `INV-CRYPTO-51` | The AuditRow -> *eventbusv1.Event adapter MUST produce a value whose AAD reconstruction is byte-equal to the AAD used at encrypt for the same event_id (superseded by INV-STORE-5 at full ns resolution; ADR holomush-f5h0). | `INV-P7-16` | pending |
 | `INV-CRYPTO-52` | Phase C.0 substrate: the plugin audit router MUST stamp the AuditRow.of (origin) on each routed row and expose it via the accessor used by the dispatcher. | `INV-P7-C0` | pending |
+| `INV-CRYPTO-53` | AdminReadStream MUST emit the crypto.system.operator_read audit event and observe a successful OperatorReadAuditEmitter.EmitStart ack BEFORE sending any ReadStarted or Event frame. | `INV-F1` | pending |
+| `INV-CRYPTO-54` | If the pre-data audit publish fails, AdminReadStream MUST return DENY_AUDIT_PRE_DATA_PUBLISH and MUST NOT invoke HistoryReader.QueryHistory. | `INV-F2` | pending |
+| `INV-CRYPTO-55` | AdminReadStream MUST reject with DENY_OPERATOR_CAPABILITY when the operator lacks crypto.operator, BEFORE any audit emit. | `INV-F3` | pending |
+| `INV-CRYPTO-56` | (until - since) > MaxWindow MUST return DENY_OPERATOR_READ_WINDOW_TOO_LARGE BEFORE the pre-data audit emit. | `INV-F6` | pending |
+| `INV-CRYPTO-57` | OperatorReadStartPayload MUST persist both the Requested-prefixed (nullable, capturing defaulting) and Resolved-prefixed (always populated) since/until/contexts fields. | `INV-F7` | pending |
+| `INV-CRYPTO-58` | ReadStarted.request_id, OperatorReadStartPayload.RequestID, the start event ID, and OperatorReadCompletedPayload.RequestID MUST all be equal. | `INV-F8` | pending |
+| `INV-CRYPTO-59` | The crypto.system.operator_read_completed event's prev_hash MUST equal the recomputed self_hash of its corresponding operator_read start event; both share NATS subject events.<game>.system.operator_read.<request_id>. | `INV-F9` | pending |
+| `INV-CRYPTO-60` | Completion-audit publish failure MUST NOT raise an error (data already delivered; the pre-data audit is the integrity anchor); it MUST be logged at WARN and counted via holomush_admin_readstream_completed_audit_failures_total. | `INV-F10` | pending |
+| `INV-CRYPTO-61` | Dual-control: when req.dual_control=true and GetByOpArgsHash returns NOT_FOUND, the handler MUST send exactly one PendingApproval frame and block via Repo.WaitForApproval; no in-process pending-approval registry. | `INV-F11` | pending |
+| `INV-CRYPTO-62` | F's classifier (classify.go::Classify) MUST match its documented matrix; every branch corresponds to a production-verified error producer, and unknown errors MUST surface as NO_PLAINTEXT_REASON_INTERNAL with a WARN log. | `INV-F12` | pending |
+| `INV-CRYPTO-63` | crypto.system.operator_read and crypto.system.operator_read_completed MUST be registered in internal/core/builtins.go with DisplayTarget == EVENT_CHANNEL_AUDIT_ONLY. | `INV-F13` | pending |
+| `INV-CRYPTO-64` | A per-frame write deadline (WriteDeadline, default 30s) MUST be enforced via sendWithDeadline; total stream duration MUST NOT be capped. | `INV-F14` | pending |
+| `INV-CRYPTO-65` | F MUST set HistoryQuery.SensitiveOnly=true on every cold-tier query (canonical server-side WHERE dek_ref IS NOT NULL filter); identity-codec rows MUST NOT reach the operator's stream. | `INV-F15` | pending |
+| `INV-CRYPTO-66` | The NoPlaintextReason enum expansion (4→7) MUST preserve INV-GW-14 parity, and the new values (DEK_MISSING, DEK_BAD_COLUMNS, INTERNAL) MUST NOT be stamped by cold_postgres.go or history/dispatcher.go — F's classifier is the only producer. | `INV-F16` | pending |
+| `INV-CRYPTO-67` | approval.Repo.GetByOpArgsHash MUST apply all filters server-side (op_kind, op_args_hash, expires_at>now(), approved_at IS NOT NULL, primary_player_id != excludePlayerID); tiebreaker = most recently approved. | `INV-F17` | pending |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -18,17 +18,17 @@ scopes:
     # Family→scope evidence: bare INV-N (crypto payload/DEK/KEK/AAD) →
     # 2026-04-25-event-payload-crypto-design.md; RB → 2026-05-25-plugin-readback-decrypt-design.md;
     # P7 (crypto half) → 2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md;
-    # reader-options INV-1..6 → 2026-05-05-history-reader-crypto-options-design.md.
-    # See redesign spec §2.1 and bead holomush-hz0v4.14.15. LEFT untouched (closed-world,
-    # flagged on epic .14): INV-F* sub-epic-F family (AdminReadStream operator-read) and
-    # master INV-6/INV-7 emit-time sensitivity-fence (home in internal/plugin/) — both
-    # unclassified, need a dedicated pass before .14.17 final verification.
+    # reader-options INV-1..6 → 2026-05-05-history-reader-crypto-options-design.md;
+    # sub-epic-F AdminReadStream INV-F1..F17 (→53..67) → 2026-05-11-...phase5-sub-epic-f.
+    # See redesign spec §2.1 and beads holomush-hz0v4.14.15/.14.23. NOTE: master INV-6/INV-7
+    # emit-time sensitivity-fence is classified to INV-PLUGIN ('emit gates') in .14.24, NOT here.
     status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
       - "docs/superpowers/specs/2026-05-25-plugin-readback-decrypt-design.md"
       - "docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md"
       - "docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md"
+      - "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
     owned_paths:
       - "internal/eventbus/crypto/**"
       - "internal/eventbus/history/**"
@@ -89,6 +89,21 @@ scopes:
       - "api/proto/holomush/core/v1/core.proto"
       - "api/proto/holomush/plugin/v1/plugin.proto"
       - "api/proto/holomush/plugin/v1/audit.proto"
+      # INV-F sub-epic-F AdminReadStream (.14.23). admin/readstream/** is already owned above;
+      # these are the non-readstream sites: dual-control approval repo (→67), operator-read
+      # window config (→56/61/64), builtins operator-read golden test (→63), NoPlaintextReason
+      # proto-sync test (→66, EVENTBUS-shared too), the admin proto SOURCES (regen 3 targets),
+      # and the cmd/holomush E2E + wiring tests that exercise the operator-read flow end-to-end.
+      - "internal/admin/approval/repo.go"
+      - "internal/admin/approval/repo_integration_test.go"
+      - "internal/config/config.go"
+      - "internal/core/builtins_operator_read_test.go"
+      - "internal/eventbus/types_proto_sync_test.go"
+      - "api/proto/holomush/admin/v1/read_stream.proto"
+      - "api/proto/holomush/admin/v1/admin.proto"
+      - "cmd/holomush/admin_read_stream_e2e_test.go"
+      - "cmd/holomush/admin_authenticate_e2e_test.go"
+      - "cmd/holomush/readstream_wiring_test.go"
 
   - name: INV-PRIVACY
     description: "Stream history temporal floors, scope gating, guest-session bounds, reattach/Idle arrival-timestamp semantics"
@@ -1160,6 +1175,142 @@ invariants:
     binding: pending
     refs:
       - {file: "internal/eventbus/history/phase7_boundary_meta_test.go", token: "INV-P7-C0"}
+  - id: INV-CRYPTO-53
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F1@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "AdminReadStream MUST emit the crypto.system.operator_read audit event and observe a successful OperatorReadAuditEmitter.EmitStart
+      ack BEFORE sending any ReadStarted or Event frame."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F1"}
+  - id: INV-CRYPTO-54
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F2@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "If the pre-data audit publish fails, AdminReadStream MUST return DENY_AUDIT_PRE_DATA_PUBLISH and MUST NOT invoke
+      HistoryReader.QueryHistory."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F2"}
+  - id: INV-CRYPTO-55
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F3@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "AdminReadStream MUST reject with DENY_OPERATOR_CAPABILITY when the operator lacks crypto.operator, BEFORE any
+      audit emit."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F3"}
+  - id: INV-CRYPTO-56
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F6@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "(until - since) > MaxWindow MUST return DENY_OPERATOR_READ_WINDOW_TOO_LARGE BEFORE the pre-data audit emit."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F6"}
+      - {file: "cmd/holomush/readstream_wiring_test.go", token: "INV-F6"}
+  - id: INV-CRYPTO-57
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F7@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "OperatorReadStartPayload MUST persist both the Requested-prefixed (nullable, capturing defaulting) and Resolved-prefixed
+      (always populated) since/until/contexts fields."
+    binding: pending
+    refs:
+  - id: INV-CRYPTO-58
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F8@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "ReadStarted.request_id, OperatorReadStartPayload.RequestID, the start event ID, and OperatorReadCompletedPayload.RequestID
+      MUST all be equal."
+    binding: pending
+    refs:
+  - id: INV-CRYPTO-59
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F9@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "The crypto.system.operator_read_completed event's prev_hash MUST equal the recomputed self_hash of its corresponding
+      operator_read start event; both share NATS subject events.<game>.system.operator_read.<request_id>."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F9"}
+  - id: INV-CRYPTO-60
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F10@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "Completion-audit publish failure MUST NOT raise an error (data already delivered; the pre-data audit is the
+      integrity anchor); it MUST be logged at WARN and counted via holomush_admin_readstream_completed_audit_failures_total."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F10"}
+  - id: INV-CRYPTO-61
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F11@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "Dual-control: when req.dual_control=true and GetByOpArgsHash returns NOT_FOUND, the handler MUST send exactly
+      one PendingApproval frame and block via Repo.WaitForApproval; no in-process pending-approval registry."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F11"}
+      - {file: "cmd/holomush/readstream_wiring_test.go", token: "INV-F11"}
+  - id: INV-CRYPTO-62
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F12@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "F's classifier (classify.go::Classify) MUST match its documented matrix; every branch corresponds to a production-verified
+      error producer, and unknown errors MUST surface as NO_PLAINTEXT_REASON_INTERNAL with a WARN log."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_authenticate_e2e_test.go", token: "INV-F12"}
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F12"}
+  - id: INV-CRYPTO-63
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F13@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "crypto.system.operator_read and crypto.system.operator_read_completed MUST be registered in internal/core/builtins.go
+      with DisplayTarget == EVENT_CHANNEL_AUDIT_ONLY."
+    binding: pending
+    refs:
+  - id: INV-CRYPTO-64
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F14@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "A per-frame write deadline (WriteDeadline, default 30s) MUST be enforced via sendWithDeadline; total stream
+      duration MUST NOT be capped."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F14"}
+      - {file: "cmd/holomush/readstream_wiring_test.go", token: "INV-F14"}
+  - id: INV-CRYPTO-65
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F15@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "F MUST set HistoryQuery.SensitiveOnly=true on every cold-tier query (canonical server-side WHERE dek_ref IS
+      NOT NULL filter); identity-codec rows MUST NOT reach the operator's stream."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_authenticate_e2e_test.go", token: "INV-F15"}
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F15"}
+  - id: INV-CRYPTO-66
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F16@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "The NoPlaintextReason enum expansion (4→7) MUST preserve INV-GW-14 parity, and the new values (DEK_MISSING,
+      DEK_BAD_COLUMNS, INTERNAL) MUST NOT be stamped by cold_postgres.go or history/dispatcher.go — F's classifier is the
+      only producer."
+    binding: pending
+    refs:
+  - id: INV-CRYPTO-67
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
+    legacy: ["INV-F17@docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"]
+    summary: "approval.Repo.GetByOpArgsHash MUST apply all filters server-side (op_kind, op_args_hash, expires_at>now(), approved_at
+      IS NOT NULL, primary_player_id != excludePlayerID); tiebreaker = most recently approved."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/admin_read_stream_e2e_test.go", token: "INV-F17"}
   # ── INV-PRESENCE ── migrated from I-PRES-N (holomush-hz0v4.14.5).
   # Origin: docs/superpowers/specs/2026-05-19-presence-snapshot-design.md §7.
   # binding: pending across the scope — verification backfill is holomush-hz0v4.11.

--- a/internal/admin/approval/repo.go
+++ b/internal/admin/approval/repo.go
@@ -141,7 +141,7 @@ func (r *PostgresRepo) getRaw(ctx context.Context, id RequestID) (Approval, erro
 
 // GetByOpArgsHash returns the most-recently-approved fresh approval for the
 // given (opKind, opArgsHash) pair that was not authored by excludePlayerID.
-// All filters are applied server-side in a single query. INV-F17.
+// All filters are applied server-side in a single query. INV-CRYPTO-67.
 //
 // Returns APPROVAL_NOT_FOUND if no matching row exists (expired, unapproved,
 // authored by excludePlayerID, or simply absent).

--- a/internal/admin/approval/repo_integration_test.go
+++ b/internal/admin/approval/repo_integration_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Approval Repo", func() {
 		})
 	})
 
-	Describe("GetByOpArgsHash (INV-F17)", func() {
+	Describe("GetByOpArgsHash (INV-CRYPTO-67)", func() {
 		// openAndApprove is a spec-local helper that opens a fresh approval and
 		// immediately marks it approved by secondOp, returning the resulting Approval.
 		openAndApprove := func(r *approval.PostgresRepo, primary, secondOp, opKind string, opArgsHash []byte) approval.Approval {

--- a/internal/admin/readstream/audit_emitter.go
+++ b/internal/admin/readstream/audit_emitter.go
@@ -17,13 +17,13 @@ import (
 )
 
 // CompletedAuditFailuresTotal counts completion-audit publish failures
-// (INV-F10). Exported so tests can read via testutil.ToFloat64.
+// (INV-CRYPTO-60). Exported so tests can read via testutil.ToFloat64.
 //
 // Registered via promauto (process-global DefaultRegisterer) so it survives
 // test suite restarts in the same process without duplicate-registration panics.
 var CompletedAuditFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "holomush_admin_readstream_completed_audit_failures_total",
-	Help: "Total failures emitting the crypto.system.operator_read_completed audit event (INV-F10)",
+	Help: "Total failures emitting the crypto.system.operator_read_completed audit event (INV-CRYPTO-60)",
 })
 
 const (
@@ -37,13 +37,13 @@ type OperatorReadAuditEmitter interface {
 	// EmitStart canonicalizes the start payload, computes prev_hash for the
 	// scope (genesis: nil), stamps prev_hash + self_hash into the payload,
 	// and publishes to events.<game>.system.operator_read.<request_id>.
-	// Returns an error; callers MUST NOT stream data if EmitStart fails (INV-F1).
+	// Returns an error; callers MUST NOT stream data if EmitStart fails (INV-CRYPTO-53).
 	EmitStart(ctx context.Context, payload OperatorReadStartPayload, requestID ulid.ULID) error
 
 	// EmitCompleted does the same for the completed event. The chain emitter
 	// loads existing entries by scope (returns the start event), and its
 	// recomputed self_hash becomes prev_hash. Returns nil on publish success.
-	// On failure: increments INV-F10 metric and returns wrapped error.
+	// On failure: increments INV-CRYPTO-60 metric and returns wrapped error.
 	EmitCompleted(ctx context.Context, payload OperatorReadCompletedPayload, requestID ulid.ULID) error
 }
 
@@ -109,9 +109,9 @@ func (e *operatorReadAuditEmitter) EmitStart(ctx context.Context, payload Operat
 
 // EmitCompleted implements OperatorReadAuditEmitter.
 //
-// INV-F9: prev_hash MUST equal the recomputed self_hash of the start event.
+// INV-CRYPTO-59: prev_hash MUST equal the recomputed self_hash of the start event.
 // Returns a wrapped error on publish/chain failure; the caller MUST log and
-// discard the error per INV-F10 (see handler.go::handleInternal step 10).
+// discard the error per INV-CRYPTO-60 (see handler.go::handleInternal step 10).
 // CompletedAuditFailuresTotal is incremented inside this method on every
 // failure path before returning.
 func (e *operatorReadAuditEmitter) EmitCompleted(ctx context.Context, payload OperatorReadCompletedPayload, requestID ulid.ULID) error {

--- a/internal/admin/readstream/audit_emitter_test.go
+++ b/internal/admin/readstream/audit_emitter_test.go
@@ -126,10 +126,10 @@ func TestOperatorReadAuditEmitter_EmitStartPropagatesPublishError(t *testing.T) 
 	errutil.AssertErrorCode(t, err, "OPERATOR_READ_AUDIT_PUBLISH_FAILED")
 }
 
-// TestINV_F8_RequestIDCoherence verifies INV-F8:
+// TestINV_CRYPTO_58_RequestIDCoherence verifies INV-CRYPTO-58:
 // EmitStart and EmitCompleted must both publish events with the same RequestID
 // in the payload, and subjects must share the request_id suffix.
-func TestINV_F8_RequestIDCoherence(t *testing.T) {
+func TestINV_CRYPTO_58_RequestIDCoherence(t *testing.T) {
 	// First call: genesis (no prev)
 	// Second call: prevHash = some bytes (simulating the start's self_hash)
 	callCount := 0
@@ -166,10 +166,10 @@ func TestINV_F8_RequestIDCoherence(t *testing.T) {
 
 	assert.Equal(t, requestID.String(), startReqID, "start payload request_id must match input")
 	assert.Equal(t, requestID.String(), completedReqID, "completed payload request_id must match input")
-	assert.Equal(t, startReqID, completedReqID, "both events must share request_id (INV-F8)")
+	assert.Equal(t, startReqID, completedReqID, "both events must share request_id (INV-CRYPTO-58)")
 
 	// Both subjects must contain the request_id suffix
-	assert.Equal(t, pub.events[0].Subject, pub.events[1].Subject, "both events must share the NATS subject (INV-F9)")
+	assert.Equal(t, pub.events[0].Subject, pub.events[1].Subject, "both events must share the NATS subject (INV-CRYPTO-59)")
 }
 
 // TestOperatorReadAuditEmitter_EmitCompletedRefusesWithoutStart tests that
@@ -187,12 +187,12 @@ func TestOperatorReadAuditEmitter_EmitCompletedRefusesWithoutStart(t *testing.T)
 	errutil.AssertErrorCode(t, err, "OPERATOR_READ_AUDIT_COMPLETED_NO_START")
 
 	// Metric must have incremented
-	assert.Equal(t, float64(0), float64(0)) // see TestINV_F10_MetricIncrements
+	assert.Equal(t, float64(0), float64(0)) // see TestINV_CRYPTO_60_MetricIncrements
 }
 
-// TestINV_F10_MetricIncrements verifies INV-F10: EmitCompleted failure increments
+// TestINV_CRYPTO_60_MetricIncrements verifies INV-CRYPTO-60: EmitCompleted failure increments
 // holomush_admin_readstream_completed_audit_failures_total.
-func TestINV_F10_MetricIncrements(t *testing.T) {
+func TestINV_CRYPTO_60_MetricIncrements(t *testing.T) {
 	before := testutil.ToFloat64(readstream.CompletedAuditFailuresTotal)
 
 	// Fault-inject: chain returns nil prevHash → OPERATOR_READ_AUDIT_COMPLETED_NO_START
@@ -206,12 +206,12 @@ func TestINV_F10_MetricIncrements(t *testing.T) {
 	require.Error(t, err)
 
 	after := testutil.ToFloat64(readstream.CompletedAuditFailuresTotal)
-	assert.Equal(t, before+1, after, "metric must increment on EmitCompleted failure (INV-F10)")
+	assert.Equal(t, before+1, after, "metric must increment on EmitCompleted failure (INV-CRYPTO-60)")
 }
 
-// TestINV_F10_EmitStartFailureDoesNotIncrementMetric verifies INV-F10 inverse:
+// TestINV_CRYPTO_60_EmitStartFailureDoesNotIncrementMetric verifies INV-CRYPTO-60 inverse:
 // EmitStart failure must NOT increment the completed-audit-failures metric.
-func TestINV_F10_EmitStartFailureDoesNotIncrementMetric(t *testing.T) {
+func TestINV_CRYPTO_60_EmitStartFailureDoesNotIncrementMetric(t *testing.T) {
 	before := testutil.ToFloat64(readstream.CompletedAuditFailuresTotal)
 
 	// Fault-inject: publisher fails
@@ -225,7 +225,7 @@ func TestINV_F10_EmitStartFailureDoesNotIncrementMetric(t *testing.T) {
 	require.Error(t, err)
 
 	after := testutil.ToFloat64(readstream.CompletedAuditFailuresTotal)
-	assert.Equal(t, before, after, "EmitStart failure must NOT increment completed-audit metric (INV-F10)")
+	assert.Equal(t, before, after, "EmitStart failure must NOT increment completed-audit metric (INV-CRYPTO-60)")
 }
 
 // chainEmitterFunc is a function-backed chain.Emitter for test flexibility.

--- a/internal/admin/readstream/audit_payload.go
+++ b/internal/admin/readstream/audit_payload.go
@@ -22,7 +22,7 @@ type ContextRef struct {
 
 // encodeHash mirrors internal/eventbus/crypto/dek/audit.go::encodeHash
 // (package-private there). MUST produce byte-identical output to maintain
-// cross-chain JCS canonical-form parity (INV-F7).
+// cross-chain JCS canonical-form parity (INV-CRYPTO-57).
 func encodeHash(b []byte) string {
 	return fmt.Sprintf("sha256:%s", hex.EncodeToString(b))
 }
@@ -40,7 +40,7 @@ func encodeHashPtr(b []byte) *string {
 // OperatorReadStartPayload is the JSON-shaped payload of the
 // crypto.system.operator_read audit event.
 //
-// INV-F7: both Requested-* (nullable, capturing defaulting) and Resolved-*
+// INV-CRYPTO-57: both Requested-* (nullable, capturing defaulting) and Resolved-*
 // (always populated) fields for since/until/contexts MUST be present.
 type OperatorReadStartPayload struct {
 	// Operator identity

--- a/internal/admin/readstream/audit_payload_test.go
+++ b/internal/admin/readstream/audit_payload_test.go
@@ -70,8 +70,8 @@ func TestEncodeHashPtr_NilForGenesis(t *testing.T) {
 	assert.False(t, hasPrevHash, "genesis payload must have no prev_hash key in JSON")
 }
 
-func TestINV_F7_PayloadPreservesRequestedAndResolved(t *testing.T) {
-	// INV-F7: OperatorReadStartPayload MUST persist both Requested-* (nullable)
+func TestINV_CRYPTO_57_PayloadPreservesRequestedAndResolved(t *testing.T) {
+	// INV-CRYPTO-57: OperatorReadStartPayload MUST persist both Requested-* (nullable)
 	// and Resolved-* (always populated) fields for since/until/contexts.
 	// JSON round-trip must preserve all fields including nullable *time.Time pointers.
 

--- a/internal/admin/readstream/chain.go
+++ b/internal/admin/readstream/chain.go
@@ -25,7 +25,7 @@ import (
 // INV-E26: SubjectPrefix starts with "events.".
 // INV-E27: ScopePayloadField is "request_id" (non-empty).
 // INV-E28: SelfHashField is "self_hash"; PrevHashField is "prev_hash".
-// INV-F9: Both events share the same NATS subject pattern.
+// INV-CRYPTO-59: Both events share the same NATS subject pattern.
 func OperatorReadChainFor(gameID string) chain.Chain {
 	return chain.Chain{
 		SubjectPrefix:     "events." + gameID + ".system.operator_read",

--- a/internal/admin/readstream/chain_test.go
+++ b/internal/admin/readstream/chain_test.go
@@ -92,8 +92,8 @@ func TestOperatorReadHandler_ScopeFromSubjectRejectsInvalidSuffix(t *testing.T) 
 	}
 }
 
-func TestINV_F9_AuditChainLinksStartToCompletedSameSubject(t *testing.T) {
-	// INV-F9: both events share NATS subject; chain primitive links them.
+func TestINV_CRYPTO_59_AuditChainLinksStartToCompletedSameSubject(t *testing.T) {
+	// INV-CRYPTO-59: both events share NATS subject; chain primitive links them.
 	// Construct fake start + completed envelopes with shared request_id.
 	h := readstream.OperatorReadHandlerFor("g1")
 	requestID := "01ARZ3NDEKTSV4RRFFQ69G5FAV"
@@ -123,7 +123,7 @@ func TestINV_F9_AuditChainLinksStartToCompletedSameSubject(t *testing.T) {
 	// (a) Both subjects are equal via SubjectFor
 	startSubject := h.SubjectFor(requestID)
 	completedSubject := h.SubjectFor(requestID)
-	assert.Equal(t, startSubject, completedSubject, "both events must share the same subject (INV-F9)")
+	assert.Equal(t, startSubject, completedSubject, "both events must share the same subject (INV-CRYPTO-59)")
 
 	// (b) ScopeFromPayload extracts request_id from both
 	startScope, err := h.ScopeFromPayload(startBytes)

--- a/internal/admin/readstream/deadline_writer.go
+++ b/internal/admin/readstream/deadline_writer.go
@@ -17,7 +17,7 @@ import (
 // not cancelled (i.e., the slow path is server-side, not a client disconnect).
 var ErrWriteDeadlineExceeded = errors.New("readstream: write deadline exceeded")
 
-// SendWithDeadline enforces a per-frame write deadline (INV-F14) using a
+// SendWithDeadline enforces a per-frame write deadline (INV-CRYPTO-64) using a
 // hybrid mechanism:
 //
 //  1. setDeadline(now+deadline) primes the underlying conn's write deadline so

--- a/internal/admin/readstream/deadline_writer_test.go
+++ b/internal/admin/readstream/deadline_writer_test.go
@@ -71,10 +71,10 @@ func TestSendWithDeadline_PassesDeadlineToSetter(t *testing.T) {
 		"first call must set deadline ≤ after+dur; got %v (after+dur=%v)", (*calls)[0], after.Add(dur))
 }
 
-// TestINV_F14_SendWithDeadlineTrips verifies that when send returns
+// TestINV_CRYPTO_64_SendWithDeadlineTrips verifies that when send returns
 // os.ErrDeadlineExceeded (the kernel-level signal that the write deadline
 // tripped at the conn), SendWithDeadline returns ErrWriteDeadlineExceeded.
-func TestINV_F14_SendWithDeadlineTrips(t *testing.T) {
+func TestINV_CRYPTO_64_SendWithDeadlineTrips(t *testing.T) {
 	err := readstream.SendWithDeadline(
 		context.Background(),
 		func(_ string) error { return os.ErrDeadlineExceeded },

--- a/internal/admin/readstream/decrypt.go
+++ b/internal/admin/readstream/decrypt.go
@@ -6,7 +6,7 @@
 // omits AuthGuard, SessionAuditEmitter, and plugin-identity branching — F has
 // no per-event auth and no per-decrypt audit.
 //
-// INV-F12: the 6-branch classifier matrix maps decrypt errors to
+// INV-CRYPTO-62: the 6-branch classifier matrix maps decrypt errors to
 // NoPlaintextReason values. Row-level failures produce metadata-only frames;
 // context cancellation/deadline is fatal and bails the stream.
 
@@ -100,7 +100,7 @@ func DecryptRow(
 }
 
 // classifyDecryptErr maps an error to a NoPlaintextReason + fatal flag per
-// INV-F12's 6-branch matrix.
+// INV-CRYPTO-62's 6-branch matrix.
 //
 // Fatal=true means the entire stream should bail (ctx canceled/deadline).
 // Fatal=false means the row becomes a metadata-only frame and streaming continues.

--- a/internal/admin/readstream/decrypt_test.go
+++ b/internal/admin/readstream/decrypt_test.go
@@ -96,9 +96,9 @@ func buildEncryptedColdRow(t *testing.T, plaintext []byte) (readstream.ColdRow, 
 	return row, testKey
 }
 
-// ---- INV-F12 classifier matrix ----
+// ---- INV-CRYPTO-62 classifier matrix ----
 
-func TestINV_F12_ClassifierMatrix(t *testing.T) {
+func TestINV_CRYPTO_62_ClassifierMatrix(t *testing.T) {
 	// We test classifyDecryptErr indirectly through DecryptRow by injecting
 	// errors at the DEK-resolve step and checking the (reason, fatal) output.
 	tests := []struct {

--- a/internal/admin/readstream/export_test.go
+++ b/internal/admin/readstream/export_test.go
@@ -101,7 +101,7 @@ func (c *ColdReader) BuildSQLForTest(q ColdQuery) (string, []any, error) {
 
 // BuildMetadataOnlyEventFrameForTest exposes the package-private metadata-only
 // frame builder. Used by handler_test.go to assert that metadata-only frames
-// carry typed redaction fields (INV-F12).
+// carry typed redaction fields (INV-CRYPTO-62).
 func BuildMetadataOnlyEventFrameForTest(row ColdRow, reason eventbus.NoPlaintextReason) *adminv1.AdminReadStreamResponse {
 	return buildMetadataOnlyEventFrame(row, reason)
 }

--- a/internal/admin/readstream/filter.go
+++ b/internal/admin/readstream/filter.go
@@ -24,7 +24,7 @@ type typeSpec struct {
 }
 
 // sensitiveTypes is the package-private registry of recognised context types
-// (INV-F6/F7). Hardcoded — no runtime registration.
+// (INV-CRYPTO-56/INV-CRYPTO-57). Hardcoded — no runtime registration.
 var sensitiveTypes = map[string]typeSpec{
 	"scene":     {Arity: 1, OrderInsensitiveIDs: false, MatchID: isULID},
 	"location":  {Arity: 1, OrderInsensitiveIDs: false, MatchID: isULID},

--- a/internal/admin/readstream/filter_test.go
+++ b/internal/admin/readstream/filter_test.go
@@ -53,7 +53,7 @@ func TestResolveBounds_DefaultsFromZeroBounds(t *testing.T) {
 	assert.WithinDuration(t, now, resolved.Until, time.Second)
 }
 
-func TestINV_F6_WindowTooLargeRejected(t *testing.T) {
+func TestINV_CRYPTO_56_WindowTooLargeRejected(t *testing.T) {
 	now := time.Now()
 	req := &readstream.Request{
 		Contexts:      []readstream.ContextRef{{Type: "scene", IDs: []string{"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}},

--- a/internal/admin/readstream/handler.go
+++ b/internal/admin/readstream/handler.go
@@ -4,16 +4,16 @@
 // handler.go is the AdminReadStream entry point. It orchestrates the full
 // operator-read flow per ADR-0017:
 //
-//  1. Capability check (INV-F3): the bearer must hold crypto.operator BEFORE
+//  1. Capability check (INV-CRYPTO-55): the bearer must hold crypto.operator BEFORE
 //     any audit publish or data read.
-//  2. ResolveBounds (INV-F6/F7): validate + default + canonicalise the request.
-//  3. Dual-control (INV-F11/F17): on req.DualControl, reuse a fresh approved
+//  2. ResolveBounds (INV-CRYPTO-56/INV-CRYPTO-57): validate + default + canonicalise the request.
+//  3. Dual-control (INV-CRYPTO-61/INV-CRYPTO-67): on req.DualControl, reuse a fresh approved
 //     row from approval.Repo.GetByOpArgsHash or Open + WaitForApproval.
-//  4. Pre-data audit publish (INV-F1/F2): EmitStart MUST succeed BEFORE the
+//  4. Pre-data audit publish (INV-CRYPTO-53/INV-CRYPTO-54): EmitStart MUST succeed BEFORE the
 //     first frame is sent or any cold-tier row is read.
 //  5. scanAndStream: ColdReader.Read → DecryptRow per row → typed frame send
-//     via SendWithDeadline (INV-F12/F14).
-//  6. Post-data audit publish (INV-F10): EmitCompleted is best-effort; its
+//     via SendWithDeadline (INV-CRYPTO-62/INV-CRYPTO-64).
+//  6. Post-data audit publish (INV-CRYPTO-60): EmitCompleted is best-effort; its
 //     failure increments the metric but does NOT raise.
 //
 // The production handler is wired in R.14. R.15 supplies the in-process
@@ -46,7 +46,7 @@ import (
 // from an authenticated operator session. Mirrors the layering-decoupling
 // pattern in internal/admin/socket/rekey_handler.go::OperatorSession but
 // preserves PeerCred (UID/PID) because F's audit payload requires it
-// (INV-F7).
+// (INV-CRYPTO-57).
 type OperatorSession struct {
 	PlayerID       string
 	SessionTokenID string
@@ -79,9 +79,9 @@ type Config struct {
 	// Sessions resolves the session_token to an OperatorSession.
 	Sessions SessionStore
 	// Grants is the ABAC resolver for the crypto.operator capability check
-	// (INV-F3). Passed to access.HasPlayerGrant.
+	// (INV-CRYPTO-55). Passed to access.HasPlayerGrant.
 	Grants access.SubjectResolver
-	// Approvals is the dual-control repository (INV-F11/F17). When
+	// Approvals is the dual-control repository (INV-CRYPTO-61/INV-CRYPTO-67). When
 	// req.DualControl=false, this is never called.
 	Approvals approval.Repo
 	// ColdReader executes the cold-tier read against events_audit. Owned
@@ -92,7 +92,7 @@ type Config struct {
 	DEK DEKResolver
 	// Codecs resolves the codec for per-row decryption (R.11).
 	Codecs CodecResolver
-	// AuditEmitter publishes the start + completed audit events (INV-F1/F2/F10).
+	// AuditEmitter publishes the start + completed audit events (INV-CRYPTO-53/INV-CRYPTO-54/INV-CRYPTO-60).
 	AuditEmitter OperatorReadAuditEmitter
 	// PolicyHash is the canonical "sha256:<hex>" of the active site
 	// policy, captured at bootstrap. Stamped into both audit payloads.
@@ -104,11 +104,11 @@ type Config struct {
 	Logger *slog.Logger
 	// Game is the game ID used to build NATS subjects (BuildSubjects).
 	Game string
-	// MaxWindow caps the (until - since) span (INV-F6).
+	// MaxWindow caps the (until - since) span (INV-CRYPTO-56).
 	MaxWindow time.Duration
-	// DefaultWindow is the size of since-defaulted reads (INV-F6).
+	// DefaultWindow is the size of since-defaulted reads (INV-CRYPTO-56).
 	DefaultWindow time.Duration
-	// WriteDeadline is the per-frame send deadline (INV-F14).
+	// WriteDeadline is the per-frame send deadline (INV-CRYPTO-64).
 	WriteDeadline time.Duration
 	// ApprovalTTL is the dual-control wait budget. Used as the deadline
 	// passed to approval.Repo.WaitForApproval.
@@ -197,7 +197,7 @@ func (c *connectStream) Send(resp *adminv1.AdminReadStreamResponse) error {
 }
 
 // handleInternal runs the full operator-read flow per ADR-0017. The
-// invariant ordering enforced here is INV-CRYPTO-23 / INV-F1 / INV-F2:
+// invariant ordering enforced here is INV-CRYPTO-23 / INV-CRYPTO-53 / INV-CRYPTO-54:
 //
 //	capability check → resolve bounds → (optional) dual-control →
 //	EmitStart → first frame send → cold read → frame stream →
@@ -217,7 +217,7 @@ func (h *Handler) handleInternal(
 		return oops.Wrap(err)
 	}
 
-	// Step 2: capability check (INV-F3 — MUST precede EmitStart).
+	// Step 2: capability check (INV-CRYPTO-55 — MUST precede EmitStart).
 	hasCap, err := access.HasPlayerGrant(ctx, h.cfg.Grants, session.PlayerID, access.CapabilityCryptoOperator)
 	if err != nil {
 		return oops.Code("INGAME_GRANT_LOOKUP_FAILED").
@@ -229,7 +229,7 @@ func (h *Handler) handleInternal(
 			Errorf("crypto.operator capability absent")
 	}
 
-	// Step 3: validate + canonicalise the request shape (INV-F6/F7).
+	// Step 3: validate + canonicalise the request shape (INV-CRYPTO-56/INV-CRYPTO-57).
 	domesticReq := protoToDomesticRequest(req)
 	resolved, flags, err := ResolveBounds(&domesticReq, h.cfg.Clock(), h.cfg.DefaultWindow, h.cfg.MaxWindow)
 	if err != nil {
@@ -245,7 +245,7 @@ func (h *Handler) handleInternal(
 		return oops.Wrap(err)
 	}
 
-	// Step 5: dual-control (INV-F11/F17). On reuse, approvalInfo carries the
+	// Step 5: dual-control (INV-CRYPTO-61/INV-CRYPTO-67). On reuse, approvalInfo carries the
 	// existing row; on Open + Wait, it carries the freshly approved row.
 	var approvalInfo *approvalRecord
 	if req.GetDualControl() {
@@ -265,7 +265,7 @@ func (h *Handler) handleInternal(
 		}
 	}
 
-	// Step 6: build the start payload and emit (INV-F1/F2). After this point
+	// Step 6: build the start payload and emit (INV-CRYPTO-53/INV-CRYPTO-54). After this point
 	// the audit trail has captured the operator's intent.
 	requestID := idgen.New()
 	startPayload := h.buildStartPayload(session, resolved, flags, domesticReq, req, requestID, approvalInfo)
@@ -273,7 +273,7 @@ func (h *Handler) handleInternal(
 		// Build a fresh DENY_AUDIT_PRE_DATA_PUBLISH oops carrying the inner
 		// error's message. oops.Code().Wrap() preserves the DEEPEST code in
 		// the chain — wrapping here would surface EMITTER_PUBLISH_FAILED to
-		// the operator, defeating INV-F2 classification. Use .Errorf with
+		// the operator, defeating INV-CRYPTO-54 classification. Use .Errorf with
 		// inner.Error() so the outer code wins (classifyTerminator + the
 		// audit-emit-failure terminator depend on this).
 		return oops.Code("DENY_AUDIT_PRE_DATA_PUBLISH").
@@ -297,7 +297,7 @@ func (h *Handler) handleInternal(
 	term := classifyTerminator(streamErr)
 	_ = stream.Send(buildFinishedFrame(term, eventsScanned, decryptFails, h.cfg.Clock())) //nolint:errcheck // best-effort terminator send; client may have disconnected and we still record the audit completion
 
-	// Step 10: emit the completed audit event (INV-F10 — failure does NOT
+	// Step 10: emit the completed audit event (INV-CRYPTO-60 — failure does NOT
 	// raise, just logs WARN; metric increments inside EmitCompleted).
 	completedPayload := buildCompletedPayload(requestID, term, eventsScanned, decryptFails, h.cfg.PolicyHash, h.cfg.Clock())
 	if cerr := h.cfg.AuditEmitter.EmitCompleted(ctx, completedPayload, requestID); cerr != nil {
@@ -320,7 +320,7 @@ type approvalRecord struct {
 	ApprovedBy ulid.ULID
 }
 
-// acquireApproval implements the INV-F11/F17 dual-control flow:
+// acquireApproval implements the INV-CRYPTO-61/INV-CRYPTO-67 dual-control flow:
 //
 //   - Reuse: if a fresh approved row exists for (opKind, opArgsHash) authored
 //     by another operator, return it directly. No PendingApproval frame.
@@ -430,7 +430,7 @@ func (h *Handler) scanAndStream( //nolint:gocritic // unnamedResult: three-retur
 	var eventsScanned, decryptFails int64
 	send := stream.Send
 
-	// Per INV-F14: per-frame write deadline. Production requests carry the
+	// Per INV-CRYPTO-64: per-frame write deadline. Production requests carry the
 	// underlying *net.UnixConn via socket.UnixConnFromContext (wired through
 	// http.Server.ConnContext), so SendWithDeadline enforces the deadline at
 	// the kernel I/O layer with no orphan goroutine. Unit tests that bypass
@@ -468,7 +468,7 @@ func (h *Handler) scanAndStream( //nolint:gocritic // unnamedResult: three-retur
 	return eventsScanned, decryptFails, nil
 }
 
-// buildStartPayload assembles the audit start payload. INV-F7: both
+// buildStartPayload assembles the audit start payload. INV-CRYPTO-57: both
 // Requested-* (nullable, captures defaulting) and Resolved-* (always
 // populated) MUST be present.
 func (h *Handler) buildStartPayload(
@@ -661,7 +661,7 @@ func terminatedByLabel(t adminv1.ReadFinished_TerminatedBy) string {
 
 // noPlaintextReasonToProto maps the eventbus.NoPlaintextReason enum (Go
 // internal) to the corev1.NoPlaintextReason proto enum. Mirrors the
-// 1:1 mapping enforced by TestINV_F16_NoPlaintextReasonProtoGoParity.
+// 1:1 mapping enforced by TestINV_CRYPTO_66_NoPlaintextReasonProtoGoParity.
 func noPlaintextReasonToProto(r eventbus.NoPlaintextReason) corev1.NoPlaintextReason {
 	switch r {
 	case eventbus.NoPlaintextReasonAuthGuardDeny:

--- a/internal/admin/readstream/handler_test.go
+++ b/internal/admin/readstream/handler_test.go
@@ -199,7 +199,7 @@ func (f *fakeAuditEmitter) firstCompletedCallID() int64 {
 // stubDEKResolver and stubCodecResolver are inert resolvers for handler
 // unit tests that DO NOT reach DecryptRow. The handler tests focus on
 // flows that succeed or fail BEFORE ColdReader.Read is called
-// (INV-F1/F2/F3/F11); the per-row decrypt classifier matrix is exercised
+// (INV-CRYPTO-53/INV-CRYPTO-54/INV-CRYPTO-55/INV-CRYPTO-61); the per-row decrypt classifier matrix is exercised
 // in decrypt_test.go and the scan-and-stream contract in integration
 // tests (R.17-R.19).
 type stubDEKResolver struct{}
@@ -217,7 +217,7 @@ func (stubCodecResolver) Resolve(_ codec.Name) (codec.Codec, error) {
 // stubColdReader replaces *ColdReader in unit tests. It returns the
 // configured rows + err deterministically and records the last query it
 // received so tests can assert that BuildSubjects + ResolveBounds produced
-// the expected SQL inputs (INV-F8 subjects + INV-F6 bounds round-trip).
+// the expected SQL inputs (INV-CRYPTO-58 subjects + INV-CRYPTO-56 bounds round-trip).
 type stubColdReader struct {
 	mu        sync.Mutex
 	rows      []readstream.ColdRow
@@ -324,13 +324,13 @@ func runHandler(t *testing.T, cfg readstream.Config, req *adminv1.AdminReadStrea
 	return stream, runErr
 }
 
-// ---------- INV-F3: capability check precedes audit ----------
+// ---------- INV-CRYPTO-55: capability check precedes audit ----------
 
-// TestINV_F3_CapabilityCheckPrecedesAudit asserts that the capability check
+// TestINV_CRYPTO_55_CapabilityCheckPrecedesAudit asserts that the capability check
 // runs BEFORE EmitStart and BEFORE any frame send. A player without
 // crypto.operator must see DENY_OPERATOR_CAPABILITY, zero frames sent, and
 // EmitStart NEVER called.
-func TestINV_F3_CapabilityCheckPrecedesAudit(t *testing.T) {
+func TestINV_CRYPTO_55_CapabilityCheckPrecedesAudit(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Grants = &fakeGrantsResolver{grants: nil} // no grants
 
@@ -361,15 +361,15 @@ func TestSessionLookupFails(t *testing.T) {
 	assert.Equal(t, 0, stream.Len(), "ZERO frames may be sent on session failure")
 }
 
-// ---------- INV-F2: audit-publish failure refuses to stream ----------
+// ---------- INV-CRYPTO-54: audit-publish failure refuses to stream ----------
 
-// TestINV_F2_AuditPublishFailRefuses asserts that an EmitStart failure
+// TestINV_CRYPTO_54_AuditPublishFailRefuses asserts that an EmitStart failure
 // blocks all data emission: handler returns DENY_AUDIT_PRE_DATA_PUBLISH,
 // ZERO frames are sent (no PendingApproval, no ReadStarted, no Event), and
 // ColdReader.Read is never called. (We assert the latter indirectly: the
 // Config carries a ColdReader whose pool is nil — if Read were called it
 // would panic.)
-func TestINV_F2_AuditPublishFailRefuses(t *testing.T) {
+func TestINV_CRYPTO_54_AuditPublishFailRefuses(t *testing.T) {
 	cfg := newTestConfig()
 	emitter := &fakeAuditEmitter{
 		emitStartErr: oops.Code("EMITTER_PUBLISH_FAILED").Errorf("simulated publish failure"),
@@ -386,9 +386,9 @@ func TestINV_F2_AuditPublishFailRefuses(t *testing.T) {
 	assert.Equal(t, 0, stream.Len(), "ZERO frames may be sent when EmitStart fails")
 }
 
-// ---------- INV-F1: pre-data audit ordering ----------
+// ---------- INV-CRYPTO-53: pre-data audit ordering ----------
 
-// TestINV_F1_PreDataAuditOrdering asserts the canonical ordering for the
+// TestINV_CRYPTO_53_PreDataAuditOrdering asserts the canonical ordering for the
 // non-dual-control happy path with a small row set:
 //
 //	EmitStart → ReadStarted frame → Event frames → ReadFinished frame → EmitCompleted
@@ -397,7 +397,7 @@ func TestINV_F2_AuditPublishFailRefuses(t *testing.T) {
 // resolver is never reached because identity-codec rows pass plaintext
 // through directly. The test asserts the EmitStart call-id precedes EVERY
 // frame send and EmitCompleted call-id follows the LAST frame send.
-func TestINV_F1_PreDataAuditOrdering(t *testing.T) {
+func TestINV_CRYPTO_53_PreDataAuditOrdering(t *testing.T) {
 	cfg := newTestConfig()
 	emitter := &fakeAuditEmitter{}
 	cfg.AuditEmitter = emitter
@@ -434,14 +434,14 @@ func TestINV_F1_PreDataAuditOrdering(t *testing.T) {
 	assert.Equal(t, 1, cold.CallCount(), "ColdReader.Read must be called exactly once")
 }
 
-// ---------- INV-F10: completion audit failure does not raise ----------
+// ---------- INV-CRYPTO-60: completion audit failure does not raise ----------
 
-// TestINV_F10_CompletionAuditFailureNotRaised asserts that when
+// TestINV_CRYPTO_60_CompletionAuditFailureNotRaised asserts that when
 // EmitCompleted fails after a clean scan-and-stream run, the failure is
 // logged + metric-counted but NEVER raised back to the operator. The
 // outer handler return value reflects only stream-level errors (which is
 // nil on the happy path used here).
-func TestINV_F10_CompletionAuditFailureNotRaised(t *testing.T) {
+func TestINV_CRYPTO_60_CompletionAuditFailureNotRaised(t *testing.T) {
 	cfg := newTestConfig()
 	completedErr := oops.Code("COMPLETION_PUBLISH_FAILED").Errorf("simulated completion failure")
 	emitter := &fakeAuditEmitter{emitCompletedErr: completedErr}
@@ -453,22 +453,22 @@ func TestINV_F10_CompletionAuditFailureNotRaised(t *testing.T) {
 	after := testutil.ToFloat64(readstream.CompletedAuditFailuresTotal)
 
 	require.NoError(t, err,
-		"handler MUST NOT raise on EmitCompleted failure — return value reflects stream-level errors only (INV-F10)")
+		"handler MUST NOT raise on EmitCompleted failure — return value reflects stream-level errors only (INV-CRYPTO-60)")
 	require.NotErrorIs(t, err, completedErr,
-		"handler MUST NOT return the EmitCompleted error to the operator (INV-F10)")
+		"handler MUST NOT return the EmitCompleted error to the operator (INV-CRYPTO-60)")
 	assert.Equal(t, 1, emitter.CompletedCalls(),
 		"EmitCompleted must be attempted exactly once (best-effort)")
 	assert.Greater(t, after, before,
-		"CompletedAuditFailuresTotal must increment on completion-audit failure (INV-F10)")
+		"CompletedAuditFailuresTotal must increment on completion-audit failure (INV-CRYPTO-60)")
 }
 
-// ---------- INV-F11: dual-control flow ----------
+// ---------- INV-CRYPTO-61: dual-control flow ----------
 
-// TestINV_F11_DualControlBlocksUntilApproval asserts the Open + Wait path:
+// TestINV_CRYPTO_61_DualControlBlocksUntilApproval asserts the Open + Wait path:
 // when no fresh approved row exists, the handler opens a new approval row,
 // emits the PendingApproval frame, waits for approval, then proceeds with
 // EmitStart and ReadStarted.
-func TestINV_F11_DualControlBlocksUntilApproval(t *testing.T) {
+func TestINV_CRYPTO_61_DualControlBlocksUntilApproval(t *testing.T) {
 	cfg := newTestConfig()
 	approverULID := otherPlayerULID
 	openedID := approval.RequestID(ulid.MustParse("01HZB000000000000000000000"))
@@ -509,11 +509,11 @@ func TestINV_F11_DualControlBlocksUntilApproval(t *testing.T) {
 	assert.True(t, isStarted, "second frame MUST be ReadStarted; got %T", frames[1].GetPayload())
 }
 
-// TestINV_F11_DualControlIdempotentReuse asserts the reuse path: when
+// TestINV_CRYPTO_61_DualControlIdempotentReuse asserts the reuse path: when
 // GetByOpArgsHash returns a fresh approved row, NO PendingApproval frame is
 // sent, Open + WaitForApproval are NEVER called, and the handler proceeds
 // directly to EmitStart.
-func TestINV_F11_DualControlIdempotentReuse(t *testing.T) {
+func TestINV_CRYPTO_61_DualControlIdempotentReuse(t *testing.T) {
 	cfg := newTestConfig()
 	approverULID := otherPlayerULID
 	reusedID := approval.RequestID(ulid.MustParse("01HZB000000000000000000001"))
@@ -636,15 +636,15 @@ func TestDualControlNonDeadlineError_EmitsFinishedAndReturnsWrappedErr(t *testin
 		"TerminatedBy must be SERVER_ERROR for non-deadline dual-control failures")
 }
 
-// ---------- INV-F15: cold-tier filters on dek_ref IS NOT NULL ----------
+// ---------- INV-CRYPTO-65: cold-tier filters on dek_ref IS NOT NULL ----------
 
-// TestINV_F15_ColdReaderFiltersByDekRefNotNull asserts that the cold-tier
+// TestINV_CRYPTO_65_ColdReaderFiltersByDekRefNotNull asserts that the cold-tier
 // reader's SQL filters by dek_ref IS NOT NULL — i.e., identity-codec rows
 // (cleartext) are excluded from break-glass reads. The handler delegates
 // to ColdReader.Read; this test verifies the contract at the reader level
 // where the SQL is built. The handler tests above use a stub ColdReader to
 // keep the handler-flow tests independent of the SQL details.
-func TestINV_F15_ColdReaderFiltersByDekRefNotNull(t *testing.T) {
+func TestINV_CRYPTO_65_ColdReaderFiltersByDekRefNotNull(t *testing.T) {
 	r := readstream.NewColdReader(nil)
 	sql, _, err := r.BuildSQLForTest(readstream.ColdQuery{
 		Subjects: []eventbus.Subject{"events.g1.scene.01H.>"},
@@ -653,7 +653,7 @@ func TestINV_F15_ColdReaderFiltersByDekRefNotNull(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, sql, "dek_ref IS NOT NULL",
-		"cold-tier SQL must filter by dek_ref IS NOT NULL (INV-F15)")
+		"cold-tier SQL must filter by dek_ref IS NOT NULL (INV-CRYPTO-65)")
 }
 
 // TestHandler_ColdReaderQueryWiring asserts the handler passes
@@ -680,7 +680,7 @@ func TestHandler_ColdReaderQueryWiring(t *testing.T) {
 		"Until must round-trip from the proto request")
 }
 
-// ---------- Typed redaction assertion (INV-F12) ----------
+// ---------- Typed redaction assertion (INV-CRYPTO-62) ----------
 
 // TestEventFrameCarriesTypedRedaction asserts the metadata-only frame
 // builder produces an EventFrame with metadata_only=true and a typed

--- a/internal/admin/readstream/handler_test_support.go
+++ b/internal/admin/readstream/handler_test_support.go
@@ -4,7 +4,7 @@
 // handler_test_support.go exposes a narrow test-support API to callers
 // outside the readstream package — specifically, E2E tests in
 // cmd/holomush that need to drive Handler.handleInternal with an
-// injected StreamSender (e.g. to inject a per-frame sleep for INV-F14
+// injected StreamSender (e.g. to inject a per-frame sleep for INV-CRYPTO-64
 // write-deadline tests, or to drive idempotent dual-control reuse with
 // a non-UDS session adapter).
 //

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,24 +93,24 @@ type CryptoConfig struct {
 	RekeyCheckpointSweepInterval time.Duration `koanf:"rekey_checkpoint_sweep_interval"`
 
 	// OperatorReadDefaultWindow is the size of since-defaulted AdminReadStream
-	// reads (INV-F6 / spec §6). Defaults to 1h via Defaults() when unset/zero.
+	// reads (INV-CRYPTO-56 / spec §6). Defaults to 1h via Defaults() when unset/zero.
 	// Sub-epic F R.14 (holomush-jxo8.8.38).
 	OperatorReadDefaultWindow time.Duration `koanf:"operator_read_default_window"`
 
 	// OperatorReadMaxWindow caps the (until - since) span on AdminReadStream
-	// requests (INV-F6). Defaults to 30d via Defaults() when unset/zero.
+	// requests (INV-CRYPTO-56). Defaults to 30d via Defaults() when unset/zero.
 	// Operators configuring values >90d trigger a WARN at boot — the cap
 	// remains in force but oversized windows greatly inflate row-count and
 	// memory pressure on the cold-tier reader.
 	OperatorReadMaxWindow time.Duration `koanf:"operator_read_max_window"`
 
 	// OperatorReadWriteDeadline is the per-frame send deadline on the
-	// AdminReadStream server stream (INV-F14). Defaults to 30s via Defaults()
+	// AdminReadStream server stream (INV-CRYPTO-64). Defaults to 30s via Defaults()
 	// when unset/zero.
 	OperatorReadWriteDeadline time.Duration `koanf:"operator_read_write_deadline"`
 
 	// OperatorReadApprovalTTL is the dual-control wait budget on AdminReadStream
-	// (INV-F11). Defaults to 5m via Defaults() when unset/zero.
+	// (INV-CRYPTO-61). Defaults to 5m via Defaults() when unset/zero.
 	OperatorReadApprovalTTL time.Duration `koanf:"operator_read_approval_ttl"`
 }
 
@@ -124,19 +124,19 @@ const DefaultRekeyCheckpointTTL = 24 * time.Hour
 const DefaultRekeyCheckpointSweepInterval = 1 * time.Hour
 
 // DefaultOperatorReadDefaultWindow is the default since-defaulted window for
-// AdminReadStream reads (INV-F6). Sub-epic F R.14 (holomush-jxo8.8.38).
+// AdminReadStream reads (INV-CRYPTO-56). Sub-epic F R.14 (holomush-jxo8.8.38).
 const DefaultOperatorReadDefaultWindow = 1 * time.Hour
 
 // DefaultOperatorReadMaxWindow caps the (until - since) span on
-// AdminReadStream reads (INV-F6). Sub-epic F R.14.
+// AdminReadStream reads (INV-CRYPTO-56). Sub-epic F R.14.
 const DefaultOperatorReadMaxWindow = 30 * 24 * time.Hour
 
 // DefaultOperatorReadWriteDeadline is the per-frame send deadline on the
-// AdminReadStream server stream (INV-F14). Sub-epic F R.14.
+// AdminReadStream server stream (INV-CRYPTO-64). Sub-epic F R.14.
 const DefaultOperatorReadWriteDeadline = 30 * time.Second
 
 // DefaultOperatorReadApprovalTTL is the default dual-control wait budget on
-// AdminReadStream (INV-F11). Sub-epic F R.14.
+// AdminReadStream (INV-CRYPTO-61). Sub-epic F R.14.
 const DefaultOperatorReadApprovalTTL = 5 * time.Minute
 
 // Defaults returns a copy of c with the zero-valued fields populated from

--- a/internal/core/builtins.go
+++ b/internal/core/builtins.go
@@ -95,7 +95,7 @@ func registerBuiltinTypes(r *VerbRegistry, hostVersion string) error {
 		// F's AdminReadStream handler at stream-start and stream-end respectively.
 		// AUDIT_ONLY: gRPC Subscribe drops before delivery; audit projection
 		// persists to events_audit. Registered here so RenderingPublisher does
-		// not reject with EMIT_UNKNOWN_VERB (INV-F13).
+		// not reject with EMIT_UNKNOWN_VERB (INV-CRYPTO-63).
 		{Type: "crypto.system.operator_read", Category: "system", Format: "audit", DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_AUDIT_ONLY, Source: "builtin"},
 		{Type: "crypto.system.operator_read_completed", Category: "system", Format: "audit", DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_AUDIT_ONLY, Source: "builtin"},
 		// Phase 7 PluginDowngradeFence violation audit (host-emit, persistence-only).

--- a/internal/core/builtins_operator_read_test.go
+++ b/internal/core/builtins_operator_read_test.go
@@ -14,12 +14,12 @@ import (
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 )
 
-// TestINV_F13_BuiltinEventTypesRegistered asserts that
+// TestINV_CRYPTO_63_BuiltinEventTypesRegistered asserts that
 // crypto.system.operator_read and crypto.system.operator_read_completed are
-// registered with the correct field values by registerBuiltinTypes (INV-F13).
+// registered with the correct field values by registerBuiltinTypes (INV-CRYPTO-63).
 // Both types MUST have Category="system", Format="audit",
 // DisplayTarget=EVENT_CHANNEL_AUDIT_ONLY, Source="builtin".
-func TestINV_F13_BuiltinEventTypesRegistered(t *testing.T) {
+func TestINV_CRYPTO_63_BuiltinEventTypesRegistered(t *testing.T) {
 	r := NewVerbRegistry()
 	require.NoError(t, registerBuiltinTypes(r, "test"))
 
@@ -44,13 +44,13 @@ func TestINV_F13_BuiltinEventTypesRegistered(t *testing.T) {
 }
 
 // TestBuiltinRekeyRowUnchanged is a golden-test assertion that the existing
-// crypto.system.rekey registration is not disturbed by the INV-F13 additions.
+// crypto.system.rekey registration is not disturbed by the INV-CRYPTO-63 additions.
 func TestBuiltinRekeyRowUnchanged(t *testing.T) {
 	r := NewVerbRegistry()
 	require.NoError(t, registerBuiltinTypes(r, "test"))
 
 	reg, ok := r.Lookup("crypto.system.rekey")
-	require.True(t, ok, "crypto.system.rekey must still be registered after INV-F13 additions")
+	require.True(t, ok, "crypto.system.rekey must still be registered after INV-CRYPTO-63 additions")
 	assert.Equal(t, "system", reg.Category)
 	assert.Equal(t, "audit", reg.Format)
 	assert.Equal(t, corev1.EventChannel_EVENT_CHANNEL_AUDIT_ONLY, reg.DisplayTarget)

--- a/internal/eventbus/history/phase7_boundary_meta_test.go
+++ b/internal/eventbus/history/phase7_boundary_meta_test.go
@@ -22,7 +22,7 @@ import (
 // TestPhase7InvariantsHaveNamedTests is the drift detector for the
 // invariants table in
 // docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md
-// §2. For each Phase-7 §2 invariant (the legacy INV-P7-1..16 set, migrated to
+// §2. For each Phase-7 §2 invariant (the legacy INV-P7 set, numbers 1..16, migrated to
 // INV-CRYPTO-* for the crypto half and INV-EVENTBUS-25/26/27 for the
 // audit-plumbing half per holomush-hz0v4.14.15) plus the two plan-internal
 // substrate keys (INV-CRYPTO-43, INV-CRYPTO-52), the test verifies the named

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -45,7 +45,7 @@ const (
 	NoPlaintextReasonAuditQueueFull NoPlaintextReason = 3
 	// NoPlaintextReasonDEKMissing indicates the cold-tier audit row has no
 	// dek_ref (DEK reference column missing or NULL). Stamped exclusively by
-	// F's operator-read classifier (INV-F16).
+	// F's operator-read classifier (INV-CRYPTO-66).
 	NoPlaintextReasonDEKMissing NoPlaintextReason = 4
 	// NoPlaintextReasonDEKBadColumns indicates the cold-tier audit row
 	// references a DEK whose column set does not match the event's AAD

--- a/internal/eventbus/types_proto_sync_test.go
+++ b/internal/eventbus/types_proto_sync_test.go
@@ -97,11 +97,11 @@ func TestNoPlaintextReasonEnumParity(t *testing.T) {
 	}
 }
 
-// TestINV_F16_NoPlaintextReasonProtoGoParity is the INV-F16 parity test for
+// TestINV_CRYPTO_66_NoPlaintextReasonProtoGoParity is the INV-CRYPTO-66 parity test for
 // the 4→7 expansion. Asserts all 7 values have matching proto-Go pairs in both
 // directions. This is an alias for the extended TestNoPlaintextReasonEnumParity
 // kept separately so the invariant name appears in test output.
-func TestINV_F16_NoPlaintextReasonProtoGoParity(t *testing.T) {
+func TestINV_CRYPTO_66_NoPlaintextReasonProtoGoParity(t *testing.T) {
 	cases := []struct {
 		name     string
 		goVal    eventbus.NoPlaintextReason
@@ -125,16 +125,16 @@ func TestINV_F16_NoPlaintextReasonProtoGoParity(t *testing.T) {
 	}
 }
 
-// TestINV_F16_HotColdStampersDoNotEmitNewValues asserts that the three new
+// TestINV_CRYPTO_66_HotColdStampersDoNotEmitNewValues asserts that the three new
 // NoPlaintextReason values (DEK_MISSING, DEK_BAD_COLUMNS, INTERNAL) are NOT
 // referenced in the hot/cold tier stampers or subscriber. These values MUST be
-// stamped exclusively by F's operator-read classifier (INV-F16).
+// stamped exclusively by F's operator-read classifier (INV-CRYPTO-66).
 //
 // This is a static-analysis-style test: it reads the source files and fails if
 // any of the new constant names appear. Because Go source is text, even a
 // comment mentioning the constant would flag — intentional, since comments are
 // also specifications.
-func TestINV_F16_HotColdStampersDoNotEmitNewValues(t *testing.T) {
+func TestINV_CRYPTO_66_HotColdStampersDoNotEmitNewValues(t *testing.T) {
 	// Resolve absolute paths via runtime.Caller so the test is stable
 	// regardless of the working directory when invoked.
 	_, thisFile, _, ok := runtime.Caller(0)
@@ -164,7 +164,7 @@ func TestINV_F16_HotColdStampersDoNotEmitNewValues(t *testing.T) {
 			for _, name := range forbidden {
 				assert.NotContains(t, src, name,
 					"hot/cold stamper %s MUST NOT reference new NoPlaintextReason value %s; "+
-						"only F's classifier produces these (INV-F16)", relPath, name)
+						"only F's classifier produces these (INV-CRYPTO-66)", relPath, name)
 			}
 		})
 	}

--- a/pkg/proto/holomush/admin/v1/admin_grpc.pb.go
+++ b/pkg/proto/holomush/admin/v1/admin_grpc.pb.go
@@ -118,7 +118,7 @@ type AdminServiceClient interface {
 	// typed metadata_only and no_plaintext_reason redaction fields for
 	// destroyed-DEK and plaintext-suppressed events. When dual_control is set
 	// in the request, the handler blocks until a second operator approves via
-	// the admin_approvals table before emitting any event frames (INV-F11/F17).
+	// the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
 	// Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
 	AdminReadStream(ctx context.Context, in *AdminReadStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AdminReadStreamResponse], error)
 }
@@ -351,7 +351,7 @@ type AdminServiceServer interface {
 	// typed metadata_only and no_plaintext_reason redaction fields for
 	// destroyed-DEK and plaintext-suppressed events. When dual_control is set
 	// in the request, the handler blocks until a second operator approves via
-	// the admin_approvals table before emitting any event frames (INV-F11/F17).
+	// the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
 	// Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
 	AdminReadStream(*AdminReadStreamRequest, grpc.ServerStreamingServer[AdminReadStreamResponse]) error
 	mustEmbedUnimplementedAdminServiceServer()

--- a/pkg/proto/holomush/admin/v1/adminv1connect/admin.connect.go
+++ b/pkg/proto/holomush/admin/v1/adminv1connect/admin.connect.go
@@ -138,7 +138,7 @@ type AdminServiceClient interface {
 	// typed metadata_only and no_plaintext_reason redaction fields for
 	// destroyed-DEK and plaintext-suppressed events. When dual_control is set
 	// in the request, the handler blocks until a second operator approves via
-	// the admin_approvals table before emitting any event frames (INV-F11/F17).
+	// the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
 	// Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
 	AdminReadStream(context.Context, *connect.Request[v1.AdminReadStreamRequest]) (*connect.ServerStreamForClient[v1.AdminReadStreamResponse], error)
 }
@@ -357,7 +357,7 @@ type AdminServiceHandler interface {
 	// typed metadata_only and no_plaintext_reason redaction fields for
 	// destroyed-DEK and plaintext-suppressed events. When dual_control is set
 	// in the request, the handler blocks until a second operator approves via
-	// the admin_approvals table before emitting any event frames (INV-F11/F17).
+	// the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
 	// Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
 	AdminReadStream(context.Context, *connect.Request[v1.AdminReadStreamRequest], *connect.ServerStream[v1.AdminReadStreamResponse]) error
 }

--- a/pkg/proto/holomush/admin/v1/read_stream.pb.go
+++ b/pkg/proto/holomush/admin/v1/read_stream.pb.go
@@ -45,19 +45,19 @@ const (
 	ReadFinished_TERMINATED_BY_CLIENT_DISCONNECT ReadFinished_TerminatedBy = 2
 	// TERMINATED_BY_DEADLINE_EXCEEDED indicates either the request context
 	// deadline was exceeded (context.DeadlineExceeded) or a per-frame write
-	// deadline fired (ErrWriteDeadlineExceeded, INV-F14) during streaming.
+	// deadline fired (ErrWriteDeadlineExceeded, INV-CRYPTO-64) during streaming.
 	ReadFinished_TERMINATED_BY_DEADLINE_EXCEEDED ReadFinished_TerminatedBy = 3
 	// TERMINATED_BY_SERVER_ERROR indicates an unexpected server-side failure
 	// (cold-reader error, codec failure, or other unclassified error). Mapped
 	// by the classifyTerminator catch-all branch.
 	ReadFinished_TERMINATED_BY_SERVER_ERROR ReadFinished_TerminatedBy = 4
 	// TERMINATED_BY_DUAL_CONTROL_TIMEOUT indicates the ApprovalTTL elapsed
-	// before a second operator approved the request (INV-F11/F17). Mapped
+	// before a second operator approved the request (INV-CRYPTO-61/INV-CRYPTO-67). Mapped
 	// from READSTREAM_DUAL_CONTROL_TIMEOUT oops code.
 	ReadFinished_TERMINATED_BY_DUAL_CONTROL_TIMEOUT ReadFinished_TerminatedBy = 5
 	// TERMINATED_BY_AUDIT_EMIT_FAILURE indicates the pre-data audit publish
 	// (EmitStart) failed before any event data was read or sent. Mapped from
-	// DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-F2). No event data was
+	// DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-CRYPTO-54). No event data was
 	// delivered when this value appears.
 	ReadFinished_TERMINATED_BY_AUDIT_EMIT_FAILURE ReadFinished_TerminatedBy = 6
 )
@@ -125,7 +125,7 @@ type AdminReadStreamRequest struct {
 	// session_token is the bearer token identifying the operator. The handler
 	// resolves it to an OperatorSession via SessionStore.GetOperatorSession and
 	// then checks that the resolved player holds the crypto.operator ABAC grant
-	// (INV-F3) before any data read or audit publish occurs.
+	// (INV-CRYPTO-55) before any data read or audit publish occurs.
 	SessionToken string `protobuf:"bytes,1,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
 	// subject_pattern is an optional additional NATS subject filter applied
 	// server-side on top of the context-derived subjects. An empty string means
@@ -142,11 +142,11 @@ type AdminReadStreamRequest struct {
 	// ResolveBounds validates type, arity, and ID format per sensitiveTypes.
 	Context []*ContextRef `protobuf:"bytes,4,rep,name=context,proto3" json:"context,omitempty"`
 	// since is the inclusive lower bound of the query window. When absent (nil),
-	// the server defaults to now minus the configured DefaultWindow (INV-F6).
+	// the server defaults to now minus the configured DefaultWindow (INV-CRYPTO-56).
 	// ResolveBounds rejects since >= until with DENY_OPERATOR_READ_TIME_INVERTED.
 	Since *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=since,proto3" json:"since,omitempty"`
 	// until is the exclusive upper bound of the query window. When absent (nil),
-	// the server defaults to now (INV-F6). ResolveBounds rejects until more than
+	// the server defaults to now (INV-CRYPTO-56). ResolveBounds rejects until more than
 	// 5 seconds in the future with DENY_OPERATOR_READ_FUTURE_BOUND.
 	Until *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=until,proto3" json:"until,omitempty"`
 	// limit caps the maximum number of EventFrame responses the client wants to
@@ -156,7 +156,7 @@ type AdminReadStreamRequest struct {
 	// dual_control requires a second operator to approve the request before the
 	// stream begins. When true, the server sends a PendingApproval frame and
 	// blocks until approval.Repo.WaitForApproval resolves or the ApprovalTTL
-	// elapses (INV-F11/F17). When false, the fast single-control path runs
+	// elapses (INV-CRYPTO-61/INV-CRYPTO-67). When false, the fast single-control path runs
 	// immediately after the capability check.
 	DualControl bool `protobuf:"varint,8,opt,name=dual_control,json=dualControl,proto3" json:"dual_control,omitempty"`
 	// dual_control_timeout_seconds overrides the server's configured ApprovalTTL
@@ -165,7 +165,7 @@ type AdminReadStreamRequest struct {
 	// justification is the operator's plain-text reason for the read. REQUIRED:
 	// ResolveBounds rejects empty or whitespace-only values with
 	// DENY_OPERATOR_READ_JUSTIFICATION_EMPTY. Maximum 4096 UTF-8 bytes.
-	// Captured verbatim in the pre-data audit payload (INV-F1/F7).
+	// Captured verbatim in the pre-data audit payload (INV-CRYPTO-53/INV-CRYPTO-57).
 	Justification string `protobuf:"bytes,10,opt,name=justification,proto3" json:"justification,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -347,8 +347,8 @@ func (x *ContextRef) GetIds() []string {
 // zero or more EventFrame frames, and exactly one ReadFinished frame as the
 // terminal message. The handler (internal/admin/readstream/handler.go
 // handleInternal) enforces the audit invariants: the pre-data audit is emitted
-// before the first frame (INV-F1/F2) and the post-data audit is emitted after
-// the final frame (INV-F10).
+// before the first frame (INV-CRYPTO-53/INV-CRYPTO-54) and the post-data audit is emitted after
+// the final frame (INV-CRYPTO-60).
 type AdminReadStreamResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payload carries the frame for this response message. Exactly one variant

--- a/pkg/proto/holomush/core/v1/core.pb.go
+++ b/pkg/proto/holomush/core/v1/core.pb.go
@@ -56,7 +56,7 @@ const (
 	NoPlaintextReason_NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL NoPlaintextReason = 3
 	// NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref
 	// (DEK reference column missing or NULL). Stamped exclusively by sub-epic F's
-	// operator-read classifier (INV-F16).
+	// operator-read classifier (INV-CRYPTO-66).
 	NoPlaintextReason_NO_PLAINTEXT_REASON_DEK_MISSING NoPlaintextReason = 4
 	// NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS means a cold-tier audit row references a
 	// DEK whose column set does not match the event's AAD declaration. Stamped

--- a/site/src/content/docs/reference/grpc-api.md
+++ b/site/src/content/docs/reference/grpc-api.md
@@ -1388,7 +1388,7 @@ counterpart here.
 | NO_PLAINTEXT_REASON_AUTHGUARD_DENY | 1 | NO_PLAINTEXT_REASON_AUTHGUARD_DENY means the recipient was not in the DEK&#39;s participant set or lacked the requisite plugin manifest declaration / ABAC grant. Phase 3b AuthGuard deny. |
 | NO_PLAINTEXT_REASON_STALE_DEK | 2 | NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were indecipherable — a production-real outcome after a sub-epic E rekey plus DEK destruction (INV-E21 double miss). |
 | NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL | 3 | NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL means a plugin audit-emit hit backpressure (queue full) — a host-side TOCTOU defense. |
-| NO_PLAINTEXT_REASON_DEK_MISSING | 4 | NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref (DEK reference column missing or NULL). Stamped exclusively by sub-epic F&#39;s operator-read classifier (INV-F16). |
+| NO_PLAINTEXT_REASON_DEK_MISSING | 4 | NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref (DEK reference column missing or NULL). Stamped exclusively by sub-epic F&#39;s operator-read classifier (INV-CRYPTO-66). |
 | NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS | 5 | NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS means a cold-tier audit row references a DEK whose column set does not match the event&#39;s AAD declaration. Stamped exclusively by sub-epic F&#39;s classifier. |
 | NO_PLAINTEXT_REASON_INTERNAL | 6 | NO_PLAINTEXT_REASON_INTERNAL is the catch-all for unexpected decrypt failures not covered by the specific cases above. Stamped exclusively by sub-epic F&#39;s classifier. |
 | NO_PLAINTEXT_REASON_DOWNGRADE_REFUSED | 7 | NO_PLAINTEXT_REASON_DOWNGRADE_REFUSED is a Phase 7 PluginDowngradeFence layer (1) refusal — the host&#39;s read-side fence rejected the row before decrypt, either because the type is in the always-sensitive manifest set and the plugin returned an identity codec (INV-CRYPTO-42), or because the dek_ref is unknown / absent for a non-identity codec (INV-CRYPTO-50). The original event_id is preserved; payload is empty per master INV-26. |
@@ -1489,16 +1489,16 @@ DENY_OPERATOR_READ_JUSTIFICATION_EMPTY when it is absent or whitespace-only.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| session_token | [string](#string) |  | session_token is the bearer token identifying the operator. The handler resolves it to an OperatorSession via SessionStore.GetOperatorSession and then checks that the resolved player holds the crypto.operator ABAC grant (INV-F3) before any data read or audit publish occurs. |
+| session_token | [string](#string) |  | session_token is the bearer token identifying the operator. The handler resolves it to an OperatorSession via SessionStore.GetOperatorSession and then checks that the resolved player holds the crypto.operator ABAC grant (INV-CRYPTO-55) before any data read or audit publish occurs. |
 | subject_pattern | [string](#string) |  | subject_pattern is an optional additional NATS subject filter applied server-side on top of the context-derived subjects. An empty string means no additional filter; the handler uses the context-derived subjects alone. |
 | type_filter | [string](#string) |  | type_filter is an optional event type prefix filter. When non-empty, only events whose type string has this prefix are returned. An empty string means no type filtering. |
 | context | [ContextRef](#holomush-admin-v1-ContextRef) | repeated | context scopes the read to one or more event streams. Each entry maps to a NATS wildcard subject &#34;events.&lt;game&gt;.&lt;type&gt;.&lt;id...&gt;.&gt;&#34; via BuildSubjects (internal/admin/readstream/subjects.go). When empty, a single game-wide wildcard &#34;events.&lt;game&gt;.&gt;&#34; is used. Up to 64 context entries are accepted; ResolveBounds validates type, arity, and ID format per sensitiveTypes. |
-| since | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | since is the inclusive lower bound of the query window. When absent (nil), the server defaults to now minus the configured DefaultWindow (INV-F6). ResolveBounds rejects since &gt;= until with DENY_OPERATOR_READ_TIME_INVERTED. |
-| until | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | until is the exclusive upper bound of the query window. When absent (nil), the server defaults to now (INV-F6). ResolveBounds rejects until more than 5 seconds in the future with DENY_OPERATOR_READ_FUTURE_BOUND. |
+| since | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | since is the inclusive lower bound of the query window. When absent (nil), the server defaults to now minus the configured DefaultWindow (INV-CRYPTO-56). ResolveBounds rejects since &gt;= until with DENY_OPERATOR_READ_TIME_INVERTED. |
+| until | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | until is the exclusive upper bound of the query window. When absent (nil), the server defaults to now (INV-CRYPTO-56). ResolveBounds rejects until more than 5 seconds in the future with DENY_OPERATOR_READ_FUTURE_BOUND. |
 | limit | [uint32](#uint32) |  | limit caps the maximum number of EventFrame responses the client wants to receive. A value of 0 means no client-imposed limit; the server enforces its own window-size ceiling independently via MaxWindow. |
-| dual_control | [bool](#bool) |  | dual_control requires a second operator to approve the request before the stream begins. When true, the server sends a PendingApproval frame and blocks until approval.Repo.WaitForApproval resolves or the ApprovalTTL elapses (INV-F11/F17). When false, the fast single-control path runs immediately after the capability check. |
+| dual_control | [bool](#bool) |  | dual_control requires a second operator to approve the request before the stream begins. When true, the server sends a PendingApproval frame and blocks until approval.Repo.WaitForApproval resolves or the ApprovalTTL elapses (INV-CRYPTO-61/INV-CRYPTO-67). When false, the fast single-control path runs immediately after the capability check. |
 | dual_control_timeout_seconds | [uint32](#uint32) |  | dual_control_timeout_seconds overrides the server&#39;s configured ApprovalTTL for this request. A value of 0 uses the server&#39;s default. |
-| justification | [string](#string) |  | justification is the operator&#39;s plain-text reason for the read. REQUIRED: ResolveBounds rejects empty or whitespace-only values with DENY_OPERATOR_READ_JUSTIFICATION_EMPTY. Maximum 4096 UTF-8 bytes. Captured verbatim in the pre-data audit payload (INV-F1/F7). |
+| justification | [string](#string) |  | justification is the operator&#39;s plain-text reason for the read. REQUIRED: ResolveBounds rejects empty or whitespace-only values with DENY_OPERATOR_READ_JUSTIFICATION_EMPTY. Maximum 4096 UTF-8 bytes. Captured verbatim in the pre-data audit payload (INV-CRYPTO-53/INV-CRYPTO-57). |
 
 
 
@@ -1515,8 +1515,8 @@ when dual_control=true), exactly one ReadStarted frame once streaming begins,
 zero or more EventFrame frames, and exactly one ReadFinished frame as the
 terminal message. The handler (internal/admin/readstream/handler.go
 handleInternal) enforces the audit invariants: the pre-data audit is emitted
-before the first frame (INV-F1/F2) and the post-data audit is emitted after
-the final frame (INV-F10).
+before the first frame (INV-CRYPTO-53/INV-CRYPTO-54) and the post-data audit is emitted after
+the final frame (INV-CRYPTO-60).
 
 
 | Field | Type | Label | Description |
@@ -1639,10 +1639,10 @@ terminatedByLabel.
 | TERMINATED_BY_UNSPECIFIED | 0 | TERMINATED_BY_UNSPECIFIED is the zero/default value; not used in production — classifyTerminator always resolves to a specific variant. |
 | TERMINATED_BY_CLIENT_EOF | 1 | TERMINATED_BY_CLIENT_EOF indicates the cold-tier scan finished cleanly with no error (streamErr == nil). All requested events were delivered. |
 | TERMINATED_BY_CLIENT_DISCONNECT | 2 | TERMINATED_BY_CLIENT_DISCONNECT indicates the client disconnected mid-stream. Mapped from context.Canceled by classifyTerminator. |
-| TERMINATED_BY_DEADLINE_EXCEEDED | 3 | TERMINATED_BY_DEADLINE_EXCEEDED indicates either the request context deadline was exceeded (context.DeadlineExceeded) or a per-frame write deadline fired (ErrWriteDeadlineExceeded, INV-F14) during streaming. |
+| TERMINATED_BY_DEADLINE_EXCEEDED | 3 | TERMINATED_BY_DEADLINE_EXCEEDED indicates either the request context deadline was exceeded (context.DeadlineExceeded) or a per-frame write deadline fired (ErrWriteDeadlineExceeded, INV-CRYPTO-64) during streaming. |
 | TERMINATED_BY_SERVER_ERROR | 4 | TERMINATED_BY_SERVER_ERROR indicates an unexpected server-side failure (cold-reader error, codec failure, or other unclassified error). Mapped by the classifyTerminator catch-all branch. |
-| TERMINATED_BY_DUAL_CONTROL_TIMEOUT | 5 | TERMINATED_BY_DUAL_CONTROL_TIMEOUT indicates the ApprovalTTL elapsed before a second operator approved the request (INV-F11/F17). Mapped from READSTREAM_DUAL_CONTROL_TIMEOUT oops code. |
-| TERMINATED_BY_AUDIT_EMIT_FAILURE | 6 | TERMINATED_BY_AUDIT_EMIT_FAILURE indicates the pre-data audit publish (EmitStart) failed before any event data was read or sent. Mapped from DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-F2). No event data was delivered when this value appears. |
+| TERMINATED_BY_DUAL_CONTROL_TIMEOUT | 5 | TERMINATED_BY_DUAL_CONTROL_TIMEOUT indicates the ApprovalTTL elapsed before a second operator approved the request (INV-CRYPTO-61/INV-CRYPTO-67). Mapped from READSTREAM_DUAL_CONTROL_TIMEOUT oops code. |
+| TERMINATED_BY_AUDIT_EMIT_FAILURE | 6 | TERMINATED_BY_AUDIT_EMIT_FAILURE indicates the pre-data audit publish (EmitStart) failed before any event data was read or sent. Mapped from DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-CRYPTO-54). No event data was delivered when this value appears. |
 
 
  
@@ -2127,7 +2127,7 @@ allowing incremental feature deployment without breaking callers.
 | RekeyAbort | [RekeyAbortRequest](#holomush-admin-v1-RekeyAbortRequest) | [RekeyAbortResponse](#holomush-admin-v1-RekeyAbortResponse) | RekeyAbort cancels an in-progress rekey checkpoint. Requires the crypto.operator capability only; no admin role re-check and no dual-control approval — abort is single-control regardless of site policy (INV-E17). Any crypto.operator session may abort any non-terminal checkpoint, not just the primary operator who started it. Handler: internal/admin/socket/rekey_handler.go. |
 | RekeyStatus | [RekeyStatusRequest](#holomush-admin-v1-RekeyStatusRequest) | [RekeyStatusResponse](#holomush-admin-v1-RekeyStatusResponse) | RekeyStatus returns the current state of a single rekey operation identified by request_id. Requires the crypto.operator capability; no admin role re-check. Reads from the crypto_rekey_checkpoints table via CheckpointStatusReader.GetCheckpoint. Handler: internal/admin/socket/rekey_handler.go. |
 | RekeyList | [RekeyListRequest](#holomush-admin-v1-RekeyListRequest) | [RekeyStatusResponse](#holomush-admin-v1-RekeyStatusResponse) stream | RekeyList streams status records for rekey operations. By default only non-terminal checkpoints are returned; set include_terminal to include completed and aborted rows. Results are capped at 100 rows (any limit above 100 or zero is silently clamped to 100). Requires the crypto.operator capability; no admin role re-check. Handler: internal/admin/socket/rekey_handler.go. |
-| AdminReadStream | [AdminReadStreamRequest](#holomush-admin-v1-AdminReadStreamRequest) | [AdminReadStreamResponse](#holomush-admin-v1-AdminReadStreamResponse) stream | AdminReadStream is the operator break-glass streaming read RPC. Streams EventFrame payloads for the requested context(s) and time bounds, with typed metadata_only and no_plaintext_reason redaction fields for destroyed-DEK and plaintext-suppressed events. When dual_control is set in the request, the handler blocks until a second operator approves via the admin_approvals table before emitting any event frames (INV-F11/F17). Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler). |
+| AdminReadStream | [AdminReadStreamRequest](#holomush-admin-v1-AdminReadStreamRequest) | [AdminReadStreamResponse](#holomush-admin-v1-AdminReadStreamResponse) stream | AdminReadStream is the operator break-glass streaming read RPC. Streams EventFrame payloads for the requested context(s) and time bounds, with typed metadata_only and no_plaintext_reason redaction fields for destroyed-DEK and plaintext-suppressed events. When dual_control is set in the request, the handler blocks until a second operator approves via the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67). Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler). |
 
  
 

--- a/web/src/lib/connect/holomush/admin/v1/admin_connect.ts
+++ b/web/src/lib/connect/holomush/admin/v1/admin_connect.ts
@@ -179,7 +179,7 @@ export const AdminService = {
      * typed metadata_only and no_plaintext_reason redaction fields for
      * destroyed-DEK and plaintext-suppressed events. When dual_control is set
      * in the request, the handler blocks until a second operator approves via
-     * the admin_approvals table before emitting any event frames (INV-F11/F17).
+     * the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
      * Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
      *
      * @generated from rpc holomush.admin.v1.AdminService.AdminReadStream

--- a/web/src/lib/connect/holomush/admin/v1/admin_pb.ts
+++ b/web/src/lib/connect/holomush/admin/v1/admin_pb.ts
@@ -404,7 +404,7 @@ export const AdminService: GenService<{
    * typed metadata_only and no_plaintext_reason redaction fields for
    * destroyed-DEK and plaintext-suppressed events. When dual_control is set
    * in the request, the handler blocks until a second operator approves via
-   * the admin_approvals table before emitting any event frames (INV-F11/F17).
+   * the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67).
    * Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler).
    *
    * @generated from rpc holomush.admin.v1.AdminService.AdminReadStream

--- a/web/src/lib/connect/holomush/admin/v1/read_stream_pb.ts
+++ b/web/src/lib/connect/holomush/admin/v1/read_stream_pb.ts
@@ -37,7 +37,7 @@ export type AdminReadStreamRequest = Message<"holomush.admin.v1.AdminReadStreamR
    * session_token is the bearer token identifying the operator. The handler
    * resolves it to an OperatorSession via SessionStore.GetOperatorSession and
    * then checks that the resolved player holds the crypto.operator ABAC grant
-   * (INV-F3) before any data read or audit publish occurs.
+   * (INV-CRYPTO-55) before any data read or audit publish occurs.
    *
    * @generated from field: string session_token = 1;
    */
@@ -74,7 +74,7 @@ export type AdminReadStreamRequest = Message<"holomush.admin.v1.AdminReadStreamR
 
   /**
    * since is the inclusive lower bound of the query window. When absent (nil),
-   * the server defaults to now minus the configured DefaultWindow (INV-F6).
+   * the server defaults to now minus the configured DefaultWindow (INV-CRYPTO-56).
    * ResolveBounds rejects since >= until with DENY_OPERATOR_READ_TIME_INVERTED.
    *
    * @generated from field: google.protobuf.Timestamp since = 5;
@@ -83,7 +83,7 @@ export type AdminReadStreamRequest = Message<"holomush.admin.v1.AdminReadStreamR
 
   /**
    * until is the exclusive upper bound of the query window. When absent (nil),
-   * the server defaults to now (INV-F6). ResolveBounds rejects until more than
+   * the server defaults to now (INV-CRYPTO-56). ResolveBounds rejects until more than
    * 5 seconds in the future with DENY_OPERATOR_READ_FUTURE_BOUND.
    *
    * @generated from field: google.protobuf.Timestamp until = 6;
@@ -103,7 +103,7 @@ export type AdminReadStreamRequest = Message<"holomush.admin.v1.AdminReadStreamR
    * dual_control requires a second operator to approve the request before the
    * stream begins. When true, the server sends a PendingApproval frame and
    * blocks until approval.Repo.WaitForApproval resolves or the ApprovalTTL
-   * elapses (INV-F11/F17). When false, the fast single-control path runs
+   * elapses (INV-CRYPTO-61/INV-CRYPTO-67). When false, the fast single-control path runs
    * immediately after the capability check.
    *
    * @generated from field: bool dual_control = 8;
@@ -122,7 +122,7 @@ export type AdminReadStreamRequest = Message<"holomush.admin.v1.AdminReadStreamR
    * justification is the operator's plain-text reason for the read. REQUIRED:
    * ResolveBounds rejects empty or whitespace-only values with
    * DENY_OPERATOR_READ_JUSTIFICATION_EMPTY. Maximum 4096 UTF-8 bytes.
-   * Captured verbatim in the pre-data audit payload (INV-F1/F7).
+   * Captured verbatim in the pre-data audit payload (INV-CRYPTO-53/INV-CRYPTO-57).
    *
    * @generated from field: string justification = 10;
    */
@@ -186,8 +186,8 @@ export const ContextRefSchema: GenMessage<ContextRef> = /*@__PURE__*/
  * zero or more EventFrame frames, and exactly one ReadFinished frame as the
  * terminal message. The handler (internal/admin/readstream/handler.go
  * handleInternal) enforces the audit invariants: the pre-data audit is emitted
- * before the first frame (INV-F1/F2) and the post-data audit is emitted after
- * the final frame (INV-F10).
+ * before the first frame (INV-CRYPTO-53/INV-CRYPTO-54) and the post-data audit is emitted after
+ * the final frame (INV-CRYPTO-60).
  *
  * @generated from message holomush.admin.v1.AdminReadStreamResponse
  */
@@ -445,7 +445,7 @@ export enum ReadFinished_TerminatedBy {
   /**
    * TERMINATED_BY_DEADLINE_EXCEEDED indicates either the request context
    * deadline was exceeded (context.DeadlineExceeded) or a per-frame write
-   * deadline fired (ErrWriteDeadlineExceeded, INV-F14) during streaming.
+   * deadline fired (ErrWriteDeadlineExceeded, INV-CRYPTO-64) during streaming.
    *
    * @generated from enum value: TERMINATED_BY_DEADLINE_EXCEEDED = 3;
    */
@@ -462,7 +462,7 @@ export enum ReadFinished_TerminatedBy {
 
   /**
    * TERMINATED_BY_DUAL_CONTROL_TIMEOUT indicates the ApprovalTTL elapsed
-   * before a second operator approved the request (INV-F11/F17). Mapped
+   * before a second operator approved the request (INV-CRYPTO-61/INV-CRYPTO-67). Mapped
    * from READSTREAM_DUAL_CONTROL_TIMEOUT oops code.
    *
    * @generated from enum value: TERMINATED_BY_DUAL_CONTROL_TIMEOUT = 5;
@@ -472,7 +472,7 @@ export enum ReadFinished_TerminatedBy {
   /**
    * TERMINATED_BY_AUDIT_EMIT_FAILURE indicates the pre-data audit publish
    * (EmitStart) failed before any event data was read or sent. Mapped from
-   * DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-F2). No event data was
+   * DENY_AUDIT_PRE_DATA_PUBLISH oops code (INV-CRYPTO-54). No event data was
    * delivered when this value appears.
    *
    * @generated from enum value: TERMINATED_BY_AUDIT_EMIT_FAILURE = 6;

--- a/web/src/lib/connect/holomush/core/v1/core_pb.ts
+++ b/web/src/lib/connect/holomush/core/v1/core_pb.ts
@@ -2120,7 +2120,7 @@ export enum NoPlaintextReason {
   /**
    * NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref
    * (DEK reference column missing or NULL). Stamped exclusively by sub-epic F's
-   * operator-read classifier (INV-F16).
+   * operator-read classifier (INV-CRYPTO-66).
    *
    * @generated from enum value: NO_PLAINTEXT_REASON_DEK_MISSING = 4;
    */


### PR DESCRIPTION
## What

Classification pass **1/2** for the `.14.17` final-verification prerequisite (epic **holomush-hz0v4.14**, bead **holomush-hz0v4.14.23**). Migrates the **INV-F\*** family — Phase-5 sub-epic-F AdminReadStream — to canonical `INV-CRYPTO-53..67` via closed-world `{file,token}` rename. Doc-comment/annotation only; no behavior change.

INV-F is the **operator-read** surface: pre-data-audit-before-plaintext ordering, dual-control approval, audit-chain start↔completed `prev_hash` linkage, NoPlaintextReason classifier matrix, per-frame write deadline, sensitive-only cold-tier filter. `internal/admin/readstream/**` is already a CRYPTO owned_path (master INV-42/43 are INV-CRYPTO); the non-readstream sites (`admin/approval` dual-control, `config` window, `core/builtins` golden test, `eventbus/types` NoPlaintextReason, `cmd/holomush` E2E + wiring, admin+core `.proto` sources) are added as CRYPTO shared_files.

| Token | Domain |
|---|---|
| F1/F2/F3 → 53/54/55 | pre-data audit ordering, audit-publish-fail refusal, capability-precedes-audit |
| F6/F14 → 56/64 | window-too-large, per-frame write deadline |
| F7/F8/F9 → 57/58/59 | start-payload fields, request-id coherence, audit-chain linkage |
| F10/F12 → 60/62 | completion-audit-failure-not-raised, classifier matrix |
| F11/F17 → 61/67 | dual-control gating, GetByOpArgsHash server-side filters |
| F13/F15/F16 → 63/65/66 | builtins AUDIT_ONLY, sensitive-only cold filter, NoPlaintextReason parity |

## Review-driven fixes (both reviewers READY)
- **crypto-reviewer** caught slash-joined compound refs (`INV-F6/F7` → the prefixed-only rewrite left `/F7` dangling). Expanded to full `INV-CRYPTO-56/INV-CRYPTO-57` form. Tool-hardening follow-up bead filed.
- **code-reviewer** caught (and I fixed): 51 residual INV-F refs in 3 `cmd/holomush` E2E/wiring files (my survey missed `cmd/`), 4 dangling test-func cross-refs, and a range-rewrite corruption `INV-P7-1..16 → INV-CRYPTO-38..16` in `phase7_boundary_meta_test.go` (re-running `inv-migrate -scope` re-hit prose added after the .14.15 migrate; reworded to be re-run-safe). Re-review: **READY**, registry integrity confirmed.

Underscore-form test func names + cross-file cites renamed in lockstep to `TestINV_CRYPTO_<canonical>_...`. Proto regen 3 targets; generated diffs comment-token-only.

## Verification
- `inv-migrate` applied (idempotent); zero `INV-F`/`INV_F` remaining (source + generated + cmd/); zero dangling `/F` refs; phase7 re-run-safe.
- Guard + partition + binding + full `./test/meta/` green; 657 touched-package tests + integration-compile (incl `cmd/holomush` E2E) green; `task lint` / `fmt:check` / `build` green.

> **Local pr-prep note:** `generate:ebnf:check` bats self-test needs network (`railroad@latest`); offline-blocked, unrelated to this diff (zero DSL/EBNF files). CI validates.

PR 2/2 (master INV-6/7 fence + INV-S split → PLUGIN/EVENTBUS/SCENE) is `.14.24`; both block `.14.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)