### PR TITLE
docs(aneim): event-type wire convention canonicalization — spec, plan, ADRs

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,9 @@ edge and the file's `**Status:**` reflects the supersession.
 
 | Title | Date | Status | bd decision |
 |-------|------|--------|-------------|
+| [Canonical wire event-type is plugin-qualified &lt;plugin&gt;:&lt;verb&gt;](holomush-yl3mf-canonical-wire-event-type-is-plugin-qualified-plugin-verb.md) | 2026-06-07 | Accepted | `holomush-yl3mf` |
+| [Three-vocabulary event-type model: bare crypto/registered, qualified wire/verbs, one bridge](holomush-8aure-three-vocabulary-event-type-model-bare-crypto-registered-qua.md) | 2026-06-07 | Accepted | `holomush-8aure` |
+| [Qualify core-scenes event types end-to-end (no backward-compat transformation layer)](holomush-1gwns-qualify-core-scenes-event-types-end-end-no-backward-compat-t.md) | 2026-06-07 | Accepted | `holomush-1gwns` |
 | [INV-<SCOPE>-<N> canonical invariant naming convention](holomush-6wcf2-adr-inv-scope-n-canonical-invariant-naming-convention.md) | 2026-05-31 | Accepted | `holomush-6wcf2` |
 | [Paired YAML+markdown invariant registry with drift meta-test](holomush-4v2dq-adr-paired-yaml-markdown-invariant-registry-drift-meta-test.md) | 2026-05-31 | Accepted | `holomush-4v2dq` |
 | [Derive world-read subject host-side; no subject field on wire](holomush-nthq6-derive-world-read-subject-host-side-no-subject-field-wire.md) | 2026-05-30 | Accepted | `holomush-nthq6` |

--- a/docs/adr/holomush-1gwns-qualify-core-scenes-event-types-end-end-no-backward-compat-t.md
+++ b/docs/adr/holomush-1gwns-qualify-core-scenes-event-types-end-end-no-backward-compat-t.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-1gwns; do not edit manually; use `/adr update holomush-1gwns` -->
+
+# Qualify core-scenes event types end-to-end (no backward-compat transformation layer)
+
+**Date:** 2026-06-07
+**Status:** Accepted
+**Decision:** holomush-1gwns
+**Deciders:** Sean Brandt
+
+## Context
+
+Given canonical-qualified-wire, core-scenes internal consumers (replayEventKinds, snapshotEventKinds, audit dispatch, the SQL type filter in ReadSceneLogForSnapshot, verb-name derivation) all key on the stored/wire type. Two shapes: (a) qualify at emit only + a transformation layer so internals keep seeing bare; (b) qualify end-to-end, re-keying internals in the same change. HoloMUSH has no users and waives backward-compat.
+
+## Decision
+
+core-scenes qualifies END-TO-END: emit sites stamp `core-scenes:<verb>`, scene_log.type stores the qualified form, and every internal consumer keyed on the stored/wire type is re-keyed to the qualified form in the same atomic change. No transformation layer is introduced.
+
+## Rationale
+
+No users exist and backward-compat is explicitly waived (2026-06-06), making the clean migration free of the usual constraint. A transformation layer trades a one-time migration for permanent maintenance complexity — the wrong trade. Atomicity (emit + internal consumers in one change) is achievable: core-scenes is self-contained with a well-enumerated consumer list. End-to-end qualification means internal and wire consumers see the same string, eliminating which-form-does-this-consumer-expect confusion.
+
+## Alternatives Considered
+
+Qualify-at-wire-only + normalize at each internal consumer — rejected (permanent transformation layer; every new internal consumer must normalize; storage/code form mismatch). Phased migration with backward-compat period — rejected (no users; mixed-history + reader-side legacy normalization add permanent complexity for a temporary non-problem).
+
+## Consequences
+
+Positive: scene_log.type, snapshot, audit, SQL filter all key on the same qualified form as wire+verbs — no impedance mismatch; migration is a mechanical re-key over a known site set; core-scenes becomes indistinguishable from any other plugin. Negative: all internal re-keys must land in the same PR as emit qualification (else a window where stored bare types fail to dispatch); verb-name derivation must strip the full core-scenes:scene_ prefix. Neutral: registered-emit + crypto.emits for core-scenes stay bare; existing bare scene_log rows are a non-issue (no users).

--- a/docs/adr/holomush-8aure-three-vocabulary-event-type-model-bare-crypto-registered-qua.md
+++ b/docs/adr/holomush-8aure-three-vocabulary-event-type-model-bare-crypto-registered-qua.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-8aure; do not edit manually; use `/adr update holomush-8aure` -->
+
+# Three-vocabulary event-type model: bare crypto/registered, qualified wire/verbs, one bridge
+
+**Date:** 2026-06-07
+**Status:** Accepted
+**Decision:** holomush-8aure
+**Deciders:** Sean Brandt
+
+## Context
+
+The same event type string appears in three vocabularies governed by different rules. INV-PLUGIN-32 requires the registered-emit set and crypto.emits to be set-equal (both bare); requests_decryption refs are `<plugin>:<verb>` and splitQualifiedRef recovers the bare verb; but the wire type and verbs[].type must be qualified. emitEntryMatchesWireType (from holomush-50zqs) is the seam where the bare crypto vocabulary meets the qualified wire vocabulary.
+
+## Decision
+
+The registered-emit set and crypto.emits stay BARE (required by INV-PLUGIN-32 and the requests_decryption mechanism); the wire type and verbs[].type are QUALIFIED. emitEntryMatchesWireType is the single sanctioned bridging point between the two vocabulary families.
+
+## Rationale
+
+INV-PLUGIN-32 requires set-equality between the registered-emit set and crypto.emits — changing either requires changing the other plus splitQualifiedRef; disproportionate. emitEntryMatchesWireType already exists as a correct bridge; promoting it to documented architecture is minimal-churn. Confining bare<->qualified translation to one named function (one call site, crypto match) keeps the bridging surface auditable by the crypto-reviewer gate.
+
+## Alternatives Considered
+
+Qualify all three vocabularies uniformly — rejected (breaks INV-PLUGIN-32; would change requests_decryption ref format + splitQualifiedRef; trips EVENT_TYPE_REGISTRY_MISMATCH at load). Normalize at emit time (strip qualifier before store/register) — rejected (web renderer + RenderingPublisher exact-match qualified wire types; would migrate those consumers; storage inconsistent with documented convention).
+
+## Consequences
+
+Positive: INV-PLUGIN-32 + crypto subsystem unaffected by the wire-qualification migration; bridging surface is one auditable function; future plugins keep bare crypto.emits. Negative: authors must internalize qualified-wire/bare-registry distinction; a mis-vocabularied string is a load/emit-time error, not compile-time. Neutral: three-vocabulary model is now documented architecture, not emergent; eventbus.NewType accepts bare tokens, so the loader gate (not NewType) is the enforcement point.

