### PR TITLE
test(invariants): retire inv_binding_test.go, relocate shared helpers (holomush-hz0v4.14.16)

### DIFF
--- a/test/meta/focus_delta_gate_test.go
+++ b/test/meta/focus_delta_gate_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// repoRoot is provided by findRepoRoot in inv_binding_test.go (same package).
+// repoRoot is provided by findRepoRoot in meta_helpers_test.go (same package).
 
 func nonTestGoFilesContaining(t *testing.T, root, needle string) []string {
 	t.Helper()

--- a/test/meta/meta_helpers_test.go
+++ b/test/meta/meta_helpers_test.go
@@ -1,16 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-// Package meta contains repository-wide meta-tests that enforce structural
-// invariants.
-//
-// This file hosts shared helpers (findRepoRoot, skipDirs) used by many
-// meta-tests in the package. The former Phase-3c per-family coverage test
-// (TestEveryPhase3cInvariantHasAtLeastOneTestBinding) was retired when its
-// INV-53..60 invariants migrated to the registry as INV-CLUSTER-1..10
-// (holomush-hz0v4.14.11); the registry meta-test
-// (TestEveryRegistryInvariantHasBinding) now owns that coverage. The helpers
-// remain here pending relocation by holomush-hz0v4.14.16.
 package meta
 
 import (
@@ -18,6 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 )
+
+// This file is the home for shared helpers used across the test/meta package's
+// structural meta-tests. Relocated from inv_binding_test.go (holomush-hz0v4.14.16)
+// when that file — whose per-family coverage test had already been retired in
+// favour of TestEveryRegistryInvariantHasBinding — was removed.
 
 // skipDirs are directories that meta-tests MUST NOT descend into when scanning
 // the repo tree. Keeping this in sync with project layout avoids false


### PR DESCRIPTION
## Summary
Retires the per-family meta-test now subsumed by the provenance guard (`TestEveryRegistryInvariantHasBinding` + `checkProvenance`). Test-infra only; no production code, no assertion lost.

On current main the retirement set had already shrunk to one file: the `i_priv`/`i_pres`/`scenes_phase6` per-family tests were removed earlier, and `inv_binding_test.go`'s own per-family test (`TestEveryPhase3cInvariantHasAtLeastOneTestBinding`) was retired in **.14.11** when INV-53..60 migrated to INV-CLUSTER-1..10. `inv_binding_test.go` was left as a **misnamed helper-only file** (zero `func Test`) holding the package's shared `findRepoRoot` + `skipDirs`.

### Changes
- **Relocate** `findRepoRoot` (used by 11 test/meta files) + `skipDirs` (used by 4, incl. `checkProvenance`'s residual walk) **verbatim** into a new `test/meta/meta_helpers_test.go` — helper-safe ordering (new home compiles before the old file is removed).
- **Delete** `inv_binding_test.go`; its `// Package meta` doc is dropped (the canonical one survives on `liveness_invariants_test.go` — no duplicate package comment).
- **Fix** the stale findRepoRoot-location comment in `focus_delta_gate_test.go`.

### Verification
`task pr-prep` **pass**. Full `task lint` + 53 test/meta + build green. **code-reviewer: READY** — verified byte-faithful relocation (`diff` of both helper bodies identical), helpers defined exactly once, single package doc, zero `func Test` in the deleted file (no lost coverage — owned by the registry guard), no dangling code references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)