### PR TITLE
fix(scenes): omit location attr instead of empty-string sentinel (holomush-8cxo6)

### DIFF
--- a/plugins/core-scenes/resolver.go
+++ b/plugins/core-scenes/resolver.go
@@ -27,8 +27,9 @@ const resourceTypeScene = "scene"
 //
 // Per the spec section 5.5 hard-privacy boundary, this resolver MUST NOT
 // expose log content, vote tallies, or any other content that lives behind
-// the privacy boundary. Phase 1 only exposes owner/state/visibility/location
-// for use in the read-own-scene policy.
+// the privacy boundary. It exposes only non-content attributes
+// (id/owner/state/visibility/location/has_location/participants/invitees)
+// for use by scene read-access policies.
 type SceneResolver struct {
 	pluginv1.UnimplementedAttributeResolverServiceServer
 	store sceneStorer
@@ -54,6 +55,7 @@ func (r *SceneResolver) GetSchema(ctx context.Context, _ *pluginv1.GetSchemaRequ
 					"state":        pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
 					"visibility":   pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
 					"location":     pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING,
+					"has_location": pluginv1.AttributeType_ATTRIBUTE_TYPE_BOOL,
 					"participants": pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING_LIST,
 					"invitees":     pluginv1.AttributeType_ATTRIBUTE_TYPE_STRING_LIST,
 				},
@@ -92,27 +94,36 @@ func (r *SceneResolver) ResolveResource(ctx context.Context, req *pluginv1.Resol
 		if errors.As(err, &oe) && oe.Code() == "SCENE_NOT_FOUND" {
 			return nil, status.Errorf(codes.NotFound, "scene not found: %s", req.GetResourceId())
 		}
-		return nil, status.Errorf(codes.Internal, "failed to resolve scene: %v", err)
+		// Inner error is already captured on the span via recordError above;
+		// returning a generic message keeps internal detail (table names, query
+		// fragments) off the wire per .claude/rules/grpc-errors.md.
+		return nil, status.Error(codes.Internal, "failed to resolve scene") //nolint:wrapcheck // gRPC status errors pass through as-is
 	}
 
-	location := ""
-	if row.LocationID != nil {
-		location = *row.LocationID
+	attrs := map[string]*pluginv1.AttributeValue{
+		"id":         {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.ID}},
+		"owner":      {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.OwnerID}},
+		"state":      {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.State}},
+		"visibility": {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.Visibility}},
+		"participants": {Kind: &pluginv1.AttributeValue_StringListValue{
+			StringListValue: &pluginv1.StringList{Values: participants},
+		}},
+		"invitees": {Kind: &pluginv1.AttributeValue_StringListValue{
+			StringListValue: &pluginv1.StringList{Values: invitees},
+		}},
 	}
 
-	return &pluginv1.ResolveResourceResponse{
-		Attributes: map[string]*pluginv1.AttributeValue{
-			"id":         {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.ID}},
-			"owner":      {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.OwnerID}},
-			"state":      {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.State}},
-			"visibility": {Kind: &pluginv1.AttributeValue_StringValue{StringValue: row.Visibility}},
-			"location":   {Kind: &pluginv1.AttributeValue_StringValue{StringValue: location}},
-			"participants": {Kind: &pluginv1.AttributeValue_StringListValue{
-				StringListValue: &pluginv1.StringList{Values: participants},
-			}},
-			"invitees": {Kind: &pluginv1.AttributeValue_StringListValue{
-				StringListValue: &pluginv1.StringList{Values: invitees},
-			}},
-		},
-	}, nil
+	// Optional attribute: emit location only when resolved; the has_location
+	// witness is always present. An empty-string sentinel would fail-open in the
+	// DSL evaluator (a present "" is a value, not a missing key), so the key is
+	// omitted when absent — .claude/rules/abac-providers.md, ADR holomush-ti1b.
+	if row.LocationID != nil && *row.LocationID != "" {
+		attrs["location"] = &pluginv1.AttributeValue{Kind: &pluginv1.AttributeValue_StringValue{StringValue: *row.LocationID}}
+		attrs["has_location"] = &pluginv1.AttributeValue{Kind: &pluginv1.AttributeValue_BoolValue{BoolValue: true}}
+	} else {
+		attrs["has_location"] = &pluginv1.AttributeValue{Kind: &pluginv1.AttributeValue_BoolValue{BoolValue: false}}
+		// location key INTENTIONALLY ABSENT (fail-safe).
+	}
+
+	return &pluginv1.ResolveResourceResponse{Attributes: attrs}, nil
 }

