### PR TITLE
docs(crypto): scene DEK genesis-on-first-focus — spec, plan, ADR (holomush-5rh.8.29.13)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ edge and the file's `**Status:**` reflects the supersession.
 | [Require a provisioned KEK to boot; auto-generate keyfile, never the passphrase](holomush-kddop-require-provisioned-kek-boot-auto-generate-keyfile-never-pas.md) | 2026-06-09 | Accepted | `holomush-kddop` |
 | [DEK seed failure is FATAL and refuses scene focus](holomush-mihtk-dek-seed-failure-is-fatal-and-refuses-scene-focus.md) | 2026-06-09 | Accepted | `holomush-mihtk` |
 | [Seed comms recipients host-side at the publisher genesis boundary](holomush-olpdd-seed-comms-recipients-host-side-at-publisher-genesis-boundar.md) | 2026-06-09 | Accepted | `holomush-olpdd` |
+| [Scene DEK genesis happens lazily on first SetSceneFocus](holomush-r90tl-scene-dek-genesis-happens-lazily-first-setscenefocus.md) | 2026-06-09 | Accepted | `holomush-r90tl` |
 | [Use player-scoped workspace over terminal focus-pivot for scenes](holomush-wf4zj-use-player-scoped-workspace-over-terminal-focus-pivot-scenes.md) | 2026-06-07 | Accepted | `holomush-wf4zj` |
 | [Observer auto-join preserves INV-SCENE-60 participant-list boundary](holomush-zukuh-observer-auto-join-preserves-inv-scene-60-participant-list-b.md) | 2026-06-07 | Accepted | `holomush-zukuh` |
 | [Scene log reads ride QueryStreamHistory; no plugin-side ReadSceneLog](holomush-pc3bg-scene-log-reads-ride-querystreamhistory-no-plugin-side-reads.md) | 2026-06-07 | Accepted | `holomush-pc3bg` |

--- a/docs/adr/holomush-r90tl-scene-dek-genesis-happens-lazily-first-setscenefocus.md
+++ b/docs/adr/holomush-r90tl-scene-dek-genesis-happens-lazily-first-setscenefocus.md
@@ -1,0 +1,34 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright 2026 HoloMUSH Contributors
+-->
+
+<!-- markdownlint-disable MD013 -->
+<!-- adr-render: source=bd:holomush-r90tl; do not edit manually; use `/adr update holomush-r90tl` -->
+
+# Scene DEK genesis happens lazily on first SetSceneFocus
+
+**Date:** 2026-06-09
+**Status:** Accepted
+**Decision:** holomush-r90tl
+**Deciders:** Sean Brandt
+
+## Context
+
+The production scene DEK does not exist until a sensitive event (pose) is emitted (genesis-on-emit). But the first `SetSceneFocus` always precedes the first pose. `SetSceneFocus` seeds the focusing character as a DEK participant via `dek.Manager.Add`, which can only append to an *existing* active DEK — on a never-posed scene `updateParticipants` returns `pgx.ErrNoRows`, and per the fail-closed seed contract (ADR holomush-mihtk) focus is refused, making the live decrypt path unreachable (the holomush-5rh.8.29.10 E2E S3 "pose card appears live" 500). Surfaced by holomush-5rh.8.29.13.
+
+## Decision
+
+The scene DEK is genesised **lazily at the first `SetSceneFocus`** on a scene with no active DEK, seeded with the focusing reader — not eagerly at scene creation/activation. The focus seed path is made genesis-safe (genesis-if-absent, then idempotent add) via a new `dek.Manager.EnsureParticipant` method.
+
+## Rationale
+
+Minimal and localized to the focus path; reuses the existing `GetOrCreate` genesis primitive (which already mints v1 with the supplied initial participants on `ErrNoRows`). Preserves the master crypto design scene asymmetry (`publisher.go:494` — scene contexts seed no one at genesis; readers seeded at `SetSceneFocus`): lazy-at-focus upholds "readers seeded at focus" by fixing only the unstated assumption that the DEK pre-exists. Genesis triggers converge — the scene DEK is created by whichever of first-focus or first-pose happens first, both via idempotent `GetOrCreate`; no participant loss in either ordering.
+
+## Alternatives Considered
+
+**Eager genesis at scene creation/activation** — mint the scene DEK when the scene is created, so focus only ever appends. Rejected: adds a genesis trigger to the scene-creation path (more surface, more code touched), couples the DEK lifecycle to the scene lifecycle, and is unnecessary given `GetOrCreate` already provides idempotent genesis-on-demand. Lazy-at-focus is the smaller, behavior-equivalent change.
+
+## Consequences
+
+First `SetSceneFocus` on a fresh scene both genesises the DEK and seeds the first reader. Concurrent first-focusers (or focus racing the publisher first-pose genesis) converge via `GetOrCreate` unique-violation re-select + `updateParticipants` `SELECT … FOR UPDATE`. The fail-closed-on-seed-failure policy (ADR holomush-mihtk) is unchanged — only the genesis-gap *cause* of failure is removed. Pinned by INV-CRYPTO-121.

