### PR TITLE
feat(crypto): scene DEK genesis-on-first-focus (holomush-5rh.8.29.13)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -170,6 +170,7 @@ invariants.
 | `INV-CRYPTO-118` | Subscriber identity-build MUST be gated solely on KEK presence (cryptoActive wired from RekeyManager != nil), never an independent flag; when the gate is false or no binding repo is wired, the built identity MUST be the zero passthrough identity. The publisher half of the same RekeyManager-sourced lockstep is INV-CRYPTO-117. | — | bound |
 | `INV-CRYPTO-119` | The server MUST refuse to boot without a provisionable KEK; missing keyfile path, missing passphrase, or keyfile absent without auto-gen all produce a fatal error — degraded KEK-less boot is never permitted. | — | bound |
 | `INV-CRYPTO-120` | Every character-creation path (normal and guest) MUST mint a current DEK binding in the same transaction, so bindings.Current always resolves for a newly created character with no orphan row. | — | bound |
+| `INV-CRYPTO-121` | The first SetSceneFocus on a scene context with no active DEK MUST genesis the DEK, seeded with the focusing reader as a participant; a participant-seeding focus MUST NOT fail solely because no DEK pre-existed. The publisher's scene-context genesis remains participant-empty (the scene genesis asymmetry, publisher.go initialParticipantsForContext, preserved). | — | bound |
 
 ### `INV-PRIVACY`
 

--- a/docs/architecture/invariants.yaml
+++ b/docs/architecture/invariants.yaml
@@ -4422,3 +4422,16 @@ invariants:
     refs:
       - {file: "internal/grpc/auth_handlers_test.go", token: "INV-CRYPTO-120"}
       - {file: "internal/auth/guest_service_test.go", token: "INV-CRYPTO-120"}
+  - id: INV-CRYPTO-121
+    scope: INV-CRYPTO
+    origin_spec: "docs/superpowers/specs/2026-06-09-scene-dek-genesis-on-focus-design.md"
+    legacy: []
+    summary: "The first SetSceneFocus on a scene context with no active DEK MUST genesis the DEK, seeded with the focusing
+      reader as a participant; a participant-seeding focus MUST NOT fail solely because no DEK pre-existed. The publisher's
+      scene-context genesis remains participant-empty (the scene genesis asymmetry, publisher.go initialParticipantsForContext,
+      preserved)."
+    binding: bound
+    asserted_by:
+      - "test/integration/crypto/scene_focus_genesis_test.go"
+    refs:
+      - {file: "test/integration/crypto/scene_focus_genesis_test.go", token: "INV-CRYPTO-121"}

--- a/internal/eventbus/authguard/adapter_dek_test.go
+++ b/internal/eventbus/authguard/adapter_dek_test.go
@@ -37,6 +37,10 @@ func (s *stubDEKManager) Add(_ context.Context, _ dek.ContextID, _ dek.Participa
 	return nil
 }
 
+func (s *stubDEKManager) EnsureParticipant(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+	return nil
+}
+
 func (s *stubDEKManager) Rotate(_ context.Context, _ dek.ContextID, _ []dek.Participant, _ string) error {
 	return nil
 }

--- a/internal/eventbus/crypto/dek/manager.go
+++ b/internal/eventbus/crypto/dek/manager.go
@@ -34,6 +34,14 @@ type Manager interface {
 
 	// Phase 4 stub — see holomush-fi0n.
 	Add(ctx context.Context, ctxID ContextID, p Participant) error
+
+	// EnsureParticipant guarantees the active DEK for ctxID exists and that p
+	// is a participant. Unlike Add (which requires a pre-existing active DEK),
+	// it genesises the DEK seeded with p when none exists — the genesis-safe
+	// form used by the first reader to focus a never-posed scene
+	// (INV-CRYPTO-121). Idempotent.
+	EnsureParticipant(ctx context.Context, ctxID ContextID, p Participant) error
+
 	Rotate(ctx context.Context, ctxID ContextID, newParticipants []Participant, reason string) error
 
 	// Phase 5 stub — see holomush-jxo8.
@@ -384,6 +392,25 @@ func (m *manager) Add(ctx context.Context, ctxID ContextID, p Participant) error
 	)
 
 	return m.invalidate(ctx, ctxID, "participants_changed", activeRow.Version, 0)
