### PR TITLE
refactor(invariants): add INV-COMMAND scope (command-surfacing family) (holomush-hz0v4.14.27)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -1,42 +1,17 @@
-- **Per-family `// Verifies:`-grep coverage meta-test MUST be DELETED on registry
-  migration (hz0v4.14.9 NOT-READY).** `test/meta/i_<old>_coverage_test.go` greps
-  `// Verifies: I-<OLD>-N` and requires each 1..N bound. Migration renames every
-  annotation to `INV-<SCOPE>-N`, so the stale test finds ZERO and fails ALL N. `.14.5`
-  DELETED it; `.14.9` MISSED → I-PRIV-1..8 failed. Coverage is absorbed by registry-driven
-  `TestEveryRegistryInvariantHasBinding`. CHECK: after `rg 'Verifies:\s*I-<OLD>-[0-9]'
-  *_test.go`→ZERO, the `i_<old>_coverage_test.go` MUST be absent (if present = guaranteed
-  FAIL). FROM-anchor: `checkProvenance` greps canonical `e.ID` not `r.Token`, so refs
-  recording legacy tokens is harmless. Bare `go vet -tags=integration` `lostcancel`
-  warnings at //nolint:govet sites are NOT findings (`task lint` is the gate).
-  hz0v4.14.9 (2026-06-02) — NOT READY.
-
-- **Bare-INV-N (CLUSTER) migration is the same shape as I-<OLD>-N but the
-  per-family test lives in `test/meta/inv_binding_test.go`, not a separate
-  `i_<old>_coverage_test.go` (hz0v4.14.11 READY).** Phase-3c invariants
-  (INV-53..60 + INV-28/29) were tracked by
-  `TestEveryPhase3cInvariantHasAtLeastOneTestBinding` (scanned `// Verifies:
-  INV-<digits>`). On migration this test + its 3 locals
-  (`phase3cInvariants`/`invLintEnforced`/`verifiesRE`) MUST be removed, but the
-  shared `findRepoRoot`/`skipDirs` helpers in the SAME file MUST be KEPT (used by
-  10+ meta files — `liveness_invariants_test.go`, `proto_doc_comments_test.go`,
-  `invariant_registry_test.go`, etc.). Verify file still compiles via `task test
-  -- ./test/meta/`. The lone surviving `TestEveryPhase3c...` mention is fine if
-  it's in the rewritten doc-comment explaining the retirement (not a symbol ref).
-  Review pattern for bare-INV-N: (1) `rg '\bINV-(28|29|53..60)\b' -g '!docs/**'
-  -g '!*.md' -g '!test/meta/**'` → exit 1 (NO matches); (2) closed-world
-  {file,token} rewrite preserves co-located non-set bare tokens — INV-27 in
-  participants_cache.go must read "INV-CLUSTER-9 + INV-27", and CRYPTO tokens
-  (INV-9,12,13,17-21,25,26,30,32,33,34,37,39,49) elsewhere untouched; (3) DENSE
-  renumber: non-contiguous legacy maps ascending-by-position to 1..N — verify each
-  entry's `legacy:` AND every `refs[].token` equals the legacy token (awk
-  block-scan), no dup legacy; (4) gorules is a SEPARATE module — its analyzer
-  user-facing diagnostic message + Doc + testdata `// want` directives rename in
-  lockstep (INV-58→INV-CLUSTER-8); run `task test:gorules` after `go clean
-  -testcache` (else cached `ok` masks the testdata edit); (5) `task
-  lint:invariants` (= `inv-render -check`) must exit 0 for invariants.md sync.
-  Origin SPEC is NOT migrated (spec line still says INV-58) — by design; legacy
-  column in invariants.md/yaml records the link. Encountered: hz0v4.14.11
-  (2026-06-02) — READY.
+- **Early registry-migration lessons (.14.9 NOT-READY, .14.11 READY) — consolidated.**
+  (a) Fragile `// Verifies:`-grep coverage meta-tests (`test/meta/i_<old>_coverage_test.go`,
+  per-family `TestEveryPhase3c...` scanning `// Verifies: I-<OLD>-N`/`INV-<digits>`) MUST be
+  DELETED on migration — renamed annotations make them find ZERO and fail ALL N (.14.9 missed →
+  I-PRIV-1..8 failed). Coverage is absorbed by `TestEveryRegistryInvariantHasBinding`. DISTINCT
+  from robust `testName`-EXISTENCE checks (go/parser Test* names) which MIGRATE in lockstep. Keep
+  shared helpers (`findRepoRoot`/`skipDirs`) in a gutted meta file — 10+ files use them; verify
+  it still compiles. (b) FROM-anchor: `checkProvenance` greps canonical `e.ID`, NOT `r.Token`, so
+  refs recording legacy tokens is harmless/correct. (c) Origin SPEC is NOT migrated by design;
+  legacy column records the link. (d) gorules is a SEPARATE module — analyzer diagnostic + Doc +
+  testdata `// want` rename in lockstep; `go clean -testcache` before `task test:gorules`.
+  (e) `task lint:invariants` (= `inv-render -check`) must exit 0 for invariants.md sync. (f) DENSE
+  renumber maps non-contiguous legacy ascending-by-position; verify each entry's legacy + every
+  refs[].token. hz0v4.14.9 NOT-READY / .14.11 READY (2026-06-02).
 
 - **Multi-family + dense letter-suffix renumber (EVENTBUS=GW+ROPS+P7-split .14.12;
   SCENE=P4/P5/P6/FS/Y5INX/SH+bare → 59 ids/86 files .14.13; both READY).** GW dense
