### PR TITLE
feat(plugin): enforce qualified wire event-type convention (holomush-aneim)

### DIFF
--- a/.claude/rules/event-conventions.md
+++ b/.claude/rules/event-conventions.md
@@ -54,6 +54,24 @@ events.<game_id>.<domain>.<entity-id>[.<facet>...]
 - Host-side ABAC infra (e.g., `ResourceChannel`, channel resource type, action validations) IS allowed in `internal/`
 - Rationale: the boundary keeps `internal/core/` independent of any specific plugin's event vocabulary. Plugin authors don't need to modify `internal/` to add new event types or verbs.
 
+## Event-type vocabularies (qualified wire / bare crypto)
+
+An event type appears in three places, governed differently (INV-PLUGIN-40):
+
+- **Wire type + `verbs[].type` + downstream stored type** MUST be plugin-qualified
+  `<plugin>:<verb>` (one colon, non-empty verb). `RenderingPublisher.Lookup`
+  resolves the wire type against `verbs[].type` and hard-fails `EMIT_UNKNOWN_VERB`
+  on a miss. `Manifest.Validate()` rejects an unqualified `verbs[].type` at
+  discovery with `PLUGIN_WIRE_TYPE_NOT_QUALIFIED`.
+- **Registered-emit set (`RegisterEmitTypes` / `register_emit_type`) and
+  `crypto.emits[].event_type`** stay **bare** `<verb>`. INV-PLUGIN-32 forces the
+  two set-equal; `requests_decryption` refs are `<plugin>:<verb>` and
+  `splitQualifiedRef` recovers the bare verb. Qualifying these trips
+  `EVENT_TYPE_REGISTRY_MISMATCH` at load.
+- `emitEntryMatchesWireType` (`internal/plugin/crypto_manifest.go`) is the single
+  bridge: it matches a bare `crypto.emits` entry against the qualified wire type
+  by composing the plugin name. Do not add other bare↔qualified shims.
+
 ## Emitting from plugins
 
 - Lua: return events from handler functions; the host translates and publishes

--- a/.claude/rules/event-conventions.md
+++ b/.claude/rules/event-conventions.md
@@ -16,6 +16,8 @@ paths:
 
 These conventions apply when emitting, declaring, or consuming events. The full design is in `docs/superpowers/specs/2026-04-18-jetstream-event-log-design.md`.
 
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in this document are to be interpreted as described in RFC 2119 and RFC 8174 (see the root `CLAUDE.md` "RFC2119 Keywords" table).
+
 ## Subject naming
 
 Subjects are NATS dot-delimited:

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -301,7 +301,7 @@ invariants.
 | `INV-PLUGIN-37` | The INV-S5 validator MUST fire in manager.go::loadPlugin AFTER host.Load returns successfully and BEFORE the plugin is added to the manager's ready plugin cache. | `INV-M5` | pending |
 | `INV-PLUGIN-38` | Lua Load-pass DoString errors MUST fail plugin load with the same wrapper shape as the syntax-check error (oops.In("lua"), operation=load); the Hint string is branch-specific ("INV-S5 capture pass execution error" for crypto plugins). | `INV-M6` | pending |
 | `INV-PLUGIN-39` | Every primitive in the INV-S5 mechanism MUST ship a Go SDK method + Lua hostfunc + parity test together (per parent substrate invariant INV-S3 / INV-PLUGIN-31). | `INV-M7` | pending |
-| `INV-PLUGIN-40` | Every emitted wire event type and every verbs[].type MUST be plugin-qualified <owning-plugin>:<verb> (one colon). The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption); the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type with PLUGIN_WIRE_TYPE_NOT_QUALIFIED. | — | pending |
+| `INV-PLUGIN-40` | Every emitted wire event type and every verbs[].type MUST be plugin-qualified <owning-plugin>:<verb> (one colon). The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption); the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type with PLUGIN_WIRE_TYPE_NOT_QUALIFIED. | — | bound |
 
 ### `INV-EVENTBUS`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3609,6 +3609,7 @@ invariants:
     binding: bound
     asserted_by:
       - "internal/plugin/manifest_test.go"
