### PR TITLE
test(invariants): remove scaffolding empty-registry t.Skip — fail loudly (holomush-hz0v4.14.18)

### DIFF
--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -242,14 +242,13 @@ func TestEveryRegistryInvariantHasBinding(t *testing.T) {
 		t.Fatalf("parse invariants.yaml: %v", err)
 	}
 	if len(reg.Invariants) == 0 {
-		// Scaffolding phase: the registry is populated per-scope during the
-		// holomush-hz0v4.14 migration. Until the first scope lands, an empty
-		// registry is expected — skip rather than fail so the scaffold can land
-		// green. Once any invariant exists, the binding assertions below enforce.
-		// TEMPORARY: this skip MUST be removed once the registry is populated —
-		// tracked by holomush-hz0v4.14.18 (gates final verification .14.17), so a
-		// later regression that empties the registry fails loudly instead of skipping.
-		t.Skip("invariants.yaml has no entries yet — populated per-scope by the holomush-hz0v4.14 migration (skip removed by holomush-hz0v4.14.18)")
+		// The registry is fully populated by the holomush-hz0v4.14 migration. A
+		// zero-entry registry can now only mean a regression (a bad edit, a parse
+		// that silently dropped the invariants: block, or a wrong path), so fail
+		// loudly rather than vacuously pass. The scaffolding-phase t.Skip that
+		// tolerated an empty registry while scopes landed one-by-one was removed
+		// here (holomush-hz0v4.14.18).
+		t.Fatal("invariants.yaml has zero invariant entries — the registry must be populated; an empty registry is a regression, not a valid state")
 	}
 
 	// 2. Walk the repo for // Verifies: annotations.


### PR DESCRIPTION
## Summary
Removes the scaffolding-phase `t.Skip` in `TestEveryRegistryInvariantHasBinding` (`test/meta/invariant_registry_test.go`) that tolerated an empty `invariants.yaml`. Test-infra only; no production code.

The skip let the `.14` registry scaffold (#4358) land green before any scope was migrated. The registry is now **fully populated** (252 entries, all scopes migrated), so a zero-entry registry can only mean a regression (a bad edit, a parse that silently dropped the `invariants:` block, a wrong path). The `t.Skip` turned that into a **vacuous green pass** — the exact silent-failure the bead calls out. Replaced with `t.Fatal` so zero entries fails loudly.

**Out of scope (untouched):** the per-scope *pending-scope* tolerance (a `migrated` scope with no invariants is still flagged; `pending` scopes legitimately empty) and all other guard logic.

### Verification
`task pr-prep` **pass**. 53 test/meta green with the populated registry; full `task lint` + build green. **code-reviewer: READY** — confirmed the guard targets the whole registry (`reg.Invariants`, not a subset), `t.Fatal` is the right abort (the rest of the test is meaningless on an empty registry), pending-scope tolerance unchanged, comment accurate.

Unblocks `.14.17` (final verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)