### PR TITLE
feat(crypto): wire sensitive-event crypto into live publisher + subscriber (holomush-5rh.8.29)

### DIFF
--- a/.claude/agent-memory/abac-reviewer/MEMORY.md
+++ b/.claude/agent-memory/abac-reviewer/MEMORY.md
@@ -421,3 +421,26 @@ Accumulated patterns from prior reviews. Read at the start of each review; updat
   when a facade calls an UNCONDITIONAL substrate mutation that subscribes streams, the
   facade-side participation check is load-bearing — trace that it runs on EVERY path reaching
   the mutation, and that an oracle error fails closed (not skip).
+- **SetSceneFocus DEK-participant seed (5rh.8.29.4, 2026-06-09) — READY**: extends the .8.26
+  gate. After the participation gate → JoinFocus, seeds the focusing char into the scene DEK
+  participant set via `s.dekAdder.Add` (`sceneaccess_service.go:411-426`) so AuthGuard
+  `checkCharacter` (`guard.go:69-80`) permits decrypt. Order MUST be gate→JoinFocus→Add(fatal)
+  →SetConnectionFocus. Fatal on Add err = `codes.Internal` + NO SetConnectionFocus (test pins
+  `setConnFocusCall==0`). KEY INSIGHT: AuthGuard `checkCharacter` permits decrypt on
+  DEK-participant-set membership ALONE (binding_id match) — NOT on focused connection or
+  FocusMembership. So a dangling DEK-participant entry (after a fatal SetConnectionFocus) DOES
+  confer standalone decrypt capability — but it's benign because the participation gate already
+  authorized that char to decrypt the scene, and no-focus = no stream = no ciphertext to decrypt.
+  Idempotent Add (`manager.go:357-359` added=false) self-heals on retry. `s.dekAdder==nil` is a
+  legit degraded mode (T5 wires only when `RekeyManager != nil`, i.e. crypto stack present), NOT
+  a bypass — no crypto stack = no encrypted events = nothing to gate. Identity: `gameSession.CharacterID`
+  is `session.Info.CharacterID` (session.go:203, server-stored), validated by
+  `ownedCharacter(ps.PlayerID, ...)`; only `req.SceneId`/`req.ConnectionId` are client input.
+  ADR `holomush-mihtk` documents the fatal-refuse decision + benign-dangling rationale.
+  Two Lows: (1) `// Verifies: INV-CRYPTO-116` references a registry id NOT YET in invariants.yaml
+  — registered in plan Task 11 of the SAME epic (forward-ref within sequenced epic, NOT a
+  fabricated binding; orphaned master INV-8 being registered); (2) dangling DEK-participant residue
+  is broader than the plan's "dangling FocusMembership" framing but equally benign. Pattern: when
+  a host facade seeds a crypto-participant set, the AuthGuard char-branch gates on set-membership
+  alone — confirm the seed is preceded by an authz gate that ALREADY licenses decrypt, else the
+  seed over-grants.

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -161,6 +161,47 @@ func (s *grpcSubsystem) DependsOn() []lifecycle.SubsystemID {
 	}
 }
 
+// publisherOptionsFor returns the PublishOptions for the live publisher.
+// When a DEK manager (RekeyManager) is configured, the publisher is DEK-aware
+// so Sensitive=true events take the encrypt branch (publisher.go:208); when
+// nil, the publisher stays plaintext-only and the subsystem still starts
+// (degraded-but-safe for KEK-less deployments).
+func publisherOptionsFor(cfg grpcSubsystemConfig) []eventbus.PublishOption {
+	if cfg.RekeyManager == nil {
+		return nil
+	}
+	return []eventbus.PublishOption{eventbus.WithDEKManager(cfg.RekeyManager)}
+}
+
+// subscriberOptionsFor returns the SubscribeOptions for the live subscriber.
+// When the AuthGuard is present (KEK configured), the subscriber decodes and
+// authorizes sensitive events (subscriber.go:505 decodeAndAuthorize),
+// delivering plaintext to DEK participants and metadata-only to others. When
+// the guard is nil, the bare subscriber preserves the pre-flag-flip
+// passthrough (subscriber.go:514).
+func subscriberOptionsFor(
+	guard eventbus.SessionAuthGuard,
+	dekMgr eventbus.SessionDEKManager,
+	auditEm eventbus.SessionAuditEmitter,
+) []eventbus.SubscribeOption {
+	// Require both guard and dekMgr: a guard without a DEK manager is a
+	// half-configured decrypt path. This mirrors newHistoryReader's
+	// all-or-nothing contract (see this file's newHistoryReader doc); the
+	// inner fail-closed at subscriber.go:645 (EVENTBUS_DEK_MANAGER_NIL) is the
+	// deeper guard if the subscriber is ever built directly without this seam.
+	if guard == nil || dekMgr == nil {
+		return nil
+	}
+	opts := []eventbus.SubscribeOption{
+		eventbus.WithSubscriberAuthGuard(guard),
+		eventbus.WithSubscriberDEKManager(dekMgr),
+	}
+	if auditEm != nil {
+		opts = append(opts, eventbus.WithSubscriberDecryptAuditEmitter(auditEm))
+	}
+	return opts
+}
+
 // Start wires all dependencies and starts the gRPC server.
 // Start is idempotent: if the gRPC server is already running, it returns nil.
 // codecov:ignore — tested by integration and E2E tests
@@ -200,7 +241,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 		return oops.Code("GRPC_EVENTBUS_MISSING").
 			Errorf("gRPC subsystem requires EventBus subsystem for plugin emit routing")
 	}