--- a/docs/adr/holomush-yl3mf-canonical-wire-event-type-is-plugin-qualified-plugin-verb.md
+++ b/docs/adr/holomush-yl3mf-canonical-wire-event-type-is-plugin-qualified-plugin-verb.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-yl3mf; do not edit manually; use `/adr update holomush-yl3mf` -->
+
+# Canonical wire event-type is plugin-qualified <plugin>:<verb>
+
+**Date:** 2026-06-07
+**Status:** Accepted
+**Decision:** holomush-yl3mf
+**Deciders:** Sean Brandt
+
+## Context
+
+HoloMUSH had two coexisting wire event-type conventions — plugin-qualified `<plugin>:<verb>` (core-communication, core-objects, docs, web renderer) and bare `<verb>` (core-scenes). Exact-match consumers (RenderingPublisher verb registry, crypto match sites, audit dispatch, history) break silently when a plugin's wire type does not match what the consumer expects; core-scenes hard-failed EMIT_UNKNOWN_VERB in production (holomush-r0kup), masked only by test seeding. Nothing prevented future drift.
+
+## Decision
+
+The canonical wire event-type identity is plugin-qualified `<owning-plugin>:<verb>`. Every emitted wire type and every `verbs[].type` MUST be exactly `<owning-plugin>:<verb>`; a load-time gate (Manifest.Validate) rejects manifests with bare or foreign-qualified verbs[].type entries.
+
+## Rationale
+
+Qualified is already the documented convention, the web-renderer expectation, and the shape core-communication/core-objects use — convergence, not a pivot. Exact-match consumers need one authoritative form. No users exist and backward-compat is waived, so the migration is clean (no mixed-history). A load-time gate enforces the invariant structurally so new plugins cannot reintroduce bare wire types.
+
+## Alternatives Considered
+
+Bare everywhere — rejected (conflicts with docs/web-renderer/verb-registry; majority would migrate the wrong way). Document-both-and-normalize-every-consumer — rejected (unbounded drift; each new consumer must normalize). Structured fields on core.Event — rejected (YAGNI; proto + core.Event + every-consumer rewrite; string convention entrenched).
+
+## Consequences
+
+Positive: EMIT_UNKNOWN_VERB structurally impossible for plugins passing loader validation; audit/history/snapshot key on one form; drift bounded at load; core-scenes becomes a normal plugin. Negative: core-scenes migration (emit sites, dispatch maps, SQL filter, scene_log rows); verb-name derivation updated; future plugins learn qualify-on-wire/bare-in-registry. Neutral: registered-emit + crypto.emits stay bare by INV-PLUGIN-32 (three-vocabulary model).

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -301,6 +301,7 @@ invariants.
 | `INV-PLUGIN-37` | The INV-S5 validator MUST fire in manager.go::loadPlugin AFTER host.Load returns successfully and BEFORE the plugin is added to the manager's ready plugin cache. | `INV-M5` | pending |
 | `INV-PLUGIN-38` | Lua Load-pass DoString errors MUST fail plugin load with the same wrapper shape as the syntax-check error (oops.In("lua"), operation=load); the Hint string is branch-specific ("INV-S5 capture pass execution error" for crypto plugins). | `INV-M6` | pending |
 | `INV-PLUGIN-39` | Every primitive in the INV-S5 mechanism MUST ship a Go SDK method + Lua hostfunc + parity test together (per parent substrate invariant INV-S3 / INV-PLUGIN-31). | `INV-M7` | pending |
+| `INV-PLUGIN-40` | Every emitted wire event type and every verbs[].type MUST be plugin-qualified <owning-plugin>:<verb> (one colon). The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption); the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type with PLUGIN_WIRE_TYPE_NOT_QUALIFIED. | — | pending |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3599,6 +3599,14 @@ invariants:
     binding: pending
     refs:
       - {file: "internal/plugin/goplugin/manager_parity_test.go", token: "INV-M7"}