--- a/docs/superpowers/plans/2026-06-09-scene-dek-genesis-on-focus.md
+++ b/docs/superpowers/plans/2026-06-09-scene-dek-genesis-on-focus.md
@@ -1,0 +1,432 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Scene DEK Genesis-on-First-Focus Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the first `SetSceneFocus` on a never-posed scene succeed by genesising the scene DEK (seeded with the focusing reader) instead of failing because no DEK exists yet.
+
+**Architecture:** Add a genesis-safe `EnsureParticipant` method to `dek.Manager` (`GetOrCreate(initial=[p])` then idempotent `Add(p)`). Rename the scene-focus-specific `sceneDEKAdder` interface method from `Add` to `EnsureParticipant` (single consumer) and route `SetSceneFocus` through it. Register and bind an invariant; prove end-to-end via an integration test; the `.10` E2E (`scenes.spec.ts` S3) is the live reproducer.
+
+**Tech Stack:** Go, pgx/pgxpool (Postgres), Ginkgo/Gomega integration suites (`//go:build integration`), the existing `internal/eventbus/crypto/dek` DEK substrate.
+
+**Spec:** [`docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md`](../specs/2026-06-09-scene-dek-genesis-on-focus-design.md)
+
+**Review gating:** event-payload-cryptography surface — `crypto-reviewer` THEN `code-reviewer` MUST run before push; green on `task test:int` AND `task test:e2e` before landing. Crypto tasks → `model:opus`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `internal/eventbus/crypto/dek/manager.go` | `Manager` interface + `manager` impl; add `EnsureParticipant` | 1 |
+| `internal/eventbus/crypto/dek/manager_integration_test.go` | DEK-integration Ginkgo specs for `EnsureParticipant` | 1 |
+| `internal/grpc/sceneaccess_service.go` | `sceneDEKAdder` interface + `SetSceneFocus` seed call | 2 |
+| `internal/grpc/sceneaccess_service_test.go` | Three `sceneDEKAdder` fakes + focus tests | 2 |
+| `test/integration/crypto/scene_focus_genesis_test.go` (new) | End-to-end first-focus genesis proof (`// Verifies: INV-CRYPTO-121`) | 3 |
+| `docs/architecture/invariants.yaml` (+ generated `invariants.md`) | Register INV-CRYPTO-121 | 4 |
+
+---
+
+## Task 1: `EnsureParticipant` on `dek.Manager`
+
+**Files:**
+
+- Modify: `internal/eventbus/crypto/dek/manager.go` (interface `Manager` at :25; `manager` impl near `Add` at :348)
+- Test: `internal/eventbus/crypto/dek/manager_integration_test.go` (Ginkgo `Describe("Manager")` suite; entrypoint `TestDEKIntegration`)
+
+**Model:** opus (crypto surface)
+
+- [ ] **Step 1: Write the failing DEK-integration test**
+
+Add to `internal/eventbus/crypto/dek/manager_integration_test.go`, inside the existing `var _ = Describe("Manager", func() { … })` block (mirror the construction pattern at manager_integration_test.go:158-170):
+
+```go
+It("EnsureParticipant genesises the DEK seeded with p when none exists", func() {
+	ctx := context.Background()
+	connStr, teardown := newTestPGPool(suiteT)
+	DeferCleanup(teardown)
+	pool, err := pgxpool.New(ctx, connStr)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
+
+	provider := newTestProvider(suiteT)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+	Expect(err).NotTo(HaveOccurred())
+
+	ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS01"}
+	p := dek.Participant{PlayerID: "01PLAYER0000000001", CharacterID: "01CHAR00000000001", AddedVia: "test.first_focus"}
+
+	// No DEK exists yet — bare Add would fail with ErrNoRows; EnsureParticipant must genesis.
+	Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+	key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	Expect(err).NotTo(HaveOccurred())
+	parts, err := mgr.Participants(ctx, key.ID, 1)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(parts).To(HaveLen(1))
+	Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
+})
+
+It("EnsureParticipant appends p when an active DEK already exists without p", func() {
+	ctx := context.Background()
+	connStr, teardown := newTestPGPool(suiteT)
+	DeferCleanup(teardown)
+	pool, err := pgxpool.New(ctx, connStr)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
+
+	provider := newTestProvider(suiteT)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+	Expect(err).NotTo(HaveOccurred())
+
+	ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS02"}
+	// Publisher-style empty genesis (no participants), mirroring initialParticipantsForContext nil.
+	_, err = mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	Expect(err).NotTo(HaveOccurred())
+
+	p := dek.Participant{PlayerID: "01PLAYER0000000002", CharacterID: "01CHAR00000000002", AddedVia: "test.focus_after_pose"}
+	Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+	key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	Expect(err).NotTo(HaveOccurred())
+	parts, err := mgr.Participants(ctx, key.ID, 1)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(parts).To(HaveLen(1))
+	Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
+})
+
+It("EnsureParticipant is an idempotent no-op when p already present", func() {
+	ctx := context.Background()
+	connStr, teardown := newTestPGPool(suiteT)
+	DeferCleanup(teardown)
+	pool, err := pgxpool.New(ctx, connStr)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(pool.Close)
+
+	provider := newTestProvider(suiteT)
+	cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+	mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+	Expect(err).NotTo(HaveOccurred())
+
+	ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS03"}
+	p := dek.Participant{PlayerID: "01PLAYER0000000003", CharacterID: "01CHAR00000000003", AddedVia: "test.idempotent"}
+	Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+	Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+	key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+	Expect(err).NotTo(HaveOccurred())
+	parts, err := mgr.Participants(ctx, key.ID, 1)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(parts).To(HaveLen(1), "duplicate EnsureParticipant must not double-append")
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `task test:int -- -run TestDEKIntegration ./internal/eventbus/crypto/dek/ -ginkgo.focus='EnsureParticipant'`
+Expected: FAIL — compile error `mgr.EnsureParticipant undefined (type dek.Manager has no field or method EnsureParticipant)`.
+
+- [ ] **Step 3: Add `EnsureParticipant` to the `Manager` interface**
+
+In `internal/eventbus/crypto/dek/manager.go`, in the `Manager` interface (at :25), immediately after the `Add` declaration (:35):
+
+```go
+	// EnsureParticipant guarantees the active DEK for ctxID exists and that p
+	// is a participant. Unlike Add (which requires a pre-existing active DEK),
+	// it genesises the DEK seeded with p when none exists — the genesis-safe
+	// form used by the first reader to focus a never-posed scene
+	// (INV-CRYPTO-121). Idempotent.
+	EnsureParticipant(ctx context.Context, ctxID ContextID, p Participant) error
+```
+
+- [ ] **Step 4: Implement `EnsureParticipant` on the `manager` struct**
+
+In `internal/eventbus/crypto/dek/manager.go`, immediately after the `Add` method (which ends at :387):
+
+```go
+// EnsureParticipant guarantees the active DEK for ctxID exists and contains p.
+//
+//   - No active DEK: GetOrCreate mints v1 seeded with p (genesis). The
+//     subsequent Add hits the idempotency branch (p already present) and is a
+//     no-op.
+//   - Active DEK without p: GetOrCreate short-circuits (existing-row branch
+//     ignores initial); Add appends p under SELECT … FOR UPDATE.
+//   - Active DEK with p: GetOrCreate no-op; Add idempotent no-op.
+//
+// Concurrency: GetOrCreate resolves the INSERT race via unique-violation
+// re-select (manager.go GetOrCreate); Add serializes via updateParticipants'
+// row lock. Both orderings converge on one active DEK with p present.
+func (m *manager) EnsureParticipant(ctx context.Context, ctxID ContextID, p Participant) error {
+	if _, err := m.GetOrCreate(ctx, ctxID, []Participant{p}); err != nil {
+		return err
+	}
+	return m.Add(ctx, ctxID, p)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `task test:int -- -run TestDEKIntegration ./internal/eventbus/crypto/dek/ -ginkgo.focus='EnsureParticipant'`
+Expected: PASS — 3 specs ran, 0 failed (confirm a non-zero spec count; `0 of N` = false green).
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "feat(crypto): dek.Manager.EnsureParticipant — genesis-safe participant seed (holomush-5rh.8.29.13)"
+jj new
+```
+
+---
+
+## Task 2: Route `SetSceneFocus` through `EnsureParticipant`
+
+**Files:**
+
+- Modify: `internal/grpc/sceneaccess_service.go` (`sceneDEKAdder` interface at :36; seed call at :413)
+- Test: `internal/grpc/sceneaccess_service_test.go` (fakes `stubSceneDEKAdder`:40, `failingSceneDEKAdder`:610, `capturingSceneDEKAdder`:618)
+
+**Model:** opus (crypto surface)
+
+**Decision (resolves spec §3.2):** Rename the `sceneDEKAdder` interface method `Add → EnsureParticipant` rather than adding a second method — `sceneDEKAdder` has exactly one consumer (`SetSceneFocus`) and one production implementer (`dek.Manager`, which gains `EnsureParticipant` in Task 1).
+
+- [ ] **Step 1: Update the three test fakes to the new method name (write the failing test first)**
+
+In `internal/grpc/sceneaccess_service_test.go`, rename the `Add` method on each fake to `EnsureParticipant` (signatures are identical):
+
+```go
+// line ~40
+func (stubSceneDEKAdder) EnsureParticipant(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+	return nil
+}
+
+// line ~610
+func (failingSceneDEKAdder) EnsureParticipant(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+	return errors.New("dek seed boom")
+}
+
+// line ~624 — capturingSceneDEKAdder records the call. Rename the method ONLY;
+// keep the body verbatim (fields are called/gotCtxID/gotPart, defined at :618-621).
+func (c *capturingSceneDEKAdder) EnsureParticipant(_ context.Context, ctxID dek.ContextID, p dek.Participant) error {
+	c.called = true
+	c.gotCtxID = ctxID
+	c.gotPart = p
+	return nil
+}
+```
+
+Leave the existing assertions (failing-adder ⇒ focus refused with `codes.Internal`; capturing-adder ⇒ participant captured) unchanged — they now exercise `EnsureParticipant`.
+
+- [ ] **Step 2: Run the package tests to verify they fail**
+
+Run: `task test -- ./internal/grpc/ -run 'TestWithSceneDEKAdderSetsField|SetSceneFocus'`
+Expected: FAIL — compile error `failingSceneDEKAdder does not implement sceneDEKAdder (missing method Add)` / the interface still names `Add`.
+
+- [ ] **Step 3: Rename the interface method**
+
+In `internal/grpc/sceneaccess_service.go` at the `sceneDEKAdder` interface (:36), rename `Add` → `EnsureParticipant` (signature unchanged):
+
+```go
+// sceneDEKAdder seeds a character as a DEK participant so the AuthGuard's
+// hot tier permits that session to decrypt sensitive scene events. The
+// genesis-safe form: it mints the scene DEK (seeded with the character) when
+// none exists yet — the first reader to focus a never-posed scene
+// (INV-CRYPTO-121). Satisfied by dek.Manager.
+type sceneDEKAdder interface {
+	EnsureParticipant(ctx context.Context, ctxID dek.ContextID, p dek.Participant) error
+}
+```
+
+- [ ] **Step 4: Update the seed call site**
+
+In `internal/grpc/sceneaccess_service.go` at :413, change `s.dekAdder.Add(` to `s.dekAdder.EnsureParticipant(`. The surrounding comment (:403-410) and FATAL-on-failure block (:419-425) stay — update only the comment's "Add is idempotent (manager.go:377)" phrasing to "EnsureParticipant is genesis-safe and idempotent":
+
+```go
+		// Seed the character as a DEK participant so the AuthGuard hot-tier
+		// permits this session to decrypt sensitive scene events. Genesis-safe:
+		// mints the scene DEK seeded with this reader if none exists yet
+		// (first focus precedes first pose). FATAL: if the seed fails the
+		// connection MUST NOT be focused (ADR holomush-mihtk). EnsureParticipant
+		// is idempotent so a client retry is a safe no-op. (INV-CRYPTO-121.)
+		if s.dekAdder != nil {
+			ctxID := dek.ContextID{Type: "scene", ID: sceneIDStr}
+			addErr := s.dekAdder.EnsureParticipant(ctx, ctxID, dek.Participant{
+				PlayerID:    ps.PlayerID.String(),
+				CharacterID: gameSession.CharacterID.String(),
+				JoinedAt:    time.Now().UTC(),
+				AddedVia:    "sceneaccess.SetSceneFocus",
+			})
+			if addErr != nil {
+				slog.ErrorContext(ctx, "scene access: SetSceneFocus DEK seed failed",
+					"scene_id", sceneIDStr,
+					"character_id", gameSession.CharacterID.String(),
+					"error", addErr)
+				return nil, status.Error(codes.Internal, "internal error") //nolint:wrapcheck // gRPC status error at handler boundary
+			}
+		}
+```
+
+- [ ] **Step 5: Run the package tests to verify they pass**
+
+Run: `task test -- ./internal/grpc/ -run 'TestWithSceneDEKAdderSetsField|SetSceneFocus'`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```text
+jj describe -m "feat(crypto): SetSceneFocus genesis-seeds via EnsureParticipant (holomush-5rh.8.29.13)"
+jj new
+```
+
+---
+
+## Task 3: Integration proof — first focus on a fresh scene genesises + seeds
+
+**Files:**
+
+- Create: `test/integration/crypto/scene_focus_genesis_test.go`
+
+**Model:** opus (crypto surface)
+
+This test drives the bug's exact shape through the production seed path: a fresh scene (no prior pose) is focused by a participant; the focus succeeds, the character becomes a scene DEK participant, and a subsequent sensitive pose decrypts on the live fan-out path to that participant. It uses the same `subscribeHarness` / DEK-manager construction the `.12` integration tests use (see `test/integration/crypto/decrypt_to_participant_test.go` for the canonical harness: `buildCommsHarness(suiteT)` → `subscribeHarness{publisher, subscriber, dekMgr}`, `h.subscriber.OpenSession`, `delivery.Event().Payload` / `delivery.MetadataOnly()`).
+
+- [ ] **Step 1: Write the failing integration test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+)
+
+// Verifies: INV-CRYPTO-121
+var _ = Describe("Scene DEK genesis-on-first-focus", func() {
+	It("first EnsureParticipant on a never-posed scene genesises the DEK and seeds the reader", func() {
+		ctx := context.Background()
+		h := buildCommsHarness(suiteT) // provides h.dekMgr backed by a real Postgres pool
+
+		// A scene that has never been posed to: no active DEK row exists.
+		sceneCtx := dek.ContextID{Type: "scene", ID: "01FRESHSCENEFOCUS1"}
+		reader := dek.Participant{
+			PlayerID:    "01PLAYERFOCUS00001",
+			CharacterID: "01CHARFOCUS000001",
+			AddedVia:    "sceneaccess.SetSceneFocus",
+		}
+
+		// The production focus seed path. Before the fix this returned ErrNoRows.
+		Expect(h.dekMgr.EnsureParticipant(ctx, sceneCtx, reader)).To(Succeed())
+
+		// The scene DEK now exists with the reader as a participant.
+		key, err := h.dekMgr.GetOrCreate(ctx, sceneCtx, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+		parts, err := h.dekMgr.Participants(ctx, key.ID, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].CharacterID).To(Equal(reader.CharacterID))
+	})
+})
+```
+
+> If `buildCommsHarness` does not expose `dekMgr`, use the direct `dek.NewManager` construction from `manager_integration_test.go:158-170` (real pool via `newTestPGPool`) instead — the implementer probes the harness fields first and adapts. The assertion contract (EnsureParticipant succeeds on a fresh scene; reader becomes the sole participant) is fixed.
+
+- [ ] **Step 2: Run the test to verify it fails (before Task 1/2 land) or passes (after)**
+
+Run: `task test:int -- ./test/integration/crypto/ -ginkgo.focus='genesis-on-first-focus'`
+Expected (with Tasks 1-2 already committed): PASS, 1 spec ran. (If run against pre-fix code, FAIL with `select_active_dek_for_update` ErrNoRows.)
+
+- [ ] **Step 3: Confirm the `// Verifies:` annotation is present**
+
+Run: `rg -n 'Verifies: INV-CRYPTO-121' test/integration/crypto/scene_focus_genesis_test.go`
+Expected: one match immediately above the `Describe`.
+
+- [ ] **Step 4: Commit**
+
+```text
+jj describe -m "test(crypto): integration proof of scene DEK genesis-on-first-focus (holomush-5rh.8.29.13)"
+jj new
+```
+
+---
+
+## Task 4: Register and bind INV-CRYPTO-121
+
+**Files:**
+
+- Modify: `docs/architecture/invariants.yaml` (add INV-CRYPTO-121)
+- Generated: `docs/architecture/invariants.md` (via `go run ./cmd/inv-render` — never hand-edit)
+
+**Model:** opus (crypto surface)
+
+- [ ] **Step 1: Add the invariant entry**
+
+In `docs/architecture/invariants.yaml`, in the `INV-CRYPTO` scope (after the INV-CRYPTO-120 entry), add:
+
+```yaml
+  - id: INV-CRYPTO-121
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md"
+    legacy: []
+    summary: "The first SetSceneFocus on a scene context with no active DEK MUST
+      genesis the DEK, seeded with the focusing reader as a participant; a
+      participant-seeding focus MUST NOT fail solely because no DEK pre-existed.
+      The publisher's scene-context genesis remains participant-empty (the scene
+      genesis asymmetry, publisher.go initialParticipantsForContext, preserved)."
+    binding: bound
+    asserted_by:
+      - "test/integration/crypto/scene_focus_genesis_test.go"
+    refs:
+      - {file: "test/integration/crypto/scene_focus_genesis_test.go", token: "INV-CRYPTO-121"}
+```
+
+- [ ] **Step 2: Regenerate the rendered table**
+
+Run: `go run ./cmd/inv-render`
+Expected: `docs/architecture/invariants.md` updated to include INV-CRYPTO-121 in the generated regions.
+
+- [ ] **Step 3: Run the registry meta-tests + confirm no generated-doc drift**
+
+Run: `task test -- -run 'TestEveryRegistryInvariantHasBinding|TestRegistryBindingChecks|TestBoundInvariantsAreGenuinelyAsserted|TestProvenanceGuard' ./test/meta/`
+Expected: PASS — INV-CRYPTO-121 is bound and its `asserted_by` test genuinely asserts it.
+
+Then confirm the regenerated `invariants.md` has no uncommitted drift beyond the new entry:
+Run: `go run ./cmd/inv-render && jj diff --stat docs/architecture/invariants.md`
+Expected: only the INV-CRYPTO-121 additions show; re-running `inv-render` is a no-op (generate-and-diff clean).
+
+- [ ] **Step 4: Commit**
+
+```text
+jj describe -m "docs(invariants): register INV-CRYPTO-121 scene DEK genesis-on-first-focus (holomush-5rh.8.29.13)"
+jj new
+```
+
+---
+
+## Final verification (before push)
+
+- [ ] `task test:int` (full crypto + scene integration suites green)
+- [ ] `task test -- ./internal/grpc/ ./internal/eventbus/crypto/dek/ ./test/meta/` (unit + meta green)
+- [ ] `task lint`
+- [ ] `crypto-reviewer` READY, then `code-reviewer` READY
+- [ ] `task test:e2e` — `scenes.spec.ts` S3 "pose card appears live" passes (the `.10` reproducer); this confirms the end-to-end live-decrypt path. Coordinate with `holomush-5rh.8.29.10`, which carries the strengthened S3 spec.
+
+## Out of scope
+
+Eager genesis-at-scene-creation; any change to `Add`/`Rotate`/publisher/comms recipient seeding; rekey. `.10`'s E2E surface stays its own bead; this plan unblocks it.
+<!-- adr-capture: sha256=58b7b20a57ad5ae4; session=cli; ts=2026-06-09T23:42:57Z; adrs=holomush-r90tl -->

--- a/docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md
+++ b/docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md
@@ -1,0 +1,214 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Scene DEK Genesis-on-First-Focus — Design
+
+**Bead:** `holomush-5rh.8.29.13`
+**Status:** Draft (design-review pending)
+**Author:** brainstorming session, 2026-06-09
+**Master crypto spec:** [`docs/superpowers/specs/2026-04-25-event-payload-crypto-design.md`](2026-04-25-event-payload-crypto-design.md) (event-payload-crypto architecture + data model)
+**Fail-closed seed contract:** ADR [`holomush-mihtk`](../../adr/holomush-mihtk-dek-seed-failure-is-fatal-and-refuses-scene-focus.md) (DEK-seed failure is FATAL, refuses scene focus)
+**Scene genesis asymmetry:** grounded in `internal/eventbus/publisher.go:494` (`initialParticipantsForContext` — scene contexts seed no one; readers seeded at `SetSceneFocus`) and `test/integration/crypto/genesis_seed_test.go`
+**Surfaced by:** the `holomush-5rh.8.29.10` E2E (`scenes.spec.ts` S3 "pose card appears live")
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, **MAY** are to be interpreted as in RFC 2119 / RFC 8174.
+
+## 1. Problem
+
+`SetSceneFocus` seeds the focusing character as a scene DEK participant so the
+AuthGuard permits that session to decrypt sensitive scene events
+(`scene_pose`/`scene_say`/`scene_emit`/`scene_ooc`). It does this via
+`dek.Manager.Add` (`internal/grpc/sceneaccess_service.go:413`).
+
+`Add` **appends to an already-active DEK**: `Manager.Add` (manager.go:373) calls
+`store.updateParticipants` (store.go:197), which runs `SELECT … active row …
+FOR UPDATE` and returns `pgx.ErrNoRows` when no active DEK exists for the
+context (store.go:226, `operation=select_active_dek_for_update`,
+`context_type=scene`). `Add` performs no genesis.
+
+The scene DEK does not exist at first focus. Per
+`publisher.go:494` (`initialParticipantsForContext`), a `scene.<id>` context
+**seeds no one at genesis**; scene readers are seeded only at `SetSceneFocus`,
+and the scene DEK is otherwise minted on the first sensitive *emit* (genesis-on-pose).
+But the first *focus* always precedes the first *pose*. So on a fresh,
+never-posed scene:
+
+1. `SetSceneFocus` → `Add` → `updateParticipants` → `pgx.ErrNoRows`.
+2. Per the fail-closed seed contract (ADR `holomush-mihtk`), "Add-failure is
+   FATAL": `SetSceneFocus` returns `codes.Internal` and **skips**
+   `SetConnectionFocus`.
+3. The connection is never focused with decrypt → the live pose path is
+   unreachable → the web PoseCard never renders (the E2E S3 500).
+
+This is a **chicken-and-egg genesis gap**, not a wiring gap: `cryptoActive` is
+true in the affected deployments (RekeyManager wired; the `SetSceneFocus`
+DEK-seed path only runs when a DEK adder is present). The
+`select_active_dek_for_update` `ErrNoRows` is logged at
+`sceneaccess_service.go:420` with stack `store.go:226 → manager.go:373 →
+sceneaccess_service.go:413`. Reproduced twice against the e2e compose stack
+(`--auto-gen-kek` active): 71/73 e2e pass; only S3 fails.
+
+### 1.1 Why the existing genesis primitive is not already on the focus path
+
+`Manager.GetOrCreate` (manager.go:204) **already genesises**: it tries
+`selectActive`, and on `pgx.ErrNoRows` mints v1 with the supplied `initial`
+participants (resolving any unbound `BindingID` at manager.go:246, exactly as
+`Add` does). The publisher uses `GetOrCreate` on the emit path. But:
+
+- `Add` (the focus path) never calls `GetOrCreate`; it only appends.
+- `GetOrCreate`'s **existing-DEK branch short-circuits and ignores `initial`**
+  (manager.go:212): it returns the active key without adding the supplied
+  participant. So `GetOrCreate` alone is not a drop-in for `Add`'s
+  "ensure this participant is present" contract.
+
+The fix therefore needs genesis-**then**-ensure-present semantics.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- First `SetSceneFocus` on a scene with no active DEK MUST succeed and seed the
+  focusing character as a participant.
+- A subsequent pose MUST be emitted encrypted, decrypted on the live fan-out
+  path, and render in the web PoseCard.
+- The fix MUST be faithful to the scene genesis asymmetry (`publisher.go:494`)
+  and the fail-closed seed contract (ADR `holomush-mihtk`).
+
+**Non-goals (out of scope)**
+
+- Eager genesis at scene creation/activation (the rejected fork).
+- Any change to `Add`'s contract, the publisher emit path, or comms/character
+  recipient seeding.
+- Rekey, rotation, or DEK destruction behavior.
+
+## 3. Design
+
+### 3.1 New `dek.Manager` method: `EnsureParticipant`
+
+Add one method to the `dek.Manager` interface and its `manager` implementation
+(`internal/eventbus/crypto/dek/manager.go`):
+
+```go
+// EnsureParticipant guarantees the active DEK for ctxID exists and that p is a
+// participant. It is the genesis-safe form of Add for callers that may be the
+// first to touch a context (e.g. the first reader to focus a never-posed scene).
+//
+//   - If no active DEK exists, GetOrCreate mints v1 seeded with p (genesis).
+//   - If an active DEK exists, GetOrCreate is a no-op and Add appends p.
+//   - If p is already present, Add is an idempotent no-op.
+//
+// Concurrency: GetOrCreate resolves the INSERT race via unique-violation
+// re-select (manager.go:267); Add serializes via SELECT … FOR UPDATE
+// (store.go updateParticipants). Both orderings converge on one active DEK.
+func (m *manager) EnsureParticipant(ctx context.Context, ctxID ContextID, p Participant) error {
+    if _, err := m.GetOrCreate(ctx, ctxID, []Participant{p}); err != nil {
+        return err
+    }
+    return m.Add(ctx, ctxID, p)
+}
+```
+
+Rationale for a dedicated Manager method (vs. caller-side composition or
+mutating `Add`): it encapsulates the genesis + concurrency reasoning in the
+crypto layer, keeps `Add`'s existing contract intact (zero blast radius to the
+publisher/comms seeding that depend on `Add`'s append-only semantics), and is
+unit-testable in the `dek` package.
+
+### 3.2 Wire `SetSceneFocus` to `EnsureParticipant`
+
+In `internal/grpc/sceneaccess_service.go`:
+
+- The `sceneDEKAdder` interface (currently `Add(ctx, ContextID, Participant) error`)
+  gains `EnsureParticipant(ctx, ContextID, Participant) error`. `dek.Manager`
+  already satisfies it after §3.1; the `WithSceneDEKAdder` setter is unchanged.
+- The seed call at `sceneaccess_service.go:413` changes from
+  `s.dekAdder.Add(ctx, ctxID, …)` to
+  `s.dekAdder.EnsureParticipant(ctx, ctxID, …)`.
+- The surrounding FATAL-on-failure block (refuse focus, return
+  `codes.Internal`, skip `SetConnectionFocus`) is **unchanged** — the seed is
+  still fail-closed per ADR `holomush-mihtk`; we have only removed the
+  genesis-gap cause of failure.
+
+> **Interface note for the reviewer.** Confirm the minimal interface change.
+> If `sceneDEKAdder` is the only consumer, replacing `Add` with
+> `EnsureParticipant` on that interface (rather than adding a second method) is
+> acceptable and narrower. The spec mandates: `SetSceneFocus`'s seed call MUST
+> go through a genesis-safe path; the exact interface shape is an implementation
+> detail the plan fixes after probing the call sites.
+
+### 3.3 Convergence and faithfulness to the scene genesis asymmetry
+
+| Ordering | Step 1 | Step 2 | Result |
+|---|---|---|---|
+| **Focus before pose** | `SetSceneFocus` → `EnsureParticipant` → `GetOrCreate(scene, [char])` mints DEK seeded with char | first pose → publisher `GetOrCreate(scene, nil)` no-ops (DEK exists) | char persists; pose encrypts/decrypts |
+| **Pose before focus** | first pose → publisher `GetOrCreate(scene, nil)` mints **empty** DEK | `SetSceneFocus` → `EnsureParticipant` → `GetOrCreate` no-op, `Add(char)` appends | char added; live decrypt works |
+
+The publisher continues to seed **no one** for scene contexts
+(`initialParticipantsForContext` returns nil — unchanged). `SetSceneFocus`
+continues to be the place scene readers are seeded. The only behavioral change
+is that the focus seed is now genesis-if-absent. This **upholds** the scene
+genesis asymmetry (`publisher.go:494`) rather than amending it.
+
+### 3.4 Invariant
+
+Register a new invariant in `docs/architecture/invariants.yaml` (scope
+`INV-CRYPTO`, next free N):
+
+> **INV-CRYPTO-N (scene DEK genesis-on-first-focus):** The first
+> `SetSceneFocus` on a scene context with no active DEK MUST genesis the DEK,
+> seeded with the focusing reader as a participant; a participant-seeding focus
+> MUST NOT fail solely because no DEK pre-existed. The publisher's scene-context
+> genesis remains participant-empty (the `publisher.go:494` asymmetry preserved).
+
+Ships `binding: bound`, asserted by the new integration test (§4). The plan MUST
+allocate the concrete `N` against the live registry and add the `// Verifies:`
+annotation.
+
+## 4. Testing
+
+| Tier | Assertion |
+|---|---|
+| **DEK-integration** (`internal/eventbus/crypto/dek`, `//go:build integration`) | `EnsureParticipant`: (a) genesises and seeds `p` when no active DEK exists; (b) appends `p` when an active DEK exists without `p`; (c) idempotent no-op when `p` already present; (d) propagates `GetOrCreate`/`Add` errors. Table-driven; real Postgres testcontainer per the dek integration-test pattern — target `manager_integration_test.go` and run via the Ginkgo suite entrypoint (`TestDEKIntegration`), **not** `-run TestDEKManager` (matches no func → false-green). |
+| **Integration** | First `SetSceneFocus` on a fresh (never-posed) scene succeeds; the focusing character is a scene DEK participant; a subsequent sensitive pose decrypts on the live fan-out path to that participant. Carries `// Verifies: INV-CRYPTO-N`. |
+| **E2E** (the reproducer) | `.10`'s `scenes.spec.ts` S3 "pose card appears live" passes; full e2e suite green. |
+
+Concurrency (two simultaneous first-focusers converging on one DEK with both
+participants) SHOULD be covered by a focused integration assertion or argued
+from the `GetOrCreate` race-resolution + `FOR UPDATE` serialization already
+under test.
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `internal/eventbus/crypto/dek/manager.go` | Add `EnsureParticipant` to interface + `manager`. |
+| `internal/grpc/sceneaccess_service.go` | `sceneDEKAdder` gains genesis-safe seed; `SetSceneFocus` calls it. |
+| `internal/eventbus/crypto/dek/*_test.go` | Unit coverage for `EnsureParticipant`. |
+| `test/integration/crypto/…` | First-focus genesis integration test (`// Verifies: INV-CRYPTO-N`). |
+| `docs/architecture/invariants.yaml` (+ regenerate `invariants.md`) | Register INV-CRYPTO-N. |
+| `test/e2e` (`.10` surface) | No change here; `.10`'s existing S3 strengthening is the E2E proof. |
+
+## 6. Review gating
+
+This is event-payload-cryptography-surface work (`internal/eventbus/crypto/`,
+the DEK genesis path). Per the epic mandate and `.claude/rules` it MUST pass
+**`crypto-reviewer` then `code-reviewer`** before push, and be green on
+`task test:int` **and** `task test:e2e` before landing. Not
+autonomous-drain-landable.
+
+## 7. Risks
+
+- **Wrong genesis participant.** The focusing character MUST be the seeded
+  participant (with `BindingID` resolved by `GetOrCreate`, same as the publisher's
+  character-context seed). The plan MUST confirm the `Participant` fields
+  (`PlayerID`, `CharacterID`, `JoinedAt`, `AddedVia`) match the existing
+  `sceneaccess.SetSceneFocus` seed shape.
+- **Interface churn.** Changing `sceneDEKAdder` ripples to its test doubles;
+  the plan probes call sites first (per §3.2 note).
+- **Dangling-participant residue** (benign, per the `abac-reviewer` precedent on
+  `.12`): if a step after `EnsureParticipant` fails, the seeded participant was
+  already authorized at the participation gate that runs before the seed; no
+  focus ⇒ no ciphertext delivered; `Add`/`GetOrCreate` are idempotent so retry
+  self-heals. No compensating "unseed" logic.
+<!-- adr-capture: sha256=067b1af900400377; session=cli; ts=2026-06-09T23:42:57Z; adrs=holomush-r90tl -->


### PR DESCRIPTION
## What

Design docs for **holomush-5rh.8.29.13** — the scene DEK genesis gap surfaced by the `.10` E2E (`scenes.spec.ts` S3 "pose card appears live").

**The bug:** the first `SetSceneFocus` on a never-posed scene 500s. `SetSceneFocus` seeds the focusing reader via `dek.Manager.Add`, which can only append to an *existing* active DEK — on a fresh scene `updateParticipants` returns `pgx.ErrNoRows`, focus is refused (ADR `holomush-mihtk` fail-closed), and the live decrypt path is unreachable.

**The fix (designed here):** a genesis-safe `dek.Manager.EnsureParticipant` (`GetOrCreate(initial=[p])` then idempotent `Add(p)`); route `SetSceneFocus` through it. Lazy genesis-on-first-focus — faithful to the scene genesis asymmetry (`publisher.go:494`), not an amendment to it.

## Contents (docs only)

- `docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md` — design (`design-reviewer`: READY)
- `docs/superpowers/plans/2026-06-09-scene-dek-genesis-on-focus.md` — 4-task TDD plan (`plan-reviewer`: READY)
- `docs/adr/holomush-r90tl-...md` — ADR: lazy genesis trigger (+ README index)

## Follow-up

Implementation lands in a separate PR (beads `.13.1`–`.13.4`), crypto-review-gated, green on `task test:int` + `task test:e2e`. Unblocks `.10` and closes parent epic `.8.29`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)