+      - "internal/plugin/lua/corecomm_sensitive_emit_test.go"
       - "test/meta/plugin_verb_qualification_test.go"
   - id: INV-COMMAND-1
     scope: INV-COMMAND

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -3606,7 +3606,10 @@ invariants:
       The registered-emit set and crypto.emits[].event_type stay bare (INV-PLUGIN-32 set-equality + requests_decryption);
       the host bridges bare<->qualified only via emitEntryMatchesWireType. Manifest.Validate rejects an unqualified verbs[].type
       with PLUGIN_WIRE_TYPE_NOT_QUALIFIED."
-    binding: pending
+    binding: bound
+    asserted_by:
+      - "internal/plugin/manifest_test.go"
+      - "test/meta/plugin_verb_qualification_test.go"
   - id: INV-COMMAND-1
     scope: INV-COMMAND
     origin_spec: "docs/superpowers/specs/2026-05-29-recognized-command-chip-design.md"

--- a/internal/plugin/communication_integration_test.go
+++ b/internal/plugin/communication_integration_test.go
@@ -364,10 +364,11 @@ var _ = Describe("Communication Plugin Integration", func() {
 				Expect(resp.Status).To(Equal(pluginsdk.CommandOK))
 				Expect(resp.Events).To(HaveLen(1))
 				Expect(resp.Events[0].Stream).To(Equal("location.loc456"))
-				// The Lua emit handler returns type = "emit" (unqualified); the host
-				// namespace-qualifies emitted types only when going through PluginEventEmitter.Emit,
-				// not on the direct DeliverCommand path.
-				Expect(string(resp.Events[0].Type)).To(Equal("emit"))
+				// The Lua emit handler now returns the plugin-qualified wire type
+				// core-communication:emit directly (holomush-aneim), matching its
+				// verbs[].type so RenderingPublisher.Lookup resolves it instead of
+				// hard-failing EMIT_UNKNOWN_VERB.
+				Expect(string(resp.Events[0].Type)).To(Equal("core-communication:emit"))
 				Expect(resp.Events[0].Payload).To(ContainSubstring(`The room shakes!`))
 			})
 		})