+}
+
+// EnsureParticipant guarantees the active DEK for ctxID exists and contains p.
+//
+//   - No active DEK: GetOrCreate mints v1 seeded with p (genesis). The
+//     subsequent Add hits the idempotency branch (p already present) and is a
+//     no-op.
+//   - Active DEK without p: GetOrCreate short-circuits (existing-row branch
+//     ignores initial); Add appends p under SELECT … FOR UPDATE.
+//   - Active DEK with p: GetOrCreate no-op; Add idempotent no-op.
+//
+// Concurrency: GetOrCreate resolves the INSERT race via unique-violation
+// re-select (manager.go GetOrCreate); Add serializes via updateParticipants'
+// row lock. Both orderings converge on one active DEK with p present.
+func (m *manager) EnsureParticipant(ctx context.Context, ctxID ContextID, p Participant) error {
+	if _, err := m.GetOrCreate(ctx, ctxID, []Participant{p}); err != nil {
+		return err
+	}
+	return m.Add(ctx, ctxID, p)
 }
 
 // Rotate mints a new DEK version and marks the old one rotated.

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -940,6 +940,90 @@ var _ = Describe("Manager", func() {
 		Expect(parts).To(HaveLen(2))
 		Expect(parts[1].BindingID).To(Equal("bind-explicit"))
 	})
+
+	It("EnsureParticipant genesises the DEK seeded with p when none exists", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS01"}
+		p := dek.Participant{PlayerID: "01PLAYER0000000001", CharacterID: "01CHAR00000000001", AddedVia: "test.first_focus"}
+
+		// No DEK exists yet — bare Add would fail with ErrNoRows; EnsureParticipant must genesis.
+		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+		parts, err := mgr.Participants(ctx, key.ID, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
+	})
+
+	It("EnsureParticipant appends p when an active DEK already exists without p", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS02"}
+		// Publisher-style empty genesis (no participants), mirroring initialParticipantsForContext nil.
+		_, err = mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+
+		p := dek.Participant{PlayerID: "01PLAYER0000000002", CharacterID: "01CHAR00000000002", AddedVia: "test.focus_after_pose"}
+		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+		parts, err := mgr.Participants(ctx, key.ID, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
+	})
+
+	It("EnsureParticipant is an idempotent no-op when p already present", func() {
+		ctx := context.Background()
+		connStr, teardown := newTestPGPool(suiteT)
+		DeferCleanup(teardown)
+		pool, err := pgxpool.New(ctx, connStr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(pool.Close)
+
+		provider := newTestProvider(suiteT)
+		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS03"}
+		p := dek.Participant{PlayerID: "01PLAYER0000000003", CharacterID: "01CHAR00000000003", AddedVia: "test.idempotent"}
+		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+
+		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+		parts, err := mgr.Participants(ctx, key.ID, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1), "duplicate EnsureParticipant must not double-append")
+	})
 })
 
 // dekCapturingProvider wraps a real kek.Provider and captures the

--- a/internal/eventbus/crypto/dek/manager_integration_test.go
+++ b/internal/eventbus/crypto/dek/manager_integration_test.go
@@ -941,89 +941,63 @@ var _ = Describe("Manager", func() {
 		Expect(parts[1].BindingID).To(Equal("bind-explicit"))
 	})
 
