### PR TITLE
refactor(invariants): classify INV-6/7 fence → PLUGIN + INV-S split (holomush-hz0v4.14.24)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -47,55 +47,25 @@
   column in invariants.md/yaml records the link. Encountered: hz0v4.14.11
   (2026-06-02) — READY.
 
-- **Multi-family scope migration (EVENTBUS = GW+ROPS+P7-split) is the same shape
-  as single-family but with three legacy specs feeding one scope, and includes a
-  DENSE-with-letter-suffix renumber (GW-3a) (hz0v4.14.12 READY).** Verify per
-  family: GW 1..16 DENSE over spec set {1,2,3,3a,4,5,6,7,8,9,10,11,13,14,15,16}
-  (16 ids; GW-3a→EB-4 shifts 4..11 by one; GW-12 forward-declared, NOT migrated);
-  ROPS 1..8 → 16+N (offset by GW count); P7 SPLIT — only audit-half P7-3/4/10 →
-  25/26/27, P7-1,2,5-9,11-16 STAY as bare INV-P7-N for later CRYPTO/PLUGIN scopes.
-  Checks that held: (1) `awk` ref/legacy match scans give FALSE mismatches on
-  `3a` (splits at `INV-GW-3`), `refs: []`, and `,}` — hand-read the diff, don't
-  trust awk; (2) the per-family coverage test for GW was
-  `TestAllGatewayRegistryInvariantsHaveTests` living INSIDE
-  `internal/gateway_invariants/meta_test.go` (NOT a separate
-  `i_<old>_coverage_test.go`) — retired correctly, generic
-  `TestInvariantTokenBoundariesRejectFalsePositives` KEPT with documented
-  INV-GW-* regex fixtures (residual GW tokens there are intentional, not
-  unmigrated annotations); (3) global partition: 76 owned paths across all
-  scopes, 0 dup, 0 glob/concrete overlap — other scopes (PRIVACY/PRESENCE) may
-  list an EVENTBUS-owned file in THEIR shared_files (correct: shared = rides on
-  another scope's owned file); (4) generated pb.go/_pb.ts + proto sources must be
-  comment-only — filter `^[+-]` minus `(//|*|/*)` → empty. WATCH FOR: stray
-  trailing-comma edits to a NON-migrated scope's flow-mapping (saw `INV-60",}`
-  added to INV-CLUSTER's last ref) — valid YAML, renderer-inert, but out-of-scope
-  noise in a closed-world diff → Low non-blocking. Encountered: hz0v4.14.12
-  (2026-06-02) — READY.
+- **Multi-family scope (EVENTBUS=GW+ROPS+P7-split) + DENSE letter-suffix renumber
+  (GW-3a) (hz0v4.14.12 READY).** GW 1..16 dense over {1,2,3,3a,4..11,13..16};
+  P7 SPLIT (audit-half P7-3/4/10→25/26/27, rest stay bare for later scopes). `awk`
+  ref/legacy scans FALSE-mismatch on `3a`/`refs:[]`/`,}` — hand-read. Per-family
+  coverage test was `TestAllGatewayRegistryInvariantsHaveTests` in
+  `internal/gateway_invariants/meta_test.go`; generic
+  `TestInvariantTokenBoundariesRejectFalsePositives` KEPT (its INV-GW-* fixtures
+  intentional). Global partition: other scopes may list a foreign-owned file in
+  THEIR shared_files. Trailing-comma `,}` noise recurs — Low non-blocking.
 
-- **Largest multi-family scope migration to date (SCENE = P4+P5+P6+FS(+FW)+Y5INX+SH
-  + phase-8 bare 2/5/6/7 → 59 ids across 6 origin specs, 86 files) follows the
-  established shape; all checks held (hz0v4.14.13 READY).** Reusable patterns: (1)
-  the P4/P5 in-place coverage meta-tests (`inv_p4/p5_coverage_meta_test.go`) are
-  `testName`-EXISTENCE checks (go/parser collects Test* func names; table has
-  `{inv, testName}` rows) — robust to rename so long as the `testName:` strings AND
-  any manually-renamed funcs move in lockstep. Distinct from the FRAGILE
-  `// Verifies:`-annotation scanners (those MUST be deleted on migration, per .14.9).
-  Confirm which kind before deciding delete-vs-migrate-in-place. (2) The retired
-  `scenes_phase6_invariants_test.go` SCANNED for `INV-P6-N` substrings (broke on
-  rename); verify the deleted file defined ONLY locals (`phase6Invariants`,
-  `invP6CitationRE`, `TestPhase6...`) and merely USED shared helpers — `rg` the
-  deleted symbols across `test/meta/` → zero dangling. (3) Manual `\b`-unreachable
-  underscore-form renames: `TestINV_P4_4/5→_SCENE_4/5`,
-  `TestStreamScopeFloor_..._INV_P4_9→_SCENE_9` — grep old names → ZERO, and chase
-  their string refs (coverage table) + cross-file doc-comment cite
-  (`late_joiner_temporal_floor_test.go`). (4) Closed-world with co-located foreign
-  families: `INV-S*` substrate (~48 sites, NOT a scope yet) + `INV-S9`/`INV-S5`
-  must survive UNTOUCHED next to rewritten scene tokens (e.g. `INV-S9 / INV-SCENE-32`);
-  crypto's bare `INV-2/5/6/7` elsewhere untouched (scene rewrite is path-scoped).
-  (5) Same renderer-inert `token: "...",}` trailing-comma noise on an out-of-scope
-  line (here INV-P7-10 in EVENTBUS) recurs — Low non-blocking. spec-only refs:[]
-  count must equal exactly the declared spec-only set (FS-2/6/7 + SH-1..5 = 8).
-  Encountered: hz0v4.14.13 (2026-06-02) — READY.
+- **Largest multi-family (SCENE=P4+P5+P6+FS+Y5INX+SH+phase-8 bare → 59 ids, 86
+  files) (hz0v4.14.13 READY).** P4/P5 coverage meta-tests
+  (`inv_p4/p5_coverage_meta_test.go`) are `testName`-EXISTENCE checks (go/parser
+  Test* names; `{inv,testName}` table) — robust to rename if `testName:` strings +
+  renamed funcs move in lockstep; DISTINCT from fragile `// Verifies:` scanners
+  (delete those, per .14.9). Confirm which kind before delete-vs-migrate-in-place.
+  Manual `\b`-unreachable underscore renames (`TestINV_P4_4→_SCENE_4`): grep old →
+  ZERO + chase string refs + cross-file cites. spec-only `refs:[]` count = declared
+  spec-only set exactly. Same `,}` noise — Low non-blocking.
 
 - **Scope with DEFERRED bare-INV-N + foreign tokens uses file-path owned_paths
   (NOT /** globs) to keep the residual walk clean (hz0v4.14.14 PLUGIN READY).**
@@ -198,3 +168,21 @@
   Mechanical search-replace correct part: 35 diffed files all comment/string/test-func
   swaps, dense 53..67, no executable edits, generated artifacts in sync. The DEFECT
   is what was MISSED, not what was changed. Encountered: hz0v4.14.23 (2026-06-03) — NOT READY.
+
+- **INV-S\* substrate-contract per-token SPLIT across THREE scopes + master-crypto
+  fence (hz0v4.14.24 READY).** S3→PLUGIN-31, S5→PLUGIN-32, S4→EVENTBUS-28,
+  S9→SCENE-60; master fence INV-6→PLUGIN-29, INV-7→PLUGIN-30. Checks that held:
+  (1) tri+-overload: 8 fence files (sensitivity_fence{,_test}.go, event_emitter{,_crypto_test}.go,
+  lua/host.go, pkg/plugin/event.go, integrationtest/crypto.go, plugin.proto) → ZERO bare
+  INV-6/7; foreign INV-6/7 LEFT in web frontend (themeStore/commandListStore/composerChip),
+  CI-tooling (tooling_no_mandatory_int_test.go), reader-opts (cmd/holomush/sub_grpc_test.go),
+  settings (goplugin/host_service.go:610), AND phase-8 board-content SCENE-58/59 legacy
+  (a DIFFERENT INV-6/7 namespace — its legacy column STAYS INV-6/7). (2) S1/S2/S6/S7/S8/S10
+  have ZERO code/manifest refs → split is complete; only S3/S4/S5/S9 were ever code-bound.
+  Remaining INV-S* hits are ONLY docs/roadmap.md + site/docs + ADRs (prose, not annotations) +
+  invariants.yaml legacy/refs.token (FROM-anchor). (3) service.go + store.go genuinely
+  multi-scope → carry BOTH INV-EVENTBUS-28 (S4) AND INV-SCENE-60 (S9): EVENTBUS-shared +
+  SCENE-owned, listed in both. (4) checked cmd/ + api/proto/ (prior-pass blind spots, see
+  .14.23) → clean. Dense: PLUGIN 1..32, EVENTBUS 1..28, SCENE 1..60, no dup/gap. Trailing-comma
+  ,} noise recurred (6th time): added 2 (EVENTBUS-28/SCENE-60 last refs), cleaned 2 — Low
+  non-blocking, renderer-inert. Encountered: hz0v4.14.24 (2026-06-04) — READY.

--- a/api/proto/holomush/plugin/v1/plugin.proto
+++ b/api/proto/holomush/plugin/v1/plugin.proto
@@ -23,7 +23,7 @@ service PluginService {
   // hands the plugin its ServiceConfig (DB connection string, required-service
   // addresses, opaque runtime config) and returns the gRPC service names the
   // plugin provides plus the emit-type set the host validates against the
-  // manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+  // manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
   // which also lazily dials the plugin-host connection for any host-facing
   // facade (sink/focus/evaluator/decryptor) the provider opts into.
   rpc Init(InitRequest) returns (InitResponse);
@@ -249,7 +249,7 @@ message InitResponse {
   repeated string provided_services = 1;
 
   // Set of plugin-owned event types this plugin may emit. Host validates
-  // set-equality against manifest's crypto.emits per INV-S5. Plugins
+  // set-equality against manifest's crypto.emits per INV-PLUGIN-32. Plugins
   // without crypto.emits leave empty and skip validation; plugins WITH
   // crypto.emits MUST populate (mismatch fails load).
   repeated string registered_emit_types = 2;
@@ -300,8 +300,8 @@ message EmitEvent {
   string payload = 3 [(buf.validate.field).string.max_len = 65536];
   // Per-event sensitivity claim for a return-value emit, validated against the
   // plugin manifest by event_emitter.go::Emit via EnforceSensitivity
-  // (internal/plugin/sensitivity_fence.go) — INV-6: a sensitivity=never manifest
-  // rejects true; INV-7: a sensitivity=always manifest rejects false. Carries
+  // (internal/plugin/sensitivity_fence.go) — INV-PLUGIN-29: a sensitivity=never manifest
+  // rejects true; INV-PLUGIN-30: a sensitivity=always manifest rejects false. Carries
   // the same semantics as the active EmitEvent RPC's sensitive field so a binary
   // plugin's return-value emit cannot silently downgrade to plaintext where the
   // Lua runtime would encrypt (holomush-av954). Default false for backward
@@ -465,9 +465,9 @@ message PluginHostServiceEmitEventRequest {
   // sensitive declares per-event sensitivity at emit time.
   // Phase 3a's host-side fence at internal/plugin/event_emitter.go::Emit
   // validates this against the plugin manifest's declared sensitivity:
-  //   - manifest sensitivity=never:  sensitive=true rejected (INV-6).
-  //   - manifest sensitivity=may:    sensitive=true|false honored.
-  //   - manifest sensitivity=always: sensitive=false rejected (INV-7).
+  //   - manifest sensitivity=never:  sensitive=true rejected (INV-PLUGIN-29).
+  //   - manifest sensitivity=may:    sensitive=true/false honored.
+  //   - manifest sensitivity=always: sensitive=false rejected (INV-PLUGIN-30).
   // Default false (proto3 zero) for older plugins compiled before this
   // field existed — matching pre-Phase-3d behavior.
   bool sensitive = 4;

--- a/api/proto/holomush/scene/v1/scene.proto
+++ b/api/proto/holomush/scene/v1/scene.proto
@@ -25,7 +25,7 @@ option go_package = "github.com/holomush/holomush/pkg/proto/holomush/scene/v1;sc
 // the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
 // (SceneServiceImpl holds no policy engine). The sole exceptions are the
 // participant-gate reads (GetPoseOrder and the publish reads), which enforce a
-// direct plugin-code participation check (INV-S9) precisely because it is a
+// direct plugin-code participation check (INV-SCENE-60) precisely because it is a
 // hard privacy boundary that must not be delegable.
 //
 // Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -111,7 +111,7 @@ service SceneService {
   rpc CastPublishVote(CastPublishVoteRequest) returns (CastPublishVoteResponse);
 
   // GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-  // the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+  // the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
   // NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
   // fires before any existence check so a non-participant cannot distinguish a
   // missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -141,7 +141,7 @@ service SceneService {
   rpc WithdrawScenePublish(WithdrawScenePublishRequest) returns (WithdrawScenePublishResponse);
 
   // GetPublishedScene returns a publication attempt's full state to a scene
-  // participant. Enforces the INV-S9 plugin-code participant gate with a
+  // participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
   // load-bearing step order (INV-SCENE-32): header read → participant gate → content
   // read (only for PUBLISHED rows, only after the gate passes). A non-participant
   // is denied with the §10 triple-signal before any content is read. See
@@ -156,7 +156,7 @@ service SceneService {
 
   // ListScenePublishAttempts returns the audit list of a scene's publication
   // attempts (header summaries, no content) to a participant. Participant-gated
-  // (INV-S9) so a non-participant cannot enumerate attempts. See
+  // (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
   // publish_service.go::ListScenePublishAttempts.
   rpc ListScenePublishAttempts(ListScenePublishAttemptsRequest) returns (ListScenePublishAttemptsResponse);
 
@@ -178,7 +178,7 @@ service SceneService {
   // ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
   // by a positive amount and emits the extension notice. Admin-only, enforced
   // by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-  // role check (the inverse of INV-S9's plugin-code privacy gate). See
+  // role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
   // publish_service.go::ExtendScenePublishVoteAttempts.
   rpc ExtendScenePublishVoteAttempts(ExtendScenePublishVoteAttemptsRequest) returns (ExtendScenePublishVoteAttemptsResponse);
 }
@@ -651,7 +651,7 @@ message PublishedSceneVoteSummary {
 }
 
 // GetPublishedSceneRequest reads a publication attempt's full state as a scene
-// participant (participant-gated, INV-S9).
+// participant (participant-gated, INV-SCENE-60).
 message GetPublishedSceneRequest {
   // The reading character, who MUST be a participant of the scene; required.
   string caller_character_id = 1 [(buf.validate.field).string.min_len = 1];
@@ -697,7 +697,7 @@ message GetPublishedSceneResponse {
 }
 
 // DownloadPublishedSceneRequest fetches a PUBLISHED attempt rendered to a file
-// format, as a participant (participant-gated, INV-S9).
+// format, as a participant (participant-gated, INV-SCENE-60).
 message DownloadPublishedSceneRequest {
   // The downloading character, who MUST be a participant; required.
   string caller_character_id = 1 [(buf.validate.field).string.min_len = 1];
@@ -718,7 +718,7 @@ message DownloadPublishedSceneResponse {
 }
 
 // ListScenePublishAttemptsRequest lists a scene's publication attempts as a
-// participant (participant-gated, INV-S9).
+// participant (participant-gated, INV-SCENE-60).
 message ListScenePublishAttemptsRequest {
   // The reading character, who MUST be a participant; required.
   string caller_character_id = 1 [(buf.validate.field).string.min_len = 1];

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -207,6 +207,7 @@ invariants.
 | `INV-SCENE-57` | With no game-configured taxonomy, core-scenes' DefaultCWTaxonomy MUST apply; a fresh game validates/filters correctly with zero operator configuration. | `INV-5` | pending |
 | `INV-SCENE-58` | content.cw_block resolution MUST be the union of GAME, PLAYER, and CHARACTER scope lists (safety-accumulating), not first-match-wins. | `INV-6` | pending |
 | `INV-SCENE-59` | Scene settings/sensitivity access MUST be ABAC-authorized and default-deny: a principal may read/write its own PLAYER/CHARACTER settings; GAME-scope writes require an operator action. | `INV-7` | pending |
+| `INV-SCENE-60` | The hard privacy boundary for scene-log reads MUST remain plugin-code-enforced; ABAC MUST NOT be in the path for scene-log reads (a non-participant read fails before the ABAC engine is consulted). | `INV-S9` | pending |
 
 ### `INV-PLUGIN`
 
@@ -240,6 +241,10 @@ invariants.
 | `INV-PLUGIN-26` | The binary (gRPC) and Lua (hostfunc) surfaces reach identical host evaluation logic via a single shared mapping (runtime parity). | `INV-5` | pending |
 | `INV-PLUGIN-27` | Each settings host RPC MUST ship a Go SDK method AND a Lua hostfunc together (runtime parity); the settings access gate is the single shared path for both runtimes. | `INV-8` | pending |
 | `INV-PLUGIN-28` | Cross-plugin settings isolation MUST be structural: the host binds the plugin partition from the authenticated caller identity (stamped at server construction), never from caller-supplied input; a plugin MUST NOT address another plugin's owner partition. | `INV-11` | pending |
+| `INV-PLUGIN-29` | Emitting an event with Sensitive=true whose type is not declared in the plugin's crypto.emits as 'may' or 'always' MUST fail at the emit-time fence with EVENT_SENSITIVITY_NOT_DECLARED (over-claim reject). | `INV-6` | pending |
+| `INV-PLUGIN-30` | A plugin declaring an event type as sensitivity:always MUST NOT publish that event with Sensitive=false; the emit-time fence rejects with EVENT_SENSITIVITY_REQUIRED (under-claim reject). | `INV-7` | pending |
+| `INV-PLUGIN-31` | Every Plugin Host RPC and SDK primitive MUST ship a Go SDK method AND a Lua hostfunc together; asymmetric capability between the binary and Lua runtimes is forbidden. | `INV-S3` | pending |
+| `INV-PLUGIN-32` | Every plugin declaring crypto.emits MUST pass startup-time set-equality validation: the manifest-declared emit-type set MUST equal the code-registered emit-type set in both directions, or plugin startup fails closed. | `INV-S5` | pending |
 
 ### `INV-EVENTBUS`
 
@@ -272,6 +277,7 @@ invariants.
 | `INV-EVENTBUS-25` | Plugin audit tables MUST add dek_ref BIGINT NULL and dek_version INTEGER NULL columns (mirror-events_audit contract); the columns are nullable, and identity-codec rows store NULL on both. | `INV-P7-3` | pending |
 | `INV-EVENTBUS-26` | Plugin SDK Layer 2: pluginsdk.AuditRow Go struct fields MUST be 1:1 with pluginauditpb.AuditRow proto fields (id, subject, type, timestamp, actor, codec, payload, dek_ref, dek_version). | `INV-P7-4` | pending |
 | `INV-EVENTBUS-27` | Plugin migrations MAY run before or after Phase 7's host migration (no host-side schema change beyond Phases 2–5); the two crypto columns added to plugin tables are nullable and require no new host-side support. | `INV-P7-10` | pending |
+| `INV-EVENTBUS-28` | New event subjects MUST use the NATS dot-style form events.<game_id>.<domain>.<entity-id>[.<facet>...]; colon-style is legacy and translated at the EventSink boundary. | `INV-S4` | pending |
 
 ### `INV-CLUSTER`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -173,9 +173,11 @@ scopes:
     boundary: "All scene-domain behavior. Cross-cuts multiple Phase specs (P4–P8)."
     # Families P4/P5/P6/FS/FW/Y5INX and the SH publish-driving harness, plus phase-8
     # board-content-warnings bare INV-2/5/6/7. FW subsumed into FS. See redesign spec §2.1
-    # and bead holomush-hz0v4.14.13. NOTE: the INV-S* substrate-contract family
-    # (origin 2026-05-16-social-spaces-substrate-contract.md, ~48 sites in core-scenes)
-    # is a SEPARATE family NOT in this scope — left untouched (closed-world).
+    # and bead holomush-hz0v4.14.13. The INV-S* substrate-contract family
+    # (origin 2026-05-16-social-spaces-substrate-contract.md) was per-token SPLIT in .14.24:
+    # INV-S9 (scene-log privacy, plugin-code-enforced) → INV-SCENE-60 (here); INV-S3/S5
+    # → INV-PLUGIN, INV-S4 → INV-EVENTBUS. S1/S2/S6/S7/S8/S10 are spec-only/process invariants
+    # (no code refs). The bare phase-8 board-content-warnings INV-2/5/6/7 remain SCENE.
     status: migrated
     origin_specs:
       - "docs/superpowers/specs/2026-05-19-scenes-phase-4-streams-and-pose-order-design.md"
@@ -184,6 +186,7 @@ scopes:
       - "docs/superpowers/specs/2026-05-28-focus-delta-coordinator-unification-design.md"
       - "docs/superpowers/specs/2026-05-28-scene-bare-ulid-identity-design.md"
       - "docs/superpowers/specs/2026-05-27-shcyu-harness-publish-driving-design.md"
+      - "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
     owned_paths:
       - "plugins/core-scenes/**"
       - "internal/grpc/focus/**"
@@ -256,6 +259,8 @@ scopes:
       - "docs/superpowers/specs/2026-05-25-wholesystem-plugin-integration-design.md"
       - "docs/superpowers/specs/2026-05-25-plugin-host-evaluate-design.md"
       - "docs/superpowers/specs/2026-05-29-scenes-phase-8-board-content-warnings-design.md"
+      - "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+      - "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
     owned_paths:
       # PC (plugin-runtime-config): config files are PLUGIN-exclusive.
       - "internal/plugin/config.go"
@@ -288,6 +293,18 @@ scopes:
       # INV-4 audit-wiring sites in internal/access/setup/ (plugin-evaluate, not ABAC-scope).
       - "internal/access/setup/subsystem.go"
       - "internal/access/setup/setup_warn_integ_test.go"
+      # .14.24: emit-time sensitivity fence INV-6/7 (master crypto, →29/30) + INV-S3 runtime
+      # symmetry (→31) + INV-S5 manifest crypto.emits set-equality (→32). Clean, exclusive sites.
+      - "internal/plugin/sensitivity_fence.go"
+      - "internal/plugin/sensitivity_fence_test.go"
+      - "internal/plugin/event_emitter.go"
+      - "internal/plugin/event_emitter_crypto_test.go"
+      - "pkg/plugin/event.go"
+      - "internal/plugin/emit_type_validator.go"
+      - "internal/plugin/hostfunc/stdlib_emit_registry.go"
+      - "pkg/plugin/emit_registry.go"
+      - "pkg/plugin/sdk.go"
+      - "internal/plugin/lua/host_test.go"
     shared_files:
       # PLUGIN+STORE: no_delete grep gate (W9ML-9) lives in a STORE-owned file.
       - "internal/store/no_delete_grep_test.go"
@@ -315,6 +332,20 @@ scopes:
       - "plugins/core-scenes/publish_helpers.go"
       - "plugins/core-scenes/service.go"
       - "plugins/core-scenes/testhelpers_test.go"
+      # .14.24 fence/INV-S sites carrying FOREIGN co-located tokens or owned by other scopes:
+      # crypto.go (CRYPTO), host.go/manager_test.go (CRYPTO), manager_parity_test.go (INV-M7),
+      # inv_p4/p5 coverage (SCENE-owned), plugin.proto (regen), core-scenes/main.go (CRYPTO+SCENE),
+      # other-plugin Lua (core-communication/core-objects). Foreign tokens stay; residual skips shared.
+      - "internal/testsupport/integrationtest/crypto.go"
+      - "internal/plugin/host.go"
+      - "internal/plugin/manager_test.go"
+      - "internal/plugin/goplugin/manager_parity_test.go"
+      - "internal/test/invariants/inv_p4_coverage_meta_test.go"
+      - "internal/test/invariants/inv_p5_coverage_meta_test.go"
+      - "api/proto/holomush/plugin/v1/plugin.proto"
+      - "plugins/core-scenes/main.go"
+      - "plugins/core-communication/main.lua"
+      - "plugins/core-objects/main.lua"
 
   - name: INV-EVENTBUS
     description: "Subject naming, JetStream consumer config, audit projection, delivery contracts, tier routing, rendering
@@ -330,6 +361,7 @@ scopes:
       - "docs/superpowers/specs/2026-04-26-gateway-verb-registry-sourcing.md"
       - "docs/superpowers/specs/2026-05-29-colon-style-subject-eradication-design.md"
       - "docs/superpowers/specs/2026-05-13-event-payload-crypto-phase7-plugin-sdk-design.md"
+      - "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
     owned_paths:
       - "internal/eventbus/rendering_publisher*.go"
       - "internal/gateway_invariants/**"
@@ -386,6 +418,11 @@ scopes:
       - "test/integration/plugin/testdata/test_downgrade_attacker/plugin.yaml"
       # Shared integration harness (see CRYPTO.shared_files). Carries GW-5 + P7.
       - "internal/testsupport/integrationtest/harness.go"
+      # .14.24 INV-S4 (NATS dot-style subjects → INV-EVENTBUS-28): SCENE-owned core-scenes
+      # files (plugins/core-scenes/** is SCENE owned_paths) carrying the subject-naming token;
+      # also carry INV-S9 (SCENE) — genuinely multi-scope, so shared here for the EVENTBUS ref.
+      - "plugins/core-scenes/service.go"
+      - "plugins/core-scenes/store.go"
 
   - name: INV-CLUSTER
     description: "Member identity, heartbeats, cache invalidation (cross-replica coordination path), probe-and-pill, clock
@@ -2233,7 +2270,17 @@ invariants:
       - {file: "test/integration/eventbus_e2e/plugin_downgrade_attacker_test.go", token: "INV-P7-10"}
       - {file: "test/integration/plugin/plugin_migration_test.go", token: "INV-P7-10"}
       - {file: "test/integration/plugin/testdata/test_downgrade_attacker/main.go", token: "INV-P7-10"}
-      - {file: "test/integration/plugin/testdata/test_downgrade_attacker/plugin.yaml", token: "INV-P7-10",}
+      - {file: "test/integration/plugin/testdata/test_downgrade_attacker/plugin.yaml", token: "INV-P7-10"}
+  - id: INV-EVENTBUS-28
+    scope: INV-EVENTBUS
+    origin_spec: "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
+    legacy: ["INV-S4@docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"]
+    summary: "New event subjects MUST use the NATS dot-style form events.<game_id>.<domain>.<entity-id>[.<facet>...]; colon-style
+      is legacy and translated at the EventSink boundary."
+    binding: pending
+    refs:
+      - {file: "plugins/core-scenes/service.go", token: "INV-S4"}
+      - {file: "plugins/core-scenes/store.go", token: "INV-S4",}
 
   # -- INV-SCENE -- migrated from families P4/P5/P6/FS(+FW)/Y5INX/SH + phase-8 bare INV-N (holomush-hz0v4.14.13).
   # Dense by family: P4-1..13->1..13, P5-1..14->14..27, P6-1..10->28..37, FS-1..8->38..45,
@@ -2875,7 +2922,31 @@ invariants:
     refs:
       - {file: "plugins/core-scenes/commands_test.go", token: "INV-7"}
       - {file: "test/integration/scenes/publish_e2e_test.go", token: "INV-7"}
-      - {file: "test/integration/scenes/seed_encrypted_ic_validation_test.go", token: "INV-7",}
+      - {file: "test/integration/scenes/seed_encrypted_ic_validation_test.go", token: "INV-7"}
+  - id: INV-SCENE-60
+    scope: INV-SCENE
+    origin_spec: "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
+    legacy: ["INV-S9@docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"]
+    summary: "The hard privacy boundary for scene-log reads MUST remain plugin-code-enforced; ABAC MUST NOT be in the path
+      for scene-log reads (a non-participant read fails before the ABAC engine is consulted)."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/scene/v1/scene.proto", token: "INV-S9"}
+      - {file: "internal/test/invariants/scene_no_abac_in_getposeorder_test.go", token: "INV-S9"}
+      - {file: "internal/test/invariants/scene_resolver_no_poseorder_leak_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/commands.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/commands_log_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/commands_publish_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/metrics.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/plugin.yaml", token: "INV-S9"}
+      - {file: "plugins/core-scenes/publish_service.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/resolver_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/service.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/service_publish_gate_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/service_test.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/store.go", token: "INV-S9"}
+      - {file: "plugins/core-scenes/store_integration_test.go", token: "INV-S9"}
+      - {file: "test/integration/scenes/publish_e2e_test.go", token: "INV-S9",}
 
   # -- INV-PLUGIN -- migrated from families PC/W9ML/WS + pluginauthz bare INV-N (holomush-hz0v4.14.14).
   # P7 SPLIT: PLUGIN gets ZERO P7 tokens (redesign §2.1: crypto half=1,2,5,6,7,9,11,12,15,16; P7-13/14 ride
@@ -3153,3 +3224,72 @@ invariants:
       - {file: "internal/plugin/goplugin/host_settings_test.go", token: "INV-11"}
       - {file: "internal/plugin/lua/settings_ops_adapter_test.go", token: "INV-11"}
       - {file: "internal/plugin/pluginauthz/principal.go", token: "INV-11"}
+  - id: INV-PLUGIN-29
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-6@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "Emitting an event with Sensitive=true whose type is not declared in the plugin's crypto.emits as 'may' or 'always'
+      MUST fail at the emit-time fence with EVENT_SENSITIVITY_NOT_DECLARED (over-claim reject)."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/sensitivity_fence.go", token: "INV-6"}
+      - {file: "internal/plugin/sensitivity_fence_test.go", token: "INV-6"}
+      - {file: "internal/plugin/event_emitter.go", token: "INV-6"}
+      - {file: "internal/plugin/event_emitter_crypto_test.go", token: "INV-6"}
+      - {file: "internal/plugin/lua/host.go", token: "INV-6"}
+      - {file: "api/proto/holomush/plugin/v1/plugin.proto", token: "INV-6"}
+      - {file: "pkg/plugin/event.go", token: "INV-6"}
+      - {file: "internal/testsupport/integrationtest/crypto.go", token: "INV-6"}
+  - id: INV-PLUGIN-30
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
+    legacy: ["INV-7@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "A plugin declaring an event type as sensitivity:always MUST NOT publish that event with Sensitive=false; the
+      emit-time fence rejects with EVENT_SENSITIVITY_REQUIRED (under-claim reject)."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/sensitivity_fence.go", token: "INV-7"}
+      - {file: "internal/plugin/sensitivity_fence_test.go", token: "INV-7"}
+      - {file: "internal/plugin/event_emitter.go", token: "INV-7"}
+      - {file: "internal/plugin/event_emitter_crypto_test.go", token: "INV-7"}
+      - {file: "internal/plugin/lua/host.go", token: "INV-7"}
+      - {file: "api/proto/holomush/plugin/v1/plugin.proto", token: "INV-7"}
+      - {file: "pkg/plugin/event.go", token: "INV-7"}
+      - {file: "internal/testsupport/integrationtest/crypto.go", token: "INV-7"}
+  - id: INV-PLUGIN-31
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
+    legacy: ["INV-S3@docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"]
+    summary: "Every Plugin Host RPC and SDK primitive MUST ship a Go SDK method AND a Lua hostfunc together; asymmetric capability
+      between the binary and Lua runtimes is forbidden."
+    binding: pending
+    refs:
+      - {file: "internal/plugin/goplugin/manager_parity_test.go", token: "INV-S3"}
+      - {file: "internal/test/invariants/inv_p5_coverage_meta_test.go", token: "INV-S3"}
+  - id: INV-PLUGIN-32
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"
+    legacy: ["INV-S5@docs/superpowers/specs/2026-05-16-social-spaces-substrate-contract.md"]
+    summary: "Every plugin declaring crypto.emits MUST pass startup-time set-equality validation: the manifest-declared emit-type
+      set MUST equal the code-registered emit-type set in both directions, or plugin startup fails closed."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/plugin/v1/plugin.proto", token: "INV-S5"}
+      - {file: "internal/plugin/emit_type_validator.go", token: "INV-S5"}
+      - {file: "internal/plugin/goplugin/host.go", token: "INV-S5"}
+      - {file: "internal/plugin/goplugin/host_test.go", token: "INV-S5"}
+      - {file: "internal/plugin/goplugin/manager_parity_test.go", token: "INV-S5"}
+      - {file: "internal/plugin/host.go", token: "INV-S5"}
+      - {file: "internal/plugin/hostfunc/functions.go", token: "INV-S5"}
+      - {file: "internal/plugin/hostfunc/stdlib_emit_registry.go", token: "INV-S5"}
+      - {file: "internal/plugin/lua/host.go", token: "INV-S5"}
+      - {file: "internal/plugin/lua/host_test.go", token: "INV-S5"}
+      - {file: "internal/plugin/manager.go", token: "INV-S5"}
+      - {file: "internal/plugin/manager_test.go", token: "INV-S5"}
+      - {file: "internal/test/invariants/inv_p4_coverage_meta_test.go", token: "INV-S5"}
+      - {file: "pkg/plugin/emit_registry.go", token: "INV-S5"}
+      - {file: "pkg/plugin/sdk.go", token: "INV-S5"}
+      - {file: "plugins/core-communication/main.lua", token: "INV-S5"}
+      - {file: "plugins/core-objects/main.lua", token: "INV-S5"}
+      - {file: "plugins/core-scenes/main.go", token: "INV-S5"}
+      - {file: "plugins/core-scenes/main_test.go", token: "INV-S5"}

--- a/internal/plugin/emit_type_validator.go
+++ b/internal/plugin/emit_type_validator.go
@@ -11,7 +11,7 @@ import (
 
 // hostOwnedEmitTypes lists event-type strings that are host-owned (per
 // pkg/plugin/event.go constants) and therefore filtered out of the
-// registered set before INV-S5 set-equality comparison. Per INV-M2.
+// registered set before INV-PLUGIN-32 set-equality comparison. Per INV-M2.
 var hostOwnedEmitTypes = map[string]struct{}{
 	string(pluginsdk.HostEventTypeSystem):          {},
 	string(pluginsdk.HostEventTypeSessionEnded):    {},
@@ -25,7 +25,7 @@ var hostOwnedEmitTypes = map[string]struct{}{
 }
 
 // EmitTypeMismatch describes the diff between a plugin's manifest-declared
-// crypto.emits set and the SDK-registered emit-type set per INV-S5.
+// crypto.emits set and the SDK-registered emit-type set per INV-PLUGIN-32.
 type EmitTypeMismatch struct {
 	DeclaredButUnregistered []string
 	RegisteredButUndeclared []string
@@ -39,7 +39,7 @@ func (m EmitTypeMismatch) HasMismatch() bool {
 
 // ValidateEmitTypeSetEquality compares the manifest-declared emit-type
 // set against the SDK-registered set (with host-owned types filtered out
-// per INV-M2). Per INV-S5, the two sets MUST be equal in both directions.
+// per INV-M2). Per INV-PLUGIN-32, the two sets MUST be equal in both directions.
 func ValidateEmitTypeSetEquality(declared, registered []string) EmitTypeMismatch {
 	declSet := toEmitSet(declared)
 	regSet := toEmitSet(filterHostOwned(registered))
@@ -61,7 +61,7 @@ func ValidateEmitTypeSetEquality(declared, registered []string) EmitTypeMismatch
 }
 
 // filterHostOwned removes host-owned event types from the registered
-// set before INV-S5 comparison. Per INV-M2 — substrate filters; the
+// set before INV-PLUGIN-32 comparison. Per INV-M2 — substrate filters; the
 // SDK + hostfunc surface accepts any string (plugins MAY register host-
 // owned types; the validator MUST NOT count them as plugin-owned).
 func filterHostOwned(registered []string) []string {

--- a/internal/plugin/event_emitter.go
+++ b/internal/plugin/event_emitter.go
@@ -67,7 +67,7 @@ func WithGameID(p GameIDProvider) EmitterOption {
 // (the default and the production state at Phase 3a merge time), the
 // emitter skips the manifest sensitivity lookup + EnforceSensitivity
 // check and stamps event.Sensitive=false unconditionally — matching
-// pre-Phase-3a behavior. When true, the fence runs and INV-6/INV-7 are
+// pre-Phase-3a behavior. When true, the fence runs and INV-PLUGIN-29/INV-PLUGIN-30 are
 // enforced. The flag is sourced from eventbus.Config.Crypto.Enabled in
 // internal/bootstrap.
 //

--- a/internal/plugin/event_emitter_crypto_test.go
+++ b/internal/plugin/event_emitter_crypto_test.go
@@ -73,7 +73,7 @@ func TestEmitterDoesNotRunFenceWhenCryptoDisabled(t *testing.T) {
 		Subject:   "scene.01HXXXTESTSCENE000000000",
 		Type:      pluginsdk.EventType("test-plugin:secret"),
 		Payload:   `{}`,
-		Sensitive: false, // would trigger INV-7 if the fence ran
+		Sensitive: false, // would trigger INV-PLUGIN-30 if the fence ran
 	}
 	require.NoError(t, emitter.Emit(context.Background(), "test-plugin", intent),
 		"crypto disabled: fence MUST be skipped")
@@ -131,7 +131,7 @@ func TestEmitterRejectsClaimTrueOnManifestNeverEvent(t *testing.T) {
 		Subject:   "scene.01HXXXTESTSCENE000000000",
 		Type:      pluginsdk.EventType("test-plugin:pose"),
 		Payload:   `{}`,
-		Sensitive: true, // INV-6 over-claim
+		Sensitive: true, // INV-PLUGIN-29 over-claim
 	}
 	err := emitter.Emit(context.Background(), "test-plugin", intent)
 	require.Error(t, err)
@@ -149,7 +149,7 @@ func TestEmitterRejectsClaimFalseOnManifestAlwaysEvent(t *testing.T) {
 		Subject:   "scene.01HXXXTESTSCENE000000000",
 		Type:      pluginsdk.EventType("test-plugin:secret"),
 		Payload:   `{}`,
-		Sensitive: false, // INV-7 under-claim
+		Sensitive: false, // INV-PLUGIN-30 under-claim
 	}
 	err := emitter.Emit(context.Background(), "test-plugin", intent)
 	require.Error(t, err)

--- a/internal/plugin/goplugin/host.go
+++ b/internal/plugin/goplugin/host.go
@@ -273,7 +273,7 @@ type loadedPlugin struct {
 	conn                grpc.ClientConnInterface // underlying gRPC conn to the plugin process
 	certDir             string                   // temp cert directory, cleaned up on unload
 	broker              *hashiplug.GRPCBroker    // broker for service injection, nil if factory-mocked
-	registeredEmitTypes []string                 // INV-S5: populated from InitResponse.RegisteredEmitTypes
+	registeredEmitTypes []string                 // INV-PLUGIN-32: populated from InitResponse.RegisteredEmitTypes
 }
 
 // NewHost creates a new binary plugin host.
@@ -338,7 +338,7 @@ func (h *Host) overrideFor(pluginName string) map[string]string {
 
 // manifestNeedsInit reports whether the host must call Init on a plugin.
 // Init injects services (requires/provides), provisions storage, captures
-// crypto.emits (INV-S5), AND — INV-PLUGIN-8 — delivers plugin_config for any
+// crypto.emits (INV-PLUGIN-32), AND — INV-PLUGIN-8 — delivers plugin_config for any
 // plugin declaring a config schema.
 func manifestNeedsInit(m *plugins.Manifest) bool {
 	return len(m.Requires) > 0 ||
@@ -695,7 +695,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 	}
 
 	// Call Init on plugins that need service injection (storage or requires),
-	// declare crypto.emits (INV-S5 needs InitResponse), or declare a config
+	// declare crypto.emits (INV-PLUGIN-32 needs InitResponse), or declare a config
 	// schema (INV-PLUGIN-8: plugin_config must be delivered).
 	needsInit := manifestNeedsInit(manifest)
 	var registeredEmitTypes []string

--- a/internal/plugin/goplugin/host_test.go
+++ b/internal/plugin/goplugin/host_test.go
@@ -116,13 +116,13 @@ type mockGRPCPluginClient struct {
 	initCalled   bool
 	initReq      *pluginv1.InitRequest
 	initErr      error
-	initResponse *pluginv1.InitResponse // INV-S5: per-test override; nil falls back to empty InitResponse
+	initResponse *pluginv1.InitResponse // INV-PLUGIN-32: per-test override; nil falls back to empty InitResponse
 
 	QuerySessionStreamsFunc func(ctx context.Context, req *pluginv1.QuerySessionStreamsRequest) (*pluginv1.QuerySessionStreamsResponse, error)
 }
 
 // setInitResponse installs a per-test override for the Init RPC response
-// (used by INV-S5 tests to feed RegisteredEmitTypes through the host).
+// (used by INV-PLUGIN-32 tests to feed RegisteredEmitTypes through the host).
 func (m *mockGRPCPluginClient) setInitResponse(r *pluginv1.InitResponse) {
 	m.initResponse = r
 }

--- a/internal/plugin/goplugin/manager_parity_test.go
+++ b/internal/plugin/goplugin/manager_parity_test.go
@@ -21,8 +21,8 @@ import (
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
 
-// TestManager_INVS5_ParityAcrossRuntimes verifies that INV-S5 validation is
-// equally enforced on both runtimes — Lua and binary — per INV-M7 / INV-S3.
+// TestManager_INVS5_ParityAcrossRuntimes verifies that INV-PLUGIN-32 validation is
+// equally enforced on both runtimes — Lua and binary — per INV-M7 / INV-PLUGIN-31.
 //
 // Four scenarios x 2 runtimes = 8 subtests. The "host-owned-filtered"
 // scenario verifies INV-M2 round-trips through both the Lua hostfunc path
@@ -84,7 +84,7 @@ func TestManager_INVS5_ParityAcrossRuntimes(t *testing.T) {
 				// table (and for binary, a live subprocess + gRPC client)
 				// would leak.
 				assert.NotContains(t, mgr.ListPlugins(), pluginName,
-					"INV-S5 rejection MUST roll back: plugin %q should not appear in manager's plugin list after fail-closed", pluginName)
+					"INV-PLUGIN-32 rejection MUST roll back: plugin %q should not appear in manager's plugin list after fail-closed", pluginName)
 			}
 		})
 
@@ -116,7 +116,7 @@ func TestManager_INVS5_ParityAcrossRuntimes(t *testing.T) {
 				errutil.AssertErrorCode(t, err, sc.wantCode)
 				// INV-M3 rollback regression: see lua/ subtest above.
 				assert.NotContains(t, mgr.ListPlugins(), pluginName,
-					"INV-S5 rejection MUST roll back: plugin %q should not appear in manager's plugin list after fail-closed", pluginName)
+					"INV-PLUGIN-32 rejection MUST roll back: plugin %q should not appear in manager's plugin list after fail-closed", pluginName)
 			}
 		})
 	}

--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -64,8 +64,8 @@ type Host interface {
 
 	// PluginEmitRegistry returns the code-registered emit-type set for a
 	// loaded plugin, captured during Load. Returns:
-	//   - (set, true)  : plugin loaded and opted into INV-S5 (non-empty crypto.emits)
-	//   - (nil, true)  : plugin loaded; INV-S5 not applicable (empty crypto.emits)
+	//   - (set, true)  : plugin loaded and opted into INV-PLUGIN-32 (non-empty crypto.emits)
+	//   - (nil, true)  : plugin loaded; INV-PLUGIN-32 not applicable (empty crypto.emits)
 	//   - (nil, false) : plugin not loaded under this Host
 	PluginEmitRegistry(name string) ([]string, bool)
 

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -284,12 +284,12 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 	// Register audit read-back decrypt functions.
 	RegisterAuditFuncs(ls, mod, pluginName, f.auditDecryptor)
 
-	// INV-S5: install a no-op register_emit_type in the per-delivery
+	// INV-PLUGIN-32: install a no-op register_emit_type in the per-delivery
 	// hostfunc surface. Lua plugins call register_emit_type at top level
 	// (idempotent registrations), and main.lua is re-executed on every
 	// event/command delivery — so the function MUST exist at runtime even
 	// though only Load-time calls matter. RegisterWithEmitCapture (used by
-	// the Lua Host's INV-S5 Load pass) overwrites this with the capturing
+	// the Lua Host's INV-PLUGIN-32 Load pass) overwrites this with the capturing
 	// variant.
 	ls.SetField(mod, "register_emit_type", ls.NewFunction(func(ls *lua.LState) int {
 		_ = ls.CheckString(1)
@@ -310,7 +310,7 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 }
 
 // RegisterWithEmitCapture is the variant of Register used during the
-// Lua Host's INV-S5 Load-pass. Identical to Register, but overwrites the
+// Lua Host's INV-PLUGIN-32 Load-pass. Identical to Register, but overwrites the
 // no-op register_emit_type stub with the capturing variant that appends
 // to reg.
 //
@@ -318,7 +318,7 @@ func (f *Functions) Register(ls *lua.LState, pluginName string, requires ...stri
 // register_emit_type (see the no-op installation block above); plugin
 // main.lua is re-executed on every event/command delivery, so calls to
 // register_emit_type MUST not raise at runtime. Only Load-time captures
-// are honored by the INV-S5 substrate validator — per-delivery calls
+// are honored by the INV-PLUGIN-32 substrate validator — per-delivery calls
 // are accepted but discarded by the no-op stub.
 func (f *Functions) RegisterWithEmitCapture(
 	ls *lua.LState,
@@ -380,7 +380,7 @@ func (f *Functions) RegisteredFunctionsForAudit() []AuditEntry {
 		{Name: "holomush.query_stream_history"},
 		// Unconditionally registered by RegisterAuditFuncs.
 		{Name: "holomush.decrypt_own_audit_rows"},
-		// INV-S5 (jg9b.3): per-delivery no-op; Load-pass capturing variant
+		// INV-PLUGIN-32 (jg9b.3): per-delivery no-op; Load-pass capturing variant
 		// is installed by RegisterWithEmitCapture.
 		{Name: "holomush.register_emit_type"},
 	}

--- a/internal/plugin/hostfunc/stdlib_emit_registry.go
+++ b/internal/plugin/hostfunc/stdlib_emit_registry.go
@@ -11,7 +11,7 @@ import (
 )
 
 // LuaEmitRegistry accumulates registrations from holomush.register_emit_type
-// calls during a Lua plugin's INV-S5 Load-pass. One instance per plugin.
+// calls during a Lua plugin's INV-PLUGIN-32 Load-pass. One instance per plugin.
 type LuaEmitRegistry struct {
 	mu    sync.Mutex
 	types map[string]struct{}
@@ -44,7 +44,7 @@ func (r *LuaEmitRegistry) Types() []string {
 // the given module table; calls append to reg.
 //
 // Called via Functions.RegisterWithEmitCapture during the Lua Host's
-// INV-S5 Load-pass to install the capturing variant. The standard
+// INV-PLUGIN-32 Load-pass to install the capturing variant. The standard
 // per-delivery Functions.Register path installs a no-op variant of
 // register_emit_type so that Lua plugin code (whose main.lua executes
 // at top level on every event/command delivery) doesn't crash on the

--- a/internal/plugin/lua/host.go
+++ b/internal/plugin/lua/host.go
@@ -36,7 +36,7 @@ var (
 type luaPlugin struct {
 	manifest     *plugins.Manifest
 	code         string   // Lua source (compiled at load time in future)
-	emitRegistry []string // INV-S5: populated during Load capture pass; nil when crypto.emits empty
+	emitRegistry []string // INV-PLUGIN-32: populated during Load capture pass; nil when crypto.emits empty
 }
 
 // Host manages Lua plugins.
@@ -217,7 +217,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 		return oops.In("lua").With("plugin", manifest.Name).With("operation", "load").With("path", realEntry).Hint("failed to read entry file").Wrap(err)
 	}
 
-	// Branch the Load pass on whether INV-S5 capture is needed.
+	// Branch the Load pass on whether INV-PLUGIN-32 capture is needed.
 	//
 	// Plugins WITHOUT non-empty crypto.emits: existing syntax-check
 	// throwaway state (no hostfuncs). Unchanged from today.
@@ -234,7 +234,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 	defer L.Close()
 
 	if manifest.Crypto != nil && len(manifest.Crypto.Emits) > 0 {
-		// INV-S5 capture pass. Install ONLY register_emit_type so the
+		// INV-PLUGIN-32 capture pass. Install ONLY register_emit_type so the
 		// pass is side-effect-isolated: top-level plugin code can register
 		// emit types but cannot call kv_set, create_location, or any
 		// other holomush.* hostfunc. Exposing the full surface here
@@ -250,7 +250,7 @@ func (h *Host) Load(ctx context.Context, manifest *plugins.Manifest, dir string)
 		if err := L.DoString(string(code)); err != nil {
 			return oops.In("lua").With("plugin", manifest.Name).With("operation", "load").
 				With("entry", manifest.LuaPlugin.Entry).
-				Hint("INV-S5 capture pass execution error").Wrap(err)
+				Hint("INV-PLUGIN-32 capture pass execution error").Wrap(err)
 		}
 		emitRegistry = reg.Types()
 	} else {
@@ -634,7 +634,7 @@ func (h *Host) parseEmitEvents(ret lua.LValue) (emits []pluginsdk.EmitEvent, val
 		// silent false would emit plaintext, defeating the operator-
 		// set sensitivity intent. The host-side downgrade fence at
 		// event_emitter.go::Emit validates correct boolean claims
-		// against the plugin manifest (INV-6 / INV-7).
+		// against the plugin manifest (INV-PLUGIN-29 / INV-PLUGIN-30).
 		sensitive, sensitiveOK := emitTableBool(eventTable, "sensitive")
 		if !sensitiveOK {
 			validationErrs = append(validationErrs,

--- a/internal/plugin/lua/host_test.go
+++ b/internal/plugin/lua/host_test.go
@@ -1969,7 +1969,7 @@ func TestLuaHostLoadEntryLegitimatePathSucceeds(t *testing.T) {
 	require.NoError(t, err, "legitimate nested entry path should load successfully")
 }
 
-// TestLuaHost_INVS5 covers the INV-S5 mechanism across the PluginEmitRegistry
+// TestLuaHost_INVS5 covers the INV-PLUGIN-32 mechanism across the PluginEmitRegistry
 // lookup surface (not-loaded, loaded-without-emits, loaded-with-emits) and
 // the capture-pass execution-error path. Each case shares the same shape:
 // optionally write main.lua + manifest, optionally Load, then either assert
@@ -2014,7 +2014,7 @@ end
 `,
 			pluginName: "noemit",
 			expectedOk: true,
-			// expectedRegistry nil — plugin known but out of INV-S5 scope
+			// expectedRegistry nil — plugin known but out of INV-PLUGIN-32 scope
 		},
 		{
 			name: "loaded plugin with crypto.emits returns ([alpha beta], true) from capture pass",
@@ -2033,7 +2033,7 @@ end
 			expectedRegistry:     []string{"alpha", "beta"},
 		},
 		{
-			name: "capture-pass execution error surfaces operation=load + INV-S5 hint",
+			name: "capture-pass execution error surfaces operation=load + INV-PLUGIN-32 hint",
 			luaSource: `
 error("intentional capture-pass failure")
 `,
@@ -2041,7 +2041,7 @@ error("intentional capture-pass failure")
 			pluginName:           "explodes",
 			declaredEmits:        []string{"ignored"},
 			expectLoadErr:        true,
-			expectedHint:         "INV-S5 capture pass execution error",
+			expectedHint:         "INV-PLUGIN-32 capture pass execution error",
 		},
 	}
 
@@ -2098,7 +2098,7 @@ error("intentional capture-pass failure")
 }
 
 // TestLuaHost_Load_CryptoEmitsCapturePassExecutionError verifies that a
-// plugin whose top-level Lua throws an error during the INV-S5 capture
+// plugin whose top-level Lua throws an error during the INV-PLUGIN-32 capture
 // pass fails Load with operation=load and a hint mentioning the capture
 // pass.
 func TestLuaHost_Load_CryptoEmitsCapturePassExecutionError(t *testing.T) {
@@ -2126,7 +2126,7 @@ error("intentional capture-pass failure")
 	require.Error(t, err)
 	oopsErr, ok := oops.AsOops(err)
 	require.True(t, ok, "Load failure should be an oops error")
-	assert.Equal(t, "INV-S5 capture pass execution error", oopsErr.Hint(),
+	assert.Equal(t, "INV-PLUGIN-32 capture pass execution error", oopsErr.Hint(),
 		"hint must surface that the capture pass failed")
 	assert.Equal(t, "load", oopsErr.Context()["operation"])
 }

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1048,7 +1048,7 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 		return oops.In("manager").With("plugin", dp.Manifest.Name).With("operation", "load").Wrap(err)
 	}
 
-	// INV-S5: manifest emit-type startup validation. Scope per INV-M1:
+	// INV-PLUGIN-32: manifest emit-type startup validation. Scope per INV-M1:
 	// only plugins with non-empty crypto.emits participate.
 	if dp.Manifest.Crypto != nil && len(dp.Manifest.Crypto.Emits) > 0 {
 		registered, ok := host.PluginEmitRegistry(dp.Manifest.Name)
@@ -1071,14 +1071,14 @@ func (m *Manager) loadPlugin(ctx context.Context, dp *DiscoveredPlugin, knownRes
 			// table (and any live subprocess / gRPC client for binary
 			// plugins) does not leak after fail-closed rejection.
 			if unloadErr := host.Unload(ctx, dp.Manifest.Name); unloadErr != nil {
-				slog.ErrorContext(ctx, "failed to rollback plugin load after INV-S5 mismatch",
+				slog.ErrorContext(ctx, "failed to rollback plugin load after INV-PLUGIN-32 mismatch",
 					"plugin", dp.Manifest.Name, "error", unloadErr)
 			}
 			return oops.Code("EVENT_TYPE_REGISTRY_MISMATCH").
 				In("manager").With("plugin", dp.Manifest.Name).
 				With("declared_but_unregistered", mismatch.DeclaredButUnregistered).
 				With("registered_but_undeclared", mismatch.RegisteredButUndeclared).
-				Errorf("plugin crypto.emits manifest does not match registered emit-type set (INV-S5)")
+				Errorf("plugin crypto.emits manifest does not match registered emit-type set (INV-PLUGIN-32)")
 		}
 	}
 
@@ -1666,7 +1666,7 @@ func displayTargetFromString(s string) corev1.EventChannel {
 }
 
 // manifestDeclaredEmitTypes extracts the event-type strings from
-// manifest.Crypto.Emits for INV-S5 set-equality validation. Returns nil
+// manifest.Crypto.Emits for INV-PLUGIN-32 set-equality validation. Returns nil
 // when manifest.Crypto is nil.
 func manifestDeclaredEmitTypes(m *Manifest) []string {
 	if m.Crypto == nil {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -2053,7 +2053,7 @@ func TestEmitPluginEventPropagatesSensitive(t *testing.T) {
 
 // writeINVS5LuaPlugin writes a synthetic Lua plugin under pluginsDir whose
 // main.lua calls register_emit_type with `registered` and whose plugin.yaml
-// declares `declared` in crypto.emits. Used by INV-S5 manager validator tests.
+// declares `declared` in crypto.emits. Used by INV-PLUGIN-32 manager validator tests.
 func writeINVS5LuaPlugin(t *testing.T, pluginsDir, name string, declared, registered []string) {
 	t.Helper()
 	dir := filepath.Join(pluginsDir, name)
@@ -2079,7 +2079,7 @@ func writeINVS5LuaPlugin(t *testing.T, pluginsDir, name string, declared, regist
 	writeFile(t, filepath.Join(dir, "main.lua"), []byte(main.String()))
 }
 
-// TestManagerLoadAll_INVS5 covers the manager-level INV-S5 wiring across
+// TestManagerLoadAll_INVS5 covers the manager-level INV-PLUGIN-32 wiring across
 // mismatch (declared/registered set inequality), matching-sets (equal sets),
 // and no-crypto-emits (validator gated off via INV-M1) scenarios. Each case
 // shares the same setup → LoadAll → assert flow; a table form keeps future
@@ -2101,14 +2101,14 @@ func TestManagerLoadAll_INVS5(t *testing.T) {
 			registeredEmits:   []string{"a"},
 			expectError:       true,
 			expectedErrorCode: "EVENT_TYPE_REGISTRY_MISMATCH",
-			assertMsg:         "INV-S5 mismatch must surface as a load error",
+			assertMsg:         "INV-PLUGIN-32 mismatch must surface as a load error",
 		},
 		{
 			name:            "matching sets load successfully",
 			pluginName:      "matched",
 			declaredEmits:   []string{"a", "b"},
 			registeredEmits: []string{"a", "b"},
-			assertMsg:       "matched INV-S5 sets must load cleanly",
+			assertMsg:       "matched INV-PLUGIN-32 sets must load cleanly",
 		},
 		{
 			name:       "no crypto.emits skips validator entirely (INV-M1 gate)",

--- a/internal/plugin/sensitivity_fence.go
+++ b/internal/plugin/sensitivity_fence.go
@@ -6,7 +6,7 @@ package plugins
 import "github.com/samber/oops"
 
 // EnforceSensitivity is the host-side ground-truth check that closes
-// INV-6 (over-claim reject) and INV-7 (under-claim reject) at emit
+// INV-PLUGIN-29 (over-claim reject) and INV-PLUGIN-30 (under-claim reject) at emit
 // time. Given the manifest-declared sensitivity for an event type
 // and the plugin's per-event Sensitive flag, returns the effective
 // sensitivity the host MUST use, or a typed error when the
@@ -15,10 +15,10 @@ import "github.com/samber/oops"
 // Truth table:
 //
 //	manifest=never  + claim=false → effective=never
-//	manifest=never  + claim=true  → REJECT (INV-6, EVENT_SENSITIVITY_NOT_DECLARED)
+//	manifest=never  + claim=true  → REJECT (INV-PLUGIN-29, EVENT_SENSITIVITY_NOT_DECLARED)
 //	manifest=may    + claim=false → effective=never (plaintext)
 //	manifest=may    + claim=true  → effective=always (encrypt)
-//	manifest=always + claim=false → REJECT (INV-7, EVENT_SENSITIVITY_REQUIRED)
+//	manifest=always + claim=false → REJECT (INV-PLUGIN-30, EVENT_SENSITIVITY_REQUIRED)
 //	manifest=always + claim=true  → effective=always
 func EnforceSensitivity(manifest Sensitivity, claimed bool) (Sensitivity, error) {
 	switch manifest {
@@ -26,7 +26,7 @@ func EnforceSensitivity(manifest Sensitivity, claimed bool) (Sensitivity, error)
 		if claimed {
 			return "", oops.Code("EVENT_SENSITIVITY_NOT_DECLARED").
 				With("manifest", string(manifest)).
-				Errorf("plugin claimed Sensitive=true on an event the manifest declares plaintext (INV-6)")
+				Errorf("plugin claimed Sensitive=true on an event the manifest declares plaintext (INV-PLUGIN-29)")
 		}
 		return SensitivityNever, nil
 	case SensitivityMay:
@@ -38,7 +38,7 @@ func EnforceSensitivity(manifest Sensitivity, claimed bool) (Sensitivity, error)
 		if !claimed {
 			return "", oops.Code("EVENT_SENSITIVITY_REQUIRED").
 				With("manifest", string(manifest)).
-				Errorf("plugin claimed Sensitive=false on an event the manifest declares always sensitive (INV-7)")
+				Errorf("plugin claimed Sensitive=false on an event the manifest declares always sensitive (INV-PLUGIN-30)")
 		}
 		return SensitivityAlways, nil
 	}

--- a/internal/plugin/sensitivity_fence_test.go
+++ b/internal/plugin/sensitivity_fence_test.go
@@ -22,10 +22,10 @@ func TestEnforceSensitivity(t *testing.T) {
 		wantErr  string
 	}{
 		{"never + claim=false → never", plugins.SensitivityNever, false, plugins.SensitivityNever, ""},
-		{"never + claim=true → INV-6 reject", plugins.SensitivityNever, true, "", "EVENT_SENSITIVITY_NOT_DECLARED"},
+		{"never + claim=true → INV-PLUGIN-29 reject", plugins.SensitivityNever, true, "", "EVENT_SENSITIVITY_NOT_DECLARED"},
 		{"may + claim=false → never (plaintext)", plugins.SensitivityMay, false, plugins.SensitivityNever, ""},
 		{"may + claim=true → always (encrypt)", plugins.SensitivityMay, true, plugins.SensitivityAlways, ""},
-		{"always + claim=false → INV-7 reject", plugins.SensitivityAlways, false, "", "EVENT_SENSITIVITY_REQUIRED"},
+		{"always + claim=false → INV-PLUGIN-30 reject", plugins.SensitivityAlways, false, "", "EVENT_SENSITIVITY_REQUIRED"},
 		{"always + claim=true → always", plugins.SensitivityAlways, true, plugins.SensitivityAlways, ""},
 	}
 	for _, tt := range tests {

--- a/internal/test/invariants/inv_p4_coverage_meta_test.go
+++ b/internal/test/invariants/inv_p4_coverage_meta_test.go
@@ -60,7 +60,7 @@ func TestINV_P4_Coverage_Meta(t *testing.T) {
 		// (scene_subjects_test.go) was retired by holomush-rops.8.
 		// INV-SCENE-2: manifest crypto.emits set == EmitTypeRegistrar set.
 		// Pinned by manifest-parse unit test in plugins/core-scenes/main_test.go
-		// (package main). The substrate INV-S5 integration check runs under
+		// (package main). The substrate INV-PLUGIN-32 integration check runs under
 		// TestCoreScenesIntegration but the manifest-parse unit is the named pin.
 		{
 			inv:      "INV-SCENE-2",

--- a/internal/test/invariants/inv_p5_coverage_meta_test.go
+++ b/internal/test/invariants/inv_p5_coverage_meta_test.go
@@ -86,7 +86,7 @@ func TestINV_P5_Coverage_Meta(t *testing.T) {
 			note:     "in internal/grpc/focus/restore_connection_focus_test.go (not session/)",
 		},
 		// INV-SCENE-19: 3 new PluginHostService RPCs ship with Go SDK + Lua hostfunc
-		// bindings together (INV-S3 substrate-contract parity).
+		// bindings together (INV-PLUGIN-31 substrate-contract parity).
 		// Pinned by the Lua parity test in stdlib_focus_test.go.
 		{
 			inv:      "INV-SCENE-19",

--- a/internal/test/invariants/scene_no_abac_in_getposeorder_test.go
+++ b/internal/test/invariants/scene_no_abac_in_getposeorder_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestINV_SCENE_4_NoABACInGetPoseOrder pins INV-SCENE-4 / INV-S9 plugin-code-gate
+// TestINV_SCENE_4_NoABACInGetPoseOrder pins INV-SCENE-4 / INV-SCENE-60 plugin-code-gate
 // discipline: GetPoseOrder MUST NOT consult the ABAC engine. The participant
 // gate is direct (IsParticipant store check), NOT via engine.Evaluate.
 //

--- a/internal/test/invariants/scene_resolver_no_poseorder_leak_test.go
+++ b/internal/test/invariants/scene_resolver_no_poseorder_leak_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestINV_SCENE_5_ResolverNoPoseOrderLeak rg-asserts that resolver.go does
 // not reference pose-metadata columns in attribute-construction code
-// paths. INV-S9 / ADR holomush-nt2d: pose-order data is reachable
+// paths. INV-SCENE-60 / ADR holomush-nt2d: pose-order data is reachable
 // exclusively via the gated GetPoseOrder RPC; ABAC attribute path is
 // forbidden.
 func TestINV_SCENE_5_ResolverNoPoseOrderLeak(t *testing.T) {
@@ -25,5 +25,5 @@ func TestINV_SCENE_5_ResolverNoPoseOrderLeak(t *testing.T) {
 	forbidden := regexp.MustCompile(`\b(last_pose_at|last_pose_seq|total_pose_count|LastPoseAt|LastPoseSeq|TotalPoseCount)\b`)
 	matches := forbidden.FindAll(data, -1)
 	assert.Empty(t, matches,
-		"INV-SCENE-5: resolver.go MUST NOT reference pose-metadata columns; INV-S9 forbids attribute-driven path to pose data")
+		"INV-SCENE-5: resolver.go MUST NOT reference pose-metadata columns; INV-SCENE-60 forbids attribute-driven path to pose data")
 }

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -169,7 +169,7 @@ func (s *Server) EmitPluginEvent(ctx context.Context, plugin, eventType, payload
 
 // EmitSceneICContent emits an encrypted (Sensitive=true) scene IC event for an
 // ARBITRARY scene + actor — used to seed content into a CreateScene-created
-// scene (the command emit path can't set Sensitive; INV-7 fence, spec §3.4).
+// scene (the command emit path can't set Sensitive; INV-PLUGIN-30 fence, spec §3.4).
 // Requires WithPluginCrypto + WithInTreePlugins. The scene row MUST already
 // exist (via CreateScene) so core-scenes' InsertScenePose UPDATE … RETURNING
 // resolves.
@@ -193,7 +193,7 @@ func (s *Server) EmitSceneICContent(ctx context.Context, plugin string, sceneID,
 //
 // Complement of EmitSceneICContent (which always emits Sensitive=true for
 // content events). Use this for event types whose manifest declares
-// sensitivity: never; the INV-6 fence rejects Sensitive=true for those types.
+// sensitivity: never; the INV-PLUGIN-29 fence rejects Sensitive=true for those types.
 func (s *Server) EmitScenePlaintextContent(ctx context.Context, plugin string, sceneID, actorID ulid.ULID, eventType, payloadJSON string) EmittedEvent {
 	return s.emitPluginEventForScene(ctx, plugin,
 		sceneID.String(), actorID, eventType, payloadJSON, false)

--- a/pkg/plugin/emit_registry.go
+++ b/pkg/plugin/emit_registry.go
@@ -11,7 +11,7 @@ import (
 // EmitRegistry accumulates the set of event types a binary plugin can
 // emit. Plugins register types during construction or in Init. The host
 // reads the set via InitResponse.registered_emit_types and validates
-// against manifest's crypto.emits per INV-S5.
+// against manifest's crypto.emits per INV-PLUGIN-32.
 type EmitRegistry struct {
 	mu    sync.Mutex
 	types map[string]struct{}
@@ -59,7 +59,7 @@ func (r *EmitRegistry) RegisteredEmitTypes() []string {
 //
 // Plugins with non-empty crypto.emits MUST implement this interface;
 // the substrate validator fails load on mismatch. Plugins without
-// crypto.emits are out of INV-S5 scope (per INV-M1) and may skip.
+// crypto.emits are out of INV-PLUGIN-32 scope (per INV-M1) and may skip.
 type EmitTypeRegistrar interface {
 	EmitRegistry() *EmitRegistry
 }

--- a/pkg/plugin/event.go
+++ b/pkg/plugin/event.go
@@ -122,9 +122,9 @@ type EmitIntent struct {
 	// Sensitive declares per-event sensitivity at emit time.
 	//
 	// Phase 3a runtime semantics (host-side fence):
-	//   - manifest sensitivity=never:  Sensitive=true rejected (INV-6).
+	//   - manifest sensitivity=never:  Sensitive=true rejected (INV-PLUGIN-29).
 	//   - manifest sensitivity=may:    field decides (false → plaintext, true → encrypted).
-	//   - manifest sensitivity=always: Sensitive=false rejected (INV-7).
+	//   - manifest sensitivity=always: Sensitive=false rejected (INV-PLUGIN-30).
 	//
 	// Default false. Plugins that do not emit sensitive events leave
 	// this zero.

--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -208,7 +208,7 @@ func (a *pluginServerAdapter) Init(ctx context.Context, req *pluginv1.InitReques
 		return nil, oops.With("phase", "init").Wrap(err)
 	}
 
-	// INV-S5: populate RegisteredEmitTypes from EmitTypeRegistrar if the
+	// INV-PLUGIN-32: populate RegisteredEmitTypes from EmitTypeRegistrar if the
 	// provider opts in. Plugins without crypto.emits leave the set empty.
 	// A registrar may legally return nil from EmitRegistry() (e.g., during
 	// early construction); guard the dereference to avoid an init-time

--- a/pkg/proto/holomush/plugin/v1/plugin.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin.pb.go
@@ -493,7 +493,7 @@ type InitResponse struct {
 	// the host's service registry can route requires→provides between plugins.
 	ProvidedServices []string `protobuf:"bytes,1,rep,name=provided_services,json=providedServices,proto3" json:"provided_services,omitempty"`
 	// Set of plugin-owned event types this plugin may emit. Host validates
-	// set-equality against manifest's crypto.emits per INV-S5. Plugins
+	// set-equality against manifest's crypto.emits per INV-PLUGIN-32. Plugins
 	// without crypto.emits leave empty and skip validation; plugins WITH
 	// crypto.emits MUST populate (mismatch fails load).
 	RegisteredEmitTypes []string `protobuf:"bytes,2,rep,name=registered_emit_types,json=registeredEmitTypes,proto3" json:"registered_emit_types,omitempty"`
@@ -680,8 +680,8 @@ type EmitEvent struct {
 	Payload string `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
 	// Per-event sensitivity claim for a return-value emit, validated against the
 	// plugin manifest by event_emitter.go::Emit via EnforceSensitivity
-	// (internal/plugin/sensitivity_fence.go) — INV-6: a sensitivity=never manifest
-	// rejects true; INV-7: a sensitivity=always manifest rejects false. Carries
+	// (internal/plugin/sensitivity_fence.go) — INV-PLUGIN-29: a sensitivity=never manifest
+	// rejects true; INV-PLUGIN-30: a sensitivity=always manifest rejects false. Carries
 	// the same semantics as the active EmitEvent RPC's sensitive field so a binary
 	// plugin's return-value emit cannot silently downgrade to plaintext where the
 	// Lua runtime would encrypt (holomush-av954). Default false for backward
@@ -1265,9 +1265,9 @@ type PluginHostServiceEmitEventRequest struct {
 	// sensitive declares per-event sensitivity at emit time.
 	// Phase 3a's host-side fence at internal/plugin/event_emitter.go::Emit
 	// validates this against the plugin manifest's declared sensitivity:
-	//   - manifest sensitivity=never:  sensitive=true rejected (INV-6).
-	//   - manifest sensitivity=may:    sensitive=true|false honored.
-	//   - manifest sensitivity=always: sensitive=false rejected (INV-7).
+	//   - manifest sensitivity=never:  sensitive=true rejected (INV-PLUGIN-29).
+	//   - manifest sensitivity=may:    sensitive=true/false honored.
+	//   - manifest sensitivity=always: sensitive=false rejected (INV-PLUGIN-30).
 	//
 	// Default false (proto3 zero) for older plugins compiled before this
 	// field existed — matching pre-Phase-3d behavior.

--- a/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
+++ b/pkg/proto/holomush/plugin/v1/plugin_grpc.pb.go
@@ -44,7 +44,7 @@ type PluginServiceClient interface {
 	// hands the plugin its ServiceConfig (DB connection string, required-service
 	// addresses, opaque runtime config) and returns the gRPC service names the
 	// plugin provides plus the emit-type set the host validates against the
-	// manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+	// manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
 	// which also lazily dials the plugin-host connection for any host-facing
 	// facade (sink/focus/evaluator/decryptor) the provider opts into.
 	Init(ctx context.Context, in *InitRequest, opts ...grpc.CallOption) (*InitResponse, error)
@@ -130,7 +130,7 @@ type PluginServiceServer interface {
 	// hands the plugin its ServiceConfig (DB connection string, required-service
 	// addresses, opaque runtime config) and returns the gRPC service names the
 	// plugin provides plus the emit-type set the host validates against the
-	// manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+	// manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
 	// which also lazily dials the plugin-host connection for any host-facing
 	// facade (sink/focus/evaluator/decryptor) the provider opts into.
 	Init(context.Context, *InitRequest) (*InitResponse, error)

--- a/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
+++ b/pkg/proto/holomush/plugin/v1/pluginv1connect/plugin.connect.go
@@ -122,7 +122,7 @@ type PluginServiceClient interface {
 	// hands the plugin its ServiceConfig (DB connection string, required-service
 	// addresses, opaque runtime config) and returns the gRPC service names the
 	// plugin provides plus the emit-type set the host validates against the
-	// manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+	// manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
 	// which also lazily dials the plugin-host connection for any host-facing
 	// facade (sink/focus/evaluator/decryptor) the provider opts into.
 	Init(context.Context, *connect.Request[v1.InitRequest]) (*connect.Response[v1.InitResponse], error)
@@ -218,7 +218,7 @@ type PluginServiceHandler interface {
 	// hands the plugin its ServiceConfig (DB connection string, required-service
 	// addresses, opaque runtime config) and returns the gRPC service names the
 	// plugin provides plus the emit-type set the host validates against the
-	// manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+	// manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
 	// which also lazily dials the plugin-host connection for any host-facing
 	// facade (sink/focus/evaluator/decryptor) the provider opts into.
 	Init(context.Context, *connect.Request[v1.InitRequest]) (*connect.Response[v1.InitResponse], error)

--- a/pkg/proto/holomush/scene/v1/scene.pb.go
+++ b/pkg/proto/holomush/scene/v1/scene.pb.go
@@ -2433,7 +2433,7 @@ func (x *PublishedSceneVoteSummary) GetPending() int32 {
 }
 
 // GetPublishedSceneRequest reads a publication attempt's full state as a scene
-// participant (participant-gated, INV-S9).
+// participant (participant-gated, INV-SCENE-60).
 type GetPublishedSceneRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The reading character, who MUST be a participant of the scene; required.
@@ -2650,7 +2650,7 @@ func (x *GetPublishedSceneResponse) GetPublishedAtUnixNs() int64 {
 }
 
 // DownloadPublishedSceneRequest fetches a PUBLISHED attempt rendered to a file
-// format, as a participant (participant-gated, INV-S9).
+// format, as a participant (participant-gated, INV-SCENE-60).
 type DownloadPublishedSceneRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The downloading character, who MUST be a participant; required.
@@ -2772,7 +2772,7 @@ func (x *DownloadPublishedSceneResponse) GetMimeType() string {
 }
 
 // ListScenePublishAttemptsRequest lists a scene's publication attempts as a
-// participant (participant-gated, INV-S9).
+// participant (participant-gated, INV-SCENE-60).
 type ListScenePublishAttemptsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The reading character, who MUST be a participant; required.

--- a/pkg/proto/holomush/scene/v1/scene_grpc.pb.go
+++ b/pkg/proto/holomush/scene/v1/scene_grpc.pb.go
@@ -65,7 +65,7 @@ const (
 // the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
 // (SceneServiceImpl holds no policy engine). The sole exceptions are the
 // participant-gate reads (GetPoseOrder and the publish reads), which enforce a
-// direct plugin-code participation check (INV-S9) precisely because it is a
+// direct plugin-code participation check (INV-SCENE-60) precisely because it is a
 // hard privacy boundary that must not be delegable.
 //
 // Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -138,7 +138,7 @@ type SceneServiceClient interface {
 	// provides no handler, so a call returns codes.Unimplemented.
 	CastPublishVote(ctx context.Context, in *CastPublishVoteRequest, opts ...grpc.CallOption) (*CastPublishVoteResponse, error)
 	// GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-	// the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+	// the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
 	// NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
 	// fires before any existence check so a non-participant cannot distinguish a
 	// missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -164,7 +164,7 @@ type SceneServiceClient interface {
 	// closes the direct-RPC gap). See publish_service.go::WithdrawScenePublish.
 	WithdrawScenePublish(ctx context.Context, in *WithdrawScenePublishRequest, opts ...grpc.CallOption) (*WithdrawScenePublishResponse, error)
 	// GetPublishedScene returns a publication attempt's full state to a scene
-	// participant. Enforces the INV-S9 plugin-code participant gate with a
+	// participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
 	// load-bearing step order (INV-SCENE-32): header read → participant gate → content
 	// read (only for PUBLISHED rows, only after the gate passes). A non-participant
 	// is denied with the §10 triple-signal before any content is read. See
@@ -177,7 +177,7 @@ type SceneServiceClient interface {
 	DownloadPublishedScene(ctx context.Context, in *DownloadPublishedSceneRequest, opts ...grpc.CallOption) (*DownloadPublishedSceneResponse, error)
 	// ListScenePublishAttempts returns the audit list of a scene's publication
 	// attempts (header summaries, no content) to a participant. Participant-gated
-	// (INV-S9) so a non-participant cannot enumerate attempts. See
+	// (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
 	// publish_service.go::ListScenePublishAttempts.
 	ListScenePublishAttempts(ctx context.Context, in *ListScenePublishAttemptsRequest, opts ...grpc.CallOption) (*ListScenePublishAttemptsResponse, error)
 	// GetPublishedScene's PUBLIC counterpart: GetPublicSceneArchive is the
@@ -196,7 +196,7 @@ type SceneServiceClient interface {
 	// ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
 	// by a positive amount and emits the extension notice. Admin-only, enforced
 	// by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-	// role check (the inverse of INV-S9's plugin-code privacy gate). See
+	// role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
 	// publish_service.go::ExtendScenePublishVoteAttempts.
 	ExtendScenePublishVoteAttempts(ctx context.Context, in *ExtendScenePublishVoteAttemptsRequest, opts ...grpc.CallOption) (*ExtendScenePublishVoteAttemptsResponse, error)
 }
@@ -457,7 +457,7 @@ func (c *sceneServiceClient) ExtendScenePublishVoteAttempts(ctx context.Context,
 // the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
 // (SceneServiceImpl holds no policy engine). The sole exceptions are the
 // participant-gate reads (GetPoseOrder and the publish reads), which enforce a
-// direct plugin-code participation check (INV-S9) precisely because it is a
+// direct plugin-code participation check (INV-SCENE-60) precisely because it is a
 // hard privacy boundary that must not be delegable.
 //
 // Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -530,7 +530,7 @@ type SceneServiceServer interface {
 	// provides no handler, so a call returns codes.Unimplemented.
 	CastPublishVote(context.Context, *CastPublishVoteRequest) (*CastPublishVoteResponse, error)
 	// GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-	// the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+	// the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
 	// NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
 	// fires before any existence check so a non-participant cannot distinguish a
 	// missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -556,7 +556,7 @@ type SceneServiceServer interface {
 	// closes the direct-RPC gap). See publish_service.go::WithdrawScenePublish.
 	WithdrawScenePublish(context.Context, *WithdrawScenePublishRequest) (*WithdrawScenePublishResponse, error)
 	// GetPublishedScene returns a publication attempt's full state to a scene
-	// participant. Enforces the INV-S9 plugin-code participant gate with a
+	// participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
 	// load-bearing step order (INV-SCENE-32): header read → participant gate → content
 	// read (only for PUBLISHED rows, only after the gate passes). A non-participant
 	// is denied with the §10 triple-signal before any content is read. See
@@ -569,7 +569,7 @@ type SceneServiceServer interface {
 	DownloadPublishedScene(context.Context, *DownloadPublishedSceneRequest) (*DownloadPublishedSceneResponse, error)
 	// ListScenePublishAttempts returns the audit list of a scene's publication
 	// attempts (header summaries, no content) to a participant. Participant-gated
-	// (INV-S9) so a non-participant cannot enumerate attempts. See
+	// (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
 	// publish_service.go::ListScenePublishAttempts.
 	ListScenePublishAttempts(context.Context, *ListScenePublishAttemptsRequest) (*ListScenePublishAttemptsResponse, error)
 	// GetPublishedScene's PUBLIC counterpart: GetPublicSceneArchive is the
@@ -588,7 +588,7 @@ type SceneServiceServer interface {
 	// ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
 	// by a positive amount and emits the extension notice. Admin-only, enforced
 	// by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-	// role check (the inverse of INV-S9's plugin-code privacy gate). See
+	// role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
 	// publish_service.go::ExtendScenePublishVoteAttempts.
 	ExtendScenePublishVoteAttempts(context.Context, *ExtendScenePublishVoteAttemptsRequest) (*ExtendScenePublishVoteAttemptsResponse, error)
 	mustEmbedUnimplementedSceneServiceServer()

--- a/pkg/proto/holomush/scene/v1/scenev1connect/scene.connect.go
+++ b/pkg/proto/holomush/scene/v1/scenev1connect/scene.connect.go
@@ -170,7 +170,7 @@ type SceneServiceClient interface {
 	// provides no handler, so a call returns codes.Unimplemented.
 	CastPublishVote(context.Context, *connect.Request[v1.CastPublishVoteRequest]) (*connect.Response[v1.CastPublishVoteResponse], error)
 	// GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-	// the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+	// the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
 	// NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
 	// fires before any existence check so a non-participant cannot distinguish a
 	// missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -196,7 +196,7 @@ type SceneServiceClient interface {
 	// closes the direct-RPC gap). See publish_service.go::WithdrawScenePublish.
 	WithdrawScenePublish(context.Context, *connect.Request[v1.WithdrawScenePublishRequest]) (*connect.Response[v1.WithdrawScenePublishResponse], error)
 	// GetPublishedScene returns a publication attempt's full state to a scene
-	// participant. Enforces the INV-S9 plugin-code participant gate with a
+	// participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
 	// load-bearing step order (INV-SCENE-32): header read → participant gate → content
 	// read (only for PUBLISHED rows, only after the gate passes). A non-participant
 	// is denied with the §10 triple-signal before any content is read. See
@@ -209,7 +209,7 @@ type SceneServiceClient interface {
 	DownloadPublishedScene(context.Context, *connect.Request[v1.DownloadPublishedSceneRequest]) (*connect.Response[v1.DownloadPublishedSceneResponse], error)
 	// ListScenePublishAttempts returns the audit list of a scene's publication
 	// attempts (header summaries, no content) to a participant. Participant-gated
-	// (INV-S9) so a non-participant cannot enumerate attempts. See
+	// (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
 	// publish_service.go::ListScenePublishAttempts.
 	ListScenePublishAttempts(context.Context, *connect.Request[v1.ListScenePublishAttemptsRequest]) (*connect.Response[v1.ListScenePublishAttemptsResponse], error)
 	// GetPublishedScene's PUBLIC counterpart: GetPublicSceneArchive is the
@@ -228,7 +228,7 @@ type SceneServiceClient interface {
 	// ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
 	// by a positive amount and emits the extension notice. Admin-only, enforced
 	// by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-	// role check (the inverse of INV-S9's plugin-code privacy gate). See
+	// role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
 	// publish_service.go::ExtendScenePublishVoteAttempts.
 	ExtendScenePublishVoteAttempts(context.Context, *connect.Request[v1.ExtendScenePublishVoteAttemptsRequest]) (*connect.Response[v1.ExtendScenePublishVoteAttemptsResponse], error)
 }
@@ -597,7 +597,7 @@ type SceneServiceHandler interface {
 	// provides no handler, so a call returns codes.Unimplemented.
 	CastPublishVote(context.Context, *connect.Request[v1.CastPublishVoteRequest]) (*connect.Response[v1.CastPublishVoteResponse], error)
 	// GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-	// the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+	// the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
 	// NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
 	// fires before any existence check so a non-participant cannot distinguish a
 	// missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -623,7 +623,7 @@ type SceneServiceHandler interface {
 	// closes the direct-RPC gap). See publish_service.go::WithdrawScenePublish.
 	WithdrawScenePublish(context.Context, *connect.Request[v1.WithdrawScenePublishRequest]) (*connect.Response[v1.WithdrawScenePublishResponse], error)
 	// GetPublishedScene returns a publication attempt's full state to a scene
-	// participant. Enforces the INV-S9 plugin-code participant gate with a
+	// participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
 	// load-bearing step order (INV-SCENE-32): header read → participant gate → content
 	// read (only for PUBLISHED rows, only after the gate passes). A non-participant
 	// is denied with the §10 triple-signal before any content is read. See
@@ -636,7 +636,7 @@ type SceneServiceHandler interface {
 	DownloadPublishedScene(context.Context, *connect.Request[v1.DownloadPublishedSceneRequest]) (*connect.Response[v1.DownloadPublishedSceneResponse], error)
 	// ListScenePublishAttempts returns the audit list of a scene's publication
 	// attempts (header summaries, no content) to a participant. Participant-gated
-	// (INV-S9) so a non-participant cannot enumerate attempts. See
+	// (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
 	// publish_service.go::ListScenePublishAttempts.
 	ListScenePublishAttempts(context.Context, *connect.Request[v1.ListScenePublishAttemptsRequest]) (*connect.Response[v1.ListScenePublishAttemptsResponse], error)
 	// GetPublishedScene's PUBLIC counterpart: GetPublicSceneArchive is the
@@ -655,7 +655,7 @@ type SceneServiceHandler interface {
 	// ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
 	// by a positive amount and emits the extension notice. Admin-only, enforced
 	// by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-	// role check (the inverse of INV-S9's plugin-code privacy gate). See
+	// role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
 	// publish_service.go::ExtendScenePublishVoteAttempts.
 	ExtendScenePublishVoteAttempts(context.Context, *connect.Request[v1.ExtendScenePublishVoteAttemptsRequest]) (*connect.Response[v1.ExtendScenePublishVoteAttemptsResponse], error)
 }

--- a/plugins/core-communication/main.lua
+++ b/plugins/core-communication/main.lua
@@ -3,7 +3,7 @@
 
 -- core-communication: provides say, pose, ooc, emit, page, whisper, pemit, wall.
 
--- INV-S5: register the 8 event types this plugin can emit.
+-- INV-PLUGIN-32: register the 8 event types this plugin can emit.
 -- These MUST match plugin.yaml's crypto.emits block exactly.
 holomush.register_emit_type("say")
 holomush.register_emit_type("pose")

--- a/plugins/core-objects/main.lua
+++ b/plugins/core-objects/main.lua
@@ -3,7 +3,7 @@
 
 -- core-objects: provides describe, examine, create, and set commands.
 
--- INV-S5: register the 5 event types this plugin can emit.
+-- INV-PLUGIN-32: register the 5 event types this plugin can emit.
 -- These MUST match plugin.yaml's crypto.emits block exactly.
 holomush.register_emit_type("object_create")
 holomush.register_emit_type("object_destroy")

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -111,7 +111,7 @@ func decodeReplayEntries(events []pluginsdk.Event) ([]PublishedSceneEntry, error
 // handleLog dispatches the "scene log" sub-commands (spec §6.1; folds in
 // holomush-cb4x): the bare form replays the IC content history as plain text;
 // "export <format>" (E4) renders it to markdown / plain_text / jsonl. Both are
-// participant-gated (INV-S9, plugin-code) and read DECRYPTED content via the
+// participant-gated (INV-SCENE-60, plugin-code) and read DECRYPTED content via the
 // host's QueryStreamHistory — NOT the plugin's own audit QueryHistory, which
 // serves ciphertext. Speaker is the actor character id; name resolution is a
 // follow-up.
@@ -152,7 +152,7 @@ func (p *scenePlugin) handleLogExport(ctx context.Context, req pluginsdk.Command
 	return &pluginsdk.CommandResponse{Status: pluginsdk.CommandOK, Output: string(content)}, nil
 }
 
-// fetchSceneLogEntries resolves the scene, runs the INV-S9 participant gate
+// fetchSceneLogEntries resolves the scene, runs the INV-SCENE-60 participant gate
 // (plugin-code, before any history read), and returns the decoded IC content
 // entries via the host's QueryStreamHistory (decrypted host-side, membership-
 // gated). On any failure it returns a non-nil error CommandResponse for the
@@ -258,7 +258,7 @@ func (p *scenePlugin) handleWithdraw(ctx context.Context, req pluginsdk.CommandR
 }
 
 // handleStatus shows the latest publish attempt's state for a scene (spec §6.1).
-// Participant-gated: GetPublishedScene (B5) enforces the INV-S9 participant gate.
+// Participant-gated: GetPublishedScene (B5) enforces the INV-SCENE-60 participant gate.
 func (p *scenePlugin) handleStatus(ctx context.Context, req pluginsdk.CommandRequest, args string) (*pluginsdk.CommandResponse, error) {
 	sceneID, err := resolveSceneRef(ctx, p.service.store, req.CharacterID, args)
 	if err != nil {
@@ -1343,7 +1343,7 @@ func (p *scenePlugin) handleEmit(
 //
 // Authorization note: handleOrder is intentionally NOT engine-gated. Pose-order
 // read authorization is enforced at the service layer via store.IsParticipant
-// (INV-S9), which is fail-closed: non-members and invited-only characters both
+// (INV-SCENE-60), which is fail-closed: non-members and invited-only characters both
 // receive PermissionDenied before any scene data is returned. This is the one
 // read path that was deliberately kept as a substrate-level check rather than
 // consolidated into the engine, because the check is already precise, atomic

--- a/plugins/core-scenes/commands_log_test.go
+++ b/plugins/core-scenes/commands_log_test.go
@@ -57,7 +57,7 @@ func TestDecodeReplayEntriesRejectsMalformedPayload(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestHandleLogDeniesNonParticipant pins the INV-S9 gate: a non-participant is
+// TestHandleLogDeniesNonParticipant pins the INV-SCENE-60 gate: a non-participant is
 // denied before any history read (the focus client is never consulted).
 func TestHandleLogDeniesNonParticipant(t *testing.T) {
 	t.Parallel()

--- a/plugins/core-scenes/commands_publish_test.go
+++ b/plugins/core-scenes/commands_publish_test.go
@@ -241,7 +241,7 @@ func TestHandleStatusShowsAttemptState(t *testing.T) {
 }
 
 // TestHandleStatusDeniesNonParticipant — a non-participant is denied
-// (GetPublishedScene INV-S9 gate).
+// (GetPublishedScene INV-SCENE-60 gate).
 func TestHandleStatusDeniesNonParticipant(t *testing.T) {
 	t.Parallel()
 	p, _, sceneID, _, _ := newPublishOpFixture(t, StatusCollecting)

--- a/plugins/core-scenes/main.go
+++ b/plugins/core-scenes/main.go
@@ -156,7 +156,7 @@ func (p *scenePlugin) SetSettingsClient(c pluginsdk.SettingsClient) {
 }
 
 // EmitRegistry implements pluginsdk.EmitTypeRegistrar. The substrate
-// INV-S5 validator reads this set via the binary-plugin Init RPC and
+// INV-PLUGIN-32 validator reads this set via the binary-plugin Init RPC and
 // validates set-equality against manifest crypto.emits.
 func (p *scenePlugin) EmitRegistry() *pluginsdk.EmitRegistry {
 	return p.emitRegistry
@@ -182,7 +182,7 @@ func phase4EmitTypes() []string {
 // phase6EmitTypes returns the 6 Phase 6 publication notice event types
 // declared in crypto.emits (all sensitivity:never). These MUST be
 // registered alongside phase4EmitTypes so the EmitTypeRegistrar set equals
-// the manifest crypto.emits set (INV-S5 / INV-SCENE-2); the host fails plugin
+// the manifest crypto.emits set (INV-PLUGIN-32 / INV-SCENE-2); the host fails plugin
 // load otherwise. The matching emitter wiring lands in Phase D2.
 func phase6EmitTypes() []string {
 	return []string{

--- a/plugins/core-scenes/main_test.go
+++ b/plugins/core-scenes/main_test.go
@@ -45,7 +45,7 @@ func TestApplyConfigRejectsNonPositiveSchedulerInterval(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "SCENE_INIT_FAILED")
 }
 
-// TestPlugin_CryptoEmitsMatchesRegistry pins INV-SCENE-2 / INV-S5: the scene
+// TestPlugin_CryptoEmitsMatchesRegistry pins INV-SCENE-2 / INV-PLUGIN-32: the scene
 // event types in crypto.emits (8 Phase 4 + 6 Phase 6 publication notices)
 // MUST equal the set registered via EmitTypeRegistrar.
 func TestPlugin_CryptoEmitsMatchesRegistry(t *testing.T) {

--- a/plugins/core-scenes/metrics.go
+++ b/plugins/core-scenes/metrics.go
@@ -120,7 +120,7 @@ func metricSceneOpsEventRecorded(kind string) {
 	_ = kind
 }
 
-// metricScenePublishPrivacyBlock counts INV-S9 hard-privacy-boundary denials
+// metricScenePublishPrivacyBlock counts INV-SCENE-60 hard-privacy-boundary denials
 // — a participant-gated publication read rejected for a non-participant.
 // Part of the spec §10 triple-signal (slog WARN + this metric + span error).
 // Metric: scene_publish_privacy_block_total{operation, reason}. No-op stub

--- a/plugins/core-scenes/plugin.yaml
+++ b/plugins/core-scenes/plugin.yaml
@@ -65,7 +65,7 @@ storage: postgres
 crypto:
   emits:
     # Content events (sensitivity: always) — participant-only IC/OOC RP
-    # content. Privacy boundary is the participant list per INV-S9, NOT
+    # content. Privacy boundary is the participant list per INV-SCENE-60, NOT
     # the location. Analog to whisper/page in core-communication, not
     # to say/pose (which are location-bounded). See ADR holomush-sb3n.
     - event_type: scene_pose

--- a/plugins/core-scenes/publish_service.go
+++ b/plugins/core-scenes/publish_service.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GetPublishedScene returns a publication attempt's full state to a scene
-// participant. It is the canonical INV-S9 participant-gated read, and its
+// participant. It is the canonical INV-SCENE-60 participant-gated read, and its
 // step ordering is LOAD-BEARING (INV-SCENE-32):
 //
 //  1. validate the caller_character_id;
@@ -51,7 +51,7 @@ func (s *SceneServiceImpl) GetPublishedScene(ctx context.Context, req *scenev1.G
 			Errorf("publication not found"))
 	}
 
-	// Step 3 — INV-S9 plugin-code participant gate. No ABAC engine is
+	// Step 3 — INV-SCENE-60 plugin-code participant gate. No ABAC engine is
 	// consulted; the deny path runs BEFORE any content read (INV-SCENE-32).
 	ok, err := s.store.IsParticipant(ctx, pub.SceneID, callerID)
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *SceneServiceImpl) GetPublishedScene(ctx context.Context, req *scenev1.G
 	return assembleParticipantResponse(pub, entries, tally), nil
 }
 
-// emitPrivacyBoundaryBlock fires the spec §10 triple-signal for an INV-S9
+// emitPrivacyBoundaryBlock fires the spec §10 triple-signal for an INV-SCENE-60
 // hard-privacy-boundary denial: a WARN log, a metric, and a span error. It
 // deliberately emits NO IC event — a denial must not surface on any scene
 // stream that could leak the attempt's existence to a non-participant.
@@ -232,7 +232,7 @@ var publishRenderMime = map[string]string{
 }
 
 // DownloadPublishedScene returns a published scene rendered in the requested
-// format to a participant. It uses the SAME load-bearing INV-S9 / INV-SCENE-32
+// format to a participant. It uses the SAME load-bearing INV-SCENE-60 / INV-SCENE-32
 // ordering as GetPublishedScene: caller validation → format validation →
 // header read (no content) → IsParticipant gate (NO ABAC) → PUBLISHED check →
 // content read only on gate pass → render. A non-participant is denied with
@@ -267,7 +267,7 @@ func (s *SceneServiceImpl) DownloadPublishedScene(ctx context.Context, req *scen
 			Errorf("publication not found"))
 	}
 
-	// INV-S9 plugin-code participant gate (NO ABAC); deny BEFORE any content
+	// INV-SCENE-60 plugin-code participant gate (NO ABAC); deny BEFORE any content
 	// read (INV-SCENE-32).
 	isParticipant, err := s.store.IsParticipant(ctx, pub.SceneID, callerID)
 	if err != nil {
@@ -419,7 +419,7 @@ func (s *SceneServiceImpl) DownloadPublicSceneArchive(ctx context.Context, req *
 }
 
 // ListScenePublishAttempts returns the audit list of a scene's publish
-// attempts to a participant. Participant-gated (INV-S9, plugin-code, NO ABAC):
+// attempts to a participant. Participant-gated (INV-SCENE-60, plugin-code, NO ABAC):
 // caller validation → IsParticipant gate on the scene → list. The summaries
 // carry NO content_entries (header only), so there is no content-read step;
 // the gate still runs first so a non-participant cannot enumerate the attempts
@@ -478,7 +478,7 @@ func assembleAttemptsResponse(attempts []PublishedScene) *scenev1.ListScenePubli
 // attempts` policy at command dispatch (spec §8, "ABAC-gated, not name-gated").
 // Like every other scene RPC, this handler trusts the host's authorization and
 // performs NO in-plugin role check — admin is ABAC-gated, never a plugin-code
-// gate (the inverse of INV-S9's hard privacy boundary, which is plugin-code by
+// gate (the inverse of INV-SCENE-60's hard privacy boundary, which is plugin-code by
 // design). Adding an in-handler role check here would create a runtime
 // privilege gradient and duplicate the policy engine.
 func (s *SceneServiceImpl) ExtendScenePublishVoteAttempts(ctx context.Context, req *scenev1.ExtendScenePublishVoteAttemptsRequest) (*scenev1.ExtendScenePublishVoteAttemptsResponse, error) {

--- a/plugins/core-scenes/resolver_test.go
+++ b/plugins/core-scenes/resolver_test.go
@@ -33,7 +33,7 @@ func TestSceneResolverGetSchemaReturnsSceneAttributes(t *testing.T) {
 // TestResolverNeverExposesContentByForbiddenAttributeName pins INV-SCENE-34
 // (spec §9.3): the scene attribute resolver MUST NOT expose any attribute
 // whose name could carry IC content (pose/say/emit/ooc text, the publication
-// log, or content_entries). The hard privacy boundary (INV-S9) keeps log
+// log, or content_entries). The hard privacy boundary (INV-SCENE-60) keeps log
 // content out of the ABAC attribute path entirely; this is the regression
 // lock. It passes today — GetSchema exposes only id/owner/state/visibility/
 // location/participants/invitees — and fails any future PR that adds a
@@ -153,7 +153,7 @@ func TestResolveResourceReturnsParticipantsAndInviteesLists(t *testing.T) {
 // populated in the store, ResolveResource must omit them from the
 // returned attribute map.
 //
-// Spec §5.5 hard-privacy boundary / INV-S9 / ADR holomush-nt2d:
+// Spec §5.5 hard-privacy boundary / INV-SCENE-60 / ADR holomush-nt2d:
 // pose-order data is reachable exclusively via the gated GetPoseOrder RPC.
 func TestResolveResourceDoesNotLeakPoseOrderMetadata(t *testing.T) {
 	store := newFakeStore()

--- a/plugins/core-scenes/service.go
+++ b/plugins/core-scenes/service.go
@@ -52,14 +52,14 @@ type sceneStorer interface {
 	GetParticipant(ctx context.Context, sceneID, characterID string) (*ParticipantRow, error)
 	// IsParticipant returns true if the character is a current participant
 	// of the scene with role "owner" or "member" (NOT "invited"). Used by
-	// the INV-S9 plugin-code gate at GetPoseOrder per ADR holomush-nt2d.
+	// the INV-SCENE-60 plugin-code gate at GetPoseOrder per ADR holomush-nt2d.
 	// Returns (false, nil) if the character is not a participant — no
 	// distinction from "not found"; the gate's contract is binary.
 	IsParticipant(ctx context.Context, sceneID, characterID string) (bool, error)
 	// ListParticipantsWithPoseMeta fetches scenes.total_pose_count and the
 	// per-participant pose metadata (last_pose_at, last_pose_seq) for all
 	// owner+member rows in a single SELECT. Excludes invited role per
-	// INV-S9 pose-order-only-for-participants discipline. Pinned by spec
+	// INV-SCENE-60 pose-order-only-for-participants discipline. Pinned by spec
 	// §6.1 / INV-SCENE-7. See ADR holomush-r4th (denormalize pose-order metadata).
 	ListParticipantsWithPoseMeta(ctx context.Context, sceneID string) (ParticipantsWithPoseMeta, error)
 	// ListScenesForCharacter returns the scene IDs the character is
@@ -73,7 +73,7 @@ type sceneStorer interface {
 	// filtering are applied by the caller (iokti.13).
 	ListBoard(ctx context.Context, q BoardQuery) ([]*SceneRow, error)
 	// Phase 6 publication reads used by the publish-vote handlers. The
-	// header read deliberately EXCLUDES content_entries so the INV-S9
+	// header read deliberately EXCLUDES content_entries so the INV-SCENE-60
 	// participant gate runs between the header read and the content read
 	// (INV-SCENE-32). Implemented by *SceneStore in publish_store.go.
 	GetPublishedSceneHeader(ctx context.Context, id string) (*PublishedScene, error)
@@ -130,7 +130,7 @@ type SceneServiceImpl struct {
 	scenev1.UnimplementedSceneServiceServer
 	store     sceneStorer
 	eventSink pluginsdk.EventSink
-	gameID    string // per substrate INV-S4. Defaults to "main"; wired in Init.
+	gameID    string // per substrate INV-EVENTBUS-28. Defaults to "main"; wired in Init.
 	// Phase 6 publish-vote machinery.
 	cfg    SceneServiceConfig // game-wide vote/cool-off defaults.
 	events publishEventer     // scene_publish_* notice emitter; noop until Phase D wires the real one.
@@ -1093,7 +1093,7 @@ func (s *SceneServiceImpl) TransferOwnership(ctx context.Context, req *scenev1.T
 
 // GetPoseOrder returns the current pose-order entries for a scene.
 //
-// INV-S9 plugin-code gate: the caller MUST be a current participant
+// INV-SCENE-60 plugin-code gate: the caller MUST be a current participant
 // of the scene (owner or member, NOT invited). The ABAC engine is
 // NEVER consulted from this handler; INV-SCENE-4 (T23 meta-test, future
 // bead) enforces this by rg-asserting that no engine.Evaluate /
@@ -1121,7 +1121,7 @@ func (s *SceneServiceImpl) GetPoseOrder(ctx context.Context, req *scenev1.GetPos
 	)
 	defer span.End()
 
-	// INV-S9 gate: direct plugin-code participant check, NO ABAC.
+	// INV-SCENE-60 gate: direct plugin-code participant check, NO ABAC.
 	// Fires before scene-existence check to avoid leaking the
 	// existence of a scene to non-participants.
 	ok, err := s.store.IsParticipant(ctx, req.GetSceneId(), req.GetCharacterId())

--- a/plugins/core-scenes/service_publish_gate_test.go
+++ b/plugins/core-scenes/service_publish_gate_test.go
@@ -41,7 +41,7 @@ func (s *contentTripwireStore) GetPublishedSceneContent(ctx context.Context, id 
 }
 
 // TestGetPublishedSceneDeniesNonParticipantWithoutReadingContent is the
-// load-bearing INV-S9 / INV-SCENE-32 tripwire: a non-participant is denied with
+// load-bearing INV-SCENE-60 / INV-SCENE-32 tripwire: a non-participant is denied with
 // SCENE_PRIVACY_BOUNDARY_BLOCK (PermissionDenied) BEFORE any content read.
 func TestGetPublishedSceneDeniesNonParticipantWithoutReadingContent(t *testing.T) {
 	t.Parallel()
@@ -118,7 +118,7 @@ func TestGetPublishedSceneDenialEmitsPrivacyBoundaryWarn(t *testing.T) {
 	require.Error(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "scene privacy boundary block", "the §10 triple-signal WARN MUST fire on an INV-S9 denial")
+	assert.Contains(t, out, "scene privacy boundary block", "the §10 triple-signal WARN MUST fire on an INV-SCENE-60 denial")
 	assert.Contains(t, out, "SCENE_PRIVACY_BOUNDARY_BLOCK")
 	assert.Contains(t, out, "not_participant")
 	assert.Contains(t, out, "scene-3", "the WARN must record the affected scene")
@@ -259,7 +259,7 @@ func TestDownloadPublishedSceneRejectsNonPublishedAttempt(t *testing.T) {
 		"a non-published attempt must not reach the content read")
 }
 
-// TestListScenePublishAttemptsDeniesNonParticipant is the INV-S9 gate on the
+// TestListScenePublishAttemptsDeniesNonParticipant is the INV-SCENE-60 gate on the
 // audit list: a non-participant cannot enumerate a scene's publish attempts
 // (the list itself is participant-only, even though summaries carry no content).
 func TestListScenePublishAttemptsDeniesNonParticipant(t *testing.T) {

--- a/plugins/core-scenes/service_test.go
+++ b/plugins/core-scenes/service_test.go
@@ -1610,7 +1610,7 @@ func TestUpdateScene_NoEmit_OnNonModeUpdate(t *testing.T) {
 	assert.Equal(t, 0, count, "non-mode update MUST NOT emit scene_pose_order_changed_ic")
 }
 
-// TestGetPoseOrder_NotParticipant_PermissionDenied pins the INV-S9
+// TestGetPoseOrder_NotParticipant_PermissionDenied pins the INV-SCENE-60
 // plugin-code gate: a caller who is NOT a current participant of the
 // scene MUST receive PermissionDenied, NOT NotFound. The gate fires
 // before any scene-existence check so the error path does not leak
@@ -1636,10 +1636,10 @@ func TestGetPoseOrder_NotParticipant_PermissionDenied(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.PermissionDenied, st.Code(),
-		"non-participant MUST receive PermissionDenied (INV-S9 gate)")
+		"non-participant MUST receive PermissionDenied (INV-SCENE-60 gate)")
 }
 
-// TestGetPoseOrder_InvitedRole_PermissionDenied pins INV-S9's
+// TestGetPoseOrder_InvitedRole_PermissionDenied pins INV-SCENE-60's
 // "invited" exclusion: an invited (but not yet accepted) character
 // is NOT a member of the scene for pose-order purposes and MUST be
 // rejected by the gate. fakeStore.IsParticipant treats invited as
@@ -1670,11 +1670,11 @@ func TestGetPoseOrder_InvitedRole_PermissionDenied(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.PermissionDenied, st.Code(),
-		"invited-but-not-member MUST receive PermissionDenied (INV-S9 gate excludes invited role)")
+		"invited-but-not-member MUST receive PermissionDenied (INV-SCENE-60 gate excludes invited role)")
 }
 
 // TestGetPoseOrder_NoScene_PermissionDenied pins the
-// scene-existence-non-disclosure aspect of INV-S9: a request for a
+// scene-existence-non-disclosure aspect of INV-SCENE-60: a request for a
 // non-existent scene from a non-participant returns PermissionDenied
 // (not NotFound). The IsParticipant gate runs before Get, so the
 // response collapses both "scene does not exist" and "you are not a
@@ -1692,7 +1692,7 @@ func TestGetPoseOrder_NoScene_PermissionDenied(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.PermissionDenied, st.Code(),
-		"non-existent scene MUST be indistinguishable from non-membership (INV-S9)")
+		"non-existent scene MUST be indistinguishable from non-membership (INV-SCENE-60)")
 }
 
 // TestGetPoseOrder_HappyPath_FreeMode verifies the composition:

--- a/plugins/core-scenes/store.go
+++ b/plugins/core-scenes/store.go
@@ -1247,7 +1247,7 @@ func (s *SceneStore) GetParticipant(ctx context.Context, sceneID, characterID st
 
 // IsParticipant reports whether the character is a participant (owner or
 // member, NOT invited) of the scene. The invited-role exclusion is
-// load-bearing: INV-S9's gate at GetPoseOrder MUST NOT treat pending
+// load-bearing: INV-SCENE-60's gate at GetPoseOrder MUST NOT treat pending
 // invites as participants. Pinned by spec INV-SCENE-4 / INV-SCENE-11.
 //
 // Returns (false, nil) for both "not found" and "invited" — the binary
@@ -1560,7 +1560,7 @@ func (s *SceneStore) classifyTransitionMiss(ctx context.Context, id string, span
 }
 
 // dotStyleSceneSubject returns the NATS dot-style entity-level subject
-// for a scene per substrate INV-S4: events.<gameID>.scene.<sceneID>.
+// for a scene per substrate INV-EVENTBUS-28: events.<gameID>.scene.<sceneID>.
 // Used for lifecycle/system events that target the scene itself, not
 // a facet. ADR holomush-s9nu.
 func dotStyleSceneSubject(gameID, sceneID string) string {

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -1638,7 +1638,7 @@ var _ = Describe("SceneStore", func() {
 
 			ok, err := store.IsParticipant(ctx, row.ID, "char-owner-1")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeTrue(), "owner MUST pass the INV-S9 gate")
+			Expect(ok).To(BeTrue(), "owner MUST pass the INV-SCENE-60 gate")
 		})
 
 		It("returns true for member", func() {
@@ -1656,10 +1656,10 @@ var _ = Describe("SceneStore", func() {
 
 			ok, err := store.IsParticipant(ctx, row.ID, "char-member-2")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeTrue(), "member MUST pass the INV-S9 gate")
+			Expect(ok).To(BeTrue(), "member MUST pass the INV-SCENE-60 gate")
 		})
 
-		It("returns false for invited role (NOT a participant for INV-S9 gate)", func() {
+		It("returns false for invited role (NOT a participant for INV-SCENE-60 gate)", func() {
 			store := newTestStore()
 			ctx := context.Background()
 			row := &SceneRow{
@@ -1674,7 +1674,7 @@ var _ = Describe("SceneStore", func() {
 
 			ok, err := store.IsParticipant(ctx, row.ID, "char-invitee-3")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeFalse(), "invited role MUST NOT count as participant for INV-S9 gate")
+			Expect(ok).To(BeFalse(), "invited role MUST NOT count as participant for INV-SCENE-60 gate")
 		})
 
 		It("returns false for character not in scene", func() {
@@ -1749,14 +1749,14 @@ var _ = Describe("SceneStore", func() {
 
 			result, err := store.ListParticipantsWithPoseMeta(ctx, sceneID)
 			Expect(err).NotTo(HaveOccurred())
-			// Only owner + member — invited MUST be excluded per INV-S9.
+			// Only owner + member — invited MUST be excluded per INV-SCENE-60.
 			Expect(result.Participants).To(HaveLen(2))
 			charIDs := make([]string, 0, 2)
 			for _, p := range result.Participants {
 				charIDs = append(charIDs, p.CharacterID)
 			}
 			Expect(charIDs).To(ConsistOf(owner, member))
-			Expect(charIDs).NotTo(ContainElement(invitee), "invited role MUST be excluded per INV-S9")
+			Expect(charIDs).NotTo(ContainElement(invitee), "invited role MUST be excluded per INV-SCENE-60")
 		})
 
 		It("reflects updated pose metadata after direct column write", func() {

--- a/site/src/content/docs/reference/grpc-api.md
+++ b/site/src/content/docs/reference/grpc-api.md
@@ -2963,7 +2963,7 @@ directly — the host routes it through the PluginEventEmitter.Emit fence.
 | stream | [string](#string) |  | Target stream the event is published to (legacy &#34;prefix:id&#34; form). |
 | type | [string](#string) |  | Event-type discriminator for the emitted event; gated by the manifest&#39;s emits / crypto.emits declarations at the fence. |
 | payload | [string](#string) |  | JSON-encoded payload (max 64 KiB); validated as well-formed JSON at the fence before publish. |
-| sensitive | [bool](#bool) |  | Per-event sensitivity claim for a return-value emit, validated against the plugin manifest by event_emitter.go::Emit via EnforceSensitivity (internal/plugin/sensitivity_fence.go) — INV-6: a sensitivity=never manifest rejects true; INV-7: a sensitivity=always manifest rejects false. Carries the same semantics as the active EmitEvent RPC&#39;s sensitive field so a binary plugin&#39;s return-value emit cannot silently downgrade to plaintext where the Lua runtime would encrypt (holomush-av954). Default false for backward compatibility. |
+| sensitive | [bool](#bool) |  | Per-event sensitivity claim for a return-value emit, validated against the plugin manifest by event_emitter.go::Emit via EnforceSensitivity (internal/plugin/sensitivity_fence.go) — INV-PLUGIN-29: a sensitivity=never manifest rejects true; INV-PLUGIN-30: a sensitivity=always manifest rejects false. Carries the same semantics as the active EmitEvent RPC&#39;s sensitive field so a binary plugin&#39;s return-value emit cannot silently downgrade to plaintext where the Lua runtime would encrypt (holomush-av954). Default false for backward compatibility. |
 
 
 
@@ -3115,7 +3115,7 @@ what it may emit.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | provided_services | [string](#string) | repeated | gRPC service names this plugin implements on the go-plugin transport, so the host&#39;s service registry can route requires→provides between plugins. |
-| registered_emit_types | [string](#string) | repeated | Set of plugin-owned event types this plugin may emit. Host validates set-equality against manifest&#39;s crypto.emits per INV-S5. Plugins without crypto.emits leave empty and skip validation; plugins WITH crypto.emits MUST populate (mismatch fails load). |
+| registered_emit_types | [string](#string) | repeated | Set of plugin-owned event types this plugin may emit. Host validates set-equality against manifest&#39;s crypto.emits per INV-PLUGIN-32. Plugins without crypto.emits leave empty and skip validation; plugins WITH crypto.emits MUST populate (mismatch fails load). |
 
 
 
@@ -3218,7 +3218,7 @@ x-holomush-emit-token header (see PluginHostService.EmitEvent).
 | stream | [string](#string) |  | Target stream (legacy &#34;prefix:id&#34; form); its namespace must be declared in the manifest&#39;s emits list or the fence rejects the emit. |
 | event_type | [string](#string) |  | Event-type discriminator for the emitted event. |
 | payload | [bytes](#bytes) |  | Raw event payload bytes (validated as JSON at the fence). |
-| sensitive | [bool](#bool) |  | sensitive declares per-event sensitivity at emit time. Phase 3a&#39;s host-side fence at internal/plugin/event_emitter.go::Emit validates this against the plugin manifest&#39;s declared sensitivity: - manifest sensitivity=never: sensitive=true rejected (INV-6). - manifest sensitivity=may: sensitive=true|false honored. - manifest sensitivity=always: sensitive=false rejected (INV-7). Default false (proto3 zero) for older plugins compiled before this field existed — matching pre-Phase-3d behavior. |
+| sensitive | [bool](#bool) |  | sensitive declares per-event sensitivity at emit time. Phase 3a&#39;s host-side fence at internal/plugin/event_emitter.go::Emit validates this against the plugin manifest&#39;s declared sensitivity: - manifest sensitivity=never: sensitive=true rejected (INV-PLUGIN-29). - manifest sensitivity=may: sensitive=true/false honored. - manifest sensitivity=always: sensitive=false rejected (INV-PLUGIN-30). Default false (proto3 zero) for older plugins compiled before this field existed — matching pre-Phase-3d behavior. |
 
 
 
@@ -4035,7 +4035,7 @@ below, which the host implements and plugins call back into.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| Init | [InitRequest](#holomush-plugin-v1-InitRequest) | [InitResponse](#holomush-plugin-v1-InitResponse) | Init is the first call the host makes after the go-plugin handshake. It hands the plugin its ServiceConfig (DB connection string, required-service addresses, opaque runtime config) and returns the gRPC service names the plugin provides plus the emit-type set the host validates against the manifest&#39;s crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init, which also lazily dials the plugin-host connection for any host-facing facade (sink/focus/evaluator/decryptor) the provider opts into. |
+| Init | [InitRequest](#holomush-plugin-v1-InitRequest) | [InitResponse](#holomush-plugin-v1-InitResponse) | Init is the first call the host makes after the go-plugin handshake. It hands the plugin its ServiceConfig (DB connection string, required-service addresses, opaque runtime config) and returns the gRPC service names the plugin provides plus the emit-type set the host validates against the manifest&#39;s crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init, which also lazily dials the plugin-host connection for any host-facing facade (sink/focus/evaluator/decryptor) the provider opts into. |
 | HandleEvent | [HandleEventRequest](#holomush-plugin-v1-HandleEventRequest) | [HandleEventResponse](#holomush-plugin-v1-HandleEventResponse) | HandleEvent delivers one subscribed event to the plugin and collects the events the plugin wants to emit in response. Bridged by pluginServerAdapter.HandleEvent, which converts the proto Event to the SDK Event type, invokes the author&#39;s handler, and converts returned EmitEvents back to the wire. Response emits flow through the host emit fence, not straight to the bus. |
 | HandleCommand | [HandleCommandRequest](#holomush-plugin-v1-HandleCommandRequest) | [HandleCommandResponse](#holomush-plugin-v1-HandleCommandResponse) | HandleCommand delivers a parsed player command to the plugin and returns the command result (output text, status, response emits, and audit hints). Bridged by pluginServerAdapter.HandleCommand; if the plugin registered no command handler the adapter returns an empty response rather than erroring. |
 | QuerySessionStreams | [QuerySessionStreamsRequest](#holomush-plugin-v1-QuerySessionStreamsRequest) | [QuerySessionStreamsResponse](#holomush-plugin-v1-QuerySessionStreamsResponse) | QuerySessionStreams asks the plugin which stream names it wants subscribed for a session being established, before LISTEN/subscription setup. Called exactly once at session establishment, and only for plugins that declare session_streams: true in their manifest. A plugin-reported error degrades gracefully (the host logs and skips that plugin&#39;s contribution). |
@@ -4191,7 +4191,7 @@ and their MIME type.
 
 ### DownloadPublishedSceneRequest
 DownloadPublishedSceneRequest fetches a PUBLISHED attempt rendered to a file
-format, as a participant (participant-gated, INV-S9).
+format, as a participant (participant-gated, INV-SCENE-60).
 
 
 | Field | Type | Label | Description |
@@ -4365,7 +4365,7 @@ failure_reason (the §5.1 two-pair separation).
 
 ### GetPublishedSceneRequest
 GetPublishedSceneRequest reads a publication attempt&#39;s full state as a scene
-participant (participant-gated, INV-S9).
+participant (participant-gated, INV-SCENE-60).
 
 
 | Field | Type | Label | Description |
@@ -4555,7 +4555,7 @@ body.
 
 ### ListScenePublishAttemptsRequest
 ListScenePublishAttemptsRequest lists a scene&#39;s publication attempts as a
-participant (participant-gated, INV-S9).
+participant (participant-gated, INV-SCENE-60).
 
 
 | Field | Type | Label | Description |
@@ -5091,7 +5091,7 @@ has already authorized the command-execute action at dispatch time
 the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
 (SceneServiceImpl holds no policy engine). The sole exceptions are the
 participant-gate reads (GetPoseOrder and the publish reads), which enforce a
-direct plugin-code participation check (INV-S9) precisely because it is a
+direct plugin-code participation check (INV-SCENE-60) precisely because it is a
 hard privacy boundary that must not be delegable.
 
 Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -5112,16 +5112,16 @@ plugins/core-scenes/publish_service.go.
 | KickFromScene | [KickFromSceneRequest](#holomush-scene-v1-KickFromSceneRequest) | [KickFromSceneResponse](#holomush-scene-v1-KickFromSceneResponse) | KickFromScene removes a target character from a scene (owner-only via ABAC). The scene owner cannot be kicked (codes.FailedPrecondition, enforced both at the service layer and by a store WHERE filter). Emits a leave IC notice with reason=kicked. See service.go::KickFromScene. |
 | TransferOwnership | [TransferOwnershipRequest](#holomush-scene-v1-TransferOwnershipRequest) | [TransferOwnershipResponse](#holomush-scene-v1-TransferOwnershipResponse) | TransferOwnership reassigns scene ownership from the calling owner to a target who MUST already be a member (owner-only via ABAC). The former owner is demoted to member. See service.go::TransferOwnership. |
 | CastPublishVote | [CastPublishVoteRequest](#holomush-scene-v1-CastPublishVoteRequest) | [CastPublishVoteResponse](#holomush-scene-v1-CastPublishVoteResponse) | CastPublishVote is DECLARED BUT NOT SERVED. It is the legacy scene-keyed publish-vote shape, superseded by CastPublishSceneVote (which is keyed by published_scene_id and is the served vote RPC). The plugin provides no handler, so a call returns codes.Unimplemented. |
-| GetPoseOrder | [GetPoseOrderRequest](#holomush-scene-v1-GetPoseOrderRequest) | [GetPoseOrderResponse](#holomush-scene-v1-GetPoseOrderResponse) | GetPoseOrder returns the computed pose-order roster for a scene. Enforces the INV-S9 plugin-code participant gate (caller MUST be an owner or member, NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate fires before any existence check so a non-participant cannot distinguish a missing scene from one they may not see. See service.go::GetPoseOrder. |
+| GetPoseOrder | [GetPoseOrderRequest](#holomush-scene-v1-GetPoseOrderRequest) | [GetPoseOrderResponse](#holomush-scene-v1-GetPoseOrderResponse) | GetPoseOrder returns the computed pose-order roster for a scene. Enforces the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member, NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate fires before any existence check so a non-participant cannot distinguish a missing scene from one they may not see. See service.go::GetPoseOrder. |
 | StartScenePublish | [StartScenePublishRequest](#holomush-scene-v1-StartScenePublishRequest) | [StartScenePublishResponse](#holomush-scene-v1-StartScenePublishResponse) | StartScenePublish opens a publication attempt for an `ended` scene (publish.go §5 precondition ladder). The scene must be ended, must not already have a published archive (one-and-done) nor an active attempt, and must not have exhausted its attempt budget. Seeds a COLLECTING attempt with a frozen vote roster. See publish_service.go::StartScenePublish. |
 | CastPublishSceneVote | [CastPublishSceneVoteRequest](#holomush-scene-v1-CastPublishSceneVoteRequest) | [CastPublishSceneVoteResponse](#holomush-scene-v1-CastPublishSceneVoteResponse) | CastPublishSceneVote records a roster member&#39;s yes/no vote on an active publication attempt and runs the §4.3 resolution check, which may transition the attempt (COLLECTING→COOLOFF on all-yes, COLLECTING→ ATTEMPT_FAILED on any-no-after-all-voted, or COOLOFF→COLLECTING on a flip to no). A vote on a terminal attempt is rejected. The recorded vote is the durable effect; a failed resolution or emit is logged but does not fail the cast. See publish_service.go::CastPublishSceneVote. |
 | WithdrawScenePublish | [WithdrawScenePublishRequest](#holomush-scene-v1-WithdrawScenePublishRequest) | [WithdrawScenePublishResponse](#holomush-scene-v1-WithdrawScenePublishResponse) | WithdrawScenePublish lets the scene owner abandon an active publication attempt (COLLECTING or COOLOFF), transitioning it to ATTEMPT_FAILED with failure_reason WITHDRAWN. Owner-gated by ABAC AND a defense-in-depth in-handler owner check (the plugin holds the owner attribute, so this closes the direct-RPC gap). See publish_service.go::WithdrawScenePublish. |
-| GetPublishedScene | [GetPublishedSceneRequest](#holomush-scene-v1-GetPublishedSceneRequest) | [GetPublishedSceneResponse](#holomush-scene-v1-GetPublishedSceneResponse) | GetPublishedScene returns a publication attempt&#39;s full state to a scene participant. Enforces the INV-S9 plugin-code participant gate with a load-bearing step order (INV-SCENE-32): header read → participant gate → content read (only for PUBLISHED rows, only after the gate passes). A non-participant is denied with the §10 triple-signal before any content is read. See publish_service.go::GetPublishedScene. |
+| GetPublishedScene | [GetPublishedSceneRequest](#holomush-scene-v1-GetPublishedSceneRequest) | [GetPublishedSceneResponse](#holomush-scene-v1-GetPublishedSceneResponse) | GetPublishedScene returns a publication attempt&#39;s full state to a scene participant. Enforces the INV-SCENE-60 plugin-code participant gate with a load-bearing step order (INV-SCENE-32): header read → participant gate → content read (only for PUBLISHED rows, only after the gate passes). A non-participant is denied with the §10 triple-signal before any content is read. See publish_service.go::GetPublishedScene. |
 | DownloadPublishedScene | [DownloadPublishedSceneRequest](#holomush-scene-v1-DownloadPublishedSceneRequest) | [DownloadPublishedSceneResponse](#holomush-scene-v1-DownloadPublishedSceneResponse) | DownloadPublishedScene returns a PUBLISHED attempt rendered in the requested format (markdown/plain_text/jsonl) to a participant. Same load-bearing participant-gate ordering as GetPublishedScene; only PUBLISHED attempts are downloadable. See publish_service.go::DownloadPublishedScene. |
-| ListScenePublishAttempts | [ListScenePublishAttemptsRequest](#holomush-scene-v1-ListScenePublishAttemptsRequest) | [ListScenePublishAttemptsResponse](#holomush-scene-v1-ListScenePublishAttemptsResponse) | ListScenePublishAttempts returns the audit list of a scene&#39;s publication attempts (header summaries, no content) to a participant. Participant-gated (INV-S9) so a non-participant cannot enumerate attempts. See publish_service.go::ListScenePublishAttempts. |
+| ListScenePublishAttempts | [ListScenePublishAttemptsRequest](#holomush-scene-v1-ListScenePublishAttemptsRequest) | [ListScenePublishAttemptsResponse](#holomush-scene-v1-ListScenePublishAttemptsResponse) | ListScenePublishAttempts returns the audit list of a scene&#39;s publication attempts (header summaries, no content) to a participant. Participant-gated (INV-SCENE-60) so a non-participant cannot enumerate attempts. See publish_service.go::ListScenePublishAttempts. |
 | GetPublicSceneArchive | [GetPublicSceneArchiveRequest](#holomush-scene-v1-GetPublicSceneArchiveRequest) | [GetPublicSceneArchiveResponse](#holomush-scene-v1-GetPublicSceneArchiveResponse) | GetPublishedScene&#39;s PUBLIC counterpart: GetPublicSceneArchive is the unauthenticated read of a published scene. Structurally separate — NO caller validation, NO participant gate, NO ABAC. The only gate is status==PUBLISHED; a missing id OR any non-PUBLISHED attempt returns one opaque NOT_FOUND so existence/progress of an attempt cannot be inferred (INV-SCENE-35). Carries only public-safe fields. See publish_service.go::GetPublicSceneArchive. |
 | DownloadPublicSceneArchive | [DownloadPublicSceneArchiveRequest](#holomush-scene-v1-DownloadPublicSceneArchiveRequest) | [DownloadPublicSceneArchiveResponse](#holomush-scene-v1-DownloadPublicSceneArchiveResponse) | DownloadPublicSceneArchive is the PUBLIC, unauthenticated download of a published scene in the requested format. Same status-gate and opacity contract (INV-SCENE-35) as GetPublicSceneArchive; shares the renderer with DownloadPublishedScene. See publish_service.go::DownloadPublicSceneArchive. |
-| ExtendScenePublishVoteAttempts | [ExtendScenePublishVoteAttemptsRequest](#holomush-scene-v1-ExtendScenePublishVoteAttemptsRequest) | [ExtendScenePublishVoteAttemptsResponse](#holomush-scene-v1-ExtendScenePublishVoteAttemptsResponse) | ExtendScenePublishVoteAttempts raises a scene&#39;s max-publish-attempts budget by a positive amount and emits the extension notice. Admin-only, enforced by the host&#39;s ABAC policy at dispatch — there is deliberately NO in-plugin role check (the inverse of INV-S9&#39;s plugin-code privacy gate). See publish_service.go::ExtendScenePublishVoteAttempts. |
+| ExtendScenePublishVoteAttempts | [ExtendScenePublishVoteAttemptsRequest](#holomush-scene-v1-ExtendScenePublishVoteAttemptsRequest) | [ExtendScenePublishVoteAttemptsResponse](#holomush-scene-v1-ExtendScenePublishVoteAttemptsResponse) | ExtendScenePublishVoteAttempts raises a scene&#39;s max-publish-attempts budget by a positive amount and emits the extension notice. Admin-only, enforced by the host&#39;s ABAC policy at dispatch — there is deliberately NO in-plugin role check (the inverse of INV-SCENE-60&#39;s plugin-code privacy gate). See publish_service.go::ExtendScenePublishVoteAttempts. |
 
  
 

--- a/test/integration/scenes/publish_e2e_test.go
+++ b/test/integration/scenes/publish_e2e_test.go
@@ -142,7 +142,7 @@ var _ = Describe("happy-path scene publish lifecycle reaches PUBLISHED with decr
 //
 //   - INV-SCENE-35: GetPublicSceneArchive returns codes.NotFound (opaque) while
 //     the attempt is COLLECTING — the attempt's existence MUST NOT leak.
-//   - INV-S9:   GetPublishedScene returns codes.PermissionDenied for a
+//   - INV-SCENE-60:   GetPublishedScene returns codes.PermissionDenied for a
 //     non-participant after PUBLISHED (plugin-code participant gate;
 //     SCENE_PRIVACY_BOUNDARY_BLOCK → PermissionDenied).
 //   - INV-SCENE-35 (post-publish): GetPublicSceneArchive flips from NOT_FOUND to
@@ -153,7 +153,7 @@ var _ = Describe("happy-path scene publish lifecycle reaches PUBLISHED with decr
 // emitPrivacyBoundaryBlock fires INSIDE the binary subprocess and is NOT
 // capturable in-process from this E2E harness. That signal is unit-covered by
 // plugins/core-scenes/service_privacy_block_test.go (Task D7). This spec
-// asserts only the wire-observable gRPC status codes (INV-S9 / spec §9.1).
+// asserts only the wire-observable gRPC status codes (INV-SCENE-60 / spec §9.1).
 //
 // NOTE: INV-SCENE-34 (AttributeResolverService MUST NOT leak content under any
 // attribute) is unit-covered by
@@ -289,7 +289,7 @@ var _ = Describe("Phase 6 hard-privacy-boundary gate for a non-participant (Char
 		Expect(publishedSceneID).To(Equal(collectingAttemptID),
 			"PUBLISHED attempt must be the same row that was COLLECTING (transition, not replacement)")
 
-		// ── POST-PUBLISH: INV-S9 denial on GetPublishedScene ─────────────────
+		// ── POST-PUBLISH: INV-SCENE-60 denial on GetPublishedScene ─────────────────
 		// Charlie (non-participant) calls GetPublishedScene with the published
 		// attempt id. The plugin-code IsParticipant gate (publish_service.go,
 		// GetPublishedScene step 3) fires BEFORE any content is read and returns
@@ -298,7 +298,7 @@ var _ = Describe("Phase 6 hard-privacy-boundary gate for a non-participant (Char
 		// error from emitPrivacyBoundaryBlock) fires inside the binary subprocess
 		// and is NOT observable here — it is unit-covered by D7
 		// (plugins/core-scenes/service_privacy_block_test.go). This assertion is
-		// the wire-observable contract (INV-S9 / spec §9.1).
+		// the wire-observable contract (INV-SCENE-60 / spec §9.1).
 		_, deniedErr := ts.SceneServiceClient().GetPublishedScene(ctx, &scenev1.GetPublishedSceneRequest{
 			CallerCharacterId: charlie.CharacterID.String(),
 			PublishedSceneId:  publishedSceneID,
@@ -306,7 +306,7 @@ var _ = Describe("Phase 6 hard-privacy-boundary gate for a non-participant (Char
 		deniedSt, deniedOk := status.FromError(deniedErr)
 		Expect(deniedOk).To(BeTrue(), "GetPublishedScene must return a gRPC status error for non-participant Charlie")
 		Expect(deniedSt.Code()).To(Equal(codes.PermissionDenied),
-			"INV-S9: non-participant GetPublishedScene MUST return PermissionDenied (SCENE_PRIVACY_BOUNDARY_BLOCK)")
+			"INV-SCENE-60: non-participant GetPublishedScene MUST return PermissionDenied (SCENE_PRIVACY_BOUNDARY_BLOCK)")
 
 		// ── POST-PUBLISH: INV-SCENE-35 opacity flip on GetPublicSceneArchive ─────
 		// Once PUBLISHED the public archive has NO caller gate (no participant

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_connect.ts
@@ -29,7 +29,7 @@ export const PluginService = {
      * hands the plugin its ServiceConfig (DB connection string, required-service
      * addresses, opaque runtime config) and returns the gRPC service names the
      * plugin provides plus the emit-type set the host validates against the
-     * manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+     * manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
      * which also lazily dials the plugin-host connection for any host-facing
      * facade (sink/focus/evaluator/decryptor) the provider opts into.
      *

--- a/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/plugin_pb.ts
@@ -101,7 +101,7 @@ export type InitResponse = Message<"holomush.plugin.v1.InitResponse"> & {
 
   /**
    * Set of plugin-owned event types this plugin may emit. Host validates
-   * set-equality against manifest's crypto.emits per INV-S5. Plugins
+   * set-equality against manifest's crypto.emits per INV-PLUGIN-32. Plugins
    * without crypto.emits leave empty and skip validation; plugins WITH
    * crypto.emits MUST populate (mismatch fails load).
    *
@@ -232,8 +232,8 @@ export type EmitEvent = Message<"holomush.plugin.v1.EmitEvent"> & {
   /**
    * Per-event sensitivity claim for a return-value emit, validated against the
    * plugin manifest by event_emitter.go::Emit via EnforceSensitivity
-   * (internal/plugin/sensitivity_fence.go) — INV-6: a sensitivity=never manifest
-   * rejects true; INV-7: a sensitivity=always manifest rejects false. Carries
+   * (internal/plugin/sensitivity_fence.go) — INV-PLUGIN-29: a sensitivity=never manifest
+   * rejects true; INV-PLUGIN-30: a sensitivity=always manifest rejects false. Carries
    * the same semantics as the active EmitEvent RPC's sensitive field so a binary
    * plugin's return-value emit cannot silently downgrade to plaintext where the
    * Lua runtime would encrypt (holomush-av954). Default false for backward
@@ -577,9 +577,9 @@ export type PluginHostServiceEmitEventRequest = Message<"holomush.plugin.v1.Plug
    * sensitive declares per-event sensitivity at emit time.
    * Phase 3a's host-side fence at internal/plugin/event_emitter.go::Emit
    * validates this against the plugin manifest's declared sensitivity:
-   *   - manifest sensitivity=never:  sensitive=true rejected (INV-6).
-   *   - manifest sensitivity=may:    sensitive=true|false honored.
-   *   - manifest sensitivity=always: sensitive=false rejected (INV-7).
+   *   - manifest sensitivity=never:  sensitive=true rejected (INV-PLUGIN-29).
+   *   - manifest sensitivity=may:    sensitive=true/false honored.
+   *   - manifest sensitivity=always: sensitive=false rejected (INV-PLUGIN-30).
    * Default false (proto3 zero) for older plugins compiled before this
    * field existed — matching pre-Phase-3d behavior.
    *
@@ -2144,7 +2144,7 @@ export const PluginService: GenService<{
    * hands the plugin its ServiceConfig (DB connection string, required-service
    * addresses, opaque runtime config) and returns the gRPC service names the
    * plugin provides plus the emit-type set the host validates against the
-   * manifest's crypto.emits (INV-S5). Bridged by pluginServerAdapter.Init,
+   * manifest's crypto.emits (INV-PLUGIN-32). Bridged by pluginServerAdapter.Init,
    * which also lazily dials the plugin-host connection for any host-facing
    * facade (sink/focus/evaluator/decryptor) the provider opts into.
    *

--- a/web/src/lib/connect/holomush/scene/v1/scene_connect.ts
+++ b/web/src/lib/connect/holomush/scene/v1/scene_connect.ts
@@ -24,7 +24,7 @@ import { MethodKind } from "@bufbuild/protobuf";
  * the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
  * (SceneServiceImpl holds no policy engine). The sole exceptions are the
  * participant-gate reads (GetPoseOrder and the publish reads), which enforce a
- * direct plugin-code participation check (INV-S9) precisely because it is a
+ * direct plugin-code participation check (INV-SCENE-60) precisely because it is a
  * hard privacy boundary that must not be delegable.
  *
  * Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -220,7 +220,7 @@ export const SceneService = {
     },
     /**
      * GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-     * the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+     * the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
      * NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
      * fires before any existence check so a non-participant cannot distinguish a
      * missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -282,7 +282,7 @@ export const SceneService = {
     },
     /**
      * GetPublishedScene returns a publication attempt's full state to a scene
-     * participant. Enforces the INV-S9 plugin-code participant gate with a
+     * participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
      * load-bearing step order (INV-SCENE-32): header read → participant gate → content
      * read (only for PUBLISHED rows, only after the gate passes). A non-participant
      * is denied with the §10 triple-signal before any content is read. See
@@ -313,7 +313,7 @@ export const SceneService = {
     /**
      * ListScenePublishAttempts returns the audit list of a scene's publication
      * attempts (header summaries, no content) to a participant. Participant-gated
-     * (INV-S9) so a non-participant cannot enumerate attempts. See
+     * (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
      * publish_service.go::ListScenePublishAttempts.
      *
      * @generated from rpc holomush.scene.v1.SceneService.ListScenePublishAttempts
@@ -359,7 +359,7 @@ export const SceneService = {
      * ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
      * by a positive amount and emits the extension notice. Admin-only, enforced
      * by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-     * role check (the inverse of INV-S9's plugin-code privacy gate). See
+     * role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
      * publish_service.go::ExtendScenePublishVoteAttempts.
      *
      * @generated from rpc holomush.scene.v1.SceneService.ExtendScenePublishVoteAttempts

--- a/web/src/lib/connect/holomush/scene/v1/scene_pb.ts
+++ b/web/src/lib/connect/holomush/scene/v1/scene_pb.ts
@@ -1339,7 +1339,7 @@ export const PublishedSceneVoteSummarySchema: GenMessage<PublishedSceneVoteSumma
 
 /**
  * GetPublishedSceneRequest reads a publication attempt's full state as a scene
- * participant (participant-gated, INV-S9).
+ * participant (participant-gated, INV-SCENE-60).
  *
  * @generated from message holomush.scene.v1.GetPublishedSceneRequest
  */
@@ -1480,7 +1480,7 @@ export const GetPublishedSceneResponseSchema: GenMessage<GetPublishedSceneRespon
 
 /**
  * DownloadPublishedSceneRequest fetches a PUBLISHED attempt rendered to a file
- * format, as a participant (participant-gated, INV-S9).
+ * format, as a participant (participant-gated, INV-SCENE-60).
  *
  * @generated from message holomush.scene.v1.DownloadPublishedSceneRequest
  */
@@ -1546,7 +1546,7 @@ export const DownloadPublishedSceneResponseSchema: GenMessage<DownloadPublishedS
 
 /**
  * ListScenePublishAttemptsRequest lists a scene's publication attempts as a
- * participant (participant-gated, INV-S9).
+ * participant (participant-gated, INV-SCENE-60).
  *
  * @generated from message holomush.scene.v1.ListScenePublishAttemptsRequest
  */
@@ -2120,7 +2120,7 @@ export const ScenePublishVoteAttemptsExtendedEventSchema: GenMessage<ScenePublis
  * the publish-attempt-budget extension). The plugin itself runs NO ABAC engine
  * (SceneServiceImpl holds no policy engine). The sole exceptions are the
  * participant-gate reads (GetPoseOrder and the publish reads), which enforce a
- * direct plugin-code participation check (INV-S9) precisely because it is a
+ * direct plugin-code participation check (INV-SCENE-60) precisely because it is a
  * hard privacy boundary that must not be delegable.
  *
  * Implemented by SceneServiceImpl in plugins/core-scenes/service.go and
@@ -2301,7 +2301,7 @@ export const SceneService: GenService<{
   },
   /**
    * GetPoseOrder returns the computed pose-order roster for a scene. Enforces
-   * the INV-S9 plugin-code participant gate (caller MUST be an owner or member,
+   * the INV-SCENE-60 plugin-code participant gate (caller MUST be an owner or member,
    * NOT merely invited; NO ABAC engine is consulted). The PermissionDenied gate
    * fires before any existence check so a non-participant cannot distinguish a
    * missing scene from one they may not see. See service.go::GetPoseOrder.
@@ -2359,7 +2359,7 @@ export const SceneService: GenService<{
   },
   /**
    * GetPublishedScene returns a publication attempt's full state to a scene
-   * participant. Enforces the INV-S9 plugin-code participant gate with a
+   * participant. Enforces the INV-SCENE-60 plugin-code participant gate with a
    * load-bearing step order (INV-SCENE-32): header read → participant gate → content
    * read (only for PUBLISHED rows, only after the gate passes). A non-participant
    * is denied with the §10 triple-signal before any content is read. See
@@ -2388,7 +2388,7 @@ export const SceneService: GenService<{
   /**
    * ListScenePublishAttempts returns the audit list of a scene's publication
    * attempts (header summaries, no content) to a participant. Participant-gated
-   * (INV-S9) so a non-participant cannot enumerate attempts. See
+   * (INV-SCENE-60) so a non-participant cannot enumerate attempts. See
    * publish_service.go::ListScenePublishAttempts.
    *
    * @generated from rpc holomush.scene.v1.SceneService.ListScenePublishAttempts
@@ -2431,7 +2431,7 @@ export const SceneService: GenService<{
    * ExtendScenePublishVoteAttempts raises a scene's max-publish-attempts budget
    * by a positive amount and emits the extension notice. Admin-only, enforced
    * by the host's ABAC policy at dispatch — there is deliberately NO in-plugin
-   * role check (the inverse of INV-S9's plugin-code privacy gate). See
+   * role check (the inverse of INV-SCENE-60's plugin-code privacy gate). See
    * publish_service.go::ExtendScenePublishVoteAttempts.
    *
    * @generated from rpc holomush.scene.v1.SceneService.ExtendScenePublishVoteAttempts


### PR DESCRIPTION
## What

Classification pass **2/2** for the `.14.17` final-verification prerequisite (epic **holomush-hz0v4.14**, bead **holomush-hz0v4.14.24**) — the last two unclassified families. Doc-comment/annotation rename via `cmd/inv-migrate`; no behavior change.

### (A) master sensitivity-fence INV-6/INV-7 → INV-PLUGIN-29/30
The sole emit-time gate for the `crypto.emits` sensitivity contract: over-claim (`INV-6` → `EVENT_SENSITIVITY_NOT_DECLARED`) / under-claim (`INV-7` → `EVENT_SENSITIVITY_REQUIRED`) reject. Code home is the plugin-emit path; INV-PLUGIN's description is literally "emit gates".

**`INV-6` is six-way overloaded** — only the **8 fence sites** migrate (7 code + the `plugin.proto` `sensitive`-field doc). Correctly **left untouched**: reader-options `INV-6` (`cmd/sub_grpc_test.go` → INV-CRYPTO-5), settings `INV-6` (`host_service.go`), CI-tooling `INV-6` (`test/meta`), web-frontend `INV-6/7` (TS stores), and phase-8 board-content `INV-6/7` (already `INV-SCENE-58/59`).

### (B) INV-S* social-spaces substrate (per-token split by domain)
| Token | → | Domain |
|---|---|---|
| `INV-S3` | `INV-PLUGIN-31` | Go-SDK + Lua-hostfunc runtime parity |
| `INV-S5` | `INV-PLUGIN-32` | manifest crypto.emits set-equality startup validation |
| `INV-S4` | `INV-EVENTBUS-28` | NATS dot-style event subjects |
| `INV-S9` | `INV-SCENE-60` | scene-log privacy (plugin-code-enforced, ABAC-not-in-path) |

`INV-S1/S2/S6/S7/S8/S10` are spec-only/process invariants (no code refs). `service.go`/`store.go` carry **both** `INV-S4` (EVENTBUS) and `INV-S9` (SCENE) — recorded separately per token.

## Review-driven fix
crypto-reviewer caught fence `INV-6/7` in `plugin.proto` missing from the migrate set (my survey missed `api/proto/` — the recurring "missed dir" lesson, now folded into the survey checklist). Added plugin.proto to INV-PLUGIN-29/30 refs, re-migrated, regenerated.

## Verification
- `inv-migrate` applied (idempotent); zero `INV-S`/fence-`INV-6/7` in source + generated; compound `INV-6/INV-7` → `INV-PLUGIN-29/INV-PLUGIN-30` no dangling; foreign tokens preserved (INV-M7, reader-opts/settings/tooling/web INV-6).
- Guard + partition + binding + full `./test/meta/`; **full `task lint` incl `lint:yaml`** (ran `task fmt` after every yaml edit — .14.23 lesson); 1934 unit tests; build + plugin:build-all + integration-compile green.
- **crypto-reviewer READY** (fence/INV-S5 sensitivity contract unchanged). **code-reviewer READY** (tri-overload disambiguation verified, completeness scans clean incl cmd/+api/proto, dense numbering).

> Filed follow-up bead for residual stray tokens (reader-opts `INV-6`→CRYPTO-5, CI-tooling `INV-6`, `INV-M7`) to resolve before `.14.17`. EBNF bats self-test network-blocked offline (unrelated; zero DSL files).

**This completes the classification pass** — both `.14.23` (merged) and `.14.24` unblock `.14.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)