### PR TITLE
refactor(invariants): close command-vis misses + residual classification record (holomush-hz0v4.14.27)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -194,3 +194,23 @@
   foreign PLUGIN-27/32 / 13-scope / wholesystem-INV-5 tokens, residual-skipped).
   Zero executable edits; dense 1..3; no generated artifact. Encountered:
   hz0v4.14.27 PR B (2026-06-04) — READY.
+
+- **.14.27 PR C: 2 missed command-vis sites + residual-classification doc (the
+  .14.17 completeness record) — READY.** Tiny: help_integration_test.go (→
+  COMMAND owned_paths) + setup/subsystem.go (→ COMMAND shared_files), INV-1 →
+  INV-COMMAND-1 comment-only. CRITICAL leftover-token check HELD: subsystem.go
+  RETAINS INV-PLUGIN-25/3, INV-SCENE-38, INV-EVENTBUS-11 (only its INV-1
+  migrated); help_integration_test.go → zero bare INV-N. Partition: help_int is
+  in COMMAND owned_paths ONCE (no collision); subsystem.go is shared by 4 scopes
+  (SCENE/PLUGIN/EVENTBUS/COMMAND shared_files) — legal (only owned_paths must
+  partition). PR-B's 6 ref files ALL already carry canonical INV-COMMAND-1 (this
+  PR only adds the 2 missed). Doc: the spec-token scan trap (.14.23) — `rg -o
+  'INV-<registered-scope>-N'` over the specfile returned ONLY existing tokens
+  (CRYPTO-1/3/16, PLUGIN-22/33, SCENE-3, COMMAND-1); the dropped slot is written
+  as LEGACY `INV-TS-8` (NOT `INV-STORE-8`), so binding-guard-inert. All residual
+  doc claims verified TRUE against repo: INV-BRANDING/INV-DOCS status:pending +
+  0 entries; world service{,_test}.go INV-1/2/2b genuinely bare & NOT registry-
+  owned; gorules dekmaterial*/codeckeybytesallowlist cite INV-27→canonical
+  INV-CRYPTO-16 (legacy line confirms), filed as bead .14.28 (exists). Guards
+  green (provenance/partition/binding). Encountered: hz0v4.14.27 PR C
+  (2026-06-04) — READY.

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -636,12 +636,14 @@ scopes:
       - "internal/command/commandquery/**"
       - "internal/plugin/hostfunc/commands.go"
       - "internal/plugin/hostfunc/commands_test.go"
+      - "internal/plugin/help_integration_test.go"
       - "internal/grpc/list_available_commands.go"
       - "test/integration/plugin/command_introspection_parity_test.go"
       - "test/integration/plugin/testdata/cmd_introspection_plugin/main.go"
       - "test/integration/plugin/testdata/cmd_introspection_plugin/plugin.yaml"
     shared_files:
       - "internal/plugin/hostfunc/functions.go"
+      - "internal/plugin/setup/subsystem.go"
       - "internal/testsupport/integrationtest/harness.go"
       - "test/integration/wholesystem/census_test.go"
 
@@ -3451,6 +3453,8 @@ invariants:
       - {file: "internal/plugin/hostfunc/functions.go", token: "INV-1"}
       - {file: "internal/testsupport/integrationtest/harness.go", token: "INV-1"}
       - {file: "test/integration/wholesystem/census_test.go", token: "INV-1"}
+      - {file: "internal/plugin/help_integration_test.go", token: "INV-1"}
+      - {file: "internal/plugin/setup/subsystem.go", token: "INV-1"}
   - id: INV-COMMAND-2
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/docs/superpowers/specs/2026-06-01-invariant-registry-migration-redesign.md
+++ b/docs/superpowers/specs/2026-06-01-invariant-registry-migration-redesign.md
@@ -298,4 +298,62 @@ Binding backfill (`holomush-hz0v4.11`) remains a follow-up.
 - No bare `INV-N` remains in any `migrated` scope.
 - `task lint` and `task test` are green; per-family meta-tests retired only
   after the guard subsumes them.