--- a/internal/plugin/lua/corecomm_sensitive_emit_test.go
+++ b/internal/plugin/lua/corecomm_sensitive_emit_test.go
@@ -69,6 +69,8 @@ func TestCoreCommunicationAlwaysEmitsClaimSensitive(t *testing.T) {
 // `core-communication:emit`, matching its verbs[].type declaration. A bare
 // `type = "emit"` fails RenderingPublisher.Lookup with EMIT_UNKNOWN_VERB in
 // production (the verb registry is keyed on the qualified type).
+//
+// Verifies: INV-PLUGIN-40
 func TestCoreCommunicationEmitUsesQualifiedWireType(t *testing.T) {
 	root := repoRoot(t)
 	mainLua := filepath.Join(root, "plugins", "core-communication", "main.lua")

--- a/internal/plugin/lua/corecomm_sensitive_emit_test.go
+++ b/internal/plugin/lua/corecomm_sensitive_emit_test.go
@@ -64,6 +64,24 @@ func TestCoreCommunicationAlwaysEmitsClaimSensitive(t *testing.T) {
 	}
 }
 
+// TestCoreCommunicationEmitUsesQualifiedWireType pins holomush-aneim: the
+// generic `emit` command in main.lua MUST emit the plugin-qualified wire type
+// `core-communication:emit`, matching its verbs[].type declaration. A bare
+// `type = "emit"` fails RenderingPublisher.Lookup with EMIT_UNKNOWN_VERB in
+// production (the verb registry is keyed on the qualified type).
+func TestCoreCommunicationEmitUsesQualifiedWireType(t *testing.T) {
+	root := repoRoot(t)
+	mainLua := filepath.Join(root, "plugins", "core-communication", "main.lua")
+	raw, err := os.ReadFile(mainLua)
+	require.NoError(t, err, "read core-communication main.lua")
+	src := string(raw)
+
+	require.Contains(t, src, `type = "core-communication:emit"`,
+		"the generic emit command MUST emit the qualified wire type (matches verbs[].type; holomush-aneim)")
+	require.NotContains(t, src, `type = "emit"`,
+		"bare emit wire type must be gone (EMIT_UNKNOWN_VERB in production)")
+}
+
 // enclosingEmitTables returns, for every occurrence of needle in src, the text
 // of the innermost brace-delimited table { ... } that encloses it. Brace
 // matching is scoped to the nearest unbalanced "{" before the needle and its

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1708,12 +1708,12 @@ func TestManagerLoadAllRegistersVerbsFromManifest(t *testing.T) {
 version: 1.0.0
 type: lua
 verbs:
-  - type: whisper
+  - type: chat-plugin:whisper
     category: communication
     format: speech
     label: whispers to
     display_target: terminal
-  - type: shout
+  - type: chat-plugin:shout
     category: communication
     format: speech
     label: shouts
@@ -1735,14 +1735,14 @@ lua-plugin:
 	require.NoError(t, mgrErr)
 	require.NoError(t, mgr.LoadAll(context.Background()))
 
-	whisper, ok := reg.Lookup("whisper")
+	whisper, ok := reg.Lookup("chat-plugin:whisper")
 	require.True(t, ok, "whisper verb should be registered")
 	assert.Equal(t, "communication", whisper.Category)
 	assert.Equal(t, "speech", whisper.Format)
 	assert.Equal(t, "whispers to", whisper.Label)
 	assert.Equal(t, "chat-plugin", whisper.Source)
 
-	shout, ok := reg.Lookup("shout")
+	shout, ok := reg.Lookup("chat-plugin:shout")
 	require.True(t, ok, "shout verb should be registered")
 	assert.Equal(t, "chat-plugin", shout.Source)
 
@@ -1763,7 +1763,7 @@ func TestManagerLoadAllRejectsPluginWithDuplicateVerbType(t *testing.T) {
 version: 1.0.0
 type: lua
 verbs:
-  - type: existing_verb
+  - type: dup-plugin:existing_verb
     category: communication
     format: action
     display_target: terminal
@@ -1778,7 +1778,7 @@ lua-plugin:
 	reg := core.NewVerbRegistry()
 	// Pre-register a verb that the plugin also declares.
 	require.NoError(t, reg.RegisterWithSource(core.VerbRegistration{
-		Type:          "existing_verb",
+		Type:          "dup-plugin:existing_verb",
 		Category:      "state",
 		Format:        "snapshot",
 		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_STATE,
@@ -1807,11 +1807,11 @@ func TestManagerLoadAllCleansUpVerbsOnPartialFailure(t *testing.T) {
 version: 1.0.0
 type: lua
 verbs:
-  - type: good_verb
+  - type: partial-plugin:good_verb
     category: communication
     format: action
     display_target: terminal
-  - type: conflict
+  - type: partial-plugin:conflict
     category: state
     format: snapshot
     display_target: state
@@ -1826,7 +1826,7 @@ lua-plugin:
 	reg := core.NewVerbRegistry()
 	// Pre-register the conflict verb so the second registration fails.
 	require.NoError(t, reg.RegisterWithSource(core.VerbRegistration{
-		Type:          "conflict",
+		Type:          "partial-plugin:conflict",
 		Category:      "state",
 		Format:        "snapshot",
 		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_STATE,
@@ -1843,11 +1843,11 @@ lua-plugin:
 	require.Error(t, err)
 
 	// good_verb should have been cleaned up via UnregisterBySource.
-	_, ok := reg.Lookup("good_verb")
+	_, ok := reg.Lookup("partial-plugin:good_verb")
 	assert.False(t, ok, "good_verb should have been cleaned up after partial failure")
 
 	// The pre-existing conflict verb should remain (owned by builtin, not the plugin).
-	conflict, ok := reg.Lookup("conflict")
+	conflict, ok := reg.Lookup("partial-plugin:conflict")
 	require.True(t, ok, "builtin conflict verb should still exist")
 	assert.Equal(t, "builtin", conflict.Source)
 }

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -526,6 +526,18 @@ func (m *Manifest) Validate() error {
 			return oops.In("manifest").With("plugin", m.Name).With("verb_index", i).
 				New("verb type must not be empty")
 		}
+		// The wire event type and verbs[].type MUST be plugin-qualified
+		// <owning-plugin>:<verb> (exactly one colon, non-empty verb), or
+		// RenderingPublisher.Lookup hard-fails EMIT_UNKNOWN_VERB in production.
+		// The registered-emit set and crypto.emits[].event_type stay bare
+		// (INV-PLUGIN-32); only the wire/verb-registry vocabulary is qualified
+		// (INV-PLUGIN-40, holomush-aneim).
+		if want := m.Name + ":"; !strings.HasPrefix(v.Type, want) ||
+			len(v.Type) <= len(want) || strings.Count(v.Type, ":") != 1 {
+			return oops.Code("PLUGIN_WIRE_TYPE_NOT_QUALIFIED").
+				In("manifest").With("plugin", m.Name).With("verb", v.Type).
+				Errorf("verbs[].type must be %q-prefixed (<plugin>:<verb>, one colon); got %q", m.Name, v.Type)
+		}
 		if !validVerbCategories[v.Category] {
 			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).
 				With("category", v.Category).New("unknown verb category")

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -536,7 +536,7 @@ func (m *Manifest) Validate() error {
 			len(v.Type) <= len(want) || strings.Count(v.Type, ":") != 1 {
 			return oops.Code("PLUGIN_WIRE_TYPE_NOT_QUALIFIED").
 				In("manifest").With("plugin", m.Name).With("verb", v.Type).
-				Errorf("verbs[].type must be %q-prefixed (<plugin>:<verb>, one colon); got %q", m.Name, v.Type)
+				Errorf("verbs[].type must be %q-prefixed (<plugin>:<verb>, one colon); got %q", want, v.Type)
 		}
 		if !validVerbCategories[v.Category] {
 			return oops.In("manifest").With("plugin", m.Name).With("verb", v.Type).

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -2029,12 +2030,12 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: speech
     label: says
     display_target: terminal
-  - type: channel.pose
+  - type: channels:pose
     category: communication
     format: action
     display_target: both
@@ -2043,13 +2044,13 @@ verbs:
 	require.NoError(t, err)
 	require.Len(t, m.Verbs, 2)
 
-	assert.Equal(t, "channel.say", m.Verbs[0].Type)
+	assert.Equal(t, "channels:say", m.Verbs[0].Type)
 	assert.Equal(t, "communication", m.Verbs[0].Category)
 	assert.Equal(t, "speech", m.Verbs[0].Format)
 	assert.Equal(t, "says", m.Verbs[0].Label)
 	assert.Equal(t, "terminal", m.Verbs[0].DisplayTarget)
 
-	assert.Equal(t, "channel.pose", m.Verbs[1].Type)
+	assert.Equal(t, "channels:pose", m.Verbs[1].Type)
 	assert.Equal(t, "action", m.Verbs[1].Format)
 	assert.Equal(t, "both", m.Verbs[1].DisplayTarget)
 }
@@ -2062,7 +2063,7 @@ type: binary
 binary-plugin:
   executable: scenes
 verbs:
-  - type: scene.narrate
+  - type: scenes:narrate
     category: state
     format: narrative
     display_target: terminal
@@ -2070,7 +2071,7 @@ verbs:
 	m, err := plugins.ParseManifest(data)
 	require.NoError(t, err)
 	require.Len(t, m.Verbs, 1)
-	assert.Equal(t, "scene.narrate", m.Verbs[0].Type)
+	assert.Equal(t, "scenes:narrate", m.Verbs[0].Type)
 }
 
 func TestManifestRejectsSettingPluginWithVerbs(t *testing.T) {
@@ -2112,6 +2113,45 @@ verbs:
 	assert.Contains(t, err.Error(), "verb type must not be empty")
 }
 
+func TestManifestValidateRejectsUnqualifiedVerbType(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"bare":        "say",
+		"foreign":     "other:say",
+		"multi-colon": "demo:say:extra",
+		"prefix-only": "demo:",
+	}
+	for name, verbType := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			m := &plugins.Manifest{
+				Name: "demo", Version: "1.0.0", Type: plugins.TypeLua,
+				LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+				Verbs: []plugins.VerbSpec{{
+					Type: verbType, Category: "communication", Format: "action", DisplayTarget: "terminal",
+				}},
+			}
+			err := m.Validate()
+			require.Error(t, err)
+			oopsErr, ok := oops.AsOops(err)
+			require.True(t, ok, "error must be an oops error")
+			require.Equal(t, "PLUGIN_WIRE_TYPE_NOT_QUALIFIED", oopsErr.Code())
+		})
+	}
+}
+
+func TestManifestValidateAcceptsQualifiedVerbType(t *testing.T) {
+	t.Parallel()
+	m := &plugins.Manifest{
+		Name: "demo", Version: "1.0.0", Type: plugins.TypeLua,
+		LuaPlugin: &plugins.LuaConfig{Entry: "main.lua"},
+		Verbs: []plugins.VerbSpec{{
+			Type: "demo:say", Category: "communication", Format: "action", DisplayTarget: "terminal",
+		}},
+	}
+	require.NoError(t, m.Validate())
+}
+
 func TestManifestRejectsVerbWithUnknownCategory(t *testing.T) {
 	data := []byte(`
 name: channels
@@ -2120,7 +2160,7 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: unknown-category
     format: speech
     label: says
@@ -2139,7 +2179,7 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: unknown-format
     display_target: terminal
@@ -2157,7 +2197,7 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: action
     display_target: unknown-target
@@ -2175,7 +2215,7 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: speech
     display_target: terminal
@@ -2193,11 +2233,11 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: action
     display_target: terminal
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: narrative
     display_target: both
@@ -2218,7 +2258,7 @@ type: lua
 lua-plugin:
   entry: main.lua
 verbs:
-  - type: channel.say
+  - type: channels:say
     category: communication
     format: action
     display_target: %s

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -2113,6 +2113,7 @@ verbs:
 	assert.Contains(t, err.Error(), "verb type must not be empty")
 }
 
+// Verifies: INV-PLUGIN-40
 func TestManifestValidateRejectsUnqualifiedVerbType(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{

--- a/plugins/core-communication/main.lua
+++ b/plugins/core-communication/main.lua
@@ -175,7 +175,7 @@ local function handle_emit(ctx)
     local payload = '{"message":' .. json_string(msg) .. '}'
 
     return ok_events({
-        {subject ="location." .. loc, type = "emit", payload = payload}
+        {subject ="location." .. loc, type = "core-communication:emit", payload = payload}
     })
 end
 

--- a/test/integration/plugin/verb_registration_test.go
+++ b/test/integration/plugin/verb_registration_test.go
@@ -50,12 +50,12 @@ name: verb-plugin
 version: 1.0.0
 type: lua
 verbs:
-  - type: custom_say
+  - type: verb-plugin:custom_say
     category: communication
     format: speech
     label: "says"
     display_target: terminal
-  - type: custom_action
+  - type: verb-plugin:custom_action
     category: communication
     format: action
     display_target: both
@@ -71,22 +71,23 @@ lua-plugin:
 		Expect(mgrErr).NotTo(HaveOccurred())
 		Expect(mgr.LoadAll(context.Background())).To(Succeed())
 
-		reg, ok := verbReg.Lookup("custom_say")
+		reg, ok := verbReg.Lookup("verb-plugin:custom_say")
 		Expect(ok).To(BeTrue(), "custom_say should be registered")
 		Expect(reg.Category).To(Equal("communication"))
 		Expect(reg.Format).To(Equal("speech"))
 		Expect(reg.Label).To(Equal("says"))
 		Expect(reg.Source).To(Equal("verb-plugin"))
 
-		reg, ok = verbReg.Lookup("custom_action")
+		reg, ok = verbReg.Lookup("verb-plugin:custom_action")
 		Expect(ok).To(BeTrue(), "custom_action should be registered")
 		Expect(reg.Source).To(Equal("verb-plugin"))
 	})
 
-	It("rejects a plugin whose verb type conflicts with a builtin", func() {
-		// "system" is a host-owned event type registered by RegisterBuiltinTypes.
-		// (Plugin-owned types like say/pose are no longer registered as builtins
-		// per the plugin-boundary discipline; they're owned by their plugin.)
+	It("skips a plugin that declares an unqualified (bare) verb type", func() {
+		// The qualification gate (INV-PLUGIN-40, holomush-aneim) rejects a bare
+		// verb type at manifest parse, so the plugin is skipped at discovery
+		// (warn + continue). A plugin can no longer shadow a host-owned builtin
+		// like "system": every plugin verb MUST be <plugin>:<verb>.
 		writePlugin("conflict-plugin", `
 name: conflict-plugin
 version: 1.0.0
@@ -106,15 +107,16 @@ lua-plugin:
 			plugins.WithVerbRegistry(verbReg),
 		)
 		Expect(mgrErr).NotTo(HaveOccurred())
-		err := mgr.LoadAll(context.Background())
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("already registered"))
+		// An invalid manifest is skipped, not a hard load error.
+		Expect(mgr.LoadAll(context.Background())).To(Succeed())
+		_, loaded := mgr.GetLoadedPlugin("conflict-plugin")
+		Expect(loaded).To(BeFalse(), "plugin with a bare verb type must be skipped at discovery")
 	})
 
 	It("cleans up verbs when plugin load fails partway through verb list", func() {
-		// Pre-register "conflict" so the second verb in the manifest fails
+		// Pre-register "partial-fail:conflict" so the second verb in the manifest fails
 		Expect(verbReg.RegisterWithSource(core.VerbRegistration{
-			Type: "conflict", Category: "system", Format: "notification",
+			Type: "partial-fail:conflict", Category: "system", Format: "notification",
 			DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL, Source: "pre-existing",
 		}, "1.0.0")).To(Succeed())
 
@@ -123,11 +125,11 @@ name: partial-fail
 version: 1.0.0
 type: lua
 verbs:
-  - type: good_verb
+  - type: partial-fail:good_verb
     category: communication
     format: action
     display_target: terminal
-  - type: conflict
+  - type: partial-fail:conflict
     category: system
     format: notification
     display_target: terminal
@@ -145,7 +147,7 @@ lua-plugin:
 		Expect(err).To(HaveOccurred())
 
 		// good_verb should have been cleaned up by UnregisterBySource
-		_, ok := verbReg.Lookup("good_verb")
+		_, ok := verbReg.Lookup("partial-fail:good_verb")
 		Expect(ok).To(BeFalse(), "good_verb should have been cleaned up after partial failure")
 	})
 })

--- a/test/meta/plugin_verb_qualification_test.go
+++ b/test/meta/plugin_verb_qualification_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestEveryInTreePluginVerbTypeIsQualified pins holomush-aneim: every plugin's
+// verbs[].type MUST be "<plugin-dir>:<verb>" (exactly one colon, non-empty
+// verb), so RenderingPublisher.Lookup resolves the emitted wire type instead of
+// hard-failing EMIT_UNKNOWN_VERB in production. It deliberately asserts nothing
+// about crypto.emits / the registered-emit set — those stay bare (INV-PLUGIN-32).
+func TestEveryInTreePluginVerbTypeIsQualified(t *testing.T) {
+	root := findRepoRoot(t)
+	manifests, err := filepath.Glob(filepath.Join(root, "plugins", "*", "plugin.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, manifests, "expected at least one in-tree plugin manifest")
+
+	for _, path := range manifests {
+		pluginDir := filepath.Base(filepath.Dir(path))
+		data, err := os.ReadFile(path) //nolint:gosec // test-only scan of in-tree manifests
+		require.NoError(t, err)
+		var m struct {
+			Verbs []struct {
+				Type string `yaml:"type"`
+			} `yaml:"verbs"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &m), "parse %s", path)
+
+		want := pluginDir + ":"
+		for _, v := range m.Verbs {
+			require.Truef(t,
+				strings.HasPrefix(v.Type, want) &&
+					strings.Count(v.Type, ":") == 1 &&
+					len(v.Type) > len(want),
+				"%s: verbs[].type %q must be %q-prefixed (<plugin>:<verb>, one colon)",
+				path, v.Type, pluginDir)
+		}
+	}
+}

--- a/test/meta/plugin_verb_qualification_test.go
+++ b/test/meta/plugin_verb_qualification_test.go
@@ -14,10 +14,17 @@ import (
 )
 
 // TestEveryInTreePluginVerbTypeIsQualified pins holomush-aneim: every plugin's
-// verbs[].type MUST be "<plugin-dir>:<verb>" (exactly one colon, non-empty
+// verbs[].type MUST be "<plugin-name>:<verb>" (exactly one colon, non-empty
 // verb), so RenderingPublisher.Lookup resolves the emitted wire type instead of
 // hard-failing EMIT_UNKNOWN_VERB in production. It deliberately asserts nothing
 // about crypto.emits / the registered-emit set — those stay bare (INV-PLUGIN-32).
+//
+// The prefix is keyed on the manifest `name` field, NOT the directory basename,
+// to mirror Manifest.Validate()'s gate (`want := m.Name + ":"`). The two diverge
+// for plugins whose name != dir (e.g. setting-crossroads/name:crossroads); keying
+// on dir here would demand a prefix the gate would reject at load.
+//
+// Verifies: INV-PLUGIN-40
 func TestEveryInTreePluginVerbTypeIsQualified(t *testing.T) {
 	root := findRepoRoot(t)
 	manifests, err := filepath.Glob(filepath.Join(root, "plugins", "*", "plugin.yaml"))
@@ -25,24 +32,25 @@ func TestEveryInTreePluginVerbTypeIsQualified(t *testing.T) {
 	require.NotEmpty(t, manifests, "expected at least one in-tree plugin manifest")
 
 	for _, path := range manifests {
-		pluginDir := filepath.Base(filepath.Dir(path))
-		data, err := os.ReadFile(path) //nolint:gosec // test-only scan of in-tree manifests
+		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 		var m struct {
+			Name  string `yaml:"name"`
 			Verbs []struct {
 				Type string `yaml:"type"`
 			} `yaml:"verbs"`
 		}
 		require.NoError(t, yaml.Unmarshal(data, &m), "parse %s", path)
+		require.NotEmptyf(t, m.Name, "%s: manifest name must not be empty", path)
 
-		want := pluginDir + ":"
+		want := m.Name + ":"
 		for _, v := range m.Verbs {
 			require.Truef(t,
 				strings.HasPrefix(v.Type, want) &&
 					strings.Count(v.Type, ":") == 1 &&
 					len(v.Type) > len(want),
-				"%s: verbs[].type %q must be %q-prefixed (<plugin>:<verb>, one colon)",
-				path, v.Type, pluginDir)
+				"%s: verbs[].type %q must be %q-prefixed (<plugin-name>:<verb>, one colon)",
+				path, v.Type, m.Name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Enforcement half of epic `holomush-aneim` (plan Tasks 5–8). The foundational core-scenes fix (`holomush-r0kup`, #4397) already landed; this PR makes the qualified-wire event-type convention **mechanically enforced** so it can't drift again.

Three event-type vocabularies, governed differently:
- **Wire type + `verbs[].type` + downstream stored type** → plugin-qualified `<plugin>:<verb>` (one colon).
- **Registered-emit set + `crypto.emits[].event_type`** → stay **bare** (INV-PLUGIN-32 set-equality; `requests_decryption`/`splitQualifiedRef` need the bare verb).
- `emitEntryMatchesWireType` is the sole bare↔qualified bridge (unchanged).

## Changes

| Bead | Change |
|------|--------|
| `aneim.9` | `plugins/core-communication/main.lua:178` — the generic `emit` command emitted a bare `type = "emit"` while `verbs[].type` declares `core-communication:emit`, so `RenderingPublisher.Lookup` would return `EMIT_UNKNOWN_VERB` in production. Now qualified. |
| `aneim.10` | `internal/plugin/manifest.go` — new `PLUGIN_WIRE_TYPE_NOT_QUALIFIED` gate in `Manifest.Validate()` rejecting any unqualified `verbs[].type`, fail-fast at discovery via `ParseManifest`. |
| `aneim.11` | `test/meta/plugin_verb_qualification_test.go` — census asserting every in-tree plugin's `verbs[].type` is `<manifest-name>:<verb>`. |
| `aneim.12` | `.claude/rules/event-conventions.md` three-vocabulary section + binds `INV-PLUGIN-40` (`pending` → `bound`). |

## Notable: fixture blast radius

The plan claimed "a grep found none in-tree," but the gate rejecting unqualified verbs at parse time forced requalifying ~13 verb fixtures across `manifest_test.go`, `manager_test.go`, and `verb_registration_test.go` — including registry lookup keys and pre-registered conflict entries (the registry keys verbs by `Type`). The "conflicts with a builtin" integration spec was **converted to a skip-at-discovery assertion**, since the gate structurally prevents a plugin from declaring a bare builtin name at all (`Manager.Discover` warns-and-skips invalid manifests rather than erroring).

## Invariants

- `crypto.emits[].event_type` stays bare — verified by crypto-reviewer (READY).
- `INV-PLUGIN-40` bound to `manifest_test.go` (gate reject) + `test/meta` census (positive).

## Verification

- `task pr-prep` (fast lane) — green.
- Full unit suite — 8974 tests green.
- `task test:int -- ./test/integration/plugin/...` — green (the converted skip spec + requalified specs pass at runtime).
- crypto-reviewer: READY. code-reviewer: READY (one Minor fixed — meta-test now keys on manifest `name`, mirroring the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)