-	rawPublisher := s.cfg.EventBus.Publisher()
+	rawPublisher := s.cfg.EventBus.Publisher(publisherOptionsFor(s.cfg)...)
 	if rawPublisher == nil {
 		return oops.Code("GRPC_EVENTBUS_NOT_STARTED").
 			Errorf("EventBus publisher is nil; subsystem not started")
@@ -317,16 +358,6 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 	}
 
 	// 8. Create CoreServer and register with gRPC.
-	// F3: wire the JetStream event bus subscriber into the Subscribe RPC.
-	// The bus owns per-session durable consumers; the gRPC handler pumps
-	// deliveries through Send → Ack. EventBus subsystem is a DependsOn
-	// above, so Subscriber is guaranteed non-nil by the time Start runs.
-	subscriber := s.cfg.EventBus.Subscriber()
-	if subscriber == nil {
-		return oops.Code("GRPC_EVENTBUS_SUBSCRIBER_NIL").
-			Errorf("EventBus subscriber is nil; subsystem not started")
-	}
-
 	// F4: wire the JetStream/PostgreSQL tier crossover history reader into
 	// QueryStreamHistory. Both the JetStream context and the PG pool are
 	// in scope here, making Option B the natural construction site. The
@@ -371,6 +402,22 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 				}
 			}
 		}
+	}
+
+	// F3 / Phase 3d flag flip (holomush-5rh.8.29): wire the JetStream event bus
+	// subscriber into the Subscribe RPC. The bus owns per-session durable
+	// consumers; the gRPC handler pumps deliveries through Send → Ack. The
+	// subscriber is built AFTER the AuthGuard/DEK/audit triad is resolved so
+	// decode-on-fan-out can decrypt sensitive events for DEK participants. When
+	// KEK is absent (historyAuthGuard==nil) the bare subscriber preserves the
+	// pre-flag-flip passthrough. EventBus subsystem is a DependsOn above, so
+	// Subscriber is guaranteed non-nil by the time Start runs.
+	subscriber := s.cfg.EventBus.Subscriber(
+		subscriberOptionsFor(historyAuthGuard, historyDEKMgr, historyAuditEm)...,
+	)
+	if subscriber == nil {
+		return oops.Code("GRPC_EVENTBUS_SUBSCRIBER_NIL").
+			Errorf("EventBus subscriber is nil; subsystem not started")
 	}
 
 	// Phase 7 INV-CRYPTO-42 + INV-CRYPTO-50: assemble the PluginDowngradeFence
