### PR TITLE
fix(core-scenes): qualify event types + declare manifest verbs (holomush-r0kup)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -2,207 +2,100 @@
   (a) Fragile `// Verifies:`-grep coverage meta-tests (`test/meta/i_<old>_coverage_test.go`,
   per-family `TestEveryPhase3c...` scanning `// Verifies: I-<OLD>-N`/`INV-<digits>`) MUST be
   DELETED on migration — renamed annotations make them find ZERO and fail ALL N (.14.9 missed →
-  I-PRIV-1..8 failed). Coverage is absorbed by `TestEveryRegistryInvariantHasBinding`. DISTINCT
+  I-PRIV-1..8 failed). Coverage absorbed by `TestEveryRegistryInvariantHasBinding`. DISTINCT
   from robust `testName`-EXISTENCE checks (go/parser Test* names) which MIGRATE in lockstep. Keep
   shared helpers (`findRepoRoot`/`skipDirs`) in a gutted meta file — 10+ files use them; verify
   it still compiles. (b) FROM-anchor: `checkProvenance` greps canonical `e.ID`, NOT `r.Token`, so
   refs recording legacy tokens is harmless/correct. (c) Origin SPEC is NOT migrated by design;
   legacy column records the link. (d) gorules is a SEPARATE module — analyzer diagnostic + Doc +
   testdata `// want` rename in lockstep; `go clean -testcache` before `task test:gorules`.
-  (e) `task lint:invariants` (= `inv-render -check`) must exit 0 for invariants.md sync. (f) DENSE
-  renumber maps non-contiguous legacy ascending-by-position; verify each entry's legacy + every
-  refs[].token. hz0v4.14.9 NOT-READY / .14.11 READY (2026-06-02).
+  (e) `task lint:invariants` (= `inv-render -check`) must exit 0 for invariants.md sync.
 
-- **Multi-family + dense letter-suffix renumber (EVENTBUS=GW+ROPS+P7-split .14.12;
-  SCENE=P4/P5/P6/FS/Y5INX/SH+bare → 59 ids/86 files .14.13; both READY).** GW dense
-  over {1,2,3,3a,4..11,13..16} (letter-suffix 3a); P7 SPLIT (audit-half →25/26/27,
-  rest bare for later). `awk` ref/legacy scans FALSE-mismatch on `3a`/`refs:[]`/`,}`
-  — hand-read. Coverage-test taxonomy: per-family `TestAll*RegistryInvariantsHaveTests`
-  + `inv_p4/p5_coverage_meta_test.go` are `testName`-EXISTENCE checks (go/parser Test*
-  names; `{inv,testName}` table) — robust to rename when testName strings + funcs move
-  in lockstep; DISTINCT from fragile `// Verifies:` scanners (DELETE those, .14.9).
-  Confirm which kind before delete-vs-migrate. Manual `\b`-unreachable underscore
-  renames (TestINV_P4_4→_SCENE_4): grep old→ZERO + chase string/cross-file cites.
-  Generic `TestInvariantTokenBoundariesRejectFalsePositives` KEPT (INV-GW-* fixtures
-  intentional). Partition: other scopes MAY list a foreign-owned file in THEIR
-  shared_files. Trailing-comma `,}` noise — Low non-blocking.
+- **Registry-renumber series (.14.12–.14.27, ~9 legs, all READY except .14.23) — CONSOLIDATED.**
+  Each leg renames a legacy invariant family (GW/ROPS/P7-split/P4/P5/P6/FS/SCENE/PLUGIN/ACCESS/
+  CRYPTO/S*/M*/COMMAND) to canonical `INV-<SCOPE>-N`, dense non-contiguous ascending-by-position.
+  Recurring checks that HOLD: (1) Per-file token scan of EVERY owned file → ONLY `INV-<SCOPE>-N`;
+  residual walk `bareInvRE = \bINV-\d+\b` (invariant_registry_test.go:488) matches ONLY bare
+  NUMERIC `INV-9` — NOT `INV-P7-1`/`INV-RB-1`/`INV-PLUGIN-22` (the `-XX-` segment breaks `\d+`),
+  and `continue`s on shared files (~line 554). So foreign/deferred tokens survive ONLY in
+  shared_files, and descriptive prose like `INV-P7-1..16` in an owned file is INERT. (2)
+  checkProvenance greps CANONICAL `e.ID` at each ref site, NOT `r.Token` — refs recording legacy
+  `token:"INV-15"` is the standing FROM-anchor convention; the canonical id must ALSO be
+  physically present. (3) TestOwnedPathsPartition only forbids the SAME glob in two scopes'
+  owned_paths; an unowned shared file is permissible (checkProvenance accepts shared-OR-owned).
+  Genuinely multi-scope files carry BOTH tokens, listed in both scopes (one owned, one shared).
+  (4) PER-SITE not per-number: same bare number → different outcome per file (bare INV-1 →
+  PLUGIN-22 in plugin-evaluate files, LEFT bare in command-visibility files). (5) Coverage
+  meta-tests: distinguish `testName`-EXISTENCE checks (go/parser Test* names; t.Run `inv` labels
+  robust to rename, MIGRATE in lockstep) from fragile `// Verifies:`-grep scanners (DELETE —
+  .14.9). (6) refs:[] spec-only/binding:pending is HONEST when the origin spec maps a mechanism
+  to the PARENT token's code site, not its own (M4/5/6→parent PLUGIN-32; W9ML 1..6).
+  TestEveryRegistryInvariantHasBinding tolerates pending+refs:[]. (7) Generated artifacts
+  (.pb.go/_grpc.pb.go/.connect.go/_pb.ts/_connect.ts/grpc-api.md) must regen in sync when a proto
+  INV-comment is renamed. (8) Deferred-bare-INV + foreign tokens → use file-path owned_paths NOT
+  `dir/**` globs (else residual walk trips on left-behind tokens) — .14.14. (9) Trailing-comma
+  `token:"...",}` noise recurs ~6×; renderer-inert, Low non-blocking. (10) Zero executable-line
+  edits expected — every .go diff line is a comment or test-assertion string-literal token swap.
+  Final counts: CRYPTO=67/PLUGIN=39/ACCESS=8/EVENTBUS=28/SCENE=60; COMMAND-scope created by LAYER
+  split (Go-backend→COMMAND, web-composer TS LEFT exempt). Encountered .14.12–.14.27 (2026-06-02..04).
 
