### PR TITLE
test(invariants): harden guard — residual legacy tokens + file-glob walk + semantic partition (holomush-hz0v4.14.20, .14.21)

### DIFF
--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -401,6 +401,12 @@ scopes:
       - "api/proto/holomush/core/v1/core.proto"
       - "api/proto/holomush/web/v1/web.proto"
       - "api/proto/holomush/plugin/v1/audit.proto"
+      # Gateway-family coverage meta-test: RETAINS INV-GW-* tokens as DELIBERATE
+      # regex fixtures (they test the word-boundary matcher, e.g. INV-GW-1 must
+      # not match INV-GW-10). Shared so the hardened residual walk (holomush-hz0v4.14.21
+      # — now also flags prefixed legacy tokens like INV-GW-N) skips it; the
+      # fixtures are intentional, not an un-migrated annotation.
+      - "internal/gateway_invariants/meta_test.go"
       # EVENTBUS+CRYPTO+STORE: publisher/types (see CRYPTO.shared_files). types carries P7 too.
       - "internal/eventbus/publisher.go"
       - "internal/eventbus/types.go"

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -112,22 +112,49 @@ invariants:
 // pass the provenance guard's ownership check.
 func TestOwnedPathsPartition(t *testing.T) {
 	reg := loadRegistry(t)
-	owner := map[string]string{} // path glob -> scope
 	shared := map[string]bool{}
 	for _, sc := range reg.Scopes {
 		for _, f := range sc.SharedFiles {
 			shared[f] = true
 		}
 	}
+	type entry struct {
+		scope string
+		g     ownedGlob
+	}
+	var all []entry
 	for _, sc := range reg.Scopes {
 		for _, p := range sc.OwnedPaths {
 			if shared[p] {
 				continue // explicitly shared; ownership waived
 			}
-			if prev, dup := owner[p]; dup {
-				t.Errorf("owned_paths overlap: %q owned by both %s and %s", p, prev, sc.Name)
+			all = append(all, entry{sc.Name, parseOwnedGlob(p)})
+		}
+	}
+	// Cross-scope pairwise. owned_paths MUST partition the annotated tree under
+	// longest-prefix-wins semantics: a more-specific glob may carve a sub-area
+	// out of a broader one (strict one-way containment — e.g. INV-CLUSTER
+	// internal/eventbus/crypto/invalidation/** under INV-CRYPTO
+	// internal/eventbus/crypto/**). Only flag (a) two globs covering the exact
+	// same files, or (b) a genuinely ambiguous partial overlap where neither
+	// contains the other (no winner). This supersedes the old exact-string-dup
+	// check, which silently passed semantic prefix overlaps (holomush-hz0v4.14.20).
+	for i := 0; i < len(all); i++ {
+		for j := i + 1; j < len(all); j++ {
+			a, b := all[i], all[j]
+			if a.scope == b.scope {
+				continue // a scope may sub-divide its own territory freely
 			}
-			owner[p] = sc.Name
+			switch globConflict(a.g, b.g) {
+			case conflictSameFiles:
+				t.Errorf("owned_paths overlap: %q (%s) and %q (%s) cover the same files; declare one in shared_files or make one a more-specific carve-out",
+					a.g.raw, a.scope, b.g.raw, b.scope)
+			case conflictAmbiguous:
+				t.Errorf("ambiguous owned_paths overlap: %q (%s) and %q (%s) intersect but neither contains the other (no longest-prefix-wins winner); disambiguate via a more-specific glob or shared_files",
+					a.g.raw, a.scope, b.g.raw, b.scope)
+			}
+			// conflictNone: disjoint, or strict one-way containment (intentional
+			// longest-prefix-wins carve-out) — both allowed.
 		}
 	}
 }
@@ -527,39 +554,78 @@ func checkProvenance(root string, reg registryDoc) []string {
 		}
 	}
 	// Residual check: a migrated scope's owned files MUST NOT still carry a bare
