### PR TITLE
refactor(invariants): migrate INV-E family (crypto sub-epic e) → INV-CRYPTO-88..115 (holomush-hz0v4.14.30)

### DIFF
--- a/api/proto/holomush/admin/v1/admin.proto
+++ b/api/proto/holomush/admin/v1/admin.proto
@@ -64,7 +64,7 @@ service AdminService {
 
   // RekeyResume resumes a paused or interrupted rekey identified by
   // request_id. Requires the crypto.operator capability and admin role
-  // (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+  // (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
   // enforced inside the orchestrator, not here. The handler validates that
   // request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
   // adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -75,7 +75,7 @@ service AdminService {
   // RekeyAbort cancels an in-progress rekey checkpoint. Requires the
   // crypto.operator capability only; no admin role re-check and no
   // dual-control approval — abort is single-control regardless of site
-  // policy (INV-E17). Any crypto.operator session may abort any non-terminal
+  // policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
   // checkpoint, not just the primary operator who started it.
   // Handler: internal/admin/socket/rekey_handler.go.
   rpc RekeyAbort(RekeyAbortRequest) returns (RekeyAbortResponse);

--- a/api/proto/holomush/admin/v1/rekey.proto
+++ b/api/proto/holomush/admin/v1/rekey.proto
@@ -27,7 +27,7 @@ message RekeyRequest {
   string context_type = 2;
   // context_id is the entity identifier within context_type, e.g. a scene
   // ULID. The orchestrator uses (context_type, context_id) to locate the
-  // active DEK and enforce INV-E5 (at most one non-terminal checkpoint per
+  // active DEK and enforce INV-CRYPTO-92 (at most one non-terminal checkpoint per
   // context at a time).
   string context_id = 3;
   // justification is a free-text operator rationale stored on the checkpoint
@@ -88,7 +88,7 @@ message PhaseStarted {
 // cold-tier re-encryption phase. The orchestrator rewrites events_audit rows
 // in batches of up to 1000, decrypting each under the old DEK and
 // re-encrypting under the new DEK with AAD rebound to the new (dek_ref,
-// dek_version) — INV-E8. Clients may use these messages to render a
+// dek_version) — INV-CRYPTO-95. Clients may use these messages to render a
 // progress bar; the stream is terminated by RekeyCompleted or RekeyError.
 message Phase3Progress {
   // rows_rewritten is the cumulative count of events_audit rows re-encrypted
@@ -101,7 +101,7 @@ message Phase3Progress {
   int64 rows_remaining_estimate = 2;
   // last_processed_event_id is the ULID bytes of the most recently committed
   // batch's last row. Stored as the Phase 3 resume cursor in the checkpoint
-  // row (INV-E7-COLD-RESUME-CURSOR); a crash and resume picks up exactly
+  // row (INV-CRYPTO-94); a crash and resume picks up exactly
   // where this cursor points.
   bytes last_processed_event_id = 3;
 }
@@ -192,7 +192,7 @@ message RekeyError {
 
 // RekeyResumeRequest resumes a paused or interrupted rekey operation identified
 // by request_id. The orchestrator determines the resume entry point from the
-// checkpoint's current FSM status and drives forward from there. INV-E16:
+// checkpoint's current FSM status and drives forward from there. INV-CRYPTO-103:
 // resuming a complete checkpoint is a no-op that re-emits RekeyCompleted.
 // Resuming an aborted checkpoint surfaces DEK_REKEY_CHECKPOINT_TERMINAL.
 message RekeyResumeRequest {
@@ -213,14 +213,14 @@ message RekeyResumeRequest {
 }
 
 // RekeyAbortRequest cancels a non-terminal rekey operation, transitioning its
-// checkpoint to the aborted state. Abort is single-control (INV-E17): any
+// checkpoint to the aborted state. Abort is single-control (INV-CRYPTO-104): any
 // session holding crypto.operator capability may abort any non-terminal
 // checkpoint, regardless of site dual-control policy or which operator
 // initiated the rekey. Once aborted the checkpoint is terminal; a new Rekey
 // call is required to restart.
 message RekeyAbortRequest {
   // session_token authenticates the aborting operator. Only crypto.operator
-  // capability is required — no admin role re-check (INV-E17).
+  // capability is required — no admin role re-check (INV-CRYPTO-104).
   string session_token = 1;
   // request_id is the 16-byte ULID of the checkpoint to abort. The handler
   // rejects zero bytes with REKEY_INVALID_REQUEST_ID. If the checkpoint is
@@ -282,7 +282,7 @@ message RekeyStatusResponse {
   google.protobuf.Timestamp started_at = 6;
   // last_heartbeat_at is the server timestamp of the most recent heartbeat
   // written by Phase 3. The sweep worker uses this to TTL-abort stalled
-  // checkpoints (INV-E18/E19). A value far in the past indicates a stalled
+  // checkpoints (INV-CRYPTO-105/INV-CRYPTO-106). A value far in the past indicates a stalled
   // or crashed orchestrator run.
   google.protobuf.Timestamp last_heartbeat_at = 7;
   // completed_at is the server timestamp when the checkpoint reached a

--- a/api/proto/holomush/core/v1/core.proto
+++ b/api/proto/holomush/core/v1/core.proto
@@ -326,7 +326,7 @@ enum NoPlaintextReason {
 
   // NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were
   // indecipherable — a production-real outcome after a sub-epic E rekey plus DEK
-  // destruction (INV-E21 double miss).
+  // destruction (INV-CRYPTO-108 double miss).
   NO_PLAINTEXT_REASON_STALE_DEK = 2;
 
   // NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL means a plugin audit-emit hit

--- a/api/proto/holomush/plugin/v1/audit.proto
+++ b/api/proto/holomush/plugin/v1/audit.proto
@@ -233,7 +233,7 @@ message RowResult {
     // (recipient not authorized by manifest declaration / ABAC grant — Phase 3b
     // AuthGuard deny), "downgrade_refused" (INV-CRYPTO-42 fence — sensitive event
     // stored under identity codec), "dek_missing" (INV-CRYPTO-50 fence — no DEK
-    // exists for this row's context), "stale_dek" (INV-E21 — both hot and cold
+    // exists for this row's context), "stale_dek" (INV-CRYPTO-108 — both hot and cold
     // DEK tiers gone), "audit_queue_full" (plugin audit-emit backpressure), and
     // "internal" (host-side error, details logged server-side only).
     string no_plaintext_reason = 3;

--- a/cmd/holomush/cmd_crypto_rekey.go
+++ b/cmd/holomush/cmd_crypto_rekey.go
@@ -37,7 +37,7 @@ type RekeyStreamReader interface {
 
 // rekeyProgressError is a typed error that carries a server-sent error code
 // and message from a RekeyError progress event.  mapToExitCodeErr inspects
-// this type to assign sysexits.h exit codes (INV-E23).
+// this type to assign sysexits.h exit codes (INV-CRYPTO-110).
 type rekeyProgressError struct {
 	code string
 	msg  string
@@ -207,7 +207,7 @@ func streamProgress(stream RekeyStreamReader, noProgress bool, w io.Writer) erro
 }
 
 // mapErrToExitCodeForTest maps any error carrying a known oops code or
-// rekeyProgressError code to its sysexits.h integer (INV-E23).  Returns 1
+// rekeyProgressError code to its sysexits.h integer (INV-CRYPTO-110).  Returns 1
 // for unknown errors.  This testable helper is callable from tests so the
 // exit-code logic is exercisable without invoking os.Exit.
 func mapErrToExitCodeForTest(err error) int {
@@ -238,7 +238,7 @@ func mapErrToExitCodeForTest(err error) int {
 }
 
 // mapToExitCodeErr maps a rekey error to an exitCodeError carrying the
-// appropriate sysexits.h code per INV-E23.  Unknown errors pass through
+// appropriate sysexits.h code per INV-CRYPTO-110.  Unknown errors pass through
 // unchanged.
 func mapToExitCodeErr(err error) error {
 	var pe *rekeyProgressError
@@ -273,7 +273,7 @@ func openApprovalAndWait(
 // --- Sub-subcommands ---
 
 // newRekeyResumeCmd returns `holomush crypto rekey resume <request_id>`.
-// --force-destroy bypasses Phase 5 cluster invalidation (INV-E10 gates this
+// --force-destroy bypasses Phase 5 cluster invalidation (INV-CRYPTO-97 gates this
 // server-side: checkpoint must be at phase5_timeout).  In non-TTY mode the
 // --confirm <context_id> flag is required; missing or empty value exits 64
 // (EX_USAGE).  In TTY mode the operator is prompted interactively.

--- a/cmd/holomush/cmd_crypto_rekey_errors_test.go
+++ b/cmd/holomush/cmd_crypto_rekey_errors_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestRekeyProgressErrorAndExitCodeError covers the Is and Unwrap methods of
 // rekeyProgressError and exitCodeError, which mapToExitCodeErr and friends
-// rely on for sysexits.h code assignment (INV-E23).
+// rely on for sysexits.h code assignment (INV-CRYPTO-110).
 func TestRekeyProgressErrorAndExitCodeError(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/holomush/cmd_crypto_rekey_test.go
+++ b/cmd/holomush/cmd_crypto_rekey_test.go
@@ -421,7 +421,7 @@ func TestNewCryptoCmdRekeySubcmdRegistered(t *testing.T) {
 	assert.Equal(t, "rekey", cmd.Name())
 }
 
-// --- Tests for mapToExitCodeErr (INV-E23) ---
+// --- Tests for mapToExitCodeErr (INV-CRYPTO-110) ---
 
 // TestMapToExitCodeErr_TEMPFAIL verifies DEK_REKEY_PHASE5_TIMEOUT → exitCode 75.
 func TestMapToExitCodeErr_TEMPFAIL(t *testing.T) {
@@ -783,7 +783,7 @@ func TestCmd_CryptoRekey_Resume_Registered(t *testing.T) {
 
 // TestCmd_CryptoRekey_Resume_ForceDestroy_IgnoredWhenStatusNotTimeout verifies
 // that DEK_REKEY_FORCE_DESTROY_FORBIDDEN from the server surfaces as an error
-// (INV-E10: server-side guard).  The CLI passes the flag through; the server
+// (INV-CRYPTO-97: server-side guard).  The CLI passes the flag through; the server
 // rejects it.
 func TestCmd_CryptoRekey_Resume_ForceDestroy_RejectedByServer(t *testing.T) {
 	h := &fakeAdminHandlerWithRekey{
@@ -1005,7 +1005,7 @@ func TestCmd_CryptoRekey_List_Empty(t *testing.T) {
 	assert.Contains(t, out.String(), "REQUEST_ID")
 }
 
-// --- INV-E23 exit-code invariant test (bead holomush-jxo8.7.33) ---
+// --- INV-CRYPTO-110 exit-code invariant test (bead holomush-jxo8.7.33) ---
 
 // TestCmd_CryptoRekey_ExitCodes_INV_E23 is the table-driven exit-code invariant
 // test.  Every named oops error code must map to its sysexits.h exit code via

--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -688,7 +688,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// bead wires; until then those RPCs remain unimplemented).
 	//
 	// The sweep subsystem auto-aborts non-terminal checkpoints whose
-	// last_heartbeat_at has exceeded TTL (INV-E18 / INV-E19, spec §6.2);
+	// last_heartbeat_at has exceeded TTL (INV-CRYPTO-105 / INV-CRYPTO-106, spec §6.2);
 	// it depends only on CheckpointRepo + AuditEmitter, both of which the
 	// host already has at this point.
 	cryptoCfg := cryptoConfig.Defaults()
@@ -697,7 +697,7 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 		chain.NewEmitter(auditChainRepo),
 		&rekeyAuditPublisherAdapter{publisher: auditPublisher, clock: totp.NewRealClock()},
 	)
-	// policyHashSource backs the Phase 1 policy_hash freeze (INV-E25).
+	// policyHashSource backs the Phase 1 policy_hash freeze (INV-CRYPTO-112).
 	// Sub-epic E T44 (holomush-jxo8.7.44) consumes it via buildRekeyWiring
 	// below; earlier beads referenced the constructor but did not wire it
 	// into a Manager yet (no production dek.NewManager call site existed).

--- a/cmd/holomush/crypto_rekey_wiring.go
+++ b/cmd/holomush/crypto_rekey_wiring.go
@@ -44,7 +44,7 @@ type rekeyWiring struct {
 	// admin handler's CheckpointStatusReader + RekeyAbortRunner adapters.
 	CheckpointRepo *dek.CheckpointRepo
 	// AuditEmitter is the *dek.RekeyAuditEmitter; the abort path reuses it
-	// to emit the abort audit event (INV-E17).
+	// to emit the abort audit event (INV-CRYPTO-104).
 	AuditEmitter *dek.RekeyAuditEmitter
 	// RekeyHandler is the socket-layer RekeyConnectHandler ready to install
 	// in the admin-socket Config. nil when the upstream wiring (KEK / Manager)
@@ -115,7 +115,7 @@ type coordHolder struct {
 //   - SetDestroyer: *dek.manager (satisfies Destroyer via DestroyDEK +
 //     EvictCachedDEK)
 //   - SetAuditEmitter: the supplied *dek.RekeyAuditEmitter
-//   - SetDataDir: the runtime data directory for INV-E13 fallback log
+//   - SetDataDir: the runtime data directory for INV-CRYPTO-100 fallback log
 func buildRekeyWiring(
 	_ context.Context,
 	deps rekeyWiringDeps,
@@ -268,7 +268,7 @@ type productionOrchestratorRunner struct {
 //
 // Resume path: when req.RequestID is non-zero (RekeyResume RPC), the handler
 // supplies only RequestID + Operator + ForceDestroy. RunByRequestID looks up
-// the checkpoint by ID, enforces INV-E16 operator-binding, and drives the
+// the checkpoint by ID, enforces INV-CRYPTO-103 operator-binding, and drives the
 // remaining phases to completion.
 func (a *productionOrchestratorRunner) Run(ctx context.Context, req socket.RekeyRunRequest) (socket.RekeyRunOutcome, error) {
 	operator := dek.OperatorIdentity{
@@ -316,7 +316,7 @@ func (a *productionOrchestratorRunner) Run(ctx context.Context, req socket.Rekey
 }
 
 // productionRekeyAbortRunner adapts *dek.CheckpointRepo + *dek.RekeyAuditEmitter
-// to socket.RekeyAbortRunner. INV-E17: abort is single-control regardless of
+// to socket.RekeyAbortRunner. INV-CRYPTO-104: abort is single-control regardless of
 // dual_control_required policy.
 type productionRekeyAbortRunner struct {
 	repo    *dek.CheckpointRepo

--- a/cmd/holomush/gateway_imports_test.go
+++ b/cmd/holomush/gateway_imports_test.go
@@ -37,7 +37,7 @@ var coreOnlyFiles = map[string]struct{}{
 	"bootstrap_orphan_test.go":        {},
 	// Phase 5 sub-epic E rekey wiring (holomush-jxo8.7.34). Constructs
 	// dek.PolicyHashSource over auditchain.Repo for the orchestrator's
-	// INV-E25 capture-at-Phase-1 dependency. Core-only.
+	// INV-CRYPTO-112 capture-at-Phase-1 dependency. Core-only.
 	"policy_hash_source.go": {},
 	// Phase 5 sub-epic E rekey wiring (holomush-jxo8.7.44). Production
 	// dek.Manager + Orchestrator + admin RekeyHandler construction. Imports

--- a/cmd/holomush/phase7_fence_wiring.go
+++ b/cmd/holomush/phase7_fence_wiring.go
@@ -20,7 +20,7 @@ import (
 // newViolationEmitter constructs a ViolationEmitter that publishes
 // `events.<game>.system.plugin_integrity_violation` events on every
 // PluginDowngradeFence INV-CRYPTO-42 refusal. The events.> prefix is required
-// by INV-E26 (Phase 5 sub-epic E §3.6) — only the EVENTS JetStream
+// by INV-CRYPTO-113 (Phase 5 sub-epic E §3.6) — only the EVENTS JetStream
 // SubjectFilter feeds events_audit. The emitter MUST NOT block —
 // the fence already enforces a 100ms ceiling around EmitViolation, but
 // this implementation also serializes the payload into a tiny Event so
@@ -66,7 +66,7 @@ func (e *violationEmitter) EmitViolation(
 		// log an emit-error on every refusal.
 		return nil
 	}
-	// Subject prefix MUST be `events.<game>.` per INV-E26 (Phase 5 sub-epic E
+	// Subject prefix MUST be `events.<game>.` per INV-CRYPTO-113 (Phase 5 sub-epic E
 	// §3.6 supersession of master spec §4.6 line 830): the EVENTS JetStream
 	// SubjectFilter at internal/eventbus/subsystem.go:24,27 is the only path
 	// by which audit projection writes to events_audit, so audit-bearing

--- a/cmd/holomush/policy_hash_source.go
+++ b/cmd/holomush/policy_hash_source.go
@@ -18,7 +18,7 @@ import (
 // is constructed at the wiring layer where both packages are importable —
 // per the wiring contract documented on dek.NewAuditChainPolicyHashSource.
 //
-// INV-E25 (sub-epic E spec §3.6 / spec §6): Phase 1 calls CurrentPolicyHash
+// INV-CRYPTO-112 (sub-epic E spec §3.6 / spec §6): Phase 1 calls CurrentPolicyHash
 // once and freezes the result on the checkpoint row. Later phases never
 // re-query the policy hash.
 //

--- a/cmd/holomush/readstream_wiring.go
+++ b/cmd/holomush/readstream_wiring.go
@@ -150,7 +150,7 @@ func buildReadStreamWiring(
 		grants = readstreamGrantsOverrideForTest
 	}
 
-	// Compute the canonical policy_hash string. INV-E25 / INV-F-policy_hash:
+	// Compute the canonical policy_hash string. INV-CRYPTO-112 / INV-F-policy_hash:
 	// the audit payload stores "sha256:<hex>"; the ReadStarted wire frame
 	// decodes back to the raw 32 bytes via decodeHashString. Genesis (no
 	// crypto.policy_set chain entries) maps to the all-zero 32-byte

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -137,6 +137,34 @@ invariants.
 | `INV-CRYPTO-85` | The google.golang.org/protobuf module MUST be pinned in go.mod; a meta-test asserts the pin, because proto.MarshalOptions{Deterministic: true} is documented stable only within a binary version, and cross-process op_args_hash agreement (INV-CRYPTO-75/76) is load-bearing on it. | `INV-D18` | pending |
 | `INV-CRYPTO-86` | Authenticate MUST reject any request whose verified player_id does not have at least one character with the admin role (DENY_NOT_ADMIN_ROLE); the crypto.operator capability is narrowing on top of RoleAdmin. | `INV-D19` | pending |
 | `INV-CRYPTO-87` | The verifier MUST distinguish first-boot-no-chain from chain-truncated via a persistent chain-init signal in bootstrap_metadata (key crypto.policy_chain_initialized.<policy_name> = true): after a successful genesis Publish the emitter writes the signal idempotently; a later boot with an empty audit row-set but the signal present returns POLICY_CHAIN_TRUNCATED. | `INV-D20` | pending |
+| `INV-CRYPTO-88` | Rekey checkpoint status MUST only transition forward through the documented sequence or to aborted; status-update SQL MUST use a WHERE status = ? predicate (stale-writer rejection). | `INV-E1` | pending |
+| `INV-CRYPTO-89` | Forward checkpoint transitions MUST be to the immediate next status; the only exception is phase5_timeout → phase6_complete when force_destroy = true. | `INV-E2` | pending |
+| `INV-CRYPTO-90` | The complete and aborted checkpoint statuses are absorbing (terminal); a CHECK constraint enforces consistency. | `INV-E3` | pending |
+| `INV-CRYPTO-91` | A rekey resume invocation MUST match an existing checkpoint by BOTH op_args_hash and primary_player_id. | `INV-E4` | pending |
+| `INV-CRYPTO-92` | At most one non-terminal rekey checkpoint may exist per (context_type, context_id), enforced by a UNIQUE partial index. | `INV-E5` | pending |
+| `INV-CRYPTO-93` | At Phase-2 INSERT the new DEK row's participants MUST be byte-equal to the old DEK row's participants. | `INV-E6` | pending |
+| `INV-CRYPTO-94` | After a crash mid-Phase-3, the next attempt MUST resume from the last committed last_processed_event_id and produce byte-identical final cold-tier content. | `INV-E7` | pending |
+| `INV-CRYPTO-95` | Each cold-tier row's re-encrypted payload AAD MUST be rebuilt from (subject, type, new_key_id, new_version, codec); the old AAD must fail with an AEAD tag mismatch. | `INV-E8` | pending |
+| `INV-CRYPTO-96` | Phase 4 introduces no status transitions in the rekey orchestrator (happy-path trace skips a Phase-4 status). | `INV-E9` | pending |
+| `INV-CRYPTO-97` | --force-destroy MUST be rejected when the checkpoint status is not phase5_timeout. | `INV-E10` | pending |
+| `INV-CRYPTO-98` | Force-destroy completion MUST emit an audit event with force_destroy: true and final_missing_members: [...]. | `INV-E11` | pending |
+| `INV-CRYPTO-99` | The Phase-6 UPDATE MUST be idempotent on retry; a second invocation on an already-destroyed checkpoint is a no-op. | `INV-E12` | pending |
+| `INV-CRYPTO-100` | Phase-7 audit emission MUST be confirmed via projection ack before transition to complete; on failure the payload MUST be written to a host-local fallback log. | `INV-E13` | pending |
+| `INV-CRYPTO-101` | Every events.<game>.system.rekey.* event MUST have rekey_chain.prev_hash equal to auditchain.RecomputeSelfHash(prev event payload), or null for the per-scope genesis. | `INV-E14` | pending |
+| `INV-CRYPTO-102` | Server boot MUST refuse with AUDIT_CHAIN_BROKEN when any registered chain (policy_set or rekey) has a break. | `INV-E15` | pending |
+| `INV-CRYPTO-103` | A rekey resume MUST bypass dual-control approval when a non-terminal checkpoint exists AND the session player_id matches primary_player_id; a different operator MUST be rejected. | `INV-E16` | pending |
+| `INV-CRYPTO-104` | Abort MUST accept single-control regardless of site policy on rekey; the audit captures aborter_player_id distinct from primary_player_id. | `INV-E17` | pending |
+| `INV-CRYPTO-105` | The 24h heartbeat-TTL sweep MUST emit a chained audit event with aborted_reason: "ttl_expired" for every checkpoint it aborts. | `INV-E18` | pending |
+| `INV-CRYPTO-106` | A running orchestrator MUST update last_heartbeat_at within min(30s, sweep_interval/3). | `INV-E19` | pending |
+| `INV-CRYPTO-107` | After a cold-envelope fallback the dispatcher AAD construction MUST use the substituted cold envelope's fields, NOT the original hot envelope's. | `INV-E20` | pending |
+| `INV-CRYPTO-108` | When FallbackResolver returns ErrMetadataOnly, the dispatcher MUST deliver metadata_only=true with empty payload bytes. | `INV-E21` | pending |
+| `INV-CRYPTO-109` | Phase 5 MUST invoke invalidation.Coordinator.RequestInvalidation with Action: ActionRekey — no bespoke invalidation surface. | `INV-E22` | pending |
+| `INV-CRYPTO-110` | Rekey CLI exit codes MUST follow the sysexits.h mappings. | `INV-E23` | pending |
+| `INV-CRYPTO-111` | op_args_hash MUST be computed via the same proto.MarshalOptions{Deterministic: true} helper sub-epic-d ships, against the resolved RekeyRequest proto, and MUST be stable across builds with protobuf-go pinned per INV-CRYPTO-85. | `INV-E24` | pending |
+| `INV-CRYPTO-112` | A rekey event's policy_hash MUST be captured at Phase-1 INSERT into crypto_rekey_checkpoints.policy_hash; Phase-7 emit reads this column verbatim and never re-queries the chain head; a policy_set event mid-rekey MUST NOT change the persisted hash. | `INV-E25` | pending |
+| `INV-CRYPTO-113` | Every registered auditchain.Chain's SubjectFor(scope) MUST return a string starting with events.<game>. so chain-bearing audit events reach events_audit via the EVENTS JetStream events.> SubjectFilter. | `INV-E26` | pending |
+| `INV-CRYPTO-114` | Every registered auditchain.Chain MUST populate ScopeFromPayload; the verifier MUST reject with AUDIT_CHAIN_SCOPE_MISMATCH any row where ScopeFromSubject(subject) != ScopeFromPayload(payload). | `INV-E27` | pending |
+| `INV-CRYPTO-115` | The auditchain.Verifier self-hash recompute MUST be SHA-256(Canonicalize(zero(payload, SelfHashFieldName))); SHA-256 and composition order are pinned at the primitive level, while per-chain Canonicalize MAY apply domain normalization (e.g. PolicySetChain renormalizes empty PrevHash → nil to preserve INV-CRYPTO-77 semantics). | `INV-E28` | pending |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -30,6 +30,7 @@ scopes:
       - "docs/superpowers/specs/2026-05-05-history-reader-crypto-options-design.md"
       - "docs/superpowers/specs/2026-05-11-event-payload-crypto-phase5-sub-epic-f-design.md"
       - "docs/superpowers/specs/2026-05-09-event-payload-crypto-phase5-sub-epic-d-design.md"
+      - "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
     owned_paths:
       - "internal/eventbus/crypto/**"
       - "internal/eventbus/history/**"
@@ -78,10 +79,21 @@ scopes:
       - "internal/admin/totp_audit/auditing_test.go"
       - "test/integration/admin_policy_chain_test.go"
       - "test/integration/eventbus_e2e/audit_only_channel_test.go"
+      # INV-E (.14.30): crypto phase-5 sub-epic-e — rekey/checkpoint FSM CLI + admin rekey/policy tests.
+      - "cmd/holomush/cmd_crypto_rekey.go"
+      - "cmd/holomush/cmd_crypto_rekey_errors_test.go"
+      - "cmd/holomush/cmd_crypto_rekey_test.go"
+      - "cmd/holomush/crypto_rekey_wiring.go"
+      - "cmd/holomush/policy_hash_source.go"
+      - "internal/admin/policy/verifier_integration_test.go"
+      - "internal/admin/socket/rekey_handler_test.go"
     shared_files:
       # CRYPTO+STORE: history files carrying both P7/RB and TS (nanos) annotations.
       # INV-D sub-epic-d co-located with sibling INV-E (migrating .14.30) / go.mod dep-pins / multi-scope.
       - "api/proto/holomush/admin/v1/rekey.proto"
+      # INV-E sub-epic-e: readstream policy_hash wiring (+ stray INV-F-policy_hash, holomush bead) / multi-scope test server.
+      - "cmd/holomush/readstream_wiring.go"
+      - "internal/testsupport/holomushtest/server.go"
       - "go.mod"
       - "internal/admin/policy/chain.go"
       - "internal/admin/policy/verifier.go"
@@ -544,8 +556,11 @@ scopes:
       # are PRIVACY-shared (I-PRIV-6 co-located) so they are SHARED below, not owned; these two
       # are ACCESS-exclusive for the deny-policy invariants.
       - "internal/access/policy/seed_smoke_test.go"
-      - "internal/access/spec_amendments_test.go"
     shared_files:
+      # spec-amendment fingerprint test: retains a literal "INV-E16" matched against
+      # the (un-migrated) master spec text — shared so the .14.21 residual legacy-token
+      # walk skips it (INV-E16 became a registered legacy token in .14.30).
+      - "internal/access/spec_amendments_test.go"
       # General integration harness (RA-4 pointer-identity ride-along).
       - "internal/testsupport/integrationtest/harness.go"
       - "internal/testsupport/integrationtest/plugins.go"
@@ -3790,3 +3805,419 @@ invariants:
       emitter writes the signal idempotently; a later boot with an empty audit row-set but the signal present returns POLICY_CHAIN_TRUNCATED."
     binding: pending
     refs: []
+  - id: INV-CRYPTO-88
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E1@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Rekey checkpoint status MUST only transition forward through the documented sequence or to aborted; status-update
+      SQL MUST use a WHERE status = ? predicate (stale-writer rejection)."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm_test.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_integration_test.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator_test.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase6_integration_test.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7_integration_test.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E1"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E1"}
+  - id: INV-CRYPTO-89
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E2@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Forward checkpoint transitions MUST be to the immediate next status; the only exception is phase5_timeout →
+      phase6_complete when force_destroy = true."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm.go", token: "INV-E2"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm_test.go", token: "INV-E2"}
+  - id: INV-CRYPTO-90
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E3@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "The complete and aborted checkpoint statuses are absorbing (terminal); a CHECK constraint enforces consistency."
+    binding: pending
+    refs: []
+  - id: INV-CRYPTO-91
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E4@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "A rekey resume invocation MUST match an existing checkpoint by BOTH op_args_hash and primary_player_id."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/admin/v1/admin.proto", token: "INV-E4"}
+      - {file: "internal/admin/socket/rekey_handler.go", token: "INV-E4"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E4"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E4"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_internal_test.go", token: "INV-E4"}
+      - {file: "test/integration/crypto/rekey_phase5_timeout_test.go", token: "INV-E4"}
+      - {file: "test/integration/crypto/rekey_policy_hash_frozen_at_phase1_test.go", token: "INV-E4"}
+      - {file: "test/integration/crypto/rekey_resume_rpc_test.go", token: "INV-E4"}
+      - {file: "test/integration/crypto/rekey_resume_test.go", token: "INV-E4"}
+  - id: INV-CRYPTO-92
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E5@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "At most one non-terminal rekey checkpoint may exist per (context_type, context_id), enforced by a UNIQUE partial
+      index."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E5"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E5"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E5"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator_test.go", token: "INV-E5"}
+  - id: INV-CRYPTO-93
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E6@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "At Phase-2 INSERT the new DEK row's participants MUST be byte-equal to the old DEK row's participants."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-E6-PARTICIPANT-INVARIANCE"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E6-PARTICIPANT-INVARIANCE"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator_test.go", token: "INV-E6-PARTICIPANT-INVARIANCE"}
+      - {file: "internal/eventbus/crypto/dek/store.go", token: "INV-E6-PARTICIPANT-INVARIANCE"}
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-E6"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E6"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator_test.go", token: "INV-E6"}
+      - {file: "internal/eventbus/crypto/dek/store.go", token: "INV-E6"}
+  - id: INV-CRYPTO-94
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E7@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "After a crash mid-Phase-3, the next attempt MUST resume from the last committed last_processed_event_id and
+      produce byte-identical final cold-tier content."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E7-COLD-RESUME-CURSOR"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3.go", token: "INV-E7-COLD-RESUME-CURSOR"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3_integration_test.go", token: "INV-E7-COLD-RESUME-CURSOR"}
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E7"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E7"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm.go", token: "INV-E7"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3.go", token: "INV-E7"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3_integration_test.go", token: "INV-E7"}
+  - id: INV-CRYPTO-95
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E8@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Each cold-tier row's re-encrypted payload AAD MUST be rebuilt from (subject, type, new_key_id, new_version,
+      codec); the old AAD must fail with an AEAD tag mismatch."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E8"}
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-E8"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3.go", token: "INV-E8"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3_integration_test.go", token: "INV-E8"}
+  - id: INV-CRYPTO-96
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E9@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Phase 4 introduces no status transitions in the rekey orchestrator (happy-path trace skips a Phase-4 status)."
+    binding: pending
+    refs: []
+  - id: INV-CRYPTO-97
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E10@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "--force-destroy MUST be rejected when the checkpoint status is not phase5_timeout."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5.go", token: "INV-E10-FORCE-DESTROY-GATED"}
+      - {file: "cmd/holomush/cmd_crypto_rekey.go", token: "INV-E10"}
+      - {file: "cmd/holomush/cmd_crypto_rekey_test.go", token: "INV-E10"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E10"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5.go", token: "INV-E10"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5_integration_test.go", token: "INV-E10"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5_internal_test.go", token: "INV-E10"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E10"}
+      - {file: "test/integration/crypto/rekey_force_destroy_test.go", token: "INV-E10"}
+  - id: INV-CRYPTO-98
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E11@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Force-destroy completion MUST emit an audit event with force_destroy: true and final_missing_members: [...]."
+    binding: pending
+    refs:
+      - {file: "internal/admin/socket/rekey_handler_test.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5_integration_test.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7_integration_test.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E11"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E11"}
+      - {file: "test/integration/crypto/rekey_force_destroy_test.go", token: "INV-E11"}
+  - id: INV-CRYPTO-99
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E12@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "The Phase-6 UPDATE MUST be idempotent on retry; a second invocation on an already-destroyed checkpoint is a
+      no-op."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-E12-PHASE6-IDEMPOTENT"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase6.go", token: "INV-E12-PHASE6-IDEMPOTENT"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase6_integration_test.go", token: "INV-E12-PHASE6-IDEMPOTENT"}
+      - {file: "internal/eventbus/crypto/dek/store.go", token: "INV-E12-PHASE6-IDEMPOTENT"}
+      - {file: "internal/eventbus/crypto/dek/manager.go", token: "INV-E12"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase6.go", token: "INV-E12"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase6_integration_test.go", token: "INV-E12"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E12"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E12"}
+      - {file: "internal/eventbus/crypto/dek/store.go", token: "INV-E12"}
+  - id: INV-CRYPTO-100
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E13@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Phase-7 audit emission MUST be confirmed via projection ack before transition to complete; on failure the payload
+      MUST be written to a host-local fallback log."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E13-PHASE7-AUDIT-OR-FALLBACK"}
+      - {file: "test/integration/crypto/rekey_phase7_audit_failure_test.go", token: "INV-E13-PHASE7-AUDIT-OR-FALLBACK"}
+      - {file: "cmd/holomush/crypto_rekey_wiring.go", token: "INV-E13"}
+      - {file: "internal/eventbus/crypto/dek/audit.go", token: "INV-E13"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E13"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E13"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7_integration_test.go", token: "INV-E13"}
+      - {file: "test/integration/crypto/rekey_phase7_audit_failure_test.go", token: "INV-E13"}
+  - id: INV-CRYPTO-101
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E14@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Every events.<game>.system.rekey.* event MUST have rekey_chain.prev_hash equal to auditchain.RecomputeSelfHash(prev
+      event payload), or null for the per-scope genesis."
+    binding: pending
+    refs:
+      - {file: "internal/core/builtins.go", token: "INV-E14"}
+      - {file: "internal/eventbus/crypto/dek/audit.go", token: "INV-E14"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5_integration_test.go", token: "INV-E14"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E14"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7_integration_test.go", token: "INV-E14"}
+      - {file: "internal/testsupport/holomushtest/server.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/harness_impl_test.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/rekey_force_destroy_test.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/rekey_happy_path_test.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/rekey_phase5_timeout_test.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/rekey_resume_rpc_test.go", token: "INV-E14"}
+      - {file: "test/integration/crypto/rekey_resume_test.go", token: "INV-E14"}
+  - id: INV-CRYPTO-102
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E15@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Server boot MUST refuse with AUDIT_CHAIN_BROKEN when any registered chain (policy_set or rekey) has a break."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem.go", token: "INV-E15-CHAIN-VERIFIER-BOOT"}
+      - {file: "test/integration/crypto/rekey_chain_verifier_refuses_boot_test.go", token: "INV-E15-CHAIN-VERIFIER-BOOT"}
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem.go", token: "INV-E15"}
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem_test.go", token: "INV-E15"}
+      - {file: "test/integration/crypto/policy_set_chain_post_refactor_test.go", token: "INV-E15"}
+      - {file: "test/integration/crypto/rekey_chain_verifier_refuses_boot_test.go", token: "INV-E15"}
+  - id: INV-CRYPTO-103
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E16@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "A rekey resume MUST bypass dual-control approval when a non-terminal checkpoint exists AND the session player_id
+      matches primary_player_id; a different operator MUST be rejected."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E16-AUTH-RESUME-NOAPPROVAL"}
+      - {file: "api/proto/holomush/admin/v1/admin.proto", token: "INV-E16"}
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E16"}
+      - {file: "cmd/holomush/crypto_rekey_wiring.go", token: "INV-E16"}
+      - {file: "internal/admin/socket/rekey_handler.go", token: "INV-E16"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run.go", token: "INV-E16"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E16"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_internal_test.go", token: "INV-E16"}
+      - {file: "test/integration/crypto/rekey_policy_hash_frozen_at_phase1_test.go", token: "INV-E16"}
+      - {file: "test/integration/crypto/rekey_resume_rpc_test.go", token: "INV-E16"}
+      - {file: "test/integration/crypto/rekey_resume_test.go", token: "INV-E16"}
+  - id: INV-CRYPTO-104
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E17@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Abort MUST accept single-control regardless of site policy on rekey; the audit captures aborter_player_id distinct
+      from primary_player_id."
+    binding: pending
+    refs:
+      - {file: "internal/admin/socket/rekey_handler.go", token: "INV-E17-ABORT-NO-DUAL-CONTROL"}
+      - {file: "api/proto/holomush/admin/v1/admin.proto", token: "INV-E17"}
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E17"}
+      - {file: "cmd/holomush/crypto_rekey_wiring.go", token: "INV-E17"}
+      - {file: "internal/admin/socket/rekey_handler.go", token: "INV-E17"}
+      - {file: "internal/admin/socket/rekey_handler_test.go", token: "INV-E17"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm.go", token: "INV-E17"}
+      - {file: "internal/testsupport/holomushtest/server.go", token: "INV-E17"}
+      - {file: "test/integration/crypto/rekey_abort_test.go", token: "INV-E17"}
+  - id: INV-CRYPTO-105
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E18@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "The 24h heartbeat-TTL sweep MUST emit a chained audit event with aborted_reason: \"ttl_expired\" for every checkpoint
+      it aborts."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/sweep.go", token: "INV-E18-SWEEP-TTL-AUDIT"}
+      - {file: "internal/eventbus/crypto/dek/sweep_integration_test.go", token: "INV-E18-SWEEP-TTL-AUDIT"}
+      - {file: "test/integration/crypto/rekey_sweep_ttl_test.go", token: "INV-E18-SWEEP-TTL-AUDIT"}
+      - {file: "api/proto/holomush/admin/v1/rekey.proto", token: "INV-E18"}
+      - {file: "cmd/holomush/core.go", token: "INV-E18"}
+      - {file: "internal/config/config.go", token: "INV-E18"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E18"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint_fsm.go", token: "INV-E18"}
+      - {file: "internal/eventbus/crypto/dek/sweep.go", token: "INV-E18"}
+      - {file: "internal/eventbus/crypto/dek/sweep_integration_test.go", token: "INV-E18"}
+      - {file: "test/integration/crypto/rekey_sweep_ttl_test.go", token: "INV-E18"}
+  - id: INV-CRYPTO-106
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E19@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "A running orchestrator MUST update last_heartbeat_at within min(30s, sweep_interval/3)."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/core.go", token: "INV-E19"}
+      - {file: "internal/config/config.go", token: "INV-E19"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3.go", token: "INV-E19"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase3_integration_test.go", token: "INV-E19"}
+  - id: INV-CRYPTO-107
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E20@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "After a cold-envelope fallback the dispatcher AAD construction MUST use the substituted cold envelope's fields,
+      NOT the original hot envelope's."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/history/dispatcher.go", token: "INV-E20"}
+      - {file: "internal/eventbus/history/dispatcher_test.go", token: "INV-E20"}
+  - id: INV-CRYPTO-108
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E21@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "When FallbackResolver returns ErrMetadataOnly, the dispatcher MUST deliver metadata_only=true with empty payload
+      bytes."
+    binding: pending
+    refs:
+      - {file: "api/proto/holomush/core/v1/core.proto", token: "INV-E21"}
+      - {file: "api/proto/holomush/plugin/v1/audit.proto", token: "INV-E21"}
+      - {file: "internal/eventbus/history/dispatcher.go", token: "INV-E21"}
+      - {file: "internal/eventbus/history/dispatcher_errors_test.go", token: "INV-E21"}
+      - {file: "internal/eventbus/history/dispatcher_test.go", token: "INV-E21"}
+      - {file: "internal/eventbus/types.go", token: "INV-E21"}
+  - id: INV-CRYPTO-109
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E22@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Phase 5 MUST invoke invalidation.Coordinator.RequestInvalidation with Action: ActionRekey — no bespoke invalidation
+      surface."
+    binding: pending
+    refs:
+      - {file: "test/integration/crypto/rekey_phase5_timeout_test.go", token: "INV-E22-INVALIDATION-REUSE"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5.go", token: "INV-E22"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase5_integration_test.go", token: "INV-E22"}
+      - {file: "test/integration/crypto/rekey_phase5_timeout_test.go", token: "INV-E22"}
+  - id: INV-CRYPTO-110
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E23@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Rekey CLI exit codes MUST follow the sysexits.h mappings."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/cmd_crypto_rekey.go", token: "INV-E23"}
+      - {file: "cmd/holomush/cmd_crypto_rekey_errors_test.go", token: "INV-E23"}
+      - {file: "cmd/holomush/cmd_crypto_rekey_test.go", token: "INV-E23"}
+  - id: INV-CRYPTO-111
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E24@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "op_args_hash MUST be computed via the same proto.MarshalOptions{Deterministic: true} helper sub-epic-d ships,
+      against the resolved RekeyRequest proto, and MUST be stable across builds with protobuf-go pinned per INV-CRYPTO-85."
+    binding: pending
+    refs:
+      - {file: "internal/eventbus/crypto/dek/rekey.go", token: "INV-E24"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E24"}
+      - {file: "test/integration/crypto/rekey_resume_test.go", token: "INV-E24"}
+  - id: INV-CRYPTO-112
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E25@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "A rekey event's policy_hash MUST be captured at Phase-1 INSERT into crypto_rekey_checkpoints.policy_hash; Phase-7
+      emit reads this column verbatim and never re-queries the chain head; a policy_set event mid-rekey MUST NOT change the
+      persisted hash."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/core.go", token: "INV-E25"}
+      - {file: "cmd/holomush/gateway_imports_test.go", token: "INV-E25"}
+      - {file: "cmd/holomush/policy_hash_source.go", token: "INV-E25"}
+      - {file: "cmd/holomush/readstream_wiring.go", token: "INV-E25"}
+      - {file: "internal/eventbus/crypto/dek/checkpoint.go", token: "INV-E25"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator.go", token: "INV-E25"}
+      - {file: "internal/eventbus/crypto/dek/rekey_orchestrator_test.go", token: "INV-E25"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E25"}
+      - {file: "internal/eventbus/crypto/dek/rekey_run_integration_test.go", token: "INV-E25"}
+      - {file: "test/integration/crypto/harness_impl_test.go", token: "INV-E25"}
+      - {file: "test/integration/crypto/rekey_policy_hash_frozen_at_phase1_test.go", token: "INV-E25"}
+  - id: INV-CRYPTO-113
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E26@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Every registered auditchain.Chain's SubjectFor(scope) MUST return a string starting with events.<game>. so chain-bearing
+      audit events reach events_audit via the EVENTS JetStream events.> SubjectFilter."
+    binding: pending
+    refs:
+      - {file: "cmd/holomush/phase7_fence_wiring.go", token: "INV-E26"}
+      - {file: "internal/admin/policy/chain.go", token: "INV-E26"}
+      - {file: "internal/admin/readstream/chain.go", token: "INV-E26"}
+      - {file: "internal/admin/readstream/chain_test.go", token: "INV-E26"}
+      - {file: "internal/core/builtins.go", token: "INV-E26"}
+      - {file: "internal/eventbus/audit/chain/chain.go", token: "INV-E26"}
+      - {file: "internal/eventbus/audit/chain/chain_test.go", token: "INV-E26"}
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem.go", token: "INV-E26"}
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem_test.go", token: "INV-E26"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain.go", token: "INV-E26"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain_internal_test.go", token: "INV-E26"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain_test.go", token: "INV-E26"}
+      - {file: "internal/eventbus/crypto/dek/audit_test.go", token: "INV-E26"}
+  - id: INV-CRYPTO-114
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E27@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "Every registered auditchain.Chain MUST populate ScopeFromPayload; the verifier MUST reject with AUDIT_CHAIN_SCOPE_MISMATCH
+      any row where ScopeFromSubject(subject) != ScopeFromPayload(payload)."
+    binding: pending
+    refs:
+      - {file: "internal/admin/policy/chain.go", token: "INV-E27"}
+      - {file: "internal/admin/policy/verifier.go", token: "INV-E27"}
+      - {file: "internal/admin/policy/verifier_integration_test.go", token: "INV-E27"}
+      - {file: "internal/admin/policy/verifier_test.go", token: "INV-E27"}
+      - {file: "internal/admin/readstream/chain.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/chain.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/chain_test.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/verifier.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/verifier_errors_test.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/verifier_subsystem.go", token: "INV-E27"}
+      - {file: "internal/eventbus/audit/chain/verifier_test.go", token: "INV-E27"}
+      - {file: "internal/eventbus/crypto/dek/audit.go", token: "INV-E27"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain.go", token: "INV-E27"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain_test.go", token: "INV-E27"}
+      - {file: "internal/eventbus/crypto/dek/audit_test.go", token: "INV-E27"}
+  - id: INV-CRYPTO-115
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"
+    legacy: ["INV-E28@docs/superpowers/specs/2026-05-10-event-payload-crypto-phase5-sub-epic-e-design.md"]
+    summary: "The auditchain.Verifier self-hash recompute MUST be SHA-256(Canonicalize(zero(payload, SelfHashFieldName)));
+      SHA-256 and composition order are pinned at the primitive level, while per-chain Canonicalize MAY apply domain normalization
+      (e.g. PolicySetChain renormalizes empty PrevHash → nil to preserve INV-CRYPTO-77 semantics)."
+    binding: pending
+    refs:
+      - {file: "internal/admin/policy/chain.go", token: "INV-E28"}
+      - {file: "internal/admin/readstream/chain.go", token: "INV-E28"}
+      - {file: "internal/eventbus/audit/chain/chain.go", token: "INV-E28"}
+      - {file: "internal/eventbus/audit/chain/chain_test.go", token: "INV-E28"}
+      - {file: "internal/eventbus/audit/chain/verifier.go", token: "INV-E28"}
+      - {file: "internal/eventbus/crypto/dek/audit.go", token: "INV-E28"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain.go", token: "INV-E28"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain_internal_test.go", token: "INV-E28"}
+      - {file: "internal/eventbus/crypto/dek/audit_chain_test.go", token: "INV-E28"}
+      - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E28"}

--- a/internal/admin/policy/chain.go
+++ b/internal/admin/policy/chain.go
@@ -86,9 +86,9 @@ const PolicySetChainName = "crypto.policy_set"
 // the chain's existing event-type name; the stutter against the package
 // name is unavoidable without renaming the chain.
 //
-// INV-E26: SubjectPrefix starts with "events.".
-// INV-E27: ScopePayloadField is "policy_name" (non-empty).
-// INV-E28: SelfHashField is "policy_hash"; PrevHashField is "prev_hash".
+// INV-CRYPTO-113: SubjectPrefix starts with "events.".
+// INV-CRYPTO-114: ScopePayloadField is "policy_name" (non-empty).
+// INV-CRYPTO-115: SelfHashField is "policy_hash"; PrevHashField is "prev_hash".
 //
 //nolint:revive // name is canonical per master crypto spec §6 and matches the chain's event type
 func PolicySetChainFor(gameID string) chain.Chain {
@@ -196,7 +196,7 @@ func canonicalizePolicySetPayload(envOrJSON []byte) ([]byte, error) {
 }
 
 // policyScopeFromPayload extracts policy_name from the envelope (or raw JSON
-// for test fakes). Satisfies INV-E27 (independent payload-derived scope).
+// for test fakes). Satisfies INV-CRYPTO-114 (independent payload-derived scope).
 func policyScopeFromPayload(envOrJSON []byte) (string, error) {
 	payload, err := decodePolicyPayloadJSON(envOrJSON)
 	if err != nil {

--- a/internal/admin/policy/verifier.go
+++ b/internal/admin/policy/verifier.go
@@ -45,7 +45,7 @@ import (
 // the policyName parameter is used to construct the chain handler's
 // gameID-parameterized prefix. When subject and policyName disagree at
 // the suffix level, the test fixtures' "loose" subject is honored — the
-// chain handler's INV-E27 ScopeFromPayload cross-check still rejects
+// chain handler's INV-CRYPTO-114 ScopeFromPayload cross-check still rejects
 // payload-level mismatches.
 func VerifyChain(ctx context.Context, pool *pgxpool.Pool, subject, policyName string) error {
 	gameID, scope, err := parsePolicySubject(subject)

--- a/internal/admin/policy/verifier_integration_test.go
+++ b/internal/admin/policy/verifier_integration_test.go
@@ -168,7 +168,7 @@ var _ = Describe("VerifyChain (integration)", func() {
 	Context("with a clean 3-row chain in events_audit", func() {
 		It("verifies cleanly, then surfaces a chain integrity error after envelope tamper", func() {
 			// Subject suffix MUST agree with payload.policy_name post Phase 5
-			// sub-epic E (INV-E27 — chain.Verifier enforces). D's pre-E verifier
+			// sub-epic E (INV-CRYPTO-114 — chain.Verifier enforces). D's pre-E verifier
 			// queried by subject directly and only cross-checked at the typed
 			// struct level, tolerating fixture mismatches like the prior
 			// "crypto_operators_int" subject paired with "crypto.operators"

--- a/internal/admin/policy/verifier_test.go
+++ b/internal/admin/policy/verifier_test.go
@@ -27,7 +27,7 @@ import (
 //
 // The cross-check semantics formerly enforced by POLICY_CHAIN_NAME_MISMATCH
 // now surface as AUDIT_CHAIN_SCOPE_MISMATCH via the chain handler's
-// ScopeFromPayload extractor (INV-E27).
+// ScopeFromPayload extractor (INV-CRYPTO-114).
 
 const testGameID = "testgame"
 
@@ -236,7 +236,7 @@ func TestVerifyChainEntriesAcceptsMultiplePolicyNames(t *testing.T) {
 
 // TestVerifyChainEntriesRejectsPolicyNameMismatchAtGenesis verifies the
 // cross-check between Payload.PolicyName and the expected policy_name arg
-// (now via Handler.ScopeFromPayload — INV-E27). Post-E refactor surfaces
+// (now via Handler.ScopeFromPayload — INV-CRYPTO-114). Post-E refactor surfaces
 // as AUDIT_CHAIN_SCOPE_MISMATCH (was POLICY_CHAIN_NAME_MISMATCH).
 func TestVerifyChainEntriesRejectsPolicyNameMismatchAtGenesis(t *testing.T) {
 	repo := newFakeRepo()

--- a/internal/admin/readstream/chain.go
+++ b/internal/admin/readstream/chain.go
@@ -22,9 +22,9 @@ import (
 // LoadEntriesByScope returns both rows ordered by js_seq ASC, giving the
 // completed event its predecessor naturally.
 //
-// INV-E26: SubjectPrefix starts with "events.".
-// INV-E27: ScopePayloadField is "request_id" (non-empty).
-// INV-E28: SelfHashField is "self_hash"; PrevHashField is "prev_hash".
+// INV-CRYPTO-113: SubjectPrefix starts with "events.".
+// INV-CRYPTO-114: ScopePayloadField is "request_id" (non-empty).
+// INV-CRYPTO-115: SelfHashField is "self_hash"; PrevHashField is "prev_hash".
 // INV-CRYPTO-59: Both events share the same NATS subject pattern.
 func OperatorReadChainFor(gameID string) chain.Chain {
 	return chain.Chain{
@@ -126,7 +126,7 @@ func canonicalizeOperatorReadPayload(envOrJSON []byte) ([]byte, error) {
 }
 
 // operatorReadScopeFromPayload extracts request_id from the envelope (or raw
-// JSON for test fakes). Satisfies INV-E27 (independent payload-derived scope).
+// JSON for test fakes). Satisfies INV-CRYPTO-114 (independent payload-derived scope).
 func operatorReadScopeFromPayload(envOrJSON []byte) (string, error) {
 	payload, err := decodeOperatorReadPayloadJSON(envOrJSON)
 	if err != nil {

--- a/internal/admin/readstream/chain_test.go
+++ b/internal/admin/readstream/chain_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func TestOperatorReadChainFor_SubjectPrefixSatisfiesINVE26(t *testing.T) {
-	// INV-E26: SubjectPrefix MUST start with "events.".
+	// INV-CRYPTO-113: SubjectPrefix MUST start with "events.".
 	c := readstream.OperatorReadChainFor("g1")
 	err := chain.ValidateRegistration(c)
-	require.NoError(t, err, "OperatorReadChainFor must satisfy chain.ValidateRegistration (INV-E26/E27/E28)")
+	require.NoError(t, err, "OperatorReadChainFor must satisfy chain.ValidateRegistration (INV-CRYPTO-113/INV-CRYPTO-114/INV-CRYPTO-115)")
 }
 
 func TestOperatorReadHandlerFor_AllSevenFieldsPopulated(t *testing.T) {

--- a/internal/admin/socket/rekey_handler.go
+++ b/internal/admin/socket/rekey_handler.go
@@ -162,7 +162,7 @@ type RekeyAbortOutcome struct {
 // and dek.RekeyAuditEmitter behind this interface to avoid importing dek
 // (which would create an import cycle via approval → adminauth → socket).
 //
-// INV-E17: the runner MUST accept single-control regardless of site policy.
+// INV-CRYPTO-104: the runner MUST accept single-control regardless of site policy.
 type RekeyAbortRunner interface {
 	RunAbort(ctx context.Context, req RekeyAbortRequest) (RekeyAbortOutcome, error)
 }
@@ -242,7 +242,7 @@ func (h *RekeyHandler) Rekey(
 // session, re-asserts capability + role, and resumes an in-flight rekey by
 // delegating to OrchestratorRunner.Run with the RequestID from the proto.
 //
-// INV-E16 idempotency and INV-E4 same-args resume are enforced inside
+// INV-CRYPTO-103 idempotency and INV-CRYPTO-91 same-args resume are enforced inside
 // Orchestrator.Run — the handler does not need to re-check them.
 func (h *RekeyHandler) RekeyResume(
 	ctx context.Context,
@@ -286,7 +286,7 @@ func (h *RekeyHandler) RekeyResume(
 		ForceDestroy: req.GetForceDestroy(),
 		// ContextType/ContextID/Justification are intentionally zero here.
 		// The OrchestratorRunner adapter looks them up from the checkpoint row
-		// keyed by RequestID before calling dek.Orchestrator.Run (INV-E4/E16).
+		// keyed by RequestID before calling dek.Orchestrator.Run (INV-CRYPTO-91/INV-CRYPTO-103).
 	}
 	return h.runWithProgress(ctx, orchReq, stream)
 }
@@ -294,7 +294,7 @@ func (h *RekeyHandler) RekeyResume(
 // RekeyAbort is the AdminService.RekeyAbort RPC entry point. Validates the
 // session and crypto.operator capability, then delegates to RekeyAbortRunner.
 //
-// INV-E17-ABORT-NO-DUAL-CONTROL: abort is single-control regardless of site
+// INV-CRYPTO-104: abort is single-control regardless of site
 // dual_control_required policy. Any crypto.operator session may abort any
 // non-terminal checkpoint — not just the original primary operator.
 func (h *RekeyHandler) RekeyAbort(
@@ -305,7 +305,7 @@ func (h *RekeyHandler) RekeyAbort(
 	if err != nil {
 		return nil, oops.Wrap(err)
 	}
-	// INV-E17: only the crypto.operator capability is required — no admin role
+	// INV-CRYPTO-104: only the crypto.operator capability is required — no admin role
 	// re-check, no dual-control approval. Abort is a non-destructive control
 	// operation; the destructive phase (DEK destroy) is part of rekey itself.
 	hasCap, err := access.HasPlayerGrant(ctx, h.grants, identity.PlayerID, access.CapabilityCryptoOperator)

--- a/internal/admin/socket/rekey_handler_test.go
+++ b/internal/admin/socket/rekey_handler_test.go
@@ -301,7 +301,7 @@ func TestRekeyResumeHandler_RequestID_PassThrough(t *testing.T) {
 
 // TestRekeyResumeHandler_ForceDestroy_PassThrough verifies that
 // ForceDestroy=true from the proto request is forwarded to OrchestratorRunner.Run
-// (INV-E11 force-destroy escape hatch pass-through).
+// (INV-CRYPTO-98 force-destroy escape hatch pass-through).
 func TestRekeyResumeHandler_ForceDestroy_PassThrough(t *testing.T) {
 	capturer := &capturingOrchRunner{}
 	h := newHandlerWithOperator(t, capturer)
@@ -317,7 +317,7 @@ func TestRekeyResumeHandler_ForceDestroy_PassThrough(t *testing.T) {
 		ForceDestroy: true,
 	}, stream)
 	require.True(t, capturer.lastReq.ForceDestroy,
-		"ForceDestroy=true must be forwarded to OrchestratorRunner.Run (INV-E11)")
+		"ForceDestroy=true must be forwarded to OrchestratorRunner.Run (INV-CRYPTO-98)")
 }
 
 // TestRekeyResumeHandler_Streams_Completed verifies the happy path for
@@ -402,7 +402,7 @@ func newAbortHandlerWithOperator(t *testing.T, abort socket.RekeyAbortRunner) *s
 	return socket.NewRekeyHandler(sessions, grants, roles, orch, abort, nil)
 }
 
-// TestRekeyHandler_Abort_SingleControl_Allowed verifies INV-E17: a session with
+// TestRekeyHandler_Abort_SingleControl_Allowed verifies INV-CRYPTO-104: a session with
 // only crypto.operator capability (no dual-control approval) can abort an
 // in-flight checkpoint even when site policy mandates dual-control for rekey.
 func TestRekeyHandler_Abort_SingleControl_Allowed(t *testing.T) {
@@ -427,7 +427,7 @@ func TestRekeyHandler_Abort_SingleControl_Allowed(t *testing.T) {
 		SessionToken: rekeyTestToken,
 		RequestId:    rid[:],
 	})
-	require.NoError(t, err, "INV-E17: Abort accepts single-control even when site mandates dual for rekey")
+	require.NoError(t, err, "INV-CRYPTO-104: Abort accepts single-control even when site mandates dual for rekey")
 	require.NotNil(t, res)
 	require.NotNil(t, res.AbortedAt, "AbortedAt must be populated")
 	require.Equal(t, eventID[:], res.AuditEventId, "AuditEventId must be the runner's returned event ID")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,12 +83,12 @@ type CryptoConfig struct {
 
 	// RekeyCheckpointTTL is the maximum age of a non-terminal rekey
 	// checkpoint's last_heartbeat_at before the sweep subsystem auto-aborts
-	// it (INV-E18 / spec §6.2). Defaults to 24h via Defaults() when
+	// it (INV-CRYPTO-105 / spec §6.2). Defaults to 24h via Defaults() when
 	// unset/zero. Sub-epic E T37 (holomush-jxo8.7.34).
 	RekeyCheckpointTTL time.Duration `koanf:"rekey_checkpoint_ttl"`
 
 	// RekeyCheckpointSweepInterval is the interval between background sweep
-	// scans (INV-E19 / spec §6.2). Defaults to 1h via Defaults() when
+	// scans (INV-CRYPTO-106 / spec §6.2). Defaults to 1h via Defaults() when
 	// unset/zero. Sub-epic E T37 (holomush-jxo8.7.34).
 	RekeyCheckpointSweepInterval time.Duration `koanf:"rekey_checkpoint_sweep_interval"`
 
@@ -115,11 +115,11 @@ type CryptoConfig struct {
 }
 
 // DefaultRekeyCheckpointTTL is the default age cutoff for non-terminal rekey
-// checkpoints (spec §6.2 INV-E18). 24h matches the master spec default.
+// checkpoints (spec §6.2 INV-CRYPTO-105). 24h matches the master spec default.
 const DefaultRekeyCheckpointTTL = 24 * time.Hour
 
 // DefaultRekeyCheckpointSweepInterval is the default scan cadence for the
-// rekey-checkpoint sweep subsystem (spec §6.2 INV-E19). 1h is the
+// rekey-checkpoint sweep subsystem (spec §6.2 INV-CRYPTO-106). 1h is the
 // master-spec default.
 const DefaultRekeyCheckpointSweepInterval = 1 * time.Hour
 

--- a/internal/core/builtins.go
+++ b/internal/core/builtins.go
@@ -89,7 +89,7 @@ func registerBuiltinTypes(r *VerbRegistry, hostVersion string) error {
 		// Rekey orchestrator via rekeyAuditPublisherAdapter → RenderingPublisher.
 		// AUDIT_ONLY: gRPC Subscribe handler drops it before delivery; the audit
 		// projection persists it to events_audit. Registered here so
-		// RenderingPublisher does not reject it with EMIT_UNKNOWN_VERB (INV-E14).
+		// RenderingPublisher does not reject it with EMIT_UNKNOWN_VERB (INV-CRYPTO-101).
 		{Type: "crypto.system.rekey", Category: "system", Format: "audit", DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_AUDIT_ONLY, Source: "builtin"},
 		// Operator-read audit events (host-emit, persistence-only). Emitted by
 		// F's AdminReadStream handler at stream-start and stream-end respectively.
@@ -103,7 +103,7 @@ func registerBuiltinTypes(r *VerbRegistry, hostVersion string) error {
 		// INV-CRYPTO-42 row refusal, via RenderingPublisher. AUDIT_ONLY so the gRPC
 		// Subscribe handler drops the event before delivery; audit projection
 		// persists it to events_audit on subject events.<game>.system.plugin_integrity_violation
-		// (events.> prefix per INV-E26 — only events.> reaches the EVENTS stream filter).
+		// (events.> prefix per INV-CRYPTO-113 — only events.> reaches the EVENTS stream filter).
 		// Registered here so RenderingPublisher does not reject with
 		// EMIT_UNKNOWN_VERB — without this entry the documented operator-facing
 		// integrity-violation signal silently fails on every refusal.

--- a/internal/eventbus/audit/chain/chain.go
+++ b/internal/eventbus/audit/chain/chain.go
@@ -10,7 +10,7 @@
 // identifier. [ValidateRegistration] enforces the structural invariants before
 // a chain is wired into a subsystem.
 //
-// Hash algorithm (INV-E28):
+// Hash algorithm (INV-CRYPTO-115):
 //
 //	self_hash = SHA-256(JCS_canonicalize(zero(payload, SelfHashFieldName)))
 //
@@ -37,13 +37,13 @@ import (
 // fields (e.g. "meta.self_hash" addresses payload["meta"]["self_hash"]).
 type Chain struct {
 	// SubjectPrefix is the NATS subject prefix for this chain family.
-	// MUST start with "events." (INV-E26).
+	// MUST start with "events." (INV-CRYPTO-113).
 	// Example: "events.game.system.rekey"
 	SubjectPrefix string
 
 	// SelfHashField is the dot-path name of the payload field that holds
 	// this event's own hash. This field is zeroed before canonicalization
-	// to prevent the hash from being its own input (INV-E28).
+	// to prevent the hash from being its own input (INV-CRYPTO-115).
 	SelfHashField string
 
 	// PrevHashField is the dot-path name of the payload field that holds
@@ -52,26 +52,26 @@ type Chain struct {
 
 	// ScopePayloadField is the dot-path name of the payload field that
 	// identifies the chain's scope (e.g. policy name, context ID).
-	// MUST be non-empty (INV-E27).
+	// MUST be non-empty (INV-CRYPTO-114).
 	ScopePayloadField string
 }
 
 // ValidateRegistration returns an error if c does not satisfy the structural
 // invariants required of every chain registration.
 //
-// INV-E26: SubjectPrefix MUST start with "events.".
-// INV-E27: ScopePayloadField MUST be non-empty.
+// INV-CRYPTO-113: SubjectPrefix MUST start with "events.".
+// INV-CRYPTO-114: ScopePayloadField MUST be non-empty.
 // Additionally: SelfHashField and PrevHashField MUST be non-empty.
 func ValidateRegistration(c Chain) error {
 	if !strings.HasPrefix(c.SubjectPrefix, "events.") {
 		return fmt.Errorf(
-			"auditchain: SubjectPrefix %q must start with \"events.\" (INV-E26)",
+			"auditchain: SubjectPrefix %q must start with \"events.\" (INV-CRYPTO-113)",
 			c.SubjectPrefix,
 		)
 	}
 	if c.ScopePayloadField == "" {
 		return fmt.Errorf(
-			"auditchain: ScopePayloadField must not be empty for chain %q (INV-E27)",
+			"auditchain: ScopePayloadField must not be empty for chain %q (INV-CRYPTO-114)",
 			c.SubjectPrefix,
 		)
 	}
@@ -131,7 +131,7 @@ func ZeroField(payload map[string]any, fieldPath string) map[string]any {
 }
 
 // RecomputeSelfHash computes SHA-256 over the RFC 8785 JCS-canonicalized JSON
-// of payload with selfHashField zeroed out. This implements INV-E28:
+// of payload with selfHashField zeroed out. This implements INV-CRYPTO-115:
 //
 //	self_hash = SHA-256(JCS_canonicalize(zero(payload, SelfHashFieldName)))
 //

--- a/internal/eventbus/audit/chain/chain_test.go
+++ b/internal/eventbus/audit/chain/chain_test.go
@@ -66,7 +66,7 @@ func TestZeroField_MissingField_NoOp(t *testing.T) {
 // TestRecomputeSelfHash_DeterministicOverPayloadOrder verifies that two
 // logically-equivalent payloads (same keys and values, different insertion
 // order) produce the same SHA-256 hash — proving JCS key-sort is applied.
-// INV-E28: hash = SHA-256(JCS(zero(payload, SelfHashFieldName))).
+// INV-CRYPTO-115: hash = SHA-256(JCS(zero(payload, SelfHashFieldName))).
 func TestRecomputeSelfHash_DeterministicOverPayloadOrder(t *testing.T) {
 	// Build two maps with identical contents but different key insertion order.
 	p1 := map[string]any{
@@ -105,7 +105,7 @@ func TestRecomputeSelfHash_DeterministicOverPayloadOrder(t *testing.T) {
 // ValidateRegistration tests
 // ---------------------------------------------------------------------------
 
-// TestValidateRegistration_RejectsNonEventsPrefix verifies INV-E26: a Chain
+// TestValidateRegistration_RejectsNonEventsPrefix verifies INV-CRYPTO-113: a Chain
 // whose SubjectPrefix does not start with "events." is rejected.
 func TestValidateRegistration_RejectsNonEventsPrefix(t *testing.T) {
 	bad := chain.Chain{
@@ -115,11 +115,11 @@ func TestValidateRegistration_RejectsNonEventsPrefix(t *testing.T) {
 		ScopePayloadField: "scope",
 	}
 	err := chain.ValidateRegistration(bad)
-	require.Error(t, err, "INV-E26: non-events. prefix must be rejected")
+	require.Error(t, err, "INV-CRYPTO-113: non-events. prefix must be rejected")
 	assert.Contains(t, err.Error(), "events.")
 }
 
-// TestValidateRegistration_RejectsMissingScopeFromPayload verifies INV-E27:
+// TestValidateRegistration_RejectsMissingScopeFromPayload verifies INV-CRYPTO-114:
 // a Chain with an empty ScopePayloadField is rejected.
 func TestValidateRegistration_RejectsMissingScopeFromPayload(t *testing.T) {
 	bad := chain.Chain{
@@ -129,7 +129,7 @@ func TestValidateRegistration_RejectsMissingScopeFromPayload(t *testing.T) {
 		ScopePayloadField: "", // missing
 	}
 	err := chain.ValidateRegistration(bad)
-	require.Error(t, err, "INV-E27: empty ScopePayloadField must be rejected")
+	require.Error(t, err, "INV-CRYPTO-114: empty ScopePayloadField must be rejected")
 }
 
 // TestValidateRegistration_AcceptsValidChain verifies that a well-formed Chain

--- a/internal/eventbus/audit/chain/verifier.go
+++ b/internal/eventbus/audit/chain/verifier.go
@@ -29,11 +29,11 @@ type Handler struct {
 	SubjectFor func(scope string) string
 
 	// ScopeFromSubject is the inverse of SubjectFor. Parses the domain scope
-	// from a full NATS subject. Used for INV-E27 cross-check.
+	// from a full NATS subject. Used for INV-CRYPTO-114 cross-check.
 	ScopeFromSubject func(subject string) (string, error)
 
 	// ScopeFromPayload extracts the domain scope from raw payload bytes.
-	// This is an independent extraction path for the INV-E27 cross-check —
+	// This is an independent extraction path for the INV-CRYPTO-114 cross-check —
 	// the verifier asserts ScopeFromSubject(entry.Subject) == ScopeFromPayload(entry.Payload).
 	ScopeFromPayload func(payload []byte) (string, error)
 
@@ -54,8 +54,8 @@ type Handler struct {
 // Verifier walks one chain scope or all scopes of a chain, validating the
 // tamper-evident hash chain invariants.
 //
-// INV-E27: for each entry, ScopeFromSubject(subject) MUST equal ScopeFromPayload(payload).
-// INV-E28: for each entry, the stored self_hash MUST equal
+// INV-CRYPTO-114: for each entry, ScopeFromSubject(subject) MUST equal ScopeFromPayload(payload).
+// INV-CRYPTO-115: for each entry, the stored self_hash MUST equal
 //
 //	SHA-256(JCS(zero(canonicalized_payload, SelfHashField))).
 //
@@ -100,7 +100,7 @@ func (v *verifier) VerifyAll(ctx context.Context, h Handler) error {
 		// chain's ScopeFromSubject. For chains that use a different separator
 		// in the scope (e.g. colon) vs the subject (dot), this converts
 		// "scene.01ABC" → "scene:01ABC" so ScopeFromPayload's return value
-		// agrees with the scope passed to VerifyScope (INV-E27 cross-check).
+		// agrees with the scope passed to VerifyScope (INV-CRYPTO-114 cross-check).
 		canonicalScope, scopeErr := h.ScopeFromSubject(h.Chain.SubjectPrefix + "." + suffix)
 		if scopeErr != nil {
 			return oops.Code("AUDIT_CHAIN_SCOPE_CONVERT_FAILED").
@@ -159,7 +159,7 @@ func (v *verifier) VerifyScope(ctx context.Context, h Handler, scope string) err
 		return nil
 	}
 
-	// Pass the canonical scope to verifyEntries for the INV-E27 cross-check:
+	// Pass the canonical scope to verifyEntries for the INV-CRYPTO-114 cross-check:
 	// ScopeFromPayload(entry.Payload) must equal scope.
 	return v.verifyEntries(ctx, h, scope, entries)
 }
@@ -167,7 +167,7 @@ func (v *verifier) VerifyScope(ctx context.Context, h Handler, scope string) err
 // verifyEntries performs the actual chain-walk integrity checks on a non-empty
 // slice of entries (ordered by js_seq ASC).
 func (v *verifier) verifyEntries(_ context.Context, h Handler, scope string, entries []Entry) error {
-	// INV-E27: for every entry, ScopeFromPayload MUST agree with the query scope.
+	// INV-CRYPTO-114: for every entry, ScopeFromPayload MUST agree with the query scope.
 	// (The query scope is derived from ScopeFromSubject on the stored subject, but
 	// we check against the caller-supplied scope for simplicity — the Repo query
 	// is authoritative for which rows are returned for a given scope.)
@@ -184,7 +184,7 @@ func (v *verifier) verifyEntries(_ context.Context, h Handler, scope string, ent
 				With("subject_scope", scope).
 				With("payload_scope", payloadScope).
 				With("js_seq", e.JSSeq).
-				Errorf("INV-E27: subject and payload scope disagree")
+				Errorf("INV-CRYPTO-114: subject and payload scope disagree")
 		}
 	}
 
@@ -203,7 +203,7 @@ func (v *verifier) verifyEntries(_ context.Context, h Handler, scope string, ent
 			Errorf("genesis prev_hash must be nil")
 	}
 
-	// INV-E28: genesis self_hash MUST equal recomputed hash.
+	// INV-CRYPTO-115: genesis self_hash MUST equal recomputed hash.
 	genHash, err := v.recomputeFor(h, entries[0].Payload)
 	if err != nil {
 		return err
@@ -223,7 +223,7 @@ func (v *verifier) verifyEntries(_ context.Context, h Handler, scope string, ent
 	}
 
 	// Walk remaining entries: INV-CRYPTO-78 (prev_hash == predecessor recompute)
-	// and INV-CRYPTO-79 / INV-E28 (stored self_hash == own recompute).
+	// and INV-CRYPTO-79 / INV-CRYPTO-115 (stored self_hash == own recompute).
 	for i := 1; i < len(entries); i++ {
 		// Predecessor's recomputed hash is what this entry's prev_hash must equal.
 		prevRecompute, err := v.recomputeFor(h, entries[i-1].Payload)
@@ -267,7 +267,7 @@ func (v *verifier) verifyEntries(_ context.Context, h Handler, scope string, ent
 
 // recomputeFor runs h.Canonicalize on payload, unmarshals the canonical bytes
 // into map[string]any, then calls chain.RecomputeSelfHash.
-// This is the INV-E28 recompute path: caller applies chain-specific
+// This is the INV-CRYPTO-115 recompute path: caller applies chain-specific
 // normalization (via h.Canonicalize) before RecomputeSelfHash zeroes
 // and hashes.
 func (v *verifier) recomputeFor(h Handler, payload []byte) ([]byte, error) {

--- a/internal/eventbus/audit/chain/verifier_errors_test.go
+++ b/internal/eventbus/audit/chain/verifier_errors_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestVerifyEntries_ScopeMismatch confirms that when ScopeFromPayload returns a
 // value different from the query scope, the verifier rejects with
-// AUDIT_CHAIN_SCOPE_MISMATCH (INV-E27). This is a focused error-path test
+// AUDIT_CHAIN_SCOPE_MISMATCH (INV-CRYPTO-114). This is a focused error-path test
 // constructed via a custom handler so that the hash machinery does not need
 // to be valid.
 func TestVerifyEntries_ScopeMismatch(t *testing.T) {

--- a/internal/eventbus/audit/chain/verifier_subsystem.go
+++ b/internal/eventbus/audit/chain/verifier_subsystem.go
@@ -34,7 +34,7 @@ type VerifierSubsystemConfig struct {
 
 // VerifierSubsystem is a [lifecycle.Subsystem] that verifies every registered
 // audit chain at server boot. Start validates the registration shape of each
-// Handler's Chain metadata (INV-E26, INV-E27) and then calls
+// Handler's Chain metadata (INV-CRYPTO-113, INV-CRYPTO-114) and then calls
 // [Verifier.VerifyAll] for each registered chain. Any integrity failure is
 // fatal — the server refuses to start.
 //
@@ -71,7 +71,7 @@ func (s *VerifierSubsystem) DependsOn() []lifecycle.SubsystemID {
 // Start validates each registered Handler's Chain metadata and then walks
 // every chain via [Verifier.VerifyAll]. Returns on the first failure.
 //
-// INV-E15-CHAIN-VERIFIER-BOOT: server boot MUST refuse with
+// INV-CRYPTO-102: server boot MUST refuse with
 // AUDIT_CHAIN_BROKEN (or a more specific AUDIT_CHAIN_* code) when any
 // registered chain has a break.
 func (s *VerifierSubsystem) Start(ctx context.Context) error {

--- a/internal/eventbus/audit/chain/verifier_subsystem_test.go
+++ b/internal/eventbus/audit/chain/verifier_subsystem_test.go
@@ -121,7 +121,7 @@ func TestVerifierSubsystem_WalksAllRegisteredChains(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestVerifierSubsystem_RefusesBootOnBreak (INV-E15): a tampered self_hash
+// TestVerifierSubsystem_RefusesBootOnBreak (INV-CRYPTO-102): a tampered self_hash
 // in the repo causes Start to return AUDIT_CHAIN_HASH_MISMATCH.
 // ---------------------------------------------------------------------------
 
@@ -158,7 +158,7 @@ func TestVerifierSubsystem_RefusesBootOnBreak(t *testing.T) {
 func TestVerifierSubsystem_RejectsInvalidChainRegistration(t *testing.T) {
 	bad := chain.Handler{
 		Chain: chain.Chain{
-			SubjectPrefix:     "audit.bad.chain", // violates INV-E26
+			SubjectPrefix:     "audit.bad.chain", // violates INV-CRYPTO-113
 			SelfHashField:     "self_hash",
 			PrevHashField:     "prev_hash",
 			ScopePayloadField: "scope",

--- a/internal/eventbus/audit/chain/verifier_test.go
+++ b/internal/eventbus/audit/chain/verifier_test.go
@@ -291,7 +291,7 @@ func TestVerifier_SelfHashTamperDetected(t *testing.T) {
 
 // TestVerifier_ScopeMismatchBetweenSubjectAndPayload_RejectsRow: an entry
 // whose subject says scopeA but payload.scope says scopeB must be rejected
-// with AUDIT_CHAIN_SCOPE_MISMATCH (INV-E27).
+// with AUDIT_CHAIN_SCOPE_MISMATCH (INV-CRYPTO-114).
 func TestVerifier_ScopeMismatchBetweenSubjectAndPayload_RejectsRow(t *testing.T) {
 	h := makeTestHandler(t)
 
@@ -299,7 +299,7 @@ func TestVerifier_ScopeMismatchBetweenSubjectAndPayload_RejectsRow(t *testing.T)
 	// The scope check runs before the hash check, so hash correctness doesn't matter.
 	e := buildValidEntry(t, h, "scopeB", nil, 1)
 	// Overwrite the subject to say scopeA so the Repo returns it for the scopeA query,
-	// while the payload still says scopeB — triggering INV-E27.
+	// while the payload still says scopeB — triggering INV-CRYPTO-114.
 	e.Subject = "events.g1.system.example.scopeA"
 
 	repo := &fakeRepo{

--- a/internal/eventbus/crypto/dek/audit.go
+++ b/internal/eventbus/crypto/dek/audit.go
@@ -59,11 +59,11 @@ func NewRekeyAuditEmitter(ce chain.Emitter, pub AuditPublisher) *RekeyAuditEmitt
 // Returns the published eventID, the finalized payload (with scope,
 // prev_hash, self_hash filled in), and any error. The caller MUST persist
 // the finalized payload to the audit-fallback log on error so the recorded
-// chain-link fields match what would have been published (INV-E13).
+// chain-link fields match what would have been published (INV-CRYPTO-100).
 //
-// INV-E14: prev_hash is the recomputed self-hash of the tail entry, or nil
+// INV-CRYPTO-101: prev_hash is the recomputed self-hash of the tail entry, or nil
 // for genesis (empty chain for this scope).
-// INV-E28: self_hash is SHA-256(JCS(zero(payload, "rekey_chain.self_hash"))).
+// INV-CRYPTO-115: self_hash is SHA-256(JCS(zero(payload, "rekey_chain.self_hash"))).
 func (e *RekeyAuditEmitter) Emit(ctx context.Context, payload RekeyAuditPayload) (ulid.ULID, RekeyAuditPayload, error) {
 	h := RekeyHandlerFor(currentGameIDForRekey)
 	scope := payload.Context.Type + ":" + payload.Context.ID
@@ -80,7 +80,7 @@ func (e *RekeyAuditEmitter) Emit(ctx context.Context, payload RekeyAuditPayload)
 	payload.RekeyChainField.SelfHash = "" // zeroed before self-hash computation
 
 	// Step 2: marshal with zeroed self_hash; compute self_hash via
-	// chain.RecomputeSelfHash (INV-E28 pinned composition).
+	// chain.RecomputeSelfHash (INV-CRYPTO-115 pinned composition).
 	raw, err := json.Marshal(&payload)
 	if err != nil {
 		return ulid.ULID{}, payload, oops.Code("DEK_REKEY_AUDIT_MARSHAL_FAILED").Wrap(err)
@@ -104,7 +104,7 @@ func (e *RekeyAuditEmitter) Emit(ctx context.Context, payload RekeyAuditPayload)
 	// Step 4: publish via the narrow AuditPublisher seam. On failure, the
 	// finalized payload (with chain-link fields populated) is returned so
 	// the caller's fallback log persists the exact record that would have
-	// been emitted (INV-E13).
+	// been emitted (INV-CRYPTO-100).
 	subject := h.SubjectFor(scope)
 	eventID, err := e.publisher.PublishAudit(ctx, subject, rekeyEventType, raw)
 	if err != nil {
@@ -141,8 +141,8 @@ func encodeHashPtr(b []byte) *string {
 // [policy.PolicySetHandlerFor].
 //
 // SubjectFor converts scope "ct:cid" → "events.<game>.system.rekey.<ct>.<cid>".
-// ScopeFromSubject is the inverse (INV-E27).
-// ScopeFromPayload extracts scope from context.type:context.id (INV-E27).
+// ScopeFromSubject is the inverse (INV-CRYPTO-114).
+// ScopeFromPayload extracts scope from context.type:context.id (INV-CRYPTO-114).
 // Canonicalize applies plain JCS (no empty-form normalization needed, spec §3.7).
 // PrevHashOf and SelfHashOf extract the respective chain-link fields.
 //

--- a/internal/eventbus/crypto/dek/audit_chain.go
+++ b/internal/eventbus/crypto/dek/audit_chain.go
@@ -9,9 +9,9 @@
 //
 // RekeyChainFor(gameID) returns the [chain.Chain] descriptor for the
 // system.rekey chain registered in the generalized auditchain verifier.
-// The subject prefix is "events.<gameID>.system.rekey" (INV-E26).
-// ScopePayloadField is "context" (INV-E27).
-// SelfHashField is "rekey_chain.self_hash" (INV-E28).
+// The subject prefix is "events.<gameID>.system.rekey" (INV-CRYPTO-113).
+// ScopePayloadField is "context" (INV-CRYPTO-114).
+// SelfHashField is "rekey_chain.self_hash" (INV-CRYPTO-115).
 package dek
 
 import (
@@ -119,7 +119,7 @@ func canonicalizeRekeyPayload(payload []byte) ([]byte, error) {
 }
 
 // parseRekeyScopeFromPayload extracts the scope key "<context.type>:<context.id>"
-// from the raw JSON payload. Satisfies INV-E27 (independent payload-derived scope).
+// from the raw JSON payload. Satisfies INV-CRYPTO-114 (independent payload-derived scope).
 //
 // Unexported — called from RekeyChain registration and tested internally.
 func parseRekeyScopeFromPayload(payload []byte) (string, error) {
@@ -244,9 +244,9 @@ func GameIDForTest() string { return currentGameIDForRekey }
 // hash chain parameterized by gameID. The subject prefix embeds gameID so
 // the verifier can scope its SQL LIKE query.
 //
-// INV-E26: SubjectPrefix starts with "events.".
-// INV-E27: ScopePayloadField is "context" (non-empty).
-// INV-E28: SelfHashField is "rekey_chain.self_hash".
+// INV-CRYPTO-113: SubjectPrefix starts with "events.".
+// INV-CRYPTO-114: ScopePayloadField is "context" (non-empty).
+// INV-CRYPTO-115: SelfHashField is "rekey_chain.self_hash".
 func RekeyChainFor(gameID string) chain.Chain {
 	return chain.Chain{
 		SubjectPrefix:     fmt.Sprintf("events.%s.system.rekey", gameID),

--- a/internal/eventbus/crypto/dek/audit_chain_internal_test.go
+++ b/internal/eventbus/crypto/dek/audit_chain_internal_test.go
@@ -6,7 +6,7 @@
 // extractRekeyPrevHash, extractRekeySelfHash) and are therefore in package dek.
 // The companion external test file (audit_chain_test.go in dek_test package)
 // covers the exported surface (RekeyChainFor, ParseRekeyScopeFromSubject,
-// INV-E26/E27/E28 validation).
+// INV-CRYPTO-113/INV-CRYPTO-114/INV-CRYPTO-115 validation).
 package dek
 
 import (
@@ -75,7 +75,7 @@ func TestExtractRekeyPrevHash_GenesisReturnsNil(t *testing.T) {
 	require.Nil(t, prev)
 }
 
-// TestRekeyChain_INV_E28_RecomputeSelfHashRoundTrip verifies INV-E28:
+// TestRekeyChain_INV_E28_RecomputeSelfHashRoundTrip verifies INV-CRYPTO-115:
 // RecomputeSelfHash over two logically-identical payloads (different key
 // order, different self_hash value) produces the same SHA-256 output.
 func TestRekeyChain_INV_E28_RecomputeSelfHashRoundTrip(t *testing.T) {

--- a/internal/eventbus/crypto/dek/audit_chain_test.go
+++ b/internal/eventbus/crypto/dek/audit_chain_test.go
@@ -24,17 +24,17 @@ func TestRekeyChain_INV_E26_SubjectPrefix(t *testing.T) {
 	c := dek.RekeyChainFor("g1")
 	require.NoError(t, chain.ValidateRegistration(c))
 	require.True(t, strings.HasPrefix(c.SubjectPrefix, "events."),
-		"INV-E26: SubjectPrefix must start with \"events.\"")
+		"INV-CRYPTO-113: SubjectPrefix must start with \"events.\"")
 }
 
 func TestRekeyChain_INV_E27_ScopeFromPayloadPresent(t *testing.T) {
 	c := dek.RekeyChainFor("g1")
 	require.NotEmpty(t, c.ScopePayloadField,
-		"INV-E27: ScopePayloadField MUST be populated")
+		"INV-CRYPTO-114: ScopePayloadField MUST be populated")
 }
 
 func TestRekeyChain_INV_E28_SelfHashFieldName(t *testing.T) {
 	c := dek.RekeyChainFor("g1")
 	require.Equal(t, "rekey_chain.self_hash", c.SelfHashField,
-		"INV-E28: SelfHashField must be \"rekey_chain.self_hash\"")
+		"INV-CRYPTO-115: SelfHashField must be \"rekey_chain.self_hash\"")
 }

--- a/internal/eventbus/crypto/dek/audit_test.go
+++ b/internal/eventbus/crypto/dek/audit_test.go
@@ -99,7 +99,7 @@ func TestRekeyAuditEmitter_Emit_PopulatesChainLinkage(t *testing.T) {
 }
 
 // TestRekeyHandlerFor_ValidateRegistration ensures RekeyHandlerFor produces
-// a Handler whose Chain passes ValidateRegistration (INV-E26/E27/E28).
+// a Handler whose Chain passes ValidateRegistration (INV-CRYPTO-113/INV-CRYPTO-114/INV-CRYPTO-115).
 func TestRekeyHandlerFor_ValidateRegistration(t *testing.T) {
 	h := dek.RekeyHandlerFor("testgame")
 	require.NoError(t, chain.ValidateRegistration(h.Chain))
@@ -122,7 +122,7 @@ func TestRekeyHandlerFor_ScopeFromSubject(t *testing.T) {
 	require.Equal(t, "scene:01ABC", scope)
 }
 
-// TestRekeyHandlerFor_ScopeFromPayload verifies INV-E27 independent extraction.
+// TestRekeyHandlerFor_ScopeFromPayload verifies INV-CRYPTO-114 independent extraction.
 func TestRekeyHandlerFor_ScopeFromPayload(t *testing.T) {
 	h := dek.RekeyHandlerFor("mygame")
 	raw := []byte(`{"context":{"type":"scene","id":"01ABC"}}`)

--- a/internal/eventbus/crypto/dek/checkpoint.go
+++ b/internal/eventbus/crypto/dek/checkpoint.go
@@ -96,7 +96,7 @@ type Checkpoint struct {
 	AbortedReason        *string
 }
 
-// PolicyHash returns the policy_hash captured at Phase 1 (INV-E25) as a
+// PolicyHash returns the policy_hash captured at Phase 1 (INV-CRYPTO-112) as a
 // [32]byte array. Using a fixed-size array rather than []byte preserves
 // INV-CRYPTO-16 (no exported []byte in the dek package). The array is zero-padded
 // if the stored slice is shorter than 32 bytes (should not happen in
@@ -150,7 +150,7 @@ func (c *Checkpoint) Phase5MissingMembers() ([]string, error) {
 
 // Phase5HasMissingMembers reports whether phase5_missing_members is populated
 // (a non-empty JSON value). Useful for the Phase 5 timeout discriminator
-// without paying the JSON-decode cost. INV-E10's force-destroy gate consumes
+// without paying the JSON-decode cost. INV-CRYPTO-97's force-destroy gate consumes
 // this: force-destroy MUST be rejected unless the checkpoint sits in the
 // (status=phase5_invalidate, missing_members!=NULL) state.
 func (c *Checkpoint) Phase5HasMissingMembers() bool {
@@ -181,7 +181,7 @@ func NewCheckpointRepo(pool *pgxpool.Pool) *CheckpointRepo { return &CheckpointR
 // Open inserts a new checkpoint row with status=pending and returns the
 // generated RequestID. Returns DEK_REKEY_ALREADY_IN_PROGRESS if a non-
 // terminal checkpoint already exists for the same (context_type, context_id)
-// pair (INV-E5, enforced by the partial unique index).
+// pair (INV-CRYPTO-92, enforced by the partial unique index).
 // Construct req with NewCheckpointOpenRequest to satisfy hash-length
 // invariants before calling Open.
 func (r *CheckpointRepo) Open(ctx context.Context, req CheckpointOpenRequest) (RequestID, error) {
@@ -239,7 +239,7 @@ func (r *CheckpointRepo) Get(ctx context.Context, rid RequestID) (Checkpoint, er
 
 // UpdateStatus transitions status from → to using a CAS UPDATE that
 // atomically guards against stale writers. Returns DEK_REKEY_STALE_TRANSITION
-// if the row was not in state `from` at commit time (INV-E1).
+// if the row was not in state `from` at commit time (INV-CRYPTO-88).
 // AssertTransitionAllowed gates the FSM semantics before issuing SQL.
 func (r *CheckpointRepo) UpdateStatus(ctx context.Context, rid RequestID, from, to CheckpointStatus) error {
 	if err := AssertTransitionAllowed(from, to); err != nil {
@@ -327,7 +327,7 @@ func (r *CheckpointRepo) FindNonTerminalByContext(ctx context.Context, ctxType, 
 
 // ListExpired returns all non-terminal checkpoints whose
 // last_heartbeat_at is older than ttl ago. Called by the sweep subsystem
-// (INV-E18).
+// (INV-CRYPTO-105).
 func (r *CheckpointRepo) ListExpired(ctx context.Context, ttl time.Duration) ([]Checkpoint, error) {
 	// Bind ttl.Nanoseconds() directly against the BIGINT-ns last_heartbeat_at
 	// column. The prior int64(ttl.Seconds()) truncated sub-second durations
@@ -416,7 +416,7 @@ func (r *CheckpointRepo) SetForceDestroy(ctx context.Context, rid RequestID) err
 
 // UpdateStatusForceDestroy transitions phase5_invalidate → phase6_destroy_old
 // when force_destroy=true, bypassing the normal Phase 5 invalidation wait
-// (INV-E10). The CAS predicate requires both status='phase5_invalidate' AND
+// (INV-CRYPTO-97). The CAS predicate requires both status='phase5_invalidate' AND
 // force_destroy=true.
 func (r *CheckpointRepo) UpdateStatusForceDestroy(ctx context.Context, rid RequestID) error {
 	if err := AssertTransitionAllowed(CheckpointStatusPhase5Invalidate, CheckpointStatusPhase6DestroyOld); err != nil {
@@ -441,7 +441,7 @@ func (r *CheckpointRepo) UpdateStatusForceDestroy(ctx context.Context, rid Reque
 // IncrementPhase3Count atomically increments the cumulative Phase 3
 // row-rewrite count on the checkpoint row by delta. Called by
 // processPhase3Batch INSIDE the batch transaction so the count, the row
-// rewrites, and the cursor advance all commit atomically (INV-E7).
+// rewrites, and the cursor advance all commit atomically (INV-CRYPTO-94).
 // Crash-resume correctness: any successfully-committed batch is reflected
 // in the count; a crashed-mid-batch run leaves the count consistent with
 // the cursor (both unchanged from before the batch began).
@@ -473,7 +473,7 @@ func (r *CheckpointRepo) IncrementPhase3Count(ctx context.Context, tx pgx.Tx, ri
 
 // AdvanceCursor updates last_processed_event_id within the caller's active
 // pgx.Tx so that the cursor advance commits atomically with the events_audit
-// row UPDATEs (INV-E7). The CAS predicate requires status='phase3_reencrypt_cold'.
+// row UPDATEs (INV-CRYPTO-94). The CAS predicate requires status='phase3_reencrypt_cold'.
 func (r *CheckpointRepo) AdvanceCursor(ctx context.Context, tx pgx.Tx, rid RequestID, eventID []byte) error {
 	tag, err := tx.Exec(ctx, `
         UPDATE crypto_rekey_checkpoints

--- a/internal/eventbus/crypto/dek/checkpoint_fsm.go
+++ b/internal/eventbus/crypto/dek/checkpoint_fsm.go
@@ -17,8 +17,8 @@ import "github.com/samber/oops"
 //
 //	Any non-terminal state → Aborted  (operator-abort or sweep-TTL-abort)
 //
-// INV-E1: Transitions MUST follow validTransitions only (monotone forward).
-// INV-E2: Complete and Aborted are absorbing terminal states.
+// INV-CRYPTO-88: Transitions MUST follow validTransitions only (monotone forward).
+// INV-CRYPTO-89: Complete and Aborted are absorbing terminal states.
 type CheckpointStatus string
 
 const (
@@ -36,7 +36,7 @@ const (
 
 	// CheckpointStatusPhase3ReencryptCold indicates Phase 3 (re-encrypt cold
 	// tier / events_audit rows) is in progress. This phase is resumable via
-	// the cursor stored in the checkpoint row (INV-E7/E8).
+	// the cursor stored in the checkpoint row (INV-CRYPTO-94/INV-CRYPTO-95).
 	CheckpointStatusPhase3ReencryptCold CheckpointStatus = "phase3_reencrypt_cold"
 
 	// CheckpointStatusPhase5Invalidate indicates Phase 5 (synchronous
@@ -54,12 +54,12 @@ const (
 	CheckpointStatusPhase7Audit CheckpointStatus = "phase7_audit"
 
 	// CheckpointStatusComplete is the terminal success state. Absorbing:
-	// no transitions out (INV-E2).
+	// no transitions out (INV-CRYPTO-89).
 	CheckpointStatusComplete CheckpointStatus = "complete"
 
 	// CheckpointStatusAborted is the terminal failure/abort state. Set by
-	// operator-initiated abort (INV-E17) or sweep TTL-expiry (INV-E18).
-	// Absorbing: no transitions out (INV-E2).
+	// operator-initiated abort (INV-CRYPTO-104) or sweep TTL-expiry (INV-CRYPTO-105).
+	// Absorbing: no transitions out (INV-CRYPTO-89).
 	CheckpointStatusAborted CheckpointStatus = "aborted"
 )
 
@@ -77,7 +77,7 @@ var validTransitions = map[CheckpointStatus][]CheckpointStatus{
 	CheckpointStatusPhase5Invalidate:    {CheckpointStatusPhase6DestroyOld, CheckpointStatusAborted},
 	CheckpointStatusPhase6DestroyOld:    {CheckpointStatusPhase7Audit, CheckpointStatusAborted},
 	CheckpointStatusPhase7Audit:         {CheckpointStatusComplete, CheckpointStatusAborted},
-	// Terminal states — no outgoing transitions (absorbing per INV-E2).
+	// Terminal states — no outgoing transitions (absorbing per INV-CRYPTO-89).
 	CheckpointStatusComplete: {},
 	CheckpointStatusAborted:  {},
 }
@@ -115,7 +115,7 @@ func ValidTransitionPairs() [][2]CheckpointStatus {
 // in validTransitions, or an oops error with code
 // DEK_REKEY_FSM_INVALID_TRANSITION otherwise.
 //
-// INV-E1: CheckpointRepo.UpdateStatus MUST call AssertTransitionAllowed before
+// INV-CRYPTO-88: CheckpointRepo.UpdateStatus MUST call AssertTransitionAllowed before
 // issuing the CAS UPDATE; the CAS provides the concurrent-write guard but the
 // FSM guard is the semantic correctness gate.
 func AssertTransitionAllowed(from, to CheckpointStatus) error {
@@ -134,10 +134,10 @@ func AssertTransitionAllowed(from, to CheckpointStatus) error {
 	return oops.Code("DEK_REKEY_FSM_INVALID_TRANSITION").
 		With("from", string(from)).
 		With("to", string(to)).
-		Errorf("transition %s → %s is not allowed by the CheckpointStatus FSM (INV-E1)", from, to)
+		Errorf("transition %s → %s is not allowed by the CheckpointStatus FSM (INV-CRYPTO-88)", from, to)
 }
 
-// IsTerminal reports whether s is an absorbing terminal state (INV-E2).
+// IsTerminal reports whether s is an absorbing terminal state (INV-CRYPTO-89).
 // Terminal states have no outgoing transitions: Complete and Aborted.
 func (s CheckpointStatus) IsTerminal() bool {
 	return s == CheckpointStatusComplete || s == CheckpointStatusAborted

--- a/internal/eventbus/crypto/dek/checkpoint_fsm_test.go
+++ b/internal/eventbus/crypto/dek/checkpoint_fsm_test.go
@@ -14,7 +14,7 @@ import (
 //
 //   - If (from, to) is in validTransitions: AssertTransitionAllowed returns nil.
 //   - If (from, to) is NOT in validTransitions: AssertTransitionAllowed returns a
-//     non-nil error carrying code DEK_REKEY_FSM_INVALID_TRANSITION (INV-E1/E2).
+//     non-nil error carrying code DEK_REKEY_FSM_INVALID_TRANSITION (INV-CRYPTO-88/INV-CRYPTO-89).
 //
 // The meta-test also confirms that every declared CheckpointStatus constant
 // appears in the validTransitions map as a key or value (no orphaned states).
@@ -55,7 +55,7 @@ func TestFSM_MetaTest_EveryPairCovered(t *testing.T) {
 }
 
 // TestFSM_AbsorbingStates verifies that Complete and Aborted have no outgoing
-// transitions (INV-E2: terminal states are absorbing).
+// transitions (INV-CRYPTO-89: terminal states are absorbing).
 func TestFSM_AbsorbingStates(t *testing.T) {
 	allStatuses := dek.AllCheckpointStatuses()
 
@@ -68,7 +68,7 @@ func TestFSM_AbsorbingStates(t *testing.T) {
 		for _, to := range allStatuses {
 			err := dek.AssertTransitionAllowed(terminal, to)
 			if err == nil {
-				t.Errorf("terminal state %s -> %s should be rejected (absorbing state, INV-E2)",
+				t.Errorf("terminal state %s -> %s should be rejected (absorbing state, INV-CRYPTO-89)",
 					terminal, to)
 			}
 		}

--- a/internal/eventbus/crypto/dek/checkpoint_integration_test.go
+++ b/internal/eventbus/crypto/dek/checkpoint_integration_test.go
@@ -99,7 +99,7 @@ var _ = Describe("CheckpointRepo", func() {
 
 		// Row is at 'pending'. Try a transition from Phase2MintDEK → Phase3ReencryptCold
 		// which the FSM allows, but the CAS predicate (status = 'phase2_mint_dek') fails
-		// because the row is actually 'pending'. (INV-E1)
+		// because the row is actually 'pending'. (INV-CRYPTO-88)
 		err := repo.UpdateStatus(
 			context.Background(), rid,
 			dek.CheckpointStatusPhase2MintDEK,

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -47,13 +47,13 @@ type Manager interface {
 	// MintNewDEKForRekey is used by the Rekey orchestrator's Phase 2.
 	// Generates a fresh DEK, wraps it via Provider, and INSERTs a new
 	// crypto_keys row with version = old.version+1 and byte-equal
-	// participants (INV-E6). Returns the new row's primary key id.
+	// participants (INV-CRYPTO-93). Returns the new row's primary key id.
 	// Manager satisfies dek.Minter via this method.
 	MintNewDEKForRekey(ctx context.Context, oldDEKID int64) (int64, error)
 
 	// DestroyDEK soft-deletes the crypto_keys row whose primary key id
 	// equals dekID by setting destroyed_at = NOW(). Idempotent: a row
-	// already destroyed is a no-op success (INV-E12-PHASE6-IDEMPOTENT).
+	// already destroyed is a no-op success (INV-CRYPTO-99).
 	// Used by the Rekey orchestrator's Phase 6.
 	DestroyDEK(ctx context.Context, dekID int64) error
 
@@ -507,7 +507,7 @@ func (m *manager) unwrapAndCache(ctx context.Context, r row) (codec.Key, error) 
 // row with version = old.version+1 and the SAME participants bytes.
 // Returns the new row's primary key id.
 //
-// INV-E6-PARTICIPANT-INVARIANCE: the new row's participants column is
+// INV-CRYPTO-93: the new row's participants column is
 // byte-equal to the old row's (same Go slice re-marshaled).
 func (m *manager) MintNewDEKForRekey(ctx context.Context, oldDEKID int64) (int64, error) {
 	if err := m.configured(); err != nil {
@@ -560,7 +560,7 @@ func (m *manager) MintNewDEKForRekey(ctx context.Context, oldDEKID int64) (int64
 // DestroyDEK soft-deletes the crypto_keys row with the given primary key by
 // setting destroyed_at = NOW(). Idempotent: a row whose destroyed_at is
 // already set is unaffected — zero rows updated is treated as success,
-// satisfying INV-E12-PHASE6-IDEMPOTENT. Used by the Rekey orchestrator's
+// satisfying INV-CRYPTO-99. Used by the Rekey orchestrator's
 // Phase 6.
 func (m *manager) DestroyDEK(ctx context.Context, dekID int64) error {
 	if err := m.configured(); err != nil {
@@ -600,7 +600,7 @@ func (m *manager) EvictCachedDEK(ctx context.Context, dekID int64) error {
 
 // VersionForDEKID returns the version column of the crypto_keys row whose
 // primary key id equals dekID. Used by the Rekey orchestrator's Phase 3
-// to discover the new DEK's version for AAD construction (INV-E8). The
+// to discover the new DEK's version for AAD construction (INV-CRYPTO-95). The
 // checkpoint row stores only new_dek_id; the version column is the row's
 // natural attribute, not duplicated.
 //

--- a/internal/eventbus/crypto/dek/rekey.go
+++ b/internal/eventbus/crypto/dek/rekey.go
@@ -2,7 +2,7 @@
 
 // Package dek provides the orchestrator-internal types for the Rekey lifecycle,
 // including RekeyRequest, RekeyOutcome, OperatorIdentity, DualControlBinding,
-// and ComputeRekeyArgsHash for INV-E24 request idempotency.
+// and ComputeRekeyArgsHash for INV-CRYPTO-111 request idempotency.
 package dek
 
 import (
@@ -82,7 +82,7 @@ type ArgsHash [32]byte
 
 // ComputeRekeyArgsHash matches the algorithm D ships in approval.ComputeOpArgsHash:
 // SHA-256 over proto.MarshalOptions{Deterministic: true}.Marshal(args) where
-// args is the proto RekeyRequest. INV-E24 (stable across binary builds with
+// args is the proto RekeyRequest. INV-CRYPTO-111 (stable across binary builds with
 // protobuf-go pinned per INV-CRYPTO-85).
 //
 // The hash binds the WORK (context_type, context_id, justification), not WHO.

--- a/internal/eventbus/crypto/dek/rekey_orchestrator.go
+++ b/internal/eventbus/crypto/dek/rekey_orchestrator.go
@@ -16,7 +16,7 @@ import (
 // chain for a given policyName and return its recomputed self-hash".
 //
 // Phase 1 calls CurrentPolicyHash once and persists the result on the
-// checkpoint row (INV-E25: policy_hash is frozen at Phase 1 and never
+// checkpoint row (INV-CRYPTO-112: policy_hash is frozen at Phase 1 and never
 // re-queried during later phases).
 //
 // Returns nil when the chain is empty (genesis: no policy_set event yet).
@@ -73,7 +73,7 @@ func (s *auditChainPolicyHashSource) CurrentPolicyHash(ctx context.Context, poli
 type Minter interface {
 	// MintNewDEKForRekey generates a fresh DEK, wraps it via Provider, and
 	// INSERTs a new crypto_keys row with version = old.version+1 and
-	// byte-equal participants (INV-E6). Returns the new row's primary key id.
+	// byte-equal participants (INV-CRYPTO-93). Returns the new row's primary key id.
 	MintNewDEKForRekey(ctx context.Context, oldDEKID int64) (int64, error)
 }
 
@@ -97,7 +97,7 @@ type Orchestrator struct {
 	phase5Coord      Phase5Coordinator
 	dekDestroyer     Destroyer
 	auditEmitter     AuditEmitter // Phase 7: emit chained audit event (holomush-jxo8.7.24)
-	dataDir          string       // Phase 7: fallback log directory (INV-E13)
+	dataDir          string       // Phase 7: fallback log directory (INV-CRYPTO-100)
 	serverID         string       // Phase 7: server_identity field in audit payload
 	batchHookForTest func(rowsRewrittenSoFar int)
 	logger           *slog.Logger
@@ -134,15 +134,15 @@ func NewOrchestrator(
 }
 
 // RunPhase1Fresh is the entry point for a fresh rekey. It:
-//  1. Computes the op_args_hash (INV-E24: idempotency key binding the WORK).
-//  2. Captures the current policy_set chain head as policy_hash (INV-E25).
+//  1. Computes the op_args_hash (INV-CRYPTO-111: idempotency key binding the WORK).
+//  2. Captures the current policy_set chain head as policy_hash (INV-CRYPTO-112).
 //     If the chain is empty (genesis), stores a 32-byte zero sentinel.
 //  3. Reads the active DEK row to obtain old_dek_id.
 //  4. Opens (INSERTs) the checkpoint row with status=pending.
 //  5. Advances the checkpoint to phase1_auth.
 //
 // Returns DEK_REKEY_ALREADY_IN_PROGRESS if a non-terminal checkpoint
-// already exists for (context_type, context_id) (INV-E5, enforced by the
+// already exists for (context_type, context_id) (INV-CRYPTO-92, enforced by the
 // partial unique index in the Open step).
 //
 // Phase 1 does NOT authenticate the operator — that is the admin handler's
@@ -204,7 +204,7 @@ func (o *Orchestrator) RunPhase1Fresh(ctx context.Context, req RekeyRequest) (Re
 }
 
 // RunPhase2 mints a new DEK for the rekey context, preserving the old DEK's
-// participant set byte-for-byte (INV-E6-PARTICIPANT-INVARIANCE), and advances
+// participant set byte-for-byte (INV-CRYPTO-93), and advances
 // the checkpoint from phase1_auth to phase2_mint_dek atomically.
 //
 // Pre-condition: checkpoint status MUST be phase1_auth.
@@ -213,7 +213,7 @@ func (o *Orchestrator) RunPhase1Fresh(ctx context.Context, req RekeyRequest) (Re
 //  1. Load the checkpoint row to obtain old_dek_id and verify pre-condition.
 //  2. Delegate to Minter.MintNewDEKForRekey to generate a fresh DEK,
 //     wrap it, and INSERT a new crypto_keys row (version = old + 1,
-//     participants byte-equal to old per INV-E6).
+//     participants byte-equal to old per INV-CRYPTO-93).
 //  3. Atomically persist new_dek_id and advance status to phase2_mint_dek
 //     via SetNewDEKAndAdvance (CAS UPDATE on status = 'phase1_auth').
 func (o *Orchestrator) RunPhase2(ctx context.Context, rid RequestID) error {
@@ -229,7 +229,7 @@ func (o *Orchestrator) RunPhase2(ctx context.Context, rid RequestID) error {
 	}
 
 	// Mint new DEK via Minter (which calls Provider.Wrap and INSERTs into
-	// crypto_keys with participants copied from the old row — INV-E6).
+	// crypto_keys with participants copied from the old row — INV-CRYPTO-93).
 	newDEKID, err := o.minter.MintNewDEKForRekey(ctx, ckpt.OldDEKID)
 	if err != nil {
 		return oops.Code("DEK_REKEY_MINT_NEW_DEK_FAILED").Wrap(err)

--- a/internal/eventbus/crypto/dek/rekey_orchestrator_test.go
+++ b/internal/eventbus/crypto/dek/rekey_orchestrator_test.go
@@ -106,8 +106,8 @@ func newTestOrchestratorWithProvider(t *testing.T, pool *pgxpool.Pool, gameID st
 }
 
 // TestOrchestrator_Phase1_FreshStart_CapturesPolicyHash verifies:
-//   - checkpoint status transitions pending → phase1_auth (INV-E1)
-//   - policy_hash on the checkpoint row equals the recomputed chain head hash (INV-E25)
+//   - checkpoint status transitions pending → phase1_auth (INV-CRYPTO-88)
+//   - policy_hash on the checkpoint row equals the recomputed chain head hash (INV-CRYPTO-112)
 //   - RequestID is non-zero
 func TestOrchestrator_Phase1_FreshStart_CapturesPolicyHash(t *testing.T) {
 	pool := testIntegrationPool(t)
@@ -146,14 +146,14 @@ func TestOrchestrator_Phase1_FreshStart_CapturesPolicyHash(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, dek.CheckpointStatusPhase1Auth, ckpt.Status,
-		"INV-E1: checkpoint must be in phase1_auth after RunPhase1Fresh")
+		"INV-CRYPTO-88: checkpoint must be in phase1_auth after RunPhase1Fresh")
 
-	// INV-E25: policy_hash MUST be captured at Phase 1 from the chain head.
+	// INV-CRYPTO-112: policy_hash MUST be captured at Phase 1 from the chain head.
 	// Convert wantPolicyHash ([]byte, from ComputePrevHashFor) to [32]byte for comparison.
 	var wantArr [32]byte
 	copy(wantArr[:], wantPolicyHash)
 	require.Equal(t, wantArr, ckpt.PolicyHash(),
-		"INV-E25: policy_hash MUST be captured at Phase 1 from the chain head")
+		"INV-CRYPTO-112: policy_hash MUST be captured at Phase 1 from the chain head")
 }
 
 // TestOrchestrator_Phase1_GenesisPolicy_ZeroHash verifies that when no
@@ -192,7 +192,7 @@ func TestOrchestrator_Phase1_GenesisPolicy_ZeroHash(t *testing.T) {
 
 // TestOrchestrator_Phase1_ConcurrentSameContext_Rejected verifies:
 //   - a second RunPhase1Fresh on the same context while the first is active
-//     returns DEK_REKEY_ALREADY_IN_PROGRESS (INV-E5)
+//     returns DEK_REKEY_ALREADY_IN_PROGRESS (INV-CRYPTO-92)
 func TestOrchestrator_Phase1_ConcurrentSameContext_Rejected(t *testing.T) {
 	pool := testIntegrationPool(t)
 	const gameID = "g1"
@@ -248,7 +248,7 @@ type cryptoKeyRowForTest struct {
 }
 
 // loadCryptoKeyRow loads a crypto_keys row by its primary key id. Used to
-// assert INV-E6 (participants byte-equal between old and new DEK rows).
+// assert INV-CRYPTO-93 (participants byte-equal between old and new DEK rows).
 func loadCryptoKeyRow(t *testing.T, pool *pgxpool.Pool, id int64) cryptoKeyRowForTest {
 	t.Helper()
 	var r cryptoKeyRowForTest
@@ -261,10 +261,10 @@ func loadCryptoKeyRow(t *testing.T, pool *pgxpool.Pool, id int64) cryptoKeyRowFo
 }
 
 // TestOrchestrator_Phase2_MintsNewDEK_PreservesParticipants verifies:
-//   - RunPhase2 advances checkpoint status to phase2_mint_dek (INV-E1)
+//   - RunPhase2 advances checkpoint status to phase2_mint_dek (INV-CRYPTO-88)
 //   - checkpoint.NewDEKID is populated after RunPhase2
 //   - new crypto_keys row has version = old+1
-//   - new row's participants JSON is byte-equal to old (INV-E6-PARTICIPANT-INVARIANCE)
+//   - new row's participants JSON is byte-equal to old (INV-CRYPTO-93)
 func TestOrchestrator_Phase2_MintsNewDEK_PreservesParticipants(t *testing.T) {
 	pool := testIntegrationPool(t)
 	const gameID = "g1"
@@ -296,21 +296,21 @@ func TestOrchestrator_Phase2_MintsNewDEK_PreservesParticipants(t *testing.T) {
 	ckpt, err := repo.Get(context.Background(), rid)
 	require.NoError(t, err)
 	require.Equal(t, dek.CheckpointStatusPhase2MintDEK, ckpt.Status,
-		"INV-E1: checkpoint must advance to phase2_mint_dek after RunPhase2")
+		"INV-CRYPTO-88: checkpoint must advance to phase2_mint_dek after RunPhase2")
 	require.NotNil(t, ckpt.NewDEKID, "NewDEKID must be populated after Phase 2")
 
-	// INV-E6: new DEK row's participants MUST be byte-equal to old.
+	// INV-CRYPTO-93: new DEK row's participants MUST be byte-equal to old.
 	oldRow := loadCryptoKeyRow(t, pool, ckpt.OldDEKID)
 	newRow := loadCryptoKeyRow(t, pool, *ckpt.NewDEKID)
 	require.Equal(t, oldRow.ParticipantsJSON, newRow.ParticipantsJSON,
-		"INV-E6: new DEK row participants must be byte-equal to old")
+		"INV-CRYPTO-93: new DEK row participants must be byte-equal to old")
 	require.Equal(t, oldRow.Version+1, newRow.Version,
 		"new DEK version must be old+1")
 }
 
 // TestOrchestrator_Phase2_RequiresPreconditionPhase1Auth verifies:
 //   - RunPhase2 returns DEK_REKEY_PHASE_PRECONDITION_FAILED when checkpoint
-//     is not in phase1_auth status (INV-E1 / INV-E6 rejection path)
+//     is not in phase1_auth status (INV-CRYPTO-88 / INV-CRYPTO-93 rejection path)
 func TestOrchestrator_Phase2_RequiresPreconditionPhase1Auth(t *testing.T) {
 	pool := testIntegrationPool(t)
 	const gameID = "g1"

--- a/internal/eventbus/crypto/dek/rekey_phase3.go
+++ b/internal/eventbus/crypto/dek/rekey_phase3.go
@@ -23,14 +23,14 @@ import (
 const defaultPhase3BatchSize = 1000
 
 // phase3HeartbeatInterval is the wall-clock cadence at which Phase 3
-// updates last_heartbeat_at to reset the sweep-TTL clock (INV-E19).
+// updates last_heartbeat_at to reset the sweep-TTL clock (INV-CRYPTO-106).
 const phase3HeartbeatInterval = 30 * time.Second
 
 // MaterialResolver supplies decrypted DEK material for Phase 3 cold-tier
 // rewrite. The Orchestrator needs both the OLD DEK (to decrypt existing
 // events_audit rows) and the NEW DEK (to re-encrypt under the rekeyed
 // key). VersionForDEKID maps a crypto_keys primary key to its version
-// column so that AAD construction (INV-E8) sees the correct dek_version.
+// column so that AAD construction (INV-CRYPTO-95) sees the correct dek_version.
 //
 // Production wiring: *dek.manager satisfies this interface via Resolve
 // (resolves by keyID + version) and a thin VersionForDEKID adapter that
@@ -45,7 +45,7 @@ type MaterialResolver interface {
 	// VersionForDEKID returns the version column of the crypto_keys row
 	// whose primary key id equals dekID. Used by Phase 3 to discover the
 	// new DEK's version (the orchestrator's checkpoint row stores only
-	// new_dek_id, not new_dek_version) for AAD construction (INV-E8).
+	// new_dek_id, not new_dek_version) for AAD construction (INV-CRYPTO-95).
 	VersionForDEKID(ctx context.Context, dekID int64) (uint32, error)
 }
 
@@ -73,10 +73,10 @@ func (o *Orchestrator) SetBatchHookForTest(fn func(rowsRewrittenSoFar int)) {
 // rekey checkpoint's old DEK, in deterministic id-order batches. For
 // each row the loop decrypts the existing ciphertext under the OLD DEK +
 // OLD AAD, re-encrypts the plaintext under the NEW DEK with AAD rebuilt
-// from (subject, type, new_key_id, new_version, codec) per INV-E8, and
+// from (subject, type, new_key_id, new_version, codec) per INV-CRYPTO-95, and
 // UPDATEs the events_audit row plus the checkpoint cursor inside one
 // pgx.Tx so a crash mid-batch leaves no partially-rewritten state
-// (INV-E7-COLD-RESUME-CURSOR).
+// (INV-CRYPTO-94).
 //
 // Pre-condition: checkpoint.Status ∈ {Phase2MintDEK,
 // Phase3ReencryptCold}. Phase2MintDEK is the fresh-entry case (Phase 2
@@ -207,7 +207,7 @@ func (o *Orchestrator) RunPhase3(ctx context.Context, rid RequestID) (int, error
 // processPhase3Batch handles a single transactional batch: SELECT rows,
 // decrypt + re-encrypt each, UPDATE events_audit, AdvanceCursor — all
 // committed together so a crashed batch leaves the cursor and the
-// events_audit rows mutually consistent (INV-E7).
+// events_audit rows mutually consistent (INV-CRYPTO-94).
 //
 // Returns (rowsRewritten, newCursor, error). rowsRewritten == 0 with
 // nil cursor + nil error signals "no more rows" to the caller's loop.
@@ -238,7 +238,7 @@ func (o *Orchestrator) processPhase3Batch(
 	// (initial scan, cursor never advanced), match all rows by treating
 	// the comparison as a no-op via the COALESCE'd '\x00'::bytea bound.
 	// Order by id (ULID) so re-running with the same cursor reproduces
-	// the same row sequence on resume — load-bearing for INV-E7.
+	// the same row sequence on resume — load-bearing for INV-CRYPTO-94.
 	rows, err := tx.Query(ctx, `
         SELECT id, subject, type, envelope, codec, dek_version
           FROM events_audit
@@ -297,7 +297,7 @@ func (o *Orchestrator) processPhase3Batch(
 	for _, r := range batch {
 		// Unmarshal the stored envelope so AAD construction sees the
 		// full event metadata (subject/type/timestamp/actor/eventID)
-		// exactly as the original encrypt path did — INV-E8 requires the
+		// exactly as the original encrypt path did — INV-CRYPTO-95 requires the
 		// AAD bytes to differ ONLY in dek_ref + dek_version after rewrite.
 		var envelope eventbusv1.Event
 		if unmarshalErr := proto.Unmarshal(r.envelope, &envelope); unmarshalErr != nil {
@@ -340,7 +340,7 @@ func (o *Orchestrator) processPhase3Batch(
 				With("codec", r.codecName).Wrap(decErr)
 		}
 
-		// AAD rebind (INV-E8): new AAD is built from the same envelope
+		// AAD rebind (INV-CRYPTO-95): new AAD is built from the same envelope
 		// fields but with the NEW (dek_ref, dek_version). Old AAD MUST
 		// fail to decode the rewritten ciphertext — proved by
 		// TestPhase3_AADRebindOnRewrite.
@@ -390,7 +390,7 @@ func (o *Orchestrator) processPhase3Batch(
 
 	// Advance the cursor as the FINAL action inside the transaction so a
 	// rollback reverts both the row UPDATEs and the cursor advance
-	// atomically (INV-E7-COLD-RESUME-CURSOR). The CAS predicate inside
+	// atomically (INV-CRYPTO-94). The CAS predicate inside
 	// AdvanceCursor (status='phase3_reencrypt_cold') guards against a
 	// concurrent abort racing the commit.
 	if cursorErr := o.repo.AdvanceCursor(ctx, tx, rid, lastID); cursorErr != nil {

--- a/internal/eventbus/crypto/dek/rekey_phase3_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase3_integration_test.go
@@ -52,7 +52,7 @@ type phase3TestSetup struct {
 	newKey    codec.Key
 	codecName codec.Name
 	// eventIDs records the ULIDs of every seeded event, in insertion order.
-	// Tests use this to look up rows post-rewrite for INV-E8 assertions.
+	// Tests use this to look up rows post-rewrite for INV-CRYPTO-95 assertions.
 	eventIDs []ulid.ULID
 	// plaintexts mirrors eventIDs and records the cleartext payload each
 	// row was encrypted from, so the round-trip assertion can compare bytes
@@ -99,7 +99,7 @@ func newPhase3TestSetup() *phase3TestSetup {
 
 	// Resolve the new DEK material so encrypted-row seeding can verify
 	// round-trip later. We don't actually need newKey at setup, but it's
-	// load-bearing for INV-E8 assertions in the AADRebindOnRewrite spec.
+	// load-bearing for INV-CRYPTO-95 assertions in the AADRebindOnRewrite spec.
 	const newDEKVer uint32 = 2                                                         // GetOrCreate seeded at v1; MintNewDEKForRekey produces v2
 	newKey, err := mgr.Resolve(context.Background(), codec.KeyID(newDEKID), newDEKVer) //nolint:gosec // G115: newDEKID is a BIGSERIAL PK
 	Expect(err).NotTo(HaveOccurred())
@@ -279,7 +279,7 @@ func (s *phase3TestSetup) LoadEventsAuditRow(id ulid.ULID) phase3RewrittenRow {
 // stubBindingResolver / noopInvalidator are shared with manager_integration_test.go
 // (package dek_test). Re-declared here is unnecessary.
 
-var _ = Describe("Phase3_RewriteAllRowsAtomically (INV-E7)", func() {
+var _ = Describe("Phase3_RewriteAllRowsAtomically (INV-CRYPTO-94)", func() {
 	It("rewrites all seeded rows atomically, advances checkpoint to phase3_reencrypt_cold, and sets cursor to largest-id row", func() {
 		setup := newPhase3TestSetup()
 		const eventCount = 100
@@ -289,7 +289,7 @@ var _ = Describe("Phase3_RewriteAllRowsAtomically (INV-E7)", func() {
 		rowsRewritten, err := setup.orch.RunPhase3(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rowsRewritten).To(Equal(eventCount),
-			"INV-E7: every seeded row must be rewritten in one invocation")
+			"INV-CRYPTO-94: every seeded row must be rewritten in one invocation")
 
 		ckpt, err := setup.repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
@@ -314,11 +314,11 @@ var _ = Describe("Phase3_RewriteAllRowsAtomically (INV-E7)", func() {
 			}
 		}
 		Expect(finalID).To(Equal(maxSeed),
-			"INV-E7: cursor advances to the largest-id row processed")
+			"INV-CRYPTO-94: cursor advances to the largest-id row processed")
 	})
 })
 
-var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", func() {
+var _ = Describe("Phase3_CrashResumeIdempotent (INV-CRYPTO-94)", func() {
 	It("resumes from crash cursor and produces state identical to a non-crashed run", func() {
 		setup := newPhase3TestSetup()
 		const eventCount = 2500
@@ -338,7 +338,7 @@ var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", fun
 		})
 
 		firstAttemptCount, firstErr := setup.orch.RunPhase3(ctx, rid)
-		Expect(firstErr).To(HaveOccurred(), "INV-E7: context cancel must surface an error")
+		Expect(firstErr).To(HaveOccurred(), "INV-CRYPTO-94: context cancel must surface an error")
 		Expect(firstAttemptCount).To(BeNumerically(">=", 1000),
 			"first attempt processed at least one batch before crash")
 		Expect(firstAttemptCount).To(BeNumerically("<", eventCount),
@@ -346,7 +346,7 @@ var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", fun
 
 		// Verify the cursor advanced ONLY to the last committed batch
 		// boundary. The crashed batch's rows + cursor advance MUST have been
-		// rolled back together (INV-E7).
+		// rolled back together (INV-CRYPTO-94).
 		ckptMid, err := setup.repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckptMid.Status).To(Equal(dek.CheckpointStatusPhase3ReencryptCold),
@@ -376,11 +376,11 @@ var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", fun
 		// resume-invocation's contribution (eventCount-firstAttemptCount)
 		// and silently drop the firstAttemptCount rows from the audit trail.
 		Expect(ckptFinal.Phase3RowsRewritten).To(Equal(eventCount),
-			"INV-E7 + jxo8.7.54: Phase3RowsRewritten on checkpoint must be cumulative across crash-resume cycles")
+			"INV-CRYPTO-94 + jxo8.7.54: Phase3RowsRewritten on checkpoint must be cumulative across crash-resume cycles")
 
 		// Plaintext round-trip: decrypt each rewritten row under the NEW
 		// DEK + new AAD; bytes MUST equal the seeded plaintext for that
-		// row. This is the strongest form of INV-E7 (final state is
+		// row. This is the strongest form of INV-CRYPTO-94 (final state is
 		// observationally identical to a non-crashed run).
 		codecImpl, err := codec.Resolve(setup.codecName)
 		Expect(err).NotTo(HaveOccurred())
@@ -396,12 +396,12 @@ var _ = Describe("Phase3_CrashResumeIdempotent (INV-E7-COLD-RESUME-CURSOR)", fun
 			decoded, err := codecImpl.Decode(context.Background(), envelope.GetPayload(), setup.newKey, aadBytes)
 			Expect(err).NotTo(HaveOccurred(), "row %d (%s) must decrypt under new DEK + new AAD after rewrite", i, id.String())
 			Expect(decoded).To(Equal(setup.plaintexts[i]),
-				"INV-E7: plaintext byte-equal between pre-rewrite and post-rewrite for row %d", i)
+				"INV-CRYPTO-94: plaintext byte-equal between pre-rewrite and post-rewrite for row %d", i)
 		}
 	})
 })
 
-var _ = Describe("Phase3_AADRebindOnRewrite (INV-E8)", func() {
+var _ = Describe("Phase3_AADRebindOnRewrite (INV-CRYPTO-95)", func() {
 	It("old AAD fails AEAD tag check and new AAD succeeds after rewrite", func() {
 		setup := newPhase3TestSetup()
 		setup.InsertEncryptedRows(1)
@@ -427,7 +427,7 @@ var _ = Describe("Phase3_AADRebindOnRewrite (INV-E8)", func() {
 		newAAD, err := aad.Build(&envelope, string(rewritten.Codec), uint64(rewritten.DEKRef), rewritten.DEKVersion) //nolint:gosec // G115: rewritten.DEKRef is BIGSERIAL PK
 		Expect(err).NotTo(HaveOccurred())
 		_, err = codecImpl.Decode(context.Background(), envelope.GetPayload(), setup.newKey, newAAD)
-		Expect(err).NotTo(HaveOccurred(), "INV-E8: new AAD MUST decode the rewritten ciphertext")
+		Expect(err).NotTo(HaveOccurred(), "INV-CRYPTO-95: new AAD MUST decode the rewritten ciphertext")
 
 		// Old AAD: must fail. Two distinct mutations probe the rebind
 		// surface: (1) old dek_ref (= setup.oldDEKID) with new version,
@@ -436,16 +436,16 @@ var _ = Describe("Phase3_AADRebindOnRewrite (INV-E8)", func() {
 		oldRefAAD, err := aad.Build(&envelope, string(rewritten.Codec), uint64(setup.oldDEKID), rewritten.DEKVersion) //nolint:gosec // G115
 		Expect(err).NotTo(HaveOccurred())
 		_, err = codecImpl.Decode(context.Background(), envelope.GetPayload(), setup.newKey, oldRefAAD)
-		Expect(err).To(HaveOccurred(), "INV-E8: old dek_ref in AAD MUST fail AEAD tag check")
+		Expect(err).To(HaveOccurred(), "INV-CRYPTO-95: old dek_ref in AAD MUST fail AEAD tag check")
 
 		oldVerAAD, err := aad.Build(&envelope, string(rewritten.Codec), uint64(rewritten.DEKRef), setup.oldDEKVer) //nolint:gosec // G115
 		Expect(err).NotTo(HaveOccurred())
 		_, err = codecImpl.Decode(context.Background(), envelope.GetPayload(), setup.newKey, oldVerAAD)
-		Expect(err).To(HaveOccurred(), "INV-E8: old dek_version in AAD MUST fail AEAD tag check")
+		Expect(err).To(HaveOccurred(), "INV-CRYPTO-95: old dek_version in AAD MUST fail AEAD tag check")
 	})
 })
 
-var _ = Describe("Phase3_HeartbeatAdvancesDuringLongRun (INV-E19)", func() {
+var _ = Describe("Phase3_HeartbeatAdvancesDuringLongRun (INV-CRYPTO-106)", func() {
 	It("last_heartbeat_at advances past its pre-run value after RunPhase3 with multiple batches", func() {
 		setup := newPhase3TestSetup()
 		setup.InsertEncryptedRows(2500) // > 2 batches → multiple AdvanceCursor calls
@@ -467,7 +467,7 @@ var _ = Describe("Phase3_HeartbeatAdvancesDuringLongRun (INV-E19)", func() {
 		ckptAfter, err := setup.repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckptAfter.LastHeartbeatAt.After(beforeHB)).To(BeTrue(),
-			"INV-E19: heartbeat MUST advance during the Phase 3 loop (before=%s after=%s)",
+			"INV-CRYPTO-106: heartbeat MUST advance during the Phase 3 loop (before=%s after=%s)",
 			beforeHB, ckptAfter.LastHeartbeatAt)
 	})
 })

--- a/internal/eventbus/crypto/dek/rekey_phase5.go
+++ b/internal/eventbus/crypto/dek/rekey_phase5.go
@@ -19,7 +19,7 @@ import (
 // dependency on internal/eventbus/crypto/invalidation.
 //
 // Returns nil on N-of-N success. On partial-ack timeout (the case
-// INV-E22 / INV-E11 governs) the implementation MUST return an oops error
+// INV-CRYPTO-109 / INV-CRYPTO-98 governs) the implementation MUST return an oops error
 // whose Context()["missing_members"] is a []string or []cluster.MemberID;
 // the orchestrator extracts that field and persists it on the checkpoint
 // row. Any other error class is treated as fatal — the orchestrator
@@ -79,7 +79,7 @@ func (o *Orchestrator) SetPhase5Coordinator(c Phase5Coordinator) {
 }
 
 // RunPhase5 drives the Phase 5 cluster cache-invalidation fan-out
-// (INV-E22). It is the orchestrator's "publish the new DEK has arrived,
+// (INV-CRYPTO-109). It is the orchestrator's "publish the new DEK has arrived,
 // every replica MUST evict its cached old-DEK material" step.
 //
 // Pre-condition: checkpoint.Status ∈
@@ -157,7 +157,7 @@ func (o *Orchestrator) RunPhase5(ctx context.Context, rid RequestID) error {
 
 	// Resolve the version numbers from the crypto_keys rows. The
 	// orchestrator has the PKs on the checkpoint; selectByPK returns
-	// the version column. INV-E22 calls for Version=old, SuccessorVersion=new
+	// the version column. INV-CRYPTO-109 calls for Version=old, SuccessorVersion=new
 	// per the invalidation.Payload action table (rekey row).
 	oldRow, err := o.store.selectByPK(ctx, ckpt.OldDEKID)
 	if err != nil {
@@ -226,26 +226,26 @@ func (o *Orchestrator) RunPhase5(ctx context.Context, rid RequestID) error {
 // stuck in the "timed-out" state (status=phase5_invalidate AND
 // phase5_missing_members IS NOT NULL).
 //
-// INV-E10-FORCE-DESTROY-GATED: any other status / missing-members combo
+// INV-CRYPTO-97: any other status / missing-members combo
 // MUST be rejected with DEK_REKEY_FORCE_DESTROY_FORBIDDEN. This is the
 // hard gate that prevents force-destroy from skipping Phase 5 when the
 // fan-out has never been attempted.
 //
 // Steps:
-//  1. Load the checkpoint; verify gate (INV-E10).
+//  1. Load the checkpoint; verify gate (INV-CRYPTO-97).
 //  2. SetForceDestroy(true) so the audit projection and operator surface
 //     can see the bypass was used.
 //  3. UpdateStatusForceDestroy advances phase5_invalidate → phase6_destroy_old
 //     with the CAS predicate (status='phase5_invalidate' AND force_destroy=true).
 //
 // On the operator side, the audit emit (Phase 7, holomush-jxo8.7.24) records
-// `force_destroy: true` and `final_missing_members: [...]` per INV-E11.
+// `force_destroy: true` and `final_missing_members: [...]` per INV-CRYPTO-98.
 // That row already persists from RunPhase5's RecordPhase5Timeout call; the
 // Phase 7 emitter reads it back from the checkpoint.
 //
 // This call is NOT idempotent against repeated force-destroy invocations:
 // after the first call advances status to phase6_destroy_old, a second
-// call observes status=phase6_destroy_old and rejects with INV-E10. That's
+// call observes status=phase6_destroy_old and rejects with INV-CRYPTO-97. That's
 // the right shape — repeated force-destroy is a real operator error
 // (Phase 6 is the next step, not another Phase 5 retry).
 func (o *Orchestrator) RunPhase5WithForceDestroy(ctx context.Context, rid RequestID) error {
@@ -253,21 +253,21 @@ func (o *Orchestrator) RunPhase5WithForceDestroy(ctx context.Context, rid Reques
 	if err != nil {
 		return err
 	}
-	// INV-E10: gate is (status==phase5_invalidate AND
+	// INV-CRYPTO-97: gate is (status==phase5_invalidate AND
 	// phase5_missing_members IS NOT NULL). Phase5HasMissingMembers
 	// encodes the NULL / "null" / "[]" tolerance.
 	if ckpt.Status != CheckpointStatusPhase5Invalidate || !ckpt.Phase5HasMissingMembers() {
 		return oops.Code("DEK_REKEY_FORCE_DESTROY_FORBIDDEN").
 			With("status", string(ckpt.Status)).
 			With("phase5_missing_members_set", ckpt.Phase5HasMissingMembers()).
-			Errorf("INV-E10: --force-destroy requires checkpoint at phase5_invalidate with missing_members set")
+			Errorf("INV-CRYPTO-97: --force-destroy requires checkpoint at phase5_invalidate with missing_members set")
 	}
 
 	// Audit signal: emit a structured warn-level log line so the
 	// operator surface and any log-based monitoring catch the split-brain
-	// bypass. INV-E11's audit-event capture is the canonical record
+	// bypass. INV-CRYPTO-98's audit-event capture is the canonical record
 	// (lands in Phase 7); this log is the in-flight signal. A decode
-	// failure here is non-fatal — the row clears INV-E10 by
+	// failure here is non-fatal — the row clears INV-CRYPTO-97 by
 	// Phase5HasMissingMembers, and the log line still fires with a nil
 	// member list.
 	missing, decodeErr := ckpt.Phase5MissingMembers()

--- a/internal/eventbus/crypto/dek/rekey_phase5_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase5_integration_test.go
@@ -218,11 +218,11 @@ func (s *phase5TestSetup) RunUpToPhase3Complete() dek.RequestID {
 
 // Phase 5 rekey — Orchestrator integration specs.
 var _ = Describe("Orchestrator Phase 5 rekey", func() {
-	// TestOrchestrator_Phase5_NofN_AdvancesToComplete — INV-E22 happy path.
+	// TestOrchestrator_Phase5_NofN_AdvancesToComplete — INV-CRYPTO-109 happy path.
 	// On full N-of-N ack the checkpoint advances to phase5_invalidate with
 	// phase5_missing_members cleared to NULL (the FSM equivalent of the
 	// plan-symbolic StatusPhase5Complete).
-	It("N-of-N ack advances checkpoint to phase5_invalidate (INV-E22)", func() {
+	It("N-of-N ack advances checkpoint to phase5_invalidate (INV-CRYPTO-109)", func() {
 		setup := newPhase5TestSetup()
 		rid := setup.RunUpToPhase3Complete()
 
@@ -246,20 +246,20 @@ var _ = Describe("Orchestrator Phase 5 rekey", func() {
 		Expect(calls[0].ContextType).To(Equal("scene"))
 		Expect(calls[0].ContextID).To(Equal("01PH5"))
 		// Old DEK was minted at v=1 by GetOrCreate; MintNewDEKForRekey
-		// produces v=old+1 = 2. INV-E22 payload-row table: Version=old,
+		// produces v=old+1 = 2. INV-CRYPTO-109 payload-row table: Version=old,
 		// SuccessorVersion=new.
 		Expect(calls[0].Version).To(Equal(uint32(1)))
 		Expect(calls[0].SuccessorVersion).To(Equal(uint32(2)))
 	})
 
-	// TestOrchestrator_Phase5_PartialTimeout_PersistsMissingMembers — INV-E14
+	// TestOrchestrator_Phase5_PartialTimeout_PersistsMissingMembers — INV-CRYPTO-101
 	// timeout semantics. On partial-ack timeout the orchestrator:
 	//   - returns DEK_REKEY_PHASE5_TIMEOUT (operator-facing typed error)
 	//   - persists missing_members as JSON on the checkpoint row
 	//   - sets phase5_attempt_count to reflect the fan-out attempt
 	//   - leaves status at phase5_invalidate (FSM equiv of plan
 	//     StatusPhase5Timeout — distinguished by missing_members IS NOT NULL)
-	It("partial-ack timeout persists missing_members (INV-E14)", func() {
+	It("partial-ack timeout persists missing_members (INV-CRYPTO-101)", func() {
 		setup := newPhase5TestSetup()
 		rid := setup.RunUpToPhase3Complete()
 
@@ -314,17 +314,17 @@ var _ = Describe("Orchestrator Phase 5 rekey", func() {
 			"two fan-out attempts: one timeout + one success")
 	})
 
-	// TestOrchestrator_Phase5_ForceDestroy_OnlyAfterTimeout — INV-E10 gate
+	// TestOrchestrator_Phase5_ForceDestroy_OnlyAfterTimeout — INV-CRYPTO-97 gate
 	// enforcement. Force-destroy is rejected when the precondition isn't
 	// (status==phase5_invalidate AND missing_members IS NOT NULL); once the
 	// state is in the timed-out slot, force-destroy advances directly to
 	// phase6_destroy_old, skipping the normal phase5_invalidate-clean path.
-	It("ForceDestroy only permitted after timeout (INV-E10)", func() {
+	It("ForceDestroy only permitted after timeout (INV-CRYPTO-97)", func() {
 		setup := newPhase5TestSetup()
 		rid := setup.RunUpToPhase3Complete()
 
 		// At phase3_reencrypt_cold (Phase 5 hasn't run): force-destroy
-		// rejected. INV-E10 rejects fresh checkpoint with no fan-out attempt.
+		// rejected. INV-CRYPTO-97 rejects fresh checkpoint with no fan-out attempt.
 		err := setup.Orch.RunPhase5WithForceDestroy(context.Background(), rid)
 		Expect(err).To(HaveOccurred())
 		errutil.AssertErrorCode(suiteT, err, "DEK_REKEY_FORCE_DESTROY_FORBIDDEN")
@@ -349,7 +349,7 @@ var _ = Describe("Orchestrator Phase 5 rekey", func() {
 
 		// The missing_members set was persisted during the timeout and MUST
 		// remain readable on the row — Phase 7's audit emit consumes it
-		// to populate the INV-E11 final_missing_members audit field
+		// to populate the INV-CRYPTO-98 final_missing_members audit field
 		// (handled in holomush-jxo8.7.24, not this bead).
 		missing, decodeErr := ckpt.Phase5MissingMembers()
 		Expect(decodeErr).NotTo(HaveOccurred())
@@ -359,9 +359,9 @@ var _ = Describe("Orchestrator Phase 5 rekey", func() {
 
 	// TestOrchestrator_Phase5_ForceDestroy_RejectedOnRepeatedInvocation —
 	// the second force-destroy call sees status=phase6_destroy_old and
-	// rejects via INV-E10. Documents the non-idempotency of force-destroy:
+	// rejects via INV-CRYPTO-97. Documents the non-idempotency of force-destroy:
 	// the operator escape hatch is one-shot per checkpoint.
-	It("ForceDestroy rejected on repeated invocation (INV-E10)", func() {
+	It("ForceDestroy rejected on repeated invocation (INV-CRYPTO-97)", func() {
 		setup := newPhase5TestSetup()
 		rid := setup.RunUpToPhase3Complete()
 
@@ -369,19 +369,19 @@ var _ = Describe("Orchestrator Phase 5 rekey", func() {
 		_ = setup.Orch.RunPhase5(context.Background(), rid)
 		Expect(setup.Orch.RunPhase5WithForceDestroy(context.Background(), rid)).To(Succeed())
 
-		// Second force-destroy: status is now phase6_destroy_old, INV-E10
+		// Second force-destroy: status is now phase6_destroy_old, INV-CRYPTO-97
 		// gate trips again.
 		err := setup.Orch.RunPhase5WithForceDestroy(context.Background(), rid)
 		Expect(err).To(HaveOccurred())
 		errutil.AssertErrorCode(suiteT, err, "DEK_REKEY_FORCE_DESTROY_FORBIDDEN")
 	})
 
-	// TestOrchestrator_Phase5_RejectsWrongStatus — INV-E22 / FSM-precondition
+	// TestOrchestrator_Phase5_RejectsWrongStatus — INV-CRYPTO-109 / FSM-precondition
 	// guard. Phase 5 must refuse to run when the checkpoint is at a status
 	// that isn't a valid entry point (phase3_reencrypt_cold or
 	// phase5_invalidate). Tests the pending-state case as the failure
 	// representative.
-	It("rejects checkpoint in wrong status (INV-E22 FSM precondition)", func() {
+	It("rejects checkpoint in wrong status (INV-CRYPTO-109 FSM precondition)", func() {
 		setup := newPhase5TestSetup()
 		// Open a checkpoint via Open() — status='pending'.
 		req, err := dek.NewCheckpointOpenRequest(

--- a/internal/eventbus/crypto/dek/rekey_phase5_internal_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase5_internal_test.go
@@ -91,7 +91,7 @@ func TestStringifyMember_AllArms(t *testing.T) {
 }
 
 // TestCheckpoint_Phase5HasMissingMembers_Null — the (NULL,
-// "null", "[]") cases all report false. INV-E10's force-destroy gate
+// "null", "[]") cases all report false. INV-CRYPTO-97's force-destroy gate
 // depends on this tolerance: a row with an empty array MUST NOT be
 // treated as "stuck in timeout".
 func TestCheckpoint_Phase5HasMissingMembers_Null(t *testing.T) {

--- a/internal/eventbus/crypto/dek/rekey_phase6.go
+++ b/internal/eventbus/crypto/dek/rekey_phase6.go
@@ -19,7 +19,7 @@ import (
 type Destroyer interface {
 	// DestroyDEK soft-deletes the crypto_keys row by primary key id.
 	// Idempotent: a row already destroyed is a no-op success
-	// (INV-E12-PHASE6-IDEMPOTENT).
+	// (INV-CRYPTO-99).
 	DestroyDEK(ctx context.Context, dekID int64) error
 
 	// EvictCachedDEK removes the DEK's context from the local DEK
@@ -39,7 +39,7 @@ func (o *Orchestrator) SetDestroyer(d Destroyer) {
 	o.dekDestroyer = d
 }
 
-// RunPhase6 destroys the old DEK (INV-E12-PHASE6-IDEMPOTENT) and advances
+// RunPhase6 destroys the old DEK (INV-CRYPTO-99) and advances
 // the checkpoint from phase5_invalidate to phase6_destroy_old.
 //
 // Pre-conditions: checkpoint.Status MUST be CheckpointStatusPhase5Invalidate
@@ -57,7 +57,7 @@ func (o *Orchestrator) SetDestroyer(d Destroyer) {
 //     eviction (other replicas already evicted in Phase 5 cluster invalidation).
 //  5. CAS UPDATE: transition phase5_invalidate → phase6_destroy_old.
 //
-// INV-E12-PHASE6-IDEMPOTENT: a second RunPhase6 invocation on an already-
+// INV-CRYPTO-99: a second RunPhase6 invocation on an already-
 // phase6_destroy_old checkpoint returns nil immediately (step 2). The
 // underlying markDestroyedByPK SQL also uses WHERE destroyed_at IS NULL,
 // making the DB write independently idempotent.
@@ -87,7 +87,7 @@ func (o *Orchestrator) RunPhase6(ctx context.Context, rid RequestID) error {
 		}
 	case CheckpointStatusPhase6DestroyOld:
 		// Idempotent re-invoke: old DEK already destroyed. Return nil
-		// per INV-E12-PHASE6-IDEMPOTENT.
+		// per INV-CRYPTO-99.
 		return nil
 	default:
 		return oops.Code("DEK_REKEY_PHASE_PRECONDITION_FAILED").

--- a/internal/eventbus/crypto/dek/rekey_phase6_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase6_integration_test.go
@@ -111,10 +111,10 @@ func (s *phase6TestSetupImpl) loadDestroyedAt(dekID int64) *pgnanos.Time {
 // Phase 6 — Orchestrator integration specs.
 var _ = Describe("Orchestrator Phase 6", func() {
 	// TestOrchestrator_Phase6_DestroyOldDEK_Idempotent verifies:
-	//   - RunPhase6 advances checkpoint status to phase6_destroy_old (INV-E1)
-	//   - old crypto_keys row has destroyed_at set after Phase 6 (INV-E12)
-	//   - a second RunPhase6 invocation is a no-op (INV-E12-PHASE6-IDEMPOTENT)
-	It("destroys old DEK and is idempotent (INV-E1, INV-E12, INV-E12-PHASE6-IDEMPOTENT)", func() {
+	//   - RunPhase6 advances checkpoint status to phase6_destroy_old (INV-CRYPTO-88)
+	//   - old crypto_keys row has destroyed_at set after Phase 6 (INV-CRYPTO-99)
+	//   - a second RunPhase6 invocation is a no-op (INV-CRYPTO-99)
+	It("destroys old DEK and is idempotent (INV-CRYPTO-88, INV-CRYPTO-99, INV-CRYPTO-99)", func() {
 		setup := newPhase6TestSetup()
 		rid := setup.RunUpToPhase5Complete()
 
@@ -124,27 +124,27 @@ var _ = Describe("Orchestrator Phase 6", func() {
 		ckpt, err := setup.Repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusPhase6DestroyOld),
-			"INV-E1: checkpoint must advance to phase6_destroy_old after RunPhase6")
+			"INV-CRYPTO-88: checkpoint must advance to phase6_destroy_old after RunPhase6")
 
 		destroyedAt := setup.loadDestroyedAt(ckpt.OldDEKID)
 		Expect(destroyedAt).NotTo(BeNil(),
-			"INV-E12: old DEK row must have destroyed_at set after Phase 6")
+			"INV-CRYPTO-99: old DEK row must have destroyed_at set after Phase 6")
 
 		// Second invocation: idempotent — must succeed without error.
 		Expect(setup.Orch.RunPhase6(context.Background(), rid)).To(Succeed(),
-			"INV-E12-PHASE6-IDEMPOTENT: second RunPhase6 on phase6_destroy_old must be a no-op")
+			"INV-CRYPTO-99: second RunPhase6 on phase6_destroy_old must be a no-op")
 
 		// Status must remain phase6_destroy_old (not re-transitioned).
 		ckpt2, err := setup.Repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt2.Status).To(Equal(dek.CheckpointStatusPhase6DestroyOld),
-			"INV-E12-PHASE6-IDEMPOTENT: status must remain phase6_destroy_old after idempotent re-invoke")
+			"INV-CRYPTO-99: status must remain phase6_destroy_old after idempotent re-invoke")
 	})
 
 	// TestOrchestrator_Phase6_RequiresPreconditionPhase5Complete verifies:
 	//   - RunPhase6 rejects a checkpoint not in a valid Phase 6 entry state
-	//     with DEK_REKEY_PHASE_PRECONDITION_FAILED (INV-E1 FSM guard)
-	It("requires phase5_invalidate precondition (INV-E1 FSM guard)", func() {
+	//     with DEK_REKEY_PHASE_PRECONDITION_FAILED (INV-CRYPTO-88 FSM guard)
+	It("requires phase5_invalidate precondition (INV-CRYPTO-88 FSM guard)", func() {
 		setup := newPhase6TestSetup()
 
 		// Seed a checkpoint at 'pending' — not a valid Phase 6 entry point.

--- a/internal/eventbus/crypto/dek/rekey_phase7.go
+++ b/internal/eventbus/crypto/dek/rekey_phase7.go
@@ -20,10 +20,10 @@ import (
 // audit-event emission. The production implementation is *RekeyAuditEmitter
 // (defined in audit.go). Tests may substitute a fake.
 //
-// Emit fills in the rekey_chain block (INV-E14: prev_hash, INV-E28: self_hash)
+// Emit fills in the rekey_chain block (INV-CRYPTO-101: prev_hash, INV-CRYPTO-115: self_hash)
 // and publishes the rekey audit event. Returns the minted event ULID along
 // with the finalized payload (scope/prev_hash/self_hash populated) so the
-// caller can persist the exact record on publish failure (INV-E13 fallback).
+// caller can persist the exact record on publish failure (INV-CRYPTO-100 fallback).
 type AuditEmitter interface {
 	Emit(ctx context.Context, payload RekeyAuditPayload) (ulid.ULID, RekeyAuditPayload, error)
 }
@@ -48,7 +48,7 @@ func (o *Orchestrator) SetAuditEmitter(e AuditEmitter) {
 // log write is skipped (the caller logs the gap at Error level).
 //
 // The fallback log path is: <data_dir>/audit-fallback/rekey-<request_id>.log
-// Per spec §4.3 Phase 7 and INV-E13.
+// Per spec §4.3 Phase 7 and INV-CRYPTO-100.
 func (o *Orchestrator) SetDataDir(dir string) {
 	o.dataDir = dir
 }
@@ -63,18 +63,18 @@ func (o *Orchestrator) SetDataDir(dir string) {
 //  2. Advance status phase6_destroy_old → phase7_audit (CAS UPDATE).
 //  3. Look up old and new DEK rows to populate version numbers in the payload.
 //  4. Build RekeyAuditPayload from the checkpoint row and request.
-//     INV-E25: policy_hash read from checkpoint row, never re-queried.
-//     INV-E11: force_destroy=true and final_missing_members populated when
+//     INV-CRYPTO-112: policy_hash read from checkpoint row, never re-queried.
+//     INV-CRYPTO-98: force_destroy=true and final_missing_members populated when
 //     the force-destroy path was used.
-//  5. Emit via AuditEmitter (INV-E14: prev_hash from ComputePrevHashFor;
-//     INV-E28: self_hash via RecomputeSelfHash).
+//  5. Emit via AuditEmitter (INV-CRYPTO-101: prev_hash from ComputePrevHashFor;
+//     INV-CRYPTO-115: self_hash via RecomputeSelfHash).
 //  6. On emit failure: write fallback log to
-//     <data_dir>/audit-fallback/rekey-<request_id>.log (INV-E13);
+//     <data_dir>/audit-fallback/rekey-<request_id>.log (INV-CRYPTO-100);
 //     return DEK_REKEY_PHASE7_AUDIT_FAILED. Checkpoint stays at phase7_audit
 //     for retry.
 //  7. On emit success: advance status phase7_audit → complete via MarkComplete.
 //
-// INV-E13-PHASE7-AUDIT-OR-FALLBACK: emit confirmed before complete transition.
+// INV-CRYPTO-100: emit confirmed before complete transition.
 func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRequest) (RekeyOutcome, error) {
 	if o.auditEmitter == nil {
 		return RekeyOutcome{}, oops.Code("DEK_REKEY_AUDIT_EMITTER_NIL").
@@ -123,7 +123,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 		newVersion = newRow.Version
 	}
 
-	// Decode missing members for the INV-E11 force-destroy payload field.
+	// Decode missing members for the INV-CRYPTO-98 force-destroy payload field.
 	// Treat decode failure as an empty list — the operator surface will show
 	// an empty list rather than blocking the audit emit.
 	missingMembers, memberErr := ckpt.Phase5MissingMembers()
@@ -139,7 +139,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 		missingMembers = []string{}
 	}
 
-	// Build the audit payload. INV-E25: policy_hash is read from the
+	// Build the audit payload. INV-CRYPTO-112: policy_hash is read from the
 	// checkpoint row (frozen at Phase 1) — never re-queried from the chain.
 	policyHashArr := ckpt.PolicyHash()
 	payload := RekeyAuditPayload{
@@ -153,7 +153,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 			AuthProviderName: req.Operator.AuthProviderName,
 		},
 		Justification: req.Justification,
-		// INV-E25: encoded verbatim from the row — never re-queried.
+		// INV-CRYPTO-112: encoded verbatim from the row — never re-queried.
 		PolicyHash: fmt.Sprintf("sha256:%s", hex.EncodeToString(policyHashArr[:])),
 		Phases: RekeyAuditPhases{
 			Phase3RowsRewritten:       ckpt.Phase3RowsRewritten,
@@ -161,7 +161,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 			Phase5FinalMissingMembers: missingMembers,
 			Phase6DestroyedAt:         time.Now(), // approximate; canonical record is DB state
 		},
-		ForceDestroy:   ckpt.ForceDestroy, // INV-E11: true when force-destroy path used
+		ForceDestroy:   ckpt.ForceDestroy, // INV-CRYPTO-98: true when force-destroy path used
 		StartedAt:      ckpt.StartedAt,
 		CompletedAt:    time.Now(),
 		ServerIdentity: o.serverID,
@@ -177,11 +177,11 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 		}
 	}
 
-	// Step 5: emit via AuditEmitter (INV-E14 + INV-E28 are satisfied by the
+	// Step 5: emit via AuditEmitter (INV-CRYPTO-101 + INV-CRYPTO-115 are satisfied by the
 	// emitter itself — it calls ComputePrevHashFor + RecomputeSelfHash).
 	eventID, finalizedPayload, emitErr := o.auditEmitter.Emit(ctx, payload)
 	if emitErr != nil {
-		// INV-E13: on failure, write fallback log so the rekey record is
+		// INV-CRYPTO-100: on failure, write fallback log so the rekey record is
 		// not silently lost. The rekey state in the DB (DEK rows) is
 		// irreversibly committed; the audit emit is the cross-reference,
 		// not the canonical record. Persist the FINALIZED payload (with
@@ -218,7 +218,7 @@ func (o *Orchestrator) RunPhase7(ctx context.Context, rid RequestID, req RekeyRe
 // <data_dir>/audit-fallback/rekey-<request_id>.log with mode 0600.
 // The directory is created with mode 0700 if it does not already exist.
 //
-// INV-E13: the fallback log is the sole record when Phase 7 audit emission
+// INV-CRYPTO-100: the fallback log is the sole record when Phase 7 audit emission
 // fails. It is NOT the canonical record — that is DB state. Operators MUST
 // consult the operational runbook (§11) for escalation steps.
 func (o *Orchestrator) writeFallbackLog(rid RequestID, p RekeyAuditPayload) error {

--- a/internal/eventbus/crypto/dek/rekey_phase7_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_phase7_integration_test.go
@@ -124,7 +124,7 @@ func (s *phase7TestSetupImpl) RunUpToPhase6Complete() dek.RequestID {
 
 // RunUpToPhase6CompleteWithForceDestroy seeds a checkpoint row at phase6_destroy_old
 // with force_destroy=true and phase5_missing_members populated to simulate
-// the force-destroy path for INV-E11 assertions.
+// the force-destroy path for INV-CRYPTO-98 assertions.
 func (s *phase7TestSetupImpl) RunUpToPhase6CompleteWithForceDestroy(missingMembers string) dek.RequestID {
 	rid := dek.RequestID(idgen.New())
 	_, err := s.pool.Exec(context.Background(), `
@@ -143,11 +143,11 @@ func (s *phase7TestSetupImpl) RunUpToPhase6CompleteWithForceDestroy(missingMembe
 // Phase 7 — Orchestrator integration specs.
 var _ = Describe("Orchestrator Phase 7", func() {
 	// TestOrchestrator_Phase7_EmitsChainedAudit_AdvancesToComplete verifies:
-	//   - RunPhase7 emits the rekey audit event via the audit emitter (INV-E14)
+	//   - RunPhase7 emits the rekey audit event via the audit emitter (INV-CRYPTO-101)
 	//   - outcome.AuditEventID is non-empty
-	//   - checkpoint advances to status=complete (INV-E1)
+	//   - checkpoint advances to status=complete (INV-CRYPTO-88)
 	//   - completed_at is set
-	It("emits chained audit and advances to complete (INV-E14, INV-E1)", func() {
+	It("emits chained audit and advances to complete (INV-CRYPTO-101, INV-CRYPTO-88)", func() {
 		setup := newPhase7TestSetup()
 		rid := setup.RunUpToPhase6Complete()
 
@@ -159,12 +159,12 @@ var _ = Describe("Orchestrator Phase 7", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(outcome.AuditEventID).NotTo(BeEmpty(),
-			"INV-E14: AuditEventID must be populated after Phase 7")
+			"INV-CRYPTO-101: AuditEventID must be populated after Phase 7")
 
 		ckpt, err := setup.Repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusComplete),
-			"INV-E1: checkpoint must advance to complete after RunPhase7")
+			"INV-CRYPTO-88: checkpoint must advance to complete after RunPhase7")
 		Expect(ckpt.CompletedAt).NotTo(BeNil(),
 			"completed_at must be set after Phase 7")
 
@@ -175,11 +175,11 @@ var _ = Describe("Orchestrator Phase 7", func() {
 		Expect(emittedPayload.Context.ID).To(Equal("01PH7"))
 	})
 
-	// TestOrchestrator_Phase7_AuditEmitFailure_FallbackLog verifies (INV-E13):
+	// TestOrchestrator_Phase7_AuditEmitFailure_FallbackLog verifies (INV-CRYPTO-100):
 	//   - on audit emit failure, RunPhase7 returns DEK_REKEY_PHASE7_AUDIT_FAILED
 	//   - the fallback log file is written at <data_dir>/audit-fallback/rekey-<rid>.log
 	//   - the checkpoint does NOT advance to complete (DB state is preserved)
-	It("audit emit failure writes fallback log and does not advance checkpoint (INV-E13)", func() {
+	It("audit emit failure writes fallback log and does not advance checkpoint (INV-CRYPTO-100)", func() {
 		setup := newPhase7TestSetup()
 		rid := setup.RunUpToPhase6Complete()
 		setup.AuditEmitter.SetEmitErrorForTest(errors.New("simulated emit failure"))
@@ -192,23 +192,23 @@ var _ = Describe("Orchestrator Phase 7", func() {
 		Expect(err).To(HaveOccurred())
 		errutil.AssertErrorCode(suiteT, err, "DEK_REKEY_PHASE7_AUDIT_FAILED")
 
-		// INV-E13: fallback log written to <data_dir>/audit-fallback/rekey-<rid>.log.
+		// INV-CRYPTO-100: fallback log written to <data_dir>/audit-fallback/rekey-<rid>.log.
 		logPath := filepath.Join(setup.DataDir, "audit-fallback", "rekey-"+rid.String()+".log")
 		Expect(logPath).To(BeAnExistingFile(),
-			"INV-E13: fallback log must be written on audit emit failure")
+			"INV-CRYPTO-100: fallback log must be written on audit emit failure")
 
 		// The checkpoint must NOT be at complete — rekey DB state is committed,
 		// but the phase7_audit status means retry is possible.
 		ckpt, cerr := setup.Repo.Get(context.Background(), rid)
 		Expect(cerr).NotTo(HaveOccurred())
 		Expect(ckpt.Status).NotTo(Equal(dek.CheckpointStatusComplete),
-			"INV-E13: checkpoint must not advance to complete on audit emit failure")
+			"INV-CRYPTO-100: checkpoint must not advance to complete on audit emit failure")
 	})
 
-	// TestOrchestrator_Phase7_ForceDestroyPath_AuditCaptures verifies (INV-E11):
+	// TestOrchestrator_Phase7_ForceDestroyPath_AuditCaptures verifies (INV-CRYPTO-98):
 	//   - when force_destroy=true on the checkpoint, the emitted payload has
 	//     ForceDestroy=true and the missing_members list is non-nil.
-	It("force-destroy path audit captures ForceDestroy and missing_members (INV-E11)", func() {
+	It("force-destroy path audit captures ForceDestroy and missing_members (INV-CRYPTO-98)", func() {
 		setup := newPhase7TestSetup()
 		rid := setup.RunUpToPhase6CompleteWithForceDestroy(`["m1","m2"]`)
 
@@ -220,19 +220,19 @@ var _ = Describe("Orchestrator Phase 7", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		// INV-E11: audit payload must capture force_destroy and missing_members.
+		// INV-CRYPTO-98: audit payload must capture force_destroy and missing_members.
 		Expect(setup.AuditEmitter.emitted).To(HaveLen(1))
 		p := setup.AuditEmitter.emitted[0]
 		Expect(p.ForceDestroy).To(BeTrue(),
-			"INV-E11: audit payload must have force_destroy=true")
+			"INV-CRYPTO-98: audit payload must have force_destroy=true")
 		Expect(p.Phases.Phase5FinalMissingMembers).To(ConsistOf("m1", "m2"),
-			"INV-E11: audit payload must embed final_missing_members from the checkpoint")
+			"INV-CRYPTO-98: audit payload must embed final_missing_members from the checkpoint")
 	})
 
 	// TestOrchestrator_Phase7_RequiresPreconditionPhase6Complete verifies:
 	//   - RunPhase7 with a checkpoint not in phase6_destroy_old returns
-	//     DEK_REKEY_PHASE_PRECONDITION_FAILED (INV-E1 FSM guard).
-	It("requires phase6_destroy_old precondition (INV-E1 FSM guard)", func() {
+	//     DEK_REKEY_PHASE_PRECONDITION_FAILED (INV-CRYPTO-88 FSM guard).
+	It("requires phase6_destroy_old precondition (INV-CRYPTO-88 FSM guard)", func() {
 		pool := testIntegrationPool(suiteT)
 		const gameID = "g1"
 		dek.SetGameIDForTest(gameID)

--- a/internal/eventbus/crypto/dek/rekey_run.go
+++ b/internal/eventbus/crypto/dek/rekey_run.go
@@ -41,7 +41,7 @@ const (
 	// resumeEntryPhase5ForceDestroy: status = phase5_invalidate with
 	// phase5_missing_members IS NOT NULL and req.ForceDestroy == true.
 	// The operator chose the split-brain escape hatch; the dispatcher
-	// invokes RunPhase5WithForceDestroy. INV-E10's gate is checked inside
+	// invokes RunPhase5WithForceDestroy. INV-CRYPTO-97's gate is checked inside
 	// that method.
 	resumeEntryPhase5ForceDestroy
 
@@ -55,7 +55,7 @@ const (
 	resumeEntryPhase7
 
 	// resumeEntryComplete: status = complete (terminal success). Resume is
-	// idempotent (INV-E16): Run returns the prior outcome without invoking
+	// idempotent (INV-CRYPTO-103): Run returns the prior outcome without invoking
 	// any phase.
 	resumeEntryComplete
 
@@ -103,7 +103,7 @@ func decideResumeEntry(status CheckpointStatus, hasMissingMembers, forceDestroy 
 		// Phase 7 advanced status before the audit emit failed. The FSM
 		// guard inside RunPhase7 only accepts phase6_destroy_old; we
 		// surface a manual-recovery signal rather than silently retrying
-		// in a way that breaks INV-E1.
+		// in a way that breaks INV-CRYPTO-88.
 		return resumeEntryManual, true
 	case CheckpointStatusComplete:
 		return resumeEntryComplete, false
@@ -123,20 +123,20 @@ func decideResumeEntry(status CheckpointStatus, hasMissingMembers, forceDestroy 
 //   - Fresh-start path: no non-terminal checkpoint exists for
 //     (context_type, context_id). Run computes op_args_hash, opens a new
 //     checkpoint via RunPhase1Fresh, then drives the lifecycle to completion.
-//   - Resume path (INV-E16): a non-terminal checkpoint exists with
+//   - Resume path (INV-CRYPTO-103): a non-terminal checkpoint exists with
 //     op_args_hash matching the request AND primary_player_id matching the
-//     operator's player_id. Run picks up the existing RequestID (INV-E4:
+//     operator's player_id. Run picks up the existing RequestID (INV-CRYPTO-91:
 //     never re-enter Phase 1) and drives the remaining phases.
-//   - Operator-mismatch (INV-E16): matching op_args_hash but different
+//   - Operator-mismatch (INV-CRYPTO-103): matching op_args_hash but different
 //     primary_player_id → DEK_REKEY_RESUME_OPERATOR_MISMATCH.
 //   - Args-conflict: non-terminal checkpoint with DIFFERENT op_args_hash
 //     on the same context → DEK_REKEY_ARGS_CONFLICT.
-//   - Already-complete (INV-E16 idempotency): if a terminal-complete row
+//   - Already-complete (INV-CRYPTO-103 idempotency): if a terminal-complete row
 //     exists matching args, that row is treated as terminal and the
 //     dispatcher proceeds to fresh-start (per FindByContextAndArgs scope,
 //     which already filters terminal rows out of the resume predicate).
 //
-// req.ForceDestroy is only honored on the resume path (INV-E11): a fresh
+// req.ForceDestroy is only honored on the resume path (INV-CRYPTO-98): a fresh
 // rekey never bypasses Phase 5 invalidation.
 func (o *Orchestrator) Run(ctx context.Context, req RekeyRequest) (RekeyOutcome, error) {
 	argsHash, err := ComputeRekeyArgsHash(req)
@@ -144,7 +144,7 @@ func (o *Orchestrator) Run(ctx context.Context, req RekeyRequest) (RekeyOutcome,
 		return RekeyOutcome{}, err
 	}
 
-	// INV-E16 resume predicate: same context + same args + non-terminal status.
+	// INV-CRYPTO-103 resume predicate: same context + same args + non-terminal status.
 	existing, found, err := o.repo.FindByContextAndArgs(ctx, req.ContextType, req.ContextID, argsHash[:])
 	if err != nil {
 		return RekeyOutcome{}, oops.Code("DEK_REKEY_RESUME_LOOKUP_FAILED").Wrap(err)
@@ -153,13 +153,13 @@ func (o *Orchestrator) Run(ctx context.Context, req RekeyRequest) (RekeyOutcome,
 	var rid RequestID
 	resumed := false
 	if found {
-		// Operator-binding check (INV-E16-AUTH-RESUME-NOAPPROVAL).
+		// Operator-binding check (INV-CRYPTO-103).
 		if existing.PrimaryPlayerID != req.Operator.PlayerID {
 			return RekeyOutcome{}, oops.Code("DEK_REKEY_RESUME_OPERATOR_MISMATCH").
 				With("expected_player_id", existing.PrimaryPlayerID).
 				With("got_player_id", req.Operator.PlayerID).
 				With("request_id", existing.RequestID.String()).
-				Errorf("INV-E16: only the original primary may resume")
+				Errorf("INV-CRYPTO-103: only the original primary may resume")
 		}
 		rid = existing.RequestID
 		resumed = true
@@ -210,7 +210,7 @@ func (o *Orchestrator) driveToCompletion(ctx context.Context, rid RequestID, req
 	// invoking any phase.
 	switch entry {
 	case resumeEntryComplete:
-		// INV-E16 idempotency: return the prior outcome. The original
+		// INV-CRYPTO-103 idempotency: return the prior outcome. The original
 		// AuditEventID is not stored on the checkpoint (it lives only on
 		// the events_audit row), so we synthesise a minimal RekeyOutcome
 		// from the row. Callers needing the audit event ID query
@@ -280,11 +280,11 @@ func (o *Orchestrator) driveToCompletion(ctx context.Context, rid RequestID, req
 		}
 		return o.runPhase7AndSetResumed(ctx, rid, req, resumed)
 	case resumeEntryPhase5ForceDestroy:
-		// Operator chose the split-brain escape (INV-E10 / INV-E11).
+		// Operator chose the split-brain escape (INV-CRYPTO-97 / INV-CRYPTO-98).
 		// RunPhase5WithForceDestroy advances directly to phase6_destroy_old
 		// without invoking the destroyer; we still call RunPhase6 to
 		// soft-delete the row (it observes phase6_destroy_old and runs
-		// idempotently — see INV-E12 in rekey_phase6.go).
+		// idempotently — see INV-CRYPTO-99 in rekey_phase6.go).
 		if err := o.RunPhase5WithForceDestroy(ctx, rid); err != nil {
 			return RekeyOutcome{}, err
 		}
@@ -330,7 +330,7 @@ func (o *Orchestrator) runPhase7AndSetResumed(ctx context.Context, rid RequestID
 //  1. Loads the checkpoint row (error on DEK_REKEY_CHECKPOINT_NOT_FOUND).
 //  2. Verifies the checkpoint is non-terminal (returns
 //     DEK_REKEY_CHECKPOINT_TERMINAL on status=complete or status=aborted).
-//  3. Enforces the operator-binding invariant (INV-E16): if the checkpoint's
+//  3. Enforces the operator-binding invariant (INV-CRYPTO-103): if the checkpoint's
 //     primary_player_id does not match req.Operator.PlayerID, returns
 //     DEK_REKEY_RESUME_OPERATOR_MISMATCH.
 //  4. Calls driveToCompletion with the checkpoint's ContextType, ContextID,
@@ -338,7 +338,7 @@ func (o *Orchestrator) runPhase7AndSetResumed(ctx context.Context, rid RequestID
 //     RunPhase7's audit payload carries the operator's original justification
 //     on the explicit-resume path).
 //
-// req.ForceDestroy is honored on the resume path per INV-E11.
+// req.ForceDestroy is honored on the resume path per INV-CRYPTO-98.
 func (o *Orchestrator) RunByRequestID(ctx context.Context, rid RequestID, req RekeyRequest) (RekeyOutcome, error) {
 	ckpt, err := o.repo.Get(ctx, rid)
 	if err != nil {
@@ -360,13 +360,13 @@ func (o *Orchestrator) RunByRequestID(ctx context.Context, rid RequestID, req Re
 			Errorf("checkpoint already aborted; open a fresh rekey to retry")
 	}
 
-	// INV-E16: only the original primary operator may resume.
+	// INV-CRYPTO-103: only the original primary operator may resume.
 	if ckpt.PrimaryPlayerID != req.Operator.PlayerID {
 		return RekeyOutcome{}, oops.Code("DEK_REKEY_RESUME_OPERATOR_MISMATCH").
 			With("expected_player_id", ckpt.PrimaryPlayerID).
 			With("got_player_id", req.Operator.PlayerID).
 			With("request_id", rid.String()).
-			Errorf("INV-E16: only the original primary operator may resume")
+			Errorf("INV-CRYPTO-103: only the original primary operator may resume")
 	}
 
 	// Populate context fields from the stored checkpoint row so RunPhase7's

--- a/internal/eventbus/crypto/dek/rekey_run_integration_test.go
+++ b/internal/eventbus/crypto/dek/rekey_run_integration_test.go
@@ -94,7 +94,7 @@ func (s *runTestSetup) BasicRequest(playerID string) dek.RekeyRequest {
 	}
 }
 
-var _ = Describe("Orchestrator_Run_FreshStart_RunsAllPhases (INV-E1)", func() {
+var _ = Describe("Orchestrator_Run_FreshStart_RunsAllPhases (INV-CRYPTO-88)", func() {
 	It("drives all phases and lands checkpoint at complete with Resumed=false", func() {
 		setup := newRunTestSetup("01RUN1")
 		req := setup.BasicRequest("01PRIM")
@@ -107,13 +107,13 @@ var _ = Describe("Orchestrator_Run_FreshStart_RunsAllPhases (INV-E1)", func() {
 		ckpt, err := setup.Repo.Get(context.Background(), out.RequestID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusComplete),
-			"INV-E1: fresh-start must drive the checkpoint to complete")
+			"INV-CRYPTO-88: fresh-start must drive the checkpoint to complete")
 		Expect(ckpt.CompletedAt).NotTo(BeNil())
 		Expect(setup.Audit.emitted).To(HaveLen(1), "Phase 7 must emit exactly once")
 	})
 })
 
-var _ = Describe("Orchestrator_Run_Resume_MatchingArgs_BypassesApproval (INV-E16)", func() {
+var _ = Describe("Orchestrator_Run_Resume_MatchingArgs_BypassesApproval (INV-CRYPTO-103)", func() {
 	It("re-uses existing RequestID and signals Resumed=true for same-args same-operator invocation", func() {
 		setup := newRunTestSetup("01RUN2")
 		req := setup.BasicRequest("01PRIM")
@@ -129,9 +129,9 @@ var _ = Describe("Orchestrator_Run_Resume_MatchingArgs_BypassesApproval (INV-E16
 		out, err := setup.Orch.Run(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out.Resumed).To(BeTrue(),
-			"INV-E16: same-args same-operator invocation must signal Resumed=true")
+			"INV-CRYPTO-103: same-args same-operator invocation must signal Resumed=true")
 		Expect(out.RequestID).To(Equal(rid),
-			"INV-E4: resume must re-use the existing RequestID, not allocate a new one")
+			"INV-CRYPTO-91: resume must re-use the existing RequestID, not allocate a new one")
 
 		ckpt, err := setup.Repo.Get(context.Background(), out.RequestID)
 		Expect(err).NotTo(HaveOccurred())
@@ -139,7 +139,7 @@ var _ = Describe("Orchestrator_Run_Resume_MatchingArgs_BypassesApproval (INV-E16
 	})
 })
 
-var _ = Describe("Orchestrator_Run_Resume_DifferentOperator_Rejected (INV-E16)", func() {
+var _ = Describe("Orchestrator_Run_Resume_DifferentOperator_Rejected (INV-CRYPTO-103)", func() {
 	It("rejects resume with DEK_REKEY_RESUME_OPERATOR_MISMATCH for a different operator", func() {
 		setup := newRunTestSetup("01RUN3")
 		req := setup.BasicRequest("01PRIM")
@@ -173,7 +173,7 @@ var _ = Describe("Orchestrator_Run_ArgsConflict", func() {
 	})
 })
 
-var _ = Describe("Orchestrator_Run_AfterPriorComplete_FreshStartSucceeds (INV-E16)", func() {
+var _ = Describe("Orchestrator_Run_AfterPriorComplete_FreshStartSucceeds (INV-CRYPTO-103)", func() {
 	It("succeeds as a new fresh rekey and emits a second audit event after the prior completed rekey", func() {
 		setup := newRunTestSetup("01RUN5")
 		req := setup.BasicRequest("01PRIM")
@@ -196,7 +196,7 @@ var _ = Describe("Orchestrator_Run_AfterPriorComplete_FreshStartSucceeds (INV-E1
 	})
 })
 
-var _ = Describe("Orchestrator_Run_NeverReentersPhase1 (INV-E4)", func() {
+var _ = Describe("Orchestrator_Run_NeverReentersPhase1 (INV-CRYPTO-91)", func() {
 	It("reuses the original RequestID on resume and does not re-enter Phase 1", func() {
 		setup := newRunTestSetup("01RUN6")
 		req := setup.BasicRequest("01PRIM")
@@ -207,7 +207,7 @@ var _ = Describe("Orchestrator_Run_NeverReentersPhase1 (INV-E4)", func() {
 		out, err := setup.Orch.Run(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out.RequestID).To(Equal(rid),
-			"INV-E4: resume MUST NOT re-enter Phase 1 — RequestID must be stable")
+			"INV-CRYPTO-91: resume MUST NOT re-enter Phase 1 — RequestID must be stable")
 		Expect(out.Resumed).To(BeTrue())
 	})
 })
@@ -248,7 +248,7 @@ var _ = Describe("Orchestrator_Run_ResumeFromAborted_TerminalError", func() {
 	})
 })
 
-var _ = Describe("Orchestrator_Run_DispatchFromPhase5Timeout_ForceDestroy (INV-E11)", func() {
+var _ = Describe("Orchestrator_Run_DispatchFromPhase5Timeout_ForceDestroy (INV-CRYPTO-98)", func() {
 	It("routes to RunPhase5WithForceDestroy and completes when ForceDestroy=true", func() {
 		setup := newRunTestSetup("01RUN8")
 		req := setup.BasicRequest("01PRIM")
@@ -285,11 +285,11 @@ var _ = Describe("Orchestrator_Run_DispatchFromPhase5Timeout_ForceDestroy (INV-E
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusComplete))
 		Expect(ckpt.ForceDestroy).To(BeTrue(),
-			"INV-E11: force-destroy must be recorded on the checkpoint")
+			"INV-CRYPTO-98: force-destroy must be recorded on the checkpoint")
 	})
 })
 
-var _ = Describe("Orchestrator_Run_DispatchFromPhase6 (INV-E12)", func() {
+var _ = Describe("Orchestrator_Run_DispatchFromPhase6 (INV-CRYPTO-99)", func() {
 	It("skips Phases 1-5 and runs Phase 6 idempotently then Phase 7 to complete", func() {
 		setup := newRunTestSetup("01RUN9")
 		req := setup.BasicRequest("01PRIM")
@@ -321,7 +321,7 @@ var _ = Describe("Orchestrator_Run_DispatchFromPhase6 (INV-E12)", func() {
 	})
 })
 
-var _ = Describe("Orchestrator_Run_ResumeFromPhase7Audit_ManualRecovery (INV-E4, INV-E1)", func() {
+var _ = Describe("Orchestrator_Run_ResumeFromPhase7Audit_ManualRecovery (INV-CRYPTO-91, INV-CRYPTO-88)", func() {
 	It("surfaces DEK_REKEY_PHASE7_AUDIT_RETRY_REQUIRED for a checkpoint stuck at phase7_audit", func() {
 		setup := newRunTestSetup("01RUN10")
 		req := setup.BasicRequest("01PRIM")
@@ -366,7 +366,7 @@ var _ = Describe("Orchestrator_RunByRequestID_PreservesJustificationInAudit (hol
 
 		// Resume via RunByRequestID — operator supplies a DIFFERENT
 		// justification on the resume request. This pins the
-		// rehydration-wins semantic (INV-E25 analog): the checkpoint row's
+		// rehydration-wins semantic (INV-CRYPTO-112 analog): the checkpoint row's
 		// Justification is authoritative, the resume-call value MUST be
 		// ignored. Without this sentinel, a regression that accidentally
 		// honored req.Justification would only be caught if the resume
@@ -391,7 +391,7 @@ var _ = Describe("Orchestrator_RunByRequestID_PreservesJustificationInAudit (hol
 		Expect(emittedPayload.Justification).To(Equal(originalJustification),
 			"RunByRequestID must rehydrate justification from checkpoint row into Phase 7 audit payload")
 		Expect(emittedPayload.Justification).NotTo(Equal(overrideAttempt),
-			"resume-call Justification MUST NOT win over the stored checkpoint value (INV-E25 analog)")
+			"resume-call Justification MUST NOT win over the stored checkpoint value (INV-CRYPTO-112 analog)")
 
 		// Sanity: checkpoint reached complete.
 		ckpt, err := setup.Repo.Get(context.Background(), rid)

--- a/internal/eventbus/crypto/dek/rekey_run_internal_test.go
+++ b/internal/eventbus/crypto/dek/rekey_run_internal_test.go
@@ -13,7 +13,7 @@ import (
 // non-terminal FSM state has a defined resume entry decision. The Resume
 // dispatcher (Orchestrator.Run) consumes this decision to pick the first
 // RunPhaseN to invoke; missing coverage would manifest as a silent
-// fall-through to a default error path (INV-E4 violation: never
+// fall-through to a default error path (INV-CRYPTO-91 violation: never
 // re-enter Phase 1 when a checkpoint exists).
 //
 // This is a unit-level meta-test: it does NOT touch the database; it
@@ -58,7 +58,7 @@ func TestDecideResumeEntry_NonTerminalStatusCoverage(t *testing.T) {
 func TestDecideResumeEntry_TerminalStates(t *testing.T) {
 	entry, _ := decideResumeEntry(CheckpointStatusComplete, false, false)
 	require.Equal(t, resumeEntryComplete, entry,
-		"INV-E16: complete checkpoint is idempotent no-op")
+		"INV-CRYPTO-103: complete checkpoint is idempotent no-op")
 
 	entry, _ = decideResumeEntry(CheckpointStatusAborted, false, false)
 	require.Equal(t, resumeEntryAborted, entry,

--- a/internal/eventbus/crypto/dek/store.go
+++ b/internal/eventbus/crypto/dek/store.go
@@ -324,7 +324,7 @@ func (s *Store) markDestroyed(ctx context.Context, keyID codec.KeyID, version ui
 // markDestroyedByPK sets destroyed_at on the crypto_keys row with the
 // given primary key id. Idempotent: a row already destroyed (destroyed_at IS
 // NOT NULL) is unaffected — zero rows updated is a no-op success, satisfying
-// INV-E12-PHASE6-IDEMPOTENT. Used by Phase 6 of the Rekey orchestrator.
+// INV-CRYPTO-99. Used by Phase 6 of the Rekey orchestrator.
 func (s *Store) markDestroyedByPK(ctx context.Context, dekID int64) error {
 	_, err := s.pool.Exec(
 		ctx, `
@@ -417,7 +417,7 @@ func (s *Store) selectByPK(ctx context.Context, id int64) (row, error) {
 
 // insertRekeyed INSERTs a crypto_keys row at version = old.Version+1 with
 // the same participants column bytes as old (re-marshaled from the same Go
-// slice). Used by Phase 2 to mint the new DEK with INV-E6-PARTICIPANT-INVARIANCE.
+// slice). Used by Phase 2 to mint the new DEK with INV-CRYPTO-93.
 // Returns the new row's primary key id.
 func (s *Store) insertRekeyed(ctx context.Context, old row, wrapped []byte, wrapKeyID string) (int64, error) {
 	participantsJSON, err := json.Marshal(old.Participants)

--- a/internal/eventbus/crypto/dek/sweep.go
+++ b/internal/eventbus/crypto/dek/sweep.go
@@ -6,7 +6,7 @@
 // CheckpointSweepSubsystem runs a boot-time sweep followed by a periodic
 // background scan that aborts non-terminal checkpoints whose last_heartbeat_at
 // is older than TTL (default 24h). Each abort emits a chained rekey audit
-// event satisfying INV-E18-SWEEP-TTL-AUDIT.
+// event satisfying INV-CRYPTO-105.
 //
 // The subsystem depends on SubsystemCryptoChainVerifier (chain integrity
 // confirmed before any new emission), SubsystemEventBus, and
@@ -152,7 +152,7 @@ func (s *CheckpointSweepSubsystem) SweepOnceForTest(ctx context.Context) error {
 }
 
 // abortAndAudit marks the checkpoint aborted via a CAS UPDATE then
-// emits a chained audit event. INV-E18-SWEEP-TTL-AUDIT.
+// emits a chained audit event. INV-CRYPTO-105.
 func (s *CheckpointSweepSubsystem) abortAndAudit(ctx context.Context, ckpt Checkpoint, reason string) error {
 	if err := s.cfg.Repo.MarkAborted(ctx, ckpt.RequestID, reason); err != nil {
 		return oops.Code("DEK_REKEY_SWEEP_ABORT_FAILED").Wrap(err)

--- a/internal/eventbus/crypto/dek/sweep_integration_test.go
+++ b/internal/eventbus/crypto/dek/sweep_integration_test.go
@@ -91,7 +91,7 @@ func (s *rekeyTestSetup) LoadEventsAuditBySubject(subject string) []capturedPubl
 	return out
 }
 
-var _ = Describe("Sweep_TTLExpiryEmitsAudit (INV-E18-SWEEP-TTL-AUDIT)", func() {
+var _ = Describe("Sweep_TTLExpiryEmitsAudit (INV-CRYPTO-105)", func() {
 	It("aborts a TTL-expired checkpoint and emits a chained rekey audit event with aborted_reason=ttl_expired", func() {
 		setup := newRekeyTestSetup()
 
@@ -111,15 +111,15 @@ var _ = Describe("Sweep_TTLExpiryEmitsAudit (INV-E18-SWEEP-TTL-AUDIT)", func() {
 		ckpt, err := setup.Repo.Get(context.Background(), rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt.Status).To(Equal(dek.CheckpointStatusAborted),
-			"INV-E18: TTL-expired checkpoint MUST be marked aborted by sweep")
+			"INV-CRYPTO-105: TTL-expired checkpoint MUST be marked aborted by sweep")
 		Expect(ckpt.AbortedReason).NotTo(BeNil())
 		Expect(*ckpt.AbortedReason).To(Equal("ttl_expired"),
-			"INV-E18: aborted_reason MUST be ttl_expired")
+			"INV-CRYPTO-105: aborted_reason MUST be ttl_expired")
 
-		// INV-E18: chained audit event MUST be emitted for the aborted context.
+		// INV-CRYPTO-105: chained audit event MUST be emitted for the aborted context.
 		events := setup.LoadEventsAuditBySubject("events.g1.system.rekey.scene.01ABC")
 		Expect(len(events)).To(BeNumerically(">=", 1),
-			"INV-E18: sweep MUST emit a chained audit event for each aborted checkpoint")
+			"INV-CRYPTO-105: sweep MUST emit a chained audit event for each aborted checkpoint")
 
 		// Verify the emitted payload contains the expected context and reason.
 		var payload dek.RekeyAuditPayload
@@ -127,7 +127,7 @@ var _ = Describe("Sweep_TTLExpiryEmitsAudit (INV-E18-SWEEP-TTL-AUDIT)", func() {
 		Expect(payload.Context.Type).To(Equal("scene"))
 		Expect(payload.Context.ID).To(Equal("01ABC"))
 		Expect(payload.Justification).To(ContainSubstring("ttl_expired"),
-			"INV-E18: audit payload Justification MUST reference ttl_expired")
+			"INV-CRYPTO-105: audit payload Justification MUST reference ttl_expired")
 	})
 })
 

--- a/internal/eventbus/history/dispatcher.go
+++ b/internal/eventbus/history/dispatcher.go
@@ -64,12 +64,12 @@ func newDispatcher(opts ...DispatcherOption) *dispatcher {
 // short-circuits; AuthGuard decision gates decryption; plugin decrypts
 // produce an audit record.
 //
-// INV-E20: AAD is constructed from resolved.Envelope's fields, not the
+// INV-CRYPTO-107: AAD is constructed from resolved.Envelope's fields, not the
 // original envelope parameter. For TierColdFallback, resolved.Envelope
 // carries the cold-tier substitute proto bytes; its keyID/keyVersion supply
 // the DEK reference that was used to re-encrypt during Rekey.
 //
-// INV-E21: when resolver returns ErrMetadataOnly (double miss), the event is
+// INV-CRYPTO-108: when resolver returns ErrMetadataOnly (double miss), the event is
 // delivered with MetadataOnly=true and empty payload.
 func (d *dispatcher) DispatchFor(
 	ctx context.Context,
@@ -139,7 +139,7 @@ func (d *dispatcher) DispatchFor(
 
 	resolved, err := d.resolver.Resolve(ctx, hotEnv)
 	if errors.Is(err, source.ErrMetadataOnly) {
-		// INV-E21: double miss — deliver metadata-only, no error.
+		// INV-CRYPTO-108: double miss — deliver metadata-only, no error.
 		ev := buildHistoryEventFromEnvelope(eventID, envelope, nil)
 		ev.NoPlaintextReason = eventbus.NoPlaintextReasonStaleDEK
 		return ev, true, nil
@@ -150,7 +150,7 @@ func (d *dispatcher) DispatchFor(
 			Wrap(err)
 	}
 
-	// INV-E20: AAD and ciphertext come from resolved.Envelope, not the
+	// INV-CRYPTO-107: AAD and ciphertext come from resolved.Envelope, not the
 	// original envelope. For TierColdFallback, resolved.Envelope carries
 	// the cold-tier proto bytes (marshaled eventbusv1.Event); we unmarshal
 	// them to obtain the cold envelope's Subject/Type/Actor/Timestamp
@@ -175,7 +175,7 @@ func (d *dispatcher) DispatchFor(
 		ciphertext = resolved.Envelope.Payload()
 	}
 
-	// INV-E20: AAD is built from activeProto (resolved envelope's fields).
+	// INV-CRYPTO-107: AAD is built from activeProto (resolved envelope's fields).
 	aadBytes, err := aad.Build(activeProto, string(codecName), uint64(resolved.KeyID), resolved.KeyVersion)
 	if err != nil {
 		return eventbus.Event{}, false, oops.Code("EVENTBUS_AAD_BUILD_FAILED").Wrap(err)

--- a/internal/eventbus/history/dispatcher_errors_test.go
+++ b/internal/eventbus/history/dispatcher_errors_test.go
@@ -372,7 +372,7 @@ func TestDispatcher_PluginAuditQueueFullProducesMetadataOnly(t *testing.T) {
 }
 
 // TestDispatcher_StaleDEKProducesMetadataOnlyWithStaleDEKReason verifies
-// INV-E21: when the resolver returns ErrMetadataOnly (hot+cold double miss),
+// INV-CRYPTO-108: when the resolver returns ErrMetadataOnly (hot+cold double miss),
 // the event is delivered with metadataOnly=true and NoPlaintextReasonStaleDEK
 // (holomush-ojw1.6, dispatcher.go:141-143).
 func TestDispatcher_StaleDEKProducesMetadataOnlyWithStaleDEKReason(t *testing.T) {
@@ -398,7 +398,7 @@ func TestDispatcher_StaleDEKProducesMetadataOnlyWithStaleDEKReason(t *testing.T)
 		&dispatcherAlwaysPermitGuard{},
 		nil,
 	)
-	require.NoError(t, err, "INV-E21: ErrMetadataOnly must not surface as an error")
+	require.NoError(t, err, "INV-CRYPTO-108: ErrMetadataOnly must not surface as an error")
 	assert.True(t, metaOnly, "stale-DEK double miss must stamp metadataOnly=true")
 	assert.Empty(t, ev.Payload, "stale-DEK double miss must redact payload")
 	assert.Equal(t, eventbus.NoPlaintextReasonStaleDEK, ev.NoPlaintextReason,

--- a/internal/eventbus/history/dispatcher_test.go
+++ b/internal/eventbus/history/dispatcher_test.go
@@ -80,7 +80,7 @@ func TestDispatcherIdentityCodecPassesThroughResolver(t *testing.T) {
 	assert.Equal(t, []byte("hello via resolver path"), ev.Payload)
 }
 
-// TestDispatcher_AADFromResolvedEnvelope verifies INV-E20: when the resolver
+// TestDispatcher_AADFromResolvedEnvelope verifies INV-CRYPTO-107: when the resolver
 // returns a TierColdFallback result, the dispatcher builds AAD from the cold
 // (resolved) envelope's fields, not the original hot envelope's fields.
 //
@@ -102,7 +102,7 @@ func TestDispatcher_AADFromResolvedEnvelope(t *testing.T) {
 		Type:      "scene.pose",
 		Timestamp: timestamppb.New(dispatcherTestEpoch()),
 	}
-	// Build AAD from cold proto's fields (INV-E20 requires dispatcher to use these).
+	// Build AAD from cold proto's fields (INV-CRYPTO-107 requires dispatcher to use these).
 	coldAADBytes, err := aad.Build(coldProto, string(codec.NameXChaCha20v1), uint64(testKey.ID), testKey.Version)
 	require.NoError(t, err)
 
@@ -161,11 +161,11 @@ func TestDispatcher_AADFromResolvedEnvelope(t *testing.T) {
 		guard,
 		nil,
 	)
-	// INV-E20: must succeed — cold AAD was used.
-	require.NoError(t, dispErr, "INV-E20: dispatcher must use cold envelope fields for AAD after fallback")
+	// INV-CRYPTO-107: must succeed — cold AAD was used.
+	require.NoError(t, dispErr, "INV-CRYPTO-107: dispatcher must use cold envelope fields for AAD after fallback")
 }
 
-// TestDispatcher_MetadataOnlyDeliveryOnDoubleMiss verifies INV-E21: when the
+// TestDispatcher_MetadataOnlyDeliveryOnDoubleMiss verifies INV-CRYPTO-108: when the
 // resolver returns ErrMetadataOnly (double miss), the dispatcher delivers
 // the event with MetadataOnly=true and empty Payload, with no error.
 func TestDispatcher_MetadataOnlyDeliveryOnDoubleMiss(t *testing.T) {
@@ -191,10 +191,10 @@ func TestDispatcher_MetadataOnlyDeliveryOnDoubleMiss(t *testing.T) {
 		guard,
 		nil,
 	)
-	// INV-E21: ErrMetadataOnly MUST produce (event, metadataOnly=true, nil).
-	require.NoError(t, err, "INV-E21: ErrMetadataOnly must not surface as an error")
+	// INV-CRYPTO-108: ErrMetadataOnly MUST produce (event, metadataOnly=true, nil).
+	require.NoError(t, err, "INV-CRYPTO-108: ErrMetadataOnly must not surface as an error")
 	assert.True(t, ok, "metadataOnly flag must be true on double miss")
-	assert.Empty(t, out.Payload, "INV-E21: payload must be empty on double miss")
+	assert.Empty(t, out.Payload, "INV-CRYPTO-108: payload must be empty on double miss")
 }
 
 // TestDispatcherResolverNilAfterPermitFailsClosed asserts that a permit with no

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -38,7 +38,7 @@ const (
 	NoPlaintextReasonAuthGuardDeny NoPlaintextReason = 1
 	// NoPlaintextReasonStaleDEK indicates both hot AND cold tier DEKs are
 	// indecipherable. Production-real post sub-epic E rekey + DEK
-	// destruction. INV-E21 double miss.
+	// destruction. INV-CRYPTO-108 double miss.
 	NoPlaintextReasonStaleDEK NoPlaintextReason = 2
 	// NoPlaintextReasonAuditQueueFull indicates plugin audit-emit
 	// backpressure (queue full). Host-side TOCTOU defense.

--- a/internal/testsupport/holomushtest/server.go
+++ b/internal/testsupport/holomushtest/server.go
@@ -92,7 +92,7 @@ func (s *Server) GetRekeyOrchestrator() *dek.Orchestrator { return s.orch }
 // GetCheckpointRepo returns the CheckpointRepo for direct DB assertions.
 func (s *Server) GetCheckpointRepo() *dek.CheckpointRepo { return s.ckptRepo }
 
-// GetAuditChainVerifier returns the chain Verifier for INV-E14/E15 assertions.
+// GetAuditChainVerifier returns the chain Verifier for INV-CRYPTO-101/INV-CRYPTO-102 assertions.
 func (s *Server) GetAuditChainVerifier() chain.Verifier { return s.verifier }
 
 // GetDEKManager returns the DEK manager for seeding fixture DEK rows.
@@ -659,7 +659,7 @@ func (a *orchestratorRunnerAdapter) Run(ctx context.Context, req socket.RekeyRun
 }
 
 // rekeyAbortAdapter satisfies socket.RekeyAbortRunner by delegating to
-// CheckpointRepo.MarkAborted and RekeyAuditEmitter.Emit (INV-E17).
+// CheckpointRepo.MarkAborted and RekeyAuditEmitter.Emit (INV-CRYPTO-104).
 type rekeyAbortAdapter struct {
 	repo    *dek.CheckpointRepo
 	emitter *dek.RekeyAuditEmitter
@@ -677,7 +677,7 @@ func (a *rekeyAbortAdapter) RunAbort(ctx context.Context, req socket.RekeyAbortR
 		return socket.RekeyAbortOutcome{}, err
 	}
 
-	// Emit a minimal abort audit event (INV-E17). The payload carries
+	// Emit a minimal abort audit event (INV-CRYPTO-104). The payload carries
 	// only the fields available at abort time.
 	payload := dek.RekeyAuditPayload{
 		RequestID:       rid.String(),

--- a/pkg/proto/holomush/admin/v1/admin_grpc.pb.go
+++ b/pkg/proto/holomush/admin/v1/admin_grpc.pb.go
@@ -86,7 +86,7 @@ type AdminServiceClient interface {
 	Rekey(ctx context.Context, in *RekeyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RekeyProgress], error)
 	// RekeyResume resumes a paused or interrupted rekey identified by
 	// request_id. Requires the crypto.operator capability and admin role
-	// (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+	// (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
 	// enforced inside the orchestrator, not here. The handler validates that
 	// request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
 	// adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -96,7 +96,7 @@ type AdminServiceClient interface {
 	// RekeyAbort cancels an in-progress rekey checkpoint. Requires the
 	// crypto.operator capability only; no admin role re-check and no
 	// dual-control approval — abort is single-control regardless of site
-	// policy (INV-E17). Any crypto.operator session may abort any non-terminal
+	// policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
 	// checkpoint, not just the primary operator who started it.
 	// Handler: internal/admin/socket/rekey_handler.go.
 	RekeyAbort(ctx context.Context, in *RekeyAbortRequest, opts ...grpc.CallOption) (*RekeyAbortResponse, error)
@@ -319,7 +319,7 @@ type AdminServiceServer interface {
 	Rekey(*RekeyRequest, grpc.ServerStreamingServer[RekeyProgress]) error
 	// RekeyResume resumes a paused or interrupted rekey identified by
 	// request_id. Requires the crypto.operator capability and admin role
-	// (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+	// (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
 	// enforced inside the orchestrator, not here. The handler validates that
 	// request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
 	// adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -329,7 +329,7 @@ type AdminServiceServer interface {
 	// RekeyAbort cancels an in-progress rekey checkpoint. Requires the
 	// crypto.operator capability only; no admin role re-check and no
 	// dual-control approval — abort is single-control regardless of site
-	// policy (INV-E17). Any crypto.operator session may abort any non-terminal
+	// policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
 	// checkpoint, not just the primary operator who started it.
 	// Handler: internal/admin/socket/rekey_handler.go.
 	RekeyAbort(context.Context, *RekeyAbortRequest) (*RekeyAbortResponse, error)

--- a/pkg/proto/holomush/admin/v1/adminv1connect/admin.connect.go
+++ b/pkg/proto/holomush/admin/v1/adminv1connect/admin.connect.go
@@ -106,7 +106,7 @@ type AdminServiceClient interface {
 	Rekey(context.Context, *connect.Request[v1.RekeyRequest]) (*connect.ServerStreamForClient[v1.RekeyProgress], error)
 	// RekeyResume resumes a paused or interrupted rekey identified by
 	// request_id. Requires the crypto.operator capability and admin role
-	// (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+	// (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
 	// enforced inside the orchestrator, not here. The handler validates that
 	// request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
 	// adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -116,7 +116,7 @@ type AdminServiceClient interface {
 	// RekeyAbort cancels an in-progress rekey checkpoint. Requires the
 	// crypto.operator capability only; no admin role re-check and no
 	// dual-control approval — abort is single-control regardless of site
-	// policy (INV-E17). Any crypto.operator session may abort any non-terminal
+	// policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
 	// checkpoint, not just the primary operator who started it.
 	// Handler: internal/admin/socket/rekey_handler.go.
 	RekeyAbort(context.Context, *connect.Request[v1.RekeyAbortRequest]) (*connect.Response[v1.RekeyAbortResponse], error)
@@ -325,7 +325,7 @@ type AdminServiceHandler interface {
 	Rekey(context.Context, *connect.Request[v1.RekeyRequest], *connect.ServerStream[v1.RekeyProgress]) error
 	// RekeyResume resumes a paused or interrupted rekey identified by
 	// request_id. Requires the crypto.operator capability and admin role
-	// (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+	// (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
 	// enforced inside the orchestrator, not here. The handler validates that
 	// request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
 	// adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -335,7 +335,7 @@ type AdminServiceHandler interface {
 	// RekeyAbort cancels an in-progress rekey checkpoint. Requires the
 	// crypto.operator capability only; no admin role re-check and no
 	// dual-control approval — abort is single-control regardless of site
-	// policy (INV-E17). Any crypto.operator session may abort any non-terminal
+	// policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
 	// checkpoint, not just the primary operator who started it.
 	// Handler: internal/admin/socket/rekey_handler.go.
 	RekeyAbort(context.Context, *connect.Request[v1.RekeyAbortRequest]) (*connect.Response[v1.RekeyAbortResponse], error)

--- a/pkg/proto/holomush/admin/v1/rekey.pb.go
+++ b/pkg/proto/holomush/admin/v1/rekey.pb.go
@@ -44,7 +44,7 @@ type RekeyRequest struct {
 	ContextType string `protobuf:"bytes,2,opt,name=context_type,json=contextType,proto3" json:"context_type,omitempty"`
 	// context_id is the entity identifier within context_type, e.g. a scene
 	// ULID. The orchestrator uses (context_type, context_id) to locate the
-	// active DEK and enforce INV-E5 (at most one non-terminal checkpoint per
+	// active DEK and enforce INV-CRYPTO-92 (at most one non-terminal checkpoint per
 	// context at a time).
 	ContextId string `protobuf:"bytes,3,opt,name=context_id,json=contextId,proto3" json:"context_id,omitempty"`
 	// justification is a free-text operator rationale stored on the checkpoint
@@ -348,7 +348,7 @@ func (x *PhaseStarted) GetPhase() string {
 // cold-tier re-encryption phase. The orchestrator rewrites events_audit rows
 // in batches of up to 1000, decrypting each under the old DEK and
 // re-encrypting under the new DEK with AAD rebound to the new (dek_ref,
-// dek_version) — INV-E8. Clients may use these messages to render a
+// dek_version) — INV-CRYPTO-95. Clients may use these messages to render a
 // progress bar; the stream is terminated by RekeyCompleted or RekeyError.
 type Phase3Progress struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -362,7 +362,7 @@ type Phase3Progress struct {
 	RowsRemainingEstimate int64 `protobuf:"varint,2,opt,name=rows_remaining_estimate,json=rowsRemainingEstimate,proto3" json:"rows_remaining_estimate,omitempty"`
 	// last_processed_event_id is the ULID bytes of the most recently committed
 	// batch's last row. Stored as the Phase 3 resume cursor in the checkpoint
-	// row (INV-E7-COLD-RESUME-CURSOR); a crash and resume picks up exactly
+	// row (INV-CRYPTO-94); a crash and resume picks up exactly
 	// where this cursor points.
 	LastProcessedEventId []byte `protobuf:"bytes,3,opt,name=last_processed_event_id,json=lastProcessedEventId,proto3" json:"last_processed_event_id,omitempty"`
 	unknownFields        protoimpl.UnknownFields
@@ -729,7 +729,7 @@ func (x *RekeyError) GetDetails() []byte {
 
 // RekeyResumeRequest resumes a paused or interrupted rekey operation identified
 // by request_id. The orchestrator determines the resume entry point from the
-// checkpoint's current FSM status and drives forward from there. INV-E16:
+// checkpoint's current FSM status and drives forward from there. INV-CRYPTO-103:
 // resuming a complete checkpoint is a no-op that re-emits RekeyCompleted.
 // Resuming an aborted checkpoint surfaces DEK_REKEY_CHECKPOINT_TERMINAL.
 type RekeyResumeRequest struct {
@@ -804,7 +804,7 @@ func (x *RekeyResumeRequest) GetForceDestroy() bool {
 }
 
 // RekeyAbortRequest cancels a non-terminal rekey operation, transitioning its
-// checkpoint to the aborted state. Abort is single-control (INV-E17): any
+// checkpoint to the aborted state. Abort is single-control (INV-CRYPTO-104): any
 // session holding crypto.operator capability may abort any non-terminal
 // checkpoint, regardless of site dual-control policy or which operator
 // initiated the rekey. Once aborted the checkpoint is terminal; a new Rekey
@@ -812,7 +812,7 @@ func (x *RekeyResumeRequest) GetForceDestroy() bool {
 type RekeyAbortRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// session_token authenticates the aborting operator. Only crypto.operator
-	// capability is required — no admin role re-check (INV-E17).
+	// capability is required — no admin role re-check (INV-CRYPTO-104).
 	SessionToken string `protobuf:"bytes,1,opt,name=session_token,json=sessionToken,proto3" json:"session_token,omitempty"`
 	// request_id is the 16-byte ULID of the checkpoint to abort. The handler
 	// rejects zero bytes with REKEY_INVALID_REQUEST_ID. If the checkpoint is
@@ -1015,7 +1015,7 @@ type RekeyStatusResponse struct {
 	StartedAt *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	// last_heartbeat_at is the server timestamp of the most recent heartbeat
 	// written by Phase 3. The sweep worker uses this to TTL-abort stalled
-	// checkpoints (INV-E18/E19). A value far in the past indicates a stalled
+	// checkpoints (INV-CRYPTO-105/INV-CRYPTO-106). A value far in the past indicates a stalled
 	// or crashed orchestrator run.
 	LastHeartbeatAt *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=last_heartbeat_at,json=lastHeartbeatAt,proto3" json:"last_heartbeat_at,omitempty"`
 	// completed_at is the server timestamp when the checkpoint reached a

--- a/pkg/proto/holomush/core/v1/core.pb.go
+++ b/pkg/proto/holomush/core/v1/core.pb.go
@@ -49,7 +49,7 @@ const (
 	NoPlaintextReason_NO_PLAINTEXT_REASON_AUTHGUARD_DENY NoPlaintextReason = 1
 	// NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were
 	// indecipherable — a production-real outcome after a sub-epic E rekey plus DEK
-	// destruction (INV-E21 double miss).
+	// destruction (INV-CRYPTO-108 double miss).
 	NoPlaintextReason_NO_PLAINTEXT_REASON_STALE_DEK NoPlaintextReason = 2
 	// NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL means a plugin audit-emit hit
 	// backpressure (queue full) — a host-side TOCTOU defense.

--- a/pkg/proto/holomush/plugin/v1/audit.pb.go
+++ b/pkg/proto/holomush/plugin/v1/audit.pb.go
@@ -664,7 +664,7 @@ type RowResult_NoPlaintextReason struct {
 	// (recipient not authorized by manifest declaration / ABAC grant — Phase 3b
 	// AuthGuard deny), "downgrade_refused" (INV-CRYPTO-42 fence — sensitive event
 	// stored under identity codec), "dek_missing" (INV-CRYPTO-50 fence — no DEK
-	// exists for this row's context), "stale_dek" (INV-E21 — both hot and cold
+	// exists for this row's context), "stale_dek" (INV-CRYPTO-108 — both hot and cold
 	// DEK tiers gone), "audit_queue_full" (plugin audit-emit backpressure), and
 	// "internal" (host-side error, details logged server-side only).
 	NoPlaintextReason string `protobuf:"bytes,3,opt,name=no_plaintext_reason,json=noPlaintextReason,proto3,oneof"`

--- a/site/src/content/docs/reference/grpc-api.md
+++ b/site/src/content/docs/reference/grpc-api.md
@@ -1386,7 +1386,7 @@ counterpart here.
 | ---- | ------ | ----------- |
 | NO_PLAINTEXT_REASON_UNSPECIFIED | 0 | NO_PLAINTEXT_REASON_UNSPECIFIED is the zero value and MUST hold when metadata_only=false. A client that sees it together with metadata_only=true MUST treat the delivery as a contract violation (host stamped without classifying). |
 | NO_PLAINTEXT_REASON_AUTHGUARD_DENY | 1 | NO_PLAINTEXT_REASON_AUTHGUARD_DENY means the recipient was not in the DEK&#39;s participant set or lacked the requisite plugin manifest declaration / ABAC grant. Phase 3b AuthGuard deny. |
-| NO_PLAINTEXT_REASON_STALE_DEK | 2 | NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were indecipherable — a production-real outcome after a sub-epic E rekey plus DEK destruction (INV-E21 double miss). |
+| NO_PLAINTEXT_REASON_STALE_DEK | 2 | NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were indecipherable — a production-real outcome after a sub-epic E rekey plus DEK destruction (INV-CRYPTO-108 double miss). |
 | NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL | 3 | NO_PLAINTEXT_REASON_AUDIT_QUEUE_FULL means a plugin audit-emit hit backpressure (queue full) — a host-side TOCTOU defense. |
 | NO_PLAINTEXT_REASON_DEK_MISSING | 4 | NO_PLAINTEXT_REASON_DEK_MISSING means the cold-tier audit row had no dek_ref (DEK reference column missing or NULL). Stamped exclusively by sub-epic F&#39;s operator-read classifier (INV-CRYPTO-66). |
 | NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS | 5 | NO_PLAINTEXT_REASON_DEK_BAD_COLUMNS means a cold-tier audit row references a DEK whose column set does not match the event&#39;s AAD declaration. Stamped exclusively by sub-epic F&#39;s classifier. |
@@ -1667,7 +1667,7 @@ Phase3Progress reports incremental progress during Phase 3, the bulk
 cold-tier re-encryption phase. The orchestrator rewrites events_audit rows
 in batches of up to 1000, decrypting each under the old DEK and
 re-encrypting under the new DEK with AAD rebound to the new (dek_ref,
-dek_version) — INV-E8. Clients may use these messages to render a
+dek_version) — INV-CRYPTO-95. Clients may use these messages to render a
 progress bar; the stream is terminated by RekeyCompleted or RekeyError.
 
 
@@ -1675,7 +1675,7 @@ progress bar; the stream is terminated by RekeyCompleted or RekeyError.
 | ----- | ---- | ----- | ----------- |
 | rows_rewritten | [int64](#int64) |  | rows_rewritten is the cumulative count of events_audit rows re-encrypted by this Phase 3 invocation so far. Resets to zero on a fresh resume; the checkpoint row&#39;s phase3_rows_rewritten column holds the cross-resume total. |
 | rows_remaining_estimate | [int64](#int64) |  | rows_remaining_estimate is a best-effort count of events_audit rows whose dek_ref still points at the old DEK. Not guaranteed to be exact (rows may be written concurrently); use for display only. |
-| last_processed_event_id | [bytes](#bytes) |  | last_processed_event_id is the ULID bytes of the most recently committed batch&#39;s last row. Stored as the Phase 3 resume cursor in the checkpoint row (INV-E7-COLD-RESUME-CURSOR); a crash and resume picks up exactly where this cursor points. |
+| last_processed_event_id | [bytes](#bytes) |  | last_processed_event_id is the ULID bytes of the most recently committed batch&#39;s last row. Stored as the Phase 3 resume cursor in the checkpoint row (INV-CRYPTO-94); a crash and resume picks up exactly where this cursor points. |
 
 
 
@@ -1741,7 +1741,7 @@ phase-by-phase progress indicator.
 
 ### RekeyAbortRequest
 RekeyAbortRequest cancels a non-terminal rekey operation, transitioning its
-checkpoint to the aborted state. Abort is single-control (INV-E17): any
+checkpoint to the aborted state. Abort is single-control (INV-CRYPTO-104): any
 session holding crypto.operator capability may abort any non-terminal
 checkpoint, regardless of site dual-control policy or which operator
 initiated the rekey. Once aborted the checkpoint is terminal; a new Rekey
@@ -1750,7 +1750,7 @@ call is required to restart.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| session_token | [string](#string) |  | session_token authenticates the aborting operator. Only crypto.operator capability is required — no admin role re-check (INV-E17). |
+| session_token | [string](#string) |  | session_token authenticates the aborting operator. Only crypto.operator capability is required — no admin role re-check (INV-CRYPTO-104). |
 | request_id | [bytes](#bytes) |  | request_id is the 16-byte ULID of the checkpoint to abort. The handler rejects zero bytes with REKEY_INVALID_REQUEST_ID. If the checkpoint is already terminal (complete or aborted), the handler returns DEK_REKEY_CHECKPOINT_TERMINAL. |
 
 
@@ -1885,7 +1885,7 @@ admin_approvals row when dual-control is required by site policy.
 | ----- | ---- | ----- | ----------- |
 | session_token | [string](#string) |  | session_token authenticates the issuing operator. Must be a non-expired token returned by AdminService.Authenticate; the handler re-validates crypto.operator capability and admin role on every call (INV-CRYPTO-83). |
 | context_type | [string](#string) |  | context_type identifies the encryption domain, e.g. &#34;scene&#34;. Together with context_id it resolves the active DEK row (old_dek_id) that the orchestrator&#39;s Phase 1 reads from crypto_keys. |
-| context_id | [string](#string) |  | context_id is the entity identifier within context_type, e.g. a scene ULID. The orchestrator uses (context_type, context_id) to locate the active DEK and enforce INV-E5 (at most one non-terminal checkpoint per context at a time). |
+| context_id | [string](#string) |  | context_id is the entity identifier within context_type, e.g. a scene ULID. The orchestrator uses (context_type, context_id) to locate the active DEK and enforce INV-CRYPTO-92 (at most one non-terminal checkpoint per context at a time). |
 | justification | [string](#string) |  | justification is a free-text operator rationale stored on the checkpoint row and included in the Phase 7 chained audit event. Required for accountability; non-empty values are enforced by the handler. |
 | approval_request_id | [string](#string) | optional | approval_request_id, when present, links a pending admin_approvals row created by the first operator under dual-control policy. Absent for single-control sites. The orchestrator validates the approval row before advancing past Phase 1. |
 
@@ -1899,7 +1899,7 @@ admin_approvals row when dual-control is required by site policy.
 ### RekeyResumeRequest
 RekeyResumeRequest resumes a paused or interrupted rekey operation identified
 by request_id. The orchestrator determines the resume entry point from the
-checkpoint&#39;s current FSM status and drives forward from there. INV-E16:
+checkpoint&#39;s current FSM status and drives forward from there. INV-CRYPTO-103:
 resuming a complete checkpoint is a no-op that re-emits RekeyCompleted.
 Resuming an aborted checkpoint surfaces DEK_REKEY_CHECKPOINT_TERMINAL.
 
@@ -1950,7 +1950,7 @@ crypto_rekey_checkpoints row.
 | status | [string](#string) |  | status is the current FSM state of this checkpoint. Values match the CheckpointStatus constants: &#34;pending&#34;, &#34;phase1_auth&#34;, &#34;phase2_mint_dek&#34;, &#34;phase3_reencrypt_cold&#34;, &#34;phase5_invalidate&#34;, &#34;phase6_destroy_old&#34;, &#34;phase7_audit&#34;, &#34;complete&#34;, or &#34;aborted&#34;. |
 | primary_player_id | [string](#string) |  | primary_player_id is the player ID of the operator who initiated the rekey (the first operator under dual-control). Used for accountability and is included in the Phase 7 audit event. |
 | started_at | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | started_at is the server timestamp when the checkpoint row was opened (Phase 1 INSERT). Combined with completed_at it bounds the total rekey wall-clock time. |
-| last_heartbeat_at | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | last_heartbeat_at is the server timestamp of the most recent heartbeat written by Phase 3. The sweep worker uses this to TTL-abort stalled checkpoints (INV-E18/E19). A value far in the past indicates a stalled or crashed orchestrator run. |
+| last_heartbeat_at | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | last_heartbeat_at is the server timestamp of the most recent heartbeat written by Phase 3. The sweep worker uses this to TTL-abort stalled checkpoints (INV-CRYPTO-105/INV-CRYPTO-106). A value far in the past indicates a stalled or crashed orchestrator run. |
 | completed_at | [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp) |  | completed_at is the server timestamp when the checkpoint reached a terminal state (complete or aborted). Zero if not yet terminal. |
 | phase5_attempt_count | [int32](#int32) |  | phase5_attempt_count is the total number of cluster cache-invalidation attempts made during Phase 5 for this checkpoint. Incremented before each attempt; zero means Phase 5 has not started yet. |
 | phase5_missing_members | [string](#string) | repeated | phase5_missing_members lists the node identifiers that failed to acknowledge the most recent Phase 5 cache-invalidation request. Non-empty indicates a Phase 5 timeout; the operator may resume or use force_destroy. Empty when Phase 5 has not yet run or succeeded. |
@@ -2123,8 +2123,8 @@ allowing incremental feature deployment without breaking callers.
 | Approve | [ApproveRequest](#holomush-admin-v1-ApproveRequest) | [ApproveResponse](#holomush-admin-v1-ApproveResponse) | Approve is the second-operator signoff on a pending admin_approvals row. The caller supplies their session_token (proving identity and live operator status) and the request_id of the approval row to sign off. Repo.MarkApproved atomically enforces three invariants: INV-CRYPTO-72 (the row must not be expired), INV-CRYPTO-73 (the approver cannot be the same player as the primary operator who opened the row), and INV-CRYPTO-74 (each row may only be approved once). Requires the crypto.operator capability and admin role re-checked at call time (INV-CRYPTO-83); handler in internal/admin/approval. |
 | ResetTOTP | [ResetTOTPRequest](#holomush-admin-v1-ResetTOTPRequest) | [ResetTOTPResponse](#holomush-admin-v1-ResetTOTPResponse) | ResetTOTP clears a target player&#39;s TOTP enrollment, allowing them to re-enroll on next login. On success, AuditingService.ClearTOTP emits a crypto.totp_cleared audit event with cleared_by=&#34;admin_reset&#34; (T13). Response.cleared is false when the player was not enrolled (no-op). Requires a valid session_token with the crypto.operator capability and admin role re-checked at call time (INV-CRYPTO-83); handler in internal/admin/auth (reset_handler.go). |
 | Rekey | [RekeyRequest](#holomush-admin-v1-RekeyRequest) | [RekeyProgress](#holomush-admin-v1-RekeyProgress) stream | Rekey initiates a fresh DEK rekey for the given context. Requires the crypto.operator capability and admin role (re-checked at call time, INV-CRYPTO-83). Streams a single terminal RekeyProgress event: RekeyCompleted on success or RekeyError on orchestrator failure. Per-phase progress updates are pre-defined in the proto but not yet emitted (follow-up). Uses the shared RekeyProgress stream type (also used by RekeyResume) — the buf RPC_REQUEST_RESPONSE_UNIQUE / RPC_RESPONSE_STANDARD_NAME exemptions are intentional (jxo8.7.27). Handler: internal/admin/socket/rekey_handler.go. |
-| RekeyResume | [RekeyResumeRequest](#holomush-admin-v1-RekeyResumeRequest) | [RekeyProgress](#holomush-admin-v1-RekeyProgress) stream | RekeyResume resumes a paused or interrupted rekey identified by request_id. Requires the crypto.operator capability and admin role (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are enforced inside the orchestrator, not here. The handler validates that request_id is a non-zero 16-byte ULID and forwards it to the orchestrator adapter, which looks up the checkpoint to resolve ContextType/ContextID. Streams a terminal RekeyProgress event — same shared type as Rekey. Handler: internal/admin/socket/rekey_handler.go. |
-| RekeyAbort | [RekeyAbortRequest](#holomush-admin-v1-RekeyAbortRequest) | [RekeyAbortResponse](#holomush-admin-v1-RekeyAbortResponse) | RekeyAbort cancels an in-progress rekey checkpoint. Requires the crypto.operator capability only; no admin role re-check and no dual-control approval — abort is single-control regardless of site policy (INV-E17). Any crypto.operator session may abort any non-terminal checkpoint, not just the primary operator who started it. Handler: internal/admin/socket/rekey_handler.go. |
+| RekeyResume | [RekeyResumeRequest](#holomush-admin-v1-RekeyResumeRequest) | [RekeyProgress](#holomush-admin-v1-RekeyProgress) stream | RekeyResume resumes a paused or interrupted rekey identified by request_id. Requires the crypto.operator capability and admin role (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are enforced inside the orchestrator, not here. The handler validates that request_id is a non-zero 16-byte ULID and forwards it to the orchestrator adapter, which looks up the checkpoint to resolve ContextType/ContextID. Streams a terminal RekeyProgress event — same shared type as Rekey. Handler: internal/admin/socket/rekey_handler.go. |
+| RekeyAbort | [RekeyAbortRequest](#holomush-admin-v1-RekeyAbortRequest) | [RekeyAbortResponse](#holomush-admin-v1-RekeyAbortResponse) | RekeyAbort cancels an in-progress rekey checkpoint. Requires the crypto.operator capability only; no admin role re-check and no dual-control approval — abort is single-control regardless of site policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal checkpoint, not just the primary operator who started it. Handler: internal/admin/socket/rekey_handler.go. |
 | RekeyStatus | [RekeyStatusRequest](#holomush-admin-v1-RekeyStatusRequest) | [RekeyStatusResponse](#holomush-admin-v1-RekeyStatusResponse) | RekeyStatus returns the current state of a single rekey operation identified by request_id. Requires the crypto.operator capability; no admin role re-check. Reads from the crypto_rekey_checkpoints table via CheckpointStatusReader.GetCheckpoint. Handler: internal/admin/socket/rekey_handler.go. |
 | RekeyList | [RekeyListRequest](#holomush-admin-v1-RekeyListRequest) | [RekeyStatusResponse](#holomush-admin-v1-RekeyStatusResponse) stream | RekeyList streams status records for rekey operations. By default only non-terminal checkpoints are returned; set include_terminal to include completed and aborted rows. Results are capped at 100 rows (any limit above 100 or zero is silently clamped to 100). Requires the crypto.operator capability; no admin role re-check. Handler: internal/admin/socket/rekey_handler.go. |
 | AdminReadStream | [AdminReadStreamRequest](#holomush-admin-v1-AdminReadStreamRequest) | [AdminReadStreamResponse](#holomush-admin-v1-AdminReadStreamResponse) stream | AdminReadStream is the operator break-glass streaming read RPC. Streams EventFrame payloads for the requested context(s) and time bounds, with typed metadata_only and no_plaintext_reason redaction fields for destroyed-DEK and plaintext-suppressed events. When dual_control is set in the request, the handler blocks until a second operator approves via the admin_approvals table before emitting any event frames (INV-CRYPTO-61/INV-CRYPTO-67). Handler: internal/admin/socket/handlers.go (delegated to ReadStreamRPCHandler). |
@@ -2822,7 +2822,7 @@ decrypted; no_plaintext_reason is set iff the row was refused (e.g.
 | ----- | ---- | ----- | ----------- |
 | id | [bytes](#bytes) |  | id echoes AuditRow.id so the caller can correlate results back to their source rows without relying solely on positional ordering. |
 | plaintext | [bytes](#bytes) |  | plaintext holds the decrypted event payload bytes when decryption succeeded. May be empty bytes for zero-length payloads; callers MUST distinguish this from no_plaintext_reason by which oneof arm is set, not by length. |
-| no_plaintext_reason | [string](#string) |  | no_plaintext_reason is a short ASCII token describing why decryption was refused. It is a stable wire contract (the values MUST NOT drift; SDKs switch on them — see readback.go). The full set: &#34;not_owner&#34; (g1 OwnerMap gate — subject belongs to a different plugin), &#34;auth_guard_deny&#34; (recipient not authorized by manifest declaration / ABAC grant — Phase 3b AuthGuard deny), &#34;downgrade_refused&#34; (INV-CRYPTO-42 fence — sensitive event stored under identity codec), &#34;dek_missing&#34; (INV-CRYPTO-50 fence — no DEK exists for this row&#39;s context), &#34;stale_dek&#34; (INV-E21 — both hot and cold DEK tiers gone), &#34;audit_queue_full&#34; (plugin audit-emit backpressure), and &#34;internal&#34; (host-side error, details logged server-side only). |
+| no_plaintext_reason | [string](#string) |  | no_plaintext_reason is a short ASCII token describing why decryption was refused. It is a stable wire contract (the values MUST NOT drift; SDKs switch on them — see readback.go). The full set: &#34;not_owner&#34; (g1 OwnerMap gate — subject belongs to a different plugin), &#34;auth_guard_deny&#34; (recipient not authorized by manifest declaration / ABAC grant — Phase 3b AuthGuard deny), &#34;downgrade_refused&#34; (INV-CRYPTO-42 fence — sensitive event stored under identity codec), &#34;dek_missing&#34; (INV-CRYPTO-50 fence — no DEK exists for this row&#39;s context), &#34;stale_dek&#34; (INV-CRYPTO-108 — both hot and cold DEK tiers gone), &#34;audit_queue_full&#34; (plugin audit-emit backpressure), and &#34;internal&#34; (host-side error, details logged server-side only). |
 
 
 

--- a/test/integration/crypto/harness_impl_test.go
+++ b/test/integration/crypto/harness_impl_test.go
@@ -43,7 +43,7 @@ type Harness struct {
 	PartnerPlayer holomushtest.PlayerCreds
 	SceneContext  dek.ContextID
 	// OriginalPolicyHash stores the policy_hash captured by RememberCurrentPolicyHash.
-	// Used by INV-E25 tests to assert the hash did not change after a policy edit.
+	// Used by INV-CRYPTO-112 tests to assert the hash did not change after a policy edit.
 	OriginalPolicyHash string
 }
 
@@ -252,13 +252,13 @@ func (h *Harness) AssertAuditEventEmitted(subjectPattern, eventType string) {
 }
 
 // AssertRekeyChainIntactForContext walks the rekey audit chain for ctx via
-// the primary replica's chain verifier (INV-E14/E15).
+// the primary replica's chain verifier (INV-CRYPTO-101/INV-CRYPTO-102).
 func (h *Harness) AssertRekeyChainIntactForContext(ctx dek.ContextID) {
 	scope := ctx.Type + ":" + ctx.ID
 	err := h.Primary.GetAuditChainVerifier().VerifyScope(
 		context.Background(), dek.RekeyHandlerFor(h.Game), scope,
 	)
-	Expect(err).NotTo(HaveOccurred(), "INV-E14/E15: chain intact for %s", scope)
+	Expect(err).NotTo(HaveOccurred(), "INV-CRYPTO-101/INV-CRYPTO-102: chain intact for %s", scope)
 }
 
 // --- Fault injection helpers ---
@@ -498,7 +498,7 @@ func (h *Harness) TamperPolicySetSelfHash(policyName string) {
 // --- policy-hash-frozen helpers (Task 50) ---
 
 // RememberCurrentPolicyHash reads the current tail hash of the policy_set chain
-// for policyName and stores it in h.OriginalPolicyHash. Used by INV-E25 tests
+// for policyName and stores it in h.OriginalPolicyHash. Used by INV-CRYPTO-112 tests
 // to capture the hash before a mid-Rekey policy edit.
 //
 // Encoding mirrors Phase 7's audit payload format:
@@ -519,7 +519,7 @@ func (h *Harness) RememberCurrentPolicyHash(policyName string) {
 
 // LoadRekeyAuditEvent loads and decodes the rekey audit event identified by
 // the given 16-byte raw request_id slice. Returns the decoded RekeyAuditPayload
-// so callers can assert PolicyHash (INV-E25) and other fields.
+// so callers can assert PolicyHash (INV-CRYPTO-112) and other fields.
 //
 // The raw 16 bytes are converted to ULID string format (same as rid.String())
 // and matched against the "request_id" field in the JSON payload.

--- a/test/integration/crypto/policy_set_chain_post_refactor_test.go
+++ b/test/integration/crypto/policy_set_chain_post_refactor_test.go
@@ -70,7 +70,7 @@ var _ = Describe("policy_set chain (post auditchain refactor)", func() {
 		// The oops error code AUDIT_CHAIN_HASH_MISMATCH is in the Code() field;
 		// .Error() surfaces the human-readable message. Either the code or message
 		// must confirm a hash mismatch (matches rekey_chain_verifier_refuses_boot_test.go
-		// assertion pattern — see INV-E15 spec).
+		// assertion pattern — see INV-CRYPTO-102 spec).
 		Expect(err.Error()).To(ContainSubstring("self_hash does not match recompute"),
 			"INV-CRYPTO-77/INV-CRYPTO-78/INV-CRYPTO-79: tampered self_hash must produce a self_hash mismatch error")
 	})

--- a/test/integration/crypto/rekey_abort_test.go
+++ b/test/integration/crypto/rekey_abort_test.go
@@ -5,7 +5,7 @@
 
 // rekey_abort_test.go — E2E spec for the Rekey abort path.
 //
-// Verifies INV-E17 (ABORT-NO-DUAL-CONTROL): the RekeyAbort RPC accepts a
+// Verifies INV-CRYPTO-104 (ABORT-NO-DUAL-CONTROL): the RekeyAbort RPC accepts a
 // single-control invocation; abort is non-destructive (the in-progress
 // checkpoint is marked aborted, the old DEK remains valid, reads continue).
 // A subsequent fresh-start rekey succeeds after the abort.
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = Describe("Rekey abort", func() {
-	It("aborts an in-flight checkpoint and allows a fresh start (INV-E17)", func() {
+	It("aborts an in-flight checkpoint and allows a fresh start (INV-CRYPTO-104)", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
 
@@ -40,7 +40,7 @@ var _ = Describe("Rekey abort", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt0.Status.IsTerminal()).To(BeFalse(), "checkpoint must be non-terminal before abort")
 
-		// INV-E17: abort must succeed via single-control. The abort handler
+		// INV-CRYPTO-104: abort must succeed via single-control. The abort handler
 		// requires only crypto.operator capability — no dual-control approval
 		// is accepted or required. This test verifies that single-control
 		// RekeyAbort succeeds even for an in-flight checkpoint.
@@ -52,7 +52,7 @@ var _ = Describe("Rekey abort", func() {
 			RequestId:    rid[:],
 		}))
 		Expect(err).NotTo(HaveOccurred(),
-			"INV-E17: RekeyAbort must succeed via single-control")
+			"INV-CRYPTO-104: RekeyAbort must succeed via single-control")
 		Expect(abortResp.Msg.GetAbortedAt()).NotTo(BeNil(),
 			"AbortedAt must be populated in the response")
 		Expect(abortResp.Msg.GetAuditEventId()).NotTo(BeEmpty(),

--- a/test/integration/crypto/rekey_chain_verifier_refuses_boot_test.go
+++ b/test/integration/crypto/rekey_chain_verifier_refuses_boot_test.go
@@ -3,10 +3,10 @@
 
 //go:build integration
 
-// rekey_chain_verifier_refuses_boot_test.go — E2E spec for INV-E15: the
+// rekey_chain_verifier_refuses_boot_test.go — E2E spec for INV-CRYPTO-102: the
 // audit-chain verifier refuses boot when a rekey chain entry has been tampered.
 //
-// Verifies INV-E15-CHAIN-VERIFIER-BOOT: any tampering with a rekey audit
+// Verifies INV-CRYPTO-102: any tampering with a rekey audit
 // row's self_hash causes the VerifierSubsystem (which runs at boot time) to
 // return AUDIT_CHAIN_HASH_MISMATCH. The clean-fixture boot path (no tampering)
 // must pass to confirm the baseline.
@@ -71,7 +71,7 @@ func buildTamperedRekeyPayload() []byte {
 }
 
 var _ = Describe("Rekey chain verifier", func() {
-	It("refuses to boot when the rekey chain has a break (INV-E15)", func() {
+	It("refuses to boot when the rekey chain has a break (INV-CRYPTO-102)", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
 
@@ -96,7 +96,7 @@ var _ = Describe("Rekey chain verifier", func() {
 			context.Background(), handler, scope,
 		)
 		Expect(cleanErr).NotTo(HaveOccurred(),
-			"INV-E15: clean chain must verify without error before tampering")
+			"INV-CRYPTO-102: clean chain must verify without error before tampering")
 
 		// Tamper: overwrite the most recent rekey audit row's envelope with a
 		// structurally valid JSON body that has a deliberately wrong self_hash.
@@ -119,21 +119,21 @@ var _ = Describe("Rekey chain verifier", func() {
 			rekeySubject)
 		Expect(updateErr).NotTo(HaveOccurred(), "tamper UPDATE must succeed")
 		Expect(tag.RowsAffected()).To(BeNumerically("==", 1),
-			"INV-E15: tamper UPDATE must affect exactly 1 row (subject=%q)", rekeySubject)
+			"INV-CRYPTO-102: tamper UPDATE must affect exactly 1 row (subject=%q)", rekeySubject)
 
 		// Re-verify the chain via VerifyScope — the same operation that
 		// VerifierSubsystem.Start performs internally at boot.
-		// INV-E15: tampering MUST cause an AUDIT_CHAIN_HASH_MISMATCH.
+		// INV-CRYPTO-102: tampering MUST cause an AUDIT_CHAIN_HASH_MISMATCH.
 		// The error is an oops.OopsError with Code()="AUDIT_CHAIN_HASH_MISMATCH";
 		// its .Error() string contains the message "self_hash does not match recompute".
 		bootErr := h.Primary.GetAuditChainVerifier().VerifyScope(
 			context.Background(), handler, scope,
 		)
 		Expect(bootErr).To(HaveOccurred(),
-			"INV-E15: chain verifier MUST detect tampering")
+			"INV-CRYPTO-102: chain verifier MUST detect tampering")
 		// Extract the oops error code (the code is not in .Error() for direct calls;
 		// it is in the oops.Code field). The message confirms hash mismatch.
 		Expect(bootErr.Error()).To(ContainSubstring("self_hash does not match recompute"),
-			"INV-E15: tampered entry MUST produce a self_hash mismatch error")
+			"INV-CRYPTO-102: tampered entry MUST produce a self_hash mismatch error")
 	})
 })

--- a/test/integration/crypto/rekey_force_destroy_test.go
+++ b/test/integration/crypto/rekey_force_destroy_test.go
@@ -6,11 +6,11 @@
 // rekey_force_destroy_test.go — E2E specs for the --force-destroy escape hatch.
 //
 // Covers:
-//   - INV-E10 (FORCE-DESTROY-GATED): --force-destroy is rejected when the
+//   - INV-CRYPTO-97 (FORCE-DESTROY-GATED): --force-destroy is rejected when the
 //     checkpoint is not in the timed-out Phase 5 state (i.e., when
 //     phase5_missing_members IS NULL). Verified at phase1_auth (before Phase 5)
 //     and at phase5_invalidate without missing members (after Phase 5 success).
-//   - INV-E11 (FORCE-DESTROY-AUDITED): when --force-destroy is used after a
+//   - INV-CRYPTO-98 (FORCE-DESTROY-AUDITED): when --force-destroy is used after a
 //     Phase 5 timeout, the rekey completes and the audit event carries
 //     force_destroy=true and final_missing_members populated.
 //
@@ -38,7 +38,7 @@ import (
 
 // assertAuditEventHasForceDestroy queries events_audit for the most recent
 // rekey audit event for SceneContext and asserts force_destroy=true and
-// final_missing_members contains all expected members (INV-E11).
+// final_missing_members contains all expected members (INV-CRYPTO-98).
 func assertAuditEventHasForceDestroy(h *Harness, expectedMissing []string) {
 	GinkgoHelper()
 
@@ -49,22 +49,22 @@ func assertAuditEventHasForceDestroy(h *Harness, expectedMissing []string) {
 		  ORDER BY js_seq DESC LIMIT 1`,
 		"events.g1.system.rekey.scene.%").Scan(&envelopeBytes)
 	Expect(err).NotTo(HaveOccurred(),
-		"INV-E11: rekey audit event must exist in events_audit")
+		"INV-CRYPTO-98: rekey audit event must exist in events_audit")
 
 	var payload dek.RekeyAuditPayload
 	Expect(json.Unmarshal(envelopeBytes, &payload)).To(Succeed(),
-		"INV-E11: audit event envelope must be valid RekeyAuditPayload JSON")
+		"INV-CRYPTO-98: audit event envelope must be valid RekeyAuditPayload JSON")
 
 	Expect(payload.ForceDestroy).To(BeTrue(),
-		"INV-E11: audit payload force_destroy must be true")
+		"INV-CRYPTO-98: audit payload force_destroy must be true")
 	for _, m := range expectedMissing {
 		Expect(payload.Phases.Phase5FinalMissingMembers).To(ContainElement(m),
-			"INV-E11: audit payload final_missing_members must include %q", m)
+			"INV-CRYPTO-98: audit payload final_missing_members must include %q", m)
 	}
 }
 
 var _ = Describe("Rekey force-destroy", func() {
-	It("E2E_ForceDestroyAuditCapture: --force-destroy bypasses invalidation and captures bypass in audit (INV-E10, INV-E11)", func() {
+	It("E2E_ForceDestroyAuditCapture: --force-destroy bypasses invalidation and captures bypass in audit (INV-CRYPTO-97, INV-CRYPTO-98)", func() {
 		h := SetupRekeyHarness(suiteT, WithEventCount(50))
 		defer h.Cleanup()
 
@@ -85,7 +85,7 @@ var _ = Describe("Rekey force-destroy", func() {
 		Expect(timeoutErr).To(HaveOccurred(), "Phase 5 must timeout")
 		Expect(timeoutErr.Error()).To(ContainSubstring("DEK_REKEY_PHASE5_TIMEOUT"))
 
-		// INV-E10: force-destroy is permitted on a timed-out checkpoint.
+		// INV-CRYPTO-97: force-destroy is permitted on a timed-out checkpoint.
 		// Drive it via the orchestrator directly (ForceDestroy=true + same args
 		// → same op_args_hash → auto-resumes the phase5_timeout checkpoint).
 		// The coordinator is still in timeout mode; force-destroy skips it.
@@ -100,21 +100,21 @@ var _ = Describe("Rekey force-destroy", func() {
 			context.Background(), forceReq,
 		)
 		Expect(forceErr).NotTo(HaveOccurred(),
-			"INV-E10: force-destroy on a phase5_timeout checkpoint must succeed")
+			"INV-CRYPTO-97: force-destroy on a phase5_timeout checkpoint must succeed")
 		Expect(outcome.ForceDestroyUsed).To(BeTrue(),
-			"INV-E11: RekeyOutcome.ForceDestroyUsed must be true")
+			"INV-CRYPTO-98: RekeyOutcome.ForceDestroyUsed must be true")
 
 		// Checkpoint must be complete.
 		h.AssertCheckpointStatus(outcome.RequestID, dek.CheckpointStatusComplete)
 
-		// INV-E11: audit event must capture force_destroy=true + missing members.
+		// INV-CRYPTO-98: audit event must capture force_destroy=true + missing members.
 		assertAuditEventHasForceDestroy(h, missingMembers)
 
-		// Audit chain intact (INV-E14/E15).
+		// Audit chain intact (INV-CRYPTO-101/INV-CRYPTO-102).
 		h.AssertRekeyChainIntactForContext(h.SceneContext)
 	})
 
-	It("INV-E10: force-destroy is rejected when Phase 5 has not timed out (pre-timeout)", func() {
+	It("INV-CRYPTO-97: force-destroy is rejected when Phase 5 has not timed out (pre-timeout)", func() {
 		h := SetupRekeyHarness(suiteT, WithEventCount(10))
 		defer h.Cleanup()
 
@@ -131,12 +131,12 @@ var _ = Describe("Rekey force-destroy", func() {
 			context.Background(), rid,
 		)
 		Expect(forceErr).To(HaveOccurred(),
-			"INV-E10: force-destroy must be rejected before phase5_timeout")
+			"INV-CRYPTO-97: force-destroy must be rejected before phase5_timeout")
 		Expect(forceErr.Error()).To(ContainSubstring("phase5_invalidate"),
-			"INV-E10: rejection message must reference required state")
+			"INV-CRYPTO-97: rejection message must reference required state")
 	})
 
-	It("INV-E10: force-destroy is rejected after successful Phase 5 (phase5_complete / no missing members)", func() {
+	It("INV-CRYPTO-97: force-destroy is rejected after successful Phase 5 (phase5_complete / no missing members)", func() {
 		h := SetupRekeyHarness(suiteT, WithEventCount(10))
 		defer h.Cleanup()
 
@@ -161,8 +161,8 @@ var _ = Describe("Rekey force-destroy", func() {
 			context.Background(), rid,
 		)
 		Expect(forceErr).To(HaveOccurred(),
-			"INV-E10: force-destroy must be rejected after a successful Phase 5")
+			"INV-CRYPTO-97: force-destroy must be rejected after a successful Phase 5")
 		Expect(forceErr.Error()).To(ContainSubstring("phase5_invalidate"),
-			"INV-E10: rejection message must reference the required phase5_invalidate+missing_members state")
+			"INV-CRYPTO-97: rejection message must reference the required phase5_invalidate+missing_members state")
 	})
 })

--- a/test/integration/crypto/rekey_happy_path_test.go
+++ b/test/integration/crypto/rekey_happy_path_test.go
@@ -7,7 +7,7 @@
 //
 // Verifies: full fresh rekey completes end-to-end, checkpoint advances to
 // complete, new DEK is active at version+1, old DEK has destroyed_at set,
-// and the rekey audit chain integrity holds (INV-E14/E15).
+// and the rekey audit chain integrity holds (INV-CRYPTO-101/INV-CRYPTO-102).
 //
 // Part of holomush-jxo8.7 (bead jxo8.7.36, merged T39+T40).
 package crypto_test
@@ -118,7 +118,7 @@ var _ = Describe("Rekey happy path", func() {
 		Expect(err2).NotTo(HaveOccurred())
 		h.AssertCryptoKeysDestroyedAtSet(ckpt.OldDEKID)
 
-		// Verify the rekey audit chain is intact (INV-E14/E15).
+		// Verify the rekey audit chain is intact (INV-CRYPTO-101/INV-CRYPTO-102).
 		h.AssertRekeyChainIntactForContext(h.SceneContext)
 	})
 })

--- a/test/integration/crypto/rekey_phase5_timeout_test.go
+++ b/test/integration/crypto/rekey_phase5_timeout_test.go
@@ -17,7 +17,7 @@
 // first Rekey call; incremented attempt_count and success on a second Rekey
 // invocation with the same args (auto-resume path).
 //
-// Spec: spec §4.3 Phase 5; INV-E22-INVALIDATION-REUSE.
+// Spec: spec §4.3 Phase 5; INV-CRYPTO-109.
 //
 // Part of holomush-jxo8.7 (bead jxo8.7.38, merged T43+T44).
 package crypto_test
@@ -172,11 +172,11 @@ var _ = Describe("Rekey Phase 5 timeout", func() {
 			"Rekey with same args after cluster heal must complete successfully")
 		Expect(out.RequestID).NotTo(BeEmpty(), "RequestId must be set on completion")
 
-		// The resumed run must reuse the SAME request ID (INV-E4).
+		// The resumed run must reuse the SAME request ID (INV-CRYPTO-91).
 		var resumedRID dek.RequestID
 		copy(resumedRID[:], out.RequestID)
 		Expect(resumedRID).To(Equal(rid),
-			"INV-E4: same-args invocation after timeout must reuse the existing RequestID")
+			"INV-CRYPTO-91: same-args invocation after timeout must reuse the existing RequestID")
 
 		// Checkpoint must be complete.
 		h.AssertCheckpointStatus(resumedRID, dek.CheckpointStatusComplete)
@@ -187,7 +187,7 @@ var _ = Describe("Rekey Phase 5 timeout", func() {
 		Expect(finalStatus.GetPhase5AttemptCount()).To(BeNumerically(">=", 2),
 			"phase5_attempt_count must reflect both the timeout and the retry")
 
-		// Audit chain intact (INV-E14/E15).
+		// Audit chain intact (INV-CRYPTO-101/INV-CRYPTO-102).
 		h.AssertRekeyChainIntactForContext(h.SceneContext)
 	})
 })

--- a/test/integration/crypto/rekey_phase7_audit_failure_test.go
+++ b/test/integration/crypto/rekey_phase7_audit_failure_test.go
@@ -5,7 +5,7 @@
 
 // rekey_phase7_audit_failure_test.go — E2E spec for Phase 7 audit-emit failure.
 //
-// Covers INV-E13-PHASE7-AUDIT-OR-FALLBACK:
+// Covers INV-CRYPTO-100:
 //   - When the Phase 7 audit-event emit fails, the rekey DB state (DEK rows) is
 //     irreversibly committed (old DEK destroyed, new DEK active at version+1).
 //   - A fallback log file is written to <data_dir>/audit-fallback/rekey-<rid>.log.
@@ -13,7 +13,7 @@
 //     possible.
 //   - The Rekey RPC returns DEK_REKEY_PHASE7_AUDIT_FAILED.
 //
-// Spec: §4.3 Phase 7, INV-E13.
+// Spec: §4.3 Phase 7, INV-CRYPTO-100.
 //
 // Part of holomush-jxo8.7 (bead jxo8.7.38, merged T43+T44).
 package crypto_test
@@ -31,7 +31,7 @@ import (
 )
 
 // alwaysFailAuditEmitter satisfies dek.AuditEmitter and always returns an error.
-// Used to simulate Phase 7 audit-emit failure in E2E tests (INV-E13).
+// Used to simulate Phase 7 audit-emit failure in E2E tests (INV-CRYPTO-100).
 type alwaysFailAuditEmitter struct{}
 
 func (*alwaysFailAuditEmitter) Emit(_ context.Context, p dek.RekeyAuditPayload) (ulid.ULID, dek.RekeyAuditPayload, error) {
@@ -39,7 +39,7 @@ func (*alwaysFailAuditEmitter) Emit(_ context.Context, p dek.RekeyAuditPayload) 
 }
 
 var _ = Describe("Rekey Phase 7 audit failure", func() {
-	It("commits DB state and writes fallback log on emit failure (INV-E13)", func() {
+	It("commits DB state and writes fallback log on emit failure (INV-CRYPTO-100)", func() {
 		h := SetupRekeyHarness(suiteT, WithEventCount(20))
 		defer h.Cleanup()
 
@@ -61,9 +61,9 @@ var _ = Describe("Rekey Phase 7 audit failure", func() {
 		)
 		Expect(rekeyErr).To(HaveOccurred(), "rekey must fail when audit emit fails")
 		Expect(rekeyErr.Error()).To(ContainSubstring("DEK_REKEY_PHASE7_AUDIT_FAILED"),
-			"INV-E13: error code must be DEK_REKEY_PHASE7_AUDIT_FAILED")
+			"INV-CRYPTO-100: error code must be DEK_REKEY_PHASE7_AUDIT_FAILED")
 
-		// INV-E13: DB state must be irreversibly committed.
+		// INV-CRYPTO-100: DB state must be irreversibly committed.
 		// Phase 6 destroyed the old DEK and Phase 2 minted version 2 as the active DEK.
 		h.AssertCryptoKeysActiveVersion(h.SceneContext, 2)
 
@@ -79,12 +79,12 @@ var _ = Describe("Rekey Phase 7 audit failure", func() {
 
 		h.AssertCryptoKeysDestroyedAtSet(ckpt.OldDEKID)
 
-		// INV-E13: fallback log must be written at
+		// INV-CRYPTO-100: fallback log must be written at
 		// <data_dir>/audit-fallback/rekey-<request_id>.log.
 		logPath := filepath.Join(dataDir, "audit-fallback",
 			"rekey-"+ckpt.RequestID.String()+".log")
 		Expect(logPath).To(BeAnExistingFile(),
-			"INV-E13: fallback log must be written when Phase 7 audit emit fails")
+			"INV-CRYPTO-100: fallback log must be written when Phase 7 audit emit fails")
 
 		// Checkpoint must be at phase7_audit (not complete) — retry is possible.
 		h.AssertCheckpointStatus(ckpt.RequestID, dek.CheckpointStatusPhase7Audit)

--- a/test/integration/crypto/rekey_policy_hash_frozen_at_phase1_test.go
+++ b/test/integration/crypto/rekey_policy_hash_frozen_at_phase1_test.go
@@ -3,11 +3,11 @@
 
 //go:build integration
 
-// rekey_policy_hash_frozen_at_phase1_test.go — E2E spec for INV-E25:
+// rekey_policy_hash_frozen_at_phase1_test.go — E2E spec for INV-CRYPTO-112:
 // the policy_hash captured at Phase 1 INSERT is frozen for the lifetime
 // of the rekey operation.
 //
-// Verifies INV-E25: a mid-Rekey policy edit (which emits a new policy_set
+// Verifies INV-CRYPTO-112: a mid-Rekey policy edit (which emits a new policy_set
 // chain event and changes the policy_set chain's tail hash) does NOT change
 // the policy_hash embedded in the rekey audit event. The Phase 7 audit emit
 // reads policy_hash from the checkpoint row (set at Phase 1), not from the
@@ -32,7 +32,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 )
 
-var _ = Describe("Rekey policy_hash frozen at Phase 1 (INV-E25)", func() {
+var _ = Describe("Rekey policy_hash frozen at Phase 1 (INV-CRYPTO-112)", func() {
 	It("captures policy_hash at Phase 1 INSERT; mid-Rekey policy edit does not change it", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
@@ -43,33 +43,33 @@ var _ = Describe("Rekey policy_hash frozen at Phase 1 (INV-E25)", func() {
 		h.RememberCurrentPolicyHash("dual_control_required")
 
 		// Drive Phase 1 directly (bypassing the UDS). This inserts a non-terminal
-		// checkpoint row with policy_hash = zeros (genesis sentinel per INV-E25).
+		// checkpoint row with policy_hash = zeros (genesis sentinel per INV-CRYPTO-112).
 		// The checkpoint is left at phase1_auth so the dispatcher treats it as
 		// non-terminal (resume path, not fresh-start) on the next UDS call.
 		firstRID := openNonTerminalCheckpoint(h, "inv-e25-test-justification")
 
 		// Edit the policy mid-Rekey: emit a new crypto.policy_set genesis event.
 		// This advances the policy chain tail hash to a non-zero value.
-		// The checkpoint's policy_hash MUST NOT reflect this change (INV-E25).
+		// The checkpoint's policy_hash MUST NOT reflect this change (INV-CRYPTO-112).
 		require.NoError(suiteT, h.Primary.EditDualControlRequired([]string{"admin_read_stream"}))
 
 		// Resume via the UDS. The dispatcher auto-resumes the existing non-terminal
-		// checkpoint (same op_args_hash, same operator = INV-E4 + INV-E16). Phase 7
+		// checkpoint (same op_args_hash, same operator = INV-CRYPTO-91 + INV-CRYPTO-103). Phase 7
 		// must read policy_hash from the checkpoint row — NOT from the live chain.
 		out, err := h.AdminCli.Rekey(h.SceneContext, "inv-e25-test-justification")
 		Expect(err).NotTo(HaveOccurred(),
-			"INV-E25: resumed rekey must complete without error")
+			"INV-CRYPTO-112: resumed rekey must complete without error")
 
-		// The resumed rekey MUST reuse the original request_id (INV-E4).
+		// The resumed rekey MUST reuse the original request_id (INV-CRYPTO-91).
 		var resumedRID dek.RequestID
 		copy(resumedRID[:], out.RequestID())
 		Expect(resumedRID).To(Equal(firstRID),
-			"INV-E4: resume MUST reuse the original RequestID")
+			"INV-CRYPTO-91: resume MUST reuse the original RequestID")
 
 		// Load the rekey audit event emitted by Phase 7 and assert its
 		// policy_hash equals the hash captured at Phase 1 (before the policy edit).
 		evt := h.LoadRekeyAuditEvent(out.RequestID())
 		Expect(evt.PolicyHash).To(Equal(h.OriginalPolicyHash),
-			"INV-E25: Phase 7 audit event policy_hash MUST equal the Phase 1 captured hash — a mid-Rekey policy edit MUST NOT shift it")
+			"INV-CRYPTO-112: Phase 7 audit event policy_hash MUST equal the Phase 1 captured hash — a mid-Rekey policy edit MUST NOT shift it")
 	})
 })

--- a/test/integration/crypto/rekey_resume_rpc_test.go
+++ b/test/integration/crypto/rekey_resume_rpc_test.go
@@ -11,9 +11,9 @@
 // directly and delegates to Orchestrator.RunByRequestID.
 //
 // Verifies:
-//   - INV-E4 (resume-not-restart): RekeyResume reuses the original RequestID when
+//   - INV-CRYPTO-91 (resume-not-restart): RekeyResume reuses the original RequestID when
 //     given the exact request_id bytes from Phase 1.
-//   - INV-E16 (operator binding): RekeyResume with a request_id owned by a different
+//   - INV-CRYPTO-103 (operator binding): RekeyResume with a request_id owned by a different
 //     player is rejected with DEK_REKEY_RESUME_OPERATOR_MISMATCH.
 //   - Bug regression (code-reviewer finding, phase5-sub-epic-e): RekeyRunRequest.RequestID
 //     was discarded with `_ = ridFixed` before this fix; Orchestrator.RunByRequestID
@@ -80,7 +80,7 @@ func runRekeyResumeViaUDS(
 }
 
 var _ = Describe("RekeyResume RPC explicit request_id path", func() {
-	It("resumes by request_id and reuses the original RequestID (INV-E4, bug regression)", func() {
+	It("resumes by request_id and reuses the original RequestID (INV-CRYPTO-91, bug regression)", func() {
 		// Boot the harness with default fixture.
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
@@ -102,7 +102,7 @@ var _ = Describe("RekeyResume RPC explicit request_id path", func() {
 		ckpt0, err := h.Primary.GetCheckpointRepo().Get(context.Background(), firstRID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt0.Status.IsTerminal()).To(BeFalse(),
-			"INV-E4: checkpoint must be non-terminal before resume")
+			"INV-CRYPTO-91: checkpoint must be non-terminal before resume")
 
 		// Call AdminService.RekeyResume with the explicit request_id.
 		// noopRekeySessionStore echoes the session token as the player_id.
@@ -119,19 +119,19 @@ var _ = Describe("RekeyResume RPC explicit request_id path", func() {
 		var returnedRID dek.RequestID
 		copy(returnedRID[:], out.RequestID)
 
-		// INV-E4: RunByRequestID must re-use the existing RequestID, not
+		// INV-CRYPTO-91: RunByRequestID must re-use the existing RequestID, not
 		// allocate a new one via RunPhase1Fresh.
 		Expect(returnedRID).To(Equal(firstRID),
-			"INV-E4: RekeyResume MUST NOT re-enter Phase 1 — RequestID must be stable")
+			"INV-CRYPTO-91: RekeyResume MUST NOT re-enter Phase 1 — RequestID must be stable")
 
 		// Checkpoint must be complete after the explicit resume.
 		h.AssertCheckpointStatus(firstRID, dek.CheckpointStatusComplete)
 
-		// Audit chain intact (INV-E14/E15).
+		// Audit chain intact (INV-CRYPTO-101/INV-CRYPTO-102).
 		h.AssertRekeyChainIntactForContext(h.SceneContext)
 	})
 
-	It("rejects RekeyResume from a different operator (INV-E16)", func() {
+	It("rejects RekeyResume from a different operator (INV-CRYPTO-103)", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
 
@@ -148,6 +148,6 @@ var _ = Describe("RekeyResume RPC explicit request_id path", func() {
 		)
 		Expect(err).To(HaveOccurred(), "different-operator RekeyResume must fail")
 		Expect(err.Error()).To(ContainSubstring("DEK_REKEY_RESUME_OPERATOR_MISMATCH"),
-			"INV-E16: wrong operator must receive DEK_REKEY_RESUME_OPERATOR_MISMATCH")
+			"INV-CRYPTO-103: wrong operator must receive DEK_REKEY_RESUME_OPERATOR_MISMATCH")
 	})
 })

--- a/test/integration/crypto/rekey_resume_test.go
+++ b/test/integration/crypto/rekey_resume_test.go
@@ -7,13 +7,13 @@
 // args-conflict paths.
 //
 // Verifies:
-//   - INV-E4 (resume-not-restart): after a non-terminal checkpoint is opened
+//   - INV-CRYPTO-91 (resume-not-restart): after a non-terminal checkpoint is opened
 //     directly via the orchestrator (simulating a pre-Phase-3 crash), the same
 //     args UDS invocation auto-resumes and completes with Resumed=true, reusing
 //     the original RequestID.
-//   - INV-E16 (operator binding): a different operator attempting to resume
+//   - INV-CRYPTO-103 (operator binding): a different operator attempting to resume
 //     with the same args is rejected with DEK_REKEY_RESUME_OPERATOR_MISMATCH.
-//   - INV-E24 (args-hash idempotency): a concurrent fresh-start attempt with
+//   - INV-CRYPTO-111 (args-hash idempotency): a concurrent fresh-start attempt with
 //     different args is rejected with DEK_REKEY_ARGS_CONFLICT when a
 //     non-terminal checkpoint exists for the same context.
 //
@@ -121,7 +121,7 @@ func openNonTerminalCheckpoint(h *Harness, justification string) dek.RequestID {
 }
 
 var _ = Describe("Rekey resume", func() {
-	It("auto-resumes same-args invocation after pre-Phase-2 park (INV-E4, INV-E16)", func() {
+	It("auto-resumes same-args invocation after pre-Phase-2 park (INV-CRYPTO-91, INV-CRYPTO-103)", func() {
 		// Boot the harness with default fixture.
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
@@ -135,12 +135,12 @@ var _ = Describe("Rekey resume", func() {
 		ckpt0, err := h.Primary.GetCheckpointRepo().Get(context.Background(), firstRID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt0.Status.IsTerminal()).To(BeFalse(),
-			"INV-E4: checkpoint must be non-terminal before resume")
+			"INV-CRYPTO-91: checkpoint must be non-terminal before resume")
 
 		// Second call via UDS: same player_id (session token = player ID via
 		// noopRekeySessionStore), same context, same justification → same
 		// op_args_hash → auto-resume path, bypassing dual-control approval
-		// (INV-E16).
+		// (INV-CRYPTO-103).
 		out, resumeErr := runRekeyViaUDSWithPlayer(
 			h,
 			h.AdminPlayer.PlayerID,
@@ -154,18 +154,18 @@ var _ = Describe("Rekey resume", func() {
 		var rid dek.RequestID
 		copy(rid[:], out.RequestID)
 
-		// INV-E4: dispatcher must re-use the existing RequestID, not allocate a new one.
+		// INV-CRYPTO-91: dispatcher must re-use the existing RequestID, not allocate a new one.
 		Expect(rid).To(Equal(firstRID),
-			"INV-E4: resume MUST NOT re-enter Phase 1 — RequestID must be stable")
+			"INV-CRYPTO-91: resume MUST NOT re-enter Phase 1 — RequestID must be stable")
 
 		// Checkpoint must be complete.
 		h.AssertCheckpointStatus(rid, dek.CheckpointStatusComplete)
 
-		// Audit chain intact (INV-E14/E15).
+		// Audit chain intact (INV-CRYPTO-101/INV-CRYPTO-102).
 		h.AssertRekeyChainIntactForContext(h.SceneContext)
 	})
 
-	It("rejects resume from a different operator (INV-E16)", func() {
+	It("rejects resume from a different operator (INV-CRYPTO-103)", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
 
@@ -184,10 +184,10 @@ var _ = Describe("Rekey resume", func() {
 		)
 		Expect(err).To(HaveOccurred(), "different-operator resume must fail")
 		Expect(err.Error()).To(ContainSubstring("DEK_REKEY_RESUME_OPERATOR_MISMATCH"),
-			"INV-E16: wrong operator must receive DEK_REKEY_RESUME_OPERATOR_MISMATCH")
+			"INV-CRYPTO-103: wrong operator must receive DEK_REKEY_RESUME_OPERATOR_MISMATCH")
 	})
 
-	It("rejects concurrent fresh start with different args (INV-E24)", func() {
+	It("rejects concurrent fresh start with different args (INV-CRYPTO-111)", func() {
 		h := SetupRekeyHarness(suiteT)
 		defer h.Cleanup()
 
@@ -205,6 +205,6 @@ var _ = Describe("Rekey resume", func() {
 		)
 		Expect(err).To(HaveOccurred(), "different-args fresh start must fail")
 		Expect(err.Error()).To(ContainSubstring("DEK_REKEY_ARGS_CONFLICT"),
-			"INV-E24: different args on same context must receive DEK_REKEY_ARGS_CONFLICT")
+			"INV-CRYPTO-111: different args on same context must receive DEK_REKEY_ARGS_CONFLICT")
 	})
 })

--- a/test/integration/crypto/rekey_sweep_ttl_test.go
+++ b/test/integration/crypto/rekey_sweep_ttl_test.go
@@ -3,10 +3,10 @@
 
 //go:build integration
 
-// rekey_sweep_ttl_test.go — E2E spec for INV-E18: the sweep subsystem aborts
+// rekey_sweep_ttl_test.go — E2E spec for INV-CRYPTO-105: the sweep subsystem aborts
 // stale checkpoints and emits a chained rekey audit event.
 //
-// Verifies INV-E18-SWEEP-TTL-AUDIT:
+// Verifies INV-CRYPTO-105:
 //   - A checkpoint whose last_heartbeat_at is older than TTL is auto-aborted
 //     by CheckpointSweepSubsystem.sweepOnce.
 //   - The sweep emits a chained rekey audit event with aborted_reason="ttl_expired"
@@ -62,7 +62,7 @@ func (p *sweepTestAuditPublisher) PublishAudit(
 }
 
 var _ = Describe("Rekey sweep TTL", func() {
-	It("aborts stale checkpoints and emits a chained audit event (INV-E18)", func() {
+	It("aborts stale checkpoints and emits a chained audit event (INV-CRYPTO-105)", func() {
 		h := SetupRekeyHarness(suiteT, WithEventCount(10))
 		defer h.Cleanup()
 
@@ -104,17 +104,17 @@ var _ = Describe("Rekey sweep TTL", func() {
 		Expect(sub.SweepOnceForTest(context.Background())).To(Succeed(),
 			"SweepOnceForTest must not return an error")
 
-		// INV-E18: the checkpoint MUST be aborted.
+		// INV-CRYPTO-105: the checkpoint MUST be aborted.
 		ckpt1, err := h.findCheckpointByID(rid)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ckpt1.Status).To(Equal(dek.CheckpointStatusAborted),
-			"INV-E18: TTL-expired checkpoint MUST be marked aborted by sweep")
+			"INV-CRYPTO-105: TTL-expired checkpoint MUST be marked aborted by sweep")
 		Expect(ckpt1.AbortedReason).NotTo(BeNil(),
-			"INV-E18: aborted_reason must be set")
+			"INV-CRYPTO-105: aborted_reason must be set")
 		Expect(*ckpt1.AbortedReason).To(Equal("ttl_expired"),
-			"INV-E18: aborted_reason MUST be ttl_expired")
+			"INV-CRYPTO-105: aborted_reason MUST be ttl_expired")
 
-		// INV-E18: a chained rekey audit event MUST be emitted.
+		// INV-CRYPTO-105: a chained rekey audit event MUST be emitted.
 		// The event is written to events_audit by sweepTestAuditPublisher.
 		// Assert it landed by checking the events_audit table directly.
 		h.AssertAuditEventEmitted(
@@ -130,12 +130,12 @@ var _ = Describe("Rekey sweep TTL", func() {
 			  ORDER BY js_seq DESC LIMIT 1`,
 			"events.g1.system.rekey.scene.%").Scan(&envelopeBytes)
 		Expect(queryErr).NotTo(HaveOccurred(),
-			"INV-E18: must be able to read the emitted sweep audit event")
+			"INV-CRYPTO-105: must be able to read the emitted sweep audit event")
 
 		var payload dek.RekeyAuditPayload
 		Expect(json.Unmarshal(envelopeBytes, &payload)).To(Succeed(),
-			"INV-E18: sweep audit payload must be valid RekeyAuditPayload JSON")
+			"INV-CRYPTO-105: sweep audit payload must be valid RekeyAuditPayload JSON")
 		Expect(payload.Justification).To(ContainSubstring("ttl_expired"),
-			"INV-E18: audit Justification MUST reference ttl_expired")
+			"INV-CRYPTO-105: audit Justification MUST reference ttl_expired")
 	})
 })

--- a/web/src/lib/connect/holomush/admin/v1/admin_connect.ts
+++ b/web/src/lib/connect/holomush/admin/v1/admin_connect.ts
@@ -111,7 +111,7 @@ export const AdminService = {
     /**
      * RekeyResume resumes a paused or interrupted rekey identified by
      * request_id. Requires the crypto.operator capability and admin role
-     * (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+     * (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
      * enforced inside the orchestrator, not here. The handler validates that
      * request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
      * adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -130,7 +130,7 @@ export const AdminService = {
      * RekeyAbort cancels an in-progress rekey checkpoint. Requires the
      * crypto.operator capability only; no admin role re-check and no
      * dual-control approval — abort is single-control regardless of site
-     * policy (INV-E17). Any crypto.operator session may abort any non-terminal
+     * policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
      * checkpoint, not just the primary operator who started it.
      * Handler: internal/admin/socket/rekey_handler.go.
      *

--- a/web/src/lib/connect/holomush/admin/v1/admin_pb.ts
+++ b/web/src/lib/connect/holomush/admin/v1/admin_pb.ts
@@ -340,7 +340,7 @@ export const AdminService: GenService<{
   /**
    * RekeyResume resumes a paused or interrupted rekey identified by
    * request_id. Requires the crypto.operator capability and admin role
-   * (INV-CRYPTO-83). Idempotency (INV-E16) and same-args invariant (INV-E4) are
+   * (INV-CRYPTO-83). Idempotency (INV-CRYPTO-103) and same-args invariant (INV-CRYPTO-91) are
    * enforced inside the orchestrator, not here. The handler validates that
    * request_id is a non-zero 16-byte ULID and forwards it to the orchestrator
    * adapter, which looks up the checkpoint to resolve ContextType/ContextID.
@@ -358,7 +358,7 @@ export const AdminService: GenService<{
    * RekeyAbort cancels an in-progress rekey checkpoint. Requires the
    * crypto.operator capability only; no admin role re-check and no
    * dual-control approval — abort is single-control regardless of site
-   * policy (INV-E17). Any crypto.operator session may abort any non-terminal
+   * policy (INV-CRYPTO-104). Any crypto.operator session may abort any non-terminal
    * checkpoint, not just the primary operator who started it.
    * Handler: internal/admin/socket/rekey_handler.go.
    *

--- a/web/src/lib/connect/holomush/admin/v1/rekey_pb.ts
+++ b/web/src/lib/connect/holomush/admin/v1/rekey_pb.ts
@@ -50,7 +50,7 @@ export type RekeyRequest = Message<"holomush.admin.v1.RekeyRequest"> & {
   /**
    * context_id is the entity identifier within context_type, e.g. a scene
    * ULID. The orchestrator uses (context_type, context_id) to locate the
-   * active DEK and enforce INV-E5 (at most one non-terminal checkpoint per
+   * active DEK and enforce INV-CRYPTO-92 (at most one non-terminal checkpoint per
    * context at a time).
    *
    * @generated from field: string context_id = 3;
@@ -197,7 +197,7 @@ export const PhaseStartedSchema: GenMessage<PhaseStarted> = /*@__PURE__*/
  * cold-tier re-encryption phase. The orchestrator rewrites events_audit rows
  * in batches of up to 1000, decrypting each under the old DEK and
  * re-encrypting under the new DEK with AAD rebound to the new (dek_ref,
- * dek_version) — INV-E8. Clients may use these messages to render a
+ * dek_version) — INV-CRYPTO-95. Clients may use these messages to render a
  * progress bar; the stream is terminated by RekeyCompleted or RekeyError.
  *
  * @generated from message holomush.admin.v1.Phase3Progress
@@ -224,7 +224,7 @@ export type Phase3Progress = Message<"holomush.admin.v1.Phase3Progress"> & {
   /**
    * last_processed_event_id is the ULID bytes of the most recently committed
    * batch's last row. Stored as the Phase 3 resume cursor in the checkpoint
-   * row (INV-E7-COLD-RESUME-CURSOR); a crash and resume picks up exactly
+   * row (INV-CRYPTO-94); a crash and resume picks up exactly
    * where this cursor points.
    *
    * @generated from field: bytes last_processed_event_id = 3;
@@ -431,7 +431,7 @@ export const RekeyErrorSchema: GenMessage<RekeyError> = /*@__PURE__*/
 /**
  * RekeyResumeRequest resumes a paused or interrupted rekey operation identified
  * by request_id. The orchestrator determines the resume entry point from the
- * checkpoint's current FSM status and drives forward from there. INV-E16:
+ * checkpoint's current FSM status and drives forward from there. INV-CRYPTO-103:
  * resuming a complete checkpoint is a no-op that re-emits RekeyCompleted.
  * Resuming an aborted checkpoint surfaces DEK_REKEY_CHECKPOINT_TERMINAL.
  *
@@ -477,7 +477,7 @@ export const RekeyResumeRequestSchema: GenMessage<RekeyResumeRequest> = /*@__PUR
 
 /**
  * RekeyAbortRequest cancels a non-terminal rekey operation, transitioning its
- * checkpoint to the aborted state. Abort is single-control (INV-E17): any
+ * checkpoint to the aborted state. Abort is single-control (INV-CRYPTO-104): any
  * session holding crypto.operator capability may abort any non-terminal
  * checkpoint, regardless of site dual-control policy or which operator
  * initiated the rekey. Once aborted the checkpoint is terminal; a new Rekey
@@ -488,7 +488,7 @@ export const RekeyResumeRequestSchema: GenMessage<RekeyResumeRequest> = /*@__PUR
 export type RekeyAbortRequest = Message<"holomush.admin.v1.RekeyAbortRequest"> & {
   /**
    * session_token authenticates the aborting operator. Only crypto.operator
-   * capability is required — no admin role re-check (INV-E17).
+   * capability is required — no admin role re-check (INV-CRYPTO-104).
    *
    * @generated from field: string session_token = 1;
    */
@@ -640,7 +640,7 @@ export type RekeyStatusResponse = Message<"holomush.admin.v1.RekeyStatusResponse
   /**
    * last_heartbeat_at is the server timestamp of the most recent heartbeat
    * written by Phase 3. The sweep worker uses this to TTL-abort stalled
-   * checkpoints (INV-E18/E19). A value far in the past indicates a stalled
+   * checkpoints (INV-CRYPTO-105/INV-CRYPTO-106). A value far in the past indicates a stalled
    * or crashed orchestrator run.
    *
    * @generated from field: google.protobuf.Timestamp last_heartbeat_at = 7;

--- a/web/src/lib/connect/holomush/core/v1/core_pb.ts
+++ b/web/src/lib/connect/holomush/core/v1/core_pb.ts
@@ -2103,7 +2103,7 @@ export enum NoPlaintextReason {
   /**
    * NO_PLAINTEXT_REASON_STALE_DEK means both the hot and cold tier DEKs were
    * indecipherable — a production-real outcome after a sub-epic E rekey plus DEK
-   * destruction (INV-E21 double miss).
+   * destruction (INV-CRYPTO-108 double miss).
    *
    * @generated from enum value: NO_PLAINTEXT_REASON_STALE_DEK = 2;
    */

--- a/web/src/lib/connect/holomush/plugin/v1/audit_pb.ts
+++ b/web/src/lib/connect/holomush/plugin/v1/audit_pb.ts
@@ -395,7 +395,7 @@ export type RowResult = Message<"holomush.plugin.v1.RowResult"> & {
      * (recipient not authorized by manifest declaration / ABAC grant — Phase 3b
      * AuthGuard deny), "downgrade_refused" (INV-CRYPTO-42 fence — sensitive event
      * stored under identity codec), "dek_missing" (INV-CRYPTO-50 fence — no DEK
-     * exists for this row's context), "stale_dek" (INV-E21 — both hot and cold
+     * exists for this row's context), "stale_dek" (INV-CRYPTO-108 — both hot and cold
      * DEK tiers gone), "audit_queue_full" (plugin audit-emit backpressure), and
      * "internal" (host-side error, details logged server-side only).
      *


### PR DESCRIPTION
## Summary
Migrates the **INV-E family** (crypto Phase-5 sub-epic-e, rekey/checkpoint) `INV-E1..E28` → canonical **INV-CRYPTO-88..115**. Closed-world annotation-id rename; **no behavior change**. The largest migration of the epic (88 files).

This is the **rekey/checkpoint** family: checkpoint state-machine (monotonic / no-skip / terminal / resume-match / one-active), the 7-phase rekey orchestration (participant invariance, cold-resume cursor, AAD rebuild, force-destroy gating, phase-6 idempotency, phase-7 audit-or-fallback), the rekey **audit hash-chain** (prev-hash, boot verifier, subject-prefix, scope-payload match, pinned recompose), resume/abort auth, TTL sweep + heartbeat, dispatcher fallback AAD, invalidation reuse, CLI exit codes. Sibling of INV-D/INV-F (already CRYPTO); **E was missed** (.14.28 census).

### Mechanics
- `INV-E1..E28 → INV-CRYPTO-88..115` (dense +87). E3/E9 spec-only (`refs:[]`).
- **Dual-form**: 10 invariants carried both a plain (`INV-E6`) and a descriptive-suffix (`INV-E6-PARTICIPANT-INVARIANCE`) annotation. Both normalize to the bare canonical; suffixed refs recorded **before** plain so the whole-token rewrite collapses the long form first — **zero dangling `-SUFFIX`** verified repo-wide.
- Most INV-E lives in already-CRYPTO-owned dirs (`crypto/dek/**`, `audit/chain/**`, `history/**`, `test/integration/crypto/**`); 7 new owned + 2 new shared. Generated `pkg/proto/**` excluded (adminv1connect slip caught by guard). Proto regen ×3.
- **Left intentionally**: `spec_amendments_test.go` retains a literal `"INV-E16"` spec-fingerprint (matched against the un-migrated master spec) — moved owned→shared in INV-ACCESS so the .14.21 residual legacy-token guard skips it. Filed: a stray `INV-F-policy_hash` (.14.23 dual-form miss).

### Verification
`task pr-prep` **pass**. Guard + partition + binding + full `task lint` + 878 unit tests + build + integration-compile green. CRYPTO entries now **1..115**.

### Reviews
- **crypto-reviewer: READY** — every security path (checkpoint FSM, AAD rebuild, audit-chain verifier/recompose, force-destroy/sweep gates, resume/abort auth) byte-identical; dual-form normalization correct.
- **code-reviewer: READY** — dense 1..115; all 177 canonical refs physically present; zero INV-E residual / zero dangling suffix; spec_amendments move correct; no generated file recorded as a ref; zero executable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)