@@ -518,7 +565,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 	const sceneServiceName = "holomush.scene.v1.SceneService"
 	var sceneAccessSrv sceneaccessv1.SceneAccessServiceServer
 	if sceneSvc, resolveErr := serviceRegistry.Resolve(sceneServiceName); resolveErr == nil {
-		sceneAccessSrv = holoGRPC.NewSceneAccessServer(
+		saSrv := holoGRPC.NewSceneAccessServer(
 			authPlayerSessionRepo,
 			authPlayerRepo,
 			authCharRepo,
@@ -527,6 +574,14 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 			scenev1.NewSceneServiceClient(sceneSvc.Conn),
 			pluginManager,
 		)
+		// Seed DEK participants on SetSceneFocus when the KEK/DEK stack is
+		// present so the AuthGuard permits decryption of sensitive scene
+		// events for the focusing session (holomush-5rh.8.29). Gated on
+		// RekeyManager != nil to mirror the publisher/subscriber gating.
+		if s.cfg.RekeyManager != nil {
+			saSrv.WithSceneDEKAdder(s.cfg.RekeyManager)
+		}
+		sceneAccessSrv = saSrv
 		slog.InfoContext(ctx, "sceneAccessService facade registered")
 	} else {
 		slog.WarnContext(ctx, "sceneAccessService unavailable: plugin absent", "service", sceneServiceName)

--- a/cmd/holomush/sub_grpc_test.go
+++ b/cmd/holomush/sub_grpc_test.go
@@ -14,9 +14,34 @@ import (
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/codec"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	"github.com/holomush/holomush/internal/lifecycle"
 	"github.com/holomush/holomush/pkg/errutil"
 )
+
+// stubDEKManager satisfies dek.Manager via embedding; its methods are nil and
+// unused — these tests only assert option construction, never invoke the manager.
+type stubDEKManager struct{ dek.Manager }
+
+// stubSessionAuthGuard / stubSessionAuditEmitter satisfy their interfaces via
+// embedding; methods are nil and unused — subscriber-option tests only assert
+// construction, never invoke the guard or emitter.
+type (
+	stubSessionAuthGuard    struct{ eventbus.SessionAuthGuard }
+	stubSessionAuditEmitter struct{ eventbus.SessionAuditEmitter }
+)
+
+// Verifies: INV-CRYPTO-117
+func TestPublisherOptionsIncludeDEKManagerWhenRekeySet(t *testing.T) {
+	cfg := grpcSubsystemConfig{RekeyManager: &stubDEKManager{}}
+	require.Len(t, publisherOptionsFor(cfg), 1, "RekeyManager set ⇒ exactly the WithDEKManager option")
+}
+
+// Verifies: INV-CRYPTO-117
+func TestPublisherOptionsEmptyWhenRekeyNil(t *testing.T) {
+	require.Empty(t, publisherOptionsFor(grpcSubsystemConfig{RekeyManager: nil}),
+		"no KEK ⇒ plaintext-only publisher, no DEK option")
+}
 
 // TestGRPCSubsystemImplementsSubsystem is a compile-time interface check.
 func TestGRPCSubsystemImplementsSubsystem(_ *testing.T) {
@@ -197,4 +222,22 @@ type grpcTestAuditEmitter struct{}
 
 func (s *grpcTestAuditEmitter) EmitPluginDecrypt(_ context.Context, _ eventbus.PluginDecryptRecord) error {
 	return nil
+}
+
+// Verifies: INV-CRYPTO-117
+func TestSubscriberOptionsIncludeAuthGuardWhenGuardPresent(t *testing.T) {
+	opts := subscriberOptionsFor(stubSessionAuthGuard{}, &stubDEKManager{}, stubSessionAuditEmitter{})
+	require.Len(t, opts, 3, "guard present ⇒ AuthGuard + DEKManager + DecryptAuditEmitter")
+}
+
+// Verifies: INV-CRYPTO-117
+func TestSubscriberOptionsEmptyWhenGuardNil(t *testing.T) {
+	require.Empty(t, subscriberOptionsFor(nil, nil, nil),
+		"no guard ⇒ bare subscriber preserves guard==nil passthrough")
+}
+
+// Verifies: INV-CRYPTO-117
+func TestSubscriberOptionsEmptyWhenGuardPresentButDEKManagerNil(t *testing.T) {
+	require.Empty(t, subscriberOptionsFor(stubSessionAuthGuard{}, nil, stubSessionAuditEmitter{}),
+		"guard without a DEK manager is a half-configured decrypt path ⇒ all-or-nothing returns no options")
 }

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -55,7 +55,7 @@ invariants.
 | `INV-CRYPTO-3` | NewReader MUST forward accumulated hotOpts to newJetStreamHotTier when building the default hot tier. | `INV-3` | pending |
 | `INV-CRYPTO-4` | WithCryptoHot MUST be a no-op when WithHotTier is also supplied — crypto options are not forwarded to a custom tier. | `INV-4` | pending |
 | `INV-CRYPTO-5` | newHistoryReader(nil, nil, nil) MUST preserve the existing nil-auth passthrough behavior (no auth option appended). | `INV-6` | pending |
-| `INV-CRYPTO-6` | A subject NOT in a DEK's participant set MUST NOT receive plaintext via fan-out, even when subscribed to the matching subject. | `INV-9` | pending |
+| `INV-CRYPTO-6` | A subject NOT in a DEK's participant set MUST NOT receive plaintext via fan-out, even when subscribed to the matching subject. | `INV-9` | bound |
 | `INV-CRYPTO-7` | Add(participant) MUST grant immediate read access to all existing DEK history without rotating the DEK. | `INV-12` | bound |
 | `INV-CRYPTO-8` | Rotate(context) MUST preserve the old DEK ciphertext and old DEK record unchanged (holds under Phase 3c soft-delete). | `INV-13` | pending |
 | `INV-CRYPTO-9` | A plugin without manifest requests_decryption for an event class MUST receive metadata-only delivery, regardless of subject subscription. | `INV-17` | bound |
@@ -165,6 +165,8 @@ invariants.
 | `INV-CRYPTO-113` | Every registered auditchain.Chain's SubjectFor(scope) MUST return a string starting with events.<game>. so chain-bearing audit events reach events_audit via the EVENTS JetStream events.> SubjectFilter. | `INV-E26` | pending |
 | `INV-CRYPTO-114` | Every registered auditchain.Chain MUST populate ScopeFromPayload; the verifier MUST reject with AUDIT_CHAIN_SCOPE_MISMATCH any row where ScopeFromSubject(subject) != ScopeFromPayload(payload). | `INV-E27` | pending |
 | `INV-CRYPTO-115` | The auditchain.Verifier self-hash recompute MUST be SHA-256(Canonicalize(zero(payload, SelfHashFieldName))); SHA-256 and composition order are pinned at the primitive level, while per-chain Canonicalize MAY apply domain normalization (e.g. PolicySetChain renormalizes empty PrevHash → nil to preserve INV-CRYPTO-77 semantics). | `INV-E28` | pending |
+| `INV-CRYPTO-116` | A subject in a DEK's participant set MUST receive plaintext via live fan-out when policy permits. | `INV-8` | bound |
+| `INV-CRYPTO-117` | When RekeyManager is non-nil the production gRPC subsystem MUST build the live Publisher DEK-aware and the live Subscriber AuthGuard-wired; when nil, both MUST preserve plaintext/passthrough and the subsystem MUST start. | — | bound |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -771,7 +771,9 @@ invariants:
     legacy: ["INV-9@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
     summary: "A subject NOT in a DEK's participant set MUST NOT receive plaintext via fan-out, even when subscribed to the
       matching subject."
-    binding: pending
+    asserted_by:
+      - "test/integration/crypto/metadata_only_test.go"
+    binding: bound
     refs:
       - {file: "test/integration/crypto/metadata_only_test.go", token: "INV-9"}
   - id: INV-CRYPTO-7
@@ -4355,3 +4357,23 @@ invariants:
       - {file: "internal/eventbus/crypto/dek/audit_chain_internal_test.go", token: "INV-E28"}
       - {file: "internal/eventbus/crypto/dek/audit_chain_test.go", token: "INV-E28"}
       - {file: "internal/eventbus/crypto/dek/rekey_phase7.go", token: "INV-E28"}
+  - id: INV-CRYPTO-116
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-08-sensitive-event-crypto-production-golive-design.md"
+    legacy: ["INV-8@docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"]
+    summary: "A subject in a DEK's participant set MUST receive plaintext via live fan-out when policy permits."
+    asserted_by:
+      - "test/integration/crypto/genesis_seed_test.go"
+    binding: bound
+    refs:
+      - {file: "test/integration/crypto/genesis_seed_test.go", token: "INV-CRYPTO-116"}
+  - id: INV-CRYPTO-117
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-08-sensitive-event-crypto-production-golive-design.md"
+    summary: "When RekeyManager is non-nil the production gRPC subsystem MUST build the live Publisher DEK-aware and the live
+      Subscriber AuthGuard-wired; when nil, both MUST preserve plaintext/passthrough and the subsystem MUST start."
+    asserted_by:
+      - "cmd/holomush/sub_grpc_test.go"
+    binding: bound
+    refs:
+      - {file: "cmd/holomush/sub_grpc_test.go", token: "INV-CRYPTO-117"}

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -233,6 +233,26 @@ func (m *manager) GetOrCreate(ctx context.Context, ctxID ContextID, initial []Pa
 	if validateErr := validateProviderWrapOutput(wrapped, kekKeyID); validateErr != nil {
 		return codec.Key{}, validateErr
 	}
+	// Resolve any participant supplied without a BindingID (e.g. the publisher's
+	// genesis-seed for a character.<id> context). Pre-bound participants pass
+	// through unchanged. m.bindings is guaranteed non-nil (NewManager:175).
+	// Mirrors the resolution Add performs (manager.go:364). Genesis-only: the
+	// active-row short-circuit above means this never runs once the DEK exists.
+	resolved := initial
+	if len(initial) > 0 {
+		resolved = make([]Participant, len(initial))
+		for i, p := range initial {
+			if p.BindingID == "" {
+				bindingID, bErr := m.bindings.Current(ctx, p.CharacterID)
+				if bErr != nil {
+					return codec.Key{}, oops.Code("DEK_BINDING_RESOLVE_FAILED").
+						With("character_id", p.CharacterID).Wrap(bErr)
+				}
+				p.BindingID = bindingID
+			}
+			resolved[i] = p
+		}
+	}
 	in := row{
 		ContextType:  ctxID.Type,
 		ContextID:    ctxID.ID,
@@ -240,7 +260,7 @@ func (m *manager) GetOrCreate(ctx context.Context, ctxID ContextID, initial []Pa
 		WrappedDEK:   wrapped,
 		WrapProvider: m.provider.Name(),
 		WrapKeyID:    kekKeyID,
-		Participants: initial,
+		Participants: resolved,
 	}
 	id, err := m.store.insert(ctx, in)
 	if err != nil {
@@ -264,7 +284,7 @@ func (m *manager) GetOrCreate(ctx context.Context, ctxID ContextID, initial []Pa
 	m.cache.Put(CacheKey{KeyID: keyID, Version: 1}, ctxID, material)
 	m.partCache.Put(
 		ParticipantsCacheKey{ContextType: ctxID.Type, ContextID: ctxID.ID, Version: 1},
-		initial,
+		resolved,
 	)
 	return material.AsCodecKey(keyID, 1), nil
 }

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -276,6 +276,33 @@ var _ = Describe("Manager", func() {
 			"INV-STORE-1: JoinedAt ns precision MUST survive round-trip")
 	})
 
+	It("resolves an empty BindingID on genesis via the BindingResolver", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		const wantBinding = "01RESOLVEDBINDING0000000"
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache,
+			noopInvalidator, &stubBindingResolver{bindingID: wantBinding})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "character", ID: "01HRECIPIENTCHAR000000000"}
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{{CharacterID: "01HRECIPIENTCHAR000000000"}})
+		Expect(err).NotTo(HaveOccurred())
+
+		parts, err := mgr.Participants(ctx, key.ID, key.Version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].BindingID).To(Equal(wantBinding),
+			"genesis must resolve empty BindingID via BindingResolver.Current")
+	})
+
 	It("Participants not found returns DEK_NOT_FOUND", func() {
 		ctx := context.Background()
 		connStr, teardown := newTestPGPool(suiteT)

--- a/internal/eventbus/publisher.go
+++ b/internal/eventbus/publisher.go
@@ -135,7 +135,8 @@ type JetStreamPublisher struct {
 	// nil → publisher rejects sensitive events with
 	// EVENTBUS_SENSITIVE_EVENT_NO_DEK_MANAGER and takes the legacy
 	// identity/selector path for non-sensitive events. Wired via
-	// WithDEKManager; bootstrap supplies it when CryptoConfig.Enabled.
+	// WithDEKManager; bootstrap supplies it when a KEK is configured
+	// (RekeyManager present) — not gated on CryptoConfig.Enabled.
 	dekMgr DEKManager
 }
 
@@ -212,7 +213,7 @@ func (p *JetStreamPublisher) Publish(ctx context.Context, event Event) error {
 				With("subject", string(event.Subject)).
 				Wrap(ctxErr)
 		}
-		k, dekErr := p.dekMgr.GetOrCreate(ctx, ctxID, nil)
+		k, dekErr := p.dekMgr.GetOrCreate(ctx, ctxID, initialParticipantsForContext(ctxID))
 		if dekErr != nil {
 			return oops.Code("EVENTBUS_DEK_GETORCREATE_FAILED").
 				With("subject", string(event.Subject)).
@@ -488,6 +489,24 @@ func (identityKeySelector) SelectForEncrypt(_ context.Context, _ string) (codec.
 
 func (identityKeySelector) SelectForDecrypt(_ context.Context, _ codec.Name, _ codec.KeyID) (codec.Key, error) {
 	return codec.NoKey, nil
+}
+
+// initialParticipantsForContext returns the DEK participant set to seed at
+// genesis for a context, derived from the subject. A character.<id> context is
+// a personal stream whose owner (the recipient of a private message —
+// page/whisper/pemit) must be able to decrypt, so seed that character. The
+// BindingID is left empty; GetOrCreate resolves it via the BindingResolver on
+// its create branch (manager.go). Scene and other contexts seed nothing here
+// (scene readers are seeded at SetSceneFocus).
+func initialParticipantsForContext(ctxID dek.ContextID) []dek.Participant {
+	if ctxID.Type != "character" {
+		return nil
+	}
+	return []dek.Participant{{
+		CharacterID: ctxID.ID,
+		JoinedAt:    time.Now().UTC(),
+		AddedVia:    "publisher.genesis",
+	}}
 }
 
 // contextIDFromSubject derives a dek.ContextID from a NATS-native subject

--- a/internal/eventbus/publisher_internal_test.go
+++ b/internal/eventbus/publisher_internal_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build !integration
+
+package eventbus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+)
+
+func TestInitialParticipantsForContextCharacterSeedsRecipient(t *testing.T) {
+	got := initialParticipantsForContext(dek.ContextID{Type: "character", ID: "01HRECIPIENT0000000000000000"})
+	require.Len(t, got, 1)
+	require.Equal(t, "01HRECIPIENT0000000000000000", got[0].CharacterID)
+	require.Empty(t, got[0].BindingID, "binding resolved downstream in GetOrCreate, not here")
+}
+
+func TestInitialParticipantsForContextSceneIsNil(t *testing.T) {
+	require.Nil(t, initialParticipantsForContext(dek.ContextID{Type: "scene", ID: "01HSCENE"}))
+}
+
+func TestInitialParticipantsForContextOtherIsNil(t *testing.T) {
+	require.Nil(t, initialParticipantsForContext(dek.ContextID{Type: "location", ID: "01HLOC"}))
+}

--- a/internal/grpc/sceneaccess_service.go
+++ b/internal/grpc/sceneaccess_service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/holomush/holomush/internal/auth"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	holoFocus "github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/session"
 	"github.com/holomush/holomush/internal/world"
@@ -26,6 +28,13 @@ import (
 // the plugin manager — only BeginServiceDispatch.
 type sceneAccessPluginManager interface {
 	BeginServiceDispatch(ctx context.Context, pluginName string, actor core.Actor, ownerPlayerID string) (context.Context, func(), error)
+}
+
+// sceneDEKAdder seeds a character as a DEK participant so the AuthGuard's
+// hot-tier checkCharacter branch permits this session to decrypt sensitive
+// scene events (e.g. scene_pose). Satisfied by dek.Manager (its Add method).
+type sceneDEKAdder interface {
+	Add(ctx context.Context, ctxID dek.ContextID, p dek.Participant) error
 }
 
 // SceneAccessServer is the host-side facade that owns player authentication,
@@ -43,6 +52,12 @@ type SceneAccessServer struct {
 	coordinator       holoFocus.Coordinator
 	sceneClient       scenev1.SceneServiceClient
 	pluginManager     sceneAccessPluginManager
+
+	// dekAdder is optional. When non-nil, SetSceneFocus seeds the focusing
+	// character as a DEK participant after the participation gate passes, so
+	// the AuthGuard permits decryption of sensitive scene events. nil disables
+	// seeding (KEK-less deployments / tests).
+	dekAdder sceneDEKAdder
 }
 
 // NewSceneAccessServer constructs a SceneAccessServer. All fields are required;
@@ -65,6 +80,13 @@ func NewSceneAccessServer(
 		sceneClient:       sceneClient,
 		pluginManager:     pluginManager,
 	}
+}
+
+// WithSceneDEKAdder attaches a DEK participant adder. Call after construction;
+// when set, SetSceneFocus seeds the focusing character as a DEK participant
+// (fatal on failure).
+func (s *SceneAccessServer) WithSceneDEKAdder(a sceneDEKAdder) {
+	s.dekAdder = a
 }
 
 // ownedCharacter verifies that charIDStr is a valid ULID and is owned by
@@ -376,6 +398,31 @@ func (s *SceneAccessServer) SetSceneFocus(ctx context.Context, req *sceneaccessv
 				return nil, status.Error(codes.Internal, "internal error") //nolint:wrapcheck // gRPC status error at handler boundary
 			}
 			// FOCUS_ALREADY_MEMBER — membership already present; proceed to SetConnectionFocus.
+		}
+
+		// Seed the character as a DEK participant so the AuthGuard hot-tier
+		// permits this session to decrypt sensitive scene events (scene_pose,
+		// scene_say, scene_emit, scene_ooc). FATAL: if the seed fails the
+		// connection MUST NOT be focused — a focused connection that cannot
+		// decrypt would receive blank (metadata-only) poses. Refusing focus
+		// surfaces the error so the client retries; Add is idempotent
+		// (manager.go:377) so retry is a safe no-op. (Invariant: a connection
+		// is focused on a scene only if its character can decrypt that scene.)
+		if s.dekAdder != nil {
+			ctxID := dek.ContextID{Type: "scene", ID: sceneIDStr}
+			addErr := s.dekAdder.Add(ctx, ctxID, dek.Participant{
+				PlayerID:    ps.PlayerID.String(),
+				CharacterID: gameSession.CharacterID.String(),
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "sceneaccess.SetSceneFocus",
+			})
+			if addErr != nil {
+				slog.ErrorContext(ctx, "scene access: SetSceneFocus DEK seed failed",
+					"scene_id", sceneIDStr,
+					"character_id", gameSession.CharacterID.String(),
+					"error", addErr)
+				return nil, status.Error(codes.Internal, "internal error") //nolint:wrapcheck // gRPC status error at handler boundary
+			}
 		}
 	}
 

--- a/internal/grpc/sceneaccess_service_test.go
+++ b/internal/grpc/sceneaccess_service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/oops"
@@ -19,6 +20,7 @@ import (
 	"github.com/holomush/holomush/internal/auth"
 	authmocks "github.com/holomush/holomush/internal/auth/mocks"
 	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
 	holoFocus "github.com/holomush/holomush/internal/grpc/focus"
 	"github.com/holomush/holomush/internal/grpc/scenemocks"
 	"github.com/holomush/holomush/internal/idgen"
@@ -28,6 +30,16 @@ import (
 	scenev1 "github.com/holomush/holomush/pkg/proto/holomush/scene/v1"
 	sceneaccessv1 "github.com/holomush/holomush/pkg/proto/holomush/sceneaccess/v1"
 )
+
+func TestWithSceneDEKAdderSetsField(t *testing.T) {
+	s := &SceneAccessServer{}
+	s.WithSceneDEKAdder(stubSceneDEKAdder{})
+	require.NotNil(t, s.dekAdder, "WithSceneDEKAdder must set the dekAdder field")
+}
+
+type stubSceneDEKAdder struct{}
+
+func (stubSceneDEKAdder) Add(_ context.Context, _ dek.ContextID, _ dek.Participant) error { return nil }
 
 const testSAToken = "test-scene-access-token"
 
@@ -52,9 +64,10 @@ func buildSASessionRepo(t *testing.T, ps *auth.PlayerSession) *authmocks.MockPla
 
 // stubFocusCoordinator is a minimal Coordinator stub that records calls.
 type stubFocusCoordinator struct {
-	setConnFocusErr error
-	joinFocusErr    error
-	joinFocusCalls  int
+	setConnFocusErr  error
+	joinFocusErr     error
+	joinFocusCalls   int
+	setConnFocusCall int
 }
 
 func (s *stubFocusCoordinator) JoinFocus(_ context.Context, _ string, _ session.FocusKey) error {
@@ -87,6 +100,7 @@ func (s *stubFocusCoordinator) RestoreConnectionFocus(_ context.Context, _ strin
 }
 
 func (s *stubFocusCoordinator) SetConnectionFocus(_ context.Context, _ ulid.ULID, _ *session.FocusKey, _ bool) (holoFocus.SetConnectionFocusResult, error) {
+	s.setConnFocusCall++
 	return holoFocus.SetConnectionFocusResult{}, s.setConnFocusErr
 }
 
@@ -589,6 +603,114 @@ func TestSetSceneFocusJoinsFocusThenSetsConnectionFocus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, coord.joinFocusCalls,
 		"JoinFocus MUST be called exactly once for a valid participant")
+}
+
+// failingSceneDEKAdder is a sceneDEKAdder whose Add always fails, used to drive
+// the fatal-seed branch of SetSceneFocus.
+type failingSceneDEKAdder struct{}
+
+func (failingSceneDEKAdder) Add(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+	return oops.Code("DEK_ADD_FAILED").Errorf("seed failed")
+}
+
+// capturingSceneDEKAdder records the (ctxID, participant) passed to Add so tests
+// can assert the seeded values.
+type capturingSceneDEKAdder struct {
+	called   bool
+	gotCtxID dek.ContextID
+	gotPart  dek.Participant
+}
+
+func (c *capturingSceneDEKAdder) Add(_ context.Context, ctxID dek.ContextID, p dek.Participant) error {
+	c.called = true
+	c.gotCtxID = ctxID
+	c.gotPart = p
+	return nil
+}
+
+// TestSetSceneFocusReturnsInternalWhenDEKSeedFails verifies the fatal-seed
+// contract: when a dekAdder is attached and its Add fails, SetSceneFocus returns
+// codes.Internal and MUST NOT proceed to SetConnectionFocus — a focused
+// connection that cannot decrypt would receive blank (metadata-only) poses.
+func TestSetSceneFocusReturnsInternalWhenDEKSeedFails(t *testing.T) {
+	ctx := context.Background()
+	coord := &stubFocusCoordinator{}
+	sceneMock := scenemocks.NewMockSceneServiceClient(t)
+
+	srv, charID, connID := buildSetSceneFocusServer(t, coord, sceneMock)
+	srv.WithSceneDEKAdder(failingSceneDEKAdder{})
+
+	sceneID := idgen.New()
+	sceneInfo := &scenev1.SceneInfo{Id: sceneID.String()}
+	sceneMock.EXPECT().ListCharacterScenes(mock.Anything, mock.MatchedBy(func(req *scenev1.ListCharacterScenesRequest) bool {
+		return req.GetCharacterId() == charID.String()
+	})).Return(
+		&scenev1.ListCharacterScenesResponse{
+			Scenes: []*scenev1.CharacterSceneInfo{
+				{Scene: sceneInfo},
+			},
+		}, nil,
+	).Once()
+
+	_, err := srv.SetSceneFocus(ctx, &sceneaccessv1.SetSceneFocusRequest{
+		PlayerSessionToken: testSAToken,
+		ConnectionId:       connID.String(),
+		SceneId:            sceneID.String(),
+	})
+
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err),
+		"a failed DEK seed MUST surface as Internal")
+	require.Equal(t, 1, coord.joinFocusCalls,
+		"the seed runs AFTER JoinFocus — JoinFocus must have been called once")
+	require.Equal(t, 0, coord.setConnFocusCall,
+		"a fatal DEK seed MUST refuse focus — SetConnectionFocus must not run")
+}
+
+// TestSetSceneFocusSeedsParticipantThenSetsConnectionFocus verifies the happy
+// path with a dekAdder attached: the focusing character is seeded as a DEK
+// participant on context {scene, sceneID} with a populated JoinedAt and
+// AddedVia, and only then is SetConnectionFocus called.
+func TestSetSceneFocusSeedsParticipantThenSetsConnectionFocus(t *testing.T) {
+	ctx := context.Background()
+	coord := &stubFocusCoordinator{}
+	sceneMock := scenemocks.NewMockSceneServiceClient(t)
+
+	srv, charID, connID := buildSetSceneFocusServer(t, coord, sceneMock)
+	adder := &capturingSceneDEKAdder{}
+	srv.WithSceneDEKAdder(adder)
+
+	sceneID := idgen.New()
+	sceneInfo := &scenev1.SceneInfo{Id: sceneID.String()}
+	sceneMock.EXPECT().ListCharacterScenes(mock.Anything, mock.MatchedBy(func(req *scenev1.ListCharacterScenesRequest) bool {
+		return req.GetCharacterId() == charID.String()
+	})).Return(
+		&scenev1.ListCharacterScenesResponse{
+			Scenes: []*scenev1.CharacterSceneInfo{
+				{Scene: sceneInfo},
+			},
+		}, nil,
+	).Once()
+
+	_, err := srv.SetSceneFocus(ctx, &sceneaccessv1.SetSceneFocusRequest{
+		PlayerSessionToken: testSAToken,
+		ConnectionId:       connID.String(),
+		SceneId:            sceneID.String(),
+	})
+
+	require.NoError(t, err)
+	require.True(t, adder.called, "the seed MUST run on the focus path")
+	require.Equal(t, dek.ContextID{Type: "scene", ID: sceneID.String()}, adder.gotCtxID,
+		"the DEK context MUST be {scene, sceneID}")
+	require.Equal(t, charID.String(), adder.gotPart.CharacterID,
+		"the seeded participant MUST carry the focusing character's ID")
+	require.False(t, adder.gotPart.JoinedAt.IsZero(),
+		"the seeded participant MUST carry a JoinedAt timestamp")
+	require.NotEmpty(t, adder.gotPart.AddedVia, "the seeded participant MUST carry an AddedVia provenance")
+	require.WithinDuration(t, time.Now(), adder.gotPart.JoinedAt, time.Minute,
+		"JoinedAt MUST be a recent UTC timestamp")
+	require.Equal(t, 1, coord.setConnFocusCall,
+		"a successful seed MUST proceed to SetConnectionFocus")
 }
 
 // TestSetSceneFocusTreatsFocusAlreadyMemberAsSuccess verifies idempotency: when