-	// INV-N (un-migrated). Walk each migrated scope's owned dirs, reusing the
-	// package-level skipDirs set (.git/.jj/.worktrees/vendor/node_modules/bin/
-	// build/dist) AND the explicit .claude/worktrees path guard — skipDirs does
-	// NOT contain a plain "worktrees" key, so the bare WalkDir-into-.claude/
-	// worktrees pollution bug (holomush-jb1ec) is only prevented by the path
-	// guard below; keep both.
+	// INV-N (un-migrated) OR a registry-known *prefixed* legacy family token
+	// (INV-RB-2, INV-P7-5, I-PRES-6, …). bareInvRE alone (\bINV-\d+\b) misses the
+	// prefixed legacy tokens, so a forgotten legacy annotation in a migrated-scope
+	// owned file survived silently until human diff review caught it
+	// (holomush-hz0v4.14.21). legRE covers the prefixed legacy tokens; the two
+	// regexes are disjoint by construction (legRE excludes bare INV-N), so a file
+	// is reported at most once per offending token class.
+	legRE := legacyTokenRE(reg)
+	checkFile := func(scope, abs string) {
+		rel, _ := filepath.Rel(root, abs)
+		if shared[scope][rel] {
+			return // shared files carry mixed/foreign scopes; checked via refs only
+		}
+		// abs is built from in-repo owned_paths globs (filepath.Join under root); no external taint.
+		body, rerr := os.ReadFile(abs)
+		if rerr != nil {
+			return
+		}
+		if m := bareInvRE.Find(body); m != nil {
+			findings = append(findings, fmt.Sprintf("%s: residual bare INV-N (%s) in migrated-scope file %s", scope, m, rel))
+		}
+		if legRE != nil {
+			if m := legRE.Find(body); m != nil {
+				findings = append(findings, fmt.Sprintf("%s: residual legacy token (%s) in migrated-scope file %s", scope, m, rel))
+			}
+		}
+	}
+	// Resolve each owned_paths entry to concrete files. Three shapes:
+	//   dir/**      → WalkDir the subtree (skipDirs + .claude/worktrees guard — the
+	//                 latter is explicit because skipDirs has no plain "worktrees"
+	//                 key, so the .claude/worktrees pollution bug holomush-jb1ec is
+	//                 only prevented by the path check below; keep both).
+	//   dir/glob*.go → filepath.Glob. A literal-`*` path is NOT walkable by WalkDir
+	//                 (it errors → silent skip), so file-glob owned_paths got NO
+	//                 residual check before holomush-hz0v4.14.21 — expand them here.
+	//   dir/file.go → a single concrete path, checked directly.
 	for _, sc := range reg.Scopes {
 		if sc.Status != "migrated" {
 			continue
 		}
 		for _, glob := range sc.OwnedPaths {
-			base := strings.TrimSuffix(glob, "**")
-			base = strings.TrimSuffix(base, "/")
-			_ = filepath.WalkDir(filepath.Join(root, base), func(p string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return nil //nolint:nilerr // missing/!dir globs (file-specific owned_paths) → skip, not fatal
-				}
-				if d.IsDir() {
-					if _, skip := skipDirs[d.Name()]; skip || strings.Contains(p, "/.claude/worktrees/") {
-						return fs.SkipDir
+			switch {
+			case strings.HasSuffix(glob, "/**"):
+				base := strings.TrimSuffix(glob, "/**")
+				_ = filepath.WalkDir(filepath.Join(root, base), func(p string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return nil //nolint:nilerr // missing dir glob → skip, not fatal
 					}
+					if d.IsDir() {
+						if _, skip := skipDirs[d.Name()]; skip || strings.Contains(p, "/.claude/worktrees/") {
+							return fs.SkipDir
+						}
+						return nil
+					}
+					checkFile(sc.Name, p)
 					return nil
+				})
+			case strings.ContainsAny(glob, "*?["):
+				matches, gerr := filepath.Glob(filepath.Join(root, glob))
+				if gerr != nil {
+					// A malformed glob (e.g. an unbalanced '[') would otherwise
+					// silently skip the residual checks for this owned_path — the
+					// exact silent-skip class this walk exists to close. Fail closed.
+					findings = append(findings, fmt.Sprintf("%s: invalid owned_paths glob %q: %v", sc.Name, glob, gerr))
+					continue
 				}
-				rel, _ := filepath.Rel(root, p)
-				if shared[sc.Name][rel] {
-					return nil // shared files carry mixed scopes; checked via refs only
+				for _, p := range matches {
+					checkFile(sc.Name, p)
 				}
-				body, rerr := os.ReadFile(p) //nolint:gosec // G304: in-repo walk under owned_paths
-				if rerr == nil && bareInvRE.Match(body) {
-					findings = append(findings, fmt.Sprintf("%s: residual bare INV-N in migrated-scope file %s", sc.Name, rel))
-				}
-				return nil
-			})
+			default:
+				checkFile(sc.Name, filepath.Join(root, glob))
+			}
 		}
 	}
 	return findings
@@ -584,6 +650,209 @@ func pathOwnedBy(owned map[string]string, file, scope string) bool {
 		}
 	}
 	return false