+  - id: INV-PLUGIN-40
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md"
+    summary: "Every emitted wire event type and every verbs[].type MUST be plugin-qualified <owning-plugin>:<verb> (one colon).
+      The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption);
+      the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type
+      with PLUGIN_WIRE_TYPE_NOT_QUALIFIED."
+    binding: pending
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/docs/superpowers/plans/2026-06-06-event-type-wire-convention.md
+++ b/docs/superpowers/plans/2026-06-06-event-type-wire-convention.md
@@ -1,0 +1,696 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Event-Type Wire Convention Canonicalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every plugin's emitted wire event type plugin-qualified `<plugin>:<verb>`, fix core-scenes (which renders nothing in prod — `holomush-r0kup`) and `core-communication:emit` to conform, and add a loader gate + meta-test so the convention can't drift again.
+
+**Architecture:** Three event-type vocabularies, governed differently: the **registered-emit set** and **`crypto.emits[].event_type`** stay **bare** (INV-PLUGIN-32 forces them equal; `requests_decryption`/`splitQualifiedRef` recover the bare verb). The **wire type + `verbs[].type` + downstream stored type** are **qualified**. `emitEntryMatchesWireType` (`internal/plugin/crypto_manifest.go:89`, already merged in #4395) bridges bare-crypto ↔ qualified-wire. core-scenes is migrated **qualify-end-to-end** (no users → uniformity over churn).
+
+**Tech Stack:** Go, gopher-lua (Lua plugins), `task` runner, testify, Ginkgo (integration), the `integrationtest` harness, PostgreSQL (scene_log).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md`
+**Design bead:** `holomush-aneim` (depends on `holomush-r0kup`)
+
+---
+
+## File map
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `plugins/core-scenes/plugin.yaml` | core-scenes manifest | **Add** `verbs:` block (14 qualified types); `crypto.emits` stays bare |
+| `plugins/core-scenes/commands.go` | scene command emit + replay | Qualify `EmitIntent.Type` stamp; re-key `replayEventKinds` |
+| `plugins/core-scenes/service.go` | lifecycle emits | Qualify 3 stamped `Type` literals |
+| `plugins/core-scenes/publish_events.go` | publish-notice emits | Qualify 6 stamped `Type` literals |
+| `plugins/core-scenes/publish_snapshot.go` | snapshot reconstruction | Re-key `snapshotEventKinds` |
+| `plugins/core-scenes/publish_store.go` | scene_log read | Qualify the SQL `type IN (...)` filter |
+| `plugins/core-scenes/audit.go` | audit dispatch | Qualify the `eventType == "scene_pose"` check |
+| `plugins/core-scenes/main.go` | emit-type registration | **No change** — `phase4/phase6EmitTypes` stay bare |
+| `plugins/core-communication/main.lua` | comm emits | Qualify `emit` wire type (`:178`) |
+| `internal/plugin/manifest.go` | manifest validation | **Add** gate in `Manifest.Validate()`: `verbs[].type` must be `<plugin>:<verb>` (runs at `ParseManifest`, fail-fast at load) |
+| `internal/testsupport/integrationtest/crypto.go` | test harness | **Qualify** emit-helper stamp (`plugin + ":" + eventType`) so ~15 bare-type callers keep working; **remove** scene-verb seeding |
+| `test/meta/` | meta-tests | **Add** all-plugins-verbs-qualified test |
+| `.claude/rules/event-conventions.md` | conventions doc | Document the three-vocabulary rule |
+| `docs/architecture/invariants.yaml` | invariant registry | `INV-PLUGIN-40` already added with the spec (`binding: pending`); Task 8 **binds** it |
+
+**Invariant — these stay BARE, do NOT qualify:** `plugins/core-scenes/main.go` `phase4EmitTypes()`/`phase6EmitTypes()` and every `crypto.emits[].event_type` in `plugins/*/plugin.yaml`. Qualifying them trips `EVENT_TYPE_REGISTRY_MISMATCH` at load (INV-PLUGIN-32).
+
+The qualified prefix is composed at the **emit-stamp** boundary only; `handleEmit`'s `verb := strings.TrimPrefix(eventType, "scene_")` (`commands.go:1230`) and the dispatch site (`commands.go:519-525`) keep passing the **bare** verb-type into `handleEmit` — only the stamped `EmitIntent.Type` is qualified. So those two sites need **no change**.
+
+---
+
+## Phase 1: Foundational fix — make core-scenes a normal plugin (`holomush-r0kup`)
+
+### Task 1: Add the core-scenes `verbs:` block
+
+**Files:**
+
+- Modify: `plugins/core-scenes/plugin.yaml` (add a top-level `verbs:` block)
+- Test: `internal/plugin/manager_test.go` (or a new `plugins/core-scenes/manifest_verbs_test.go`)
+
+- [ ] **Step 1: Write the failing test** — assert the parsed manifest registers all 14 scene types as qualified verbs.
+
+In a new file `plugins/core-scenes/manifest_verbs_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType pins
+// holomush-r0kup: every emitted scene wire type MUST have a qualified
+// verbs[].type entry, or RenderingPublisher hard-fails EMIT_UNKNOWN_VERB.
+func TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType(t *testing.T) {
+	data, err := os.ReadFile("plugin.yaml")
+	require.NoError(t, err)
+	var m struct {
+		Verbs []struct {
+			Type string `yaml:"type"`
+		} `yaml:"verbs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &m))
+
+	got := make(map[string]bool, len(m.Verbs))
+	for _, v := range m.Verbs {
+		got[v.Type] = true
+	}
+	want := []string{
+		"core-scenes:scene_pose", "core-scenes:scene_say", "core-scenes:scene_emit",
+		"core-scenes:scene_ooc", "core-scenes:scene_join_ic", "core-scenes:scene_leave_ic",
+		"core-scenes:scene_pose_order_changed_ic", "core-scenes:scene_idle_nudge",
+		"core-scenes:scene_publish_started", "core-scenes:scene_publish_vote_cast",
+		"core-scenes:scene_publish_cooloff_started", "core-scenes:scene_publish_resolved",
+		"core-scenes:scene_publish_withdrawn", "core-scenes:scene_publish_vote_attempts_extended",
+	}
+	for _, w := range want {
+		require.Truef(t, got[w], "missing qualified verb entry %q", w)
+	}
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType ./plugins/core-scenes/`
+Expected: FAIL (no `verbs:` block → zero entries).
+
+- [ ] **Step 3: Add the `verbs:` block** to `plugins/core-scenes/plugin.yaml` (top level, sibling of `crypto:`). The enums are CLOSED (`internal/plugin/manifest.go`): `category` ∈ {communication, movement, state, system, command} (`:176`); `format` ∈ {speech, action, narrative, notification, error, snapshot, delta} (`:181`); `display_target` ∈ {terminal, state, both} (`:1655`). `label` is a free optional string. IC content uses `category: communication`; lifecycle + publish notices use `category: state` + `format: notification`:
+
+```yaml
+verbs:
+  - type: core-scenes:scene_pose
+    category: communication
+    format: action
+    display_target: terminal
+  - type: core-scenes:scene_say
+    category: communication
+    format: speech
+    label: says
+    display_target: terminal
+  - type: core-scenes:scene_emit
+    category: communication
+    format: action
+    display_target: terminal
+  - type: core-scenes:scene_ooc
+    category: communication
+    format: action
+    display_target: terminal
+  - type: core-scenes:scene_join_ic
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_leave_ic
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_pose_order_changed_ic
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_idle_nudge
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_started
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_vote_cast
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_cooloff_started
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_resolved
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_withdrawn
+    category: state
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_vote_attempts_extended
+    category: state
+    format: notification
+    display_target: terminal
+```
+
+- [ ] **Step 4: Run the test + schema check, verify pass**
+
+Run: `task test -- -run TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType ./plugins/core-scenes/`
+Expected: PASS.
+Run: `task lint` (the plugin schema check validates `plugin.yaml`).
+Expected: PASS (verbs items satisfy `schemas/plugin.schema.json`: `type`/`category`/`format`/`display_target` required).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(core-scenes): declare qualified verbs for every emit type (holomush-r0kup)"`
+
+---
+
+### Task 2: Qualify core-scenes emit-site stamped types
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go:1323` (the `EmitIntent.Type` stamp)
+- Modify: `plugins/core-scenes/service.go:801,842,879`
+- Modify: `plugins/core-scenes/publish_events.go` (six `scene_publish_*` stamps)
+- Test: `plugins/core-scenes/commands_emit_test.go` (existing — update expected types)
+
+- [ ] **Step 1: Add the qualifier constant + helper** at the top of `plugins/core-scenes/commands.go` (after imports):
+
+```go
+// scenePluginName is this plugin's manifest name; the qualified wire event
+// type is scenePluginName + ":" + <bare verb>. crypto.emits + RegisterEmitTypes
+// keep the bare form (INV-PLUGIN-32); only the wire/stored type is qualified
+// (holomush-aneim).
+const scenePluginName = "core-scenes"
+
+// qualifyScene returns the qualified wire event type for a bare scene verb.
+func qualifyScene(bare string) string { return scenePluginName + ":" + bare }
+```
+
+- [ ] **Step 2: Update the failing test** — `commands_emit_test.go` currently asserts `findIntentByType(sink.intents, "scene_pose")`. Change the four IC assertions to the qualified form:
+
+```go
+found := findIntentByType(sink.intents, "core-scenes:scene_pose")
+require.NotNil(t, found, "scene pose MUST emit core-scenes:scene_pose")
+assert.True(t, found.Sensitive, "scene_pose MUST be Sensitive=true (sensitivity:always)")
+```
+
+Apply the same `core-scenes:`-prefix change to the `scene_say`, `scene_emit`, `scene_ooc` lookups in that file.
+
+- [ ] **Step 3: Run it, verify it fails**
+
+Run: `task test -- -run TestSceneSubcommand ./plugins/core-scenes/`
+Expected: FAIL (`findIntentByType` returns nil — emit still stamps bare `scene_pose`).
+
+- [ ] **Step 4: Qualify the stamp** at `commands.go:1323`:
+
+```go
+	intent := pluginsdk.EmitIntent{
+		Subject:   subject,
+		Type:      pluginsdk.EventType(qualifyScene(eventType)),
+		Payload:   string(payload),
+		Sensitive: true, // sensitivity:always per crypto.emits manifest §2 / INV-SCENE-3
+	}
+```
+
+(Leave the dispatch at `commands.go:519-525` and `verb := strings.TrimPrefix(eventType, "scene_")` at `:1230` **unchanged** — `eventType` stays bare into `handleEmit`; only the stamp qualifies.)
+
+Then qualify the lifecycle stamps in `service.go` (lines ~801/842/879):
+
+```go
+		Type:      "core-scenes:scene_join_ic",
+		// ...
+		Type:      "core-scenes:scene_leave_ic",
+		// ...
+		Type:      "core-scenes:scene_pose_order_changed_ic",
+```
+
+And the six notice stamps in `publish_events.go`, e.g.:
+
+```go
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_started"),
+```
+
+(repeat for `scene_publish_vote_cast`, `scene_publish_cooloff_started`, `scene_publish_resolved`, `scene_publish_withdrawn`, `scene_publish_vote_attempts_extended`).
+
+- [ ] **Step 5: Update integration delivery-side assertions to the qualified type.** Qualifying the wire type changes what subscribers receive, so the three integration tests that wait-for/assert the bare delivered type MUST update in lockstep (else they time out on a `scene_pose` frame that never arrives — `WaitForEvent` matches `ev.GetType() == eventType`, `internal/testsupport/integrationtest/session.go:137`; the frame type is stamped verbatim at `internal/grpc/server.go:674`). Change `"scene_pose"` → `"core-scenes:scene_pose"` at:
+  - `test/integration/scenes/scene_command_join_delivery_test.go:102,106`
+  - `test/integration/scenes/lua_focus_parity_test.go:116,121`
+  - `test/integration/scenes/real_scene_join_subscription_test.go:104,109`
+
+  (Each is a `WaitForEvent(ctx, "scene_pose")` + a companion `Expect(frame.GetType()).To(Equal("scene_pose"))`. Grep `rg -n 'WaitForEvent\(.*scene_|GetType\(\)\).*scene_' test/integration/scenes/` to confirm the full set before editing — there may be other bare scene types asserted similarly.)
+
+- [ ] **Step 6: Run unit + the affected integration tests, verify pass**
+
+Run: `task test -- -run TestSceneSubcommand ./plugins/core-scenes/`
+Expected: PASS.
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected: PASS (delivery assertions now expect the qualified type).
+
+- [ ] **Step 7: Commit**
+
+`jj commit -m "feat(core-scenes): qualify emit-site wire types + delivery assertions to core-scenes:<verb> (holomush-r0kup)"`
+
+---
+
+### Task 3: Re-key core-scenes read-side consumers to the qualified stored type
+
+**Files:**
+
+- Modify: `plugins/core-scenes/commands.go:80-84` (`replayEventKinds`)
+- Modify: `plugins/core-scenes/publish_snapshot.go:32-36` (`snapshotEventKinds`)
+- Modify: `plugins/core-scenes/publish_store.go:640` (SQL `type IN (...)`)
+- Modify: `plugins/core-scenes/audit.go:399` (`eventType == "scene_pose"`)
+- Test: `plugins/core-scenes/commands_emit_test.go` / existing replay + snapshot + audit tests
+
+- [ ] **Step 1: Write/extend the failing test** — assert replay decodes a qualified-typed event. Add to `plugins/core-scenes/commands_emit_test.go`:
+
+```go
+func TestDecodeReplayEntriesAcceptsQualifiedSceneTypes(t *testing.T) {
+	events := []pluginsdk.Event{
+		{Type: "core-scenes:scene_pose", Payload: `{"actor_id":"01HZZ0000000000000000000AA","text":"waves"}`},
+	}
+	entries, err := decodeReplayEntries(events)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, EntryKindPose, entries[0].Kind)
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestDecodeReplayEntriesAcceptsQualifiedSceneTypes ./plugins/core-scenes/`
+Expected: FAIL (`replayEventKinds` keyed on bare `"scene_pose"` → `continue`, zero entries).
+
+- [ ] **Step 3: Re-key the maps + SQL + audit check to qualified.**
+
+`commands.go:80-84`:
+
+```go
+var replayEventKinds = map[string]EntryKind{
+	"core-scenes:scene_pose": EntryKindPose,
+	"core-scenes:scene_say":  EntryKindSay,
+	"core-scenes:scene_emit": EntryKindEmit,
+}
+```
+
+`publish_snapshot.go:32-36`:
+
+```go
+var snapshotEventKinds = map[string]EntryKind{
+	"core-scenes:scene_pose": EntryKindPose,
+	"core-scenes:scene_say":  EntryKindSay,
+	"core-scenes:scene_emit": EntryKindEmit,
+}
+```
+
+`publish_store.go:640` (SQL literal):
+
+```go
+		WHERE subject = $1 AND type IN ('core-scenes:scene_pose', 'core-scenes:scene_say', 'core-scenes:scene_emit')
+```
+
+`audit.go:399`:
+
+```go
+	if eventType == "core-scenes:scene_pose" {
+```
+
+- [ ] **Step 4: Run the read-side tests, verify pass**
+
+Run: `task test -- ./plugins/core-scenes/`
+Expected: PASS (replay/snapshot/audit tests green with qualified types).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "refactor(core-scenes): re-key read-side consumers to qualified stored type (holomush-r0kup)"`
+
+---
+
+### Task 4: Qualify harness emit helpers, remove scene-verb seeding, add the r0kup regression
+
+**Background (grounded):** `EmitSceneICContent`/`EmitScenePlaintextContent` (`internal/testsupport/integrationtest/crypto.go:183`) are the harness stand-ins for the core-scenes plugin emitting. They take a `plugin` arg and an `eventType`, stamp `Type: pluginsdk.EventType(eventType)` **verbatim** (`crypto.go:245`), publish via the `RenderingPublisher`-backed emitter wired by `WithPluginCrypto` (`crypto.go:117`), and **return `EmittedEvent`** (not `error`) — they `require.NoError` the publish internally, so a failed publish (e.g. `EMIT_UNKNOWN_VERB`) fails the spec. ~15 existing callers pass **bare** types (`"scene_pose"`); they only work today because `registerSceneEmitVerbs` seeds bare verbs into the registry.
+
+**Decision:** centralize qualification in the helpers (they own the `plugin` name) so they faithfully mirror the post-fix plugin AND the ~15 existing bare-type callers keep compiling unchanged. The helpers compose `plugin + ":" + eventType`; seeding is removed; verbs now come from the core-scenes manifest (Task 1).
+
+**Files:**
+
+- Modify: `internal/testsupport/integrationtest/crypto.go` — qualify the stamp in the emit helpers; delete `registerSceneEmitVerbs` + its call site
+- Test: `test/integration/scenes/scene_render_verb_test.go` (new, Ginkgo, `//go:build integration`)
+
+- [ ] **Step 1: Qualify the harness emit helpers.** In `crypto.go`, change the verbatim stamp at `:245` so the helper composes the owning-plugin prefix (mirroring the real plugin). At the stamp site in `emitPluginEventForScene` (and any sibling used by `EmitScenePlaintextContent`):
+
+```go
+	// Mirror the real plugin: emit the plugin-qualified wire type so it resolves
+	// against the manifest-sourced verb registry (holomush-aneim / r0kup).
+	wireType := eventType
+	if !strings.Contains(wireType, ":") {
+		wireType = plugin + ":" + eventType
+	}
+	// ... Type: pluginsdk.EventType(wireType)
+```
+
+(The `!Contains(":")` guard keeps it idempotent if a caller already passes a qualified type. Confirm the exact local var names by reading `emitPluginEventForScene`; ensure `strings` is imported.)
+
+- [ ] **Step 2: Write the r0kup regression test** — a core-scenes IC emit resolves against the **manifest-sourced** verb registry (no seeding) and publishes without `EMIT_UNKNOWN_VERB`. New file `test/integration/scenes/scene_render_verb_test.go`:
+
+```go
+//go:build integration
+
+package scenes_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// Verifies holomush-r0kup: core-scenes events resolve in the verb registry
+// from its MANIFEST verbs: block (no test seeding), so the production
+// RenderingPublisher does not reject them with EMIT_UNKNOWN_VERB.
+var _ = Describe("core-scenes renders via its own manifest verbs", func() {
+	It("publishes an IC pose without EMIT_UNKNOWN_VERB", func(ctx SpecContext) {
+		// WithPluginCrypto wires the RenderingPublisher-backed plugin emitter
+		// (crypto.go:117); EmitSceneICContent panics without it (crypto.go:282).
+		ts := integrationtest.Start(GinkgoT(),
+			integrationtest.WithInTreePlugins(), integrationtest.WithPluginCrypto())
+		// ... create a scene + participant + actorID via the harness helpers
+		// (ground the create-scene/join pattern from a sibling scenes spec, e.g.
+		// real_scene_join_subscription_test.go).
+		//
+		// Pass the BARE verb — the helper now qualifies it (Step 1). The helper
+		// require.NoErrors the publish internally, so EMIT_UNKNOWN_VERB fails the
+		// spec. emitted is an EmittedEvent (NOT error).
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID, actorID,
+			"scene_pose", `{"actor_id":"`+actorID.String()+`","text":"waves"}`)
+		Expect(emitted.SubjectStr).NotTo(BeEmpty(),
+			"core-scenes:scene_pose must resolve in the manifest verb registry and publish")
+	})
+})
+```
+
+(`EmitSceneICContent` returns `EmittedEvent` with a `SubjectStr` field — confirm the field name against `crypto.go` + existing callers like `seed_encrypted_ic_validation_test.go:51`. Do NOT assign to `err`.)
+
+- [ ] **Step 3: Delete the seeding.** Remove `registerSceneEmitVerbs` and its call site from `crypto.go`. core-scenes now contributes verbs via its manifest `verbs:` block (Task 1). Existing callers pass bare types; the Step-1 helper change qualifies them, so they keep working.
+
+- [ ] **Step 4: Verify the regression ordering** — confirm the new test would FAIL without Task 1's verbs block: temporarily comment out the core-scenes `verbs:` block, run the new spec, observe the `EMIT_UNKNOWN_VERB` failure (proving the test is not vacuous), then restore the block.
+
+Run: `task test:int -- ./test/integration/scenes/...`
+Expected (block present): PASS. Expected (block removed): FAIL with `EMIT_UNKNOWN_VERB`.
+
+- [ ] **Step 5: Run the full scene + crypto integration suites, verify pass**
+
+Run: `task test:int -- ./test/integration/scenes/... ./test/integration/crypto/...`
+Expected: PASS — all ~15 existing `EmitSceneICContent`/`EmitScenePlaintextContent` callers (passing bare types) now emit qualified wire types via the helper and resolve against manifest verbs; crypto/readback suites stay green (the `emitEntryMatchesWireType` bridge resolves bare `crypto.emits` against the qualified wire type).
+
+- [ ] **Step 6: Commit**
+
+`jj commit -m "test(core-scenes): qualify harness emit helpers, drop verb seeding, add r0kup regression (holomush-r0kup)"`
+
+---
+
+## Phase 2: core-communication:emit fix
+
+### Task 5: Qualify the `core-communication:emit` wire type
+
+**Files:**
+
+- Modify: `plugins/core-communication/main.lua:178`
+- Test: `internal/plugin/lua/corecomm_sensitive_emit_test.go` (extend the existing brace-aware scan, or a sibling assertion)
+
+- [ ] **Step 1: Write the failing test** — assert the generic `emit` command emits the qualified wire type. Add to `internal/plugin/lua/corecomm_sensitive_emit_test.go` (it already reads `main.lua` via `repoRoot`):
+
+```go
+func TestCoreCommunicationEmitUsesQualifiedWireType(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "plugins", "core-communication", "main.lua"))
+	require.NoError(t, err)
+	src := string(raw)
+	require.Contains(t, src, `type = "core-communication:emit"`,
+		"the generic emit command MUST emit the qualified wire type (matches verbs[].type; holomush-aneim)")
+	require.NotContains(t, src, `type = "emit"`,
+		"bare emit wire type must be gone (EMIT_UNKNOWN_VERB in production)")
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run TestCoreCommunicationEmitUsesQualifiedWireType ./internal/plugin/lua/`
+Expected: FAIL (`main.lua:178` still emits bare `type = "emit"`).
+
+- [ ] **Step 3: Qualify the emit** at `plugins/core-communication/main.lua:178`:
+
+```lua
+        {subject ="location." .. loc, type = "core-communication:emit", payload = payload}
+```
+
+- [ ] **Step 4: Run the test, verify pass**
+
+Run: `task test -- -run TestCoreCommunicationEmitUsesQualifiedWireType ./internal/plugin/lua/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "fix(core-communication): qualify the emit wire type to core-communication:emit (holomush-aneim)"`
+
+---
+
+## Phase 3: Enforcement (prevent drift)
+
+### Task 6: Manifest gate — reject unqualified `verbs[].type` in `Manifest.Validate()`
+
+> **Refinement over the spec:** the spec said "at the verb-registration loop in `manager.go:1138`". Implement it instead in `Manifest.Validate()` (`internal/plugin/manifest.go:525-537`), where the sibling verb `category`/`format`/`display_target` validation already lives. `ParseManifest` calls `Validate()` (`manifest.go:377`), so this still fires fast-at-load (at discovery/parse, before any load side-effects), AND it is directly unit-testable — unlike `manager.go`'s `TestLoadPlugin` (`:1313`), which returns no error.
+
+**Files:**
+
+- Modify: `internal/plugin/manifest.go` (verb validation loop, ~`:525-537`)
+- Test: `internal/plugin/manifest_test.go` (sibling of the existing verb-category/format validation tests)
+
+- [ ] **Step 1: Write the failing test** — a manifest whose `verbs[].type` is bare (or foreign-prefixed, or multi-colon) is rejected by `Validate()` with the typed code. Add to `internal/plugin/manifest_test.go`:
+
+```go
+func TestManifestValidateRejectsUnqualifiedVerbType(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"bare":        "say",
+		"foreign":     "other:say",
+		"multi-colon": "demo:say:extra",
+		"prefix-only": "demo:",
+	}
+	for name, verbType := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := &plugins.Manifest{
+				Name: "demo", Version: "1.0.0", Type: plugins.TypeLua,
+				Verbs: []plugins.VerbSpec{{
+					Type: verbType, Category: "communication", Format: "action", DisplayTarget: "terminal",
+				}},
+			}
+			err := m.Validate()
+			require.Error(t, err)
+			require.Equal(t, "PLUGIN_WIRE_TYPE_NOT_QUALIFIED", oops.AsOops(err).Code())
+		})
+	}
+}
+
+func TestManifestValidateAcceptsQualifiedVerbType(t *testing.T) {
+	t.Parallel()
+	m := &plugins.Manifest{
+		Name: "demo", Version: "1.0.0", Type: plugins.TypeLua,
+		Verbs: []plugins.VerbSpec{{
+			Type: "demo:say", Category: "communication", Format: "action", DisplayTarget: "terminal",
+		}},
+	}
+	require.NoError(t, m.Validate())
+}
+```
+
+(`plugins.VerbSpec` — `manifest.go:168` — fields `Type`/`Category`/`Format`/`Label`/`DisplayTarget`. `oops.AsOops(err).Code()` per `internal/plugin/manager_test.go:1796` + the grpc-errors rule. Confirm `manifest_test.go` is package `plugins_test` and imports `oops`.)
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `task test -- -run 'TestManifestValidateRejectsUnqualifiedVerbType|TestManifestValidateAcceptsQualifiedVerbType' ./internal/plugin/`
+Expected: the reject cases FAIL (bare/foreign/etc. currently accepted); the accept case passes.
+
+- [ ] **Step 3: Add the gate** in the verb loop in `Manifest.Validate()`, immediately after the existing `if v.Type == ""` empty-check (`manifest.go:525-527`), before the `validVerbCategories` check:
+
+```go
+		if want := m.Name + ":"; !strings.HasPrefix(v.Type, want) ||
+			len(v.Type) <= len(want) || strings.Count(v.Type, ":") != 1 {
+			return oops.Code("PLUGIN_WIRE_TYPE_NOT_QUALIFIED").
+				In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				Errorf("verbs[].type must be %q-prefixed (<plugin>:<verb>, one colon); got %q", m.Name, v.Type)
+		}
+```
+
+(`strings` is already imported in `manifest.go`.)
+
+- [ ] **Step 4: Run the test + the full plugin package, verify pass**
+
+Run: `task test -- -run 'TestManifestValidate' ./internal/plugin/`
+Expected: PASS.
+Run: `task test -- ./internal/plugin/...`
+Expected: PASS — core-communication/core-objects/core-scenes verbs are all qualified (Tasks 1, 5), so no real manifest regresses. If any *test fixture* constructs a bare-verb `VerbSpec`, update it to qualified (a grep found none in-tree today).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "feat(plugin): Manifest.Validate rejects unqualified verbs[].type (holomush-aneim)"`
+
+---
+
+### Task 7: Meta-test — every in-tree plugin's `verbs[].type` is qualified
+
+**Files:**
+
+- Test: `test/meta/plugin_verb_qualification_test.go` (new)
+
+- [ ] **Step 1: Write the meta-test** — walk `plugins/*/plugin.yaml`, assert each `verbs[].type` is `<dir-name>:<verb>` (single colon). It MUST NOT assert anything about `crypto.emits` / registered-emit sets (those are bare by INV-PLUGIN-32).
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestEveryInTreePluginVerbTypeIsQualified pins holomush-aneim: every plugin's
+// verbs[].type MUST be "<plugin-dir>:<verb>" so RenderingPublisher resolves it.
+func TestEveryInTreePluginVerbTypeIsQualified(t *testing.T) {
+	root := findRepoRoot(t) // the test/meta repo-root helper (meta_helpers_test.go:33)
+	dirs, err := filepath.Glob(filepath.Join(root, "plugins", "*", "plugin.yaml"))
+	require.NoError(t, err)
+	for _, path := range dirs {
+		pluginDir := filepath.Base(filepath.Dir(path))
+		data, err := os.ReadFile(path) //nolint:gosec // test-only scan of in-tree manifests
+		require.NoError(t, err)
+		var m struct {
+			Verbs []struct {
+				Type string `yaml:"type"`
+			} `yaml:"verbs"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &m), "parse %s", path)
+		want := pluginDir + ":"
+		for _, v := range m.Verbs {
+			require.Truef(t, strings.HasPrefix(v.Type, want) && strings.Count(v.Type, ":") == 1 && len(v.Type) > len(want),
+				"%s: verbs[].type %q must be %q-prefixed (<plugin>:<verb>)", path, v.Type, pluginDir)
+		}
+	}
+}
+```
+
+(`findRepoRoot(t)` is the `test/meta` helper at `meta_helpers_test.go:33`. The package is `meta` — every file in `test/meta/` is `package meta`, NOT `meta_test`; using `meta_test` would put `findRepoRoot` out of scope and fail to compile.)
+
+- [ ] **Step 2: Run it, verify it passes** (all in-tree plugins are now qualified after Tasks 1, 5)
+
+Run: `task test -- -run TestEveryInTreePluginVerbTypeIsQualified ./test/meta/`
+Expected: PASS.
+
+- [ ] **Step 3: Sanity-check the guard catches a regression** — temporarily change one core-scenes verb to bare in a scratch copy mentally; the test would fail. (No code change; this step is a reasoning check that the assertion is not vacuous — `len(m.Verbs) > 0` for core-scenes/core-communication/core-objects guarantees it runs.)
+
+- [ ] **Step 4: Commit**
+
+`jj commit -m "test(meta): enforce qualified verbs[].type across in-tree plugins (holomush-aneim)"`
+
+---
+
+### Task 8: Documentation + invariant registry
+
+**Files:**
+
+- Modify: `.claude/rules/event-conventions.md` (add the three-vocabulary rule)
+- Modify: `docs/architecture/invariants.yaml` (`INV-PLUGIN-40` already present from the spec change; flip to `binding: bound` in Step 4)
+- Generate: `docs/architecture/invariants.md` via `go run ./cmd/inv-render`
+
+- [ ] **Step 1: Add the convention** to `.claude/rules/event-conventions.md` under a new `## Event-type vocabularies` section:
+
+```markdown
+## Event-type vocabularies (qualified wire / bare crypto)
+
+An event type appears in three places, governed differently:
+
+- **Wire type + `verbs[].type` + downstream stored type** MUST be plugin-qualified
+  `<plugin>:<verb>` (one colon). `RenderingPublisher.Lookup` resolves the wire
+  type against `verbs[].type` and hard-fails `EMIT_UNKNOWN_VERB` on a miss. The
+  loader rejects an unqualified `verbs[].type` (`PLUGIN_WIRE_TYPE_NOT_QUALIFIED`).
+- **Registered-emit set (`RegisterEmitTypes`/`register_emit_type`) and
+  `crypto.emits[].event_type`** stay **bare** `<verb>`. INV-PLUGIN-32 forces the
+  two equal; `requests_decryption` refs are `<plugin>:<verb>` and
+  `splitQualifiedRef` recovers the bare verb. Qualifying these trips
+  `EVENT_TYPE_REGISTRY_MISMATCH` at load.
+- `emitEntryMatchesWireType` (`internal/plugin/crypto_manifest.go`) is the single
+  bridge: it matches a bare `crypto.emits` entry against the qualified wire type
+  by composing the plugin name. Do not add other bare↔qualified shims.
+```
+
+- [ ] **Step 2: The invariant entry already exists** — `INV-PLUGIN-40` was added to `docs/architecture/invariants.yaml` (`binding: pending`) alongside the spec (per `.claude/rules/invariants.md`'s capture-at-spec-time rule). This task does NOT add it; verify it is present and matches the summary below. Task 8's job for the invariant is the *binding* in Step 4.
+
+```yaml
+  - id: INV-PLUGIN-40
+    scope: INV-PLUGIN
+    origin_spec: "docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md"
+    summary: "Every emitted wire event type and every verbs[].type MUST be plugin-qualified
+      <owning-plugin>:<verb> (one colon); the registered-emit set and crypto.emits[].event_type
+      stay bare, bridged by emitEntryMatchesWireType. Manifest.Validate rejects an unqualified
+      verbs[].type with PLUGIN_WIRE_TYPE_NOT_QUALIFIED."
+    binding: pending
+```
+
+- [ ] **Step 3: Regenerate + verify**
+
+Run: `go run ./cmd/inv-render`
+Expected: `wrote docs/architecture/invariants.md`.
+Run: `task test -- ./test/meta/`
+Expected: PASS (registry drift check + the new verb-qualification meta-test green; the new invariant is tolerated as `binding: pending`).
+
+- [ ] **Step 4: Bind the invariant (optional, same change)** — the Task 6 gate test genuinely asserts the reject behavior, and the Task 7 meta-test asserts the positive (all in-tree verbs qualified). If binding now: add `// Verifies: INV-PLUGIN-40` above `TestManifestValidateRejectsUnqualifiedVerbType` (`internal/plugin/manifest_test.go`) and above `TestEveryInTreePluginVerbTypeIsQualified` (`test/meta/plugin_verb_qualification_test.go`), flip the entry to `binding: bound` + `asserted_by: ["internal/plugin/manifest_test.go", "test/meta/plugin_verb_qualification_test.go"]`, rerun `go run ./cmd/inv-render`, and confirm `task test -- ./test/meta/` stays green. Otherwise leave `binding: pending` (tolerated; backfill tracked separately).
+
+- [ ] **Step 5: Commit**
+
+`jj commit -m "docs(invariants): document + register the qualified-wire event-type convention (holomush-aneim)"`
+
+---
+
+## Final verification
+
+- [ ] `task test` (full unit suite) — green.
+- [ ] `task test:int -- ./test/integration/scenes/... ./test/integration/crypto/...` — green (Docker).
+- [ ] `task lint` — green (plugin schema, sloglint, license).
+- [ ] `task pr-prep` — green before PR.
+- [ ] `rg -n 'type = "emit"' plugins/core-communication/main.lua` — zero hits.
+- [ ] Confirm `holomush-r0kup` acceptance: a manifest-sourced (un-seeded) core-scenes emit publishes without `EMIT_UNKNOWN_VERB`.
+
+## Out of scope
+
+- Structured (non-string) event types (spec: considered, rejected).
+- Any change to `crypto.emits` semantics, `requests_decryption`, `splitQualifiedRef`, `emitEntryMatchesWireType`, or the `EnforceSensitivity` truth table.
+- Backward compatibility / mixed-history (no users; waived).
+
+## Pre-push review gates
+
+This change touches `internal/plugin/` (loader, plugin emit/readback adjacency) → **crypto-reviewer** (it touches the crypto-vocabulary boundary) **and** code-reviewer MUST run before push, per CLAUDE.md.
+<!-- adr-capture: sha256=c3c0095649f68e1f; session=cli; ts=2026-06-07T02:30:01Z; adrs=holomush-yl3mf,holomush-8aure,holomush-1gwns -->

--- a/docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md
+++ b/docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md
@@ -1,0 +1,287 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+# Event-Type Wire Convention: Canonicalize to `<plugin>:<verb>`
+
+- **Status:** Design (pending design-reviewer)
+- **Design bead:** `holomush-aneim`
+- **Date:** 2026-06-06
+- **Author:** Sean Brandt (with Claude Opus 4.8)
+
+## Problem
+
+HoloMUSH has two coexisting conventions for the **wire event-type string** a
+plugin stamps on emitted events, and exact-match consumers silently break when a
+plugin's wire type doesn't match what a given consumer expects:
+
+- **Plugin-qualified** `<plugin>:<verb>` — used by `core-communication`
+  (`core-communication:say`), `core-objects` (`core-objects:object_create`),
+  the documented convention (`site/.../reference/events.md`,
+  `scripts/gen-event-docs.sh`: "Each event type identifier is qualified with its
+  owning plugin"), the web renderer (`CommunicationRenderer.svelte` matches
+  `event.type === 'core-communication:ooc'`), and the verb registry
+  (`manager.go` registers `verbs[].type` verbatim).
+- **Bare** `<verb>` — used by `core-scenes` (`scene_pose`), which is internally
+  consistent on bare types: emit sites, `RegisterEmitTypes` (phase4/phase6),
+  internal `scene_* → EntryKind` dispatch maps, and persisted
+  `plugin_core_scenes.scene_log` rows are all bare.
+
+The crypto subsystem's `crypto.emits[].event_type` is **bare** in both plugins
+by design (because `requests_decryption` refs are `<plugin>:<event_type>` and
+`splitQualifiedRef` recovers the bare verb). `LookupEmitSensitivity` exact-match
+on the raw wire type is what made `holomush-50zqs` a silent no-op: for
+`core-communication` the wire type was qualified but the bare `crypto.emits`
+entry never matched. `holomush-50zqs` fixed that with `emitEntryMatchesWireType`
+(bare entry matches `entry == wire` OR `<plugin>:entry == wire`), but only at the
+crypto match sites.
+
+Two concrete, currently-latent defects motivate the cleanup:
+
+1. **core-scenes renders nothing in production (`holomush-r0kup`, the real
+   severity).** core-scenes is the only rendering-emitting plugin with **no
+   `verbs:` block**, so it registers no verbs (binary plugins have no
+   InitResponse verb path; `RegisterEmitTypes` feeds only INV-PLUGIN-32, not the
+   verb registry). The production plugin emitter publishes through the
+   `RenderingPublisher`-wrapped publisher (wired in `sub_grpc.go`'s
+   `ConfigureEventEmitter`/`wrapPublisher` path), which hard-fails
+   `EMIT_UNKNOWN_VERB`
+   (`rendering_publisher.go:60`) for any type not in the verb registry. So every
+   `scene_*` wire type fails to publish in production — masked only by the
+   integration harness seeding scene verbs. Unhit to date because there are no
+   users. This is core-scenes being treated as a special case instead of a
+   normal plugin.
+2. **`core-communication:emit` rendering break.** `main.lua:178` emits the
+   generic `emit` command with a **bare** wire type `"emit"`, while
+   `verbs[].type` (`plugin.yaml:264`) and `events.go` declare
+   `core-communication:emit`. `RenderingPublisher.Lookup` is exact-match and
+   returns `EMIT_UNKNOWN_VERB` for the unregistered bare `"emit"`. (The bare
+   `crypto.emits` entry `emit` happens to match it, so crypto is unaffected —
+   the mirror image of the `holomush-50zqs` bug.)
+3. **Convention drift is unbounded.** Nothing prevents a new plugin from picking
+   either convention, re-introducing the silent-mismatch class at any exact-match
+   consumer (rendering, crypto, audit, history).
+
+## Decision
+
+**The canonical wire event-type identity is plugin-qualified
+`<owning-plugin>:<verb>`.** This was chosen over "bare everywhere" (conflicts
+with the documented convention, the web renderer, and the verb registry) and
+over "document both + normalize every consumer" (leaves the drift unbounded).
+
+**There are no existing users and backward compatibility is explicitly NOT
+required** (decision, 2026-06-06). Therefore the migration is clean: no
+mixed-history handling, no data backfill, no reader-side legacy normalization.
+
+### The invariant
+
+> Every emitted **wire event type** and every `verbs[].type` MUST be exactly
+> `<owning-plugin>:<verb>` — the owning plugin's manifest `name`, a single
+> colon, then a verb token. The bare verb survives **only** in
+> `crypto.emits[].event_type` and the `<plugin>:<verb>` `requests_decryption`
+> refs that consume it; the host bridges bare↔qualified at the crypto match
+> sites via `emitEntryMatchesWireType`.
+
+This is registered as **`INV-PLUGIN-40`** in `docs/architecture/invariants.yaml`
+(`binding: pending` per `.claude/rules/invariants.md`), bound by the enforcement
+test (the `Manifest.Validate` gate + the meta-test) below.
+
+## Design
+
+### Considered and rejected: structured type
+
+A "most correct" alternative carries the owning plugin and the verb as separate
+structured fields on `core.Event` rather than a delimited string. Rejected as
+disproportionate (YAGNI): it is a proto + `core.Event` + every-consumer rewrite,
+and the `<plugin>:<verb>` string convention is already entrenched in the
+majority of the codebase, the docs, and the web client.
+
+### Three vocabularies (the distinction the invariant rests on)
+
+An event type appears in three places governed by **different** rules. Conflating
+them is what made the first draft of this design wrong, and what let core-scenes
+become "special". A normal plugin satisfies all three the same way:
+
+| Vocabulary | Source | Form | Governed by |
+| --- | --- | --- | --- |
+| **Registered emit set** | `register_emit_type` (Lua) / `RegisterEmitTypes`→`PluginEmitRegistry` (binary) | **bare** `<verb>` | INV-PLUGIN-32: MUST equal the `crypto.emits` set exactly (`manager.go:1052`, `manifestDeclaredEmitTypes` `:1671`) |
+| **`crypto.emits[].event_type`** | manifest `crypto:` block | **bare** `<verb>` | crypto: `requests_decryption` refs are `<plugin>:<verb>` and `splitQualifiedRef` recovers the bare verb (`crypto_validator.go`) |
+| **Wire type + `verbs[].type`** | emit-site `Type` string + manifest `verbs:` block | **qualified** `<plugin>:<verb>` | rendering: `RenderingPublisher.Lookup(wireType)` resolves against `verbs[].type` and hard-fails `EMIT_UNKNOWN_VERB` on a miss (`rendering_publisher.go:60`) |
+
+The **registered-emit and `crypto.emits` vocabularies stay bare**; the **wire
+and verb vocabularies are qualified**; `emitEntryMatchesWireType` (the
+`holomush-50zqs` bridge) is the single sanctioned place a bare `crypto.emits`
+entry meets a qualified wire type. core-communication and core-objects already
+satisfy this. **core-scenes does not** — it has no `verbs:` block at all, so it
+registers no verbs and its scene IC content hard-fails `EMIT_UNKNOWN_VERB` in
+production (`holomush-r0kup`), masked only by the integration harness seeding
+scene verbs.
+
+### Decision: where the bare↔qualified boundary sits
+
+Two vocabularies are **forced bare** (registered-emit set + `crypto.emits`, by
+INV-PLUGIN-32 and `requests_decryption`). Everything else for core-scenes is
+**downstream of the wire** — `scene_log.type` is written from the emitted wire
+event, and the snapshot/audit/dispatch logic reads that stored type. So those
+internal consumers naturally see whatever the wire carries. The decision (given
+no users — churn is free and uniformity is the goal):
+
+> **Qualify end-to-end.** core-scenes' emit sites stamp `core-scenes:<verb>`;
+> `scene_log.type` therefore stores the qualified form; and *every* internal
+> consumer that keys on the stored/wire type is re-keyed to the qualified form.
+> The **only** bare vocabularies that remain are the two forced ones
+> (registered-emit set + `crypto.emits`). There is no per-plugin bare/qualified
+> transformation layer — one type form flows from emit through storage through
+> snapshot, bridged to the bare crypto vocabulary only by
+> `emitEntryMatchesWireType`.
+
+This dissolves the "another bare site" findings: each is a uniform re-key, not a
+special case. The exhaustive site sweep is the implementation **plan**'s job
+(via grounding); this spec fixes the *decision* and enumerates the known sites
+below so the plan starts complete.
+
+### Component changes
+
+1. **Make core-scenes a normal plugin** (resolves `holomush-r0kup`). core-scenes
+   is not special; bring it to the same shape every rendering plugin has, and
+   apply the qualify-end-to-end decision above:
+   - **Add a `verbs:` block** to `plugins/core-scenes/plugin.yaml` declaring
+     **every** emitted scene type as qualified `core-scenes:<verb>` — all 14:
+     the four IC content types (`scene_pose`, `scene_say`, `scene_emit`,
+     `scene_ooc`), the lifecycle types (`scene_join_ic`, `scene_leave_ic`,
+     `scene_pose_order_changed_ic`), the six `scene_publish_*` notices, and the
+     deferred `scene_idle_nudge` — with `category`/`format`/`label`/
+     `display_target` like core-communication's block. *All* plugin emits pass
+     through `RenderingPublisher`, so every emitted type needs a verb entry or it
+     hard-fails `EMIT_UNKNOWN_VERB` (`holomush-r0kup`). The plan MUST derive the
+     authoritative list from the emit sites, not from this prose, to avoid an
+     incomplete block.
+   - **Qualify the emit-site `Type` strings:** `commands.go` (the `eventType`
+     reaching `EmitIntent`, and the bare verb strings passed to `handleEmit` at
+     the dispatch site ~`commands.go:519-525`), `service.go` (`scene_join_ic`,
+     `scene_leave_ic`, `scene_pose_order_changed_ic`), `publish_events.go` (the
+     six `scene_publish_*`).
+   - **Re-key every internal type-keyed consumer** to the qualified form (per the
+     decision): `replayEventKinds` (`commands.go`), `snapshotEventKinds`
+     (`publish_snapshot.go`), the audit dispatch equality at `audit.go:399`, the
+     SQL filter `WHERE type IN ('scene_pose', 'scene_say', 'scene_emit')` in
+     `ReadSceneLogForSnapshot` (`publish_store.go:640`), and the verb-name
+     derivation `verb := strings.TrimPrefix(eventType, "scene_")` in `handleEmit`
+     (`commands.go:1230`) — which must strip the full `core-scenes:scene_`/the
+     qualified prefix so user-facing verb names stay clean. The plan grounds the
+     complete set; these are the known sites.
+   - **`phase4EmitTypes()` / `phase6EmitTypes()` registration and
+     `crypto.emits[].event_type` stay BARE** (`scene_pose`, …, including the
+     deferred `scene_idle_nudge`). They are the crypto vocabulary; INV-PLUGIN-32
+     requires them equal to each other, and they are NOT wire types. Qualifying
+     them would trip `EVENT_TYPE_REGISTRY_MISMATCH` at load. This is the key
+     correction over the first draft.
+
+2. **`core-communication:emit` fix.** `main.lua:178` `type = "emit"` →
+   `type = "core-communication:emit"`. Same class as core-scenes: aligns the
+   generic emit with its existing `verbs[].type` (`plugin.yaml:264`) and
+   `events.go` constant, closing its own `EMIT_UNKNOWN_VERB` break. Its
+   `crypto.emits` entry `emit` (bare) is unaffected — the bridge resolves
+   `core-communication:emit` against it.
+
+3. **Loader validation.** At plugin load, reject a manifest whose **`verbs[].type`**
+   is not `<this-plugin-name>:<verb>` (a single colon, owning-plugin prefix). The
+   check lives at the verb-registration loop (`manager.go:1138`), returns a typed
+   error (e.g. `PLUGIN_WIRE_TYPE_NOT_QUALIFIED`), and rolls back the partial load
+   like the other load-time validations. **It validates `verbs[].type`, NOT the
+   registered emit set** (which is bare by INV-PLUGIN-32). This gate would have
+   caught both core-scenes (no/again-bare verbs) and core-communication:emit at
+   startup. A plugin that emits a wire type with no matching registered verb
+   still fails fast at emit time via the existing `EMIT_UNKNOWN_VERB`.
+
+4. **No change to crypto.** `crypto.emits` (bare), `requests_decryption`,
+   `splitQualifiedRef`, `emitEntryMatchesWireType`, and **INV-PLUGIN-32**
+   (registered-emit-set == `crypto.emits`, both bare) are all unaffected — the
+   migration deliberately keeps both bare vocabularies bare. The bridge is
+   promoted from a `holomush-50zqs` shim to the **documented intended
+   architecture**.
+
+5. **Remove the special-case test seeding.** Once core-scenes ships a `verbs:`
+   block, `internal/testsupport/integrationtest/crypto.go` no longer needs to
+   seed scene verbs into the registry — deleting that seeding is the proof
+   core-scenes is no longer special (the harness now loads it like any plugin).
+
+6. **Documentation.** Add the three-vocabulary rule + the qualified-wire
+   invariant to `.claude/rules/event-conventions.md`; confirm the public
+   `reference/events.md` qualified-type convention matches (no change expected).
+
+### Data flow (unchanged shape, now uniform)
+
+Emit (qualified wire type) → `event_emitter.go::Emit` → `eventbus.NewType`
+(validates one-colon form) → publish. Consumers:
+
+- **Rendering:** `RenderingPublisher.Lookup(wireType)` resolves against
+  `verbs[].type` (qualified) — now always hits for every plugin.
+- **Crypto:** `LookupEmitSensitivity` / `PluginCanReadBack` via
+  `emitEntryMatchesWireType` bridge the bare `crypto.emits` entry to the
+  qualified wire type.
+- **Audit / history / snapshot:** key on the (now-qualified) wire type; for
+  `core-scenes`, the internal dispatch is migrated in lockstep with its emit
+  sites in the same change, so there is no window where a stored type fails to
+  dispatch.
+
+### Error handling
+
+- Loader: unqualified `verbs[].type` → typed error + load rollback (fail-fast).
+  **This is the sole enforcement point for the qualified-wire invariant.**
+- Emit: `eventbus.NewType` rejects *malformed* (multi-colon / empty) type
+  strings but **accepts a bare single-token verb** (`typeRe` in
+  `internal/eventbus/types.go` permits `^[a-z][a-z0-9_-]*...`). A plan author
+  MUST NOT treat `NewType` as a defense layer against bare types — only the
+  loader gate above catches them, at registration time, not at emit time.
+- Crypto: unchanged fail-closed behavior (`EnforceSensitivity` truth table
+  untouched).
+
+## Testing
+
+- **`holomush-r0kup` regression:** a core-scenes scene emit publishes through
+  the production `RenderingPublisher` (verb registry seeded only from the
+  manifest, no test-side scene-verb seeding) without `EMIT_UNKNOWN_VERB`, and
+  resolves a rendering registration. This is the test that would have failed
+  before the `verbs:` block existed.
+- **`core-scenes` unit tests** updated to the qualified wire types (emit
+  assertions, `EntryKind` dispatch, audit projection) — while
+  `crypto.emits`/registered-emit assertions stay bare.
+- **Loader validation test:** a manifest with a bare or foreign-qualified
+  `verbs[].type` is rejected with the typed error and rolled back.
+- **Meta-test** (`test/meta` or `internal/plugin/lua`): scan every in-tree
+  plugin's **`verbs[].type`** and assert each is `<owning-plugin>:<verb>`. It
+  MUST NOT assert qualification on the registered-emit / `crypto.emits` sets —
+  those are bare by INV-PLUGIN-32. Pairs with the `holomush-72ti5`
+  `sensitive`-claim meta-test.
+- **Harness de-seeding:** remove the scene-verb seeding from
+  `internal/testsupport/integrationtest/crypto.go`; existing crypto / readback
+  integration stays green with verbs sourced from the core-scenes manifest.
+- **`holomush-qg1v5`** (the deferred end-to-end integration test) then asserts
+  the qualified types end-to-end.
+
+## Invariant registry
+
+This design introduces one system invariant (the canonical-qualified-wire-type
+rule above), registered per `.claude/rules/invariants.md` as **`INV-PLUGIN-40`**
+in `docs/architecture/invariants.yaml` with `binding: pending` in this same
+change. Implementation (the `Manifest.Validate` gate test + the meta-test) flips
+it to `binding: bound` — see plan Task 8.
+
+## Out of scope
+
+- Re-architecting event type into structured fields (considered, rejected).
+- Any change to `crypto.emits` / `requests_decryption` semantics or the
+  `EnforceSensitivity` truth table.
+- Backward compatibility / mixed-history handling (no users; explicitly waived).
+
+## Resolves / related beads
+
+- `holomush-r0kup` (P1 bug) — core-scenes scene IC content fails
+  `EMIT_UNKNOWN_VERB` in production. **Resolved by this design** (core-scenes
+  gains a `verbs:` block + qualified wire types); `r0kup` is blocked by `aneim`.
+- `holomush-qg1v5` — end-to-end integration test (asserts qualified types).
+- `holomush-72ti5` — `sensitive`-claim meta-test (pairs with the new
+  qualified-type meta-test).
+<!-- adr-capture: sha256=2dd056c93768a117; session=cli; ts=2026-06-07T02:30:01Z; adrs=holomush-yl3mf,holomush-8aure,holomush-1gwns -->


### PR DESCRIPTION
Docs-first PR (spec + plan + ADRs) for the event-type wire convention canonicalization (`holomush-aneim`). No code changes — this lands the design artifacts so implementer subagents can read them from `main`. Implementation is tracked as the `aneim` epic's task beads (not in this PR).

## What's here

- **Spec** `docs/superpowers/specs/2026-06-06-event-type-wire-convention-design.md` — design-reviewer **READY** (4 rounds).
- **Plan** `docs/superpowers/plans/2026-06-06-event-type-wire-convention.md` — plan-reviewer **READY** (6 rounds), 8 tasks.
- **3 ADRs** (`docs/adr/`): `holomush-yl3mf` canonical-qualified-wire, `holomush-8aure` three-vocabulary model, `holomush-1gwns` qualify-core-scenes-end-to-end + README index.

## The decision

Canonical wire event-type identity = plugin-qualified `<plugin>:<verb>`. The registered-emit set and `crypto.emits[].event_type` stay **bare** (INV-PLUGIN-32 / `requests_decryption`); the wire type + `verbs[].type` are **qualified**; `emitEntryMatchesWireType` (merged in #4395) is the single bridge. core-scenes is migrated qualify-end-to-end.

## Why it matters

Uncovered a latent **P1 (`holomush-r0kup`)**: core-scenes has no `verbs:` block, so all its IC content hard-fails `EMIT_UNKNOWN_VERB` through the production `RenderingPublisher` — masked only by test seeding (no users yet). The plan makes core-scenes a normal plugin and adds a `Manifest.Validate` gate + meta-test so the convention can't drift again.

## Tracking

- Epic `holomush-aneim` → 8 task beads (`aneim.5`–`.12`); foundational Tasks 1-4 (P1) resolve `holomush-r0kup`, enforcement Tasks 5-8 (P2).
- `bd ready`: `aneim.5` (verbs block) + `aneim.9` (core-communication:emit).

## Test plan

- [x] `task pr-prep` (fast lane) — green (docs + schema + lint + build).
- [ ] Implementation lands per the plan (separate PRs / subagent-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)