--- a/test/integration/crypto/genesis_seed_test.go
+++ b/test/integration/crypto/genesis_seed_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+// Package crypto_test — genesis DEK-seeding asymmetry integration coverage.
+//
+// This file proves the genesis-seed asymmetry end-to-end (INV-CRYPTO-116;
+// legacy provenance recorded in the registry):
+//
+//   - A character.<id> personal context auto-seeds its recipient at genesis
+//     (Task 6 + Task 7) → the recipient decrypts a sensitive page with NO
+//     pre-seed, while a third party (different binding) on the same stream
+//     receives metadata-only.
+//   - A scene.<id> context seeds no one at genesis → an unseeded subscriber
+//     receives metadata-only (scene readers are seeded only at SetSceneFocus).
+//
+// Subscriber decrypt mechanics for pre-seeded participants are covered by
+// metadata_only_test.go; this file proves the seeding, not the decode.
+package crypto_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/plugintest"
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+// Verifies: INV-CRYPTO-116
+var _ = Describe("Genesis DEK seeding asymmetry (character auto-seeds, scene does not)", func() {
+	It("a page recipient decrypts with NO pre-seed; a third party gets metadata-only", func() {
+		ctx := context.Background()
+		h := buildSubscribeHarness(suiteT)
+
+		recipientCharID := "01HRECIPIENTCHARACTER0000"
+		const (
+			recipientPlayerID = "01HRECIPIENTPLAYER000000"
+			thirdPlayerID     = "01HTHIRDPLAYER0000000000"
+			thirdCharacterID  = "01HTHIRDCHARACTER0000000"
+		)
+
+		// Emit a sensitive page to character.<recipient> with NO pre-seed. The
+		// publisher's genesis (Task 7) derives initial=[recipient]; GetOrCreate
+		// (Task 6) resolves the recipient's binding via the harness stub
+		// ("bind-metadata"), minting the DEK with the recipient as participant.
+		manifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"character"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
+			},
+		}
+		manifestLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return manifest
+			}
+			return nil
+		}
+		actorID := plugintest.PluginULIDFromName("test-plugin").String()
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{Kind: core.ActorPlugin, ID: actorID}, nil
+		}
+		emitter := plugins.NewPluginEventEmitter(h.publisher, manifestLookup, actorResolver)
+
+		const plaintext = `{"text":"a private page for the recipient only"}`
+		Expect(emitter.Emit(ctx, "test-plugin", pluginsdk.EmitIntent{
+			Subject:   "character." + recipientCharID,
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   plaintext,
+			Sensitive: true,
+		})).NotTo(HaveOccurred())
+
+		// Recipient identity uses the stub's resolved binding ("bind-metadata").
+		recipientID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    recipientPlayerID,
+			CharacterID: recipientCharID,
+			BindingID:   "bind-metadata",
+		}
+		recStream, err := h.subscriber.OpenSession(ctx, "recipient-"+recipientCharID, recipientID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = recStream.Close() })
+
+		rcv, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
+		d, err := recStream.Next(rcv)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery for recipient")
+		Expect(d.Ack()).NotTo(HaveOccurred())
+		Expect(d.MetadataOnly()).To(BeFalse(), "genesis auto-seeded the recipient")
+		Expect(d.Event().Payload).To(Equal([]byte(plaintext)), "INV-CRYPTO-116: recipient decrypts page")
+
+		// A third party (different binding) on the same stream gets metadata-only.
+		thirdID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    thirdPlayerID,
+			CharacterID: thirdCharacterID,
+			BindingID:   "bind-OTHER",
+		}
+		thirdStream, err := h.subscriber.OpenSession(ctx, "third-"+recipientCharID, thirdID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = thirdStream.Close() })
+
+		thirdRcv, thirdCancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer thirdCancel()
+		td, err := thirdStream.Next(thirdRcv)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery for third party")
+		Expect(td.Ack()).NotTo(HaveOccurred())
+		Expect(td.MetadataOnly()).To(BeTrue(), "non-recipient on the personal stream gets metadata-only")
+		Expect(td.Event().Payload).To(BeEmpty())
+	})
+
+	It("a scene context seeds no one at genesis (subscriber gets metadata-only with no pre-seed)", func() {
+		ctx := context.Background()
+		h := buildSubscribeHarness(suiteT)
+		sceneID := "01HXXXGENESISSCENE000001"
+
+		manifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"scene"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
+			},
+		}
+		manifestLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return manifest
+			}
+			return nil
+		}
+		actorID := plugintest.PluginULIDFromName("test-plugin").String()
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{Kind: core.ActorPlugin, ID: actorID}, nil
+		}
+		emitter := plugins.NewPluginEventEmitter(h.publisher, manifestLookup, actorResolver)
+
+		Expect(emitter.Emit(ctx, "test-plugin", pluginsdk.EmitIntent{
+			Subject:   "scene." + sceneID,
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   `{"text":"unseeded scene pose"}`,
+			Sensitive: true,
+		})).NotTo(HaveOccurred())
+
+		anyID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    "01HANYPLAYER000000000000",
+			CharacterID: "01HANYCHARACTER000000000",
+			BindingID:   "bind-metadata",
+		}
+		stream, err := h.subscriber.OpenSession(ctx, "any-"+sceneID, anyID, []eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = stream.Close() })
+
+		rcv, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
+		d, err := stream.Next(rcv)
+		Expect(err).NotTo(HaveOccurred(), "expected delivery for unseeded subscriber")
+		Expect(d.Ack()).NotTo(HaveOccurred())
+		Expect(d.MetadataOnly()).To(BeTrue(), "scene genesis seeds no one; readers seeded only at SetSceneFocus")
+	})
+})

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -172,6 +172,7 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 //   - Opens a session as a different identity (non-participant binding_id).
 //   - Asserts: MetadataOnly()==true, Event().Payload is empty.
 var _ = Describe("Subscribe with non-participant identity delivers MetadataOnly (INV-CRYPTO-15, INV-CRYPTO-6)", func() {
+	// Verifies: INV-CRYPTO-6
 	It("non-participant receives MetadataOnly=true with empty payload", func() {
 		ctx := context.Background()
 		h := buildSubscribeHarness(suiteT)


### PR DESCRIPTION
## Summary

Production wiring for the sensitive-event crypto stack (epic **holomush-5rh.8.29**), landing beads **.1–.9** of the go-live. Wires the DEK / AuthGuard / audit machinery onto the live publisher and subscriber paths, gated on **KEK presence** (`RekeyManager != nil`).

> Materialized autonomously via `/drain epic holomush-5rh.8.29` (9 beads, zero review rejections), then squashed for a clean diff. The drain halted at .10 on a genuine design-gated finding (see Deferred).

## ⚠️ Dormant until KEK is configured — no behavior change ships

With **no KEK env vars** (the current posture — no production deployment, no users; design §9), `RekeyManager` is nil, so:
- the publisher uses the identity codec → **plaintext** (`internal/eventbus/publisher.go:208`, gated `event.Sensitive && p.dekMgr != nil`);
- the subscriber wires **no AuthGuard** → passthrough (`cmd/holomush/sub_grpc.go:376`).

Confirmed by both reviewers and the operator (no KEK on any deployment). **This PR is inert in production.**

## Beads landed

| Bead | Change |
|------|--------|
| .1 | Wire DEK manager into the live Publisher |
| .2 | Wire AuthGuard into the live Subscriber |
| .3 | Add the DEK-adder seam to SceneAccessServer |
| .4 | SetSceneFocus seeds the DEK participant, fatal on failure |
| .5 | Wire the scene DEK-adder in production |
| .6 | GetOrCreate resolves an empty BindingID at genesis |
| .7 | Publisher seeds the subject-derived recipient for character contexts |
| .8 | Integration test: genesis DEK-seed asymmetry (character auto-seeds, scene does not) |
| .9 | Register INV-CRYPTO-116/117, bind INV-CRYPTO-6 |

## Reviews

- **crypto-reviewer: READY** — fail-closed verified on every path (triple fail-closed on empty BindingID; correct recipient seeding; genuine invariant bindings).
- **code-reviewer: READY** — structured logging, no gRPC error leaks, line-scoped nolint, SPDX present.
- Findings fixed in this PR: dropped a mis-scoped `// Verifies: INV-CRYPTO-116` annotation; corrected 3 stale comment line-refs (incl. the `publisher.go` KEK-gating comment).

## 🚧 Deferred — design-gated follow-up: `holomush-5rh.8.29.12`

The actual **activation** is intentionally **not** in this PR. The real gate is KEK presence, and the publisher (encrypt) and subscriber (`sessionIdentity`, `server.go:995`) gates are **asymmetric**: a KEK-present deployment with `cryptoEnabled` still false would encrypt on publish but deny on subscribe → **metadata-only delivery to everyone**. Closing that requires a binding-row backfill/guarantee story + gate alignment + its own design/plan/crypto review.

**MUST land before any KEK is ever provisioned.** The .10 E2E (KEK provisioning + live PoseCard) is WIP behind .12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)