### PR TITLE
fix(invariants): revert 2 false-green bindings + guard against Skip-only bindings

### DIFF
--- a/.claude/rules/invariants.md
+++ b/.claude/rules/invariants.md
@@ -33,13 +33,22 @@ The live binding-backfill status lives in `docs/roadmap.md` → Maintenance.
 
 ## What rises to a registry invariant
 
-Register a guarantee when it is a **durable, system-level property** — a
-cross-cutting MUST/MUST NOT that future work could silently break and that you
-want a test to pin forever (fail-closed ABAC defaults, no-plaintext-to-non-participant,
-runtime symmetry, ordering ownership). Do NOT register every RFC2119 MUST: a
-local feature requirement ("the create-scene RPC MUST return the new ID") is not
-an invariant. Rule of thumb: if violating it is a *regression in a guarantee*
-rather than a *missing feature*, it is an invariant.
+Register a guarantee when it is a **durable property that future work could
+silently break and that a test can pin forever**. Rule of thumb: if violating it
+is a *regression in a guarantee* rather than a *missing feature*, it is an
+invariant. Do NOT register every RFC2119 MUST: a local feature requirement ("the
+create-scene RPC MUST return the new ID") is not an invariant.
+
+### In scope vs. out of scope
+
+| In scope | Out of scope |
+| --- | --- |
+| **System-behavior guarantees** — fail-closed ABAC defaults, no-plaintext-to-non-participant, runtime symmetry, ordering ownership. The core of the registry. | **Migration / refactor-completeness bookkeeping** — "every pre-consolidation test is named in a `// replaces:` chain". Tracks a one-time migration, not a durable guarantee. |
+| **Test-infrastructure fidelity** — durable guarantees about *how the system is verified* (e.g. "the load harness drives the real Connect/TCP path, never a stub"; "`sessiontest.NewStore` returns an isolated store per call"). These can be silently broken and are worth pinning. Keep them, but make the summary state the **guarantee**, not the harness wiring. | **Self-admitted documentary / non-testable notes** — anything whose own summary says "documentary", "verified by spec review", "operational property, not an invariant", or describes a transient phase-implementation detail ("Phase 4 introduces no status transitions"). If no test can fail when it's violated, it is not an invariant. |
+
+Borderline test-infra entries SHOULD be phrased as the property under test, not
+the test's construction ("no `t.Fatalf`", "adds zero production code", "E6
+acceptance" are PR acceptance criteria, not invariants).
 
 Pick the **scope** by its declared `boundary` in `invariants.yaml` (CRYPTO,
 SCENE, PLUGIN, EVENTBUS, CLUSTER, ACCESS, SESSION, STORE, TELEMETRY, PRIVACY,
@@ -75,11 +84,12 @@ An invariant is only *proven* when a test asserts it. The mechanism:
 3. In `invariants.yaml`, set the entry `binding: bound` and add `asserted_by:`
    listing the verifying test file(s).
 4. Regenerate: `go run ./cmd/inv-render`.
-5. Confirm: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard' ./test/meta/`.
+5. Confirm: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestProvenanceGuard|TestBoundInvariantsAreGenuinelyAsserted' ./test/meta/`.
 
 | Requirement | Rule |
 | --- | --- |
-| **MUST NOT** fabricate a binding | If no test genuinely asserts the invariant, that is a real coverage gap — file `bd create -t bug` and leave it `binding: pending`. A `// Verifies:` on a test that doesn't actually prove the invariant is a false-green (this is precisely what bug `holomush-0sh1k`/INV-RB-3 was). |
+| **MUST NOT** fabricate a binding | If no test genuinely asserts the invariant, that is a real coverage gap — file `bd create -t bug` and leave it `binding: pending`. A `// Verifies:` on a test that doesn't actually prove the invariant is a false-green (this is precisely what bug `holomush-0sh1k`/INV-RB-3 was, and INV-PRIVACY-7 bound to a `Skip()` placeholder). |
+| **MUST NOT** bind a `Skip`/placeholder test | `TestBoundInvariantsAreGenuinelyAsserted` fails CI if a `bound` entry's every `// Verifies:` site is a Skip-only placeholder with no assertion. Note its limit: it cannot detect a *partial* binding (a test that asserts only one clause of a multi-clause invariant — that needs human review, as INV-PRIVACY-6 did). |
 | **MUST NOT** carry `asserted_by` while pending | The meta-test rejects a `binding: pending` entry that lists `asserted_by` — no fabricated provenance. |
 | **MAY** stay pending | `pending` is a tolerated state (decision `holomush-hz0v4.10`); backfill is a ratchet, not a blocker. Per-scope backfill is tracked under epic `holomush-hz0v4`. |
 

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -175,8 +175,8 @@ invariants.
 | `INV-PRIVACY-3` | Subscribe.ReattachCAS and SelectCharacter reattach leave LocationArrivedAt UNCHANGED and MUST NOT change the durable's DeliverPolicy/OptStartTime/OptStartSeq (FilterSubjects may change). | `I-PRIV-3` | bound |
 | `INV-PRIVACY-4` | Idle status change and transport/SelectCharacter reattach MUST NOT advance LocationArrivedAt. | `I-PRIV-4` | bound |
 | `INV-PRIVACY-5` | All denial paths (hard-gate, I-17, ABAC, expired/missing session) return the same wire code STREAM_ACCESS_DENIED; the internal denial_reason is slog-only and never crosses the wire. | `I-PRIV-5` | bound |
-| `INV-PRIVACY-6` | ABAC staff override bypasses the hard-gate location-match only, NOT the temporal floor. | `I-PRIV-6` | bound |
-| `INV-PRIVACY-7` | Plugin-owned subjects with divergent history-replay semantics MUST declare history_scope in the manifest and be exercised by a test; silent inheritance of permissive semantics is forbidden. | `I-PRIV-7` | bound |
+| `INV-PRIVACY-6` | ABAC staff override bypasses the hard-gate location-match only, NOT the temporal floor. | `I-PRIV-6` | pending |
+| `INV-PRIVACY-7` | Plugin-owned subjects with divergent history-replay semantics MUST declare history_scope in the manifest and be exercised by a test; silent inheritance of permissive semantics is forbidden. | `I-PRIV-7` | pending |
 | `INV-PRIVACY-8` | OpenSession (incl. reattach) and SetFilters query the existing durable before CreateOrUpdateConsumer; an existing durable's DeliverPolicy/OptStartTime/OptStartSeq are copied verbatim (only FilterSubjects mutates); NATS is the source of truth. | `I-PRIV-8` | bound |
 
 ### `INV-PRESENCE`

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -1961,9 +1961,11 @@ invariants:
     origin_spec: "docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md"
     legacy: ["I-PRIV-6@docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md"]
     summary: "ABAC staff override bypasses the hard-gate location-match only, NOT the temporal floor."
-    asserted_by:
-      - "test/integration/privacy/privacy_test.go"
-    binding: bound
+    # binding: pending — only the gate-bypass arm is exercised; the
+    # floor-preservation arm (staff still bounded by their own LocationArrivedAt)
+    # is NOT tested (the integrationtest harness can't emit timestamp-controlled
+    # events across a session boundary yet). Re-bind once that arm has a test.
+    binding: pending
     refs:
       - {file: "internal/access/policy/seed.go", token: "I-PRIV-6"}
       - {file: "internal/access/policy/seed_test.go", token: "I-PRIV-6"}
@@ -1978,9 +1980,10 @@ invariants:
     legacy: ["I-PRIV-7@docs/superpowers/specs/2026-05-17-history-scope-privacy-design.md"]
     summary: "Plugin-owned subjects with divergent history-replay semantics MUST declare history_scope in the manifest and
       be exercised by a test; silent inheritance of permissive semantics is forbidden."
-    asserted_by:
-      - "test/integration/privacy/privacy_test.go"
-    binding: bound
+    # binding: pending — the only annotated test is a Skip() placeholder
+    # (no plugin currently declares history_scope: custom). Re-bind when a
+    # custom-scope plugin lands and the test replaces Skip with a real assertion.
+    binding: pending
     refs:
       - {file: "internal/plugin/manifest.go", token: "I-PRIV-7"}
       - {file: "test/integration/privacy/privacy_test.go", token: "I-PRIV-7"}

--- a/test/meta/invariant_registry_test.go
+++ b/test/meta/invariant_registry_test.go
@@ -1011,3 +1011,284 @@ func TestOwnedPathsPartitionSemantics(t *testing.T) {
 		})
 	}
 }