-	It("EnsureParticipant genesises the DEK seeded with p when none exists", func() {
-		ctx := context.Background()
-		connStr, teardown := newTestPGPool(suiteT)
-		DeferCleanup(teardown)
-		pool, err := pgxpool.New(ctx, connStr)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(pool.Close)
+	// EnsureParticipant is the genesis-safe scene-reader seed: it must leave the
+	// active DEK seeded with exactly p as a participant regardless of the
+	// starting state (no DEK, an empty-genesis DEK, or p already present). The
+	// arrange hook drives each case's heterogeneous setup; the shared act +
+	// assert (GetOrCreate read-back, single participant = p) is identical.
+	DescribeTable(
+		"EnsureParticipant leaves the active DEK seeded with exactly p",
+		func(sceneID string, p dek.Participant, arrange func(ctx context.Context, mgr dek.Manager, ctxID dek.ContextID, p dek.Participant)) {
+			ctx := context.Background()
+			connStr, teardown := newTestPGPool(suiteT)
+			DeferCleanup(teardown)
+			pool, err := pgxpool.New(ctx, connStr)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(pool.Close)
 
-		provider := newTestProvider(suiteT)
-		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
-		Expect(err).NotTo(HaveOccurred())
+			provider := newTestProvider(suiteT)
+			cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+			partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
+			mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
+			Expect(err).NotTo(HaveOccurred())
 
-		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS01"}
-		p := dek.Participant{PlayerID: "01PLAYER0000000001", CharacterID: "01CHAR00000000001", AddedVia: "test.first_focus"}
+			ctxID := dek.ContextID{Type: "scene", ID: sceneID}
 
-		// No DEK exists yet — bare Add would fail with ErrNoRows; EnsureParticipant must genesis.
-		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+			arrange(ctx, mgr, ctxID, p)
 
-		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
-		Expect(err).NotTo(HaveOccurred())
-		parts, err := mgr.Participants(ctx, key.ID, 1)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(parts).To(HaveLen(1))
-		Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
-	})
-
-	It("EnsureParticipant appends p when an active DEK already exists without p", func() {
-		ctx := context.Background()
-		connStr, teardown := newTestPGPool(suiteT)
-		DeferCleanup(teardown)
-		pool, err := pgxpool.New(ctx, connStr)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(pool.Close)
-
-		provider := newTestProvider(suiteT)
-		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
-		Expect(err).NotTo(HaveOccurred())
-
-		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS02"}
-		// Publisher-style empty genesis (no participants), mirroring initialParticipantsForContext nil.
-		_, err = mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
-		Expect(err).NotTo(HaveOccurred())
-
-		p := dek.Participant{PlayerID: "01PLAYER0000000002", CharacterID: "01CHAR00000000002", AddedVia: "test.focus_after_pose"}
-		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
-
-		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
-		Expect(err).NotTo(HaveOccurred())
-		parts, err := mgr.Participants(ctx, key.ID, 1)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(parts).To(HaveLen(1))
-		Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
-	})
-
-	It("EnsureParticipant is an idempotent no-op when p already present", func() {
-		ctx := context.Background()
-		connStr, teardown := newTestPGPool(suiteT)
-		DeferCleanup(teardown)
-		pool, err := pgxpool.New(ctx, connStr)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(pool.Close)
-
-		provider := newTestProvider(suiteT)
-		cache := dek.NewCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		partCache := dek.NewParticipantsCache(dek.CacheConfig{Capacity: 16, TTL: time.Minute})
-		mgr, err := dek.NewManager(provider, dek.NewStore(pool), cache, partCache, noopInvalidator, &stubBindingResolver{})
-		Expect(err).NotTo(HaveOccurred())
-
-		ctxID := dek.ContextID{Type: "scene", ID: "01GENESISFOCUS03"}
-		p := dek.Participant{PlayerID: "01PLAYER0000000003", CharacterID: "01CHAR00000000003", AddedVia: "test.idempotent"}
-		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
-		Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
-
-		key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
-		Expect(err).NotTo(HaveOccurred())
-		parts, err := mgr.Participants(ctx, key.ID, 1)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(parts).To(HaveLen(1), "duplicate EnsureParticipant must not double-append")
-	})
+			key, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+			Expect(err).NotTo(HaveOccurred())
+			parts, err := mgr.Participants(ctx, key.ID, key.Version)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parts).To(HaveLen(1), "EnsureParticipant must seed exactly p — no missing/duplicate participant")
+			Expect(parts[0].PlayerID).To(Equal(p.PlayerID))
+		},
+		Entry("genesises the DEK seeded with p when none exists",
+			"01GENESISFOCUS01",
+			dek.Participant{PlayerID: "01PLAYER0000000001", CharacterID: "01CHAR00000000001", AddedVia: "test.first_focus"},
+			func(ctx context.Context, mgr dek.Manager, ctxID dek.ContextID, p dek.Participant) {
+				// No DEK exists yet — bare Add would fail with ErrNoRows; EnsureParticipant must genesis.
+				Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+			}),
+		Entry("appends p when an active DEK already exists without p",
+			"01GENESISFOCUS02",
+			dek.Participant{PlayerID: "01PLAYER0000000002", CharacterID: "01CHAR00000000002", AddedVia: "test.focus_after_pose"},
+			func(ctx context.Context, mgr dek.Manager, ctxID dek.ContextID, p dek.Participant) {
+				// Publisher-style empty genesis (no participants), mirroring initialParticipantsForContext nil.
+				_, err := mgr.GetOrCreate(ctx, ctxID, []dek.Participant{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+			}),
+		Entry("is an idempotent no-op when p already present",
+			"01GENESISFOCUS03",
+			dek.Participant{PlayerID: "01PLAYER0000000003", CharacterID: "01CHAR00000000003", AddedVia: "test.idempotent"},
+			func(ctx context.Context, mgr dek.Manager, ctxID dek.ContextID, p dek.Participant) {
+				// Two calls must not double-append.
+				Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+				Expect(mgr.EnsureParticipant(ctx, ctxID, p)).To(Succeed())
+			}),
+	)
 })
 
 // dekCapturingProvider wraps a real kek.Provider and captures the

