### PR TITLE
refactor(invariants): migrate gorules crypto analyzers INV-27 → INV-CRYPTO-16 (holomush-hz0v4.14.28)

### DIFF
--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -43,6 +43,15 @@ scopes:
       - "internal/eventbus/audit_row_access.go"
       - "internal/eventbus/audit/**"
       - "test/integration/privacy/scene_history_readback_test.go"
+      # gorules crypto analyzers (.14.28): dek.Material-opacity enforcement (INV-27 → INV-CRYPTO-16);
+      # crypto-exclusive dirs (analyzer + analysistest testdata), separate go module.
+      - "gorules/analyzers/codeckeybytesallowlist/**"
+      - "gorules/analyzers/dekmaterialnofmtformatting/**"
+      - "gorules/analyzers/dekmaterialnogob/**"
+      - "gorules/analyzers/dekmaterialnojson/**"
+      - "gorules/analyzers/dekmaterialnolog/**"
+      - "gorules/analyzers/dekmaterialnoproto/**"
+      - "gorules/analyzers/dekmaterialnoslog/**"
     shared_files:
       # CRYPTO+STORE: history files carrying both P7/RB and TS (nanos) annotations.
       - "internal/eventbus/history/readback.go"
@@ -827,6 +836,27 @@ invariants:
       - {file: "internal/eventbus/crypto/dek/participants_cache.go", token: "INV-27"}
       - {file: "internal/eventbus/crypto/dek/rekey.go", token: "INV-27"}
       - {file: "internal/eventbus/crypto/dek/store.go", token: "INV-27"}
+      - {file: "gorules/analyzers/codeckeybytesallowlist/codeckeybytesallowlist.go", token: "INV-27"}
+      - {file: "gorules/analyzers/codeckeybytesallowlist/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnofmtformatting/dekmaterialnofmtformatting.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnofmtformatting/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnogob/dekmaterialnogob.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnogob/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnojson/dekmaterialnojson.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnojson/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnolog/dekmaterialnolog.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnolog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnoproto/dekmaterialnoproto.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnoproto/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnoslog/dekmaterialnoslog.go", token: "INV-27"}
+      - {file: "gorules/analyzers/dekmaterialnoslog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go",
+        token: "INV-27"}
   - id: INV-CRYPTO-17
     scope: INV-CRYPTO
     origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"

