### PR TITLE
feat(crypto): sensitive-event crypto activation — KEK-mandatory boot, single activation gate (holomush-5rh.8.29.12)

### DIFF
--- a/cmd/holomush/core.go
+++ b/cmd/holomush/core.go
@@ -77,6 +77,7 @@ type coreConfig struct {
 	SessionBootGrace      string        `koanf:"session_boot_grace"`
 	Setting               string        `koanf:"setting"`
 	ResetSetting          bool          `koanf:"reset_setting"`
+	AutoGenKEK            bool          `koanf:"auto_gen_kek"`
 	LuaTimeout            time.Duration `koanf:"lua_timeout"`
 	LuaRegistryMaxSize    int           `koanf:"lua_registry_max_size"`
 }
@@ -163,6 +164,8 @@ manages plugins, and handles game state.`,
 	cmd.Flags().StringVar(&cfg.SessionBootGrace, "session-boot-grace", "60s", "lease-sweep suppression window after core start")
 	cmd.Flags().StringVar(&cfg.Setting, "setting", "crossroads", "setting plugin to bootstrap on first boot")
 	cmd.Flags().BoolVar(&cfg.ResetSetting, "reset-setting", false, "force re-bootstrap from setting plugin")
+	cmd.Flags().BoolVar(&cfg.AutoGenKEK, "auto-gen-kek", false,
+		"generate a KEK file if absent on first boot (passphrase still required)")
 	cmd.Flags().DurationVar(&cfg.LuaTimeout, "plugin-lua-timeout", defaultPluginLuaTimeout, "per-invocation CPU deadline for Lua plugins")
 	cmd.Flags().IntVar(&cfg.LuaRegistryMaxSize, "plugin-lua-registry-max", defaultPluginLuaRegistryMax, "max Lua registry size per plugin state")
 	registerLogSinkFlags(cmd)
@@ -737,16 +740,16 @@ func runCoreWithDeps(ctx context.Context, cfg *coreConfig, gameConfig config.Gam
 	// totp.NewRealClock() satisfies adminauth.Clock (both require Now() time.Time).
 	adminSessionStore := adminauth.NewSessionStore(totp.NewRealClock(), 10*time.Minute)
 
-	// Construct the TOTP service for use in the admin handlers. KEK provider is
-	// read from the same env-var path used by the admin-totp CLI (HOLOMUSH_KEK_FILE
-	// + HOLOMUSH_KEK_PASSPHRASE). On first boot without KEK env vars, Start will
-	// fail-open: the admin handlers will return errors on TOTP operations but the
-	// server continues to start (handler construction itself is always successful).
-	kekProvider, kekErr := buildKEKProviderFromConfig(ctx, dbSub.Pool())
+	// Provision the boot KEK provider: a KEK is REQUIRED to start. The keyfile
+	// path comes from HOLOMUSH_KEK_FILE and the passphrase from env / file-ref /
+	// prompt (resolvePassphrase); --auto-gen-kek mints the keyfile on first boot.
+	// Any provisioning failure is fatal (BOOT_KEK_REQUIRED) — there is no
+	// degraded KEK-less mode. The admin-totp CLI keeps its own stricter path
+	// (buildKEKProviderFromConfig: pre-existing keyfile only, never auto-gen).
+	kekProvider, kekErr := provisionBootKEKProvider(ctx, dbSub.Pool(), cfg.AutoGenKEK)
 	if kekErr != nil {
-		slog.WarnContext(ctx, "admin handlers: KEK provider unavailable — TOTP-gated admin RPCs will fail at runtime",
-			"error", kekErr)
-		kekProvider = nil
+		return oops.Code("BOOT_KEK_REQUIRED").
+			Errorf("a KEK is required to start: %w (set %s + a passphrase source, or pass --auto-gen-kek)", kekErr, envKEKFile)
 	}
 
 	var adminTOTPSvc totp.Service

--- a/cmd/holomush/gateway_imports_test.go
+++ b/cmd/holomush/gateway_imports_test.go
@@ -70,6 +70,11 @@ var coreOnlyFiles = map[string]struct{}{
 	// call. Imports internal/plugin; core-only (matches phase7_fence_wiring.go
 	// precedent).
 	"cryptowiring_adapter.go": {},
+	// KEK passphrase resolution + keyfile provisioning (holomush-5rh.8.29.12).
+	// Imports internal/eventbus/crypto/kek for FileSource and KEKByteLength;
+	// core-only (matches cmd_admin_totp_deps.go precedent).
+	"kek_provision.go":      {},
+	"kek_provision_test.go": {},
 }
 
 var forbidden = []string{

--- a/cmd/holomush/kek_provision.go
+++ b/cmd/holomush/kek_provision.go
@@ -85,6 +85,13 @@ func ensureKeyfile(ctx context.Context, path string, pf kek.PassphraseFunc, auto
 		return oops.Code("KEK_FILE_CREATE_FAILED").With("path", path).Wrap(claimErr)
 	}
 	if closeErr := claim.Close(); closeErr != nil {
+		// Remove the zero-byte placeholder so a retry sees a clean "absent"
+		// state — as in the persist-failure path below, but tolerating an
+		// already-absent file.
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) { //nolint:gosec // path is operator-supplied via env var, not user input
+			slog.WarnContext(ctx, "failed to remove placeholder keyfile after close failure",
+				"path", path, "error", removeErr)
+		}
 		return oops.Code("KEK_FILE_CREATE_FAILED").With("path", path).Wrap(closeErr)
 	}
 	master := make([]byte, kek.KEKByteLength)

--- a/cmd/holomush/kek_provision.go
+++ b/cmd/holomush/kek_provision.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/oops"
 	"golang.org/x/term"
 )
@@ -70,7 +71,7 @@ func ensureKeyfile(ctx context.Context, path string, pf kek.PassphraseFunc, auto
 	// boots mints the KEK. Without this, two first boots could each Persist an
 	// independent key and the rename of one would silently discard the other —
 	// any DEKs already sealed under the discarded key would be unrecoverable.
-	claim, claimErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	claim, claimErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // path is operator-supplied via env var, not user input
 	if claimErr != nil {
 		if errors.Is(claimErr, os.ErrExist) {
 			// Lost the creation race: a sibling boot owns the file. Reuse it via
@@ -94,13 +95,43 @@ func ensureKeyfile(ctx context.Context, path string, pf kek.PassphraseFunc, auto
 	if persistErr := src.Persist(ctx, master); persistErr != nil {
 		// Remove the empty placeholder so a retry sees a clean "absent" state
 		// instead of a corrupt zero-byte keyfile.
-		if removeErr := os.Remove(path); removeErr != nil {
+		if removeErr := os.Remove(path); removeErr != nil { //nolint:gosec // path is operator-supplied via env var, not user input
 			slog.WarnContext(ctx, "failed to remove placeholder keyfile after persist failure",
 				"path", path, "error", removeErr)
 		}
 		return oops.Wrap(persistErr)
 	}
 	return nil
+}
+
+// provisionBootKEKProvider builds the KEK provider for SERVER BOOT: it resolves
+// the passphrase (env / file-ref / prompt), auto-generates the sealed keyfile when
+// absent and autoGen is set, then loads it. Distinct from buildKEKProviderFromConfig
+// (the admin-CLI path, which requires a pre-existing keyfile and never auto-gens).
+func provisionBootKEKProvider(ctx context.Context, pool *pgxpool.Pool, autoGen bool) (kek.Provider, error) {
+	keyFile := os.Getenv(envKEKFile)
+	if keyFile == "" {
+		return nil, oops.Code("BOOT_KEK_FILE_MISSING").With("env_var", envKEKFile).
+			Errorf("%s is required", envKEKFile)
+	}
+	stdinFD := int(os.Stdin.Fd()) //nolint:gosec // G115: fd fits int on all supported platforms
+	pass, err := resolvePassphrase(passphraseSources{interactive: term.IsTerminal(stdinFD)})
+	if err != nil {
+		return nil, err // KEK_PASSPHRASE_UNAVAILABLE / KEK_PASSPHRASE_FILE_READ_FAILED
+	}
+	pf := func(context.Context) ([]byte, error) { return pass, nil } // capture; don't re-resolve
+	if ensureErr := ensureKeyfile(ctx, keyFile, pf, autoGen); ensureErr != nil {
+		return nil, ensureErr // KEK_FILE_NOT_FOUND when absent && !autoGen
+	}
+	source, err := kek.NewFileSource(keyFile, pf)
+	if err != nil {
+		return nil, oops.Code("BOOT_KEK_FILE_SOURCE_FAILED").Wrap(err)
+	}
+	provider, err := kek.NewLocalAEADProvider(ctx, source, pool) // calls Load internally; file now exists
+	if err != nil {
+		return nil, oops.Code("BOOT_KEK_PROVIDER_FAILED").Wrap(err)
+	}
+	return provider, nil
 }
 
 // promptPassphrase reads a passphrase from stdin without echoing it.

--- a/cmd/holomush/kek_provision.go
+++ b/cmd/holomush/kek_provision.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/samber/oops"
+	"golang.org/x/term"
+)
+
+const envKEKPassphraseFile = "HOLOMUSH_KEK_PASSPHRASE_FILE" //nolint:gosec // env var name, not a credential
+
+// passphraseSources controls how resolvePassphrase may obtain the KEK passphrase.
+type passphraseSources struct {
+	// interactive permits prompting the user on stdin when no env var is set.
+	interactive bool
+}
+
+// resolvePassphrase returns the KEK unlock passphrase from (first hit wins):
+// env HOLOMUSH_KEK_PASSPHRASE, env HOLOMUSH_KEK_PASSPHRASE_FILE (file contents,
+// trailing whitespace trimmed), or an interactive prompt when a TTY is attached.
+// It NEVER logs the passphrase and NEVER auto-generates one.
+func resolvePassphrase(src passphraseSources) ([]byte, error) {
+	if p := os.Getenv(envKEKPassphrase); p != "" {
+		return []byte(p), nil
+	}
+	if f := os.Getenv(envKEKPassphraseFile); f != "" {
+		raw, err := os.ReadFile(f) //nolint:gosec // path comes from operator-controlled env var, not user input
+		if err != nil {
+			return nil, oops.Code("KEK_PASSPHRASE_FILE_READ_FAILED").With("path", f).Wrap(err)
+		}
+		return bytes.TrimRight(raw, "\r\n \t"), nil
+	}
+	if src.interactive {
+		return promptPassphrase()
+	}
+	return nil, oops.Code("KEK_PASSPHRASE_UNAVAILABLE").
+		Errorf("no KEK passphrase: set %s, %s, or run interactively", envKEKPassphrase, envKEKPassphraseFile)
+}
+
+// promptPassphrase reads a passphrase from stdin without echoing it.
+// The prompt is written to stderr. Returns an error if stdin is not a terminal.
+func promptPassphrase() ([]byte, error) {
+	fd := int(os.Stdin.Fd()) //nolint:gosec // term.ReadPassword requires int; fd is always a small safe value
+	if !term.IsTerminal(fd) {
+		return nil, oops.Code("KEK_PASSPHRASE_UNAVAILABLE").
+			Errorf("stdin is not a TTY; set %s or %s", envKEKPassphrase, envKEKPassphraseFile)
+	}
+	fmt.Fprintf(os.Stderr, "Enter KEK passphrase: ")
+	pass, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr) // newline after hidden input
+	if err != nil {
+		return nil, oops.Code("KEK_PASSPHRASE_UNAVAILABLE").Wrap(err)
+	}
+	return pass, nil
+}

--- a/cmd/holomush/kek_provision.go
+++ b/cmd/holomush/kek_provision.go
@@ -5,9 +5,15 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 
+	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/samber/oops"
 	"golang.org/x/term"
 )
@@ -40,6 +46,61 @@ func resolvePassphrase(src passphraseSources) ([]byte, error) {
 	}
 	return nil, oops.Code("KEK_PASSPHRASE_UNAVAILABLE").
 		Errorf("no KEK passphrase: set %s, %s, or run interactively", envKEKPassphrase, envKEKPassphraseFile)
+}
+
+// ensureKeyfile guarantees a sealed keyfile exists at path. If present: no-op.
+// If absent and autoGen: mint a fresh master KEK, seal it with the passphrase,
+// persist. If absent and !autoGen: return KEK_FILE_NOT_FOUND (refuse to boot).
+// It MUST NOT overwrite an existing keyfile.
+func ensureKeyfile(ctx context.Context, path string, pf kek.PassphraseFunc, autoGen bool) error {
+	src, err := kek.NewFileSource(path, pf)
+	if err != nil {
+		return oops.Wrap(err)
+	}
+	if _, loadErr := src.Load(ctx); loadErr == nil {
+		return nil // present (load succeeded) → reuse, never regenerate
+	} else if !errors.Is(loadErr, os.ErrNotExist) {
+		return oops.Wrap(loadErr) // corrupt / wrong-passphrase / other → surface
+	}
+	if !autoGen {
+		return oops.Code("KEK_FILE_NOT_FOUND").With("path", path).
+			Errorf("no KEK file at %s; pass --auto-gen-kek for first start", path)
+	}
+	// Claim the path with O_EXCL so exactly one of N concurrently auto-gen'ing
+	// boots mints the KEK. Without this, two first boots could each Persist an
+	// independent key and the rename of one would silently discard the other —
+	// any DEKs already sealed under the discarded key would be unrecoverable.
+	claim, claimErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if claimErr != nil {
+		if errors.Is(claimErr, os.ErrExist) {
+			// Lost the creation race: a sibling boot owns the file. Reuse it via
+			// a fresh load; a sealed-format error here means the winner has not
+			// finished persisting yet — fail loudly rather than overwrite.
+			if _, loadErr := src.Load(ctx); loadErr != nil {
+				return oops.Wrap(loadErr)
+			}
+			return nil
+		}
+		return oops.Code("KEK_FILE_CREATE_FAILED").With("path", path).Wrap(claimErr)
+	}
+	if closeErr := claim.Close(); closeErr != nil {
+		return oops.Code("KEK_FILE_CREATE_FAILED").With("path", path).Wrap(closeErr)
+	}
+	master := make([]byte, kek.KEKByteLength)
+	defer clear(master)
+	if _, err := io.ReadFull(rand.Reader, master); err != nil {
+		return oops.Code("KEK_GENERATE_FAILED").Wrap(err)
+	}
+	if persistErr := src.Persist(ctx, master); persistErr != nil {
+		// Remove the empty placeholder so a retry sees a clean "absent" state
+		// instead of a corrupt zero-byte keyfile.
+		if removeErr := os.Remove(path); removeErr != nil {
+			slog.WarnContext(ctx, "failed to remove placeholder keyfile after persist failure",
+				"path", path, "error", removeErr)
+		}
+		return oops.Wrap(persistErr)
+	}
+	return nil
 }
 
 // promptPassphrase reads a passphrase from stdin without echoing it.

--- a/cmd/holomush/kek_provision_test.go
+++ b/cmd/holomush/kek_provision_test.go
@@ -84,7 +84,19 @@ func TestProvisionBootKEKProviderBootMatrix(t *testing.T) {
 		t.Setenv("HOLOMUSH_KEK_FILE", filepath.Join(t.TempDir(), "m.key.enc"))
 		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "")
 		t.Setenv("HOLOMUSH_KEK_PASSPHRASE_FILE", "")
-		_, err := provisionBootKEKProvider(context.Background(), nil, true)
+		// Replace stdin with a pipe so the provisioner sees a non-TTY even when
+		// the test process itself runs with a terminal attached — otherwise
+		// resolvePassphrase would prompt and block instead of erroring.
+		pipeR, pipeW, err := os.Pipe()
+		require.NoError(t, err)
+		savedStdin := os.Stdin
+		os.Stdin = pipeR
+		t.Cleanup(func() {
+			os.Stdin = savedStdin
+			require.NoError(t, pipeR.Close())
+			require.NoError(t, pipeW.Close())
+		})
+		_, err = provisionBootKEKProvider(context.Background(), nil, true)
 		require.Error(t, err)
 		errutil.AssertErrorCode(t, err, "KEK_PASSPHRASE_UNAVAILABLE")
 	})

--- a/cmd/holomush/kek_provision_test.go
+++ b/cmd/holomush/kek_provision_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/holomush/holomush/pkg/errutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePassphrase(t *testing.T) {
+	t.Run("env var wins", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "from-env")
+		got, err := resolvePassphrase(passphraseSources{interactive: false})
+		require.NoError(t, err)
+		require.Equal(t, "from-env", string(got))
+	})
+	t.Run("file ref read and trimmed", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "pass")
+		require.NoError(t, os.WriteFile(f, []byte("from-file\n"), 0o600))
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "")
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE_FILE", f)
+		got, err := resolvePassphrase(passphraseSources{interactive: false})
+		require.NoError(t, err)
+		require.Equal(t, "from-file", string(got)) // trailing newline trimmed
+	})
+	t.Run("none and non-interactive errors", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "")
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE_FILE", "")
+		_, err := resolvePassphrase(passphraseSources{interactive: false})
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "KEK_PASSPHRASE_UNAVAILABLE")
+	})
+	t.Run("missing file ref errors (not silently empty)", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "")
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE_FILE", "/nonexistent/pass")
+		_, err := resolvePassphrase(passphraseSources{interactive: false})
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "KEK_PASSPHRASE_FILE_READ_FAILED")
+	})
+}

--- a/cmd/holomush/kek_provision_test.go
+++ b/cmd/holomush/kek_provision_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,5 +42,38 @@ func TestResolvePassphrase(t *testing.T) {
 		_, err := resolvePassphrase(passphraseSources{interactive: false})
 		require.Error(t, err)
 		errutil.AssertErrorCode(t, err, "KEK_PASSPHRASE_FILE_READ_FAILED")
+	})
+}
+
+func TestEnsureKeyfile(t *testing.T) {
+	t.Run("absent + autoGen mints and persists, reused on second call", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "master.key.enc")
+		pf := func(_ context.Context) ([]byte, error) { return []byte("pw"), nil }
+		require.NoError(t, ensureKeyfile(context.Background(), path, pf, true))
+		info1, err := os.Stat(path)
+		require.NoError(t, err)
+		require.NoError(t, ensureKeyfile(context.Background(), path, pf, true)) // idempotent
+		info2, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, info1.ModTime(), info2.ModTime(), "MUST NOT regenerate an existing keyfile")
+	})
+	t.Run("absent + NOT autoGen refuses", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "master.key.enc")
+		err := ensureKeyfile(context.Background(), path, func(_ context.Context) ([]byte, error) { return []byte("pw"), nil }, false)
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "KEK_FILE_NOT_FOUND")
+	})
+	t.Run("wrong passphrase surfaces error, never regenerates", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "master.key.enc")
+		right := func(_ context.Context) ([]byte, error) { return []byte("right"), nil }
+		wrong := func(_ context.Context) ([]byte, error) { return []byte("wrong"), nil }
+		require.NoError(t, ensureKeyfile(context.Background(), path, right, true))
+		info1, err := os.Stat(path)
+		require.NoError(t, err)
+		err = ensureKeyfile(context.Background(), path, wrong, true)
+		require.Error(t, err, "a keyfile that fails to unseal MUST surface, not be regenerated")
+		info2, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, info1.ModTime(), info2.ModTime(), "keyfile MUST be untouched after a failed unseal")
 	})
 }

--- a/cmd/holomush/kek_provision_test.go
+++ b/cmd/holomush/kek_provision_test.go
@@ -77,3 +77,28 @@ func TestEnsureKeyfile(t *testing.T) {
 		require.Equal(t, info1.ModTime(), info2.ModTime(), "keyfile MUST be untouched after a failed unseal")
 	})
 }
+
+func TestProvisionBootKEKProviderBootMatrix(t *testing.T) {
+	t.Run("no passphrase, non-interactive ⇒ KEK_PASSPHRASE_UNAVAILABLE", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_FILE", filepath.Join(t.TempDir(), "m.key.enc"))
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "")
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE_FILE", "")
+		_, err := provisionBootKEKProvider(context.Background(), nil, true)
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "KEK_PASSPHRASE_UNAVAILABLE")
+	})
+	t.Run("passphrase set, keyfile absent, autoGen off ⇒ KEK_FILE_NOT_FOUND", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_FILE", filepath.Join(t.TempDir(), "m.key.enc"))
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "pw")
+		_, err := provisionBootKEKProvider(context.Background(), nil, false)
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "KEK_FILE_NOT_FOUND")
+	})
+	t.Run("no KEK file path ⇒ BOOT_KEK_FILE_MISSING", func(t *testing.T) {
+		t.Setenv("HOLOMUSH_KEK_FILE", "")
+		t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "pw")
+		_, err := provisionBootKEKProvider(context.Background(), nil, true)
+		require.Error(t, err)
+		errutil.AssertErrorCode(t, err, "BOOT_KEK_FILE_MISSING")
+	})
+}

--- a/cmd/holomush/kek_provision_test.go
+++ b/cmd/holomush/kek_provision_test.go
@@ -78,6 +78,7 @@ func TestEnsureKeyfile(t *testing.T) {
 	})
 }
 
+// Verifies: INV-CRYPTO-119
 func TestProvisionBootKEKProviderBootMatrix(t *testing.T) {
 	t.Run("no passphrase, non-interactive ⇒ KEK_PASSPHRASE_UNAVAILABLE", func(t *testing.T) {
 		t.Setenv("HOLOMUSH_KEK_FILE", filepath.Join(t.TempDir(), "m.key.enc"))

--- a/cmd/holomush/sub_grpc.go
+++ b/cmd/holomush/sub_grpc.go
@@ -161,6 +161,11 @@ func (s *grpcSubsystem) DependsOn() []lifecycle.SubsystemID {
 	}
 }
 
+// cryptoActiveFor reports whether sensitive-event crypto is active for this
+// subsystem config: true iff a KEK (RekeyManager) is wired. This is the single
+// activation gate (replaces the vestigial cryptoEnabled flag).
+func cryptoActiveFor(cfg grpcSubsystemConfig) bool { return cfg.RekeyManager != nil }
+
 // publisherOptionsFor returns the PublishOptions for the live publisher.
 // When a DEK manager (RekeyManager) is configured, the publisher is DEK-aware
 // so Sensitive=true events take the encrypt branch (publisher.go:208); when
@@ -463,6 +468,7 @@ func (s *grpcSubsystem) Start(ctx context.Context) error {
 		holoGRPC.WithGuestService(guestService),
 		holoGRPC.WithTransactor(transactor),
 		holoGRPC.WithBindingRepository(bindingRepo),
+		holoGRPC.WithCryptoActive(cryptoActiveFor(s.cfg)),
 		holoGRPC.WithStreamContributor(pluginManager),
 		holoGRPC.WithAccessEngine(policyEngine),
 		holoGRPC.WithCommandQuerier(s.cfg.Plugins.CommandQuerier()),

--- a/cmd/holomush/sub_grpc_test.go
+++ b/cmd/holomush/sub_grpc_test.go
@@ -245,8 +245,18 @@ func TestSubscriberOptionsEmptyWhenGuardPresentButDEKManagerNil(t *testing.T) {
 // Verifies: INV-CRYPTO-118
 // Asserts the activation gate is wired from KEK presence, not a standalone flag.
 func TestCoreServerCryptoActiveTracksKEKPresence(t *testing.T) {
-	require.True(t, cryptoActiveFor(grpcSubsystemConfig{RekeyManager: &stubDEKManager{}}),
-		"RekeyManager set ⇒ crypto active")
-	require.False(t, cryptoActiveFor(grpcSubsystemConfig{}),
-		"no RekeyManager ⇒ crypto inactive")
+	tests := []struct {
+		name string
+		cfg  grpcSubsystemConfig
+		want bool
+	}{
+		{"RekeyManager set ⇒ crypto active", grpcSubsystemConfig{RekeyManager: &stubDEKManager{}}, true},
+		{"no RekeyManager ⇒ crypto inactive", grpcSubsystemConfig{}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cryptoActiveFor(tc.cfg))
+		})
+	}
 }

--- a/cmd/holomush/sub_grpc_test.go
+++ b/cmd/holomush/sub_grpc_test.go
@@ -241,3 +241,11 @@ func TestSubscriberOptionsEmptyWhenGuardPresentButDEKManagerNil(t *testing.T) {
 	require.Empty(t, subscriberOptionsFor(stubSessionAuthGuard{}, nil, stubSessionAuditEmitter{}),
 		"guard without a DEK manager is a half-configured decrypt path ⇒ all-or-nothing returns no options")
 }
+
+// Asserts the activation gate is wired from KEK presence, not a standalone flag.
+func TestCoreServerCryptoActiveTracksKEKPresence(t *testing.T) {
+	require.True(t, cryptoActiveFor(grpcSubsystemConfig{RekeyManager: &stubDEKManager{}}),
+		"RekeyManager set ⇒ crypto active")
+	require.False(t, cryptoActiveFor(grpcSubsystemConfig{}),
+		"no RekeyManager ⇒ crypto inactive")
+}

--- a/cmd/holomush/sub_grpc_test.go
+++ b/cmd/holomush/sub_grpc_test.go
@@ -242,6 +242,7 @@ func TestSubscriberOptionsEmptyWhenGuardPresentButDEKManagerNil(t *testing.T) {
 		"guard without a DEK manager is a half-configured decrypt path ⇒ all-or-nothing returns no options")
 }
 
+// Verifies: INV-CRYPTO-118
 // Asserts the activation gate is wired from KEK presence, not a standalone flag.
 func TestCoreServerCryptoActiveTracksKEKPresence(t *testing.T) {
 	require.True(t, cryptoActiveFor(grpcSubsystemConfig{RekeyManager: &stubDEKManager{}}),

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -12,8 +12,14 @@ services:
       POSTGRES_DB: holomush_test
 
   core:
+    command: ["core", "--log-format", "text", "--grpc-addr", "0.0.0.0:9000", "--metrics-addr", "0.0.0.0:9100", "--auto-gen-kek"]
     environment:
       DATABASE_URL: postgres://holomush:holomush@postgres:5432/holomush_test?sslmode=disable
+      # KEK is required to boot. --auto-gen-kek mints a fresh ephemeral keyfile
+      # each E2E run (the container is recreated); a fixed test passphrase is
+      # sufficient because the keyfile does not leave the container.
+      HOLOMUSH_KEK_FILE: /home/holomush/.config/holomush/certs/master.key.enc
+      HOLOMUSH_KEK_PASSPHRASE: e2e-test-passphrase
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:9100/healthz/readiness || exit 1"]
       interval: 2s

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,9 +27,15 @@ services:
 
   core:
     image: holomush
-    command: ["core", "--log-format", "text", "--grpc-addr", "0.0.0.0:9000", "--metrics-addr", "0.0.0.0:9100"]
+    command: ["core", "--log-format", "text", "--grpc-addr", "0.0.0.0:9000", "--metrics-addr", "0.0.0.0:9100", "--auto-gen-kek"]
     environment:
       DATABASE_URL: postgres://holomush:holomush@postgres:5432/holomush?sslmode=disable
+      # KEK is required to boot. The keyfile is minted on first start via
+      # --auto-gen-kek and persisted in the certs volume; subsequent starts
+      # reuse it. HOLOMUSH_KEK_PASSPHRASE is a fixed dev value — change this
+      # for production deployments (or use HOLOMUSH_KEK_PASSPHRASE_FILE).
+      HOLOMUSH_KEK_FILE: /home/holomush/.config/holomush/certs/master.key.enc
+      HOLOMUSH_KEK_PASSPHRASE: ${HOLOMUSH_KEK_PASSPHRASE:-dev-local-passphrase}
       # Set unconditionally — when the observability profile is inactive, the OTel SDK
       # retries silently with a no-op error handler (see internal/telemetry/provider.go).
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -167,6 +167,9 @@ invariants.
 | `INV-CRYPTO-115` | The auditchain.Verifier self-hash recompute MUST be SHA-256(Canonicalize(zero(payload, SelfHashFieldName))); SHA-256 and composition order are pinned at the primitive level, while per-chain Canonicalize MAY apply domain normalization (e.g. PolicySetChain renormalizes empty PrevHash → nil to preserve INV-CRYPTO-77 semantics). | `INV-E28` | pending |
 | `INV-CRYPTO-116` | A subject in a DEK's participant set MUST receive plaintext via live fan-out when policy permits. | `INV-8` | bound |
 | `INV-CRYPTO-117` | When RekeyManager is non-nil the production gRPC subsystem MUST build the live Publisher DEK-aware and the live Subscriber AuthGuard-wired; when nil, both MUST preserve plaintext/passthrough and the subsystem MUST start. | — | bound |
+| `INV-CRYPTO-118` | Subscriber identity-build MUST be gated solely on KEK presence (cryptoActive wired from RekeyManager != nil), never an independent flag; when the gate is false or no binding repo is wired, the built identity MUST be the zero passthrough identity. The publisher half of the same RekeyManager-sourced lockstep is INV-CRYPTO-117. | — | bound |
+| `INV-CRYPTO-119` | The server MUST refuse to boot without a provisionable KEK; missing keyfile path, missing passphrase, or keyfile absent without auto-gen all produce a fatal error — degraded KEK-less boot is never permitted. | — | bound |
+| `INV-CRYPTO-120` | Every character-creation path (normal and guest) MUST mint a current DEK binding in the same transaction, so bindings.Current always resolves for a newly created character with no orphan row. | — | bound |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -175,6 +175,12 @@ scopes:
       - "cmd/holomush/phase7_fence_wiring_test.go"
       - "cmd/holomush/gateway_imports_test.go"
       - "cmd/holomush/admin_rekey_e2e_test.go"
+      # INV-CRYPTO-118/119/120 (single-gate / boot-refusal / creation-time binding): activation
+      # gate, KEK boot provision, and character/guest binding tests — multi-scope files shared here.
+      - "cmd/holomush/kek_provision_test.go"
+      - "internal/grpc/session_identity_test.go"
+      - "internal/grpc/auth_handlers_test.go"
+      - "internal/auth/guest_service_test.go"
 
   - name: INV-PRIVACY
     description: "Stream history temporal floors, scope gating, guest-session bounds, reattach/Idle arrival-timestamp semantics"
@@ -4377,3 +4383,38 @@ invariants:
     binding: bound
     refs:
       - {file: "cmd/holomush/sub_grpc_test.go", token: "INV-CRYPTO-117"}
+  - id: INV-CRYPTO-118
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-09-sensitive-event-crypto-activation-design.md"
+    summary: "Subscriber identity-build MUST be gated solely on KEK presence (cryptoActive wired from RekeyManager != nil),
+      never an independent flag; when the gate is false or no binding repo is wired, the built identity MUST be the zero passthrough
+      identity. The publisher half of the same RekeyManager-sourced lockstep is INV-CRYPTO-117."
+    asserted_by:
+      - "cmd/holomush/sub_grpc_test.go"
+      - "internal/grpc/session_identity_test.go"
+    binding: bound
+    refs:
+      - {file: "cmd/holomush/sub_grpc_test.go", token: "INV-CRYPTO-118"}
+      - {file: "internal/grpc/session_identity_test.go", token: "INV-CRYPTO-118"}
+  - id: INV-CRYPTO-119
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-09-sensitive-event-crypto-activation-design.md"
+    summary: "The server MUST refuse to boot without a provisionable KEK; missing keyfile path, missing passphrase, or keyfile
+      absent without auto-gen all produce a fatal error — degraded KEK-less boot is never permitted."
+    asserted_by:
+      - "cmd/holomush/kek_provision_test.go"
+    binding: bound
+    refs:
+      - {file: "cmd/holomush/kek_provision_test.go", token: "INV-CRYPTO-119"}
+  - id: INV-CRYPTO-120
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-09-sensitive-event-crypto-activation-design.md"
+    summary: "Every character-creation path (normal and guest) MUST mint a current DEK binding in the same transaction, so
+      bindings.Current always resolves for a newly created character with no orphan row."
+    asserted_by:
+      - "internal/grpc/auth_handlers_test.go"
+      - "internal/auth/guest_service_test.go"
+    binding: bound
+    refs:
+      - {file: "internal/grpc/auth_handlers_test.go", token: "INV-CRYPTO-120"}
+      - {file: "internal/auth/guest_service_test.go", token: "INV-CRYPTO-120"}

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -779,9 +779,11 @@ invariants:
       matching subject."
     asserted_by:
       - "test/integration/crypto/metadata_only_test.go"
+      - "test/integration/crypto/decrypt_to_participant_test.go"
     binding: bound
     refs:
       - {file: "test/integration/crypto/metadata_only_test.go", token: "INV-9"}
+      - {file: "test/integration/crypto/decrypt_to_participant_test.go", token: "INV-CRYPTO-6"}
   - id: INV-CRYPTO-7
     scope: INV-CRYPTO
     origin_spec: "docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md"
@@ -4370,9 +4372,11 @@ invariants:
     summary: "A subject in a DEK's participant set MUST receive plaintext via live fan-out when policy permits."
     asserted_by:
       - "test/integration/crypto/genesis_seed_test.go"
+      - "test/integration/crypto/decrypt_to_participant_test.go"
     binding: bound
     refs:
       - {file: "test/integration/crypto/genesis_seed_test.go", token: "INV-CRYPTO-116"}
+      - {file: "test/integration/crypto/decrypt_to_participant_test.go", token: "INV-CRYPTO-116"}
   - id: INV-CRYPTO-117
     scope: INV-CRYPTO
     origin_spec: "docs/superpowers/specs/2026-06-08-sensitive-event-crypto-production-golive-design.md"

--- a/docs/superpowers/specs/2026-06-08-sensitive-event-crypto-production-golive-design.md
+++ b/docs/superpowers/specs/2026-06-08-sensitive-event-crypto-production-golive-design.md
@@ -111,6 +111,12 @@ In `cmd/holomush/sub_grpc.go::Start`:
   when `RekeyManager != nil`. When `RekeyManager == nil` (no KEK configured),
   the publisher MUST remain in its current plaintext-only mode — a KEK-less
   deployment is a supported degraded posture and MUST NOT fail to start.
+  > **Superseded (2026-06-09):** the KEK-less degraded posture is retired by
+  > [the sensitive-event crypto activation design](2026-06-09-sensitive-event-crypto-activation-design.md)
+  > — a KEK is now REQUIRED to boot (`BOOT_KEK_REQUIRED`, INV-CRYPTO-119);
+  > `--auto-gen-kek` provisions the keyfile on first start. The
+  > `RekeyManager == nil` publisher branch survives only as a defensive
+  > guard, never as a supported deployment mode.
 - The live **Subscriber** MUST be constructed with
   `WithSubscriberAuthGuard(historyAuthGuard)` +
   `WithSubscriberDEKManager(historyDEKMgr)` +

--- a/internal/auth/guest_service_test.go
+++ b/internal/auth/guest_service_test.go
@@ -372,3 +372,53 @@ func TestGuestServiceReturnsErrorWhenExistsByNameFails(t *testing.T) {
 	assert.Nil(t, result)
 	errutil.AssertErrorCode(t, err, "GUEST_CREATE_FAILED")
 }
+
+// Asserts guest creation mints a binding with reason "initial_bind_guest" in the
+// same transaction, and that the returned binding ID is non-empty so a subsequent
+// bindings.Current call resolves it (i.e., no orphan character row without a binding).
+func TestCreateGuestMintsBinding(t *testing.T) {
+	ctx := context.Background()
+	startLoc := ulid.MustNew(ulid.Now(), nil)
+	guestName := "Onyx_River"
+
+	namer := mocks.NewMockGuestNamer(t)
+	players := mocks.NewMockPlayerRepository(t)
+	chars := mocks.NewMockGuestCharacterRepository(t)
+	sessions := mocks.NewMockPlayerSessionRepository(t)
+	transactor := passthroughTransactor(t)
+	bindings := mocks.NewMockGuestBindingCreator(t)
+
+	namer.EXPECT().GenerateName().Return(guestName, nil).Once()
+	namer.EXPECT().StartLocation().Return(startLoc)
+	chars.EXPECT().ExistsByName(ctx, "Onyx River").Return(false, nil).Once()
+	players.EXPECT().Create(mock.Anything, mock.AnythingOfType("*auth.Player")).Return(nil).Once()
+	players.EXPECT().Update(ctx, mock.AnythingOfType("*auth.Player")).Return(nil).Once()
+	sessions.EXPECT().Create(ctx, mock.AnythingOfType("*auth.PlayerSession")).Return(nil).Once()
+	chars.EXPECT().Create(mock.Anything, mock.AnythingOfType("*world.Character")).Return(nil).Once()
+
+	var (
+		capturedPlayerID string
+		capturedCharID   string
+		capturedReason   string
+	)
+	bindings.EXPECT().
+		Create(mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), "initial_bind_guest").
+		RunAndReturn(func(_ context.Context, playerID, characterID, reason string) (string, error) {
+			capturedPlayerID = playerID
+			capturedCharID = characterID
+			capturedReason = reason
+			return "bind-guest-mint-1", nil
+		}).Once()
+
+	svc, err := auth.NewGuestService(namer, players, chars, sessions, transactor, bindings)
+	require.NoError(t, err)
+
+	result, err := svc.CreateGuest(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Create was called with reason "initial_bind_guest" for the guest character.
+	assert.Equal(t, "initial_bind_guest", capturedReason)
+	assert.Equal(t, result.Character.ID.String(), capturedCharID)
+	assert.Equal(t, result.Player.ID.String(), capturedPlayerID)
+}

--- a/internal/auth/guest_service_test.go
+++ b/internal/auth/guest_service_test.go
@@ -373,6 +373,7 @@ func TestGuestServiceReturnsErrorWhenExistsByNameFails(t *testing.T) {
 	errutil.AssertErrorCode(t, err, "GUEST_CREATE_FAILED")
 }
 
+// Verifies: INV-CRYPTO-120
 // Asserts guest creation mints a binding with reason "initial_bind_guest" in the
 // same transaction, and that the returned binding ID is non-empty so a subsequent
 // bindings.Current call resolves it (i.e., no orphan character row without a binding).

--- a/internal/eventbus/crypto/kek/source_file_test.go
+++ b/internal/eventbus/crypto/kek/source_file_test.go
@@ -6,6 +6,7 @@ package kek_test
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,6 +74,15 @@ func TestFileSource_Load_FailsOnMissingFile(t *testing.T) {
 	_, err = src.Load(context.Background())
 	require.Error(t, err)
 	errutil.AssertErrorCode(t, err, "KEK_FILE_LOAD_FAILED")
+}
+
+func TestFileSource_Load_AbsentFileIsDistinguishable(t *testing.T) {
+	src, err := kek.NewFileSource("/nonexistent/master.key.enc", staticPassphraseFunc("x"))
+	require.NoError(t, err)
+	_, loadErr := src.Load(context.Background())
+	require.Error(t, loadErr)
+	require.True(t, errors.Is(loadErr, os.ErrNotExist),
+		"absent keyfile MUST be distinguishable via errors.Is(os.ErrNotExist) through the oops wrap")
 }
 
 func TestFileSource_New_FailsWhenPassphraseFuncIsNil(t *testing.T) {

--- a/internal/grpc/auth_handlers.go
+++ b/internal/grpc/auth_handlers.go
@@ -148,14 +148,14 @@ func WithBindingRepository(b BindingRepo) CoreServerOption {
 	}
 }
 
-// WithCryptoEnabled gates Phase 3b crypto features (binding lookup in Subscribe
-// and QueryStreamHistory). Default false so crypto-off production servers skip
-// binding resolution rather than failing with BINDING_NOT_FOUND for characters
-// that have no active binding row. Flip to true when Crypto.Enabled=true in
-// the server config (Phase 3d wiring).
-func WithCryptoEnabled(enabled bool) CoreServerOption {
+// WithCryptoActive gates sensitive-event crypto features (binding lookup in
+// Subscribe and QueryStreamHistory) on KEK presence. Pass true when
+// RekeyManager != nil (wired via cryptoActiveFor in the gRPC subsystem).
+// Default false so KEK-less deployments skip binding resolution rather than
+// failing with BINDING_NOT_FOUND.
+func WithCryptoActive(active bool) CoreServerOption {
 	return func(s *CoreServer) {
-		s.cryptoEnabled = enabled
+		s.cryptoActive = active
 	}
 }
 

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -813,6 +813,7 @@ func (passthroughTransactorForGRPC) InTransaction(ctx context.Context, fn func(c
 
 var _ Transactor = passthroughTransactorForGRPC{}
 
+// Verifies: INV-CRYPTO-120
 // Asserts createCharacterAtomic mints a current binding so bindings.Current resolves.
 func TestCreateCharacterMintsBindingResolvableByCurrent(t *testing.T) {
 	ctx := context.Background()

--- a/internal/grpc/auth_handlers_test.go
+++ b/internal/grpc/auth_handlers_test.go
@@ -773,6 +773,91 @@ func TestCreateCharacter_ErrorPaths(t *testing.T) {
 	}
 }
 
+// recordingBindingRepo implements BindingRepo for testing. Create records
+// (playerID, characterID, reason) and returns the canned ID; Current returns
+// the last recorded binding ID for the given character, or "" if none.
+type recordingBindingRepo struct {
+	bindingID string // returned by Create
+	creates   []recordedCreate
+}
+
+type recordedCreate struct {
+	playerID    string
+	characterID string
+	reason      string
+}
+
+func (r *recordingBindingRepo) Create(_ context.Context, playerID, characterID, reason string) (string, error) {
+	r.creates = append(r.creates, recordedCreate{playerID: playerID, characterID: characterID, reason: reason})
+	return r.bindingID, nil
+}
+
+func (r *recordingBindingRepo) Current(_ context.Context, characterID string) (string, error) {
+	for i := len(r.creates) - 1; i >= 0; i-- {
+		if r.creates[i].characterID == characterID {
+			return r.bindingID, nil
+		}
+	}
+	return "", samberOops.Code("BINDING_NOT_FOUND").Errorf("no active binding for character %s", characterID)
+}
+
+var _ BindingRepo = (*recordingBindingRepo)(nil)
+
+// passthroughTransactorForGRPC implements Transactor for tests by executing fn
+// directly with the provided ctx, simulating a committed transaction.
+type passthroughTransactorForGRPC struct{}
+
+func (passthroughTransactorForGRPC) InTransaction(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+var _ Transactor = passthroughTransactorForGRPC{}
+
+// Asserts createCharacterAtomic mints a current binding so bindings.Current resolves.
+func TestCreateCharacterMintsBindingResolvableByCurrent(t *testing.T) {
+	ctx := context.Background()
+	playerID := ulid.Make()
+	charID := ulid.Make()
+
+	ps := makePlayerSession(playerID)
+	sessionRepo := setupSessionRepo(t, ps)
+
+	charSvc := newMockCharacterService(t)
+	charSvc.createFunc = func(_ context.Context, pid ulid.ULID, name string) (*world.Character, error) {
+		require.Equal(t, playerID, pid)
+		return &world.Character{ID: charID, PlayerID: pid, Name: name}, nil
+	}
+
+	repo := &recordingBindingRepo{bindingID: "bind-mint-1"}
+
+	server := &CoreServer{
+		engine:            core.NewEngine(coretest.NewMemoryEventStore()),
+		sessionStore:      sessiontest.NewStore(t),
+		playerSessionRepo: sessionRepo,
+		characterService:  charSvc,
+		transactor:        passthroughTransactorForGRPC{},
+		bindings:          repo,
+	}
+
+	resp, err := server.CreateCharacter(ctx, &corev1.CreateCharacterRequest{
+		PlayerSessionToken: validToken,
+		CharacterName:      "Binding Hero",
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	// Create was called with reason "initial_bind" for the new character.
+	require.Len(t, repo.creates, 1)
+	assert.Equal(t, "initial_bind", repo.creates[0].reason)
+	assert.Equal(t, charID.String(), repo.creates[0].characterID)
+	assert.Equal(t, playerID.String(), repo.creates[0].playerID)
+
+	// Current resolves the binding for the new character — no error, non-empty ID.
+	bindingID, err := repo.Current(ctx, charID.String())
+	require.NoError(t, err)
+	assert.NotEmpty(t, bindingID)
+}
+
 // --- ListCharacters ---
 
 // replaces: TestListCharacters_InvalidSession_ReturnsError,

--- a/internal/grpc/query_stream_history.go
+++ b/internal/grpc/query_stream_history.go
@@ -19,7 +19,6 @@ import (
 	"github.com/holomush/holomush/internal/access"
 	accessTypes "github.com/holomush/holomush/internal/access/policy/types"
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/authguard"
 	"github.com/holomush/holomush/internal/eventbus/cursor"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
@@ -302,26 +301,9 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 	// Build the typed authenticated identity for the hot-tier AuthGuard path.
 	// Decision 2 (Phase 3b grounding doc): derived solely from the server-side
 	// session record — never from client-supplied fields.
-	var historyIdentity eventbus.SessionIdentity
-	if s.bindings != nil && s.cryptoActive {
-		// Binding lookup is only needed when a KEK is wired (cryptoActive).
-		// Without a KEK, skip this so characters without a binding row don't
-		// break QueryStreamHistory in KEK-less deployments.
-		bindingID, bindingErr := s.bindings.Current(ctx, info.CharacterID.String())
-		if bindingErr != nil {
-			return nil, oops.Code("HISTORY_BINDING_LOOKUP_FAILED").
-				With("character_id", info.CharacterID.String()).
-				Wrap(bindingErr)
-		}
-		historyAuthIdentity, identityErr := authguard.NewCharacterIdentity(
-			info.PlayerID.String(),
-			info.CharacterID.String(),
-			bindingID,
-		)
-		if identityErr != nil {
-			return nil, oops.Code("HISTORY_IDENTITY_INVALID").Wrap(identityErr)
-		}
-		historyIdentity = authguard.ToSessionIdentity(historyAuthIdentity)
+	historyIdentity, identityErr := s.buildCharacterIdentity(ctx, info.PlayerID.String(), info.CharacterID.String())
+	if identityErr != nil {
+		return nil, oops.Code("HISTORY_BINDING_LOOKUP_FAILED").Wrap(identityErr)
 	}
 
 	frames, fetchErr := fetchHistoryFramesFromBus(

--- a/internal/grpc/query_stream_history.go
+++ b/internal/grpc/query_stream_history.go
@@ -303,10 +303,10 @@ func (s *CoreServer) QueryStreamHistory(ctx context.Context, req *corev1.QuerySt
 	// Decision 2 (Phase 3b grounding doc): derived solely from the server-side
 	// session record — never from client-supplied fields.
 	var historyIdentity eventbus.SessionIdentity
-	if s.bindings != nil && s.cryptoEnabled {
-		// Binding lookup is only needed when crypto is enabled (Phase 3b+).
-		// With crypto disabled (current production default), we skip this so
-		// characters without a binding row don't break QueryStreamHistory.
+	if s.bindings != nil && s.cryptoActive {
+		// Binding lookup is only needed when a KEK is wired (cryptoActive).
+		// Without a KEK, skip this so characters without a binding row don't
+		// break QueryStreamHistory in KEK-less deployments.
 		bindingID, bindingErr := s.bindings.Current(ctx, info.CharacterID.String())
 		if bindingErr != nil {
 			return nil, oops.Code("HISTORY_BINDING_LOOKUP_FAILED").

--- a/internal/grpc/query_stream_history_test.go
+++ b/internal/grpc/query_stream_history_test.go
@@ -1008,7 +1008,7 @@ func TestQueryStreamHistoryPassesIdentityFromBindingsToHistoryQuery(t *testing.T
 		historyReader: reader,
 		accessEngine:  policytest.AllowAllEngine(),
 		bindings:      &fakeBindingRepo{bindingID: bindingID},
-		cryptoEnabled: true, // required to activate binding lookup (Phase 3b gate)
+		cryptoActive:  true, // required to activate binding lookup (KEK-presence gate)
 	}
 
 	_, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{
@@ -1049,7 +1049,7 @@ func TestQueryStreamHistoryBindingLookupFailureReturnsError(t *testing.T) {
 		historyReader: reader,
 		accessEngine:  policytest.AllowAllEngine(),
 		bindings:      &fakeBindingRepo{err: errors.New("db error")},
-		cryptoEnabled: true, // required to activate binding lookup (Phase 3b gate)
+		cryptoActive:  true, // required to activate binding lookup (KEK-presence gate)
 	}
 
 	_, err := s.QueryStreamHistory(context.Background(), &corev1.QueryStreamHistoryRequest{

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/holomush/holomush/internal/command/commandquery"
 	"github.com/holomush/holomush/internal/core"
 	"github.com/holomush/holomush/internal/eventbus"
-	"github.com/holomush/holomush/internal/eventbus/authguard"
 	"github.com/holomush/holomush/internal/grpc/focus"
 	plugins "github.com/holomush/holomush/internal/plugin"
 	"github.com/holomush/holomush/internal/session"
@@ -991,26 +990,9 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// Decision 2 (Phase 3b grounding doc): the gRPC handler is the
 	// authentication boundary; identity is derived solely from the
 	// server-side session record — never from client-supplied fields.
-	var sessionIdentity eventbus.SessionIdentity
-	if s.bindings != nil && s.cryptoActive {
-		// Binding lookup is only needed when a KEK is wired (cryptoActive).
-		// Without a KEK, skip this so characters without a binding row don't
-		// break Subscribe in KEK-less deployments.
-		bindingID, bindingErr := s.bindings.Current(ctx, info.CharacterID.String())
-		if bindingErr != nil {
-			return oops.Code("SUBSCRIBE_BINDING_LOOKUP_FAILED").
-				With("character_id", info.CharacterID.String()).
-				Wrap(bindingErr)
-		}
-		identity, identityErr := authguard.NewCharacterIdentity(
-			info.PlayerID.String(),
-			info.CharacterID.String(),
-			bindingID,
-		)
-		if identityErr != nil {
-			return oops.Code("SUBSCRIBE_IDENTITY_INVALID").Wrap(identityErr)
-		}
-		sessionIdentity = authguard.ToSessionIdentity(identity)
+	sessionIdentity, identityErr := s.buildCharacterIdentity(ctx, info.PlayerID.String(), info.CharacterID.String())
+	if identityErr != nil {
+		return oops.Code("SUBSCRIBE_BINDING_LOOKUP_FAILED").Wrap(identityErr)
 	}
 
 	// Compute minFloor across all subscribed subjects per holomush-iwzt §6.2 Tier 1.

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -173,9 +173,9 @@ type CoreServer struct {
 
 	// Phase 3b: transactor and binding repository for atomic character + binding INSERTs
 	// (Create) and current-binding lookup for Subscribe / QueryStreamHistory (Current).
-	transactor    Transactor
-	bindings      BindingRepo
-	cryptoEnabled bool // Phase 3b flag; gates binding lookup in Subscribe / QueryStreamHistory
+	transactor   Transactor
+	bindings     BindingRepo
+	cryptoActive bool // true when KEK (RekeyManager) is wired; gates binding lookup in Subscribe / QueryStreamHistory
 
 	// Plugin stream contribution and mid-session stream control.
 	streamContributor SessionStreamContributor
@@ -992,10 +992,10 @@ func (s *CoreServer) Subscribe(req *corev1.SubscribeRequest, stream grpc.ServerS
 	// authentication boundary; identity is derived solely from the
 	// server-side session record — never from client-supplied fields.
 	var sessionIdentity eventbus.SessionIdentity
-	if s.bindings != nil && s.cryptoEnabled {
-		// Binding lookup is only needed when crypto is enabled (Phase 3b+).
-		// With crypto disabled (current production default), we skip this so
-		// characters without a binding row don't break Subscribe.
+	if s.bindings != nil && s.cryptoActive {
+		// Binding lookup is only needed when a KEK is wired (cryptoActive).
+		// Without a KEK, skip this so characters without a binding row don't
+		// break Subscribe in KEK-less deployments.
 		bindingID, bindingErr := s.bindings.Current(ctx, info.CharacterID.String())
 		if bindingErr != nil {
 			return oops.Code("SUBSCRIBE_BINDING_LOOKUP_FAILED").

--- a/internal/grpc/session_identity.go
+++ b/internal/grpc/session_identity.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+
+	"github.com/samber/oops"
+
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/authguard"
+)
+
+// buildCharacterIdentity returns the typed session identity for the character
+// when crypto is active and a binding repo is wired; otherwise the zero
+// (passthrough) identity. Single source of truth for the Subscribe and
+// QueryStreamHistory identity gate (formerly duplicated at server.go:995 /
+// query_stream_history.go:306).
+//
+// Binding lookup is only performed when a KEK is wired (cryptoActive).
+// Without a KEK, skip this so characters without a binding row don't
+// break Subscribe or QueryStreamHistory in KEK-less deployments.
+//
+// Errors are returned without a top-level oops code so call sites can wrap
+// them with the appropriate surface-specific code (SUBSCRIBE_BINDING_LOOKUP_FAILED
+// or HISTORY_BINDING_LOOKUP_FAILED) that remains observable via oops.AsOops.
+func (s *CoreServer) buildCharacterIdentity(ctx context.Context, playerID, characterID string) (eventbus.SessionIdentity, error) {
+	if s.bindings == nil || !s.cryptoActive {
+		return eventbus.SessionIdentity{}, nil
+	}
+	bindingID, err := s.bindings.Current(ctx, characterID)
+	if err != nil {
+		return eventbus.SessionIdentity{}, oops.With("character_id", characterID).
+			With("cause", "binding_lookup_failed").Wrap(err)
+	}
+	identity, err := authguard.NewCharacterIdentity(playerID, characterID, bindingID)
+	if err != nil {
+		return eventbus.SessionIdentity{}, oops.With("cause", "identity_invalid").Wrap(err)
+	}
+	return authguard.ToSessionIdentity(identity), nil
+}

--- a/internal/grpc/session_identity.go
+++ b/internal/grpc/session_identity.go
@@ -25,6 +25,9 @@ import (
 // Errors are returned without a top-level oops code so call sites can wrap
 // them with the appropriate surface-specific code (SUBSCRIBE_BINDING_LOOKUP_FAILED
 // or HISTORY_BINDING_LOOKUP_FAILED) that remains observable via oops.AsOops.
+// The binding is minted at character creation (auth_handlers.go createCharacterAtomic;
+// guest_service.go CreateGuest), so a Current failure here is a misconfiguration
+// assertion, never an expected path once KEK is mandatory.
 func (s *CoreServer) buildCharacterIdentity(ctx context.Context, playerID, characterID string) (eventbus.SessionIdentity, error) {
 	if s.bindings == nil || !s.cryptoActive {
 		return eventbus.SessionIdentity{}, nil

--- a/internal/grpc/session_identity_test.go
+++ b/internal/grpc/session_identity_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus"
 )
 
+// Verifies: INV-CRYPTO-118
 func TestBuildCharacterIdentity(t *testing.T) {
 	pid := core.NewULID().String()
 	cid := core.NewULID().String()

--- a/internal/grpc/session_identity_test.go
+++ b/internal/grpc/session_identity_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
+)
+
+func TestBuildCharacterIdentity(t *testing.T) {
+	pid := core.NewULID().String()
+	cid := core.NewULID().String()
+
+	t.Run("crypto inactive returns zero identity no lookup", func(t *testing.T) {
+		s := &CoreServer{bindings: &fakeBindingRepo{}, cryptoActive: false}
+		id, err := s.buildCharacterIdentity(context.Background(), pid, cid)
+		require.NoError(t, err)
+		require.Equal(t, eventbus.SessionIdentity{}, id)
+	})
+
+	t.Run("nil bindings returns zero identity", func(t *testing.T) {
+		s := &CoreServer{bindings: nil, cryptoActive: true}
+		id, err := s.buildCharacterIdentity(context.Background(), pid, cid)
+		require.NoError(t, err)
+		require.Equal(t, eventbus.SessionIdentity{}, id)
+	})
+
+	t.Run("active with binding returns character identity", func(t *testing.T) {
+		s := &CoreServer{bindings: &fakeBindingRepo{bindingID: "bind-1"}, cryptoActive: true}
+		id, err := s.buildCharacterIdentity(context.Background(), pid, cid)
+		require.NoError(t, err)
+		require.NotEqual(t, eventbus.SessionIdentity{}, id)
+	})
+
+	t.Run("Current error returns a non-nil error without consuming a surface code", func(t *testing.T) {
+		// The helper intentionally returns an oops-without-code error so call
+		// sites can wrap it with the appropriate surface code
+		// (SUBSCRIBE_BINDING_LOOKUP_FAILED or HISTORY_BINDING_LOOKUP_FAILED)
+		// and that code remains observable via oops.AsOops.
+		s := &CoreServer{bindings: &fakeBindingRepo{err: errors.New("boom")}, cryptoActive: true}
+		_, err := s.buildCharacterIdentity(context.Background(), pid, cid)
+		require.Error(t, err)
+	})
+}

--- a/internal/grpc/subscribe_server_test.go
+++ b/internal/grpc/subscribe_server_test.go
@@ -350,7 +350,7 @@ func TestSubscribeBindingLookupFailureReturnsError(t *testing.T) {
 		sessionStore:      newTestSessionStore(t, map[string]*session.Info{"s1": info}),
 		playerSessionRepo: newFakePlayerSessionRepo(playerID),
 		bindings:          &fakeBindingRepo{err: errors.New("db down")},
-		cryptoEnabled:     true, // required to activate binding lookup (Phase 3b gate)
+		cryptoActive:      true, // required to activate binding lookup (KEK-presence gate)
 	}
 	err := s.Subscribe(&corev1.SubscribeRequest{
 		SessionId:          "s1",
@@ -383,7 +383,7 @@ func TestSubscribePassesNonZeroSessionIdentityWhenBindingsWired(t *testing.T) {
 		sessionStore:      newTestSessionStore(t, map[string]*session.Info{"s1": info}),
 		playerSessionRepo: newFakePlayerSessionRepo(playerID),
 		bindings:          &fakeBindingRepo{bindingID: bindingID},
-		cryptoEnabled:     true, // required to activate binding lookup (Phase 3b gate)
+		cryptoActive:      true, // required to activate binding lookup (KEK-presence gate)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -561,7 +561,7 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	if cfg.withPluginCrypto {
 		coreServerOpts = append(
 			coreServerOpts,
-			holoGRPC.WithCryptoEnabled(true),
+			holoGRPC.WithCryptoActive(true),
 			holoGRPC.WithBindingRepository(worldpg.NewBindingRepository(pool)),
 		)
 	}
@@ -914,7 +914,7 @@ func (s *Server) ConnectAuthedWithRoles(ctx context.Context, charName string, ro
 	require.NoError(s.t, s.charRepo.Create(ctx, char),
 		"integrationtest.ConnectAuthedWithRoles: persist character")
 
-	// Under WithPluginCrypto the CoreServer runs with WithCryptoEnabled(true), so
+	// Under WithPluginCrypto the CoreServer runs with WithCryptoActive(true), so
 	// Subscribe / QueryStreamHistory perform a binding lookup
 	// (BindingRepository.Current) to build the typed CHARACTER identity. Create
 	// the binding row here — production characters always have one; the harness's

--- a/internal/testsupport/integrationtest/harness.go
+++ b/internal/testsupport/integrationtest/harness.go
@@ -58,8 +58,10 @@ package integrationtest
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"io"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -79,6 +81,7 @@ import (
 	"github.com/holomush/holomush/internal/eventbus"
 	"github.com/holomush/holomush/internal/eventbus/audit"
 	authguardaudit "github.com/holomush/holomush/internal/eventbus/authguard/audit"
+	"github.com/holomush/holomush/internal/eventbus/crypto/kek"
 	"github.com/holomush/holomush/internal/eventbus/eventbustest"
 	"github.com/holomush/holomush/internal/eventbus/history"
 	holoGRPC "github.com/holomush/holomush/internal/grpc"
@@ -258,6 +261,31 @@ func Start(t *testing.T, opts ...StartOption) *Server {
 	t.Helper()
 
 	ctx := context.Background()
+
+	// Provision boot-KEK env vars so any code path that reads
+	// HOLOMUSH_KEK_FILE / HOLOMUSH_KEK_PASSPHRASE (e.g. future helpers that
+	// call through to the production provisioning path) finds a valid, per-test
+	// ephemeral keyfile. A real sealed keyfile is persisted at the path so the
+	// env vars are truthful — an env reader would load it successfully rather
+	// than hit os.ErrNotExist. The harness itself constructs CoreServer
+	// directly (newPluginCrypto wires the active DEK manager) and never calls
+	// provisionBootKEKProvider; this complements that substrate, it does not
+	// replace it.
+	//
+	// t.Setenv is safe: the harness callers do not call t.Parallel (verified
+	// 2026-06-09; re-verify if t.Parallel is ever added to integration suites).
+	kekFile := filepath.Join(t.TempDir(), "integration-test-master.key.enc")
+	kekPassphrase := func(context.Context) ([]byte, error) {
+		return []byte("integration-test-passphrase"), nil
+	}
+	kekSource, err := kek.NewFileSource(kekFile, kekPassphrase)
+	require.NoError(t, err, "harness: build KEK file source")
+	bootMaster := make([]byte, kek.KEKByteLength)
+	_, err = rand.Read(bootMaster)
+	require.NoError(t, err, "harness: generate boot KEK")
+	require.NoError(t, kekSource.Persist(ctx, bootMaster), "harness: persist boot keyfile")
+	t.Setenv("HOLOMUSH_KEK_FILE", kekFile)
+	t.Setenv("HOLOMUSH_KEK_PASSPHRASE", "integration-test-passphrase")
 
 	// Postgres: shared container, fresh per-test database.
 	shared := testutil.SharedPostgres(t)

--- a/site/src/content/docs/operating/how-to/deploy/installation.md
+++ b/site/src/content/docs/operating/how-to/deploy/installation.md
@@ -6,6 +6,27 @@ sidebar:
 
 This guide covers installing HoloMUSH using Docker or pre-built binaries.
 
+## KEK requirement
+
+HoloMUSH requires a Key Encryption Key (KEK) to boot. The core server reads
+the keyfile path from `HOLOMUSH_KEK_FILE` and the unlock passphrase from one
+of three sources (first hit wins):
+
+| Source                         | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `HOLOMUSH_KEK_PASSPHRASE`      | Passphrase as a plain env var                     |
+| `HOLOMUSH_KEK_PASSPHRASE_FILE` | Path to a file containing the passphrase          |
+| Interactive prompt             | Prompted on stdin when a TTY is attached          |
+
+On first boot, pass `--auto-gen-kek` to mint the keyfile automatically. After
+that the keyfile is never overwritten — if the file exists, `--auto-gen-kek`
+is a no-op. Providing a wrong passphrase or a corrupt keyfile surfaces an error
+at startup rather than silently degrading.
+
+The admin-totp CLI (`holomush admin totp …`) uses the same `HOLOMUSH_KEK_FILE`
+and `HOLOMUSH_KEK_PASSPHRASE` env vars but does not support `--auto-gen-kek`.
+It requires a pre-existing keyfile.
+
 ## Docker Installation (Recommended)
 
 Docker provides the simplest deployment method with automatic dependency management.
@@ -85,10 +106,15 @@ services:
 
   core:
     image: ghcr.io/holomush/holomush:latest
-    command: ["core", "--grpc-addr=0.0.0.0:9000", "--metrics-addr=0.0.0.0:9100"]
+    command: ["core", "--grpc-addr=0.0.0.0:9000", "--metrics-addr=0.0.0.0:9100", "--auto-gen-kek"]
     environment:
       DATABASE_URL: postgres://holomush:${POSTGRES_PASSWORD}@postgres:5432/holomush?sslmode=disable
       HOME: /home/holomush
+      # KEK is required. --auto-gen-kek mints the keyfile on first boot;
+      # subsequent starts reuse it. Store the passphrase in a secrets manager
+      # and reference it via HOLOMUSH_KEK_PASSPHRASE_FILE for production.
+      HOLOMUSH_KEK_FILE: /home/holomush/.config/holomush/certs/master.key.enc
+      HOLOMUSH_KEK_PASSPHRASE: ${HOLOMUSH_KEK_PASSPHRASE}
     volumes:
       - holomush_config:/home/holomush/.config/holomush
     depends_on:
@@ -182,10 +208,21 @@ DATABASE_URL="postgres://holomush:secret@localhost:5432/holomush?sslmode=disable
 
 HoloMUSH uses a two-process architecture. Start both processes:
 
-**Terminal 1 - Core:**
+**Terminal 1 - Core (first start):**
 
 ```bash
 DATABASE_URL="postgres://holomush:secret@localhost:5432/holomush?sslmode=disable" \
