### PR TITLE
refactor(invariants): normalize stray INV-F-policy_hash → INV-CRYPTO-53 (holomush-hz0v4.14.32)

### DIFF
--- a/cmd/holomush/readstream_wiring.go
+++ b/cmd/holomush/readstream_wiring.go
@@ -150,7 +150,7 @@ func buildReadStreamWiring(
 		grants = readstreamGrantsOverrideForTest
 	}
 
-	// Compute the canonical policy_hash string. INV-CRYPTO-112 / INV-F-policy_hash:
+	// Compute the canonical policy_hash string. INV-CRYPTO-112 / INV-CRYPTO-53:
 	// the audit payload stores "sha256:<hex>"; the ReadStarted wire frame
 	// decodes back to the raw 32 bytes via decodeHashString. Genesis (no
 	// crypto.policy_set chain entries) maps to the all-zero 32-byte

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -91,7 +91,8 @@ scopes:
       # CRYPTO+STORE: history files carrying both P7/RB and TS (nanos) annotations.
       # INV-D sub-epic-d co-located with sibling INV-E (migrating .14.30) / go.mod dep-pins / multi-scope.
       - "api/proto/holomush/admin/v1/rekey.proto"
-      # INV-E sub-epic-e: readstream policy_hash wiring (+ stray INV-F-policy_hash, holomush bead) / multi-scope test server.
+      # INV-E sub-epic-e: readstream policy_hash wiring (INV-CRYPTO-112/53; the .14.23 stray
+      # INV-F-policy_hash descriptive label was normalized to INV-CRYPTO-53 in .14.32) / multi-scope test server.
       - "cmd/holomush/readstream_wiring.go"
       - "internal/testsupport/holomushtest/server.go"
       - "go.mod"


### PR DESCRIPTION
## Summary
Resolves the single dangling `INV-F-policy_hash` token in `cmd/holomush/readstream_wiring.go` (a `.14.23` leftover surfaced during `.14.30`). **Comment-only**; zero behavior change.

`INV-F-policy_hash` was never a registered invariant — it appears nowhere in the sub-epic-f spec or registry; it's a **descriptive cross-reference label** the `.14.23` INV-F→CRYPTO migration left because it isn't a numbered `INV-Fn` token. The comment documents the AdminReadStream ReadStarted policy_hash encoding (`sha256:<hex>` → 32 bytes), governed by the operator-read audit family (INV-F1..F17 → INV-CRYPTO-53..67). Normalized the label to **INV-CRYPTO-53** (the operator_read audit invariant that carries the policy_hash), preserving the dual cross-reference with INV-CRYPTO-112 (rekey policy_hash @ phase 1). Updated the `.14.30` shared_files comment that flagged the stray.

### Verification
`task pr-prep` **pass**. Guard + lint:invariants + cmd/holomush tests (523) + build green. **code-reviewer: READY** — confirmed comment-only (the `PolicyHashSrc.CurrentPolicyHash` computation is untouched), mapping accurate, zero `INV-F-policy_hash` remains in code, no orphan. crypto-reviewer confirmed not required (doc cross-ref, no crypto behavior).

With this, **zero un-classified / dangling `INV-*` tokens remain** in code — the registry residual is truly clean for `.14.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)