--- a/gorules/analyzers/codeckeybytesallowlist/codeckeybytesallowlist.go
+++ b/gorules/analyzers/codeckeybytesallowlist/codeckeybytesallowlist.go
@@ -30,7 +30,7 @@ const (
 	codecPkg = "github.com/holomush/holomush/internal/eventbus/codec"
 	keyType  = "Key"
 	field    = "Bytes"
-	message  = "INV-27 (residual defense): codec.Key.Bytes reads are restricted to internal/eventbus/codec/... and internal/eventbus/crypto/... — Material exposure goes through dek.Material.AsCodecKey only"
+	message  = "INV-CRYPTO-16 (residual defense): codec.Key.Bytes reads are restricted to internal/eventbus/codec/... and internal/eventbus/crypto/... — Material exposure goes through dek.Material.AsCodecKey only"
 )
 
 var allowlist = []string{
@@ -42,7 +42,7 @@ var allowlist = []string{
 // crypto/ package trees.
 var Analyzer = &analysis.Analyzer{
 	Name:     "codeckeybytesallowlist",
-	Doc:      "INV-27 residual defense: codec.Key.Bytes reads are restricted",
+	Doc:      "INV-CRYPTO-16 residual defense: codec.Key.Bytes reads are restricted",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }

--- a/gorules/analyzers/codeckeybytesallowlist/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/codeckeybytesallowlist/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -12,23 +12,23 @@ package positive
 import "github.com/holomush/holomush/internal/eventbus/codec"
 
 func readValue(k codec.Key) []byte {
-	return k.Bytes // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return k.Bytes // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 func readPointerExplicit(pk *codec.Key) []byte {
-	return (*pk).Bytes // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return (*pk).Bytes // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 func readPointerAuto(pk *codec.Key) []byte {
-	return pk.Bytes // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return pk.Bytes // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 func readIndex(k codec.Key) byte {
-	return k.Bytes[0] // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return k.Bytes[0] // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 func readSlice(k codec.Key, n int) []byte {
-	return k.Bytes[:n] // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return k.Bytes[:n] // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 // Alias-receiver bypass: `type K = codec.Key` makes the selection's
@@ -38,9 +38,9 @@ func readSlice(k codec.Key, n int) []byte {
 type K = codec.Key
 
 func readViaAlias(k K) []byte {
-	return k.Bytes // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return k.Bytes // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }
 
 func readViaAliasPointer(pk *K) []byte {
-	return pk.Bytes // want `INV-27 \(residual defense\): codec.Key.Bytes reads are restricted`
+	return pk.Bytes // want `INV-CRYPTO-16 \(residual defense\): codec.Key.Bytes reads are restricted`
 }

--- a/gorules/analyzers/dekmaterialnofmtformatting/dekmaterialnofmtformatting.go
+++ b/gorules/analyzers/dekmaterialnofmtformatting/dekmaterialnofmtformatting.go
@@ -4,7 +4,7 @@
 // Package dekmaterialnofmtformatting forbids passing dek.Material (or
 // *dek.Material) to fmt formatting sinks (Sprint, Sprintf, Sprintln,
 // Print, Printf, Println, Fprint, Fprintf, Fprintln, Errorf). Part of
-// INV-27 (Material non-leakage). See bead holomush-46ya for context.
+// INV-CRYPTO-16 (Material non-leakage). See bead holomush-46ya for context.
 package dekmaterialnofmtformatting
 
 import (
@@ -34,7 +34,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnofmtformatting",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to fmt formatting",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to fmt formatting",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -49,7 +49,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnofmtformatting/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnofmtformatting/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -17,13 +17,13 @@ import (
 )
 
 func leakViaSprintf(m *dek.Material) string {
-	return fmt.Sprintf("%v", m) // want `INV-27: dek.Material MUST NOT be passed to fmt formatting`
+	return fmt.Sprintf("%v", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to fmt formatting`
 }
 
 func leakViaErrorf(m *dek.Material) error {
-	return fmt.Errorf("material: %v", m) // want `INV-27: dek.Material MUST NOT be passed to fmt formatting`
+	return fmt.Errorf("material: %v", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to fmt formatting`
 }
 
 func leakViaPrintf(m *dek.Material) {
-	fmt.Printf("%v\n", m) // want `INV-27: dek.Material MUST NOT be passed to fmt formatting`
+	fmt.Printf("%v\n", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to fmt formatting`
 }

--- a/gorules/analyzers/dekmaterialnogob/dekmaterialnogob.go
+++ b/gorules/analyzers/dekmaterialnogob/dekmaterialnogob.go
@@ -3,7 +3,7 @@
 
 // Package dekmaterialnogob forbids passing dek.Material (or
 // *dek.Material) to encoding/gob sinks ((*gob.Encoder).Encode,
-// gob.Register). Part of INV-27 (Material non-leakage).
+// gob.Register). Part of INV-CRYPTO-16 (Material non-leakage).
 package dekmaterialnogob
 
 import (
@@ -25,7 +25,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnogob",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to encoding/gob",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/gob",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -40,7 +40,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnogob/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnogob/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -18,9 +18,9 @@ import (
 )
 
 func leakViaEncode(m *dek.Material, w io.Writer) error {
-	return gob.NewEncoder(w).Encode(m) // want `INV-27: dek.Material MUST NOT be passed to encoding/gob`
+	return gob.NewEncoder(w).Encode(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/gob`
 }
 
 func leakViaRegister(m *dek.Material) {
-	gob.Register(m) // want `INV-27: dek.Material MUST NOT be passed to encoding/gob`
+	gob.Register(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/gob`
 }

--- a/gorules/analyzers/dekmaterialnojson/dekmaterialnojson.go
+++ b/gorules/analyzers/dekmaterialnojson/dekmaterialnojson.go
@@ -3,7 +3,7 @@
 
 // Package dekmaterialnojson forbids passing dek.Material (or
 // *dek.Material) to encoding/json sinks (json.Marshal,
-// json.MarshalIndent, (*json.Encoder).Encode). Part of INV-27 (Material
+// json.MarshalIndent, (*json.Encoder).Encode). Part of INV-CRYPTO-16 (Material
 // non-leakage).
 package dekmaterialnojson
 
@@ -27,7 +27,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnojson",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to encoding/json",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -42,7 +42,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnojson/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnojson/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -18,15 +18,15 @@ import (
 )
 
 func leakViaMarshal(m *dek.Material) ([]byte, error) {
-	return json.Marshal(m) // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.Marshal(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }
 
 func leakViaMarshalIndent(m *dek.Material) ([]byte, error) {
-	return json.MarshalIndent(m, "", "  ") // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.MarshalIndent(m, "", "  ") // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }
 
 func leakViaEncoder(m *dek.Material, w io.Writer) error {
-	return json.NewEncoder(w).Encode(m) // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.NewEncoder(w).Encode(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }
 
 // Conversion-wrapped bypass: any(m) wraps the *dek.Material into an
@@ -34,13 +34,13 @@ func leakViaEncoder(m *dek.Material, w io.Writer) error {
 // The analyzer must unwrap conversion-call expressions before the type
 // check. CodeRabbit finding on PR #3457.
 func leakViaAnyConversion(m *dek.Material) ([]byte, error) {
-	return json.Marshal(any(m)) // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.Marshal(any(m)) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }
 
 // Parenthesized conversion: (any)(m) — unwrap ParenExpr around the
 // type-conversion CallExpr too.
 func leakViaParenConversion(m *dek.Material) ([]byte, error) {
-	return json.Marshal((any)(m)) // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.Marshal((any)(m)) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }
 
 // Alias-type bypass: `type AliasedMaterial = dek.Material` is a Go
@@ -50,5 +50,5 @@ func leakViaParenConversion(m *dek.Material) ([]byte, error) {
 type AliasedMaterial = dek.Material
 
 func leakViaAlias(m *AliasedMaterial) ([]byte, error) {
-	return json.Marshal(m) // want `INV-27: dek.Material MUST NOT be passed to encoding/json`
+	return json.Marshal(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to encoding/json`
 }

--- a/gorules/analyzers/dekmaterialnolog/dekmaterialnolog.go
+++ b/gorules/analyzers/dekmaterialnolog/dekmaterialnolog.go
@@ -4,7 +4,7 @@
 // Package dekmaterialnolog forbids passing dek.Material (or
 // *dek.Material) to standard log package sinks (Print, Printf, Println,
 // Fatal, Fatalf, Fatalln, Panic, Panicf, Panicln; both package-level
-// functions and *log.Logger methods). Part of INV-27 (Material
+// functions and *log.Logger methods). Part of INV-CRYPTO-16 (Material
 // non-leakage). See bead holomush-46ya for context.
 package dekmaterialnolog
 
@@ -45,7 +45,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnolog",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to log",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to log",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -60,7 +60,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnolog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnolog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -18,11 +18,11 @@ import (
 )
 
 func leakViaPrintf(m *dek.Material) {
-	log.Printf("material: %v", m) // want `INV-27: dek.Material MUST NOT be passed to log`
+	log.Printf("material: %v", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log`
 }
 
 func leakViaLoggerPrintf(m *dek.Material, l *log.Logger) {
-	l.Printf("material: %v", m) // want `INV-27: dek.Material MUST NOT be passed to log`
+	l.Printf("material: %v", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log`
 }
 
 // Dot-imported call: with `import . "log"`, the call's Fun is an
@@ -30,5 +30,5 @@ func leakViaLoggerPrintf(m *dek.Material, l *log.Logger) {
 // `call.Fun.(*ast.SelectorExpr)` type assertion misses this entirely.
 // CodeRabbit finding on PR #3457.
 func leakViaDotImport(m *dek.Material) {
-	Printf("material: %v", m) // want `INV-27: dek.Material MUST NOT be passed to log`
+	Printf("material: %v", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log`
 }

--- a/gorules/analyzers/dekmaterialnoproto/dekmaterialnoproto.go
+++ b/gorules/analyzers/dekmaterialnoproto/dekmaterialnoproto.go
@@ -3,7 +3,7 @@
 
 // Package dekmaterialnoproto forbids passing dek.Material (or
 // *dek.Material) to google.golang.org/protobuf/proto sinks
-// (proto.Marshal, (MarshalOptions).Marshal). Part of INV-27 (Material
+// (proto.Marshal, (MarshalOptions).Marshal). Part of INV-CRYPTO-16 (Material
 // non-leakage).
 //
 // Forward-defensive: dek.Material does not implement proto.Message
@@ -33,7 +33,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnoproto",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -48,7 +48,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnoproto/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnoproto/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -25,9 +25,9 @@ import (
 )
 
 func leakViaMarshal(m *dek.Material) ([]byte, error) {
-	return proto.Marshal(m) // want `INV-27: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto`
+	return proto.Marshal(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto`
 }
 
 func leakViaOpts(m *dek.Material) ([]byte, error) {
-	return proto.MarshalOptions{Deterministic: true}.Marshal(m) // want `INV-27: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto`
+	return proto.MarshalOptions{Deterministic: true}.Marshal(m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to google.golang.org/protobuf/proto`
 }

--- a/gorules/analyzers/dekmaterialnoslog/dekmaterialnoslog.go
+++ b/gorules/analyzers/dekmaterialnoslog/dekmaterialnoslog.go
@@ -5,7 +5,7 @@
 // *dek.Material) to standard log/slog package sinks (Info, Debug, Warn,
 // Error, Log, Any, Group; both package-level functions and *slog.Logger
 // methods, except Any and Group which are not *Logger methods). Part
-// of INV-27 (Material non-leakage). See bead holomush-46ya for context.
+// of INV-CRYPTO-16 (Material non-leakage). See bead holomush-46ya for context.
 package dekmaterialnoslog
 
 import (
@@ -52,7 +52,7 @@ var sinks = []holomushlint.Sink{
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "dekmaterialnoslog",
-	Doc:      "INV-27: dek.Material MUST NOT be passed to log/slog",
+	Doc:      "INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -67,7 +67,7 @@ func run(pass *analysis.Pass) (any, error) {
 		for _, arg := range call.Args {
 			if holomushlint.IsDEKMaterialArg(pass, arg) {
 				pass.Reportf(arg.Pos(),
-					"INV-27: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
+					"INV-CRYPTO-16: dek.Material MUST NOT be passed to %s — Material is opaque by design (see internal/eventbus/crypto/dek/material.go and bead holomush-46ya for context)",
 					sinkDescription)
 				return
 			}

--- a/gorules/analyzers/dekmaterialnoslog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
+++ b/gorules/analyzers/dekmaterialnoslog/testdata/src/github.com/holomush/holomush/plugins/positive/positive.go
@@ -18,18 +18,18 @@ import (
 )
 
 func leakViaSlogInfo(m *dek.Material) {
-	slog.Info("dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.Info("dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerInfo(m *dek.Material, l *slog.Logger) {
-	l.Info("dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.Info("dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 // Conversion-wrapped bypass: any(m) hides the *dek.Material type behind
 // an interface, so a naive pass.TypesInfo.TypeOf(arg) check misses it.
 // CodeRabbit finding on PR #3457.
 func leakViaAnyConversion(m *dek.Material) {
-	slog.Info("dek", "material", any(m)) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.Info("dek", "material", any(m)) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 // One positive per newly added sink symbol so a typo in the sink slice
@@ -41,57 +41,57 @@ func leakViaAnyConversion(m *dek.Material) {
 // Free-function *Context variants.
 
 func leakViaSlogInfoContext(ctx context.Context, m *dek.Material) {
-	slog.InfoContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.InfoContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaSlogDebugContext(ctx context.Context, m *dek.Material) {
-	slog.DebugContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.DebugContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaSlogWarnContext(ctx context.Context, m *dek.Material) {
-	slog.WarnContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.WarnContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaSlogErrorContext(ctx context.Context, m *dek.Material) {
-	slog.ErrorContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.ErrorContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 // Free-function LogAttrs takes (ctx, level, msg, ...Attr); a Material
 // wrapped in slog.Any still routes to the same sink check.
 
 func leakViaSlogLogAttrs(ctx context.Context, m *dek.Material) {
-	slog.LogAttrs(ctx, slog.LevelInfo, "dek", slog.Any("material", m)) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	slog.LogAttrs(ctx, slog.LevelInfo, "dek", slog.Any("material", m)) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 // slog.With bakes Material into a returned logger's attributes; every
 // subsequent log call leaks without Material appearing as a direct arg.
 
 func leakViaSlogWith(m *dek.Material) {
-	_ = slog.With("dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	_ = slog.With("dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 // *Logger method variants — same rationale as the free-function block.
 
 func leakViaLoggerInfoContext(ctx context.Context, m *dek.Material, l *slog.Logger) {
-	l.InfoContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.InfoContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerDebugContext(ctx context.Context, m *dek.Material, l *slog.Logger) {
-	l.DebugContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.DebugContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerWarnContext(ctx context.Context, m *dek.Material, l *slog.Logger) {
-	l.WarnContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.WarnContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerErrorContext(ctx context.Context, m *dek.Material, l *slog.Logger) {
-	l.ErrorContext(ctx, "dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.ErrorContext(ctx, "dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerLogAttrs(ctx context.Context, m *dek.Material, l *slog.Logger) {
-	l.LogAttrs(ctx, slog.LevelInfo, "dek", slog.Any("material", m)) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	l.LogAttrs(ctx, slog.LevelInfo, "dek", slog.Any("material", m)) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }
 
 func leakViaLoggerWith(m *dek.Material, l *slog.Logger) {
-	_ = l.With("dek", "material", m) // want `INV-27: dek.Material MUST NOT be passed to log/slog`
+	_ = l.With("dek", "material", m) // want `INV-CRYPTO-16: dek.Material MUST NOT be passed to log/slog`
 }


### PR DESCRIPTION
## Summary
Migrates the 7 gorules `dek.Material`-opacity lint analyzers' cited invariant id from master `INV-27` to its canonical registry id **INV-CRYPTO-16**. Annotation/diagnostic-string rename via closed-world `inv-migrate`; **no detection-logic change**.

Surfaced by the `.14.27` residual census (a *crypto* miss, out of that PR's cat-B scope). The analyzers (`dekmaterialno{json,proto,log,slog,gob,fmtformatting}` + `codeckeybytesallowlist`) cited `INV-27` in their `Doc` strings, diagnostic messages, and analysistest `// want` directives — a **stale id absent from the registry**, so a developer hitting the lint error couldn't find it. INV-CRYPTO-16 is the dek.Material non-leakage fence (8 existing refs in `internal/eventbus/crypto/dek/`).

### Changes
- 14 files rewritten (7 analyzer `.go` + 7 testdata `positive.go`); 14 refs added to INV-CRYPTO-16. The whole-token rewrite changes the analyzer **message** and the matching **`// want`** directive in lockstep, so `task test:gorules` (analysistest) stays green.
- The 7 crypto-analyzer dirs (crypto-exclusive, separate go module) added to INV-CRYPTO `owned_paths`; residual walk keeps them clean. Non-crypto sibling analyzers (`ulidmakeforbidden`, etc.) correctly left unclaimed.

### Verification
`task pr-prep` **pass**. `task test:gorules` (12 analyzers green, testcache-cleared re-run by review) + full `task lint` (bin/custom-gcl rebuilt with new messages) + invariant guard + build green.

### Reviews
- **crypto-reviewer: READY** — detection logic byte-identical (AST-matching, sink lists, codec.Key.Bytes allowlist untouched); the Material-exfiltration fence is not weakened; mapping INV-27→INV-CRYPTO-16 correct.
- **code-reviewer: READY** — zero `INV-27` survives in any code dir; partition correct (no over-reach); message==want lockstep confirmed on a fresh (cache-cleared) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)