+  HOLOMUSH_KEK_FILE="/etc/holomush/master.key.enc" \
+  HOLOMUSH_KEK_PASSPHRASE="your-passphrase" \
+  holomush core --auto-gen-kek
+```
+
+On subsequent starts, `--auto-gen-kek` is a no-op if the keyfile already exists:
+
+```bash
+DATABASE_URL="postgres://holomush:secret@localhost:5432/holomush?sslmode=disable" \
+  HOLOMUSH_KEK_FILE="/etc/holomush/master.key.enc" \
+  HOLOMUSH_KEK_PASSPHRASE="your-passphrase" \
   holomush core
 ```
 
@@ -255,6 +292,10 @@ Type=simple
 User=holomush
 Group=holomush
 Environment=DATABASE_URL=postgres://holomush:secret@localhost:5432/holomush?sslmode=disable
+Environment=HOLOMUSH_KEK_FILE=/etc/holomush/master.key.enc
+# Use EnvironmentFile or HOLOMUSH_KEK_PASSPHRASE_FILE for the passphrase
+# to avoid it appearing in systemd logs or process listings.
+EnvironmentFile=/etc/holomush/kek-passphrase.env
 ExecStart=/usr/local/bin/holomush core
 Restart=on-failure
 RestartSec=5

--- a/test/integration/crypto/decrypt_to_participant_test.go
+++ b/test/integration/crypto/decrypt_to_participant_test.go
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+//go:build integration
+
+// Package crypto_test — end-to-end proof that with a KEK present:
+//
+//   - A scene participant receives a sensitive event DECRYPTED
+//     (MetadataOnly()==false, payload == original plaintext).
+//   - A comms recipient (page on a character.<id> subject) likewise
+//     receives plaintext — proving the behaviour is domain-generic,
+//     not scene-specific.
+//   - A non-participant receives metadata-only (MetadataOnly()==true,
+//     payload empty).
+//
+// Asserts the publish/subscribe asymmetry is gone end-to-end under
+// live crypto (real KEK + real DEK + real AEAD encryption/decryption).
+//
+// Pre-covered by metadata_only_test.go (referenced here to avoid duplication):
+//   - TestSubscribeWithNonParticipantIdentityDeliversMetadataOnly: scene type,
+//     non-participant MetadataOnly=true, empty payload (INV-CRYPTO-15, INV-CRYPTO-6).
+//   - TestSubscribeWithParticipantIdentityDeliversPlaintext: scene type,
+//     participant MetadataOnly=false, payload == plaintext (INV-CRYPTO-15).
+//
+// New legs added in this file:
+//   - Comms (character subject / page event type): recipient participant
+//     receives plaintext (MetadataOnly=false).
+//   - Comms non-recipient receives metadata-only (MetadataOnly=true).
+//   - Combined three-party scene test: participant + non-participant in one
+//     describe block for clarity, confirming asymmetry in a single harness run.
+package crypto_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/core"
+	"github.com/holomush/holomush/internal/eventbus"
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+	plugins "github.com/holomush/holomush/internal/plugin"
+	"github.com/holomush/holomush/internal/plugin/plugintest"
+	pluginsdk "github.com/holomush/holomush/pkg/plugin"
+	corev1 "github.com/holomush/holomush/pkg/proto/holomush/core/v1"
+	"github.com/holomush/holomush/test/testutil"
+)
+
+// buildCommsHarness is buildSubscribeHarness plus the test-plugin:page verb
+// registration, so emitSensitivePage (which flows through
+// RenderingPublisher.Lookup) resolves the page verb instead of failing
+// EMIT_UNKNOWN_VERB.
+func buildCommsHarness(t *testing.T) *subscribeHarness {
+	t.Helper()
+	return buildSubscribeHarness(t, core.VerbRegistration{
+		Type:          "test-plugin:page",
+		Category:      "communication",
+		Format:        "speech",
+		Label:         "pages",
+		DisplayTarget: corev1.EventChannel_EVENT_CHANNEL_TERMINAL,
+		Source:        "test-plugin",
+	})
+}
+
+// emitSensitivePage emits a sensitive page event to the character subject
+// events.main.character.<recipientCharID> using a freshly-wired emitter.
+// The verb type is test-plugin:page (parallel to test-plugin:whisper for
+// scene events). The emit flows through PluginEventEmitter into the
+// harness's RenderingPublisher, so the rendering lookup gate fires — which
+// is why buildCommsHarness registers the page verb (an unregistered verb
+// would hard-fail EMIT_UNKNOWN_VERB). Same path as binary-plugin gRPC
+// EmitEvent against the production publisher.
+//
+// Asserts the comms domain uses a character-typed ContextID, not scene.
+func emitSensitivePage(ctx context.Context, h *subscribeHarness, recipientCharID, plaintext string) {
+	manifest := &plugins.Manifest{
+		Name:                "test-plugin",
+		Emits:               []string{"character"},
+		ActorKindsClaimable: []string{"plugin"},
+		Crypto: &plugins.CryptoSection{
+			Emits: []plugins.CryptoEmit{
+				{EventType: "test-plugin:page", Sensitivity: plugins.SensitivityMay},
+			},
+		},
+	}
+	manifestLookup := func(name string) *plugins.Manifest {
+		if name == "test-plugin" {
+			return manifest
+		}
+		return nil
+	}
+	actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+		return core.Actor{
+			Kind: core.ActorPlugin,
+			ID:   plugintest.PluginULIDFromName("test-plugin").String(),
+		}, nil
+	}
+	emitter := plugins.NewPluginEventEmitter(h.publisher, manifestLookup, actorResolver)
+
+	intent := pluginsdk.EmitIntent{
+		Subject:   "character." + recipientCharID,
+		Type:      pluginsdk.EventType("test-plugin:page"),
+		Payload:   plaintext,
+		Sensitive: true,
+	}
+	err := emitter.Emit(ctx, "test-plugin", intent)
+	Expect(err).NotTo(HaveOccurred(), "emitSensitivePage: emit must succeed")
+}
+
+// Asserts participant of a scene event receives plaintext AND a non-participant
+// in the same harness run receives metadata-only — combined three-party proof.
+// (The individual legs are also covered separately in metadata_only_test.go;
+// this Describe shows both in a single harness invocation for clarity.)
+var _ = Describe("Decrypt-to-participant: scene combined three-party proof", func() {
+	It("participant receives plaintext and non-participant receives metadata-only in the same run", func() {
+		ctx := context.Background()
+		h := buildCommsHarness(suiteT)
+
+		const (
+			participantPlayerID    = "01DTPSCENEPLAYER000000001"
+			participantCharacterID = "01DTPSCENECHARACT00000001"
+			participantBindingID   = "01DTPSCENEBINDING0000001"
+
+			nonPartPlayerID    = "01DTPSCENENONPLAYER000001"
+			nonPartCharacterID = "01DTPSCENENONCHARACT00001"
+			nonPartBindingID   = "01DTPSCENENONBINDING00001"
+		)
+
+		sceneID := "01DTPSCENETESTSCENE000001"
+		ctxID := dek.ContextID{Type: "scene", ID: sceneID}
+
+		// Pre-create DEK with participant only.
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    participantPlayerID,
+				CharacterID: participantCharacterID,
+				BindingID:   participantBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred(), "pre-create DEK with scene participant")
+
+		// Emit via PluginEventEmitter (same manifest/emitter setup as metadata_only_test.go).
+		sceneManifest := &plugins.Manifest{
+			Name:                "test-plugin",
+			Emits:               []string{"scene"},
+			ActorKindsClaimable: []string{"plugin"},
+			Crypto: &plugins.CryptoSection{
+				Emits: []plugins.CryptoEmit{
+					{EventType: "test-plugin:whisper", Sensitivity: plugins.SensitivityMay},
+				},
+			},
+		}
+		sceneLookup := func(name string) *plugins.Manifest {
+			if name == "test-plugin" {
+				return sceneManifest
+			}
+			return nil
+		}
+		actorResolver := func(_ context.Context, _ string) (core.Actor, error) {
+			return core.Actor{
+				Kind: core.ActorPlugin,
+				ID:   plugintest.PluginULIDFromName("test-plugin").String(),
+			}, nil
+		}
+		emitter := plugins.NewPluginEventEmitter(h.publisher, sceneLookup, actorResolver)
+
+		const plaintext = `{"text":"scene secret for participant only"}`
+		intent := pluginsdk.EmitIntent{
+			Subject:   "scene." + sceneID,
+			Type:      pluginsdk.EventType("test-plugin:whisper"),
+			Payload:   plaintext,
+			Sensitive: true,
+		}
+
+		// Open sessions BEFORE emitting so both consumers are subscribed
+		// when the message lands on JetStream.
+		participantID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    participantPlayerID,
+			CharacterID: participantCharacterID,
+			BindingID:   participantBindingID,
+		}
+		partStream, err := h.subscriber.OpenSession(ctx, "dtp-scene-part-session", participantID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = partStream.Close() })
+
+		nonPartID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    nonPartPlayerID,
+			CharacterID: nonPartCharacterID,
+			BindingID:   nonPartBindingID,
+		}
+		nonPartStream, err := h.subscriber.OpenSession(ctx, "dtp-scene-nonpart-session", nonPartID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = nonPartStream.Close() })
+
+		// Emit after both sessions are open.
+		Expect(emitter.Emit(ctx, "test-plugin", intent)).NotTo(HaveOccurred())
+
+		recvCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
+
+		// Participant delivery: plaintext, MetadataOnly=false.
+		partDelivery, err := partStream.Next(recvCtx)
+		Expect(err).NotTo(HaveOccurred(), "participant session must receive the event")
+		Expect(partDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Asserts participant of a live-crypto sensitive scene event receives decrypted
+		// plaintext with MetadataOnly==false (end-to-end KEK+DEK+AEAD round-trip).
+		Expect(partDelivery.MetadataOnly()).To(BeFalse(),
+			"participant must receive MetadataOnly=false (decrypt-to-participant)")
+		Expect(partDelivery.Event().Payload).To(Equal([]byte(plaintext)),
+			"participant payload must equal original plaintext after AEAD decryption")
+
+		// Non-participant delivery: metadata-only, empty payload.
+		recvCtx2, cancel2 := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel2()
+
+		nonPartDelivery, err := nonPartStream.Next(recvCtx2)
+		Expect(err).NotTo(HaveOccurred(), "non-participant session must receive the event")
+		Expect(nonPartDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Asserts non-participant receives metadata-only with empty payload under live crypto.
+		Expect(nonPartDelivery.MetadataOnly()).To(BeTrue(),
+			"non-participant must receive MetadataOnly=true (no plaintext)")
+		Expect(nonPartDelivery.Event().Payload).To(BeEmpty(),
+			"non-participant payload must be empty — no plaintext leaks")
+		Expect(nonPartDelivery.Event().Type).To(Equal(eventbus.Type("test-plugin:whisper")),
+			"non-participant metadata: event type must still be visible")
+	})
+})
+
+// Asserts comms recipient (page to character subject) receives decrypted plaintext
+// under live crypto, and a non-recipient receives metadata-only.
+// This proves the decrypt-to-participant behaviour is domain-generic
+// (character context, not just scene context).
+var _ = Describe("Decrypt-to-participant: comms (character subject) domain proof", func() {
+	It("comms recipient receives plaintext and non-recipient receives metadata-only", func() {
+		ctx := context.Background()
+		// buildCommsHarness registers both test-plugin:whisper and test-plugin:page
+		// in the RenderingPublisher's verb registry so emitSensitivePage succeeds.
+		h := buildCommsHarness(suiteT)
+
+		const (
+			recipientPlayerID  = "01DTPCOMMRECIPIENTPLAYER0"
+			recipientCharID    = "01DTPCOMMRECIPIENTCHAR000"
+			recipientBindingID = "01DTPCOMMRECIPIENTBIND000"
+
+			nonRecipientPlayerID  = "01DTPCOMMNONRECIPPLAYER00"
+			nonRecipientCharID    = "01DTPCOMMNONRECIPCHAR0000"
+			nonRecipientBindingID = "01DTPCOMMNONRECIPBIND0000"
+		)
+
+		// For character context, the subject is "character.<recipientCharID>".
+		// ContextID type becomes "character", derived by contextIDFromSubject.
+		// Pre-create the DEK for this character context with the recipient as participant.
+		ctxID := dek.ContextID{Type: "character", ID: recipientCharID}
+		_, err := h.dekMgr.GetOrCreate(ctx, ctxID, []dek.Participant{
+			{
+				PlayerID:    recipientPlayerID,
+				CharacterID: recipientCharID,
+				BindingID:   recipientBindingID,
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "test_setup",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred(), "pre-create DEK for character context with recipient")
+
+		// Open sessions before emitting.
+		recipientID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    recipientPlayerID,
+			CharacterID: recipientCharID,
+			BindingID:   recipientBindingID,
+		}
+		recipientStream, err := h.subscriber.OpenSession(ctx, "dtp-comms-recipient-session", recipientID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = recipientStream.Close() })
+
+		nonRecipientID := eventbus.SessionIdentity{
+			Kind:        eventbus.IdentityKindCharacter,
+			PlayerID:    nonRecipientPlayerID,
+			CharacterID: nonRecipientCharID,
+			BindingID:   nonRecipientBindingID,
+		}
+		nonRecipientStream, err := h.subscriber.OpenSession(ctx, "dtp-comms-nonrecipient-session", nonRecipientID,
+			[]eventbus.Subject{"events.>"}, time.Time{})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = nonRecipientStream.Close() })
+
+		// Emit sensitive page event to character subject.
+		const plaintext = `{"text":"private page to recipient only"}`
+		emitSensitivePage(ctx, h, recipientCharID, plaintext)
+
+		recvCtx, cancel := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel()
+
+		// Recipient delivery: plaintext, MetadataOnly=false.
+		recipientDelivery, err := recipientStream.Next(recvCtx)
+		Expect(err).NotTo(HaveOccurred(), "recipient session must receive the page event")
+		Expect(recipientDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Asserts comms recipient (page on character subject) receives decrypted
+		// plaintext under live crypto — proves domain-generic decrypt-to-participant.
+		Expect(recipientDelivery.MetadataOnly()).To(BeFalse(),
+			"comms recipient must receive MetadataOnly=false (decrypt-to-participant)")
+		Expect(recipientDelivery.Event().Payload).To(Equal([]byte(plaintext)),
+			"comms recipient payload must equal original plaintext after AEAD decryption")
+
+		// Non-recipient delivery: metadata-only, empty payload.
+		recvCtx2, cancel2 := context.WithTimeout(ctx, testutil.DefaultWait)
+		defer cancel2()
+
+		nonRecipientDelivery, err := nonRecipientStream.Next(recvCtx2)
+		Expect(err).NotTo(HaveOccurred(), "non-recipient session must receive the event (metadata-only)")
+		Expect(nonRecipientDelivery.Ack()).NotTo(HaveOccurred())
+
+		// Asserts non-recipient of a comms page event receives metadata-only under live crypto.
+		Expect(nonRecipientDelivery.MetadataOnly()).To(BeTrue(),
+			"non-recipient must receive MetadataOnly=true (no plaintext leaks)")
+		Expect(nonRecipientDelivery.Event().Payload).To(BeEmpty(),
+			"non-recipient payload must be empty — no comms plaintext visible")
+		Expect(nonRecipientDelivery.Event().Type).To(Equal(eventbus.Type("test-plugin:page")),
+			"non-recipient metadata: event type must still be visible")
+	})
+})

--- a/test/integration/crypto/decrypt_to_participant_test.go
+++ b/test/integration/crypto/decrypt_to_participant_test.go
@@ -114,6 +114,8 @@ func emitSensitivePage(ctx context.Context, h *subscribeHarness, recipientCharID
 // (The individual legs are also covered separately in metadata_only_test.go;
 // this Describe shows both in a single harness invocation for clarity.)
 var _ = Describe("Decrypt-to-participant: scene combined three-party proof", func() {
+	// Verifies: INV-CRYPTO-116
+	// Verifies: INV-CRYPTO-6
 	It("participant receives plaintext and non-participant receives metadata-only in the same run", func() {
 		ctx := context.Background()
 		h := buildCommsHarness(suiteT)
@@ -241,6 +243,8 @@ var _ = Describe("Decrypt-to-participant: scene combined three-party proof", fun
 // This proves the decrypt-to-participant behaviour is domain-generic
 // (character context, not just scene context).
 var _ = Describe("Decrypt-to-participant: comms (character subject) domain proof", func() {
+	// Verifies: INV-CRYPTO-116
+	// Verifies: INV-CRYPTO-6
 	It("comms recipient receives plaintext and non-recipient receives metadata-only", func() {
 		ctx := context.Background()
 		// buildCommsHarness registers both test-plugin:whisper and test-plugin:page

--- a/test/integration/crypto/metadata_only_test.go
+++ b/test/integration/crypto/metadata_only_test.go
@@ -56,7 +56,11 @@ type subscribeHarness struct {
 // JetStream, DEK manager, AuthGuard, audit emitter — and returns the harness.
 // The harness is self-contained: the publisher can emit sensitive events and the
 // subscriber can open sessions and receive deliveries.
-func buildSubscribeHarness(t *testing.T) *subscribeHarness {
+//
+// test-plugin:whisper is always registered; callers needing additional verbs
+// in the RenderingPublisher's registry (e.g. test-plugin:page for the comms
+// domain in decrypt_to_participant_test.go) pass them as extraVerbs.
+func buildSubscribeHarness(t *testing.T, extraVerbs ...core.VerbRegistration) *subscribeHarness {
 	t.Helper()
 	ctx := context.Background()
 
@@ -109,6 +113,11 @@ func buildSubscribeHarness(t *testing.T) *subscribeHarness {
 		Source:        "test-plugin",
 	}, "1.0.0"); err != nil {
 		t.Fatalf("buildSubscribeHarness: RegisterWithSource: %v", err)
+	}
+	for _, reg := range extraVerbs {
+		if err := registry.RegisterWithSource(reg, "1.0.0"); err != nil {
+			t.Fatalf("buildSubscribeHarness: RegisterWithSource(%s): %v", reg.Type, err)
+		}
 	}
 
 	rawPub := eventbus.NewJetStreamPublisher(


### PR DESCRIPTION
## Summary

Implements epic **holomush-5rh.8.29.12** (sensitive-event crypto activation, 11 commits — spec/plan/ADRs landed in #4410):

- **Single activation gate (INV-CRYPTO-118):** retires the vestigial `cryptoEnabled` flag — subscriber identity-build (`Subscribe` + `QueryStreamHistory`) is now gated on KEK presence (`cryptoActive` wired from `RekeyManager != nil`), in lockstep with the publisher's existing DEK gate. The extracted, unit-tested `buildCharacterIdentity` helper is the single source of truth for both gate sites.
- **KEK mandatory to boot (INV-CRYPTO-119):** `provisionBootKEKProvider` resolves the passphrase (env → file-ref → TTY prompt), auto-generates the sealed keyfile on first boot via `--auto-gen-kek` (O_EXCL-claimed, never regenerates/overwrites), and any provisioning failure is fatal (`BOOT_KEK_REQUIRED`). The admin-TOTP CLI path is untouched (pre-existing keyfile only).
- **Creation-time binding guarantee (INV-CRYPTO-120):** tests pin that normal + guest character creation mint a current DEK binding (`initial_bind` / `initial_bind_guest`) resolvable by `bindings.Current`.
- **Blast radius:** integration harness persists a real sealed test keyfile; dev + e2e compose provision KEK env + `--auto-gen-kek`; operating docs cover the requirement, the three passphrase sources, and the no-regenerate guarantee; golive spec §3.1's KEK-less-degraded clause superseded.
- **End-to-end proof:** new integration specs assert a scene participant and a comms (character-subject) recipient receive decrypted plaintext (`MetadataOnly()==false`, payload == plaintext) while a non-participant gets metadata-only — in single three-party harness runs.

## Review trail

Every commit passed two-stage review (spec-compliance + code-quality) during the autonomous drain (drain bead `holomush-qv3o5` carries the full audit trail); whole-branch `crypto-reviewer` and `code-reviewer` both returned READY. Follow-up filed: `holomush-7kl40` (pre-existing: incomplete rekey wiring warn-degrades instead of fatal).

## Test Plan

- [x] `task pr-prep` fast lane green (bats, schema, license, lint, fmt, unit, build)
- [x] `task test:int -- ./test/integration/crypto/...` — 51 specs green (Docker)
- [x] Invariant meta-tests green (INV-CRYPTO-118/119/120 bound, no false-greens)
- [ ] CI required checks: Integration Test + E2E Test (Namespace runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)