-- **Scope with DEFERRED bare-INV-N + foreign tokens uses file-path owned_paths
-  (NOT /** globs) to keep the residual walk clean (hz0v4.14.14 PLUGIN READY).**
-  When a scope's directory holds un-migrated bare INV-N (deferred to a later pass)
-  or foreign-family tokens, owning the `dir/**` glob would make the residual walk
-  trip on those left-behind tokens. Fix: list only the specific migrated files in
-  `owned_paths`; put every mixed/foreign-carrying file in `shared_files` (shared ≠
-  residual-walked). PLUGIN: `pluginauthz/**`, `wholesystem/**`, `plugin/**` REMOVED
-  from scaffold globs → only `config.go`, `identity_registry.go`, `plugin_repo.go`,
-  2 eventbus grep tests, 3 WS harness files owned. Review checks that HELD: (1)
-  per-file token scan of every owned file → ONLY INV-<SCOPE>-N (no bare/foreign
-  leftover) ⇒ residual walk clean; (2) every mixed file in shared_files actually
-  carries a foreign/deferred token (lua/host.go=INV-6/7/8/S5, manager.go=EVENTBUS-11/
-  M1/S5, subsystem.go=INV-1/4/SCENE-38, harness.go=PRIVACY/ACCESS-4/P7-9/bare-1,
-  plugins.go=ACCESS-4) — justifies shared-not-owned; (3) STORE-owned
-  no_delete_grep_test.go is in PLUGIN shared (not owned); (4) deferred bare INV-1..5/8/11
-  LEFT in pluginauthz/hostfunc untouched. P7-split sanity: PLUGIN block has NO P7 entry,
-  no P7 token rewritten (pre-existing EVENTBUS P7-3/4/10 refs untouched). W9ML source
-  spec defines 1..9 (redesign §2.1 undercounted to 1..8) — code reality authoritative;
-  spec-only refs:[] = exactly W9ML-1..6 (6). Same `token: "...",}` trailing-comma noise
-  recurred AGAIN (3rd time: SCENE INV-7 ref) — Low non-blocking; renderer-inert.
-  Encountered: hz0v4.14.14 (2026-06-03) — READY.
+- **First NOT-READY in the series: registry guards are BLIND to unregistered files, so a green
+  meta-test run does NOT prove a family migration is complete (hz0v4.14.23 INV-F NOT READY).**
+  Two defects survived a fully-green run (lint:invariants, provenance, partition, binding, 617
+  unit tests, int-compile): (A) **51 residual bare `INV-F*` token refs** in THREE cmd/holomush
+  files NOT in the diff (admin_read_stream_e2e_test.go ×45, readstream_wiring_test.go ×4,
+  admin_authenticate_e2e_test.go ×2) — same family migrated, but files neither owned_paths nor
+  shared_files nor in any `refs[]`, so residual walk + provenance never look → green despite
+  incomplete. 4 are STALE cross-file func-name cites (`TestINV_F2/F6/...`) pointing at funcs THIS
+  diff RENAMED → dangling. (B) **Range-rewrite corruption**: `INV-P7-1..16` → `INV-CRYPTO-38..16`
+  (tool rewrote left side of a `..N` range, left suffix); substring `INV-CRYPTO-38` keeps
+  provenance green, CI blind. **Review pattern for family migrations: do NOT trust green guards
+  as proof of completeness. ALWAYS `rg -c '\bINV-<OLD>[0-9]' --glob '!docs/**'` over the WHOLE
+  tree (not just diffed files) — residual hits in unregistered files = incomplete. Also
+  `rg 'INV-<SCOPE>-[0-9]+\.\.[0-9]+'` for range corruption, `rg 'TestINV_<OLD>[0-9]'` for
+  dangling renamed-func cites.** Encountered: hz0v4.14.23 (2026-06-03) — NOT READY.
 
-- **Final/hardest CRYPTO leg (52 ids: reader-opts 1..6→1..5 + master-crypto bare
-  9..49 + RB-1..12 + P7-crypto-half) is the same shape; all checks held (hz0v4.14.15
-  READY).** Key residual-walk subtlety confirmed at source: `bareInvRE` in
-  `test/meta/invariant_registry_test.go:488` is `\bINV-\d+\b` — matches ONLY bare
-  NUMERIC `INV-9`. It does NOT match `INV-P7-1` / `INV-RB-1` (the `-P7-`/`-RB-`
-  segment breaks `\d+` right after `INV-`). So a surviving descriptive prose
-  reference like `// the legacy INV-P7-1..16 set, migrated to...` in an OWNED file
-  (phase7_boundary_meta_test.go:25) is INERT to the residual walk — NOT a finding.
-  Residual walk also `continue`s on shared files (line 554). The
-  `phase7_boundary_meta_test.go` is a `testName`-EXISTENCE meta-test (collects Go
-  Test* func names via go/parser; `tc.inv` is a t.Run label only, robust to rename)
-  — distinct from `// Verifies:`-grep scanners that MUST be deleted (.14.9). Its
-  `cases` table `inv` strings migrate in lockstep. Shared_files MAY be unowned by
-  any scope: `TestOwnedPathsPartition` (line 113) only forbids the SAME glob in two
-  scopes' owned_paths; an unowned shared file (crypto_manifest.go carrying only
-  INV-CRYPTO-27; plugin_role_permissions_test.go only INV-CRYPTO-48) is permissible —
-  `checkProvenance` line 524 accepts shared-OR-owned. Dense renumber maps
-  non-contiguous legacy ascending-by-position (reader INV-5 was never a real inv →
-  1,2,3,4,6→1,2,3,4,5; master INV-17→CRYPTO-9). Provenance check greps canonical
-  `e.ID` (line 520), NOT `r.Token` (legacy FROM-anchor) — so 209 refs showing
-  "legacy TOKEN-ABSENT" is EXPECTED/correct; re-scan for canonical id instead.
-  grpc-api.md table-row "non-comment" diffs are doc prose; verify each ± pair
-  differs ONLY in the token. No `token:",}` trailing-comma noise this time.
-  Encountered: hz0v4.14.15 (2026-06-03) — READY.
+- **Verification-BINDING backfill (pending→bound flip, NOT a renumber) — hz0v4 binding-backfill
+  READY.** Flips registry entries pending→bound + adds asserted_by, ONLY where a `// Verifies:
+  INV-<id>` annotation ALREADY exists; may add the comment to a pre-existing asserting test.
+  TestEveryRegistryInvariantHasBinding walks ALL *_test.go (raw regex, build tags irrelevant —
+  integration files ARE scanned); a `bound` entry needs ≥1 annotation ANYWHERE, and asserted_by
+  is NOT cross-checked against annotation sites — so a typo'd/fabricated asserted_by path passes
+  the gate. MUST hand-verify each asserted_by file genuinely contains the annotation. `pending`
+  MUST NOT carry asserted_by. For bug-closing flips (0sh1k 'asserted only in comments'), the
+  `// Verifies:` comment does NOT fix a false-green — READ the cited test and confirm a REAL
+  runtime assertion of EACH invariant clause (CRYPTO-28: audit-emit = WaitForOneJetStreamMsg on
+  AUDIT stream + header assert; fail-closed = audit=nil → res.Err set, no plaintext). Gates:
+  `inv-render -check` exit 0; meta binding+provenance green. Encountered: 2026-06-05 — READY.
 
-- **Final bare-INV-N PER-SITE pass (tri-overloaded namespace: same bare number
-  → DIFFERENT outcomes per file) — all checks held (hz0v4.14.22 READY).** The
-  whole point: bare INV-1 → INV-PLUGIN-22 ONLY in plugin-evaluate files
-  (pluginauthz/evaluate.go, hostfunc/evaluate.go, hostfunc/stdlib_settings.go,
-  goplugin/evaluate_invariants_test.go), while command-visibility INV-1 (commands.go,
-  functions.go, setup/subsystem.go) LEFT bare; settings INV-6 (host_service.go) +
-  fence INV-6/7 (lua/host.go) LEFT. Verify per-file, not per-number. Key checks:
-  (1) `rg '\bINV-[0-9]+\b'` over EVERY owned file → ZERO (residual walk = `bareInvRE
-  \bINV-\d+\b` at invariant_registry_test.go:488); foreign bare tokens survive ONLY
-  in shared_files (residual `continue`s on shared, line ~550). (2) checkProvenance
-  (line 492) greps CANONICAL `e.ID` at each ref site, NOT `r.Token` — so refs
-  recording legacy `token: "INV-15"/"INV-A16"/"INV-4"` is the standing FROM-anchor
-  convention, NOT a finding; the canonical token must ALSO be physically present
-  (it is). (3) Cross-scope ownership is legit: access/setup/subsystem.go +
-  setup_warn_integ_test.go are PLUGIN-owned (INV-4 audit-wiring is plugin-evaluate,
-  not ABAC) — confirm each appears ONCE in owned_paths and carries ONLY the migrated
-  token; no scope owns `internal/access/**` glob so TestOwnedPathsPartition is safe.
-  (4) seed.go/seed_test.go genuinely multi-scope (PRIVACY I-PRIV-6 + now ACCESS) →
-  ACCESS-shared not owned; seed_smoke_test.go/spec_amendments_test.go ACCESS-owned.
-  (5) Bare `A16` prose (no INV- prefix) MUST stay — `\bA16\b` rewrite would corrupt
-  `INV-A16`; `INV-A16` → INV-ACCESS-8 cleanly. (6) Zero `.go` executable-line edits;
-  every .go diff line is a comment or test-assertion string-literal token swap.
-  (7) This diff CLEANED a pre-existing `,}` (INV-RA-6 line 1657) but ADDED a new one
-  (INV-A16 line 1682) — 5th recurrence, Low non-blocking, renderer-inert. PLUGIN dense
-  1..28, ACCESS dense 1..8. Encountered: hz0v4.14.22 (2026-06-03) — READY.
-
-- **First NOT-READY in the .14.x classification series: registry guards are
-  BLIND to unregistered files, so a green meta-test run does NOT prove a family
-  migration is complete (hz0v4.14.23 INV-F NOT READY).** Two defects survived a
-  fully-green run (lint:invariants, provenance, partition, binding, 617 unit tests,
-  int-compile): (A) **51 residual bare `INV-F*` token refs** (INV-F1/2/3/6/9/10/11/
-  12/14/15/17) in THREE cmd/holomush files NOT in the diff: admin_read_stream_e2e_test.go
-  (45), readstream_wiring_test.go (4), admin_authenticate_e2e_test.go (2). These are
-  the SAME family the bead migrates, but the files are neither owned_paths nor
-  shared_files nor in any registry `refs[]`, so the residual walk + provenance guard
-  never look at them → green despite incomplete migration. 4 of those are STALE
-  cross-file func-name cites (`TestINV_F2/F6/F3/F17_...` at lines 1124/1159/1245/2137)
-  pointing at funcs THIS diff RENAMED to TestINV_CRYPTO_54/56/55/67 — now dangling.
-  (B) **Range-rewrite corruption**: phase7_boundary_meta_test.go:25 prose
-  `INV-P7-1..16` → `INV-CRYPTO-38..16` (tool rewrote left side of a `..N` range,
-  left suffix). `INV-P7-1` is a P7 token (handled in .14.15), OUT OF SCOPE for the
-  F pass — tool should not have touched it. Substring `INV-CRYPTO-38` keeps
-  provenance green (real anchor is the table row at line 54), so CI is blind.
-  Redesign spec (2026-06-01-...-redesign.md:42) DOCUMENTS this exact class:
-  "INV-CRYPTO-1..5 — nonsensical as crypto. Every CI gate passed." Same bug the
-  crypto-reviewer caught on F-compound-refs (INV-CRYPTO-56/F7), recurred on a
-  `..N` range. **Review pattern for family migrations: do NOT trust green guards
-  as proof of completeness. ALWAYS run `rg -c '\bINV-<OLD>[0-9]' --glob '!docs/**'`
-  over the WHOLE tree (not just diffed files) — residual hits in unregistered files
-  = incomplete migration. Also `rg 'INV-<SCOPE>-[0-9]+\.\.[0-9]+'` for range
-  corruption, and `rg 'TestINV_<OLD>[0-9]'` for dangling renamed-func cites.**
-  Mechanical search-replace correct part: 35 diffed files all comment/string/test-func
-  swaps, dense 53..67, no executable edits, generated artifacts in sync. The DEFECT
-  is what was MISSED, not what was changed. Encountered: hz0v4.14.23 (2026-06-03) — NOT READY.
-
-- **INV-S\* substrate-contract per-token SPLIT across THREE scopes + master-crypto
-  fence (hz0v4.14.24 READY).** S3→PLUGIN-31, S5→PLUGIN-32, S4→EVENTBUS-28,
-  S9→SCENE-60; master fence INV-6→PLUGIN-29, INV-7→PLUGIN-30. Checks that held:
-  (1) tri+-overload: 8 fence files (sensitivity_fence{,_test}.go, event_emitter{,_crypto_test}.go,
-  lua/host.go, pkg/plugin/event.go, integrationtest/crypto.go, plugin.proto) → ZERO bare
-  INV-6/7; foreign INV-6/7 LEFT in web frontend (themeStore/commandListStore/composerChip),
-  CI-tooling (tooling_no_mandatory_int_test.go), reader-opts (cmd/holomush/sub_grpc_test.go),
-  settings (goplugin/host_service.go:610), AND phase-8 board-content SCENE-58/59 legacy
-  (a DIFFERENT INV-6/7 namespace — its legacy column STAYS INV-6/7). (2) S1/S2/S6/S7/S8/S10
-  have ZERO code/manifest refs → split is complete; only S3/S4/S5/S9 were ever code-bound.
-  Remaining INV-S* hits are ONLY docs/roadmap.md + site/docs + ADRs (prose, not annotations) +
-  invariants.yaml legacy/refs.token (FROM-anchor). (3) service.go + store.go genuinely
-  multi-scope → carry BOTH INV-EVENTBUS-28 (S4) AND INV-SCENE-60 (S9): EVENTBUS-shared +
-  SCENE-owned, listed in both. (4) checked cmd/ + api/proto/ (prior-pass blind spots, see
-  .14.23) → clean. Dense: PLUGIN 1..32, EVENTBUS 1..28, SCENE 1..60, no dup/gap. Trailing-comma
-  ,} noise recurred (6th time): added 2 (EVENTBUS-28/SCENE-60 last refs), cleaned 2 — Low
-  non-blocking, renderer-inert. Encountered: hz0v4.14.24 (2026-06-04) — READY.
-
-- **INV-S5 MECHANISM family (M1..M7 → PLUGIN-33..39) + missed plugin.proto INV-1
-  api/proto site → PLUGIN-22 (hz0v4.14.27 READY).** Companion pass to .14.24's
-  INV-S5 substrate token (S5→PLUGIN-32): adds the 7 mechanism sub-invariants.
-  Key: M4/M5/M6 are `refs: []` spec-only/binding:pending — HONEST because the
-  origin spec (2026-05-17-inv-s5-mechanism-design.md:62-68) maps those mechanisms
-  to code sites that annotate with the PARENT token INV-PLUGIN-32 (lua/host.go:39,237;
-  stdlib_emit_registry.go:14,47), NOT their own INV-M4/5/6 tokens. The migrate tool
-  can only rename tokens physically present; M4/5/6 never existed as annotations →
-  refs:[] is correct, NOT an incomplete migration. (Same convention as .14.14 W9ML
-  1..6.) `TestEveryRegistryInvariantHasBinding` tolerates binding:pending+refs:[].
-  M1/M2/M3/M7 DID have annotations → canonical PLUGIN-33/34/35/39 verified physically
-  present in their ref files. The .14.22 missed plugin.proto INV-1 ('no subject field'
-  plugin-host-evaluate) → PLUGIN-22 now closed across proto + 5 generated artifacts
-  (.pb.go/_grpc.pb.go/.connect.go/_pb.ts/_connect.ts/grpc-api.md) — all in sync, zero
-  stale '(spec §2, INV-1)'. CRITICAL non-collision: command-vis INV-1 (commandquery/
-  query.go, hostfunc/commands.go+functions.go, setup/subsystem.go, help_integration_test.go,
-  harness.go) + world/service_test.go per-property INV-1 ALL untouched — diff only
-  touched plugin.proto's INV-1, a distinct namespace. Owned emit_type_validator{,_test}.go
-  carry ONLY INV-PLUGIN-* (bareInvRE \bINV-\d+\b doesn't match INV-PLUGIN-NN, residual
-  clean). manager.go/manager_test.go/manager_parity_test.go/plugin.proto are SHARED (carry
-  foreign EVENTBUS-11/W9ML-8/CRYPTO/regen). Zero executable edits; dense PLUGIN 1..39.
-  NO trailing-comma ,} noise this time. Counts CRYPTO=67/PLUGIN=39/ACCESS=8/EVENTBUS=28/
-  SCENE=60. Encountered: hz0v4.14.27 (2026-06-04) — READY.
-
-- **NEW-scope creation by LAYER split + missed-site mop-up (.14.27 PR B/C,
-  INV-COMMAND, READY).** Multi-INV spec (command-chip INV-1..7) split by LAYER not
-  number: Go-backend INV-1/2/5 → INV-COMMAND-1/2/3; web-composer INV-3/4/6/7 LEFT
-  web-local TS (exempt). Review BOTH directions: no Go annotation wrongly left
-  (rg the legacy bare number over internal/ → ZERO) AND no web token wrongly pulled
-  (per-SITE, never value-keyed — INV-5 was layer-overloaded: Go list_available
-  →COMMAND-3 migrated, web composerChip INV-5 LEFT). New-scope partition: owns
-  commandquery/** + specific files; confirm no other scope globs same dir. PR C
-  mopped 2 missed sites (help_integration_test.go owned, setup/subsystem.go shared-
-  by-4-scopes — legal, only owned_paths must partition; subsystem.go RETAINS its
-  foreign PLUGIN-25/3/SCENE-38/EVENTBUS-11). Spec-token scan trap (.14.23): dropped
-  slots written as LEGACY (INV-TS-8 not INV-STORE-8) = binding-guard-inert.
-  Encountered: hz0v4.14.27 PR B/C (2026-06-04) — READY.
-
-- **Verification-BINDING backfill (pending→bound flip, NOT a renumber) —
-  hz0v4 binding-backfill READY.** Distinct recurring shape (trackers hz0v4.11/16/
-  17/18/19 open): flips registry entries pending→bound + adds asserted_by list,
-  ONLY where a `// Verifies: INV-<id>` annotation ALREADY exists; may add the
-  Verifies comment to a pre-existing asserting test. KEY meta-test semantics:
-  TestEveryRegistryInvariantHasBinding walks ALL *_test.go (raw regex, build tags
-  irrelevant — integration files ARE scanned) for `// Verifies: INV-<SCOPE>-N`;
-  a `bound` entry needs ≥1 annotation ANYWHERE, and asserted_by is NOT cross-
-  checked against annotation sites — so a typo'd/fabricated asserted_by path
-  passes the gate. MUST hand-verify each asserted_by file genuinely contains the
-  annotation (rg the canonical token, cross-ref). `pending` MUST NOT carry
-  asserted_by (checkRegistryBindings). For bug-closing flips (0sh1k: 'asserted
-  only in comments'), the `// Verifies:` comment does NOT fix a false-green — READ
-  the cited test and confirm a REAL runtime assertion of each invariant clause
-  (CRYPTO-28: audit-emit clause = WaitForOneJetStreamMsgOnStream on AUDIT stream +
-  header assert; fail-closed clause = audit=nil → res.Err set, no plaintext). Both
-  pre-existed; diff only added the comment. Gates: `go run ./cmd/inv-render -check`
-  exit 0 (md↔yaml sync); meta TestEveryRegistryInvariantHasBinding+TestProvenance
-  green. Roadmap counts cross-foot (bound+pending=total; per-scope remaining =
-  scope_total − bound). No production code; comment-only test edits. Encountered:
-  hz0v4 binding-backfill (2026-06-05) — READY.
+- **NEW shape — wire event-type qualification migration (bare scene_* → core-scenes:<verb>),
+  aneim Phase 1 / holomush-r0kup READY.** Distinct from the .14.x renumbers. Three vocabularies,
+  DIFFERENT rules: (1) registered-emit set (main.go phase4/phase6EmitTypes) + (2)
+  crypto.emits[].event_type MUST stay BARE (INV-PLUGIN-32 set-equality + splitQualifiedRef);
+  (3) wire type + verbs[].type MUST be qualified `<plugin>:<verb>`. So per-SITE judgement, not
+  per-token: bare main.go/crypto.emits/main_test.go assertions are CORRECT, not misses. Checklist
+  that held: (a) whole-tree `rg scene_pose|scene_say|...` ex-core-scenes/docs — only proto
+  doc-comments, generated *.pb.go/_pb.ts, crypto-bridge unit tests, and raw-bus `mintEvent`/
+  `eventbus.Type` synthetic integration tests (published via `bus.Bus.Publisher()` NOT
+  RenderingPublisher → bypass verb registry, self-consistent bare). (b) ALL scene_log INSERTs incl
+  SQL single-quote literals (seedScenePoseLog, poseorder `type='...'`, publish_store.go `WHERE
+  type IN (...)`) — silent zero-row risk; both late-found literals qualified. (c) audit dispatch
+  `eventType := row.GetType()` (qualified stored) vs `if eventType == "core-scenes:scene_pose"` —
+  match. (d) handleEmit `strings.TrimPrefix(eventType,"core-scenes:scene_")` clean for
+  pose/say/emit/ooc; `verb` only feeds user output, wire `Type` stays qualified. (e) DOWNGRADE
+  FENCE NON-DEFEAT: `cryptowiring.AlwaysSensitiveSet` already PREFIXES bare crypto.emits with
+  `<plugin>:`, so fence `alwaysSensitive` was always qualified — qualifying scene_log.type CLOSES
+  a pre-existing keying gap (row.GetType() now matches), does not open fail-open; fenceCheckRow
+  only consults alwaysSensitive on identity-codec rows (encrypted use DEK-exists). (f)
+  `emitEntryMatchesWireType` (crypto_manifest.go:89) bridges bare entry ↔ qualified wire for
+  LookupEmitSensitivity + PluginCanReadBack — emit/readback unaffected. (g) harness regression
+  validity: SAME verbRegistry instance wrapped into crypto RenderingPublisher AND populated by
+  plugin loader from manifest (harness.go:333→347 & →376→plugins.go:311); EmitSceneICContent's
+  internal require.NoError surfaces EMIT_UNKNOWN_VERB so the spec genuinely fails w/o the verbs
+  block. (h) harness emit helper qualifies bare→qualified IDEMPOTENTLY (`if !strings.Contains
+  (wireType,":")`), so untouched tests passing bare verbs still work; readback/privacy tests
+  already used `pluginName+":scene_pose"`. (i) manifest enums closed (manifest.go:176-187):
+  category{communication,movement,state,system,command}, format{speech,action,narrative,
+  notification,error,snapshot,delta}, speech needs label. Design: IC content (pose/say/emit/ooc)→
+  communication; lifecycle/publish notices→system+notification. No false-green (no `// Verifies:
+  INV-PLUGIN-40`; loader-gate aneim.10 + meta-test aneim.11 deferred). 2026-06-07 — READY.

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -35,7 +36,6 @@ import (
 	"github.com/holomush/holomush/internal/plugin/cryptowiring"
 	worldpg "github.com/holomush/holomush/internal/world/postgres"
 	pluginsdk "github.com/holomush/holomush/pkg/plugin"
-	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
 	eventbusv1 "github.com/holomush/holomush/pkg/proto/holomush/eventbus/v1"
 	pluginv1 "github.com/holomush/holomush/pkg/proto/holomush/plugin/v1"
 )
@@ -102,13 +102,11 @@ func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Poo
 	require.NoError(t, err, "newPluginCrypto: dek.NewManager")
 
 	// The RenderingPublisher (wrapped below) looks up a verb for every emitted
-	// event type. core-scenes registers its scene event types as crypto.emits
-	// (not manifest verbs:), so the bootstrap registry has no entry — register
-	// them here so plugin emits resolve. Mirrors the reference round-trip test
-	// (test/integration/crypto/readback_test.go:141) which registers the scene
-	// emit type as a verb before emitting.
-	registerSceneEmitVerbs(t, verbReg)
-
+	// event type. verbReg is the SAME registry the plugin subsystem populates
+	// from each loaded plugin's manifest verbs: block (harness.go shares one
+	// instance), and WithPluginCrypto REQUIRES WithInTreePlugins — so core-scenes'
+	// qualified scene verbs (core-scenes:scene_pose, …) are registered from its
+	// manifest at load (holomush-r0kup). No standalone seeding needed.
 	sel := cryptowiring.KeySelector()
 	raw := bus.Bus.Publisher(eventbus.WithDEKManager(dekMgr), eventbus.WithCodecSelector(sel))
 	return &pluginCrypto{
@@ -117,32 +115,6 @@ func newPluginCrypto(t *testing.T, bus *eventbustest.Embedded, pool *pgxpool.Poo
 		publisher: eventbus.NewRenderingPublisher(raw, verbReg),
 		actorID:   idgen.New(),
 		sceneID:   idgen.New(),
-	}
-}
-
-// registerSceneEmitVerbs registers core-scenes' plugin-owned scene event types
-// as rendering verbs so the RenderingPublisher resolves them on the plugin emit
-// path. The list mirrors core-scenes' phase4EmitTypes (sensitive IC content) +
-// phase6EmitTypes (publication notices); the harness can't import the
-// `package main` plugin, so the set is duplicated here. RegisterWithSource is
-// idempotent-safe for fresh per-test registries.
-func registerSceneEmitVerbs(t *testing.T, verbReg *core.VerbRegistry) {
-	t.Helper()
-	sceneEmitTypes := []string{
-		"scene_pose", "scene_say", "scene_emit", "scene_ooc",
-		"scene_join_ic", "scene_leave_ic", "scene_pose_order_changed_ic", "scene_idle_nudge",
-		"scene_publish_started", "scene_publish_vote_cast", "scene_publish_cooloff_started",
-		"scene_publish_resolved", "scene_publish_withdrawn", "scene_publish_vote_attempts_extended",
-	}
-	for _, et := range sceneEmitTypes {
-		require.NoErrorf(t, verbReg.RegisterWithSource(core.VerbRegistration{
-			Type:          et,
-			Category:      "communication",
-			Format:        "speech",
-			Label:         et,
-			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
-			Source:        "core-scenes",
-		}, "1.0.0"), "registerSceneEmitVerbs: register %q", et)
 	}
 }
 
@@ -240,9 +212,18 @@ func (s *Server) emitPluginEventForScene(ctx context.Context, plugin, sceneSubje
 	// stable per emit.
 	ctx = core.WithActor(ctx, core.Actor{Kind: core.ActorCharacter, ID: actorID.String()})
 
+	// Mirror the real plugin: emit the plugin-qualified wire type (<plugin>:<verb>)
+	// so it resolves against the manifest-sourced verb registry instead of the
+	// removed seeding (holomush-r0kup). The guard keeps it idempotent if a caller
+	// already passes a qualified type.
+	wireType := eventType
+	if !strings.Contains(wireType, ":") {
+		wireType = plugin + ":" + eventType
+	}
+
 	err := s.pluginSub.Manager().EmitPluginEvent(ctx, plugin, pluginsdk.EmitEvent{
 		Stream:    natsSubject, // already a dot-style events.<gid>.scene.<id>.ic subject; passed through unchanged
-		Type:      pluginsdk.EventType(eventType),
+		Type:      pluginsdk.EventType(wireType),
 		Payload:   payloadJSON,
 		Sensitive: sensitive,
 	})

--- a/plugins/core-scenes/audit.go
+++ b/plugins/core-scenes/audit.go
@@ -396,7 +396,7 @@ func (s *SceneAuditServer) AuditEvent(ctx context.Context, req *pluginv1.AuditEv
 	// scenes.total_pose_count UPDATE + scene_participants metadata UPDATE
 	// transactionally per T7/INV-SCENE-10); all other event types route
 	// through plain Insert (existing behaviour).
-	if eventType == "scene_pose" {
+	if eventType == "core-scenes:scene_pose" {
 		// scene_pose MUST come from a character actor carrying a full
 		// 16-byte ULID. Earlier code copied actorID into a fixed array
 		// with `copy(posedCharULID[:], actorID)`, which silently zero-

--- a/plugins/core-scenes/audit_integration_test.go
+++ b/plugins/core-scenes/audit_integration_test.go
@@ -61,7 +61,7 @@ var _ = Describe("SceneAuditStore.InsertScenePose", func() {
 			ctx,
 			eventID,
 			"events.main.scene."+sceneID+".ic",
-			"scene_pose",
+			"core-scenes:scene_pose",
 			timestamppb.New(eventTime),
 			"character", []byte("char-isp-owner-actor"),
 			[]byte(`{"pose":"waves"}`), 1, "identity", nil, nil,
@@ -115,7 +115,7 @@ var _ = Describe("SceneAuditStore.InsertScenePose", func() {
 		err := audit.InsertScenePose(
 			ctx,
 			eventID,
-			"events.main.scene.nonexistent-scene.ic", "scene_pose",
+			"events.main.scene.nonexistent-scene.ic", "core-scenes:scene_pose",
 			timestamppb.Now(),
 			"character", []byte("char-rollback-actor"),
 			[]byte("{}"), 1, "identity", nil, nil,
@@ -155,7 +155,7 @@ var _ = Describe("SceneAuditStore.InsertScenePose", func() {
 		err := audit.InsertScenePose(
 			ctx,
 			eventID,
-			"events.main.scene."+sceneID+".ic", "scene_pose",
+			"events.main.scene."+sceneID+".ic", "core-scenes:scene_pose",
 			timestamppb.Now(),
 			"character", []byte("char-orphan-actor"),
 			[]byte("{}"), 1, "identity", nil, nil,
@@ -256,7 +256,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 		eventID := newPoseULID()
 		subject := "events.main.scene." + sceneID + ".ic"
 
-		req := makeAuditRow(eventID, subject, "scene_pose", timestamppb.New(eventTime), ownerBytes[:])
+		req := makeAuditRow(eventID, subject, "core-scenes:scene_pose", timestamppb.New(eventTime), ownerBytes[:])
 		_, err := srv.AuditEvent(ctx, req)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -312,7 +312,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 		subject := "events.main.scene." + sceneID + ".ic"
 		actorBytes := newPoseULID() // arbitrary 16-byte actor; type is scene_join_ic not scene_pose
 
-		req := makeAuditRow(eventID, subject, "scene_join_ic", timestamppb.Now(), actorBytes)
+		req := makeAuditRow(eventID, subject, "core-scenes:scene_join_ic", timestamppb.Now(), actorBytes)
 		_, err := srv.AuditEvent(ctx, req)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -342,7 +342,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 
 		eventID := newPoseULID()
 		// Subject missing the required scene segment — parseSceneSubject rejects it.
-		req := makeAuditRow(eventID, "events.main.bad", "scene_pose", timestamppb.Now(), newPoseULID())
+		req := makeAuditRow(eventID, "events.main.bad", "core-scenes:scene_pose", timestamppb.Now(), newPoseULID())
 		_, err := srv.AuditEvent(ctx, req)
 		Expect(err).To(HaveOccurred())
 		// parseSceneSubject is the sole oops wrapper on this path; the
@@ -374,7 +374,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 			Row: &pluginv1.AuditRow{
 				Id:        eventID,
 				Subject:   subject,
-				Type:      "scene_pose",
+				Type:      "core-scenes:scene_pose",
 				Timestamp: timestamppb.Now(),
 				Actor: &eventbusv1.Actor{
 					Kind: eventbusv1.ActorKind_ACTOR_KIND_PLUGIN,
@@ -419,7 +419,7 @@ var _ = Describe("SceneAuditServer.AuditEvent dispatcher", func() {
 		subject := "events.main.scene." + sceneID + ".ic"
 		shortActor := []byte{0x01, 0x02, 0x03} // not 16 bytes
 
-		req := makeAuditRow(eventID, subject, "scene_pose", timestamppb.Now(), shortActor)
+		req := makeAuditRow(eventID, subject, "core-scenes:scene_pose", timestamppb.Now(), shortActor)
 		_, err := srv.AuditEvent(ctx, req)
 		Expect(err).To(HaveOccurred())
 		errutil.AssertErrorCode(suiteT, err, "SCENE_AUDIT_INVALID_ACTOR_ID")

--- a/plugins/core-scenes/commands.go
+++ b/plugins/core-scenes/commands.go
@@ -78,9 +78,9 @@ const sceneLogReplayLimit = 50
 // these three are replayed by "scene log"; joins, ops, OOC, and publish-
 // lifecycle notices are skipped.
 var replayEventKinds = map[string]EntryKind{
-	"scene_pose": EntryKindPose,
-	"scene_say":  EntryKindSay,
-	"scene_emit": EntryKindEmit,
+	"core-scenes:scene_pose": EntryKindPose,
+	"core-scenes:scene_say":  EntryKindSay,
+	"core-scenes:scene_emit": EntryKindEmit,
 }
 
 // decodeReplayEntries converts QueryStreamHistory events (oldest→newest) into
@@ -516,13 +516,13 @@ func (p *scenePlugin) dispatchCommand(ctx context.Context, req pluginsdk.Command
 		}
 		return p.handleSceneGrid(ctx, req)
 	case "pose":
-		return p.handleEmit(ctx, req, rest, "scene_pose", false)
+		return p.handleEmit(ctx, req, rest, "core-scenes:scene_pose", false)
 	case "say":
-		return p.handleEmit(ctx, req, rest, "scene_say", false)
+		return p.handleEmit(ctx, req, rest, "core-scenes:scene_say", false)
 	case "emit":
-		return p.handleEmit(ctx, req, rest, "scene_emit", false)
+		return p.handleEmit(ctx, req, rest, "core-scenes:scene_emit", false)
 	case "ooc":
-		return p.handleEmit(ctx, req, rest, "scene_ooc", true)
+		return p.handleEmit(ctx, req, rest, "core-scenes:scene_ooc", true)
 	case "order":
 		return p.handleOrder(ctx, req, rest)
 	case "publish":
@@ -1227,7 +1227,7 @@ func (p *scenePlugin) handleEmit(
 	eventType string,
 	ooc bool,
 ) (*pluginsdk.CommandResponse, error) {
-	verb := strings.TrimPrefix(eventType, "scene_")
+	verb := strings.TrimPrefix(eventType, "core-scenes:scene_")
 	ctx, span := startSpan(
 		ctx, "scene.command.emit",
 		attribute.String("subject_id", req.CharacterID),

--- a/plugins/core-scenes/commands_emit_test.go
+++ b/plugins/core-scenes/commands_emit_test.go
@@ -48,7 +48,7 @@ func TestSceneSubcommand_Pose_EmitsSceneEventOnICFacet(t *testing.T) {
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "You pose: smiles at the room")
 
-	found := findIntentByType(sink.intents, "scene_pose")
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose")
 	require.NotNil(t, found, "scene pose MUST emit scene_pose")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-pose-test"), found.Subject)
 	assert.True(t, found.Sensitive, "scene_pose MUST be Sensitive=true (sensitivity:always)")
@@ -70,7 +70,7 @@ func TestSceneSubcommand_Say_EmitsSceneEventOnICFacet(t *testing.T) {
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "You say: hello everyone")
 
-	found := findIntentByType(sink.intents, "scene_say")
+	found := findIntentByType(sink.intents, "core-scenes:scene_say")
 	require.NotNil(t, found, "scene say MUST emit scene_say")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-say-test"), found.Subject)
 	assert.True(t, found.Sensitive, "scene_say MUST be Sensitive=true (sensitivity:always)")
@@ -90,7 +90,7 @@ func TestSceneSubcommand_Emit_EmitsSceneEventOnICFacet(t *testing.T) {
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "You emit: A bell rings in the distance.")
 
-	found := findIntentByType(sink.intents, "scene_emit")
+	found := findIntentByType(sink.intents, "core-scenes:scene_emit")
 	require.NotNil(t, found, "scene emit MUST emit scene_emit")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-emit-test"), found.Subject)
 	assert.True(t, found.Sensitive, "scene_emit MUST be Sensitive=true (sensitivity:always)")
@@ -110,7 +110,7 @@ func TestSceneSubcommand_OOC_EmitsSceneEventOnOOCFacet(t *testing.T) {
 	assert.Equal(t, pluginsdk.CommandOK, resp.Status)
 	assert.Contains(t, resp.Output, "You ooc: brb getting coffee")
 
-	found := findIntentByType(sink.intents, "scene_ooc")
+	found := findIntentByType(sink.intents, "core-scenes:scene_ooc")
 	require.NotNil(t, found, "scene ooc MUST emit scene_ooc")
 	assert.Equal(t, dotStyleSceneSubjectOOC("main", "scene-ooc-test"), found.Subject,
 		"scene_ooc MUST land on the .ooc facet, not .ic")

--- a/plugins/core-scenes/commands_log_test.go
+++ b/plugins/core-scenes/commands_log_test.go
@@ -32,10 +32,10 @@ func newSceneLogFixture(t *testing.T, events ...pluginsdk.Event) (p *scenePlugin
 func TestDecodeReplayEntries(t *testing.T) {
 	t.Parallel()
 	events := []pluginsdk.Event{
-		{ID: "1", Type: pluginsdk.EventType("scene_pose"), Payload: `{"actor_id":"Alice","text":"smiles warmly."}`},
-		{ID: "2", Type: pluginsdk.EventType("scene_join_ic"), Payload: `{"actor_id":"Bob"}`}, // non-content → skipped
-		{ID: "3", Type: pluginsdk.EventType("scene_say"), Payload: `{"actor_id":"Bob","text":"Hello."}`},
-		{ID: "4", Type: pluginsdk.EventType("scene_emit"), Payload: `{"actor_id":"Cara","text":"A bell rings."}`},
+		{ID: "1", Type: pluginsdk.EventType("core-scenes:scene_pose"), Payload: `{"actor_id":"Alice","text":"smiles warmly."}`},
+		{ID: "2", Type: pluginsdk.EventType("core-scenes:scene_join_ic"), Payload: `{"actor_id":"Bob"}`}, // non-content → skipped
+		{ID: "3", Type: pluginsdk.EventType("core-scenes:scene_say"), Payload: `{"actor_id":"Bob","text":"Hello."}`},
+		{ID: "4", Type: pluginsdk.EventType("core-scenes:scene_emit"), Payload: `{"actor_id":"Cara","text":"A bell rings."}`},
 	}
 
 	entries, err := decodeReplayEntries(events)
@@ -52,7 +52,7 @@ func TestDecodeReplayEntries(t *testing.T) {
 func TestDecodeReplayEntriesRejectsMalformedPayload(t *testing.T) {
 	t.Parallel()
 	_, err := decodeReplayEntries([]pluginsdk.Event{
-		{ID: "x", Type: pluginsdk.EventType("scene_say"), Payload: `{not json}`},
+		{ID: "x", Type: pluginsdk.EventType("core-scenes:scene_say"), Payload: `{not json}`},
 	})
 	require.Error(t, err)
 }
@@ -81,8 +81,8 @@ func TestHandleLogRendersForParticipant(t *testing.T) {
 	store.installRoster("scene-x", "owner-char")
 	svc := newTestService(t, store)
 	fc := &fakeFocusClient{queryHistoryEvents: []pluginsdk.Event{
-		{ID: "1", Type: pluginsdk.EventType("scene_say"), Payload: `{"actor_id":"owner-char","text":"Hello."}`},
-		{ID: "2", Type: pluginsdk.EventType("scene_pose"), Payload: `{"actor_id":"owner-char","text":"waves."}`},
+		{ID: "1", Type: pluginsdk.EventType("core-scenes:scene_say"), Payload: `{"actor_id":"owner-char","text":"Hello."}`},
+		{ID: "2", Type: pluginsdk.EventType("core-scenes:scene_pose"), Payload: `{"actor_id":"owner-char","text":"waves."}`},
 	}}
 	p := &scenePlugin{service: svc, focusClient: fc}
 
@@ -99,7 +99,7 @@ func TestHandleLogRendersForParticipant(t *testing.T) {
 func TestHandleLogExportMarkdown(t *testing.T) {
 	t.Parallel()
 	p, sceneID, caller := newSceneLogFixture(t,
-		pluginsdk.Event{ID: "1", Type: pluginsdk.EventType("scene_say"), Payload: `{"actor_id":"Alice","text":"Hi."}`})
+		pluginsdk.Event{ID: "1", Type: pluginsdk.EventType("core-scenes:scene_say"), Payload: `{"actor_id":"Alice","text":"Hi."}`})
 
 	resp, err := p.handleLog(context.Background(),
 		pluginsdk.CommandRequest{CharacterID: caller}, "export markdown #"+sceneID)
@@ -113,7 +113,7 @@ func TestHandleLogExportMarkdown(t *testing.T) {
 func TestHandleLogExportJSONL(t *testing.T) {
 	t.Parallel()
 	p, sceneID, caller := newSceneLogFixture(t,
-		pluginsdk.Event{ID: "1", Type: pluginsdk.EventType("scene_say"), Payload: `{"actor_id":"Alice","text":"Hi."}`})
+		pluginsdk.Event{ID: "1", Type: pluginsdk.EventType("core-scenes:scene_say"), Payload: `{"actor_id":"Alice","text":"Hi."}`})
 
 	resp, err := p.handleLog(context.Background(),
 		pluginsdk.CommandRequest{CharacterID: caller}, "export jsonl #"+sceneID)

--- a/plugins/core-scenes/manifest_verbs_test.go
+++ b/plugins/core-scenes/manifest_verbs_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType pins
+// holomush-r0kup: every emitted scene wire type MUST have a qualified
+// verbs[].type entry, or the production RenderingPublisher hard-fails
+// EMIT_UNKNOWN_VERB. Before the fix core-scenes shipped no verbs: block at all.
+func TestCoreScenesManifestDeclaresQualifiedVerbsForEveryEmitType(t *testing.T) {
+	data, err := os.ReadFile("plugin.yaml")
+	require.NoError(t, err)
+
+	var m struct {
+		Verbs []struct {
+			Type string `yaml:"type"`
+		} `yaml:"verbs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &m))
+
+	got := make(map[string]bool, len(m.Verbs))
+	for _, v := range m.Verbs {
+		got[v.Type] = true
+	}
+
+	want := []string{
+		"core-scenes:scene_pose", "core-scenes:scene_say", "core-scenes:scene_emit",
+		"core-scenes:scene_ooc", "core-scenes:scene_join_ic", "core-scenes:scene_leave_ic",
+		"core-scenes:scene_pose_order_changed_ic", "core-scenes:scene_idle_nudge",
+		"core-scenes:scene_publish_started", "core-scenes:scene_publish_vote_cast",
+		"core-scenes:scene_publish_cooloff_started", "core-scenes:scene_publish_resolved",
+		"core-scenes:scene_publish_withdrawn", "core-scenes:scene_publish_vote_attempts_extended",
+	}
+	for _, w := range want {
+		require.Truef(t, got[w], "missing qualified verb entry %q", w)
+	}
+}

--- a/plugins/core-scenes/plugin.yaml
+++ b/plugins/core-scenes/plugin.yaml
@@ -62,6 +62,70 @@ actions:
 
 storage: postgres
 
+verbs:
+  # IC content types (sensitivity: always per crypto.emits)
+  - type: core-scenes:scene_pose
+    category: communication
+    format: action
+    display_target: terminal
+  - type: core-scenes:scene_say
+    category: communication
+    format: speech
+    label: says
+    display_target: terminal
+  - type: core-scenes:scene_emit
+    category: communication
+    format: action
+    display_target: terminal
+  - type: core-scenes:scene_ooc
+    category: communication
+    format: action
+    display_target: terminal
+
+  # Notice types (sensitivity: never per crypto.emits)
+  - type: core-scenes:scene_join_ic
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_leave_ic
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_pose_order_changed_ic
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_idle_nudge
+    category: system
+    format: notification
+    display_target: terminal
+
+  # Publication notice types (sensitivity: never per crypto.emits)
+  - type: core-scenes:scene_publish_started
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_vote_cast
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_cooloff_started
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_resolved
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_withdrawn
+    category: system
+    format: notification
+    display_target: terminal
+  - type: core-scenes:scene_publish_vote_attempts_extended
+    category: system
+    format: notification
+    display_target: terminal
+
 crypto:
   emits:
     # Content events (sensitivity: always) — participant-only IC/OOC RP

--- a/plugins/core-scenes/poseorder_integration_test.go
+++ b/plugins/core-scenes/poseorder_integration_test.go
@@ -77,7 +77,7 @@ func rebuildMetadataFromSceneLog(ctx context.Context, pool *pgxpool.Pool, sceneI
 		SELECT actor_id, timestamp
 		FROM scene_log
 		WHERE subject LIKE 'events.%.scene.' || $1 || '.ic'
-		  AND type = 'scene_pose'
+		  AND type = 'core-scenes:scene_pose'
 		ORDER BY id ASC
 	`, sceneID)
 	Expect(err).NotTo(HaveOccurred())
@@ -198,7 +198,7 @@ var _ = Describe("INV-SCENE-8: pose-order metadata is a function of scene_log", 
 			Expect(audit.InsertScenePose(
 				ctx,
 				eventID,
-				subject, "scene_pose",
+				subject, "core-scenes:scene_pose",
 				timestamppb.New(poseTs[i]),
 				"character", p.bytes,
 				[]byte(`{}`), 1, "identity", nil, nil,

--- a/plugins/core-scenes/publish_event_emission_integration_test.go
+++ b/plugins/core-scenes/publish_event_emission_integration_test.go
@@ -224,8 +224,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		// Wait for the scene_publish_started row to appear in scene_log.
 		// Payload fields: AttemptId, AttemptNumber, InitiatedBy,
 		//   VoteWindowSeconds, CooloffWindowSeconds, RosterCharacterIds.
-		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_started", 1)
-		startRow := findAuditRowByType(rows, "scene_publish_started")
+		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_started", 1)
+		startRow := findAuditRowByType(rows, "core-scenes:scene_publish_started")
 		Expect(startRow).NotTo(BeNil(), "D4/started: scene_log must have a scene_publish_started row")
 
 		var startedEv scenev1.ScenePublishStartedEvent
@@ -259,8 +259,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(err).NotTo(HaveOccurred(), "CastPublishSceneVote (alice, yes) must succeed")
 
 		// Wait for the first vote_cast row. IsChange=false for a first cast.
-		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_vote_cast", 1)
-		voteCastRows := findAllAuditRowsByType(rows, "scene_publish_vote_cast")
+		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_vote_cast", 1)
+		voteCastRows := findAllAuditRowsByType(rows, "core-scenes:scene_publish_vote_cast")
 
 		// Find the first alice-yes row (IsChange=false).
 		var firstAliceYes *scenev1.ScenePublishVoteCastEvent
@@ -288,8 +288,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(err).NotTo(HaveOccurred(), "CastPublishSceneVote (alice, no) must succeed")
 
 		// Wait for a second vote_cast row where alice changes to no.
-		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_vote_cast", 2)
-		voteCastRows = findAllAuditRowsByType(rows, "scene_publish_vote_cast")
+		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_vote_cast", 2)
+		voteCastRows = findAllAuditRowsByType(rows, "core-scenes:scene_publish_vote_cast")
 
 		var aliceChangeToNo *scenev1.ScenePublishVoteCastEvent
 		for _, r := range voteCastRows {
@@ -328,8 +328,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 
 		// Wait for the bob-yes vote_cast row AND the cooloff_started row.
 		// Bob's vote is his first, so IsChange=false.
-		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_vote_cast", 4)
-		voteCastRows = findAllAuditRowsByType(rows, "scene_publish_vote_cast")
+		rows = pollAtLeastAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_vote_cast", 4)
+		voteCastRows = findAllAuditRowsByType(rows, "core-scenes:scene_publish_vote_cast")
 		var bobFirstYes *scenev1.ScenePublishVoteCastEvent
 		for _, r := range voteCastRows {
 			var ev scenev1.ScenePublishVoteCastEvent
@@ -344,8 +344,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(bobFirstYes.GetAttemptId()).To(Equal(attemptID))
 
 		// Now wait for scene_publish_cooloff_started.
-		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_cooloff_started", 1)
-		cooloffRow := findAuditRowByType(rows, "scene_publish_cooloff_started")
+		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_cooloff_started", 1)
+		cooloffRow := findAuditRowByType(rows, "core-scenes:scene_publish_cooloff_started")
 		Expect(cooloffRow).NotTo(BeNil(), "D4/cooloff_started: scene_log must have a scene_publish_cooloff_started row")
 
 		var cooloffEv scenev1.ScenePublishCoolOffStartedEvent
@@ -360,8 +360,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		// The scheduler sweeps every ~20ms with a ~1ms cooloff_window. Poll for
 		// the scene_publish_resolved row to appear in scene_log (async after
 		// the scheduler fires applyTrigger → emitResolved).
-		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_resolved", 1)
-		resolvedRow := findAuditRowByType(rows, "scene_publish_resolved")
+		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_resolved", 1)
+		resolvedRow := findAuditRowByType(rows, "core-scenes:scene_publish_resolved")
 		Expect(resolvedRow).NotTo(BeNil(), "D4/resolved: scene_log must have a scene_publish_resolved row")
 
 		var resolvedEv scenev1.ScenePublishResolvedEvent
@@ -405,7 +405,7 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(attemptID).NotTo(BeEmpty())
 
 		// Wait for the started row so we know the attempt is live.
-		pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_started", 1)
+		pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_started", 1)
 
 		// ── scene_publish_withdrawn ──────────────────────────────────────────
 		// WithdrawScenePublish emits scene_publish_withdrawn synchronously
@@ -418,8 +418,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(err).NotTo(HaveOccurred(), "WithdrawScenePublish must succeed")
 
 		// Wait for the scene_publish_withdrawn row.
-		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_withdrawn", 1)
-		withdrawnRow := findAuditRowByType(rows, "scene_publish_withdrawn")
+		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_withdrawn", 1)
+		withdrawnRow := findAuditRowByType(rows, "core-scenes:scene_publish_withdrawn")
 		Expect(withdrawnRow).NotTo(BeNil(), "D4/withdrawn: scene_log must have a scene_publish_withdrawn row")
 
 		var withdrawnEv scenev1.ScenePublishWithdrawnEvent
@@ -432,8 +432,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 
 		// WithdrawScenePublish also fires applyTrigger which emits
 		// scene_publish_resolved (outcome=ATTEMPT_FAILED, reason=WITHDRAWN).
-		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_resolved", 1)
-		resolvedRow := findAuditRowByType(rows, "scene_publish_resolved")
+		rows = pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_resolved", 1)
+		resolvedRow := findAuditRowByType(rows, "core-scenes:scene_publish_resolved")
 		Expect(resolvedRow).NotTo(BeNil(), "D4/withdrawn: scene_log must also have a scene_publish_resolved row")
 
 		var resolvedEv scenev1.ScenePublishResolvedEvent
@@ -468,7 +468,7 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		Expect(startResp.GetPublishedSceneId()).NotTo(BeEmpty())
 
 		// Wait for started row so the scene row exists in published_scenes.
-		pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_started", 1)
+		pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_started", 1)
 
 		// ── scene_publish_vote_attempts_extended ──────────────────────────────
 		// ExtendScenePublishVoteAttempts emits scene_publish_vote_attempts_extended
@@ -486,8 +486,8 @@ var _ = Describe("D4: Phase-6 publish lifecycle events", func() {
 		expectedNewMax := extResp.GetNewMax() // use the RPC-returned value as ground truth for the event assertion
 
 		// Wait for the scene_publish_vote_attempts_extended row.
-		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "scene_publish_vote_attempts_extended", 1)
-		extRow := findAuditRowByType(rows, "scene_publish_vote_attempts_extended")
+		rows := pollAuditRows(ctx, ts, "core-scenes", sceneICSubject, "core-scenes:scene_publish_vote_attempts_extended", 1)
+		extRow := findAuditRowByType(rows, "core-scenes:scene_publish_vote_attempts_extended")
 		Expect(extRow).NotTo(BeNil(), "D4/extended: scene_log must have a scene_publish_vote_attempts_extended row")
 
 		var extEv scenev1.ScenePublishVoteAttemptsExtendedEvent

--- a/plugins/core-scenes/publish_events.go
+++ b/plugins/core-scenes/publish_events.go
@@ -56,7 +56,7 @@ func (e *publishEventEmitter) emitPublishStarted(ctx context.Context, pub *Publi
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, pub.SceneID),
-		Type:      pluginsdk.EventType("scene_publish_started"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_started"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})
@@ -82,7 +82,7 @@ func (e *publishEventEmitter) emitVoteCast(ctx context.Context, attemptID, chara
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, pub.SceneID),
-		Type:      pluginsdk.EventType("scene_publish_vote_cast"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_vote_cast"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})
@@ -113,7 +113,7 @@ func (e *publishEventEmitter) emitCoolOffStarted(ctx context.Context, attemptID 
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, pub.SceneID),
-		Type:      pluginsdk.EventType("scene_publish_cooloff_started"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_cooloff_started"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})
@@ -151,7 +151,7 @@ func (e *publishEventEmitter) emitResolved(ctx context.Context, attemptID string
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, pub.SceneID),
-		Type:      pluginsdk.EventType("scene_publish_resolved"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_resolved"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})
@@ -175,7 +175,7 @@ func (e *publishEventEmitter) emitWithdrawn(ctx context.Context, attemptID, with
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, pub.SceneID),
-		Type:      pluginsdk.EventType("scene_publish_withdrawn"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_withdrawn"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})
@@ -193,7 +193,7 @@ func (e *publishEventEmitter) emitAttemptsExtended(ctx context.Context, sceneID,
 	}
 	return e.sink.Emit(ctx, pluginsdk.EmitIntent{ //nolint:wrapcheck // EventSink error passes through as-is; caller decides logging
 		Subject:   dotStyleSceneSubjectIC(e.gameID, sceneID),
-		Type:      pluginsdk.EventType("scene_publish_vote_attempts_extended"),
+		Type:      pluginsdk.EventType("core-scenes:scene_publish_vote_attempts_extended"),
 		Payload:   string(payload),
 		Sensitive: false,
 	})

--- a/plugins/core-scenes/publish_events_test.go
+++ b/plugins/core-scenes/publish_events_test.go
@@ -45,7 +45,7 @@ func TestEmitPublishStartedSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-1"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_started"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_started"), intent.Type)
 	assert.False(t, intent.Sensitive, "scene_publish_started is sensitivity:never")
 
 	var ev scenev1.ScenePublishStartedEvent
@@ -76,7 +76,7 @@ func TestEmitPublishVoteCastSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-2"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_vote_cast"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_vote_cast"), intent.Type)
 	assert.False(t, intent.Sensitive)
 
 	var ev scenev1.ScenePublishVoteCastEvent
@@ -107,7 +107,7 @@ func TestEmitPublishCoolOffStartedSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-3"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_cooloff_started"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_cooloff_started"), intent.Type)
 	assert.False(t, intent.Sensitive)
 
 	var ev scenev1.ScenePublishCoolOffStartedEvent
@@ -136,7 +136,7 @@ func TestEmitPublishResolvedSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-4"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_resolved"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_resolved"), intent.Type)
 	assert.False(t, intent.Sensitive)
 
 	var ev scenev1.ScenePublishResolvedEvent
@@ -166,7 +166,7 @@ func TestEmitPublishWithdrawnSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-5"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_withdrawn"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_withdrawn"), intent.Type)
 	assert.False(t, intent.Sensitive)
 
 	var ev scenev1.ScenePublishWithdrawnEvent
@@ -191,7 +191,7 @@ func TestEmitPublishAttemptsExtendedSetsSubjectTypeAndPayload(t *testing.T) {
 	intent := sink.intents[0]
 
 	assert.Equal(t, dotStyleSceneSubjectIC("test-game", "scene-6"), intent.Subject)
-	assert.Equal(t, pluginsdk.EventType("scene_publish_vote_attempts_extended"), intent.Type)
+	assert.Equal(t, pluginsdk.EventType("core-scenes:scene_publish_vote_attempts_extended"), intent.Type)
 	assert.False(t, intent.Sensitive)
 
 	var ev scenev1.ScenePublishVoteAttemptsExtendedEvent

--- a/plugins/core-scenes/publish_scheduler_integration_test.go
+++ b/plugins/core-scenes/publish_scheduler_integration_test.go
@@ -217,7 +217,7 @@ var _ = Describe("E5 publishScheduler", func() {
 
 		// Seed a real encrypted pose under the PRODUCTION .ic subject.
 		// emitAndSeedIC inserts into scene_log with subject=dotStyleSceneSubjectIC(gameID, sceneID).
-		emitAndSeedIC(ctx, env, sceneID, "scene_pose",
+		emitAndSeedIC(ctx, env, sceneID, "core-scenes:scene_pose",
 			`{"actor_id":"`+ownerID+`","text":"`+text+`"}`,
 			[]dek.Participant{{
 				PlayerID:    "01E5SCHED_COOLOFFPLAYER0A",

--- a/plugins/core-scenes/publish_snapshot.go
+++ b/plugins/core-scenes/publish_snapshot.go
@@ -30,9 +30,9 @@ const snapshotDecryptBatch = 500
 // PublishedSceneEntry kind. scene_ooc and all notice/ops events are excluded by
 // ReadSceneLogForSnapshot's type filter, so any other type here is unreachable.
 var snapshotEventKinds = map[string]EntryKind{
-	"scene_pose": EntryKindPose,
-	"scene_say":  EntryKindSay,
-	"scene_emit": EntryKindEmit,
+	"core-scenes:scene_pose": EntryKindPose,
+	"core-scenes:scene_say":  EntryKindSay,
+	"core-scenes:scene_emit": EntryKindEmit,
 }
 
 // snapshotDecryptor is the narrow host-mediated read-back decrypt seam the

--- a/plugins/core-scenes/publish_snapshot_integration_test.go
+++ b/plugins/core-scenes/publish_snapshot_integration_test.go
@@ -230,14 +230,15 @@ func buildSnapshotRealEnv(ctx context.Context, pluginName string) *snapshotRealE
 	hostSub := audit.NewSubsystem(snapFixedJS{js: bus.JS}, snapFixedPool{pool: cryptoPool}, audit.Config{})
 	Expect(hostSub.Start(ctx)).To(Succeed())
 
-	// Production scene IC events are emitted with BARE types (scene_pose /
-	// scene_say / scene_emit — commands.go:516-520), so the AAD binds the bare
-	// type and scene_log stores it bare. The fixture mirrors that exactly:
-	// verb registry, manifest, alwaysSensitive, and the manifest lookup all key
-	// on bare types, and the emit uses the bare type.
+	// Production scene IC events are emitted with QUALIFIED wire types
+	// (core-scenes:scene_pose / :scene_say / :scene_emit — commands.go:516-520,
+	// holomush-r0kup), so the AAD binds the qualified type and scene_log stores
+	// it qualified. The fixture mirrors that exactly: verb registry, manifest,
+	// alwaysSensitive, and the manifest lookup all key on the qualified types,
+	// and the emit uses the qualified type.
 	registry, err := core.BootstrapVerbRegistry("test")
 	Expect(err).NotTo(HaveOccurred())
-	for _, et := range []string{"scene_pose", "scene_say", "scene_emit"} {
+	for _, et := range []string{"core-scenes:scene_pose", "core-scenes:scene_say", "core-scenes:scene_emit"} {
 		Expect(registry.RegisterWithSource(core.VerbRegistration{
 			Type:          et,
 			Category:      "communication",
@@ -254,9 +255,9 @@ func buildSnapshotRealEnv(ctx context.Context, pluginName string) *snapshotRealE
 	manifestLookup := &snapManifestLookup{
 		pluginName: pluginName,
 		eventTypes: map[string]struct{}{
-			"scene_pose": {},
-			"scene_say":  {},
-			"scene_emit": {},
+			"core-scenes:scene_pose": {},
+			"core-scenes:scene_say":  {},
+			"core-scenes:scene_emit": {},
 		},
 	}
 	guardCore, err := authguard.New(
@@ -284,9 +285,9 @@ func buildSnapshotRealEnv(ctx context.Context, pluginName string) *snapshotRealE
 	})
 	Expect(err).NotTo(HaveOccurred())
 	alwaysSensitive := map[string]struct{}{
-		"scene_pose": {},
-		"scene_say":  {},
-		"scene_emit": {},
+		"core-scenes:scene_pose": {},
+		"core-scenes:scene_say":  {},
+		"core-scenes:scene_emit": {},
 	}
 
 	decryptor := history.NewReadbackDecryptor(
@@ -473,7 +474,7 @@ func seedScenePoseLog(ctx context.Context, store *SceneStore, sceneID, actorID, 
 	_, err = store.Pool().Exec(
 		ctx, `
 		INSERT INTO scene_log (id, subject, type, timestamp, actor_kind, actor_id, payload, schema_ver, codec)
-		VALUES ($1, $2, 'scene_pose', $3, 'character', $4, $5, 1, 'identity')`,
+		VALUES ($1, $2, 'core-scenes:scene_pose', $3, 'character', $4, $5, 1, 'identity')`,
 		id, subject, time.Now().UnixNano(), []byte(actorID), payload,
 	)
 	Expect(err).NotTo(HaveOccurred())
@@ -524,7 +525,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 
 		// Seed a real encrypted pose into scene_log; use the EXACT subject it
 		// was stored under (the AAD binds it).
-		seededSubject := env.emitAndSeed(ctx, sceneID, "scene_pose", `{"actor_id":"`+ownerID+`","text":"`+text+`"}`,
+		seededSubject := env.emitAndSeed(ctx, sceneID, "core-scenes:scene_pose", `{"actor_id":"`+ownerID+`","text":"`+text+`"}`,
 			[]dek.Participant{{
 				PlayerID: "01C7SNAPHAPPYPLAYER00000A", CharacterID: ownerID,
 				BindingID: "01C7SNAPHAPPYBIND00000A", JoinedAt: time.Now().UTC(), AddedVia: "c7_test",
@@ -603,7 +604,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 		const sceneID = "01C7SNAPRENDER0000000000A"
 		const ownerID = "01C7SNAPRENDEROWNER00000A"
 		dec := &fakeSnapshotDecryptor{plaintextFor: map[string][]byte{
-			"scene_pose": []byte("this is not json"),
+			"core-scenes:scene_pose": []byte("this is not json"),
 		}}
 		store, svc := newSnapshotPlainEnv(dec)
 
@@ -625,7 +626,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 		const sceneID = "01C7SNAPIDEMPOTENT00000A0"
 		const ownerID = "01C7SNAPIDEMPOTENTOWN000A"
 		dec := &fakeSnapshotDecryptor{plaintextFor: map[string][]byte{
-			"scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"once"}`),
+			"core-scenes:scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"once"}`),
 		}}
 		store, svc := newSnapshotPlainEnv(dec)
 
@@ -652,7 +653,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 		const sceneID = "01C7SNAPINVARIANT00000A00"
 		const ownerID = "01C7SNAPINVARIANTOWNER0A0"
 		dec := &fakeSnapshotDecryptor{plaintextFor: map[string][]byte{
-			"scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"x"}`),
+			"core-scenes:scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"x"}`),
 		}}
 		store, svc := newSnapshotPlainEnv(dec)
 
@@ -683,7 +684,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 		const sceneID = "01C7SNAPFKGONE00000000A00"
 		const ownerID = "01C7SNAPFKGONEOWNER0000A0"
 		dec := &fakeSnapshotDecryptor{plaintextFor: map[string][]byte{
-			"scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"survives deletion"}`),
+			"core-scenes:scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"survives deletion"}`),
 		}}
 		store, svc := newSnapshotPlainEnv(dec)
 
@@ -716,7 +717,7 @@ var _ = Describe("C7 snapshot pipeline (COOLOFF → PUBLISHED)", func() {
 		const sceneID = "01C7SNAPCHUNK00000000A000"
 		const ownerID = "01C7SNAPCHUNKOWNER0000A00"
 		dec := &fakeSnapshotDecryptor{plaintextFor: map[string][]byte{
-			"scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"chunk"}`),
+			"core-scenes:scene_pose": []byte(`{"actor_id":"` + ownerID + `","text":"chunk"}`),
 		}}
 		store, svc := newSnapshotPlainEnv(dec)
 

--- a/plugins/core-scenes/publish_store.go
+++ b/plugins/core-scenes/publish_store.go
@@ -637,7 +637,7 @@ func (s *SceneStore) ReadSceneLogForSnapshot(ctx context.Context, tx pgx.Tx, sub
 	rows, err := tx.Query(ctx, `
 		SELECT id, type, timestamp, actor_kind, actor_id, payload, schema_ver, codec, dek_ref, dek_version
 		FROM scene_log
-		WHERE subject = $1 AND type IN ('scene_pose', 'scene_say', 'scene_emit')
+		WHERE subject = $1 AND type IN ('core-scenes:scene_pose', 'core-scenes:scene_say', 'core-scenes:scene_emit')
 		ORDER BY id ASC
 	`, subject)
 	if err != nil {

--- a/plugins/core-scenes/service.go
+++ b/plugins/core-scenes/service.go
@@ -798,7 +798,7 @@ func (s *SceneServiceImpl) emitSceneJoinIC(ctx context.Context, sceneID, actorID
 
 	intent := pluginsdk.EmitIntent{
 		Subject:   dotStyleSceneSubjectIC(s.gameID, sceneID),
-		Type:      "scene_join_ic",
+		Type:      "core-scenes:scene_join_ic",
 		Payload:   string(payload),
 		Sensitive: false, // sensitivity:never per crypto.emits manifest
 	}
@@ -839,7 +839,7 @@ func (s *SceneServiceImpl) emitSceneLeaveIC(ctx context.Context, sceneID, actorI
 
 	intent := pluginsdk.EmitIntent{
 		Subject:   dotStyleSceneSubjectIC(s.gameID, sceneID),
-		Type:      "scene_leave_ic",
+		Type:      "core-scenes:scene_leave_ic",
 		Payload:   string(payload),
 		Sensitive: false, // sensitivity:never per crypto.emits manifest
 	}
@@ -876,7 +876,7 @@ func (s *SceneServiceImpl) emitScenePoseOrderChangedIC(ctx context.Context, scen
 
 	intent := pluginsdk.EmitIntent{
 		Subject:   dotStyleSceneSubjectIC(s.gameID, sceneID),
-		Type:      "scene_pose_order_changed_ic",
+		Type:      "core-scenes:scene_pose_order_changed_ic",
 		Payload:   string(payload),
 		Sensitive: false, // sensitivity:never per crypto.emits manifest
 	}

--- a/plugins/core-scenes/service_test.go
+++ b/plugins/core-scenes/service_test.go
@@ -1389,7 +1389,7 @@ func TestJoinScene_EmitsSceneJoinIC_OnInsert(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	found := findIntentByType(sink.intents, "scene_join_ic")
+	found := findIntentByType(sink.intents, "core-scenes:scene_join_ic")
 	require.NotNil(t, found, "JoinScene MUST auto-emit scene_join_ic on OpInserted")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-join-emit"), found.Subject)
 	assert.False(t, found.Sensitive, "scene_join_ic is sensitivity:never")
@@ -1417,7 +1417,7 @@ func TestJoinScene_EmitsSceneJoinIC_OnPromote(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	found := findIntentByType(sink.intents, "scene_join_ic")
+	found := findIntentByType(sink.intents, "core-scenes:scene_join_ic")
 	require.NotNil(t, found, "JoinScene MUST auto-emit scene_join_ic on OpPromoted")
 	assert.Contains(t, found.Payload, `"from_role":"invited"`)
 }
@@ -1444,7 +1444,7 @@ func TestJoinScene_NoEmit_OnNoChange(t *testing.T) {
 
 	joinCount := 0
 	for _, it := range sink.intents {
-		if string(it.Type) == "scene_join_ic" {
+		if string(it.Type) == "core-scenes:scene_join_ic" {
 			joinCount++
 		}
 	}
@@ -1470,7 +1470,7 @@ func TestLeaveScene_EmitsSceneLeaveIC_ReasonLeft(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	found := findIntentByType(sink.intents, "scene_leave_ic")
+	found := findIntentByType(sink.intents, "core-scenes:scene_leave_ic")
 	require.NotNil(t, found, "LeaveScene MUST auto-emit scene_leave_ic")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-leave-emit"), found.Subject)
 	assert.False(t, found.Sensitive, "scene_leave_ic is sensitivity:never")
@@ -1500,7 +1500,7 @@ func TestKickFromScene_EmitsSceneLeaveIC_ReasonKicked(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	found := findIntentByType(sink.intents, "scene_leave_ic")
+	found := findIntentByType(sink.intents, "core-scenes:scene_leave_ic")
 	require.NotNil(t, found, "KickFromScene MUST auto-emit scene_leave_ic")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-kick-emit"), found.Subject)
 	assert.False(t, found.Sensitive, "scene_leave_ic is sensitivity:never")
@@ -1534,7 +1534,7 @@ func TestUpdateScene_EmitsPoseOrderChangedIC_OnModeChange(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	found := findIntentByType(sink.intents, "scene_pose_order_changed_ic")
+	found := findIntentByType(sink.intents, "core-scenes:scene_pose_order_changed_ic")
 	require.NotNil(t, found, "UpdateScene MUST auto-emit scene_pose_order_changed_ic on mode change")
 	assert.Equal(t, dotStyleSceneSubjectIC("main", "scene-mode-change"), found.Subject)
 	assert.False(t, found.Sensitive, "scene_pose_order_changed_ic is sensitivity:never")
@@ -1570,7 +1570,7 @@ func TestUpdateScene_NoEmit_OnNoModeChange(t *testing.T) {
 
 	count := 0
 	for _, it := range sink.intents {
-		if it.Type == "scene_pose_order_changed_ic" {
+		if it.Type == "core-scenes:scene_pose_order_changed_ic" {
 			count++
 		}
 	}
@@ -1603,7 +1603,7 @@ func TestUpdateScene_NoEmit_OnNonModeUpdate(t *testing.T) {
 
 	count := 0
 	for _, it := range sink.intents {
-		if it.Type == "scene_pose_order_changed_ic" {
+		if it.Type == "core-scenes:scene_pose_order_changed_ic" {
 			count++
 		}
 	}

--- a/plugins/core-scenes/store_integration_test.go
+++ b/plugins/core-scenes/store_integration_test.go
@@ -2417,12 +2417,12 @@ var _ = Describe("Publish store — ReadSceneLogForSnapshot", func() {
 				id.Bytes(), subj, eventType, []byte(eventType))
 			Expect(err).NotTo(HaveOccurred())
 		}
-		insertLog(subject, "scene_pose")
-		insertLog(subject, "scene_ooc") // OOC — excluded
-		insertLog(subject, "scene_say")
-		insertLog(subject, "scene_leave_ic") // ops/notice — excluded
-		insertLog(subject, "scene_emit")
-		insertLog("events.main.scene.other.ic", "scene_pose") // different scene — excluded by subject
+		insertLog(subject, "core-scenes:scene_pose")
+		insertLog(subject, "core-scenes:scene_ooc") // OOC — excluded
+		insertLog(subject, "core-scenes:scene_say")
+		insertLog(subject, "core-scenes:scene_leave_ic") // ops/notice — excluded
+		insertLog(subject, "core-scenes:scene_emit")
+		insertLog("events.main.scene.other.ic", "core-scenes:scene_pose") // different scene — excluded by subject
 
 		tx, err := store.pool.Begin(ctx)
 		Expect(err).NotTo(HaveOccurred())
@@ -2431,9 +2431,9 @@ var _ = Describe("Publish store — ReadSceneLogForSnapshot", func() {
 		logs, err := store.ReadSceneLogForSnapshot(ctx, tx, subject)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logs).To(HaveLen(3), "only pose/say/emit for this subject; OOC + ops + other-scene excluded")
-		Expect(logs[0].Type).To(Equal("scene_pose"))
-		Expect(logs[1].Type).To(Equal("scene_say"))
-		Expect(logs[2].Type).To(Equal("scene_emit"), "chronological order preserved via ULID id ASC")
+		Expect(logs[0].Type).To(Equal("core-scenes:scene_pose"))
+		Expect(logs[1].Type).To(Equal("core-scenes:scene_say"))
+		Expect(logs[2].Type).To(Equal("core-scenes:scene_emit"), "chronological order preserved via ULID id ASC")
 		Expect(logs[0].Codec).To(Equal("identity"))
 		Expect(logs[0].DEKRef).To(BeNil(), "identity-codec rows have NULL dek_ref")
 	})

--- a/test/integration/scenes/lua_focus_parity_test.go
+++ b/test/integration/scenes/lua_focus_parity_test.go
@@ -113,12 +113,12 @@ var _ = Describe("INV-SCENE-40: Lua-runtime auto_focus_on_join parity — live I
 		// Lua hostfunc or coordinator wiring) this would time out because no
 		// subscription was ever added. Post-fix the frame arrives once the
 		// Lua auto_focus_on_join call succeeds and registers the subscription.
-		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		frame := joiner.WaitForEvent(ctx, "core-scenes:scene_pose")
 		Expect(frame).NotTo(BeNil(),
 			"INV-SCENE-40: post-join pose MUST be delivered via the Lua-runtime "+
 				"auto_focus_on_join path — the scene IC subscription must be "+
 				"wired into the joiner's live Subscribe filter set")
-		Expect(frame.GetType()).To(Equal("scene_pose"))
+		Expect(frame.GetType()).To(Equal("core-scenes:scene_pose"))
 		// The joiner is a non-DEK-participant, so the delivered frame MUST be
 		// metadata-only (no plaintext payload). Mirrors the binary assertion in
 		// scene_command_join_delivery_test.go: fail-closed, no plaintext leak.

--- a/test/integration/scenes/real_scene_join_subscription_test.go
+++ b/test/integration/scenes/real_scene_join_subscription_test.go
@@ -101,12 +101,12 @@ var _ = Describe("INV-SCENE-48: bare-ULID scene join opens a live subscription",
 		// Subscribe stream receives a scene_pose frame. Pre-fix this always
 		// timed out because the subscription was never registered. Post-fix
 		// the frame arrives once AutoFocusOnJoin succeeds.
-		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		frame := joiner.WaitForEvent(ctx, "core-scenes:scene_pose")
 		Expect(frame).NotTo(BeNil(),
 			"INV-SCENE-48: post-join pose MUST be delivered — pre-fix: "+
 				"protoToFocusKey could not parse the prefixed join key, "+
 				"so AutoFocusOnJoin never registered the subscription")
-		Expect(frame.GetType()).To(Equal("scene_pose"))
+		Expect(frame.GetType()).To(Equal("core-scenes:scene_pose"))
 		// The joiner is not a DEK participant, so the frame MUST be
 		// metadata-only — no plaintext payload leak (fail-closed).
 		Expect(frame.GetMetadataOnly()).To(BeTrue(),

--- a/test/integration/scenes/scene_command_join_delivery_test.go
+++ b/test/integration/scenes/scene_command_join_delivery_test.go
@@ -99,11 +99,11 @@ var _ = Describe("holomush-y5inx.9: real scene join command delivers post-join I
 		// stream receives a scene_pose frame. Pre-fix this times out (no
 		// subscription was ever added). A frame whose Type == "scene_pose"
 		// proves the scene IC stream reached the live loop.
-		frame := joiner.WaitForEvent(ctx, "scene_pose")
+		frame := joiner.WaitForEvent(ctx, "core-scenes:scene_pose")
 		Expect(frame).NotTo(BeNil(),
 			"holomush-y5inx.9: the post-join pose MUST be delivered to the joiner's "+
 				"live Subscribe stream once the focus coordinator + stream registry are wired")
-		Expect(frame.GetType()).To(Equal("scene_pose"))
+		Expect(frame.GetType()).To(Equal("core-scenes:scene_pose"))
 		// The joiner is a non-DEK-participant, so the delivered frame MUST be
 		// metadata-only (no plaintext payload). This pins the live-path fail-closed
 		// (no-plaintext-leak) invariant — defense-in-depth per abac-reviewer.

--- a/test/integration/scenes/scene_render_verb_test.go
+++ b/test/integration/scenes/scene_render_verb_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+package scenes_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/testsupport/integrationtest"
+)
+
+// Regression spec (holomush-r0kup): core-scenes IC content resolves in the verb
+// registry from its OWN manifest verbs: block — the test-harness scene-verb
+// seeding (registerSceneEmitVerbs) is gone. So the production
+// RenderingPublisher-backed plugin emitter does not reject scene emits with
+// EMIT_UNKNOWN_VERB.
+//
+// ROOT CAUSE (pre-fix): core-scenes shipped NO verbs: block. Binary plugins
+// register rendering verbs ONLY from the manifest verbs: block
+// (manager.go:1138); core-scenes' types lived only in crypto.emits +
+// RegisterEmitTypes (which feed the INV-PLUGIN-32 set-equality check, NOT the
+// verb registry). RenderingPublisher.Publish hard-fails EMIT_UNKNOWN_VERB
+// (internal/eventbus/rendering_publisher.go) for any type missing from the verb
+// registry. In production every scene emit failed; it only appeared to work in
+// tests because the harness explicitly seeded scene verbs.
+//
+// FIX: core-scenes ships a verbs: block of qualified core-scenes:<verb> types,
+// and the harness emit helpers qualify the wire type (mirroring the real
+// plugin) so they resolve against the manifest-sourced registry. The seeding is
+// removed; the SAME verbRegistry the plugin loader populates from manifests
+// (harness.go) backs the RenderingPublisher here (WithPluginCrypto REQUIRES
+// WithInTreePlugins).
+//
+// EmitSceneICContent require.NoErrors the publish internally, so an
+// EMIT_UNKNOWN_VERB would fail this spec. A non-empty returned subject proves
+// the qualified wire type resolved against a manifest-sourced verb.
+var _ = Describe("holomush-r0kup: core-scenes renders via its own manifest verbs", func() {
+	var (
+		ts    *integrationtest.Server
+		ctx   context.Context
+		owner *integrationtest.Session
+	)
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 90*time.Second)
+		DeferCleanup(cancel)
+		// WithPluginCrypto wires the RenderingPublisher-backed plugin emitter and
+		// REQUIRES WithInTreePlugins, which loads core-scenes and registers its
+		// manifest verbs into the shared verb registry — no seeding.
+		ts = integrationtest.Start(
+			suiteT,
+			integrationtest.WithInTreePlugins(),
+			integrationtest.WithPluginCrypto(),
+		)
+		owner = ts.ConnectAuthed(ctx, "Owner")
+	})
+
+	AfterEach(func() {
+		if owner != nil {
+			owner.Logout(ctx)
+		}
+		ts.Stop()
+	})
+
+	It("publishes an IC pose without EMIT_UNKNOWN_VERB using manifest-sourced verbs", func() {
+		loc := ts.NewLocation(ctx)
+		sceneID := owner.CreateScene(ctx, loc)
+		Expect(sceneID).NotTo(BeZero(), "CreateScene must return a non-zero bare ULID")
+
+		// Pass the BARE verb — the harness helper qualifies it to
+		// core-scenes:scene_pose (mirroring the real plugin). Without the
+		// manifest verbs: block the manifest-sourced registry would have no
+		// entry, RenderingPublisher would reject with EMIT_UNKNOWN_VERB, and
+		// EmitSceneICContent's internal require.NoError would fail the spec.
+		const poseJSON = `{"text":"r0kup regression: manifest-sourced scene verb"}`
+		emitted := ts.EmitSceneICContent(ctx, "core-scenes", sceneID,
+			owner.CharacterID, "scene_pose", poseJSON)
+		Expect(emitted.SubjectStr).NotTo(BeEmpty(),
+			"core-scenes:scene_pose MUST resolve in the manifest verb registry and publish")
+		Expect(emitted.SubjectStr).To(ContainSubstring(sceneID.String()),
+			"emitted subject must carry the bare scene ULID")
+	})
+})


### PR DESCRIPTION
## Problem (holomush-r0kup, P1)

core-scenes was the only rendering-emitting in-tree plugin with **no `verbs:` block**. Binary plugins register rendering verbs *only* from the manifest `verbs:` block (`manager.go`); core-scenes' types lived only in `crypto.emits` + `RegisterEmitTypes` (which feed the INV-PLUGIN-32 set-equality check, **not** the verb registry). `RenderingPublisher.Publish` hard-fails `EMIT_UNKNOWN_VERB` for any type missing from the verb registry — so in production **every** core-scenes wire type (`scene_pose/say/emit/ooc`, the `*_ic` lifecycle notices, the `scene_publish_*` notices, `scene_idle_nudge`) failed to publish. It only appeared to work because the integration harness explicitly seeded scene verbs. Unhit to date: no production users.

## Fix — Phase 1 of holomush-aneim (Tasks 1–4)

core-scenes becomes a normal plugin: it ships a `verbs:` block of plugin-qualified `core-scenes:<verb>` types, and its wire/stored event types are qualified to match.

- **Manifest** (`plugin.yaml`): add 14 qualified verbs. IC content → `category: communication`; lifecycle/publish **notices** → `category: system` (system-feel, not IC/OOC). `crypto.emits` stays **bare** (INV-PLUGIN-32); the `emitEntryMatchesWireType` bridge (#4395) reconciles bare-crypto ↔ qualified-wire.
- **Emit sites**: qualified wire types at dispatch; `handleEmit`'s verb derivation updated to `TrimPrefix(eventType, "core-scenes:scene_")`.
- **Read-side**: `replayEventKinds`, `snapshotEventKinds`, the `scene_log` SQL filter, and audit pose-count routing re-keyed to the qualified stored type.
- **Harness** (`integrationtest/crypto.go`): emit helpers qualify the stamp (mirroring the real plugin); `registerSceneEmitVerbs` **removed** — verbs are now sourced from the manifest via the shared verb registry (`WithPluginCrypto` requires `WithInTreePlugins`).

## Tests

- New `manifest_verbs_test.go` (all 14 qualified verbs declared).
- New `scene_render_verb_test.go` integration regression: a core-scenes IC emit publishes without `EMIT_UNKNOWN_VERB` resolving against the **manifest-sourced** verb registry (no seeding).
- Existing unit + integration assertions/feeds re-keyed to the qualified type (incl. two SQL single-quoted literals — `seedScenePoseLog`, the poseorder filter — that silently matched zero rows under the new qualified stored type).

## Verification

`task pr-prep` (fast lane) green. Integration suites run green locally: `scenes`, `crypto`, `plugincrypto`, `audit`, `integrationtest`, and the `core-scenes` package. Crypto round-trips confirm the qualified type flows uniformly through AAD (encrypt and decrypt derive it from the same stored envelope). Pre-push `code-reviewer` and `crypto-reviewer` gates: **READY**, no blocking findings.

## Scope

Phase 1 only. The enforcement layer — `core-communication:emit` qualification, the `Manifest.Validate` loader gate (`PLUGIN_WIRE_TYPE_NOT_QUALIFIED`), the all-plugins meta-test, and binding `INV-PLUGIN-40` — is the remainder of the holomush-aneim epic (filed as follow-up beads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)