### PR TITLE
fix(plugin): delete WithCryptoEnabled gate — run sensitivity fence unconditionally (holomush-dj95.3)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -99,3 +99,24 @@
   notification,error,snapshot,delta}, speech needs label. Design: IC content (pose/say/emit/ooc)→
   communication; lifecycle/publish notices→system+notification. No false-green (no `// Verifies:
   INV-PLUGIN-40`; loader-gate aneim.10 + meta-test aneim.11 deferred). 2026-06-07 — READY.
+
+- **Gate-removal (delete WithCryptoEnabled emit fence gate, run fence unconditionally) —
+  holomush-dj95.3 READY.** Deleting a runtime safety-gate is only safe once EVERY emit path
+  that the now-unconditional check could reject is already compliant. Review pattern that held:
+  (1) Completeness: `rg WithCryptoEnabled|cryptoEnabled` whole-tree — plugins-package gate fully
+  gone; SEPARATE `internal/grpc/` read-side gate (server.go:178, auth_handlers.go:156) is a
+  DISTINCT Phase-3b binding-lookup gate that MUST remain (don't flag). (2) Production-safety is
+  the crux, NOT completeness: enumerate ALL `sensitivity: always` manifest entries
+  (`rg always plugins/*/plugin.yaml`) and verify each emit SITE claims Sensitive=true — core-scenes
+  IC content commands.go:1325 (Sensitive:true), core-communication Lua page/whisper/pemit main.lua
+  carry `sensitive = true` (guarded by lua/corecomm_sensitive_emit_test.go, the 50zqs regression).
+  (3) Undeclared-event safety: LookupEmitSensitivity (crypto_manifest.go:66) defaults
+  SensitivityNever for nil-manifest AND unmatched type → EnforceSensitivity(never,false)=never,nil →
+  Sensitive=false, IDENTICAL to pre-gate behavior; only NEW rejection is over-claim (claim=true on
+  never/undeclared) which no production path does. (4) Precursor dep (50zqs, SDK Sensitive plumbing)
+  CLOSED; proto sensitive=4 + bidirectional event_marshal.go + Lua flush `sensitive` key all landed.
+  (5) Bead acceptance criterion `rg ... internal/ → zero hits` is STALE (grpc gate legitimately
+  remains) — note for close, not a code defect. (6) Minor: package-doc wire_crypto.go:6-10 retains
+  cfg.Crypto-gated framing predating the change (DEK-wiring clause still accurate); function-doc
+  37-43 is the authoritative+correct one. `_ eventbus.Config` unused param: no lint risk (unparam
+  skips exported funcs; `_` signals intent). 746 unit tests green. 2026-06-07 — READY.

--- a/internal/bootstrap/wire_crypto.go
+++ b/internal/bootstrap/wire_crypto.go
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 HoloMUSH Contributors
 
-// Package bootstrap — Phase 3a crypto wiring (holomush-ojw1.1).
+// Package bootstrap — plugin crypto wiring (holomush-ojw1.1).
 //
-// BuildPluginEmitter constructs a PluginEventEmitter; when
-// cfg.Crypto.Enabled is true, the caller MUST also wire a DEK manager
-// into the publisher via eventbus.WithDEKManager (this happens during
-// JetStreamPublisher construction, not here — this helper produces
-// the emitter half only).
+// BuildPluginEmitter produces the emitter half of the plugin-crypto path; its
+// host-side sensitivity fence runs unconditionally (holomush-dj95.3), so it
+// does not branch on cfg.Crypto. Separately, when cfg.Crypto.Enabled is true
+// the caller MUST also wire a DEK manager into the publisher via
+// eventbus.WithDEKManager — that happens during JetStreamPublisher
+// construction, not here.
 package bootstrap
 
 import (
@@ -34,17 +35,15 @@ type PluginEmitterDeps struct {
 	Resolver  plugins.ActorResolver
 }
 
-// BuildPluginEmitter constructs a PluginEventEmitter from cfg + deps.
-// cfg.Crypto.IsEnabled() gates the host-side sensitivity fence inside
-// the emitter (see plugins.WithCryptoEnabled). As of Phase 3d the
-// effective default is true; when explicitly set to false (e.g. for
-// dev/test deployments), the emitter skips the fence and stamps
-// Sensitive=false unconditionally, matching pre-Phase-3a behavior.
-// When true, the fence runs and the publisher's DEK-manager-aware
-// crypto branch activates downstream.
-func BuildPluginEmitter(_ context.Context, cfg eventbus.Config, deps PluginEmitterDeps) (*plugins.PluginEventEmitter, error) {
+// BuildPluginEmitter constructs a PluginEventEmitter from deps. The emitter
+// runs the host-side sensitivity fence unconditionally — the plugin manifest
+// declaration is the single source of truth, with no runtime gate
+// (holomush-dj95.3 removed the WithCryptoEnabled fossil). The cfg argument is
+// retained for call-site symmetry; crypto's downstream effect (DEK-manager
+// wiring on the publisher) is configured during JetStreamPublisher
+// construction, not here.
+func BuildPluginEmitter(_ context.Context, _ eventbus.Config, deps PluginEmitterDeps) (*plugins.PluginEventEmitter, error) {
 	return plugins.NewPluginEventEmitter(
 		deps.Publisher, deps.Manifests, deps.Resolver,
-		plugins.WithCryptoEnabled(cfg.Crypto.IsEnabled()),
 	), nil
 }

--- a/internal/bootstrap/wire_crypto_test.go
+++ b/internal/bootstrap/wire_crypto_test.go
@@ -14,30 +14,29 @@ import (
 	"github.com/holomush/holomush/internal/eventbus"
 )
 
-func TestPluginEmitterDepsBuildSucceedsWithCryptoDisabled(t *testing.T) {
-	falseV := false
-	cfg := eventbus.Config{Crypto: eventbus.CryptoConfig{Enabled: &falseV}}
-	deps := bootstrap.PluginEmitterDeps{
-		Publisher: &noopPublisher{},
-		Manifests: func(string) *bootstrap.Manifest { return nil },
-		Resolver:  func(context.Context, string) (bootstrap.Actor, error) { return bootstrap.Actor{}, nil },
+// TestBuildPluginEmitterSucceedsRegardlessOfCryptoConfig pins that the emitter
+// constructor is crypto-config-agnostic: holomush-dj95.3 removed the
+// WithCryptoEnabled gate, so the host-side sensitivity fence runs
+// unconditionally and BuildPluginEmitter no longer branches on cfg.Crypto.
+func TestBuildPluginEmitterSucceedsRegardlessOfCryptoConfig(t *testing.T) {
+	for _, cryptoEnabled := range []bool{false, true} {
+		name := "crypto config disabled"
+		if cryptoEnabled {
+			name = "crypto config enabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			enabled := cryptoEnabled
+			cfg := eventbus.Config{Crypto: eventbus.CryptoConfig{Enabled: &enabled}}
+			deps := bootstrap.PluginEmitterDeps{
+				Publisher: &noopPublisher{},
+				Manifests: func(string) *bootstrap.Manifest { return nil },
+				Resolver:  func(context.Context, string) (bootstrap.Actor, error) { return bootstrap.Actor{}, nil },
+			}
+			emitter, err := bootstrap.BuildPluginEmitter(context.Background(), cfg, deps)
+			require.NoError(t, err)
+			assert.NotNil(t, emitter)
+		})
 	}
-	emitter, err := bootstrap.BuildPluginEmitter(context.Background(), cfg, deps)
-	require.NoError(t, err)
-	assert.NotNil(t, emitter)
-}
-
-func TestPluginEmitterDepsBuildSucceedsWithCryptoEnabled(t *testing.T) {
-	trueV := true
-	cfg := eventbus.Config{Crypto: eventbus.CryptoConfig{Enabled: &trueV}}
-	deps := bootstrap.PluginEmitterDeps{
-		Publisher: &noopPublisher{},
-		Manifests: func(string) *bootstrap.Manifest { return nil },
-		Resolver:  func(context.Context, string) (bootstrap.Actor, error) { return bootstrap.Actor{}, nil },
-	}
-	emitter, err := bootstrap.BuildPluginEmitter(context.Background(), cfg, deps)
-	require.NoError(t, err)
-	assert.NotNil(t, emitter)
 }
 
 type noopPublisher struct{}

--- a/internal/plugin/event_emitter.go
+++ b/internal/plugin/event_emitter.go
@@ -51,7 +51,6 @@ type PluginEventEmitter struct {
 	lookupManifest ManifestLookup
 	resolveActor   ActorResolver
 	gameID         GameIDProvider
-	cryptoEnabled  bool
 }
 
 // EmitterOption customizes PluginEventEmitter construction.
@@ -61,25 +60,6 @@ type EmitterOption func(*PluginEventEmitter)
 // "main" (matches eventbus.Config default game_id).
 func WithGameID(p GameIDProvider) EmitterOption {
 	return func(e *PluginEventEmitter) { e.gameID = p }
-}
-
-// WithCryptoEnabled toggles the Phase 3a sensitivity fence. When false
-// (the default and the production state at Phase 3a merge time), the
-// emitter skips the manifest sensitivity lookup + EnforceSensitivity
-// check and stamps event.Sensitive=false unconditionally — matching
-// pre-Phase-3a behavior. When true, the fence runs and INV-PLUGIN-29/INV-PLUGIN-30 are
-// enforced. The flag is sourced from eventbus.Config.Crypto.Enabled in
-// internal/bootstrap.
-//
-// This gate is required because production manifests already declare
-// sensitivity: always for events like core-communication's page,
-// whisper, and pemit (plugins/core-communication/plugin.yaml), and
-// neither the Lua nor binary plugin SDK currently surfaces
-// EmitIntent.Sensitive over the wire. Running the fence unconditionally
-// would reject every page/whisper/pemit emit with
-// EVENT_SENSITIVITY_REQUIRED until the plugin SDK gains the field.
-func WithCryptoEnabled(enabled bool) EmitterOption {
-	return func(e *PluginEventEmitter) { e.cryptoEnabled = enabled }
 }
 
 // NewPluginEventEmitter wires a new shared host event emitter.
@@ -155,28 +135,23 @@ func (e *PluginEventEmitter) Emit(ctx context.Context, pluginName string, intent
 			Errorf("plugin manifest does not declare %q as a claimable actor kind", actor.Kind.String())
 	}
 
-	// Phase 3a: resolve manifest sensitivity + run the host-side fence.
-	// Result is stamped on event.Sensitive; the publisher acts on it.
-	//
-	// The fence is gated behind WithCryptoEnabled because production
-	// manifests already declare sensitivity: always for events whose
-	// emit path cannot yet set EmitIntent.Sensitive=true (the proto
-	// EmitEventRequest has no sensitive field). Running the fence
-	// unconditionally would break those emits. When crypto is off the
-	// emitter behaves as it did pre-Phase-3a: event.Sensitive=false
-	// regardless of manifest declaration.
-	sensitive := false
-	if e.cryptoEnabled {
-		manifestSensitivity := LookupEmitSensitivity(manifest, string(intent.Type))
-		effective, fenceErr := EnforceSensitivity(manifestSensitivity, intent.Sensitive)
-		if fenceErr != nil {
-			return oops.With("plugin", pluginName).
-				With("subject", subjectRaw).
-				With("event_type", string(intent.Type)).
-				Wrap(fenceErr)
-		}
-		sensitive = effective == SensitivityAlways
+	// Resolve manifest sensitivity + run the host-side fence on every emit.
+	// The manifest sensitivity declaration is the single source of truth
+	// (INV-PLUGIN-29/INV-PLUGIN-30): the SDK plumbs EmitIntent.Sensitive
+	// end-to-end for both Lua and binary runtimes, so there is no runtime
+	// override — a sensitivity:always event under-claimed as Sensitive=false
+	// is rejected (EVENT_SENSITIVITY_REQUIRED) rather than silently shipped
+	// as plaintext. The result is stamped on event.Sensitive; the publisher
+	// acts on it (holomush-dj95.3 removed the WithCryptoEnabled gate fossil).
+	manifestSensitivity := LookupEmitSensitivity(manifest, string(intent.Type))
+	effective, fenceErr := EnforceSensitivity(manifestSensitivity, intent.Sensitive)
+	if fenceErr != nil {
+		return oops.With("plugin", pluginName).
+			With("subject", subjectRaw).
+			With("event_type", string(intent.Type)).
+			Wrap(fenceErr)
 	}
+	sensitive := effective == SensitivityAlways
 
 	if e.publisher == nil {
 		return oops.With("plugin", pluginName).With("subject", subjectRaw).

--- a/internal/plugin/event_emitter_crypto_test.go
+++ b/internal/plugin/event_emitter_crypto_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/samber/oops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -39,21 +40,20 @@ func newCryptoTestEmitter(t *testing.T, pub eventbus.Publisher, manifest *plugin
 	resolve := func(_ context.Context, _ string) (core.Actor, error) {
 		return core.Actor{Kind: core.ActorPlugin, ID: fixturePluginULID.String()}, nil
 	}
-	// These tests exercise the Phase 3a sensitivity fence directly, so
-	// they MUST explicitly enable crypto. The default (off) bypasses
-	// the fence — see TestEmitterDoesNotRunFenceWhenCryptoDisabled.
-	return plugins.NewPluginEventEmitter(pub, lookup, resolve, plugins.WithCryptoEnabled(true))
+	// The host-side sensitivity fence runs on every emit (no gate), so a
+	// plainly-constructed emitter exercises it directly.
+	return plugins.NewPluginEventEmitter(pub, lookup, resolve)
 }
 
-// TestEmitterDoesNotRunFenceWhenCryptoDisabled is the regression test
-// for the Phase 3a-merge-time bug where production manifests declare
-// sensitivity: always for events the SDK cannot yet flag as sensitive
-// (proto EmitEventRequest has no sensitive field). With crypto
-// disabled (the Phase 3a default), the emitter MUST skip the fence
-// and emit successfully even if the manifest would otherwise
-// EVENT_SENSITIVITY_REQUIRED-reject.
-func TestEmitterDoesNotRunFenceWhenCryptoDisabled(t *testing.T) {
-	pub := &recordingPublisher{}
+// TestEmitterRunsFenceUnconditionallyWithoutFlag is the holomush-dj95.3
+// regression. With the WithCryptoEnabled gate removed, the host-side
+// sensitivity fence runs on EVERY emit: the plugin manifest declaration is
+// the single source of truth with no runtime override. A plainly-constructed
+// emitter (no options — mirroring production after the fossil deletion) MUST
+// stamp Sensitive per the manifest and MUST reject an under-claimed
+// sensitivity:always emit, where the old gate would have silently bypassed it
+// and shipped plaintext.
+func TestEmitterRunsFenceUnconditionallyWithoutFlag(t *testing.T) {
 	manifest := newSensitiveTestManifest([]plugins.CryptoEmit{
 		{EventType: "test-plugin:secret", Sensitivity: plugins.SensitivityAlways},
 	})
@@ -66,20 +66,38 @@ func TestEmitterDoesNotRunFenceWhenCryptoDisabled(t *testing.T) {
 	resolve := func(_ context.Context, _ string) (core.Actor, error) {
 		return core.Actor{Kind: core.ActorPlugin, ID: fixturePluginULID.String()}, nil
 	}
-	// Construct without WithCryptoEnabled — defaults to false.
-	emitter := plugins.NewPluginEventEmitter(pub, lookup, resolve)
 
-	intent := pluginsdk.EmitIntent{
-		Subject:   "scene.01HXXXTESTSCENE000000000",
-		Type:      pluginsdk.EventType("test-plugin:secret"),
-		Payload:   `{}`,
-		Sensitive: false, // would trigger INV-PLUGIN-30 if the fence ran
-	}
-	require.NoError(t, emitter.Emit(context.Background(), "test-plugin", intent),
-		"crypto disabled: fence MUST be skipped")
-	require.Len(t, pub.events, 1)
-	assert.False(t, pub.events[0].Sensitive,
-		"crypto disabled: event.Sensitive MUST be false regardless of manifest")
+	t.Run("manifest always + claim true stamps Sensitive=true with no flag", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		emitter := plugins.NewPluginEventEmitter(pub, lookup, resolve)
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene.01HXXXTESTSCENE000000000",
+			Type:      pluginsdk.EventType("test-plugin:secret"),
+			Payload:   `{}`,
+			Sensitive: true,
+		}
+		require.NoError(t, emitter.Emit(context.Background(), "test-plugin", intent))
+		require.Len(t, pub.events, 1)
+		assert.True(t, pub.events[0].Sensitive,
+			"manifest sensitivity:always MUST stamp Sensitive=true with no game-config flag set")
+	})
+
+	t.Run("manifest always + claim false is rejected unconditionally", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		emitter := plugins.NewPluginEventEmitter(pub, lookup, resolve)
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene.01HXXXTESTSCENE000000000",
+			Type:      pluginsdk.EventType("test-plugin:secret"),
+			Payload:   `{}`,
+			Sensitive: false, // under-claims an always-sensitive event
+		}
+		err := emitter.Emit(context.Background(), "test-plugin", intent)
+		require.Error(t, err, "the fence MUST reject an under-claimed always-sensitive emit (no bypass)")
+		oopsErr, ok := oops.AsOops(err)
+		require.True(t, ok, "error must be an oops error")
+		assert.Equal(t, "EVENT_SENSITIVITY_REQUIRED", oopsErr.Code())
+		assert.Empty(t, pub.events, "a rejected emit MUST NOT publish")
+	})
 }
 
 func TestEmitterStampsSensitiveTrueForManifestMayPlusClaimTrue(t *testing.T) {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -2031,9 +2031,9 @@ func TestEmitPluginEventPropagatesSensitive(t *testing.T) {
 	mgr.RegisterHost(plugins.TypeLua, mockLua)
 	mgr.TestLoadPlugin("core-test", manifest)
 
-	// Wire the shared emitter with crypto enabled so the fence runs and
+	// The shared emitter runs the sensitivity fence unconditionally, so it
 	// stamps sensitive=true (manifest=may + intent.Sensitive=true → SensitivityAlways).
-	mgr.ConfigureEventEmitter(pub, plugins.WithCryptoEnabled(true))
+	mgr.ConfigureEventEmitter(pub)
 
 	// Emit must run with a plugin-actor context so the emitter resolves
 	// an actor; ActorPlugin matches the manifest's actor_kinds_claimable.

--- a/internal/testsupport/integrationtest/crypto.go
+++ b/internal/testsupport/integrationtest/crypto.go
@@ -43,10 +43,11 @@ import (
 // WithPluginCrypto wires the full plugin-crypto round-trip (emit fence → publish
 // encrypt → audit projection → read-back) into the harness. REQUIRES
 // WithInTreePlugins (the emitter, per-plugin consumer, and read-back decryptor
-// all need the loaded Manager). Assumes crypto-CORRECT plugins: WithCryptoEnabled
-// is global to the shared emitter, so a loaded plugin that emits
-// sensitivity:always content without claiming Sensitive=true would reject (spec
-// §6.2). Drive only crypto-correct plugins (e.g. core-scenes) under this option.
+// all need the loaded Manager). Assumes crypto-CORRECT plugins: the host-side
+// sensitivity fence runs unconditionally on the shared emitter, so a loaded
+// plugin that emits sensitivity:always content without claiming Sensitive=true
+// would reject (spec §6.2). Drive only crypto-correct plugins (e.g. core-scenes)
+// under this option.
 func WithPluginCrypto() StartOption {
 	return func(c *startConfig) { c.withPluginCrypto = true }
 }

--- a/internal/testsupport/integrationtest/plugins.go
+++ b/internal/testsupport/integrationtest/plugins.go
@@ -321,15 +321,14 @@ func startPlugins(t *testing.T, ctx context.Context, d pluginDeps) *pluginsetup.
 	// Wire the plugin event emitter to the crypto-enabled publisher when
 	// WithPluginCrypto supplied one. WithGameID takes a GameIDProvider
 	// (func() string), NOT a string (event_emitter.go:63-64) — wrap the
-	// captured gameID in a closure. WithCryptoEnabled(true) turns on the Phase
-	// 3a sensitivity fence so sensitivity:always emits (e.g. scene_pose) that
-	// claim Sensitive=true publish encrypted.
+	// captured gameID in a closure. The host-side sensitivity fence runs
+	// unconditionally (holomush-dj95.3), so sensitivity:always emits (e.g.
+	// scene_pose) that claim Sensitive=true publish encrypted.
 	if d.cryptoPublisher != nil {
 		gameID := d.gameID
 		ps.Manager().ConfigureEventEmitter(
 			d.cryptoPublisher,
 			plugins.WithGameID(func() string { return gameID }),
-			plugins.WithCryptoEnabled(true),
 		)
 	}
 	return ps

--- a/plugins/core-scenes/publish_scheduler_integration_test.go
+++ b/plugins/core-scenes/publish_scheduler_integration_test.go
@@ -76,7 +76,7 @@ func emitAndSeedIC(ctx context.Context, env *snapshotRealEnv, sceneID, eventType
 	actorFn := func(_ context.Context, _ string) (core.Actor, error) {
 		return core.Actor{Kind: core.ActorPlugin, ID: pluginActorID}, nil
 	}
-	emitter := plugins.NewPluginEventEmitter(env.pluginPub, manifestFn, actorFn, plugins.WithCryptoEnabled(true))
+	emitter := plugins.NewPluginEventEmitter(env.pluginPub, manifestFn, actorFn)
 	intent := pluginsdk.EmitIntent{
 		Subject:   icSubject, // DOT-STYLE .ic subject — AAD binds this exact string
 		Type:      pluginsdk.EventType(eventType),

--- a/plugins/core-scenes/publish_snapshot_integration_test.go
+++ b/plugins/core-scenes/publish_snapshot_integration_test.go
@@ -354,7 +354,7 @@ func (e *snapshotRealEnv) emitAndSeed(ctx context.Context, sceneID, eventType, p
 	actorFn := func(_ context.Context, _ string) (core.Actor, error) {
 		return core.Actor{Kind: core.ActorPlugin, ID: pluginActorID}, nil
 	}
-	emitter := plugins.NewPluginEventEmitter(e.pluginPub, manifestFn, actorFn, plugins.WithCryptoEnabled(true))
+	emitter := plugins.NewPluginEventEmitter(e.pluginPub, manifestFn, actorFn)
 	intent := pluginsdk.EmitIntent{
 		Subject:   "scene." + sceneID,
 		Type:      pluginsdk.EventType(eventType), // bare type — mirrors production (commands.go:516)

--- a/test/integration/crypto/e2e_test.go
+++ b/test/integration/crypto/e2e_test.go
@@ -214,7 +214,6 @@ func emitSensitivePluginEvent(
 	}
 	emitter := plugins.NewPluginEventEmitter(
 		env.publisher, manifestLookup, actorResolver,
-		plugins.WithCryptoEnabled(true),
 	)
 	intent := pluginsdk.EmitIntent{
 		Subject:   subject,

--- a/test/integration/crypto/emit_test.go
+++ b/test/integration/crypto/emit_test.go
@@ -143,11 +143,10 @@ var _ = Describe("Sensitive emit produces ciphertext on bus and in audit (INV-CR
 		// projection requires; it is the single writer of that header.
 		hostPub := eventbus.NewRenderingPublisher(rawPub, registry)
 
-		// Phase 3a sensitivity fence is gated behind WithCryptoEnabled —
-		// this E2E exercises the enabled path end-to-end (encrypt + audit).
+		// The host-side sensitivity fence runs unconditionally; this E2E
+		// exercises the encrypt + audit path end-to-end.
 		emitter := plugins.NewPluginEventEmitter(
 			hostPub, manifestLookup, actorResolver,
-			plugins.WithCryptoEnabled(true),
 		)
 
 		const plaintext = `{"text":"hello, secret world"}`

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -231,7 +231,6 @@ var _ = Describe("Subscribe with non-participant identity delivers MetadataOnly 
 		}
 		emitter := plugins.NewPluginEventEmitter(
 			h.publisher, manifestLookup, actorResolver,
-			plugins.WithCryptoEnabled(true),
 		)
 
 		const plaintext = `{"text":"secret message for participant only"}`
@@ -332,7 +331,6 @@ var _ = Describe("Subscribe with participant identity delivers plaintext (INV-CR
 		}
 		emitter := plugins.NewPluginEventEmitter(
 			h.publisher, manifestLookup, actorResolver,
-			plugins.WithCryptoEnabled(true),
 		)
 
 		const plaintext = `{"text":"hello participant"}`

--- a/test/integration/crypto/plugin_decrypt_test.go
+++ b/test/integration/crypto/plugin_decrypt_test.go
@@ -303,7 +303,6 @@ func emitSensitiveWhisper(t *testing.T, h *pluginDecryptHarness, sceneID, plaint
 	}
 	emitter := plugins.NewPluginEventEmitter(
 		h.publisher, manifestLookup, actorResolver,
-		plugins.WithCryptoEnabled(true),
 	)
 
 	intent := pluginsdk.EmitIntent{

--- a/test/integration/crypto/readback_test.go
+++ b/test/integration/crypto/readback_test.go
@@ -283,7 +283,6 @@ func emitSensitiveScenePose(
 	}
 	emitter := plugins.NewPluginEventEmitter(
 		env.pluginPub, manifestLookupFn, actorResolver,
-		plugins.WithCryptoEnabled(true),
 	)
 	intent := pluginsdk.EmitIntent{
 		Subject:   "scene." + sceneID,
@@ -568,7 +567,7 @@ func TestReadbackWithoutReadbackFlagDenied(t *testing.T) {
 	actorFn := func(_ context.Context, _ string) (core.Actor, error) {
 		return core.Actor{Kind: core.ActorPlugin, ID: pluginActorID}, nil
 	}
-	emitter := plugins.NewPluginEventEmitter(hostPub, manifestFn, actorFn, plugins.WithCryptoEnabled(true))
+	emitter := plugins.NewPluginEventEmitter(hostPub, manifestFn, actorFn)
 	intent := pluginsdk.EmitIntent{
 		Subject:   "scene." + sceneID,
 		Type:      pluginsdk.EventType(pluginName + ":scene_pose"),

--- a/test/integration/privacy/scene_history_readback_test.go
+++ b/test/integration/privacy/scene_history_readback_test.go
@@ -422,7 +422,6 @@ func emitSensitiveScenePoseForPrivacy(
 	}
 	emitter := plugins.NewPluginEventEmitter(
 		env.pluginPub, manifestLookupFn, actorResolver,
-		plugins.WithCryptoEnabled(true),
 	)
 	intent := pluginsdk.EmitIntent{
 		Subject:   "scene." + sceneID,


### PR DESCRIPTION
## Summary

Deletes the `plugins.WithCryptoEnabled` host-global flag that gated the emit-path sensitivity fence in `internal/plugin/event_emitter.go`. Default-off silently **bypassed** the fence and stamped `Sensitive=false`, ignoring a plugin manifest's `sensitivity: always` declaration — a security footgun (forgetting the flag ships sensitive payloads as plaintext).

The flag was a scaffold for when the plugin SDK couldn't surface `EmitIntent.Sensitive` over the wire. That plumbing has landed, and the precursor **`holomush-50zqs` (#4395)** made every production `sensitivity: always` plugin crypto-correct — so the fence can now run unconditionally with the manifest as the single source of truth.

## Changes

- **`event_emitter.go`** — remove the `WithCryptoEnabled` option + `cryptoEnabled` field; the fence (`LookupEmitSensitivity` → `EnforceSensitivity`) now runs on **every** emit. An under-claimed `always`-sensitive emit is **rejected** (`EVENT_SENSITIVITY_REQUIRED`, INV-PLUGIN-30) rather than silently shipped as plaintext.
- **`wire_crypto.go`** — `BuildPluginEmitter` drops the option (now config-agnostic).
- **~11 integration/harness emitter-construction sites** — drop `plugins.WithCryptoEnabled(true)` (these are `//go:build integration`, invisible to `task test`/`task build`).
- **Tests** — replace the obsolete `TestEmitterDoesNotRunFenceWhenCryptoDisabled` (asserted the removed bypass) with `TestEmitterRunsFenceUnconditionallyWithoutFlag`: `always`+claim=true → `Sensitive=true` with no flag; `always`+claim=false → `EVENT_SENSITIVITY_REQUIRED`.

## Scope boundary

The **separate** `grpc.WithCryptoEnabled` / `s.cryptoEnabled` read-side gate (binding lookup in `Subscribe`/`QueryStreamHistory`, `internal/grpc/`) is a different concern and is **left untouched**. The bead's verification step #2 (`rg WithCryptoEnabled internal/` → zero hits) is over-broad; zero hits in the emit-path surface (`internal/plugin`, `internal/bootstrap`).

## Test plan

- [x] `TestEmitterRunsFenceUnconditionallyWithoutFlag` (RED → GREEN)
- [x] Unit: `internal/plugin` + `internal/bootstrap` (1595 green)
- [x] Full integration suite — 9264 tests green (crypto, privacy, scenes, plugincrypto, wholesystem, …)
- [x] `task pr-prep` fast lane green
- [x] crypto-reviewer: READY · code-reviewer: READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)