### PR TITLE
feat(inv-migrate): expand slash-joined shorthand compounds at rewrite time (holomush-hz0v4.14.25)

### DIFF
--- a/cmd/inv-migrate/migrate.go
+++ b/cmd/inv-migrate/migrate.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 )
 
 // rewrite is one recorded site: replace whole-token Token with Canonical in File.
@@ -28,14 +29,20 @@ type rewrite struct {
 // file with multiple recorded token rewrites counts once). A recorded file that
 // does not exist is an error (the registry is stale — fail loud).
 func rewriteAll(plan []rewrite) (int, error) {
+	// planMap (legacy token → canonical) over the WHOLE plan lets rewriteToken
+	// expand slash-joined shorthand compounds whose tail components are sibling
+	// legacy tokens recorded as their own refs (holomush-hz0v4.14.25).
+	planMap := make(map[string]string, len(plan))
+	for _, r := range plan {
+		planMap[r.Token] = r.Canonical
+	}
 	changedFiles := map[string]bool{}
 	for _, r := range plan {
 		data, err := os.ReadFile(r.File)
 		if err != nil {
 			return len(changedFiles), fmt.Errorf("recorded ref unreadable %s: %w", r.File, err)
 		}
-		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(r.Token) + `\b`)
-		out := re.ReplaceAll(data, []byte(r.Canonical))
+		out := rewriteToken(data, r.Token, r.Canonical, planMap)
 		if bytes.Equal(out, data) {
 			continue
 		}
@@ -45,4 +52,43 @@ func rewriteAll(plan []rewrite) (int, error) {
 		changedFiles[r.File] = true
 	}
 	return len(changedFiles), nil
+}
+
+// compoundTailRE captures an optional slash-joined shorthand tail after a token:
+// the `/6/12` in `INV-RB-2/6/12` or the `/F7` in `INV-F6/F7`. Each tail segment
+// is a sibling invariant's final component under the leading token's family.
+var compoundTailRE = `((?:/[A-Za-z0-9]+)+)?`
+
+// rewriteToken replaces whole-token `token` with `canonical`, and additionally
+// expands a slash-joined shorthand tail (`token/<suffix>/<suffix>…`). Authors
+// sometimes abbreviate a run of sibling invariants as `INV-RB-2/6/12` (drop the
+// `INV-RB-` prefix) or `INV-F6/F7` (drop only `INV-`); a plain whole-token
+// rewrite leaves the bare suffixes dangling (`INV-CRYPTO-27/6/12`,
+// `INV-CRYPTO-56/F7`), which the residual guard's `\bINV-\d+\b` cannot see
+// (holomush-hz0v4.14.23/.26 hand-fixes). Here each suffix is reconstructed as
+// `<prefix><suffix>` (prefix = token up to and including its last '-') and, IF
+// that reconstructed legacy token is itself a recorded ref (present in planMap),
+// replaced with its canonical full token. An unrecognised suffix is preserved
+// verbatim so a cross-family, fractional, or already-canonical tail is never
+// corrupted — the closed-world rule (touch only recorded tokens) still holds.
+// Whole-token match only: INV-3 never matches inside INV-31.
+func rewriteToken(data []byte, token, canonical string, planMap map[string]string) []byte {
+	prefix := token[:strings.LastIndexByte(token, '-')+1]
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(token) + compoundTailRE + `\b`)
+	return re.ReplaceAllFunc(data, func(m []byte) []byte {
+		tail := m[len(token):] // "" or "/s1/s2…"
+		var b bytes.Buffer
+		b.WriteString(canonical)
+		if len(tail) > 0 {
+			for _, suf := range strings.Split(string(tail[1:]), "/") {
+				b.WriteByte('/')
+				if canon, ok := planMap[prefix+suf]; ok {
+					b.WriteString(canon)
+				} else {
+					b.WriteString(suf) // unrecognised suffix: preserve verbatim
+				}
+			}
+		}
+		return b.Bytes()
+	})
 }

--- a/cmd/inv-migrate/migrate_test.go
+++ b/cmd/inv-migrate/migrate_test.go
@@ -59,3 +59,83 @@ func TestRewriteRefusesMissingFile(t *testing.T) {
 		t.Fatal("want error for missing recorded file, got nil")
 	}
 }