--- a/internal/eventbus/history/source/fallback_test.go
+++ b/internal/eventbus/history/source/fallback_test.go
@@ -52,6 +52,10 @@ func (f *fakeDEKManager) Participants(context.Context, codec.KeyID, uint32) ([]d
 
 func (f *fakeDEKManager) Add(context.Context, dek.ContextID, dek.Participant) error { panic("unused") }
 
+func (f *fakeDEKManager) EnsureParticipant(context.Context, dek.ContextID, dek.Participant) error {
+	panic("unused")
+}
+
 func (f *fakeDEKManager) Rotate(context.Context, dek.ContextID, []dek.Participant, string) error {
 	panic("unused")
 }

--- a/internal/eventbus/history/source/simple_test.go
+++ b/internal/eventbus/history/source/simple_test.go
@@ -37,6 +37,10 @@ func (s *stubDEKManager) Participants(context.Context, codec.KeyID, uint32) ([]d
 
 func (s *stubDEKManager) Add(context.Context, dek.ContextID, dek.Participant) error { panic("unused") }
 
+func (s *stubDEKManager) EnsureParticipant(context.Context, dek.ContextID, dek.Participant) error {
+	panic("unused")
+}
+
 func (s *stubDEKManager) Rotate(context.Context, dek.ContextID, []dek.Participant, string) error {
 	panic("unused")
 }

--- a/internal/grpc/sceneaccess_service.go
+++ b/internal/grpc/sceneaccess_service.go
@@ -32,9 +32,11 @@ type sceneAccessPluginManager interface {
 
 // sceneDEKAdder seeds a character as a DEK participant so the AuthGuard's
 // hot-tier checkCharacter branch permits this session to decrypt sensitive
-// scene events (e.g. scene_pose). Satisfied by dek.Manager (its Add method).
+// scene events (e.g. scene_pose). The genesis-safe form: it mints the scene
+// DEK (seeded with the character) when none exists yet — the first reader to
+// focus a never-posed scene (INV-CRYPTO-121). Satisfied by dek.Manager.
 type sceneDEKAdder interface {
-	Add(ctx context.Context, ctxID dek.ContextID, p dek.Participant) error
+	EnsureParticipant(ctx context.Context, ctxID dek.ContextID, p dek.Participant) error
 }
 
 // SceneAccessServer is the host-side facade that owns player authentication,
@@ -402,15 +404,17 @@ func (s *SceneAccessServer) SetSceneFocus(ctx context.Context, req *sceneaccessv
 
 		// Seed the character as a DEK participant so the AuthGuard hot-tier
 		// permits this session to decrypt sensitive scene events (scene_pose,
-		// scene_say, scene_emit, scene_ooc). FATAL: if the seed fails the
-		// connection MUST NOT be focused — a focused connection that cannot
-		// decrypt would receive blank (metadata-only) poses. Refusing focus
-		// surfaces the error so the client retries; Add is idempotent
-		// (manager.go:377) so retry is a safe no-op. (Invariant: a connection
-		// is focused on a scene only if its character can decrypt that scene.)
+		// scene_say, scene_emit, scene_ooc). Genesis-safe: mints the scene DEK
+		// seeded with this reader if none exists yet (first focus precedes
+		// first pose). FATAL: if the seed fails the connection MUST NOT be
+		// focused — a focused connection that cannot decrypt would receive
+		// blank (metadata-only) poses. Refusing focus surfaces the error so the
+		// client retries; EnsureParticipant is idempotent so retry is a safe
+		// no-op. (INV-CRYPTO-121. Invariant: a connection is focused on a scene
+		// only if its character can decrypt that scene.)
 		if s.dekAdder != nil {
 			ctxID := dek.ContextID{Type: "scene", ID: sceneIDStr}
-			addErr := s.dekAdder.Add(ctx, ctxID, dek.Participant{
+			addErr := s.dekAdder.EnsureParticipant(ctx, ctxID, dek.Participant{
 				PlayerID:    ps.PlayerID.String(),
 				CharacterID: gameSession.CharacterID.String(),
 				JoinedAt:    time.Now().UTC(),

--- a/internal/grpc/sceneaccess_service_test.go
+++ b/internal/grpc/sceneaccess_service_test.go
@@ -39,7 +39,9 @@ func TestWithSceneDEKAdderSetsField(t *testing.T) {
 
 type stubSceneDEKAdder struct{}
 
-func (stubSceneDEKAdder) Add(_ context.Context, _ dek.ContextID, _ dek.Participant) error { return nil }
+func (stubSceneDEKAdder) EnsureParticipant(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+	return nil
+}
 
 const testSAToken = "test-scene-access-token"
 
@@ -605,23 +607,23 @@ func TestSetSceneFocusJoinsFocusThenSetsConnectionFocus(t *testing.T) {
 		"JoinFocus MUST be called exactly once for a valid participant")
 }
 
-// failingSceneDEKAdder is a sceneDEKAdder whose Add always fails, used to drive
-// the fatal-seed branch of SetSceneFocus.
+// failingSceneDEKAdder is a sceneDEKAdder whose EnsureParticipant always fails,
+// used to drive the fatal-seed branch of SetSceneFocus.
 type failingSceneDEKAdder struct{}
 
-func (failingSceneDEKAdder) Add(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
+func (failingSceneDEKAdder) EnsureParticipant(_ context.Context, _ dek.ContextID, _ dek.Participant) error {
 	return oops.Code("DEK_ADD_FAILED").Errorf("seed failed")
 }
 
-// capturingSceneDEKAdder records the (ctxID, participant) passed to Add so tests
-// can assert the seeded values.
+// capturingSceneDEKAdder records the (ctxID, participant) passed to
+// EnsureParticipant so tests can assert the seeded values.
 type capturingSceneDEKAdder struct {
 	called   bool
 	gotCtxID dek.ContextID
 	gotPart  dek.Participant
 }
 
-func (c *capturingSceneDEKAdder) Add(_ context.Context, ctxID dek.ContextID, p dek.Participant) error {
+func (c *capturingSceneDEKAdder) EnsureParticipant(_ context.Context, ctxID dek.ContextID, p dek.Participant) error {
 	c.called = true
 	c.gotCtxID = ctxID
 	c.gotPart = p
@@ -629,7 +631,7 @@ func (c *capturingSceneDEKAdder) Add(_ context.Context, ctxID dek.ContextID, p d
 }
 
 // TestSetSceneFocusReturnsInternalWhenDEKSeedFails verifies the fatal-seed
-// contract: when a dekAdder is attached and its Add fails, SetSceneFocus returns
+// contract: when a dekAdder is attached and its EnsureParticipant fails, SetSceneFocus returns
 // codes.Internal and MUST NOT proceed to SetConnectionFocus — a focused
 // connection that cannot decrypt would receive blank (metadata-only) poses.
 func TestSetSceneFocusReturnsInternalWhenDEKSeedFails(t *testing.T) {

--- a/test/integration/crypto/scene_focus_genesis_test.go
+++ b/test/integration/crypto/scene_focus_genesis_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Scene DEK genesis-on-first-focus", func() {
 		// The scene DEK now exists with the reader as a participant.
 		key, err := h.dekMgr.GetOrCreate(ctx, sceneCtx, []dek.Participant{})
 		Expect(err).NotTo(HaveOccurred())
-		parts, err := h.dekMgr.Participants(ctx, key.ID, 1)
+		parts, err := h.dekMgr.Participants(ctx, key.ID, key.Version)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(parts).To(HaveLen(1))
 		Expect(parts[0].CharacterID).To(Equal(reader.CharacterID))

--- a/test/integration/crypto/scene_focus_genesis_test.go
+++ b/test/integration/crypto/scene_focus_genesis_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 HoloMUSH Contributors
+
+package crypto_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive // gomega convention
+
+	"github.com/holomush/holomush/internal/eventbus/crypto/dek"
+)
+
+// Verifies: INV-CRYPTO-121
+var _ = Describe("Scene DEK genesis-on-first-focus", func() {
+	It("first EnsureParticipant on a never-posed scene genesises the DEK and seeds the reader", func() {
+		ctx := context.Background()
+		h := buildCommsHarness(suiteT) // provides h.dekMgr backed by a real Postgres pool
+
+		// A scene that has never been posed to: no active DEK row exists.
+		sceneCtx := dek.ContextID{Type: "scene", ID: "01FRESHSCENEFOCUS1"}
+		reader := dek.Participant{
+			PlayerID:    "01PLAYERFOCUS00001",
+			CharacterID: "01CHARFOCUS000001",
+			AddedVia:    "sceneaccess.SetSceneFocus",
+		}
+
+		// The production focus seed path. Before the fix this returned ErrNoRows.
+		Expect(h.dekMgr.EnsureParticipant(ctx, sceneCtx, reader)).To(Succeed())
+
+		// The scene DEK now exists with the reader as a participant.
+		key, err := h.dekMgr.GetOrCreate(ctx, sceneCtx, []dek.Participant{})
+		Expect(err).NotTo(HaveOccurred())
+		parts, err := h.dekMgr.Participants(ctx, key.ID, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parts).To(HaveLen(1))
+		Expect(parts[0].CharacterID).To(Equal(reader.CharacterID))
+	})
+})


### PR DESCRIPTION
## Summary

Fixes the chicken-and-egg bug where the **first `SetSceneFocus` on a never-posed scene 500s** because no scene DEK exists yet: `dek.Manager.Add` requires a pre-existing active DEK (`SELECT … FOR UPDATE` → `pgx.ErrNoRows`), but the first focusing reader precedes the first pose (genesis-on-emit), so the seed fails and — per the FATAL-on-seed-failure policy (ADR holomush-mihtk) — focus is refused and the live PoseCard never renders.

Implements epic **holomush-5rh.8.29.13** (spec + plan + ADR landed in #4412). Design decision: genesis is **lazy on first focus** (genesis-then-add), reusing the existing `GetOrCreate` genesis primitive.

## Changes (4 commits)

| Task | Commit | What |
| ---- | ------ | ---- |
| T1 | `feat(crypto): dek.Manager.EnsureParticipant` | New genesis-safe `EnsureParticipant(ctx, ctxID, p) = GetOrCreate(initial=[p]) → Add(p)` — the first reader to touch a never-posed context seeds itself. Converges under all orderings (genesis / existing-without-p / idempotent / concurrent race). |
| T2 | `feat(crypto): SetSceneFocus genesis-seeds via EnsureParticipant` | Routes `SetSceneFocus`'s DEK-seed through `EnsureParticipant` (renamed the narrow single-consumer `sceneDEKAdder` interface method). FATAL-on-failure preserved. |
| T3 | `test(crypto): integration proof of scene DEK genesis-on-first-focus` | New `test/integration/crypto/scene_focus_genesis_test.go` proving first `EnsureParticipant` on a never-posed scene genesises the DEK + seeds the reader (real Postgres). Carries `// Verifies: INV-CRYPTO-121`. |
| T4 | `docs(invariants): register INV-CRYPTO-121` | Registers INV-CRYPTO-121 (`binding: bound`, asserted_by the T3 test); regenerated `invariants.md`. |

## Invariant

**INV-CRYPTO-121** — The first `SetSceneFocus` on a scene context with no active DEK MUST genesis the DEK seeded with the focusing reader; a participant-seeding focus MUST NOT fail solely because no DEK pre-existed. The publisher's scene-context genesis remains participant-empty (the scene genesis asymmetry, preserved — INV-CRYPTO-116).

## Verification

- `task pr-prep` (fast lane): **pass** (bats, lint, fmt, license, unit, build).
- Per-task during TDD: T1 DEK-integration specs green (genuine via sabotage-revert); T2 `./internal/grpc/` 433/433; T3 `Ran 1/52` genuine; T4 registry meta-tests 18/0 incl `TestBoundInvariantsAreGenuinelyAsserted`.
- Each task passed adversarial **crypto-reviewer + code-reviewer** (both READY).
- Integration + E2E run as required CI checks.

## Scope

Out of scope: eager genesis-at-scene-creation; `Add`/`Rotate`/publisher/comms recipient seeding; rekey. **Unblocks holomush-5rh.8.29.10** (its strengthened E2E S3 "pose card appears live" reproducer), which carries the E2E surface on its own bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)