+
+## Residual classification (epic `holomush-hz0v4.14.27`, final)
+
+The `.14.26` census surfaced bare `INV-N` tokens in namespaces §2.1 never
+enumerated — per-spec / per-bead **local** numbering. Per the 2026-06-04
+decision (*new scopes for coherent families; exempt one-off / per-bead /
+meta-test local numbering*), the full residual is classified into three
+buckets. This section is the completeness record for `.14.17` — every remaining
+bare `INV-N` in the tree is accounted for here.
+
+### 1. Migrated scopes (12) — done
+
+`INV-CRYPTO`, `INV-PRIVACY`, `INV-PRESENCE`, `INV-SCENE`, `INV-PLUGIN`,
+`INV-EVENTBUS`, `INV-CLUSTER`, `INV-ACCESS`, `INV-SESSION`, `INV-STORE`,
+`INV-TELEMETRY`, and `INV-COMMAND` (new in `.14.27` PR B — the command-surfacing
+family: single visibility filter, runtime parity, self-scoped enumeration).
+`.14.27` also added the `INV-S5` mechanism family `INV-PLUGIN-33..39` (PR A) and
+closed two missed sites (`plugin.proto INV-1 → INV-PLUGIN-22`;
+`help_integration_test.go` + `setup/subsystem.go` command-vis `INV-1 →
+INV-COMMAND-1`, PR C).
+
+### 2. Pending scopes (2) — future per-scope migration, NOT exempt
+
+`INV-BRANDING` (owns `site/src/styles/custom.css`; INV-1/3/5/6/7 brand-token
+invariants from `.claude/rules/branding.md`) and `INV-DOCS` (docs-IA /
+docs-quality invariants in `scripts/check-docs-ia.sh`, `check-docs-quality.sh`,
+and their `scripts/tests/*.bats`). Both are `status: pending` with zero entries,
+so the provenance guard does NOT residual-walk their `owned_paths` — their bare
+`INV-N` is expected, awaiting each scope's own migration pass. These are tracked
+separately from `.14.27`.
+
+### 3. Exempt — out-of-registry local numbering (closed-world LEFT)
+
+Genuinely per-spec / per-bead / per-tool local `INV-N` that does NOT belong to
+any cross-cutting registry family. None of these dirs is owned by a `migrated`
+scope, so none trips the residual guard. Do **not** migrate; do **not** re-flag:
+
+| Namespace | Sites | Why exempt |
+| --- | --- | --- |
+| world ABAC | `internal/world/service{,_test}.go` (INV-1/2/2b, `holomush-72ou`) | bead-local; 3 invariants from one design, not a recurring family |
+| auth config | `internal/auth/player.go` (INV-10) | single token, plugin-config key opacity |
+| settings | `internal/plugin/goplugin/host_service.go` (INV-6) | single token, settings-sharing |
+| web composer | `web/src/lib/**` (composerChip/CommandInput/ModeChip/commandListStore/themeStore INV-1..7) | web-frontend per-feature local numbering (incl. chip-design INV-3/4/6/7, the presentation half of the command-surfacing feature whose backend half is `INV-COMMAND`) |
+| meta-tests | `test/meta/*_test.go` (ci_required_jobs INV-5, depguard INV-1/2/3, proto_doc_comments INV-1..5, pr_prep_fast_lane INV-4, quarantine_registry INV-2, tooling_no_mandatory_int INV-6, inv_binding INV-53 [historical]) | each meta-test numbers its own spec locally |
+| CI / tooling | `Taskfile.yaml`, `scripts/*.sh`, `scripts/tests/*.bats` (INV-N) | per-script local numbering |
+| migration tooling | `cmd/inv-migrate/**`, `cmd/inv-render/**`, `test/meta/invariant_registry_test.go` (INV-3/4/31 regex examples) | the tool's own test fixtures — must NOT self-rewrite |
+| gateway fixtures | `internal/gateway_invariants/meta_test.go` (INV-GW-*) | RETAINED regex fixtures for the boundary matcher |
+| wholesystem | `test/integration/wholesystem/census_test.go` (INV-5) | whole-system plugin-load census, distinct local numbering (co-located foreign, `INV-COMMAND` shared_file) |
+| dropped | `internal/store/spec_meta_test.go` (INV-TS-8) | a deliberately dropped invariant — the `INV-STORE` scope intentionally skips that slot (no successor entry) |
+
+### 4. Deferred miss — `gorules` crypto analyzers
+
+`gorules/analyzers/dekmaterial*` and `codeckeybytesallowlist` cite master
+`INV-27` (dek.Material opacity → canonical `INV-CRYPTO-16`) in their linter `Doc`
+strings and diagnostic messages. This is a genuine *crypto* miss (stale ID in
+user-facing lint output), not cat-B — tracked as its own crypto-sweep bead
+(diagnostic-string change ⇒ crypto-reviewer), out of `.14.27` scope.
+
 <!-- adr-capture: sha256=54306f703f33c26d; session=cli; ts=2026-06-01T15:03:24Z; adrs= -->