+
+// TestRewriteTokenExpandsSlashShorthandCompounds covers holomush-hz0v4.14.25:
+// slash-joined shorthand compounds (INV-RB-2/6/12, INV-F6/F7) must expand every
+// tail component to its canonical, not leave a bare dangling suffix.
+func TestRewriteTokenExpandsSlashShorthandCompounds(t *testing.T) {
+	planMap := map[string]string{
+		"INV-RB-2": "INV-CRYPTO-27", "INV-RB-6": "INV-CRYPTO-31", "INV-RB-12": "INV-CRYPTO-37",
+		"INV-F6": "INV-CRYPTO-56", "INV-F7": "INV-CRYPTO-57",
+	}
+	cases := []struct {
+		name, token, canonical, in, want string
+	}{
+		{
+			"number shorthand expands every tail component", "INV-RB-2", "INV-CRYPTO-27",
+			"see INV-RB-2/6/12 here", "see INV-CRYPTO-27/INV-CRYPTO-31/INV-CRYPTO-37 here",
+		},
+		{
+			"letter shorthand expands the sibling", "INV-F6", "INV-CRYPTO-56",
+			"// INV-F6/F7 fence", "// INV-CRYPTO-56/INV-CRYPTO-57 fence",
+		},
+		{
+			"standalone token without a tail still rewrites", "INV-RB-2", "INV-CRYPTO-27",
+			"// INV-RB-2 only", "// INV-CRYPTO-27 only",
+		},
+		{
+			"unrecorded suffix is preserved verbatim (no corruption)", "INV-RB-2", "INV-CRYPTO-27",
+			"INV-RB-2/99", "INV-CRYPTO-27/99",
+		},
+		{
+			"no false match inside a longer number", "INV-RB-2", "INV-CRYPTO-27",
+			"INV-RB-29 unchanged", "INV-RB-29 unchanged",
+		},
+		{
+			"a canonical compound for a different token is untouched", "INV-RB-2", "INV-CRYPTO-27",
+			"INV-CRYPTO-27/31/37", "INV-CRYPTO-27/31/37",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(rewriteToken([]byte(tc.in), tc.token, tc.canonical, planMap))
+			if got != tc.want {
+				t.Errorf("rewriteToken(%q, token=%q) =\n %q\nwant %q", tc.in, tc.token, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRewriteAllExpandsCompoundFromPlan proves the planMap that drives tail
+// expansion is built from the whole plan (the siblings INV-RB-6/12 are recorded
+// as their own refs), and that the expansion is idempotent.
+func TestRewriteAllExpandsCompoundFromPlan(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.go")
+	if err := os.WriteFile(src, []byte("// fence INV-RB-2/6/12 here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plan := []rewrite{
+		{File: src, Token: "INV-RB-2", Canonical: "INV-CRYPTO-27"},
+		{File: src, Token: "INV-RB-6", Canonical: "INV-CRYPTO-31"},
+		{File: src, Token: "INV-RB-12", Canonical: "INV-CRYPTO-37"},
+	}
+	if _, err := rewriteAll(plan); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "// fence INV-CRYPTO-27/INV-CRYPTO-31/INV-CRYPTO-37 here\n"
+	if string(got) != want {
+		t.Errorf("compound expand:\n got %q\nwant %q", got, want)
+	}
+	changed, err := rewriteAll(plan) // re-run: all tokens gone
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed != 0 {
+		t.Errorf("re-run changed %d files, want 0 (idempotent)", changed)
+	}
+}


### PR DESCRIPTION
## Summary
Hardens `cmd/inv-migrate` so slash-joined shorthand compounds expand fully instead of leaving a bare dangling suffix. Tooling only; closed-world preserved.

### Problem
The tool rewrites recorded `{file, token}` refs via `\bTOKEN\b → canonical`. Authors abbreviate a run of sibling invariants as `INV-RB-2/6/12` (drop `INV-RB-` on the tail) or `INV-F6/F7` (drop only `INV-`). A plain whole-token rewrite left the bare tail dangling — `INV-CRYPTO-27/6/12`, `INV-CRYPTO-56/F7` — hand-fixed in .14.23 and .14.26.

**Why not a residual guard?** The number-shorthand dangling case (`INV-CRYPTO-27/6/12`) is **pattern-indistinguishable** from a legitimate canonical shorthand (`INV-CRYPTO-27/31/37`) that the migration itself produces and that already exists in the tree. So detection-by-guard is infeasible; the fix must prevent the bug at rewrite time.

### Fix
New pure `rewriteToken(data, token, canonical, planMap)`: matches `TOKEN` + an optional `(/<suffix>)+` tail. For each suffix it reconstructs the sibling legacy token `<prefix><suffix>` (prefix = token up to & including its last `-`, handling both `INV-RB-` and `INV-` styles); **if that token is itself a recorded ref** (in the plan map, built across the whole plan) it expands to the canonical full token, **else preserves the suffix verbatim**. Whole-token match preserved (`INV-3` never matches inside `INV-31`).

### Closed-world / no-corruption
Re-running `-scope INV-CRYPTO` / `INV-PLUGIN` on the fully-migrated tree rewrites **0 files** — existing canonical compounds and not-yet-migrated future-scope compounds (`INV-E14/E15`) are untouched (their leading token isn't a recorded ref for the run). An unrecorded/fractional/path tail (`INV-RB-2/2026`) is preserved verbatim.

### Verification
`task pr-prep` **pass**. 11 cmd/inv-migrate tests (6 new table cases + planMap-from-plan integration + idempotence) + full `task lint` + build green. **code-reviewer: READY** — all 6 axes verified incl. the closed-world re-run on the real tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)