+}
+
+// legacyTokenRE builds a regex matching any registry-known *prefixed* legacy
+// family token (INV-RB-2, INV-P7-5, I-PRES-6, INV-GW-1, INV-W9ML-3, …) recorded
+// in any entry's legacy: list, stripped of its @origin suffix. Bare INV-N legacy
+// tokens are EXCLUDED — those are already caught by bareInvRE, so excluding them
+// keeps the two residual regexes disjoint (no double-report). Returns nil when
+// there are no prefixed legacy tokens (empty alternation). Word boundaries on
+// both ends mean a short token (INV-1) never matches inside a canonical id
+// (INV-COMMAND-1) or a longer legacy token (INV-GW-1 vs INV-1). (holomush-hz0v4.14.21)
+func legacyTokenRE(reg registryDoc) *regexp.Regexp {
+	bareLegacy := regexp.MustCompile(`^INV-\d+$`)
+	seen := map[string]bool{}
+	var toks []string
+	for _, e := range reg.Invariants {
+		for _, l := range e.Legacy {
+			tok := l
+			if i := strings.IndexByte(tok, '@'); i >= 0 {
+				tok = tok[:i]
+			}
+			tok = strings.TrimSpace(tok)
+			if tok == "" || seen[tok] || bareLegacy.MatchString(tok) {
+				continue
+			}
+			seen[tok] = true
+			toks = append(toks, regexp.QuoteMeta(tok))
+		}
+	}
+	if len(toks) == 0 {
+		return nil
+	}
+	return regexp.MustCompile(`\b(?:` + strings.Join(toks, "|") + `)\b`)
+}
+
+// ownedGlob is a parsed owned_paths entry for semantic-overlap analysis.
+//
+//	subtree "dir/**"   → owns every path under dir/
+//	file    "dir/name" → owns files matching name directly in dir (name MAY carry
+//	                     a single-segment wildcard *,?,[…]; concrete if literal)
+type ownedGlob struct {
+	raw     string
+	subtree bool
+	dir     string // subtree root, or the containing directory for file globs
+	name    string // file glob/name (empty for subtree)
+}
+
+func parseOwnedGlob(g string) ownedGlob {
+	if strings.HasSuffix(g, "/**") {
+		return ownedGlob{raw: g, subtree: true, dir: strings.TrimSuffix(g, "/**")}
+	}
+	dir, name := filepath.Split(g)
+	return ownedGlob{raw: g, dir: strings.TrimSuffix(dir, "/"), name: name}
+}
+
+// dirUnderOrEq reports whether child is the same directory as parent or nested
+// beneath it (segment-aligned path prefix).
+func dirUnderOrEq(parent, child string) bool {
+	return child == parent || strings.HasPrefix(child, parent+"/")
+}
+
+// globContains reports whether every file matched by b is also matched by a
+// (a's coverage ⊇ b's). A strict one-way containment is an intentional
+// longest-prefix-wins carve-out (the more-specific glob legitimately owns a
+// sub-area of the broader one).
+func globContains(a, b ownedGlob) bool {
+	if a.subtree {
+		return dirUnderOrEq(a.dir, b.dir) // b's subtree root, or its files' dir, lies under a
+	}
+	if b.subtree {
+		return false // a file-level glob can never contain a whole subtree
+	}
+	if a.dir != b.dir {
+		return false
+	}
+	return namePatternContains(a.name, b.name)
+}
+
+// globsOverlap reports whether a and b can both match some common file.
+func globsOverlap(a, b ownedGlob) bool {
+	if a.subtree && b.subtree {
+		return dirUnderOrEq(a.dir, b.dir) || dirUnderOrEq(b.dir, a.dir)
+	}
+	if a.subtree {
+		return dirUnderOrEq(a.dir, b.dir)
+	}
+	if b.subtree {
+		return dirUnderOrEq(b.dir, a.dir)
+	}
+	if a.dir != b.dir {
+		return false
+	}
+	return namePatternsOverlap(a.name, b.name)
+}
+
+// splitStar splits a single-segment filename pattern around its star span:
+// everything before the first '*' and everything after the last '*'. Caller
+// MUST ensure p contains a '*' (guarded by starOnly); the i<0 fallback keeps it
+// panic-safe regardless.
+func splitStar(p string) (pre, suf string) {
+	i := strings.IndexByte(p, '*')
+	if i < 0 {
+		return p, ""
+	}
+	return p[:i], p[strings.LastIndexByte(p, '*')+1:]
+}
+
+// starOnly reports whether a pattern's only wildcard metacharacter is '*' (no
+// '?' or '['). The prefix/suffix reconciliation in namePatternsOverlap and the
+// witness method in namePatternContains are only sound for '*'-only patterns.
+func starOnly(p string) bool {
+	return strings.Contains(p, "*") && !strings.ContainsAny(p, "?[")
+}
+
+// namePatternsOverlap reports whether two single-segment filename patterns can
+// match a common filename. Exact-vs-glob defers to filepath.Match; '*'-only
+// glob-vs-glob reconciles the required prefix and suffix around the stars (a
+// witness exists iff the literal prefixes are prefix-compatible and the literal
+// suffixes are suffix-compatible — the star absorbs the middle). Patterns using
+// '?'/'[' that can't be decided precisely are treated as POSSIBLY overlapping
+// (fail-closed: a spurious flag forces an explicit shared_files/carve-out, while
+// a missed overlap would let an ambiguous partition slip through).
+func namePatternsOverlap(p, q string) bool {
+	if p == q {
+		return true
+	}
+	pWild := strings.ContainsAny(p, "*?[")
+	qWild := strings.ContainsAny(q, "*?[")
+	switch {
+	case pWild && !qWild:
+		ok, _ := filepath.Match(p, q)
+		return ok
+	case !pWild && qWild:
+		ok, _ := filepath.Match(q, p)
+		return ok
+	case !pWild && !qWild:
+		return p == q
+	}
+	if !starOnly(p) || !starOnly(q) {
+		return true // '?'/'[' present — assume possible overlap (fail-closed)
+	}
+	pp, ps := splitStar(p)
+	qp, qs := splitStar(q)
+	return (strings.HasPrefix(pp, qp) || strings.HasPrefix(qp, pp)) &&
+		(strings.HasSuffix(ps, qs) || strings.HasSuffix(qs, ps))
+}
+
+// namePatternContains reports whether every filename matching b also matches a.
+// An exact a contains only itself; a '*'-only a is tested against representative
+// witnesses of b. A '?'/'['-bearing a can't be soundly proven to contain b, so
+// it returns false — fail-closed: a non-containment turns an overlap into a
+// flagged ambiguity rather than silently allowing it as a carve-out.
+func namePatternContains(a, b string) bool {
+	if !strings.ContainsAny(a, "*?[") {
+		return a == b
+	}
+	if !starOnly(a) {
+		return false
+	}
+	for _, w := range nameWitnesses(b) {
+		if ok, _ := filepath.Match(a, w); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// nameWitnesses returns representative filenames matching pattern b: the literal
+// itself when b has no '*', else the star span filled with both the empty string
+// and a non-empty padding so a candidate container must match every length.
+func nameWitnesses(b string) []string {
+	if !strings.Contains(b, "*") {
+		return []string{b}
+	}
+	pre, suf := splitStar(b)
+	return []string{pre + suf, pre + "Zz9" + suf}
+}
+
+// globConflictKind classifies a cross-scope owned_paths pair.
+type globConflictKind int
+
+const (
+	conflictNone      globConflictKind = iota // disjoint, or intentional one-way carve-out
+	conflictSameFiles                         // two globs cover the exact same files
+	conflictAmbiguous                         // overlap with no longest-prefix-wins winner
+)
+
+// globConflict decides whether two cross-scope owned globs violate the
+// longest-prefix-wins partition. Factored so the negative test can assert the
+// decision directly (holomush-hz0v4.14.20).
+func globConflict(a, b ownedGlob) globConflictKind {
+	if !globsOverlap(a, b) {
+		return conflictNone
+	}
+	ab := globContains(a, b)
+	ba := globContains(b, a)
+	switch {
+	case ab && ba:
+		return conflictSameFiles
+	case !ab && !ba:
+		return conflictAmbiguous
+	default:
+		return conflictNone // strict one-way containment: a carve-out, allowed
+	}
 }
 
 func TestProvenanceGuard(t *testing.T) {
@@ -627,5 +896,119 @@ func TestProvenanceGuardFailsOnMislabel(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected an owned_paths ownership finding, got: %v", f)
+	}
+}
+
+// TestProvenanceGuardFailsOnResidualLegacyToken proves the holomush-hz0v4.14.21
+// hardening: a forgotten *prefixed* legacy family token (INV-GW-7) left in a
+// migrated scope's owned file is caught. bareInvRE (\bINV-\d+\b) misses it (the
+// "GW" follows "INV-", so no bare INV-N match), so before .14.21 only human diff
+// review caught such a leftover.
+func TestProvenanceGuardFailsOnResidualLegacyToken(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "gateway_invariants"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	owned := filepath.Join("internal", "gateway_invariants", "stale.go")
+	if err := os.WriteFile(filepath.Join(dir, owned), []byte("// INV-GW-7: forgotten legacy annotation\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg := registryDoc{
+		Scopes: []scopeRecord{{Name: "INV-EVENTBUS", Status: "migrated", OwnedPaths: []string{"internal/gateway_invariants/**"}}},
+		// INV-GW-7 is registry-known (recorded on some entry's legacy: list).
+		Invariants: []registryEntry{{ID: "INV-EVENTBUS-1", Scope: "INV-EVENTBUS", Legacy: []string{"INV-GW-7@docs/x.md"}}},
+	}
+	f := checkProvenance(dir, reg)
+	found := false
+	for _, line := range f {
+		if strings.Contains(line, "residual legacy token (INV-GW-7)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("guard must flag a residual prefixed legacy token in a migrated-owned file, got: %v", f)
+	}
+}
+
+// TestProvenanceGuardWalksFileGlobOwnedPaths proves the second half of
+// holomush-hz0v4.14.21: a `*`-file-glob owned_path is now residual-walked via
+// filepath.Glob. Before the fix, WalkDir on a literal-`*` path errored and the
+// file got NO residual check at all (silent skip).
+func TestProvenanceGuardWalksFileGlobOwnedPaths(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "grpc"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	owned := filepath.Join("internal", "grpc", "foo_wiring.go")
+	if err := os.WriteFile(filepath.Join(dir, owned), []byte("// INV-3: un-migrated bare token\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg := registryDoc{
+		Scopes: []scopeRecord{{Name: "INV-SCENE", Status: "migrated", OwnedPaths: []string{"internal/grpc/foo_wiring*.go"}}},
+	}
+	f := checkProvenance(dir, reg)
+	found := false
+	for _, line := range f {
+		if strings.Contains(line, "residual bare INV-N (INV-3)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("guard must residual-walk file-glob owned_paths, got: %v", f)
+	}
+}
+
+// TestProvenanceGuardFailsOnMalformedGlob proves the residual walk fails closed
+// on an invalid owned_paths glob (e.g. an unbalanced '['): filepath.Glob returns
+// ErrBadPattern, which MUST surface as a finding rather than be discarded and
+// silently skip the residual checks for that owned_path (CodeRabbit PR #4381).
+func TestProvenanceGuardFailsOnMalformedGlob(t *testing.T) {
+	reg := registryDoc{
+		Scopes: []scopeRecord{{Name: "INV-SCENE", Status: "migrated", OwnedPaths: []string{"internal/grpc/[bad.go"}}},
+	}
+	f := checkProvenance(t.TempDir(), reg)
+	found := false
+	for _, line := range f {
+		if strings.Contains(line, "invalid owned_paths glob") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("guard must fail closed on a malformed owned_paths glob, got: %v", f)
+	}
+}
+
+// TestOwnedPathsPartitionSemantics proves the holomush-hz0v4.14.20 hardening:
+// the partition check flags genuinely-ambiguous overlaps and exact-same-file
+// duplicates while ALLOWING intentional longest-prefix-wins carve-outs.
+func TestOwnedPathsPartitionSemantics(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want globConflictKind
+	}{
+		{"ambiguous crossing patterns (a*.go ∩ *b.go, neither contains)", "internal/foo/a*.go", "internal/foo/*b.go", conflictAmbiguous},
+		{"longest-prefix-wins subtree carve-out", "internal/eventbus/crypto/**", "internal/eventbus/crypto/invalidation/**", conflictNone},
+		{"concrete carve-out under a subtree", "internal/foo/**", "internal/foo/bar.go", conflictNone},
+		{"file-glob carve-out under a subtree", "internal/foo/**", "internal/foo/bar*.go", conflictNone},
+		{"identical subtree globs", "internal/foo/**", "internal/foo/**", conflictSameFiles},
+		{"disjoint subtrees", "internal/foo/**", "internal/bar/**", conflictNone},
+		{"disjoint same-dir file-globs", "internal/foo/a*.go", "internal/foo/c*.go", conflictNone},
+		{"identical concrete files", "internal/foo/x.go", "internal/foo/x.go", conflictSameFiles},
+		// '?'-bearing patterns can't be decided precisely → fail-closed: assume
+		// overlap, and (neither soundly contains the other) report ambiguous
+		// rather than panic or silently pass. Guards the splitStar no-'*' path.
+		{"question-mark patterns are handled fail-closed (no panic)", "internal/foo/a?.go", "internal/foo/?b.go", conflictAmbiguous},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := globConflict(parseOwnedGlob(tc.a), parseOwnedGlob(tc.b))
+			if got != tc.want {
+				t.Errorf("globConflict(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Hardens the invariant guard (`test/meta/invariant_registry_test.go`) so the provenance + partition checks are **mechanically complete** instead of reliant on human diff review. Closes **holomush-hz0v4.14.20** + **holomush-hz0v4.14.21**. Test-infra only; no production code.

### .14.21 — `checkProvenance` residual walk
1. **Catch leftover prefixed legacy tokens** (INV-RB-2, INV-P7-5, I-PRES-6, INV-GW-1, …), not just bare `INV-N`. New `legacyTokenRE` builds the set from every entry's `legacy:` (stripped of `@origin`), **excluding** bare `^INV-\d+$` so it stays disjoint from `bareInvRE` (no double-report). Closes the gap that let a forgotten `// Verifies: I-PRES-6` survive PRESENCE migration (.14.5), caught only by a human.
2. **Walk file-glob owned_paths** (`dir/foo*.go`). `WalkDir` errored on the literal `*` → silent skip, so file-glob owned files got **no** residual check. Now resolved via `filepath.Glob` (subtree / file-glob / concrete in a switch).
3. `internal/gateway_invariants/meta_test.go` → EVENTBUS `shared_files` (it RETAINS INV-GW-* as deliberate regex fixtures; the only file needing exemption — verified the stricter walk masks no real leftover).

### .14.20 — `TestOwnedPathsPartition`
Replaces exact-string-dup detection with **longest-prefix-wins semantic overlap**. A more-specific glob may carve a sub-area out of a broader one (strict one-way containment — e.g. CLUSTER `crypto/invalidation/**` under CRYPTO `crypto/**`); only flags exact-same-file dups or ambiguous partial overlaps where neither contains the other. New `ownedGlob`/`globsOverlap`/`globContains`/`globConflict` + filename-pattern helpers (`*`-only reconciliation; `?`/`[` handled **fail-closed**).

### Tests
3 new negatives: `TestProvenanceGuardFailsOnResidualLegacyToken`, `TestProvenanceGuardWalksFileGlobOwnedPaths`, `TestOwnedPathsPartitionSemantics` (table: ambiguous→flag, carve-out→allow, exact-dup→flag, disjoint→ok, `?`-pattern→fail-closed no-panic).

### Verification
`task pr-prep` **pass**. Full `task lint` + 52 test/meta (real guard + partition green for the right reasons) + build. **code-reviewer: READY** — token-collision proven empty (legacyTokenRE can't false-match canonicals; INV-TS-8 correctly excluded as a dropped slot), partition logic sound; one Low latent `splitStar` panic on `?`-only globs **fixed in this PR** (fail-closed + regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)