@@ -195,3 +170,27 @@
   foreign EVENTBUS-11/W9ML-8/CRYPTO/regen). Zero executable edits; dense PLUGIN 1..39.
   NO trailing-comma ,} noise this time. Counts CRYPTO=67/PLUGIN=39/ACCESS=8/EVENTBUS=28/
   SCENE=60. Encountered: hz0v4.14.27 (2026-06-04) — READY.
+
+- **NEW-scope creation by LAYER split (.14.27 PR B: INV-COMMAND, READY).** A
+  multi-INV design spec (recognized-command-chip INV-1..7) split by LAYER, not
+  number: Go-backend INV-1/2/5 → new scope INV-COMMAND-1/2/3; web-composer
+  presentation INV-3/4/6/7 → LEFT web-local (web/src TS), exempt. Review the
+  split BOTH directions: (1) no Go-backend annotation wrongly left — `rg 'INV-3\b'
+  internal/web/ internal/grpc/` → ZERO confirmed NOTHING to migrate (INV-3
+  gateway-boundary was conceptual, never code-annotated; WebListCommands proxy
+  carries no INV token). (2) No web-presentation token wrongly pulled in — the
+  chip INV-5 is LAYER-OVERLOADED: Go list_available_commands.go INV-5 (self-scoped
+  enum → COMMAND-3) migrated, web composerChip.integration.test.ts INV-5
+  (chip-omission) LEFT. Verify per-SITE, never value-keyed. Web TS INV-N tokens
+  (composerChip/commandListStore/CommandInput INV-4/5/6/7, themeStore INV-1..6,
+  ModeChip INV-1) are ALL distinct invariants — confirm none migrated. Apply the
+  .14.23 whole-tree sweep: `rg '\bINV-[125]\b'` over EVERY .go/.yaml mentioning
+  commandquery/list_commands/ListAvailableCommands/CommandQuerier → ZERO stale =
+  complete (registry guards are blind to unregistered files). New-scope partition:
+  scope owns commandquery/** + specific files; confirm NO other scope globs the
+  same dir — INV-PLUGIN owns specific hostfunc files (evaluate.go/stdlib_settings*
+  /functions_audit_wiring_test/stdlib_emit_registry) NOT commands.go/functions.go,
+  so no collision; functions.go/harness.go/census_test.go correctly shared (carry
+  foreign PLUGIN-27/32 / 13-scope / wholesystem-INV-5 tokens, residual-skipped).
+  Zero executable edits; dense 1..3; no generated artifact. Encountered:
+  hz0v4.14.27 PR B (2026-06-04) — READY.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -34,6 +34,7 @@ The prose outside the regions is hand-authored. CI runs `inv-render -check`
 | `INV-TELEMETRY` | Logging discipline, trace context, metric naming, sloglint policy | Observability contracts. |
 | `INV-BRANDING` | Asset integrity, palette tokens, logo generation | Visual identity invariants. Does NOT include: docs quality (separate concern). |
 | `INV-DOCS` | Proto doc comments, doc IA, contributor onboarding surface | Documentation quality invariants. |
+| `INV-COMMAND` | Command surfacing: the single command-visibility/ABAC filter, runtime parity across the Lua hostfunc + binary PluginHostService + CoreService RPC surfaces, and self-scoped enumeration. | Backend command-surfacing contract (origin 2026-05-29-recognized-command-chip-design.md, §INV-1/2/5). Does NOT include: web-composer chip presentation — INV-3 gateway boundary (→ .claude/rules/gateway-boundary.md), INV-4 server-sourced recognition, INV-6 graceful incompleteness, INV-7 speech-mode chips — those are web-frontend per-feature local numbering, exempt (.14.27), living in web/src TS (composerChip.ts/CommandInput.svelte/commandListStore.ts). Also does NOT include whole-system plugin load/census (wholesystem INV-5, distinct local numbering — co-located foreign in census_test.go, residual-skipped via shared_files). |
 
 <!-- END GENERATED: scope-index -->
 
@@ -348,5 +349,13 @@ invariants.
 | `INV-TELEMETRY-6` | Load scenario must not issue command verbs not registered in the running server (command-availability gating). | `INV-LOAD-6` | pending |
 | `INV-TELEMETRY-7` | Load action selection is seeded deterministically so two runs of the same scenario config produce the same action sequence. | `INV-LOAD-7` | pending |
 | `INV-TELEMETRY-8` | The load harness must not be wired into task pr-prep (fast lane). | `INV-LOAD-8` | pending |
+
+### `INV-COMMAND`
+
+| ID | Summary | Legacy | Binding |
+|----|---------|--------|---------|
+| `INV-COMMAND-1` | There MUST be exactly one command-visibility/ABAC-filter implementation (commandquery.Querier) in core; the Lua hostfunc shim, the binary PluginHostService handler, and the CoreService RPC MUST all delegate to it — none may reimplement the filter. | `INV-1` | pending |
+| `INV-COMMAND-2` | ListCommands and GetCommandHelp MUST be reachable by both Lua plugins (in-VM hostfunc bridge) and binary plugins (PluginHostService), both delegating to the same commandquery.Querier, so the ABAC-filtered command set is identical across runtimes. | `INV-2` | pending |
+| `INV-COMMAND-3` | The self-scoped enumeration RPC (WebListCommands / ListAvailableCommands) MUST return only commands the requesting character can execute, never ABAC-filtered-out ones; ownership failures collapse to SESSION_NOT_FOUND. | `INV-5` | pending |
 
 <!-- END GENERATED: invariant-tables -->

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -612,6 +612,39 @@ scopes:
       - "scripts/check-docs-ia.sh"
     shared_files: []
 
+  - name: INV-COMMAND
+    description: "Command surfacing: the single command-visibility/ABAC filter, runtime parity across the Lua hostfunc + binary
+      PluginHostService + CoreService RPC surfaces, and self-scoped enumeration."
+    boundary: "Backend command-surfacing contract (origin 2026-05-29-recognized-command-chip-design.md, §INV-1/2/5). Does
+      NOT include: web-composer chip presentation — INV-3 gateway boundary (→ .claude/rules/gateway-boundary.md), INV-4 server-sourced
+      recognition, INV-6 graceful incompleteness, INV-7 speech-mode chips — those are web-frontend per-feature local numbering,
+      exempt (.14.27), living in web/src TS (composerChip.ts/CommandInput.svelte/commandListStore.ts). Also does NOT include
+      whole-system plugin load/census (wholesystem INV-5, distinct local numbering — co-located foreign in census_test.go,
+      residual-skipped via shared_files)."
+    # .14.27 PR B: the recognized-command-chip design INV-1..7 splits by LAYER — INV-1/2/5 are the Go
+    # backend command-surfacing invariants (migrated here); INV-3/4/6/7 are web-composer presentation
+    # (exempt, web-local). The chip INV-5 token is layer-overloaded: Go list_available_commands.go =
+    # self-scoped enumeration (→ COMMAND-3); web composerChip.integration.test.ts INV-5 = chip-omission
+    # (web-local, LEFT). Per-SITE classification, never value-keyed. The earlier-spec "commandquery INV-1"
+    # and "command-introspection INV-2" are the SAME invariants referenced pre-chip-design; one canonical
+    # entry each. functions.go/harness.go/census_test.go are shared (multi-token: PLUGIN canonicals /
+    # 13-scope harness / wholesystem INV-5) — migrate only their INV-1 occurrence.
+    status: migrated
+    origin_specs:
+      - "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"
+    owned_paths:
+      - "internal/command/commandquery/**"
+      - "internal/plugin/hostfunc/commands.go"
+      - "internal/plugin/hostfunc/commands_test.go"
+      - "internal/grpc/list_available_commands.go"
+      - "test/integration/plugin/command_introspection_parity_test.go"
+      - "test/integration/plugin/testdata/cmd_introspection_plugin/main.go"
+      - "test/integration/plugin/testdata/cmd_introspection_plugin/plugin.yaml"
+    shared_files:
+      - "internal/plugin/hostfunc/functions.go"
+      - "internal/testsupport/integrationtest/harness.go"
+      - "test/integration/wholesystem/census_test.go"
+
 invariants:
   # ── INV-CRYPTO ── migrated (holomush-hz0v4.14.15). Origins: 2026-04-25 master
   # crypto, 2026-05-25 plugin-readback (RB), 2026-05-13 phase-7 (P7 crypto half),
@@ -3403,3 +3436,39 @@ invariants:
     binding: pending
     refs:
       - {file: "internal/plugin/goplugin/manager_parity_test.go", token: "INV-M7"}
+  - id: INV-COMMAND-1
+    scope: INV-COMMAND
+    origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"
+    legacy: ["INV-1@docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"]
+    summary: "There MUST be exactly one command-visibility/ABAC-filter implementation (commandquery.Querier) in core; the
+      Lua hostfunc shim, the binary PluginHostService handler, and the CoreService RPC MUST all delegate to it — none may
+      reimplement the filter."
+    binding: pending
+    refs:
+      - {file: "internal/command/commandquery/query.go", token: "INV-1"}
+      - {file: "internal/plugin/hostfunc/commands.go", token: "INV-1"}
+      - {file: "internal/plugin/hostfunc/commands_test.go", token: "INV-1"}
+      - {file: "internal/plugin/hostfunc/functions.go", token: "INV-1"}
+      - {file: "internal/testsupport/integrationtest/harness.go", token: "INV-1"}
+      - {file: "test/integration/wholesystem/census_test.go", token: "INV-1"}
+  - id: INV-COMMAND-2
+    scope: INV-COMMAND
+    origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"
+    legacy: ["INV-2@docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"]
+    summary: "ListCommands and GetCommandHelp MUST be reachable by both Lua plugins (in-VM hostfunc bridge) and binary plugins
+      (PluginHostService), both delegating to the same commandquery.Querier, so the ABAC-filtered command set is identical
+      across runtimes."
+    binding: pending
+    refs:
+      - {file: "test/integration/plugin/command_introspection_parity_test.go", token: "INV-2"}
+      - {file: "test/integration/plugin/testdata/cmd_introspection_plugin/main.go", token: "INV-2"}
+      - {file: "test/integration/plugin/testdata/cmd_introspection_plugin/plugin.yaml", token: "INV-2"}
+  - id: INV-COMMAND-3
+    scope: INV-COMMAND
+    origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"
+    legacy: ["INV-5@docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"]
+    summary: "The self-scoped enumeration RPC (WebListCommands / ListAvailableCommands) MUST return only commands the requesting
+      character can execute, never ABAC-filtered-out ones; ownership failures collapse to SESSION_NOT_FOUND."
+    binding: pending
+    refs:
+      - {file: "internal/grpc/list_available_commands.go", token: "INV-5"}

--- a/internal/command/commandquery/query.go
+++ b/internal/command/commandquery/query.go
@@ -4,7 +4,7 @@
 // Package commandquery owns the single ABAC-filtered enumeration of registered
 // commands for a subject. The Lua hostfunc bridge, the binary PluginHostService
 // handler, and the CoreService RPC are intended to delegate here so there is
-// exactly one command-visibility filter (design spec INV-1); the delegating
+// exactly one command-visibility filter (design spec INV-COMMAND-1); the delegating
 // adapters land in later tasks of the recognized-command-chip plan.
 package commandquery
 

--- a/internal/grpc/list_available_commands.go
+++ b/internal/grpc/list_available_commands.go
@@ -16,7 +16,7 @@ import (
 
 // ListAvailableCommands returns the commands the session's own character may
 // execute. Self-scoped (the subject is the session character, never an arbitrary
-// id) per design INV-5. Ownership failures collapse to SESSION_NOT_FOUND, mirroring
+// id) per design INV-COMMAND-3. Ownership failures collapse to SESSION_NOT_FOUND, mirroring
 // ListFocusPresence.
 func (s *CoreServer) ListAvailableCommands(ctx context.Context, req *corev1.ListAvailableCommandsRequest) (*corev1.ListAvailableCommandsResponse, error) {
 	if req == nil {

--- a/internal/plugin/hostfunc/commands.go
+++ b/internal/plugin/hostfunc/commands.go
@@ -18,7 +18,7 @@ import (
 // WithCommandQuerier injects the shared command-query service. The
 // list_commands / get_command_help host functions delegate to it exclusively,
 // providing the single ABAC-filtered enumeration via commandquery.Querier
-// (design spec INV-1: exactly one command-visibility filter). There is no
+// (design spec INV-COMMAND-1: exactly one command-visibility filter). There is no
 // second filter implementation in this package.
 func WithCommandQuerier(q *commandquery.Querier) Option {
 	return func(f *Functions) {
@@ -42,7 +42,7 @@ func WithCommandQuerier(q *commandquery.Querier) Option {
 //   - The error string (second return) is non-nil only when incomplete is true.
 //
 // This function is a thin shim: it parses/validates the character_id, then
-// delegates to commandquery.Querier (INV-1). All ABAC filtering, capability
+// delegates to commandquery.Querier (INV-COMMAND-1). All ABAC filtering, capability
 // AND-logic, and the engine-error circuit breaker live in commandquery.
 func (f *Functions) listCommandsFn(_ string) lua.LGFunction {
 	return func(ls *lua.LState) int {
@@ -115,7 +115,7 @@ func listCommandsViaQuerier(ctx context.Context, ls *lua.LState, q *commandquery
 // Args: command_name (string), character_id (string)
 // Returns: (command info table, error string)
 //
-// This function is a thin shim over commandquery.Querier.Help (INV-1). It maps
+// This function is a thin shim over commandquery.Querier.Help (INV-COMMAND-1). It maps
 // the querier's typed errors back to the legacy error strings the Lua help
 // plugin matches on:
 //   - NOT_FOUND          → "command not found: <name>"

--- a/internal/plugin/hostfunc/commands_test.go
+++ b/internal/plugin/hostfunc/commands_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // These tests cover ONLY the list_commands / get_command_help host-function
-// SHIMS — the thin Go↔Lua bridge over commandquery.Querier (design spec INV-1).
+// SHIMS — the thin Go↔Lua bridge over commandquery.Querier (design spec INV-COMMAND-1).
 // The ABAC filter itself (deny/error/infra-failure/circuit-breaker/AND-logic,
 // no-capability visibility, capability-gated denial) is exercised exhaustively
 // in internal/command/commandquery/query_test.go and is NOT re-tested here.

--- a/internal/plugin/hostfunc/functions.go
+++ b/internal/plugin/hostfunc/functions.go
@@ -70,7 +70,7 @@ type Option func(*Functions)
 // and the requires-gated capability checks (functions.go). Command-visibility
 // filtering does NOT use this engine directly — that flows through the
 // commandquery.Querier wired via WithCommandQuerier / SetCommandQuerier
-// (design spec INV-1: single command-visibility filter).
+// (design spec INV-COMMAND-1: single command-visibility filter).
 func WithEngine(engine types.AccessPolicyEngine) Option {
 	return func(f *Functions) {
 		f.engine = engine

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -628,7 +628,7 @@ func (s *Server) CommandRegistry() *command.Registry {
 // production PluginSubsystem.Start() path (subsystem.go) and late-bound into the
 // Lua host via SetCommandQuerier. Panics if WithInTreePlugins was not passed.
 // Used by the whole-system wiring regression to prove Start() yields a non-nil
-// querier (design spec INV-1: single command-visibility filter).
+// querier (design spec INV-COMMAND-1: single command-visibility filter).
 func (s *Server) CommandQuerier() *commandquery.Querier {
 	s.requirePlugins("CommandQuerier")
 	return s.pluginSub.CommandQuerier()

--- a/test/integration/plugin/command_introspection_parity_test.go
+++ b/test/integration/plugin/command_introspection_parity_test.go
@@ -7,7 +7,7 @@ package plugin_test
 
 // Command-introspection runtime-parity integration test (holomush-2zjio.10)
 //
-// INV-2 claim: the binary PluginHostService.ListCommands path and the Lua
+// INV-COMMAND-2 claim: the binary PluginHostService.ListCommands path and the Lua
 // holomush.list_commands host function BOTH delegate to the same
 // commandquery.Querier. For the same character and registry, both runtimes
 // MUST return an identical filtered command-name set, and BOTH must omit a
@@ -114,7 +114,7 @@ const parityCharID = "01HPAR0000000000000000CHAR"
 
 // buildParityQuerier constructs the shared commandquery.Querier for a given
 // engine. Both runtime paths are wired to this querier so their outputs are
-// identical iff both delegate to it (INV-2).
+// identical iff both delegate to it (INV-COMMAND-2).
 func buildParityQuerier(engine accesstypes.AccessPolicyEngine) *commandquery.Querier {
 	GinkgoT().Helper()
 	reg := command.NewRegistry()
@@ -137,7 +137,7 @@ func buildParityQuerier(engine accesstypes.AccessPolicyEngine) *commandquery.Que
 }
 
 // luaNamesForQuerier calls holomush.list_commands via the Lua hostfunc path
-// and returns the sorted command names (the Lua runtime path for INV-2).
+// and returns the sorted command names (the Lua runtime path for INV-COMMAND-2).
 func luaNamesForQuerier(ctx context.Context, q *commandquery.Querier, charID string) ([]string, bool) {
 	GinkgoT().Helper()
 	hf := hostfunc.New(nil, hostfunc.WithCommandQuerier(q))
@@ -173,7 +173,7 @@ func luaNamesForQuerier(ctx context.Context, q *commandquery.Querier, charID str
 
 // binaryNamesForQuerier loads the cmd_introspection_plugin binary, triggers it
 // with the given charID, and returns the sorted command names from the plugin's
-// HandleEvent return value (the binary runtime path for INV-2).
+// HandleEvent return value (the binary runtime path for INV-COMMAND-2).
 //
 // The plugin receives the CommandLister SDK facade wired over
 // PluginHostService.ListCommands (the binary gRPC handler), calls
@@ -243,9 +243,9 @@ var _ = Describe("Command-introspection runtime parity (holomush-2zjio)", func()
 		}
 	})
 
-	// INV-2: both runtimes delegate to the same commandquery.Querier. With an
+	// INV-COMMAND-2: both runtimes delegate to the same commandquery.Querier. With an
 	// AllowAll engine, both must return the full registry (dig + look + say).
-	Describe("INV-2 identical filtered set for AllowAll engine", func() {
+	Describe("INV-COMMAND-2 identical filtered set for AllowAll engine", func() {
 		It("binary plugin ListCommands returns the same set as the Lua host function for the same character", func() {
 			q := buildParityQuerier(policytest.AllowAllEngine())
 
@@ -262,20 +262,20 @@ var _ = Describe("Command-introspection runtime parity (holomush-2zjio)", func()
 			Expect(luaNames).To(ConsistOf("dig", "look", "say"),
 				"Lua runtime must return the full AllowAll registry, not a degraded set")
 
-			// Both runtimes MUST return the same sorted names (INV-2).
+			// Both runtimes MUST return the same sorted names (INV-COMMAND-2).
 			Expect(binNames).To(Equal(luaNames),
 				"binary ListCommands MUST return the same command names as Lua "+
-					"holomush.list_commands for the same character (INV-2 runtime parity): "+
+					"holomush.list_commands for the same character (INV-COMMAND-2 runtime parity): "+
 					"both delegate to the same commandquery.Querier")
 			Expect(binIncomplete).To(Equal(luaIncomplete),
 				"binary and Lua runtimes MUST agree on the 'incomplete' flag")
 		})
 	})
 
-	// INV-2 denial case: a capability-gated command denied by DenyAll must be
+	// INV-COMMAND-2 denial case: a capability-gated command denied by DenyAll must be
 	// absent from BOTH runtimes' results, while the no-capability command must
 	// appear in both.
-	Describe("INV-2 both runtimes omit a capability-gated command the character is denied", func() {
+	Describe("INV-COMMAND-2 both runtimes omit a capability-gated command the character is denied", func() {
 		It("omits denied capability-gated commands and includes no-capability commands in both runtimes", func() {
 			// DenyAll: "say" and "dig" (capability-gated) are denied;
 			// "look" (no capabilities) is always visible.
@@ -299,9 +299,9 @@ var _ = Describe("Command-introspection runtime parity (holomush-2zjio)", func()
 			luaNames, _ := luaNamesForQuerier(ctx, q, parityCharID)
 			binNames, _ := binaryNamesForQuerier(ctx, q, parityCharID)
 
-			// Both runtimes must agree with each other (INV-2).
+			// Both runtimes must agree with each other (INV-COMMAND-2).
 			Expect(binNames).To(Equal(luaNames),
-				"binary and Lua runtimes MUST agree on denied-command filtering (INV-2): "+
+				"binary and Lua runtimes MUST agree on denied-command filtering (INV-COMMAND-2): "+
 					"both runtimes delegate to the same commandquery.Querier")
 
 			// Both must include "look" (no caps) and exclude "say"/"dig" (denied).

--- a/test/integration/plugin/testdata/cmd_introspection_plugin/main.go
+++ b/test/integration/plugin/testdata/cmd_introspection_plugin/main.go
@@ -2,7 +2,7 @@
 // Copyright 2026 HoloMUSH Contributors
 
 // Package main implements the cmd_introspection_plugin: a test-only binary
-// plugin used by command_introspection_parity_test.go to prove INV-2
+// plugin used by command_introspection_parity_test.go to prove INV-COMMAND-2
 // (runtime parity): the binary PluginHostService.ListCommands and the Lua
 // holomush.list_commands host function delegate to the same
 // commandquery.Querier and return identical filtered command-name sets.

--- a/test/integration/plugin/testdata/cmd_introspection_plugin/plugin.yaml
+++ b/test/integration/plugin/testdata/cmd_introspection_plugin/plugin.yaml
@@ -3,7 +3,7 @@
 
 # cmd_introspection_plugin is a test-only binary plugin used by the
 # command_introspection_parity_test.go integration suite to prove
-# INV-2: the binary PluginHostService.ListCommands and the Lua
+# INV-COMMAND-2: the binary PluginHostService.ListCommands and the Lua
 # holomush.list_commands host function delegate to the same
 # commandquery.Querier, returning identical filtered command-name sets.
 #

--- a/test/integration/wholesystem/census_test.go
+++ b/test/integration/wholesystem/census_test.go
@@ -59,7 +59,7 @@ var _ = Describe("whole-system plugin load (INV-5)", Ordered, func() {
 	// so without the late-bind the Lua list_commands would return "command
 	// registry not available". Driving the REAL Start() here (not a hand-wired
 	// hostfunc.New) proves the production wiring yields a non-nil querier that
-	// enumerates real registered commands (design spec INV-1: single filter).
+	// enumerates real registered commands (design spec INV-COMMAND-1: single filter).
 	It("late-binds a non-nil command querier that lists real commands (Start wiring)", func() {
 		q := srv.CommandQuerier()
 		Expect(q).NotTo(BeNil(), "Start() must produce a non-nil command querier")


### PR DESCRIPTION
## Summary
Cat-B classification **PR B** (epic holomush-hz0v4.14.27). Per the .14.27 decision (*new scopes for coherent families*), the command-surfacing family graduates from per-spec local `INV-N` to a registry scope. Annotation RENAME via `cmd/inv-migrate`; **zero behavior change**; no generated artifacts.

### New scope `INV-COMMAND` (3 invariants, origin `2026-05-29-recognized-command-chip-design.md` §INV-1/2/5)
| id | invariant | legacy |
|----|-----------|--------|
| **INV-COMMAND-1** | exactly one command-visibility/ABAC filter (commandquery.Querier); Lua hostfunc + binary PluginHostService + CoreService RPC all delegate | INV-1 |
| **INV-COMMAND-2** | runtime parity — both runtimes reach ListCommands/GetCommandHelp via the same Querier → identical filtered set | INV-2 |
| **INV-COMMAND-3** | self-scoped enumeration — WebListCommands/ListAvailableCommands returns only the character's executable commands; ownership failure → SESSION_NOT_FOUND | INV-5 |

### The LAYER split (the key call)
The chip design enumerates `INV-1..7`. They split by **layer**:
- **INV-1/2/5 → Go backend** → migrated into INV-COMMAND.
- **INV-3/4/6/7 → web-composer presentation** (gateway boundary, server-sourced recognition, graceful incompleteness, speech-mode chips) → **web-frontend per-feature local numbering, EXEMPT** (.14.27), living in `web/src` TS.

The chip `INV-5` token is **layer-overloaded**: Go `list_available_commands.go` = self-scoped enumeration (→ COMMAND-3); web `composerChip.integration.test.ts` INV-5 = chip-omission (LEFT web-local). Per-SITE classification, never value-keyed.

### Shared (multi-token, migrate only the `INV-1` occurrence)
`functions.go` (+INV-PLUGIN-27/32), `harness.go` (13-scope), `census_test.go` (+wholesystem INV-5, residual-skipped).

### Verification
`task pr-prep` **pass** (one load-induced flake in unrelated `cmd/holomush/TestRunGatewayWithDeps_HappyPath` on the first run — diff doesn't touch `cmd/holomush`; passed 3/3 isolated; clean re-run green). Guard + partition + binding (new scope) + full `task lint` + 880+ unit tests + build + integration-compile green. Scopes: 14 (was 13). 

### Review
- **code-reviewer: READY** — layer-split verified coherent (no Go invariant left in web; no web token pulled in; INV-5 split correct); per-site leftovers correct (census_test.go retains wholesystem INV-5; functions.go/harness.go canonicals intact); partition clean; dense 1..3; zero executable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)