--- a/plugins/core-scenes/resolver_test.go
+++ b/plugins/core-scenes/resolver_test.go
@@ -36,8 +36,8 @@ func TestSceneResolverGetSchemaReturnsSceneAttributes(t *testing.T) {
 // log, or content_entries). The hard privacy boundary (INV-SCENE-60) keeps log
 // content out of the ABAC attribute path entirely; this is the regression
 // lock. It passes today — GetSchema exposes only id/owner/state/visibility/
-// location/participants/invitees — and fails any future PR that adds a
-// content-bearing attribute to the resolver schema.
+// location/has_location/participants/invitees — and fails any future PR that
+// adds a content-bearing attribute to the resolver schema.
 func TestResolverNeverExposesContentByForbiddenAttributeName(t *testing.T) {
 	t.Parallel()
 	r := NewSceneResolver(newFakeStore())
@@ -76,6 +76,74 @@ func TestSceneResolverResolveResourceReturnsSceneAttributes(t *testing.T) {
 	assert.Equal(t, "active", attrs["state"].GetStringValue())
 	require.NotNil(t, attrs["visibility"])
 	assert.Equal(t, "open", attrs["visibility"].GetStringValue())
+}
+
+// TestResolveResourceLocationWitness exercises the omit-optional-attrs contract
+// for the scene location attribute (.claude/rules/abac-providers.md, ADR
+// holomush-ti1b): the resolver emits the "location" key only when LocationID
+// resolves to a non-empty value, and the has_location boolean witness is always
+// present. An empty-string sentinel ("location": "") would fail-open in the DSL
+// evaluator — a present "" is a value, not a missing key — so an absent or
+// empty-string location omits the key entirely.
+func TestResolveResourceLocationWitness(t *testing.T) {
+	empty := ""
+	loc := "loc-tavern"
+	tests := []struct {
+		name        string
+		locationID  *string
+		wantPresent bool
+		wantValue   string
+	}{
+		{"omits location when LocationID is nil", nil, false, ""},
+		{"omits location when LocationID derefs to empty string", &empty, false, ""},
+		{"emits location when LocationID is set", &loc, true, "loc-tavern"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newFakeStore()
+			store.scenes["scene-loc"] = &SceneRow{
+				ID:         "scene-loc",
+				OwnerID:    "char-alice",
+				State:      string(SceneStateActive),
+				Visibility: string(SceneVisibilityOpen),
+				LocationID: tt.locationID,
+			}
+			r := NewSceneResolver(store)
+
+			resp, err := r.ResolveResource(context.Background(), &pluginv1.ResolveResourceRequest{
+				ResourceType: "scene",
+				ResourceId:   "scene-loc",
+			})
+			require.NoError(t, err)
+			attrs := resp.GetAttributes()
+
+			require.NotNil(t, attrs["has_location"], "has_location witness MUST always be present")
+			assert.Equal(t, tt.wantPresent, attrs["has_location"].GetBoolValue(),
+				"has_location witness MUST reflect whether location resolved")
+			if tt.wantPresent {
+				require.NotNil(t, attrs["location"], "location key MUST be present when LocationID is set")
+				assert.Equal(t, tt.wantValue, attrs["location"].GetStringValue())
+			} else {
+				assert.NotContains(t, attrs, "location",
+					"abac-providers.md: location key MUST be absent (no empty-string sentinel)")
+			}
+		})
+	}
+}
+
+// TestGetSchemaDeclaresHasLocationWitness verifies the has_location witness is
+// declared in the schema as a BOOL so policies can type-check it.
+func TestGetSchemaDeclaresHasLocationWitness(t *testing.T) {
+	r := NewSceneResolver(newFakeStore())
+
+	resp, err := r.GetSchema(context.Background(), &pluginv1.GetSchemaRequest{})
+	require.NoError(t, err)
+	sceneSchema, ok := resp.GetResourceTypes()["scene"]
+	require.True(t, ok, "schema must include 'scene' resource type")
+	assert.Equal(t, pluginv1.AttributeType_ATTRIBUTE_TYPE_BOOL,
+		sceneSchema.GetAttributes()["has_location"],
+		"has_location MUST be declared as a BOOL witness")
 }
 
 func TestSceneResolverResolveResourceRejectsForeignResourceType(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a **P1 fail-open ABAC bug** (`holomush-8cxo6`) in the scene attribute resolver. `SceneResolver.ResolveResource` emitted `"location": {StringValue: ""}` *unconditionally* when `row.LocationID` was nil — the forbidden empty-string sentinel form per `.claude/rules/abac-providers.md` / ADR `holomush-9gtl`. The DSL evaluator treats a *missing* key as fail-safe `false` but a *present* `""` as a real value, so the sentinel fail-open matched any other unresolved peer attribute that also resolved to `""`.
- The fix emits the `location` value only when `LocationID` is non-nil **and** non-empty, always emits a `has_location` BOOL witness (true/false on every path), and declares `has_location` in `GetSchema`. It mirrors the canonical `StreamProvider` reference (`internal/access/policy/attribute/stream.go`).

## Test Plan

- [x] 4 new table tests in `plugins/core-scenes/resolver_test.go`: location omitted when `LocationID` is nil; omitted when it derefs to `""`; emitted with `has_location=true` when set; schema declares `has_location` as BOOL.
- [x] `task test ./plugins/core-scenes/` — 529 pass, 0 failures (watched all 4 fail first, RED→GREEN).
- [x] `task lint` — exit 0.
- [x] `task pr-prep` (fast lane) — `status=pass`.
- [x] `abac-reviewer` agent — verdict **READY**, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)