--- a/internal/plugin/help_integration_test.go
+++ b/internal/plugin/help_integration_test.go
@@ -194,7 +194,7 @@ func setupHelpTestWithEngine(engine accesstypes.AccessPolicyEngine) (*helpFixtur
 	}
 
 	registry := &mockHelpCommandRegistry{}
-	// Delegate to the single ABAC-filtered enumerator (INV-1). The help plugin's
+	// Delegate to the single ABAC-filtered enumerator (INV-COMMAND-1). The help plugin's
 	// list_commands/get_command_help host functions go through commandquery.Querier;
 	// there is no second filter in hostfunc. nil AliasLister: these fixtures don't
 	// exercise system aliases.

--- a/internal/plugin/setup/subsystem.go
+++ b/internal/plugin/setup/subsystem.go
@@ -461,7 +461,7 @@ func (s *PluginSubsystem) CommandRegistry() *command.Registry {
 
 // CommandQuerier returns the shared command querier. Panics if called before Start().
 // Consumed by the gRPC subsystem (holoGRPC.WithCommandQuerier) and the binary
-// PluginHostService (bead .8) to ensure a single command-visibility filter (INV-1).
+// PluginHostService (bead .8) to ensure a single command-visibility filter (INV-COMMAND-1).
 func (s *PluginSubsystem) CommandQuerier() *commandquery.Querier {
 	if s.commandQuerier == nil {
 		panic("plugin/setup: CommandQuerier() called before Start()")


### PR DESCRIPTION
## Summary
Cat-B classification **PR C (final)** — closes epic holomush-hz0v4.14.27. Two low-risk parts.

### 1. Command-visibility misses → INV-COMMAND-1
`internal/plugin/help_integration_test.go` (→ owned) and `internal/plugin/setup/subsystem.go` (→ shared; retains INV-EVENTBUS-11 / INV-PLUGIN-25 / INV-PLUGIN-3 / INV-SCENE-38) carry the single-command-visibility-filter `INV-1`. They were in the epic's command-vis file list but PR B's narrower census skipped them (the recurring survey-gap). Pure comment rename.

### 2. Residual classification record (the `.14.17` completeness evidence)
New section in the redesign spec classifying **every** remaining bare `INV-N` in the tree:

| Bucket | Contents |
|--------|----------|
| **Migrated scopes (12)** | incl. new `INV-COMMAND` + `INV-S5`-mechanism `INV-PLUGIN-33..39` |
| **Pending scopes (2)** | `INV-BRANDING` (custom.css), `INV-DOCS` (docs-IA/quality scripts) — `status: pending`, owned dirs not residual-walked, awaiting their own migration; **not exempt** |
| **Exempt** (out-of-registry local numbering) | world / auth / settings / web-composer / meta-tests / CI-tooling / migration-tool fixtures / gateway regex fixtures / wholesystem / dropped INV-TS-8 — per-spec/per-bead/per-tool numbering, no cross-cutting family, none owned by a migrated scope (so none trips the residual guard) |
| **Deferred crypto miss** | gorules `INV-27` → `INV-CRYPTO-16` (stale id in lint diagnostics) — filed as **holomush-hz0v4.14.28** (crypto-reviewer gates the diagnostic-string change) |

### Verification
`task pr-prep` **pass**. Guard + partition + binding + full `task lint` (incl lint:yaml + markdownlint) + test/meta + internal/plugin/setup (57 green) + build + integration-compile green. 4 files, +64/-2; no generated artifacts.

### Review
- **code-reviewer: READY** — subsystem.go retains its 4 canonicals (only INV-1 migrated); all residual-classification doc claims verified TRUE against repo state (BRANDING/DOCS genuinely pending, gorules→INV-CRYPTO-16, exempt list complete/correct); no phantom canonical token in prose (an early draft tripped the binding guard with a literal dropped-slot token — fixed); no executable change.

Closes the registry's residual landscape — every bare `INV-N` is now accounted for, unblocking `.14.17` final verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)