+
+// assertionCallRE matches a real assertion *call* (testify / gomega / std), not a
+// prose mention of the word "assert" in a comment. Used to tell a genuine test
+// from a Skip-only placeholder when validating bound invariants.
+var assertionCallRE = regexp.MustCompile(`(?:assert|require)\.[A-Za-z]+\(|\bExpect\(|\bEventually\(|\bConsistently\(|\.Should(?:Not)?\(|\bt\.(?:Errorf?|Fatalf?)\(`)
+
+// skipCallRE matches a test-skip call (std `t.Skip(` or ginkgo `Skip(`).
+var skipCallRE = regexp.MustCompile(`\b(?:t\.)?Skip\(`)
+
+// blockStartRE matches the start of a test block — a top-level Go decl
+// (`func `, `var _ = `) OR a (possibly indented, possibly focus/pending-prefixed)
+// Ginkgo container/spec opener (`Describe`/`Context`/`When`/`It`/`Specify`/
+// `DescribeTable`/`Entry`). The leading-whitespace capture group records the
+// block's indentation so a nested spec can be scoped to itself rather than its
+// outer `Describe` (Qodo finding on PR #4393: top-level-only scoping let a
+// Skip-only nested spec be masked by an asserting sibling).
+var blockStartRE = regexp.MustCompile(`^(\s*)(?:func |var _ = |(?:F|P|X)?(?:Describe|Context|When|It|Specify)\(|DescribeTable(?:Subtree)?\(|Entry\()`)
+
+// blockStart is one block opener: its line index and indentation width.
+type blockStart struct {
+	line   int
+	indent int
+}
+
+// findBlockStarts returns every block opener in source order.
+func findBlockStarts(lines []string) []blockStart {
+	var bs []blockStart
+	for i, l := range lines {
+		if m := blockStartRE.FindStringSubmatch(l); m != nil {
+			bs = append(bs, blockStart{line: i, indent: len(m[1])})
+		}
+	}
+	return bs
+}
+
+// scopedBlock returns the source block that a `// Verifies:` annotation at line
+// annLine documents: the nearest following opener, bounded by the next opener at
+// the SAME-or-shallower indentation (a sibling or an outer block). This scopes an
+// indented Ginkgo spec to itself — its own nested children (deeper indent) are
+// included, but a sibling spec is not — so a Skip-only nested spec is classified
+// on its own merits and cannot be masked by an asserting sibling.
+func scopedBlock(lines []string, starts []blockStart, annLine int) string {
+	own := -1
+	ownIndent := 0
+	for _, b := range starts {
+		if b.line >= annLine {
+			own, ownIndent = b.line, b.indent
+			break
+		}
+	}
+	if own == -1 {
+		return "" // annotation after the last opener — nothing to classify
+	}
+	end := len(lines)
+	for _, b := range starts {
+		if b.line > own && b.indent <= ownIndent {
+			end = b.line
+			break
+		}
+	}
+	return strings.Join(lines[own:end], "\n")
+}
+
+// classifyTestBlock classifies one top-level test block:
+//
+//	"asserts"  — contains at least one assertion call (genuine)
+//	"skiponly" — contains a Skip() and NO assertion call (placeholder)
+//	"bare"     — neither (e.g. asserts only via an unrecognized helper) — not
+//	             flagged, to avoid false-positives on helper-based assertions
+//
+// Factored out so the decision is unit-testable (TestClassifyTestBlock).
+func classifyTestBlock(block string) string {
+	if assertionCallRE.MatchString(block) {
+		return "asserts"
+	}
+	if skipCallRE.MatchString(block) {
+		return "skiponly"
+	}
+	return "bare"
+}
+
+// isPlaceholderOnly reports whether a bound invariant's `// Verifies:` sites are
+// EVERY one a Skip-only placeholder — the only state the guard flags. A single
+// "asserts" site means genuine; a "bare" site (assertion via a helper the
+// classifier doesn't recognize) is TOLERATED, not treated as a placeholder, so a
+// mixed bare+skiponly binding is NOT flagged (the verdict must match the
+// "every site is Skip-only" contract — CodeRabbit, PR #4393). Empty input is not
+// a placeholder: the missing-annotation case belongs to
+// TestEveryRegistryInvariantHasBinding.
+func isPlaceholderOnly(classes []string) bool {
+	if len(classes) == 0 {
+		return false
+	}
+	for _, c := range classes {
+		if c != "skiponly" {
+			return false
+		}
+	}
+	return true
+}
+
+// TestBoundInvariantsAreGenuinelyAsserted guards against false-green bindings:
+// a registry entry marked binding: bound whose every `// Verifies:` annotation
+// sits on a Skip-only placeholder. The binding-presence check
+// (TestEveryRegistryInvariantHasBinding) only checks the annotation EXISTS — it
+// cannot tell a real assertion from a Skip("not implemented yet") placeholder.
+// Regression: INV-PRIVACY-7 was bound to a Skip placeholder and INV-PRIVACY-6 to
+// a half-covered test; both were caught only by a manual audit before this guard
+// existed.
+//
+// It flags ONLY the unambiguous failure mode (every site is Skip-only with no
+// assertion). A "bare" block (no assertion call, no Skip — e.g. assertion via an
+// unrecognized helper) is tolerated to avoid false-positives; the
+// binding-presence test still owns the "annotation entirely missing" case.
+func TestBoundInvariantsAreGenuinelyAsserted(t *testing.T) {
+	root := findRepoRoot(t)
+	reg := loadRegistry(t)
+
+	bound := make(map[string]bool)
+	for _, e := range reg.Invariants {
+		if e.External || e.Binding == "" || e.Binding == "pending" {
+			continue
+		}
+		bound[e.ID] = true
+	}
+
+	// Read test files through an os.Root rooted at the repo so the read path is
+	// constrained to the repo tree (no Gosec G304 suppression needed — same
+	// pattern as TestEveryRegistryInvariantHasBinding).
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatalf("open repo root: %v", err)
+	}
+	defer func() { _ = rootFS.Close() }()
+
+	classes := make(map[string][]string) // INV-ID -> block classification per site
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, skip := skipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		f, openErr := rootFS.Open(rel)
+		if openErr != nil {
+			return openErr
+		}
+		data, readErr := io.ReadAll(f)
+		closeErr := f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		lines := strings.Split(string(data), "\n")
+		starts := findBlockStarts(lines)
+		for i, l := range lines {
+			m := registryVerifiesRE.FindStringSubmatch(l)
+			if m == nil || !bound[m[1]] {
+				continue
+			}
+			block := scopedBlock(lines, starts, i)
+			if block == "" {
+				continue
+			}
+			classes[m[1]] = append(classes[m[1]], classifyTestBlock(block))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+
+	for id := range bound {
+		if isPlaceholderOnly(classes[id]) {
+			t.Errorf("%s: binding: bound but every // Verifies: site is a Skip-only placeholder with no assertion — false-green. Revert to binding: pending until a genuine assertion exists.", id)
+		}
+	}
+}
+
+// TestClassifyTestBlock unit-tests the genuine/placeholder classifier.
+func TestClassifyTestBlock(t *testing.T) {
+	cases := []struct{ name, block, want string }{
+		{"testify assert", "func TestX(t *testing.T) {\n\tassert.Equal(t, 1, 1)\n}", "asserts"},
+		{"testify require", "func TestX(t *testing.T) {\n\trequire.NoError(t, err)\n}", "asserts"},
+		{"gomega Expect", "var _ = It(\"x\", func() {\n\tExpect(got).To(Equal(1))\n})", "asserts"},
+		{"gomega Eventually", "var _ = It(\"x\", func() {\n\tEventually(f).Should(Succeed())\n})", "asserts"},
+		{"std t.Fatalf", "func TestX(t *testing.T) {\n\tif err != nil {\n\t\tt.Fatalf(\"x\")\n\t}\n}", "asserts"},
+		{"skip-only ginkgo", "var _ = It(\"x\", func() {\n\tSkip(\"not yet\")\n})", "skiponly"},
+		{"skip-only std", "func TestX(t *testing.T) {\n\tt.Skip(\"todo\")\n}", "skiponly"},
+		{"assert wins over conditional skip", "func TestX(t *testing.T) {\n\tif c {\n\t\tt.Skip(\"flaky precondition\")\n\t}\n\tassert.True(t, ok)\n}", "asserts"},
+		{"bare (helper-based)", "func TestX(t *testing.T) {\n\thelper(t)\n}", "bare"},
+		{"prose 'asserts' in a comment is not a call", "// this test asserts the thing\nfunc TestX(t *testing.T) {\n\thelper(t)\n}", "bare"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyTestBlock(tc.block); got != tc.want {
+				t.Errorf("classifyTestBlock(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScopedBlockNestedGinkgoNotMasked reproduces the Qodo PR #4393 finding: with
+// top-level-only block scoping, a Skip-only NESTED Ginkgo spec was masked by an
+// asserting sibling under the same outer Describe and wrongly classified
+// "asserts". Indentation-aware scoping must classify the nested Skip-only spec on
+// its own merits ("skiponly") while the sibling is "asserts".
+func TestScopedBlockNestedGinkgoNotMasked(t *testing.T) {
+	src := "package x\n" +
+		"\n" +
+		"var _ = Describe(\"outer suite\", func() {\n" +
+		"\t// Verifies: INV-FOO-1\n" +
+		"\tDescribe(\"skip-only nested spec\", func() {\n" +
+		"\t\tIt(\"placeholder\", func() {\n" +
+		"\t\t\tSkip(\"not implemented\")\n" +
+		"\t\t})\n" +
+		"\t})\n" +
+		"\n" +
+		"\t// Verifies: INV-FOO-2\n" +
+		"\tDescribe(\"asserting sibling\", func() {\n" +
+		"\t\tIt(\"does a thing\", func() {\n" +
+		"\t\t\tExpect(got).To(Equal(want))\n" +
+		"\t\t})\n" +
+		"\t})\n" +
+		"})\n"
+
+	lines := strings.Split(src, "\n")
+	starts := findBlockStarts(lines)
+	got := make(map[string]string)
+	for i, l := range lines {
+		m := registryVerifiesRE.FindStringSubmatch(l)
+		if m == nil {
+			continue
+		}
+		got[m[1]] = classifyTestBlock(scopedBlock(lines, starts, i))
+	}
+	if got["INV-FOO-1"] != "skiponly" {
+		t.Errorf("nested Skip-only spec: got %q, want skiponly (must not be masked by the asserting sibling)", got["INV-FOO-1"])
+	}
+	if got["INV-FOO-2"] != "asserts" {
+		t.Errorf("asserting sibling spec: got %q, want asserts", got["INV-FOO-2"])
+	}
+}
+
+// TestIsPlaceholderOnly unit-tests the verdict: a bound entry is a false-green
+// only when EVERY annotation site is Skip-only. A "bare" site (helper-asserted)
+// must NOT trip the failure even alongside a skiponly site (CodeRabbit, PR #4393).
+func TestIsPlaceholderOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want bool
+	}{
+		{"empty → not flagged", nil, false},
+		{"single skiponly → flagged", []string{"skiponly"}, true},
+		{"all skiponly → flagged", []string{"skiponly", "skiponly"}, true},
+		{"any asserts → not flagged", []string{"asserts"}, false},
+		{"asserts + skiponly → not flagged", []string{"asserts", "skiponly"}, false},
+		{"mixed bare + skiponly → not flagged", []string{"bare", "skiponly"}, false},
+		{"all bare → not flagged", []string{"bare"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPlaceholderOnly(tc.in); got != tc.want {
+				t.Errorf("isPlaceholderOnly(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

An audit of the registry against the `.claude/rules/invariants.md` bar found two **false-green bindings** introduced by the #4391 backfill — which checked that a `// Verifies:` annotation *exists*, not that the annotated test *asserts*:

- **INV-PRIVACY-7** was bound to a `Skip("no plugin declares history_scope: custom")` placeholder (`privacy_test.go:32-36`) that asserts nothing. → reverted to `pending`.
- **INV-PRIVACY-6** was bound to a test covering only the gate-bypass arm; its summary also guarantees the **floor-preservation** arm (staff still bounded by their own `LocationArrivedAt`), which the harness can't exercise yet (per the test's own comment). → reverted to `pending`.

## Hardening (so the class can't recur)

- **`TestBoundInvariantsAreGenuinelyAsserted`** — fails CI if a `bound` entry's every `// Verifies:` site is a Skip-only / assertion-free block. The existing binding-presence test only checks the annotation *exists*; this checks it *asserts*. **Proven to fire on INV-PRIVACY-7** before the revert.
- **`classifyTestBlock` + `TestClassifyTestBlock`** unit-test the genuine/placeholder/bare classifier (testify, gomega, std; rejects prose "assert" in comments).
- Block-scoping handles both column-0 annotations (scope to the decl below) and **indented** annotations (scope to the enclosing decl) — the latter fix per code-review, so the indented-annotation majority is validated against the *right* test, not a neighbor.

## Scope ruling (`.claude/rules/invariants.md`)

Added an in/out table: the registry holds **system-behavior guarantees** AND **test-infrastructure-fidelity guarantees**, but NOT migration/refactor-completeness bookkeeping or self-admitted documentary/phase notes. Borderline test-infra entries must state the property, not the harness wiring.

## Scope

`test/meta` + docs/registry only — **no production code touched**. `invariants.md` regenerated (30 → 28 bound).

## Follow-ups filed

- `holomush-hz0v4.20` — re-bind PRIVACY-6/7 when their test gaps close
- `holomush-hz0v4.21` — reclassify/remove the bar-failing entries the audit surfaced (self-admitted non-invariants `INV-CRYPTO-70`/`PLUGIN-14`/`CRYPTO-96`/`SESSION-4`, enforcement-conflated summaries, the test-fidelity cluster)
- Closed `holomush-9mxr.10.1` (stale — the presence dedup test was already rewritten to use a mock; INV-PRESENCE-9's binding is legitimate)

## Verification

- `task pr-prep` (fast lane) → `status=pass`
- `go run ./cmd/inv-render -check` → exit 0
- meta suite green; guard proven non-vacuous (fires on the placeholder, passes on all 28 genuine bound)
- `code-reviewer` → READY (the indented-scoping finding it raised is fixed in this PR)

Refs: holomush-hz0v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)